### PR TITLE
#47433: copy a subset of ops to experimental/quasar

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -298,6 +298,8 @@ ttnn/cpp/ttnn/operations/experimental/matmul/ @tenstorrent/metalium-developers-m
 ttnn/cpp/ttnn/operations/experimental/matmul/**/CMakeLists.txt @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/experimental/minimal_matmul/ @cglagovichTT @jonathansuTT @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/experimental/minimal_matmul/**/CMakeLists.txt @cglagovichTT @jonathansuTT @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
+ttnn/cpp/ttnn/operations/experimental/quasar/ @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
+ttnn/cpp/ttnn/operations/experimental/quasar/**/CMakeLists.txt @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/experimental/slice_write/ @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/experimental/slice_write/**/CMakeLists.txt @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/experimental/padded_slice/ @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -294,6 +294,7 @@ target_link_libraries(
         TTNN::Ops::Experimental::DeepSeekPrefill::PerTokenCastBack
         TTNN::Ops::Experimental::PagedCache
         TTNN::Ops::Experimental::PlusOne
+        TTNN::Ops::Experimental::Quasar
         TTNN::Ops::Experimental::Reduction
         TTNN::Ops::Experimental::Reshape
         TTNN::Ops::Experimental::SliceWrite
@@ -524,6 +525,7 @@ add_subdirectory(cpp/ttnn/operations/embedding)
 add_subdirectory(cpp/ttnn/operations/embedding_backward)
 add_subdirectory(cpp/ttnn/operations/examples)
 add_subdirectory(cpp/ttnn/operations/experimental/adaptive_pool)
+add_subdirectory(cpp/ttnn/operations/experimental/quasar)
 add_subdirectory(cpp/ttnn/operations/experimental/bcast_to)
 add_subdirectory(cpp/ttnn/operations/experimental/multi_scale_deformable_attn)
 add_subdirectory(cpp/ttnn/operations/experimental/ccl)

--- a/ttnn/cpp/ttnn/operations/experimental/experimental_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/experimental_nanobind.cpp
@@ -49,6 +49,7 @@
 #include "ttnn/operations/experimental/matmul/group_attn_matmul/group_attn_matmul_nanobind.hpp"
 #include "ttnn/operations/experimental/ccl/ccl_experimental_nanobind.hpp"
 #include "ttnn/operations/experimental/plusone/plusone_nanobind.hpp"
+#include "ttnn/operations/experimental/quasar/quasar_nanobind.hpp"
 #include "ttnn/operations/experimental/dropout/dropout_nanobind.hpp"
 #include "ttnn/operations/experimental/bcast_to/bcast_to_nanobind.hpp"
 #include "ttnn/operations/experimental/multi_scale_deformable_attn/multi_scale_deformable_attn_nanobind.hpp"
@@ -151,6 +152,9 @@ void py_module(nb::module_& mod) {
     deepseek_prefill::per_token_cast_back::detail::bind_experimental_per_token_cast_back_operation(mod);
 
     plusone::detail::bind_experimental_plusone_operation(mod);
+
+    // Quasar (metal 2.0) ops — creates the ttnn.experimental.quasar submodule.
+    quasar::bind_quasar(mod);
     dropout::detail::bind_experimental_dropout_operation(mod);
     reshape::detail::bind_view(mod);
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/CMakeLists.txt
@@ -1,0 +1,46 @@
+include(sources.cmake)
+
+add_library(ttnn_op_experimental_quasar ${LIB_TYPE})
+add_library(TTNN::Ops::Experimental::Quasar ALIAS ttnn_op_experimental_quasar)
+
+tt_reuse_precompile_headers(ttnn_op_experimental_quasar TTNN::PCHFull)
+# NOTE: unity build intentionally NOT enabled here. The quasar ops are clones of ops that
+# originally live in separate libraries; combining them in one unity translation unit could
+# surface file-local-helper name collisions across ops. Compiling each file standalone avoids that.
+
+set_target_properties(
+    ttnn_op_experimental_quasar
+    PROPERTIES
+        INTERFACE_HEADER_SETS_TO_VERIFY
+            api
+)
+
+file(GLOB_RECURSE kernels */device/kernels/*)
+
+target_sources(
+    ttnn_op_experimental_quasar
+    PUBLIC
+        FILE_SET api
+        TYPE HEADERS
+        BASE_DIRS ${FixmeOpAPIDir}
+        FILES ${TTNN_OP_EXPERIMENTAL_QUASAR_API_HEADERS}
+        FILE_SET kernels
+        TYPE HEADERS
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
+        FILES ${kernels}
+    PRIVATE
+        ${TTNN_OP_EXPERIMENTAL_QUASAR_SRCS}
+)
+
+target_link_libraries(ttnn_op_experimental_quasar PRIVATE TT::Metalium PUBLIC TTNN::Core)
+
+install(
+    TARGETS
+        ttnn_op_experimental_quasar
+    FILE_SET
+    kernels
+        DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/ttnn/cpp/ttnn/operations/experimental/quasar
+        COMPONENT ttnn-runtime
+)
+
+install(TARGETS ttnn_op_experimental_quasar FILE_SET api COMPONENT ttnn-dev LIBRARY COMPONENT tar)

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary/binary.cpp
@@ -1,0 +1,1294 @@
+
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "binary.hpp"
+#include <tt-metalium/sub_device_types.hpp>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/data_movement/repeat/repeat.hpp"
+#include "ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.hpp"
+#include "ttnn/operations/eltwise/unary/unary.hpp"
+#include "ttnn/operations/copy/typecast/typecast.hpp"
+#include "ttnn/operations/core/core.hpp"
+
+// Implementation macros for binary operations (must match declarations in binary.hpp)
+#define TTNN_BINARY_OP_TENSOR_TENSOR_IMPL(NAME, OP_TYPE)                                 \
+    Tensor NAME(                                                                         \
+        const Tensor& lhs,                                                               \
+        const Tensor& rhs,                                                               \
+        const std::optional<const DataType>& output_dtype,                               \
+        const std::optional<MemoryConfig>& memory_config,                                \
+        const std::optional<Tensor>& output,                                             \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,     \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,      \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,      \
+        const std::optional<CoreRangeSet>& sub_core_grids,                               \
+        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {                 \
+        return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng( \
+            lhs,                                                                         \
+            rhs,                                                                         \
+            operations::experimental::quasar::binary::BinaryOpType::OP_TYPE,             \
+            output_dtype,                                                                \
+            memory_config,                                                               \
+            output,                                                                      \
+            post_activations,                                                            \
+            lhs_activations,                                                             \
+            rhs_activations,                                                             \
+            /*fast_and_approximate_mode*/ false,                                         \
+            sub_core_grids,                                                              \
+            sub_device_id);                                                              \
+    }
+
+#define TTNN_BINARY_OP_TENSOR_TENSOR_UINT8_IMPL(NAME, OP_TYPE)                                                \
+    Tensor NAME(                                                                                              \
+        const Tensor& lhs,                                                                                    \
+        const Tensor& rhs,                                                                                    \
+        const std::optional<const DataType>& output_dtype,                                                    \
+        const std::optional<MemoryConfig>& memory_config,                                                     \
+        const std::optional<Tensor>& output,                                                                  \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,                          \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,                           \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,                           \
+        const std::optional<CoreRangeSet>& sub_core_grids,                                                    \
+        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {                                      \
+        const std::optional<Tensor> lhs_cast =                                                                \
+            lhs.dtype() == DataType::UINT8 ? ttnn::typecast(lhs, DataType::UINT16) : std::optional<Tensor>{}; \
+        const Tensor& a = lhs_cast.has_value() ? *lhs_cast : lhs;                                             \
+        const std::optional<Tensor> rhs_cast =                                                                \
+            rhs.dtype() == DataType::UINT8 ? ttnn::typecast(rhs, DataType::UINT16) : std::optional<Tensor>{}; \
+        const Tensor& b = rhs_cast.has_value() ? *rhs_cast : rhs;                                             \
+        return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(                      \
+            a,                                                                                                \
+            b,                                                                                                \
+            operations::experimental::quasar::binary::BinaryOpType::OP_TYPE,                                  \
+            output_dtype,                                                                                     \
+            memory_config,                                                                                    \
+            output,                                                                                           \
+            post_activations,                                                                                 \
+            lhs_activations,                                                                                  \
+            rhs_activations,                                                                                  \
+            /*fast_and_approximate_mode*/ false,                                                              \
+            sub_core_grids,                                                                                   \
+            sub_device_id);                                                                                   \
+    }
+
+#define TTNN_BINARY_OP_TENSOR_SCALAR_UINT8_IMPL(NAME, OP_TYPE)                                                \
+    Tensor NAME(                                                                                              \
+        const Tensor& lhs,                                                                                    \
+        operations::unary::ScalarVariant rhs,                                                                 \
+        const std::optional<const DataType>& output_dtype,                                                    \
+        const std::optional<MemoryConfig>& memory_config,                                                     \
+        const std::optional<Tensor>& output,                                                                  \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,                          \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,                           \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,                           \
+        const std::optional<CoreRangeSet>& sub_core_grids,                                                    \
+        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {                                      \
+        const std::optional<Tensor> lhs_cast =                                                                \
+            lhs.dtype() == DataType::UINT8 ? ttnn::typecast(lhs, DataType::UINT16) : std::optional<Tensor>{}; \
+        const Tensor& a = lhs_cast.has_value() ? *lhs_cast : lhs;                                             \
+        return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(                      \
+            a,                                                                                                \
+            rhs,                                                                                              \
+            operations::experimental::quasar::binary::BinaryOpType::OP_TYPE,                                  \
+            output_dtype,                                                                                     \
+            memory_config,                                                                                    \
+            output,                                                                                           \
+            post_activations,                                                                                 \
+            lhs_activations,                                                                                  \
+            rhs_activations,                                                                                  \
+            /*fast_and_approximate_mode*/ false,                                                              \
+            sub_core_grids,                                                                                   \
+            sub_device_id);                                                                                   \
+    }
+
+#define TTNN_BINARY_OP_FLOAT_TENSOR_UINT8_IMPL(NAME, OP_TYPE)                                                       \
+    Tensor NAME(                                                                                                    \
+        float lhs,                                                                                                  \
+        const Tensor& rhs,                                                                                          \
+        const std::optional<const DataType>& dtype,                                                                 \
+        const std::optional<MemoryConfig>& memory_config,                                                           \
+        const std::optional<Tensor>& output) {                                                                      \
+        const std::optional<Tensor> rhs_cast =                                                                      \
+            rhs.dtype() == DataType::UINT8 ? ttnn::typecast(rhs, DataType::UINT16) : std::optional<Tensor>{};       \
+        const Tensor& b = rhs_cast.has_value() ? *rhs_cast : rhs;                                                   \
+        return operations::experimental::quasar::binary::relational_binary<                                         \
+            operations::experimental::quasar::binary::BinaryOpType::OP_TYPE>(lhs, b, dtype, memory_config, output); \
+    }
+
+#define TTNN_BINARY_OP_TENSOR_SCALAR_IMPL(NAME, OP_TYPE)                                 \
+    Tensor NAME(                                                                         \
+        const Tensor& lhs,                                                               \
+        operations::unary::ScalarVariant rhs,                                            \
+        const std::optional<const DataType>& output_dtype,                               \
+        const std::optional<MemoryConfig>& memory_config,                                \
+        const std::optional<Tensor>& output,                                             \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,     \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,      \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,      \
+        const std::optional<CoreRangeSet>& sub_core_grids,                               \
+        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {                 \
+        return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng( \
+            lhs,                                                                         \
+            rhs,                                                                         \
+            operations::experimental::quasar::binary::BinaryOpType::OP_TYPE,             \
+            output_dtype,                                                                \
+            memory_config,                                                               \
+            output,                                                                      \
+            post_activations,                                                            \
+            lhs_activations,                                                             \
+            rhs_activations,                                                             \
+            /*fast_and_approximate_mode*/ false,                                         \
+            sub_core_grids,                                                              \
+            sub_device_id);                                                              \
+    }
+
+#define TTNN_BINARY_OP_INPLACE_IMPL(NAME, OP_TYPE)                                       \
+    Tensor NAME(                                                                         \
+        const Tensor& lhs,                                                               \
+        const Tensor& rhs,                                                               \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,     \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,      \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,      \
+        const std::optional<CoreRangeSet>& sub_core_grids,                               \
+        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {                 \
+        return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng( \
+            lhs,                                                                         \
+            rhs,                                                                         \
+            operations::experimental::quasar::binary::BinaryOpType::OP_TYPE,             \
+            std::nullopt,                                                                \
+            std::nullopt,                                                                \
+            lhs,                                                                         \
+            post_activations,                                                            \
+            lhs_activations,                                                             \
+            rhs_activations,                                                             \
+            /*fast_and_approximate_mode*/ false,                                         \
+            sub_core_grids,                                                              \
+            sub_device_id);                                                              \
+    }                                                                                    \
+    Tensor NAME(                                                                         \
+        const Tensor& lhs,                                                               \
+        operations::unary::ScalarVariant rhs,                                            \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,     \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,      \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,      \
+        const std::optional<CoreRangeSet>& sub_core_grids,                               \
+        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {                 \
+        return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng( \
+            lhs,                                                                         \
+            rhs,                                                                         \
+            operations::experimental::quasar::binary::BinaryOpType::OP_TYPE,             \
+            std::nullopt,                                                                \
+            std::nullopt,                                                                \
+            lhs,                                                                         \
+            post_activations,                                                            \
+            lhs_activations,                                                             \
+            rhs_activations,                                                             \
+            /*fast_and_approximate_mode*/ false,                                         \
+            sub_core_grids,                                                              \
+            sub_device_id);                                                              \
+    }
+
+#define TTNN_BINARY_OP_INPLACE_RELATIONAL_IMPL(NAME, OP_TYPE)                                             \
+    Tensor NAME(                                                                                          \
+        const Tensor& lhs,                                                                                \
+        const Tensor& rhs,                                                                                \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,                      \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,                       \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,                       \
+        const std::optional<CoreRangeSet>& sub_core_grids,                                                \
+        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {                                  \
+        return operations::experimental::quasar::binary::inplace_relational_binary<                       \
+            operations::experimental::quasar::binary::BinaryOpType::OP_TYPE>(                             \
+            lhs, rhs, post_activations, lhs_activations, rhs_activations, sub_core_grids, sub_device_id); \
+    }                                                                                                     \
+    Tensor NAME(                                                                                          \
+        const Tensor& lhs,                                                                                \
+        operations::unary::ScalarVariant rhs,                                                             \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,                      \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,                       \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,                       \
+        const std::optional<CoreRangeSet>& sub_core_grids,                                                \
+        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {                                  \
+        return operations::experimental::quasar::binary::inplace_relational_binary<                       \
+            operations::experimental::quasar::binary::BinaryOpType::OP_TYPE>(                             \
+            lhs, rhs, post_activations, lhs_activations, rhs_activations, sub_core_grids, sub_device_id); \
+    }
+
+#define TTNN_BINARY_OP_INPLACE_INVOKE_IMPL(NAME, OP_TYPE)                                \
+    Tensor NAME(                                                                         \
+        const Tensor& lhs,                                                               \
+        const Tensor& rhs,                                                               \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,     \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,      \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,      \
+        const std::optional<CoreRangeSet>& sub_core_grids,                               \
+        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {                 \
+        return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng( \
+            lhs,                                                                         \
+            rhs,                                                                         \
+            operations::experimental::quasar::binary::BinaryOpType::OP_TYPE,             \
+            std::nullopt,                                                                \
+            std::nullopt,                                                                \
+            lhs,                                                                         \
+            post_activations,                                                            \
+            lhs_activations,                                                             \
+            rhs_activations,                                                             \
+            /*fast_and_approximate_mode*/ false,                                         \
+            sub_core_grids,                                                              \
+            sub_device_id);                                                              \
+    }                                                                                    \
+    Tensor NAME(                                                                         \
+        const Tensor& lhs,                                                               \
+        operations::unary::ScalarVariant rhs,                                            \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,     \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,      \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,      \
+        const std::optional<CoreRangeSet>& sub_core_grids,                               \
+        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {                 \
+        return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng( \
+            lhs,                                                                         \
+            rhs,                                                                         \
+            operations::experimental::quasar::binary::BinaryOpType::OP_TYPE,             \
+            std::nullopt,                                                                \
+            std::nullopt,                                                                \
+            lhs,                                                                         \
+            post_activations,                                                            \
+            lhs_activations,                                                             \
+            rhs_activations,                                                             \
+            /*fast_and_approximate_mode*/ false,                                         \
+            sub_core_grids,                                                              \
+            sub_device_id);                                                              \
+    }
+
+#define TTNN_BINARY_OP_TENSOR_TENSOR_BITWISE_IMPL(NAME, OP_TYPE)                         \
+    Tensor NAME(                                                                         \
+        const Tensor& lhs,                                                               \
+        const Tensor& rhs,                                                               \
+        const std::optional<MemoryConfig>& memory_config,                                \
+        const std::optional<Tensor>& output,                                             \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,     \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,      \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,      \
+        const std::optional<CoreRangeSet>& sub_core_grids,                               \
+        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {                 \
+        return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng( \
+            lhs,                                                                         \
+            rhs,                                                                         \
+            operations::experimental::quasar::binary::BinaryOpType::OP_TYPE,             \
+            std::nullopt,                                                                \
+            memory_config,                                                               \
+            output,                                                                      \
+            post_activations,                                                            \
+            lhs_activations,                                                             \
+            rhs_activations,                                                             \
+            /*fast_and_approximate_mode*/ false,                                         \
+            sub_core_grids,                                                              \
+            sub_device_id);                                                              \
+    }
+
+#define TTNN_BINARY_OP_TENSOR_INT32_BITWISE_IMPL(NAME, OP_TYPE)                          \
+    Tensor NAME(                                                                         \
+        const Tensor& lhs,                                                               \
+        int32_t rhs,                                                                     \
+        const std::optional<MemoryConfig>& memory_config,                                \
+        const std::optional<Tensor>& output,                                             \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,     \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,      \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,      \
+        const std::optional<CoreRangeSet>& sub_core_grids,                               \
+        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {                 \
+        return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng( \
+            lhs,                                                                         \
+            rhs,                                                                         \
+            operations::experimental::quasar::binary::BinaryOpType::OP_TYPE,             \
+            std::nullopt,                                                                \
+            memory_config,                                                               \
+            output,                                                                      \
+            post_activations,                                                            \
+            lhs_activations,                                                             \
+            rhs_activations,                                                             \
+            /*fast_and_approximate_mode*/ false,                                         \
+            sub_core_grids,                                                              \
+            sub_device_id);                                                              \
+    }
+
+namespace ttnn::operations::experimental::quasar::binary::detail {
+
+inline Tensor to_dtype(const Tensor& input, DataType dtype) {
+    if (input.dtype() == dtype) {
+        return input;
+    }
+
+    return ttnn::typecast(input, dtype);
+}
+
+inline float to_dtype(float input, [[maybe_unused]] DataType dtype) { return input; }
+inline unary::ScalarVariant to_dtype(unary::ScalarVariant input, [[maybe_unused]] DataType dtype) { return input; }
+
+inline bool is_block_format(DataType dtype) {
+    using enum DataType;
+    switch (dtype) {
+        case BFLOAT4_B:
+        case BFLOAT8_B: return true;
+        default: return false;
+    }
+}
+
+inline bool is_layout_or_scalar(const Tensor& input, Layout layout) { return input.layout() == layout; }
+
+inline bool is_layout_or_scalar([[maybe_unused]] float input, [[maybe_unused]] Layout layout) { return true; }
+inline bool is_layout_or_scalar([[maybe_unused]] unary::ScalarVariant input, [[maybe_unused]] Layout layout) {
+    return true;
+}
+
+inline Tensor to_layout(const Tensor& input, Layout layout) {
+    if (detail::is_layout_or_scalar(input, layout)) {
+        return input;
+    }
+
+    return ttnn::to_layout(input, layout);
+}
+
+inline float to_layout(float input, [[maybe_unused]] Layout layout) { return input; }
+inline unary::ScalarVariant to_layout(unary::ScalarVariant input, [[maybe_unused]] Layout layout) { return input; }
+
+constexpr bool is_associative(BinaryOpType op) {
+    return op == BinaryOpType::ADD || op == BinaryOpType::MUL || op == BinaryOpType::EQ || op == BinaryOpType::NE ||
+           op == BinaryOpType::LOGICAL_AND || op == BinaryOpType::LOGICAL_OR || op == BinaryOpType::LOGADDEXP ||
+           op == BinaryOpType::LOGADDEXP2 || op == BinaryOpType::LOGICAL_XOR || op == BinaryOpType::MAXIMUM ||
+           op == BinaryOpType::MINIMUM || op == BinaryOpType::GCD || op == BinaryOpType::LCM;
+}
+
+// Tensor - Scalar
+inline Tensor binary_impl(
+    operations::experimental::quasar::binary::BinaryOpType binary_op_type,
+    const ttnn::Tensor& lhs,
+    const float rhs,
+    const std::optional<const DataType>& dtype = std::nullopt,
+    const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& output = std::nullopt) {
+    auto output_tensor = lhs;
+    if (binary_op_type == BinaryOpType::GT) {
+        output_tensor = ttnn::gt_unary(lhs, rhs, memory_config, output);
+    } else if (binary_op_type == BinaryOpType::LT) {
+        output_tensor = ttnn::lt_unary(lhs, rhs, memory_config, output);
+    } else if (binary_op_type == BinaryOpType::NE) {
+        output_tensor = ttnn::ne_unary(lhs, rhs, memory_config, output);
+    } else if (binary_op_type == BinaryOpType::GE) {
+        output_tensor = ttnn::ge_unary(lhs, rhs, memory_config, output);
+    } else if (binary_op_type == BinaryOpType::LE) {
+        output_tensor = ttnn::le_unary(lhs, rhs, memory_config, output);
+    } else if (binary_op_type == BinaryOpType::EQ) {
+        output_tensor = ttnn::eq_unary(lhs, rhs, memory_config, output);
+    } else {
+        TT_THROW("Unsupported operation");
+    }
+    if (dtype.has_value()) {
+        output_tensor = ttnn::typecast(output_tensor, *dtype, std::nullopt, output);
+    }
+    return output_tensor;
+}
+
+// Scalar - Tensor
+inline Tensor binary_impl(
+    operations::experimental::quasar::binary::BinaryOpType binary_op_type,
+    const float lhs,
+    const ttnn::Tensor& rhs,
+    const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& output = std::nullopt) {
+    if (binary_op_type == BinaryOpType::GE) {
+        return ttnn::gez(ttnn::sub_sfpu(lhs, rhs, memory_config), memory_config, output);
+    }
+    if (binary_op_type == BinaryOpType::LE) {
+        return ttnn::lez(ttnn::sub_sfpu(lhs, rhs, memory_config), memory_config, output);
+    }
+    if (binary_op_type == BinaryOpType::EQ) {
+        return ttnn::eqz(ttnn::sub_sfpu(lhs, rhs, memory_config), memory_config, output);
+    }
+
+    TT_THROW("Unsupported operation");
+}
+
+inline auto preprocess_inputs(BinaryOpType binary_op_type, Tensor a, Tensor b) {
+    // TODO: #7731 (Remove calls to repeat)
+    constexpr auto repeat_smaller = [](const Tensor& first, Tensor& second) {
+        const auto& first_shape = first.logical_shape();
+        const auto& second_shape = second.logical_shape();
+        // repeats second if it is smaller
+        if (first_shape.rank() == 4 and second_shape.rank() == 4 and first_shape[0] > second_shape[0]) {
+            TT_FATAL(second_shape[0] == 1, "Dimension trying to broadcast is not equal to 1");
+            Shape repeats(std::array<uint32_t, 4>{first_shape[0], 1, 1, 1});
+            second = ttnn::repeat(second, repeats);
+        }
+        // repeats second if it is smaller
+        if (first_shape.rank() >= 3 and second_shape.rank() >= 3 and first_shape[-3] > second_shape[-3]) {
+            TT_FATAL(second_shape[-3] == 1, "Dimension trying to broadcast is not equal to 1");
+            int rank_a = first_shape.rank();
+            std::vector<uint32_t> repeat_dim(rank_a, 1);
+            repeat_dim[rank_a - 3] = first_shape[rank_a - 3];
+            Shape repeats(repeat_dim);
+            second = ttnn::repeat(second, repeats);
+        }
+    };
+
+    repeat_smaller(a, b);
+    repeat_smaller(b, a);
+
+    // Swap tensors if a needs to be broadcasted to b
+    if (detail::is_associative(binary_op_type) and a.logical_volume() < b.logical_volume()) {
+        return std::make_tuple(b, a);
+    }
+
+    return std::make_tuple(a, b);
+}
+
+inline auto any_sharded_block_format(const Tensor& a, const auto& b) {
+    if (a.is_sharded() and is_block_format(a.dtype())) {
+        return true;
+    }
+
+    if constexpr (requires { b.is_sharded(); }) {
+        if (b.is_sharded() and is_block_format(b.dtype())) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+inline auto any_subtile_broadcasted_block_format(const Tensor& a, const auto& b) {
+    if constexpr (requires { b.logical_shape(); }) {
+        const auto& a_shape = a.logical_shape();
+        const auto& b_shape = b.logical_shape();
+
+        if (is_block_format(a.dtype()) &&
+            ((a_shape[-2] == 1 && b_shape[-2] > 1) || (a_shape[-1] == 1 && b_shape[-1] > 1))) {
+            return true;
+        }
+
+        if (is_block_format(b.dtype()) &&
+            ((b_shape[-2] == 1 && a_shape[-2] > 1) || (b_shape[-1] == 1 && a_shape[-1] > 1))) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+}  // namespace ttnn::operations::experimental::quasar::binary::detail
+
+namespace ttnn::operations::experimental::quasar::binary::detail {
+
+inline auto invoke_binary_ng_impl(
+    const Tensor& lhs,
+    const auto& rhs,
+    operations::experimental::quasar::binary::BinaryOpType binary_op_type,
+    const std::optional<const DataType>& dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<bool>& fast_and_approximate_mode,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    const auto a_dtype = lhs.dtype();
+    const DataType b_dtype = [&] {
+        if constexpr (requires { rhs.dtype(); }) {
+            return rhs.dtype();
+        } else {
+            return a_dtype;
+        }
+    }();
+    const auto output_preallocated = output.has_value();
+    const auto is_integer_division = (binary_op_type == operations::experimental::quasar::binary::BinaryOpType::DIV) &&
+                                     (a_dtype == DataType::INT32) && (b_dtype == DataType::INT32);
+    if (is_integer_division) {
+        // For integer division, output dtype should be float32
+        if (dtype.has_value() || output_preallocated) {
+            auto temp_dtype = output_preallocated ? output->dtype() : *dtype;
+            TT_FATAL(temp_dtype == DataType::FLOAT32, "For integer division, supported output dtype is FLOAT32");
+        }
+    }
+    const auto out_dtype = output_preallocated ? output->dtype() : dtype.value_or(a_dtype);
+
+    if (dtype.has_value() && output_preallocated) {
+        TT_FATAL(*dtype == out_dtype, "If both output dtype and output tensor are provided, their dtypes should match");
+    }
+
+    // RM is never BFLOAT8 or BFLOAT4 so we can assume it goes in here.
+
+    const auto input_a_rm =
+        operations::experimental::quasar::binary::detail::is_layout_or_scalar(lhs, Layout::ROW_MAJOR);
+    const auto input_b_rm =
+        operations::experimental::quasar::binary::detail::is_layout_or_scalar(rhs, Layout::ROW_MAJOR);
+    const auto input_a_sharded = lhs.memory_config().is_sharded();
+    const auto input_b_sharded = [&]() {
+        if constexpr (requires { rhs.memory_config(); }) {
+            return rhs.memory_config().is_sharded();
+        } else {
+            return false;
+        }
+    }();
+    // we don't support to_layout with optional output tensor
+    TT_FATAL(
+        !(output_preallocated && input_a_rm && input_b_rm),
+        "Optional output tensor with Row Major input is not supported right now for Elementwise operations");
+    if (input_a_rm and input_b_rm and not input_a_sharded and not input_b_sharded) {
+        auto result = ttnn::prim::qsr::binary_ng(
+            lhs,
+            rhs,
+            binary_op_type,
+            out_dtype,
+            memory_config,
+            output,
+            fast_and_approximate_mode,
+            lhs_activations,
+            rhs_activations,
+            post_activations,
+            std::nullopt,
+            sub_core_grids,
+            sub_device_id);
+
+        return result;
+    }
+    // Either one or both are tiles
+    const auto input_a = operations::experimental::quasar::binary::detail::to_layout(lhs, Layout::TILE);
+    const auto input_b = operations::experimental::quasar::binary::detail::to_layout(rhs, Layout::TILE);
+
+    auto result = ttnn::prim::qsr::binary_ng(
+        input_a,
+        input_b,
+        binary_op_type,
+        out_dtype,
+        memory_config,
+        output,
+        fast_and_approximate_mode,
+        lhs_activations,
+        rhs_activations,
+        post_activations,
+        std::nullopt,
+        sub_core_grids,
+        sub_device_id);
+
+    // if both inputs are in row major, convert the output to row major
+    // since there's no consensus here, avoiding the conversion if we have an excuse to is likely the best option
+    // since it leads to better perf
+    if (input_a_rm and input_b_rm) {
+        return operations::experimental::quasar::binary::detail::to_layout(result, Layout::ROW_MAJOR);
+    }
+
+    return result;
+}
+
+Tensor invoke_binary_ng(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    operations::experimental::quasar::binary::BinaryOpType binary_op_type,
+    const std::optional<const DataType>& dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<bool>& fast_and_approximate_mode,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    return invoke_binary_ng_impl(
+        lhs,
+        rhs,
+        binary_op_type,
+        dtype,
+        memory_config,
+        output,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        fast_and_approximate_mode,
+        sub_core_grids,
+        sub_device_id);
+}
+
+Tensor invoke_binary_ng(
+    const Tensor& lhs,
+    operations::unary::ScalarVariant rhs,
+    operations::experimental::quasar::binary::BinaryOpType binary_op_type,
+    const std::optional<const DataType>& dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<bool>& fast_and_approximate_mode,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    return invoke_binary_ng_impl(
+        lhs,
+        rhs,
+        binary_op_type,
+        dtype,
+        memory_config,
+        output,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        fast_and_approximate_mode,
+        sub_core_grids,
+        sub_device_id);
+}
+
+Tensor invoke_binary_ng_isclose(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    float rtol,
+    float atol,
+    bool equal_nan,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
+    const auto fa = lhs.dtype() == DataType::INT32 ? ttnn::typecast(lhs, DataType::FLOAT32) : lhs;
+    const auto fb = rhs.dtype() == DataType::INT32 ? ttnn::typecast(rhs, DataType::FLOAT32) : rhs;
+
+    const auto input_a_rm = fa.layout() == Layout::ROW_MAJOR;
+    const auto input_b_rm = fb.layout() == Layout::ROW_MAJOR;
+    const auto input_a_sharded = fa.memory_config().is_sharded();
+    const auto input_b_sharded = fb.memory_config().is_sharded();
+
+    using BinaryOpType = ttnn::operations::experimental::quasar::binary_ng::BinaryOpType;
+
+    if (input_a_rm && input_b_rm && !input_a_sharded && !input_b_sharded) {
+        return ttnn::prim::qsr::binary_ng(
+            fa,
+            fb,
+            BinaryOpType::ISCLOSE,
+            std::nullopt,
+            memory_config,
+            output,
+            std::nullopt,
+            {},
+            {},
+            {},
+            std::nullopt,
+            sub_core_grids,
+            std::nullopt,
+            rtol,
+            atol,
+            equal_nan);
+    }
+
+    const auto input_a = operations::experimental::quasar::binary::detail::to_layout(fa, Layout::TILE);
+    const auto input_b = operations::experimental::quasar::binary::detail::to_layout(fb, Layout::TILE);
+    auto result = ttnn::prim::qsr::binary_ng(
+        input_a,
+        input_b,
+        BinaryOpType::ISCLOSE,
+        std::nullopt,
+        memory_config,
+        output,
+        std::nullopt,
+        {},
+        {},
+        {},
+        std::nullopt,
+        sub_core_grids,
+        std::nullopt,
+        rtol,
+        atol,
+        equal_nan);
+
+    // if both inputs are in row major, convert the output to row major
+    // since there's no consensus here, avoiding the conversion if we have an excuse to is likely the best option
+    // since it leads to better perf
+    if (input_a_rm && input_b_rm) {
+        return operations::experimental::quasar::binary::detail::to_layout(result, Layout::ROW_MAJOR);
+    }
+    return result;
+}
+
+}  // namespace ttnn::operations::experimental::quasar::binary::detail
+
+namespace ttnn::operations::experimental::quasar::binary {
+
+template <BinaryOpType binary_op_type>
+Tensor relational_binary(
+    const ttnn::Tensor& lhs,
+    unary::ScalarVariant rhs,
+    const std::optional<const DataType>& dtype,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+        lhs,
+        rhs,
+        binary_op_type,
+        dtype,
+        memory_config,
+        output,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        /*fast_and_approximate_mode*/ false,
+        sub_core_grids,
+        sub_device_id);
+}
+
+// scalar - tensor combination not available on Pytorch for this op
+template <BinaryOpType binary_op_type>
+Tensor relational_binary(
+    const float lhs,
+    const ttnn::Tensor& rhs,
+    const std::optional<const DataType>& /*dtype*/,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output) {
+    return detail::binary_impl(binary_op_type, lhs, rhs, memory_config, output);
+}
+
+template <BinaryOpType binary_op_type>
+Tensor inplace_relational_binary(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+        lhs,
+        rhs,
+        binary_op_type,
+        std::nullopt,
+        std::nullopt,
+        lhs,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        /*fast_and_approximate_mode*/ false,
+        sub_core_grids,
+        sub_device_id);
+}
+
+template <BinaryOpType binary_op_type>
+Tensor inplace_relational_binary(
+    const ttnn::Tensor& lhs,
+    unary::ScalarVariant rhs,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    return relational_binary<binary_op_type>(
+        lhs,
+        rhs,
+        std::nullopt,
+        std::nullopt,
+        lhs,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        sub_core_grids,
+        sub_device_id);
+}
+
+template <BinaryOpType binary_op_type>
+Tensor inplace_mul_operation_with_fast_approx(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    std::optional<bool> fast_and_approximate_mode,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    bool is_block_fmt_inp = (is_block_float(lhs.dtype()) || is_block_float(rhs.dtype()));
+    bool fast_and_approx = is_block_fmt_inp ? true : fast_and_approximate_mode.value_or(false);
+    return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+        lhs,
+        rhs,
+        binary_op_type,
+        std::nullopt,
+        std::nullopt,
+        lhs,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        fast_and_approx,
+        sub_core_grids,
+        sub_device_id);
+}
+
+template <BinaryOpType binary_op_type>
+Tensor inplace_mul_operation_with_fast_approx(
+    const ttnn::Tensor& lhs,
+    unary::ScalarVariant rhs,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    std::optional<bool> fast_and_approximate_mode,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    bool is_block_fmt_inp = (is_block_float(lhs.dtype()));
+    bool fast_and_approx = is_block_fmt_inp ? true : fast_and_approximate_mode.value_or(false);
+    return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+        lhs,
+        rhs,
+        binary_op_type,
+        std::nullopt,
+        std::nullopt,
+        lhs,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        fast_and_approx,
+        sub_core_grids,
+        sub_device_id);
+}
+
+template <BinaryOpType binary_op_type>
+Tensor binary_operation_addalpha(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    float alpha,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output) {
+    SmallVector<unary::EltwiseUnaryWithParam> rhs_activations{{unary::UnaryOpType::MUL_UNARY_SFPU, alpha}};
+    return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+        lhs,
+        rhs,
+        operations::experimental::quasar::binary::BinaryOpType::ADD,
+        std::nullopt,
+        memory_config,
+        output,
+        {},
+        {},
+        rhs_activations,
+        /*fast_and_approximate_mode*/ false,
+        std::nullopt);
+}
+
+template <BinaryOpType binary_op_type>
+Tensor binary_operation_subalpha(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    float alpha,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output) {
+    SmallVector<unary::EltwiseUnaryWithParam> rhs_activations{{unary::UnaryOpType::MUL_UNARY_SFPU, alpha}};
+    return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+        lhs,
+        rhs,
+        operations::experimental::quasar::binary::BinaryOpType::SUB,
+        std::nullopt,
+        memory_config,
+        output,
+        {},
+        {},
+        rhs_activations,
+        /*fast_and_approximate_mode*/ false,
+        std::nullopt);
+}
+
+template <BinaryOpType binary_op_type>
+Tensor where_operation_with_scalar(
+    const Tensor& condition,
+    const Tensor& true_false_tensor,
+    unary::ScalarVariant scalar_value,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    constexpr ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> none{};
+    return ttnn::prim::qsr::binary_ng(
+        condition,
+        true_false_tensor,
+        binary_op_type,
+        std::nullopt,
+        memory_config,
+        optional_output_tensor,
+        false,         // fast_and_approximate_mode
+        none,          // lhs_activations
+        none,          // rhs_activations
+        none,          // post_activations
+        scalar_value,  // scalar
+        sub_core_grids,
+        sub_device_id);
+}
+
+template Tensor where_operation_with_scalar<BinaryOpType::WHERE_TST>(
+    const Tensor&,
+    const Tensor&,
+    unary::ScalarVariant,
+    const std::optional<MemoryConfig>&,
+    const std::optional<Tensor>&,
+    const std::optional<CoreRangeSet>&,
+    const std::optional<tt::tt_metal::SubDeviceId>&);
+template Tensor where_operation_with_scalar<BinaryOpType::WHERE_TTS>(
+    const Tensor&,
+    const Tensor&,
+    unary::ScalarVariant,
+    const std::optional<MemoryConfig>&,
+    const std::optional<Tensor>&,
+    const std::optional<CoreRangeSet>&,
+    const std::optional<tt::tt_metal::SubDeviceId>&);
+
+}  // namespace ttnn::operations::experimental::quasar::binary
+
+namespace ttnn::operations::experimental::quasar::binary {
+
+TTNN_BINARY_OP_TENSOR_TENSOR_IMPL(add, ADD)
+TTNN_BINARY_OP_TENSOR_SCALAR_IMPL(add, ADD)
+TTNN_BINARY_OP_INPLACE_IMPL(add_, ADD)
+TTNN_BINARY_OP_TENSOR_TENSOR_IMPL(subtract, SUB)
+TTNN_BINARY_OP_TENSOR_SCALAR_IMPL(subtract, SUB)
+TTNN_BINARY_OP_INPLACE_IMPL(subtract_, SUB)
+TTNN_BINARY_OP_TENSOR_TENSOR_UINT8_IMPL(eq, EQ)
+TTNN_BINARY_OP_TENSOR_SCALAR_UINT8_IMPL(eq, EQ)
+TTNN_BINARY_OP_FLOAT_TENSOR_UINT8_IMPL(eq, EQ)
+TTNN_BINARY_OP_TENSOR_TENSOR_UINT8_IMPL(ne, NE)
+TTNN_BINARY_OP_TENSOR_SCALAR_UINT8_IMPL(ne, NE)
+TTNN_BINARY_OP_FLOAT_TENSOR_UINT8_IMPL(ne, NE)
+TTNN_BINARY_OP_TENSOR_TENSOR_UINT8_IMPL(ge, GE)
+TTNN_BINARY_OP_TENSOR_SCALAR_UINT8_IMPL(ge, GE)
+TTNN_BINARY_OP_FLOAT_TENSOR_UINT8_IMPL(ge, GE)
+TTNN_BINARY_OP_TENSOR_TENSOR_UINT8_IMPL(gt, GT)
+TTNN_BINARY_OP_TENSOR_SCALAR_UINT8_IMPL(gt, GT)
+TTNN_BINARY_OP_FLOAT_TENSOR_UINT8_IMPL(gt, GT)
+TTNN_BINARY_OP_TENSOR_TENSOR_UINT8_IMPL(le, LE)
+TTNN_BINARY_OP_TENSOR_SCALAR_UINT8_IMPL(le, LE)
+TTNN_BINARY_OP_FLOAT_TENSOR_UINT8_IMPL(le, LE)
+TTNN_BINARY_OP_TENSOR_TENSOR_UINT8_IMPL(lt, LT)
+TTNN_BINARY_OP_TENSOR_SCALAR_UINT8_IMPL(lt, LT)
+TTNN_BINARY_OP_FLOAT_TENSOR_UINT8_IMPL(lt, LT)
+TTNN_BINARY_OP_TENSOR_TENSOR_IMPL(logical_and, LOGICAL_AND)
+TTNN_BINARY_OP_TENSOR_SCALAR_IMPL(logical_and, LOGICAL_AND)
+TTNN_BINARY_OP_TENSOR_TENSOR_IMPL(logical_or, LOGICAL_OR)
+TTNN_BINARY_OP_TENSOR_SCALAR_IMPL(logical_or, LOGICAL_OR)
+TTNN_BINARY_OP_TENSOR_TENSOR_IMPL(logical_xor, LOGICAL_XOR)
+TTNN_BINARY_OP_TENSOR_SCALAR_IMPL(logical_xor, LOGICAL_XOR)
+TTNN_BINARY_OP_TENSOR_TENSOR_IMPL(ldexp, LDEXP)
+TTNN_BINARY_OP_TENSOR_SCALAR_IMPL(ldexp, LDEXP)
+TTNN_BINARY_OP_INPLACE_IMPL(ldexp_, LDEXP)
+TTNN_BINARY_OP_TENSOR_TENSOR_IMPL(logaddexp, LOGADDEXP)
+TTNN_BINARY_OP_TENSOR_SCALAR_IMPL(logaddexp, LOGADDEXP)
+TTNN_BINARY_OP_INPLACE_IMPL(logaddexp_, LOGADDEXP)
+TTNN_BINARY_OP_TENSOR_TENSOR_IMPL(logaddexp2, LOGADDEXP2)
+TTNN_BINARY_OP_TENSOR_SCALAR_IMPL(logaddexp2, LOGADDEXP2)
+TTNN_BINARY_OP_INPLACE_IMPL(logaddexp2_, LOGADDEXP2)
+TTNN_BINARY_OP_TENSOR_TENSOR_IMPL(squared_difference, SQUARED_DIFFERENCE)
+TTNN_BINARY_OP_TENSOR_SCALAR_IMPL(squared_difference, SQUARED_DIFFERENCE)
+TTNN_BINARY_OP_INPLACE_IMPL(squared_difference_, SQUARED_DIFFERENCE)
+TTNN_BINARY_OP_TENSOR_TENSOR_IMPL(logical_right_shift, LOGICAL_RIGHT_SHIFT)
+TTNN_BINARY_OP_TENSOR_SCALAR_IMPL(logical_right_shift, LOGICAL_RIGHT_SHIFT)
+TTNN_BINARY_OP_TENSOR_TENSOR_BITWISE_IMPL(bitwise_and, BITWISE_AND)
+TTNN_BINARY_OP_TENSOR_INT32_BITWISE_IMPL(bitwise_and, BITWISE_AND)
+TTNN_BINARY_OP_TENSOR_TENSOR_BITWISE_IMPL(bitwise_or, BITWISE_OR)
+TTNN_BINARY_OP_TENSOR_INT32_BITWISE_IMPL(bitwise_or, BITWISE_OR)
+TTNN_BINARY_OP_TENSOR_TENSOR_BITWISE_IMPL(bitwise_xor, BITWISE_XOR)
+TTNN_BINARY_OP_TENSOR_INT32_BITWISE_IMPL(bitwise_xor, BITWISE_XOR)
+TTNN_BINARY_OP_TENSOR_TENSOR_BITWISE_IMPL(bitwise_left_shift, LEFT_SHIFT)
+TTNN_BINARY_OP_TENSOR_INT32_BITWISE_IMPL(bitwise_left_shift, LEFT_SHIFT)
+TTNN_BINARY_OP_TENSOR_TENSOR_BITWISE_IMPL(bitwise_right_shift, RIGHT_SHIFT)
+TTNN_BINARY_OP_TENSOR_INT32_BITWISE_IMPL(bitwise_right_shift, RIGHT_SHIFT)
+TTNN_BINARY_OP_TENSOR_TENSOR_BITWISE_IMPL(logical_left_shift, LEFT_SHIFT)
+TTNN_BINARY_OP_TENSOR_INT32_BITWISE_IMPL(logical_left_shift, LEFT_SHIFT)
+TTNN_BINARY_OP_TENSOR_TENSOR_IMPL(xlogy, XLOGY)
+TTNN_BINARY_OP_TENSOR_SCALAR_IMPL(xlogy, XLOGY)
+
+Tensor divide(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    const std::optional<const DataType>& output_dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<bool>& fast_and_approximate_mode,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+        lhs,
+        rhs,
+        operations::experimental::quasar::binary::BinaryOpType::DIV,
+        output_dtype,
+        memory_config,
+        output,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        fast_and_approximate_mode,
+        sub_core_grids,
+        sub_device_id);
+}
+Tensor divide(
+    const Tensor& lhs,
+    operations::unary::ScalarVariant rhs,
+    const std::optional<const DataType>& output_dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<bool>& fast_and_approximate_mode,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+        lhs,
+        rhs,
+        operations::experimental::quasar::binary::BinaryOpType::DIV,
+        output_dtype,
+        memory_config,
+        output,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        fast_and_approximate_mode,
+        sub_core_grids,
+        sub_device_id);
+}
+Tensor divide_(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    std::optional<bool> fast_and_approximate_mode,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+        lhs,
+        rhs,
+        operations::experimental::quasar::binary::BinaryOpType::DIV,
+        std::nullopt,
+        std::nullopt,
+        lhs,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        fast_and_approximate_mode,
+        sub_core_grids,
+        sub_device_id);
+}
+Tensor divide_(
+    const Tensor& lhs,
+    operations::unary::ScalarVariant rhs,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    std::optional<bool> fast_and_approximate_mode,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+        lhs,
+        rhs,
+        operations::experimental::quasar::binary::BinaryOpType::DIV,
+        std::nullopt,
+        std::nullopt,
+        lhs,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        fast_and_approximate_mode,
+        sub_core_grids,
+        sub_device_id);
+}
+Tensor multiply(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    const std::optional<const DataType>& output_dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<bool>& fast_and_approximate_mode,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    bool is_block_fmt_inp = (is_block_float(lhs.dtype()) || is_block_float(rhs.dtype()));
+    bool fast_and_approx = is_block_fmt_inp ? true : fast_and_approximate_mode.value_or(false);
+    return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+        lhs,
+        rhs,
+        operations::experimental::quasar::binary::BinaryOpType::MUL,
+        output_dtype,
+        memory_config,
+        output,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        fast_and_approx,
+        sub_core_grids,
+        sub_device_id);
+}
+Tensor multiply(
+    const Tensor& lhs,
+    operations::unary::ScalarVariant rhs,
+    const std::optional<const DataType>& output_dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<bool>& fast_and_approximate_mode,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    bool is_block_fmt_inp = (is_block_float(lhs.dtype()));
+    bool fast_and_approx = is_block_fmt_inp ? true : fast_and_approximate_mode.value_or(false);
+    return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+        lhs,
+        rhs,
+        operations::experimental::quasar::binary::BinaryOpType::MUL,
+        output_dtype,
+        memory_config,
+        output,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        fast_and_approx,
+        sub_core_grids,
+        sub_device_id);
+}
+Tensor multiply(const Tensor& lhs, const Tensor& rhs, bool fast_and_approximate_mode) {
+    return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+        lhs,
+        rhs,
+        operations::experimental::quasar::binary::BinaryOpType::MUL,
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        {},
+        {},
+        {},
+        fast_and_approximate_mode,
+        std::nullopt);
+}
+Tensor multiply(const Tensor& lhs, operations::unary::ScalarVariant rhs, bool fast_and_approximate_mode) {
+    return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+        lhs,
+        rhs,
+        operations::experimental::quasar::binary::BinaryOpType::MUL,
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        {},
+        {},
+        {},
+        fast_and_approximate_mode,
+        std::nullopt);
+}
+Tensor multiply_(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    std::optional<bool> fast_and_approximate_mode,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    return operations::experimental::quasar::binary::inplace_mul_operation_with_fast_approx<
+        operations::experimental::quasar::binary::BinaryOpType::MUL>(
+        lhs,
+        rhs,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        fast_and_approximate_mode,
+        sub_core_grids,
+        sub_device_id);
+}
+Tensor multiply_(
+    const Tensor& lhs,
+    operations::unary::ScalarVariant rhs,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    std::optional<bool> fast_and_approximate_mode,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    return operations::experimental::quasar::binary::inplace_mul_operation_with_fast_approx<
+        operations::experimental::quasar::binary::BinaryOpType::MUL>(
+        lhs,
+        rhs,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        fast_and_approximate_mode,
+        sub_core_grids,
+        sub_device_id);
+}
+TTNN_BINARY_OP_INPLACE_RELATIONAL_IMPL(gt_, GT)
+TTNN_BINARY_OP_INPLACE_RELATIONAL_IMPL(ge_, GE)
+TTNN_BINARY_OP_INPLACE_RELATIONAL_IMPL(le_, LE)
+TTNN_BINARY_OP_INPLACE_RELATIONAL_IMPL(lt_, LT)
+TTNN_BINARY_OP_INPLACE_INVOKE_IMPL(logical_and_, LOGICAL_AND)
+TTNN_BINARY_OP_INPLACE_INVOKE_IMPL(logical_or_, LOGICAL_OR)
+TTNN_BINARY_OP_INPLACE_INVOKE_IMPL(logical_xor_, LOGICAL_XOR)
+TTNN_BINARY_OP_INPLACE_RELATIONAL_IMPL(eq_, EQ)
+TTNN_BINARY_OP_INPLACE_RELATIONAL_IMPL(ne_, NE)
+TTNN_BINARY_OP_INPLACE_INVOKE_IMPL(rsub_, RSUB)
+TTNN_BINARY_OP_INPLACE_INVOKE_IMPL(bias_gelu_, BIAS_GELU)
+#undef TTNN_BINARY_OP_TENSOR_TENSOR_IMPL
+#undef TTNN_BINARY_OP_FLOAT_TENSOR_UINT8_IMPL
+#undef TTNN_BINARY_OP_TENSOR_SCALAR_UINT8_IMPL
+#undef TTNN_BINARY_OP_TENSOR_TENSOR_UINT8_IMPL
+#undef TTNN_BINARY_OP_TENSOR_SCALAR_IMPL
+#undef TTNN_BINARY_OP_TENSOR_TENSOR_BITWISE_IMPL
+#undef TTNN_BINARY_OP_TENSOR_INT32_BITWISE_IMPL
+#undef TTNN_BINARY_OP_INPLACE_IMPL
+#undef TTNN_BINARY_OP_INPLACE_RELATIONAL_IMPL
+#undef TTNN_BINARY_OP_INPLACE_INVOKE_IMPL
+Tensor addalpha(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    float alpha,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output) {
+    return operations::experimental::quasar::binary::binary_operation_addalpha<
+        operations::experimental::quasar::binary::BinaryOpType::ADDALPHA>(lhs, rhs, alpha, memory_config, output);
+}
+Tensor subalpha(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    float alpha,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output) {
+    return operations::experimental::quasar::binary::binary_operation_subalpha<
+        operations::experimental::quasar::binary::BinaryOpType::SUBALPHA>(lhs, rhs, alpha, memory_config, output);
+}
+Tensor hypot(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor) {
+    return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+        input_tensor_a,
+        input_tensor_b,
+        operations::experimental::quasar::binary::BinaryOpType::HYPOT,
+        std::nullopt,
+        memory_config,
+        optional_output_tensor,
+        {},
+        {},
+        {},
+        /*fast_and_approximate_mode*/ false,
+        std::nullopt);
+}
+
+Tensor isclose(
+    const Tensor& input_a,
+    const Tensor& input_b,
+    float rtol,
+    float atol,
+    bool equal_nan,
+    const std::optional<MemoryConfig>& output_mem_config) {
+    return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng_isclose(
+        input_a, input_b, rtol, atol, equal_nan, output_mem_config, std::nullopt);
+}
+
+}  // namespace ttnn::operations::experimental::quasar::binary

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary/binary.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary/binary.hpp
@@ -1,0 +1,506 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+#include "ttnn/operations/experimental/quasar/binary/common/binary_op_types.hpp"
+#include "ttnn/types.hpp"
+#include <tt-metalium/sub_device_types.hpp>
+
+// Macros for binary operations with identical argument signatures and implementation.
+// Each macro generates function declaration(s). Use the corresponding TTNN_*_IMPL macro in .cpp.
+
+// Tensor-Tensor binary op (calls invoke_binary_ng)
+#define TTNN_BINARY_OP_TENSOR_TENSOR(NAME, OP_TYPE)                                       \
+    Tensor NAME(                                                                          \
+        const Tensor& lhs,                                                                \
+        const Tensor& rhs,                                                                \
+        const std::optional<const DataType>& output_dtype = std::nullopt,                 \
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,                  \
+        const std::optional<Tensor>& output = std::nullopt,                               \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {}, \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},  \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},  \
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,                 \
+        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+
+// Tensor-scalar binary op (calls invoke_binary_ng)
+#define TTNN_BINARY_OP_TENSOR_SCALAR(NAME, OP_TYPE)                                       \
+    Tensor NAME(                                                                          \
+        const Tensor& lhs,                                                                \
+        operations::unary::ScalarVariant rhs,                                             \
+        const std::optional<const DataType>& output_dtype = std::nullopt,                 \
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,                  \
+        const std::optional<Tensor>& output = std::nullopt,                               \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {}, \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},  \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},  \
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,                 \
+        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+
+// Inplace binary op (Tensor-Tensor and Tensor-scalar, calls invoke_binary_ng with output=lhs)
+#define TTNN_BINARY_OP_INPLACE(NAME, OP_TYPE)                                             \
+    Tensor NAME(                                                                          \
+        const Tensor& lhs,                                                                \
+        const Tensor& rhs,                                                                \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {}, \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},  \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},  \
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,                 \
+        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);    \
+    Tensor NAME(                                                                          \
+        const Tensor& lhs,                                                                \
+        operations::unary::ScalarVariant rhs,                                             \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {}, \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},  \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},  \
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,                 \
+        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+
+// Inplace relational binary op (Tensor-Tensor and Tensor-scalar, calls inplace_relational_binary)
+#define TTNN_BINARY_OP_INPLACE_RELATIONAL(NAME, OP_TYPE)                                  \
+    Tensor NAME(                                                                          \
+        const Tensor& lhs,                                                                \
+        const Tensor& rhs,                                                                \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {}, \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},  \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},  \
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,                 \
+        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);    \
+    Tensor NAME(                                                                          \
+        const Tensor& lhs,                                                                \
+        operations::unary::ScalarVariant rhs,                                             \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {}, \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},  \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},  \
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,                 \
+        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+
+// Tensor-Tensor bitwise binary op (no output_dtype, calls invoke_binary_ng)
+#define TTNN_BINARY_OP_TENSOR_TENSOR_BITWISE(NAME, OP_TYPE)                               \
+    Tensor NAME(                                                                          \
+        const Tensor& lhs,                                                                \
+        const Tensor& rhs,                                                                \
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,                  \
+        const std::optional<Tensor>& output = std::nullopt,                               \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {}, \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},  \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},  \
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,                 \
+        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+
+// Tensor-int32_t bitwise binary op (no output_dtype, calls invoke_binary_ng)
+#define TTNN_BINARY_OP_TENSOR_INT32_BITWISE(NAME, OP_TYPE)                                \
+    Tensor NAME(                                                                          \
+        const Tensor& lhs,                                                                \
+        int32_t rhs,                                                                      \
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,                  \
+        const std::optional<Tensor>& output = std::nullopt,                               \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {}, \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},  \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},  \
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,                 \
+        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+
+// Inplace binary op that calls invoke_binary_ng (logical_and_, logical_or_, logical_xor_, rsub_, bias_gelu_)
+#define TTNN_BINARY_OP_INPLACE_INVOKE(NAME, OP_TYPE)                                      \
+    Tensor NAME(                                                                          \
+        const Tensor& lhs,                                                                \
+        const Tensor& rhs,                                                                \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {}, \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},  \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},  \
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,                 \
+        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);    \
+    Tensor NAME(                                                                          \
+        const Tensor& lhs,                                                                \
+        operations::unary::ScalarVariant rhs,                                             \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {}, \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},  \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},  \
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,                 \
+        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+
+namespace ttnn::operations::experimental::quasar::binary {
+// (flattened into enclosing quasar::binary namespace)
+
+template <BinaryOpType binary_op_type>
+Tensor where_operation_with_scalar(
+    const Tensor& condition,
+    const Tensor& true_false_tensor,
+    unary::ScalarVariant scalar_value,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+
+// (end flattened operations::binary)
+
+namespace detail {
+
+Tensor invoke_binary_ng(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    operations::experimental::quasar::binary::BinaryOpType binary_op_type,
+    const std::optional<const DataType>& dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<bool>& fast_and_approximate_mode = false,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+
+Tensor invoke_binary_ng(
+    const Tensor& lhs,
+    operations::unary::ScalarVariant rhs,
+    operations::experimental::quasar::binary::BinaryOpType binary_op_type,
+    const std::optional<const DataType>& dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<bool>& fast_and_approximate_mode = false,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+
+Tensor invoke_binary_ng_isclose(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    float rtol,
+    float atol,
+    bool equal_nan,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+
+}  // namespace detail
+
+TTNN_BINARY_OP_TENSOR_TENSOR(add, ADD)
+TTNN_BINARY_OP_TENSOR_SCALAR(add, ADD)
+TTNN_BINARY_OP_INPLACE(add_, ADD)
+TTNN_BINARY_OP_TENSOR_TENSOR(subtract, SUB)
+TTNN_BINARY_OP_TENSOR_SCALAR(subtract, SUB)
+TTNN_BINARY_OP_INPLACE(subtract_, SUB)
+TTNN_BINARY_OP_TENSOR_TENSOR(eq, EQ)
+Tensor eq(
+    const Tensor& lhs,
+    operations::unary::ScalarVariant rhs,
+    const std::optional<const DataType>& dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& output = std::nullopt,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+Tensor eq(
+    float lhs,
+    const Tensor& rhs,
+    const std::optional<const DataType>& dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& output = std::nullopt);
+TTNN_BINARY_OP_TENSOR_TENSOR(ne, NE)
+Tensor ne(
+    const Tensor& lhs,
+    operations::unary::ScalarVariant rhs,
+    const std::optional<const DataType>& dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& output = std::nullopt,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+Tensor ne(
+    float lhs,
+    const Tensor& rhs,
+    const std::optional<const DataType>& dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& output = std::nullopt);
+TTNN_BINARY_OP_TENSOR_TENSOR(ge, GE)
+Tensor ge(
+    const Tensor& lhs,
+    operations::unary::ScalarVariant rhs,
+    const std::optional<const DataType>& dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& output = std::nullopt,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+Tensor ge(
+    float lhs,
+    const Tensor& rhs,
+    const std::optional<const DataType>& dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& output = std::nullopt);
+TTNN_BINARY_OP_TENSOR_TENSOR(gt, GT)
+Tensor gt(
+    const Tensor& lhs,
+    operations::unary::ScalarVariant rhs,
+    const std::optional<const DataType>& dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& output = std::nullopt,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+Tensor gt(
+    float lhs,
+    const Tensor& rhs,
+    const std::optional<const DataType>& dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& output = std::nullopt);
+TTNN_BINARY_OP_TENSOR_TENSOR(le, LE)
+Tensor le(
+    const Tensor& lhs,
+    operations::unary::ScalarVariant rhs,
+    const std::optional<const DataType>& dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& output = std::nullopt,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+Tensor le(
+    float lhs,
+    const Tensor& rhs,
+    const std::optional<const DataType>& dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& output = std::nullopt);
+TTNN_BINARY_OP_TENSOR_TENSOR(lt, LT)
+Tensor lt(
+    const Tensor& lhs,
+    operations::unary::ScalarVariant rhs,
+    const std::optional<const DataType>& dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& output = std::nullopt,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+Tensor lt(
+    float lhs,
+    const Tensor& rhs,
+    const std::optional<const DataType>& dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& output = std::nullopt);
+TTNN_BINARY_OP_TENSOR_TENSOR(logical_and, LOGICAL_AND)
+TTNN_BINARY_OP_TENSOR_SCALAR(logical_and, LOGICAL_AND)
+TTNN_BINARY_OP_TENSOR_TENSOR(logical_or, LOGICAL_OR)
+TTNN_BINARY_OP_TENSOR_SCALAR(logical_or, LOGICAL_OR)
+TTNN_BINARY_OP_TENSOR_TENSOR(logical_xor, LOGICAL_XOR)
+TTNN_BINARY_OP_TENSOR_SCALAR(logical_xor, LOGICAL_XOR)
+TTNN_BINARY_OP_TENSOR_TENSOR(ldexp, LDEXP)
+TTNN_BINARY_OP_TENSOR_SCALAR(ldexp, LDEXP)
+TTNN_BINARY_OP_INPLACE(ldexp_, LDEXP)
+TTNN_BINARY_OP_TENSOR_TENSOR(logaddexp, LOGADDEXP)
+TTNN_BINARY_OP_TENSOR_SCALAR(logaddexp, LOGADDEXP)
+TTNN_BINARY_OP_INPLACE(logaddexp_, LOGADDEXP)
+TTNN_BINARY_OP_TENSOR_TENSOR(logaddexp2, LOGADDEXP2)
+TTNN_BINARY_OP_TENSOR_SCALAR(logaddexp2, LOGADDEXP2)
+TTNN_BINARY_OP_INPLACE(logaddexp2_, LOGADDEXP2)
+TTNN_BINARY_OP_TENSOR_TENSOR(squared_difference, SQUARED_DIFFERENCE)
+TTNN_BINARY_OP_TENSOR_SCALAR(squared_difference, SQUARED_DIFFERENCE)
+TTNN_BINARY_OP_INPLACE(squared_difference_, SQUARED_DIFFERENCE)
+Tensor divide(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    const std::optional<const DataType>& output_dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& output = std::nullopt,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+    const std::optional<bool>& fast_and_approximate_mode = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+Tensor divide(
+    const Tensor& lhs,
+    operations::unary::ScalarVariant rhs,
+    const std::optional<const DataType>& output_dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& output = std::nullopt,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+    const std::optional<bool>& fast_and_approximate_mode = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+Tensor divide_(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+    std::optional<bool> fast_and_approximate_mode = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+Tensor divide_(
+    const Tensor& lhs,
+    operations::unary::ScalarVariant rhs,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+    std::optional<bool> fast_and_approximate_mode = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+Tensor multiply(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    const std::optional<const DataType>& output_dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& output = std::nullopt,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+    const std::optional<bool>& fast_and_approximate_mode = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+Tensor multiply(
+    const Tensor& lhs,
+    operations::unary::ScalarVariant rhs,
+    const std::optional<const DataType>& output_dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& output = std::nullopt,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+    const std::optional<bool>& fast_and_approximate_mode = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+Tensor multiply(const Tensor& lhs, const Tensor& rhs, bool fast_and_approximate_mode);
+Tensor multiply(const Tensor& lhs, operations::unary::ScalarVariant rhs, bool fast_and_approximate_mode);
+Tensor multiply_(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+    std::optional<bool> fast_and_approximate_mode = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+Tensor multiply_(
+    const Tensor& lhs,
+    operations::unary::ScalarVariant rhs,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+    std::optional<bool> fast_and_approximate_mode = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+TTNN_BINARY_OP_INPLACE_RELATIONAL(gt_, GT)
+TTNN_BINARY_OP_INPLACE_RELATIONAL(ge_, GE)
+TTNN_BINARY_OP_INPLACE_RELATIONAL(le_, LE)
+TTNN_BINARY_OP_INPLACE_RELATIONAL(lt_, LT)
+TTNN_BINARY_OP_INPLACE_INVOKE(logical_and_, LOGICAL_AND)
+TTNN_BINARY_OP_INPLACE_INVOKE(logical_or_, LOGICAL_OR)
+TTNN_BINARY_OP_INPLACE_INVOKE(logical_xor_, LOGICAL_XOR)
+TTNN_BINARY_OP_INPLACE_RELATIONAL(eq_, EQ)
+TTNN_BINARY_OP_INPLACE_RELATIONAL(ne_, NE)
+TTNN_BINARY_OP_INPLACE_INVOKE(rsub_, RSUB)
+TTNN_BINARY_OP_INPLACE_INVOKE(bias_gelu_, BIAS_GELU)
+Tensor addalpha(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    float alpha,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& output = std::nullopt);
+Tensor subalpha(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    float alpha,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& output = std::nullopt);
+TTNN_BINARY_OP_TENSOR_TENSOR(logical_right_shift, LOGICAL_RIGHT_SHIFT)
+TTNN_BINARY_OP_TENSOR_SCALAR(logical_right_shift, LOGICAL_RIGHT_SHIFT)
+TTNN_BINARY_OP_TENSOR_TENSOR_BITWISE(bitwise_and, BITWISE_AND)
+TTNN_BINARY_OP_TENSOR_INT32_BITWISE(bitwise_and, BITWISE_AND)
+TTNN_BINARY_OP_TENSOR_TENSOR_BITWISE(bitwise_or, BITWISE_OR)
+TTNN_BINARY_OP_TENSOR_INT32_BITWISE(bitwise_or, BITWISE_OR)
+TTNN_BINARY_OP_TENSOR_TENSOR_BITWISE(bitwise_xor, BITWISE_XOR)
+TTNN_BINARY_OP_TENSOR_INT32_BITWISE(bitwise_xor, BITWISE_XOR)
+TTNN_BINARY_OP_TENSOR_TENSOR_BITWISE(bitwise_left_shift, LEFT_SHIFT)
+TTNN_BINARY_OP_TENSOR_INT32_BITWISE(bitwise_left_shift, LEFT_SHIFT)
+TTNN_BINARY_OP_TENSOR_TENSOR_BITWISE(bitwise_right_shift, RIGHT_SHIFT)
+TTNN_BINARY_OP_TENSOR_INT32_BITWISE(bitwise_right_shift, RIGHT_SHIFT)
+TTNN_BINARY_OP_TENSOR_TENSOR_BITWISE(logical_left_shift, LEFT_SHIFT)
+TTNN_BINARY_OP_TENSOR_INT32_BITWISE(logical_left_shift, LEFT_SHIFT)
+TTNN_BINARY_OP_TENSOR_TENSOR(xlogy, XLOGY)
+TTNN_BINARY_OP_TENSOR_SCALAR(xlogy, XLOGY)
+Tensor hypot(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+Tensor isclose(
+    const Tensor& input_a,
+    const Tensor& input_b,
+    float rtol,
+    float atol,
+    bool equal_nan,
+    const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
+
+template <typename InputBType>
+ttnn::Tensor operator+(const ttnn::Tensor& lhs, InputBType rhs) {
+    return add(lhs, rhs);
+}
+
+template <typename InputBType>
+ttnn::Tensor operator-(const ttnn::Tensor& lhs, InputBType rhs) {
+    return subtract(lhs, rhs);
+}
+
+template <typename InputBType>
+ttnn::Tensor operator*(const ttnn::Tensor& lhs, InputBType rhs) {
+    return multiply(lhs, rhs);
+}
+
+template <typename InputBType>
+ttnn::Tensor operator==(const ttnn::Tensor& lhs, InputBType rhs) {
+    return eq(lhs, rhs);
+}
+
+template <typename InputBType>
+ttnn::Tensor operator!=(const ttnn::Tensor& lhs, InputBType rhs) {
+    return ne(lhs, rhs);
+}
+
+template <typename InputBType>
+ttnn::Tensor operator>(const ttnn::Tensor& lhs, InputBType rhs) {
+    return gt(lhs, rhs);
+}
+
+template <typename InputBType>
+ttnn::Tensor operator>=(const ttnn::Tensor& lhs, InputBType rhs) {
+    return ge(lhs, rhs);
+}
+
+template <typename InputBType>
+ttnn::Tensor operator<(const ttnn::Tensor& lhs, InputBType rhs) {
+    return lt(lhs, rhs);
+}
+
+template <typename InputBType>
+ttnn::Tensor operator<=(const ttnn::Tensor& lhs, InputBType rhs) {
+    return le(lhs, rhs);
+}
+
+}  // namespace ttnn::operations::experimental::quasar::binary
+
+#undef TTNN_BINARY_OP_TENSOR_TENSOR
+#undef TTNN_BINARY_OP_TENSOR_SCALAR
+#undef TTNN_BINARY_OP_TENSOR_TENSOR_BITWISE
+#undef TTNN_BINARY_OP_TENSOR_INT32_BITWISE
+#undef TTNN_BINARY_OP_INPLACE
+#undef TTNN_BINARY_OP_INPLACE_RELATIONAL
+#undef TTNN_BINARY_OP_INPLACE_INVOKE

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary/binary_composite.hpp
@@ -1,0 +1,275 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <array>
+#include <optional>
+#include <vector>
+
+#include <tt_stl/span.hpp>
+
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/experimental/quasar/binary/binary.hpp"
+#include "ttnn/operations/eltwise/unary/unary.hpp"
+#include "ttnn/types.hpp"
+#include <tt-metalium/sub_device_types.hpp>
+
+namespace ttnn::operations::experimental::quasar::binary {
+
+/**
+ * @brief Performs element-wise power operation on the input with the exponent.
+ * When exponent is Tensor, the supported dtypes are float32 and bfloat16.
+ * The tested range for the input is (-30,30) and for the exponent is (-20, 20).
+ *
+ * @param input The input tensor, i.e the base.
+ * @param exponent The exponent
+ * @return The result tensor
+ */
+Tensor pow(
+    const Tensor& input,
+    int32_t exponent,
+    const std::optional<MemoryConfig>& output_mem_config = std::nullopt,
+    const std::optional<Tensor>& output_tensor = std::nullopt);
+
+Tensor pow(
+    const Tensor& input_a,
+    float exponent,
+    const std::optional<MemoryConfig>& output_mem_config = std::nullopt,
+    const std::optional<Tensor>& output_tensor = std::nullopt);
+
+Tensor pow(
+    float input_a,
+    const Tensor& exponent,
+    const std::optional<const DataType>& dtype = std::nullopt,
+    const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {});
+
+Tensor pow(
+    const Tensor& input,
+    const Tensor& exponent,
+    const std::optional<const DataType>& dtype = std::nullopt,
+    const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {});
+
+Tensor div(
+    const Tensor& input_a,
+    const Tensor& input_b,
+    bool fast_and_approximate_mode = false,
+    const std::optional<std::string>& rounding_mode = std::nullopt,
+    const std::optional<const DataType>& output_dtype = std::nullopt,
+    const std::optional<MemoryConfig>& output_mem_config = std::nullopt,
+    const std::optional<Tensor>& output_tensor = std::nullopt,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+
+Tensor div(
+    const Tensor& input,
+    operations::unary::ScalarVariant value,
+    bool fast_and_approximate_mode = false,
+    const std::optional<std::string>& rounding_mode = std::nullopt,
+    const std::optional<const DataType>& output_dtype = std::nullopt,
+    const std::optional<MemoryConfig>& output_mem_config = std::nullopt,
+    const std::optional<Tensor>& output_tensor = std::nullopt,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+
+Tensor bias_gelu(
+    const Tensor& input_tensor_a_arg,
+    const Tensor& input_tensor_b_arg,
+    const std::optional<const DataType>& output_dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+
+Tensor bias_gelu(
+    const ttnn::Tensor& input_tensor_a,
+    operations::unary::ScalarVariant bias,
+    const std::optional<const DataType>& dtype = std::nullopt,
+    const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+
+Tensor fmod(
+    const Tensor& input_a,
+    const Tensor& input_b,
+    const std::optional<MemoryConfig>& output_mem_config = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+
+Tensor fmod(
+    const Tensor& input,
+    operations::unary::ScalarVariant scalar,
+    const std::optional<MemoryConfig>& output_mem_config = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+
+Tensor remainder(
+    const Tensor& input_a,
+    const Tensor& input_b,
+    const std::optional<const DataType>& output_dtype = std::nullopt,
+    const std::optional<MemoryConfig>& output_mem_config = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+
+Tensor remainder(
+    const Tensor& input,
+    operations::unary::ScalarVariant scalar,
+    const std::optional<const DataType>& output_dtype = std::nullopt,
+    const std::optional<MemoryConfig>& output_mem_config = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+
+Tensor lcm(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const std::optional<const DataType>& output_dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {});
+
+Tensor gcd(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const std::optional<const DataType>& output_dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {});
+
+Tensor maximum(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const std::optional<const DataType>& output_dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {});
+
+Tensor maximum(
+    const Tensor& input_a,
+    operations::unary::ScalarVariant value,
+    const std::optional<const DataType>& output_dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {});
+
+Tensor minimum(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const std::optional<const DataType>& output_dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {});
+
+Tensor minimum(
+    const Tensor& input_a,
+    operations::unary::ScalarVariant value,
+    const std::optional<const DataType>& output_dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {});
+
+Tensor prelu(
+    const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
+
+Tensor prelu(
+    const Tensor& input,
+    const std::array<float, 1>& weight,
+    const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
+
+Tensor prelu(
+    const Tensor& input,
+    operations::unary::ScalarVariant weight,
+    const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
+
+Tensor rsub(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const std::optional<const DataType>& output_dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {});
+
+Tensor rsub(
+    const Tensor& input_tensor_a,
+    operations::unary::ScalarVariant input_b,
+    const std::optional<const DataType>& output_dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {});
+
+Tensor atan2(
+    const Tensor& input_b, const Tensor& input_a, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
+
+Tensor nextafter(
+    const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
+
+Tensor div_no_nan(
+    const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
+
+Tensor div_no_nan(
+    const Tensor& input_a,
+    operations::unary::ScalarVariant value,
+    const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
+
+Tensor floor_div(
+    const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
+
+Tensor floor_div(
+    const Tensor& input_a,
+    operations::unary::ScalarVariant value,
+    const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
+
+Tensor outer(
+    const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
+
+Tensor polyval(
+    const Tensor& input_a,
+    const std::vector<float>& coeffs,
+    const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
+
+}  // namespace ttnn::operations::experimental::quasar::binary

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary/binary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary/binary_nanobind.cpp
@@ -1,0 +1,2257 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "binary_nanobind.hpp"
+#include <tt-metalium/sub_device_types.hpp>
+
+#include <array>
+#include <string>
+#include <optional>
+#include <utility>
+
+#include <fmt/format.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/operators.h>  // testing
+#include <nanobind/stl/array.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/vector.h>
+#include <nanobind/stl/variant.h>
+
+#include <ttnn-nanobind/small_vector_caster.hpp>
+#include <ttnn-nanobind/span_caster.hpp>
+
+#include "ttnn-nanobind/bind_function.hpp"
+#include "ttnn-nanobind/export_enum.hpp"
+#include "ttnn/operations/experimental/quasar/binary/binary.hpp"
+#include "ttnn/operations/experimental/quasar/binary/binary_composite.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::experimental::quasar::binary {
+
+namespace unary = operations::unary;
+
+namespace detail {
+
+Tensor hypot_composite_wrapper(const Tensor& a, const Tensor& b, const std::optional<MemoryConfig>& m) {
+    return hypot(a, b, m, std::nullopt);
+}
+
+// Common broadcasting and performance documentation for binary operations
+constexpr auto BINARY_BROADCAST_DOC = R"doc(
+        Binary elementwise operations, C=op(A,B), support input tensors A and B in row major and tile layout, in interleaved or sharded format (height, width or block sharded), in DRAM or L1. A and B are completely independent, and can have different tensor specs.
+
+        Broadcast of A and B operands is supported up to dimension 5 (DNCHW). Any dimensions of size 1 in either A or B will be expanded to match the other input, and data will be duplicated along that dimension. For example, if the shape of A is [2,1,1,32] and B is [1,16,8,1], the output shape will be [2,16,8,32]. The size of dimensions higher than 5 must match between A and B.
+
+        The output C also supports row major and tile layout, interleaved or sharded format (height, width or block sharded), in DRAM or L1. The tensor spec of C is independent of A and B, and can be explicitly set using the optional output tensor input; if not provided, the operation will attempt a best decision at an appropriate tensor spec. The dimensions of C, or equivalently the optional output tensor, must match the broadcast-matched size of A and B.
+
+        Performance considerations:
+        Elementwise operations operate natively in tile format, tiled tensors are preferred as an input, and row-major tensors are tilized and untilized during the operation.
+        L1 sharded layout is preferred, with no broadcast and matching tensor specs for A, B and C.
+)doc";
+
+// Function pointer types for binary operation overload disambiguation
+using BinaryOpTensorScalarFn = Tensor (*)(
+    const Tensor&,
+    unary::ScalarVariant,
+    const std::optional<const DataType>&,
+    const std::optional<MemoryConfig>&,
+    const std::optional<Tensor>&,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    const std::optional<CoreRangeSet>&,
+    const std::optional<tt::tt_metal::SubDeviceId>&);
+using BinaryOpTensorTensorFn = Tensor (*)(
+    const Tensor&,
+    const Tensor&,
+    const std::optional<const DataType>&,
+    const std::optional<MemoryConfig>&,
+    const std::optional<Tensor>&,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    const std::optional<CoreRangeSet>&,
+    const std::optional<tt::tt_metal::SubDeviceId>&);
+
+using InplaceScalarFn = Tensor (*)(
+    const Tensor&,
+    unary::ScalarVariant,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    const std::optional<CoreRangeSet>&,
+    const std::optional<tt::tt_metal::SubDeviceId>&);
+
+using InplaceTensorFn = Tensor (*)(
+    const Tensor&,
+    const Tensor&,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    const std::optional<CoreRangeSet>&,
+    const std::optional<tt::tt_metal::SubDeviceId>&);
+
+using BitwiseScalarFn = Tensor (*)(
+    const Tensor&,
+    int32_t,
+    const std::optional<MemoryConfig>&,
+    const std::optional<Tensor>&,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    const std::optional<CoreRangeSet>&,
+    const std::optional<tt::tt_metal::SubDeviceId>&);
+using BitwiseTensorFn = Tensor (*)(
+    const Tensor&,
+    const Tensor&,
+    const std::optional<MemoryConfig>&,
+    const std::optional<Tensor>&,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    const std::optional<CoreRangeSet>&,
+    const std::optional<tt::tt_metal::SubDeviceId>&);
+using BinaryUnaryScalarFn = Tensor (*)(
+    const Tensor&,
+    unary::ScalarVariant,
+    const std::optional<const DataType>&,
+    const std::optional<MemoryConfig>&,
+    const std::optional<Tensor>&,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>);
+using BinaryUnaryTensorFn = Tensor (*)(
+    const Tensor&,
+    const Tensor&,
+    const std::optional<const DataType>&,
+    const std::optional<MemoryConfig>&,
+    const std::optional<Tensor>&,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>);
+using BinaryUnaryMaxScalarFn = Tensor (*)(
+    const Tensor&,
+    unary::ScalarVariant,
+    const std::optional<const DataType>&,
+    const std::optional<MemoryConfig>&,
+    const std::optional<Tensor>&,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>);
+using BinaryUnaryMaxTensorFn = Tensor (*)(
+    const Tensor&,
+    const Tensor&,
+    const std::optional<const DataType>&,
+    const std::optional<MemoryConfig>&,
+    const std::optional<Tensor>&,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>);
+using BinaryCompositeTensorTensorFn = Tensor (*)(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
+using BinaryCompositeTensorScalarFn =
+    Tensor (*)(const Tensor&, unary::ScalarVariant, const std::optional<MemoryConfig>&);
+using BinaryOverloadScalarFn = Tensor (*)(
+    const Tensor&,
+    unary::ScalarVariant,
+    const std::optional<MemoryConfig>&,
+    const std::optional<CoreRangeSet>&,
+    const std::optional<tt::tt_metal::SubDeviceId>&);
+using BinaryOverloadTensorFn = Tensor (*)(
+    const Tensor&,
+    const Tensor&,
+    const std::optional<MemoryConfig>&,
+    const std::optional<CoreRangeSet>&,
+    const std::optional<tt::tt_metal::SubDeviceId>&);
+using PreluTensorArrayFn = Tensor (*)(const Tensor&, const std::array<float, 1>&, const std::optional<MemoryConfig>&);
+using InplaceFastApproxScalarFn = Tensor (*)(
+    const Tensor&,
+    unary::ScalarVariant,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    std::optional<bool>,
+    const std::optional<CoreRangeSet>&,
+    const std::optional<tt::tt_metal::SubDeviceId>&);
+using InplaceFastApproxTensorFn = Tensor (*)(
+    const Tensor&,
+    const Tensor&,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    ttsl::Span<const unary::EltwiseUnaryWithParam>,
+    std::optional<bool>,
+    const std::optional<CoreRangeSet>&,
+    const std::optional<tt::tt_metal::SubDeviceId>&);
+
+template <ttnn::unique_string Name, typename TensorScalarFn, typename TensorTensorFn>
+void bind_binary_inplace_operation(
+    nb::module_& mod,
+    const std::string& description,
+    const std::string& math,
+    TensorScalarFn tensor_scalar_fn,
+    TensorTensorFn tensor_tensor_fn,
+    const std::string& supported_dtype = "BFLOAT16",
+    const std::string& note = " ") {
+    auto doc = fmt::format(
+        R"doc(
+        {2}
+
+        .. math::
+            {3}
+
+        Args:
+            input_tensor_a (ttnn.Tensor): the input tensor.
+            input_tensor_b (ttnn.Tensor or Number): the input tensor.
+
+        Keyword args:
+            activations (List[str], optional): list of activation functions to apply to the output tensor. Defaults to `None`.
+            input_tensor_a_activations (List[str], optional): list of activation functions to apply to input_a. Defaults to `None`.
+            input_tensor_b_activations (List[str], optional): list of activation functions to apply to input_b. Defaults to `None`.
+            sub_core_grids (CoreRangeSet, optional): sub core grids. Defaults to `None`.
+            sub_device_id (ttnn.SubDeviceId, optional): sub device ID for core resolution. Mutually exclusive with sub_core_grids. Defaults to `None`.
+
+        {6}
+
+        Note:
+            Supported dtypes and layouts:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+               * - {4}
+                 - TILE, ROW_MAJOR
+
+            If the input tensor is ROW_MAJOR layout, it will be internally converted to TILE layout.
+
+            {5}
+        )doc",
+        std::string(Name),
+        "ttnn." + std::string(Name),
+        description,
+        math,
+        supported_dtype,
+        note,
+        BINARY_BROADCAST_DOC);
+
+    ttnn::bind_function<Name>(
+        mod,
+        doc.c_str(),
+        ttnn::overload_t(
+            tensor_scalar_fn,
+            nb::arg("input_tensor_a"),
+            nb::arg("input_tensor_b"),
+            nb::kw_only(),
+            nb::arg("activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_a_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_b_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("sub_core_grids") = nb::none(),
+            nb::arg("sub_device_id") = nb::none()),
+        ttnn::overload_t(
+            tensor_tensor_fn,
+            nb::arg("input_tensor_a"),
+            nb::arg("input_tensor_b"),
+            nb::kw_only(),
+            nb::arg("activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_a_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_b_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("sub_core_grids") = nb::none(),
+            nb::arg("sub_device_id") = nb::none()));
+}
+
+template <ttnn::unique_string Name, typename TensorScalarFn, typename TensorTensorFn>
+void bind_binary_operation(
+    nb::module_& mod,
+    const std::string& description,
+    const std::string& math,
+    TensorScalarFn tensor_scalar_fn,
+    TensorTensorFn tensor_tensor_fn,
+    const std::string& info = ". ",
+    const std::string& supported_dtype = "BFLOAT16",
+    const std::string& note = " ") {
+    auto doc = fmt::format(
+        R"doc(
+        {2}
+
+        .. math::
+            {3}
+
+        Args:
+            input_tensor_a (ttnn.Tensor): the input tensor.
+            input_tensor_b (ttnn.Tensor or Number): the input tensor.
+
+        Keyword args:
+            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+            dtype (ttnn.DataType, optional): data type for the output tensor. Defaults to `None`.
+            output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
+            activations (List[str], optional): list of activation functions to apply to the output tensor. Defaults to `None`.
+
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        {7}
+
+        Note:
+            Supported dtypes and layouts:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+               * - {5}
+                 - TILE, ROW_MAJOR
+
+            If the input tensor is ROW_MAJOR layout, it will be internally converted to TILE layout.
+
+            {6}
+        )doc",
+        std::string(Name),
+        "ttnn." + std::string(Name),
+        description,
+        math,
+        info,
+        supported_dtype,
+        note,
+        BINARY_BROADCAST_DOC);
+
+    ttnn::bind_function<Name>(
+        mod,
+        doc.c_str(),
+        ttnn::overload_t(
+            tensor_scalar_fn,
+            nb::arg("input_tensor_a"),
+            nb::arg("input_tensor_b"),
+            nb::kw_only(),
+            nb::arg("dtype") = nb::none(),
+            nb::arg("memory_config") = nb::none(),
+            nb::arg("output_tensor") = nb::none(),
+            nb::arg("activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_a_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_b_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("sub_core_grids") = nb::none(),
+            nb::arg("sub_device_id") = nb::none()),
+        ttnn::overload_t(
+            tensor_tensor_fn,
+            nb::arg("input_tensor_a"),
+            nb::arg("input_tensor_b"),
+            nb::kw_only(),
+            nb::arg("dtype") = nb::none(),
+            nb::arg("memory_config") = nb::none(),
+            nb::arg("output_tensor") = nb::none(),
+            nb::arg("activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_a_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_b_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("sub_core_grids") = nb::none(),
+            nb::arg("sub_device_id") = nb::none()));
+}
+
+template <ttnn::unique_string Name, typename Fn>
+void bind_binary_gcd_lcm_operation(
+    nb::module_& mod,
+    const std::string& description,
+    const std::string& math,
+    Fn fn,
+    const std::string& supported_dtype = "BFLOAT16",
+    const std::string& note = "") {
+    auto doc = fmt::format(
+        R"doc(
+        {2}
+
+        .. math::
+            {3}
+
+        Args:
+            input_tensor_a (ttnn.Tensor): the input tensor.
+            input_tensor_b (ttnn.Tensor): the input tensor.
+
+        Keyword args:
+            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+            dtype (ttnn.DataType, optional): data type for the output tensor. Defaults to `None`.
+            output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
+            activations (List[str], optional): list of activation functions to apply to the output tensor. Defaults to `None`.
+
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        {6}
+
+        Note:
+            Supported dtypes and layouts:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+               * - {4}
+                 - TILE, ROW_MAJOR
+
+            If the input tensor is ROW_MAJOR layout, it will be internally converted to TILE layout.
+
+            {5}
+        )doc",
+
+        std::string(Name),
+        "ttnn." + std::string(Name),
+        description,
+        math,
+        supported_dtype,
+        note,
+        BINARY_BROADCAST_DOC);
+
+    ttnn::bind_function<Name>(
+        mod,
+        doc.c_str(),
+        fn,
+        nb::arg("input_tensor_a"),
+        nb::arg("input_tensor_b"),
+        nb::kw_only(),
+        nb::arg("dtype") = nb::none(),
+        nb::arg("memory_config") = nb::none(),
+        nb::arg("output_tensor") = nb::none(),
+        nb::arg("activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+        nb::arg("input_tensor_a_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+        nb::arg("input_tensor_b_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}));
+}
+
+template <ttnn::unique_string Name, typename TensorScalarFn, typename TensorTensorFn>
+void bind_binary_unary_max_operation(
+    nb::module_& mod,
+    const std::string& description,
+    TensorScalarFn tensor_scalar_fn,
+    TensorTensorFn tensor_tensor_fn,
+    const std::string& note = " ",
+    const std::string& supported_dtype = "BFLOAT16, FLOAT32, INT32") {
+    auto doc = fmt::format(
+        R"doc(
+        {2}
+
+        Args:
+            input_tensor_a (ttnn.Tensor): the input tensor.
+            input_tensor_b (ttnn.Tensor or Number): the input tensor.
+
+        Keyword args:
+            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+            dtype (ttnn.DataType, optional): data type for the output tensor. Defaults to `None`.
+            output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
+            activations (List[str], optional): list of activation functions to apply to the output tensor. Defaults to `None`.
+
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        {5}
+
+        Note:
+            Supported dtypes and layouts:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+               * - {3}
+                 - TILE, ROW_MAJOR
+
+            If the input tensor is ROW_MAJOR layout, it will be internally converted to TILE layout.
+
+            {4}
+        )doc",
+        std::string(Name),
+        "ttnn." + std::string(Name),
+        description,
+        supported_dtype,
+        note,
+        BINARY_BROADCAST_DOC);
+
+    auto scalar_overload = ttnn::overload_t(
+        tensor_scalar_fn,
+        nb::arg("input_tensor_a"),
+        nb::arg("input_b"),
+        nb::kw_only(),
+        nb::arg("dtype") = nb::none(),
+        nb::arg("memory_config") = nb::none(),
+        nb::arg("output_tensor") = nb::none(),
+        nb::arg("activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+        nb::arg("input_tensor_a_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+        nb::arg("input_tensor_b_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}));
+    auto tensor_overload = ttnn::overload_t(
+        tensor_tensor_fn,
+        nb::arg("input_tensor_a"),
+        nb::arg("input_tensor_b"),
+        nb::kw_only(),
+        nb::arg("dtype") = nb::none(),
+        nb::arg("memory_config") = nb::none(),
+        nb::arg("output_tensor") = nb::none(),
+        nb::arg("activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+        nb::arg("input_tensor_a_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+        nb::arg("input_tensor_b_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}));
+    ttnn::bind_function<Name>(mod, doc.c_str(), scalar_overload, tensor_overload);
+}
+
+template <ttnn::unique_string Name, typename TensorScalarFn, typename TensorTensorFn>
+void bind_binary_unary_operation(
+    nb::module_& mod,
+    const std::string& description,
+    const std::string& math,
+    TensorScalarFn tensor_scalar_fn,
+    TensorTensorFn tensor_tensor_fn,
+    const std::string& info = ". ",
+    const std::string& supported_dtype = "BFLOAT16",
+    const std::string& note = " ") {
+    auto doc = fmt::format(
+        R"doc(
+        {2}
+
+        .. math::
+            {3}
+
+        Args:
+            input_tensor_a (ttnn.Tensor): the input tensor.
+            input_tensor_b (ttnn.Tensor or Number): the input tensor.
+
+        Keyword args:
+            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+            dtype (ttnn.DataType, optional): data type for the output tensor. Defaults to `None`.
+            output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
+            activations (List[str], optional): list of activation functions to apply to the output tensor. Defaults to `None`.
+
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        {7}
+
+        Note:
+            Supported dtypes and layouts:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+               * - {5}
+                 - TILE, ROW_MAJOR
+
+            If the input tensor is ROW_MAJOR layout, it will be internally converted to TILE layout.
+
+            {6}
+        )doc",
+        std::string(Name),
+        "ttnn." + std::string(Name),
+        description,
+        math,
+        info,
+        supported_dtype,
+        note,
+        BINARY_BROADCAST_DOC);
+
+    ttnn::bind_function<Name>(
+        mod,
+        doc.c_str(),
+        ttnn::overload_t(
+            tensor_scalar_fn,
+            nb::arg("input_tensor_a"),
+            nb::arg("input_b"),
+            nb::kw_only(),
+            nb::arg("dtype") = nb::none(),
+            nb::arg("memory_config") = nb::none(),
+            nb::arg("output_tensor") = nb::none(),
+            nb::arg("activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_a_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_b_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{})),
+        ttnn::overload_t(
+            tensor_tensor_fn,
+            nb::arg("input_tensor_a"),
+            nb::arg("input_tensor_b"),
+            nb::kw_only(),
+            nb::arg("dtype") = nb::none(),
+            nb::arg("memory_config") = nb::none(),
+            nb::arg("output_tensor") = nb::none(),
+            nb::arg("activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_a_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_b_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{})));
+}
+
+template <ttnn::unique_string Name, typename Fn>
+void bind_binary_with_float_param(
+    nb::module_& mod,
+    const std::string& description,
+    const std::string& math,
+    Fn fn,
+    const std::string& supported_dtype = "BFLOAT16",
+    const std::string& note = "") {
+    auto doc = fmt::format(
+        R"doc(
+        {2}
+
+        .. math::
+            {3}
+
+        Args:
+            input_tensor_a (ttnn.Tensor): the input tensor.
+            input_tensor_b (ttnn.Tensor): the input tensor.
+            alpha (float): the value to be multiplied.
+
+        Keyword args:
+            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+            output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
+
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        {6}
+
+        Note:
+            Supported dtypes and layouts:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+               * - {4}
+                 - TILE, ROW_MAJOR
+
+            If the input tensor is ROW_MAJOR layout, it will be internally converted to TILE layout.
+
+            {5}
+        )doc",
+        std::string(Name),
+        "ttnn." + std::string(Name),
+        description,
+        math,
+        supported_dtype,
+        note,
+        BINARY_BROADCAST_DOC);
+
+    ttnn::bind_function<Name>(
+        mod,
+        doc.c_str(),
+        fn,
+        nb::arg("input_tensor_a"),
+        nb::arg("input_tensor_b"),
+        nb::arg("alpha"),
+        nb::kw_only(),
+        nb::arg("memory_config") = nb::none(),
+        nb::arg("output_tensor") = nb::none());
+}
+
+template <ttnn::unique_string Name, typename TensorScalarFn, typename TensorTensorFn>
+void bind_bitwise_binary_ops_operation(
+    nb::module_& mod,
+    const std::string& description,
+    const std::string& math,
+    TensorScalarFn tensor_scalar_fn,
+    TensorTensorFn tensor_tensor_fn,
+    const std::string& info = ". ",
+    const std::string& supported_dtype = "BFLOAT16",
+    const std::string& note = " ") {
+    auto doc = fmt::format(
+        R"doc(
+        {2}
+
+        .. math::
+            {3}
+
+        Args:
+            input_tensor_a (ttnn.Tensor): the input tensor.
+            input_tensor_b (ttnn.Tensor or Integer): the input tensor.
+
+        Keyword args:
+            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+            output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
+            sub_core_grids (ttnn.CoreRangeSet, optional): restrict execution to a subset of cores (e.g. for subdevice use). Defaults to `None`.
+            sub_device_id (ttnn.SubDeviceId, optional): sub device ID — the op resolves cores internally. Mutually exclusive with sub_core_grids. Defaults to `None`.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        {7}
+
+        Note:
+            Supported dtypes and layouts:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+               * - {5}
+                 - TILE, ROW_MAJOR
+
+            If the input tensor is ROW_MAJOR layout, it will be internally converted to TILE layout.
+
+            {6}
+        )doc",
+        std::string(Name),
+        "ttnn." + std::string(Name),
+        description,
+        math,
+        info,
+        supported_dtype,
+        note,
+        BINARY_BROADCAST_DOC);
+
+    ttnn::bind_function<Name>(
+        mod,
+        doc.c_str(),
+        ttnn::overload_t(
+            tensor_scalar_fn,
+            nb::arg("input_tensor_a"),
+            nb::arg("input_b"),
+            nb::kw_only(),
+            nb::arg("memory_config") = nb::none(),
+            nb::arg("output_tensor") = nb::none(),
+            nb::arg("activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_a_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_b_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("sub_core_grids") = nb::none(),
+            nb::arg("sub_device_id") = nb::none()),
+        ttnn::overload_t(
+            tensor_tensor_fn,
+            nb::arg("input_tensor_a"),
+            nb::arg("input_tensor_b"),
+            nb::kw_only(),
+            nb::arg("memory_config") = nb::none(),
+            nb::arg("output_tensor") = nb::none(),
+            nb::arg("activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_a_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_b_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("sub_core_grids") = nb::none(),
+            nb::arg("sub_device_id") = nb::none()));
+}
+
+template <ttnn::unique_string Name, typename Fn>
+void bind_binary_composite(
+    nb::module_& mod,
+    const std::string& description,
+    const std::string& math,
+    Fn fn,
+    const std::string& supported_dtype = "BFLOAT16",
+    const std::string& note = "") {
+    auto doc = fmt::format(
+        R"doc(
+        {2}
+
+        .. math::
+            {3}
+
+        Args:
+            input_tensor_a (ttnn.Tensor): the input tensor.
+            input_tensor_b (ttnn.Tensor): the input tensor.
+
+        Keyword args:
+            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        {6}
+
+        Note:
+            Supported dtypes and layouts:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+               * - {4}
+                 - TILE, ROW_MAJOR
+
+            If the input tensor is ROW_MAJOR layout, it will be internally converted to TILE layout.
+
+            {5}
+        )doc",
+        std::string(Name),
+        "ttnn." + std::string(Name),
+        description,
+        math,
+        supported_dtype,
+        note,
+        BINARY_BROADCAST_DOC);
+
+    ttnn::bind_function<Name>(
+        mod,
+        doc.c_str(),
+        fn,
+        nb::arg("input_tensor_a"),
+        nb::arg("input_tensor_b"),
+        nb::kw_only(),
+        nb::arg("memory_config") = nb::none());
+}
+
+template <ttnn::unique_string Name, typename Fn>
+void bind_binary_composite_with_rtol_atol(
+    nb::module_& mod, const std::string& description, const std::string& math, Fn fn) {
+    auto doc = fmt::format(
+        R"doc(
+        {2}
+
+        .. math::
+            {3}
+
+        Args:
+            input_tensor_a (ttnn.Tensor): the input tensor.
+            input_tensor_b (ttnn.Tensor): the input tensor.
+
+        Keyword args:
+            rtol (float): relative tolerance. Defaults to `1e-05f`.
+            atol (float): absolute tolerance. Defaults to `1e-08f`.
+            equal_nan (bool): if NaN values should be treated as equal during comparison. Defaults to `False`.
+            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        {4}
+
+        Note:
+            Supported dtypes and layouts:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+               * - BFLOAT16
+                 - TILE, ROW_MAJOR
+
+            If the input tensor is ROW_MAJOR layout, it will be internally converted to TILE layout.
+        )doc",
+
+        std::string(Name),
+        "ttnn." + std::string(Name),
+        description,
+        math,
+        BINARY_BROADCAST_DOC);
+
+    ttnn::bind_function<Name>(
+        mod,
+        doc.c_str(),
+        fn,
+        nb::arg("input_tensor_a"),
+        nb::arg("input_tensor_b"),
+        nb::kw_only(),
+        nb::arg("rtol") = 1e-05f,
+        nb::arg("atol") = 1e-08f,
+        nb::arg("equal_nan") = false,
+        nb::arg("memory_config") = nb::none());
+}
+
+// https://nanobind.readthedocs.io/en/latest/api_extra.html
+
+template <ttnn::unique_string Name, typename TensorTensorFn, typename TensorScalarFn>
+void bind_binary_composite_overload(
+    nb::module_& mod,
+    const std::string& description,
+    TensorTensorFn tensor_tensor_fn,
+    TensorScalarFn tensor_scalar_fn,
+    const std::string& supported_dtype = "BFLOAT16",
+    const std::string& note = "") {
+    auto doc = fmt::format(
+        R"doc(
+        {2}
+
+        .. math::
+            \mathrm{{output\_tensor}} = \verb|{0}|(\mathrm{{input\_tensor\_a,input\_tensor\_b}})
+
+        Args:
+            input_tensor_a (ttnn.Tensor): the input tensor.
+            input_tensor_b (ttnn.Tensor or Number): the input tensor.
+
+        Keyword Args:
+            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        {5}
+
+        Note:
+            Supported dtypes and layouts:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+               * - {3}
+                 - TILE, ROW_MAJOR
+
+            If the input tensor is ROW_MAJOR layout, it will be internally converted to TILE layout.
+
+            {4}
+        )doc",
+        std::string(Name),
+        "ttnn." + std::string(Name),
+        description,
+        supported_dtype,
+        note,
+        BINARY_BROADCAST_DOC);
+
+    ttnn::bind_function<Name>(
+        mod,
+        doc.c_str(),
+        ttnn::overload_t(
+            tensor_tensor_fn,
+            nb::arg("input_tensor_a"),
+            nb::arg("input_tensor_b"),
+            nb::kw_only(),
+            nb::arg("memory_config") = nb::none()),
+        ttnn::overload_t(
+            tensor_scalar_fn,
+            nb::arg("input_tensor_a"),
+            nb::arg("value"),
+            nb::kw_only(),
+            nb::arg("memory_config") = nb::none()));
+}
+
+template <ttnn::unique_string Name, typename TensorTensorFn, typename TensorScalarFn, typename TensorArrayFn>
+void bind_prelu(
+    nb::module_& mod,
+    const std::string& description,
+    TensorTensorFn tensor_tensor_fn,
+    TensorScalarFn tensor_scalar_fn,
+    TensorArrayFn tensor_array_fn,
+    const std::string& supported_dtype = "BFLOAT16",
+    const std::string& note = "") {
+    auto doc = fmt::format(
+        R"doc(
+        {2}
+
+        .. math::
+            \mathrm{{output\_tensor}} = \verb|{0}|(\mathrm{{input\_tensor\_a,input\_tensor\_b}})
+
+        Args:
+            input_tensor_a (ttnn.Tensor): the input tensor.
+            input_tensor_b (ttnn.Tensor or List[float] of length 1 or Number): weight.
+
+        Keyword Args:
+            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        {5}
+
+        Note:
+            Supported dtypes and layouts:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+               * - {3}
+                 - TILE, ROW_MAJOR
+
+            If the input tensor is ROW_MAJOR layout, it will be internally converted to TILE layout.
+
+            {4}
+        )doc",
+        std::string(Name),
+        "ttnn." + std::string(Name),
+        description,
+        supported_dtype,
+        note,
+        BINARY_BROADCAST_DOC);
+
+    ttnn::bind_function<Name>(
+        mod,
+        doc.c_str(),
+        ttnn::overload_t(
+            tensor_tensor_fn,
+            nb::arg("input_tensor_a"),
+            nb::arg("weight"),
+            nb::kw_only(),
+            nb::arg("memory_config") = nb::none()),
+        ttnn::overload_t(
+            tensor_scalar_fn,
+            nb::arg("input_tensor_a"),
+            nb::arg("weight"),
+            nb::kw_only(),
+            nb::arg("memory_config") = nb::none()),
+        ttnn::overload_t(
+            tensor_array_fn,
+            nb::arg("input_tensor_a"),
+            nb::arg("weight"),
+            nb::kw_only(),
+            nb::arg("memory_config") = nb::none()));
+}
+
+template <ttnn::unique_string Name, typename TensorTensorFn, typename TensorScalarFn>
+void bind_div(
+    nb::module_& mod,
+    const std::string& description,
+    const std::string& math,
+    TensorTensorFn tensor_tensor_fn,
+    TensorScalarFn tensor_scalar_fn,
+    const std::string& supported_dtype = "BFLOAT16",
+    const std::string& note = " ") {
+    auto doc = fmt::format(
+        R"doc(
+        {2}
+
+        .. math::
+            {3}
+
+        Args:
+            input_tensor_a (ttnn.Tensor): the input tensor.
+            input_tensor_b (ttnn.Tensor or Number): the input tensor.
+
+        Keyword args:
+            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+            fast_and_approximate_mode (bool, optional): `true` if input_tensor_b is non-zero for fast approximation, else `false` for accurate division (Only if the input tensor is not ComplexTensor). Defaults to `false`.
+            rounding_mode (string, optional): can be `None`, `floor` and `trunc` (only if the input tensor is not ComplexTensor). Defaults to `None`.
+            output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
+
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        {6}
+
+        Note:
+            Supported dtypes and layouts:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+               * - BFLOAT16
+                 - TILE, ROW_MAJOR
+
+            If the input tensor is ROW_MAJOR layout, it will be internally converted to TILE layout.
+
+        )doc",
+
+        std::string(Name),
+        "ttnn." + std::string(Name),
+        description,
+        math,
+        supported_dtype,
+        note,
+        BINARY_BROADCAST_DOC);
+
+    auto tensor_tensor_overload = ttnn::overload_t(
+        tensor_tensor_fn,
+        nb::arg("input_tensor_a"),
+        nb::arg("input_tensor_b"),
+        nb::kw_only(),
+        nb::arg("fast_and_approximate_mode") = false,
+        nb::arg("rounding_mode") = nb::none(),
+        nb::arg("dtype") = nb::none(),
+        nb::arg("memory_config") = nb::none(),
+        nb::arg("output_tensor") = nb::none(),
+        nb::arg("activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+        nb::arg("input_tensor_a_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+        nb::arg("input_tensor_b_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+        nb::arg("sub_core_grids") = nb::none(),
+        nb::arg("sub_device_id") = nb::none());
+    auto tensor_scalar_overload = ttnn::overload_t(
+        tensor_scalar_fn,
+        nb::arg("input_tensor_a"),
+        nb::arg("value"),
+        nb::kw_only(),
+        nb::arg("fast_and_approximate_mode") = false,
+        nb::arg("rounding_mode") = nb::none(),
+        nb::arg("dtype") = nb::none(),
+        nb::arg("memory_config") = nb::none(),
+        nb::arg("output_tensor") = nb::none(),
+        nb::arg("activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+        nb::arg("input_tensor_a_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+        nb::arg("input_tensor_b_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+        nb::arg("sub_core_grids") = nb::none(),
+        nb::arg("sub_device_id") = nb::none());
+    ttnn::bind_function<Name>(mod, doc.c_str(), tensor_tensor_overload, tensor_scalar_overload);
+}
+
+// Free functions for multiply and divide with fast_and_approximate_mode
+Tensor multiply_fast_approx_tensor_scalar(
+    const Tensor& input_tensor_a,
+    unary::ScalarVariant value,
+    bool fast_and_approximate_mode,
+    const std::optional<const DataType>& dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<ttnn::Tensor>& output_tensor,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> input_tensor_a_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> input_tensor_b_activations,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt) {
+    return multiply(
+        input_tensor_a,
+        value,
+        dtype,
+        memory_config,
+        output_tensor,
+        ttsl::Span<const unary::EltwiseUnaryWithParam>(activations.data(), activations.size()),
+        ttsl::Span<const unary::EltwiseUnaryWithParam>(
+            input_tensor_a_activations.data(), input_tensor_a_activations.size()),
+        ttsl::Span<const unary::EltwiseUnaryWithParam>(
+            input_tensor_b_activations.data(), input_tensor_b_activations.size()),
+        fast_and_approximate_mode,
+        sub_core_grids,
+        sub_device_id);
+}
+
+Tensor multiply_fast_approx_tensor_tensor(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    bool fast_and_approximate_mode,
+    const std::optional<const DataType>& dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<ttnn::Tensor>& output_tensor,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> input_tensor_a_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> input_tensor_b_activations,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt) {
+    return multiply(
+        input_tensor_a,
+        input_tensor_b,
+        dtype,
+        memory_config,
+        output_tensor,
+        ttsl::Span<const unary::EltwiseUnaryWithParam>(activations.data(), activations.size()),
+        ttsl::Span<const unary::EltwiseUnaryWithParam>(
+            input_tensor_a_activations.data(), input_tensor_a_activations.size()),
+        ttsl::Span<const unary::EltwiseUnaryWithParam>(
+            input_tensor_b_activations.data(), input_tensor_b_activations.size()),
+        fast_and_approximate_mode,
+        sub_core_grids,
+        sub_device_id);
+}
+
+Tensor divide_fast_approx_tensor_scalar(
+    const Tensor& input_tensor_a,
+    unary::ScalarVariant value,
+    bool fast_and_approximate_mode,
+    const std::optional<const DataType>& dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<ttnn::Tensor>& output_tensor,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> input_tensor_a_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> input_tensor_b_activations,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt) {
+    return divide(
+        input_tensor_a,
+        value,
+        dtype,
+        memory_config,
+        output_tensor,
+        ttsl::Span<const unary::EltwiseUnaryWithParam>(activations.data(), activations.size()),
+        ttsl::Span<const unary::EltwiseUnaryWithParam>(
+            input_tensor_a_activations.data(), input_tensor_a_activations.size()),
+        ttsl::Span<const unary::EltwiseUnaryWithParam>(
+            input_tensor_b_activations.data(), input_tensor_b_activations.size()),
+        fast_and_approximate_mode,
+        sub_core_grids,
+        sub_device_id);
+}
+
+Tensor divide_fast_approx_tensor_tensor(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    bool fast_and_approximate_mode,
+    const std::optional<const DataType>& dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<ttnn::Tensor>& output_tensor,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> input_tensor_a_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> input_tensor_b_activations,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt) {
+    return divide(
+        input_tensor_a,
+        input_tensor_b,
+        dtype,
+        memory_config,
+        output_tensor,
+        ttsl::Span<const unary::EltwiseUnaryWithParam>(activations.data(), activations.size()),
+        ttsl::Span<const unary::EltwiseUnaryWithParam>(
+            input_tensor_a_activations.data(), input_tensor_a_activations.size()),
+        ttsl::Span<const unary::EltwiseUnaryWithParam>(
+            input_tensor_b_activations.data(), input_tensor_b_activations.size()),
+        fast_and_approximate_mode,
+        sub_core_grids,
+        sub_device_id);
+}
+
+template <ttnn::unique_string Name, typename TensorScalarFn, typename TensorTensorFn>
+void bind_binary_operation_with_fast_approx(
+    nb::module_& mod,
+    const std::string& description,
+    const std::string& math,
+    TensorScalarFn tensor_scalar_fn,
+    TensorTensorFn tensor_tensor_fn,
+    const std::string& supported_dtype = "BFLOAT16",
+    const std::string& note = " ") {
+    auto doc = fmt::format(
+        R"doc(
+        {2}
+
+        .. math::
+            {3}
+
+        Args:
+            input_tensor_a (ttnn.Tensor): the input tensor.
+            input_tensor_b (ttnn.Tensor or Number): the input tensor.
+
+        Keyword args:
+            fast_and_approximate_mode (bool, optional): Use the fast and approximate mode. Defaults to `False`.
+            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+            output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        {6}
+
+        Note:
+            Supported dtypes and layouts:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+               * - {4}
+                 - TILE, ROW_MAJOR
+
+            If the input tensor is ROW_MAJOR layout, it will be internally converted to TILE layout.
+
+            {5}
+        )doc",
+        std::string(Name),
+        "ttnn." + std::string(Name),
+        description,
+        math,
+        supported_dtype,
+        note,
+        BINARY_BROADCAST_DOC);
+
+    ttnn::bind_function<Name>(
+        mod,
+        doc.c_str(),
+        ttnn::overload_t(
+            tensor_scalar_fn,
+            nb::arg("input_tensor_a"),
+            nb::arg("input_tensor_b"),
+            nb::kw_only(),
+            nb::arg("fast_and_approximate_mode") = false,
+            nb::arg("dtype") = nb::none(),
+            nb::arg("memory_config") = nb::none(),
+            nb::arg("output_tensor") = nb::none(),
+            nb::arg("activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_a_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_b_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("sub_core_grids") = nb::none(),
+            nb::arg("sub_device_id") = nb::none()),
+        ttnn::overload_t(
+            tensor_tensor_fn,
+            nb::arg("input_tensor_a"),
+            nb::arg("input_tensor_b"),
+            nb::kw_only(),
+            nb::arg("fast_and_approximate_mode") = false,
+            nb::arg("dtype") = nb::none(),
+            nb::arg("memory_config") = nb::none(),
+            nb::arg("output_tensor") = nb::none(),
+            nb::arg("activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_a_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_b_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("sub_core_grids") = nb::none(),
+            nb::arg("sub_device_id") = nb::none()));
+}
+
+template <ttnn::unique_string Name, typename Fn>
+void bind_polyval(
+    nb::module_& mod,
+    const std::string& description,
+    const std::string& math,
+    Fn fn,
+    const std::string& supported_dtype = "BFLOAT16",
+    const std::string& note = " ") {
+    auto doc = fmt::format(
+        R"doc(
+        {2}
+
+        .. math::
+            {3}
+
+        Args:
+            input_tensor (ttnn.Tensor): the input tensor.
+            Coeffs (Vector of floats): coefficients of the polynomial.
+
+        Keyword args:
+            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        {6}
+
+        Note:
+            Supported dtypes and layouts:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+               * - {4}
+                 - TILE, ROW_MAJOR
+
+            If the input tensor is ROW_MAJOR layout, it will be internally converted to TILE layout.
+
+            {5}
+        )doc",
+        std::string(Name),
+        "ttnn." + std::string(Name),
+        description,
+        math,
+        supported_dtype,
+        note,
+        BINARY_BROADCAST_DOC);
+
+    ttnn::bind_function<Name>(
+        mod,
+        doc.c_str(),
+        fn,
+        nb::arg("input_tensor_a"),
+        nb::arg("coeffs"),
+        nb::kw_only(),
+        nb::arg("memory_config") = nb::none());
+}
+
+template <ttnn::unique_string Name, typename TensorScalarFn, typename TensorTensorFn>
+void bind_binary_overload_operation(
+    nb::module_& mod,
+    const std::string& description,
+    const std::string& math,
+    TensorScalarFn tensor_scalar_fn,
+    TensorTensorFn tensor_tensor_fn,
+    const std::string& supported_dtype = "BFLOAT16",
+    const std::string& note = " ") {
+    auto doc = fmt::format(
+        R"doc(
+        {2}
+
+        .. math::
+            {3}
+
+        Args:
+            input_tensor_a (ttnn.Tensor): the input tensor.
+            input_tensor_b (ttnn.Tensor or Number): the input tensor.
+
+        Keyword Args:
+            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+            sub_core_grids (ttnn.CoreRangeSet, optional): sub core grids for the operation. Defaults to `None`.
+            sub_device_id (ttnn.SubDeviceId, optional): sub device ID for core resolution. Mutually exclusive with sub_core_grids. Defaults to ``None``.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        {6}
+
+        Note:
+            Supported dtypes and layouts:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+               * - {4}
+                 - TILE, ROW_MAJOR
+
+            If the input tensor is ROW_MAJOR layout, it will be internally converted to TILE layout.
+
+            {5}
+        )doc",
+        std::string(Name),
+        "ttnn." + std::string(Name),
+        description,
+        math,
+        supported_dtype,
+        note,
+        BINARY_BROADCAST_DOC);
+
+    ttnn::bind_function<Name>(
+        mod,
+        doc.c_str(),
+        ttnn::overload_t(
+            tensor_scalar_fn,
+            nb::arg("input_tensor_a"),
+            nb::arg("scalar"),
+            nb::kw_only(),
+            nb::arg("memory_config") = nb::none(),
+            nb::arg("sub_core_grids") = nb::none(),
+            nb::arg("sub_device_id") = nb::none()),
+        ttnn::overload_t(
+            tensor_tensor_fn,
+            nb::arg("input_tensor_a"),
+            nb::arg("input_tensor_b"),
+            nb::kw_only(),
+            nb::arg("memory_config") = nb::none(),
+            nb::arg("sub_core_grids") = nb::none(),
+            nb::arg("sub_device_id") = nb::none()));
+}
+
+template <ttnn::unique_string Name, typename TensorScalarFn, typename TensorTensorFn>
+void bind_inplace_operation(
+    nb::module_& mod,
+    const std::string& description,
+    const std::string& math,
+    TensorScalarFn tensor_scalar_fn,
+    TensorTensorFn tensor_tensor_fn,
+    const std::string& supported_dtype = "BFLOAT16",
+    const std::string& note = "") {
+    auto doc = fmt::format(
+        R"doc(
+        {2}
+
+        .. math::
+            {3}
+
+        Args:
+            input_tensor_a (ttnn.Tensor): the input tensor.
+            input_tensor_b (ttnn.Tensor or Number): the input tensor.
+
+        Keyword Args:
+            sub_core_grids (ttnn.CoreRangeSet, optional): sub core grids for the operation. Defaults to `None`.
+            sub_device_id (ttnn.SubDeviceId, optional): sub device ID for core resolution. Mutually exclusive with sub_core_grids. Defaults to ``None``.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        {6}
+
+        Note:
+            Supported dtypes and layouts:
+
+            .. list-table::
+                :header-rows: 1
+
+                * - Dtypes
+                  - Layouts
+                * - {4}
+                  - TILE, ROW_MAJOR
+
+            If the input tensor is ROW_MAJOR layout, it will be internally converted to TILE layout.
+
+            {5}
+        )doc",
+        std::string(Name),
+        "ttnn." + std::string(Name),
+        description,
+        math,
+        supported_dtype,
+        note,
+        BINARY_BROADCAST_DOC);
+
+    ttnn::bind_function<Name>(
+        mod,
+        doc.c_str(),
+        ttnn::overload_t(
+            tensor_scalar_fn,
+            nb::arg("input_a"),
+            nb::arg("input_b"),
+            nb::kw_only(),
+            nb::arg("activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_a_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_b_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("sub_core_grids") = nb::none(),
+            nb::arg("sub_device_id") = nb::none()),
+        ttnn::overload_t(
+            tensor_tensor_fn,
+            nb::arg("input_a"),
+            nb::arg("input_b"),
+            nb::kw_only(),
+            nb::arg("activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_a_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_b_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("sub_core_grids") = nb::none(),
+            nb::arg("sub_device_id") = nb::none()));
+}
+
+template <ttnn::unique_string Name, typename TensorScalarFn, typename TensorTensorFn>
+void bind_inplace_operation_with_fast_approx(
+    nb::module_& mod,
+    const std::string& description,
+    const std::string& math,
+    TensorScalarFn tensor_scalar_fn,
+    TensorTensorFn tensor_tensor_fn,
+    const std::string& supported_dtype = "BFLOAT16",
+    const std::string& note = " ") {
+    auto doc = fmt::format(
+        R"doc(
+        {2}
+
+        .. math::
+            {3}
+
+        Args:
+            input_tensor_a (ttnn.Tensor): the input tensor.
+            input_tensor_b (ttnn.Tensor): the input tensor.
+
+        Keyword args:
+            fast_and_approximate_mode (bool, optional): Use the fast and approximate mode. Defaults to `False`.
+            sub_core_grids (ttnn.CoreRangeSet, optional): sub core grids for the operation. Defaults to `None`.
+            sub_device_id (ttnn.SubDeviceId, optional): sub device ID for core resolution. Mutually exclusive with sub_core_grids. Defaults to ``None``.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        {6}
+
+        Note:
+            Supported dtypes and layouts:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+               * - {4}
+                 - TILE, ROW_MAJOR
+
+            If the input tensor is ROW_MAJOR layout, it will be internally converted to TILE layout.
+
+            {5}
+        )doc",
+        std::string(Name),
+        "ttnn." + std::string(Name),
+        description,
+        math,
+        supported_dtype,
+        note,
+        BINARY_BROADCAST_DOC);
+
+    ttnn::bind_function<Name>(
+        mod,
+        doc.c_str(),
+        ttnn::overload_t(
+            tensor_scalar_fn,
+            nb::arg("input_a"),
+            nb::arg("input_b"),
+            nb::kw_only(),
+            nb::arg("activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_a_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_b_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("fast_and_approximate_mode") = false,
+            nb::arg("sub_core_grids") = nb::none(),
+            nb::arg("sub_device_id") = nb::none()),
+        ttnn::overload_t(
+            tensor_tensor_fn,
+            nb::arg("input_a"),
+            nb::arg("input_b"),
+            nb::kw_only(),
+            nb::arg("activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_a_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_b_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("fast_and_approximate_mode") = false,
+            nb::arg("sub_core_grids") = nb::none(),
+            nb::arg("sub_device_id") = nb::none()));
+}
+
+void bind_power(nb::module_& mod, const std::string& note = "") {
+    auto doc = fmt::format(
+        R"doc(
+        Perform element-wise {0} operation on :attr:`input_tensor` with :attr:`exponent`.
+
+        .. math::
+            \mathrm{{output\_tensor}}_i = (\mathrm{{input\_tensor}}_i ** \mathrm{{exponent}}_i)
+
+        Args:
+            input_tensor (ttnn.Tensor, float): the input tensor.
+            exponent (float, int, ttnn.Tensor): the exponent value.
+
+        Keyword Args:
+            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+            output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
+
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        {3}
+
+        Note:
+            Supported dtypes and layouts:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+               * - BFLOAT16, BFLOAT8_B, FLOAT32
+                 - TILE, ROW_MAJOR
+
+            If the input tensor is ROW_MAJOR layout, it will be internally converted to TILE layout.
+
+            {2}
+        )doc",
+        "pow",
+        "ttnn.pow",
+        note,
+        BINARY_BROADCAST_DOC);
+
+    ttnn::bind_function<"pow">(
+        mod,
+        doc.c_str(),
+        ttnn::overload_t(
+            nb::overload_cast<const Tensor&, int32_t, const std::optional<MemoryConfig>&, const std::optional<Tensor>&>(
+                &pow),
+            nb::arg("input_tensor"),
+            nb::arg("exponent"),
+            nb::kw_only(),
+            nb::arg("memory_config") = nb::none(),
+            nb::arg("output_tensor") = nb::none()),
+        ttnn::overload_t(
+            nb::overload_cast<const Tensor&, float, const std::optional<MemoryConfig>&, const std::optional<Tensor>&>(
+                &pow),
+            nb::arg("input_tensor"),
+            nb::arg("exponent"),
+            nb::kw_only(),
+            nb::arg("memory_config") = nb::none(),
+            nb::arg("output_tensor") = nb::none()),
+        ttnn::overload_t(
+            nb::overload_cast<
+                const Tensor&,
+                const Tensor&,
+                const std::optional<const DataType>&,
+                const std::optional<MemoryConfig>&,
+                const std::optional<Tensor>&,
+                ttsl::Span<const unary::EltwiseUnaryWithParam>,
+                ttsl::Span<const unary::EltwiseUnaryWithParam>,
+                ttsl::Span<const unary::EltwiseUnaryWithParam>>(&pow),
+            nb::arg("input_tensor"),
+            nb::arg("exponent"),
+            nb::kw_only(),
+            nb::arg("dtype") = nb::none(),
+            nb::arg("memory_config") = nb::none(),
+            nb::arg("output_tensor") = nb::none(),
+            nb::arg("activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_a_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_b_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{})),
+        ttnn::overload_t(
+            nb::overload_cast<
+                float,
+                const Tensor&,
+                const std::optional<const DataType>&,
+                const std::optional<MemoryConfig>&,
+                const std::optional<Tensor>&,
+                ttsl::Span<const unary::EltwiseUnaryWithParam>,
+                ttsl::Span<const unary::EltwiseUnaryWithParam>,
+                ttsl::Span<const unary::EltwiseUnaryWithParam>>(&pow),
+            nb::arg("input_tensor"),
+            nb::arg("exponent"),
+            nb::kw_only(),
+            nb::arg("dtype") = nb::none(),
+            nb::arg("memory_config") = nb::none(),
+            nb::arg("output_tensor") = nb::none(),
+            nb::arg("activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_a_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
+            nb::arg("input_tensor_b_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{})));
+}
+}  // namespace detail
+
+void py_module(nb::module_& mod) {
+    export_enum<BinaryOpType>(mod, "BinaryOpType");
+    detail::bind_binary_operation<"remainder">(
+        mod,
+        R"doc(Computes the remainder of :attr:`input_tensor_a` by :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{{output\_tensor}}_i = \mathrm{{input\_tensor\_a}}_i \mod \mathrm{{input\_tensor\_b}}_i)doc",
+        static_cast<detail::BinaryOpTensorScalarFn>(&remainder),
+        static_cast<detail::BinaryOpTensorTensorFn>(&remainder),
+        R"doc(: :code:`'None'` | :code:`'relu'`. )doc",
+        R"doc(BFLOAT16, FLOAT32, INT32)doc");
+
+    detail::bind_binary_operation<"add">(
+        mod,
+        R"doc(Adds :attr:`input_tensor_a` to :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{{output\_tensor}}_i = \mathrm{{input\_tensor\_a}}_i + \mathrm{{input\_tensor\_b}}_i)doc",
+        static_cast<detail::BinaryOpTensorScalarFn>(&add),
+        static_cast<detail::BinaryOpTensorTensorFn>(&add),
+        R"doc(: :code:`'None'` | :code:`'relu'`. )doc",
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32, INT32, UINT32 (range: [0, 4294967295]), UINT16 (range: [0, 65535]))doc");
+
+    detail::bind_binary_inplace_operation<"add_">(
+        mod,
+        R"doc(Adds :attr:`input_tensor_a` to :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a` in-place)doc",
+        R"doc(\mathrm{{input\_tensor\_a}}_i + \mathrm{{input\_tensor\_b}}_i)doc",
+        static_cast<detail::InplaceScalarFn>(&add_),
+        static_cast<detail::InplaceTensorFn>(&add_),
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32, INT32, UINT32 (range: [0, 4294967295]), UINT16 (range: [0, 65535]))doc");
+
+    detail::bind_binary_operation<"subtract">(
+        mod,
+        R"doc(Subtracts :attr:`input_tensor_b` from :attr:`input_tensor_a` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{{output\_tensor}}_i = \mathrm{{input\_tensor\_a}}_i - \mathrm{{input\_tensor\_b}}_i)doc",
+        static_cast<detail::BinaryOpTensorScalarFn>(&subtract),
+        static_cast<detail::BinaryOpTensorTensorFn>(&subtract),
+        R"doc(: :code:`'None'` | :code:`'relu'`. )doc",
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32, INT32, UINT16 (range: 0 - 65535), UINT32 (range: 0 - 4294967295))doc");
+
+    detail::bind_binary_inplace_operation<"subtract_">(
+        mod,
+        R"doc(Subtracts :attr:`input_tensor_b` from :attr:`input_tensor_a` and returns the tensor with the same layout as :attr:`input_tensor_a` in-place)doc",
+        R"doc(\mathrm{{input\_tensor\_a}}_i - \mathrm{{input\_tensor\_b}}_i)doc",
+        static_cast<detail::InplaceScalarFn>(&subtract_),
+        static_cast<detail::InplaceTensorFn>(&subtract_),
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32, INT32, UINT16 (range: 0 - 65535), UINT32 (range: 0 - 4294967295))doc");
+
+    detail::bind_binary_operation<"eq">(
+        mod,
+        R"doc(Compares if :attr:`input_tensor_a` is equal to :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{{output\_tensor}}_i = (\mathrm{{input\_tensor\_a}}_i == \mathrm{{input\_tensor\_b}}_i))doc",
+        static_cast<detail::BinaryOpTensorScalarFn>(&eq),
+        static_cast<detail::BinaryOpTensorTensorFn>(&eq),
+        ". ",
+        R"doc(Float32, BFLOAT16, BFLOAT8_B, INT32, UINT32, UINT16, UINT8 (cast to UINT16))doc");
+
+    detail::bind_binary_operation<"ne">(
+        mod,
+        R"doc(Compares if :attr:`input_tensor_a` is not equal to :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{{output\_tensor}}_i = (\mathrm{{input\_tensor\_a}}_i != \mathrm{{input\_tensor\_b}}_i))doc",
+        static_cast<detail::BinaryOpTensorScalarFn>(&ne),
+        static_cast<detail::BinaryOpTensorTensorFn>(&ne),
+        ". ",
+        R"doc(Float32, BFLOAT16, BFLOAT8_B, INT32, UINT32, UINT16, UINT8 (cast to UINT16))doc");
+
+    detail::bind_binary_operation<"lt">(
+        mod,
+        R"doc(Compares if :attr:`input_tensor_a` is less than :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{{output\_tensor}}_i = (\mathrm{{input\_tensor\_a}}_i < \mathrm{{input\_tensor\_b}}_i))doc",
+        static_cast<detail::BinaryOpTensorScalarFn>(&lt),
+        static_cast<detail::BinaryOpTensorTensorFn>(&lt),
+        ". ",
+        R"doc(Float32, BFLOAT16, BFLOAT8_B, INT32, UINT16, UINT8 (cast to UINT16))doc",
+        "INT32 supported only for tensor-tensor.");
+
+    detail::bind_binary_operation<"le">(
+        mod,
+        R"doc(Compares if :attr:`input_tensor_a` is less than or equal to :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{{output\_tensor}}_i = (\mathrm{{input\_tensor\_a}}_i <= \mathrm{{input\_tensor\_b}}_i))doc",
+        static_cast<detail::BinaryOpTensorScalarFn>(&le),
+        static_cast<detail::BinaryOpTensorTensorFn>(&le),
+        ". ",
+        R"doc(Float32, BFLOAT16, BFLOAT8_B, INT32, UINT16, UINT8 (cast to UINT16))doc",
+        "INT32 supported only for tensor-tensor.");
+
+    detail::bind_binary_operation<"gt">(
+        mod,
+        R"doc(Compares if :attr:`input_tensor_a` is greater than :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{{output\_tensor}}_i = (\mathrm{{input\_tensor\_a}}_i > \mathrm{{input\_tensor\_b}}_i))doc",
+        static_cast<detail::BinaryOpTensorScalarFn>(&gt),
+        static_cast<detail::BinaryOpTensorTensorFn>(&gt),
+        ". ",
+        R"doc(Float32, BFLOAT16, BFLOAT8_B, INT32, UINT16, UINT8 (cast to UINT16))doc",
+        "INT32 supported only for tensor-tensor.");
+
+    detail::bind_binary_operation<"ge">(
+        mod,
+        R"doc(Compares if :attr:`input_tensor_a` is greater than or equal to :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{{output\_tensor}}_i = (\mathrm{{input\_tensor\_a}}_i >= \mathrm{{input\_tensor\_b}}_i))doc",
+        static_cast<detail::BinaryOpTensorScalarFn>(&ge),
+        static_cast<detail::BinaryOpTensorTensorFn>(&ge),
+        ". ",
+        R"doc(Float32, BFLOAT16, BFLOAT8_B, INT32, UINT16, UINT8 (cast to UINT16))doc",
+        "INT32 supported only for tensor-tensor.");
+
+    detail::bind_binary_operation<"logical_and">(
+        mod,
+        R"doc(Computes logical AND of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{{output\_tensor}}_i = \mathrm{{input\_tensor\_a}}_i \, \& \, \mathrm{{input\_tensor\_b}}_i)doc",
+        static_cast<detail::BinaryOpTensorScalarFn>(&logical_and),
+        static_cast<detail::BinaryOpTensorTensorFn>(&logical_and),
+        ". ",
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32, INT32, UINT16)doc",
+        "INT32 supported only for tensor-tensor.");
+
+    detail::bind_binary_operation<"logical_or">(
+        mod,
+        R"doc(Computes logical OR of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{{output\_tensor}}_i = \mathrm{{input\_tensor\_a}}_i \, | \, \mathrm{{input\_tensor\_b}}_i)doc",
+        static_cast<detail::BinaryOpTensorScalarFn>(&logical_or),
+        static_cast<detail::BinaryOpTensorTensorFn>(&logical_or),
+        ". ",
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32, INT32, UINT32, UINT16)doc");
+
+    detail::bind_binary_operation<"ldexp">(
+        mod,
+        R"doc(Computes ldexp of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{{output\_tensor}} = \verb|ldexp|(\mathrm{{input\_tensor\_a,input\_tensor\_b}}))doc",
+        static_cast<detail::BinaryOpTensorScalarFn>(&ldexp),
+        static_cast<detail::BinaryOpTensorTensorFn>(&ldexp),
+        ". ",
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
+
+    detail::bind_binary_operation<"logaddexp">(
+        mod,
+        R"doc(Computes logaddexp of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{{output\_tensor}} = \verb|logaddexp|(\mathrm{{input\_tensor\_a,input\_tensor\_b}}))doc",
+        static_cast<detail::BinaryOpTensorScalarFn>(&logaddexp),
+        static_cast<detail::BinaryOpTensorTensorFn>(&logaddexp),
+        ". ",
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
+
+    detail::bind_binary_operation<"logaddexp2">(
+        mod,
+        R"doc(Computes logaddexp2 of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{{output\_tensor}} = \verb|logaddexp2|(\mathrm{{input\_tensor\_a,input\_tensor\_b}}))doc",
+        static_cast<detail::BinaryOpTensorScalarFn>(&logaddexp2),
+        static_cast<detail::BinaryOpTensorTensorFn>(&logaddexp2),
+        ". ",
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
+
+    detail::bind_binary_operation<"squared_difference">(
+        mod,
+        R"doc(Computes squared difference of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{{output\_tensor}} = \verb|squared_difference|(\mathrm{{input\_tensor\_a,input\_tensor\_b}}))doc",
+        static_cast<detail::BinaryOpTensorScalarFn>(&squared_difference),
+        static_cast<detail::BinaryOpTensorTensorFn>(&squared_difference),
+        ". ",
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32, INT32, UINT32, UINT16)doc");
+
+    detail::bind_binary_operation<"bias_gelu">(
+        mod,
+        R"doc(Computes bias_gelu of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{{output\_tensor}} = \verb|bias_gelu|(\mathrm{{input\_tensor\_a,input\_tensor\_b}}))doc",
+        static_cast<detail::BinaryOpTensorScalarFn>(&bias_gelu),
+        static_cast<detail::BinaryOpTensorTensorFn>(&bias_gelu),
+        ". ",
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
+
+    detail::bind_binary_operation_with_fast_approx<"multiply">(
+        mod,
+        R"doc(Multiplies :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{{output\_tensor}}_i = \mathrm{{input\_tensor\_a}}_i * \mathrm{{input\_tensor\_b}}_i)doc",
+        &detail::multiply_fast_approx_tensor_scalar,
+        &detail::multiply_fast_approx_tensor_tensor,
+        R"doc(BFLOAT16, FLOAT32, INT32, UINT16, UINT32)doc",
+        R"doc(
+        When :attr:`fast_and_approximate_mode` is `True` for bfloat16 datatype, the operation uses FPU implementation for better performance.
+        When :attr:`fast_and_approximate_mode` is `False` for bfloat16 datatype, the operation uses SFPU with the result rounded to nearest even (RNE).
+        )doc");
+    detail::bind_binary_operation_with_fast_approx<"divide">(
+        mod,
+        R"doc(Divides :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{{output\_tensor}}_i = (\mathrm{{input\_tensor\_a}}_i / \mathrm{{input\_tensor\_b}}_i))doc",
+        &detail::divide_fast_approx_tensor_scalar,
+        &detail::divide_fast_approx_tensor_tensor,
+        R"doc(BFLOAT16, FLOAT32, INT32, UINT16)doc",
+        R"doc(
+        When :attr:`fast_and_approximate_mode` is `True`, operation assumes that :attr:`input_tensor_b` is not zero.
+        When :attr:`fast_and_approximate_mode` is `False` (default), operation properly handle division by zero.
+        When the inputs are INT32, the outputs are FLOAT32 and output datatype conversion is not supported.
+        )doc");
+
+    detail::bind_binary_operation<"xlogy">(
+        mod,
+        R"doc(Computes xlogy :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{output\_tensor}_i = \mathrm{input\_tensor\_a}_i \cdot \log(\mathrm{input\_tensor\_b}_i)
+        )doc",
+        static_cast<detail::BinaryOpTensorScalarFn>(&xlogy),
+        static_cast<detail::BinaryOpTensorTensorFn>(&xlogy));
+
+    detail::bind_binary_unary_operation<"rsub">(
+        mod,
+        R"doc(Subtracts :attr:`input_tensor_a` from :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{{output\_tensor}}_i = \mathrm{{input\_tensor\_b}}_i - \mathrm{{input\_tensor\_a}}_i)doc",
+        static_cast<detail::BinaryUnaryScalarFn>(&rsub),
+        static_cast<detail::BinaryUnaryTensorFn>(&rsub),
+        ". ",
+        R"doc(FLOAT32,BFLOAT16, BFLOAT8_B, INT32, UINT32, UINT16)doc");
+
+    detail::bind_bitwise_binary_ops_operation<"bitwise_and">(
+        mod,
+        R"doc(Perform bitwise_and operation on :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{{output\_tensor}}_i = \verb|bitwise_and|(\mathrm{{input\_tensor\_a, input\_tensor\_b}}))doc",
+        static_cast<detail::BitwiseScalarFn>(&bitwise_and),
+        static_cast<detail::BitwiseTensorFn>(&bitwise_and),
+        ". ",
+        R"doc(INT32, UINT16 (range: 0 - 65535), UINT32)doc");
+
+    detail::bind_bitwise_binary_ops_operation<"bitwise_or">(
+        mod,
+        R"doc(Perform bitwise_or operation on :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{{output\_tensor}}_i = \verb|bitwise_or|(\mathrm{{input\_tensor\_a, input\_tensor\_b}}))doc",
+        static_cast<detail::BitwiseScalarFn>(&bitwise_or),
+        static_cast<detail::BitwiseTensorFn>(&bitwise_or),
+        ". ",
+        R"doc(INT32, UINT16 (range: 0 - 65535), UINT32)doc");
+
+    detail::bind_bitwise_binary_ops_operation<"bitwise_xor">(
+        mod,
+        R"doc(Perform bitwise_xor operation on :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{{output\_tensor}}_i = \verb|bitwise_xor|(\mathrm{{input\_tensor\_a, input\_tensor\_b}}))doc",
+        static_cast<detail::BitwiseScalarFn>(&bitwise_xor),
+        static_cast<detail::BitwiseTensorFn>(&bitwise_xor),
+        ". ",
+        R"doc(INT32, UINT16 (range: 0 - 65535), UINT32)doc");
+
+    detail::bind_bitwise_binary_ops_operation<"bitwise_left_shift">(
+        mod,
+        R"doc(Perform bitwise_left_shift operation on :attr:`input_tensor_a` by :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`. :attr:`input_tensor_b` has shift_bits which are integers within range (0, 31))doc",
+        R"doc(\mathrm{{output\_tensor}}_i = \verb|bitwise_and|(\mathrm{{input\_tensor\_a, input\_tensor\_b}}))doc",
+        static_cast<detail::BitwiseScalarFn>(&bitwise_left_shift),
+        static_cast<detail::BitwiseTensorFn>(&bitwise_left_shift),
+        ". ",
+        R"doc(INT32, UINT32, UINT16)doc");
+
+    detail::bind_bitwise_binary_ops_operation<"bitwise_right_shift">(
+        mod,
+        R"doc(Perform bitwise_right_shift operation on :attr:`input_tensor_a` by :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`. :attr:`input_tensor_b` has shift_bits which are integers within range (0, 31))doc",
+        R"doc(\mathrm{{output\_tensor}}_i = \verb|bitwise_and|(\mathrm{{input\_tensor\_a, input\_tensor\_b}}))doc",
+        static_cast<detail::BitwiseScalarFn>(&bitwise_right_shift),
+        static_cast<detail::BitwiseTensorFn>(&bitwise_right_shift),
+        ". ",
+        R"doc(INT32, UINT32, UINT16)doc");
+
+    detail::bind_bitwise_binary_ops_operation<"logical_left_shift">(
+        mod,
+        R"doc(Perform logical_left_shift operation on :attr:`input_tensor_a` by :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`. :attr:`input_tensor_b` has shift_bits which are integers within range (0, 31). Equivalent to multiplying by 2^shift_amt.)doc",
+        R"doc(\mathrm{{output\_tensor}}_i = \verb|logical_left_shift|(\mathrm{{input\_tensor\_a, input\_tensor\_b}}))doc",
+        static_cast<detail::BitwiseScalarFn>(&logical_left_shift),
+        static_cast<detail::BitwiseTensorFn>(&logical_left_shift),
+        ". ",
+        R"doc(INT32, UINT32)doc");
+
+    detail::bind_binary_operation<"logical_right_shift">(
+        mod,
+        R"doc(Perform logical_right_shift operation on :attr:`input_tensor_a` by :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`. :attr:`input_tensor_b` has shift_bits which are integers within range (0, 31). Logical right shift fills vacated bits with zeros. Equivalent to integer division by 2^shift_amt.)doc",
+        R"doc(\mathrm{{output\_tensor}}_i = \verb|logical_right_shift|(\mathrm{{input\_tensor\_a, input\_tensor\_b}}))doc",
+        static_cast<detail::BinaryOpTensorScalarFn>(&logical_right_shift),
+        static_cast<detail::BinaryOpTensorTensorFn>(&logical_right_shift),
+        ". ",
+        R"doc(INT32, UINT32)doc");
+
+    detail::bind_binary_composite<"hypot">(
+        mod,
+        R"doc(Computes hypot :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{output\_tensor}_i = \sqrt{(\mathrm{input\_tensor\_a}_i^2 + \mathrm{input\_tensor\_b}_i^2)})doc",
+        &detail::hypot_composite_wrapper,
+        R"doc(FLOAT32, BFLOAT16, BFLOAT8_B)doc");
+
+    detail::bind_binary_composite<"nextafter">(
+        mod,
+        R"doc(Computes nextafter :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{output\_tensor}_i = \begin{cases} \mathrm{next\_float}(\mathrm{input\_tensor\_a}_i, \mathrm{input\_tensor\_b}_i), & \text{if } \mathrm{input\_tensor\_a}_i \neq \mathrm{input\_tensor\_b}_i \\ \mathrm{input\_tensor\_a}_i, & \text{if } \mathrm{input\_tensor\_a}_i = \mathrm{input\_tensor\_b}_i \end{cases}
+        )doc",
+        &nextafter,
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
+
+    detail::bind_binary_unary_max_operation<"minimum">(
+        mod,
+        R"doc(Computes minimum for :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        static_cast<detail::BinaryUnaryMaxScalarFn>(&minimum),
+        static_cast<detail::BinaryUnaryMaxTensorFn>(&minimum));
+
+    detail::bind_binary_composite<"atan2">(
+        mod,
+        R"doc(Element-wise arctangent of :attr:`input_tensor_a_i` / :attr:`input_tensor_b_i` with consideration of the quadrant. Returns signed angles in radians between the vector (:attr:`input_tensor_b_i`, :attr:`input_tensor_a_i`) and the vector (1, 0).)doc",
+        R"doc(\mathrm{output\_tensor}_i = \operatorname{atan2}(\mathrm{input\_tensor\_a}_i, \mathrm{input\_tensor\_b}_i))doc",
+        &atan2,
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc",
+        R"doc(The second parameter, :attr:`input_tensor_b`, is the x-coordinate, while the first parameter, :attr:`input_tensor_a`, is the y-coordinate.)doc");
+
+    detail::bind_binary_operation<"logical_xor">(
+        mod,
+        R"doc(Compute logical_xor :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{output\_tensor}_i = (\mathrm{input\_tensor\_a}_i \land \lnot \mathrm{input\_tensor\_b}_i) \lor (\lnot \mathrm{input\_tensor\_a}_i \land \mathrm{input\_tensor\_b}_i))doc",
+        static_cast<detail::BinaryOpTensorScalarFn>(&logical_xor),
+        static_cast<detail::BinaryOpTensorTensorFn>(&logical_xor),
+        ".",
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32, INT32, UINT32, UINT16)doc");
+
+    detail::bind_inplace_operation<"logical_or_">(
+        mod,
+        R"doc(Computes inplace logical OR of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{{input\_tensor\_a}}_i | \mathrm{{input\_tensor\_b}}_i)doc",
+        static_cast<detail::InplaceScalarFn>(&logical_or_),
+        static_cast<detail::InplaceTensorFn>(&logical_or_),
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32, INT32, UINT32, UINT16)doc");
+
+    detail::bind_inplace_operation<"logical_xor_">(
+        mod,
+        R"doc(Computes inplace logical XOR of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{input\_tensor\_a}_i \land \lnot \mathrm{input\_tensor\_b}_i) \lor (\lnot \mathrm{input\_tensor\_a}_i \land \mathrm{input\_tensor\_b}_i)doc",
+        static_cast<detail::InplaceScalarFn>(&logical_xor_),
+        static_cast<detail::InplaceTensorFn>(&logical_xor_),
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32, INT32, UINT32, UINT16)doc");
+
+    detail::bind_inplace_operation<"logical_and_">(
+        mod,
+        R"doc(Computes inplace logical AND of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{{input\_tensor\_a}}_i \& \mathrm{{input\_tensor\_b}}_i)doc",
+        static_cast<detail::InplaceScalarFn>(&logical_and_),
+        static_cast<detail::InplaceTensorFn>(&logical_and_),
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32, INT32, UINT32, UINT16)doc");
+
+    detail::bind_binary_gcd_lcm_operation<"gcd">(
+        mod,
+        R"doc(Computes Greatest common divisor of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`.
+        [supported range [-2147483648, 2147483647]].)doc",
+        R"doc(\mathrm{output\_tensor}_i = \verb|gcd|\left(\mathrm{input\_tensor\_a}_i , \mathrm{input\_tensor\_b}_i\right)
+        )doc",
+        &gcd,
+        R"doc(INT32)doc");
+
+    detail::bind_binary_gcd_lcm_operation<"lcm">(
+        mod,
+        R"doc(Computes Least common multiple of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`.
+        [supported range [-32768, 32767]].)doc",
+        R"doc(\mathrm{output\_tensor}_i = \verb|lcm|\left(\mathrm{input\_tensor\_a}_i , \mathrm{input\_tensor\_b}_i\right)
+        )doc",
+        &lcm,
+        R"doc(INT32)doc");
+
+    detail::bind_binary_with_float_param<"addalpha">(
+        mod,
+        R"doc(Computes addalpha for :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{{output\_tensor}} = \mathrm{{input\_tensor\_a\ + input\_tensor\_b\ * \alpha}})doc",
+        &addalpha,
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
+
+    detail::bind_binary_with_float_param<"subalpha">(
+        mod,
+        R"doc(Computes subalpha for :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{{output\_tensor}} = \mathrm{{input\_tensor\_a\ - input\_tensor\_b\ * \alpha}})doc",
+        &subalpha,
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
+
+    detail::bind_binary_composite_with_rtol_atol<"isclose">(
+        mod,
+        R"doc(Computes isclose for :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`. INT32 tensors are typecast to FLOAT32 on device; for integers with magnitude much larger than 2^24 (~1.67e7), that cast can round distinct values to the same float, so the result may differ from ``torch.isclose`` on the original integer tensors.)doc",
+        R"doc(\mathrm{output\_tensor} = \begin{cases} 1, & \text{if } |\mathrm{input\_tensor\_a} - \mathrm{input\_tensor\_b}| \leq (\mathrm{atol} + \mathrm{rtol} \times |\mathrm{input\_tensor\_b}|) \\ 0, & \text{otherwise} \end{cases}
+        )doc",
+        &isclose);
+
+    detail::bind_div<"div">(
+        mod,
+        R"doc(Divides :attr:`input_tensor_a` by :attr:`input_tensor_b` and returns a tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{output}_i = \begin{cases} \mathrm{\left(\frac{\mathrm{input\_tensor\_a}_i}{\mathrm{input\_tensor\_b}_i}\right)}, & \text{if } \mathrm{round\_mode} = \mathrm{None} \\ \mathrm{\text{floor}\left(\frac{\mathrm{input\_tensor\_a}_i}{\mathrm{input\_tensor\_b}_i}\right)}, & \text{if } \mathrm{round\_mode} = \mathrm{floor} \\ \mathrm{\text{trunc}\left(\frac{\mathrm{input\_tensor\_a}_i}{\mathrm{input\_tensor\_b}_i}\right)}, & \text{if } \mathrm{round\_mode} = \mathrm{trunc} \end{cases}
+        )doc",
+        nb::overload_cast<
+            const Tensor&,
+            const Tensor&,
+            bool,
+            const std::optional<std::string>&,
+            const std::optional<const DataType>&,
+            const std::optional<MemoryConfig>&,
+            const std::optional<Tensor>&,
+            ttsl::Span<const unary::EltwiseUnaryWithParam>,
+            ttsl::Span<const unary::EltwiseUnaryWithParam>,
+            ttsl::Span<const unary::EltwiseUnaryWithParam>,
+            const std::optional<CoreRangeSet>&,
+            const std::optional<tt::tt_metal::SubDeviceId>&>(&div),
+        nb::overload_cast<
+            const Tensor&,
+            unary::ScalarVariant,
+            bool,
+            const std::optional<std::string>&,
+            const std::optional<const DataType>&,
+            const std::optional<MemoryConfig>&,
+            const std::optional<Tensor>&,
+            ttsl::Span<const unary::EltwiseUnaryWithParam>,
+            ttsl::Span<const unary::EltwiseUnaryWithParam>,
+            ttsl::Span<const unary::EltwiseUnaryWithParam>,
+            const std::optional<CoreRangeSet>&,
+            const std::optional<tt::tt_metal::SubDeviceId>&>(&div),
+        R"doc(BFLOAT16, FLOAT32, INT32, UINT16)doc",
+        R"doc(
+        With INT32 inputs, rounding_mode `None` produces a FLOAT32 output, while `floor` and `trunc` produce an INT32 output.
+        When :attr:`fast_and_approximate_mode` is `True`, operation assumes that :attr:`input_tensor_b` is not zero for fast approximation.
+        When :attr:`fast_and_approximate_mode` is `False` (default), operation properly handles division by zero (accurate mode).
+        )doc");
+
+    detail::bind_binary_composite_overload<"div_no_nan">(
+        mod,
+        R"doc(Computes div_no_nan for :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        static_cast<detail::BinaryCompositeTensorTensorFn>(&div_no_nan),
+        static_cast<detail::BinaryCompositeTensorScalarFn>(&div_no_nan));
+
+    detail::bind_binary_composite_overload<"floor_div">(
+        mod,
+        R"doc(Computes floor division for :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        static_cast<detail::BinaryCompositeTensorTensorFn>(&floor_div),
+        static_cast<detail::BinaryCompositeTensorScalarFn>(&floor_div));
+
+    detail::bind_binary_unary_max_operation<"maximum">(
+        mod,
+        R"doc(Computes maximum for :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        static_cast<detail::BinaryUnaryMaxScalarFn>(&maximum),
+        static_cast<detail::BinaryUnaryMaxTensorFn>(&maximum),
+        R"doc(Supported range for :attr:`input_tensor_b` when its of scalar type is [-16777216, 16777216])doc");
+
+    detail::bind_prelu<"prelu">(
+        mod,
+        R"doc(Perform an eltwise-prelu operation.)doc",
+        static_cast<detail::BinaryCompositeTensorTensorFn>(&prelu),
+        static_cast<detail::BinaryCompositeTensorScalarFn>(&prelu),
+        static_cast<detail::PreluTensorArrayFn>(&prelu),
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc",
+        R"doc(PReLU supports the case where weight is a scalar or 1D list/array of size=1 or a 1D tensor :attr:`input_tensor_b` of size = the second dimension in :attr:`input_tensor_a`)doc");
+
+    detail::bind_binary_composite<"outer">(
+        mod,
+        R"doc(Computes outer for :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{output\_tensor} = \mathrm{input\_tensor\_a} \text{ } \otimes \text{ } \mathrm{input\_tensor\_b})doc",
+        &outer,
+        R"doc(BFLOAT16, FLOAT32)doc");
+
+    detail::bind_polyval<"polyval">(
+        mod,
+        R"doc(Computes polyval of all elements of :attr:`input_tensor_a` with coefficients :attr:`coeffs` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{output\_tensor} = \sum_{i=0}^{n} (\mathrm{coeffs}_i) (\mathrm{input\_tensor}^i)
+        )doc",
+        &polyval,
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
+
+    detail::bind_binary_overload_operation<"fmod">(
+        mod,
+        R"doc(Performs an eltwise-fmod operation.)doc",
+        R"doc(\mathrm{{output\_tensor}} = \verb|fmod|(\mathrm{{input\_tensor\_a,input\_tensor\_b}}))doc",
+        static_cast<detail::BinaryOverloadScalarFn>(&fmod),
+        static_cast<detail::BinaryOverloadTensorFn>(&fmod),
+        R"doc(BFLOAT16, FLOAT32, INT32)doc");
+
+    detail::bind_inplace_operation<"gt_">(
+        mod,
+        R"doc(Performs Greater than in-place operation on :attr:`input_a` and :attr:`input_b` and returns the tensor with the same layout as :attr:`input_tensor`)doc",
+        R"doc(\mathrm{{input\_tensor\_a}} > \mathrm{{input\_tensor\_b}})doc",
+        static_cast<detail::InplaceScalarFn>(&gt_),
+        static_cast<detail::InplaceTensorFn>(&gt_),
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
+
+    detail::bind_inplace_operation<"ge_">(
+        mod,
+        R"doc(Performs Greater than or equal to in-place operation on :attr:`input_a` and :attr:`input_b` and returns the tensor with the same layout as :attr:`input_tensor`)doc",
+        R"doc(\mathrm{{input\_tensor\_a}} >= \mathrm{{input\_tensor\_b}})doc",
+        static_cast<detail::InplaceScalarFn>(&ge_),
+        static_cast<detail::InplaceTensorFn>(&ge_),
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
+
+    detail::bind_inplace_operation<"lt_">(
+        mod,
+        R"doc(Performs Less than in-place operation on :attr:`input_a` and :attr:`input_b` and returns the tensor with the same layout as :attr:`input_tensor`)doc",
+        R"doc(\mathrm{{input\_tensor\_a}} < \mathrm{{input\_tensor\_b}})doc",
+        static_cast<detail::InplaceScalarFn>(&lt_),
+        static_cast<detail::InplaceTensorFn>(&lt_),
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
+
+    detail::bind_inplace_operation<"le_">(
+        mod,
+        R"doc(Performs Less than or equal to in-place operation on :attr:`input_a` and :attr:`input_b` and returns the tensor with the same layout as :attr:`input_tensor`)doc",
+        R"doc(\mathrm{{input\_tensor\_a}} <= \mathrm{{input\_tensor\_b}})doc",
+        static_cast<detail::InplaceScalarFn>(&le_),
+        static_cast<detail::InplaceTensorFn>(&le_),
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
+
+    detail::bind_inplace_operation<"eq_">(
+        mod,
+        R"doc(Performs Equal to in-place operation on :attr:`input_a` and :attr:`input_b` and returns the tensor with the same layout as :attr:`input_tensor`)doc",
+        R"doc(\mathrm{{input\_tensor\_a}} == \mathrm{{input\_tensor\_b}})doc",
+        static_cast<detail::InplaceScalarFn>(&eq_),
+        static_cast<detail::InplaceTensorFn>(&eq_),
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
+
+    detail::bind_inplace_operation<"ne_">(
+        mod,
+        R"doc(Performs Not equal to in-place operation on :attr:`input_a` and :attr:`input_b` and returns the tensor with the same layout as :attr:`input_tensor`)doc",
+        R"doc(\mathrm{{input\_tensor\_a}}\: != \mathrm{{input\_tensor\_b}})doc",
+        static_cast<detail::InplaceScalarFn>(&ne_),
+        static_cast<detail::InplaceTensorFn>(&ne_),
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
+
+    detail::bind_inplace_operation<"ldexp_">(
+        mod,
+        R"doc(Performs ldexp in-place operation on :attr:`input_a` and :attr:`input_b` and returns the tensor with the same layout as :attr:`input_tensor`)doc",
+        R"doc(\verb|ldexp|(\mathrm{{input\_tensor\_a,input\_tensor\_b}}))doc",
+        static_cast<detail::InplaceScalarFn>(&ldexp_),
+        static_cast<detail::InplaceTensorFn>(&ldexp_),
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
+
+    detail::bind_inplace_operation<"logaddexp_">(
+        mod,
+        R"doc(Performs logaddexp in-place operation on :attr:`input_a` and :attr:`input_b` and returns the tensor with the same layout as :attr:`input_tensor`)doc",
+        R"doc(\verb|logaddexp|(\mathrm{{input\_tensor\_a,input\_tensor\_b}}))doc",
+        static_cast<detail::InplaceScalarFn>(&logaddexp_),
+        static_cast<detail::InplaceTensorFn>(&logaddexp_),
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
+
+    detail::bind_inplace_operation<"logaddexp2_">(
+        mod,
+        R"doc(Performs logaddexp2 in-place operation on :attr:`input_a` and :attr:`input_b` and returns the tensor with the same layout as :attr:`input_tensor`)doc",
+        R"doc(\verb|logaddexp2|(\mathrm{{input\_tensor\_a,input\_tensor\_b}}))doc",
+        static_cast<detail::InplaceScalarFn>(&logaddexp2_),
+        static_cast<detail::InplaceTensorFn>(&logaddexp2_),
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
+
+    detail::bind_inplace_operation<"squared_difference_">(
+        mod,
+        R"doc(Performs squared_difference in-place operation on :attr:`input_a` and :attr:`input_b` and returns the tensor with the same layout as :attr:`input_tensor`)doc",
+        R"doc(\verb|squared_difference|(\mathrm{{input\_tensor\_a,input\_tensor\_b}}))doc",
+        static_cast<detail::InplaceScalarFn>(&squared_difference_),
+        static_cast<detail::InplaceTensorFn>(&squared_difference_),
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32, INT32, UINT32, UINT16)doc");
+
+    detail::bind_inplace_operation_with_fast_approx<"multiply_">(
+        mod,
+        R"doc(Performs in-place multiplication operation on :attr:`input_a` and :attr:`input_b` and returns the tensor with the same layout as :attr:`input_tensor`)doc",
+        R"doc(\verb|multiply|(\mathrm{{input\_tensor\_a,input\_tensor\_b}}))doc",
+        static_cast<detail::InplaceFastApproxScalarFn>(&multiply_),
+        static_cast<detail::InplaceFastApproxTensorFn>(&multiply_),
+        R"doc(BFLOAT16, FLOAT32, UINT16)doc",
+        R"doc(
+        When :attr:`fast_and_approximate_mode` is `True` for bfloat16 datatype, the operation uses FPU implementation for better performance.
+        When :attr:`fast_and_approximate_mode` is `False` for bfloat16 datatype, the operation uses SFPU with the result rounded to nearest even (RNE).
+        The operation is not supported for INT32 inputs since the outputs are returned as FLOAT32.
+        )doc");
+    detail::bind_inplace_operation_with_fast_approx<"divide_">(
+        mod,
+        R"doc(Performs in-place division operation on :attr:`input_a` and :attr:`input_b` and returns the tensor with the same layout as :attr:`input_tensor`)doc",
+        R"doc(\verb|divide|(\mathrm{{input\_tensor\_a,input\_tensor\_b}}))doc",
+        static_cast<detail::InplaceFastApproxScalarFn>(&divide_),
+        static_cast<detail::InplaceFastApproxTensorFn>(&divide_),
+        R"doc(BFLOAT16, FLOAT32, UINT16)doc",
+        R"doc(
+        When :attr:`fast_and_approximate_mode` is `True`, the operation uses FPU+SFPU implementation for better performance.
+        When :attr:`fast_and_approximate_mode` is `False` (default), the operation uses SFPU implementation for better accuracy.
+        The operation is not supported for INT32 inputs since the outputs are returned as FLOAT32.
+        )doc");
+
+    detail::bind_inplace_operation<"rsub_">(
+        mod,
+        R"doc(Subtracts :attr:`input_a` from :attr:`input_b` in-place and returns the tensor with the same layout as :attr:`input_tensor`)doc",
+        R"doc(\mathrm{{input\_tensor\_b}} - \mathrm{{input\_tensor\_a}})doc",
+        static_cast<detail::InplaceScalarFn>(&rsub_),
+        static_cast<detail::InplaceTensorFn>(&rsub_),
+        R"doc(FLOAT32, BFLOAT16, BFLOAT8_B, INT32, UINT32, UINT16)doc");
+
+    detail::bind_inplace_operation<"bias_gelu_">(
+        mod,
+        R"doc(Performs bias_gelu in-place operation on :attr:`input_a` and :attr:`input_b` and returns the tensor with the same layout as :attr:`input_tensor`)doc",
+        R"doc(\verb|bias_gelu|(\mathrm{{input\_tensor\_a,input\_tensor\_b}}))doc",
+        static_cast<detail::InplaceScalarFn>(&bias_gelu_),
+        static_cast<detail::InplaceTensorFn>(&bias_gelu_),
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
+
+    detail::bind_power(
+        mod,
+        R"doc(When :attr:`exponent` is a Tensor, supported dtypes are: BFLOAT16, FLOAT32. Both input tensors should be of same dtype.)doc");
+}
+
+}  // namespace ttnn::operations::experimental::quasar::binary

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary/binary_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary/binary_nanobind.hpp
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::experimental::quasar::binary {
+namespace nb = nanobind;
+void py_module(nb::module_& mod);
+}  // namespace ttnn::operations::experimental::quasar::binary

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary/common/binary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary/common/binary_op_types.hpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+namespace ttnn::operations::experimental::quasar::binary {
+
+enum class BinaryOpType {
+    ADD,
+    SUB,
+    MUL,
+    GT,
+    LT,
+    LE,
+    GE,
+    EQ,
+    NE,
+    SQUARED_DIFFERENCE,
+    BIAS_GELU,
+    LOGADDEXP,
+    LOGICAL_AND,
+    LOGICAL_OR,
+    LOGICAL_XOR,
+    LDEXP,
+    LOGADDEXP2,
+    DIV,
+    DIV_FLOOR,
+    DIV_TRUNC,
+    REMAINDER,
+    FMOD,
+    RSUB,
+    POWER,
+    BITWISE_XOR,
+    BITWISE_AND,
+    BITWISE_OR,
+    LEFT_SHIFT,
+    RIGHT_SHIFT,
+    LOGICAL_RIGHT_SHIFT,
+    QUANT,
+    REQUANT,
+    DEQUANT,
+    MAXIMUM,
+    MINIMUM,
+    GCD,
+    LCM,
+    ADDALPHA,
+    SUBALPHA,
+    XLOGY,
+    HYPOT,
+    ATAN2,
+    WHERE_TST,
+    WHERE_TTS,
+    ISCLOSE,
+};
+
+}  // namespace ttnn::operations::experimental::quasar::binary

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary/common/binary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary/common/binary_op_utils.cpp
@@ -1,0 +1,586 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "binary_op_utils.hpp"
+
+#include <tt_stl/assert.hpp>
+#include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
+#include "ttnn/tensor/types.hpp"
+
+using namespace tt::tt_metal;
+
+namespace ttnn::operations::experimental::quasar::binary::utils {
+
+using ttnn::operations::unary::EltwiseUnaryWithParam;
+using ttnn::operations::unary::UnaryOpType;
+
+bool is_typecast(tt::tt_metal::DataType input, tt::tt_metal::DataType output) {
+    using enum tt::tt_metal::DataType;
+
+    return (input == BFLOAT4_B && output == INT32) || (input == BFLOAT4_B && output == UINT16) ||
+           (input == BFLOAT4_B && output == UINT32) || (input == BFLOAT8_B && output == INT32) ||
+           (input == BFLOAT8_B && output == UINT16) || (input == BFLOAT8_B && output == UINT32) ||
+           (input == BFLOAT16 && output == INT32) || (input == BFLOAT16 && output == UINT16) ||
+           (input == BFLOAT16 && output == UINT32) || (input == FLOAT32 && output == BFLOAT16) ||
+           (input == FLOAT32 && output == INT32) || (input == FLOAT32 && output == UINT16) ||
+           (input == FLOAT32 && output == UINT32) || (input == INT32 && output == BFLOAT4_B) ||
+           (input == INT32 && output == BFLOAT8_B) || (input == INT32 && output == BFLOAT16) ||
+           (input == INT32 && output == FLOAT32) || (input == UINT16 && output == BFLOAT4_B) ||
+           (input == UINT16 && output == BFLOAT8_B) || (input == UINT16 && output == BFLOAT16) ||
+           (input == UINT16 && output == FLOAT32) || (input == UINT16 && output == UINT32) ||
+           (input == UINT32 && output == BFLOAT4_B) || (input == UINT32 && output == BFLOAT8_B) ||
+           (input == UINT32 && output == BFLOAT16) || (input == UINT32 && output == FLOAT32) ||
+           (input == UINT16 && output == INT32) || (input == INT32 && output == UINT16) ||
+           (input == UINT32 && output == UINT16);
+}
+
+std::map<std::string, std::string> get_defines(
+    BinaryOpType op_type,
+    const std::optional<tt::tt_metal::DataType> input_dtype,
+    const std::optional<tt::tt_metal::DataType> output_dtype,
+    const std::optional<std::vector<EltwiseUnaryWithParam>>& fused_activations,
+    const std::optional<EltwiseUnaryWithParam>& input_tensor_a_activation) {
+    std::map<std::string, std::string> defines;
+    std::string op_name = "sub_tiles";
+    std::string op_binary_type = "EltwiseBinaryType::ELWSUB";
+    std::string idst = "i";
+
+    using ttnn::operations::unary::utils::get_defines;
+
+    switch (op_type) {
+        case BinaryOpType::ADD:
+            op_name = "add_tiles";
+            op_binary_type = "EltwiseBinaryType::ELWADD";
+            break;
+        case BinaryOpType::SUB:
+            op_name = "sub_tiles";
+            op_binary_type = "EltwiseBinaryType::ELWSUB";
+            break;
+        case BinaryOpType::MUL:
+            op_name = "mul_tiles";
+            op_binary_type = "EltwiseBinaryType::ELWMUL";
+            break;
+        case BinaryOpType::GT:
+            defines.merge(get_defines(UnaryOpType::GTZ, std::nullopt, "0", idst, input_dtype));
+            break;
+        case BinaryOpType::LT:
+            defines.merge(get_defines(UnaryOpType::LTZ, std::nullopt, "0", idst, input_dtype));
+            break;
+        case BinaryOpType::GE:
+            defines.merge(get_defines(UnaryOpType::GEZ, std::nullopt, "0", idst, input_dtype));
+            break;
+        case BinaryOpType::LE:
+            defines.merge(get_defines(UnaryOpType::LEZ, std::nullopt, "0", idst, input_dtype));
+            break;
+        case BinaryOpType::EQ:
+            defines.merge(get_defines(UnaryOpType::EQZ, std::nullopt, "0", idst, input_dtype));
+            break;
+        case BinaryOpType::NE:
+            defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "0", idst, input_dtype));
+            break;
+        case BinaryOpType::SQUARED_DIFFERENCE:
+            defines.merge(get_defines(UnaryOpType::SQUARE, std::nullopt, "0", idst));
+            break;
+        case BinaryOpType::LOGICAL_AND:
+            op_name = "mul_tiles";
+            op_binary_type = "EltwiseBinaryType::ELWMUL";
+            defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "0", idst, input_dtype));
+            break;
+        case BinaryOpType::BIAS_GELU:
+            op_name = "add_tiles";
+            op_binary_type = "EltwiseBinaryType::ELWADD";
+            defines.merge(get_defines(UnaryOpType::GELU, std::vector<float>{0}, "0", idst));
+            break;
+        case BinaryOpType::LOGADDEXP:
+            // PRE_IN0_0 ===> Applies prescaling for first input
+            // PRE_IN1_0 ====> Applies prescaling for second input
+            defines.merge(get_defines(UnaryOpType::EXP, std::vector<float>{0}, "PRE_IN0_0"));
+            defines.merge(get_defines(UnaryOpType::EXP, std::vector<float>{0}, "PRE_IN1_0"));
+            op_name = "add_tiles";
+            op_binary_type = "EltwiseBinaryType::ELWADD";
+            defines.merge(get_defines(UnaryOpType::LOG, std::nullopt, "0", idst));
+            break;
+        case BinaryOpType::RSUB:
+            //  rsub(a,b) = b - a
+            defines.merge(get_defines(UnaryOpType::NEG, std::nullopt, "PRE_IN0_0"));
+            op_name = "add_tiles";
+            op_binary_type = "EltwiseBinaryType::ELWADD";
+            break;
+        case BinaryOpType::DIV:
+            // Divide by a non-zero tensor
+            defines.merge(get_defines(UnaryOpType::RECIP, std::nullopt, "PRE_IN1_0"));
+            op_name = "mul_tiles";
+            op_binary_type = "EltwiseBinaryType::ELWMUL";
+            break;
+        case BinaryOpType::LOGICAL_OR:
+            defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN0_0", "0", input_dtype));
+            defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN1_0", "0", input_dtype));
+            op_name = "add_tiles";
+            op_binary_type = "EltwiseBinaryType::ELWADD";
+            defines.merge(get_defines(UnaryOpType::GTZ, std::nullopt, "0", idst, input_dtype));
+            break;
+        case BinaryOpType::LOGICAL_XOR:
+            defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN0_0", "0", input_dtype));
+            defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN1_0", "0", input_dtype));
+            op_name = "sub_tiles";
+            op_binary_type = "EltwiseBinaryType::ELWSUB";
+            defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "0", idst, input_dtype));
+            break;
+        case BinaryOpType::LDEXP:
+            defines.merge(get_defines(UnaryOpType::EXP2, std::nullopt, "PRE_IN1_0"));
+            op_name = "mul_tiles";
+            op_binary_type = "EltwiseBinaryType::ELWMUL";
+            break;
+        case BinaryOpType::LOGADDEXP2:
+            defines.merge(get_defines(UnaryOpType::EXP2, std::nullopt, "PRE_IN0_0"));
+            defines.merge(get_defines(UnaryOpType::EXP2, std::nullopt, "PRE_IN1_0"));
+            op_name = "add_tiles";
+            op_binary_type = "EltwiseBinaryType::ELWADD";
+            defines.merge(get_defines(UnaryOpType::LOG2, std::nullopt, "0", idst));
+            break;
+        case BinaryOpType::HYPOT:
+            // Hypot: sqrt(a^2 + b^2)
+            defines.merge(get_defines(UnaryOpType::SQUARE, std::nullopt, "PRE_IN0_0", "0", input_dtype));
+            defines.merge(get_defines(UnaryOpType::SQUARE, std::nullopt, "PRE_IN1_0", "0", input_dtype));
+            op_name = "add_tiles";
+            op_binary_type = "EltwiseBinaryType::ELWADD";
+            defines.merge(get_defines(UnaryOpType::SQRT, std::nullopt, "0", idst, input_dtype));
+            break;
+        default: TT_THROW("Undefined op type {}", op_type);
+    }
+
+    if (input_dtype.has_value() && output_dtype.has_value() && is_typecast(*input_dtype, *output_dtype)) {
+        TT_ASSERT(!defines.contains("SFPU_OP_CHAIN_0"), "SFPU_OP_CHAIN_0 already defined");
+
+        auto in_dataformat = static_cast<uint32_t>(datatype_to_dataformat_converter(input_dtype.value()));
+        auto out_dataformat = static_cast<uint32_t>(datatype_to_dataformat_converter(output_dtype.value()));
+        defines.insert(
+            {"SFPU_OP_CHAIN_0",
+             fmt::format(
+                 "typecast_tile_init<{0}u, {1}u>(); typecast_tile<{0}u, {1}u>(i);", in_dataformat, out_dataformat)});
+        defines.insert({"SFPU_OP_TYPECAST_INCLUDE", "1"});
+    }
+
+    defines["ELTWISE_OP"] = op_name;
+    defines["ELTWISE_OP_TYPE"] = op_binary_type;
+    if (fused_activations.has_value()) {
+        if (op_type == BinaryOpType::ADD and fused_activations->size() == 1 and
+            fused_activations->at(0).type() == UnaryOpType::RELU and not input_tensor_a_activation.has_value()) {
+            defines["PACK_RELU"] = "1";
+        } else {
+            defines.merge(ttnn::operations::unary::utils::get_block_defines(*fused_activations, "0", idst));
+        }
+    }
+
+    if (input_tensor_a_activation.has_value()) {
+        defines.merge(ttnn::operations::unary::utils::get_defines(
+            input_tensor_a_activation.value().type(), std::nullopt, "PRE_IN0_0", idst, input_dtype));
+    }
+
+    return defines;
+}
+
+std::map<std::string, std::string> get_defines_fp32(
+    BinaryOpType op_type,
+    const std::optional<tt::tt_metal::DataType> input_a_dtype,
+    const std::optional<tt::tt_metal::DataType> input_b_dtype,
+    const std::optional<std::vector<EltwiseUnaryWithParam>>& fused_activations,
+    const std::optional<EltwiseUnaryWithParam>& input_tensor_a_activation) {
+    std::map<std::string, std::string> new_defines;
+    std::string op_name = "sub_binary_tile";
+    std::string idst1 = "i*2";    // tile index for input A in dst and final output
+    std::string idst2 = "i*2+1";  // tile index for input B in dst
+    std::string idst = "i";       // tile index for input prescaling
+
+    using ttnn::operations::unary::utils::get_defines;
+    switch (op_type) {
+        case BinaryOpType::ADD:
+            if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {
+                new_defines.insert({"ADD_INT_INIT", fmt::format("add_int_tile_init();")});
+                op_name = "add_int_tile<DataFormat::Int32>";
+            } else if (input_a_dtype == DataType::UINT32 && input_b_dtype == DataType::UINT32) {
+                new_defines.insert({"ADD_INT_INIT", fmt::format("add_int_tile_init();")});
+                op_name = "add_int_tile<DataFormat::UInt32>";
+            } else if (input_a_dtype == DataType::UINT16 && input_b_dtype == DataType::UINT16) {
+                new_defines.insert({"ADD_INT_INIT", fmt::format("add_int_tile_init();")});
+                op_name = "add_int_tile<DataFormat::UInt16>";
+            } else {
+                new_defines.insert({"BINOP_INIT", fmt::format("add_binary_tile_init();")});
+                op_name = "add_binary_tile";
+            }
+            break;
+        case BinaryOpType::SUB:
+            if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {
+                new_defines.insert({"SUB_INT_INIT", fmt::format("sub_int_tile_init();")});
+                op_name = "sub_int_tile<DataFormat::Int32>";
+            } else if (input_a_dtype == DataType::UINT32 && input_b_dtype == DataType::UINT32) {
+                new_defines.insert({"SUB_INT_INIT", fmt::format("sub_int_tile_init();")});
+                op_name = "sub_int_tile<DataFormat::UInt32>";
+            } else if (input_a_dtype == DataType::UINT16 && input_b_dtype == DataType::UINT16) {
+                new_defines.insert({"SUB_INT_INIT", fmt::format("sub_int_tile_init();")});
+                op_name = "sub_int_tile<DataFormat::UInt16>";
+            } else {
+                new_defines.insert({"BINOP_INIT", "sub_binary_tile_init();"});
+                op_name = "sub_binary_tile";
+            }
+            break;
+        case BinaryOpType::MUL:
+            if (input_a_dtype == DataType::UINT16 && input_b_dtype == DataType::UINT16) {
+                new_defines.insert({"MUL_INT_INIT", fmt::format("mul_int_tile_init<DataFormat::UInt16>();")});
+                op_name = "mul_int_tile<DataFormat::UInt16>";
+            } else if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {
+                new_defines.insert({"MUL_INT_INIT", fmt::format("mul_int_tile_init<DataFormat::Int32>();")});
+                op_name = "mul_int_tile<DataFormat::Int32>";
+            } else if (input_a_dtype == DataType::UINT32 && input_b_dtype == DataType::UINT32) {
+                new_defines.insert({"MUL_INT_INIT", fmt::format("mul_int_tile_init<DataFormat::UInt32>();")});
+                op_name = "mul_int_tile<DataFormat::UInt32>";
+            } else {
+                new_defines.insert({"BINOP_INIT", fmt::format("mul_binary_tile_init();")});
+                op_name = "mul_binary_tile";
+            }
+            break;
+        case BinaryOpType::RSUB:
+            if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {
+                new_defines.insert({"BINOP_INIT", fmt::format("rsub_int_tile_init();")});
+                op_name = "rsub_int_tile<DataFormat::Int32>";
+            } else if (input_a_dtype == DataType::UINT32 && input_b_dtype == DataType::UINT32) {
+                new_defines.insert({"BINOP_INIT", fmt::format("rsub_int_tile_init();")});
+                op_name = "rsub_int_tile<DataFormat::UInt32>";
+            } else if (input_a_dtype == DataType::UINT16 && input_b_dtype == DataType::UINT16) {
+                new_defines.insert({"BINOP_INIT", fmt::format("rsub_int_tile_init();")});
+                op_name = "rsub_int_tile<DataFormat::UInt16>";
+            } else {
+                new_defines.insert({"BINOP_INIT", fmt::format("rsub_binary_tile_init();")});
+                op_name = "rsub_binary_tile";
+            }
+            break;
+        case BinaryOpType::POWER:
+            new_defines.insert({"BINOP_INIT", fmt::format("power_binary_tile_init();")});
+            op_name = "power_binary_tile";
+            break;
+        case BinaryOpType::DIV:
+            if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {
+                new_defines.insert({"BINOP_INIT", fmt::format("div_int32_tile_init();")});
+                op_name = "div_int32_tile";
+            } else {
+                new_defines.insert({"BINOP_INIT", fmt::format("div_binary_tile_init();")});
+                op_name = "div_binary_tile";
+            }
+            break;
+        case BinaryOpType::BITWISE_AND:
+            if (input_a_dtype == DataType::UINT16 && input_b_dtype == DataType::UINT16) {
+                new_defines.insert({"BITWISE_UINT16_INIT", fmt::format("binary_bitwise_tile_init();")});
+                op_name = "bitwise_and_binary_tile<DataFormat::UInt16>";
+            } else if (input_a_dtype == DataType::UINT32 && input_b_dtype == DataType::UINT32) {
+                new_defines.insert({"BITWISE_UINT32_INIT", fmt::format("binary_bitwise_tile_init();")});
+                op_name = "bitwise_and_binary_tile<DataFormat::UInt32>";
+            } else {
+                new_defines.insert({"BITWISE_INIT", fmt::format("binary_bitwise_tile_init();")});
+                op_name = "bitwise_and_binary_tile<DataFormat::Int32>";
+            }
+            break;
+        case BinaryOpType::BITWISE_OR:
+            if (input_a_dtype == DataType::UINT16 && input_b_dtype == DataType::UINT16) {
+                new_defines.insert({"BITWISE_UINT16_INIT", fmt::format("binary_bitwise_tile_init();")});
+                op_name = "bitwise_or_binary_tile<DataFormat::UInt16>";
+            } else if (input_a_dtype == DataType::UINT32 && input_b_dtype == DataType::UINT32) {
+                new_defines.insert({"BITWISE_UINT32_INIT", fmt::format("binary_bitwise_tile_init();")});
+                op_name = "bitwise_or_binary_tile<DataFormat::UInt32>";
+            } else {
+                new_defines.insert({"BITWISE_INIT", fmt::format("binary_bitwise_tile_init();")});
+                op_name = "bitwise_or_binary_tile<DataFormat::Int32>";
+            }
+            break;
+        case BinaryOpType::BITWISE_XOR:
+            if (input_a_dtype == DataType::UINT16 && input_b_dtype == DataType::UINT16) {
+                new_defines.insert({"BITWISE_UINT16_INIT", fmt::format("binary_bitwise_tile_init();")});
+                op_name = "bitwise_xor_binary_tile<DataFormat::UInt16>";
+            } else if (input_a_dtype == DataType::UINT32 && input_b_dtype == DataType::UINT32) {
+                new_defines.insert({"BITWISE_UINT32_INIT", fmt::format("binary_bitwise_tile_init();")});
+                op_name = "bitwise_xor_binary_tile<DataFormat::UInt32>";
+            } else {
+                new_defines.insert({"BITWISE_INIT", fmt::format("binary_bitwise_tile_init();")});
+                op_name = "bitwise_xor_binary_tile<DataFormat::Int32>";
+            }
+            break;
+        case BinaryOpType::LEFT_SHIFT: {
+            const char* data_format =
+                (input_a_dtype == DataType::UINT32 && input_b_dtype == DataType::UINT32)   ? "UInt32"
+                : (input_a_dtype == DataType::UINT16 && input_b_dtype == DataType::UINT16) ? "UInt16"
+                                                                                           : "Int32";
+            new_defines.insert({"SHIFT_INIT", fmt::format("binary_shift_tile_init();")});
+            op_name = fmt::format("binary_left_shift_tile<DataFormat::{}>", data_format);
+            break;
+        }
+        case BinaryOpType::RIGHT_SHIFT: {
+            const char* data_format =
+                (input_a_dtype == DataType::UINT32 && input_b_dtype == DataType::UINT32)   ? "UInt32"
+                : (input_a_dtype == DataType::UINT16 && input_b_dtype == DataType::UINT16) ? "UInt16"
+                                                                                           : "Int32";
+            new_defines.insert({"SHIFT_INIT", fmt::format("binary_shift_tile_init();")});
+            op_name = fmt::format("binary_right_shift_tile<DataFormat::{}>", data_format);
+            break;
+        }
+        case BinaryOpType::LOGICAL_RIGHT_SHIFT: {
+            const char* data_format =
+                (input_a_dtype == DataType::UINT32 && input_b_dtype == DataType::UINT32)   ? "UInt32"
+                : (input_a_dtype == DataType::UINT16 && input_b_dtype == DataType::UINT16) ? "UInt16"
+                                                                                           : "Int32";
+            new_defines.insert({"SHIFT_INIT", fmt::format("binary_shift_tile_init();")});
+            op_name = fmt::format("binary_logical_right_shift_tile<DataFormat::{}>", data_format);
+            break;
+        }
+        case BinaryOpType::MAXIMUM:
+            if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {
+                new_defines.insert({"BINOP_INIT", fmt::format("binary_max_int32_tile_init();")});
+                op_name = "binary_max_int32_tile";
+            } else if (input_a_dtype == DataType::UINT32 && input_b_dtype == DataType::UINT32) {
+                new_defines.insert({"BINOP_INIT", fmt::format("binary_max_uint32_tile_init();")});
+                op_name = "binary_max_uint32_tile";
+            } else {
+                new_defines.insert({"BINOP_INIT", fmt::format("binary_max_tile_init();")});
+                op_name = "binary_max_tile";
+            }
+            break;
+        case BinaryOpType::MINIMUM:
+            if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {
+                new_defines.insert({"BINOP_INIT", fmt::format("binary_min_int32_tile_init();")});
+                op_name = "binary_min_int32_tile";
+            } else if (input_a_dtype == DataType::UINT32 && input_b_dtype == DataType::UINT32) {
+                new_defines.insert({"BINOP_INIT", fmt::format("binary_min_uint32_tile_init();")});
+                op_name = "binary_min_uint32_tile";
+            } else {
+                new_defines.insert({"BINOP_INIT", fmt::format("binary_min_tile_init();")});
+                op_name = "binary_min_tile";
+            }
+            break;
+        case BinaryOpType::GCD:
+            new_defines.insert({"BINOP_INIT", fmt::format("gcd_tile_init();")});
+            op_name = "gcd_tile";
+            break;
+        case BinaryOpType::LCM:
+            new_defines.insert({"BINOP_INIT", fmt::format("lcm_tile_init();")});
+            op_name = "lcm_tile";
+            break;
+        case BinaryOpType::LOGADDEXP:
+            // PRE_IN0_0 ===> Applies prescaling for first input
+            // PRE_IN1_0 ====> Applies prescaling for second input
+            new_defines.merge(get_defines(UnaryOpType::EXP, std::vector<float>{0}, "PRE_IN0_0"));
+            new_defines.merge(get_defines(UnaryOpType::EXP, std::vector<float>{0}, "PRE_IN1_0"));
+            new_defines.insert({"BINOP_INIT", fmt::format("add_binary_tile_init();")});
+            op_name = "add_binary_tile";
+            new_defines.merge(get_defines(UnaryOpType::LOG, std::nullopt, "0", idst1));
+            break;
+        case BinaryOpType::LOGADDEXP2:
+            new_defines.merge(get_defines(UnaryOpType::EXP2, std::nullopt, "PRE_IN0_0"));
+            new_defines.merge(get_defines(UnaryOpType::EXP2, std::nullopt, "PRE_IN1_0"));
+            new_defines.insert({"BINOP_INIT", fmt::format("add_binary_tile_init();")});
+            op_name = "add_binary_tile";
+            new_defines.merge(get_defines(UnaryOpType::LOG2, std::nullopt, "0", idst1));
+            break;
+        case BinaryOpType::LDEXP:
+            new_defines.merge(get_defines(UnaryOpType::EXP2, std::nullopt, "PRE_IN1_0"));
+            op_name = "mul_binary_tile";
+            break;
+        case BinaryOpType::SQUARED_DIFFERENCE:
+            if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {
+                op_name = "sub_int_tile<DataFormat::Int32>";
+            } else if (input_a_dtype == DataType::UINT32 && input_b_dtype == DataType::UINT32) {
+                op_name = "sub_int_tile<DataFormat::UInt32>";
+            } else if (input_a_dtype == DataType::UINT16 && input_b_dtype == DataType::UINT16) {
+                op_name = "sub_int_tile<DataFormat::UInt16>";
+            } else {
+                op_name = "sub_binary_tile";
+            }
+            new_defines.merge(get_defines(UnaryOpType::SQUARE, std::nullopt, "0", idst1, input_a_dtype));
+            break;
+        case BinaryOpType::BIAS_GELU:
+            new_defines.insert({"BINOP_INIT", fmt::format("add_binary_tile_init();")});
+            op_name = "add_binary_tile";
+            new_defines.merge(get_defines(UnaryOpType::GELU, std::vector<float>{0}, "0", idst1));
+            break;
+        case BinaryOpType::LOGICAL_OR:
+            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN0_0", "0", input_a_dtype));
+            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN1_0", "0", input_b_dtype));
+            if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {
+                new_defines.insert({"ADD_INT_INIT", fmt::format("add_int_tile_init();")});
+                op_name = "add_int_tile<DataFormat::Int32>";
+            } else if (input_a_dtype == DataType::UINT32 && input_b_dtype == DataType::UINT32) {
+                new_defines.insert({"ADD_INT_INIT", fmt::format("add_int_tile_init();")});
+                op_name = "add_int_tile<DataFormat::UInt32>";
+            } else if (input_a_dtype == DataType::UINT16 && input_b_dtype == DataType::UINT16) {
+                new_defines.insert({"ADD_INT_INIT", fmt::format("add_int_tile_init();")});
+                op_name = "add_int_tile<DataFormat::UInt16>";
+            } else {
+                new_defines.insert({"BINOP_INIT", fmt::format("add_binary_tile_init();")});
+                op_name = "add_binary_tile";
+            }
+            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "0", idst1, input_a_dtype));
+            break;
+        case BinaryOpType::LOGICAL_XOR:
+            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN0_0", "0", input_a_dtype));
+            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN1_0", "0", input_b_dtype));
+            if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {
+                op_name = "sub_int_tile<DataFormat::Int32>";
+            } else if (input_a_dtype == DataType::UINT32 && input_b_dtype == DataType::UINT32) {
+                op_name = "sub_int_tile<DataFormat::UInt32>";
+            } else if (input_a_dtype == DataType::UINT16 && input_b_dtype == DataType::UINT16) {
+                op_name = "sub_int_tile<DataFormat::UInt16>";
+            } else {
+                op_name = "sub_binary_tile";
+            }
+            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "0", idst1, input_a_dtype));
+            break;
+        case BinaryOpType::LOGICAL_AND:
+            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN0_0", "0", input_a_dtype));
+            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN1_0", "0", input_b_dtype));
+            if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {
+                new_defines.insert({"MUL_INT_INIT", fmt::format("mul_int_tile_init<DataFormat::Int32>();")});
+                op_name = "mul_int_tile<DataFormat::Int32>";
+            } else if (input_a_dtype == DataType::UINT32 && input_b_dtype == DataType::UINT32) {
+                new_defines.insert({"MUL_INT_INIT", fmt::format("mul_int_tile_init<DataFormat::UInt32>();")});
+                op_name = "mul_int_tile<DataFormat::UInt32>";
+            } else if (input_a_dtype == DataType::UINT16 && input_b_dtype == DataType::UINT16) {
+                new_defines.insert({"MUL_INT_INIT", fmt::format("mul_int_tile_init<DataFormat::UInt16>();")});
+                op_name = "mul_int_tile<DataFormat::UInt16>";
+            } else {
+                new_defines.insert({"BINOP_INIT", fmt::format("mul_binary_tile_init();")});
+                op_name = "mul_binary_tile";
+            }
+            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "0", idst1, input_a_dtype));
+            break;
+        // applied on A-B
+        case BinaryOpType::GT:
+            if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {
+                new_defines.insert({"GT_INT32_INIT", fmt::format("gt_int_tile_init<DataFormat::Int32>();")});
+                op_name = "gt_int_tile<DataFormat::Int32>";
+            } else if (input_a_dtype == DataType::UINT32 && input_b_dtype == DataType::UINT32) {
+                new_defines.insert({"GT_UINT32_INIT", fmt::format("gt_int_tile_init<DataFormat::UInt32>();")});
+                op_name = "gt_int_tile<DataFormat::UInt32>";
+            } else if (input_a_dtype == DataType::UINT16 && input_b_dtype == DataType::UINT16) {
+                new_defines.insert({"GT_UINT16_INIT", fmt::format("gt_int_tile_init<DataFormat::UInt16>();")});
+                op_name = "gt_int_tile<DataFormat::UInt16>";
+            } else {
+                op_name = "sub_binary_tile";
+                new_defines.merge(get_defines(UnaryOpType::GTZ, std::nullopt, "0", idst1, input_a_dtype));
+            }
+            break;
+        case BinaryOpType::LT:
+            if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {
+                new_defines.insert({"LT_INT32_INIT", fmt::format("lt_int_tile_init<DataFormat::Int32>();")});
+                op_name = "lt_int_tile<DataFormat::Int32>";
+            } else if (input_a_dtype == DataType::UINT32 && input_b_dtype == DataType::UINT32) {
+                new_defines.insert({"LT_UINT32_INIT", fmt::format("lt_int_tile_init<DataFormat::UInt32>();")});
+                op_name = "lt_int_tile<DataFormat::UInt32>";
+            } else if (input_a_dtype == DataType::UINT16 && input_b_dtype == DataType::UINT16) {
+                new_defines.insert({"LT_UINT16_INIT", fmt::format("lt_int_tile_init<DataFormat::UInt16>();")});
+                op_name = "lt_int_tile<DataFormat::UInt16>";
+            } else {
+                op_name = "sub_binary_tile";
+                new_defines.merge(get_defines(UnaryOpType::LTZ, std::nullopt, "0", idst1, input_a_dtype));
+            }
+            break;
+        case BinaryOpType::GE:
+            if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {
+                new_defines.insert({"GE_INT32_INIT", fmt::format("ge_int_tile_init<DataFormat::Int32>();")});
+                op_name = "ge_int_tile<DataFormat::Int32>";
+            } else if (input_a_dtype == DataType::UINT32 && input_b_dtype == DataType::UINT32) {
+                new_defines.insert({"GE_UINT32_INIT", fmt::format("ge_int_tile_init<DataFormat::UInt32>();")});
+                op_name = "ge_int_tile<DataFormat::UInt32>";
+            } else if (input_a_dtype == DataType::UINT16 && input_b_dtype == DataType::UINT16) {
+                new_defines.insert({"GE_UINT16_INIT", fmt::format("ge_int_tile_init<DataFormat::UInt16>();")});
+                op_name = "ge_int_tile<DataFormat::UInt16>";
+            } else {
+                op_name = "sub_binary_tile";
+                new_defines.merge(get_defines(UnaryOpType::GEZ, std::nullopt, "0", idst1, input_a_dtype));
+            }
+            break;
+        case BinaryOpType::LE:
+            if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {
+                new_defines.insert({"LE_INT32_INIT", fmt::format("le_int_tile_init<DataFormat::Int32>();")});
+                op_name = "le_int_tile<DataFormat::Int32>";
+            } else if (input_a_dtype == DataType::UINT32 && input_b_dtype == DataType::UINT32) {
+                new_defines.insert({"LE_UINT32_INIT", fmt::format("le_int_tile_init<DataFormat::UInt32>();")});
+                op_name = "le_int_tile<DataFormat::UInt32>";
+            } else if (input_a_dtype == DataType::UINT16 && input_b_dtype == DataType::UINT16) {
+                new_defines.insert({"LE_UINT16_INIT", fmt::format("le_int_tile_init<DataFormat::UInt16>();")});
+                op_name = "le_int_tile<DataFormat::UInt16>";
+            } else {
+                op_name = "sub_binary_tile";
+                new_defines.merge(get_defines(UnaryOpType::LEZ, std::nullopt, "0", idst1, input_a_dtype));
+            }
+            break;
+        case BinaryOpType::EQ:
+            if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {
+                op_name = "sub_int_tile<DataFormat::Int32>";
+            } else if (input_a_dtype == DataType::UINT32 && input_b_dtype == DataType::UINT32) {
+                op_name = "sub_int_tile<DataFormat::UInt32>";
+            } else if (input_a_dtype == DataType::UINT16 && input_b_dtype == DataType::UINT16) {
+                op_name = "sub_int_tile<DataFormat::UInt16>";
+            } else {
+                op_name = "sub_binary_tile";
+            }
+            new_defines.merge(get_defines(UnaryOpType::EQZ, std::nullopt, "0", idst1, input_a_dtype));
+            break;
+        case BinaryOpType::NE:
+            if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {
+                op_name = "sub_int_tile<DataFormat::Int32>";
+            } else if (input_a_dtype == DataType::UINT32 && input_b_dtype == DataType::UINT32) {
+                op_name = "sub_int_tile<DataFormat::UInt32>";
+            } else if (input_a_dtype == DataType::UINT16 && input_b_dtype == DataType::UINT16) {
+                op_name = "sub_int_tile<DataFormat::UInt16>";
+            } else {
+                op_name = "sub_binary_tile";
+            }
+            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "0", idst1, input_a_dtype));
+            break;
+        case BinaryOpType::XLOGY:
+            new_defines.insert({"BINOP_INIT", fmt::format("xlogy_binary_tile_init();")});
+            op_name = "xlogy_binary_tile";
+            break;
+        case BinaryOpType::FMOD:
+            new_defines.insert({"BINOP_INIT", fmt::format("fmod_binary_tile_init();")});
+            op_name = "fmod_binary_tile";
+            break;
+        case BinaryOpType::REMAINDER:
+            new_defines.insert({"BINOP_INIT", fmt::format("remainder_binary_tile_init();")});
+            op_name = "remainder_binary_tile";
+            break;
+        case BinaryOpType::HYPOT:
+            // Hypot: sqrt(a^2 + b^2)
+            new_defines.merge(get_defines(UnaryOpType::SQUARE, std::nullopt, "PRE_IN0_0", idst, input_a_dtype));
+            new_defines.merge(get_defines(UnaryOpType::SQUARE, std::nullopt, "PRE_IN1_0", idst, input_b_dtype));
+            new_defines.insert({"BINOP_INIT", fmt::format("add_binary_tile_init();")});
+            op_name = "add_binary_tile";
+            new_defines.merge(get_defines(UnaryOpType::SQRT, std::nullopt, "0", idst1, input_a_dtype));
+            break;
+        case BinaryOpType::ATAN2:
+            new_defines.insert({"BINOP_INIT", fmt::format("atan2_binary_tile_init();")});
+            op_name = "atan2_binary_tile";
+            break;
+        default:
+            log_debug(tt::LogOp, "Undefined op type {}", op_type);
+            TT_FATAL(false, "Undefined op type for binary sfpu operation {}", op_type);
+    }
+
+    new_defines.insert({"BINARY_SFPU_OP", fmt::format("{}({}, {}, {});", op_name, idst1, idst2, idst1)});
+
+    if (fused_activations.has_value()) {
+        if (op_type == BinaryOpType::ADD and fused_activations.value().size() == 1 and
+            fused_activations.value().at(0).type() == UnaryOpType::RELU) {
+            new_defines["PACK_RELU"] = "1";
+        } else {
+            new_defines.merge(ttnn::operations::unary::utils::get_block_defines(fused_activations.value(), "0", idst1));
+        }
+    }
+
+    if (input_tensor_a_activation.has_value()) {
+        new_defines.merge(ttnn::operations::unary::utils::get_defines(
+            input_tensor_a_activation.value().type(), std::nullopt, "PRE_IN0_0", idst));
+    }
+
+    return new_defines;
+}
+
+}  // namespace ttnn::operations::experimental::quasar::binary::utils

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary/common/binary_op_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary/common/binary_op_utils.hpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <map>
+#include <string>
+
+#include "binary_op_types.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+
+namespace tt::tt_metal {
+enum class DataType;
+}
+
+namespace ttnn::operations::experimental::quasar::binary::utils {
+bool is_typecast(tt::tt_metal::DataType input, tt::tt_metal::DataType output);
+
+std::map<std::string, std::string> get_defines(
+    BinaryOpType op_type,
+    std::optional<tt::tt_metal::DataType> input_dtype = std::nullopt,
+    std::optional<tt::tt_metal::DataType> output_dtype = std::nullopt,
+    const std::optional<ttnn::operations::unary::EltwiseFusedActivations>& fused_activations = std::nullopt,
+    const std::optional<ttnn::operations::unary::EltwiseUnaryWithParam>& input_tensor_a_activation = std::nullopt);
+
+std::map<std::string, std::string> get_defines_fp32(
+    BinaryOpType op_type,
+    std::optional<tt::tt_metal::DataType> input_a_dtype = std::nullopt,
+    std::optional<tt::tt_metal::DataType> input_b_dtype = std::nullopt,
+    const std::optional<ttnn::operations::unary::EltwiseFusedActivations>& fused_activations = std::nullopt,
+    const std::optional<ttnn::operations::unary::EltwiseUnaryWithParam>& input_tensor_a_activation = std::nullopt);
+
+}  // namespace ttnn::operations::experimental::quasar::binary::utils

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary/device/binary_composite_op.cpp
@@ -1,0 +1,830 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <type_traits>
+#include <utility>
+#include "ttnn/operations/experimental/quasar/binary/binary.hpp"
+#include "ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.hpp"
+#include "ttnn/operations/eltwise/unary/unary.hpp"
+#include "ttnn/types.hpp"
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/hal.hpp>
+#include "ttnn/operations/experimental/quasar/binary/binary_composite.hpp"
+#include "ttnn/operations/eltwise/ternary/ternary.hpp"
+#include "ttnn/operations/copy/typecast/typecast.hpp"
+#include "ttnn/operations/eltwise/unary/unary_composite.hpp"
+#include "ttnn/operations/data_movement/pad/pad.hpp"
+#include "ttnn/operations/matmul/matmul.hpp"
+#include "ttnn/operations/creation/creation.hpp"
+#include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
+#include "ttnn/device.hpp"
+#include <variant>
+#include <tt-metalium/sub_device_types.hpp>
+
+namespace ttnn::operations::experimental::quasar::binary {
+
+using namespace operations;
+
+// nextafter
+Tensor nextafter(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
+    const float eps = tt::tt_metal::hal::get_eps();
+    Tensor result(input_a);
+    {
+        Tensor eps_gt(input_a);
+        {
+            eps_gt = ttnn::where(
+                gt(input_a, input_b, std::nullopt, output_mem_config),
+                add(input_a, eps, std::nullopt, output_mem_config),
+                input_a);
+        }
+        result = ttnn::where(
+            lt(input_a, input_b, std::nullopt, output_mem_config),
+            subtract(input_a, eps, std::nullopt, output_mem_config),
+            eps_gt);
+    }
+    return result;
+}
+
+Tensor minimum(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const std::optional<const DataType>& /*output_dtype*/,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations) {
+    return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+        input_tensor_a,
+        input_tensor_b,
+        binary::BinaryOpType::MINIMUM,
+        std::nullopt,
+        memory_config,
+        optional_output_tensor,
+        post_activations,
+        lhs_activations,
+        rhs_activations);
+}
+
+Tensor minimum(
+    const Tensor& input_a,
+    unary::ScalarVariant value,
+    const std::optional<const DataType>& /*output_dtype*/,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> /*post_activations*/,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> /*lhs_activations*/,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> /*rhs_activations*/) {
+    return std::visit(
+        [&](auto input_b) {
+            return ttnn::operations::unary::detail::unary_impl(
+                input_a,
+                {unary::EltwiseUnaryWithParam{unary::UnaryOpType::MINIMUM, (input_b)}},
+                memory_config,
+                optional_output_tensor);
+        },
+        value);
+}
+
+Tensor maximum(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const std::optional<const DataType>& /*output_dtype*/,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations) {
+    return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+        input_tensor_a,
+        input_tensor_b,
+        binary::BinaryOpType::MAXIMUM,
+        std::nullopt,
+        memory_config,
+        optional_output_tensor,
+        post_activations,
+        lhs_activations,
+        rhs_activations);
+}
+
+Tensor maximum(
+    const Tensor& input_a,
+    unary::ScalarVariant value,
+    const std::optional<const DataType>& /*output_dtype*/,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> /*post_activations*/,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> /*lhs_activations*/,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> /*rhs_activations*/) {
+    return std::visit(
+        [&](auto input_b) {
+            return ttnn::operations::unary::detail::unary_impl(
+                input_a,
+                {unary::EltwiseUnaryWithParam{unary::UnaryOpType::MAXIMUM, (input_b)}},
+                memory_config,
+                optional_output_tensor);
+        },
+        value);
+}
+
+Tensor atan2(const Tensor& input_b, const Tensor& input_a, const std::optional<MemoryConfig>& output_mem_config) {
+    return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+        input_b,
+        input_a,
+        binary::BinaryOpType::ATAN2,
+        std::nullopt,
+        output_mem_config,
+        std::nullopt,
+        {},
+        {},
+        {},
+        std::nullopt);
+}
+
+Tensor div(
+    const Tensor& input,
+    unary::ScalarVariant value,
+    bool fast_and_approximate_mode,
+    const std::optional<std::string>& rounding_mode,
+    const std::optional<const DataType>& output_dtype,
+    const std::optional<MemoryConfig>& output_mem_config,
+    const std::optional<Tensor>& output_tensor,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    const bool is_int32 = input.dtype() == DataType::INT32;
+
+    if (is_int32) {
+        TT_FATAL(
+            !fast_and_approximate_mode,
+            "Integer Division does not support fast_and_approximate_mode=true {}",
+            fast_and_approximate_mode);
+        // fast_and_approximate_mode is not supported for integer division yet.
+
+        if (rounding_mode == "floor") {
+            return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+                input,
+                value,
+                binary::BinaryOpType::DIV_FLOOR,
+                std::nullopt,
+                output_mem_config,
+                output_tensor,
+                post_activations,
+                lhs_activations,
+                rhs_activations,
+                /*fast_and_approximate_mode=*/std::nullopt,
+                sub_core_grids,
+                sub_device_id);
+        }
+        if (rounding_mode == "trunc") {
+            return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+                input,
+                value,
+                binary::BinaryOpType::DIV_TRUNC,
+                std::nullopt,
+                output_mem_config,
+                output_tensor,
+                post_activations,
+                lhs_activations,
+                rhs_activations,
+                /*fast_and_approximate_mode=*/std::nullopt,
+                sub_core_grids,
+                sub_device_id);
+        }
+        // rounding_mode = None
+        TT_FATAL(
+            (!output_dtype.has_value() || output_dtype == DataType::FLOAT32),
+            "Incorrect output_dtype value for Integer Division(rounding_mode=None) ; valid input values are None or "
+            "ttnn.float32");
+        return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+            input,
+            value,
+            binary::BinaryOpType::DIV,
+            std::nullopt,
+            output_mem_config,
+            output_tensor,
+            post_activations,
+            lhs_activations,
+            rhs_activations,
+            std::nullopt,  // fast_and_approximate_mode
+            sub_core_grids,
+            sub_device_id);
+    }
+
+    // Non-int32 inputs: with rounding_mode=None, use DIV directly; with "trunc"/"floor",
+    // compute the float divide then apply trunc/floor rounding.
+    if (!rounding_mode.has_value()) {
+        return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+            input,
+            value,
+            binary::BinaryOpType::DIV,
+            std::nullopt,
+            output_mem_config,
+            output_tensor,
+            post_activations,
+            lhs_activations,
+            rhs_activations,
+            fast_and_approximate_mode,
+            sub_core_grids,
+            sub_device_id);
+    }
+
+    TT_FATAL(
+        (rounding_mode == "trunc" || rounding_mode == "floor"),
+        "Incorrect rounding mode (expected None, 'trunc', or 'floor')");
+
+    // Workaround for a known bfloat16 fast_and_approximate divide bug (issue #43209):
+    // 0/0 returns 0 instead of NaN, and sign-of-zero is lost. The pre-legacy-removal
+    // path used a float32 typecast as a safety guard; we restore the same invariant by
+    // suppressing fast_and_approximate on bfloat16 inside the rounding-mode branch.
+    // The rounding_mode=None case is documented via the existing test skip in
+    // tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py. Remove this
+    // workaround when #43209 is fixed.
+    const bool suppress_fap = fast_and_approximate_mode && input.dtype() == DataType::BFLOAT16;
+    const bool effective_fap = suppress_fap ? false : fast_and_approximate_mode;
+
+    std::optional<Tensor> divided = divide(
+        input,
+        value,
+        std::nullopt,
+        output_mem_config,
+        output_tensor,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        effective_fap,
+        sub_core_grids,
+        sub_device_id);
+
+    if (rounding_mode == "trunc") {
+        return ttnn::trunc(divided.value(), output_mem_config, output_tensor, sub_core_grids);
+    }
+    return ttnn::floor(divided.value(), output_mem_config, output_tensor, sub_core_grids);
+}
+
+Tensor div(
+    const Tensor& input_a,
+    const Tensor& input_b,
+    bool fast_and_approximate_mode,
+    const std::optional<std::string>& rounding_mode,
+    const std::optional<const DataType>& output_dtype,
+    const std::optional<MemoryConfig>& output_mem_config,
+    const std::optional<Tensor>& output_tensor,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    DataType input_dtype = input_a.dtype();
+    const bool is_int32 = input_dtype == DataType::INT32 && input_b.dtype() == DataType::INT32;
+
+    if (is_int32) {
+        TT_FATAL(
+            !fast_and_approximate_mode,
+            "Integer Division does not support fast_and_approximate_mode=true {}",
+            fast_and_approximate_mode);
+        // fast_and_approximate_mode is not supported for integer division yet.
+
+        if (rounding_mode == "floor") {
+            return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+                input_a,
+                input_b,
+                binary::BinaryOpType::DIV_FLOOR,
+                std::nullopt,
+                output_mem_config,
+                output_tensor,
+                post_activations,
+                lhs_activations,
+                rhs_activations,
+                /*fast_and_approximate_mode=*/std::nullopt,
+                sub_core_grids,
+                sub_device_id);
+        }
+        if (rounding_mode == "trunc") {
+            return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+                input_a,
+                input_b,
+                binary::BinaryOpType::DIV_TRUNC,
+                std::nullopt,
+                output_mem_config,
+                output_tensor,
+                post_activations,
+                lhs_activations,
+                rhs_activations,
+                /*fast_and_approximate_mode=*/std::nullopt,
+                sub_core_grids,
+                sub_device_id);
+        }
+        // rounding_mode = None
+        TT_FATAL(
+            (!output_dtype.has_value() || output_dtype == DataType::FLOAT32),
+            "Incorrect output_dtype value for Integer Division(rounding_mode=None) ; valid input values are None or "
+            "ttnn.float32");
+        return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+            input_a,
+            input_b,
+            binary::BinaryOpType::DIV,
+            std::nullopt,
+            output_mem_config,
+            output_tensor,
+            post_activations,
+            lhs_activations,
+            rhs_activations,
+            std::nullopt,  // fast_and_approximate_mode
+            sub_core_grids,
+            sub_device_id);
+    }
+
+    // Non-int32 inputs: with rounding_mode=None, use DIV directly; with "trunc"/"floor",
+    // compute the float divide then apply trunc/floor rounding.
+    if (!rounding_mode.has_value()) {
+        return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+            input_a,
+            input_b,
+            binary::BinaryOpType::DIV,
+            std::nullopt,
+            output_mem_config,
+            output_tensor,
+            post_activations,
+            lhs_activations,
+            rhs_activations,
+            fast_and_approximate_mode,
+            sub_core_grids,
+            sub_device_id);
+    }
+
+    TT_FATAL(
+        (rounding_mode == "trunc" || rounding_mode == "floor"),
+        "Incorrect rounding mode (expected None, 'trunc', or 'floor')");
+
+    // Workaround for a known bfloat16 fast_and_approximate divide bug (issue #43209):
+    // 0/0 returns 0 instead of NaN, and sign-of-zero is lost. The pre-legacy-removal
+    // path used a float32 typecast as a safety guard; we restore the same invariant by
+    // suppressing fast_and_approximate on bfloat16 inside the rounding-mode branch.
+    // The rounding_mode=None case is documented via the existing test skip in
+    // tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py. Remove this
+    // workaround when #43209 is fixed.
+    const bool suppress_fap = fast_and_approximate_mode && input_dtype == DataType::BFLOAT16;
+    const bool effective_fap = suppress_fap ? false : fast_and_approximate_mode;
+
+    std::optional<Tensor> divided = divide(
+        input_a,
+        input_b,
+        std::nullopt,
+        output_mem_config,
+        output_tensor,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        effective_fap,
+        sub_core_grids,
+        sub_device_id);
+
+    if (rounding_mode == "trunc") {
+        return ttnn::trunc(divided.value(), output_mem_config, output_tensor, sub_core_grids);
+    }
+    return ttnn::floor(divided.value(), output_mem_config, output_tensor, sub_core_grids);
+}
+
+Tensor div_no_nan(
+    const Tensor& input_a, unary::ScalarVariant value, const std::optional<MemoryConfig>& /*output_mem_config*/) {
+    float value_f = std::visit([](auto v) -> float { return static_cast<float>(v); }, value);
+    if (value_f == 0) {
+        return ttnn::zeros_like(input_a);
+    }
+    return multiply(input_a, (1.0f / value_f));
+}
+
+Tensor div_no_nan(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
+    if (input_a.dtype() == DataType::FLOAT32 && input_b.dtype() == DataType::FLOAT32) {
+        // Not using SFPU div op here since inf/nan handling is not required
+        Tensor div_result = multiply(input_a, ttnn::reciprocal(input_b), std::nullopt, output_mem_config);
+        return ttnn::where(ttnn::eqz(input_b, output_mem_config), 0.0f, div_result);
+    }
+    Tensor div_result = divide(input_a, input_b, std::nullopt, output_mem_config);
+    return ttnn::where(ttnn::eqz(input_b, output_mem_config), 0.0f, div_result);
+}
+
+Tensor prelu(
+    const Tensor& input, unary::ScalarVariant weight, const std::optional<MemoryConfig>& /*output_mem_config*/) {
+    float weight_f = std::visit([](auto v) -> float { return static_cast<float>(v); }, weight);
+    return ttnn::prelu_sfpu(input, weight_f);
+}
+
+Tensor prelu(
+    const Tensor& input, const std::array<float, 1>& weight, const std::optional<MemoryConfig>& /*output_mem_config*/) {
+    float scalar_weight = weight[0];
+    return ttnn::prelu_sfpu(input, scalar_weight);
+}
+
+Tensor prelu(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
+    const auto& s_a = input_a.logical_shape();
+    const auto volume = input_b.logical_volume();
+    TT_FATAL(
+        s_a[1] == volume,
+        "Mismatch of parameter numbers and input channel size. Found parameter numbers = {} and channel size = {}.",
+        volume,
+        s_a[1]);
+    Tensor b = input_b;
+    if (s_a.rank() > 2) {
+        SmallVector<uint32_t> reshape(s_a.rank(), 1);
+        reshape[1] = s_a[1];
+        b = ttnn::reshape(input_b, ttnn::Shape(reshape));
+    }
+
+    Tensor result = ttnn::where(ttnn::ltz(input_a, output_mem_config), multiply(input_a, b), input_a);
+    return result;
+}
+
+// REMAINDER result = input − (other * floor(input/other))
+Tensor remainder(
+    const Tensor& input_a,
+    const Tensor& input_b,
+    const std::optional<const DataType>& output_dtype,
+    const std::optional<MemoryConfig>& output_mem_config,
+    const std::optional<Tensor>& output_tensor,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+        input_a,
+        input_b,
+        binary::BinaryOpType::REMAINDER,
+        output_dtype,
+        output_mem_config,
+        output_tensor,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        std::nullopt,
+        sub_core_grids,
+        sub_device_id);
+}
+
+Tensor remainder(
+    const Tensor& input,
+    unary::ScalarVariant scalar,
+    const std::optional<const DataType>& /*output_dtype*/,
+    const std::optional<MemoryConfig>& output_mem_config,
+    const std::optional<Tensor>& output_tensor,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> /*post_activations*/,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> /*lhs_activations*/,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> /*rhs_activations*/,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& /*sub_device_id*/) {
+    float scalar_f = std::visit([](auto v) -> float { return static_cast<float>(v); }, scalar);
+    return ttnn::unary_remainder(input, scalar_f, output_mem_config, output_tensor, sub_core_grids);
+}
+
+// FMOD result = input − (other * trunc(input/other))
+Tensor fmod(
+    const Tensor& input_a,
+    const Tensor& input_b,
+    const std::optional<MemoryConfig>& output_mem_config,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+        input_a,
+        input_b,
+        binary::BinaryOpType::FMOD,
+        std::nullopt,
+        output_mem_config,
+        std::nullopt,
+        {},
+        {},
+        {},
+        std::nullopt,
+        sub_core_grids,
+        sub_device_id);
+}
+
+Tensor fmod(
+    const Tensor& input,
+    unary::ScalarVariant scalar,
+    const std::optional<MemoryConfig>& output_mem_config,
+    const std::optional<CoreRangeSet>& /*sub_core_grids*/,
+    const std::optional<tt::tt_metal::SubDeviceId>& /*sub_device_id*/) {
+    float scalar_f = std::visit([](auto v) -> float { return static_cast<float>(v); }, scalar);
+    return ttnn::unary_fmod(input, scalar_f, output_mem_config);
+}
+
+Tensor floor_div(
+    const Tensor& input_a, unary::ScalarVariant value, const std::optional<MemoryConfig>& output_mem_config) {
+    float value_f = std::visit([](auto v) -> float { return static_cast<float>(v); }, value);
+    if (value_f == 0) {
+        float t_inf = std::numeric_limits<float>::infinity();
+        float t_nan = std::nanf("");
+        return ttnn::where(
+            ttnn::eqz(input_a, output_mem_config),
+            t_nan,
+            multiply(ttnn::sign(input_a, output_mem_config), t_inf, std::nullopt, output_mem_config));
+    }
+    Tensor temp = multiply(input_a, (1.0f / value_f), std::nullopt, output_mem_config);
+    return ttnn::floor(temp);
+}
+
+Tensor floor_div(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
+    Tensor temp = div(input_a, input_b, false, std::nullopt, std::nullopt, output_mem_config);
+    Tensor result = div(input_a, input_b, false, "floor", std::nullopt, output_mem_config);
+    // floor(nan, inf, -inf) = nan, inf, -inf
+    return ttnn::where(
+        logical_or(
+            eq(temp, std::nanf("")),
+            logical_or(
+                eq(temp, std::numeric_limits<float>::infinity()), eq(temp, -std::numeric_limits<float>::infinity()))),
+        temp,
+        result);
+}
+
+/**
+ * outer product = matrix multiply when a = [1,1,N,1] and b = [1,1,1,M]
+ * and result is of size [1,1,N,M].
+ * - implementation supports any 1D "squeezable tensor" at input operands
+ *   by running reshape.
+ */
+Tensor outer(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& /*output_mem_config*/) {
+    const ttnn::Shape& s_a = input_a.logical_shape();
+    const ttnn::Shape& s_b = input_b.logical_shape();
+    auto num_ones = [](const ttnn::Shape& s) -> uint32_t {
+        uint32_t num1s = 0;
+        for (uint32_t idx = 0; idx < 4; idx++) {
+            num1s += (uint32_t)(s[idx] == 1);
+        }
+        return num1s;
+    };
+
+    // check if 3 dimensions are 1
+    TT_FATAL((num_ones(s_a) >= 3), "3 dimensions are required to be 1 for use with outer product");
+    TT_FATAL((num_ones(s_b) >= 3), "3 dimensions are required to be 1 for use with outer product");
+
+    const bool skip_reshape_a = (s_a[0] == 1 && s_a[1] == 1 && s_a[2] >= 1 && s_a[3] == 1);
+    const bool skip_reshape_b = (s_b[0] == 1 && s_b[1] == 1 && s_b[2] == 1 && s_b[3] >= 1);
+
+    Tensor a_slim = input_a;
+    Tensor b_slim = input_b;
+
+    if (!skip_reshape_a) {
+        uint32_t a_volume = s_a[0] * s_a[1] * s_a[2] * s_a[3];
+        a_slim = ttnn::reshape(input_a, ttnn::Shape{std::array<uint32_t, 4>{1, 1, a_volume, 1}});
+    }
+    if (!skip_reshape_b) {
+        uint32_t b_volume = s_b[0] * s_b[1] * s_b[2] * s_b[3];
+        b_slim = ttnn::reshape(input_b, ttnn::Shape{std::array<uint32_t, 4>{1, 1, 1, b_volume}});
+    }
+    a_slim = ttnn::to_layout(a_slim, ttnn::TILE_LAYOUT);
+    b_slim = ttnn::to_layout(b_slim, ttnn::TILE_LAYOUT);
+
+    auto* device = ttnn::GetDefaultDevice();
+    if (device != nullptr) {
+        if (a_slim.storage_type() != tt::tt_metal::StorageType::DEVICE) {
+            a_slim = a_slim.to_device(device);
+        }
+        if (b_slim.storage_type() != tt::tt_metal::StorageType::DEVICE) {
+            b_slim = b_slim.to_device(device);
+        }
+    }
+
+    return ttnn::matmul(a_slim, b_slim);
+}
+
+Tensor polyval(
+    const Tensor& input_a, const std::vector<float>& coeffs, const std::optional<MemoryConfig>& output_mem_config) {
+    TT_ASSERT(!coeffs.empty() && "coeffs should be 1 or more coefficients");
+    if (coeffs.size() == 1) {
+        return ttnn::full_like(input_a, coeffs[0]);
+    }
+    Tensor result = multiply(input_a, coeffs[0], std::nullopt, output_mem_config);
+    for (int idx = 1; idx < coeffs.size() - 1; idx++) {
+        result = add(result, coeffs[idx], std::nullopt, output_mem_config);
+        result = multiply(input_a, result, std::nullopt, output_mem_config);
+    }
+    Tensor final_tensor = add(result, coeffs.back(), std::nullopt, output_mem_config);
+    return final_tensor;
+}
+
+Tensor gcd(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const std::optional<const DataType>& /*output_dtype*/,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations) {
+    return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+        input_tensor_a,
+        input_tensor_b,
+        binary::BinaryOpType::GCD,
+        std::nullopt,
+        memory_config,
+        optional_output_tensor,
+        post_activations,
+        lhs_activations,
+        rhs_activations);
+}
+
+Tensor lcm(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const std::optional<const DataType>& /*output_dtype*/,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations) {
+    return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+        input_tensor_a,
+        input_tensor_b,
+        binary::BinaryOpType::LCM,
+        std::nullopt,
+        memory_config,
+        optional_output_tensor,
+        post_activations,
+        lhs_activations,
+        rhs_activations);
+}
+
+// power - floating point exponent
+Tensor pow(
+    const Tensor& input_a,
+    float exponent,
+    const std::optional<MemoryConfig>& output_mem_config,
+    const std::optional<Tensor>& output_tensor) {
+    float exponent_floor = std::floor(exponent);
+    if (static_cast<int32_t>(exponent_floor) == exponent) {
+        int32_t exp = exponent;
+        return pow(input_a, exp, output_mem_config, output_tensor);
+    }
+    return ttnn::power(input_a, exponent, output_mem_config, output_tensor);
+}
+
+// power - integer exponent
+Tensor pow(
+    const Tensor& input,
+    int32_t exponent,
+    const std::optional<MemoryConfig>& output_mem_config,
+    const std::optional<Tensor>& output_tensor) {
+    // For exponents 0, 1, 2, 3: use iterative approach
+    if (exponent == 0 || exponent == 1 || exponent == 2 || exponent == 3) {
+        uint32_t exp = exponent;
+        return ttnn::power_iterative(input, exp, output_mem_config, output_tensor);
+    }
+    return ttnn::power(input, unary::ScalarVariant(exponent), output_mem_config, output_tensor);
+}
+
+// power - tensor exponent
+Tensor pow(
+    const Tensor& input,
+    const Tensor& exponent,
+    const std::optional<const DataType>& /*dtype*/,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations) {
+    return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+        input,
+        exponent,
+        binary::BinaryOpType::POWER,
+        std::nullopt,
+        memory_config,
+        optional_output_tensor,
+        post_activations,
+        lhs_activations,
+        rhs_activations);
+}
+
+// power - scalar input, tensor exponent
+Tensor pow(
+    float input_a,
+    const Tensor& exponent,
+    const std::optional<const DataType>& /*dtype*/,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations) {
+    // As per binary infra, first input is always a tensor but this support needed for pytorch2 tracing
+    // https://github.com/tenstorrent/pytorch2.0_ttnn/blob/main/docs/operations/aten.pow.Scalar.md
+
+    Tensor input = ttnn::full_like(exponent, input_a);
+    return pow(
+        input,
+        exponent,
+        std::nullopt,
+        memory_config,
+        optional_output_tensor,
+        post_activations,
+        lhs_activations,
+        rhs_activations);
+}
+
+Tensor rsub(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const std::optional<const DataType>& output_dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations) {
+    return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+        input_tensor_a,
+        input_tensor_b,
+        binary::BinaryOpType::RSUB,
+        output_dtype,
+        memory_config,
+        optional_output_tensor,
+        post_activations,
+        lhs_activations,
+        rhs_activations);
+}
+
+Tensor rsub(
+    const Tensor& input_tensor_a,
+    unary::ScalarVariant input_b,
+    const std::optional<const DataType>& output_dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations) {
+    return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+        input_tensor_a,
+        input_b,
+        binary::BinaryOpType::RSUB,
+        output_dtype,
+        memory_config,
+        optional_output_tensor,
+        post_activations,
+        lhs_activations,
+        rhs_activations);
+}
+
+Tensor bias_gelu(
+    const Tensor& input_tensor_a_arg,
+    const Tensor& input_tensor_b_arg,
+    const std::optional<const DataType>& output_dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
+        input_tensor_a_arg,
+        input_tensor_b_arg,
+        binary::BinaryOpType::BIAS_GELU,
+        output_dtype,
+        memory_config,
+        optional_output_tensor,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        /*fast_and_approximate_mode=*/std::nullopt,
+        sub_core_grids,
+        sub_device_id);
+}
+
+Tensor bias_gelu(
+    const Tensor& input_tensor_a,
+    unary::ScalarVariant bias,
+    const std::optional<const DataType>& /*dtype*/,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> /*post_activations*/,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> /*lhs_activations*/,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> /*rhs_activations*/,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    // Resolve sub_device_id to sub_core_grids so both add and gelu use the same core restriction
+    auto resolved_sub_core_grids = sub_core_grids;
+    if (sub_device_id.has_value()) {
+        TT_FATAL(!sub_core_grids.has_value(), "Cannot specify both sub_core_grids and sub_device_id");
+        auto* device = input_tensor_a.device();
+        resolved_sub_core_grids =
+            device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sub_device_id.value());
+    }
+    return ttnn::gelu(
+        add(input_tensor_a,
+            bias,
+            std::nullopt,
+            memory_config,
+            optional_output_tensor,
+            {},
+            {},
+            {},
+            resolved_sub_core_grids),
+        true,
+        memory_config,
+        optional_output_tensor,
+        resolved_sub_core_grids);
+}
+
+}  // namespace ttnn::operations::experimental::quasar::binary

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary/device/kernels/compute/eltwise_binary_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary/device/kernels/compute/eltwise_binary_kernel.cpp
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/tile_move_copy.h"
+
+#include "api/compute/eltwise_unary/sfpu_split_includes.h"
+#include "api/dataflow/circular_buffer.h"
+
+#define PRE_SCALE defined SFPU_OP_INIT_PRE_IN0_0 || defined SFPU_OP_INIT_PRE_IN1_0
+
+void kernel_main() {
+    uint32_t per_core_block_cnt = get_arg_val<uint32_t>(0);
+    uint32_t per_core_block_size = get_arg_val<uint32_t>(1);
+
+    CircularBuffer cb_in0(tt::CBIndex::c_0);
+    CircularBuffer cb_in1(tt::CBIndex::c_1);
+    CircularBuffer cb_out0(tt::CBIndex::c_2);
+#ifdef SFPU_OP_INIT_PRE_IN0_0
+    CircularBuffer cb_inp0(tt::CBIndex::c_3);
+#else
+    CircularBuffer cb_inp0 = cb_in0;
+#endif
+#ifdef SFPU_OP_INIT_PRE_IN1_0
+    CircularBuffer cb_inp1(tt::CBIndex::c_4);
+#else
+    CircularBuffer cb_inp1 = cb_in1;
+#endif
+
+    binary_op_init_common(cb_inp0.get_cb_id(), cb_inp1.get_cb_id(), cb_out0.get_cb_id());
+
+#if not PRE_SCALE
+    binary_tiles_init<false, ELTWISE_OP_TYPE>(cb_inp0.get_cb_id(), cb_inp1.get_cb_id());
+#endif
+
+#ifdef PACK_RELU
+    PACK((llk_pack_relu_config(ReluConfig::zero())));
+#endif
+
+    for (uint32_t block = 0; block < per_core_block_cnt; ++block) {
+#if PRE_SCALE
+        copy_tile_to_dst_init_short(cb_in0.get_cb_id());  // need to copy from CB to DST to be able to run sfpu math
+#endif
+
+#ifdef SFPU_OP_INIT_PRE_IN0_0
+        reconfig_data_format_srca(cb_inp0.get_cb_id(), cb_in0.get_cb_id());
+        pack_reconfig_data_format(cb_out0.get_cb_id(), cb_inp0.get_cb_id());
+        cb_in0.wait_front(per_core_block_size);
+        cb_inp0.reserve_back(per_core_block_size);
+
+        tile_regs_acquire();
+        SFPU_OP_INIT_PRE_IN0_0
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {
+            copy_tile(cb_in0.get_cb_id(), i, i);  // copy from c_in[0] to DST[0]
+            SFPU_OP_FUNC_PRE_IN0_0
+        }
+        tile_regs_commit();
+
+        tile_regs_wait();
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {
+            pack_tile(i, cb_inp0.get_cb_id());  // DST[0]->cb
+        }
+        tile_regs_release();
+
+        cb_in0.pop_front(per_core_block_size);
+        cb_inp0.push_back(per_core_block_size);
+#ifndef SFPU_OP_INIT_PRE_IN1_0
+        reconfig_data_format_srca(cb_in0.get_cb_id(), cb_inp0.get_cb_id());
+        pack_reconfig_data_format(cb_inp0.get_cb_id(), cb_out0.get_cb_id());
+#endif
+#endif
+
+#ifdef SFPU_OP_INIT_PRE_IN1_0
+#ifndef SFPU_OP_INIT_PRE_IN0_0
+        reconfig_data_format_srca(cb_inp0.get_cb_id(), cb_in1.get_cb_id());
+        pack_reconfig_data_format(cb_out0.get_cb_id(), cb_inp1.get_cb_id());
+#else
+        reconfig_data_format_srca(cb_in0.get_cb_id(), cb_in1.get_cb_id());
+        pack_reconfig_data_format(cb_inp0.get_cb_id(), cb_inp1.get_cb_id());
+#endif
+        cb_in1.wait_front(per_core_block_size);
+        cb_inp1.reserve_back(per_core_block_size);
+
+        tile_regs_acquire();
+        SFPU_OP_INIT_PRE_IN1_0
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {
+            copy_tile(cb_in1.get_cb_id(), i, i);  // copy from c_in[0] to DST[0]
+            SFPU_OP_FUNC_PRE_IN1_0
+        }
+        tile_regs_commit();
+
+        tile_regs_wait();
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {
+            pack_tile(i, cb_inp1.get_cb_id());  // DST[0]->cb
+        }
+        tile_regs_release();
+
+        cb_in1.pop_front(per_core_block_size);
+        cb_inp1.push_back(per_core_block_size);
+        reconfig_data_format_srca(cb_in1.get_cb_id(), cb_inp0.get_cb_id());
+        pack_reconfig_data_format(cb_inp1.get_cb_id(), cb_out0.get_cb_id());
+#endif
+
+        cb_inp0.wait_front(per_core_block_size);
+        cb_inp1.wait_front(per_core_block_size);
+        cb_out0.reserve_back(per_core_block_size);
+
+#if PRE_SCALE
+        binary_tiles_init<true, ELTWISE_OP_TYPE>(cb_inp0.get_cb_id(), cb_inp1.get_cb_id());
+#endif
+
+        tile_regs_acquire();
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {
+            ELTWISE_OP(cb_inp0.get_cb_id(), cb_inp1.get_cb_id(), i, i, i);
+
+#ifdef SFPU_OP_INIT_0
+            SFPU_OP_INIT_0
+            SFPU_OP_FUNC_0
+#endif
+
+#ifdef SFPU_OP_CHAIN_0
+            SFPU_OP_CHAIN_0
+#endif
+        }
+        tile_regs_commit();
+
+        tile_regs_wait();
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {
+            pack_tile(i, cb_out0.get_cb_id());
+        }
+        tile_regs_release();
+
+        cb_inp0.pop_front(per_core_block_size);
+        cb_inp1.pop_front(per_core_block_size);
+        cb_out0.push_back(per_core_block_size);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
@@ -1,0 +1,196 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/eltwise_unary/sfpu_split_includes.h"
+
+#include "api/compute/common.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/eltwise_binary_sfpu.h"
+#include "api/compute/binary_bitwise_sfpu.h"
+#include "api/compute/binary_shift.h"
+#include "api/compute/add_int_sfpu.h"
+#include "api/compute/sub_int_sfpu.h"
+#include "api/compute/mul_int_sfpu.h"
+#include "api/compute/div_int32_floor.h"
+#include "api/compute/div_int32_sfpu.h"
+#include "api/compute/binary_remainder.h"
+#include "api/compute/binary_fmod.h"
+#include "api/compute/binary_max_min.h"
+#include "api/compute/xlogy.h"
+#include "api/compute/atan2.h"
+#include "api/compute/gcd.h"
+#include "api/compute/lcm.h"
+#include "api/compute/binary_comp.h"
+#include "api/dataflow/circular_buffer.h"
+
+#define PRE_SCALE defined SFPU_OP_INIT_PRE_IN0_0 || defined SFPU_OP_INIT_PRE_IN1_0
+
+void kernel_main() {
+    uint32_t per_core_block_cnt = get_arg_val<uint32_t>(0);
+    uint32_t per_core_block_size = get_arg_val<uint32_t>(1);
+
+    CircularBuffer cb_in0(tt::CBIndex::c_0);
+    CircularBuffer cb_in1(tt::CBIndex::c_1);
+    CircularBuffer cb_out0(tt::CBIndex::c_2);
+#ifdef SFPU_OP_INIT_PRE_IN0_0
+    CircularBuffer cb_inp0(tt::CBIndex::c_3);
+#else
+    CircularBuffer cb_inp0 = cb_in0;
+#endif
+#ifdef SFPU_OP_INIT_PRE_IN1_0
+    CircularBuffer cb_inp1(tt::CBIndex::c_4);
+#else
+    CircularBuffer cb_inp1 = cb_in1;
+#endif
+
+    unary_op_init_common(cb_in0.get_cb_id(), cb_out0.get_cb_id());
+
+#ifdef PACK_RELU
+    PACK((llk_pack_relu_config(ReluConfig::zero())));
+#endif
+
+    for (uint32_t block = 0; block < per_core_block_cnt; ++block) {
+#if PRE_SCALE
+        copy_tile_to_dst_init_short(cb_in0.get_cb_id());  // need to copy from CB to DST to be able to run sfpu math
+#endif
+
+#ifdef SFPU_OP_INIT_PRE_IN0_0
+        cb_in0.wait_front(per_core_block_size);
+        cb_inp0.reserve_back(per_core_block_size);
+
+        tile_regs_acquire();
+        SFPU_OP_INIT_PRE_IN0_0
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {
+            copy_tile(cb_in0.get_cb_id(), i, i);  // copy from c_in[0] to DST[0]
+            SFPU_OP_FUNC_PRE_IN0_0
+        }
+        tile_regs_commit();
+
+        tile_regs_wait();
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {
+            pack_tile(i, cb_inp0.get_cb_id());  // DST[0]->cb
+        }
+        tile_regs_release();
+
+        cb_in0.pop_front(per_core_block_size);
+        cb_inp0.push_back(per_core_block_size);
+#endif
+
+#ifdef SFPU_OP_INIT_PRE_IN1_0
+        cb_in1.wait_front(per_core_block_size);
+        cb_inp1.reserve_back(per_core_block_size);
+
+        tile_regs_acquire();
+        SFPU_OP_INIT_PRE_IN1_0
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {
+            copy_tile(cb_in1.get_cb_id(), i, i);  // copy from c_in[0] to DST[0]
+            SFPU_OP_FUNC_PRE_IN1_0
+        }
+        tile_regs_commit();
+
+        tile_regs_wait();
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {
+            pack_tile(i, cb_inp1.get_cb_id());  // DST[0]->cb
+        }
+        tile_regs_release();
+
+        cb_in1.pop_front(per_core_block_size);
+        cb_inp1.push_back(per_core_block_size);
+#endif
+        cb_inp0.wait_front(per_core_block_size);
+        cb_inp1.wait_front(per_core_block_size);
+        cb_out0.reserve_back(per_core_block_size);
+
+        tile_regs_acquire();
+        tile_regs_wait();
+        copy_tile_to_dst_init_short_with_dt(cb_inp1.get_cb_id(), cb_inp0.get_cb_id());
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {
+            copy_tile(cb_inp0.get_cb_id(), i, i * 2);
+        }
+        copy_tile_to_dst_init_short_with_dt(cb_inp0.get_cb_id(), cb_inp1.get_cb_id());
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {
+            copy_tile(cb_inp1.get_cb_id(), i, i * 2 + 1);
+
+#ifdef BINOP_INIT
+            BINOP_INIT
+#endif
+#ifdef ADD_INT_INIT
+            ADD_INT_INIT
+#endif
+#ifdef SUB_INT_INIT
+            SUB_INT_INIT
+#endif
+#ifdef MUL_INT_INIT
+            MUL_INT_INIT
+#endif
+#ifdef LT_INT32_INIT
+            LT_INT32_INIT
+#endif
+#ifdef LT_UINT32_INIT
+            LT_UINT32_INIT
+#endif
+#ifdef LT_UINT16_INIT
+            LT_UINT16_INIT
+#endif
+#ifdef GT_INT32_INIT
+            GT_INT32_INIT
+#endif
+#ifdef GT_UINT32_INIT
+            GT_UINT32_INIT
+#endif
+#ifdef GT_UINT16_INIT
+            GT_UINT16_INIT
+#endif
+#ifdef GE_INT32_INIT
+            GE_INT32_INIT
+#endif
+#ifdef GE_UINT32_INIT
+            GE_UINT32_INIT
+#endif
+#ifdef GE_UINT16_INIT
+            GE_UINT16_INIT
+#endif
+#ifdef LE_INT32_INIT
+            LE_INT32_INIT
+#endif
+#ifdef LE_UINT32_INIT
+            LE_UINT32_INIT
+#endif
+#ifdef LE_UINT16_INIT
+            LE_UINT16_INIT
+#endif
+#ifdef BITWISE_INIT
+            BITWISE_INIT
+#endif
+#ifdef BITWISE_UINT16_INIT
+            BITWISE_UINT16_INIT
+#endif
+#ifdef SHIFT_INIT
+            SHIFT_INIT
+#endif
+
+#ifdef BINARY_SFPU_OP
+            BINARY_SFPU_OP
+#endif
+#ifdef SFPU_OP_INIT_0
+            SFPU_OP_INIT_0
+            SFPU_OP_FUNC_0
+#endif
+
+#ifdef SFPU_OP_CHAIN_0
+            SFPU_OP_CHAIN_0
+#endif
+            pack_tile(i * 2, cb_out0.get_cb_id());
+        }
+        tile_regs_commit();
+        tile_regs_release();
+
+        cb_inp0.pop_front(per_core_block_size);
+        cb_inp1.pop_front(per_core_block_size);
+        cb_out0.push_back(per_core_block_size);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary/device/kernels/dataflow/reader_binary_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary/device/kernels/dataflow/reader_binary_interleaved_start_id.cpp
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// This code is temporarily copied from ttnn/operations/datamovement/binary/device/ to demonstrate
+// the new ability to keep the CircularBufferConfigs continuous during dispatching.  See the use of CBIndex::c_2 below.
+// When broadcating is properly supported we expect this code to be deleted or refactored substantially.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    // same arg indices as in reader_binary_diff_lengths for compat
+    uint32_t src0_addr = get_arg_val<uint32_t>(0);
+    uint32_t src1_addr = get_arg_val<uint32_t>(1);
+    uint32_t num_tiles = get_arg_val<uint32_t>(2);
+    uint32_t start_id = get_arg_val<uint32_t>(3);
+    uint32_t block_height = get_arg_val<uint32_t>(4);
+    uint32_t block_width = get_arg_val<uint32_t>(5);
+    uint32_t num_cores_y = get_arg_val<uint32_t>(6);
+
+    constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0;
+    constexpr uint32_t cb_id_in1 = tt::CBIndex::c_1;
+    constexpr bool block_or_width_sharded = get_compile_time_arg_val(0) == 1;
+#if !defined(IN0_SHARDED) && !defined(IN1_SHARDED)
+    constexpr auto src0_args = TensorAccessorArgs<1>();
+    constexpr auto src1_args = TensorAccessorArgs<src0_args.next_compile_time_args_offset()>();
+#elif !defined(IN0_SHARDED)
+    constexpr auto src0_args = TensorAccessorArgs<1>();
+#elif !defined(IN1_SHARDED)
+    constexpr auto src1_args = TensorAccessorArgs<1>();
+#endif
+
+    Noc noc;
+    CircularBuffer cb0(cb_id_in0);
+    CircularBuffer cb1(cb_id_in1);
+
+#ifdef IN0_SHARDED
+    cb0.reserve_back(num_tiles);
+    cb0.push_back(num_tiles);
+#else
+    uint32_t src0_tile_bytes = get_tile_size(cb_id_in0);
+    const auto s0 = TensorAccessor(src0_args, src0_addr);
+#endif
+#ifdef IN1_SHARDED
+    cb1.reserve_back(num_tiles);
+    cb1.push_back(num_tiles);
+#else
+    uint32_t src1_tile_bytes = get_tile_size(cb_id_in1);
+    const auto s1 = TensorAccessor(src1_args, src1_addr);
+#endif
+
+#if !(defined IN0_SHARDED && defined IN1_SHARDED)
+
+    constexpr uint32_t onetile = 1;
+
+    if constexpr (block_or_width_sharded) {
+        uint32_t row_start_tile_id = start_id;
+        for (uint32_t h = 0; h < block_height; h++) {
+            uint32_t tile_id = row_start_tile_id;
+            for (uint32_t w = 0; w < block_width; w++) {
+#ifndef IN0_SHARDED
+                cb0.reserve_back(onetile);
+                noc.async_read(s0, cb0, src0_tile_bytes, {.page_id = tile_id}, {.offset_bytes = 0});
+#endif
+
+#ifndef IN1_SHARDED
+                cb1.reserve_back(onetile);
+                noc.async_read(s1, cb1, src1_tile_bytes, {.page_id = tile_id}, {.offset_bytes = 0});
+#endif
+
+                tile_id++;
+                noc.async_read_barrier();
+
+#ifndef IN0_SHARDED
+                cb0.push_back(onetile);
+#endif
+
+#ifndef IN1_SHARDED
+                cb1.push_back(onetile);
+#endif
+            }
+            row_start_tile_id += num_cores_y * block_width;
+        }
+    } else {
+        for (uint32_t tile_id = start_id; tile_id < start_id + num_tiles; tile_id++) {
+#ifndef IN0_SHARDED
+            cb0.reserve_back(onetile);
+            noc.async_read(s0, cb0, src0_tile_bytes, {.page_id = tile_id}, {.offset_bytes = 0});
+#endif
+
+#ifndef IN1_SHARDED
+            cb1.reserve_back(onetile);
+            noc.async_read(s1, cb1, src1_tile_bytes, {.page_id = tile_id}, {.offset_bytes = 0});
+#endif
+
+            noc.async_read_barrier();
+
+#ifndef IN0_SHARDED
+            cb0.push_back(onetile);
+#endif
+
+#ifndef IN1_SHARDED
+            cb1.push_back(onetile);
+#endif
+        }
+    }
+#endif
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.cpp
@@ -1,0 +1,742 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "binary_ng_device_operation.hpp"
+#include <tt-metalium/sub_device_types.hpp>
+#include "ttnn/device_operation.hpp"
+#include "binary_ng_utils.hpp"
+#include "ttnn/tensor/tensor_ops.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
+#include <cmath>
+
+using namespace tt::tt_metal;
+
+namespace ttnn::operations::experimental::quasar::binary_ng {
+
+namespace utils {
+bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b, bool fast_and_approximate_mode = false) {
+    using enum BinaryOpType;
+    using enum DataType;
+    switch (val) {
+        case ADD:
+        case SUB:
+        case LOGICAL_AND:
+        case LOGICAL_OR:
+        case LOGICAL_XOR:
+        case SQUARED_DIFFERENCE:
+        case RSUB: return a == b && (a == FLOAT32 || a == INT32 || a == UINT32 || a == UINT16);
+        case MUL:
+            return !fast_and_approximate_mode || (a == b && (a == FLOAT32 || a == INT32 || a == UINT32 || a == UINT16));
+        case DIV: return !fast_and_approximate_mode || (a == FLOAT32 && b == FLOAT32) || (a == INT32 && b == INT32);
+        case LOGADDEXP:
+        case LOGADDEXP2:
+        case LDEXP:
+        case BIAS_GELU:
+        case HYPOT: return (a == FLOAT32 && b == FLOAT32);
+        case EQ:
+        case NE:
+        case GT:
+        case LT:
+        case GE:
+        case LE: return a == b && (a == FLOAT32 || a == BFLOAT16 || a == INT32 || a == UINT16 || a == UINT32);
+        case LCM:
+        case GCD: return (a == INT32 && b == INT32);
+        case LEFT_SHIFT:
+        case RIGHT_SHIFT:
+            return ((a == INT32 || a == UINT32 || a == UINT16) && (b == INT32 || b == UINT32 || b == UINT16));
+        case LOGICAL_RIGHT_SHIFT: return ((a == INT32 || a == UINT32) && (b == INT32 || b == UINT32));
+        case BITWISE_XOR:
+        case BITWISE_OR:
+        case BITWISE_AND: return a == b && (a == INT32 || a == UINT32 || a == UINT16);
+        case DIV_FLOOR:
+        case DIV_TRUNC:
+        case REMAINDER:
+        case FMOD:
+        case QUANT:
+        case REQUANT:
+        case DEQUANT:
+        case MAXIMUM:
+        case MINIMUM:
+        case XLOGY:
+        case ATAN2:
+        case POWER:
+        case WHERE_TST:
+        case WHERE_TTS:
+        case ISCLOSE: return true;
+        default: return false;
+    }
+    return false;
+}
+
+bool is_quant_op(const BinaryOpType val) {
+    return (val == BinaryOpType::QUANT) || (val == BinaryOpType::DEQUANT) || (val == BinaryOpType::REQUANT);
+}
+
+ShardSpec generate_shard_spec_all_cores(
+    const Tensor& input_tensor_a, const Shape& padded_out_shape, const TensorMemoryLayout& memory_layout) {
+    // Generate shard spec using all worker cores
+    auto* device = input_tensor_a.device();
+    auto compute_grid_size = device->compute_with_storage_grid_size();
+    auto all_cores = CoreRangeSet(CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1}));
+    uint32_t num_cores = all_cores.num_cores();
+
+    // Calculate squeezed tensor height (all dims except last) and width (last dim)
+    uint32_t tensor_height = 1;
+    for (int i = 0; i < static_cast<int>(padded_out_shape.rank()) - 1; ++i) {
+        tensor_height *= padded_out_shape[i];
+    }
+    uint32_t tensor_width = padded_out_shape[-1];
+
+    // Calculate shard shape based on memory layout (must be tile-aligned for TILE layout)
+    std::array<uint32_t, 2> shard_shape = {0, 0};
+    if (memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+        auto height_padded = tt::round_up(tensor_height, num_cores * tt::constants::TILE_HEIGHT);
+        auto shard_height = tt::round_up(tt::div_up(height_padded, num_cores), tt::constants::TILE_HEIGHT);
+        shard_shape = {shard_height, tensor_width};
+    } else if (memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
+        auto shard_width = tt::round_up(tt::div_up(tensor_width, num_cores), tt::constants::TILE_WIDTH);
+        shard_shape = {tensor_height, shard_width};
+    } else {
+        // BLOCK_SHARDED
+        CoreCoord grid_size = all_cores.bounding_box().grid_size();
+        auto height_padded = tt::round_up(tensor_height, grid_size.y * tt::constants::TILE_HEIGHT);
+        auto shard_height = tt::round_up(tt::div_up(height_padded, grid_size.y), tt::constants::TILE_HEIGHT);
+        auto shard_width = tt::round_up(tt::div_up(tensor_width, grid_size.x), tt::constants::TILE_WIDTH);
+        shard_shape = {shard_height, shard_width};
+    }
+    log_debug(tt::LogOp, "BinaryNgDeviceOperation: Generated shard spec using all {} worker cores", num_cores);
+    return ShardSpec(all_cores, shard_shape, ShardOrientation::ROW_MAJOR);
+}
+}  // namespace utils
+
+CoreRangeSet get_worker_grid(
+    const Tensor& input_tensor_a,
+    const Tensor* input_tensor_b,
+    const std::optional<Tensor>& output_tensor,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const MemoryConfig& memory_config_actual) {
+    // If sub_core_grids is provided, use it directly
+    if (sub_core_grids.has_value()) {
+        log_debug(tt::LogOp, "Using provided sub_core_grids for worker grid {}", sub_core_grids->str());
+        return sub_core_grids.value();
+    }
+
+    auto get_tensor_grid = [](const Tensor& tensor) -> CoreRangeSet {
+        const auto& grid = tensor.shard_spec()->grid;
+        auto* device = tensor.device();
+        for (const auto& sub_device_id : device->get_sub_device_ids()) {
+            const auto& sub_device_workers = device->worker_cores(HalProgrammableCoreType::TENSIX, sub_device_id);
+            if (sub_device_workers.intersects(grid)) {
+                return sub_device_workers;
+            }
+        }
+        __builtin_unreachable();
+    };
+
+    if (output_tensor.has_value() && output_tensor->is_sharded()) {
+        log_debug(tt::LogOp, "Using output tensor grid for worker grid {}", output_tensor->shard_spec()->grid.str());
+        return get_tensor_grid(*output_tensor);
+    }
+
+    if (memory_config.has_value()) {
+        if (memory_config->is_sharded()) {
+            // Use the shard spec from memory config if provided
+            const auto& shard_spec_opt = memory_config->shard_spec();
+            if (shard_spec_opt.has_value()) {
+                log_debug(
+                    tt::LogOp, "Using memory config shard spec grid for worker grid {}", shard_spec_opt->grid.str());
+                auto* device = input_tensor_a.device();
+                for (const auto& sub_device_id : device->get_sub_device_ids()) {
+                    const auto& sub_device_workers =
+                        device->worker_cores(HalProgrammableCoreType::TENSIX, sub_device_id);
+                    if (sub_device_workers.intersects(shard_spec_opt->grid)) {
+                        return sub_device_workers;
+                    }
+                }
+            }
+        } else {
+            log_debug(tt::LogOp, "Memory config not sharded");
+        }
+    } else {
+        log_debug(tt::LogOp, "No memory config provided");
+    }
+    if (output_tensor.has_value() || memory_config.has_value()) {
+        // If output tensor or memory config is provided but not sharded, use all worker cores
+        log_debug(
+            tt::LogOp, "Using all worker cores of the device for worker grid, output or memory config not sharded");
+        auto* device = input_tensor_a.device();
+        return device->worker_cores(HalProgrammableCoreType::TENSIX, device->get_sub_device_ids().front());
+    }
+
+    if (is_native_L1_sharding(
+            input_tensor_a.tensor_spec(),
+            input_tensor_b ? std::optional<TensorSpec>{input_tensor_b->tensor_spec()} : std::nullopt,
+            memory_config_actual)) {
+        if (input_tensor_a.is_sharded()) {
+            log_debug(
+                tt::LogOp,
+                "Native L1 sharding using input tensor A grid for worker grid {}",
+                input_tensor_a.shard_spec()->grid.str());
+            return get_tensor_grid(input_tensor_a);
+        }
+        if (input_tensor_b && input_tensor_b->is_sharded()) {
+            log_debug(
+                tt::LogOp,
+                "Native L1 sharding using input tensor B grid for worker grid {}",
+                input_tensor_b->shard_spec()->grid.str());
+            return get_tensor_grid(*input_tensor_b);
+        }
+    }
+    // use all worker cores of the device
+    log_debug(tt::LogOp, "Using all worker cores of the device for worker grid");
+    auto* device = input_tensor_a.device();
+    return device->worker_cores(HalProgrammableCoreType::TENSIX, device->get_sub_device_ids().front());
+}
+
+SubtileBroadcastType get_subtile_broadcast_type(uint32_t a_h, uint32_t a_w, uint32_t b_h, uint32_t b_w) {
+    if (a_h == b_h && a_w == b_w) {
+        return SubtileBroadcastType::NONE;
+    }
+    if (a_h == 1 && a_w == 1) {
+        return SubtileBroadcastType::SCALAR_A;
+    }
+    if (b_h == 1 && b_w == 1) {
+        return SubtileBroadcastType::SCALAR_B;
+    }
+    if (a_h == 1 /* && a_w != 1 */ && b_w == 1 /* && b_h != 1 */) {
+        return SubtileBroadcastType::ROW_A_COL_B;
+    }
+    if (a_w == 1 /* && a_h != 1 */ && b_h == 1 /* && b_w != 1 */) {
+        return SubtileBroadcastType::ROW_B_COL_A;
+    }
+    if (a_h == 1) {
+        return SubtileBroadcastType::ROW_A;
+    }
+    if (a_w == 1) {
+        return SubtileBroadcastType::COL_A;
+    }
+    if (b_h == 1) {
+        return SubtileBroadcastType::ROW_B;
+    }
+    if (b_w == 1) {
+        return SubtileBroadcastType::COL_B;
+    }
+
+    TT_THROW("Invalid subtile broadcast type");
+}
+
+ttsl::hash::hash_t BinaryNgDeviceOperation::operation_attributes_t::to_hash() const {
+    // TODO: a more generalized way to skip the hashing of an EltwiseUnaryWithParam?
+    auto base_hash = ttsl::hash::hash_objects_with_default_seed(
+        binary_op_type,
+        lhs_activations,
+        rhs_activations,
+        (is_where_op || is_quant_op) ? ttnn::SmallVector<unary::EltwiseUnaryWithParam>{} : post_activations,
+        memory_config,
+        get_dtype(),
+        compute_kernel_config,
+        sub_core_grids,
+        subtile_broadcast_type,
+        is_sfpu,
+        is_quant_op,
+        is_where_op,
+        input_layout_a,
+        input_layout_b,
+        output_layout);
+    if (binary_op_type == BinaryOpType::ISCLOSE) {
+        base_hash = ttsl::hash::hash_objects(base_hash, equal_nan);
+    }
+    return base_hash;
+}
+
+DataType BinaryNgDeviceOperation::operation_attributes_t::get_dtype() const {
+    return this->dtype.value_or(this->input_dtype);
+}
+
+void BinaryNgDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    // We don't support sharding for now
+    const auto& input_tensor_a = tensor_args.input_tensor_a;
+    const auto& input_tensor_b = tensor_args.input_tensor_b;
+    const auto& output_tensor = tensor_args.output_tensor;
+
+    // Validate storage type for input tensors
+    TT_FATAL(
+        input_tensor_a.storage_type() == StorageType::DEVICE,
+        "Input tensor A must be on device, got storage type: {}",
+        input_tensor_a.storage_type());
+
+    if (input_tensor_b.has_value()) {
+        TT_FATAL(
+            input_tensor_b->storage_type() == StorageType::DEVICE,
+            "Input tensor B must be on device, got storage type: {}",
+            input_tensor_b->storage_type());
+    }
+    if (attributes.binary_op_type == BinaryOpType::WHERE_TST || attributes.binary_op_type == BinaryOpType::WHERE_TTS) {
+        TT_FATAL(
+            input_tensor_b.has_value() && attributes.scalar.has_value(), "Input tensor B and scalar value must be set");
+    } else {
+        TT_FATAL(
+            input_tensor_b.has_value() != attributes.scalar.has_value(), "Either the tensor b or scalar should be set");
+    }
+
+    BinaryNgDeviceOperation::validate_on_program_cache_hit(attributes, tensor_args);
+
+    if (attributes.dtype.has_value() && output_tensor.has_value()) {
+        TT_FATAL(
+            *attributes.dtype == output_tensor->dtype(),
+            "If both output dtype and output tensor provided dtype should match");
+    }
+
+    TT_FATAL(
+        input_tensor_a.layout() == Layout::TILE || input_tensor_a.layout() == Layout::ROW_MAJOR,
+        "First operand to eltwise binary must have TILE or ROW_MAJOR layout, got {}",
+        input_tensor_a.layout());
+
+    bool tensor_a_sharded = input_tensor_a.memory_config().is_sharded();
+    if (not tensor_a_sharded) {
+        TT_FATAL(
+            input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+            "LHS operand must be either sharded or interleaved");
+    }
+
+    bool output_sharded = attributes.memory_config.is_sharded();
+    if (not output_sharded) {
+        TT_FATAL(
+            attributes.memory_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
+            "Output must be interleaved or sharded");
+    }
+
+    bool tensor_b_sharded = false;
+
+    if (input_tensor_b.has_value()) {
+        tensor_b_sharded = input_tensor_b->memory_config().is_sharded();
+        TT_FATAL(
+            input_tensor_a.device() == input_tensor_b->device(),
+            "Operands to eltwise binary need to be on the same device!");
+        TT_FATAL(
+            input_tensor_b->layout() == Layout::TILE || input_tensor_b->layout() == Layout::ROW_MAJOR,
+            "Second operand to eltwise binary must have TILE or ROW_MAJOR layout, got {}",
+            input_tensor_b->layout());
+
+        if (not tensor_b_sharded) {
+            TT_FATAL(
+                input_tensor_b->memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+                "RHS operand must be either sharded or interleaved");
+        }
+    }
+}
+
+void BinaryNgDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    const auto& input_tensor_a = tensor_args.input_tensor_a;
+    const auto& input_tensor_b = tensor_args.input_tensor_b;
+    const auto& output_tensor = tensor_args.output_tensor;
+
+    bool has_shard_spec = input_tensor_a.memory_config().is_sharded() ||
+                          (input_tensor_b.has_value() && input_tensor_b->memory_config().is_sharded()) ||
+                          attributes.memory_config.is_sharded();
+
+    if (output_tensor.has_value() && !has_shard_spec) {
+        compute_output_specs(attributes, tensor_args);
+    }
+
+    const auto& input_shape_a = input_tensor_a.logical_shape();
+    const auto& input_shape_b = input_tensor_b.has_value() ? input_tensor_b->logical_shape() : input_shape_a;
+
+    const int rank_a = input_shape_a.rank();
+    const int rank_b = input_shape_b.rank();
+    const int larger_rank = std::max(rank_a, rank_b);
+
+    for (int i = -1; i >= -larger_rank; --i) {
+        auto a_dim = (i >= -rank_a) ? input_shape_a[i] : 1;
+        auto b_dim = (i >= -rank_b) ? input_shape_b[i] : 1;
+        TT_FATAL(
+            a_dim == b_dim || a_dim == 1 || b_dim == 1,
+            "Broadcasting rule violation at dimension index {} (output rank {}), dim a: {}, dim b: {}",
+            i,
+            larger_rank,
+            a_dim,
+            b_dim);
+
+        if (i <= -7) {
+            TT_FATAL(
+                a_dim == b_dim,
+                "Broadcasting rule violation for rank >= 7 at dimension index {} (output rank {}). "
+                "Broadcast is supported up to rank 6. dim a: {}, dim b: {}",
+                i,
+                larger_rank,
+                a_dim,
+                b_dim);
+        }
+    }
+    if (attributes.binary_op_type == BinaryOpType::ISCLOSE) {
+        TT_FATAL(
+            std::isfinite(attributes.rtol) && attributes.rtol >= 0.0f,
+            "isclose: rtol must be a finite, non-negative value, got {}",
+            attributes.rtol);
+        TT_FATAL(
+            std::isfinite(attributes.atol) && attributes.atol >= 0.0f,
+            "isclose: atol must be a finite, non-negative value, got {}",
+            attributes.atol);
+    }
+}
+
+BinaryNgDeviceOperation::spec_return_value_t BinaryNgDeviceOperation::compute_output_specs(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    const auto& output_tensor = tensor_args.output_tensor;
+
+    const auto& input_tensor_a = tensor_args.input_tensor_a;
+    const auto input_shape_a = input_tensor_a.logical_shape();
+    const auto& tensor_b = tensor_args.input_tensor_b;
+    const auto input_shape_b = tensor_b.has_value() ? tensor_b->logical_shape() : ttnn::Shape{};
+
+    const int rank_a = input_shape_a.rank();
+    const int rank_b = input_shape_b.rank();
+    const int larger_rank = std::max(rank_a, rank_b);
+    auto output_dtype = attributes.get_dtype();
+
+    // Integer division results in FP32 outputs.
+    if (attributes.binary_op_type == BinaryOpType::DIV && input_tensor_a.dtype() == DataType::INT32) {
+        if (!tensor_b.has_value() || tensor_b->dtype() == DataType::INT32) {
+            output_dtype = DataType::FLOAT32;
+        }
+    }
+
+    auto output_shape = compute_broadcasted_output(input_shape_a, input_shape_b);
+
+    if (output_tensor.has_value()) {
+        auto shapes_equal = [=](const auto& shape_a, const auto& shape_b) {
+            const auto smaller_rank = std::min(shape_a.rank(), shape_b.rank());
+            for (int i = 0; i < smaller_rank; ++i) {
+                auto dim = -1 - i;
+                if (shape_a[dim] != shape_b[dim]) {
+                    return false;
+                }
+            }
+            const auto& larger_shape = shape_a.rank() > shape_b.rank() ? shape_a : shape_b;
+            for (int i = smaller_rank; i < larger_rank; ++i) {
+                auto dim = -1 - i;
+                if (larger_shape[dim] != 1) {
+                    return false;
+                }
+            }
+            return true;
+        };
+        auto shape = output_tensor.value().logical_shape();
+        TT_FATAL(
+            shapes_equal(shape, output_shape),
+            "Shape of Output tensor {} provided does not match the broadcasted output shape {}",
+            shape,
+            output_shape);
+        return output_tensor->tensor_spec();
+    }
+
+    if (attributes.memory_config.is_sharded()) {
+        const auto& memory_layout = attributes.memory_config.memory_layout();
+        const auto& buffer_type = attributes.memory_config.buffer_type();
+        auto shard_spec_opt = attributes.memory_config.shard_spec();
+
+        // If no shard spec is provided, inherit from input tensor
+        if (!shard_spec_opt.has_value()) {
+            const auto& padded_out_shape =
+                input_tensor_a.tensor_spec().tensor_layout().compute_padded_shape(output_shape);
+            if (input_tensor_a.is_sharded()) {
+                // Adjust shard spec from input A to match output shape
+                const auto& padded_a_shape = input_tensor_a.padded_shape();
+
+                shard_spec_opt = ttnn::operations::experimental::quasar::binary_ng::adjust_to_shape(
+                    *input_tensor_a.memory_config().shard_spec(), padded_a_shape, padded_out_shape);
+            } else if (tensor_b.has_value() && tensor_b->is_sharded()) {
+                // Adjust shard spec from input B to match output shape
+                const auto& padded_b_shape = tensor_b->padded_shape();
+                shard_spec_opt = ttnn::operations::experimental::quasar::binary_ng::adjust_to_shape(
+                    *tensor_b->memory_config().shard_spec(), padded_b_shape, padded_out_shape);
+            } else {
+                shard_spec_opt = utils::generate_shard_spec_all_cores(input_tensor_a, padded_out_shape, memory_layout);
+            }
+        }
+
+        return TensorSpec(
+            output_shape,
+            TensorLayout(
+                output_dtype,
+                PageConfig(attributes.output_layout),
+                MemoryConfig(memory_layout, buffer_type, shard_spec_opt)));
+    }
+
+    // If not sharded, use the memory config from input a that is interleaved
+    return TensorSpec(
+        output_shape, TensorLayout(output_dtype, PageConfig(attributes.output_layout), attributes.memory_config));
+}
+
+BinaryNgDeviceOperation::tensor_return_value_t BinaryNgDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& output_tensor = tensor_args.output_tensor;
+    if (output_tensor.has_value()) {
+        return output_tensor.value();
+    }
+
+    return create_device_tensor(
+        compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor_a.device());
+}
+
+ttsl::hash::hash_t BinaryNgDeviceOperation::compute_program_hash(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    const auto& input_tensor_a = tensor_args.input_tensor_a;
+    const auto& input_tensor_b = tensor_args.input_tensor_b;
+
+    TT_FATAL(is_device_tensor(input_tensor_a), "Unexpected Tensor type {}", input_tensor_a.storage_type());
+
+    if (input_tensor_b.has_value()) {
+        TT_FATAL(is_device_tensor(*input_tensor_b), "Unexpected Tensor type {}", input_tensor_b->storage_type());
+
+        const auto shard_volumes = get_shard_volumes(
+            input_tensor_a.tensor_spec(), input_tensor_b->tensor_spec(), compute_output_specs(attributes, tensor_args));
+
+        return operation::hash_operation<BinaryNgDeviceOperation>(
+            attributes,
+            input_tensor_a.dtype(),
+            input_tensor_a.memory_config(),
+            input_tensor_b->dtype(),
+            input_tensor_b->memory_config(),
+            shard_volumes);
+    }
+
+    return operation::hash_operation<BinaryNgDeviceOperation>(
+        attributes, input_tensor_a.dtype(), input_tensor_a.memory_config());
+}
+
+bool BinaryNgDeviceOperation::skip_launch(
+    const operation_attributes_t& /*attributes*/,
+    const tensor_args_t& /*tensor_args*/,
+    const tensor_return_value_t& tensor_return_value) {
+    return tensor_return_value.logical_shape().volume() == 0;
+}
+
+}  // namespace ttnn::operations::experimental::quasar::binary_ng
+
+namespace ttnn::prim::qsr {
+
+ttnn::operations::experimental::quasar::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t binary_ng(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    ttnn::operations::experimental::quasar::binary_ng::BinaryOpType binary_op_type,
+    const std::optional<const DataType>& output_dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output_tensor,
+    const std::optional<bool>& fast_and_approximate_mode,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    std::optional<ttnn::operations::unary::ScalarVariant> scalar_value,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    float rtol,
+    float atol,
+    bool equal_nan) {
+    using OperationType = ttnn::operations::experimental::quasar::binary_ng::BinaryNgDeviceOperation;
+
+    // Validate storage type for input tensors
+    TT_FATAL(
+        input_tensor_a.storage_type() == StorageType::DEVICE,
+        "Input tensor A must be on device, got storage type: {}",
+        input_tensor_a.storage_type());
+
+    TT_FATAL(
+        input_tensor_b.storage_type() == StorageType::DEVICE,
+        "Input tensor B must be on device, got storage type: {}",
+        input_tensor_b.storage_type());
+
+    // Resolve sub_device_id to sub_core_grids if provided (after device validation)
+    auto resolved_sub_core_grids = sub_core_grids;
+    if (sub_device_id.has_value()) {
+        TT_FATAL(!sub_core_grids.has_value(), "Cannot specify both sub_core_grids and sub_device_id");
+        auto* device = input_tensor_a.device();
+        resolved_sub_core_grids =
+            device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sub_device_id.value());
+    }
+
+    auto subtile_broadcast_type = ttnn::operations::experimental::quasar::binary_ng::get_subtile_broadcast_type(
+        input_tensor_a.logical_shape()[-2],
+        input_tensor_a.logical_shape()[-1],
+        input_tensor_b.logical_shape()[-2],
+        input_tensor_b.logical_shape()[-1]);
+
+    DataType dtype_a = input_tensor_a.dtype();
+    DataType dtype_b = input_tensor_b.dtype();
+    bool is_sfpu_op = (ttnn::operations::experimental::quasar::binary_ng::utils::is_binary_sfpu_op(
+        binary_op_type, dtype_a, dtype_b, fast_and_approximate_mode.value_or(false)));
+    bool is_quant_op = ttnn::operations::experimental::quasar::binary_ng::utils::is_quant_op(binary_op_type);
+    bool is_where_op =
+        (binary_op_type == ttnn::operations::experimental::quasar::binary_ng::BinaryOpType::WHERE_TTS ||
+         binary_op_type == ttnn::operations::experimental::quasar::binary_ng::BinaryOpType::WHERE_TST);
+
+    auto output_layout = output_tensor ? output_tensor->layout() : Layout::TILE;
+    if (!output_tensor.has_value() && input_tensor_a.layout() == Layout::ROW_MAJOR &&
+        input_tensor_b.layout() == Layout::ROW_MAJOR) {
+        output_layout = Layout::ROW_MAJOR;
+    }
+
+    MemoryConfig mem_config_actual = input_tensor_a.memory_config();
+    if (input_tensor_a.is_sharded()) {
+        mem_config_actual = operations::experimental::quasar::binary_ng::compute_mem_config_actual(
+            input_tensor_a, input_tensor_b.logical_shape());
+    }
+    if (!memory_config.has_value() && !output_tensor.has_value()) {
+        if (input_tensor_b.memory_config().is_sharded()) {
+            // if a is interleaved but in L1 (not DRAM), still use a's memory config
+            if (!input_tensor_a.memory_config().is_sharded()) {
+                if (input_tensor_a.memory_config().buffer_type() == BufferType::DRAM) {
+                    mem_config_actual = operations::experimental::quasar::binary_ng::compute_mem_config_actual(
+                        input_tensor_b, input_tensor_a.logical_shape());
+                    log_debug(
+                        tt::LogOp,
+                        "BinaryNgDeviceOperation: Using memory config from input tensor B since it is sharded");
+                }
+            } else if (input_tensor_b.shard_spec()->num_cores() > input_tensor_a.shard_spec()->num_cores()) {
+                mem_config_actual = operations::experimental::quasar::binary_ng::compute_mem_config_actual(
+                    input_tensor_b, input_tensor_a.logical_shape());
+                log_debug(
+                    tt::LogOp,
+                    "BinaryNgDeviceOperation: Using memory config from input tensor B since it has a larger shard "
+                    "grid");
+            }
+        }
+    } else if (memory_config.has_value()) {
+        mem_config_actual = *memory_config;
+        // If the provided memory config is sharded but doesn't have a shard spec, inherit from input
+        if (mem_config_actual.is_sharded() && !mem_config_actual.shard_spec().has_value()) {
+            if (input_tensor_a.is_sharded()) {
+                mem_config_actual = operations::experimental::quasar::binary_ng::compute_mem_config_actual(
+                    input_tensor_a, input_tensor_b.logical_shape());
+                log_debug(tt::LogOp, "BinaryNgDeviceOperation: Inheriting shard spec from input tensor A");
+            } else if (input_tensor_b.is_sharded()) {
+                mem_config_actual = operations::experimental::quasar::binary_ng::compute_mem_config_actual(
+                    input_tensor_b, input_tensor_a.logical_shape());
+                log_debug(tt::LogOp, "BinaryNgDeviceOperation: Inheriting shard spec from input tensor B");
+            } else {
+                auto memory_layout = mem_config_actual.memory_layout();
+                auto output_shape = operations::experimental::quasar::binary_ng::compute_broadcasted_output(
+                    input_tensor_a.logical_shape(), input_tensor_b.logical_shape());
+                const auto& padded_out_shape =
+                    input_tensor_a.tensor_spec().tensor_layout().compute_padded_shape(output_shape);
+                mem_config_actual = MemoryConfig(
+                    memory_layout,
+                    mem_config_actual.buffer_type(),
+                    operations::experimental::quasar::binary_ng::utils::generate_shard_spec_all_cores(
+                        input_tensor_a, padded_out_shape, memory_layout));
+            }
+        } else {
+            log_debug(tt::LogOp, "BinaryNgDeviceOperation: Using provided memory config from function argument");
+        }
+    } else {
+        mem_config_actual = output_tensor->memory_config();
+        log_debug(tt::LogOp, "BinaryNgDeviceOperation: Using memory config from output tensor since it is provided");
+    }
+
+    auto operation_attributes = OperationType::operation_attributes_t{
+        binary_op_type,
+        {lhs_activations.begin(), lhs_activations.end()},
+        {rhs_activations.begin(), rhs_activations.end()},
+        {post_activations.begin(), post_activations.end()},
+        scalar_value,
+        mem_config_actual,
+        is_where_op ? dtype_b : dtype_a,  // TODO: For mixed dtypes we need to set this value to the appropriate
+                                          // dtype depending on which LLK is meant to be used.
+        output_dtype,
+        ttnn::operations::experimental::quasar::binary_ng::get_worker_grid(
+            input_tensor_a, &input_tensor_b, output_tensor, memory_config, resolved_sub_core_grids, mem_config_actual),
+        std::nullopt,
+        resolved_sub_core_grids,
+        sub_device_id,
+        subtile_broadcast_type,
+        is_sfpu_op,
+        is_quant_op,
+        is_where_op,
+        rtol,
+        atol,
+        equal_nan,
+        input_tensor_a.layout(),
+        input_tensor_b.layout(),
+        output_layout};
+
+    auto tensor_args = OperationType::tensor_args_t{input_tensor_a, input_tensor_b, output_tensor};
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
+}
+
+ttnn::operations::experimental::quasar::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t binary_ng(
+    const Tensor& input_tensor_a,
+    ttnn::operations::unary::ScalarVariant scalar,
+    ttnn::operations::experimental::quasar::binary_ng::BinaryOpType binary_op_type,
+    const std::optional<const DataType>& output_dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output_tensor,
+    const std::optional<bool>& fast_and_approximate_mode,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    std::optional<ttnn::operations::unary::ScalarVariant> /*scalar_value*/,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    using OperationType = ttnn::operations::experimental::quasar::binary_ng::BinaryNgDeviceOperation;
+
+    // Validate storage type
+    TT_FATAL(
+        input_tensor_a.storage_type() == StorageType::DEVICE,
+        "Input tensor A must be on device, got storage type: {}",
+        input_tensor_a.storage_type());
+
+    // Resolve sub_device_id to sub_core_grids if provided (after device validation)
+    auto resolved_sub_core_grids = sub_core_grids;
+    if (sub_device_id.has_value()) {
+        TT_FATAL(!sub_core_grids.has_value(), "Cannot specify both sub_core_grids and sub_device_id");
+        auto* device = input_tensor_a.device();
+        resolved_sub_core_grids =
+            device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sub_device_id.value());
+    }
+
+    DataType dtype_a = input_tensor_a.dtype();
+    bool is_sfpu_op = (ttnn::operations::experimental::quasar::binary_ng::utils::is_binary_sfpu_op(
+        binary_op_type, dtype_a, dtype_a, fast_and_approximate_mode.value_or(false)));
+    bool is_quant_op = ttnn::operations::experimental::quasar::binary_ng::utils::is_quant_op(binary_op_type);
+    MemoryConfig mem_config_actual = memory_config.value_or(
+        output_tensor.has_value() ? output_tensor->memory_config() : input_tensor_a.memory_config());
+
+    auto output_layout = output_tensor ? output_tensor->layout() : Layout::TILE;
+    if (!output_tensor.has_value() && input_tensor_a.layout() == Layout::ROW_MAJOR) {
+        output_layout = Layout::ROW_MAJOR;
+    }
+
+    auto operation_attributes = OperationType::operation_attributes_t{
+        binary_op_type,
+        {lhs_activations.begin(), lhs_activations.end()},
+        {rhs_activations.begin(), rhs_activations.end()},
+        {post_activations.begin(), post_activations.end()},
+        scalar,
+        mem_config_actual,
+        input_tensor_a.dtype(),
+        output_dtype,
+        ttnn::operations::experimental::quasar::binary_ng::get_worker_grid(
+            input_tensor_a, nullptr, output_tensor, memory_config, resolved_sub_core_grids, mem_config_actual),
+        std::nullopt,
+        resolved_sub_core_grids,
+        sub_device_id,
+        ttnn::operations::experimental::quasar::binary_ng::SubtileBroadcastType::NONE,
+        is_sfpu_op,
+        is_quant_op,
+        false,
+        /*rtol=*/0.0f,
+        /*atol=*/0.0f,
+        /*equal_nan=*/false,
+        input_tensor_a.layout(),
+        Layout::INVALID,
+        output_layout};
+
+    auto tensor_args = OperationType::tensor_args_t{input_tensor_a, std::nullopt, output_tensor};
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.hpp
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/experimental/quasar/binary_ng/types.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+#include <tt-metalium/sub_device_types.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+namespace ttnn::operations::experimental::quasar::binary_ng {
+
+enum class SubtileBroadcastType {
+    NONE,         // both tensors have equal tile dimensions (H & W)
+    SCALAR_A,     // a is a scalar (H = 1, W = 1)
+    SCALAR_B,     // b is a scalar (H = 1, W = 1)
+    ROW_A_COL_B,  // a has a single tile row, b has a single tile column
+    ROW_B_COL_A,  // b has a single tile row, a has a single tile column
+    ROW_A,        // a has a single tile row, b is full
+    ROW_B,        // b has a single tile row, a is full
+    COL_A,        // a has a single tile column, b is full
+    COL_B,        // b has a single tile column, a is full
+};
+
+SubtileBroadcastType get_subtile_broadcast_type(uint32_t a_h, uint32_t a_w, uint32_t b_h, uint32_t b_w);
+
+struct BinaryNgDeviceOperation {
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
+
+    struct operation_attributes_t {
+        BinaryOpType binary_op_type;
+        ttnn::SmallVector<unary::EltwiseUnaryWithParam> lhs_activations;
+        ttnn::SmallVector<unary::EltwiseUnaryWithParam> rhs_activations;
+        ttnn::SmallVector<unary::EltwiseUnaryWithParam> post_activations;
+        std::optional<unary::ScalarVariant> scalar;
+        tt::tt_metal::MemoryConfig memory_config;
+        DataType input_dtype;
+        std::optional<DataType> dtype;
+        const CoreRangeSet worker_grid;
+        std::optional<DeviceComputeKernelConfig> compute_kernel_config;
+        std::optional<CoreRangeSet> sub_core_grids;
+        std::optional<tt::tt_metal::SubDeviceId> sub_device_id;
+        SubtileBroadcastType subtile_broadcast_type = SubtileBroadcastType::NONE;
+        bool is_sfpu = false;
+        bool is_quant_op = false;
+        bool is_where_op = false;
+        float rtol = 0.0f;
+        float atol = 0.0f;
+        bool equal_nan = false;
+        Layout input_layout_a = Layout::TILE;
+        Layout input_layout_b = Layout::TILE;
+        Layout output_layout = Layout::TILE;
+
+        ttsl::hash::hash_t to_hash() const;
+        DataType get_dtype() const;
+    };
+
+    struct tensor_args_t {
+        const Tensor& input_tensor_a;
+        std::optional<Tensor> input_tensor_b;
+        std::optional<Tensor> output_tensor;
+    };
+
+    struct ProgramFactory {
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& c);
+    };
+
+    using program_factory_t = std::variant<ProgramFactory>;
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static bool skip_launch(const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
+};
+
+}  // namespace ttnn::operations::experimental::quasar::binary_ng
+
+namespace ttnn::prim::qsr {
+
+ttnn::operations::experimental::quasar::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t binary_ng(
+    const Tensor& input_tensor_a_arg,
+    const Tensor& input_tensor_b_arg,
+    ttnn::operations::experimental::quasar::binary_ng::BinaryOpType binary_op_type,
+    const std::optional<const DataType>& output_dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    const std::optional<bool>& fast_and_approximate_mode = std::nullopt,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    std::optional<ttnn::operations::unary::ScalarVariant> scalar_value = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt,
+    float rtol = 0.0f,
+    float atol = 0.0f,
+    bool equal_nan = false);
+
+ttnn::operations::experimental::quasar::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t binary_ng(
+    const Tensor& input_tensor_a_arg,
+    ttnn::operations::unary::ScalarVariant scalar,
+    ttnn::operations::experimental::quasar::binary_ng::BinaryOpType binary_op_type,
+    const std::optional<const DataType>& output_dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    const std::optional<bool>& fast_and_approximate_mode = std::nullopt,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    std::optional<ttnn::operations::unary::ScalarVariant> scalar_value = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_program_factory.cpp
@@ -1,0 +1,1327 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "binary_ng_utils.hpp"
+#include <tt-metalium/work_split.hpp>
+#include "ttnn/operations/cb_utils.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include "ttnn/operations/experimental/quasar/binary/common/binary_op_utils.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+
+#include <algorithm>
+using namespace tt::tt_metal;
+
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+
+using namespace ttnn::operations::experimental::quasar::binary_ng;
+
+// For rank > 5 dims will be collapsed into a single dim
+uint32_t extract_nD_dims(const Tensor& x, const int out_rank) {
+    const auto& shape = x.logical_shape();
+    uint32_t nD_dim = 1;
+    if (out_rank >= 6 && shape.rank() >= 6) {
+        for (int i = -6; i >= -out_rank; --i) {
+            auto dim = shape[i];
+            nD_dim *= dim;
+        }
+    }
+    return nD_dim;
+}
+
+std::tuple<uint32_t, uint32_t, uint32_t, uint32_t, uint32_t> get_shape_dims(const Tensor& x) {
+    const auto& shape = x.padded_shape();
+    const auto& tile = x.tensor_spec().tile();
+    return {
+        shape.rank() >= 5 ? shape[-5] : 1,
+        shape[-4],
+        shape[-3],
+        tt::div_up(shape[-2], tile.get_height()),
+        tt::div_up(shape[-1], tile.get_width())};
+}
+
+std::tuple<uint32_t, uint32_t> calculate_compute_kernel_args(
+    SubtileBroadcastType broadcast_type, uint32_t start_tile_id, uint32_t Ht, uint32_t Wt) {
+    uint32_t start_t = start_tile_id % (Ht * Wt);
+    uint32_t start_tw = start_t % Wt;
+
+    switch (broadcast_type) {
+        case SubtileBroadcastType::NONE:
+        case SubtileBroadcastType::ROW_A:
+        case SubtileBroadcastType::ROW_B: return {1, 0};
+        case SubtileBroadcastType::SCALAR_A:
+        case SubtileBroadcastType::SCALAR_B: return {Ht * Wt, start_t};
+        case SubtileBroadcastType::COL_A:
+        case SubtileBroadcastType::ROW_B_COL_A:
+        case SubtileBroadcastType::COL_B:
+        case SubtileBroadcastType::ROW_A_COL_B: return {Wt, start_tw};
+        default: __builtin_unreachable();  // GCC 12 doesn't compile even though we exhaustively match
+    }
+}
+
+TensorMemoryLayout get_memory_layout(const Tensor& a, const std::optional<Tensor>& b, const Tensor& c) {
+    if (!b.has_value()) {
+        return TensorMemoryLayout::INTERLEAVED;
+    }
+    // c is first preferred
+    if (c.memory_config().is_sharded()) {
+        return c.memory_config().memory_layout();
+    }
+
+    if (a.memory_config().is_sharded()) {
+        return a.memory_config().memory_layout();
+    }
+    if (b.has_value() && b->memory_config().is_sharded()) {
+        return b->memory_config().memory_layout();
+    }
+
+    return TensorMemoryLayout::INTERLEAVED;
+}
+
+std::optional<AllShardSpecs> get_shard_specs(
+    const TensorSpec& a, const std::optional<TensorSpec>& b, const TensorSpec& c) {
+    bool a_sharded = a.memory_config().is_sharded();
+    bool b_sharded = b.has_value() && b->memory_config().is_sharded();
+    bool c_sharded = c.memory_config().is_sharded();
+
+    if ((!a_sharded && !b_sharded) && !c_sharded) {
+        return std::nullopt;
+    }
+
+    if (!is_native_L1_sharding(a, b, c.memory_config())) {
+        return std::nullopt;
+    }
+
+    // If the output is unevenly sharded, only allow when all tensors share the same shard spec
+    // (each core sees identical tile counts for a, b, c -- no deadlock risk).
+    if (is_uneven(c)) {
+        bool all_specs_match =
+            b.has_value() && a_sharded && b_sharded && c_sharded && a.memory_config().shard_spec().has_value() &&
+            b->memory_config().shard_spec().has_value() && c.memory_config().shard_spec().has_value() &&
+            *a.memory_config().shard_spec() == *b->memory_config().shard_spec() &&
+            *a.memory_config().shard_spec() == *c.memory_config().shard_spec();
+        if (!all_specs_match) {
+            return std::nullopt;
+        }
+    }
+
+    const auto& a_shape = a.padded_shape();
+    auto b_shape = b.has_value() ? b->padded_shape() : ttnn::Shape{1, 1};
+    const auto& c_shape = c.padded_shape();
+
+    TT_FATAL(get_shard_spec(c).has_value(), "C must have a shard spec");
+    return AllShardSpecs{
+        a_sharded ? *get_shard_spec(a) : adjust_to_shape(*get_shard_spec(c), c_shape, a_shape),
+        b_sharded ? *get_shard_spec(*b) : adjust_to_shape(*get_shard_spec(c), c_shape, b_shape),
+        *get_shard_spec(c)};
+}
+
+bool should_use_row_major_path(
+    const BinaryNgDeviceOperation::operation_attributes_t& operation_attributes,
+    const std::optional<Tensor>& b,
+    const bool has_sharding) {
+    if (operation_attributes.input_layout_a != Layout::ROW_MAJOR ||
+        operation_attributes.output_layout != Layout::ROW_MAJOR || has_sharding) {
+        return false;
+    }
+    if (b.has_value()) {
+        return operation_attributes.input_layout_b == Layout::ROW_MAJOR;
+    }
+    return true;
+}
+
+uint32_t get_shards_per_width(const ShardSpec& shard_spec, TensorMemoryLayout memory_layout) {
+    auto num_cores = shard_spec.grid.num_cores();
+    if (memory_layout == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED) {
+        return 1;
+    }
+
+    if (memory_layout == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED) {
+        return num_cores;
+    }
+
+    const auto& bbox = shard_spec.grid.bounding_box();
+    const auto& start = bbox.start_coord;
+    const auto& end = bbox.end_coord;
+    return (shard_spec.orientation == ShardOrientation::ROW_MAJOR ? end.x - start.x : end.y - start.y) + 1;
+}
+
+class ShardShapeGenerator {
+    CoreCoord end_core;
+    bool row_major{};
+    TensorMemoryLayout memory_layout{TensorMemoryLayout::INTERLEAVED};
+    std::array<uint32_t, 2> shard_shape{};
+    std::array<uint32_t, 2> last_shard_shape{};
+
+public:
+    ShardShapeGenerator() = default;
+
+    ShardShapeGenerator(const ShardSpec& shard_spec, const Tensor& tensor) :
+        // core ranges are sorted, so the last one is indeed the last core
+        end_core(shard_spec.grid.ranges().rbegin()->end_coord),
+        row_major(shard_spec.orientation == ShardOrientation::ROW_MAJOR),
+        memory_layout(tensor.memory_config().memory_layout()) {
+        auto tile_height = tensor.tensor_spec().tile().get_height();
+        auto tile_width = tensor.tensor_spec().tile().get_width();
+
+        shard_shape = {
+            tt::round_up(shard_spec.shape[0], tile_height) / tile_height,
+            tt::round_up(shard_spec.shape[1], tile_width) / tile_width};
+
+        TT_FATAL(
+            shard_shape[0] != 0 and shard_shape[1] != 0,
+            "Shard shape must not contain zero dimensions but got {{{}, {}}}",
+            shard_shape[0],
+            shard_shape[1]);
+
+        const auto [D, N, C, Ht, Wt] = get_shape_dims(tensor);
+        const auto unrolled_Ht = D * N * C * Ht;
+        last_shard_shape = {
+            shard_shape[0] - (tt::round_up(unrolled_Ht, shard_shape[0]) - unrolled_Ht),
+            shard_shape[1] - (tt::round_up(Wt, shard_shape[1]) - Wt),
+        };
+    }
+    std::array<uint32_t, 2> operator()(CoreCoord core) const {
+        const unsigned majorDim = row_major ? 1 : 0;
+        const unsigned minorDim = row_major ? 0 : 1;
+        auto current_shape = shard_shape;
+        if (memory_layout == TensorMemoryLayout::HEIGHT_SHARDED || memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
+            if (core == end_core) {
+                current_shape[majorDim] = last_shard_shape[majorDim];
+                current_shape[minorDim] = last_shard_shape[minorDim];
+            }
+        } else if (memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
+            // For BLOCK_SHARDED, edges can have uneven shards
+            if (row_major) {
+                if (core.x == end_core.x) {
+                    current_shape[1] = last_shard_shape[1];  // width
+                }
+                if (core.y == end_core.y) {
+                    current_shape[0] = last_shard_shape[0];  // height
+                }
+            } else {  // col_major
+                if (core.y == end_core.y) {
+                    current_shape[1] = last_shard_shape[1];  // width
+                }
+                if (core.x == end_core.x) {
+                    current_shape[0] = last_shard_shape[0];  // height
+                }
+            }
+        }
+        return current_shape;
+    }
+};
+
+KernelName get_reader_kernel_name_and_defines(
+    const SubtileBroadcastType subtile_broadcast_type, std::map<std::string, std::string>& reader_defines) {
+    if (subtile_broadcast_type == SubtileBroadcastType::NONE) {
+        return KernelName::ReaderNoBcastNg;
+    }
+    if (subtile_broadcast_type == SubtileBroadcastType::ROW_A ||
+        subtile_broadcast_type == SubtileBroadcastType::ROW_B) {
+        reader_defines["SRC_BCAST"] = subtile_broadcast_type == SubtileBroadcastType::ROW_A ? "1" : "0";
+        reader_defines["SRC_BCAST_B"] = subtile_broadcast_type == SubtileBroadcastType::ROW_B ? "1" : "0";
+        return KernelName::ReaderRowBcastNg;
+    }
+    if (subtile_broadcast_type == SubtileBroadcastType::COL_A ||
+        subtile_broadcast_type == SubtileBroadcastType::COL_B) {
+        reader_defines["SRC_BCAST"] = subtile_broadcast_type == SubtileBroadcastType::COL_A ? "1" : "0";
+        reader_defines["SRC_BCAST_B"] = subtile_broadcast_type == SubtileBroadcastType::COL_B ? "1" : "0";
+        return KernelName::ReaderColBcastNg;
+    }
+    if (subtile_broadcast_type == SubtileBroadcastType::ROW_B_COL_A ||
+        subtile_broadcast_type == SubtileBroadcastType::ROW_A_COL_B) {
+        reader_defines["SRC_BCAST_COL"] = subtile_broadcast_type == SubtileBroadcastType::ROW_B_COL_A ? "1" : "0";
+        reader_defines["SRC_BCAST_ROW_B"] = subtile_broadcast_type == SubtileBroadcastType::ROW_B_COL_A ? "1" : "0";
+        return KernelName::ReaderRowBColABcastNg;
+    }
+    if (subtile_broadcast_type == SubtileBroadcastType::SCALAR_A ||
+        subtile_broadcast_type == SubtileBroadcastType::SCALAR_B) {
+        reader_defines["SRC_BCAST"] = subtile_broadcast_type == SubtileBroadcastType::SCALAR_A ? "1" : "0";
+        reader_defines["SRC_BCAST_B"] = subtile_broadcast_type == SubtileBroadcastType::SCALAR_B ? "1" : "0";
+        return KernelName::ReaderScalarBcastNg;
+    }
+    TT_FATAL(false, "Unsupported subtile broadcast type {}", static_cast<int>(subtile_broadcast_type));
+}
+
+KernelName get_reader_rm_kernel_name_and_defines(
+    const SubtileBroadcastType subtile_broadcast_type,
+    const bool has_rhs_tensor,
+    std::map<std::string, std::string>& reader_defines) {
+    if (!has_rhs_tensor) {
+        return KernelName::ReaderRmScalarOpNg;
+    }
+    if (subtile_broadcast_type == SubtileBroadcastType::NONE) {
+        return KernelName::ReaderRmNoBcastNg;
+    }
+    if (subtile_broadcast_type == SubtileBroadcastType::ROW_A ||
+        subtile_broadcast_type == SubtileBroadcastType::ROW_B) {
+        reader_defines["SRC_BCAST"] = subtile_broadcast_type == SubtileBroadcastType::ROW_A ? "1" : "0";
+        reader_defines["SRC_BCAST_B"] = subtile_broadcast_type == SubtileBroadcastType::ROW_B ? "1" : "0";
+        return KernelName::ReaderRmRowBcastNg;
+    }
+    if (subtile_broadcast_type == SubtileBroadcastType::COL_A ||
+        subtile_broadcast_type == SubtileBroadcastType::COL_B) {
+        reader_defines["SRC_BCAST"] = subtile_broadcast_type == SubtileBroadcastType::COL_A ? "1" : "0";
+        reader_defines["SRC_BCAST_B"] = subtile_broadcast_type == SubtileBroadcastType::COL_B ? "1" : "0";
+        return KernelName::ReaderRmColBcastNg;
+    }
+    if (subtile_broadcast_type == SubtileBroadcastType::ROW_B_COL_A ||
+        subtile_broadcast_type == SubtileBroadcastType::ROW_A_COL_B) {
+        reader_defines["SRC_BCAST_ROW_B"] = subtile_broadcast_type == SubtileBroadcastType::ROW_B_COL_A ? "1" : "0";
+        return KernelName::ReaderRmRowBColABcastNg;
+    }
+    if (subtile_broadcast_type == SubtileBroadcastType::SCALAR_A ||
+        subtile_broadcast_type == SubtileBroadcastType::SCALAR_B) {
+        reader_defines["SRC_BCAST"] = subtile_broadcast_type == SubtileBroadcastType::SCALAR_A ? "1" : "0";
+        reader_defines["SRC_BCAST_B"] = subtile_broadcast_type == SubtileBroadcastType::SCALAR_B ? "1" : "0";
+        return KernelName::ReaderRmScalarBcastNg;
+    }
+    TT_FATAL(false, "Unsupported row-major subtile broadcast type {}", static_cast<int>(subtile_broadcast_type));
+}
+
+void overwrite_compute_kernel_name_and_defines(
+    KernelName& kernel_name,
+    const SubtileBroadcastType subtile_broadcast_type,
+    std::map<std::string, std::string>& compute_defines,
+    bool is_where_op) {
+    if (subtile_broadcast_type == SubtileBroadcastType::ROW_A ||
+        subtile_broadcast_type == SubtileBroadcastType::ROW_B) {
+        compute_defines["SRC_BCAST"] = subtile_broadcast_type == SubtileBroadcastType::ROW_A ? "1" : "0";
+        compute_defines["SRC_BCAST_B"] = subtile_broadcast_type == SubtileBroadcastType::ROW_B ? "1" : "0";
+        kernel_name = KernelName::ComputeRowBcastNg;
+    } else if (
+        subtile_broadcast_type == SubtileBroadcastType::ROW_A_COL_B ||
+        subtile_broadcast_type == SubtileBroadcastType::ROW_B_COL_A) {
+        kernel_name = KernelName::ComputeRowColBcastNg;
+    } else if (
+        not is_where_op && (subtile_broadcast_type == SubtileBroadcastType::COL_A ||
+                            subtile_broadcast_type == SubtileBroadcastType::COL_B)) {
+        compute_defines["SRC_BCAST"] = subtile_broadcast_type == SubtileBroadcastType::COL_A ? "1" : "0";
+        compute_defines["SRC_BCAST_B"] = subtile_broadcast_type == SubtileBroadcastType::COL_B ? "1" : "0";
+        kernel_name = KernelName::ComputeColBcastNg;
+    } else if (
+        not is_where_op && (subtile_broadcast_type == SubtileBroadcastType::SCALAR_A ||
+                            subtile_broadcast_type == SubtileBroadcastType::SCALAR_B)) {
+        compute_defines["SRC_BCAST"] = subtile_broadcast_type == SubtileBroadcastType::SCALAR_A ? "1" : "0";
+        compute_defines["SRC_BCAST_B"] = subtile_broadcast_type == SubtileBroadcastType::SCALAR_B ? "1" : "0";
+        kernel_name = KernelName::ComputeScalarBcastNg;
+    }
+}
+
+// Returns true on the (arch, broadcast, dtype) tuple that hangs the LLK
+// `unary_bcast` path on Blackhole: COL bcast + BFLOAT16 input + fp32_dest_acc_en.
+bool hits_bh_col_bcast_bf16_to_fp32_hang(
+    SubtileBroadcastType subtile_broadcast_type, DataType a_dtype, DataType b_dtype, bool fp32_dest_acc_en) {
+    const bool is_col_bcast =
+        subtile_broadcast_type == SubtileBroadcastType::COL_A || subtile_broadcast_type == SubtileBroadcastType::COL_B;
+    const bool has_bf16_input = a_dtype == DataType::BFLOAT16 || b_dtype == DataType::BFLOAT16;
+    return tt::tt_metal::hal::get_arch() == tt::ARCH::BLACKHOLE && is_col_bcast && fp32_dest_acc_en && has_bf16_input;
+}
+
+bool is_llk_bcast(
+    const SubtileBroadcastType subtile_broadcast_type,
+    const DataType a_dtype,
+    const DataType b_dtype,
+    const bool fp32_dest_acc_en) {
+    if (hits_bh_col_bcast_bf16_to_fp32_hang(subtile_broadcast_type, a_dtype, b_dtype, fp32_dest_acc_en)) {
+        return false;
+    }
+
+    auto all_match = [&](DataType dt) { return a_dtype == dt && b_dtype == dt; };
+
+    if (subtile_broadcast_type == SubtileBroadcastType::ROW_A ||
+        subtile_broadcast_type == SubtileBroadcastType::ROW_B ||
+        subtile_broadcast_type == SubtileBroadcastType::ROW_A_COL_B ||
+        subtile_broadcast_type == SubtileBroadcastType::ROW_B_COL_A ||
+        subtile_broadcast_type == SubtileBroadcastType::COL_A ||
+        subtile_broadcast_type == SubtileBroadcastType::COL_B ||
+        subtile_broadcast_type == SubtileBroadcastType::SCALAR_A ||
+        subtile_broadcast_type == SubtileBroadcastType::SCALAR_B) {
+        if (all_match(DataType::BFLOAT16) || all_match(DataType::BFLOAT8_B) || all_match(DataType::BFLOAT4_B)) {
+            return true;
+        }
+        if (all_match(DataType::FLOAT32) || all_match(DataType::INT32) || all_match(DataType::UINT32) ||
+            all_match(DataType::UINT16)) {
+            tt::ARCH arch = tt::tt_metal::hal::get_arch();
+            if (arch == tt::ARCH::WORMHOLE_B0) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+
+namespace ttnn::operations::experimental::quasar::binary_ng {
+
+std::optional<AllShardVolumes> get_shard_volumes(
+    const TensorSpec& a, const std::optional<TensorSpec>& b, const TensorSpec& c) {
+    const auto shard_specs = CMAKE_UNIQUE_NAMESPACE::get_shard_specs(a, b, c);
+
+    if (not shard_specs.has_value()) {
+        return std::nullopt;
+    }
+
+    const auto a_sharded = a.memory_config().is_sharded();
+    const auto b_sharded = b.has_value() and b->memory_config().is_sharded();
+    const auto c_sharded = c.memory_config().is_sharded();
+    const auto tile_hw = c.tile().get_tile_hw();
+
+    return AllShardVolumes{
+        .a_shard_volume = a_sharded ? shard_specs->a_shard_spec.numel() / tile_hw : std::optional<std::uint32_t>{},
+        .b_shard_volume = b_sharded ? shard_specs->b_shard_spec.numel() / tile_hw : std::optional<std::uint32_t>{},
+        .c_shard_volume = c_sharded ? shard_specs->c_shard_spec.numel() / tile_hw : std::optional<std::uint32_t>{},
+    };
+}
+
+// Implements c = a op b
+tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_descriptor(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, tensor_return_value_t& c) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
+    ProgramDescriptor desc;
+
+    const auto& a = tensor_args.input_tensor_a;
+    const auto& b = tensor_args.input_tensor_b;
+    const bool is_sfpu_op = operation_attributes.is_sfpu;
+    const bool is_quant_op = operation_attributes.is_quant_op;
+    const bool is_where_op = operation_attributes.is_where_op;
+    // TODO: For mixed dtypes we need to set this value to the appropriate dtype depending on which LLK is meant to be
+    // used.
+    const auto input_dtype = operation_attributes.input_dtype;
+    if (is_quant_op) {
+        TT_FATAL(is_sfpu_op, "Quantization op is SFPU-only");
+    }
+
+    const auto shard_volumes = get_shard_volumes(
+        a.tensor_spec(), b.has_value() ? b->tensor_spec() : std::optional<TensorSpec>{}, c.tensor_spec());
+    const auto has_sharding = shard_volumes.has_value();
+    const auto a_sharded = has_sharding and shard_volumes->a_shard_volume.has_value();
+    const auto b_sharded = has_sharding and shard_volumes->b_shard_volume.has_value();
+    const auto c_sharded = has_sharding and shard_volumes->c_shard_volume.has_value();
+    const auto a_num_tiles_per_shard = has_sharding ? shard_volumes->a_shard_volume : std::nullopt;
+    const auto b_num_tiles_per_shard = has_sharding ? shard_volumes->b_shard_volume : std::nullopt;
+    const auto c_num_tiles_per_shard = has_sharding ? shard_volumes->c_shard_volume : std::nullopt;
+
+    const auto a_dtype = a.dtype();
+    // Always pass the more accurate fp32 when the quantization scale is passed as a scalar.
+    // When b is a scalar, it is packed as bfloat16 for block-float input types (BFLOAT8_B,
+    // BFLOAT4_B), so the CB format must be BFLOAT16 to match — not the block-float a_dtype.
+    const auto b_dtype = b.has_value()                              ? b->dtype()
+                         : is_quant_op                              ? DataType::FLOAT32
+                         : (is_sfpu_op && !is_block_float(a_dtype)) ? a_dtype
+                                                                    : DataType::BFLOAT16;
+    const auto c_dtype = c.dtype();
+    const auto a_data_format = datatype_to_dataformat_converter(a_dtype);
+    const auto b_data_format = datatype_to_dataformat_converter(b_dtype);
+    const auto c_data_format = datatype_to_dataformat_converter(c_dtype);
+
+    uint32_t a_single_tile_size = tt::tile_size(a_data_format);
+    uint32_t b_single_tile_size = tt::tile_size(b_data_format);
+    uint32_t c_single_tile_size = tt::tile_size(c_data_format);
+
+    // we parallelize the computation across the output tiles
+    const auto& all_device_cores = operation_attributes.worker_grid;
+
+    Buffer* a_buffer = a.buffer();
+    Buffer* b_buffer = b.has_value() ? b->buffer() : nullptr;
+    Buffer* c_buffer = c.buffer();
+
+    auto op_type = operation_attributes.binary_op_type;
+
+    // TODO: when handling mixed types, we must identify the appropriate dtype and pass it here to define the respective
+    // LLK APIs
+    const auto op_config = is_sfpu_op ? OpConfig(op_type, std::in_place_type<OpConfig::SfpuBinaryOp>, a_dtype)
+                                      : OpConfig(op_type, std::in_place_type<OpConfig::FpuBinaryOp>, a_dtype);
+
+    auto compute_kernel_defines = op_config.as_defines(a_dtype);
+
+    // Indices 3 and 4 in the compute runtime args vector are reserved for rtol and atol bits.
+    if (operation_attributes.binary_op_type == BinaryOpType::ISCLOSE) {
+        compute_kernel_defines["ISCLOSE_OP"] = "1";
+        compute_kernel_defines["ISCLOSE_EQUAL_NAN"] = operation_attributes.equal_nan ? "1" : "0";
+        compute_kernel_defines["ISCLOSE_RTOL_RT_ARG_IDX"] = "3";
+        compute_kernel_defines["ISCLOSE_ATOL_RT_ARG_IDX"] = "4";
+    }
+
+    {
+        ttnn::SmallVector<unary::EltwiseUnaryWithParam> lhs_activations = operation_attributes.lhs_activations;
+        ttnn::SmallVector<unary::EltwiseUnaryWithParam> rhs_activations = operation_attributes.rhs_activations;
+        ttnn::SmallVector<unary::EltwiseUnaryWithParam> post_activations = operation_attributes.post_activations;
+
+        if (op_config.process_lhs.has_value()) {
+            lhs_activations.push_back(*op_config.process_lhs);
+        }
+
+        if (op_config.process_rhs.has_value()) {
+            rhs_activations.push_back(*op_config.process_rhs);
+        }
+
+        // LDEXP decomposes to EXP2(rhs) then MUL on the FPU path.  The RHS
+        // intermediate CB is Float16_b (due to op_has_exp), but LHS has no
+        // activation and stays in its original block-float format (BFLOAT8_B /
+        // BFLOAT4_B).  The resulting data-format mismatch between the two FPU
+        // binary operands produces incorrect results.  Adding a typecast for
+        // LHS forces it through a Float16_b intermediate CB so both operands
+        // use the same format.
+        // Note: LOGADDEXP / LOGADDEXP2 are not affected because they process
+        // both sides (EXP/EXP2), so lhs_activations is never empty for them.
+        if (!is_sfpu_op && lhs_activations.empty() && !rhs_activations.empty() && op_type == BinaryOpType::LDEXP &&
+            (a_dtype == DataType::BFLOAT8_B || a_dtype == DataType::BFLOAT4_B)) {
+            lhs_activations.push_back({
+                unary::UnaryOpType::TYPECAST,
+                {static_cast<int>(a_dtype), static_cast<int>(DataType::BFLOAT16)},
+            });
+        }
+
+        if (op_config.postprocess.has_value()) {
+            post_activations.insert(post_activations.begin(), *op_config.postprocess);
+        }
+
+        bool is_integer_division =
+            (operation_attributes.binary_op_type == BinaryOpType::DIV && a_dtype == DataType::INT32 &&
+             b_dtype == DataType::INT32);
+
+        if (binary::utils::is_typecast(a_dtype, c_dtype) and !is_quant_op and !is_integer_division) {
+            post_activations.push_back({
+                unary::UnaryOpType::TYPECAST,
+                {static_cast<int>(a_dtype), static_cast<int>(c_dtype)},
+            });
+        }
+
+        add_activation_defines(compute_kernel_defines, lhs_activations, "LHS", a_dtype);
+        add_activation_defines(compute_kernel_defines, rhs_activations, "RHS", b_dtype);
+
+        // The PACK_RELU fast path applies ZERO_RELU via the packer config set once at the top
+        // of the compute kernel.  Subtile-broadcast kernels do an intermediate
+        // `pack_tile(0, cb_llk_post)` followed by `pack_reconfig_data_format(cb_llk_post, cb_out)`
+        // per iteration, which clears the packer's ZERO_RELU state, so the final pack to
+        // `cb_out` no longer clips negatives and RELU is silently dropped.  Restrict the
+        // PACK_RELU optimization to the non-broadcast case and fall through to the SFPU
+        // activation path (used by every other unary post-activation) for broadcast cases.
+        const bool is_subtile_broadcast = operation_attributes.subtile_broadcast_type != SubtileBroadcastType::NONE;
+
+        if (lhs_activations.empty() and rhs_activations.empty() and post_activations.size() == 1) {
+            compute_kernel_defines["PROCESS_POST_ACTIVATIONS(i)"] = "";
+            if (post_activations[0].type() == unary::UnaryOpType::RELU && !is_subtile_broadcast) {
+                compute_kernel_defines["PACK_RELU"] = "1";
+                unary::utils::update_macro_defines(unary::UnaryOpType::RELU, compute_kernel_defines);
+            } else if (post_activations[0].type() == unary::UnaryOpType::ZERO_POINT) {
+                // Zero-point is passed as the 4th run-time kernel argument
+                compute_kernel_defines["QUANT_ZERO_POINT_RT_ARGS_IDX"] = "3";
+                unary::utils::update_macro_defines(unary::UnaryOpType::ZERO_POINT, compute_kernel_defines);
+            } else {
+                add_activation_defines(compute_kernel_defines, post_activations, "POST", input_dtype);
+            }
+        } else {
+            add_activation_defines(compute_kernel_defines, post_activations, "POST", input_dtype);
+        }
+    }
+
+    // Determine max tiles per cycle based on sharding and output data type
+    // Multi-tile processing only enabled when all tensors are sharded
+    uint32_t num_tiles_per_cycle = 1;  // Conservative default
+    bool enable_multi_tile = false;
+
+    // Enable for no-broadcast case when all tensors are sharded
+    if (operation_attributes.subtile_broadcast_type == SubtileBroadcastType::NONE && a_sharded && b_sharded &&
+        c_sharded) {
+        enable_multi_tile = true;
+    }
+    // Enable for scalar value case (not scalar broadcast) when input and output are sharded
+    if (!b.has_value() && a_sharded && c_sharded) {
+        enable_multi_tile = true;
+    }
+
+    if (enable_multi_tile && !is_where_op) {
+        if (!is_sfpu_op) {
+            // FPU kernels: 16-bit types can handle 8 tiles,
+            num_tiles_per_cycle = 8;  // Default for 16-bit types (BF16, BF8, BF4)
+        } else {
+            // SFPU kernel should handle 4, but for unknown reason, only 2 works
+            // no document and example to show why 4 does not work, need further investigation
+            num_tiles_per_cycle = 2;
+        }
+    }
+
+    bool op_has_exp =
+        op_type == BinaryOpType::LOGADDEXP || op_type == BinaryOpType::LDEXP || op_type == BinaryOpType::LOGADDEXP2;
+    const bool inputs_row_major =
+        CMAKE_UNIQUE_NAMESPACE::should_use_row_major_path(operation_attributes, b, has_sharding);
+
+    // CB: a (c_0)
+    {
+        uint32_t a_num_pages = a_num_tiles_per_shard.value_or(2);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = a_single_tile_size * a_num_pages,
+            .core_ranges = all_device_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_0),
+                .data_format = a_data_format,
+                .page_size = a_single_tile_size,
+            }}},
+            .buffer = a_sharded ? a_buffer : nullptr,
+        });
+    }
+
+    if (not compute_kernel_defines["PROCESS_LHS_ACTIVATIONS(i)"].empty()) {
+        auto a_intermediate_format = is_sfpu_op   ? a_data_format
+                                     : op_has_exp ? tt::DataFormat::Float16_b
+                                                  : a_data_format;
+        uint32_t a_intermediate_single_tile_size = tt::tile_size(a_intermediate_format);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = a_intermediate_single_tile_size * num_tiles_per_cycle,
+            .core_ranges = all_device_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_3),
+                .data_format = a_intermediate_format,
+                .page_size = a_intermediate_single_tile_size,
+            }}},
+        });
+    }
+
+    // CB: b (c_1)
+    {
+        uint32_t b_num_pages = b_buffer == nullptr ? 1 : b_num_tiles_per_shard.value_or(2);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = b_single_tile_size * b_num_pages,
+            .core_ranges = all_device_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_1),
+                .data_format = b_data_format,
+                .page_size = b_single_tile_size,
+            }}},
+            .buffer = b_sharded ? b_buffer : nullptr,
+        });
+    }
+
+    if (not compute_kernel_defines["PROCESS_RHS_ACTIVATIONS(i)"].empty()) {
+        auto b_intermediate_format = is_sfpu_op   ? b_data_format
+                                     : op_has_exp ? tt::DataFormat::Float16_b
+                                                  : b_data_format;
+        uint32_t b_intermediate_single_tile_size = tt::tile_size(b_intermediate_format);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = b_intermediate_single_tile_size * num_tiles_per_cycle,
+            .core_ranges = all_device_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_4),
+                .data_format = b_intermediate_format,
+                .page_size = b_intermediate_single_tile_size,
+            }}},
+        });
+    }
+
+    if (operation_attributes.subtile_broadcast_type == SubtileBroadcastType::ROW_A ||
+        operation_attributes.subtile_broadcast_type == SubtileBroadcastType::ROW_A_COL_B ||
+        operation_attributes.subtile_broadcast_type == SubtileBroadcastType::COL_A ||
+        operation_attributes.subtile_broadcast_type == SubtileBroadcastType::SCALAR_A) {
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = a_single_tile_size * 2,
+            .core_ranges = all_device_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_5),
+                .data_format = a_data_format,
+                .page_size = a_single_tile_size,
+            }}},
+        });
+    }
+    if (operation_attributes.subtile_broadcast_type == SubtileBroadcastType::ROW_B ||
+        operation_attributes.subtile_broadcast_type == SubtileBroadcastType::ROW_B_COL_A ||
+        operation_attributes.subtile_broadcast_type == SubtileBroadcastType::COL_B ||
+        operation_attributes.subtile_broadcast_type == SubtileBroadcastType::SCALAR_B) {
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = b_single_tile_size * 2,
+            .core_ranges = all_device_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_6),
+                .data_format = b_data_format,
+                .page_size = b_single_tile_size,
+            }}},
+        });
+    }
+
+    // CB: c (c_2)
+    {
+        uint32_t c_num_pages = c_num_tiles_per_shard.value_or(2);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = c_single_tile_size * c_num_pages,
+            .core_ranges = all_device_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_2),
+                .data_format = c_data_format,
+                .page_size = c_single_tile_size,
+            }}},
+            .buffer = c_sharded ? c_buffer : nullptr,
+        });
+    }
+
+    const bool outputs_row_major = inputs_row_major && operation_attributes.output_layout == Layout::ROW_MAJOR;
+    if (inputs_row_major) {
+        TT_FATAL(!has_sharding, "Row-major binary_ng path does not support sharded tensors yet");
+        TT_FATAL(outputs_row_major, "Row-major binary_ng path requires row-major output layout");
+    }
+
+    auto kernel_config = CMAKE_UNIQUE_NAMESPACE::BinaryNgKernelConfig(operation_attributes.subtile_broadcast_type);
+    // WRITER KERNEL
+    auto writer_kernel = CMAKE_UNIQUE_NAMESPACE::KernelName::WriterScalar;
+    auto compute_kernel = CMAKE_UNIQUE_NAMESPACE::KernelName::ComputeScalar;
+    if (b.has_value()) {
+        writer_kernel = kernel_config.writer_kernel;
+        compute_kernel = kernel_config.compute_kernel;
+    }
+
+    auto writer_defines = make_dataflow_defines(b_dtype);
+    writer_defines["SRC_SHARDED"] = b_sharded ? "1" : "0";
+    writer_defines["DST_SHARDED"] = c_sharded ? "1" : "0";
+
+    auto reader_defines = make_dataflow_defines(a_dtype, b_dtype);
+    reader_defines["SRC_SHARDED"] = a_sharded ? "1" : "0";
+    reader_defines["SRC_SHARDED_B"] = b_sharded ? "1" : "0";
+    if (inputs_row_major) {
+        kernel_config.reader_kernel = CMAKE_UNIQUE_NAMESPACE::get_reader_rm_kernel_name_and_defines(
+            operation_attributes.subtile_broadcast_type, b.has_value(), reader_defines);
+        writer_kernel = KernelName::WriterRmNoBcastNg;
+    } else if (b.has_value()) {
+        kernel_config.reader_kernel = CMAKE_UNIQUE_NAMESPACE::get_reader_kernel_name_and_defines(
+            operation_attributes.subtile_broadcast_type, reader_defines);
+        writer_kernel = KernelName::WriterNoBcastNg;
+    }
+
+    // WRITER KERNEL DESCRIPTOR
+    std::vector<uint32_t> writer_compile_time_args;
+    std::vector<uint32_t> writer_common_runtime_args;
+    tt::tt_metal::TensorAccessorArgs(*c_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(writer_compile_time_args, writer_common_runtime_args);
+    writer_compile_time_args.push_back(static_cast<uint32_t>(has_sharding));
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = get_kernel_file_path(writer_kernel, is_sfpu_op, is_where_op);
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_device_cores;
+    writer_desc.compile_time_args = writer_compile_time_args;
+    writer_desc.defines = {writer_defines.begin(), writer_defines.end()};
+    writer_desc.config = WriterConfigDescriptor{};
+    writer_desc.common_runtime_args = writer_common_runtime_args;
+
+    // COMPUTE KERNEL
+    // fp32 dest accumulation must be enabled whenever any input or output is fp32, otherwise
+    // loading fp32 tiles into a DST configured for bf16 produces tile-aligned corruption
+    // for broadcast multiply (issue 43196).
+    bool fp32_dest_acc_en = c_data_format == tt::DataFormat::UInt32 || c_data_format == tt::DataFormat::Int32 ||
+                            c_data_format == tt::DataFormat::Float32 || a_data_format == tt::DataFormat::Float32 ||
+                            b_data_format == tt::DataFormat::Float32 ||
+                            (a_data_format == tt::DataFormat::Int32 && b_data_format == tt::DataFormat::Int32) ||
+                            (a_data_format == tt::DataFormat::UInt32 && b_data_format == tt::DataFormat::UInt32);
+
+    uint32_t src0_cb_index = tt::CBIndex::c_0;
+    uint32_t src1_cb_index = tt::CBIndex::c_1;
+    uint32_t src0interim_cb_index = tt::CBIndex::c_3;
+    uint32_t src1interim_cb_index = tt::CBIndex::c_4;
+
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+
+    if (is_sfpu_op) {
+        if (op_type != BinaryOpType::POWER) {
+            unpack_to_dest_mode[src0_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+            unpack_to_dest_mode[src1_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+            unpack_to_dest_mode[src0interim_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+            unpack_to_dest_mode[src1interim_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+            unpack_to_dest_mode[tt::CBIndex::c_5] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+            unpack_to_dest_mode[tt::CBIndex::c_6] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        } else {
+            unpack_to_dest_mode[src0_cb_index] = (a_dtype == DataType::FLOAT32)
+                                                     ? tt::tt_metal::UnpackToDestMode::UnpackToDestFp32
+                                                     : tt::tt_metal::UnpackToDestMode::Default;
+            unpack_to_dest_mode[src1_cb_index] = (b_dtype == DataType::FLOAT32)
+                                                     ? tt::tt_metal::UnpackToDestMode::UnpackToDestFp32
+                                                     : tt::tt_metal::UnpackToDestMode::Default;
+            unpack_to_dest_mode[src0interim_cb_index] = (a_dtype == DataType::FLOAT32)
+                                                            ? tt::tt_metal::UnpackToDestMode::UnpackToDestFp32
+                                                            : tt::tt_metal::UnpackToDestMode::Default;
+            unpack_to_dest_mode[src1interim_cb_index] = (b_dtype == DataType::FLOAT32)
+                                                            ? tt::tt_metal::UnpackToDestMode::UnpackToDestFp32
+                                                            : tt::tt_metal::UnpackToDestMode::Default;
+            unpack_to_dest_mode[tt::CBIndex::c_5] = (a_dtype == DataType::FLOAT32)
+                                                        ? tt::tt_metal::UnpackToDestMode::UnpackToDestFp32
+                                                        : tt::tt_metal::UnpackToDestMode::Default;
+            unpack_to_dest_mode[tt::CBIndex::c_6] = (b_dtype == DataType::FLOAT32)
+                                                        ? tt::tt_metal::UnpackToDestMode::UnpackToDestFp32
+                                                        : tt::tt_metal::UnpackToDestMode::Default;
+        }
+    }
+
+    compute_kernel_defines["BCAST_INPUT"] = kernel_config.bcast_input_str();
+
+    bool use_llk_bcast =
+        !inputs_row_major && CMAKE_UNIQUE_NAMESPACE::is_llk_bcast(
+                                 operation_attributes.subtile_broadcast_type, a_dtype, b_dtype, fp32_dest_acc_en);
+
+    // The B2D broadcast path for BFP formats introduces rounding that EXP/EXP2
+    // amplifies beyond acceptable tolerance.
+    if (use_llk_bcast && op_has_exp) {
+        use_llk_bcast = false;
+    }
+
+    // Where op does not support LLK bcast for scalar and col broadcast
+    if (use_llk_bcast && is_where_op &&
+        (operation_attributes.subtile_broadcast_type == SubtileBroadcastType::COL_A ||
+         operation_attributes.subtile_broadcast_type == SubtileBroadcastType::COL_B ||
+         operation_attributes.subtile_broadcast_type == SubtileBroadcastType::SCALAR_A ||
+         operation_attributes.subtile_broadcast_type == SubtileBroadcastType::SCALAR_B)) {
+        use_llk_bcast = false;
+    }
+
+    // Integer relational ops on UInt16 use either the FPU SUB + {EQZ/NEZ} postprocess
+    // path (EQ/NE) or direct SFPU comparison (LT/GT/LE/GE), both with DEST configured
+    // for Fp16_b accumulation (fp32_dest_acc_en is false for UInt16).  Under SCALAR
+    // broadcast the B2D datacopy unpacker writes a single u16 lane into all DEST
+    // positions; the resulting Fp16_b-tagged DEST is then read back by the postprocess
+    // or SFPU comparison kernel, which interprets the integer bit pattern through the
+    // format-conversion path and corrupts the comparison result (#36217).
+    // Fall back to software broadcast for this combination - non-broadcast u16
+    // relational ops and broadcasted arithmetic u16 ops (no postprocess) are
+    // unaffected.
+    if (use_llk_bcast && a_data_format == tt::DataFormat::UInt16 && b_data_format == tt::DataFormat::UInt16 &&
+        (op_config.postprocess.has_value() ||
+         (std::holds_alternative<OpConfig::SfpuBinaryOp>(op_config.binary_op) &&
+          (std::get<OpConfig::SfpuBinaryOp>(op_config.binary_op) == OpConfig::SfpuBinaryOp::LT ||
+           std::get<OpConfig::SfpuBinaryOp>(op_config.binary_op) == OpConfig::SfpuBinaryOp::GT ||
+           std::get<OpConfig::SfpuBinaryOp>(op_config.binary_op) == OpConfig::SfpuBinaryOp::LE ||
+           std::get<OpConfig::SfpuBinaryOp>(op_config.binary_op) == OpConfig::SfpuBinaryOp::GE))) &&
+        (operation_attributes.subtile_broadcast_type == SubtileBroadcastType::SCALAR_A ||
+         operation_attributes.subtile_broadcast_type == SubtileBroadcastType::SCALAR_B)) {
+        use_llk_bcast = false;
+    }
+
+    // On Blackhole, the B2D datacopy path (MOVB2D) has a known issue in FP32 dest
+    // accumulation mode with non-32-bit source formats (BH Issue #449).  SCALAR and
+    // ROW broadcasts use MOVB2D, which produces corrupted results when
+    // fp32_dest_acc_en is true.  COL broadcast is unaffected because it uses ELWADD
+    // instead of MOVB2D.  Fall back to the software-broadcast path for the affected
+    // broadcast types on Blackhole when FP32 dest accumulation is active.
+    if (use_llk_bcast && fp32_dest_acc_en) {
+        tt::ARCH arch = tt::tt_metal::hal::get_arch();
+        if (arch == tt::ARCH::BLACKHOLE) {
+            auto sbt = operation_attributes.subtile_broadcast_type;
+            bool uses_movb2d =
+                (sbt == SubtileBroadcastType::SCALAR_A || sbt == SubtileBroadcastType::SCALAR_B ||
+                 sbt == SubtileBroadcastType::ROW_A || sbt == SubtileBroadcastType::ROW_B ||
+                 sbt == SubtileBroadcastType::ROW_A_COL_B || sbt == SubtileBroadcastType::ROW_B_COL_A);
+            if (uses_movb2d) {
+                use_llk_bcast = false;
+            }
+        }
+    }
+
+    if (use_llk_bcast) {
+        CMAKE_UNIQUE_NAMESPACE::overwrite_compute_kernel_name_and_defines(
+            compute_kernel, operation_attributes.subtile_broadcast_type, compute_kernel_defines, is_where_op);
+        reader_defines["BCAST_LLK"] = "1";
+    } else {
+        reader_defines["BCAST_LLK"] = "0";
+    }
+
+    if (op_type == BinaryOpType::WHERE_TTS || op_type == BinaryOpType::WHERE_TST) {
+        // Add common fill defines
+        compute_kernel_defines["FILL_LLK"] = "fill_tile";
+        if (b_dtype == DataType::INT32) {
+            compute_kernel_defines["FILL_LLK"] = "fill_tile_int<DataFormat::Int32>";
+            compute_kernel_defines["FILL_WITH_VALUE_INT"] = "1";
+        } else if (b_dtype == DataType::UINT32) {
+            compute_kernel_defines["FILL_LLK"] = "fill_tile_uint<DataFormat::UInt32>";
+            compute_kernel_defines["FILL_WITH_VALUE_INT"] = "1";
+        } else {
+            compute_kernel_defines["FILL_WITH_VALUE_FLOAT"] = "1";
+        }
+    }
+    compute_kernel_defines["WHERE_TTS"] = (op_type == BinaryOpType::WHERE_TTS) ? "1" : "0";
+    compute_kernel_defines["WHERE_TST"] = (op_type == BinaryOpType::WHERE_TST) ? "1" : "0";
+
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source = get_kernel_file_path(compute_kernel, is_sfpu_op, is_where_op);
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = all_device_cores;
+    compute_desc.defines = {compute_kernel_defines.begin(), compute_kernel_defines.end()};
+    compute_desc.compile_time_args = {num_tiles_per_cycle};
+    compute_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .unpack_to_dest_mode = {unpack_to_dest_mode.begin(), unpack_to_dest_mode.end()},
+    };
+
+    // READER KERNEL DESCRIPTOR
+    std::vector<uint32_t> reader_compile_time_args;
+    std::vector<uint32_t> reader_common_runtime_args;
+    tt::tt_metal::TensorAccessorArgs(*a_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(reader_compile_time_args, reader_common_runtime_args);
+    tt::tt_metal::TensorAccessorArgs(
+        b_buffer != nullptr ? *b_buffer : *a_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(reader_compile_time_args, reader_common_runtime_args);
+    reader_compile_time_args.push_back(static_cast<uint32_t>(has_sharding));
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = get_kernel_file_path(kernel_config.reader_kernel, is_sfpu_op, is_where_op);
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_device_cores;
+    reader_desc.compile_time_args = reader_compile_time_args;
+    reader_desc.defines = {reader_defines.begin(), reader_defines.end()};
+    reader_desc.config = ReaderConfigDescriptor{};
+    reader_desc.common_runtime_args = reader_common_runtime_args;
+
+    // === Inline per-core runtime arguments (previously set_or_update_runtime_arguments) ===
+    {
+        const auto out_rank = c.logical_shape().rank();
+        auto aND = CMAKE_UNIQUE_NAMESPACE::extract_nD_dims(a, out_rank);
+        auto bND = b.has_value() ? CMAKE_UNIQUE_NAMESPACE::extract_nD_dims(*b, out_rank) : 1;
+        auto cND = CMAKE_UNIQUE_NAMESPACE::extract_nD_dims(c, out_rank);
+        const auto aHt_r = a.padded_shape()[-2];
+        const auto aWt_r = a.padded_shape()[-1];
+        const auto bHt_r = b.has_value() ? b->padded_shape()[-2] : 0;
+        const auto bWt_r = b.has_value() ? b->padded_shape()[-1] : 0;
+        const auto cHt_r = c.padded_shape()[-2];
+        const auto cWt_r = c.padded_shape()[-1];
+
+        const auto [aD, aN, aC, aHt, aWt] = CMAKE_UNIQUE_NAMESPACE::get_shape_dims(a);
+        const auto [bD, bN, bC, bHt, bWt] =
+            b.has_value() ? CMAKE_UNIQUE_NAMESPACE::get_shape_dims(*b) : std::tuple{1u, 1u, 1u, 1u, 1u};
+        const auto [cD, cN, cC, cHt, cWt] = CMAKE_UNIQUE_NAMESPACE::get_shape_dims(c);
+
+        const auto shard_specs = CMAKE_UNIQUE_NAMESPACE::get_shard_specs(
+            a.tensor_spec(), b.has_value() ? b->tensor_spec() : std::optional<TensorSpec>{}, c.tensor_spec());
+        const bool rt_has_sharding = shard_specs.has_value();
+        auto grid = rt_has_sharding ? shard_specs->a_shard_spec.grid : CoreRangeSet{};
+
+        const auto row_major =
+            rt_has_sharding ? shard_specs->a_shard_spec.orientation == ShardOrientation::ROW_MAJOR : true;
+
+        bool zero_start_grid = false;
+        CoreCoord compute_with_storage_grid;
+        if (grid.size() == 1) {
+            const auto& cr = *all_device_cores.ranges().begin();
+            if (cr.start_coord.x == 0 && cr.start_coord.y == 0) {
+                if (rt_has_sharding) {
+                    const auto& shard_start_coord = grid.ranges()[0].start_coord;
+                    if (shard_start_coord.x == 0 && shard_start_coord.y == 0) {
+                        zero_start_grid = true;
+                        compute_with_storage_grid = CoreCoord(cr.end_coord.x + 1, cr.end_coord.y + 1);
+                    }
+                } else {
+                    zero_start_grid = true;
+                    compute_with_storage_grid = CoreCoord(cr.end_coord.x + 1, cr.end_coord.y + 1);
+                }
+            }
+        }
+        const uint32_t num_cores_total =
+            zero_start_grid ? compute_with_storage_grid.x * compute_with_storage_grid.y : all_device_cores.num_cores();
+
+        uint32_t num_tiles_per_core_group_1{}, num_tiles_per_core_group_2{};
+        CoreRangeSet all_cores, core_group_1, core_group_2;
+        uint32_t num_cores;
+        std::vector<CoreCoord> cores;
+
+        const bool row_major_inputs =
+            CMAKE_UNIQUE_NAMESPACE::should_use_row_major_path(operation_attributes, b, rt_has_sharding);
+        const uint32_t a_alignment = a.buffer()->alignment();
+        const uint32_t b_alignment = b.has_value() ? b->buffer()->alignment() : a_alignment;
+        const uint32_t c_alignment = c.buffer()->alignment();
+
+        const uint32_t tile_height = c.tensor_spec().tile().get_height();
+        const uint32_t tile_width = c.tensor_spec().tile().get_width();
+        const uint32_t tile_hw = tile_height * tile_width;
+
+        uint32_t rt_c_num_tiles;
+        uint32_t num_rows_per_tile = 0;
+        uint32_t row_blocks_per_channel = 1;
+        uint32_t tiles_per_row_width = 1;
+        uint32_t common_row_width_elements = 0;
+        uint32_t reader_stride_size_bytes = 0;
+        uint32_t writer_stride_size_bytes = 0;
+
+        if (row_major_inputs) {
+            const uint32_t c_aligned_page_size = c.buffer()->aligned_page_size();
+            const uint32_t a_aligned_page_size = a.buffer()->aligned_page_size();
+            const uint32_t b_aligned_page_size = b.has_value() ? b->buffer()->aligned_page_size() : a_aligned_page_size;
+
+            const uint32_t c_row_width_elements_aligned = c_aligned_page_size / c.element_size();
+            const uint32_t a_row_width_elements_aligned = a_aligned_page_size / a.element_size();
+            const uint32_t b_row_width_elements_aligned =
+                b.has_value() ? (b_aligned_page_size / b->element_size()) : a_row_width_elements_aligned;
+
+            common_row_width_elements = c_row_width_elements_aligned;
+            if (aWt_r == cWt_r) {
+                common_row_width_elements = std::min(common_row_width_elements, a_row_width_elements_aligned);
+            }
+            if (b.has_value() && bWt_r == cWt_r) {
+                common_row_width_elements = std::min(common_row_width_elements, b_row_width_elements_aligned);
+            }
+            common_row_width_elements = std::max<uint32_t>(1u, common_row_width_elements);
+
+            num_rows_per_tile = std::max<uint32_t>(1u, tile_hw / common_row_width_elements);
+            const bool aligned_for_a =
+                (aWt_r == cWt_r) ? ((common_row_width_elements * a.element_size()) == a_aligned_page_size) : true;
+            const bool aligned_for_b = (b.has_value() && bWt_r == cWt_r)
+                                           ? ((common_row_width_elements * b->element_size()) == b_aligned_page_size)
+                                           : true;
+            const bool aligned_for_c = (common_row_width_elements * c.element_size()) == c_aligned_page_size;
+            if (!aligned_for_a || !aligned_for_b || !aligned_for_c) {
+                num_rows_per_tile = 1;
+            }
+
+            row_blocks_per_channel = tt::div_up(cHt_r, num_rows_per_tile);
+            const uint32_t total_row_blocks = cND * cD * cN * cC * row_blocks_per_channel;
+            tiles_per_row_width = tt::div_up(common_row_width_elements, tile_hw);
+            const uint32_t a_tile_bytes = tile_hw * a.element_size();
+            const uint32_t a_row_width_bytes = common_row_width_elements * a.element_size();
+            reader_stride_size_bytes =
+                (a_row_width_bytes > a_tile_bytes) ? a_tile_bytes : tt::round_up(a_row_width_bytes, a_alignment);
+            const uint32_t c_tile_bytes = tile_hw * c.element_size();
+            const uint32_t c_row_width_bytes = common_row_width_elements * c.element_size();
+            writer_stride_size_bytes =
+                (c_row_width_bytes > c_tile_bytes) ? c_tile_bytes : tt::round_up(c_row_width_bytes, c_alignment);
+            rt_c_num_tiles = total_row_blocks;
+        } else {
+            rt_c_num_tiles = c.physical_volume() / tile_hw;
+        }
+
+        uint32_t c_shard_height{}, c_shard_width{}, num_shards_per_width{};
+
+        CMAKE_UNIQUE_NAMESPACE::ShardShapeGenerator a_shard_shape_generator;
+        CMAKE_UNIQUE_NAMESPACE::ShardShapeGenerator b_shard_shape_generator;
+        CMAKE_UNIQUE_NAMESPACE::ShardShapeGenerator c_shard_shape_generator;
+
+        bool all_same_shard_spec = rt_has_sharding && a.memory_config().is_sharded() && b.has_value() &&
+                                   b->memory_config().is_sharded() && c.memory_config().is_sharded() &&
+                                   shard_specs->a_shard_spec == shard_specs->b_shard_spec &&
+                                   shard_specs->a_shard_spec == shard_specs->c_shard_spec;
+
+        if (rt_has_sharding) {
+            core_group_1 = grid;
+            a_shard_shape_generator = CMAKE_UNIQUE_NAMESPACE::ShardShapeGenerator(shard_specs->a_shard_spec, a);
+            if (b.has_value()) {
+                b_shard_shape_generator = CMAKE_UNIQUE_NAMESPACE::ShardShapeGenerator(shard_specs->b_shard_spec, *b);
+            }
+            c_shard_shape_generator = CMAKE_UNIQUE_NAMESPACE::ShardShapeGenerator(shard_specs->c_shard_spec, c);
+            c_shard_height = shard_specs->c_shard_spec.shape[0] / tile_height;
+            c_shard_width = shard_specs->c_shard_spec.shape[1] / tile_width;
+            num_shards_per_width = CMAKE_UNIQUE_NAMESPACE::get_shards_per_width(
+                shard_specs->c_shard_spec, CMAKE_UNIQUE_NAMESPACE::get_memory_layout(a, b, c));
+
+            if (zero_start_grid) {
+                auto bbox = core_group_1.bounding_box();
+                cores = grid_to_cores_with_noop(
+                    bbox.end_coord.x,
+                    bbox.end_coord.y,
+                    compute_with_storage_grid.x,
+                    compute_with_storage_grid.y,
+                    row_major);
+            } else {
+                cores = grid_to_cores_with_noop(core_group_1, all_device_cores, row_major);
+            }
+        } else if (zero_start_grid) {
+            std::tie(
+                num_cores,
+                all_cores,
+                core_group_1,
+                core_group_2,
+                num_tiles_per_core_group_1,
+                num_tiles_per_core_group_2) =
+                tt::tt_metal::split_work_to_cores(compute_with_storage_grid, rt_c_num_tiles, row_major);
+            cores = grid_to_cores(num_cores_total, compute_with_storage_grid.x, compute_with_storage_grid.y, row_major);
+        } else {
+            std::tie(
+                num_cores,
+                all_cores,
+                core_group_1,
+                core_group_2,
+                num_tiles_per_core_group_1,
+                num_tiles_per_core_group_2) =
+                tt::tt_metal::split_work_to_cores(all_device_cores, rt_c_num_tiles, row_major);
+            cores = corerange_to_cores(all_device_cores, {}, row_major);
+        }
+
+        uint32_t current_block = 0;
+        for (uint32_t i = 0, start_tile_id = 0; i < num_cores_total; i++) {
+            const auto& core = cores[i];
+
+            uint32_t a_num_tiles = 0;
+            uint32_t b_num_tiles = 0;
+            uint32_t c_num_tiles_core = 0;
+            if (core_group_1.contains(core)) {
+                c_num_tiles_core = num_tiles_per_core_group_1;
+            } else if (core_group_2.contains(core)) {
+                c_num_tiles_core = num_tiles_per_core_group_2;
+            } else {
+                // Keep dummy runtime-arg sizes aligned with the active kernel variant so unused cores do not
+                // inflate the per-kernel max runtime-arg allocation.
+                if (row_major_inputs) {
+                    std::array<uint32_t, 26> dummy_reader{0};
+                    reader_desc.runtime_args.emplace_back(
+                        core, KernelDescriptor::CoreRuntimeArgs{dummy_reader.begin(), dummy_reader.end()});
+                    std::array<uint32_t, 14> dummy_writer{0};
+                    writer_desc.runtime_args.emplace_back(
+                        core, KernelDescriptor::CoreRuntimeArgs{dummy_writer.begin(), dummy_writer.end()});
+                } else if (b.has_value()) {
+                    std::array<uint32_t, 21> dummy_reader{0};
+                    reader_desc.runtime_args.emplace_back(
+                        core, KernelDescriptor::CoreRuntimeArgs{dummy_reader.begin(), dummy_reader.end()});
+                    std::array<uint32_t, 11> dummy_writer{0};
+                    writer_desc.runtime_args.emplace_back(
+                        core, KernelDescriptor::CoreRuntimeArgs{dummy_writer.begin(), dummy_writer.end()});
+                } else {
+                    std::array<uint32_t, 21> dummy_reader{0};
+                    reader_desc.runtime_args.emplace_back(
+                        core, KernelDescriptor::CoreRuntimeArgs{dummy_reader.begin(), dummy_reader.end()});
+                    std::array<uint32_t, 12> dummy_writer{0};
+                    writer_desc.runtime_args.emplace_back(
+                        core, KernelDescriptor::CoreRuntimeArgs{dummy_writer.begin(), dummy_writer.end()});
+                }
+                if (op_type == BinaryOpType::ISCLOSE) {
+                    std::array<uint32_t, 5> dummy_compute{0};
+                    compute_desc.runtime_args.emplace_back(
+                        core, KernelDescriptor::CoreRuntimeArgs{dummy_compute.begin(), dummy_compute.end()});
+                } else {
+                    std::array<uint32_t, 4> dummy_compute{0};
+                    compute_desc.runtime_args.emplace_back(
+                        core, KernelDescriptor::CoreRuntimeArgs{dummy_compute.begin(), dummy_compute.end()});
+                }
+                continue;
+            }
+
+            uint32_t c_start_id = 0;
+            uint32_t c_current_shard_width = 0;
+            if (rt_has_sharding) {
+                if (all_same_shard_spec) {
+                    c_num_tiles_core = c_shard_height * c_shard_width;
+                    c_current_shard_width = c_shard_width;
+                    a_num_tiles = c_shard_height * c_shard_width;
+                } else {
+                    auto c_shard_shape = c_shard_shape_generator(core);
+                    c_num_tiles_core = c_shard_shape[0] * c_shard_shape[1];
+                    c_current_shard_width = c_shard_shape[1];
+                    auto a_shard_shape = a_shard_shape_generator(core);
+                    a_num_tiles = a_shard_shape[0] * a_shard_shape[1];
+                }
+                c_start_id =
+                    (i / num_shards_per_width) * (c_shard_height * cWt) + (i % num_shards_per_width) * c_shard_width;
+            } else {
+                c_start_id = start_tile_id;
+            }
+
+            const bool rt_is_quant_op = operation_attributes.is_quant_op;
+            TT_FATAL(
+                rt_is_quant_op == ((operation_attributes.post_activations.size() == 1) &&
+                                   (operation_attributes.post_activations[0].type() ==
+                                    ttnn::operations::unary::UnaryOpType::ZERO_POINT)),
+                "Quantization op needs to exactly one zero-point value as a post activation");
+            const uint32_t quantization_zero_point =
+                rt_is_quant_op ? std::bit_cast<uint32_t>(
+                                     operation_attributes.post_activations[0].get_param_if<float>(0).value_or(0.0f))
+                               : 0u;
+            uint32_t compute_scalar_value = quantization_zero_point;
+
+            uint32_t compute_tiles = row_major_inputs ? (c_num_tiles_core * tiles_per_row_width) : c_num_tiles_core;
+
+            uint32_t packed_scalar_for_reader = 0u;
+            if (b.has_value()) {
+                if (rt_has_sharding) {
+                    if (all_same_shard_spec) {
+                        b_num_tiles = c_shard_height * c_shard_width;
+                    } else {
+                        auto b_shard_shape = b_shard_shape_generator(core);
+                        b_num_tiles = b_shard_shape[0] * b_shard_shape[1];
+                    }
+                }
+                std::vector<uint32_t> writer_runtime_args;
+                if (row_major_inputs) {
+                    writer_runtime_args = {
+                        c.buffer()->address(),
+                        common_row_width_elements,
+                        c_num_tiles_core,
+                        cD,
+                        cN,
+                        cC,
+                        cHt_r,
+                        cND,
+                        current_block,
+                        num_rows_per_tile,
+                        static_cast<uint32_t>(c.buffer()->aligned_page_size()),
+                        c_alignment,
+                        tiles_per_row_width,
+                        writer_stride_size_bytes};
+                } else {
+                    writer_runtime_args = {
+                        c.buffer()->address(),
+                        c_start_id,
+                        c_num_tiles_core,
+                        c_current_shard_width,
+                        cD,
+                        cN,
+                        cC,
+                        cHt,
+                        cWt,
+                        cND,
+                        0u};
+                }
+                writer_desc.runtime_args.emplace_back(
+                    core, KernelDescriptor::CoreRuntimeArgs{writer_runtime_args.begin(), writer_runtime_args.end()});
+
+                auto [freq, counter] = CMAKE_UNIQUE_NAMESPACE::calculate_compute_kernel_args(
+                    operation_attributes.subtile_broadcast_type, c_start_id, cHt, cWt);
+                if (operation_attributes.binary_op_type == BinaryOpType::WHERE_TTS ||
+                    operation_attributes.binary_op_type == BinaryOpType::WHERE_TST) {
+                    compute_scalar_value = pack_scalar_runtime_arg(
+                        operation_attributes.scalar.value(), b.has_value() ? b->dtype() : a.dtype(), false);
+                }
+                if (row_major_inputs) {
+                    freq = 1;
+                    counter = 0;
+                }
+                if (operation_attributes.binary_op_type == BinaryOpType::ISCLOSE) {
+                    const std::array<uint32_t, 5> compute_runtime_args = {
+                        compute_tiles,
+                        freq,
+                        counter,
+                        // rtol and atol are float variables
+                        std::bit_cast<uint32_t>(operation_attributes.rtol),
+                        std::bit_cast<uint32_t>(operation_attributes.atol)};
+                    compute_desc.runtime_args.emplace_back(
+                        core,
+                        KernelDescriptor::CoreRuntimeArgs{compute_runtime_args.begin(), compute_runtime_args.end()});
+                } else {
+                    const std::array<uint32_t, 4> compute_runtime_args = {
+                        compute_tiles, freq, counter, compute_scalar_value};
+                    compute_desc.runtime_args.emplace_back(
+                        core,
+                        KernelDescriptor::CoreRuntimeArgs{compute_runtime_args.begin(), compute_runtime_args.end()});
+                }
+            } else {
+                const auto scalar = *operation_attributes.scalar;
+                const auto packed_scalar = pack_scalar_runtime_arg(scalar, a.dtype(), rt_is_quant_op);
+                packed_scalar_for_reader = packed_scalar;
+                std::vector<uint32_t> writer_runtime_args;
+                if (row_major_inputs) {
+                    writer_runtime_args = {
+                        c.buffer()->address(),
+                        common_row_width_elements,
+                        c_num_tiles_core,
+                        cD,
+                        cN,
+                        cC,
+                        cHt_r,
+                        cND,
+                        current_block,
+                        num_rows_per_tile,
+                        static_cast<uint32_t>(c.buffer()->aligned_page_size()),
+                        c_alignment,
+                        tiles_per_row_width,
+                        writer_stride_size_bytes};
+                } else {
+                    writer_runtime_args = {
+                        packed_scalar,
+                        c.buffer()->address(),
+                        c_start_id,
+                        c_num_tiles_core,
+                        c_current_shard_width,
+                        cD,
+                        cN,
+                        cC,
+                        cHt,
+                        cWt,
+                        cND,
+                        0u};
+                }
+                writer_desc.runtime_args.emplace_back(
+                    core, KernelDescriptor::CoreRuntimeArgs{writer_runtime_args.begin(), writer_runtime_args.end()});
+
+                std::array compute_runtime_args = {compute_tiles, 0u, 0u, compute_scalar_value};
+                compute_desc.runtime_args.emplace_back(
+                    core, KernelDescriptor::CoreRuntimeArgs{compute_runtime_args.begin(), compute_runtime_args.end()});
+            }
+            std::vector<uint32_t> reader_runtime_args;
+
+            if (row_major_inputs) {
+                const uint32_t b_addr = b.has_value() ? b->buffer()->address() : 0u;
+                const uint32_t b_page_size = b.has_value() ? static_cast<uint32_t>(b->buffer()->aligned_page_size())
+                                                           : static_cast<uint32_t>(a.buffer()->aligned_page_size());
+                const uint32_t bD_arg = b.has_value() ? bD : 1u;
+                const uint32_t bN_arg = b.has_value() ? bN : 1u;
+                const uint32_t bC_arg = b.has_value() ? bC : 1u;
+                const uint32_t bHt_r_arg = b.has_value() ? bHt_r : 1u;
+                reader_runtime_args = {
+                    a.buffer()->address(),
+                    c_num_tiles_core,
+                    aD,
+                    aN,
+                    aC,
+                    aHt_r,
+                    aND,
+                    b_addr,
+                    bD_arg,
+                    bN_arg,
+                    bC_arg,
+                    bHt_r_arg,
+                    bND,
+                    cHt_r,
+                    cC,
+                    cND,
+                    current_block,
+                    num_rows_per_tile,
+                    common_row_width_elements,
+                    static_cast<uint32_t>(a.buffer()->aligned_page_size()),
+                    b_page_size,
+                    a_alignment,
+                    b_alignment,
+                    tiles_per_row_width,
+                    reader_stride_size_bytes,
+                    packed_scalar_for_reader};
+            } else {
+                reader_runtime_args = {
+                    a.buffer()->address(),
+                    c_start_id,
+                    a_num_tiles,
+                    c_num_tiles_core,
+                    c_current_shard_width,
+                    aHt * aWt * aC * aN * aD * (aND > 1),
+                    aHt * aWt * aC * aN * (aD > 1),
+                    aHt * aWt * aC * (aN > 1),
+                    aHt * aWt * (aC > 1),
+                    cD,
+                    cN,
+                    cC,
+                    cHt,
+                    cWt,
+                    cND,
+                    b.has_value() ? b->buffer()->address() : 0u,
+                    bHt * bWt * bC * bN * bD * (bND > 1),
+                    bHt * bWt * bC * bN * (bD > 1),
+                    bHt * bWt * bC * (bN > 1),
+                    bHt * bWt * (bC > 1),
+                    b_num_tiles,
+                };
+            }
+
+            reader_desc.runtime_args.emplace_back(
+                core, KernelDescriptor::CoreRuntimeArgs{reader_runtime_args.begin(), reader_runtime_args.end()});
+
+            start_tile_id += c_num_tiles_core;
+            if (row_major_inputs) {
+                current_block += c_num_tiles_core;
+            }
+        }
+    }
+
+    // Push kernel descriptors: reader (index 0), writer (index 1), compute (index 2)
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
+    return desc;
+}
+
+}  // namespace ttnn::operations::experimental::quasar::binary_ng

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_utils.cpp
@@ -1,0 +1,887 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "binary_ng_utils.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
+#include <tt-metalium/hal.hpp>
+#include <tt_stl/assert.hpp>
+
+#include <fmt/core.h>
+#include <fmt/format.h>
+#include <enchantum/enchantum.hpp>
+
+namespace ttnn::operations::experimental::quasar::binary_ng {
+
+struct Lowercase {
+    std::string_view view;
+};
+
+}  // namespace ttnn::operations::experimental::quasar::binary_ng
+
+template <>
+struct fmt::formatter<ttnn::operations::experimental::quasar::binary_ng::Lowercase> : fmt::formatter<std::string_view> {
+    auto format(
+        const ttnn::operations::experimental::quasar::binary_ng::Lowercase& value, fmt::format_context& ctx) const {
+        auto out = ctx.out();
+        for (char c : value.view) {
+            *out++ = std::tolower(static_cast<unsigned char>(c));
+        }
+        return out;
+    }
+};
+
+namespace ttnn::operations::experimental::quasar::binary_ng {
+
+BinaryNgKernelConfig::BinaryNgKernelConfig(SubtileBroadcastType subtile_broadcast_type) {
+    switch (subtile_broadcast_type) {
+        case SubtileBroadcastType::NONE:
+            reader_kernel = KernelName::ReaderNoBcast;
+            compute_kernel = KernelName::ComputeNoBcast;
+            writer_kernel = KernelName::WriterScalar;
+            bcast_input = std::nullopt;
+            break;
+
+        case SubtileBroadcastType::SCALAR_A:;
+            compute_kernel = KernelName::ComputeBcast;
+            bcast_input = 0;
+            break;
+
+        case SubtileBroadcastType::SCALAR_B:
+            compute_kernel = KernelName::ComputeBcast;
+            bcast_input = 1;
+            break;
+
+        case SubtileBroadcastType::ROW_A:
+        case SubtileBroadcastType::ROW_B:
+            compute_kernel = KernelName::ComputeNoBcast;
+            bcast_input = std::nullopt;
+            break;
+
+        case SubtileBroadcastType::COL_A:
+        case SubtileBroadcastType::ROW_B_COL_A:
+            compute_kernel = KernelName::ComputeBcast;
+            bcast_input = 0;
+            break;
+
+        case SubtileBroadcastType::COL_B:
+        case SubtileBroadcastType::ROW_A_COL_B:
+            compute_kernel = KernelName::ComputeBcast;
+            bcast_input = 1;
+            break;
+    }
+}
+
+std::string BinaryNgKernelConfig::bcast_input_str() const {
+    if (bcast_input.has_value()) {
+        return std::to_string(*bcast_input);
+    }
+    return "";
+}
+
+std::string get_kernel_file_path(KernelName kernel_name, bool is_sfpu, bool is_where_op) {
+    constexpr std::string_view root = "ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels";
+    constexpr std::string_view root_ng = "ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng";
+    constexpr std::string_view dataflow = "{}/dataflow/{}";
+    constexpr std::string_view compute = "{}/compute/{}";
+
+    switch (kernel_name) {
+        case KernelName::ReaderNoBcastNg: return fmt::format(dataflow, root_ng, "reader_interleaved_no_bcast.cpp");
+        case KernelName::ReaderRowBcastNg: return fmt::format(dataflow, root_ng, "reader_interleaved_row_bcast.cpp");
+        case KernelName::ReaderColBcastNg: return fmt::format(dataflow, root_ng, "reader_interleaved_col_bcast.cpp");
+        case KernelName::ReaderRowBColABcastNg:
+            return fmt::format(dataflow, root_ng, "reader_interleaved_row_col_mixed_bcast.cpp");
+        case KernelName::ReaderScalarBcastNg:
+            return fmt::format(dataflow, root_ng, "reader_interleaved_scalar_bcast.cpp");
+        case KernelName::ReaderRmNoBcastNg: return fmt::format(dataflow, root_ng, "reader_interleaved_rm_no_bcast.cpp");
+        case KernelName::ReaderRmRowBcastNg:
+            return fmt::format(dataflow, root_ng, "reader_interleaved_rm_row_bcast.cpp");
+        case KernelName::ReaderRmColBcastNg:
+            return fmt::format(dataflow, root_ng, "reader_interleaved_rm_col_bcast.cpp");
+        case KernelName::ReaderRmRowBColABcastNg:
+            return fmt::format(dataflow, root_ng, "reader_interleaved_rm_row_col_mixed_bcast.cpp");
+        case KernelName::ReaderRmScalarBcastNg:
+            return fmt::format(dataflow, root_ng, "reader_interleaved_rm_scalar_bcast.cpp");
+        case KernelName::ReaderRmScalarOpNg:
+            return fmt::format(dataflow, root_ng, "reader_interleaved_rm_scalar_op.cpp");
+        case KernelName::WriterRmNoBcastNg: return fmt::format(dataflow, root_ng, "writer_interleaved_rm_no_bcast.cpp");
+        case KernelName::WriterNoBcastNg: return fmt::format(dataflow, root_ng, "writer_interleaved_no_bcast.cpp");
+        case KernelName::ReaderNoBcast: return fmt::format(dataflow, root, "reader_interleaved_no_bcast.cpp");
+        case KernelName::WriterScalar: return fmt::format(dataflow, root, "writer_interleaved_scalar.cpp");
+        case KernelName::ComputeNoBcast:
+            return fmt::format(
+                compute,
+                root,
+                is_where_op ? "eltwise_where_no_bcast.cpp"
+                            : (is_sfpu ? "eltwise_binary_sfpu_no_bcast.cpp" : "eltwise_binary_no_bcast.cpp"));
+        case KernelName::ComputeBcast:
+            return fmt::format(
+                compute,
+                root,
+                is_where_op ? "eltwise_where_sfpu.cpp" : (is_sfpu ? "eltwise_binary_sfpu.cpp" : "eltwise_binary.cpp"));
+        case KernelName::ComputeScalar:
+            return fmt::format(
+                compute,
+                root,
+                is_where_op ? "eltwise_where_sfpu_scalar"
+                            : (is_sfpu ? "eltwise_binary_sfpu_scalar.cpp" : "eltwise_binary_scalar.cpp"));
+        case KernelName::ComputeRowBcastNg:
+            return fmt::format(
+                compute,
+                root_ng,
+                is_where_op ? "eltwise_where_sfpu_row_bcast.cpp"
+                            : (is_sfpu ? "eltwise_binary_sfpu_row_bcast.cpp" : "eltwise_binary_row_bcast.cpp"));
+        case KernelName::ComputeColBcastNg:
+            return fmt::format(
+                compute, root_ng, is_sfpu ? "eltwise_binary_sfpu_col_bcast.cpp" : "eltwise_binary_col_bcast.cpp");
+        case KernelName::ComputeScalarBcastNg:
+            return fmt::format(
+                compute, root_ng, is_sfpu ? "eltwise_binary_sfpu_scalar_bcast.cpp" : "eltwise_binary_scalar_bcast.cpp");
+        case KernelName::ComputeRowColBcastNg:
+            return fmt::format(
+                compute,
+                root_ng,
+                is_where_op ? "eltwise_where_sfpu_row_col_bcast.cpp"
+                            : (is_sfpu ? "eltwise_binary_sfpu_row_col_bcast.cpp" : "eltwise_binary_row_col_bcast.cpp"));
+        default: __builtin_unreachable();  // GCC 12 doesn't compile even though we exhaustively match
+    }
+}
+
+//  EnumT can either be FpuBinaryOp or SfpuBinaryOp
+template <class EnumT>
+OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<EnumT>, std::optional<DataType> dtype) :
+    binary_op(EnumT::SUB) {
+    switch (binary_op_type) {
+        case BinaryOpType::ADD: binary_op = EnumT::ADD; break;
+        case BinaryOpType::SUB: break;
+        case BinaryOpType::MUL: binary_op = EnumT::MUL; break;
+        case BinaryOpType::DIV:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::DIV;
+            } else {
+                process_rhs = unary::UnaryOpType::RECIP;
+                binary_op = FpuBinaryOp::MUL;
+            }
+            break;
+        case BinaryOpType::DIV_FLOOR: binary_op = SfpuBinaryOp::DIV_FLOOR; break;
+        case BinaryOpType::DIV_TRUNC: binary_op = SfpuBinaryOp::DIV_TRUNC; break;
+        case BinaryOpType::REMAINDER: binary_op = SfpuBinaryOp::REMAINDER; break;
+        case BinaryOpType::FMOD: binary_op = SfpuBinaryOp::FMOD; break;
+        // b - a
+        case BinaryOpType::RSUB:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::RSUB;
+            } else {
+                process_lhs = unary::UnaryOpType::NEG;
+                binary_op = FpuBinaryOp::ADD;
+            }
+            break;
+        case BinaryOpType::LT:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::LT;
+            } else {
+                postprocess = unary::UnaryOpType::LTZ;
+            }
+            break;
+        case BinaryOpType::GT:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::GT;
+            } else {
+                postprocess = unary::UnaryOpType::GTZ;
+            }
+            break;
+        case BinaryOpType::GE:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::GE;
+            } else {
+                postprocess = unary::UnaryOpType::GEZ;
+            }
+            break;
+        case BinaryOpType::LE:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::LE;
+            } else {
+                postprocess = unary::UnaryOpType::LEZ;
+            }
+            break;
+        case BinaryOpType::EQ:
+            if (is_sfpu_op() && (dtype == DataType::FLOAT32 || dtype == DataType::BFLOAT16)) {
+                binary_op = SfpuBinaryOp::EQ;
+            } else {
+                postprocess = unary::UnaryOpType::EQZ;
+            }
+            break;
+        case BinaryOpType::NE:
+            if (is_sfpu_op() && (dtype == DataType::FLOAT32 || dtype == DataType::BFLOAT16)) {
+                binary_op = SfpuBinaryOp::NE;
+            } else {
+                postprocess = unary::UnaryOpType::NEZ;
+            }
+            break;
+        // (a-b)**2
+        case BinaryOpType::SQUARED_DIFFERENCE: postprocess = unary::UnaryOpType::SQUARE; break;
+        // gelu(a+b)
+        case BinaryOpType::BIAS_GELU:
+            binary_op = EnumT::ADD;
+            postprocess = unary::UnaryOpType::GELU;
+            break;
+        case BinaryOpType::LOGICAL_AND:
+            process_lhs = unary::UnaryOpType::NEZ;
+            process_rhs = unary::UnaryOpType::NEZ;
+            binary_op = EnumT::MUL;
+            postprocess = unary::UnaryOpType::NEZ;
+            break;
+        case BinaryOpType::LOGICAL_OR:
+            process_lhs = unary::UnaryOpType::NEZ;
+            process_rhs = unary::UnaryOpType::NEZ;
+            binary_op = EnumT::ADD;
+            postprocess = unary::UnaryOpType::NEZ;
+            break;
+        case BinaryOpType::LOGICAL_XOR:
+            process_lhs = unary::UnaryOpType::NEZ;
+            process_rhs = unary::UnaryOpType::NEZ;
+            postprocess = unary::UnaryOpType::NEZ;
+            break;
+        // a * (2**b)
+        case BinaryOpType::LDEXP:
+            process_rhs = unary::UnaryOpType::EXP2;
+            binary_op = EnumT::MUL;
+            break;
+        // log( exp(a) + exp(b) )
+        case BinaryOpType::LOGADDEXP:
+            process_lhs = unary::UnaryOpType::EXP;
+            process_rhs = unary::UnaryOpType::EXP;
+            binary_op = EnumT::ADD;
+            postprocess = unary::UnaryOpType::LOG;
+            break;
+        // log2( 2**a + 2**b )
+        case BinaryOpType::LOGADDEXP2:
+            process_lhs = unary::UnaryOpType::EXP2;
+            process_rhs = unary::UnaryOpType::EXP2;
+            binary_op = EnumT::ADD;
+            postprocess = unary::UnaryOpType::LOG2;
+            break;
+        case BinaryOpType::BITWISE_AND:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::BITWISE_AND;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
+            break;
+        case BinaryOpType::BITWISE_OR:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::BITWISE_OR;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
+            break;
+        case BinaryOpType::BITWISE_XOR:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::BITWISE_XOR;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
+            break;
+        case BinaryOpType::LEFT_SHIFT:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::LEFT_SHIFT;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
+            break;
+        case BinaryOpType::RIGHT_SHIFT:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::RIGHT_SHIFT;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
+            break;
+        case BinaryOpType::LOGICAL_RIGHT_SHIFT:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::LOGICAL_RIGHT_SHIFT;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
+            break;
+        case BinaryOpType::POWER:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::POWER;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
+            break;
+        case BinaryOpType::QUANT:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::QUANT;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
+            break;
+        case BinaryOpType::REQUANT:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::REQUANT;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
+            break;
+        case BinaryOpType::DEQUANT:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::DEQUANT;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
+            break;
+        case BinaryOpType::MAXIMUM:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::MAXIMUM;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
+            break;
+        case BinaryOpType::MINIMUM:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::MINIMUM;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
+            break;
+        case BinaryOpType::GCD:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::GCD;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
+            break;
+        case BinaryOpType::LCM:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::LCM;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
+            break;
+        case BinaryOpType::XLOGY:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::XLOGY;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
+            break;
+        case BinaryOpType::ATAN2:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::ATAN2;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
+            break;
+        case BinaryOpType::WHERE_TTS:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::WHERE;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
+            break;
+        case BinaryOpType::WHERE_TST:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::WHERE;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
+            break;
+        // sqrt(a^2 + b^2)
+        case BinaryOpType::HYPOT:
+            process_lhs = unary::UnaryOpType::SQUARE;
+            process_rhs = unary::UnaryOpType::SQUARE;
+            binary_op = EnumT::ADD;
+            postprocess = unary::UnaryOpType::SQRT;
+            break;
+        case BinaryOpType::ISCLOSE: binary_op = SfpuBinaryOp::ISCLOSE; break;
+        default: TT_THROW("Unsupported binary op {}", binary_op_type);
+    }
+}
+
+std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu_binary_op, DataType dtype) {
+    using enum OpConfig::SfpuBinaryOp;
+
+    std::optional<std::string> int_data_format;
+    if (dtype == DataType::INT32 || dtype == DataType::UINT32 || dtype == DataType::UINT16) {
+        int_data_format = (dtype == DataType::INT32) ? "Int32" : (dtype == DataType::UINT32) ? "UInt32" : "UInt16";
+    }
+    switch (sfpu_binary_op) {
+        case ADD:
+            if (int_data_format) {
+                return {"add_int_tile_init();", fmt::format("add_int_tile<DataFormat::{}>", *int_data_format)};
+            }
+            return {"add_binary_tile_init();", "add_binary_tile"};
+        case SUB:
+            if (int_data_format) {
+                return {"sub_int_tile_init();", fmt::format("sub_int_tile<DataFormat::{}>", *int_data_format)};
+            }
+            return {"sub_binary_tile_init();", "sub_binary_tile"};
+        case MUL:
+            if (int_data_format) {
+                return {
+                    fmt::format("mul_int_tile_init<DataFormat::{}>();", *int_data_format),
+                    fmt::format("mul_int_tile<DataFormat::{}>", *int_data_format)};
+            }
+            return {"mul_binary_tile_init();", "mul_binary_tile"};
+        case DIV:
+            if (dtype == DataType::INT32) {
+                return {"div_int32_tile_init();", "div_int32_tile"};
+            } else {
+                return {"div_binary_tile_init();", "div_binary_tile"};
+            }
+        case DIV_FLOOR: return {"div_int32_floor_tile_init();", "div_int32_floor_tile"};
+        case DIV_TRUNC: return {"div_int32_trunc_tile_init();", "div_int32_trunc_tile"};
+        case REMAINDER:
+            if (dtype == DataType::UINT32 || dtype == DataType::UINT16 || dtype == DataType::UINT8) {
+                TT_THROW("Unsupported data type for remainder {}", dtype);
+            } else if (dtype == DataType::INT32) {
+                return {"remainder_int32_tile_init();", "remainder_int32_tile"};
+            } else {
+                return {"remainder_binary_tile_init();", "remainder_binary_tile"};
+            }
+        case FMOD:
+            if (dtype == DataType::INT32) {
+                return {"fmod_int32_tile_init();", "fmod_int32_tile"};
+            } else {
+                return {"fmod_binary_tile_init();", "fmod_binary_tile"};
+            }
+        case POWER: return {"power_binary_tile_init();", "power_binary_tile"};
+        case RSUB:
+            if (int_data_format) {
+                return {"rsub_int_tile_init();", fmt::format("rsub_int_tile<DataFormat::{}>", *int_data_format)};
+            }
+            return {"rsub_binary_tile_init();", "rsub_binary_tile"};
+        case GCD: return {"gcd_tile_init();", "gcd_tile"};
+        case LCM: return {"lcm_tile_init();", "lcm_tile"};
+        case LEFT_SHIFT:
+            return {
+                "binary_shift_tile_init();",
+                fmt::format("binary_left_shift_tile<DataFormat::{}>", int_data_format.value_or("Int32"))};
+        case RIGHT_SHIFT:
+            return {
+                "binary_shift_tile_init();",
+                fmt::format("binary_right_shift_tile<DataFormat::{}>", int_data_format.value_or("Int32"))};
+        case LOGICAL_RIGHT_SHIFT:
+            return {
+                "binary_shift_tile_init();",
+                fmt::format("binary_logical_right_shift_tile<DataFormat::{}>", int_data_format.value_or("Int32"))};
+        case BITWISE_AND:
+            return {
+                "binary_bitwise_tile_init();",
+                fmt::format("bitwise_and_binary_tile<DataFormat::{}>", int_data_format.value_or("UInt16"))};
+        case BITWISE_OR:
+            return {
+                "binary_bitwise_tile_init();",
+                fmt::format("bitwise_or_binary_tile<DataFormat::{}>", int_data_format.value_or("UInt16"))};
+        case BITWISE_XOR:
+            return {
+                "binary_bitwise_tile_init();",
+                fmt::format("bitwise_xor_binary_tile<DataFormat::{}>", int_data_format.value_or("UInt16"))};
+        case MAXIMUM:
+            if (dtype == DataType::INT32) {
+                return {"binary_max_int32_tile_init();", "binary_max_int32_tile"};
+            } else if (dtype == DataType::UINT32) {
+                return {"binary_max_uint32_tile_init();", "binary_max_uint32_tile"};
+            } else {
+                return {"binary_max_tile_init();", "binary_max_tile"};
+            }
+        case MINIMUM:
+            if (dtype == DataType::INT32) {
+                return {"binary_min_int32_tile_init();", "binary_min_int32_tile"};
+            } else if (dtype == DataType::UINT32) {
+                return {"binary_min_uint32_tile_init();", "binary_min_uint32_tile"};
+            } else {
+                return {"binary_min_tile_init();", "binary_min_tile"};
+            }
+        case QUANT: return {"quant_tile_init(get_arg_val<uint32_t>(QUANT_ZERO_POINT_RT_ARGS_IDX));", "quant_tile"};
+        case REQUANT:
+            return {"requant_tile_init(get_arg_val<uint32_t>(QUANT_ZERO_POINT_RT_ARGS_IDX));", "requant_tile"};
+        case DEQUANT:
+            return {"dequant_tile_init(get_arg_val<uint32_t>(QUANT_ZERO_POINT_RT_ARGS_IDX));", "dequant_tile"};
+        case XLOGY: return {"xlogy_binary_tile_init();", "xlogy_binary_tile"};
+        case ATAN2: return {"atan2_binary_tile_init();", "atan2_binary_tile"};
+        case LT:
+            if (int_data_format) {
+                return {
+                    fmt::format("lt_int_tile_init<DataFormat::{}>();", *int_data_format),
+                    fmt::format("lt_int_tile<DataFormat::{}>", *int_data_format)};
+            }
+            return {"lt_binary_tile_init();", "lt_binary_tile"};
+        case GT:
+            if (int_data_format) {
+                return {
+                    fmt::format("gt_int_tile_init<DataFormat::{}>();", *int_data_format),
+                    fmt::format("gt_int_tile<DataFormat::{}>", *int_data_format)};
+            }
+            return {"gt_binary_tile_init();", "gt_binary_tile"};
+        case GE:
+            if (int_data_format) {
+                return {
+                    fmt::format("ge_int_tile_init<DataFormat::{}>();", *int_data_format),
+                    fmt::format("ge_int_tile<DataFormat::{}>", *int_data_format)};
+            }
+            return {"ge_binary_tile_init();", "ge_binary_tile"};
+        case LE:
+            if (int_data_format) {
+                return {
+                    fmt::format("le_int_tile_init<DataFormat::{}>();", *int_data_format),
+                    fmt::format("le_int_tile<DataFormat::{}>", *int_data_format)};
+            }
+            return {"le_binary_tile_init();", "le_binary_tile"};
+        case EQ:
+            if (dtype == DataType::FLOAT32 || dtype == DataType::BFLOAT16) {
+                return {"eq_binary_tile_init();", "eq_binary_tile"};
+            }
+            TT_THROW("SFPU EQ binary tile is only defined for Float32");
+        case NE:
+            if (dtype == DataType::FLOAT32 || dtype == DataType::BFLOAT16) {
+                return {"ne_binary_tile_init();", "ne_binary_tile"};
+            }
+            TT_THROW("SFPU NE binary tile is only defined for Float32");
+        case WHERE: {
+            const char* data_format = (dtype == DataType::INT32)     ? "Int32"
+                                      : (dtype == DataType::UINT32)  ? "UInt32"
+                                      : (dtype == DataType::FLOAT32) ? "Float32"
+                                                                     : "Float16_b";
+            return {"where_tile_init();", fmt::format("where_tile<DataFormat::{}>", data_format)};
+        }
+        case ISCLOSE: return {"isclose_binary_tile_init();", "isclose_binary_tile<(bool)ISCLOSE_EQUAL_NAN>"};
+        default: TT_THROW("Unsupported sfpu binary op {}", sfpu_binary_op);
+    }
+}
+
+std::map<std::string, std::string> OpConfig::as_defines(DataType dtype) const {
+    std::map<std::string, std::string> defines;
+
+    if (!is_sfpu_op()) {
+        auto fpu_binary_op = std::get<FpuBinaryOp>(binary_op);
+        auto binary_op_str = enchantum::to_string(fpu_binary_op);
+        defines["BINARY_OP"] = fmt::format("{}_tiles", Lowercase{binary_op_str});
+        defines["BINARY_OP_TYPE"] = fmt::format("EltwiseBinaryType::ELW{}", binary_op_str);
+        return defines;
+    }
+    auto&& [tile_init, tile_fn] = get_sfpu_init_fn(std::get<SfpuBinaryOp>(binary_op), dtype);
+    defines["BINARY_SFPU_INIT"] = std::move(tile_init);
+    defines["BINARY_SFPU_OP"] = std::move(tile_fn);
+    return defines;
+}
+
+void add_activation_defines(
+    std::map<std::string, std::string>& defines,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> activations,
+    std::string_view operand,
+    std::optional<DataType> dtype) {
+    defines[fmt::format("PROCESS_{}_ACTIVATIONS(i)", operand)] = std::accumulate(
+        activations.begin(),
+        activations.end(),
+        std::string{},
+        [&](std::string&& process, const unary::EltwiseUnaryWithParam& a) {
+            const auto& [op_init, op_func] = std::visit(
+                [&](auto params) { return unary::utils::get_op_init_and_func(a.type(), params, "i", dtype); },
+                a.get_params());
+            process += op_init;
+            process += op_func;
+            unary::utils::update_macro_defines(a.type(), defines);
+            return std::move(process);
+        });
+}
+
+std::map<std::string, std::string> make_dataflow_defines(
+    const DataType dtype, const std::optional<DataType> b_dtype_opt) {
+    std::map<std::string, std::string> defines;
+    const auto b_dtype = b_dtype_opt.value_or(dtype);
+    // to maintain backward compatibility, we need to support both dtype and b_dtype
+    if (dtype == DataType::FLOAT32) {
+        defines["FILL_TILE_WITH_FIRST_COLUMN"] = "fill_tile_with_first_column";
+        defines["FILL_TILE_WITH_FIRST_COLUMN_RM"] = "fill_tile_with_first_column_rm";
+        defines["FILL_TILE_WITH_FIRST_ROW_RM"] = "fill_tile_with_first_row_rm";
+        defines["FILL_TILE_WITH_FIRST_ROW"] = "fill_tile_with_first_row";
+        defines["FILL_TILE_WITH_FIRST_ELEMENT"] = "fill_tile_with_first_element<float>";
+        defines["FILL_WITH_VALUE_FLOAT"] = "fill_with_val<1024, float>";
+    } else if (dtype == DataType::INT32) {
+        defines["FILL_TILE_WITH_FIRST_COLUMN_RM"] = "fill_tile_with_first_column_rm";
+        defines["FILL_TILE_WITH_FIRST_ROW_RM"] = "fill_tile_with_first_row_rm";
+        defines["FILL_TILE_WITH_FIRST_COLUMN"] = "fill_tile_with_first_column";
+        defines["FILL_TILE_WITH_FIRST_ROW"] = "fill_tile_with_first_row";
+        defines["FILL_TILE_WITH_FIRST_ELEMENT"] = "fill_tile_with_first_element<int32_t>";
+        defines["FILL_WITH_VALUE"] = "fill_with_val<1024, int32_t>";
+    } else if (dtype == DataType::UINT32) {
+        defines["FILL_TILE_WITH_FIRST_COLUMN_RM"] = "fill_tile_with_first_column_rm";
+        defines["FILL_TILE_WITH_FIRST_ROW_RM"] = "fill_tile_with_first_row_rm";
+        defines["FILL_TILE_WITH_FIRST_COLUMN"] = "fill_tile_with_first_column";
+        defines["FILL_TILE_WITH_FIRST_ROW"] = "fill_tile_with_first_row";
+        defines["FILL_TILE_WITH_FIRST_ELEMENT"] = "fill_tile_with_first_element<uint32_t>";
+        defines["FILL_WITH_VALUE"] = "fill_with_val<1024, uint32_t>";
+    } else if (dtype == DataType::BFLOAT8_B) {
+        defines["FILL_TILE_WITH_FIRST_COLUMN"] = "fill_tile_with_first_column_bfp8";
+        defines["FILL_TILE_WITH_FIRST_ROW"] = "fill_tile_with_first_row_bfp8";
+        defines["FILL_TILE_WITH_FIRST_ELEMENT"] = "fill_tile_with_first_element_bfp8";
+        defines["FILL_WITH_VALUE"] = "fill_with_val_bfloat16";
+    } else if (dtype == DataType::BFLOAT4_B) {
+        defines["FILL_TILE_WITH_FIRST_COLUMN"] = "fill_tile_with_first_column_bfp4";
+        defines["FILL_TILE_WITH_FIRST_ROW"] = "fill_tile_with_first_row_bfp4";
+        defines["FILL_TILE_WITH_FIRST_ELEMENT"] = "fill_tile_with_first_element_bfp4";
+        defines["FILL_WITH_VALUE"] = "fill_with_val_bfloat16";
+    } else {
+        defines["FILL_TILE_WITH_FIRST_COLUMN_RM"] = "fill_tile_with_first_column_rm_bfloat16";
+        defines["FILL_TILE_WITH_FIRST_ROW_RM"] = "fill_tile_with_first_row_rm_bfloat16";
+        defines["FILL_TILE_WITH_FIRST_COLUMN"] = "fill_tile_with_first_column_bfloat16";
+        defines["FILL_TILE_WITH_FIRST_ROW"] = "fill_tile_with_first_row_bfloat16";
+        defines["FILL_TILE_WITH_FIRST_ELEMENT"] = "fill_tile_with_first_element_bfloat16";
+        defines["FILL_WITH_VALUE"] = "fill_with_val_bfloat16";
+    }
+
+    if (b_dtype == DataType::FLOAT32) {
+        defines["FILL_TILE_WITH_FIRST_COLUMN_B"] = "fill_tile_with_first_column";
+        defines["FILL_TILE_WITH_FIRST_ROW_B"] = "fill_tile_with_first_row";
+        defines["FILL_TILE_WITH_FIRST_ELEMENT_B"] = "fill_tile_with_first_element<float>";
+        defines["FILL_WITH_VALUE_FLOAT_B"] = "fill_with_val<1024, float>";
+    } else if (b_dtype == DataType::INT32) {
+        defines["FILL_TILE_WITH_FIRST_COLUMN_B"] = "fill_tile_with_first_column";
+        defines["FILL_TILE_WITH_FIRST_ROW_B"] = "fill_tile_with_first_row";
+        defines["FILL_TILE_WITH_FIRST_ELEMENT_B"] = "fill_tile_with_first_element<int32_t>";
+        defines["FILL_WITH_VALUE_B"] = "fill_with_val<1024, int32_t>";
+    } else if (b_dtype == DataType::UINT32) {
+        defines["FILL_TILE_WITH_FIRST_COLUMN_B"] = "fill_tile_with_first_column";
+        defines["FILL_TILE_WITH_FIRST_ROW_B"] = "fill_tile_with_first_row";
+        defines["FILL_TILE_WITH_FIRST_ELEMENT_B"] = "fill_tile_with_first_element<uint32_t>";
+        defines["FILL_WITH_VALUE_B"] = "fill_with_val<1024, uint32_t>";
+    } else if (b_dtype == DataType::BFLOAT8_B) {
+        defines["FILL_TILE_WITH_FIRST_COLUMN_B"] = "fill_tile_with_first_column_bfp8";
+        defines["FILL_TILE_WITH_FIRST_ROW_B"] = "fill_tile_with_first_row_bfp8";
+        defines["FILL_TILE_WITH_FIRST_ELEMENT_B"] = "fill_tile_with_first_element_bfp8";
+        defines["FILL_WITH_VALUE_B"] = "fill_with_val_bfloat16";
+    } else if (b_dtype == DataType::BFLOAT4_B) {
+        defines["FILL_TILE_WITH_FIRST_COLUMN_B"] = "fill_tile_with_first_column_bfp4";
+        defines["FILL_TILE_WITH_FIRST_ROW_B"] = "fill_tile_with_first_row_bfp4";
+        defines["FILL_TILE_WITH_FIRST_ELEMENT_B"] = "fill_tile_with_first_element_bfp4";
+        defines["FILL_WITH_VALUE_B"] = "fill_with_val_bfloat16";
+    } else {
+        defines["FILL_TILE_WITH_FIRST_COLUMN_B"] = "fill_tile_with_first_column_bfloat16";
+        defines["FILL_TILE_WITH_FIRST_ROW_B"] = "fill_tile_with_first_row_bfloat16";
+        defines["FILL_TILE_WITH_FIRST_ELEMENT_B"] = "fill_tile_with_first_element_bfloat16";
+        defines["FILL_WITH_VALUE_B"] = "fill_with_val_bfloat16";
+    }
+    return defines;
+}
+
+bool OpConfig::is_sfpu_op() const { return std::holds_alternative<SfpuBinaryOp>(binary_op); }
+
+uint32_t pack_scalar_runtime_arg(const unary::ScalarVariant scalar, const DataType dtype, const bool is_quant_op) {
+    // std::visit([&](auto v) {
+    //     std::cout << "pack_scalar_runtime_arg: " << v << std::endl;
+    // }, scalar);
+    return std::visit(
+        [&](auto v) -> uint32_t {
+            // Always pass the more accurate fp32 when the quantization scale is passed as a scalar
+            if ((dtype == DataType::FLOAT32) || is_quant_op) {
+                return std::bit_cast<uint32_t>(static_cast<float>(v));
+            }
+            if (dtype == DataType::INT32) {
+                return std::bit_cast<uint32_t>(static_cast<int32_t>(v));
+            }
+            if (dtype == DataType::UINT32) {
+                return static_cast<uint32_t>(v);
+            }
+            if (dtype == DataType::UINT16) {
+                auto val = static_cast<uint16_t>(static_cast<float>(v));
+                return (static_cast<uint32_t>(val) << 16) | val;
+            }
+            auto scalar_bf16 = bfloat16(static_cast<float>(v));
+            return pack_two_bfloat16_into_uint32({scalar_bf16, scalar_bf16});
+        },
+        scalar);
+}
+
+template OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<FpuBinaryOp>, std::optional<DataType>);
+template OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<SfpuBinaryOp>, std::optional<DataType>);
+
+tt::tt_metal::ShardSpec adjust_to_shape(
+    const tt::tt_metal::ShardSpec& shard_spec, const ttnn::Shape& from_shape, const ttnn::Shape& to_shape) {
+    auto ret = shard_spec;
+
+    // Calculate volume of all dimensions EXCEPT the last (width)
+    // This is the "collapsed height" for sharding purposes
+    uint32_t from_volume_except_width = 1;
+    uint32_t to_volume_except_width = 1;
+
+    const auto from_rank = static_cast<int>(from_shape.rank());
+    const auto to_rank = static_cast<int>(to_shape.rank());
+
+    for (int i = 0; i < from_rank - 1; ++i) {
+        from_volume_except_width *= from_shape[i];
+    }
+
+    for (int i = 0; i < to_rank - 1; ++i) {
+        to_volume_except_width *= to_shape[i];
+    }
+
+    // Get width dimensions
+    uint32_t from_width = from_shape[-1];
+    uint32_t to_width = to_shape[-1];
+
+    // Adjust shard shape based on full volume ratios
+    TT_FATAL(from_volume_except_width > 0, "Invalid from_shape: volume is zero");
+    TT_FATAL(from_width > 0, "Invalid from_shape: width dimension is zero");
+    ret.shape[0] = std::max((ret.shape[0] * to_volume_except_width) / from_volume_except_width, 32u);
+    ret.shape[1] = std::max((ret.shape[1] * to_width) / from_width, 32u);
+    return ret;
+}
+
+const std::optional<tt::tt_metal::ShardSpec>& get_shard_spec(const TensorSpec& tensor_spec) {
+    return tensor_spec.memory_config().shard_spec();
+}
+
+bool is_uneven(const TensorSpec& t) {
+    if (not t.memory_config().is_sharded()) {
+        return false;
+    }
+
+    const auto& shape = t.padded_shape();
+    const auto& shard = get_shard_spec(t)->shape;
+    const auto rank = shape.rank();
+
+    TT_FATAL(rank >= 2, "Rank must be at least 2");
+    // Compute product of all dimensions except the last
+    uint64_t volume_except_last = 1;
+    for (int i = 0; i < static_cast<int>(rank) - 1; ++i) {
+        volume_except_last *= shape[i];
+    }
+
+    return (volume_except_last % shard[0]) != 0 or (shape[-1] % shard[1]) != 0;
+}
+
+// the check is based on user facing information, input tensors and output memory config
+// more info may be checked in other places, such as actual output is uneven or not
+// this function is called in both earlier and later stages of the program execution
+bool is_native_L1_sharding(const TensorSpec& a, const std::optional<TensorSpec>& b, const MemoryConfig& c) {
+    if (!c.is_sharded()) {
+        return false;
+    }
+
+    // Scalar value path (b is not a tensor)
+    if (!b.has_value() && a.memory_config().is_sharded()) {
+        return !is_uneven(a);
+    }
+
+    if (!b.has_value()) {
+        return false;
+    }
+
+    // enable a few more conditions for faster performance
+    auto output_shape = compute_broadcasted_output(a.logical_shape(), b->logical_shape());
+    bool a_is_sharded = a.memory_config().is_sharded();
+    bool b_is_sharded = b->memory_config().is_sharded();
+    bool a_not_broadcast = (output_shape == a.logical_shape());
+    bool a_sharded_ok = a_is_sharded && a_not_broadcast && !is_uneven(a);
+
+    // avoid complex case when a and b are both sharded
+    if (a_sharded_ok && !b_is_sharded) {
+        auto subtile_bcast = get_subtile_broadcast_type(
+            a.logical_shape()[-2], a.logical_shape()[-1], b->logical_shape()[-2], b->logical_shape()[-1]);
+        [[maybe_unused]] bool is_height = a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
+
+        switch (subtile_bcast) {
+            case SubtileBroadcastType::COL_A:
+            case SubtileBroadcastType::COL_B:
+            case SubtileBroadcastType::SCALAR_A:
+            case SubtileBroadcastType::SCALAR_B: return is_height;
+            case SubtileBroadcastType::ROW_A:
+            case SubtileBroadcastType::ROW_B:
+            case SubtileBroadcastType::ROW_A_COL_B:
+            case SubtileBroadcastType::ROW_B_COL_A:
+            case SubtileBroadcastType::NONE: break;
+        }
+    }
+
+    // Both tensors have identical shape and memory config (no broadcast on any dimension)
+    if ((a.logical_shape() == b->logical_shape()) && (a.memory_config() == b->memory_config())) {
+        if (is_uneven(a) || is_uneven(*b)) {
+            // Uneven shards are safe when all tensors (a, b, c) are L1 sharded with identical
+            // shard specs -- each core sees the same tile counts for all tensors, matching legacy
+            // binary behavior. a.memory_config() == b->memory_config() already guarantees a == b.
+            bool all_l1 = a.memory_config().buffer_type() == BufferType::L1 &&
+                          b->memory_config().buffer_type() == BufferType::L1 && c.buffer_type() == BufferType::L1;
+            bool c_shard_matches = c.is_sharded() && c.shard_spec().has_value() &&
+                                   a.memory_config().shard_spec().has_value() &&
+                                   *c.shard_spec() == *a.memory_config().shard_spec();
+            return all_l1 && c_shard_matches;
+        }
+        if (a.memory_config().buffer_type() == BufferType::DRAM ||
+            b->memory_config().buffer_type() == BufferType::DRAM || c.buffer_type() == BufferType::DRAM) {
+            return false;
+        }
+
+        // Check if output grid differs from input grids - if so, cannot use native sharding
+        // This will force resharding through interleaved path
+        if (c.is_sharded() && c.shard_spec().has_value()) {
+            const auto& c_grid = c.shard_spec()->grid;
+            if (a.memory_config().is_sharded() && a.memory_config().shard_spec().has_value()) {
+                const auto& a_grid = a.memory_config().shard_spec()->grid;
+                if (a_grid != c_grid) {
+                    return false;
+                }
+            }
+            if (b->memory_config().is_sharded() && b->memory_config().shard_spec().has_value()) {
+                const auto& b_grid = b->memory_config().shard_spec()->grid;
+                if (b_grid != c_grid) {
+                    return false;
+                }
+            }
+        }
+
+        if ((a.memory_config().is_sharded() && a.memory_config().buffer_type() == BufferType::L1)) {
+            return true;
+        }
+        if (b->memory_config().is_sharded() && b->memory_config().buffer_type() == BufferType::L1) {
+            return true;
+        }
+        if (c.is_sharded() && c.buffer_type() == BufferType::L1) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+ttnn::Shape compute_broadcasted_output(const ttnn::Shape& shape_a, const ttnn::Shape& shape_b) {
+    // Broadcasting Rules Overview:
+    // - If the two tensors have different ranks, we virtually pad the smaller-rank tensor's shape
+    //   with ones on the left (i.e., higher-order dimensions) until both shapes have the same length.
+    // - For each dimension (starting from the rightmost), the sizes are compatible if:
+    //     - They are equal, or
+    //     - One of them is 1 (the dimension can be broadcast to match the other size).
+
+    const int rank_a = shape_a.rank();
+    const int rank_b = shape_b.rank();
+    const int larger_rank = std::max(rank_a, rank_b);
+    SmallVector<uint32_t> output_shape(larger_rank, 1);
+    for (int i = -1; i >= -larger_rank; --i) {
+        auto dim_a = (i >= -rank_a) ? shape_a[i] : 1;
+        auto dim_b = (i >= -rank_b) ? shape_b[i] : 1;
+        if (dim_a != 1 && dim_b != 1) {
+            output_shape[i + larger_rank] = dim_a;
+        } else {
+            output_shape[i + larger_rank] = dim_a + dim_b - 1;
+        }
+    }
+    return ttnn::Shape(output_shape);
+}
+
+MemoryConfig compute_mem_config_actual(const ttnn::Tensor& input_tensor_a, const ttnn::Shape& shape_b) {
+    // Compute adjusted shard spec for output shape
+    const auto& padded_a_shape = input_tensor_a.padded_shape();
+    const auto& logical_out_shape = operations::experimental::quasar::binary_ng::compute_broadcasted_output(
+        input_tensor_a.logical_shape(), shape_b);
+    const auto& padded_out_shape = input_tensor_a.tensor_spec().tensor_layout().compute_padded_shape(logical_out_shape);
+
+    auto adjusted_shard_spec = ttnn::operations::experimental::quasar::binary_ng::adjust_to_shape(
+        *input_tensor_a.memory_config().shard_spec(), padded_a_shape, padded_out_shape);
+
+    return MemoryConfig(
+        input_tensor_a.memory_config().memory_layout(),
+        input_tensor_a.memory_config().buffer_type(),
+        adjusted_shard_spec);
+}
+}  // namespace ttnn::operations::experimental::quasar::binary_ng

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_utils.hpp
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "binary_ng_device_operation.hpp"
+#include "ttnn/operations/experimental/quasar/binary_ng/types.hpp"
+#include "ttnn/tensor/types.hpp"
+
+#include <optional>
+#include <string>
+
+namespace ttnn::operations::experimental::quasar::binary_ng {
+
+enum class KernelName {
+    ReaderNoBcast,
+    WriterScalar,
+    ComputeNoBcast,
+    ComputeBcast,
+    ComputeScalar,
+    ReaderNoBcastNg,
+    WriterNoBcastNg,
+    ReaderRowBcastNg,
+    ReaderColBcastNg,
+    ReaderRowBColABcastNg,
+    ReaderScalarBcastNg,
+    ReaderRmNoBcastNg,
+    ReaderRmRowBcastNg,
+    ReaderRmColBcastNg,
+    ReaderRmRowBColABcastNg,
+    ReaderRmScalarBcastNg,
+    ReaderRmScalarOpNg,
+    WriterRmNoBcastNg,
+    ComputeRowBcastNg,
+    ComputeColBcastNg,
+    ComputeScalarBcastNg,
+    ComputeRowColBcastNg,
+};
+
+struct BinaryNgKernelConfig {
+    BinaryNgKernelConfig(SubtileBroadcastType subtile_broadcast_type);
+
+    std::string bcast_input_str() const;
+
+    KernelName reader_kernel;
+    KernelName compute_kernel;
+    KernelName writer_kernel;
+    std::optional<uint32_t> bcast_input;
+};
+
+std::string get_kernel_file_path(KernelName kernel_name, bool is_sfpu, bool is_where_op);
+
+struct OpConfig {
+    enum class FpuBinaryOp { ADD, SUB, MUL };
+    enum class SfpuBinaryOp {
+        ADD,
+        SUB,
+        MUL,
+        DIV,
+        DIV_FLOOR,
+        DIV_TRUNC,
+        REMAINDER,
+        FMOD,
+        POWER,
+        RSUB,
+        GCD,
+        LCM,
+        LEFT_SHIFT,
+        RIGHT_SHIFT,
+        LOGICAL_RIGHT_SHIFT,
+        BITWISE_AND,
+        BITWISE_OR,
+        BITWISE_XOR,
+        QUANT,
+        REQUANT,
+        DEQUANT,
+        MAXIMUM,
+        MINIMUM,
+        XLOGY,
+        ATAN2,
+        LT,
+        GT,
+        GE,
+        LE,
+        HYPOT,
+        WHERE,
+        EQ,
+        NE,
+        ISCLOSE,
+    };
+
+    template <class EnumT>
+    OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<EnumT>, std::optional<DataType> dtype = std::nullopt);
+
+    std::map<std::string, std::string> as_defines(DataType dtype) const;
+
+    std::optional<unary::UnaryOpType> process_lhs;
+    std::optional<unary::UnaryOpType> process_rhs;
+    std::optional<unary::UnaryOpType> postprocess;
+    std::variant<FpuBinaryOp, SfpuBinaryOp> binary_op;
+    bool is_sfpu_op() const;
+};
+
+void add_activation_defines(
+    std::map<std::string, std::string>& defines,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> activations,
+    std::string_view operand,
+    std::optional<DataType> dtype = std::nullopt);
+
+uint32_t pack_scalar_runtime_arg(unary::ScalarVariant scalar, DataType dtype, bool is_quant_op);
+
+std::map<std::string, std::string> make_dataflow_defines(
+    DataType dtype, std::optional<DataType> b_dtype = std::nullopt);
+
+struct AllShardSpecs {
+    tt::tt_metal::ShardSpec a_shard_spec;
+    tt::tt_metal::ShardSpec b_shard_spec;
+    tt::tt_metal::ShardSpec c_shard_spec;
+};
+
+tt::tt_metal::ShardSpec adjust_to_shape(
+    const tt::tt_metal::ShardSpec& shard_spec, const ttnn::Shape& from_shape, const ttnn::Shape& to_shape);
+
+struct AllShardVolumes {
+    std::optional<std::uint32_t> a_shard_volume;
+    std::optional<std::uint32_t> b_shard_volume;
+    std::optional<std::uint32_t> c_shard_volume;
+};
+
+std::optional<AllShardVolumes> get_shard_volumes(
+    const TensorSpec& a, const std::optional<TensorSpec>& b, const TensorSpec& c);
+
+const std::optional<tt::tt_metal::ShardSpec>& get_shard_spec(const TensorSpec& tensor_spec);
+
+bool is_uneven(const TensorSpec& t);
+
+bool is_native_L1_sharding(const TensorSpec& a, const std::optional<TensorSpec>& b, const MemoryConfig& c);
+
+ttnn::Shape compute_broadcasted_output(const ttnn::Shape& shape_a, const ttnn::Shape& shape_b);
+
+MemoryConfig compute_mem_config_actual(const ttnn::Tensor& input_tensor_a, const ttnn::Shape& shape_b);
+}  // namespace ttnn::operations::experimental::quasar::binary_ng

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary.cpp
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/compute/eltwise_unary/sfpu_split_includes.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/eltwise_unary/trigonometry.h"
+
+#include "eltwise_utils_common.hpp"
+#include "eltwise_utils.hpp"
+
+ALWI void process_tile(
+    tt::CBIndex cb_pre_lhs_id,
+    tt::CBIndex cb_post_lhs_id,
+    tt::CBIndex cb_pre_rhs_id,
+    tt::CBIndex cb_post_rhs_id,
+    tt::CBIndex cb_out_id,
+    uint32_t freq,
+    uint32_t tile_start,
+    uint32_t num_tiles_per_cycle) {
+    using namespace ckernel;
+
+    CircularBuffer cb_post_lhs(cb_post_lhs_id);
+    CircularBuffer cb_post_rhs(cb_post_rhs_id);
+    CircularBuffer cb_out(cb_out_id);
+
+#if BCAST_INPUT
+#define CB_PRE_BCAST cb_pre_rhs_id
+#define CB_PRE_OTHER cb_pre_lhs_id
+    CircularBuffer& cb_post_bcast = cb_post_rhs;
+    CircularBuffer& cb_post_other = cb_post_lhs;
+#else
+#define CB_PRE_BCAST cb_pre_lhs_id
+#define CB_PRE_OTHER cb_pre_rhs_id
+    CircularBuffer& cb_post_bcast = cb_post_lhs;
+    CircularBuffer& cb_post_other = cb_post_rhs;
+#endif
+
+    PREPROCESS(BCAST_OP, CircularBuffer(CB_PRE_BCAST), cb_post_bcast, cb_out, num_tiles_per_cycle);
+    cb_post_bcast.wait_front(num_tiles_per_cycle);
+
+    for (uint32_t j = tile_start; j < freq; ++j) {
+        PREPROCESS(OTHER_OP, CircularBuffer(CB_PRE_OTHER), cb_post_other, cb_out, num_tiles_per_cycle);
+        cb_post_other.wait_front(num_tiles_per_cycle);
+
+        cb_out.reserve_back(num_tiles_per_cycle);
+
+#if HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST)
+        binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs.get_cb_id(), cb_post_rhs.get_cb_id());
+#endif
+        tile_regs_acquire();
+        BINARY_OP(cb_post_lhs.get_cb_id(), cb_post_rhs.get_cb_id(), 0, 0, 0);
+        PROCESS_POST_ACTIVATIONS(0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, cb_out.get_cb_id());
+        tile_regs_release();
+
+        cb_out.push_back(num_tiles_per_cycle);
+        cb_post_other.pop_front(num_tiles_per_cycle);
+    }
+    cb_post_bcast.pop_front(num_tiles_per_cycle);
+}
+
+void kernel_main() {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+    uint32_t tile_freq = get_arg_val<uint32_t>(1);
+    uint32_t tile_start = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
+
+    if (num_tiles == 0) {
+        return;
+    }
+
+    constexpr auto cb_pre_lhs_id = tt::CBIndex::c_0;
+    constexpr auto cb_pre_rhs_id = tt::CBIndex::c_1;
+    constexpr auto cb_out_id = tt::CBIndex::c_2;
+
+    constexpr auto cb_post_lhs_id = HAS_ACTIVATIONS(LHS) ? tt::CBIndex::c_3 : cb_pre_lhs_id;
+    constexpr auto cb_post_rhs_id = HAS_ACTIVATIONS(RHS) ? tt::CBIndex::c_4 : cb_pre_rhs_id;
+
+    binary_op_init_common(cb_post_lhs_id, cb_post_rhs_id, cb_out_id);
+#ifdef PACK_RELU
+    PACK((llk_pack_relu_config(ReluConfig::zero())));
+#endif
+
+#if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST))
+    binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs_id, cb_post_rhs_id);
+#endif
+
+    uint32_t complete_iterations = (num_tiles + tile_start) / tile_freq;
+    uint32_t remaining_iterations = (num_tiles + tile_start) % tile_freq;
+
+    for (uint32_t i = 0; i < complete_iterations; ++i, tile_start = 0) {
+        process_tile(
+            cb_pre_lhs_id,
+            cb_post_lhs_id,
+            cb_pre_rhs_id,
+            cb_post_rhs_id,
+            cb_out_id,
+            tile_freq,
+            tile_start,
+            num_tiles_per_cycle);
+    }
+
+    if (remaining_iterations > 0) {
+        process_tile(
+            cb_pre_lhs_id,
+            cb_post_lhs_id,
+            cb_pre_rhs_id,
+            cb_post_rhs_id,
+            cb_out_id,
+            remaining_iterations,
+            tile_start,
+            num_tiles_per_cycle);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_no_bcast.cpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/eltwise_unary/sfpu_split_includes.h"
+#include "api/compute/eltwise_binary.h"
+#include "eltwise_utils_common.hpp"
+#include "eltwise_utils.hpp"
+
+void kernel_main() {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
+
+    constexpr auto cb_pre_lhs_id = tt::CBIndex::c_0;
+    constexpr auto cb_pre_rhs_id = tt::CBIndex::c_1;
+
+    CircularBuffer cb_post_lhs(HAS_ACTIVATIONS(LHS) ? tt::CBIndex::c_3 : cb_pre_lhs_id);
+    CircularBuffer cb_post_rhs(HAS_ACTIVATIONS(RHS) ? tt::CBIndex::c_4 : cb_pre_rhs_id);
+    CircularBuffer cb_out(tt::CBIndex::c_2);
+
+    binary_op_init_common(cb_post_lhs.get_cb_id(), cb_post_rhs.get_cb_id(), cb_out.get_cb_id());
+#ifdef PACK_RELU
+    PACK((llk_pack_relu_config(ReluConfig::zero())));
+#endif
+
+#if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST))
+    binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs.get_cb_id(), cb_post_rhs.get_cb_id());
+#endif
+
+    // Inline helper to process n tiles
+    auto process_tiles = [&](uint32_t n) {
+        PREPROCESS(LHS, CircularBuffer(cb_pre_lhs_id), cb_post_lhs, cb_out, n);
+        cb_post_lhs.wait_front(n);
+
+        PREPROCESS(RHS, CircularBuffer(cb_pre_rhs_id), cb_post_rhs, cb_out, n);
+        cb_post_rhs.wait_front(n);
+
+        cb_out.reserve_back(n);
+
+#if HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST)
+        binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs.get_cb_id(), cb_post_rhs.get_cb_id());
+#endif
+        tile_regs_acquire();
+        for (uint32_t i = 0; i < n; ++i) {
+            BINARY_OP(cb_post_lhs.get_cb_id(), cb_post_rhs.get_cb_id(), i, i, i);
+            PROCESS_POST_ACTIVATIONS(i);
+        }
+        tile_regs_commit();
+
+        tile_regs_wait();
+        for (uint32_t i = 0; i < n; ++i) {
+            pack_tile(i, cb_out.get_cb_id());
+        }
+        tile_regs_release();
+
+        cb_out.push_back(n);
+        cb_post_lhs.pop_front(n);
+        cb_post_rhs.pop_front(n);
+    };
+
+    // Process full chunks
+    uint32_t num_full_chunks = num_tiles / num_tiles_per_cycle;
+    for (uint32_t chunk = 0; chunk < num_full_chunks; ++chunk) {
+        process_tiles(num_tiles_per_cycle);
+    }
+
+    // Process remainder
+    uint32_t remainder = num_tiles % num_tiles_per_cycle;
+    if (remainder > 0) {
+        process_tiles(remainder);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/compute/eltwise_unary/sfpu_split_includes.h"
+#include "api/compute/eltwise_binary.h"
+
+#include "eltwise_utils_common.hpp"
+#include "eltwise_utils.hpp"
+
+void kernel_main() {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
+    // DPRINT("num_tiles_per_cycle: {}\n", num_tiles_per_cycle);
+    constexpr auto cb_pre_lhs_id = tt::CBIndex::c_0;
+    constexpr auto cb_pre_rhs_id = tt::CBIndex::c_1;
+
+    CircularBuffer cb_post_lhs(HAS_ACTIVATIONS(LHS) ? tt::CBIndex::c_3 : cb_pre_lhs_id);
+    CircularBuffer cb_post_rhs(HAS_ACTIVATIONS(RHS) ? tt::CBIndex::c_4 : cb_pre_rhs_id);
+    CircularBuffer cb_out(tt::CBIndex::c_2);
+
+    binary_op_init_common(cb_post_lhs.get_cb_id(), cb_post_rhs.get_cb_id(), cb_out.get_cb_id());
+#ifdef PACK_RELU
+    PACK((llk_pack_relu_config(ReluConfig::zero())));
+#endif
+
+#if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST))
+    binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs.get_cb_id(), cb_post_rhs.get_cb_id());
+#endif
+
+    PREPROCESS(RHS, CircularBuffer(cb_pre_rhs_id), cb_post_rhs, cb_out, 1);
+    cb_post_rhs.wait_front(1);
+
+    // Inline lambda to process n tiles with the scalar value
+    auto process_tiles = [&](uint32_t n) {
+        PREPROCESS(LHS, CircularBuffer(cb_pre_lhs_id), cb_post_lhs, cb_out, n);
+        cb_post_lhs.wait_front(n);
+
+        cb_out.reserve_back(n);
+
+#if HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST)
+        binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs.get_cb_id(), cb_post_rhs.get_cb_id());
+#endif
+        tile_regs_acquire();
+        for (uint32_t i = 0; i < n; ++i) {
+            BINARY_OP(cb_post_lhs.get_cb_id(), cb_post_rhs.get_cb_id(), i, 0, i);
+            PROCESS_POST_ACTIVATIONS(i);
+        }
+        tile_regs_commit();
+
+        tile_regs_wait();
+        for (uint32_t i = 0; i < n; ++i) {
+            pack_tile(i, cb_out.get_cb_id());
+        }
+        tile_regs_release();
+
+        cb_post_lhs.pop_front(n);
+        cb_out.push_back(n);
+    };
+
+    // Process full chunks
+    uint32_t full_chunks = num_tiles / num_tiles_per_cycle;
+    for (uint32_t chunk = 0; chunk < full_chunks; ++chunk) {
+        process_tiles(num_tiles_per_cycle);
+    }
+
+    // Process remainder
+    uint32_t remainder = num_tiles % num_tiles_per_cycle;
+    if (remainder > 0) {
+        process_tiles(remainder);
+    }
+
+    // Pop the scalar tile from RHS CB
+    cb_post_rhs.pop_front(1);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/eltwise_unary/sfpu_split_includes.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+
+#include "api/compute/eltwise_binary_sfpu.h"
+#include "api/compute/binary_bitwise_sfpu.h"
+#include "api/compute/binary_shift.h"
+#include "api/compute/add_int_sfpu.h"
+#include "api/compute/sub_int_sfpu.h"
+#include "api/compute/mul_int_sfpu.h"
+#include "api/compute/div_int32_floor.h"
+#include "api/compute/div_int32_sfpu.h"
+#include "api/compute/binary_fmod.h"
+#include "api/compute/binary_remainder.h"
+#include "api/compute/quantization.h"
+#include "api/compute/binary_max_min.h"
+#include "api/compute/gcd.h"
+#include "api/compute/lcm.h"
+#include "api/compute/xlogy.h"
+#include "api/compute/atan2.h"
+#include "api/compute/binary_comp.h"
+#include "api/compute/isclose.h"
+#include "eltwise_utils_common.hpp"
+#include "eltwise_utils_sfpu.hpp"
+
+ALWI void process_tile(
+    tt::CBIndex cb_pre_lhs_id,
+    tt::CBIndex cb_post_lhs_id,
+    tt::CBIndex cb_pre_rhs_id,
+    tt::CBIndex cb_post_rhs_id,
+    tt::CBIndex cb_out_id,
+    uint32_t freq,
+    uint32_t tile_start,
+    uint32_t num_tiles_per_cycle ISCLOSE_RT_ARG_PARAMS) {
+    using namespace ckernel;
+
+    CircularBuffer cb_post_lhs(cb_post_lhs_id);
+    CircularBuffer cb_post_rhs(cb_post_rhs_id);
+    CircularBuffer cb_out(cb_out_id);
+
+#if BCAST_INPUT
+#define CB_PRE_BCAST cb_pre_rhs_id
+#define CB_PRE_OTHER cb_pre_lhs_id
+    CircularBuffer& cb_post_bcast = cb_post_rhs;
+    CircularBuffer& cb_post_other = cb_post_lhs;
+#else
+#define CB_PRE_BCAST cb_pre_lhs_id
+#define CB_PRE_OTHER cb_pre_rhs_id
+    CircularBuffer& cb_post_bcast = cb_post_lhs;
+    CircularBuffer& cb_post_other = cb_post_rhs;
+#endif
+
+    PREPROCESS(BCAST_OP, CircularBuffer(CB_PRE_BCAST), cb_post_bcast, cb_out, num_tiles_per_cycle);
+    cb_post_bcast.wait_front(num_tiles_per_cycle);
+
+    for (uint32_t j = tile_start; j < freq; ++j) {
+        PREPROCESS(OTHER_OP, CircularBuffer(CB_PRE_OTHER), cb_post_other, cb_out, num_tiles_per_cycle);
+        cb_post_other.wait_front(num_tiles_per_cycle);
+
+        cb_out.reserve_back(num_tiles_per_cycle);
+
+#if (HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))
+        BINARY_SFPU_INIT
+#endif
+        tile_regs_acquire();
+        copy_tile_to_dst_init_short_with_dt(cb_post_rhs.get_cb_id(), cb_post_lhs.get_cb_id());
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            copy_tile(cb_post_lhs.get_cb_id(), i, i * 2);
+        }
+        copy_tile_to_dst_init_short_with_dt(cb_post_lhs.get_cb_id(), cb_post_rhs.get_cb_id());
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            copy_tile(cb_post_rhs.get_cb_id(), i, i * 2 + 1);
+
+#if HAS_ACTIVATIONS(POST)
+            BINARY_SFPU_INIT
+#endif
+#if ISCLOSE_OP
+            BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2, rtol_bits, atol_bits);
+#else
+            BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2);
+#endif
+            PROCESS_POST_ACTIVATIONS(i * 2);
+        }
+        tile_regs_commit();
+
+        tile_regs_wait();
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            pack_tile(i * 2, cb_out.get_cb_id());
+        }
+        tile_regs_release();
+
+        cb_out.push_back(num_tiles_per_cycle);
+        cb_post_other.pop_front(num_tiles_per_cycle);
+    }
+    cb_post_bcast.pop_front(num_tiles_per_cycle);
+}
+
+void kernel_main() {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+    uint32_t tile_freq = get_arg_val<uint32_t>(1);
+    uint32_t tile_start = get_arg_val<uint32_t>(2);
+#ifdef ISCLOSE_OP
+    const uint32_t rtol_bits = get_arg_val<uint32_t>(ISCLOSE_RTOL_RT_ARG_IDX);
+    const uint32_t atol_bits = get_arg_val<uint32_t>(ISCLOSE_ATOL_RT_ARG_IDX);
+#endif
+
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
+
+    if (num_tiles == 0) {
+        return;
+    }
+
+    constexpr auto cb_pre_lhs_id = tt::CBIndex::c_0;
+    constexpr auto cb_pre_rhs_id = tt::CBIndex::c_1;
+    constexpr auto cb_out_id = tt::CBIndex::c_2;
+
+    constexpr auto cb_post_lhs_id = HAS_ACTIVATIONS(LHS) ? tt::CBIndex::c_3 : cb_pre_lhs_id;
+    constexpr auto cb_post_rhs_id = HAS_ACTIVATIONS(RHS) ? tt::CBIndex::c_4 : cb_pre_rhs_id;
+
+    unary_op_init_common(cb_post_lhs_id, cb_out_id);
+#ifdef PACK_RELU
+    PACK((llk_pack_relu_config(ReluConfig::zero())));
+#endif
+
+#if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))
+    BINARY_SFPU_INIT
+#endif
+
+    uint32_t complete_iterations = (num_tiles + tile_start) / tile_freq;
+    uint32_t remaining_iterations = (num_tiles + tile_start) % tile_freq;
+
+    for (uint32_t i = 0; i < complete_iterations; ++i, tile_start = 0) {
+        process_tile(
+            cb_pre_lhs_id,
+            cb_post_lhs_id,
+            cb_pre_rhs_id,
+            cb_post_rhs_id,
+            cb_out_id,
+            tile_freq,
+            tile_start,
+            num_tiles_per_cycle ISCLOSE_RT_ARG_FWD);
+    }
+
+    if (remaining_iterations > 0) {
+        process_tile(
+            cb_pre_lhs_id,
+            cb_post_lhs_id,
+            cb_pre_rhs_id,
+            cb_post_rhs_id,
+            cb_out_id,
+            remaining_iterations,
+            tile_start,
+            num_tiles_per_cycle ISCLOSE_RT_ARG_FWD);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/eltwise_unary/sfpu_split_includes.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+
+#include "api/compute/eltwise_binary_sfpu.h"
+#include "api/compute/binary_bitwise_sfpu.h"
+#include "api/compute/binary_shift.h"
+#include "api/compute/add_int_sfpu.h"
+#include "api/compute/sub_int_sfpu.h"
+#include "api/compute/mul_int_sfpu.h"
+#include "api/compute/div_int32_floor.h"
+#include "api/compute/div_int32_sfpu.h"
+#include "api/compute/binary_remainder.h"
+#include "api/compute/binary_fmod.h"
+#include "api/compute/quantization.h"
+#include "api/compute/binary_max_min.h"
+#include "api/compute/gcd.h"
+#include "api/compute/lcm.h"
+#include "api/compute/xlogy.h"
+#include "api/compute/atan2.h"
+#include "api/compute/binary_comp.h"
+#include "api/compute/isclose.h"
+
+#include "eltwise_utils_common.hpp"
+#include "eltwise_utils_sfpu.hpp"
+FORCE_INLINE void process_sfpu_tiles(
+    uint32_t n,
+    uint32_t cb_pre_lhs_id,
+    uint32_t cb_post_lhs_id,
+    uint32_t cb_pre_rhs_id,
+    uint32_t cb_post_rhs_id,
+    uint32_t cb_out_id ISCLOSE_RT_ARG_PARAMS) {
+    CircularBuffer cb_post_lhs(cb_post_lhs_id);
+    CircularBuffer cb_post_rhs(cb_post_rhs_id);
+    CircularBuffer cb_out(cb_out_id);
+
+    PREPROCESS(LHS, CircularBuffer(cb_pre_lhs_id), cb_post_lhs, cb_out, n);
+    cb_post_lhs.wait_front(n);
+
+    PREPROCESS(RHS, CircularBuffer(cb_pre_rhs_id), cb_post_rhs, cb_out, n);
+    cb_post_rhs.wait_front(n);
+
+    cb_out.reserve_back(n);
+
+#if (HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))
+    BINARY_SFPU_INIT;
+#endif
+
+    tile_regs_acquire();
+    copy_tile_to_dst_init_short_with_dt(cb_post_rhs.get_cb_id(), cb_post_lhs.get_cb_id());
+    for (uint32_t i = 0; i < n; ++i) {
+        copy_tile(cb_post_lhs.get_cb_id(), i, i * 2);
+    }
+    copy_tile_to_dst_init_short_with_dt(cb_post_lhs.get_cb_id(), cb_post_rhs.get_cb_id());
+    for (uint32_t i = 0; i < n; ++i) {
+        copy_tile(cb_post_rhs.get_cb_id(), i, i * 2 + 1);
+#if HAS_ACTIVATIONS(POST)
+        BINARY_SFPU_INIT;
+#endif
+#if ISCLOSE_OP
+        BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2, rtol_bits, atol_bits);
+#else
+        BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2);
+#endif
+        PROCESS_POST_ACTIVATIONS(i * 2);
+    }
+    tile_regs_commit();
+
+    tile_regs_wait();
+    for (uint32_t i = 0; i < n; ++i) {
+        pack_tile(i * 2, cb_out.get_cb_id());
+    }
+    tile_regs_release();
+
+    cb_out.push_back(n);
+    cb_post_lhs.pop_front(n);
+    cb_post_rhs.pop_front(n);
+}
+
+void kernel_main() {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+#ifdef ISCLOSE_OP
+    const uint32_t rtol_bits = get_arg_val<uint32_t>(ISCLOSE_RTOL_RT_ARG_IDX);
+    const uint32_t atol_bits = get_arg_val<uint32_t>(ISCLOSE_ATOL_RT_ARG_IDX);
+#endif
+
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
+
+    constexpr auto cb_pre_lhs_id = tt::CBIndex::c_0;
+    constexpr auto cb_pre_rhs_id = tt::CBIndex::c_1;
+    constexpr auto cb_out_id = tt::CBIndex::c_2;
+
+    constexpr auto cb_post_lhs_id = HAS_ACTIVATIONS(LHS) ? tt::CBIndex::c_3 : cb_pre_lhs_id;
+    constexpr auto cb_post_rhs_id = HAS_ACTIVATIONS(RHS) ? tt::CBIndex::c_4 : cb_pre_rhs_id;
+
+    unary_op_init_common(cb_post_lhs_id, cb_out_id);
+#ifdef PACK_RELU
+    PACK((llk_pack_relu_config(ReluConfig::zero())));
+#endif
+
+#if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))
+    BINARY_SFPU_INIT
+#endif
+
+    // Process full chunks
+    uint32_t num_full_chunks = num_tiles / num_tiles_per_cycle;
+    for (uint32_t chunk = 0; chunk < num_full_chunks; ++chunk) {
+        process_sfpu_tiles(
+            num_tiles_per_cycle,
+            cb_pre_lhs_id,
+            cb_post_lhs_id,
+            cb_pre_rhs_id,
+            cb_post_rhs_id,
+            cb_out_id ISCLOSE_RT_ARG_FWD);
+    }
+
+    // Process remainder
+    uint32_t remainder = num_tiles % num_tiles_per_cycle;
+    if (remainder > 0) {
+        process_sfpu_tiles(
+            remainder, cb_pre_lhs_id, cb_post_lhs_id, cb_pre_rhs_id, cb_post_rhs_id, cb_out_id ISCLOSE_RT_ARG_FWD);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/eltwise_unary/sfpu_split_includes.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+
+#include "api/compute/eltwise_binary_sfpu.h"
+#include "api/compute/binary_bitwise_sfpu.h"
+#include "api/compute/binary_shift.h"
+#include "api/compute/add_int_sfpu.h"
+#include "api/compute/sub_int_sfpu.h"
+#include "api/compute/mul_int_sfpu.h"
+#include "api/compute/div_int32_sfpu.h"
+#include "api/compute/div_int32_floor.h"
+#include "api/compute/quantization.h"
+#include "api/compute/xlogy.h"
+#include "api/compute/atan2.h"
+#include "api/compute/binary_comp.h"
+#include "api/compute/isclose.h"
+#include "eltwise_utils_common.hpp"
+#include "eltwise_utils_sfpu.hpp"
+
+// Process n LHS tiles against a scalar tile at index 0 in cb_post_rhs
+FORCE_INLINE void process_sfpu_scalar_tiles(
+    uint32_t n,
+    uint32_t cb_pre_lhs_id,
+    uint32_t cb_post_lhs_id,
+    uint32_t cb_post_rhs_id,
+    uint32_t cb_out_id ISCLOSE_RT_ARG_PARAMS) {
+    CircularBuffer cb_post_lhs(cb_post_lhs_id);
+    CircularBuffer cb_post_rhs(cb_post_rhs_id);
+    CircularBuffer cb_out(cb_out_id);
+
+    PREPROCESS(LHS, CircularBuffer(cb_pre_lhs_id), cb_post_lhs, cb_out, n);
+    cb_post_lhs.wait_front(n);
+
+    cb_out.reserve_back(n);
+
+#if (HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))
+    BINARY_SFPU_INIT;
+#endif
+
+    tile_regs_acquire();
+    copy_tile_to_dst_init_short_with_dt(cb_post_rhs.get_cb_id(), cb_post_lhs.get_cb_id());
+    for (uint32_t i = 0; i < n; ++i) {
+        copy_tile(cb_post_lhs.get_cb_id(), i, i * 2);
+    }
+    copy_tile_to_dst_init_short_with_dt(cb_post_lhs.get_cb_id(), cb_post_rhs.get_cb_id());
+    for (uint32_t i = 0; i < n; ++i) {
+        copy_tile(cb_post_rhs.get_cb_id(), 0, i * 2 + 1);  // Always use scalar at index 0
+#if HAS_ACTIVATIONS(POST)
+        BINARY_SFPU_INIT;
+#endif
+#if ISCLOSE_OP
+        BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2, rtol_bits, atol_bits);
+#else
+        BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2);
+#endif
+        PROCESS_POST_ACTIVATIONS(i * 2);
+    }
+    tile_regs_commit();
+
+    tile_regs_wait();
+    for (uint32_t i = 0; i < n; ++i) {
+        pack_tile(i * 2, cb_out.get_cb_id());
+    }
+    tile_regs_release();
+
+    cb_post_lhs.pop_front(n);
+    cb_out.push_back(n);
+}
+
+void kernel_main() {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+#ifdef ISCLOSE_OP
+    const uint32_t rtol_bits = get_arg_val<uint32_t>(ISCLOSE_RTOL_RT_ARG_IDX);
+    const uint32_t atol_bits = get_arg_val<uint32_t>(ISCLOSE_ATOL_RT_ARG_IDX);
+#endif
+
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
+
+    constexpr auto cb_pre_lhs_id = tt::CBIndex::c_0;
+    constexpr auto cb_pre_rhs_id = tt::CBIndex::c_1;
+    constexpr auto cb_out_id = tt::CBIndex::c_2;
+
+    constexpr auto cb_post_lhs_id = HAS_ACTIVATIONS(LHS) ? tt::CBIndex::c_3 : cb_pre_lhs_id;
+
+    CircularBuffer cb_post_rhs(HAS_ACTIVATIONS(RHS) ? tt::CBIndex::c_4 : cb_pre_rhs_id);
+
+    unary_op_init_common(cb_post_lhs_id, cb_out_id);
+#ifdef PACK_RELU
+    PACK((llk_pack_relu_config(ReluConfig::zero())));
+#endif
+
+#if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))
+    BINARY_SFPU_INIT
+#endif
+
+    PREPROCESS(RHS, CircularBuffer(cb_pre_rhs_id), cb_post_rhs, CircularBuffer(cb_out_id), 1);
+    cb_post_rhs.wait_front(1);
+
+    // Process full chunks
+    uint32_t full_chunks = num_tiles / num_tiles_per_cycle;
+    for (uint32_t chunk = 0; chunk < full_chunks; ++chunk) {
+        process_sfpu_scalar_tiles(
+            num_tiles_per_cycle, cb_pre_lhs_id, cb_post_lhs_id, cb_post_rhs.get_cb_id(), cb_out_id ISCLOSE_RT_ARG_FWD);
+    }
+
+    // Process remainder
+    uint32_t remainder = num_tiles % num_tiles_per_cycle;
+    if (remainder > 0) {
+        process_sfpu_scalar_tiles(
+            remainder, cb_pre_lhs_id, cb_post_lhs_id, cb_post_rhs.get_cb_id(), cb_out_id ISCLOSE_RT_ARG_FWD);
+    }
+
+    // Pop the scalar tile from RHS CB
+    cb_post_rhs.pop_front(1);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils.hpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "api/compute/common.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/dataflow/circular_buffer.h"
+
+// Reads `per_core_block_size` tiles from cb_pre, runs the per-operand activation chain
+// on each tile in DST, and writes the results into cb_post — i.e. produces the
+// "activated" input that the downstream binary op consumes. cb_out is passed in only
+// so we can briefly retarget the packer at cb_post and then restore it to cb_out's
+// data format on the way out. FPU variant: also reconfigures the unpacker srca format
+// for the pre/post switch, since the FPU binary op will read from a different CB next.
+template <typename ActivationFn>
+ALWI void preprocess_fpu_impl(
+    CircularBuffer cb_pre,
+    CircularBuffer cb_post,
+    CircularBuffer cb_out,
+    uint32_t per_core_block_size,
+    ActivationFn&& process_activations) {
+    using namespace ckernel;
+
+    reconfig_data_format_srca(/*old*/ cb_post.get_cb_id(), /*new*/ cb_pre.get_cb_id());
+    pack_reconfig_data_format(/*old*/ cb_out.get_cb_id(), /*new*/ cb_post.get_cb_id());
+
+    cb_pre.wait_front(per_core_block_size);
+    cb_post.reserve_back(per_core_block_size);
+
+    tile_regs_acquire();
+    for (uint32_t i = 0; i < per_core_block_size; ++i) {
+        copy_tile_to_dst_init_short(cb_pre.get_cb_id());
+        copy_tile(cb_pre.get_cb_id(), i, i);
+        process_activations(i);
+    }
+    tile_regs_commit();
+
+    tile_regs_wait();
+    for (uint32_t i = 0; i < per_core_block_size; ++i) {
+        pack_tile(i, cb_post.get_cb_id());
+    }
+    tile_regs_release();
+
+    cb_pre.pop_front(per_core_block_size);
+    cb_post.push_back(per_core_block_size);
+
+    reconfig_data_format_srca(/*old*/ cb_pre.get_cb_id(), /*new*/ cb_post.get_cb_id());
+    pack_reconfig_data_format(/*old*/ cb_post.get_cb_id(), /*new*/ cb_out.get_cb_id());
+}
+
+// Dispatcher: per-operand activation lists are configured at compile time via host-side
+// defines (e.g. PROCESS_LHS_ACTIVATIONS, PROCESS_RHS_ACTIVATIONS). HAS_ACTIVATIONS(op)
+// expands to 1 or 0; this macro pastes that bit onto PREPROCESS_ to pick the matching
+// arm below, so kernels can write a single `PREPROCESS(LHS, ...)` call and have it
+// compile to either the activation pass or nothing at all.
+#define PREPROCESS(op, ...) P_CAT(PREPROCESS_, HAS_ACTIVATIONS(op))(op, __VA_ARGS__)
+
+// No-op arm: when an operand has no activations the kernel skips the entire preprocess
+// step (no extra CB hop, no copy_tile pass) and reads the pre CB directly downstream.
+#define PREPROCESS_0(...)
+
+// Active arm: forwards to preprocess_fpu_impl, which performs the
+// pre -> activation -> post copy/pack pass plus the FPU srca format reconfigures.
+// The macro layer exists only to bind the `op` token (LHS / RHS / BCAST_OP / OTHER_OP)
+// so PROCESS_##op##_ACTIVATIONS resolves via preprocessor concatenation — that part
+// can't be a function template, since `op` is a token, not a value. The lambda then
+// hands the resolved activation sequence to the (real, always-inline) helper.
+#define PREPROCESS_1(op, cb_pre, cb_post, cb_out, per_core_block_size) \
+    preprocess_fpu_impl(                                               \
+        (cb_pre), (cb_post), (cb_out), (per_core_block_size), [&](uint32_t i) { PROCESS_ACTIVATIONS(op, i); })

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils_common.hpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#define IS_EMPTY(...) P_CAT(IS_EMPTY_, IS_BEGIN_PARENS(__VA_ARGS__))(__VA_ARGS__)
+#define IS_EMPTY_0(...) IS_BEGIN_PARENS(IS_EMPTY_NON_FUNCTION_C __VA_ARGS__())
+#define IS_EMPTY_1(...) 0
+#define IS_EMPTY_NON_FUNCTION_C(...) ()
+
+#define IS_BEGIN_PARENS(...) P_FIRST(P_CAT(P_IS_VARIADIC_R_, P_IS_VARIADIC_C __VA_ARGS__))
+
+#define P_IS_VARIADIC_R_1 1,
+#define P_IS_VARIADIC_R_P_IS_VARIADIC_C 0,
+#define P_IS_VARIADIC_C(...) 1
+
+#define P_FIRST(...) P_FIRST_(__VA_ARGS__, )
+#define P_FIRST_(a, ...) a
+
+#define P_CAT(a, ...) P_CAT_(a, __VA_ARGS__)
+#define P_CAT_(a, ...) a##__VA_ARGS__
+
+#define P_COMPL(b) P_CAT(P_COMPL_, b)
+#define P_COMPL_0 1
+#define P_COMPL_1 0
+
+#define PROCESS_ACTIVATIONS(op, i) PROCESS_ACTIVATIONS_(op)(i)
+#define PROCESS_ACTIVATIONS_(op) PROCESS_##op##_ACTIVATIONS
+#define HAS_ACTIVATIONS(op) P_COMPL(IS_EMPTY(PROCESS_ACTIVATIONS(op, 0)))
+
+#define BCAST_OP P_CAT(BCAST_OP_, BCAST_INPUT)
+#define OTHER_OP P_CAT(BCAST_OP_, P_COMPL(BCAST_INPUT))
+#define BCAST_OP_0 LHS
+#define BCAST_OP_1 RHS
+
+// In that build, the SFPU tile API takes two extra runtime-arg scalars
+// (rtol/atol IEEE-754 bits) which are read once at the top of kernel_main and
+// then forwarded into the inlined process_tile helpers via these macros.
+#ifdef ISCLOSE_OP
+#define ISCLOSE_RT_ARG_PARAMS , uint32_t rtol_bits, uint32_t atol_bits
+#define ISCLOSE_RT_ARG_FWD , rtol_bits, atol_bits
+#else
+#define ISCLOSE_RT_ARG_PARAMS
+#define ISCLOSE_RT_ARG_FWD
+#endif

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils_sfpu.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils_sfpu.hpp
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "api/compute/common.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/dataflow/circular_buffer.h"
+
+// Reads `per_core_block_size` tiles from cb_pre, runs the per-operand activation chain
+// on each tile in DST, and writes the results into cb_post — i.e. produces the
+// "activated" input that the downstream binary op consumes. cb_out is passed in only
+// so we can briefly retarget the packer at cb_post and then restore it to cb_out's
+// data format on the way out. SFPU variant: no unpacker srca reconfigure is needed —
+// the downstream binary SFPU op uses copy_tile_to_dst_init_short_with_dt to switch
+// formats itself.
+template <typename ActivationFn>
+ALWI void preprocess_sfpu_impl(
+    CircularBuffer cb_pre,
+    CircularBuffer cb_post,
+    CircularBuffer cb_out,
+    uint32_t per_core_block_size,
+    ActivationFn&& process_activations) {
+    using namespace ckernel;
+
+    pack_reconfig_data_format(/*old*/ cb_out.get_cb_id(), /*new*/ cb_post.get_cb_id());
+
+    cb_pre.wait_front(per_core_block_size);
+    cb_post.reserve_back(per_core_block_size);
+
+    tile_regs_acquire();
+    for (uint32_t i = 0; i < per_core_block_size; ++i) {
+        copy_tile_to_dst_init_short(cb_pre.get_cb_id());
+        copy_tile(cb_pre.get_cb_id(), i, i);
+        process_activations(i);
+    }
+    tile_regs_commit();
+
+    tile_regs_wait();
+    for (uint32_t i = 0; i < per_core_block_size; ++i) {
+        pack_tile(i, cb_post.get_cb_id());
+    }
+    tile_regs_release();
+
+    cb_pre.pop_front(per_core_block_size);
+    cb_post.push_back(per_core_block_size);
+
+    pack_reconfig_data_format(/*old*/ cb_post.get_cb_id(), /*new*/ cb_out.get_cb_id());
+}
+
+// Dispatcher: per-operand activation lists are configured at compile time via host-side
+// defines (e.g. PROCESS_LHS_ACTIVATIONS, PROCESS_RHS_ACTIVATIONS). HAS_ACTIVATIONS(op)
+// expands to 1 or 0; this macro pastes that bit onto PREPROCESS_ to pick the matching
+// arm below, so kernels can write a single `PREPROCESS(LHS, ...)` call and have it
+// compile to either the activation pass or nothing at all.
+#define PREPROCESS(op, ...) P_CAT(PREPROCESS_, HAS_ACTIVATIONS(op))(op, __VA_ARGS__)
+
+// No-op arm: when an operand has no activations the kernel skips the entire preprocess
+// step (no extra CB hop, no copy_tile pass) and reads the pre CB directly downstream.
+#define PREPROCESS_0(...)
+
+// Active arm: forwards to preprocess_sfpu_impl, which performs the
+// pre -> activation -> post copy/pack pass. The macro layer exists only to bind the
+// `op` token (LHS / RHS / BCAST_OP / OTHER_OP) so PROCESS_##op##_ACTIVATIONS resolves
+// via preprocessor concatenation — that part can't be a function template, since `op`
+// is a token, not a value. The lambda then hands the resolved activation sequence to
+// the (real, always-inline) helper.
+#define PREPROCESS_1(op, cb_pre, cb_post, cb_out, per_core_block_size) \
+    preprocess_sfpu_impl(                                              \
+        (cb_pre), (cb_post), (cb_out), (per_core_block_size), [&](uint32_t i) { PROCESS_ACTIVATIONS(op, i); })

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_where_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_where_no_bcast.cpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/eltwise_unary/where.h"
+#include "api/compute/eltwise_unary/fill.h"
+#include "eltwise_utils_common.hpp"
+#include "eltwise_utils_sfpu.hpp"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+
+void kernel_main() {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+    const uint32_t scalar_value = get_arg_val<uint32_t>(3);
+    const auto scalar_val = reinterpret_cast<const float*>(&scalar_value);
+
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
+
+    CircularBuffer cb_in0(tt::CBIndex::c_0);
+    CircularBuffer cb_in1(tt::CBIndex::c_1);
+    CircularBuffer cb_out(tt::CBIndex::c_2);
+
+    unary_op_init_common(cb_in0.get_cb_id(), cb_out.get_cb_id());
+    BINARY_SFPU_INIT
+
+    for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
+        cb_in0.wait_front(num_tiles_per_cycle);
+        cb_in1.wait_front(num_tiles_per_cycle);
+        cb_out.reserve_back(num_tiles_per_cycle);
+
+        tile_regs_acquire();
+        copy_tile_to_dst_init_short(cb_in0.get_cb_id());
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            copy_tile(cb_in0.get_cb_id(), i, i * 3);
+        }
+        copy_tile_to_dst_init_short(cb_in1.get_cb_id());
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            // TTS: tensor is true value, goes to dst_reg 1
+#if WHERE_TTS
+            copy_tile(cb_in1.get_cb_id(), i, i * 3 + 1);  // Copy true tensor to dst_reg 1
+            fill_tile_init();
+            // TTS: scalar is false value, goes to dst_reg 2
+#ifdef FILL_WITH_VALUE_FLOAT
+            FILL_LLK(i * 3 + 2, *scalar_val);
+#endif
+#ifdef FILL_WITH_VALUE_INT
+            FILL_LLK(i * 3 + 2, scalar_value);
+#endif
+#endif
+
+// TST: tensor is false value, goes to dst_reg 2
+#if WHERE_TST
+            copy_tile(cb_in1.get_cb_id(), i, i * 3 + 2);  // Copy false tensor to dst_reg 2
+            fill_tile_init();
+            // TST: scalar is true value, goes to dst_reg 1
+#ifdef FILL_WITH_VALUE_FLOAT
+            FILL_LLK(i * 3 + 1, *scalar_val);
+#endif
+#ifdef FILL_WITH_VALUE_INT
+            FILL_LLK(i * 3 + 1, scalar_value);
+#endif
+#endif
+
+            BINARY_SFPU_OP(i * 3, i * 3 + 1, i * 3 + 2, i * 3);
+        }
+
+        tile_regs_commit();
+
+        tile_regs_wait();
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            pack_tile(i * 3, cb_out.get_cb_id());
+        }
+        tile_regs_release();
+
+        cb_out.push_back(num_tiles_per_cycle);
+        cb_in0.pop_front(num_tiles_per_cycle);
+        cb_in1.pop_front(num_tiles_per_cycle);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_where_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_where_sfpu.cpp
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/eltwise_unary/where.h"
+#include "api/compute/eltwise_unary/fill.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "eltwise_utils_common.hpp"
+#include "eltwise_utils_sfpu.hpp"
+
+ALWI void process_tile(
+    tt::CBIndex cb_in0_id,
+    tt::CBIndex cb_in1_id,
+    tt::CBIndex cb_out_id,
+    const uint32_t scalar_value,
+    const float* scalar_val,
+    uint32_t freq,
+    uint32_t tile_start,
+    uint32_t num_tiles_per_cycle) {
+    using namespace ckernel;
+
+    CircularBuffer cb_in0(cb_in0_id);
+    CircularBuffer cb_in1(cb_in1_id);
+    CircularBuffer cb_out(cb_out_id);
+
+#if BCAST_INPUT  // BCAST_INPUT == 1 : input B ( true or false tensor) is broadcasted
+    CircularBuffer& cb_bcast = cb_in1;
+    CircularBuffer& cb_other = cb_in0;
+#else  // BCAST_INPUT == 0 : input A (condition tensor)  is broadcasted
+    CircularBuffer& cb_bcast = cb_in0;
+    CircularBuffer& cb_other = cb_in1;
+#endif
+
+    cb_bcast.wait_front(num_tiles_per_cycle);
+
+    for (uint32_t j = tile_start; j < freq; ++j) {
+        cb_other.wait_front(num_tiles_per_cycle);
+        cb_out.reserve_back(num_tiles_per_cycle);
+
+        tile_regs_acquire();
+        copy_tile_to_dst_init_short(cb_in0.get_cb_id());
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            copy_tile(cb_in0.get_cb_id(), i, i * 3);
+        }
+        copy_tile_to_dst_init_short(cb_in1.get_cb_id());
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            // TTS: tensor is true value, goes to dst_reg 1
+#if WHERE_TTS
+            copy_tile(cb_in1.get_cb_id(), i, i * 3 + 1);  // Copy true tensor to dst_reg 1
+            fill_tile_init();
+// TTS: scalar is false value, goes to dst_reg 2
+#ifdef FILL_WITH_VALUE_FLOAT
+            FILL_LLK(i * 3 + 2, *scalar_val);
+#endif
+#ifdef FILL_WITH_VALUE_INT
+            FILL_LLK(i * 3 + 2, scalar_value);
+#endif
+#endif
+
+// TST: tensor is false value, goes to dst_reg 2
+#if WHERE_TST
+            copy_tile(cb_in1.get_cb_id(), i, i * 3 + 2);  // Copy false tensor to dst_reg 2
+            fill_tile_init();
+// TST: scalar is true value, goes to dst_reg 1
+#ifdef FILL_WITH_VALUE_FLOAT
+            FILL_LLK(i * 3 + 1, *scalar_val);
+#endif
+#ifdef FILL_WITH_VALUE_INT
+            FILL_LLK(i * 3 + 1, scalar_value);
+#endif
+#endif
+            BINARY_SFPU_OP(i * 3, i * 3 + 1, i * 3 + 2, i * 3);
+        }
+
+        tile_regs_commit();
+
+        tile_regs_wait();
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            pack_tile(i * 3, cb_out.get_cb_id());
+        }
+        tile_regs_release();
+
+        cb_out.push_back(num_tiles_per_cycle);
+        cb_other.pop_front(num_tiles_per_cycle);
+    }
+    cb_bcast.pop_front(num_tiles_per_cycle);
+}
+
+void kernel_main() {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+    uint32_t tile_freq = get_arg_val<uint32_t>(1);
+    uint32_t tile_start = get_arg_val<uint32_t>(2);
+    const uint32_t scalar_value = get_arg_val<uint32_t>(3);
+    const float* scalar_value_ptr = reinterpret_cast<const float*>(&scalar_value);
+
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
+
+    if (num_tiles == 0) {
+        return;
+    }
+
+    constexpr auto cb_in0_id = tt::CBIndex::c_0;
+    constexpr auto cb_in1_id = tt::CBIndex::c_1;
+    constexpr auto cb_out_id = tt::CBIndex::c_2;
+
+    unary_op_init_common(cb_in0_id, cb_out_id);
+    BINARY_SFPU_INIT
+
+    uint32_t complete_iterations = (num_tiles + tile_start) / tile_freq;
+    uint32_t remaining_iterations = (num_tiles + tile_start) % tile_freq;
+
+    for (uint32_t i = 0; i < complete_iterations; ++i, tile_start = 0) {
+        process_tile(
+            cb_in0_id,
+            cb_in1_id,
+            cb_out_id,
+            scalar_value,
+            scalar_value_ptr,
+            tile_freq,
+            tile_start,
+            num_tiles_per_cycle);
+    }
+
+    if (remaining_iterations > 0) {
+        process_tile(
+            cb_in0_id,
+            cb_in1_id,
+            cb_out_id,
+            scalar_value,
+            scalar_value_ptr,
+            remaining_iterations,
+            tile_start,
+            num_tiles_per_cycle);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_where_sfpu_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_where_sfpu_scalar.cpp
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/eltwise_unary/where.h"
+#include "api/compute/eltwise_unary/fill.h"
+#include "eltwise_utils_common.hpp"
+#include "eltwise_utils_sfpu.hpp"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+
+void kernel_main() {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+    const uint32_t scalar_value = get_arg_val<uint32_t>(3);
+    const auto scalar_val = reinterpret_cast<const float*>(&scalar_value);
+
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
+
+    CircularBuffer cb_in0(tt::CBIndex::c_0);
+    CircularBuffer cb_in1(tt::CBIndex::c_1);
+    CircularBuffer cb_out(tt::CBIndex::c_2);
+
+    unary_op_init_common(cb_in0.get_cb_id(), cb_out.get_cb_id());
+
+    BINARY_SFPU_INIT
+
+    cb_in1.wait_front(num_tiles_per_cycle);
+
+    for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
+        cb_in0.wait_front(num_tiles_per_cycle);
+
+        cb_out.reserve_back(num_tiles_per_cycle);
+
+        tile_regs_acquire();
+        copy_tile_to_dst_init_short(cb_in0.get_cb_id());
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            copy_tile(cb_in0.get_cb_id(), i, i * 3);
+        }
+        copy_tile_to_dst_init_short(cb_in1.get_cb_id());
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            // TTS: tensor is true value, goes to dst_reg 1
+#if WHERE_TTS
+            copy_tile(cb_in1.get_cb_id(), i, i * 3 + 1);  // Copy true tensor to dst_reg 1
+            fill_tile_init();
+            // TTS: scalar is false value, goes to dst_reg 2
+#ifdef FILL_WITH_VALUE_FLOAT
+            FILL_LLK(i * 3 + 2, *scalar_val);
+#endif
+#ifdef FILL_WITH_VALUE_INT
+            FILL_LLK(i * 3 + 2, scalar_value);
+#endif
+#endif
+
+// TST: tensor is false value, goes to dst_reg 2
+#if WHERE_TST
+            copy_tile(cb_in1.get_cb_id(), i, i * 3 + 2);  // Copy false tensor to dst_reg 2
+            fill_tile_init();
+            // TST: scalar is true value, goes to dst_reg 1
+#ifdef FILL_WITH_VALUE_FLOAT
+            FILL_LLK(i * 3 + 1, *scalar_val);
+#endif
+#ifdef FILL_WITH_VALUE_INT
+            FILL_LLK(i * 3 + 1, scalar_value);
+#endif
+#endif
+            BINARY_SFPU_OP(i * 3, i * 3 + 1, i * 3 + 2, i * 3);
+        }
+
+        tile_regs_commit();
+
+        tile_regs_wait();
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            pack_tile(i * 3, cb_out.get_cb_id());
+        }
+        tile_regs_release();
+
+        cb_in0.pop_front(num_tiles_per_cycle);
+        cb_out.push_back(num_tiles_per_cycle);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp
@@ -1,0 +1,494 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "api/dataflow/dataflow_api.h"
+
+// Fills one full tile of bfloat16 with a scalar value
+// Scalar is assumed to be a 16-bit value double packed into a u32
+FORCE_INLINE void fill_with_val_bfloat16(uint32_t l1_write_ptr, uint32_t packed_scalar) {
+    auto* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_ptr);
+    // 1024 is the number of elements in a full tile, but since the scalar is packed into a u32,
+    // each iteration writes 2 elements, hence the division by 2
+    for (uint32_t i = 0; i < 512; ++i) {
+        ptr[i] = packed_scalar;
+    }
+}
+
+template <uint32_t ElementsV, class ScalarT>
+FORCE_INLINE void fill_with_val(uint32_t l1_write_ptr, ScalarT scalar) {
+    auto* ptr = reinterpret_cast<volatile tt_l1_ptr ScalarT*>(l1_write_ptr);
+    for (uint32_t i = 0; i < ElementsV; ++i) {
+        ptr[i] = scalar;
+    }
+}
+
+// Reads the very first element of the CB and fills the entire tile with that value.
+// Tile is assumed to have 16-bit elements
+FORCE_INLINE void fill_tile_with_first_element_bfloat16(uint32_t l1_write_ptr) {
+    auto* read_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_ptr);
+    const uint16_t first_elem = read_ptr[0];
+    const uint32_t packed_first_elem = (static_cast<uint32_t>(first_elem) << 16) | static_cast<uint32_t>(first_elem);
+
+    // Since all elements in the tile are the same, we can ignore the faces and assume the entire
+    // tile is contiguous in memory.
+    auto* write_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_ptr);
+    // TODO: should I fill one face like this and then use noc to fill the rest?
+    for (uint32_t i = 0; i < 512; ++i) {
+        write_ptr[i] = packed_first_elem;
+    }
+}
+
+// Reads the very first element of the CB and fills the entire tile with that value.
+// Tile is assumed to have 32-bit elements (float32 or int32).
+template <typename T>
+FORCE_INLINE void fill_tile_with_first_element(uint32_t l1_write_ptr) {
+    auto* read_ptr = reinterpret_cast<volatile tt_l1_ptr T*>(l1_write_ptr);
+    const T first_elem = read_ptr[0];
+
+    auto* write_ptr = reinterpret_cast<volatile tt_l1_ptr T*>(l1_write_ptr);
+    for (uint32_t i = 0; i < 1024; ++i) {
+        write_ptr[i] = first_elem;
+    }
+}
+
+// Reads the very first element of the CB and fills the entire tile with that value.
+// Tile is assumed to be in BFP8 format (Bfp8 or Bfp8_b).
+// BFP8 tile layout (32x32 = 1024 elements, 1088 bytes total):
+//   Bytes 0-63:    Exponent section (16 uint32_t words = 64 bytes)
+//                  4 faces x 16 rows/face, one exponent byte per row of 16 elements
+//   Bytes 64-1087: Data section (256 uint32_t words = 1024 bytes)
+//                  4 faces x 256 bytes/face, one byte per element
+FORCE_INLINE void fill_tile_with_first_element_bfp8(uint32_t l1_write_ptr) {
+    auto* word_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_ptr);
+    uint32_t packed_exp = (word_ptr[0] & 0xFF) * 0x01010101u;
+    uint32_t packed_data = (word_ptr[16] & 0xFF) * 0x01010101u;
+
+    // Fill 64 exponent bytes = 16 uint32_t words (unrolled by 4)
+    for (uint32_t i = 0; i < 16; i += 4) {
+        word_ptr[i] = packed_exp;
+        word_ptr[i + 1] = packed_exp;
+        word_ptr[i + 2] = packed_exp;
+        word_ptr[i + 3] = packed_exp;
+    }
+    // Fill 1024 data bytes = 256 uint32_t words (unrolled by 4, direct indexing)
+    for (uint32_t i = 16; i < 272; i += 4) {
+        word_ptr[i] = packed_data;
+        word_ptr[i + 1] = packed_data;
+        word_ptr[i + 2] = packed_data;
+        word_ptr[i + 3] = packed_data;
+    }
+}
+
+// Reads the very first element of the CB and fills the entire tile with that value.
+// Tile is assumed to be in BFP4 format (Bfp4 or Bfp4_b).
+// BFP4 tile layout (32x32 = 1024 elements, 576 bytes total):
+//   Bytes 0-63:   Exponent section (16 uint32_t words = 64 bytes)
+//                 4 faces x 16 rows/face, one exponent byte per row of 16 elements
+//   Bytes 64-575: Data section (128 uint32_t words = 512 bytes)
+//                 4 faces x 128 bytes/face, 4 bits per element (2 elements per byte)
+// BFP4 nibble packing: element[even] in low nibble (bits 0-3), element[odd] in high nibble (bits 4-7).
+FORCE_INLINE void fill_tile_with_first_element_bfp4(uint32_t l1_write_ptr) {
+    auto* byte_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_ptr);
+    uint8_t exp_val = byte_ptr[0];  // First exponent byte
+
+    // Element 0 (the scalar) is in the LOW nibble of the first data byte.
+    // Element 1 (padding, typically 0) is in the HIGH nibble.
+    // We must pack the scalar into both nibbles so every element gets the same value.
+    uint8_t elem0 = byte_ptr[64] & 0x0F;
+    uint8_t data_val = (elem0 << 4) | elem0;
+
+    uint32_t packed_exp =
+        (uint32_t)exp_val | ((uint32_t)exp_val << 8) | ((uint32_t)exp_val << 16) | ((uint32_t)exp_val << 24);
+    uint32_t packed_data =
+        (uint32_t)data_val | ((uint32_t)data_val << 8) | ((uint32_t)data_val << 16) | ((uint32_t)data_val << 24);
+
+    auto* write_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_ptr);
+    // Fill 64 exponent bytes = 16 uint32_t words
+    for (uint32_t i = 0; i < 16; ++i) {
+        write_ptr[i] = packed_exp;
+    }
+    // Fill 512 data bytes = 128 uint32_t words (starting at word offset 16)
+    for (uint32_t i = 0; i < 128; ++i) {
+        write_ptr[16 + i] = packed_data;
+    }
+}
+
+// Reads the very first column of the CB and fills the entire tile with the same column.
+// Tile is assumed to be in BFP4 format (Bfp4 or Bfp4_b).
+// BFP4 tile layout (576 bytes):
+//   Exponents: face0 [0..15], face1 [16..31], face2 [32..47], face3 [48..63]
+//   Data:      face0 [64..191], face1 [192..319], face2 [320..447], face3 [448..575]
+//   Each face data: 16 rows x 8 bytes/row (2 elements per byte, 16 elements per row)
+// Face arrangement: 0=top-left, 1=top-right, 2=bottom-left, 3=bottom-right
+// Column broadcast: left faces (0,2) have column 0 data; right faces (1,3) are zero.
+//   -> Extract column 0 nibble, pack into both nibbles, fill row, then copy left to right face.
+FORCE_INLINE void fill_tile_with_first_column_bfp4(uint32_t l1_write_ptr) {
+    auto* byte_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_ptr);
+    auto* word_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_ptr);
+
+    // Process left->right face pairs: (face0->face1) and (face2->face3)
+    for (uint32_t pair = 0; pair < 2; ++pair) {
+        uint32_t left_exp_word = pair * 8;               // word 0 or 8
+        uint32_t right_exp_word = left_exp_word + 4;     // word 4 or 12
+        uint32_t left_data_byte = 64 + pair * 256;       // byte 64 or 320
+        uint32_t left_data_word = left_data_byte / 4;    // word 16 or 80
+        uint32_t right_data_word = left_data_word + 32;  // word 48 or 112
+
+        // 1. For each row, extract column 0 (low nibble of first byte), fill all 8 bytes (2 words)
+        for (uint32_t row = 0; row < 16; ++row) {
+            uint8_t elem0 = byte_ptr[left_data_byte + row * 8] & 0x0F;
+            uint8_t fill_byte = (elem0 << 4) | elem0;
+            uint32_t packed = (uint32_t)fill_byte | ((uint32_t)fill_byte << 8) | ((uint32_t)fill_byte << 16) |
+                              ((uint32_t)fill_byte << 24);
+            uint32_t row_word = left_data_word + row * 2;
+            word_ptr[row_word] = packed;
+            word_ptr[row_word + 1] = packed;
+        }
+
+        // 2. Copy left face exponents to right face (4 words)
+        for (uint32_t i = 0; i < 4; ++i) {
+            word_ptr[right_exp_word + i] = word_ptr[left_exp_word + i];
+        }
+
+        // 3. Copy left face data to right face (32 words)
+        for (uint32_t i = 0; i < 32; ++i) {
+            word_ptr[right_data_word + i] = word_ptr[left_data_word + i];
+        }
+    }
+}
+
+// Reads the very first row of the CB and fills the entire tile with the same row.
+// Tile is assumed to be in BFP4 format (Bfp4 or Bfp4_b).
+// Row broadcast: top faces (0,1) have row 0 data; bottom faces (2,3) are zero.
+//   -> Replicate row 0 within top faces, then copy top faces to bottom faces.
+FORCE_INLINE void fill_tile_with_first_row_bfp4(uint32_t l1_write_ptr) {
+    auto* byte_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_ptr);
+    auto* word_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_ptr);
+
+    // Pack row-0 exponents into words and write all 4 faces at once
+    uint32_t packed_exp0 = static_cast<uint32_t>(byte_ptr[0]) * 0x01010101u;
+    uint32_t packed_exp1 = static_cast<uint32_t>(byte_ptr[16]) * 0x01010101u;
+    word_ptr[0] = packed_exp0;
+    word_ptr[1] = packed_exp0;
+    word_ptr[2] = packed_exp0;
+    word_ptr[3] = packed_exp0;
+    word_ptr[4] = packed_exp1;
+    word_ptr[5] = packed_exp1;
+    word_ptr[6] = packed_exp1;
+    word_ptr[7] = packed_exp1;
+    word_ptr[8] = packed_exp0;
+    word_ptr[9] = packed_exp0;
+    word_ptr[10] = packed_exp0;
+    word_ptr[11] = packed_exp0;
+    word_ptr[12] = packed_exp1;
+    word_ptr[13] = packed_exp1;
+    word_ptr[14] = packed_exp1;
+    word_ptr[15] = packed_exp1;
+
+    // Cache row-0 data into registers to avoid repeated volatile reads
+    uint32_t f0_w0 = word_ptr[16], f0_w1 = word_ptr[17];
+    uint32_t f1_w0 = word_ptr[48], f1_w1 = word_ptr[49];
+
+    // Fill face 0 rows 1-15, then face 2 all 16 rows (both from face 0's row 0)
+    uint32_t dst = 18;
+    for (uint32_t row = 1; row < 16; ++row, dst += 2) {
+        word_ptr[dst] = f0_w0;
+        word_ptr[dst + 1] = f0_w1;
+    }
+    dst = 80;
+    for (uint32_t row = 0; row < 16; ++row, dst += 2) {
+        word_ptr[dst] = f0_w0;
+        word_ptr[dst + 1] = f0_w1;
+    }
+
+    // Fill face 1 rows 1-15, then face 3 all 16 rows (both from face 1's row 0)
+    dst = 50;
+    for (uint32_t row = 1; row < 16; ++row, dst += 2) {
+        word_ptr[dst] = f1_w0;
+        word_ptr[dst + 1] = f1_w1;
+    }
+    dst = 112;
+    for (uint32_t row = 0; row < 16; ++row, dst += 2) {
+        word_ptr[dst] = f1_w0;
+        word_ptr[dst + 1] = f1_w1;
+    }
+}
+
+// Reads the very first column of the CB and fills the entire tile with the same column.
+// Tile is assumed to be in BFP8 format (Bfp8 or Bfp8_b).
+// BFP8 tile layout (1088 bytes):
+//   Exponents: face0 [0..15], face1 [16..31], face2 [32..47], face3 [48..63]
+//   Data:      face0 [64..319], face1 [320..575], face2 [576..831], face3 [832..1087]
+//   Each face data: 16 rows x 16 cols = 256 bytes (1 byte per element, row-major)
+// Face arrangement: 0=top-left, 1=top-right, 2=bottom-left, 3=bottom-right
+// Column broadcast: left faces (0,2) have column 0 data; right faces (1,3) are zero.
+//   -> Replicate column 0 within left faces, then copy left faces to right faces.
+FORCE_INLINE void fill_tile_with_first_column_bfp8(uint32_t l1_write_ptr) {
+    auto* word_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_ptr);
+
+    // --- Face pair 0: face0 (left) -> face1 (right) ---
+    // Replicate column 0 across all 16 columns in left face data (4 words per row)
+    uint32_t row_word = 16;  // left face data starts at word 16
+    for (uint32_t row = 0; row < 16; ++row) {
+        uint32_t col0_val = word_ptr[row_word] & 0xFF;
+        uint32_t packed = col0_val | (col0_val << 8) | (col0_val << 16) | (col0_val << 24);
+        word_ptr[row_word] = packed;
+        word_ptr[row_word + 1] = packed;
+        word_ptr[row_word + 2] = packed;
+        word_ptr[row_word + 3] = packed;
+        row_word += 4;
+    }
+    // Copy left face exponents to right face (words 0-3 -> 4-7)
+    word_ptr[4] = word_ptr[0];
+    word_ptr[5] = word_ptr[1];
+    word_ptr[6] = word_ptr[2];
+    word_ptr[7] = word_ptr[3];
+    // Copy left face data to right face (words 16-79 -> 80-143)
+    for (uint32_t i = 0; i < 64; ++i) {
+        word_ptr[80 + i] = word_ptr[16 + i];
+    }
+
+    // --- Face pair 1: face2 (left) -> face3 (right) ---
+    // Replicate column 0 across all 16 columns in left face data (4 words per row)
+    row_word = 144;  // left face data starts at word 144
+    for (uint32_t row = 0; row < 16; ++row) {
+        uint32_t col0_val = word_ptr[row_word] & 0xFF;
+        uint32_t packed = col0_val | (col0_val << 8) | (col0_val << 16) | (col0_val << 24);
+        word_ptr[row_word] = packed;
+        word_ptr[row_word + 1] = packed;
+        word_ptr[row_word + 2] = packed;
+        word_ptr[row_word + 3] = packed;
+        row_word += 4;
+    }
+    // Copy left face exponents to right face (words 8-11 -> 12-15)
+    word_ptr[12] = word_ptr[8];
+    word_ptr[13] = word_ptr[9];
+    word_ptr[14] = word_ptr[10];
+    word_ptr[15] = word_ptr[11];
+    // Copy left face data to right face (words 144-207 -> 208-271)
+    for (uint32_t i = 0; i < 64; ++i) {
+        word_ptr[208 + i] = word_ptr[144 + i];
+    }
+}
+
+// Reads the very first row of the CB and fills the entire tile with the same row.
+// Tile is assumed to be in BFP8 format (Bfp8 or Bfp8_b).
+// Row broadcast: top faces (0,1) have row 0 data; bottom faces (2,3) are zero.
+//   -> Replicate row 0 within top faces, then copy top faces to bottom faces.
+FORCE_INLINE void fill_tile_with_first_row_bfp8(uint32_t l1_write_ptr) {
+    auto* byte_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_ptr);
+    auto* word_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_ptr);
+
+    // Pack row-0 exponents into words and write all 4 faces at once
+    uint32_t packed_exp0 = static_cast<uint32_t>(byte_ptr[0]) * 0x01010101u;
+    uint32_t packed_exp1 = static_cast<uint32_t>(byte_ptr[16]) * 0x01010101u;
+    word_ptr[0] = packed_exp0;
+    word_ptr[1] = packed_exp0;
+    word_ptr[2] = packed_exp0;
+    word_ptr[3] = packed_exp0;
+    word_ptr[4] = packed_exp1;
+    word_ptr[5] = packed_exp1;
+    word_ptr[6] = packed_exp1;
+    word_ptr[7] = packed_exp1;
+    word_ptr[8] = packed_exp0;
+    word_ptr[9] = packed_exp0;
+    word_ptr[10] = packed_exp0;
+    word_ptr[11] = packed_exp0;
+    word_ptr[12] = packed_exp1;
+    word_ptr[13] = packed_exp1;
+    word_ptr[14] = packed_exp1;
+    word_ptr[15] = packed_exp1;
+
+    // Cache row-0 data into registers to avoid repeated volatile reads
+    uint32_t f0_w0 = word_ptr[16], f0_w1 = word_ptr[17];
+    uint32_t f0_w2 = word_ptr[18], f0_w3 = word_ptr[19];
+    uint32_t f1_w0 = word_ptr[80], f1_w1 = word_ptr[81];
+    uint32_t f1_w2 = word_ptr[82], f1_w3 = word_ptr[83];
+
+    // Fill face 0 rows 1-15, then face 2 all 16 rows (both from face 0's row 0)
+    uint32_t dst = 20;
+    for (uint32_t row = 1; row < 16; ++row, dst += 4) {
+        word_ptr[dst] = f0_w0;
+        word_ptr[dst + 1] = f0_w1;
+        word_ptr[dst + 2] = f0_w2;
+        word_ptr[dst + 3] = f0_w3;
+    }
+    dst = 144;
+    for (uint32_t row = 0; row < 16; ++row, dst += 4) {
+        word_ptr[dst] = f0_w0;
+        word_ptr[dst + 1] = f0_w1;
+        word_ptr[dst + 2] = f0_w2;
+        word_ptr[dst + 3] = f0_w3;
+    }
+
+    // Fill face 1 rows 1-15, then face 3 all 16 rows (both from face 1's row 0)
+    dst = 84;
+    for (uint32_t row = 1; row < 16; ++row, dst += 4) {
+        word_ptr[dst] = f1_w0;
+        word_ptr[dst + 1] = f1_w1;
+        word_ptr[dst + 2] = f1_w2;
+        word_ptr[dst + 3] = f1_w3;
+    }
+    dst = 208;
+    for (uint32_t row = 0; row < 16; ++row, dst += 4) {
+        word_ptr[dst] = f1_w0;
+        word_ptr[dst + 1] = f1_w1;
+        word_ptr[dst + 2] = f1_w2;
+        word_ptr[dst + 3] = f1_w3;
+    }
+}
+
+// Reads the very first row of the CB and fills the entire tile with the same row.
+// Tile is assumed to have 16-bit elements.
+FORCE_INLINE void fill_tile_with_first_row_bfloat16(uint32_t l1_write_ptr) {
+    // Here we have to account for the fact that a tile consists of 4 16x16 faces.
+    // So we have to fill faces 0 and 2 with the first row of face 0, and faces 1 and 3
+    // with the first row of face 1.
+    auto* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_ptr);
+    uint32_t row_offset = 8;  // start at second row since first row is source
+    uint32_t num_rows = 15;
+
+    // iterate over face pairs (0,1) and (2,3)
+    for (uint32_t k = 0, face_offset = 0; k < 2; ++k, face_offset += 256) {
+        for (uint32_t row = 0; row < num_rows; ++row) {
+            uint32_t dst_offset = face_offset + row_offset;
+            for (uint32_t col = 0; col < 8; ++col) {
+                ptr[dst_offset + col] = ptr[col];              // left face
+                ptr[dst_offset + col + 128] = ptr[col + 128];  // right face
+            }
+            row_offset += 8;
+        }
+        row_offset = 0;
+        num_rows = 16;
+    }
+}
+
+// Reads the very first row of the CB and fills the entire tile with the same row.
+// Tile is assumed to have 32-bit elements (float32/int32).
+FORCE_INLINE void fill_tile_with_first_row(uint32_t l1_write_ptr) {
+    // Tile with 4 faces (16x16) and 32-bit elements
+    auto* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_ptr);
+
+    uint32_t row_offset = 16;  // Start at the second row (offset by 16 elements)
+    uint32_t num_rows = 15;    // 15 rows to fill per face
+
+    // Iterate over face pairs (0,1) and (2,3)
+    for (uint32_t k = 0, face_offset = 0; k < 2; ++k, face_offset += 512) {  // Offset 512 = 256 elements x 2 faces
+        for (uint32_t row = 0; row < num_rows; ++row) {
+            uint32_t dst_offset = face_offset + row_offset;
+            for (uint32_t col = 0; col < 16; ++col) {
+                ptr[dst_offset + col] = ptr[col];              // left face
+                ptr[dst_offset + col + 256] = ptr[col + 256];  // right face
+            }
+            row_offset += 16;  // Move to the next row (16 elements per row)
+        }
+        row_offset = 0;  // Reset for the next face pair
+        num_rows = 16;   // Process all rows for the next face pair
+    }
+}
+
+// Reads the very first column of the CB and fills the entire tile with the same column.
+// Tile is assumed to have 16-bit elements.
+FORCE_INLINE void fill_tile_with_first_column_bfloat16(uint32_t l1_write_ptr) {
+    // Here we have to account for the fact that a tile consists of 4 16x16 faces.
+    // So we have to fill faces 0 and 1 with the first column of face 0, and faces 2 and 3
+    // with the first column of face 2.
+    auto* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_ptr);
+
+    constexpr uint32_t num_rows = 16;
+
+    // iterate over face pairs (0,1) and (2,3)
+    for (uint32_t k = 0, face_offset = 0; k < 2; ++k, face_offset += 512) {
+        for (uint32_t row = 0, row_offset = 0; row < num_rows; ++row, row_offset += 16) {
+            uint32_t dst_offset = face_offset + row_offset;
+            auto src_val = ptr[dst_offset];
+
+            ptr[dst_offset + 256] = src_val;  // first column of right face
+            for (uint32_t col = 1; col < 16; ++col) {
+                ptr[dst_offset + col] = src_val;        // left face
+                ptr[dst_offset + col + 256] = src_val;  // right face
+            }
+        }
+    }
+}
+
+// Reads the very first column of the CB and fills the entire tile with the same column.
+// Tile is assumed to have 32-bit elements (float32/int32).
+FORCE_INLINE void fill_tile_with_first_column(uint32_t l1_write_ptr) {
+    // Tile with 4 faces (16x16) and 32-bit elements
+    auto* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_ptr);
+
+    constexpr uint32_t num_rows = 16;             // Number of rows per face
+    constexpr uint32_t face_row_stride = 16;      // Elements per row
+    constexpr uint32_t face_size = 256;           // Total elements per face (16x16)
+    constexpr uint32_t face_offset_stride = 512;  // Total elements per pair of faces (2x16x16)
+
+    // Iterate over face pairs (0,1) and (2,3)
+    for (uint32_t k = 0, face_offset = 0; k < 2; ++k, face_offset += face_offset_stride) {
+        for (uint32_t row = 0, row_offset = 0; row < num_rows; ++row, row_offset += face_row_stride) {
+            uint32_t left_dst_offset = face_offset + row_offset;      // Left face (0 or 2)
+            uint32_t right_dst_offset = left_dst_offset + face_size;  // Right face (1 or 3)
+
+            // Read the first column value for the current row from the left face
+            auto src_val = ptr[left_dst_offset];
+
+            for (uint32_t col = 0; col < face_row_stride; ++col) {
+                ptr[left_dst_offset + col] = src_val;   // left face
+                ptr[right_dst_offset + col] = src_val;  // right face
+            }
+        }
+    }
+}
+
+// Row-major helpers for 32-bit elements (float32/int32/uint32).
+FORCE_INLINE void fill_tile_with_first_column_rm(uint32_t ptr_arg, uint32_t row_width) {
+    auto* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(ptr_arg);
+    const uint32_t first_elem = ptr[0];
+    for (uint32_t i = 1; i < row_width; i++) {
+        ptr[i] = first_elem;
+    }
+}
+
+FORCE_INLINE void fill_tile_with_first_row_rm(uint32_t ptr_arg, uint32_t row_width, uint32_t num_rows) {
+    auto* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(ptr_arg);
+    for (uint32_t row = 1; row < num_rows; row++) {
+        const uint32_t row_offset = row * row_width;
+        for (uint32_t col = 0; col < row_width; col++) {
+            ptr[row_offset + col] = ptr[col];
+        }
+    }
+}
+FORCE_INLINE void fill_tile_with_first_column_rm_bfloat16(uint32_t ptr_arg, uint32_t row_width) {
+    auto* ptr16 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(ptr_arg);
+    const uint16_t first_elem = ptr16[0];
+    const uint32_t packed = (static_cast<uint32_t>(first_elem) << 16) | first_elem;
+    const uint32_t row_width_words = row_width >> 1;
+    auto* ptr32 = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(ptr_arg);
+    for (uint32_t i = 0; i < row_width_words; i++) {
+        ptr32[i] = packed;
+    }
+    if (row_width & 1) {
+        ptr16[row_width - 1] = first_elem;
+    }
+}
+
+FORCE_INLINE void fill_tile_with_first_row_rm_bfloat16(uint32_t ptr_arg, uint32_t row_width, uint32_t num_rows) {
+    const uint32_t row_width_words = row_width >> 1;
+    auto* ptr32 = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(ptr_arg);
+    for (uint32_t i = 1; i < num_rows; i++) {
+        const uint32_t row_offset = i * row_width_words;
+        for (uint32_t j = 0; j < row_width_words; j++) {
+            ptr32[row_offset + j] = ptr32[j];
+        }
+    }
+    if (row_width & 1) {
+        auto* ptr16 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(ptr_arg);
+        const uint32_t last_elem = row_width - 1;
+        for (uint32_t i = 1; i < num_rows; i++) {
+            ptr16[i * row_width + last_elem] = ptr16[last_elem];
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast.cpp
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t start_tile_id = get_arg_val<uint32_t>(1);
+    const uint32_t src_num_tiles = get_arg_val<uint32_t>(2);
+    const uint32_t dst_num_tiles = get_arg_val<uint32_t>(3);
+    const uint32_t dst_shard_width = get_arg_val<uint32_t>(4);
+    const uint32_t nD_stride = get_arg_val<uint32_t>(5);
+    const uint32_t d_stride = get_arg_val<uint32_t>(6);
+    const uint32_t n_stride = get_arg_val<uint32_t>(7);
+    const uint32_t c_stride = get_arg_val<uint32_t>(8);
+    const uint32_t D = get_arg_val<uint32_t>(9);
+    const uint32_t N = get_arg_val<uint32_t>(10);
+    const uint32_t C = get_arg_val<uint32_t>(11);
+    const uint32_t Ht = get_arg_val<uint32_t>(12);
+    const uint32_t Wt = get_arg_val<uint32_t>(13);
+    const uint32_t cND = get_arg_val<uint32_t>(14);  // collapsed dims > 5
+
+    constexpr auto cb_id_src = tt::CBIndex::c_0;
+
+    Noc noc;
+    CircularBuffer cb_src(cb_id_src);
+
+#if SRC_SHARDED
+    cb_src.reserve_back(src_num_tiles);
+    cb_src.push_back(src_num_tiles);
+#else
+    constexpr uint32_t onetile = 1;
+    constexpr auto src_args = TensorAccessorArgs<0, 0>();
+    constexpr bool has_sharding = get_compile_time_arg_val(src_args.next_compile_time_args_offset()) == 1;
+    const uint32_t src_tile_bytes = cb_src.get_tile_size();
+    const auto src = TensorAccessor(src_args, src_addr);
+    const uint32_t HtWt = Ht * Wt;
+
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_tile_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    const uint32_t offset_c = offset_n % HtWt;
+    uint32_t start_nd = start_tile_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_th = offset_c / Wt;
+    uint32_t start_tw = offset_c % Wt;
+    uint32_t end_tw = has_sharding ? start_tw + dst_shard_width : Wt;
+
+    // this is the INPUT tile offset
+    uint32_t tile_offset =
+        start_nd * nD_stride + start_d * d_stride + start_n * n_stride + start_c * c_stride + start_th * Wt;
+    uint32_t next_c_shift = c_stride - HtWt;
+    uint32_t next_n_shift = n_stride - c_stride * C;
+    uint32_t next_d_shift = d_stride - n_stride * N;
+    uint32_t next_nd_shift = nD_stride - d_stride * D;
+
+    uint32_t num_tiles_read = 0;
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_read < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
+                    for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th) {
+                        for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
+                             ++tw, ++num_tiles_read) {
+                            cb_src.reserve_back(onetile);
+                            noc.async_read(
+                                src, cb_src, src_tile_bytes, {.page_id = tile_offset + tw}, {.offset_bytes = 0});
+                            noc.async_read_barrier();
+                            cb_src.push_back(onetile);
+                        }
+                        if constexpr (!has_sharding) {
+                            // next row of tiles should start at the first column
+                            start_tw = 0;
+                        }
+                        tile_offset += Wt;
+                    }
+                    tile_offset += next_c_shift;
+                }
+                tile_offset += next_n_shift;
+            }
+            tile_offset += next_d_shift;
+        }
+        tile_offset += next_nd_shift;
+    }
+#endif
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/dataflow/writer_interleaved_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/dataflow/writer_interleaved_scalar.cpp
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+
+void kernel_main() {
+    const uint32_t packed_scalar = get_arg_val<uint32_t>(0);
+    const uint32_t dst_addr = get_arg_val<uint32_t>(1);
+    const uint32_t start_tile_id = get_arg_val<uint32_t>(2);
+    const uint32_t dst_num_tiles = get_arg_val<uint32_t>(3);
+    const uint32_t dst_shard_width = get_arg_val<uint32_t>(4);
+    const uint32_t D = get_arg_val<uint32_t>(5);
+    const uint32_t N = get_arg_val<uint32_t>(6);
+    const uint32_t C = get_arg_val<uint32_t>(7);
+    const uint32_t Ht = get_arg_val<uint32_t>(8);
+    const uint32_t Wt = get_arg_val<uint32_t>(9);
+    const uint32_t cND = get_arg_val<uint32_t>(10);  // collapsed dims > 5
+    const uint32_t HtWt = Ht * Wt;
+
+    constexpr auto cb_id_src = tt::CBIndex::c_1;
+    constexpr auto cb_id_dst = tt::CBIndex::c_2;
+    constexpr uint32_t onetile = 1;
+
+    Noc noc;
+    CircularBuffer cb_src(cb_id_src);
+    CircularBuffer cb_dst(cb_id_dst);
+
+    // we only need to fill a tile with the scalar value once
+    cb_src.reserve_back(onetile);
+#ifdef FILL_WITH_VALUE_FLOAT
+    const auto float_ptr = reinterpret_cast<const float*>(&packed_scalar);
+    FILL_WITH_VALUE_FLOAT(cb_src.get_write_ptr(), *float_ptr);
+#endif
+#ifdef FILL_WITH_VALUE
+    FILL_WITH_VALUE(cb_src.get_write_ptr(), packed_scalar);
+#endif
+    cb_src.push_back(onetile);
+
+#if !DST_SHARDED
+    constexpr auto dst_args = TensorAccessorArgs<0, 0>();
+    const uint32_t dst_tile_bytes = cb_dst.get_tile_size();
+    const auto dst = TensorAccessor(dst_args, dst_addr);
+    constexpr bool has_sharding = get_compile_time_arg_val(dst_args.next_compile_time_args_offset()) == 1;
+
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_tile_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    const uint32_t offset_c = offset_n % HtWt;
+    uint32_t start_nd = start_tile_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_th = offset_c / Wt;
+    uint32_t start_tw = offset_c % Wt;
+    uint32_t end_tw = has_sharding ? start_tw + dst_shard_width : Wt;
+
+    uint32_t num_tiles_written = 0;
+    uint32_t dst_tile_offset = start_tile_id;
+
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_written < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_written < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_written < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_written < dst_num_tiles; ++c, start_th = 0) {
+                    for (uint32_t th = start_th; th < Ht && num_tiles_written < dst_num_tiles; ++th) {
+                        for (uint32_t tw = start_tw; tw < end_tw && num_tiles_written < dst_num_tiles;
+                             ++tw, ++num_tiles_written) {
+                            // write a tile to dst
+                            cb_dst.wait_front(onetile);
+                            noc.async_write(
+                                cb_dst, dst, dst_tile_bytes, {}, {.page_id = dst_tile_offset + num_tiles_written});
+                            noc.async_write_barrier();
+                            cb_dst.pop_front(onetile);
+                        }
+                        if constexpr (has_sharding) {
+                            // adjust the output tile offset since we had to skip parts of the row
+                            dst_tile_offset += (Wt - dst_shard_width);
+                        } else {
+                            // otherwise, next row of tiles should start at the first column
+                            start_tw = 0;
+                        }
+                    }
+                }
+            }
+        }
+    }
+#endif
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_col_bcast.cpp
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/compute/eltwise_unary/sfpu_split_includes.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/bcast.h"
+
+#include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
+#include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+
+ALWI void process_tile(
+    tt::CBIndex cb_bcast,
+    tt::CBIndex cb_llk_post,
+    tt::CBIndex cb_pre_lhs,
+    tt::CBIndex cb_post_lhs,
+    tt::CBIndex cb_pre_rhs,
+    tt::CBIndex cb_post_rhs,
+    tt::CBIndex cb_out,
+    uint32_t freq,
+    uint32_t tile_start,
+    uint32_t num_tiles_per_cycle) {
+    using namespace ckernel;
+
+#if BCAST_INPUT
+#define CB_PRE_BCAST cb_pre_rhs
+#define CB_POST_BCAST cb_post_rhs
+#define CB_PRE_OTHER cb_pre_lhs
+#define CB_POST_OTHER cb_post_lhs
+#define EXP_CB_POST_BCAST exp_cb_post_rhs
+#define EXP_CB_POST_OTHER exp_cb_post_lhs
+#else
+#define CB_PRE_BCAST cb_pre_lhs
+#define CB_POST_BCAST cb_post_lhs
+#define CB_PRE_OTHER cb_pre_rhs
+#define CB_POST_OTHER cb_post_rhs
+#define EXP_CB_POST_BCAST exp_cb_post_lhs
+#define EXP_CB_POST_OTHER exp_cb_post_rhs
+#endif
+    CircularBuffer exp_cb_bcast(cb_bcast);
+    CircularBuffer exp_cb_llk_post(cb_llk_post);
+    CircularBuffer exp_cb_post_lhs(cb_post_lhs);
+    CircularBuffer exp_cb_post_rhs(cb_post_rhs);
+    CircularBuffer exp_cb_out(cb_out);
+
+    exp_cb_bcast.wait_front(num_tiles_per_cycle);
+    pack_reconfig_data_format(cb_out, cb_llk_post);
+    unary_bcast_init<BroadcastType::COL>(cb_bcast, cb_llk_post);
+    exp_cb_llk_post.reserve_back(num_tiles_per_cycle);
+    tile_regs_acquire();
+    unary_bcast<BroadcastType::COL>(cb_bcast, 0, 0);
+    tile_regs_commit();
+    tile_regs_wait();
+    pack_tile(0, cb_llk_post);
+    exp_cb_llk_post.push_back(num_tiles_per_cycle);
+    tile_regs_release();
+
+    pack_reconfig_data_format(cb_llk_post, cb_out);
+#ifdef ARCH_BLACKHOLE
+    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
+#endif
+
+    PREPROCESS(
+        BCAST_OP,
+        CircularBuffer(CB_PRE_BCAST),
+        CircularBuffer(CB_POST_BCAST),
+        CircularBuffer(cb_out),
+        num_tiles_per_cycle);
+    EXP_CB_POST_BCAST.wait_front(num_tiles_per_cycle);
+
+#if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST))
+    binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
+#endif
+
+    for (uint32_t j = tile_start; j < freq; ++j) {
+        PREPROCESS(
+            OTHER_OP,
+            CircularBuffer(CB_PRE_OTHER),
+            CircularBuffer(CB_POST_OTHER),
+            CircularBuffer(cb_out),
+            num_tiles_per_cycle);
+        EXP_CB_POST_OTHER.wait_front(num_tiles_per_cycle);
+
+        exp_cb_out.reserve_back(num_tiles_per_cycle);
+
+#if HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST)
+        binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
+#endif
+        tile_regs_acquire();
+        BINARY_OP(cb_post_lhs, cb_post_rhs, 0, 0, 0);
+        PROCESS_POST_ACTIVATIONS(0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, cb_out);
+        tile_regs_release();
+
+        exp_cb_out.push_back(num_tiles_per_cycle);
+        EXP_CB_POST_OTHER.pop_front(num_tiles_per_cycle);
+    }
+    exp_cb_bcast.pop_front(num_tiles_per_cycle);
+    EXP_CB_POST_BCAST.pop_front(num_tiles_per_cycle);
+}
+
+void kernel_main() {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+    uint32_t tile_freq = get_arg_val<uint32_t>(1);
+    uint32_t tile_start = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
+
+    if (num_tiles == 0) {
+        return;
+    }
+
+    constexpr auto cb_out = tt::CBIndex::c_2;
+
+#if SRC_BCAST
+    constexpr auto cb_bcast = tt::CBIndex::c_0;
+    constexpr auto cb_llk_post = tt::CBIndex::c_5;
+    constexpr auto cb_pre_lhs = cb_llk_post;
+    constexpr auto cb_pre_rhs = tt::CBIndex::c_1;
+    constexpr auto cb_post_lhs = HAS_ACTIVATIONS(LHS) ? tt::CBIndex::c_3 : cb_llk_post;
+    constexpr auto cb_post_rhs = HAS_ACTIVATIONS(RHS) ? tt::CBIndex::c_4 : tt::CBIndex::c_1;
+#endif
+#if SRC_BCAST_B
+    constexpr auto cb_bcast = tt::CBIndex::c_1;
+    constexpr auto cb_llk_post = tt::CBIndex::c_6;
+    constexpr auto cb_pre_lhs = tt::CBIndex::c_0;
+    constexpr auto cb_pre_rhs = cb_llk_post;
+    constexpr auto cb_post_lhs = HAS_ACTIVATIONS(LHS) ? tt::CBIndex::c_3 : tt::CBIndex::c_0;
+    constexpr auto cb_post_rhs = HAS_ACTIVATIONS(RHS) ? tt::CBIndex::c_4 : cb_llk_post;
+#endif
+
+    binary_op_init_common(cb_post_lhs, cb_post_rhs, cb_out);
+#ifdef PACK_RELU
+    PACK((llk_pack_relu_config(ReluConfig::zero())));
+#endif
+
+#if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST))
+    binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
+#endif
+
+    uint32_t complete_iterations = (num_tiles + tile_start) / tile_freq;
+    uint32_t remaining_iterations = (num_tiles + tile_start) % tile_freq;
+
+    for (uint32_t i = 0; i < complete_iterations; ++i, tile_start = 0) {
+        process_tile(
+            cb_bcast,
+            cb_llk_post,
+            cb_pre_lhs,
+            cb_post_lhs,
+            cb_pre_rhs,
+            cb_post_rhs,
+            cb_out,
+            tile_freq,
+            tile_start,
+            num_tiles_per_cycle);
+    }
+
+    if (remaining_iterations > 0) {
+        process_tile(
+            cb_bcast,
+            cb_llk_post,
+            cb_pre_lhs,
+            cb_post_lhs,
+            cb_pre_rhs,
+            cb_post_rhs,
+            cb_out,
+            remaining_iterations,
+            tile_start,
+            num_tiles_per_cycle);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_row_bcast.cpp
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/eltwise_unary/sfpu_split_includes.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/bcast.h"
+
+#include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
+#include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+#include "api/dataflow/circular_buffer.h"
+
+void kernel_main() {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
+    constexpr auto cb_out = tt::CBIndex::c_2;
+    CircularBuffer exp_cb_out(cb_out);
+
+#if SRC_BCAST
+    constexpr auto cb_bcast = tt::CBIndex::c_0;
+    constexpr auto cb_llk_post = tt::CBIndex::c_5;
+    constexpr auto cb_pre_lhs = cb_llk_post;
+    constexpr auto cb_pre_rhs = tt::CBIndex::c_1;
+    constexpr auto cb_post_lhs = HAS_ACTIVATIONS(LHS) ? tt::CBIndex::c_3 : cb_llk_post;
+    constexpr auto cb_post_rhs = HAS_ACTIVATIONS(RHS) ? tt::CBIndex::c_4 : tt::CBIndex::c_1;
+#endif
+#if SRC_BCAST_B
+    constexpr auto cb_bcast = tt::CBIndex::c_1;
+    constexpr auto cb_llk_post = tt::CBIndex::c_6;
+    constexpr auto cb_pre_lhs = tt::CBIndex::c_0;
+    constexpr auto cb_pre_rhs = cb_llk_post;
+    constexpr auto cb_post_lhs = HAS_ACTIVATIONS(LHS) ? tt::CBIndex::c_3 : tt::CBIndex::c_0;
+    constexpr auto cb_post_rhs = HAS_ACTIVATIONS(RHS) ? tt::CBIndex::c_4 : cb_llk_post;
+#endif
+
+    CircularBuffer exp_cb_bcast(cb_bcast);
+    CircularBuffer exp_cb_llk_post(cb_llk_post);
+    CircularBuffer exp_cb_post_lhs(cb_post_lhs);
+    CircularBuffer exp_cb_post_rhs(cb_post_rhs);
+
+    binary_op_init_common(cb_post_lhs, cb_post_rhs, cb_out);
+#ifdef PACK_RELU
+    PACK((llk_pack_relu_config(ReluConfig::zero())));
+#endif
+
+    for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
+        exp_cb_bcast.wait_front(num_tiles_per_cycle);
+        exp_cb_llk_post.reserve_back(num_tiles_per_cycle);
+        pack_reconfig_data_format(cb_out, cb_llk_post);
+        unary_bcast_init<BroadcastType::ROW>(cb_bcast, cb_llk_post);
+
+        tile_regs_acquire();
+        unary_bcast<BroadcastType::ROW>(cb_bcast, 0, 0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, cb_llk_post);
+        exp_cb_llk_post.push_back(num_tiles_per_cycle);
+        tile_regs_release();
+        exp_cb_bcast.pop_front(num_tiles_per_cycle);
+        // unary_bcast_uninit<BroadcastType::ROW>(cb_bcast);
+        pack_reconfig_data_format(cb_llk_post, cb_out);
+#ifdef ARCH_BLACKHOLE
+        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
+#endif
+
+        PREPROCESS(LHS, CircularBuffer(cb_pre_lhs), exp_cb_post_lhs, exp_cb_out, num_tiles_per_cycle);
+        exp_cb_post_lhs.wait_front(num_tiles_per_cycle);
+
+        PREPROCESS(RHS, CircularBuffer(cb_pre_rhs), exp_cb_post_rhs, exp_cb_out, num_tiles_per_cycle);
+        exp_cb_post_rhs.wait_front(num_tiles_per_cycle);
+
+        binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
+        exp_cb_out.reserve_back(num_tiles_per_cycle);
+
+        tile_regs_acquire();
+        BINARY_OP(cb_post_lhs, cb_post_rhs, 0, 0, 0);
+        PROCESS_POST_ACTIVATIONS(0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, cb_out);
+        tile_regs_release();
+
+        exp_cb_out.push_back(num_tiles_per_cycle);
+        exp_cb_post_lhs.pop_front(num_tiles_per_cycle);
+        exp_cb_post_rhs.pop_front(num_tiles_per_cycle);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_row_col_bcast.cpp
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/compute/eltwise_unary/sfpu_split_includes.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/eltwise_unary/trigonometry.h"
+#include "api/compute/bcast.h"
+
+#include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
+#include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+#include "api/dataflow/circular_buffer.h"
+
+ALWI void process_tile(
+    tt::CBIndex cb_pre_lhs,
+    tt::CBIndex cb_post_lhs,
+    tt::CBIndex cb_pre_rhs,
+    tt::CBIndex cb_post_rhs,
+    tt::CBIndex cb_out,
+    uint32_t freq,
+    uint32_t tile_start,
+    uint32_t num_tiles_per_cycle) {
+    using namespace ckernel;
+    CircularBuffer exp_cb_out(cb_out);
+
+#if BCAST_INPUT  // ROW_A_COL_B
+#define CB_PRE_BCAST cb_pre_rhs
+#define CB_POST_BCAST cb_post_rhs
+#define CB_POST_OTHER cb_post_lhs
+    constexpr auto cb_raw_other = tt::CBIndex::c_0;
+    constexpr auto cb_llk_post = tt::CBIndex::c_5;
+    auto cb_left = cb_post_lhs;
+    auto cb_right = cb_post_rhs;
+#else  // ROW_B_COL_A
+#define CB_PRE_BCAST cb_pre_lhs
+#define CB_POST_BCAST cb_post_lhs
+#define CB_POST_OTHER cb_post_rhs
+    constexpr auto cb_raw_other = tt::CBIndex::c_1;
+    constexpr auto cb_llk_post = tt::CBIndex::c_6;
+    auto cb_left = cb_post_lhs;
+    auto cb_right = cb_post_rhs;
+#endif
+
+    CircularBuffer exp_cb_raw_other(cb_raw_other);
+    CircularBuffer exp_cb_llk_post(cb_llk_post);
+    CircularBuffer exp_cb_post_bcast(CB_POST_BCAST);
+    CircularBuffer exp_cb_post_other(CB_POST_OTHER);
+
+    binary_op_init_common(cb_left, cb_right, cb_out);
+    PREPROCESS(BCAST_OP, CircularBuffer(CB_PRE_BCAST), exp_cb_post_bcast, exp_cb_out, num_tiles_per_cycle);
+    exp_cb_post_bcast.wait_front(num_tiles_per_cycle);
+
+    for (uint32_t j = tile_start; j < freq; ++j) {
+        exp_cb_raw_other.wait_front(num_tiles_per_cycle);
+        exp_cb_llk_post.reserve_back(num_tiles_per_cycle);
+        pack_reconfig_data_format(cb_out, cb_llk_post);
+        unary_bcast_init<BroadcastType::ROW>(cb_raw_other, cb_llk_post);
+
+        tile_regs_acquire();
+        unary_bcast<BroadcastType::ROW>(cb_raw_other, 0, 0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, cb_llk_post);
+        exp_cb_llk_post.push_back(num_tiles_per_cycle);
+        tile_regs_release();
+        exp_cb_raw_other.pop_front(num_tiles_per_cycle);
+        // unary_bcast_uninit<BroadcastType::ROW>(cb_raw_other);
+        pack_reconfig_data_format(cb_llk_post, cb_out);
+#ifdef ARCH_BLACKHOLE
+        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
+#endif
+
+        PREPROCESS(OTHER_OP, CircularBuffer(cb_llk_post), exp_cb_post_other, exp_cb_out, num_tiles_per_cycle);
+        exp_cb_post_other.wait_front(num_tiles_per_cycle);
+
+        binary_tiles_init<true, BINARY_OP_TYPE>(cb_left, cb_right);
+        exp_cb_out.reserve_back(num_tiles_per_cycle);
+
+        tile_regs_acquire();
+        BINARY_OP(cb_left, cb_right, 0, 0, 0);
+        PROCESS_POST_ACTIVATIONS(0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, cb_out);
+        tile_regs_release();
+
+        exp_cb_out.push_back(num_tiles_per_cycle);
+        exp_cb_post_other.pop_front(num_tiles_per_cycle);
+    }
+    exp_cb_post_bcast.pop_front(num_tiles_per_cycle);
+}
+
+void kernel_main() {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+    uint32_t tile_freq = get_arg_val<uint32_t>(1);
+    uint32_t tile_start = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
+
+    if (num_tiles == 0) {
+        return;
+    }
+
+    constexpr auto cb_out = tt::CBIndex::c_2;
+
+#if BCAST_INPUT  // ROW_A_COL_B: A=row bcast, B=col bcast
+    constexpr auto cb_llk_post = tt::CBIndex::c_5;
+    constexpr auto cb_pre_lhs = cb_llk_post;
+    constexpr auto cb_post_lhs = HAS_ACTIVATIONS(LHS) ? tt::CBIndex::c_3 : cb_llk_post;
+    constexpr auto cb_pre_rhs = tt::CBIndex::c_1;
+    constexpr auto cb_post_rhs = HAS_ACTIVATIONS(RHS) ? tt::CBIndex::c_4 : tt::CBIndex::c_1;
+#else  // ROW_B_COL_A: B=row bcast, A=col bcast
+    constexpr auto cb_llk_post = tt::CBIndex::c_6;
+    constexpr auto cb_pre_lhs = tt::CBIndex::c_0;
+    constexpr auto cb_post_lhs = HAS_ACTIVATIONS(LHS) ? tt::CBIndex::c_3 : tt::CBIndex::c_0;
+    constexpr auto cb_pre_rhs = cb_llk_post;
+    constexpr auto cb_post_rhs = HAS_ACTIVATIONS(RHS) ? tt::CBIndex::c_4 : cb_llk_post;
+#endif
+
+#ifdef PACK_RELU
+    PACK((llk_pack_relu_config(ReluConfig::zero())));
+#endif
+
+    uint32_t complete_iterations = (num_tiles + tile_start) / tile_freq;
+    uint32_t remaining_iterations = (num_tiles + tile_start) % tile_freq;
+
+    for (uint32_t i = 0; i < complete_iterations; ++i, tile_start = 0) {
+        process_tile(
+            cb_pre_lhs, cb_post_lhs, cb_pre_rhs, cb_post_rhs, cb_out, tile_freq, tile_start, num_tiles_per_cycle);
+    }
+
+    if (remaining_iterations > 0) {
+        process_tile(
+            cb_pre_lhs,
+            cb_post_lhs,
+            cb_pre_rhs,
+            cb_post_rhs,
+            cb_out,
+            remaining_iterations,
+            tile_start,
+            num_tiles_per_cycle);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_scalar_bcast.cpp
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/compute/eltwise_unary/sfpu_split_includes.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/bcast.h"
+
+#include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
+#include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+
+ALWI void process_tile(
+    tt::CBIndex cb_bcast,
+    tt::CBIndex cb_llk_post,
+    tt::CBIndex cb_pre_lhs,
+    tt::CBIndex cb_post_lhs,
+    tt::CBIndex cb_pre_rhs,
+    tt::CBIndex cb_post_rhs,
+    tt::CBIndex cb_out,
+    uint32_t freq,
+    uint32_t tile_start,
+    uint32_t num_tiles_per_cycle) {
+    using namespace ckernel;
+
+#if BCAST_INPUT
+#define CB_PRE_BCAST cb_pre_rhs
+#define CB_POST_BCAST cb_post_rhs
+#define CB_PRE_OTHER cb_pre_lhs
+#define CB_POST_OTHER cb_post_lhs
+#define EXP_CB_POST_BCAST exp_cb_post_rhs
+#define EXP_CB_POST_OTHER exp_cb_post_lhs
+#else
+#define CB_PRE_BCAST cb_pre_lhs
+#define CB_POST_BCAST cb_post_lhs
+#define CB_PRE_OTHER cb_pre_rhs
+#define CB_POST_OTHER cb_post_rhs
+#define EXP_CB_POST_BCAST exp_cb_post_lhs
+#define EXP_CB_POST_OTHER exp_cb_post_rhs
+#endif
+    CircularBuffer exp_cb_bcast(cb_bcast);
+    CircularBuffer exp_cb_llk_post(cb_llk_post);
+    CircularBuffer exp_cb_post_lhs(cb_post_lhs);
+    CircularBuffer exp_cb_post_rhs(cb_post_rhs);
+    CircularBuffer exp_cb_out(cb_out);
+
+    exp_cb_bcast.wait_front(num_tiles_per_cycle);
+    pack_reconfig_data_format(cb_out, cb_llk_post);
+    unary_bcast_init<BroadcastType::SCALAR>(cb_bcast, cb_llk_post);
+    exp_cb_llk_post.reserve_back(num_tiles_per_cycle);
+    tile_regs_acquire();
+    unary_bcast<BroadcastType::SCALAR>(cb_bcast, 0, 0);
+    tile_regs_commit();
+    tile_regs_wait();
+    pack_tile(0, cb_llk_post);
+    exp_cb_llk_post.push_back(num_tiles_per_cycle);
+    tile_regs_release();
+
+    pack_reconfig_data_format(cb_llk_post, cb_out);
+#ifdef ARCH_BLACKHOLE
+    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
+#endif
+
+    PREPROCESS(
+        BCAST_OP,
+        CircularBuffer(CB_PRE_BCAST),
+        CircularBuffer(CB_POST_BCAST),
+        CircularBuffer(cb_out),
+        num_tiles_per_cycle);
+    EXP_CB_POST_BCAST.wait_front(num_tiles_per_cycle);
+
+#if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST))
+    binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
+#endif
+
+    for (uint32_t j = tile_start; j < freq; ++j) {
+        PREPROCESS(
+            OTHER_OP,
+            CircularBuffer(CB_PRE_OTHER),
+            CircularBuffer(CB_POST_OTHER),
+            CircularBuffer(cb_out),
+            num_tiles_per_cycle);
+        EXP_CB_POST_OTHER.wait_front(num_tiles_per_cycle);
+
+        exp_cb_out.reserve_back(num_tiles_per_cycle);
+
+#if HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST)
+        binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
+#endif
+        tile_regs_acquire();
+        BINARY_OP(cb_post_lhs, cb_post_rhs, 0, 0, 0);
+        PROCESS_POST_ACTIVATIONS(0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, cb_out);
+        tile_regs_release();
+
+        exp_cb_out.push_back(num_tiles_per_cycle);
+        EXP_CB_POST_OTHER.pop_front(num_tiles_per_cycle);
+    }
+    exp_cb_bcast.pop_front(num_tiles_per_cycle);
+    EXP_CB_POST_BCAST.pop_front(num_tiles_per_cycle);
+}
+void kernel_main() {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+    uint32_t tile_freq = get_arg_val<uint32_t>(1);
+    uint32_t tile_start = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
+
+    if (num_tiles == 0) {
+        return;
+    }
+
+    constexpr auto cb_out = tt::CBIndex::c_2;
+
+#if SRC_BCAST
+    constexpr auto cb_bcast = tt::CBIndex::c_0;
+    constexpr auto cb_llk_post = tt::CBIndex::c_5;
+    constexpr auto cb_pre_lhs = cb_llk_post;
+    constexpr auto cb_pre_rhs = tt::CBIndex::c_1;
+    constexpr auto cb_post_lhs = HAS_ACTIVATIONS(LHS) ? tt::CBIndex::c_3 : cb_llk_post;
+    constexpr auto cb_post_rhs = HAS_ACTIVATIONS(RHS) ? tt::CBIndex::c_4 : tt::CBIndex::c_1;
+#endif
+#if SRC_BCAST_B
+    constexpr auto cb_bcast = tt::CBIndex::c_1;
+    constexpr auto cb_llk_post = tt::CBIndex::c_6;
+    constexpr auto cb_pre_lhs = tt::CBIndex::c_0;
+    constexpr auto cb_pre_rhs = cb_llk_post;
+    constexpr auto cb_post_lhs = HAS_ACTIVATIONS(LHS) ? tt::CBIndex::c_3 : tt::CBIndex::c_0;
+    constexpr auto cb_post_rhs = HAS_ACTIVATIONS(RHS) ? tt::CBIndex::c_4 : cb_llk_post;
+#endif
+
+    binary_op_init_common(cb_post_lhs, cb_post_rhs, cb_out);
+#ifdef PACK_RELU
+    PACK((llk_pack_relu_config(ReluConfig::zero())));
+#endif
+
+#if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST))
+    binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
+#endif
+
+    uint32_t complete_iterations = (num_tiles + tile_start) / tile_freq;
+    uint32_t remaining_iterations = (num_tiles + tile_start) % tile_freq;
+
+    for (uint32_t i = 0; i < complete_iterations; ++i, tile_start = 0) {
+        process_tile(
+            cb_bcast,
+            cb_llk_post,
+            cb_pre_lhs,
+            cb_post_lhs,
+            cb_pre_rhs,
+            cb_post_rhs,
+            cb_out,
+            tile_freq,
+            tile_start,
+            num_tiles_per_cycle);
+    }
+
+    if (remaining_iterations > 0) {
+        process_tile(
+            cb_bcast,
+            cb_llk_post,
+            cb_pre_lhs,
+            cb_post_lhs,
+            cb_pre_rhs,
+            cb_post_rhs,
+            cb_out,
+            remaining_iterations,
+            tile_start,
+            num_tiles_per_cycle);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_col_bcast.cpp
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/eltwise_unary/sfpu_split_includes.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+
+#include "api/compute/eltwise_binary_sfpu.h"
+#include "api/compute/binary_bitwise_sfpu.h"
+#include "api/compute/binary_shift.h"
+#include "api/compute/add_int_sfpu.h"
+#include "api/compute/sub_int_sfpu.h"
+#include "api/compute/mul_int_sfpu.h"
+#include "api/compute/div_int32_floor.h"
+#include "api/compute/div_int32_sfpu.h"
+#include "api/compute/binary_fmod.h"
+#include "api/compute/binary_remainder.h"
+#include "api/compute/quantization.h"
+#include "api/compute/binary_max_min.h"
+#include "api/compute/gcd.h"
+#include "api/compute/lcm.h"
+#include "api/compute/xlogy.h"
+#include "api/compute/atan2.h"
+#include "api/compute/binary_comp.h"
+#include "api/compute/isclose.h"
+#include "api/compute/bcast.h"
+#include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
+#include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+
+ALWI void process_tile(
+    tt::CBIndex cb_bcast,
+    tt::CBIndex cb_llk_post,
+    tt::CBIndex cb_pre_lhs,
+    tt::CBIndex cb_post_lhs,
+    tt::CBIndex cb_pre_rhs,
+    tt::CBIndex cb_post_rhs,
+    tt::CBIndex cb_out,
+    uint32_t freq,
+    uint32_t tile_start,
+    uint32_t num_tiles_per_cycle ISCLOSE_RT_ARG_PARAMS) {
+    using namespace ckernel;
+
+#if BCAST_INPUT
+#define CB_PRE_BCAST cb_pre_rhs
+#define CB_POST_BCAST cb_post_rhs
+#define CB_PRE_OTHER cb_pre_lhs
+#define CB_POST_OTHER cb_post_lhs
+#define EXP_CB_POST_BCAST exp_cb_post_rhs
+#define EXP_CB_POST_OTHER exp_cb_post_lhs
+#else
+#define CB_PRE_BCAST cb_pre_lhs
+#define CB_POST_BCAST cb_post_lhs
+#define CB_PRE_OTHER cb_pre_rhs
+#define CB_POST_OTHER cb_post_rhs
+#define EXP_CB_POST_BCAST exp_cb_post_lhs
+#define EXP_CB_POST_OTHER exp_cb_post_rhs
+#endif
+    CircularBuffer exp_cb_bcast(cb_bcast);
+    CircularBuffer exp_cb_llk_post(cb_llk_post);
+    CircularBuffer exp_cb_post_lhs(cb_post_lhs);
+    CircularBuffer exp_cb_post_rhs(cb_post_rhs);
+    CircularBuffer exp_cb_out(cb_out);
+
+    exp_cb_bcast.wait_front(num_tiles_per_cycle);
+    pack_reconfig_data_format(cb_out, cb_llk_post);
+    unary_bcast_init<BroadcastType::COL>(cb_bcast, cb_llk_post);
+    exp_cb_llk_post.reserve_back(num_tiles_per_cycle);
+    tile_regs_acquire();
+    unary_bcast<BroadcastType::COL>(cb_bcast, 0, 0);
+    tile_regs_commit();
+
+    tile_regs_wait();
+    pack_tile(0, cb_llk_post);
+    exp_cb_llk_post.push_back(num_tiles_per_cycle);
+    tile_regs_release();
+
+    pack_reconfig_data_format(cb_llk_post, cb_out);
+    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
+
+    PREPROCESS(
+        BCAST_OP,
+        CircularBuffer(CB_PRE_BCAST),
+        CircularBuffer(CB_POST_BCAST),
+        CircularBuffer(cb_out),
+        num_tiles_per_cycle);
+    EXP_CB_POST_BCAST.wait_front(num_tiles_per_cycle);
+
+    for (uint32_t j = tile_start; j < freq; ++j) {
+        PREPROCESS(
+            OTHER_OP,
+            CircularBuffer(CB_PRE_OTHER),
+            CircularBuffer(CB_POST_OTHER),
+            CircularBuffer(cb_out),
+            num_tiles_per_cycle);
+        EXP_CB_POST_OTHER.wait_front(num_tiles_per_cycle);
+
+        exp_cb_out.reserve_back(num_tiles_per_cycle);
+
+#if (HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))
+        BINARY_SFPU_INIT
+#endif
+        tile_regs_acquire();
+        copy_tile_to_dst_init_short_with_dt(cb_post_rhs, cb_post_lhs);
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            copy_tile(cb_post_lhs, i, i * 2);
+        }
+        copy_tile_to_dst_init_short_with_dt(cb_post_lhs, cb_post_rhs);
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            copy_tile(cb_post_rhs, i, i * 2 + 1);
+
+#if HAS_ACTIVATIONS(POST)
+            BINARY_SFPU_INIT
+#endif
+#if ISCLOSE_OP
+            BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2, rtol_bits, atol_bits);
+#else
+            BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2);
+#endif
+            PROCESS_POST_ACTIVATIONS(i * 2);
+        }
+        tile_regs_commit();
+
+        tile_regs_wait();
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            pack_tile(i * 2, cb_out);
+        }
+        tile_regs_release();
+
+        exp_cb_out.push_back(num_tiles_per_cycle);
+        EXP_CB_POST_OTHER.pop_front(num_tiles_per_cycle);
+    }
+    EXP_CB_POST_BCAST.pop_front(num_tiles_per_cycle);
+    exp_cb_bcast.pop_front(num_tiles_per_cycle);
+}
+
+void kernel_main() {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+    uint32_t tile_freq = get_arg_val<uint32_t>(1);
+    uint32_t tile_start = get_arg_val<uint32_t>(2);
+#ifdef ISCLOSE_OP
+    const uint32_t rtol_bits = get_arg_val<uint32_t>(ISCLOSE_RTOL_RT_ARG_IDX);
+    const uint32_t atol_bits = get_arg_val<uint32_t>(ISCLOSE_ATOL_RT_ARG_IDX);
+#endif
+
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
+
+    if (num_tiles == 0) {
+        return;
+    }
+
+    constexpr auto cb_out = tt::CBIndex::c_2;
+
+#if SRC_BCAST
+    constexpr auto cb_bcast = tt::CBIndex::c_0;
+    constexpr auto cb_llk_post = tt::CBIndex::c_5;
+    constexpr auto cb_pre_lhs = cb_llk_post;
+    constexpr auto cb_pre_rhs = tt::CBIndex::c_1;
+    constexpr auto cb_post_lhs = HAS_ACTIVATIONS(LHS) ? tt::CBIndex::c_3 : cb_llk_post;
+    constexpr auto cb_post_rhs = HAS_ACTIVATIONS(RHS) ? tt::CBIndex::c_4 : tt::CBIndex::c_1;
+#endif
+#if SRC_BCAST_B
+    constexpr auto cb_bcast = tt::CBIndex::c_1;
+    constexpr auto cb_llk_post = tt::CBIndex::c_6;
+    constexpr auto cb_pre_lhs = tt::CBIndex::c_0;
+    constexpr auto cb_pre_rhs = cb_llk_post;
+    constexpr auto cb_post_lhs = HAS_ACTIVATIONS(LHS) ? tt::CBIndex::c_3 : tt::CBIndex::c_0;
+    constexpr auto cb_post_rhs = HAS_ACTIVATIONS(RHS) ? tt::CBIndex::c_4 : cb_llk_post;
+#endif
+
+    unary_op_init_common(cb_post_lhs, cb_out);
+#ifdef PACK_RELU
+    PACK((llk_pack_relu_config(ReluConfig::zero())));
+#endif
+
+#if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))
+    BINARY_SFPU_INIT
+#endif
+
+    uint32_t complete_iterations = (num_tiles + tile_start) / tile_freq;
+    uint32_t remaining_iterations = (num_tiles + tile_start) % tile_freq;
+
+    for (uint32_t i = 0; i < complete_iterations; ++i, tile_start = 0) {
+        process_tile(
+            cb_bcast,
+            cb_llk_post,
+            cb_pre_lhs,
+            cb_post_lhs,
+            cb_pre_rhs,
+            cb_post_rhs,
+            cb_out,
+            tile_freq,
+            tile_start,
+            num_tiles_per_cycle ISCLOSE_RT_ARG_FWD);
+    }
+
+    if (remaining_iterations > 0) {
+        process_tile(
+            cb_bcast,
+            cb_llk_post,
+            cb_pre_lhs,
+            cb_post_lhs,
+            cb_pre_rhs,
+            cb_post_rhs,
+            cb_out,
+            remaining_iterations,
+            tile_start,
+            num_tiles_per_cycle ISCLOSE_RT_ARG_FWD);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/eltwise_unary/sfpu_split_includes.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+
+#include "api/compute/eltwise_binary_sfpu.h"
+#include "api/compute/binary_bitwise_sfpu.h"
+#include "api/compute/binary_shift.h"
+#include "api/compute/add_int_sfpu.h"
+#include "api/compute/sub_int_sfpu.h"
+#include "api/compute/mul_int_sfpu.h"
+#include "api/compute/div_int32_floor.h"
+#include "api/compute/div_int32_sfpu.h"
+#include "api/compute/binary_fmod.h"
+#include "api/compute/binary_remainder.h"
+#include "api/compute/quantization.h"
+#include "api/compute/binary_max_min.h"
+#include "api/compute/gcd.h"
+#include "api/compute/lcm.h"
+#include "api/compute/xlogy.h"
+#include "api/compute/binary_comp.h"
+#include "api/compute/isclose.h"
+#include "api/compute/atan2.h"
+#include "api/compute/bcast.h"
+#include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
+#include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+#include "api/dataflow/circular_buffer.h"
+
+void kernel_main() {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+#ifdef ISCLOSE_OP
+    const uint32_t rtol_bits = get_arg_val<uint32_t>(ISCLOSE_RTOL_RT_ARG_IDX);
+    const uint32_t atol_bits = get_arg_val<uint32_t>(ISCLOSE_ATOL_RT_ARG_IDX);
+#endif
+
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
+
+    constexpr auto cb_out = tt::CBIndex::c_2;
+    CircularBuffer exp_cb_out(cb_out);
+
+#if SRC_BCAST
+    constexpr auto cb_bcast = tt::CBIndex::c_0;
+    constexpr auto cb_llk_post = tt::CBIndex::c_5;
+    constexpr auto cb_pre_lhs = cb_llk_post;
+    constexpr auto cb_pre_rhs = tt::CBIndex::c_1;
+    constexpr auto cb_post_lhs = HAS_ACTIVATIONS(LHS) ? tt::CBIndex::c_3 : cb_llk_post;
+    constexpr auto cb_post_rhs = HAS_ACTIVATIONS(RHS) ? tt::CBIndex::c_4 : tt::CBIndex::c_1;
+#endif
+#if SRC_BCAST_B
+    constexpr auto cb_bcast = tt::CBIndex::c_1;
+    constexpr auto cb_llk_post = tt::CBIndex::c_6;
+    constexpr auto cb_pre_lhs = tt::CBIndex::c_0;
+    constexpr auto cb_pre_rhs = cb_llk_post;
+    constexpr auto cb_post_lhs = HAS_ACTIVATIONS(LHS) ? tt::CBIndex::c_3 : tt::CBIndex::c_0;
+    constexpr auto cb_post_rhs = HAS_ACTIVATIONS(RHS) ? tt::CBIndex::c_4 : cb_llk_post;
+#endif
+
+    CircularBuffer exp_cb_bcast(cb_bcast);
+    CircularBuffer exp_cb_llk_post(cb_llk_post);
+    CircularBuffer exp_cb_post_lhs(cb_post_lhs);
+    CircularBuffer exp_cb_post_rhs(cb_post_rhs);
+
+    unary_op_init_common(cb_post_lhs, cb_out);
+#ifdef PACK_RELU
+    PACK((llk_pack_relu_config(ReluConfig::zero())));
+#endif
+
+#if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))
+    BINARY_SFPU_INIT
+#endif
+
+    for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
+        exp_cb_bcast.wait_front(num_tiles_per_cycle);
+        exp_cb_llk_post.reserve_back(num_tiles_per_cycle);
+        pack_reconfig_data_format(cb_out, cb_llk_post);
+        unary_bcast_init<BroadcastType::ROW>(cb_bcast, cb_llk_post);
+
+        tile_regs_acquire();
+        unary_bcast<BroadcastType::ROW>(cb_bcast, 0, 0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, cb_llk_post);
+        exp_cb_llk_post.push_back(num_tiles_per_cycle);
+        tile_regs_release();
+        exp_cb_bcast.pop_front(num_tiles_per_cycle);
+        // unary_bcast_uninit<BroadcastType::ROW>(cb_bcast);
+        pack_reconfig_data_format(cb_llk_post, cb_out);
+        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
+
+        PREPROCESS(LHS, CircularBuffer(cb_pre_lhs), exp_cb_post_lhs, exp_cb_out, num_tiles_per_cycle);
+        exp_cb_post_lhs.wait_front(num_tiles_per_cycle);
+
+        PREPROCESS(RHS, CircularBuffer(cb_pre_rhs), exp_cb_post_rhs, exp_cb_out, num_tiles_per_cycle);
+        exp_cb_post_rhs.wait_front(num_tiles_per_cycle);
+
+        exp_cb_out.reserve_back(num_tiles_per_cycle);
+#if (HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))
+        BINARY_SFPU_INIT
+#endif
+        tile_regs_acquire();
+        copy_tile_to_dst_init_short_with_dt(cb_post_rhs, cb_post_lhs);
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            copy_tile(cb_post_lhs, i, i * 2);
+        }
+        copy_tile_to_dst_init_short_with_dt(cb_post_lhs, cb_post_rhs);
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            copy_tile(cb_post_rhs, i, i * 2 + 1);
+
+#if HAS_ACTIVATIONS(POST)
+            BINARY_SFPU_INIT
+#endif
+#if ISCLOSE_OP
+            BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2, rtol_bits, atol_bits);
+#else
+            BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2);
+#endif
+            PROCESS_POST_ACTIVATIONS(i * 2);
+        }
+        tile_regs_commit();
+
+        tile_regs_wait();
+
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            pack_tile(i * 2, cb_out);
+        }
+        tile_regs_release();
+
+        exp_cb_out.push_back(num_tiles_per_cycle);
+        exp_cb_post_lhs.pop_front(num_tiles_per_cycle);
+        exp_cb_post_rhs.pop_front(num_tiles_per_cycle);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp
@@ -1,0 +1,195 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/eltwise_unary/sfpu_split_includes.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+
+#include "api/compute/eltwise_binary_sfpu.h"
+#include "api/compute/binary_bitwise_sfpu.h"
+#include "api/compute/binary_shift.h"
+#include "api/compute/add_int_sfpu.h"
+#include "api/compute/sub_int_sfpu.h"
+#include "api/compute/mul_int_sfpu.h"
+#include "api/compute/div_int32_floor.h"
+#include "api/compute/div_int32_sfpu.h"
+#include "api/compute/binary_remainder.h"
+#include "api/compute/binary_fmod.h"
+#include "api/compute/quantization.h"
+#include "api/compute/binary_max_min.h"
+#include "api/compute/gcd.h"
+#include "api/compute/lcm.h"
+#include "api/compute/xlogy.h"
+#include "api/compute/atan2.h"
+#include "api/compute/binary_comp.h"
+#include "api/compute/isclose.h"
+#include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
+#include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils_sfpu.hpp"
+#include "api/compute/bcast.h"
+#include "api/dataflow/circular_buffer.h"
+
+ALWI void process_tile(
+    tt::CBIndex cb_pre_lhs,
+    tt::CBIndex cb_post_lhs,
+    tt::CBIndex cb_pre_rhs,
+    tt::CBIndex cb_post_rhs,
+    tt::CBIndex cb_out,
+    uint32_t freq,
+    uint32_t tile_start,
+    uint32_t num_tiles_per_cycle ISCLOSE_RT_ARG_PARAMS) {
+    using namespace ckernel;
+    CircularBuffer exp_cb_out(cb_out);
+
+#if BCAST_INPUT  // ROW_A_COL_B
+#define CB_PRE_BCAST cb_pre_rhs
+#define CB_POST_BCAST cb_post_rhs
+#define CB_POST_OTHER cb_post_lhs
+    constexpr auto cb_raw_other = tt::CBIndex::c_0;
+    constexpr auto cb_llk_post = tt::CBIndex::c_5;
+    auto cb_left = cb_post_lhs;
+    auto cb_right = cb_post_rhs;
+#else  // ROW_B_COL_A
+#define CB_PRE_BCAST cb_pre_lhs
+#define CB_POST_BCAST cb_post_lhs
+#define CB_POST_OTHER cb_post_rhs
+    constexpr auto cb_raw_other = tt::CBIndex::c_1;
+    constexpr auto cb_llk_post = tt::CBIndex::c_6;
+    auto cb_left = cb_post_lhs;
+    auto cb_right = cb_post_rhs;
+#endif
+
+    CircularBuffer exp_cb_raw_other(cb_raw_other);
+    CircularBuffer exp_cb_llk_post(cb_llk_post);
+    CircularBuffer exp_cb_post_bcast(CB_POST_BCAST);
+    CircularBuffer exp_cb_post_other(CB_POST_OTHER);
+
+    unary_op_init_common(cb_left, cb_out);
+    PREPROCESS(BCAST_OP, CircularBuffer(CB_PRE_BCAST), exp_cb_post_bcast, exp_cb_out, num_tiles_per_cycle);
+    exp_cb_post_bcast.wait_front(num_tiles_per_cycle);
+
+    for (uint32_t j = tile_start; j < freq; ++j) {
+        exp_cb_raw_other.wait_front(num_tiles_per_cycle);
+        exp_cb_llk_post.reserve_back(num_tiles_per_cycle);
+        pack_reconfig_data_format(cb_out, cb_llk_post);
+        unary_bcast_init<BroadcastType::ROW>(cb_raw_other, cb_llk_post);
+
+        tile_regs_acquire();
+        unary_bcast<BroadcastType::ROW>(cb_raw_other, 0, 0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, cb_llk_post);
+        exp_cb_llk_post.push_back(num_tiles_per_cycle);
+        tile_regs_release();
+        exp_cb_raw_other.pop_front(num_tiles_per_cycle);
+        // unary_bcast_uninit<BroadcastType::ROW>(cb_raw_other);
+        pack_reconfig_data_format(cb_llk_post, cb_out);
+        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
+
+        PREPROCESS(OTHER_OP, CircularBuffer(cb_llk_post), exp_cb_post_other, exp_cb_out, num_tiles_per_cycle);
+        exp_cb_post_other.wait_front(num_tiles_per_cycle);
+
+        exp_cb_out.reserve_back(num_tiles_per_cycle);
+#if (HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))
+        BINARY_SFPU_INIT
+#endif
+        tile_regs_acquire();
+        copy_tile_to_dst_init_short_with_dt(cb_right, cb_left);
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            copy_tile(cb_left, i, i * 2);
+        }
+        copy_tile_to_dst_init_short_with_dt(cb_left, cb_right);
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            copy_tile(cb_right, i, i * 2 + 1);
+
+#if HAS_ACTIVATIONS(POST)
+            BINARY_SFPU_INIT
+#endif
+#if ISCLOSE_OP
+            BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2, rtol_bits, atol_bits);
+#else
+            BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2);
+#endif
+            PROCESS_POST_ACTIVATIONS(i * 2);
+        }
+        tile_regs_commit();
+
+        tile_regs_wait();
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            pack_tile(i * 2, cb_out);
+        }
+        tile_regs_release();
+        exp_cb_out.push_back(num_tiles_per_cycle);
+        exp_cb_post_other.pop_front(num_tiles_per_cycle);
+    }
+    exp_cb_post_bcast.pop_front(num_tiles_per_cycle);
+}
+
+void kernel_main() {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+    uint32_t tile_freq = get_arg_val<uint32_t>(1);
+    uint32_t tile_start = get_arg_val<uint32_t>(2);
+#ifdef ISCLOSE_OP
+    const uint32_t rtol_bits = get_arg_val<uint32_t>(ISCLOSE_RTOL_RT_ARG_IDX);
+    const uint32_t atol_bits = get_arg_val<uint32_t>(ISCLOSE_ATOL_RT_ARG_IDX);
+#endif
+
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
+
+    if (num_tiles == 0) {
+        return;
+    }
+
+    constexpr auto cb_out = tt::CBIndex::c_2;
+
+#if BCAST_INPUT  // ROW_A_COL_B: A=row bcast, B=col bcast
+    constexpr auto cb_llk_post = tt::CBIndex::c_5;
+    constexpr auto cb_pre_lhs = cb_llk_post;
+    constexpr auto cb_post_lhs = HAS_ACTIVATIONS(LHS) ? tt::CBIndex::c_3 : cb_llk_post;
+    constexpr auto cb_pre_rhs = tt::CBIndex::c_1;
+    constexpr auto cb_post_rhs = HAS_ACTIVATIONS(RHS) ? tt::CBIndex::c_4 : tt::CBIndex::c_1;
+#else  // ROW_B_COL_A: B=row bcast, A=col bcast
+    constexpr auto cb_llk_post = tt::CBIndex::c_6;
+    constexpr auto cb_pre_lhs = tt::CBIndex::c_0;
+    constexpr auto cb_post_lhs = HAS_ACTIVATIONS(LHS) ? tt::CBIndex::c_3 : tt::CBIndex::c_0;
+    constexpr auto cb_pre_rhs = cb_llk_post;
+    constexpr auto cb_post_rhs = HAS_ACTIVATIONS(RHS) ? tt::CBIndex::c_4 : cb_llk_post;
+#endif
+
+#ifdef PACK_RELU
+    PACK((llk_pack_relu_config(ReluConfig::zero())));
+#endif
+
+#if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))
+    BINARY_SFPU_INIT
+#endif
+
+    uint32_t complete_iterations = (num_tiles + tile_start) / tile_freq;
+    uint32_t remaining_iterations = (num_tiles + tile_start) % tile_freq;
+
+    for (uint32_t i = 0; i < complete_iterations; ++i, tile_start = 0) {
+        process_tile(
+            cb_pre_lhs,
+            cb_post_lhs,
+            cb_pre_rhs,
+            cb_post_rhs,
+            cb_out,
+            tile_freq,
+            tile_start,
+            num_tiles_per_cycle ISCLOSE_RT_ARG_FWD);
+    }
+
+    if (remaining_iterations > 0) {
+        process_tile(
+            cb_pre_lhs,
+            cb_post_lhs,
+            cb_pre_rhs,
+            cb_post_rhs,
+            cb_out,
+            remaining_iterations,
+            tile_start,
+            num_tiles_per_cycle ISCLOSE_RT_ARG_FWD);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_scalar_bcast.cpp
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/eltwise_unary/sfpu_split_includes.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+
+#include "api/compute/eltwise_binary_sfpu.h"
+#include "api/compute/binary_bitwise_sfpu.h"
+#include "api/compute/binary_shift.h"
+#include "api/compute/add_int_sfpu.h"
+#include "api/compute/sub_int_sfpu.h"
+#include "api/compute/mul_int_sfpu.h"
+#include "api/compute/div_int32_floor.h"
+#include "api/compute/div_int32_sfpu.h"
+#include "api/compute/binary_remainder.h"
+#include "api/compute/binary_fmod.h"
+#include "api/compute/quantization.h"
+#include "api/compute/binary_max_min.h"
+#include "api/compute/gcd.h"
+#include "api/compute/lcm.h"
+#include "api/compute/xlogy.h"
+#include "api/compute/atan2.h"
+#include "api/compute/binary_comp.h"
+#include "api/compute/isclose.h"
+#include "api/compute/bcast.h"
+#include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
+#include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+
+ALWI void process_tile(
+    tt::CBIndex cb_bcast,
+    tt::CBIndex cb_llk_post,
+    tt::CBIndex cb_pre_lhs,
+    tt::CBIndex cb_post_lhs,
+    tt::CBIndex cb_pre_rhs,
+    tt::CBIndex cb_post_rhs,
+    tt::CBIndex cb_out,
+    uint32_t freq,
+    uint32_t tile_start,
+    uint32_t num_tiles_per_cycle ISCLOSE_RT_ARG_PARAMS) {
+    using namespace ckernel;
+
+#if BCAST_INPUT
+#define CB_PRE_BCAST cb_pre_rhs
+#define CB_POST_BCAST cb_post_rhs
+#define CB_PRE_OTHER cb_pre_lhs
+#define CB_POST_OTHER cb_post_lhs
+#define EXP_CB_POST_BCAST exp_cb_post_rhs
+#define EXP_CB_POST_OTHER exp_cb_post_lhs
+#else
+#define CB_PRE_BCAST cb_pre_lhs
+#define CB_POST_BCAST cb_post_lhs
+#define CB_PRE_OTHER cb_pre_rhs
+#define CB_POST_OTHER cb_post_rhs
+#define EXP_CB_POST_BCAST exp_cb_post_lhs
+#define EXP_CB_POST_OTHER exp_cb_post_rhs
+#endif
+    CircularBuffer exp_cb_bcast(cb_bcast);
+    CircularBuffer exp_cb_llk_post(cb_llk_post);
+    CircularBuffer exp_cb_post_lhs(cb_post_lhs);
+    CircularBuffer exp_cb_post_rhs(cb_post_rhs);
+    CircularBuffer exp_cb_out(cb_out);
+
+    exp_cb_bcast.wait_front(num_tiles_per_cycle);
+    pack_reconfig_data_format(cb_out, cb_llk_post);
+    unary_bcast_init<BroadcastType::SCALAR>(cb_bcast, cb_llk_post);
+    exp_cb_llk_post.reserve_back(num_tiles_per_cycle);
+    tile_regs_acquire();
+    unary_bcast<BroadcastType::SCALAR>(cb_bcast, 0, 0);
+    tile_regs_commit();
+
+    tile_regs_wait();
+    pack_tile(0, cb_llk_post);
+    exp_cb_llk_post.push_back(num_tiles_per_cycle);
+    tile_regs_release();
+
+    pack_reconfig_data_format(cb_llk_post, cb_out);
+    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
+
+    PREPROCESS(
+        BCAST_OP,
+        CircularBuffer(CB_PRE_BCAST),
+        CircularBuffer(CB_POST_BCAST),
+        CircularBuffer(cb_out),
+        num_tiles_per_cycle);
+    EXP_CB_POST_BCAST.wait_front(num_tiles_per_cycle);
+
+    for (uint32_t j = tile_start; j < freq; ++j) {
+        PREPROCESS(
+            OTHER_OP,
+            CircularBuffer(CB_PRE_OTHER),
+            CircularBuffer(CB_POST_OTHER),
+            CircularBuffer(cb_out),
+            num_tiles_per_cycle);
+        EXP_CB_POST_OTHER.wait_front(num_tiles_per_cycle);
+
+        exp_cb_out.reserve_back(num_tiles_per_cycle);
+
+#if (HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))
+        BINARY_SFPU_INIT
+#endif
+        tile_regs_acquire();
+        copy_tile_to_dst_init_short_with_dt(cb_post_rhs, cb_post_lhs);
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            copy_tile(cb_post_lhs, i, i * 2);
+        }
+        copy_tile_to_dst_init_short_with_dt(cb_post_lhs, cb_post_rhs);
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            copy_tile(cb_post_rhs, i, i * 2 + 1);
+
+#if HAS_ACTIVATIONS(POST)
+            BINARY_SFPU_INIT
+#endif
+#if ISCLOSE_OP
+            BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2, rtol_bits, atol_bits);
+#else
+            BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2);
+#endif
+            PROCESS_POST_ACTIVATIONS(i * 2);
+        }
+        tile_regs_commit();
+
+        tile_regs_wait();
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            pack_tile(i * 2, cb_out);
+        }
+        tile_regs_release();
+
+        exp_cb_out.push_back(num_tiles_per_cycle);
+        EXP_CB_POST_OTHER.pop_front(num_tiles_per_cycle);
+    }
+    EXP_CB_POST_BCAST.pop_front(num_tiles_per_cycle);
+    exp_cb_bcast.pop_front(num_tiles_per_cycle);
+}
+
+void kernel_main() {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+    uint32_t tile_freq = get_arg_val<uint32_t>(1);
+    uint32_t tile_start = get_arg_val<uint32_t>(2);
+#ifdef ISCLOSE_OP
+    const uint32_t rtol_bits = get_arg_val<uint32_t>(ISCLOSE_RTOL_RT_ARG_IDX);
+    const uint32_t atol_bits = get_arg_val<uint32_t>(ISCLOSE_ATOL_RT_ARG_IDX);
+#endif
+
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
+
+    if (num_tiles == 0) {
+        return;
+    }
+
+    constexpr auto cb_out = tt::CBIndex::c_2;
+
+#if SRC_BCAST
+    constexpr auto cb_bcast = tt::CBIndex::c_0;
+    constexpr auto cb_llk_post = tt::CBIndex::c_5;
+    constexpr auto cb_pre_lhs = cb_llk_post;
+    constexpr auto cb_pre_rhs = tt::CBIndex::c_1;
+    constexpr auto cb_post_lhs = HAS_ACTIVATIONS(LHS) ? tt::CBIndex::c_3 : cb_llk_post;
+    constexpr auto cb_post_rhs = HAS_ACTIVATIONS(RHS) ? tt::CBIndex::c_4 : tt::CBIndex::c_1;
+#endif
+#if SRC_BCAST_B
+    constexpr auto cb_bcast = tt::CBIndex::c_1;
+    constexpr auto cb_llk_post = tt::CBIndex::c_6;
+    constexpr auto cb_pre_lhs = tt::CBIndex::c_0;
+    constexpr auto cb_pre_rhs = cb_llk_post;
+    constexpr auto cb_post_lhs = HAS_ACTIVATIONS(LHS) ? tt::CBIndex::c_3 : tt::CBIndex::c_0;
+    constexpr auto cb_post_rhs = HAS_ACTIVATIONS(RHS) ? tt::CBIndex::c_4 : cb_llk_post;
+#endif
+
+    unary_op_init_common(cb_post_lhs, cb_out);
+#ifdef PACK_RELU
+    PACK((llk_pack_relu_config(ReluConfig::zero())));
+#endif
+
+#if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))
+    BINARY_SFPU_INIT
+#endif
+
+    uint32_t complete_iterations = (num_tiles + tile_start) / tile_freq;
+    uint32_t remaining_iterations = (num_tiles + tile_start) % tile_freq;
+
+    for (uint32_t i = 0; i < complete_iterations; ++i, tile_start = 0) {
+        process_tile(
+            cb_bcast,
+            cb_llk_post,
+            cb_pre_lhs,
+            cb_post_lhs,
+            cb_pre_rhs,
+            cb_post_rhs,
+            cb_out,
+            tile_freq,
+            tile_start,
+            num_tiles_per_cycle ISCLOSE_RT_ARG_FWD);
+    }
+
+    if (remaining_iterations > 0) {
+        process_tile(
+            cb_bcast,
+            cb_llk_post,
+            cb_pre_lhs,
+            cb_post_lhs,
+            cb_pre_rhs,
+            cb_post_rhs,
+            cb_out,
+            remaining_iterations,
+            tile_start,
+            num_tiles_per_cycle ISCLOSE_RT_ARG_FWD);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_bcast.cpp
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/eltwise_unary/where.h"
+#include "api/compute/eltwise_unary/fill.h"
+#include "api/compute/bcast.h"
+#include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
+#include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+#include "api/dataflow/circular_buffer.h"
+
+void kernel_main() {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+    const uint32_t scalar_value = get_arg_val<uint32_t>(3);
+    const auto scalar_val = reinterpret_cast<const float*>(&scalar_value);
+
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
+
+    constexpr auto cb_in0 = tt::CBIndex::c_0;
+    constexpr auto cb_in1 = tt::CBIndex::c_1;
+    constexpr auto cb_out = tt::CBIndex::c_2;
+    CircularBuffer exp_cb_out(cb_out);
+
+#if SRC_BCAST
+    constexpr auto cb_bcast = cb_in0;
+    constexpr auto cb_llk_post = tt::CBIndex::c_5;
+    constexpr auto cb_left = tt::CBIndex::c_5;
+    constexpr auto cb_right = cb_in1;
+#endif
+#if SRC_BCAST_B
+    constexpr auto cb_bcast = cb_in1;
+    constexpr auto cb_llk_post = tt::CBIndex::c_6;
+    constexpr auto cb_left = cb_in0;
+    constexpr auto cb_right = tt::CBIndex::c_6;
+#endif
+
+    CircularBuffer exp_cb_in0(cb_in0);
+    CircularBuffer exp_cb_in1(cb_in1);
+    CircularBuffer exp_cb_bcast(cb_bcast);
+    CircularBuffer exp_cb_llk_post(cb_llk_post);
+    CircularBuffer exp_cb_left(cb_left);
+    CircularBuffer exp_cb_right(cb_right);
+
+    unary_op_init_common(cb_in0, cb_out);
+    BINARY_SFPU_INIT
+
+    for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
+        exp_cb_in0.wait_front(num_tiles_per_cycle);
+        exp_cb_in1.wait_front(num_tiles_per_cycle);
+
+        exp_cb_llk_post.reserve_back(num_tiles_per_cycle);
+        pack_reconfig_data_format(cb_out, cb_llk_post);
+        unary_bcast_init<BroadcastType::ROW>(cb_bcast, cb_llk_post);
+
+        tile_regs_acquire();
+        unary_bcast<BroadcastType::ROW>(cb_bcast, 0, 0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, cb_llk_post);
+        exp_cb_llk_post.push_back(num_tiles_per_cycle);
+        tile_regs_release();
+
+        exp_cb_bcast.pop_front(num_tiles_per_cycle);
+        // unary_bcast_uninit<BroadcastType::ROW>(cb_bcast);
+        pack_reconfig_data_format(cb_llk_post, cb_out);
+        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
+
+        exp_cb_out.reserve_back(num_tiles_per_cycle);
+        exp_cb_llk_post.wait_front(num_tiles_per_cycle);
+
+        tile_regs_acquire();
+
+        copy_tile_to_dst_init_short(cb_left);
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            copy_tile(cb_left, i, i * 3);
+        }
+        copy_tile_to_dst_init_short(cb_right);
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+// TTS: tensor is true value, goes to dst_reg 1
+#if WHERE_TTS
+            copy_tile(cb_right, i, i * 3 + 1);  // Copy true tensor to dst_reg 1
+            fill_tile_init();
+// TTS: scalar is false value, goes to dst_reg 2
+#ifdef FILL_WITH_VALUE_FLOAT
+            FILL_LLK(i * 3 + 2, *scalar_val);
+#endif
+#ifdef FILL_WITH_VALUE_INT
+            FILL_LLK(i * 3 + 2, scalar_value);
+#endif
+#endif
+
+// TST: tensor is false value, goes to dst_reg 2
+#if WHERE_TST
+            copy_tile(cb_right, i, i * 3 + 2);  // Copy false tensor to dst_reg 2
+            fill_tile_init();
+// TST: scalar is true value, goes to dst_reg 1
+#ifdef FILL_WITH_VALUE_FLOAT
+            FILL_LLK(i * 3 + 1, *scalar_val);
+#endif
+#ifdef FILL_WITH_VALUE_INT
+            FILL_LLK(i * 3 + 1, scalar_value);
+#endif
+#endif
+
+            BINARY_SFPU_OP(i * 3, i * 3 + 1, i * 3 + 2, i * 3);
+        }
+
+        tile_regs_commit();
+
+        tile_regs_wait();
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            pack_tile(i * 3, cb_out);
+        }
+        tile_regs_release();
+
+        exp_cb_out.push_back(num_tiles_per_cycle);
+        exp_cb_left.pop_front(num_tiles_per_cycle);
+        exp_cb_right.pop_front(num_tiles_per_cycle);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_col_bcast.cpp
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+
+#include "api/compute/eltwise_unary/where.h"
+#include "api/compute/eltwise_unary/fill.h"
+#include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
+#include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils_sfpu.hpp"
+#include "api/compute/bcast.h"
+#include "api/dataflow/circular_buffer.h"
+
+ALWI void process_tile(
+    tt::CBIndex cb_in0,
+    tt::CBIndex cb_in1,
+    tt::CBIndex cb_out,
+    const uint32_t scalar_value,
+    const float* scalar_val,
+    uint32_t freq,
+    uint32_t tile_start,
+    uint32_t num_tiles_per_cycle) {
+    using namespace ckernel;
+    CircularBuffer exp_cb_out(cb_out);
+
+#if BCAST_INPUT  // ROW_A_COL_B
+                 // BCAST_INPUT == 1 : input B ( true or false tensor) is broadcasted
+#define CB_BCAST cb_in1
+#define CB_OTHER cb_in0
+    constexpr auto cb_llk_post = tt::CBIndex::c_5;
+    constexpr auto cb_left = tt::CBIndex::c_5;
+    auto cb_right = cb_in1;
+#else  // ROW_B_COL_A
+    // BCAST_INPUT == 0 : input A (condition tensor)  is broadcasted
+#define CB_BCAST cb_in0
+#define CB_OTHER cb_in1
+    constexpr auto cb_llk_post = tt::CBIndex::c_6;
+    auto cb_left = cb_in0;
+    constexpr auto cb_right = tt::CBIndex::c_6;
+#endif
+
+    CircularBuffer exp_cb_bcast(CB_BCAST);
+    CircularBuffer exp_cb_other(CB_OTHER);
+    CircularBuffer exp_cb_llk_post(cb_llk_post);
+
+    unary_op_init_common(cb_left, cb_out);
+    BINARY_SFPU_INIT
+
+    exp_cb_bcast.wait_front(num_tiles_per_cycle);
+
+    for (uint32_t j = tile_start; j < freq; ++j) {
+        exp_cb_other.wait_front(num_tiles_per_cycle);
+        exp_cb_llk_post.reserve_back(num_tiles_per_cycle);
+        pack_reconfig_data_format(cb_out, cb_llk_post);
+        unary_bcast_init<BroadcastType::ROW>(CB_OTHER, cb_llk_post);
+
+        tile_regs_acquire();
+        unary_bcast<BroadcastType::ROW>(CB_OTHER, 0, 0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, cb_llk_post);
+        exp_cb_llk_post.push_back(num_tiles_per_cycle);
+        tile_regs_release();
+
+        exp_cb_other.pop_front(num_tiles_per_cycle);
+        // unary_bcast_uninit<BroadcastType::ROW>(CB_OTHER);
+        pack_reconfig_data_format(cb_llk_post, cb_out);
+        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
+
+        exp_cb_out.reserve_back(num_tiles_per_cycle);
+        exp_cb_llk_post.wait_front(num_tiles_per_cycle);
+
+        tile_regs_acquire();
+
+        copy_tile_to_dst_init_short(cb_left);
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            copy_tile(cb_left, i, i * 3);
+        }
+        copy_tile_to_dst_init_short(cb_right);
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+// TTS: tensor is true value, goes to dst_reg 1
+#if WHERE_TTS
+            copy_tile(cb_right, i, i * 3 + 1);  // Copy true tensor to dst_reg 1
+            fill_tile_init();
+// TTS: scalar is false value, goes to dst_reg 2
+#ifdef FILL_WITH_VALUE_FLOAT
+            FILL_LLK(i * 3 + 2, *scalar_val);
+#endif
+#ifdef FILL_WITH_VALUE_INT
+            FILL_LLK(i * 3 + 2, scalar_value);
+#endif
+#endif
+
+// TST: tensor is false value, goes to dst_reg 2
+#if WHERE_TST
+            copy_tile(cb_right, i, i * 3 + 2);  // Copy false tensor to dst_reg 2
+            fill_tile_init();
+// TST: scalar is true value, goes to dst_reg 1
+#ifdef FILL_WITH_VALUE_FLOAT
+            FILL_LLK(i * 3 + 1, *scalar_val);
+#endif
+#ifdef FILL_WITH_VALUE_INT
+            FILL_LLK(i * 3 + 1, scalar_value);
+#endif
+#endif
+
+            BINARY_SFPU_OP(i * 3, i * 3 + 1, i * 3 + 2, i * 3);
+        }
+
+        tile_regs_commit();
+
+        tile_regs_wait();
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            pack_tile(i * 3, cb_out);
+        }
+        tile_regs_release();
+
+        exp_cb_out.push_back(num_tiles_per_cycle);
+        exp_cb_llk_post.pop_front(num_tiles_per_cycle);
+    }
+    exp_cb_bcast.pop_front(num_tiles_per_cycle);
+}
+
+void kernel_main() {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+    uint32_t tile_freq = get_arg_val<uint32_t>(1);
+    uint32_t tile_start = get_arg_val<uint32_t>(2);
+    const uint32_t scalar_value = get_arg_val<uint32_t>(3);
+    const float* scalar_value_ptr = reinterpret_cast<const float*>(&scalar_value);
+
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
+
+    if (num_tiles == 0) {
+        return;
+    }
+
+    constexpr auto cb_in0 = tt::CBIndex::c_0;
+    constexpr auto cb_in1 = tt::CBIndex::c_1;
+    constexpr auto cb_out = tt::CBIndex::c_2;
+
+    uint32_t complete_iterations = (num_tiles + tile_start) / tile_freq;
+    uint32_t remaining_iterations = (num_tiles + tile_start) % tile_freq;
+
+    for (uint32_t i = 0; i < complete_iterations; ++i, tile_start = 0) {
+        process_tile(
+            cb_in0, cb_in1, cb_out, scalar_value, scalar_value_ptr, tile_freq, tile_start, num_tiles_per_cycle);
+    }
+
+    if (remaining_iterations > 0) {
+        process_tile(
+            cb_in0,
+            cb_in1,
+            cb_out,
+            scalar_value,
+            scalar_value_ptr,
+            remaining_iterations,
+            tile_start,
+            num_tiles_per_cycle);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_col_bcast.cpp
@@ -1,0 +1,203 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+
+void kernel_main() {
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t start_tile_id = get_arg_val<uint32_t>(1);
+    const uint32_t src_num_tiles = get_arg_val<uint32_t>(2);
+    const uint32_t dst_num_tiles = get_arg_val<uint32_t>(3);
+    const uint32_t dst_shard_width = get_arg_val<uint32_t>(4);
+    const uint32_t nD_stride = get_arg_val<uint32_t>(5);
+    const uint32_t d_stride = get_arg_val<uint32_t>(6);
+    const uint32_t n_stride = get_arg_val<uint32_t>(7);
+    const uint32_t c_stride = get_arg_val<uint32_t>(8);
+    const uint32_t D = get_arg_val<uint32_t>(9);
+    const uint32_t N = get_arg_val<uint32_t>(10);
+    const uint32_t C = get_arg_val<uint32_t>(11);
+    const uint32_t Ht = get_arg_val<uint32_t>(12);
+    const uint32_t Wt = get_arg_val<uint32_t>(13);
+    const uint32_t cND = get_arg_val<uint32_t>(14);  // collapsed dims > 5
+    const uint32_t src_addr_b = get_arg_val<uint32_t>(15);
+    const uint32_t nD_stride_b = get_arg_val<uint32_t>(16);
+    const uint32_t d_stride_b = get_arg_val<uint32_t>(17);
+    const uint32_t n_stride_b = get_arg_val<uint32_t>(18);
+    const uint32_t c_stride_b = get_arg_val<uint32_t>(19);
+    const uint32_t src_num_tiles_b = get_arg_val<uint32_t>(20);
+
+    constexpr auto cb_id_src = tt::CBIndex::c_0;
+    constexpr auto cb_id_src_b = tt::CBIndex::c_1;
+    constexpr auto src_args = TensorAccessorArgs<0, 0>();
+    constexpr auto src_b_args =
+        TensorAccessorArgs<src_args.next_compile_time_args_offset(), src_args.next_common_runtime_args_offset()>();
+
+    Noc noc;
+    CircularBuffer cb_src(cb_id_src);
+    CircularBuffer cb_src_b(cb_id_src_b);
+
+#if SRC_SHARDED
+#if !SRC_BCAST
+    cb_src.reserve_back(src_num_tiles);
+    cb_src.push_back(src_num_tiles);
+#endif
+#else
+    const uint32_t src_tile_bytes = cb_src.get_tile_size();
+    const auto src = TensorAccessor(src_args, src_addr);
+#endif
+#if SRC_SHARDED_B
+#if !SRC_BCAST_B
+    cb_src_b.reserve_back(src_num_tiles_b);
+    cb_src_b.push_back(src_num_tiles_b);
+#endif
+#else
+    const uint32_t src_tile_bytes_b = cb_src_b.get_tile_size();
+    const auto src_b = TensorAccessor(src_b_args, src_addr_b);
+#endif
+    constexpr uint32_t onetile = 1;
+    constexpr bool has_sharding = get_compile_time_arg_val(src_b_args.next_compile_time_args_offset()) == 1;
+    const uint32_t HtWt = Ht * Wt;
+
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_tile_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    const uint32_t offset_c = offset_n % HtWt;
+    uint32_t start_nd = start_tile_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_th = offset_c / Wt;
+    uint32_t start_tw = offset_c % Wt;
+    uint32_t end_tw = has_sharding ? start_tw + dst_shard_width : Wt;
+
+    // this is the INPUT tile offset
+    uint32_t tile_offset = start_nd * nD_stride + start_d * d_stride + start_n * n_stride + start_c * c_stride;
+#if !SRC_BCAST
+    tile_offset += start_th * Wt;
+#endif
+    uint32_t next_c_shift = c_stride - HtWt;
+    uint32_t next_n_shift = n_stride - c_stride * C;
+    uint32_t next_d_shift = d_stride - n_stride * N;
+    uint32_t next_nd_shift = nD_stride - d_stride * D;
+
+    uint32_t tile_offset_b =
+        start_nd * nD_stride_b + start_d * d_stride_b + start_n * n_stride_b + start_c * c_stride_b;
+#if !SRC_BCAST_B
+    tile_offset_b += start_th * Wt;
+#endif
+    uint32_t next_c_shift_b = c_stride_b - HtWt;
+    uint32_t next_n_shift_b = n_stride_b - c_stride_b * C;
+    uint32_t next_d_shift_b = d_stride_b - n_stride_b * N;
+    uint32_t next_nd_shift_b = nD_stride_b - d_stride_b * D;
+
+    uint32_t num_tiles_read = 0;
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_read < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
+                    for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th) {
+#if SRC_BCAST
+                        cb_src.reserve_back(onetile);
+#if !SRC_SHARDED
+                        noc.async_read(src, cb_src, src_tile_bytes, {.page_id = tile_offset + th}, {.offset_bytes = 0});
+                        noc.async_read_barrier();
+#endif
+#if !BCAST_LLK
+                        FILL_TILE_WITH_FIRST_COLUMN(cb_src.get_write_ptr());
+#endif
+                        cb_src.push_back(onetile);
+#endif
+#if SRC_BCAST_B
+                        cb_src_b.reserve_back(onetile);
+#if !SRC_SHARDED_B
+                        noc.async_read(
+                            src_b, cb_src_b, src_tile_bytes_b, {.page_id = tile_offset_b + th}, {.offset_bytes = 0});
+                        noc.async_read_barrier();
+#endif
+#if !BCAST_LLK
+                        FILL_TILE_WITH_FIRST_COLUMN_B(cb_src_b.get_write_ptr());
+#endif
+                        cb_src_b.push_back(onetile);
+#endif
+                        for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
+                             ++tw, ++num_tiles_read) {
+#if !SRC_BCAST && !SRC_SHARDED
+                            cb_src.reserve_back(onetile);
+                            noc.async_read(
+                                src, cb_src, src_tile_bytes, {.page_id = tile_offset + tw}, {.offset_bytes = 0});
+                            noc.async_read_barrier();
+                            cb_src.push_back(onetile);
+#endif
+#if !SRC_BCAST_B && !SRC_SHARDED_B
+                            cb_src_b.reserve_back(onetile);
+                            noc.async_read(
+                                src_b,
+                                cb_src_b,
+                                src_tile_bytes_b,
+                                {.page_id = tile_offset_b + tw},
+                                {.offset_bytes = 0});
+                            noc.async_read_barrier();
+                            cb_src_b.push_back(onetile);
+#endif
+                        }
+                        if constexpr (!has_sharding) {
+                            // next row of tiles should start at the first column
+                            start_tw = 0;
+                        }
+#if !SRC_BCAST && !SRC_SHARDED
+                        tile_offset += Wt;
+#endif
+#if !SRC_BCAST_B && !SRC_SHARDED_B
+                        tile_offset_b += Wt;
+#endif
+                    }
+#if !SRC_SHARDED
+#if SRC_BCAST
+                    // same as following logically
+                    // tile_offset += HtWt;
+                    // tile_offset += next_c_shift;
+                    tile_offset += c_stride;
+#else
+                    tile_offset += next_c_shift;
+#endif
+#endif
+#if !SRC_SHARDED_B
+#if SRC_BCAST_B
+                    tile_offset_b += c_stride_b;
+#else
+                    tile_offset_b += next_c_shift_b;
+#endif
+#endif
+                }
+#if !SRC_SHARDED
+                tile_offset += next_n_shift;
+#endif
+#if !SRC_SHARDED_B
+                tile_offset_b += next_n_shift_b;
+#endif
+            }
+#if !SRC_SHARDED
+            tile_offset += next_d_shift;
+#endif
+#if !SRC_SHARDED_B
+            tile_offset_b += next_d_shift_b;
+#endif
+        }
+#if !SRC_SHARDED
+        tile_offset += next_nd_shift;
+#endif
+#if !SRC_SHARDED_B
+        tile_offset_b += next_nd_shift_b;
+#endif
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_no_bcast.cpp
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t start_tile_id = get_arg_val<uint32_t>(1);
+    const uint32_t src_num_tiles = get_arg_val<uint32_t>(2);
+    const uint32_t dst_num_tiles = get_arg_val<uint32_t>(3);
+    const uint32_t dst_shard_width = get_arg_val<uint32_t>(4);
+    const uint32_t nD_stride = get_arg_val<uint32_t>(5);
+    const uint32_t d_stride = get_arg_val<uint32_t>(6);
+    const uint32_t n_stride = get_arg_val<uint32_t>(7);
+    const uint32_t c_stride = get_arg_val<uint32_t>(8);
+    const uint32_t D = get_arg_val<uint32_t>(9);
+    const uint32_t N = get_arg_val<uint32_t>(10);
+    const uint32_t C = get_arg_val<uint32_t>(11);
+    const uint32_t Ht = get_arg_val<uint32_t>(12);
+    const uint32_t Wt = get_arg_val<uint32_t>(13);
+    const uint32_t cND = get_arg_val<uint32_t>(14);  // collapsed dims > 5
+    const uint32_t src_addr_b = get_arg_val<uint32_t>(15);
+    const uint32_t nD_stride_b = get_arg_val<uint32_t>(16);
+    const uint32_t d_stride_b = get_arg_val<uint32_t>(17);
+    const uint32_t n_stride_b = get_arg_val<uint32_t>(18);
+    const uint32_t c_stride_b = get_arg_val<uint32_t>(19);
+    const uint32_t src_num_tiles_b = get_arg_val<uint32_t>(20);
+
+    constexpr auto cb_id_src = tt::CBIndex::c_0;
+    constexpr auto cb_id_src_b = tt::CBIndex::c_1;
+
+    constexpr auto src_args = TensorAccessorArgs<0, 0>();
+    constexpr auto src_b_args =
+        TensorAccessorArgs<src_args.next_compile_time_args_offset(), src_args.next_common_runtime_args_offset()>();
+
+    Noc noc;
+    CircularBuffer cb_src(cb_id_src);
+    CircularBuffer cb_src_b(cb_id_src_b);
+
+#if SRC_SHARDED
+    cb_src.reserve_back(src_num_tiles);
+    cb_src.push_back(src_num_tiles);
+#else
+    const uint32_t src_tile_bytes = cb_src.get_tile_size();
+    const auto src = TensorAccessor(src_args, src_addr);
+#endif
+#if SRC_SHARDED_B
+    cb_src_b.reserve_back(src_num_tiles_b);
+    cb_src_b.push_back(src_num_tiles_b);
+#else
+    const uint32_t src_tile_bytes_b = cb_src_b.get_tile_size();
+    const auto src_b = TensorAccessor(src_b_args, src_addr_b);
+#endif
+#if !SRC_SHARDED || !SRC_SHARDED_B
+    constexpr uint32_t onetile = 1;
+    constexpr bool has_sharding = get_compile_time_arg_val(src_b_args.next_compile_time_args_offset()) == 1;
+    const uint32_t HtWt = Ht * Wt;
+
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_tile_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    const uint32_t offset_c = offset_n % HtWt;
+    uint32_t start_nd = start_tile_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_th = offset_c / Wt;
+    uint32_t start_tw = offset_c % Wt;
+    uint32_t end_tw = has_sharding ? start_tw + dst_shard_width : Wt;
+
+    // this is the INPUT tile offset
+    uint32_t tile_offset =
+        start_nd * nD_stride + start_d * d_stride + start_n * n_stride + start_c * c_stride + start_th * Wt;
+    uint32_t next_c_shift = c_stride - HtWt;
+    uint32_t next_n_shift = n_stride - c_stride * C;
+    uint32_t next_d_shift = d_stride - n_stride * N;
+    uint32_t next_nd_shift = nD_stride - d_stride * D;
+
+    uint32_t tile_offset_b =
+        start_nd * nD_stride_b + start_d * d_stride_b + start_n * n_stride_b + start_c * c_stride_b + start_th * Wt;
+    uint32_t next_c_shift_b = c_stride_b - HtWt;
+    uint32_t next_n_shift_b = n_stride_b - c_stride_b * C;
+    uint32_t next_d_shift_b = d_stride_b - n_stride_b * N;
+    uint32_t next_nd_shift_b = nD_stride_b - d_stride_b * D;
+
+    uint32_t num_tiles_read = 0;
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_read < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
+                    for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th) {
+                        for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
+                             ++tw, ++num_tiles_read) {
+#if !SRC_SHARDED
+                            cb_src.reserve_back(onetile);
+                            noc.async_read(
+                                src, cb_src, src_tile_bytes, {.page_id = tile_offset + tw}, {.offset_bytes = 0});
+#endif
+#if !SRC_SHARDED_B
+                            // read a tile from src_b
+                            cb_src_b.reserve_back(onetile);
+                            noc.async_read(
+                                src_b,
+                                cb_src_b,
+                                src_tile_bytes_b,
+                                {.page_id = tile_offset_b + tw},
+                                {.offset_bytes = 0});
+#endif
+#if !SRC_SHARDED || !SRC_SHARDED_B
+                            noc.async_read_barrier();
+#endif
+#if !SRC_SHARDED
+                            cb_src.push_back(onetile);
+#endif
+#if !SRC_SHARDED_B
+                            cb_src_b.push_back(onetile);
+#endif
+                        }
+                        if constexpr (!has_sharding) {
+                            // next row of tiles should start at the first column
+                            start_tw = 0;
+                        }
+                        tile_offset += Wt;
+                        tile_offset_b += Wt;
+                    }
+                    tile_offset += next_c_shift;
+                    tile_offset_b += next_c_shift_b;
+                }
+                tile_offset += next_n_shift;
+                tile_offset_b += next_n_shift_b;
+            }
+            tile_offset += next_d_shift;
+            tile_offset_b += next_d_shift_b;
+        }
+        tile_offset += next_nd_shift;
+        tile_offset_b += next_nd_shift_b;
+    }
+#endif
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_col_bcast.cpp
@@ -1,0 +1,248 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/alignment.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "api/core_local_mem.h"
+#include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+
+namespace {
+// Broadcast reads land in a scratch slot offset by source low bits; normalize the seed value to row start before fill.
+template <uint32_t element_size>
+FORCE_INLINE void copy_one_element(uint32_t dst_l1_addr, uint32_t src_l1_addr) {
+    static_assert(element_size == 1 || element_size == 2 || element_size == 4);
+
+    if constexpr (element_size == 1) {
+        auto* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(src_l1_addr);
+        auto* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(dst_l1_addr);
+        dst_ptr[0] = src_ptr[0];
+    } else if constexpr (element_size == 2) {
+        auto* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(src_l1_addr);
+        auto* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(dst_l1_addr);
+        dst_ptr[0] = src_ptr[0];
+    } else {
+        auto* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(src_l1_addr);
+        auto* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dst_l1_addr);
+        dst_ptr[0] = src_ptr[0];
+    }
+}
+}  // namespace
+
+void kernel_main() {
+    uint32_t index = 0;
+    const uint32_t src_addr = get_arg_val<uint32_t>(index++);
+    const uint32_t dst_num_tiles = get_arg_val<uint32_t>(index++);
+
+    const uint32_t aD = get_arg_val<uint32_t>(index++);
+    const uint32_t aN = get_arg_val<uint32_t>(index++);
+    const uint32_t aC = get_arg_val<uint32_t>(index++);
+    const uint32_t aHt = get_arg_val<uint32_t>(index++);
+    const uint32_t aND = get_arg_val<uint32_t>(index++);
+
+    const uint32_t src_addr_b = get_arg_val<uint32_t>(index++);
+    const uint32_t bD = get_arg_val<uint32_t>(index++);
+    const uint32_t bN = get_arg_val<uint32_t>(index++);
+    const uint32_t bC = get_arg_val<uint32_t>(index++);
+    const uint32_t bHt = get_arg_val<uint32_t>(index++);
+    const uint32_t bND = get_arg_val<uint32_t>(index++);
+
+    const uint32_t cHt = get_arg_val<uint32_t>(index++);
+    const uint32_t cC = get_arg_val<uint32_t>(index++);
+    const uint32_t cND = get_arg_val<uint32_t>(index++);
+    const uint32_t current_block_start = get_arg_val<uint32_t>(index++);
+    const uint32_t rows_per_tile = get_arg_val<uint32_t>(index++);
+    const uint32_t row_width_elements = get_arg_val<uint32_t>(index++);
+    const uint32_t page_size_a_arg = get_arg_val<uint32_t>(index++);
+    const uint32_t page_size_b_arg = get_arg_val<uint32_t>(index++);
+    const uint32_t alignment_a = get_arg_val<uint32_t>(index++);
+    const uint32_t alignment_b = get_arg_val<uint32_t>(index++);
+    const uint32_t tiles_per_row = get_arg_val<uint32_t>(index++);
+    const uint32_t stride_size_bytes = get_arg_val<uint32_t>(index++);
+
+    constexpr auto cb_id_src = tt::CBIndex::c_0;
+    constexpr auto cb_id_src_b = tt::CBIndex::c_1;
+    constexpr auto src_args = TensorAccessorArgs<0>();
+    constexpr auto src_b_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
+
+    Noc noc;
+    CircularBuffer cb_src(cb_id_src);
+    CircularBuffer cb_src_b(cb_id_src_b);
+
+    constexpr uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    constexpr uint32_t tile_hw = get_tile_hw(cb_id_src);
+    constexpr uint32_t element_size = src_tile_bytes / tile_hw;
+    const uint32_t element_size_aligned_a = align(element_size, alignment_a);
+    const uint32_t element_size_aligned_b = align(element_size, alignment_b);
+    const uint32_t row_width_bytes = row_width_elements * element_size;
+
+    const uint32_t outHt = cHt;
+    const uint32_t outC = cC;
+    const uint32_t outN = (aN > bN) ? aN : bN;
+    const uint32_t outD = (aD > bD) ? aD : bD;
+    const uint32_t outND = cND;
+
+#if SRC_BCAST
+    const uint32_t page_size_a = element_size_aligned_a;
+    const uint32_t page_size_b = align(page_size_b_arg, alignment_b);
+#else
+    const uint32_t page_size_a = align(page_size_a_arg, alignment_a);
+    const uint32_t page_size_b = element_size_aligned_b;
+#endif
+
+    // Third argument page_size from runtime args overrides TensorAccessorArgs::AlignedPageSize, which may be stale on
+    // program cache hits.
+    const auto src = TensorAccessor(src_args, src_addr, page_size_a);
+    const auto src_b = TensorAccessor(src_b_args, src_addr_b, page_size_b);
+
+    const uint32_t s_h_a = (aHt == 1) ? 0 : 1;
+    const uint32_t s_c_a = (aC == 1) ? 0 : aHt;
+    const uint32_t s_n_a = (aN == 1) ? 0 : aC * aHt;
+    const uint32_t s_d_a = (aD == 1) ? 0 : aN * aC * aHt;
+    const uint32_t s_nd_a = (aND == 1) ? 0 : aD * aN * aC * aHt;
+
+    const uint32_t s_h_b = (bHt == 1) ? 0 : 1;
+    const uint32_t s_c_b = (bC == 1) ? 0 : bHt;
+    const uint32_t s_n_b = (bN == 1) ? 0 : bC * bHt;
+    const uint32_t s_d_b = (bD == 1) ? 0 : bN * bC * bHt;
+    const uint32_t s_nd_b = (bND == 1) ? 0 : bD * bN * bC * bHt;
+
+    const uint32_t row_blocks_per_channel = (outHt + rows_per_tile - 1) / rows_per_tile;
+
+    uint32_t tmp = current_block_start;
+    uint32_t start_th = (tmp % row_blocks_per_channel) * rows_per_tile;
+    tmp /= row_blocks_per_channel;
+    uint32_t start_c = tmp % outC;
+    tmp /= outC;
+    uint32_t start_n = tmp % outN;
+    tmp /= outN;
+    uint32_t start_d = tmp % outD;
+    tmp /= outD;
+    uint32_t start_nd = tmp;
+
+    uint32_t row_blocks_pushed = 0;
+
+    for (uint32_t nd = start_nd; nd < outND && row_blocks_pushed < dst_num_tiles; ++nd, start_d = 0) {
+        const uint32_t ptr_nd_a = nd * s_nd_a;
+        const uint32_t ptr_nd_b = nd * s_nd_b;
+
+        for (uint32_t d = start_d; d < outD && row_blocks_pushed < dst_num_tiles; ++d, start_n = 0) {
+            const uint32_t ptr_d_a = ptr_nd_a + d * s_d_a;
+            const uint32_t ptr_d_b = ptr_nd_b + d * s_d_b;
+
+            for (uint32_t n = start_n; n < outN && row_blocks_pushed < dst_num_tiles; ++n, start_c = 0) {
+                const uint32_t ptr_n_a = ptr_d_a + n * s_n_a;
+                const uint32_t ptr_n_b = ptr_d_b + n * s_n_b;
+
+                for (uint32_t c = start_c; c < outC && row_blocks_pushed < dst_num_tiles; ++c, start_th = 0) {
+                    const uint32_t ptr_c_a = ptr_n_a + c * s_c_a;
+                    const uint32_t ptr_c_b = ptr_n_b + c * s_c_b;
+
+                    for (uint32_t th = start_th; th < outHt && row_blocks_pushed < dst_num_tiles; th += rows_per_tile) {
+                        const uint32_t rows_remaining_in_block = outHt - th;
+                        const uint32_t limit =
+                            (rows_remaining_in_block < rows_per_tile) ? rows_remaining_in_block : rows_per_tile;
+
+                        const uint32_t row_block_a = ptr_c_a + th * s_h_a;
+                        const uint32_t row_block_b = ptr_c_b + th * s_h_b;
+
+                        for (uint32_t t_i = 0; t_i < tiles_per_row; ++t_i) {
+                            const uint32_t current_chunk_offset = t_i * stride_size_bytes;
+                            const uint32_t bytes_left_in_row = row_width_bytes - current_chunk_offset;
+                            const uint32_t current_chunk_bytes =
+                                (stride_size_bytes < bytes_left_in_row) ? stride_size_bytes : bytes_left_in_row;
+                            const uint32_t current_chunk_elements = current_chunk_bytes / element_size;
+
+                            cb_src.reserve_back(1);
+                            const uint32_t l1_write_addr_src = cb_src.get_write_ptr();
+
+                            cb_src_b.reserve_back(1);
+                            const uint32_t l1_write_addr_src_b = cb_src_b.get_write_ptr();
+
+#if SRC_BCAST
+                            const uint32_t current_read_len_b = align(current_chunk_bytes, alignment_b);
+
+                            for (int32_t k = static_cast<int32_t>(limit) - 1; k >= 0; --k) {
+                                const uint32_t row_idx_a = row_block_a + static_cast<uint32_t>(k) * s_h_a;
+                                const uint64_t addr_a = src.get_noc_addr(row_idx_a);
+                                const uint32_t src_low_bits = static_cast<uint32_t>(addr_a & (alignment_a - 1));
+                                const uint32_t scratch_l1_addr = l1_write_addr_src + src_low_bits;
+                                const uint32_t row_l1_addr =
+                                    l1_write_addr_src + static_cast<uint32_t>(k) * current_chunk_bytes;
+
+                                noc.async_read(
+                                    src,
+                                    CoreLocalMem<uint32_t>(scratch_l1_addr),
+                                    element_size,
+                                    {.page_id = row_idx_a},
+                                    {});
+                                noc.async_read_barrier();
+
+                                copy_one_element<element_size>(row_l1_addr, scratch_l1_addr);
+                                FILL_TILE_WITH_FIRST_COLUMN_RM(row_l1_addr, current_chunk_elements);
+                            }
+
+                            uint32_t curr_l1_b = l1_write_addr_src_b;
+                            for (uint32_t k = 0; k < limit; ++k) {
+                                const uint32_t row_idx_b = row_block_b + k * s_h_b;
+                                noc.async_read(
+                                    src_b,
+                                    CoreLocalMem<uint32_t>(curr_l1_b),
+                                    current_read_len_b,
+                                    {.page_id = row_idx_b, .offset_bytes = current_chunk_offset},
+                                    {});
+                                curr_l1_b += current_chunk_bytes;
+                            }
+                            noc.async_read_barrier();
+#else
+                            const uint32_t current_read_len_a = align(current_chunk_bytes, alignment_a);
+
+                            uint32_t curr_l1_a = l1_write_addr_src;
+                            for (uint32_t k = 0; k < limit; ++k) {
+                                const uint32_t row_idx_a = row_block_a + k * s_h_a;
+                                noc.async_read(
+                                    src,
+                                    CoreLocalMem<uint32_t>(curr_l1_a),
+                                    current_read_len_a,
+                                    {.page_id = row_idx_a, .offset_bytes = current_chunk_offset},
+                                    {});
+                                curr_l1_a += current_chunk_bytes;
+                            }
+                            noc.async_read_barrier();
+
+                            for (int32_t k = static_cast<int32_t>(limit) - 1; k >= 0; --k) {
+                                const uint32_t row_idx_b = row_block_b + static_cast<uint32_t>(k) * s_h_b;
+                                const uint64_t addr_b = src_b.get_noc_addr(row_idx_b);
+                                const uint32_t src_low_bits = static_cast<uint32_t>(addr_b & (alignment_b - 1));
+                                const uint32_t scratch_l1_addr = l1_write_addr_src_b + src_low_bits;
+                                const uint32_t row_l1_addr =
+                                    l1_write_addr_src_b + static_cast<uint32_t>(k) * current_chunk_bytes;
+
+                                noc.async_read(
+                                    src_b,
+                                    CoreLocalMem<uint32_t>(scratch_l1_addr),
+                                    element_size,
+                                    {.page_id = row_idx_b},
+                                    {});
+                                noc.async_read_barrier();
+
+                                copy_one_element<element_size>(row_l1_addr, scratch_l1_addr);
+                                FILL_TILE_WITH_FIRST_COLUMN_RM(row_l1_addr, current_chunk_elements);
+                            }
+#endif
+
+                            cb_src.push_back(1);
+                            cb_src_b.push_back(1);
+                        }
+
+                        row_blocks_pushed++;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_no_bcast.cpp
@@ -1,0 +1,173 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/alignment.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "api/core_local_mem.h"
+
+void kernel_main() {
+    uint32_t index = 0;
+    const uint32_t src_addr = get_arg_val<uint32_t>(index++);
+    const uint32_t dst_num_tiles = get_arg_val<uint32_t>(index++);
+
+    const uint32_t aD = get_arg_val<uint32_t>(index++);
+    const uint32_t aN = get_arg_val<uint32_t>(index++);
+    const uint32_t aC = get_arg_val<uint32_t>(index++);
+    const uint32_t aHt = get_arg_val<uint32_t>(index++);
+    const uint32_t aND = get_arg_val<uint32_t>(index++);
+
+    const uint32_t src_addr_b = get_arg_val<uint32_t>(index++);
+    const uint32_t bD = get_arg_val<uint32_t>(index++);
+    const uint32_t bN = get_arg_val<uint32_t>(index++);
+    const uint32_t bC = get_arg_val<uint32_t>(index++);
+    const uint32_t bHt = get_arg_val<uint32_t>(index++);
+    const uint32_t bND = get_arg_val<uint32_t>(index++);
+
+    const uint32_t cHt = get_arg_val<uint32_t>(index++);
+    const uint32_t cC = get_arg_val<uint32_t>(index++);
+    const uint32_t cND = get_arg_val<uint32_t>(index++);
+    const uint32_t current_block_start = get_arg_val<uint32_t>(index++);
+    const uint32_t rows_per_tile = get_arg_val<uint32_t>(index++);
+    const uint32_t row_width_elements = get_arg_val<uint32_t>(index++);
+    const uint32_t page_size_a_arg = get_arg_val<uint32_t>(index++);
+    const uint32_t page_size_b_arg = get_arg_val<uint32_t>(index++);
+    const uint32_t alignment_a = get_arg_val<uint32_t>(index++);
+    const uint32_t alignment_b = get_arg_val<uint32_t>(index++);
+    const uint32_t tiles_per_row = get_arg_val<uint32_t>(index++);
+    const uint32_t stride_size_bytes = get_arg_val<uint32_t>(index++);
+
+    constexpr auto cb_id_src = tt::CBIndex::c_0;
+    constexpr auto cb_id_src_b = tt::CBIndex::c_1;
+    constexpr auto src_args = TensorAccessorArgs<0>();
+    constexpr auto src_b_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
+
+    Noc noc;
+    CircularBuffer cb_src(cb_id_src);
+    CircularBuffer cb_src_b(cb_id_src_b);
+
+    constexpr uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    constexpr uint32_t tile_hw = get_tile_hw(cb_id_src);
+    constexpr uint32_t element_size = src_tile_bytes / tile_hw;
+    const uint32_t row_width_bytes = row_width_elements * element_size;
+
+    const uint32_t outHt = cHt;
+    const uint32_t outC = cC;
+    const uint32_t outN = (aN > bN) ? aN : bN;
+    const uint32_t outD = (aD > bD) ? aD : bD;
+    const uint32_t outND = cND;
+
+    const uint32_t page_size_a = align(page_size_a_arg, alignment_a);
+    const uint32_t page_size_b = align(page_size_b_arg, alignment_b);
+
+    // Third argument page_size from runtime args overrides TensorAccessorArgs::AlignedPageSize, which may be stale on
+    // program cache hits.
+    const auto src = TensorAccessor(src_args, src_addr, page_size_a);
+    const auto src_b = TensorAccessor(src_b_args, src_addr_b, page_size_b);
+
+    const uint32_t s_h_a = (aHt == 1) ? 0 : 1;
+    const uint32_t s_c_a = (aC == 1) ? 0 : aHt;
+    const uint32_t s_n_a = (aN == 1) ? 0 : aC * aHt;
+    const uint32_t s_d_a = (aD == 1) ? 0 : aN * aC * aHt;
+    const uint32_t s_nd_a = (aND == 1) ? 0 : aD * aN * aC * aHt;
+
+    const uint32_t s_h_b = (bHt == 1) ? 0 : 1;
+    const uint32_t s_c_b = (bC == 1) ? 0 : bHt;
+    const uint32_t s_n_b = (bN == 1) ? 0 : bC * bHt;
+    const uint32_t s_d_b = (bD == 1) ? 0 : bN * bC * bHt;
+    const uint32_t s_nd_b = (bND == 1) ? 0 : bD * bN * bC * bHt;
+
+    const uint32_t row_blocks_per_channel = (outHt + rows_per_tile - 1) / rows_per_tile;
+
+    uint32_t tmp = current_block_start;
+    uint32_t start_th = (tmp % row_blocks_per_channel) * rows_per_tile;
+    tmp /= row_blocks_per_channel;
+    uint32_t start_c = tmp % outC;
+    tmp /= outC;
+    uint32_t start_n = tmp % outN;
+    tmp /= outN;
+    uint32_t start_d = tmp % outD;
+    tmp /= outD;
+    uint32_t start_nd = tmp;
+
+    uint32_t row_blocks_pushed = 0;
+
+    for (uint32_t nd = start_nd; nd < outND && row_blocks_pushed < dst_num_tiles; ++nd, start_d = 0) {
+        const uint32_t ptr_nd_a = nd * s_nd_a;
+        const uint32_t ptr_nd_b = nd * s_nd_b;
+
+        for (uint32_t d = start_d; d < outD && row_blocks_pushed < dst_num_tiles; ++d, start_n = 0) {
+            const uint32_t ptr_d_a = ptr_nd_a + d * s_d_a;
+            const uint32_t ptr_d_b = ptr_nd_b + d * s_d_b;
+
+            for (uint32_t n = start_n; n < outN && row_blocks_pushed < dst_num_tiles; ++n, start_c = 0) {
+                const uint32_t ptr_n_a = ptr_d_a + n * s_n_a;
+                const uint32_t ptr_n_b = ptr_d_b + n * s_n_b;
+
+                for (uint32_t c = start_c; c < outC && row_blocks_pushed < dst_num_tiles; ++c, start_th = 0) {
+                    const uint32_t ptr_c_a = ptr_n_a + c * s_c_a;
+                    const uint32_t ptr_c_b = ptr_n_b + c * s_c_b;
+
+                    for (uint32_t th = start_th; th < outHt && row_blocks_pushed < dst_num_tiles; th += rows_per_tile) {
+                        const uint32_t rows_remaining_in_block = outHt - th;
+                        const uint32_t limit =
+                            (rows_remaining_in_block < rows_per_tile) ? rows_remaining_in_block : rows_per_tile;
+
+                        const uint32_t row_block_a = ptr_c_a + th * s_h_a;
+                        const uint32_t row_block_b = ptr_c_b + th * s_h_b;
+
+                        for (uint32_t t_i = 0; t_i < tiles_per_row; ++t_i) {
+                            const uint32_t current_chunk_offset = t_i * stride_size_bytes;
+                            const uint32_t bytes_left_in_row = row_width_bytes - current_chunk_offset;
+                            const uint32_t current_chunk_bytes =
+                                (stride_size_bytes < bytes_left_in_row) ? stride_size_bytes : bytes_left_in_row;
+                            const uint32_t current_read_len_a = align(current_chunk_bytes, alignment_a);
+                            const uint32_t current_read_len_b = align(current_chunk_bytes, alignment_b);
+
+                            cb_src.reserve_back(1);
+                            const uint32_t l1_write_addr_src = cb_src.get_write_ptr();
+
+                            cb_src_b.reserve_back(1);
+                            const uint32_t l1_write_addr_src_b = cb_src_b.get_write_ptr();
+
+                            uint32_t curr_l1_a = l1_write_addr_src;
+                            for (uint32_t k = 0; k < limit; ++k) {
+                                const uint32_t row_idx_a = row_block_a + k * s_h_a;
+                                noc.async_read(
+                                    src,
+                                    CoreLocalMem<uint32_t>(curr_l1_a),
+                                    current_read_len_a,
+                                    {.page_id = row_idx_a, .offset_bytes = current_chunk_offset},
+                                    {});
+                                curr_l1_a += current_chunk_bytes;
+                            }
+                            noc.async_read_barrier();
+
+                            uint32_t curr_l1_b = l1_write_addr_src_b;
+                            for (uint32_t k = 0; k < limit; ++k) {
+                                const uint32_t row_idx_b = row_block_b + k * s_h_b;
+                                noc.async_read(
+                                    src_b,
+                                    CoreLocalMem<uint32_t>(curr_l1_b),
+                                    current_read_len_b,
+                                    {.page_id = row_idx_b, .offset_bytes = current_chunk_offset},
+                                    {});
+                                curr_l1_b += current_chunk_bytes;
+                            }
+                            noc.async_read_barrier();
+
+                            cb_src.push_back(1);
+                            cb_src_b.push_back(1);
+                        }
+
+                        row_blocks_pushed++;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_bcast.cpp
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/alignment.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "api/core_local_mem.h"
+#include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+
+void kernel_main() {
+    uint32_t index = 0;
+    const uint32_t src_addr = get_arg_val<uint32_t>(index++);
+    const uint32_t dst_num_tiles = get_arg_val<uint32_t>(index++);
+
+    const uint32_t aD = get_arg_val<uint32_t>(index++);
+    const uint32_t aN = get_arg_val<uint32_t>(index++);
+    const uint32_t aC = get_arg_val<uint32_t>(index++);
+    const uint32_t aHt = get_arg_val<uint32_t>(index++);
+    const uint32_t aND = get_arg_val<uint32_t>(index++);
+
+    const uint32_t src_addr_b = get_arg_val<uint32_t>(index++);
+    const uint32_t bD = get_arg_val<uint32_t>(index++);
+    const uint32_t bN = get_arg_val<uint32_t>(index++);
+    const uint32_t bC = get_arg_val<uint32_t>(index++);
+    const uint32_t bHt = get_arg_val<uint32_t>(index++);
+    const uint32_t bND = get_arg_val<uint32_t>(index++);
+
+    const uint32_t cHt = get_arg_val<uint32_t>(index++);
+    const uint32_t cC = get_arg_val<uint32_t>(index++);
+    const uint32_t cND = get_arg_val<uint32_t>(index++);
+    const uint32_t current_block_start = get_arg_val<uint32_t>(index++);
+    const uint32_t rows_per_tile = get_arg_val<uint32_t>(index++);
+    const uint32_t row_width_elements = get_arg_val<uint32_t>(index++);
+    const uint32_t page_size_a_arg = get_arg_val<uint32_t>(index++);
+    const uint32_t page_size_b_arg = get_arg_val<uint32_t>(index++);
+    const uint32_t alignment_a = get_arg_val<uint32_t>(index++);
+    const uint32_t alignment_b = get_arg_val<uint32_t>(index++);
+    const uint32_t tiles_per_row = get_arg_val<uint32_t>(index++);
+    const uint32_t stride_size_bytes = get_arg_val<uint32_t>(index++);
+
+    constexpr auto cb_id_src = tt::CBIndex::c_0;
+    constexpr auto cb_id_src_b = tt::CBIndex::c_1;
+    constexpr auto src_args = TensorAccessorArgs<0>();
+    constexpr auto src_b_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
+
+    Noc noc;
+    CircularBuffer cb_src(cb_id_src);
+    CircularBuffer cb_src_b(cb_id_src_b);
+
+    constexpr uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    constexpr uint32_t tile_hw = get_tile_hw(cb_id_src);
+    constexpr uint32_t element_size = src_tile_bytes / tile_hw;
+    const uint32_t row_width_bytes = row_width_elements * element_size;
+
+    const uint32_t outHt = cHt;
+    const uint32_t outC = cC;
+    const uint32_t outN = (aN > bN) ? aN : bN;
+    const uint32_t outD = (aD > bD) ? aD : bD;
+    const uint32_t outND = cND;
+
+#if SRC_BCAST
+    const uint32_t page_size_a = align(page_size_a_arg, alignment_a);
+    const uint32_t page_size_b = align(page_size_b_arg, alignment_b);
+#else
+    const uint32_t page_size_a = align(page_size_a_arg, alignment_a);
+    const uint32_t page_size_b = align(page_size_b_arg, alignment_b);
+#endif
+
+    // Third argument page_size from runtime args overrides TensorAccessorArgs::AlignedPageSize, which may be stale on
+    // program cache hits.
+    const auto src = TensorAccessor(src_args, src_addr, page_size_a);
+    const auto src_b = TensorAccessor(src_b_args, src_addr_b, page_size_b);
+
+    const uint32_t s_h_a = (aHt == 1) ? 0 : 1;
+    const uint32_t s_c_a = (aC == 1) ? 0 : aHt;
+    const uint32_t s_n_a = (aN == 1) ? 0 : aC * aHt;
+    const uint32_t s_d_a = (aD == 1) ? 0 : aN * aC * aHt;
+    const uint32_t s_nd_a = (aND == 1) ? 0 : aD * aN * aC * aHt;
+
+    const uint32_t s_h_b = (bHt == 1) ? 0 : 1;
+    const uint32_t s_c_b = (bC == 1) ? 0 : bHt;
+    const uint32_t s_n_b = (bN == 1) ? 0 : bC * bHt;
+    const uint32_t s_d_b = (bD == 1) ? 0 : bN * bC * bHt;
+    const uint32_t s_nd_b = (bND == 1) ? 0 : bD * bN * bC * bHt;
+
+    const uint32_t row_blocks_per_channel = (outHt + rows_per_tile - 1) / rows_per_tile;
+
+    uint32_t tmp = current_block_start;
+    uint32_t start_th = (tmp % row_blocks_per_channel) * rows_per_tile;
+    tmp /= row_blocks_per_channel;
+    uint32_t start_c = tmp % outC;
+    tmp /= outC;
+    uint32_t start_n = tmp % outN;
+    tmp /= outN;
+    uint32_t start_d = tmp % outD;
+    tmp /= outD;
+    uint32_t start_nd = tmp;
+
+    uint32_t row_blocks_pushed = 0;
+
+    for (uint32_t nd = start_nd; nd < outND && row_blocks_pushed < dst_num_tiles; ++nd, start_d = 0) {
+        const uint32_t ptr_nd_a = nd * s_nd_a;
+        const uint32_t ptr_nd_b = nd * s_nd_b;
+
+        for (uint32_t d = start_d; d < outD && row_blocks_pushed < dst_num_tiles; ++d, start_n = 0) {
+            const uint32_t ptr_d_a = ptr_nd_a + d * s_d_a;
+            const uint32_t ptr_d_b = ptr_nd_b + d * s_d_b;
+
+            for (uint32_t n = start_n; n < outN && row_blocks_pushed < dst_num_tiles; ++n, start_c = 0) {
+                const uint32_t ptr_n_a = ptr_d_a + n * s_n_a;
+                const uint32_t ptr_n_b = ptr_d_b + n * s_n_b;
+
+                for (uint32_t c = start_c; c < outC && row_blocks_pushed < dst_num_tiles; ++c, start_th = 0) {
+                    const uint32_t ptr_c_a = ptr_n_a + c * s_c_a;
+                    const uint32_t ptr_c_b = ptr_n_b + c * s_c_b;
+
+                    for (uint32_t th = start_th; th < outHt && row_blocks_pushed < dst_num_tiles; th += rows_per_tile) {
+                        const uint32_t rows_remaining_in_block = outHt - th;
+                        const uint32_t limit =
+                            (rows_remaining_in_block < rows_per_tile) ? rows_remaining_in_block : rows_per_tile;
+
+                        const uint32_t row_block_a = ptr_c_a + th * s_h_a;
+                        const uint32_t row_block_b = ptr_c_b + th * s_h_b;
+
+                        for (uint32_t t_i = 0; t_i < tiles_per_row; ++t_i) {
+                            const uint32_t current_chunk_offset = t_i * stride_size_bytes;
+                            const uint32_t bytes_left_in_row = row_width_bytes - current_chunk_offset;
+                            const uint32_t current_chunk_bytes =
+                                (stride_size_bytes < bytes_left_in_row) ? stride_size_bytes : bytes_left_in_row;
+                            const uint32_t current_chunk_elements = current_chunk_bytes / element_size;
+                            const uint32_t current_read_len_a = align(current_chunk_bytes, alignment_a);
+                            const uint32_t current_read_len_b = align(current_chunk_bytes, alignment_b);
+
+                            cb_src.reserve_back(1);
+                            const uint32_t l1_write_addr_src = cb_src.get_write_ptr();
+
+                            cb_src_b.reserve_back(1);
+                            const uint32_t l1_write_addr_src_b = cb_src_b.get_write_ptr();
+
+#if SRC_BCAST
+                            noc.async_read(
+                                src,
+                                CoreLocalMem<uint32_t>(l1_write_addr_src),
+                                current_read_len_a,
+                                {.page_id = row_block_a, .offset_bytes = current_chunk_offset},
+                                {});
+
+                            uint32_t curr_l1_b = l1_write_addr_src_b;
+                            for (uint32_t k = 0; k < limit; ++k) {
+                                const uint32_t row_idx_b = row_block_b + k * s_h_b;
+                                noc.async_read(
+                                    src_b,
+                                    CoreLocalMem<uint32_t>(curr_l1_b),
+                                    current_read_len_b,
+                                    {.page_id = row_idx_b, .offset_bytes = current_chunk_offset},
+                                    {});
+                                curr_l1_b += current_chunk_bytes;
+                            }
+                            noc.async_read_barrier();
+                            FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src, current_chunk_elements, limit);
+#else
+                            uint32_t curr_l1_a = l1_write_addr_src;
+                            for (uint32_t k = 0; k < limit; ++k) {
+                                const uint32_t row_idx_a = row_block_a + k * s_h_a;
+                                noc.async_read(
+                                    src,
+                                    CoreLocalMem<uint32_t>(curr_l1_a),
+                                    current_read_len_a,
+                                    {.page_id = row_idx_a, .offset_bytes = current_chunk_offset},
+                                    {});
+                                curr_l1_a += current_chunk_bytes;
+                            }
+
+                            noc.async_read(
+                                src_b,
+                                CoreLocalMem<uint32_t>(l1_write_addr_src_b),
+                                current_read_len_b,
+                                {.page_id = row_block_b, .offset_bytes = current_chunk_offset},
+                                {});
+
+                            noc.async_read_barrier();
+                            FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src_b, current_chunk_elements, limit);
+#endif
+
+                            cb_src.push_back(1);
+                            cb_src_b.push_back(1);
+                        }
+
+                        row_blocks_pushed++;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_col_mixed_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_col_mixed_bcast.cpp
@@ -1,0 +1,240 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/alignment.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "api/core_local_mem.h"
+#include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+
+namespace {
+// Broadcast reads land in a scratch slot offset by source low bits; normalize the seed value to row start before fill.
+template <uint32_t element_size>
+FORCE_INLINE void copy_one_element(uint32_t dst_l1_addr, uint32_t src_l1_addr) {
+    static_assert(element_size == 1 || element_size == 2 || element_size == 4);
+
+    if constexpr (element_size == 1) {
+        auto* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(src_l1_addr);
+        auto* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(dst_l1_addr);
+        dst_ptr[0] = src_ptr[0];
+    } else if constexpr (element_size == 2) {
+        auto* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(src_l1_addr);
+        auto* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(dst_l1_addr);
+        dst_ptr[0] = src_ptr[0];
+    } else {
+        auto* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(src_l1_addr);
+        auto* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dst_l1_addr);
+        dst_ptr[0] = src_ptr[0];
+    }
+}
+}  // namespace
+
+void kernel_main() {
+    uint32_t index = 0;
+    const uint32_t src_addr = get_arg_val<uint32_t>(index++);
+    const uint32_t dst_num_tiles = get_arg_val<uint32_t>(index++);
+
+    const uint32_t aD = get_arg_val<uint32_t>(index++);
+    const uint32_t aN = get_arg_val<uint32_t>(index++);
+    const uint32_t aC = get_arg_val<uint32_t>(index++);
+    const uint32_t aHt = get_arg_val<uint32_t>(index++);
+    const uint32_t aND = get_arg_val<uint32_t>(index++);
+
+    const uint32_t src_addr_b = get_arg_val<uint32_t>(index++);
+    const uint32_t bD = get_arg_val<uint32_t>(index++);
+    const uint32_t bN = get_arg_val<uint32_t>(index++);
+    const uint32_t bC = get_arg_val<uint32_t>(index++);
+    const uint32_t bHt = get_arg_val<uint32_t>(index++);
+    const uint32_t bND = get_arg_val<uint32_t>(index++);
+
+    const uint32_t cHt = get_arg_val<uint32_t>(index++);
+    const uint32_t cC = get_arg_val<uint32_t>(index++);
+    const uint32_t cND = get_arg_val<uint32_t>(index++);
+    const uint32_t current_block_start = get_arg_val<uint32_t>(index++);
+    const uint32_t rows_per_tile = get_arg_val<uint32_t>(index++);
+    const uint32_t row_width_elements = get_arg_val<uint32_t>(index++);
+    const uint32_t page_size_a_arg = get_arg_val<uint32_t>(index++);
+    const uint32_t page_size_b_arg = get_arg_val<uint32_t>(index++);
+    const uint32_t alignment_a = get_arg_val<uint32_t>(index++);
+    const uint32_t alignment_b = get_arg_val<uint32_t>(index++);
+    const uint32_t tiles_per_row = get_arg_val<uint32_t>(index++);
+    const uint32_t stride_size_bytes = get_arg_val<uint32_t>(index++);
+
+    constexpr auto cb_id_src = tt::CBIndex::c_0;
+    constexpr auto cb_id_src_b = tt::CBIndex::c_1;
+    constexpr auto src_args = TensorAccessorArgs<0>();
+    constexpr auto src_b_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
+
+    Noc noc;
+    CircularBuffer cb_src(cb_id_src);
+    CircularBuffer cb_src_b(cb_id_src_b);
+
+    constexpr uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    constexpr uint32_t tile_hw = get_tile_hw(cb_id_src);
+    constexpr uint32_t element_size = src_tile_bytes / tile_hw;
+    const uint32_t element_size_aligned_a = align(element_size, alignment_a);
+    const uint32_t element_size_aligned_b = align(element_size, alignment_b);
+    const uint32_t row_width_bytes = row_width_elements * element_size;
+
+    const uint32_t outHt = cHt;
+    const uint32_t outC = cC;
+    const uint32_t outN = (aN > bN) ? aN : bN;
+    const uint32_t outD = (aD > bD) ? aD : bD;
+    const uint32_t outND = cND;
+
+#if SRC_BCAST_ROW_B
+    const uint32_t page_size_a = element_size_aligned_a;
+    const uint32_t page_size_b = align(page_size_b_arg, alignment_b);
+#else
+    const uint32_t page_size_a = align(page_size_a_arg, alignment_a);
+    const uint32_t page_size_b = element_size_aligned_b;
+#endif
+
+    // Third argument page_size from runtime args overrides TensorAccessorArgs::AlignedPageSize, which may be stale on
+    // program cache hits.
+    const auto src = TensorAccessor(src_args, src_addr, page_size_a);
+    const auto src_b = TensorAccessor(src_b_args, src_addr_b, page_size_b);
+
+    const uint32_t s_h_a = (aHt == 1) ? 0 : 1;
+    const uint32_t s_c_a = (aC == 1) ? 0 : aHt;
+    const uint32_t s_n_a = (aN == 1) ? 0 : aC * aHt;
+    const uint32_t s_d_a = (aD == 1) ? 0 : aN * aC * aHt;
+    const uint32_t s_nd_a = (aND == 1) ? 0 : aD * aN * aC * aHt;
+
+    const uint32_t s_h_b = (bHt == 1) ? 0 : 1;
+    const uint32_t s_c_b = (bC == 1) ? 0 : bHt;
+    const uint32_t s_n_b = (bN == 1) ? 0 : bC * bHt;
+    const uint32_t s_d_b = (bD == 1) ? 0 : bN * bC * bHt;
+    const uint32_t s_nd_b = (bND == 1) ? 0 : bD * bN * bC * bHt;
+
+    const uint32_t row_blocks_per_channel = (outHt + rows_per_tile - 1) / rows_per_tile;
+
+    uint32_t tmp = current_block_start;
+    uint32_t start_th = (tmp % row_blocks_per_channel) * rows_per_tile;
+    tmp /= row_blocks_per_channel;
+    uint32_t start_c = tmp % outC;
+    tmp /= outC;
+    uint32_t start_n = tmp % outN;
+    tmp /= outN;
+    uint32_t start_d = tmp % outD;
+    tmp /= outD;
+    uint32_t start_nd = tmp;
+
+    uint32_t row_blocks_pushed = 0;
+
+    for (uint32_t nd = start_nd; nd < outND && row_blocks_pushed < dst_num_tiles; ++nd, start_d = 0) {
+        const uint32_t ptr_nd_a = nd * s_nd_a;
+        const uint32_t ptr_nd_b = nd * s_nd_b;
+
+        for (uint32_t d = start_d; d < outD && row_blocks_pushed < dst_num_tiles; ++d, start_n = 0) {
+            const uint32_t ptr_d_a = ptr_nd_a + d * s_d_a;
+            const uint32_t ptr_d_b = ptr_nd_b + d * s_d_b;
+
+            for (uint32_t n = start_n; n < outN && row_blocks_pushed < dst_num_tiles; ++n, start_c = 0) {
+                const uint32_t ptr_n_a = ptr_d_a + n * s_n_a;
+                const uint32_t ptr_n_b = ptr_d_b + n * s_n_b;
+
+                for (uint32_t c = start_c; c < outC && row_blocks_pushed < dst_num_tiles; ++c, start_th = 0) {
+                    const uint32_t ptr_c_a = ptr_n_a + c * s_c_a;
+                    const uint32_t ptr_c_b = ptr_n_b + c * s_c_b;
+
+                    for (uint32_t th = start_th; th < outHt && row_blocks_pushed < dst_num_tiles; th += rows_per_tile) {
+                        const uint32_t rows_remaining_in_block = outHt - th;
+                        const uint32_t limit =
+                            (rows_remaining_in_block < rows_per_tile) ? rows_remaining_in_block : rows_per_tile;
+
+                        const uint32_t row_block_a = ptr_c_a + th * s_h_a;
+                        const uint32_t row_block_b = ptr_c_b + th * s_h_b;
+
+                        for (uint32_t t_i = 0; t_i < tiles_per_row; ++t_i) {
+                            const uint32_t current_chunk_offset = t_i * stride_size_bytes;
+                            const uint32_t bytes_left_in_row = row_width_bytes - current_chunk_offset;
+                            const uint32_t current_chunk_bytes =
+                                (stride_size_bytes < bytes_left_in_row) ? stride_size_bytes : bytes_left_in_row;
+                            const uint32_t current_chunk_elements = current_chunk_bytes / element_size;
+
+                            cb_src.reserve_back(1);
+                            const uint32_t l1_write_addr_src = cb_src.get_write_ptr();
+
+                            cb_src_b.reserve_back(1);
+                            const uint32_t l1_write_addr_src_b = cb_src_b.get_write_ptr();
+
+#if SRC_BCAST_ROW_B
+                            const uint32_t current_read_len_b = align(current_chunk_bytes, alignment_b);
+
+                            for (int32_t k = static_cast<int32_t>(limit) - 1; k >= 0; --k) {
+                                const uint32_t row_idx_a = row_block_a + static_cast<uint32_t>(k) * s_h_a;
+                                const uint64_t addr_a = src.get_noc_addr(row_idx_a);
+                                const uint32_t src_low_bits = static_cast<uint32_t>(addr_a & (alignment_a - 1));
+                                const uint32_t scratch_l1_addr = l1_write_addr_src + src_low_bits;
+                                const uint32_t row_l1_addr =
+                                    l1_write_addr_src + static_cast<uint32_t>(k) * current_chunk_bytes;
+
+                                noc.async_read(
+                                    src,
+                                    CoreLocalMem<uint32_t>(scratch_l1_addr),
+                                    element_size,
+                                    {.page_id = row_idx_a},
+                                    {});
+                                noc.async_read_barrier();
+
+                                copy_one_element<element_size>(row_l1_addr, scratch_l1_addr);
+                                FILL_TILE_WITH_FIRST_COLUMN_RM(row_l1_addr, current_chunk_elements);
+                            }
+
+                            noc.async_read(
+                                src_b,
+                                CoreLocalMem<uint32_t>(l1_write_addr_src_b),
+                                current_read_len_b,
+                                {.page_id = row_block_b, .offset_bytes = current_chunk_offset},
+                                {});
+                            noc.async_read_barrier();
+                            FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src_b, current_chunk_elements, limit);
+#else
+                            const uint32_t current_read_len_a = align(current_chunk_bytes, alignment_a);
+
+                            for (int32_t k = static_cast<int32_t>(limit) - 1; k >= 0; --k) {
+                                const uint32_t row_idx_b = row_block_b + static_cast<uint32_t>(k) * s_h_b;
+                                const uint64_t addr_b = src_b.get_noc_addr(row_idx_b);
+                                const uint32_t src_low_bits = static_cast<uint32_t>(addr_b & (alignment_b - 1));
+                                const uint32_t scratch_l1_addr = l1_write_addr_src_b + src_low_bits;
+                                const uint32_t row_l1_addr =
+                                    l1_write_addr_src_b + static_cast<uint32_t>(k) * current_chunk_bytes;
+
+                                noc.async_read(
+                                    src_b,
+                                    CoreLocalMem<uint32_t>(scratch_l1_addr),
+                                    element_size,
+                                    {.page_id = row_idx_b},
+                                    {});
+                                noc.async_read_barrier();
+
+                                copy_one_element<element_size>(row_l1_addr, scratch_l1_addr);
+                                FILL_TILE_WITH_FIRST_COLUMN_RM(row_l1_addr, current_chunk_elements);
+                            }
+
+                            noc.async_read(
+                                src,
+                                CoreLocalMem<uint32_t>(l1_write_addr_src),
+                                current_read_len_a,
+                                {.page_id = row_block_a, .offset_bytes = current_chunk_offset},
+                                {});
+                            noc.async_read_barrier();
+                            FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src, current_chunk_elements, limit);
+#endif
+
+                            cb_src.push_back(1);
+                            cb_src_b.push_back(1);
+                        }
+
+                        row_blocks_pushed++;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_bcast.cpp
@@ -1,0 +1,239 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/alignment.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "api/core_local_mem.h"
+#include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+
+namespace {
+// Broadcast reads land in a scratch slot offset by source low bits; normalize the seed value to row start before fill.
+template <uint32_t element_size>
+FORCE_INLINE void copy_one_element(uint32_t dst_l1_addr, uint32_t src_l1_addr) {
+    static_assert(element_size == 1 || element_size == 2 || element_size == 4);
+
+    if constexpr (element_size == 1) {
+        auto* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(src_l1_addr);
+        auto* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(dst_l1_addr);
+        dst_ptr[0] = src_ptr[0];
+    } else if constexpr (element_size == 2) {
+        auto* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(src_l1_addr);
+        auto* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(dst_l1_addr);
+        dst_ptr[0] = src_ptr[0];
+    } else {
+        auto* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(src_l1_addr);
+        auto* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dst_l1_addr);
+        dst_ptr[0] = src_ptr[0];
+    }
+}
+}  // namespace
+
+void kernel_main() {
+    uint32_t index = 0;
+    const uint32_t src_addr = get_arg_val<uint32_t>(index++);
+    const uint32_t dst_num_tiles = get_arg_val<uint32_t>(index++);
+
+    const uint32_t aD = get_arg_val<uint32_t>(index++);
+    const uint32_t aN = get_arg_val<uint32_t>(index++);
+    const uint32_t aC = get_arg_val<uint32_t>(index++);
+    const uint32_t aHt = get_arg_val<uint32_t>(index++);
+    const uint32_t aND = get_arg_val<uint32_t>(index++);
+
+    const uint32_t src_addr_b = get_arg_val<uint32_t>(index++);
+    const uint32_t bD = get_arg_val<uint32_t>(index++);
+    const uint32_t bN = get_arg_val<uint32_t>(index++);
+    const uint32_t bC = get_arg_val<uint32_t>(index++);
+    const uint32_t bHt = get_arg_val<uint32_t>(index++);
+    const uint32_t bND = get_arg_val<uint32_t>(index++);
+
+    const uint32_t cHt = get_arg_val<uint32_t>(index++);
+    const uint32_t cC = get_arg_val<uint32_t>(index++);
+    const uint32_t cND = get_arg_val<uint32_t>(index++);
+    const uint32_t current_block_start = get_arg_val<uint32_t>(index++);
+    const uint32_t rows_per_tile = get_arg_val<uint32_t>(index++);
+    const uint32_t row_width_elements = get_arg_val<uint32_t>(index++);
+    const uint32_t page_size_a_arg = get_arg_val<uint32_t>(index++);
+    const uint32_t page_size_b_arg = get_arg_val<uint32_t>(index++);
+    const uint32_t alignment_a = get_arg_val<uint32_t>(index++);
+    const uint32_t alignment_b = get_arg_val<uint32_t>(index++);
+    const uint32_t tiles_per_row = get_arg_val<uint32_t>(index++);
+    const uint32_t stride_size_bytes = get_arg_val<uint32_t>(index++);
+
+    constexpr auto cb_id_src = tt::CBIndex::c_0;
+    constexpr auto cb_id_src_b = tt::CBIndex::c_1;
+    constexpr auto src_args = TensorAccessorArgs<0>();
+    constexpr auto src_b_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
+
+    Noc noc;
+    CircularBuffer cb_src(cb_id_src);
+    CircularBuffer cb_src_b(cb_id_src_b);
+
+    constexpr uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    constexpr uint32_t tile_hw = get_tile_hw(cb_id_src);
+    constexpr uint32_t element_size = src_tile_bytes / tile_hw;
+    const uint32_t element_size_aligned_a = align(element_size, alignment_a);
+    const uint32_t element_size_aligned_b = align(element_size, alignment_b);
+    const uint32_t row_width_bytes = row_width_elements * element_size;
+
+    const uint32_t outHt = cHt;
+    const uint32_t outC = cC;
+    const uint32_t outN = (aN > bN) ? aN : bN;
+    const uint32_t outD = (aD > bD) ? aD : bD;
+    const uint32_t outND = cND;
+
+#if SRC_BCAST
+    const uint32_t page_size_a = element_size_aligned_a;
+    const uint32_t page_size_b = align(page_size_b_arg, alignment_b);
+#else
+    const uint32_t page_size_a = align(page_size_a_arg, alignment_a);
+    const uint32_t page_size_b = element_size_aligned_b;
+#endif
+
+    // Third argument page_size from runtime args overrides TensorAccessorArgs::AlignedPageSize, which may be stale on
+    // program cache hits.
+    const auto src = TensorAccessor(src_args, src_addr, page_size_a);
+    const auto src_b = TensorAccessor(src_b_args, src_addr_b, page_size_b);
+
+    const uint32_t s_h_a = (aHt == 1) ? 0 : 1;
+    const uint32_t s_c_a = (aC == 1) ? 0 : aHt;
+    const uint32_t s_n_a = (aN == 1) ? 0 : aC * aHt;
+    const uint32_t s_d_a = (aD == 1) ? 0 : aN * aC * aHt;
+    const uint32_t s_nd_a = (aND == 1) ? 0 : aD * aN * aC * aHt;
+
+    const uint32_t s_h_b = (bHt == 1) ? 0 : 1;
+    const uint32_t s_c_b = (bC == 1) ? 0 : bHt;
+    const uint32_t s_n_b = (bN == 1) ? 0 : bC * bHt;
+    const uint32_t s_d_b = (bD == 1) ? 0 : bN * bC * bHt;
+    const uint32_t s_nd_b = (bND == 1) ? 0 : bD * bN * bC * bHt;
+
+    const uint32_t row_blocks_per_channel = (outHt + rows_per_tile - 1) / rows_per_tile;
+
+    uint32_t tmp = current_block_start;
+    uint32_t start_th = (tmp % row_blocks_per_channel) * rows_per_tile;
+    tmp /= row_blocks_per_channel;
+    uint32_t start_c = tmp % outC;
+    tmp /= outC;
+    uint32_t start_n = tmp % outN;
+    tmp /= outN;
+    uint32_t start_d = tmp % outD;
+    tmp /= outD;
+    uint32_t start_nd = tmp;
+
+    uint32_t row_blocks_pushed = 0;
+
+    for (uint32_t nd = start_nd; nd < outND && row_blocks_pushed < dst_num_tiles; ++nd, start_d = 0) {
+        const uint32_t ptr_nd_a = nd * s_nd_a;
+        const uint32_t ptr_nd_b = nd * s_nd_b;
+
+        for (uint32_t d = start_d; d < outD && row_blocks_pushed < dst_num_tiles; ++d, start_n = 0) {
+            const uint32_t ptr_d_a = ptr_nd_a + d * s_d_a;
+            const uint32_t ptr_d_b = ptr_nd_b + d * s_d_b;
+
+            for (uint32_t n = start_n; n < outN && row_blocks_pushed < dst_num_tiles; ++n, start_c = 0) {
+                const uint32_t ptr_n_a = ptr_d_a + n * s_n_a;
+                const uint32_t ptr_n_b = ptr_d_b + n * s_n_b;
+
+                for (uint32_t c = start_c; c < outC && row_blocks_pushed < dst_num_tiles; ++c, start_th = 0) {
+                    const uint32_t ptr_c_a = ptr_n_a + c * s_c_a;
+                    const uint32_t ptr_c_b = ptr_n_b + c * s_c_b;
+
+                    for (uint32_t th = start_th; th < outHt && row_blocks_pushed < dst_num_tiles; th += rows_per_tile) {
+                        const uint32_t rows_remaining_in_block = outHt - th;
+                        const uint32_t limit =
+                            (rows_remaining_in_block < rows_per_tile) ? rows_remaining_in_block : rows_per_tile;
+
+                        const uint32_t row_block_a = ptr_c_a + th * s_h_a;
+                        const uint32_t row_block_b = ptr_c_b + th * s_h_b;
+
+                        for (uint32_t t_i = 0; t_i < tiles_per_row; ++t_i) {
+                            const uint32_t current_chunk_offset = t_i * stride_size_bytes;
+                            const uint32_t bytes_left_in_row = row_width_bytes - current_chunk_offset;
+                            const uint32_t current_chunk_bytes =
+                                (stride_size_bytes < bytes_left_in_row) ? stride_size_bytes : bytes_left_in_row;
+                            const uint32_t current_chunk_elements = current_chunk_bytes / element_size;
+
+                            cb_src.reserve_back(1);
+                            const uint32_t l1_write_addr_src = cb_src.get_write_ptr();
+
+                            cb_src_b.reserve_back(1);
+                            const uint32_t l1_write_addr_src_b = cb_src_b.get_write_ptr();
+
+#if SRC_BCAST
+                            const uint32_t current_read_len_b = align(current_chunk_bytes, alignment_b);
+                            const uint64_t addr_a = src.get_noc_addr(row_block_a);
+                            const uint32_t src_low_bits = static_cast<uint32_t>(addr_a & (alignment_a - 1));
+                            const uint32_t scratch_l1_addr = l1_write_addr_src + src_low_bits;
+
+                            noc.async_read(
+                                src,
+                                CoreLocalMem<uint32_t>(scratch_l1_addr),
+                                element_size,
+                                {.page_id = row_block_a},
+                                {});
+                            noc.async_read_barrier();
+
+                            copy_one_element<element_size>(l1_write_addr_src, scratch_l1_addr);
+                            FILL_TILE_WITH_FIRST_COLUMN_RM(l1_write_addr_src, current_chunk_elements);
+
+                            uint32_t curr_l1_b = l1_write_addr_src_b;
+                            for (uint32_t k = 0; k < limit; ++k) {
+                                const uint32_t row_idx_b = row_block_b + k * s_h_b;
+                                noc.async_read(
+                                    src_b,
+                                    CoreLocalMem<uint32_t>(curr_l1_b),
+                                    current_read_len_b,
+                                    {.page_id = row_idx_b, .offset_bytes = current_chunk_offset},
+                                    {});
+                                curr_l1_b += current_chunk_bytes;
+                            }
+                            noc.async_read_barrier();
+
+                            FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src, current_chunk_elements, limit);
+#else
+                            const uint32_t current_read_len_a = align(current_chunk_bytes, alignment_a);
+                            uint32_t curr_l1_a = l1_write_addr_src;
+                            for (uint32_t k = 0; k < limit; ++k) {
+                                const uint32_t row_idx_a = row_block_a + k * s_h_a;
+                                noc.async_read(
+                                    src,
+                                    CoreLocalMem<uint32_t>(curr_l1_a),
+                                    current_read_len_a,
+                                    {.page_id = row_idx_a, .offset_bytes = current_chunk_offset},
+                                    {});
+                                curr_l1_a += current_chunk_bytes;
+                            }
+                            noc.async_read_barrier();
+
+                            const uint64_t addr_b = src_b.get_noc_addr(row_block_b);
+                            const uint32_t src_low_bits = static_cast<uint32_t>(addr_b & (alignment_b - 1));
+                            const uint32_t scratch_l1_addr = l1_write_addr_src_b + src_low_bits;
+
+                            noc.async_read(
+                                src_b,
+                                CoreLocalMem<uint32_t>(scratch_l1_addr),
+                                element_size,
+                                {.page_id = row_block_b},
+                                {});
+                            noc.async_read_barrier();
+
+                            copy_one_element<element_size>(l1_write_addr_src_b, scratch_l1_addr);
+                            FILL_TILE_WITH_FIRST_COLUMN_RM(l1_write_addr_src_b, current_chunk_elements);
+                            FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src_b, current_chunk_elements, limit);
+#endif
+
+                            cb_src.push_back(1);
+                            cb_src_b.push_back(1);
+                        }
+
+                        row_blocks_pushed++;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_op.cpp
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/alignment.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "api/core_local_mem.h"
+#include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+
+void kernel_main() {
+    uint32_t index = 0;
+    const uint32_t src_addr = get_arg_val<uint32_t>(index++);
+    const uint32_t dst_num_tiles = get_arg_val<uint32_t>(index++);
+
+    const uint32_t aD = get_arg_val<uint32_t>(index++);
+    const uint32_t aN = get_arg_val<uint32_t>(index++);
+    const uint32_t aC = get_arg_val<uint32_t>(index++);
+    const uint32_t aHt = get_arg_val<uint32_t>(index++);
+    const uint32_t aND = get_arg_val<uint32_t>(index++);
+
+    index += 6;  // Scalar-op reader shares the RM reader ABI but does not consume tensor-B shape/address args.
+
+    const uint32_t cHt = get_arg_val<uint32_t>(index++);
+    const uint32_t cC = get_arg_val<uint32_t>(index++);
+    const uint32_t cND = get_arg_val<uint32_t>(index++);
+    const uint32_t current_block_start = get_arg_val<uint32_t>(index++);
+    const uint32_t rows_per_tile = get_arg_val<uint32_t>(index++);
+    const uint32_t row_width_elements = get_arg_val<uint32_t>(index++);
+    const uint32_t page_size_a_arg = get_arg_val<uint32_t>(index++);
+    index++;  // Skip tensor-B page size.
+    const uint32_t alignment_a = get_arg_val<uint32_t>(index++);
+    index++;  // Skip tensor-B alignment.
+    const uint32_t tiles_per_row = get_arg_val<uint32_t>(index++);
+    const uint32_t stride_size_bytes = get_arg_val<uint32_t>(index++);
+    const uint32_t packed_scalar = get_arg_val<uint32_t>(index++);
+
+    constexpr auto cb_id_src = tt::CBIndex::c_0;
+    constexpr auto cb_id_src_b = tt::CBIndex::c_1;
+    constexpr auto src_args = TensorAccessorArgs<0>();
+
+    Noc noc;
+    CircularBuffer cb_src(cb_id_src);
+    CircularBuffer cb_src_b(cb_id_src_b);
+
+    constexpr uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    constexpr uint32_t tile_hw = get_tile_hw(cb_id_src);
+    constexpr uint32_t element_size = src_tile_bytes / tile_hw;
+    const uint32_t row_width_bytes = row_width_elements * element_size;
+
+    const uint32_t outHt = cHt;
+    const uint32_t outC = cC;
+    const uint32_t outN = aN;
+    const uint32_t outD = aD;
+    const uint32_t outND = cND;
+
+    const uint32_t page_size_a = align(page_size_a_arg, alignment_a);
+    // Third argument page_size from runtime args overrides TensorAccessorArgs::AlignedPageSize, which may be stale on
+    // program cache hits.
+    const auto src = TensorAccessor(src_args, src_addr, page_size_a);
+
+    cb_src_b.reserve_back(1);
+#ifdef FILL_WITH_VALUE_FLOAT_B
+    const auto float_ptr_b = reinterpret_cast<const float*>(&packed_scalar);
+    FILL_WITH_VALUE_FLOAT_B(cb_src_b.get_write_ptr(), *float_ptr_b);
+#endif
+#ifdef FILL_WITH_VALUE_B
+    FILL_WITH_VALUE_B(cb_src_b.get_write_ptr(), packed_scalar);
+#endif
+    cb_src_b.push_back(1);
+
+    const uint32_t s_h_a = (aHt == 1) ? 0 : 1;
+    const uint32_t s_c_a = (aC == 1) ? 0 : aHt;
+    const uint32_t s_n_a = (aN == 1) ? 0 : aC * aHt;
+    const uint32_t s_d_a = (aD == 1) ? 0 : aN * aC * aHt;
+    const uint32_t s_nd_a = (aND == 1) ? 0 : aD * aN * aC * aHt;
+
+    const uint32_t row_blocks_per_channel = (outHt + rows_per_tile - 1) / rows_per_tile;
+
+    uint32_t tmp = current_block_start;
+    uint32_t start_th = (tmp % row_blocks_per_channel) * rows_per_tile;
+    tmp /= row_blocks_per_channel;
+    uint32_t start_c = tmp % outC;
+    tmp /= outC;
+    uint32_t start_n = tmp % outN;
+    tmp /= outN;
+    uint32_t start_d = tmp % outD;
+    tmp /= outD;
+    uint32_t start_nd = tmp;
+
+    uint32_t row_blocks_pushed = 0;
+
+    for (uint32_t nd = start_nd; nd < outND && row_blocks_pushed < dst_num_tiles; ++nd, start_d = 0) {
+        const uint32_t ptr_nd_a = nd * s_nd_a;
+
+        for (uint32_t d = start_d; d < outD && row_blocks_pushed < dst_num_tiles; ++d, start_n = 0) {
+            const uint32_t ptr_d_a = ptr_nd_a + d * s_d_a;
+
+            for (uint32_t n = start_n; n < outN && row_blocks_pushed < dst_num_tiles; ++n, start_c = 0) {
+                const uint32_t ptr_n_a = ptr_d_a + n * s_n_a;
+
+                for (uint32_t c = start_c; c < outC && row_blocks_pushed < dst_num_tiles; ++c, start_th = 0) {
+                    const uint32_t ptr_c_a = ptr_n_a + c * s_c_a;
+
+                    for (uint32_t th = start_th; th < outHt && row_blocks_pushed < dst_num_tiles; th += rows_per_tile) {
+                        const uint32_t rows_remaining_in_block = outHt - th;
+                        const uint32_t limit =
+                            (rows_remaining_in_block < rows_per_tile) ? rows_remaining_in_block : rows_per_tile;
+
+                        const uint32_t row_block_a = ptr_c_a + th * s_h_a;
+
+                        for (uint32_t t_i = 0; t_i < tiles_per_row; ++t_i) {
+                            const uint32_t current_chunk_offset = t_i * stride_size_bytes;
+                            const uint32_t bytes_left_in_row = row_width_bytes - current_chunk_offset;
+                            const uint32_t current_chunk_bytes =
+                                (stride_size_bytes < bytes_left_in_row) ? stride_size_bytes : bytes_left_in_row;
+                            const uint32_t current_read_len = align(current_chunk_bytes, alignment_a);
+
+                            cb_src.reserve_back(1);
+                            const uint32_t l1_write_addr_src = cb_src.get_write_ptr();
+
+                            uint32_t curr_l1_a = l1_write_addr_src;
+                            for (uint32_t k = 0; k < limit; ++k) {
+                                const uint32_t row_idx_a = row_block_a + k * s_h_a;
+                                noc.async_read(
+                                    src,
+                                    CoreLocalMem<uint32_t>(curr_l1_a),
+                                    current_read_len,
+                                    {.page_id = row_idx_a, .offset_bytes = current_chunk_offset},
+                                    {});
+                                curr_l1_a += current_chunk_bytes;
+                            }
+                            noc.async_read_barrier();
+
+                            cb_src.push_back(1);
+                        }
+
+                        row_blocks_pushed++;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_bcast.cpp
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+
+void kernel_main() {
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t start_tile_id = get_arg_val<uint32_t>(1);
+    const uint32_t src_num_tiles = get_arg_val<uint32_t>(2);
+    const uint32_t dst_num_tiles = get_arg_val<uint32_t>(3);
+    const uint32_t dst_shard_width = get_arg_val<uint32_t>(4);
+    const uint32_t nD_stride = get_arg_val<uint32_t>(5);
+    const uint32_t d_stride = get_arg_val<uint32_t>(6);
+    const uint32_t n_stride = get_arg_val<uint32_t>(7);
+    const uint32_t c_stride = get_arg_val<uint32_t>(8);
+    const uint32_t D = get_arg_val<uint32_t>(9);
+    const uint32_t N = get_arg_val<uint32_t>(10);
+    const uint32_t C = get_arg_val<uint32_t>(11);
+    const uint32_t Ht = get_arg_val<uint32_t>(12);
+    const uint32_t Wt = get_arg_val<uint32_t>(13);
+    const uint32_t cND = get_arg_val<uint32_t>(14);  // collapsed dims > 5
+    const uint32_t src_addr_b = get_arg_val<uint32_t>(15);
+    const uint32_t nD_stride_b = get_arg_val<uint32_t>(16);
+    const uint32_t d_stride_b = get_arg_val<uint32_t>(17);
+    const uint32_t n_stride_b = get_arg_val<uint32_t>(18);
+    const uint32_t c_stride_b = get_arg_val<uint32_t>(19);
+    const uint32_t src_num_tiles_b = get_arg_val<uint32_t>(20);
+
+    constexpr auto cb_id_src = tt::CBIndex::c_0;
+    constexpr auto cb_id_src_b = tt::CBIndex::c_1;
+    constexpr auto src_args = TensorAccessorArgs<0, 0>();
+    constexpr auto src_b_args =
+        TensorAccessorArgs<src_args.next_compile_time_args_offset(), src_args.next_common_runtime_args_offset()>();
+
+    Noc noc;
+    CircularBuffer cb_src(cb_id_src);
+    CircularBuffer cb_src_b(cb_id_src_b);
+
+#if SRC_SHARDED
+    cb_src.reserve_back(src_num_tiles);
+    cb_src.push_back(src_num_tiles);
+#else
+    const uint32_t src_tile_bytes = cb_src.get_tile_size();
+    const auto src = TensorAccessor(src_args, src_addr);
+#endif
+#if SRC_SHARDED_B
+    cb_src_b.reserve_back(src_num_tiles_b);
+    cb_src_b.push_back(src_num_tiles_b);
+#else
+    const uint32_t src_tile_bytes_b = cb_src_b.get_tile_size();
+    const auto src_b = TensorAccessor(src_b_args, src_addr_b);
+#endif
+#if !SRC_SHARDED || !SRC_SHARDED_B
+    constexpr uint32_t onetile = 1;
+    constexpr bool has_sharding = get_compile_time_arg_val(src_b_args.next_compile_time_args_offset()) == 1;
+    const uint32_t HtWt = Ht * Wt;
+
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_tile_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    const uint32_t offset_c = offset_n % HtWt;
+    uint32_t start_nd = start_tile_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_th = offset_c / Wt;
+    uint32_t start_tw = offset_c % Wt;
+    uint32_t end_tw = has_sharding ? start_tw + dst_shard_width : Wt;
+
+    // this is the INPUT tile offset
+    uint32_t tile_offset = start_nd * nD_stride + start_d * d_stride + start_n * n_stride + start_c * c_stride;
+#if !SRC_BCAST
+    tile_offset += start_th * Wt;
+#endif
+    uint32_t next_c_shift = c_stride - HtWt;
+    uint32_t next_n_shift = n_stride - c_stride * C;
+    uint32_t next_d_shift = d_stride - n_stride * N;
+    uint32_t next_nd_shift = nD_stride - d_stride * D;
+
+    uint32_t tile_offset_b =
+        start_nd * nD_stride_b + start_d * d_stride_b + start_n * n_stride_b + start_c * c_stride_b;
+#if !SRC_BCAST_B
+    tile_offset_b += start_th * Wt;
+#endif
+    uint32_t next_c_shift_b = c_stride_b - HtWt;
+    uint32_t next_n_shift_b = n_stride_b - c_stride_b * C;
+    uint32_t next_d_shift_b = d_stride_b - n_stride_b * N;
+    uint32_t next_nd_shift_b = nD_stride_b - d_stride_b * D;
+
+    uint32_t num_tiles_read = 0;
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_read < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
+                    for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th) {
+                        for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
+                             ++tw, ++num_tiles_read) {
+#if !SRC_SHARDED
+                            cb_src.reserve_back(onetile);
+                            noc.async_read(
+                                src, cb_src, src_tile_bytes, {.page_id = tile_offset + tw}, {.offset_bytes = 0});
+#endif
+#if !SRC_SHARDED_B
+                            // read a tile from src_b
+                            cb_src_b.reserve_back(onetile);
+                            noc.async_read(
+                                src_b,
+                                cb_src_b,
+                                src_tile_bytes_b,
+                                {.page_id = tile_offset_b + tw},
+                                {.offset_bytes = 0});
+#endif
+#if !SRC_SHARDED || !SRC_SHARDED_B
+                            noc.async_read_barrier();
+#endif
+#if SRC_BCAST && !BCAST_LLK  // no sharding support for row bcast yet
+                            FILL_TILE_WITH_FIRST_ROW(cb_src.get_write_ptr());
+#endif
+#if SRC_BCAST_B && !BCAST_LLK  // no sharding support for row bcast yet
+                            FILL_TILE_WITH_FIRST_ROW_B(cb_src_b.get_write_ptr());
+#endif
+#if !SRC_SHARDED
+                            cb_src.push_back(onetile);
+#endif
+#if !SRC_SHARDED_B
+                            cb_src_b.push_back(onetile);
+#endif
+                        }
+                        if constexpr (!has_sharding) {
+                            // next row of tiles should start at the first column
+                            start_tw = 0;
+                        }
+#if !SRC_BCAST
+                        tile_offset += Wt;
+#endif
+#if !SRC_BCAST_B
+                        tile_offset_b += Wt;
+#endif
+                    }
+#if SRC_BCAST
+                    // same as following logically
+                    // tile_offset += HtWt;
+                    // tile_offset += next_c_shift;
+                    tile_offset += c_stride;
+#else
+                    tile_offset += next_c_shift;
+#endif
+#if SRC_BCAST_B
+                    tile_offset_b += c_stride_b;
+#else
+                    tile_offset_b += next_c_shift_b;
+#endif
+                }
+                tile_offset += next_n_shift;
+                tile_offset_b += next_n_shift_b;
+            }
+            tile_offset += next_d_shift;
+            tile_offset_b += next_d_shift_b;
+        }
+        tile_offset += next_nd_shift;
+        tile_offset_b += next_nd_shift_b;
+    }
+#endif
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_col_mixed_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_col_mixed_bcast.cpp
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+
+void kernel_main() {
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t start_tile_id = get_arg_val<uint32_t>(1);
+    const uint32_t src_num_tiles = get_arg_val<uint32_t>(2);
+    const uint32_t dst_num_tiles = get_arg_val<uint32_t>(3);
+    const uint32_t dst_shard_width = get_arg_val<uint32_t>(4);
+    const uint32_t nD_stride = get_arg_val<uint32_t>(5);
+    const uint32_t d_stride = get_arg_val<uint32_t>(6);
+    const uint32_t n_stride = get_arg_val<uint32_t>(7);
+    const uint32_t c_stride = get_arg_val<uint32_t>(8);
+    const uint32_t D = get_arg_val<uint32_t>(9);
+    const uint32_t N = get_arg_val<uint32_t>(10);
+    const uint32_t C = get_arg_val<uint32_t>(11);
+    const uint32_t Ht = get_arg_val<uint32_t>(12);
+    const uint32_t Wt = get_arg_val<uint32_t>(13);
+    const uint32_t cND = get_arg_val<uint32_t>(14);  // collapsed dims > 5
+    const uint32_t src_addr_b = get_arg_val<uint32_t>(15);
+    const uint32_t nD_stride_b = get_arg_val<uint32_t>(16);
+    const uint32_t d_stride_b = get_arg_val<uint32_t>(17);
+    const uint32_t n_stride_b = get_arg_val<uint32_t>(18);
+    const uint32_t c_stride_b = get_arg_val<uint32_t>(19);
+    const uint32_t src_num_tiles_b = get_arg_val<uint32_t>(20);
+
+    constexpr auto cb_id_src = tt::CBIndex::c_0;
+    constexpr auto cb_id_src_b = tt::CBIndex::c_1;
+    constexpr auto src_args = TensorAccessorArgs<0, 0>();
+    constexpr auto src_b_args =
+        TensorAccessorArgs<src_args.next_compile_time_args_offset(), src_args.next_common_runtime_args_offset()>();
+
+    Noc noc;
+    CircularBuffer cb_src(cb_id_src);
+    CircularBuffer cb_src_b(cb_id_src_b);
+
+#if !SRC_SHARDED
+    const uint32_t src_tile_bytes = cb_src.get_tile_size();
+    const auto src = TensorAccessor(src_args, src_addr);
+#endif
+#if !SRC_SHARDED_B
+    const uint32_t src_tile_bytes_b = cb_src_b.get_tile_size();
+    const auto src_b = TensorAccessor(src_b_args, src_addr_b);
+#endif
+    constexpr uint32_t onetile = 1;
+    constexpr bool has_sharding = get_compile_time_arg_val(src_b_args.next_compile_time_args_offset()) == 1;
+    const uint32_t HtWt = Ht * Wt;
+
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_tile_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    const uint32_t offset_c = offset_n % HtWt;
+    uint32_t start_nd = start_tile_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_th = offset_c / Wt;
+    uint32_t start_tw = offset_c % Wt;
+    uint32_t end_tw = has_sharding ? start_tw + dst_shard_width : Wt;
+
+    // this is the INPUT tile offset
+    uint32_t tile_offset = start_nd * nD_stride + start_d * d_stride + start_n * n_stride + start_c * c_stride;
+
+    uint32_t next_c_shift = c_stride - HtWt;
+    uint32_t next_n_shift = n_stride - c_stride * C;
+    uint32_t next_d_shift = d_stride - n_stride * N;
+    uint32_t next_nd_shift = nD_stride - d_stride * D;
+
+    uint32_t tile_offset_b =
+        start_nd * nD_stride_b + start_d * d_stride_b + start_n * n_stride_b + start_c * c_stride_b;
+
+    uint32_t next_c_shift_b = c_stride_b - HtWt;
+    uint32_t next_n_shift_b = n_stride_b - c_stride_b * C;
+    uint32_t next_d_shift_b = d_stride_b - n_stride_b * N;
+    uint32_t next_nd_shift_b = nD_stride_b - d_stride_b * D;
+
+    uint32_t num_tiles_read = 0;
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_read < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
+                    for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th) {
+#if SRC_BCAST_COL
+                        cb_src.reserve_back(onetile);
+#if !SRC_SHARDED
+                        noc.async_read(src, cb_src, src_tile_bytes, {.page_id = tile_offset + th}, {.offset_bytes = 0});
+                        noc.async_read_barrier();
+#endif
+                        FILL_TILE_WITH_FIRST_COLUMN(cb_src.get_write_ptr());
+                        cb_src.push_back(onetile);
+#else
+                        cb_src_b.reserve_back(onetile);
+#if !SRC_SHARDED_B
+                        noc.async_read(
+                            src_b, cb_src_b, src_tile_bytes_b, {.page_id = tile_offset_b + th}, {.offset_bytes = 0});
+                        noc.async_read_barrier();
+#endif
+                        FILL_TILE_WITH_FIRST_COLUMN_B(cb_src_b.get_write_ptr());
+                        cb_src_b.push_back(onetile);
+#endif
+                        for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
+                             ++tw, ++num_tiles_read) {
+#if SRC_BCAST_ROW_B
+                            // read a tile from src_b
+                            cb_src_b.reserve_back(onetile);
+#if !SRC_SHARDED_B
+                            noc.async_read(
+                                src_b,
+                                cb_src_b,
+                                src_tile_bytes_b,
+                                {.page_id = tile_offset_b + tw},
+                                {.offset_bytes = 0});
+                            noc.async_read_barrier();
+#endif
+#if !BCAST_LLK
+                            FILL_TILE_WITH_FIRST_ROW_B(cb_src_b.get_write_ptr());
+#endif
+#if !SRC_SHARDED_B
+                            cb_src_b.push_back(onetile);
+#endif
+#else
+                            // read a tile from src
+                            cb_src.reserve_back(onetile);
+#if !SRC_SHARDED_B
+                            noc.async_read(
+                                src, cb_src, src_tile_bytes, {.page_id = tile_offset + tw}, {.offset_bytes = 0});
+                            noc.async_read_barrier();
+#endif
+#if !BCAST_LLK
+                            FILL_TILE_WITH_FIRST_ROW(cb_src.get_write_ptr());
+#endif
+#if !SRC_SHARDED_B
+                            cb_src.push_back(onetile);
+#endif
+#endif
+                        }
+                        if constexpr (!has_sharding) {
+                            // next row of tiles should start at the first column
+                            start_tw = 0;
+                        }
+                    }
+#if !SRC_SHARDED
+                    // same as following logically
+                    // tile_offset += HtWt;
+                    // tile_offset += next_c_shift;
+                    tile_offset += c_stride;
+#endif
+#if !SRC_SHARDED_B
+                    tile_offset_b += c_stride_b;
+#endif
+                }
+#if !SRC_SHARDED
+                tile_offset += next_n_shift;
+#endif
+#if !SRC_SHARDED_B
+                tile_offset_b += next_n_shift_b;
+#endif
+            }
+#if !SRC_SHARDED
+            tile_offset += next_d_shift;
+#endif
+#if !SRC_SHARDED_B
+            tile_offset_b += next_d_shift_b;
+#endif
+        }
+#if !SRC_SHARDED
+        tile_offset += next_nd_shift;
+#endif
+#if !SRC_SHARDED_B
+        tile_offset_b += next_nd_shift_b;
+#endif
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_scalar_bcast.cpp
@@ -1,0 +1,204 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+
+void kernel_main() {
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t start_tile_id = get_arg_val<uint32_t>(1);
+    const uint32_t src_num_tiles = get_arg_val<uint32_t>(2);
+    const uint32_t dst_num_tiles = get_arg_val<uint32_t>(3);
+    const uint32_t dst_shard_width = get_arg_val<uint32_t>(4);
+    const uint32_t nD_stride = get_arg_val<uint32_t>(5);
+    const uint32_t d_stride = get_arg_val<uint32_t>(6);
+    const uint32_t n_stride = get_arg_val<uint32_t>(7);
+    const uint32_t c_stride = get_arg_val<uint32_t>(8);
+    const uint32_t D = get_arg_val<uint32_t>(9);
+    const uint32_t N = get_arg_val<uint32_t>(10);
+    const uint32_t C = get_arg_val<uint32_t>(11);
+    const uint32_t Ht = get_arg_val<uint32_t>(12);
+    const uint32_t Wt = get_arg_val<uint32_t>(13);
+    const uint32_t cND = get_arg_val<uint32_t>(14);  // collapsed dims > 5
+    const uint32_t src_addr_b = get_arg_val<uint32_t>(15);
+    const uint32_t nD_stride_b = get_arg_val<uint32_t>(16);
+    const uint32_t d_stride_b = get_arg_val<uint32_t>(17);
+    const uint32_t n_stride_b = get_arg_val<uint32_t>(18);
+    const uint32_t c_stride_b = get_arg_val<uint32_t>(19);
+    const uint32_t src_num_tiles_b = get_arg_val<uint32_t>(20);
+
+    constexpr auto cb_id_src = tt::CBIndex::c_0;
+    constexpr auto cb_id_src_b = tt::CBIndex::c_1;
+    constexpr auto src_args = TensorAccessorArgs<0, 0>();
+    constexpr auto src_b_args =
+        TensorAccessorArgs<src_args.next_compile_time_args_offset(), src_args.next_common_runtime_args_offset()>();
+
+    Noc noc;
+    CircularBuffer cb_src(cb_id_src);
+    CircularBuffer cb_src_b(cb_id_src_b);
+
+#if SRC_SHARDED
+#if !SRC_BCAST
+    cb_src.reserve_back(src_num_tiles);
+    cb_src.push_back(src_num_tiles);
+#endif
+#else
+    const uint32_t src_tile_bytes = cb_src.get_tile_size();
+    const auto src = TensorAccessor(src_args, src_addr);
+#endif
+#if SRC_SHARDED_B
+#if !SRC_BCAST_B
+    cb_src_b.reserve_back(src_num_tiles_b);
+    cb_src_b.push_back(src_num_tiles_b);
+#endif
+#else
+    const uint32_t src_tile_bytes_b = cb_src_b.get_tile_size();
+    const auto src_b = TensorAccessor(src_b_args, src_addr_b);
+#endif
+    constexpr uint32_t onetile = 1;
+    constexpr bool has_sharding = get_compile_time_arg_val(src_b_args.next_compile_time_args_offset()) == 1;
+    const uint32_t HtWt = Ht * Wt;
+
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_tile_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    const uint32_t offset_c = offset_n % HtWt;
+    uint32_t start_nd = start_tile_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_th = offset_c / Wt;
+    uint32_t start_tw = offset_c % Wt;
+    uint32_t end_tw = has_sharding ? start_tw + dst_shard_width : Wt;
+
+    // this is the INPUT tile offset
+    uint32_t tile_offset = start_nd * nD_stride + start_d * d_stride + start_n * n_stride + start_c * c_stride;
+#if !SRC_BCAST
+    tile_offset += start_th * Wt;
+#endif
+    uint32_t next_c_shift = c_stride - HtWt;
+    uint32_t next_n_shift = n_stride - c_stride * C;
+    uint32_t next_d_shift = d_stride - n_stride * N;
+    uint32_t next_nd_shift = nD_stride - d_stride * D;
+
+    uint32_t tile_offset_b =
+        start_nd * nD_stride_b + start_d * d_stride_b + start_n * n_stride_b + start_c * c_stride_b;
+#if !SRC_BCAST_B
+    tile_offset_b += start_th * Wt;
+#endif
+    uint32_t next_c_shift_b = c_stride_b - HtWt;
+    uint32_t next_n_shift_b = n_stride_b - c_stride_b * C;
+    uint32_t next_d_shift_b = d_stride_b - n_stride_b * N;
+    uint32_t next_nd_shift_b = nD_stride_b - d_stride_b * D;
+
+    uint32_t num_tiles_read = 0;
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_read < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
+#if SRC_BCAST
+                    cb_src.reserve_back(onetile);
+#if !SRC_SHARDED
+                    noc.async_read(src, cb_src, src_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
+                    noc.async_read_barrier();
+#endif
+#if !BCAST_LLK
+                    FILL_TILE_WITH_FIRST_ELEMENT(cb_src.get_write_ptr());
+#endif
+                    cb_src.push_back(onetile);
+#endif
+#if SRC_BCAST_B
+                    cb_src_b.reserve_back(onetile);
+#if !SRC_SHARDED_B
+                    noc.async_read(src_b, cb_src_b, src_tile_bytes_b, {.page_id = tile_offset_b}, {.offset_bytes = 0});
+                    noc.async_read_barrier();
+#endif
+#if !BCAST_LLK
+                    FILL_TILE_WITH_FIRST_ELEMENT_B(cb_src_b.get_write_ptr());
+#endif
+                    cb_src_b.push_back(onetile);
+#endif
+                    for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th) {
+                        for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
+                             ++tw, ++num_tiles_read) {
+#if !SRC_BCAST
+                            cb_src.reserve_back(onetile);
+#if !SRC_SHARDED
+                            noc.async_read(
+                                src, cb_src, src_tile_bytes, {.page_id = tile_offset + tw}, {.offset_bytes = 0});
+                            noc.async_read_barrier();
+#endif
+                            cb_src.push_back(onetile);
+#endif
+#if !SRC_BCAST_B && !SRC_SHARDED_B
+                            cb_src_b.reserve_back(onetile);
+                            noc.async_read(
+                                src_b,
+                                cb_src_b,
+                                src_tile_bytes_b,
+                                {.page_id = tile_offset_b + tw},
+                                {.offset_bytes = 0});
+                            noc.async_read_barrier();
+                            cb_src_b.push_back(onetile);
+#endif
+                        }
+                        if constexpr (!has_sharding) {
+                            // next row of tiles should start at the first column
+                            start_tw = 0;
+                        }
+#if !SRC_BCAST && !SRC_SHARDED
+                        tile_offset += Wt;
+#endif
+#if !SRC_BCAST_B && !SRC_SHARDED_B
+                        tile_offset_b += Wt;
+#endif
+                    }
+#if !SRC_SHARDED
+#if SRC_BCAST
+                    // same as following logically
+                    // tile_offset += HtWt;
+                    // tile_offset += next_c_shift;
+                    tile_offset += c_stride;
+#else
+                    tile_offset += next_c_shift;
+#endif
+#endif
+#if !SRC_SHARDED_B
+#if SRC_BCAST_B
+                    tile_offset_b += c_stride_b;
+#else
+                    tile_offset_b += next_c_shift_b;
+#endif
+#endif
+                }
+#if !SRC_SHARDED
+                tile_offset += next_n_shift;
+#endif
+#if !SRC_SHARDED_B
+                tile_offset_b += next_n_shift_b;
+#endif
+            }
+#if !SRC_SHARDED
+            tile_offset += next_d_shift;
+#endif
+#if !SRC_SHARDED_B
+            tile_offset_b += next_d_shift_b;
+#endif
+        }
+#if !SRC_SHARDED
+        tile_offset += next_nd_shift;
+#endif
+#if !SRC_SHARDED_B
+        tile_offset_b += next_nd_shift_b;
+#endif
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/writer_interleaved_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/writer_interleaved_no_bcast.cpp
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    uint32_t index = 0;
+    const uint32_t dst_addr = get_arg_val<uint32_t>(index++);
+    const uint32_t start_tile_id = get_arg_val<uint32_t>(index++);
+    const uint32_t dst_num_tiles = get_arg_val<uint32_t>(index++);
+    const uint32_t dst_shard_width = get_arg_val<uint32_t>(index++);
+    const uint32_t D = get_arg_val<uint32_t>(index++);
+    const uint32_t N = get_arg_val<uint32_t>(index++);
+    const uint32_t C = get_arg_val<uint32_t>(index++);
+    const uint32_t Ht = get_arg_val<uint32_t>(index++);
+    const uint32_t Wt = get_arg_val<uint32_t>(index++);
+    const uint32_t cND = get_arg_val<uint32_t>(index++);  // collapsed dims > 5
+
+    constexpr uint32_t onetile = 1;
+
+    constexpr auto cb_id_dst = tt::CBIndex::c_2;
+
+    Noc noc;
+    CircularBuffer cb_dst(cb_id_dst);
+
+#if !DST_SHARDED
+    constexpr auto dst_args = TensorAccessorArgs<0, 0>();
+    const uint32_t dst_tile_bytes = cb_dst.get_tile_size();
+    const auto dst = TensorAccessor(dst_args, dst_addr);
+#endif
+
+#if !DST_SHARDED
+    constexpr bool has_sharding = get_compile_time_arg_val(dst_args.next_compile_time_args_offset()) == 1;
+    const uint32_t HtWt = Ht * Wt;
+
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_tile_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    const uint32_t offset_c = offset_n % HtWt;
+    uint32_t start_nd = start_tile_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_th = offset_c / Wt;
+    uint32_t start_tw = offset_c % Wt;
+    uint32_t end_tw = has_sharding ? start_tw + dst_shard_width : Wt;
+
+    uint32_t num_tiles_written = 0;
+    uint32_t dst_tile_offset = start_tile_id;
+
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_written < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_written < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_written < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_written < dst_num_tiles; ++c, start_th = 0) {
+                    for (uint32_t th = start_th; th < Ht && num_tiles_written < dst_num_tiles; ++th) {
+                        for (uint32_t tw = start_tw; tw < end_tw && num_tiles_written < dst_num_tiles;
+                             ++tw, ++num_tiles_written) {
+#if !DST_SHARDED
+                            //  write a tile to dst, since the dst shape is full, the tile offset simply grows linearly
+                            cb_dst.wait_front(onetile);
+                            noc.async_write(
+                                cb_dst, dst, dst_tile_bytes, {}, {.page_id = dst_tile_offset + num_tiles_written});
+                            noc.async_write_barrier();
+                            cb_dst.pop_front(onetile);
+#endif
+                        }
+                        if constexpr (has_sharding) {
+                            // adjust the output tile offset since we had to skip parts of the row
+                            dst_tile_offset += (Wt - dst_shard_width);
+                        } else {
+                            // otherwise, next row of tiles should start at the first column
+                            start_tw = 0;
+                        }
+                    }
+                }
+            }
+        }
+    }
+#endif
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/writer_interleaved_rm_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/writer_interleaved_rm_no_bcast.cpp
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/alignment.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "api/core_local_mem.h"
+
+void kernel_main() {
+    uint32_t index = 0;
+    const uint32_t dst_addr = get_arg_val<uint32_t>(index++);
+    const uint32_t row_width_elements = get_arg_val<uint32_t>(index++);
+    const uint32_t dst_num_tiles = get_arg_val<uint32_t>(index++);
+
+    const uint32_t outD = get_arg_val<uint32_t>(index++);
+    const uint32_t outN = get_arg_val<uint32_t>(index++);
+    const uint32_t outC = get_arg_val<uint32_t>(index++);
+    const uint32_t outHt = get_arg_val<uint32_t>(index++);
+    const uint32_t outND = get_arg_val<uint32_t>(index++);
+
+    const uint32_t current_block_start = get_arg_val<uint32_t>(index++);
+    const uint32_t rows_per_tile = get_arg_val<uint32_t>(index++);
+    const uint32_t page_size_arg = get_arg_val<uint32_t>(index++);
+    const uint32_t alignment = get_arg_val<uint32_t>(index++);
+    const uint32_t tiles_per_row = get_arg_val<uint32_t>(index++);
+    const uint32_t stride_size_bytes = get_arg_val<uint32_t>(index++);
+
+    constexpr auto cb_id_out = tt::CBIndex::c_2;
+    constexpr auto dst_args = TensorAccessorArgs<0>();
+
+    Noc noc;
+    CircularBuffer cb_out(cb_id_out);
+
+    constexpr uint32_t tile_bytes = get_tile_size(cb_id_out);
+    constexpr uint32_t tile_hw = get_tile_hw(cb_id_out);
+    constexpr uint32_t element_size = tile_bytes / tile_hw;
+    const uint32_t full_page_size = align(page_size_arg, alignment);
+    const uint32_t row_width_bytes = row_width_elements * element_size;
+
+    // Third argument page_size from runtime args overrides TensorAccessorArgs::AlignedPageSize, which may be stale on
+    // program cache hits.
+    const auto dst = TensorAccessor(dst_args, dst_addr, full_page_size);
+
+    const uint32_t row_blocks_per_channel = (outHt + rows_per_tile - 1) / rows_per_tile;
+
+    uint32_t tmp = current_block_start;
+    uint32_t start_th = (tmp % row_blocks_per_channel) * rows_per_tile;
+    tmp /= row_blocks_per_channel;
+    uint32_t start_c = tmp % outC;
+    tmp /= outC;
+    uint32_t start_n = tmp % outN;
+    tmp /= outN;
+    uint32_t start_d = tmp % outD;
+    tmp /= outD;
+    uint32_t start_nd = tmp;
+
+    uint32_t row_blocks_written = 0;
+
+    for (uint32_t nd = start_nd; nd < outND && row_blocks_written < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < outD && row_blocks_written < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < outN && row_blocks_written < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < outC && row_blocks_written < dst_num_tiles; ++c, start_th = 0) {
+                    for (uint32_t th = start_th; th < outHt && row_blocks_written < dst_num_tiles;
+                         th += rows_per_tile) {
+                        const uint32_t rows_remaining = outHt - th;
+                        const uint32_t limit = (rows_remaining < rows_per_tile) ? rows_remaining : rows_per_tile;
+                        const uint32_t row_block_base_row = (((((nd * outD) + d) * outN + n) * outC + c) * outHt) + th;
+
+                        for (uint32_t t_i = 0; t_i < tiles_per_row; ++t_i) {
+                            const uint32_t current_chunk_offset = t_i * stride_size_bytes;
+                            const uint32_t bytes_left_in_row = row_width_bytes - current_chunk_offset;
+                            const uint32_t current_chunk_bytes =
+                                (stride_size_bytes < bytes_left_in_row) ? stride_size_bytes : bytes_left_in_row;
+                            const uint32_t current_write_len = align(current_chunk_bytes, alignment);
+
+                            cb_out.wait_front(1);
+
+                            uint32_t l1_read_addr = cb_out.get_read_ptr();
+                            for (uint32_t row = 0; row < limit; ++row) {
+                                const uint32_t row_abs_idx = row_block_base_row + row;
+                                noc.async_write(
+                                    CoreLocalMem<uint32_t>(l1_read_addr),
+                                    dst,
+                                    current_write_len,
+                                    {},
+                                    {.page_id = row_abs_idx, .offset_bytes = current_chunk_offset});
+                                l1_read_addr += current_chunk_bytes;
+                            }
+
+                            noc.async_write_barrier();
+                            cb_out.pop_front(1);
+                        }
+
+                        row_blocks_written++;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/types.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/operations/experimental/quasar/binary/common/binary_op_types.hpp"
+
+namespace ttnn::operations::experimental::quasar::binary_ng {
+
+using binary::BinaryOpType;
+
+}  // namespace ttnn::operations::experimental::quasar::binary_ng

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/conv2d.cpp
@@ -1,0 +1,1009 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include <tt-metalium/buffer_types.hpp>
+#include <tt_stl/assert.hpp>
+#include <tt-logger/tt-logger.hpp>
+
+#include "tt-metalium/math.hpp"
+#include "ttnn/operations/sliding_window/op_slicing/op_slicing.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/types.hpp"
+#include "ttnn/types.hpp"
+#include "ttnn/tensor/tensor_ops.hpp"
+
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/experimental/quasar/conv2d/conv2d.hpp"
+#include "ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.hpp"
+#include "ttnn/operations/conv/conv2d/conv2d_utils.hpp"
+#include "ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp"
+#include "ttnn/operations/data_movement/move/move.hpp"
+#include "ttnn/operations/matmul/matmul.hpp"
+#include "ttnn/operations/experimental/quasar/halo/halo.hpp"
+#include "ttnn/operations/sliding_window/sliding_window.hpp"
+
+namespace ttnn::operations::experimental::quasar::detail {
+
+// Shared conv host infrastructure (conv2d_utils.hpp, prepare_conv2d_weights.hpp) is reused from the
+// original conv namespaces; bring it into scope so this impl's bare references resolve unchanged.
+using namespace ttnn::operations::conv;          // conv2d_utils helpers (get_conv_configs, determine_*, ...)
+using namespace ttnn::operations::conv::conv2d;  // prepare_conv2d_weights helpers, get_conv2d_slice_attr
+
+using ttnn::operations::experimental::quasar::Conv2dResult;
+using ttnn::operations::experimental::quasar::Conv2dResultWithOptions;
+using Result = Conv2dResult;
+using ResultWithOptions = Conv2dResultWithOptions;
+
+Result conv2d_L1(
+    const ttnn::Tensor& input_tensor_,
+    const ttnn::Tensor& weight_tensor_,
+    MeshDevice* device,
+    uint32_t in_channels,
+    uint32_t out_channels,
+    uint32_t batch_size,
+    uint32_t input_height,
+    uint32_t input_width,
+    std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> stride,
+    std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding,
+    std::array<uint32_t, 2> dilation,
+    uint32_t groups,
+    const std::optional<const DataType>& dtype,
+    const std::optional<const ttnn::Tensor>& bias_tensor_,
+    const std::optional<const Conv2dConfig>& conv_config_,
+    const std::optional<const DeviceComputeKernelConfig>& compute_config_,
+    const std::optional<const MemoryConfig>& memory_config) {
+    Conv2dConfig conv_config = conv_config_.value_or(Conv2dConfig());
+    const DataType output_dtype = dtype.value_or(input_tensor_.dtype());
+    std::array<uint32_t, 4> padding_n4 = sliding_window::get_pair_n4_padding(padding);
+    const auto& weight_tensor = weight_tensor_;
+    std::optional<ttnn::Tensor> bias_tensor = bias_tensor_;
+    bool mm_conv = use_matmul_for_1x1_conv(kernel_size, stride, padding_n4, dilation, groups, conv_config);
+    // Store the original stride size for weight folding
+    auto orig_stride = stride;
+
+    auto input_tensor = fold_input_tensor_if_required(
+        input_tensor_,
+        device,
+        batch_size,
+        input_height,
+        input_width,
+        in_channels,
+        kernel_size,
+        stride,
+        dilation,
+        padding_n4,
+        mm_conv,
+        conv_config);
+
+    if (conv_config.enable_activation_reuse) {
+        if (conv_config.enable_act_double_buffer) {
+            conv_config.enable_act_double_buffer = false;
+            log_debug(
+                tt::LogOp,
+                "Activation double buffering is currently not supported when activation reuse optimization is enabled, "
+                "disabling double buffering.");
+        }
+
+        if (conv_config.enable_weights_double_buffer) {
+            conv_config.enable_weights_double_buffer = false;
+            log_debug(
+                tt::LogOp,
+                "Weights are already fully buffered when activation reuse optimization is enabled, disabling weights "
+                "double buffering.");
+        }
+    }
+    auto [output_height, output_width] =
+        calculate_output_image_size({input_height, input_width}, kernel_size, stride, padding_n4, dilation);
+
+    // Use weights_dtype from config if set, otherwise use weight tensor's dtype
+    DataType weight_dtype = conv_config.weights_dtype.value_or(weight_tensor_.dtype());
+    DeviceComputeKernelConfig compute_config =
+        compute_config_.value_or(get_conv_default_compute_kernel_config(device, input_tensor_.dtype(), weight_dtype));
+
+    const auto compute_grid_size = device->compute_with_storage_grid_size();
+
+    bool auto_shard = false;
+    if (!input_tensor.is_sharded() && !conv_config.shard_layout.has_value()) {
+        if (!conv_config.weights_dtype.has_value()) {
+            conv_config.weights_dtype = weight_tensor.dtype();
+        }
+        // In this case we deduce the shard layout.
+        conv_config = determine_conv_config_for_auto_shard(
+            conv_config,
+            mm_conv,
+            batch_size,
+            in_channels,
+            out_channels,
+            output_height,
+            output_width,
+            kernel_size[1],
+            input_height,
+            input_width,
+            compute_grid_size,
+            input_tensor.layout(),
+            input_tensor.dtype(),
+            output_dtype,
+            tt::tt_metal::is_device_tensor(input_tensor) ? std::make_optional(input_tensor.memory_config())
+                                                         : std::nullopt,
+            kernel_size,
+            stride,
+            dilation,
+            padding_n4,
+            groups,
+            bias_tensor.has_value(),
+            compute_config);
+        auto_shard = true;
+    }
+    const bool should_deallocate_act = conv_config.deallocate_activation && !input_tensor.memory_config().is_dram();
+    auto [input_tensor_post_tm, parallel_config, output_parallel_config] = shard_or_reshard_tensor_if_required(
+        device,
+        input_tensor,
+        conv_config,
+        batch_size,
+        output_height,
+        output_width,
+        in_channels,
+        out_channels,
+        mm_conv,
+        auto_shard);
+
+    const uint32_t input_channels_alignment = get_input_channels_alignment(
+        input_tensor_post_tm.memory_config().memory_layout(),
+        input_tensor_post_tm.layout(),
+        false,
+        mm_conv,
+        input_tensor_post_tm.memory_config());
+    const uint32_t in_channels_padded = tt::round_up(
+        in_channels, get_num_cores_channels_from_parallel_config(parallel_config) * input_channels_alignment);
+
+    const bool conv_is_1d_depthwise =
+        is_1d_depthwise_conv(groups, in_channels, out_channels, kernel_size[0], input_height, bias_tensor.has_value());
+    const bool coalesce_1d_depthwise_kw_reads = should_coalesce_1d_depthwise_conv_reads(
+        conv_is_1d_depthwise,
+        parallel_config.shard_scheme,
+        in_channels_padded,
+        kernel_size[1],
+        dilation[1],
+        input_tensor_post_tm.dtype());
+
+    auto [opt_conv_op_parallel_config, opt_conv_op_block_config, conv_out_memory_config] = get_conv_configs(
+        conv_config,
+        compute_config,
+        parallel_config,
+        output_parallel_config,
+        in_channels_padded,
+        out_channels,
+        batch_size,
+        output_height,
+        output_width,
+        kernel_size,
+        compute_grid_size,
+        conv_is_1d_depthwise,
+        coalesce_1d_depthwise_kw_reads);
+
+    ttnn::Tensor weight_tensor_on_device = weight_tensor;
+    std::optional<ttnn::Tensor> bias_tensor_on_device = bias_tensor;
+
+    // Configure weight and bias preparation parameters
+    Conv2dWeightsBiasPrepConfig params(
+        input_channels_alignment,
+        conv_config.weights_dtype,
+        opt_conv_op_block_config.act_block_w_ntiles,
+        opt_conv_op_block_config.out_subblock_w_ntiles,
+        parallel_config,
+        output_parallel_config,
+        groups,
+        opt_conv_op_block_config.act_block_h_ntiles,
+        input_height,
+        input_width,
+        mm_conv && auto_shard,
+        out_channels,
+        bias_tensor.has_value(),
+        conv_config.enable_kernel_stride_folding.value(),
+        conv_config.full_inner_dim,
+        conv_config.enable_activation_reuse,
+        coalesce_1d_depthwise_kw_reads,
+        orig_stride);
+
+    // Prepare weights and move to device if necessary
+    if (!is_device_tensor(weight_tensor)) {
+        log_trace(tt::LogOp, "conv2d: Preprocessing weights on host and moving to device.");
+        std::tie(weight_tensor_on_device, bias_tensor_on_device) =
+            prepare_conv_weights_biases_and_move_to_device(weight_tensor, bias_tensor, params, device);
+    } else {
+        // Check if device weights are properly prepared
+        if (is_valid_device_conv_weights(
+                weight_tensor_on_device, in_channels, out_channels, conv_config.weights_dtype)) {
+            log_debug(tt::LogOp, "conv2d: Using preprocessed weights from device.");
+        } else {
+            log_warning(
+                tt::LogOp,
+                "conv2d: Device weights not properly prepared, pulling back to host and trying to reprocess.");
+            // Pull weights back to host, prepare them, and push back to device
+            ttnn::Tensor host_weight_tensor = ttnn::operations::core::from_device(weight_tensor_on_device);
+            std::tie(weight_tensor_on_device, bias_tensor_on_device) =
+                prepare_conv_weights_biases_and_move_to_device(host_weight_tensor, bias_tensor, params, device);
+        }
+    }
+
+    // Prepare bias tensor if it exists and is not yet on device
+    if (bias_tensor_on_device.has_value()) {
+        if (!is_device_tensor(bias_tensor_on_device.value())) {
+            log_trace(tt::LogOp, "conv2d: Preprocessing bias on host and moving to device.");
+
+            bias_tensor_on_device = prepare_conv_bias_internal(
+                bias_tensor_on_device, out_channels, params, weight_tensor_on_device.dtype(), device);
+        } else {
+            // Check if device bias is properly prepared
+            if (is_valid_device_conv_bias(bias_tensor_on_device.value(), out_channels, conv_config.weights_dtype)) {
+                log_debug(tt::LogOp, "conv2d: Using preprocessed bias from device.");
+            } else {
+                log_warning(
+                    tt::LogOp, "conv2d: Device bias not properly prepared, pulling back to host and reprocessing.");
+                // Pull bias back to host, prepare it, and push back to device
+                ttnn::Tensor host_bias_tensor = ttnn::operations::core::from_device(bias_tensor_on_device.value());
+                bias_tensor_on_device = prepare_conv_bias_internal(
+                    std::optional<const ttnn::Tensor>(host_bias_tensor),
+                    out_channels,
+                    params,
+                    weight_tensor_on_device.dtype(),
+                    device);
+            }
+        }
+    }
+
+    // call conv op or matmul micro op
+    bool input_is_on_device = tt::tt_metal::is_device_tensor(input_tensor_post_tm);
+    TT_ASSERT(input_is_on_device);
+
+    if (!mm_conv) {
+        // call halo op
+        sliding_window::SlidingWindowConfig sliding_window_config = sliding_window::SlidingWindowConfig{
+            .batch_size = batch_size,
+            .input_hw = {input_height, input_width},
+            .window_hw = {kernel_size[0], kernel_size[1]},
+            .stride_hw = {stride[0], stride[1]},
+            .padding = {{padding_n4[0], padding_n4[1], padding_n4[2], padding_n4[3]}},
+            .dilation_hw = {dilation[0], dilation[1]},
+            .num_cores_nhw = opt_conv_op_parallel_config.num_cores_nhw,
+            .core_range_set = input_tensor_post_tm.memory_config().shard_spec().value().grid,
+            .snap_to_tile = true,
+            .padding_mode = conv_config.padding_mode,
+        };
+
+        if (parallel_config.shard_scheme != TensorMemoryLayout::WIDTH_SHARDED ||
+            input_tensor_post_tm.layout() != Layout::ROW_MAJOR || sliding_window_config.get_pad_h() != 0 ||
+            sliding_window_config.get_pad_w() != 0) {
+            ttnn::Tensor halo_output = ttnn::operations::experimental::quasar::halo(
+                input_tensor_post_tm,
+                sliding_window_config,
+                compute_config,
+                0,
+                false,
+                parallel_config.shard_orientation == ShardOrientation::COL_MAJOR,
+                true,
+                conv_config.config_tensors_in_dram);
+
+            // In cases where input tensor is in DRAM and it gets sharded, we need to deallocate the sharded input
+            // tensor at this point (it will be deallocated automatically because nothing is using it, but reallocating
+            // halo output will be affected so we need to deallocate it manually before reallocating halo output)
+            if (conv_config.deallocate_activation && !input_tensor_post_tm.memory_config().is_dram()) {
+                input_tensor_post_tm.deallocate(/*force*/ true);
+            }
+
+            input_tensor_post_tm = std::move(halo_output);
+
+            if (conv_config.reallocate_halo_output) {
+                input_tensor_post_tm = ttnn::move(input_tensor_post_tm);
+            }
+        }
+
+        const std::array<std::uint32_t, 4> input_tensor_shape = {
+            batch_size,
+            input_height,
+            input_width,
+            in_channels,
+        };
+
+        // call conv micro op
+        auto conv_output = ttnn::prim::qsr::conv2d(
+            input_tensor_post_tm,
+            weight_tensor_on_device,
+            bias_tensor_on_device,
+            sliding_window_config,
+            out_channels,
+            groups,
+            conv_config.output_layout == Layout::ROW_MAJOR,
+            conv_config.activation,
+            opt_conv_op_parallel_config,
+            opt_conv_op_block_config,
+            conv_out_memory_config,
+            output_dtype,
+            input_tensor_shape,
+            compute_config,
+            conv_config.enable_act_double_buffer,
+            conv_config.enable_weights_double_buffer,
+            conv_config.full_inner_dim,
+            conv_config.enable_activation_reuse,
+            conv_config.config_tensors_in_dram,
+            conv_config.force_split_reader);
+
+        if (memory_config.has_value() && memory_config.value() != conv_output.memory_config()) {
+            conv_output = ttnn::to_memory_config(conv_output, memory_config.value(), std::nullopt);
+        }
+        return {conv_output, output_height, output_width, weight_tensor_on_device, bias_tensor_on_device};
+    }  // Matmul expects inputs to be in Tile Layout
+    tilize_with_optional_deallocation(input_tensor_post_tm, should_deallocate_act);
+
+    // run conv as matmul
+    std::optional<ttnn::operations::matmul::MatmulProgramConfig> program_config = std::nullopt;
+    std::optional<MemoryConfig> mm_output_memory_config = std::nullopt;
+
+    if (input_tensor_post_tm.is_sharded()) {
+        uint32_t num_cores_c = get_num_cores_channels_from_parallel_config(parallel_config);
+        program_config = determine_matmul_op_config_from_conv_op_config(
+            opt_conv_op_parallel_config,
+            opt_conv_op_block_config,
+            parallel_config.shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED,
+            conv_config.activation,
+            parallel_config.shard_orientation == ShardOrientation::COL_MAJOR,
+            num_cores_c);
+        mm_output_memory_config = conv_out_memory_config;
+    }
+
+    ttnn::Tensor matmul_output = ttnn::linear(
+        input_tensor_post_tm,
+        weight_tensor_on_device,
+        bias_tensor_on_device,
+        false,
+        false,
+        mm_output_memory_config,
+        output_dtype,
+        program_config,
+        // for sharded input, activation is set on program config
+        input_tensor_post_tm.is_sharded() ? std::nullopt : conv_config.activation,
+        compute_config);
+
+    if (should_deallocate_act) {
+        input_tensor_post_tm.deallocate(/*force*/ true);
+    }
+    if (memory_config.has_value() && memory_config.value() != matmul_output.memory_config()) {
+        matmul_output = ttnn::to_memory_config(matmul_output, memory_config.value(), std::nullopt);
+    }
+
+    return {matmul_output, output_height, output_width, weight_tensor_on_device, bias_tensor_on_device};
+}
+
+ResultWithOptions result_to_result_with_options(
+    const Result& result, const bool return_output_dim, const bool return_weights_and_bias) {
+    if (return_output_dim && return_weights_and_bias) {
+        return std::make_tuple(
+            std::get<0>(result),
+            std::make_tuple(std::get<1>(result), std::get<2>(result)),
+            std::make_tuple(std::get<3>(result), std::get<4>(result)));
+    }
+    if (return_output_dim) {
+        return std::make_tuple(std::get<0>(result), std::make_tuple(std::get<1>(result), std::get<2>(result)));
+    }
+    if (return_weights_and_bias) {
+        return std::make_tuple(std::get<0>(result), std::make_tuple(std::get<3>(result), std::get<4>(result)));
+    }
+    return std::get<0>(result);
+}
+
+class Conv2dSliceAttr : public ttnn::operations::op_slicing::OpSliceAttr {
+    using OptionalRefTensor = std::optional<std::reference_wrapper<ttnn::Tensor>>;
+
+    Conv2dConfig auto_slice_conv_config;
+    uint32_t batch_size;
+    IOShape input_shape;
+    uint32_t input_channels;
+    uint32_t output_channels;
+    std::array<uint32_t, 2> kernel_size;
+    std::array<uint32_t, 2> stride;
+    std::array<uint32_t, 4> padding_n4;
+    std::array<uint32_t, 2> dilation;
+    uint32_t groups;
+    tt::tt_metal::Layout input_layout;
+    tt::tt_metal::DataType input_dtype;
+    tt::tt_metal::DataType output_dtype;
+    Tensor& weight_tensor;
+    OptionalRefTensor bias_tensor;
+    Conv2dConfig conv_config;
+    DeviceComputeKernelConfig compute_config;
+    MeshDevice* device;
+
+public:
+    Conv2dSliceAttr(
+        uint32_t batch_size,
+        IOShape input_shape,
+        uint32_t input_channels,
+        uint32_t output_channels,
+        std::array<uint32_t, 2> kernel_size,
+        std::array<uint32_t, 2> stride,
+        std::array<uint32_t, 4> padding_n4,
+        std::array<uint32_t, 2> dilation,
+        uint32_t groups,
+        tt::tt_metal::Layout input_layout,
+        tt::tt_metal::DataType input_dtype,
+        tt::tt_metal::DataType output_dtype,
+        Tensor& weight_tensor,
+        OptionalRefTensor bias_tensor,
+        const Conv2dConfig& conv_config,
+        const DeviceComputeKernelConfig& compute_config,
+        MeshDevice* device) :
+        batch_size(batch_size),
+        input_shape(input_shape),
+        input_channels(input_channels),
+        output_channels(output_channels),
+        kernel_size(kernel_size),
+        stride(stride),
+        padding_n4(padding_n4),
+        dilation(dilation),
+        groups(groups),
+        input_layout(input_layout),
+        input_dtype(input_dtype),
+        output_dtype(output_dtype),
+        weight_tensor(weight_tensor),
+        bias_tensor(bias_tensor),
+        conv_config(conv_config),
+        compute_config(compute_config),
+        device(device) {}
+
+    std::tuple<std::tuple<IOShape, IOShape>, std::array<uint32_t, 4>> get_input_slice_and_padding(
+        const IOShape& output_slice_start, const IOShape& output_slice_end) const {
+        auto [output_slice_height_start, output_slice_width_start] = output_slice_start;
+        auto [output_slice_height_end, output_slice_width_end] = output_slice_end;
+        auto [input_height, input_width] = input_shape;
+
+        // Calculate required input slice range based on output slice
+        // Formula: input_start = (output_start * stride) - padding
+        // Formula: input_end = ((output_end - 1) * stride) - padding + dilated_kernel_size
+        int input_slice_height_start = (output_slice_height_start * stride[0]) - padding_n4[0];
+        int input_slice_height_end = ((output_slice_height_end - 1) * stride[0]) - padding_n4[0] +
+                                     ((kernel_size[0] - 1) * (dilation[0] - 1)) + kernel_size[0];
+        int input_slice_width_start = (output_slice_width_start * stride[1]) - padding_n4[2];
+        int input_slice_width_end = ((output_slice_width_end - 1) * stride[1]) - padding_n4[2] +
+                                    ((kernel_size[1] - 1) * (dilation[1] - 1)) + kernel_size[1];
+
+        // Calculate padding needed if input slice extends beyond input tensor
+        uint32_t pad_top = std::max<int>(0, -input_slice_height_start);
+        uint32_t pad_bottom = std::max<int>(0, input_slice_height_end - input_height);
+        uint32_t pad_left = std::max<int>(0, -input_slice_width_start);
+        uint32_t pad_right = std::max<int>(0, input_slice_width_end - input_width);
+
+        // Clamp input slice to valid input tensor bounds
+        input_slice_height_start = std::max<int>(0, input_slice_height_start);
+        input_slice_height_end = std::min<int>(input_height, input_slice_height_end);
+        input_slice_width_start = std::max<int>(0, input_slice_width_start);
+        input_slice_width_end = std::min<int>(input_width, input_slice_width_end);
+
+        // Calculate full output dimensions
+        auto [output_height, output_width] = calculate_output_image_size(
+            std::array<uint32_t, 2>{input_height, input_width}, kernel_size, stride, padding_n4, dilation);
+
+        // Special handling for edges: if output slice starts/ends at tensor boundary,
+        // use the full original padding and reset input slice to tensor boundary
+        if (output_slice_height_start == 0) {
+            pad_top = padding_n4[0];
+            input_slice_height_start = 0;
+        }
+        if (output_slice_height_end == output_height) {
+            pad_bottom = padding_n4[1];
+            input_slice_height_end = input_height;
+        }
+        if (output_slice_width_start == 0) {
+            pad_left = padding_n4[2];
+            input_slice_width_start = 0;
+        }
+        if (output_slice_width_end == output_width) {
+            pad_right = padding_n4[3];
+            input_slice_width_end = input_width;
+        }
+        uint32_t input_slice_height = input_slice_height_end - input_slice_height_start;
+        uint32_t input_slice_width = input_slice_width_end - input_slice_width_start;
+        uint32_t output_slice_width = output_slice_width_end - output_slice_width_start;
+        // Apply width rounding and adjust right padding if necessary
+        uint32_t width_rounding_value =
+            (conv_config.output_layout == tt::tt_metal::Layout::TILE) ? tt::constants::TILE_HEIGHT : 1;
+
+        bool single_slice =
+            (input_slice_height == std::get<0>(input_shape)) && (input_slice_width == std::get<1>(input_shape));
+
+        if (output_slice_width % width_rounding_value != 0 && !single_slice) {
+            uint32_t additional_padded_width = width_rounding_value - (output_slice_width % width_rounding_value);
+            log_trace(
+                tt::LogOp,
+                "Conv2d DRAM Slicing: Additional padding of {} added to the right side.",
+                additional_padded_width);
+            pad_right += additional_padded_width * stride[1];  // Adjust right padding
+        }
+
+        return {
+            {{input_slice_height_start, input_slice_width_start}, {input_slice_height_end, input_slice_width_end}},
+            {pad_top, pad_bottom, pad_left, pad_right}};
+    }
+
+    std::tuple<IOShape, IOShape> get_input_slice(
+        const IOShape& output_slice_start, const IOShape& output_slice_end) const override {
+        return std::get<0>(get_input_slice_and_padding(output_slice_start, output_slice_end));
+    }
+
+    uint32_t get_L1_usage(
+        const IOShape& output_slice_start,
+        const IOShape& output_slice_end,
+        const op_slicing::Op2DSliceConfig& slice_config) const override {
+        // Remove this->conv_config from scope so that for each slice, conv_config can be calculated independently.
+        auto conv_config = this->conv_config;
+        bool mm_conv = use_matmul_for_1x1_conv(kernel_size, stride, padding_n4, dilation, groups, conv_config);
+        TT_FATAL(!mm_conv, "Conv2D DRAM with matmul should never use the slicing code path.");
+
+        auto [input_slicing, slice_padding] = get_input_slice_and_padding(output_slice_start, output_slice_end);
+        auto [input_slice_start, input_slice_end] = input_slicing;
+        auto [input_slice_height_start, input_slice_width_start] = input_slice_start;
+        auto [input_slice_height_end, input_slice_width_end] = input_slice_end;
+        auto input_slice_height = input_slice_height_end - input_slice_height_start;
+        auto input_slice_width = input_slice_width_end - input_slice_width_start;
+
+        auto [output_slice_height, output_slice_width] = calculate_output_image_size(
+            {input_slice_height, input_slice_width}, kernel_size, stride, slice_padding, dilation);
+        auto compute_grid = device->compute_with_storage_grid_size();
+        log_trace(
+            tt::LogOp,
+            "Conv2D DRAM Auto Slice Max Input Size : {}x{}, Max Output Size : {}x{}",
+            input_slice_height,
+            input_slice_width,
+            output_slice_height,
+            output_slice_width);
+
+        auto sliced_input_tensor_memory_config = get_input_memory_config(output_slice_start, output_slice_end);
+        if (!conv_config.shard_layout.has_value()) {
+            conv_config.shard_layout = sliced_input_tensor_memory_config.memory_layout();
+        }
+        auto conv_L1_usage = calculate_L1_usage_for_conv_op(
+            batch_size,
+            input_channels,
+            output_channels,
+            input_slice_height,
+            input_slice_width,
+            output_slice_height,
+            output_slice_width,
+            kernel_size,
+            stride,
+            slice_padding,
+            dilation,
+            groups,
+            bias_tensor.has_value(),
+            input_dtype,
+            output_dtype,
+            input_layout,
+            compute_grid,
+            false,
+            conv_config.shard_layout.value(),
+            compute_config,
+            conv_config,
+            sliced_input_tensor_memory_config);
+
+        log_trace(
+            tt::LogOp,
+            "Conv DRAM Auto slicing: num_slices = {}, input_memory_config = {}, L1 usage = {}",
+            slice_config.num_slices,
+            sliced_input_tensor_memory_config,
+            conv_L1_usage);
+        return std::max(conv_L1_usage.halo_input_size + conv_L1_usage.halo_output_size, conv_L1_usage.total_size);
+    }
+
+    tt::tt_metal::MemoryConfig get_input_memory_config(
+        const IOShape& output_slice_start, const IOShape& output_slice_end) const override {
+        auto compute_grid_size = device->compute_with_storage_grid_size();
+        auto conv_config = this->conv_config;
+
+        auto [input_slicing, slice_padding] = get_input_slice_and_padding(output_slice_start, output_slice_end);
+        auto [input_start, input_end] = input_slicing;
+        uint32_t input_slice_height = std::get<0>(input_end) - std::get<0>(input_start);
+        uint32_t input_slice_width = std::get<1>(input_end) - std::get<1>(input_start);
+        // Use padded output dimensions to match what the halo op actually produces.
+        // The halo output is tile-aligned, so edge slices get additional padding
+        // (e.g., output width 4 pads to 32). Without this, the shard spec is computed
+        // for the unpadded dimensions, leading to L1 underestimation.
+        auto [output_slice_height, output_slice_width] = calculate_output_image_size(
+            {input_slice_height, input_slice_width}, kernel_size, stride, slice_padding, dilation);
+
+        bool single_slice =
+            (input_slice_height == std::get<0>(input_shape)) && (input_slice_width == std::get<1>(input_shape));
+
+        if (!conv_config.shard_layout.has_value()) {
+            if (!conv_config.weights_dtype.has_value()) {
+                conv_config.weights_dtype = weight_tensor.dtype();
+            }
+            conv_config = determine_conv_config_for_auto_shard(
+                conv_config,
+                false,
+                batch_size,
+                input_channels,
+                output_channels,
+                output_slice_height,
+                output_slice_width,
+                weight_tensor.logical_shape()[3],
+                input_slice_height,
+                input_slice_width,
+                device->compute_with_storage_grid_size(),
+                input_layout,
+                input_dtype,
+                output_dtype,
+                std::nullopt,
+                kernel_size,
+                stride,
+                dilation,
+                padding_n4,
+                groups,
+                bias_tensor.has_value(),
+                compute_config);
+        }
+        TT_FATAL(conv_config.shard_layout.has_value(), " Conv2D DRAM Slicing must have a shard layout set.");
+
+        ShardOrientation shard_orientation =
+            conv_config.transpose_shards ? ShardOrientation::COL_MAJOR : ShardOrientation::ROW_MAJOR;
+        auto sliced_input_tensor_memory_config = std::get<1>(determine_input_memory_config(
+            conv_config.shard_layout.value(),
+            shard_orientation,
+            batch_size,
+            ttnn::Shape({batch_size, input_slice_height, input_slice_width, input_channels}),
+            ttnn::Shape({batch_size, output_slice_height, output_slice_width, output_channels}),
+            false,
+            compute_grid_size,
+            input_layout,
+            single_slice ? BufferType::L1 : BufferType::DRAM));
+        return sliced_input_tensor_memory_config;
+    }
+
+    std::string name() const override { return "Conv2D"; }
+
+    std::vector<ttnn::Tensor> run_L1_op(
+        const ttnn::Tensor& sliced_input_tensor,
+        const IOShape& output_slice_start,
+        const IOShape& output_slice_end) override {
+        // Use helper function to calculate slice bounds and padding
+        auto [input_slicing, this_op_padding] = get_input_slice_and_padding(output_slice_start, output_slice_end);
+        auto [input_slice_start, input_slice_end] = input_slicing;
+        auto [input_slice_height_start, input_slice_width_start] = input_slice_start;
+        auto [input_slice_height_end, input_slice_width_end] = input_slice_end;
+        // Calculate dimensions directly from result
+        uint32_t input_slice_height = input_slice_height_end - input_slice_height_start;
+        uint32_t input_slice_width = input_slice_width_end - input_slice_width_start;
+
+        if (!conv_config.shard_layout.has_value() && sliced_input_tensor.is_sharded()) {
+            conv_config.shard_layout = sliced_input_tensor.memory_config().memory_layout();
+        }
+        auto conv_config_l1 = conv_config;
+
+        conv_config_l1.deallocate_activation = true;
+        conv_config_l1.reallocate_halo_output = true;
+
+        // Force Conv2d_L1 to always output tiled layout to reduce CB Memory usage.
+        conv_config_l1.output_layout = Layout::TILE;
+
+        auto conv2d_result = conv2d_L1(
+            sliced_input_tensor,
+            weight_tensor,
+            device,
+            input_channels,
+            output_channels,
+            batch_size,
+            input_slice_height,
+            input_slice_width,
+            kernel_size,
+            stride,
+            this_op_padding,
+            dilation,
+            groups,
+            output_dtype,
+            bias_tensor,
+            conv_config_l1,
+            compute_config,
+            std::nullopt);
+        weight_tensor = std::get<3>(conv2d_result);
+        if (bias_tensor.has_value()) {
+            bias_tensor->get() = std::get<4>(conv2d_result).value();
+        }
+        return {std::get<0>(conv2d_result)};
+    }
+};
+
+// This function is used for DRAM Slicing
+// It divides the output tensor into slices, and calculates the corresponding input slices.
+// Uses ttnn::slice to slice the input tensor and bring it to L1.
+// Calls conv2d_L1 to perform the convolution on the sliced input tensor.
+// Finally, it uses ttnn::experimental::slice_write to write the output tensor back to DRAM.
+// The function is called in a loop for each slice of the output tensor.
+// The Conv2dSliceConfig is used to determine the slicing configuration. The dimension along which it is sliced, and the
+// number of such slices.
+// Conv2dConfig does not control the final output, but rather the conv2d_L1 function that is called internally.
+Result conv2d_DRAM(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& weight_tensor,
+    MeshDevice* device,
+    uint32_t in_channels,
+    uint32_t out_channels,
+    uint32_t batch_size,
+    uint32_t input_height,
+    uint32_t input_width,
+    std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> stride,
+    std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding,
+    std::array<uint32_t, 2> dilation,
+    uint32_t groups,
+    const std::optional<const DataType>& dtype,
+    const std::optional<const ttnn::Tensor>& bias_tensor,
+    const std::optional<const Conv2dConfig>& conv_config_,
+    const std::optional<const DeviceComputeKernelConfig>& compute_config_,
+    const std::optional<const MemoryConfig>& memory_config_,
+    const std::optional<const Conv2dSliceConfig>& dram_slice_config_) {
+    Conv2dConfig conv_config = conv_config_.value_or(Conv2dConfig());
+    const DataType output_dtype = dtype.value_or(input_tensor.dtype());
+    std::array<uint32_t, 4> padding_n4 = sliding_window::get_pair_n4_padding(padding);
+    bool mm_conv = use_matmul_for_1x1_conv(kernel_size, stride, padding_n4, dilation, groups, conv_config);
+    // Use weights_dtype from config if set, otherwise use weight tensor's dtype
+    DataType weight_dtype = conv_config.weights_dtype.value_or(weight_tensor.dtype());
+    DeviceComputeKernelConfig compute_config =
+        compute_config_.value_or(get_conv_default_compute_kernel_config(device, input_tensor.dtype(), weight_dtype));
+    TT_FATAL(
+        !conv_config.override_output_sharding_config,
+        "Conv2D DRAM slicing doesn't support override_output_sharding_config.");
+
+    // Fold the input tensor if required - this may update mm_conv after folding
+    ttnn::Tensor input_tensor_on_device = fold_input_tensor_if_required(
+        input_tensor,
+        device,
+        batch_size,
+        input_height,
+        input_width,
+        in_channels,
+        kernel_size,
+        stride,
+        dilation,
+        padding_n4,
+        mm_conv,
+        conv_config);
+    if (!is_device_tensor(input_tensor_on_device)) {
+        input_tensor_on_device =
+            ttnn::operations::core::to_device(input_tensor_on_device, device, ttnn::DRAM_MEMORY_CONFIG);
+    }
+
+    // After folding, check if this can be implemented as matmul and delegate to conv2d_L1
+    // Note: mm_conv may have been updated by fold_input_tensor_if_required
+    if (mm_conv) {
+        return conv2d_L1(
+            input_tensor_on_device,
+            weight_tensor,
+            device,
+            in_channels,
+            out_channels,
+            batch_size,
+            input_height,
+            input_width,
+            kernel_size,
+            stride,
+            padding_n4,
+            dilation,
+            groups,
+            output_dtype,
+            bias_tensor,
+            conv_config,
+            compute_config_,
+            memory_config_);
+    }
+
+    // DRAM slicing path - only executed when mm_conv is false
+    const bool should_deallocate_act = conv_config.deallocate_activation && !input_tensor.memory_config().is_dram();
+    ttnn::Tensor weight_tensor_on_device;
+    std::optional<ttnn::Tensor> bias_tensor_on_device;
+    if (memory_config_.has_value()) {
+        log_warning(
+            tt::LogOp,
+            "Conv2D DRAM doesn't support specifying memory config, as the output will always be DRAM Interleaved");
+    }
+
+    TT_FATAL(
+        !(conv_config.output_layout == Layout::ROW_MAJOR && output_dtype == DataType::BFLOAT8_B),
+        "Conv output can't be in Row Major if output dtype is BFloat8_B.");
+
+    auto [output_height, output_width] =
+        calculate_output_image_size({input_height, input_width}, kernel_size, stride, padding_n4, dilation);
+
+    if (!conv_config.weights_dtype.has_value()) {
+        conv_config.weights_dtype = weight_tensor.dtype();
+    }
+
+    const auto unflattened_input_shape = ttnn::Shape{batch_size, input_height, input_width, in_channels};
+    input_tensor_on_device = ttnn::reshape(input_tensor_on_device, unflattened_input_shape, unflattened_input_shape);
+    TT_FATAL(input_tensor_on_device.memory_config().is_dram(), "Conv DRAM expects the input tensor to be in DRAM.");
+    TT_FATAL(
+        input_tensor_on_device.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+        "Input Tensor to Conv DRAM should be in Interleaved Memory Layout");
+
+    ttnn::Tensor dram_output_tensor = tt::tt_metal::create_device_tensor(
+        tt::tt_metal::TensorSpec(
+            ttnn::Shape({batch_size, output_height, output_width, out_channels}),
+            tt::tt_metal::TensorLayout(
+                output_dtype,
+                tt::tt_metal::PageConfig(conv_config.output_layout),
+                MemoryConfig{
+                    TensorMemoryLayout::INTERLEAVED,
+                    BufferType::DRAM,
+                })),
+        device);
+
+    weight_tensor_on_device = weight_tensor;
+    bias_tensor_on_device = bias_tensor;
+    auto slice_attr = Conv2dSliceAttr(
+        batch_size,
+        {input_height, input_width},
+        in_channels,
+        out_channels,
+        kernel_size,
+        stride,
+        padding_n4,
+        dilation,
+        groups,
+        input_tensor.layout(),
+        input_tensor.dtype(),
+        output_dtype,
+        std::ref(weight_tensor_on_device),
+        bias_tensor_on_device.has_value() ? std::make_optional(std::ref(bias_tensor_on_device.value())) : std::nullopt,
+        conv_config,
+        compute_config,
+        device);
+
+    std::vector<std::reference_wrapper<Tensor>> output_tensors = {std::ref(dram_output_tensor)};
+    ttnn::operations::op_slicing::run_sliced_op(
+        input_tensor_on_device, output_tensors, &slice_attr, dram_slice_config_);
+
+    if (should_deallocate_act) {
+        input_tensor_on_device.deallocate(true);
+    }
+    const auto flattened_output_shape = flatten_4d_shape(dram_output_tensor.logical_shape());
+    const auto flattened_padded_output_shape = flatten_4d_shape(dram_output_tensor.padded_shape());
+
+    dram_output_tensor = ttnn::reshape(dram_output_tensor, flattened_output_shape, flattened_padded_output_shape);
+
+    return {dram_output_tensor, output_height, output_width, weight_tensor_on_device, bias_tensor_on_device};
+}
+
+}  // namespace ttnn::operations::experimental::quasar::detail
+
+namespace ttnn::operations::experimental::quasar {
+
+Conv2dResultWithOptions conv2d(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& weight_tensor,
+    MeshDevice* device,
+    uint32_t in_channels,
+    uint32_t out_channels,
+    uint32_t batch_size,
+    uint32_t input_height,
+    uint32_t input_width,
+    std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> stride,
+    std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding,
+    std::array<uint32_t, 2> dilation,
+    uint32_t groups,
+    const std::optional<const DataType>& dtype,
+    const std::optional<const ttnn::Tensor>& bias_tensor,
+    const std::optional<const Conv2dConfig>& conv_config_,
+    const std::optional<const DeviceComputeKernelConfig>& compute_config_,
+    const std::optional<const MemoryConfig>& memory_config,
+    const std::optional<const Conv2dSliceConfig>& slice_config_,
+    bool return_output_dim,
+    bool return_weights_and_bias) {
+    using namespace detail;
+    using operations::conv::Conv2dExecutionPath;
+    using operations::conv::determine_conv2d_execution_path;
+    // Determine execution path based on configuration and input properties
+    Conv2dExecutionPath path = determine_conv2d_execution_path(input_tensor, slice_config_);
+
+    // Execute L1 path
+    if (path == Conv2dExecutionPath::L1) {
+        log_trace(tt::LogOp, "Conv2d L1 {}", slice_config_.has_value() ? "with slice config" : "without slice config");
+        return result_to_result_with_options(
+            conv2d_L1(
+                input_tensor,
+                weight_tensor,
+                device,
+                in_channels,
+                out_channels,
+                batch_size,
+                input_height,
+                input_width,
+                kernel_size,
+                stride,
+                padding,
+                dilation,
+                groups,
+                dtype,
+                bias_tensor,
+                conv_config_,
+                compute_config_,
+                memory_config),
+            return_output_dim,
+            return_weights_and_bias);
+    }
+
+    // Execute DRAM path
+    log_trace(tt::LogOp, "Conv2d DRAM {}", slice_config_.has_value() ? "with slice config" : "without slice config");
+    return result_to_result_with_options(
+        conv2d_DRAM(
+            input_tensor,
+            weight_tensor,
+            device,
+            in_channels,
+            out_channels,
+            batch_size,
+            input_height,
+            input_width,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+            groups,
+            dtype,
+            bias_tensor,
+            conv_config_,
+            compute_config_,
+            memory_config,
+            slice_config_),
+        return_output_dim,
+        return_weights_and_bias);
+}
+
+}  // namespace ttnn::operations::experimental::quasar
+
+namespace ttnn::operations::experimental::quasar::detail {
+
+std::unique_ptr<op_slicing::OpSliceAttr> get_conv2d_slice_attr(
+    uint32_t batch_size,
+    uint32_t input_height,
+    uint32_t input_width,
+    uint32_t in_channels,
+    uint32_t out_channels,
+    std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> stride,
+    std::array<uint32_t, 4> padding_n4,
+    std::array<uint32_t, 2> dilation,
+    uint32_t groups,
+    Layout input_layout,
+    DataType input_dtype,
+    DataType conv_output_dtype,
+    Tensor& weight_tensor,
+    std::optional<std::reference_wrapper<Tensor>> bias_tensor,
+    const Conv2dConfig& conv_config_,
+    const DeviceComputeKernelConfig& compute_config,
+    MeshDevice* device) {
+    return std::unique_ptr<op_slicing::OpSliceAttr>(new Conv2dSliceAttr(
+        batch_size,
+        {input_height, input_width},
+        in_channels,
+        out_channels,
+        kernel_size,
+        stride,
+        padding_n4,
+        dilation,
+        groups,
+        input_layout,
+        input_dtype,
+        conv_output_dtype,
+        weight_tensor,
+        bias_tensor,
+        conv_config_,
+        compute_config,
+        device));
+}
+}  // namespace ttnn::operations::experimental::quasar::detail

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/conv2d.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/conv2d.hpp
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+#include <tuple>
+#include <variant>
+
+#include "ttnn/distributed/types.hpp"
+#include "ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp"
+#include "ttnn/operations/conv/conv2d/device/conv2d_device_operation.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::experimental::quasar {
+using OutputHeight = uint32_t;
+using OutputWidth = uint32_t;
+using Conv2dResult = std::tuple<ttnn::Tensor, OutputHeight, OutputWidth, ttnn::Tensor, std::optional<ttnn::Tensor>>;
+using Conv2dResultWithOptions = std::variant<
+    ttnn::Tensor,
+    std::tuple<ttnn::Tensor, std::tuple<OutputHeight, OutputWidth>>,
+    std::tuple<ttnn::Tensor, std::tuple<ttnn::Tensor, std::optional<ttnn::Tensor>>>,
+    std::tuple<
+        ttnn::Tensor,
+        std::tuple<OutputHeight, OutputWidth>,
+        std::tuple<ttnn::Tensor, std::optional<ttnn::Tensor>>>>;
+
+using ttnn::prim::Conv2dConfig;
+using ttnn::prim::Conv2dSliceConfig;
+
+Conv2dResultWithOptions conv2d(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& weight_tensor,
+    MeshDevice* device,
+    uint32_t in_channels,
+    uint32_t out_channels,
+    uint32_t batch_size,
+    uint32_t input_height,
+    uint32_t input_width,
+    std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> stride = std::array<uint32_t, 2>{1, 1},
+    std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding = std::array<uint32_t, 2>{0, 0},
+    std::array<uint32_t, 2> dilation = std::array<uint32_t, 2>{1, 1},
+    uint32_t groups = 1,
+    const std::optional<const DataType>& dtype = std::nullopt,
+    const std::optional<const ttnn::Tensor>& bias_tensor = std::nullopt,
+    const std::optional<const Conv2dConfig>& conv_config_ = std::nullopt,
+    const std::optional<const DeviceComputeKernelConfig>& compute_config_ = std::nullopt,
+    const std::optional<const MemoryConfig>& memory_config_ = std::nullopt,
+    const std::optional<const Conv2dSliceConfig>& dram_slice_config_ = std::nullopt,
+    bool return_output_dim = false,
+    bool return_weights_and_bias = false);
+
+}  // namespace ttnn::operations::experimental::quasar
+
+namespace ttnn::operations::experimental::quasar::detail {
+
+std::unique_ptr<op_slicing::OpSliceAttr> get_conv2d_slice_attr(
+    uint32_t batch_size,
+    uint32_t input_height,
+    uint32_t input_width,
+    uint32_t in_channels,
+    uint32_t out_channels,
+    std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> stride,
+    std::array<uint32_t, 4> padding_n4,
+    std::array<uint32_t, 2> dilation,
+    uint32_t groups,
+    Layout input_layout,
+    DataType input_dtype,
+    DataType conv_output_dtype,
+    Tensor& weight_tensor,
+    std::optional<std::reference_wrapper<Tensor>> bias_tensor,
+    const Conv2dConfig& conv_config_,
+    const DeviceComputeKernelConfig& compute_config,
+    MeshDevice* device);
+
+}  // namespace ttnn::operations::experimental::quasar::detail

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/conv2d_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/conv2d_nanobind.cpp
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "conv2d_nanobind.hpp"
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <variant>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/array.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/variant.h>
+
+#include "ttnn-nanobind/decorators.hpp"
+#include "ttnn-nanobind/export_enum.hpp"
+#include "ttnn-nanobind/bind_function.hpp"
+#include "ttnn/operations/experimental/quasar/conv2d/conv2d.hpp"
+#include "ttnn/operations/conv/conv2d/conv2d_utils.hpp"
+#include "ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp"
+#include "ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp"
+#include "ttnn/operations/sliding_window/sliding_window_nanobind.hpp"
+#include "ttnn/types.hpp"
+#include <tt-metalium/constants.hpp>
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+
+namespace ttnn::operations::experimental::quasar::detail {
+
+void bind_conv2d(nb::module_& mod) {
+    const auto* doc = R"doc(
+        Applies a 2D convolution over an input signal composed of several input planes.
+
+        Performs a 2D convolution between the input tensor and weight tensor. A 2D kernel (weights tensor) traverses the image (4D input tensor) and a dot product is computed over the overlapping region. For more information, refer to `CNNs on Tenstorrent Architectures <https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/CNNs/ttcnn.md>`_ tech report.
+
+        Args:
+            input_tensor (ttnn.Tensor): The input tensor in [N, H, W, C] format. The tensor can be on either the host or the device.
+            weight_tensor (ttnn.Tensor): The convolution weights, typically in [out_channels, in_channels // groups, kernel_height, kernel_width] format.
+            device (ttnn.MeshDevice): This is a Tenstorrent-specific parameter. The device which will run the operation.
+            in_channels (int): Number of channels in the input tensor.
+            out_channels (int): Number of channels produced by the convolution.
+            batch_size (int): The batch size of the input tensor.
+            input_height (int): This is a Tenstorrent-specific parameter. The height of the input tensor.
+            input_width (int): This is a Tenstorrent-specific parameter. The width of the input tensor.
+            kernel_size (tuple[int, int]): The size of the convolving kernel.
+            stride (tuple[int, int]): The stride of the convolution. Default: (1, 1).
+            padding (tuple[int, int] or tuple[int, int, int, int]): Zero-padding added to both sides of the input. Default: (0, 0). [pad_height, pad_width] or [pad_top, pad_bottom, pad_left, pad_right].
+            dilation (tuple[int, int]): The spacing between kernel elements. Default: (1, 1).
+            groups (int): Number of blocked connections from input channels to output channels. Default: 1.
+
+        Keyword Args:
+            dtype (ttnn.DataType, optional): The data type of the output tensor. If not provided, it is inferred from the input tensor.
+            bias_tensor (ttnn.Tensor, optional): The bias tensor to be added. Default: None.
+            conv_config (ttnn.Conv2dConfig, optional): Configuration for convolution. Default: None.
+            compute_config (ttnn.DeviceComputeKernelConfig, optional): Configuration for compute kernel. Default: None
+            memory_config (ttnn.MemoryConfig, optional): Output Tensor's Memory Configuration. Default: None.
+            slice_config (ttnn.Conv2dSliceConfig, optional): Configuration for slicing input & output tensors in DRAM. If set to None and input is in DRAM, DRAM slicing is automatically enabled. Default: None.
+            return_output_dim (bool, optional): If true, the op also returns the height and width of the output tensor in [N, H, W, C] format. Default: False
+            return_weights_and_bias (bool, optional): If true, the op also returns the preprocessed weight and bias on device. Default: False
+
+        Returns:
+            The output tensor, output height and width, and the preprocessed weights and bias.
+
+            - ttnn.Tensor: Default. The output tensor, when return_output_dim = False and return_weights_and_bias = False
+            - tuple[ttnn.Tensor, tuple[int, int]]: The output tensor, and its height and width, if return_output_dim = True
+            - tuple[ttnn.Tensor, tuple[ttnn.Tensor, ttnn.Tensor]]: The output tensor, and its height and width, if return_weights_and_bias = True
+            - tuple[ttnn.Tensor, tuple[int, int], tuple[ttnn.Tensor, ttnn.Tensor]]: The output tensor, and its height and width, if return_output_dim = True and return_weights_and_bias = True
+
+        Note:
+            The `input_tensor` supports the following data type and layout:
+
+            .. list-table:: input_tensor
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - FLOAT32
+                  - ROW_MAJOR, TILE
+                * - BFLOAT16
+                  - ROW_MAJOR, TILE
+                * - BFLOAT8_B
+                  - TILE
+
+            The `output_tensor` supports the following data type and layout:
+
+            .. list-table:: output_tensor
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - FLOAT32
+                  - ROW_MAJOR, TILE
+                * - BFLOAT16
+                  - ROW_MAJOR, TILE
+                * - BFLOAT8_B
+                  - TILE
+
+            The `weights_tensor` on the host, supports the following data type and layout:
+
+            .. list-table:: weights_tensor (host)
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - FLOAT32
+                  - ROW_MAJOR
+                * - BFLOAT16
+                  - ROW_MAJOR
+
+            The `weights_tensor` prepared on device, supports the following data type and layout:
+
+            .. list-table:: weights_tensor (prepared on device)
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - FLOAT32
+                  - TILE
+                * - BFLOAT16
+                  - TILE
+                * - BFLOAT8_B
+                  - TILE
+
+            The `bias_tensor` on the host, supports the following data type and layout:
+
+            .. list-table:: bias_tensor (host)
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - FLOAT32
+                  - ROW_MAJOR
+                * - BFLOAT16
+                  - ROW_MAJOR
+
+            The `bias_tensor` prepared on device, supports the following data type and layout:
+
+            .. list-table:: bias_tensor (prepared on device)
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - FLOAT32
+                  - TILE
+                * - BFLOAT16
+                  - TILE
+                * - BFLOAT8_B
+                  - TILE
+        )doc";
+
+    ttnn::bind_function<"conv2d">(
+        mod,
+        doc,
+        &ttnn::operations::experimental::quasar::conv2d,
+        nb::kw_only(),
+        nb::arg("input_tensor"),
+        nb::arg("weight_tensor"),
+        nb::arg("device"),
+        nb::arg("in_channels"),
+        nb::arg("out_channels"),
+        nb::arg("batch_size"),
+        nb::arg("input_height"),
+        nb::arg("input_width"),
+        nb::arg("kernel_size"),
+        nb::arg("stride") = nb::cast(std::array<uint32_t, 2>{1, 1}),
+        nb::arg("padding") = nb::cast(std::array<uint32_t, 2>{0, 0}),
+        nb::arg("dilation") = nb::cast(std::array<uint32_t, 2>{1, 1}),
+        nb::arg("groups") = 1,
+        nb::arg("dtype") = nb::none(),
+        nb::arg("bias_tensor") = nb::none(),
+        nb::arg("conv_config") = nb::none(),
+        nb::arg("compute_config") = nb::none(),
+        nb::arg("memory_config") = nb::none(),
+        nb::arg("slice_config") = nb::none(),
+        nb::arg("return_output_dim") = false,
+        nb::arg("return_weights_and_bias") = false);
+}
+
+}  // namespace ttnn::operations::experimental::quasar::detail

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/conv2d_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/conv2d_nanobind.hpp
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::experimental::quasar::detail {
+namespace nb = nanobind;
+void bind_conv2d(nb::module_& mod);
+}  // namespace ttnn::operations::experimental::quasar::detail

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.cpp
@@ -1,0 +1,286 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.hpp"
+#include "ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.hpp"
+#include "ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_width_sharded_program_factory.hpp"
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <tt-metalium/math.hpp>
+
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/constants.hpp>
+
+#include <tt-metalium/work_split.hpp>
+#include "tt-metalium/shape.hpp"
+#include "ttnn/operations/conv/conv2d/conv2d_utils.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+#include "ttnn/operations/cb_utils.hpp"
+#include "ttnn/tensor/tensor_ops.hpp"
+
+#include "ttnn/operations/sliding_window/sliding_window.hpp"
+#include "ttnn/tensor/shape/shape.hpp"
+
+namespace ttnn::prim::qsr {
+
+using ttnn::operations::conv::calculate_output_image_size;
+
+Conv2dDeviceOperation::program_factory_t Conv2dDeviceOperation::select_program_factory(
+    const operation_attributes_t& /*args*/, const tensor_args_t& tensor_args) {
+    if (tensor_args.a.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED) {
+        // Use width sharded implementation
+        return Conv2dWidthShardedProgramFactory{};
+    }  // Use regular sharded implementation
+    return Conv2dShardedProgramFactory{};
+}
+
+TensorSpec Conv2dDeviceOperation::compute_output_specs(
+    const operation_attributes_t& args, const tensor_args_t& /*tensor_args*/) {
+    const auto& input_tensor_a_shape = args.input_tensor_shape;
+    uint32_t batch_size = input_tensor_a_shape[0];
+
+    auto sliding_window_output_shape = args.sliding_window_config.get_output_shape();
+    uint32_t conv_output_h = sliding_window_output_shape[1];
+    uint32_t conv_output_w = sliding_window_output_shape[2];
+
+    // Tiled output shape is padded shape. Padded to tile shape.
+    auto shape_w = batch_size * conv_output_h * conv_output_w;
+    auto shape_c = args.output_channels;
+    auto padded_shape_w = args.parallelization_config.num_cores_nhw *
+                          args.parallelization_config.per_core_out_matrix_height_ntile * tt::constants::TILE_HEIGHT;
+    auto padded_shape_c = tt::round_up(args.output_channels, tt::constants::TILE_WIDTH);
+    ttnn::Shape output_shape({1, 1, shape_w, shape_c});
+    ttnn::Shape padded_output_shape({1, 1, padded_shape_w, padded_shape_c});
+
+    auto output_layout = args.untilize_out ? Layout::ROW_MAJOR : Layout::TILE;
+    if (args.memory_config.is_sharded()) {
+        std::array<uint32_t, 2> shard_shape = {
+            args.parallelization_config.per_core_out_matrix_height_ntile * tt::constants::TILE_HEIGHT,
+            args.parallelization_config.per_core_out_matrix_width_ntile * tt::constants::TILE_WIDTH};
+        auto shard_grid = args.memory_config.shard_spec().value().grid;
+        auto shard_spec =
+            tt::tt_metal::ShardSpec{shard_grid, shard_shape, args.memory_config.shard_spec().value().orientation};
+        auto mem_config = tt::tt_metal::MemoryConfig(
+            args.memory_config.memory_layout(), args.memory_config.buffer_type(), shard_spec);
+        return TensorSpec(
+            output_shape,
+            tt::tt_metal::TensorLayout(
+                args.dtype,
+                tt::tt_metal::PageConfig(output_layout),
+                mem_config,
+                tt::tt_metal::Alignment(
+                    {tt::constants::TILE_HEIGHT,
+                     tt::constants::TILE_WIDTH})  // Conv2D always outputs in tile multiples, even if output layout is
+                                                  // Row Major.
+                ));
+    }
+    return TensorSpec(
+        output_shape,
+        tt::tt_metal::TensorLayout::fromPaddedShape(
+            args.dtype,
+            tt::tt_metal::PageConfig(output_layout),
+            args.memory_config,
+            output_shape,
+            padded_output_shape));
+}
+
+Tensor Conv2dDeviceOperation::create_output_tensors(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.a.device());
+}
+
+void Conv2dDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& input_tensor_a = tensor_args.a;
+    const auto& input_tensor_b = tensor_args.b;
+    TT_FATAL(input_tensor_a.memory_config().is_sharded(), "Activation tensor should be sharded.");
+    TT_FATAL(!input_tensor_b.memory_config().is_sharded(), "Weights tensor should not be sharded.");
+    if (args.untilize_out) {
+        TT_FATAL(
+            (args.dtype == DataType::BFLOAT16) || (args.dtype == DataType::FLOAT32),
+            "Untilize output requires BFLOAT16 or FLOAT32 data type but got {}",
+            args.dtype);
+    }
+    if (args.memory_config.is_sharded()) {
+        uint32_t per_core_out_matrix_width_ntiles = args.parallelization_config.per_core_out_matrix_width_ntile;
+        uint32_t out_width_ntiles =
+            compute_output_specs(args, tensor_args).padded_shape()[-1] / tt::constants::TILE_WIDTH;
+        if (args.memory_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
+            TT_FATAL(
+                per_core_out_matrix_width_ntiles == out_width_ntiles,
+                "Per-core output matrix width in tiles ({}) must equal output width in tiles ({}) for height sharded "
+                "layout",
+                per_core_out_matrix_width_ntiles,
+                out_width_ntiles);
+            TT_FATAL(
+                args.block_config.out_subblock_w_ntiles == out_width_ntiles ||
+                    args.block_config.out_subblock_h_ntiles == 1,
+                "Error");
+        } else if (args.memory_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
+            // For block sharded, out_width per core is shard width, and this is split along row
+            // TODO: We should clean this up and relax constraints on out_subblock h and w
+            if (args.memory_config.shard_spec().value().orientation == ShardOrientation::COL_MAJOR) {
+                out_width_ntiles = tt::div_up(out_width_ntiles, args.parallelization_config.grid_size.y);
+            } else {
+                out_width_ntiles = tt::div_up(out_width_ntiles, args.parallelization_config.grid_size.x);
+            }
+            TT_FATAL(
+                args.block_config.out_subblock_w_ntiles == out_width_ntiles ||
+                    args.block_config.out_subblock_h_ntiles == 1,
+                "Error");
+        } else {
+            TT_FATAL(
+                args.block_config.out_subblock_w_ntiles == per_core_out_matrix_width_ntiles ||
+                    args.block_config.out_subblock_h_ntiles == 1,
+                "Error");
+        }
+    }
+}
+
+ttsl::hash::hash_t Conv2dDeviceOperation::compute_program_hash(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    hashable_operation_attributes_t hashable_args = {
+        .sliding_window_config = args.sliding_window_config,
+        .output_channels = args.output_channels,
+        .untilize_out = args.untilize_out,
+        .has_bias = args.has_bias,
+        .activation = args.activation,
+        .parallelization_config = args.parallelization_config,
+        .block_config = args.block_config,
+        .memory_config = args.memory_config,
+        .dtype = args.dtype,
+        .input_tensor_shape = args.input_tensor_shape,
+        .compute_kernel_config = args.compute_kernel_config,
+        .enable_act_double_buffer = args.enable_act_double_buffer,
+        .enable_weights_double_buffer = args.enable_weights_double_buffer,
+        .enable_activation_reuse = args.enable_activation_reuse,
+        .config_tensors_in_dram = args.config_tensors_in_dram,
+        .force_split_reader = args.force_split_reader,
+    };
+    return ttsl::hash::hash_objects_with_default_seed(hashable_args, tensor_args);
+}
+
+tt::tt_metal::operation::OpPerformanceModelGeneral<Tensor> Conv2dDeviceOperation::create_op_performance_model(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensor) {
+    const auto& input_tensor_a_shape = args.input_tensor_shape;
+    uint32_t batch_size = input_tensor_a_shape[0];
+    uint32_t conv_activation_h = input_tensor_a_shape[1];
+    uint32_t conv_activation_w = input_tensor_a_shape[2];
+    uint32_t conv_activation_c = input_tensor_a_shape[3];
+    uint32_t filter_h = (uint32_t)args.sliding_window_config.window_hw.first;   // filter_h
+    uint32_t filter_w = (uint32_t)args.sliding_window_config.window_hw.second;  // filter_W
+    uint32_t stride_h = (uint32_t)args.sliding_window_config.stride_hw.first;
+    uint32_t stride_w = (uint32_t)args.sliding_window_config.stride_hw.second;
+    uint32_t dilation_h = (uint32_t)args.sliding_window_config.dilation_hw.first;
+    uint32_t dilation_w = (uint32_t)args.sliding_window_config.dilation_hw.second;
+
+    const CoreCoord compute_grid = output_tensor.device()->compute_with_storage_grid_size();
+    const int num_cores = compute_grid.x * compute_grid.y;
+    // The Wormhole/Blackhole matrix engine performs 8x16 x 16x16 = 8x16 in a single cycle.
+    // This is 2*8*16*16 = 4096 muladds in a single cycle.
+    constexpr int tensix_mul_adds_per_cycle_lofi = 4096;
+
+    // Calculate output dimensions: relevant for window/stride based OPs (conv, maxpool, downsample)
+    auto [output_height, output_width] = calculate_output_image_size(
+        {conv_activation_h, conv_activation_w},
+        {filter_h, filter_w},
+        {stride_h, stride_w},
+        args.sliding_window_config.padding,
+        {dilation_h, dilation_w});
+
+    // Calculate number of mul/add operations
+    // TODO: add bias modeling
+    int64_t num_mul_adds_per_elem = conv_activation_c * filter_h * filter_w * 2;  // 1 multiply and 1 add per element
+    int64_t num_mul_adds = num_mul_adds_per_elem * output_height * output_width * args.output_channels * batch_size;
+
+    int ideal_dev_clock_cycles = std::ceil(
+        ((float)num_mul_adds / (float)(num_cores * tensix_mul_adds_per_cycle_lofi)) *
+        (float)tt::tt_metal::operation::OpPerformanceModel::fidelity_multiplier(
+            get_math_fidelity(args.compute_kernel_config)));
+
+    Tensors input_tensors = {tensor_args.a, tensor_args.b};
+    if (tensor_args.bias.has_value()) {
+        input_tensors.push_back(tensor_args.bias.value());
+    }
+    tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> result(
+        input_tensors, output_tensor, ideal_dev_clock_cycles);
+
+#if 0
+    log_info(tt::LogOp, "Conv2d PerfModel:");
+    log_info(tt::LogOp, "\t Batch: {}", batch_size);
+    log_info(tt::LogOp, "\t In (H, W, C): ({}, {}, {})", conv_activation_h, conv_activation_w, conv_activation_c);
+    log_info(tt::LogOp, "\t Filter (H, W): ({}, {})", filter_h, filter_w);
+    log_info(tt::LogOp, "\t Filter Stride (H, W): ({}, {})", stride_h, stride_w);
+    log_info(tt::LogOp, "\t Pad (H, W): ({}, {})", pad_h, pad_w);
+    log_info(tt::LogOp, "\t Out (H, W, C): ({}, {}, {})", output_height, output_width, this->output_channels);
+    log_info(tt::LogOp, "\t ideal_dev_clock_cycles: {}", ideal_dev_clock_cycles);
+#endif
+
+    return result;
+}
+
+Tensor conv2d(
+    const Tensor& a,
+    const Tensor& b,
+    const std::optional<const Tensor>& bias,
+    const ttnn::operations::sliding_window::SlidingWindowConfig& sliding_window_config,
+    uint32_t output_channels,
+    uint32_t groups,
+    bool untilize_out,
+    const std::optional<ttnn::operations::unary::UnaryWithParam>& activation,
+    const Conv2dParallelizationConfig& parallelization_config,
+    const Conv2dBlockConfig& block_config,
+    const tt::tt_metal::MemoryConfig& memory_config,
+    tt::tt_metal::DataType dtype,
+    std::array<std::uint32_t, 4> input_tensor_shape,
+    const ttnn::DeviceComputeKernelConfig& compute_kernel_config,
+    bool enable_act_double_buffer,
+    bool enable_weights_double_buffer,
+    bool full_inner_dim,
+    bool enable_activation_reuse,
+    bool config_tensors_in_dram,
+    std::optional<bool> force_split_reader) {
+    using OperationType = Conv2dDeviceOperation;
+
+    TT_FATAL(b.layout() == Layout::TILE, "Weights should be in TILE layout.");
+
+    auto operation_attributes = OperationType::operation_attributes_t{
+        .sliding_window_config = sliding_window_config,
+        .output_channels = output_channels,
+        .groups = groups,
+        .untilize_out = untilize_out,
+        .has_bias = bias.has_value(),
+        .activation = activation,
+        .parallelization_config = parallelization_config,
+        .block_config = block_config,
+        .memory_config = memory_config,
+        .dtype = dtype,
+        .input_tensor_shape = input_tensor_shape,
+        .compute_kernel_config = compute_kernel_config,
+        .enable_act_double_buffer = enable_act_double_buffer,
+        .enable_weights_double_buffer = enable_weights_double_buffer,
+        .full_inner_dim = full_inner_dim,
+        .enable_activation_reuse = enable_activation_reuse,
+        .config_tensors_in_dram = config_tensors_in_dram,
+        .force_split_reader = force_split_reader,
+    };
+    auto tensor_args = OperationType::tensor_args_t{
+        .a = a,
+        .b = b,
+        .bias = bias,
+    };
+
+    auto* device = a.device();
+
+    operation_attributes.pre_op_l1_allocation_size_bytes =
+        device->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_allocated_bytes;
+
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.hpp
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/core/core.hpp"
+
+#include "ttnn/device_operation.hpp"
+#include <tt-metalium/global_circular_buffer.hpp>
+#include "ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp"
+#include "ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.hpp"
+#include "ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_width_sharded_program_factory.hpp"
+
+#include <string>
+#include <utility>
+#include "ttnn/operations/sliding_window/sliding_window.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+#include "ttnn/operations/sliding_window/op_slicing/op_slicing.hpp"
+
+namespace ttnn::prim::qsr {
+
+namespace sliding_window = ttnn::operations::sliding_window;
+
+struct Conv2dDeviceOperation {
+    using operation_attributes_t = Conv2dParams;
+    using hashable_operation_attributes_t = Conv2dHashableParams;
+    using tensor_args_t = Conv2dInputs;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
+    using program_factory_t = std::variant<Conv2dShardedProgramFactory, Conv2dWidthShardedProgramFactory>;
+
+    static program_factory_t select_program_factory(
+        const operation_attributes_t& args, const tensor_args_t& tensor_args);
+    static spec_return_value_t compute_output_specs(
+        const operation_attributes_t& args, const tensor_args_t& tensor_args);
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t& args, const tensor_args_t& tensor_args);
+    static void validate_on_program_cache_miss(const operation_attributes_t& args, const tensor_args_t& tensor_args);
+    static ttsl::hash::hash_t compute_program_hash(
+        const operation_attributes_t& args, const tensor_args_t& tensor_args);
+    static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
+        const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensor);
+};
+
+// Only enable packer l1 accumulation when there are in0_num_blocks_w > 2, otherwise
+// unnecessary overhead for reconfigs are added. Last iteration of l1 accumulation
+// does a spill and reload, so need more than 2 blocks to use l1 acc for packer
+// For bias, last iteration of l1 acc remains in intermediate buffer, does not spill and reload
+bool determine_packer_l1_acc(bool packer_l1_acc, bool enable_bias, uint32_t in0_num_blocks_w);
+
+// L1 allocation is either for the output tensor or for Circular Buffers.
+// reader_indices_actual_page_size lets the program factory communicate the in-DRAM config tensor's
+// true per-core page size; auto-shard estimation passes std::nullopt and falls back to the worst
+// case (1 uint16 index per output row).
+conv_op_l1_usage calculate_L1_usage(
+    const DeviceComputeKernelConfig& compute_kernel_config,
+    const Conv2dBlockConfig& block_config,
+    const Conv2dParallelizationConfig& pconfig,
+    const ttnn::Shape& weights_shape,
+    const sliding_window::SlidingWindowConfig& sliding_window_config,
+    std::array<uint32_t, 2> dilation,
+    const Conv2dConfig& conv_config,
+    tt::tt_metal::DataType input_datatype,
+    tt::tt_metal::DataType output_datatype,
+    uint32_t output_image_width,
+    bool enable_bias,
+    bool is_1d_depthwise_conv,
+    uint32_t input_channels_padded,
+    bool skip_act_cb_create = false,
+    std::optional<uint32_t> reader_indices_actual_page_size = std::nullopt);
+
+Tensor conv2d(
+    const Tensor& a,
+    const Tensor& b,
+    const std::optional<const Tensor>& bias,
+    const ttnn::operations::sliding_window::SlidingWindowConfig& sliding_window_config,
+    uint32_t output_channels,
+    uint32_t groups,
+    bool untilize_out,
+    const std::optional<ttnn::operations::unary::UnaryWithParam>& activation,
+    const Conv2dParallelizationConfig& parallelization_config,
+    const Conv2dBlockConfig& block_config,
+    const tt::tt_metal::MemoryConfig& memory_config,
+    tt::tt_metal::DataType dtype,
+    std::array<std::uint32_t, 4> input_tensor_shape,
+    const ttnn::DeviceComputeKernelConfig& compute_kernel_config,
+    bool enable_act_double_buffer,
+    bool enable_weights_double_buffer,
+    bool full_inner_dim,
+    bool enable_activation_reuse,
+    bool config_tensors_in_dram,
+    std::optional<bool> force_split_reader);
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -1,0 +1,1594 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <tt_stl/assert.hpp>
+#include "tt-metalium/circular_buffer_config.hpp"
+#include "tt-metalium/core_coord.hpp"
+#include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/tt_backend_api_types.hpp"
+#include "ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp"
+#include "ttnn/operations/conv/conv2d/conv2d_utils.hpp"
+#include "ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.hpp"
+#include "ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
+#include "ttnn/operations/sliding_window/sliding_window.hpp"
+#include "ttnn/tensor/types.hpp"
+#include <tt-logger/tt-logger.hpp>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
+#include "ttnn/operations/compute_throttle_utils.hpp"
+
+namespace ttnn::prim::qsr {
+
+namespace unary = ttnn::operations::unary;
+using ttnn::operations::conv::conv_skip_mcast;
+using ttnn::operations::conv::get_num_cores_channels_from_parallel_config;
+using ttnn::operations::conv::is_1d_depthwise_conv;
+using ttnn::operations::conv::should_coalesce_1d_depthwise_conv_reads;
+using ttnn::operations::conv::SkipMcast;
+
+// Compute kernel addressing mode divides addresses with 16
+constexpr uint32_t COMPUTE_KERNEL_ADDRESS_DIVISOR = 16;
+
+struct ActivationReuseConfig {
+    uint32_t image_width_tiles = 0;
+    uint32_t image_width_mod_tile = 0;
+    uint32_t act_cb_num_tiles_split = 0;
+    uint32_t act_cb_num_tiles_split_last = 0;
+    uint32_t reuse_window_offset = 0;
+    bool readers_process_full_image_widths = false;
+    uint32_t tilized_cb_row_offset = 0;
+    uint32_t tilized_cb_second_reader_offset = 0;
+    // Configuration needed to handle cores with non-meaningful work
+    uint32_t num_cores_with_non_meaningful_work = 0;
+    std::set<CoreCoord> cores_with_non_meaningful_work;
+    bool has_partial_core = false;
+    CoreCoord partial_work_core{0, 0};
+    uint32_t partial_core_reader_tiles_to_push = 0;
+    uint32_t partial_core_writer_remaining_tiles_to_push_to_push = 0;
+    bool single_core_processes_multiple_batches = false;
+};
+
+ActivationReuseConfig calculate_activation_reuse_params(
+    uint32_t output_image_height,
+    uint32_t output_image_width,
+    uint32_t filter_w,
+    uint32_t filter_h,
+    uint32_t conv_act_c_read_bytes,
+    uint32_t act_block_w_extra_align_bytes,
+    uint32_t act_block_h_nsubblocks_split,
+    uint32_t act_block_h_nsubblocks_split_last,
+    uint32_t tilized_act_tile_size,
+    uint32_t act_block_w_ntiles,
+    uint32_t act_block_h_ntiles,
+    uint32_t single_core_height_ntiles,
+    uint32_t total_output_height_ntiles,
+    uint32_t padded_total_output_height_ntiles,
+    const std::vector<CBInfo>& cb_info,
+    bool enable_split_reader,
+    const CoreRangeSet& input_cores,
+    uint32_t batch) {
+    ActivationReuseConfig config;
+
+    // Calculate compile time args needed for activation reuse feature
+    config.image_width_tiles = tt::div_up(output_image_width, tt::constants::TILE_HEIGHT);
+    config.image_width_mod_tile = output_image_width % tt::constants::TILE_HEIGHT;
+    const uint32_t image_width_tile_leftover =
+        config.image_width_mod_tile == 0 ? 0 : tt::constants::TILE_HEIGHT - config.image_width_mod_tile;
+
+    // We rely that double buffering is turned off here
+    // TODO(sjovic): avoid this assumption
+    config.act_cb_num_tiles_split = get_cb_info_by_name(cb_info, Conv2dCb::ACT).num_pages;
+    if (enable_split_reader) {
+        config.act_cb_num_tiles_split_last = get_cb_info_by_name(cb_info, Conv2dCb::ACT_SECOND_READER).num_pages;
+    }
+
+    // Number of bytes to move the CB read pointer when passing on to the new output image row;
+    // We need to skip the first kernel_w*in_channels_padded elements
+    config.reuse_window_offset = filter_w * conv_act_c_read_bytes;
+    // In case the output image width is not a multiple of the tile height, we need to skip the additional elements
+    // we read to fill in the tile height
+    if (image_width_tile_leftover) {
+        config.reuse_window_offset +=
+            (filter_w * filter_h * conv_act_c_read_bytes + act_block_w_extra_align_bytes) * image_width_tile_leftover;
+    }
+
+    // Precompute happy path for the feature - if each reader processes full image rows only, we can skip many if
+    // conditions in the kernel. There are two cases which can affect this:
+    // - shards are split in such way that one shard ends in the middle of the image width
+    // - shards contain full image widths only, but split reader splits shard in the middle of the image width
+    // - output image width is not a multiple of the tile height, so we need to process more than one image width at
+    // once
+    config.readers_process_full_image_widths = act_block_h_nsubblocks_split % config.image_width_tiles == 0 &&
+                                               act_block_h_nsubblocks_split_last % config.image_width_tiles == 0 &&
+                                               image_width_tile_leftover == 0;
+
+    // Compute kernel interleaves tilizing data coming from two readers so it needs to calculate the address in the
+    // tilized CB
+    config.tilized_cb_row_offset = tilized_act_tile_size * act_block_w_ntiles;
+    config.tilized_cb_second_reader_offset = tilized_act_tile_size * act_block_h_nsubblocks_split * act_block_w_ntiles;
+
+    // Last cores sometime have less work to do, but we still need to push the same number of tiles
+    // to avoid blocking compute kernels; Here we compute how many cores will be pushing the remaining tiles
+    uint32_t total_remaining_tiles_to_push = padded_total_output_height_ntiles - total_output_height_ntiles;
+
+    config.num_cores_with_non_meaningful_work = tt::div_up(total_remaining_tiles_to_push, single_core_height_ntiles);
+
+    std::vector<CoreCoord> all_input_cores;
+    for (const CoreRange& range : input_cores.ranges()) {
+        for (const CoreCoord& core : range) {
+            all_input_cores.push_back(core);
+        }
+    }
+
+    // Calculate tiles for the partial core (the one core that may have less than full work)
+    uint32_t partial_core_remaining_tiles = total_remaining_tiles_to_push % single_core_height_ntiles;
+    config.has_partial_core = partial_core_remaining_tiles > 0;
+    config.partial_core_reader_tiles_to_push = partial_core_remaining_tiles;
+
+    if (partial_core_remaining_tiles > 0) {
+        if (enable_split_reader) {
+            uint32_t partial_core_act_blocks_to_push = partial_core_remaining_tiles / act_block_h_ntiles;
+            config.partial_core_reader_tiles_to_push = partial_core_act_blocks_to_push * act_block_h_nsubblocks_split;
+            config.partial_core_writer_remaining_tiles_to_push_to_push =
+                partial_core_act_blocks_to_push * act_block_h_nsubblocks_split_last;
+
+            uint32_t partial_core_leftover_tiles = partial_core_remaining_tiles % act_block_h_ntiles;
+            if (partial_core_leftover_tiles > act_block_h_nsubblocks_split_last) {
+                config.partial_core_writer_remaining_tiles_to_push_to_push += act_block_h_nsubblocks_split_last;
+                config.partial_core_reader_tiles_to_push +=
+                    partial_core_leftover_tiles - act_block_h_nsubblocks_split_last;
+            } else {
+                config.partial_core_writer_remaining_tiles_to_push_to_push += partial_core_leftover_tiles;
+            }
+        }
+        uint32_t partial_core_idx = all_input_cores.size() - config.num_cores_with_non_meaningful_work;
+        config.partial_work_core = all_input_cores[partial_core_idx];
+    }
+
+    // Put all cores with non-meaningful work to the set
+    uint32_t start_idx = all_input_cores.size() - config.num_cores_with_non_meaningful_work;
+    for (uint32_t i = start_idx; i < all_input_cores.size(); i++) {
+        config.cores_with_non_meaningful_work.insert(all_input_cores[i]);
+    }
+
+    // If we have cores processing data from more than 1 batch, we need to trigger a check inside the kernel
+    // to 'restart' the optimization and fill in the whole output image width
+    // before the reuse for the new batch starts
+    const uint32_t per_core_out_hw = single_core_height_ntiles * tt::constants::TILE_HEIGHT;
+    const uint32_t total_batch_out_hw = output_image_height * output_image_width;
+    config.single_core_processes_multiple_batches = (batch > 1) && (total_batch_out_hw % per_core_out_hw != 0);
+
+    return config;
+}
+
+namespace {
+
+// The intermediate conv_reader_indices tensor is allocated once by
+// create_workload_descriptor and parked on the WorkloadDescriptor; we receive
+// the raw Buffer* here and wire it into the READER_INDICES CB and reader CT args.
+tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
+    const Conv2dParams& operation_attributes,
+    const Conv2dInputs& tensor_args,
+    Tensor& output_tensor,
+    tt::tt_metal::Buffer* conv_reader_indices_buffer) {
+    using tt::tt_metal::CBDescriptor;
+    using tt::tt_metal::CBFormatDescriptor;
+    using tt::tt_metal::ComputeConfigDescriptor;
+    using tt::tt_metal::DataMovementConfigDescriptor;
+    using tt::tt_metal::KernelDescriptor;
+    using tt::tt_metal::ProgramDescriptor;
+    using tt::tt_metal::SemaphoreDescriptor;
+
+    ProgramDescriptor desc;
+    const auto& a = tensor_args.a;
+    const auto& b = tensor_args.b;
+
+    const auto& ashape = ttnn::Shape(operation_attributes.input_tensor_shape);
+    const auto& bias = tensor_args.bias;
+    const auto& sliding_window_config = operation_attributes.sliding_window_config;
+
+    ttnn::operations::sliding_window::ParallelConfig parallel_config{
+        .grid = a.shard_spec().value().grid,
+        .shard_scheme = a.memory_config().memory_layout(),
+        .shard_orientation = a.shard_spec().value().orientation};
+
+    std::vector<uint32_t> op_trace_metadata =
+        ttnn::operations::sliding_window::generate_op_trace_metadata(sliding_window_config);
+    std::vector<sliding_window::ShardBoundary> shard_boundaries =
+        ttnn::operations::sliding_window::generate_shard_boundaries(sliding_window_config);
+
+    const auto output_channels = operation_attributes.output_channels;
+    const auto groups = operation_attributes.groups;
+    const auto untilize_out = operation_attributes.untilize_out;
+    const auto has_bias = operation_attributes.has_bias;
+    const auto& fused_activation = operation_attributes.activation;
+    const auto& parallelization_config = operation_attributes.parallelization_config;
+    const auto& block_config = operation_attributes.block_config;
+    const auto transpose_mcast = a.shard_spec().value().orientation == ShardOrientation::COL_MAJOR;
+    auto& output = output_tensor;
+    const auto& compute_kernel_config = operation_attributes.compute_kernel_config;
+    const auto enable_act_double_buffer = operation_attributes.enable_act_double_buffer;
+    const auto enable_weights_double_buffer = operation_attributes.enable_weights_double_buffer;
+    const auto full_inner_dim = operation_attributes.full_inner_dim;
+    const auto enable_activation_reuse = operation_attributes.enable_activation_reuse;
+    const auto config_tensors_in_dram = operation_attributes.config_tensors_in_dram;
+    const auto& force_split_reader = operation_attributes.force_split_reader;
+
+    distributed::MeshDevice* device = a.device();
+    TT_FATAL(a.layout() == Layout::ROW_MAJOR, "Conv activation should be in row major layout");
+    TT_FATAL(a.memory_config().is_sharded(), "Conv activation must be sharded.");
+    TT_FATAL(output_channels <= b.padded_shape()[3], "Invalid weight shape. Incorrect weight tensor.");
+    const uint32_t act_block_h_ntiles = block_config.act_block_h_ntiles;
+    const uint32_t act_block_w_ntiles = block_config.act_block_w_ntiles;
+    const uint32_t weight_block_w_ntiles = parallelization_config.per_core_out_matrix_width_ntile;
+    const uint32_t out_block_h_ntiles = parallelization_config.per_core_out_matrix_height_ntile;
+    const uint32_t out_subblock_h_ntiles = block_config.out_subblock_h_ntiles;
+    const uint32_t out_subblock_w_ntiles = block_config.out_subblock_w_ntiles;
+
+    const SkipMcast skip_mcast = conv_skip_mcast(parallelization_config, a.memory_config().memory_layout());
+    const bool skip_activation_mcast = skip_mcast.skip_activation_mcast;
+    const bool skip_weights_mcast = skip_mcast.skip_weights_mcast;
+
+    const tt::DataFormat tilized_act_df = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), compute_kernel_config);
+
+    TT_FATAL(
+        out_block_h_ntiles >= act_block_h_ntiles,
+        "Output block height (in # of tiles) ({}) should be greater than or equal to activation block height (in # of "
+        "tiles) ({})",
+        out_block_h_ntiles,
+        act_block_h_ntiles);
+
+    // Tensor b has weights and it should be tiled layout after converting conv weights into weight matrix
+    TT_FATAL(b.layout() == Layout::TILE, "Conv weights should be in tiled layout");
+    TT_FATAL(b.padded_shape()[0] == 1, "Conv weight matrix shape is invalid");
+    TT_FATAL(b.padded_shape()[1] == 1, "Conv weight matrix shape is invalid");
+    uint32_t weight_matrix_height = b.padded_shape()[2];
+    uint32_t weight_matrix_width = b.padded_shape()[3];
+    uint32_t weight_matrix_width_ntiles = weight_matrix_width / tt::constants::TILE_WIDTH;
+
+    const std::array<uint32_t, 2> shard_shape = a.shard_spec().value().shape;
+
+    const bool block_sharded = a.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
+    const bool height_sharded = a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
+
+    // parallelization config
+    CoreRangeSet input_cores = a.memory_config().shard_spec().value().grid;
+    CoreRangeSet output_cores = output.memory_config().shard_spec().value().grid;
+    TT_ASSERT(
+        input_cores == output_cores || block_sharded,
+        "For height sharded convs input and output cores must be the same");
+
+    CoreRangeSet all_cores;
+    if (height_sharded) {
+        all_cores = CoreRangeSet(CoreRange(
+            CoreCoord(0, 0),
+            CoreCoord(parallelization_config.grid_size.x - 1, parallelization_config.grid_size.y - 1)));
+    } else {
+        all_cores = input_cores.merge(output_cores);
+    }
+
+    const uint32_t num_cores_x = parallelization_config.grid_size.x;
+    const uint32_t num_cores_y = parallelization_config.grid_size.y;
+    const uint32_t total_num_cores = all_cores.num_cores();
+
+    const uint32_t per_core_out_matrix_width_ntiles = parallelization_config.per_core_out_matrix_width_ntile;
+    const uint32_t per_core_out_matrix_height_ntiles = parallelization_config.per_core_out_matrix_height_ntile;
+
+    const bool slice_inner_dim = (height_sharded && !enable_activation_reuse) || (block_sharded && !full_inner_dim);
+
+    uint32_t conv_act_c_blocks = 1;
+    uint32_t out_conv_c_blocks = 1;
+    uint32_t input_channels_padded = shard_shape[1];
+    if (block_sharded) {
+        TT_ASSERT(input_cores.size() == 1, "Block sharded convs should have only one input core range!");
+        const uint32_t in_num_cores_x = input_cores.bounding_box().end_coord.x + 1;
+        const uint32_t in_num_cores_y = input_cores.bounding_box().end_coord.y + 1;
+
+        conv_act_c_blocks =
+            a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR ? in_num_cores_x : in_num_cores_y;
+        out_conv_c_blocks =
+            output.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR ? num_cores_x : num_cores_y;
+        if (transpose_mcast) {
+            TT_FATAL(conv_act_c_blocks == in_num_cores_y, "Expected conv_act_c_blocks to be equal to height of grid");
+            input_channels_padded = shard_shape[1] * in_num_cores_y;
+        } else {
+            TT_FATAL(conv_act_c_blocks == in_num_cores_x, "Expected conv_act_c_blocks to be equal to width of grid");
+            input_channels_padded = shard_shape[1] * in_num_cores_x;
+        }
+    }
+
+    const ttnn::Shape ashape_with_channels_padded({ashape[0], ashape[1], ashape[2], input_channels_padded});
+    uint32_t conv_act_size_w = ashape_with_channels_padded[2];
+    const uint32_t conv_act_size_c = ashape_with_channels_padded[3];
+    const uint32_t filter_h = (uint32_t)sliding_window_config.window_hw.first;   // filter_h
+    const uint32_t filter_w = (uint32_t)sliding_window_config.window_hw.second;  // filter_W
+    uint32_t pad_w = (uint32_t)sliding_window_config.get_pad_w();
+    const uint32_t dilation_h = (uint32_t)sliding_window_config.dilation_hw.first;
+    const uint32_t dilation_w = (uint32_t)sliding_window_config.dilation_hw.second;
+    const uint32_t stride_h = sliding_window_config.is_transpose ? 1 : (uint32_t)sliding_window_config.stride_hw.first;
+    const uint32_t stride_w = sliding_window_config.is_transpose ? 1 : (uint32_t)sliding_window_config.stride_hw.second;
+
+    if (sliding_window_config.is_transpose) {
+        auto input_shape = sliding_window_config.get_transposed_full_input_shape();
+        conv_act_size_w = input_shape[2];
+        pad_w = 0;
+    }
+
+    const bool is_conv_1d_depthwise_conv =
+        is_1d_depthwise_conv(groups, ashape[3], output_channels, filter_h, ashape[1], has_bias);
+    const uint32_t conv_act_c_read_bytes = conv_act_size_c * a.element_size() / conv_act_c_blocks;
+    const bool coalesce_1d_depthwise_kw_reads = should_coalesce_1d_depthwise_conv_reads(
+        is_conv_1d_depthwise_conv,
+        a.memory_config().memory_layout(),
+        input_channels_padded,
+        filter_w,
+        dilation_w,
+        a.dtype());
+    TT_FATAL(
+        !coalesce_1d_depthwise_kw_reads || filter_h == 1,
+        "Coalesced 1D depthwise reads require filter_h == 1, got {}",
+        filter_h);
+
+    const bool enable_split_reader =
+        is_split_reader_supported(a.memory_config().memory_layout(), is_conv_1d_depthwise_conv, act_block_h_ntiles) &&
+        force_split_reader.value_or(is_split_reader_viable(
+            a.memory_config().memory_layout(),
+            act_block_h_ntiles,
+            input_channels_padded,
+            filter_w,
+            tt::tt_metal::hal::get_arch(),
+            a.dtype(),
+            parallelization_config.per_core_out_matrix_width_ntile * block_config.act_block_w_ntiles,
+            tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(b.dtype())),
+            dilation_w,
+            per_core_out_matrix_height_ntiles / block_config.act_block_h_ntiles,
+            act_block_w_ntiles,
+            fp32_dest_acc_en,
+            output.dtype(),
+            enable_activation_reuse));
+    log_debug(
+        tt::LogOp,
+        "force_split_reader: {}, enable_split_reader: {}, num_blocks_act_h: {}, "
+        "per_core_out_matrix_height_ntiles: {}, act_block_h_ntiles: {}",
+        force_split_reader,
+        enable_split_reader,
+        per_core_out_matrix_height_ntiles / block_config.act_block_h_ntiles,
+        per_core_out_matrix_height_ntiles,
+        block_config.act_block_h_ntiles);
+
+    // Activation reuse validation
+    if (enable_activation_reuse) {
+        TT_FATAL(!block_sharded, "Activation data reuse is not supported for block sharded");
+        TT_FATAL(dilation_h == 1 && dilation_w == 1, "Activation data reuse is not supported for dilation > 1");
+        TT_FATAL(stride_h == 1 && stride_w == 1, "Activation data reuse is not supported for stride > 1");
+        TT_FATAL(enable_split_reader, "Activation data reuse requires split reader to be on");
+    }
+
+    TT_FATAL(input_channels_padded >= ashape[3], "Incorrect padding of input channels!");
+    if (is_conv_1d_depthwise_conv && height_sharded) {
+        const uint32_t expected_act_block_w_ntiles =
+            tt::round_up(
+                input_channels_padded * (coalesce_1d_depthwise_kw_reads ? filter_w : 1), tt::constants::TILE_WIDTH) /
+            tt::constants::TILE_WIDTH;
+        TT_FATAL(
+            act_block_w_ntiles == expected_act_block_w_ntiles,
+            "1D depthwise activation block width mismatch. Got {} tiles, expected {} tiles",
+            act_block_w_ntiles,
+            expected_act_block_w_ntiles);
+    }
+    // check is for 16-byte alignment
+    TT_FATAL(
+        // Since fp16 is smalleset data format used for halo output, 8 input_channels is enough for 16 byte alignment
+        input_channels_padded % 8 == 0,
+        "Expected input channels to be padded for 16 byte alignment in L1 ({} % 16 != 0)",
+        input_channels_padded);
+
+    const uint32_t act_matrix_height_ntiles = out_block_h_ntiles * parallelization_config.num_cores_nhw;
+    const uint32_t act_matrix_height = act_matrix_height_ntiles * tt::constants::TILE_HEIGHT;
+
+    if (has_bias) {
+        if (is_conv_1d_depthwise_conv) {
+            TT_THROW("Bias is not supported for depthwise conv1d");
+        }
+        // Tensor bias is of shape {output_channels}
+        TT_FATAL(bias.has_value(), "Bias tensor must be provided when has_bias is true");
+        TT_FATAL(bias.value().buffer() != nullptr, "Bias tensor buffer must not be null");
+        auto bias_shape_without_padding = bias.value().logical_shape();
+        TT_FATAL(bias_shape_without_padding[0] == 1, "Bias should have batch == 1");
+    }
+
+    // Tile size divisibility checks
+    TT_FATAL(
+        weight_matrix_height % tt::constants::TILE_HEIGHT == 0, "Height of weight matrix needs to be divisible by 32");
+    TT_FATAL(
+        weight_matrix_width % tt::constants::TILE_WIDTH == 0, "Width of weight matrix needs to be divisible by 32");
+
+    // Device compatibility checks
+    TT_FATAL(
+        a.storage_type() == StorageType::DEVICE && b.storage_type() == StorageType::DEVICE,
+        "Operands to large matmul need to be on device!");
+    TT_FATAL(a.device() == b.device(), "Operands to conv need to be on the same device!");
+    TT_FATAL(
+        a.buffer() != nullptr && b.buffer() != nullptr, "Operands to conv need to be allocated in buffers on device!");
+    if (has_bias) {
+        TT_FATAL(bias.value().storage_type() == StorageType::DEVICE, "Bias should be on device");
+        TT_FATAL(bias.value().device() == a.device(), "Bias should be on the same device as act tensor");
+    }
+
+    TT_FATAL(
+        act_matrix_height_ntiles % act_block_h_ntiles == 0,
+        "act_matrix_height_ntiles {} should be divisible by act_block_h_ntiles {}",
+        act_matrix_height_ntiles,
+        act_block_h_ntiles);
+    TT_FATAL(
+        weight_matrix_width_ntiles % weight_block_w_ntiles == 0,
+        "weight_matrix_width_ntiles {} should be divisible by weight_block_w_ntiles {}",
+        weight_matrix_width_ntiles,
+        weight_block_w_ntiles);
+    TT_FATAL(
+        act_matrix_height_ntiles % out_block_h_ntiles == 0,
+        "act_matrix_height_ntiles {} should be divisible by out_block_h_ntiles {}",
+        act_matrix_height_ntiles,
+        out_block_h_ntiles);
+
+    const uint32_t num_blocks_act_h = act_matrix_height_ntiles / act_block_h_ntiles;
+    const uint32_t num_blocks_act_w = is_conv_1d_depthwise_conv
+                                          ? (coalesce_1d_depthwise_kw_reads ? 1 : filter_h * filter_w)
+                                          : (slice_inner_dim ? filter_h : 1);
+    const uint32_t num_blocks_weight_w = weight_matrix_width_ntiles / weight_block_w_ntiles;
+
+    // act block info
+    uint32_t act_block_h_datums = act_matrix_height / num_blocks_act_h;
+
+    uint32_t act_block_h_nsubblocks_split = block_config.act_block_h_ntiles;
+    uint32_t act_block_h_nsubblocks_split_last = 0;
+    if (enable_split_reader) {
+        act_block_h_nsubblocks_split_last = block_config.act_block_h_ntiles / 2;
+        act_block_h_nsubblocks_split = block_config.act_block_h_ntiles - act_block_h_nsubblocks_split_last;
+    }
+    uint32_t act_block_h_datums_split = act_block_h_nsubblocks_split * tt::constants::TILE_HEIGHT;
+
+    uint32_t act_block_num_tiles_split = act_block_h_nsubblocks_split * act_block_w_ntiles;
+    uint32_t act_block_num_tiles_split_last = act_block_h_nsubblocks_split_last * act_block_w_ntiles;
+
+    // weight block info
+    uint32_t weight_block_w_datums = weight_matrix_width / num_blocks_weight_w;
+    TT_FATAL(
+        weight_block_w_ntiles % out_subblock_w_ntiles == 0,
+        "weight_block_w_ntiles {} should be divisible by weight_block_w_ntiles {}",
+        weight_block_w_ntiles,
+        out_subblock_w_ntiles);
+    uint32_t weight_num_subblocks = weight_block_w_ntiles / out_subblock_w_ntiles;
+    uint32_t weight_block_h_ntiles = is_conv_1d_depthwise_conv
+                                         ? act_block_h_ntiles * (coalesce_1d_depthwise_kw_reads ? filter_w : 1)
+                                         : act_block_w_ntiles;
+    uint32_t weight_block_num_tiles = weight_block_w_ntiles * weight_block_h_ntiles;
+
+    // writer of conv op partially removes padding on the width
+    // it removes the padding done for block width but it doesn't remove padding done for tiled width
+    uint32_t output_channels_padded_to_tile_width = tt::round_up(output_channels, tt::constants::TILE_WIDTH);
+    TT_FATAL(
+        output_channels_padded_to_tile_width <= weight_matrix_width,
+        "output_channels_padded_to_tile_width {} should be less than or equal to weight_matrix_width {}",
+        output_channels_padded_to_tile_width,
+        weight_matrix_width);
+    uint32_t last_block_width_datums = (output_channels_padded_to_tile_width % weight_block_w_datums == 0)
+                                           ? weight_block_w_datums
+                                           : (output_channels_padded_to_tile_width % weight_block_w_datums);
+    TT_FATAL(
+        last_block_width_datums % tt::constants::TILE_WIDTH == 0,
+        "last_block_width_datums {} should be divisible by TILE_WIDTH",
+        last_block_width_datums);
+
+    TT_FATAL(output.is_sharded(), "Output buffer must be sharded!");
+
+    // out
+    uint32_t out_subblock_num_tiles = out_subblock_h_ntiles * out_subblock_w_ntiles;
+    TT_FATAL(out_subblock_num_tiles <= 8, "Need to ensure that matmul partials fit in dst");
+
+    TT_FATAL(
+        act_block_h_ntiles % out_subblock_h_ntiles == 0,
+        "act_block_h_ntiles {} should be divisible by out_subblock_h_ntiles {}",
+        act_block_h_ntiles,
+        out_subblock_h_ntiles);
+
+    const uint32_t act_num_subblocks = act_block_h_ntiles / out_subblock_h_ntiles;
+    const uint32_t act_block_num_tiles = act_block_h_ntiles * act_block_w_ntiles;
+    const uint32_t act_subblock_h_ntiles = out_subblock_h_ntiles;
+    const uint32_t act_subblock_num_tiles = act_subblock_h_ntiles * act_block_w_ntiles;
+
+    const uint32_t in0_num_blocks_w = conv_act_c_blocks * num_blocks_act_w;
+
+    // weight
+    tt::tt_metal::Buffer* weights_buffer = b.buffer();
+
+    // bias
+    tt::tt_metal::Buffer* bias_buffer = nullptr;
+    uint32_t bias_ntiles = 0;
+    if (has_bias) {
+        bias_buffer = bias.value().buffer();
+        bias_ntiles =
+            bias.value().padded_shape()[3] / tt::constants::TILE_WIDTH;  // TODO: support non tile multiple sizes
+    }
+
+    const uint32_t window_outer = num_blocks_act_w;
+    const uint32_t window_inner = block_sharded ? filter_h : filter_h * filter_w / num_blocks_act_w;
+    log_debug(tt::LogOp, "window_outer: {}, window_inner: {}", window_outer, window_inner);
+
+    TT_FATAL(
+        weight_matrix_width_ntiles % per_core_out_matrix_width_ntiles == 0,
+        "weight_matrix_width_ntiles {} should be divisible by per_core_out_matrix_width_ntiles {}",
+        weight_matrix_width_ntiles,
+        per_core_out_matrix_width_ntiles);
+    TT_FATAL(
+        per_core_out_matrix_width_ntiles % weight_block_w_ntiles == 0,
+        "per_core_out_matrix_width_ntiles {} should be divisible by weight_block_w_ntiles {}",
+        per_core_out_matrix_width_ntiles,
+        weight_block_w_ntiles);
+    uint32_t num_blocks_weight_w_per_core = per_core_out_matrix_width_ntiles / weight_block_w_ntiles;
+    if (height_sharded) {
+        TT_FATAL(
+            num_blocks_weight_w_per_core == num_blocks_weight_w,
+            "num_blocks_weight_w_per_core {} should be equal to num_blocks_weight_w {}",
+            num_blocks_weight_w_per_core,
+            num_blocks_weight_w);
+    }
+    uint32_t num_weight_slices_width = weight_matrix_width_ntiles / per_core_out_matrix_width_ntiles;
+    uint32_t total_num_cores_per_weight_slice = 0;
+    if (block_sharded) {
+        if (transpose_mcast) {
+            TT_FATAL(
+                num_cores_y % num_weight_slices_width == 0,
+                "num_cores_y {} should be divisible by num_weight_slices_width {}",
+                num_cores_y,
+                num_weight_slices_width);
+            uint32_t num_cores_y_per_weight_slice_width = num_cores_y / num_weight_slices_width;
+            total_num_cores_per_weight_slice = num_cores_y_per_weight_slice_width * num_cores_x;
+        } else {
+            TT_FATAL(
+                num_cores_x % num_weight_slices_width == 0,
+                "num_cores_x {} should be divisible by num_weight_slices_width {}",
+                num_cores_x,
+                num_weight_slices_width);
+            uint32_t num_cores_x_per_weight_slice_width = num_cores_x / num_weight_slices_width;
+            total_num_cores_per_weight_slice = num_cores_x_per_weight_slice_width * num_cores_y;
+        }
+        TT_FATAL(
+            total_num_cores_per_weight_slice * per_core_out_matrix_height_ntiles == act_matrix_height_ntiles,
+            "total_num_cores_per_weight_slice {} * per_core_out_matrix_height_ntiles {} should be equal to "
+            "act_matrix_height_ntiles {}",
+            total_num_cores_per_weight_slice,
+            per_core_out_matrix_height_ntiles,
+            act_matrix_height_ntiles);
+    } else {
+        TT_FATAL(
+            num_cores_y % num_weight_slices_width == 0,
+            "num_cores_y {} should be divisible by num_weight_slices_width {}",
+            num_cores_y,
+            num_weight_slices_width);
+        uint32_t num_cores_y_per_weight_slice_width = num_cores_y / num_weight_slices_width;
+        total_num_cores_per_weight_slice = num_cores_y_per_weight_slice_width * num_cores_x;
+        TT_FATAL(
+            total_num_cores * per_core_out_matrix_height_ntiles >= act_matrix_height_ntiles,
+            "total_num_cores {} * per_core_out_matrix_height_ntiles {} should be greater than or equal to "
+            "act_matrix_height_ntiles {}",
+            total_num_cores,
+            per_core_out_matrix_height_ntiles,
+            act_matrix_height_ntiles);
+    }
+    TT_FATAL(
+        per_core_out_matrix_height_ntiles % act_block_h_ntiles == 0,
+        "per_core_out_matrix_height_ntiles {} should be divisible by act_block_h_ntiles {}",
+        per_core_out_matrix_height_ntiles,
+        act_block_h_ntiles);
+    uint32_t num_blocks_act_h_per_core = per_core_out_matrix_height_ntiles / act_block_h_ntiles;
+
+    TT_FATAL(
+        act_matrix_height_ntiles % per_core_out_matrix_height_ntiles == 0,
+        "Activation matrix height in tiles ({}) must be divisible by per-core output matrix height in tiles ({})",
+        act_matrix_height_ntiles,
+        per_core_out_matrix_height_ntiles);
+    uint32_t total_noop_cores = total_num_cores_per_weight_slice - parallelization_config.num_cores_nhw;
+    uint32_t total_active_num_cores = parallelization_config.num_cores_nhw * num_weight_slices_width;
+    TT_FATAL(!block_sharded || total_noop_cores == 0, "All cores should be active for block sharded convs");
+
+    if (has_bias) {
+        TT_FATAL(
+            bias_ntiles == weight_matrix_width_ntiles,
+            "Bias tiles ({}) must equal weight matrix width in tiles ({})",
+            bias_ntiles,
+            weight_matrix_width_ntiles);
+    }
+    uint32_t bias_ntiles_per_core = bias_ntiles / num_weight_slices_width;
+
+    const uint32_t act_block_w_logical_scalars =
+        is_conv_1d_depthwise_conv
+            ? shard_shape[1] * (coalesce_1d_depthwise_kw_reads ? filter_w : 1)
+            : (!slice_inner_dim ? shard_shape[1] * filter_h * filter_w : shard_shape[1] * filter_w);
+    uint32_t act_block_w_extra_align_bytes =
+        (tt::round_up(act_block_w_logical_scalars, tt::constants::TILE_WIDTH) - act_block_w_logical_scalars) *
+        a.element_size();
+    const uint32_t act_block_w_extra_align_scalars = act_block_w_extra_align_bytes / a.element_size();
+    // When using block float format, we must handle cases where the data doesn't align to 16-scalar boundaries.
+    // If act_block_w_extra_align_bytes contains a number of scalars that isn't a multiple of 16,
+    // we need to zero out the temporary circular buffers used during the tiling process.
+    // Failing to do this could allow residual junk data in L1 memory to corrupt valid input data.
+    const bool needs_act_block_zero_out =
+        act_block_w_extra_align_scalars % 16 != 0 && tt::tt_metal::is_block_float(output.dtype());
+
+    const uint32_t tilized_act_tile_size = tt::tile_size(tilized_act_df);
+
+    // Only enable packer l1 accumulation when there are in0_num_blocks_w > 2, otherwise
+    // unnecessary overhead for reconfigs are added. Last iteration of l1 accumulation
+    // does a spill and reload, so need more than 2 blocks to use l1 acc for packer
+    // For bias, last iteration of l1 acc remains in intermediate buffer, does not spill and reload
+    const bool packer_l1_acc_en = determine_packer_l1_acc(packer_l1_acc, has_bias, in0_num_blocks_w);
+    const uint32_t batch = sliding_window_config.get_output_shape()[0];
+    const uint32_t output_image_width = sliding_window_config.get_output_shape()[2];
+    const uint32_t output_image_height = sliding_window_config.get_output_shape()[1];
+    const uint32_t total_output_height_ntiles =
+        (batch * output_image_height * output_image_width) / tt::constants::TILE_HEIGHT;
+
+    Conv2dConfig conv_config = Conv2dConfig{
+        .weights_dtype = b.dtype(),
+        .config_tensors_in_dram = config_tensors_in_dram,
+        .shard_layout = a.memory_config().memory_layout(),
+        .output_layout = (untilize_out ? Layout::ROW_MAJOR : Layout::TILE),
+        .enable_act_double_buffer = enable_act_double_buffer,
+        .enable_weights_double_buffer = enable_weights_double_buffer,
+        .enable_activation_reuse = enable_activation_reuse,
+        .force_split_reader = force_split_reader};
+    // The conv_reader_indices tensor itself is allocated once in
+    // create_workload_descriptor and parked on workload_descriptor.buffers; we
+    // receive the raw Buffer* and read its page size for the CB sizing below.
+    // Pass the actual DRAM/L1-small config buffer page size into get_cb_info so the predicted
+    // READER_INDICES CB footprint matches the CB this factory creates. Without this, the in-DRAM
+    // path was sized to the worst case (1 uint16 per output row), holding spare L1 that is never
+    // populated by the reader kernel.
+    const uint32_t reader_indices_actual_page_size = conv_reader_indices_buffer->page_size();
+    std::vector<CBInfo> cb_info = get_cb_info(
+        compute_kernel_config,
+        block_config,
+        parallelization_config,
+        b.padded_shape(),
+        {filter_h, filter_w},
+        {sliding_window_config.input_hw.first, sliding_window_config.input_hw.second},
+        {dilation_h, dilation_w},
+        conv_config,
+        a.dtype(),
+        output.dtype(),
+        shard_shape,
+        output_image_width,
+        has_bias,
+        is_conv_1d_depthwise_conv,
+        skip_activation_mcast,
+        input_channels_padded,
+        reader_indices_actual_page_size);
+
+    // Emit CBDescriptors directly onto the ProgramDescriptor.  The framework
+    // tracks the globally-allocated CBs (ACT_SHARDED on input, OUT/PARTIALS on
+    // output, READER_INDICES on the workload-scoped indices buffer) and patches
+    // their addresses on cache hits — no per-op UpdateDynamicCircularBufferAddress
+    // override needed.
+    emit_cb_descriptors(cb_info, desc, all_cores, a.buffer(), output.buffer(), conv_reader_indices_buffer);
+
+    const uint32_t in_num_cores_x = input_cores.bounding_box().end_coord.x + 1;
+    const uint32_t in_num_cores_y = input_cores.bounding_box().end_coord.y + 1;
+
+    const CoreCoord top_left_core = {(std::size_t)0, (std::size_t)0};
+    const CoreCoord top_left_core_plus_one = {(std::size_t)1, (std::size_t)1};
+    const CoreCoord bottom_right_core = {(std::size_t)in_num_cores_x - 1, (std::size_t)in_num_cores_y - 1};
+    const CoreCoord top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
+    const CoreCoord top_left_core_plus_one_physical = device->worker_core_from_logical_core(top_left_core_plus_one);
+    const CoreCoord bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
+
+    CoreRangeSet mcast_sender_cores =
+        CoreRangeSet(CoreRange(top_left_core, top_left_core));  // If single core, this kernel doesn't do mcasting
+    CoreRangeSet mcast_receiver_cores;
+    uint32_t weights_mcast_sender_semaphore_id = 0;
+    uint32_t weights_mcast_receiver_semaphore_id = 0;
+    uint32_t act_mcast_sender_semaphore_id = 0;
+    uint32_t act_mcast_receiver_semaphore_id = 0;
+    uint32_t act_split_reader_reserve_done_semaphore_id = 0;
+    uint32_t act_split_reader_write_done_semaphore_id = 0;
+
+    // Check if we should run BRISC kernels on cores that are not in the output grid ( when split reader is enabled and
+    // the output grid is smaller than the input grid)
+    const bool populate_skipped_work_cores =
+        enable_split_reader && block_sharded && input_cores.num_cores() > output_cores.num_cores();
+
+    const bool overlap_act_cb =
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT_ROW_MAJOR_BFLOAT16).overlapped_by_cb.has_value();
+    // When split reader is enabled with overlapped CBs, both readers write to the same circular buffer.
+    // This requires synchronization between the main reader and the second reader to prevent race conditions.
+    const bool split_reader_cb_shared = enable_split_reader && overlap_act_cb && block_sharded;
+
+    // Sequential semaphore IDs match the order in which CreateSemaphore would have
+    // allocated them; the framework realises desc.semaphores in this order on cache miss.
+    auto push_semaphore = [&desc](const CoreRangeSet& cores) -> uint32_t {
+        uint32_t id = static_cast<uint32_t>(desc.semaphores.size());
+        desc.semaphores.push_back(SemaphoreDescriptor{
+            .id = id,
+            .core_ranges = cores,
+            .initial_value = 0,  // 0 == INVALID
+        });
+        return id;
+    };
+
+    if (block_sharded) {
+        const CoreCoord out_bottom_right_core = {(std::size_t)num_cores_x - 1, (std::size_t)num_cores_y - 1};
+        // 2D mcast
+        if (transpose_mcast) {
+            mcast_sender_cores = CoreRangeSet(CoreRange(top_left_core, CoreCoord(0, num_cores_y - 1)));
+            if (!skip_weights_mcast) {
+                mcast_receiver_cores = CoreRange(CoreCoord(1, 0), out_bottom_right_core);
+            }
+        } else {
+            mcast_sender_cores = CoreRangeSet(CoreRange(top_left_core, CoreCoord(num_cores_x - 1, 0)));
+            if (!skip_weights_mcast) {
+                mcast_receiver_cores = CoreRange(CoreCoord(0, 1), out_bottom_right_core);
+            }
+        }
+        if (populate_skipped_work_cores) {
+            mcast_sender_cores = input_cores.subtract(mcast_receiver_cores);
+        }
+        act_mcast_sender_semaphore_id = push_semaphore(all_cores);
+        act_mcast_receiver_semaphore_id = push_semaphore(all_cores);
+
+        if (split_reader_cb_shared) {
+            weights_mcast_sender_semaphore_id = push_semaphore(all_cores);
+            weights_mcast_receiver_semaphore_id = push_semaphore(all_cores);
+            act_split_reader_reserve_done_semaphore_id = push_semaphore(all_cores);
+            act_split_reader_write_done_semaphore_id = push_semaphore(all_cores);
+        } else {
+            weights_mcast_sender_semaphore_id = push_semaphore(output_cores);
+            weights_mcast_receiver_semaphore_id = push_semaphore(output_cores);
+        }
+    } else {
+        // 1D mcast
+        if (!skip_weights_mcast) {
+            mcast_receiver_cores = all_cores.subtract(mcast_sender_cores);
+            weights_mcast_sender_semaphore_id = push_semaphore(output_cores);
+            weights_mcast_receiver_semaphore_id = push_semaphore(output_cores);
+        }
+    }
+
+    // 1D depthwise compute uses dest-reuse for accumulation — no MATMUL_PARTIALS CB is allocated.
+    const bool partials_cb_uses_output =
+        !is_conv_1d_depthwise_conv && get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).is_globally_allocated;
+    log_debug(tt::LogOp, "partials_cb_uses_output: {}", partials_cb_uses_output);
+
+    std::string reader_kernel;
+    std::string compute_kernel =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_bmm_tilize.cpp";
+    std::string writer_mcast_sender_kernel =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/"
+        "reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp";
+    std::string writer_mcast_receiver_kernel =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/"
+        "reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp";
+
+    if (!is_conv_1d_depthwise_conv && block_sharded) {
+        // Block sharded conv
+        reader_kernel =
+            "ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/"
+            "reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp";
+        writer_mcast_sender_kernel =
+            "ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/"
+            "writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp";
+        writer_mcast_receiver_kernel =
+            "ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/"
+            "writer_tiled_out_2d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp";
+    } else if (is_conv_1d_depthwise_conv) {
+        // 1D Depthwise Conv (height sharded)
+        compute_kernel =
+            "ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/compute_depthwise_conv1d.cpp";
+        reader_kernel =
+            "ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/reader_depthwise_conv1d.cpp";
+    } else {
+        // Height sharded conv
+        reader_kernel =
+            "ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/"
+            "reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp";
+    }
+
+    uint32_t reader_arg_act_block_h_datums = (enable_split_reader ? act_block_h_datums_split : act_block_h_datums);
+    TT_FATAL(reader_arg_act_block_h_datums % 2 == 0, "2 Indices are packed in one uint32_t word.");
+
+    ActivationReuseConfig activation_reuse_config;
+    if (enable_activation_reuse) {
+        activation_reuse_config = calculate_activation_reuse_params(
+            output_image_height,
+            output_image_width,
+            filter_w,
+            filter_h,
+            conv_act_c_read_bytes,
+            act_block_w_extra_align_bytes,
+            act_block_h_nsubblocks_split,
+            act_block_h_nsubblocks_split_last,
+            tilized_act_tile_size,
+            act_block_w_ntiles,
+            act_block_h_ntiles,
+            out_block_h_ntiles,
+            total_output_height_ntiles,
+            act_matrix_height_ntiles,
+            cb_info,
+            enable_split_reader,
+            input_cores,
+            batch);
+    }
+
+    std::vector<uint32_t> reader_compile_time_args = {
+        (uint32_t)dilation_h,
+        (uint32_t)dilation_w,
+        (uint32_t)stride_w,
+        (uint32_t)conv_act_c_read_bytes,
+        (uint32_t)window_outer,
+        (uint32_t)window_inner,
+        (uint32_t)(enable_split_reader && !split_reader_cb_shared ? act_block_num_tiles_split : act_block_num_tiles),
+        (uint32_t)filter_h,
+        (uint32_t)filter_w,
+        (uint32_t)conv_act_size_w + (pad_w),
+        (uint32_t)act_block_w_extra_align_bytes,                          // only used for 1d systolic variant
+        (uint32_t)num_blocks_act_h_per_core,                              // act_num_blocks_h
+        (uint32_t)act_block_num_tiles,                                    // act_block_num_tiles
+        (uint32_t)conv_act_c_blocks,                                      // act_w_num_outer
+        (uint32_t)(transpose_mcast ? num_cores_y - 1 : num_cores_x - 1),  // act_mcast_num_dests
+        (uint32_t)(transpose_mcast ? num_cores_y - 1 : num_cores_x - 1),  // act_mcast_num_cores
+        (uint32_t)act_mcast_sender_semaphore_id,
+        (uint32_t)act_mcast_receiver_semaphore_id,
+        (uint32_t)tilized_act_tile_size,  // act_mcast_tile_size_bytes
+        (uint32_t)(transpose_mcast ? 1 : 0),
+        (uint32_t)needs_act_block_zero_out,  // zero_out_act_cb
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT_SHARDED).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT_TILIZED).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT_ROW_MAJOR_BFLOAT16).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::L1_ARRAY).index,
+        (uint32_t)enable_split_reader,
+        (uint32_t)(is_conv_1d_depthwise_conv ? coalesce_1d_depthwise_kw_reads : enable_activation_reuse)};
+
+    std::map<std::string, std::string> reader_defines;
+    std::map<std::string, std::string> writer_defines;
+    std::map<std::string, std::string> writer_mcast_sender_defines;
+    std::map<std::string, std::string> compute_defines;
+
+    if (config_tensors_in_dram) {
+        reader_defines["CONFIG_TENSOR_IN_DRAM"] = "1";
+        writer_defines["CONFIG_TENSOR_IN_DRAM"] = "1";               // Needed for split reader
+        writer_mcast_sender_defines["CONFIG_TENSOR_IN_DRAM"] = "1";  // Needed for split reader
+        reader_compile_time_args.push_back(conv_reader_indices_buffer->address());
+        reader_compile_time_args.push_back(conv_reader_indices_buffer->page_size());
+        tt::tt_metal::TensorAccessorArgs(conv_reader_indices_buffer).append_to(reader_compile_time_args);
+    } else {
+        // Put enough 0s so that the offsets of activation reuse args are the same.
+        // TensorAccessorArgs appends 2 CT args (is_dram + aligned_page_size), so we need 4 zeros total
+        // (address + page_size + 2 TensorAccessorArgs) to match the DRAM path.
+        reader_compile_time_args.push_back(0);
+        reader_compile_time_args.push_back(0);
+        reader_compile_time_args.push_back(0);
+        reader_compile_time_args.push_back(0);
+    }
+
+    if (enable_activation_reuse) {
+        std::vector<uint32_t> activation_reuse_args = {
+            activation_reuse_config.act_cb_num_tiles_split,
+            act_block_w_ntiles,
+            static_cast<uint32_t>(activation_reuse_config.readers_process_full_image_widths),
+            activation_reuse_config.image_width_tiles,
+            output_image_width,
+            activation_reuse_config.reuse_window_offset,
+            static_cast<uint32_t>(activation_reuse_config.num_cores_with_non_meaningful_work > 0),
+            static_cast<uint32_t>(activation_reuse_config.single_core_processes_multiple_batches)};
+
+        reader_compile_time_args.insert(
+            reader_compile_time_args.end(), activation_reuse_args.begin(), activation_reuse_args.end());
+    } else if (height_sharded) {
+        // Add dummy activation reuse arguments when not enabled
+        std::vector<uint32_t> activation_reuse_dummy_args(8, 0);
+        reader_compile_time_args.insert(
+            reader_compile_time_args.end(), activation_reuse_dummy_args.begin(), activation_reuse_dummy_args.end());
+    }
+
+    if (split_reader_cb_shared) {
+        reader_compile_time_args.push_back(static_cast<uint32_t>(split_reader_cb_shared));
+        reader_compile_time_args.push_back(act_split_reader_reserve_done_semaphore_id);
+        reader_compile_time_args.push_back(act_split_reader_write_done_semaphore_id);
+    } else if (block_sharded) {
+        reader_compile_time_args.push_back(static_cast<uint32_t>(split_reader_cb_shared));
+        reader_compile_time_args.push_back(0);
+        reader_compile_time_args.push_back(0);
+    }
+    if (skip_activation_mcast) {
+        reader_defines["SKIP_MCAST"] = "1";
+    }
+    if (skip_weights_mcast) {
+        writer_mcast_sender_defines["SKIP_MCAST"] = "1";
+    }
+    bool pack_relu = fused_activation.has_value() && fused_activation.value().op_type == unary::UnaryOpType::RELU;
+    if (fused_activation.has_value() && !pack_relu) {
+        compute_defines.merge(ttnn::operations::unary::utils::get_defines(
+            fused_activation.value().op_type, fused_activation.value().params, "ACTIVATION", "i"));
+    }
+    if (enable_split_reader) {
+        compute_defines["SPLIT_READER"] = "1";
+        reader_defines["SPLIT_READER"] = "1";
+        writer_mcast_sender_defines["SPLIT_READER"] = "1";
+        writer_defines["SPLIT_READER"] = "1";
+    }
+
+    if (enable_activation_reuse) {
+        reader_defines["ACTIVATION_REUSE"] = "1";
+        writer_mcast_sender_defines["ACTIVATION_REUSE"] = "1";
+        writer_defines["ACTIVATION_REUSE"] = "1";
+    }
+
+    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
+        device->arch(), output_cores.num_cores(), compute_defines, ttnn::get_throttle_level(compute_kernel_config));
+
+    for (auto elem : compute_defines) {
+        log_trace(tt::LogOp, "compute_defines: {} = {}", elem.first, elem.second);
+    }
+
+    std::vector<uint32_t> writer_compile_time_args = {
+        get_cb_info_by_name(cb_info, Conv2dCb::WEIGHTS).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::BIAS).index,
+        (uint32_t)(bias_buffer == nullptr ? 0 : (bias_buffer->buffer_type() == BufferType::DRAM ? 1 : 0)),
+        get_cb_info_by_name(cb_info, (split_reader_cb_shared ? Conv2dCb::ACT : Conv2dCb::ACT_SECOND_READER)).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT_SHARDED).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).index,
+        num_blocks_act_w,
+        weight_block_num_tiles,
+        conv_act_c_blocks,
+        weight_block_h_ntiles,
+        weight_block_w_ntiles,
+        weight_matrix_width_ntiles,
+        weight_matrix_width_ntiles * weight_block_h_ntiles,
+        weight_block_w_ntiles,
+
+        // bias
+        bias_ntiles_per_core,
+
+        num_blocks_act_h_per_core,
+        num_blocks_weight_w_per_core,
+        out_conv_c_blocks,
+        (uint32_t)has_bias,
+        (uint32_t)enable_split_reader,
+        (uint32_t)(enable_activation_reuse && height_sharded)};
+
+    std::vector<uint32_t> split_reader_args = {
+        (uint32_t)act_block_num_tiles_split_last,
+        (uint32_t)conv_act_c_read_bytes,
+        (uint32_t)filter_w,                       // weight_size_w
+        (uint32_t)(conv_act_size_w + pad_w),      // conv_act_size_w_padded
+        (uint32_t)act_block_w_extra_align_bytes,  // only used for 1d systolic variant
+        (uint32_t)needs_act_block_zero_out,
+        (uint32_t)dilation_h,
+        (uint32_t)dilation_w,
+        (uint32_t)stride_w,
+        (uint32_t)filter_h};
+
+    if (block_sharded) {
+        split_reader_args.push_back(static_cast<uint32_t>(split_reader_cb_shared));
+    }
+    if (split_reader_cb_shared) {
+        const tt::DataFormat img2col_cb_df = get_cb_info_by_name(cb_info, Conv2dCb::ACT_ROW_MAJOR_BFLOAT16).data_format;
+
+        const uint32_t img2col_cb_tile_size = tt::tile_size(img2col_cb_df);
+        const uint32_t act_cb_id_stride =
+            skip_activation_mcast ? 1 : 1 + get_num_cores_channels_from_parallel_config(parallel_config);
+        // get total number of blocks in the ACT CB so that we can compute the loop around when moving write
+        // pointer in second reader
+        const uint32_t act_cb_block_cnt = get_cb_info_by_name(cb_info, Conv2dCb::ACT).num_pages /
+                                          (act_block_num_tiles_split + act_block_num_tiles_split_last);
+
+        // In cases where the overlapped buffer is double buffered and number of push_backs done on NCRISC is odd,
+        // there are two addresses that need to be written to on the BRISC side for the second reader.
+        const bool second_writer_two_addr = (act_cb_block_cnt > 1) && (act_cb_id_stride % 2 == 1);
+        const uint32_t act_write_offset = act_block_num_tiles_split * img2col_cb_tile_size;
+        const uint32_t act_write_offset_last =
+            second_writer_two_addr
+                ? (act_block_num_tiles_split_last + 2 * act_block_num_tiles_split) * img2col_cb_tile_size
+                : act_write_offset;
+        split_reader_args.push_back(act_split_reader_reserve_done_semaphore_id);
+        split_reader_args.push_back(act_split_reader_write_done_semaphore_id);
+        split_reader_args.push_back(act_write_offset);
+        split_reader_args.push_back(act_write_offset_last);
+    } else if (block_sharded) {
+        split_reader_args.push_back(0);
+        split_reader_args.push_back(0);
+        split_reader_args.push_back(0);
+        split_reader_args.push_back(0);
+    }
+
+    if (enable_activation_reuse && height_sharded) {
+        std::vector<uint32_t> activation_reuse_args = {
+            activation_reuse_config.act_cb_num_tiles_split_last,
+            act_block_w_ntiles,
+            static_cast<uint32_t>(activation_reuse_config.readers_process_full_image_widths),
+            activation_reuse_config.image_width_tiles,
+            output_image_width,
+            activation_reuse_config.reuse_window_offset,
+            static_cast<uint32_t>(activation_reuse_config.num_cores_with_non_meaningful_work > 0),
+            static_cast<uint32_t>(activation_reuse_config.single_core_processes_multiple_batches)};
+        split_reader_args.insert(split_reader_args.end(), activation_reuse_args.begin(), activation_reuse_args.end());
+    } else if (height_sharded) {
+        // Add dummy activation reuse arguments when not enabled
+        std::vector<uint32_t> activation_reuse_dummy_args(8, 0);
+        split_reader_args.insert(
+            split_reader_args.end(), activation_reuse_dummy_args.begin(), activation_reuse_dummy_args.end());
+    }
+    writer_compile_time_args.insert(writer_compile_time_args.end(), split_reader_args.begin(), split_reader_args.end());
+    tt::tt_metal::TensorAccessorArgs(b.buffer()).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(bias ? bias->buffer() : nullptr).append_to(writer_compile_time_args);
+
+    const bool check_skip_compute = input_cores != output_cores;
+
+    std::vector<uint32_t> compute_kernel_args;
+    if (is_conv_1d_depthwise_conv) {
+        // compute_depthwise_conv1d.cpp uses a specialized dest-reuse accumulation path. The last
+        // two args select the coalesced kernel-width activation layout when the reader can fetch
+        // all kernel-width sticks as one NoC packet.
+        compute_kernel_args = {
+            act_block_w_ntiles,                                         // 0: in0_block_w
+            act_num_subblocks,                                          // 1: in0_num_subblocks
+            act_block_num_tiles,                                        // 2: in0_block_num_tiles
+            num_blocks_act_h_per_core,                                  // 3: in0_num_blocks_h
+            in0_num_blocks_w,                                           // 4: in0_num_blocks_w
+            get_cb_info_by_name(cb_info, Conv2dCb::ACT).index,          // 5: in0_cb_id (raw RM)
+            get_cb_info_by_name(cb_info, Conv2dCb::WEIGHTS).index,      // 6: in1_cb_id
+            get_cb_info_by_name(cb_info, Conv2dCb::ACT_TILIZED).index,  // 7: tilized_in0_cb_id
+            get_cb_info_by_name(cb_info, Conv2dCb::OUT).index,          // 8: out_cb_id
+            filter_w,                                                   // 9: kernel_width
+            coalesce_1d_depthwise_kw_reads,                             // 10: coalesced activation block
+        };
+    } else {
+        compute_kernel_args = {
+            act_block_w_ntiles,
+            act_num_subblocks,
+            act_block_num_tiles,
+            act_subblock_num_tiles,
+            enable_split_reader ? act_block_h_ntiles
+                                : act_subblock_h_ntiles * act_num_subblocks,  // reader_num_h_subblocks
+            weight_num_subblocks,
+            weight_block_num_tiles,
+            weight_block_w_ntiles,
+
+            num_blocks_act_h_per_core,
+            in0_num_blocks_w,
+            num_blocks_weight_w_per_core,
+
+            out_subblock_h_ntiles,
+            out_subblock_w_ntiles,
+            out_subblock_num_tiles,
+
+            height_sharded,
+            untilize_out,
+
+            bias_ntiles_per_core,
+
+            get_cb_info_by_name(cb_info, Conv2dCb::BIAS).index,
+            get_cb_info_by_name(cb_info, Conv2dCb::ACT).index,
+            get_cb_info_by_name(cb_info, Conv2dCb::WEIGHTS).index,
+            get_cb_info_by_name(cb_info, Conv2dCb::ACT_ROW_MAJOR_BFLOAT16).index,
+            get_cb_info_by_name(cb_info, Conv2dCb::ACT_SECOND_READER).index,
+            get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).index,
+            get_cb_info_by_name(cb_info, Conv2dCb::ACT_TILIZED).index,
+            get_cb_info_by_name(cb_info, Conv2dCb::OUT).index,
+            partials_cb_uses_output,
+            conv_act_c_blocks,
+            check_skip_compute,
+            pack_relu,
+            weight_block_w_ntiles <= 8,  // packer_untilize
+            packer_l1_acc_en,
+            has_bias,
+            enable_split_reader,
+            enable_activation_reuse};
+
+        if (enable_activation_reuse) {
+            compute_kernel_args.push_back(activation_reuse_config.image_width_tiles);
+            compute_kernel_args.push_back(activation_reuse_config.reuse_window_offset / COMPUTE_KERNEL_ADDRESS_DIVISOR);
+            compute_kernel_args.push_back(
+                activation_reuse_config.tilized_cb_row_offset / COMPUTE_KERNEL_ADDRESS_DIVISOR);
+            compute_kernel_args.push_back(
+                activation_reuse_config.tilized_cb_second_reader_offset / COMPUTE_KERNEL_ADDRESS_DIVISOR);
+        } else {
+            std::vector<uint32_t> activation_reuse_dummy_args = {0, 0, 0, 0};
+            compute_kernel_args.insert(
+                compute_kernel_args.end(), activation_reuse_dummy_args.begin(), activation_reuse_dummy_args.end());
+        }
+        compute_kernel_args.push_back(static_cast<uint32_t>(split_reader_cb_shared));
+    }
+
+    const tt::tt_metal::NOC writer_mcast_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+    const tt::tt_metal::NOC reader_noc =
+        writer_mcast_noc == tt::tt_metal::NOC::NOC_0 ? tt::tt_metal::NOC::NOC_1 : tt::tt_metal::NOC::NOC_0;
+
+    // Build the writer_mcast_sender kernel descriptor (placed on mcast_sender_cores).
+    // We build runtime_args below after kernel placement is fixed.
+    KernelDescriptor writer_mcast_sender_desc;
+    writer_mcast_sender_desc.kernel_source = writer_mcast_sender_kernel;
+    writer_mcast_sender_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_mcast_sender_desc.core_ranges = mcast_sender_cores;
+    writer_mcast_sender_desc.compile_time_args = writer_compile_time_args;
+    for (const auto& [k, v] : writer_mcast_sender_defines) {
+        writer_mcast_sender_desc.defines.emplace_back(k, v);
+    }
+    writer_mcast_sender_desc.config = DataMovementConfigDescriptor{
+        .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+        .noc = writer_mcast_noc,
+    };
+
+    // Optional writer_mcast_receiver kernel (created only when weights mcast is not skipped).
+    KernelDescriptor writer_mcast_receiver_desc;
+    const bool create_writer_mcast_receiver = !skip_weights_mcast;
+    if (create_writer_mcast_receiver) {
+        writer_mcast_receiver_desc.kernel_source = writer_mcast_receiver_kernel;
+        writer_mcast_receiver_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        writer_mcast_receiver_desc.core_ranges = mcast_receiver_cores;
+        writer_mcast_receiver_desc.compile_time_args = writer_compile_time_args;
+        for (const auto& [k, v] : writer_defines) {
+            writer_mcast_receiver_desc.defines.emplace_back(k, v);
+        }
+        writer_mcast_receiver_desc.config = DataMovementConfigDescriptor{
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = writer_mcast_noc,
+        };
+    }
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = reader_kernel;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = height_sharded ? input_cores : all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    for (const auto& [k, v] : reader_defines) {
+        reader_desc.defines.emplace_back(k, v);
+    }
+    reader_desc.config = DataMovementConfigDescriptor{
+        .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+        .noc = reader_noc,
+    };
+
+    KernelDescriptor compute_kernel_desc;
+    compute_kernel_desc.kernel_source = compute_kernel;
+    compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_kernel_desc.core_ranges = height_sharded ? input_cores : all_cores;
+    compute_kernel_desc.compile_time_args = std::move(compute_kernel_args);
+    for (const auto& [k, v] : compute_defines) {
+        compute_kernel_desc.defines.emplace_back(k, v);
+    }
+    compute_kernel_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+    };
+
+    // Helper lambda to setup mcast arguments
+    auto setup_mcast_args = [&](bool is_noc_0, uint32_t start_x, uint32_t start_y, uint32_t end_x, uint32_t end_y) {
+        return is_noc_0 ? std::vector<uint32_t>{start_x, start_y, end_x, end_y}
+                        : std::vector<uint32_t>{end_x, end_y, start_x, start_y};
+    };
+
+    // Setup reader runtime arguments
+    if (block_sharded) {
+        const uint32_t in_num_cores_x = input_cores.bounding_box().end_coord.x + 1;
+        const uint32_t in_num_cores_y = input_cores.bounding_box().end_coord.y + 1;
+        std::vector<uint32_t> act_mcast_noc_y;
+        if (transpose_mcast) {
+            act_mcast_noc_y.reserve(in_num_cores_y);
+            for (uint32_t core_idx_y = 0; core_idx_y < in_num_cores_y; ++core_idx_y) {
+                act_mcast_noc_y.push_back(device->worker_core_from_logical_core({0, core_idx_y}).y);
+            }
+        } else {
+            // NOTE: using same var for x as well, this is intentional
+            act_mcast_noc_y.reserve(in_num_cores_x);
+            for (int32_t core_idx_x = 0; core_idx_x < in_num_cores_x; ++core_idx_x) {
+                act_mcast_noc_y.push_back(device->worker_core_from_logical_core({core_idx_x, 0}).x);
+            }
+        }
+
+        const CoreCoord out_bottom_right_core = {(std::size_t)num_cores_x - 1, (std::size_t)num_cores_y - 1};
+        const CoreCoord out_bottom_right_core_physical = device->worker_core_from_logical_core(out_bottom_right_core);
+        const bool reader_is_noc_0 = reader_noc == tt::tt_metal::NOC::NOC_0;
+
+        for (const CoreRange& core_range : all_cores.ranges()) {
+            for (const CoreCoord& core : core_range) {
+                const bool is_receiver_core = output_cores.contains(core);
+                const bool is_sender_core = input_cores.contains(core);
+                std::vector<uint32_t> reader_rt_args;
+                if (transpose_mcast) {
+                    CoreCoord bottom_core = {(std::size_t)core.x, (std::size_t)num_cores_y - 1};
+                    CoreCoord bottom_core_physical = device->worker_core_from_logical_core(bottom_core);
+
+                    reader_rt_args = setup_mcast_args(
+                        reader_is_noc_0,
+                        bottom_core_physical.x,
+                        top_left_core_physical.y,
+                        bottom_core_physical.x,
+                        bottom_core_physical.y);
+
+                    reader_rt_args.push_back(core.y);                  // act_mcast_sender_id
+                    reader_rt_args.push_back(bottom_core_physical.x);  // act_mcast_sender_noc_x
+                } else {
+                    CoreCoord core_physical = device->worker_core_from_logical_core(core);
+
+                    reader_rt_args = setup_mcast_args(
+                        reader_is_noc_0,
+                        top_left_core_physical.x,
+                        core_physical.y,
+                        out_bottom_right_core_physical.x,
+                        core_physical.y);
+                    reader_rt_args.push_back(core.x);           // act_mcast_sender_id
+                    reader_rt_args.push_back(core_physical.y);  // act_mcast_sender_noc_x
+                }
+                reader_rt_args.push_back(static_cast<uint32_t>(is_receiver_core));  // is_receiver_core
+                reader_rt_args.push_back(static_cast<uint32_t>(is_sender_core));    // is_receiver_core
+                reader_rt_args.push_back(transpose_mcast ? core.x : core.y);        // dram config reader index
+                reader_rt_args.insert(reader_rt_args.end(), act_mcast_noc_y.begin(), act_mcast_noc_y.end());
+                reader_desc.runtime_args.emplace_back(core, std::move(reader_rt_args));
+            }
+        }
+    } else {
+        uint32_t core_index = 0;
+        for (const CoreRange& core_range : input_cores.ranges()) {
+            for (const CoreCoord& core : core_range) {
+                uint32_t reader_remaining_tiles_to_push = 0;
+                if (enable_activation_reuse) {
+                    if (activation_reuse_config.has_partial_core && core == activation_reuse_config.partial_work_core) {
+                        reader_remaining_tiles_to_push = activation_reuse_config.partial_core_reader_tiles_to_push;
+                    } else if (activation_reuse_config.cores_with_non_meaningful_work.contains(core)) {
+                        reader_remaining_tiles_to_push = act_block_h_nsubblocks_split;
+                    }
+                }
+                std::vector<uint32_t> reader_rt_args{core_index, reader_remaining_tiles_to_push};
+                reader_desc.runtime_args.emplace_back(core, std::move(reader_rt_args));
+                core_index++;
+            }
+        }
+    }
+
+    // Setup writer mcast arguments
+    // Setup sender args first.  runtime_args[0] is the weight buffer address and
+    // runtime_args[1] is the (optional) bias buffer address; both are registered
+    // as Buffer* bindings via emplace_runtime_args so the framework's fast
+    // cache-hit path patches addresses without GetRuntimeArgs.  When bias is
+    // absent we embed a literal 0 — has_bias gates the bias read on the kernel
+    // side.
+    for (const CoreRange& core_range : mcast_sender_cores.ranges()) {
+        for (const CoreCoord& core : core_range) {
+            if (populate_skipped_work_cores && !output_cores.contains(core)) {
+                // Pad-out path: 14 zeros with only the semaphore/bias-flag slots
+                // populated.  weight/bias addresses are unused for skipped work
+                // cores so we keep them as literal zeros (no buffer binding).
+                KernelDescriptor::RTArgList args;
+                args.reserve(14);
+                args.push_back(uint32_t{0});  // 0: weight addr (unused for skipped cores)
+                args.push_back(uint32_t{0});  // 1: bias addr (unused)
+                for (int i = 2; i < 10; ++i) {
+                    args.push_back(uint32_t{0});
+                }
+                args.push_back(weights_mcast_sender_semaphore_id);
+                args.push_back(weights_mcast_receiver_semaphore_id);
+                args.push_back(uint32_t{1});  // is_sender_core, always true for input_cores
+                args.push_back(uint32_t{1});  // skip_work
+                writer_mcast_sender_desc.emplace_runtime_args(core, args);
+                continue;
+            }
+            // Calculate weight slice indices
+            uint32_t weight_slice_i = ((block_sharded && transpose_mcast) || !block_sharded) ? core.y : core.x;
+
+            uint32_t out_start_tile_id_w = weight_slice_i * per_core_out_matrix_width_ntiles;
+            uint32_t bias_tile_offset = out_start_tile_id_w;
+
+            TT_FATAL(
+                bias_tile_offset < bias_ntiles || !has_bias,
+                "bias_tile_offset {} should be less than bias_ntiles {}",
+                bias_tile_offset,
+                bias_ntiles);
+
+            KernelDescriptor::RTArgList sender_rt_args;
+            sender_rt_args.push_back(weights_buffer);  // 0: weight buffer address (Buffer* binding)
+            if (bias_buffer != nullptr) {
+                sender_rt_args.push_back(bias_buffer);  // 1: bias buffer address (Buffer* binding)
+            } else {
+                sender_rt_args.push_back(uint32_t{0});  // 1: bias placeholder (has_bias gates the read)
+            }
+            sender_rt_args.push_back(out_start_tile_id_w);  // 2
+            sender_rt_args.push_back(bias_tile_offset);     // 3
+
+            if (block_sharded) {
+                const bool is_sender_core = input_cores.contains(core);
+                // 2D multicast setup
+                if (transpose_mcast) {
+                    CoreCoord right_core = {(std::size_t)num_cores_x - 1, (std::size_t)core.y};
+                    CoreCoord right_core_physical = device->worker_core_from_logical_core(right_core);
+                    TT_FATAL(core.x == 0, "Expected core.x to be 0 for sender in 2D mcast setup");
+
+                    std::vector<uint32_t> mcast_coords = setup_mcast_args(
+                        writer_mcast_noc == tt::tt_metal::NOC::NOC_0,
+                        top_left_core_plus_one_physical.x,
+                        right_core_physical.y,
+                        bottom_right_core_physical.x,
+                        right_core_physical.y);
+
+                    sender_rt_args.append(mcast_coords);
+                    sender_rt_args.push_back(num_cores_x - 1);  // mcast_num_dests
+                    sender_rt_args.push_back(num_cores_x - 1);  // mcast_num_cores
+                    sender_rt_args.push_back(weights_mcast_sender_semaphore_id);
+                    sender_rt_args.push_back(weights_mcast_receiver_semaphore_id);
+                    sender_rt_args.push_back(static_cast<uint32_t>(is_sender_core));
+                    sender_rt_args.push_back(uint32_t{0});  // skip_work
+                    writer_mcast_sender_desc.emplace_runtime_args(core, sender_rt_args);
+                } else {
+                    CoreCoord top_core = {(std::size_t)core.x, 0};
+                    CoreCoord top_core_physical = device->worker_core_from_logical_core(top_core);
+                    TT_FATAL(core.y == 0, "Expected core.y to be 0 for sender in 2D mcast setup");
+                    std::vector<uint32_t> mcast_coords = setup_mcast_args(
+                        writer_mcast_noc == tt::tt_metal::NOC::NOC_0,
+                        top_core_physical.x,
+                        top_left_core_plus_one_physical.y,
+                        top_core_physical.x,
+                        bottom_right_core_physical.y);
+
+                    sender_rt_args.append(mcast_coords);
+                    sender_rt_args.push_back(num_cores_y - 1);  // mcast_num_dests
+                    sender_rt_args.push_back(num_cores_y - 1);  // mcast_num_cores
+                    sender_rt_args.push_back(weights_mcast_sender_semaphore_id);
+                    sender_rt_args.push_back(weights_mcast_receiver_semaphore_id);
+                    sender_rt_args.push_back(static_cast<uint32_t>(is_sender_core));
+                    sender_rt_args.push_back(uint32_t{0});  // skip_work
+                    writer_mcast_sender_desc.emplace_runtime_args(core, sender_rt_args);
+                }
+            } else {
+                // 1D multicast setup
+                std::vector<uint32_t> mcast_coords = setup_mcast_args(
+                    writer_mcast_noc == tt::tt_metal::NOC::NOC_0,
+                    top_left_core_physical.x,
+                    top_left_core_physical.y,
+                    bottom_right_core_physical.x,
+                    bottom_right_core_physical.y);
+
+                sender_rt_args.append(mcast_coords);
+                sender_rt_args.push_back(total_active_num_cores - 1);  // mcast_num_dests
+                sender_rt_args.push_back(total_num_cores - 1);         // mcast_num_cores
+                sender_rt_args.push_back(weights_mcast_sender_semaphore_id);
+                sender_rt_args.push_back(weights_mcast_receiver_semaphore_id);
+                if (enable_activation_reuse) {
+                    uint32_t writer_remaining_tiles_to_push = 0;
+                    if (activation_reuse_config.has_partial_core && core == activation_reuse_config.partial_work_core) {
+                        writer_remaining_tiles_to_push =
+                            activation_reuse_config.partial_core_writer_remaining_tiles_to_push_to_push;
+                    } else if (activation_reuse_config.cores_with_non_meaningful_work.contains(core)) {
+                        writer_remaining_tiles_to_push = act_block_h_nsubblocks_split_last;
+                    }
+                    sender_rt_args.push_back(writer_remaining_tiles_to_push);
+                }
+                writer_mcast_sender_desc.emplace_runtime_args(core, sender_rt_args);
+            }
+        }
+    }
+
+    // Setup receiver args second
+    if (create_writer_mcast_receiver) {
+        for (const CoreRange& core_range : mcast_receiver_cores.ranges()) {
+            // Helper lambda to create receiver runtime args
+            auto create_receiver_args = [&](uint32_t sender_noc_x, uint32_t sender_noc_y) {
+                return std::vector<uint32_t>{
+                    sender_noc_x, sender_noc_y, weights_mcast_sender_semaphore_id, weights_mcast_receiver_semaphore_id};
+            };
+
+            for (const CoreCoord& core : core_range) {
+                std::vector<uint32_t> receiver_args;
+                if (block_sharded) {
+                    if (transpose_mcast) {
+                        CoreCoord right_core = {(std::size_t)num_cores_x - 1, (std::size_t)core.y};
+                        CoreCoord right_core_physical = device->worker_core_from_logical_core(right_core);
+                        receiver_args = create_receiver_args(top_left_core_physical.x, right_core_physical.y);
+                    } else {
+                        CoreCoord top_core = {(std::size_t)core.x, 0};
+                        CoreCoord top_core_physical = device->worker_core_from_logical_core(top_core);
+                        receiver_args = create_receiver_args(top_core_physical.x, top_left_core_physical.y);
+                    }
+                    const bool is_sender_core = input_cores.contains(core);
+                    receiver_args.push_back(static_cast<uint32_t>(is_sender_core));
+                } else {
+                    bool is_no_op_core = !input_cores.contains(core);
+                    receiver_args = std::vector<uint32_t>{
+                        static_cast<uint32_t>(is_no_op_core),
+                        top_left_core_physical.x,
+                        top_left_core_physical.y,
+                        weights_mcast_sender_semaphore_id,
+                        weights_mcast_receiver_semaphore_id};
+                    if (enable_activation_reuse) {
+                        uint32_t writer_remaining_tiles_to_push = 0;
+                        if (activation_reuse_config.has_partial_core &&
+                            core == activation_reuse_config.partial_work_core) {
+                            writer_remaining_tiles_to_push =
+                                activation_reuse_config.partial_core_writer_remaining_tiles_to_push_to_push;
+                        } else if (activation_reuse_config.cores_with_non_meaningful_work.contains(core)) {
+                            writer_remaining_tiles_to_push = act_block_h_nsubblocks_split_last;
+                        }
+                        receiver_args.push_back(writer_remaining_tiles_to_push);
+                    }
+                }
+                writer_mcast_receiver_desc.runtime_args.emplace_back(core, std::move(receiver_args));
+            }
+        }
+    }
+
+    if (input_cores != output_cores) {
+        CoreCoord bottom_right_core_out = output_cores.bounding_box().end_coord;
+        uint32_t end_coord_x = bottom_right_core_out.x;
+        uint32_t end_coord_y = bottom_right_core_out.y;
+        for (const CoreRange range : all_cores.ranges()) {
+            for (const CoreCoord core : range) {
+                bool skip_compute = transpose_mcast ? core.y > end_coord_y : core.x > end_coord_x;
+                compute_kernel_desc.runtime_args.emplace_back(
+                    core, std::vector<uint32_t>{static_cast<uint32_t>(skip_compute)});
+            }
+        }
+    }
+
+    // Descriptor-path CB-size check (mirrors the legacy post_conv2d_op_memory_checks
+    // CB-sizing equality).  The L1-allocator delta half of the legacy check requires a
+    // realised Program and so isn't reachable here: the framework realises the Program
+    // after this function returns.
+    post_conv2d_op_memory_checks_descriptor(desc, operation_attributes, tensor_args, reader_indices_actual_page_size);
+
+    desc.kernels.push_back(std::move(writer_mcast_sender_desc));
+    if (create_writer_mcast_receiver) {
+        desc.kernels.push_back(std::move(writer_mcast_receiver_desc));
+    }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(compute_kernel_desc));
+    return desc;
+}
+
+}  // namespace
+
+tt::tt_metal::WorkloadDescriptor Conv2dShardedProgramFactory::create_workload_descriptor(
+    const Conv2dParams& operation_attributes,
+    const Conv2dInputs& tensor_args,
+    Tensor& output_tensor,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
+
+    // Allocate the conv_reader_indices tensor on device once for the whole
+    // workload.  Wrap it in a shared_ptr<Tensor> so ~Tensor doesn't fire when
+    // the local goes out of scope: ~Tensor calls DeviceStorage::deallocate
+    // which force-frees the device buffer regardless of any shared_ptr
+    // ownership of the MeshBuffer (see WorkloadBuffer rationale in
+    // workload_descriptor.hpp).  Holding the Tensor in the WorkloadDescriptor
+    // defers destruction until the cached workload is evicted.
+    const auto& a = tensor_args.a;
+    const auto& sliding_window_config = operation_attributes.sliding_window_config;
+    const auto& block_config = operation_attributes.block_config;
+    const auto& parallelization_config = operation_attributes.parallelization_config;
+    const auto enable_activation_reuse = operation_attributes.enable_activation_reuse;
+    const auto force_split_reader = operation_attributes.force_split_reader;
+    const bool config_tensors_in_dram = operation_attributes.config_tensors_in_dram;
+    const bool block_sharded = a.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
+
+    sliding_window::ParallelConfig input_parallel_config = {
+        .grid = a.memory_config().shard_spec().value().grid,
+        .shard_scheme = a.memory_config().memory_layout(),
+        .shard_orientation = a.memory_config().shard_spec().value().orientation,
+    };
+
+    std::vector<uint32_t> op_trace_metadata =
+        ttnn::operations::sliding_window::generate_op_trace_metadata(sliding_window_config);
+    std::vector<sliding_window::ShardBoundary> shard_boundaries =
+        ttnn::operations::sliding_window::generate_shard_boundaries(sliding_window_config);
+
+    const uint32_t stride_w = sliding_window_config.is_transpose ? 1 : (uint32_t)sliding_window_config.stride_hw.second;
+    const uint32_t act_block_h_ntiles = block_config.act_block_h_ntiles;
+
+    // Determine the (act_block_h_datums, last) pair for the host-side index
+    // generator.  This must agree exactly with the enable_split_reader path
+    // computed by build_program_descriptor_sharded(), since the generated index tensor
+    // is consumed by the reader kernel.
+    const auto& b = tensor_args.b;
+    const auto output_channels = operation_attributes.output_channels;
+    const auto groups = operation_attributes.groups;
+    const auto has_bias = operation_attributes.has_bias;
+    const uint32_t filter_h = (uint32_t)sliding_window_config.window_hw.first;
+    const uint32_t filter_w = (uint32_t)sliding_window_config.window_hw.second;
+    const uint32_t dilation_w = (uint32_t)sliding_window_config.dilation_hw.second;
+    const ttnn::Shape ashape(operation_attributes.input_tensor_shape);
+    const std::array<uint32_t, 2> shard_shape = a.shard_spec().value().shape;
+
+    uint32_t input_channels_padded = shard_shape[1];
+    if (block_sharded) {
+        const uint32_t in_num_cores_x = input_parallel_config.grid.bounding_box().end_coord.x + 1;
+        const uint32_t in_num_cores_y = input_parallel_config.grid.bounding_box().end_coord.y + 1;
+        const bool transpose_mcast = a.shard_spec().value().orientation == ShardOrientation::COL_MAJOR;
+        input_channels_padded = shard_shape[1] * (transpose_mcast ? in_num_cores_y : in_num_cores_x);
+    }
+    const bool is_conv_1d_depthwise_conv =
+        is_1d_depthwise_conv(groups, ashape[3], output_channels, filter_h, ashape[1], has_bias);
+
+    auto compute_kernel_config_args =
+        get_compute_kernel_config_args(a.device()->arch(), operation_attributes.compute_kernel_config);
+    const bool fp32_dest_acc_en = std::get<2>(compute_kernel_config_args);
+
+    const bool enable_split_reader =
+        is_split_reader_supported(a.memory_config().memory_layout(), is_conv_1d_depthwise_conv, act_block_h_ntiles) &&
+        force_split_reader.value_or(is_split_reader_viable(
+            a.memory_config().memory_layout(),
+            act_block_h_ntiles,
+            input_channels_padded,
+            filter_w,
+            tt::tt_metal::hal::get_arch(),
+            a.dtype(),
+            parallelization_config.per_core_out_matrix_width_ntile * block_config.act_block_w_ntiles,
+            tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(b.dtype())),
+            dilation_w,
+            parallelization_config.per_core_out_matrix_height_ntile / block_config.act_block_h_ntiles,
+            block_config.act_block_w_ntiles,
+            fp32_dest_acc_en,
+            output_tensor.dtype(),
+            enable_activation_reuse));
+
+    uint32_t act_block_h_nsubblocks_split = block_config.act_block_h_ntiles;
+    uint32_t act_block_h_nsubblocks_split_last = 0;
+    if (enable_split_reader) {
+        act_block_h_nsubblocks_split_last = block_config.act_block_h_ntiles / 2;
+        act_block_h_nsubblocks_split = block_config.act_block_h_ntiles - act_block_h_nsubblocks_split_last;
+    }
+    const uint32_t act_block_h_datums = act_block_h_ntiles * tt::constants::TILE_HEIGHT;
+    const uint32_t act_block_h_datums_split = act_block_h_nsubblocks_split * tt::constants::TILE_HEIGHT;
+    const uint32_t act_block_h_datums_split_last = act_block_h_nsubblocks_split_last * tt::constants::TILE_HEIGHT;
+
+    std::vector<std::vector<uint16_t>> conv_sharded_input_top_left_indices =
+        ttnn::operations::sliding_window::generate_sliding_window_op_config(
+            op_trace_metadata,
+            shard_boundaries,
+            stride_w,
+            true,
+            enable_split_reader ? act_block_h_datums_split : act_block_h_datums,
+            enable_split_reader ? act_block_h_datums_split_last : 0);
+
+    Tensor conv_reader_indices_tensor = ttnn::operations::sliding_window::construct_on_host_config_tensor(
+        conv_sharded_input_top_left_indices, input_parallel_config, config_tensors_in_dram);
+    conv_reader_indices_tensor = ttnn::operations::sliding_window::move_config_tensor_to_device(
+        conv_reader_indices_tensor, input_parallel_config, block_sharded, a.device(), config_tensors_in_dram);
+
+    log_trace(tt::LogOp, "Conv2D Config Tensor : {}", conv_reader_indices_tensor);
+
+    auto conv_reader_indices_tensor_owner = std::make_shared<Tensor>(std::move(conv_reader_indices_tensor));
+    tt::tt_metal::Buffer* conv_reader_indices_buffer = conv_reader_indices_tensor_owner->buffer();
+    workload_descriptor.buffers.push_back({conv_reader_indices_tensor_owner, conv_reader_indices_buffer});
+
+    // Single-device op: per-coord program is structurally identical for every
+    // coord in `tensor_coords` (conv2d doesn't depend on cluster position).
+    // Build the ProgramDescriptor once and copy into each range entry.
+    tt::tt_metal::ProgramDescriptor desc =
+        build_program_descriptor_sharded(operation_attributes, tensor_args, output_tensor, conv_reader_indices_buffer);
+
+    auto ranges = tensor_coords.ranges();
+    workload_descriptor.programs.reserve(ranges.size());
+    for (size_t i = 0; i + 1 < ranges.size(); ++i) {
+        workload_descriptor.programs.push_back({ranges[i], desc});
+    }
+    if (!ranges.empty()) {
+        workload_descriptor.programs.push_back({ranges.back(), std::move(desc)});
+    }
+    return workload_descriptor;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.hpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <tt-metalium/workload_descriptor.hpp>
+#include "ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp"
+#include "ttnn/device_operation.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct Conv2dShardedProgramFactory {
+    // Builds the workload in one call (cache miss).  The intermediate
+    // conv_reader_indices tensor — which must outlive the cached program — is
+    // allocated here and parked on the WorkloadDescriptor's `buffers` vector
+    // (wrapped in `shared_ptr<Tensor>` so `~Tensor` cannot force-deallocate the
+    // device memory while the cached program is still alive).
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
+        const Conv2dParams& operation_attributes,
+        const Conv2dInputs& tensor_args,
+        Tensor& output_tensor,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -1,0 +1,756 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include "ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
+#include "ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_width_sharded_program_factory.hpp"
+#include "ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp"
+#include "ttnn/operations/sliding_window/sliding_window.hpp"
+#include "ttnn/operations/conv/conv2d/conv2d_utils.hpp"
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
+#include "ttnn/operations/compute_throttle_utils.hpp"
+
+namespace ttnn::prim::qsr {
+
+namespace unary = ttnn::operations::unary;
+using ttnn::operations::conv::conv_skip_mcast;
+using ttnn::operations::conv::SkipMcast;
+
+std::pair<std::vector<uint32_t>, std::vector<uint32_t>> compute_opt_conv_activation_as_mm_shape(
+    const ttnn::Shape& conv_activation_shape,
+    const ttnn::operations::sliding_window::SlidingWindowConfig& sliding_window_config,
+    uint32_t num_cores_nhw,
+    uint32_t act_block_h_ntiles) {
+    uint32_t filter_h = (uint32_t)sliding_window_config.window_hw.first;   // filter_h
+    uint32_t filter_w = (uint32_t)sliding_window_config.window_hw.second;  // filter_W
+    auto output_shape = sliding_window_config.get_output_shape();
+    uint32_t batch_size = output_shape[0];
+    uint32_t conv_output_h = output_shape[1];
+    uint32_t conv_output_w = output_shape[2];
+
+    // pad height
+    uint32_t num_rows = (uint32_t)batch_size * conv_output_h * conv_output_w;
+    uint32_t act_block_h_datums = act_block_h_ntiles * tt::constants::TILE_HEIGHT;
+    uint32_t num_rows_padded = tt::round_up(num_rows, num_cores_nhw * act_block_h_datums);
+    uint32_t num_cols = conv_activation_shape[3] * filter_h * filter_w;
+    uint32_t num_cols_padded = tt::round_up(conv_activation_shape[3] * filter_w, tt::constants::TILE_WIDTH) * filter_h;
+    return {{1, num_rows_padded, num_cols_padded}, {1, num_rows, num_cols}};
+}
+
+namespace {
+
+// The intermediate conv_reader_indices tensor is allocated once by
+// create_workload_descriptor and parked on the WorkloadDescriptor; we receive
+// the raw Buffer* here and wire it into the READER_INDICES CB and reader CT args.
+tt::tt_metal::ProgramDescriptor build_program_descriptor(
+    const Conv2dParams& operation_attributes,
+    const Conv2dInputs& tensor_args,
+    Tensor& output_tensor,
+    tt::tt_metal::Buffer* conv_reader_indices_buffer) {
+    using tt::tt_metal::CBDescriptor;
+    using tt::tt_metal::CBFormatDescriptor;
+    using tt::tt_metal::ComputeConfigDescriptor;
+    using tt::tt_metal::DataMovementConfigDescriptor;
+    using tt::tt_metal::KernelDescriptor;
+    using tt::tt_metal::ProgramDescriptor;
+    using tt::tt_metal::SemaphoreDescriptor;
+
+    ProgramDescriptor desc;
+    const auto& a = tensor_args.a;
+    const auto& b = tensor_args.b;
+
+    const auto& ashape = ttnn::Shape(operation_attributes.input_tensor_shape);
+    const auto& bias = tensor_args.bias;
+    const auto& sliding_window_config = operation_attributes.sliding_window_config;
+
+    ttnn::operations::sliding_window::ParallelConfig parallel_config{
+        .grid = a.shard_spec().value().grid,
+        .shard_scheme = a.memory_config().memory_layout(),
+        .shard_orientation = a.shard_spec().value().orientation};
+
+    std::vector<uint32_t> op_trace_metadata =
+        ttnn::operations::sliding_window::generate_op_trace_metadata(sliding_window_config);
+    std::vector<sliding_window::ShardBoundary> shard_boundaries =
+        ttnn::operations::sliding_window::generate_shard_boundaries(sliding_window_config);
+
+    const auto output_channels = operation_attributes.output_channels;
+    const auto untilize_out = operation_attributes.untilize_out;
+    const auto has_bias = operation_attributes.has_bias;
+    const auto& fused_activation = operation_attributes.activation;
+    const auto& parallelization_config = operation_attributes.parallelization_config;
+    const auto& block_config = operation_attributes.block_config;
+    auto& output = output_tensor;
+    const auto& compute_kernel_config = operation_attributes.compute_kernel_config;
+    const auto enable_act_double_buffer = operation_attributes.enable_act_double_buffer;
+    const auto enable_weights_double_buffer = operation_attributes.enable_weights_double_buffer;
+    const auto config_tensors_in_dram = operation_attributes.config_tensors_in_dram;
+
+    tt::tt_metal::IDevice* device = a.device();
+    TT_FATAL(a.layout() == tt::tt_metal::Layout::ROW_MAJOR, "Conv activation should be in row major layout");
+    TT_FATAL(a.memory_config().is_sharded(), "Conv activation must be sharded.");
+    TT_FATAL(output_channels <= b.padded_shape()[3], "Invalid weight shape. Incorrect weight tensor.");
+    uint32_t act_block_h_ntiles = block_config.act_block_h_ntiles;
+    uint32_t act_block_w_ntiles = block_config.act_block_w_ntiles;
+    uint32_t weight_block_w_ntiles = parallelization_config.per_core_out_matrix_width_ntile;
+    uint32_t out_block_h_ntiles = parallelization_config.per_core_out_matrix_height_ntile;
+    uint32_t out_subblock_h_ntiles = block_config.out_subblock_h_ntiles;
+    uint32_t out_subblock_w_ntiles = block_config.out_subblock_w_ntiles;
+
+    const tt::DataFormat tilized_act_df = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), compute_kernel_config);
+
+    TT_FATAL(
+        out_block_h_ntiles >= act_block_h_ntiles,
+        "Output block height (in # of tiles) ({}) should be greater than or equal to activation block height (in # of "
+        "tiles) ({})",
+        out_block_h_ntiles,
+        act_block_h_ntiles);
+
+    // Tensor b has weights and it should be tiled layout after converting conv weights into weight matrix
+    TT_FATAL(b.layout() == tt::tt_metal::Layout::TILE, "Conv weights should be in tiled layout");
+    TT_FATAL(b.padded_shape()[0] == 1, "Conv weight matrix shape is invalid");
+    TT_FATAL(b.padded_shape()[1] == 1, "Conv weight matrix shape is invalid");
+    uint32_t weight_matrix_height = b.padded_shape()[2];
+    uint32_t weight_matrix_width = b.padded_shape()[3];
+    uint32_t weight_matrix_width_ntiles = weight_matrix_width / tt::constants::TILE_WIDTH;
+
+    const auto shard_shape = a.shard_spec().value().shape;
+
+    CoreRangeSet input_cores = a.memory_config().shard_spec().value().grid;
+    CoreRangeSet output_cores = output.memory_config().shard_spec().value().grid;
+    CoreRangeSet all_cores = output.memory_config().shard_spec().value().grid;
+    if (input_cores.num_cores() > output_cores.num_cores()) {
+        all_cores = input_cores;
+    }
+    CoreRange all_reader_cores = all_cores.bounding_box();
+    auto input_num_cores = input_cores.num_cores();
+    auto output_num_cores = output_cores.num_cores();
+
+    // parallelization config
+    const auto& p_config = parallelization_config;
+    uint32_t input_channels_padded = shard_shape[1] * input_num_cores;
+    TT_FATAL(input_channels_padded >= ashape[3], "Incorrect padding of input channels!");
+    // check is for 16-byte alignment
+    TT_FATAL(
+        input_channels_padded % 16 == 0,
+        "Expected input channels to be padded for 16 byte alignment in L1");  // TODO: For bfp16, check if its divisible
+                                                                              // by 8 not 16.
+
+    ttnn::Shape ashape_with_channels_padded({ashape[0], ashape[1], ashape[2], input_channels_padded});
+
+    uint32_t conv_act_size_w = ashape_with_channels_padded[2];
+    uint32_t conv_act_size_c = ashape_with_channels_padded[3];
+
+    const uint32_t filter_h = (uint32_t)sliding_window_config.window_hw.first;   // filter_h
+    const uint32_t filter_w = (uint32_t)sliding_window_config.window_hw.second;  // filter_W
+    const uint32_t stride_w = sliding_window_config.is_transpose ? 1 : (uint32_t)sliding_window_config.stride_hw.second;
+    const uint32_t dilation_h = (uint32_t)sliding_window_config.dilation_hw.first;
+    const uint32_t dilation_w = (uint32_t)sliding_window_config.dilation_hw.second;
+
+    uint32_t pad_w = (uint32_t)sliding_window_config.get_pad_w();
+
+    uint32_t input_size_w = conv_act_size_w + pad_w;
+    if (sliding_window_config.is_transpose) {
+        auto input_shape = sliding_window_config.get_transposed_full_input_shape();
+        input_size_w = input_shape[2];
+    }
+
+    // Compute the 2d matrix shape
+    auto [act_matrix_shape, act_matrix_shape_unpadded] = compute_opt_conv_activation_as_mm_shape(
+        ashape_with_channels_padded, sliding_window_config, parallelization_config.num_cores_nhw, out_block_h_ntiles);
+    TT_FATAL(
+        act_matrix_shape.size() == 3,
+        "Activation matrix shape must have 3 dimensions but got {}",
+        act_matrix_shape.size());
+    TT_FATAL(act_matrix_shape[0] == 1, "Activation matrix first dimension must be 1 but got {}", act_matrix_shape[0]);
+    uint32_t act_matrix_height = (uint32_t)act_matrix_shape[1];
+    uint32_t act_matrix_width = (uint32_t)act_matrix_shape[2];
+
+    // TODO: Move all these TT_FATALs/checks to validate?
+
+    if (has_bias) {
+        // Tensor bias is of shape {output_channels}
+        TT_FATAL(bias.has_value(), "Bias tensor must be provided when has_bias is true");
+        TT_FATAL(bias.value().buffer() != nullptr, "Bias tensor buffer must not be null");
+        auto bias_shape_without_padding = bias.value().logical_shape();
+        TT_FATAL(bias_shape_without_padding[0] == 1, "Bias should have batch == 1");
+    }
+
+    // Normal matrix shape check
+    TT_FATAL(act_matrix_width == weight_matrix_height, "The width of tensor a needs to match the height of tensor b");
+
+    // Tile size divisibility checks
+    TT_FATAL(
+        act_matrix_height % tt::constants::TILE_HEIGHT == 0, "Height of activation matrix needs to be divisible by 32");
+    TT_FATAL(
+        act_matrix_width % tt::constants::TILE_WIDTH == 0, "Width of activation matrix needs to be divisible by 32");
+    TT_FATAL(
+        weight_matrix_height % tt::constants::TILE_HEIGHT == 0, "Height of weight matrix needs to be divisible by 32");
+    TT_FATAL(
+        weight_matrix_width % tt::constants::TILE_WIDTH == 0, "Width of weight matrix needs to be divisible by 32");
+
+    // Device compatibility checks
+    TT_FATAL(
+        a.storage_type() == tt::tt_metal::StorageType::DEVICE && b.storage_type() == tt::tt_metal::StorageType::DEVICE,
+        "Operands to large matmul need to be on device!");
+    TT_FATAL(a.device() == b.device(), "Operands to conv need to be on the same device!");
+    TT_FATAL(
+        a.buffer() != nullptr && b.buffer() != nullptr, "Operands to conv need to be allocated in buffers on device!");
+    if (has_bias) {
+        TT_FATAL(bias.value().storage_type() == tt::tt_metal::StorageType::DEVICE, "Bias should be on device");
+        TT_FATAL(bias.value().device() == a.device(), "Bias should be on the same device as act tensor");
+    }
+
+    // Convert tensor dims to tile dims
+    uint32_t act_matrix_height_ntiles = act_matrix_height / tt::constants::TILE_HEIGHT;
+    uint32_t act_matrix_width_ntiles = act_matrix_width / tt::constants::TILE_WIDTH;
+
+    TT_FATAL(
+        act_matrix_height_ntiles % act_block_h_ntiles == 0,
+        "act_matrix_height_ntiles {} should be divisible by act_block_h_ntiles {}",
+        act_matrix_height_ntiles,
+        act_block_h_ntiles);
+    TT_FATAL(
+        act_matrix_width_ntiles % act_block_w_ntiles == 0,
+        "act_matrix_width_ntiles {} should be divisible by act_block_w_ntiles {}",
+        act_matrix_width_ntiles,
+        act_block_w_ntiles);
+    TT_FATAL(
+        weight_matrix_width_ntiles % weight_block_w_ntiles == 0,
+        "weight_+matrix_width_ntiles {} should be divisible by weight_block_w_ntiles {}",
+        weight_matrix_width_ntiles,
+        weight_block_w_ntiles);
+    TT_FATAL(
+        act_matrix_height_ntiles % out_block_h_ntiles == 0,
+        "act_matrix_height_ntiles {} should be divisible by out_block_h_ntiles {}",
+        act_matrix_height_ntiles,
+        out_block_h_ntiles);
+
+    uint32_t num_blocks_act_h = act_matrix_height_ntiles / act_block_h_ntiles;
+    uint32_t num_blocks_act_w = act_matrix_width_ntiles / act_block_w_ntiles;
+    uint32_t num_blocks_weight_w = weight_matrix_width_ntiles / weight_block_w_ntiles;
+
+    TT_FATAL(
+        num_blocks_act_w % input_num_cores == 0,
+        "Number of Act Blocks along the Width {} should be divisible by the number of cores {}",
+        num_blocks_act_w,
+        input_num_cores);
+
+    TT_FATAL(
+        num_blocks_act_w % input_num_cores == 0,
+        "Number of Act Blocks along the Width {} should be divisible by the number of cores {}",
+        num_blocks_act_w,
+        input_num_cores);
+    uint32_t per_core_num_blocks_act_w = num_blocks_act_w / input_num_cores;
+
+    // act block info
+    uint32_t act_block_h_datums = act_matrix_height / num_blocks_act_h;
+
+    const uint32_t act_block_num_tiles = act_block_h_ntiles * act_block_w_ntiles;
+
+    // weight block info
+    uint32_t weight_block_w_datums = weight_matrix_width / num_blocks_weight_w;
+    TT_FATAL(
+        weight_block_w_ntiles % out_subblock_w_ntiles == 0,
+        "weight_block_w_ntiles {} should be divisible by out_subblock_w_ntiles {}",
+        weight_block_w_ntiles,
+        out_subblock_w_ntiles);
+    uint32_t weight_num_subblocks = weight_block_w_ntiles / out_subblock_w_ntiles;
+    uint32_t weight_block_num_tiles = weight_block_w_ntiles * act_block_w_ntiles;
+    uint32_t weight_block_in_channels_ntiles =
+        input_channels_padded / (32 * input_num_cores * per_core_num_blocks_act_w);
+    TT_FATAL(
+        input_channels_padded >= (tt::constants::TILE_HEIGHT * input_num_cores),
+        "input_channels_padded {} should be greater than or equal to TILE_HEIGHT * input_num_cores {}",
+        input_channels_padded,
+        tt::constants::TILE_HEIGHT * input_num_cores);
+    TT_FATAL(
+        input_channels_padded % (tt::constants::TILE_HEIGHT * input_num_cores) == 0,
+        "input_channels_padded {} should be divisible by TILE_HEIGHT * input_num_cores {}",
+        input_channels_padded,
+        tt::constants::TILE_HEIGHT * input_num_cores);
+
+    // writer of conv op partially removes padding on the width
+    // it removes the padding done for block width but it doesn't remove padding done for tiled width
+    uint32_t output_channels_padded_to_tile_width =
+        tt::round_up(output_channels, output_num_cores * tt::constants::TILE_WIDTH);
+    TT_FATAL(
+        output_channels_padded_to_tile_width <= weight_matrix_width,
+        "output_channels_padded_to_tile_width {} should be less than or equal to weight_matrix_width {}",
+        output_channels_padded_to_tile_width,
+        weight_matrix_width);
+    uint32_t num_blocks_output_w =
+        (uint32_t)std::ceil((double)output_channels_padded_to_tile_width / (double)weight_block_w_datums);
+    uint32_t last_block_width_datums = (output_channels_padded_to_tile_width % weight_block_w_datums == 0)
+                                           ? weight_block_w_datums
+                                           : (output_channels_padded_to_tile_width % weight_block_w_datums);
+    TT_FATAL(
+        last_block_width_datums % tt::constants::TILE_WIDTH == 0,
+        "last_block_width_datums {} should be divisible by TILE_WIDTH {}",
+        last_block_width_datums,
+        tt::constants::TILE_WIDTH);
+
+    // sanity check
+    TT_FATAL(
+        num_blocks_output_w == num_blocks_weight_w,
+        "num_blocks_output_w {} should be equal to num_blocks_weight_w {}",
+        num_blocks_output_w,
+        num_blocks_weight_w);
+
+    TT_FATAL(output.buffer() != nullptr, "Output buffer should be allocated on device!");
+
+    uint32_t out_subblock_num_tiles = out_subblock_h_ntiles * out_subblock_w_ntiles;
+    TT_FATAL(out_subblock_num_tiles <= 8, "Need to ensure that matmul partials fit in dst");
+
+    TT_FATAL(
+        act_block_h_ntiles % out_subblock_h_ntiles == 0,
+        "act_block_h_ntiles {} should be divisible by out_subblock_h_ntiles {}",
+        act_block_h_ntiles,
+        out_subblock_h_ntiles);
+    uint32_t act_num_subblocks = act_block_h_ntiles / out_subblock_h_ntiles;
+    uint32_t act_subblock_h_ntiles = out_subblock_h_ntiles;
+    uint32_t act_subblock_num_tiles = act_subblock_h_ntiles * act_block_w_ntiles;
+
+    // bias
+    uint32_t bias_ntiles = 0;
+    if (has_bias) {
+        bias_ntiles = weight_block_w_ntiles;
+    }
+
+    uint32_t num_blocks_act_h_per_core =
+        (p_config.per_core_out_matrix_height_ntile + act_block_h_ntiles - 1) / act_block_h_ntiles;
+    uint32_t num_blocks_weight_w_per_core = p_config.per_core_out_matrix_width_ntile / weight_block_w_ntiles;
+
+    std::map<std::string, std::string> reader_defines;
+
+    uint32_t conv_act_c_read_bytes = conv_act_size_c * a.element_size() / (input_num_cores * per_core_num_blocks_act_w);
+
+    std::string compute_kernel_path =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_bmm_tilize.cpp";
+    std::string activation_kernel_path =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/activation_reader_width_sharded.cpp";
+    std::string weights_kernel_path =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/weights_reader_width_sharded.cpp";
+
+    bool tilize_in0 = false;
+
+    // Select preferred NoCs for DRAM operations based on architecture
+    // Must be done early to use in multicast coordinate setup
+    // weights_kernel (RISCV_1) reads weights/bias from DRAM -> use preferred read NoC
+    // act_kernel (RISCV_0) primarily does L1 reads and multicasts -> use preferred write NoC
+    // This optimizes NoC bandwidth by separating DRAM reads from L1/multicast operations
+    tt::tt_metal::NOC weights_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+    tt::tt_metal::NOC act_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+
+    log_debug(
+        tt::LogOp,
+        "Conv2D NoC selection: act_noc={}, weights_noc={} for arch={}",
+        (uint32_t)act_noc,
+        (uint32_t)weights_noc,
+        (uint32_t)device->arch());
+
+    // Sequential semaphore IDs match the order in which CreateSemaphore would have
+    // allocated them; the framework realises desc.semaphores in this order on cache miss.
+    uint32_t act_mcast_sender_semaphore = static_cast<uint32_t>(desc.semaphores.size());
+    desc.semaphores.push_back(SemaphoreDescriptor{
+        .id = act_mcast_sender_semaphore,
+        .core_ranges = all_cores,
+        .initial_value = 0,  // 0 == INVALID
+    });
+    uint32_t act_mcast_receiver_semaphore = static_cast<uint32_t>(desc.semaphores.size());
+    desc.semaphores.push_back(SemaphoreDescriptor{
+        .id = act_mcast_receiver_semaphore,
+        .core_ranges = all_cores,
+        .initial_value = 0,  // 0 == INVALID
+    });
+
+    CoreCoord act_mcast_start_core_logical(0, 0);
+    CoreCoord act_mcast_end_core_logical(all_cores.bounding_box().end_coord.x, all_cores.bounding_box().end_coord.y);
+    auto act_mcast_start = device->worker_core_from_logical_core(act_mcast_start_core_logical);
+    auto act_mcast_end = device->worker_core_from_logical_core(act_mcast_end_core_logical);
+
+    // Swap multicast coordinates if using NOC_1 for proper addressing
+    // NOC_0 and NOC_1 have inverted coordinate systems on some architectures
+    if (act_noc == tt::tt_metal::NOC::NOC_1) {
+        std::swap(act_mcast_start, act_mcast_end);
+        log_debug(
+            tt::LogOp,
+            "Conv2D: Swapped mcast coords for NOC_1: start=({},{}), end=({},{})",
+            act_mcast_start.x,
+            act_mcast_start.y,
+            act_mcast_end.x,
+            act_mcast_end.y);
+    }
+
+    TT_FATAL(act_block_h_datums % 2 == 0, "2 Indices are packed in one uint32_t word.");
+
+    std::map<std::string, std::string> writer_defines;
+    std::map<std::string, std::string> writer_mcast_sender_defines;
+    std::map<std::string, std::string> compute_defines;
+
+    const SkipMcast skip_mcast = conv_skip_mcast(parallelization_config, a.memory_config().memory_layout());
+    const bool skip_activation_mcast = skip_mcast.skip_activation_mcast;
+    const bool skip_weights_mcast = skip_mcast.skip_weights_mcast;
+    if (skip_activation_mcast) {
+        reader_defines["SKIP_MCAST"] = "1";
+    }
+    if (skip_weights_mcast) {
+        writer_mcast_sender_defines["SKIP_MCAST"] = "1";
+    }
+
+    bool pack_relu = fused_activation.has_value() && fused_activation.value().op_type == unary::UnaryOpType::RELU;
+    if (fused_activation.has_value() && !pack_relu) {
+        compute_defines.merge(ttnn::operations::unary::utils::get_defines(
+            fused_activation.value().op_type, fused_activation.value().params, "ACTIVATION", "i"));
+    }
+
+    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
+        device->arch(), output_cores.num_cores(), compute_defines, ttnn::get_throttle_level(compute_kernel_config));
+
+    for (auto elem : compute_defines) {
+        log_debug(tt::LogOp, "compute_defines: {} = {}", elem.first, elem.second);
+    }
+
+    const uint32_t output_image_width = sliding_window_config.get_output_shape()[2];
+    Conv2dConfig conv_config = Conv2dConfig{
+        .weights_dtype = b.dtype(),
+        .config_tensors_in_dram = config_tensors_in_dram,
+        .shard_layout = a.memory_config().memory_layout(),
+        .output_layout = (untilize_out ? Layout::ROW_MAJOR : Layout::TILE),
+        .enable_act_double_buffer = enable_act_double_buffer,
+        .enable_weights_double_buffer = enable_weights_double_buffer};
+
+    // The conv_reader_indices tensor itself is allocated once in
+    // create_workload_descriptor and parked on workload_descriptor.buffers; we
+    // receive the raw Buffer* and read its page size for the CB sizing below.
+    // Pass the actual DRAM/L1-small config buffer page size into get_cb_info so the predicted
+    // READER_INDICES CB footprint matches the CB this factory creates. Without this, the in-DRAM
+    // path was sized to the worst case (1 uint16 per output row), holding spare L1 that is never
+    // populated by the reader kernel.
+    const uint32_t reader_indices_actual_page_size = conv_reader_indices_buffer->page_size();
+    std::vector<CBInfo> cb_info = get_cb_info(
+        compute_kernel_config,
+        block_config,
+        p_config,
+        b.padded_shape(),
+        {filter_h, filter_w},
+        {sliding_window_config.input_hw.first, sliding_window_config.input_hw.second},
+        {dilation_h, dilation_w},
+        conv_config,
+        a.dtype(),
+        output.dtype(),
+        a.memory_config().shard_spec().value().shape,
+        output_image_width,
+        has_bias,
+        false,
+        skip_activation_mcast,
+        input_channels_padded,
+        reader_indices_actual_page_size);
+
+    // Emit CBDescriptors directly onto the ProgramDescriptor.  The framework
+    // tracks the globally-allocated CBs (ACT_SHARDED on input, OUT/PARTIALS on
+    // output, READER_INDICES on the workload-scoped indices buffer) and patches
+    // their addresses on cache hits — no per-op UpdateDynamicCircularBufferAddress
+    // override needed.
+    const CoreRangeSet all_reader_cores_set(all_reader_cores);
+    emit_cb_descriptors(cb_info, desc, all_reader_cores_set, a.buffer(), output.buffer(), conv_reader_indices_buffer);
+    // partials_cb_uses_output is still consumed by compute_kernel_args below; the
+    // CB-on-output wiring is handled inline by emit_cb_descriptors (MATMUL_PARTIALS
+    // is mapped to output_buffer when is_globally_allocated is true), so we no
+    // longer need to call UpdateDynamicCircularBufferAddress on cache hit.
+    const bool partials_cb_uses_output = get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).is_globally_allocated;
+
+    std::vector<uint32_t> compute_kernel_args = {
+        act_block_w_ntiles,                         // in0_block_w
+        act_num_subblocks,                          // in0_num_sublocks
+        act_block_num_tiles,                        // in0_block_num_tiles,
+        act_subblock_num_tiles,                     // in0_sublock_num_tiles
+        act_subblock_h_ntiles * act_num_subblocks,  // reader_num_h_subblocks
+
+        weight_num_subblocks,    // in1_num_sublocks
+        weight_block_num_tiles,  // in1_block_num_tiles,
+        weight_block_w_ntiles,   // in1_block_w
+
+        num_blocks_act_h_per_core,     // in0_num_blocks_h
+        num_blocks_act_w,              // in0_num_blocks_w,
+        num_blocks_weight_w_per_core,  // in1_num_blocks_w
+
+        out_subblock_h_ntiles,   // out_sublock_h
+        out_subblock_w_ntiles,   // out_sublock_w
+        out_subblock_num_tiles,  // out_sublock_num_tiles
+
+        tilize_in0,    // tilize_in0
+        untilize_out,  // untilize_out
+
+        bias_ntiles,
+        get_cb_info_by_name(cb_info, Conv2dCb::BIAS).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::WEIGHTS).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT_ROW_MAJOR_BFLOAT16).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT_SECOND_READER).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT_TILIZED).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::OUT).index,
+        partials_cb_uses_output,
+        input_num_cores,  // in0_nblocks_w_tilize. Repeat tilize after all cores have done one round of MCAST.
+        false,            // check_skip_compute; not used in width sharded
+        pack_relu,
+        weight_block_w_ntiles <= 8,  // packer_untilize
+        packer_l1_acc,
+        has_bias,
+        false,  // enable_split_reader (not used in width sharded)
+        false,  // enable_activation_reuse (not used in width sharded)
+        0,
+        0,
+        0,
+        0,                              // activation reuse related arguments
+        static_cast<uint32_t>(false)};  // split_reader_cb_shared (not used in width sharded)
+
+    std::vector<uint32_t> activation_kernel_compile_args = {
+        (uint32_t)stride_w,
+        (uint32_t)dilation_h,
+        (uint32_t)dilation_w,
+        (uint32_t)input_size_w,
+        (uint32_t)conv_act_c_read_bytes,
+        (uint32_t)filter_h,  // Input filter window height
+        (uint32_t)filter_w,  // Input filter window width
+        (uint32_t)act_block_h_datums,
+        (uint32_t)act_block_num_tiles,
+        (uint32_t)input_num_cores,
+        (uint32_t)num_blocks_act_h_per_core,
+        (uint32_t)per_core_num_blocks_act_w,
+        (uint32_t)act_mcast_sender_semaphore,
+        (uint32_t)act_mcast_receiver_semaphore,
+        (uint32_t)act_mcast_start.x,
+        (uint32_t)act_mcast_start.y,
+        (uint32_t)act_mcast_end.x,
+        (uint32_t)act_mcast_end.y,
+        (uint32_t)act_block_num_tiles * tt::tile_size(tilized_act_df),
+        (uint32_t)output_num_cores,
+        (uint32_t)all_reader_cores.size(),
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT_SHARDED).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::L1_ARRAY).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT_ROW_MAJOR_BFLOAT16).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT_TILIZED).index};
+
+    std::vector<uint32_t> weights_kernel_compile_args = {
+        get_cb_info_by_name(cb_info, Conv2dCb::WEIGHTS).index,          // cb_id_weight
+        act_block_w_ntiles / (filter_h * filter_w),                     // core_in_channels_ntiles
+        filter_h * filter_w,                                            // window_size_hw
+        weight_block_w_ntiles,                                          // weight_block_width_ntiles
+        weight_block_num_tiles,                                         // weight_block_num_tiles
+        weight_matrix_width_ntiles,                                     // weight_matrix_width_ntiles
+        (weight_matrix_width_ntiles * input_channels_padded) / 32,      // weight_next_channel_stride_h
+        weight_matrix_width_ntiles * weight_block_in_channels_ntiles,   // weight_next_block_this_core_stride_h
+        weight_matrix_width_ntiles * weight_block_in_channels_ntiles *  // weight_next_block_other_core_stride_h
+            per_core_num_blocks_act_w,
+        input_num_cores,            // other_core_weight_height_blocks
+        per_core_num_blocks_act_w,  // this_core_weight_height_blocks
+        num_blocks_act_h_per_core,
+        get_cb_info_by_name(cb_info, Conv2dCb::BIAS).index,
+        (uint32_t)has_bias};
+
+    if (config_tensors_in_dram) {
+        reader_defines["CONFIG_TENSOR_IN_DRAM"] = "1";
+        activation_kernel_compile_args.push_back(conv_reader_indices_buffer->address());
+        activation_kernel_compile_args.push_back(conv_reader_indices_buffer->page_size());
+        tt::tt_metal::TensorAccessorArgs(conv_reader_indices_buffer).append_to(activation_kernel_compile_args);
+    }
+
+    for (uint32_t index = 0; index < activation_kernel_compile_args.size(); index++) {
+        log_debug(tt::LogOp, "activation_kernel_compile_args[{}] = {}", index, activation_kernel_compile_args[index]);
+    }
+
+    tt::tt_metal::TensorAccessorArgs(b.buffer()).append_to(weights_kernel_compile_args);
+    tt::tt_metal::TensorAccessorArgs(bias ? bias->buffer() : nullptr).append_to(weights_kernel_compile_args);
+
+    KernelDescriptor act_kernel_desc;
+    act_kernel_desc.kernel_source = activation_kernel_path;
+    act_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    act_kernel_desc.core_ranges = CoreRangeSet(all_reader_cores);
+    act_kernel_desc.compile_time_args = std::move(activation_kernel_compile_args);
+    for (const auto& [k, v] : reader_defines) {
+        act_kernel_desc.defines.emplace_back(k, v);
+    }
+    act_kernel_desc.config = DataMovementConfigDescriptor{
+        .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+        .noc = act_noc,
+    };
+
+    KernelDescriptor weights_kernel_desc;
+    weights_kernel_desc.kernel_source = weights_kernel_path;
+    weights_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    weights_kernel_desc.core_ranges = all_cores;
+    weights_kernel_desc.compile_time_args = std::move(weights_kernel_compile_args);
+    for (const auto& [k, v] : writer_defines) {
+        weights_kernel_desc.defines.emplace_back(k, v);
+    }
+    weights_kernel_desc.config = DataMovementConfigDescriptor{
+        .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+        .noc = weights_noc,
+    };
+
+    KernelDescriptor compute_kernel_desc;
+    compute_kernel_desc.kernel_source = compute_kernel_path;
+    compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_kernel_desc.core_ranges = all_cores;
+    compute_kernel_desc.compile_time_args = std::move(compute_kernel_args);
+    for (const auto& [k, v] : compute_defines) {
+        compute_kernel_desc.defines.emplace_back(k, v);
+    }
+    compute_kernel_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+    };
+
+    auto full_core_grid = device->compute_with_storage_grid_size();
+    std::vector<uint32_t> act_mcast_noc_y;
+    std::vector<uint32_t> act_mcast_noc_x;
+
+    act_mcast_noc_x.reserve(full_core_grid.x);
+    for (uint32_t core_index = 0; core_index < full_core_grid.x; core_index++) {
+        act_mcast_noc_x.push_back(device->worker_core_from_logical_core(CoreCoord(core_index, 0)).x);
+    }
+
+    act_mcast_noc_y.reserve(full_core_grid.y);
+    for (uint32_t core_index = 0; core_index < full_core_grid.y; core_index++) {
+        act_mcast_noc_y.push_back(device->worker_core_from_logical_core(CoreCoord(0, core_index)).y);
+    }
+
+    tt::tt_metal::Buffer* weights_buffer = b.buffer();
+    tt::tt_metal::Buffer* bias_buffer = bias ? bias->buffer() : nullptr;
+    auto total_num_active_cores = std::max(input_num_cores, output_num_cores);
+    auto total_num_cores = all_reader_cores.size();
+    act_kernel_desc.runtime_args.reserve(total_num_cores);
+    weights_kernel_desc.runtime_args.reserve(total_num_active_cores);
+    for (uint32_t core_index = 0; core_index < total_num_cores; core_index++) {
+        uint32_t core_x = core_index % full_core_grid.x;
+        uint32_t core_y = core_index / full_core_grid.x;
+        std::vector<uint32_t> rt_args = {
+            core_x,
+            core_y,
+            full_core_grid.x,  // num_cores_x
+        };
+
+        // Mcast X Lookup table
+        rt_args.insert(rt_args.end(), act_mcast_noc_x.begin(), act_mcast_noc_x.end());
+
+        // Mcast Y Lookup Table
+        rt_args.insert(rt_args.end(), act_mcast_noc_y.begin(), act_mcast_noc_y.end());
+
+        act_kernel_desc.runtime_args.emplace_back(CoreCoord(core_x, core_y), std::move(rt_args));
+
+        // Weights kernel is not placed on inactive cores.  Weights[1] is the
+        // weight buffer base address and bias[2] is the (optional) bias address;
+        // emplace_runtime_args registers them as buffer bindings so the
+        // framework's fast cache-hit path patches addresses without
+        // GetRuntimeArgs.  When bias is absent we embed a literal 0 — has_bias
+        // gates the bias read on the kernel side.
+        if (core_index < total_num_active_cores) {
+            KernelDescriptor::RTArgList weights_rt_args;
+            weights_rt_args.reserve(4);
+            weights_rt_args.push_back(static_cast<uint32_t>(core_index * weight_block_w_ntiles));
+            weights_rt_args.push_back(weights_buffer);
+            if (bias_buffer != nullptr) {
+                weights_rt_args.push_back(bias_buffer);
+            } else {
+                weights_rt_args.push_back(uint32_t{0});
+            }
+            weights_rt_args.push_back(static_cast<uint32_t>(core_index < output_num_cores));
+            weights_kernel_desc.emplace_runtime_args(CoreCoord(core_x, core_y), weights_rt_args);
+        }
+    }
+
+    // Descriptor-path CB-size check (mirrors the legacy post_conv2d_op_memory_checks
+    // CB-sizing equality).  The L1-allocator delta half of the legacy check requires a
+    // realised Program and so isn't reachable here: the framework realises the Program
+    // after this function returns.
+    post_conv2d_op_memory_checks_descriptor(desc, operation_attributes, tensor_args, reader_indices_actual_page_size);
+
+    desc.kernels.push_back(std::move(act_kernel_desc));
+    desc.kernels.push_back(std::move(weights_kernel_desc));
+    desc.kernels.push_back(std::move(compute_kernel_desc));
+    return desc;
+}
+
+}  // namespace
+
+tt::tt_metal::WorkloadDescriptor Conv2dWidthShardedProgramFactory::create_workload_descriptor(
+    const Conv2dParams& operation_attributes,
+    const Conv2dInputs& tensor_args,
+    Tensor& output_tensor,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
+
+    // Allocate the conv_reader_indices tensor on device once for the whole
+    // workload.  Wrap it in a shared_ptr<Tensor> so ~Tensor doesn't fire when
+    // the local goes out of scope: ~Tensor calls DeviceStorage::deallocate
+    // which force-frees the device buffer regardless of any shared_ptr
+    // ownership of the MeshBuffer (see WorkloadBuffer rationale in
+    // workload_descriptor.hpp).  Holding the Tensor in the WorkloadDescriptor
+    // defers destruction until the cached workload is evicted.
+    const auto& a = tensor_args.a;
+    const auto& sliding_window_config = operation_attributes.sliding_window_config;
+    const bool config_tensors_in_dram = operation_attributes.config_tensors_in_dram;
+
+    ttnn::operations::sliding_window::ParallelConfig parallel_config{
+        .grid = a.shard_spec().value().grid,
+        .shard_scheme = a.memory_config().memory_layout(),
+        .shard_orientation = a.shard_spec().value().orientation};
+
+    std::vector<uint32_t> op_trace_metadata =
+        ttnn::operations::sliding_window::generate_op_trace_metadata(sliding_window_config);
+    std::vector<sliding_window::ShardBoundary> shard_boundaries =
+        ttnn::operations::sliding_window::generate_shard_boundaries(sliding_window_config);
+    const uint32_t stride_w = sliding_window_config.is_transpose ? 1 : (uint32_t)sliding_window_config.stride_hw.second;
+    const uint32_t act_block_h_ntiles = operation_attributes.block_config.act_block_h_ntiles;
+    const uint32_t act_block_h_datums = act_block_h_ntiles * tt::constants::TILE_HEIGHT;
+
+    std::vector<std::vector<uint16_t>> conv_sharded_input_top_left_indices =
+        ttnn::operations::sliding_window::generate_sliding_window_op_config(
+            op_trace_metadata, shard_boundaries, stride_w, true, act_block_h_datums, 0);
+
+    Tensor conv_reader_indices_tensor = ttnn::operations::sliding_window::construct_on_host_config_tensor(
+        conv_sharded_input_top_left_indices, parallel_config, config_tensors_in_dram);
+    conv_reader_indices_tensor = ttnn::operations::sliding_window::move_config_tensor_to_device(
+        conv_reader_indices_tensor, parallel_config, false, a.device(), config_tensors_in_dram);
+
+    log_trace(tt::LogOp, "Conv2D Config Tensor : {}", conv_reader_indices_tensor);
+
+    auto conv_reader_indices_tensor_owner = std::make_shared<Tensor>(std::move(conv_reader_indices_tensor));
+    tt::tt_metal::Buffer* conv_reader_indices_buffer = conv_reader_indices_tensor_owner->buffer();
+    workload_descriptor.buffers.push_back({conv_reader_indices_tensor_owner, conv_reader_indices_buffer});
+
+    // Single-device op: per-coord program is structurally identical for every
+    // coord in `tensor_coords` (conv2d doesn't depend on cluster position).
+    // Build the ProgramDescriptor once and copy into each range entry.
+    tt::tt_metal::ProgramDescriptor desc =
+        build_program_descriptor(operation_attributes, tensor_args, output_tensor, conv_reader_indices_buffer);
+
+    auto ranges = tensor_coords.ranges();
+    workload_descriptor.programs.reserve(ranges.size());
+    for (size_t i = 0; i + 1 < ranges.size(); ++i) {
+        workload_descriptor.programs.push_back({ranges[i], desc});
+    }
+    if (!ranges.empty()) {
+        workload_descriptor.programs.push_back({ranges.back(), std::move(desc)});
+    }
+    return workload_descriptor;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_width_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_width_sharded_program_factory.hpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <tt-metalium/workload_descriptor.hpp>
+#include "ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp"
+#include "ttnn/device_operation.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct Conv2dWidthShardedProgramFactory {
+    // Builds the workload in one call (cache miss).  The intermediate
+    // conv_reader_indices tensor — which must outlive the cached program — is
+    // allocated here and parked on the WorkloadDescriptor's `buffers` vector
+    // (wrapped in `shared_ptr<Tensor>` so `~Tensor` cannot force-deallocate the
+    // device memory while the cached program is still alive).
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
+        const Conv2dParams& operation_attributes,
+        const Conv2dInputs& tensor_args,
+        Tensor& output_tensor,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/activation_reader_width_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/activation_reader_width_sharded.cpp
@@ -1,0 +1,282 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <api/dataflow/dataflow_api.h>
+#include "conv_reader_common.hpp"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
+
+#define ENABLE_DEBUG 0
+
+#if ENABLE_DEBUG
+#include "api/debug/dprint.h"
+#include "api/debug/dprint_pages.h"
+#endif
+
+constexpr uint32_t weight_size_h = get_compile_time_arg_val(5);
+constexpr uint32_t weight_size_w = get_compile_time_arg_val(6);
+// Only a part of the total channel depth (width) is used in one block.
+template <int window_height, int window_width>
+FORCE_INLINE void read_channels(
+    Noc noc,
+    uint32_t& l1_write_addr_act,
+    const uint32_t act_l1_read_addr,
+    const uint32_t reader_channel_idx,
+    const uint32_t conv_act_c_bytes,
+    const uint32_t conv_act_c_read_bytes,
+    const uint32_t stride_h_bytes,
+    const uint32_t stride_w_bytes) {
+    uint32_t act_l1_read_addr_plus_offset = act_l1_read_addr + (reader_channel_idx * conv_act_c_bytes);
+#pragma GCC unroll weight_size_h
+    for (uint32_t outer = 0; outer < window_height; outer++) {
+        uint32_t act_l1_read_addr_row_offset = act_l1_read_addr_plus_offset;
+#pragma GCC unroll weight_size_w
+        for (uint32_t inner = 0; inner < window_width; inner++) {
+            // Read the partial depth.
+            experimental::read_with_state(noc, l1_write_addr_act, act_l1_read_addr_row_offset);
+            // Increment by full depth to go to the next pixel
+            l1_write_addr_act += conv_act_c_read_bytes;
+            act_l1_read_addr_row_offset += stride_w_bytes;
+        }
+        // Go to the next row
+        act_l1_read_addr_plus_offset += stride_h_bytes;
+    }
+}
+
+void kernel_main() {
+    constexpr uint32_t stride_w = get_compile_time_arg_val(0);
+    constexpr uint32_t dilation_h = get_compile_time_arg_val(1);
+    constexpr uint32_t dilation_w = get_compile_time_arg_val(2);
+    constexpr uint32_t conv_act_size_w = get_compile_time_arg_val(3);
+    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(4);
+    constexpr uint32_t act_block_h_datums = get_compile_time_arg_val(7);
+    constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(8);
+    constexpr uint32_t num_input_cores = get_compile_time_arg_val(9);
+    constexpr uint32_t act_num_blocks_h = get_compile_time_arg_val(10);
+    constexpr uint32_t act_num_blocks_w = get_compile_time_arg_val(11);
+    Semaphore<> act_mcast_sender_sem(get_compile_time_arg_val(12));
+    Semaphore<> act_mcast_receiver_sem(get_compile_time_arg_val(13));
+    constexpr McastRect mcast_rect = {
+        get_compile_time_arg_val(14),
+        get_compile_time_arg_val(15),
+        get_compile_time_arg_val(16),
+        get_compile_time_arg_val(17)};
+    constexpr uint32_t act_mcast_sender_size_bytes = get_compile_time_arg_val(18);
+    constexpr uint32_t num_output_cores = get_compile_time_arg_val(19);
+    constexpr uint32_t num_reader_cores = get_compile_time_arg_val(20);
+
+    constexpr uint32_t cb_id_act = get_compile_time_arg_val(21);
+    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(22);
+    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(23);
+    constexpr uint32_t cb_id_act_row_major_bfloat16 = get_compile_time_arg_val(25);
+    constexpr uint32_t tilized_in0_cb_id = get_compile_time_arg_val(26);
+
+    constexpr uint32_t num_mcast_cores = num_input_cores > num_output_cores ? num_input_cores : num_output_cores;
+    uint32_t i = 0;  // Runtime arg index
+
+    uint32_t this_core_x = get_arg_val<uint32_t>(i);
+    i += 1;
+    uint32_t this_core_y = get_arg_val<uint32_t>(i);
+    i += 1;
+
+    // Num of cols of compute cores. (Total Cores, not active cores.)
+    uint32_t num_cores_x = get_arg_val<uint32_t>(i);
+    i += 1;
+
+    // X and Y lookup are independent.
+    // X Lookup table for translating logical to physical cores.
+    tt_l1_ptr uint32_t* act_mcast_x_lookup = (tt_l1_ptr uint32_t*)(get_arg_addr(i));
+    i += num_cores_x;
+    // Y lookup.
+    tt_l1_ptr uint32_t* act_mcast_y_lookup = (tt_l1_ptr uint32_t*)(get_arg_addr(i));
+
+    // Equivalent to Core Index.
+    uint32_t this_core_id = this_core_x + (num_cores_x * this_core_y);
+
+    if (this_core_id >= num_mcast_cores) {
+        return;
+    }
+
+    // Experimental API objects
+    experimental::CB reader_indices_cb(cb_reader_indices);
+    experimental::CB act_rm_cb(cb_id_act_row_major_bfloat16);
+    experimental::CB act_cb(cb_id_act);
+    experimental::CB tilized_in0_cb(tilized_in0_cb_id);
+    experimental::CB sharded_act_cb(cb_id_sharded_act);
+    Noc noc;
+
+    load_config_tensor_if_in_dram<27, 28, 29, cb_reader_indices>(noc, reader_indices_cb, 0);
+
+    volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reader_indices_cb.get_write_ptr());
+
+    // Experimental API multicast endpoint
+    MulticastEndpoint mcast_ep;
+    // Pre-built mcast destination; .addr is updated per mcast call
+    McastDst mcast_dst = {
+        .noc_x_start = mcast_rect.noc_x_start,
+        .noc_y_start = mcast_rect.noc_y_start,
+        .noc_x_end = mcast_rect.noc_x_end,
+        .noc_y_end = mcast_rect.noc_y_end,
+        .addr = 0};
+
+    // Set up remote VALID value
+    act_mcast_receiver_sem.set(VALID);
+
+    // Compute is divided along the width to reduce the size of CBs.
+    // Only a part of the width on each core is used in one block.
+    // Bytes read is conv_act_c_read_bytes.
+    // Size of channel in bytes on this core is conv_act_c_bytes.
+    constexpr uint32_t conv_act_c_bytes = conv_act_c_read_bytes * act_num_blocks_w;
+
+    // Stride after each channel read.
+    constexpr uint32_t stride_w_bytes = conv_act_c_bytes * dilation_w;
+
+    // Striding to next row happens using stride_h_bytes
+    constexpr uint32_t stride_h_bytes = (conv_act_size_w)*conv_act_c_bytes * dilation_h;
+
+    uint32_t act_l1_read_addr = sharded_act_cb.get_read_ptr();
+    experimental::set_read_state<conv_act_c_read_bytes>(noc, act_l1_read_addr);
+    uint32_t reader_idx = 0;
+    uint32_t l1_write_addr_act = 0;
+
+    constexpr uint32_t TILE_HEIGHT = 32;
+    constexpr uint32_t ntile_height = act_block_h_datums / TILE_HEIGHT;
+    constexpr uint32_t ntile_width = act_block_num_tiles / ntile_height;
+
+    // Reset reader_idx to finish act_block_h_datums
+    for (uint32_t block_h_index = 0; block_h_index < act_num_blocks_h; block_h_index++) {
+        act_l1_read_addr = sharded_act_cb.get_read_ptr();
+        uint32_t old_reader_idx = reader_idx;
+        for (uint32_t block_w_index = 0; block_w_index < act_num_blocks_w; block_w_index++) {
+            reader_idx = old_reader_idx;
+            if (this_core_id < num_input_cores) {
+                uint32_t two_reader_indices = packed_reader_indices_ptr[reader_idx];
+                uint16_t num_elems = two_reader_indices & 0xffff;
+
+                uint16_t remaining_indexes = TILE_HEIGHT;
+                while (num_elems--) {
+                    reader_idx++;
+                    two_reader_indices = packed_reader_indices_ptr[reader_idx];
+                    uint16_t start_ind = two_reader_indices & 0xffff;
+                    uint16_t end_ind = two_reader_indices >> 16;
+                    for (uint16_t ind = start_ind; ind <= end_ind; ind += stride_w) {
+                        if (remaining_indexes == TILE_HEIGHT) {
+                            l1_write_addr_act = act_rm_cb.get_write_ptr();
+                            act_rm_cb.reserve_back(ntile_width);
+                        }
+                        read_channels<weight_size_h, weight_size_w>(
+                            noc,
+                            l1_write_addr_act,
+                            act_l1_read_addr,
+                            ind,
+                            conv_act_c_bytes,
+                            conv_act_c_read_bytes,
+                            stride_h_bytes,
+                            stride_w_bytes);
+
+                        if (--remaining_indexes == 0) {
+                            noc.async_read_barrier();
+                            act_rm_cb.push_back(ntile_width);
+                            l1_write_addr_act = act_rm_cb.get_write_ptr();
+                            remaining_indexes = TILE_HEIGHT;
+                        }
+                    }
+                }
+                if (remaining_indexes && remaining_indexes != TILE_HEIGHT) {
+                    noc.async_read_barrier();
+                    act_rm_cb.push_back(ntile_width);
+                }
+                reader_idx++;
+
+                // After reading one block, increment the starting read pointer by the width of the block.
+                // Next read uses the next set of channels.
+                act_l1_read_addr += conv_act_c_read_bytes;
+            } else {
+                for (uint32_t tile_h_index = 0; tile_h_index < ntile_height; tile_h_index++) {
+                    act_rm_cb.reserve_back(ntile_width);
+                    act_rm_cb.push_back(ntile_width);
+                }
+            }
+
+            // Round robin self-mcast and receive tilized act matrix in cb_id_act
+            // Compute should function like regular mm
+#ifndef SKIP_MCAST
+            for (uint32_t act_w_outer_i = 0; act_w_outer_i < num_input_cores; act_w_outer_i++) {
+                act_cb.reserve_back(act_block_num_tiles);
+                if (act_w_outer_i == this_core_id) {
+                    // MCAST SENDER: send entire tilized input to other cores in column
+                    // wait until all act mcast destinations have atomically incremented the act semaphore_addr (i.e.
+                    // its value should be act_mcast_num_dests), then reset the semaphore_addr value back to zero for
+                    // the next block
+
+                    act_mcast_sender_sem.wait_min(num_mcast_cores - 1);
+                    act_mcast_sender_sem.set(0);
+
+                    act_mcast_receiver_sem.set(INVALID);
+
+                    // compute tilizes and pops cb_id_act and pushes to tilized_in0_cb_id
+                    tilized_in0_cb.wait_front(act_block_num_tiles);
+
+                    // Now we have the block in the CB address, we can mcast to dests!
+                    auto tilized_src = use<CircularBuffer::AddrSelector::READ_PTR>(tilized_in0_cb);
+
+                    // Multicast tilized activations to all reader cores (including self)
+                    mcast_dst.addr = act_cb.get_write_ptr();
+                    noc.async_write_multicast<NocOptions::MCAST_INCL_SRC>(
+                        tilized_src,
+                        mcast_ep,
+                        act_mcast_sender_size_bytes,
+                        num_reader_cores,
+                        {.offset_bytes = 0},
+                        mcast_dst,
+                        true);
+
+                    // Note: no need for write barrier, since these two multicasts are done on the same noc id and same
+                    // vc even though cmd bufs are different Also, this only works because we are setting VCs statically
+                    // (using NOC_CMD_STATIC_VC).
+
+                    // Multicast VALID flag to destinations for receiver semaphore.
+                    // The old code used a separate scratch L1 address as the multicast source
+                    // and wait(VALID) on the loopback as a fence. The new Semaphore::set_multicast
+                    // API uses the semaphore itself as both source and destination, so we can't
+                    // clear the local value and wait for loopback — use write barrier instead.
+                    act_mcast_receiver_sem.set(VALID);
+                    act_mcast_receiver_sem.set_multicast<NocOptions::MCAST_INCL_SRC>(
+                        noc,
+                        mcast_rect.noc_x_start,
+                        mcast_rect.noc_y_start,
+                        mcast_rect.noc_x_end,
+                        mcast_rect.noc_y_end,
+                        num_reader_cores);
+                    noc.async_write_barrier();
+                } else {
+                    // MCAST RECEIVER: receive entire tilized input from sender core
+                    // Set act semaphore value to INVALID
+                    act_mcast_receiver_sem.set(INVALID);
+
+                    // Compute sender's logical coordinates from iteration index
+                    uint32_t sender_logical_x = act_w_outer_i % num_cores_x;
+                    uint32_t sender_logical_y = act_w_outer_i / num_cores_x;
+
+                    // Lookup physical coordinates
+                    uint32_t sender_x = act_mcast_x_lookup[sender_logical_x];
+                    uint32_t sender_y = act_mcast_y_lookup[sender_logical_y];
+
+                    // Atomic increment source core counter
+                    act_mcast_sender_sem.up(noc, sender_x, sender_y, 1);
+
+                    // wait on act semaphore value to become VALID (set by mcast sender after it multicasts data)
+                    act_mcast_receiver_sem.wait(VALID);
+                }
+
+                act_cb.push_back(act_block_num_tiles);
+
+            }  // num_input_cores
+            tilized_in0_cb.pop_front(act_block_num_tiles);
+#endif
+        }
+    }
+    noc.async_read_barrier();
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/compute_depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/compute_depthwise_conv1d.cpp
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/tilize.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/reconfig_data_format.h"
+#include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
+
+// Compute one block (one kernel-tap slice) of a 1D depthwise conv.
+//
+// Per output tile:
+//   dst[0]  = in0 * in1                                                 (FPU mul)
+//   if idx > 0: dst[0] += prior partial loaded from out_cb              (FPU add via DST reuse)
+//   pack dst[0] -> out_cb
+//
+// `idx` is the kernel-tap block index (0 .. filter_h*filter_w-1). The very first call (idx == 0)
+// initializes out_cb with the tap-0 product; subsequent calls accumulate via the DST_TO_SRCB
+// dest-reuse pattern, which keeps the running partial in DST and only pulls the prior partial
+// from L1. This gives a single pack per output tile (to out_cb) and avoids the pack-format flips
+// that corrupt block-float (BFLOAT8_B/BFLOAT4_B) outputs in the round-tripped variant — while
+// still using FPU (not SFPU) for the add.
+//
+// srcB (cfg92) tile descriptor: must match in1 for the mul, and is repopulated from DST for the
+// dest-reuse add. We force srcB back to in1's format every iteration so block-float weights are
+// decoded correctly.
+inline void mul_and_accumulate_block(
+    experimental::CB in0_cb, experimental::CB in1_cb, experimental::CB out_cb, uint32_t block_num_tiles, uint32_t idx) {
+    const uint32_t in0_cb_id = in0_cb.get_cb_id();
+    const uint32_t in1_cb_id = in1_cb.get_cb_id();
+    const uint32_t out_cb_id = out_cb.get_cb_id();
+
+    for (uint32_t i = 0; i < block_num_tiles; i++) {
+        in1_cb.wait_front(1);
+        in0_cb.wait_front(1);
+
+        tile_regs_acquire();
+        // mul: srcA = in0 (bf16), srcB = in1 (bf8/bf16) -> dst[0]
+        reconfig_data_format_srcb(in1_cb_id);
+        mul_tiles_init(in0_cb_id, in1_cb_id);
+        mul_tiles(in0_cb_id, in1_cb_id, 0, 0, 0);
+
+        if (idx != 0) {
+            // dest-reuse add: dst[0] += out_cb. srcA gets out_cb (cfg52 must match out_cb fmt);
+            // srcB is filled from dst[0] by the dest-reuse path.
+            reconfig_data_format_srca(out_cb_id);
+            binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
+                out_cb_id);
+            out_cb.wait_front(1);
+            binary_dest_reuse_tiles<EltwiseBinaryType::ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
+                out_cb_id, 0, 0);
+            out_cb.pop_front(1);
+
+            // Restore srcA to in0's format for the next iteration's mul unpack.
+            reconfig_data_format_srca(in0_cb_id);
+        }
+        tile_regs_commit();
+
+        out_cb.reserve_back(1);
+        tile_regs_wait();
+        pack_tile(0, out_cb_id);
+        out_cb.push_back(1);
+        tile_regs_release();
+
+        in0_cb.pop_front(1);
+        in1_cb.pop_front(1);
+    }
+}
+
+template <uint32_t in0_block_w, uint32_t kernel_width, uint32_t block_num_tiles>
+inline void mul_and_accumulate_coalesced_block(
+    experimental::CB in0_cb, experimental::CB in1_cb, experimental::CB out_cb) {
+    static_assert(kernel_width > 1);
+    static_assert(in0_block_w % kernel_width == 0);
+    static_assert(block_num_tiles % in0_block_w == 0);
+
+    constexpr uint32_t in_channels_ntiles = in0_block_w / kernel_width;
+    constexpr uint32_t act_block_h_ntiles = block_num_tiles / in0_block_w;
+
+    const uint32_t in0_cb_id = in0_cb.get_cb_id();
+    const uint32_t in1_cb_id = in1_cb.get_cb_id();
+    const uint32_t out_cb_id = out_cb.get_cb_id();
+
+    in0_cb.wait_front(block_num_tiles);
+    in1_cb.wait_front(block_num_tiles);
+
+    for (uint32_t h = 0; h < act_block_h_ntiles; ++h) {
+        for (uint32_t c = 0; c < in_channels_ntiles; ++c) {
+            tile_regs_acquire();
+            reconfig_data_format_srca(in0_cb_id);
+            reconfig_data_format_srcb(in1_cb_id);
+
+            for (uint32_t tap = 0; tap < kernel_width; ++tap) {
+                const uint32_t act_tile_idx = h * in0_block_w + tap * in_channels_ntiles + c;
+                const uint32_t weight_tile_idx =
+                    tap * act_block_h_ntiles * in_channels_ntiles + h * in_channels_ntiles + c;
+                mul_tiles_init(in0_cb_id, in1_cb_id, tap != 0 ? 1U : 0U, __builtin_LINE());
+                mul_tiles(in0_cb_id, in1_cb_id, act_tile_idx, weight_tile_idx, 0);
+            }
+            tile_regs_commit();
+
+            out_cb.reserve_back(1);
+            tile_regs_wait();
+            pack_tile(0, out_cb_id);
+            out_cb.push_back(1);
+            tile_regs_release();
+        }
+    }
+
+    in0_cb.pop_front(block_num_tiles);
+    in1_cb.pop_front(block_num_tiles);
+}
+
+void kernel_main() {
+    constexpr uint32_t in0_block_w = get_compile_time_arg_val(0);
+    constexpr uint32_t in0_num_subblocks = get_compile_time_arg_val(1);
+    constexpr uint32_t in0_block_num_tiles = get_compile_time_arg_val(2);
+    constexpr uint32_t in0_num_blocks_h = get_compile_time_arg_val(3);
+    constexpr uint32_t in0_num_blocks_w = get_compile_time_arg_val(4);
+    constexpr uint32_t in0_cb_id = get_compile_time_arg_val(5);
+    constexpr uint32_t in1_cb_id = get_compile_time_arg_val(6);
+    constexpr uint32_t tilized_in0_cb_id = get_compile_time_arg_val(7);
+    constexpr uint32_t out_cb_id = get_compile_time_arg_val(8);
+    constexpr uint32_t kernel_width = get_compile_time_arg_val(9);
+    constexpr bool coalesce_kw_reads = get_compile_time_arg_val(10) == 1;
+
+    experimental::CB cb_tilized_in0(tilized_in0_cb_id);
+    experimental::CB cb_in1(in1_cb_id);
+    experimental::CB cb_out(out_cb_id);
+
+    // binary_op_init_common configures pack for out_cb, math for in0/in1, and unpack for in0/in1.
+    // The pack target never changes (we only ever pack to out_cb), so no further pack reconfig is
+    // needed for the lifetime of the kernel.
+    binary_op_init_common(in0_cb_id, in1_cb_id, out_cb_id);
+
+    for (uint32_t in0_block_h_i = 0; in0_block_h_i < in0_num_blocks_h; ++in0_block_h_i) {
+        for (uint32_t in0_block_w_i = 0; in0_block_w_i < in0_num_blocks_w; ++in0_block_w_i) {
+            compute_kernel_lib::tilize<in0_block_w, in0_cb_id, tilized_in0_cb_id>(in0_num_subblocks);
+            reconfig_data_format_srca(tilized_in0_cb_id);
+            if constexpr (coalesce_kw_reads) {
+                mul_and_accumulate_coalesced_block<in0_block_w, kernel_width, in0_block_num_tiles>(
+                    cb_tilized_in0, cb_in1, cb_out);
+            } else {
+                const uint32_t idx = in0_block_h_i * in0_num_blocks_w + in0_block_w_i;
+                mul_and_accumulate_block(cb_tilized_in0, cb_in1, cb_out, in0_block_num_tiles, idx);
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_bmm_tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_bmm_tilize.cpp
@@ -1,0 +1,679 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "internal/mod_div_lib.h"
+#include "api/compute/bcast.h"
+#include "api/compute/eltwise_unary/sfpu_split_includes.h"
+#include "api/compute/matmul.h"
+#include "api/compute/pack_untilize.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/tilize.h"
+#include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
+
+// #include "api/debug/dprint.h"
+
+#define DEBUG_PRINT 0
+
+#ifdef SPLIT_READER
+template <
+    uint32_t in_block_w,
+    uint32_t in_cb_id,
+    uint32_t out_cb_id,
+    bool init_tilize = true,
+    bool uninit_tilize = true>
+__attribute__((noinline)) void tilize_in(
+#else
+template <
+    uint32_t in_block_w,
+    uint32_t in_cb_id,
+    uint32_t out_cb_id,
+    bool init_tilize = true,
+    bool uninit_tilize = true>
+void tilize_in(
+#endif
+    uint32_t in_num_subblocks) {
+    constexpr compute_kernel_lib::tilize_config::InitUninitMode init_uninit_mode =
+        init_tilize ? (uninit_tilize ? compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit
+                                     : compute_kernel_lib::tilize_config::InitUninitMode::InitOnly)
+                    : (uninit_tilize ? compute_kernel_lib::tilize_config::InitUninitMode::UninitOnly
+                                     : compute_kernel_lib::tilize_config::InitUninitMode::Neither);
+    // Split-reader fires tilize_in twice back-to-back (first: init=true+uninit=false,
+    // second: init=false+uninit=true). The second call must NOT reconfig datatypes —
+    // doing so clobbers the bf16 SrcA override that fast_tilize_init installs for
+    // fp32 input on BH (see _llk_unpack_fast_tilize_init_), breaking the second
+    // tilize's MOP. Only reconfig on the init call; continuation reuses that state.
+    constexpr auto reconfig_mode =
+        init_tilize ? compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::UnpackReconfigure
+                    : compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure;
+    compute_kernel_lib::tilize<
+        in_block_w,
+        in_cb_id,
+        out_cb_id,
+        init_uninit_mode,
+        compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
+        reconfig_mode>(in_num_subblocks);
+}  // tilize_in()
+
+template <uint32_t in_cb_id, uint32_t in_block_w, uint32_t out_cb_id>
+inline void tilize_single_block(experimental::CB in_cb) {
+    in_cb.wait_front(in_block_w);
+    fast_tilize_block(in_cb_id, in_block_w, out_cb_id);
+    in_cb.pop_front(in_block_w);
+}
+
+template <uint32_t in_cb_id, uint32_t window_reuse_offset>
+inline uint32_t update_in_cb(uint32_t in_cb_addr) {
+    UNPACK((get_local_cb_interface(in_cb_id).fifo_rd_ptr = in_cb_addr));
+    return in_cb_addr + window_reuse_offset;
+}
+
+template <uint32_t in_cb_id, uint32_t in_block_w, uint32_t out_cb_id, uint32_t tilized_cb_row_offset>
+inline void tilize_single_block_with_out_cb_update(experimental::CB in_cb, uint32_t& out_cb_addr) {
+    PACK((get_local_cb_interface(out_cb_id).fifo_wr_ptr = out_cb_addr));
+    PACK((out_cb_addr += tilized_cb_row_offset));
+    tilize_single_block<in_cb_id, in_block_w, out_cb_id>(in_cb);
+}
+
+template <
+    uint32_t in1_cb_id,
+    uint32_t in2_cb_id,
+    uint32_t in_block_w,
+    uint32_t in1_num_subblocks,
+    uint32_t in2_num_subblocks,
+    uint32_t out_cb_id,
+    uint32_t out_cb_tiles,
+    uint32_t window_reuse_offset,
+    uint32_t tilized_cb_row_offset,
+    uint32_t tilized_cb_second_reader_offset,
+    uint32_t image_width_in_tiles>
+inline void tilize_in_reuse_split_reader(
+    experimental::CB in1_cb,
+    experimental::CB in2_cb,
+    experimental::CB out_cb,
+    uint32_t act_cb_start_address,
+    uint32_t act_cb_second_reader_start_address) {
+    // with activation reuse, the activation buffers are sized to fit one output image width only,
+    // so we need to interleave waits and pops on the two buffers to allow parallelization;
+    // we reserve back tilized CB to store whole act block h - and then we update write pointers so that
+    // we fill in first row of the first half (NCRISC), first row of the second half (BRISC) and so on
+    out_cb.reserve_back(out_cb_tiles);
+    fast_tilize_init_with_dt(in1_cb_id, in_block_w, out_cb_id);
+
+    uint32_t in1_cb_addr = act_cb_start_address;
+    uint32_t in2_cb_addr = act_cb_second_reader_start_address;
+
+    uint32_t out_cb_addr, out_cb_addr_second_reader, out_cb_addr_init;
+    PACK((out_cb_addr_init = get_local_cb_interface(out_cb_id).fifo_wr_ptr));
+    PACK((out_cb_addr = out_cb_addr_init));
+    PACK((out_cb_addr_second_reader = out_cb_addr_init + tilized_cb_second_reader_offset));
+
+    constexpr uint32_t min_num_subblocks =
+        in1_num_subblocks > in2_num_subblocks ? in2_num_subblocks : in1_num_subblocks;
+    constexpr uint32_t min_num_image_rows = min_num_subblocks / image_width_in_tiles;
+    constexpr uint32_t leftover_in1 = in1_num_subblocks - min_num_image_rows * image_width_in_tiles;
+    constexpr uint32_t leftover_in2 = in2_num_subblocks - min_num_image_rows * image_width_in_tiles;
+    constexpr uint32_t max_leftover = leftover_in1 > leftover_in2 ? leftover_in1 : leftover_in2;
+
+    // process minimum number of image rows for both readers in the same loop
+    for (uint32_t image_row = 0; image_row < min_num_image_rows; ++image_row) {
+        // each time we start processing a new image row, we need to update the read pointer to the appropriate offset
+        // from the start of the CB to match the reader behavior
+        in1_cb_addr = update_in_cb<in1_cb_id, window_reuse_offset>(in1_cb_addr);
+        in2_cb_addr = update_in_cb<in2_cb_id, window_reuse_offset>(in2_cb_addr);
+        for (uint32_t image_col = 0; image_col < image_width_in_tiles; ++image_col) {
+            tilize_single_block_with_out_cb_update<in1_cb_id, in_block_w, out_cb_id, tilized_cb_row_offset>(
+                in1_cb, out_cb_addr);
+            tilize_single_block_with_out_cb_update<in2_cb_id, in_block_w, out_cb_id, tilized_cb_row_offset>(
+                in2_cb, out_cb_addr_second_reader);
+        }
+    }
+
+    // leftover image rows if one reader had more rows than the other
+    in1_cb_addr = update_in_cb<in1_cb_id, window_reuse_offset>(in1_cb_addr);
+    in2_cb_addr = update_in_cb<in2_cb_id, window_reuse_offset>(in2_cb_addr);
+    for (uint32_t image_col = 0; image_col < max_leftover; ++image_col) {
+        if (image_col < leftover_in1) {
+            tilize_single_block_with_out_cb_update<in1_cb_id, in_block_w, out_cb_id, tilized_cb_row_offset>(
+                in1_cb, out_cb_addr);
+
+            if (image_col == image_width_in_tiles - 1) {
+                in1_cb_addr = update_in_cb<in1_cb_id, window_reuse_offset>(in1_cb_addr);
+            }
+        }
+
+        if (image_col < leftover_in2) {
+            tilize_single_block_with_out_cb_update<in2_cb_id, in_block_w, out_cb_id, tilized_cb_row_offset>(
+                in2_cb, out_cb_addr_second_reader);
+
+            if (image_col == image_width_in_tiles - 1) {
+                in2_cb_addr = update_in_cb<in2_cb_id, window_reuse_offset>(in2_cb_addr);
+            }
+        }
+    }
+
+    // Restore fifo_wr_ptr to the reserved-region base so push_back advances from a
+    // known starting point. Without this, push_back's fifo_wr_ptr += num_words
+    // starts from whichever mid-region offset the last tilize_single_block left
+    // and trips the LLK bounds assert (see GH #42510).
+    PACK((get_local_cb_interface(out_cb_id).fifo_wr_ptr = out_cb_addr_init));
+    out_cb.push_back(out_cb_tiles);
+    fast_tilize_uninit(in2_cb_id, out_cb_id, in_block_w);
+}
+
+template <uint32_t out_subblock_w, uint32_t out_block_w>
+inline void reblock_and_untilize(
+    experimental::CB interm_cb,
+    experimental::CB out_cb,
+    uint32_t num_out_subblocks_in_col,
+    uint32_t out_subblock_num_tiles,
+    uint32_t out_subblock_h) {
+    const uint32_t interm_cb_id = interm_cb.get_cb_id();
+    const uint32_t out_cb_id = out_cb.get_cb_id();
+    uint32_t num_tiles_in_row_of_subblocks = mulsi3(out_subblock_num_tiles, num_out_subblocks_in_col);
+    interm_cb.wait_front(num_tiles_in_row_of_subblocks);
+    uint32_t within_block_index = 0;
+    for (uint32_t h = 0; h < out_subblock_h; h++) {
+        uint32_t block_offset = 0;
+        out_cb.reserve_back(out_block_w);
+        for (uint32_t n = 0; n < num_out_subblocks_in_col; n++) {
+            tile_regs_acquire();
+            for (uint32_t w = 0; w < out_subblock_w; w++) {
+                uint32_t tile_index = block_offset + within_block_index + w;
+                copy_tile(interm_cb_id, tile_index, w);
+            }
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_untilize_dest<out_subblock_w, out_block_w>(out_cb_id, 1, n);
+            tile_regs_release();
+            block_offset += out_subblock_num_tiles;
+        }
+        out_cb.push_back(out_block_w);
+        within_block_index += out_subblock_w;
+    }
+    interm_cb.pop_front(num_tiles_in_row_of_subblocks);
+}
+
+void kernel_main() {
+    constexpr uint32_t in0_block_w = get_compile_time_arg_val(0);        // inner block size in tiles
+    constexpr uint32_t in0_num_subblocks = get_compile_time_arg_val(1);  // outer row block size (in inner row blocks)
+    constexpr uint32_t in0_block_num_tiles =
+        get_compile_time_arg_val(2);  // out_subblock_h*in0_block_w*in0_num_subblocks;
+    constexpr uint32_t in0_subblock_num_tiles = get_compile_time_arg_val(3);  // out_subblock_h*in0_block_w
+    constexpr uint32_t reader_num_h_subblocks = get_compile_time_arg_val(4);
+    constexpr uint32_t in1_num_subblocks =
+        get_compile_time_arg_val(5);  // outer column block size (in inner column blocks)
+    constexpr uint32_t in1_block_num_tiles =
+        get_compile_time_arg_val(6);                               // out_subblock_w*in0_block_w* in1_num_subblocks;
+    constexpr uint32_t in1_block_w = get_compile_time_arg_val(7);  // out_subblock_w*in1_num_subblocks
+    // if these are not defined as volatile, it causes code size for TRISC2 to be too large if num_blocks > 1
+    constexpr uint32_t in0_num_blocks_h = get_compile_time_arg_val(8);
+    constexpr uint32_t in0_num_blocks_w = get_compile_time_arg_val(9);
+    constexpr uint32_t in1_num_blocks_w = get_compile_time_arg_val(10);
+    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(11);          // inner row block size in tiles
+    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(12);          // inner column block size in tiles
+    constexpr uint32_t out_subblock_num_tiles = get_compile_time_arg_val(13);  // out_subblock_h * out_subblock_w;
+    constexpr bool height_sharded = get_compile_time_arg_val(14);
+    constexpr bool untilize_out = get_compile_time_arg_val(15);
+    constexpr uint32_t in0_cb_id = get_compile_time_arg_val(18);
+    constexpr uint32_t in1_cb_id = get_compile_time_arg_val(19);
+    constexpr uint32_t in0_pretilize_cb_id = get_compile_time_arg_val(20);
+    constexpr uint32_t in0_cb_second_reader_id = get_compile_time_arg_val(21);
+    constexpr uint32_t matmul_partials_cb = get_compile_time_arg_val(22);
+    constexpr uint32_t tilized_in0_cb_id = get_compile_time_arg_val(23);
+    constexpr uint32_t out_cb_id = get_compile_time_arg_val(24);
+    constexpr bool partials_cb_uses_output = get_compile_time_arg_val(25);
+    constexpr uint32_t in0_nblocks_w_tilize = get_compile_time_arg_val(26);
+    constexpr bool check_skip_compute = get_compile_time_arg_val(27);
+    constexpr bool pack_relu = get_compile_time_arg_val(28);
+    constexpr bool packer_untilize = get_compile_time_arg_val(29);
+    constexpr bool packer_l1_acc = get_compile_time_arg_val(30);
+    constexpr bool fuse_bias = get_compile_time_arg_val(31);
+    constexpr bool split_reader = get_compile_time_arg_val(32);
+    constexpr bool activation_reuse = get_compile_time_arg_val(33);
+
+    constexpr uint32_t image_width_in_tiles = get_compile_time_arg_val(34);
+    constexpr uint32_t window_reuse_offset = get_compile_time_arg_val(35);
+    constexpr uint32_t tilized_cb_row_offset = get_compile_time_arg_val(36);
+    constexpr uint32_t tilized_cb_second_reader_offset = get_compile_time_arg_val(37);
+    constexpr bool split_reader_cb_shared = get_compile_time_arg_val(38) == 1;
+
+    constexpr uint32_t out_block_num_tiles = in0_num_subblocks * in1_num_subblocks * out_subblock_num_tiles;
+    constexpr uint32_t out_block_w = in1_block_w;
+    constexpr bool spill = in0_num_blocks_w > 1;
+
+    constexpr uint32_t untilize_mode_out_cb_id = untilize_out ? matmul_partials_cb : out_cb_id;
+
+    uint32_t bias_block_offset = 0;
+    constexpr uint32_t bias_ntiles_w = get_compile_time_arg_val(16);
+    constexpr uint32_t bias_cb_id = get_compile_time_arg_val(17);
+    constexpr uint32_t mm_out_cb_id = fuse_bias ? matmul_partials_cb : untilize_mode_out_cb_id;
+
+    constexpr uint32_t mm_in0_cb_id = height_sharded ? tilized_in0_cb_id : in0_cb_id;
+
+    constexpr uint32_t in0_num_subblocks_read_last =
+        (split_reader && !split_reader_cb_shared) ? reader_num_h_subblocks / 2 : 0;
+    constexpr uint32_t in0_num_subblocks_read = reader_num_h_subblocks - in0_num_subblocks_read_last;
+
+    // if activation reuse is enabled, we need to update read pointers of the act buffers
+    // each time we pass on to the new output image row to match the reader behavior
+    uint32_t act_cb_start_address = activation_reuse ? get_local_cb_interface(in0_cb_id).fifo_rd_ptr : 0;
+    const uint32_t out_cb_tiles =
+        activation_reuse ? in0_block_w * (in0_num_subblocks_read + in0_num_subblocks_read_last) : 0;
+    const uint32_t tilized_cb_start_address =
+        activation_reuse ? get_local_cb_interface(tilized_in0_cb_id).fifo_wr_ptr : 0;
+    const uint32_t act_cb_second_reader_start_address =
+        activation_reuse ? get_local_cb_interface(in0_cb_second_reader_id).fifo_rd_ptr : 0;
+
+    // For block sharded conv2d, compute kernels may be scheduled on cores that only need tilize
+    // operations (input grid) while actual matmul occurs on different cores (output grid).
+    // Skip dummy compute operations when possible to reduce di/dt issues, but allow dummy
+    // tilize operations on cores without input data for code simplicity.
+    bool skip_compute = false;
+    if constexpr (check_skip_compute) {
+        skip_compute = (bool)get_arg_val<uint32_t>(0);
+    }
+
+    experimental::CB cb_in0(in0_cb_id);
+    experimental::CB cb_in0_second_reader(in0_cb_second_reader_id);
+    experimental::CB cb_tilized_in0(tilized_in0_cb_id);
+    experimental::CB cb_mm_in0(mm_in0_cb_id);
+    experimental::CB cb_in1(in1_cb_id);
+    experimental::CB cb_matmul_partials(matmul_partials_cb);
+    experimental::CB cb_mm_out(mm_out_cb_id);
+    experimental::CB cb_out(out_cb_id);
+    experimental::CB cb_bias(bias_cb_id);
+    experimental::CB cb_untilize_mode_out(untilize_mode_out_cb_id);
+
+    mm_block_init(mm_in0_cb_id, in1_cb_id, out_cb_id, false, out_subblock_w, out_subblock_h, in0_block_w);
+#ifdef SFPU_OP_INIT_ACTIVATION
+    SFPU_OP_INIT_ACTIVATION
+#endif
+    UNPACK(uint32_t partials_cb_read_ptr = get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr;)
+    PACK(uint32_t partials_cb_write_ptr = get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr;)
+    // in1 num blocks w is the outer loop. Output blocks are computed in col major order.
+    for (uint32_t in1_block_w_i = 0; in1_block_w_i < in1_num_blocks_w; ++in1_block_w_i) {
+        for (uint32_t in0_block_h_i = 0; in0_block_h_i < in0_num_blocks_h; ++in0_block_h_i) {
+            bool enable_reload = false;
+
+            if constexpr (pack_relu) {
+                // for each output block we start we relu disabled so that intermediate results are not relu'd
+                PACK((llk_pack_relu_config(ReluConfig::none())));
+            }
+            if constexpr (partials_cb_uses_output) {
+                UNPACK(partials_cb_read_ptr = get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr;)
+                PACK(partials_cb_write_ptr = get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr;)
+            }
+            uint32_t curr_matmul_out_cb = matmul_partials_cb;
+            for (uint32_t in0_block_w_i = 0; in0_block_w_i < in0_num_blocks_w; ++in0_block_w_i) {
+                bool last_inner_dim_block = (in0_block_w_i == in0_num_blocks_w - 1);
+                if constexpr (!height_sharded) {
+                    if (in0_block_w_i % in0_nblocks_w_tilize == 0) {
+                        if constexpr (pack_relu && !fuse_bias) {
+                            if (last_inner_dim_block) {
+                                // if last block we pack the final result with relu enabled
+                                PACK((llk_pack_relu_config(ReluConfig::none())));
+                            }
+                        }
+                        if constexpr (packer_l1_acc) {
+                            pack_reconfig_data_format(curr_matmul_out_cb, tilized_in0_cb_id);
+                            pack_reconfig_l1_acc(0);
+                        }
+                        tilize_in<
+                            in0_block_w,
+                            in0_pretilize_cb_id,
+                            tilized_in0_cb_id,
+                            true,
+                            !split_reader || split_reader_cb_shared>(in0_num_subblocks_read);
+
+                        if constexpr (split_reader && !split_reader_cb_shared) {
+                            tilize_in<in0_block_w, in0_cb_second_reader_id, tilized_in0_cb_id, false, true>(
+                                in0_num_subblocks_read_last);
+                        }
+                        mm_block_init_short_with_both_dt(
+                            in0_cb_id,
+                            in1_cb_id,
+                            in0_pretilize_cb_id,
+                            in0_pretilize_cb_id,
+                            false,
+                            out_subblock_w,
+                            out_subblock_h,
+                            in0_block_w);
+                    }
+                } else {
+                    if constexpr (pack_relu && !fuse_bias) {
+                        if (last_inner_dim_block) {
+                            // if last block we pack the final result with relu enabled
+                            PACK((llk_pack_relu_config(ReluConfig::none())));
+                        }
+                    }
+                    if constexpr (packer_l1_acc) {
+                        pack_reconfig_data_format(curr_matmul_out_cb, tilized_in0_cb_id);
+                        pack_reconfig_l1_acc(0);
+                    }
+
+                    if constexpr (!activation_reuse) {
+                        tilize_in<in0_block_w, in0_cb_id, tilized_in0_cb_id, true, !split_reader>(
+                            in0_num_subblocks_read);
+                    }
+
+                    if constexpr (split_reader) {
+                        if constexpr (!activation_reuse) {
+                            tilize_in<in0_block_w, in0_cb_second_reader_id, tilized_in0_cb_id, false, true>(
+                                in0_num_subblocks_read_last);
+                        } else {
+                            PACK((get_local_cb_interface(tilized_in0_cb_id).fifo_wr_ptr = tilized_cb_start_address));
+                            tilize_in_reuse_split_reader<
+                                in0_cb_id,
+                                in0_cb_second_reader_id,
+                                in0_block_w,
+                                in0_num_subblocks_read,
+                                in0_num_subblocks_read_last,
+                                tilized_in0_cb_id,
+                                out_cb_tiles,
+                                window_reuse_offset,
+                                tilized_cb_row_offset,
+                                tilized_cb_second_reader_offset,
+                                image_width_in_tiles>(
+                                cb_in0,
+                                cb_in0_second_reader,
+                                cb_tilized_in0,
+                                act_cb_start_address,
+                                act_cb_second_reader_start_address);
+                        }
+                    }
+
+                    mm_block_init_short_with_both_dt(
+                        mm_in0_cb_id,
+                        in1_cb_id,
+                        in0_cb_id,
+                        in0_cb_id,
+                        false,
+                        out_subblock_w,
+                        out_subblock_h,
+                        in0_block_w);
+                }
+
+                cb_mm_in0.wait_front(in0_block_num_tiles);
+
+                uint32_t in0_index_subblock_offset = 0;
+                if constexpr (check_skip_compute) {
+                    if (skip_compute) {
+                        cb_mm_in0.pop_front(in0_block_num_tiles);
+                        continue;
+                    }
+                }
+
+                cb_in1.wait_front(in1_block_num_tiles);
+
+                if (last_inner_dim_block) {
+                    if constexpr (!fuse_bias) {
+                        if constexpr (pack_relu) {
+                            // if last block we pack the final result with relu enabled
+                            PACK((llk_pack_relu_config(ReluConfig::zero())));
+                        }
+                        curr_matmul_out_cb = mm_out_cb_id;
+                    }
+                }
+
+                if constexpr (packer_l1_acc) {
+                    pack_reconfig_data_format(curr_matmul_out_cb);
+                }
+                for (uint32_t in0_subblock_i = 0; in0_subblock_i < in0_num_subblocks; ++in0_subblock_i) {
+                    uint32_t in1_index_subblock_offset = 0;
+                    for (uint32_t in1_subblock_i = 0; in1_subblock_i < in1_num_subblocks; ++in1_subblock_i) {
+                        if (enable_reload) {
+                            // Reconfigure input
+                            copy_tile_to_dst_init_short_with_dt(in1_cb_id, matmul_partials_cb);
+                            cb_matmul_partials.wait_front(out_subblock_num_tiles);
+                            tile_regs_acquire();
+
+                            uint32_t start_dst_index = 0;
+                            uint32_t start_tile_index = 0;
+                            copy_block_matmul_partials(
+                                matmul_partials_cb, start_tile_index, start_dst_index, out_subblock_num_tiles);
+
+                            cb_matmul_partials.pop_front(out_subblock_num_tiles);
+                            // Reconfigure srcA back
+                            mm_block_init_short_with_dt(
+                                mm_in0_cb_id,
+                                in1_cb_id,
+                                matmul_partials_cb,
+                                false,
+                                out_subblock_w,
+                                out_subblock_h,
+                                in0_block_w);
+                        } else {
+                            // just acquire
+                            tile_regs_acquire();
+                        }
+
+                        // Compute output sub-block
+                        uint32_t dst_index =
+                            0;  // start at 0, each call to matmul_block internally increments dst_index
+                        uint32_t in0_index = in0_index_subblock_offset;  // offset into in0 block
+                        uint32_t in1_index = in1_index_subblock_offset;  // offset into in1 block
+                        // inner dim that we accumulate is the inner dim of in0/in1, which is in0_block_w
+                        for (uint32_t inner_dim_idx = 0; inner_dim_idx < in0_block_w; inner_dim_idx++) {
+                            // matmul outer product of (out_subblock_h x out_subblock_w) tiles that fill dst
+                            // accumulation is done by iterating matmul_block across inner dim
+                            // in0_block_w is passed as innder dim (kt) to matmul_block, internally used to stride in0
+                            matmul_block(
+                                mm_in0_cb_id,
+                                in1_cb_id,
+                                in0_index,
+                                in1_index,
+                                dst_index,
+                                false,
+                                out_subblock_w,
+                                out_subblock_h,
+                                in0_block_w);
+                            in0_index++;               // stride right by 1
+                            in1_index += in1_block_w;  // to stride down by 1 need to stride by in_per_core_w (should be
+                                                       // called in1_block_w)
+                        }
+
+#ifdef SFPU_OP_INIT_ACTIVATION
+                        if constexpr (!fuse_bias) {
+                            if (last_inner_dim_block) {
+                                for (uint32_t i = 0; i < out_subblock_num_tiles; ++i) {
+                                    SFPU_OP_FUNC_ACTIVATION
+                                }
+                            }
+                        }
+#endif
+                        tile_regs_commit();
+                        experimental::CB curr_out_cb =
+                            curr_matmul_out_cb == matmul_partials_cb ? cb_matmul_partials : cb_mm_out;
+                        curr_out_cb.reserve_back(out_subblock_num_tiles);
+                        tile_regs_wait();
+
+                        if constexpr (packer_l1_acc) {
+                            // no accumulation for first iteration, last iteration
+                            // accumulation happens with copying tiles to dst
+                            if (in0_block_w_i == 0) {
+                                pack_reconfig_l1_acc(0);
+                            } else if (last_inner_dim_block) {
+                                pack_reconfig_l1_acc(fuse_bias ? 1 : 0);
+                            } else {
+                                pack_reconfig_l1_acc(1);
+                            }
+                        }
+
+                        uint32_t start_dst_index = 0;
+                        pack_tile_block(start_dst_index, curr_matmul_out_cb, out_subblock_num_tiles);
+
+                        tile_regs_release();
+                        curr_out_cb.push_back(out_subblock_num_tiles);
+
+                        in1_index_subblock_offset += out_subblock_w;
+                    }  // for in1_num_subblocks
+                    in0_index_subblock_offset += in0_subblock_num_tiles;
+                }
+                if (curr_matmul_out_cb == matmul_partials_cb) {
+                    if constexpr (!partials_cb_uses_output) {
+                        UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr;)
+                        PACK(get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr = partials_cb_write_ptr;)
+                    }
+                }
+                if constexpr (packer_l1_acc) {
+                    if constexpr (fuse_bias) {
+                        if (in0_block_w_i < in0_num_blocks_w - 1) {
+                            // Wait for l1 accumulation to populate interm buffer,
+                            // then pop to update fifo rd pointer
+                            cb_matmul_partials.wait_front(out_block_num_tiles);
+                            cb_matmul_partials.pop_front(out_block_num_tiles);
+                            if constexpr (spill) {
+                                UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr);
+                                PACK(get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr = partials_cb_write_ptr);
+                            }
+                        }
+                        // never reload when with bias, bias uses interm buffer
+                        enable_reload = false;
+                    } else {
+                        // Last iteration does spill and reload to output buffer
+                        if (in0_block_w_i < in0_num_blocks_w - 2) {
+                            cb_matmul_partials.wait_front(out_block_num_tiles);
+                            cb_matmul_partials.pop_front(out_block_num_tiles);
+                            if constexpr (spill) {
+                                UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr);
+                                PACK(get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr = partials_cb_write_ptr);
+                            }
+                        }
+                        if (in0_block_w_i == in0_num_blocks_w - 2) {
+                            enable_reload = true;
+                        }
+                    }
+                } else {
+                    if constexpr (spill) {
+                        enable_reload = true;
+
+                        if constexpr (fuse_bias) {
+                            if (!last_inner_dim_block) {
+                                UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr);
+                                PACK(get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr = partials_cb_write_ptr);
+                            }
+                        } else {
+                            if (!last_inner_dim_block) {
+                                UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr);
+                            }
+                            if (in0_block_w_i < in0_num_blocks_w - 2) {
+                                PACK(get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr = partials_cb_write_ptr);
+                            }
+                        }
+                    }
+                }
+
+                cb_mm_in0.pop_front(in0_block_num_tiles);
+                cb_in1.pop_front(in1_block_num_tiles);
+            }  // for in0_num_blocks_w
+            if constexpr (matmul_partials_cb == mm_out_cb_id && partials_cb_uses_output) {
+                UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr);
+            }
+            if constexpr (check_skip_compute) {
+                if (skip_compute) {
+                    continue;
+                }
+            }
+            if constexpr (fuse_bias) {
+                if constexpr (pack_relu) {
+                    // if last block we pack the final result with relu enabled
+                    PACK((llk_pack_relu_config(ReluConfig::zero())));
+                }
+                pack_reconfig_data_format(matmul_partials_cb, untilize_mode_out_cb_id);
+                if constexpr (packer_l1_acc) {
+                    pack_reconfig_l1_acc(0);
+                }
+                reconfig_data_format(in1_cb_id, matmul_partials_cb, mm_in0_cb_id, bias_cb_id);
+                add_bcast_rows_init_short(matmul_partials_cb, bias_cb_id);
+
+                cb_bias.wait_front(bias_ntiles_w);
+                cb_matmul_partials.wait_front(out_block_num_tiles);
+                for (uint32_t in0_subblock_i = 0; in0_subblock_i < in0_num_subblocks; ++in0_subblock_i) {
+                    uint32_t in1_index_subblock_offset = 0;
+                    for (uint32_t in1_subblock_i = 0; in1_subblock_i < in1_num_subblocks; ++in1_subblock_i) {
+                        tile_regs_acquire();
+                        uint32_t i = 0;
+                        for (uint32_t h = 0; h < out_subblock_h; ++h) {
+                            uint32_t bcast_tile_i = bias_block_offset + in1_index_subblock_offset;
+                            for (uint32_t w = 0; w < out_subblock_w; ++w) {
+                                add_tiles_bcast_rows(matmul_partials_cb, bias_cb_id, i, bcast_tile_i, i);
+                                ++bcast_tile_i;
+                                ++i;
+                            }
+                        }
+
+#ifdef SFPU_OP_INIT_ACTIVATION
+                        for (uint32_t i = 0; i < out_subblock_num_tiles; ++i) {
+                            SFPU_OP_FUNC_ACTIVATION
+                        }
+#endif
+                        tile_regs_commit();
+                        // do not pop front bias as it may be used again for subsequent blocks
+                        cb_matmul_partials.pop_front(out_subblock_num_tiles);
+
+                        cb_untilize_mode_out.reserve_back(out_subblock_num_tiles);
+                        tile_regs_wait();
+                        for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
+                            pack_tile(i, untilize_mode_out_cb_id);
+                        }
+                        tile_regs_release();
+                        cb_untilize_mode_out.push_back(out_subblock_num_tiles);
+
+                        in1_index_subblock_offset += out_subblock_w;
+                    }  // for in1_num_subblocks
+                }  // in0_num_subblocks
+                if constexpr (untilize_out) {
+                    UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr);
+                    PACK(get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr = partials_cb_write_ptr);
+                }
+            }
+            if constexpr (untilize_out) {
+                if constexpr (packer_l1_acc) {
+                    pack_reconfig_data_format(matmul_partials_cb, out_cb_id);
+                    pack_reconfig_l1_acc(0);
+                }
+                if constexpr (pack_relu) {
+                    PACK((llk_pack_relu_config(ReluConfig::none())));
+                }
+                if constexpr (!fuse_bias) {
+                    reconfig_data_format_srca(in1_cb_id, matmul_partials_cb);
+                }
+
+                if constexpr (packer_untilize) {
+                    pack_untilize_dest_init<out_subblock_w, out_block_w>(out_cb_id);
+                    copy_tile_to_dst_init_short(matmul_partials_cb);
+                    for (uint32_t in0_subblock_i = 0; in0_subblock_i < in0_num_subblocks; ++in0_subblock_i) {
+                        reblock_and_untilize<out_subblock_w, out_block_w>(
+                            cb_matmul_partials, cb_out, in1_num_subblocks, out_subblock_num_tiles, out_subblock_h);
+                    }
+                    pack_untilize_uninit(matmul_partials_cb);
+                } else {
+                    // Flatten nested loops into single iteration count: in0_num_subblocks * out_subblock_h
+                    compute_kernel_lib::untilize<
+                        out_block_w,
+                        matmul_partials_cb,
+                        out_cb_id,
+                        compute_kernel_lib::untilize_config::InitUninitMode::InitAndUninit,
+                        compute_kernel_lib::untilize_config::WaitMode::WaitBlock,
+                        compute_kernel_lib::untilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(
+                        in0_num_subblocks * out_subblock_h);
+                }
+            }
+            if constexpr ((in1_num_blocks_w > 1 || in0_num_blocks_h > 1)) {
+                if constexpr (fuse_bias) {
+                    reconfig_data_format(matmul_partials_cb, in1_cb_id, bias_cb_id, mm_in0_cb_id);
+                } else {
+                    reconfig_data_format_srca(matmul_partials_cb, in1_cb_id);
+                }
+            }
+        }  // for in0_num_blocks_h
+        if constexpr (fuse_bias) {
+            bias_block_offset += in1_block_w;
+        }
+    }  // for in1_num_blocks_w
+}  // void kernel_main()

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_reader_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_reader_common.hpp
@@ -1,0 +1,473 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/constants.hpp>
+#include <api/dataflow/dataflow_api.h>
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
+
+// Multicast rectangle: defines the NOC coordinate range for multicast destinations.
+struct McastRect {
+    uint32_t noc_x_start, noc_y_start, noc_x_end, noc_y_end;
+};
+
+#ifndef COMPILE_FOR_TRISC
+// Shorthand for the multicast destination args type used by Noc::async_write_multicast.
+using McastDst = noc_traits_t<MulticastEndpoint>::dst_args_mcast_type;
+#endif
+
+// Zero out all tiles for a given circular buffer.
+template <uint32_t cb_id>
+FORCE_INLINE void zero_out_tiles(Noc noc, experimental::CB cb) {
+    constexpr uint32_t tile_size = get_tile_size(cb_id);
+    const uint32_t num_tiles = get_local_cb_interface(cb_id).fifo_num_pages;
+    noc.async_write_zeros(cb, tile_size * num_tiles);
+    noc.write_zeros_l1_barrier();
+}
+
+template <
+    uint32_t dilation_w,
+    uint32_t coalesced_read_bytes,
+    uint32_t conv_act_c_read_bytes,
+    uint32_t act_block_w_extra_align_bytes,
+    uint32_t stride_w_bytes,
+    uint32_t weight_size_w,
+    uint32_t stride_w>
+FORCE_INLINE void read_sticks(
+    Noc noc,
+    volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr,
+    uint32_t reader_offset,
+    uint32_t& l1_write_addr_act,
+    uint32_t& reader_idx) {
+    uint16_t num_segments = packed_reader_indices_ptr[reader_idx] & 0xffff;
+
+    while (num_segments--) {
+        reader_idx++;
+        uint16_t start_ind = packed_reader_indices_ptr[reader_idx] & 0xffff;
+        uint16_t end_ind = packed_reader_indices_ptr[reader_idx] >> 16;
+
+        if constexpr (dilation_w == 1) {
+            for (uint16_t ind = start_ind; ind <= end_ind; ind += stride_w) {
+                uint32_t src_addr = reader_offset + (ind * conv_act_c_read_bytes);
+                experimental::read_with_state(noc, l1_write_addr_act, src_addr);
+                l1_write_addr_act += (coalesced_read_bytes + act_block_w_extra_align_bytes);
+            }
+        } else {
+            for (uint16_t ind = start_ind; ind <= end_ind; ind += stride_w) {
+                uint32_t src_addr = reader_offset + (ind * conv_act_c_read_bytes);
+                for (uint32_t inner = 0; inner < weight_size_w; inner++) {
+                    experimental::read_with_state(noc, l1_write_addr_act, src_addr);
+                    l1_write_addr_act += conv_act_c_read_bytes;
+                    src_addr += stride_w_bytes;
+                }
+                l1_write_addr_act += act_block_w_extra_align_bytes;
+            }
+        }
+    }
+    reader_idx++;
+}
+
+template <uint32_t coalesced_read_bytes, uint32_t stride_h_bytes>
+FORCE_INLINE void read_kernel_w(Noc noc, uint32_t& l1_write_addr_act, uint32_t& act_l1_offset) {
+    experimental::read_with_state(noc, l1_write_addr_act, act_l1_offset);
+    l1_write_addr_act += coalesced_read_bytes;
+    act_l1_offset += stride_h_bytes;
+}
+
+template <uint32_t cb_id_act, uint32_t act_cb_tiles, uint32_t window_reuse_offset>
+FORCE_INLINE void pass_to_the_next_image_width(
+    experimental::CB cb_act,
+    uint32_t& l1_write_addr_act,
+    uint32_t cb_start_addr,
+    uint32_t& pixel_row,
+    uint32_t& pixel_column,
+    uint32_t& new_batch_image_rows_to_fill) {
+    pixel_column = 0;
+    pixel_row++;
+    cb_act.reserve_back(act_cb_tiles);
+    l1_write_addr_act = cb_start_addr + pixel_row * window_reuse_offset;
+    get_local_cb_interface(cb_id_act).fifo_wr_ptr = l1_write_addr_act;
+
+    if (new_batch_image_rows_to_fill > 0) {
+        new_batch_image_rows_to_fill--;
+    }
+}
+
+template <uint32_t cb_id_act, uint32_t act_cb_w_tiles>
+FORCE_INLINE void push_full_tile_height(Noc noc, experimental::CB cb_act) {
+    noc.async_read_barrier();
+    cb_act.push_back(act_cb_w_tiles);
+}
+
+template <uint32_t cb_id_act, uint32_t act_cb_w_tiles, uint32_t image_width_tiles>
+FORCE_INLINE void push_remaining_tiles(
+    experimental::CB cb_act, uint32_t remaining_tiles_to_push, uint32_t cb_start_addr) {
+    constexpr uint32_t tiles_to_push = image_width_tiles * act_cb_w_tiles;
+    for (uint32_t i = 0; i < remaining_tiles_to_push; i += image_width_tiles) {
+        get_local_cb_interface(cb_id_act).fifo_wr_ptr = cb_start_addr;
+        cb_act.push_back(tiles_to_push);
+    }
+}
+
+// Function to read the windows in the first output image row where we don't reuse anything
+template <
+    uint32_t coalesced_read_bytes,
+    uint32_t stride_h_bytes,
+    uint32_t window_outer,
+    uint32_t cb_id_act,
+    uint32_t act_cb_w_tiles,
+    uint32_t conv_act_c_read_bytes,
+    uint32_t act_block_w_extra_align_bytes>
+FORCE_INLINE void read_first_image_row_window(
+    Noc noc,
+    experimental::CB cb_act,
+    uint32_t& l1_write_addr_act,
+    uint32_t reader_offset,
+    uint16_t ind,
+    uint32_t& pixel_column) {
+    uint32_t act_l1_offset = reader_offset + (ind * conv_act_c_read_bytes);
+    for (uint32_t outer = 0; outer < window_outer; outer++) {
+        read_kernel_w<coalesced_read_bytes, stride_h_bytes>(noc, l1_write_addr_act, act_l1_offset);
+    }
+    l1_write_addr_act += act_block_w_extra_align_bytes;
+
+    pixel_column++;
+    // if full tile, push back
+    if ((pixel_column & 31) == 0) {
+        push_full_tile_height<cb_id_act, act_cb_w_tiles>(noc, cb_act);
+    }
+}
+
+template <
+    uint32_t coalesced_read_bytes,
+    uint32_t stride_h_bytes,
+    uint32_t outer_coalesced_read_bytes,
+    uint32_t outer_stride_h_bytes>
+FORCE_INLINE void read_image_row_window_with_reuse(Noc noc, uint32_t& l1_write_addr_act, uint32_t& act_l1_offset) {
+    l1_write_addr_act += outer_coalesced_read_bytes;
+    act_l1_offset += outer_stride_h_bytes;
+    read_kernel_w<coalesced_read_bytes, stride_h_bytes>(noc, l1_write_addr_act, act_l1_offset);
+}
+
+template <uint32_t window_inner, bool single_core_processes_multiple_batches>
+FORCE_INLINE void load_next_segment(
+    volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr,
+    uint32_t& reader_idx,
+    uint16_t& start_ind,
+    uint16_t& end_ind,
+    uint32_t& new_batch_image_rows_to_fill) {
+    reader_idx++;
+    start_ind = packed_reader_indices_ptr[reader_idx] & 0xffff;
+    if constexpr (single_core_processes_multiple_batches) {
+        // Check if new batch is starting
+        // Feature currently works for stride and dilation h/w == 1, to be updated if the support is expanded
+        if (start_ind > end_ind + window_inner) {
+            // When we start a new batch, we need to 'restart' the optimization and fill in the whole output image width
+            // before the reuse starts; Since we might encounter new batch in the middle of the output image width
+            // where we have the reuse activated for the previous one, we need to:
+            // - finish the current width without the reuse
+            // - use the next width to 'restart optimization' and fill in the CB with new batch data
+            // - only then start reusing data
+            new_batch_image_rows_to_fill = 2;
+        }
+    }
+    end_ind = packed_reader_indices_ptr[reader_idx] >> 16;
+}
+
+template <
+    uint32_t coalesced_read_bytes,
+    uint32_t conv_act_c_read_bytes,
+    uint32_t act_block_w_extra_align_bytes,
+    uint32_t stride_h_bytes,
+    uint32_t window_inner,
+    uint32_t stride_w,
+    uint32_t window_outer,
+    uint32_t cb_id_act,
+    uint32_t act_cb_tiles,
+    uint32_t act_cb_w_tiles,
+    bool readers_process_full_image_widths,
+    uint32_t image_width_tiles,
+    uint32_t output_image_width,
+    uint32_t window_reuse_offset,
+    bool single_core_processes_multiple_batches>
+FORCE_INLINE void read_sticks_activation_reuse(
+    Noc noc,
+    experimental::CB cb_act,
+    volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr,
+    uint32_t reader_offset,
+    uint32_t& l1_write_addr_act,
+    uint32_t& reader_idx,
+    uint32_t cb_start_addr) {
+    constexpr uint32_t image_width_padded_to_tile = image_width_tiles * tt::constants::TILE_HEIGHT;
+    constexpr bool output_image_width_full_tile = output_image_width == image_width_padded_to_tile;
+    constexpr uint32_t reuse_outer = window_outer - 1;
+    constexpr uint32_t outer_coalesced_read_bytes = reuse_outer * coalesced_read_bytes;
+    constexpr uint32_t outer_stride_h_bytes = reuse_outer * stride_h_bytes;
+
+    uint16_t num_segments = packed_reader_indices_ptr[reader_idx] & 0xffff;
+    uint32_t pixel_row = 0, pixel_column = 0;
+    uint32_t new_batch_image_rows_to_fill = 0;
+
+    cb_act.reserve_back(act_cb_tiles);
+
+    if (num_segments == 0) {
+        return;
+    }
+
+    reader_idx++;
+    uint16_t start_ind = packed_reader_indices_ptr[reader_idx] & 0xffff;
+    uint16_t end_ind = packed_reader_indices_ptr[reader_idx] >> 16;
+
+    // ------ HANDLE FIRST OUTPUT IMAGE WIDTH SEPARATELY, WHERE WE NEED TO READ THE FULL WINDOW ------
+    for (uint16_t ind = start_ind; ind <= end_ind; ind += stride_w) {
+        read_first_image_row_window<
+            coalesced_read_bytes,
+            stride_h_bytes,
+            window_outer,
+            cb_id_act,
+            act_cb_w_tiles,
+            conv_act_c_read_bytes,
+            act_block_w_extra_align_bytes>(noc, cb_act, l1_write_addr_act, reader_offset, ind, pixel_column);
+    }
+
+    num_segments--;
+    load_next_segment<window_inner, single_core_processes_multiple_batches>(
+        packed_reader_indices_ptr, reader_idx, start_ind, end_ind, new_batch_image_rows_to_fill);
+
+    if constexpr (!readers_process_full_image_widths) {
+        if (num_segments) {
+            // The first image width might be split between two rows
+            uint16_t leftover_row_width = image_width_padded_to_tile - pixel_column;
+            uint16_t second_row_width = leftover_row_width, third_row_width = 0;
+            if constexpr (!output_image_width_full_tile) {
+                // If the output image width is not a multiple of the tile width, the first 'image width' might be split
+                // between three rows since we pad image width to tile size; otherwise, it is always split between
+                // maximum two rows
+                const uint16_t interval_width = end_ind - start_ind + 1;
+                if (leftover_row_width > interval_width) {
+                    second_row_width = interval_width;
+                    third_row_width = leftover_row_width - second_row_width;
+                }
+            }
+
+            for (uint16_t ind = start_ind; ind < start_ind + second_row_width; ind += stride_w) {
+                read_first_image_row_window<
+                    coalesced_read_bytes,
+                    stride_h_bytes,
+                    window_outer,
+                    cb_id_act,
+                    act_cb_w_tiles,
+                    conv_act_c_read_bytes,
+                    act_block_w_extra_align_bytes>(noc, cb_act, l1_write_addr_act, reader_offset, ind, pixel_column);
+            }
+
+            start_ind = start_ind + second_row_width;
+
+            if constexpr (!output_image_width_full_tile) {
+                if (third_row_width > 0) {
+                    num_segments--;
+                    load_next_segment<window_inner, single_core_processes_multiple_batches>(
+                        packed_reader_indices_ptr, reader_idx, start_ind, end_ind, new_batch_image_rows_to_fill);
+
+                    for (uint16_t ind = start_ind; ind < start_ind + third_row_width; ind += stride_w) {
+                        read_first_image_row_window<
+                            coalesced_read_bytes,
+                            stride_h_bytes,
+                            window_outer,
+                            cb_id_act,
+                            act_cb_w_tiles,
+                            conv_act_c_read_bytes,
+                            act_block_w_extra_align_bytes>(
+                            noc, cb_act, l1_write_addr_act, reader_offset, ind, pixel_column);
+                    }
+
+                    start_ind = start_ind + third_row_width;
+                }
+            }
+        }
+    }
+    // Move on to the next output image width
+    pass_to_the_next_image_width<cb_id_act, act_cb_tiles, window_reuse_offset>(
+        cb_act, l1_write_addr_act, cb_start_addr, pixel_row, pixel_column, new_batch_image_rows_to_fill);
+
+    // ------ HANDLE REMAINING INPUT, WHERE WE READ JUST THE LAST KERNEL WIDTH OF THE WINDOW ------
+    while (num_segments--) {
+        for (uint16_t ind = start_ind; ind <= end_ind; ind += stride_w) {
+            uint32_t act_l1_offset = reader_offset + (ind * conv_act_c_read_bytes);
+            if constexpr (output_image_width_full_tile && !single_core_processes_multiple_batches) {
+                // In this case, everything is reused after the first image width
+                read_image_row_window_with_reuse<
+                    coalesced_read_bytes,
+                    stride_h_bytes,
+                    outer_coalesced_read_bytes,
+                    outer_stride_h_bytes>(noc, l1_write_addr_act, act_l1_offset);
+            } else {
+                // In this case, we need to check if we are in the limits of image width since we pad it to tile size
+                if (pixel_column < output_image_width && new_batch_image_rows_to_fill == 0) {
+                    read_image_row_window_with_reuse<
+                        coalesced_read_bytes,
+                        stride_h_bytes,
+                        outer_coalesced_read_bytes,
+                        outer_stride_h_bytes>(noc, l1_write_addr_act, act_l1_offset);
+                } else {
+                    for (uint32_t outer = 0; outer < window_outer; outer++) {
+                        read_kernel_w<coalesced_read_bytes, stride_h_bytes>(noc, l1_write_addr_act, act_l1_offset);
+                    }
+                }
+            }
+
+            l1_write_addr_act += act_block_w_extra_align_bytes;
+
+            pixel_column++;
+            if ((pixel_column & 31) == 0) {
+                push_full_tile_height<cb_id_act, act_cb_w_tiles>(noc, cb_act);
+
+                // Move on to the next output image width
+                if constexpr (!readers_process_full_image_widths) {
+                    if (pixel_column == image_width_padded_to_tile) {
+                        pass_to_the_next_image_width<cb_id_act, act_cb_tiles, window_reuse_offset>(
+                            cb_act,
+                            l1_write_addr_act,
+                            cb_start_addr,
+                            pixel_row,
+                            pixel_column,
+                            new_batch_image_rows_to_fill);
+                    }
+                }
+            }
+        }
+
+        if constexpr (readers_process_full_image_widths) {
+            // Move on to the next output image width
+            pass_to_the_next_image_width<cb_id_act, act_cb_tiles, window_reuse_offset>(
+                cb_act, l1_write_addr_act, cb_start_addr, pixel_row, pixel_column, new_batch_image_rows_to_fill);
+        }
+
+        load_next_segment<window_inner, single_core_processes_multiple_batches>(
+            packed_reader_indices_ptr, reader_idx, start_ind, end_ind, new_batch_image_rows_to_fill);
+    }
+}
+
+template <uint32_t dram_addr_index, uint32_t page_size_index, uint32_t tensor_args_index, uint32_t cb_reader_index>
+void load_config_tensor_if_in_dram(Noc noc, experimental::CB reader_cb, uint32_t core_index) {
+#ifdef CONFIG_TENSOR_IN_DRAM
+    // TODO: Instead of all cores reading from dram, only the first column reads, and does an MCAST to all the other
+    // cores in the row.
+    constexpr uint32_t config_dram_addr = get_compile_time_arg_val(dram_addr_index);
+    constexpr uint32_t config_page_size = get_compile_time_arg_val(page_size_index);
+    const auto config_tensor_args = TensorAccessorArgs<tensor_args_index>();
+    const auto config_accessor = TensorAccessor(config_tensor_args, config_dram_addr);
+
+    noc.async_read(config_accessor, reader_cb, config_page_size, {.page_id = core_index}, {});
+    noc.async_read_barrier();
+    reader_cb.push_back(1);
+#endif
+}
+
+template <int window_height, int window_width>
+FORCE_INLINE void read_dilated_channels(
+    Noc noc,
+    uint32_t& l1_write_addr_act,
+    const uint32_t act_l1_read_addr,
+    const uint32_t reader_channel_idx,
+    const uint32_t conv_act_c_bytes,
+    const uint32_t stride_h_bytes,
+    const uint32_t stride_w_bytes) {
+    uint32_t src_addr = act_l1_read_addr + (reader_channel_idx * conv_act_c_bytes);
+#pragma GCC unroll(window_height)
+    for (uint32_t outer = 0; outer < window_height; outer++) {
+        uint32_t row_addr = src_addr;
+#pragma GCC unroll(window_width)
+        for (uint32_t inner = 0; inner < window_width; inner++) {
+            experimental::read_with_state(noc, l1_write_addr_act, row_addr);
+            l1_write_addr_act += conv_act_c_bytes;
+            row_addr += stride_w_bytes;
+        }
+        src_addr += stride_h_bytes;
+    }
+}
+
+template <int window_height>
+FORCE_INLINE void read_channels(
+    Noc noc,
+    uint32_t& l1_write_addr_act,
+    const uint32_t act_l1_read_addr,
+    const uint32_t reader_channel_idx,
+    const uint32_t conv_act_c_read_bytes,
+    const uint32_t coalesced_read_bytes,
+    const uint32_t stride_h_bytes) {
+    uint32_t src_addr = act_l1_read_addr + (reader_channel_idx * conv_act_c_read_bytes);
+#pragma GCC unroll(window_height)
+    for (uint32_t inner = 0; inner < window_height; inner++) {
+        experimental::read_with_state(noc, l1_write_addr_act, src_addr);
+        l1_write_addr_act += coalesced_read_bytes;
+        src_addr += stride_h_bytes;
+    }
+}
+
+template <
+    bool sliced_inner_dim,
+    uint32_t dilation_w,
+    uint32_t coalesced_read_bytes,
+    uint32_t conv_act_c_read_bytes,
+    uint32_t act_block_w_extra_align_bytes,
+    uint32_t stride_w_bytes,
+    uint32_t weight_size_w,
+    uint32_t stride_w,
+    uint32_t weight_size_h,
+    uint32_t window_outer_offset>
+FORCE_INLINE void read_activation_data(
+    Noc noc,
+    volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr,
+    uint32_t& reader_offset,
+    uint32_t& l1_write_addr_act,
+    uint32_t& reader_idx,
+    uint32_t act_l1_read_addr,
+    uint32_t stride_h_bytes) {
+    if constexpr (sliced_inner_dim) {
+        read_sticks<
+            dilation_w,
+            coalesced_read_bytes,
+            conv_act_c_read_bytes,
+            act_block_w_extra_align_bytes,
+            stride_w_bytes,
+            weight_size_w,
+            stride_w>(noc, packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
+    } else {
+        uint16_t num_elems = packed_reader_indices_ptr[reader_idx] & 0xffff;
+        while (num_elems--) {
+            reader_idx++;
+            uint16_t start_ind = packed_reader_indices_ptr[reader_idx] & 0xffff;
+            uint16_t end_ind = packed_reader_indices_ptr[reader_idx] >> 16;
+            for (uint16_t ind = start_ind; ind <= end_ind; ind += stride_w) {
+                if constexpr (dilation_w == 1) {
+                    read_channels<weight_size_h>(
+                        noc,
+                        l1_write_addr_act,
+                        act_l1_read_addr,
+                        ind,
+                        conv_act_c_read_bytes,
+                        coalesced_read_bytes,
+                        stride_h_bytes);
+                } else {
+                    read_dilated_channels<weight_size_h, weight_size_w>(
+                        noc,
+                        l1_write_addr_act,
+                        act_l1_read_addr,
+                        ind,
+                        conv_act_c_read_bytes,
+                        stride_h_bytes,
+                        stride_w_bytes);
+                }
+                if constexpr (act_block_w_extra_align_bytes) {
+                    l1_write_addr_act += act_block_w_extra_align_bytes;
+                }
+            }
+        }
+        reader_idx++;
+    }
+    noc.async_read_barrier();
+    reader_offset += window_outer_offset;
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
@@ -1,0 +1,347 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <api/dataflow/dataflow_api.h>
+#include "conv_reader_common.hpp"
+#include "noc/noc_parameters.h"
+#define ENABLE_DEBUG 0
+
+#if ENABLE_DEBUG
+#include "api/debug/dprint.h"
+#include "api/debug/dprint_pages.h"
+#endif
+
+// Multicasts activation data from src_cb to dst_cb across cores in the multicast rectangle.
+// Three cases depending on the sender's role and number of multicast destinations:
+//   is_receiver_core && act_mcast_num_cores > 0:  mcast with INCLUDE_SRC loopback
+//   is_receiver_core && act_mcast_num_cores == 0: local self-write (mcast loopback hangs with 0 destinations)
+//   !is_receiver_core:                            standard mcast EXCLUDE_SRC (even when act_mcast_num_cores == 0,
+//                                                 because the sender still needs to send to the output core)
+template <uint32_t act_mcast_num_cores>
+void multicast_data(
+    Noc noc,
+    MulticastEndpoint mcast_ep,
+    bool is_receiver_core,
+    experimental::CB src_cb,
+    uint32_t src_offset,
+    McastDst& dst,
+    uint32_t total_bytes) {
+    auto src = use<CircularBuffer::AddrSelector::READ_PTR>(src_cb);
+    if (is_receiver_core) {
+        if constexpr (act_mcast_num_cores > 0) {
+            noc.async_write_multicast<NocOptions::MCAST_INCL_SRC>(
+                src, mcast_ep, total_bytes, act_mcast_num_cores + 1, {.offset_bytes = src_offset}, dst, true);
+        } else {
+            // Sender is the only receiver — can't use multicast loopback (hangs with 0 destinations)
+            noc.async_write(
+                src,
+                UnicastEndpoint{},
+                total_bytes,
+                {.offset_bytes = src_offset},
+                {.noc_x = my_x[noc.get_noc_id()], .noc_y = my_y[noc.get_noc_id()], .addr = dst.addr});
+        }
+    } else {
+        noc.async_write_multicast(
+            src, mcast_ep, total_bytes, act_mcast_num_cores + 1, {.offset_bytes = src_offset}, dst, true);
+    }
+}
+
+// Multicast activation data from the local circular buffer to multiple destinations (dst_cb in receiver cores).
+// This function sends a block of data (the activation block) using NOC multicast commands, it avoids waiting for the
+// whole block to be available in the source CB before starting the multicast, instead waits for enough tiles to do one
+// multicast of NOC_MAX_BURST_SIZE size. This is because under the hood, the multicast splits the data into chunks of
+// NOC_MAX_BURST_SIZE size
+// It calls the multicast_data function for each chunk of maximum size NOC_MAX_BURST_SIZE bytes.
+// Said function does mcast loopback when the sender core is also a receiver core (it is both in output and input grids)
+// or mcast when the sender core is not a receiver core (it is only present in the input grid, mcast loopback will hang
+// if the core isn't one of receivers) or just local write when it is in both input and output grids but is the only
+// receiver core (will hang if mcast loopback is used)
+template <
+    uint32_t act_mcast_num_dest_cores,
+    uint32_t mcast_noc_burst_size,
+    uint32_t block_tile_count,
+    uint32_t tile_size>
+void mcast_block_chunked(
+    Noc noc,
+    MulticastEndpoint mcast_ep,
+    experimental::CB src_cb_obj,
+    bool is_receiver_core,
+    experimental::CB dst_cb_obj,
+    const McastRect& rect) {
+    // Build mcast dst once; only .addr is updated per burst
+    // number of full bursts
+    constexpr uint32_t mcast_full_burst_cnt = block_tile_count * tile_size / mcast_noc_burst_size;
+    // size of the leftover burst, if 0 means we have no leftover burst
+    constexpr uint32_t mcast_leftover_burst_size = block_tile_count * tile_size % mcast_noc_burst_size;
+    // number of tiles that we need to wait for to cover the full burst size
+    constexpr uint32_t wait_tile_full_cnt = (mcast_noc_burst_size + tile_size - 1) / tile_size;
+
+    // In full burst iterations we wait for a bit more than the full burst size in case where the
+    // tile size does not divide the burst size evenly.
+    // we need to insure that we don't wait for more tiles than we have in the block
+    constexpr uint32_t wait_tile_full_done = std::min(mcast_full_burst_cnt * wait_tile_full_cnt, block_tile_count);
+
+    // optimization to avoid unnecessary branching in the loop
+    constexpr bool no_need_partial_wait_tile = mcast_full_burst_cnt * wait_tile_full_cnt <= block_tile_count;
+
+    // number of times we need to increase the wait_tile_curr for the full burst iterations
+    constexpr uint32_t wait_tile_full_iter_cnt = (wait_tile_full_done / wait_tile_full_cnt) - 1;
+
+    uint32_t src_offset = 0;
+    McastDst dst = {
+        .noc_x_start = rect.noc_x_start,
+        .noc_y_start = rect.noc_y_start,
+        .noc_x_end = rect.noc_x_end,
+        .noc_y_end = rect.noc_y_end,
+        .addr = dst_cb_obj.get_write_ptr()};
+
+    constexpr uint32_t wait_tile_start_cnt = std::min(block_tile_count, wait_tile_full_cnt);
+    uint32_t wait_tile_curr = wait_tile_start_cnt;
+    for (uint32_t i = 0; i < mcast_full_burst_cnt; i++) {
+        src_cb_obj.wait_front(wait_tile_curr);
+        multicast_data<act_mcast_num_dest_cores>(
+            noc, mcast_ep, is_receiver_core, src_cb_obj, src_offset, dst, mcast_noc_burst_size);
+        src_offset += mcast_noc_burst_size;
+        dst.addr += mcast_noc_burst_size;
+
+        if constexpr (no_need_partial_wait_tile) {
+            wait_tile_curr += wait_tile_full_cnt;
+        } else {
+            // we shouldn't wait for more than the number of tiles in the block
+            if (i < wait_tile_full_iter_cnt) {
+                wait_tile_curr += wait_tile_full_cnt;
+            } else {
+                wait_tile_curr = block_tile_count;
+            }
+        }
+    }
+    if constexpr (mcast_leftover_burst_size > 0) {
+        src_cb_obj.wait_front(block_tile_count);
+        multicast_data<act_mcast_num_dest_cores>(
+            noc, mcast_ep, is_receiver_core, src_cb_obj, src_offset, dst, mcast_leftover_burst_size);
+    }
+
+    // In case we only do local l1 writes, we need to wait for the barrier to complete
+    if constexpr (act_mcast_num_dest_cores == 0) {
+        if (is_receiver_core) {
+            noc.async_write_barrier();
+        }
+    }
+}
+
+constexpr uint32_t DILATION_W = get_compile_time_arg_val(1);
+void kernel_main() {
+    constexpr uint32_t dilation_h = get_compile_time_arg_val(0);
+    constexpr uint32_t dilation_w = get_compile_time_arg_val(1);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(2);
+    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(3);
+    constexpr uint32_t window_outer = get_compile_time_arg_val(4);
+    constexpr uint32_t act_block_num_tiles_read = get_compile_time_arg_val(6);
+    constexpr uint32_t weight_size_h = get_compile_time_arg_val(7);
+    constexpr uint32_t weight_size_w = get_compile_time_arg_val(8);
+    constexpr uint32_t padded_conv_act_size_w = get_compile_time_arg_val(9);
+    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(10);
+    constexpr uint32_t act_num_blocks_h = get_compile_time_arg_val(11);
+    constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(12);
+    constexpr uint32_t act_w_num_outer = get_compile_time_arg_val(13);
+    constexpr uint32_t act_mcast_num_dests = get_compile_time_arg_val(14);
+    constexpr uint32_t act_mcast_num_cores = get_compile_time_arg_val(15);
+    constexpr uint32_t act_mcast_tile_size_bytes = get_compile_time_arg_val(18);
+    constexpr bool transpose_mcast = get_compile_time_arg_val(19) == 1;
+    constexpr bool needs_act_block_zero_out = get_compile_time_arg_val(20) == 1;
+    constexpr uint32_t cb_id_act = get_compile_time_arg_val(21);
+    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(22);
+    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(23);
+    constexpr uint32_t tilized_in0_cb_id = get_compile_time_arg_val(24);
+    constexpr uint32_t cb_id_act_row_major_bfloat16 = get_compile_time_arg_val(25);
+    constexpr bool split_reader_enabled = get_compile_time_arg_val(27);
+
+    constexpr bool split_reader_cb_shared = get_compile_time_arg_val(33) == 1;
+
+    // Experimental API objects
+    Noc noc;
+    Semaphore<> act_mcast_sender_sem(get_compile_time_arg_val(16));
+    Semaphore<> act_mcast_receiver_sem(get_compile_time_arg_val(17));
+    MulticastEndpoint mcast_ep;
+    experimental::CB cb_act_obj(cb_id_act);
+    experimental::CB cb_act_rm_obj(cb_id_act_row_major_bfloat16);
+    experimental::CB cb_tilized_in0_obj(tilized_in0_cb_id);
+    experimental::CB cb_reader_indices_obj(cb_reader_indices);
+    experimental::CB cb_sharded_act_obj(cb_id_sharded_act);
+
+    Semaphore<> reserve_done_sem(0);
+    Semaphore<> write_done_sem(0);
+    if constexpr (split_reader_cb_shared) {
+        // When the split reader CB is shared, both readers write to the same circular buffer.
+        // Synchronization is required: the main reader signals when CB space is reserved,
+        // and the second reader signals when it has finished writing its portion.
+        reserve_done_sem = Semaphore<>(get_compile_time_arg_val(34));
+        write_done_sem = Semaphore<>(get_compile_time_arg_val(35));
+    }
+
+    if constexpr (needs_act_block_zero_out) {
+        zero_out_tiles<cb_id_act_row_major_bfloat16>(noc, cb_act_rm_obj);
+    }
+
+    uint32_t i = 0;
+    const McastRect act_mcast_rect = {
+        get_arg_val<uint32_t>(i++), get_arg_val<uint32_t>(i++), get_arg_val<uint32_t>(i++), get_arg_val<uint32_t>(i++)};
+    uint32_t act_mcast_sender_id = get_arg_val<uint32_t>(i++);
+    uint32_t act_mcast_sender_noc_x = get_arg_val<uint32_t>(i++);
+    const bool is_receiver_core = get_arg_val<uint32_t>(i++) > 0;
+    const bool is_sender_core = get_arg_val<uint32_t>(i++) > 0;
+    uint32_t dram_config_reader_index = get_arg_val<uint32_t>(i++);
+
+    tt_l1_ptr uint32_t* act_mcast_sender_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(i));
+
+    load_config_tensor_if_in_dram<29, 30, 31, cb_reader_indices>(noc, cb_reader_indices_obj, dram_config_reader_index);
+
+    volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_reader_indices_obj.get_write_ptr());
+
+    // Set up receiver semaphore VALID value, to be mcasted to destinations after the data has been mcasted
+    act_mcast_receiver_sem.set(VALID);
+    // local address that will be atomically incremented by mcast receivers, to know when all receivers are ready
+    // to receive the mcast
+
+    // TODO: need to make the read coalescing optimization cleaner
+    // currently works for the case of num_coalesced_reads == weight_size_w since these reads are contiguous on both
+    // src/dst side
+    constexpr uint32_t coalesced_read_bytes =
+        ((dilation_w == 1) ? weight_size_w * conv_act_c_read_bytes : conv_act_c_read_bytes);
+
+    // Fully create act matrix and tilize it before mcast
+    uint32_t act_l1_read_addr = cb_sharded_act_obj.get_read_ptr();
+
+    if constexpr (!split_reader_cb_shared) {
+        experimental::set_read_state<coalesced_read_bytes>(noc, act_l1_read_addr);
+    }
+
+    constexpr uint32_t window_outer_offset = padded_conv_act_size_w * conv_act_c_read_bytes * dilation_h;
+    constexpr uint32_t stride_h_bytes = padded_conv_act_size_w * conv_act_c_read_bytes * dilation_h;
+    constexpr uint32_t stride_w_bytes = dilation_w * conv_act_c_read_bytes;
+    constexpr bool sliced_inner_dim = window_outer > 1;
+
+    // Reset reader_idx to finish act_block_h_datums
+    uint32_t reader_idx = 0;
+    uint32_t start_reader_idx = 0;
+    for (uint32_t nbh = 0; nbh < act_num_blocks_h; nbh++) {
+        uint32_t reader_offset = act_l1_read_addr;
+        for (uint32_t outer = 0; outer < window_outer; outer++) {
+            reader_idx = start_reader_idx;
+            cb_act_rm_obj.reserve_back(act_block_num_tiles_read);
+            if (is_sender_core) {
+                uint32_t l1_write_addr_act = cb_act_rm_obj.get_write_ptr();
+                if constexpr (split_reader_cb_shared) {
+                    reserve_done_sem.set(VALID);
+                    experimental::set_read_state<coalesced_read_bytes>(noc, act_l1_read_addr);
+                }
+                read_activation_data<
+                    sliced_inner_dim,
+                    dilation_w,
+                    coalesced_read_bytes,
+                    conv_act_c_read_bytes,
+                    act_block_w_extra_align_bytes,
+                    stride_w_bytes,
+                    weight_size_w,
+                    stride_w,
+                    weight_size_h,
+                    window_outer_offset>(
+                    noc,
+                    packed_reader_indices_ptr,
+                    reader_offset,
+                    l1_write_addr_act,
+                    reader_idx,
+                    act_l1_read_addr,
+                    stride_h_bytes);
+                if constexpr (split_reader_cb_shared) {
+                    write_done_sem.wait(VALID);
+                    write_done_sem.set(INVALID);
+                }
+            }
+            cb_act_rm_obj.push_back(act_block_num_tiles_read);
+
+#ifndef SKIP_MCAST
+            // Round robin self-mcast and receive tilized act matrix in cb_id_act
+            // Compute should function like regular mm
+            for (uint32_t act_w_outer_i = 0; act_w_outer_i < act_w_num_outer; act_w_outer_i++) {
+                cb_act_obj.reserve_back(act_block_num_tiles);
+                if (act_w_outer_i == act_mcast_sender_id) {
+                    // MCAST SENDER: send entire tilized input to other cores in column
+                    // wait until all act mcast destinations have atomically incremented the act semaphore_addr
+                    // (i.e. its value should be act_mcast_num_dests), then reset the semaphore_addr value back to
+                    // zero for the next block
+                    act_mcast_sender_sem.wait(act_mcast_num_dests + (is_receiver_core ? 0 : 1));
+                    act_mcast_sender_sem.set(0);
+
+                    act_mcast_receiver_sem.set(INVALID);
+
+                    mcast_block_chunked<
+                        act_mcast_num_cores,
+                        NOC_MAX_BURST_SIZE,
+                        act_block_num_tiles,
+                        act_mcast_tile_size_bytes>(
+                        noc, mcast_ep, cb_tilized_in0_obj, is_receiver_core, cb_act_obj, act_mcast_rect);
+
+                    // Note: no need for write barrier, since these two multicasts are done on the same noc id and
+                    // same vc even though cmd bufs are different Also, this only works because we are setting VCs
+                    // statically (using NOC_CMD_STATIC_VC).
+
+                    if (is_receiver_core) {
+                        // We should also multicast VALID flag to destinations for receiver semaphore
+                        if constexpr (act_mcast_num_cores) {
+                            act_mcast_receiver_sem.set(VALID);
+                            act_mcast_receiver_sem.set_multicast<NocOptions::MCAST_INCL_SRC>(
+                                noc,
+                                act_mcast_rect.noc_x_start,
+                                act_mcast_rect.noc_y_start,
+                                act_mcast_rect.noc_x_end,
+                                act_mcast_rect.noc_y_end,
+                                act_mcast_num_cores + 1);
+                            noc.async_write_barrier();
+                        }
+                    } else {
+                        act_mcast_receiver_sem.set(VALID);
+                        act_mcast_receiver_sem.set_multicast(
+                            noc,
+                            act_mcast_rect.noc_x_start,
+                            act_mcast_rect.noc_y_start,
+                            act_mcast_rect.noc_x_end,
+                            act_mcast_rect.noc_y_end,
+                            act_mcast_num_cores + 1);
+                    }
+                } else if (is_receiver_core) {
+                    // MCAST RECEIVER: receive entire tilized input from sender core
+                    // Set act semaphore value to INVALID
+                    act_mcast_receiver_sem.set(INVALID);
+
+                    // Atomic increment source core counter
+                    if constexpr (transpose_mcast) {
+                        act_mcast_sender_sem.up(noc, act_mcast_sender_noc_x, act_mcast_sender_noc_y[act_w_outer_i], 1);
+                    } else {
+                        act_mcast_sender_sem.up(noc, act_mcast_sender_noc_y[act_w_outer_i], act_mcast_sender_noc_x, 1);
+                    }
+
+                    // wait on act semaphore value to become VALID (set by mcast sender after it multicasts data)
+                    act_mcast_receiver_sem.wait(VALID);
+                }
+                cb_act_obj.push_back(act_block_num_tiles);
+            }  // act_w_num_outer
+
+            cb_tilized_in0_obj.pop_front(act_block_num_tiles);
+#endif
+        }
+        start_reader_idx = reader_idx;
+        if constexpr (split_reader_enabled) {
+            // Increment reader index for the next number of segments (number of segments for other reader)
+            // Only read reader indices on cores that have sharded input (is_sender_core).
+            if (is_sender_core) {
+                start_reader_idx += (static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1);
+            }
+        }
+    }
+
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <api/dataflow/dataflow_api.h>
+#include "conv_reader_common.hpp"
+
+void kernel_main() {
+    constexpr uint32_t dilation_h = get_compile_time_arg_val(0);
+    constexpr uint32_t dilation_w = get_compile_time_arg_val(1);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(2);
+    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(3);
+    // need to have these as compile-time, they are inner loop bounds / unroll loops / constexpr conditionals based on
+    // them
+    constexpr uint32_t window_outer = get_compile_time_arg_val(4);
+    constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(6);
+    constexpr uint32_t weight_size_h = get_compile_time_arg_val(7);
+    constexpr uint32_t weight_size_w = get_compile_time_arg_val(8);
+    constexpr uint32_t conv_act_size_w_padded = get_compile_time_arg_val(9);
+    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(10);
+    constexpr uint32_t act_num_blocks_h = get_compile_time_arg_val(11);
+
+    constexpr bool needs_act_block_zero_out = get_compile_time_arg_val(20) == 1;
+    constexpr uint32_t cb_id_act = get_compile_time_arg_val(21);
+    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(22);
+    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(23);
+
+    constexpr bool split_reader_enabled = get_compile_time_arg_val(27);
+    constexpr bool activation_reuse_enabled = get_compile_time_arg_val(28);
+
+    experimental::CB cb_act(cb_id_act);
+    experimental::CB cb_sharded_act(cb_id_sharded_act);
+    experimental::CB cb_reader_idx(cb_reader_indices);
+
+    volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_reader_idx.get_write_ptr());
+
+    uint32_t runtime_arg_idx = 0;
+    uint32_t core_index = get_arg_val<uint32_t>(runtime_arg_idx++);
+    load_config_tensor_if_in_dram<29, 30, 31, cb_reader_indices>(Noc(), cb_reader_idx, core_index);
+    // Activation reuse args (offset by 4 from index 29: address + page_size + 2 TensorAccessorArgs)
+    constexpr uint32_t act_reuse_cb_tiles = get_compile_time_arg_val(33);
+    constexpr uint32_t act_block_w_tiles = get_compile_time_arg_val(34);
+    constexpr bool readers_process_full_image_widths = get_compile_time_arg_val(35) == 1;
+    constexpr uint32_t image_width_tiles = get_compile_time_arg_val(36);
+    constexpr uint32_t output_image_width = get_compile_time_arg_val(37);
+    constexpr uint32_t window_reuse_offset = get_compile_time_arg_val(38);
+    constexpr bool need_to_push_remaining_tiles = get_compile_time_arg_val(39) == 1;
+    constexpr bool single_core_processes_multiple_batches = get_compile_time_arg_val(40) == 1;
+
+    uint32_t remaining_tiles_to_push = get_arg_val<uint32_t>(runtime_arg_idx++);
+
+    Noc noc;
+
+    if constexpr (needs_act_block_zero_out) {
+        zero_out_tiles<cb_id_act>(noc, cb_act);
+    }
+
+    constexpr uint32_t window_outer_offset = conv_act_size_w_padded * conv_act_c_read_bytes * dilation_h;
+
+    // LOOP TO FILL READER INDICES
+
+    uint32_t reader_idx = 0;
+
+    // TODO: need to make the read coalescing optimization cleaner
+    // pass coalesce_window_inner_reads as a compile time arg and num_coalesced_reads so we can constexpr the if
+    // currently works for the case of num_coalesced_reads == weight_size_w since these reads are contiguous on both
+    // src/dst side we check if window_inner == weight_size_w to make sure coalescing is legal along full window_inner
+    // so the loop can be removed
+    constexpr uint32_t num_coalesced_reads = weight_size_w;
+    constexpr uint32_t coalesced_read_bytes =
+        ((dilation_w == 1) ? num_coalesced_reads * conv_act_c_read_bytes : conv_act_c_read_bytes);
+    // the conditional selecting between coalescing and no-colescing must be constexpr to that compiler can optimized
+    // the other path away this has shown to be a big perf win
+
+    // coalesce reads along weight_size_w
+    uint32_t act_l1_read_addr = cb_sharded_act.get_read_ptr();
+
+    static_assert(coalesced_read_bytes <= NOC_MAX_BURST_SIZE);
+    experimental::set_read_state<coalesced_read_bytes>(noc, act_l1_read_addr);
+
+    constexpr uint32_t stride_w_bytes = dilation_w * conv_act_c_read_bytes;
+    uint32_t start_reader_idx = 0;
+    uint32_t l1_write_addr_act = 0;
+    const uint32_t cb_start_addr = cb_act.get_write_ptr();
+    for (uint32_t bh = 0; bh < act_num_blocks_h; bh++) {
+        if constexpr (activation_reuse_enabled) {
+            l1_write_addr_act = cb_start_addr;
+            get_local_cb_interface(cb_id_act).fifo_wr_ptr = l1_write_addr_act;
+        }
+        uint32_t reader_offset = act_l1_read_addr;
+        for (uint32_t outer = 0; outer < window_outer; outer++) {
+            reader_idx = start_reader_idx;
+
+            if constexpr (!activation_reuse_enabled) {
+                cb_act.reserve_back(act_block_num_tiles);
+                l1_write_addr_act = cb_act.get_write_ptr();
+
+                read_sticks<
+                    dilation_w,
+                    coalesced_read_bytes,
+                    conv_act_c_read_bytes,
+                    act_block_w_extra_align_bytes,
+                    stride_w_bytes,
+                    weight_size_w,
+                    stride_w>(noc, packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
+
+                noc.async_read_barrier();
+                cb_act.push_back(act_block_num_tiles);
+                reader_offset += window_outer_offset;
+            } else {
+                read_sticks_activation_reuse<
+                    coalesced_read_bytes,
+                    conv_act_c_read_bytes,
+                    act_block_w_extra_align_bytes,
+                    window_outer_offset,
+                    weight_size_w,
+                    stride_w,
+                    weight_size_h,
+                    cb_id_act,
+                    act_reuse_cb_tiles,
+                    act_block_w_tiles,
+                    readers_process_full_image_widths,
+                    image_width_tiles,
+                    output_image_width,
+                    window_reuse_offset,
+                    single_core_processes_multiple_batches>(
+                    noc,
+                    cb_act,
+                    packed_reader_indices_ptr,
+                    act_l1_read_addr,
+                    l1_write_addr_act,
+                    reader_idx,
+                    cb_start_addr);
+            }
+        }
+
+        start_reader_idx = reader_idx;
+        if constexpr (split_reader_enabled) {
+            // Increment reader index for the next number of segments (number of segments for other reader)
+            start_reader_idx += (static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1);
+        }
+    }
+
+    if constexpr (activation_reuse_enabled) {
+        // Last core sometimes has less work to do, but we still need to push the same number of tiles
+        // to avoid blocking compute kernels
+        if constexpr (need_to_push_remaining_tiles) {
+            push_remaining_tiles<cb_id_act, act_block_w_tiles, image_width_tiles>(
+                cb_act, remaining_tiles_to_push, cb_start_addr);
+        }
+    }
+
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/reader_depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/reader_depthwise_conv1d.cpp
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include <api/dataflow/dataflow_api.h>
+#include "api/compile_time_args.h"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
+
+template <uint32_t read_bytes>
+FORCE_INLINE void read_activation_stick(Noc noc, uint32_t l1_write_addr, uint32_t l1_read_addr) {
+    if constexpr (read_bytes <= NOC_MAX_BURST_SIZE) {
+        experimental::read_with_state<read_bytes>(noc, l1_write_addr, l1_read_addr);
+    } else {
+        UnicastEndpoint self_ep;
+        noc.async_read(
+            self_ep,
+            CoreLocalMem<uint32_t>(l1_write_addr),
+            read_bytes,
+            experimental::local_addr(l1_read_addr, noc.get_noc_id()),
+            {});
+    }
+}
+
+// conv1D reader kernel
+void kernel_main() {
+    constexpr uint32_t stride_w = get_compile_time_arg_val(2);
+    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(3);
+    // need to have these as compile-time, they are inner loop bounds / unroll loops / constexpr conditionals based on
+    // them
+    constexpr uint32_t window_outer = get_compile_time_arg_val(4);
+    constexpr uint32_t window_inner = get_compile_time_arg_val(5);
+    constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(6);
+    constexpr uint32_t weight_size_h = get_compile_time_arg_val(7);
+    constexpr uint32_t weight_size_w = get_compile_time_arg_val(8);
+    constexpr uint32_t conv_act_size_w_padded = get_compile_time_arg_val(9);
+    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(10);
+    constexpr uint32_t act_num_blocks_h = get_compile_time_arg_val(11);
+    constexpr uint32_t cb_id_act = get_compile_time_arg_val(21);
+    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(22);
+    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(23);
+    // Depthwise reuses the common reader arg slot that non-depthwise height-sharded conv uses for
+    // activation reuse. Activation reuse is unsupported for the 1D depthwise path.
+    constexpr bool coalesce_kw_reads = get_compile_time_arg_val(28) == 1;
+
+    // LOOP TO FILL READER OFFSETS
+    /* We can add another loop to read chunks of a stick as well.
+     * - Duplicate reader_offset for same stick X times (window_inner must be 1)
+     * - New loop between outer and inner that loops X times reading from same stick
+     * - Read conv_act_c_read_bytes / X each time
+     * - Update l1_write_addr_act by conv_act_c_read_bytes
+     */
+    uint32_t reader_offsets[weight_size_w * weight_size_h];
+    uint32_t reader_offset = 0;  // Constant offset for each pixel within filter window
+    uint32_t reader_offset_idx = 0;
+    for (uint32_t channel_stick_h = 0; channel_stick_h < weight_size_h; channel_stick_h++) {
+        uint32_t reader_offset_row = reader_offset;
+        for (uint32_t channel_stick_w = 0; channel_stick_w < weight_size_w; channel_stick_w++) {
+            reader_offsets[reader_offset_idx++] = reader_offset_row++;
+        }
+        // -1 to go back to previous reader_offset
+        reader_offset += conv_act_size_w_padded;
+    }
+
+    experimental::CB act_cb(cb_id_act);
+    experimental::CB sharded_act_cb(cb_id_sharded_act);
+    experimental::CB reader_indices_cb(cb_reader_indices);
+    Noc noc;
+
+    // LOOP TO FILL READER INDICES
+    volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reader_indices_cb.get_write_ptr());
+
+    uint32_t reader_idx = 0;
+
+    constexpr uint32_t num_coalesced_reads = coalesce_kw_reads ? weight_size_w : 1;
+    constexpr uint32_t coalesced_read_bytes = num_coalesced_reads * conv_act_c_read_bytes;
+    static_assert(!coalesce_kw_reads || weight_size_h == 1);
+    static_assert(!coalesce_kw_reads || window_outer == 1);
+    static_assert(!coalesce_kw_reads || window_inner == weight_size_w);
+
+    reader_offset_idx = 0;
+    uint32_t act_l1_offset = 0;
+    uint32_t act_l1_read_addr = sharded_act_cb.get_read_ptr();
+
+    if constexpr (coalesced_read_bytes <= NOC_MAX_BURST_SIZE) {
+        experimental::set_read_state<coalesced_read_bytes>(noc, act_l1_read_addr);
+    }
+    uint32_t start_reader_idx = 0;
+    for (uint32_t bh = 0; bh < act_num_blocks_h; bh++) {
+        for (uint32_t outer = 0; outer < window_outer; outer++) {
+            // Reset reader_idx to finish act_block_h_datums
+            reader_idx = start_reader_idx;
+
+            act_cb.reserve_back(act_block_num_tiles);
+            uint32_t l1_write_addr_act = act_cb.get_write_ptr();
+            uint32_t reader_offset = act_l1_read_addr + (reader_offsets[reader_offset_idx] * conv_act_c_read_bytes);
+            // #pragma GCC unroll 4 // unroll didn't help, but act_block_h_datums (loop bound) being const does help
+            uint32_t two_reader_indices = packed_reader_indices_ptr[reader_idx];
+
+            uint16_t num_elems = two_reader_indices & 0xffff;
+
+            while (num_elems--) {
+                reader_idx++;
+                two_reader_indices = packed_reader_indices_ptr[reader_idx];
+
+                uint16_t start_ind = two_reader_indices & 0xffff;
+                uint16_t end_ind = two_reader_indices >> 16;
+
+                for (uint16_t ind = start_ind; ind <= end_ind; ind += stride_w) {
+                    act_l1_offset = reader_offset + (ind * conv_act_c_read_bytes);
+                    read_activation_stick<coalesced_read_bytes>(noc, l1_write_addr_act, act_l1_offset);
+                    l1_write_addr_act += (coalesced_read_bytes + act_block_w_extra_align_bytes);
+                }
+            }
+            noc.async_read_barrier();
+            act_cb.push_back(act_block_num_tiles);
+
+            reader_offset_idx += window_inner;
+        }
+        reader_offset_idx = 0;
+
+        start_reader_idx = reader_idx;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -1,0 +1,216 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <api/dataflow/dataflow_api.h>
+#include "conv_reader_common.hpp"
+#include "debug/debug.h"
+
+void kernel_main() {
+    // This writer is for output tensor in tile format
+    constexpr uint32_t cb_id_weight = get_compile_time_arg_val(0);
+    constexpr uint32_t bias_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_id_act_second_reader = get_compile_time_arg_val(3);
+    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(4);
+    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(5);
+    constexpr uint32_t num_blocks_weight_h = get_compile_time_arg_val(6);
+    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(7);
+
+    // Bias arg. Unused if bias fusion is not enabled.
+    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(14);
+
+    constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(15);
+
+    constexpr bool fuse_bias = get_compile_time_arg_val(18);
+
+    constexpr bool split_reader_enabled = get_compile_time_arg_val(19);
+    constexpr bool activation_reuse_enabled = get_compile_time_arg_val(20);
+
+    // Split reader args
+    constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(21);
+    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(22);
+    constexpr uint32_t weight_size_w = get_compile_time_arg_val(23);
+    constexpr uint32_t conv_act_size_w_padded = get_compile_time_arg_val(24);
+    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(25);
+    constexpr bool needs_act_block_zero_out = get_compile_time_arg_val(26) == 1;
+    constexpr uint32_t dilation_h = get_compile_time_arg_val(27);
+    constexpr uint32_t dilation_w = get_compile_time_arg_val(28);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(29);
+    constexpr uint32_t weights_size_h = get_compile_time_arg_val(30);
+
+    // Activation reuse args
+    constexpr uint32_t act_reuse_cb_tiles = get_compile_time_arg_val(31);
+    constexpr uint32_t act_block_w_tiles = get_compile_time_arg_val(32);
+    constexpr bool readers_process_full_image_widths = get_compile_time_arg_val(33) == 1;
+    constexpr uint32_t image_width_tiles = get_compile_time_arg_val(34);
+    constexpr uint32_t output_image_width = get_compile_time_arg_val(35);
+    constexpr uint32_t window_reuse_offset = get_compile_time_arg_val(36);
+    constexpr bool need_to_push_remaining_tiles = get_compile_time_arg_val(37) == 1;
+    constexpr bool single_core_processes_multiple_batches = get_compile_time_arg_val(38) == 1;
+
+    uint32_t i = 0;
+    uint32_t noop = get_arg_val<uint32_t>(i++);
+
+    if (noop) {
+        return;
+    }
+
+    // Experimental API objects
+    Noc noc;
+
+    if constexpr (split_reader_enabled) {
+        if constexpr (needs_act_block_zero_out) {
+            zero_out_tiles<cb_id_act_second_reader>(noc, experimental::CB(cb_id_act_second_reader));
+        }
+    }
+
+    // mcast args
+    const uint32_t weights_mcast_sender_noc_x = get_arg_val<uint32_t>(i++);
+    const uint32_t weights_mcast_sender_noc_y = get_arg_val<uint32_t>(i++);
+    Semaphore<> weights_mcast_sender_sem(get_arg_val<uint32_t>(i++));
+    Semaphore<> weights_mcast_receiver_sem(get_arg_val<uint32_t>(i++));
+    experimental::CB cb_weight_obj(cb_id_weight);
+    experimental::CB cb_bias_obj(bias_cb_id);
+    experimental::CB cb_act_second_obj(cb_id_act_second_reader);
+    experimental::CB cb_reader_indices_obj(cb_reader_indices);
+    experimental::CB cb_sharded_act_obj(cb_id_sharded_act);
+
+    const uint32_t remaining_tiles_to_push =
+        split_reader_enabled && activation_reuse_enabled ? get_arg_val<uint32_t>(i++) : 0;
+
+    // Split reader configuration
+    if constexpr (split_reader_enabled) {
+#ifdef CONFIG_TENSOR_IN_DRAM
+        cb_reader_indices_obj.wait_front(1);
+#endif
+    }
+    constexpr uint32_t window_outer_offset = conv_act_size_w_padded * conv_act_c_read_bytes * dilation_h;
+    volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
+        split_reader_enabled ? reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_reader_indices_obj.get_write_ptr())
+                             : nullptr;
+    uint32_t reader_idx = 0;
+    constexpr uint32_t stride_w_bytes = dilation_w * conv_act_c_read_bytes;
+    constexpr uint32_t coalesced_read_bytes =
+        ((dilation_w == 1) ? weight_size_w * conv_act_c_read_bytes : conv_act_c_read_bytes);
+    const uint32_t act_l1_read_addr = split_reader_enabled ? cb_sharded_act_obj.get_read_ptr() : 0;
+    uint32_t start_reader_idx =
+        split_reader_enabled ? (uint32_t)(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1 : 0;
+    const uint32_t cb_start_addr = split_reader_enabled ? cb_act_second_obj.get_write_ptr() : 0;
+
+    // read in bias if enabled (done only once for all batches)
+    bool load_bias = true;
+    uint32_t l1_write_addr_act = 0;
+    uint32_t reader_offset = 0;
+    for (uint32_t bh = 0; bh < out_num_blocks_h; bh++) {
+        // MCAST RECEIVE WEIGHTS
+        // read weight blocks inner dim
+        // read weight slice - 1 block of weights in width dim and full weight matrix height
+        // read slice only once for all activation blocks
+
+        if constexpr (split_reader_enabled) {
+            if constexpr (activation_reuse_enabled) {
+                l1_write_addr_act = cb_start_addr;
+                get_local_cb_interface(cb_id_act_second_reader).fifo_wr_ptr = l1_write_addr_act;
+            }
+            reader_offset = act_l1_read_addr;
+        }
+        for (uint32_t block_weight_h = 0; block_weight_h < num_blocks_weight_h; block_weight_h++) {
+            if constexpr (split_reader_enabled) {
+                // Do the second half of the reads for act
+                experimental::set_read_state<coalesced_read_bytes>(noc, act_l1_read_addr);
+                reader_idx = start_reader_idx;
+
+                if constexpr (!activation_reuse_enabled) {
+                    cb_act_second_obj.reserve_back(act_block_num_tiles);
+                    l1_write_addr_act = cb_act_second_obj.get_write_ptr();
+                    read_sticks<
+                        dilation_w,
+                        coalesced_read_bytes,
+                        conv_act_c_read_bytes,
+                        act_block_w_extra_align_bytes,
+                        stride_w_bytes,
+                        weight_size_w,
+                        stride_w>(noc, packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
+                    noc.async_read_barrier();
+                    cb_act_second_obj.push_back(act_block_num_tiles);
+
+                    reader_offset += window_outer_offset;
+                } else {
+                    read_sticks_activation_reuse<
+                        coalesced_read_bytes,
+                        conv_act_c_read_bytes,
+                        act_block_w_extra_align_bytes,
+                        window_outer_offset,
+                        weight_size_w,
+                        stride_w,
+                        weights_size_h,
+                        cb_id_act_second_reader,
+                        act_reuse_cb_tiles,
+                        act_block_w_tiles,
+                        readers_process_full_image_widths,
+                        image_width_tiles,
+                        output_image_width,
+                        window_reuse_offset,
+                        single_core_processes_multiple_batches>(
+                        noc,
+                        cb_act_second_obj,
+                        packed_reader_indices_ptr,
+                        act_l1_read_addr,
+                        l1_write_addr_act,
+                        reader_idx,
+                        cb_start_addr);
+
+                    if constexpr (need_to_push_remaining_tiles) {
+                        if (block_weight_h == num_blocks_weight_h - 1) {
+                            // Last core sometimes has less work to do, but we still need to push the same number of
+                            // tiles to avoid blocking compute kernels
+                            push_remaining_tiles<cb_id_act_second_reader, act_block_w_tiles, image_width_tiles>(
+                                cb_act_second_obj, remaining_tiles_to_push, cb_start_addr);
+                        }
+                    }
+                }
+            }
+
+            // Receive weights
+            cb_weight_obj.reserve_back(weight_block_num_tiles);
+            if (bh == 0) {
+                // Set weights semaphore value to INVALID
+                weights_mcast_receiver_sem.set(INVALID);
+
+                // Atomic increment source core counter
+                weights_mcast_sender_sem.up(noc, weights_mcast_sender_noc_x, weights_mcast_sender_noc_y, 1);
+
+                // wait on weights semaphore value to become VALID (set by mcast sender after it multicasts
+                // data)
+                weights_mcast_receiver_sem.wait(VALID);
+            }
+
+            cb_weight_obj.push_back(weight_block_num_tiles);
+        }
+
+        if constexpr (fuse_bias) {
+            if (load_bias) {
+                cb_bias_obj.reserve_back(bias_ntiles);
+
+                // Set weights semaphore value to INVALID
+                weights_mcast_receiver_sem.set(INVALID);
+
+                // Atomic increment source core counter
+                weights_mcast_sender_sem.up(noc, weights_mcast_sender_noc_x, weights_mcast_sender_noc_y, 1);
+
+                // wait on weights semaphore value to become VALID (set by mcast sender after it multicasts data)
+                weights_mcast_receiver_sem.wait(VALID);
+
+                cb_bias_obj.push_back(bias_ntiles);
+                load_bias = false;
+            }
+        }
+
+        if constexpr (split_reader_enabled) {
+            // Increment reader index for the next number of segments (number of segments for other reader)
+            start_reader_idx = reader_idx + static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
+        }
+    }  // out_num_blocks_h
+
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -1,0 +1,349 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <api/dataflow/dataflow_api.h>
+#include "conv_reader_common.hpp"
+
+void kernel_main() {
+    // This writer is for output tensor in tile format
+    constexpr uint32_t cb_id_weight = get_compile_time_arg_val(0);
+    constexpr uint32_t bias_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_id_act_second_reader = get_compile_time_arg_val(3);
+    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(4);
+    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(5);
+    constexpr uint32_t num_blocks_weight_h = get_compile_time_arg_val(6);
+    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(7);
+
+    constexpr uint32_t weight_block_height_num_outer = get_compile_time_arg_val(8);
+    constexpr uint32_t weight_block_height_ntiles = get_compile_time_arg_val(9);
+    constexpr uint32_t weight_block_width_ntiles = get_compile_time_arg_val(10);
+    constexpr uint32_t weight_stride_h = get_compile_time_arg_val(11);
+    constexpr uint32_t weight_next_block_stride_h = get_compile_time_arg_val(12);
+
+    // Bias arg. Unused if bias fusion is not enabled.
+    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(14);
+
+    constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(15);
+
+    constexpr bool fuse_bias = get_compile_time_arg_val(18);
+
+    constexpr bool split_reader_enabled = get_compile_time_arg_val(19);
+    constexpr bool activation_reuse_enabled = get_compile_time_arg_val(20);
+
+    // Split reader args
+    constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(21);
+    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(22);
+    constexpr uint32_t weight_size_w = get_compile_time_arg_val(23);
+    constexpr uint32_t conv_act_size_w_padded = get_compile_time_arg_val(24);
+    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(25);
+    constexpr bool needs_act_block_zero_out = get_compile_time_arg_val(26) == 1;
+    constexpr uint32_t dilation_h = get_compile_time_arg_val(27);
+    constexpr uint32_t dilation_w = get_compile_time_arg_val(28);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(29);
+    constexpr uint32_t weights_size_h = get_compile_time_arg_val(30);
+
+    // Activation reuse args
+    constexpr uint32_t act_reuse_cb_tiles = get_compile_time_arg_val(31);
+    constexpr uint32_t act_block_w_tiles = get_compile_time_arg_val(32);
+    constexpr bool readers_process_full_image_widths = get_compile_time_arg_val(33) == 1;
+    constexpr uint32_t image_width_tiles = get_compile_time_arg_val(34);
+    constexpr uint32_t output_image_width = get_compile_time_arg_val(35);
+    constexpr uint32_t window_reuse_offset = get_compile_time_arg_val(36);
+    constexpr bool need_to_push_remaining_tiles = get_compile_time_arg_val(37) == 1;
+    constexpr bool single_core_processes_multiple_batches = get_compile_time_arg_val(38) == 1;
+
+    constexpr auto s_weight_args = TensorAccessorArgs<39>();
+    constexpr auto s_bias_args = TensorAccessorArgs<s_weight_args.next_compile_time_args_offset()>();
+
+    uint32_t i = 0;
+    const uint32_t weight_addr_dram_base = get_arg_val<uint32_t>(i++);
+    // Bias arg. Unused if bias fusion is not enabled.
+    const uint32_t bias_addr = get_arg_val<uint32_t>(i++);
+
+    const uint32_t out_start_tile_id_w = get_arg_val<uint32_t>(i++);
+    const uint32_t bias_tile_offset = get_arg_val<uint32_t>(i++);
+
+    // Experimental API objects
+    Noc noc;
+
+    if constexpr (split_reader_enabled) {
+        if constexpr (needs_act_block_zero_out) {
+            zero_out_tiles<cb_id_act_second_reader>(noc, experimental::CB(cb_id_act_second_reader));
+        }
+    }
+
+    // mcast args
+    const McastRect mcast_rect = {
+        get_arg_val<uint32_t>(i++), get_arg_val<uint32_t>(i++), get_arg_val<uint32_t>(i++), get_arg_val<uint32_t>(i++)};
+    const uint32_t weights_mcast_num_dests = get_arg_val<uint32_t>(i++);
+    const uint32_t weights_mcast_num_cores = get_arg_val<uint32_t>(i++);
+    Semaphore<> weights_mcast_sender_sem(get_arg_val<uint32_t>(i++));
+    Semaphore<> weights_mcast_receiver_sem(get_arg_val<uint32_t>(i++));
+    MulticastEndpoint mcast_ep;
+    experimental::CB cb_weight_obj(cb_id_weight);
+    experimental::CB cb_bias_obj(bias_cb_id);
+    experimental::CB cb_act_second_obj(cb_id_act_second_reader);
+    experimental::CB cb_reader_indices_obj(cb_reader_indices);
+    experimental::CB cb_sharded_act_obj(cb_id_sharded_act);
+    // Pre-built mcast destination; .addr is updated per mcast call
+    McastDst mcast_dst = {
+        .noc_x_start = mcast_rect.noc_x_start,
+        .noc_y_start = mcast_rect.noc_y_start,
+        .noc_x_end = mcast_rect.noc_x_end,
+        .noc_y_end = mcast_rect.noc_y_end,
+        .addr = 0};
+
+    const uint32_t remaining_tiles_to_push =
+        split_reader_enabled && activation_reuse_enabled ? get_arg_val<uint32_t>(i++) : 0;
+
+    // Split reader configuration
+    if constexpr (split_reader_enabled) {
+#ifdef CONFIG_TENSOR_IN_DRAM
+        cb_reader_indices_obj.wait_front(1);
+#endif
+    }
+
+    constexpr uint32_t window_outer_offset = conv_act_size_w_padded * conv_act_c_read_bytes * dilation_h;
+    volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
+        split_reader_enabled ? reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_reader_indices_obj.get_write_ptr())
+                             : nullptr;
+    uint32_t reader_idx = 0;
+    constexpr uint32_t stride_w_bytes = dilation_w * conv_act_c_read_bytes;
+    constexpr uint32_t coalesced_read_bytes =
+        ((dilation_w == 1) ? weight_size_w * conv_act_c_read_bytes : conv_act_c_read_bytes);
+    uint32_t act_l1_read_addr = split_reader_enabled ? cb_sharded_act_obj.get_read_ptr() : 0;
+    // coalesce reads along weight_size_w
+    uint32_t start_reader_idx = split_reader_enabled ? (uint32_t)(packed_reader_indices_ptr[0] & 0xffff) + 1 : 0;
+    uint32_t cb_start_addr = split_reader_enabled ? cb_act_second_obj.get_write_ptr() : 0;
+    uint32_t reader_offset = act_l1_read_addr;
+
+#ifndef SKIP_MCAST
+    // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
+    weights_mcast_receiver_sem.set(VALID);
+    // local address that will be atomically incremented by mcast receivers, to know when all receivers are ready
+    // to receive the mcast
+#endif
+
+    // read in bias if enabled (done only once for all batches)
+    constexpr uint32_t bias_pagesize =
+        fuse_bias ? get_tile_size(bias_cb_id) : 0;  // dummy but valid value in case bias is not enabled
+    const auto s_bias = TensorAccessor(s_bias_args, bias_addr);
+    bool load_bias = true;
+
+    constexpr uint32_t weight_tile_nbytes = get_tile_size(cb_id_weight);
+    const auto s_weight = TensorAccessor(s_weight_args, weight_addr_dram_base);
+
+    // OUTER most loop is looping over out blocks in width dim because blocks from compute are in col major order.
+    // Write out col major blocks in row major layout to output
+    constexpr uint32_t weight_inner_block_stride_h =
+        weight_next_block_stride_h / weight_block_height_num_outer;  // TODO: Pass as args
+
+    uint32_t l1_write_addr_act = 0;
+    for (uint32_t bh = 0; bh < out_num_blocks_h; bh++) {
+        // READ WEIGHTS + MCAST SEND WEIGHTS
+        // read weight blocks inner dim
+        // read weight slice - 1 block of weights in width dim and full weight matrix height
+        // read slice only once for all activation blocks
+        uint32_t weight_h_offset = 0;
+
+        uint32_t weight_current_block_start_tile_id = 0;
+
+        if constexpr (split_reader_enabled) {
+            if constexpr (activation_reuse_enabled) {
+                l1_write_addr_act = cb_start_addr;
+                get_local_cb_interface(cb_id_act_second_reader).fifo_wr_ptr = l1_write_addr_act;
+            }
+            reader_offset = act_l1_read_addr;
+        }
+
+        for (uint32_t block_weight_h = 0; block_weight_h < num_blocks_weight_h; block_weight_h++) {
+            if constexpr (split_reader_enabled) {
+                // Do the second half of the reads for act
+                experimental::set_read_state<coalesced_read_bytes>(noc, act_l1_read_addr);
+                reader_idx = start_reader_idx;
+
+                if constexpr (!activation_reuse_enabled) {
+                    cb_act_second_obj.reserve_back(act_block_num_tiles);
+                    l1_write_addr_act = cb_act_second_obj.get_write_ptr();
+                    read_sticks<
+                        dilation_w,
+                        coalesced_read_bytes,
+                        conv_act_c_read_bytes,
+                        act_block_w_extra_align_bytes,
+                        stride_w_bytes,
+                        weight_size_w,
+                        stride_w>(noc, packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
+                    noc.async_read_barrier();
+                    cb_act_second_obj.push_back(act_block_num_tiles);
+
+                    reader_offset += window_outer_offset;
+                } else {
+                    read_sticks_activation_reuse<
+                        coalesced_read_bytes,
+                        conv_act_c_read_bytes,
+                        act_block_w_extra_align_bytes,
+                        window_outer_offset,
+                        weight_size_w,
+                        stride_w,
+                        weights_size_h,
+                        cb_id_act_second_reader,
+                        act_reuse_cb_tiles,
+                        act_block_w_tiles,
+                        readers_process_full_image_widths,
+                        image_width_tiles,
+                        output_image_width,
+                        window_reuse_offset,
+                        single_core_processes_multiple_batches>(
+                        noc,
+                        cb_act_second_obj,
+                        packed_reader_indices_ptr,
+                        act_l1_read_addr,
+                        l1_write_addr_act,
+                        reader_idx,
+                        cb_start_addr);
+
+                    if constexpr (need_to_push_remaining_tiles) {
+                        if (block_weight_h == num_blocks_weight_h - 1) {
+                            // Last core sometimes has less work to do, but we still need to push the same number of
+                            // tiles to avoid blocking compute kernels
+                            push_remaining_tiles<cb_id_act_second_reader, act_block_w_tiles, image_width_tiles>(
+                                cb_act_second_obj, remaining_tiles_to_push, cb_start_addr);
+                        }
+                    }
+                }
+            }
+
+            // Do weights read + mcast
+            cb_weight_obj.reserve_back(weight_block_num_tiles);
+            if (bh == 0) {
+                uint32_t weight_row_start_tile_id = weight_current_block_start_tile_id + weight_h_offset;
+
+                uint32_t weight_write_offset = 0;
+                uint32_t weights_block_size_bytes = 0;
+
+                // loop over weight block tiles along h
+                for (uint32_t weight_tile_h_i = 0; weight_tile_h_i < weight_block_height_ntiles; ++weight_tile_h_i) {
+                    uint32_t weight_tile_id = weight_row_start_tile_id;
+                    // loop over weight block tiles along w
+                    for (uint32_t weight_tile_w_i = 0; weight_tile_w_i < weight_block_width_ntiles; ++weight_tile_w_i) {
+                        // DPRINT("weight_tile_id={}\n", weight_tile_id);
+                        noc.async_read(
+                            s_weight,
+                            cb_weight_obj,
+                            weight_tile_nbytes,
+                            {.page_id = weight_tile_id},
+                            {.offset_bytes = weight_write_offset});
+                        weight_write_offset += weight_tile_nbytes;
+                        weights_block_size_bytes += weight_tile_nbytes;
+                        weight_tile_id += 1;
+                    }  // for weight_block_w
+                    weight_row_start_tile_id += weight_stride_h;
+                }  // for weight_block_h
+                noc.async_read_barrier();
+
+#ifndef SKIP_MCAST
+                // wait until all weights mcast destinations have atomically incremented the weights
+                // semaphore_addr (i.e. its value should be weights_mcast_num_dests), then reset the
+                // semaphore_addr value back to zero for the next block
+                weights_mcast_sender_sem.wait(weights_mcast_num_dests);
+                weights_mcast_sender_sem.set(0);
+
+                // Now we have the block in the CB address, we can mcast to dests!
+                // num_dests must not include source, since we are NOT really doing a local copy!
+                mcast_dst.addr = cb_weight_obj.get_write_ptr();
+                noc.async_write_multicast(
+                    use<experimental::CB::AddrSelector::WRITE_PTR>(cb_weight_obj),
+                    mcast_ep,
+                    weights_block_size_bytes,
+                    weights_mcast_num_cores,
+                    {},
+                    mcast_dst,
+                    true);
+
+                // Note: no need for write barrier, since these two multicasts are done on the same noc id and
+                // same vc even though cmd bufs are different Also, this only works because we are setting VCs
+                // statically (using NOC_CMD_STATIC_VC).
+                // We should also multicast the flag to destinations
+                // num_dests must not include source, since we are NOT really doing a local copy!
+                weights_mcast_receiver_sem.set_multicast(
+                    noc,
+                    mcast_rect.noc_x_start,
+                    mcast_rect.noc_y_start,
+                    mcast_rect.noc_x_end,
+                    mcast_rect.noc_y_end,
+                    weights_mcast_num_cores,
+                    false);
+#endif
+
+                weight_current_block_start_tile_id += weight_next_block_stride_h;
+            }
+
+            cb_weight_obj.push_back(weight_block_num_tiles);
+        }  // for num_blocks_weight_h
+        weight_h_offset += weight_inner_block_stride_h;
+
+        if constexpr (fuse_bias) {
+            if (load_bias) {
+                cb_bias_obj.reserve_back(bias_ntiles);
+
+                uint32_t bias_write_offset = 0;
+                uint32_t bias_block_size_bytes = 0;
+                for (uint32_t bias_tile = bias_tile_offset; bias_tile < bias_tile_offset + bias_ntiles; ++bias_tile) {
+                    noc.async_read(
+                        s_bias,
+                        cb_bias_obj,
+                        bias_pagesize,
+                        {.page_id = bias_tile},
+                        {.offset_bytes = bias_write_offset});
+                    bias_write_offset += bias_pagesize;
+                    bias_block_size_bytes += bias_pagesize;
+                }
+                noc.async_read_barrier();
+
+// MCAST BIAS (shares some mcast args with weights)
+#ifndef SKIP_MCAST
+                // wait until all weights mcast destinations have atomically incremented the weights semaphore_addr
+                // (i.e. its value should be weights_mcast_num_dests), then reset the semaphore_addr value back to zero
+                // for the next block
+                weights_mcast_sender_sem.wait(weights_mcast_num_dests);
+                weights_mcast_sender_sem.set(0);
+
+                // Now we have the block in the CB address, we can mcast to dests!
+                // num_dests must not include source, since we are NOT really doing a local copy!
+                mcast_dst.addr = cb_bias_obj.get_write_ptr();
+                noc.async_write_multicast(
+                    use<experimental::CB::AddrSelector::WRITE_PTR>(cb_bias_obj),
+                    mcast_ep,
+                    bias_block_size_bytes,
+                    weights_mcast_num_cores,
+                    {},
+                    mcast_dst,
+                    true);
+
+                // Note: no need for write barrier, since these two multicasts are done on the same noc id and same vc
+                // even though cmd bufs are different Also, this only works because we are setting VCs statically (using
+                // NOC_CMD_STATIC_VC).
+                // We should also multicast the flag to destinations
+                // num_dests must not include source, since we are NOT really doing a local copy!
+                weights_mcast_receiver_sem.set_multicast(
+                    noc,
+                    mcast_rect.noc_x_start,
+                    mcast_rect.noc_y_start,
+                    mcast_rect.noc_x_end,
+                    mcast_rect.noc_y_end,
+                    weights_mcast_num_cores,
+                    false);
+#endif
+
+                cb_bias_obj.push_back(bias_ntiles);
+                load_bias = false;
+            }
+        }
+        if constexpr (split_reader_enabled) {
+            // Increment reader index for the next number of segments (number of segments for other reader)
+            start_reader_idx = reader_idx + static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
+        }
+    }  // out_num_blocks_h
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/weights_reader_width_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/weights_reader_width_sharded.cpp
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include <api/dataflow/dataflow_api.h>
+#include "api/debug/dprint.h"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
+
+void kernel_main() {
+    constexpr uint32_t cb_id_weight = get_compile_time_arg_val(0);
+    constexpr uint32_t core_in_channels_ntiles = get_compile_time_arg_val(1);
+    constexpr uint32_t window_size_hw = get_compile_time_arg_val(2);
+
+    // weight_block_width_ntiles corresponds to the full output width of each core.
+    constexpr uint32_t weight_block_width_ntiles = get_compile_time_arg_val(3);
+    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(4);
+    constexpr uint32_t weight_matrix_width_ntiles = get_compile_time_arg_val(5);
+    constexpr uint32_t weight_next_channel_stride_h = get_compile_time_arg_val(6);
+    constexpr uint32_t weight_next_block_this_core_stride_h = get_compile_time_arg_val(7);
+    constexpr uint32_t weight_next_block_other_core_stride_h = get_compile_time_arg_val(8);
+    constexpr uint32_t remote_weight_height_blocks = get_compile_time_arg_val(9);
+    constexpr uint32_t local_weight_height_blocks = get_compile_time_arg_val(10);
+    constexpr uint32_t act_num_blocks_h = get_compile_time_arg_val(11);
+    constexpr uint32_t bias_cb_id = get_compile_time_arg_val(12);
+    constexpr bool fuse_bias = get_compile_time_arg_val(13);
+    constexpr auto s_weight_args = TensorAccessorArgs<14>();
+    constexpr auto s_bias_args = TensorAccessorArgs<s_weight_args.next_compile_time_args_offset()>();
+
+    uint32_t i = 0;
+    const uint32_t init_weight_start_tile_id = get_arg_val<uint32_t>(i);
+    i += 1;
+    const uint32_t weight_addr_dram_base = get_arg_val<uint32_t>(i);
+    i += 1;
+
+    uint32_t bias_addr_dram_base = get_arg_val<uint32_t>(i);
+    i += 1;
+    const uint32_t is_active = get_arg_val<uint32_t>(i);
+    i += 1;
+
+    const uint32_t weight_tile_nbytes = get_tile_size(cb_id_weight);
+    const auto s_weight = TensorAccessor(s_weight_args, weight_addr_dram_base);
+    const uint32_t bias_pagesize =
+        fuse_bias ? get_tile_size(bias_cb_id) : 0;  // dummy but valid value in case bias is not enabled
+    const auto s_bias = TensorAccessor(s_bias_args, bias_addr_dram_base);
+
+    experimental::CB weight_cb(cb_id_weight);
+    experimental::CB bias_cb(bias_cb_id);
+    Noc noc;
+
+    bool to_load_bias = true;
+
+    for (uint32_t act_block_h_index = 0; act_block_h_index < act_num_blocks_h; act_block_h_index++) {
+        uint32_t weight_start_tile_id = init_weight_start_tile_id;
+        uint32_t bias_start_tile_id = init_weight_start_tile_id;
+
+        // Outer most loop is each core's block width.
+        // This interleaves reader/tilization with compute. Hopefully better perf.
+        // Activation reader first sends data from the same block of all cores. Then iterates to the next block and
+        // repeats for all cores. Stride = act_block_w*out_channels*sizeof(elem)
+        for (uint32_t local_weight_block_index = 0; local_weight_block_index < local_weight_height_blocks;
+             local_weight_block_index++) {
+            uint32_t weight_block_start_tile_id = weight_start_tile_id;
+
+            // Iterates over all the cores.
+            // Stride = in_channels*out_channels*sizeof(elem)/num_cores.
+            for (uint32_t remote_weight_block_index = 0; remote_weight_block_index < remote_weight_height_blocks;
+                 remote_weight_block_index++) {
+                weight_cb.reserve_back(weight_block_num_tiles);
+                if (is_active) {
+                    uint32_t weight_current_block_start_tile_id = weight_block_start_tile_id;
+
+                    // for window size, picking up the channels for that window.
+                    // Stride is in_channels*out_channels*sizeof(elem).
+                    uint32_t weight_write_offset = 0;
+                    for (uint32_t block_weight_h = 0; block_weight_h < window_size_hw; block_weight_h++) {
+                        uint32_t weight_row_start_tile_id = weight_current_block_start_tile_id;
+
+                        // read the channels in one block.
+                        for (uint32_t weight_tile_h_i = 0; weight_tile_h_i < core_in_channels_ntiles;
+                             ++weight_tile_h_i) {
+                            uint32_t weight_tile_id = weight_row_start_tile_id;
+
+                            // loop over output channels, width of the output/weights.
+                            for (uint32_t weight_tile_w_i = 0; weight_tile_w_i < weight_block_width_ntiles;
+                                 ++weight_tile_w_i) {
+                                noc.async_read(
+                                    s_weight,
+                                    weight_cb,
+                                    weight_tile_nbytes,
+                                    {.page_id = weight_tile_id},
+                                    {.offset_bytes = weight_write_offset});
+                                weight_write_offset += weight_tile_nbytes;
+                                weight_tile_id += 1;
+                            }  // for weight_block_w
+                            weight_row_start_tile_id += weight_matrix_width_ntiles;
+                        }  // for weight_block_h
+                        weight_current_block_start_tile_id += weight_next_channel_stride_h;
+                    }
+                    noc.async_read_barrier();
+                }
+                weight_cb.push_back(weight_block_num_tiles);
+                weight_block_start_tile_id += weight_next_block_other_core_stride_h;
+            }
+            weight_start_tile_id += weight_next_block_this_core_stride_h;
+            if (to_load_bias) {
+                if constexpr (fuse_bias) {
+                    bias_cb.reserve_back(weight_block_width_ntiles);
+                    uint32_t bias_write_offset = 0;
+                    for (uint32_t weight_tile_w_i = 0; weight_tile_w_i < weight_block_width_ntiles; ++weight_tile_w_i) {
+                        noc.async_read(
+                            s_bias,
+                            bias_cb,
+                            bias_pagesize,
+                            {.page_id = bias_start_tile_id},
+                            {.offset_bytes = bias_write_offset});
+                        bias_write_offset += bias_pagesize;
+                        bias_start_tile_id += 1;
+                    }
+                    noc.async_read_barrier();
+                    bias_cb.push_back(weight_block_width_ntiles);
+                }
+                to_load_bias = false;
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/writer_tiled_out_2d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/writer_tiled_out_2d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -1,0 +1,219 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <api/dataflow/dataflow_api.h>
+#include "conv_reader_common.hpp"
+
+#define ENABLE_DEBUG 0
+
+#if ENABLE_DEBUG
+#include "api/debug/dprint.h"
+#include "api/debug/dprint_pages.h"
+#endif
+
+void kernel_main() {
+    // This writer is for output tensor in tile format
+    constexpr uint32_t cb_id_weight = get_compile_time_arg_val(0);
+    constexpr uint32_t bias_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t num_blocks_weight_h = get_compile_time_arg_val(6);
+    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(7);
+    constexpr uint32_t weight_block_height_num_outer = get_compile_time_arg_val(8);
+
+    // Bias arg. Unused if bias fusion is not enabled.
+    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(14);
+    constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(15);
+    constexpr uint32_t out_num_blocks_w = get_compile_time_arg_val(16);
+
+    constexpr bool fuse_bias = get_compile_time_arg_val(18);
+
+    constexpr bool split_reader_enabled = get_compile_time_arg_val(19);
+
+    // Split reader args
+    constexpr uint32_t cb_id_act_second_reader = get_compile_time_arg_val(3);
+    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(4);
+    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(5);
+    constexpr uint32_t window_outer = get_compile_time_arg_val(6);  // num_blocks_act_w
+    constexpr bool sliced_inner_dim = window_outer > 1;             // Derived like block sharded reader
+    constexpr uint32_t act_block_num_tiles_split_last = get_compile_time_arg_val(21);
+    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(22);
+    constexpr uint32_t weight_size_w = get_compile_time_arg_val(23);
+    constexpr uint32_t padded_conv_act_size_w = get_compile_time_arg_val(24);
+    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(25);
+    constexpr bool needs_act_block_zero_out = get_compile_time_arg_val(26) == 1;
+    constexpr uint32_t dilation_h = get_compile_time_arg_val(27);
+    constexpr uint32_t dilation_w = get_compile_time_arg_val(28);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(29);
+    constexpr uint32_t weight_size_h = get_compile_time_arg_val(30);
+
+    // When the split reader CB is shared, both readers write to the same circular buffer.
+    // Synchronization is required: the main reader signals when CB space is reserved,
+    // and the second reader signals when it has finished writing its portion.
+    constexpr bool split_reader_cb_shared = get_compile_time_arg_val(31) == 1;
+    Semaphore<> reserve_done_sem((split_reader_cb_shared) ? get_compile_time_arg_val(32) : 0);
+    Semaphore<> write_done_sem((split_reader_cb_shared) ? get_compile_time_arg_val(33) : 0);
+    constexpr uint32_t act_write_offset = get_compile_time_arg_val(34);
+    constexpr uint32_t act_write_offset_last = get_compile_time_arg_val(35);
+
+    experimental::CB cb_act_second_obj(cb_id_act_second_reader);
+    const uint32_t split_reader_cb_write_addr =
+        (split_reader_cb_shared) ? cb_act_second_obj.get_write_ptr() + act_write_offset : 0;
+    // In case of double buffering the split reader can write to two different addresses
+    const uint32_t split_reader_cb_write_addr_last =
+        (split_reader_cb_shared) ? cb_act_second_obj.get_write_ptr() + act_write_offset_last : 0;
+    const uint32_t split_reader_cb_write_addr_sum = split_reader_cb_write_addr + split_reader_cb_write_addr_last;
+
+    // mcast args
+    uint32_t i = 0;
+    const uint32_t weights_mcast_sender_noc_x = get_arg_val<uint32_t>(i++);
+    const uint32_t weights_mcast_sender_noc_y = get_arg_val<uint32_t>(i++);
+
+    // Experimental API objects
+    Noc noc;
+    Semaphore<> weights_mcast_sender_sem(get_arg_val<uint32_t>(i++));
+    Semaphore<> weights_mcast_receiver_sem(get_arg_val<uint32_t>(i++));
+    experimental::CB cb_weight_obj(cb_id_weight);
+    experimental::CB cb_bias_obj(bias_cb_id);
+    experimental::CB cb_reader_indices_obj(cb_reader_indices);
+    experimental::CB cb_sharded_act_obj(cb_id_sharded_act);
+
+    const bool is_sender_core = get_arg_val<uint32_t>(i++) > 0;
+
+    // Split reader configuration
+    if constexpr (split_reader_enabled) {
+#ifdef CONFIG_TENSOR_IN_DRAM
+        cb_reader_indices_obj.wait_front(1);
+#endif
+        if constexpr (needs_act_block_zero_out) {
+            zero_out_tiles<cb_id_act_second_reader>(noc, cb_act_second_obj);
+        }
+    }
+
+    volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
+        (split_reader_enabled && is_sender_core)
+            ? reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_reader_indices_obj.get_write_ptr())
+            : nullptr;
+
+    // Initial setup for second reader (starting from second reader's data)
+    // Only read reader indices on cores that have sharded input (is_sender_core).
+    uint32_t start_reader_idx =
+        (split_reader_enabled && is_sender_core) ? (uint32_t)(packed_reader_indices_ptr[0] & 0xffff) + 1 : 0;
+    uint32_t reader_idx = start_reader_idx;
+
+    constexpr uint32_t stride_w_bytes = dilation_w * conv_act_c_read_bytes;
+    constexpr uint32_t coalesced_read_bytes =
+        ((dilation_w == 1) ? weight_size_w * conv_act_c_read_bytes : conv_act_c_read_bytes);
+    constexpr uint32_t window_outer_offset = padded_conv_act_size_w * conv_act_c_read_bytes * dilation_h;
+    constexpr uint32_t stride_h_bytes = padded_conv_act_size_w * conv_act_c_read_bytes * dilation_h;
+
+    const uint32_t act_l1_read_addr = split_reader_enabled ? cb_sharded_act_obj.get_read_ptr() : 0;
+    // read in bias if enabled (done only once for all batches)
+    bool load_bias = true;
+
+    // OUTER most loop is looping over out blocks in width dim because blocks from compute are in col major order.
+    // Write out col major blocks in row major layout to output
+    uint32_t l1_write_addr_act = split_reader_cb_write_addr;
+    uint32_t prev_addr = 0;
+    uint32_t reader_offset = 0;
+    for (uint32_t bw = 0; bw < out_num_blocks_w; bw++) {
+        for (uint32_t bh = 0; bh < out_num_blocks_h; bh++) {
+            if constexpr (split_reader_enabled) {
+                // Read activation data using block sharded pattern (for second reader)
+                reader_offset = act_l1_read_addr;
+            }
+            for (uint32_t height_block_index = 0; height_block_index < num_blocks_weight_h; height_block_index++) {
+                if constexpr (split_reader_enabled) {
+                    reader_idx = start_reader_idx;
+                    if constexpr (!split_reader_cb_shared) {
+                        cb_act_second_obj.reserve_back(act_block_num_tiles_split_last);
+                    }
+
+                    if (is_sender_core) {
+                        if constexpr (split_reader_cb_shared) {
+                            reserve_done_sem.wait(VALID);
+                            reserve_done_sem.set(INVALID);
+                            prev_addr = l1_write_addr_act;
+                        } else {
+                            l1_write_addr_act = cb_act_second_obj.get_write_ptr();
+                        }
+                        experimental::set_read_state<coalesced_read_bytes>(noc, act_l1_read_addr);
+                        read_activation_data<
+                            sliced_inner_dim,
+                            dilation_w,
+                            coalesced_read_bytes,
+                            conv_act_c_read_bytes,
+                            act_block_w_extra_align_bytes,
+                            stride_w_bytes,
+                            weight_size_w,
+                            stride_w,
+                            weight_size_h,
+                            window_outer_offset>(
+                            noc,
+                            packed_reader_indices_ptr,
+                            reader_offset,
+                            l1_write_addr_act,
+                            reader_idx,
+                            act_l1_read_addr,
+                            stride_h_bytes);
+                        if constexpr (split_reader_cb_shared) {
+                            // in case of shared cb we update the write address (it will remain the same if double
+                            // buffering is not enabled)
+                            l1_write_addr_act = split_reader_cb_write_addr_sum - prev_addr;
+                            write_done_sem.set(VALID);
+                        }
+                    }
+                    if constexpr (!split_reader_cb_shared) {
+                        cb_act_second_obj.push_back(act_block_num_tiles_split_last);
+                    }
+                }
+                for (uint32_t weight_tile_h_outer_i = 0; weight_tile_h_outer_i < weight_block_height_num_outer;
+                     weight_tile_h_outer_i++) {
+                    // MCAST RECEIVE WEIGHTS
+                    // read weight blocks inner dim
+                    // read weight slice - 1 block of weights in width dim and full weight matrix height
+                    // read slice only once for all activation blocks
+                    cb_weight_obj.reserve_back(weight_block_num_tiles);
+                    // Set weights semaphore value to INVALID
+                    weights_mcast_receiver_sem.set(INVALID);
+
+                    // Atomic increment source core counter
+                    weights_mcast_sender_sem.up(noc, weights_mcast_sender_noc_x, weights_mcast_sender_noc_y, 1);
+
+                    // wait on weights semaphore value to become VALID (set by mcast sender after it multicasts data)
+                    weights_mcast_receiver_sem.wait(VALID);
+
+                    cb_weight_obj.push_back(weight_block_num_tiles);
+                }  // for weight_block_height_num_outer
+            }
+            if constexpr (split_reader_enabled) {
+                // Update reader index for next iteration (split reader increment)
+                // Only read reader indices on cores that have sharded input (is_sender_core).
+                if (is_sender_core) {
+                    start_reader_idx =
+                        reader_idx + static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
+                }
+            }
+            if constexpr (fuse_bias) {
+                if (load_bias) {
+                    cb_bias_obj.reserve_back(bias_ntiles);
+
+                    // Set weights semaphore value to INVALID
+                    weights_mcast_receiver_sem.set(INVALID);
+
+                    // Atomic increment source core counter
+                    weights_mcast_sender_sem.up(noc, weights_mcast_sender_noc_x, weights_mcast_sender_noc_y, 1);
+
+                    // wait on weights semaphore value to become VALID (set by mcast sender after it multicasts data)
+                    weights_mcast_receiver_sem.wait(VALID);
+
+                    cb_bias_obj.push_back(bias_ntiles);
+                    load_bias = false;
+                }
+            }
+
+        }  // out_num_blocks_h
+    }  // out_num_blocks_w
+
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -1,0 +1,361 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <api/dataflow/dataflow_api.h>
+#include "conv_reader_common.hpp"
+
+#define ENABLE_DEBUG 0
+
+#if ENABLE_DEBUG
+#include "api/debug/dprint.h"
+#include "api/debug/dprint_pages.h"
+#endif
+
+void kernel_main() {
+    // This writer is for output tensor in tile format
+    constexpr uint32_t cb_id_weight = get_compile_time_arg_val(0);
+    constexpr uint32_t bias_cb_id = get_compile_time_arg_val(1);
+
+    constexpr uint32_t num_blocks_weight_h = get_compile_time_arg_val(6);
+    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(7);
+    constexpr uint32_t weight_block_height_num_outer = get_compile_time_arg_val(8);
+    constexpr uint32_t weight_block_height_ntiles = get_compile_time_arg_val(9);
+    constexpr uint32_t weight_block_width_ntiles = get_compile_time_arg_val(10);
+    constexpr uint32_t weight_stride_h = get_compile_time_arg_val(11);
+    constexpr uint32_t weight_next_block_stride_w = get_compile_time_arg_val(13);
+
+    // Bias arg. Unused if bias fusion is not enabled.
+    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(14);
+
+    constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(15);
+    constexpr uint32_t out_num_blocks_w = get_compile_time_arg_val(16);
+    constexpr uint32_t weight_block_height_num_outer_in = get_compile_time_arg_val(17);
+
+    constexpr bool fuse_bias = get_compile_time_arg_val(18);
+
+    constexpr bool split_reader_enabled = get_compile_time_arg_val(19);
+
+    // Split reader args
+    constexpr uint32_t cb_id_act_second_reader = get_compile_time_arg_val(3);
+    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(4);
+    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(5);
+    constexpr uint32_t window_outer = get_compile_time_arg_val(6);  // num_blocks_act_w
+    constexpr bool sliced_inner_dim = num_blocks_weight_h > 1;      // Derived like block sharded reader
+    constexpr uint32_t act_block_num_tiles_split_last = get_compile_time_arg_val(21);
+    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(22);
+    constexpr uint32_t weight_size_w = get_compile_time_arg_val(23);
+    constexpr uint32_t padded_conv_act_size_w = get_compile_time_arg_val(24);
+    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(25);
+    constexpr bool needs_act_block_zero_out = get_compile_time_arg_val(26) == 1;
+    constexpr uint32_t dilation_h = get_compile_time_arg_val(27);
+    constexpr uint32_t dilation_w = get_compile_time_arg_val(28);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(29);
+    constexpr uint32_t weight_size_h = get_compile_time_arg_val(30);  // Input filter window height
+
+    constexpr bool split_reader_cb_shared = get_compile_time_arg_val(31) == 1;
+
+    // When the split reader CB is shared, both readers write to the same circular buffer.
+    // Synchronization is required: the main reader signals when CB space is reserved,
+    // and the second reader signals when it has finished writing its portion.
+    Semaphore<> reserve_done_sem((split_reader_cb_shared) ? get_compile_time_arg_val(32) : 0);
+    Semaphore<> write_done_sem((split_reader_cb_shared) ? get_compile_time_arg_val(33) : 0);
+    constexpr uint32_t act_write_offset = get_compile_time_arg_val(34);
+    constexpr uint32_t act_write_offset_last = get_compile_time_arg_val(35);
+
+    experimental::CB cb_act_second_obj(cb_id_act_second_reader);
+    const uint32_t split_reader_cb_write_addr =
+        (split_reader_cb_shared) ? cb_act_second_obj.get_write_ptr() + act_write_offset : 0;
+    // In case of double buffering the split reader can write to two different addresses
+    const uint32_t split_reader_cb_write_addr_last =
+        (split_reader_cb_shared) ? cb_act_second_obj.get_write_ptr() + act_write_offset_last : 0;
+    const uint32_t split_reader_cb_write_addr_sum = split_reader_cb_write_addr + split_reader_cb_write_addr_last;
+
+    constexpr uint32_t ct_arg_idx = 36;
+    constexpr auto s_weight_args = TensorAccessorArgs<ct_arg_idx>();
+    constexpr auto s_bias_args = TensorAccessorArgs<s_weight_args.next_compile_time_args_offset()>();
+
+    uint32_t i = 0;
+    const uint32_t weight_addr_dram_base = get_arg_val<uint32_t>(i++);
+    // Bias arg. Unused if bias fusion is not enabled.
+    const uint32_t bias_addr = get_arg_val<uint32_t>(i++);
+    const uint32_t out_start_tile_id_w = get_arg_val<uint32_t>(i++);
+    const uint32_t bias_tile_offset = get_arg_val<uint32_t>(i++);
+
+    // mcast args
+    const McastRect mcast_rect = {
+        get_arg_val<uint32_t>(i++), get_arg_val<uint32_t>(i++), get_arg_val<uint32_t>(i++), get_arg_val<uint32_t>(i++)};
+    const uint32_t weights_mcast_num_dests = get_arg_val<uint32_t>(i++);
+    const uint32_t weights_mcast_num_cores = get_arg_val<uint32_t>(i++);
+
+    // Experimental API objects
+    Noc noc;
+    Semaphore<> weights_mcast_sender_sem(get_arg_val<uint32_t>(i++));
+    Semaphore<> weights_mcast_receiver_sem(get_arg_val<uint32_t>(i++));
+    MulticastEndpoint mcast_ep;
+    experimental::CB cb_weight_obj(cb_id_weight);
+    experimental::CB cb_bias_obj(bias_cb_id);
+    experimental::CB cb_reader_indices_obj(cb_reader_indices);
+    experimental::CB cb_sharded_act_obj(cb_id_sharded_act);
+    // Pre-built mcast destination; .addr is updated per mcast call
+    McastDst mcast_dst = {
+        .noc_x_start = mcast_rect.noc_x_start,
+        .noc_y_start = mcast_rect.noc_y_start,
+        .noc_x_end = mcast_rect.noc_x_end,
+        .noc_y_end = mcast_rect.noc_y_end,
+        .addr = 0};
+
+    const bool is_sender_core = get_arg_val<uint32_t>(i++) > 0;
+    const bool skip_work = get_arg_val<uint32_t>(i++) > 0;
+
+    if (skip_work && !split_reader_enabled) {
+        return;
+    }
+
+    // Split reader configuration
+    if constexpr (split_reader_enabled) {
+#ifdef CONFIG_TENSOR_IN_DRAM
+        cb_reader_indices_obj.wait_front(1);
+#endif
+        if constexpr (needs_act_block_zero_out) {
+            zero_out_tiles<cb_id_act_second_reader>(noc, cb_act_second_obj);
+        }
+    }
+
+    volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
+        (split_reader_enabled && is_sender_core)
+            ? reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_reader_indices_obj.get_write_ptr())
+            : nullptr;
+    // Initial setup for second reader (starting from second reader's data)
+    // Only read reader indices on cores that have sharded input (is_sender_core).
+    uint32_t start_reader_idx =
+        (split_reader_enabled && is_sender_core) ? (uint32_t)(packed_reader_indices_ptr[0] & 0xffff) + 1 : 0;
+    uint32_t reader_idx = start_reader_idx;
+
+    constexpr uint32_t stride_w_bytes = dilation_w * conv_act_c_read_bytes;
+    constexpr uint32_t coalesced_read_bytes =
+        ((dilation_w == 1) ? weight_size_w * conv_act_c_read_bytes : conv_act_c_read_bytes);
+    constexpr uint32_t window_outer_offset = padded_conv_act_size_w * conv_act_c_read_bytes * dilation_h;
+    constexpr uint32_t stride_h_bytes = padded_conv_act_size_w * conv_act_c_read_bytes * dilation_h;
+
+    const uint32_t act_l1_read_addr = split_reader_enabled ? cb_sharded_act_obj.get_read_ptr() : 0;
+
+#ifndef SKIP_MCAST
+    // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
+    weights_mcast_receiver_sem.set(VALID);
+    // local address that will be atomically incremented by mcast receivers, to know when all receivers are ready
+    // to receive the mcast
+#endif
+
+    // read in bias if enabled (done only once for all batches)
+    constexpr uint32_t bias_pagesize =
+        fuse_bias ? get_tile_size(bias_cb_id) : 0;  // dummy value in case bias is not enabled
+    const auto s_bias = TensorAccessor(s_bias_args, bias_addr);
+
+    bool load_bias = true;
+
+    constexpr uint32_t weight_tile_nbytes = get_tile_size(cb_id_weight);
+    const auto s_weight = TensorAccessor(s_weight_args, weight_addr_dram_base);
+    constexpr uint32_t weights_block_size_bytes = weight_tile_nbytes * weight_block_num_tiles;
+
+    // Pre-compute constants used in tile_id calculation (preserving exact original logic)
+    constexpr uint32_t tiles_per_full_block =
+        num_blocks_weight_h * weight_block_height_ntiles * weight_block_height_num_outer_in * weight_block_width_ntiles;
+    constexpr uint32_t height_stride_factor = weight_block_height_ntiles * weight_stride_h;
+
+    // OUTER most loop is looping over out blocks in width dim because blocks from compute are in col major order.
+    // Write out col major blocks in row major layout to output
+    uint32_t reader_offset = 0;
+    uint32_t weight_start_tile_id = out_start_tile_id_w;
+    uint32_t l1_write_addr_act = split_reader_cb_write_addr;
+    uint32_t prev_addr = 0;
+    for (uint32_t bw = 0; bw < out_num_blocks_w; bw++) {
+        for (uint32_t bh = 0; bh < out_num_blocks_h; bh++) {
+            if constexpr (split_reader_enabled) {
+                reader_offset = act_l1_read_addr;
+            }
+            for (uint32_t height_block_index = 0; height_block_index < num_blocks_weight_h; height_block_index++) {
+                if constexpr (split_reader_enabled) {
+                    reader_idx = start_reader_idx;
+                    if constexpr (!split_reader_cb_shared) {
+                        cb_act_second_obj.reserve_back(act_block_num_tiles_split_last);
+                    }
+                    if (is_sender_core) {
+                        if constexpr (split_reader_cb_shared) {
+                            reserve_done_sem.wait(VALID);
+                            reserve_done_sem.set(INVALID);
+                            prev_addr = l1_write_addr_act;
+                        } else {
+                            l1_write_addr_act = cb_act_second_obj.get_write_ptr();
+                        }
+                        experimental::set_read_state<coalesced_read_bytes>(noc, act_l1_read_addr);
+                        read_activation_data<
+                            sliced_inner_dim,
+                            dilation_w,
+                            coalesced_read_bytes,
+                            conv_act_c_read_bytes,
+                            act_block_w_extra_align_bytes,
+                            stride_w_bytes,
+                            weight_size_w,
+                            stride_w,
+                            weight_size_h,
+                            window_outer_offset>(
+                            noc,
+                            packed_reader_indices_ptr,
+                            reader_offset,
+                            l1_write_addr_act,
+                            reader_idx,
+                            act_l1_read_addr,
+                            stride_h_bytes);
+                        if constexpr (split_reader_cb_shared) {
+                            // in case of shared cb we update the write address (it will remain the same if double
+                            // buffering is not enabled)
+                            l1_write_addr_act = split_reader_cb_write_addr_sum - prev_addr;
+                            write_done_sem.set(VALID);
+                        }
+                    }
+                    if constexpr (!split_reader_cb_shared) {
+                        cb_act_second_obj.push_back(act_block_num_tiles_split_last);
+                    }
+                    if (skip_work) {
+                        continue;
+                    }
+                }
+                // Compute height block offset once per outer loop iteration
+                const uint32_t height_block_offset = height_block_index * height_stride_factor;
+                for (uint32_t weight_tile_h_outer_i = 0; weight_tile_h_outer_i < weight_block_height_num_outer;
+                     weight_tile_h_outer_i++) {
+                    cb_weight_obj.reserve_back(weight_block_num_tiles);
+
+                    const uint32_t outer_block_offset = weight_tile_h_outer_i * tiles_per_full_block;
+                    uint32_t tile_id = weight_start_tile_id + height_block_offset + outer_block_offset;
+                    uint32_t weight_write_offset = 0;
+                    for (uint32_t block_weight_h = 0; block_weight_h < weight_block_height_ntiles; block_weight_h++) {
+                        uint32_t weight_tile_id = tile_id;
+
+                        for (uint32_t weight_tile_w_i = 0; weight_tile_w_i < weight_block_width_ntiles;
+                             ++weight_tile_w_i) {
+                            noc.async_read(
+                                s_weight,
+                                cb_weight_obj,
+                                weight_tile_nbytes,
+                                {.page_id = weight_tile_id++},
+                                {.offset_bytes = weight_write_offset});
+                            weight_write_offset += weight_tile_nbytes;
+                        }
+                        tile_id += weight_stride_h;
+                    }
+                    noc.async_read_barrier();
+
+#ifndef SKIP_MCAST
+                    // wait until all weights mcast destinations have atomically incremented the weights semaphore_addr
+                    // (i.e. its value should be weights_mcast_num_dests), then reset the semaphore_addr value back to
+                    // zero for the next block
+                    weights_mcast_sender_sem.wait(weights_mcast_num_dests);
+                    weights_mcast_sender_sem.set(0);
+
+                    // Now we have the block in the CB address, we can mcast to dests!
+                    // num_dests must not include source, since we are NOT really doing a local copy!
+                    mcast_dst.addr = cb_weight_obj.get_write_ptr();
+                    noc.async_write_multicast(
+                        use<experimental::CB::AddrSelector::WRITE_PTR>(cb_weight_obj),
+                        mcast_ep,
+                        weights_block_size_bytes,
+                        weights_mcast_num_cores,
+                        {},
+                        mcast_dst,
+                        true);
+
+                    // Note: no need for write barrier, since these two multicasts are done on the same noc id and same
+                    // vc even though cmd bufs are different Also, this only works because we are setting VCs statically
+                    // (using NOC_CMD_STATIC_VC).
+                    // We should also multicast the flag to destinations
+                    // num_dests must not include source, since we are NOT really doing a local copy!
+                    weights_mcast_receiver_sem.set_multicast(
+                        noc,
+                        mcast_rect.noc_x_start,
+                        mcast_rect.noc_y_start,
+                        mcast_rect.noc_x_end,
+                        mcast_rect.noc_y_end,
+                        weights_mcast_num_cores);
+#endif
+                    cb_weight_obj.push_back(weight_block_num_tiles);
+                }  // for weight_block_height_num_outer
+            }
+            if constexpr (split_reader_enabled) {
+                // Update reader index for next iteration (split reader increment)
+                // Only read reader indices on cores that have sharded input (is_sender_core).
+                if (is_sender_core) {
+                    start_reader_idx =
+                        reader_idx + static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
+                }
+                if (skip_work) {
+                    continue;
+                }
+            }
+            if constexpr (fuse_bias) {
+                if (load_bias) {
+                    cb_bias_obj.reserve_back(bias_ntiles);
+
+                    uint32_t bias_write_offset = 0;
+                    uint32_t bias_block_size_bytes = 0;
+                    for (uint32_t bias_tile = bias_tile_offset; bias_tile < bias_tile_offset + bias_ntiles;
+                         ++bias_tile) {
+                        noc.async_read(
+                            s_bias,
+                            cb_bias_obj,
+                            bias_pagesize,
+                            {.page_id = bias_tile},
+                            {.offset_bytes = bias_write_offset});
+                        bias_write_offset += bias_pagesize;
+                        bias_block_size_bytes += bias_pagesize;
+                    }
+                    noc.async_read_barrier();
+
+// MCAST BIAS (shares some mcast args with weights)
+#ifndef SKIP_MCAST
+                    // wait until all weights mcast destinations have atomically incremented the weights semaphore_addr
+                    // (i.e. its value should be weights_mcast_num_dests), then reset the semaphore_addr value back to
+                    // zero for the next block
+                    weights_mcast_sender_sem.wait(weights_mcast_num_dests);
+                    weights_mcast_sender_sem.set(0);
+
+                    // Now we have the block in the CB address, we can mcast to dests!
+                    // num_dests must not include source, since we are NOT really doing a local copy!
+                    mcast_dst.addr = cb_bias_obj.get_write_ptr();
+                    noc.async_write_multicast(
+                        use<experimental::CB::AddrSelector::WRITE_PTR>(cb_bias_obj),
+                        mcast_ep,
+                        bias_block_size_bytes,
+                        weights_mcast_num_cores,
+                        {},
+                        mcast_dst,
+                        true);
+
+                    // Note: no need for write barrier, since these two multicasts are done on the same noc id and same
+                    // vc even though cmd bufs are different Also, this only works because we are setting VCs statically
+                    // (using NOC_CMD_STATIC_VC).
+                    // We should also multicast the flag to destinations
+                    // num_dests must not include source, since we are NOT really doing a local copy!
+                    weights_mcast_receiver_sem.set_multicast(
+                        noc,
+                        mcast_rect.noc_x_start,
+                        mcast_rect.noc_y_start,
+                        mcast_rect.noc_x_end,
+                        mcast_rect.noc_y_end,
+                        weights_mcast_num_cores);
+#endif
+
+                    cb_bias_obj.push_back(bias_ntiles);
+                    load_bias = false;
+                }
+            }
+
+        }  // out_num_blocks_h
+
+        // Increment weight start tile id for next block in width dim
+        weight_start_tile_id += weight_next_block_stride_w;
+    }  // out_num_blocks_w
+
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/halo_device_operation.cpp
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "untilize_with_halo_program_factory.hpp"
+#include "ttnn/tensor/tensor_ops.hpp"
+#include "ttnn/operations/conv/conv2d/conv2d_utils.hpp"
+#include "ttnn/tensor/shape/shape.hpp"
+#include "ttnn/operations/experimental/quasar/halo/device/halo_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
+#include <array>
+
+namespace ttnn::prim::qsr {
+
+using namespace tt::tt_metal;
+
+thread_local std::unordered_map<std::size_t, std::uint32_t>
+    HaloDeviceOperation::sliding_window_max_out_nsticks_per_core = {};
+
+// TODO: Look into increasing this to tradeoff some L1 for performance (#19980)
+
+void HaloDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& /*args*/, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args;
+
+    // validate input data tensor
+    if (input_tensor.layout() == Layout::ROW_MAJOR) {
+        // skip the untilize, only do halo
+        log_debug(tt::LogOp, "Input is ROW_MAJOR, no need to untilize.");
+    } else {
+        TT_FATAL(
+            input_tensor.physical_volume() % tt::constants::TILE_HW == 0,
+            "Input tensor physical volume ({}) must be divisible by TILE_HW ({})",
+            input_tensor.physical_volume(),
+            tt::constants::TILE_HW);
+    }
+    TT_FATAL(
+        input_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED ||
+            input_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ||
+            input_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED,
+        "Only height, width or block sharded tensors are supported.");
+    TT_FATAL(input_tensor.shard_spec().has_value(), "Shard spec should not be empty");
+}
+
+HaloDeviceOperation::spec_return_value_t HaloDeviceOperation::compute_output_specs(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args;
+    const auto& input_shape = input_tensor.padded_shape();
+    ttnn::Shape output_shape = ttnn::Shape(input_shape.to_array_4D());
+
+    uint32_t nbatch = input_shape[0];
+    uint32_t total_nsticks = args.config.num_cores_nhw * args.max_out_nsticks_per_core;
+
+    // output_shape[0] remains same
+    // output_shape[1] remains same
+    // output_shape[2] changes
+    // output_shape[3] remains same
+    output_shape[2] = (uint32_t)std::ceil((float)total_nsticks / nbatch);
+
+    log_debug(
+        tt::LogOp, "output_shape: [{} {} {} {}]", output_shape[0], output_shape[1], output_shape[2], output_shape[3]);
+    log_debug(tt::LogOp, "max_out_nsticks_per_core: {}", args.max_out_nsticks_per_core);
+    log_debug(
+        tt::LogOp, "size : {}", args.in_nsticks_per_core * input_tensor.memory_config().shard_spec()->shape[1] * 2);
+    log_debug(tt::LogOp, "num_cores_nhw: {}", args.config.num_cores_nhw);
+
+    tt::tt_metal::DataType output_dtype;
+    switch (input_tensor.dtype()) {
+        case tt::tt_metal::DataType::FLOAT32: output_dtype = tt::tt_metal::DataType::FLOAT32; break;
+        case tt::tt_metal::DataType::UINT16: output_dtype = tt::tt_metal::DataType::UINT16; break;
+        default: output_dtype = tt::tt_metal::DataType::BFLOAT16; break;
+    }
+
+    std::array<uint32_t, 2> shard_shape = {
+        tt::div_up(output_shape[0] * output_shape[2], args.config.num_cores_nhw),
+        input_tensor.memory_config().shard_spec()->shape[1]};
+
+    auto out_mem_config = MemoryConfig(
+        input_tensor.memory_config().memory_layout(),
+        input_tensor.memory_config().buffer_type(),
+        ShardSpec{
+            input_tensor.memory_config().shard_spec()->grid,
+            shard_shape,
+            input_tensor.memory_config().shard_spec()->orientation});
+    auto padded_output_shape = output_shape;
+    padded_output_shape[-2] = tt::round_up(padded_output_shape[-2], shard_shape[0]);
+    padded_output_shape[-1] = tt::round_up(padded_output_shape[-1], shard_shape[1]);
+    return TensorSpec(
+        output_shape,
+        TensorLayout::fromPaddedShape(
+            output_dtype, PageConfig(Layout::ROW_MAJOR), out_mem_config, output_shape, padded_output_shape));
+}
+
+HaloDeviceOperation::tensor_return_value_t HaloDeviceOperation::create_output_tensors(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    auto output_spec = compute_output_specs(args, tensor_args);
+    return create_device_tensor(output_spec, tensor_args.device());
+}
+
+Tensor halo(
+    const Tensor& input_tensor,
+    const ttnn::operations::sliding_window::SlidingWindowConfig& config,
+    const DeviceComputeKernelConfig& compute_kernel_config,
+    uint32_t pad_val,
+    bool remote_read,
+    bool transpose_mcast,
+    bool is_out_tiled,
+    bool config_tensors_in_dram) {
+    using OperationType = HaloDeviceOperation;
+
+    TT_FATAL(input_tensor.memory_config().is_sharded(), "Halo expects sharded input tensor");
+    TT_FATAL(
+        input_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED ||
+            input_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ||
+            input_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED,
+        "Only height, width or block sharded tensors are supported.");
+    // NOTE: for HEIGHT_SHARDED, ncores_nhw == ncores
+    //       for BLOCK_SHARDED, ncores_nhw is just the ncores along height dim (last tensor dim is split along
+    //       width)
+    auto sliding_window_hash = config.get_hash();
+    if (!OperationType::sliding_window_max_out_nsticks_per_core.contains(sliding_window_hash)) {
+        auto op_trace_metadata = ttnn::operations::sliding_window::generate_op_trace_metadata(config);
+        auto shard_boundaries = ttnn::operations::sliding_window::generate_shard_boundaries(config);
+        OperationType::sliding_window_max_out_nsticks_per_core.emplace(
+            sliding_window_hash, ttnn::operations::sliding_window::generate_max_out_nsticks_per_core(shard_boundaries));
+    }
+
+    uint32_t max_out_nsticks_per_core = OperationType::sliding_window_max_out_nsticks_per_core.at(sliding_window_hash);
+    uint32_t in_nsticks_per_core = input_tensor.memory_config().shard_spec()->shape[0];
+    ttnn::operations::sliding_window::ParallelConfig p_config;
+    p_config.grid = input_tensor.shard_spec().value().grid;
+    p_config.shard_scheme = input_tensor.memory_config().memory_layout();
+    p_config.shard_orientation = input_tensor.shard_spec().value().orientation;
+
+    return ttnn::device_operation::launch<OperationType>(
+        OperationType::operation_attributes_t{
+            .config = config,
+            .parallel_config = p_config,
+            .pad_val = pad_val,
+            .remote_read = remote_read,
+            .transpose_mcast = transpose_mcast,
+            .max_out_nsticks_per_core = max_out_nsticks_per_core,
+            .in_nsticks_per_core = in_nsticks_per_core,
+            .is_out_tiled = is_out_tiled,
+            .config_tensors_in_dram = config_tensors_in_dram,
+            .compute_kernel_config = compute_kernel_config},
+        input_tensor);
+}
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/halo_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/halo_device_operation.hpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <string>
+#include <tuple>
+#include "ttnn/operations/core/core.hpp"
+
+#include "ttnn/device_operation.hpp"
+
+#include "ttnn/operations/sliding_window/sliding_window.hpp"
+#include "ttnn/operations/experimental/quasar/halo/device/halo_device_operation_types.hpp"
+#include "ttnn/operations/experimental/quasar/halo/device/untilize_with_halo_program_factory.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct HaloDeviceOperation {
+    thread_local static std::unordered_map<std::size_t, std::uint32_t> sliding_window_max_out_nsticks_per_core;
+    using operation_attributes_t = HaloParams;
+    using tensor_args_t = Tensor;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
+    using program_factory_t = std::variant<UntilizeWithHaloProgramFactory>;
+    static void validate_on_program_cache_miss(const operation_attributes_t& args, const tensor_args_t& tensor_args);
+    static spec_return_value_t compute_output_specs(
+        const operation_attributes_t& args, const tensor_args_t& tensor_args);
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t& args, const tensor_args_t& tensor_args);
+};
+
+Tensor halo(
+    const Tensor& input_tensor,
+    const ttnn::operations::sliding_window::SlidingWindowConfig& config,
+    const DeviceComputeKernelConfig& compute_kernel_config,
+    uint32_t pad_val,
+    bool remote_read,
+    bool transpose_mcast,
+    bool is_out_tiled,
+    bool config_tensors_in_dram);
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/halo_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/halo_device_operation_types.hpp
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/sliding_window/sliding_window.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct HaloParams {
+    ttnn::operations::sliding_window::SlidingWindowConfig config{};
+    ttnn::operations::sliding_window::ParallelConfig parallel_config{};
+    uint32_t pad_val = 0;
+    bool remote_read = false;
+    bool transpose_mcast = false;
+    uint32_t max_out_nsticks_per_core = 0;
+    uint32_t in_nsticks_per_core = 0;
+    tt::tt_metal::MemoryConfig output_memory_config;
+    bool is_out_tiled = false;
+    bool config_tensors_in_dram = false;
+    // Required: caller must pass compute_kernel_config so the halo's untilize
+    // compute kernel runs with the correct fp32_dest_acc_en (see issue #43229).
+    DeviceComputeKernelConfig compute_kernel_config;
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/kernels/compute/pack_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/kernels/compute/pack_untilize.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "ttnn/kernel_lib/untilize_helpers.hpp"
+#include "api/compute/pack_untilize.h"
+
+constexpr uint32_t MAX_PACK_UNTILIZE_WIDTH = 8;
+constexpr uint32_t NUM_RISCV_DATA_MOVEMENT_CORES = 2;
+#include "ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp"
+
+void kernel_main() {
+    constexpr uint32_t src_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t out_cb_id0 = get_compile_time_arg_val(1);
+    constexpr uint32_t out_cb_id1 = get_compile_time_arg_val(2);
+    constexpr uint32_t tiles_per_row = get_compile_time_arg_val(3);  // number of tiles along width of shard
+    constexpr uint32_t block_size = get_compile_time_arg_val(4);  // number of tiles along height that make up a block
+
+    const uint32_t total_blocks = get_arg_val<uint32_t>(0);
+
+    compute_kernel_hw_startup(src_cb_id, out_cb_id0);
+
+    // Initialize once before the loop
+    compute_kernel_lib::untilize_init<tiles_per_row, src_cb_id, out_cb_id0>();
+
+    for (uint32_t block_idx = 0; block_idx < total_blocks; block_idx++) {
+        // Use unified untilize with Neither mode since we handle init/uninit outside the loop
+        if (block_idx % 2 == 0) {
+            compute_kernel_lib::untilize<
+                tiles_per_row,
+                src_cb_id,
+                out_cb_id0,
+                compute_kernel_lib::untilize_config::InitUninitMode::Neither,
+                compute_kernel_lib::untilize_config::WaitMode::WaitBlock,
+                compute_kernel_lib::untilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(block_size);
+        } else {
+            compute_kernel_lib::untilize<
+                tiles_per_row,
+                src_cb_id,
+                out_cb_id1,
+                compute_kernel_lib::untilize_config::InitUninitMode::Neither,
+                compute_kernel_lib::untilize_config::WaitMode::WaitBlock,
+                compute_kernel_lib::untilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(block_size);
+        }
+    }
+
+    // Uninit after loop
+    compute_kernel_lib::untilize_uninit<tiles_per_row, src_cb_id, out_cb_id0>();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/kernels/dataflow/halo_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/kernels/dataflow/halo_gather.cpp
@@ -1,0 +1,358 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include <cstdint>
+
+#include "api/dataflow/dataflow_api.h"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
+
+#define ENABLE_DEBUG 0
+
+#if ENABLE_DEBUG
+#include "api/debug/dprint.h"
+#include "api/debug/dprint_pages.h"
+#endif
+
+constexpr uint16_t TILE_SIZE = 32;
+
+template <uint32_t N, uint16_t PaddingValue>
+FORCE_INLINE void fill_with_val(uint32_t begin_addr) {
+    volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(begin_addr);
+    for (uint32_t i = 0; i < N; ++i) {
+        ptr[i] = PaddingValue;
+    }
+}
+
+template <uint32_t StickNBytes, uint32_t MaxChunkSize>
+FORCE_INLINE void copy_padding_small_sticks(Noc noc, uint32_t padding_l1_addr, uint32_t dst_addr, uint16_t nsticks) {
+    static_assert(MaxChunkSize >= StickNBytes, "This function assumes max chunk size > stick size");
+
+    constexpr uint32_t sticks_per_batch = MaxChunkSize / StickNBytes;
+    constexpr uint32_t batch_size_bytes = sticks_per_batch * StickNBytes;
+    static_assert(batch_size_bytes <= NOC_MAX_BURST_SIZE, "batch_size_bytes must be single-packet");
+
+    if constexpr (sticks_per_batch > 1) {
+        const uint16_t num_full_batches = nsticks / sticks_per_batch;
+        const uint16_t remaining_sticks = nsticks % sticks_per_batch;
+
+        uint32_t current_dst = dst_addr;
+
+        experimental::set_read_state<batch_size_bytes>(noc, padding_l1_addr);
+        for (uint16_t batch = 0; batch < num_full_batches; ++batch) {
+            experimental::read_with_state(noc, current_dst, padding_l1_addr);
+            current_dst += batch_size_bytes;
+        }
+
+        if (remaining_sticks > 0) {
+            experimental::set_read_state<StickNBytes>(noc, padding_l1_addr);
+            for (uint16_t k = 0; k < remaining_sticks; ++k) {
+                experimental::read_with_state(noc, current_dst, padding_l1_addr);
+                current_dst += StickNBytes;
+            }
+        }
+    } else {
+        experimental::set_read_state<StickNBytes>(noc, padding_l1_addr);
+        uint32_t current_dst = dst_addr;
+        for (uint16_t k = 0; k < nsticks; ++k) {
+            experimental::read_with_state(noc, current_dst, padding_l1_addr);
+            current_dst += StickNBytes;
+        }
+    }
+}
+
+template <uint32_t StickNBytes, uint32_t MaxChunkSize>
+FORCE_INLINE void copy_padding_large_sticks(Noc noc, uint32_t padding_l1_addr, uint32_t dst_addr, uint16_t nsticks) {
+    constexpr uint32_t num_full_chunks = StickNBytes / MaxChunkSize;
+    constexpr uint32_t remainder_bytes = StickNBytes % MaxChunkSize;
+    constexpr uint32_t remainder_offset = num_full_chunks * MaxChunkSize;
+    static_assert(MaxChunkSize <= NOC_MAX_BURST_SIZE, "MaxChunkSize must be single-packet");
+    static_assert(remainder_bytes <= NOC_MAX_BURST_SIZE, "remainder must be single-packet");
+
+    // Copy all full chunks for all sticks
+    if constexpr (num_full_chunks > 0) {
+        experimental::set_read_state<MaxChunkSize>(noc, padding_l1_addr);
+
+        uint32_t stick_base_addr = dst_addr;
+        for (uint16_t stick = 0; stick < nsticks; ++stick) {
+            uint32_t chunk_addr = stick_base_addr;
+            for (uint32_t chunk = 0; chunk < num_full_chunks; ++chunk) {
+                experimental::read_with_state(noc, chunk_addr, padding_l1_addr);
+                chunk_addr += MaxChunkSize;
+            }
+            stick_base_addr += StickNBytes;
+        }
+    }
+
+    // Copy all remainder chunks for all sticks
+    if constexpr (remainder_bytes > 0) {
+        experimental::set_read_state<remainder_bytes>(noc, padding_l1_addr);
+
+        uint32_t remainder_base_addr = dst_addr + remainder_offset;
+        for (uint16_t stick = 0; stick < nsticks; ++stick) {
+            experimental::read_with_state(noc, remainder_base_addr, padding_l1_addr);
+            remainder_base_addr += StickNBytes;
+        }
+    }
+}
+
+template <uint32_t PaddingConfigCBId, uint32_t OutCBId, uint32_t StickNBytes, uint32_t MaxChunkSize>
+FORCE_INLINE void copy_padding(
+    Noc noc, experimental::CB padding_config_cb, experimental::CB out_cb, uint32_t padding_l1_addr) {
+    const uint32_t padding_config_l1_addr = padding_config_cb.get_read_ptr();
+    volatile tt_l1_ptr uint16_t* config_data = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(padding_config_l1_addr);
+
+    const uint32_t dst_base_addr = out_cb.get_write_ptr();
+
+    uint16_t nsticks = 1;
+    constexpr uint32_t stick_stride = StickNBytes;
+    for (uint16_t j = 0; nsticks != 0; j += 2) {
+        uint16_t dst_local_idx = config_data[j + 0];
+        nsticks = config_data[j + 1];
+
+        const uint32_t dst_addr = dst_base_addr + (static_cast<uint32_t>(dst_local_idx) * stick_stride);
+        if constexpr (StickNBytes <= MaxChunkSize) {
+            copy_padding_small_sticks<StickNBytes, MaxChunkSize>(noc, padding_l1_addr, dst_addr, nsticks);
+        } else {
+            copy_padding_large_sticks<StickNBytes, MaxChunkSize>(noc, padding_l1_addr, dst_addr, nsticks);
+        }
+    }
+}
+
+template <bool IsBlockSharded, bool IsWidthSharded, bool IsColumnMajor>
+static inline void resolve_destination_coords(
+    uint16_t destination_noc_x,
+    uint16_t destination_noc_y,
+    uint16_t my_noc_x,
+    uint16_t my_noc_y,
+    uint16_t& out_noc_x,
+    uint16_t& out_noc_y) {
+    static_assert(!(IsBlockSharded && IsWidthSharded), "Cannot be block and width sharding");
+    if constexpr ((IsBlockSharded && !IsColumnMajor) || IsWidthSharded) {
+        out_noc_x = my_noc_x;
+    } else {
+        out_noc_x = destination_noc_x;
+    }
+    if constexpr ((IsBlockSharded && IsColumnMajor) || IsWidthSharded) {
+        out_noc_y = my_noc_y;
+    } else {
+        out_noc_y = destination_noc_y;
+    }
+}
+
+template <uint32_t StickSizeBytes, bool EnableBlocking, uint32_t BlockHeightSticks, typename Src>
+static inline void write_stick_async(
+    Noc noc,
+    const Src& in_src,
+    uint32_t out_base_l1_addr,
+    uint16_t dst_noc_x,
+    uint16_t dst_noc_y,
+    uint16_t src_offset_id,
+    uint16_t dst_offset_id,
+    uint16_t transfer_size) {
+    uint32_t src_offset;
+    if constexpr (EnableBlocking) {
+        src_offset = (src_offset_id % BlockHeightSticks) * StickSizeBytes;
+    } else {
+        src_offset = src_offset_id * StickSizeBytes;
+    }
+    const uint32_t dst_offset = dst_offset_id * StickSizeBytes;
+    const uint32_t size = transfer_size * StickSizeBytes;
+    const uint32_t dst_addr = out_base_l1_addr + dst_offset;
+
+    noc.async_write(
+        in_src,
+        UnicastEndpoint{},
+        size,
+        {.offset_bytes = src_offset},
+        {.noc_x = dst_noc_x, .noc_y = dst_noc_y, .addr = dst_addr});
+}
+
+template <
+    uint32_t InputCBIndex,
+    uint32_t OutputCBIndex,
+    uint32_t StickSizeBytes,
+    uint32_t BlockSizeHeight,
+    uint32_t BlockSizeWidthTiles,
+    uint32_t BlockStride,
+    uint32_t BlockStartOffset,
+    bool EnableBlocking,
+    bool IsBlockSharded,
+    bool IsWidthSharded,
+    bool IsColumnMajor>
+static inline void run_halo_gather(
+    Noc noc,
+    experimental::CB in_cb,
+    experimental::CB out_cb,
+    const tt_l1_ptr uint16_t* config,
+    uint16_t my_noc_x,
+    uint16_t my_noc_y) {
+    static_assert(BlockStride >= 1, "Blocks stride must be at least 1");
+
+    constexpr uint32_t block_size_height_tiles = BlockSizeHeight / TILE_SIZE;
+    constexpr uint32_t total_tiles_in_single_block = block_size_height_tiles * BlockSizeWidthTiles;
+
+    uint16_t current_config_index = 0;
+    uint16_t number_of_segments_remaining = config[current_config_index++];
+
+    if (number_of_segments_remaining == 0) {
+        return;
+    }
+
+    const uint32_t out_base_l1_addr = out_cb.get_write_ptr();
+    auto in_src = use<experimental::CB::AddrSelector::READ_PTR>(in_cb);
+
+    // Assume input is already ready when !EnableBlocking (like when using RM)
+    if constexpr (EnableBlocking) {
+        in_cb.wait_front(total_tiles_in_single_block);
+    }
+
+    uint16_t block_id = BlockStartOffset;
+    uint16_t block_boundary_offset = BlockSizeHeight + (BlockSizeHeight * BlockStartOffset);
+    while (number_of_segments_remaining) {
+        //  Read header for to get destination for this route
+        const uint16_t destination_noc_x = config[current_config_index++];
+        const uint16_t destination_noc_y = config[current_config_index++];
+        uint16_t transfers_remaining = config[current_config_index++];
+
+        uint16_t dst_noc_x, dst_noc_y;
+        resolve_destination_coords<IsBlockSharded, IsWidthSharded, IsColumnMajor>(
+            destination_noc_x, destination_noc_y, my_noc_x, my_noc_y, dst_noc_x, dst_noc_y);
+
+        // Perform all transfers in this route
+        while (transfers_remaining > 0) {
+            const uint16_t src_offset = config[current_config_index++];
+            const uint16_t dst_offset = config[current_config_index++];
+            const uint16_t transfer_size = config[current_config_index++];
+            if constexpr (EnableBlocking) {
+                // Pop blocks until we have the right one - this works because transfers are globally ordered by
+                // ascending block IDs
+                while (src_offset >= block_boundary_offset) {
+                    noc.async_write_barrier();
+                    in_cb.pop_front(total_tiles_in_single_block);
+                    in_cb.wait_front(total_tiles_in_single_block);
+                    block_boundary_offset +=
+                        BlockSizeHeight *
+                        BlockStride;  // When block stride > 1 we are expecting the input CB to skip
+                                      // BlockStride number of blocks (like when splitting work across cores)
+                    block_id += BlockStride;
+                    // in_src tracks the CB's read_ptr dynamically via AddrSelector::READ_PTR
+                }
+            }
+            write_stick_async<StickSizeBytes, EnableBlocking, BlockSizeHeight>(
+                noc, in_src, out_base_l1_addr, dst_noc_x, dst_noc_y, src_offset, dst_offset, transfer_size);
+            transfers_remaining--;
+        }
+        number_of_segments_remaining--;
+    }
+
+    if constexpr (EnableBlocking) {
+        in_cb.pop_front(total_tiles_in_single_block);
+    }
+}
+
+void kernel_main() {
+    constexpr uint32_t padding_config_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t gather_config_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t src_cb_id = get_compile_time_arg_val(2);
+    constexpr uint32_t in_cb_id = get_compile_time_arg_val(3);
+    constexpr uint32_t out_cb_id = get_compile_time_arg_val(4);
+    constexpr uint32_t pad_cb_id = get_compile_time_arg_val(5);
+    constexpr uint32_t pad_val_u32 = get_compile_time_arg_val(6);
+    constexpr uint32_t in_nsticks = get_compile_time_arg_val(7);
+    constexpr uint32_t aligned_stick_nbytes = get_compile_time_arg_val(8);
+    constexpr bool is_block_sharded = get_compile_time_arg_val(9) == 1;
+    constexpr bool remote_read = get_compile_time_arg_val(10) == 1;
+    constexpr bool is_col_major = get_compile_time_arg_val(11) == 1;
+    constexpr bool is_width_sharded = get_compile_time_arg_val(12) == 1;
+    constexpr bool skip_untilize = get_compile_time_arg_val(13) == 1;
+    constexpr uint32_t block_size_height = get_compile_time_arg_val(14);
+    constexpr uint32_t block_size_width_tiles = get_compile_time_arg_val(15);
+    constexpr uint32_t block_start_offset = get_compile_time_arg_val(16);
+    constexpr uint32_t block_stride = get_compile_time_arg_val(17);
+
+    static_assert(!remote_read, "Remote read is not supported in this kernel");
+
+    constexpr uint32_t elem_nbytes = sizeof(uint16_t);
+    constexpr bool enable_blocking = !skip_untilize;
+
+    Noc noc;
+    experimental::CB padding_config_cb(padding_config_cb_id);
+    experimental::CB gather_config_cb(gather_config_cb_id);
+    experimental::CB src_cb(src_cb_id);
+    experimental::CB in_cb(in_cb_id);
+    experimental::CB out_cb(out_cb_id);
+    experimental::CB pad_cb(pad_cb_id);
+
+#ifdef CONFIG_TENSOR_IN_DRAM
+    constexpr uint32_t padding_config_dram_addr = get_compile_time_arg_val(18);
+    constexpr uint32_t padding_config_page_size = get_compile_time_arg_val(19);
+    constexpr uint32_t gather_config_dram_addr = get_compile_time_arg_val(20);
+    constexpr uint32_t gather_config_page_size = get_compile_time_arg_val(21);
+
+    constexpr auto padding_config_tensor_args = TensorAccessorArgs<22>();
+    constexpr auto gather_config_tensor_args =
+        TensorAccessorArgs<padding_config_tensor_args.next_compile_time_args_offset()>();
+
+    const auto padding_config_accessor = TensorAccessor(padding_config_tensor_args, padding_config_dram_addr);
+    const auto gather_config_accessor = TensorAccessor(gather_config_tensor_args, gather_config_dram_addr);
+
+    uint32_t config_read_index = get_arg_val<uint32_t>(0);
+
+    noc.async_read(
+        padding_config_accessor, padding_config_cb, padding_config_page_size, {.page_id = config_read_index}, {});
+    noc.async_read(
+        gather_config_accessor, gather_config_cb, gather_config_page_size, {.page_id = config_read_index}, {});
+    noc.async_read_barrier();
+#endif
+
+    const uint16_t my_noc_x = my_x[noc.get_noc_id()];
+    const uint16_t my_noc_y = my_y[noc.get_noc_id()];
+
+    // Only one of the cores should push the input
+    if constexpr (block_start_offset == 0) {
+        src_cb.reserve_back(in_nsticks);
+        src_cb.push_back(in_nsticks);
+    }
+
+    if constexpr (padding_config_cb_id != 0) {
+        if constexpr (pad_val_u32 == 0) {
+            // Use MEM_ZEROS_BASE if we are zero padded
+            constexpr uint32_t padding_region_size = MEM_ZEROS_SIZE;
+            copy_padding<padding_config_cb_id, out_cb_id, aligned_stick_nbytes, padding_region_size>(
+                noc, padding_config_cb, out_cb, MEM_ZEROS_BASE);
+        } else {
+            constexpr uint16_t pad_val = static_cast<uint16_t>(pad_val_u32);
+            constexpr uint32_t num_elements_to_fill = aligned_stick_nbytes / elem_nbytes;
+            fill_with_val<num_elements_to_fill, pad_val>(pad_cb.get_write_ptr());
+
+            // MaxChunkSize must be in bytes and >= StickNBytes to avoid misaligned NOC transactions
+            constexpr uint32_t padding_region_size = aligned_stick_nbytes;
+            copy_padding<padding_config_cb_id, out_cb_id, aligned_stick_nbytes, padding_region_size>(
+                noc, padding_config_cb, out_cb, pad_cb.get_read_ptr());
+        }
+    }
+
+    if constexpr (skip_untilize) {
+        src_cb.wait_front(in_nsticks);
+    }
+
+    const uint32_t config_data_l1_addr = gather_config_cb.get_read_ptr();
+    const tt_l1_ptr uint16_t* config_data = reinterpret_cast<const tt_l1_ptr uint16_t*>(config_data_l1_addr);
+    run_halo_gather<
+        in_cb_id,
+        out_cb_id,
+        aligned_stick_nbytes,
+        block_size_height,
+        block_size_width_tiles,
+        block_stride,
+        block_start_offset,
+        enable_blocking,
+        is_block_sharded,
+        is_width_sharded,
+        is_col_major>(noc, in_cb, out_cb, config_data, my_noc_x, my_noc_y);
+
+    noc.async_read_barrier();
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/untilize_with_halo_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/untilize_with_halo_program_factory.cpp
@@ -1,0 +1,517 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/experimental/quasar/halo/device/untilize_with_halo_program_factory.hpp"
+
+#include <cstdint>
+#include <optional>
+#include <cmath>
+
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
+
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/common/constants.hpp"
+#include "ttnn/types.hpp"
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+
+// TODO: Look into increasing this to tradeoff some L1 for performance (#19980)
+constexpr int UNTILIZE_BLOCK_SIZE = 32;
+
+// In order to make circular buffer indices sequential, we use variable to keep track of the next available index.
+// Circular buffer indices should be assigned right before their creation.
+struct CBIndices {
+    // Invalid value for cb id is 32, number greater than the maximum number of index circular buffer can have.
+    // Not assigning get_next_cb_index() value before creating cb will throw exception in circular_buffer_config.cpp
+    // which can be used as a reminder.
+    uint32_t src_cb_id = 32;
+    uint32_t pad_cb_id0 = 32;
+    uint32_t pad_cb_id1 = 32;
+    uint32_t out_cb_id = 32;
+
+    // Additional CBs for sharded data kernel configs
+    uint32_t padding_config0 = 32;
+    uint32_t padding_config1 = 32;
+    uint32_t gather_config0 = 32;
+    uint32_t gather_config1 = 32;
+    uint32_t untilize_out_cb_id0 = 32;
+    uint32_t untilize_out_cb_id1 = 32;
+    uint32_t get_next_cb_id() { return next_cb_id++; }
+
+private:
+    uint32_t next_cb_id = tt::CBIndex::c_0;
+};
+
+constexpr bool ENABLE_UNTILIZE_DOUBLE_BUFFERING = true;
+
+namespace {
+
+// Append a CBDescriptor for a single-format circular buffer.  When `buffer`
+// is non-null the CB is globally-allocated against that buffer so address
+// patching on cache hit works via the framework's dynamic CB update path.
+void add_cb(
+    ProgramDescriptor& desc,
+    const CoreRangeSet& cores,
+    uint32_t cb_id,
+    tt::DataFormat df,
+    uint32_t npages,
+    uint32_t pagesize,
+    Buffer* buffer = nullptr) {
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = npages * pagesize,
+        .core_ranges = cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_id),
+            .data_format = df,
+            .page_size = pagesize,
+        }}},
+        .buffer = buffer,
+    });
+}
+
+// Build the per-coord halo ProgramDescriptor.  All workload-scoped
+// intermediate buffers (the four halo config tensors) are passed in by
+// pointer — their owning Tensors live on the WorkloadDescriptor.
+ProgramDescriptor build_halo_program(
+    const HaloParams& operation_attributes,
+    const Tensor& input_tensor,
+    Tensor& output_tensor,
+    Buffer* padding_config_buffer0,
+    Buffer* padding_config_buffer1,
+    Buffer* gather_config_buffer0,
+    Buffer* gather_config_buffer1,
+    const std::vector<uint16_t>& number_of_blocks_per_core) {
+    const auto& pad_val = operation_attributes.pad_val;
+    const int block_size = UNTILIZE_BLOCK_SIZE;
+    const uint32_t ncores_nhw = operation_attributes.config.num_cores_nhw;
+    const uint32_t max_out_nsticks_per_core = operation_attributes.max_out_nsticks_per_core;
+    const bool config_tensors_in_dram = operation_attributes.config_tensors_in_dram;
+    const bool remote_read = operation_attributes.remote_read;
+    const bool transpose_mcast = operation_attributes.transpose_mcast;
+
+    const bool is_block_sharded = input_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
+
+    Buffer* src_buffer = input_tensor.buffer();
+    Buffer* dst_buffer = output_tensor.buffer();
+    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    const bool skip_untilize = input_tensor.layout() == Layout::ROW_MAJOR;
+
+    const auto& input_shape = input_tensor.padded_shape();
+
+    const tt::DataFormat in_df = datatype_to_dataformat_converter(input_tensor.dtype());
+    const tt::DataFormat out_df = datatype_to_dataformat_converter(output_tensor.dtype());
+    const uint32_t out_nbytes = datum_size(out_df);
+
+    const CoreRangeSet all_cores = output_tensor.shard_spec().value().grid;
+
+    const ShardOrientation shard_orientation = output_tensor.shard_spec().value().orientation;
+    const auto input_shard_shape = input_tensor.shard_spec().value().shape;
+    const auto output_shard_shape = output_tensor.shard_spec().value().shape;
+    TT_ASSERT(input_shard_shape[1] == output_shard_shape[1], "Expected input and output shard widths to match");
+
+    const uint32_t input_nhw_height = input_shape[0] * input_shape[1] * input_shape[2];
+    const uint32_t remapped_input_shard_shape_for_output_grid = tt::div_up(input_nhw_height, ncores_nhw);
+
+    uint32_t ntiles_per_block = tt::div_up(input_shard_shape[1], TILE_WIDTH);
+    uint32_t input_nblocks_per_core = tt::div_up(remapped_input_shard_shape_for_output_grid, TILE_HEIGHT);
+    uint32_t input_npages = ntiles_per_block * input_nblocks_per_core;
+
+    uint32_t in_page_size = tt::tile_size(in_df);
+
+    // Calculate aligned stick size - used for both input and output since channels don't change
+    const uint32_t stick_nbytes = output_shard_shape[1] * out_nbytes;
+    uint32_t aligned_stick_nbytes = stick_nbytes;
+    if (stick_nbytes % input_tensor.buffer()->alignment() != 0) {
+        aligned_stick_nbytes = tt::round_up(stick_nbytes, input_tensor.buffer()->alignment());
+    }
+    const uint32_t out_tile_size = tt::tile_size(out_df);
+
+    // For ROW_MAJOR input the kernel reads with aligned_stick_nbytes stride
+    // across the full input shard, so the CB must match the actual buffer layout:
+    // page size = aligned stick width, npages = actual shard height.
+    if (skip_untilize) {
+        in_page_size = aligned_stick_nbytes;
+        input_npages = input_shard_shape[0];
+    }
+
+    ProgramDescriptor desc;
+
+    CBIndices cb_indices = CBIndices();
+
+    // The input CB can either be tiled or row-major
+    cb_indices.src_cb_id = cb_indices.get_next_cb_id();
+    add_cb(desc, all_cores, cb_indices.src_cb_id, in_df, input_npages, in_page_size, src_buffer);
+
+    // We need to clamp in the case that the block size is larger than the nhw input size
+    TT_FATAL(block_size % TILE_HEIGHT == 0, "Block size must be a multiple of tile height (was {})", block_size);
+    const uint32_t clamped_block_size_height =
+        std::min(static_cast<uint32_t>(block_size), input_nblocks_per_core * TILE_HEIGHT);
+    TT_FATAL(
+        clamped_block_size_height % TILE_HEIGHT == 0,
+        "Block size must be a multiple of tile height (was {})",
+        clamped_block_size_height);
+
+    const uint32_t out_cb_pagesize = aligned_stick_nbytes;
+    const uint32_t out_cb_npages = max_out_nsticks_per_core;
+    cb_indices.out_cb_id = cb_indices.get_next_cb_id();
+    add_cb(desc, all_cores, cb_indices.out_cb_id, out_df, out_cb_npages, out_cb_pagesize, dst_buffer);
+
+    // Used for storing padding immediate values (only used if not zero padding)
+    const uint32_t pad_cb_pagesize = aligned_stick_nbytes;
+    const uint32_t pad_cb_npages = 1;
+    cb_indices.pad_cb_id0 = cb_indices.get_next_cb_id();
+    add_cb(desc, all_cores, cb_indices.pad_cb_id0, out_df, pad_cb_npages, pad_cb_pagesize);
+    cb_indices.pad_cb_id1 = cb_indices.get_next_cb_id();
+    add_cb(desc, all_cores, cb_indices.pad_cb_id1, out_df, pad_cb_npages, pad_cb_pagesize);
+
+    const tt::DataFormat kernel_config_df = tt::DataFormat::RawUInt16;  // NOTE: UInt16 is not supported for CB types
+
+    uint32_t input_to_writer_cb_id0 = cb_indices.src_cb_id;
+    uint32_t input_to_writer_cb_id1 = cb_indices.src_cb_id;
+    const bool is_rm_orientation = shard_orientation == ShardOrientation::ROW_MAJOR;
+    const auto cores = corerange_to_cores(all_cores, std::nullopt, is_rm_orientation);
+
+    if (!skip_untilize) {
+        cb_indices.untilize_out_cb_id0 = cb_indices.get_next_cb_id();
+        cb_indices.untilize_out_cb_id1 = cb_indices.get_next_cb_id();
+        input_to_writer_cb_id0 = cb_indices.untilize_out_cb_id0;
+        input_to_writer_cb_id1 = cb_indices.untilize_out_cb_id1;
+        const uint32_t output_ntiles = (clamped_block_size_height / TILE_HEIGHT) * ntiles_per_block;
+        const uint32_t untilize_out_cb_num_pages = ENABLE_UNTILIZE_DOUBLE_BUFFERING ? 2 * output_ntiles : output_ntiles;
+        add_cb(desc, all_cores, cb_indices.untilize_out_cb_id0, out_df, untilize_out_cb_num_pages, out_tile_size);
+        add_cb(desc, all_cores, cb_indices.untilize_out_cb_id1, out_df, untilize_out_cb_num_pages, out_tile_size);
+
+        const std::vector<uint32_t> compute_ct_args = {
+            cb_indices.src_cb_id,
+            input_to_writer_cb_id0,
+            input_to_writer_cb_id1,
+            ntiles_per_block,                        // number of tiles in the width dimension (channels)
+            clamped_block_size_height / TILE_HEIGHT  // number of tiles in height dimension that make up a block
+
+        };
+        auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+            get_compute_kernel_config_args(input_tensor.device()->arch(), operation_attributes.compute_kernel_config);
+
+        KernelDescriptor compute_desc;
+        compute_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/kernels/compute/pack_untilize.cpp";
+        compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc.core_ranges = all_cores;
+        compute_desc.compile_time_args = compute_ct_args;
+        compute_desc.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .math_approx_mode = math_approx_mode,
+        };
+
+        for (size_t core_id = 0; core_id < cores.size(); core_id++) {
+            compute_desc.runtime_args.emplace_back(
+                cores[core_id], std::vector<uint32_t>{number_of_blocks_per_core[core_id]});
+        }
+
+        desc.kernels.push_back(std::move(compute_desc));
+    }
+
+    TT_ASSERT(padding_config_buffer0 != nullptr);
+    TT_ASSERT(padding_config_buffer1 != nullptr);
+    TT_ASSERT(gather_config_buffer0 != nullptr);
+    TT_ASSERT(gather_config_buffer1 != nullptr);
+
+    cb_indices.padding_config0 = cb_indices.get_next_cb_id();
+    add_cb(
+        desc,
+        all_cores,
+        cb_indices.padding_config0,
+        kernel_config_df,
+        1,
+        padding_config_buffer0->page_size(),
+        config_tensors_in_dram ? nullptr : padding_config_buffer0);
+
+    cb_indices.padding_config1 = cb_indices.get_next_cb_id();
+    add_cb(
+        desc,
+        all_cores,
+        cb_indices.padding_config1,
+        kernel_config_df,
+        1,
+        padding_config_buffer1->page_size(),
+        config_tensors_in_dram ? nullptr : padding_config_buffer1);
+
+    cb_indices.gather_config0 = cb_indices.get_next_cb_id();
+    add_cb(
+        desc,
+        all_cores,
+        cb_indices.gather_config0,
+        kernel_config_df,
+        1,
+        gather_config_buffer0->page_size(),
+        config_tensors_in_dram ? nullptr : gather_config_buffer0);
+
+    cb_indices.gather_config1 = cb_indices.get_next_cb_id();
+    add_cb(
+        desc,
+        all_cores,
+        cb_indices.gather_config1,
+        kernel_config_df,
+        1,
+        gather_config_buffer1->page_size(),
+        config_tensors_in_dram ? nullptr : gather_config_buffer1);
+
+    const bool is_height_sharded = output_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
+    const bool is_width_sharded = input_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
+
+    const uint32_t block_stride = 2;  // Skip every 2nd block because of split reader
+    const std::string reader_kernel_name =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/kernels/dataflow/halo_gather.cpp";
+    std::vector<uint32_t> common_reader_ct_args = {
+        0,  // padding config cb
+        0,  // gather config cb
+        cb_indices.src_cb_id,
+        input_to_writer_cb_id0,
+        cb_indices.out_cb_id,
+        0,  // padding value cb
+        pad_val,
+        input_npages,
+        aligned_stick_nbytes,
+        is_block_sharded,
+        remote_read,
+        (uint32_t)(transpose_mcast ? 1 : 0),
+        is_width_sharded,
+        skip_untilize,
+        clamped_block_size_height,  // Block size in sticks
+        ntiles_per_block,
+        0,            // Block start offset
+        block_stride  // Block stride
+    };
+    KernelDescriptor::Defines reader_defines;
+    std::vector<uint32_t> core_0_reader_ct_args = common_reader_ct_args;
+    std::vector<uint32_t> core_1_reader_ct_args = common_reader_ct_args;
+
+    if (config_tensors_in_dram) {
+        reader_defines.emplace_back("CONFIG_TENSOR_IN_DRAM", "1");
+        // NOTE: the config-buffer addresses are baked into compile-time args
+        // here.  The buffers themselves are parked on the WorkloadDescriptor,
+        // so their device allocations stay valid for the cached workload's
+        // lifetime — the address embedded below remains correct on cache hit
+        // because the buffers are not re-allocated.
+        core_0_reader_ct_args.push_back(padding_config_buffer0->address());
+        core_0_reader_ct_args.push_back(padding_config_buffer0->page_size());
+
+        core_0_reader_ct_args.push_back(gather_config_buffer0->address());
+        core_0_reader_ct_args.push_back(gather_config_buffer0->page_size());
+
+        core_1_reader_ct_args.push_back(padding_config_buffer1->address());
+        core_1_reader_ct_args.push_back(padding_config_buffer1->page_size());
+
+        core_1_reader_ct_args.push_back(gather_config_buffer1->address());
+        core_1_reader_ct_args.push_back(gather_config_buffer1->page_size());
+
+        tt::tt_metal::TensorAccessorArgs(padding_config_buffer0).append_to(core_0_reader_ct_args);
+        tt::tt_metal::TensorAccessorArgs(gather_config_buffer0).append_to(core_0_reader_ct_args);
+
+        tt::tt_metal::TensorAccessorArgs(padding_config_buffer1).append_to(core_1_reader_ct_args);
+        tt::tt_metal::TensorAccessorArgs(gather_config_buffer1).append_to(core_1_reader_ct_args);
+    }
+    const uint32_t EMPTY_PADDING_CONFIG_BUFFER_SIZE = 4;
+    const bool enable_padding = config_tensors_in_dram ||
+                                padding_config_buffer0->page_size() != EMPTY_PADDING_CONFIG_BUFFER_SIZE ||
+                                padding_config_buffer1->page_size() != EMPTY_PADDING_CONFIG_BUFFER_SIZE;
+
+    core_0_reader_ct_args[0] = enable_padding ? cb_indices.padding_config0 : 0;
+    core_0_reader_ct_args[1] = cb_indices.gather_config0;
+    core_0_reader_ct_args[5] = cb_indices.pad_cb_id0;
+
+    core_1_reader_ct_args[0] = enable_padding ? cb_indices.padding_config1 : 0;
+    core_1_reader_ct_args[1] = cb_indices.gather_config1;
+    core_1_reader_ct_args[3] = input_to_writer_cb_id1;
+    core_1_reader_ct_args[5] = cb_indices.pad_cb_id1;
+    core_1_reader_ct_args[16] = 1;  // Block start offset
+
+    KernelDescriptor reader_0_desc;
+    reader_0_desc.kernel_source = reader_kernel_name;
+    reader_0_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_0_desc.core_ranges = all_cores;
+    reader_0_desc.compile_time_args = std::move(core_0_reader_ct_args);
+    reader_0_desc.defines = reader_defines;
+    reader_0_desc.config = DataMovementConfigDescriptor{
+        .processor = DataMovementProcessor::RISCV_0,
+        .noc = NOC::RISCV_0_default,
+    };
+
+    KernelDescriptor reader_1_desc;
+    reader_1_desc.kernel_source = reader_kernel_name;
+    reader_1_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_1_desc.core_ranges = all_cores;
+    reader_1_desc.compile_time_args = std::move(core_1_reader_ct_args);
+    reader_1_desc.defines = std::move(reader_defines);
+    reader_1_desc.config = DataMovementConfigDescriptor{
+        .processor = DataMovementProcessor::RISCV_1,
+        .noc = NOC::RISCV_1_default,
+    };
+
+    if (config_tensors_in_dram) {
+        uint32_t core_index = 0;
+        for (const auto& core : cores) {
+            if (is_height_sharded) {
+                reader_0_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{core_index});
+                reader_1_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{core_index});
+            } else if (is_width_sharded) {
+                reader_0_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{0});
+                reader_1_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{0});
+            } else if (is_block_sharded) {
+                const auto nhw_index = is_rm_orientation ? core.y : core.x;
+                reader_0_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{nhw_index});
+                reader_1_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{nhw_index});
+            }
+            core_index++;
+        }
+    }
+
+    desc.kernels.push_back(std::move(reader_0_desc));
+    desc.kernels.push_back(std::move(reader_1_desc));
+
+    return desc;
+}
+
+}  // namespace
+
+tt::tt_metal::WorkloadDescriptor UntilizeWithHaloProgramFactory::create_workload_descriptor(
+    const HaloParams& operation_attributes,
+    const Tensor& tensor_args,
+    Tensor& output_tensor,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    const auto& input_tensor = tensor_args;
+    auto* device = input_tensor.device();
+
+    const bool is_in_tiled = input_tensor.layout() == Layout::TILE;
+    const bool is_block_sharded = input_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
+    const bool remote_read = operation_attributes.remote_read;
+    const bool transpose_mcast = operation_attributes.transpose_mcast;
+
+    using namespace ttnn::operations;
+    auto pad_metadata = sliding_window::generate_pad_metadata(operation_attributes.config);
+    auto op_trace_metadata = sliding_window::generate_op_trace_metadata(operation_attributes.config);
+    auto shard_boundaries = sliding_window::generate_shard_boundaries(operation_attributes.config);
+    const uint32_t input_shard_height = input_tensor.memory_config().shard_spec()->shape[0];
+    auto tensor_metadata =
+        sliding_window::generate_tensor_metadata(pad_metadata, operation_attributes.config, input_shard_height);
+
+    const uint32_t num_cores_x = input_tensor.memory_config().shard_spec()->grid.bounding_box().grid_size().x;
+
+    auto kernel_config = sliding_window::generate_halo_kernel_config_tensors(
+        tensor_metadata,
+        shard_boundaries,
+        is_block_sharded,
+        transpose_mcast,
+        remote_read,
+        device,
+        num_cores_x,
+        is_in_tiled,
+        UNTILIZE_BLOCK_SIZE);
+
+    const auto& pad_config0 = kernel_config.pad_config0;
+    const auto& pad_config1 = kernel_config.pad_config1;
+    const auto& gather_config0 = kernel_config.gather_config0;
+    const auto& gather_config1 = kernel_config.gather_config1;
+
+    const auto pad_config_tensor0 = sliding_window::construct_on_host_config_tensor(
+        pad_config0, operation_attributes.parallel_config, operation_attributes.config_tensors_in_dram);
+    const auto pad_config_tensor1 = sliding_window::construct_on_host_config_tensor(
+        pad_config1, operation_attributes.parallel_config, operation_attributes.config_tensors_in_dram);
+    const auto gather_config_tensor0 = sliding_window::construct_on_host_config_tensor(
+        gather_config0, operation_attributes.parallel_config, operation_attributes.config_tensors_in_dram);
+    const auto gather_config_tensor1 = sliding_window::construct_on_host_config_tensor(
+        gather_config1, operation_attributes.parallel_config, operation_attributes.config_tensors_in_dram);
+
+    Tensor pad_config_device_tensor0 = sliding_window::move_config_tensor_to_device(
+        pad_config_tensor0,
+        operation_attributes.parallel_config,
+        is_block_sharded,
+        device,
+        operation_attributes.config_tensors_in_dram);
+    Tensor pad_config_device_tensor1 = sliding_window::move_config_tensor_to_device(
+        pad_config_tensor1,
+        operation_attributes.parallel_config,
+        is_block_sharded,
+        device,
+        operation_attributes.config_tensors_in_dram);
+    Tensor gather_config_device_tensor0 = sliding_window::move_config_tensor_to_device(
+        gather_config_tensor0,
+        operation_attributes.parallel_config,
+        is_block_sharded,
+        device,
+        operation_attributes.config_tensors_in_dram);
+    Tensor gather_config_device_tensor1 = sliding_window::move_config_tensor_to_device(
+        gather_config_tensor1,
+        operation_attributes.parallel_config,
+        is_block_sharded,
+        device,
+        operation_attributes.config_tensors_in_dram);
+
+    TT_ASSERT(pad_config_device_tensor0.dtype() == DataType::UINT16);
+    TT_ASSERT(pad_config_device_tensor1.dtype() == DataType::UINT16);
+    TT_ASSERT(gather_config_device_tensor0.dtype() == DataType::UINT16);
+    TT_ASSERT(gather_config_device_tensor1.dtype() == DataType::UINT16);
+
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
+
+    // Park each intermediate halo-config Tensor on the WorkloadDescriptor.
+    // The Tensor itself (not just shared_ptr<MeshBuffer>) must outlive the
+    // cached workload: ~Tensor force-deallocates the underlying device memory
+    // via DeviceStorage::deallocate regardless of other shared owners.  See
+    // pool_multi_core_program_factory.cpp for the lifetime rationale.
+    auto pad0_owner = std::make_shared<Tensor>(std::move(pad_config_device_tensor0));
+    Buffer* pad0_buf = pad0_owner->buffer();
+    workload_descriptor.buffers.push_back({pad0_owner, pad0_buf});
+
+    auto pad1_owner = std::make_shared<Tensor>(std::move(pad_config_device_tensor1));
+    Buffer* pad1_buf = pad1_owner->buffer();
+    workload_descriptor.buffers.push_back({pad1_owner, pad1_buf});
+
+    auto gather0_owner = std::make_shared<Tensor>(std::move(gather_config_device_tensor0));
+    Buffer* gather0_buf = gather0_owner->buffer();
+    workload_descriptor.buffers.push_back({gather0_owner, gather0_buf});
+
+    auto gather1_owner = std::make_shared<Tensor>(std::move(gather_config_device_tensor1));
+    Buffer* gather1_buf = gather1_owner->buffer();
+    workload_descriptor.buffers.push_back({gather1_owner, gather1_buf});
+
+    const auto number_of_blocks_per_core = sliding_window::remap_nhw_scalar_argument_across_full_grid(
+        kernel_config.number_of_blocks_per_core, operation_attributes.parallel_config);
+
+    // Single-device op: the kernel program is structurally identical for every
+    // coord in `tensor_coords` (halo doesn't depend on cluster position).
+    // Build the per-coord ProgramDescriptor ONCE and copy it into each
+    // coord-range entry to avoid redundant work on multi-coord workloads.
+    auto desc = build_halo_program(
+        operation_attributes,
+        input_tensor,
+        output_tensor,
+        pad0_buf,
+        pad1_buf,
+        gather0_buf,
+        gather1_buf,
+        number_of_blocks_per_core);
+
+    auto ranges = tensor_coords.ranges();
+    workload_descriptor.programs.reserve(ranges.size());
+    for (size_t i = 0; i + 1 < ranges.size(); ++i) {
+        workload_descriptor.programs.push_back({ranges[i], desc});
+    }
+    if (!ranges.empty()) {
+        workload_descriptor.programs.push_back({ranges.back(), std::move(desc)});
+    }
+    return workload_descriptor;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/untilize_with_halo_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/untilize_with_halo_program_factory.hpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/experimental/quasar/halo/device/halo_device_operation_types.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct UntilizeWithHaloProgramFactory {
+    // create_workload_descriptor() allocates the four sliding-window halo
+    // config tensors (pad_config0/1, gather_config0/1) on device and parks
+    // them on the returned WorkloadDescriptor so their backing buffers
+    // outlive the cached programs.  The buffers are bound to the
+    // CBDescriptor entries that the reader kernels stream from.
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
+        const HaloParams& operation_attributes,
+        const Tensor& tensor_args,
+        Tensor& output_tensor,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/halo/halo.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/halo/halo.cpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "halo.hpp"
+
+#include "ttnn/operations/experimental/quasar/halo/device/halo_device_operation.hpp"
+
+namespace ttnn::operations::experimental::quasar {
+
+Tensor halo(
+    const Tensor& input_tensor,
+    const operations::sliding_window::SlidingWindowConfig& config,
+    const DeviceComputeKernelConfig& compute_kernel_config,
+    uint32_t pad_val,
+    bool remote_read,
+    bool transpose_mcast,
+    bool is_out_tiled,
+    bool config_tensors_in_dram) {
+    return ttnn::prim::qsr::halo(
+        input_tensor,
+        config,
+        compute_kernel_config,
+        pad_val,
+        remote_read,
+        transpose_mcast,
+        is_out_tiled,
+        config_tensors_in_dram);
+}
+
+}  // namespace ttnn::operations::experimental::quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/halo/halo.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/halo/halo.hpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/operations/sliding_window/sliding_window.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::experimental::quasar {
+
+Tensor halo(
+    const Tensor& input_tensor,
+    const operations::sliding_window::SlidingWindowConfig& config,
+    const DeviceComputeKernelConfig& compute_kernel_config,
+    uint32_t pad_val = 0x0,
+    bool remote_read = false,
+    bool transpose_mcast = true,
+    bool is_out_tiled = true,
+    bool config_tensors_in_dram = false);
+
+}  // namespace ttnn::operations::experimental::quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/config/matmul_program_config.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/config/matmul_program_config.cpp
@@ -1,0 +1,1305 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/experimental/quasar/matmul/device/config/matmul_program_config.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/utilities/matmul_utilities.hpp"
+#include "ttnn/types.hpp"
+#include <ranges>
+
+namespace ttnn::operations::experimental::quasar::matmul {
+
+namespace {
+
+// Ensure there are always symmetrical values. Different paths use different
+// index ordering (0,1 vs 1,0) to meet test PCC requirements.
+constexpr std::array<std::tuple<uint32_t, uint32_t>, 20> SUBBLOCK_HW_CHOICES = {{
+    {4, 2}, {2, 4}, {8, 1}, {1, 8},  // subblock_hw = 8
+    {7, 1}, {1, 7},                  // subblock_hw = 7
+    {3, 2}, {2, 3}, {6, 1}, {1, 6},  // subblock_hw = 6
+    {5, 1}, {1, 5},                  // subblock_hw = 5
+    {2, 2}, {4, 1}, {1, 4},          // subblock_hw = 4
+    {3, 1}, {1, 3},                  // subblock_hw = 3
+    {2, 1}, {1, 2},                  // subblock_hw = 2
+    {1, 1},                          // subblock_hw = 1
+}};
+
+// This function helps determine if an optimised 1D MM config will provide perf benefits for a matmul
+bool is_narrow_shape(uint32_t height, uint32_t width, bool all_dram) {
+    constexpr uint32_t NARROW_SHAPE_RATIO_THRESHOLD = 8;
+    uint32_t height_width_ratio = (height > width) ? height / width : width / height;
+
+    // Check if tensor is actually narrow and will benefit from 1D config
+    if (height_width_ratio > NARROW_SHAPE_RATIO_THRESHOLD) {
+        return true;
+    }
+
+    // MMs that are entirely in DRAM but with a dimension smaller than the tile size will benefit from 1D config
+    if (all_dram) {
+        return height <= ttnn::types::TILE_SIZE || width <= ttnn::types::TILE_SIZE;
+    }
+
+    return false;
+}
+
+inline uint32_t get_per_core_factor(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const bool transpose_a,
+    const bool transpose_b,
+    const uint32_t bias_single_tile_size,
+    uint32_t in0_block_w,
+    const std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
+    const tt::tt_metal::DataType output_dtype) {
+    uint32_t max_l1_space = utilities::get_max_l1_space(input_tensor_a);
+    for (uint32_t per_core_factor = 16; per_core_factor > 1; per_core_factor /= 2) {
+        uint32_t size = utilities::get_estimated_size_of_cbs(
+            per_core_factor,
+            per_core_factor,
+            in0_block_w,
+            input_tensor_a,
+            input_tensor_b,
+            transpose_a,
+            transpose_b,
+            utilities::estimate_interm_tile_size(compute_kernel_config, output_dtype),
+            bias_single_tile_size);
+        if (size < max_l1_space) {
+            return per_core_factor;
+        }
+    }
+    return 1;
+}
+
+std::vector<uint32_t> get_multi_dim_per_core_factor(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const bool transpose_a,
+    const bool transpose_b,
+    const uint32_t bias_single_tile_size,
+    uint32_t per_core_M,
+    uint32_t per_core_N,
+    uint32_t in0_block_w,
+    uint32_t interm_cb_size,
+    const bool adjust_in0_block_w) {
+    uint32_t max_l1_space = utilities::get_max_l1_space(input_tensor_a);
+    uint32_t size = utilities::get_estimated_size_of_cbs(
+        per_core_M,
+        per_core_N,
+        in0_block_w,
+        input_tensor_a,
+        input_tensor_b,
+        transpose_a,
+        transpose_b,
+        interm_cb_size,
+        bias_single_tile_size);
+    if (size < max_l1_space) {
+        return {per_core_M, per_core_N, in0_block_w};
+    }
+
+    std::vector<uint32_t> m_factors = {per_core_M, 1};
+    std::vector<uint32_t> n_factors = {per_core_N, 1};
+    for (uint32_t per_core_factor_m = per_core_M / 2; per_core_factor_m > 1; per_core_factor_m--) {
+        if (per_core_M % per_core_factor_m == 0) {
+            m_factors.push_back(per_core_factor_m);
+        }
+    }
+    for (uint32_t per_core_factor_n = per_core_N / 2; per_core_factor_n > 1; per_core_factor_n--) {
+        if (per_core_N % per_core_factor_n == 0) {
+            n_factors.push_back(per_core_factor_n);
+        }
+    }
+    // Insert into ordered map, over write entry if new one is closer to a square
+    // (smallest ratio closest to 1).
+    std::map<uint32_t, std::tuple<uint32_t, uint32_t>> factors;
+    for (uint32_t per_core_factor_m : m_factors) {
+        for (uint32_t per_core_factor_n : n_factors) {
+            uint32_t multiple = per_core_factor_m * per_core_factor_n;
+            float ratio = (float)std::max(per_core_factor_m, per_core_factor_n) /
+                          (float)std::min(per_core_factor_m, per_core_factor_n);
+            auto entry = factors.find(multiple);
+            bool add = true;
+            if (entry != factors.end()) {
+                auto [existing_m, existing_n] = entry->second;
+                float existing_ratio =
+                    (float)std::max(existing_m, existing_n) / (float)std::min(existing_m, existing_n);
+                if (existing_ratio < ratio) {
+                    add = false;
+                }
+            }
+            if (add) {
+                factors[multiple] = {per_core_factor_m, per_core_factor_n};
+            }
+        }
+    }
+
+    // Find what fits, going from largest to smallest m*n. Have k in outer loop to
+    // try to maintain per_core_factor_k.
+    uint32_t min_per_core_factor_k = adjust_in0_block_w ? 1 : in0_block_w;
+    for (uint32_t per_core_factor_k = in0_block_w; per_core_factor_k >= min_per_core_factor_k; per_core_factor_k--) {
+        if (in0_block_w % per_core_factor_k != 0) {
+            continue;
+        }
+        for (const auto& factor : std::ranges::reverse_view(factors)) {
+            uint32_t per_core_factor_m = std::get<0>(factor.second);
+            uint32_t per_core_factor_n = std::get<1>(factor.second);
+
+            size = utilities::get_estimated_size_of_cbs(
+                per_core_factor_m,
+                per_core_factor_n,
+                per_core_factor_k,
+                input_tensor_a,
+                input_tensor_b,
+                transpose_a,
+                transpose_b,
+                interm_cb_size,
+                bias_single_tile_size);
+            if (size < max_l1_space) {
+                return {per_core_factor_m, per_core_factor_n, per_core_factor_k};
+            }
+        }
+    }
+    return {1, 1, 1};
+}
+
+std::tuple<uint32_t, uint32_t> get_subblock_sizes(
+    uint32_t m_tiles_per_core, uint32_t n_tiles_per_core, bool fp32_dest_acc_en) {
+    uint32_t out_subblock_h, out_subblock_w;
+    for (const auto& subblock_hw : SUBBLOCK_HW_CHOICES) {
+        out_subblock_w = std::get<0>(subblock_hw);
+        out_subblock_h = std::get<1>(subblock_hw);
+        if ((out_subblock_h * out_subblock_w) <= 4 || !fp32_dest_acc_en) {
+            if (m_tiles_per_core % out_subblock_h == 0 && n_tiles_per_core % out_subblock_w == 0) {
+                return {out_subblock_h, out_subblock_w};
+            }
+        }
+    }
+    TT_THROW("Unable to find subblock sizes");
+}
+
+bool can_cbs_fit_in_l1(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const bool transpose_a,
+    const bool transpose_b,
+    const uint32_t bias_single_tile_size,
+    uint32_t per_core_M,
+    uint32_t per_core_N,
+    uint32_t in0_block_w,
+    const std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
+    const tt::tt_metal::DataType output_dtype) {
+    uint32_t max_l1_space = utilities::get_max_l1_space(input_tensor_a);
+    uint32_t size = utilities::get_estimated_size_of_cbs(
+        per_core_M,
+        per_core_N,
+        in0_block_w,
+        input_tensor_a,
+        input_tensor_b,
+        transpose_a,
+        transpose_b,
+        utilities::estimate_interm_tile_size(compute_kernel_config, output_dtype),
+        bias_single_tile_size);
+    return size < max_l1_space;
+}
+
+/*********************************    FACTORIES    *****************************************************/
+
+MatmulProgramConfig create_matmul_1d_systolic_array_program_config(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const bool transpose_a,
+    const bool transpose_b,
+    const uint32_t bias_single_tile_size,
+    const CoreCoord& core_coord,
+    const std::optional<const unary::UnaryWithParam>& fused_activation,
+    const bool fp32_dest_acc_en,
+    const TensorMemoryLayout input_layout_a,
+    const std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
+    const tt::tt_metal::DataType output_dtype) {
+    using namespace tt;
+    const auto& a_padded_shape = utilities::get_matmul_tensor_padded_shape(input_tensor_a, transpose_a);
+    const auto& b_padded_shape = utilities::get_matmul_tensor_padded_shape(input_tensor_b, transpose_b);
+    auto k_size = a_padded_shape[-1];
+    auto m_size = a_padded_shape[-2];
+    auto n_size = b_padded_shape[-1];
+    uint32_t batch_size_a = get_batch_size(a_padded_shape);
+    uint32_t batch_size_b = get_batch_size(b_padded_shape);
+    TT_FATAL(
+        batch_size_b == 1,
+        "Second input cannot be currently batched when running matmul using "
+        "1d systolic array");
+    TT_FATAL(
+        (batch_size_a * m_size) % ttnn::TILE_SIZE == 0 && k_size % ttnn::TILE_SIZE == 0 &&
+            n_size % ttnn::TILE_SIZE == 0,
+        "The last two dimensions of the first tensor and the last dimension "
+        "of the second tensor must be a multiple of "
+        "tile size");
+    uint32_t batch_and_m_tiles = (batch_size_a * m_size) / ttnn::TILE_SIZE;
+    uint32_t k_tiles = k_size / ttnn::TILE_SIZE;
+    uint32_t n_tiles = n_size / ttnn::TILE_SIZE;
+    uint32_t num_cores = core_coord.x * core_coord.y;
+    bool is_tall = batch_and_m_tiles > n_tiles;
+    // specific 1D mcasts require specific layout types. Override accordingly.
+    if (input_layout_a == TensorMemoryLayout::HEIGHT_SHARDED) {
+        is_tall = true;
+    } else if (input_layout_a == TensorMemoryLayout::WIDTH_SHARDED) {
+        is_tall = false;
+    }
+
+    bool is_wide = !is_tall;
+    uint32_t batch_and_m_tiles_per_core;
+    uint32_t k_tiles_per_core;
+    uint32_t n_tiles_per_core;
+    if (is_tall) {
+        batch_and_m_tiles_per_core = div_up(batch_and_m_tiles, num_cores);
+        k_tiles_per_core = div_up(k_tiles, num_cores);
+        n_tiles_per_core = n_tiles;
+    } else {
+        batch_and_m_tiles_per_core = batch_and_m_tiles;
+        k_tiles_per_core = div_up(k_tiles, num_cores);
+        n_tiles_per_core = div_up(n_tiles, num_cores);
+    }
+    while (k_tiles % k_tiles_per_core != 0) {
+        k_tiles_per_core -= 1;
+    }
+    auto mutlti_dim_per_core_factor = get_multi_dim_per_core_factor(
+        input_tensor_a,
+        input_tensor_b,
+        transpose_a,
+        transpose_b,
+        bias_single_tile_size,
+        batch_and_m_tiles_per_core,
+        n_tiles_per_core,
+        k_tiles_per_core,
+        utilities::estimate_interm_tile_size(compute_kernel_config, output_dtype),
+        /*adjust_in0_block_w=*/false);
+    uint32_t out_block_h = mutlti_dim_per_core_factor[0];
+    uint32_t out_block_w = mutlti_dim_per_core_factor[1];
+
+    auto matmul_params = get_subblock_sizes(out_block_h, out_block_w, fp32_dest_acc_en);
+    uint32_t out_subblock_h = std::get<0>(matmul_params);
+    uint32_t out_subblock_w = std::get<1>(matmul_params);
+    return MatmulMultiCoreReuseMultiCast1DProgramConfig{
+        .compute_with_storage_grid_size = {core_coord.x, core_coord.y},
+        .in0_block_w = k_tiles_per_core,
+        .out_subblock_h = out_subblock_h,
+        .out_subblock_w = out_subblock_w,
+        .out_block_h = out_block_h,
+        .out_block_w = out_block_w,
+        .per_core_M = batch_and_m_tiles_per_core,
+        .per_core_N = n_tiles_per_core,
+        .fuse_batch = true,
+        .fused_activation = fused_activation,
+        .mcast_in0 = is_wide,
+    };
+}
+
+MatmulMultiCoreReuseMultiCast1DProgramConfig get_mcast_1d_config(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const bool transpose_a,
+    const bool transpose_b,
+    const uint32_t bias_single_tile_size,
+    const bool fuse_batch,
+    const std::optional<unary::UnaryWithParam>& fused_activation,
+    const bool mcast_in0,
+    const bool out_sharded,
+    const std::optional<const CoreCoord> compute_with_storage_grid_size,
+    const std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
+    const tt::tt_metal::DataType output_dtype,
+    const bool /*all_dram_interleaved*/,
+    const std::optional<tt::tt_metal::ShardSpec>& user_shard_spec = std::nullopt) {
+    using namespace tt;
+    auto* device = input_tensor_a.device();
+    auto grid_size = compute_with_storage_grid_size.value_or(device->compute_with_storage_grid_size());
+
+    const auto& a_shape_padded = utilities::get_matmul_tensor_padded_shape(input_tensor_a, transpose_a);
+    const auto& b_shape_padded = utilities::get_matmul_tensor_padded_shape(input_tensor_b, transpose_b);
+    auto in0_tile = utilities::get_matmul_tile(input_tensor_a, transpose_a);
+    auto in1_tile = utilities::get_matmul_tile(input_tensor_b, transpose_b);
+
+    const auto M = utilities::get_M_dim(a_shape_padded, /*tile=*/std::nullopt, fuse_batch);
+    const auto K = utilities::get_K_dim(a_shape_padded, /*tile=*/std::nullopt);
+    const auto N = utilities::get_N_dim(b_shape_padded, /*tile=*/std::nullopt);
+    uint32_t per_core_M, per_core_N;
+
+    // If user provided a shard spec (BLOCK_SHARDED on 1D grid), derive per_core values from it
+    if (user_shard_spec.has_value()) {
+        const auto& shard_shape = user_shard_spec->shape;
+        // Validate tile alignment
+        TT_FATAL(
+            shard_shape[0] % in0_tile.get_height() == 0,
+            "Shard height {} must be divisible by tile height {} for BLOCK_SHARDED on 1D grid",
+            shard_shape[0],
+            in0_tile.get_height());
+        TT_FATAL(
+            shard_shape[1] % in1_tile.get_width() == 0,
+            "Shard width {} must be divisible by tile width {} for BLOCK_SHARDED on 1D grid",
+            shard_shape[1],
+            in1_tile.get_width());
+        per_core_M = shard_shape[0] / in0_tile.get_height();
+        per_core_N = shard_shape[1] / in1_tile.get_width();
+        // Also use the user's grid size for compute
+        auto grid_bbox = user_shard_spec->grid.bounding_box();
+        uint32_t bbox_num_cores = (grid_bbox.end_coord.x - grid_bbox.start_coord.x + 1) *
+                                  (grid_bbox.end_coord.y - grid_bbox.start_coord.y + 1);
+        // Validate that grid is contiguous (no gaps)
+        TT_FATAL(
+            bbox_num_cores == user_shard_spec->grid.num_cores(),
+            "BLOCK_SHARDED on 1D grid requires a contiguous core grid without gaps. "
+            "Bounding box has {} cores but grid has {} cores.",
+            bbox_num_cores,
+            user_shard_spec->grid.num_cores());
+        grid_size = CoreCoord{
+            grid_bbox.end_coord.x - grid_bbox.start_coord.x + 1, grid_bbox.end_coord.y - grid_bbox.start_coord.y + 1};
+    } else if (mcast_in0) {
+        per_core_M = M / in0_tile.get_height();
+        per_core_N = div_up(div_up(N, grid_size.x * grid_size.y), in1_tile.get_width());
+    } else {
+        per_core_M = div_up(div_up(M, grid_size.x * grid_size.y), in0_tile.get_height());
+        per_core_N = N / in1_tile.get_width();
+    }
+    uint32_t in0_block_w = K / in0_tile.get_width() % 2 == 0 ? 2 : 1;
+    bool per_core_N_equals_subblock_w_constraint = out_sharded && !mcast_in0;
+    bool per_core_M_equals_subblock_h_constraint = out_sharded && mcast_in0;
+    bool fp32_dest_acc_en = get_fp32_dest_acc_en(compute_kernel_config);
+
+    auto mutlti_dim_per_core_factor = get_multi_dim_per_core_factor(
+        input_tensor_a,
+        input_tensor_b,
+        transpose_a,
+        transpose_b,
+        bias_single_tile_size,
+        per_core_M,
+        per_core_N,
+        in0_block_w,
+        utilities::estimate_interm_tile_size(compute_kernel_config, output_dtype),
+        /*adjust_in0_block_w=*/false);
+    uint32_t out_block_h = mutlti_dim_per_core_factor[0];
+    uint32_t out_block_w = mutlti_dim_per_core_factor[1];
+
+    auto subblock_hw = bmm_op_utils_qsr::get_matmul_subblock_params(
+        out_block_h,
+        out_block_w,
+        per_core_M_equals_subblock_h_constraint,
+        per_core_N_equals_subblock_w_constraint,
+        fp32_dest_acc_en);
+    auto out_subblock_h = std::get<0>(subblock_hw);
+    auto out_subblock_w = std::get<1>(subblock_hw);
+
+    return MatmulMultiCoreReuseMultiCast1DProgramConfig{
+        .compute_with_storage_grid_size = grid_size,
+        .in0_block_w = in0_block_w,
+        .out_subblock_h = out_subblock_h,
+        .out_subblock_w = out_subblock_w,
+        .out_block_h = out_block_h,
+        .out_block_w = out_block_w,
+        .per_core_M = per_core_M,
+        .per_core_N = per_core_N,
+        .fuse_batch = fuse_batch,
+        .fused_activation = fused_activation,
+        .mcast_in0 = mcast_in0};
+}
+
+MatmulProgramConfig create_matmul_program_config(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const bool transpose_a,
+    const bool transpose_b,
+    const uint32_t bias_single_tile_size,
+    const std::optional<const CoreCoord> user_core_coord,
+    const std::optional<unary::UnaryWithParam>& fused_activation,
+    const std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
+    const MemoryConfig& mem_config,
+    const tt::tt_metal::DataType output_dtype) {
+    using namespace tt;
+    const auto a_shape = utilities::get_matmul_tensor_logical_shape(input_tensor_a, transpose_a);
+    const auto b_shape = utilities::get_matmul_tensor_logical_shape(input_tensor_b, transpose_b);
+    const auto& a_padded_shape = utilities::get_matmul_tensor_padded_shape(input_tensor_a, transpose_a);
+    const auto& b_padded_shape = utilities::get_matmul_tensor_padded_shape(input_tensor_b, transpose_b);
+    auto a_layout = input_tensor_a.memory_config().memory_layout();
+    auto inteneded_k_size_of_a = a_shape[-1];
+    auto inteneded_k_size_of_b = b_shape[-2];
+    auto k_size = a_padded_shape[-1];
+    auto m_size = a_padded_shape[-2];
+    auto n_size = b_padded_shape[-1];
+    uint32_t batch_size_a = get_batch_size(a_padded_shape);
+    uint32_t batch_size_b = get_batch_size(b_padded_shape);
+    bool input_b_is_batched = batch_size_b > 1;
+    bool any_size_within_tile = k_size <= ttnn::TILE_SIZE || m_size <= ttnn::TILE_SIZE || n_size <= ttnn::TILE_SIZE;
+    const auto& input_tensor_a_memory_config = input_tensor_a.memory_config();
+    const auto& input_tensor_b_memory_config = input_tensor_b.memory_config();
+    bool fp32_dest_acc_en = get_fp32_dest_acc_en(compute_kernel_config);
+    bool a_is_sharded = input_tensor_a.is_sharded();
+    TT_FATAL(inteneded_k_size_of_a == inteneded_k_size_of_b, "The k dimension does not match between tensors");
+    TT_FATAL(
+        (batch_size_a * m_size) % ttnn::TILE_SIZE == 0 && k_size % ttnn::TILE_SIZE == 0 &&
+            n_size % ttnn::TILE_SIZE == 0,
+        "The last two dimensions of the first tensor and the last dimension "
+        "of the second tensor must be a multiple of "
+        "tile size");
+    auto core_coord = input_tensor_a.device()->compute_with_storage_grid_size();
+    bool has_user_core_coord = user_core_coord.has_value();
+    if (has_user_core_coord) {
+        auto x = user_core_coord.value().x;
+        auto y = user_core_coord.value().y;
+        if (x <= core_coord.x && y <= core_coord.y) {
+            core_coord = user_core_coord.value();
+        }
+    }
+
+    uint32_t m_tiles_per_core;
+    uint32_t n_tiles_per_core;
+    uint32_t k_tiles_per_core;
+    if (input_b_is_batched) {
+        TT_FATAL(!fused_activation.has_value(), "Cannot use activation with batched input b");
+        if (!a_is_sharded && !input_tensor_b.is_sharded()) {
+            m_tiles_per_core = div_up(m_size, ttnn::TILE_SIZE);
+            n_tiles_per_core = div_up(n_size, ttnn::TILE_SIZE);
+            k_tiles_per_core = 1;  // TODO(arakhmati): Can it be more than 1 without
+                                   // running out of memory?
+            if (!can_cbs_fit_in_l1(
+                    input_tensor_a,
+                    input_tensor_b,
+                    transpose_a,
+                    transpose_b,
+                    bias_single_tile_size,
+                    m_tiles_per_core,
+                    n_tiles_per_core,
+                    k_tiles_per_core,
+                    compute_kernel_config,
+                    output_dtype)) {
+                return create_simple_matmul_program_config(
+                    input_tensor_a,
+                    input_tensor_b,
+                    transpose_a,
+                    transpose_b,
+                    bias_single_tile_size,
+                    compute_kernel_config,
+                    core_coord,
+                    mem_config,
+                    output_dtype);
+            }
+        } else if (a_is_sharded) {
+            TT_FATAL(
+                a_layout != TensorMemoryLayout::WIDTH_SHARDED,
+                "MatmulMultiCoreReuseProgramConfig: Input A cannot be width sharded, got layout: {}",
+                a_layout);
+            auto shard_shape = input_tensor_a_memory_config.shard_spec().value().shape;
+            uint32_t n = b_shape[-1] / ttnn::TILE_SIZE;
+            m_tiles_per_core = shard_shape[0] / ttnn::TILE_SIZE;
+            n_tiles_per_core = n;
+            k_tiles_per_core = shard_shape[1] / ttnn::TILE_SIZE;
+        } else {
+            TT_FATAL(
+                input_tensor_b_memory_config.memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
+                "MatmulMultiCoreReuseProgramConfig: Input B cannot be width sharded, got layout: {}",
+                input_tensor_b_memory_config.memory_layout());
+            auto shard_shape = input_tensor_b_memory_config.shard_spec().value().shape;
+            m_tiles_per_core = div_up(m_size, ttnn::TILE_SIZE);
+            n_tiles_per_core = shard_shape[1] / ttnn::TILE_SIZE;
+            k_tiles_per_core = 1;
+        }
+
+        auto matmul_params = get_subblock_sizes(m_tiles_per_core, n_tiles_per_core, fp32_dest_acc_en);
+        uint32_t out_subblock_h = std::get<0>(matmul_params);
+        uint32_t out_subblock_w = std::get<1>(matmul_params);
+
+        return MatmulMultiCoreReuseProgramConfig{
+            .compute_with_storage_grid_size = {core_coord.x, core_coord.y},
+            .in0_block_w = k_tiles_per_core,
+            .out_subblock_h = out_subblock_h,
+            .out_subblock_w = out_subblock_w,
+            .per_core_M = m_tiles_per_core,
+            .per_core_N = n_tiles_per_core,
+        };
+    }
+
+    auto height = batch_size_a * m_size;
+    auto width = n_size;
+    bool a_is_block_sharded = a_layout == TensorMemoryLayout::BLOCK_SHARDED;
+    if (is_narrow_shape(height, width, false) || any_size_within_tile) {
+        if (!a_is_block_sharded) {
+            return create_matmul_1d_systolic_array_program_config(
+                input_tensor_a,
+                input_tensor_b,
+                transpose_a,
+                transpose_b,
+                bias_single_tile_size,
+                core_coord,
+                fused_activation,
+                fp32_dest_acc_en,
+                a_layout,
+                compute_kernel_config,
+                output_dtype);
+        }
+    }
+    if (!a_is_sharded) {
+        m_tiles_per_core = (uint32_t)std::ceil((((double)batch_size_a * m_size) / ttnn::TILE_SIZE) / core_coord.y);
+        n_tiles_per_core = (uint32_t)std::ceil((double)n_size / ttnn::TILE_SIZE / core_coord.x);
+        k_tiles_per_core = 4;  // TODO(arakhmati): What is a good starting point?
+        while ((k_size / ttnn::TILE_SIZE) % k_tiles_per_core != 0) {
+            k_tiles_per_core -= 1;
+        }
+    } else {
+        if (!a_is_block_sharded) {
+            return create_matmul_1d_systolic_array_program_config(
+                input_tensor_a,
+                input_tensor_b,
+                transpose_a,
+                transpose_b,
+                bias_single_tile_size,
+                core_coord,
+                fused_activation,
+                fp32_dest_acc_en,
+                a_layout,
+                compute_kernel_config,
+                output_dtype);
+        }
+        uint32_t k = a_padded_shape[-1] / ttnn::TILE_SIZE;
+        uint32_t n = b_padded_shape[-1] / ttnn::TILE_SIZE;
+        auto shard_shape = input_tensor_a_memory_config.shard_spec().value().shape;
+        m_tiles_per_core = shard_shape[0] / ttnn::TILE_SIZE;
+        n_tiles_per_core = (n * shard_shape[1]) / (k * ttnn::TILE_SIZE);
+        k_tiles_per_core = std::gcd(shard_shape[1] / ttnn::TILE_SIZE, k);
+    }
+
+    n_tiles_per_core = std::max(n_tiles_per_core, (unsigned int)1);
+
+    auto mutlti_dim_per_core_factor = get_multi_dim_per_core_factor(
+        input_tensor_a,
+        input_tensor_b,
+        transpose_a,
+        transpose_b,
+        bias_single_tile_size,
+        m_tiles_per_core,
+        n_tiles_per_core,
+        k_tiles_per_core,
+        utilities::estimate_interm_tile_size(compute_kernel_config, output_dtype),
+        /*adjust_in0_block_w=*/false);
+    uint32_t out_block_h = mutlti_dim_per_core_factor[0];
+    uint32_t out_block_w = mutlti_dim_per_core_factor[1];
+
+    auto matmul_params = get_subblock_sizes(out_block_h, out_block_w, fp32_dest_acc_en);
+    uint32_t out_subblock_h = std::get<0>(matmul_params);
+    uint32_t out_subblock_w = std::get<1>(matmul_params);
+    bool transpose_mcast =
+        a_is_block_sharded && input_tensor_a.shard_spec().value().orientation == ShardOrientation::COL_MAJOR;
+    if (out_subblock_w != n_tiles_per_core) {
+        out_subblock_h = 1;
+    }
+
+    return MatmulMultiCoreReuseMultiCastProgramConfig{
+        .compute_with_storage_grid_size = {core_coord.x, core_coord.y},
+        .in0_block_w = k_tiles_per_core,
+        .out_subblock_h = out_subblock_h,
+        .out_subblock_w = out_subblock_w,
+        .out_block_h = out_block_h,
+        .out_block_w = out_block_w,
+        .per_core_M = m_tiles_per_core,
+        .per_core_N = n_tiles_per_core,
+        .transpose_mcast = transpose_mcast,
+        .fused_activation = fused_activation,
+    };
+}
+
+// TODO: Only supports sharded matmul for now; infer most matmul params from
+// shard spec
+MatmulProgramConfig get_matmul_program_config(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const bool transpose_a,
+    const bool transpose_b,
+    const uint32_t bias_single_tile_size,
+    const MemoryConfig& output_mem_config,
+    const std::optional<unary::UnaryWithParam>& fused_activation,
+    const bool matmul,
+    const std::optional<const CoreCoord> user_core_coord,
+    const std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
+    const tt::tt_metal::DataType output_dtype) {
+    using namespace tt;
+    TT_FATAL(input_tensor_a.is_sharded(), "Input tensor A must be sharded");
+    bool fp32_dest_acc_en = get_fp32_dest_acc_en(compute_kernel_config);
+    // TODO: allow overwriting of grid size by user_core_coord after allowing
+    // support of arbitrary compute grid and more generic sharded output tensor
+    // creation
+    auto grid_size = input_tensor_a.shard_spec().value().grid.bounding_box().grid_size();
+
+    const auto& a_shape_padded = utilities::get_matmul_tensor_padded_shape(input_tensor_a, transpose_a);
+    const auto& b_shape_padded = utilities::get_matmul_tensor_padded_shape(input_tensor_b, transpose_b);
+    auto in0_tile = utilities::get_matmul_tile(input_tensor_a, transpose_a);
+    auto in1_tile = utilities::get_matmul_tile(input_tensor_b, transpose_b);
+
+    // MCAST matmuls only support input_b in INTERLEAVED
+    if (matmul) {
+        TT_FATAL(
+            input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+            "Input tensor B must have INTERLEAVED memory layout, got: {}",
+            input_tensor_b.memory_config().memory_layout());
+        if ((input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED or
+             input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) and
+            (grid_size.x > 1 or grid_size.y > 1)) {
+            TT_FATAL(
+                input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
+                "Input tensor A must have ROW_MAJOR shard orientation, got: {}",
+                input_tensor_a.shard_spec().value().orientation);
+
+            bool per_core_N_equals_subblock_w_constraint = false;
+            if (output_mem_config.is_sharded()) {
+                TT_FATAL(
+                    input_tensor_a.memory_config().buffer_type() == output_mem_config.buffer_type(),
+                    "Input A and output buffer types must match, got input: {} vs output: {}",
+                    input_tensor_a.memory_config().buffer_type(),
+                    output_mem_config.buffer_type());
+                TT_FATAL(
+                    input_tensor_a.memory_config().memory_layout() == output_mem_config.memory_layout(),
+                    "Input A and output memory layouts must match, got input: {} vs output: {}",
+                    input_tensor_a.memory_config().memory_layout(),
+                    output_mem_config.memory_layout());
+                per_core_N_equals_subblock_w_constraint = true;
+            }
+
+            const auto M = utilities::get_M_dim(a_shape_padded, in0_tile, /*fuse_batch=*/true);
+            const auto K = utilities::get_K_dim(a_shape_padded, in0_tile);
+            const auto N = utilities::get_N_dim(b_shape_padded, in1_tile);
+            auto shard_shape = input_tensor_a.shard_spec().value().shape;
+
+            bool mcast_in0;
+            uint32_t per_core_M;
+            uint32_t per_core_N;
+            uint32_t in0_block_w;
+            if (input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED) {
+                mcast_in0 = true;
+                per_core_M = M;
+                per_core_N = div_up(N, input_tensor_a.shard_spec().value().grid.num_cores());
+                in0_block_w = std::gcd(shard_shape[1] / in0_tile.get_width(), K);
+            } else if (input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
+                mcast_in0 = false;
+                per_core_M = shard_shape[0] / in0_tile.get_height();
+                per_core_N = N;  // Only necessary if output is sharded; otherwise, can
+                                 // set this to be < N
+                in0_block_w = K;
+            } else {
+                TT_THROW(
+                    "Input tensor must be WIDTH or HEIGHT sharded for 1D mcast "
+                    "matmul!");
+            }
+
+            auto mutlti_dim_per_core_factor = get_multi_dim_per_core_factor(
+                input_tensor_a,
+                input_tensor_b,
+                transpose_a,
+                transpose_b,
+                bias_single_tile_size,
+                per_core_M,
+                per_core_N,
+                in0_block_w,
+                utilities::estimate_interm_tile_size(compute_kernel_config, output_dtype),
+                /*adjust_in0_block_w=*/false);
+            uint32_t out_block_h = mutlti_dim_per_core_factor[0];
+            uint32_t out_block_w = mutlti_dim_per_core_factor[1];
+
+            auto subblock_hw = bmm_op_utils_qsr::get_matmul_subblock_params(
+                out_block_h, out_block_w, false, per_core_N_equals_subblock_w_constraint, fp32_dest_acc_en);
+            auto out_subblock_h = std::get<0>(subblock_hw);
+            auto out_subblock_w = std::get<1>(subblock_hw);
+
+            return MatmulMultiCoreReuseMultiCast1DProgramConfig{
+                .compute_with_storage_grid_size = grid_size,
+                .in0_block_w = in0_block_w,
+                .out_subblock_h = out_subblock_h,
+                .out_subblock_w = out_subblock_w,
+                .out_block_h = out_block_h,
+                .out_block_w = out_block_w,
+                .per_core_M = per_core_M,
+                .per_core_N = per_core_N,
+                .fuse_batch = true,
+                .fused_activation = fused_activation,
+                .mcast_in0 = mcast_in0,
+            };
+        }
+        if (input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED and
+            (grid_size.x > 1 and grid_size.y > 1)) {
+            bool transpose_mcast = input_tensor_a.shard_spec().value().orientation == ShardOrientation::COL_MAJOR;
+
+            bool per_core_N_equals_subblock_w_constraint = false;
+            if (output_mem_config.is_sharded()) {
+                TT_FATAL(
+                    input_tensor_a.memory_config().buffer_type() == output_mem_config.buffer_type(),
+                    "Input A and output buffer types must match, got input: {} vs output: {}",
+                    input_tensor_a.memory_config().buffer_type(),
+                    output_mem_config.buffer_type());
+                TT_FATAL(
+                    input_tensor_a.memory_config().memory_layout() == output_mem_config.memory_layout(),
+                    "Input A and output memory layouts must match, got input: {} vs output: {}",
+                    input_tensor_a.memory_config().memory_layout(),
+                    output_mem_config.memory_layout());
+                per_core_N_equals_subblock_w_constraint = true;
+            }
+
+            const auto M = utilities::get_M_dim(a_shape_padded, in0_tile, /*fuse_batch=*/true);
+            const auto K = utilities::get_K_dim(a_shape_padded, in0_tile);
+            const auto N = utilities::get_N_dim(b_shape_padded, in1_tile);
+
+            auto shard_shape = input_tensor_a.shard_spec().value().shape;
+            uint32_t virtual_x = transpose_mcast ? grid_size.y : grid_size.x;
+            uint32_t virtual_y = transpose_mcast ? grid_size.x : grid_size.y;
+            bool cores_along_x_match_grid_size = virtual_x == (K / (shard_shape[1] / in0_tile.get_width()));
+            bool cores_along_y_match_grid_size = virtual_y == (M / (shard_shape[0] / in0_tile.get_height()));
+            TT_FATAL(
+                cores_along_y_match_grid_size || virtual_y == div_up(M, (shard_shape[0] / in0_tile.get_height())),
+                "Num cores along y ({}) must match provided grid size ({}) or divided up size ({})",
+                virtual_y,
+                M / (shard_shape[0] / in0_tile.get_height()),
+                div_up(M, (shard_shape[0] / in0_tile.get_height())));
+            TT_FATAL(
+                cores_along_x_match_grid_size || virtual_x == div_up(K, (shard_shape[1] / in0_tile.get_width())),
+                "Num cores along x ({}) must match provided grid size ({}) or divided up size ({})",
+                virtual_x,
+                K / (shard_shape[1] / in0_tile.get_width()),
+                div_up(K, (shard_shape[1] / in0_tile.get_width())));
+
+            uint32_t per_core_M = div_up(M, virtual_y);
+            uint32_t per_core_N = div_up(N, virtual_x);
+            uint32_t in0_block_w =
+                cores_along_x_match_grid_size ? std::gcd(shard_shape[1] / in0_tile.get_width(), K) : 1;
+
+            auto mutlti_dim_per_core_factor = get_multi_dim_per_core_factor(
+                input_tensor_a,
+                input_tensor_b,
+                transpose_a,
+                transpose_b,
+                bias_single_tile_size,
+                per_core_M,
+                per_core_N,
+                in0_block_w,
+                utilities::estimate_interm_tile_size(compute_kernel_config, output_dtype),
+                /*adjust_in0_block_w=*/false);
+            uint32_t out_block_h = mutlti_dim_per_core_factor[0];
+            uint32_t out_block_w = mutlti_dim_per_core_factor[1];
+
+            auto subblock_hw = bmm_op_utils_qsr::get_matmul_subblock_params(
+                out_block_h, out_block_w, false, per_core_N_equals_subblock_w_constraint, fp32_dest_acc_en);
+            auto out_subblock_h = std::get<0>(subblock_hw);
+            auto out_subblock_w = std::get<1>(subblock_hw);
+
+            return MatmulMultiCoreReuseMultiCastProgramConfig{
+                .compute_with_storage_grid_size = grid_size,
+                .in0_block_w = in0_block_w,
+                .out_subblock_h = out_subblock_h,
+                .out_subblock_w = out_subblock_w,
+                .out_block_h = out_block_h,
+                .out_block_w = out_block_w,
+                .per_core_M = per_core_M,
+                .per_core_N = per_core_N,
+                .transpose_mcast = transpose_mcast,
+                .fused_activation = fused_activation,
+            };
+        }
+    } else {
+        // TODO: Need a better criteria for BMMs and
+        // MatmulMultiCoreReuseProgramConfig
+        TT_FATAL(
+            input_tensor_a.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
+            "Input A memory layout must not be WIDTH_SHARDED, got: {}",
+            input_tensor_a.memory_config().memory_layout());
+
+        bool per_core_N_equals_subblock_w_constraint = false;
+        if (output_mem_config.is_sharded()) {
+            TT_FATAL(
+                input_tensor_a.memory_config().buffer_type() == output_mem_config.buffer_type(),
+                "Input A and output buffer types must match, got input: {} vs output: {}",
+                input_tensor_a.memory_config().buffer_type(),
+                output_mem_config.buffer_type());
+            TT_FATAL(
+                input_tensor_a.memory_config().memory_layout() == output_mem_config.memory_layout(),
+                "Input A and output memory layouts must match, got input: {} vs output: {}",
+                input_tensor_a.memory_config().memory_layout(),
+                output_mem_config.memory_layout());
+            per_core_N_equals_subblock_w_constraint = true;
+        }
+
+        const auto N = utilities::get_N_dim(b_shape_padded, in1_tile);
+
+        auto in0_shard_shape = input_tensor_a.shard_spec().value().shape;
+        uint32_t per_core_M = in0_shard_shape[0] / in0_tile.get_height();
+        uint32_t per_core_N = N;
+        uint32_t in0_block_w = in0_shard_shape[1] / in0_tile.get_width();
+
+        auto subblock_hw = bmm_op_utils_qsr::get_matmul_subblock_params(
+            per_core_M, per_core_N, false, per_core_N_equals_subblock_w_constraint, fp32_dest_acc_en);
+        auto out_subblock_h = std::get<0>(subblock_hw);
+        auto out_subblock_w = std::get<1>(subblock_hw);
+
+        // TODO: Temporarily allow for single core; should support bcast_batch in general
+        const auto batch_size_a =
+            get_batch_size(utilities::get_matmul_tensor_padded_shape(input_tensor_a, transpose_a));
+        const auto batch_size_b =
+            get_batch_size(utilities::get_matmul_tensor_padded_shape(input_tensor_b, transpose_b));
+        bool broadcast_batch = batch_size_a > 1 and batch_size_b == 1;
+        TT_FATAL(!broadcast_batch, "Batch broadcasting is not supported for the chosen program config");
+
+        if (input_tensor_b.is_sharded()) {
+            TT_FATAL(
+                input_tensor_a.memory_config().buffer_type() == input_tensor_b.memory_config().buffer_type(),
+                "Input A and B buffer types must match, got A: {} vs B: {}",
+                input_tensor_a.memory_config().buffer_type(),
+                input_tensor_b.memory_config().buffer_type());
+            TT_FATAL(
+                input_tensor_a.memory_config().memory_layout() == input_tensor_b.memory_config().memory_layout(),
+                "Input A and B memory layouts must match, got A: {} vs B: {}",
+                input_tensor_a.memory_config().memory_layout(),
+                input_tensor_b.memory_config().memory_layout());
+            TT_FATAL(
+                input_tensor_a.shard_spec().value().grid == input_tensor_b.shard_spec().value().grid,
+                "Input A and B shard grids must match");
+            TT_FATAL(
+                input_tensor_a.shard_spec().value().orientation == input_tensor_b.shard_spec().value().orientation,
+                "Orientation mismatch a {} vs b {}.",
+                input_tensor_a.shard_spec().value().orientation,
+                input_tensor_b.shard_spec().value().orientation);
+        }
+
+        return MatmulMultiCoreReuseProgramConfig{
+            .compute_with_storage_grid_size = grid_size,
+            .in0_block_w = in0_block_w,
+            .out_subblock_h = out_subblock_h,
+            .out_subblock_w = out_subblock_w,
+            .per_core_M = per_core_M,
+            .per_core_N = per_core_N,
+        };
+    }
+    return create_matmul_program_config(
+        input_tensor_a,
+        input_tensor_b,
+        transpose_a,
+        transpose_b,
+        bias_single_tile_size,
+        user_core_coord,
+        fused_activation,
+        compute_kernel_config,
+        output_mem_config,
+        output_dtype);
+}
+
+inline MatmulProgramConfig generate_matmul_program_config(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const bool transpose_a,
+    const bool transpose_b,
+    const uint32_t bias_single_tile_size,
+    const MemoryConfig& mem_config,
+    const std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
+    const std::optional<const CoreCoord> user_core_coord,
+    const std::optional<unary::UnaryWithParam>& user_fused_activation,
+    const bool user_run_batched,
+    const tt::tt_metal::DataType output_dtype) {
+    const bool has_user_grid = user_core_coord.has_value();
+    if (has_user_grid || !input_tensor_a.is_sharded()) {
+        CoreCoord core_coord;
+        if (has_user_grid) {
+            core_coord = user_core_coord.value();
+            return create_matmul_program_config(
+                input_tensor_a,
+                input_tensor_b,
+                transpose_a,
+                transpose_b,
+                bias_single_tile_size,
+                user_core_coord,
+                user_fused_activation,
+                compute_kernel_config,
+                mem_config,
+                output_dtype);
+        }
+        tt::tt_metal::IDevice* device = input_tensor_a.device();
+        auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+        return create_simple_matmul_program_config(
+            input_tensor_a,
+            input_tensor_b,
+            transpose_a,
+            transpose_b,
+            bias_single_tile_size,
+            compute_kernel_config,
+            compute_with_storage_grid_size,
+            mem_config,
+            output_dtype);
+    }
+    bool bmm = user_run_batched;
+    return get_matmul_program_config(
+        input_tensor_a,
+        input_tensor_b,
+        transpose_a,
+        transpose_b,
+        bias_single_tile_size,
+        mem_config,
+        std::nullopt,
+        !bmm,
+        user_core_coord,
+        compute_kernel_config,
+        output_dtype);
+}
+
+/***************************************************************************************/
+
+}  // namespace
+
+namespace bmm_op_utils_qsr {
+std::tuple<uint32_t, uint32_t> get_matmul_subblock_params(
+    const uint32_t per_core_M,
+    const uint32_t per_core_N,
+    const bool per_core_M_equals_subblock_h_constraint,
+    const bool per_core_N_equals_subblock_w_constraint,
+    const bool fp32_dest_acc_en) {
+    TT_FATAL(
+        !(per_core_M_equals_subblock_h_constraint and per_core_N_equals_subblock_w_constraint),
+        "Only one constraint may be true for h or w!");
+
+    uint32_t out_subblock_h, out_subblock_w;
+    for (const auto& subblock_hw : SUBBLOCK_HW_CHOICES) {
+        out_subblock_h = std::get<0>(subblock_hw);
+        out_subblock_w = std::get<1>(subblock_hw);
+        if (fp32_dest_acc_en) {
+            if ((out_subblock_h * out_subblock_w) > 4) {
+                continue;  // Total number of tiles in a subblock must be less than 4
+                           // when in fp32_dest_acc mode
+            }
+        }
+        if (per_core_N_equals_subblock_w_constraint) {
+            if (out_subblock_w != per_core_N || out_subblock_h != 1) {
+                continue;
+            }
+        }
+        if (per_core_M_equals_subblock_h_constraint) {
+            if (out_subblock_h != per_core_M || out_subblock_w != 1) {
+                continue;
+            }
+        }
+        if (per_core_M % out_subblock_h == 0 and per_core_N % out_subblock_w == 0) {
+            return {out_subblock_h, out_subblock_w};
+        }
+    }
+    // Return basic value that should work in most cases.
+    return {1, 1};
+}
+}  // namespace bmm_op_utils_qsr
+
+MatmulProgramConfig get_program_config(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const bool transpose_a,
+    const bool transpose_b,
+    const uint32_t bias_single_tile_size,
+    const ttnn::prim::qsr::MatmulParams& attributes) {
+    if (attributes.program_config.has_value()) {
+        return attributes.program_config.value();
+    }
+    auto config = generate_matmul_program_config(
+        input_tensor_a,
+        input_tensor_b,
+        transpose_a,
+        transpose_b,
+        bias_single_tile_size,
+        attributes.output_mem_config,
+        attributes.compute_kernel_config,
+        attributes.user_core_coord,
+        attributes.user_fused_activation,
+        attributes.user_run_batched,
+        attributes.output_dtype.value_or(input_tensor_a.dtype()));
+    log_debug(tt::LogOp, "Auto generated program config: {}", config);
+
+    // Sanity checks for matmul program configs
+    std::visit(
+        [input_tensor_a](const auto& program_config) {
+            using ProgramConfigType = std::decay_t<decltype(program_config)>;
+            if constexpr (
+                not std::is_same_v<ProgramConfigType, MatmulMultiCoreProgramConfig> and
+                not std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig> and
+                not std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>) {
+                TT_FATAL(
+                    program_config.compute_with_storage_grid_size.x <=
+                        input_tensor_a.device()->compute_with_storage_grid_size().x,
+                    "Number of columns in matmul compute grid exceeds maximum device "
+                    "compute grid size!");
+                TT_FATAL(
+                    program_config.compute_with_storage_grid_size.y <=
+                        input_tensor_a.device()->compute_with_storage_grid_size().y,
+                    "Number of rows in matmul compute grid exceeds maximum device "
+                    "compute grid size!");
+                TT_FATAL(
+                    program_config.compute_with_storage_grid_size.x > 0,
+                    "Number of columns in matmul compute grid must be greater "
+                    "than 0!");
+                TT_FATAL(
+                    program_config.compute_with_storage_grid_size.y > 0,
+                    "Number of rows in matmul compute grid must be greater than 0!");
+                TT_FATAL(program_config.in0_block_w > 0, "in0_block_w must be greater than 0!");
+                TT_FATAL(program_config.out_subblock_h > 0, "out_subblock_h must be greater than 0!");
+                TT_FATAL(program_config.out_subblock_w > 0, "out_subblock_w must be greater than 0!");
+                TT_FATAL(program_config.per_core_M > 0, "per_core_M must be greater than 0!");
+                TT_FATAL(program_config.per_core_N > 0, "per_core_N must be greater than 0!");
+                TT_FATAL(
+                    program_config.per_core_M % program_config.out_subblock_h == 0,
+                    "per_core_M must be divisible by out_subblock_h!");
+                TT_FATAL(
+                    program_config.per_core_N % program_config.out_subblock_w == 0,
+                    "per_core_N must be divisible by out_subblock_w!");
+            }
+            if constexpr (requires { program_config.allowed_worker_cores; }) {
+                if (program_config.allowed_worker_cores.has_value()) {
+                    const auto& awc = program_config.allowed_worker_cores.value();
+                    TT_FATAL(awc.num_cores() > 0, "allowed_worker_cores must be non-empty!");
+                    auto bbox = awc.bounding_box();
+                    TT_FATAL(
+                        awc.num_cores() == bbox.size(),
+                        "allowed_worker_cores must form a dense rectangle (got {} cores in a {} bounding box)",
+                        awc.num_cores(),
+                        bbox);
+                    auto device_grid = input_tensor_a.device()->compute_with_storage_grid_size();
+                    CoreRangeSet device_cores({CoreRange({0, 0}, {device_grid.x - 1, device_grid.y - 1})});
+                    TT_FATAL(
+                        device_cores.contains(awc),
+                        "allowed_worker_cores must be a subset of the device compute grid!");
+                }
+            }
+        },
+        config);
+    return config;
+}
+
+MatmulProgramConfig create_simple_matmul_program_config(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const bool transpose_a,
+    const bool transpose_b,
+    const uint32_t bias_single_tile_size,
+    const std::optional<const ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
+    const CoreCoord& compute_with_storage_grid_size,
+    const tt::tt_metal::MemoryConfig& mem_config,
+    const tt::tt_metal::DataType output_dtype) {
+    using namespace tt::tt_metal;
+    const auto& a_shape_padded = utilities::get_matmul_tensor_padded_shape(input_tensor_a, transpose_a);
+    const auto& b_shape_padded = utilities::get_matmul_tensor_padded_shape(input_tensor_b, transpose_b);
+
+    auto in0_tile = utilities::get_matmul_tile(input_tensor_a, transpose_a);
+    auto in1_tile = utilities::get_matmul_tile(input_tensor_b, transpose_b);
+
+    // Parameters for large matmul with reuse
+    const auto Mt = utilities::get_M_dim(a_shape_padded, in0_tile, /*fuse_batch=*/false);
+    const auto Kt = utilities::get_K_dim(a_shape_padded, in0_tile);
+    const auto Nt = utilities::get_N_dim(b_shape_padded, in1_tile);
+    uint32_t in0_block_w = 2;
+
+    TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "input tensor needs to be on device");
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    uint32_t per_core_M, per_core_N, out_subblock_h, out_subblock_w;
+    uint32_t num_blocks_x, num_blocks_y;
+
+    const bool all_interleaved = input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED &&
+                                 mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED &&
+                                 input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED;
+
+    const bool all_dram = input_tensor_a.memory_config().buffer_type() == BufferType::DRAM &&
+                          input_tensor_b.memory_config().buffer_type() == BufferType::DRAM &&
+                          mem_config.buffer_type() == BufferType::DRAM;
+
+    const bool all_dram_interleaved = all_dram && all_interleaved;
+
+    uint32_t height = a_shape_padded[-2];
+    uint32_t width = b_shape_padded[-1];
+    const bool is_narrow = is_narrow_shape(height, width, all_dram);
+    bool is_wide = false;
+    bool is_tall = false;
+    if (all_interleaved && is_narrow) {
+        is_wide = width > height;
+        is_tall = !is_wide;
+    }
+
+    // out_subblock h/w doesn't matter
+    per_core_M = get_per_core_factor(
+        input_tensor_a,
+        input_tensor_b,
+        transpose_a,
+        transpose_b,
+        bias_single_tile_size,
+        in0_block_w,
+        compute_kernel_config,
+        output_dtype);
+    per_core_N = per_core_M;
+
+    // Calculate number of blocks along x and y; tensor dims are padded up to 512
+    num_blocks_y = (Mt - 1) / per_core_M + 1;
+    num_blocks_x = (Nt - 1) / per_core_N + 1;
+
+    // MatmulMultiCoreProgramConfig does not support sharded output.
+    // Reduce in0_block_w if necessary or might benefit from mcast due to size to
+    // choose other configs.
+    if ((mem_config.is_sharded() or num_blocks_y > 1 or num_blocks_x > 1) and Kt % in0_block_w != 0) {
+        in0_block_w = 1;
+    }
+
+    auto get_core_range = [](uint32_t num_blocks_rows,
+                             uint32_t num_blocks_cols,
+                             uint32_t max_num_rows,
+                             uint32_t max_num_cols) -> CoreCoord {
+        CoreCoord core_range(0, 0);
+        if (!(num_blocks_rows == 1 && num_blocks_cols == 1) && num_blocks_rows <= max_num_rows &&
+            num_blocks_cols <= max_num_cols) {
+            core_range.x = num_blocks_cols;
+            core_range.y = num_blocks_rows;
+        }
+        return core_range;
+    };
+
+    if (all_dram_interleaved or (num_blocks_x * num_blocks_y <= num_cores_x * num_cores_y and Kt % in0_block_w == 0)) {
+        CoreCoord core_range = get_core_range(num_blocks_y, num_blocks_x, num_cores_y, num_cores_x);
+        // Check if BLOCK_SHARDED is on a 1D grid (equivalent to HEIGHT_SHARDED or WIDTH_SHARDED)
+        // Note: 1x1 grids (single core) are NOT treated as 1D grids - they work fine with the 2D mcast path
+        bool block_sharded_on_1d_column_grid = false;
+        bool block_sharded_on_1d_row_grid = false;
+        if (mem_config.is_sharded() && mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED &&
+            mem_config.shard_spec().has_value()) {
+            auto grid_bbox = mem_config.shard_spec()->grid.bounding_box();
+            bool is_single_core = (grid_bbox.end_coord.x == grid_bbox.start_coord.x) &&
+                                  (grid_bbox.end_coord.y == grid_bbox.start_coord.y);
+            // 1-column grid (e.g., 1x5): end_coord.x == start_coord.x means only 1 column
+            // Exclude single-core grids which work fine with 2D mcast
+            block_sharded_on_1d_column_grid = !is_single_core && (grid_bbox.end_coord.x == grid_bbox.start_coord.x);
+            // 1-row grid (e.g., 5x1): end_coord.y == start_coord.y means only 1 row
+            // Exclude single-core grids which work fine with 2D mcast
+            block_sharded_on_1d_row_grid = !is_single_core && (grid_bbox.end_coord.y == grid_bbox.start_coord.y);
+
+            // Check for unsupported configuration: BLOCK_SHARDED on 1D grid with both tensors batched
+            // This configuration requires the 2D mcast program which doesn't handle 1D grids correctly
+            const auto& b_shape = utilities::get_matmul_tensor_padded_shape(input_tensor_b, transpose_b);
+            bool b_is_batched = (get_batch_size(b_shape) > 1);
+            if ((block_sharded_on_1d_column_grid || block_sharded_on_1d_row_grid) && b_is_batched) {
+                TT_FATAL(
+                    false,
+                    "BLOCK_SHARDED output on a 1D grid (single row or column of cores) is not supported when both "
+                    "input tensors are batched. Either use HEIGHT_SHARDED/WIDTH_SHARDED explicitly, use a 2D core "
+                    "grid for BLOCK_SHARDED, or ensure the second input tensor (B) has batch size 1. "
+                    "See GitHub issue #32306 for details.");
+            }
+        }
+
+        bool use_mcast_1d_in0_config =
+            is_wide or
+            (core_range.y == 0 and mem_config.is_sharded() and
+             (mem_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED or block_sharded_on_1d_row_grid));
+        bool use_mcast_1d_in1_config =
+            is_tall or
+            (core_range.y == 0 and mem_config.is_sharded() and
+             (mem_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED or block_sharded_on_1d_column_grid));
+        bool use_mcast_2d_config =
+            all_dram_interleaved or (core_range.y == 0 and mem_config.is_sharded() and
+                                     mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED and
+                                     not block_sharded_on_1d_column_grid and not block_sharded_on_1d_row_grid);
+        if (core_range.y == 1 or use_mcast_1d_in0_config) {
+            // Pass user's shard_spec when BLOCK_SHARDED on 1D row grid
+            std::optional<tt::tt_metal::ShardSpec> user_shard_spec =
+                (block_sharded_on_1d_row_grid && mem_config.shard_spec().has_value())
+                    ? std::make_optional(mem_config.shard_spec().value())
+                    : std::nullopt;
+            // fuse_batch can only be true when B has batch size 1
+            const auto& b_shape = utilities::get_matmul_tensor_padded_shape(input_tensor_b, transpose_b);
+            bool b_is_unbatched = (get_batch_size(b_shape) == 1);
+            bool fuse_batch_for_sharding = user_shard_spec.has_value() && b_is_unbatched;
+            return get_mcast_1d_config(
+                input_tensor_a,
+                input_tensor_b,
+                transpose_a,
+                transpose_b,
+                bias_single_tile_size,
+                fuse_batch_for_sharding /* fuse_batch */,
+                std::nullopt /* fused_activation */,
+                true /* mcast_in0 */,
+                false /* out_sharded */,
+                std::nullopt /* compute_with_storage_grid_size */,
+                compute_kernel_config,
+                output_dtype,
+                all_dram_interleaved,
+                user_shard_spec);
+        }
+        if (core_range.x == 1 or use_mcast_1d_in1_config) {
+            // Pass user's shard_spec when BLOCK_SHARDED on 1D column grid
+            std::optional<tt::tt_metal::ShardSpec> user_shard_spec =
+                (block_sharded_on_1d_column_grid && mem_config.shard_spec().has_value())
+                    ? std::make_optional(mem_config.shard_spec().value())
+                    : std::nullopt;
+            // fuse_batch can only be true when B has batch size 1
+            const auto& b_shape = utilities::get_matmul_tensor_padded_shape(input_tensor_b, transpose_b);
+            bool b_is_unbatched = (get_batch_size(b_shape) == 1);
+            bool fuse_batch_for_sharding = user_shard_spec.has_value() && b_is_unbatched;
+            return get_mcast_1d_config(
+                input_tensor_a,
+                input_tensor_b,
+                transpose_a,
+                transpose_b,
+                bias_single_tile_size,
+                fuse_batch_for_sharding /* fuse_batch */,
+                std::nullopt /* fused_activation */,
+                false /* mcast_in0 */,
+                false /* out_sharded */,
+                std::nullopt /* compute_with_storage_grid_size */,
+                compute_kernel_config,
+                output_dtype,
+                all_dram_interleaved,
+                user_shard_spec);
+        }
+        if ((core_range.y > 0 and num_blocks_x <= num_cores_x and num_blocks_y <= num_cores_y) or use_mcast_2d_config) {
+            bool transpose_mcast =
+                input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED &&
+                input_tensor_a.shard_spec().value().orientation == ShardOrientation::COL_MAJOR;
+            uint32_t out_block_h = per_core_M;
+            uint32_t out_block_w = per_core_N;
+            out_subblock_h = 4;
+            out_subblock_w = 2;
+            if (out_subblock_w != per_core_N) {
+                out_subblock_h = 1;
+            }
+            if (all_dram_interleaved) {
+                in0_block_w = !transpose_mcast ? (Kt % num_cores_x == 0 ? Kt / num_cores_x : 1)
+                                               : (Kt % num_cores_x == 0 ? Kt / num_cores_y : 1);
+                per_core_M = !transpose_mcast ? tt::div_up(Mt, num_cores_y) : tt::div_up(Mt, num_cores_x);
+                per_core_N = !transpose_mcast ? tt::div_up(Nt, num_cores_x) : tt::div_up(Nt, num_cores_y);
+
+                auto mutlti_dim_per_core_factor = get_multi_dim_per_core_factor(
+                    input_tensor_a,
+                    input_tensor_b,
+                    transpose_a,
+                    transpose_b,
+                    bias_single_tile_size,
+                    per_core_M,
+                    per_core_N,
+                    in0_block_w,
+                    utilities::estimate_interm_tile_size(compute_kernel_config, output_dtype),
+                    /*adjust_in0_block_w=*/true);
+                out_block_h = mutlti_dim_per_core_factor[0];
+                out_block_w = mutlti_dim_per_core_factor[1];
+                in0_block_w = mutlti_dim_per_core_factor[2];
+
+                bool fp32_dest_acc_en = get_fp32_dest_acc_en(compute_kernel_config);
+                auto subblock_hw = bmm_op_utils_qsr::get_matmul_subblock_params(
+                    out_block_h, out_block_w, false, false, fp32_dest_acc_en);
+                out_subblock_h = std::get<0>(subblock_hw);
+                out_subblock_w = std::get<1>(subblock_hw);
+            }
+            return MatmulMultiCoreReuseMultiCastProgramConfig{
+                .compute_with_storage_grid_size = {num_cores_x, num_cores_y},
+                .in0_block_w = in0_block_w,
+                .out_subblock_h = out_subblock_h,
+                .out_subblock_w = out_subblock_w,
+                .out_block_h = out_block_h,
+                .out_block_w = out_block_w,
+                .per_core_M = per_core_M,
+                .per_core_N = per_core_N,
+                .transpose_mcast = transpose_mcast,
+                .fused_activation = std::nullopt,
+                .fuse_batch = false,
+            };
+        }
+    }
+    return MatmulMultiCoreProgramConfig{};
+}
+
+}  // namespace ttnn::operations::experimental::quasar::matmul

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/config/matmul_program_config.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/config/matmul_program_config.hpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/operations/experimental/quasar/matmul/device/matmul_device_operation_types.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/config/matmul_program_config_types.hpp"
+
+namespace ttnn::operations::experimental::quasar::matmul {
+namespace bmm_op_utils_qsr {
+std::tuple<uint32_t, uint32_t> get_matmul_subblock_params(
+    uint32_t per_core_M,
+    uint32_t per_core_N,
+    bool per_core_M_equals_subblock_h_constraint,
+    bool per_core_N_equals_subblock_w_constraint,
+    bool fp32_dest_acc_en);
+}
+
+MatmulProgramConfig create_simple_matmul_program_config(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    bool transpose_a,
+    bool transpose_b,
+    uint32_t bias_single_tile_size,
+    const std::optional<const ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
+    const CoreCoord& compute_with_storage_grid_size,
+    const tt::tt_metal::MemoryConfig& mem_config,
+    tt::tt_metal::DataType output_dtype);
+
+MatmulProgramConfig get_program_config(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    bool transpose_a,
+    bool transpose_b,
+    uint32_t bias_single_tile_size,
+    const ttnn::prim::qsr::MatmulParams& attributes);
+
+}  // namespace ttnn::operations::experimental::quasar::matmul

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/config/matmul_program_config_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/config/matmul_program_config_types.hpp
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "tt-metalium/core_coord.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+
+namespace ttnn::operations::experimental::quasar::matmul {
+
+// TODO: Uplift this to support fused activation and bias
+// TODO: Uplift this to support bcast batch for in1; currently, only allows B=1
+// for in1 iff B=1 for in0 (ie. single core)
+struct MatmulMultiCoreReuseProgramConfig {
+    CoreCoord compute_with_storage_grid_size;
+    std::size_t in0_block_w{};
+    std::size_t out_subblock_h{};
+    std::size_t out_subblock_w{};
+    std::size_t per_core_M{};
+    std::size_t per_core_N{};
+    std::optional<CoreRangeSet> allowed_worker_cores = std::nullopt;
+};
+
+struct MatmulMultiCoreReuseMultiCastProgramConfig {
+    CoreCoord compute_with_storage_grid_size;
+    std::size_t in0_block_w{};
+    std::size_t out_subblock_h{};
+    std::size_t out_subblock_w{};
+    std::size_t out_block_h{};
+    std::size_t out_block_w{};
+    std::size_t per_core_M{};
+    std::size_t per_core_N{};
+    bool transpose_mcast{};
+    std::optional<ttnn::operations::unary::UnaryWithParam> fused_activation;
+    bool fuse_batch = true;
+    std::optional<CoreRangeSet> allowed_worker_cores = std::nullopt;
+};
+
+// 1D mcast matmul program config.
+//
+// When `gather_in0 == false`, `compute_with_storage_grid_size` describes the size of the
+// rectangular grid of worker cores that the multicast paths will use, anchored at (0, 0) on
+// the device, or at the bounding-box start of the active sub-device when `sub_device_id` is
+// set on the op. The 1D mcast factory targets a single bounding-box rectangle for multicast
+// and the per-core index math assumes a single contiguous row-major rectangle, so when
+// `sub_device_id` is provided the sub-device's worker cores must themselves form a single
+// rectangle. Non-rectangular sub-device grids are rejected at validate time.
+//
+// When `gather_in0 == true`, `compute_with_storage_grid_size` is ignored and the gather path
+// can run on any sub-device worker layout, including non-rectangular ones.
+struct MatmulMultiCoreReuseMultiCast1DProgramConfig {
+    CoreCoord compute_with_storage_grid_size;
+    std::size_t in0_block_w{};
+    std::size_t out_subblock_h{};
+    std::size_t out_subblock_w{};
+    std::size_t out_block_h{};
+    std::size_t out_block_w{};
+    std::size_t per_core_M{};
+    std::size_t per_core_N{};
+    bool fuse_batch{};
+    std::optional<ttnn::operations::unary::UnaryWithParam> fused_activation;
+    bool mcast_in0{};
+    bool gather_in0{};
+    CoreRangeSet hop_cores;
+    std::size_t num_global_cb_receivers{};
+    bool untilize_out{};
+    std::optional<CoreRangeSet> allowed_worker_cores = std::nullopt;
+};
+
+struct MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig {
+    std::size_t in0_block_w{};
+    std::size_t per_core_M{};
+    std::size_t per_core_N{};
+    std::optional<ttnn::operations::unary::UnaryWithParam> fused_activation;
+};
+
+struct MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig {
+    std::size_t in0_block_w{};
+    std::size_t per_core_M{};
+    std::size_t per_core_N{};
+    std::optional<ttnn::operations::unary::UnaryWithParam> fused_activation;
+};
+
+struct MatmulMultiCoreProgramConfig {
+    std::optional<CoreRangeSet> allowed_worker_cores = std::nullopt;
+};
+
+using MatmulProgramConfig = std::variant<
+    MatmulMultiCoreProgramConfig,
+    MatmulMultiCoreReuseProgramConfig,
+    MatmulMultiCoreReuseMultiCastProgramConfig,
+    MatmulMultiCoreReuseMultiCast1DProgramConfig,
+    MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig,
+    MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>;
+
+// Ensures allowed_worker_cores is populated on every config variant that supports it.
+// If allowed_worker_cores is already set, it is left unchanged.  Otherwise it is
+// synthesized from compute_with_storage_grid_size (or from the device grid for
+// MatmulMultiCoreProgramConfig).  After this call, factories can read
+// config.allowed_worker_cores.value() unconditionally.
+inline void normalize_program_config(MatmulProgramConfig& config, const CoreCoord& device_grid) {
+    auto make_crs = [](const CoreCoord& grid) {
+        return CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(grid.x - 1, grid.y - 1)));
+    };
+    std::visit(
+        [&](auto& c) {
+            using T = std::decay_t<decltype(c)>;
+            if constexpr (
+                std::is_same_v<T, MatmulMultiCoreReuseProgramConfig> ||
+                std::is_same_v<T, MatmulMultiCoreReuseMultiCastProgramConfig> ||
+                std::is_same_v<T, MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
+                if (!c.allowed_worker_cores.has_value()) {
+                    c.allowed_worker_cores = make_crs(c.compute_with_storage_grid_size);
+                }
+            } else if constexpr (std::is_same_v<T, MatmulMultiCoreProgramConfig>) {
+                if (!c.allowed_worker_cores.has_value()) {
+                    c.allowed_worker_cores = make_crs(device_grid);
+                }
+            }
+            // DRAM-sharded configs have no grid fields to normalize.
+        },
+        config);
+}
+
+}  // namespace ttnn::operations::experimental::quasar::matmul

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_program_factory.cpp
@@ -1,0 +1,249 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_program_factory.hpp"
+#include <map>
+#include <string>
+#include "ttnn/operations/compute_throttle_utils.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+using namespace tt;
+using namespace tt::constants;
+using tt::tt_metal::CBDescriptor;
+using tt::tt_metal::CBFormatDescriptor;
+using tt::tt_metal::ComputeConfigDescriptor;
+using tt::tt_metal::KernelDescriptor;
+using tt::tt_metal::ProgramDescriptor;
+using tt::tt_metal::ReaderConfigDescriptor;
+using tt::tt_metal::WriterConfigDescriptor;
+
+namespace ttnn::prim::qsr {
+
+ProgramDescriptor MatmulMultiCoreProgramFactory::create_descriptor(
+    const ttnn::prim::qsr::MatmulParams& operation_attributes,
+    const ttnn::prim::qsr::MatmulInputs& tensor_args,
+    std::vector<ttnn::Tensor>& tensor_return_value,
+    const std::optional<CoreRangeSet>& /*core_range_set*/) {
+    if (!tensor_args.optional_input_tensors.empty()) {
+        TT_FATAL(!tensor_args.optional_input_tensors[0].has_value(), "Bias is not supported for matmul multi core");
+    }
+
+    const auto& a = tensor_args.input_tensors.at(0).mesh_tensor();
+    const auto& b = tensor_args.input_tensors.at(1).mesh_tensor();
+    const auto& output = tensor_return_value.at(0).mesh_tensor();
+
+    TT_FATAL(operation_attributes.bcast_batch.has_value(), "Error: bcast_batch field should have been populated");
+    bool bcast_batch = operation_attributes.bcast_batch.value();
+
+    const auto& ashape = a.padded_shape();
+    const auto& bshape = b.padded_shape();
+
+    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());
+    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(b.dtype());
+    tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
+    uint32_t in0_single_tile_size = tt::tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = tt::tile_size(in1_data_format);
+    uint32_t output_single_tile_size = tt::tile_size(output_data_format);
+
+    tt::tt_metal::IDevice* device = &a.mutable_device();
+    TT_FATAL(operation_attributes.compute_kernel_config.has_value(), "Compute kernel config should have been provided");
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config.value());
+    (void)packer_l1_acc;
+
+    const auto& cshape = output.padded_shape();  // C=A*B, N1MK*11KN->N1MN
+
+    TT_FATAL(
+        operation_attributes.program_config.has_value(),
+        "program_config must be provided for MatmulMultiCoreProgramFactory");
+    auto pc = std::get<operations::experimental::quasar::matmul::MatmulMultiCoreProgramConfig>(
+        operation_attributes.program_config.value());
+    if (!pc.allowed_worker_cores.has_value()) {
+        log_warning(
+            tt::LogOp,
+            "MatmulMultiCoreProgramFactory: program_config.allowed_worker_cores not populated; auto-populating "
+            "from device compute_with_storage_grid_size. Callers that bypass ttnn::prim::qsr::matmul() should invoke "
+            "ttnn::operations::experimental::quasar::matmul::normalize_program_config() on the program config first. "
+            "This will become "
+            "a hard error in a future release.");
+        auto device_grid = device->compute_with_storage_grid_size();
+        pc.allowed_worker_cores =
+            CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(device_grid.x - 1, device_grid.y - 1)));
+    }
+    auto compute_with_storage_grid_size = pc.allowed_worker_cores.value().bounding_box().grid_size();
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    uint32_t c_batch_size = get_batch_size(cshape);
+    auto num_output_tiles_total = c_batch_size * cshape[-2] * cshape[-1] / TILE_HW;
+    auto
+        [num_cores,
+         all_cores,
+         core_group_1,
+         core_group_2,
+         num_output_tiles_per_core_group_1,
+         num_output_tiles_per_core_group_2] =
+            tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_output_tiles_total);
+
+    // C = A*B*...
+    // MN = MK*KN
+    uint32_t B = get_batch_size(ashape);
+    uint32_t Mt = ashape[-2] / TILE_HEIGHT;
+    uint32_t Kt = ashape[-1] / TILE_WIDTH;
+    uint32_t Nt = bshape[-1] / TILE_WIDTH;
+    uint32_t KtNt = Kt * Nt;
+    uint32_t MtKt = Mt * Kt;
+    uint32_t MtNt = Mt * Nt;
+
+    ProgramDescriptor desc;
+
+    // Circular buffers
+    uint32_t num_input_tiles = 2;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * in0_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = 0,
+            .data_format = in0_data_format,
+            .page_size = in0_single_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * in1_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = 1,
+            .data_format = in1_data_format,
+            .page_size = in1_single_tile_size,
+        }}},
+    });
+    uint32_t output_cb_index = tt::CBIndex::c_16;
+    uint32_t num_output_tiles = 2;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_output_tiles * output_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = output_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
+
+    // Reader kernel
+    uint32_t last_ktile_w = a.logical_shape()[-1] % TILE_WIDTH;
+    uint32_t last_ktile_h = 0;
+    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)last_ktile_w, (uint32_t)last_ktile_h};
+    tt::tt_metal::TensorAccessorArgs(a).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(b).append_to(reader_compile_time_args);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+        "reader_bmm_8bank_output_tiles_partitioned.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = reader_compile_time_args;
+    reader_desc.named_compile_time_args = {{"cb_in0", tt::CBIndex::c_0}, {"cb_in1", tt::CBIndex::c_1}};
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    // Writer kernel
+    std::vector<uint32_t> writer_compile_time_args = {};
+    tt::tt_metal::TensorAccessorArgs(output).append_to(writer_compile_time_args);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+        "writer_unary_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = writer_compile_time_args;
+    writer_desc.named_compile_time_args = {{"cb_out", output_cb_index}};
+    writer_desc.config = WriterConfigDescriptor{};
+
+    // Per-core runtime args for reader and writer
+    for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+        uint32_t num_output_tiles_per_core = 0;
+        if (core_group_1.contains(core)) {
+            num_output_tiles_per_core = num_output_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_output_tiles_per_core = num_output_tiles_per_core_group_2;
+        } else {
+            TT_THROW("Core not in specified core ranges");
+        }
+        reader_desc.emplace_runtime_args(
+            core,
+            {a,
+             b,
+             Mt,
+             Kt,
+             Nt,
+             MtKt,
+             KtNt,
+             B,
+             uint32_t(bcast_batch),
+             num_tiles_written,
+             num_output_tiles_per_core,
+             MtNt});
+        writer_desc.emplace_runtime_args(core, {output, num_output_tiles_per_core, num_tiles_written});
+        num_tiles_written += num_output_tiles_per_core;
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    const auto throttle_level = ttnn::get_throttle_level(operation_attributes.compute_kernel_config);
+    std::map<std::string, std::string> mm_kernel_defines;
+    ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
+        device->arch(), num_cores, mm_kernel_defines);
+    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
+        device->arch(), num_cores, mm_kernel_defines, throttle_level);
+
+    // Compute kernel(s) — one per core group with different tile counts
+    // bmm compute kernel: B, Mt, Nt are just 3 for loops that act as 1 large loop,
+    // so only set Nt for simplicity
+    std::vector<uint32_t> compute_args_group_1 = {1, 1, Kt, num_output_tiles_per_core_group_1};
+
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source = "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm.cpp";
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = compute_args_group_1;
+    compute_desc_1.named_compile_time_args = {
+        {"cb_in0", tt::CBIndex::c_0}, {"cb_in1", tt::CBIndex::c_1}, {"cb_out", tt::CBIndex::c_16}};
+    compute_desc_1.defines = {mm_kernel_defines.begin(), mm_kernel_defines.end()};
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .math_approx_mode = math_approx_mode};
+    desc.kernels.push_back(std::move(compute_desc_1));
+
+    if (!core_group_2.ranges().empty()) {
+        std::vector<uint32_t> compute_args_group_2 = {1, 1, Kt, num_output_tiles_per_core_group_2};
+
+        KernelDescriptor compute_desc_2;
+        compute_desc_2.kernel_source =
+            "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm.cpp";
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = compute_args_group_2;
+        compute_desc_2.named_compile_time_args = {
+            {"cb_in0", tt::CBIndex::c_0}, {"cb_in1", tt::CBIndex::c_1}, {"cb_out", tt::CBIndex::c_16}};
+        compute_desc_2.defines = {mm_kernel_defines.begin(), mm_kernel_defines.end()};
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .math_approx_mode = math_approx_mode};
+        desc.kernels.push_back(std::move(compute_desc_2));
+    }
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_program_factory.hpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/matmul_device_operation_types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace ttnn::prim::qsr {
+
+struct MatmulMultiCoreProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const ttnn::prim::qsr::MatmulParams& operation_attributes,
+        const ttnn::prim::qsr::MatmulInputs& tensor_args,
+        std::vector<ttnn::Tensor>& tensor_return_value,
+        const std::optional<CoreRangeSet>& core_range_set = std::nullopt);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
@@ -1,0 +1,720 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/utilities/matmul_utilities.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/config/matmul_program_config.hpp"
+
+#include <algorithm>
+#include <map>
+#include <set>
+#include <utility>
+
+#include "hostdevcommon/common_values.hpp"
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/work_split.hpp>
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+#include "ttnn/operations/compute_throttle_utils.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/tensor/shape/shape.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/shared_with_host/activation_type.hpp"
+
+using namespace tt;
+
+using ttnn::operations::unary::UnaryOpType;
+using ttnn::operations::unary::UnaryWithParam;
+
+using tt::tt_metal::CBDescriptor;
+using tt::tt_metal::CBFormatDescriptor;
+using tt::tt_metal::ComputeConfigDescriptor;
+using tt::tt_metal::DataMovementConfigDescriptor;
+using tt::tt_metal::KernelDescriptor;
+using tt::tt_metal::ProgramDescriptor;
+
+namespace ttnn::prim::qsr {
+namespace reuse_batched_hs_dram_sharded_optimized_helpers {
+
+using dram_sharded_helpers::get_max_page_size_and_num_pages;
+using dram_sharded_helpers::get_optimal_dram_bank_to_reader_assignment;
+
+// Batch-sharded DRAM matmul
+// For batched matmul: [1, B, M, K] x [1, B, K, N] = [1, B, M, N]
+// Sharded by batch dimension - each worker handles B/num_workers complete matmuls
+// ProgramDescriptor variant: translates the same logic as create_program_batch_sharded
+// into a lightweight ProgramDescriptor (no Program object created).
+static ProgramDescriptor create_program_batch_sharded_descriptor(
+    tt::tt_metal::IDevice* device,
+    const CoreRangeSet& input_all_storage_cores,
+    const CoreRangeSet& output_all_storage_cores,
+    MathFidelity math_fidelity,
+    bool fp32_dest_acc_en,
+    bool math_approx_mode,
+    bool packer_l1_acc,
+    bool dst_full_sync_en,
+    ttnn::operations::compute_throttle_utils::ThrottleLevel throttle_level,
+    uint32_t B,
+    uint32_t /* M */,
+    uint32_t K,
+    uint32_t /* N */,
+    uint32_t in0_block_w,
+    uint32_t per_core_M,
+    uint32_t per_core_N,
+    std::optional<UnaryWithParam> fused_activation,
+    const tt_metal::MeshTensor& in0_tensor,
+    const tt_metal::MeshTensor& in1_tensor,
+    ttsl::optional_reference<const tt_metal::MeshTensor> bias_tensor,
+    const tt_metal::MeshTensor& out_tensor,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const tt::tt_metal::Tile& bias_tile,
+    const tt::tt_metal::Tile& output_tile,
+    tt::DataFormat in0_data_format,
+    tt::DataFormat in1_data_format,
+    tt::DataFormat bias_data_format,
+    tt::DataFormat output_data_format,
+    bool untilize_out,
+    bool skip_compute,
+    bool skip_write_back) {
+    tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+
+    std::vector<CoreCoord> all_worker_cores_ordered;
+    CoreRangeSet all_worker_cores;
+    get_optimal_dram_bank_to_reader_assignment(device, all_worker_cores_ordered, all_worker_cores, in1_noc);
+
+    // Input / output storage core ordering
+    std::vector<CoreCoord> input_storage_cores_ordered =
+        corerange_to_cores(input_all_storage_cores, std::nullopt, true);
+    std::vector<CoreCoord> output_storage_cores_ordered =
+        corerange_to_cores(output_all_storage_cores, std::nullopt, true);
+
+    uint32_t num_workers = all_worker_cores_ordered.size();
+    TT_FATAL(
+        input_storage_cores_ordered.size() == num_workers,
+        "Input storage cores ({}) must match number of workers/DRAM banks ({})",
+        input_storage_cores_ordered.size(),
+        num_workers);
+    TT_FATAL(
+        output_storage_cores_ordered.size() == num_workers,
+        "Output storage cores ({}) must match number of workers/DRAM banks ({})",
+        output_storage_cores_ordered.size(),
+        num_workers);
+    for (uint32_t i = 0; i < num_workers; ++i) {
+        TT_FATAL(
+            input_storage_cores_ordered[i] == all_worker_cores_ordered[i],
+            "Input storage core ordering mismatch at index {}",
+            i);
+        TT_FATAL(
+            output_storage_cores_ordered[i] == all_worker_cores_ordered[i],
+            "Output storage core ordering mismatch at index {}",
+            i);
+    }
+
+    // NOC coordinate vectors for storage cores
+    std::vector<uint32_t> input_storage_noc_x, input_storage_noc_y;
+    std::vector<uint32_t> output_storage_noc_x, output_storage_noc_y;
+    for (const auto& core : input_storage_cores_ordered) {
+        auto phys_core = device->worker_core_from_logical_core(core);
+        input_storage_noc_x.push_back(phys_core.x);
+        input_storage_noc_y.push_back(phys_core.y);
+    }
+    for (const auto& core : output_storage_cores_ordered) {
+        auto phys_core = device->worker_core_from_logical_core(core);
+        output_storage_noc_x.push_back(phys_core.x);
+        output_storage_noc_y.push_back(phys_core.y);
+    }
+
+    // Bounding box of all cores (workers + storage)
+    std::set<CoreRange> all_cores_set;
+    for (const auto& core : all_worker_cores_ordered) {
+        all_cores_set.insert(CoreRange(core));
+    }
+    for (const auto& core : input_storage_cores_ordered) {
+        all_cores_set.insert(CoreRange(core));
+    }
+    for (const auto& core : output_storage_cores_ordered) {
+        all_cores_set.insert(CoreRange(core));
+    }
+    CoreRangeSet all_cores(all_cores_set);
+    CoreRange bounding_box = all_cores.bounding_box();
+    CoreRangeSet all_cores_in_rect_grid({bounding_box});
+
+    uint32_t num_cores = num_workers;
+    uint32_t num_dram_banks = device->num_dram_channels();
+    uint32_t batches_per_core = (B + num_cores - 1) / num_cores;
+
+    TT_FATAL(
+        num_cores <= num_dram_banks,
+        "Number of worker cores ({}) cannot exceed number of DRAM banks ({})",
+        num_cores,
+        num_dram_banks);
+
+    // Subblock parameters
+    auto subblock_hw = operations::experimental::quasar::matmul::bmm_op_utils_qsr::get_matmul_subblock_params(
+        per_core_M, per_core_N, false, false, fp32_dest_acc_en);
+    auto out_subblock_h = std::get<0>(subblock_hw);
+    auto out_subblock_w = std::get<1>(subblock_hw);
+
+    uint32_t num_blocks = K / in0_block_w;
+    bool packer_l1_acc_en = packer_l1_acc && num_blocks > 1;
+
+    tt::DataFormat interm0_data_format = packer_l1_acc_en
+                                             ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)
+                                             : (fp32_dest_acc_en ? tt::DataFormat::Float32 : output_data_format);
+
+    // Tile sizes
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    uint32_t bias_single_tile_size = bias_tile.get_tile_size(bias_data_format);
+    uint32_t output_single_tile_size = output_tile.get_tile_size(output_data_format);
+    uint32_t interm0_single_tile_size = output_tile.get_tile_size(interm0_data_format);
+
+    // CB sizes
+    uint32_t in0_block_tiles = per_core_M * in0_block_w;
+    uint32_t in0_CB_tiles = in0_block_tiles * 2;
+    uint32_t in0_CB_size = in0_CB_tiles * in0_single_tile_size;
+
+    uint32_t in1_block_tiles = in0_block_w * per_core_N;
+    uint32_t in1_CB_tiles = in1_block_tiles * 3;
+    uint32_t in1_CB_size = in1_CB_tiles * in1_single_tile_size;
+
+    uint32_t out_block_tiles = per_core_M * per_core_N;
+    uint32_t interm0_CB_size = out_block_tiles * interm0_single_tile_size;
+
+    uint32_t in0_shard_tiles = in0_tensor.shard_spec()->shape[0] / in0_tile.get_tile_shape()[0] *
+                               in0_tensor.shard_spec()->shape[1] / in0_tile.get_tile_shape()[1];
+    uint32_t in2_CB_size = in0_shard_tiles * in0_single_tile_size;
+
+    uint32_t in3_block_tiles = per_core_N;
+    uint32_t in3_CB_size = in3_block_tiles * bias_single_tile_size;
+
+    uint32_t out_shard_tiles = out_tensor.shard_spec()->shape[0] / output_tile.get_tile_shape()[0] *
+                               out_tensor.shard_spec()->shape[1] / output_tile.get_tile_shape()[1];
+    uint32_t out_reshard_CB_size = out_shard_tiles * output_single_tile_size;
+
+    // Page sizes for DRAM reads
+    uint32_t in1_buffer_page_size, in1_buffer_num_pages;
+    get_max_page_size_and_num_pages(
+        device, in1_block_tiles, in1_single_tile_size, in1_buffer_page_size, in1_buffer_num_pages);
+
+    uint32_t bias_buffer_page_size, bias_buffer_num_pages;
+    get_max_page_size_and_num_pages(
+        device, in3_block_tiles, bias_single_tile_size, bias_buffer_page_size, bias_buffer_num_pages);
+
+    // Tensor stride calculations
+    uint32_t in0_batch_stride_bytes = per_core_M * K * in0_single_tile_size;
+    uint32_t in1_batch_stride_bytes = K * per_core_N * in1_single_tile_size;
+    uint32_t out_batch_stride_bytes = per_core_M * per_core_N * output_single_tile_size;
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Build CBDescriptors
+    ////////////////////////////////////////////////////////////////////////////
+    ProgramDescriptor desc;
+
+    tt::tt_metal::TileDescriptor in0_tile_desc{in0_tile};
+    tt::tt_metal::TileDescriptor in1_tile_desc{in1_tile};
+    tt::tt_metal::TileDescriptor bias_tile_desc{bias_tile};
+    tt::tt_metal::TileDescriptor output_tile_desc{output_tile};
+
+    // CB 0: in0 (activations) - on all cores in bounding box
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in0_CB_size;
+        cb_desc.core_ranges = all_cores_in_rect_grid;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_0,
+            .data_format = in0_data_format,
+            .page_size = in0_single_tile_size,
+            .tile = in0_tile_desc});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 1: in1 (weights) - on all cores in bounding box
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in1_CB_size;
+        cb_desc.core_ranges = all_cores_in_rect_grid;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_1,
+            .data_format = in1_data_format,
+            .page_size = in1_single_tile_size,
+            .tile = in1_tile_desc});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 2: sharded in0 buffer - on INPUT storage cores, backed by in0_buffer
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in2_CB_size;
+        cb_desc.core_ranges = input_all_storage_cores;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_2,
+            .data_format = in0_data_format,
+            .page_size = in0_single_tile_size,
+            .tile = in0_tile_desc});
+        cb_desc.tensor = &in0_tensor;
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 3: bias (if fused) - on all cores in bounding box
+    if (bias_tensor.has_value()) {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in3_CB_size;
+        cb_desc.core_ranges = all_cores_in_rect_grid;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_3,
+            .data_format = bias_data_format,
+            .page_size = bias_single_tile_size,
+            .tile = bias_tile_desc});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 4 & 5: output and intermediate - on worker cores
+    uint32_t output_cb_index = tt::CBIndex::c_4;
+    uint32_t interm0_cb_index = tt::CBIndex::c_5;
+    if (interm0_data_format != output_data_format) {
+        // Separate CBs for output and intermediate
+        {
+            CBDescriptor cb_desc;
+            cb_desc.total_size = out_reshard_CB_size;
+            cb_desc.core_ranges = all_worker_cores;
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = output_cb_index,
+                .data_format = output_data_format,
+                .page_size = output_single_tile_size,
+                .tile = output_tile_desc});
+            desc.cbs.push_back(std::move(cb_desc));
+        }
+        {
+            CBDescriptor cb_desc;
+            cb_desc.total_size = interm0_CB_size;
+            cb_desc.core_ranges = all_worker_cores;
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = interm0_cb_index,
+                .data_format = interm0_data_format,
+                .page_size = interm0_single_tile_size,
+                .tile = output_tile_desc});
+            desc.cbs.push_back(std::move(cb_desc));
+        }
+    } else {
+        // Output and intermediate share the same buffer
+        CBDescriptor cb_desc;
+        cb_desc.total_size = out_reshard_CB_size;
+        cb_desc.core_ranges = all_worker_cores;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = output_data_format,
+            .page_size = output_single_tile_size,
+            .tile = output_tile_desc});
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = interm0_cb_index,
+            .data_format = interm0_data_format,
+            .page_size = interm0_single_tile_size,
+            .tile = output_tile_desc});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 6: output reshard buffer - on OUTPUT storage cores, backed by out_buffer
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = out_reshard_CB_size;
+        cb_desc.core_ranges = output_all_storage_cores;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_6,
+            .data_format = output_data_format,
+            .page_size = output_single_tile_size,
+            .tile = output_tile_desc});
+        cb_desc.tensor = &out_tensor;
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Kernel defines
+    ////////////////////////////////////////////////////////////////////////////
+    std::map<std::string, std::string> mm_kernel_defines;
+    std::map<std::string, std::string> reader_defines;
+    std::map<std::string, std::string> writer_defines;
+
+    if (bias_tensor.has_value()) {
+        mm_kernel_defines["FUSE_BIAS"] = "1";
+        writer_defines["FUSE_BIAS"] = "1";
+    }
+    if (fused_activation.has_value()) {
+        if (fused_activation.value().op_type == UnaryOpType::RELU) {
+            mm_kernel_defines["PACK_RELU"] = "1";
+        } else {
+            mm_kernel_defines["SFPU_ACTIVATION"] = "1";
+        }
+    }
+    if (packer_l1_acc_en) {
+        mm_kernel_defines["PACKER_L1_ACC"] = "1";
+    }
+    if (fp32_dest_acc_en) {
+        mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    if (skip_compute) {
+        mm_kernel_defines["SKIP_COMPUTE"] = "1";
+    }
+    if (skip_write_back) {
+        writer_defines["SKIP_WRITE_BACK"] = "1";
+    }
+    mm_kernel_defines["MATMUL_DRAM_SHARDED"] = "1";
+
+    ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
+        device->arch(), num_cores, mm_kernel_defines);
+    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
+        device->arch(), num_cores, mm_kernel_defines, throttle_level);
+
+    // Helper to convert std::map defines to KernelDescriptor::Defines
+    auto map_to_defines = [](const std::map<std::string, std::string>& m) -> KernelDescriptor::Defines {
+        KernelDescriptor::Defines result;
+        result.reserve(m.size());
+        for (const auto& [k, v] : m) {
+            result.emplace_back(k, v);
+        }
+        return result;
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Compile-time args
+    ////////////////////////////////////////////////////////////////////////////
+    std::vector<uint32_t> in0_reader_compile_args = {
+        (uint32_t)in0_block_tiles,
+        (uint32_t)in0_block_tiles * in0_single_tile_size,
+        (uint32_t)num_blocks,
+        (uint32_t)batches_per_core,
+        (uint32_t)in0_batch_stride_bytes,
+        (uint32_t)in2_CB_size,
+    };
+
+    std::vector<uint32_t> in1_writer_compile_args = {
+        (uint32_t)in1_buffer_page_size,
+        (uint32_t)in1_buffer_num_pages,
+        (uint32_t)per_core_N,
+        (uint32_t)in1_block_tiles,
+        (uint32_t)num_blocks,
+        (uint32_t)out_block_tiles,
+        (uint32_t)batches_per_core,
+        (uint32_t)in1_batch_stride_bytes,
+        (uint32_t)out_batch_stride_bytes,
+        (uint32_t)out_reshard_CB_size,
+    };
+    if (bias_tensor.has_value()) {
+        in1_writer_compile_args.push_back(bias_buffer_page_size);
+        in1_writer_compile_args.push_back(bias_buffer_num_pages);
+        in1_writer_compile_args.push_back(in3_block_tiles);
+    }
+
+    uint32_t in0_num_subblocks = per_core_M / out_subblock_h;
+    uint32_t in1_num_subblocks = per_core_N / out_subblock_w;
+    uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
+    uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
+
+    std::vector<uint32_t> compute_kernel_args = {
+        in0_block_w,
+        in0_num_subblocks,
+        in0_block_tiles,
+        in0_subblock_num_tiles,
+        in1_num_subblocks,
+        in1_block_tiles,
+        per_core_N,
+        num_blocks,
+        1,
+        1,
+        out_subblock_h,
+        out_subblock_w,
+        out_subblock_num_tiles,
+        batches_per_core,
+        out_block_tiles,
+        untilize_out ? 1u : 0u,
+        0u,
+        0u,
+    };
+    if (bias_tensor.has_value()) {
+        compute_kernel_args.push_back(1u);  // row_broadcast_bias: DRAM sharded always uses row broadcast
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Build Kernel Descriptors
+    ////////////////////////////////////////////////////////////////////////////
+    tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+
+    writer_defines["OUT_SHARDED"] = "1";
+
+    // in0 reader kernel
+    KernelDescriptor in0_reader_kernel_desc;
+    in0_reader_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+        "reader_bmm_tile_layout_in0_sender_dram_sharded_height.cpp";
+    in0_reader_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    in0_reader_kernel_desc.core_ranges = all_cores_in_rect_grid;
+    in0_reader_kernel_desc.compile_time_args = in0_reader_compile_args;
+    in0_reader_kernel_desc.defines = map_to_defines(reader_defines);
+    in0_reader_kernel_desc.named_compile_time_args = {
+        {"cb_in0", tt::CBIndex::c_0},
+    };
+    in0_reader_kernel_desc.config =
+        DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = in0_noc};
+
+    // in1 writer kernel
+    KernelDescriptor in1_writer_kernel_desc;
+    in1_writer_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+        "reader_bmm_tile_layout_in1_sender_dram_sharded_height.cpp";
+    in1_writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    in1_writer_kernel_desc.core_ranges = all_cores_in_rect_grid;
+    in1_writer_kernel_desc.compile_time_args = in1_writer_compile_args;
+    in1_writer_kernel_desc.defines = map_to_defines(writer_defines);
+    in1_writer_kernel_desc.named_compile_time_args = {
+        {"cb_in1", tt::CBIndex::c_1},
+        {"cb_bias", tt::CBIndex::c_3},
+        {"cb_out", tt::CBIndex::c_4},
+    };
+    in1_writer_kernel_desc.config =
+        DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = in1_noc};
+
+    // compute kernel
+    KernelDescriptor compute_kernel_desc;
+    compute_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/"
+        "bmm_large_block_zm_fused_bias_activation.cpp";
+    compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_kernel_desc.core_ranges = all_cores_in_rect_grid;
+    compute_kernel_desc.compile_time_args = compute_kernel_args;
+    compute_kernel_desc.defines = map_to_defines(mm_kernel_defines);
+    {
+        KernelDescriptor::NamedCompileTimeArgs named_compile_args = {
+            {"cb_in0", tt::CBIndex::c_0},
+            {"cb_in1", tt::CBIndex::c_1},
+            {"cb_bias", tt::CBIndex::c_3},
+            {"cb_out", tt::CBIndex::c_4},
+            {"cb_intermed0", tt::CBIndex::c_5},
+            {"cb_in0_intermediate", tt::CBIndex::c_8},
+            {"cb_in1_intermediate", tt::CBIndex::c_9},
+            {"cb_in0_transposed", tt::CBIndex::c_10},
+            {"bias_ntiles", per_core_N},
+            // This factory does not pad per_core_N_compute beyond per_core_N_in1_sender, so the
+            // last subblock is always fully valid. Pass out_subblock_w so the compute kernel takes
+            // its original full-width path (last_subblock_padded == false).
+            {"last_subblock_w_valid", out_subblock_w},
+        };
+        if (fused_activation.has_value() && fused_activation.value().op_type != UnaryOpType::RELU) {
+            using ttnn::operations::experimental::quasar::matmul::utilities::get_activation_params;
+            const auto params = get_activation_params(fused_activation.value());
+            named_compile_args.push_back({"activation_type", static_cast<uint32_t>(params.type)});
+            named_compile_args.push_back({"activation_param0", params.param0});
+            named_compile_args.push_back({"activation_param1", params.param1});
+            named_compile_args.push_back({"activation_param2", params.param2});
+        }
+        compute_kernel_desc.named_compile_time_args = std::move(named_compile_args);
+    }
+    compute_kernel_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .math_approx_mode = math_approx_mode};
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Runtime Args (per-core loop)
+    ////////////////////////////////////////////////////////////////////////////
+    std::vector<CoreCoord> all_cores_in_rect_grid_vec = corerange_to_cores(all_cores_in_rect_grid);
+    std::set<CoreCoord> worker_cores_set(all_worker_cores_ordered.begin(), all_worker_cores_ordered.end());
+
+    std::vector<uint32_t> bank_ids;
+
+    // Idle cores in the bounding box
+    for (const auto& core : all_cores_in_rect_grid_vec) {
+        bool is_worker = worker_cores_set.contains(core);
+
+        if (!is_worker) {
+            std::vector<uint32_t> in0_idle_args = {0u};
+            in0_reader_kernel_desc.runtime_args.emplace_back(core, in0_idle_args);
+
+            std::vector<uint32_t> in1_idle_args = {0u};
+            in1_writer_kernel_desc.runtime_args.emplace_back(core, in1_idle_args);
+
+            std::vector<uint32_t> compute_idle_args = {0u};
+            compute_kernel_desc.runtime_args.emplace_back(core, compute_idle_args);
+        }
+    }
+
+    // Worker cores
+    for (uint32_t worker_idx = 0; worker_idx < all_worker_cores_ordered.size(); ++worker_idx) {
+        auto core = all_worker_cores_ordered[worker_idx];
+
+        uint32_t bank_id = worker_idx;
+        uint32_t vc = bank_id & 0x3;
+        bank_ids.push_back(bank_id);
+        for (uint32_t j = 0; j < worker_idx; ++j) {
+            auto core_prev = all_worker_cores_ordered[j];
+            if (core_prev.y == core.y && ((bank_id & 0x3) == (bank_ids[j] & 0x3))) {
+                vc = (vc + 1) & 0x3;
+                break;
+            }
+        }
+
+        // in0 reader runtime args
+        KernelDescriptor::RTArgList in0_reader_args;
+        in0_reader_args.push_back(uint32_t{1u});
+        in0_reader_args.push_back(uint32_t{input_storage_noc_x[worker_idx]});
+        in0_reader_args.push_back(uint32_t{input_storage_noc_y[worker_idx]});
+        in0_reader_args.push_back(in0_tensor);
+        in0_reader_kernel_desc.emplace_runtime_args(core, in0_reader_args);
+
+        // in1 writer runtime args
+        KernelDescriptor::RTArgList in1_writer_args;
+        in1_writer_args.push_back(uint32_t{1u});
+        in1_writer_args.push_back(in1_tensor);
+        if (bias_tensor.has_value()) {
+            in1_writer_args.push_back(*bias_tensor);
+        } else {
+            in1_writer_args.push_back(uint32_t{0u});
+        }
+        in1_writer_args.push_back(uint32_t{bank_id});
+        in1_writer_args.push_back(uint32_t{vc});
+        in1_writer_args.push_back(uint32_t{output_storage_noc_x[worker_idx]});
+        in1_writer_args.push_back(uint32_t{output_storage_noc_y[worker_idx]});
+        in1_writer_args.push_back(out_tensor);
+        in1_writer_kernel_desc.emplace_runtime_args(core, in1_writer_args);
+
+        // Compute runtime args
+        std::vector<uint32_t> compute_runtime_args = {
+            1u,
+        };
+        compute_kernel_desc.runtime_args.emplace_back(core, compute_runtime_args);
+    }
+
+    // Push all kernel descriptors
+    desc.kernels.push_back(std::move(in0_reader_kernel_desc));
+    desc.kernels.push_back(std::move(in1_writer_kernel_desc));
+    desc.kernels.push_back(std::move(compute_kernel_desc));
+
+    return desc;
+}
+
+}  // namespace reuse_batched_hs_dram_sharded_optimized_helpers
+
+ProgramDescriptor MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory::create_descriptor(
+    const ttnn::prim::qsr::MatmulParams& operation_attributes,
+    const ttnn::prim::qsr::MatmulInputs& tensor_args,
+    std::vector<ttnn::Tensor>& tensor_return_value,
+    const std::optional<CoreRangeSet>& /*core_range_set*/) {
+    const auto& input_tensors = tensor_args.input_tensors;
+    const auto& optional_input_tensors = tensor_args.optional_input_tensors;
+    const auto& output_tensors = tensor_return_value;
+
+    const auto& a = input_tensors.at(0).mesh_tensor();
+    const auto& b = input_tensors.at(1).mesh_tensor();
+    auto bias = tt::tt_metal::as_optional_mesh_tensor(optional_input_tensors.at(0));
+    const auto& output = output_tensors.at(0).mesh_tensor();
+    const auto& ashape = a.padded_shape();
+    const auto& bshape = b.padded_shape();
+    auto in0_tile = a.tensor_spec().tile();
+    auto in1_tile = b.tensor_spec().tile();
+    auto in0_tile_shape = in0_tile.get_tile_shape();
+    auto in1_tile_shape = in1_tile.get_tile_shape();
+    auto output_tile = tt::tt_metal::Tile({in0_tile.get_tile_shape()[0], in1_tile.get_tile_shape()[1]});
+
+    // CB dataformats
+    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());
+    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(b.dtype());
+    tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
+
+    tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;
+    if (bias.has_value()) {
+        const auto& c = bias.value();
+        TT_FATAL(&a.device() == &c.device(), "Operands to matmul need to be on the same device!");
+        bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
+    }
+
+    tt::tt_metal::IDevice* device = &a.mutable_device();
+
+    TT_FATAL(
+        a.shard_spec().has_value() && output.shard_spec().has_value(), "Both input A and output must have shard specs");
+    CoreRangeSet input_all_cores_storage = a.shard_spec().value().grid;
+    CoreRangeSet output_all_cores_storage = output.shard_spec().value().grid;
+
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(tt_metal::datatype_to_dataformat_converter(a.dtype()));
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(tt_metal::datatype_to_dataformat_converter(b.dtype()));
+
+    TT_FATAL(
+        a.mesh_buffer().device_local_size() % in0_single_tile_size == 0,
+        "Input A buffer size ({}) must be divisible by single tile size ({})",
+        a.mesh_buffer().device_local_size(),
+        in0_single_tile_size);
+    TT_FATAL(
+        b.mesh_buffer().device_local_size() % in1_single_tile_size == 0,
+        "Input B buffer size ({}) must be divisible by single tile size ({})",
+        b.mesh_buffer().device_local_size(),
+        in1_single_tile_size);
+
+    TT_FATAL(
+        ashape[-1] == bshape[-2],
+        "Dimension K (A.shape[-1] = {}, B.shape[-2] = {}) must match for matmul",
+        ashape[-1],
+        bshape[-2]);
+    TT_FATAL(ashape[-2] % in0_tile_shape[0] == 0, "A.shape[-2] must be divisible by tile shape[0]");
+    TT_FATAL(ashape[-1] % in0_tile_shape[1] == 0, "A.shape[-1] must be divisible by tile shape[1]");
+    TT_FATAL(bshape[-2] % in1_tile_shape[0] == 0, "B.shape[-2] must be divisible by tile shape[0]");
+    TT_FATAL(bshape[-1] % in1_tile_shape[1] == 0, "B.shape[-1] must be divisible by tile shape[1]");
+
+    const auto& compute_kernel_config = operation_attributes.compute_kernel_config.value();
+    const auto& program_config = std::get<
+        operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>(
+        operation_attributes.program_config.value());
+    const auto& in0_block_w = program_config.in0_block_w;
+    const auto& per_core_M = program_config.per_core_M;
+    const auto& per_core_N = program_config.per_core_N;
+    const auto& fused_activation = program_config.fused_activation;
+    const auto& untilize_out = operation_attributes.untilize_out;
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), compute_kernel_config);
+
+    uint32_t B = ashape[1];
+    uint32_t M = ashape[-2] / in0_tile_shape[0];
+    uint32_t K = ashape[-1] / in0_tile_shape[1];
+    uint32_t N = bshape[-1] / in1_tile_shape[1];
+
+    TT_FATAL(per_core_M == M, "For batch sharding, per_core_M ({}) must equal M ({})", per_core_M, M);
+    TT_FATAL(per_core_N == N, "For batch sharding, per_core_N ({}) must equal N ({})", per_core_N, N);
+    TT_FATAL(K % in0_block_w == 0, "K ({}) must be divisible by in0_block_w ({})", K, in0_block_w);
+
+    return reuse_batched_hs_dram_sharded_optimized_helpers::create_program_batch_sharded_descriptor(
+        device,
+        input_all_cores_storage,
+        output_all_cores_storage,
+        math_fidelity,
+        fp32_dest_acc_en,
+        math_approx_mode,
+        packer_l1_acc,
+        dst_full_sync_en,
+        ttnn::get_throttle_level(operation_attributes.compute_kernel_config),
+        B,
+        M,
+        K,
+        N,
+        in0_block_w,
+        per_core_M,
+        per_core_N,
+        fused_activation,
+        a,
+        b,
+        bias,
+        output,
+        in0_tile,
+        in1_tile,
+        bias.has_value() ? bias->tensor_spec().tile() : output_tile,
+        output_tile,
+        in0_data_format,
+        in1_data_format,
+        bias_data_format,
+        output_data_format,
+        untilize_out,
+        false,   // skip_compute
+        false);  // skip_write_back
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.hpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/matmul_device_operation_types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace ttnn::prim::qsr {
+
+struct MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const ttnn::prim::qsr::MatmulParams& operation_attributes,
+        const ttnn::prim::qsr::MatmulInputs& tensor_args,
+        std::vector<ttnn::Tensor>& tensor_return_value,
+        const std::optional<CoreRangeSet>& core_range_set = std::nullopt);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -1,0 +1,5507 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/utilities/matmul_utilities.hpp"
+#include <algorithm>
+#include <utility>
+
+#include "hostdevcommon/common_values.hpp"
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/math.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/tt_align.hpp>
+
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+#include "ttnn/operations/compute_throttle_utils.hpp"
+#include "ttnn/operations/ccl/ccl_op_fusion.hpp"
+#include "ttnn/tensor/shape/shape.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/shared_with_host/activation_type.hpp"
+
+using namespace tt;
+
+using ttnn::operations::unary::UnaryOpType;
+using ttnn::operations::unary::UnaryWithParam;
+
+using tt::tt_metal::CBDescriptor;
+using tt::tt_metal::CBFormatDescriptor;
+using tt::tt_metal::ComputeConfigDescriptor;
+using tt::tt_metal::DataMovementConfigDescriptor;
+using tt::tt_metal::KernelDescriptor;
+using tt::tt_metal::MeshTensor;
+using tt::tt_metal::ProgramDescriptor;
+
+namespace ttnn::prim::qsr {
+
+namespace reuse_mcast_1d_optimized_helpers {
+
+uint32_t get_preferred_noc(
+    const ttnn::CoreCoord src,
+    const ttnn::CoreCoord dst,
+    const tt_metal::IDevice* device,
+    const bool use_dedicated_noc = false) {
+    /*
+        NOC0: Preferred +x -> +y
+        NOC1: Preferred -y -> -x
+    */
+
+    uint32_t src_x = src.x, src_y = src.y;
+    uint32_t dst_x = dst.x, dst_y = dst.y;
+
+    uint32_t MAX_X = device->grid_size().x;
+    uint32_t MAX_Y = device->grid_size().y;
+
+    // Get the wrapped distances
+    uint32_t dist_right = src_x <= dst_x ? dst_x - src_x : MAX_X - src_x + dst_x;
+    uint32_t dist_left = src_x < dst_x ? src_x + MAX_X - dst_x : src_x - dst_x;
+
+    uint32_t dist_bottom = src_y <= dst_y ? dst_y - src_y : MAX_Y - src_y + dst_y;
+    uint32_t dist_top = src_y < dst_y ? src_y + MAX_Y - dst_y : src_y - dst_y;
+
+    uint32_t dist_noc_0 = dist_right + dist_bottom;
+    uint32_t dist_noc_1 = dist_top + dist_left;
+
+    uint32_t noc = dist_noc_0 < dist_noc_1 ? 0 : 1;
+
+    // Debug print if needed
+    // std::cout << "src: (" << src_x << ", " << src_y << "), dst: (" << dst_x << ", " << dst_y << "), noc: " << noc <<
+    // std::endl;
+
+    return use_dedicated_noc ? 1 : noc;
+}
+
+MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_program_and_create_override_variables(
+    tt_metal::Program& program,
+    const tt::tt_metal::Tensor& a,
+    tt_metal::IDevice* device,
+    MathFidelity math_fidelity,
+    bool fp32_dest_acc_en,
+    bool math_approx_mode,
+    bool packer_l1_acc,
+    CoreCoord compute_with_storage_grid_size,
+    ttnn::operations::compute_throttle_utils::ThrottleLevel throttle_level,
+    uint32_t B,
+    uint32_t M,
+    uint32_t N,
+    uint32_t K,
+    bool bcast_batch,
+    bool transpose_a,
+    bool transpose_b,
+    uint32_t in0_block_w,
+    uint32_t out_subblock_h,
+    uint32_t out_subblock_w,
+    uint32_t out_block_h,
+    uint32_t out_block_w,
+    uint32_t per_core_M,
+    uint32_t per_core_N,
+    std::optional<UnaryWithParam> fused_activation,
+    const MeshTensor& in0_tensor,
+    const MeshTensor& in1_tensor,
+    ttsl::optional_reference<const MeshTensor> bias_tensor,
+    const MeshTensor& out_tensor,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const tt::tt_metal::Tile& bias_tile,
+    const tt::tt_metal::Tile& output_tile,
+    tt::DataFormat in0_data_format,
+    tt::DataFormat in1_data_format,
+    tt::DataFormat bias_data_format,
+    tt::DataFormat output_data_format,
+    bool in0_is_sharded,
+    bool in1_is_sharded,
+    bool bias_is_sharded,
+    bool output_is_sharded,
+    bool untilize_out,
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler,
+    bool row_broadcast_bias = true,
+    CoreCoord sub_device_start_core = {0, 0}) {
+    using tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids;
+
+    // currently only support transpose of the full tile
+    bool in0_transpose_tile = in0_tile.get_transpose_of_faces() && in0_tile.get_transpose_within_face();
+    bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
+
+    bool fuse_op = fused_op_signaler.has_value();
+
+    uint32_t num_blocks = K / in0_block_w;
+    // Only enable packer l1 accumulation when there are spills, otherwise
+    // unnecessary overhead for reconfigs are added
+    bool packer_l1_acc_en = packer_l1_acc && num_blocks > 1;
+
+    // if fp32 enabled then we pack fp32 in l1, if not, then we pack fp16 in l1
+    tt::DataFormat interm0_data_format = packer_l1_acc_en
+                                             ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)
+                                             : (fp32_dest_acc_en ? tt::DataFormat::Float32 : output_data_format);
+
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    uint32_t bias_single_tile_size = bias_tile.get_tile_size(bias_data_format);
+    uint32_t output_single_tile_size = output_tile.get_tile_size(output_data_format);
+    uint32_t interm0_single_tile_size = output_tile.get_tile_size(interm0_data_format);
+
+    bool do_not_inplace_interm0_out_CB = output_is_sharded && (per_core_M != out_block_h);
+
+    uint32_t in0_block_h = out_block_h;
+    uint32_t in1_block_w = out_block_w;
+    uint32_t in0_num_blocks_y = per_core_M / out_block_h;
+    uint32_t in1_num_blocks_x = per_core_N / out_block_w;
+    uint32_t out_num_blocks_x = in1_num_blocks_x;
+    uint32_t out_num_blocks_y = in0_num_blocks_y;
+
+    uint32_t in0_block_tiles = in0_block_h * in0_block_w;
+    uint32_t in0_CB_tiles = in0_block_tiles;
+    if (B * num_blocks > 1) {
+        in0_CB_tiles *= operations::experimental::quasar::matmul::utilities::MCAST_INPUT_BUFFERING_DEPTH;
+    }
+    // Tiles whose size is not a multiple of the DRAM alignment (e.g. bfp8 32x16 = 544B on
+    // Blackhole's 64B alignment) are padded to it in DRAM. The interleaved reader copies tiles at
+    // the padded stride, so the in0/in1/bias CBs must hold pages at the aligned stride and the
+    // reader/unpacker walk tiles at the same stride. No-op when already aligned (all bf16 tiles,
+    // 32-wide bfp8, Wormhole). Replaces the staging-CB workaround. Sharded CBs are backed by the
+    // tensor buffer and keep their natural page size.
+    const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
+    uint32_t in0_aligned_tile_size =
+        in0_is_sharded ? in0_single_tile_size : tt::align(in0_single_tile_size, dram_alignment);
+    uint32_t in1_aligned_tile_size =
+        in1_is_sharded ? in1_single_tile_size : tt::align(in1_single_tile_size, dram_alignment);
+    uint32_t in0_CB_size = in0_CB_tiles * in0_aligned_tile_size;
+
+    uint32_t in2_block_tiles = 0;
+    uint32_t in0_shard_width_in_tiles = 0;
+    uint32_t in0_shard_height_in_tiles = 0;
+    if (in0_is_sharded) {
+        in0_shard_width_in_tiles = in0_tensor.shard_spec()->shape[1] / in0_tile.get_width();
+        in0_shard_height_in_tiles = in0_tensor.shard_spec()->shape[0] / in0_tile.get_height();
+        in2_block_tiles = per_core_M * in0_shard_width_in_tiles;
+    }
+    uint32_t in2_CB_tiles = in2_block_tiles;
+    uint32_t in2_CB_size = in2_CB_tiles * in0_single_tile_size;
+
+    uint32_t in1_block_tiles = out_block_w * in0_block_w;
+    uint32_t in1_CB_tiles = in1_block_tiles;
+    if (B * num_blocks > 1) {
+        in1_CB_tiles *= operations::experimental::quasar::matmul::utilities::MCAST_INPUT_BUFFERING_DEPTH;
+    }
+    if (in1_is_sharded) {
+        uint32_t in1_shard_height_in_tiles = in1_tensor.shard_spec()->shape[0] / in1_tile.get_height();
+        in1_CB_tiles = per_core_N * in1_shard_height_in_tiles;
+    }
+
+    uint32_t in1_CB_size = in1_CB_tiles * in1_aligned_tile_size;
+
+    uint32_t out_block_tiles = out_block_h * out_block_w;
+    uint32_t out_shard_tiles = per_core_M * per_core_N;
+    uint32_t out_CB_tiles = out_block_tiles;  // No double buffer
+    if (output_is_sharded) {
+        out_CB_tiles = out_shard_tiles;
+    }
+    uint32_t out_CB_size = out_CB_tiles * output_single_tile_size;
+    uint32_t interm0_CB_tiles = out_block_tiles;  // No double buffer
+    uint32_t interm0_CB_size = interm0_CB_tiles * interm0_single_tile_size;
+
+    uint32_t in3_block_tiles = out_block_w;
+    uint32_t in3_CB_tiles = in3_block_tiles;  // No double buffer
+    uint32_t in3_CB_size = in3_CB_tiles * bias_single_tile_size;
+
+    CoreCoord start_core = sub_device_start_core;
+    uint32_t start_core_x = start_core.x;
+    uint32_t start_core_y = start_core.y;
+    uint32_t num_cores_c = compute_with_storage_grid_size.x;
+
+    // The matmul region is the rectangle of size `compute_with_storage_grid_size`
+    // anchored at `start_core`. Callers must ensure this rectangle lies entirely
+    // within the active sub-device's worker cores (validated upstream). Using a
+    // CoreRangeSet here lets num_cores_to_corerangeset_in_subcoregrids honour the
+    // start offset when the sub-device is not anchored at (0, 0).
+    CoreRangeSet matmul_core_rect(CoreRange(
+        start_core,
+        CoreCoord(
+            start_core_x + compute_with_storage_grid_size.x - 1, start_core_y + compute_with_storage_grid_size.y - 1)));
+
+    uint32_t num_blocks_y = ((M - 1) / per_core_M) + 1;
+    uint32_t num_blocks_x = ((N - 1) / per_core_N) + 1;
+    uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
+    uint32_t num_cores_with_work = num_blocks_total;
+
+    // mcast_in0 broadcasts a single M-block across all cores; only the start_core gets in0 sender
+    // runtime args (with output_idx_y == 0), so M must fit within per_core_M.
+    TT_FATAL(
+        num_blocks_y == 1,
+        "matmul_multicore_reuse_mcast_1d requires num_blocks_y == 1 (M <= per_core_M) for mcast_in0. "
+        "Got M={}, per_core_M={}, num_blocks_y={}.",
+        M,
+        per_core_M,
+        num_blocks_y);
+
+    uint32_t in0_sender_num_cores = in0_is_sharded ? a.shard_spec().value().grid.num_cores() : 1;
+    uint32_t num_cores = in0_is_sharded ? std::max(num_cores_with_work, in0_sender_num_cores) : num_cores_with_work;
+
+    constexpr bool row_major = true;
+    CoreRangeSet all_cores =
+        num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores, matmul_core_rect, row_major);
+
+    CoreRangeSet in0_mcast_sender_cores =
+        num_cores_to_corerangeset_in_subcoregrids(start_core, in0_sender_num_cores, matmul_core_rect, row_major);
+    CoreCoord in0_mcast_sender_cores_grid = in0_mcast_sender_cores.bounding_box().grid_size();
+
+    CoreRangeSet all_cores_with_work =
+        num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores_with_work, matmul_core_rect, row_major);
+    CoreRange in0_mcast_receiver_cores_bounding_box = all_cores_with_work.bounding_box();
+    uint32_t in0_mcast_receiver_num_cores = in0_mcast_receiver_cores_bounding_box.size();  // always mcast to full grid
+    uint32_t in0_mcast_receiver_num_dests = std::min(
+        in0_mcast_receiver_num_cores,
+        num_cores);  // should always be number of cores in receiver grid up to number of active cores
+
+    CoreRangeSet in0_mcast_cores_with_work_and_in_receiver_grid;
+    CoreRangeSet in0_mcast_cores_without_work_and_in_receiver_grid;
+    CoreRangeSet in0_mcast_cores_without_work_and_not_in_receiver_grid;
+    CoreRangeSet in0_mcast_receivers;
+    std::vector<uint32_t> in0_mcast_noc_x;
+    std::vector<uint32_t> in0_mcast_noc_y;
+    if (in0_is_sharded) {
+        in0_mcast_cores_with_work_and_in_receiver_grid = all_cores_with_work;
+
+        if (in0_mcast_receiver_num_dests > num_cores_with_work) {
+            const uint32_t in0_mcast_cores_without_work_and_in_receiver_grid_num_cores =
+                in0_mcast_receiver_num_dests - num_cores_with_work;
+            uint32_t core_idx_x = num_cores_with_work % num_cores_c;
+            uint32_t core_idx_y = num_cores_with_work / num_cores_c;
+            CoreCoord start_core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
+            in0_mcast_cores_without_work_and_in_receiver_grid = num_cores_to_corerangeset_in_subcoregrids(
+                start_core, in0_mcast_cores_without_work_and_in_receiver_grid_num_cores, matmul_core_rect, row_major);
+        }
+
+        if (in0_sender_num_cores > in0_mcast_receiver_num_dests) {
+            const uint32_t in0_mcast_cores_without_work_and_not_in_receiver_grid_num_cores =
+                in0_sender_num_cores - in0_mcast_receiver_num_dests;
+            uint32_t core_idx_x = in0_mcast_receiver_num_dests % num_cores_c;
+            uint32_t core_idx_y = in0_mcast_receiver_num_dests / num_cores_c;
+            CoreCoord start_core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
+            in0_mcast_cores_without_work_and_not_in_receiver_grid = num_cores_to_corerangeset_in_subcoregrids(
+                start_core,
+                in0_mcast_cores_without_work_and_not_in_receiver_grid_num_cores,
+                matmul_core_rect,
+                row_major);
+        }
+
+        in0_mcast_noc_x.reserve(in0_mcast_sender_cores_grid.x);
+        in0_mcast_noc_y.reserve(in0_mcast_sender_cores_grid.y);
+        for (uint32_t core_idx_x = 0; core_idx_x < in0_mcast_sender_cores_grid.x; ++core_idx_x) {
+            in0_mcast_noc_x.push_back(
+                device->worker_core_from_logical_core({start_core_x + core_idx_x, start_core_y}).x);
+        }
+        for (uint32_t core_idx_y = 0; core_idx_y < in0_mcast_sender_cores_grid.y; ++core_idx_y) {
+            in0_mcast_noc_y.push_back(
+                device->worker_core_from_logical_core({start_core_x, start_core_y + core_idx_y}).y);
+        }
+    } else {
+        in0_mcast_cores_with_work_and_in_receiver_grid = CoreRangeSet({CoreRange(start_core, start_core)});
+        if (in0_mcast_receiver_num_cores > 1) {
+            // Check against the actual rectangle width (instead of bare grid_size.x-1) so that
+            // sub-devices anchored away from (0, 0) wrap correctly.
+            auto receiver_start_core = compute_with_storage_grid_size.x > 1 ? CoreCoord{start_core.x + 1, start_core.y}
+                                                                            : CoreCoord{start_core.x, start_core.y + 1};
+            in0_mcast_receivers = num_cores_to_corerangeset_in_subcoregrids(
+                receiver_start_core, num_cores - 1, matmul_core_rect, row_major);
+        }
+    }
+
+    // Mcast args
+    auto in0_mcast_sender_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto in0_mcast_receiver_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+
+    CoreCoord top_left_core = in0_mcast_receiver_cores_bounding_box.start_coord;
+    CoreCoord bottom_right_core = in0_mcast_receiver_cores_bounding_box.end_coord;
+    auto top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
+    auto bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
+
+    uint32_t in0_num_subblocks = (out_block_h / out_subblock_h);
+    uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
+    const auto& a_shape_logical =
+        operations::experimental::quasar::matmul::utilities::get_matmul_tensor_logical_shape(a, transpose_a);
+    // When transpose_a is true, the K dimension maps to the row dimension of the raw tile,
+    // which is already zero-padded during tile layout conversion. pad_last_ktile operates on
+    // columns, so applying it would incorrectly zero valid data that becomes output rows
+    // after the compute kernel transposes the tile.
+    const auto in0_last_ktile_w = transpose_a ? 0 : a_shape_logical[-1] % in0_tile.get_width();
+    const auto in0_last_ktile_h = transpose_a ? a_shape_logical[-1] % in0_tile.get_width() : 0;
+    TT_FATAL(
+        in0_last_ktile_w == 0 || in0_last_ktile_h == 0,
+        "At most one of in0_last_ktile_w ({}) and in0_last_ktile_h ({}) can be non-zero",
+        in0_last_ktile_w,
+        in0_last_ktile_h);
+
+    const auto& a_padded_shape =
+        operations::experimental::quasar::matmul::utilities::get_matmul_tensor_padded_shape(a, transpose_a);
+    const uint32_t M_per_batch = a_padded_shape[-2] / in0_tile.get_height();
+    const auto [in0_tensor_stride_w, in0_tensor_stride_h] =
+        operations::experimental::quasar::matmul::utilities::get_in0_transpose_strides(M, M_per_batch, transpose_a, K);
+    const auto in0_tensor_next_block_stride = in0_block_w * in0_tensor_stride_w;
+    const auto in0_tensor_next_h_dim_block_stride = in0_block_h * in0_tensor_stride_h;
+    const auto in0_tensor_start_tile_id_stride = per_core_M * in0_tensor_stride_h;
+
+    const auto in1_tensor_stride_w = transpose_b ? K : 1;
+    const auto in1_tensor_stride_h = transpose_b ? 1 : N;
+    const auto in1_tensor_next_block_stride = in0_block_w * in1_tensor_stride_h;
+    const auto in1_tensor_next_w_dim_block_stride = in1_block_w * in1_tensor_stride_w;
+    const auto in1_tensor_start_tile_id_stride = per_core_N * in1_tensor_stride_w;
+
+    std::vector<uint32_t> in0_sender_compile_time_args;
+    if (in0_is_sharded) {
+        in0_sender_compile_time_args = {
+            (std::uint32_t)1,  // core_has_output_block_work
+            (std::uint32_t)1,  // core_in_in0_receiver_mcast_grid
+
+            (std::uint32_t)in0_block_num_tiles,                         // in0_block_num_tiles
+            (std::uint32_t)in0_block_num_tiles * in0_single_tile_size,  // in0_block_size_bytes
+            (std::uint32_t)in0_last_ktile_w,
+            (std::uint32_t)in0_last_ktile_h,
+
+            // in0/in1 common args
+            (std::uint32_t)num_blocks,        // num_blocks
+            (std::uint32_t)out_num_blocks_x,  // num_blocks_x
+            (std::uint32_t)out_num_blocks_y,  // num_blocks_y
+            // in0 mcast args
+            (std::uint32_t)in0_mcast_sender_semaphore_id,
+            (std::uint32_t)in0_mcast_receiver_semaphore_id,
+            (std::uint32_t)in0_mcast_receiver_num_dests,  // in0_mcast_num_dests
+            (std::uint32_t)in0_mcast_receiver_num_cores,  // in0_mcast_num_cores
+            (std::uint32_t)(in0_mcast_sender_cores_grid.x),
+            (std::uint32_t)(in0_mcast_sender_cores_grid.y),
+            (std::uint32_t)(false),
+            (std::uint32_t)(in0_shard_width_in_tiles),
+            (std::uint32_t)(in0_shard_height_in_tiles),
+            (std::uint32_t)(in0_block_w),
+            (std::uint32_t)in0_block_h,  // in0_block_h
+
+            // batch args
+            (std::uint32_t)B  // batch
+        };
+    } else {
+        in0_sender_compile_time_args = {
+            // in0 tensor args
+            (std::uint32_t)in0_tensor_stride_w,
+            (std::uint32_t)in0_tensor_stride_h,
+            (std::uint32_t)in0_tensor_next_block_stride,
+            (std::uint32_t)in0_tensor_next_h_dim_block_stride,
+            // in0 block args
+            (std::uint32_t)in0_block_w,          // in0_block_w
+            (std::uint32_t)in0_block_h,          // in0_block_h
+            (std::uint32_t)in0_block_num_tiles,  // in0_block_num_tiles
+            (std::uint32_t)in0_last_ktile_w,
+            (std::uint32_t)in0_last_ktile_h,
+            (std::uint32_t)false,  // extract_shard_sub_blocks (not used for interleaved)
+            (std::uint32_t)0,      // shard_width_in_tiles (not used for interleaved)
+            (std::uint32_t)0,      // shard_height_in_tiles (not used for interleaved)
+            // in0/in1 common args
+            (std::uint32_t)num_blocks,        // num_blocks
+            (std::uint32_t)out_num_blocks_x,  // num_blocks_x
+            (std::uint32_t)out_num_blocks_y,  // num_blocks_y
+            // in0 mcast args
+            (std::uint32_t)in0_mcast_sender_semaphore_id,
+            (std::uint32_t)in0_mcast_receiver_semaphore_id,
+            (std::uint32_t)num_cores - 1,                     // in0_mcast_num_dests
+            (std::uint32_t)in0_mcast_receiver_num_cores - 1,  // in0_mcast_num_cores
+            // batch args
+            (std::uint32_t)M * K,  // MtKt
+            (std::uint32_t)B,      // batch
+            (std::uint32_t)B,      // batch
+            (std::uint32_t)false,  // reuse_in0_in_CB
+            // sparsity args
+            (std::uint32_t)0,     // batchB
+            (std::uint32_t)0,     // sparsity_pagesize (placeholder since sparsity not used in this case)
+            (std::uint32_t)true,  // bcast_A
+            (std::uint32_t)false  // get_batch_from_reader
+        };
+    }
+    in0_sender_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));
+    tt::tt_metal::TensorAccessorArgs(in0_tensor).append_to(in0_sender_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs().append_to(in0_sender_compile_time_args);  // placeholder for sparsity
+    in0_sender_compile_time_args.push_back((std::uint32_t)0);  // num_batch_compute (unused, sparsity disabled)
+
+    std::vector<uint32_t> in1_sender_writer_compile_time_args = {
+        // READER
+        // in1 tensor args
+        (std::uint32_t)in1_tensor_stride_w,
+        (std::uint32_t)in1_tensor_stride_h,
+        (std::uint32_t)in1_tensor_next_block_stride,
+        (std::uint32_t)in1_tensor_next_w_dim_block_stride,
+        // in1 block args
+        (std::uint32_t)in1_block_w,                // in1_block_w
+        (std::uint32_t)in0_block_w,                // in1_block_h
+        (std::uint32_t)in1_block_w * in0_block_w,  // in1_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,        // num_blocks
+        (std::uint32_t)out_num_blocks_x,  // out_num_blocks_x
+        (std::uint32_t)out_num_blocks_y,  // out_num_blocks_y
+        // in1 mcast args
+        (std::uint32_t)0,
+        (std::uint32_t)0,
+        (std::uint32_t)0,  // in1_mcast_num_dests
+        (std::uint32_t)0,  // in1_mcast_num_cores
+        // batch args
+        (std::uint32_t)K * N,        // KtNt
+        (std::uint32_t)B,            // batch
+        (std::uint32_t)bcast_batch,  // bcast_B
+        // sparsity args
+        (std::uint32_t)0,  // batchB
+        (std::uint32_t)0,  // sparsity_pagesize (placeholder since sparsity not used in this case)
+
+        // WRITER
+        // out tensor args
+        (std::uint32_t)1,                   // out_tensor_stride_w
+        (std::uint32_t)N,                   // out_tensor_stride_h
+        (std::uint32_t)out_subblock_w,      // out_tensor_next_subblock_stride_w
+        (std::uint32_t)out_subblock_h * N,  // out_tensor_next_subblock_stride_h
+        (std::uint32_t)out_block_w,         // out_tensor_next_w_dim_block_stride
+        (std::uint32_t)out_block_h * N,     // out_tensor_next_h_dim_block_stride
+        // out subblock args
+        (std::uint32_t)out_subblock_w,                     // out_subblock_w
+        (std::uint32_t)out_subblock_h,                     // out_subblock_h
+        (std::uint32_t)(out_subblock_w * out_subblock_h),  // out_subblocks_w * out_subblocks_h
+        // batch args
+        (std::uint32_t)M * N  // MtNt
+    };
+    if (bias_tensor.has_value()) {
+        in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);  // in3_tensor_stride_w
+    } else {
+        in1_sender_writer_compile_time_args.push_back(0);  // Placeholder; not used
+    }
+
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_reduce_scatter()));
+
+    // Append TensorAccessorArgs
+    tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs().append_to(in1_sender_writer_compile_time_args);  // placeholder for sparsity
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_sender_writer_compile_time_args);
+    if (bias_tensor.has_value()) {
+        tt::tt_metal::TensorAccessorArgs(*bias_tensor).append_to(in1_sender_writer_compile_time_args);
+    }
+
+    std::vector<uint32_t> in0_receiver_compile_time_args = {
+        // in0 block args
+        (std::uint32_t)in0_block_num_tiles,  // in0_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,        // num_blocks
+        (std::uint32_t)out_num_blocks_x,  // out_num_blocks_x
+        (std::uint32_t)out_num_blocks_y,  // out_num_blocks_y
+        // in0 mcast args
+        (std::uint32_t)in0_mcast_sender_semaphore_id,
+        (std::uint32_t)in0_mcast_receiver_semaphore_id,
+        // batch args
+        (std::uint32_t)B,     // batch
+        (std::uint32_t)false  // get_batch_from_reader
+    };
+
+    std::map<std::string, std::string> mm_kernel_defines;
+    std::map<std::string, std::string> mm_kernel_in0_sender_writer_defines;
+    std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
+    if (bias_tensor.has_value()) {
+        mm_kernel_defines["FUSE_BIAS"] = "1";
+        mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
+    }
+    if (fused_activation.has_value()) {
+        if (fused_activation.value().op_type == UnaryOpType::RELU) {
+            mm_kernel_defines["PACK_RELU"] = "1";
+        } else {
+            mm_kernel_defines["SFPU_ACTIVATION"] = "1";
+        }
+    }
+    if (packer_l1_acc_en) {
+        mm_kernel_defines["PACKER_L1_ACC"] = "1";
+    }
+    if (fp32_dest_acc_en) {
+        mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    if (in1_transpose_tile) {
+        mm_kernel_defines["IN1_TRANSPOSE_TILE"] = "1";
+    }
+
+    ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
+        device->arch(), num_cores, mm_kernel_defines);
+    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
+        device->arch(), num_cores, mm_kernel_defines, throttle_level);
+
+    if (in1_is_sharded) {
+        mm_kernel_in1_sender_writer_defines["IN1_SHARDED"] = "1";
+    }
+
+    if (bias_is_sharded) {
+        mm_kernel_in1_sender_writer_defines["BIAS_SHARDED"] = "1";
+    }
+
+    if (output_is_sharded) {
+        mm_kernel_in1_sender_writer_defines["OUT_SHARDED"] = "1";
+    }
+
+    // TODO: SKIP_MCAST flag isn't used for the sharded reader kernel because internal mcast logic already works without
+    // skipping We can use this flag to turn off unnecessary mcast overhead if necessary
+    if (in0_mcast_receiver_num_cores == 1) {
+        mm_kernel_in0_sender_writer_defines["SKIP_MCAST"] = "1";
+    }
+
+    mm_kernel_in1_sender_writer_defines["SKIP_MCAST"] = "1";
+
+    // Intermediate CB read
+    /*
+    Blackhole architecture alignment issue workaround for tiny tiles:
+
+    Problem: When reading tiny tiles from DRAM to circular buffers (CB), address alignment
+    issues occur. DRAM tile addresses are 64-byte aligned within each block, but L1 CB
+    addresses are not necessarily aligned due to non-64-byte-aligned page sizes.
+
+    Example scenario:
+    - Two consecutive 544-byte tiles (16x32 tile of dtype bfloat8_b) stored on different DRAM banks
+    - CB configured with size=2 to hold both tiles
+
+    Result:
+    - Tile 0: DRAM Bank 0, Address 64    → CB L1 Address 0   (64-byte aligned ✓)
+    - Tile 1: DRAM Bank 1, Address 64    → CB L1 Address 544 (not 64-byte aligned ✗)
+
+    Solution: Use an intermediate single-tile CB as a staging area. Read each tile into
+    the intermediate CB first, then copy to the destination CB. This ensures proper
+    alignment at the cost of additional memory bandwidth overhead.
+
+    Note: This workaround should only be used for this specific alignment issue case.
+    */
+
+    // in1 is the reader of weights/output writer, and we choose to make it use the optimized reader noc
+    tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+    tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+
+    if (fuse_op && fused_op_signaler->is_all_gather()) {
+        // Create semaphores
+        fused_op_signaler->init_fused_op(
+            program,
+            device,
+            in0_mcast_sender_cores,
+            in0_is_sharded ? ttnn::experimental::ccl::FusedOpSignalerMode::SINGLE
+                           : ttnn::experimental::ccl::FusedOpSignalerMode::MULTI);
+    }
+
+    auto mm_kernel_in0_mcast_cores_with_work_and_in_receiver_grid_id = tt_metal::CreateKernel(
+        program,
+        in0_is_sharded ? "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+                         "reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp"
+                       : "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+                         "reader_bmm_tile_layout_in0_sender_padding.cpp",
+        in0_mcast_cores_with_work_and_in_receiver_grid,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = in0_noc,
+            .compile_args = in0_sender_compile_time_args,
+            .defines = mm_kernel_in0_sender_writer_defines,
+            .named_compile_args = {
+                {"cb_in0", tt::CBIndex::c_0},
+                {"cb_in0_sharded", tt::CBIndex::c_2},
+                {"cb_l1_array", tt::CBIndex::c_6},
+                {"cb_sparsity", tt::CBIndex::c_6},
+            }});
+
+    tt::tt_metal::KernelHandle mm_kernel_in0_mcast_cores_without_work_and_in_receiver_grid_id = 0;
+    tt::tt_metal::KernelHandle mm_kernel_in0_mcast_cores_without_work_and_not_in_receiver_grid_id = 0;
+    if (in0_is_sharded) {
+        if (in0_mcast_cores_without_work_and_in_receiver_grid.num_cores() > 0) {
+            in0_sender_compile_time_args[0] = 0;  // core_has_output_block_work
+            in0_sender_compile_time_args[1] = 1;  // core_in_in0_receiver_mcast_grid
+            mm_kernel_in0_mcast_cores_without_work_and_in_receiver_grid_id = tt_metal::CreateKernel(
+                program,
+                "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+                "reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp",
+                in0_mcast_cores_without_work_and_in_receiver_grid,
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                    .noc = in0_noc,
+                    .compile_args = in0_sender_compile_time_args,
+                    .defines = mm_kernel_in0_sender_writer_defines,
+                    .named_compile_args = {
+                        {"cb_in0", tt::CBIndex::c_0},
+                        {"cb_in0_sharded", tt::CBIndex::c_2},
+                        {"cb_l1_array", tt::CBIndex::c_6},
+                    }});
+        }
+        if (in0_mcast_cores_without_work_and_not_in_receiver_grid.num_cores() > 0) {
+            in0_sender_compile_time_args[0] = 0;  // core_has_output_block_work
+            in0_sender_compile_time_args[1] = 0;  // core_in_in0_receiver_mcast_grid
+            mm_kernel_in0_mcast_cores_without_work_and_not_in_receiver_grid_id = tt_metal::CreateKernel(
+                program,
+                "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+                "reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp",
+                in0_mcast_cores_without_work_and_not_in_receiver_grid,
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                    .noc = in0_noc,
+                    .compile_args = in0_sender_compile_time_args,
+                    .defines = mm_kernel_in0_sender_writer_defines,
+                    .named_compile_args = {
+                        {"cb_in0", tt::CBIndex::c_0},
+                        {"cb_in0_sharded", tt::CBIndex::c_2},
+                        {"cb_l1_array", tt::CBIndex::c_6},
+                    }});
+        }
+    }
+
+    tt::tt_metal::KernelHandle mm_kernel_in0_receiver_id = 0;
+    if (!in0_is_sharded and in0_mcast_receivers.num_cores() > 0) {
+        mm_kernel_in0_receiver_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+            "reader_bmm_tile_layout_in0_receiver.cpp",
+            in0_mcast_receivers,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = in0_noc,
+                .compile_args = in0_receiver_compile_time_args,
+                .named_compile_args = {
+                    {"cb_in0", tt::CBIndex::c_0},
+                }});
+    }
+
+    auto mm_kernel_in1_sender_writer_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+        "reader_bmm_tile_layout_in1_sender_writer_padding.cpp",
+        all_cores_with_work,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = in1_noc,
+            .compile_args = in1_sender_writer_compile_time_args,
+            .defines = mm_kernel_in1_sender_writer_defines,
+            .named_compile_args = {
+                {"cb_in1", tt::CBIndex::c_1},
+                {"cb_bias", tt::CBIndex::c_3},
+                {"cb_out", tt::CBIndex::c_4},
+                {"cb_sparsity", tt::CBIndex::c_7},
+            }});
+
+    // Compute kernel compile time args
+
+    uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
+
+    uint32_t in1_num_subblocks = (out_block_w / out_subblock_w);
+    uint32_t in1_block_num_tiles = out_subblock_w * in0_block_w * in1_num_subblocks;
+    uint32_t in1_per_core_w = out_subblock_w * in1_num_subblocks;
+
+    uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
+
+    std::vector<uint32_t> compute_kernel_args = {
+        in0_block_w,             // in0_block_w
+        in0_num_subblocks,       // in0_num_subblocks
+        in0_block_num_tiles,     // in0_block_num_tiles
+        in0_subblock_num_tiles,  // in0_subblock_num_tiles
+
+        in1_num_subblocks,    // in1_num_subblocks
+        in1_block_num_tiles,  // in1_block_num_tiles
+        in1_per_core_w,       // in1_per_core_w
+
+        num_blocks,        // num_blocks
+        out_num_blocks_x,  // out_num_blocks_x
+        out_num_blocks_y,  // out_num_blocks_y
+
+        out_subblock_h,          // out_subblock_h
+        out_subblock_w,          // out_subblock_w
+        out_subblock_num_tiles,  // out_subblock_num_tiles
+        B,                       // batch
+        out_block_tiles,         // out_block_num_tiles
+
+        untilize_out,  // untilize_out
+        false,         // get_batch_from_reader
+        in0_transpose_tile,
+    };
+    if (bias_tensor.has_value()) {
+        compute_kernel_args.push_back(row_broadcast_bias ? 1u : 0u);
+    }
+
+    std::unordered_map<std::string, uint32_t> compute_named_compile_args = {
+        {"cb_in0", tt::CBIndex::c_0},
+        {"cb_in1", tt::CBIndex::c_1},
+        {"cb_bias", tt::CBIndex::c_3},
+        {"cb_out", tt::CBIndex::c_4},
+        {"cb_intermed0", tt::CBIndex::c_5},
+        {"cb_in0_transposed", tt::CBIndex::c_10},
+        {"bias_ntiles", in1_per_core_w},
+    };
+
+    if (fused_activation.has_value() && fused_activation.value().op_type != UnaryOpType::RELU) {
+        using ttnn::operations::experimental::quasar::matmul::utilities::get_activation_params;
+        const auto& activation = fused_activation.value();
+        const auto params = get_activation_params(activation);
+        compute_named_compile_args["activation_type"] = static_cast<uint32_t>(params.type);
+        compute_named_compile_args["activation_param0"] = params.param0;
+        compute_named_compile_args["activation_param1"] = params.param1;
+        compute_named_compile_args["activation_param2"] = params.param2;
+    }
+
+    // Create compute kernel
+    // bool fp32_dest_acc_en = false;
+    // Gelu currently has better accuracy when run in approx mode
+    // bool math_approx_mode = false;
+    tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/"
+        "bmm_large_block_zm_fused_bias_activation.cpp",
+        all_cores_with_work,
+        tt_metal::ComputeConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .math_approx_mode = math_approx_mode,
+            .compile_args = compute_kernel_args,
+            .defines = mm_kernel_defines,
+            .named_compile_args = compute_named_compile_args});
+
+    // Create circular buffers
+    uint32_t src0_cb_index = tt::CBIndex::c_0;
+    tt_metal::CircularBufferConfig src0_cb_config =
+        tt_metal::CircularBufferConfig(in0_CB_size, {{src0_cb_index, in0_data_format}})
+            .set_page_size(src0_cb_index, in0_aligned_tile_size)
+            .set_tile_dims(src0_cb_index, in0_tile);
+    tt_metal::CreateCircularBuffer(program, all_cores, src0_cb_config);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        src0_cb_index,
+        in0_single_tile_size,
+        in0_CB_size / in0_single_tile_size,
+        in0_CB_size);
+
+    uint32_t src1_cb_index = tt::CBIndex::c_1;
+    tt_metal::CircularBufferConfig src1_cb_config =
+        tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_data_format}})
+            .set_page_size(src1_cb_index, in1_aligned_tile_size)
+            .set_tile_dims(src1_cb_index, in1_tile);
+
+    if (in1_is_sharded) {
+        src1_cb_config = src1_cb_config.set_globally_allocated_address(in1_tensor);
+    }
+
+    auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        src1_cb_index,
+        in1_single_tile_size,
+        in1_CB_size / in1_single_tile_size,
+        in1_CB_size);
+
+    uint32_t src2_cb_index = tt::CBIndex::c_2;
+    tt::tt_metal::CBHandle cb_src2 = 0;
+    if (in0_is_sharded) {
+        tt_metal::CircularBufferConfig src2_cb_config =
+            tt_metal::CircularBufferConfig(in2_CB_size, {{src2_cb_index, in0_data_format}})
+                .set_page_size(src2_cb_index, in0_single_tile_size)
+                .set_globally_allocated_address(in0_tensor)
+                .set_tile_dims(src2_cb_index, in0_tile);
+        cb_src2 = tt_metal::CreateCircularBuffer(program, all_cores, src2_cb_config);
+        log_debug(
+            LogOp,
+            "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+            src2_cb_index,
+            in0_single_tile_size,
+            in2_CB_size / in0_single_tile_size,
+            in2_CB_size);
+
+        // Local L1 to store temp vars
+        uint32_t l1_cb_index = tt::CBIndex::c_6;
+        tt::tt_metal::CircularBufferConfig cb_for_l1_array_config =
+            tt::tt_metal::CircularBufferConfig(32 * 2, {{l1_cb_index, tt::DataFormat::Float16_b}})
+                .set_page_size(l1_cb_index, 32 * 2);
+        tt_metal::CreateCircularBuffer(program, all_cores, cb_for_l1_array_config);
+    }
+
+    uint32_t output_cb_index = tt::CBIndex::c_4;
+    uint32_t interm0_cb_index = tt::CBIndex::c_5;
+    tt_metal::CircularBufferConfig interm0_cb_config =
+        tt_metal::CircularBufferConfig(0, {{interm0_cb_index, interm0_data_format}});
+    tt_metal::CircularBufferConfig output_cb_config =
+        tt_metal::CircularBufferConfig(0, {{output_cb_index, output_data_format}});
+
+    if (do_not_inplace_interm0_out_CB || (interm0_data_format != output_data_format) ||
+        (untilize_out && (in1_num_subblocks > 1))) {
+        // output
+        std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
+            {output_cb_index, output_data_format},
+        };
+        output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
+                               .set_page_size(output_cb_index, output_single_tile_size)
+                               .set_tile_dims(output_cb_index, output_tile);
+        // interm0
+        std::map<uint8_t, tt::DataFormat> interm0_cb_data_format_spec{
+            {interm0_cb_index, interm0_data_format},
+        };
+        interm0_cb_config = tt_metal::CircularBufferConfig(interm0_CB_size, interm0_cb_data_format_spec)
+                                .set_page_size(interm0_cb_index, interm0_single_tile_size)
+                                .set_tile_dims(interm0_cb_index, output_tile);
+
+        tt_metal::CreateCircularBuffer(program, CoreRangeSet({all_cores}), interm0_cb_config);
+        log_debug(
+            LogOp,
+            "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+            interm0_cb_index,
+            interm0_single_tile_size,
+            interm0_CB_size / interm0_single_tile_size,
+            interm0_CB_size);
+    } else {
+        // share buffer
+        std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
+            {output_cb_index, output_data_format}, {interm0_cb_index, interm0_data_format}};
+        output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
+                               .set_page_size(output_cb_index, output_single_tile_size)
+                               .set_page_size(interm0_cb_index, interm0_single_tile_size)
+                               .set_tile_dims(output_cb_index, output_tile)
+                               .set_tile_dims(interm0_cb_index, output_tile);
+    }
+
+    if (output_is_sharded) {
+        output_cb_config = output_cb_config.set_globally_allocated_address(out_tensor);
+    }
+    auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        output_cb_index,
+        output_single_tile_size,
+        out_CB_size / output_single_tile_size,
+        out_CB_size);
+
+    tt_metal::CBHandle cb_src3 = 0;
+    if (bias_tensor.has_value()) {
+        uint32_t src3_cb_index = tt::CBIndex::c_3;
+        tt_metal::CircularBufferConfig cb_src3_config =
+            tt_metal::CircularBufferConfig(in3_CB_size, {{src3_cb_index, bias_data_format}})
+                .set_page_size(src3_cb_index, bias_single_tile_size)
+                .set_tile_dims(src3_cb_index, bias_tile);
+
+        if (bias_is_sharded) {
+            cb_src3_config = cb_src3_config.set_globally_allocated_address(*bias_tensor);
+        }
+
+        cb_src3 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src3_config);
+        log_debug(
+            LogOp,
+            "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+            src3_cb_index,
+            bias_single_tile_size,
+            in3_CB_size / bias_single_tile_size,
+            in3_CB_size);
+    }
+
+    // Intermediate CB read
+
+    // Transpose CB for input0
+    if (in0_transpose_tile) {
+        const uint32_t in0_transpose_cb_index = tt::CBIndex::c_10;
+        auto in0_transpose_cb_config =
+            tt_metal::CircularBufferConfig(in0_CB_size, {{in0_transpose_cb_index, in0_data_format}})
+                .set_page_size(in0_transpose_cb_index, in0_aligned_tile_size)
+                .set_tile_dims(in0_transpose_cb_index, in0_tile);
+        tt_metal::CreateCircularBuffer(program, all_cores, in0_transpose_cb_config);
+    }
+
+    // Parameters for last row, col, or block. mcast_in0 replicates M across all cores
+    // (num_blocks_y == 1), so any M-direction padding lives entirely within a single h-block.
+    uint32_t last_per_core_N = N % per_core_N == 0 ? per_core_N : N % per_core_N;
+    uint32_t last_out_block_w = last_per_core_N % out_block_w == 0 ? out_block_w : last_per_core_N % out_block_w;
+    uint32_t last_out_num_blocks_w = ((last_per_core_N - 1) / out_block_w) + 1;
+    uint32_t last_block_num_nonzero_subblocks_w = ((last_out_block_w - 1) / out_subblock_w) + 1;
+    uint32_t last_subblock_of_last_block_w =
+        last_out_block_w % out_subblock_w == 0 ? out_subblock_w : last_out_block_w % out_subblock_w;
+    uint32_t last_block_padded_subblock_tiles_addr_skip =
+        output_single_tile_size * (out_subblock_w - last_subblock_of_last_block_w);
+    uint32_t last_block_padded_block_tiles_w_skip =
+        (out_subblock_w * out_subblock_h) * (out_block_w / out_subblock_w - last_block_num_nonzero_subblocks_w);
+
+    // M-direction padding when M < per_core_M. With num_blocks_y == 1 the last (only) h-block
+    // holds last_out_block_h valid tile rows out of out_block_h.
+    uint32_t in0_last_per_core_M = M < per_core_M ? M : per_core_M;
+    uint32_t in0_last_out_block_h =
+        in0_last_per_core_M % out_block_h == 0 ? out_block_h : in0_last_per_core_M % out_block_h;
+    uint32_t in0_last_block_num_nonzero_subblocks_h = ((in0_last_out_block_h - 1) / out_subblock_h) + 1;
+    uint32_t in0_last_subblock_of_last_block_h =
+        in0_last_out_block_h % out_subblock_h == 0 ? out_subblock_h : in0_last_out_block_h % out_subblock_h;
+    uint32_t in0_last_block_padded_block_tiles_h_skip =
+        (out_block_h / out_subblock_h - in0_last_block_num_nonzero_subblocks_h) * (out_block_w * out_subblock_h);
+
+    CoreCoord start_core_noc = top_left_core_physical;
+    CoreCoord end_core_noc = bottom_right_core_physical;
+    if (in0_noc == tt::tt_metal::NOC::NOC_1) {
+        std::swap(start_core_noc, end_core_noc);
+    }
+
+    const auto& cores = corerange_to_cores(all_cores, std::nullopt, row_major);
+    for (uint32_t i = 0; i < num_cores; ++i) {
+        const auto& core = cores[i];
+        uint32_t output_idx_x = i % num_blocks_x;
+        uint32_t output_idx_y = i / num_blocks_x;
+
+        if (in0_is_sharded) {
+            std::vector<uint32_t> mm_in0_sender_args;
+            mm_in0_sender_args.reserve(5 + in0_mcast_noc_x.size() + in0_mcast_noc_y.size());
+            mm_in0_sender_args.push_back(i);
+            mm_in0_sender_args.push_back(start_core_noc.x);
+            mm_in0_sender_args.push_back(start_core_noc.y);
+            mm_in0_sender_args.push_back(end_core_noc.x);
+            mm_in0_sender_args.push_back(end_core_noc.y);
+            mm_in0_sender_args.insert(mm_in0_sender_args.end(), in0_mcast_noc_x.begin(), in0_mcast_noc_x.end());
+            mm_in0_sender_args.insert(mm_in0_sender_args.end(), in0_mcast_noc_y.begin(), in0_mcast_noc_y.end());
+
+            if (fuse_op && fused_op_signaler->is_all_gather()) {
+                fused_op_signaler->push_matmul_fused_op_rt_args(mm_in0_sender_args, false);
+            }
+
+            if (i < num_cores_with_work) {
+                tt_metal::SetRuntimeArgs(
+                    program,
+                    mm_kernel_in0_mcast_cores_with_work_and_in_receiver_grid_id,
+                    core,
+                    mm_in0_sender_args);  // RISCV_0_default
+            } else if (i < in0_mcast_receiver_num_dests) {
+                tt_metal::SetRuntimeArgs(
+                    program,
+                    mm_kernel_in0_mcast_cores_without_work_and_in_receiver_grid_id,
+                    core,
+                    mm_in0_sender_args);  // RISCV_0_default
+            } else {
+                tt_metal::SetRuntimeArgs(
+                    program,
+                    mm_kernel_in0_mcast_cores_without_work_and_not_in_receiver_grid_id,
+                    core,
+                    mm_in0_sender_args);  // RISCV_0_default
+            }
+        }
+        // in0 sender and in1 sender
+        else if (core == start_core) {
+            std::vector<uint32_t> mm_in0_sender_args = {
+                // in0 tensor args
+                (std::uint32_t)in0_tensor.address(),
+                (std::uint32_t)in0_tensor_start_tile_id_stride * output_idx_y,  // in0_tensor_start_tile_id
+                // in0 mcast args
+                (std::uint32_t)start_core_noc.x,  // in0_mcast_dest_noc_start_x
+                (std::uint32_t)start_core_noc.y,  // in0_mcast_dest_noc_start_y
+                (std::uint32_t)end_core_noc.x,    // in0_mcast_dest_noc_end_x
+                (std::uint32_t)end_core_noc.y,    // in0_mcast_dest_noc_end_y
+
+                // padding args
+                (std::uint32_t)in0_last_out_block_h,  // last_block_h
+
+                // sparsity args
+                (std::uint32_t)0,  // sparsity_addr
+            };
+
+            if (fuse_op && fused_op_signaler->is_all_gather()) {
+                fused_op_signaler->push_matmul_fused_op_rt_args(mm_in0_sender_args, false);
+            }
+
+            tt_metal::SetRuntimeArgs(
+                program,
+                mm_kernel_in0_mcast_cores_with_work_and_in_receiver_grid_id,
+                core,
+                mm_in0_sender_args);  // RISCV_0_default
+        }
+        // in0 receiver and in 1 sender
+        else {
+            std::vector<uint32_t> mm_in0_receiver_args = {
+                // in0 mcast args
+                (std::uint32_t)top_left_core_physical.x,  // in0_mcast_sender_noc_x
+                (std::uint32_t)top_left_core_physical.y   // in0_mcast_sender_noc_y
+            };
+            tt_metal::SetRuntimeArgs(
+                program, mm_kernel_in0_receiver_id, core, mm_in0_receiver_args);  // RISCV_1_default
+        }
+        if (i < num_cores_with_work) {
+            std::vector<uint32_t> mm_in1_sender_writer_args = {
+                // READER
+                // in1 tensor args
+                (std::uint32_t)in1_tensor.address(),
+                (std::uint32_t)in1_tensor_start_tile_id_stride * output_idx_x,  // in1_tensor_start_tile_id
+                // in1 mcast args
+                (std::uint32_t)0,  // in1_mcast_dest_noc_start_x
+                (std::uint32_t)0,  // in1_mcast_dest_noc_start_y
+                (std::uint32_t)0,  // in1_mcast_dest_noc_end_x
+                (std::uint32_t)0,  // in1_mcast_dest_noc_end_y
+
+                // sparsity args
+                (std::uint32_t)0,  // sparsity_addr
+
+                // WRITER
+                // out tensor args
+                (std::uint32_t)out_tensor.address(),
+                ((std::uint32_t)output_idx_x * per_core_N) +
+                    (output_idx_y * per_core_M * N)  // out_tensor_start_tile_id
+            };
+
+            if (output_idx_x == num_blocks_x - 1) {
+                // padding args (READER)
+                mm_in1_sender_writer_args.push_back(last_out_block_w);
+
+                // padding args (WRITER)
+                mm_in1_sender_writer_args.push_back(in0_last_block_num_nonzero_subblocks_h);
+                mm_in1_sender_writer_args.push_back(in0_last_subblock_of_last_block_h);
+                mm_in1_sender_writer_args.push_back(in0_last_block_padded_block_tiles_h_skip);
+                mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);  // out_num_nonzero_subblocks_w
+                mm_in1_sender_writer_args.push_back(last_block_num_nonzero_subblocks_w);
+                mm_in1_sender_writer_args.push_back(last_subblock_of_last_block_w);
+                mm_in1_sender_writer_args.push_back(last_block_padded_subblock_tiles_addr_skip);
+                mm_in1_sender_writer_args.push_back(last_block_padded_block_tiles_w_skip);
+            } else {
+                // padding args (READER)
+                mm_in1_sender_writer_args.push_back(out_block_w);
+
+                // padding args (WRITER)
+                mm_in1_sender_writer_args.push_back(in0_last_block_num_nonzero_subblocks_h);
+                mm_in1_sender_writer_args.push_back(in0_last_subblock_of_last_block_h);
+                mm_in1_sender_writer_args.push_back(in0_last_block_padded_block_tiles_h_skip);
+                mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);  // out_num_nonzero_subblocks_w
+                mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
+                mm_in1_sender_writer_args.push_back(out_subblock_w);
+                mm_in1_sender_writer_args.push_back(0);
+                mm_in1_sender_writer_args.push_back(0);
+            }
+
+            mm_in1_sender_writer_args.push_back(bias_tensor.has_value() ? (std::uint32_t)bias_tensor->address() : 0);
+            mm_in1_sender_writer_args.push_back(
+                bias_tensor.has_value() ? (std::uint32_t)per_core_N * output_idx_x : 0);  // in3_tensor_start_tile_id
+            if (!output_is_sharded) {
+                if (output_idx_x == num_blocks_x - 1) {
+                    mm_in1_sender_writer_args.push_back(last_out_num_blocks_w);
+                } else {
+                    mm_in1_sender_writer_args.push_back(out_num_blocks_x);
+                }
+            }
+
+            if (fuse_op && fused_op_signaler->is_all_gather()) {
+                fused_op_signaler->push_matmul_fused_op_rt_args(mm_in1_sender_writer_args, true);
+            }
+
+            tt_metal::SetRuntimeArgs(
+                program, mm_kernel_in1_sender_writer_id, core, mm_in1_sender_writer_args);  // RISCV_0_default
+        }
+    }
+
+    return MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t{
+        {mm_kernel_in0_mcast_cores_with_work_and_in_receiver_grid_id, mm_kernel_in1_sender_writer_id},
+        {cb_src1, cb_src2, cb_src3, cb_output},
+        false,
+        start_core,
+        cores,
+        num_cores_with_work,
+        ttnn::prim::qsr::Matmul1DType::MCAST_IN0};
+}
+
+MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_program_and_create_override_variables(
+    tt_metal::Program& program,
+    const tt::tt_metal::Tensor& a,
+    tt_metal::IDevice* device,
+    MathFidelity math_fidelity,
+    bool fp32_dest_acc_en,
+    bool math_approx_mode,
+    bool packer_l1_acc,
+    CoreCoord compute_with_storage_grid_size,
+    ttnn::operations::compute_throttle_utils::ThrottleLevel throttle_level,
+    uint32_t in0_B,
+    uint32_t in1_B,
+    uint32_t M,
+    uint32_t N,
+    uint32_t K,
+    bool bcast_batch,
+    bool transpose_a,
+    bool transpose_b,
+    uint32_t in0_block_w,
+    uint32_t out_subblock_h,
+    uint32_t out_subblock_w,
+    uint32_t out_block_h,
+    uint32_t out_block_w,
+    uint32_t per_core_M,
+    uint32_t per_core_N,
+    std::optional<UnaryWithParam> fused_activation,
+    const MeshTensor& in0_tensor,
+    const MeshTensor& in1_tensor,
+    ttsl::optional_reference<const MeshTensor> bias_tensor,
+    const MeshTensor& out_tensor,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const tt::tt_metal::Tile& bias_tile,
+    const tt::tt_metal::Tile& output_tile,
+    tt::DataFormat in0_data_format,
+    tt::DataFormat in1_data_format,
+    tt::DataFormat bias_data_format,
+    tt::DataFormat output_data_format,
+    bool in0_is_sharded,
+    bool output_is_sharded,
+    bool untilize_out,
+    bool row_broadcast_bias = true,
+    CoreCoord sub_device_start_core = {0, 0}) {
+    // currently only support transpose of the full tile
+    bool in0_transpose_tile = in0_tile.get_transpose_of_faces() && in0_tile.get_transpose_within_face();
+    bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
+
+    bool fuse_op = false;
+
+    uint32_t num_blocks = K / in0_block_w;
+    // Only enable packer l1 accumulation when there are num_blocks > 2, otherwise
+    // unnecessary overhead for reconfigs are added. Last iteration of l1 accumulation
+    // does a spill and reload, so need more than 2 blocks to use l1 acc for packer
+    // For bias, last iteration of l1 acc remains in intermediate buffer, does not spill and reload
+    bool packer_l1_acc_en = packer_l1_acc && (((bias_tensor.has_value()) && num_blocks > 1) || (num_blocks > 2));
+
+    // if fp32 enabled then we pack fp32 in l1, if not, then we pack fp16 in l1
+    tt::DataFormat interm0_data_format = packer_l1_acc_en
+                                             ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)
+                                             : (fp32_dest_acc_en ? tt::DataFormat::Float32 : output_data_format);
+
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    uint32_t bias_single_tile_size = bias_tile.get_tile_size(bias_data_format);
+    uint32_t output_single_tile_size = output_tile.get_tile_size(output_data_format);
+    uint32_t interm0_single_tile_size = output_tile.get_tile_size(interm0_data_format);
+
+    bool do_not_inplace_interm0_out_CB = output_is_sharded && (per_core_M != out_block_h);
+
+    uint32_t in0_block_h = out_block_h;
+    uint32_t in1_block_w = out_block_w;
+    uint32_t in0_num_blocks_y = per_core_M / out_block_h;
+    uint32_t in1_num_blocks_x = per_core_N / out_block_w;
+    uint32_t out_num_blocks_x = in1_num_blocks_x;
+    uint32_t out_num_blocks_y = in0_num_blocks_y;
+
+    uint32_t in0_block_tiles = in0_block_h * in0_block_w;
+    uint32_t in0_CB_tiles = in0_block_tiles;
+
+    bool reuse_in0_in_CB =
+        ((in0_B == 1 && in1_B > 1) && !in0_is_sharded && !output_is_sharded && !bcast_batch &&
+         !fused_activation.has_value());
+
+    if (reuse_in0_in_CB) {
+        in0_CB_tiles = per_core_M * num_blocks * in0_block_w;
+    } else if (in0_is_sharded) {
+        in0_CB_tiles = num_blocks * per_core_M * in0_block_w * in0_B;
+    } else if (in0_B * num_blocks > 1) {
+        in0_CB_tiles = in0_CB_tiles * 2;  // double buffer
+    }
+    // Tiles whose size is not a multiple of the DRAM alignment (e.g. bfp8 32x16 = 544B on
+    // Blackhole's 64B alignment) are padded to it in DRAM. The interleaved reader copies tiles at
+    // the padded stride, so the in0/in1/bias CBs must hold pages at the aligned stride and the
+    // reader/unpacker walk tiles at the same stride. No-op when already aligned (all bf16 tiles,
+    // 32-wide bfp8, Wormhole). Replaces the staging-CB workaround. Sharded CBs are backed by the
+    // tensor buffer and keep their natural page size.
+    const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
+    uint32_t in0_aligned_tile_size =
+        in0_is_sharded ? in0_single_tile_size : tt::align(in0_single_tile_size, dram_alignment);
+    uint32_t in1_aligned_tile_size = tt::align(in1_single_tile_size, dram_alignment);
+    uint32_t in0_CB_size = in0_CB_tiles * in0_aligned_tile_size;
+
+    const auto& a_shape_logical =
+        operations::experimental::quasar::matmul::utilities::get_matmul_tensor_logical_shape(a, transpose_a);
+    // When transpose_a is true, the K dimension maps to the row dimension of the raw tile,
+    // which is already zero-padded during tile layout conversion. pad_last_ktile operates on
+    // columns, so applying it would incorrectly zero valid data that becomes output rows
+    // after the compute kernel transposes the tile.
+    const auto in0_last_ktile_w = transpose_a ? 0 : a_shape_logical[-1] % in0_tile.get_width();
+    const auto in0_last_ktile_h = transpose_a ? a_shape_logical[-1] % in0_tile.get_width() : 0;
+    TT_FATAL(
+        in0_last_ktile_w == 0 || in0_last_ktile_h == 0,
+        "At most one of in0_last_ktile_w ({}) and in0_last_ktile_h ({}) can be non-zero",
+        in0_last_ktile_w,
+        in0_last_ktile_h);
+
+    bool extract_shard_sub_blocks = false;
+    uint32_t in0_shard_height_in_tiles = 0;
+    uint32_t in0_shard_width_in_tiles = 0;
+    if (in0_is_sharded) {
+        in0_shard_height_in_tiles = in0_tensor.shard_spec()->shape[0] / in0_tile.get_height();
+        in0_shard_width_in_tiles = in0_tensor.shard_spec()->shape[1] / in0_tile.get_width();
+        // NOTE: Criteria for extract_shard_sub_blocks is different from mcast in0
+        // In the reader kernel, always need to copy to cb0 even for height=1 shards since we may not always do mcast
+        // In mcast in0 sharded reader kernel, this is handled by mcast with loopback src
+        // For mcast in1, if we don't need to extract_shard_sub_blocks, set the sharded in0 cb to cb0
+        // For mcast in0, sharded in0 cb is always cb2
+        if (in0_shard_width_in_tiles / in0_block_w > 1) {
+            extract_shard_sub_blocks = true;
+        }
+    }
+    uint32_t in2_CB_tiles = in0_block_tiles;
+    uint32_t in2_CB_size = in2_CB_tiles * in0_single_tile_size;
+
+    uint32_t in1_block_tiles = out_block_w * in0_block_w;
+    uint32_t in1_CB_tiles = in1_block_tiles;
+    if (in1_B * num_blocks > 1) {
+        in1_CB_tiles = in1_CB_tiles * 2;  // double buffer
+    }
+
+    uint32_t in1_CB_size = in1_CB_tiles * in1_aligned_tile_size;
+
+    uint32_t out_block_tiles = out_block_h * out_block_w;
+    uint32_t out_shard_tiles = per_core_M * per_core_N;
+    uint32_t out_CB_tiles = out_block_tiles;  // No double buffer
+    if (output_is_sharded) {
+        out_CB_tiles = out_shard_tiles;
+    }
+    uint32_t out_CB_size = out_CB_tiles * output_single_tile_size;
+    uint32_t interm0_CB_tiles = out_block_tiles;  // No double buffer
+    uint32_t interm0_CB_size = interm0_CB_tiles * interm0_single_tile_size;
+
+    uint32_t in3_block_tiles = out_block_w;
+    uint32_t in3_CB_tiles = in3_block_tiles;  // No double buffer
+    uint32_t in3_CB_size = in3_CB_tiles * bias_single_tile_size;
+
+    CoreCoord start_core = sub_device_start_core;
+
+    // The matmul region is the rectangle of size `compute_with_storage_grid_size`
+    // anchored at `start_core`. Callers must ensure this rectangle lies entirely
+    // within the active sub-device's worker cores (validated upstream).
+    CoreRangeSet matmul_core_rect(CoreRange(
+        start_core,
+        CoreCoord(
+            start_core.x + compute_with_storage_grid_size.x - 1, start_core.y + compute_with_storage_grid_size.y - 1)));
+
+    uint32_t num_blocks_y = ((M - 1) / per_core_M) + 1;
+    uint32_t num_blocks_x = ((N - 1) / per_core_N) + 1;
+    uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
+    uint32_t num_cores = num_blocks_total;
+
+    constexpr bool row_major = true;
+    CoreRangeSet all_cores =
+        tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores, matmul_core_rect, row_major);
+    CoreRange in1_mcast_receiver_cores_bounding_box = all_cores.bounding_box();
+    uint32_t in1_mcast_receiver_num_cores = in1_mcast_receiver_cores_bounding_box.size();  // always mcast to full grid
+
+    CoreRange in1_mcast_sender(start_core, start_core);
+    CoreRangeSet in1_mcast_receivers;
+    if (in1_mcast_receiver_num_cores > 1) {
+        // Check against the actual rectangle width (instead of bare grid_size.x-1) so that
+        // sub-devices anchored away from (0, 0) wrap correctly.
+        auto receiver_start_core = compute_with_storage_grid_size.x > 1 ? CoreCoord{start_core.x + 1, start_core.y}
+                                                                        : CoreCoord{start_core.x, start_core.y + 1};
+        in1_mcast_receivers = tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(
+            receiver_start_core, num_cores - 1, matmul_core_rect, row_major);
+    }
+
+    // Mcast args
+    auto in1_mcast_sender_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto in1_mcast_receiver_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+
+    CoreCoord top_left_core = in1_mcast_receiver_cores_bounding_box.start_coord;
+    CoreCoord bottom_right_core = in1_mcast_receiver_cores_bounding_box.end_coord;
+    auto top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
+    auto bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
+
+    const auto& a_padded_shape =
+        operations::experimental::quasar::matmul::utilities::get_matmul_tensor_padded_shape(a, transpose_a);
+    const uint32_t M_per_batch = a_padded_shape[-2] / in0_tile.get_height();
+    const auto [in0_tensor_stride_w, in0_tensor_stride_h] =
+        operations::experimental::quasar::matmul::utilities::get_in0_transpose_strides(M, M_per_batch, transpose_a, K);
+    const auto in0_tensor_next_block_stride = in0_block_w * in0_tensor_stride_w;
+    const auto in0_tensor_next_h_dim_block_stride = in0_block_h * in0_tensor_stride_h;
+    const auto in0_tensor_start_tile_id_stride = per_core_M * in0_tensor_stride_h;
+
+    const auto in1_tensor_stride_w = transpose_b ? K : 1;
+    const auto in1_tensor_stride_h = transpose_b ? 1 : N;
+    const auto in1_tensor_next_block_stride = in0_block_w * in1_tensor_stride_h;
+    const auto in1_tensor_next_w_dim_block_stride = in1_block_w * in1_tensor_stride_w;
+    const auto in1_tensor_start_tile_id_stride = per_core_N * in1_tensor_stride_w;
+
+    std::vector<uint32_t> in0_sender_compile_time_args = {
+        // in0 tensor args
+        (std::uint32_t)in0_tensor_stride_w,
+        (std::uint32_t)in0_tensor_stride_h,
+        (std::uint32_t)in0_tensor_next_block_stride,
+        (std::uint32_t)in0_tensor_next_h_dim_block_stride,
+        // in0 block args
+        (std::uint32_t)in0_block_w,                // in0_block_w
+        (std::uint32_t)in0_block_h,                // in0_block_h
+        (std::uint32_t)in0_block_w * in0_block_h,  // in0_block_num_tiles
+        (std::uint32_t)in0_last_ktile_w,
+        (std::uint32_t)in0_last_ktile_h,
+
+        (std::uint32_t)extract_shard_sub_blocks,
+        (std::uint32_t)in0_shard_width_in_tiles,
+        (std::uint32_t)in0_shard_height_in_tiles,
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,        // num_blocks
+        (std::uint32_t)out_num_blocks_x,  // out_num_blocks_x
+        (std::uint32_t)out_num_blocks_y,  // out_num_blocks_y
+        // in0 mcast args
+        (std::uint32_t)0,
+        (std::uint32_t)0,
+        (std::uint32_t)0,  // in0_mcast_num_dests
+        (std::uint32_t)0,  // in0_mcast_num_cores
+        // batch args
+        (std::uint32_t)M * K,            // MtKt
+        (std::uint32_t)in0_B,            // batch
+        (std::uint32_t)in1_B,            // batch
+        (std::uint32_t)reuse_in0_in_CB,  // reuse_in0_in_CB
+        // sparsity args
+        (std::uint32_t)0,     // batchB
+        (std::uint32_t)0,     // sparsity_pagesize (placeholder since sparsity not used in this case)
+        (std::uint32_t)true,  // bcast_A
+        (std::uint32_t)false  // get_batch_from_reader
+    };
+    in0_sender_compile_time_args.push_back((std::uint32_t)fuse_op);
+    tt::tt_metal::TensorAccessorArgs(in0_tensor).append_to(in0_sender_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs().append_to(in0_sender_compile_time_args);  // placeholder for sparsity
+    in0_sender_compile_time_args.push_back((std::uint32_t)0);  // num_batch_compute (unused, sparsity disabled)
+
+    std::vector<uint32_t> in1_sender_writer_compile_time_args = {
+        // READER
+        // in1 tensor args
+        (std::uint32_t)in1_tensor_stride_w,
+        (std::uint32_t)in1_tensor_stride_h,
+        (std::uint32_t)in1_tensor_next_block_stride,
+        (std::uint32_t)in1_tensor_next_w_dim_block_stride,
+        // in1 block args
+        (std::uint32_t)in1_block_w,                // in1_block_w
+        (std::uint32_t)in0_block_w,                // in1_block_h
+        (std::uint32_t)in1_block_w * in0_block_w,  // in1_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,        // num_blocks
+        (std::uint32_t)out_num_blocks_x,  // out_num_blocks_x
+        (std::uint32_t)out_num_blocks_y,  // out_num_blocks_y
+        // in1 mcast args
+        (std::uint32_t)in1_mcast_sender_semaphore_id,
+        (std::uint32_t)in1_mcast_receiver_semaphore_id,
+        (std::uint32_t)num_cores - 1,                     // in1_mcast_num_dests
+        (std::uint32_t)in1_mcast_receiver_num_cores - 1,  // in1_mcast_num_cores
+        // batch args
+        (std::uint32_t)K * N,                              // KtNt
+        (std::uint32_t)(reuse_in0_in_CB ? in1_B : in0_B),  // batch
+        (std::uint32_t)bcast_batch,                        // bcast_B
+        // sparsity args
+        (std::uint32_t)0,  // batchB
+        (std::uint32_t)0,  // sparsity_pagesize (placeholder since sparsity not used in this case)
+
+        // WRITER
+        // out tensor args
+        (std::uint32_t)1,                   // out_tensor_stride_w
+        (std::uint32_t)N,                   // out_tensor_stride_h
+        (std::uint32_t)out_subblock_w,      // out_tensor_next_subblock_stride_w
+        (std::uint32_t)out_subblock_h * N,  // out_tensor_next_subblock_stride_h
+        (std::uint32_t)out_block_w,         // out_tensor_next_w_dim_block_stride
+        (std::uint32_t)out_block_h * N,     // out_tensor_next_h_dim_block_stride
+        // out subblock args
+        (std::uint32_t)out_subblock_w,                     // out_subblock_w
+        (std::uint32_t)out_subblock_h,                     // out_subblock_h
+        (std::uint32_t)(out_subblock_w * out_subblock_h),  // out_subblocks_w * out_subblocks_h
+        // batch args
+        (std::uint32_t)M * N  // MtNt
+    };
+
+    if (bias_tensor.has_value()) {
+        in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);  // in3_tensor_stride_w
+    } else {
+        in1_sender_writer_compile_time_args.push_back(0);  // Placeholder; not used
+    }
+
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)fuse_op);
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)fuse_op);
+
+    // Append TensorAccessorArgs
+    tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs().append_to(in1_sender_writer_compile_time_args);  // placeholder for sparsity
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_sender_writer_compile_time_args);
+    if (bias_tensor.has_value()) {
+        tt::tt_metal::TensorAccessorArgs(*bias_tensor).append_to(in1_sender_writer_compile_time_args);
+    }
+
+    std::vector<uint32_t> in1_receiver_writer_compile_time_args = {
+        // READER
+        // in1 block args
+        (std::uint32_t)in1_block_w * in0_block_w,  // in1_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,        // num_blocks
+        (std::uint32_t)out_num_blocks_x,  // out_num_blocks_x
+        (std::uint32_t)out_num_blocks_y,  // out_num_blocks_y
+        // in1 mcast args
+        (std::uint32_t)in1_mcast_sender_semaphore_id,
+        (std::uint32_t)in1_mcast_receiver_semaphore_id,
+        // batch args
+        (std::uint32_t)(reuse_in0_in_CB ? in1_B : in0_B),  // batch
+
+        // WRITER
+        // out tensor args
+        (std::uint32_t)1,                   // out_tensor_stride_w
+        (std::uint32_t)N,                   // out_tensor_stride_h
+        (std::uint32_t)out_subblock_w,      // out_tensor_next_subblock_stride_w
+        (std::uint32_t)out_subblock_h * N,  // out_tensor_next_subblock_stride_h
+        (std::uint32_t)out_block_w,         // out_tensor_next_w_dim_block_stride
+        (std::uint32_t)out_block_h * N,     // out_tensor_next_h_dim_block_stride
+        // out subblock args
+        (std::uint32_t)out_subblock_w,                     // out_subblock_w
+        (std::uint32_t)out_subblock_h,                     // out_subblock_h
+        (std::uint32_t)(out_subblock_w * out_subblock_h),  // out_subblocks_w * out_subblocks_h
+        // batch args
+        (std::uint32_t)M * N  // MtNt
+    };
+
+    if (bias_tensor.has_value()) {
+        in1_receiver_writer_compile_time_args.push_back((std::uint32_t)in1_block_w);
+    } else {
+        in1_receiver_writer_compile_time_args.push_back(0);  // Placeholder; not used
+    }
+    in1_receiver_writer_compile_time_args.push_back((std::uint32_t)fuse_op);
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_receiver_writer_compile_time_args);
+
+    std::map<std::string, std::string> mm_kernel_defines;
+    std::map<std::string, std::string> mm_kernel_in0_sender_defines;
+    std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
+    std::map<std::string, std::string> mm_kernel_in1_receiver_writer_defines;
+    if (bias_tensor.has_value()) {
+        mm_kernel_defines["FUSE_BIAS"] = "1";
+        mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
+        mm_kernel_in1_receiver_writer_defines["FUSE_BIAS"] = "1";
+    }
+    if (fused_activation.has_value()) {
+        if (fused_activation.value().op_type == UnaryOpType::RELU) {
+            mm_kernel_defines["PACK_RELU"] = "1";
+        } else {
+            mm_kernel_defines["SFPU_ACTIVATION"] = "1";
+        }
+    }
+    if (packer_l1_acc_en) {
+        mm_kernel_defines["PACKER_L1_ACC"] = "1";
+    }
+    if (fp32_dest_acc_en) {
+        mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    if (in1_transpose_tile) {
+        mm_kernel_defines["IN1_TRANSPOSE_TILE"] = "1";
+    }
+
+    ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
+        device->arch(), num_cores, mm_kernel_defines);
+    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
+        device->arch(), num_cores, mm_kernel_defines, throttle_level);
+
+    if (in0_is_sharded) {
+        mm_kernel_in0_sender_defines["IN0_SHARDED"] = "1";
+    }
+    if (output_is_sharded) {
+        mm_kernel_in1_sender_writer_defines["OUT_SHARDED"] = "1";
+        mm_kernel_in1_receiver_writer_defines["OUT_SHARDED"] = "1";
+    }
+
+    mm_kernel_in0_sender_defines["SKIP_MCAST"] = "1";
+
+    if (in1_mcast_receiver_num_cores == 1) {
+        mm_kernel_in1_sender_writer_defines["SKIP_MCAST"] = "1";
+    }
+
+    // Intermediate CB read
+    /*
+    Blackhole architecture alignment issue workaround for tiny tiles:
+
+    Problem: When reading tiny tiles from DRAM to circular buffers (CB), address alignment
+    issues occur. DRAM tile addresses are 64-byte aligned within each block, but L1 CB
+    addresses are not necessarily aligned due to non-64-byte-aligned page sizes.
+
+    Example scenario:
+    - Two consecutive 544-byte tiles (16x32 tile of dtype bfloat8_b) stored on different DRAM banks
+    - CB configured with size=2 to hold both tiles
+
+    Result:
+    - Tile 0: DRAM Bank 0, Address 64    → CB L1 Address 0   (64-byte aligned ✓)
+    - Tile 1: DRAM Bank 1, Address 64    → CB L1 Address 544 (not 64-byte aligned ✗)
+
+    Solution: Use an intermediate single-tile CB as a staging area. Read each tile into
+    the intermediate CB first, then copy to the destination CB. This ensures proper
+    alignment at the cost of additional memory bandwidth overhead.
+
+    Note: This workaround should only be used for this specific alignment issue case.
+    */
+
+    // in1 is the reader of weights/output writer, and we choose to make it use the optimized reader noc
+    tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+    tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+
+    auto mm_kernel_in0_sender_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+        "reader_bmm_tile_layout_in0_sender_padding.cpp",
+        all_cores,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = in0_noc,
+            .compile_args = in0_sender_compile_time_args,
+            .defines = mm_kernel_in0_sender_defines,
+            .named_compile_args = {
+                {"cb_in0", tt::CBIndex::c_0},
+                {"cb_in0_sharded", tt::CBIndex::c_2},
+                {"cb_sparsity", tt::CBIndex::c_6},
+            }});
+
+    auto mm_kernel_in1_sender_writer_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+        "reader_bmm_tile_layout_in1_sender_writer_padding.cpp",
+        in1_mcast_sender,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = in1_noc,
+            .compile_args = in1_sender_writer_compile_time_args,
+            .defines = mm_kernel_in1_sender_writer_defines,
+            .named_compile_args = {
+                {"cb_in1", tt::CBIndex::c_1},
+                {"cb_bias", tt::CBIndex::c_3},
+                {"cb_out", tt::CBIndex::c_4},
+                {"cb_sparsity", tt::CBIndex::c_7},
+            }});
+
+    tt::tt_metal::KernelHandle mm_kernel_in1_receiver_writer_id = 0;
+    if (in1_mcast_receivers.num_cores() > 0) {
+        mm_kernel_in1_receiver_writer_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+            "reader_bmm_tile_layout_in1_receiver_writer_padding.cpp",
+            in1_mcast_receivers,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = in1_noc,
+                .compile_args = in1_receiver_writer_compile_time_args,
+                .defines = mm_kernel_in1_receiver_writer_defines,
+                .named_compile_args = {
+                    {"cb_in1", tt::CBIndex::c_1},
+                    {"cb_bias", tt::CBIndex::c_3},
+                    {"cb_out", tt::CBIndex::c_4},
+                }});
+    }
+
+    // Compute kernel compile time args
+
+    uint32_t in0_num_subblocks = (out_block_h / out_subblock_h);
+    uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
+    uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
+
+    uint32_t in1_num_subblocks = (out_block_w / out_subblock_w);
+    uint32_t in1_block_num_tiles = out_subblock_w * in0_block_w * in1_num_subblocks;
+    uint32_t in1_per_core_w = out_subblock_w * in1_num_subblocks;
+
+    uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
+
+    std::vector<uint32_t> compute_kernel_args = {
+        in0_block_w,             // in0_block_w
+        in0_num_subblocks,       // in0_num_subblocks
+        in0_block_num_tiles,     // in0_block_num_tiles
+        in0_subblock_num_tiles,  // in0_subblock_num_tiles
+
+        in1_num_subblocks,    // in1_num_subblocks
+        in1_block_num_tiles,  // in1_block_num_tiles
+        in1_per_core_w,       // in1_per_core_w
+
+        num_blocks,        // num_blocks
+        out_num_blocks_x,  // out_num_blocks_x
+        out_num_blocks_y,  // out_num_blocks_y
+
+        out_subblock_h,                     // out_subblock_h
+        out_subblock_w,                     // out_subblock_w
+        out_subblock_num_tiles,             // out_subblock_num_tiles
+        (reuse_in0_in_CB ? in1_B : in0_B),  // batch
+        out_block_tiles,                    // out_block_num_tiles
+
+        untilize_out,  // untilize_out
+        false,         // get_batch_from_reader
+        in0_transpose_tile,
+    };
+    if (bias_tensor.has_value()) {
+        compute_kernel_args.push_back(row_broadcast_bias ? 1u : 0u);
+    }
+
+    // Setup named compile args
+    std::unordered_map<std::string, uint32_t> compute_named_compile_args = {
+        {"cb_in0", tt::CBIndex::c_0},
+        {"cb_in1", tt::CBIndex::c_1},
+        {"cb_bias", tt::CBIndex::c_3},
+        {"cb_out", tt::CBIndex::c_4},
+        {"cb_intermed0", tt::CBIndex::c_5},
+        {"cb_in0_transposed", tt::CBIndex::c_10},
+        {"bias_ntiles", in1_per_core_w},
+    };
+
+    // Add activation type if needed
+    if (fused_activation.has_value() && fused_activation.value().op_type != UnaryOpType::RELU) {
+        using ttnn::operations::experimental::quasar::matmul::utilities::get_activation_params;
+        const auto& activation = fused_activation.value();
+        const auto params = get_activation_params(activation);
+        compute_named_compile_args["activation_type"] = static_cast<uint32_t>(params.type);
+        compute_named_compile_args["activation_param0"] = params.param0;
+        compute_named_compile_args["activation_param1"] = params.param1;
+        compute_named_compile_args["activation_param2"] = params.param2;
+    }
+
+    // Create compute kernel
+    // bool fp32_dest_acc_en = false;
+    // Gelu currently has better accuracy when run in approx mode
+    // bool math_approx_mode = false;
+    tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/"
+        "bmm_large_block_zm_fused_bias_activation.cpp",
+        all_cores,
+        tt_metal::ComputeConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .math_approx_mode = math_approx_mode,
+            .compile_args = compute_kernel_args,
+            .defines = mm_kernel_defines,
+            .named_compile_args = compute_named_compile_args});
+
+    // Create circular buffers
+    uint32_t src0_cb_index = tt::CBIndex::c_0;
+    tt_metal::CircularBufferConfig src0_cb_config =
+        tt_metal::CircularBufferConfig(in0_CB_size, {{src0_cb_index, in0_data_format}})
+            .set_page_size(src0_cb_index, in0_aligned_tile_size)
+            .set_tile_dims(src0_cb_index, in0_tile);
+    if (in0_is_sharded and not extract_shard_sub_blocks) {
+        src0_cb_config = src0_cb_config.set_globally_allocated_address(in0_tensor);
+    }
+    auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, src0_cb_config);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        src0_cb_index,
+        in0_single_tile_size,
+        in0_CB_size / in0_single_tile_size,
+        in0_CB_size);
+
+    uint32_t src2_cb_index = tt::CBIndex::c_2;
+    tt::tt_metal::CBHandle cb_src2 = 0;
+    if (in0_is_sharded and extract_shard_sub_blocks) {  // in0_is_sharded is technically redundant
+        tt_metal::CircularBufferConfig src2_cb_config =
+            tt_metal::CircularBufferConfig(in2_CB_size, {{src2_cb_index, in0_data_format}})
+                .set_page_size(src2_cb_index, in0_single_tile_size)
+                .set_globally_allocated_address(in0_tensor)
+                .set_tile_dims(src2_cb_index, in0_tile);
+        cb_src2 = tt_metal::CreateCircularBuffer(program, all_cores, src2_cb_config);
+        log_debug(
+            LogOp,
+            "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+            src2_cb_index,
+            in0_single_tile_size,
+            in2_CB_size / in0_single_tile_size,
+            in2_CB_size);
+    }
+
+    uint32_t src1_cb_index = tt::CBIndex::c_1;
+    tt_metal::CircularBufferConfig src1_cb_config =
+        tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_data_format}})
+            .set_page_size(src1_cb_index, in1_aligned_tile_size)
+            .set_tile_dims(src1_cb_index, in1_tile);
+    tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        src1_cb_index,
+        in1_single_tile_size,
+        in1_CB_size / in1_single_tile_size,
+        in1_CB_size);
+
+    uint32_t output_cb_index = tt::CBIndex::c_4;
+    uint32_t interm0_cb_index = tt::CBIndex::c_5;
+    tt_metal::CircularBufferConfig interm0_cb_config =
+        tt_metal::CircularBufferConfig(0, {{interm0_cb_index, interm0_data_format}});
+    tt_metal::CircularBufferConfig output_cb_config =
+        tt_metal::CircularBufferConfig(0, {{output_cb_index, output_data_format}});
+
+    if (do_not_inplace_interm0_out_CB || (interm0_data_format != output_data_format) ||
+        (untilize_out && (in1_num_subblocks > 1))) {
+        // output
+        std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
+            {output_cb_index, output_data_format},
+        };
+        output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
+                               .set_page_size(output_cb_index, output_single_tile_size)
+                               .set_tile_dims(output_cb_index, output_tile);
+        // interm0
+        std::map<uint8_t, tt::DataFormat> interm0_cb_data_format_spec{
+            {interm0_cb_index, interm0_data_format},
+        };
+        interm0_cb_config = tt_metal::CircularBufferConfig(interm0_CB_size, interm0_cb_data_format_spec)
+                                .set_page_size(interm0_cb_index, interm0_single_tile_size)
+                                .set_tile_dims(interm0_cb_index, output_tile);
+
+        tt_metal::CreateCircularBuffer(program, CoreRangeSet({all_cores}), interm0_cb_config);
+        log_debug(
+            LogOp,
+            "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+            interm0_cb_index,
+            interm0_single_tile_size,
+            interm0_CB_size / interm0_single_tile_size,
+            interm0_CB_size);
+    } else {
+        // share buffer
+        std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
+            {output_cb_index, output_data_format}, {interm0_cb_index, interm0_data_format}};
+        output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
+                               .set_page_size(output_cb_index, output_single_tile_size)
+                               .set_page_size(interm0_cb_index, interm0_single_tile_size)
+                               .set_tile_dims(output_cb_index, output_tile)
+                               .set_tile_dims(interm0_cb_index, output_tile);
+    }
+
+    if (output_is_sharded) {
+        output_cb_config = output_cb_config.set_globally_allocated_address(out_tensor);
+    }
+    auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        output_cb_index,
+        output_single_tile_size,
+        out_CB_size / output_single_tile_size,
+        out_CB_size);
+
+    if (bias_tensor.has_value()) {
+        uint32_t src3_cb_index = tt::CBIndex::c_3;
+        tt_metal::CircularBufferConfig cb_src3_config =
+            tt_metal::CircularBufferConfig(in3_CB_size, {{src3_cb_index, bias_data_format}})
+                .set_page_size(src3_cb_index, bias_single_tile_size)
+                .set_tile_dims(src3_cb_index, bias_tile);
+        tt_metal::CreateCircularBuffer(program, all_cores, cb_src3_config);
+        log_debug(
+            LogOp,
+            "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+            src3_cb_index,
+            bias_single_tile_size,
+            in3_CB_size / bias_single_tile_size,
+            in3_CB_size);
+    }
+
+    // Intermediate CB read
+
+    if (in0_transpose_tile) {
+        const uint32_t in0_transpose_cb_index = tt::CBIndex::c_10;
+        auto in0_transpose_cb_config =
+            tt_metal::CircularBufferConfig(in0_CB_size, {{in0_transpose_cb_index, in0_data_format}})
+                .set_page_size(in0_transpose_cb_index, in0_aligned_tile_size)
+                .set_tile_dims(in0_transpose_cb_index, in0_tile);
+        tt_metal::CreateCircularBuffer(program, all_cores, in0_transpose_cb_config);
+    }
+
+    // Parameters for last row, col, or block
+    uint32_t last_per_core_M = M % per_core_M == 0 ? per_core_M : M % per_core_M;
+    uint32_t last_out_block_h = last_per_core_M % out_block_h == 0 ? out_block_h : last_per_core_M % out_block_h;
+    uint32_t last_out_num_blocks_h = ((last_per_core_M - 1) / out_block_h) + 1;
+    uint32_t last_block_num_nonzero_subblocks_h = ((last_out_block_h - 1) / out_subblock_h) + 1;
+    uint32_t last_subblock_of_last_block_h =
+        last_out_block_h % out_subblock_h == 0 ? out_subblock_h : last_out_block_h % out_subblock_h;
+    uint32_t last_block_padded_block_tiles_h_skip =
+        (out_block_h / out_subblock_h - last_block_num_nonzero_subblocks_h) * (out_block_w * out_subblock_h);
+
+    CoreCoord start_core_noc = bottom_right_core_physical;
+    CoreCoord end_core_noc = top_left_core_physical;
+    if (in1_noc == tt::tt_metal::NOC::NOC_0) {
+        std::swap(start_core_noc, end_core_noc);
+    }
+
+    const auto& cores = corerange_to_cores(all_cores, std::nullopt, row_major);
+    for (uint32_t i = 0; i < num_cores; ++i) {
+        const auto& core = cores[i];
+        uint32_t output_idx_x = i / num_blocks_y;
+        uint32_t output_idx_y = i % num_blocks_y;
+
+        // in0 sender and in1 sender
+        if (core == start_core) {
+            std::vector<uint32_t> mm_in1_sender_writer_args = {
+                // READER
+                // in1 tensor args
+                (std::uint32_t)in1_tensor.address(),
+                (std::uint32_t)in1_tensor_start_tile_id_stride * output_idx_x,  // in1_tensor_start_tile_id
+                // in1 mcast args
+                (std::uint32_t)start_core_noc.x,  // in1_mcast_dest_noc_start_x
+                (std::uint32_t)start_core_noc.y,  // in1_mcast_dest_noc_start_y
+                (std::uint32_t)end_core_noc.x,    // in1_mcast_dest_noc_end_x
+                (std::uint32_t)end_core_noc.y,    // in1_mcast_dest_noc_end_y
+
+                // sparsity args
+                (std::uint32_t)0,  // sparsity_addr
+
+                // WRITER
+                // out tensor args
+                (std::uint32_t)out_tensor.address(),
+                ((std::uint32_t)output_idx_x * per_core_N) +
+                    (output_idx_y * per_core_M * N),  // out_tensor_start_tile_id
+
+                // padding args (READER)
+                (std::uint32_t)out_block_w,  // last_block_w
+                // padding args (WRITER)
+                (std::uint32_t)out_block_h / out_subblock_h,
+                (std::uint32_t)out_subblock_h,
+                (std::uint32_t)0,
+                (std::uint32_t)out_block_w / out_subblock_w,
+                (std::uint32_t)out_block_w / out_subblock_w,
+                (std::uint32_t)out_subblock_w,
+                (std::uint32_t)0,
+                (std::uint32_t)0};
+
+            if (bias_tensor.has_value()) {
+                mm_in1_sender_writer_args.push_back((std::uint32_t)bias_tensor->address());
+                mm_in1_sender_writer_args.push_back(
+                    (std::uint32_t)per_core_N * output_idx_x);  // in3_tensor_start_tile_id
+            } else {
+                mm_in1_sender_writer_args.push_back(0);
+                mm_in1_sender_writer_args.push_back(0);
+            }
+            if (!output_is_sharded) {
+                mm_in1_sender_writer_args.push_back(out_num_blocks_x);
+            }
+
+            tt_metal::SetRuntimeArgs(
+                program, mm_kernel_in1_sender_writer_id, core, mm_in1_sender_writer_args);  // RISCV_1_default
+        }
+        // in0 sender and in1 receiver
+        else {
+            std::vector<uint32_t> mm_in1_receiver_writer_args = {
+                // READER
+                // in1 mcast args
+                (std::uint32_t)top_left_core_physical.x,  // in1_mcast_sender_noc_x
+                (std::uint32_t)top_left_core_physical.y,  // in1_mcast_sender_noc_y
+
+                // WRITER
+                // out tensor args
+                (std::uint32_t)out_tensor.address(),  // out_tensor_addr
+                ((std::uint32_t)output_idx_x * per_core_N) +
+                    (output_idx_y * per_core_M * N)  // out_tensor_start_tile_id
+            };
+
+            if (output_idx_y == num_blocks_y - 1) {
+                // padding args (WRITER)
+                mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                mm_in1_receiver_writer_args.push_back(last_block_num_nonzero_subblocks_h);
+                mm_in1_receiver_writer_args.push_back(last_subblock_of_last_block_h);
+                mm_in1_receiver_writer_args.push_back(last_block_padded_block_tiles_h_skip);
+                mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                mm_in1_receiver_writer_args.push_back(out_subblock_w);
+                mm_in1_receiver_writer_args.push_back(0);
+                mm_in1_receiver_writer_args.push_back(0);
+            } else {
+                // padding args (WRITER)
+                mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                mm_in1_receiver_writer_args.push_back(out_subblock_h);
+                mm_in1_receiver_writer_args.push_back(0);
+                mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                mm_in1_receiver_writer_args.push_back(out_subblock_w);
+                mm_in1_receiver_writer_args.push_back(0);
+                mm_in1_receiver_writer_args.push_back(0);
+            }
+            if (!output_is_sharded) {
+                if (output_idx_y == num_blocks_y - 1) {
+                    mm_in1_receiver_writer_args.push_back(last_out_num_blocks_h);
+                    mm_in1_receiver_writer_args.push_back(out_num_blocks_x);
+                } else {
+                    mm_in1_receiver_writer_args.push_back(out_num_blocks_y);
+                    mm_in1_receiver_writer_args.push_back(out_num_blocks_x);
+                }
+            }
+
+            tt_metal::SetRuntimeArgs(
+                program,
+                mm_kernel_in1_receiver_writer_id,
+                core,
+                mm_in1_receiver_writer_args);  // RISCV_0_default
+        }
+        std::vector<uint32_t> mm_in0_sender_args = {
+            // in0 tensor args
+            (std::uint32_t)in0_tensor.address(),
+            (std::uint32_t)in0_tensor_start_tile_id_stride * output_idx_y,  // in0_tensor_start_tile_id
+            // in0 mcast args
+            (std::uint32_t)0,  // in0_mcast_dest_noc_start_x
+            (std::uint32_t)0,  // in0_mcast_dest_noc_start_y
+            (std::uint32_t)0,  // in0_mcast_dest_noc_end_x
+            (std::uint32_t)0,  // in0_mcast_dest_noc_end_y
+
+            // padding args
+            (std::uint32_t)per_core_M,  // last_block_h
+
+            // sparsity args
+            (std::uint32_t)0,  // sparsity_addr
+        };
+        tt_metal::SetRuntimeArgs(program, mm_kernel_in0_sender_id, core, mm_in0_sender_args);  // RISCV_1_default
+    }
+    return MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t{
+        {mm_kernel_in0_sender_id, mm_kernel_in1_sender_writer_id, mm_kernel_in1_receiver_writer_id},
+        {cb_src0, cb_src2, cb_output},
+        extract_shard_sub_blocks,
+        start_core,
+        cores,
+        0,
+        ttnn::prim::qsr::Matmul1DType::MCAST_IN1};
+}
+
+enum class CORE_TYPE : uint32_t { IDLE_CORE = 0, WORKER_CORE = 1, HOP_CORE = 2 };
+
+MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0_program_and_create_override_variables(
+    tt_metal::Program& program,
+    const tt::tt_metal::Tensor& a,
+    const std::vector<tt::tt_metal::Tensor>& b_tensors,
+    tt_metal::IDevice* device,
+    MathFidelity math_fidelity,
+    bool fp32_dest_acc_en,
+    bool math_approx_mode,
+    bool packer_l1_acc,
+    bool dst_full_sync_en,
+    CoreCoord /*compute_with_storage_grid_size*/,
+    ttnn::operations::compute_throttle_utils::ThrottleLevel throttle_level,
+    uint32_t base_cb_index,
+    uint32_t /*B*/,
+    uint32_t /*M*/,
+    uint32_t /*N*/,
+    uint32_t K,
+    bool /*bcast_batch*/,
+    uint32_t in0_block_w,
+    uint32_t out_subblock_h,
+    uint32_t out_subblock_w,
+    uint32_t per_core_M,
+    uint32_t per_core_N,
+    std::optional<UnaryWithParam> fused_activation,
+    const CoreRangeSet& hop_cores,
+    const MeshTensor& in0_tensor,
+    const MeshTensor& in1_tensor,
+    std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>> out_buffers,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const tt::tt_metal::Tile& output_tile,
+    tt::DataFormat in0_data_format,
+    tt::DataFormat in1_data_format,
+    tt::DataFormat output_data_format,
+    bool untilize_out,
+    const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb,
+    uint32_t num_global_cb_receivers,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    std::optional<CoreRangeSet> restricted_cores,
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler) {
+    const auto& b = b_tensors[0];
+    const auto num_output_cb = out_buffers.size();
+    const auto batch = b_tensors.size();
+    const bool in1_is_dram_interleaved = in1_tensor.memory_config().is_dram() && !b.is_sharded();
+    const bool in1_is_dram_sharded =
+        in1_tensor.memory_config().is_dram() && b.is_sharded() && !global_cb.has_value();  // read from DRAM directly
+
+    /* Core setup */
+    constexpr bool row_major = true;
+    CoreRangeSet all_worker_cores = a.shard_spec().value().grid;
+    CoreRangeSet non_idle_cores = all_worker_cores.merge(hop_cores);
+    CoreRangeSet all_cores = non_idle_cores;
+    std::vector<CoreRange> non_idle_cores_vec;
+    auto subdevice_cores = device->worker_cores(
+        tt::tt_metal::HalProgrammableCoreType::TENSIX,
+        sub_device_id.has_value() ? *sub_device_id : device->get_sub_device_ids().at(0));
+    if (restricted_cores.has_value()) {
+        subdevice_cores = subdevice_cores.subtract(restricted_cores.value());
+    }
+    for (const auto& cr : subdevice_cores.ranges()) {
+        auto intersection = non_idle_cores.intersection(cr);
+        if (intersection.empty()) {
+            continue;
+        }
+        bool is_rectangular = cr.end_coord.x > cr.start_coord.x && cr.end_coord.y > cr.start_coord.y;
+        if (is_rectangular) {
+            non_idle_cores_vec.push_back(intersection.bounding_box());
+        } else {
+            for (const auto& ir : intersection.ranges()) {
+                non_idle_cores_vec.push_back(ir);
+            }
+        }
+    }
+    all_cores = CoreRangeSet(non_idle_cores_vec);
+    std::vector<CoreRange> ring_list = all_worker_cores.ranges();
+    std::vector<CoreRange> hop_list = hop_cores.ranges();
+    ring_list.insert(ring_list.end(), hop_list.begin(), hop_list.end());
+
+    CoreRangeSet ring_cores = CoreRangeSet(ring_list);
+    const uint32_t num_cores = all_worker_cores.num_cores();
+    const uint32_t ring_size = num_cores;
+
+    uint32_t num_hop_cores = hop_cores.num_cores();
+    bool use_hop_cores = num_hop_cores > 0;
+
+    /* Inner dim padding */
+    const uint32_t Kt_pad = in0_tensor.shard_spec()->shape[1] / in0_tile.get_width() * num_cores;
+    in0_block_w = Kt_pad / num_cores;
+
+    uint32_t num_blocks = Kt_pad / in0_block_w;
+    // Only enable packer l1 accumulation when there are spills, otherwise
+    // unnecessary overhead for reconfigs are added
+    bool packer_l1_acc_en = packer_l1_acc && num_blocks > 1;
+
+    bool use_global_cb = global_cb.has_value();
+
+    // if fp32 enabled then we pack fp32 in l1, if not, then we pack fp16 in l1
+    tt::DataFormat interm0_data_format = packer_l1_acc_en
+                                             ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)
+                                             : (fp32_dest_acc_en ? tt::DataFormat::Float32 : output_data_format);
+
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    uint32_t output_single_tile_size = output_tile.get_tile_size(output_data_format);
+    uint32_t interm0_single_tile_size = output_tile.get_tile_size(interm0_data_format);
+
+    /* in0 */
+    uint32_t in0_shard_width_in_tiles = in0_tensor.shard_spec()->shape[1] / in0_tile.get_width();
+    uint32_t in0_CB_tiles = per_core_M * in0_shard_width_in_tiles;
+    uint32_t in0_CB_size = in0_CB_tiles * in0_single_tile_size;
+
+    /* in1 */
+    uint32_t in1_shard_height_in_tiles = 0;
+    uint32_t in1_shard_width_in_tiles = 0;
+    uint32_t in1_CB_tiles = 0;
+
+    const auto& bshape =
+        operations::experimental::quasar::matmul::utilities::get_matmul_tensor_padded_shape(b, /*transpose=*/false);
+    uint32_t in1_tensor_width_in_tiles = bshape[-1] / in1_tile.get_width();
+
+    if (in1_is_dram_sharded || in1_is_dram_interleaved) {
+        in1_CB_tiles = 2 * in0_shard_width_in_tiles * per_core_N;  // Double buffered
+    } else if (use_global_cb) {
+        // in1 is fed via the remote GCB CB (created from global_cb->size() below), so this
+        // local in1_CB_size is dead. Skip reading the weight's legacy shard_spec — a
+        // receiver-contiguous weight is allocated with an NdShardSpec (no legacy shard_spec),
+        // and the per-receiver block geometry is fully described by per_core_N / the GCB page.
+        in1_shard_height_in_tiles = in0_block_w;
+        in1_shard_width_in_tiles = per_core_N;
+        in1_CB_tiles = in1_shard_height_in_tiles * in1_shard_width_in_tiles;
+    } else {
+        in1_shard_height_in_tiles = in1_tensor.shard_spec()->shape[0] / in1_tile.get_height();
+        in1_shard_width_in_tiles = in1_tensor.shard_spec()->shape[1] / in1_tile.get_width() / num_global_cb_receivers;
+        in1_CB_tiles = in1_shard_height_in_tiles * in1_shard_width_in_tiles;
+    }
+    uint32_t in1_CB_size = in1_CB_tiles * in1_single_tile_size;
+
+    // get the max page size based on num tiles
+    uint32_t per_core_N_size_bytes = per_core_N * in1_single_tile_size;
+    uint32_t max_packet_size = 8192;
+    uint32_t in1_block_page_size = per_core_N_size_bytes > max_packet_size ? max_packet_size : per_core_N_size_bytes;
+    uint32_t in1_block_page_size_last =
+        per_core_N_size_bytes > max_packet_size ? per_core_N_size_bytes % max_packet_size : per_core_N_size_bytes;
+    uint32_t in1_block_width_num_pages = (per_core_N_size_bytes + in1_block_page_size - 1) / in1_block_page_size;
+    uint32_t in1_shard_width_in_dram = 0;
+    if (in1_is_dram_sharded) {
+        in1_shard_width_in_dram = in1_tensor.shard_spec()->shape[1] / in1_tile.get_width();
+    }
+
+    /* in2 */
+    uint32_t in2_single_tile_size = in0_single_tile_size;
+    uint32_t in2_CB_tiles = (ring_size - 1) * in0_CB_tiles;  // All shards except local
+    uint32_t in2_CB_size = in2_CB_tiles * in2_single_tile_size;
+
+    /* out */
+    uint32_t out_block_tiles = per_core_M * per_core_N;
+    uint32_t out_CB_tiles = out_block_tiles;  // No double buffer
+    uint32_t out_CB_size = out_CB_tiles * output_single_tile_size;
+    uint32_t interm0_CB_size = out_CB_tiles * interm0_single_tile_size;
+
+    uint32_t K_ = K;
+    std::vector<uint32_t> unpadded_in0_shard_widths_in_tiles(num_cores, 0);
+    for (uint32_t i = 0; i < num_cores && K_ > 0; ++i) {
+        unpadded_in0_shard_widths_in_tiles[i] = std::min(K_, in0_shard_width_in_tiles);
+        K_ -= unpadded_in0_shard_widths_in_tiles[i];
+    }
+
+    /* semaphores */
+    auto in0_signal_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+
+    uint32_t in0_num_subblocks = (per_core_M / out_subblock_h);
+    uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
+    uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
+    uint32_t in1_num_subblocks = per_core_N / out_subblock_w;
+    uint32_t in1_block_height_in_tiles = in0_block_w;
+    uint32_t in1_block_num_tiles = out_subblock_w * in1_block_height_in_tiles * in1_num_subblocks;
+    uint32_t in1_block_size_bytes = in1_block_num_tiles * in1_single_tile_size;
+    uint32_t in1_tensor_size_bytes = in1_block_num_tiles * num_blocks * in1_single_tile_size;
+    uint32_t in1_per_core_w = out_subblock_w * in1_num_subblocks;
+    uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
+
+    /* Create circular buffers */
+    uint32_t src0_cb_index = base_cb_index;
+    tt_metal::CircularBufferConfig src0_cb_config =
+        tt_metal::CircularBufferConfig(in0_CB_size, {{src0_cb_index, in0_data_format}})
+            .set_page_size(src0_cb_index, in0_single_tile_size)
+            .set_tile_dims(src0_cb_index, in0_tile)
+            .set_globally_allocated_address(in0_tensor);
+    auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, src0_cb_config);
+
+    uint32_t src1_cb_index = base_cb_index + 1;
+    tt::tt_metal::CBHandle cb_src1;
+    uint32_t remote_cb_index = tt::CBIndex::c_31;
+    if (use_global_cb) {
+        uint32_t in1_block_size_bytes = in1_single_tile_size * in1_block_num_tiles;
+        tt_metal::CircularBufferConfig remote_cb_config =
+            tt_metal::CircularBufferConfig((global_cb->size() / in1_block_size_bytes) * in1_block_size_bytes);
+        remote_cb_config.remote_index(remote_cb_index)
+            .set_page_size(in1_block_size_bytes)
+            .set_data_format(in1_data_format);
+        remote_cb_config.index(src1_cb_index).set_page_size(in1_single_tile_size).set_data_format(in1_data_format);
+        cb_src1 = tt_metal::experimental::CreateCircularBuffer(program, all_cores, remote_cb_config, *global_cb);
+    } else {
+        tt_metal::CircularBufferConfig src1_cb_config =
+            tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_data_format}})
+                .set_page_size(src1_cb_index, in1_single_tile_size)
+                .set_tile_dims(src1_cb_index, in1_tile);
+        if (!in1_is_dram_interleaved && !in1_is_dram_sharded) {
+            src1_cb_config = src1_cb_config.set_globally_allocated_address(in1_tensor);
+        }
+        cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
+    }
+
+    uint32_t src2_cb_index = base_cb_index + 2;
+    tt_metal::CircularBufferConfig src2_cb_config =
+        tt_metal::CircularBufferConfig(in2_CB_size, {{src2_cb_index, in0_data_format}})
+            .set_page_size(src2_cb_index, in2_single_tile_size)
+            .set_tile_dims(src2_cb_index, in0_tile);
+    tt_metal::CreateCircularBuffer(program, all_cores, src2_cb_config);
+
+    uint32_t sync_cb_index = base_cb_index + 3;
+    uint32_t sync_cb_size_bytes = 16;
+    tt_metal::CircularBufferConfig sync_cb_config =
+        tt_metal::CircularBufferConfig(sync_cb_size_bytes, {{sync_cb_index, DataFormat::UInt16}})
+            .set_page_size(sync_cb_index, sync_cb_size_bytes);
+    tt_metal::CreateCircularBuffer(program, all_cores, sync_cb_config);
+
+    uint32_t sync_cb2_index = base_cb_index + 4;
+    uint32_t sync_cb2_size_bytes = 16;
+    tt_metal::CircularBufferConfig sync_cb2_config =
+        tt_metal::CircularBufferConfig(sync_cb2_size_bytes, {{sync_cb2_index, DataFormat::UInt16}})
+            .set_page_size(sync_cb2_index, sync_cb2_size_bytes);
+    tt_metal::CreateCircularBuffer(program, all_cores, sync_cb2_config);
+
+    uint32_t output_cb_index = base_cb_index + 5;  // output operands start at index 16
+    uint32_t interm0_cb_index = base_cb_index + 6;
+    tt_metal::CircularBufferConfig interm0_cb_config =
+        tt_metal::CircularBufferConfig(0, {{interm0_cb_index, interm0_data_format}});
+    tt_metal::CircularBufferConfig output_cb_config =
+        tt_metal::CircularBufferConfig(0, {{output_cb_index, output_data_format}});
+    std::vector<tt::tt_metal::CBHandle> cb_outputs;
+    std::vector<tt::tt_metal::CBHandle> output_cb_indices;
+    std::vector<tt::tt_metal::CBHandle> interm_cb_indices;
+
+    if ((interm0_data_format != output_data_format) || (untilize_out && (in1_num_subblocks > 1))) {
+        // interm0
+        std::map<uint8_t, tt::DataFormat> interm0_cb_data_format_spec{
+            {interm0_cb_index, interm0_data_format},
+        };
+        interm0_cb_config = tt_metal::CircularBufferConfig(interm0_CB_size, interm0_cb_data_format_spec)
+                                .set_page_size(interm0_cb_index, interm0_single_tile_size)
+                                .set_tile_dims(interm0_cb_index, output_tile);
+
+        tt_metal::CreateCircularBuffer(program, all_cores, interm0_cb_config);
+
+        for (uint32_t i = 0; i < out_buffers.size(); ++i) {
+            const auto& out_buffer = out_buffers[i];
+            output_cb_index += i * 2;  // 5, 7, 9...
+            TT_FATAL(
+                output_cb_index <= tt::CBIndex::c_31,
+                "Output circular buffer index {} exceeds maximum value {}",
+                output_cb_index,
+                tt::CBIndex::c_31);
+            // output
+            std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
+                {output_cb_index, output_data_format},
+            };
+            output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
+                                   .set_page_size(output_cb_index, output_single_tile_size)
+                                   .set_tile_dims(output_cb_index, output_tile)
+                                   .set_globally_allocated_address(out_buffer);
+            auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
+            cb_outputs.push_back(cb_output);
+            output_cb_indices.push_back(output_cb_index);
+            interm_cb_indices.push_back(interm0_cb_index);
+        }
+    } else {
+        for (uint32_t i = 0; i < out_buffers.size(); ++i) {
+            const auto& out_buffer = out_buffers[i];
+            output_cb_index += i * 2;   // 5, 7, 9...
+            interm0_cb_index += i * 2;  // 6, 8, 10...
+            TT_FATAL(
+                output_cb_index <= tt::CBIndex::c_31,
+                "Output circular buffer index {} exceeds maximum value {}",
+                output_cb_index,
+                tt::CBIndex::c_31);
+            TT_FATAL(
+                interm0_cb_index <= tt::CBIndex::c_31,
+                "Interm circular buffer index {} exceeds maximum value {}",
+                interm0_cb_index,
+                tt::CBIndex::c_31);
+            // share buffer
+            std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
+                {output_cb_index, output_data_format}, {interm0_cb_index, interm0_data_format}};
+            output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
+                                   .set_page_size(output_cb_index, output_single_tile_size)
+                                   .set_page_size(interm0_cb_index, interm0_single_tile_size)
+                                   .set_tile_dims(output_cb_index, output_tile)
+                                   .set_tile_dims(interm0_cb_index, output_tile)
+                                   .set_globally_allocated_address(out_buffer);
+            auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
+            cb_outputs.push_back(cb_output);
+            output_cb_indices.push_back(output_cb_index);
+            interm_cb_indices.push_back(interm0_cb_index);
+        }
+    }
+
+    /* Compile time args */
+    std::vector<uint32_t> in0_sender_compile_time_args = {
+        (std::uint32_t)in0_shard_width_in_tiles,
+        (std::uint32_t)per_core_M,  // in0_shard_height_in_tiles
+        (std::uint32_t)batch,       // batch
+        (std::uint32_t)ring_size,   // ring_size
+        (std::uint32_t)in0_signal_semaphore_id,
+    };
+
+    std::vector<uint32_t> in1_sender_writer_compile_time_args = {
+        (std::uint32_t)in1_is_dram_interleaved,    // in1_is_dram_interleaved
+        (std::uint32_t)in1_is_dram_sharded,        // in1_is_dram_sharded
+        (std::uint32_t)in1_block_height_in_tiles,  // in1_block_height_in_tiles
+        (std::uint32_t)per_core_N,                 // in1_block_width_in_tiles
+        (std::uint32_t)in1_tensor_width_in_tiles,  // in1_tensor_width_in_tiles
+        (std::uint32_t)num_blocks,                 // num_blocks
+        (std::uint32_t)batch,                      // batch
+        (std::uint32_t)in1_block_page_size,
+        (std::uint32_t)in1_block_page_size_last,
+        (std::uint32_t)in1_block_width_num_pages,
+        (std::uint32_t)in1_shard_width_in_dram,
+        (std::uint32_t)fused_op_signaler.has_value(),
+    };
+    tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);
+
+    /* compute kernel args */
+    const uint32_t out_block_num_subblocks = out_block_tiles / out_subblock_num_tiles;
+    TT_FATAL(
+        out_block_num_subblocks == 1 || !untilize_out,
+        "untilize_out is not supported for cases that out_block_num_subblocks > 1");
+    std::vector<uint32_t> compute_kernel_args = {
+        in0_block_w,             // in0_block_w
+        in0_num_subblocks,       // in0_num_subblocks
+        in0_block_num_tiles,     // in0_block_num_tiles
+        in0_subblock_num_tiles,  // in0_subblock_num_tiles
+
+        in1_num_subblocks,      // in1_num_subblocks
+        in1_block_num_tiles,    // in1_block_num_tiles
+        in1_block_size_bytes,   // in1_block_size_bytes
+        in1_tensor_size_bytes,  // in1_tensor_size_bytes
+        in1_per_core_w,         // in1_per_core_w
+
+        num_blocks,  // num_blocks
+
+        out_subblock_h,          // out_subblock_h
+        out_subblock_w,          // out_subblock_w
+        out_subblock_num_tiles,  // out_subblock_num_tiles
+        batch,                   // batch
+        out_block_tiles,         // out_block_num_tiles
+
+        untilize_out,             // untilize_out
+        in1_is_dram_interleaved,  // in1_is_dram_interleaved
+        in1_is_dram_sharded,      // in1_is_dram_sharded
+    };
+    std::unordered_map<std::string, uint32_t> compute_named_compile_args = {
+        {"cb_in0", src0_cb_index},
+        {"cb_in1", src1_cb_index},
+        {"cb_in2", src2_cb_index},
+        {"cb_sync", sync_cb_index},
+        {"cb_sync2", sync_cb2_index},
+    };
+    for (uint32_t i = 0; i < num_output_cb; ++i) {
+        compute_named_compile_args["cb_mm_out_" + std::to_string(i)] = output_cb_indices[i];
+    }
+    for (uint32_t i = 0; i < num_output_cb; ++i) {
+        compute_named_compile_args["cb_mm_partials_" + std::to_string(i)] = interm_cb_indices[i];
+    }
+
+    /* Kernel defines */
+    std::map<std::string, std::string> mm_in1_kernel_defines;
+    std::map<std::string, std::string> mm_kernel_defines;
+
+    if (use_global_cb) {
+        mm_in1_kernel_defines["ENABLE_GLOBAL_CB"] = "1";
+        mm_kernel_defines["ENABLE_GLOBAL_CB"] = "1";
+    }
+
+    if (fused_activation.has_value()) {
+        const auto& activation = fused_activation.value();
+        const auto& op_type = activation.op_type;
+        if (op_type == UnaryOpType::RELU) {
+            mm_kernel_defines["PACK_RELU"] = "1";
+        } else {
+            mm_kernel_defines["SFPU_ACTIVATION"] = "1";
+            using ttnn::operations::experimental::quasar::matmul::utilities::get_activation_params;
+            const auto params = get_activation_params(activation);
+            compute_named_compile_args["activation_type"] = static_cast<uint32_t>(params.type);
+            compute_named_compile_args["activation_param0"] = params.param0;
+            compute_named_compile_args["activation_param1"] = params.param1;
+            compute_named_compile_args["activation_param2"] = params.param2;
+        }
+    }
+    if (packer_l1_acc_en) {
+        mm_kernel_defines["PACKER_L1_ACC"] = "1";
+    }
+    if (fp32_dest_acc_en) {
+        mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
+        device->arch(), num_cores, mm_kernel_defines);
+    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
+        device->arch(), num_cores, mm_kernel_defines, throttle_level);
+
+    // in1 is the reader of weights/output writer, and we choose to make it use the optimized reader noc
+    tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+    tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+
+    bool use_dedicated_noc = true;
+    tt_metal::NOC_MODE noc_mode =
+        use_dedicated_noc ? tt_metal::NOC_MODE::DM_DEDICATED_NOC : tt_metal::NOC_MODE::DM_DYNAMIC_NOC;
+
+    // Init the signaler
+    if (fused_op_signaler.has_value()) {
+        ttnn::experimental::ccl::MatmulFusedOpSignaler& signaler = fused_op_signaler.value();
+        signaler.init_llama_rs_cores_mm(all_cores, program, device, 0);
+    }
+    /* Create the kernels */
+    auto mm_kernel_in0_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+        "reader_bmm_tile_layout_in0_ring_all_gather.cpp",
+        all_cores,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = in0_noc,
+            .noc_mode = noc_mode,
+            .compile_args = in0_sender_compile_time_args,
+            .named_compile_args = {{"cb_in0", src0_cb_index}, {"cb_in2", src2_cb_index}}});
+    // Each core needs to signal to all RS cores, need to get a count of how many cores are in all_cores
+    auto mm_kernel_in1_sender_writer_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+        "reader_bmm_tile_layout_in1_ring_all_gather.cpp",
+        all_cores,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = in1_noc,
+            .noc_mode = noc_mode,
+            .compile_args = in1_sender_writer_compile_time_args,
+            .defines = mm_in1_kernel_defines,
+            .named_compile_args = {
+                {"cb_in1", src1_cb_index},
+                {"cb_sync", sync_cb_index},
+                {"cb_sync2", sync_cb2_index},
+                {"cb_remote", remote_cb_index}}});
+
+    auto mm_kernel = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/"
+        "bmm_large_block_zm_fused_bias_activation_gathered.cpp",
+        all_cores,
+        tt_metal::ComputeConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .math_approx_mode = math_approx_mode,
+            .compile_args = compute_kernel_args,
+            .defines = mm_kernel_defines,
+            .named_compile_args = compute_named_compile_args});
+
+    // for all the cores in the rect grid, we send one rt arg to determine if they are worker core
+    auto all_cores_vec = corerange_to_cores(all_cores, std::nullopt, row_major);
+    auto worker_cores_vec = corerange_to_cores(all_worker_cores, std::nullopt, row_major);
+    auto hop_cores_vec = corerange_to_cores(hop_cores, std::nullopt, row_major);
+    for (auto core : all_cores_vec) {
+        auto all_worker_cores_iter = std::find(worker_cores_vec.begin(), worker_cores_vec.end(), core);
+        auto hop_cores_iter = std::find(hop_cores_vec.begin(), hop_cores_vec.end(), core);
+        bool core_is_in_all_worker_cores = all_worker_cores_iter != worker_cores_vec.end();
+        bool core_is_in_hop_cores = hop_cores_iter != hop_cores_vec.end();
+        if (!use_hop_cores) {
+            core_is_in_hop_cores = false;
+        }
+
+        if (!core_is_in_all_worker_cores && !core_is_in_hop_cores) {  // not worker core and not hop core
+            auto core_type = CORE_TYPE::IDLE_CORE;                    // idle core
+            // in0
+            std::vector<uint32_t> mm_kernel_in0_args;
+            mm_kernel_in0_args.push_back((std::uint32_t)core_type);
+            tt_metal::SetRuntimeArgs(program, mm_kernel_in0_id, core, mm_kernel_in0_args);
+
+            // in1
+            std::vector<uint32_t> mm_kernel_in1_sender_writer_args;
+            mm_kernel_in1_sender_writer_args.push_back((std::uint32_t)core_type);
+            if (fused_op_signaler.has_value()) {
+                ttnn::experimental::ccl::MatmulFusedOpSignaler& signaler = fused_op_signaler.value();
+                signaler.push_llama_rs_rt_args_for_mm(mm_kernel_in1_sender_writer_args, core, in1_noc, device);
+            }
+
+            tt_metal::SetRuntimeArgs(program, mm_kernel_in1_sender_writer_id, core, mm_kernel_in1_sender_writer_args);
+
+            // compute
+            std::vector<uint32_t> mm_kernel_args;
+            mm_kernel_args.push_back((std::uint32_t)core_type);
+            tt_metal::SetRuntimeArgs(program, mm_kernel, core, mm_kernel_args);
+        }
+    }
+
+    /* Runtime args */
+    // Mapping from worker core y-coordinate (and column group) to DRAM bank IDs.
+    // The DRAM banks are split into two column groups (left and right halves of the chip).
+    // On Wormhole: hardcoded mapping; banks 0-3 left column (x <= 3), banks 4-11 right column.
+    // On Blackhole: dynamically derived from optimal DRAM bank API; banks split at x <= 6.
+    std::map<uint32_t, uint32_t> worker_y_to_dram_bank_first_col;
+    std::map<uint32_t, uint32_t> worker_y_to_dram_bank_second_col;
+    uint32_t first_col_max_x = device->arch() == tt::ARCH::WORMHOLE_B0 ? 3 : 7;
+    uint32_t num_receiver_cores_per_dram = 2;  // default to 2 for wormhole b0 and blackhole
+    if (in1_is_dram_sharded) {
+        num_receiver_cores_per_dram = ring_size / in1_tensor.shard_spec()->grid.num_cores();
+        if (device->arch() == tt::ARCH::WORMHOLE_B0) {
+            worker_y_to_dram_bank_first_col[0] = 1;
+            worker_y_to_dram_bank_first_col[4] = 2;
+            worker_y_to_dram_bank_first_col[5] = 3;
+            worker_y_to_dram_bank_first_col[9] = 0;
+
+            worker_y_to_dram_bank_second_col[0] = 4;
+            worker_y_to_dram_bank_second_col[1] = 6;
+            worker_y_to_dram_bank_second_col[2] = 9;
+            worker_y_to_dram_bank_second_col[4] = 10;
+            worker_y_to_dram_bank_second_col[5] = 11;
+            worker_y_to_dram_bank_second_col[6] = 8;
+            worker_y_to_dram_bank_second_col[7] = 7;
+            worker_y_to_dram_bank_second_col[9] = 5;
+        } else {
+            // Dynamically derive mapping from optimal DRAM bank API
+            auto optimal_dram_workers = device->get_optimal_dram_bank_to_logical_worker_assignment(in1_noc);
+            uint32_t num_banks = optimal_dram_workers.size();
+            uint32_t banks_in_first_col = num_banks / 2;
+
+            std::vector<std::pair<uint32_t, uint32_t>> first_col_anchors;   // (y, bank_id)
+            std::vector<std::pair<uint32_t, uint32_t>> second_col_anchors;  // (y, bank_id)
+
+            for (uint32_t bank = 0; bank < num_banks; ++bank) {
+                const auto& core = optimal_dram_workers[bank];
+                if (bank < banks_in_first_col) {
+                    first_col_anchors.push_back({core.y, bank});
+                } else {
+                    second_col_anchors.push_back({core.y, bank});
+                }
+            }
+
+            // Sort anchors by y-coordinate for nearest-neighbor lookup
+            auto sort_by_y = [](const auto& a, const auto& b) { return a.first < b.first; };
+            std::sort(first_col_anchors.begin(), first_col_anchors.end(), sort_by_y);
+            std::sort(second_col_anchors.begin(), second_col_anchors.end(), sort_by_y);
+
+            // Helper to find nearest bank for a given y-coordinate
+            auto find_nearest_bank = [](uint32_t y,
+                                        const std::vector<std::pair<uint32_t, uint32_t>>& anchors) -> uint32_t {
+                if (anchors.empty()) {
+                    return 0;  // Fallback
+                }
+                uint32_t best_bank = anchors[0].second;
+                uint32_t best_dist = std::abs((int)y - (int)anchors[0].first);
+                for (const auto& [anchor_y, bank] : anchors) {
+                    uint32_t dist = std::abs((int)y - (int)anchor_y);
+                    if (dist < best_dist) {
+                        best_dist = dist;
+                        best_bank = bank;
+                    }
+                }
+                return best_bank;
+            };
+
+            // Build complete maps for all possible y-coordinates (0 to max worker y)
+            auto compute_grid = device->compute_with_storage_grid_size();
+            for (uint32_t y = 0; y < compute_grid.y; ++y) {
+                if (!first_col_anchors.empty()) {
+                    worker_y_to_dram_bank_first_col[y] = find_nearest_bank(y, first_col_anchors);
+                }
+                if (!second_col_anchors.empty()) {
+                    worker_y_to_dram_bank_second_col[y] = find_nearest_bank(y, second_col_anchors);
+                }
+            }
+        }
+    }
+
+    uint32_t bank_id = 0;
+    std::vector<uint32_t> bank_ids;
+    for (uint32_t i = 0; i < num_cores; ++i) {
+        bool send_to_hop_core = i == 0 && use_hop_cores;
+        const auto& core = worker_cores_vec[i];
+        const auto& core_noc = device->worker_core_from_logical_core(core);
+
+        /* in0 */
+        auto core_type = CORE_TYPE::WORKER_CORE;  // worker core
+        CoreCoord next_core;
+        if (send_to_hop_core) {
+            next_core = hop_cores_vec[0];  // Send to first hop core
+        } else {
+            uint32_t next_i = i == 0 ? num_cores - 1 : i - 1;
+            next_core = worker_cores_vec[next_i % num_cores];
+        }
+        const auto& next_core_noc = device->worker_core_from_logical_core(next_core);
+        uint32_t noc = get_preferred_noc(core_noc, next_core_noc, device, use_dedicated_noc);
+
+        std::vector<uint32_t> mm_in0_args = {
+            (std::uint32_t)core_type,
+            i,                // ring_index
+            next_core_noc.x,  // next_core_noc_x
+            next_core_noc.y,  // next_core_noc_y
+            noc,
+            (std::uint32_t)false,  // end_of_hop
+        };
+
+        mm_in0_args.insert(
+            mm_in0_args.end(), unpadded_in0_shard_widths_in_tiles.begin(), unpadded_in0_shard_widths_in_tiles.end());
+        tt_metal::SetRuntimeArgs(program, mm_kernel_in0_id, core, mm_in0_args);
+
+        /* in1 */
+        std::vector<uint32_t> mm_in1_args = {
+            (std::uint32_t)core_type,
+            in1_tensor.address(),  // in1_tensor_addr
+            i,                     // ring_idx
+        };
+        if (in1_is_dram_sharded) {
+            // Look up bank_id based on core.y and which column group core.x belongs to
+            if (core.x <= first_col_max_x) {
+                auto it = worker_y_to_dram_bank_first_col.find(core.y);
+                if (it == worker_y_to_dram_bank_first_col.end()) {
+                    log_info(
+                        tt::LogOp,
+                        "ERROR: Worker core ({}, {}) y={} NOT FOUND in first-col map! Available y values:",
+                        core.x,
+                        core.y,
+                        core.y);
+                    for (const auto& [y, bank] : worker_y_to_dram_bank_first_col) {
+                        log_info(tt::LogOp, "  y={}", y);
+                    }
+                }
+                bank_id = it->second;
+            } else {
+                auto it = worker_y_to_dram_bank_second_col.find(core.y);
+                if (it == worker_y_to_dram_bank_second_col.end()) {
+                    log_info(
+                        tt::LogOp,
+                        "ERROR: Worker core ({}, {}) y={} NOT FOUND in second-col map! Available y values:",
+                        core.x,
+                        core.y,
+                        core.y);
+                    for (const auto& [y, bank] : worker_y_to_dram_bank_second_col) {
+                        log_info(tt::LogOp, "  y={}", y);
+                    }
+                }
+                bank_id = it->second;
+            }
+
+            uint32_t dram_read_offset = 0;
+            /* TODO: This is a temporary solution to handle the dram read offset for the wormhole b0. */
+            /* TODO: The dram read offset is x coordinate dependent for wormhole because all usage on wormhole assumes
+             * input core range is column major, whereas blackhole usage is row major*/
+            /* TODO: The correct behaviour is that first core next to dram bank always has offset 0 and then offset
+             * increases by 1 for each core in the same row*/
+            /* TODO: This logic should be removed once all usage of ring matmul asserts that the input core ranges are
+             * arranged in row major order*/
+            if (device->arch() == tt::ARCH::WORMHOLE_B0) {
+                if (core.x % 2 == 0) {
+                    dram_read_offset = 1;
+                }
+            } else {
+                // For iterating through ring matmul cores in row major order
+                dram_read_offset = i % num_receiver_cores_per_dram;
+            }
+
+            bank_ids.push_back(bank_id);
+            uint32_t vc = 0;
+            for (uint32_t j = 0; j < i; ++j) {
+                auto core_prev = worker_cores_vec[j];
+                if (core_prev.y == core.y) {
+                    vc = (vc + 1) & 0x3;
+                }
+            }
+            mm_in1_args.push_back((std::uint32_t)bank_id);
+            mm_in1_args.push_back((std::uint32_t)vc);
+            mm_in1_args.push_back((std::uint32_t)dram_read_offset);
+        }
+        if (fused_op_signaler.has_value()) {
+            ttnn::experimental::ccl::MatmulFusedOpSignaler& signaler = fused_op_signaler.value();
+            signaler.push_llama_rs_rt_args_for_mm(mm_in1_args, core, in1_noc, device);
+        }
+        tt_metal::SetRuntimeArgs(program, mm_kernel_in1_sender_writer_id, core, mm_in1_args);
+
+        /* compute */
+        std::vector<uint32_t> mm_kernel_compute_args = {
+            (std::uint32_t)core_type,
+            i,  // ring_idx
+        };
+        mm_kernel_compute_args.insert(
+            mm_kernel_compute_args.end(),
+            unpadded_in0_shard_widths_in_tiles.begin(),
+            unpadded_in0_shard_widths_in_tiles.end());
+
+        tt_metal::SetRuntimeArgs(program, mm_kernel, core, mm_kernel_compute_args);
+    }
+
+    // Runtime args for hop cores
+    for (uint32_t i = 0; i < num_hop_cores; ++i) {
+        bool end_of_hop = i == num_hop_cores - 1;
+
+        auto core_type = CORE_TYPE::HOP_CORE;  // hop core
+        const auto& core = hop_cores_vec[i];
+        const auto& core_noc = device->worker_core_from_logical_core(core);
+
+        /* in0 */
+        CoreCoord next_core = end_of_hop ? worker_cores_vec[num_cores - 1] : hop_cores_vec[i + 1];
+        const auto& next_core_noc = device->worker_core_from_logical_core(next_core);
+        uint32_t noc = get_preferred_noc(core_noc, next_core_noc, device, use_dedicated_noc);
+
+        std::vector<uint32_t> mm_in0_args = {
+            (std::uint32_t)core_type,
+            0,                // ring_index
+            next_core_noc.x,  // next_core_noc_x
+            next_core_noc.y,  // next_core_noc_y
+            noc,
+            (std::uint32_t)end_of_hop,  // end_of_hop
+        };
+        tt_metal::SetRuntimeArgs(program, mm_kernel_in0_id, core, mm_in0_args);
+
+        // in1
+        std::vector<uint32_t> mm_kernel_in1_sender_writer_args;
+        mm_kernel_in1_sender_writer_args.push_back((std::uint32_t)core_type);
+        if (fused_op_signaler.has_value()) {
+            ttnn::experimental::ccl::MatmulFusedOpSignaler& signaler = fused_op_signaler.value();
+            signaler.push_llama_rs_rt_args_for_mm(mm_kernel_in1_sender_writer_args, core, in1_noc, device);
+        }
+        tt_metal::SetRuntimeArgs(program, mm_kernel_in1_sender_writer_id, core, mm_kernel_in1_sender_writer_args);
+
+        // compute
+        std::vector<uint32_t> mm_kernel_args;
+        mm_kernel_args.push_back((std::uint32_t)core_type);
+        tt_metal::SetRuntimeArgs(program, mm_kernel, core, mm_kernel_args);
+    }
+    std::vector<tt::tt_metal::CBHandle> shared_cbs = {cb_src0, cb_src1};
+    shared_cbs.insert(shared_cbs.end(), cb_outputs.begin(), cb_outputs.end());
+
+    return MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t{
+        {mm_kernel_in1_sender_writer_id},
+        shared_cbs,
+        false,
+        CoreCoord{0, 0},
+        worker_cores_vec,
+        0,
+        ttnn::prim::qsr::Matmul1DType::GATHER_IN0};
+}
+
+inline void override_mcast_in1_program_parameters(
+    tt_metal::Program& program,
+    const MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t& override_variables,
+    const ttnn::prim::qsr::MatmulInputs& tensor_args,
+    const std::vector<ttnn::Tensor>& output_tensors) {
+    const auto& input_tensors = tensor_args.input_tensors;
+    const auto& optional_input_tensors = tensor_args.optional_input_tensors;
+
+    TT_FATAL(
+        input_tensors.size() + optional_input_tensors.size() == 3,
+        "mcast in1 requires 3 input tensors, {} + {} = {} provided",
+        input_tensors.size(),
+        optional_input_tensors.size(),
+        optional_input_tensors.size() + input_tensors.size());
+    TT_FATAL(
+        output_tensors.size() == 1, "matmul mcast in1 requires 1 output tensor, {} provided", output_tensors.size());
+
+    const MeshTensor& src_a_tensor = input_tensors.at(0).mesh_tensor();
+    const MeshTensor& src_b_tensor = input_tensors.at(1).mesh_tensor();
+    const auto& bias_tensor = optional_input_tensors.at(0);
+
+    ttsl::optional_reference<const MeshTensor> bias_mesh_tensor;
+    if (bias_tensor.has_value()) {
+        bias_mesh_tensor = bias_tensor.value().mesh_tensor();
+    }
+
+    const MeshTensor& dst_tensor = output_tensors.at(0).mesh_tensor();
+
+    bool src0_sharded = input_tensors[0].is_sharded();
+    bool out_sharded = output_tensors[0].is_sharded();
+
+    auto& reader_runtime_args_by_core = GetRuntimeArgs(program, override_variables.kernels.at(0));
+
+    // Manually unroll sender core
+    {
+        // in0 sender
+        auto& reader_runtime_args =
+            reader_runtime_args_by_core[override_variables.start_core.x][override_variables.start_core.y];
+        reader_runtime_args[0] = src_a_tensor.address();
+
+        // in1 sender
+        auto& sender_writer_runtime_args =
+            GetRuntimeArgs(program, override_variables.kernels.at(1), override_variables.start_core);
+        sender_writer_runtime_args[0] = src_b_tensor.address();
+        sender_writer_runtime_args[7] = dst_tensor.address();
+        if (bias_tensor.has_value()) {
+            sender_writer_runtime_args[18] = bias_mesh_tensor->address();
+        }
+    }
+
+    auto& receiver_writer_runtime_args_by_core = GetRuntimeArgs(program, override_variables.kernels.at(2));
+
+    for (uint32_t i = 1; i < override_variables.cores.size(); ++i) {
+        const CoreCoord& core = override_variables.cores[i];
+
+        auto& reader_runtime_args = reader_runtime_args_by_core[core.x][core.y];
+
+        auto& writer_runtime_args = receiver_writer_runtime_args_by_core[core.x][core.y];
+
+        // in0 sender
+        reader_runtime_args[0] = src_a_tensor.address();
+        // in1 receiver
+        writer_runtime_args[2] = dst_tensor.address();
+    }
+
+    if (src0_sharded) {
+        if (override_variables.extract_shard_sub_blocks) {
+            UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(1), src_a_tensor);
+        } else {
+            UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(0), src_a_tensor);
+        }
+    }
+
+    if (out_sharded) {
+        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(2), dst_tensor);
+    }
+}
+
+static void override_mcast_in0_program_parameters(
+    tt_metal::Program& program,
+    const MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t& override_variables,
+    const ttnn::prim::qsr::MatmulInputs& tensor_args,
+    const std::vector<ttnn::Tensor>& output_tensors) {
+    const auto& input_tensors = tensor_args.input_tensors;
+    const auto& optional_input_tensors = tensor_args.optional_input_tensors;
+
+    TT_FATAL(
+        input_tensors.size() + optional_input_tensors.size() == 3,
+        "mcast in0 requires 3 input tensors, {} + {} = {} provided",
+        input_tensors.size(),
+        optional_input_tensors.size(),
+        optional_input_tensors.size() + input_tensors.size());
+    TT_FATAL(
+        output_tensors.size() == 1, "matmul mcast in0 requires 1 output tensor, {} provided", output_tensors.size());
+
+    const MeshTensor& src_a_tensor = input_tensors.at(0).mesh_tensor();
+    const MeshTensor& src_b_tensor = input_tensors.at(1).mesh_tensor();
+    const auto& bias_tensor = optional_input_tensors.at(0);
+
+    ttsl::optional_reference<const MeshTensor> bias_mesh_tensor;
+    if (bias_tensor.has_value()) {
+        bias_mesh_tensor = bias_tensor.value().mesh_tensor();
+    }
+
+    const MeshTensor& dst_tensor = output_tensors.at(0).mesh_tensor();
+
+    bool src0_sharded = input_tensors[0].is_sharded();
+    bool src1_sharded = input_tensors[1].is_sharded();
+    bool out_sharded = output_tensors[0].is_sharded();
+
+    // Manually unroll sender core
+    if (src0_sharded) {
+        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(1), src_a_tensor);
+    } else {
+        // in0 sender
+        auto& reader_sender_runtime_args =
+            GetRuntimeArgs(program, override_variables.kernels.at(0), override_variables.start_core);
+        reader_sender_runtime_args[0] = src_a_tensor.address();
+    }
+
+    if (src1_sharded) {
+        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(0), src_b_tensor);
+    }
+
+    if (bias_tensor.has_value() && bias_tensor.value().is_sharded()) {
+        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(2), *bias_mesh_tensor);
+    }
+
+    auto& writer_runtime_args_by_core = GetRuntimeArgs(program, override_variables.kernels.at(1));
+
+    for (uint32_t i = 0; i < override_variables.num_cores_with_work; ++i) {
+        const auto& core = override_variables.cores[i];
+
+        auto& writer_runtime_args = writer_runtime_args_by_core[core.x][core.y];
+
+        // in1 sender
+        writer_runtime_args[0] = src_b_tensor.address();
+        writer_runtime_args[7] = dst_tensor.address();
+        if (bias_tensor.has_value()) {
+            writer_runtime_args[18] = bias_mesh_tensor->address();
+        }
+    }
+
+    if (out_sharded) {
+        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(3), dst_tensor);
+    }
+}
+
+inline void override_gather_in0_program_parameters(
+    tt_metal::Program& program,
+    const MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t& override_variables,
+    const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb,
+    const ttnn::prim::qsr::MatmulInputs& tensor_args,
+    const std::vector<ttnn::Tensor>& output_tensors) {
+    const auto& input_tensors = tensor_args.input_tensors;
+
+    const MeshTensor& src_a_tensor = input_tensors[0].mesh_tensor();
+    const MeshTensor& src_b_tensor = input_tensors[1].mesh_tensor();
+
+    bool src0_sharded = input_tensors[0].is_sharded();
+    bool src1_sharded = input_tensors[1].is_sharded();
+    bool out_sharded = output_tensors[0].is_sharded();
+
+    // Manually unroll sender core
+    if (src0_sharded) {
+        UpdateDynamicCircularBufferAddress(program, override_variables.cbs[0], src_a_tensor);
+    }
+    if (src1_sharded) {
+        if (!global_cb.has_value() && !src_b_tensor.memory_config().is_dram()) {
+            UpdateDynamicCircularBufferAddress(program, override_variables.cbs[1], src_b_tensor);
+        }
+    }
+    if (out_sharded) {
+        for (uint32_t i = 0; i < override_variables.cbs.size() - 2; ++i) {
+            // cbs 0 and 1 contain cb_src0 and cb_src1
+            // the rest contains the actual output cbs
+            const auto& cb_output = override_variables.cbs[i + 2];
+            const MeshTensor& out_tensor = output_tensors[i].mesh_tensor();
+            UpdateDynamicCircularBufferAddress(program, cb_output, out_tensor);
+        }
+    }
+
+    // Update in1 tensor address for all worker cores.
+    // Note: override_variables.cores only contains worker cores (not hop/idle cores),
+    // so it's safe to unconditionally update index [1] which holds in1_tensor_addr.
+    auto& writer_runtime_args_by_core = GetRuntimeArgs(program, override_variables.kernels.at(0));
+    for (const auto& core : override_variables.cores) {
+        auto& writer_runtime_args = writer_runtime_args_by_core[core.x][core.y];
+
+        /* in1 */
+        writer_runtime_args[1] = src_b_tensor.address();
+    }
+}
+
+void override_program_parameters(
+    const MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t& override_variables,
+    const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb,
+    Program& program,
+    const ttnn::prim::qsr::MatmulInputs& tensor_args,
+    const std::vector<ttnn::Tensor>& tensor_return_value) {
+    switch (override_variables.type) {
+        case ttnn::prim::qsr::Matmul1DType::MCAST_IN0:
+            override_mcast_in0_program_parameters(program, override_variables, tensor_args, tensor_return_value);
+            break;
+        case ttnn::prim::qsr::Matmul1DType::GATHER_IN0: {
+            override_gather_in0_program_parameters(
+                program, override_variables, global_cb, tensor_args, tensor_return_value);
+            break;
+        }
+        case ttnn::prim::qsr::Matmul1DType::MCAST_IN1:
+            override_mcast_in1_program_parameters(program, override_variables, tensor_args, tensor_return_value);
+            break;
+    }
+}
+
+static ProgramDescriptor create_program_mcast_in0_descriptor(
+    const tt::tt_metal::Tensor& a,
+    tt_metal::IDevice* device,
+    MathFidelity math_fidelity,
+    bool fp32_dest_acc_en,
+    bool math_approx_mode,
+    bool packer_l1_acc,
+    CoreCoord compute_with_storage_grid_size,
+    ttnn::operations::compute_throttle_utils::ThrottleLevel throttle_level,
+    uint32_t in0_B,
+    uint32_t in1_B,
+    uint32_t M,
+    uint32_t N,
+    uint32_t K,
+    bool bcast_batch,
+    bool transpose_a,
+    bool transpose_b,
+    uint32_t in0_block_w,
+    uint32_t out_subblock_h,
+    uint32_t out_subblock_w,
+    uint32_t out_block_h,
+    uint32_t out_block_w,
+    uint32_t per_core_M,
+    uint32_t per_core_N,
+    std::optional<UnaryWithParam> fused_activation,
+    const MeshTensor& in0_tensor,
+    const MeshTensor& in1_tensor,
+    ttsl::optional_reference<const MeshTensor> bias_tensor,
+    const MeshTensor& out_tensor,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const tt::tt_metal::Tile& bias_tile,
+    const tt::tt_metal::Tile& output_tile,
+    tt::DataFormat in0_data_format,
+    tt::DataFormat in1_data_format,
+    tt::DataFormat bias_data_format,
+    tt::DataFormat output_data_format,
+    bool in0_is_sharded,
+    bool in1_is_sharded,
+    bool bias_is_sharded,
+    bool output_is_sharded,
+    bool untilize_out,
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler,
+    bool row_broadcast_bias = true,
+    CoreCoord sub_device_start_core = {0, 0}) {
+    using tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids;
+
+    // currently only support transpose of the full tile
+    bool in0_transpose_tile = in0_tile.get_transpose_of_faces() && in0_tile.get_transpose_within_face();
+    bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
+
+    bool fuse_op = fused_op_signaler.has_value();
+
+    uint32_t num_blocks = K / in0_block_w;
+    // Only enable packer l1 accumulation when there are spills, otherwise
+    // unnecessary overhead for reconfigs are added
+    bool packer_l1_acc_en = packer_l1_acc && num_blocks > 1;
+
+    // if fp32 enabled then we pack fp32 in l1, if not, then we pack fp16 in l1
+    tt::DataFormat interm0_data_format = packer_l1_acc_en
+                                             ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)
+                                             : (fp32_dest_acc_en ? tt::DataFormat::Float32 : output_data_format);
+
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    uint32_t bias_single_tile_size = bias_tile.get_tile_size(bias_data_format);
+
+    // Tiles whose size is not a multiple of the DRAM alignment (e.g. bfp8 32x16 = 544B on
+    // Blackhole's 64B alignment) are padded to it in DRAM. The interleaved reader copies tiles at
+    // the padded stride, so the in0/in1/bias CBs must hold pages at the aligned stride and the
+    // reader/unpacker walk tiles at the same stride. No-op when already aligned (all bf16 tiles,
+    // 32-wide bfp8, Wormhole). Replaces the staging-CB workaround. Sharded CBs are backed by the
+    // tensor buffer and keep their natural page size.
+    const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
+    uint32_t in0_aligned_tile_size =
+        in0_is_sharded ? in0_single_tile_size : tt::align(in0_single_tile_size, dram_alignment);
+    uint32_t in1_aligned_tile_size =
+        in1_is_sharded ? in1_single_tile_size : tt::align(in1_single_tile_size, dram_alignment);
+    uint32_t output_single_tile_size = output_tile.get_tile_size(output_data_format);
+    uint32_t interm0_single_tile_size = output_tile.get_tile_size(interm0_data_format);
+
+    bool do_not_inplace_interm0_out_CB = output_is_sharded && (per_core_M != out_block_h);
+
+    uint32_t in0_block_h = out_block_h;
+    uint32_t in1_block_w = out_block_w;
+    uint32_t in0_num_blocks_y = per_core_M / out_block_h;
+    uint32_t in1_num_blocks_x = per_core_N / out_block_w;
+    uint32_t out_num_blocks_x = in1_num_blocks_x;
+    uint32_t out_num_blocks_y = in0_num_blocks_y;
+
+    uint32_t in0_block_tiles = in0_block_h * in0_block_w;
+    uint32_t in0_CB_tiles = in0_block_tiles;
+    if (in0_B * num_blocks > 1) {
+        in0_CB_tiles *= operations::experimental::quasar::matmul::utilities::MCAST_INPUT_BUFFERING_DEPTH;
+    }
+    uint32_t in0_CB_size = in0_CB_tiles * in0_aligned_tile_size;
+
+    uint32_t in2_block_tiles = 0;
+    uint32_t in0_shard_width_in_tiles = 0;
+    uint32_t in0_shard_height_in_tiles = 0;
+    if (in0_is_sharded) {
+        in0_shard_width_in_tiles = in0_tensor.shard_spec()->shape[1] / in0_tile.get_width();
+        in0_shard_height_in_tiles = in0_tensor.shard_spec()->shape[0] / in0_tile.get_height();
+        in2_block_tiles = per_core_M * in0_shard_width_in_tiles;
+    }
+    uint32_t in2_CB_tiles = in2_block_tiles;
+    uint32_t in2_CB_size = in2_CB_tiles * in0_single_tile_size;
+
+    uint32_t in1_block_tiles = out_block_w * in0_block_w;
+    uint32_t in1_CB_tiles = in1_block_tiles;
+    if (in1_B * num_blocks > 1) {
+        in1_CB_tiles *= operations::experimental::quasar::matmul::utilities::MCAST_INPUT_BUFFERING_DEPTH;
+    }
+    if (in1_is_sharded) {
+        uint32_t in1_shard_height_in_tiles = in1_tensor.shard_spec()->shape[0] / in1_tile.get_height();
+        in1_CB_tiles = per_core_N * in1_shard_height_in_tiles;
+    }
+
+    uint32_t in1_CB_size = in1_CB_tiles * in1_aligned_tile_size;
+
+    uint32_t out_block_tiles = out_block_h * out_block_w;
+    uint32_t out_shard_tiles = per_core_M * per_core_N;
+    uint32_t out_CB_tiles = out_block_tiles;  // No double buffer
+    if (output_is_sharded) {
+        out_CB_tiles = out_shard_tiles;
+    }
+    uint32_t out_CB_size = out_CB_tiles * output_single_tile_size;
+    uint32_t interm0_CB_tiles = out_block_tiles;  // No double buffer
+    uint32_t interm0_CB_size = interm0_CB_tiles * interm0_single_tile_size;
+
+    uint32_t in3_block_tiles = out_block_w;
+    uint32_t in3_CB_tiles = in3_block_tiles;  // No double buffer
+    uint32_t in3_CB_size = in3_CB_tiles * bias_single_tile_size;
+
+    CoreCoord start_core = sub_device_start_core;
+    uint32_t start_core_x = start_core.x;
+    uint32_t start_core_y = start_core.y;
+    uint32_t num_cores_c = compute_with_storage_grid_size.x;
+
+    // The matmul region is the rectangle of size `compute_with_storage_grid_size`
+    // anchored at `start_core`. Callers must ensure this rectangle lies entirely
+    // within the active sub-device's worker cores (validated upstream).
+    CoreRangeSet matmul_core_rect(CoreRange(
+        start_core,
+        CoreCoord(
+            start_core_x + compute_with_storage_grid_size.x - 1, start_core_y + compute_with_storage_grid_size.y - 1)));
+
+    uint32_t num_blocks_y = ((M - 1) / per_core_M) + 1;
+    uint32_t num_blocks_x = ((N - 1) / per_core_N) + 1;
+    uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
+    uint32_t num_cores_with_work = num_blocks_total;
+
+    // mcast_in0 broadcasts a single M-block across all cores; only the start_core gets in0 sender
+    // runtime args (with output_idx_y == 0), so M must fit within per_core_M.
+    TT_FATAL(
+        num_blocks_y == 1,
+        "matmul_multicore_reuse_mcast_1d requires num_blocks_y == 1 (M <= per_core_M) for mcast_in0. "
+        "Got M={}, per_core_M={}, num_blocks_y={}.",
+        M,
+        per_core_M,
+        num_blocks_y);
+
+    uint32_t in0_sender_num_cores = in0_is_sharded ? a.shard_spec().value().grid.num_cores() : 1;
+    uint32_t num_cores = in0_is_sharded ? std::max(num_cores_with_work, in0_sender_num_cores) : num_cores_with_work;
+
+    constexpr bool row_major = true;
+    CoreRangeSet all_cores =
+        num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores, matmul_core_rect, row_major);
+
+    CoreRangeSet in0_mcast_sender_cores =
+        num_cores_to_corerangeset_in_subcoregrids(start_core, in0_sender_num_cores, matmul_core_rect, row_major);
+    CoreCoord in0_mcast_sender_cores_grid = in0_mcast_sender_cores.bounding_box().grid_size();
+
+    CoreRangeSet all_cores_with_work =
+        num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores_with_work, matmul_core_rect, row_major);
+    CoreRange in0_mcast_receiver_cores_bounding_box = all_cores_with_work.bounding_box();
+    uint32_t in0_mcast_receiver_num_cores = in0_mcast_receiver_cores_bounding_box.size();  // always mcast to full grid
+    uint32_t in0_mcast_receiver_num_dests = std::min(
+        in0_mcast_receiver_num_cores,
+        num_cores);  // should always be number of cores in receiver grid up to number of active cores
+
+    CoreRangeSet in0_mcast_cores_with_work_and_in_receiver_grid;
+    CoreRangeSet in0_mcast_cores_without_work_and_in_receiver_grid;
+    CoreRangeSet in0_mcast_cores_without_work_and_not_in_receiver_grid;
+    CoreRangeSet in0_mcast_receivers;
+    std::vector<uint32_t> in0_mcast_noc_x;
+    std::vector<uint32_t> in0_mcast_noc_y;
+    if (in0_is_sharded) {
+        in0_mcast_cores_with_work_and_in_receiver_grid = all_cores_with_work;
+
+        if (in0_mcast_receiver_num_dests > num_cores_with_work) {
+            const uint32_t in0_mcast_cores_without_work_and_in_receiver_grid_num_cores =
+                in0_mcast_receiver_num_dests - num_cores_with_work;
+            uint32_t core_idx_x = num_cores_with_work % num_cores_c;
+            uint32_t core_idx_y = num_cores_with_work / num_cores_c;
+            CoreCoord start_core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
+            in0_mcast_cores_without_work_and_in_receiver_grid = num_cores_to_corerangeset_in_subcoregrids(
+                start_core, in0_mcast_cores_without_work_and_in_receiver_grid_num_cores, matmul_core_rect, row_major);
+        }
+
+        if (in0_sender_num_cores > in0_mcast_receiver_num_dests) {
+            const uint32_t in0_mcast_cores_without_work_and_not_in_receiver_grid_num_cores =
+                in0_sender_num_cores - in0_mcast_receiver_num_dests;
+            uint32_t core_idx_x = in0_mcast_receiver_num_dests % num_cores_c;
+            uint32_t core_idx_y = in0_mcast_receiver_num_dests / num_cores_c;
+            CoreCoord start_core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
+            in0_mcast_cores_without_work_and_not_in_receiver_grid = num_cores_to_corerangeset_in_subcoregrids(
+                start_core,
+                in0_mcast_cores_without_work_and_not_in_receiver_grid_num_cores,
+                matmul_core_rect,
+                row_major);
+        }
+
+        in0_mcast_noc_x.reserve(in0_mcast_sender_cores_grid.x);
+        in0_mcast_noc_y.reserve(in0_mcast_sender_cores_grid.y);
+        for (uint32_t core_idx_x = 0; core_idx_x < in0_mcast_sender_cores_grid.x; ++core_idx_x) {
+            in0_mcast_noc_x.push_back(
+                device->worker_core_from_logical_core({start_core_x + core_idx_x, start_core_y}).x);
+        }
+        for (uint32_t core_idx_y = 0; core_idx_y < in0_mcast_sender_cores_grid.y; ++core_idx_y) {
+            in0_mcast_noc_y.push_back(
+                device->worker_core_from_logical_core({start_core_x, start_core_y + core_idx_y}).y);
+        }
+    } else {
+        in0_mcast_cores_with_work_and_in_receiver_grid = CoreRangeSet({CoreRange(start_core, start_core)});
+        if (in0_mcast_receiver_num_cores > 1) {
+            // Check against the actual rectangle width (instead of bare grid_size.x-1) so that
+            // sub-devices anchored away from (0, 0) wrap correctly.
+            auto receiver_start_core = compute_with_storage_grid_size.x > 1 ? CoreCoord{start_core.x + 1, start_core.y}
+                                                                            : CoreCoord{start_core.x, start_core.y + 1};
+            in0_mcast_receivers = num_cores_to_corerangeset_in_subcoregrids(
+                receiver_start_core, num_cores - 1, matmul_core_rect, row_major);
+        }
+    }
+
+    // Mcast args — semaphore IDs assigned sequentially (0, 1)
+    uint32_t in0_mcast_sender_semaphore_id = 0;
+    uint32_t in0_mcast_receiver_semaphore_id = 1;
+
+    CoreCoord top_left_core = in0_mcast_receiver_cores_bounding_box.start_coord;
+    CoreCoord bottom_right_core = in0_mcast_receiver_cores_bounding_box.end_coord;
+    auto top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
+    auto bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
+
+    uint32_t in0_num_subblocks = (out_block_h / out_subblock_h);
+    uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
+    const auto& a_shape_logical =
+        operations::experimental::quasar::matmul::utilities::get_matmul_tensor_logical_shape(a, transpose_a);
+    // When transpose_a is true, the K dimension maps to the row dimension of the raw tile,
+    // which is already zero-padded during tile layout conversion. pad_last_ktile operates on
+    // columns, so applying it would incorrectly zero valid data that becomes output rows
+    // after the compute kernel transposes the tile.
+    const auto in0_last_ktile_w = transpose_a ? 0 : a_shape_logical[-1] % in0_tile.get_width();
+    const auto in0_last_ktile_h = transpose_a ? a_shape_logical[-1] % in0_tile.get_width() : 0;
+    TT_FATAL(
+        in0_last_ktile_w == 0 || in0_last_ktile_h == 0,
+        "At most one of in0_last_ktile_w ({}) and in0_last_ktile_h ({}) can be non-zero",
+        in0_last_ktile_w,
+        in0_last_ktile_h);
+
+    const auto& a_padded_shape =
+        operations::experimental::quasar::matmul::utilities::get_matmul_tensor_padded_shape(a, transpose_a);
+    const uint32_t M_per_batch = a_padded_shape[-2] / in0_tile.get_height();
+    const auto [in0_tensor_stride_w, in0_tensor_stride_h] =
+        operations::experimental::quasar::matmul::utilities::get_in0_transpose_strides(M, M_per_batch, transpose_a, K);
+    const auto in0_tensor_next_block_stride = in0_block_w * in0_tensor_stride_w;
+    const auto in0_tensor_next_h_dim_block_stride = in0_block_h * in0_tensor_stride_h;
+    const auto in0_tensor_start_tile_id_stride = per_core_M * in0_tensor_stride_h;
+
+    const auto in1_tensor_stride_w = transpose_b ? K : 1;
+    const auto in1_tensor_stride_h = transpose_b ? 1 : N;
+    const auto in1_tensor_next_block_stride = in0_block_w * in1_tensor_stride_h;
+    const auto in1_tensor_next_w_dim_block_stride = in1_block_w * in1_tensor_stride_w;
+    const auto in1_tensor_start_tile_id_stride = per_core_N * in1_tensor_stride_w;
+
+    std::vector<uint32_t> in0_sender_compile_time_args;
+    if (in0_is_sharded) {
+        in0_sender_compile_time_args = {
+            (std::uint32_t)1,  // core_has_output_block_work
+            (std::uint32_t)1,  // core_in_in0_receiver_mcast_grid
+
+            (std::uint32_t)in0_block_num_tiles,                         // in0_block_num_tiles
+            (std::uint32_t)in0_block_num_tiles * in0_single_tile_size,  // in0_block_size_bytes
+            (std::uint32_t)in0_last_ktile_w,
+            (std::uint32_t)in0_last_ktile_h,
+
+            // in0/in1 common args
+            (std::uint32_t)num_blocks,        // num_blocks
+            (std::uint32_t)out_num_blocks_x,  // num_blocks_x
+            (std::uint32_t)out_num_blocks_y,  // num_blocks_y
+            // in0 mcast args
+            (std::uint32_t)in0_mcast_sender_semaphore_id,
+            (std::uint32_t)in0_mcast_receiver_semaphore_id,
+            (std::uint32_t)in0_mcast_receiver_num_dests,  // in0_mcast_num_dests
+            (std::uint32_t)in0_mcast_receiver_num_cores,  // in0_mcast_num_cores
+            (std::uint32_t)(in0_mcast_sender_cores_grid.x),
+            (std::uint32_t)(in0_mcast_sender_cores_grid.y),
+            (std::uint32_t)(false),
+            (std::uint32_t)(in0_shard_width_in_tiles),
+            (std::uint32_t)(in0_shard_height_in_tiles),
+            (std::uint32_t)(in0_block_w),
+            (std::uint32_t)in0_block_h,  // in0_block_h
+
+            // batch args
+            (std::uint32_t)in0_B  // batch
+        };
+    } else {
+        in0_sender_compile_time_args = {
+            // in0 tensor args
+            (std::uint32_t)in0_tensor_stride_w,
+            (std::uint32_t)in0_tensor_stride_h,
+            (std::uint32_t)in0_tensor_next_block_stride,
+            (std::uint32_t)in0_tensor_next_h_dim_block_stride,
+            // in0 block args
+            (std::uint32_t)in0_block_w,          // in0_block_w
+            (std::uint32_t)in0_block_h,          // in0_block_h
+            (std::uint32_t)in0_block_num_tiles,  // in0_block_num_tiles
+            (std::uint32_t)in0_last_ktile_w,
+            (std::uint32_t)in0_last_ktile_h,
+            (std::uint32_t)false,  // extract_shard_sub_blocks (not used for interleaved)
+            (std::uint32_t)0,      // shard_width_in_tiles (not used for interleaved)
+            (std::uint32_t)0,      // shard_height_in_tiles (not used for interleaved)
+            // in0/in1 common args
+            (std::uint32_t)num_blocks,        // num_blocks
+            (std::uint32_t)out_num_blocks_x,  // num_blocks_x
+            (std::uint32_t)out_num_blocks_y,  // num_blocks_y
+            // in0 mcast args
+            (std::uint32_t)in0_mcast_sender_semaphore_id,
+            (std::uint32_t)in0_mcast_receiver_semaphore_id,
+            (std::uint32_t)num_cores - 1,                     // in0_mcast_num_dests
+            (std::uint32_t)in0_mcast_receiver_num_cores - 1,  // in0_mcast_num_cores
+            // batch args
+            (std::uint32_t)M * K,  // MtKt
+            (std::uint32_t)in0_B,  // batch
+            (std::uint32_t)in1_B,  // batch
+            (std::uint32_t)false,  // reuse_in0_in_CB
+            // sparsity args
+            (std::uint32_t)0,     // batchB
+            (std::uint32_t)0,     // sparsity_pagesize (placeholder since sparsity not used in this case)
+            (std::uint32_t)true,  // bcast_A
+            (std::uint32_t)false  // get_batch_from_reader
+        };
+    }
+    in0_sender_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));
+    tt::tt_metal::TensorAccessorArgs(in0_tensor).append_to(in0_sender_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs().append_to(in0_sender_compile_time_args);  // placeholder for sparsity
+    in0_sender_compile_time_args.push_back((std::uint32_t)0);  // num_batch_compute (unused, sparsity disabled)
+
+    std::vector<uint32_t> in1_sender_writer_compile_time_args = {
+        // READER
+        // in1 tensor args
+        (std::uint32_t)in1_tensor_stride_w,
+        (std::uint32_t)in1_tensor_stride_h,
+        (std::uint32_t)in1_tensor_next_block_stride,
+        (std::uint32_t)in1_tensor_next_w_dim_block_stride,
+        // in1 block args
+        (std::uint32_t)in1_block_w,                // in1_block_w
+        (std::uint32_t)in0_block_w,                // in1_block_h
+        (std::uint32_t)in1_block_w * in0_block_w,  // in1_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,        // num_blocks
+        (std::uint32_t)out_num_blocks_x,  // out_num_blocks_x
+        (std::uint32_t)out_num_blocks_y,  // out_num_blocks_y
+        // in1 mcast args
+        (std::uint32_t)0,
+        (std::uint32_t)0,
+        (std::uint32_t)0,  // in1_mcast_num_dests
+        (std::uint32_t)0,  // in1_mcast_num_cores
+        // batch args
+        (std::uint32_t)K * N,        // KtNt
+        (std::uint32_t)in0_B,        // batch
+        (std::uint32_t)bcast_batch,  // bcast_B
+        // sparsity args
+        (std::uint32_t)0,  // batchB
+        (std::uint32_t)0,  // sparsity_pagesize (placeholder since sparsity not used in this case)
+
+        // WRITER
+        // out tensor args
+        (std::uint32_t)1,                   // out_tensor_stride_w
+        (std::uint32_t)N,                   // out_tensor_stride_h
+        (std::uint32_t)out_subblock_w,      // out_tensor_next_subblock_stride_w
+        (std::uint32_t)out_subblock_h * N,  // out_tensor_next_subblock_stride_h
+        (std::uint32_t)out_block_w,         // out_tensor_next_w_dim_block_stride
+        (std::uint32_t)out_block_h * N,     // out_tensor_next_h_dim_block_stride
+        // out subblock args
+        (std::uint32_t)out_subblock_w,                     // out_subblock_w
+        (std::uint32_t)out_subblock_h,                     // out_subblock_h
+        (std::uint32_t)(out_subblock_w * out_subblock_h),  // out_subblocks_w * out_subblocks_h
+        // batch args
+        (std::uint32_t)M * N  // MtNt
+    };
+    if (bias_tensor.has_value()) {
+        in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);  // in3_tensor_stride_w
+    } else {
+        in1_sender_writer_compile_time_args.push_back(0);  // Placeholder; not used
+    }
+
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_reduce_scatter()));
+
+    // Append TensorAccessorArgs
+    tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs().append_to(in1_sender_writer_compile_time_args);  // placeholder for sparsity
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_sender_writer_compile_time_args);
+    if (bias_tensor.has_value()) {
+        tt::tt_metal::TensorAccessorArgs(*bias_tensor).append_to(in1_sender_writer_compile_time_args);
+    }
+
+    std::vector<uint32_t> in0_receiver_compile_time_args = {
+        // in0 block args
+        (std::uint32_t)in0_block_num_tiles,  // in0_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,        // num_blocks
+        (std::uint32_t)out_num_blocks_x,  // out_num_blocks_x
+        (std::uint32_t)out_num_blocks_y,  // out_num_blocks_y
+        // in0 mcast args
+        (std::uint32_t)in0_mcast_sender_semaphore_id,
+        (std::uint32_t)in0_mcast_receiver_semaphore_id,
+        // batch args
+        (std::uint32_t)in0_B,  // batch
+        (std::uint32_t)false   // get_batch_from_reader
+    };
+
+    std::map<std::string, std::string> mm_kernel_defines;
+    std::map<std::string, std::string> mm_kernel_in0_sender_writer_defines;
+    std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
+    if (bias_tensor.has_value()) {
+        mm_kernel_defines["FUSE_BIAS"] = "1";
+        mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
+    }
+    if (fused_activation.has_value()) {
+        if (fused_activation.value().op_type == UnaryOpType::RELU) {
+            mm_kernel_defines["PACK_RELU"] = "1";
+        } else {
+            mm_kernel_defines["SFPU_ACTIVATION"] = "1";
+        }
+    }
+    if (packer_l1_acc_en) {
+        mm_kernel_defines["PACKER_L1_ACC"] = "1";
+    }
+    if (fp32_dest_acc_en) {
+        mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    if (in1_transpose_tile) {
+        mm_kernel_defines["IN1_TRANSPOSE_TILE"] = "1";
+    }
+
+    ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
+        device->arch(), num_cores, mm_kernel_defines);
+    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
+        device->arch(), num_cores, mm_kernel_defines, throttle_level);
+
+    if (in1_is_sharded) {
+        mm_kernel_in1_sender_writer_defines["IN1_SHARDED"] = "1";
+    }
+
+    if (bias_is_sharded) {
+        mm_kernel_in1_sender_writer_defines["BIAS_SHARDED"] = "1";
+    }
+
+    if (output_is_sharded) {
+        mm_kernel_in1_sender_writer_defines["OUT_SHARDED"] = "1";
+    }
+
+    // TODO: SKIP_MCAST flag isn't used for the sharded reader kernel because internal mcast logic already works without
+    // skipping We can use this flag to turn off unnecessary mcast overhead if necessary
+    if (in0_mcast_receiver_num_cores == 1) {
+        mm_kernel_in0_sender_writer_defines["SKIP_MCAST"] = "1";
+    }
+
+    mm_kernel_in1_sender_writer_defines["SKIP_MCAST"] = "1";
+
+    // Intermediate CB read
+
+    // Helper to convert std::map defines to KernelDescriptor::Defines (vector of pairs)
+    auto map_to_defines = [](const std::map<std::string, std::string>& m) -> KernelDescriptor::Defines {
+        KernelDescriptor::Defines result;
+        result.reserve(m.size());
+        for (const auto& [k, v] : m) {
+            result.emplace_back(k, v);
+        }
+        return result;
+    };
+
+    // in1 is the reader of weights/output writer, and we choose to make it use the optimized reader noc
+    tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+    tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Build Kernel Descriptors
+    ////////////////////////////////////////////////////////////////////////////
+    KernelDescriptor in0_sender_kernel_desc;
+    KernelDescriptor in0_no_work_in_receiver_kernel_desc;
+    bool has_in0_no_work_in_receiver_kernel = false;
+    KernelDescriptor in0_no_work_not_in_receiver_kernel_desc;
+    bool has_in0_no_work_not_in_receiver_kernel = false;
+    KernelDescriptor in0_receiver_kernel_desc;
+    bool has_in0_receiver_kernel = false;
+    KernelDescriptor in1_sender_writer_kernel_desc;
+    KernelDescriptor compute_kernel_desc;
+
+    in0_sender_kernel_desc.kernel_source =
+        in0_is_sharded ? "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+                         "reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp"
+                       : "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+                         "reader_bmm_tile_layout_in0_sender_padding.cpp";
+    in0_sender_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    in0_sender_kernel_desc.core_ranges = in0_mcast_cores_with_work_and_in_receiver_grid;
+    in0_sender_kernel_desc.compile_time_args = in0_sender_compile_time_args;
+    in0_sender_kernel_desc.defines = map_to_defines(mm_kernel_in0_sender_writer_defines);
+    if (in0_is_sharded) {
+        in0_sender_kernel_desc.named_compile_time_args = {
+            {"cb_in0", tt::CBIndex::c_0},
+            {"cb_in0_sharded", tt::CBIndex::c_2},
+            {"cb_l1_array", tt::CBIndex::c_6},
+            {"cb_sparsity", tt::CBIndex::c_6},
+        };
+    } else {
+        in0_sender_kernel_desc.named_compile_time_args = {
+            {"cb_in0", tt::CBIndex::c_0},
+            {"cb_in0_sharded", tt::CBIndex::c_2},
+            {"cb_sparsity", tt::CBIndex::c_6},
+        };
+    }
+    in0_sender_kernel_desc.config =
+        DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = in0_noc};
+
+    if (in0_is_sharded) {
+        if (in0_mcast_cores_without_work_and_in_receiver_grid.num_cores() > 0) {
+            has_in0_no_work_in_receiver_kernel = true;
+            auto no_work_ct_args = in0_sender_compile_time_args;
+            no_work_ct_args[0] = 0;  // core_has_output_block_work
+            no_work_ct_args[1] = 1;  // core_in_in0_receiver_mcast_grid
+            in0_no_work_in_receiver_kernel_desc.kernel_source =
+                "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+                "reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp";
+            in0_no_work_in_receiver_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+            in0_no_work_in_receiver_kernel_desc.core_ranges = in0_mcast_cores_without_work_and_in_receiver_grid;
+            in0_no_work_in_receiver_kernel_desc.compile_time_args = no_work_ct_args;
+            in0_no_work_in_receiver_kernel_desc.defines = map_to_defines(mm_kernel_in0_sender_writer_defines);
+            in0_no_work_in_receiver_kernel_desc.named_compile_time_args = {
+                {"cb_in0", tt::CBIndex::c_0},
+                {"cb_in0_sharded", tt::CBIndex::c_2},
+                {"cb_l1_array", tt::CBIndex::c_6},
+            };
+            in0_no_work_in_receiver_kernel_desc.config =
+                DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = in0_noc};
+        }
+        if (in0_mcast_cores_without_work_and_not_in_receiver_grid.num_cores() > 0) {
+            has_in0_no_work_not_in_receiver_kernel = true;
+            auto no_work_ct_args = in0_sender_compile_time_args;
+            no_work_ct_args[0] = 0;  // core_has_output_block_work
+            no_work_ct_args[1] = 0;  // core_in_in0_receiver_mcast_grid
+            in0_no_work_not_in_receiver_kernel_desc.kernel_source =
+                "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+                "reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp";
+            in0_no_work_not_in_receiver_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+            in0_no_work_not_in_receiver_kernel_desc.core_ranges = in0_mcast_cores_without_work_and_not_in_receiver_grid;
+            in0_no_work_not_in_receiver_kernel_desc.compile_time_args = no_work_ct_args;
+            in0_no_work_not_in_receiver_kernel_desc.defines = map_to_defines(mm_kernel_in0_sender_writer_defines);
+            in0_no_work_not_in_receiver_kernel_desc.named_compile_time_args = {
+                {"cb_in0", tt::CBIndex::c_0},
+                {"cb_in0_sharded", tt::CBIndex::c_2},
+                {"cb_l1_array", tt::CBIndex::c_6},
+            };
+            in0_no_work_not_in_receiver_kernel_desc.config =
+                DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = in0_noc};
+        }
+    }
+
+    if (!in0_is_sharded && in0_mcast_receivers.num_cores() > 0) {
+        has_in0_receiver_kernel = true;
+        in0_receiver_kernel_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+            "reader_bmm_tile_layout_in0_receiver.cpp";
+        in0_receiver_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        in0_receiver_kernel_desc.core_ranges = in0_mcast_receivers;
+        in0_receiver_kernel_desc.compile_time_args = in0_receiver_compile_time_args;
+        in0_receiver_kernel_desc.named_compile_time_args = {
+            {"cb_in0", tt::CBIndex::c_0},
+        };
+        in0_receiver_kernel_desc.config =
+            DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = in0_noc};
+    }
+
+    in1_sender_writer_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+        "reader_bmm_tile_layout_in1_sender_writer_padding.cpp";
+    in1_sender_writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    in1_sender_writer_kernel_desc.core_ranges = all_cores_with_work;
+    in1_sender_writer_kernel_desc.compile_time_args = in1_sender_writer_compile_time_args;
+    in1_sender_writer_kernel_desc.defines = map_to_defines(mm_kernel_in1_sender_writer_defines);
+    in1_sender_writer_kernel_desc.named_compile_time_args = {
+        {"cb_in1", tt::CBIndex::c_1},
+        {"cb_bias", tt::CBIndex::c_3},
+        {"cb_out", tt::CBIndex::c_4},
+        {"cb_sparsity", tt::CBIndex::c_7},
+    };
+    in1_sender_writer_kernel_desc.config =
+        DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = in1_noc};
+
+    // Compute kernel compile time args
+    uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
+
+    uint32_t in1_num_subblocks = (out_block_w / out_subblock_w);
+    uint32_t in1_block_num_tiles = out_subblock_w * in0_block_w * in1_num_subblocks;
+    uint32_t in1_per_core_w = out_subblock_w * in1_num_subblocks;
+
+    uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
+
+    std::vector<uint32_t> compute_kernel_args = {
+        in0_block_w,             // in0_block_w
+        in0_num_subblocks,       // in0_num_subblocks
+        in0_block_num_tiles,     // in0_block_num_tiles
+        in0_subblock_num_tiles,  // in0_subblock_num_tiles
+
+        in1_num_subblocks,    // in1_num_subblocks
+        in1_block_num_tiles,  // in1_block_num_tiles
+        in1_per_core_w,       // in1_per_core_w
+
+        num_blocks,        // num_blocks
+        out_num_blocks_x,  // out_num_blocks_x
+        out_num_blocks_y,  // out_num_blocks_y
+
+        out_subblock_h,          // out_subblock_h
+        out_subblock_w,          // out_subblock_w
+        out_subblock_num_tiles,  // out_subblock_num_tiles
+        in0_B,                   // batch
+        out_block_tiles,         // out_block_num_tiles
+
+        untilize_out,  // untilize_out
+        false,         // get_batch_from_reader
+        in0_transpose_tile,
+    };
+    if (bias_tensor.has_value()) {
+        compute_kernel_args.push_back(row_broadcast_bias ? 1u : 0u);
+    }
+
+    compute_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/"
+        "bmm_large_block_zm_fused_bias_activation.cpp";
+    compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_kernel_desc.core_ranges = all_cores_with_work;
+    compute_kernel_desc.compile_time_args = compute_kernel_args;
+    compute_kernel_desc.defines = map_to_defines(mm_kernel_defines);
+    {
+        KernelDescriptor::NamedCompileTimeArgs named_compile_args = {
+            {"cb_in0", tt::CBIndex::c_0},
+            {"cb_in1", tt::CBIndex::c_1},
+            {"cb_bias", tt::CBIndex::c_3},
+            {"cb_out", tt::CBIndex::c_4},
+            {"cb_intermed0", tt::CBIndex::c_5},
+            {"cb_in0_transposed", tt::CBIndex::c_10},
+            {"bias_ntiles", in1_per_core_w},
+        };
+        if (fused_activation.has_value() && fused_activation.value().op_type != UnaryOpType::RELU) {
+            using ttnn::operations::experimental::quasar::matmul::utilities::get_activation_params;
+            const auto params = get_activation_params(fused_activation.value());
+            named_compile_args.push_back({"activation_type", static_cast<uint32_t>(params.type)});
+            named_compile_args.push_back({"activation_param0", params.param0});
+            named_compile_args.push_back({"activation_param1", params.param1});
+            named_compile_args.push_back({"activation_param2", params.param2});
+        }
+        compute_kernel_desc.named_compile_time_args = std::move(named_compile_args);
+    }
+    compute_kernel_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity, .fp32_dest_acc_en = fp32_dest_acc_en, .math_approx_mode = math_approx_mode};
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Build CBDescriptors
+    ////////////////////////////////////////////////////////////////////////////
+    ProgramDescriptor desc;
+
+    tt::tt_metal::TileDescriptor in0_tile_desc{in0_tile};
+    tt::tt_metal::TileDescriptor in1_tile_desc{in1_tile};
+    tt::tt_metal::TileDescriptor bias_tile_desc{bias_tile};
+    tt::tt_metal::TileDescriptor output_tile_desc{output_tile};
+
+    // CB 0: in0
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in0_CB_size;
+        cb_desc.core_ranges = all_cores;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_0,
+            .data_format = in0_data_format,
+            .page_size = in0_aligned_tile_size,
+            .tile = in0_tile_desc});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 1: in1
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in1_CB_size;
+        cb_desc.core_ranges = all_cores;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_1,
+            .data_format = in1_data_format,
+            .page_size = in1_aligned_tile_size,
+            .tile = in1_tile_desc});
+        if (in1_is_sharded) {
+            cb_desc.tensor = &in1_tensor;
+        }
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 2: in0 sharded
+    if (in0_is_sharded) {
+        {
+            CBDescriptor cb_desc;
+            cb_desc.total_size = in2_CB_size;
+            cb_desc.core_ranges = all_cores;
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = tt::CBIndex::c_2,
+                .data_format = in0_data_format,
+                .page_size = in0_single_tile_size,
+                .tile = in0_tile_desc});
+            cb_desc.tensor = &in0_tensor;
+            desc.cbs.push_back(std::move(cb_desc));
+        }
+
+        // Local L1 to store temp vars
+        {
+            CBDescriptor cb_desc;
+            cb_desc.total_size = 32 * 2;
+            cb_desc.core_ranges = all_cores;
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = tt::CBIndex::c_6, .data_format = tt::DataFormat::Float16_b, .page_size = 32 * 2});
+            desc.cbs.push_back(std::move(cb_desc));
+        }
+    }
+
+    // CB 4 and CB 5: output and intermediate
+    if (do_not_inplace_interm0_out_CB || (interm0_data_format != output_data_format) ||
+        (untilize_out && (in1_num_subblocks > 1))) {
+        // Separate output and intermediate CBs
+        // output
+        {
+            CBDescriptor cb_desc;
+            cb_desc.total_size = out_CB_size;
+            cb_desc.core_ranges = all_cores;
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = tt::CBIndex::c_4,
+                .data_format = output_data_format,
+                .page_size = output_single_tile_size,
+                .tile = output_tile_desc});
+            if (output_is_sharded) {
+                cb_desc.tensor = &out_tensor;
+            }
+            desc.cbs.push_back(std::move(cb_desc));
+        }
+        // interm0
+        {
+            CBDescriptor cb_desc;
+            cb_desc.total_size = interm0_CB_size;
+            cb_desc.core_ranges = CoreRangeSet({all_cores});
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = tt::CBIndex::c_5,
+                .data_format = interm0_data_format,
+                .page_size = interm0_single_tile_size,
+                .tile = output_tile_desc});
+            desc.cbs.push_back(std::move(cb_desc));
+        }
+    } else {
+        // share buffer
+        CBDescriptor cb_desc;
+        cb_desc.total_size = out_CB_size;
+        cb_desc.core_ranges = all_cores;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_4,
+            .data_format = output_data_format,
+            .page_size = output_single_tile_size,
+            .tile = output_tile_desc});
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_5,
+            .data_format = interm0_data_format,
+            .page_size = interm0_single_tile_size,
+            .tile = output_tile_desc});
+        if (output_is_sharded) {
+            cb_desc.tensor = &out_tensor;
+        }
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB for bias
+    if (bias_tensor.has_value()) {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in3_CB_size;
+        cb_desc.core_ranges = all_cores;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_3,
+            .data_format = bias_data_format,
+            .page_size = bias_single_tile_size,
+            .tile = bias_tile_desc});
+        if (bias_is_sharded) {
+            cb_desc.tensor = &*bias_tensor;
+        }
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // Intermediate CB read
+
+    // Transpose CB for input0
+    if (in0_transpose_tile) {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in0_CB_size;
+        cb_desc.core_ranges = all_cores;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_10,
+            .data_format = in0_data_format,
+            .page_size = in0_aligned_tile_size,
+            .tile = in0_tile_desc});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Semaphore Descriptors
+    ////////////////////////////////////////////////////////////////////////////
+    desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+        .id = in0_mcast_sender_semaphore_id, .core_ranges = all_cores, .initial_value = INVALID});
+    desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+        .id = in0_mcast_receiver_semaphore_id, .core_ranges = all_cores, .initial_value = INVALID});
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Runtime Args (per-core loop)
+    ////////////////////////////////////////////////////////////////////////////
+    // Parameters for last row, col, or block. mcast_in0 replicates M across all cores
+    // (num_blocks_y == 1), so any M-direction padding lives entirely within a single h-block.
+    uint32_t last_per_core_N = N % per_core_N == 0 ? per_core_N : N % per_core_N;
+    uint32_t last_out_block_w = last_per_core_N % out_block_w == 0 ? out_block_w : last_per_core_N % out_block_w;
+    uint32_t last_out_num_blocks_w = ((last_per_core_N - 1) / out_block_w) + 1;
+    uint32_t last_block_num_nonzero_subblocks_w = ((last_out_block_w - 1) / out_subblock_w) + 1;
+    uint32_t last_subblock_of_last_block_w =
+        last_out_block_w % out_subblock_w == 0 ? out_subblock_w : last_out_block_w % out_subblock_w;
+    uint32_t last_block_padded_subblock_tiles_addr_skip =
+        output_single_tile_size * (out_subblock_w - last_subblock_of_last_block_w);
+    uint32_t last_block_padded_block_tiles_w_skip =
+        (out_subblock_w * out_subblock_h) * (out_block_w / out_subblock_w - last_block_num_nonzero_subblocks_w);
+
+    // M-direction padding when M < per_core_M. With num_blocks_y == 1 the last (only) h-block
+    // holds last_out_block_h valid tile rows out of out_block_h.
+    uint32_t in0_last_per_core_M = M < per_core_M ? M : per_core_M;
+    uint32_t in0_last_out_block_h =
+        in0_last_per_core_M % out_block_h == 0 ? out_block_h : in0_last_per_core_M % out_block_h;
+    uint32_t in0_last_block_num_nonzero_subblocks_h = ((in0_last_out_block_h - 1) / out_subblock_h) + 1;
+    uint32_t in0_last_subblock_of_last_block_h =
+        in0_last_out_block_h % out_subblock_h == 0 ? out_subblock_h : in0_last_out_block_h % out_subblock_h;
+    uint32_t in0_last_block_padded_block_tiles_h_skip =
+        (out_block_h / out_subblock_h - in0_last_block_num_nonzero_subblocks_h) * (out_block_w * out_subblock_h);
+
+    CoreCoord start_core_noc = top_left_core_physical;
+    CoreCoord end_core_noc = bottom_right_core_physical;
+    if (in0_noc == tt::tt_metal::NOC::NOC_1) {
+        std::swap(start_core_noc, end_core_noc);
+    }
+
+    const auto& cores = corerange_to_cores(all_cores, std::nullopt, row_major);
+    for (uint32_t i = 0; i < num_cores; ++i) {
+        const auto& core = cores[i];
+        uint32_t output_idx_x = i % num_blocks_x;
+        uint32_t output_idx_y = i / num_blocks_x;
+
+        if (in0_is_sharded) {
+            std::vector<uint32_t> mm_in0_sender_args;
+            mm_in0_sender_args.reserve(5 + in0_mcast_noc_x.size() + in0_mcast_noc_y.size());
+            mm_in0_sender_args.push_back(i);
+            mm_in0_sender_args.push_back(start_core_noc.x);
+            mm_in0_sender_args.push_back(start_core_noc.y);
+            mm_in0_sender_args.push_back(end_core_noc.x);
+            mm_in0_sender_args.push_back(end_core_noc.y);
+            mm_in0_sender_args.insert(mm_in0_sender_args.end(), in0_mcast_noc_x.begin(), in0_mcast_noc_x.end());
+            mm_in0_sender_args.insert(mm_in0_sender_args.end(), in0_mcast_noc_y.begin(), in0_mcast_noc_y.end());
+
+            if (fuse_op && fused_op_signaler->is_all_gather()) {
+                fused_op_signaler->push_matmul_fused_op_rt_args(mm_in0_sender_args, false);
+            }
+
+            if (i < num_cores_with_work) {
+                in0_sender_kernel_desc.runtime_args.emplace_back(core, mm_in0_sender_args);
+            } else if (i < in0_mcast_receiver_num_dests) {
+                in0_no_work_in_receiver_kernel_desc.runtime_args.emplace_back(core, mm_in0_sender_args);
+            } else {
+                in0_no_work_not_in_receiver_kernel_desc.runtime_args.emplace_back(core, mm_in0_sender_args);
+            }
+        }
+        // in0 sender and in1 sender
+        else if (core == start_core) {
+            std::vector<uint32_t> mm_in0_sender_args = {
+                // in0 tensor args
+                (std::uint32_t)in0_tensor.address(),
+                (std::uint32_t)in0_tensor_start_tile_id_stride * output_idx_y,  // in0_tensor_start_tile_id
+                // in0 mcast args
+                (std::uint32_t)start_core_noc.x,  // in0_mcast_dest_noc_start_x
+                (std::uint32_t)start_core_noc.y,  // in0_mcast_dest_noc_start_y
+                (std::uint32_t)end_core_noc.x,    // in0_mcast_dest_noc_end_x
+                (std::uint32_t)end_core_noc.y,    // in0_mcast_dest_noc_end_y
+
+                // padding args
+                (std::uint32_t)in0_last_out_block_h,  // last_block_h
+
+                // sparsity args
+                (std::uint32_t)0,  // sparsity_addr
+            };
+
+            if (fuse_op && fused_op_signaler->is_all_gather()) {
+                fused_op_signaler->push_matmul_fused_op_rt_args(mm_in0_sender_args, false);
+            }
+
+            {
+                std::vector<std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>> in0_sender_variant(
+                    mm_in0_sender_args.begin(), mm_in0_sender_args.end());
+                in0_sender_variant[0] = in0_tensor;
+                in0_sender_kernel_desc.emplace_runtime_args(core, in0_sender_variant);
+            }
+        }
+        // in0 receiver and in 1 sender
+        else {
+            std::vector<uint32_t> mm_in0_receiver_args = {
+                // in0 mcast args
+                (std::uint32_t)top_left_core_physical.x,  // in0_mcast_sender_noc_x
+                (std::uint32_t)top_left_core_physical.y   // in0_mcast_sender_noc_y
+            };
+            in0_receiver_kernel_desc.runtime_args.emplace_back(core, mm_in0_receiver_args);
+        }
+        if (i < num_cores_with_work) {
+            std::vector<uint32_t> mm_in1_sender_writer_args = {
+                // READER
+                // in1 tensor args
+                (std::uint32_t)in1_tensor.address(),
+                (std::uint32_t)in1_tensor_start_tile_id_stride * output_idx_x,  // in1_tensor_start_tile_id
+                // in1 mcast args
+                (std::uint32_t)0,  // in1_mcast_dest_noc_start_x
+                (std::uint32_t)0,  // in1_mcast_dest_noc_start_y
+                (std::uint32_t)0,  // in1_mcast_dest_noc_end_x
+                (std::uint32_t)0,  // in1_mcast_dest_noc_end_y
+
+                // sparsity args
+                (std::uint32_t)0,  // sparsity_addr
+
+                // WRITER
+                // out tensor args
+                (std::uint32_t)out_tensor.address(),
+                ((std::uint32_t)output_idx_x * per_core_N) +
+                    (output_idx_y * per_core_M * N)  // out_tensor_start_tile_id
+            };
+
+            if (output_idx_x == num_blocks_x - 1) {
+                // padding args (READER)
+                mm_in1_sender_writer_args.push_back(last_out_block_w);
+
+                // padding args (WRITER)
+                mm_in1_sender_writer_args.push_back(in0_last_block_num_nonzero_subblocks_h);
+                mm_in1_sender_writer_args.push_back(in0_last_subblock_of_last_block_h);
+                mm_in1_sender_writer_args.push_back(in0_last_block_padded_block_tiles_h_skip);
+                mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);  // out_num_nonzero_subblocks_w
+                mm_in1_sender_writer_args.push_back(last_block_num_nonzero_subblocks_w);
+                mm_in1_sender_writer_args.push_back(last_subblock_of_last_block_w);
+                mm_in1_sender_writer_args.push_back(last_block_padded_subblock_tiles_addr_skip);
+                mm_in1_sender_writer_args.push_back(last_block_padded_block_tiles_w_skip);
+            } else {
+                // padding args (READER)
+                mm_in1_sender_writer_args.push_back(out_block_w);
+
+                // padding args (WRITER)
+                mm_in1_sender_writer_args.push_back(in0_last_block_num_nonzero_subblocks_h);
+                mm_in1_sender_writer_args.push_back(in0_last_subblock_of_last_block_h);
+                mm_in1_sender_writer_args.push_back(in0_last_block_padded_block_tiles_h_skip);
+                mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);  // out_num_nonzero_subblocks_w
+                mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
+                mm_in1_sender_writer_args.push_back(out_subblock_w);
+                mm_in1_sender_writer_args.push_back(0);
+                mm_in1_sender_writer_args.push_back(0);
+            }
+
+            mm_in1_sender_writer_args.push_back(bias_tensor.has_value() ? (std::uint32_t)bias_tensor->address() : 0);
+            mm_in1_sender_writer_args.push_back(
+                bias_tensor.has_value() ? (std::uint32_t)per_core_N * output_idx_x : 0);  // in3_tensor_start_tile_id
+            if (!output_is_sharded) {
+                if (output_idx_x == num_blocks_x - 1) {
+                    mm_in1_sender_writer_args.push_back(last_out_num_blocks_w);
+                } else {
+                    mm_in1_sender_writer_args.push_back(out_num_blocks_x);
+                }
+            }
+
+            if (fuse_op && fused_op_signaler->is_all_gather()) {
+                fused_op_signaler->push_matmul_fused_op_rt_args(mm_in1_sender_writer_args, true);
+            }
+
+            {
+                std::vector<std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>> in1_sender_variant(
+                    mm_in1_sender_writer_args.begin(), mm_in1_sender_writer_args.end());
+                in1_sender_variant[0] = in1_tensor;
+                in1_sender_variant[7] = out_tensor;
+                if (bias_tensor.has_value()) {
+                    in1_sender_variant[18] = *bias_tensor;
+                }
+                in1_sender_writer_kernel_desc.emplace_runtime_args(core, in1_sender_variant);
+            }
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Push kernels to descriptor
+    ////////////////////////////////////////////////////////////////////////////
+    desc.kernels.push_back(std::move(in0_sender_kernel_desc));
+    if (has_in0_no_work_in_receiver_kernel) {
+        desc.kernels.push_back(std::move(in0_no_work_in_receiver_kernel_desc));
+    }
+    if (has_in0_no_work_not_in_receiver_kernel) {
+        desc.kernels.push_back(std::move(in0_no_work_not_in_receiver_kernel_desc));
+    }
+    if (has_in0_receiver_kernel) {
+        desc.kernels.push_back(std::move(in0_receiver_kernel_desc));
+    }
+    desc.kernels.push_back(std::move(in1_sender_writer_kernel_desc));
+    desc.kernels.push_back(std::move(compute_kernel_desc));
+
+    return desc;
+}
+
+static ProgramDescriptor create_program_mcast_in1_descriptor(
+    const tt::tt_metal::Tensor& a,
+    tt_metal::IDevice* device,
+    MathFidelity math_fidelity,
+    bool fp32_dest_acc_en,
+    bool math_approx_mode,
+    bool packer_l1_acc,
+    CoreCoord compute_with_storage_grid_size,
+    ttnn::operations::compute_throttle_utils::ThrottleLevel throttle_level,
+    uint32_t in0_B,
+    uint32_t in1_B,
+    uint32_t M,
+    uint32_t N,
+    uint32_t K,
+    bool bcast_batch,
+    bool transpose_a,
+    bool transpose_b,
+    uint32_t in0_block_w,
+    uint32_t out_subblock_h,
+    uint32_t out_subblock_w,
+    uint32_t out_block_h,
+    uint32_t out_block_w,
+    uint32_t per_core_M,
+    uint32_t per_core_N,
+    std::optional<UnaryWithParam> fused_activation,
+    const MeshTensor& in0_tensor,
+    const MeshTensor& in1_tensor,
+    ttsl::optional_reference<const MeshTensor> bias_tensor,
+    const MeshTensor& out_tensor,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const tt::tt_metal::Tile& bias_tile,
+    const tt::tt_metal::Tile& output_tile,
+    tt::DataFormat in0_data_format,
+    tt::DataFormat in1_data_format,
+    tt::DataFormat bias_data_format,
+    tt::DataFormat output_data_format,
+    bool in0_is_sharded,
+    bool output_is_sharded,
+    bool untilize_out,
+    bool row_broadcast_bias = true,
+    CoreCoord sub_device_start_core = {0, 0}) {
+    // currently only support transpose of the full tile
+    bool in0_transpose_tile = in0_tile.get_transpose_of_faces() && in0_tile.get_transpose_within_face();
+    bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
+
+    bool fuse_op = false;
+
+    uint32_t num_blocks = K / in0_block_w;
+    // Only enable packer l1 accumulation when there are num_blocks > 2, otherwise
+    // unnecessary overhead for reconfigs are added. Last iteration of l1 accumulation
+    // does a spill and reload, so need more than 2 blocks to use l1 acc for packer
+    // For bias, last iteration of l1 acc remains in intermediate buffer, does not spill and reload
+    bool packer_l1_acc_en = packer_l1_acc && (((bias_tensor.has_value()) && num_blocks > 1) || (num_blocks > 2));
+
+    // if fp32 enabled then we pack fp32 in l1, if not, then we pack fp16 in l1
+    tt::DataFormat interm0_data_format = packer_l1_acc_en
+                                             ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)
+                                             : (fp32_dest_acc_en ? tt::DataFormat::Float32 : output_data_format);
+
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    uint32_t bias_single_tile_size = bias_tile.get_tile_size(bias_data_format);
+
+    // Tiles whose size is not a multiple of the DRAM alignment (e.g. bfp8 32x16 = 544B on
+    // Blackhole's 64B alignment) are padded to it in DRAM. The interleaved reader copies tiles at
+    // the padded stride, so the in0/in1/bias CBs must hold pages at the aligned stride and the
+    // reader/unpacker walk tiles at the same stride. No-op when already aligned (all bf16 tiles,
+    // 32-wide bfp8, Wormhole). Replaces the staging-CB workaround. Sharded CBs are backed by the
+    // tensor buffer and keep their natural page size.
+    const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
+    uint32_t in0_aligned_tile_size =
+        in0_is_sharded ? in0_single_tile_size : tt::align(in0_single_tile_size, dram_alignment);
+    uint32_t in1_aligned_tile_size = tt::align(in1_single_tile_size, dram_alignment);
+    uint32_t output_single_tile_size = output_tile.get_tile_size(output_data_format);
+    uint32_t interm0_single_tile_size = output_tile.get_tile_size(interm0_data_format);
+
+    bool do_not_inplace_interm0_out_CB = output_is_sharded && (per_core_M != out_block_h);
+
+    uint32_t in0_block_h = out_block_h;
+    uint32_t in1_block_w = out_block_w;
+    uint32_t in0_num_blocks_y = per_core_M / out_block_h;
+    uint32_t in1_num_blocks_x = per_core_N / out_block_w;
+    uint32_t out_num_blocks_x = in1_num_blocks_x;
+    uint32_t out_num_blocks_y = in0_num_blocks_y;
+
+    uint32_t in0_block_tiles = in0_block_h * in0_block_w;
+    uint32_t in0_CB_tiles = in0_block_tiles;
+
+    if (in0_B == 1 && in1_B > 1) {
+        in0_CB_tiles = per_core_M * num_blocks * in0_block_w;
+    } else if (in0_is_sharded) {
+        in0_CB_tiles = num_blocks * per_core_M * in0_block_w * in0_B;
+    } else if (in0_B * num_blocks > 1) {
+        in0_CB_tiles = in0_CB_tiles * 2;  // double buffer
+    }
+    uint32_t in0_CB_size = in0_CB_tiles * in0_aligned_tile_size;
+
+    const auto& a_shape_logical =
+        operations::experimental::quasar::matmul::utilities::get_matmul_tensor_logical_shape(a, transpose_a);
+    const auto in0_last_ktile_w = transpose_a ? 0 : a_shape_logical[-1] % in0_tile.get_width();
+    const auto in0_last_ktile_h = transpose_a ? a_shape_logical[-1] % in0_tile.get_width() : 0;
+    TT_FATAL(
+        in0_last_ktile_w == 0 || in0_last_ktile_h == 0,
+        "At most one of in0_last_ktile_w ({}) and in0_last_ktile_h ({}) can be non-zero",
+        in0_last_ktile_w,
+        in0_last_ktile_h);
+
+    bool extract_shard_sub_blocks = false;
+    uint32_t in0_shard_height_in_tiles = 0;
+    uint32_t in0_shard_width_in_tiles = 0;
+    if (in0_is_sharded) {
+        in0_shard_height_in_tiles = in0_tensor.shard_spec()->shape[0] / in0_tile.get_height();
+        in0_shard_width_in_tiles = in0_tensor.shard_spec()->shape[1] / in0_tile.get_width();
+        if (in0_shard_width_in_tiles / in0_block_w > 1) {
+            extract_shard_sub_blocks = true;
+        }
+    }
+    uint32_t in2_CB_tiles = in0_block_tiles;
+    uint32_t in2_CB_size = in2_CB_tiles * in0_single_tile_size;
+
+    uint32_t in1_block_tiles = out_block_w * in0_block_w;
+    uint32_t in1_CB_tiles = in1_block_tiles;
+    if (in1_B * num_blocks > 1) {
+        in1_CB_tiles = in1_CB_tiles * 2;  // double buffer
+    }
+    uint32_t in1_CB_size = in1_CB_tiles * in1_aligned_tile_size;
+
+    uint32_t out_block_tiles = out_block_h * out_block_w;
+    uint32_t out_shard_tiles = per_core_M * per_core_N;
+    uint32_t out_CB_tiles = out_block_tiles;  // No double buffer
+    if (output_is_sharded) {
+        out_CB_tiles = out_shard_tiles;
+    }
+    uint32_t out_CB_size = out_CB_tiles * output_single_tile_size;
+    uint32_t interm0_CB_tiles = out_block_tiles;  // No double buffer
+    uint32_t interm0_CB_size = interm0_CB_tiles * interm0_single_tile_size;
+
+    uint32_t in3_block_tiles = out_block_w;
+    uint32_t in3_CB_tiles = in3_block_tiles;  // No double buffer
+    uint32_t in3_CB_size = in3_CB_tiles * bias_single_tile_size;
+
+    CoreCoord start_core = sub_device_start_core;
+
+    // The matmul region is the rectangle of size `compute_with_storage_grid_size`
+    // anchored at `start_core`. Callers must ensure this rectangle lies entirely
+    // within the active sub-device's worker cores (validated upstream).
+    CoreRangeSet matmul_core_rect(CoreRange(
+        start_core,
+        CoreCoord(
+            start_core.x + compute_with_storage_grid_size.x - 1, start_core.y + compute_with_storage_grid_size.y - 1)));
+
+    uint32_t num_blocks_y = ((M - 1) / per_core_M) + 1;
+    uint32_t num_blocks_x = ((N - 1) / per_core_N) + 1;
+    uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
+    uint32_t num_cores = num_blocks_total;
+
+    constexpr bool row_major = true;
+    CoreRangeSet all_cores =
+        tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores, matmul_core_rect, row_major);
+    CoreRange in1_mcast_receiver_cores_bounding_box = all_cores.bounding_box();
+    uint32_t in1_mcast_receiver_num_cores = in1_mcast_receiver_cores_bounding_box.size();  // always mcast to full grid
+
+    CoreRange in1_mcast_sender(start_core, start_core);
+    CoreRangeSet in1_mcast_receivers;
+    if (in1_mcast_receiver_num_cores > 1) {
+        // Check against the actual rectangle width (instead of bare grid_size.x-1) so that
+        // sub-devices anchored away from (0, 0) wrap correctly.
+        auto receiver_start_core = compute_with_storage_grid_size.x > 1 ? CoreCoord{start_core.x + 1, start_core.y}
+                                                                        : CoreCoord{start_core.x, start_core.y + 1};
+        in1_mcast_receivers = tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(
+            receiver_start_core, num_cores - 1, matmul_core_rect, row_major);
+    }
+
+    // Mcast args — semaphore IDs assigned sequentially (0, 1)
+    uint32_t in1_mcast_sender_semaphore_id = 0;
+    uint32_t in1_mcast_receiver_semaphore_id = 1;
+
+    CoreCoord top_left_core = in1_mcast_receiver_cores_bounding_box.start_coord;
+    CoreCoord bottom_right_core = in1_mcast_receiver_cores_bounding_box.end_coord;
+    auto top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
+    auto bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
+
+    const auto& a_padded_shape =
+        operations::experimental::quasar::matmul::utilities::get_matmul_tensor_padded_shape(a, transpose_a);
+    const uint32_t M_per_batch = a_padded_shape[-2] / in0_tile.get_height();
+    const auto [in0_tensor_stride_w, in0_tensor_stride_h] =
+        operations::experimental::quasar::matmul::utilities::get_in0_transpose_strides(M, M_per_batch, transpose_a, K);
+    const auto in0_tensor_next_block_stride = in0_block_w * in0_tensor_stride_w;
+    const auto in0_tensor_next_h_dim_block_stride = in0_block_h * in0_tensor_stride_h;
+    const auto in0_tensor_start_tile_id_stride = per_core_M * in0_tensor_stride_h;
+
+    const auto in1_tensor_stride_w = transpose_b ? K : 1;
+    const auto in1_tensor_stride_h = transpose_b ? 1 : N;
+    const auto in1_tensor_next_block_stride = in0_block_w * in1_tensor_stride_h;
+    const auto in1_tensor_next_w_dim_block_stride = in1_block_w * in1_tensor_stride_w;
+    const auto in1_tensor_start_tile_id_stride = per_core_N * in1_tensor_stride_w;
+
+    const bool reuse_in0_in_CB = (in0_B == 1 && in1_B > 1) && !in0_is_sharded && !output_is_sharded && !bcast_batch &&
+                                 !fused_activation.has_value();
+
+    std::vector<uint32_t> in0_sender_compile_time_args = {
+        // in0 tensor args
+        (std::uint32_t)in0_tensor_stride_w,
+        (std::uint32_t)in0_tensor_stride_h,
+        (std::uint32_t)in0_tensor_next_block_stride,
+        (std::uint32_t)in0_tensor_next_h_dim_block_stride,
+        // in0 block args
+        (std::uint32_t)in0_block_w,                // in0_block_w
+        (std::uint32_t)in0_block_h,                // in0_block_h
+        (std::uint32_t)in0_block_w * in0_block_h,  // in0_block_num_tiles
+        (std::uint32_t)in0_last_ktile_w,
+        (std::uint32_t)in0_last_ktile_h,
+
+        (std::uint32_t)extract_shard_sub_blocks,
+        (std::uint32_t)in0_shard_width_in_tiles,
+        (std::uint32_t)in0_shard_height_in_tiles,
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,        // num_blocks
+        (std::uint32_t)out_num_blocks_x,  // out_num_blocks_x
+        (std::uint32_t)out_num_blocks_y,  // out_num_blocks_y
+        // in0 mcast args
+        (std::uint32_t)0,
+        (std::uint32_t)0,
+        (std::uint32_t)0,  // in0_mcast_num_dests
+        (std::uint32_t)0,  // in0_mcast_num_cores
+        // batch args
+        (std::uint32_t)M * K,            // MtKt
+        (std::uint32_t)in0_B,            // batch
+        (std::uint32_t)in1_B,            // batch
+        (std::uint32_t)reuse_in0_in_CB,  // reuse_in0_in_CB
+
+        // sparsity args
+        (std::uint32_t)0,     // batchB
+        (std::uint32_t)0,     // sparsity_pagesize (placeholder since sparsity not used in this case)
+        (std::uint32_t)true,  // bcast_A
+        (std::uint32_t)false  // get_batch_from_reader
+    };
+    in0_sender_compile_time_args.push_back((std::uint32_t)fuse_op);
+    tt::tt_metal::TensorAccessorArgs(in0_tensor).append_to(in0_sender_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs().append_to(in0_sender_compile_time_args);  // placeholder for sparsity
+    in0_sender_compile_time_args.push_back((std::uint32_t)0);  // num_batch_compute (unused, sparsity disabled)
+
+    std::vector<uint32_t> in1_sender_writer_compile_time_args = {
+        // READER
+        // in1 tensor args
+        (std::uint32_t)in1_tensor_stride_w,
+        (std::uint32_t)in1_tensor_stride_h,
+        (std::uint32_t)in1_tensor_next_block_stride,
+        (std::uint32_t)in1_tensor_next_w_dim_block_stride,
+        // in1 block args
+        (std::uint32_t)in1_block_w,                // in1_block_w
+        (std::uint32_t)in0_block_w,                // in1_block_h
+        (std::uint32_t)in1_block_w * in0_block_w,  // in1_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,        // num_blocks
+        (std::uint32_t)out_num_blocks_x,  // out_num_blocks_x
+        (std::uint32_t)out_num_blocks_y,  // out_num_blocks_y
+        // in1 mcast args
+        (std::uint32_t)in1_mcast_sender_semaphore_id,
+        (std::uint32_t)in1_mcast_receiver_semaphore_id,
+        (std::uint32_t)num_cores - 1,                     // in1_mcast_num_dests
+        (std::uint32_t)in1_mcast_receiver_num_cores - 1,  // in1_mcast_num_cores
+        // batch args
+        (std::uint32_t)K * N,                              // KtNt
+        (std::uint32_t)(reuse_in0_in_CB ? in1_B : in0_B),  // batch
+        (std::uint32_t)bcast_batch,                        // bcast_B
+        // sparsity args
+        (std::uint32_t)0,  // batchB
+        (std::uint32_t)0,  // sparsity_pagesize (placeholder since sparsity not used in this case)
+
+        // WRITER
+        // out tensor args
+        (std::uint32_t)1,                   // out_tensor_stride_w
+        (std::uint32_t)N,                   // out_tensor_stride_h
+        (std::uint32_t)out_subblock_w,      // out_tensor_next_subblock_stride_w
+        (std::uint32_t)out_subblock_h * N,  // out_tensor_next_subblock_stride_h
+        (std::uint32_t)out_block_w,         // out_tensor_next_w_dim_block_stride
+        (std::uint32_t)out_block_h * N,     // out_tensor_next_h_dim_block_stride
+        // out subblock args
+        (std::uint32_t)out_subblock_w,                     // out_subblock_w
+        (std::uint32_t)out_subblock_h,                     // out_subblock_h
+        (std::uint32_t)(out_subblock_w * out_subblock_h),  // out_subblocks_w * out_subblocks_h
+        // batch args
+        (std::uint32_t)M * N  // MtNt
+    };
+
+    if (bias_tensor.has_value()) {
+        in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);  // in3_tensor_stride_w
+    } else {
+        in1_sender_writer_compile_time_args.push_back(0);  // Placeholder; not used
+    }
+
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)fuse_op);
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)fuse_op);
+
+    // Append TensorAccessorArgs
+    tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs().append_to(in1_sender_writer_compile_time_args);  // placeholder for sparsity
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_sender_writer_compile_time_args);
+    if (bias_tensor.has_value()) {
+        tt::tt_metal::TensorAccessorArgs(*bias_tensor).append_to(in1_sender_writer_compile_time_args);
+    }
+
+    std::vector<uint32_t> in1_receiver_writer_compile_time_args = {
+        // READER
+        // in1 block args
+        (std::uint32_t)in1_block_w * in0_block_w,  // in1_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,        // num_blocks
+        (std::uint32_t)out_num_blocks_x,  // out_num_blocks_x
+        (std::uint32_t)out_num_blocks_y,  // out_num_blocks_y
+        // in1 mcast args
+        (std::uint32_t)in1_mcast_sender_semaphore_id,
+        (std::uint32_t)in1_mcast_receiver_semaphore_id,
+        // batch args
+        (std::uint32_t)(reuse_in0_in_CB ? in1_B : in0_B),  // batch (must match in1 sender)
+
+        // WRITER
+        // out tensor args
+        (std::uint32_t)1,                   // out_tensor_stride_w
+        (std::uint32_t)N,                   // out_tensor_stride_h
+        (std::uint32_t)out_subblock_w,      // out_tensor_next_subblock_stride_w
+        (std::uint32_t)out_subblock_h * N,  // out_tensor_next_subblock_stride_h
+        (std::uint32_t)out_block_w,         // out_tensor_next_w_dim_block_stride
+        (std::uint32_t)out_block_h * N,     // out_tensor_next_h_dim_block_stride
+        // out subblock args
+        (std::uint32_t)out_subblock_w,                     // out_subblock_w
+        (std::uint32_t)out_subblock_h,                     // out_subblock_h
+        (std::uint32_t)(out_subblock_w * out_subblock_h),  // out_subblocks_w * out_subblocks_h
+        // batch args
+        (std::uint32_t)M * N  // MtNt
+    };
+
+    if (bias_tensor.has_value()) {
+        in1_receiver_writer_compile_time_args.push_back((std::uint32_t)in1_block_w);
+    } else {
+        in1_receiver_writer_compile_time_args.push_back(0);  // Placeholder; not used
+    }
+    in1_receiver_writer_compile_time_args.push_back((std::uint32_t)fuse_op);
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_receiver_writer_compile_time_args);
+
+    std::map<std::string, std::string> mm_kernel_defines;
+    std::map<std::string, std::string> mm_kernel_in0_sender_defines;
+    std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
+    std::map<std::string, std::string> mm_kernel_in1_receiver_writer_defines;
+    if (bias_tensor.has_value()) {
+        mm_kernel_defines["FUSE_BIAS"] = "1";
+        mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
+        mm_kernel_in1_receiver_writer_defines["FUSE_BIAS"] = "1";
+    }
+    if (fused_activation.has_value()) {
+        if (fused_activation.value().op_type == UnaryOpType::RELU) {
+            mm_kernel_defines["PACK_RELU"] = "1";
+        } else {
+            mm_kernel_defines["SFPU_ACTIVATION"] = "1";
+        }
+    }
+    if (packer_l1_acc_en) {
+        mm_kernel_defines["PACKER_L1_ACC"] = "1";
+    }
+    if (fp32_dest_acc_en) {
+        mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    if (in1_transpose_tile) {
+        mm_kernel_defines["IN1_TRANSPOSE_TILE"] = "1";
+    }
+
+    ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
+        device->arch(), num_cores, mm_kernel_defines);
+    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
+        device->arch(), num_cores, mm_kernel_defines, throttle_level);
+
+    if (in0_is_sharded) {
+        mm_kernel_in0_sender_defines["IN0_SHARDED"] = "1";
+    }
+    if (output_is_sharded) {
+        mm_kernel_in1_sender_writer_defines["OUT_SHARDED"] = "1";
+        mm_kernel_in1_receiver_writer_defines["OUT_SHARDED"] = "1";
+    }
+
+    mm_kernel_in0_sender_defines["SKIP_MCAST"] = "1";
+
+    if (in1_mcast_receiver_num_cores == 1) {
+        mm_kernel_in1_sender_writer_defines["SKIP_MCAST"] = "1";
+    }
+
+    // Intermediate CB read
+
+    // Helper to convert std::map defines to KernelDescriptor::Defines (vector of pairs)
+    auto map_to_defines = [](const std::map<std::string, std::string>& m) -> KernelDescriptor::Defines {
+        KernelDescriptor::Defines result;
+        result.reserve(m.size());
+        for (const auto& [k, v] : m) {
+            result.emplace_back(k, v);
+        }
+        return result;
+    };
+
+    // in1 is the reader of weights/output writer, and we choose to make it use the optimized reader noc
+    tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+    tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Build Kernel Descriptors
+    ////////////////////////////////////////////////////////////////////////////
+    KernelDescriptor in0_sender_kernel_desc;
+    KernelDescriptor in1_sender_writer_kernel_desc;
+    KernelDescriptor in1_receiver_writer_kernel_desc;
+    bool has_in1_receiver_writer_kernel = false;
+    KernelDescriptor compute_kernel_desc;
+
+    in0_sender_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+        "reader_bmm_tile_layout_in0_sender_padding.cpp";
+    in0_sender_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    in0_sender_kernel_desc.core_ranges = all_cores;
+    in0_sender_kernel_desc.compile_time_args = in0_sender_compile_time_args;
+    in0_sender_kernel_desc.defines = map_to_defines(mm_kernel_in0_sender_defines);
+    in0_sender_kernel_desc.named_compile_time_args = {
+        {"cb_in0", tt::CBIndex::c_0},
+        {"cb_in0_sharded", tt::CBIndex::c_2},
+        {"cb_sparsity", tt::CBIndex::c_6},
+    };
+    in0_sender_kernel_desc.config =
+        DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = in0_noc};
+
+    in1_sender_writer_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+        "reader_bmm_tile_layout_in1_sender_writer_padding.cpp";
+    in1_sender_writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    in1_sender_writer_kernel_desc.core_ranges = CoreRangeSet(in1_mcast_sender);
+    in1_sender_writer_kernel_desc.compile_time_args = in1_sender_writer_compile_time_args;
+    in1_sender_writer_kernel_desc.defines = map_to_defines(mm_kernel_in1_sender_writer_defines);
+    in1_sender_writer_kernel_desc.named_compile_time_args = {
+        {"cb_in1", tt::CBIndex::c_1},
+        {"cb_bias", tt::CBIndex::c_3},
+        {"cb_out", tt::CBIndex::c_4},
+        {"cb_sparsity", tt::CBIndex::c_7},
+    };
+    in1_sender_writer_kernel_desc.config =
+        DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = in1_noc};
+
+    if (in1_mcast_receivers.num_cores() > 0) {
+        has_in1_receiver_writer_kernel = true;
+        in1_receiver_writer_kernel_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+            "reader_bmm_tile_layout_in1_receiver_writer_padding.cpp";
+        in1_receiver_writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        in1_receiver_writer_kernel_desc.core_ranges = in1_mcast_receivers;
+        in1_receiver_writer_kernel_desc.compile_time_args = in1_receiver_writer_compile_time_args;
+        in1_receiver_writer_kernel_desc.defines = map_to_defines(mm_kernel_in1_receiver_writer_defines);
+        in1_receiver_writer_kernel_desc.named_compile_time_args = {
+            {"cb_in1", tt::CBIndex::c_1},
+            {"cb_bias", tt::CBIndex::c_3},
+            {"cb_out", tt::CBIndex::c_4},
+        };
+        in1_receiver_writer_kernel_desc.config =
+            DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = in1_noc};
+    }
+
+    // Compute kernel compile time args
+    uint32_t in0_num_subblocks = (out_block_h / out_subblock_h);
+    uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
+    uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
+
+    uint32_t in1_num_subblocks = (out_block_w / out_subblock_w);
+    uint32_t in1_block_num_tiles = out_subblock_w * in0_block_w * in1_num_subblocks;
+    uint32_t in1_per_core_w = out_subblock_w * in1_num_subblocks;
+
+    uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
+
+    std::vector<uint32_t> compute_kernel_args = {
+        in0_block_w,             // in0_block_w
+        in0_num_subblocks,       // in0_num_subblocks
+        in0_block_num_tiles,     // in0_block_num_tiles
+        in0_subblock_num_tiles,  // in0_subblock_num_tiles
+
+        in1_num_subblocks,    // in1_num_subblocks
+        in1_block_num_tiles,  // in1_block_num_tiles
+        in1_per_core_w,       // in1_per_core_w
+
+        num_blocks,        // num_blocks
+        out_num_blocks_x,  // out_num_blocks_x
+        out_num_blocks_y,  // out_num_blocks_y
+
+        out_subblock_h,                   // out_subblock_h
+        out_subblock_w,                   // out_subblock_w
+        out_subblock_num_tiles,           // out_subblock_num_tiles
+        reuse_in0_in_CB ? in1_B : in0_B,  // batch
+        out_block_tiles,                  // out_block_num_tiles
+
+        untilize_out,  // untilize_out
+        false,         // get_batch_from_reader
+        in0_transpose_tile,
+    };
+    if (bias_tensor.has_value()) {
+        compute_kernel_args.push_back(row_broadcast_bias ? 1u : 0u);
+    }
+
+    compute_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/"
+        "bmm_large_block_zm_fused_bias_activation.cpp";
+    compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_kernel_desc.core_ranges = all_cores;
+    compute_kernel_desc.compile_time_args = compute_kernel_args;
+    compute_kernel_desc.defines = map_to_defines(mm_kernel_defines);
+    {
+        KernelDescriptor::NamedCompileTimeArgs named_compile_args = {
+            {"cb_in0", tt::CBIndex::c_0},
+            {"cb_in1", tt::CBIndex::c_1},
+            {"cb_bias", tt::CBIndex::c_3},
+            {"cb_out", tt::CBIndex::c_4},
+            {"cb_intermed0", tt::CBIndex::c_5},
+            {"cb_in0_transposed", tt::CBIndex::c_10},
+            {"bias_ntiles", in1_per_core_w},
+        };
+        if (fused_activation.has_value() && fused_activation.value().op_type != UnaryOpType::RELU) {
+            using ttnn::operations::experimental::quasar::matmul::utilities::get_activation_params;
+            const auto params = get_activation_params(fused_activation.value());
+            named_compile_args.push_back({"activation_type", static_cast<uint32_t>(params.type)});
+            named_compile_args.push_back({"activation_param0", params.param0});
+            named_compile_args.push_back({"activation_param1", params.param1});
+            named_compile_args.push_back({"activation_param2", params.param2});
+        }
+        compute_kernel_desc.named_compile_time_args = std::move(named_compile_args);
+    }
+    compute_kernel_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity, .fp32_dest_acc_en = fp32_dest_acc_en, .math_approx_mode = math_approx_mode};
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Build CBDescriptors
+    ////////////////////////////////////////////////////////////////////////////
+    ProgramDescriptor desc;
+
+    tt::tt_metal::TileDescriptor in0_tile_desc{in0_tile};
+    tt::tt_metal::TileDescriptor in1_tile_desc{in1_tile};
+    tt::tt_metal::TileDescriptor bias_tile_desc{bias_tile};
+    tt::tt_metal::TileDescriptor output_tile_desc{output_tile};
+
+    // CB 0: in0
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in0_CB_size;
+        cb_desc.core_ranges = all_cores;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_0,
+            .data_format = in0_data_format,
+            .page_size = in0_aligned_tile_size,
+            .tile = in0_tile_desc});
+        if (in0_is_sharded && !extract_shard_sub_blocks) {
+            cb_desc.tensor = &in0_tensor;
+        }
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 2: in0 sharded (only for extract_shard_sub_blocks)
+    if (in0_is_sharded && extract_shard_sub_blocks) {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in2_CB_size;
+        cb_desc.core_ranges = all_cores;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_2,
+            .data_format = in0_data_format,
+            .page_size = in0_single_tile_size,
+            .tile = in0_tile_desc});
+        cb_desc.tensor = &in0_tensor;
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 1: in1
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in1_CB_size;
+        cb_desc.core_ranges = all_cores;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_1,
+            .data_format = in1_data_format,
+            .page_size = in1_aligned_tile_size,
+            .tile = in1_tile_desc});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 4 and CB 5: output and intermediate
+    if (do_not_inplace_interm0_out_CB || (interm0_data_format != output_data_format) ||
+        (untilize_out && (in1_num_subblocks > 1))) {
+        // Separate output and intermediate CBs
+        // output
+        {
+            CBDescriptor cb_desc;
+            cb_desc.total_size = out_CB_size;
+            cb_desc.core_ranges = all_cores;
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = tt::CBIndex::c_4,
+                .data_format = output_data_format,
+                .page_size = output_single_tile_size,
+                .tile = output_tile_desc});
+            if (output_is_sharded) {
+                cb_desc.tensor = &out_tensor;
+            }
+            desc.cbs.push_back(std::move(cb_desc));
+        }
+        // interm0
+        {
+            CBDescriptor cb_desc;
+            cb_desc.total_size = interm0_CB_size;
+            cb_desc.core_ranges = CoreRangeSet({all_cores});
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = tt::CBIndex::c_5,
+                .data_format = interm0_data_format,
+                .page_size = interm0_single_tile_size,
+                .tile = output_tile_desc});
+            desc.cbs.push_back(std::move(cb_desc));
+        }
+    } else {
+        // share buffer
+        CBDescriptor cb_desc;
+        cb_desc.total_size = out_CB_size;
+        cb_desc.core_ranges = all_cores;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_4,
+            .data_format = output_data_format,
+            .page_size = output_single_tile_size,
+            .tile = output_tile_desc});
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_5,
+            .data_format = interm0_data_format,
+            .page_size = interm0_single_tile_size,
+            .tile = output_tile_desc});
+        if (output_is_sharded) {
+            cb_desc.tensor = &out_tensor;
+        }
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB for bias
+    if (bias_tensor.has_value()) {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in3_CB_size;
+        cb_desc.core_ranges = all_cores;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_3,
+            .data_format = bias_data_format,
+            .page_size = bias_single_tile_size,
+            .tile = bias_tile_desc});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // Intermediate CB read
+
+    if (in0_transpose_tile) {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in0_CB_size;
+        cb_desc.core_ranges = all_cores;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_10,
+            .data_format = in0_data_format,
+            .page_size = in0_aligned_tile_size,
+            .tile = in0_tile_desc});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Semaphore Descriptors
+    ////////////////////////////////////////////////////////////////////////////
+    desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+        .id = in1_mcast_sender_semaphore_id, .core_ranges = all_cores, .initial_value = INVALID});
+    desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+        .id = in1_mcast_receiver_semaphore_id, .core_ranges = all_cores, .initial_value = INVALID});
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Runtime Args (per-core loop)
+    ////////////////////////////////////////////////////////////////////////////
+    // Parameters for last row, col, or block
+    uint32_t last_per_core_M = M % per_core_M == 0 ? per_core_M : M % per_core_M;
+    uint32_t last_out_block_h = last_per_core_M % out_block_h == 0 ? out_block_h : last_per_core_M % out_block_h;
+    uint32_t last_out_num_blocks_h = ((last_per_core_M - 1) / out_block_h) + 1;
+    uint32_t last_block_num_nonzero_subblocks_h = ((last_out_block_h - 1) / out_subblock_h) + 1;
+    uint32_t last_subblock_of_last_block_h =
+        last_out_block_h % out_subblock_h == 0 ? out_subblock_h : last_out_block_h % out_subblock_h;
+    uint32_t last_block_padded_block_tiles_h_skip =
+        (out_block_h / out_subblock_h - last_block_num_nonzero_subblocks_h) * (out_block_w * out_subblock_h);
+
+    CoreCoord start_core_noc = bottom_right_core_physical;
+    CoreCoord end_core_noc = top_left_core_physical;
+    if (in1_noc == tt::tt_metal::NOC::NOC_0) {
+        std::swap(start_core_noc, end_core_noc);
+    }
+
+    const auto& cores = corerange_to_cores(all_cores, std::nullopt, row_major);
+    for (uint32_t i = 0; i < num_cores; ++i) {
+        const auto& core = cores[i];
+        uint32_t output_idx_x = i / num_blocks_y;
+        uint32_t output_idx_y = i % num_blocks_y;
+
+        // in0 sender and in1 sender
+        if (core == start_core) {
+            std::vector<std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>> mm_in1_sender_writer_args = {
+                // READER
+                // in1 tensor args
+                in1_tensor,
+                (std::uint32_t)in1_tensor_start_tile_id_stride * output_idx_x,  // in1_tensor_start_tile_id
+                // in1 mcast args
+                (std::uint32_t)start_core_noc.x,  // in1_mcast_dest_noc_start_x
+                (std::uint32_t)start_core_noc.y,  // in1_mcast_dest_noc_start_y
+                (std::uint32_t)end_core_noc.x,    // in1_mcast_dest_noc_end_x
+                (std::uint32_t)end_core_noc.y,    // in1_mcast_dest_noc_end_y
+
+                // sparsity args
+                (std::uint32_t)0,  // sparsity_addr
+
+                // WRITER
+                // out tensor args
+                out_tensor,
+                ((std::uint32_t)output_idx_x * per_core_N) +
+                    (output_idx_y * per_core_M * N),  // out_tensor_start_tile_id
+
+                // padding args (READER)
+                (std::uint32_t)out_block_w,  // last_block_w
+                // padding args (WRITER)
+                (std::uint32_t)out_block_h / out_subblock_h,
+                (std::uint32_t)out_subblock_h,
+                (std::uint32_t)0,
+                (std::uint32_t)out_block_w / out_subblock_w,
+                (std::uint32_t)out_block_w / out_subblock_w,
+                (std::uint32_t)out_subblock_w,
+                (std::uint32_t)0,
+                (std::uint32_t)0};
+
+            if (bias_tensor.has_value()) {
+                mm_in1_sender_writer_args.push_back(*bias_tensor);
+                mm_in1_sender_writer_args.push_back(
+                    (std::uint32_t)per_core_N * output_idx_x);  // in3_tensor_start_tile_id
+            } else {
+                mm_in1_sender_writer_args.push_back(0u);
+                mm_in1_sender_writer_args.push_back(0u);
+            }
+            if (!output_is_sharded) {
+                mm_in1_sender_writer_args.push_back(out_num_blocks_x);
+            }
+
+            {
+                std::vector<std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>> in1_sender_variant(
+                    mm_in1_sender_writer_args.begin(), mm_in1_sender_writer_args.end());
+                in1_sender_variant[0] = in1_tensor;
+                in1_sender_variant[7] = out_tensor;
+                if (bias_tensor.has_value()) {
+                    in1_sender_variant[18] = *bias_tensor;
+                }
+                in1_sender_writer_kernel_desc.emplace_runtime_args(core, in1_sender_variant);
+            }
+        }
+        // in0 sender and in1 receiver
+        else {
+            std::vector<std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>> mm_in1_receiver_writer_args =
+                {
+                    // READER
+                    // in1 mcast args
+                    (std::uint32_t)top_left_core_physical.x,  // in1_mcast_sender_noc_x
+                    (std::uint32_t)top_left_core_physical.y,  // in1_mcast_sender_noc_y
+
+                    // WRITER
+                    // out tensor args
+                    out_tensor,  // out_tensor_addr
+                    ((std::uint32_t)output_idx_x * per_core_N) +
+                        (output_idx_y * per_core_M * N)  // out_tensor_start_tile_id
+                };
+
+            if (output_idx_y == num_blocks_y - 1) {
+                // padding args (WRITER)
+                mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                mm_in1_receiver_writer_args.push_back(last_block_num_nonzero_subblocks_h);
+                mm_in1_receiver_writer_args.push_back(last_subblock_of_last_block_h);
+                mm_in1_receiver_writer_args.push_back(last_block_padded_block_tiles_h_skip);
+                mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                mm_in1_receiver_writer_args.push_back(out_subblock_w);
+                mm_in1_receiver_writer_args.push_back(0u);
+                mm_in1_receiver_writer_args.push_back(0u);
+            } else {
+                // padding args (WRITER)
+                mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                mm_in1_receiver_writer_args.push_back(out_subblock_h);
+                mm_in1_receiver_writer_args.push_back(0u);
+                mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                mm_in1_receiver_writer_args.push_back(out_subblock_w);
+                mm_in1_receiver_writer_args.push_back(0u);
+                mm_in1_receiver_writer_args.push_back(0u);
+            }
+            if (!output_is_sharded) {
+                if (output_idx_y == num_blocks_y - 1) {
+                    mm_in1_receiver_writer_args.push_back(last_out_num_blocks_h);
+                    mm_in1_receiver_writer_args.push_back(out_num_blocks_x);
+                } else {
+                    mm_in1_receiver_writer_args.push_back(out_num_blocks_y);
+                    mm_in1_receiver_writer_args.push_back(out_num_blocks_x);
+                }
+            }
+
+            {
+                std::vector<std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>> in1_recv_variant(
+                    mm_in1_receiver_writer_args.begin(), mm_in1_receiver_writer_args.end());
+                in1_recv_variant[2] = out_tensor;
+                in1_receiver_writer_kernel_desc.emplace_runtime_args(core, in1_recv_variant);
+            }
+        }
+        std::vector<std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>> mm_in0_sender_args = {
+            // in0 tensor args
+            in0_tensor,
+            (std::uint32_t)in0_tensor_start_tile_id_stride * output_idx_y,  // in0_tensor_start_tile_id
+            // in0 mcast args
+            (std::uint32_t)0,  // in0_mcast_dest_noc_start_x
+            (std::uint32_t)0,  // in0_mcast_dest_noc_start_y
+            (std::uint32_t)0,  // in0_mcast_dest_noc_end_x
+            (std::uint32_t)0,  // in0_mcast_dest_noc_end_y
+
+            // padding args
+            (std::uint32_t)per_core_M,  // last_block_h
+
+            // sparsity args
+            (std::uint32_t)0,  // sparsity_addr
+        };
+        {
+            std::vector<std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>> in0_sender_variant(
+                mm_in0_sender_args.begin(), mm_in0_sender_args.end());
+            in0_sender_variant[0] = in0_tensor;
+            in0_sender_kernel_desc.emplace_runtime_args(core, in0_sender_variant);
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Push kernels to descriptor
+    ////////////////////////////////////////////////////////////////////////////
+    desc.kernels.push_back(std::move(in0_sender_kernel_desc));
+    desc.kernels.push_back(std::move(in1_sender_writer_kernel_desc));
+    if (has_in1_receiver_writer_kernel) {
+        desc.kernels.push_back(std::move(in1_receiver_writer_kernel_desc));
+    }
+    desc.kernels.push_back(std::move(compute_kernel_desc));
+
+    return desc;
+}
+
+}  // namespace reuse_mcast_1d_optimized_helpers
+
+MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_reuse_mcast_1d_optimized_(
+    tt_metal::Program& program,
+    const Tensor& a,
+    const std::vector<Tensor>& b_tensors,
+    const std::optional<const Tensor>& bias,
+    const std::vector<Tensor>& output_tensors,
+    bool bcast_batch,
+    bool transpose_a,
+    bool transpose_b,
+    CoreCoord compute_with_storage_grid_size,
+    DeviceComputeKernelConfig compute_kernel_config,
+    ttnn::operations::compute_throttle_utils::ThrottleLevel throttle_level,
+    uint32_t in0_block_w,
+    uint32_t out_subblock_h,
+    uint32_t out_subblock_w,
+    uint32_t out_block_h,
+    uint32_t out_block_w,
+    uint32_t per_core_M,
+    uint32_t per_core_N,
+    bool fuse_batch,
+    const std::optional<UnaryWithParam>& fused_activation,
+    bool mcast_in0,
+    bool gather_in0,
+    const CoreRangeSet& hop_cores,
+    bool untilize_out,
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler,
+    const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb,
+    uint32_t num_global_cb_receivers,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    uint32_t start_cb_index,
+    std::optional<CoreRangeSet> restricted_cores) {
+    const auto& b = b_tensors[0];
+    const auto& output = output_tensors[0].mesh_tensor();
+
+    TT_FATAL(output_tensors.size() == b_tensors.size(), "number of outputs must match number of inputs b");
+
+    const auto& ashape =
+        operations::experimental::quasar::matmul::utilities::get_matmul_tensor_padded_shape(a, transpose_a);
+    const auto& bshape =
+        operations::experimental::quasar::matmul::utilities::get_matmul_tensor_padded_shape(b, transpose_b);
+    auto in0_tile = operations::experimental::quasar::matmul::utilities::get_matmul_tile(a, transpose_a);
+    auto in1_tile = operations::experimental::quasar::matmul::utilities::get_matmul_tile(b, transpose_b);
+    // cannot use the output tensor tile directly as that might be changed by user override
+    auto output_tile = tt::tt_metal::Tile({in0_tile.get_height(), in1_tile.get_width()});
+
+    // CB dataformats
+    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());  // in0
+    const MeshTensor& in1_tensor = b.mesh_tensor();
+    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(in1_tensor.dtype());  // in1
+    tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());   // output
+
+    ttsl::optional_reference<const MeshTensor> bias_mesh_tensor;
+    tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;  // bias; doesn't matter if bias=nullptr
+    if (bias.has_value()) {
+        const auto& c = bias.value();
+        TT_FATAL(
+            c.storage_type() == StorageType::DEVICE,
+            "Bias tensor must be on device, got storage type: {}",
+            c.storage_type());
+        TT_FATAL(a.device() == c.device(), "Operands to matmul need to be on the same device!");
+
+        bias_mesh_tensor = c.mesh_tensor();
+
+        bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
+    }
+
+    tt_metal::IDevice* device = a.device();
+
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    const MeshTensor& in0_tensor = a.mesh_tensor();
+    TT_FATAL(
+        in0_tensor.mesh_buffer().device_local_size() % in0_single_tile_size == 0,
+        "Input A buffer size ({}) must be divisible by single tile size ({})",
+        in0_tensor.mesh_buffer().device_local_size(),
+        in0_single_tile_size);
+    TT_FATAL(
+        in1_tensor.mesh_buffer().device_local_size() % in1_single_tile_size == 0,
+        "Input B buffer size ({}) must be divisible by single tile size ({})",
+        in1_tensor.mesh_buffer().device_local_size(),
+        in1_single_tile_size);
+
+    TT_FATAL(
+        ashape[-1] == bshape[-2],
+        "Dimension K (A.shape[-1] and B.shape[-2]) must match for A and B in bmm_op");  // A.K == B.K
+    TT_FATAL(
+        ashape[-2] % in0_tile.get_height() == 0,
+        "A.shape[-2] ({}) must be divisible by tile height ({})",
+        ashape[-2],
+        in0_tile.get_height());
+    TT_FATAL(
+        ashape[-1] % in0_tile.get_width() == 0,
+        "A.shape[-1] ({}) must be divisible by tile width ({})",
+        ashape[-1],
+        in0_tile.get_width());
+    TT_FATAL(
+        bshape[-2] % in1_tile.get_height() == 0,
+        "B.shape[-2] ({}) must be divisible by tile height ({})",
+        bshape[-2],
+        in1_tile.get_height());
+    TT_FATAL(
+        bshape[-1] % in1_tile.get_width() == 0,
+        "B.shape[-1] ({}) must be divisible by tile width ({})",
+        bshape[-1],
+        in1_tile.get_width());
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), compute_kernel_config);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Matmul Parameters Setup
+    ////////////////////////////////////////////////////////////////////////////
+    // NOTE: Pads matmul input dims to 512 x 512 multiples (ie. multiples of 16*32 x 16*32)
+    // NOTE: Maximum number of tiles in output is 120 * 16^2 = 30,720 (eg. [1, 1, 5120, 6144])
+    const auto in0_B = fuse_batch ? 1 : get_batch_size(ashape);
+    const auto in1_B = fuse_batch ? 1 : get_batch_size(bshape);
+    const auto Mt = operations::experimental::quasar::matmul::utilities::get_M_dim(ashape, in0_tile, fuse_batch);
+    const auto Kt = operations::experimental::quasar::matmul::utilities::get_K_dim(ashape, in0_tile);
+    const auto Nt = operations::experimental::quasar::matmul::utilities::get_N_dim(bshape, in1_tile);
+
+    TT_FATAL(Kt % in0_block_w == 0, "Kt ({}) must be divisible by in0_block_w ({})", Kt, in0_block_w);
+
+    // This should allocate a DRAM buffer on the device
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    uint32_t num_cores = num_cores_x * num_cores_y;
+
+    // Calculate number of blocks along x and y; tensor dims are padded up to 512
+    uint32_t num_blocks_y = ((Mt - 1) / per_core_M) + 1;
+    uint32_t num_blocks_x = ((Nt - 1) / per_core_N) + 1;
+    uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
+
+    // TODO: Max used grid can actually exceed mcast receiver grid if in0 is sharded
+    // TODO: Move these validates to op validate and properly check for this
+    TT_FATAL(
+        num_blocks_total <= num_cores,
+        "Number of blocks exceeds number of cores: {} blocks > {} cores",
+        num_blocks_total,
+        num_cores);
+
+    if (!gather_in0) {
+        TT_FATAL(hop_cores.empty(), "Hop cores are not supported for any mode besides gather_in0.");
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Grayskull Device Setup
+    ////////////////////////////////////////////////////////////////////////////
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Application Setup
+    ////////////////////////////////////////////////////////////////////////////
+
+    if (gather_in0) {
+        TT_FATAL(
+            !transpose_a,
+            "Transpose A is ({}) not supported for gather_in0, please use a different program configuration",
+            transpose_a);
+        TT_FATAL(
+            !transpose_b,
+            "Transpose B is ({}) not supported for gather_in0, please use a different program configuration",
+            transpose_b);
+        std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>> out_buffers;
+        out_buffers.reserve(output_tensors.size());
+        for (const auto& output_tensor : output_tensors) {
+            out_buffers.push_back(output_tensor.mesh_tensor());
+        }
+        return reuse_mcast_1d_optimized_helpers::process_gather_in0_program_and_create_override_variables(
+            program,
+            a,
+            b_tensors,
+            device,
+            math_fidelity,
+            fp32_dest_acc_en,
+            math_approx_mode,
+            packer_l1_acc,
+            dst_full_sync_en,
+            compute_with_storage_grid_size,
+            throttle_level,
+            start_cb_index,
+            in0_B,
+            Mt,
+            Nt,
+            Kt,
+            bcast_batch,
+            in0_block_w,
+            out_subblock_h,
+            out_subblock_w,
+            per_core_M,
+            per_core_N,
+            fused_activation,
+            hop_cores,
+            in0_tensor,
+            in1_tensor,
+            out_buffers,
+            in0_tile,
+            in1_tile,
+            output_tile,
+            in0_data_format,
+            in1_data_format,
+            output_data_format,
+            untilize_out,
+            global_cb,
+            num_global_cb_receivers,
+            sub_device_id,
+            std::move(restricted_cores),
+            fused_op_signaler);
+    }
+    TT_FATAL(start_cb_index == tt::CBIndex::c_0, "mcast does not support a non-zero start cb index");
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Sub-device start core
+    ////////////////////////////////////////////////////////////////////////////
+    // The 1D mcast matmul only supports rectangular sub-device worker grids, because the in0/in1
+    // multicast targets a single bounding-box rectangle and the per-core index math assumes a
+    // contiguous row-major rectangle of width `compute_with_storage_grid_size.x`.
+    CoreCoord sub_device_start_core = {0, 0};
+    if (sub_device_id.has_value()) {
+        auto sd_worker_cores =
+            device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sub_device_id.value());
+        auto bbox = sd_worker_cores.bounding_box();
+        TT_FATAL(
+            sd_worker_cores.num_cores() == bbox.size(),
+            "matmul_multicore_reuse_mcast_1d only supports rectangular sub-device worker grids. "
+            "Got sub-device worker cores: {} (bounding box: {})",
+            sd_worker_cores,
+            bbox);
+        TT_FATAL(
+            bbox.start_coord.x + compute_with_storage_grid_size.x - 1 <= bbox.end_coord.x &&
+                bbox.start_coord.y + compute_with_storage_grid_size.y - 1 <= bbox.end_coord.y,
+            "matmul_multicore_reuse_mcast_1d compute_with_storage_grid_size {} anchored at sub-device start {} "
+            "extends past the sub-device's worker bounding box {}",
+            compute_with_storage_grid_size,
+            bbox.start_coord,
+            bbox);
+        sub_device_start_core = bbox.start_coord;
+    }
+
+    if (mcast_in0) {
+        return reuse_mcast_1d_optimized_helpers::process_mcast_in0_program_and_create_override_variables(
+            program,
+            a,
+            device,
+            math_fidelity,
+            fp32_dest_acc_en,
+            math_approx_mode,
+            packer_l1_acc,
+            compute_with_storage_grid_size,
+            throttle_level,
+            in0_B,
+            Mt,
+            Nt,
+            Kt,
+            bcast_batch,
+            transpose_a,
+            transpose_b,
+            in0_block_w,
+            out_subblock_h,
+            out_subblock_w,
+            out_block_h,
+            out_block_w,
+            per_core_M,
+            per_core_N,
+            fused_activation,
+            in0_tensor,
+            in1_tensor,
+            bias_mesh_tensor,
+            output,
+            in0_tile,
+            in1_tile,
+            bias.has_value() ? bias->tensor_spec().tile() : output_tile,
+            output_tile,
+            in0_data_format,
+            in1_data_format,
+            bias_data_format,
+            output_data_format,
+            a.memory_config().is_sharded(),
+            in1_tensor.memory_config().is_sharded(),
+            bias.has_value() ? bias->memory_config().is_sharded() : false,
+            output.memory_config().is_sharded(),
+            untilize_out,
+            fused_op_signaler,
+            operations::experimental::quasar::matmul::utilities::fused_matmul_bias_row_broadcastable(bias),
+            sub_device_start_core);
+    }
+    return reuse_mcast_1d_optimized_helpers::process_mcast_in1_program_and_create_override_variables(
+        program,
+        a,
+        device,
+        math_fidelity,
+        fp32_dest_acc_en,
+        math_approx_mode,
+        packer_l1_acc,
+        compute_with_storage_grid_size,
+        throttle_level,
+        in0_B,
+        in1_B,
+        Mt,
+        Nt,
+        Kt,
+        bcast_batch,
+        transpose_a,
+        transpose_b,
+        in0_block_w,
+        out_subblock_h,
+        out_subblock_w,
+        out_block_h,
+        out_block_w,
+        per_core_M,
+        per_core_N,
+        fused_activation,
+        in0_tensor,
+        in1_tensor,
+        bias_mesh_tensor,
+        output,
+        in0_tile,
+        in1_tile,
+        bias.has_value() ? bias->tensor_spec().tile() : output_tile,
+        output_tile,
+        in0_data_format,
+        in1_data_format,
+        bias_data_format,
+        output_data_format,
+        a.memory_config().is_sharded(),
+        output.memory_config().is_sharded(),
+        untilize_out,
+        operations::experimental::quasar::matmul::utilities::fused_matmul_bias_row_broadcastable(bias),
+        sub_device_start_core);
+}
+
+void MatmulMultiCoreReuseMcast1DProgramFactory::override_runtime_arguments(
+    tt::tt_metal::Program& program,
+    const shared_variables_t& shared_variables,
+    const ttnn::prim::qsr::MatmulParams& operation_attributes,
+    const ttnn::prim::qsr::MatmulInputs& tensor_args,
+    std::vector<ttnn::Tensor>& tensor_return_value) {
+    reuse_mcast_1d_optimized_helpers::override_program_parameters(
+        shared_variables, operation_attributes.global_cb, program, tensor_args, tensor_return_value);
+}
+
+ProgramDescriptor MatmulMultiCoreReuseMcast1DProgramFactory::create_descriptor(
+    const ttnn::prim::qsr::MatmulParams& operation_attributes,
+    const ttnn::prim::qsr::MatmulInputs& tensor_args,
+    std::vector<ttnn::Tensor>& tensor_return_value,
+    const std::optional<CoreRangeSet>& /*core_range_set*/) {
+    using namespace tt;
+    using namespace operations::experimental::quasar::matmul::utilities;
+
+    const auto& a = tensor_args.input_tensors.at(0);
+    const auto& b = tensor_args.input_tensors.at(1);
+    const auto& bias = tensor_args.optional_input_tensors.at(0);
+    const auto& output = tensor_return_value.at(0).mesh_tensor();
+
+    TT_FATAL(operation_attributes.bcast_batch.has_value(), "Error: bcast_batch field should have been populated");
+    TT_FATAL(operation_attributes.program_config.has_value(), "Error: program_config field should have been populated");
+    bool bcast_batch = operation_attributes.bcast_batch.value();
+    bool transpose_a = operation_attributes.transpose_a;
+    bool transpose_b = operation_attributes.transpose_b;
+
+    auto program_config =
+        std::get<operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(
+            operation_attributes.program_config.value());
+
+    auto fuse_batch = program_config.fuse_batch;
+    auto in0_block_w = program_config.in0_block_w;
+    auto out_subblock_h = program_config.out_subblock_h;
+    auto out_subblock_w = program_config.out_subblock_w;
+    auto out_block_h = program_config.out_block_h;
+    auto out_block_w = program_config.out_block_w;
+    auto per_core_M = program_config.per_core_M;
+    auto per_core_N = program_config.per_core_N;
+    auto mcast_in0 = program_config.mcast_in0;
+    auto gather_in0 = program_config.gather_in0;
+
+    TT_FATAL(!gather_in0, "create_descriptor does not support gather_in0 mode");
+
+    TT_FATAL(
+        operation_attributes.compute_kernel_config.has_value(),
+        "Error: compute_kernel_config field should have been populated");
+    auto compute_kernel_config = operation_attributes.compute_kernel_config.value();
+    auto untilize_out = operation_attributes.untilize_out;
+
+    const auto& a_shape_padded = get_matmul_tensor_padded_shape(a, transpose_a);
+    const auto& b_shape_padded = get_matmul_tensor_padded_shape(b, transpose_b);
+    const auto in0_tile = get_matmul_tile(a, transpose_a);
+    const auto in1_tile = get_matmul_tile(b, transpose_b);
+
+    // cannot use the output tensor tile directly as that might be changed by user override
+    const auto output_tile = tt::tt_metal::Tile({in0_tile.get_height(), in1_tile.get_width()});
+
+    // CB dataformats
+    const MeshTensor& in0_tensor = a.mesh_tensor();
+    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(in0_tensor.dtype());
+    const MeshTensor& in1_tensor = b.mesh_tensor();
+    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(in1_tensor.dtype());
+    tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
+
+    ttsl::optional_reference<const MeshTensor> bias_mesh_tensor;
+    tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;
+    if (bias.has_value()) {
+        const auto& c = bias.value();
+        bias_mesh_tensor = c.mesh_tensor();
+        bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
+    }
+
+    tt_metal::IDevice* device = &in0_tensor.mutable_device();
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), compute_kernel_config);
+
+    const auto in0_B = fuse_batch ? 1 : get_batch_size(a_shape_padded);
+    const auto in1_B = fuse_batch ? 1 : get_batch_size(b_shape_padded);
+    const auto Mt = get_M_dim(a_shape_padded, in0_tile, fuse_batch);
+    const auto Kt = get_K_dim(a_shape_padded, in0_tile);
+    const auto Nt = get_N_dim(b_shape_padded, in1_tile);
+
+    // The 1D mcast matmul only supports rectangular sub-device worker grids, because the in0/in1
+    // multicast targets a single bounding-box rectangle and the per-core index math assumes a
+    // contiguous row-major rectangle of width `grid_size.x`.
+    if (!program_config.allowed_worker_cores.has_value()) {
+        log_warning(
+            tt::LogOp,
+            "MatmulMultiCoreReuseMcast1DProgramFactory::create_descriptor: program_config.allowed_worker_cores not "
+            "populated; auto-populating from compute_with_storage_grid_size. Callers that bypass "
+            "ttnn::prim::qsr::matmul() should invoke "
+            "ttnn::operations::experimental::quasar::matmul::normalize_program_config() on the "
+            "program config first. This will become a hard error in a future release.");
+        program_config.allowed_worker_cores = CoreRangeSet(CoreRange(
+            CoreCoord(0, 0),
+            CoreCoord(
+                program_config.compute_with_storage_grid_size.x - 1,
+                program_config.compute_with_storage_grid_size.y - 1)));
+    }
+    auto grid_size = program_config.allowed_worker_cores.value().bounding_box().grid_size();
+
+    // When a sub-device is present use its bounding-box start; otherwise fall
+    // back to allowed_worker_cores start so non-(0,0) placements work correctly.
+    CoreCoord sub_device_start_core = program_config.allowed_worker_cores.value().bounding_box().start_coord;
+    if (operation_attributes.sub_device_id.has_value()) {
+        auto sd_worker_cores = device->worker_cores(
+            tt::tt_metal::HalProgrammableCoreType::TENSIX, operation_attributes.sub_device_id.value());
+        auto bbox = sd_worker_cores.bounding_box();
+        TT_FATAL(
+            sd_worker_cores.num_cores() == bbox.size(),
+            "matmul_multicore_reuse_mcast_1d only supports rectangular sub-device worker grids. "
+            "Got sub-device worker cores: {} (bounding box: {})",
+            sd_worker_cores,
+            bbox);
+        TT_FATAL(
+            bbox.start_coord.x + grid_size.x - 1 <= bbox.end_coord.x &&
+                bbox.start_coord.y + grid_size.y - 1 <= bbox.end_coord.y,
+            "matmul_multicore_reuse_mcast_1d grid_size {} anchored at sub-device start {} "
+            "extends past the sub-device's worker bounding box {}",
+            grid_size,
+            bbox.start_coord,
+            bbox);
+        sub_device_start_core = bbox.start_coord;
+    }
+
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler> fused_op_signaler = std::nullopt;
+
+    if (mcast_in0) {
+        return reuse_mcast_1d_optimized_helpers::create_program_mcast_in0_descriptor(
+            a,
+            device,
+            math_fidelity,
+            fp32_dest_acc_en,
+            math_approx_mode,
+            packer_l1_acc,
+            grid_size,
+            ttnn::get_throttle_level(compute_kernel_config),
+            in0_B,
+            in1_B,
+            Mt,
+            Nt,
+            Kt,
+            bcast_batch,
+            transpose_a,
+            transpose_b,
+            in0_block_w,
+            out_subblock_h,
+            out_subblock_w,
+            out_block_h,
+            out_block_w,
+            per_core_M,
+            per_core_N,
+            program_config.fused_activation,
+            in0_tensor,
+            in1_tensor,
+            bias_mesh_tensor,
+            output,
+            in0_tile,
+            in1_tile,
+            bias.has_value() ? bias->tensor_spec().tile() : output_tile,
+            output_tile,
+            in0_data_format,
+            in1_data_format,
+            bias_data_format,
+            output_data_format,
+            in0_tensor.memory_config().is_sharded(),
+            in1_tensor.memory_config().is_sharded(),
+            bias.has_value() ? bias->memory_config().is_sharded() : false,
+            output.memory_config().is_sharded(),
+            untilize_out,
+            fused_op_signaler,
+            fused_matmul_bias_row_broadcastable(bias),
+            sub_device_start_core);
+    }
+    return reuse_mcast_1d_optimized_helpers::create_program_mcast_in1_descriptor(
+        a,
+        device,
+        math_fidelity,
+        fp32_dest_acc_en,
+        math_approx_mode,
+        packer_l1_acc,
+        grid_size,
+        ttnn::get_throttle_level(compute_kernel_config),
+        in0_B,
+        in1_B,
+        Mt,
+        Nt,
+        Kt,
+        bcast_batch,
+        transpose_a,
+        transpose_b,
+        in0_block_w,
+        out_subblock_h,
+        out_subblock_w,
+        out_block_h,
+        out_block_w,
+        per_core_M,
+        per_core_N,
+        program_config.fused_activation,
+        in0_tensor,
+        in1_tensor,
+        bias_mesh_tensor,
+        output,
+        in0_tile,
+        in1_tile,
+        bias.has_value() ? bias->tensor_spec().tile() : output_tile,
+        output_tile,
+        in0_data_format,
+        in1_data_format,
+        bias_data_format,
+        output_data_format,
+        in0_tensor.memory_config().is_sharded(),
+        output.memory_config().is_sharded(),
+        untilize_out,
+        fused_matmul_bias_row_broadcastable(bias),
+        sub_device_start_core);
+}
+
+MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_reuse_mcast_1d_optimized_helper(
+    tt_metal::Program& program,
+    const Tensor& a,
+    const std::vector<Tensor>& b_tensors,
+    const std::optional<const Tensor>& bias,
+    const std::vector<Tensor>& output_tensors,
+    bool broadcast_batch,
+    DeviceComputeKernelConfig compute_kernel_config,
+    const operations::experimental::quasar::matmul::MatmulProgramConfig& program_config,
+    bool untilize_out,
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler,
+    const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    uint32_t start_cb_index,
+    std::optional<CoreRangeSet> restricted_cores) {
+    auto config = std::get<operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(
+        program_config);
+
+    if (!config.allowed_worker_cores.has_value()) {
+        log_warning(
+            tt::LogOp,
+            "matmul_multi_core_reuse_mcast_1d_optimized_helper: program_config.allowed_worker_cores not populated; "
+            "auto-populating from compute_with_storage_grid_size. Callers that bypass ttnn::prim::qsr::matmul() (e.g. "
+            "CCL fused ops) should invoke ttnn::operations::experimental::quasar::matmul::normalize_program_config() "
+            "on the program "
+            "config first. This will become a hard error in a future release.");
+        config.allowed_worker_cores = CoreRangeSet(CoreRange(
+            CoreCoord(0, 0),
+            CoreCoord(config.compute_with_storage_grid_size.x - 1, config.compute_with_storage_grid_size.y - 1)));
+    }
+    auto resolved_grid = config.allowed_worker_cores.value().bounding_box().grid_size();
+
+    return matmul_multi_core_reuse_mcast_1d_optimized_(
+        program,
+        a,
+        b_tensors,
+        bias,
+        output_tensors,
+        broadcast_batch,
+        /*transpose_a=*/false,
+        /*transpose_b=*/false,
+        resolved_grid,
+        compute_kernel_config,
+        ttnn::get_throttle_level(compute_kernel_config),
+        config.in0_block_w,
+        config.out_subblock_h,
+        config.out_subblock_w,
+        config.out_block_h,
+        config.out_block_w,
+        config.per_core_M,
+        config.per_core_N,
+        config.fuse_batch,
+        config.fused_activation,
+        config.mcast_in0,
+        config.gather_in0,
+        config.hop_cores,
+        untilize_out,
+        fused_op_signaler,
+        global_cb,
+        config.num_global_cb_receivers,
+        sub_device_id,
+        start_cb_index,
+        std::move(restricted_cores));
+}
+
+MatmulMeshWorkloadMultiCoreReuseMcast1DProgramFactory::cached_mesh_workload_t
+MatmulMeshWorkloadMultiCoreReuseMcast1DProgramFactory::create_mesh_workload(
+    const ttnn::prim::qsr::MatmulParams& attributes,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const ttnn::prim::qsr::MatmulInputs& tensor_args,
+    std::vector<ttnn::Tensor>& tensor_return_value) {
+    tt::tt_metal::distributed::MeshWorkload workload;
+    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
+    for (const auto& mesh_coord_range : tensor_coords.ranges()) {
+        for (const auto& mesh_coord : mesh_coord_range) {
+            const ttnn::MeshCoordinateRange mesh_coord_range{mesh_coord, mesh_coord};
+            auto pc = std::get<operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(
+                attributes.program_config.value());
+            if (!pc.allowed_worker_cores.has_value()) {
+                log_warning(
+                    tt::LogOp,
+                    "MatmulMeshWorkloadMultiCoreReuseMcast1DProgramFactory::create_mesh_workload: "
+                    "program_config.allowed_worker_cores not populated; auto-populating from "
+                    "compute_with_storage_grid_size. Callers that bypass ttnn::prim::qsr::matmul() should invoke "
+                    "ttnn::operations::experimental::quasar::matmul::normalize_program_config() on the program config "
+                    "first. This will "
+                    "become a hard error in a future release.");
+                pc.allowed_worker_cores = CoreRangeSet(CoreRange(
+                    CoreCoord(0, 0),
+                    CoreCoord(pc.compute_with_storage_grid_size.x - 1, pc.compute_with_storage_grid_size.y - 1)));
+            }
+            auto mesh_grid = pc.allowed_worker_cores.value().bounding_box().grid_size();
+            DeviceComputeKernelConfig ckc = attributes.compute_kernel_config.value();
+            tt_metal::Program program{};
+            std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler> empty_signaler = std::nullopt;
+            auto b_tensors =
+                std::vector<Tensor>{tensor_args.input_tensors.begin() + 1, tensor_args.input_tensors.end()};
+            auto shared_vars = matmul_multi_core_reuse_mcast_1d_optimized_(
+                program,
+                tensor_args.input_tensors.at(0),
+                b_tensors,
+                tensor_args.optional_input_tensors.at(0),
+                tensor_return_value,
+                attributes.bcast_batch.value_or(false),
+                attributes.transpose_a,
+                attributes.transpose_b,
+                mesh_grid,
+                ckc,
+                ttnn::get_throttle_level(ckc),
+                pc.in0_block_w,
+                pc.out_subblock_h,
+                pc.out_subblock_w,
+                pc.out_block_h,
+                pc.out_block_w,
+                pc.per_core_M,
+                pc.per_core_N,
+                pc.fuse_batch,
+                pc.fused_activation,
+                pc.mcast_in0,
+                pc.gather_in0,
+                pc.hop_cores,
+                attributes.untilize_out,
+                empty_signaler,
+                attributes.global_cb,
+                pc.num_global_cb_receivers,
+                attributes.sub_device_id,
+                tt::CBIndex::c_0,
+                std::nullopt);
+            shared_variables[mesh_coord_range] = std::move(shared_vars);
+            workload.add_program(mesh_coord_range, std::move(program));
+        }
+    }
+    return {std::move(workload), std::move(shared_variables)};
+}
+
+void MatmulMeshWorkloadMultiCoreReuseMcast1DProgramFactory::override_runtime_arguments(
+    cached_mesh_workload_t& cached_workload,
+    const ttnn::prim::qsr::MatmulParams& attributes,
+    const ttnn::prim::qsr::MatmulInputs& tensor_args,
+    std::vector<ttnn::Tensor>& tensor_return_value) {
+    for (auto& [mesh_coord_range, program] : cached_workload.workload.get_programs()) {
+        MatmulMultiCoreReuseMcast1DProgramFactory::override_runtime_arguments(
+            program,
+            cached_workload.shared_variables.at(mesh_coord_range),
+            attributes,
+            tensor_args,
+            tensor_return_value);
+    }
+}
+
+ttnn::device_operation::CachedProgram<MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t>
+matmul_multi_core_reuse_mcast_1d_optimized_helper(
+    tt_metal::Program& program,
+    const Tensor& a,
+    const std::vector<Tensor>& b_tensors,
+    const std::optional<const Tensor>& bias,
+    const std::vector<Tensor>& output_tensors,
+    bool broadcast_batch,
+    DeviceComputeKernelConfig compute_kernel_config,
+    const operations::experimental::quasar::matmul::MatmulProgramConfig& program_config,
+    bool untilize_out,
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler,
+    const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t shared_vars =
+        matmul_multi_core_reuse_mcast_1d_optimized_helper(
+            program,
+            a,
+            b_tensors,
+            bias,
+            output_tensors,
+            broadcast_batch,
+            compute_kernel_config,
+            program_config,
+            untilize_out,
+            fused_op_signaler,
+            global_cb,
+            sub_device_id,
+            tt::CBIndex::c_0,
+            std::nullopt);
+
+    return {std::move(program), std::move(shared_vars)};
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.hpp
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/matmul_device_operation_types.hpp"
+#include "ttnn/operations/ccl/ccl_op_fusion.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/matmul_1d_type.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace ttnn::prim::qsr {
+
+struct matmul_mcast_1d_common_override_variables_t {
+    std::vector<tt::tt_metal::KernelHandle> kernels;
+    std::vector<tt::tt_metal::CBHandle> cbs;
+    bool extract_shard_sub_blocks{};
+    CoreCoord start_core;
+    std::vector<CoreCoord> cores;
+    uint32_t num_cores_with_work{};
+    ttnn::prim::qsr::Matmul1DType type{};
+};
+
+struct MatmulMultiCoreReuseMcast1DProgramFactory {
+    using shared_variables_t = matmul_mcast_1d_common_override_variables_t;
+
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
+        const shared_variables_t& shared_variables,
+        const ttnn::prim::qsr::MatmulParams& operation_attributes,
+        const ttnn::prim::qsr::MatmulInputs& tensor_args,
+        std::vector<ttnn::Tensor>& tensor_return_value);
+
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const ttnn::prim::qsr::MatmulParams& operation_attributes,
+        const ttnn::prim::qsr::MatmulInputs& tensor_args,
+        std::vector<ttnn::Tensor>& tensor_return_value,
+        const std::optional<CoreRangeSet>& core_range_set = std::nullopt);
+};
+
+struct MatmulMeshWorkloadMultiCoreReuseMcast1DProgramFactory {
+    using shared_variables_t = MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t;
+    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
+
+    static cached_mesh_workload_t create_mesh_workload(
+        const ttnn::prim::qsr::MatmulParams& operation_attributes,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
+        const ttnn::prim::qsr::MatmulInputs& tensor_args,
+        std::vector<ttnn::Tensor>& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_mesh_workload_t& cached_workload,
+        const ttnn::prim::qsr::MatmulParams& operation_attributes,
+        const ttnn::prim::qsr::MatmulInputs& tensor_args,
+        std::vector<ttnn::Tensor>& tensor_return_value);
+};
+
+MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_reuse_mcast_1d_optimized_helper(
+    tt::tt_metal::Program& program,
+    const Tensor& a,
+    const std::vector<Tensor>& b_tensors,
+    const std::optional<const Tensor>& bias,
+    const std::vector<Tensor>& output_tensors,
+    bool broadcast_batch,
+    DeviceComputeKernelConfig compute_kernel_config,
+    const operations::experimental::quasar::matmul::MatmulProgramConfig& program_config,
+    bool untilize_out,
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler,
+    const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    uint32_t start_cb_index,
+    std::optional<CoreRangeSet> restricted_cores);
+
+ttnn::device_operation::CachedProgram<MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t>
+matmul_multi_core_reuse_mcast_1d_optimized_helper(
+    tt::tt_metal::Program& program,
+    const Tensor& a,
+    const std::vector<Tensor>& b_tensors,
+    const std::optional<const Tensor>& bias,
+    const std::vector<Tensor>& output_tensors,
+    bool broadcast_batch,
+    DeviceComputeKernelConfig compute_kernel_config,
+    const operations::experimental::quasar::matmul::MatmulProgramConfig& program_config,
+    bool untilize_out,
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler,
+    const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id);
+
+namespace reuse_mcast_1d_optimized_helpers {
+void override_program_parameters(
+    const MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t& override_variables,
+    const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb,
+    Program& program,
+    const ttnn::prim::qsr::MatmulInputs& tensor_args,
+    const std::vector<ttnn::Tensor>& tensor_return_value);
+}  // namespace reuse_mcast_1d_optimized_helpers
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
@@ -1,0 +1,3453 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/utilities/matmul_utilities.hpp"
+
+#include <algorithm>
+#include <utility>
+
+#include "hostdevcommon/common_values.hpp"
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/tt_align.hpp>
+#include "tt-metalium/buffer_types.hpp"
+
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+#include "ttnn/operations/compute_throttle_utils.hpp"
+#include "ttnn/operations/ccl/ccl_op_fusion.hpp"
+#include "ttnn/tensor/shape/shape.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/shared_with_host/activation_type.hpp"
+
+using ttnn::operations::unary::UnaryOpType;
+using ttnn::operations::unary::UnaryWithParam;
+
+using tt::tt_metal::CBDescriptor;
+using tt::tt_metal::CBFormatDescriptor;
+using tt::tt_metal::ComputeConfigDescriptor;
+using tt::tt_metal::DataMovementConfigDescriptor;
+using tt::tt_metal::KernelDescriptor;
+using tt::tt_metal::ProgramDescriptor;
+
+namespace ttnn::prim::qsr {
+
+namespace reuse_mcast_optimized_helpers {
+
+static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
+    tt::tt_metal::IDevice* device,
+    MathFidelity math_fidelity,
+    bool fp32_dest_acc_en,
+    bool math_approx_mode,
+    bool packer_l1_acc,
+    bool dst_full_sync_en,
+    uint32_t B,
+    uint32_t M,
+    uint32_t M_per_batch,
+    uint32_t N,
+    uint32_t K,
+    bool bcast_batch,
+    bool transpose_a,
+    bool transpose_b,
+    ttnn::operations::compute_throttle_utils::ThrottleLevel throttle_level,
+    uint32_t in0_block_w,
+    uint32_t in0_last_ktile_w,
+    uint32_t in0_last_ktile_h,
+    uint32_t out_subblock_h,
+    uint32_t out_subblock_w,
+    uint32_t out_block_h,
+    uint32_t out_block_w,
+    uint32_t per_core_M,
+    uint32_t per_core_N,
+    bool transpose_mcast,
+    std::optional<UnaryWithParam> fused_activation,
+    const tt::tt_metal::MeshTensor& in0_tensor,
+    const tt::tt_metal::MeshTensor& in1_tensor,
+    ttsl::optional_reference<const tt::tt_metal::MeshTensor> bias_tensor,
+    const tt::tt_metal::MeshTensor& out_tensor,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const tt::tt_metal::Tile& bias_tile,
+    const tt::tt_metal::Tile& output_tile,
+    tt::DataFormat in0_data_format,
+    tt::DataFormat in1_data_format,
+    tt::DataFormat bias_data_format,
+    tt::DataFormat output_data_format,
+    bool untilize_out,
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler,
+    bool row_broadcast_bias = true,
+    CoreCoord sub_device_start_core = {0, 0}) {
+    using namespace tt;
+    using tt::tt_metal::TensorMemoryLayout;
+
+    ttsl::optional_reference<const tt_metal::MeshTensor> bias_mesh;
+    if (bias_tensor.has_value()) {
+        bias_mesh = *bias_tensor;
+    }
+
+    // currently only support transpose of the full tile
+    bool in0_transpose_tile = in0_tile.get_transpose_of_faces() && in0_tile.get_transpose_within_face();
+    bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
+
+    bool fuse_op = fused_op_signaler.has_value();
+
+    TensorMemoryLayout in0_memory_layout = in0_tensor.memory_config().memory_layout();
+
+    uint32_t num_blocks = K / in0_block_w;
+
+    // Only enable packer l1 accumulation when there are num_blocks > 2, otherwise
+    // unnecessary overhead for reconfigs are added. Last iteration of l1 accumulation
+    // does a spill and reload, so need more than 2 blocks to use l1 acc for packer
+    // For bias, last iteration of l1 acc remains in intermediate buffer, does not spill and reload
+    bool packer_l1_acc_en = packer_l1_acc && (((bias_mesh.has_value()) && num_blocks > 1) || (num_blocks > 2));
+
+    // if fp32 enabled then we pack fp32 in l1, if not, then we pack fp16 in l1
+    tt::DataFormat interm0_data_format = packer_l1_acc_en
+                                             ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)
+                                             : (fp32_dest_acc_en ? tt::DataFormat::Float32 : output_data_format);
+
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    uint32_t bias_single_tile_size = bias_tile.get_tile_size(bias_data_format);
+    uint32_t output_single_tile_size = output_tile.get_tile_size(output_data_format);
+    uint32_t interm0_single_tile_size = output_tile.get_tile_size(interm0_data_format);
+
+    const bool in0_block_sharded = in0_memory_layout == TensorMemoryLayout::BLOCK_SHARDED;
+    const bool in0_height_sharded = in0_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED;
+    const bool in0_is_sharded = in0_block_sharded || in0_height_sharded;
+    const bool in1_is_width_sharded = in1_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
+    const bool in1_is_height_sharded = in1_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
+    const bool in1_is_sharded = in1_is_width_sharded || in1_is_height_sharded;
+    const bool output_is_sharded = out_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
+
+    // Tiles whose size is not a multiple of the DRAM alignment (e.g. bfp8 32x16 = 544B on
+    // Blackhole's 64B alignment) are padded to it in DRAM. The interleaved reader copies tiles at
+    // the padded stride, so the in0/in1/bias CBs must hold pages at the aligned stride and the
+    // reader/unpacker walk tiles at the same stride. No-op when already aligned (all bf16 tiles,
+    // 32-wide bfp8, Wormhole). Replaces the staging-CB workaround. Sharded CBs are backed by the
+    // tensor buffer and keep their natural page size.
+    const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
+    uint32_t in0_aligned_tile_size =
+        in0_is_sharded ? in0_single_tile_size : tt::align(in0_single_tile_size, dram_alignment);
+    uint32_t in1_aligned_tile_size =
+        in1_is_sharded ? in1_single_tile_size : tt::align(in1_single_tile_size, dram_alignment);
+
+    bool do_not_inplace_interm0_out_CB = output_is_sharded && (per_core_M != out_block_h);
+
+    uint32_t in0_block_h = out_block_h;
+    uint32_t in1_block_w = out_block_w;
+    uint32_t in0_num_blocks_y = per_core_M / out_block_h;
+    uint32_t in1_num_blocks_x = per_core_N / out_block_w;
+    uint32_t out_num_blocks_x = in1_num_blocks_x;
+    uint32_t out_num_blocks_y = in0_num_blocks_y;
+
+    uint32_t in0_block_tiles = out_block_h * in0_block_w;
+    uint32_t in0_CB_tiles = in0_block_tiles;
+    if (B * num_blocks > 1) {
+        in0_CB_tiles *= operations::experimental::quasar::matmul::utilities::MCAST_INPUT_BUFFERING_DEPTH;
+    }
+    uint32_t in0_CB_size = in0_CB_tiles * in0_aligned_tile_size;
+    uint32_t in1_block_tiles = out_block_w * in0_block_w;
+    uint32_t in1_CB_tiles = in1_block_tiles;
+    if (B * num_blocks > 1) {
+        in1_CB_tiles *= operations::experimental::quasar::matmul::utilities::MCAST_INPUT_BUFFERING_DEPTH;
+    }
+    uint32_t in1_CB_size = in1_CB_tiles * in1_aligned_tile_size;
+
+    uint32_t out_block_tiles = out_block_h * out_block_w;
+    uint32_t out_shard_tiles = per_core_M * per_core_N;
+    uint32_t out_CB_tiles = out_block_tiles;  // No double buffer
+    if (output_is_sharded) {
+        out_CB_tiles = out_shard_tiles;
+    }
+    uint32_t out_CB_size = out_CB_tiles * output_single_tile_size;
+    uint32_t interm0_CB_tiles = out_block_tiles;  // No double buffer
+    uint32_t interm0_CB_size = interm0_CB_tiles * interm0_single_tile_size;
+
+    uint32_t in2_block_tiles = 0;
+    uint32_t in0_shard_width_in_tiles = 0;
+    uint32_t in0_shard_height_in_tiles = 0;
+    if (in0_is_sharded) {
+        in0_shard_width_in_tiles = in0_tensor.shard_spec()->shape[1] / in0_tile.get_width();
+        in0_shard_height_in_tiles = in0_tensor.shard_spec()->shape[0] / in0_tile.get_height();
+        in2_block_tiles = per_core_M * in0_shard_width_in_tiles;
+    }
+
+    uint32_t in2_CB_tiles = in2_block_tiles;
+    uint32_t in2_CB_size = in2_CB_tiles * in0_single_tile_size;
+
+    uint32_t in3_block_tiles = out_block_w;
+    uint32_t in3_CB_tiles = in3_block_tiles;  // No double buffer
+    uint32_t in3_CB_size = in3_CB_tiles * bias_single_tile_size;
+
+    uint32_t start_core_x = sub_device_start_core.x;
+    uint32_t start_core_y = sub_device_start_core.y;
+
+    uint32_t num_blocks_y = ((M - 1) / per_core_M) + 1;
+    uint32_t num_blocks_x = ((N - 1) / per_core_N) + 1;
+    uint32_t num_cores_with_work_c = num_blocks_x;
+    uint32_t num_cores_with_work_r = num_blocks_y;
+    if (transpose_mcast) {
+        std::swap(num_cores_with_work_c, num_cores_with_work_r);
+    }
+
+    CoreRange all_cores_with_work(
+        {(std::size_t)start_core_x, (std::size_t)start_core_y},
+        {(std::size_t)start_core_x + num_cores_with_work_c - 1, (std::size_t)start_core_y + num_cores_with_work_r - 1});
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      IN0 SHARDED SENDER/RECEIVER
+    ////////////////////////////////////////////////////////////////////////////
+    uint32_t num_cores_c = num_cores_with_work_c;
+    uint32_t num_cores_r = num_cores_with_work_r;
+    uint32_t in0_mcast_receiver_grid_diff_coord_start;
+    uint32_t in0_mcast_receiver_grid_diff_coord_end;
+    std::vector<uint32_t> in0_mcast_noc_x;
+    std::vector<uint32_t> in0_mcast_noc_y;
+    uint32_t in0_sender_num_cores_along_width = 0;
+
+    // Only used for in0 block sharded
+    std::optional<CoreRange> in0_mcast_cores_without_work_and_not_in_receiver_grid;
+    if (in0_block_sharded) {
+        CoreCoord in0_shard_grid = in0_tensor.shard_spec()->grid.bounding_box().grid_size();
+        // in0 shard grid already accounts for transpose_mcast
+        // ie. If transpose_mcast, in0 width is along y
+        in0_sender_num_cores_along_width = transpose_mcast ? in0_shard_grid.y : in0_shard_grid.x;
+        if (in0_sender_num_cores_along_width > num_blocks_x) {
+            in0_mcast_cores_without_work_and_not_in_receiver_grid =
+                transpose_mcast ? CoreRange(
+                                      {(std::size_t)start_core_x, (std::size_t)start_core_y + num_blocks_x},
+                                      {(std::size_t)start_core_x + num_blocks_y - 1,
+                                       (std::size_t)start_core_y + in0_sender_num_cores_along_width - 1})
+                                : CoreRange(
+                                      {(std::size_t)start_core_x + num_blocks_x, (std::size_t)start_core_y},
+                                      {(std::size_t)start_core_x + in0_sender_num_cores_along_width - 1,
+                                       (std::size_t)start_core_y + num_blocks_y - 1});
+        }
+
+        if (transpose_mcast) {
+            in0_mcast_receiver_grid_diff_coord_start =
+                device->worker_core_from_logical_core({start_core_x, start_core_y}).y;
+            in0_mcast_receiver_grid_diff_coord_end =
+                device->worker_core_from_logical_core({start_core_x, start_core_y + num_blocks_x - 1}).y;
+            in0_mcast_noc_y.reserve(in0_sender_num_cores_along_width);
+            for (uint32_t core_idx_y = 0; core_idx_y < in0_sender_num_cores_along_width; ++core_idx_y) {
+                in0_mcast_noc_y.push_back(
+                    device->worker_core_from_logical_core({start_core_x, start_core_y + core_idx_y}).y);
+            }
+        } else {
+            in0_mcast_receiver_grid_diff_coord_start =
+                device->worker_core_from_logical_core({start_core_x, start_core_y}).x;
+            in0_mcast_receiver_grid_diff_coord_end =
+                device->worker_core_from_logical_core({start_core_x + num_blocks_x - 1, start_core_y}).x;
+            in0_mcast_noc_x.reserve(in0_sender_num_cores_along_width);
+            for (uint32_t core_idx_x = 0; core_idx_x < in0_sender_num_cores_along_width; ++core_idx_x) {
+                in0_mcast_noc_x.push_back(
+                    device->worker_core_from_logical_core({start_core_x + core_idx_x, start_core_y}).x);
+            }
+        }
+
+        // Set in0 sender/receiver cores to be maximum
+        if (transpose_mcast) {
+            num_cores_r = std::max(num_cores_r, in0_sender_num_cores_along_width);
+        } else {
+            num_cores_c = std::max(num_cores_c, in0_sender_num_cores_along_width);
+        }
+    }
+
+    // Used for setting up CBs and semaphores by both in0 interleaved or sharded
+    CoreRange all_cores(
+        {(std::size_t)start_core_x, (std::size_t)start_core_y},
+        {(std::size_t)start_core_x + num_cores_c - 1, (std::size_t)start_core_y + num_cores_r - 1});
+    const auto& cores = grid_to_cores(all_cores.start_coord, all_cores.end_coord, true);
+    //////////////////////////////////////////////////////////////////////////////////////////
+    //       IN0 SENDER (interleaved only) and IN1 SENDER (both interleaved and sharded)
+    //////////////////////////////////////////////////////////////////////////////////////////
+    // Left column
+    CoreRange in0_sender_interleaved(
+        {(std::size_t)start_core_x, (std::size_t)start_core_y},
+        {(std::size_t)start_core_x, (std::size_t)start_core_y + num_cores_with_work_r - 1});
+
+    // Top row
+    CoreRange in1_sender(
+        {(std::size_t)start_core_x, (std::size_t)start_core_y},
+        {(std::size_t)start_core_x + num_cores_with_work_c - 1, (std::size_t)start_core_y});
+
+    // Left column except corner
+    std::optional<CoreRange> in0_sender_in1_receiver;
+    if (num_cores_with_work_r > 1) {
+        in0_sender_in1_receiver = {
+            {(std::size_t)start_core_x, (std::size_t)start_core_y + 1},
+            {(std::size_t)start_core_x, (std::size_t)start_core_y + num_cores_with_work_r - 1}};
+    }
+
+    // Top row except corner
+    std::optional<CoreRange> in0_receiver_in1_sender;
+    if (num_cores_with_work_c > 1) {
+        in0_receiver_in1_sender = {
+            {(std::size_t)start_core_x + 1, (std::size_t)start_core_y},
+            {(std::size_t)start_core_x + num_cores_with_work_c - 1, (std::size_t)start_core_y}};
+    }
+
+    if (transpose_mcast) {
+        std::swap(in0_sender_interleaved, in1_sender);
+        std::swap(in0_sender_in1_receiver, in0_receiver_in1_sender);
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////////////////
+    //       IN0 RECEIVER (interleaved only) and IN1 RECEIVER (both interleaved and sharded)
+    /////////////////////////////////////////////////////////////////////////////////////////////////
+    // Not exactly half-half; this seems to get slightly better perf for fused qkv and selfout
+    // TODO: Experiment with different splits?
+    bool split_half = num_cores_with_work_c > 2 && num_cores_with_work_r > 1 && !in0_is_sharded;
+    uint32_t half_core = split_half ? (num_cores_with_work_c) / 2 : num_cores_with_work_c - 1;
+
+    std::optional<CoreRange> in0_receiver_in1_receiver_left_half;
+    if (num_cores_with_work_c > 1 and num_cores_with_work_r > 1) {
+        in0_receiver_in1_receiver_left_half = {
+            {(std::size_t)start_core_x + 1, (std::size_t)start_core_y + 1},
+            {(std::size_t)start_core_x + half_core, (std::size_t)start_core_y + num_cores_with_work_r - 1}};
+    }
+
+    std::set<CoreRange> in0_receiver_interleaved_set;
+    std::set<CoreRange> in1_receiver_set;
+    if (in0_receiver_in1_sender.has_value()) {
+        in0_receiver_interleaved_set.insert(in0_receiver_in1_sender.value());
+    }
+    if (in0_sender_in1_receiver.has_value()) {
+        in1_receiver_set.insert(in0_sender_in1_receiver.value());
+    }
+    if (in0_receiver_in1_receiver_left_half.has_value()) {
+        in0_receiver_interleaved_set.insert(in0_receiver_in1_receiver_left_half.value());
+        in1_receiver_set.insert(in0_receiver_in1_receiver_left_half.value());
+    }
+    CoreRangeSet in0_receiver_interleaved(in0_receiver_interleaved_set);
+    CoreRangeSet in1_receiver(in1_receiver_set);
+
+    std::optional<CoreRange> in0_receiver_in1_receiver_interleaved_other_cores;
+    if (split_half) {
+        in0_receiver_in1_receiver_interleaved_other_cores = {
+            {(std::size_t)start_core_x + half_core + 1, (std::size_t)start_core_y + 1},
+            {(std::size_t)start_core_x + num_cores_with_work_c - 1,
+             (std::size_t)start_core_y + num_cores_with_work_r - 1}};
+    }
+
+    // Mcast args — semaphore IDs assigned sequentially (0, 1, 2, 3)
+    uint32_t in0_mcast_sender_semaphore_id = 0;
+    uint32_t in0_mcast_receiver_semaphore_id = 1;
+    uint32_t in1_mcast_sender_semaphore_id = 2;
+    uint32_t in1_mcast_receiver_semaphore_id = 3;
+
+    bool in1_is_dram = in1_tensor.mesh_buffer().device_local_config().buffer_type == tt_metal::BufferType::DRAM;
+
+    uint32_t in0_num_subblocks = (out_block_h / out_subblock_h);
+    uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
+
+    TT_FATAL(
+        out_block_h % out_subblock_h == 0 and out_block_h >= out_subblock_h,
+        "out_block_h must be multiple of out_subblock_h");
+    TT_FATAL(
+        out_block_w % out_subblock_w == 0 and out_block_w >= out_subblock_w,
+        "out_block_w must be multiple of out_subblock_w");
+
+    std::vector<uint32_t> in0_sender_compile_time_args;
+
+    uint32_t num_dram_banks = 0;
+    uint32_t per_core_N_storage = 0;
+    uint32_t batches_per_bank = 0;
+    if (in1_is_sharded and in1_is_dram) {
+        num_dram_banks = device->num_dram_channels();
+        if (in1_is_width_sharded) {
+            per_core_N_storage = (N + num_dram_banks - 1) / num_dram_banks;
+        } else {
+            // Height sharded: batches are distributed across DRAM banks
+            uint32_t in1_shard_height_in_tiles = in1_tensor.shard_spec()->shape[0] / in1_tile.get_height();
+            batches_per_bank = in1_shard_height_in_tiles / K;
+        }
+    }
+
+    const auto [in0_tensor_stride_w, in0_tensor_stride_h] =
+        operations::experimental::quasar::matmul::utilities::get_in0_transpose_strides(M, M_per_batch, transpose_a, K);
+    const auto in0_tensor_next_block_stride = in0_block_w * in0_tensor_stride_w;
+    const auto in0_tensor_next_h_dim_block_stride = in0_block_h * in0_tensor_stride_h;
+    const auto in0_tensor_start_tile_id_stride = per_core_M * in0_tensor_stride_h;
+
+    const auto in1_tensor_stride_w = transpose_b ? K : 1;
+    const auto in1_tensor_stride_h = transpose_b ? 1 : N;
+    const auto in1_tensor_next_block_stride = in0_block_w * in1_tensor_stride_h;
+    const auto in1_tensor_next_w_dim_block_stride = in1_block_w * in1_tensor_stride_w;
+    const auto in1_tensor_start_tile_id_stride = per_core_N * in1_tensor_stride_w;
+
+    if (in0_block_sharded) {
+        uint32_t num_x = in0_sender_num_cores_along_width;
+        uint32_t num_y = 1;
+        if (transpose_mcast) {
+            std::swap(num_x, num_y);
+        }
+
+        in0_sender_compile_time_args = {
+            (std::uint32_t)1,  // core_has_output_block_work
+            (std::uint32_t)1,  // core_in_in0_receiver_mcast_grid
+
+            (std::uint32_t)in0_block_num_tiles,                         // in0_block_num_tiles
+            (std::uint32_t)in0_block_num_tiles * in0_single_tile_size,  // in0_block_size_bytes
+            (std::uint32_t)in0_last_ktile_w,
+            (std::uint32_t)in0_last_ktile_h,
+
+            // in0/in1 common args
+            (std::uint32_t)num_blocks,  // num_blocks
+            (std::uint32_t)out_num_blocks_x,
+            (std::uint32_t)out_num_blocks_y,
+            // in0 mcast args
+            (std::uint32_t)in0_mcast_sender_semaphore_id,
+            (std::uint32_t)in0_mcast_receiver_semaphore_id,
+            (std::uint32_t)num_blocks_x,  // in0_mcast_num_dests
+            (std::uint32_t)num_blocks_x,  // in0_mcast_num_cores
+            (std::uint32_t)num_x,
+            (std::uint32_t)num_y,
+            (std::uint32_t)transpose_mcast,
+            (std::uint32_t)in0_shard_width_in_tiles,
+            (std::uint32_t)in0_shard_height_in_tiles,
+            (std::uint32_t)in0_block_w,
+            (std::uint32_t)in0_block_h,
+            // batch args
+            (std::uint32_t)B  // batch
+        };
+    } else {
+        in0_sender_compile_time_args = {
+            // in0 tensor args
+            (std::uint32_t)in0_tensor_stride_w,
+            (std::uint32_t)in0_tensor_stride_h,
+            (std::uint32_t)in0_tensor_next_block_stride,
+            (std::uint32_t)in0_tensor_next_h_dim_block_stride,
+            // in0 block args
+            (std::uint32_t)in0_block_w,          // in0_block_w
+            (std::uint32_t)in0_block_h,          // in0_block_h
+            (std::uint32_t)in0_block_num_tiles,  // in0_block_num_tiles
+            (std::uint32_t)in0_last_ktile_w,
+            (std::uint32_t)in0_last_ktile_h,
+
+            (std::uint32_t)false,                      // extract_shard_sub_blocks (not used for interleaved)
+            (std::uint32_t)in0_shard_width_in_tiles,   // shard_width_in_tiles (not used for interleaved)
+            (std::uint32_t)in0_shard_height_in_tiles,  // shard_height_in_tiles (not used for interleaved)
+            // in0/in1 common args
+            (std::uint32_t)num_blocks,  // num_blocks
+            (std::uint32_t)out_num_blocks_x,
+            (std::uint32_t)out_num_blocks_y,
+            // in0 mcast args
+            (std::uint32_t)in0_mcast_sender_semaphore_id,
+            (std::uint32_t)in0_mcast_receiver_semaphore_id,
+            (std::uint32_t)(num_blocks_x - 1),  // in0_mcast_num_dests
+            (std::uint32_t)(num_blocks_x - 1),  // in0_mcast_num_cores
+            // batch args
+            (std::uint32_t)M * K,  // MtKt
+            (std::uint32_t)B,      // batch
+            (std::uint32_t)B,      // batch
+            (std::uint32_t)false,  // reuse_in0_in_CB
+
+            // sparsity args
+            (std::uint32_t)0,      // batchB
+            (std::uint32_t)0,      // sparsity_pagesize (placeholder since sparsity not used in this case)
+            (std::uint32_t)true,   // bcast_A
+            (std::uint32_t)false,  // get_batch_from_reader
+        };
+    }
+    in0_sender_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));
+    tt::tt_metal::TensorAccessorArgs(in0_tensor).append_to(in0_sender_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs().append_to(in0_sender_compile_time_args);  // placeholder for sparsity
+    in0_sender_compile_time_args.push_back((std::uint32_t)0);  // num_batch_compute (unused, sparsity disabled)
+
+    std::vector<uint32_t> in1_sender_writer_compile_time_args = {
+        // READER
+        // in1 tensor args
+        (std::uint32_t)in1_tensor_stride_w,
+        (std::uint32_t)in1_tensor_stride_h,
+        (std::uint32_t)in1_tensor_next_block_stride,
+        (std::uint32_t)in1_tensor_next_w_dim_block_stride,
+        // in1 block args
+        (std::uint32_t)in1_block_w,                // in1_block_w
+        (std::uint32_t)in0_block_w,                // in1_block_h
+        (std::uint32_t)in1_block_w * in0_block_w,  // in1_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,  // num_blocks
+        (std::uint32_t)out_num_blocks_x,
+        (std::uint32_t)out_num_blocks_y,
+        // in1 mcast args
+        (std::uint32_t)in1_mcast_sender_semaphore_id,
+        (std::uint32_t)in1_mcast_receiver_semaphore_id,
+        (std::uint32_t)(num_blocks_y - 1),  // in1_mcast_num_dests
+        (std::uint32_t)(num_blocks_y - 1),  // in1_mcast_num_cores
+        // batch args
+        (std::uint32_t)K * N,        // KtNt
+        (std::uint32_t)B,            // batch
+        (std::uint32_t)bcast_batch,  // bcast_B
+        // sparsity args
+        (std::uint32_t)0,  // batchB
+        (std::uint32_t)0,  // sparsity_pagesize (placeholder since sparsity not used in this case)
+
+        // WRITER
+        // out tensor args
+        (std::uint32_t)1,                   // out_tensor_stride_w
+        (std::uint32_t)N,                   // out_tensor_stride_h
+        (std::uint32_t)out_subblock_w,      // out_tensor_next_subblock_stride_w
+        (std::uint32_t)out_subblock_h * N,  // out_tensor_next_subblock_stride_h
+        (std::uint32_t)out_block_w,         // out_tensor_next_w_dim_block_stride
+        (std::uint32_t)out_block_h * N,     // out_tensor_next_h_dim_block_stride
+        // out subblock args
+        (std::uint32_t)out_subblock_w,                     // out_subblock_w
+        (std::uint32_t)out_subblock_h,                     // out_subblock_h
+        (std::uint32_t)(out_subblock_w * out_subblock_h),  // out_subblocks_w * out_subblocks_h
+        // batch args
+        (std::uint32_t)M * N  // MtNt
+    };
+    if (bias_mesh.has_value()) {
+        in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);  // in3_tensor_stride_w
+    } else {
+        in1_sender_writer_compile_time_args.push_back(0);  // Placeholder; not used
+    }
+
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_reduce_scatter()));
+
+    // Append TensorAccessorArgs
+    tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs().append_to(in1_sender_writer_compile_time_args);  // placeholder for sparsity
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_sender_writer_compile_time_args);
+    if (bias_mesh.has_value()) {
+        tt::tt_metal::TensorAccessorArgs(*bias_mesh).append_to(in1_sender_writer_compile_time_args);
+    }
+
+    if (in1_is_sharded and in1_is_dram) {
+        if (in1_is_width_sharded) {
+            in1_sender_writer_compile_time_args.push_back((std::uint32_t)per_core_N_storage * in0_block_w);
+            in1_sender_writer_compile_time_args.push_back((std::uint32_t)per_core_N_storage * in1_single_tile_size);
+        } else {
+            // Height sharded: pass tiles per batch and batches per bank
+            in1_sender_writer_compile_time_args.push_back((std::uint32_t)(K * N));  // KtNt per batch (tiles)
+            in1_sender_writer_compile_time_args.push_back((std::uint32_t)batches_per_bank);
+        }
+    }
+    std::vector<uint32_t> in0_receiver_compile_time_args = {
+        // in0 block args
+        (std::uint32_t)in0_block_w * in0_block_h,  // in0_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,  // num_blocks
+        (std::uint32_t)out_num_blocks_x,
+        (std::uint32_t)out_num_blocks_y,
+        // in0 mcast args
+        (std::uint32_t)in0_mcast_sender_semaphore_id,
+        (std::uint32_t)in0_mcast_receiver_semaphore_id,
+        // batch args
+        (std::uint32_t)B,     // batch
+        (std::uint32_t)false  // get_batch_from_reader
+    };
+    std::vector<uint32_t> in1_receiver_writer_compile_time_args = {
+        // READER
+        // in1 block args
+        (std::uint32_t)in1_block_w * in0_block_w,  // in1_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,  // num_blocks
+        (std::uint32_t)out_num_blocks_x,
+        (std::uint32_t)out_num_blocks_y,
+        // in1 mcast args
+        (std::uint32_t)in1_mcast_sender_semaphore_id,
+        (std::uint32_t)in1_mcast_receiver_semaphore_id,
+        // batch args
+        (std::uint32_t)B,  // batch
+
+        // WRITER
+        // out tensor args
+        (std::uint32_t)1,                   // out_tensor_stride_w
+        (std::uint32_t)N,                   // out_tensor_stride_h
+        (std::uint32_t)out_subblock_w,      // out_tensor_next_subblock_stride_w
+        (std::uint32_t)out_subblock_h * N,  // out_tensor_next_subblock_stride_h
+        (std::uint32_t)out_block_w,         // out_tensor_next_w_dim_block_stride
+        (std::uint32_t)out_block_h * N,     // out_tensor_next_h_dim_block_stride
+        // out subblock args
+        (std::uint32_t)out_subblock_w,                     // out_subblock_w
+        (std::uint32_t)out_subblock_h,                     // out_subblock_h
+        (std::uint32_t)(out_subblock_w * out_subblock_h),  // out_subblocks_w * out_subblocks_h
+        // batch args
+        (std::uint32_t)M * N  // MtNt
+    };
+    if (bias_mesh.has_value()) {
+        in1_receiver_writer_compile_time_args.push_back((std::uint32_t)in1_block_w);
+    } else {
+        in1_receiver_writer_compile_time_args.push_back(0);  // Placeholder; not used
+    }
+    in1_receiver_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_reduce_scatter()));
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_receiver_writer_compile_time_args);
+
+    std::map<std::string, std::string> mm_kernel_defines;
+    std::map<std::string, std::string> mm_kernel_in0_sender_sharded_defines;
+    std::map<std::string, std::string> mm_kernel_in0_sender_interleaved_defines;
+    std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
+    std::map<std::string, std::string> mm_kernel_in1_receiver_writer_defines;
+    std::map<std::string, std::string> mm_kernel_in1_receiver_writer_other_noc_setup_defines;
+    if (bias_mesh.has_value()) {
+        mm_kernel_defines["FUSE_BIAS"] = "1";
+        mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
+        mm_kernel_in1_receiver_writer_defines["FUSE_BIAS"] = "1";
+        mm_kernel_in1_receiver_writer_other_noc_setup_defines["FUSE_BIAS"] = "1";
+    }
+    if (fused_activation.has_value()) {
+        if (fused_activation.value().op_type == UnaryOpType::RELU) {
+            mm_kernel_defines["PACK_RELU"] = "1";
+        } else {
+            mm_kernel_defines["SFPU_ACTIVATION"] = "1";
+        }
+    }
+    if (packer_l1_acc_en) {
+        mm_kernel_defines["PACKER_L1_ACC"] = "1";
+    }
+    if (fp32_dest_acc_en) {
+        mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    if (in1_transpose_tile) {
+        mm_kernel_defines["IN1_TRANSPOSE_TILE"] = "1";
+    }
+
+    ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
+        device->arch(), cores.size(), mm_kernel_defines);
+    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
+        device->arch(), cores.size(), mm_kernel_defines, throttle_level);
+
+    if (in0_receiver_interleaved.num_cores() == 0) {
+        mm_kernel_in0_sender_interleaved_defines["SKIP_MCAST"] = "1";
+    }
+    if (in0_height_sharded) {
+        mm_kernel_in0_sender_interleaved_defines["IN0_SHARDED"] = "1";
+    }
+
+    if (in1_receiver.num_cores() == 0) {
+        mm_kernel_in1_sender_writer_defines["SKIP_MCAST"] = "1";
+    }
+    if (in1_is_sharded) {
+        if (in1_is_dram) {
+            if (in1_is_width_sharded) {
+                mm_kernel_in1_sender_writer_defines["IN1_DRAM_WIDTH_SHARDED"] = "1";
+            } else {
+                mm_kernel_in1_sender_writer_defines["IN1_DRAM_HEIGHT_SHARDED"] = "1";
+            }
+        } else {
+            mm_kernel_in1_sender_writer_defines["IN1_SHARDED"] = "1";
+        }
+    }
+
+    if (output_is_sharded) {
+        mm_kernel_in1_sender_writer_defines["OUT_SHARDED"] = "1";
+        mm_kernel_in1_receiver_writer_defines["OUT_SHARDED"] = "1";
+        mm_kernel_in1_receiver_writer_other_noc_setup_defines["OUT_SHARDED"] = "1";
+    }
+
+    // Intermediate CB read
+    /*
+    Blackhole architecture alignment issue workaround for tiny tiles:
+
+    Problem: When reading tiny tiles from DRAM to circular buffers (CB), address alignment
+    issues occur. DRAM tile addresses are 64-byte aligned within each block, but L1 CB
+    addresses are not necessarily aligned due to non-64-byte-aligned page sizes.
+
+    Example scenario:
+    - Two consecutive 544-byte tiles (16x32 tile of dtype bfloat8_b) stored on different DRAM banks
+    - CB configured with size=2 to hold both tiles
+
+    Result:
+    - Tile 0: DRAM Bank 0, Address 64    → CB L1 Address 0   (64-byte aligned ✓)
+    - Tile 1: DRAM Bank 1, Address 64    → CB L1 Address 544 (not 64-byte aligned ✗)
+
+    Solution: Use an intermediate single-tile CB as a staging area. Read each tile into
+    the intermediate CB first, then copy to the destination CB. This ensures proper
+    alignment at the cost of additional memory bandwidth overhead.
+
+    Note: This workaround should only be used for this specific alignment issue case.
+    */
+
+    // Helper to convert std::map defines to KernelDescriptor::Defines (vector of pairs)
+    auto map_to_defines = [](const std::map<std::string, std::string>& m) -> KernelDescriptor::Defines {
+        KernelDescriptor::Defines result;
+        result.reserve(m.size());
+        for (const auto& [k, v] : m) {
+            result.emplace_back(k, v);
+        }
+        return result;
+    };
+
+    // in1 is the reader of weights/output writer, and we choose to make it use the optimized reader noc
+    tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+    tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+    tt_metal::NOC in0_split_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+    tt_metal::NOC in1_split_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Build Kernel Descriptors
+    ////////////////////////////////////////////////////////////////////////////
+    // We build kernel descriptors as local variables, populate their runtime_args
+    // in the per-core loop, then push them all to desc.kernels at the end.
+    // The order they are pushed determines the kernel handle index.
+
+    // Kernel index tracking:
+    // Index 0: mm_kernel_in0_sender (block sharded or interleaved)
+    // Index 1: mm_kernel_in0_mcast_cores_without_work (only if in0_block_sharded && extra cores exist)
+    //   OR: (not created if not needed)
+    // Then: mm_kernel_in1_sender_writer
+    // Then: mm_kernel_in1_receiver_writer (if in1_receiver.num_cores() > 0)
+    // Then: mm_kernel_in0_receiver (if !in0_block_sharded && in0_receiver_interleaved.num_cores() > 0)
+    // Then: mm_kernel_in1_receiver_writer_other_noc_setup (if split_half other cores exist)
+    // Then: mm_kernel_in0_receiver_other_noc_setup (if split_half other cores exist)
+    // Then: compute kernel
+
+    KernelDescriptor in0_sender_kernel_desc;
+    KernelDescriptor in0_mcast_no_work_kernel_desc;
+    bool has_in0_mcast_no_work_kernel = false;
+    KernelDescriptor in1_sender_writer_kernel_desc;
+    KernelDescriptor in1_receiver_writer_kernel_desc;
+    bool has_in1_receiver_writer_kernel = false;
+    KernelDescriptor in0_receiver_kernel_desc;
+    bool has_in0_receiver_kernel = false;
+    KernelDescriptor in1_receiver_writer_other_kernel_desc;
+    bool has_in1_receiver_writer_other_kernel = false;
+    KernelDescriptor in0_receiver_other_kernel_desc;
+    bool has_in0_receiver_other_kernel = false;
+
+    if (in0_block_sharded) {
+        in0_sender_kernel_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+            "reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp";
+        in0_sender_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        in0_sender_kernel_desc.core_ranges = CoreRangeSet(all_cores_with_work);
+        in0_sender_kernel_desc.compile_time_args = in0_sender_compile_time_args;
+        in0_sender_kernel_desc.defines = map_to_defines(mm_kernel_in0_sender_sharded_defines);
+        in0_sender_kernel_desc.named_compile_time_args = {
+            {"cb_in0", tt::CBIndex::c_0},
+            {"cb_in0_sharded", tt::CBIndex::c_2},
+            {"cb_l1_array", tt::CBIndex::c_6},
+        };
+        in0_sender_kernel_desc.config =
+            DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = in0_noc};
+
+        if (in0_mcast_cores_without_work_and_not_in_receiver_grid.has_value()) {
+            has_in0_mcast_no_work_kernel = true;
+            auto no_work_ct_args = in0_sender_compile_time_args;
+            no_work_ct_args[0] = 0;  // core_has_output_block_work
+            no_work_ct_args[1] = 0;  // core_in_in0_receiver_mcast_grid
+            in0_mcast_no_work_kernel_desc.kernel_source =
+                "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+                "reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp";
+            in0_mcast_no_work_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+            in0_mcast_no_work_kernel_desc.core_ranges =
+                CoreRangeSet(in0_mcast_cores_without_work_and_not_in_receiver_grid.value());
+            in0_mcast_no_work_kernel_desc.compile_time_args = no_work_ct_args;
+            in0_mcast_no_work_kernel_desc.defines = map_to_defines(mm_kernel_in0_sender_sharded_defines);
+            in0_mcast_no_work_kernel_desc.named_compile_time_args = {
+                {"cb_in0", tt::CBIndex::c_0},
+                {"cb_in0_sharded", tt::CBIndex::c_2},
+                {"cb_l1_array", tt::CBIndex::c_6},
+            };
+            in0_mcast_no_work_kernel_desc.config =
+                DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = in0_noc};
+        }
+    } else {
+        // NOTE: fused_op_signaler init_fused_op() calls are NOT translated to the descriptor
+        // because they modify the Program directly. These are handled when the Program is
+        // constructed from the descriptor in create_program_mcast_in0_in1().
+
+        in0_sender_kernel_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+            "reader_bmm_tile_layout_in0_sender_padding.cpp";
+        in0_sender_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        in0_sender_kernel_desc.core_ranges = CoreRangeSet(in0_sender_interleaved);
+        in0_sender_kernel_desc.compile_time_args = in0_sender_compile_time_args;
+        in0_sender_kernel_desc.defines = map_to_defines(mm_kernel_in0_sender_interleaved_defines);
+        in0_sender_kernel_desc.named_compile_time_args = {
+            {"cb_in0", tt::CBIndex::c_0},
+            {"cb_in0_sharded", tt::CBIndex::c_2},
+            {"cb_sparsity", tt::CBIndex::c_6},
+        };
+        in0_sender_kernel_desc.config =
+            DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = in0_noc};
+    }
+
+    in1_sender_writer_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+        "reader_bmm_tile_layout_in1_sender_writer_padding.cpp";
+    in1_sender_writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    in1_sender_writer_kernel_desc.core_ranges = CoreRangeSet(in1_sender);
+    in1_sender_writer_kernel_desc.compile_time_args = in1_sender_writer_compile_time_args;
+    in1_sender_writer_kernel_desc.defines = map_to_defines(mm_kernel_in1_sender_writer_defines);
+    in1_sender_writer_kernel_desc.named_compile_time_args = {
+        {"cb_in1", tt::CBIndex::c_1},
+        {"cb_bias", tt::CBIndex::c_3},
+        {"cb_out", tt::CBIndex::c_4},
+        {"cb_sparsity", tt::CBIndex::c_7},
+    };
+    in1_sender_writer_kernel_desc.config =
+        DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = in1_noc};
+
+    if (in1_receiver.num_cores() > 0) {
+        has_in1_receiver_writer_kernel = true;
+        in1_receiver_writer_kernel_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+            "reader_bmm_tile_layout_in1_receiver_writer_padding.cpp";
+        in1_receiver_writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        in1_receiver_writer_kernel_desc.core_ranges = in1_receiver;
+        in1_receiver_writer_kernel_desc.compile_time_args = in1_receiver_writer_compile_time_args;
+        in1_receiver_writer_kernel_desc.defines = map_to_defines(mm_kernel_in1_receiver_writer_defines);
+        in1_receiver_writer_kernel_desc.named_compile_time_args = {
+            {"cb_in1", tt::CBIndex::c_1},
+            {"cb_bias", tt::CBIndex::c_3},
+            {"cb_out", tt::CBIndex::c_4},
+        };
+        in1_receiver_writer_kernel_desc.config =
+            DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = in1_noc};
+    }
+
+    if (!in0_block_sharded and in0_receiver_interleaved.num_cores() > 0) {
+        has_in0_receiver_kernel = true;
+        in0_receiver_kernel_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+            "reader_bmm_tile_layout_in0_receiver.cpp";
+        in0_receiver_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        in0_receiver_kernel_desc.core_ranges = in0_receiver_interleaved;
+        in0_receiver_kernel_desc.compile_time_args = in0_receiver_compile_time_args;
+        in0_receiver_kernel_desc.named_compile_time_args = {
+            {"cb_in0", tt::CBIndex::c_0},
+        };
+        in0_receiver_kernel_desc.config =
+            DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = in0_noc};
+    }
+
+    if (in0_receiver_in1_receiver_interleaved_other_cores.has_value()) {
+        has_in1_receiver_writer_other_kernel = true;
+        in1_receiver_writer_other_kernel_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+            "reader_bmm_tile_layout_in1_receiver_writer_padding.cpp";
+        in1_receiver_writer_other_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        in1_receiver_writer_other_kernel_desc.core_ranges =
+            CoreRangeSet(in0_receiver_in1_receiver_interleaved_other_cores.value());
+        in1_receiver_writer_other_kernel_desc.compile_time_args = in1_receiver_writer_compile_time_args;
+        in1_receiver_writer_other_kernel_desc.defines =
+            map_to_defines(mm_kernel_in1_receiver_writer_other_noc_setup_defines);
+        in1_receiver_writer_other_kernel_desc.named_compile_time_args = {
+            {"cb_in1", tt::CBIndex::c_1},
+            {"cb_bias", tt::CBIndex::c_3},
+            {"cb_out", tt::CBIndex::c_4},
+        };
+        in1_receiver_writer_other_kernel_desc.config =
+            DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = in1_split_noc};
+
+        has_in0_receiver_other_kernel = true;
+        in0_receiver_other_kernel_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+            "reader_bmm_tile_layout_in0_receiver.cpp";
+        in0_receiver_other_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        in0_receiver_other_kernel_desc.core_ranges =
+            CoreRangeSet(in0_receiver_in1_receiver_interleaved_other_cores.value());
+        in0_receiver_other_kernel_desc.compile_time_args = in0_receiver_compile_time_args;
+        in0_receiver_other_kernel_desc.named_compile_time_args = {
+            {"cb_in0", tt::CBIndex::c_0},
+        };
+        in0_receiver_other_kernel_desc.config =
+            DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = in0_split_noc};
+    }
+
+    // Compute kernel compile time args
+
+    uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
+
+    uint32_t in1_num_subblocks = (out_block_w / out_subblock_w);
+    uint32_t in1_block_num_tiles = out_subblock_w * in0_block_w * in1_num_subblocks;
+    uint32_t in1_per_core_w = out_subblock_w * in1_num_subblocks;
+
+    uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
+
+    std::vector<uint32_t> compute_kernel_args = {
+        in0_block_w,             // in0_block_w
+        in0_num_subblocks,       // in0_num_subblocks
+        in0_block_num_tiles,     // in0_block_num_tiles
+        in0_subblock_num_tiles,  // in0_subblock_num_tiles
+
+        in1_num_subblocks,    // in1_num_subblocks
+        in1_block_num_tiles,  // in1_block_num_tiles
+        in1_per_core_w,       // in1_per_core_w
+
+        num_blocks,  // num_blocks
+        out_num_blocks_x,
+        out_num_blocks_y,
+
+        out_subblock_h,          // out_subblock_h
+        out_subblock_w,          // out_subblock_w
+        out_subblock_num_tiles,  // out_subblock_num_tiles
+        B,                       // batch,
+        out_block_tiles,         // out_block_num_tiles
+
+        untilize_out,  // untilize_out
+        false,         // get_batch_from_reader
+        in0_transpose_tile,
+    };
+    if (bias_mesh.has_value()) {
+        compute_kernel_args.push_back(row_broadcast_bias ? 1u : 0u);
+    }
+
+    // Create compute kernel descriptor
+    KernelDescriptor compute_kernel_desc;
+    compute_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/"
+        "bmm_large_block_zm_fused_bias_activation.cpp";
+    compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_kernel_desc.core_ranges = CoreRangeSet(all_cores_with_work);
+    compute_kernel_desc.compile_time_args = compute_kernel_args;
+    compute_kernel_desc.defines = map_to_defines(mm_kernel_defines);
+    {
+        KernelDescriptor::NamedCompileTimeArgs named_compile_args = {
+            {"cb_in0", tt::CBIndex::c_0},
+            {"cb_in1", tt::CBIndex::c_1},
+            {"cb_bias", tt::CBIndex::c_3},
+            {"cb_out", tt::CBIndex::c_4},
+            {"cb_intermed0", tt::CBIndex::c_5},
+            {"cb_in0_transposed", tt::CBIndex::c_10},
+            {"bias_ntiles", in1_per_core_w},
+        };
+        if (fused_activation.has_value() && fused_activation.value().op_type != UnaryOpType::RELU) {
+            using ttnn::operations::experimental::quasar::matmul::utilities::get_activation_params;
+            const auto params = get_activation_params(fused_activation.value());
+            named_compile_args.push_back({"activation_type", static_cast<uint32_t>(params.type)});
+            named_compile_args.push_back({"activation_param0", params.param0});
+            named_compile_args.push_back({"activation_param1", params.param1});
+            named_compile_args.push_back({"activation_param2", params.param2});
+        }
+        compute_kernel_desc.named_compile_time_args = std::move(named_compile_args);
+    }
+    compute_kernel_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .math_approx_mode = math_approx_mode};
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Build CBDescriptors
+    ////////////////////////////////////////////////////////////////////////////
+    ProgramDescriptor desc;
+
+    tt::tt_metal::TileDescriptor in0_tile_desc{in0_tile};
+    tt::tt_metal::TileDescriptor in1_tile_desc{in1_tile};
+    tt::tt_metal::TileDescriptor bias_tile_desc{bias_tile};
+    tt::tt_metal::TileDescriptor output_tile_desc{output_tile};
+
+    // CB 0: in0
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in0_CB_size;
+        cb_desc.core_ranges = CoreRangeSet(all_cores);
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_0,
+            .data_format = in0_data_format,
+            .page_size = in0_aligned_tile_size,
+            .tile = in0_tile_desc});
+        if (in0_height_sharded) {
+            cb_desc.tensor = &in0_tensor;
+        }
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 1: in1
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in1_CB_size;
+        cb_desc.core_ranges = CoreRangeSet(all_cores);
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_1,
+            .data_format = in1_data_format,
+            .page_size = in1_aligned_tile_size,
+            .tile = in1_tile_desc});
+        if (in1_is_sharded and not in1_is_dram) {
+            cb_desc.tensor = &in1_tensor;
+        }
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 2: in0 sharded (only for block sharded)
+    if (in0_block_sharded) {
+        {
+            CBDescriptor cb_desc;
+            cb_desc.total_size = in2_CB_size;
+            cb_desc.core_ranges = CoreRangeSet(all_cores);
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = tt::CBIndex::c_2,
+                .data_format = in0_data_format,
+                .page_size = in0_single_tile_size,
+                .tile = in0_tile_desc});
+            cb_desc.tensor = &in0_tensor;
+            desc.cbs.push_back(std::move(cb_desc));
+        }
+
+        // Local L1 to store temp vars
+        {
+            CBDescriptor cb_desc;
+            cb_desc.total_size = 32 * 2;
+            cb_desc.core_ranges = CoreRangeSet(all_cores);
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = tt::CBIndex::c_6, .data_format = tt::DataFormat::Float16_b, .page_size = 32 * 2});
+            desc.cbs.push_back(std::move(cb_desc));
+        }
+    }
+
+    // CB 4 and CB 5: output and intermediate
+    if (do_not_inplace_interm0_out_CB || (interm0_data_format != output_data_format) ||
+        (untilize_out && (in1_num_subblocks > 1))) {
+        // Separate output and intermediate CBs
+        // output
+        {
+            CBDescriptor cb_desc;
+            cb_desc.total_size = out_CB_size;
+            cb_desc.core_ranges = CoreRangeSet({all_cores});
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = tt::CBIndex::c_4,
+                .data_format = output_data_format,
+                .page_size = output_single_tile_size,
+                .tile = output_tile_desc});
+            if (output_is_sharded) {
+                cb_desc.tensor = &out_tensor;
+            }
+            desc.cbs.push_back(std::move(cb_desc));
+        }
+        // interm0
+        {
+            CBDescriptor cb_desc;
+            cb_desc.total_size = interm0_CB_size;
+            cb_desc.core_ranges = CoreRangeSet({all_cores});
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = tt::CBIndex::c_5,
+                .data_format = interm0_data_format,
+                .page_size = interm0_single_tile_size,
+                .tile = output_tile_desc});
+            desc.cbs.push_back(std::move(cb_desc));
+        }
+    } else {
+        // share buffer
+        CBDescriptor cb_desc;
+        cb_desc.total_size = out_CB_size;
+        cb_desc.core_ranges = CoreRangeSet({all_cores});
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_4,
+            .data_format = output_data_format,
+            .page_size = output_single_tile_size,
+            .tile = output_tile_desc});
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_5,
+            .data_format = interm0_data_format,
+            .page_size = interm0_single_tile_size,
+            .tile = output_tile_desc});
+        if (output_is_sharded) {
+            cb_desc.tensor = &out_tensor;
+        }
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB for bias
+    if (bias_mesh.has_value()) {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in3_CB_size;
+        cb_desc.core_ranges = CoreRangeSet(all_cores);
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_3,
+            .data_format = bias_data_format,
+            .page_size = bias_single_tile_size,
+            .tile = bias_tile_desc});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // Intermediate CB read
+
+    if (in0_transpose_tile) {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in0_CB_size;
+        cb_desc.core_ranges = CoreRangeSet(all_cores);
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_10,
+            .data_format = in0_data_format,
+            .page_size = in0_aligned_tile_size,
+            .tile = in0_tile_desc});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Semaphore Descriptors
+    ////////////////////////////////////////////////////////////////////////////
+    desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+        .id = in0_mcast_sender_semaphore_id, .core_ranges = CoreRangeSet(all_cores), .initial_value = INVALID});
+    desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+        .id = in0_mcast_receiver_semaphore_id, .core_ranges = CoreRangeSet(all_cores), .initial_value = INVALID});
+    desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+        .id = in1_mcast_sender_semaphore_id, .core_ranges = CoreRangeSet(all_cores), .initial_value = INVALID});
+    desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+        .id = in1_mcast_receiver_semaphore_id, .core_ranges = CoreRangeSet(all_cores), .initial_value = INVALID});
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Runtime Args (per-core loop)
+    ////////////////////////////////////////////////////////////////////////////
+    // Parameters for last row, col, or block
+    uint32_t last_per_core_M = M % per_core_M == 0 ? per_core_M : M % per_core_M;
+    uint32_t last_per_core_N = N % per_core_N == 0 ? per_core_N : N % per_core_N;
+    uint32_t last_out_block_h = last_per_core_M % out_block_h == 0 ? out_block_h : last_per_core_M % out_block_h;
+    uint32_t last_out_block_w = last_per_core_N % out_block_w == 0 ? out_block_w : last_per_core_N % out_block_w;
+    uint32_t last_out_num_blocks_h = ((last_per_core_M - 1) / out_block_h) + 1;
+    uint32_t last_out_num_blocks_w = ((last_per_core_N - 1) / out_block_w) + 1;
+    uint32_t last_block_num_nonzero_subblocks_h = ((last_out_block_h - 1) / out_subblock_h) + 1;
+    uint32_t last_block_num_nonzero_subblocks_w = ((last_out_block_w - 1) / out_subblock_w) + 1;
+    uint32_t last_subblock_of_last_block_h =
+        last_out_block_h % out_subblock_h == 0 ? out_subblock_h : last_out_block_h % out_subblock_h;
+    uint32_t last_subblock_of_last_block_w =
+        last_out_block_w % out_subblock_w == 0 ? out_subblock_w : last_out_block_w % out_subblock_w;
+    uint32_t last_block_padded_subblock_tiles_addr_skip =
+        output_single_tile_size * (out_subblock_w - last_subblock_of_last_block_w);
+    uint32_t last_block_padded_block_tiles_w_skip =
+        (out_subblock_w * out_subblock_h) * (out_block_w / out_subblock_w - last_block_num_nonzero_subblocks_w);
+    uint32_t last_block_padded_block_tiles_h_skip =
+        (out_block_h / out_subblock_h - last_block_num_nonzero_subblocks_h) * (out_block_w * out_subblock_h);
+
+    if (in0_block_sharded) {
+        if (in0_noc == tt::tt_metal::NOC::NOC_1) {
+            std::swap(in0_mcast_receiver_grid_diff_coord_start, in0_mcast_receiver_grid_diff_coord_end);
+        }
+    }
+
+    // dram sharded weights stride params
+    uint32_t worker_core_stride = 0;   // stride in the worker core
+    uint32_t storage_core_stride = 0;  // stride in the dram bank
+    uint32_t curr_worker_core = 0;     // current worker core
+    uint32_t curr_storage_core = 0;    // current read dram bank
+    uint32_t vc = 0;
+
+    uint32_t in0_end_idx = num_blocks_y - 1;
+    uint32_t in1_end_idx = num_blocks_x - 1;
+
+    for (const auto& core : cores) {
+        CoreCoord left_core = {(std::size_t)start_core_x, (std::size_t)core.y};
+        CoreCoord left_core_plus_one = {(std::size_t)start_core_x + 1, (std::size_t)core.y};
+        CoreCoord right_core = {(std::size_t)start_core_x + num_cores_with_work_c - 1, (std::size_t)core.y};
+        CoreCoord top_core = {(std::size_t)core.x, (std::size_t)start_core_y};
+        CoreCoord top_core_plus_one = {(std::size_t)core.x, (std::size_t)start_core_y + 1};
+        CoreCoord bottom_core = {(std::size_t)core.x, (std::size_t)start_core_y + num_cores_with_work_r - 1};
+
+        auto left_core_physical = device->worker_core_from_logical_core(left_core);
+        auto left_core_plus_one_physical = device->worker_core_from_logical_core(left_core_plus_one);
+        auto right_core_physical = device->worker_core_from_logical_core(right_core);
+        auto top_core_physical = device->worker_core_from_logical_core(top_core);
+        auto top_core_plus_one_physical = device->worker_core_from_logical_core(top_core_plus_one);
+        auto bottom_core_physical = device->worker_core_from_logical_core(bottom_core);
+        uint32_t in0_idx = core.y - start_core_y;
+        uint32_t in1_idx = core.x - start_core_x;
+
+        auto in0_mcast_sender = left_core_physical;
+        auto in1_mcast_sender = top_core_physical;
+
+        // Assuming in0 is NOC0
+        auto in0_mcast_start = left_core_plus_one_physical;
+        auto in0_mcast_end = right_core_physical;
+        if (in0_noc == tt::tt_metal::NOC::NOC_1) {
+            std::swap(in0_mcast_start, in0_mcast_end);
+        }
+
+        // Assuming in1 is NOC1
+        auto in1_mcast_start = bottom_core_physical;
+        auto in1_mcast_end = top_core_plus_one_physical;
+        if (in1_noc == tt::tt_metal::NOC::NOC_0) {
+            std::swap(in1_mcast_start, in1_mcast_end);
+        }
+
+        if (transpose_mcast) {
+            std::swap(in0_idx, in1_idx);
+            std::swap(in0_mcast_sender, in1_mcast_sender);
+            std::swap(in0_mcast_start, in1_mcast_end);
+            std::swap(in0_mcast_end, in1_mcast_start);
+        }
+
+        // in0 sender
+        if (in0_block_sharded) {
+            uint32_t in0_mcast_receiver_grid_same_coord;
+            std::vector<uint32_t> mm_in0_sender_args;
+            if (transpose_mcast) {
+                in0_mcast_receiver_grid_same_coord = device->worker_core_from_logical_core(core).x;
+                mm_in0_sender_args.push_back(core.y);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_diff_coord_start);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_diff_coord_end);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
+                mm_in0_sender_args.insert(mm_in0_sender_args.end(), in0_mcast_noc_y.begin(), in0_mcast_noc_y.end());
+            } else {
+                in0_mcast_receiver_grid_same_coord = device->worker_core_from_logical_core(core).y;
+                mm_in0_sender_args.push_back(core.x);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_diff_coord_start);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_diff_coord_end);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
+                mm_in0_sender_args.insert(mm_in0_sender_args.end(), in0_mcast_noc_x.begin(), in0_mcast_noc_x.end());
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
+            }
+            if (in1_idx < num_blocks_x) {
+                in0_sender_kernel_desc.runtime_args.emplace_back(core, mm_in0_sender_args);
+            } else {
+                in0_mcast_no_work_kernel_desc.runtime_args.emplace_back(core, mm_in0_sender_args);
+            }
+        } else if (in1_idx == 0) {
+            std::vector<uint32_t> mm_in0_sender_args = {
+                // in0 tensor args
+                (std::uint32_t)in0_tensor.address(),
+                (std::uint32_t)in0_tensor_start_tile_id_stride * in0_idx,  // in0_tensor_start_tile_id
+                // in0 mcast args
+                (std::uint32_t)in0_mcast_start.x,  // in0_mcast_dest_noc_start_x
+                (std::uint32_t)in0_mcast_start.y,  // in0_mcast_dest_noc_start_y
+                (std::uint32_t)in0_mcast_end.x,    // in0_mcast_dest_noc_end_x
+                (std::uint32_t)in0_mcast_end.y,    // in0_mcast_dest_noc_end_y
+            };
+            if (in0_idx == in0_end_idx) {
+                // padding args (READER)
+                mm_in0_sender_args.push_back(last_out_block_h);  // last_out_block_h
+            } else {
+                mm_in0_sender_args.push_back(out_block_h);
+            }
+
+            // sparsity args
+            mm_in0_sender_args.push_back(0);  // sparsity_addr
+
+            if (fuse_op && fused_op_signaler->is_all_gather()) {
+                fused_op_signaler->push_matmul_fused_op_rt_args(mm_in0_sender_args, false);
+            }
+
+            {
+                std::vector<std::variant<uint32_t, std::reference_wrapper<const tt::tt_metal::MeshTensor>>> in0_args(
+                    mm_in0_sender_args.begin(), mm_in0_sender_args.end());
+                in0_args[0] = in0_tensor;
+                in0_sender_kernel_desc.emplace_runtime_args(core, in0_args);
+            }
+
+            // in0 receiver
+        } else {
+            std::vector<uint32_t> mm_in0_receiver_args = {
+                // in0 mcast args
+                (std::uint32_t)in0_mcast_sender.x,  // in0_mcast_sender_noc_x
+                (std::uint32_t)in0_mcast_sender.y   // in0_mcast_sender_noc_y
+            };
+            // left half
+            if ((core.x - start_core_x) <= half_core || (!transpose_mcast and core.y == start_core_y)) {
+                in0_receiver_kernel_desc.runtime_args.emplace_back(core, mm_in0_receiver_args);
+            }
+            // right half
+            else {
+                in0_receiver_other_kernel_desc.runtime_args.emplace_back(core, mm_in0_receiver_args);
+            }
+        }
+
+        if (in0_idx < num_blocks_y and in1_idx < num_blocks_x) {
+            // in1 sender
+            if (in0_idx == 0) {
+                std::vector<uint32_t> mm_in1_sender_writer_args = {
+                    // READER
+                    // in1 tensor args
+                    (std::uint32_t)in1_tensor.address(),
+                    (std::uint32_t)in1_tensor_start_tile_id_stride * in1_idx,  // in1_tensor_start_tile_id
+                    // in1 mcast args
+                    (std::uint32_t)in1_mcast_start.x,  // in1_mcast_dest_noc_start_x
+                    (std::uint32_t)in1_mcast_start.y,  // in1_mcast_dest_noc_start_y
+                    (std::uint32_t)in1_mcast_end.x,    // in1_mcast_dest_noc_end_x
+                    (std::uint32_t)in1_mcast_end.y,    // in1_mcast_dest_noc_end_y
+
+                    // sparsity args
+                    (std::uint32_t)0,  // sparsity_addr
+
+                    // WRITER
+                    // out tensor args
+                    (std::uint32_t)out_tensor.address(),
+                    ((std::uint32_t)in1_idx * per_core_N) + (in0_idx * per_core_M * N)  // out_tensor_start_tile_id
+                };
+
+                if (in1_idx == in1_end_idx) {  // right cores when no transpose_mcast
+                    // padding args (READER)
+                    mm_in1_sender_writer_args.push_back(last_out_block_w);
+
+                    // padding args (WRITER)
+                    mm_in1_sender_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_sender_writer_args.push_back(out_subblock_h);
+                    mm_in1_sender_writer_args.push_back(0);
+                    mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_sender_writer_args.push_back(last_block_num_nonzero_subblocks_w);
+                    mm_in1_sender_writer_args.push_back(last_subblock_of_last_block_w);
+                    mm_in1_sender_writer_args.push_back(last_block_padded_subblock_tiles_addr_skip);
+                    mm_in1_sender_writer_args.push_back(last_block_padded_block_tiles_w_skip);
+                } else {
+                    // padding args (READER)
+                    mm_in1_sender_writer_args.push_back(out_block_w);
+
+                    // padding args (WRITER)
+                    mm_in1_sender_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_sender_writer_args.push_back(out_subblock_h);
+                    mm_in1_sender_writer_args.push_back(0);
+                    mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_sender_writer_args.push_back(out_subblock_w);
+                    mm_in1_sender_writer_args.push_back(0);
+                    mm_in1_sender_writer_args.push_back(0);
+                }
+
+                mm_in1_sender_writer_args.push_back(bias_mesh.has_value() ? (std::uint32_t)bias_mesh->address() : 0);
+                mm_in1_sender_writer_args.push_back(
+                    bias_mesh.has_value() ? (std::uint32_t)per_core_N * in1_idx : 0);  // in1_tensor_start_tile_id
+                if (!output_is_sharded) {
+                    if (in1_idx == in1_end_idx) {  // right cores when no transpose_mcast
+                        mm_in1_sender_writer_args.push_back(last_out_num_blocks_w);
+                    } else {
+                        mm_in1_sender_writer_args.push_back(out_num_blocks_x);
+                    }
+                }
+
+                if (in1_is_sharded and in1_is_dram) {  // in1 is dram sharded
+                    if (in1_is_width_sharded) {
+                        uint32_t num_iter_index = mm_in1_sender_writer_args.size() + 1;
+                        vc = vc == 3 ? 0 : vc + 1;
+                        mm_in1_sender_writer_args.push_back(vc);
+
+                        uint32_t num_iter = 0;  // iterate how many banks, till fill the current worker block
+
+                        if (curr_storage_core < num_dram_banks) {
+                            num_iter++;
+
+                            worker_core_stride = per_core_N_storage - storage_core_stride;
+
+                            mm_in1_sender_writer_args.push_back(
+                                storage_core_stride * in1_single_tile_size);  // dram_tensor_start_offset
+                            mm_in1_sender_writer_args.push_back(
+                                worker_core_stride * in1_single_tile_size);          // per_core_N_dram_bytes
+                            mm_in1_sender_writer_args.push_back(curr_storage_core);  // current_dram_bank_id
+
+                            log_debug(
+                                tt::LogOp,
+                                "curr worker core: {} read {} tiles from dram bank: {}, start from index: {}",
+                                curr_worker_core,
+                                worker_core_stride,
+                                curr_storage_core,
+                                storage_core_stride);
+
+                            curr_storage_core += (storage_core_stride + worker_core_stride) / per_core_N_storage;
+                            storage_core_stride = (storage_core_stride + worker_core_stride) % per_core_N_storage;
+
+                            uint32_t curr_worker_core_old = curr_worker_core;
+                            if (worker_core_stride >= per_core_N) {
+                                curr_worker_core += 1;
+                            }
+
+                            while (curr_worker_core <= curr_worker_core_old and curr_storage_core < num_dram_banks) {
+                                num_iter++;
+
+                                uint32_t stride = worker_core_stride + per_core_N_storage;
+                                stride = std::min(stride, per_core_N);
+
+                                mm_in1_sender_writer_args.push_back(
+                                    (stride - worker_core_stride) * in1_single_tile_size);  // per_core_N_dram_bytes
+                                mm_in1_sender_writer_args.push_back(curr_storage_core);     // current_dram_bank_id
+
+                                log_debug(
+                                    tt::LogOp,
+                                    "curr worker core: {} read {} tiles from dram bank: {}, start from index: {}",
+                                    curr_worker_core,
+                                    (stride - worker_core_stride),
+                                    curr_storage_core,
+                                    storage_core_stride);
+
+                                if (stride >= per_core_N) {
+                                    curr_worker_core += 1;
+                                }
+                                storage_core_stride = (stride - worker_core_stride) % per_core_N_storage;
+                                curr_storage_core += (stride - worker_core_stride) / per_core_N_storage;
+                                worker_core_stride = stride;
+                            }
+                        }
+                        mm_in1_sender_writer_args.insert(mm_in1_sender_writer_args.begin() + num_iter_index, num_iter);
+                    } else {
+                        // Height sharded: no additional runtime args needed
+                        // (bank/offset computed from compile-time args + batch index)
+                    }
+                }
+                if (fuse_op) {
+                    if (fused_op_signaler->is_all_gather()) {
+                        fused_op_signaler->push_matmul_fused_op_rt_args(mm_in1_sender_writer_args, true);
+                    } else if (fused_op_signaler->is_reduce_scatter()) {
+                        fused_op_signaler->push_matmul_fused_op_rt_args(mm_in1_sender_writer_args, in0_idx, in1_idx);
+                    } else {
+                        TT_FATAL(false, "Fused operation must be either all_gather or reduce_scatter.");
+                    }
+                }
+                {
+                    std::vector<std::variant<uint32_t, std::reference_wrapper<const tt::tt_metal::MeshTensor>>>
+                        in1_sender_variant(mm_in1_sender_writer_args.begin(), mm_in1_sender_writer_args.end());
+                    in1_sender_variant[0] = in1_tensor;
+                    in1_sender_variant[7] = out_tensor;
+                    if (bias_mesh.has_value()) {
+                        in1_sender_variant[18] = *bias_mesh;
+                    }
+                    in1_sender_writer_kernel_desc.emplace_runtime_args(core, in1_sender_variant);
+                }
+
+                // in1 receiver
+            } else {
+                std::vector<uint32_t> mm_in1_receiver_writer_args = {
+                    // READER
+                    // in1 mcast args
+                    (std::uint32_t)in1_mcast_sender.x,  // in1_mcast_sender_noc_x
+                    (std::uint32_t)in1_mcast_sender.y,  // in1_mcast_sender_noc_y
+
+                    // WRITER
+                    // out tensor args
+                    (std::uint32_t)out_tensor.address(),                                // out_tensor_addr
+                    ((std::uint32_t)in1_idx * per_core_N) + (in0_idx * per_core_M * N)  // out_tensor_start_tile_id
+                };
+
+                if (in1_idx == in1_end_idx and in0_idx == in0_end_idx) {  // bottom-right core when no transpose_mcast
+                    // padding args (WRITER)
+                    mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(last_block_num_nonzero_subblocks_h);
+                    mm_in1_receiver_writer_args.push_back(last_subblock_of_last_block_h);
+                    mm_in1_receiver_writer_args.push_back(last_block_padded_block_tiles_h_skip);
+                    mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(last_block_num_nonzero_subblocks_w);
+                    mm_in1_receiver_writer_args.push_back(last_subblock_of_last_block_w);
+                    mm_in1_receiver_writer_args.push_back(last_block_padded_subblock_tiles_addr_skip);
+                    mm_in1_receiver_writer_args.push_back(last_block_padded_block_tiles_w_skip);
+                } else if (in0_idx == in0_end_idx) {  // bottom cores except bottom-right when no transpose_mcast
+                    // padding args (WRITER)
+                    mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(last_block_num_nonzero_subblocks_h);
+                    mm_in1_receiver_writer_args.push_back(last_subblock_of_last_block_h);
+                    mm_in1_receiver_writer_args.push_back(last_block_padded_block_tiles_h_skip);
+                    mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(0);
+                    mm_in1_receiver_writer_args.push_back(0);
+                } else if (in1_idx == in1_end_idx) {  // right cores except bottom when no transpose_mcast
+                    // padding args (WRITER)
+                    mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(0);
+                    mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(last_block_num_nonzero_subblocks_w);
+                    mm_in1_receiver_writer_args.push_back(last_subblock_of_last_block_w);
+                    mm_in1_receiver_writer_args.push_back(last_block_padded_subblock_tiles_addr_skip);
+                    mm_in1_receiver_writer_args.push_back(last_block_padded_block_tiles_w_skip);
+                } else {
+                    // padding args (WRITER)
+                    mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(0);
+                    mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(0);
+                    mm_in1_receiver_writer_args.push_back(0);
+                }
+                if (!output_is_sharded) {
+                    if (in1_idx == in1_end_idx and
+                        in0_idx == in0_end_idx) {  // bottom-right core when no transpose_mcast
+                        mm_in1_receiver_writer_args.push_back(last_out_num_blocks_h);
+                        mm_in1_receiver_writer_args.push_back(last_out_num_blocks_w);
+                    } else if (in0_idx == in0_end_idx) {  // bottom cores except bottom-right when no transpose_mcast
+                        mm_in1_receiver_writer_args.push_back(last_out_num_blocks_h);
+                        mm_in1_receiver_writer_args.push_back(out_num_blocks_x);
+                    } else if (in1_idx == in1_end_idx) {  // right cores except bottom when no transpose_mcast
+                        mm_in1_receiver_writer_args.push_back(out_num_blocks_y);
+                        mm_in1_receiver_writer_args.push_back(last_out_num_blocks_w);
+                    } else {
+                        mm_in1_receiver_writer_args.push_back(out_num_blocks_y);
+                        mm_in1_receiver_writer_args.push_back(out_num_blocks_x);
+                    }
+                }
+
+                if (fuse_op && fused_op_signaler->is_reduce_scatter()) {
+                    fused_op_signaler->push_matmul_fused_op_rt_args(mm_in1_receiver_writer_args, in0_idx, in1_idx);
+                }
+
+                {
+                    std::vector<std::variant<uint32_t, std::reference_wrapper<const tt::tt_metal::MeshTensor>>>
+                        in1_recv_variant(mm_in1_receiver_writer_args.begin(), mm_in1_receiver_writer_args.end());
+                    in1_recv_variant[2] = out_tensor;
+                    // left half
+                    if ((core.x - start_core_x) <= half_core || (transpose_mcast and core.y == start_core_y)) {
+                        in1_receiver_writer_kernel_desc.emplace_runtime_args(core, in1_recv_variant);
+                    }
+                    // right half
+                    else {
+                        in1_receiver_writer_other_kernel_desc.emplace_runtime_args(core, in1_recv_variant);
+                    }
+                }
+            }
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Push Kernels to Descriptor
+    ////////////////////////////////////////////////////////////////////////////
+    // Order matters — determines kernel handle indices
+    desc.kernels.push_back(std::move(in0_sender_kernel_desc));
+    if (has_in0_mcast_no_work_kernel) {
+        desc.kernels.push_back(std::move(in0_mcast_no_work_kernel_desc));
+    }
+    desc.kernels.push_back(std::move(in1_sender_writer_kernel_desc));
+    if (has_in1_receiver_writer_kernel) {
+        desc.kernels.push_back(std::move(in1_receiver_writer_kernel_desc));
+    }
+    if (has_in0_receiver_kernel) {
+        desc.kernels.push_back(std::move(in0_receiver_kernel_desc));
+    }
+    if (has_in1_receiver_writer_other_kernel) {
+        desc.kernels.push_back(std::move(in1_receiver_writer_other_kernel_desc));
+    }
+    if (has_in0_receiver_other_kernel) {
+        desc.kernels.push_back(std::move(in0_receiver_other_kernel_desc));
+    }
+    desc.kernels.push_back(std::move(compute_kernel_desc));
+
+    return desc;
+}
+
+ttnn::device_operation::CachedProgram<MatmulMultiCoreReuseMcast2DProgramFactory::shared_variables_t>
+create_program_mcast_in0_in1(
+    tt::tt_metal::Program& program,
+    tt::tt_metal::IDevice* device,
+    MathFidelity math_fidelity,
+    bool fp32_dest_acc_en,
+    bool math_approx_mode,
+    bool packer_l1_acc,
+    bool dst_full_sync_en,
+    uint32_t B,
+    uint32_t M,
+    uint32_t M_per_batch,
+    uint32_t N,
+    uint32_t K,
+    bool bcast_batch,
+    bool transpose_a,
+    bool transpose_b,
+    ttnn::operations::compute_throttle_utils::ThrottleLevel throttle_level,
+    uint32_t in0_block_w,
+    uint32_t in0_last_ktile_w,
+    uint32_t in0_last_ktile_h,
+    uint32_t out_subblock_h,
+    uint32_t out_subblock_w,
+    uint32_t out_block_h,
+    uint32_t out_block_w,
+    uint32_t per_core_M,
+    uint32_t per_core_N,
+    bool transpose_mcast,
+    std::optional<UnaryWithParam> fused_activation,
+    const tt::tt_metal::MeshTensor& in0_tensor,
+    const tt::tt_metal::MeshTensor& in1_tensor,
+    ttsl::optional_reference<const tt::tt_metal::MeshTensor> bias_tensor,
+    const tt::tt_metal::MeshTensor& out_tensor,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const tt::tt_metal::Tile& bias_tile,
+    const tt::tt_metal::Tile& output_tile,
+    tt::DataFormat in0_data_format,
+    tt::DataFormat in1_data_format,
+    tt::DataFormat bias_data_format,
+    tt::DataFormat output_data_format,
+    bool untilize_out,
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler,
+    bool row_broadcast_bias = true,
+    CoreCoord sub_device_start_core = {0, 0}) {
+    using namespace tt;
+    using tt::tt_metal::TensorMemoryLayout;
+
+    ttsl::optional_reference<const tt_metal::MeshTensor> bias_mesh;
+    if (bias_tensor.has_value()) {
+        bias_mesh = *bias_tensor;
+    }
+
+    // currently only support transpose of the full tile
+    bool in0_transpose_tile = in0_tile.get_transpose_of_faces() && in0_tile.get_transpose_within_face();
+    bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
+
+    bool fuse_op = fused_op_signaler.has_value();
+
+    TensorMemoryLayout in0_memory_layout = in0_tensor.memory_config().memory_layout();
+
+    uint32_t num_blocks = K / in0_block_w;
+
+    // Only enable packer l1 accumulation when there are num_blocks > 2, otherwise
+    // unnecessary overhead for reconfigs are added. Last iteration of l1 accumulation
+    // does a spill and reload, so need more than 2 blocks to use l1 acc for packer
+    // For bias, last iteration of l1 acc remains in intermediate buffer, does not spill and reload
+    bool packer_l1_acc_en = packer_l1_acc && (((bias_mesh.has_value()) && num_blocks > 1) || (num_blocks > 2));
+
+    // if fp32 enabled then we pack fp32 in l1, if not, then we pack fp16 in l1
+    tt::DataFormat interm0_data_format = packer_l1_acc_en
+                                             ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)
+                                             : (fp32_dest_acc_en ? tt::DataFormat::Float32 : output_data_format);
+
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    uint32_t bias_single_tile_size = bias_tile.get_tile_size(bias_data_format);
+    uint32_t output_single_tile_size = output_tile.get_tile_size(output_data_format);
+    uint32_t interm0_single_tile_size = output_tile.get_tile_size(interm0_data_format);
+
+    const bool in0_block_sharded = in0_memory_layout == TensorMemoryLayout::BLOCK_SHARDED;
+    const bool in0_height_sharded = in0_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED;
+    const bool in0_is_sharded = in0_block_sharded || in0_height_sharded;
+    const bool in1_is_width_sharded = in1_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
+    const bool in1_is_height_sharded = in1_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
+    const bool in1_is_sharded = in1_is_width_sharded || in1_is_height_sharded;
+    const bool output_is_sharded = out_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
+
+    TT_FATAL(
+        !(output_is_sharded && B > 1),
+        "Block-sharded output is incompatible with batch > 1 (B={}). The output CB is backed by the shard buffer "
+        "which only holds per_core_M * per_core_N = {} tiles, but the kernel would produce B * per_core_M * per_core_N "
+        "= {} tiles without draining. Use fuse_batch=True.",
+        B,
+        per_core_M * per_core_N,
+        B * per_core_M * per_core_N);
+    bool do_not_inplace_interm0_out_CB = output_is_sharded && (per_core_M != out_block_h);
+
+    uint32_t in0_block_h = out_block_h;
+    uint32_t in1_block_w = out_block_w;
+    uint32_t in0_num_blocks_y = per_core_M / out_block_h;
+    uint32_t in1_num_blocks_x = per_core_N / out_block_w;
+    uint32_t out_num_blocks_x = in1_num_blocks_x;
+    uint32_t out_num_blocks_y = in0_num_blocks_y;
+
+    uint32_t in0_block_tiles = out_block_h * in0_block_w;
+    uint32_t in0_CB_tiles = in0_block_tiles;
+    if (B * num_blocks > 1) {
+        in0_CB_tiles *= operations::experimental::quasar::matmul::utilities::MCAST_INPUT_BUFFERING_DEPTH;
+    }
+    // Tiles whose size is not a multiple of the DRAM alignment (e.g. bfp8 32x16 = 544B on
+    // Blackhole's 64B alignment) are padded to it in DRAM. The interleaved reader copies tiles at
+    // the padded stride, so the in0/in1/bias CBs must hold pages at the aligned stride and the
+    // reader/unpacker walk tiles at the same stride. No-op when already aligned (all bf16 tiles,
+    // 32-wide bfp8, Wormhole). Replaces the staging-CB workaround. Sharded CBs are backed by the
+    // tensor buffer and keep their natural page size.
+    const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
+    uint32_t in0_aligned_tile_size =
+        in0_is_sharded ? in0_single_tile_size : tt::align(in0_single_tile_size, dram_alignment);
+    uint32_t in1_aligned_tile_size =
+        in1_is_sharded ? in1_single_tile_size : tt::align(in1_single_tile_size, dram_alignment);
+    uint32_t in0_CB_size = in0_CB_tiles * in0_aligned_tile_size;
+    uint32_t in1_block_tiles = out_block_w * in0_block_w;
+    uint32_t in1_CB_tiles = in1_block_tiles;
+    if (B * num_blocks > 1) {
+        in1_CB_tiles *= operations::experimental::quasar::matmul::utilities::MCAST_INPUT_BUFFERING_DEPTH;
+    }
+    uint32_t in1_CB_size = in1_CB_tiles * in1_aligned_tile_size;
+
+    uint32_t out_block_tiles = out_block_h * out_block_w;
+    uint32_t out_shard_tiles = per_core_M * per_core_N;
+    uint32_t out_CB_tiles = out_block_tiles;  // No double buffer
+    if (output_is_sharded) {
+        out_CB_tiles = out_shard_tiles;
+    }
+    uint32_t out_CB_size = out_CB_tiles * output_single_tile_size;
+    uint32_t interm0_CB_tiles = out_block_tiles;  // No double buffer
+    uint32_t interm0_CB_size = interm0_CB_tiles * interm0_single_tile_size;
+
+    uint32_t in2_block_tiles = 0;
+    uint32_t in0_shard_width_in_tiles = 0;
+    uint32_t in0_shard_height_in_tiles = 0;
+    if (in0_is_sharded) {
+        in0_shard_width_in_tiles = in0_tensor.shard_spec()->shape[1] / in0_tile.get_width();
+        in0_shard_height_in_tiles = in0_tensor.shard_spec()->shape[0] / in0_tile.get_height();
+        in2_block_tiles = per_core_M * in0_shard_width_in_tiles;
+    }
+
+    uint32_t in2_CB_tiles = in2_block_tiles;
+    uint32_t in2_CB_size = in2_CB_tiles * in0_single_tile_size;
+
+    uint32_t in3_block_tiles = out_block_w;
+    uint32_t in3_CB_tiles = in3_block_tiles;  // No double buffer
+    uint32_t in3_CB_size = in3_CB_tiles * bias_single_tile_size;
+
+    uint32_t start_core_x = sub_device_start_core.x;
+    uint32_t start_core_y = sub_device_start_core.y;
+
+    uint32_t num_blocks_y = ((M - 1) / per_core_M) + 1;
+    uint32_t num_blocks_x = ((N - 1) / per_core_N) + 1;
+    uint32_t num_cores_with_work_c = num_blocks_x;
+    uint32_t num_cores_with_work_r = num_blocks_y;
+    if (transpose_mcast) {
+        std::swap(num_cores_with_work_c, num_cores_with_work_r);
+    }
+
+    CoreRange all_cores_with_work(
+        {(std::size_t)start_core_x, (std::size_t)start_core_y},
+        {(std::size_t)start_core_x + num_cores_with_work_c - 1, (std::size_t)start_core_y + num_cores_with_work_r - 1});
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      IN0 SHARDED SENDER/RECEIVER
+    ////////////////////////////////////////////////////////////////////////////
+    uint32_t num_cores_c = num_cores_with_work_c;
+    uint32_t num_cores_r = num_cores_with_work_r;
+    uint32_t in0_mcast_receiver_grid_diff_coord_start;
+    uint32_t in0_mcast_receiver_grid_diff_coord_end;
+    std::vector<uint32_t> in0_mcast_noc_x;
+    std::vector<uint32_t> in0_mcast_noc_y;
+    uint32_t in0_sender_num_cores_along_width = 0;
+
+    // Only used for in0 block sharded
+    std::optional<CoreRange> in0_mcast_cores_without_work_and_not_in_receiver_grid;
+    if (in0_block_sharded) {
+        CoreCoord in0_shard_grid = in0_tensor.shard_spec()->grid.bounding_box().grid_size();
+        // in0 shard grid already accounts for transpose_mcast
+        // ie. If transpose_mcast, in0 width is along y
+        in0_sender_num_cores_along_width = transpose_mcast ? in0_shard_grid.y : in0_shard_grid.x;
+        if (in0_sender_num_cores_along_width > num_blocks_x) {
+            in0_mcast_cores_without_work_and_not_in_receiver_grid =
+                transpose_mcast ? CoreRange(
+                                      {(std::size_t)start_core_x, (std::size_t)start_core_y + num_blocks_x},
+                                      {(std::size_t)start_core_x + num_blocks_y - 1,
+                                       (std::size_t)start_core_y + in0_sender_num_cores_along_width - 1})
+                                : CoreRange(
+                                      {(std::size_t)start_core_x + num_blocks_x, (std::size_t)start_core_y},
+                                      {(std::size_t)start_core_x + in0_sender_num_cores_along_width - 1,
+                                       (std::size_t)start_core_y + num_blocks_y - 1});
+        }
+
+        if (transpose_mcast) {
+            in0_mcast_receiver_grid_diff_coord_start =
+                device->worker_core_from_logical_core({start_core_x, start_core_y}).y;
+            in0_mcast_receiver_grid_diff_coord_end =
+                device->worker_core_from_logical_core({start_core_x, start_core_y + num_blocks_x - 1}).y;
+            in0_mcast_noc_y.reserve(in0_sender_num_cores_along_width);
+            for (uint32_t core_idx_y = 0; core_idx_y < in0_sender_num_cores_along_width; ++core_idx_y) {
+                in0_mcast_noc_y.push_back(
+                    device->worker_core_from_logical_core({start_core_x, start_core_y + core_idx_y}).y);
+            }
+        } else {
+            in0_mcast_receiver_grid_diff_coord_start =
+                device->worker_core_from_logical_core({start_core_x, start_core_y}).x;
+            in0_mcast_receiver_grid_diff_coord_end =
+                device->worker_core_from_logical_core({start_core_x + num_blocks_x - 1, start_core_y}).x;
+            in0_mcast_noc_x.reserve(in0_sender_num_cores_along_width);
+            for (uint32_t core_idx_x = 0; core_idx_x < in0_sender_num_cores_along_width; ++core_idx_x) {
+                in0_mcast_noc_x.push_back(
+                    device->worker_core_from_logical_core({start_core_x + core_idx_x, start_core_y}).x);
+            }
+        }
+
+        // Set in0 sender/receiver cores to be maximum
+        if (transpose_mcast) {
+            num_cores_r = std::max(num_cores_r, in0_sender_num_cores_along_width);
+        } else {
+            num_cores_c = std::max(num_cores_c, in0_sender_num_cores_along_width);
+        }
+    }
+
+    // Used for setting up CBs and semaphores by both in0 interleaved or sharded
+    CoreRange all_cores(
+        {(std::size_t)start_core_x, (std::size_t)start_core_y},
+        {(std::size_t)start_core_x + num_cores_c - 1, (std::size_t)start_core_y + num_cores_r - 1});
+    const auto& cores = grid_to_cores(all_cores.start_coord, all_cores.end_coord, true);
+    //////////////////////////////////////////////////////////////////////////////////////////
+    //       IN0 SENDER (interleaved only) and IN1 SENDER (both interleaved and sharded)
+    //////////////////////////////////////////////////////////////////////////////////////////
+    // Left column
+    CoreRange in0_sender_interleaved(
+        {(std::size_t)start_core_x, (std::size_t)start_core_y},
+        {(std::size_t)start_core_x, (std::size_t)start_core_y + num_cores_with_work_r - 1});
+
+    // Top row
+    CoreRange in1_sender(
+        {(std::size_t)start_core_x, (std::size_t)start_core_y},
+        {(std::size_t)start_core_x + num_cores_with_work_c - 1, (std::size_t)start_core_y});
+
+    // Left column except corner
+    std::optional<CoreRange> in0_sender_in1_receiver;
+    if (num_cores_with_work_r > 1) {
+        in0_sender_in1_receiver = {
+            {(std::size_t)start_core_x, (std::size_t)start_core_y + 1},
+            {(std::size_t)start_core_x, (std::size_t)start_core_y + num_cores_with_work_r - 1}};
+    }
+
+    // Top row except corner
+    std::optional<CoreRange> in0_receiver_in1_sender;
+    if (num_cores_with_work_c > 1) {
+        in0_receiver_in1_sender = {
+            {(std::size_t)start_core_x + 1, (std::size_t)start_core_y},
+            {(std::size_t)start_core_x + num_cores_with_work_c - 1, (std::size_t)start_core_y}};
+    }
+
+    if (transpose_mcast) {
+        std::swap(in0_sender_interleaved, in1_sender);
+        std::swap(in0_sender_in1_receiver, in0_receiver_in1_sender);
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////////////////
+    //       IN0 RECEIVER (interleaved only) and IN1 RECEIVER (both interleaved and sharded)
+    /////////////////////////////////////////////////////////////////////////////////////////////////
+    // Not exactly half-half; this seems to get slightly better perf for fused qkv and selfout
+    // TODO: Experiment with different splits?
+    bool split_half = num_cores_with_work_c > 2 && num_cores_with_work_r > 1 && !in0_is_sharded;
+    uint32_t half_core = split_half ? (num_cores_with_work_c) / 2 : num_cores_with_work_c - 1;
+
+    std::optional<CoreRange> in0_receiver_in1_receiver_left_half;
+    if (num_cores_with_work_c > 1 and num_cores_with_work_r > 1) {
+        in0_receiver_in1_receiver_left_half = {
+            {(std::size_t)start_core_x + 1, (std::size_t)start_core_y + 1},
+            {(std::size_t)start_core_x + half_core, (std::size_t)start_core_y + num_cores_with_work_r - 1}};
+    }
+
+    std::set<CoreRange> in0_receiver_interleaved_set;
+    std::set<CoreRange> in1_receiver_set;
+    if (in0_receiver_in1_sender.has_value()) {
+        in0_receiver_interleaved_set.insert(in0_receiver_in1_sender.value());
+    }
+    if (in0_sender_in1_receiver.has_value()) {
+        in1_receiver_set.insert(in0_sender_in1_receiver.value());
+    }
+    if (in0_receiver_in1_receiver_left_half.has_value()) {
+        in0_receiver_interleaved_set.insert(in0_receiver_in1_receiver_left_half.value());
+        in1_receiver_set.insert(in0_receiver_in1_receiver_left_half.value());
+    }
+    CoreRangeSet in0_receiver_interleaved(in0_receiver_interleaved_set);
+    CoreRangeSet in1_receiver(in1_receiver_set);
+
+    std::optional<CoreRange> in0_receiver_in1_receiver_interleaved_other_cores;
+    if (split_half) {
+        in0_receiver_in1_receiver_interleaved_other_cores = {
+            {(std::size_t)start_core_x + half_core + 1, (std::size_t)start_core_y + 1},
+            {(std::size_t)start_core_x + num_cores_with_work_c - 1,
+             (std::size_t)start_core_y + num_cores_with_work_r - 1}};
+    }
+
+    // Mcast args
+    auto in0_mcast_sender_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto in0_mcast_receiver_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto in1_mcast_sender_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto in1_mcast_receiver_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+
+    bool in1_is_dram = in1_tensor.mesh_buffer().device_local_config().buffer_type == tt_metal::BufferType::DRAM;
+
+    uint32_t in0_num_subblocks = (out_block_h / out_subblock_h);
+    uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
+
+    TT_FATAL(
+        out_block_h % out_subblock_h == 0 and out_block_h >= out_subblock_h,
+        "out_block_h must be multiple of out_subblock_h");
+    TT_FATAL(
+        out_block_w % out_subblock_w == 0 and out_block_w >= out_subblock_w,
+        "out_block_w must be multiple of out_subblock_w");
+
+    std::vector<uint32_t> in0_sender_compile_time_args;
+
+    uint32_t num_dram_banks = 0;
+    uint32_t per_core_N_storage = 0;
+    uint32_t batches_per_bank = 0;
+    if (in1_is_sharded and in1_is_dram) {
+        num_dram_banks = device->num_dram_channels();
+        if (in1_is_width_sharded) {
+            per_core_N_storage = (N + num_dram_banks - 1) / num_dram_banks;
+        } else {
+            // Height sharded: batches are distributed across DRAM banks
+            uint32_t in1_shard_height_in_tiles = in1_tensor.shard_spec()->shape[0] / in1_tile.get_height();
+            batches_per_bank = in1_shard_height_in_tiles / K;
+        }
+    }
+
+    const auto [in0_tensor_stride_w, in0_tensor_stride_h] =
+        operations::experimental::quasar::matmul::utilities::get_in0_transpose_strides(M, M_per_batch, transpose_a, K);
+    const auto in0_tensor_next_block_stride = in0_block_w * in0_tensor_stride_w;
+    const auto in0_tensor_next_h_dim_block_stride = in0_block_h * in0_tensor_stride_h;
+    const auto in0_tensor_start_tile_id_stride = per_core_M * in0_tensor_stride_h;
+
+    const auto in1_tensor_stride_w = transpose_b ? K : 1;
+    const auto in1_tensor_stride_h = transpose_b ? 1 : N;
+    const auto in1_tensor_next_block_stride = in0_block_w * in1_tensor_stride_h;
+    const auto in1_tensor_next_w_dim_block_stride = in1_block_w * in1_tensor_stride_w;
+    const auto in1_tensor_start_tile_id_stride = per_core_N * in1_tensor_stride_w;
+
+    if (in0_block_sharded) {
+        uint32_t num_x = in0_sender_num_cores_along_width;
+        uint32_t num_y = 1;
+        if (transpose_mcast) {
+            std::swap(num_x, num_y);
+        }
+
+        in0_sender_compile_time_args = {
+            (std::uint32_t)1,  // core_has_output_block_work
+            (std::uint32_t)1,  // core_in_in0_receiver_mcast_grid
+
+            (std::uint32_t)in0_block_num_tiles,                         // in0_block_num_tiles
+            (std::uint32_t)in0_block_num_tiles * in0_single_tile_size,  // in0_block_size_bytes
+            (std::uint32_t)in0_last_ktile_w,
+            (std::uint32_t)in0_last_ktile_h,
+
+            // in0/in1 common args
+            (std::uint32_t)num_blocks,  // num_blocks
+            (std::uint32_t)out_num_blocks_x,
+            (std::uint32_t)out_num_blocks_y,
+            // in0 mcast args
+            (std::uint32_t)in0_mcast_sender_semaphore_id,
+            (std::uint32_t)in0_mcast_receiver_semaphore_id,
+            (std::uint32_t)num_blocks_x,  // in0_mcast_num_dests
+            (std::uint32_t)num_blocks_x,  // in0_mcast_num_cores
+            (std::uint32_t)num_x,
+            (std::uint32_t)num_y,
+            (std::uint32_t)transpose_mcast,
+            (std::uint32_t)in0_shard_width_in_tiles,
+            (std::uint32_t)in0_shard_height_in_tiles,
+            (std::uint32_t)in0_block_w,
+            (std::uint32_t)in0_block_h,
+            // batch args
+            (std::uint32_t)B  // batch
+        };
+    } else {
+        in0_sender_compile_time_args = {
+            // in0 tensor args
+            (std::uint32_t)in0_tensor_stride_w,
+            (std::uint32_t)in0_tensor_stride_h,
+            (std::uint32_t)in0_tensor_next_block_stride,
+            (std::uint32_t)in0_tensor_next_h_dim_block_stride,
+            // in0 block args
+            (std::uint32_t)in0_block_w,          // in0_block_w
+            (std::uint32_t)in0_block_h,          // in0_block_h
+            (std::uint32_t)in0_block_num_tiles,  // in0_block_num_tiles
+            (std::uint32_t)in0_last_ktile_w,
+            (std::uint32_t)in0_last_ktile_h,
+
+            (std::uint32_t)false,                      // extract_shard_sub_blocks (not used for interleaved)
+            (std::uint32_t)in0_shard_width_in_tiles,   // shard_width_in_tiles (not used for interleaved)
+            (std::uint32_t)in0_shard_height_in_tiles,  // shard_height_in_tiles (not used for interleaved)
+            // in0/in1 common args
+            (std::uint32_t)num_blocks,  // num_blocks
+            (std::uint32_t)out_num_blocks_x,
+            (std::uint32_t)out_num_blocks_y,
+            // in0 mcast args
+            (std::uint32_t)in0_mcast_sender_semaphore_id,
+            (std::uint32_t)in0_mcast_receiver_semaphore_id,
+            (std::uint32_t)(num_blocks_x - 1),  // in0_mcast_num_dests
+            (std::uint32_t)(num_blocks_x - 1),  // in0_mcast_num_cores
+            // batch args
+            (std::uint32_t)M * K,  // MtKt
+            (std::uint32_t)B,      // batch
+            (std::uint32_t)B,      // batch
+            (std::uint32_t)false,  // reuse_in0_in_CB
+
+            // sparsity args
+            (std::uint32_t)0,      // batchB
+            (std::uint32_t)0,      // sparsity_pagesize (placeholder since sparsity not used in this case)
+            (std::uint32_t)true,   // bcast_A
+            (std::uint32_t)false,  // get_batch_from_reader
+        };
+    }
+    in0_sender_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));
+    tt::tt_metal::TensorAccessorArgs(in0_tensor).append_to(in0_sender_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs().append_to(in0_sender_compile_time_args);  // placeholder for sparsity
+    in0_sender_compile_time_args.push_back((std::uint32_t)0);  // num_batch_compute (unused, sparsity disabled)
+
+    std::vector<uint32_t> in1_sender_writer_compile_time_args = {
+        // READER
+        // in1 tensor args
+        (std::uint32_t)in1_tensor_stride_w,
+        (std::uint32_t)in1_tensor_stride_h,
+        (std::uint32_t)in1_tensor_next_block_stride,
+        (std::uint32_t)in1_tensor_next_w_dim_block_stride,
+        // in1 block args
+        (std::uint32_t)in1_block_w,                // in1_block_w
+        (std::uint32_t)in0_block_w,                // in1_block_h
+        (std::uint32_t)in1_block_w * in0_block_w,  // in1_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,  // num_blocks
+        (std::uint32_t)out_num_blocks_x,
+        (std::uint32_t)out_num_blocks_y,
+        // in1 mcast args
+        (std::uint32_t)in1_mcast_sender_semaphore_id,
+        (std::uint32_t)in1_mcast_receiver_semaphore_id,
+        (std::uint32_t)(num_blocks_y - 1),  // in1_mcast_num_dests
+        (std::uint32_t)(num_blocks_y - 1),  // in1_mcast_num_cores
+        // batch args
+        (std::uint32_t)K * N,        // KtNt
+        (std::uint32_t)B,            // batch
+        (std::uint32_t)bcast_batch,  // bcast_B
+        // sparsity args
+        (std::uint32_t)0,  // batchB
+        (std::uint32_t)0,  // sparsity_pagesize (placeholder since sparsity not used in this case)
+
+        // WRITER
+        // out tensor args
+        (std::uint32_t)1,                   // out_tensor_stride_w
+        (std::uint32_t)N,                   // out_tensor_stride_h
+        (std::uint32_t)out_subblock_w,      // out_tensor_next_subblock_stride_w
+        (std::uint32_t)out_subblock_h * N,  // out_tensor_next_subblock_stride_h
+        (std::uint32_t)out_block_w,         // out_tensor_next_w_dim_block_stride
+        (std::uint32_t)out_block_h * N,     // out_tensor_next_h_dim_block_stride
+        // out subblock args
+        (std::uint32_t)out_subblock_w,                     // out_subblock_w
+        (std::uint32_t)out_subblock_h,                     // out_subblock_h
+        (std::uint32_t)(out_subblock_w * out_subblock_h),  // out_subblocks_w * out_subblocks_h
+        // batch args
+        (std::uint32_t)M * N  // MtNt
+    };
+    if (bias_mesh.has_value()) {
+        in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);  // in3_tensor_stride_w
+    } else {
+        in1_sender_writer_compile_time_args.push_back(0);  // Placeholder; not used
+    }
+
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_reduce_scatter()));
+
+    // Append TensorAccessorArgs
+    tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs().append_to(in1_sender_writer_compile_time_args);  // placeholder for sparsity
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_sender_writer_compile_time_args);
+    if (bias_mesh.has_value()) {
+        tt::tt_metal::TensorAccessorArgs(*bias_mesh).append_to(in1_sender_writer_compile_time_args);
+    }
+
+    if (in1_is_sharded and in1_is_dram) {
+        if (in1_is_width_sharded) {
+            in1_sender_writer_compile_time_args.push_back((std::uint32_t)per_core_N_storage * in0_block_w);
+            in1_sender_writer_compile_time_args.push_back((std::uint32_t)per_core_N_storage * in1_single_tile_size);
+        } else {
+            // Height sharded: pass tiles per batch and batches per bank
+            in1_sender_writer_compile_time_args.push_back((std::uint32_t)(K * N));  // KtNt per batch (tiles)
+            in1_sender_writer_compile_time_args.push_back((std::uint32_t)batches_per_bank);
+        }
+    }
+    std::vector<uint32_t> in0_receiver_compile_time_args = {
+        // in0 block args
+        (std::uint32_t)in0_block_w * in0_block_h,  // in0_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,  // num_blocks
+        (std::uint32_t)out_num_blocks_x,
+        (std::uint32_t)out_num_blocks_y,
+        // in0 mcast args
+        (std::uint32_t)in0_mcast_sender_semaphore_id,
+        (std::uint32_t)in0_mcast_receiver_semaphore_id,
+        // batch args
+        (std::uint32_t)B,     // batch
+        (std::uint32_t)false  // get_batch_from_reader
+    };
+    std::vector<uint32_t> in1_receiver_writer_compile_time_args = {
+        // READER
+        // in1 block args
+        (std::uint32_t)in1_block_w * in0_block_w,  // in1_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,  // num_blocks
+        (std::uint32_t)out_num_blocks_x,
+        (std::uint32_t)out_num_blocks_y,
+        // in1 mcast args
+        (std::uint32_t)in1_mcast_sender_semaphore_id,
+        (std::uint32_t)in1_mcast_receiver_semaphore_id,
+        // batch args
+        (std::uint32_t)B,  // batch
+
+        // WRITER
+        // out tensor args
+        (std::uint32_t)1,                   // out_tensor_stride_w
+        (std::uint32_t)N,                   // out_tensor_stride_h
+        (std::uint32_t)out_subblock_w,      // out_tensor_next_subblock_stride_w
+        (std::uint32_t)out_subblock_h * N,  // out_tensor_next_subblock_stride_h
+        (std::uint32_t)out_block_w,         // out_tensor_next_w_dim_block_stride
+        (std::uint32_t)out_block_h * N,     // out_tensor_next_h_dim_block_stride
+        // out subblock args
+        (std::uint32_t)out_subblock_w,                     // out_subblock_w
+        (std::uint32_t)out_subblock_h,                     // out_subblock_h
+        (std::uint32_t)(out_subblock_w * out_subblock_h),  // out_subblocks_w * out_subblocks_h
+        // batch args
+        (std::uint32_t)M * N  // MtNt
+    };
+    if (bias_mesh.has_value()) {
+        in1_receiver_writer_compile_time_args.push_back((std::uint32_t)in1_block_w);
+    } else {
+        in1_receiver_writer_compile_time_args.push_back(0);  // Placeholder; not used
+    }
+    in1_receiver_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_reduce_scatter()));
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_receiver_writer_compile_time_args);
+
+    std::map<std::string, std::string> mm_kernel_defines;
+    std::map<std::string, std::string> mm_kernel_in0_sender_sharded_defines;
+    std::map<std::string, std::string> mm_kernel_in0_sender_interleaved_defines;
+    std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
+    std::map<std::string, std::string> mm_kernel_in1_receiver_writer_defines;
+    std::map<std::string, std::string> mm_kernel_in1_receiver_writer_other_noc_setup_defines;
+    if (bias_mesh.has_value()) {
+        mm_kernel_defines["FUSE_BIAS"] = "1";
+        mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
+        mm_kernel_in1_receiver_writer_defines["FUSE_BIAS"] = "1";
+        mm_kernel_in1_receiver_writer_other_noc_setup_defines["FUSE_BIAS"] = "1";
+    }
+    if (fused_activation.has_value()) {
+        if (fused_activation.value().op_type == UnaryOpType::RELU) {
+            mm_kernel_defines["PACK_RELU"] = "1";
+        } else {
+            mm_kernel_defines["SFPU_ACTIVATION"] = "1";
+        }
+    }
+    if (packer_l1_acc_en) {
+        mm_kernel_defines["PACKER_L1_ACC"] = "1";
+    }
+    if (fp32_dest_acc_en) {
+        mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    if (in1_transpose_tile) {
+        mm_kernel_defines["IN1_TRANSPOSE_TILE"] = "1";
+    }
+
+    ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
+        device->arch(), cores.size(), mm_kernel_defines);
+    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
+        device->arch(), cores.size(), mm_kernel_defines, throttle_level);
+
+    if (in0_receiver_interleaved.num_cores() == 0) {
+        mm_kernel_in0_sender_interleaved_defines["SKIP_MCAST"] = "1";
+    }
+    if (in0_height_sharded) {
+        mm_kernel_in0_sender_interleaved_defines["IN0_SHARDED"] = "1";
+    }
+
+    if (in1_receiver.num_cores() == 0) {
+        mm_kernel_in1_sender_writer_defines["SKIP_MCAST"] = "1";
+    }
+    if (in1_is_sharded) {
+        if (in1_is_dram) {
+            if (in1_is_width_sharded) {
+                mm_kernel_in1_sender_writer_defines["IN1_DRAM_WIDTH_SHARDED"] = "1";
+            } else {
+                mm_kernel_in1_sender_writer_defines["IN1_DRAM_HEIGHT_SHARDED"] = "1";
+            }
+        } else {
+            mm_kernel_in1_sender_writer_defines["IN1_SHARDED"] = "1";
+        }
+    }
+
+    if (output_is_sharded) {
+        mm_kernel_in1_sender_writer_defines["OUT_SHARDED"] = "1";
+        mm_kernel_in1_receiver_writer_defines["OUT_SHARDED"] = "1";
+        mm_kernel_in1_receiver_writer_other_noc_setup_defines["OUT_SHARDED"] = "1";
+    }
+
+    // Intermediate CB read
+    /*
+    Blackhole architecture alignment issue workaround for tiny tiles:
+
+    Problem: When reading tiny tiles from DRAM to circular buffers (CB), address alignment
+    issues occur. DRAM tile addresses are 64-byte aligned within each block, but L1 CB
+    addresses are not necessarily aligned due to non-64-byte-aligned page sizes.
+
+    Example scenario:
+    - Two consecutive 544-byte tiles (16x32 tile of dtype bfloat8_b) stored on different DRAM banks
+    - CB configured with size=2 to hold both tiles
+
+    Result:
+    - Tile 0: DRAM Bank 0, Address 64    → CB L1 Address 0   (64-byte aligned ✓)
+    - Tile 1: DRAM Bank 1, Address 64    → CB L1 Address 544 (not 64-byte aligned ✗)
+
+    Solution: Use an intermediate single-tile CB as a staging area. Read each tile into
+    the intermediate CB first, then copy to the destination CB. This ensures proper
+    alignment at the cost of additional memory bandwidth overhead.
+
+    Note: This workaround should only be used for this specific alignment issue case.
+    */
+
+    // in1 is the reader of weights/output writer, and we choose to make it use the optimized reader noc
+    tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+    tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+    tt_metal::NOC in0_split_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+    tt_metal::NOC in1_split_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+
+    tt::tt_metal::KernelHandle mm_kernel_in0_sender_id = 0;
+    tt::tt_metal::KernelHandle mm_kernel_in0_mcast_cores_without_work_and_not_in_receiver_grid_id = 0;
+    if (in0_block_sharded) {
+        mm_kernel_in0_sender_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+            "reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp",
+            all_cores_with_work,  // in0_mcast_cores_with_work_and_in_receiver_grid
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = in0_noc,
+                .compile_args = in0_sender_compile_time_args,
+                .defines = mm_kernel_in0_sender_sharded_defines,
+                .named_compile_args = {
+                    {"cb_in0", tt::CBIndex::c_0},
+                    {"cb_in0_sharded", tt::CBIndex::c_2},
+                    {"cb_l1_array", tt::CBIndex::c_6},
+                }});
+        if (in0_mcast_cores_without_work_and_not_in_receiver_grid.has_value()) {
+            in0_sender_compile_time_args[0] = 0;  // core_has_output_block_work
+            in0_sender_compile_time_args[1] = 0;  // core_in_in0_receiver_mcast_grid
+            mm_kernel_in0_mcast_cores_without_work_and_not_in_receiver_grid_id = tt_metal::CreateKernel(
+                program,
+                "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+                "reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp",
+                in0_mcast_cores_without_work_and_not_in_receiver_grid.value(),
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                    .noc = in0_noc,
+                    .compile_args = in0_sender_compile_time_args,
+                    .defines = mm_kernel_in0_sender_sharded_defines,
+                    .named_compile_args = {
+                        {"cb_in0", tt::CBIndex::c_0},
+                        {"cb_in0_sharded", tt::CBIndex::c_2},
+                        {"cb_l1_array", tt::CBIndex::c_6},
+                    }});
+        }
+    } else {
+        if (fuse_op) {
+            if (fused_op_signaler->is_all_gather()) {
+                // Create semaphores
+                fused_op_signaler->init_fused_op(program, device, in0_sender_interleaved);
+            } else if (fused_op_signaler->is_reduce_scatter()) {
+                fused_op_signaler->init_fused_op(program, device, all_cores, cores);
+            } else {
+                TT_FATAL(false, "Fused operation must be either all_gather or reduce_scatter.");
+            }
+        }
+
+        mm_kernel_in0_sender_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+            "reader_bmm_tile_layout_in0_sender_padding.cpp",
+            in0_sender_interleaved,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = in0_noc,
+                .compile_args = in0_sender_compile_time_args,
+                .defines = mm_kernel_in0_sender_interleaved_defines,
+                .named_compile_args = {
+                    {"cb_in0", tt::CBIndex::c_0},
+                    {"cb_in0_sharded", tt::CBIndex::c_2},
+                    {"cb_sparsity", tt::CBIndex::c_6},
+                }});
+    }
+
+    auto mm_kernel_in1_sender_writer_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+        "reader_bmm_tile_layout_in1_sender_writer_padding.cpp",
+        in1_sender,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = in1_noc,
+            .compile_args = in1_sender_writer_compile_time_args,
+            .defines = mm_kernel_in1_sender_writer_defines,
+            .named_compile_args = {
+                {"cb_in1", tt::CBIndex::c_1},
+                {"cb_bias", tt::CBIndex::c_3},
+                {"cb_out", tt::CBIndex::c_4},
+                {"cb_sparsity", tt::CBIndex::c_7},
+            }});
+
+    tt::tt_metal::KernelHandle mm_kernel_in1_receiver_writer_id = 0;
+    if (in1_receiver.num_cores() > 0) {
+        mm_kernel_in1_receiver_writer_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+            "reader_bmm_tile_layout_in1_receiver_writer_padding.cpp",
+            /* in0_sender_in1_receiver, // If not using half-half noc setup */
+            in1_receiver,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = in1_noc,
+                .compile_args = in1_receiver_writer_compile_time_args,
+                .defines = mm_kernel_in1_receiver_writer_defines,
+                .named_compile_args = {
+                    {"cb_in1", tt::CBIndex::c_1},
+                    {"cb_bias", tt::CBIndex::c_3},
+                    {"cb_out", tt::CBIndex::c_4},
+                }});
+    }
+
+    tt::tt_metal::KernelHandle mm_kernel_in0_receiver_id = 0;
+    if (!in0_block_sharded and in0_receiver_interleaved.num_cores() > 0) {
+        mm_kernel_in0_receiver_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+            "reader_bmm_tile_layout_in0_receiver.cpp",
+            /* in0_receiver_in1_sender, // If not using half-half noc setup */
+            in0_receiver_interleaved,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = in0_noc,
+                .compile_args = in0_receiver_compile_time_args,
+                .named_compile_args = {
+                    {"cb_in0", tt::CBIndex::c_0},
+                }});
+    }
+
+    tt::tt_metal::KernelHandle mm_kernel_in1_receiver_writer_other_noc_setup_id = mm_kernel_in1_receiver_writer_id;
+    tt::tt_metal::KernelHandle mm_kernel_in0_receiver_other_noc_setup_id = mm_kernel_in0_receiver_id;
+
+    if (in0_receiver_in1_receiver_interleaved_other_cores.has_value()) {
+        mm_kernel_in1_receiver_writer_other_noc_setup_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+            "reader_bmm_tile_layout_in1_receiver_writer_padding.cpp",
+            in0_receiver_in1_receiver_interleaved_other_cores.value(),
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = in1_split_noc,
+                .compile_args = in1_receiver_writer_compile_time_args,
+                .defines = mm_kernel_in1_receiver_writer_other_noc_setup_defines,
+                .named_compile_args = {
+                    {"cb_in1", tt::CBIndex::c_1},
+                    {"cb_bias", tt::CBIndex::c_3},
+                    {"cb_out", tt::CBIndex::c_4},
+                }});
+
+        mm_kernel_in0_receiver_other_noc_setup_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+            "reader_bmm_tile_layout_in0_receiver.cpp",
+            in0_receiver_in1_receiver_interleaved_other_cores.value(),
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = in0_split_noc,
+                .compile_args = in0_receiver_compile_time_args,
+                .named_compile_args = {
+                    {"cb_in0", tt::CBIndex::c_0},
+                }});
+    }
+
+    // Compute kernel compile time args
+
+    uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
+
+    uint32_t in1_num_subblocks = (out_block_w / out_subblock_w);
+    uint32_t in1_block_num_tiles = out_subblock_w * in0_block_w * in1_num_subblocks;
+    uint32_t in1_per_core_w = out_subblock_w * in1_num_subblocks;
+
+    uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
+
+    std::vector<uint32_t> compute_kernel_args = {
+        in0_block_w,             // in0_block_w
+        in0_num_subblocks,       // in0_num_subblocks
+        in0_block_num_tiles,     // in0_block_num_tiles
+        in0_subblock_num_tiles,  // in0_subblock_num_tiles
+
+        in1_num_subblocks,    // in1_num_subblocks
+        in1_block_num_tiles,  // in1_block_num_tiles
+        in1_per_core_w,       // in1_per_core_w
+
+        num_blocks,  // num_blocks
+        out_num_blocks_x,
+        out_num_blocks_y,
+
+        out_subblock_h,          // out_subblock_h
+        out_subblock_w,          // out_subblock_w
+        out_subblock_num_tiles,  // out_subblock_num_tiles
+        B,                       // batch,
+        out_block_tiles,         // out_block_num_tiles
+
+        untilize_out,  // untilize_out
+        false,         // get_batch_from_reader
+        in0_transpose_tile,
+    };
+    if (bias_mesh.has_value()) {
+        compute_kernel_args.push_back(row_broadcast_bias ? 1u : 0u);
+    }
+
+    std::unordered_map<std::string, uint32_t> compute_named_compile_args = {
+        {"cb_in0", tt::CBIndex::c_0},
+        {"cb_in1", tt::CBIndex::c_1},
+        {"cb_bias", tt::CBIndex::c_3},
+        {"cb_out", tt::CBIndex::c_4},
+        {"cb_intermed0", tt::CBIndex::c_5},
+        {"cb_in0_transposed", tt::CBIndex::c_10},
+        {"bias_ntiles", in1_per_core_w},
+    };
+
+    if (fused_activation.has_value() && fused_activation.value().op_type != UnaryOpType::RELU) {
+        using ttnn::operations::experimental::quasar::matmul::utilities::get_activation_params;
+        const auto& activation = fused_activation.value();
+        const auto params = get_activation_params(activation);
+        compute_named_compile_args["activation_type"] = static_cast<uint32_t>(params.type);
+        compute_named_compile_args["activation_param0"] = params.param0;
+        compute_named_compile_args["activation_param1"] = params.param1;
+        compute_named_compile_args["activation_param2"] = params.param2;
+    }
+
+    // Create compute kernel
+    // bool fp32_dest_acc_en = true;
+    // Gelu currently has better accuracy when run in approx mode
+    // bool math_approx_mode = false;
+    tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/"
+        "bmm_large_block_zm_fused_bias_activation.cpp",
+        all_cores_with_work,
+        tt_metal::ComputeConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .math_approx_mode = math_approx_mode,
+            .compile_args = compute_kernel_args,
+            .defines = mm_kernel_defines,
+            .named_compile_args = compute_named_compile_args});
+
+    // Create circular buffers
+    uint32_t src0_cb_index = tt::CBIndex::c_0;
+    tt_metal::CircularBufferConfig src0_cb_config =
+        tt_metal::CircularBufferConfig(in0_CB_size, {{src0_cb_index, in0_data_format}})
+            .set_page_size(src0_cb_index, in0_aligned_tile_size)
+            .set_tile_dims(src0_cb_index, in0_tile);
+    if (in0_height_sharded) {
+        src0_cb_config.set_globally_allocated_address(in0_tensor);
+    }
+    tt_metal::CreateCircularBuffer(program, all_cores, src0_cb_config);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        src0_cb_index,
+        in0_single_tile_size,
+        in0_CB_size / in0_single_tile_size,
+        in0_CB_size);
+
+    uint32_t src1_cb_index = tt::CBIndex::c_1;
+    tt_metal::CircularBufferConfig src1_cb_config =
+        tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_data_format}})
+            .set_page_size(src1_cb_index, in1_aligned_tile_size)
+            .set_tile_dims(src1_cb_index, in1_tile);
+    if (in1_is_sharded and not in1_is_dram) {
+        src1_cb_config.set_globally_allocated_address(in1_tensor);
+    }
+    tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        src1_cb_index,
+        in1_single_tile_size,
+        in1_CB_size / in1_single_tile_size,
+        in1_CB_size);
+
+    uint32_t src2_cb_index = tt::CBIndex::c_2;
+    tt::tt_metal::CBHandle cb_src2 = 0;
+    if (in0_block_sharded) {
+        tt_metal::CircularBufferConfig src2_cb_config =
+            tt_metal::CircularBufferConfig(in2_CB_size, {{src2_cb_index, in0_data_format}})
+                .set_page_size(src2_cb_index, in0_single_tile_size)
+                .set_globally_allocated_address(in0_tensor)
+                .set_tile_dims(src2_cb_index, in0_tile);
+        cb_src2 = tt_metal::CreateCircularBuffer(program, all_cores, src2_cb_config);
+        log_debug(
+            LogOp,
+            "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+            src2_cb_index,
+            in0_single_tile_size,
+            in2_CB_size / in0_single_tile_size,
+            in2_CB_size);
+
+        // Local L1 to store temp vars
+        uint32_t l1_cb_index = tt::CBIndex::c_6;
+        tt::tt_metal::CircularBufferConfig cb_for_l1_array_config =
+            tt::tt_metal::CircularBufferConfig(32 * 2, {{l1_cb_index, tt::DataFormat::Float16_b}})
+                .set_page_size(l1_cb_index, 32 * 2);
+        tt_metal::CreateCircularBuffer(program, all_cores, cb_for_l1_array_config);
+    }
+
+    uint32_t output_cb_index = tt::CBIndex::c_4;
+    uint32_t interm0_cb_index = tt::CBIndex::c_5;
+    tt_metal::CircularBufferConfig interm0_cb_config =
+        tt_metal::CircularBufferConfig(0, {{interm0_cb_index, interm0_data_format}});
+    tt_metal::CircularBufferConfig output_cb_config =
+        tt_metal::CircularBufferConfig(0, {{output_cb_index, output_data_format}});
+
+    if (do_not_inplace_interm0_out_CB || (interm0_data_format != output_data_format) ||
+        (untilize_out && (in1_num_subblocks > 1))) {
+        // output
+        std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
+            {output_cb_index, output_data_format},
+        };
+        output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
+                               .set_page_size(output_cb_index, output_single_tile_size)
+                               .set_tile_dims(output_cb_index, output_tile);
+        // interm0
+        std::map<uint8_t, tt::DataFormat> interm0_cb_data_format_spec{
+            {interm0_cb_index, interm0_data_format},
+        };
+        interm0_cb_config = tt_metal::CircularBufferConfig(interm0_CB_size, interm0_cb_data_format_spec)
+                                .set_page_size(interm0_cb_index, interm0_single_tile_size)
+                                .set_tile_dims(interm0_cb_index, output_tile);
+
+        tt_metal::CreateCircularBuffer(program, CoreRangeSet({all_cores}), interm0_cb_config);
+        log_debug(
+            LogOp,
+            "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+            interm0_cb_index,
+            interm0_single_tile_size,
+            interm0_CB_size / interm0_single_tile_size,
+            interm0_CB_size);
+    } else {
+        // share buffer
+        std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
+            {output_cb_index, output_data_format}, {interm0_cb_index, interm0_data_format}};
+        output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
+                               .set_page_size(output_cb_index, output_single_tile_size)
+                               .set_page_size(interm0_cb_index, interm0_single_tile_size)
+                               .set_tile_dims(output_cb_index, output_tile)
+                               .set_tile_dims(interm0_cb_index, output_tile);
+    }
+
+    if (output_is_sharded) {
+        output_cb_config = output_cb_config.set_globally_allocated_address(out_tensor);
+    }
+    auto cb_output = tt_metal::CreateCircularBuffer(program, CoreRangeSet({all_cores}), output_cb_config);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        output_cb_index,
+        output_single_tile_size,
+        out_CB_size / output_single_tile_size,
+        out_CB_size);
+
+    // CB for bias
+    if (bias_mesh.has_value()) {
+        uint32_t src3_cb_index = tt::CBIndex::c_3;
+        tt_metal::CircularBufferConfig cb_src3_config =
+            tt_metal::CircularBufferConfig(in3_CB_size, {{src3_cb_index, bias_data_format}})
+                .set_page_size(src3_cb_index, bias_single_tile_size)
+                .set_tile_dims(src3_cb_index, bias_tile);
+        tt_metal::CreateCircularBuffer(program, all_cores, cb_src3_config);
+        log_debug(
+            LogOp,
+            "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+            src3_cb_index,
+            bias_single_tile_size,
+            in3_CB_size / bias_single_tile_size,
+            in3_CB_size);
+    }
+    // Intermediate CB read
+
+    if (in0_transpose_tile) {
+        uint32_t in0_transpose_cb_index = tt::CBIndex::c_10;
+        auto in0_transpose_cb_config =
+            tt_metal::CircularBufferConfig(in0_CB_size, {{in0_transpose_cb_index, in0_data_format}})
+                .set_page_size(in0_transpose_cb_index, in0_aligned_tile_size)
+                .set_tile_dims(in0_transpose_cb_index, in0_tile);
+        tt_metal::CreateCircularBuffer(program, all_cores, in0_transpose_cb_config);
+    }
+
+    // Parameters for last row, col, or block
+    uint32_t last_per_core_M = M % per_core_M == 0 ? per_core_M : M % per_core_M;
+    uint32_t last_per_core_N = N % per_core_N == 0 ? per_core_N : N % per_core_N;
+    uint32_t last_out_block_h = last_per_core_M % out_block_h == 0 ? out_block_h : last_per_core_M % out_block_h;
+    uint32_t last_out_block_w = last_per_core_N % out_block_w == 0 ? out_block_w : last_per_core_N % out_block_w;
+    uint32_t last_out_num_blocks_h = ((last_per_core_M - 1) / out_block_h) + 1;
+    uint32_t last_out_num_blocks_w = ((last_per_core_N - 1) / out_block_w) + 1;
+    uint32_t last_block_num_nonzero_subblocks_h = ((last_out_block_h - 1) / out_subblock_h) + 1;
+    uint32_t last_block_num_nonzero_subblocks_w = ((last_out_block_w - 1) / out_subblock_w) + 1;
+    uint32_t last_subblock_of_last_block_h =
+        last_out_block_h % out_subblock_h == 0 ? out_subblock_h : last_out_block_h % out_subblock_h;
+    uint32_t last_subblock_of_last_block_w =
+        last_out_block_w % out_subblock_w == 0 ? out_subblock_w : last_out_block_w % out_subblock_w;
+    uint32_t last_block_padded_subblock_tiles_addr_skip =
+        output_single_tile_size * (out_subblock_w - last_subblock_of_last_block_w);
+    uint32_t last_block_padded_block_tiles_w_skip =
+        (out_subblock_w * out_subblock_h) * (out_block_w / out_subblock_w - last_block_num_nonzero_subblocks_w);
+    uint32_t last_block_padded_block_tiles_h_skip =
+        (out_block_h / out_subblock_h - last_block_num_nonzero_subblocks_h) * (out_block_w * out_subblock_h);
+
+    if (in0_block_sharded) {
+        if (in0_noc == tt::tt_metal::NOC::NOC_1) {
+            std::swap(in0_mcast_receiver_grid_diff_coord_start, in0_mcast_receiver_grid_diff_coord_end);
+        }
+    }
+
+    // dram sharded weights stride params
+    uint32_t worker_core_stride = 0;   // stride in the worker core
+    uint32_t storage_core_stride = 0;  // stride in the dram bank
+    uint32_t curr_worker_core = 0;     // current worker core
+    uint32_t curr_storage_core = 0;    // current read dram bank
+    uint32_t vc = 0;
+
+    uint32_t in0_end_idx = num_blocks_y - 1;
+    uint32_t in1_end_idx = num_blocks_x - 1;
+    const auto& in0_sender_interleaved_cores = grid_to_cores(
+        in0_sender_interleaved.start_coord, in0_sender_interleaved.end_coord, true);  // Only used for interleaved in0
+    const auto& in1_sender_cores = grid_to_cores(in1_sender.start_coord, in1_sender.end_coord, true);
+    const auto& in1_receiver_cores = corerange_to_cores(in1_receiver, std::nullopt, true);
+    std::vector<CoreCoord> in1_receiver_other_cores;
+    if (in0_receiver_in1_receiver_interleaved_other_cores.has_value()) {
+        in1_receiver_other_cores = grid_to_cores(
+            in0_receiver_in1_receiver_interleaved_other_cores.value().start_coord,
+            in0_receiver_in1_receiver_interleaved_other_cores.value().end_coord,
+            true);
+    }
+
+    for (const auto& core : cores) {
+        CoreCoord left_core = {(std::size_t)start_core_x, (std::size_t)core.y};
+        CoreCoord left_core_plus_one = {(std::size_t)start_core_x + 1, (std::size_t)core.y};
+        CoreCoord right_core = {(std::size_t)start_core_x + num_cores_with_work_c - 1, (std::size_t)core.y};
+        CoreCoord top_core = {(std::size_t)core.x, (std::size_t)start_core_y};
+        CoreCoord top_core_plus_one = {(std::size_t)core.x, (std::size_t)start_core_y + 1};
+        CoreCoord bottom_core = {(std::size_t)core.x, (std::size_t)start_core_y + num_cores_with_work_r - 1};
+
+        auto left_core_physical = device->worker_core_from_logical_core(left_core);
+        auto left_core_plus_one_physical = device->worker_core_from_logical_core(left_core_plus_one);
+        auto right_core_physical = device->worker_core_from_logical_core(right_core);
+        auto top_core_physical = device->worker_core_from_logical_core(top_core);
+        auto top_core_plus_one_physical = device->worker_core_from_logical_core(top_core_plus_one);
+        auto bottom_core_physical = device->worker_core_from_logical_core(bottom_core);
+        uint32_t in0_idx = core.y - start_core_y;
+        uint32_t in1_idx = core.x - start_core_x;
+
+        auto in0_mcast_sender = left_core_physical;
+        auto in1_mcast_sender = top_core_physical;
+
+        // Assuming in0 is NOC0
+        auto in0_mcast_start = left_core_plus_one_physical;
+        auto in0_mcast_end = right_core_physical;
+        if (in0_noc == tt::tt_metal::NOC::NOC_1) {
+            std::swap(in0_mcast_start, in0_mcast_end);
+        }
+
+        // Assuming in1 is NOC1
+        auto in1_mcast_start = bottom_core_physical;
+        auto in1_mcast_end = top_core_plus_one_physical;
+        if (in1_noc == tt::tt_metal::NOC::NOC_0) {
+            std::swap(in1_mcast_start, in1_mcast_end);
+        }
+
+        if (transpose_mcast) {
+            std::swap(in0_idx, in1_idx);
+            std::swap(in0_mcast_sender, in1_mcast_sender);
+            std::swap(in0_mcast_start, in1_mcast_end);
+            std::swap(in0_mcast_end, in1_mcast_start);
+        }
+
+        // in0 sender
+        if (in0_block_sharded) {
+            uint32_t in0_mcast_receiver_grid_same_coord;
+            std::vector<uint32_t> mm_in0_sender_args;
+            if (transpose_mcast) {
+                in0_mcast_receiver_grid_same_coord = device->worker_core_from_logical_core(core).x;
+                mm_in0_sender_args.push_back(core.y);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_diff_coord_start);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_diff_coord_end);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
+                mm_in0_sender_args.insert(mm_in0_sender_args.end(), in0_mcast_noc_y.begin(), in0_mcast_noc_y.end());
+            } else {
+                in0_mcast_receiver_grid_same_coord = device->worker_core_from_logical_core(core).y;
+                mm_in0_sender_args.push_back(core.x);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_diff_coord_start);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_diff_coord_end);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
+                mm_in0_sender_args.insert(mm_in0_sender_args.end(), in0_mcast_noc_x.begin(), in0_mcast_noc_x.end());
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
+            }
+            if (in1_idx < num_blocks_x) {
+                tt_metal::SetRuntimeArgs(
+                    program, mm_kernel_in0_sender_id, core, mm_in0_sender_args);  // RISCV_0_default
+            } else {
+                tt_metal::SetRuntimeArgs(
+                    program,
+                    mm_kernel_in0_mcast_cores_without_work_and_not_in_receiver_grid_id,
+                    core,
+                    mm_in0_sender_args);  // RISCV_0_default
+            }
+        } else if (in1_idx == 0) {
+            std::vector<uint32_t> mm_in0_sender_args = {
+                // in0 tensor args
+                (std::uint32_t)in0_tensor.address(),
+                (std::uint32_t)in0_tensor_start_tile_id_stride * in0_idx,  // in0_tensor_start_tile_id
+                // in0 mcast args
+                (std::uint32_t)in0_mcast_start.x,  // in0_mcast_dest_noc_start_x
+                (std::uint32_t)in0_mcast_start.y,  // in0_mcast_dest_noc_start_y
+                (std::uint32_t)in0_mcast_end.x,    // in0_mcast_dest_noc_end_x
+                (std::uint32_t)in0_mcast_end.y,    // in0_mcast_dest_noc_end_y
+            };
+            if (in0_idx == in0_end_idx) {
+                // padding args (READER)
+                mm_in0_sender_args.push_back(last_out_block_h);  // last_out_block_h
+            } else {
+                mm_in0_sender_args.push_back(out_block_h);
+            }
+
+            // sparsity args
+            mm_in0_sender_args.push_back(0);  // sparsity_addr
+
+            if (fuse_op && fused_op_signaler->is_all_gather()) {
+                fused_op_signaler->push_matmul_fused_op_rt_args(mm_in0_sender_args, false);
+            }
+
+            tt_metal::SetRuntimeArgs(program, mm_kernel_in0_sender_id, core, mm_in0_sender_args);  // RISCV_0_default
+
+            // in0 receiver
+        } else {
+            std::vector<uint32_t> mm_in0_receiver_args = {
+                // in0 mcast args
+                (std::uint32_t)in0_mcast_sender.x,  // in0_mcast_sender_noc_x
+                (std::uint32_t)in0_mcast_sender.y   // in0_mcast_sender_noc_y
+            };
+            // left half
+            if ((core.x - start_core_x) <= half_core || (!transpose_mcast and core.y == start_core_y)) {
+                tt_metal::SetRuntimeArgs(program, mm_kernel_in0_receiver_id, core, mm_in0_receiver_args);
+            }
+            // right half
+            else {
+                tt_metal::SetRuntimeArgs(
+                    program, mm_kernel_in0_receiver_other_noc_setup_id, core, mm_in0_receiver_args);
+            }
+        }
+
+        if (in0_idx < num_blocks_y and in1_idx < num_blocks_x) {
+            // in1 sender
+            if (in0_idx == 0) {
+                std::vector<uint32_t> mm_in1_sender_writer_args = {
+                    // READER
+                    // in1 tensor args
+                    (std::uint32_t)in1_tensor.address(),
+                    (std::uint32_t)in1_tensor_start_tile_id_stride * in1_idx,  // in1_tensor_start_tile_id
+                    // in1 mcast args
+                    (std::uint32_t)in1_mcast_start.x,  // in1_mcast_dest_noc_start_x
+                    (std::uint32_t)in1_mcast_start.y,  // in1_mcast_dest_noc_start_y
+                    (std::uint32_t)in1_mcast_end.x,    // in1_mcast_dest_noc_end_x
+                    (std::uint32_t)in1_mcast_end.y,    // in1_mcast_dest_noc_end_y
+
+                    // sparsity args
+                    (std::uint32_t)0,  // sparsity_addr
+
+                    // WRITER
+                    // out tensor args
+                    (std::uint32_t)out_tensor.address(),
+                    ((std::uint32_t)in1_idx * per_core_N) + (in0_idx * per_core_M * N)  // out_tensor_start_tile_id
+                };
+
+                if (in1_idx == in1_end_idx) {  // right cores when no transpose_mcast
+                    // padding args (READER)
+                    mm_in1_sender_writer_args.push_back(last_out_block_w);
+
+                    // padding args (WRITER)
+                    mm_in1_sender_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_sender_writer_args.push_back(out_subblock_h);
+                    mm_in1_sender_writer_args.push_back(0);
+                    mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_sender_writer_args.push_back(last_block_num_nonzero_subblocks_w);
+                    mm_in1_sender_writer_args.push_back(last_subblock_of_last_block_w);
+                    mm_in1_sender_writer_args.push_back(last_block_padded_subblock_tiles_addr_skip);
+                    mm_in1_sender_writer_args.push_back(last_block_padded_block_tiles_w_skip);
+                } else {
+                    // padding args (READER)
+                    mm_in1_sender_writer_args.push_back(out_block_w);
+
+                    // padding args (WRITER)
+                    mm_in1_sender_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_sender_writer_args.push_back(out_subblock_h);
+                    mm_in1_sender_writer_args.push_back(0);
+                    mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_sender_writer_args.push_back(out_subblock_w);
+                    mm_in1_sender_writer_args.push_back(0);
+                    mm_in1_sender_writer_args.push_back(0);
+                }
+
+                mm_in1_sender_writer_args.push_back(bias_mesh.has_value() ? (std::uint32_t)bias_mesh->address() : 0);
+                mm_in1_sender_writer_args.push_back(
+                    bias_mesh.has_value() ? (std::uint32_t)per_core_N * in1_idx : 0);  // in1_tensor_start_tile_id
+                if (!output_is_sharded) {
+                    if (in1_idx == in1_end_idx) {  // right cores when no transpose_mcast
+                        mm_in1_sender_writer_args.push_back(last_out_num_blocks_w);
+                    } else {
+                        mm_in1_sender_writer_args.push_back(out_num_blocks_x);
+                    }
+                }
+
+                if (fuse_op) {
+                    if (fused_op_signaler->is_all_gather()) {
+                        fused_op_signaler->push_matmul_fused_op_rt_args(mm_in1_sender_writer_args, true);
+                    } else if (fused_op_signaler->is_reduce_scatter()) {
+                        fused_op_signaler->push_matmul_fused_op_rt_args(mm_in1_sender_writer_args, in0_idx, in1_idx);
+                    } else {
+                        TT_FATAL(false, "Fused operation must be either all_gather or reduce_scatter.");
+                    }
+                }
+                if (in1_is_sharded and in1_is_dram) {  // in1 is dram sharded
+                    if (in1_is_width_sharded) {
+                        uint32_t num_iter_index = mm_in1_sender_writer_args.size() + 1;
+                        vc = vc == 3 ? 0 : vc + 1;
+                        mm_in1_sender_writer_args.push_back(vc);
+
+                        uint32_t num_iter = 0;  // iterate how many banks, till fill the current worker block
+
+                        if (curr_storage_core < num_dram_banks) {
+                            num_iter++;
+
+                            worker_core_stride = per_core_N_storage - storage_core_stride;
+
+                            mm_in1_sender_writer_args.push_back(
+                                storage_core_stride * in1_single_tile_size);  // dram_tensor_start_offset
+                            mm_in1_sender_writer_args.push_back(
+                                worker_core_stride * in1_single_tile_size);          // per_core_N_dram_bytes
+                            mm_in1_sender_writer_args.push_back(curr_storage_core);  // current_dram_bank_id
+
+                            log_debug(
+                                tt::LogOp,
+                                "curr worker core: {} read {} tiles from dram bank: {}, start from index: {}",
+                                curr_worker_core,
+                                worker_core_stride,
+                                curr_storage_core,
+                                storage_core_stride);
+
+                            curr_storage_core += (storage_core_stride + worker_core_stride) / per_core_N_storage;
+                            storage_core_stride = (storage_core_stride + worker_core_stride) % per_core_N_storage;
+
+                            uint32_t curr_worker_core_old = curr_worker_core;
+                            if (worker_core_stride >= per_core_N) {
+                                curr_worker_core += 1;
+                            }
+
+                            while (curr_worker_core <= curr_worker_core_old and curr_storage_core < num_dram_banks) {
+                                num_iter++;
+
+                                uint32_t stride = worker_core_stride + per_core_N_storage;
+                                stride = std::min(stride, per_core_N);
+
+                                mm_in1_sender_writer_args.push_back(
+                                    (stride - worker_core_stride) * in1_single_tile_size);  // per_core_N_dram_bytes
+                                mm_in1_sender_writer_args.push_back(curr_storage_core);     // current_dram_bank_id
+
+                                log_debug(
+                                    tt::LogOp,
+                                    "curr worker core: {} read {} tiles from dram bank: {}, start from index: {}",
+                                    curr_worker_core,
+                                    (stride - worker_core_stride),
+                                    curr_storage_core,
+                                    storage_core_stride);
+
+                                if (stride >= per_core_N) {
+                                    curr_worker_core += 1;
+                                }
+                                storage_core_stride = (stride - worker_core_stride) % per_core_N_storage;
+                                curr_storage_core += (stride - worker_core_stride) / per_core_N_storage;
+                                worker_core_stride = stride;
+                            }
+                        }
+                        mm_in1_sender_writer_args.insert(mm_in1_sender_writer_args.begin() + num_iter_index, num_iter);
+                    } else {
+                        // Height sharded: no additional runtime args needed
+                        // (bank/offset computed from compile-time args + batch index)
+                    }
+                }
+                tt_metal::SetRuntimeArgs(
+                    program, mm_kernel_in1_sender_writer_id, core, mm_in1_sender_writer_args);  // RISCV_1_default
+
+                // in1 receiver
+            } else {
+                std::vector<uint32_t> mm_in1_receiver_writer_args = {
+                    // READER
+                    // in1 mcast args
+                    (std::uint32_t)in1_mcast_sender.x,  // in1_mcast_sender_noc_x
+                    (std::uint32_t)in1_mcast_sender.y,  // in1_mcast_sender_noc_y
+
+                    // WRITER
+                    // out tensor args
+                    (std::uint32_t)out_tensor.address(),                                // out_tensor_addr
+                    ((std::uint32_t)in1_idx * per_core_N) + (in0_idx * per_core_M * N)  // out_tensor_start_tile_id
+                };
+
+                if (in1_idx == in1_end_idx and in0_idx == in0_end_idx) {  // bottom-right core when no transpose_mcast
+                    // padding args (WRITER)
+                    mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(last_block_num_nonzero_subblocks_h);
+                    mm_in1_receiver_writer_args.push_back(last_subblock_of_last_block_h);
+                    mm_in1_receiver_writer_args.push_back(last_block_padded_block_tiles_h_skip);
+                    mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(last_block_num_nonzero_subblocks_w);
+                    mm_in1_receiver_writer_args.push_back(last_subblock_of_last_block_w);
+                    mm_in1_receiver_writer_args.push_back(last_block_padded_subblock_tiles_addr_skip);
+                    mm_in1_receiver_writer_args.push_back(last_block_padded_block_tiles_w_skip);
+                } else if (in0_idx == in0_end_idx) {  // bottom cores except bottom-right when no transpose_mcast
+                    // padding args (WRITER)
+                    mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(last_block_num_nonzero_subblocks_h);
+                    mm_in1_receiver_writer_args.push_back(last_subblock_of_last_block_h);
+                    mm_in1_receiver_writer_args.push_back(last_block_padded_block_tiles_h_skip);
+                    mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(0);
+                    mm_in1_receiver_writer_args.push_back(0);
+                } else if (in1_idx == in1_end_idx) {  // right cores except bottom when no transpose_mcast
+                    // padding args (WRITER)
+                    mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(0);
+                    mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(last_block_num_nonzero_subblocks_w);
+                    mm_in1_receiver_writer_args.push_back(last_subblock_of_last_block_w);
+                    mm_in1_receiver_writer_args.push_back(last_block_padded_subblock_tiles_addr_skip);
+                    mm_in1_receiver_writer_args.push_back(last_block_padded_block_tiles_w_skip);
+                } else {
+                    // padding args (WRITER)
+                    mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(0);
+                    mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(0);
+                    mm_in1_receiver_writer_args.push_back(0);
+                }
+                if (!output_is_sharded) {
+                    if (in1_idx == in1_end_idx and
+                        in0_idx == in0_end_idx) {  // bottom-right core when no transpose_mcast
+                        mm_in1_receiver_writer_args.push_back(last_out_num_blocks_h);
+                        mm_in1_receiver_writer_args.push_back(last_out_num_blocks_w);
+                    } else if (in0_idx == in0_end_idx) {  // bottom cores except bottom-right when no transpose_mcast
+                        mm_in1_receiver_writer_args.push_back(last_out_num_blocks_h);
+                        mm_in1_receiver_writer_args.push_back(out_num_blocks_x);
+                    } else if (in1_idx == in1_end_idx) {  // right cores except bottom when no transpose_mcast
+                        mm_in1_receiver_writer_args.push_back(out_num_blocks_y);
+                        mm_in1_receiver_writer_args.push_back(last_out_num_blocks_w);
+                    } else {
+                        mm_in1_receiver_writer_args.push_back(out_num_blocks_y);
+                        mm_in1_receiver_writer_args.push_back(out_num_blocks_x);
+                    }
+                }
+
+                if (fuse_op && fused_op_signaler->is_reduce_scatter()) {
+                    fused_op_signaler->push_matmul_fused_op_rt_args(mm_in1_receiver_writer_args, in0_idx, in1_idx);
+                }
+
+                // left half
+                if ((core.x - start_core_x) <= half_core || (transpose_mcast and core.y == start_core_y)) {
+                    tt_metal::SetRuntimeArgs(
+                        program, mm_kernel_in1_receiver_writer_id, core, mm_in1_receiver_writer_args);
+                }
+                // right half
+                else {
+                    tt_metal::SetRuntimeArgs(
+                        program, mm_kernel_in1_receiver_writer_other_noc_setup_id, core, mm_in1_receiver_writer_args);
+                }
+            }
+        }
+    }
+
+    return {
+        std::move(program),
+        {mm_kernel_in0_sender_id,
+         in0_sender_interleaved_cores,
+         mm_kernel_in1_sender_writer_id,
+         in1_sender_cores,
+         mm_kernel_in1_receiver_writer_id,
+         in1_receiver_cores,
+         mm_kernel_in1_receiver_writer_other_noc_setup_id,
+         in1_receiver_other_cores,
+         cb_src2,
+         cb_output,
+         num_cores_with_work_r,
+         num_cores_with_work_c,
+         start_core_x,
+         start_core_y,
+         transpose_mcast,
+         cores}};
+}
+
+void override_runtime_arguments_impl(
+    const MatmulMultiCoreReuseMcast2DProgramFactory::shared_variables_t& shared_variables,
+    tt::tt_metal::Program& program,
+    const ttnn::prim::qsr::MatmulInputs& tensor_args,
+    std::vector<ttnn::Tensor>& output_tensors) {
+    auto mm_kernel_in0_sender_id = shared_variables.mm_kernel_in0_sender_id;
+    auto in0_sender_interleaved_cores = shared_variables.in0_sender_interleaved_cores;
+    auto mm_kernel_in1_sender_writer_id = shared_variables.mm_kernel_in1_sender_writer_id;
+    auto in1_sender_cores = shared_variables.in1_sender_cores;
+    auto mm_kernel_in1_receiver_writer_id = shared_variables.mm_kernel_in1_receiver_writer_id;
+    auto in1_receiver_cores = shared_variables.in1_receiver_cores;
+    auto mm_kernel_in1_receiver_writer_other_noc_setup_id =
+        shared_variables.mm_kernel_in1_receiver_writer_other_noc_setup_id;
+    auto in1_receiver_other_cores = shared_variables.in1_receiver_other_cores;
+    auto cb_src2 = shared_variables.cb_src2;
+    auto cb_output = shared_variables.cb_output;
+    auto cores = shared_variables.cores;
+
+    const auto& input_tensors = tensor_args.input_tensors;
+    const auto& optional_input_tensors = tensor_args.optional_input_tensors;
+
+    TT_FATAL(
+        input_tensors.size() + optional_input_tensors.size() == 3,
+        "Total number of input tensors (required + optional) must be 3, but got {} + {} = {}",
+        input_tensors.size(),
+        optional_input_tensors.size(),
+        input_tensors.size() + optional_input_tensors.size());
+    TT_FATAL(output_tensors.size() == 1, "Number of output tensors must be 1, but got {}", output_tensors.size());
+
+    const auto& in0 = input_tensors.at(0).mesh_tensor();
+    const auto& in1 = input_tensors.at(1).mesh_tensor();
+    const auto& bias_tensor = optional_input_tensors.at(0);
+
+    const auto& out = output_tensors.at(0).mesh_tensor();
+
+    bool src0_sharded = input_tensors[0].memory_config().is_sharded();
+    bool out_sharded = output_tensors[0].memory_config().is_sharded();
+
+    ttsl::optional_reference<const tt::tt_metal::MeshTensor> bias_mesh;
+    if (bias_tensor.has_value()) {
+        bias_mesh = bias_tensor.value().mesh_tensor();
+    }
+
+    // in0 sender
+    if (src0_sharded) {
+        UpdateDynamicCircularBufferAddress(program, cb_src2, in0);
+    } else {
+        auto& reader_sender_runtime_args_by_core = GetRuntimeArgs(program, mm_kernel_in0_sender_id);
+        for (const auto& core : in0_sender_interleaved_cores) {
+            auto& reader_runtime_args = reader_sender_runtime_args_by_core[core.x][core.y];
+            reader_runtime_args[0] = in0.address();
+        }
+    }
+
+    // in1 sender
+    auto& sender_writer_runtime_args_by_core = GetRuntimeArgs(program, mm_kernel_in1_sender_writer_id);
+    for (const auto& core : in1_sender_cores) {
+        auto& writer_runtime_args = sender_writer_runtime_args_by_core[core.x][core.y];
+        writer_runtime_args[0] = in1.address();
+        writer_runtime_args[7] = out.address();
+        if (bias_tensor.has_value()) {
+            writer_runtime_args[18] = bias_mesh->address();
+        }
+    }
+
+    // in1 receiver
+    auto& receiver_writer_runtime_args_by_core = GetRuntimeArgs(program, mm_kernel_in1_receiver_writer_id);
+    for (const auto& core : in1_receiver_cores) {
+        auto& writer_runtime_args = receiver_writer_runtime_args_by_core[core.x][core.y];
+        writer_runtime_args[2] = out.address();
+    }
+    if (mm_kernel_in1_receiver_writer_id != mm_kernel_in1_receiver_writer_other_noc_setup_id) {
+        auto& receiver_writer_runtime_args_by_core =
+            GetRuntimeArgs(program, mm_kernel_in1_receiver_writer_other_noc_setup_id);
+        for (const auto& core : in1_receiver_other_cores) {
+            auto& writer_runtime_args = receiver_writer_runtime_args_by_core[core.x][core.y];
+            writer_runtime_args[2] = out.address();
+        }
+    }
+
+    if (out_sharded) {
+        UpdateDynamicCircularBufferAddress(program, cb_output, out);
+    }
+}
+}  // namespace reuse_mcast_optimized_helpers
+
+static ttnn::device_operation::CachedProgram<MatmulMultiCoreReuseMcast2DProgramFactory::shared_variables_t>
+matmul_multi_core_reuse_mcast_2d_optimized_(
+    tt::tt_metal::Program& program,
+    const ttnn::prim::qsr::MatmulParams& operation_attributes,
+    const ttnn::prim::qsr::MatmulInputs& tensor_args,
+    std::vector<ttnn::Tensor>& tensor_return_value,
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler) {
+    using namespace tt;
+    using namespace operations::experimental::quasar::matmul::utilities;
+
+    const auto& a = tensor_args.input_tensors.at(0);
+    const auto& b = tensor_args.input_tensors.at(1);
+    const auto& bias = tensor_args.optional_input_tensors.at(0);
+    const auto& output = tensor_return_value.at(0).mesh_tensor();
+
+    TT_FATAL(operation_attributes.bcast_batch.has_value(), "Error: bcast_batch field should have been populated");
+    TT_FATAL(operation_attributes.program_config.has_value(), "Error: program_config field should have been populated");
+    bool bcast_batch = operation_attributes.bcast_batch.value();
+    bool transpose_a = operation_attributes.transpose_a;
+    bool transpose_b = operation_attributes.transpose_b;
+
+    auto program_config =
+        std::get<operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCastProgramConfig>(
+            operation_attributes.program_config.value());
+
+    if (!program_config.allowed_worker_cores.has_value()) {
+        log_warning(
+            tt::LogOp,
+            "matmul_multi_core_reuse_mcast_2d_optimized_helper: program_config.allowed_worker_cores not populated; "
+            "auto-populating from compute_with_storage_grid_size. Callers that bypass ttnn::prim::qsr::matmul() (e.g. "
+            "CCL fused ops) should invoke ttnn::operations::experimental::quasar::matmul::normalize_program_config() "
+            "on the program "
+            "config first. This will become a hard error in a future release.");
+        program_config.allowed_worker_cores = CoreRangeSet(CoreRange(
+            CoreCoord(0, 0),
+            CoreCoord(
+                program_config.compute_with_storage_grid_size.x - 1,
+                program_config.compute_with_storage_grid_size.y - 1)));
+    }
+
+    auto fuse_batch = program_config.fuse_batch;
+    auto in0_block_w = program_config.in0_block_w;
+    auto compute_with_storage_grid_size = program_config.allowed_worker_cores.value().bounding_box().grid_size();
+    auto out_subblock_h = program_config.out_subblock_h;
+    auto out_subblock_w = program_config.out_subblock_w;
+    auto out_block_h = program_config.out_block_h;
+    auto out_block_w = program_config.out_block_w;
+    auto per_core_M = program_config.per_core_M;
+    auto per_core_N = program_config.per_core_N;
+    auto transpose_mcast = program_config.transpose_mcast;
+
+    TT_FATAL(
+        operation_attributes.compute_kernel_config.has_value(),
+        "Error: compute_kernel_config field should have been populated");
+    auto compute_kernel_config = operation_attributes.compute_kernel_config.value();
+    auto untilize_out = operation_attributes.untilize_out;
+    // auto fused_op_signaler = std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>();
+
+    const auto& a_shape_padded = get_matmul_tensor_padded_shape(a, transpose_a);
+    const auto& b_shape_padded = get_matmul_tensor_padded_shape(b, transpose_b);
+    const auto in0_tile = get_matmul_tile(a, transpose_a);
+    const auto in1_tile = get_matmul_tile(b, transpose_b);
+
+    // cannot use the output tensor tile directly as that might be changed by user override
+    const auto output_tile = tt::tt_metal::Tile({in0_tile.get_height(), in1_tile.get_width()});
+
+    // CB dataformats
+    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());  // in0
+    const auto& in1_tensor = b.mesh_tensor();
+    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(in1_tensor.dtype());  // in1
+    tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());   // output
+
+    const auto& a_shape_logical = get_matmul_tensor_logical_shape(a, transpose_a);
+    // When transpose_a is true, the K dimension maps to the row dimension of the raw tile,
+    // which is already zero-padded during tile layout conversion. pad_last_ktile operates on
+    // columns, so applying it would incorrectly zero valid data that becomes output rows
+    // after the compute kernel transposes the tile.
+    const auto in0_last_ktile_w = transpose_a ? 0 : a_shape_logical[-1] % in0_tile.get_width();
+    const auto in0_last_ktile_h = transpose_a ? a_shape_logical[-1] % in0_tile.get_width() : 0;
+    TT_FATAL(
+        in0_last_ktile_w == 0 || in0_last_ktile_h == 0,
+        "At most one of in0_last_ktile_w ({}) and in0_last_ktile_h ({}) can be non-zero",
+        in0_last_ktile_w,
+        in0_last_ktile_h);
+
+    ttsl::optional_reference<const tt_metal::MeshTensor> bias_mesh;
+    tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;  // bias; doesn't matter if bias=nullptr
+    if (bias.has_value()) {
+        const auto& c = bias.value();
+        TT_FATAL(
+            c.storage_type() == StorageType::DEVICE,
+            "Bias tensor must be on device, got storage type: {}",
+            c.storage_type());
+        TT_FATAL(a.device() == c.device(), "Operands to matmul need to be on the same device!");
+        TT_FATAL(c.is_allocated(), "Operands to matmul need to be allocated in buffers on device!");
+
+        bias_mesh = c.mesh_tensor();
+
+        bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
+    }
+
+    tt_metal::IDevice* device = a.device();
+
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    const auto& in0_tensor = a.mesh_tensor();
+    TT_FATAL(
+        in0_tensor.mesh_buffer().device_local_size() % in0_single_tile_size == 0,
+        "Input A buffer size ({}) must be divisible by single tile size ({})",
+        in0_tensor.mesh_buffer().device_local_size(),
+        in0_single_tile_size);
+    TT_FATAL(
+        in1_tensor.mesh_buffer().device_local_size() % in1_single_tile_size == 0,
+        "Input B buffer size ({}) must be divisible by single tile size ({})",
+        in1_tensor.mesh_buffer().device_local_size(),
+        in1_single_tile_size);
+
+    TT_FATAL(
+        a_shape_padded[-1] == b_shape_padded[-2],
+        "Dimension K (A.shape[-1] = {}, B.shape[-2] = {}) must match for matmul",
+        a_shape_padded[-1],
+        b_shape_padded[-2]);
+    TT_FATAL(
+        a_shape_padded[-2] % in0_tile.get_height() == 0,
+        "A.shape[-2] ({}) must be divisible by tile shape[0] ({})",
+        a_shape_padded[-2],
+        in0_tile.get_height());
+    TT_FATAL(
+        a_shape_padded[-1] % in0_tile.get_width() == 0,
+        "A.shape[-1] ({}) must be divisible by tile shape[1] ({})",
+        a_shape_padded[-1],
+        in0_tile.get_width());
+    TT_FATAL(
+        b_shape_padded[-2] % in1_tile.get_height() == 0,
+        "B.shape[-2] ({}) must be divisible by tile shape[0] ({})",
+        b_shape_padded[-2],
+        in1_tile.get_height());
+    TT_FATAL(
+        b_shape_padded[-1] % in1_tile.get_width() == 0,
+        "B.shape[-1] ({}) must be divisible by tile shape[1] ({})",
+        b_shape_padded[-1],
+        in1_tile.get_width());
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), compute_kernel_config);
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Matmul Parameters Setup
+    ////////////////////////////////////////////////////////////////////////////
+    // NOTE: Pads matmul input dims to 512 x 512 multiples (ie. multiples of 16*32 x 16*32)
+    // NOTE: Maximum number of tiles in output is 120 * 16^2 = 30,720 (eg. [1, 1, 5120, 6144])
+    const auto B = fuse_batch ? 1 : get_batch_size(a_shape_padded);
+    const auto Mt = get_M_dim(a_shape_padded, in0_tile, fuse_batch);
+    const auto Mt_per_batch = get_M_dim(a_shape_padded, in0_tile, false);
+    const auto Kt = get_K_dim(a_shape_padded, in0_tile);
+    const auto Nt = get_N_dim(b_shape_padded, in1_tile);
+
+    TT_FATAL(Kt % in0_block_w == 0, "Kt ({}) must be divisible by in0_block_w ({})", Kt, in0_block_w);
+
+    // This should allocate a DRAM buffer on the device
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+
+    // Calculate number of blocks along x and y; tensor dims are padded up to 512
+    uint32_t num_blocks_y = ((Mt - 1) / per_core_M) + 1;
+    uint32_t num_blocks_x = ((Nt - 1) / per_core_N) + 1;
+    if (transpose_mcast) {
+        std::swap(num_blocks_x, num_blocks_y);
+    }
+
+    // TODO: Max used grid can actually exceed mcast receiver grid if in0 is sharded
+    // TODO: Move these validates to op validate and properly check for this
+    TT_FATAL(
+        num_blocks_x <= num_cores_x,
+        "Num output blocks along x ({}) must be smaller than or equal to the number of columns in compute grid ({})!",
+        num_blocks_x,
+        num_cores_x);
+    TT_FATAL(
+        num_blocks_y <= num_cores_y,
+        "Num output blocks along y ({}) must be smaller than or equal to the number of rows in compute grid ({})!",
+        num_blocks_y,
+        num_cores_y);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Sub-device start core
+    ////////////////////////////////////////////////////////////////////////////
+    CoreCoord sub_device_start_core = {0, 0};
+    if (operation_attributes.sub_device_id.has_value()) {
+        auto sub_device_cores = device->worker_cores(
+            tt::tt_metal::HalProgrammableCoreType::TENSIX, operation_attributes.sub_device_id.value());
+        auto bbox = sub_device_cores.bounding_box();
+        sub_device_start_core = bbox.start_coord;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Application Setup
+    ////////////////////////////////////////////////////////////////////////////
+    return reuse_mcast_optimized_helpers::create_program_mcast_in0_in1(
+        program,
+        device,
+        math_fidelity,
+        fp32_dest_acc_en,
+        math_approx_mode,
+        packer_l1_acc,
+        dst_full_sync_en,
+        B,
+        Mt,
+        Mt_per_batch,
+        Nt,
+        Kt,
+        bcast_batch,
+        transpose_a,
+        transpose_b,
+        ttnn::get_throttle_level(compute_kernel_config),
+        in0_block_w,
+        in0_last_ktile_w,
+        in0_last_ktile_h,
+        out_subblock_h,
+        out_subblock_w,
+        out_block_h,
+        out_block_w,
+        per_core_M,
+        per_core_N,
+        transpose_mcast,
+        program_config.fused_activation,
+        in0_tensor,
+        in1_tensor,
+        bias_mesh,
+        output,
+        in0_tile,
+        in1_tile,
+        bias.has_value() ? bias->tensor_spec().tile() : output_tile,
+        output_tile,
+        in0_data_format,
+        in1_data_format,
+        bias_data_format,
+        output_data_format,
+        untilize_out,
+        fused_op_signaler,
+        fused_matmul_bias_row_broadcastable(bias),
+        sub_device_start_core);
+}
+
+void MatmulMultiCoreReuseMcast2DProgramFactory::override_runtime_arguments(
+    tt::tt_metal::Program& program,
+    const shared_variables_t& shared_variables,
+    const ttnn::prim::qsr::MatmulParams& /*operation_attributes*/,
+    const ttnn::prim::qsr::MatmulInputs& tensor_args,
+    std::vector<ttnn::Tensor>& tensor_return_value) {
+    reuse_mcast_optimized_helpers::override_runtime_arguments_impl(
+        shared_variables, program, tensor_args, tensor_return_value);
+}
+
+ProgramDescriptor MatmulMultiCoreReuseMcast2DProgramFactory::create_descriptor(
+    const ttnn::prim::qsr::MatmulParams& operation_attributes,
+    const ttnn::prim::qsr::MatmulInputs& tensor_args,
+    std::vector<ttnn::Tensor>& tensor_return_value,
+    const std::optional<CoreRangeSet>& /*core_range_set*/) {
+    using namespace tt;
+    using namespace operations::experimental::quasar::matmul::utilities;
+
+    const auto& a = tensor_args.input_tensors.at(0);
+    const auto& b = tensor_args.input_tensors.at(1);
+    const auto& bias = tensor_args.optional_input_tensors.at(0);
+    const auto& output = tensor_return_value.at(0).mesh_tensor();
+
+    TT_FATAL(operation_attributes.bcast_batch.has_value(), "Error: bcast_batch field should have been populated");
+    TT_FATAL(operation_attributes.program_config.has_value(), "Error: program_config field should have been populated");
+    bool bcast_batch = operation_attributes.bcast_batch.value();
+    bool transpose_a = operation_attributes.transpose_a;
+    bool transpose_b = operation_attributes.transpose_b;
+
+    auto program_config =
+        std::get<operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCastProgramConfig>(
+            operation_attributes.program_config.value());
+
+    auto fuse_batch = program_config.fuse_batch;
+    auto in0_block_w = program_config.in0_block_w;
+    auto out_subblock_h = program_config.out_subblock_h;
+    auto out_subblock_w = program_config.out_subblock_w;
+    auto out_block_h = program_config.out_block_h;
+    auto out_block_w = program_config.out_block_w;
+    auto per_core_M = program_config.per_core_M;
+    auto per_core_N = program_config.per_core_N;
+    auto transpose_mcast = program_config.transpose_mcast;
+
+    TT_FATAL(
+        operation_attributes.compute_kernel_config.has_value(),
+        "Error: compute_kernel_config field should have been populated");
+    auto compute_kernel_config = operation_attributes.compute_kernel_config.value();
+    auto untilize_out = operation_attributes.untilize_out;
+
+    const auto& a_shape_padded = get_matmul_tensor_padded_shape(a, transpose_a);
+    const auto& b_shape_padded = get_matmul_tensor_padded_shape(b, transpose_b);
+    const auto in0_tile = get_matmul_tile(a, transpose_a);
+    const auto in1_tile = get_matmul_tile(b, transpose_b);
+
+    // cannot use the output tensor tile directly as that might be changed by user override
+    const auto output_tile = tt::tt_metal::Tile({in0_tile.get_height(), in1_tile.get_width()});
+
+    // CB dataformats
+    const auto& in0_tensor = a.mesh_tensor();
+    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(in0_tensor.dtype());
+    const auto& in1_tensor = b.mesh_tensor();
+    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(in1_tensor.dtype());
+    tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
+
+    const auto& a_shape_logical = get_matmul_tensor_logical_shape(a, transpose_a);
+    const auto in0_last_ktile_w = transpose_a ? 0 : a_shape_logical[-1] % in0_tile.get_width();
+    const auto in0_last_ktile_h = transpose_a ? a_shape_logical[-1] % in0_tile.get_width() : 0;
+    TT_FATAL(
+        in0_last_ktile_w == 0 || in0_last_ktile_h == 0,
+        "At most one of in0_last_ktile_w ({}) and in0_last_ktile_h ({}) can be non-zero",
+        in0_last_ktile_w,
+        in0_last_ktile_h);
+
+    ttsl::optional_reference<const tt_metal::MeshTensor> bias_mesh;
+    tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;
+    if (bias.has_value()) {
+        const auto& c = bias.value();
+        bias_mesh = c.mesh_tensor();
+        bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
+    }
+
+    tt_metal::IDevice* device = &in0_tensor.mutable_device();
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), compute_kernel_config);
+
+    const auto B = fuse_batch ? 1 : get_batch_size(a_shape_padded);
+    const auto Mt = get_M_dim(a_shape_padded, in0_tile, fuse_batch);
+    const auto Mt_per_batch = get_M_dim(a_shape_padded, in0_tile, false);
+    const auto Kt = get_K_dim(a_shape_padded, in0_tile);
+    const auto Nt = get_N_dim(b_shape_padded, in1_tile);
+
+    // When a sub-device is present use its bounding-box start; otherwise fall
+    // back to allowed_worker_cores start so non-(0,0) placements work correctly.
+    CoreCoord sub_device_start_core = program_config.allowed_worker_cores.has_value()
+                                          ? program_config.allowed_worker_cores.value().bounding_box().start_coord
+                                          : CoreCoord{0, 0};
+    if (operation_attributes.sub_device_id.has_value()) {
+        auto sub_device_cores = device->worker_cores(
+            tt::tt_metal::HalProgrammableCoreType::TENSIX, operation_attributes.sub_device_id.value());
+        auto bbox = sub_device_cores.bounding_box();
+        sub_device_start_core = bbox.start_coord;
+    }
+
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler> fused_op_signaler = std::nullopt;
+    return reuse_mcast_optimized_helpers::create_program_mcast_in0_in1_descriptor(
+        device,
+        math_fidelity,
+        fp32_dest_acc_en,
+        math_approx_mode,
+        packer_l1_acc,
+        dst_full_sync_en,
+        B,
+        Mt,
+        Mt_per_batch,
+        Nt,
+        Kt,
+        bcast_batch,
+        transpose_a,
+        transpose_b,
+        ttnn::get_throttle_level(compute_kernel_config),
+        in0_block_w,
+        in0_last_ktile_w,
+        in0_last_ktile_h,
+        out_subblock_h,
+        out_subblock_w,
+        out_block_h,
+        out_block_w,
+        per_core_M,
+        per_core_N,
+        transpose_mcast,
+        program_config.fused_activation,
+        in0_tensor,
+        in1_tensor,
+        bias_mesh,
+        output,
+        in0_tile,
+        in1_tile,
+        bias.has_value() ? bias->tensor_spec().tile() : output_tile,
+        output_tile,
+        in0_data_format,
+        in1_data_format,
+        bias_data_format,
+        output_data_format,
+        untilize_out,
+        fused_op_signaler,
+        fused_matmul_bias_row_broadcastable(bias),
+        sub_device_start_core);
+}
+
+ttnn::device_operation::CachedProgram<MatmulMultiCoreReuseMcast2DProgramFactory::shared_variables_t>
+matmul_multi_core_reuse_mcast_2d_optimized_helper(
+    tt::tt_metal::Program& program, /* Take programa as input by reference */
+    const Tensor& a,
+    const Tensor& b,
+    const std::optional<const Tensor>& bias,
+    Tensor& output_tensor,
+    bool broadcast_batch,
+    DeviceComputeKernelConfig compute_kernel_config,
+    const operations::experimental::quasar::matmul::MatmulProgramConfig& program_config,
+    bool untilize_out,
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler) {
+    auto attributes = ttnn::prim::qsr::MatmulParams{.program_config = program_config, .bcast_batch = broadcast_batch};
+    attributes.compute_kernel_config = compute_kernel_config;
+    attributes.untilize_out = untilize_out;
+
+    auto output_tensors = std::vector<ttnn::Tensor>{output_tensor};
+    return matmul_multi_core_reuse_mcast_2d_optimized_(
+        program, attributes, ttnn::prim::qsr::MatmulInputs{{a, b}, {bias}, {}}, output_tensors, fused_op_signaler);
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.hpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/matmul_device_operation_types.hpp"
+#include "ttnn/operations/ccl/ccl_op_fusion.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace ttnn::prim::qsr {
+
+struct MatmulMultiCoreReuseMcast2DProgramFactory {
+    struct shared_variables_t {
+        tt::tt_metal::KernelHandle mm_kernel_in0_sender_id{};
+        std::vector<CoreCoord> in0_sender_interleaved_cores;
+        tt::tt_metal::KernelHandle mm_kernel_in1_sender_writer_id{};
+        std::vector<CoreCoord> in1_sender_cores;
+        tt::tt_metal::KernelHandle mm_kernel_in1_receiver_writer_id{};
+        std::vector<CoreCoord> in1_receiver_cores;
+        tt::tt_metal::KernelHandle mm_kernel_in1_receiver_writer_other_noc_setup_id{};
+        std::vector<CoreCoord> in1_receiver_other_cores;
+        tt::tt_metal::CBHandle cb_src2{};
+        tt::tt_metal::CBHandle cb_output{};
+        uint32_t num_cores_with_work_r{};
+        uint32_t num_cores_with_work_c{};
+        uint32_t start_core_x{};
+        uint32_t start_core_y{};
+        bool transpose_mcast{};
+        std::vector<CoreCoord> cores;
+    };
+
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
+        const shared_variables_t& shared_variables,
+        const ttnn::prim::qsr::MatmulParams& operation_attributes,
+        const ttnn::prim::qsr::MatmulInputs& tensor_args,
+        std::vector<ttnn::Tensor>& tensor_return_value);
+
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const ttnn::prim::qsr::MatmulParams& operation_attributes,
+        const ttnn::prim::qsr::MatmulInputs& tensor_args,
+        std::vector<ttnn::Tensor>& tensor_return_value,
+        const std::optional<CoreRangeSet>& core_range_set = std::nullopt);
+};
+
+ttnn::device_operation::CachedProgram<MatmulMultiCoreReuseMcast2DProgramFactory::shared_variables_t>
+matmul_multi_core_reuse_mcast_2d_optimized_helper(
+    tt::tt_metal::Program& program, /* Take programa as input by reference */
+    const Tensor& a,
+    const Tensor& b,
+    const std::optional<const Tensor>& bias,
+    Tensor& output_tensor,
+    bool broadcast_batch,
+    DeviceComputeKernelConfig compute_kernel_config,
+    const operations::experimental::quasar::matmul::MatmulProgramConfig& program_config,
+    bool untilize_out,
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler);
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
@@ -1,0 +1,1058 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/utilities/matmul_utilities.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/config/matmul_program_config.hpp"
+
+#include <algorithm>
+#include <utility>
+
+#include "hostdevcommon/common_values.hpp"
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/tt_align.hpp>
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+#include "ttnn/operations/compute_throttle_utils.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/tensor/shape/shape.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/shared_with_host/activation_type.hpp"
+
+using namespace tt;
+
+using ttnn::operations::unary::UnaryOpType;
+using ttnn::operations::unary::UnaryWithParam;
+
+using tt::tt_metal::CBDescriptor;
+using tt::tt_metal::CBFormatDescriptor;
+using tt::tt_metal::ComputeConfigDescriptor;
+using tt::tt_metal::DataMovementConfigDescriptor;
+using tt::tt_metal::KernelDescriptor;
+using tt::tt_metal::ProgramDescriptor;
+
+namespace ttnn::prim::qsr {
+namespace reuse_dram_sharded_optimized_helpers {
+
+using dram_sharded_helpers::get_max_page_size_and_num_pages;
+using dram_sharded_helpers::get_optimal_dram_bank_to_reader_assignment;
+using dram_sharded_helpers::move_common_entries;
+
+static ProgramDescriptor create_program_dram_sharded_descriptor(
+    tt::tt_metal::IDevice* device,
+    const CoreRangeSet& input_all_storage_cores,
+    const CoreRangeSet& output_all_storage_cores,
+    MathFidelity math_fidelity,
+    bool fp32_dest_acc_en,
+    bool math_approx_mode,
+    bool packer_l1_acc,
+    bool dst_full_sync_en,
+    ttnn::operations::compute_throttle_utils::ThrottleLevel throttle_level,
+    uint32_t B,
+    uint32_t /* M */,
+    uint32_t N,
+    uint32_t K,
+    uint32_t in0_block_w,
+    uint32_t in0_last_ktile_w,
+    uint32_t per_core_M,
+    uint32_t per_core_N_storage,
+    std::optional<UnaryWithParam> fused_activation,
+    const tt::tt_metal::MeshTensor& in0_tensor,
+    const tt::tt_metal::MeshTensor& in1_tensor,
+    ttsl::optional_reference<const tt::tt_metal::MeshTensor> bias_tensor,
+    const tt::tt_metal::MeshTensor& out_tensor,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const tt::tt_metal::Tile& bias_tile,
+    const tt::tt_metal::Tile& output_tile,
+    tt::DataFormat in0_data_format,
+    tt::DataFormat in1_data_format,
+    tt::DataFormat bias_data_format,
+    tt::DataFormat output_data_format,
+    bool untilize_out,
+    bool skip_compute,
+    bool skip_in0_mcast,
+    bool skip_write_back,
+    bool row_broadcast_bias) {
+    using namespace tt;
+
+    ttsl::optional_reference<const tt::tt_metal::MeshTensor> bias;
+    if (bias_tensor.has_value()) {
+        bias = *bias_tensor;
+    }
+
+    // currently only support transpose of the full tile
+    bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
+    TT_FATAL(
+        in1_tensor.shard_spec()->orientation == ShardOrientation::ROW_MAJOR, "Only ROW_MAJOR sharding is supported");
+
+    uint32_t start_core_x = 0;
+    uint32_t start_core_y = 0;
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_mcast_cores = compute_with_storage_grid_size.x * compute_with_storage_grid_size.y;
+
+    CoreCoord top_left_core = {(std::size_t)start_core_x, (std::size_t)start_core_y};
+    CoreCoord bottom_right_core = {
+        (std::size_t)start_core_x + compute_with_storage_grid_size.x - 1,
+        (std::size_t)start_core_y + compute_with_storage_grid_size.y - 1};
+    auto top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
+    auto bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
+
+    // in1 is the reader of weights/output writer, and we choose to make it use the optimized reader noc
+    tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+    tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+
+    CoreCoord start_core_noc = top_left_core_physical;
+    CoreCoord end_core_noc = bottom_right_core_physical;
+    if (in0_noc == tt::tt_metal::NOC::NOC_1) {
+        std::swap(start_core_noc, end_core_noc);
+    }
+
+    // get the dram readers
+    std::vector<CoreCoord> all_worker_cores_ordered;
+    CoreRangeSet all_worker_cores;
+    get_optimal_dram_bank_to_reader_assignment(device, all_worker_cores_ordered, all_worker_cores, in1_noc);
+
+    // dram banks
+    uint32_t num_dram_banks = all_worker_cores_ordered.size();
+
+    // Remove cores assigned to padding-only DRAM banks from the workers category
+    uint32_t in1_shard_width_tiles = in1_tensor.shard_spec()->shape[1] / in1_tile.get_tile_shape()[1];
+    uint32_t in1_tensor_padded_width_tiles = in1_shard_width_tiles * num_dram_banks;
+
+    if (in1_tensor_padded_width_tiles > N) {
+        uint32_t padding_width_tiles = in1_tensor_padded_width_tiles - N;
+        uint32_t only_padding_banks = padding_width_tiles / in1_shard_width_tiles;
+        TT_FATAL(
+            only_padding_banks < all_worker_cores_ordered.size(),
+            "Padding banks count {} must be less than workers count {}",
+            only_padding_banks,
+            all_worker_cores_ordered.size());
+        for (uint32_t i = 0; i < only_padding_banks; ++i) {
+            all_worker_cores_ordered.pop_back();
+        }
+        std::set<CoreRange> new_workers_set;
+        for (const auto& worker_core : all_worker_cores_ordered) {
+            new_workers_set.insert(CoreRange(worker_core));
+        }
+        all_worker_cores = CoreRangeSet(new_workers_set);
+        num_dram_banks = all_worker_cores_ordered.size();
+    }
+
+    uint32_t per_core_N_compute = div_up(N, num_dram_banks);
+    uint32_t per_core_N_in1_sender = per_core_N_compute;
+
+    auto subblock_hw = operations::experimental::quasar::matmul::bmm_op_utils_qsr::get_matmul_subblock_params(
+        per_core_M, per_core_N_compute, false, false, fp32_dest_acc_en);
+    auto out_subblock_h = std::get<0>(subblock_hw);
+    auto out_subblock_w = std::get<1>(subblock_hw);
+
+    uint32_t max_subblock_w = fp32_dest_acc_en ? 4 : 8;
+    if (out_subblock_h == 1 and out_subblock_w < max_subblock_w) {
+        uint32_t num_subblock_w_per_core_N = per_core_N_compute / out_subblock_w;
+        uint32_t num_iter = max_subblock_w - out_subblock_w;
+        uint32_t new_out_subblock_w = out_subblock_w;
+        uint32_t preferred_out_subblock_w = out_subblock_w;
+
+        for (uint32_t i = 0; i < num_iter; ++i) {
+            new_out_subblock_w += 1;
+            uint32_t new_num_subblock_w_per_core_N = (per_core_N_compute + new_out_subblock_w - 1) / new_out_subblock_w;
+
+            if (new_num_subblock_w_per_core_N < num_subblock_w_per_core_N) {
+                num_subblock_w_per_core_N = new_num_subblock_w_per_core_N;
+                preferred_out_subblock_w = new_out_subblock_w;
+            }
+        }
+        out_subblock_w = preferred_out_subblock_w;
+        per_core_N_compute = out_subblock_w * num_subblock_w_per_core_N;
+    }
+
+    // Number of in1 columns in the last subblock that are actually backed by reader-pushed tiles.
+    // When the subblock-width optimization above pads per_core_N_compute beyond per_core_N_in1_sender,
+    // the last subblock has out_subblock_w lanes total but only this many lanes correspond to in1
+    // tiles the reader pushed into cb_in1; the rest are padded columns that the output writer drops.
+    // The compute kernel uses this to narrow the matmul_block call for the last subblock so it never
+    // reads cb_in1 tile indices that were not produced for the current block.
+    // When no padding occurs (per_core_N_compute == per_core_N_in1_sender) this equals out_subblock_w.
+    uint32_t last_subblock_w_valid = out_subblock_w - (per_core_N_compute - per_core_N_in1_sender);
+
+    uint32_t num_blocks = K / in0_block_w;
+    bool packer_l1_acc_en = packer_l1_acc && num_blocks > 1;
+
+    tt::DataFormat interm0_data_format = packer_l1_acc_en
+                                             ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)
+                                             : (fp32_dest_acc_en ? tt::DataFormat::Float32 : output_data_format);
+
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    uint32_t bias_single_tile_size = bias_tile.get_tile_size(bias_data_format);
+    uint32_t output_single_tile_size = output_tile.get_tile_size(output_data_format);
+    uint32_t interm0_single_tile_size = output_tile.get_tile_size(interm0_data_format);
+
+    // in1/bias are DRAM sharded with one tile per page; the allocator pads each page to the DRAM
+    // alignment (e.g. bfp8 32x16 tile = 544B padded to 576B on Blackhole's 64B alignment). The
+    // reader copies blocks contiguously from DRAM, so the CB must hold tiles at the padded stride.
+    const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
+    uint32_t in1_aligned_tile_size = tt::align(in1_single_tile_size, dram_alignment);
+    uint32_t bias_aligned_tile_size = tt::align(bias_single_tile_size, dram_alignment);
+
+    uint32_t in0_block_tiles = per_core_M * in0_block_w;
+    uint32_t in0_CB_tiles = in0_block_tiles;
+    if (B * num_blocks > 1) {
+        in0_CB_tiles = in0_CB_tiles * 2;  // double buffer
+    }
+    uint32_t in0_CB_size = in0_CB_tiles * in0_single_tile_size;
+    uint32_t in1_block_tiles = per_core_N_in1_sender * in0_block_w;
+    uint32_t in1_CB_tiles = in1_block_tiles;
+    if (B * num_blocks > 1) {
+        in1_CB_tiles = in1_CB_tiles * 3;  // triple buffer
+    }
+    uint32_t in1_CB_size = in1_CB_tiles * in1_aligned_tile_size;
+
+    uint32_t out_block_tiles = per_core_M * per_core_N_compute;
+    uint32_t out_CB_tiles = out_block_tiles;
+    uint32_t out_CB_size = out_CB_tiles * output_single_tile_size;
+    uint32_t interm0_CB_size = out_CB_tiles * interm0_single_tile_size;
+
+    uint32_t out_reshard_block_tiles = per_core_M * per_core_N_storage;
+    uint32_t out_reshard_CB_tiles = out_reshard_block_tiles;
+    uint32_t out_reshard_CB_size = out_reshard_CB_tiles * output_single_tile_size;
+
+    uint32_t in0_shard_width_in_tiles = in0_tensor.shard_spec()->shape[1] / in0_tile.get_tile_shape()[1];
+    uint32_t in2_block_tiles = per_core_M * in0_shard_width_in_tiles;
+    uint32_t in2_CB_tiles = in2_block_tiles;
+    uint32_t in2_CB_size = in2_CB_tiles * in0_single_tile_size;
+
+    uint32_t in3_CB_tiles = per_core_N_compute;
+    uint32_t in3_CB_size = in3_CB_tiles * bias_aligned_tile_size;
+
+    // get the max page size based on num tiles
+    uint32_t in1_buffer_page_size, in1_buffer_num_pages;
+    get_max_page_size_and_num_pages(
+        device, in1_block_tiles, in1_aligned_tile_size, in1_buffer_page_size, in1_buffer_num_pages);
+
+    uint32_t bias_buffer_page_size, bias_buffer_num_pages;
+    get_max_page_size_and_num_pages(
+        device, per_core_N_in1_sender, bias_aligned_tile_size, bias_buffer_page_size, bias_buffer_num_pages);
+
+    uint32_t num_worker_cores = num_dram_banks;
+
+    // move conflict coord from mcast receiver to mcast sender
+    std::vector<CoreCoord> input_all_storage_cores_vec = corerange_to_cores(input_all_storage_cores);
+    std::vector<CoreCoord> all_worker_cores_vec = corerange_to_cores(all_worker_cores);
+    std::vector<CoreCoord> storage_worker_common;
+    move_common_entries(input_all_storage_cores_vec, all_worker_cores_vec, storage_worker_common);
+
+    std::vector<CoreRange> input_all_storage_cores_range;
+    input_all_storage_cores_range.reserve(input_all_storage_cores_vec.size());
+    std::transform(
+        input_all_storage_cores_vec.begin(),
+        input_all_storage_cores_vec.end(),
+        std::back_inserter(input_all_storage_cores_range),
+        [](const CoreCoord& coord) { return CoreRange(coord); });
+
+    std::vector<CoreRange> all_worker_cores_range;
+    all_worker_cores_range.reserve(all_worker_cores_vec.size());
+    std::transform(
+        all_worker_cores_vec.begin(),
+        all_worker_cores_vec.end(),
+        std::back_inserter(all_worker_cores_range),
+        [](const CoreCoord& coord) { return CoreRange(coord); });
+
+    std::set<CoreRange> input_all_storage_cores_set(
+        input_all_storage_cores_range.begin(), input_all_storage_cores_range.end());
+    std::set<CoreRange> all_worker_cores_set(all_worker_cores_range.begin(), all_worker_cores_range.end());
+    CoreRangeSet mcast_senders = CoreRangeSet(input_all_storage_cores_set);
+    CoreRangeSet mcast_receivers = CoreRangeSet(all_worker_cores_set);
+
+    // all cores
+    std::set<CoreRange> all_cores_set;
+    all_cores_set.insert(mcast_senders.ranges().begin(), mcast_senders.ranges().end());
+    all_cores_set.insert(mcast_receivers.ranges().begin(), mcast_receivers.ranges().end());
+    CoreRangeSet all_cores = CoreRangeSet(all_cores_set);
+
+    // grid bounding box
+    CoreRange bounding_box = all_cores.bounding_box();
+    std::set<CoreRange> bounding_box_set;
+    bounding_box_set.insert(bounding_box);
+    CoreRangeSet all_cores_in_rect_grid(bounding_box_set);
+    std::vector<CoreCoord> all_cores_in_rect_grid_vec = corerange_to_cores(all_cores_in_rect_grid);
+
+    // Semaphore IDs (manually assigned, matching CreateSemaphore sequential allocation)
+    uint32_t in0_mcast_sender_semaphore_id = 0;
+    uint32_t in0_mcast_receiver_semaphore_id = 1;
+    uint32_t in0_mcast_sender_valid_semaphore_id = 2;
+
+    uint32_t in0_num_subblocks = (per_core_M / out_subblock_h);
+    uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
+
+    uint32_t num_blocks_per_shard = num_blocks / input_all_storage_cores_vec.size();
+    if (per_core_M > 1) {
+        TT_FATAL(
+            num_blocks_per_shard == 1,
+            "currently not support per_core_M larger than 1, while split one shard into multiple blocks (per_core_M "
+            "{}, num_blocks_per_shard {})",
+            per_core_M,
+            num_blocks_per_shard);
+    }
+
+    std::vector<uint32_t> in0_sender_compile_time_args = {
+        (std::uint32_t)in0_block_num_tiles,                         // in0_block_num_tiles
+        (std::uint32_t)in0_block_num_tiles * in0_single_tile_size,  // in0_block_size_bytes
+        (std::uint32_t)in0_last_ktile_w,                            // in0_last_ktile_w
+        (std::uint32_t)0,                                           // in0_last_ktile_h (transpose not supported)
+        // in0 mcast args
+        (std::uint32_t)in0_mcast_sender_semaphore_id,
+        (std::uint32_t)in0_mcast_receiver_semaphore_id,
+        (std::uint32_t)num_worker_cores,  // in0_mcast_num_dests
+        (std::uint32_t)num_mcast_cores,   // in0_mcast_num_cores
+        // block
+        (std::uint32_t)num_blocks,
+        // mcast noc coords
+        (std::uint32_t)start_core_noc.x,
+        (std::uint32_t)start_core_noc.y,
+        (std::uint32_t)end_core_noc.x,
+        (std::uint32_t)end_core_noc.y,
+        // semaphore valid
+        (std::uint32_t)in0_mcast_sender_valid_semaphore_id,
+        //
+        (std::uint32_t)num_blocks_per_shard,
+        (std::uint32_t)in0_block_w};
+
+    std::vector<uint32_t> in1_sender_writer_compile_time_args = {
+        (std::uint32_t)in1_buffer_page_size,
+        (std::uint32_t)in1_buffer_num_pages,
+        // in1 block args
+        (std::uint32_t)per_core_N_compute,                   // in1_block_w (padded, used only for bias CB)
+        (std::uint32_t)per_core_N_in1_sender * in0_block_w,  // in1_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,                                    // num_blocks
+        (std::uint32_t)out_block_tiles,                               // out_block_num_tiles
+        (std::uint32_t)per_core_N_compute * output_single_tile_size,  // out_tensor_stride_w_bytes
+        (std::uint32_t)per_core_N_storage * output_single_tile_size,  // out_reshard_tensor_stride_w_bytes
+        (std::uint32_t)per_core_M};
+    if (bias.has_value()) {
+        in1_sender_writer_compile_time_args.push_back(bias_buffer_page_size);
+        in1_sender_writer_compile_time_args.push_back(bias_buffer_num_pages);
+        in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);
+    }
+
+    std::map<std::string, std::string> mm_kernel_defines;
+    std::map<std::string, std::string> mm_kernel_in0_sender_define;
+    std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
+    if (bias.has_value()) {
+        mm_kernel_defines["FUSE_BIAS"] = "1";
+        mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
+    }
+    if (fused_activation.has_value()) {
+        if (fused_activation.value().op_type == UnaryOpType::RELU) {
+            mm_kernel_defines["PACK_RELU"] = "1";
+        } else {
+            mm_kernel_defines["SFPU_ACTIVATION"] = "1";
+        }
+    }
+    if (packer_l1_acc_en) {
+        mm_kernel_defines["PACKER_L1_ACC"] = "1";
+    }
+    if (fp32_dest_acc_en) {
+        mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    mm_kernel_in1_sender_writer_defines["OUT_SHARDED"] = "1";
+    mm_kernel_in1_sender_writer_defines["SKIP_MCAST"] = "1";
+
+    if (skip_compute) {
+        mm_kernel_defines["SKIP_COMPUTE"] = "1";
+    }
+    if (skip_in0_mcast) {
+        mm_kernel_in0_sender_define["SKIP_MCAST"] = "1";
+    }
+    if (skip_write_back) {
+        mm_kernel_in1_sender_writer_defines["SKIP_WRITE_BACK"] = "1";
+    }
+    mm_kernel_defines["MATMUL_DRAM_SHARDED"] = "1";
+    if (in1_transpose_tile) {
+        mm_kernel_defines["IN1_TRANSPOSE_TILE"] = "1";
+    }
+
+    const uint32_t num_compute_cores = all_cores_in_rect_grid.num_cores();
+    ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
+        device->arch(), num_compute_cores, mm_kernel_defines);
+    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
+        device->arch(), num_compute_cores, mm_kernel_defines, throttle_level);
+
+    // Helper to convert std::map defines to KernelDescriptor::Defines (vector of pairs)
+    auto map_to_defines = [](const std::map<std::string, std::string>& m) -> KernelDescriptor::Defines {
+        KernelDescriptor::Defines result;
+        result.reserve(m.size());
+        for (const auto& [k, v] : m) {
+            result.emplace_back(k, v);
+        }
+        return result;
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Build Kernel Descriptors
+    ////////////////////////////////////////////////////////////////////////////
+
+    // in0 sender kernel (reader - RISCV_1)
+    KernelDescriptor in0_sender_kernel_desc;
+    in0_sender_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+        "reader_bmm_tile_layout_in0_sender_dram_sharded.cpp";
+    in0_sender_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    in0_sender_kernel_desc.core_ranges = all_cores_in_rect_grid;
+    in0_sender_kernel_desc.compile_time_args = in0_sender_compile_time_args;
+    in0_sender_kernel_desc.defines = map_to_defines(mm_kernel_in0_sender_define);
+    in0_sender_kernel_desc.named_compile_time_args = {
+        {"cb_in0", tt::CBIndex::c_0},
+        {"cb_in0_sharded", tt::CBIndex::c_2},
+    };
+    in0_sender_kernel_desc.config =
+        DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = in0_noc};
+
+    // in1 sender/writer kernel (writer - RISCV_0)
+    KernelDescriptor in1_sender_writer_kernel_desc;
+    in1_sender_writer_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+        "reader_bmm_tile_layout_in1_sender_dram_sharded.cpp";
+    in1_sender_writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    in1_sender_writer_kernel_desc.core_ranges = all_cores_in_rect_grid;
+    in1_sender_writer_kernel_desc.compile_time_args = in1_sender_writer_compile_time_args;
+    in1_sender_writer_kernel_desc.defines = map_to_defines(mm_kernel_in1_sender_writer_defines);
+    in1_sender_writer_kernel_desc.named_compile_time_args = {
+        {"cb_in1", tt::CBIndex::c_1},
+        {"cb_bias", tt::CBIndex::c_3},
+        {"cb_out", tt::CBIndex::c_4},
+        {"cb_out_reshard", tt::CBIndex::c_6},
+    };
+    in1_sender_writer_kernel_desc.config =
+        DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = in1_noc};
+
+    // Compute kernel
+    uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
+    uint32_t in1_num_subblocks = (per_core_N_compute / out_subblock_w);
+    uint32_t in1_per_core_w = per_core_N_in1_sender;
+    uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
+
+    std::vector<uint32_t> compute_kernel_args = {
+        in0_block_w,             // in0_block_w
+        in0_num_subblocks,       // in0_num_subblocks
+        in0_block_num_tiles,     // in0_block_num_tiles
+        in0_subblock_num_tiles,  // in0_subblock_num_tiles
+
+        in1_num_subblocks,  // in1_num_subblocks
+        in1_block_tiles,    // in1_block_num_tiles
+        in1_per_core_w,     // in1_per_core_w
+
+        num_blocks,  // num_blocks
+        1,           // out_num_blocks_x
+        1,           // out_num_blocks_y
+
+        out_subblock_h,          // out_subblock_h
+        out_subblock_w,          // out_subblock_w
+        out_subblock_num_tiles,  // out_subblock_num_tiles
+        B,                       // batch
+        out_block_tiles,         // out_block_num_tiles
+
+        untilize_out,  // untilize_out
+        false,         // get_batch_from_reader
+        false,         // in0_transpose_tile
+    };
+    if (bias.has_value()) {
+        compute_kernel_args.push_back(row_broadcast_bias ? 1u : 0u);
+    }
+
+    KernelDescriptor compute_kernel_desc;
+    compute_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/"
+        "bmm_large_block_zm_fused_bias_activation.cpp";
+    compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_kernel_desc.core_ranges = all_cores_in_rect_grid;
+    compute_kernel_desc.compile_time_args = compute_kernel_args;
+    compute_kernel_desc.defines = map_to_defines(mm_kernel_defines);
+    {
+        KernelDescriptor::NamedCompileTimeArgs named_compile_args = {
+            {"cb_in0", tt::CBIndex::c_0},
+            {"cb_in1", tt::CBIndex::c_1},
+            {"cb_bias", tt::CBIndex::c_3},
+            {"cb_out", tt::CBIndex::c_4},
+            {"cb_intermed0", tt::CBIndex::c_5},
+            {"cb_in0_intermediate", tt::CBIndex::c_8},
+            {"cb_in1_intermediate", tt::CBIndex::c_9},
+            {"cb_in0_transposed", tt::CBIndex::c_10},
+            {"bias_ntiles", per_core_N_compute},
+            {"last_subblock_w_valid", last_subblock_w_valid},
+        };
+        if (fused_activation.has_value() && fused_activation.value().op_type != UnaryOpType::RELU) {
+            using ttnn::operations::experimental::quasar::matmul::utilities::get_activation_params;
+            const auto params = get_activation_params(fused_activation.value());
+            named_compile_args.push_back({"activation_type", static_cast<uint32_t>(params.type)});
+            named_compile_args.push_back({"activation_param0", params.param0});
+            named_compile_args.push_back({"activation_param1", params.param1});
+            named_compile_args.push_back({"activation_param2", params.param2});
+        }
+        compute_kernel_desc.named_compile_time_args = std::move(named_compile_args);
+    }
+    compute_kernel_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .math_approx_mode = math_approx_mode,
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Build CBDescriptors
+    ////////////////////////////////////////////////////////////////////////////
+    ProgramDescriptor desc;
+
+    tt::tt_metal::TileDescriptor in0_tile_desc{in0_tile};
+    tt::tt_metal::TileDescriptor in1_tile_desc{in1_tile};
+    tt::tt_metal::TileDescriptor bias_tile_desc{bias_tile};
+    tt::tt_metal::TileDescriptor output_tile_desc{output_tile};
+
+    // CB 0: in0
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in0_CB_size;
+        cb_desc.core_ranges = all_cores_in_rect_grid;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_0,
+            .data_format = in0_data_format,
+            .page_size = in0_single_tile_size,
+            .tile = in0_tile_desc});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 1: in1
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in1_CB_size;
+        cb_desc.core_ranges = all_cores_in_rect_grid;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_1,
+            .data_format = in1_data_format,
+            .page_size = in1_aligned_tile_size,
+            .tile = in1_tile_desc});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 2: in0 sharded (backed by in0_buffer)
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in2_CB_size;
+        cb_desc.core_ranges = all_cores_in_rect_grid;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_2,
+            .data_format = in0_data_format,
+            .page_size = in0_single_tile_size,
+            .tile = in0_tile_desc});
+        cb_desc.tensor = &in0_tensor;
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 4 and CB 5: output and intermediate
+    if ((interm0_data_format != output_data_format) || (untilize_out && (in1_num_subblocks > 1))) {
+        // Separate output and intermediate CBs
+        {
+            CBDescriptor cb_desc;
+            cb_desc.total_size = out_CB_size;
+            cb_desc.core_ranges = all_cores_in_rect_grid;
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = tt::CBIndex::c_4,
+                .data_format = output_data_format,
+                .page_size = output_single_tile_size,
+                .tile = output_tile_desc});
+            desc.cbs.push_back(std::move(cb_desc));
+        }
+        {
+            CBDescriptor cb_desc;
+            cb_desc.total_size = interm0_CB_size;
+            cb_desc.core_ranges = all_cores_in_rect_grid;
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = tt::CBIndex::c_5,
+                .data_format = interm0_data_format,
+                .page_size = interm0_single_tile_size,
+                .tile = output_tile_desc});
+            desc.cbs.push_back(std::move(cb_desc));
+        }
+    } else {
+        // share buffer
+        CBDescriptor cb_desc;
+        cb_desc.total_size = out_CB_size;
+        cb_desc.core_ranges = all_cores_in_rect_grid;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_4,
+            .data_format = output_data_format,
+            .page_size = output_single_tile_size,
+            .tile = output_tile_desc});
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_5,
+            .data_format = interm0_data_format,
+            .page_size = interm0_single_tile_size,
+            .tile = output_tile_desc});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 6: resharded output (backed by out_buffer)
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = out_reshard_CB_size;
+        cb_desc.core_ranges = all_cores_in_rect_grid;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_6,
+            .data_format = output_data_format,
+            .page_size = output_single_tile_size,
+            .tile = output_tile_desc});
+        cb_desc.tensor = &out_tensor;
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 3: bias
+    if (bias.has_value()) {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in3_CB_size;
+        cb_desc.core_ranges = all_cores_in_rect_grid;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_3,
+            .data_format = bias_data_format,
+            .page_size = bias_aligned_tile_size,
+            .tile = bias_tile_desc});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Semaphore Descriptors
+    ////////////////////////////////////////////////////////////////////////////
+    desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+        .id = in0_mcast_sender_semaphore_id, .core_ranges = all_cores_in_rect_grid, .initial_value = INVALID});
+    desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+        .id = in0_mcast_receiver_semaphore_id, .core_ranges = all_cores_in_rect_grid, .initial_value = INVALID});
+    desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+        .id = in0_mcast_sender_valid_semaphore_id, .core_ranges = all_cores_in_rect_grid, .initial_value = VALID});
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Runtime Args (per-core loop)
+    ////////////////////////////////////////////////////////////////////////////
+
+    std::vector<uint32_t> in0_mcast_sender_noc_x;
+    std::vector<uint32_t> in0_mcast_sender_noc_y;
+    std::vector<CoreCoord> mcast_senders_coords = corerange_to_cores(mcast_senders);
+    std::sort(mcast_senders_coords.begin(), mcast_senders_coords.end(), [](const CoreCoord& a, const CoreCoord& b) {
+        if (a.y != b.y) {
+            return a.y < b.y;
+        }
+        return a.x < b.x;
+    });
+    in0_mcast_sender_noc_x.reserve(mcast_senders_coords.size());
+    for (auto core : mcast_senders_coords) {
+        in0_mcast_sender_noc_x.push_back((std::uint32_t)device->worker_core_from_logical_core(core).x);
+    }
+    in0_mcast_sender_noc_y.reserve(mcast_senders_coords.size());
+    for (auto core : mcast_senders_coords) {
+        in0_mcast_sender_noc_y.push_back((std::uint32_t)device->worker_core_from_logical_core(core).y);
+    }
+
+    // in0 sender runtime args (mcast senders)
+    uint32_t sender_id = 0;
+    for (auto core : mcast_senders_coords) {
+        std::vector<uint32_t> mm_in0_sender_args;
+
+        uint32_t worker_core_type;
+        if (find(storage_worker_common.begin(), storage_worker_common.end(), core) != storage_worker_common.end()) {
+            worker_core_type = 2;
+        } else {
+            worker_core_type = 1;
+        }
+
+        mm_in0_sender_args.push_back((std::uint32_t)worker_core_type);
+        mm_in0_sender_args.push_back((std::uint32_t)sender_id);
+        mm_in0_sender_args.push_back(
+            (std::uint32_t)((core == input_all_storage_cores_vec.back()) and (in0_last_ktile_w > 0)));
+        mm_in0_sender_args.insert(
+            mm_in0_sender_args.end(), in0_mcast_sender_noc_x.begin(), in0_mcast_sender_noc_x.end());
+        mm_in0_sender_args.insert(
+            mm_in0_sender_args.end(), in0_mcast_sender_noc_y.begin(), in0_mcast_sender_noc_y.end());
+
+        in0_sender_kernel_desc.runtime_args.emplace_back(core, mm_in0_sender_args);
+        sender_id++;
+    }
+
+    // in0 sender runtime args (mcast receivers)
+    std::vector<CoreCoord> mcast_receiver_coords = corerange_to_cores(mcast_receivers);
+    for (auto core : mcast_receiver_coords) {
+        std::vector<uint32_t> mm_in0_receiver_args;
+        uint32_t worker_core_type = 3;
+        mm_in0_receiver_args.push_back((std::uint32_t)worker_core_type);
+        mm_in0_receiver_args.push_back((std::uint32_t)0);
+        mm_in0_receiver_args.push_back((std::uint32_t)0);  // in0_last_ktile_w
+        mm_in0_receiver_args.insert(
+            mm_in0_receiver_args.end(), in0_mcast_sender_noc_x.begin(), in0_mcast_sender_noc_x.end());
+        mm_in0_receiver_args.insert(
+            mm_in0_receiver_args.end(), in0_mcast_sender_noc_y.begin(), in0_mcast_sender_noc_y.end());
+
+        in0_sender_kernel_desc.runtime_args.emplace_back(core, mm_in0_receiver_args);
+    }
+
+    // in0 sender runtime args (idle cores in rect grid)
+    for (auto core : all_cores_in_rect_grid_vec) {
+        if (std::find(mcast_senders_coords.begin(), mcast_senders_coords.end(), core) == mcast_senders_coords.end() and
+            std::find(mcast_receiver_coords.begin(), mcast_receiver_coords.end(), core) ==
+                mcast_receiver_coords.end()) {
+            std::vector<uint32_t> mm_in0_idle_args;
+            uint32_t worker_core_type = 0;
+            mm_in0_idle_args.push_back((std::uint32_t)worker_core_type);
+
+            in0_sender_kernel_desc.runtime_args.emplace_back(core, mm_in0_idle_args);
+        }
+    }
+
+    // Compute and in1 sender/writer runtime args
+    uint32_t bank_id = 0;
+    std::vector<uint32_t> bank_ids;
+    uint32_t curr_storage_core_idx = 0;
+    uint32_t per_core_N_storage_curr_stride = 0;
+
+    uint32_t worker_core_stride = 0;
+    uint32_t storage_core_stride = 0;
+    uint32_t curr_worker_core = 0;
+    uint32_t curr_storage_core = 0;
+
+    std::vector<uint32_t> output_noc_x;
+    std::vector<uint32_t> output_noc_y;
+    std::vector<CoreCoord> output_coords = corerange_to_cores(output_all_storage_cores, std::nullopt, true);
+    output_noc_x.reserve(output_coords.size());
+    for (auto core : output_coords) {
+        output_noc_x.push_back((std::uint32_t)device->worker_core_from_logical_core(core).x);
+    }
+    output_noc_y.reserve(output_coords.size());
+    for (auto core : output_coords) {
+        output_noc_y.push_back((std::uint32_t)device->worker_core_from_logical_core(core).y);
+    }
+
+    uint32_t num_cores_written_back = (N + per_core_N_storage - 1) / per_core_N_storage;
+    uint32_t expected_max_total_width = num_cores_written_back * per_core_N_storage;
+    uint32_t total_tensor_width_written_back = 0;
+
+    // For all cores in the rect grid, set compute and in1 rt args for non-worker cores
+    for (auto core : all_cores_in_rect_grid_vec) {
+        if (std::find(all_worker_cores.ranges().begin(), all_worker_cores.ranges().end(), core) ==
+            all_worker_cores.ranges().end()) {  // not worker
+            bool is_worker_core = false;
+            std::vector<uint32_t> mm_in1_sender_writer_args;
+            mm_in1_sender_writer_args.push_back((std::uint32_t)is_worker_core);
+            in1_sender_writer_kernel_desc.runtime_args.emplace_back(core, mm_in1_sender_writer_args);
+
+            std::vector<uint32_t> mm_compute_args;
+            mm_compute_args.push_back((std::uint32_t)is_worker_core);
+            compute_kernel_desc.runtime_args.emplace_back(core, mm_compute_args);
+        } else {
+            bool is_worker_core = true;
+            std::vector<uint32_t> mm_compute_args;
+            mm_compute_args.push_back((std::uint32_t)is_worker_core);
+            compute_kernel_desc.runtime_args.emplace_back(core, mm_compute_args);
+        }
+    }
+
+    // Worker cores: in1 sender/writer runtime args
+    for (uint32_t i = 0; i < all_worker_cores_ordered.size(); ++i) {
+        auto core = all_worker_cores_ordered[i];
+
+        bool is_worker_core = true;
+        std::vector<uint32_t> mm_in1_sender_writer_args;
+        mm_in1_sender_writer_args.push_back((std::uint32_t)is_worker_core);
+        mm_in1_sender_writer_args.push_back(in1_tensor.address());  // [1]: will be replaced by Buffer*
+        mm_in1_sender_writer_args.push_back(bias.has_value() ? bias->address() : 0u);  // [2]: may be replaced
+
+        uint32_t vc = bank_id & 0x3;
+        bank_ids.push_back(bank_id);
+        for (uint32_t j = 0; j < i; ++j) {
+            auto core_prev = all_worker_cores_ordered[j];
+
+            if (core_prev.y == core.y and ((bank_id & 0x3) == (bank_ids[j] & 0x3))) {
+                vc = (vc + 1) & 0x3;
+                break;
+            }
+        }
+        mm_in1_sender_writer_args.push_back((std::uint32_t)bank_id);
+        mm_in1_sender_writer_args.push_back((std::uint32_t)vc);
+
+        bank_id = (bank_id + 1) % num_dram_banks;
+
+        if (per_core_N_in1_sender < per_core_N_storage) {
+            TT_FATAL(curr_storage_core_idx < num_cores_written_back, "Worker {} has no storage area assigned", core);
+
+            uint32_t remaining_per_core_N_storage = (per_core_N_storage - per_core_N_storage_curr_stride);
+            uint32_t per_core_N_reshard_1 = (remaining_per_core_N_storage > per_core_N_in1_sender)
+                                                ? per_core_N_in1_sender
+                                                : remaining_per_core_N_storage;
+            uint32_t per_core_N_reshard_2 = per_core_N_in1_sender - per_core_N_reshard_1;
+
+            if (per_core_N_reshard_2 != 0 and (curr_storage_core_idx + 1) < num_cores_written_back) {
+                mm_in1_sender_writer_args.push_back(2);
+            } else {
+                mm_in1_sender_writer_args.push_back(1);
+            }
+
+            mm_in1_sender_writer_args.push_back(
+                per_core_N_storage_curr_stride * output_single_tile_size);  // reshard_tensor_start_offset
+            mm_in1_sender_writer_args.push_back(
+                per_core_N_reshard_1 * output_single_tile_size);                       // per_core_N_reshard_bytes_1
+            mm_in1_sender_writer_args.push_back(output_noc_x[curr_storage_core_idx]);  // output_noc_x
+            mm_in1_sender_writer_args.push_back(output_noc_y[curr_storage_core_idx]);  // output_noc_y
+
+            total_tensor_width_written_back += per_core_N_reshard_1;
+
+            if (per_core_N_reshard_2 != 0 and (curr_storage_core_idx + 1) < num_cores_written_back) {
+                mm_in1_sender_writer_args.push_back(
+                    per_core_N_reshard_2 * output_single_tile_size);  // per_core_N_reshard_bytes_2
+                mm_in1_sender_writer_args.push_back(output_noc_x[curr_storage_core_idx + 1]);  // output_noc_x
+                mm_in1_sender_writer_args.push_back(output_noc_y[curr_storage_core_idx + 1]);  // output_noc_y
+
+                total_tensor_width_written_back += per_core_N_reshard_2;
+            }
+
+            curr_storage_core_idx += (per_core_N_storage_curr_stride + per_core_N_in1_sender) / per_core_N_storage;
+            per_core_N_storage_curr_stride =
+                (per_core_N_storage_curr_stride + per_core_N_in1_sender) % per_core_N_storage;
+        } else {
+            uint32_t num_cores_write_back = 0;
+
+            if (curr_storage_core < num_cores_written_back) {
+                num_cores_write_back++;
+
+                worker_core_stride = per_core_N_storage - storage_core_stride;
+
+                mm_in1_sender_writer_args.push_back(
+                    storage_core_stride * output_single_tile_size);  // reshard_tensor_start_offset
+                mm_in1_sender_writer_args.push_back(
+                    worker_core_stride * output_single_tile_size);                     // per_core_N_reshard
+                mm_in1_sender_writer_args.push_back(output_noc_x[curr_storage_core]);  // output_noc_x
+                mm_in1_sender_writer_args.push_back(output_noc_y[curr_storage_core]);  // output_noc_y
+
+                curr_storage_core += (storage_core_stride + worker_core_stride) / per_core_N_storage;
+                storage_core_stride = (storage_core_stride + worker_core_stride) % per_core_N_storage;
+
+                if (worker_core_stride >= per_core_N_in1_sender) {
+                    curr_worker_core += 1;
+                }
+
+                total_tensor_width_written_back += worker_core_stride;
+
+                while (curr_worker_core <= i and curr_storage_core < num_cores_written_back) {
+                    num_cores_write_back++;
+
+                    bool increment_worker_core = (worker_core_stride + per_core_N_storage) >= per_core_N_in1_sender;
+                    uint32_t current_worker_stride_total =
+                        increment_worker_core ? per_core_N_in1_sender : worker_core_stride + per_core_N_storage;
+                    uint32_t current_worker_write_back_tiles = current_worker_stride_total - worker_core_stride;
+
+                    if (increment_worker_core) {
+                        curr_worker_core += 1;
+                    }
+
+                    mm_in1_sender_writer_args.push_back(
+                        current_worker_write_back_tiles * output_single_tile_size);        // per_core_N_reshard
+                    mm_in1_sender_writer_args.push_back(output_noc_x[curr_storage_core]);  // output_noc_x
+                    mm_in1_sender_writer_args.push_back(output_noc_y[curr_storage_core]);  // output_noc_y
+
+                    total_tensor_width_written_back += current_worker_write_back_tiles;
+
+                    storage_core_stride = current_worker_write_back_tiles % per_core_N_storage;
+                    curr_storage_core += current_worker_write_back_tiles / per_core_N_storage;
+                    worker_core_stride = current_worker_stride_total;
+                }
+            }
+
+            mm_in1_sender_writer_args.insert(mm_in1_sender_writer_args.begin() + 5, num_cores_write_back);
+        }
+
+        // Build variant args: positions [1] and [2] are buffer addresses
+        std::vector<std::variant<uint32_t, std::reference_wrapper<const tt::tt_metal::MeshTensor>>> in1_writer_args(
+            mm_in1_sender_writer_args.begin(), mm_in1_sender_writer_args.end());
+        in1_writer_args[1] = in1_tensor;
+        if (bias.has_value()) {
+            in1_writer_args[2] = *bias;
+        }
+        in1_sender_writer_kernel_desc.emplace_runtime_args(core, in1_writer_args);
+        TT_FATAL(
+            mm_in1_sender_writer_args.size() >= 10,
+            "Kernel requires at least 10 runtime args, got {}",
+            mm_in1_sender_writer_args.size());
+    }
+
+    TT_FATAL(
+        total_tensor_width_written_back <= expected_max_total_width,
+        "more datums written back to sharded tensor, L1 corruption, expected: {}, actual: {}",
+        expected_max_total_width,
+        total_tensor_width_written_back);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Push Kernel Descriptors
+    ////////////////////////////////////////////////////////////////////////////
+    desc.kernels.push_back(std::move(in0_sender_kernel_desc));
+    desc.kernels.push_back(std::move(in1_sender_writer_kernel_desc));
+    desc.kernels.push_back(std::move(compute_kernel_desc));
+
+    return desc;
+}
+
+}  // namespace reuse_dram_sharded_optimized_helpers
+
+ProgramDescriptor MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory::create_descriptor(
+    const ttnn::prim::qsr::MatmulParams& operation_attributes,
+    const ttnn::prim::qsr::MatmulInputs& tensor_args,
+    std::vector<ttnn::Tensor>& tensor_return_value,
+    const std::optional<CoreRangeSet>& /*core_range_set*/) {
+    const auto& input_tensors = tensor_args.input_tensors;
+    const auto& optional_input_tensors = tensor_args.optional_input_tensors;
+    const auto& output_tensors = tensor_return_value;
+
+    const auto& a = input_tensors.at(0);
+    const auto& b = input_tensors.at(1).mesh_tensor();
+    const auto& bias = optional_input_tensors.at(0);
+    const auto& output = output_tensors.at(0);
+    const auto& ashape = a.padded_shape();
+    const auto& bshape = b.padded_shape();
+    auto in0_tile = a.tensor_spec().tile();
+    auto in1_tile = b.tensor_spec().tile();
+    auto in0_tile_shape = in0_tile.get_tile_shape();
+    auto in1_tile_shape = in1_tile.get_tile_shape();
+    auto output_tile = tt::tt_metal::Tile({in0_tile.get_tile_shape()[0], in1_tile.get_tile_shape()[1]});
+
+    // CB dataformats
+    tt::DataFormat in0_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
+    tt::DataFormat in1_data_format = tt::tt_metal::datatype_to_dataformat_converter(b.dtype());
+    tt::DataFormat output_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+
+    ttsl::optional_reference<const tt::tt_metal::MeshTensor> bias_mesh;
+    tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;
+    if (bias.has_value()) {
+        const auto& c = bias.value();
+        TT_FATAL(
+            c.storage_type() == StorageType::DEVICE,
+            "Bias tensor must be on device, got storage type: {}",
+            c.storage_type());
+        TT_FATAL(a.device() == c.device(), "Operands to matmul need to be on the same device!");
+
+        bias_mesh = c.mesh_tensor();
+        bias_data_format = tt::tt_metal::datatype_to_dataformat_converter(c.dtype());
+    }
+
+    const bool row_broadcast_bias =
+        operations::experimental::quasar::matmul::utilities::fused_matmul_bias_row_broadcastable(bias);
+
+    tt::tt_metal::IDevice* device = a.device();
+
+    TT_FATAL(
+        a.shard_spec().has_value() && output.shard_spec().has_value(), "Both input A and output must have shard specs");
+    CoreRangeSet input_all_cores_storage = a.shard_spec().value().grid;
+    CoreRangeSet output_all_cores_storage = output.shard_spec().value().grid;
+
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    const auto& a_mesh = a.mesh_tensor();
+    TT_FATAL(
+        a_mesh.mesh_buffer().device_local_size() % in0_single_tile_size == 0,
+        "Input A buffer size ({}) must be divisible by single tile size ({})",
+        a_mesh.mesh_buffer().device_local_size(),
+        in0_single_tile_size);
+    TT_FATAL(
+        b.mesh_buffer().device_local_size() % in1_single_tile_size == 0,
+        "Input B buffer size ({}) must be divisible by single tile size ({})",
+        b.mesh_buffer().device_local_size(),
+        in1_single_tile_size);
+
+    TT_FATAL(
+        ashape[-1] == bshape[-2],
+        "Dimension K (A.shape[-1] = {}, B.shape[-2] = {}) must match for matmul",
+        ashape[-1],
+        bshape[-2]);
+    TT_FATAL(
+        ashape[-2] % in0_tile_shape[0] == 0,
+        "A.shape[-2] ({}) must be divisible by tile shape[0] ({})",
+        ashape[-2],
+        in0_tile_shape[0]);
+    TT_FATAL(
+        ashape[-1] % in0_tile_shape[1] == 0,
+        "A.shape[-1] ({}) must be divisible by tile shape[1] ({})",
+        ashape[-1],
+        in0_tile_shape[1]);
+    TT_FATAL(
+        bshape[-2] % in1_tile_shape[0] == 0,
+        "B.shape[-2] ({}) must be divisible by tile shape[0] ({})",
+        bshape[-2],
+        in1_tile_shape[0]);
+    TT_FATAL(
+        bshape[-1] % in1_tile_shape[1] == 0,
+        "B.shape[-1] ({}) must be divisible by tile shape[1] ({})",
+        bshape[-1],
+        in1_tile_shape[1]);
+
+    const auto& compute_kernel_config = operation_attributes.compute_kernel_config.value();
+    const auto& program_config =
+        std::get<operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>(
+            operation_attributes.program_config.value());
+    const auto& in0_block_w = program_config.in0_block_w;
+    const auto& per_core_M = program_config.per_core_M;
+    const auto& per_core_N = program_config.per_core_N;
+    const auto& fused_activation = program_config.fused_activation;
+
+    const auto& untilize_out = operation_attributes.untilize_out;
+    const bool skip_compute = false;
+    const bool skip_in0_mcast = false;
+    const bool skip_write_back = false;
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), compute_kernel_config);
+
+    uint32_t B = 1;
+    uint32_t Mt = get_batch_size(ashape) * ashape[-2] / in0_tile_shape[0];
+    uint32_t Kt = ashape[-1] / in0_tile_shape[1];
+    uint32_t Nt = bshape[-1] / in1_tile_shape[1];
+    uint32_t in0_last_ktile_w = a.logical_shape()[-1] % in0_tile_shape[1];
+
+    TT_FATAL(Kt % in0_block_w == 0, "Kt ({}) must be divisible by in0_block_w ({})", Kt, in0_block_w);
+
+    const auto& output_mesh = output.mesh_tensor();
+
+    return reuse_dram_sharded_optimized_helpers::create_program_dram_sharded_descriptor(
+        device,
+        input_all_cores_storage,
+        output_all_cores_storage,
+        math_fidelity,
+        fp32_dest_acc_en,
+        math_approx_mode,
+        packer_l1_acc,
+        dst_full_sync_en,
+        ttnn::get_throttle_level(operation_attributes.compute_kernel_config),
+        B,
+        Mt,
+        Nt,
+        Kt,
+        in0_block_w,
+        in0_last_ktile_w,
+        per_core_M,
+        per_core_N,
+        fused_activation,
+        a_mesh,
+        b,
+        bias_mesh,
+        output_mesh,
+        in0_tile,
+        in1_tile,
+        bias.has_value() ? bias->tensor_spec().tile() : output_tile,
+        output_tile,
+        in0_data_format,
+        in1_data_format,
+        bias_data_format,
+        output_data_format,
+        untilize_out,
+        skip_compute,
+        skip_in0_mcast,
+        skip_write_back,
+        row_broadcast_bias);
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.hpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/matmul_device_operation_types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace ttnn::prim::qsr {
+
+struct MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const ttnn::prim::qsr::MatmulParams& operation_attributes,
+        const ttnn::prim::qsr::MatmulInputs& tensor_args,
+        std::vector<ttnn::Tensor>& tensor_return_value,
+        const std::optional<CoreRangeSet>& core_range_set = std::nullopt);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
@@ -1,0 +1,577 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#include "ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.hpp"
+
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/tt_align.hpp>
+#include "ttnn/operations/experimental/quasar/matmul/device/utilities/matmul_utilities.hpp"
+
+#include <map>
+#include <string>
+#include "ttnn/operations/compute_throttle_utils.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/tensor/shape/shape.hpp"
+
+using namespace tt;
+using tt::tt_metal::CBDescriptor;
+using tt::tt_metal::CBFormatDescriptor;
+using tt::tt_metal::ComputeConfigDescriptor;
+using tt::tt_metal::KernelDescriptor;
+using tt::tt_metal::ProgramDescriptor;
+using tt::tt_metal::ReaderConfigDescriptor;
+using tt::tt_metal::Tensor;
+using tt::tt_metal::WriterConfigDescriptor;
+
+namespace ttnn::prim::qsr {
+
+CoreRangeSet MatmulMultiCoreReuseOptimizedProgramFactory::default_core_range(IDevice* device) {
+    auto grid_size = device->compute_with_storage_grid_size();
+    return CoreRangeSet({CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1})});
+}
+
+tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::create_descriptor(
+    const ttnn::prim::qsr::MatmulParams& operation_attributes,
+    const ttnn::prim::qsr::MatmulInputs& tensor_args,
+    std::vector<ttnn::Tensor>& tensor_return_value,
+    const std::optional<CoreRangeSet>& core_range_set) {
+    TT_FATAL(operation_attributes.program_config.has_value(), "program_config must be provided for create_descriptor");
+    const auto& program_config = std::get<operations::experimental::quasar::matmul::MatmulMultiCoreReuseProgramConfig>(
+        operation_attributes.program_config.value());
+
+    TT_FATAL(operation_attributes.output_dtype.has_value(), "Output dtype should have been provided");
+    TT_FATAL(operation_attributes.compute_kernel_config.has_value(), "Compute kernel config should have been provided");
+    TT_FATAL(operation_attributes.bcast_batch.has_value(), "Bcast batch should have been provided");
+
+    const auto& a = tensor_args.input_tensors.at(0);
+    const auto& b = tensor_args.input_tensors.at(1);
+    const auto& output = tensor_return_value.at(0).mesh_tensor();
+
+    bool bcast_batch = operation_attributes.bcast_batch.value();
+    bool transpose_a = operation_attributes.transpose_a;
+    bool transpose_b = operation_attributes.transpose_b;
+    bool untilize_out = operation_attributes.untilize_out;
+
+    uint32_t in0_block_w = program_config.in0_block_w;
+    uint32_t out_subblock_h = program_config.out_subblock_h;
+    uint32_t out_subblock_w = program_config.out_subblock_w;
+    uint32_t per_core_M = program_config.per_core_M;
+    uint32_t per_core_N = program_config.per_core_N;
+
+    const auto& ashape =
+        operations::experimental::quasar::matmul::utilities::get_matmul_tensor_padded_shape(a, transpose_a);
+    const auto& bshape =
+        operations::experimental::quasar::matmul::utilities::get_matmul_tensor_padded_shape(b, transpose_b);
+    auto in0_tile = operations::experimental::quasar::matmul::utilities::get_matmul_tile(a, transpose_a);
+    auto in1_tile = operations::experimental::quasar::matmul::utilities::get_matmul_tile(b, transpose_b);
+
+    const auto& in0_buffer = a.mesh_tensor();
+    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(in0_buffer.dtype());
+    const auto& in1_buffer = b.mesh_tensor();
+    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(in1_buffer.dtype());
+    tt::DataFormat output_data_format =
+        tt_metal::datatype_to_dataformat_converter(operation_attributes.output_dtype.value());
+
+    tt_metal::IDevice* device = &in0_buffer.mutable_device();
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config.value());
+
+    if (fp32_dest_acc_en) {
+        TT_FATAL(
+            out_subblock_h * out_subblock_w <= 4,
+            "Total number of tiles in a subblock must be less than 4 when in fp32_dest_acc mode");
+    }
+
+    uint32_t B = get_batch_size(ashape);
+    uint32_t Mt = operations::experimental::quasar::matmul::utilities::get_M_dim(ashape, in0_tile, false);
+    uint32_t Kt = operations::experimental::quasar::matmul::utilities::get_K_dim(ashape, in0_tile);
+    uint32_t Nt = operations::experimental::quasar::matmul::utilities::get_N_dim(bshape, in1_tile);
+    uint32_t M = Mt;
+    uint32_t N = Nt;
+    uint32_t K = Kt;
+
+    const auto ashape_logical =
+        operations::experimental::quasar::matmul::utilities::get_matmul_tensor_logical_shape(a, transpose_a);
+    // When transpose_a is true, the K dimension maps to the row dimension of the raw tile,
+    // which is already zero-padded during tile layout conversion. pad_last_ktile operates on
+    // columns, so applying it would incorrectly zero valid data that becomes output rows
+    // after the compute kernel transposes the tile.
+    const auto in0_last_ktile_w = transpose_a ? 0 : ashape_logical[-1] % in0_tile.get_width();
+    const auto in0_last_ktile_h = transpose_a ? ashape_logical[-1] % in0_tile.get_width() : 0;
+    TT_FATAL(
+        in0_last_ktile_w == 0 || in0_last_ktile_h == 0,
+        "At most one of in0_last_ktile_w ({}) and in0_last_ktile_h ({}) can be non-zero",
+        in0_last_ktile_w,
+        in0_last_ktile_h);
+
+    // Derived parameters
+    uint32_t batch_scale_factor = per_core_M > M ? per_core_M / M : 1;
+    uint32_t per_core_M_per_batch = per_core_M > M ? M : per_core_M;
+    uint32_t num_blocks = (K / in0_block_w);
+    bool packer_l1_acc_en = packer_l1_acc && (num_blocks > 2);
+
+    tt::DataFormat interm0_data_format = packer_l1_acc_en
+                                             ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)
+                                             : (fp32_dest_acc_en ? tt::DataFormat::Float32 : output_data_format);
+
+    bool in0_transpose_tile = in0_tile.get_transpose_of_faces() && in0_tile.get_transpose_within_face();
+    bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
+
+    auto output_tile = tt::tt_metal::Tile({in0_tile.get_height(), in1_tile.get_width()});
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    uint32_t output_single_tile_size = output_tile.get_tile_size(output_data_format);
+    uint32_t interm0_single_tile_size = output_tile.get_tile_size(interm0_data_format);
+
+    bool in0_is_sharded = in0_buffer.is_sharded();
+    bool in1_is_sharded = in1_buffer.is_sharded();
+    bool output_is_sharded = output.is_sharded();
+
+    // Tiles whose size is not a multiple of the DRAM alignment (e.g. bfp8 32x16 = 544B on Blackhole's
+    // 64B alignment) are padded to it in DRAM. The interleaved reader copies tiles at that padded
+    // stride, so the in0/in1 CBs must hold pages at the aligned stride and the reader/unpacker walk
+    // tiles at the same stride. This is a no-op when the tile is already aligned (all bf16 tiles,
+    // 32-wide bfp8, and everything on Wormhole's 32B alignment) and replaces the staging-CB workaround.
+    // Sharded CBs are backed by the tensor buffer and keep their natural page size.
+    const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
+    uint32_t in0_aligned_tile_size =
+        in0_is_sharded ? in0_single_tile_size : tt::align(in0_single_tile_size, dram_alignment);
+    uint32_t in1_aligned_tile_size =
+        in1_is_sharded ? in1_single_tile_size : tt::align(in1_single_tile_size, dram_alignment);
+
+    // CB sizes
+    uint32_t in0_block_num_tiles = per_core_M_per_batch * in0_block_w;
+    uint32_t in0_CB_tiles = in0_block_num_tiles;
+    if (in0_is_sharded) {
+        in0_CB_tiles = per_core_M * K;
+    } else {
+        in0_CB_tiles *= 2;
+    }
+    uint32_t in0_CB_size = in0_CB_tiles * in0_aligned_tile_size;
+    uint32_t in1_block_num_tiles = per_core_N * in0_block_w;
+    uint32_t in1_CB_tiles = in1_block_num_tiles;
+    if (in1_is_sharded) {
+        in1_CB_tiles *= num_blocks * batch_scale_factor;
+    } else {
+        in1_CB_tiles *= 2;
+    }
+    uint32_t in1_CB_size = in1_CB_tiles * in1_aligned_tile_size;
+    uint32_t out_block_tiles = per_core_M * per_core_N;
+    uint32_t out_CB_tiles = out_block_tiles;
+    uint32_t out_CB_size = out_CB_tiles * output_single_tile_size;
+    uint32_t interm0_CB_size = out_CB_tiles * interm0_single_tile_size;
+
+    // Compute kernel args
+    uint32_t in0_num_subblocks = (per_core_M_per_batch / out_subblock_h);
+    uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
+    uint32_t in1_num_subblocks = (per_core_N / out_subblock_w);
+    uint32_t in1_per_core_w = out_subblock_w * in1_num_subblocks;
+    uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
+    uint32_t out_num_subblocks_h = per_core_M_per_batch / out_subblock_h;
+    uint32_t out_num_subblocks_w = in1_num_subblocks;
+    uint32_t num_output_blocks_total = (B * M / per_core_M) * (N / per_core_N);
+
+    std::optional<tt::tt_metal::ShardSpec> shard_spec = std::nullopt;
+    if (in0_is_sharded) {
+        shard_spec = in0_buffer.shard_spec().value();
+    } else if (in1_is_sharded) {
+        shard_spec = in1_buffer.shard_spec().value();
+    } else if (output_is_sharded) {
+        shard_spec = output.shard_spec().value();
+    }
+
+    // Core splitting
+    uint32_t num_cores = 0, num_blocks_per_core_group_1 = 0, num_blocks_per_core_group_2 = 0;
+    CoreRangeSet all_cores, core_group_1, core_group_2;
+
+    if (shard_spec.has_value()) {
+        all_cores = shard_spec.value().grid;
+        num_cores = all_cores.num_cores();
+        core_group_1 = all_cores;
+        num_blocks_per_core_group_1 = num_output_blocks_total / num_cores * batch_scale_factor;
+    } else if (core_range_set.has_value()) {
+        std::tie(
+            num_cores,
+            all_cores,
+            core_group_1,
+            core_group_2,
+            num_blocks_per_core_group_1,
+            num_blocks_per_core_group_2) =
+            tt::tt_metal::split_work_to_cores(core_range_set.value(), num_output_blocks_total);
+        num_blocks_per_core_group_1 *= batch_scale_factor;
+        num_blocks_per_core_group_2 *= batch_scale_factor;
+    } else {
+        if (!program_config.allowed_worker_cores.has_value()) {
+            log_warning(
+                tt::LogOp,
+                "MatmulMultiCoreReuseOptimizedProgramFactory: program_config.allowed_worker_cores not populated; "
+                "falling back to compute_with_storage_grid_size. Callers that bypass ttnn::prim::qsr::matmul() should "
+                "invoke ttnn::operations::experimental::quasar::matmul::normalize_program_config() on the program "
+                "config first. This "
+                "will become a hard error in a future release.");
+        }
+        // Use the CoreRangeSet overload so the output core ranges carry the actual
+        // absolute coordinates (e.g. (4,0)-(7,0)) rather than always starting at (0,0).
+        if (program_config.allowed_worker_cores.has_value()) {
+            std::tie(
+                num_cores,
+                all_cores,
+                core_group_1,
+                core_group_2,
+                num_blocks_per_core_group_1,
+                num_blocks_per_core_group_2) =
+                tt::tt_metal::split_work_to_cores(program_config.allowed_worker_cores.value(), num_output_blocks_total);
+        } else {
+            CoreCoord grid = program_config.compute_with_storage_grid_size;
+            std::tie(
+                num_cores,
+                all_cores,
+                core_group_1,
+                core_group_2,
+                num_blocks_per_core_group_1,
+                num_blocks_per_core_group_2) = tt::tt_metal::split_work_to_cores(grid, num_output_blocks_total);
+        }
+        num_blocks_per_core_group_1 *= batch_scale_factor;
+        num_blocks_per_core_group_2 *= batch_scale_factor;
+    }
+    uint32_t g1_numcores = core_group_1.num_cores();
+    uint32_t num_evenly_divided_output_blocks = num_output_blocks_total / num_cores;
+    TT_FATAL(num_evenly_divided_output_blocks > 0, "Not all cores from core_range was used!");
+
+    const auto in0_tensor_stride_w = transpose_a ? M : 1;
+    const auto in0_tensor_stride_h = transpose_a ? 1 : K;
+    const auto in0_tensor_next_block_stride = in0_block_w * in0_tensor_stride_w;
+    const auto in1_tensor_stride_w = transpose_b ? K : 1;
+    const auto in1_tensor_stride_h = transpose_b ? 1 : N;
+    const auto in1_tensor_next_block_stride = in0_block_w * in1_tensor_stride_h;
+
+    // Compile time args for reader
+    std::vector<uint32_t> reader_compile_time_args = {
+        (std::uint32_t)in0_tensor_stride_w,
+        (std::uint32_t)in0_tensor_stride_h,
+        (std::uint32_t)in0_tensor_next_block_stride,
+        (std::uint32_t)in0_block_w,
+        (std::uint32_t)per_core_M_per_batch,
+        (std::uint32_t)in0_block_num_tiles,
+        (std::uint32_t)in0_last_ktile_w,
+        (std::uint32_t)in0_last_ktile_h,
+        (std::uint32_t)num_blocks,
+        (std::uint32_t)bcast_batch,
+        (std::uint32_t)M * K,
+    };
+    tt::tt_metal::TensorAccessorArgs(in0_buffer).append_to(reader_compile_time_args);
+
+    // Compile time args for reader/writer
+    std::vector<uint32_t> reader_writer_compile_time_args = {
+        (std::uint32_t)in1_tensor_stride_w,
+        (std::uint32_t)in1_tensor_stride_h,
+        (std::uint32_t)in1_tensor_next_block_stride,
+        (std::uint32_t)per_core_N,
+        (std::uint32_t)in0_block_w,
+        (std::uint32_t)in1_block_num_tiles,
+        (std::uint32_t)num_blocks,
+        (std::uint32_t)bcast_batch,
+        (std::uint32_t)K * N,
+        (std::uint32_t)1,
+        (std::uint32_t)N,
+        (std::uint32_t)out_subblock_w,
+        (std::uint32_t)out_subblock_h * N,
+        (std::uint32_t)out_subblock_w,
+        (std::uint32_t)out_subblock_h,
+        (std::uint32_t)(out_subblock_w * out_subblock_h),
+        (std::uint32_t)out_num_subblocks_w,
+        (std::uint32_t)out_num_subblocks_h,
+        (std::uint32_t)M * N,
+    };
+    tt::tt_metal::TensorAccessorArgs(in1_buffer).append_to(reader_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(output).append_to(reader_writer_compile_time_args);
+
+    // Reader defines
+    KernelDescriptor::Defines reader_defines;
+    KernelDescriptor::Defines reader_writer_defines;
+    if (in0_is_sharded) {
+        reader_defines.emplace_back("IN0_SHARDED", "1");
+    }
+    if (in1_is_sharded) {
+        reader_writer_defines.emplace_back("IN1_SHARDED", "1");
+    }
+    if (output_is_sharded) {
+        reader_writer_defines.emplace_back("OUT_SHARDED", "1");
+    }
+
+    // Named compile-time args for CB indices (enables fusion/chaining)
+    KernelDescriptor::NamedCompileTimeArgs cb_named_args = {
+        {"cb_in0", tt::CBIndex::c_0},
+        {"cb_in1", tt::CBIndex::c_1},
+        {"cb_bias", tt::CBIndex::c_3},
+        {"cb_out", tt::CBIndex::c_4},
+        {"cb_intermed0", tt::CBIndex::c_5},
+        {"cb_in0_transposed", tt::CBIndex::c_10},
+    };
+
+    // Compute kernel compile time args (group 1)
+    std::vector<uint32_t> compute_kernel_args_group_1 = {
+        in0_block_w,
+        in0_num_subblocks,
+        in0_block_num_tiles,
+        in0_subblock_num_tiles,
+        in1_num_subblocks,
+        in1_block_num_tiles,
+        in1_per_core_w,
+        num_blocks,
+        1,  // out_num_blocks_x
+        1,  // out_num_blocks_y
+        out_subblock_h,
+        out_subblock_w,
+        out_subblock_num_tiles,
+        num_blocks_per_core_group_1,
+        out_block_tiles,
+        untilize_out,
+        false,  // get_batch_from_reader
+        in0_transpose_tile,
+    };
+
+    // Compute defines
+    std::map<std::string, std::string> mm_kernel_defines;
+    if (packer_l1_acc_en) {
+        mm_kernel_defines["PACKER_L1_ACC"] = "1";
+    }
+    if (fp32_dest_acc_en) {
+        mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    if (in1_transpose_tile) {
+        mm_kernel_defines["IN1_TRANSPOSE_TILE"] = "1";
+    }
+    const auto throttle_level = ttnn::get_throttle_level(operation_attributes.compute_kernel_config);
+    ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
+        device->arch(), num_cores, mm_kernel_defines);
+    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
+        device->arch(), num_cores, mm_kernel_defines, throttle_level);
+    KernelDescriptor::Defines compute_defines{mm_kernel_defines.begin(), mm_kernel_defines.end()};
+
+    // Build per-core runtime args
+    bool row_major = false;
+    if (shard_spec.has_value()) {
+        row_major = shard_spec.value().orientation == tt::tt_metal::ShardOrientation::ROW_MAJOR;
+    }
+    const auto cores = corerange_to_cores(all_cores, num_cores, row_major);
+
+    uint32_t m_blocks_per_batch = M / per_core_M_per_batch;
+    uint32_t n_blocks_per_batch = N / per_core_N;
+    uint32_t blocks_per_batch = m_blocks_per_batch * n_blocks_per_batch;
+    uint32_t in0_batch_stride = M * K;
+    uint32_t in1_batch_stride = K * N;
+    uint32_t in0_m_block_stride = per_core_M_per_batch * (transpose_a ? 1 : K);
+    uint32_t in1_n_block_stride = per_core_N * (transpose_b ? K : 1);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Build ProgramDescriptor
+    ////////////////////////////////////////////////////////////////////////////
+    ProgramDescriptor program_descriptor;
+
+    // Reader kernel descriptor (created before loop so emplace_runtime_args can be called in loop)
+    KernelDescriptor reader_kernel_desc;
+    reader_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0.cpp";
+    reader_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_kernel_desc.core_ranges = all_cores;
+    reader_kernel_desc.compile_time_args = reader_compile_time_args;
+    reader_kernel_desc.named_compile_time_args = cb_named_args;
+    reader_kernel_desc.defines = reader_defines;
+    reader_kernel_desc.config = ReaderConfigDescriptor{};
+
+    // Reader/Writer kernel descriptor (reads in1, writes output)
+    KernelDescriptor reader_writer_kernel_desc;
+    reader_writer_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+        "reader_writer_bmm_tile_layout_in1.cpp";
+    reader_writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_writer_kernel_desc.core_ranges = all_cores;
+    reader_writer_kernel_desc.compile_time_args = reader_writer_compile_time_args;
+    reader_writer_kernel_desc.named_compile_time_args = cb_named_args;
+    reader_writer_kernel_desc.defines = reader_writer_defines;
+    reader_writer_kernel_desc.config = WriterConfigDescriptor{};
+
+    KernelDescriptor::RuntimeArgs compute_runtime_args_g1;
+    KernelDescriptor::RuntimeArgs compute_runtime_args_g2;
+    compute_runtime_args_g1.reserve(g1_numcores);
+
+    for (uint32_t i = 0, num_blocks_written = 0; i < cores.size(); ++i) {
+        const CoreCoord& core = cores[i];
+        uint32_t num_output_blocks_per_core =
+            i < g1_numcores ? num_blocks_per_core_group_1 : num_blocks_per_core_group_2;
+
+        uint32_t start_batch = num_blocks_written / blocks_per_batch;
+        uint32_t block_within_batch = num_blocks_written % blocks_per_batch;
+        uint32_t start_m_block = block_within_batch / n_blocks_per_batch;
+        uint32_t start_n_block = block_within_batch % n_blocks_per_batch;
+
+        uint32_t in0_start_tile_id = (start_batch * in0_batch_stride) + (start_m_block * in0_m_block_stride);
+        uint32_t in1_start_tile_id =
+            (bcast_batch ? 0 : (start_batch * in1_batch_stride)) + (start_n_block * in1_n_block_stride);
+
+        reader_kernel_desc.emplace_runtime_args(core, {in0_buffer, in0_start_tile_id, num_output_blocks_per_core});
+
+        uint32_t out_start_tile_id =
+            (start_batch * M * N) + (start_m_block * per_core_M_per_batch * N) + (start_n_block * per_core_N);
+        reader_writer_kernel_desc.emplace_runtime_args(
+            core, {in1_buffer, in1_start_tile_id, num_output_blocks_per_core, output, out_start_tile_id});
+
+        // Compute kernels have no per-core runtime args
+        if (i < g1_numcores) {
+            compute_runtime_args_g1.emplace_back(core, std::vector<uint32_t>{});
+        } else {
+            compute_runtime_args_g2.emplace_back(core, std::vector<uint32_t>{});
+        }
+
+        num_blocks_written += num_output_blocks_per_core;
+    }
+
+    program_descriptor.kernels.push_back(std::move(reader_kernel_desc));
+    program_descriptor.kernels.push_back(std::move(reader_writer_kernel_desc));
+
+    // Compute kernel descriptor (core group 1)
+    KernelDescriptor compute_kernel_desc;
+    compute_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/"
+        "bmm_large_block_zm_fused_bias_activation.cpp";
+    compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_kernel_desc.core_ranges = core_group_1;
+    compute_kernel_desc.compile_time_args = compute_kernel_args_group_1;
+    compute_kernel_desc.named_compile_time_args = cb_named_args;
+    compute_kernel_desc.defines = compute_defines;
+    compute_kernel_desc.runtime_args = std::move(compute_runtime_args_g1);
+    compute_kernel_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .math_approx_mode = math_approx_mode};
+    program_descriptor.kernels.push_back(std::move(compute_kernel_desc));
+
+    // Core group 2 compute kernel (if needed)
+    if (!core_group_2.ranges().empty()) {
+        std::vector<uint32_t> compute_kernel_args_group_2 = {
+            in0_block_w,
+            in0_num_subblocks,
+            in0_block_num_tiles,
+            in0_subblock_num_tiles,
+            in1_num_subblocks,
+            in1_block_num_tiles,
+            in1_per_core_w,
+            num_blocks,
+            1,  // out_num_blocks_x
+            1,  // out_num_blocks_y
+            out_subblock_h,
+            out_subblock_w,
+            out_subblock_num_tiles,
+            num_blocks_per_core_group_2,
+            out_block_tiles,
+            untilize_out,
+            false,  // get_batch_from_reader
+            in0_transpose_tile,
+        };
+
+        KernelDescriptor compute_kernel_desc_g2;
+        compute_kernel_desc_g2.kernel_source =
+            "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/"
+            "bmm_large_block_zm_fused_bias_activation.cpp";
+        compute_kernel_desc_g2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_kernel_desc_g2.core_ranges = core_group_2;
+        compute_kernel_desc_g2.compile_time_args = compute_kernel_args_group_2;
+        compute_kernel_desc_g2.named_compile_time_args = cb_named_args;
+        compute_kernel_desc_g2.defines = compute_defines;
+        compute_kernel_desc_g2.runtime_args = std::move(compute_runtime_args_g2);
+        compute_kernel_desc_g2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .math_approx_mode = math_approx_mode};
+        program_descriptor.kernels.push_back(std::move(compute_kernel_desc_g2));
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Build CBDescriptors
+    ////////////////////////////////////////////////////////////////////////////
+    auto make_cb_descriptor = [&all_cores](
+                                  uint32_t total_size,
+                                  uint8_t buffer_index,
+                                  tt::DataFormat data_format,
+                                  uint32_t page_size,
+                                  const tt::tt_metal::Tile& tile,
+                                  const tt_metal::MeshTensor* tensor = nullptr) {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = total_size;
+        cb_desc.core_ranges = all_cores;
+        tt::tt_metal::TileDescriptor tile_desc{tile};
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = buffer_index, .data_format = data_format, .page_size = page_size, .tile = tile_desc});
+        cb_desc.tensor = tensor;
+        return cb_desc;
+    };
+
+    // CB 0: Input A
+    program_descriptor.cbs.push_back(make_cb_descriptor(
+        in0_CB_size,
+        tt::CBIndex::c_0,
+        in0_data_format,
+        in0_aligned_tile_size,
+        in0_tile,
+        in0_is_sharded ? &in0_buffer : nullptr));
+
+    // CB 1: Input B
+    program_descriptor.cbs.push_back(make_cb_descriptor(
+        in1_CB_size,
+        tt::CBIndex::c_1,
+        in1_data_format,
+        in1_aligned_tile_size,
+        in1_tile,
+        in1_is_sharded ? &in1_buffer : nullptr));
+
+    // CB 4 and CB 5: Output and intermediate accumulator
+    if ((interm0_data_format != output_data_format) || (untilize_out && (in1_num_subblocks > 1))) {
+        // Separate output and intermediate CBs
+        program_descriptor.cbs.push_back(make_cb_descriptor(
+
+            out_CB_size,
+            tt::CBIndex::c_4,
+            output_data_format,
+            output_single_tile_size,
+            output_tile,
+            output_is_sharded ? &output : nullptr));
+        program_descriptor.cbs.push_back(make_cb_descriptor(
+            interm0_CB_size, tt::CBIndex::c_5, interm0_data_format, interm0_single_tile_size, output_tile));
+    } else {
+        // Shared output+intermediate CB
+        CBDescriptor output_cb_desc;
+        output_cb_desc.total_size = out_CB_size;
+        output_cb_desc.core_ranges = all_cores;
+        tt::tt_metal::TileDescriptor output_tile_desc{output_tile};
+        output_cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_4,
+            .data_format = output_data_format,
+            .page_size = output_single_tile_size,
+            .tile = output_tile_desc});
+        output_cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_5,
+            .data_format = interm0_data_format,
+            .page_size = interm0_single_tile_size,
+            .tile = output_tile_desc});
+        output_cb_desc.tensor = output_is_sharded ? &output : nullptr;
+        program_descriptor.cbs.push_back(std::move(output_cb_desc));
+    }
+
+    // Optional transpose CB
+    if (in0_transpose_tile) {
+        program_descriptor.cbs.push_back(
+            make_cb_descriptor(in0_CB_size, tt::CBIndex::c_10, in0_data_format, in0_aligned_tile_size, in0_tile));
+    }
+
+    return program_descriptor;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.hpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/matmul_device_operation_types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace ttnn::prim::qsr {
+
+struct MatmulMultiCoreReuseOptimizedProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const ttnn::prim::qsr::MatmulParams& operation_attributes,
+        const ttnn::prim::qsr::MatmulInputs& tensor_args,
+        std::vector<ttnn::Tensor>& tensor_return_value,
+        const std::optional<CoreRangeSet>& core_range_set = std::nullopt);
+
+    static CoreRangeSet default_core_range(IDevice* device);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm.cpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/matmul.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/dataflow/circular_buffer.h"
+
+using std::uint32_t;
+
+// matmul C=A*B using dims MK*KN = MN (row major order)
+//
+void kernel_main() {
+    constexpr int onetile = 1;
+
+    int dst_tile_index = 0;
+    int in0_block_tile_index = 0;
+
+    uint32_t batch = get_compile_time_arg_val(0);
+    uint32_t Mt = get_compile_time_arg_val(1);
+    uint32_t Kt = get_compile_time_arg_val(2);
+    uint32_t Nt = get_compile_time_arg_val(3);
+
+    constexpr uint32_t cb_in0 = get_named_compile_time_arg_val("cb_in0");
+    constexpr uint32_t cb_in1 = get_named_compile_time_arg_val("cb_in1");
+    constexpr uint32_t cb_out = get_named_compile_time_arg_val("cb_out");
+
+    CircularBuffer in0_cb(cb_in0);
+    CircularBuffer in1_cb(cb_in1);
+    CircularBuffer out_cb(cb_out);
+
+    mm_init(cb_in0, cb_in1, cb_out);
+
+    // the simplest possible version of outer product blocked matmul
+    // the reader is expected to read the A's and B's tile rows and tile columns for each output tile
+    for (uint32_t nb = 0; nb < batch; nb++) {
+        for (uint32_t mt_C = 0; mt_C < Mt; ++mt_C) {    // output tile of C
+            for (uint32_t nt_C = 0; nt_C < Nt; ++nt_C)  // output tile index of C
+            {
+                tile_regs_acquire();
+                for (uint32_t kt = 0; kt < Kt; kt++) {
+                    in0_cb.wait_front(onetile);
+                    in1_cb.wait_front(onetile);
+
+                    matmul_tiles(cb_in0, cb_in1, 0, 0, 0);
+
+                    in0_cb.pop_front(onetile);
+                    in1_cb.pop_front(onetile);
+                }
+
+                tile_regs_commit();
+
+                out_cb.reserve_back(onetile);
+
+                tile_regs_wait();
+                pack_tile(0, cb_out);
+                tile_regs_release();
+
+                out_cb.push_back(onetile);
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_fused_activation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_fused_activation.hpp
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+#include "ttnn/operations/experimental/quasar/matmul/shared_with_host/activation_type.hpp"
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/eltwise_unary/gelu.h"
+#include "api/compute/eltwise_unary/relu.h"
+#include "api/compute/eltwise_unary/activations.h"
+#include "api/compute/eltwise_unary/hardtanh.h"
+#include "api/compute/eltwise_unary/selu.h"
+#include "api/compute/eltwise_unary/softplus.h"
+#include "internal/risc_attribs.h"
+#include <cstring>  // for memcpy
+
+using ttnn::operations::experimental::quasar::matmul::KernelActivation;
+
+// Helper templates to select activation variants based on parameters
+template <KernelActivation ACT, uint32_t PARAM0 = 0, uint32_t PARAM1 = 0>
+struct ActivationInitHelper {
+    // Compile-time validation
+    static_assert(
+        ACT == KernelActivation::NONE || ACT == KernelActivation::SILU || ACT == KernelActivation::TANH ||
+            ACT == KernelActivation::GELU || ACT == KernelActivation::RELU6 || ACT == KernelActivation::SIGMOID ||
+            ACT == KernelActivation::HARDSIGMOID || ACT == KernelActivation::HARDTANH ||
+            ACT == KernelActivation::SELU || ACT == KernelActivation::SOFTPLUS,
+        "Unsupported KernelActivation type for fused activation init");
+
+    FORCE_INLINE static void init() {
+        if constexpr (ACT == KernelActivation::SILU) {
+            silu_tile_init_pack();
+        } else if constexpr (ACT == KernelActivation::TANH) {
+            // PARAM0: 0 = accurate, non-zero = fast
+            tanh_tile_init_pack<PARAM0 != 0>();
+        } else if constexpr (ACT == KernelActivation::GELU) {
+            // PARAM0: 0 = accurate, non-zero = fast
+            gelu_tile_init_pack<PARAM0 != 0>();
+        } else if constexpr (ACT == KernelActivation::RELU6) {
+            relu_max_tile_init_pack();
+        } else if constexpr (ACT == KernelActivation::SIGMOID) {
+            // Enhanced: PARAM1 is fast_approximate flag
+            sigmoid_tile_init_pack<PARAM1 != 0>();
+        } else if constexpr (ACT == KernelActivation::HARDSIGMOID) {
+            hardsigmoid_tile_init_pack();
+        } else if constexpr (ACT == KernelActivation::HARDTANH) {
+            hardtanh_tile_init_pack();
+        } else if constexpr (ACT == KernelActivation::SELU) {
+            selu_tile_init_pack();
+        } else if constexpr (ACT == KernelActivation::SOFTPLUS) {
+            softplus_tile_init_pack();
+        }
+    }
+};
+
+template <KernelActivation ACT, uint32_t PARAM0 = 0, uint32_t PARAM1 = 0, uint32_t PARAM2 = 0>
+struct ActivationApplyHelper {
+    // Compile-time validation
+    static_assert(
+        ACT == KernelActivation::NONE || ACT == KernelActivation::SILU || ACT == KernelActivation::TANH ||
+            ACT == KernelActivation::GELU || ACT == KernelActivation::RELU6 || ACT == KernelActivation::SIGMOID ||
+            ACT == KernelActivation::HARDSIGMOID || ACT == KernelActivation::HARDTANH ||
+            ACT == KernelActivation::SELU || ACT == KernelActivation::SOFTPLUS,
+        "Unsupported KernelActivation type for fused activation apply");
+
+    // Parameter-specific validation
+    static_assert(
+        ACT != KernelActivation::SOFTPLUS || PARAM0 != 0,
+        "SOFTPLUS PARAM0 (beta) must be non-zero to avoid division by zero");
+
+    FORCE_INLINE static void apply(uint32_t tile_index) {
+        if constexpr (ACT == KernelActivation::SILU) {
+            silu_tile_pack(tile_index);
+        } else if constexpr (ACT == KernelActivation::TANH) {
+            // PARAM0: 0 = accurate, non-zero = fast
+            tanh_tile_pack<PARAM0 != 0>(tile_index);
+        } else if constexpr (ACT == KernelActivation::GELU) {
+            // PARAM0: 0 = accurate, non-zero = fast
+            gelu_tile_pack<PARAM0 != 0>(tile_index);
+        } else if constexpr (ACT == KernelActivation::RELU6) {
+            // PARAM0 is the max value (as uint32_t bit pattern)
+            // Default to 6.0 if PARAM0 is 0
+            constexpr uint32_t max = (PARAM0 != 0) ? PARAM0 : 0x40c00000u;
+            relu_max_tile_pack(tile_index, max);
+        } else if constexpr (ACT == KernelActivation::SIGMOID) {
+            // Enhanced: PARAM0 is vector mode, PARAM1 is fast_approximate
+            constexpr VectorMode vec_mode = (PARAM0 == 1)   ? VectorMode::R
+                                            : (PARAM0 == 2) ? VectorMode::C
+                                                            : VectorMode::RC;
+            sigmoid_tile_pack<vec_mode, PARAM1 != 0>(tile_index);
+        } else if constexpr (ACT == KernelActivation::HARDSIGMOID) {
+            hardsigmoid_tile_pack(tile_index);
+        } else if constexpr (ACT == KernelActivation::HARDTANH) {
+            hardtanh_tile_pack(tile_index, PARAM0, PARAM1);
+        } else if constexpr (ACT == KernelActivation::SELU) {
+            // PARAM0 is alpha, PARAM1 is lambda
+            selu_tile_pack(tile_index, PARAM0, PARAM1);
+        } else if constexpr (ACT == KernelActivation::SOFTPLUS) {
+            // PARAM0 is beta, PARAM2 beta reciprocal, PARAM1 is threshold
+            softplus_tile_pack(tile_index, PARAM0, PARAM2, PARAM1);
+        }
+    }
+};
+
+template <KernelActivation ACT, uint32_t PARAM0 = 0, uint32_t PARAM1 = 0, uint32_t PARAM2 = 0>
+FORCE_INLINE void apply_activation_from_pack(uint32_t out_subblock_num_tiles) {
+    PACK(TTI_SEMWAIT(
+        p_stall::STALL_TDMA | p_stall::STALL_CFG, semaphore::t6_sem(semaphore::MATH_PACK), p_stall::STALL_ON_ZERO));
+
+    // Flip destination register offset for PACKER access
+    PACK(TT_SETC16(DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, ckernel::packer::get_packer_dest_offset()));
+
+    for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
+        ActivationApplyHelper<ACT, PARAM0, PARAM1, PARAM2>::apply(i);
+    }
+
+    // Wait for SFPU completion before packing
+    PACK(TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::WAIT_SFPU));
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm.cpp
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/matmul.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/dataflow/circular_buffer.h"
+
+void kernel_main() {
+    uint32_t in0_block_w = get_compile_time_arg_val(0);              // inner block size in tiles
+    uint32_t in0_num_subblocks = get_compile_time_arg_val(1);        // outer row block size (in inner row blocks)
+    uint32_t in0_block_num_tiles = get_compile_time_arg_val(2);      // out_subblock_h*in0_block_w*in0_num_subblocks;
+    uint32_t in0_subblock_num_tiles = get_compile_time_arg_val(3);   // out_subblock_h*in0_block_w
+    uint32_t in1_num_subblocks = get_compile_time_arg_val(4);        // outer column block size (in inner column blocks)
+    uint32_t in1_block_num_tiles = get_compile_time_arg_val(5);      // out_subblock_w*in0_block_w* in1_num_subblocks;
+    uint32_t in1_per_core_w = get_compile_time_arg_val(6);           // out_subblock_w*in1_num_subblocks
+    uint32_t num_blocks = get_compile_time_arg_val(7);               // outer inner dim (in inner dim blocks)
+    uint32_t out_subblock_h = get_compile_time_arg_val(8);           // inner row block size in tiles
+    uint32_t out_subblock_w = get_compile_time_arg_val(9);           // inner column block size in tiles
+    uint32_t out_subblock_num_tiles = get_compile_time_arg_val(10);  // out_subblock_h * out_subblock_w;
+    uint32_t batch = get_compile_time_arg_val(11);                   // batch dim
+
+    constexpr uint32_t cb_in0 = get_named_compile_time_arg_val("cb_in0");
+    constexpr uint32_t cb_in1 = get_named_compile_time_arg_val("cb_in1");
+    constexpr uint32_t cb_out = get_named_compile_time_arg_val("cb_out");
+    constexpr uint32_t cb_intermed0 = get_named_compile_time_arg_val("cb_intermed0");
+
+    CircularBuffer in0_cb(cb_in0);
+    CircularBuffer in1_cb(cb_in1);
+    CircularBuffer out_cb(cb_out);
+    CircularBuffer intermed0_cb(cb_intermed0);
+
+    mm_init(cb_in0, cb_in1, cb_intermed0);
+
+    for (uint32_t b = 0; b < batch; b++) {
+        bool spill = num_blocks > 1;
+        bool enable_reload = false;
+        uint32_t out_num_tiles_to_wait = out_subblock_num_tiles;
+
+        for (uint32_t block = 0; block < num_blocks; block++) {
+            bool last_out = block == (num_blocks - 1);
+
+            in0_cb.wait_front(in0_block_num_tiles);
+            in1_cb.wait_front(in1_block_num_tiles);
+            int in0_index_subblock_offset = 0;
+            for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
+                int in1_index_subblock_offset = 0;
+                for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
+                    tile_regs_acquire();
+
+                    if (enable_reload) {
+                        copy_tile_to_dst_init_short_with_dt(cb_in1, cb_intermed0);
+                        intermed0_cb.wait_front(out_subblock_num_tiles);
+                        for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
+                            copy_tile(cb_intermed0, i, i);
+                        }
+                        intermed0_cb.pop_front(out_subblock_num_tiles);
+                        mm_init_short_with_dt(cb_in0, cb_in1, cb_intermed0);
+                    }
+
+                    // Compute output sub-block from in0_subblock x in1_subblock
+                    int dst_index = 0;
+                    int in0_index_h_offset = 0;
+                    for (uint32_t h = 0; h < out_subblock_h; h++) {
+                        for (uint32_t w = 0; w < out_subblock_w; w++) {
+                            int in1_index_inner_dim_offset = 0;
+                            for (uint32_t inner_dim = 0; inner_dim < in0_block_w; inner_dim++) {
+                                int in0_index = in0_index_subblock_offset + in0_index_h_offset + inner_dim;
+                                int in1_index = in1_index_subblock_offset + in1_index_inner_dim_offset + w;
+                                matmul_tiles(cb_in0, cb_in1, in0_index, in1_index, dst_index);
+                                in1_index_inner_dim_offset += in1_per_core_w;
+                            }
+                            dst_index++;
+                        }
+                        in0_index_h_offset += in0_block_w;
+                    }
+
+                    tile_regs_commit();
+
+                    if (last_out) {
+                        // Pack out to output buffer
+                        out_cb.reserve_back(out_subblock_num_tiles);
+                    } else {
+                        // Wait for tiles in output buffer to be written out since interm and output share memory
+                        if (block == 0) {
+                            out_cb.reserve_back(out_num_tiles_to_wait);
+                            out_num_tiles_to_wait += out_subblock_num_tiles;
+                        }
+                        // Move partial result to interm buffer
+                        intermed0_cb.reserve_back(out_subblock_num_tiles);
+                    }
+
+                    tile_regs_wait();
+                    if (last_out) {
+                        for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
+                            pack_tile(i, cb_out);
+                        }
+                    } else {
+                        for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
+                            pack_tile(i, cb_intermed0);
+                        }
+                    }
+                    tile_regs_release();
+
+                    if (last_out) {
+                        out_cb.push_back(out_subblock_num_tiles);
+                    } else {
+                        intermed0_cb.push_back(out_subblock_num_tiles);
+                    }
+                    in1_index_subblock_offset += out_subblock_w;
+                }
+                in0_index_subblock_offset += in0_subblock_num_tiles;
+            }
+
+            if (spill) {
+                enable_reload = true;
+            }
+
+            in0_cb.pop_front(in0_block_num_tiles);
+            in1_cb.pop_front(in1_block_num_tiles);
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -1,0 +1,584 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/matmul.h"
+#include "api/compute/pack_untilize.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/transpose_wh.h"
+#include "api/dataflow/circular_buffer.h"
+#include "internal/mod_div_lib.h"
+
+#ifdef FUSE_BIAS
+#include "api/compute/bcast.h"
+#endif
+
+#include "api/compute/eltwise_binary.h"
+#ifdef SFPU_ACTIVATION
+#include "bmm_fused_activation.hpp"
+#endif
+
+// Please update
+// tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/kernels/bmm_large_block_zm_fused_bias_activation_copy.cpp
+// when making any changes to this file.
+// Have to keep a copy because cannot import ttnn into tests/tt_metal.
+// With FUSE_BIAS: row_broadcast_bias (row-broadcast vs elementwise add_tiles) is compile-time arg 18 here;
+// the perf copy uses index 14 (different compile-time arg layout).
+
+/**
+ * @brief Transposes a block of tiles from one circular buffer to another.
+ *
+ * This function reads a block of tiles from the input circular buffer (cb), performs a width-height
+ * (WH) transpose on each tile, and writes the transposed tiles to the output circular buffer.
+ * The operation is performed in blocks of `block_size` tiles for efficiency, with a separate loop
+ * at the end to handle any leftover tiles when the total tile count is not divisible by
+ * `block_size`. The default block size is 4, since there are guaranteed to be 4 tiles in the dst
+ *               regs irrespective of dst sync mode or data format.
+ *
+ * @tparam in0_block_num_tiles The number of tiles in the block to be transposed.
+ * @tparam block_size The number of tiles in each block to be transposed.
+ * @param in0_transpose_cb_id Circular buffer ID to read the original tiles from.
+ * @param in0_cb_id Circular buffer ID to which the transposed tiles are written.
+ */
+template <uint32_t in0_block_num_tiles, uint32_t block_size = 4>
+FORCE_INLINE void transpose_tile_block(uint32_t in0_transpose_cb_id, uint32_t in0_cb_id) {
+    CircularBuffer in0_transpose_cb(in0_transpose_cb_id);
+    CircularBuffer in0_cb(in0_cb_id);
+    constexpr uint32_t num_blocks = in0_block_num_tiles / block_size;
+    constexpr uint32_t last_block_size = in0_block_num_tiles % block_size;
+    // Lets do 2 passes: One loop until last and one last for the left overs
+    for (uint32_t block_idx = 0; block_idx < num_blocks; ++block_idx) {
+        in0_transpose_cb.wait_front(block_size);
+        tile_regs_acquire();
+        for (uint32_t tile_idx = 0; tile_idx < block_size; tile_idx++) {
+            transpose_wh_tile(in0_transpose_cb_id, tile_idx, tile_idx);
+        }
+        tile_regs_commit();
+        in0_transpose_cb.pop_front(block_size);
+
+        in0_cb.reserve_back(block_size);
+        tile_regs_wait();
+        for (uint32_t tile_idx = 0; tile_idx < block_size; tile_idx++) {
+            pack_tile(tile_idx, in0_cb_id);
+        }
+        tile_regs_release();
+        in0_cb.push_back(block_size);
+    }
+
+    if constexpr (last_block_size > 0) {
+        in0_transpose_cb.wait_front(last_block_size);
+        tile_regs_acquire();
+        for (uint32_t tile_idx = 0; tile_idx < last_block_size; tile_idx++) {
+            transpose_wh_tile(in0_transpose_cb_id, tile_idx, tile_idx);
+        }
+        tile_regs_commit();
+        in0_transpose_cb.pop_front(last_block_size);
+
+        in0_cb.reserve_back(last_block_size);
+        tile_regs_wait();
+        for (uint32_t tile_idx = 0; tile_idx < last_block_size; tile_idx++) {
+            pack_tile(tile_idx, in0_cb_id);
+        }
+        tile_regs_release();
+        in0_cb.push_back(last_block_size);
+    }
+}
+
+FORCE_INLINE void reload_from_cb_to_dst(
+    uint32_t in0_cb_id,
+    uint32_t in1_cb_id,
+    uint32_t mm_partials_cb_id,
+    bool in1_transpose_tile,
+    uint32_t out_subblock_num_tiles,
+    uint32_t out_subblock_w,
+    uint32_t out_subblock_h,
+    uint32_t in0_block_w) {
+    CircularBuffer mm_partials_cb(mm_partials_cb_id);
+    // Reconfigure input
+    copy_tile_to_dst_init_short_with_dt(in1_cb_id, mm_partials_cb_id);
+    mm_partials_cb.wait_front(out_subblock_num_tiles);
+
+    uint32_t start_dst_index = 0;
+    uint32_t start_tile_index = 0;
+    copy_block_matmul_partials(mm_partials_cb_id, start_tile_index, start_dst_index, out_subblock_num_tiles);
+
+    mm_partials_cb.pop_front(out_subblock_num_tiles);
+    // Reconfigure srcA back
+    mm_block_init_short_with_dt(
+        in0_cb_id, in1_cb_id, mm_partials_cb_id, in1_transpose_tile, out_subblock_w, out_subblock_h, in0_block_w);
+}
+
+template <uint32_t out_subblock_w, uint32_t out_block_w>
+inline void reblock_and_untilize(
+    uint32_t num_out_subblocks_in_col,
+    uint32_t out_subblock_num_tiles,
+    uint32_t out_subblock_h,
+    uint32_t interm_cb_id,
+    uint32_t out_cb_id) {
+    CircularBuffer interm_cb(interm_cb_id);
+    CircularBuffer out_cb(out_cb_id);
+    uint32_t num_tiles_in_row_of_subblocks = mulsi3(out_subblock_num_tiles, num_out_subblocks_in_col);
+    interm_cb.wait_front(num_tiles_in_row_of_subblocks);
+
+    uint32_t within_block_index = 0;
+    for (uint32_t h = 0; h < out_subblock_h; h++) {
+        uint32_t block_offset = 0;
+
+        out_cb.reserve_back(out_block_w);
+        for (uint32_t n = 0; n < num_out_subblocks_in_col; n++) {
+            tile_regs_acquire();
+            for (uint32_t w = 0; w < out_subblock_w; w++) {
+                uint32_t tile_index = block_offset + within_block_index + w;
+                copy_tile(interm_cb_id, tile_index, w);
+            }
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_untilize_dest<out_subblock_w, out_block_w>(out_cb_id, 1, n);
+            tile_regs_release();
+            block_offset += out_subblock_num_tiles;
+        }
+        out_cb.push_back(out_block_w);
+
+        within_block_index += out_subblock_w;
+    }
+    interm_cb.pop_front(num_tiles_in_row_of_subblocks);
+}
+
+void kernel_main() {
+// RUNTIME ARGS
+#ifdef MATMUL_DRAM_SHARDED
+    const bool is_worker_core = get_arg_val<uint32_t>(0) == 1;
+    // if not worker core, skip
+    if (not is_worker_core) {
+        return;
+    }
+#endif
+
+    constexpr uint32_t in0_block_w = get_compile_time_arg_val(0);        // inner block size in tiles
+    constexpr uint32_t in0_num_subblocks = get_compile_time_arg_val(1);  // outer row block size (in inner row blocks)
+    constexpr uint32_t in0_block_num_tiles =
+        get_compile_time_arg_val(2);  // out_subblock_h*in0_block_w*in0_num_subblocks;
+    constexpr uint32_t in0_subblock_num_tiles = get_compile_time_arg_val(3);  // out_subblock_h*in0_block_w
+    constexpr uint32_t in1_num_subblocks =
+        get_compile_time_arg_val(4);  // outer column block size (in inner column blocks)
+    constexpr uint32_t in1_block_num_tiles =
+        get_compile_time_arg_val(5);                               // out_subblock_w*in0_block_w* in1_num_subblocks;
+    constexpr uint32_t in1_block_w = get_compile_time_arg_val(6);  // out_subblock_w*in1_num_subblocks
+    constexpr uint32_t num_blocks_inner_dim = get_compile_time_arg_val(7);     // outer inner dim (in inner dim blocks)
+    constexpr uint32_t num_blocks_w_dim = get_compile_time_arg_val(8);         // outer inner dim (in inner dim blocks)
+    constexpr uint32_t num_blocks_h_dim = get_compile_time_arg_val(9);         // outer inner dim (in inner dim blocks)
+    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(10);          // inner row block size in tiles
+    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(11);          // inner column block size in tiles
+    constexpr uint32_t out_subblock_num_tiles = get_compile_time_arg_val(12);  // out_subblock_h * out_subblock_w;
+    constexpr uint32_t batch = get_compile_time_arg_val(13);                   // batch dim
+    constexpr uint32_t out_block_num_tiles = get_compile_time_arg_val(14);     // number of tiles in out_block
+    constexpr bool untilize_out = get_compile_time_arg_val(15);                // untilize output
+    // This boolean is set when the number of batches is only known at runtime, typically based on a sparsity tensor.
+    constexpr bool get_batch_from_reader = (bool)get_compile_time_arg_val(16);
+    constexpr bool in0_transpose_tile = (bool)get_compile_time_arg_val(17);
+
+    constexpr uint32_t out_block_w = out_subblock_w * in1_num_subblocks;
+
+    constexpr uint32_t in0_cb_id = in0_transpose_tile ? get_named_compile_time_arg_val("cb_in0_transposed")
+                                                      : get_named_compile_time_arg_val("cb_in0");
+    constexpr uint32_t in1_cb_id = get_named_compile_time_arg_val("cb_in1");
+    constexpr uint32_t out_cb_id = get_named_compile_time_arg_val("cb_out");
+    constexpr uint32_t mm_partials_cb_id = get_named_compile_time_arg_val("cb_intermed0");
+    constexpr uint32_t untilize_mode_out_cb_id = untilize_out ? mm_partials_cb_id : out_cb_id;
+    // When in0 needs to be transposed, the original data is read from cb_in0 (in0_transpose_cb_id),
+    // transposed, and the result is written to cb_in0_transposed (in0_cb_id), which is then used
+    // as input for the matmul call.
+    constexpr uint32_t in0_transpose_cb_id = get_named_compile_time_arg_val("cb_in0");
+
+    CircularBuffer in0_cb(in0_cb_id);
+    CircularBuffer in1_cb(in1_cb_id);
+    CircularBuffer mm_partials_cb(mm_partials_cb_id);
+    CircularBuffer untilize_mode_out_cb(untilize_mode_out_cb_id);
+
+#ifdef FUSE_BIAS
+    constexpr uint32_t bias_cb_id = get_named_compile_time_arg_val("cb_bias");
+    constexpr uint32_t bias_ntiles = get_named_compile_time_arg_val("bias_ntiles");
+    constexpr uint32_t mm_out_cb_id = mm_partials_cb_id;
+    // true: row-0 broadcast ([N] / [...,1,N]); false: elementwise add_tiles (bias has multiple M rows).
+    constexpr bool row_broadcast_bias = (bool)get_compile_time_arg_val(18);
+    CircularBuffer bias_cb(bias_cb_id);
+#else
+    constexpr uint32_t mm_out_cb_id = untilize_mode_out_cb_id;
+#endif
+    CircularBuffer mm_out_cb(mm_out_cb_id);
+
+    // Number of valid in1 columns in the last in1 subblock. For the DRAM-sharded variant the
+    // planner may pad per_core_N_compute beyond per_core_N_in1_sender so that out_subblock_w can be
+    // larger; the reader only pushes per_core_N_in1_sender tiles per block into cb_in1. To avoid
+    // reading those non-existent (padded) cb_in1 tiles, the compute kernel narrows the matmul_block
+    // call on the last in1 subblock to last_subblock_w_valid lanes. When no padding occurs this
+    // equals out_subblock_w and the original full-width path is preserved.
+#ifdef MATMUL_DRAM_SHARDED
+    constexpr uint32_t last_subblock_w_valid = get_named_compile_time_arg_val("last_subblock_w_valid");
+#else
+    constexpr uint32_t last_subblock_w_valid = out_subblock_w;
+#endif
+    constexpr bool last_subblock_padded = last_subblock_w_valid < out_subblock_w;
+
+#ifdef SFPU_ACTIVATION
+    constexpr KernelActivation activation_type =
+        static_cast<KernelActivation>(get_named_compile_time_arg_val("activation_type"));
+    constexpr uint32_t activation_param0 = get_named_compile_time_arg_val("activation_param0");
+    constexpr uint32_t activation_param1 = get_named_compile_time_arg_val("activation_param1");
+    constexpr uint32_t activation_param2 = get_named_compile_time_arg_val("activation_param2");
+
+    ActivationInitHelper<activation_type, activation_param0, activation_param1>::init();
+#endif
+
+#ifdef IN1_TRANSPOSE_TILE
+    constexpr uint32_t in1_transpose_tile = true;
+#else
+    constexpr uint32_t in1_transpose_tile = false;
+#endif
+
+    constexpr bool spill = num_blocks_inner_dim > 1;
+
+    mm_block_init(
+        in0_cb_id, in1_cb_id, mm_partials_cb_id, in1_transpose_tile, out_subblock_w, out_subblock_h, in0_block_w);
+    for (uint32_t b = 0; b < batch; b++) {
+        if constexpr (get_batch_from_reader) {
+            // Check whether this batch is valid
+            bool is_batch_valid = false;
+            UNPACK(is_batch_valid = (bool)mailbox_read(ckernel::ThreadId::BriscThreadId);)
+            MATH(is_batch_valid = (bool)mailbox_read(ckernel::ThreadId::BriscThreadId);)
+            PACK(is_batch_valid = (bool)mailbox_read(ckernel::ThreadId::BriscThreadId);)
+            if (!is_batch_valid) {
+                continue;
+            }
+        }
+
+        for (uint32_t bh = 0; bh < num_blocks_h_dim; ++bh) {
+            for (uint32_t bw = 0; bw < num_blocks_w_dim; ++bw) {
+                bool enable_reload = false;
+
+#ifdef PACK_RELU
+                // for each batch we start with relu disabled so that intermediate results are not relu'd
+                if constexpr (batch > 1 || num_blocks_h_dim > 1 || num_blocks_w_dim > 1) {
+                    PACK((llk_pack_relu_config(ReluConfig::none())));
+                }
+#endif
+
+                if constexpr (batch > 1 || num_blocks_h_dim > 1 || num_blocks_w_dim > 1) {
+                    PACK((pack_reconfig_data_format(mm_partials_cb_id)));
+                }
+
+                for (uint32_t block = 0; block < num_blocks_inner_dim; block++) {
+                    bool last_out = block == (num_blocks_inner_dim - 1);
+// Configure packer once for pack out without Bias
+#if not defined FUSE_BIAS and defined PACK_RELU
+                    if (last_out) {
+                        // if last block we pack the final result with relu enabled
+                        PACK((llk_pack_relu_config(ReluConfig::zero())));
+                    }
+#endif
+
+                    if constexpr (in0_transpose_tile) {
+                        reconfig_data_format_srca(in1_cb_id, in0_transpose_cb_id);
+                        transpose_wh_init_short(in0_transpose_cb_id);
+                        PACK((pack_reconfig_data_format(in0_cb_id)));
+#ifdef PACKER_L1_ACC
+                        PACK((llk_pack_reconfig_l1_acc(0)));
+#endif
+                        transpose_tile_block<in0_block_num_tiles>(in0_transpose_cb_id, in0_cb_id);
+                        mm_block_init_short_with_dt(
+                            in0_cb_id,
+                            in1_cb_id,
+                            in0_transpose_cb_id,
+                            in1_transpose_tile,
+                            out_subblock_w,
+                            out_subblock_h,
+                            in0_block_w);
+                        PACK((pack_reconfig_data_format(mm_partials_cb_id)));
+                    }
+
+                    in0_cb.wait_front(in0_block_num_tiles);
+                    in1_cb.wait_front(in1_block_num_tiles);
+
+                    int in0_index_subblock_offset = 0;
+                    for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
+                        int in1_index_subblock_offset = 0;
+                        for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
+                            // When last_subblock_padded is true the last in1 subblock has
+                            // (out_subblock_w - last_subblock_w_valid) padded lanes whose cb_in1 tiles were
+                            // never pushed by the reader. Narrow matmul_block so the unpacker only touches
+                            // tiles that exist; the padded dst lanes are left at whatever the previous
+                            // operation wrote there and the output writer (BRISC) drops those columns.
+                            const bool is_last_in1_subblock_padded =
+                                last_subblock_padded && (in1_subblock == in1_num_subblocks - 1);
+                            const uint32_t effective_subblock_w =
+                                is_last_in1_subblock_padded ? last_subblock_w_valid : out_subblock_w;
+
+                            tile_regs_acquire();
+                            if (enable_reload) {
+                                reload_from_cb_to_dst(
+                                    in0_cb_id,
+                                    in1_cb_id,
+                                    mm_partials_cb_id,
+                                    in1_transpose_tile,
+                                    out_subblock_num_tiles,
+                                    out_subblock_w,
+                                    out_subblock_h,
+                                    in0_block_w);
+                            }
+
+#ifndef SKIP_COMPUTE
+                            // Compute output sub-block
+                            uint32_t dst_index =
+                                0;  // start at 0, each call to matmul_block internally increments dst_index
+                            uint32_t in0_index = in0_index_subblock_offset;  // offset into in0 block
+                            uint32_t in1_index = in1_index_subblock_offset;  // offset into in1 block
+                            // inner dim that we accumulate is the inner dim of in0/in1, which is in0_block_w
+                            for (uint32_t inner_dim_idx = 0; inner_dim_idx < in0_block_w; ++inner_dim_idx) {
+                                // matmul outer product of (out_subblock_h x out_subblock_w) tiles that fill dst
+                                // accumulation is done by iterating matmul_block across inner dim
+                                // in0_block_w is passed as innder dim (kt) to matmul_block, internally used to stride
+                                // in0
+                                matmul_block(
+                                    in0_cb_id,
+                                    in1_cb_id,
+                                    in0_index,
+                                    in1_index,
+                                    dst_index,
+                                    in1_transpose_tile,
+                                    effective_subblock_w,
+                                    out_subblock_h,
+                                    in0_block_w);
+                                in0_index++;               // stride right by 1
+                                in1_index += in1_block_w;  // to stride down by 1 need to stride by in_per_core_w
+                                                           // (should be called in1_block_w)
+                            }
+
+#endif  // SKIP_COMPUTE
+
+                            if (last_out) {
+                                tile_regs_commit();
+                                mm_out_cb.reserve_back(out_subblock_num_tiles);
+
+#if defined SFPU_ACTIVATION and not defined FUSE_BIAS
+                                apply_activation_from_pack<
+                                    activation_type,
+                                    activation_param0,
+                                    activation_param1,
+                                    activation_param2>(out_subblock_num_tiles);
+#else
+                                tile_regs_wait();
+#endif
+
+#if defined FP32_DEST_ACC_EN or defined PACKER_L1_ACC
+                                PACK((pack_reconfig_data_format(mm_out_cb_id)));
+#endif
+
+#ifdef PACKER_L1_ACC
+#ifdef FUSE_BIAS
+                                if (block == 0) {  // no accumulation for first iteration
+                                    PACK((llk_pack_reconfig_l1_acc(0)));
+                                } else {
+                                    PACK((llk_pack_reconfig_l1_acc(1)));
+                                }
+#else
+                                PACK((llk_pack_reconfig_l1_acc(0)));
+#endif
+#endif
+                                uint32_t start_dst_index = 0;
+                                pack_tile_block(start_dst_index, mm_out_cb_id, out_subblock_num_tiles);
+
+                                tile_regs_release();
+                                mm_out_cb.push_back(out_subblock_num_tiles);
+
+                            } else {
+                                tile_regs_commit();
+                                mm_partials_cb.reserve_back(out_subblock_num_tiles);
+                                tile_regs_wait();
+
+#ifdef PACKER_L1_ACC
+                                if (block == 0) {  // no accumulation for first iteration
+                                    PACK((llk_pack_reconfig_l1_acc(0)));
+                                } else if (block == 1) {
+                                    PACK((llk_pack_reconfig_l1_acc(1)));
+                                } else if (in0_transpose_tile) {
+                                    // For each block, l1_acc would have been enabled during the
+                                    // transpose stage. So let us put it back here.
+                                    PACK((llk_pack_reconfig_l1_acc(1)));
+                                }
+#endif
+
+                                uint32_t start_dst_index = 0;
+                                pack_tile_block(start_dst_index, mm_partials_cb_id, out_subblock_num_tiles);
+
+                                tile_regs_release();
+                                mm_partials_cb.push_back(out_subblock_num_tiles);
+                            }
+
+                            in1_index_subblock_offset += out_subblock_w;
+                        }
+                        in0_index_subblock_offset += in0_subblock_num_tiles;
+                    }
+
+#ifdef PACKER_L1_ACC
+#ifdef FUSE_BIAS
+                    if (block < num_blocks_inner_dim - 1) {
+                        // Wait/pop in subblock-sized steps so the step size
+                        // matches the bias section's wait_front(out_subblock_num_tiles),
+                        // satisfying the CB API requirement that all wait_front
+                        // increments on a given CB are identical.
+                        for (uint32_t s = 0; s < out_block_num_tiles; s += out_subblock_num_tiles) {
+                            mm_partials_cb.wait_front(out_subblock_num_tiles);
+                            mm_partials_cb.pop_front(out_subblock_num_tiles);
+                        }
+                    }
+                    // never reload when with bias, bias uses interm buffer
+                    enable_reload = false;
+#else
+                    // Last iteration does spill and reload to output buffer
+                    if (block < num_blocks_inner_dim - 2) {
+                        for (uint32_t s = 0; s < out_block_num_tiles; s += out_subblock_num_tiles) {
+                            mm_partials_cb.wait_front(out_subblock_num_tiles);
+                            mm_partials_cb.pop_front(out_subblock_num_tiles);
+                        }
+                    }
+                    if (block == num_blocks_inner_dim - 2) {
+                        enable_reload = true;
+                    }  // reload when last iteration
+#endif
+#else
+                    if constexpr (spill) {
+                        enable_reload = true;
+                    }
+#endif
+
+                    in0_cb.pop_front(in0_block_num_tiles);
+                    in1_cb.pop_front(in1_block_num_tiles);
+                }
+
+#ifdef FUSE_BIAS
+#ifdef PACK_RELU
+                // if last block we pack the final result with relu enabled
+                PACK((llk_pack_relu_config(ReluConfig::zero())));
+#endif
+#if defined FP32_DEST_ACC_EN or defined PACKER_L1_ACC
+                PACK((pack_reconfig_data_format(out_cb_id)));
+#endif
+#ifdef PACKER_L1_ACC
+                PACK((llk_pack_reconfig_l1_acc(0)));
+#endif
+                reconfig_data_format(in1_cb_id, mm_partials_cb_id, in0_cb_id, bias_cb_id);
+                if constexpr (row_broadcast_bias) {
+                    add_bcast_rows_init_short(mm_partials_cb_id, bias_cb_id);
+                } else {
+                    add_tiles_init(mm_partials_cb_id, bias_cb_id);
+                }
+                // Reader only pushes bias once when num_blocks_w_dim == 1;
+                // the tiles stay in the CB for reuse across bh/batch iterations.
+                if ((b == 0 && bh == 0) || num_blocks_w_dim > 1) {
+                    bias_cb.wait_front(bias_ntiles);
+                }
+                for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
+                    int in1_index_subblock_offset = 0;
+                    for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
+                        // See matmul stage: the last in1 subblock has padded lanes whose bias tile was
+                        // never pushed by the reader. Redirect those out-of-range bias_tile_idx reads to
+                        // tile 0 of cb_bias to keep them in-bounds; the resulting padded output columns
+                        // are dropped by the writer.
+                        const bool is_last_in1_subblock_padded =
+                            last_subblock_padded && (in1_subblock == in1_num_subblocks - 1);
+                        // Redundant wait since we know data was just pushed
+                        mm_partials_cb.wait_front(out_subblock_num_tiles);
+                        tile_regs_acquire();
+                        for (uint32_t i = 0, j = 0; j < out_subblock_h; j++) {
+                            uint32_t bias_tile_idx = in1_index_subblock_offset;
+                            for (uint32_t k = 0; k < out_subblock_w; k++, i++) {
+                                const uint32_t safe_bias_tile_idx =
+                                    (is_last_in1_subblock_padded && k >= last_subblock_w_valid)
+                                        ? 0u              // Padded output columns with tile 0 of cb_bias added are
+                                        : bias_tile_idx;  // dropped by the writer.
+
+                                if constexpr (row_broadcast_bias) {
+                                    add_tiles_bcast_rows(mm_partials_cb_id, bias_cb_id, i, safe_bias_tile_idx, i);
+                                } else {
+                                    add_tiles(mm_partials_cb_id, bias_cb_id, i, safe_bias_tile_idx, i);
+                                }
+                                bias_tile_idx++;
+                            }
+                        }
+                        tile_regs_commit();
+
+                        mm_partials_cb.pop_front(out_subblock_num_tiles);
+
+                        // Pack out to output buffer
+                        untilize_mode_out_cb.reserve_back(out_subblock_num_tiles);
+
+#ifdef SFPU_ACTIVATION
+                        PACK(TTI_SEMWAIT(
+                            p_stall::STALL_TDMA | p_stall::STALL_CFG,
+                            semaphore::t6_sem(semaphore::MATH_PACK),
+                            p_stall::STALL_ON_ZERO));
+
+                        // Flip destination register offset for PACKER access
+                        PACK(TT_SETC16(
+                            DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, ckernel::packer::get_packer_dest_offset()));
+
+                        for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
+                            ActivationApplyHelper<activation_type, activation_param0, activation_param1>::apply(i);
+                        }
+
+                        PACK(TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::WAIT_SFPU));
+#else
+                        tile_regs_wait();
+#endif
+                        for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
+                            pack_tile(i, untilize_mode_out_cb_id);
+                        }
+                        tile_regs_release();
+                        untilize_mode_out_cb.push_back(out_subblock_num_tiles);
+
+                        in1_index_subblock_offset += out_subblock_w;
+                    }
+                }
+                if constexpr (num_blocks_w_dim > 1) {
+                    bias_cb.pop_front(bias_ntiles);
+                }
+#endif  // FUSE_BIAS
+                if constexpr (untilize_out) {
+#ifdef PACK_RELU
+                    PACK((llk_pack_relu_config(ReluConfig::none())));
+#endif  // PACK_RELU
+#ifndef FUSE_BIAS
+                    reconfig_data_format_srca(in1_cb_id, mm_partials_cb_id);
+#if defined FP32_DEST_ACC_EN or defined PACKER_L1_ACC
+                    PACK((pack_reconfig_data_format(out_cb_id)));
+#endif
+#ifdef PACKER_L1_ACC
+                    PACK((llk_pack_reconfig_l1_acc(0)));
+#endif
+#endif  // FUSE_BIAS
+                    pack_untilize_dest_init<out_subblock_w, out_block_w>(out_cb_id);
+                    copy_tile_to_dst_init_short(mm_partials_cb_id);
+                    for (uint32_t in0_subblock_i = 0; in0_subblock_i < in0_num_subblocks; ++in0_subblock_i) {
+                        reblock_and_untilize<out_subblock_w, out_block_w>(
+                            in1_num_subblocks, out_subblock_num_tiles, out_subblock_h, mm_partials_cb_id, out_cb_id);
+                    }
+                    pack_untilize_uninit(mm_partials_cb_id);
+                }
+                if constexpr (batch > 1 || num_blocks_w_dim > 1 || num_blocks_h_dim > 1) {
+#ifdef FUSE_BIAS
+                    // reconfigure unpacker df for src A and src B
+                    reconfig_data_format(mm_partials_cb_id, in1_cb_id, bias_cb_id, in0_cb_id);
+#else
+                    // reconfigure unpacker df for src A
+                    reconfig_data_format_srca(mm_partials_cb_id, in1_cb_id);
+#endif
+                    // reconfigure init for matmul
+                    mm_block_init_short(
+                        in0_cb_id, in1_cb_id, in1_transpose_tile, out_subblock_w, out_subblock_h, in0_block_w);
+                }
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
@@ -1,0 +1,486 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/matmul.h"
+#include "api/compute/pack_untilize.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/dataflow/circular_buffer.h"
+#include "internal/mod_div_lib.h"
+
+#ifdef SFPU_ACTIVATION
+#include "bmm_fused_activation.hpp"
+#endif
+
+enum class CORE_TYPE : uint8_t { IDLE_CORE = 0, WORKER_CORE = 1, HOP_CORE = 2 };
+
+FORCE_INLINE void reload_from_cb_to_dst(
+    uint32_t in0_cb_id,
+    uint32_t in1_cb_id,
+    uint32_t mm_partials_cb_id,
+    bool in1_transpose_tile,
+    uint32_t out_subblock_num_tiles,
+    uint32_t out_subblock_w,
+    uint32_t out_subblock_h,
+    uint32_t in0_block_w) {
+    CircularBuffer mm_partials_cb(mm_partials_cb_id);
+    // Reconfigure input
+    copy_tile_to_dst_init_short_with_dt(in1_cb_id, mm_partials_cb_id);
+    mm_partials_cb.wait_front(out_subblock_num_tiles);
+
+    uint32_t start_dst_index = 0;
+    uint32_t start_tile_index = 0;
+    copy_block_matmul_partials(mm_partials_cb_id, start_tile_index, start_dst_index, out_subblock_num_tiles);
+
+    mm_partials_cb.pop_front(out_subblock_num_tiles);
+    // Reconfigure srcA back
+    mm_block_init_short_with_dt(
+        in0_cb_id, in1_cb_id, mm_partials_cb_id, in1_transpose_tile, out_subblock_w, out_subblock_h, in0_block_w);
+}
+
+FORCE_INLINE uint32_t get_local_cb_rd_ptr(uint32_t cb_id) {
+    LocalCBInterface& local_cb = get_local_cb_interface(cb_id);
+    return local_cb.fifo_rd_ptr;
+}
+
+FORCE_INLINE void update_local_cb_rd_ptr(uint32_t cb_id, uint32_t val) {
+    LocalCBInterface& local_cb = get_local_cb_interface(cb_id);
+    local_cb.fifo_rd_ptr = val;
+}
+
+FORCE_INLINE uint32_t get_local_cb_start_addr(uint32_t cb_id) {
+    LocalCBInterface& local_cb = get_local_cb_interface(cb_id);
+    uint32_t fifo_size = local_cb.fifo_size;
+    uint32_t fifo_limit = local_cb.fifo_limit;
+    uint32_t fifo_start_addr = fifo_limit - fifo_size;
+    return fifo_start_addr;
+}
+
+FORCE_INLINE bool is_tensor_split(uint32_t cb_id, uint32_t tensor_size_bytes) {
+    LocalCBInterface& local_cb = get_local_cb_interface(cb_id);
+    uint32_t fifo_rd_ptr = local_cb.fifo_rd_ptr;
+    uint32_t fifo_limit = local_cb.fifo_limit;
+    bool split = (fifo_limit - fifo_rd_ptr) < tensor_size_bytes / L1_ALIGNMENT;
+    return split;
+}
+
+FORCE_INLINE void calculate_next_block_index_and_update_rd_ptr(
+    uint32_t cb_id,
+    uint32_t num_blocks,
+    uint32_t block_size_bytes,
+    uint32_t curr_block_index,
+    uint32_t cb_start_addr,
+    uint32_t rd_ptr_start_addr,
+    bool tensor_split,
+    uint32_t* updated_block_index,
+    uint32_t* updated_rd_ptr) {
+    LocalCBInterface& local_cb = get_local_cb_interface(cb_id);
+    uint32_t next_block_index = curr_block_index + 1;
+    uint32_t next_fifo_rd_ptr = local_cb.fifo_rd_ptr;
+    uint32_t block_size_bytes_aligned = block_size_bytes / L1_ALIGNMENT;
+    bool reach_limit = local_cb.fifo_rd_ptr == local_cb.fifo_limit;
+    bool last_block = curr_block_index == (num_blocks - 1);
+    if (tensor_split) {
+        if (reach_limit) {
+            local_cb.fifo_rd_ptr = cb_start_addr;
+            if (last_block) {
+                next_block_index = 0;
+                next_fifo_rd_ptr = rd_ptr_start_addr;
+            } else {
+                next_fifo_rd_ptr = cb_start_addr + block_size_bytes_aligned;
+            }
+        } else {
+            if (last_block) {
+                next_block_index = 0;
+                next_fifo_rd_ptr = rd_ptr_start_addr;
+            } else {
+                next_fifo_rd_ptr += block_size_bytes_aligned;
+            }
+        }
+    } else {
+        if (last_block) {
+            next_block_index = 0;
+            next_fifo_rd_ptr = rd_ptr_start_addr;
+        } else {
+            next_fifo_rd_ptr += block_size_bytes_aligned;
+        }
+    }
+    *updated_block_index = next_block_index;
+    *updated_rd_ptr = next_fifo_rd_ptr;
+}
+
+FORCE_INLINE void update_rd_ptr_to_ring_index(
+    uint32_t cb_id, uint32_t block_size_bytes, uint32_t ring_index, bool tensor_split) {
+    LocalCBInterface& local_cb = get_local_cb_interface(cb_id);
+
+    if (tensor_split) {
+        if ((local_cb.fifo_rd_ptr + ring_index * block_size_bytes / L1_ALIGNMENT) >= local_cb.fifo_limit) {
+            uint32_t fifo_size = local_cb.fifo_size;
+            uint32_t fifo_limit = local_cb.fifo_limit;
+            uint32_t fifo_start_addr = fifo_limit - fifo_size;
+            uint32_t fifo_size_skip_bytes = local_cb.fifo_rd_ptr - fifo_start_addr;
+            local_cb.fifo_rd_ptr =
+                fifo_start_addr +
+                (fifo_size_skip_bytes + ring_index * block_size_bytes / L1_ALIGNMENT) % local_cb.fifo_size;
+
+        } else {
+            local_cb.fifo_rd_ptr = local_cb.fifo_rd_ptr + ring_index * block_size_bytes / L1_ALIGNMENT;
+        }
+    } else {
+        local_cb.fifo_rd_ptr = local_cb.fifo_rd_ptr + ring_index * block_size_bytes / L1_ALIGNMENT;
+    }
+}
+
+// Named CB arg lookup tables for batch-indexed output and partials CBs.
+// The factory emits "cb_mm_out_0" .. "cb_mm_out_N" and "cb_mm_partials_0" .. "cb_mm_partials_N"
+// as named compile-time args. These tables let fill_named_cb_array resolve them by index.
+constexpr const char* mm_out_cb_names[] = {
+    "cb_mm_out_0",
+    "cb_mm_out_1",
+    "cb_mm_out_2",
+    "cb_mm_out_3",
+    "cb_mm_out_4",
+    "cb_mm_out_5",
+    "cb_mm_out_6",
+    "cb_mm_out_7",
+    "cb_mm_out_8",
+    "cb_mm_out_9",
+    "cb_mm_out_10",
+    "cb_mm_out_11",
+    "cb_mm_out_12",
+    "cb_mm_out_13",
+    "cb_mm_out_14",
+    "cb_mm_out_15",
+};
+constexpr const char* mm_partials_cb_names[] = {
+    "cb_mm_partials_0",
+    "cb_mm_partials_1",
+    "cb_mm_partials_2",
+    "cb_mm_partials_3",
+    "cb_mm_partials_4",
+    "cb_mm_partials_5",
+    "cb_mm_partials_6",
+    "cb_mm_partials_7",
+    "cb_mm_partials_8",
+    "cb_mm_partials_9",
+    "cb_mm_partials_10",
+    "cb_mm_partials_11",
+    "cb_mm_partials_12",
+    "cb_mm_partials_13",
+    "cb_mm_partials_14",
+    "cb_mm_partials_15",
+};
+
+template <uint32_t N>
+constexpr std::array<uint32_t, N> fill_named_cb_array(const char* const* names) {
+    std::array<uint32_t, N> arr{};
+    for (uint32_t i = 0; i < N; ++i) {
+        arr[i] = get_named_compile_time_arg_val(names[i]);
+    }
+    return arr;
+}
+
+void kernel_main() {
+    // Compile time args
+    constexpr uint32_t in0_block_w = get_compile_time_arg_val(0);        // inner block size in tiles
+    constexpr uint32_t in0_num_subblocks = get_compile_time_arg_val(1);  // outer row block size (in inner row blocks)
+    constexpr uint32_t in0_block_num_tiles =
+        get_compile_time_arg_val(2);  // out_subblock_h*in0_block_w*in0_num_subblocks;
+    constexpr uint32_t in0_subblock_num_tiles = get_compile_time_arg_val(3);  // out_subblock_h*in0_block_w
+    constexpr uint32_t in1_num_subblocks =
+        get_compile_time_arg_val(4);  // outer column block size (in inner column blocks)
+    constexpr uint32_t in1_block_num_tiles =
+        get_compile_time_arg_val(5);  // out_subblock_w*in0_block_w* in1_num_subblocks;
+    constexpr uint32_t in1_block_size_bytes = get_compile_time_arg_val(6);
+    constexpr uint32_t in1_tensor_size_bytes = get_compile_time_arg_val(7);
+    constexpr uint32_t in1_per_core_w = get_compile_time_arg_val(8);           // out_subblock_w*in1_num_subblocks
+    constexpr uint32_t num_blocks = get_compile_time_arg_val(9);               // outer inner dim (in inner dim blocks)
+    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(10);          // inner row block size in tiles
+    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(11);          // inner column block size in tiles
+    constexpr uint32_t out_subblock_num_tiles = get_compile_time_arg_val(12);  // out_subblock_h * out_subblock_w;
+    constexpr uint32_t batch = get_compile_time_arg_val(13);                   // batch dim
+    constexpr uint32_t out_block_num_tiles = get_compile_time_arg_val(14);     // number of tiles in out_block
+    constexpr bool untilize_out = get_compile_time_arg_val(15);                // untilize output
+    constexpr bool in1_is_dram_interleaved = get_compile_time_arg_val(16);     // in1 is in dram
+    constexpr bool in1_is_dram_sharded = get_compile_time_arg_val(17);
+    constexpr uint32_t in0_cb_id = get_named_compile_time_arg_val("cb_in0");
+    constexpr uint32_t in1_cb_id = get_named_compile_time_arg_val("cb_in1");
+    constexpr uint32_t in2_cb_id = get_named_compile_time_arg_val("cb_in2");
+    constexpr uint32_t sync_cb = get_named_compile_time_arg_val("cb_sync");
+    constexpr uint32_t sync_cb2 = get_named_compile_time_arg_val("cb_sync2");
+
+#ifdef SFPU_ACTIVATION
+    constexpr KernelActivation activation_type =
+        static_cast<KernelActivation>(get_named_compile_time_arg_val("activation_type"));
+    constexpr uint32_t activation_param0 = get_named_compile_time_arg_val("activation_param0");
+    constexpr uint32_t activation_param1 = get_named_compile_time_arg_val("activation_param1");
+    constexpr uint32_t activation_param2 = get_named_compile_time_arg_val("activation_param2");
+#endif
+
+    CircularBuffer in1_cb(in1_cb_id);
+    CircularBuffer sync_buf(sync_cb);
+    CircularBuffer sync2_buf(sync_cb2);
+
+    constexpr std::array<uint32_t, batch> mm_out_cb_ids = fill_named_cb_array<batch>(mm_out_cb_names);
+    constexpr std::array<uint32_t, batch> mm_partials_cb_ids = fill_named_cb_array<batch>(mm_partials_cb_names);
+
+    constexpr uint32_t ring_size = num_blocks;
+    constexpr bool in1_is_dram = in1_is_dram_interleaved || in1_is_dram_sharded;
+
+    // Runtime args
+    uint32_t rt_args_idx = 0;
+    uint32_t core_type = get_arg_val<uint32_t>(rt_args_idx++);
+    if (core_type == (uint32_t)CORE_TYPE::IDLE_CORE || core_type == (uint32_t)CORE_TYPE::HOP_CORE) {
+        return;
+    }
+    uint32_t ring_idx = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t* unpadded_in0_shard_widths_in_tiles = (uint32_t*)get_arg_addr(rt_args_idx);
+    rt_args_idx += ring_size;
+
+    constexpr uint32_t out_block_w = out_subblock_w * in1_num_subblocks;
+
+#ifdef SFPU_ACTIVATION
+    ActivationInitHelper<activation_type, activation_param0, activation_param1>::init();
+#endif
+
+#ifdef IN1_TRANSPOSE_TILE
+    constexpr uint32_t in1_transpose_tile = true;
+#else
+    constexpr uint32_t in1_transpose_tile = false;
+#endif
+
+    constexpr bool spill = num_blocks > 1 && (out_block_num_tiles / out_subblock_num_tiles) > 1;
+
+    mm_block_init(
+        in0_cb_id, in1_cb_id, mm_partials_cb_ids[0], in1_transpose_tile, out_subblock_w, out_subblock_h, in0_block_w);
+    for (uint32_t b = 0; b < batch; b++) {
+#ifdef ENABLE_GLOBAL_CB
+        uint32_t in1_cb_start_addr = 0;
+        uint32_t in1_rd_ptr_start_addr = 0;
+        uint32_t curr_in1_block_index = 0;
+        bool in1_tensor_split = 0;
+        uint32_t next_in1_block_index;
+        uint32_t next_in1_rd_ptr_addr;
+
+        UNPACK((in1_cb_start_addr = get_local_cb_start_addr(in1_cb_id)));
+        UNPACK((in1_rd_ptr_start_addr = get_local_cb_rd_ptr(in1_cb_id)));
+        UNPACK((curr_in1_block_index = ring_idx));
+        UNPACK((in1_tensor_split = is_tensor_split(in1_cb_id, in1_tensor_size_bytes)));
+        UNPACK((update_rd_ptr_to_ring_index(in1_cb_id, in1_block_size_bytes, ring_idx, in1_tensor_split)));
+#endif
+        const uint32_t mm_out_cb_id = mm_out_cb_ids[b];
+        const uint32_t mm_partials_cb_id = mm_partials_cb_ids[b];
+        CircularBuffer mm_out_cb(mm_out_cb_id);
+        CircularBuffer mm_partials_cb(mm_partials_cb_id);
+
+        bool enable_reload = false;
+        uint32_t out_num_tiles_to_wait = out_subblock_num_tiles;
+
+#ifdef PACK_RELU
+        // for each batch we start we relu disabled so that intermediate results are not relu'd
+        if constexpr (batch > 1) {
+            PACK((llk_pack_relu_config(ReluConfig::none())));
+        }
+#endif
+
+        if constexpr (batch > 1) {
+            PACK((pack_reconfig_data_format(mm_partials_cb_id)));
+        }
+
+        // Wait to receive in1
+        sync2_buf.wait_front(1);
+        sync2_buf.pop_front(1);
+
+        for (uint32_t block = 0; block < num_blocks; block++) {
+            const uint32_t curr_ring_idx = (ring_idx + block) % ring_size;
+            uint32_t unpadded_in0_block_w = unpadded_in0_shard_widths_in_tiles[curr_ring_idx];
+
+            // Wait for in1 block
+            if constexpr (in1_is_dram) {
+                in1_cb.wait_front(in1_block_num_tiles);
+            }
+
+            const uint32_t input0_cb_id = block == 0 ? in0_cb_id : in2_cb_id;
+            CircularBuffer input0_cb(input0_cb_id);
+            bool last_out = block == (num_blocks - 1);
+// Configure packer once for pack out without Bias
+#if not defined FUSE_BIAS and defined PACK_RELU
+            if (last_out) {
+                // if last block we pack the final result with relu enabled
+                PACK((llk_pack_relu_config(ReluConfig::zero())));
+            }
+#endif
+
+            // Wait to receive in0 block
+            if (block == 0) {
+                input0_cb.reserve_back(in0_block_num_tiles);
+                input0_cb.push_back(in0_block_num_tiles);
+            }
+            input0_cb.wait_front(in0_block_num_tiles);
+
+#ifdef ENABLE_GLOBAL_CB
+            UNPACK((calculate_next_block_index_and_update_rd_ptr(
+                in1_cb_id,
+                num_blocks,
+                in1_block_size_bytes,
+                curr_in1_block_index,
+                in1_cb_start_addr,
+                in1_rd_ptr_start_addr,
+                in1_tensor_split,
+                &next_in1_block_index,
+                &next_in1_rd_ptr_addr)));
+#endif
+
+            int in0_index_subblock_offset = 0;
+            for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
+#ifdef ENABLE_GLOBAL_CB
+                int in1_index_subblock_offset = 0;
+#else
+                // This should always be 0 when reading in1 from DRAM
+                int in1_index_subblock_offset = in1_is_dram ? 0 : in1_block_num_tiles * (curr_ring_idx);
+#endif
+                for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
+                    tile_regs_acquire();
+                    if (enable_reload) {
+                        reload_from_cb_to_dst(
+                            input0_cb_id,
+                            in1_cb_id,
+                            mm_partials_cb_id,
+                            in1_transpose_tile,
+                            out_subblock_num_tiles,
+                            out_subblock_w,
+                            out_subblock_h,
+                            in0_block_w);
+                    }
+
+#ifndef SKIP_COMPUTE
+                    // Compute output sub-block
+                    uint32_t dst_index = 0;  // start at 0, each call to matmul_block internally increments dst_index
+                    uint32_t in0_index = in0_index_subblock_offset;  // offset into in0 block
+                    uint32_t in1_index = in1_index_subblock_offset;  // offset into in1 block
+                    // inner dim that we accumulate is the inner dim of in0/in1, which is in0_block_w
+                    for (uint32_t inner_dim_idx = 0; inner_dim_idx < unpadded_in0_block_w; ++inner_dim_idx) {
+                        // matmul outer product of (out_subblock_h x out_subblock_w) tiles that fill dst
+                        // accumulation is done by iterating matmul_block across inner dim
+                        // in0_block_w is passed as innder dim (kt) to matmul_block, internally used to stride in0
+                        matmul_block(
+                            input0_cb_id,
+                            in1_cb_id,
+                            in0_index,
+                            in1_index,
+                            dst_index,
+                            in1_transpose_tile,
+                            out_subblock_w,
+                            out_subblock_h,
+                            in0_block_w);
+                        in0_index++;                  // stride right by 1
+                        in1_index += in1_per_core_w;  // to stride down by 1 need to stride by in_per_core_w (should be
+                                                      // called in1_block_w)
+                    }
+
+#endif  // SKIP_COMPUTE
+
+                    if (last_out) {
+                        if constexpr (untilize_out) {
+                            pack_untilize_dest_init<out_subblock_num_tiles>(mm_out_cb_id);
+                        }
+                        tile_regs_commit();
+                        // Pack out to output buffer
+                        mm_out_cb.reserve_back(out_subblock_num_tiles);
+
+#if not defined FUSE_BIAS and defined SFPU_ACTIVATION
+                        apply_activation_from_pack<
+                            activation_type,
+                            activation_param0,
+                            activation_param1,
+                            activation_param2>(out_subblock_num_tiles);
+#else
+                        tile_regs_wait();
+#endif
+
+#if defined FP32_DEST_ACC_EN or defined PACKER_L1_ACC
+                        PACK((pack_reconfig_data_format(mm_out_cb_id)));
+#endif
+
+#ifdef PACKER_L1_ACC
+
+                        PACK((llk_pack_reconfig_l1_acc(0)));
+#endif
+
+                        uint32_t start_dst_index = 0;
+                        if constexpr (untilize_out) {
+                            pack_untilize_dest<out_subblock_num_tiles>(mm_out_cb_id);
+                        } else {
+                            pack_tile_block(start_dst_index, mm_out_cb_id, out_subblock_num_tiles);
+                        }
+
+                        tile_regs_release();
+                        if constexpr (untilize_out) {
+                            pack_untilize_uninit(mm_out_cb_id);
+                        }
+                        mm_out_cb.push_back(out_subblock_num_tiles);
+
+                    } else if (spill) {
+                        tile_regs_commit();
+                        // Move partial result to interm buffer
+                        mm_partials_cb.reserve_back(out_subblock_num_tiles);
+                        tile_regs_wait();
+
+#ifdef PACKER_L1_ACC
+                        if (block == 0) {  // no accumulation for first iteration
+                            PACK((llk_pack_reconfig_l1_acc(0)));
+                        } else if (block == 1) {
+                            PACK((llk_pack_reconfig_l1_acc(1)));
+                        }
+#endif
+
+                        uint32_t start_dst_index = 0;
+                        pack_tile_block(start_dst_index, mm_partials_cb_id, out_subblock_num_tiles);
+
+                        tile_regs_release();
+                        mm_partials_cb.push_back(out_subblock_num_tiles);
+                    }
+
+                    in1_index_subblock_offset += out_subblock_w;
+                }
+                in0_index_subblock_offset += in0_subblock_num_tiles;
+            }
+
+#ifdef PACKER_L1_ACC
+
+            // Last iteration does spill and reload to output buffer
+            if (block < num_blocks - 2 && spill) {
+                mm_partials_cb.wait_front(out_block_num_tiles);
+                mm_partials_cb.pop_front(out_block_num_tiles);
+            }
+            if (block == num_blocks - 2 && spill) {
+                enable_reload = true;
+            }  // reload when last iteration
+#else
+            if constexpr (spill) {
+                enable_reload = true;
+            }
+#endif
+
+            input0_cb.pop_front(in0_block_num_tiles);
+            if constexpr (in1_is_dram) {
+                in1_cb.pop_front(in1_block_num_tiles);
+            }
+#ifdef ENABLE_GLOBAL_CB
+            curr_in1_block_index = next_in1_block_index;
+            UNPACK((update_local_cb_rd_ptr(in1_cb_id, next_in1_rd_ptr_addr)));
+#endif
+        }
+
+#ifdef ENABLE_GLOBAL_CB
+        // Release in1
+        sync_buf.reserve_back(1);
+        sync_buf.push_back(1);
+        UNPACK((update_local_cb_rd_ptr(in1_cb_id, in1_rd_ptr_start_addr)));  // reset rd_ptr back to the initial addr
+        UNPACK((update_rd_ptr_to_ring_index(
+            in1_cb_id, in1_block_size_bytes, ring_size, in1_tensor_split)));  // update to next tensor addr
+#endif
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned.cpp
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "ttnn/operations/kernel_helper_functions/pad_tile.hpp"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    // same arg indices as in reader_binary_diff_lengths for compat
+    uint32_t src0_addr = get_arg_val<uint32_t>(0);
+    uint32_t src1_addr = get_arg_val<uint32_t>(1);
+    uint32_t Mt = get_arg_val<uint32_t>(2);
+    uint32_t Kt = get_arg_val<uint32_t>(3);
+    uint32_t Nt = get_arg_val<uint32_t>(4);
+    uint32_t MtKt = get_arg_val<uint32_t>(5);  // if 0
+    uint32_t KtNt = get_arg_val<uint32_t>(6);
+    uint32_t batch = get_arg_val<uint32_t>(7);
+    uint32_t bcast_B = get_arg_val<uint32_t>(8);  // if 1 we broadcast B to batch
+    uint32_t output_tile_start_id = get_arg_val<uint32_t>(9);
+    uint32_t num_output_tiles = get_arg_val<uint32_t>(10);
+    uint32_t MtNt = get_arg_val<uint32_t>(11);
+
+    constexpr uint32_t in0_last_ktile_w = get_compile_time_arg_val(0);
+    constexpr uint32_t in0_last_ktile_h = get_compile_time_arg_val(1);
+    constexpr auto src0_args = TensorAccessorArgs<2>();
+    constexpr auto src1_args = TensorAccessorArgs<src0_args.next_compile_time_args_offset()>();
+
+    // DPRINT("Mt={} Kt={} Nt={} MtKt={} KtNt={}\n", Mt, Kt, Nt, MtKt, KtNt);
+    // DPRINT("src0={} src1={}\n", src0_addr, src1_addr);
+    // DPRINT("batch={}\n", batch);
+
+    constexpr uint32_t cb_id_in0 = get_named_compile_time_arg_val("cb_in0");
+    constexpr uint32_t cb_id_in1 = get_named_compile_time_arg_val("cb_in1");
+
+    constexpr uint32_t onetile = 1;
+    const uint32_t in0_tile_bytes = get_tile_size(cb_id_in0);
+    const uint32_t in1_tile_bytes = get_tile_size(cb_id_in1);
+
+    uint32_t itileA = output_tile_start_id / Nt * Kt;  // input0 row = output row * input0 width
+
+    // Keep track of end of output row and end of output batch
+    uint32_t outbatch = output_tile_start_id % MtNt;
+    uint32_t itileB_batch = output_tile_start_id % Nt;
+    uint32_t itileB = itileB_batch;  // input1 col = output col if we are bcasting
+    if (bcast_B == 0) {
+        itileB += output_tile_start_id / MtNt * KtNt;  // offset into correct batch if not bcasting
+    }
+
+    const auto s0 = TensorAccessor(src0_args, src0_addr);
+    const auto s1 = TensorAccessor(src1_args, src1_addr);
+
+    Noc noc;
+    CircularBuffer cb_in0(cb_id_in0);
+    CircularBuffer cb_in1(cb_id_in1);
+
+    for (uint32_t n = 0; n < num_output_tiles; n++) {
+        for (uint32_t kt = 0; kt < Kt; kt++) {
+            {  // Read A's tile at (mt, kt)
+                cb_in0.reserve_back(onetile);
+                noc.async_read(s0, cb_in0, in0_tile_bytes, {.page_id = itileA}, {.offset_bytes = 0});
+                noc.async_read_barrier();
+                if constexpr (in0_last_ktile_w > 0) {
+                    if (kt == Kt - 1) {
+                        constexpr DataFormat in0_data_format = get_dataformat(cb_id_in0);
+                        pad_last_ktile<in0_data_format, in0_last_ktile_w>(cb_in0.get_write_ptr());
+                    }
+                }
+                if constexpr (in0_last_ktile_h > 0) {
+                    if (kt == Kt - 1) {
+                        constexpr DataFormat in0_data_format = get_dataformat(cb_id_in0);
+                        pad_last_transposed_ktile<in0_data_format, in0_last_ktile_h>(cb_in0.get_write_ptr());
+                    }
+                }
+                cb_in0.push_back(onetile);
+            }
+
+            {  // Read B's tile at (kt, nt)
+                cb_in1.reserve_back(onetile);
+                noc.async_read(s1, cb_in1, in1_tile_bytes, {.page_id = itileB}, {.offset_bytes = 0});
+                noc.async_read_barrier();
+                cb_in1.push_back(onetile);
+            }
+            // DPRINT("Pushed itileA={} itileB={}\n", itileA, itileB);
+
+            itileA += 1;   // A is MK
+            itileB += Nt;  // B is KN, so to get k++ we stride by Nt
+        }  // Kt loop
+        outbatch += 1;
+        itileB_batch += 1;
+        itileB -= KtNt;  // revert B to previous state before the K loop (to avoid multiplies)
+        itileB += 1;     // Move to next B col
+
+        if (itileB_batch == Nt) {
+            itileB_batch = 0;
+            itileB -= Nt;  // Go back to first column in batch
+            if (outbatch == MtNt) {
+                if (bcast_B == 0) {
+                    itileB += KtNt;  // Move B to start of next batch
+                }
+                outbatch = 0;
+            }
+        } else {
+            itileA -= Kt;  // resets tileA to kt=0, keep the same mt
+        }
+    }  // batch loop
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout.cpp
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    bool one_time_profile = true;
+
+    // in0 tensor args
+    uint32_t in0_tensor_addr = get_arg_val<uint32_t>(0);
+    uint32_t in0_tensor_start_tile_id = get_arg_val<uint32_t>(1);
+    uint32_t in0_tensor_stride_w = get_arg_val<uint32_t>(2);
+    uint32_t in0_tensor_stride_h = get_arg_val<uint32_t>(3);
+    uint32_t in0_tensor_next_block_stride = get_arg_val<uint32_t>(4);
+
+    // in0 block args
+    uint32_t in0_block_w = get_arg_val<uint32_t>(5);
+    uint32_t in0_block_h = get_arg_val<uint32_t>(6);
+    uint32_t in0_block_num_tiles = get_arg_val<uint32_t>(7);
+
+    // in1 tensor args
+    uint32_t in1_tensor_addr = get_arg_val<uint32_t>(8);
+    uint32_t in1_tensor_start_tile_id = get_arg_val<uint32_t>(9);
+    uint32_t in1_tensor_stride_w = get_arg_val<uint32_t>(10);
+    uint32_t in1_tensor_stride_h = get_arg_val<uint32_t>(11);
+    uint32_t in1_tensor_next_block_stride = get_arg_val<uint32_t>(12);
+
+    // in1 block args
+    uint32_t in1_block_w = get_arg_val<uint32_t>(13);
+    uint32_t in1_block_h = get_arg_val<uint32_t>(14);
+    uint32_t in1_block_num_tiles = get_arg_val<uint32_t>(15);
+
+    // in0/in1 common args
+    uint32_t num_blocks = get_arg_val<uint32_t>(16);
+
+    // batch args
+    uint32_t MtKt = get_arg_val<uint32_t>(17);  // if 0
+    uint32_t KtNt = get_arg_val<uint32_t>(18);
+    uint32_t batch = get_arg_val<uint32_t>(19);
+    uint32_t bcast_B = get_arg_val<uint32_t>(20);
+
+    constexpr auto in0_args = TensorAccessorArgs<0>();
+    constexpr auto in1_args = TensorAccessorArgs<in0_args.next_compile_time_args_offset()>();
+
+    constexpr uint32_t cb_id_in0 = get_named_compile_time_arg_val("cb_in0");
+    constexpr uint32_t cb_id_in1 = get_named_compile_time_arg_val("cb_in1");
+
+    const uint32_t in0_single_tile_size_bytes = get_tile_size(cb_id_in0);
+    const uint32_t in1_single_tile_size_bytes = get_tile_size(cb_id_in1);
+
+    const auto s0 = TensorAccessor(in0_args, in0_tensor_addr);
+    const auto s1 = TensorAccessor(in1_args, in1_tensor_addr);
+
+    Noc noc;
+    CircularBuffer cb_in0(cb_id_in0);
+    CircularBuffer cb_in1(cb_id_in1);
+
+    for (uint32_t b = 0; b < batch; b++) {
+        uint32_t in0_tensor_current_block_start_tile_id = in0_tensor_start_tile_id;
+        uint32_t in1_tensor_current_block_start_tile_id = in1_tensor_start_tile_id;
+        for (uint32_t block = 0; block < num_blocks; block++) {
+            cb_in0.reserve_back(in0_block_num_tiles);
+            cb_in1.reserve_back(in1_block_num_tiles);
+
+            uint32_t in0_write_offset = 0;
+            uint32_t in1_write_offset = 0;
+
+            uint32_t in0_tensor_row_start_tile_id = in0_tensor_current_block_start_tile_id;
+            for (uint32_t h = 0; h < in0_block_h; h++) {
+                uint32_t in0_tensor_tile_id = in0_tensor_row_start_tile_id;
+                for (uint32_t w = 0; w < in0_block_w; w++) {
+                    noc.async_read(
+                        s0,
+                        cb_in0,
+                        in0_single_tile_size_bytes,
+                        {.page_id = in0_tensor_tile_id},
+                        {.offset_bytes = in0_write_offset});
+                    in0_write_offset += in0_single_tile_size_bytes;
+                    in0_tensor_tile_id += in0_tensor_stride_w;
+                }
+                in0_tensor_row_start_tile_id += in0_tensor_stride_h;
+            }
+            in0_tensor_current_block_start_tile_id += in0_tensor_next_block_stride;
+
+            uint32_t in1_tensor_row_start_tile_id = in1_tensor_current_block_start_tile_id;
+            for (uint32_t h = 0; h < in1_block_h; h++) {
+                uint32_t in1_tensor_tile_id = in1_tensor_row_start_tile_id;
+                for (uint32_t w = 0; w < in1_block_w; w++) {
+                    noc.async_read(
+                        s1,
+                        cb_in1,
+                        in1_single_tile_size_bytes,
+                        {.page_id = in1_tensor_tile_id},
+                        {.offset_bytes = in1_write_offset});
+                    in1_write_offset += in1_single_tile_size_bytes;
+                    in1_tensor_tile_id += in1_tensor_stride_w;
+                }
+                in1_tensor_row_start_tile_id += in1_tensor_stride_h;
+            }
+            in1_tensor_current_block_start_tile_id += in1_tensor_next_block_stride;
+
+            noc.async_read_barrier();
+
+            cb_in0.push_back(in0_block_num_tiles);
+            cb_in1.push_back(in1_block_num_tiles);
+        }
+        if (bcast_B == 0) {
+            in1_tensor_start_tile_id += KtNt;
+        }
+        in0_tensor_start_tile_id += MtKt;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0.cpp
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "ttnn/operations/kernel_helper_functions/pad_tile.hpp"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    // RUNTIME ARGS
+    uint32_t rt_args_idx = 0;
+    // in0 tensor args
+    const uint32_t in0_tensor_addr = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t in0_tensor_start_tile_id = get_arg_val<uint32_t>(rt_args_idx++);
+    // batch args
+    const uint32_t batch = get_arg_val<uint32_t>(rt_args_idx++);
+
+    // COMPILE TIME ARGS
+    // in0 tensor args
+    constexpr uint32_t in0_tensor_stride_w = get_compile_time_arg_val(0);
+    constexpr uint32_t in0_tensor_stride_h = get_compile_time_arg_val(1);
+    constexpr uint32_t in0_tensor_next_block_stride = get_compile_time_arg_val(2);
+    // in0 block args
+    constexpr uint32_t in0_block_w = get_compile_time_arg_val(3);
+    constexpr uint32_t in0_block_h = get_compile_time_arg_val(4);
+    constexpr uint32_t in0_block_num_tiles = get_compile_time_arg_val(5);
+    constexpr uint32_t last_ktile_w = get_compile_time_arg_val(6);
+    constexpr uint32_t last_ktile_h = get_compile_time_arg_val(7);
+    // in0/in1 common args
+    constexpr uint32_t num_blocks = get_compile_time_arg_val(8);
+    // batch args
+    constexpr uint32_t bcast_B = get_compile_time_arg_val(9);
+    constexpr uint32_t MtKt = get_compile_time_arg_val(10);
+
+    constexpr auto in0_args = TensorAccessorArgs<11>();
+
+    constexpr uint32_t cb_id_in0 = get_named_compile_time_arg_val("cb_in0");
+
+    Noc noc;
+    CircularBuffer cb_in0(cb_id_in0);
+
+#ifdef IN0_SHARDED
+    const uint32_t in0_num_tiles = batch * num_blocks * in0_block_h * in0_block_w;
+    cb_in0.reserve_back(in0_num_tiles);
+    cb_in0.push_back(in0_num_tiles);
+#else
+
+    constexpr uint32_t in0_single_tile_size_bytes = get_tile_size(cb_id_in0);
+    constexpr const uint32_t in0_tile_hw = get_tile_hw(cb_id_in0);
+    // Tiles whose size is not a multiple of the DRAM alignment are padded to it in DRAM and the in0
+    // CB pages are sized to match (see the program factory), so tiles must be laid out in L1 at the
+    // padded stride. The NOC still reads the unpadded tile of data into each padded slot. No-op when
+    // the tile size is already aligned.
+    constexpr uint32_t in0_aligned_tile_size_bytes =
+        (in0_single_tile_size_bytes + (DRAM_ALIGNMENT - 1)) & ~(DRAM_ALIGNMENT - 1);
+
+    const auto s0 = TensorAccessor(in0_args, in0_tensor_addr);
+
+    for (uint32_t b = 0; b < batch; ++b) {
+        uint32_t in0_tensor_current_block_start_tile_id = in0_tensor_start_tile_id;
+        for (uint32_t block = 0; block < num_blocks; ++block) {
+            cb_in0.reserve_back(in0_block_num_tiles);
+
+            uint32_t in0_write_offset = 0;
+
+            uint32_t in0_tensor_row_start_tile_id = in0_tensor_current_block_start_tile_id;
+            for (uint32_t h = 0; h < in0_block_h; ++h) {
+                uint32_t in0_tensor_tile_id = in0_tensor_row_start_tile_id;
+                for (uint32_t w = 0; w < in0_block_w; ++w) {
+                    noc.async_read(
+                        s0,
+                        cb_in0,
+                        in0_single_tile_size_bytes,
+                        {.page_id = in0_tensor_tile_id},
+                        {.offset_bytes = in0_write_offset});
+
+                    // Zero out padded regions for the very last tile
+                    if constexpr (last_ktile_w > 0) {
+                        if ((block == num_blocks - 1) && (w == in0_block_w - 1)) {
+                            noc.async_read_barrier();
+                            constexpr DataFormat in0_data_format = get_dataformat(cb_id_in0);
+                            pad_last_ktile<in0_data_format, last_ktile_w>(cb_in0.get_write_ptr() + in0_write_offset);
+                        }
+                    }
+                    if constexpr (last_ktile_h > 0) {
+                        if ((block == num_blocks - 1) && (w == in0_block_w - 1)) {
+                            noc.async_read_barrier();
+                            constexpr DataFormat in0_data_format = get_dataformat(cb_id_in0);
+                            pad_last_transposed_ktile<in0_data_format, last_ktile_h>(
+                                cb_in0.get_write_ptr() + in0_write_offset);
+                        }
+                    }
+
+                    in0_write_offset += in0_aligned_tile_size_bytes;
+                    in0_tensor_tile_id += in0_tensor_stride_w;
+                }
+                in0_tensor_row_start_tile_id += in0_tensor_stride_h;
+            }
+            in0_tensor_current_block_start_tile_id += in0_tensor_next_block_stride;
+
+            noc.async_read_barrier();
+
+            cb_in0.push_back(in0_block_num_tiles);
+        }
+        in0_tensor_start_tile_id += MtKt;
+    }
+#endif  // IN0_SHARDED
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "hostdevcommon/common_values.hpp"
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+void kernel_main() {
+    // in0 mcast args
+    const uint32_t in0_mcast_sender_noc_x = get_arg_val<uint32_t>(0);
+    const uint32_t in0_mcast_sender_noc_y = get_arg_val<uint32_t>(1);
+
+    // COMPILE TIME ARGS
+    // in0 block args
+    constexpr uint32_t in0_block_num_tiles = get_compile_time_arg_val(0);
+    // in0/in1 common args
+    constexpr uint32_t num_blocks_inner_dim = get_compile_time_arg_val(1);
+    constexpr uint32_t num_blocks_w_dim = get_compile_time_arg_val(2);
+    constexpr uint32_t num_blocks_h_dim = get_compile_time_arg_val(3);
+    // in0 mcast args
+    uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(5));
+    // batch args
+    constexpr uint32_t batch = get_compile_time_arg_val(6);
+    // sparsity args
+    // This boolean is set when the number of batches is only known at runtime, typically based on a sparsity tensor.
+    constexpr bool get_batch_from_reader = (bool)get_compile_time_arg_val(7);
+
+    constexpr uint32_t cb_id_in0 = get_named_compile_time_arg_val("cb_in0");
+
+    Noc noc;
+    CircularBuffer cb_in0(cb_id_in0);
+    Semaphore<> sender_sem(get_compile_time_arg_val(4));
+    Semaphore<> receiver_sem(get_compile_time_arg_val(5));
+
+    volatile tt_l1_ptr uint32_t* in0_mcast_receiver_semaphore_addr_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_mcast_receiver_semaphore_addr);
+
+    for (uint32_t b = 0; b < batch; ++b) {
+        if constexpr (get_batch_from_reader) {
+            // This means we have unstructured sparsity.
+            // The compute kernel needs to be made aware whether this batch is valid or not.
+            // We do this by passing the value to the compute kernel via mailbox.
+            // But first, lets wait for the sparsity data to be multicast to us.
+            // Set in0 semaphore value to INVALID
+            receiver_sem.set(INVALID);
+            // Atomic increment source core counter
+            sender_sem.up(noc, in0_mcast_sender_noc_x, in0_mcast_sender_noc_y, 1);
+            // wait on in0 semaphore value to become VALID (set by mcast sender after it multicasts data)
+            receiver_sem.wait_min(VALID);
+
+            const auto is_batch_valid = *in0_mcast_receiver_semaphore_addr_ptr == VALID;
+
+            // We need to pass the value to compute cores regardless of the value of is_batch_valid
+            ckernel::mailbox_write(ckernel::ThreadId::UnpackThreadId, is_batch_valid);
+            ckernel::mailbox_write(ckernel::ThreadId::MathThreadId, is_batch_valid);
+            ckernel::mailbox_write(ckernel::ThreadId::PackThreadId, is_batch_valid);
+
+            // Skip sending the input tensor for this batch as it is not valid.
+            if (!is_batch_valid) {
+                continue;
+            }
+        }
+
+        for (uint32_t bh = 0; bh < num_blocks_h_dim; ++bh) {
+            for (uint32_t bw = 0; bw < num_blocks_w_dim; ++bw) {
+                for (uint32_t block = 0; block < num_blocks_inner_dim; ++block) {
+                    // Operand 0
+                    cb_in0.reserve_back(in0_block_num_tiles);
+
+                    // Set in0 semaphore value to INVALID
+                    receiver_sem.set(INVALID);
+
+                    // Atomic increment source core counter
+                    sender_sem.up(noc, in0_mcast_sender_noc_x, in0_mcast_sender_noc_y, 1);
+
+                    // wait on in0 semaphore value to become VALID (set by mcast sender after it multicasts data)
+                    receiver_sem.wait(VALID);
+
+                    cb_in0.push_back(in0_block_num_tiles);
+                }
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_ring_all_gather.cpp
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "hostdevcommon/common_values.hpp"
+#include "api/debug/dprint.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+
+enum class CORE_TYPE : uint8_t { IDLE_CORE = 0, WORKER_CORE = 1, HOP_CORE = 2 };
+
+void kernel_main() {
+    // Compile time args
+    constexpr uint32_t shard_width_in_tiles = get_compile_time_arg_val(0);
+    constexpr uint32_t shard_height_in_tiles = get_compile_time_arg_val(1);
+    constexpr uint32_t batch = get_compile_time_arg_val(2);
+
+    // All Gather specific
+    constexpr uint32_t ring_size = get_compile_time_arg_val(3);
+
+    // Runtime args
+    uint32_t rt_args_idx = 0;
+    uint32_t core_type = get_arg_val<uint32_t>(rt_args_idx++);
+    if (core_type == (uint32_t)CORE_TYPE::IDLE_CORE) {
+        return;
+    }
+    bool is_hop_core = core_type == (uint32_t)CORE_TYPE::HOP_CORE;
+
+    uint32_t ring_idx = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t next_core_noc_x = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t next_core_noc_y = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t noc_id = get_arg_val<uint32_t>(rt_args_idx++);
+    bool end_of_hop = (bool)get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t* unpadded_in0_shard_widths_in_tiles = nullptr;
+    if (!is_hop_core) {
+        unpadded_in0_shard_widths_in_tiles = (uint32_t*)get_arg_addr(rt_args_idx);
+        rt_args_idx += ring_size;
+    }
+
+    Noc noc_obj(noc_id);
+    Semaphore<> signal_sem(get_compile_time_arg_val(4));
+
+    constexpr uint32_t cb_id_in0 = get_named_compile_time_arg_val("cb_in0");
+    constexpr uint32_t cb_id_in2 = get_named_compile_time_arg_val("cb_in2");
+
+    CircularBuffer cb_in0(cb_id_in0);
+    CircularBuffer cb_in2(cb_id_in2);
+
+    constexpr uint32_t in0_single_tile_size_bytes = get_tile_size(cb_id_in0);
+    constexpr uint32_t shard_size_in_tiles = shard_width_in_tiles * shard_height_in_tiles;
+    constexpr uint32_t shard_size_bytes = shard_size_in_tiles * in0_single_tile_size_bytes;
+
+    // Reserving/pushing the local shard is done in compute
+    cb_in2.reserve_back((ring_size - 1) * shard_size_in_tiles);
+
+    uint32_t local_shard_read_addr = cb_in0.get_read_ptr();
+    uint32_t l1_write_addr_in0 = cb_in2.get_write_ptr();
+
+    uint32_t hop_core_offset = static_cast<uint32_t>(is_hop_core);
+
+    for (uint32_t shard_cnt = hop_core_offset; shard_cnt < ring_size; shard_cnt++) {
+        uint32_t curr_ring_idx = (ring_idx + shard_cnt) % ring_size;
+        bool skip_send = !is_hop_core && unpadded_in0_shard_widths_in_tiles[curr_ring_idx] == 0;
+
+        uint32_t curr_shard_write_addr = l1_write_addr_in0 + shard_size_bytes * (shard_cnt - hop_core_offset);
+        uint32_t curr_shard_read_addr =
+            shard_cnt == 0 ? local_shard_read_addr : l1_write_addr_in0 + shard_size_bytes * (shard_cnt - 1);
+
+        // Wait for signal from previous core that data has been added to this core's in0
+        signal_sem.wait_min(shard_cnt);
+
+        // Send data to next core
+        if (shard_cnt < ring_size - 1 || is_hop_core) {  // Skip sending the last shard
+            if (!skip_send) {
+                UnicastEndpoint dst_ep;
+                noc_obj.async_write(
+                    CoreLocalMem<uint32_t>(curr_shard_read_addr),
+                    dst_ep,
+                    shard_size_bytes,
+                    {},
+                    {.noc_x = next_core_noc_x, .noc_y = next_core_noc_y, .addr = curr_shard_write_addr});
+            }
+
+            // Signal the next core that data is ready
+            signal_sem.up(noc_obj, next_core_noc_x, next_core_noc_y, 1);
+        }
+
+        // Do stuff for matmul fusion here
+        if (shard_cnt > 0) {
+            cb_in2.push_back(shard_size_in_tiles);
+        }
+    }
+
+    if (!is_hop_core) {
+        for (uint32_t b = 0; b < batch - 1; ++b) {  // for rest batches, not need to gather in0 anymore
+            cb_in2.reserve_back((ring_size - 1) * shard_size_in_tiles);
+            cb_in2.push_back((ring_size - 1) * shard_size_in_tiles);
+        }
+    }
+    noc_obj.async_atomic_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
@@ -1,0 +1,238 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "hostdevcommon/common_values.hpp"
+#include "ttnn/operations/kernel_helper_functions/pad_tile.hpp"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+
+void kernel_main() {
+    // COMPILE TIME ARGS
+    // in0 block args
+    constexpr uint32_t in0_block_num_tiles = get_compile_time_arg_val(0);
+    constexpr uint32_t in0_block_size_bytes = get_compile_time_arg_val(1);
+    constexpr uint32_t in0_last_ktile_w = get_compile_time_arg_val(2);
+    constexpr uint32_t in0_last_ktile_h = get_compile_time_arg_val(3);
+    // in0 mcast args
+    constexpr uint32_t in0_mcast_num_dests = get_compile_time_arg_val(6);
+    constexpr uint32_t in0_mcast_num_cores = get_compile_time_arg_val(7);
+    // block args
+    constexpr uint32_t num_blocks = get_compile_time_arg_val(8);
+    // in0 mcast args
+    constexpr uint32_t in0_mcast_dest_noc_start_x = get_compile_time_arg_val(9);
+    constexpr uint32_t in0_mcast_dest_noc_start_y = get_compile_time_arg_val(10);
+    constexpr uint32_t in0_mcast_dest_noc_end_x = get_compile_time_arg_val(11);
+    constexpr uint32_t in0_mcast_dest_noc_end_y = get_compile_time_arg_val(12);
+    constexpr uint32_t num_blocks_per_shard = get_compile_time_arg_val(14);
+    constexpr uint32_t in0_block_w = get_compile_time_arg_val(15);
+    constexpr uint32_t in0_block_h = in0_block_num_tiles / in0_block_w;
+    constexpr uint32_t num_storage_cores = num_blocks / num_blocks_per_shard;
+
+    // RUNTIME ARGS
+    const uint32_t worker_core_type = get_arg_val<uint32_t>(0);
+    // if not worker core, skip
+    if (worker_core_type == 0) {
+        return;
+    }
+    const uint32_t sender_id = get_arg_val<uint32_t>(1);
+    const bool is_last_ktile_padded = static_cast<bool>(get_arg_val<uint32_t>(2));
+
+    tt_l1_ptr uint32_t* in0_mcast_sender_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(3));
+    tt_l1_ptr uint32_t* in0_mcast_sender_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(3 + num_storage_cores));
+
+    const uint32_t sender_block_id = sender_id * num_blocks_per_shard;
+
+    constexpr uint32_t cb_id_in0 = get_named_compile_time_arg_val("cb_in0");
+    constexpr uint32_t cb_id_in2 = get_named_compile_time_arg_val("cb_in0_sharded");  // Sharded cb
+
+    constexpr uint32_t in0_single_tile_size_bytes = get_tile_size(cb_id_in0);
+    constexpr DataFormat in0_data_format = get_dataformat(cb_id_in0);
+
+    Noc noc;
+    CircularBuffer cb_in0(cb_id_in0);
+    CircularBuffer cb_in2(cb_id_in2);
+    Semaphore<> sender_sem(get_compile_time_arg_val(4));
+    Semaphore<> receiver_sem(get_compile_time_arg_val(5));
+
+    uint32_t l1_write_addr_in0;
+
+    // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
+    receiver_sem.set(VALID);
+    // local address that will be atomically incremented by mcast receivers, to know when all receivers are ready
+    // to receive the mcast
+
+    uint32_t local_read_addr = cb_in2.get_read_ptr();
+
+    if (worker_core_type == 1) {  // mcast sender + no compute
+
+        for (uint32_t i = 0; i < num_blocks_per_shard; ++i) {
+            const uint32_t block_id = sender_block_id + i;
+
+            // Operand 0
+            l1_write_addr_in0 = cb_in0.get_write_ptr();
+            if (block_id % 2 != 0) {  // double buffer
+                l1_write_addr_in0 += in0_block_size_bytes;
+            }
+
+            // copy start address of block, to be used for mcasting
+
+            // wait until all in0 mcast destinations have atomically incremented the in0 semaphore_addr
+            sender_sem.wait(in0_mcast_num_dests);
+            sender_sem.set(0);
+
+            // Now we have the block in the CB address, we can mcast to dests!
+
+            // Zero out padded regions for tiles in the last K-column/row
+            if constexpr (in0_last_ktile_w > 0) {
+                if (is_last_ktile_padded && (i == num_blocks_per_shard - 1)) {
+                    for (uint32_t h = 0; h < in0_block_h; ++h) {
+                        auto in0_last_ktile_ptr =
+                            local_read_addr + (h * in0_block_w + in0_block_w - 1) * in0_single_tile_size_bytes;
+                        pad_last_ktile<in0_data_format, in0_last_ktile_w>(in0_last_ktile_ptr);
+                    }
+                }
+            }
+            if constexpr (in0_last_ktile_h > 0) {
+                if (is_last_ktile_padded && (i == num_blocks_per_shard - 1)) {
+                    for (uint32_t w = 0; w < in0_block_w; ++w) {
+                        auto in0_last_ktile_ptr =
+                            local_read_addr + ((in0_block_h - 1) * in0_block_w + w) * in0_single_tile_size_bytes;
+                        pad_last_transposed_ktile<in0_data_format, in0_last_ktile_h>(in0_last_ktile_ptr);
+                    }
+                }
+            }
+
+#ifndef SKIP_MCAST
+            // num_dests must not include source, since we are NOT really doing a local copy!
+            MulticastEndpoint mcast_dst;
+            noc.async_write_multicast(
+                CoreLocalMem<uint32_t>(local_read_addr),
+                mcast_dst,
+                in0_block_size_bytes,
+                in0_mcast_num_cores - 1,
+                {},
+                {.noc_x_start = in0_mcast_dest_noc_start_x,
+                 .noc_y_start = in0_mcast_dest_noc_start_y,
+                 .noc_x_end = in0_mcast_dest_noc_end_x,
+                 .noc_y_end = in0_mcast_dest_noc_end_y,
+                 .addr = l1_write_addr_in0},
+                true);
+#endif
+
+            receiver_sem.set_multicast(
+                noc,
+                in0_mcast_dest_noc_start_x,
+                in0_mcast_dest_noc_start_y,
+                in0_mcast_dest_noc_end_x,
+                in0_mcast_dest_noc_end_y,
+                in0_mcast_num_cores - 1);
+
+            local_read_addr += in0_block_size_bytes;
+        }
+
+    } else if (worker_core_type == 2) {  // mcast sender + compute
+
+        for (uint32_t block = 0; block < num_blocks; ++block) {
+            const uint32_t block_id = block / num_blocks_per_shard;
+
+            cb_in0.reserve_back(in0_block_num_tiles);
+            // Set in0 semaphore value to INVALID
+            receiver_sem.set(INVALID);
+
+            if (block_id == sender_id) {
+                uint32_t l1_write_addr_in0 = cb_in0.get_write_ptr();
+                // copy start address of block, to be used for mcasting
+
+                // wait until all in0 mcast destinations have atomically incremented the in0 semaphore_addr
+                sender_sem.wait(in0_mcast_num_dests - 1);
+                sender_sem.set(0);
+
+                // Zero out padded regions for tiles in the last K-column/row
+                if constexpr (in0_last_ktile_w > 0) {
+                    if (is_last_ktile_padded && (block == num_blocks - 1)) {
+                        for (uint32_t h = 0; h < in0_block_h; ++h) {
+                            auto in0_last_ktile_ptr =
+                                local_read_addr + (h * in0_block_w + in0_block_w - 1) * in0_single_tile_size_bytes;
+                            pad_last_ktile<in0_data_format, in0_last_ktile_w>(in0_last_ktile_ptr);
+                        }
+                    }
+                }
+                if constexpr (in0_last_ktile_h > 0) {
+                    if (is_last_ktile_padded && (block == num_blocks - 1)) {
+                        for (uint32_t w = 0; w < in0_block_w; ++w) {
+                            auto in0_last_ktile_ptr =
+                                local_read_addr + ((in0_block_h - 1) * in0_block_w + w) * in0_single_tile_size_bytes;
+                            pad_last_transposed_ktile<in0_data_format, in0_last_ktile_h>(in0_last_ktile_ptr);
+                        }
+                    }
+                }
+#ifndef SKIP_MCAST
+                MulticastEndpoint mcast_dst;
+                noc.async_write_multicast<NocOptions::MCAST_INCL_SRC>(
+                    CoreLocalMem<uint32_t>(local_read_addr),
+                    mcast_dst,
+                    in0_block_size_bytes,
+                    in0_mcast_num_cores,
+                    {},
+                    {.noc_x_start = in0_mcast_dest_noc_start_x,
+                     .noc_y_start = in0_mcast_dest_noc_start_y,
+                     .noc_x_end = in0_mcast_dest_noc_end_x,
+                     .noc_y_end = in0_mcast_dest_noc_end_y,
+                     .addr = l1_write_addr_in0},
+                    true);
+#endif
+                // Set local semaphore to VALID. For single-core configurations, this is all we need.
+                receiver_sem.set(VALID);
+                if constexpr (in0_mcast_num_cores > 1) {
+                    receiver_sem.set_multicast<NocOptions::MCAST_INCL_SRC>(
+                        noc,
+                        in0_mcast_dest_noc_start_x,
+                        in0_mcast_dest_noc_start_y,
+                        in0_mcast_dest_noc_end_x,
+                        in0_mcast_dest_noc_end_y,
+                        in0_mcast_num_cores);
+                    // Flush to ensure the NoC has read the VALID value from receiver_sem's L1
+                    // address before the next iteration overwrites it with INVALID.
+                    noc.async_writes_flushed();
+                }
+
+                local_read_addr += in0_block_size_bytes;
+
+            } else {
+                // Atomic increment source core counter
+                sender_sem.up(noc, in0_mcast_sender_noc_x[block_id], in0_mcast_sender_noc_y[block_id], 1);
+            }
+
+            receiver_sem.wait(VALID);
+            cb_in0.push_back(in0_block_num_tiles);
+        }
+    } else {  // mcast receiver + compute
+
+        for (uint32_t block = 0; block < num_blocks; ++block) {
+            const uint32_t block_id = block / num_blocks_per_shard;
+
+            // get the mcast sender noc
+
+            // Operand 0
+            cb_in0.reserve_back(in0_block_num_tiles);
+
+            // Set in0 semaphore value to INVALID
+            receiver_sem.set(INVALID);
+            // Atomic increment source core counter
+            sender_sem.up(noc, in0_mcast_sender_noc_x[block_id], in0_mcast_sender_noc_y[block_id], 1);
+            // wait on in0 semaphore value to become VALID (set by mcast sender after it multicasts data)
+            receiver_sem.wait(VALID);
+
+            cb_in0.push_back(in0_block_num_tiles);
+        }
+    }
+    noc.async_write_barrier();
+    noc.async_atomic_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded_height.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded_height.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Batch-sharded DRAM matmul - in0 reader kernel
+// For batched matmul: [1, B, M, K] x [1, B, K, N] = [1, B, M, N]
+// Each worker handles B/num_workers batches independently
+// Input A is L1 sharded by batch on INPUT STORAGE CORES
+// Workers are on OPTIMAL DRAM READER CORES (different from storage cores)
+// Workers NOC read their in0 shard from their corresponding input storage core
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "hostdevcommon/common_values.hpp"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+
+void kernel_main() {
+    // COMPILE TIME ARGS
+    constexpr uint32_t in0_block_num_tiles = get_compile_time_arg_val(0);   // tiles per block (M * in0_block_w)
+    constexpr uint32_t in0_block_size_bytes = get_compile_time_arg_val(1);  // bytes per block
+    constexpr uint32_t num_blocks = get_compile_time_arg_val(2);            // K / in0_block_w (K blocks in inner loop)
+    constexpr uint32_t num_batches_per_core = get_compile_time_arg_val(3);  // B / num_cores
+    constexpr uint32_t in0_tensor_stride_batch_bytes = get_compile_time_arg_val(4);  // bytes per batch in in0
+    constexpr uint32_t in0_shard_size_bytes = get_compile_time_arg_val(5);           // full shard size in bytes
+
+    // RUNTIME ARGS
+    const uint32_t worker_core_type = get_arg_val<uint32_t>(0);
+    if (worker_core_type == 0) {
+        return;  // idle core
+    }
+
+    // Get the input storage core coordinates and L1 address (where in0 shard is located)
+    const uint32_t input_storage_noc_x = get_arg_val<uint32_t>(1);
+    const uint32_t input_storage_noc_y = get_arg_val<uint32_t>(2);
+    const uint32_t input_shard_l1_addr = get_arg_val<uint32_t>(3);
+
+    constexpr uint32_t cb_id_in0 = get_named_compile_time_arg_val("cb_in0");
+
+    // Build NOC address for the remote input storage core
+    Noc noc;
+    CircularBuffer cb_in0(cb_id_in0);
+    UnicastEndpoint src_core;
+
+    // Process each batch
+    for (uint32_t batch = 0; batch < num_batches_per_core; ++batch) {
+        uint32_t batch_offset = batch * in0_tensor_stride_batch_bytes;
+
+        // Process K blocks within each batch
+        for (uint32_t block = 0; block < num_blocks; ++block) {
+            cb_in0.reserve_back(in0_block_num_tiles);
+
+            // NOC read block from REMOTE input storage core to local CB
+            uint32_t read_offset = batch_offset + block * in0_block_size_bytes;
+            noc.async_read(
+                src_core,
+                cb_in0,
+                in0_block_size_bytes,
+                {.noc_x = input_storage_noc_x, .noc_y = input_storage_noc_y, .addr = input_shard_l1_addr + read_offset},
+                {.offset_bytes = 0});
+            noc.async_read_barrier();
+
+            cb_in0.push_back(in0_block_num_tiles);
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -1,0 +1,440 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/debug/assert.h"
+#include "hostdevcommon/common_values.hpp"
+#include "ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
+#include "ttnn/operations/kernel_helper_functions/pad_tile.hpp"
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/tensor/noc_traits.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+void kernel_main() {
+    uint32_t rt_args_idx = 0;
+    // in0 tensor args
+    const uint32_t in0_tensor_addr = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t in0_tensor_start_tile_id = get_arg_val<uint32_t>(rt_args_idx++);
+    // in0 mcast args
+    const uint32_t in0_mcast_dest_noc_start_x = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t in0_mcast_dest_noc_start_y = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t in0_mcast_dest_noc_end_x = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t in0_mcast_dest_noc_end_y = get_arg_val<uint32_t>(rt_args_idx++);
+
+    // padding args
+    const uint32_t last_block_h = get_arg_val<uint32_t>(rt_args_idx++);
+    // sparsity args
+    const uint32_t sparsity_addr = get_arg_val<uint32_t>(rt_args_idx++);
+
+    // COMPILE TIME ARGS
+    // in0 tensor args
+    constexpr uint32_t in0_tensor_stride_w = get_compile_time_arg_val(0);
+    constexpr uint32_t in0_tensor_stride_h = get_compile_time_arg_val(1);
+    constexpr uint32_t in0_tensor_next_inner_dim_block_stride = get_compile_time_arg_val(2);
+    constexpr uint32_t in0_tensor_next_h_dim_block_stride = get_compile_time_arg_val(3);
+    // in0 block args
+    constexpr uint32_t in0_block_w = get_compile_time_arg_val(4);
+    constexpr uint32_t in0_block_h = get_compile_time_arg_val(5);
+    constexpr uint32_t in0_block_num_tiles = get_compile_time_arg_val(6);
+    constexpr uint32_t in0_last_ktile_w = get_compile_time_arg_val(7);
+    constexpr uint32_t in0_last_ktile_h = get_compile_time_arg_val(8);
+
+    constexpr bool extract_shard_sub_blocks = (bool)get_compile_time_arg_val(9);
+    constexpr uint32_t shard_width_in_tiles = get_compile_time_arg_val(10);
+    constexpr uint32_t shard_height_in_tiles = get_compile_time_arg_val(11);
+    // in0/in1 common args
+    constexpr uint32_t num_blocks_inner_dim = get_compile_time_arg_val(12);
+    constexpr uint32_t num_blocks_w_dim = get_compile_time_arg_val(13);
+    constexpr uint32_t num_blocks_h_dim = get_compile_time_arg_val(14);
+    // in0 mcast args
+    constexpr uint32_t in0_mcast_num_dests = get_compile_time_arg_val(17);
+    constexpr uint32_t in0_mcast_num_cores = get_compile_time_arg_val(18);
+    // batch args
+    constexpr uint32_t MtKt = get_compile_time_arg_val(19);  // if 0
+    constexpr uint32_t in0_B = get_compile_time_arg_val(20);
+    constexpr uint32_t in1_B = get_compile_time_arg_val(21);
+    constexpr uint32_t in0_reuse_in_CB = get_compile_time_arg_val(22);
+
+    // sparsity args
+
+    constexpr uint32_t batchB = get_compile_time_arg_val(23);
+    constexpr uint32_t sparsity_pagesize = get_compile_time_arg_val(24);
+    // Boolean that is set when input A is sparse. If set, both input A and B are assumed to be sparse.
+    // Based on the sparsity tensor, the corresponding batch in input A and B are skipped.
+    constexpr bool bcast_A = (bool)get_compile_time_arg_val(25);
+    // This boolean is set when the number of batches is only known at runtime, typically based on a sparsity tensor.
+    constexpr bool get_batch_from_reader = (bool)get_compile_time_arg_val(26);
+
+    constexpr bool fuse_op = (bool)get_compile_time_arg_val(27);
+
+    constexpr auto in0_args = TensorAccessorArgs<28>();
+
+    constexpr auto sparsity_args = TensorAccessorArgs<in0_args.next_compile_time_args_offset()>();
+
+    // Number of valid (non-zero sparsity) batches the receiver and compute kernels are configured to
+    // process. When nnz is supplied (get_batch_from_reader == false), those kernels loop exactly
+    // num_batch_compute times, while this sender only multicasts once per non-zero sparsity entry, i.e.
+    // count_nonzero(sparsity) times. The op silently requires count_nonzero(sparsity) == num_batch_compute;
+    // if they disagree, the receivers wait on multicasts that never come (or the sender waits on receivers
+    // that already finished) and the device deadlocks. count_nonzero(sparsity) is data-dependent and only
+    // known here at runtime, so we validate it on-device by counting the multicasts we actually issue and
+    // asserting the contract holds -- surfacing a loud assert (under watcher) instead of a silent hang.
+    // See https://github.com/tenstorrent/tt-metal/issues/45943.
+    [[maybe_unused]] constexpr uint32_t num_batch_compute =
+        get_compile_time_arg_val(sparsity_args.next_compile_time_args_offset());
+
+    // 0 is used to specify "INVALID" state, i.e. when the multicasted data has not been received by the receiver.
+    // 0x1 is used to specify "VALID" state, i.e. when the batch is valid.
+    // 0x2 is used to specify "IGNORE_BATCH" state, i.e. when the batch is not valid.
+    constexpr uint32_t IGNORE_BATCH = 0x2;
+
+    // When sparsity is disabled, we just loop once
+    constexpr uint32_t batchB_lim = batchB == 0 ? 1u : batchB;
+
+    MatmulOpReceiver fused_op_receiver;
+    if constexpr (fuse_op) {
+        fused_op_receiver = MatmulOpReceiver(
+            true, /* wait_for_op_signal */
+            rt_args_idx,
+            num_blocks_inner_dim,
+            in0_block_w /* tiles_per_block (in the same dimension as tensor slice) */
+        );
+    }
+
+    constexpr uint32_t cb_id_in0 = get_named_compile_time_arg_val("cb_in0");
+    constexpr uint32_t in0_single_tile_size_bytes = get_tile_size(cb_id_in0);
+    // Tiles whose size is not a multiple of the DRAM alignment are padded to it in DRAM, and the
+    // interleaved in0 CB pages are sized to match (see the program factory). The NOC reads the
+    // unpadded tile of data into each padded slot, and tiles are laid out / multicast at the padded
+    // stride. No-op when already aligned. The sharded path keeps the natural (unpadded) stride.
+    constexpr uint32_t in0_aligned_tile_size_bytes =
+        (in0_single_tile_size_bytes + (DRAM_ALIGNMENT - 1)) & ~(DRAM_ALIGNMENT - 1);
+#ifdef IN0_SHARDED
+    constexpr uint32_t in0_block_size_bytes = in0_block_num_tiles * in0_single_tile_size_bytes;
+#else
+    constexpr uint32_t in0_block_size_bytes = in0_block_num_tiles * in0_aligned_tile_size_bytes;
+#endif
+
+    Noc noc;
+    CircularBuffer cb_in0(cb_id_in0);
+    Semaphore<> sender_sem(get_compile_time_arg_val(15));
+    Semaphore<> receiver_sem(get_compile_time_arg_val(16));
+
+#ifdef IN0_SHARDED
+    // In case we need to send multiple blocks per shard, in0 sharded cb is cb2 and we extract the sub-blocks to cb0
+    constexpr uint32_t shard_read_stride = shard_width_in_tiles * in0_single_tile_size_bytes;
+    constexpr uint32_t shard_read_width = in0_single_tile_size_bytes * in0_block_w;
+    constexpr uint32_t shard_num_tiles = shard_width_in_tiles * shard_height_in_tiles;
+    constexpr uint32_t in0_tensor_next_h_dim_block_stride_bytes =
+        in0_tensor_next_h_dim_block_stride * in0_single_tile_size_bytes;
+
+    uint32_t noc_shard_read_start_addr = 0;
+    if constexpr (extract_shard_sub_blocks) {
+        constexpr uint32_t cb_id_in2 =
+            get_named_compile_time_arg_val("cb_in0_sharded");  // in0 sharded cb if extract_shard_sub_blocks
+        CircularBuffer cb_in2(cb_id_in2);
+        noc_shard_read_start_addr = cb_in2.get_read_ptr();
+    }
+
+#else
+    const auto s0 = TensorAccessor(in0_args, in0_tensor_addr);
+#endif  // IN0_SHARDED
+
+    // sparsity accessor
+    constexpr uint32_t cb_id_sparsity = get_named_compile_time_arg_val("cb_sparsity");
+    CircularBuffer cb_sparsity(cb_id_sparsity);
+    const auto s_sparsity = TensorAccessor(sparsity_args, sparsity_addr);
+
+#ifndef SKIP_MCAST
+    // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
+    receiver_sem.set(VALID);
+    // local address that will be atomically incremented by mcast receivers, to know when all receivers are ready
+    // to receive the mcast
+
+#ifdef IN0_SHARDED
+    uint32_t in0_start_address = cb_in0.get_write_ptr();
+#endif  // IN0_SHARDED
+#endif  // SKIP_MCAST
+
+    uint32_t l1_write_addr_sparsity = 0;
+    if constexpr (batchB > 0) {
+        cb_sparsity.reserve_back(1);
+        l1_write_addr_sparsity = cb_sparsity.get_write_ptr();
+    }
+
+    // Counts the in0 multicasts actually issued (one per non-zero sparsity entry). Used to validate
+    // count_nonzero(sparsity) == num_batch_compute when nnz is supplied (see num_batch_compute above).
+    [[maybe_unused]] uint32_t num_valid_batches = 0;
+
+    for (uint32_t b = 0; b < in0_B; ++b) {
+        if constexpr (batchB > 0) {
+            noc.async_read(s_sparsity, cb_sparsity, sparsity_pagesize, {.page_id = b}, {.offset_bytes = 0});
+            noc.async_read_barrier();
+        }
+
+        for (uint32_t bB = 0; bB < batchB_lim; ++bB) {
+            if constexpr (batchB > 0) {
+                volatile auto is_batch_valid =
+                    ((reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_addr_sparsity))[bB]) != 0;
+
+                if constexpr (get_batch_from_reader) {
+#ifndef SKIP_MCAST
+                    // First broadcast this to other cores
+                    sender_sem.wait(in0_mcast_num_dests);
+                    sender_sem.set(0);
+                    receiver_sem.set(is_batch_valid ? VALID : IGNORE_BATCH);
+                    receiver_sem.set_multicast(
+                        noc,
+                        in0_mcast_dest_noc_start_x,
+                        in0_mcast_dest_noc_start_y,
+                        in0_mcast_dest_noc_end_x,
+                        in0_mcast_dest_noc_end_y,
+                        in0_mcast_num_cores);
+                    noc.async_writes_flushed();
+                    // Reset the semaphore value to VALID
+                    receiver_sem.set(VALID);
+#endif  // SKIP_MCAST
+
+                    // We need to pass the value to compute cores regardless of the value of is_batch_valid
+                    ckernel::mailbox_write(ckernel::ThreadId::UnpackThreadId, is_batch_valid);
+                    ckernel::mailbox_write(ckernel::ThreadId::MathThreadId, is_batch_valid);
+                    ckernel::mailbox_write(ckernel::ThreadId::PackThreadId, is_batch_valid);
+                }
+
+                if (!is_batch_valid) {
+                    if constexpr (!bcast_A) {
+                        in0_tensor_start_tile_id += MtKt;
+                    }
+                    continue;
+                }
+
+                // This is a valid (non-zero) batch that we are about to multicast. When nnz was supplied,
+                // catch count_nonzero(sparsity) > num_batch_compute here, before the sender blocks below
+                // waiting on receivers that have already finished their num_batch_compute iterations.
+                if constexpr (!get_batch_from_reader) {
+                    ++num_valid_batches;
+                    ASSERT(num_valid_batches <= num_batch_compute);
+                }
+            }
+
+#ifdef IN0_SHARDED
+            uint32_t in0_tensor_current_h_dim_block_start_addr = noc_shard_read_start_addr;
+#endif  // IN0_SHARDED
+            uint32_t in0_tensor_current_h_dim_block_tile_id = in0_tensor_start_tile_id;
+            for (uint32_t bh = 0; bh < num_blocks_h_dim; ++bh) {
+                for (uint32_t bw = 0; bw < num_blocks_w_dim; ++bw) {
+#ifdef IN0_SHARDED
+                    uint32_t in0_tensor_current_inner_dim_block_start_addr = in0_tensor_current_h_dim_block_start_addr;
+#endif  // IN0_SHARDED
+                    uint32_t in0_tensor_current_inner_dim_block_start_tile_id = in0_tensor_current_h_dim_block_tile_id;
+                    for (uint32_t block = 0; block < num_blocks_inner_dim; ++block) {
+                        if constexpr (fuse_op) {
+                            fused_op_receiver.update_current_block_start_tile_id(
+                                block, in0_tensor_current_inner_dim_block_start_tile_id, in0_tensor_start_tile_id);
+                        }
+
+                        // Operand 0
+                        // Common for sharded and interleaved paths
+                        cb_in0.reserve_back(in0_block_num_tiles);
+#ifndef IN0_SHARDED
+
+                        uint32_t in0_write_offset = 0;
+
+#ifndef SKIP_MCAST
+                        uint32_t in0_start_address =
+                            cb_in0.get_write_ptr();  // copy start address of block, to be used for mcasting
+#endif                                               // SKIP_MCAST
+
+                        // Copy in0 block into CB, as the default kernel
+                        uint32_t in0_tensor_row_start_tile_id = in0_tensor_current_inner_dim_block_start_tile_id;
+                        for (uint32_t h = 0; h < in0_block_h; ++h) {
+                            uint32_t in0_tensor_tile_id = in0_tensor_row_start_tile_id;
+                            for (uint32_t w = 0; w < in0_block_w; ++w) {
+                                if (bh < num_blocks_h_dim - 1 || h < last_block_h) {
+                                    noc.async_read(
+                                        s0,
+                                        cb_in0,
+                                        in0_single_tile_size_bytes,
+                                        {.page_id = in0_tensor_tile_id},
+                                        {.offset_bytes = in0_write_offset});
+                                }
+
+                                // Zero out padded regions for the very last tile
+                                if constexpr (in0_last_ktile_w > 0) {
+                                    if ((block == num_blocks_inner_dim - 1) && (w == in0_block_w - 1)) {
+                                        noc.async_read_barrier();
+                                        const DataFormat in0_data_format = get_dataformat(cb_id_in0);
+                                        pad_last_ktile<in0_data_format, in0_last_ktile_w>(
+                                            cb_in0.get_write_ptr() + in0_write_offset);
+                                    }
+                                }
+                                if constexpr (in0_last_ktile_h > 0) {
+                                    if ((block == num_blocks_inner_dim - 1) && (w == in0_block_w - 1)) {
+                                        noc.async_read_barrier();
+                                        const DataFormat in0_data_format = get_dataformat(cb_id_in0);
+                                        pad_last_transposed_ktile<in0_data_format, in0_last_ktile_h>(
+                                            cb_in0.get_write_ptr() + in0_write_offset);
+                                    }
+                                }
+
+                                in0_write_offset += in0_aligned_tile_size_bytes;
+                                in0_tensor_tile_id += in0_tensor_stride_w;
+                            }
+                            in0_tensor_row_start_tile_id += in0_tensor_stride_h;
+                        }
+                        in0_tensor_current_inner_dim_block_start_tile_id += in0_tensor_next_inner_dim_block_stride;
+
+                        // Barrier! make sure the reads are done
+                        noc.async_read_barrier();
+#else
+                        if constexpr (extract_shard_sub_blocks) {
+                            uint32_t l1_write_addr_in0 = cb_in0.get_write_ptr();
+
+#ifndef SKIP_MCAST
+                            in0_start_address =
+                                l1_write_addr_in0;  // copy start address of block, to be used for mcasting
+#endif  // SKIP_MCAST
+
+                            UnicastEndpoint self_ep;
+                            uint32_t noc_shard_read_l1_addr = in0_tensor_current_inner_dim_block_start_addr;
+
+                            for (uint32_t i = 0; i < in0_block_h; i++) {
+                                noc.async_read(
+                                    self_ep,
+                                    CoreLocalMem<uint32_t>(l1_write_addr_in0),
+                                    shard_read_width,
+                                    {.noc_x = my_x[0], .noc_y = my_y[0], .addr = noc_shard_read_l1_addr},
+                                    {});
+
+                                l1_write_addr_in0 += shard_read_width;
+                                noc_shard_read_l1_addr += shard_read_stride;
+                            }
+
+                            in0_tensor_current_inner_dim_block_start_addr += shard_read_width;
+                            noc.async_read_barrier();
+                        }
+
+                        {
+                            constexpr DataFormat in0_data_format = get_dataformat(cb_id_in0);
+                            uint32_t in0_pad_base_addr = cb_in0.get_write_ptr();
+                            if constexpr (in0_last_ktile_w > 0) {
+                                if ((block == num_blocks_inner_dim - 1)) {
+                                    for (uint32_t h = 0; h < in0_block_h; ++h) {
+                                        auto ptr = in0_pad_base_addr +
+                                                   (h * in0_block_w + in0_block_w - 1) * in0_single_tile_size_bytes;
+                                        pad_last_ktile<in0_data_format, in0_last_ktile_w>(ptr);
+                                    }
+                                }
+                            }
+                            if constexpr (in0_last_ktile_h > 0) {
+                                if ((block == num_blocks_inner_dim - 1)) {
+                                    for (uint32_t w = 0; w < in0_block_w; ++w) {
+                                        auto ptr = in0_pad_base_addr +
+                                                   ((in0_block_h - 1) * in0_block_w + w) * in0_single_tile_size_bytes;
+                                        pad_last_transposed_ktile<in0_data_format, in0_last_ktile_h>(ptr);
+                                    }
+                                }
+                            }
+                        }
+#endif  // IN0_SHARDED
+
+#ifndef SKIP_MCAST
+                        // wait until all in0 mcast destinations have atomically incremented the in0 semaphore_addr
+                        // (i.e. its value should be in0_mcast_num_dests), then reset the semaphore_addr value back to
+                        // zero for the next block
+                        sender_sem.wait(in0_mcast_num_dests);
+                        sender_sem.set(0);
+
+                        // Now we have the block in the CB address, we can mcast to dests!
+                        MulticastEndpoint mcast_dst;
+                        // num_dests must not include source, since we are NOT really doing a local copy!
+                        noc.async_write_multicast(
+                            CoreLocalMem<uint32_t>(in0_start_address),
+                            mcast_dst,
+                            in0_block_size_bytes,
+                            in0_mcast_num_cores,
+                            {},
+                            {.noc_x_start = in0_mcast_dest_noc_start_x,
+                             .noc_y_start = in0_mcast_dest_noc_start_y,
+                             .noc_x_end = in0_mcast_dest_noc_end_x,
+                             .noc_y_end = in0_mcast_dest_noc_end_y,
+                             .addr = in0_start_address},
+                            true);
+
+                        // Note: no need for write barrier, since these two multicasts are done on the same noc id, same
+                        // vc, same cmd_buf Also, this only works because we are setting VCs statically (using
+                        // NOC_CMD_STATIC_VC).
+#ifdef ARCH_BLACKHOLE
+                        // On Blackhole the flush is needed because NoC latency is higher than L1 <-> RISCV
+                        // latency which means data could be changed before write is issued.
+                        noc.async_writes_flushed();
+#endif  // ARCH_BLACKHOLE
+
+                        // We should also multicast the flag to destinations
+                        // num_dests must not include source, since we are NOT really doing a local copy!
+                        receiver_sem.set_multicast(
+                            noc,
+                            in0_mcast_dest_noc_start_x,
+                            in0_mcast_dest_noc_start_y,
+                            in0_mcast_dest_noc_end_x,
+                            in0_mcast_dest_noc_end_y,
+                            in0_mcast_num_cores);
+#endif  // SKIP_MCAST
+
+                        // Common for sharded and interleaved paths
+                        cb_in0.push_back(in0_block_num_tiles);
+                    }
+                }
+#ifdef IN0_SHARDED
+                in0_tensor_current_h_dim_block_start_addr += in0_tensor_next_h_dim_block_stride_bytes;
+#endif  // IN0_SHARDED
+                in0_tensor_current_h_dim_block_tile_id += in0_tensor_next_h_dim_block_stride;
+            }
+
+            if constexpr (!bcast_A) {
+                in0_tensor_start_tile_id += MtKt;
+            }
+        }
+
+        if constexpr (bcast_A) {
+            in0_tensor_start_tile_id += MtKt;
+        }
+
+        // this is an optimization for the case when in0 is [1, 1, M, K] and in1 is [1, H, K, N], i.e. when in0_B ==
+        // 1 and in1_B > 1 in this case we originally had to replicate the in0 block for each batch, but with this
+        // optimization we just read the tensor slice once into each core's L1 and keep it there for all weight
+        // batches since the needed in0 data is already in L1 after batch 0, we can just move read pointer for this
+        // CB so compute kernel thinks it has new data
+        if (in0_reuse_in_CB) {
+            for (uint32_t fake_batch = 0; fake_batch < in1_B - in0_B; ++fake_batch) {
+                for (uint32_t blk = 0; blk < num_blocks_inner_dim; ++blk) {
+                    cb_in0.reserve_back(in0_block_num_tiles);
+                    cb_in0.push_back(in0_block_num_tiles);
+                }
+            }
+        }
+    }
+    noc.async_write_barrier();
+
+    // When nnz was supplied, the receiver and compute kernels loop exactly num_batch_compute times.
+    // If we issued fewer multicasts than that (count_nonzero(sparsity) < num_batch_compute), those
+    // kernels are now waiting on multicasts that will never arrive and the device would deadlock.
+    // Fail loudly instead. See https://github.com/tenstorrent/tt-metal/issues/45943.
+    if constexpr (!get_batch_from_reader && batchB > 0) {
+        ASSERT(num_valid_batches == num_batch_compute);
+    }
+
+    // For completeness, we empty the sparsity CB if it was reserved earlier
+    if constexpr (batchB > 0) {
+        cb_sparsity.push_back(1);
+        cb_sparsity.wait_front(1);
+        cb_sparsity.pop_front(1);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
@@ -1,0 +1,361 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "hostdevcommon/common_values.hpp"
+#include "ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
+#include "ttnn/operations/kernel_helper_functions/pad_tile.hpp"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+
+void kernel_main() {
+    constexpr bool core_has_output_block_work = (bool)get_compile_time_arg_val(0);
+    constexpr bool core_in_in0_receiver_mcast_grid = (bool)get_compile_time_arg_val(1);
+
+    constexpr uint32_t in0_block_num_tiles = get_compile_time_arg_val(2);
+    constexpr uint32_t in0_block_size_bytes = get_compile_time_arg_val(3);
+    constexpr uint32_t in0_last_ktile_w = get_compile_time_arg_val(4);
+    constexpr uint32_t in0_last_ktile_h = get_compile_time_arg_val(5);
+
+    // in0/in1 common args
+    constexpr uint32_t num_blocks_inner_dim = get_compile_time_arg_val(6);
+    constexpr uint32_t num_blocks_w_dim = get_compile_time_arg_val(7);
+    constexpr uint32_t num_blocks_h_dim = get_compile_time_arg_val(8);
+    // in0 mcast args
+    constexpr uint32_t in0_mcast_num_dests = get_compile_time_arg_val(11);
+    constexpr uint32_t in0_mcast_num_cores = get_compile_time_arg_val(12);
+    constexpr uint32_t num_x = get_compile_time_arg_val(13);
+    constexpr uint32_t num_y = get_compile_time_arg_val(14);
+    constexpr bool transpose_mcast = (bool)get_compile_time_arg_val(15);
+    constexpr uint32_t shard_width_in_tiles = get_compile_time_arg_val(16);
+    constexpr uint32_t shard_height_in_tiles = get_compile_time_arg_val(17);
+    constexpr uint32_t in0_block_w = get_compile_time_arg_val(18);
+    constexpr uint32_t in0_block_h = get_compile_time_arg_val(19);
+
+    constexpr uint32_t batch = get_compile_time_arg_val(20);
+    constexpr bool fuse_op = (bool)get_compile_time_arg_val(21);
+
+    uint32_t rt_args_idx = 0;
+    const uint32_t sender_id = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t in0_mcast_dest_noc_start_x = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t in0_mcast_dest_noc_start_y = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t in0_mcast_dest_noc_end_x = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t in0_mcast_dest_noc_end_y = get_arg_val<uint32_t>(rt_args_idx++);
+    tt_l1_ptr uint32_t* in0_mcast_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(increment_arg_idx(rt_args_idx, num_x)));
+    tt_l1_ptr uint32_t* in0_mcast_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(increment_arg_idx(rt_args_idx, num_y)));
+
+    constexpr uint32_t cb_id_in0 = get_named_compile_time_arg_val("cb_in0");
+    constexpr uint32_t cb_id_in2 = get_named_compile_time_arg_val("cb_in0_sharded");  // Sharded cb
+
+    constexpr uint32_t in0_single_tile_size_bytes = get_tile_size(cb_id_in0);
+    constexpr DataFormat in0_data_format = get_dataformat(cb_id_in0);
+
+    constexpr uint32_t num_blocks_per_shard = shard_width_in_tiles / in0_block_w;
+    // In case we need to send multiple blocks per shard, and shard height in tiles is greater than 1
+    // Than we first need to extract the sub-blocks from the shard, and then send them to the destinations
+    constexpr bool extract_shard_sub_blocks = shard_height_in_tiles > 1 && num_blocks_per_shard > 1;
+    constexpr uint32_t out_block_h = shard_height_in_tiles / num_blocks_h_dim;
+    constexpr uint32_t shard_read_stride = shard_width_in_tiles * in0_single_tile_size_bytes;
+    constexpr uint32_t shard_read_width = in0_single_tile_size_bytes * in0_block_w;
+    constexpr uint32_t in0_tensor_next_h_dim_block_stride = shard_read_stride * in0_block_h;
+
+    Noc noc;
+    CircularBuffer cb_in0(cb_id_in0);
+    CircularBuffer cb_in2(cb_id_in2);
+    // local address that will be atomically incremented by mcast receivers, to know when all receivers are ready
+    // to receive the mcast
+    Semaphore<> sender_sem(get_compile_time_arg_val(9));
+    // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
+    Semaphore<> receiver_sem(get_compile_time_arg_val(10));
+
+    constexpr uint32_t num_remote_senders = (num_blocks_inner_dim + num_blocks_per_shard - 1) / num_blocks_per_shard;
+    uint32_t remote_sender_noc_x[num_remote_senders];
+    uint32_t remote_sender_noc_y[num_remote_senders];
+    if constexpr (transpose_mcast) {
+        uint32_t x = 0, y = 0;
+        for (uint32_t i = 0; i < num_remote_senders; ++i) {
+            remote_sender_noc_x[i] = in0_mcast_noc_x[x];
+            remote_sender_noc_y[i] = in0_mcast_noc_y[y];
+            ++y;
+            if (y == num_y) {
+                y = 0;
+                ++x;
+            }
+        }
+    } else {
+        uint32_t x = 0, y = 0;
+        for (uint32_t i = 0; i < num_remote_senders; ++i) {
+            remote_sender_noc_x[i] = in0_mcast_noc_x[x];
+            remote_sender_noc_y[i] = in0_mcast_noc_y[y];
+            ++x;
+            if (x == num_x) {
+                x = 0;
+                ++y;
+            }
+        }
+    }
+    receiver_sem.set(VALID);
+
+    cb_in2.reserve_back(batch * in0_block_num_tiles);
+
+    uint32_t in0_tensor_shard_read_addr = cb_in2.get_read_ptr();
+    uint32_t in0_tensor_read_addr = 0;
+
+    MatmulOpReceiver fused_op_receiver;
+    if constexpr (fuse_op) {
+        fused_op_receiver = MatmulOpReceiver(
+            sender_id < num_remote_senders, /* wait_for_op_signal */
+            rt_args_idx,
+            num_blocks_inner_dim,
+            in0_block_w /* tiles_per_block (in the same dimension as tensor slice) */
+        );
+    }
+
+    for (uint32_t b = 0; b < batch; ++b) {
+        uint32_t in0_tensor_current_h_dim_block_start_addr = in0_tensor_shard_read_addr;
+        for (uint32_t bh = 0; bh < num_blocks_h_dim; ++bh) {
+            for (uint32_t bw = 0; bw < num_blocks_w_dim; ++bw) {
+                uint32_t in0_tensor_current_inner_dim_block_start_addr = in0_tensor_current_h_dim_block_start_addr;
+                for (uint32_t block = 0; block < num_blocks_inner_dim; ++block) {
+                    uint32_t block_id = block / num_blocks_per_shard;
+                    // If used fused op, make block_id conform to ordering of tensor slices from all
+                    // gather
+                    if constexpr (fuse_op) {
+                        block_id = fused_op_receiver.align_to_slice_and_sync(block, sender_id);
+                    }
+
+                    cb_in0.reserve_back(in0_block_num_tiles);
+
+                    // All cores in receiver grid need to participate in receiving regardless if they produce output
+                    // work or not. Otherwise, data corruption since we mcast from and to the same CB (eg.
+                    // extract_shard_sub_blocks). If we only ever mcast with loopback src (ie. always to a different
+                    // CB), we can have just the cores that produce work participate in receiving.
+                    if constexpr (core_in_in0_receiver_mcast_grid) {
+                        // Set in0 semaphore value to INVALID
+                        receiver_sem.set(INVALID);
+                    }
+
+                    if (block_id == sender_id) {
+                        // Operand 0
+                        uint32_t in0_tensor_local_l1_write_addr = cb_in0.get_write_ptr();
+
+                        if constexpr (extract_shard_sub_blocks) {
+                            in0_tensor_read_addr = in0_tensor_local_l1_write_addr;
+
+                            uint32_t l1_write_extract_shard_in0 = in0_tensor_local_l1_write_addr;
+                            UnicastEndpoint self_ep;
+                            uint32_t noc_shard_read_l1_addr = in0_tensor_current_inner_dim_block_start_addr;
+
+                            for (uint32_t i = 0; i < out_block_h; i++) {
+                                noc.async_read(
+                                    self_ep,
+                                    CoreLocalMem<uint32_t>(l1_write_extract_shard_in0),
+                                    shard_read_width,
+                                    {.noc_x = my_x[0], .noc_y = my_y[0], .addr = noc_shard_read_l1_addr},
+                                    {});
+                                l1_write_extract_shard_in0 += shard_read_width;
+                                noc_shard_read_l1_addr += shard_read_stride;
+                            }
+
+                            in0_tensor_current_inner_dim_block_start_addr += shard_read_width;
+
+                            noc.async_read_barrier();
+
+                            if constexpr (in0_last_ktile_w > 0) {
+                                if ((block == num_blocks_inner_dim - 1)) {
+                                    for (uint32_t h = 0; h < out_block_h; ++h) {
+                                        auto in0_last_ktile_w_ptr =
+                                            in0_tensor_read_addr +
+                                            (h * in0_block_w + in0_block_w - 1) * in0_single_tile_size_bytes;
+                                        pad_last_ktile<in0_data_format, in0_last_ktile_w>(in0_last_ktile_w_ptr);
+                                    }
+                                }
+                            }
+                            if constexpr (in0_last_ktile_h > 0) {
+                                if ((block == num_blocks_inner_dim - 1)) {
+                                    for (uint32_t w = 0; w < in0_block_w; ++w) {
+                                        auto in0_last_ktile_h_ptr =
+                                            in0_tensor_read_addr +
+                                            (out_block_h - 1) * in0_block_w * in0_single_tile_size_bytes +
+                                            w * in0_single_tile_size_bytes;
+                                        pad_last_transposed_ktile<in0_data_format, in0_last_ktile_h>(
+                                            in0_last_ktile_h_ptr);
+                                    }
+                                }
+                            }
+                        } else {
+                            in0_tensor_read_addr = in0_tensor_current_inner_dim_block_start_addr;
+                            in0_tensor_current_inner_dim_block_start_addr += in0_block_size_bytes;
+
+                            if constexpr (in0_last_ktile_w > 0) {
+                                if ((block == num_blocks_inner_dim - 1)) {
+                                    for (uint32_t h = 0; h < in0_block_h; ++h) {
+                                        auto in0_last_ktile_w_ptr =
+                                            in0_tensor_read_addr +
+                                            (h * in0_block_w + in0_block_w - 1) * in0_single_tile_size_bytes;
+                                        pad_last_ktile<in0_data_format, in0_last_ktile_w>(in0_last_ktile_w_ptr);
+                                    }
+                                }
+                            }
+                            if constexpr (in0_last_ktile_h > 0) {
+                                if ((block == num_blocks_inner_dim - 1)) {
+                                    for (uint32_t w = 0; w < in0_block_w; ++w) {
+                                        auto in0_last_ktile_h_ptr =
+                                            in0_tensor_read_addr +
+                                            ((in0_block_h - 1) * in0_block_w + w) * in0_single_tile_size_bytes;
+                                        pad_last_transposed_ktile<in0_data_format, in0_last_ktile_h>(
+                                            in0_last_ktile_h_ptr);
+                                    }
+                                }
+                            }
+                        }
+
+                        // wait until all in0 mcast destinations have atomically incremented the in0 semaphore_addr
+                        // (i.e. its value should be in0_mcast_num_dests), then reset the semaphore_addr value back to
+                        // zero for the next block
+                        if constexpr (core_in_in0_receiver_mcast_grid) {
+                            // wait for every core in receiver grid EXCLUDING myself
+                            sender_sem.wait(in0_mcast_num_dests - 1);
+                        } else {
+                            // wait for every core in receiver grid
+                            sender_sem.wait(in0_mcast_num_dests);
+                        }
+                        sender_sem.set(0);
+
+                        // Now we have the block in the CB address, we can mcast to dests!
+                        if constexpr (core_in_in0_receiver_mcast_grid) {
+                            // Mcast from/to same CB
+                            if constexpr (extract_shard_sub_blocks) {
+                                // multicast to every core in receiver grid EXCLUDING myself
+                                // Skip if there are no other cores since this core already has the data.
+                                // Note: noc_async_write_multicast[_loopback_src] may hang if called with 0 cores.
+                                if constexpr (in0_mcast_num_cores > 1) {
+                                    MulticastEndpoint mcast_dst;
+                                    noc.async_write_multicast(
+                                        CoreLocalMem<uint32_t>(in0_tensor_read_addr),
+                                        mcast_dst,
+                                        in0_block_size_bytes,
+                                        in0_mcast_num_cores - 1,
+                                        {},
+                                        {.noc_x_start = in0_mcast_dest_noc_start_x,
+                                         .noc_y_start = in0_mcast_dest_noc_start_y,
+                                         .noc_x_end = in0_mcast_dest_noc_end_x,
+                                         .noc_y_end = in0_mcast_dest_noc_end_y,
+                                         .addr = in0_tensor_local_l1_write_addr},
+                                        true);
+                                }
+                            }
+                            // Mcast from different CB to another CB
+                            else {
+                                if constexpr (in0_mcast_num_cores == 1) {
+                                    // noc_async_write if we only want to copy data between CB locally
+                                    UnicastEndpoint ucast_dst;
+                                    noc.async_write(
+                                        CoreLocalMem<uint32_t>(in0_tensor_read_addr),
+                                        ucast_dst,
+                                        in0_block_size_bytes,
+                                        {},
+                                        {.noc_x = in0_mcast_dest_noc_start_x,
+                                         .noc_y = in0_mcast_dest_noc_start_y,
+                                         .addr = in0_tensor_local_l1_write_addr});
+                                } else {
+                                    // multicast to every core in receiver grid
+                                    MulticastEndpoint mcast_dst;
+                                    noc.async_write_multicast<NocOptions::MCAST_INCL_SRC>(
+                                        CoreLocalMem<uint32_t>(in0_tensor_read_addr),
+                                        mcast_dst,
+                                        in0_block_size_bytes,
+                                        in0_mcast_num_cores,
+                                        {},
+                                        {.noc_x_start = in0_mcast_dest_noc_start_x,
+                                         .noc_y_start = in0_mcast_dest_noc_start_y,
+                                         .noc_x_end = in0_mcast_dest_noc_end_x,
+                                         .noc_y_end = in0_mcast_dest_noc_end_y,
+                                         .addr = in0_tensor_local_l1_write_addr},
+                                        true);
+                                }
+                            }
+
+                            // We should also multicast the flag to destinations
+                            receiver_sem.set(VALID);
+                            if constexpr (in0_mcast_num_cores > 1) {
+                                receiver_sem.set_multicast<NocOptions::MCAST_INCL_SRC>(
+                                    noc,
+                                    in0_mcast_dest_noc_start_x,
+                                    in0_mcast_dest_noc_start_y,
+                                    in0_mcast_dest_noc_end_x,
+                                    in0_mcast_dest_noc_end_y,
+                                    in0_mcast_num_cores);
+                            }
+                        } else {
+                            // If we are not part of receiver grid, always do a regular noc_async_write_multicast to all
+                            // cores in receiver grid
+                            MulticastEndpoint mcast_dst;
+                            noc.async_write_multicast(
+                                CoreLocalMem<uint32_t>(in0_tensor_read_addr),
+                                mcast_dst,
+                                in0_block_size_bytes,
+                                in0_mcast_num_cores,
+                                {},
+                                {.noc_x_start = in0_mcast_dest_noc_start_x,
+                                 .noc_y_start = in0_mcast_dest_noc_start_y,
+                                 .noc_x_end = in0_mcast_dest_noc_end_x,
+                                 .noc_y_end = in0_mcast_dest_noc_end_y,
+                                 .addr = in0_tensor_local_l1_write_addr},
+                                true);
+
+                            // We should also multicast the flag to destinations
+                            receiver_sem.set(VALID);
+                            receiver_sem.set_multicast(
+                                noc,
+                                in0_mcast_dest_noc_start_x,
+                                in0_mcast_dest_noc_start_y,
+                                in0_mcast_dest_noc_end_x,
+                                in0_mcast_dest_noc_end_y,
+                                in0_mcast_num_cores);
+                        }
+                        // Note: no need for write barrier, since these two multicasts are done on the same noc id and
+                        // same vc even though cmd bufs are different Also, this only works because we are setting VCs
+                        // statically (using NOC_CMD_STATIC_VC).
+
+                        // Flush is required because the semaphore multicast reads receiver_sem's L1
+                        // address as the source value. Without a flush, the CPU can proceed to the next
+                        // iteration and overwrite receiver_sem to INVALID before the NoC has read the
+                        // VALID value from L1, causing receivers to see INVALID and hang.
+                        // In single-core receiver-grid configurations, semaphore multicast may be compiled out;
+                        // in that case, skip the flush to avoid an unnecessary stall.
+                        if constexpr (!(core_in_in0_receiver_mcast_grid && (in0_mcast_num_cores == 1))) {
+                            noc.async_writes_flushed();
+                        }
+                    } else if constexpr (core_in_in0_receiver_mcast_grid) {
+                        // Increment remote sender's semaphore using pre-computed coordinates
+                        sender_sem.up(noc, remote_sender_noc_x[block_id], remote_sender_noc_y[block_id], 1);
+                    }
+
+                    if constexpr (core_in_in0_receiver_mcast_grid) {
+                        // wait on in0 semaphore value to become VALID (set by mcast sender after it multicasts data)
+                        receiver_sem.wait(VALID);
+                    }
+                    cb_in0.push_back(in0_block_num_tiles);
+
+                    // If core does not produce output block work, free cb_id_in0 immediately.
+                    // This is necessary since mcast is in lockstep; this ensures write ptr addresses are synced
+                    // properly for cores that only send and have no compute / writer active. Technically, don't have to
+                    // do this if cb_id_in0 is not double buffered.
+                    if constexpr (!core_has_output_block_work) {
+                        cb_in0.pop_front(in0_block_num_tiles);
+                    }
+                }
+            }
+            in0_tensor_current_h_dim_block_start_addr += in0_tensor_next_h_dim_block_stride;
+        }
+    }
+
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp
@@ -1,0 +1,237 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "hostdevcommon/common_values.hpp"
+#include "ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/tensor/noc_traits.h"
+void kernel_main() {
+    // READER
+    uint32_t rt_args_idx = 0;
+    // in1 mcast args
+    const uint32_t in1_mcast_sender_noc_x = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t in1_mcast_sender_noc_y = get_arg_val<uint32_t>(rt_args_idx++);
+
+    // WRITER
+    // out tensor args
+    const uint32_t out_tensor_addr = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t out_tensor_start_tile_id = get_arg_val<uint32_t>(rt_args_idx++);
+
+    // padding args (WRITER)
+    const uint32_t out_num_nonzero_subblocks_h = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t out_last_num_nonzero_subblocks_h = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t out_last_subblock_h = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t padded_block_tiles_h_skip = get_arg_val<uint32_t>(rt_args_idx++);
+
+    const uint32_t out_num_nonzero_subblocks_w = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t out_last_num_nonzero_subblocks_w = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t out_last_subblock_w = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t padded_subblock_tiles_addr_skip = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t padded_block_tiles_w_skip = get_arg_val<uint32_t>(rt_args_idx++);
+
+#ifndef OUT_SHARDED
+    const uint32_t last_num_blocks_h_dim = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t last_num_blocks_w_dim = get_arg_val<uint32_t>(rt_args_idx++);
+#endif
+
+    // COMPILE TIME ARGS
+    // READER
+    // in1 block args
+    constexpr uint32_t in1_block_num_tiles = get_compile_time_arg_val(0);
+    // in0/in1 common args
+    constexpr uint32_t num_blocks_inner_dim = get_compile_time_arg_val(1);
+    constexpr uint32_t num_blocks_w_dim = get_compile_time_arg_val(2);
+    constexpr uint32_t num_blocks_h_dim = get_compile_time_arg_val(3);
+    // in1 mcast args
+    // batch args
+    constexpr uint32_t batch = get_compile_time_arg_val(6);
+
+    // WRITER
+    // out tensor args
+    constexpr uint32_t out_tensor_stride_w = get_compile_time_arg_val(7);
+    constexpr uint32_t out_tensor_stride_h = get_compile_time_arg_val(8);
+    constexpr uint32_t out_tensor_next_subblock_stride_w = get_compile_time_arg_val(9);
+    constexpr uint32_t out_tensor_next_subblock_stride_h = get_compile_time_arg_val(10);
+    constexpr uint32_t out_tensor_next_w_dim_block_stride = get_compile_time_arg_val(11);
+    constexpr uint32_t out_tensor_next_h_dim_block_stride = get_compile_time_arg_val(12);
+
+    // out subblock args
+    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(13);
+    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(14);
+    constexpr uint32_t out_subblock_tile_count = get_compile_time_arg_val(15);
+
+    // batch args
+    constexpr uint32_t MtNt = get_compile_time_arg_val(16);  // if 0
+    // Don't need batch; same as batch from READER args
+
+#ifdef FUSE_BIAS
+    // in3 block args
+    constexpr uint32_t in3_block_w = get_compile_time_arg_val(17);
+
+    constexpr uint32_t cb_id_in3 = get_named_compile_time_arg_val("cb_bias");
+#endif
+    constexpr bool fuse_op_reduce_scatter = (bool)get_compile_time_arg_val(18);
+
+    constexpr auto out_args = TensorAccessorArgs<19>();
+    OpSignaler op_signaler;
+    if constexpr (fuse_op_reduce_scatter) {
+        op_signaler = OpSignaler(rt_args_idx);
+    }
+    // WRITER
+
+    constexpr uint32_t cb_id_in1 = get_named_compile_time_arg_val("cb_in1");
+
+    // WRITER
+    constexpr uint32_t cb_id_out0 = get_named_compile_time_arg_val("cb_out");
+
+    // WRITER
+    // single-tile
+    const uint32_t output_single_tile_size_bytes = get_tile_size(cb_id_out0);
+    constexpr const uint32_t output_tile_hw = get_tile_hw(cb_id_out0);
+
+    Noc noc;
+    CircularBuffer cb_in1(cb_id_in1);
+    CircularBuffer cb_out(cb_id_out0);
+    Semaphore<> sender_sem(get_compile_time_arg_val(4));
+    Semaphore<> receiver_sem(get_compile_time_arg_val(5));
+#ifdef FUSE_BIAS
+    CircularBuffer cb_in3(cb_id_in3);
+#endif
+
+    // WRITER
+    const auto s = TensorAccessor(out_args, out_tensor_addr);
+
+    for (uint32_t b = 0; b < batch; ++b) {
+        uint32_t out_tensor_current_h_dim_block_tile_id = out_tensor_start_tile_id;
+        for (uint32_t bh = 0; bh < num_blocks_h_dim; ++bh) {
+            uint32_t out_tensor_current_w_dim_block_tile_id = out_tensor_current_h_dim_block_tile_id;
+            for (uint32_t bw = 0; bw < num_blocks_w_dim; ++bw) {
+                for (uint32_t block = 0; block < num_blocks_inner_dim; ++block) {
+                    // Operand 1
+                    cb_in1.reserve_back(in1_block_num_tiles);
+
+                    // Set in1 semaphore value to INVALID
+                    receiver_sem.set(INVALID);
+
+                    // Atomic increment source core counter
+                    sender_sem.up(noc, in1_mcast_sender_noc_x, in1_mcast_sender_noc_y, 1);
+
+                    // wait on in1 semaphore value to become VALID (set by mcast sender after it multicasts data)
+                    receiver_sem.wait(VALID);
+
+                    cb_in1.push_back(in1_block_num_tiles);
+                }
+
+#ifdef FUSE_BIAS
+                // Only read bias on first batch, or we have multiple output blocks
+                if ((b == 0 && bh == 0) || num_blocks_w_dim > 1) {
+                    // Operand 2
+                    cb_in3.reserve_back(in3_block_w);
+
+                    // Set in1 semaphore value to INVALID
+                    receiver_sem.set(INVALID);
+
+                    // Atomic increment source core counter
+                    sender_sem.up(noc, in1_mcast_sender_noc_x, in1_mcast_sender_noc_y, 1);
+
+                    // wait on in1 semaphore value to become VALID (set by mcast sender after it multicasts data)
+                    receiver_sem.wait(VALID);
+
+                    cb_in3.push_back(in3_block_w);
+                }
+#endif
+
+#ifndef OUT_SHARDED
+                // WRITER
+                uint32_t num_blocks_h_dim_ = bh >= last_num_blocks_h_dim - 1 ? last_num_blocks_h_dim : num_blocks_h_dim;
+                uint32_t num_blocks_w_dim_ = bw >= last_num_blocks_w_dim - 1 ? last_num_blocks_w_dim : num_blocks_w_dim;
+                uint32_t out_num_nonzero_subblocks_h_ = out_num_nonzero_subblocks_h;
+                uint32_t out_num_nonzero_subblocks_w_ = out_num_nonzero_subblocks_w;
+                if (bh == num_blocks_h_dim_ - 1) {
+                    out_num_nonzero_subblocks_h_ = out_last_num_nonzero_subblocks_h;
+                }
+                if (bw == num_blocks_w_dim_ - 1) {
+                    out_num_nonzero_subblocks_w_ = out_last_num_nonzero_subblocks_w;
+                }
+                uint32_t out_tensor_sbh_start_tile_id = out_tensor_current_w_dim_block_tile_id;
+                for (uint32_t sbh = 0; sbh < out_num_nonzero_subblocks_h_; ++sbh) {
+                    uint32_t out_tensor_sbw_start_tile_id = out_tensor_sbh_start_tile_id;
+                    for (uint32_t sbw = 0; sbw < out_num_nonzero_subblocks_w_; ++sbw) {
+                        uint32_t out_tensor_sb_row_start_tile_id = out_tensor_sbw_start_tile_id;
+
+                        uint32_t out_subblock_h_ = out_subblock_h;
+                        uint32_t out_subblock_w_ = out_subblock_w;
+                        uint32_t subblock_tiles_addr_skip = 0;
+                        if (bh == num_blocks_h_dim_ - 1 && sbh == out_num_nonzero_subblocks_h_ - 1) {
+                            out_subblock_h_ = out_last_subblock_h;
+                        }
+                        if (bw == num_blocks_w_dim_ - 1 && sbw == out_num_nonzero_subblocks_w_ - 1) {
+                            out_subblock_w_ = out_last_subblock_w;
+                            subblock_tiles_addr_skip = padded_subblock_tiles_addr_skip;
+                        }
+
+                        cb_out.wait_front(out_subblock_tile_count);
+                        uint32_t out_read_offset = 0;
+
+                        for (uint32_t h = 0; h < out_subblock_h_; ++h) {
+                            uint32_t out_tensor_tile_id = out_tensor_sb_row_start_tile_id;
+                            for (uint32_t w = 0; w < out_subblock_w_; ++w) {
+                                if (bh < num_blocks_h_dim_ && bw < num_blocks_w_dim_) {
+                                    noc.async_write(
+                                        use<CircularBuffer::AddrSelector::READ_PTR>(cb_out),
+                                        s,
+                                        output_single_tile_size_bytes,
+                                        {.offset_bytes = out_read_offset},
+                                        {.page_id = out_tensor_tile_id});
+                                }
+
+                                out_read_offset += output_single_tile_size_bytes;
+
+                                out_tensor_tile_id += out_tensor_stride_w;
+                            }
+                            // Skip padded tiles in subblock along row
+                            out_read_offset += subblock_tiles_addr_skip;
+                            out_tensor_sb_row_start_tile_id += out_tensor_stride_h;
+                        }
+
+                        noc.async_write_barrier();
+
+                        cb_out.pop_front(out_subblock_tile_count);
+                        out_tensor_sbw_start_tile_id += out_tensor_next_subblock_stride_w;
+                    }
+                    // Pop fully padded subblocks along the row
+                    if (bw == num_blocks_w_dim_ - 1) {
+                        cb_out.wait_front(padded_block_tiles_w_skip);
+                        cb_out.pop_front(padded_block_tiles_w_skip);
+                    }
+                    out_tensor_sbh_start_tile_id += out_tensor_next_subblock_stride_h;
+                }
+                // Pop row(s) of fully padded subblocks
+                if (bh == num_blocks_h_dim_ - 1) {
+                    cb_out.wait_front(padded_block_tiles_h_skip);
+                    cb_out.pop_front(padded_block_tiles_h_skip);
+                }
+#endif
+                out_tensor_current_w_dim_block_tile_id += out_tensor_next_w_dim_block_stride;
+            }
+            out_tensor_current_h_dim_block_tile_id += out_tensor_next_h_dim_block_stride;
+        }
+        out_tensor_start_tile_id += MtNt;
+
+        if (fuse_op_reduce_scatter) {
+            // Signal reduce_scatter to go
+            op_signaler.synchronize_workers_and_signal_op(0);
+        }
+    }
+
+#if OUT_SHARDED
+    cb_out.wait_front(
+        batch * out_num_nonzero_subblocks_h * out_num_nonzero_subblocks_w * out_subblock_w * out_subblock_h);
+#endif
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -1,0 +1,220 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "hostdevcommon/common_values.hpp"
+#include "api/remote_circular_buffer.h"
+#include "api/debug/dprint.h"
+#include "api/debug/dprint_tile.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/tensor/noc_traits.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+
+enum class CORE_TYPE : uint8_t { IDLE_CORE = 0, WORKER_CORE = 1, HOP_CORE = 2 };
+
+template <typename TensorAccessorType>
+void read_block_from_dram(
+    const Noc& noc,
+    CircularBuffer& cb,
+    const TensorAccessorType& s1,
+    uint32_t tensor_width_in_tiles,
+    uint32_t block_w_idx,
+    uint32_t block_h_idx,
+    uint32_t block_w_t,
+    uint32_t block_h_t,
+    uint32_t tile_size_bytes) {
+    uint32_t write_offset = 0;
+
+    // Horizontal idx + vertical idx * width = row major index
+    uint32_t block_tile_id = block_w_idx * block_w_t + (block_h_idx * block_h_t) * tensor_width_in_tiles;
+    for (uint32_t h = 0; h < block_h_t; ++h) {
+        uint32_t tile_id = block_tile_id + h * tensor_width_in_tiles;
+        for (uint32_t w = 0; w < block_w_t; ++w) {
+            noc.async_read(s1, cb, tile_size_bytes, {.page_id = tile_id + w}, {.offset_bytes = write_offset});
+            write_offset += tile_size_bytes;
+        }
+    }
+    noc.async_read_barrier();
+}
+
+void do_signaling(const Noc& noc, uint32_t& rt_args_idx) {
+    const uint32_t pv_core_x = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t pv_core_y = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t pv_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
+    Semaphore<> pv_sem(pv_semaphore_id);
+    const bool is_privilaged = get_arg_val<uint32_t>(rt_args_idx++) == 1;
+    if (is_privilaged) {
+        const uint32_t target_sem_value = get_arg_val<uint32_t>(rt_args_idx++);
+        const uint32_t multicast_start_x = get_arg_val<uint32_t>(rt_args_idx++);
+        const uint32_t multicast_start_y = get_arg_val<uint32_t>(rt_args_idx++);
+        const uint32_t multicast_end_x = get_arg_val<uint32_t>(rt_args_idx++);
+        const uint32_t multicast_end_y = get_arg_val<uint32_t>(rt_args_idx++);
+        const uint32_t num_signalling_semaphores = get_arg_val<uint32_t>(rt_args_idx++);
+        const uint32_t signalling_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
+        Semaphore<> sig_sem(signalling_semaphore_id);
+        pv_sem.wait(target_sem_value);
+        pv_sem.set(1);
+        sig_sem.set(1);
+        sig_sem.set_multicast(
+            noc, multicast_start_x, multicast_start_y, multicast_end_x, multicast_end_y, num_signalling_semaphores);
+    } else {
+        pv_sem.up(noc, pv_core_x, pv_core_y, 1);
+        noc.async_atomic_barrier();
+    }
+}
+
+void kernel_main() {
+    // Compile time args
+    constexpr const bool in1_is_dram_interleaved = get_compile_time_arg_val(0);
+    constexpr const bool in1_is_dram_sharded = get_compile_time_arg_val(1);
+    constexpr uint32_t in1_block_height_in_tiles = get_compile_time_arg_val(2);  // Padded block shape
+    constexpr uint32_t in1_block_width_in_tiles = get_compile_time_arg_val(3);
+    constexpr uint32_t in1_tensor_width_in_tiles = get_compile_time_arg_val(4);
+    constexpr uint32_t num_blocks = get_compile_time_arg_val(5);
+    constexpr uint32_t batch = get_compile_time_arg_val(6);
+    constexpr uint32_t in1_block_page_size = get_compile_time_arg_val(7);
+    constexpr uint32_t in1_block_page_size_last = get_compile_time_arg_val(8);
+    constexpr uint32_t in1_block_width_num_pages = get_compile_time_arg_val(9);
+    constexpr uint32_t in1_shard_width_in_dram = get_compile_time_arg_val(10);
+
+    uint32_t rt_args_idx = 0;
+    constexpr bool needs_signaler = get_compile_time_arg_val(11) == 1;
+    uint32_t core_type = get_arg_val<uint32_t>(rt_args_idx++);
+    if (core_type == (uint32_t)CORE_TYPE::IDLE_CORE || core_type == (uint32_t)CORE_TYPE::HOP_CORE) {
+        if constexpr (needs_signaler) {
+            Noc early_noc;
+            do_signaling(early_noc, rt_args_idx);
+            early_noc.async_write_barrier();
+        }
+        return;
+    }
+    const uint32_t in1_tensor_addr = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t ring_idx = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t dram_bank_id = 0;
+    uint32_t vc = 0;
+    uint32_t dram_read_offset = 0;
+
+    if constexpr (in1_is_dram_sharded) {
+        dram_bank_id = get_arg_val<uint32_t>(rt_args_idx++);
+        vc = get_arg_val<uint32_t>(rt_args_idx++);
+        dram_read_offset = get_arg_val<uint32_t>(rt_args_idx++);
+    }
+
+    constexpr uint32_t cb_id_in1 = get_named_compile_time_arg_val("cb_in1");
+    constexpr uint32_t sync_cb = get_named_compile_time_arg_val("cb_sync");
+    constexpr uint32_t sync_cb2 = get_named_compile_time_arg_val("cb_sync2");
+    constexpr uint32_t remote_cb_id = get_named_compile_time_arg_val("cb_remote");
+    constexpr auto in1_args = TensorAccessorArgs<12>();
+
+    const uint32_t in1_block_num_tiles = in1_block_height_in_tiles * in1_block_width_in_tiles;
+
+    // Address setup
+    constexpr const uint32_t in1_tile_hw = get_tile_hw(cb_id_in1);
+    constexpr uint32_t in1_single_tile_size_bytes = get_tile_size(cb_id_in1);
+    const auto s1 = TensorAccessor(in1_args, in1_tensor_addr);
+
+    Noc noc;
+    CircularBuffer cb_in1(cb_id_in1);
+    CircularBuffer cb_sync(sync_cb);
+    CircularBuffer cb_sync2(sync_cb2);
+
+    uint32_t in1_shard_width_offset_bytes = 0;
+    uint32_t in1_dram_shard_block_size_bytes = 0;
+    uint32_t dram_read_offset_bytes = 0;
+    uint32_t l1_write_addr_in1;
+    uint32_t l1_read_addr_in1 = 0;
+
+    if constexpr (in1_is_dram_sharded) {
+        in1_shard_width_offset_bytes = in1_shard_width_in_dram * in1_single_tile_size_bytes;
+        in1_dram_shard_block_size_bytes = in1_shard_width_offset_bytes * in1_block_height_in_tiles;
+        dram_read_offset_bytes = dram_read_offset * in1_block_width_in_tiles * in1_single_tile_size_bytes;
+    }
+
+    for (uint32_t b = 0; b < batch; ++b) {
+        cb_sync2.reserve_back(1);
+#ifdef ENABLE_GLOBAL_CB
+        experimental::remote_cb_wait_front(remote_cb_id, num_blocks);
+#endif
+
+        cb_sync2.push_back(1);
+
+        if constexpr (in1_is_dram_interleaved) {
+            for (uint32_t block = 0; block < num_blocks; ++block) {
+                uint32_t block_idx = (ring_idx + block) % num_blocks;
+
+                cb_in1.reserve_back(in1_block_num_tiles);
+                read_block_from_dram(
+                    noc,
+                    cb_in1,
+                    s1,
+                    in1_tensor_width_in_tiles,
+                    ring_idx,
+                    block_idx,
+                    in1_block_width_in_tiles,
+                    in1_block_height_in_tiles,
+                    in1_single_tile_size_bytes);
+                cb_in1.push_back(in1_block_num_tiles);
+            }
+        } else if constexpr (in1_is_dram_sharded) {  // when in1 is sharded in DRAM, each core reads from its own bank,
+                                                     // two cores on the same row share one bank.
+            for (uint32_t block = 0; block < num_blocks; ++block) {
+                uint32_t block_idx = (ring_idx + block) % num_blocks;
+                l1_read_addr_in1 = block_idx * in1_dram_shard_block_size_bytes + dram_read_offset_bytes;
+                // Operand 1
+                cb_in1.reserve_back(in1_block_num_tiles);
+                l1_write_addr_in1 = cb_in1.get_write_ptr();
+
+                AllocatorBank<AllocatorBankType::DRAM> dram_bank;
+                for (uint32_t h = 0; h < in1_block_height_in_tiles; ++h) {
+                    uint32_t curr_l1_read_addr_in1 = l1_read_addr_in1;
+                    for (uint32_t w = 0; w < in1_block_width_num_pages; ++w) {
+                        uint32_t curr_page_size =
+                            w == in1_block_width_num_pages - 1 ? in1_block_page_size_last : in1_block_page_size;
+                        noc.set_async_read_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(
+                            dram_bank,
+                            curr_page_size,
+                            {.bank_id = dram_bank_id, .addr = in1_tensor_addr},
+                            NocOptVals{.vc = vc});
+                        noc.async_read_with_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(
+                            dram_bank,
+                            CoreLocalMem<uint32_t>(l1_write_addr_in1),
+                            curr_page_size,
+                            {.bank_id = dram_bank_id, .addr = in1_tensor_addr + curr_l1_read_addr_in1},
+                            {},
+                            NocOptVals{.vc = vc});
+                        curr_l1_read_addr_in1 += curr_page_size;
+                        l1_write_addr_in1 += curr_page_size;
+                    }
+                    l1_read_addr_in1 += in1_shard_width_offset_bytes;
+                }
+
+                noc.async_read_barrier();
+                cb_in1.push_back(in1_block_num_tiles);
+            }
+        }
+
+#ifdef ENABLE_GLOBAL_CB
+        cb_sync.wait_front(1);
+        experimental::remote_cb_pop_front(remote_cb_id, num_blocks);
+        cb_sync.pop_front(1);
+#endif
+        // Signal Here
+        if constexpr (needs_signaler) {
+            if (b == 0) {
+                do_signaling(noc, rt_args_idx);
+            }
+        }
+    }
+
+#ifdef ENABLE_GLOBAL_CB
+    experimental::update_remote_cb_config_in_l1(remote_cb_id);
+    noc.async_atomic_barrier();
+#endif
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
@@ -1,0 +1,229 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "hostdevcommon/common_values.hpp"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+
+void kernel_main() {
+    // RUNTIME ARGS
+    const bool is_worker_core = get_arg_val<uint32_t>(0) == 1;
+    // if not worker core, skip
+    if (not is_worker_core) {
+        return;
+    }
+
+    const uint32_t in1_tensor_addr = get_arg_val<uint32_t>(1);
+#ifdef FUSE_BIAS
+    const uint32_t in3_tensor_addr = get_arg_val<uint32_t>(2);
+#endif
+    const uint32_t dram_bank_id = get_arg_val<uint32_t>(3);
+    const uint32_t vc = get_arg_val<uint32_t>(4);
+    const uint32_t num_shard_to_write_back = get_arg_val<uint32_t>(5);
+    const uint32_t reshard_tensor_start_offset = get_arg_val<uint32_t>(6);
+    tt_l1_ptr uint32_t* per_core_N_reshard_bytes = (tt_l1_ptr uint32_t*)(get_arg_addr(7));
+    tt_l1_ptr uint32_t* in0_mcast_sender_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(8));
+    tt_l1_ptr uint32_t* in0_mcast_sender_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(9));
+
+    // COMPILE TIME ARGS
+    constexpr uint32_t in1_page_size = get_compile_time_arg_val(0);
+    constexpr uint32_t in1_num_pages = get_compile_time_arg_val(1);
+    // in1 block args
+    constexpr uint32_t in1_block_w = get_compile_time_arg_val(2);
+    constexpr uint32_t in1_block_num_tiles = get_compile_time_arg_val(3);
+    // in0/in1 common args
+    constexpr uint32_t num_blocks = get_compile_time_arg_val(4);
+    // WRITER
+    constexpr uint32_t out_block_num_tiles = get_compile_time_arg_val(5);
+    constexpr uint32_t out_tensor_stride_w_bytes = get_compile_time_arg_val(6);
+    constexpr uint32_t out_reshard_tensor_stride_w_bytes = get_compile_time_arg_val(7);
+    constexpr uint32_t per_core_M = get_compile_time_arg_val(8);
+
+#ifdef FUSE_BIAS
+    constexpr uint32_t in3_page_size = get_compile_time_arg_val(9);
+    constexpr uint32_t in3_num_pages = get_compile_time_arg_val(10);
+    constexpr uint32_t cb_id_in3 = get_named_compile_time_arg_val("cb_bias");
+    constexpr uint32_t bias_single_tile_size_bytes = get_tile_size(cb_id_in3);
+    constexpr DataFormat bias_data_format = get_dataformat(cb_id_in3);
+#endif
+
+    constexpr uint32_t cb_id_in1 = get_named_compile_time_arg_val("cb_in1");
+    constexpr uint32_t cb_id_out = get_named_compile_time_arg_val("cb_out");
+    constexpr uint32_t cb_id_out_reshard = get_named_compile_time_arg_val("cb_out_reshard");
+    // Tiles whose size is not a multiple of the DRAM alignment are padded to it in DRAM and the
+    // in1 CB pages are sized to match, so the block size in L1 must use the padded page stride
+    // (in1_num_pages * in1_page_size) rather than get_tile_size() (the unpadded tile size).
+    constexpr uint32_t in1_block_size_bytes = in1_num_pages * in1_page_size;
+
+    Noc noc;
+    CircularBuffer cb_in1(cb_id_in1);
+    CircularBuffer cb_out(cb_id_out);
+    CircularBuffer cb_out_reshard(cb_id_out_reshard);
+#ifdef FUSE_BIAS
+    CircularBuffer cb_in3(cb_id_in3);
+#endif
+
+    //  READER
+    uint32_t l1_write_addr_in1;
+    uint32_t l1_read_addr_in1 = 0;
+    constexpr DataFormat in1_data_format = get_dataformat(cb_id_in1);
+
+    AllocatorBank<AllocatorBankType::DRAM> dram_bank;
+    noc.set_async_read_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(
+        dram_bank, in1_page_size, {.bank_id = dram_bank_id, .addr = in1_tensor_addr}, NocOptVals{.vc = vc});
+
+#ifdef ARCH_GRAYSKULL
+    for (uint32_t block = 0; block < num_blocks; ++block) {
+        // Operand 1
+        cb_in1.reserve_back(in1_block_num_tiles);
+        l1_write_addr_in1 = cb_in1.get_write_ptr();
+
+        for (uint32_t h = 0; h < in1_num_pages; ++h) {
+            noc.async_read_with_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(
+                dram_bank,
+                CoreLocalMem<uint32_t>(l1_write_addr_in1),
+                in1_page_size,
+                {.bank_id = dram_bank_id, .addr = in1_tensor_addr + l1_read_addr_in1},
+                {},
+                NocOptVals{.vc = vc});
+            l1_read_addr_in1 += in1_page_size;
+            l1_write_addr_in1 += in1_page_size;
+        }
+
+        noc.async_read_barrier();
+        cb_in1.push_back(in1_block_num_tiles);
+    }
+#else
+    constexpr uint32_t total_num_blocks_in_buffer = 3;
+    constexpr uint32_t total_num_trid = 4;
+    uint32_t num_free_blocks_in_buffer = total_num_blocks_in_buffer;
+    uint32_t curr_block_trid = 1;
+    uint32_t block_trid_to_wait = 1;
+
+    // Reserve 2 blocks up front when num_blocks > 1: the loop's reserve_back at line 133
+    // only fires after block 1's writes complete, so the initial reservation must cover
+    // both block 0 and block 1 to avoid writing outside the reserved CB window.
+    // When num_blocks == 1 the CB is single-buffered, so reserve only 1 block.
+    constexpr uint32_t initial_reserved_blocks = (num_blocks > 1) ? 2 : 1;
+    cb_in1.reserve_back(in1_block_num_tiles * initial_reserved_blocks);
+    uint32_t l1_write_addr_in1_offset = 0;
+    uint32_t l1_write_addr_in1_start = cb_in1.get_write_ptr();
+    l1_write_addr_in1 = l1_write_addr_in1_start;
+    for (uint32_t block = 0; block < num_blocks; ++block) {
+        for (uint32_t h = 0; h < in1_num_pages; ++h) {
+            noc.async_read<NocOptions::TXN_ID, NOC_MAX_BURST_SIZE>(
+                dram_bank,
+                CoreLocalMem<uint32_t>(l1_write_addr_in1),
+                in1_page_size,
+                {.bank_id = dram_bank_id, .addr = in1_tensor_addr + l1_read_addr_in1},
+                {},
+                NocOptVals{.vc = vc, .trid = curr_block_trid});
+            l1_read_addr_in1 += in1_page_size;
+            l1_write_addr_in1 += in1_page_size;
+        }
+
+        if (num_free_blocks_in_buffer == 2) {
+            noc.async_read_barrier<NocOptions::TXN_ID>({.trid = static_cast<uint8_t>(block_trid_to_wait)});
+            cb_in1.push_back(in1_block_num_tiles);
+            // wait for next block trid
+            block_trid_to_wait = block_trid_to_wait == 3 ? 1 : (block_trid_to_wait + 1);
+            // reserve for next block
+            cb_in1.reserve_back(in1_block_num_tiles * 2);
+        } else {
+            num_free_blocks_in_buffer -= 1;
+        }
+
+        if (curr_block_trid == total_num_blocks_in_buffer) {
+            l1_write_addr_in1_offset = 0;
+            curr_block_trid = 1;
+        } else {
+            l1_write_addr_in1_offset += in1_block_size_bytes;
+            curr_block_trid += 1;
+        }
+        l1_write_addr_in1 = l1_write_addr_in1_start + l1_write_addr_in1_offset;
+    }
+    // last block to wait
+    noc.async_read_barrier<NocOptions::TXN_ID>({.trid = static_cast<uint8_t>(block_trid_to_wait)});
+    cb_in1.push_back(in1_block_num_tiles);
+#endif
+
+#ifdef FUSE_BIAS
+    // Operand 1
+    cb_in3.reserve_back(in1_block_w);
+    uint32_t l1_write_addr_in3 = cb_in3.get_write_ptr();
+    uint32_t l1_read_addr_in3 = 0;
+
+    noc.set_async_read_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(
+        dram_bank, in3_page_size, {.bank_id = dram_bank_id, .addr = in3_tensor_addr}, NocOptVals{.vc = vc});
+
+    for (uint32_t h = 0; h < in3_num_pages; ++h) {
+        noc.async_read_with_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(
+            dram_bank,
+            CoreLocalMem<uint32_t>(l1_write_addr_in3),
+            in3_page_size,
+            {.bank_id = dram_bank_id, .addr = in3_tensor_addr + l1_read_addr_in3},
+            {},
+            NocOptVals{.vc = vc});
+        l1_read_addr_in3 += in3_page_size;
+        l1_write_addr_in3 += in3_page_size;
+    }
+
+    // Barrier! make sure the reads are done
+    noc.async_read_barrier();
+    cb_in3.push_back(in1_block_w);
+#endif
+
+    // WRITER
+    cb_out.wait_front(out_block_num_tiles);
+
+#ifndef SKIP_WRITE_BACK
+    uint32_t index_offset = 0;
+    uint32_t l1_read_addr_out_offset = 0;
+
+    for (uint32_t i = 0; i < num_shard_to_write_back; ++i) {
+        uint32_t l1_read_addr_out = cb_out.get_read_ptr() + l1_read_addr_out_offset;
+        uint32_t l1_write_addr_out_reshard = cb_out_reshard.get_write_ptr();
+
+        if (i == 0) {
+            l1_write_addr_out_reshard += reshard_tensor_start_offset;
+        }
+
+        UnicastEndpoint dst_ep;
+        uint32_t reshard_dest_local_addr = l1_write_addr_out_reshard;
+
+        for (uint32_t h = 0; h < per_core_M; ++h) {
+            noc.async_write(
+                CoreLocalMem<uint32_t>(l1_read_addr_out),
+                dst_ep,
+                per_core_N_reshard_bytes[index_offset],
+                {},
+                {.noc_x = in0_mcast_sender_noc_x[index_offset],
+                 .noc_y = in0_mcast_sender_noc_y[index_offset],
+                 .addr = reshard_dest_local_addr});
+            l1_read_addr_out += out_tensor_stride_w_bytes;
+            reshard_dest_local_addr += out_reshard_tensor_stride_w_bytes;
+        }
+        l1_read_addr_out_offset += per_core_N_reshard_bytes[index_offset];
+
+        index_offset += 3;
+    }
+    noc.async_write_barrier();
+#endif
+
+    cb_out.pop_front(out_block_num_tiles);
+
+    // Restore NCRISC_RD_CMD_BUF NOC_CTRL to the firmware default (VC=1, set in
+    // noc_init). set_async_read_state<NocOptions::CUSTOM_VC> writes a per-bank VC into NOC_CTRL
+    // and this hardware register persists across kernel launches. Kernels that
+    // follow (e.g. 1d-multicast matmul readers running in DM_DEDICATED_NOC mode)
+    // rely on NOC_CTRL being at its initialized value and do not re-set it, so
+    // they inherit the stale custom VC and suffer reduced DRAM bandwidth.
+    noc.set_async_read_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(
+        dram_bank, in1_page_size, {.bank_id = dram_bank_id, .addr = in1_tensor_addr}, NocOptVals{.vc = 1});
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded_height.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded_height.cpp
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Batch-sharded DRAM matmul - in1 reader and output writer kernel
+// For batched matmul: [1, B, M, K] x [1, B, K, N] = [1, B, M, N]
+// Each worker handles B/num_workers batches independently
+// Input B (weights) is DRAM sharded by batch - each bank has B/12 complete [N, K] matrices
+// Output is NOC written to OUTPUT STORAGE CORES (different from worker cores)
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "hostdevcommon/common_values.hpp"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+
+void kernel_main() {
+    // RUNTIME ARGS
+    const bool is_worker_core = get_arg_val<uint32_t>(0) == 1;
+    if (not is_worker_core) {
+        return;
+    }
+
+    const uint32_t in1_tensor_addr = get_arg_val<uint32_t>(1);
+#ifdef FUSE_BIAS
+    const uint32_t in3_tensor_addr = get_arg_val<uint32_t>(2);
+#endif
+    const uint32_t dram_bank_id = get_arg_val<uint32_t>(3);
+    const uint32_t vc = get_arg_val<uint32_t>(4);
+
+    // Output storage core coordinates and L1 address (where to NOC write output)
+    const uint32_t output_storage_noc_x = get_arg_val<uint32_t>(5);
+    const uint32_t output_storage_noc_y = get_arg_val<uint32_t>(6);
+    const uint32_t output_shard_l1_addr = get_arg_val<uint32_t>(7);
+
+    // COMPILE TIME ARGS
+    constexpr uint32_t in1_page_size = get_compile_time_arg_val(0);
+    constexpr uint32_t in1_num_pages = get_compile_time_arg_val(1);
+    constexpr uint32_t in1_block_w = get_compile_time_arg_val(2);                    // K tiles per block
+    constexpr uint32_t in1_block_num_tiles = get_compile_time_arg_val(3);            // in0_block_w * K
+    constexpr uint32_t num_blocks = get_compile_time_arg_val(4);                     // N / in0_block_w
+    constexpr uint32_t out_block_num_tiles = get_compile_time_arg_val(5);            // M * K
+    constexpr uint32_t num_batches_per_core = get_compile_time_arg_val(6);           // B / num_cores
+    constexpr uint32_t in1_tensor_stride_batch_bytes = get_compile_time_arg_val(7);  // bytes per batch in in1
+    constexpr uint32_t out_tensor_stride_batch_bytes = get_compile_time_arg_val(8);  // bytes per batch in output
+    constexpr uint32_t out_shard_size_bytes = get_compile_time_arg_val(9);           // full output shard size
+
+#ifdef FUSE_BIAS
+    constexpr uint32_t in3_page_size = get_compile_time_arg_val(10);
+    constexpr uint32_t in3_num_pages = get_compile_time_arg_val(11);
+    constexpr uint32_t in3_block_tiles = get_compile_time_arg_val(12);  // K tiles for bias
+    constexpr uint32_t cb_id_in3 = get_named_compile_time_arg_val("cb_bias");
+#endif
+
+    constexpr uint32_t cb_id_in1 = get_named_compile_time_arg_val("cb_in1");
+    constexpr uint32_t cb_id_out = get_named_compile_time_arg_val("cb_out");  // Local output CB (compute writes here)
+    constexpr uint32_t in1_single_tile_size_bytes = get_tile_size(cb_id_in1);
+    constexpr uint32_t out_single_tile_size_bytes = get_tile_size(cb_id_out);
+    constexpr uint32_t in1_block_size_bytes = in1_block_num_tiles * in1_single_tile_size_bytes;
+    constexpr uint32_t out_block_size_bytes = out_block_num_tiles * out_single_tile_size_bytes;
+
+    Noc noc;
+    CircularBuffer cb_in1(cb_id_in1);
+    CircularBuffer cb_out(cb_id_out);
+    // DRAM read setup
+    AllocatorBank<AllocatorBankType::DRAM> dram_bank;
+    // Output reshard setup - build NOC address for remote output storage core
+    UnicastEndpoint remote;
+#ifdef FUSE_BIAS
+    CircularBuffer cb_in3(cb_id_in3);
+#endif
+
+    // Process each batch
+    for (uint32_t batch = 0; batch < num_batches_per_core; ++batch) {
+        uint32_t in1_batch_offset = batch * in1_tensor_stride_batch_bytes;
+        uint32_t l1_read_addr_in1 = 0;
+
+        // Read all N blocks of weights for this batch
+        for (uint32_t block = 0; block < num_blocks; ++block) {
+            cb_in1.reserve_back(in1_block_num_tiles);
+
+            // Read weight block from DRAM
+            uint32_t remaining_bytes = in1_block_size_bytes;
+            uint32_t cb_write_offset = 0;
+            uint32_t curr_dram_offset = l1_read_addr_in1;
+
+            while (remaining_bytes > 0) {
+                uint32_t read_size = (remaining_bytes > in1_page_size) ? in1_page_size : remaining_bytes;
+                noc.async_read(
+                    dram_bank,
+                    cb_in1,
+                    read_size,
+                    {.bank_id = dram_bank_id, .addr = in1_tensor_addr + in1_batch_offset + curr_dram_offset},
+                    {.offset_bytes = cb_write_offset});
+                cb_write_offset += read_size;
+                curr_dram_offset += read_size;
+                remaining_bytes -= read_size;
+            }
+
+            noc.async_read_barrier();
+            cb_in1.push_back(in1_block_num_tiles);
+            l1_read_addr_in1 += in1_block_size_bytes;
+        }
+
+#ifdef FUSE_BIAS
+        // Read bias for this batch (if fused)
+        cb_in3.reserve_back(in3_block_tiles);
+        noc.async_read(
+            dram_bank,
+            cb_in3,
+            in3_block_tiles * get_tile_size(cb_id_in3),
+            {.bank_id = dram_bank_id, .addr = in3_tensor_addr},
+            {.offset_bytes = 0});
+        noc.async_read_barrier();
+        cb_in3.push_back(in3_block_tiles);
+#endif
+
+        // Wait for compute to finish this batch
+        cb_out.wait_front(out_block_num_tiles);
+
+#ifdef OUT_SHARDED
+        // NOC write output to remote output storage core (CB6)
+        uint32_t out_batch_offset = batch * out_tensor_stride_batch_bytes;
+        noc.async_write(
+            use<CircularBuffer::AddrSelector::READ_PTR>(cb_out),
+            remote,
+            out_block_size_bytes,
+            {.offset_bytes = 0},
+            {.noc_x = output_storage_noc_x,
+             .noc_y = output_storage_noc_y,
+             .addr = output_shard_l1_addr + out_batch_offset});
+        noc.async_write_barrier();
+#endif
+
+        cb_out.pop_front(out_block_num_tiles);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -1,0 +1,678 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "hostdevcommon/common_values.hpp"
+#include "ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/tensor/noc_traits.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+void kernel_main() {
+    // READER
+    uint32_t rt_args_idx = 0;
+    // in1 tensor args
+    const uint32_t in1_tensor_addr = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t in1_tensor_start_tile_id = get_arg_val<uint32_t>(rt_args_idx++);
+    // in1 mcast args
+    const uint32_t in1_mcast_dest_noc_start_x = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t in1_mcast_dest_noc_start_y = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t in1_mcast_dest_noc_end_x = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t in1_mcast_dest_noc_end_y = get_arg_val<uint32_t>(rt_args_idx++);
+
+    // sparsity args
+    const uint32_t sparsity_addr = get_arg_val<uint32_t>(rt_args_idx++);
+
+    // WRITER
+    // out tensor args
+    const uint32_t out_tensor_addr = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t out_tensor_start_tile_id = get_arg_val<uint32_t>(rt_args_idx++);
+
+    // padding args (READER)
+    const uint32_t last_block_w = get_arg_val<uint32_t>(rt_args_idx++);
+    // padding args (WRITER)
+    const uint32_t out_num_nonzero_subblocks_h = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t out_last_subblock_h = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t padded_block_tiles_h_skip = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t out_num_nonzero_subblocks_w = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t out_last_num_nonzero_subblocks_w = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t out_last_subblock_w = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t padded_subblock_tiles_addr_skip = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t padded_block_tiles_w_skip = get_arg_val<uint32_t>(rt_args_idx++);
+
+    // COMPILE TIME ARGS
+    // READER
+    // in1 tensor args
+    constexpr uint32_t in1_tensor_stride_w = get_compile_time_arg_val(0);
+    constexpr uint32_t in1_tensor_stride_h = get_compile_time_arg_val(1);
+    constexpr uint32_t in1_tensor_next_block_stride = get_compile_time_arg_val(2);
+    constexpr uint32_t in1_tensor_next_w_dim_block_stride = get_compile_time_arg_val(3);
+    // in1 block args
+    constexpr uint32_t in1_block_w = get_compile_time_arg_val(4);
+    constexpr uint32_t in1_block_h = get_compile_time_arg_val(5);
+    constexpr uint32_t in1_block_num_tiles = get_compile_time_arg_val(6);
+    // in0/in1 common args
+    constexpr uint32_t num_blocks_inner_dim = get_compile_time_arg_val(7);
+    constexpr uint32_t num_blocks_w_dim = get_compile_time_arg_val(8);
+    constexpr uint32_t num_blocks_h_dim = get_compile_time_arg_val(9);
+
+    // in1 mcast args
+    constexpr uint32_t in1_mcast_num_dests = get_compile_time_arg_val(12);
+    constexpr uint32_t in1_mcast_num_cores = get_compile_time_arg_val(13);
+    // batch args
+    constexpr uint32_t KtNt = get_compile_time_arg_val(14);
+    constexpr uint32_t batch = get_compile_time_arg_val(15);
+    constexpr uint32_t bcast_B = get_compile_time_arg_val(16);
+    // sparsity args
+    constexpr uint32_t batchB = get_compile_time_arg_val(17);
+    constexpr uint32_t sparsity_pagesize = get_compile_time_arg_val(18);
+
+    // WRITER
+    // out tensor args
+    constexpr uint32_t out_tensor_stride_w = get_compile_time_arg_val(19);
+    constexpr uint32_t out_tensor_stride_h = get_compile_time_arg_val(20);
+    constexpr uint32_t out_tensor_next_subblock_stride_w = get_compile_time_arg_val(21);
+    constexpr uint32_t out_tensor_next_subblock_stride_h = get_compile_time_arg_val(22);
+    constexpr uint32_t out_tensor_next_w_dim_block_stride = get_compile_time_arg_val(23);
+    constexpr uint32_t out_tensor_next_h_dim_block_stride = get_compile_time_arg_val(24);
+    // out subblock args
+    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(25);
+    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(26);
+    constexpr uint32_t out_subblock_tile_count = get_compile_time_arg_val(27);
+    // batch args
+    constexpr uint32_t MtNt = get_compile_time_arg_val(28);  // if 0
+    // Don't need batch; same as batch from READER args
+
+    // When sparsity is disabled, we just loop once
+    constexpr uint32_t batchB_lim = batchB == 0 ? 1u : batchB;
+
+#ifdef FUSE_BIAS
+    // in3 mcast args
+    const uint32_t in3_tensor_addr = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t in3_tensor_start_tile_id = get_arg_val<uint32_t>(rt_args_idx++);
+
+    constexpr uint32_t in3_tensor_stride_w = get_compile_time_arg_val(29);
+
+    constexpr uint32_t cb_id_in3 = get_named_compile_time_arg_val("cb_bias");
+    constexpr uint32_t bias_single_tile_size_bytes = get_tile_size(cb_id_in3);
+    constexpr const uint32_t in3_tile_hw = get_tile_hw(cb_id_in3);
+
+#ifndef BIAS_SHARDED
+    uint32_t l1_write_addr_in3;
+    // Bias accessor will be defined later after TensorAccessor args
+#endif  // BIAS_SHARDED
+#else
+    rt_args_idx += 2;  // Skip over placeholders
+#endif  // FUSE_BIAS
+#ifndef OUT_SHARDED
+    const uint32_t last_num_blocks_w_dim = get_arg_val<uint32_t>(rt_args_idx++);
+#endif  // OUT_SHARDED
+
+    constexpr bool fuse_op_all_gather = (bool)get_compile_time_arg_val(30);
+    constexpr bool fuse_op_reduce_scatter = (bool)get_compile_time_arg_val(31);
+
+    MatmulOpReceiver fused_op_receiver;
+    OpSignaler op_signaler;
+    if constexpr (fuse_op_all_gather) {
+        fused_op_receiver = MatmulOpReceiver(
+            false, /* wait_for_op_signal */
+            rt_args_idx,
+            num_blocks_inner_dim,
+            in1_block_h /* tiles_per_block (in the same dimension */
+        );
+    } else if constexpr (fuse_op_reduce_scatter) {
+        op_signaler = OpSignaler(rt_args_idx);
+    }
+
+    constexpr auto in1_args = TensorAccessorArgs<32>();
+    constexpr auto sparsity_args = TensorAccessorArgs<in1_args.next_compile_time_args_offset()>();
+    constexpr auto out_args = TensorAccessorArgs<sparsity_args.next_compile_time_args_offset()>();
+#ifdef FUSE_BIAS
+    constexpr auto bias_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
+    constexpr auto after_bias_offset = bias_args.next_compile_time_args_offset();
+#else
+    constexpr auto after_bias_offset = out_args.next_compile_time_args_offset();
+#endif  // FUSE_BIAS
+
+// RT and COMPILE TIME ARGS for DRAM sharded weights
+#ifdef IN1_DRAM_WIDTH_SHARDED
+    const uint32_t vc = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t num_dram_shards_to_read = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t dram_tensor_start_offset = get_arg_val<uint32_t>(rt_args_idx++);
+    tt_l1_ptr uint32_t* in1_block_w_dram_stride_bytes = (tt_l1_ptr uint32_t*)get_arg_addr(rt_args_idx++);
+    tt_l1_ptr uint32_t* current_dram_bank_id = (tt_l1_ptr uint32_t*)get_arg_addr(rt_args_idx++);
+
+    constexpr uint32_t in1_dram_block_num_tiles = get_compile_time_arg_val(after_bias_offset);
+    constexpr uint32_t in1_block_w_dram_bytes = get_compile_time_arg_val(after_bias_offset + 1);
+#endif  // IN1_DRAM_WIDTH_SHARDED
+
+#ifdef IN1_DRAM_HEIGHT_SHARDED
+    constexpr uint32_t in1_KtNt_per_batch = get_compile_time_arg_val(after_bias_offset);        // K*N tiles per batch
+    constexpr uint32_t in1_batches_per_bank = get_compile_time_arg_val(after_bias_offset + 1);  // batches per DRAM bank
+#endif  // IN1_DRAM_HEIGHT_SHARDED
+
+#ifdef FUSE_BIAS
+#ifndef BIAS_SHARDED
+    const auto s3 = TensorAccessor(bias_args, in3_tensor_addr);
+#endif  // BIAS_SHARDED
+#endif  // FUSE_BIAS
+
+    constexpr uint32_t cb_id_in1 = get_named_compile_time_arg_val("cb_in1");
+    constexpr uint32_t in1_single_tile_size_bytes = get_tile_size(cb_id_in1);
+    constexpr const uint32_t in1_tile_hw = get_tile_hw(cb_id_in1);
+    // Tiles whose size is not a multiple of the DRAM alignment are padded to it in DRAM, and the
+    // interleaved in1 CB pages are sized to match (see the program factory). On the plain interleaved
+    // path the NOC reads the unpadded tile of data into each padded slot and tiles are laid out /
+    // multicast at the padded stride. No-op when already aligned. The sharded / DRAM-sharded paths
+    // keep their natural (unpadded) stride.
+    constexpr uint32_t in1_aligned_tile_size_bytes =
+        (in1_single_tile_size_bytes + (DRAM_ALIGNMENT - 1)) & ~(DRAM_ALIGNMENT - 1);
+#if !defined(IN1_SHARDED) && !defined(IN1_DRAM_WIDTH_SHARDED) && !defined(IN1_DRAM_HEIGHT_SHARDED)
+    constexpr uint32_t in1_block_size_bytes = in1_block_num_tiles * in1_aligned_tile_size_bytes;
+#else
+    constexpr uint32_t in1_block_size_bytes = in1_block_num_tiles * in1_single_tile_size_bytes;
+#endif
+
+    constexpr uint32_t cb_id_out0 = get_named_compile_time_arg_val("cb_out");
+    constexpr uint32_t output_single_tile_size_bytes = get_tile_size(cb_id_out0);
+    constexpr const uint32_t output_tile_hw = get_tile_hw(cb_id_out0);
+
+    Noc noc;
+    CircularBuffer cb_in1(cb_id_in1);
+    CircularBuffer cb_out(cb_id_out0);
+    Semaphore<> sender_sem(get_compile_time_arg_val(10));
+    Semaphore<> receiver_sem(get_compile_time_arg_val(11));
+#ifdef FUSE_BIAS
+    CircularBuffer cb_in3(cb_id_in3);
+#endif
+
+//  READER
+#ifdef IN1_SHARDED
+    cb_in1.reserve_back(in1_block_num_tiles * num_blocks_inner_dim);
+    cb_in1.push_back(in1_block_num_tiles * num_blocks_inner_dim);
+#else
+    uint32_t l1_write_addr_in1;
+
+    const auto s1 = TensorAccessor(in1_args, in1_tensor_addr);
+#endif  // IN1_SHARDED
+
+    //  WRITER
+    const auto s = TensorAccessor(out_args, out_tensor_addr);
+
+    // sparsity accessor
+    constexpr uint32_t cb_id_sparsity = get_named_compile_time_arg_val("cb_sparsity");
+    CircularBuffer cb_sparsity(cb_id_sparsity);
+    const auto s_sparsity = TensorAccessor(sparsity_args, sparsity_addr);
+
+#ifndef SKIP_MCAST
+    // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
+    receiver_sem.set(VALID);
+    // local address that will be atomically incremented by mcast receivers, to know when all receivers are ready
+    // to receive the mcast
+
+#ifdef IN1_SHARDED
+    uint64_t in1_start_address = cb_in1.get_write_ptr();
+#endif  // IN1_SHARDED
+#endif  // SKIP_MCAST
+
+    uint32_t l1_write_addr_sparsity = 0;
+    if constexpr (batchB > 0) {
+        cb_sparsity.reserve_back(1);
+        l1_write_addr_sparsity = cb_sparsity.get_write_ptr();
+    }
+
+#ifdef IN1_DRAM_WIDTH_SHARDED
+    constexpr uint32_t in1_dram_block_size_bytes = in1_dram_block_num_tiles * in1_single_tile_size_bytes;
+    uint32_t in1_block_w_bytes = in1_block_w * in1_single_tile_size_bytes;
+#endif  // IN1_DRAM_WIDTH_SHARDED
+
+#ifdef IN1_DRAM_HEIGHT_SHARDED
+    constexpr uint32_t in1_batch_stride_bytes = in1_KtNt_per_batch * in1_single_tile_size_bytes;
+#endif  // IN1_DRAM_HEIGHT_SHARDED
+
+    for (uint32_t b = 0; b < batch; ++b) {
+        uint32_t in1_batch_tile_id = in1_tensor_start_tile_id;
+
+#ifdef IN1_DRAM_HEIGHT_SHARDED
+        // Compute DRAM bank and offset for this batch
+        uint32_t in1_dram_bank_id = b / in1_batches_per_bank;
+        uint32_t in1_batch_in_shard = b % in1_batches_per_bank;
+        AllocatorBank<AllocatorBankType::DRAM> dram_src;
+        uint32_t in1_dram_batch_offset = in1_batch_in_shard * in1_batch_stride_bytes;
+#endif  // IN1_DRAM_HEIGHT_SHARDED
+
+        if constexpr (batchB > 0) {
+            noc.async_read(s_sparsity, cb_sparsity, sparsity_pagesize, {.page_id = b}, {.offset_bytes = 0});
+            noc.async_read_barrier();
+        }
+
+        for (uint32_t bB = 0; bB < batchB_lim; ++bB) {
+            if constexpr (batchB > 0) {
+                if (reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_addr_sparsity)[bB] == 0) {
+                    out_tensor_start_tile_id += MtNt;
+                    in1_batch_tile_id += KtNt;
+                    continue;
+                }
+            }
+
+            uint32_t in1_tensor_current_h_dim_block_tile_id = in1_batch_tile_id;
+            uint32_t out_tensor_current_h_dim_block_tile_id = out_tensor_start_tile_id;
+            for (uint32_t bh = 0; bh < num_blocks_h_dim; ++bh) {
+                uint32_t in1_tensor_current_w_dim_block_tile_id = in1_tensor_current_h_dim_block_tile_id;
+                uint32_t out_tensor_current_w_dim_block_tile_id = out_tensor_current_h_dim_block_tile_id;
+#ifdef FUSE_BIAS
+                uint32_t in3_tensor_current_w_dim_block_tile_id = in3_tensor_start_tile_id;
+#endif  // FUSE_BIAS
+                for (uint32_t bw = 0; bw < num_blocks_w_dim; ++bw) {
+                    uint32_t in1_tensor_current_inner_dim_block_start_tile_id = in1_tensor_current_w_dim_block_tile_id;
+#ifdef IN1_DRAM_WIDTH_SHARDED
+                    // Reset DRAM read offset for each bh block — the inner dim loop
+                    // advances through K, and each output row block re-reads the same
+                    // in1 columns from K=0. (bw is always 1 for DRAM-sharded senders.)
+                    uint32_t l1_read_addr_in1_offset = 0;
+#endif  // IN1_DRAM_WIDTH_SHARDED
+
+                    for (uint32_t block = 0; block < num_blocks_inner_dim; ++block) {
+                        if constexpr (fuse_op_all_gather) {
+                            fused_op_receiver.update_current_block_start_tile_id(
+                                block, in1_tensor_current_inner_dim_block_start_tile_id, in1_batch_tile_id);
+                        }
+#if defined(IN1_DRAM_WIDTH_SHARDED)
+                        // Operand 1 - DRAM width sharded
+                        cb_in1.reserve_back(in1_block_num_tiles);
+
+                        uint64_t in1_start_address =
+                            cb_in1.get_write_ptr();  // copy start address of block, to be used for mcasting
+
+                        uint32_t l1_write_addr_in1_offset = 0;
+                        uint32_t next_bank_id_and_dram_stride_index = 0;
+
+                        AllocatorBank<AllocatorBankType::DRAM> dram_bank;
+                        for (uint32_t i = 0; i < num_dram_shards_to_read; ++i) {
+                            uint32_t shard_bank_id = current_dram_bank_id[next_bank_id_and_dram_stride_index];
+                            uint32_t shard_base_addr = in1_tensor_addr;
+                            if (i == 0) {
+                                shard_base_addr += dram_tensor_start_offset;
+                            }
+                            noc.set_async_read_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(
+                                dram_bank,
+                                in1_single_tile_size_bytes,
+                                {.bank_id = shard_bank_id, .addr = shard_base_addr},
+                                NocOptVals{.vc = vc});
+
+                            uint32_t l1_read_addr_in1 = l1_read_addr_in1_offset;
+                            uint32_t l1_write_addr_in1 = cb_in1.get_write_ptr() + l1_write_addr_in1_offset;
+                            uint32_t in1_block_w_dram =
+                                in1_block_w_dram_stride_bytes[next_bank_id_and_dram_stride_index] /
+                                in1_single_tile_size_bytes;
+
+                            for (uint32_t m = 0; m < in1_block_h; ++m) {
+                                uint32_t l1_read_addr_in1_temp = l1_read_addr_in1;
+                                uint32_t l1_write_addr_in1_temp = l1_write_addr_in1;
+                                for (uint32_t w = 0; w < in1_block_w_dram; ++w) {
+                                    noc.async_read_with_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(
+                                        dram_bank,
+                                        CoreLocalMem<uint32_t>(l1_write_addr_in1_temp),
+                                        in1_single_tile_size_bytes,
+                                        {.bank_id = shard_bank_id, .addr = shard_base_addr + l1_read_addr_in1_temp},
+                                        {},
+                                        NocOptVals{.vc = vc});
+                                    l1_read_addr_in1_temp += in1_single_tile_size_bytes;
+                                    l1_write_addr_in1_temp += in1_single_tile_size_bytes;
+                                }
+                                l1_read_addr_in1 += in1_block_w_dram_bytes;
+                                l1_write_addr_in1 += in1_block_w_bytes;
+                            }
+                            l1_write_addr_in1_offset +=
+                                in1_block_w_dram_stride_bytes[next_bank_id_and_dram_stride_index];
+                            next_bank_id_and_dram_stride_index += 2;
+                        }
+                        l1_read_addr_in1_offset += in1_dram_block_size_bytes;
+                        noc.async_read_barrier();
+#elif defined(IN1_DRAM_HEIGHT_SHARDED)
+                        // Operand 1 - DRAM height sharded (batched)
+                        // Each DRAM bank holds batches_per_bank complete [K, N] matrices
+                        // Bank and offset computed at start of batch loop
+                        cb_in1.reserve_back(in1_block_num_tiles);
+
+                        l1_write_addr_in1 = cb_in1.get_write_ptr();
+                        uint64_t in1_start_address =
+                            l1_write_addr_in1;  // copy start address of block, to be used for mcasting
+
+                        // Read in1 block from the correct DRAM bank
+                        // Tile layout within a batch: row-major [K, N], same strides as interleaved
+                        uint32_t in1_tensor_row_start_tile_id = in1_tensor_current_inner_dim_block_start_tile_id;
+                        for (uint32_t h = 0; h < in1_block_h; ++h) {
+                            uint32_t in1_tensor_tile_id = in1_tensor_row_start_tile_id;
+                            for (uint32_t w = 0; w < in1_block_w; ++w) {
+                                if (bw < num_blocks_w_dim - 1 || w < last_block_w) {
+                                    uint32_t tile_byte_offset =
+                                        in1_dram_batch_offset + in1_tensor_tile_id * in1_single_tile_size_bytes;
+                                    noc.async_read(
+                                        dram_src,
+                                        CoreLocalMem<uint32_t>(l1_write_addr_in1),
+                                        in1_single_tile_size_bytes,
+                                        {.bank_id = in1_dram_bank_id, .addr = in1_tensor_addr + tile_byte_offset},
+                                        {});
+                                }
+                                l1_write_addr_in1 += in1_single_tile_size_bytes;
+                                in1_tensor_tile_id += in1_tensor_stride_w;
+                            }
+                            in1_tensor_row_start_tile_id += in1_tensor_stride_h;
+                        }
+                        in1_tensor_current_inner_dim_block_start_tile_id += in1_tensor_next_block_stride;
+
+                        // Barrier! make sure the reads are done
+                        noc.async_read_barrier();
+#elif !defined(IN1_SHARDED)
+                        // Operand 1 - interleaved
+                        cb_in1.reserve_back(in1_block_num_tiles);
+                        uint32_t in1_write_offset = 0;
+                        uint64_t in1_start_address =
+                            cb_in1.get_write_ptr();  // copy start address of block, to be used for mcasting
+
+                        // Copy in1 block into CB, as the default kernel
+                        uint32_t in1_tensor_row_start_tile_id = in1_tensor_current_inner_dim_block_start_tile_id;
+                        for (uint32_t h = 0; h < in1_block_h; ++h) {
+                            uint32_t in1_tensor_tile_id = in1_tensor_row_start_tile_id;
+                            for (uint32_t w = 0; w < in1_block_w; ++w) {
+                                if (bw < num_blocks_w_dim - 1 || w < last_block_w) {
+                                    noc.async_read(
+                                        s1,
+                                        cb_in1,
+                                        in1_single_tile_size_bytes,
+                                        {.page_id = in1_tensor_tile_id},
+                                        {.offset_bytes = in1_write_offset});
+                                }
+                                in1_write_offset += in1_aligned_tile_size_bytes;
+                                in1_tensor_tile_id += in1_tensor_stride_w;
+                            }
+                            in1_tensor_row_start_tile_id += in1_tensor_stride_h;
+                        }
+                        in1_tensor_current_inner_dim_block_start_tile_id += in1_tensor_next_block_stride;
+
+                        // Barrier! make sure the reads are done
+                        noc.async_read_barrier();
+#endif  // IN1_DRAM_WIDTH_SHARDED / IN1_DRAM_HEIGHT_SHARDED / IN1_SHARDED
+
+#ifndef SKIP_MCAST
+                        // wait until all in1 mcast destinations have atomically incremented the in1 semaphore_addr
+                        // (i.e. its value should be in0_mcast_num_dests), then reset the semaphore_addr value back to
+                        // zero for the next block
+                        sender_sem.wait(in1_mcast_num_dests);
+                        sender_sem.set(0);
+
+                        // Now we have the block in the CB address, we can mcast to dests!
+                        MulticastEndpoint mcast_dst;
+                        // num_dests must not include source, since we are NOT really doing a local copy!
+                        noc.async_write_multicast(
+                            CoreLocalMem<uint32_t>(static_cast<uint32_t>(in1_start_address)),
+                            mcast_dst,
+                            in1_block_size_bytes,
+                            in1_mcast_num_cores,
+                            {},
+                            {.noc_x_start = in1_mcast_dest_noc_start_x,
+                             .noc_y_start = in1_mcast_dest_noc_start_y,
+                             .noc_x_end = in1_mcast_dest_noc_end_x,
+                             .noc_y_end = in1_mcast_dest_noc_end_y,
+                             .addr = static_cast<uint32_t>(in1_start_address)},
+                            true);
+
+                        // Note: no need for write barrier, since these two multicasts are done on the same noc id and
+                        // same vc even though cmd bufs are different Also, this only works because we are setting VCs
+                        // statically (using NOC_CMD_STATIC_VC).
+#ifdef ARCH_BLACKHOLE
+                        // On Blackhole the flush is needed because NoC latency is higher than L1 <-> RISCV latency
+                        // which means data could be changed before
+                        //  write is issued.
+                        noc.async_writes_flushed();
+#endif  // ARCH_BLACKHOLE
+
+                        // We should also multicast the flag to destinations
+                        // num_dests must not include source, since we are NOT really doing a local copy!
+                        receiver_sem.set_multicast(
+                            noc,
+                            in1_mcast_dest_noc_start_x,
+                            in1_mcast_dest_noc_start_y,
+                            in1_mcast_dest_noc_end_x,
+                            in1_mcast_dest_noc_end_y,
+                            in1_mcast_num_cores);
+#endif  // SKIP_MCAST
+
+#ifndef IN1_SHARDED
+                        cb_in1.push_back(in1_block_num_tiles);
+#endif  // IN1_SHARDED
+                    }
+#ifdef FUSE_BIAS
+                    // Only read bias on first batch, or we have multiple output blocks
+                    if ((b == 0 && bh == 0) || num_blocks_w_dim > 1) {
+                        // Operand 1
+#ifndef BIAS_SHARDED
+                        cb_in3.reserve_back(in1_block_w);
+                        uint32_t in3_write_offset = 0;
+
+                        uint64_t in3_start_address =
+                            cb_in3.get_write_ptr();         // copy start address of block, to be used for mcasting
+                        uint32_t in3_block_size_bytes = 0;  // can be optimized later, pass it to kernel
+
+#ifdef IN1_DRAM_WIDTH_SHARDED
+                        uint32_t l1_write_addr_in3_offset = 0;
+                        uint32_t next_bank_id_and_dram_stride_index = 0;
+
+                        AllocatorBank<AllocatorBankType::DRAM> bias_dram_bank;
+                        for (uint32_t i = 0; i < num_dram_shards_to_read; ++i) {
+                            uint32_t bias_shard_bank_id = current_dram_bank_id[next_bank_id_and_dram_stride_index];
+                            uint32_t bias_shard_base_addr = in3_tensor_addr;
+                            if (i == 0) {
+                                // dram_tensor_start_offset is in in1 tile bytes; convert to
+                                // bias tile bytes since bias_dtype may differ from in1_dtype.
+                                bias_shard_base_addr += (dram_tensor_start_offset / in1_single_tile_size_bytes) *
+                                                        bias_single_tile_size_bytes;
+                            }
+
+                            noc.set_async_read_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(
+                                bias_dram_bank,
+                                bias_single_tile_size_bytes,
+                                {.bank_id = bias_shard_bank_id, .addr = bias_shard_base_addr},
+                                NocOptVals{.vc = vc});
+
+                            uint32_t l1_read_addr_in3 = 0;
+                            l1_write_addr_in3 = cb_in3.get_write_ptr() + l1_write_addr_in3_offset;
+                            // in1_block_w_dram_stride_bytes is in in1 tile bytes, so divide
+                            // by in1_single_tile_size_bytes (not bias) to get the tile count.
+                            uint32_t in3_block_w_dram =
+                                in1_block_w_dram_stride_bytes[next_bank_id_and_dram_stride_index] /
+                                in1_single_tile_size_bytes;
+
+                            for (uint32_t w = 0; w < in3_block_w_dram; ++w) {
+                                noc.async_read_with_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(
+                                    bias_dram_bank,
+                                    CoreLocalMem<uint32_t>(l1_write_addr_in3),
+                                    bias_single_tile_size_bytes,
+                                    {.bank_id = bias_shard_bank_id, .addr = bias_shard_base_addr + l1_read_addr_in3},
+                                    {},
+                                    NocOptVals{.vc = vc});
+                                l1_read_addr_in3 += bias_single_tile_size_bytes;
+                                l1_write_addr_in3 += bias_single_tile_size_bytes;
+                                in3_block_size_bytes += bias_single_tile_size_bytes;
+                            }
+                            // Advance L1 offset in bias tile bytes, not in1 stride bytes.
+                            l1_write_addr_in3_offset += in3_block_w_dram * bias_single_tile_size_bytes;
+                            next_bank_id_and_dram_stride_index += 2;
+                        }
+                        noc.async_read_barrier();
+#else
+                        // Copy in1 block into CB, as the default kernel
+                        uint32_t in3_tensor_tile_id = in3_tensor_current_w_dim_block_tile_id;
+                        for (uint32_t w = 0; w < in1_block_w; ++w) {
+                            if (bw < num_blocks_w_dim - 1 || w < last_block_w) {
+                                noc.async_read(
+                                    s3,
+                                    cb_in3,
+                                    bias_single_tile_size_bytes,
+                                    {.page_id = in3_tensor_tile_id},
+                                    {.offset_bytes = in3_write_offset});
+                            }
+                            in3_write_offset += bias_single_tile_size_bytes;
+                            in3_tensor_tile_id += in3_tensor_stride_w;
+                            in3_block_size_bytes += bias_single_tile_size_bytes;
+                        }
+                        // Barrier! make sure the reads are done
+                        noc.async_read_barrier();
+#endif  // IN1_DRAM_WIDTH_SHARDED
+
+#ifndef SKIP_MCAST
+
+                        // wait until all in1 mcast destinations have atomically incremented the in1 semaphore_addr
+                        // (i.e. its value should be in0_mcast_num_dests), then reset the semaphore_addr value back to
+                        // zero for the next block
+                        sender_sem.wait(in1_mcast_num_dests);
+                        sender_sem.set(0);
+
+                        // Now we have the block in the CB address, we can mcast to dests!
+                        MulticastEndpoint mcast_dst;
+                        // num_dests must not include source, since we are NOT really doing a local copy!
+                        noc.async_write_multicast(
+                            CoreLocalMem<uint32_t>(static_cast<uint32_t>(in3_start_address)),
+                            mcast_dst,
+                            in3_block_size_bytes,
+                            in1_mcast_num_cores,
+                            {},
+                            {.noc_x_start = in1_mcast_dest_noc_start_x,
+                             .noc_y_start = in1_mcast_dest_noc_start_y,
+                             .noc_x_end = in1_mcast_dest_noc_end_x,
+                             .noc_y_end = in1_mcast_dest_noc_end_y,
+                             .addr = static_cast<uint32_t>(in3_start_address)},
+                            true);
+                        // Note: no need for write barrier, since these two multicasts are done on the same noc id, same
+                        // vc, same cmd_buf Also, this only works because we are setting VCs statically (using
+                        // NOC_CMD_STATIC_VC).
+#ifdef ARCH_BLACKHOLE
+                        // On Blackhole the flush is needed because NoC latency is higherthan L1 <-> RISCV
+                        // latency which means data could be changed before write is issued.
+                        noc.async_writes_flushed();
+#endif  // ARCH_BLACKHOLE
+
+                        // We should also multicast the flag to destinations
+                        // num_dests must not include source, since we are NOT really doing a local copy!
+                        receiver_sem.set_multicast(
+                            noc,
+                            in1_mcast_dest_noc_start_x,
+                            in1_mcast_dest_noc_start_y,
+                            in1_mcast_dest_noc_end_x,
+                            in1_mcast_dest_noc_end_y,
+                            in1_mcast_num_cores);
+#endif  // SKIP_MCAST
+
+                        cb_in3.push_back(in1_block_w);
+#else
+                        cb_in3.reserve_back(in1_block_w);
+                        cb_in3.push_back(in1_block_w);
+#endif  // BIAS_SHARDED
+                    }
+#endif  // FUSE_BIAS
+
+#ifndef OUT_SHARDED
+                    // WRITER
+                    uint32_t num_blocks_w_dim_ =
+                        bw >= last_num_blocks_w_dim - 1 ? last_num_blocks_w_dim : num_blocks_w_dim;
+                    uint32_t out_num_nonzero_subblocks_h_ = out_num_nonzero_subblocks_h;
+                    uint32_t out_num_nonzero_subblocks_w_ = out_num_nonzero_subblocks_w;
+                    if (bw == num_blocks_w_dim_ - 1) {
+                        out_num_nonzero_subblocks_w_ = out_last_num_nonzero_subblocks_w;
+                    }
+                    uint32_t out_tensor_sbh_start_tile_id = out_tensor_current_w_dim_block_tile_id;
+                    for (uint32_t sbh = 0; sbh < out_num_nonzero_subblocks_h_; ++sbh) {
+                        uint32_t out_tensor_sbw_start_tile_id = out_tensor_sbh_start_tile_id;
+                        for (uint32_t sbw = 0; sbw < out_num_nonzero_subblocks_w_; ++sbw) {
+                            uint32_t out_tensor_sb_row_start_tile_id = out_tensor_sbw_start_tile_id;
+
+                            uint32_t out_subblock_h_ = out_subblock_h;
+                            uint32_t out_subblock_w_ = out_subblock_w;
+                            uint32_t subblock_tiles_addr_skip = 0;
+                            if (bh == num_blocks_h_dim - 1 && sbh == out_num_nonzero_subblocks_h - 1) {
+                                out_subblock_h_ = out_last_subblock_h;
+                            }
+                            if (bw == num_blocks_w_dim_ - 1 && sbw == out_num_nonzero_subblocks_w_ - 1) {
+                                out_subblock_w_ = out_last_subblock_w;
+                                subblock_tiles_addr_skip = padded_subblock_tiles_addr_skip;
+                            }
+
+                            cb_out.wait_front(out_subblock_tile_count);
+                            uint32_t out_read_offset = 0;
+
+                            for (uint32_t h = 0; h < out_subblock_h_; ++h) {
+                                uint32_t out_tensor_tile_id = out_tensor_sb_row_start_tile_id;
+                                for (uint32_t w = 0; w < out_subblock_w_; ++w) {
+                                    if (bw < num_blocks_w_dim_) {
+                                        noc.async_write(
+                                            use<CircularBuffer::AddrSelector::READ_PTR>(cb_out),
+                                            s,
+                                            output_single_tile_size_bytes,
+                                            {.offset_bytes = out_read_offset},
+                                            {.page_id = out_tensor_tile_id});
+                                    }
+
+                                    out_read_offset += output_single_tile_size_bytes;
+
+                                    out_tensor_tile_id += out_tensor_stride_w;
+                                }
+                                // Skip padded tiles in subblock along row
+                                out_read_offset += subblock_tiles_addr_skip;
+                                out_tensor_sb_row_start_tile_id += out_tensor_stride_h;
+                            }
+
+                            noc.async_write_barrier();
+                            cb_out.pop_front(out_subblock_tile_count);
+                            out_tensor_sbw_start_tile_id += out_tensor_next_subblock_stride_w;
+                        }
+                        // Pop fully padded subblocks along the row
+                        if (bw == num_blocks_w_dim_ - 1) {
+                            cb_out.wait_front(padded_block_tiles_w_skip);
+                            cb_out.pop_front(padded_block_tiles_w_skip);
+                        }
+                        out_tensor_sbh_start_tile_id += out_tensor_next_subblock_stride_h;
+                    }
+                    // Pop row(s) of fully padded subblocks
+                    if (bh == num_blocks_h_dim - 1) {
+                        cb_out.wait_front(padded_block_tiles_h_skip);
+                        cb_out.pop_front(padded_block_tiles_h_skip);
+                    }
+
+#endif
+                    in1_tensor_current_w_dim_block_tile_id += in1_tensor_next_w_dim_block_stride;
+                    out_tensor_current_w_dim_block_tile_id += out_tensor_next_w_dim_block_stride;
+#ifdef FUSE_BIAS
+                    in3_tensor_current_w_dim_block_tile_id += in1_block_w;
+#endif
+                }
+                out_tensor_current_h_dim_block_tile_id += out_tensor_next_h_dim_block_stride;
+            }
+            out_tensor_start_tile_id += MtNt;
+            in1_batch_tile_id += KtNt;
+        }
+        if constexpr (bcast_B == 0) {
+#ifndef IN1_DRAM_HEIGHT_SHARDED
+            // For height-sharded DRAM, tile IDs are relative within a batch;
+            // batch offset is handled by switching DRAM banks
+            in1_tensor_start_tile_id += KtNt;
+#endif
+        }
+
+        if (fuse_op_reduce_scatter) {
+            // Signal reduce_scatter to go
+            op_signaler.synchronize_workers_and_signal_op(0);
+        }
+    }
+
+#if OUT_SHARDED
+    cb_out.wait_front(
+        batch * out_num_nonzero_subblocks_h * out_num_nonzero_subblocks_w * out_subblock_w * out_subblock_h);
+#endif
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_writer_bmm_tile_layout_in1.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_writer_bmm_tile_layout_in1.cpp
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    // RUNTIME ARGS
+    // READER
+    uint32_t rt_args_idx = 0;
+    // in1 tensor args
+    const uint32_t in1_tensor_addr = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t in1_tensor_start_tile_id = get_arg_val<uint32_t>(rt_args_idx++);
+    // batch args
+    const uint32_t batch = get_arg_val<uint32_t>(rt_args_idx++);
+
+    // WRITER
+    // out tensor args
+    const uint32_t out_tensor_addr = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t out_tensor_start_tile_id = get_arg_val<uint32_t>(rt_args_idx++);
+
+    // COMPILE TIME ARGS
+    // READER
+    // in1 tensor args
+    constexpr uint32_t in1_tensor_stride_w = get_compile_time_arg_val(0);
+    constexpr uint32_t in1_tensor_stride_h = get_compile_time_arg_val(1);
+    constexpr uint32_t in1_tensor_next_block_stride = get_compile_time_arg_val(2);
+    // in1 block args
+    constexpr uint32_t in1_block_w = get_compile_time_arg_val(3);
+    constexpr uint32_t in1_block_h = get_compile_time_arg_val(4);
+    constexpr uint32_t in1_block_num_tiles = get_compile_time_arg_val(5);
+    // in0/in1 common args
+    constexpr uint32_t num_blocks = get_compile_time_arg_val(6);
+    // batch args
+    constexpr uint32_t bcast_B = get_compile_time_arg_val(7);
+    constexpr uint32_t KtNt = get_compile_time_arg_val(8);
+
+    // WRITER
+    // out tensor args
+    constexpr uint32_t out_tensor_stride_w = get_compile_time_arg_val(9);
+    constexpr uint32_t out_tensor_stride_h = get_compile_time_arg_val(10);
+    constexpr uint32_t out_tensor_next_subblock_stride_w = get_compile_time_arg_val(11);
+    constexpr uint32_t out_tensor_next_subblock_stride_h = get_compile_time_arg_val(12);
+    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(13);
+    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(14);
+    constexpr uint32_t out_subblock_tile_count = get_compile_time_arg_val(15);
+    constexpr uint32_t out_num_subblocks_w = get_compile_time_arg_val(16);
+    constexpr uint32_t out_num_subblocks_h = get_compile_time_arg_val(17);
+    // batch args
+    constexpr uint32_t MtNt = get_compile_time_arg_val(18);
+
+    constexpr uint32_t cb_id_in1 = get_named_compile_time_arg_val("cb_in1");
+    // WRITER
+    constexpr uint32_t cb_id_out0 = get_named_compile_time_arg_val("cb_out");
+
+    constexpr auto in1_args = TensorAccessorArgs<19>();
+    constexpr auto out_args = TensorAccessorArgs<in1_args.next_compile_time_args_offset()>();
+
+    Noc noc;
+    CircularBuffer cb_in1(cb_id_in1);
+    CircularBuffer cb_out(cb_id_out0);
+
+#ifdef IN1_SHARDED
+    const uint32_t in1_num_tiles = batch * num_blocks * in1_block_h * in1_block_w;
+    cb_in1.reserve_back(in1_num_tiles);
+    cb_in1.push_back(in1_num_tiles);
+#else
+    const uint32_t in1_single_tile_size_bytes = get_tile_size(cb_id_in1);
+    // Tiles whose size is not a multiple of the DRAM alignment are padded to it in DRAM and the in1
+    // CB pages are sized to match (see the program factory), so tiles are laid out in L1 at the
+    // padded stride while the NOC reads the unpadded tile of data into each padded slot. No-op when
+    // the tile size is already aligned.
+    const uint32_t in1_aligned_tile_size_bytes =
+        (in1_single_tile_size_bytes + (DRAM_ALIGNMENT - 1)) & ~(DRAM_ALIGNMENT - 1);
+    const auto s1 = TensorAccessor(in1_args, in1_tensor_addr);
+#endif  // IN1_SHARDED
+
+#ifndef OUT_SHARDED
+    const uint32_t output_single_tile_size_bytes = get_tile_size(cb_id_out0);
+    const auto s = TensorAccessor(out_args, out_tensor_addr);
+#endif  // OUT_SHARDED
+
+#if not defined IN1_SHARDED or not defined OUT_SHARDED
+    for (uint32_t b = 0; b < batch; ++b) {
+#ifndef IN1_SHARDED
+        uint32_t in1_tensor_current_block_start_tile_id = in1_tensor_start_tile_id;
+        for (uint32_t block = 0; block < num_blocks; ++block) {
+            cb_in1.reserve_back(in1_block_num_tiles);
+
+            uint32_t in1_write_offset = 0;
+
+            uint32_t in1_tensor_row_start_tile_id = in1_tensor_current_block_start_tile_id;
+            for (uint32_t h = 0; h < in1_block_h; ++h) {
+                uint32_t in1_tensor_tile_id = in1_tensor_row_start_tile_id;
+                for (uint32_t w = 0; w < in1_block_w; ++w) {
+                    noc.async_read(
+                        s1,
+                        cb_in1,
+                        in1_single_tile_size_bytes,
+                        {.page_id = in1_tensor_tile_id},
+                        {.offset_bytes = in1_write_offset});
+                    in1_write_offset += in1_aligned_tile_size_bytes;
+                    in1_tensor_tile_id += in1_tensor_stride_w;
+                }
+                in1_tensor_row_start_tile_id += in1_tensor_stride_h;
+            }
+            in1_tensor_current_block_start_tile_id += in1_tensor_next_block_stride;
+
+            noc.async_read_barrier();
+
+            cb_in1.push_back(in1_block_num_tiles);
+        }
+        if (bcast_B == 0) {
+            in1_tensor_start_tile_id += KtNt;
+        }
+#endif  // IN1_SHARDED
+
+#ifndef OUT_SHARDED
+        // WRITER
+        uint32_t out_tensor_sbh_start_tile_id = out_tensor_start_tile_id;
+        for (uint32_t sbh = 0; sbh < out_num_subblocks_h; ++sbh) {
+            uint32_t out_tensor_sbw_start_tile_id = out_tensor_sbh_start_tile_id;
+            for (uint32_t sbw = 0; sbw < out_num_subblocks_w; ++sbw) {
+                uint32_t out_tensor_sb_row_start_tile_id = out_tensor_sbw_start_tile_id;
+
+                cb_out.wait_front(out_subblock_tile_count);
+                uint32_t out_read_offset = 0;
+
+                for (uint32_t h = 0; h < out_subblock_h; ++h) {
+                    uint32_t out_tensor_tile_id = out_tensor_sb_row_start_tile_id;
+                    for (uint32_t w = 0; w < out_subblock_w; ++w) {
+                        noc.async_write(
+                            use<CircularBuffer::AddrSelector::READ_PTR>(cb_out),
+                            s,
+                            output_single_tile_size_bytes,
+                            {.offset_bytes = out_read_offset},
+                            {.page_id = out_tensor_tile_id});
+
+                        out_read_offset += output_single_tile_size_bytes;
+
+                        out_tensor_tile_id += out_tensor_stride_w;
+                    }
+                    out_tensor_sb_row_start_tile_id += out_tensor_stride_h;
+                }
+
+                noc.async_write_barrier();
+                cb_out.pop_front(out_subblock_tile_count);
+                out_tensor_sbw_start_tile_id += out_tensor_next_subblock_stride_w;
+            }
+            out_tensor_sbh_start_tile_id += out_tensor_next_subblock_stride_h;
+        }
+        out_tensor_start_tile_id += MtNt;
+#endif  // OUT_SHARDED
+    }
+#endif  // not defined IN1_SHARDED or not defined OUT_SHARDED
+
+#ifdef OUT_SHARDED
+    cb_out.wait_front(batch * out_num_subblocks_h * out_num_subblocks_w * out_subblock_w * out_subblock_h);
+#endif  // OUT_SHARDED
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/writer_bmm_tile_layout.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/writer_bmm_tile_layout.cpp
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    // out tensor args
+    uint32_t out_tensor_addr = get_arg_val<uint32_t>(0);
+    uint32_t out_tensor_start_tile_id = get_arg_val<uint32_t>(1);
+    uint32_t out_tensor_stride_w = get_arg_val<uint32_t>(2);
+    uint32_t out_tensor_stride_h = get_arg_val<uint32_t>(3);
+    uint32_t out_tensor_next_subblock_stride_w = get_arg_val<uint32_t>(4);
+    uint32_t out_tensor_next_subblock_stride_h = get_arg_val<uint32_t>(5);
+
+    // out subblock args
+    uint32_t out_subblock_w = get_arg_val<uint32_t>(6);
+    uint32_t out_subblock_h = get_arg_val<uint32_t>(7);
+    uint32_t out_subblock_tile_count = get_arg_val<uint32_t>(8);
+    uint32_t out_num_subblocks_w = get_arg_val<uint32_t>(9);
+    uint32_t out_num_subblocks_h = get_arg_val<uint32_t>(10);
+
+    // batch args
+    uint32_t MtNt = get_arg_val<uint32_t>(11);  // if 0
+    uint32_t batch = get_arg_val<uint32_t>(12);
+
+    constexpr uint32_t cb_id_out0 = get_named_compile_time_arg_val("cb_out");
+
+    // single-tile
+    const uint32_t single_tile_size_bytes = get_tile_size(cb_id_out0);
+
+    constexpr auto out_args = TensorAccessorArgs<0>();
+    const auto s = TensorAccessor(out_args, out_tensor_addr);
+
+    Noc noc;
+    CircularBuffer cb_out(cb_id_out0);
+
+    bool one_time_profile = true;
+    for (uint32_t b = 0; b < batch; b++) {
+        uint32_t out_tensor_sbh_start_tile_id = out_tensor_start_tile_id;
+        for (uint32_t sbh = 0; sbh < out_num_subblocks_h; sbh++) {
+            uint32_t out_tensor_sbw_start_tile_id = out_tensor_sbh_start_tile_id;
+            for (uint32_t sbw = 0; sbw < out_num_subblocks_w; sbw++) {
+                uint32_t out_tensor_sb_row_start_tile_id = out_tensor_sbw_start_tile_id;
+
+                cb_out.wait_front(out_subblock_tile_count);
+                uint32_t out_read_offset = 0;
+
+                for (uint32_t h = 0; h < out_subblock_h; h++) {
+                    uint32_t out_tensor_tile_id = out_tensor_sb_row_start_tile_id;
+                    for (uint32_t w = 0; w < out_subblock_w; w++) {
+                        noc.async_write(
+                            use<CircularBuffer::AddrSelector::READ_PTR>(cb_out),
+                            s,
+                            single_tile_size_bytes,
+                            {.offset_bytes = out_read_offset},
+                            {.page_id = out_tensor_tile_id});
+                        out_read_offset += single_tile_size_bytes;
+
+                        out_tensor_tile_id += out_tensor_stride_w;
+                    }
+                    out_tensor_sb_row_start_tile_id += out_tensor_stride_h;
+                }
+
+                noc.async_write_barrier();
+                cb_out.pop_front(out_subblock_tile_count);
+                out_tensor_sbw_start_tile_id += out_tensor_next_subblock_stride_w;
+            }
+            out_tensor_sbh_start_tile_id += out_tensor_next_subblock_stride_h;
+        }
+        out_tensor_start_tile_id += MtNt;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    const uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    const uint32_t num_pages = get_arg_val<uint32_t>(1);
+    const uint32_t start_id = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t cb_id_out = get_named_compile_time_arg_val("cb_out");
+    constexpr auto dst_args = TensorAccessorArgs<0>();
+
+    // Get page size from CB interface (works for both TILE and ROW_MAJOR layouts)
+    const uint32_t page_bytes = get_local_cb_interface(cb_id_out).fifo_page_size;
+
+    Noc noc;
+    CircularBuffer cb_out(cb_id_out);
+
+#ifdef OUT_SHARDED
+    cb_out.wait_front(num_pages);
+#else
+
+    // single-page ublocks (works for both TILE and ROW_MAJOR layouts)
+    constexpr uint32_t onepage = 1;
+
+    const auto s = TensorAccessor(dst_args, dst_addr);
+
+#ifdef BACKWARDS
+    uint32_t end_id = start_id - num_pages;
+    for (uint32_t i = start_id; i != end_id; --i) {
+#else
+    uint32_t end_id = start_id + num_pages;
+    for (uint32_t i = start_id; i < end_id; ++i) {
+#endif
+        cb_out.wait_front(onepage);
+        noc.async_write(
+            use<CircularBuffer::AddrSelector::READ_PTR>(cb_out), s, page_bytes, {.offset_bytes = 0}, {.page_id = i});
+        noc.async_writes_flushed();
+        cb_out.pop_front(onepage);
+    }
+    noc.async_write_barrier();
+#endif
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/matmul_1d_type.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/matmul_1d_type.hpp
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+namespace ttnn::prim::qsr {
+
+enum class Matmul1DType { MCAST_IN0, GATHER_IN0, MCAST_IN1 };
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/matmul_device_operation.cpp
@@ -1,0 +1,2432 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/experimental/quasar/matmul/device/matmul_device_operation.hpp"
+
+#include <string_view>
+
+#include "ttnn/tensor/tensor_ops.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/config/matmul_program_config.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/utilities/matmul_utilities.hpp"
+#include "tt-metalium/hal_types.hpp"
+#include "tt-metalium/experimental/global_circular_buffer.hpp"
+#include "tt-metalium/work_split.hpp"
+#include "tt_stl/unreachable.hpp"
+
+namespace ttnn::prim::qsr {
+
+namespace {
+
+using tt::constants::TILE_HEIGHT;
+using tt::constants::TILE_WIDTH;
+
+void check_tensor_in_grid(const Tensor& tensor, const CoreCoord& grid_size) {
+    // Validate tensor is within grid if sharded and not in DRAM
+    if (tensor.memory_config().is_sharded() && tensor.memory_config().buffer_type() != BufferType::DRAM) {
+        const auto& shard_spec = tensor.memory_config().shard_spec().value();
+        const auto& shard_grid = shard_spec.grid;
+        TT_FATAL(
+            grid_size.x > 0 && grid_size.y > 0,
+            "compute grid size must be non-zero, got ({}, {})",
+            grid_size.x,
+            grid_size.y);
+        const CoreRange range(CoreCoord(0, 0), CoreCoord(grid_size.x - 1, grid_size.y - 1));
+        TT_FATAL(
+            range.contains(shard_grid),
+            "Tensor shard spec grid {} must lie within compute grid ({}, {})",
+            shard_grid,
+            grid_size.x,
+            grid_size.y);
+    }
+}
+
+void validate_matmul_matrix_dimensions(
+    const ttnn::Shape& a_shape,
+    const ttnn::Shape& b_shape,
+    const ttnn::Shape& a_shape_padded,
+    const ttnn::Shape& b_shape_padded,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile) {
+    TT_FATAL(b_shape.rank() >= 2, "Matmul expects input B rank >= 2, got {}", b_shape.rank());
+    TT_FATAL(a_shape[-1] > 0, "K dimension must be positive, got {}", a_shape[-1]);
+    TT_FATAL(
+        a_shape[-1] == b_shape[-2],
+        "The width of the first tensor must be equal to the height of the second tensor. Mismatch: width={} height={}",
+        a_shape[-1],
+        b_shape[-2]);
+    TT_FATAL(b_shape[-1] > 0, "Matmul requires N (columns of B) > 0, got {}", b_shape[-1]);
+    if (a_shape.rank() >= 2) {
+        TT_FATAL(a_shape[-2] > 0, "Matmul requires M (rows of A) > 0, got {}", a_shape[-2]);
+    }
+
+    // Shapes are post-transpose: K is at [-1] for A and [-2] for B.
+    const uint32_t Kt_a = operations::experimental::quasar::matmul::utilities::get_K_dim(a_shape_padded, in0_tile);
+    const uint32_t Kt_b = b_shape_padded[-2] / in1_tile.get_height();
+    TT_FATAL(
+        Kt_a > 0 && Kt_b > 0,
+        "K dimension in tiles must be positive (input A: {} K-tiles, input B: {} K-tiles)",
+        Kt_a,
+        Kt_b);
+    TT_FATAL(Kt_a == Kt_b, "K dimension in tiles must match between input A ({}) and input B ({})", Kt_a, Kt_b);
+}
+
+void validate_matmul_tile_constraints(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const operations::experimental::quasar::matmul::MatmulProgramConfig& chosen_program_config) {
+    // minimum tile_h = 4: shared exponents are packed into a uint32 (4 exponents minimum)
+    constexpr uint32_t bfloat4_min_tile_height = 4;
+    if (input_tensor_a.dtype() == DataType::BFLOAT4_B) {
+        TT_FATAL(
+            in0_tile.get_height() >= bfloat4_min_tile_height,
+            "BFLOAT4_B matmul requires in0 tile height >= {} (got {})",
+            bfloat4_min_tile_height,
+            in0_tile.get_height());
+    }
+    if (input_tensor_b.dtype() == DataType::BFLOAT4_B) {
+        TT_FATAL(
+            in1_tile.get_height() >= bfloat4_min_tile_height,
+            "BFLOAT4_B matmul requires in1 tile height >= {} (got {})",
+            bfloat4_min_tile_height,
+            in1_tile.get_height());
+        TT_FATAL(
+            in1_tile.get_width() >= bfloat4_min_tile_height,
+            "BFLOAT4_B matmul requires in1 tile width >= {} (got {})",
+            bfloat4_min_tile_height,
+            in1_tile.get_width());
+    }
+
+    const bool uses_tiny_outer_tile = (in0_tile.get_height() != TILE_HEIGHT || in1_tile.get_width() != TILE_WIDTH);
+    if (!uses_tiny_outer_tile) {
+        return;
+    }
+
+    if (std::holds_alternative<operations::experimental::quasar::matmul::MatmulMultiCoreProgramConfig>(
+            chosen_program_config)) {
+        TT_FATAL(
+            false,
+            "matmul with non-optimized program config does not support tiny tile "
+            "(in0 tile height={}, in1 tile width={}, expected TILE_HEIGHT={}, TILE_WIDTH={})",
+            in0_tile.get_height(),
+            in1_tile.get_width(),
+            TILE_HEIGHT,
+            TILE_WIDTH);
+    }
+}
+
+void validate_matmul_block_and_subblock_configuration(
+    const MatmulParams& attributes,
+    const operations::experimental::quasar::matmul::MatmulProgramConfig& chosen_program_config) {
+    std::visit(
+        [&attributes](const auto& program_config) {
+            using ProgramConfigType = std::decay_t<decltype(program_config)>;
+            if constexpr (
+                std::is_same_v<
+                    ProgramConfigType,
+                    operations::experimental::quasar::matmul::MatmulMultiCoreProgramConfig> ||
+                std::is_same_v<
+                    ProgramConfigType,
+                    operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig> ||
+                std::is_same_v<
+                    ProgramConfigType,
+                    operations::experimental::quasar::matmul::
+                        MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>) {
+                return;
+            }
+            if constexpr (
+                std::is_same_v<
+                    ProgramConfigType,
+                    operations::experimental::quasar::matmul::MatmulMultiCoreReuseProgramConfig> ||
+                std::is_same_v<
+                    ProgramConfigType,
+                    operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCastProgramConfig> ||
+                std::is_same_v<
+                    ProgramConfigType,
+                    operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
+                TT_FATAL(program_config.out_subblock_h != 0, "out_subblock_h is 0, which is not valid");
+                TT_FATAL(program_config.out_subblock_w != 0, "out_subblock_w is 0, which is not valid");
+                if constexpr (
+                    std::is_same_v<
+                        ProgramConfigType,
+                        operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCastProgramConfig> ||
+                    std::is_same_v<
+                        ProgramConfigType,
+                        operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
+                    TT_FATAL(program_config.out_block_h != 0, "out_block_h is 0, which is not valid");
+                    TT_FATAL(program_config.out_block_w != 0, "out_block_w is 0, which is not valid");
+                    TT_FATAL(
+                        program_config.out_block_h % program_config.out_subblock_h == 0,
+                        "out_block_h ({}) must be divisible by out_subblock_h ({})",
+                        program_config.out_block_h,
+                        program_config.out_subblock_h);
+                    TT_FATAL(
+                        program_config.out_block_w % program_config.out_subblock_w == 0,
+                        "out_block_w ({}) must be divisible by out_subblock_w ({})",
+                        program_config.out_block_w,
+                        program_config.out_subblock_w);
+                    TT_FATAL(
+                        program_config.per_core_M % program_config.out_block_h == 0,
+                        "per_core_M ({}) must be divisible by out_block_h ({})",
+                        program_config.per_core_M,
+                        program_config.out_block_h);
+                    TT_FATAL(
+                        program_config.per_core_N % program_config.out_block_w == 0,
+                        "per_core_N ({}) must be divisible by out_block_w ({})",
+                        program_config.per_core_N,
+                        program_config.out_block_w);
+                }
+                if constexpr (std::is_same_v<
+                                  ProgramConfigType,
+                                  operations::experimental::quasar::matmul::MatmulMultiCoreReuseProgramConfig>) {
+                    TT_FATAL(
+                        program_config.per_core_M % program_config.out_subblock_h == 0,
+                        "per_core_M ({}) must be divisible by out_subblock_h ({})",
+                        program_config.per_core_M,
+                        program_config.out_subblock_h);
+                    TT_FATAL(
+                        program_config.per_core_N % program_config.out_subblock_w == 0,
+                        "per_core_N ({}) must be divisible by out_subblock_w ({})",
+                        program_config.per_core_N,
+                        program_config.out_subblock_w);
+                }
+                TT_FATAL(
+                    attributes.compute_kernel_config.has_value(),
+                    "compute_kernel_config must be set for matmul subblock validation");
+                TT_FATAL(attributes.output_tile.has_value(), "output_tile must be set for matmul subblock validation");
+                const uint32_t available_reg_count = ttnn::get_dest_reg_count(
+                    attributes.compute_kernel_config.value(), attributes.output_tile.value().get_tile_shape());
+                TT_FATAL(
+                    program_config.out_subblock_h * program_config.out_subblock_w <= available_reg_count,
+                    "out_subblock_w {} times out_subblock_h {} needs to be at "
+                    "most {} to fit in hardware",
+                    program_config.out_subblock_w,
+                    program_config.out_subblock_h,
+                    available_reg_count);
+            }
+        },
+        chosen_program_config);
+}
+
+void validate_matmul_nonzero_block_dims(std::size_t in0_block_w, std::size_t per_core_M, std::size_t per_core_N) {
+    TT_FATAL(in0_block_w != 0, "in0_block_w is 0, which is not valid");
+    TT_FATAL(per_core_M != 0, "per_core_M is 0, which is not valid");
+    TT_FATAL(per_core_N != 0, "per_core_N is 0, which is not valid");
+}
+
+void check_output_shard_grid_within_extent(
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    const tt::tt_metal::CoreCoord& extent,
+    const char* context_label) {
+    if (!output_mem_config.is_sharded() || output_mem_config.buffer_type() == tt::tt_metal::BufferType::DRAM) {
+        return;
+    }
+    if (!output_mem_config.shard_spec().has_value()) {
+        return;
+    }
+    const auto& shard_grid = output_mem_config.shard_spec().value().grid;
+    TT_FATAL(extent.x > 0 && extent.y > 0, "device grid extent must be non-zero, got ({}, {})", extent.x, extent.y);
+    const tt::tt_metal::CoreRange bbox(
+        tt::tt_metal::CoreCoord(0, 0), tt::tt_metal::CoreCoord(extent.x - 1, extent.y - 1));
+    TT_FATAL(
+        bbox.contains(shard_grid),
+        "{}: output shard grid {} must lie within extent {}",
+        context_label,
+        shard_grid,
+        extent);
+}
+
+void validate_matmul_compute_grid_and_per_core_dims(
+    const Tensor& input_tensor_a,
+    const operations::experimental::quasar::matmul::MatmulProgramConfig& chosen_program_config) {
+    const CoreCoord device_grid = input_tensor_a.device()->compute_with_storage_grid_size();
+
+    std::visit(
+        [device_grid](const auto& program_config) {
+            using ProgramConfigType = std::decay_t<decltype(program_config)>;
+            if constexpr (std::is_same_v<
+                              ProgramConfigType,
+                              operations::experimental::quasar::matmul::MatmulMultiCoreProgramConfig>) {
+                return;
+            }
+            if constexpr (
+                std::is_same_v<
+                    ProgramConfigType,
+                    operations::experimental::quasar::matmul::MatmulMultiCoreReuseProgramConfig> ||
+                std::is_same_v<
+                    ProgramConfigType,
+                    operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCastProgramConfig> ||
+                std::is_same_v<
+                    ProgramConfigType,
+                    operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig> ||
+                std::is_same_v<
+                    ProgramConfigType,
+                    operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig> ||
+                std::is_same_v<
+                    ProgramConfigType,
+                    operations::experimental::quasar::matmul::
+                        MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>) {
+                if constexpr (
+                    std::is_same_v<
+                        ProgramConfigType,
+                        operations::experimental::quasar::matmul::MatmulMultiCoreReuseProgramConfig> ||
+                    std::is_same_v<
+                        ProgramConfigType,
+                        operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCastProgramConfig> ||
+                    std::is_same_v<
+                        ProgramConfigType,
+                        operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
+                    bool skip_grid_check = false;
+                    if constexpr (std::is_same_v<
+                                      ProgramConfigType,
+                                      operations::experimental::quasar::matmul::
+                                          MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
+                        skip_grid_check = program_config.gather_in0;
+                    }
+                    if (!skip_grid_check) {
+                        const auto& grid = program_config.compute_with_storage_grid_size;
+                        TT_FATAL(
+                            grid.x > 0 && grid.y > 0,
+                            "compute_with_storage_grid_size must be non-zero, got ({}, {})",
+                            grid.x,
+                            grid.y);
+                        TT_FATAL(
+                            grid.x <= device_grid.x && grid.y <= device_grid.y,
+                            "compute_with_storage_grid_size ({}, {}) must fit within device grid ({}, {})",
+                            grid.x,
+                            grid.y,
+                            device_grid.x,
+                            device_grid.y);
+                    }
+                }
+                validate_matmul_nonzero_block_dims(
+                    program_config.in0_block_w, program_config.per_core_M, program_config.per_core_N);
+            }
+        },
+        chosen_program_config);
+}
+
+void validate_matmul_sharded_operand_grids_within_program_compute_grid(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const operations::experimental::quasar::matmul::MatmulProgramConfig& chosen_program_config) {
+    std::visit(
+        [&](const auto& program_config) {
+            using ProgramConfigType = std::decay_t<decltype(program_config)>;
+            if constexpr (std::is_same_v<
+                              ProgramConfigType,
+                              operations::experimental::quasar::matmul::MatmulMultiCoreReuseProgramConfig>) {
+                // When an input is sharded, the factory uses shard_spec.grid directly as all_cores
+                // and ignores compute_with_storage_grid_size entirely. Validating the shard grid
+                // against the origin-anchored compute_with_storage_grid_size rectangle incorrectly
+                // rejects grids that don't start at (0,0) (e.g. column 1 in a multi-chain fused op).
+                // The only physical constraint is that the shard grid fits within the device grid.
+                // For non-sharded inputs the config grid drives split_work_to_cores, so the
+                // origin-anchored check is still correct there.
+                const auto& config_grid = program_config.compute_with_storage_grid_size;
+                const auto device_grid = input_tensor_a.device()->compute_with_storage_grid_size();
+                auto effective_grid_a = input_tensor_a.memory_config().is_sharded() ? device_grid : config_grid;
+                auto effective_grid_b = input_tensor_b.memory_config().is_sharded() ? device_grid : config_grid;
+                check_tensor_in_grid(input_tensor_a, effective_grid_a);
+                check_tensor_in_grid(input_tensor_b, effective_grid_b);
+            }
+        },
+        chosen_program_config);
+}
+
+void validate_matmul_reuse_sharded_output_block_divisibility(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const ttnn::Shape& a_shape_padded,
+    const ttnn::Shape& b_shape_padded,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const operations::experimental::quasar::matmul::MatmulProgramConfig& chosen_program_config) {
+    std::visit(
+        [&](const auto& program_config) {
+            using ProgramConfigType = std::decay_t<decltype(program_config)>;
+            if constexpr (std::is_same_v<
+                              ProgramConfigType,
+                              operations::experimental::quasar::matmul::MatmulMultiCoreReuseProgramConfig>) {
+                // Mirror the shard_spec priority in MatmulMultiCoreReuseOptimizedProgramFactory::create_descriptor:
+                // when in0 is L1-sharded its shard grid becomes the kernel grid; in1's grid is only consulted when
+                // in0 is not sharded. num_output_blocks must divide evenly across that grid or the factory fatals.
+                const Tensor* sharded = nullptr;
+                if (input_tensor_a.is_sharded() && input_tensor_a.memory_config().buffer_type() != BufferType::DRAM) {
+                    sharded = &input_tensor_a;
+                } else if (
+                    input_tensor_b.is_sharded() && input_tensor_b.memory_config().buffer_type() != BufferType::DRAM) {
+                    sharded = &input_tensor_b;
+                }
+                if (sharded == nullptr) {
+                    return;
+                }
+                const uint32_t B = get_batch_size(a_shape_padded);
+                const uint32_t Mt =
+                    operations::experimental::quasar::matmul::utilities::get_M_dim(a_shape_padded, in0_tile, false);
+                const uint32_t Nt =
+                    operations::experimental::quasar::matmul::utilities::get_N_dim(b_shape_padded, in1_tile);
+                const uint32_t num_output_blocks =
+                    (B * Mt / program_config.per_core_M) * (Nt / program_config.per_core_N);
+                const uint32_t num_cores = sharded->shard_spec().value().grid.num_cores();
+                TT_FATAL(
+                    num_output_blocks % num_cores == 0,
+                    "MatmulMultiCoreReuseProgramConfig: num_output_blocks ({}) must be evenly divisible by the "
+                    "number of cores in the input shard grid ({})",
+                    num_output_blocks,
+                    num_cores);
+            }
+        },
+        chosen_program_config);
+}
+
+void validate_matmul_work_distribution_and_gather_ring_topology(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const ttnn::Shape& a_shape_padded,
+    const ttnn::Shape& b_shape_padded,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    bool transpose_a,
+    bool transpose_b,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    const operations::experimental::quasar::matmul::MatmulProgramConfig& chosen_program_config) {
+    std::visit(
+        [&](const auto& program_config) {
+            using ProgramConfigType = std::decay_t<decltype(program_config)>;
+            if constexpr (std::is_same_v<
+                              ProgramConfigType,
+                              operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
+                const tt::tt_metal::CoreCoord device_extent = input_tensor_a.device()->compute_with_storage_grid_size();
+                const auto& grid = program_config.compute_with_storage_grid_size;
+                const auto Mt = operations::experimental::quasar::matmul::utilities::get_M_dim(
+                    a_shape_padded, in0_tile, program_config.fuse_batch);
+                const auto Nt =
+                    operations::experimental::quasar::matmul::utilities::get_N_dim(b_shape_padded, in1_tile);
+                const uint32_t per_core_M = program_config.per_core_M;
+                const uint32_t per_core_N = program_config.per_core_N;
+                const uint32_t num_cores = grid.x * grid.y;
+
+                if (program_config.gather_in0) {
+                    TT_FATAL(!transpose_a, "transpose_a is not supported with gather_in0");
+                    TT_FATAL(!transpose_b, "transpose_b is not supported with gather_in0");
+                    TT_FATAL(input_tensor_a.is_sharded(), "gather_in0 requires input A to be sharded");
+                    auto* device = input_tensor_a.device();
+                    const auto& sub_device_ids = device->get_sub_device_ids();
+                    TT_FATAL(
+                        !sub_device_ids.empty(), "gather_in0 matmul requires at least one sub-device id on the device");
+                    if (!program_config.hop_cores.empty()) {
+                        const tt::tt_metal::CoreRangeSet& worker_cores = input_tensor_a.shard_spec().value().grid;
+                        TT_FATAL(
+                            !program_config.hop_cores.intersects(worker_cores),
+                            "hop_cores must not overlap with input A shard grid. hop_cores={}, workers={}",
+                            program_config.hop_cores,
+                            worker_cores);
+                    }
+                    check_output_shard_grid_within_extent(
+                        output_mem_config,
+                        device_extent,
+                        "MatmulMultiCoreReuseMultiCast1DProgramConfig (gather_in0 output vs device grid)");
+                } else {
+                    TT_FATAL(
+                        program_config.hop_cores.empty(),
+                        "Hop cores are not supported for any mode besides gather_in0.");
+                    TT_FATAL(
+                        Mt > 0 && Nt > 0, "Mt and Nt must be greater than zero in tiles (got Mt={}, Nt={})", Mt, Nt);
+                    const uint32_t num_blocks_y = ((Mt - 1) / per_core_M) + 1;
+                    const uint32_t num_blocks_x = ((Nt - 1) / per_core_N) + 1;
+                    const uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
+                    TT_FATAL(
+                        num_blocks_total <= num_cores,
+                        "Number of blocks exceeds number of cores: {} blocks > {} cores",
+                        num_blocks_total,
+                        num_cores);
+                    if (program_config.mcast_in0) {
+                        TT_FATAL(
+                            num_blocks_y == 1,
+                            "mcast_in0 requires M ({}) to fit within a single per_core_M block ({}), got "
+                            "num_blocks_y={}",
+                            Mt,
+                            per_core_M,
+                            num_blocks_y);
+                    }
+                    check_output_shard_grid_within_extent(
+                        output_mem_config, grid, "MatmulMultiCoreReuseMultiCast1DProgramConfig");
+                }
+            } else if constexpr (std::is_same_v<
+                                     ProgramConfigType,
+                                     operations::experimental::quasar::matmul::
+                                         MatmulMultiCoreReuseMultiCastProgramConfig>) {
+                const auto& grid = program_config.compute_with_storage_grid_size;
+                const auto Mt = operations::experimental::quasar::matmul::utilities::get_M_dim(
+                    a_shape_padded, in0_tile, program_config.fuse_batch);
+                const auto Nt =
+                    operations::experimental::quasar::matmul::utilities::get_N_dim(b_shape_padded, in1_tile);
+                TT_FATAL(Mt > 0 && Nt > 0, "Mt and Nt must be greater than zero in tiles (got Mt={}, Nt={})", Mt, Nt);
+                uint32_t num_blocks_y = ((Mt - 1) / program_config.per_core_M) + 1;
+                uint32_t num_blocks_x = ((Nt - 1) / program_config.per_core_N) + 1;
+                if (program_config.transpose_mcast) {
+                    std::swap(num_blocks_x, num_blocks_y);
+                }
+                TT_FATAL(
+                    num_blocks_x <= grid.x,
+                    "Num output blocks along x ({}) must be smaller than or equal to the number of columns in compute "
+                    "grid ({})!",
+                    num_blocks_x,
+                    grid.x);
+                TT_FATAL(
+                    num_blocks_y <= grid.y,
+                    "Num output blocks along y ({}) must be smaller than or equal to the number of rows in compute "
+                    "grid ({})!",
+                    num_blocks_y,
+                    grid.y);
+                check_output_shard_grid_within_extent(
+                    output_mem_config, grid, "MatmulMultiCoreReuseMultiCastProgramConfig");
+            } else if constexpr (std::is_same_v<
+                                     ProgramConfigType,
+                                     operations::experimental::quasar::matmul::MatmulMultiCoreReuseProgramConfig>) {
+                // The factory selects all_cores from the first available shard spec: in0, then in1,
+                // then output. Any of those can produce an offset grid (e.g. column 1 in a fused
+                // chain). Use the device grid as the extent whenever any operand is sharded so we
+                // don't incorrectly reject those grids against the origin-anchored config rect.
+                const auto device_extent = input_tensor_a.device()->compute_with_storage_grid_size();
+                const bool any_sharded = input_tensor_a.memory_config().is_sharded() ||
+                                         input_tensor_b.memory_config().is_sharded() || output_mem_config.is_sharded();
+                const auto effective_extent =
+                    any_sharded ? device_extent : program_config.compute_with_storage_grid_size;
+                check_output_shard_grid_within_extent(
+                    output_mem_config, effective_extent, "MatmulMultiCoreReuseProgramConfig");
+            } else {
+                (void)transpose_a;
+                (void)transpose_b;
+            }
+        },
+        chosen_program_config);
+}
+
+bool get_broadcast_batch(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const bool transpose_a,
+    const bool transpose_b,
+    const std::optional<const operations::experimental::quasar::matmul::MatmulProgramConfig>& matmul_program_config) {
+    const auto& b_shape_padded = operations::experimental::quasar::matmul::utilities::get_matmul_tensor_padded_shape(
+        input_tensor_b, transpose_b);
+    uint32_t batch_size_b = get_batch_size(b_shape_padded);
+    bool broadcast_batch = batch_size_b == 1;
+    if (!matmul_program_config.has_value()) {
+        return broadcast_batch;
+    }
+
+    bool is_multi_core_reuse = std::visit(
+        [](const auto& program_config) -> bool {
+            using ProgramConfigType = std::decay_t<decltype(program_config)>;
+            return static_cast<bool>(std::is_same_v<
+                                     ProgramConfigType,
+                                     operations::experimental::quasar::matmul::MatmulMultiCoreReuseProgramConfig>);
+        },
+        matmul_program_config.value());
+    if (is_multi_core_reuse) {
+        const auto& a_shape_padded =
+            operations::experimental::quasar::matmul::utilities::get_matmul_tensor_padded_shape(
+                input_tensor_a, transpose_a);
+        uint32_t batch_size_a = get_batch_size(a_shape_padded);
+        broadcast_batch &= batch_size_a > 1;
+    }
+    return broadcast_batch;
+}
+
+// Warns if a caller of MatmulDeviceOperation's static API hasn't populated allowed_worker_cores
+// on a program_config variant that supports the field. ttnn::prim::qsr::matmul() normalizes its
+// attributes before launch, but direct callers (e.g. CCL fused ops in
+// ttnn/operations/experimental/ccl) need to invoke
+// ttnn::operations::experimental::quasar::matmul::normalize_program_config() themselves. Downstream code in this file
+// auto-populates via normalize_program_config on the chosen_program_config local, so this is
+// currently advisory.
+// TODO(#44529): convert this back to TT_FATAL once all callers have been updated.
+void warn_if_allowed_worker_cores_missing(
+    const std::optional<operations::experimental::quasar::matmul::MatmulProgramConfig>& program_config,
+    std::string_view entry_point) {
+    if (!program_config.has_value()) {
+        return;
+    }
+    std::visit(
+        [&](const auto& pc) {
+            if constexpr (requires { pc.allowed_worker_cores; }) {
+                if (!pc.allowed_worker_cores.has_value()) {
+                    log_warning(
+                        tt::LogOp,
+                        "{}: program_config.allowed_worker_cores not populated on a MatmulProgramConfig variant "
+                        "that supports the field. Auto-populating from compute_with_storage_grid_size. Callers "
+                        "that bypass ttnn::prim::qsr::matmul() should invoke "
+                        "ttnn::operations::experimental::quasar::matmul::normalize_program_config() on the program "
+                        "config first. "
+                        "This will become a hard error in a future release.",
+                        entry_point);
+                }
+            }
+        },
+        program_config.value());
+}
+
+// Cross-validate a DRAM-sender global_cb's geometry against the matmul + weight shape.
+// These catch silent-hang configs where the matmul reads more in1 pages than the prefetcher
+// pushes (e.g. activation K padded past weight K). Gated by the caller on the DRAM-sender path
+// because the worker-sender variant predates this work and uses different sizing/ordering
+// conventions (no bank IDs; gcb_size = N * max_tile_size).
+void validate_dram_sender_global_cb_gather_in0_geometry(
+    const tt::tt_metal::experimental::GlobalCircularBuffer& gcb,
+    const Tensor& input_tensor_a,
+    const ttnn::Shape& b_shape_padded,
+    const tt::tt_metal::Tile& in1_tile,
+    const operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& program_config) {
+    const uint32_t ring_size = input_tensor_a.shard_spec().value().grid.num_cores();
+    const uint32_t weight_K_tiles = b_shape_padded[-2] / in1_tile.get_height();
+    const uint32_t weight_N_tiles = b_shape_padded[-1] / in1_tile.get_width();
+    const uint32_t num_senders = gcb.sender_cores().num_cores();
+    const uint32_t num_recv = gcb.receiver_cores().num_cores();
+    const uint32_t recv_per_bank = static_cast<uint32_t>(program_config.num_global_cb_receivers);
+
+    TT_FATAL(
+        num_senders > 0 && num_recv == num_senders * recv_per_bank,
+        "global_cb receiver count ({}) must equal num_senders ({}) * "
+        "num_global_cb_receivers ({})",
+        num_recv,
+        num_senders,
+        recv_per_bank);
+    TT_FATAL(
+        num_recv == ring_size,
+        "global_cb receiver count ({}) must equal in0 (activation) ring_size "
+        "({} = num_cores of in0.shard_spec.grid). Receivers and matmul workers "
+        "must be the same set of cores.",
+        num_recv,
+        ring_size);
+
+    // Semantic check: bank b must push to exactly the receivers at ring
+    // positions [b*recv_per_bank, (b+1)*recv_per_bank). If satisfied, the
+    // bank-to-receivers union also equals the activation grid as a set, so
+    // we don't need a separate set-equality assertion (CoreRangeSet::operator==
+    // compares ranges literally, which is brittle when one side is merged
+    // into rectangles and the other is a flat list of single-core ranges).
+    const auto& act_grid = input_tensor_a.shard_spec().value().grid;
+    const auto ring_walk = tt::tt_metal::corerange_to_cores(act_grid, std::nullopt, /*row_wise=*/true);
+    const auto& mapping = gcb.sender_receiver_core_mapping();
+    TT_FATAL(
+        mapping.size() * recv_per_bank == ring_walk.size(),
+        "global_cb sender_receiver mapping ({} senders * {} receivers each) "
+        "doesn't cover the matmul ring ({} cores)",
+        mapping.size(),
+        recv_per_bank,
+        ring_walk.size());
+    for (size_t bank_idx = 0; bank_idx < mapping.size(); ++bank_idx) {
+        const auto bank_recvs =
+            tt::tt_metal::corerange_to_cores(mapping[bank_idx].second, std::nullopt, /*row_wise=*/true);
+        TT_FATAL(
+            bank_recvs.size() == recv_per_bank,
+            "Sender at bank index {} owns {} receivers; expected "
+            "num_global_cb_receivers={}",
+            bank_idx,
+            bank_recvs.size(),
+            recv_per_bank);
+        for (size_t k = 0; k < recv_per_bank; ++k) {
+            const size_t ring_pos = bank_idx * recv_per_bank + k;
+            TT_FATAL(
+                bank_recvs[k] == ring_walk[ring_pos],
+                "global_cb bank {}'s receiver at index {} is core {} but the "
+                "matmul ring walk expects core {} at ring position {}. The "
+                "bank-to-receivers mapping must place bank b's receivers at "
+                "ring positions [b*num_global_cb_receivers, (b+1)*num_global_cb_receivers).",
+                bank_idx,
+                k,
+                bank_recvs[k],
+                ring_walk[ring_pos],
+                ring_pos);
+        }
+    }
+    TT_FATAL(
+        weight_K_tiles % ring_size == 0,
+        "Weight K must be divisible by ring_size in tiles for gather_in0 + global_cb. "
+        "Got weight_K_tiles={}, ring_size={} (remainder={}). The activation grid would "
+        "pad K past the weight K, and the matmul would wait forever for in1 pages the "
+        "prefetcher never pushes.",
+        weight_K_tiles,
+        ring_size,
+        weight_K_tiles % ring_size);
+    TT_FATAL(
+        weight_N_tiles % num_senders == 0,
+        "Weight N ({} tiles) must be divisible by num_senders ({}) so it shards "
+        "evenly across the DRAM banks the global_cb senders cover",
+        weight_N_tiles,
+        num_senders);
+    const uint32_t per_bank_N_tiles = weight_N_tiles / num_senders;
+    TT_FATAL(
+        per_bank_N_tiles % recv_per_bank == 0,
+        "Weight per-bank N ({} tiles) must be divisible by num_global_cb_receivers ({})",
+        per_bank_N_tiles,
+        recv_per_bank);
+    const uint32_t per_recv_N_tiles = per_bank_N_tiles / recv_per_bank;
+    TT_FATAL(
+        per_recv_N_tiles == program_config.per_core_N,
+        "Matmul per_core_N ({}) must equal weight per-receiver N ({} = per_bank_N_tiles {} "
+        "/ num_global_cb_receivers {})",
+        program_config.per_core_N,
+        per_recv_N_tiles,
+        per_bank_N_tiles,
+        recv_per_bank);
+}
+
+// Receiver-contiguous counterpart of the cross-check above. The recv-contig weight is an
+// NdShardSpec tensor (num_shards == ring_size) with a strided bank->ring mapping, so the
+// K-row-major "bank b owns ring positions [b*rpb, (b+1)*rpb)" convention does not apply and
+// the bank-walk assertion is intentionally omitted. The two silent-hang guards still hold:
+// the weight K-tiles must divide ring_size, and per_core_N must equal the per-receiver N
+// (N_tiles / ring_size) so the matmul's in1 page size matches what the prefetcher pushes.
+void validate_dram_sender_global_cb_gather_in0_geometry_recv_contig(
+    const tt::tt_metal::experimental::GlobalCircularBuffer& gcb,
+    const Tensor& input_tensor_a,
+    const ttnn::Shape& b_shape_padded,
+    const tt::tt_metal::Tile& in1_tile,
+    const operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& program_config) {
+    const uint32_t ring_size = input_tensor_a.shard_spec().value().grid.num_cores();
+    const uint32_t num_recv = gcb.receiver_cores().num_cores();
+    TT_FATAL(
+        num_recv == ring_size,
+        "global_cb receiver count ({}) must equal in0 (activation) ring_size ({}). Receivers and matmul "
+        "workers must be the same set of cores.",
+        num_recv,
+        ring_size);
+
+    const uint32_t weight_K_tiles = b_shape_padded[-2] / in1_tile.get_height();
+    const uint32_t weight_N_tiles = b_shape_padded[-1] / in1_tile.get_width();
+    TT_FATAL(
+        weight_K_tiles % ring_size == 0,
+        "Weight K ({} tiles) must be divisible by ring_size ({}) for receiver-contiguous gather_in0 + "
+        "global_cb (remainder {}). The activation grid pads K past the weight K and the matmul would "
+        "wait forever for in1 pages the prefetcher never pushes.",
+        weight_K_tiles,
+        ring_size,
+        weight_K_tiles % ring_size);
+    TT_FATAL(
+        weight_N_tiles % ring_size == 0,
+        "Weight N ({} tiles) must be divisible by ring_size ({}) for receiver-contiguous gather_in0 + global_cb",
+        weight_N_tiles,
+        ring_size);
+    const uint32_t per_recv_N_tiles = weight_N_tiles / ring_size;
+    TT_FATAL(
+        per_recv_N_tiles == program_config.per_core_N,
+        "Matmul per_core_N ({}) must equal weight per-receiver N ({} = N_tiles {} / ring_size {}); otherwise "
+        "the matmul's in1 page size disagrees with what the recv-contig prefetcher pushes.",
+        program_config.per_core_N,
+        per_recv_N_tiles,
+        weight_N_tiles,
+        ring_size);
+}
+
+}  // namespace
+
+MatmulDeviceOperation::program_factory_t MatmulDeviceOperation::select_program_factory(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& /*tensor_args*/) {
+    const auto& config = operation_attributes.program_config.value();
+
+    return std::visit(
+        [](const auto& c) -> program_factory_t {
+            using T = std::decay_t<decltype(c)>;
+            if constexpr (std::is_same_v<T, operations::experimental::quasar::matmul::MatmulMultiCoreProgramConfig>) {
+                return MatmulMultiCoreProgramFactory{};
+            } else if constexpr (std::is_same_v<
+                                     T,
+                                     operations::experimental::quasar::matmul::MatmulMultiCoreReuseProgramConfig>) {
+                return MatmulMultiCoreReuseOptimizedProgramFactory{};
+            } else if constexpr (std::is_same_v<
+                                     T,
+                                     operations::experimental::quasar::matmul::
+                                         MatmulMultiCoreReuseMultiCastProgramConfig>) {
+                return MatmulMultiCoreReuseMcast2DProgramFactory{};
+            } else if constexpr (std::is_same_v<
+                                     T,
+                                     operations::experimental::quasar::matmul::
+                                         MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
+                // gather_in0 uses the legacy MeshWorkload path (create_descriptor not yet supported)
+                if (c.gather_in0) {
+                    return MatmulMeshWorkloadMultiCoreReuseMcast1DProgramFactory{};
+                }
+                return MatmulMultiCoreReuseMcast1DProgramFactory{};
+            } else if constexpr (std::is_same_v<
+                                     T,
+                                     operations::experimental::quasar::matmul::
+                                         MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>) {
+                return MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory{};
+            } else if constexpr (std::is_same_v<
+                                     T,
+                                     operations::experimental::quasar::matmul::
+                                         MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>) {
+                return MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory{};
+            } else {
+                TT_THROW("Unknown program config type");
+            }
+        },
+        config);
+}
+
+void MatmulDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& attributes, const tensor_args_t& args) {
+    using namespace tt::constants;
+    warn_if_allowed_worker_cores_missing(
+        attributes.program_config, "MatmulDeviceOperation::validate_on_program_cache_miss");
+
+    const auto& input_tensors = args.input_tensors;
+    const auto& input_tensor_a = args.input_tensors.at(0);
+    const auto& input_tensor_b = args.input_tensors.at(1);
+    const auto& optional_output_tensors = args.optional_output_tensors;
+    const auto& optional_input_tensors = args.optional_input_tensors;
+
+    const auto& a_shape = operations::experimental::quasar::matmul::utilities::get_matmul_tensor_logical_shape(
+        input_tensor_a, attributes.transpose_a);
+    const auto& b_shape = operations::experimental::quasar::matmul::utilities::get_matmul_tensor_logical_shape(
+        input_tensor_b, attributes.transpose_b);
+    const auto& a_shape_padded = operations::experimental::quasar::matmul::utilities::get_matmul_tensor_padded_shape(
+        input_tensor_a, attributes.transpose_a);
+    const auto& b_shape_padded = operations::experimental::quasar::matmul::utilities::get_matmul_tensor_padded_shape(
+        input_tensor_b, attributes.transpose_b);
+    auto in0_tile =
+        operations::experimental::quasar::matmul::utilities::get_matmul_tile(input_tensor_a, attributes.transpose_a);
+    auto in1_tile =
+        operations::experimental::quasar::matmul::utilities::get_matmul_tile(input_tensor_b, attributes.transpose_b);
+    TT_FATAL(
+        input_tensor_a.storage_type() == StorageType::DEVICE and input_tensor_b.storage_type() == StorageType::DEVICE,
+        "Operands to matmul need to be on device!");
+    TT_FATAL(
+        (in0_tile.get_width() == TILE_WIDTH && in1_tile.get_height() == TILE_WIDTH),
+        "Input tile dims must have inner dim equal to 32 due to llk constraints");
+
+    TT_FATAL(
+        (input_tensor_a.layout() == Layout::TILE && input_tensor_b.layout() == Layout::TILE),
+        "Inputs to matmul must be tilized");
+    validate_matmul_matrix_dimensions(a_shape, b_shape, a_shape_padded, b_shape_padded, in0_tile, in1_tile);
+
+    const bool is_optional_output_tensor =
+        !optional_output_tensors.empty() && optional_output_tensors.at(0).has_value();
+
+    TT_FATAL(
+        optional_input_tensors.size() == 1,
+        "Must have exactly 1 optional input tensor, got: {}",
+        optional_input_tensors.size());
+
+    const auto output_tensor_spec = compute_output_specs(attributes, args).at(0);
+    if (is_optional_output_tensor) {
+        const auto& optional_output_tensor_c = optional_output_tensors.at(0);
+        const auto& optional_output_tensor_shape = optional_output_tensor_c->logical_shape();
+        TT_FATAL(
+            optional_output_tensor_shape == output_tensor_spec.logical_shape(),
+            "Shape of Optional Output Tensor {} doesn't match Output Tensor {}",
+            optional_output_tensor_shape,
+            output_tensor_spec.logical_shape());
+        TT_FATAL(
+            optional_output_tensor_c->dtype() == attributes.output_dtype.value(),
+            "Type mismatch between optional output tensor {} & output tensor {}",
+            optional_output_tensor_c->dtype(),
+            attributes.output_dtype.value());
+        TT_FATAL(
+            optional_output_tensor_c->memory_config() == attributes.output_mem_config,
+            "Memory config mismatch between optional output tensor {} & output "
+            "tensor {}",
+            optional_output_tensor_c->memory_config(),
+            attributes.output_mem_config);
+    } else {
+        // Allow BLOCK_SHARDED on 1D grids to be converted to HEIGHT_SHARDED or WIDTH_SHARDED
+        bool memory_layout_compatible =
+            output_tensor_spec.memory_config().memory_layout() == attributes.output_mem_config.memory_layout();
+        if (!memory_layout_compatible &&
+            attributes.output_mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED &&
+            attributes.output_mem_config.shard_spec().has_value()) {
+            auto grid_bbox = attributes.output_mem_config.shard_spec()->grid.bounding_box();
+            bool is_1d_column = (grid_bbox.end_coord.x == grid_bbox.start_coord.x);
+            bool is_1d_row = (grid_bbox.end_coord.y == grid_bbox.start_coord.y);
+            if ((is_1d_column &&
+                 output_tensor_spec.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) ||
+                (is_1d_row &&
+                 output_tensor_spec.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED)) {
+                memory_layout_compatible = true;
+            }
+        }
+        TT_FATAL(
+            memory_layout_compatible,
+            "Mismatch between computed {} and provided {} mem config memory layout",
+            output_tensor_spec.memory_config().memory_layout(),
+            attributes.output_mem_config.memory_layout());
+        TT_FATAL(
+            output_tensor_spec.memory_config().buffer_type() == attributes.output_mem_config.buffer_type(),
+            "Mismatch between computed {} and provided {} mem config buffer type",
+            output_tensor_spec.memory_config().buffer_type(),
+            attributes.output_mem_config.buffer_type());
+        // Don't warn when BLOCK_SHARDED on 1D grid is intentionally converted to HEIGHT/WIDTH_SHARDED
+        bool is_intentional_1d_conversion = false;
+        if (attributes.output_mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED &&
+            attributes.output_mem_config.shard_spec().has_value()) {
+            auto grid_bbox = attributes.output_mem_config.shard_spec()->grid.bounding_box();
+            bool is_1d_column = (grid_bbox.end_coord.x == grid_bbox.start_coord.x);
+            bool is_1d_row = (grid_bbox.end_coord.y == grid_bbox.start_coord.y);
+            bool is_single_core = is_1d_column && is_1d_row;
+            // Only 1D grids (not single-core) trigger intentional conversion
+            if (!is_single_core && (is_1d_column || is_1d_row)) {
+                is_intentional_1d_conversion = true;
+            }
+        }
+        if (attributes.output_mem_config.shard_spec().has_value() &&
+            output_tensor_spec.memory_config() != attributes.output_mem_config && !is_intentional_1d_conversion) {
+            log_warning(
+                tt::LogOp,
+                "Mismatch between computed {} and provided {} mem config. Using computed config.",
+                output_tensor_spec.memory_config(),
+                attributes.output_mem_config);
+        }
+    }
+
+    TT_FATAL(attributes.bcast_batch.has_value(), "Error: bcast_batch field should have been automatically populated");
+    TT_FATAL(attributes.output_tile.has_value(), "Error: output_tile field should have been automatically populated");
+    if (attributes.bcast_batch.value()) {
+        TT_FATAL(
+            get_batch_size(b_shape) == 1,
+            "The batch bcast variant of matmul requires input tensors of shapes BCMK*11KN=BCMN "
+            "or equivalent. Please change the second input tensor or adjust the program config.");
+    }
+
+    TT_FATAL(is_floating_point(input_tensor_a.dtype()), "Unsupported data format");
+
+    TT_FATAL(
+        input_tensor_a.buffer() != nullptr and input_tensor_b.buffer() != nullptr,
+        "Operands to matmul need to be allocated in buffers on device!");
+    TT_FATAL(input_tensor_a.device() == input_tensor_b.device(), "Operands to matmul need to be on the same device!");
+
+    const auto& optional_bias = optional_input_tensors.at(0);
+    uint32_t bias_single_tile_size = 0;
+    if (optional_bias.has_value()) {
+        auto bias_data_format = tt::tt_metal::datatype_to_dataformat_converter(optional_bias.value().dtype());
+        bias_single_tile_size = tt::tile_size(bias_data_format);
+    }
+    operations::experimental::quasar::matmul::MatmulProgramConfig chosen_program_config =
+        operations::experimental::quasar::matmul::get_program_config(
+            input_tensor_a,
+            input_tensor_b,
+            attributes.transpose_a,
+            attributes.transpose_b,
+            bias_single_tile_size,
+            attributes);
+    // Soft-normalize so downstream variant code can safely read allowed_worker_cores; the warning
+    // for missing allowed_worker_cores was emitted at the entry point above.
+    operations::experimental::quasar::matmul::normalize_program_config(
+        chosen_program_config, input_tensor_a.device()->compute_with_storage_grid_size());
+
+    validate_matmul_tile_constraints(input_tensor_a, input_tensor_b, in0_tile, in1_tile, chosen_program_config);
+    validate_matmul_block_and_subblock_configuration(attributes, chosen_program_config);
+
+    validate_matmul_compute_grid_and_per_core_dims(input_tensor_a, chosen_program_config);
+    validate_matmul_sharded_operand_grids_within_program_compute_grid(
+        input_tensor_a, input_tensor_b, chosen_program_config);
+    validate_matmul_reuse_sharded_output_block_divisibility(
+        input_tensor_a, input_tensor_b, a_shape_padded, b_shape_padded, in0_tile, in1_tile, chosen_program_config);
+    validate_matmul_work_distribution_and_gather_ring_topology(
+        input_tensor_a,
+        input_tensor_b,
+        a_shape_padded,
+        b_shape_padded,
+        in0_tile,
+        in1_tile,
+        attributes.transpose_a,
+        attributes.transpose_b,
+        attributes.output_mem_config,
+        chosen_program_config);
+
+    // Validate batch dimensions for non-bcast matmul
+    if (!attributes.bcast_batch.value()) {
+        TT_FATAL(
+            a_shape.rank() == b_shape.rank() && "bmm (non-bcast matmul) expects input tensors of the same rank",
+            "Input tensors must have the same rank, got a_shape rank: {} vs b_shape rank: {}",
+            a_shape.rank(),
+            b_shape.rank());
+
+        // Check if in0 reuse optimization can be applied
+        // This optimization keeps input A (batch=1) in L1 and reuses it across all input B batches
+        // 1. Program config requirements: must use 1D mcast with specific settings
+        // 2. Shape requirements: must be rank-4 tensors (to ensure dim 1 is the batch dimension)
+        // 3. Batch dimension requirement: input A must have batch size 1 on dim 1
+        // 4. Memory layout requirement: inputs must not be sharded
+        auto in0_reuse = [&]() {
+            if (!std::holds_alternative<
+                    operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(
+                    chosen_program_config)) {
+                return false;
+            }
+            const auto& config =
+                std::get<operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(
+                    chosen_program_config);
+            if (config.fuse_batch || config.fused_activation.has_value() || config.mcast_in0) {
+                return false;
+            }
+            if (a_shape.rank() != 4 || b_shape.rank() != 4) {
+                return false;
+            }
+            if (a_shape[1] != 1) {
+                return false;
+            }
+            if (input_tensor_a.is_sharded() || input_tensor_b.is_sharded()) {
+                return false;
+            }
+            return true;
+        };
+
+        for (auto i = 0; i < a_shape.rank() - 2; i++) {
+            TT_FATAL(
+                a_shape[i] == b_shape[i] || (i == 1 && in0_reuse()),
+                "bmm (non-bcast matmul) expects input tensors of shapes "
+                "BCMK*BCKN=BCMN or batch dimension {} mismatch: a={} vs b={} (dimension mismatch only allowed on dim 1 "
+                "for rank-4 tensors when a[1]=1 and using MatmulMultiCoreReuseMultiCast1DProgramConfig with "
+                "fuse_batch=false, fused_activation=none, mcast_in0=false, and non-sharded inputs for in0 reuse "
+                "optimization)",
+                i,
+                a_shape[i],
+                b_shape[i]);
+        }
+    }
+
+    // matmul_multicore_reuse_mcast_1d (both program- and descriptor-based) targets a single
+    // bounding-box rectangle for the in0/in1 multicast and expects the sub-device's worker
+    // cores to form one contiguous row-major rectangle. Reject non-rectangular sub-device
+    // grids early with a clear message.
+    if (std::holds_alternative<operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(
+            chosen_program_config) &&
+        attributes.sub_device_id.has_value()) {
+        const auto& program_config_1d =
+            std::get<operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(
+                chosen_program_config);
+        if (!program_config_1d.gather_in0) {
+            auto* device = input_tensor_a.device();
+            auto sub_device_cores =
+                device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, attributes.sub_device_id.value());
+            auto bbox = sub_device_cores.bounding_box();
+            TT_FATAL(
+                sub_device_cores.num_cores() == bbox.size(),
+                "matmul_multicore_reuse_mcast_1d only supports rectangular sub-device worker grids. "
+                "Got sub-device worker cores: {} (bounding box: {})",
+                sub_device_cores,
+                bbox);
+            auto grid_size_1d = program_config_1d.allowed_worker_cores.value().bounding_box().grid_size();
+            TT_FATAL(
+                bbox.start_coord.x + grid_size_1d.x - 1 <= bbox.end_coord.x &&
+                    bbox.start_coord.y + grid_size_1d.y - 1 <= bbox.end_coord.y,
+                "matmul grid_size {} anchored at sub-device start {} "
+                "extends past the sub-device's worker bounding box {}",
+                grid_size_1d,
+                bbox.start_coord,
+                bbox);
+        }
+    }
+
+    if (std::holds_alternative<operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(
+            chosen_program_config) &&
+        attributes.global_cb.has_value() && input_tensor_b.is_sharded() && input_tensor_b.buffer()->is_dram()) {
+        for (uint32_t i = 1; i < input_tensors.size(); ++i) {
+            TT_FATAL(
+                input_tensor_b.logical_shape() == input_tensors[i].logical_shape(),
+                "for multi-tensor matmul, all weight tensors must have the same logical_shape, {} is not equal to {}",
+                input_tensor_b.logical_shape(),
+                input_tensors[i].logical_shape());
+            TT_FATAL(
+                input_tensor_b.padded_shape() == input_tensors[i].padded_shape(),
+                "for multi-tensor matmul, all weight tensors must have the same padded_shape {} is not equal to {}",
+                input_tensor_b.padded_shape(),
+                input_tensors[i].padded_shape());
+            TT_FATAL(
+                input_tensor_b.tensor_spec() == input_tensors[i].tensor_spec(),
+                "for multi-tensor matmul, all weight tensors must have the same tensor_spec {} is not equal to {}",
+                input_tensor_b.tensor_spec(),
+                input_tensors[i].tensor_spec());
+            TT_FATAL(
+                input_tensor_b.layout() == input_tensors[i].layout(),
+                "for multi-tensor matmul, all weight tensors must have the same layout {} is not equal to {}",
+                input_tensor_b.layout(),
+                input_tensors[i].layout());
+            TT_FATAL(
+                input_tensor_b.dtype() == input_tensors[i].dtype(),
+                "for multi-tensor matmul, all weight tensors must have the same _dtype {} is not equal to {}",
+                input_tensor_b.dtype(),
+                input_tensors[i].dtype());
+        }
+    } else {
+        TT_FATAL(input_tensors.size() == 2, "Must have exactly 2 input tensors, got: {}", input_tensors.size());
+    }
+
+    if (optional_bias.has_value()) {
+        const auto& bias = optional_bias.value();
+        auto bias_tile_shape = bias.tensor_spec().tile().get_tile_shape();
+        TT_FATAL(
+            (bias_tile_shape[0] == in0_tile.get_height() && bias_tile_shape[1] == in1_tile.get_width()),
+            "Input tile dims must have inner dim equal to 32 due to llk "
+            "constraints");
+        TT_FATAL(bias.layout() == Layout::TILE, "Unsupported input layout");
+        const auto& bias_shape = bias.logical_shape();
+        const auto& bias_shape_padded = bias.padded_shape();
+        uint32_t bias_batch_size = get_batch_size(bias_shape);
+        TT_FATAL(bias_batch_size == 1, "Unsupported bias shape: batch size not equal to 1.");
+        TT_FATAL(
+            bias_shape_padded[-2] == in0_tile.get_height(),
+            "Unsupported bias shape: padded second last dimension of bias, "
+            "{}, not equal to tile height, {}",
+            bias_shape_padded[-2],
+            in0_tile.get_height());
+        TT_FATAL(
+            bias_shape_padded[-1] == b_shape_padded[-1],
+            "Unsupported bias shape: padded last dimension of bias, {}, not "
+            "equal to second input's padded last "
+            "dimension, {}.",
+            bias_shape_padded[-1],
+            b_shape_padded[-1]);
+        TT_FATAL(
+            bias_shape[-1] >= b_shape[-1],
+            "Unsupported bias shape: last dimension of bias, {}, not equal to "
+            "or greater than second input's last "
+            "dimension, {}.",
+            bias_shape[-1],
+            b_shape[-1]);
+    }
+
+    if (attributes.untilize_out) {
+        TT_FATAL(attributes.output_dtype.has_value(), "Output dtype must be specified when untilize_out is true");
+        TT_FATAL(
+            (attributes.output_dtype.value() == DataType::BFLOAT16) ||
+                (attributes.output_dtype.value() == DataType::FLOAT32),
+            "Unsupported data type: {}",
+            attributes.output_dtype.value());
+        TT_FATAL(
+            std::holds_alternative<
+                operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(
+                chosen_program_config),
+            "Untilize out is not supported for this program config: {}",
+            typeid(chosen_program_config).name());
+    }
+
+    using namespace tt;
+    std::visit(
+        [input_tensor_a,
+         input_tensor_b,
+         optional_bias,
+         a_shape_padded,
+         b_shape_padded,
+         in0_tile,
+         in1_tile,
+         &attributes](const auto& program_config) {
+            using ProgramConfigType = std::decay_t<decltype(program_config)>;
+            if constexpr (
+                std::is_same_v<
+                    ProgramConfigType,
+                    operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCastProgramConfig> ||
+                std::is_same_v<
+                    ProgramConfigType,
+                    operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
+                if (program_config.fuse_batch) {
+                    TT_FATAL(
+                        get_batch_size(b_shape_padded) == 1,
+                        "Matmul with fused batch requires input tensors of shapes BCMK*11KN=BCMN "
+                        "or equivalent. Please change the second input tensor or adjust the program config.");
+                    if (attributes.transpose_a) {
+                        uint32_t batch_size_a = get_batch_size(a_shape_padded);
+                        uint32_t M_per_batch = a_shape_padded[-2] / in0_tile.get_height();
+                        TT_FATAL(
+                            batch_size_a == 1 || M_per_batch == 1,
+                            "transpose_a with fuse_batch is not supported when batch dimensions "
+                            "exist and M_per_batch > 1 (batch_size={}, M_per_batch={}, a_shape_padded={})",
+                            batch_size_a,
+                            M_per_batch,
+                            a_shape_padded);
+                    }
+                }
+            }
+            // TODO: For 1D and 2D mcasts, we don't check if tensor is single core
+            // or single row/col We can uplift these variants to skip mcasting to
+            // support single core (1D) or single row/col (2D)
+            if constexpr (std::is_same_v<
+                              ProgramConfigType,
+                              operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
+                TT_FATAL(
+                    !(program_config.mcast_in0 && program_config.gather_in0),
+                    "Matmul1D does not support mcast_in0 and gather_in0 at the "
+                    "same time.");
+
+                // Gather in0 specific validation
+                if (program_config.gather_in0) {
+                    TT_FATAL(
+                        program_config.num_global_cb_receivers > 0, "Num global CB receivers must be greater than 0.");
+                    TT_FATAL(
+                        input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED,
+                        "Input tensor A must be width sharded when using gather_in0.");
+                    TT_FATAL(
+                        input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED ||
+                            (input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED &&
+                             input_tensor_b.buffer()->buffer_type() == tt_metal::BufferType::DRAM) ||
+                            // Receiver-contiguous Tensor prefetcher: in1 is an NdShardSpec DRAM
+                            // weight (reported as ND_SHARDED) whose data is delivered via the
+                            // global CB receivers, not read directly per its DRAM layout. The
+                            // weight's own layout is irrelevant to the matmul in this case.
+                            (attributes.global_cb.has_value() &&
+                             input_tensor_b.buffer()->buffer_type() == tt_metal::BufferType::DRAM),
+                        "Input tensor B must be width sharded, DRAM interleaved, or a DRAM weight fed "
+                        "via a global circular buffer when using gather_in0.");
+                    if (!attributes.global_cb.has_value() && input_tensor_b.is_sharded()) {
+                        if (input_tensor_b.buffer()->buffer_type() == tt_metal::BufferType::L1) {
+                            TT_FATAL(
+                                input_tensor_a.shard_spec().value().grid == input_tensor_b.shard_spec().value().grid,
+                                "Input tensor A and B must be sharded on the same cores "
+                                "when using gather_in0.");
+                        }
+                    }
+                    TT_FATAL(
+                        attributes.output_mem_config.is_sharded(),
+                        "Output tensor must be sharded when using gather_in0.");
+                    TT_FATAL(
+                        attributes.output_mem_config.shard_spec().has_value(),
+                        "Output shard spec must be provided when using gather_in0.");
+
+                    if (!input_tensor_b.is_sharded()) {
+                        TT_FATAL(
+                            !attributes.global_cb.has_value(),
+                            "Global CB is not supported for DRAM_INTERLEAVED in1 when using gather_in0.");
+                        TT_FATAL(
+                            input_tensor_b.layout() == Layout::TILE,
+                            "Input tensor B must be TILE_LAYOUT when DRAM_INTERLEAVED when using gather_in0.");
+                        TT_FATAL(
+                            input_tensor_a.shard_spec().value().grid ==
+                                attributes.output_mem_config.shard_spec().value().grid,
+                            "Input tensor A and output tensor must be sharded on the same cores when using gather_in0 "
+                            "and in1 is DRAM_INTERLEAVED.");
+                    }
+
+                    if (!attributes.global_cb.has_value()) {
+                        TT_FATAL(
+                            program_config.num_global_cb_receivers == 1,
+                            "Num global CB receivers must be 1 when global CB is not provided.");
+                    }
+
+                    // Cross-check program_config against the in1 weight shape (silent-hang guards),
+                    // gated on the DRAM-sender path. The two DRAM-sender weight layouts have
+                    // different bank->ring conventions, so dispatch per in1 memory_layout():
+                    //   * WIDTH_SHARDED (K-row-major): each bank holds one wide (K, N/num_banks)
+                    //     shard feeding the contiguous ring positions [b*rpb, (b+1)*rpb).
+                    //   * ND_SHARDED (receiver-contiguous): an NdShardSpec weight with round-robin
+                    //     shard placement and a strided bank->ring mapping.
+                    // NdShardSpec reports memory_layout() == ND_SHARDED (see MemoryConfig(BufferType,
+                    // NdShardSpec)); the prefetcher manager and validator key on the same enum.
+                    if (attributes.global_cb.has_value() && input_tensor_a.is_sharded() &&
+                        tt::tt_metal::experimental::sender_core_type(attributes.global_cb.value()) ==
+                            tt::tt_metal::experimental::SenderCoreType::Dram) {
+                        const auto in1_layout = input_tensor_b.memory_config().memory_layout();
+                        if (in1_layout == TensorMemoryLayout::WIDTH_SHARDED) {
+                            validate_dram_sender_global_cb_gather_in0_geometry(
+                                attributes.global_cb.value(), input_tensor_a, b_shape_padded, in1_tile, program_config);
+                        } else if (in1_layout == TensorMemoryLayout::ND_SHARDED) {
+                            validate_dram_sender_global_cb_gather_in0_geometry_recv_contig(
+                                attributes.global_cb.value(), input_tensor_a, b_shape_padded, in1_tile, program_config);
+                        } else {
+                            TT_FATAL(
+                                false,
+                                "gather_in0 matmul with a DRAM-sender global CB requires in1 to be WIDTH_SHARDED "
+                                "(K-row-major) or ND_SHARDED (receiver-contiguous), but got {}.",
+                                in1_layout);
+                        }
+                    }
+
+                    TT_FATAL(!optional_bias.has_value(), "Bias is not supported when using gather_in0.");
+                } else {
+                    const auto device_grid_1d = input_tensor_a.device()->compute_with_storage_grid_size();
+                    check_tensor_in_grid(input_tensor_a, device_grid_1d);
+                    check_tensor_in_grid(input_tensor_b, device_grid_1d);
+                }
+                if (program_config.mcast_in0 || program_config.gather_in0) {
+                    if (input_tensor_a.is_sharded()) {
+                        TT_FATAL(program_config.fuse_batch, "Error: Batch fusion must be enabled.");
+                        TT_FATAL(
+                            input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED,
+                            "Error: input_tensor_a must be width sharded. Provided tensor memory layout: {}",
+                            input_tensor_a.memory_config().memory_layout());
+                        if (attributes.output_mem_config.is_sharded()) {
+                            TT_FATAL(
+                                input_tensor_a.memory_config().buffer_type() ==
+                                    attributes.output_mem_config.buffer_type(),
+                                "Error: Buffer type mismatch.");
+                            TT_FATAL(
+                                input_tensor_a.memory_config().memory_layout() ==
+                                    attributes.output_mem_config.memory_layout(),
+                                "Error: Memory layout mismatch.");
+                        }
+                        TT_FATAL(
+                            input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
+                            "Error: Shard orientation must be ROW_MAJOR.");
+                        const auto M = operations::experimental::quasar::matmul::utilities::get_M_dim(
+                            a_shape_padded, in0_tile, program_config.fuse_batch);
+                        const auto K =
+                            operations::experimental::quasar::matmul::utilities::get_K_dim(a_shape_padded, in0_tile);
+                        uint32_t per_core_M = program_config.per_core_M;
+                        auto shard_shape = input_tensor_a.shard_spec().value().shape;
+
+                        // No padding
+                        TT_FATAL(M == per_core_M, "Error: M ({}) must be equal to per_core_M ({}).", M, per_core_M);
+                        TT_FATAL(
+                            per_core_M == (shard_shape[0] / in0_tile.get_height()),
+                            "Error: per_core_M must be equal to shard_shape[0] ({}) / in0_tile.get_height() ({}).",
+                            shard_shape[0],
+                            in0_tile.get_height());
+                        TT_FATAL(
+                            K % program_config.in0_block_w == 0,
+                            "Error: K {} must be divisible by in0_block_w {}.",
+                            K,
+                            program_config.in0_block_w);
+                        if (!program_config.gather_in0) {  // Padding allowed for gather_in0
+                            TT_FATAL(
+                                (shard_shape[1] / in0_tile.get_width()) % program_config.in0_block_w == 0,
+                                "Error: shard_shape[1] ({}) / in0_tile.get_width() ({}) must be divisible by "
+                                "in0_block_w ({}).",
+                                shard_shape[1],
+                                in0_tile.get_width(),
+                                program_config.in0_block_w);
+                        }
+                    }
+                    if (attributes.output_mem_config.is_sharded()) {
+                        // Allow BLOCK_SHARDED on 1-row grids (equivalent to WIDTH_SHARDED)
+                        bool is_width_sharded =
+                            attributes.output_mem_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
+                        bool is_block_sharded_1d_row = false;
+                        if (attributes.output_mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED &&
+                            attributes.output_mem_config.shard_spec().has_value()) {
+                            auto grid_bbox = attributes.output_mem_config.shard_spec()->grid.bounding_box();
+                            is_block_sharded_1d_row = (grid_bbox.end_coord.y == grid_bbox.start_coord.y);
+                        }
+                        TT_FATAL(
+                            is_width_sharded || is_block_sharded_1d_row,
+                            "Error: Output memory layout must be WIDTH_SHARDED or BLOCK_SHARDED on a 1-row grid. "
+                            "Provided tensor memory layout: {}",
+                            attributes.output_mem_config.memory_layout());
+                        const auto M = operations::experimental::quasar::matmul::utilities::get_M_dim(
+                            a_shape_padded, in0_tile, program_config.fuse_batch);
+                        uint32_t per_core_M = program_config.per_core_M;
+                        uint32_t per_core_N = program_config.per_core_N;
+
+                        // No padding
+                        TT_FATAL(M == per_core_M, "Error: M {} must be equal to per_core_M {}.", M, per_core_M);
+
+                        TT_FATAL(
+                            program_config.out_subblock_w == per_core_N || program_config.out_subblock_h == 1,
+                            "Error: out_subblock_w must be equal to per_core_N or out_subblock_h must be equal to 1.");
+                        TT_FATAL(
+                            program_config.out_block_w == per_core_N || program_config.out_block_h == 1,
+                            "Error: out_block_w must be equal to per_core_N or out_block_h must be equal to 1.");
+                    }
+                    if (input_tensor_b.buffer()->buffer_type() == tt_metal::BufferType::L1 &&
+                        input_tensor_b.memory_config().is_sharded()) {
+                        TT_FATAL(
+                            input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED,
+                            "Operand B can only be interleaved or L1 width sharded.");
+                        TT_FATAL(
+                            program_config.per_core_N ==
+                                (input_tensor_b.shard_spec().value().shape[1] / in1_tile.get_width()),
+                            "Shard width must match per core N.");
+                        if (optional_bias.has_value()) {
+                            TT_FATAL(
+                                input_tensor_b.shard_spec().value().shape[1] ==
+                                    optional_bias.value().shard_spec().value().shape[1],
+                                "Bias shard spec width must match second inputs shard spec "
+                                "width.");
+                        }
+                    }
+                } else {
+                    if (input_tensor_a.memory_config().is_sharded()) {
+                        TT_FATAL(program_config.fuse_batch, "Error: Batch fusion must be enabled.");
+                        TT_FATAL(
+                            input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED,
+                            "Error: input_tensor_a must be height sharded.");
+                        if (attributes.output_mem_config.is_sharded()) {
+                            TT_FATAL(
+                                input_tensor_a.memory_config().buffer_type() ==
+                                    attributes.output_mem_config.buffer_type(),
+                                "Error: Buffer type mismatch.");
+                            TT_FATAL(
+                                input_tensor_a.memory_config().memory_layout() ==
+                                    attributes.output_mem_config.memory_layout(),
+                                "Error: Memory layout mismatch.");
+                        }
+                        TT_FATAL(
+                            input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
+                            "Error: Shard orientation must be ROW_MAJOR.");
+                        const auto M = operations::experimental::quasar::matmul::utilities::get_M_dim(
+                            a_shape_padded, in0_tile, program_config.fuse_batch);
+                        const auto K =
+                            operations::experimental::quasar::matmul::utilities::get_K_dim(a_shape_padded, in0_tile);
+                        uint32_t per_core_M = program_config.per_core_M;
+                        auto shard_shape = input_tensor_a.shard_spec().value().shape;
+                        TT_FATAL(
+                            div_up(M, per_core_M) <= input_tensor_a.shard_spec().value().grid.num_cores(),
+                            "Error: M must be divisible by per_core_M.");
+                        TT_FATAL(
+                            per_core_M == (shard_shape[0] / in0_tile.get_height()),
+                            "Error: per_core_M must be equal to shard_shape[0] / in0_tile.get_height().");
+                        TT_FATAL(K % program_config.in0_block_w == 0, "Error: K must be divisible by in0_block_w.");
+                        TT_FATAL(
+                            K == (shard_shape[1] / in0_tile.get_width()),
+                            "Error: K must be equal to shard_shape[1] / in0_tile.get_width().");
+                    }
+                    if (attributes.output_mem_config.is_sharded()) {
+                        // Allow BLOCK_SHARDED on 1-column grids (equivalent to HEIGHT_SHARDED)
+                        bool is_height_sharded =
+                            attributes.output_mem_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
+                        bool is_block_sharded_1d_column = false;
+                        if (attributes.output_mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED &&
+                            attributes.output_mem_config.shard_spec().has_value()) {
+                            auto grid_bbox = attributes.output_mem_config.shard_spec()->grid.bounding_box();
+                            is_block_sharded_1d_column = (grid_bbox.end_coord.x == grid_bbox.start_coord.x);
+                        }
+                        TT_FATAL(
+                            is_height_sharded || is_block_sharded_1d_column,
+                            "Error: Output memory layout must be HEIGHT_SHARDED or BLOCK_SHARDED on a 1-column grid.");
+                        const auto N =
+                            operations::experimental::quasar::matmul::utilities::get_N_dim(b_shape_padded, in1_tile);
+                        uint32_t per_core_N = program_config.per_core_N;
+
+                        TT_FATAL(N == per_core_N, "Error: N must be equal to per_core_N.");
+                        TT_FATAL(
+                            program_config.out_subblock_w == per_core_N || program_config.out_subblock_h == 1,
+                            "Error: out_subblock_w must be equal to per_core_N or out_subblock_h must be equal to 1.");
+                        TT_FATAL(
+                            program_config.out_block_w == per_core_N || program_config.out_block_h == 1,
+                            "Error: out_block_w must be equal to per_core_N or out_block_h must be equal to 1.");
+                    }
+                    TT_FATAL(
+                        input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+                        "Error: Operand B must be interleaved.");
+                }
+            } else if constexpr (std::is_same_v<
+                                     ProgramConfigType,
+                                     operations::experimental::quasar::matmul::
+                                         MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>) {
+                TT_FATAL(input_tensor_a.is_sharded(), "Input tensor A must be sharded for DRAM sharded program config");
+                TT_FATAL(
+                    attributes.output_mem_config.is_sharded(),
+                    "Output memory config must be sharded for DRAM sharded program config");
+                TT_FATAL(
+                    input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED,
+                    "Input A memory layout must be WIDTH_SHARDED, got: {}",
+                    input_tensor_a.memory_config().memory_layout());
+                TT_FATAL(
+                    input_tensor_a.memory_config().buffer_type() == attributes.output_mem_config.buffer_type(),
+                    "Input A and output buffer types must match, got input: {} vs output: {}",
+                    input_tensor_a.memory_config().buffer_type(),
+                    attributes.output_mem_config.buffer_type());
+                TT_FATAL(
+                    input_tensor_a.memory_config().memory_layout() == attributes.output_mem_config.memory_layout(),
+                    "Input A and output memory layouts must match, got input: {} vs output: {}",
+                    input_tensor_a.memory_config().memory_layout(),
+                    attributes.output_mem_config.memory_layout());
+                TT_FATAL(
+                    input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
+                    "Input A shard orientation must be ROW_MAJOR, got: {}",
+                    input_tensor_a.shard_spec().value().orientation);
+                const auto M = operations::experimental::quasar::matmul::utilities::get_M_dim(
+                    a_shape_padded, in0_tile, /*fuse_batch=*/false);
+                const auto K = operations::experimental::quasar::matmul::utilities::get_K_dim(a_shape_padded, in0_tile);
+                uint32_t per_core_M = program_config.per_core_M;
+                auto shard_shape = input_tensor_a.shard_spec().value().shape;
+
+                // No padding
+                TT_FATAL(M == per_core_M, "M ({}) must equal per_core_M ({})", M, per_core_M);
+                TT_FATAL(M == 1, "currently only support in0 tensor height of tile height");
+                TT_FATAL(
+                    per_core_M == (shard_shape[0] / in0_tile.get_height()),
+                    "per_core_M ({}) must equal shard_shape[0] / in0_tile.get_height() ({})",
+                    per_core_M,
+                    (shard_shape[0] / in0_tile.get_height()));
+                TT_FATAL(
+                    K % program_config.in0_block_w == 0,
+                    "K ({}) must be divisible by in0_block_w ({})",
+                    K,
+                    program_config.in0_block_w);
+                TT_FATAL(
+                    (shard_shape[1] / in0_tile.get_width()) % program_config.in0_block_w == 0,
+                    "shard_shape[1] / in0_tile.get_width() ({}) must be divisible by in0_block_w ({})",
+                    (shard_shape[1] / in0_tile.get_width()),
+                    program_config.in0_block_w);
+
+                // tensor in1
+                TT_FATAL(
+                    input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED,
+                    "Input B memory layout must be WIDTH_SHARDED, got: {}",
+                    input_tensor_b.memory_config().memory_layout());
+            } else if constexpr (std::is_same_v<
+                                     ProgramConfigType,
+                                     operations::experimental::quasar::matmul::
+                                         MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>) {
+                // Batch-sharded DRAM matmul validations
+                // For batched matmul: [1, B, M, K] x [1, B, K, N] = [1, B, M, N]
+                // Sharded by batch dimension - each worker handles B/num_workers complete matmuls
+                // Input A: HEIGHT_SHARDED in L1 (batch-sharded, each core has B/12 complete [M, N] matrices)
+                // Input B: HEIGHT_SHARDED in DRAM (batch-sharded, each bank has B/12 complete [N, K] matrices)
+                // Output: HEIGHT_SHARDED in L1 (batch-sharded, each core outputs B/12 complete [M, K] matrices)
+                TT_FATAL(input_tensor_a.is_sharded(), "Input tensor A must be sharded for batch-sharded DRAM matmul");
+                TT_FATAL(
+                    attributes.output_mem_config.is_sharded(),
+                    "Output memory config must be sharded for batch-sharded DRAM matmul");
+                TT_FATAL(
+                    input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED,
+                    "Input A memory layout must be HEIGHT_SHARDED for batch-sharded DRAM matmul, got: {}",
+                    input_tensor_a.memory_config().memory_layout());
+                TT_FATAL(
+                    input_tensor_a.memory_config().buffer_type() == attributes.output_mem_config.buffer_type(),
+                    "Input A and output buffer types must match, got input: {} vs output: {}",
+                    input_tensor_a.memory_config().buffer_type(),
+                    attributes.output_mem_config.buffer_type());
+                TT_FATAL(
+                    input_tensor_a.memory_config().memory_layout() == attributes.output_mem_config.memory_layout(),
+                    "Input A and output memory layouts must match, got input: {} vs output: {}",
+                    input_tensor_a.memory_config().memory_layout(),
+                    attributes.output_mem_config.memory_layout());
+                TT_FATAL(
+                    input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
+                    "Input A shard orientation must be ROW_MAJOR, got: {}",
+                    input_tensor_a.shard_spec().value().orientation);
+
+                // For batch sharding, the contracted dimension (N in A, N in B) must be divisible by in0_block_w
+                const auto N_dim = operations::experimental::quasar::matmul::utilities::get_K_dim(
+                    a_shape_padded, in0_tile);  // K dim of A = N
+                TT_FATAL(
+                    N_dim % program_config.in0_block_w == 0,
+                    "N dimension ({}) must be divisible by in0_block_w ({})",
+                    N_dim,
+                    program_config.in0_block_w);
+
+                // tensor in1: HEIGHT_SHARDED in DRAM (batch-sharded)
+                TT_FATAL(
+                    input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED,
+                    "Input B memory layout must be HEIGHT_SHARDED for batch-sharded DRAM matmul, got: {}",
+                    input_tensor_b.memory_config().memory_layout());
+            } else if constexpr (std::is_same_v<
+                                     ProgramConfigType,
+                                     operations::experimental::quasar::matmul::
+                                         MatmulMultiCoreReuseMultiCastProgramConfig>) {
+                const tt::tt_metal::CoreCoord device_grid = input_tensor_a.device()->compute_with_storage_grid_size();
+                check_tensor_in_grid(input_tensor_a, device_grid);
+                check_tensor_in_grid(input_tensor_b, device_grid);
+                if (input_tensor_a.memory_config().is_sharded()) {
+                    TT_FATAL(program_config.fuse_batch, "Batch fusion is required when input A is sharded");
+                    auto tensor_a_memory_layout = input_tensor_a.memory_config().memory_layout();
+                    const auto K =
+                        operations::experimental::quasar::matmul::utilities::get_K_dim(a_shape_padded, in0_tile);
+                    uint32_t per_core_M = program_config.per_core_M;
+                    auto shard_shape = input_tensor_a.shard_spec().value().shape;
+
+                    TT_FATAL(
+                        tensor_a_memory_layout == TensorMemoryLayout::BLOCK_SHARDED ||
+                            tensor_a_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED,
+                        "Unsupported memory layout {}.",
+                        tensor_a_memory_layout);
+
+                    if (tensor_a_memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
+                        if (program_config.transpose_mcast) {
+                            TT_FATAL(
+                                input_tensor_a.shard_spec().value().orientation == ShardOrientation::COL_MAJOR,
+                                "Input tensor A must have COL_MAJOR shard orientation for transpose MCAST, got: {}",
+                                input_tensor_a.shard_spec().value().orientation);
+                        } else {
+                            TT_FATAL(
+                                input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
+                                "Input tensor A must have ROW_MAJOR shard orientation for non-transpose MCAST, got: {}",
+                                input_tensor_a.shard_spec().value().orientation);
+                        }
+                        if (attributes.output_mem_config.is_sharded()) {
+                            TT_FATAL(
+                                input_tensor_a.memory_config().buffer_type() ==
+                                    attributes.output_mem_config.buffer_type(),
+                                "Input tensor A and output buffer types must match, got input: {} vs output: {}",
+                                input_tensor_a.memory_config().buffer_type(),
+                                attributes.output_mem_config.buffer_type());
+                            TT_FATAL(
+                                input_tensor_a.memory_config().memory_layout() ==
+                                    attributes.output_mem_config.memory_layout(),
+                                "Input tensor A and output memory layouts must match, got input: {} vs output: {}",
+                                input_tensor_a.memory_config().memory_layout(),
+                                attributes.output_mem_config.memory_layout());
+                        }
+
+                    } else if (tensor_a_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+                        TT_FATAL(
+                            !program_config.transpose_mcast,
+                            "Transpose MCAST not supported with HEIGHT_SHARDED layout");
+                        TT_FATAL(
+                            K == program_config.in0_block_w,
+                            "K ({}) must equal in0_block_w ({})",
+                            K,
+                            program_config.in0_block_w);
+                        TT_FATAL(
+                            program_config.in0_block_w == (shard_shape[1] / in0_tile.get_width()),
+                            "in0_block_w ({}) must equal shard_shape[1] / in0_tile.get_width() ({})",
+                            program_config.in0_block_w,
+                            (shard_shape[1] / in0_tile.get_width()));
+                        TT_FATAL(
+                            input_tensor_a.shard_spec()->grid.bounding_box().start_coord.x ==
+                                input_tensor_a.shard_spec()->grid.bounding_box().end_coord.x,
+                            "Grid bounding box x coordinates must match, got start: {} vs end: {}",
+                            input_tensor_a.shard_spec()->grid.bounding_box().start_coord.x,
+                            input_tensor_a.shard_spec()->grid.bounding_box().end_coord.x);
+                    }
+
+                    TT_FATAL(
+                        per_core_M == (shard_shape[0] / in0_tile.get_height()),
+                        "per_core_M ({}) must equal shard_shape[0] / in0_tile.get_height() ({})",
+                        per_core_M,
+                        (shard_shape[0] / in0_tile.get_height()));
+                    TT_FATAL(
+                        (shard_shape[1] / in0_tile.get_width()) % program_config.in0_block_w == 0,
+                        "shard_shape[1] / in0_tile.get_width() ({}) must be divisible by in0_block_w ({})",
+                        (shard_shape[1] / in0_tile.get_width()),
+                        program_config.in0_block_w);
+                }
+
+                if (input_tensor_b.memory_config().is_sharded()) {
+                    TT_FATAL(!program_config.transpose_mcast, "Transpose MCAST not supported when input B is sharded");
+                    auto tensor_b_memory_layout = input_tensor_b.memory_config().memory_layout();
+                    // ND_SHARDED in1 in DRAM is read via the generic TensorAccessor path: the program
+                    // factory's in1_is_sharded only covers WIDTH/HEIGHT, so ND falls through to the
+                    // interleaved-style reader, which addresses the NdShardSpec layout from the accessor
+                    // args. The width/height-specific validation below is gated on those layouts, so ND
+                    // DRAM in1 skips it (no shard_spec() access).
+                    const bool in1_is_nd_dram = tensor_b_memory_layout == TensorMemoryLayout::ND_SHARDED &&
+                                                input_tensor_b.buffer()->buffer_type() == tt_metal::BufferType::DRAM;
+                    TT_FATAL(
+                        tensor_b_memory_layout == TensorMemoryLayout::WIDTH_SHARDED ||
+                            tensor_b_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED || in1_is_nd_dram,
+                        "Input B memory layout must be WIDTH_SHARDED, HEIGHT_SHARDED, or DRAM ND_SHARDED, got: {}",
+                        tensor_b_memory_layout);
+                    if (tensor_b_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+                        // Height-sharded in1 is only supported for DRAM batched matmuls
+                        TT_FATAL(
+                            input_tensor_b.buffer()->buffer_type() == tt_metal::BufferType::DRAM,
+                            "HEIGHT_SHARDED input B is only supported in DRAM, got: {}",
+                            input_tensor_b.buffer()->buffer_type());
+                        TT_FATAL(
+                            !program_config.fuse_batch,
+                            "HEIGHT_SHARDED input B requires fuse_batch=false for batched matmul");
+                        // Each DRAM bank must hold complete [K, N] matrices stacked vertically
+                        // K is the contracted dim: last dim of A, second-to-last of B
+                        const auto K =
+                            operations::experimental::quasar::matmul::utilities::get_K_dim(a_shape_padded, in0_tile);
+                        const auto N =
+                            operations::experimental::quasar::matmul::utilities::get_N_dim(b_shape_padded, in1_tile);
+                        const auto& in1_shard_spec = input_tensor_b.shard_spec().value();
+                        uint32_t in1_shard_height_in_tiles = in1_shard_spec.shape[0] / in1_tile.get_height();
+                        uint32_t in1_shard_width_in_tiles = in1_shard_spec.shape[1] / in1_tile.get_width();
+                        uint32_t num_banks = in1_shard_spec.grid.num_cores();
+                        TT_FATAL(
+                            in1_shard_width_in_tiles == N,
+                            "HEIGHT_SHARDED input B shard width ({} tiles) must equal N ({} tiles)",
+                            in1_shard_width_in_tiles,
+                            N);
+                        TT_FATAL(
+                            in1_shard_height_in_tiles >= K,
+                            "HEIGHT_SHARDED input B shard height ({} tiles) must be >= K ({} tiles)",
+                            in1_shard_height_in_tiles,
+                            K);
+                        TT_FATAL(
+                            in1_shard_height_in_tiles % K == 0,
+                            "HEIGHT_SHARDED input B shard height ({} tiles) must be divisible by K ({} tiles) "
+                            "so each bank holds complete [K, N] matrices",
+                            in1_shard_height_in_tiles,
+                            K);
+                        uint32_t batches_per_bank = in1_shard_height_in_tiles / K;
+                        uint32_t B = get_batch_size(b_shape_padded);
+                        // The kernel addresses batch b via: bank_id = b / batches_per_bank.
+                        // Total shard capacity (batches_per_bank * num_banks) must be >= B
+                        // to ensure all batches map to valid banks. It may exceed B when the
+                        // batch dimension is padded up to distribute evenly across banks.
+                        TT_FATAL(
+                            batches_per_bank * num_banks >= B,
+                            "HEIGHT_SHARDED input B: batches_per_bank ({}) * num_banks ({}) = {} must be >= "
+                            "batch size B ({})",
+                            batches_per_bank,
+                            num_banks,
+                            batches_per_bank * num_banks,
+                            B);
+                    }
+                    if (input_tensor_b.buffer()->buffer_type() != tt_metal::BufferType::DRAM) {
+                        const auto tensor_a_memory_layout = input_tensor_a.memory_config().memory_layout();
+                        TT_FATAL(
+                            (input_tensor_a.memory_config().is_sharded() &&
+                             tensor_a_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) ||
+                                tensor_a_memory_layout == TensorMemoryLayout::INTERLEAVED,
+                            "Error - non-DRAM width sharded input B requires input A to be interleaved or height "
+                            "sharded, rather than {}",
+                            tensor_a_memory_layout);
+                        TT_FATAL(
+                            program_config.per_core_N ==
+                                (input_tensor_b.shard_spec().value().shape[1] / in1_tile.get_width()),
+                            "per_core_N ({}) must equal input tensor B shard shape[1] / in1_tile.get_width() ({})",
+                            program_config.per_core_N,
+                            (input_tensor_b.shard_spec().value().shape[1] / in1_tile.get_width()));
+                    }
+                    if (tensor_b_memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
+                        TT_FATAL(
+                            input_tensor_b.shard_spec()->grid.bounding_box().start_coord.y ==
+                                input_tensor_b.shard_spec()->grid.bounding_box().end_coord.y,
+                            "Width-sharded input tensor B grid bounding box must have equal start and end y "
+                            "coordinates, got start: {} vs end: {}",
+                            input_tensor_b.shard_spec()->grid.bounding_box().start_coord.y,
+                            input_tensor_b.shard_spec()->grid.bounding_box().end_coord.y);
+                    }
+                }
+
+                if (attributes.output_mem_config.is_sharded()) {
+                    TT_FATAL(
+                        attributes.output_mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED,
+                        "Output memory layout must be BLOCK_SHARDED, got: {}",
+                        attributes.output_mem_config.memory_layout());
+                    uint32_t per_core_N = program_config.per_core_N;
+
+                    TT_FATAL(
+                        program_config.out_subblock_w == per_core_N || program_config.out_subblock_h == 1,
+                        "Error: out_subblock_w must be equal to per_core_N or out_subblock_h must be equal to 1.");
+                    TT_FATAL(
+                        program_config.out_block_w == per_core_N || program_config.out_block_h == 1,
+                        "Error: out_block_w must be equal to per_core_N or out_block_h must be equal to 1.");
+                }
+            } else if constexpr (std::is_same_v<
+                                     ProgramConfigType,
+                                     operations::experimental::quasar::matmul::MatmulMultiCoreReuseProgramConfig>) {
+                const auto M = operations::experimental::quasar::matmul::utilities::get_M_dim(
+                    a_shape_padded, in0_tile, /*fuse_batch=*/false);
+                const auto total_M = operations::experimental::quasar::matmul::utilities::get_M_dim(
+                    a_shape_padded, in0_tile, /*fuse_batch=*/true);
+                const auto N = operations::experimental::quasar::matmul::utilities::get_N_dim(b_shape_padded, in1_tile);
+                const auto K = operations::experimental::quasar::matmul::utilities::get_K_dim(
+                    a_shape_padded, /*tile=*/std::nullopt);
+                uint32_t per_core_M = program_config.per_core_M;
+                uint32_t per_core_N = program_config.per_core_N;
+                if (per_core_M > M) {
+                    TT_FATAL(
+                        per_core_M % M == 0,
+                        "per_core_M, {}, must be a multiple of M, {} if "
+                        "per_core_M > M!",
+                        per_core_M,
+                        M);
+                    TT_FATAL(
+                        total_M % per_core_M == 0,
+                        "input a total height, {}, must be divisible by "
+                        "per_core_M, {}!",
+                        total_M,
+                        per_core_M);
+                } else {
+                    TT_FATAL(
+                        M % per_core_M == 0, "per_core_M, {}, must divide M, {}, if per_core_M < M!", per_core_M, M);
+                }
+                TT_FATAL(N == per_core_N, "Error: N, {}, is not equal to per_core_N, {}", N, per_core_N);
+                if (input_tensor_a.is_sharded()) {
+                    TT_FATAL(
+                        input_tensor_a.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
+                        "Error: memory layout, {}, is not width sharded",
+                        input_tensor_a.memory_config().memory_layout());
+                    auto in0_shard_shape = input_tensor_a.shard_spec().value().shape;
+
+                    TT_FATAL(K == in0_shard_shape[1], "Error: K, {}, needs to be equal to {}", K, in0_shard_shape[1]);
+                    TT_FATAL(
+                        in0_shard_shape[1] == program_config.in0_block_w * in0_tile.get_width(),
+                        "Error: {} needs to equal {} * {}",
+                        in0_shard_shape[1],
+                        program_config.in0_block_w,
+                        in0_tile.get_width());
+                    TT_FATAL(
+                        per_core_M * in0_tile.get_height() == in0_shard_shape[0],
+                        "Error: {} * {} needs to equal {}",
+                        per_core_M,
+                        in0_tile.get_height(),
+                        in0_shard_shape[0]);
+
+                    if (input_tensor_b.is_sharded()) {
+                        TT_FATAL(
+                            input_tensor_a.memory_config().buffer_type() ==
+                                input_tensor_b.memory_config().buffer_type(),
+                            "Input tensors A and B must have matching buffer types, got A: {} vs B: {}",
+                            input_tensor_a.memory_config().buffer_type(),
+                            input_tensor_b.memory_config().buffer_type());
+                        TT_FATAL(
+                            input_tensor_a.memory_config().memory_layout() ==
+                                input_tensor_b.memory_config().memory_layout(),
+                            "Input tensors A and B must have matching memory layouts, got A: {} vs B: {}",
+                            input_tensor_a.memory_config().memory_layout(),
+                            input_tensor_b.memory_config().memory_layout());
+                        TT_FATAL(
+                            input_tensor_a.shard_spec().value().grid == input_tensor_b.shard_spec().value().grid,
+                            "Input tensors A and B must have matching shard spec grids");
+                        TT_FATAL(
+                            input_tensor_a.shard_spec().value().orientation ==
+                                input_tensor_b.shard_spec().value().orientation,
+                            "Input tensors A and B must have matching shard orientations, got A: {} vs B: {}",
+                            input_tensor_a.shard_spec().value().orientation,
+                            input_tensor_b.shard_spec().value().orientation);
+                    }
+                    if (attributes.output_mem_config.is_sharded()) {
+                        TT_FATAL(
+                            input_tensor_a.memory_config().buffer_type() == attributes.output_mem_config.buffer_type(),
+                            "Input tensor A and output buffer types must match, got input: {} vs output: {}",
+                            input_tensor_a.memory_config().buffer_type(),
+                            attributes.output_mem_config.buffer_type());
+                        TT_FATAL(
+                            input_tensor_a.memory_config().memory_layout() ==
+                                attributes.output_mem_config.memory_layout(),
+                            "Input tensor A and output memory layouts must match, got input: {} vs output: {}",
+                            input_tensor_a.memory_config().memory_layout(),
+                            attributes.output_mem_config.memory_layout());
+                    }
+                }
+
+                const auto batch_size_a = get_batch_size(a_shape_padded);
+                const auto batch_size_b = get_batch_size(b_shape_padded);
+                bool broadcast_batch = batch_size_a > 1 and batch_size_b == 1;
+                TT_FATAL(!broadcast_batch, "Batch broadcasting is not supported for the chosen program config");
+                if (batch_size_a > 1 && batch_size_b > 1) {
+                    TT_FATAL(
+                        M % program_config.out_subblock_h == 0,
+                        "out_subblock_h ({}) needs to divide M ({}) evenly and does not. "
+                        "Please update your program config.",
+                        program_config.out_subblock_h,
+                        M);
+                }
+
+                if (input_tensor_b.is_sharded()) {
+                    TT_FATAL(per_core_M % M == 0, "per_core_M must be a multiple of M if input b is sharded!");
+                    TT_FATAL(
+                        input_tensor_b.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
+                        "Input B memory layout must not be WIDTH_SHARDED, got: {}",
+                        input_tensor_b.memory_config().memory_layout());
+                    auto in1_shard_shape = input_tensor_b.shard_spec().value().shape;
+                    TT_FATAL(
+                        in1_shard_shape[1] == b_shape_padded[-1],
+                        "Input B shard shape[1] ({}) must equal padded shape[-1] ({})",
+                        in1_shard_shape[1],
+                        b_shape_padded[-1]);
+                    TT_FATAL(
+                        per_core_N * in1_tile.get_width() == in1_shard_shape[1],
+                        "per_core_N * in1_tile.get_width() ({}) must equal in1_shard_shape[1] ({})",
+                        per_core_N * in1_tile.get_width(),
+                        in1_shard_shape[1]);
+                    TT_FATAL(
+                        in1_shard_shape[0] % K == 0,
+                        "Input B shard shape[0] ({}) must be divisible by K ({})",
+                        in1_shard_shape[0],
+                        K);
+                }
+                if (attributes.output_mem_config.is_sharded()) {
+                    TT_FATAL(
+                        attributes.output_mem_config.memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
+                        "Output memory layout must not be WIDTH_SHARDED, got: {}",
+                        attributes.output_mem_config.memory_layout());
+                    TT_FATAL(
+                        program_config.out_subblock_w == per_core_N || program_config.out_subblock_h == 1,
+                        "Either out_subblock_w ({}) must equal per_core_N ({}) or out_subblock_h ({}) must be 1",
+                        program_config.out_subblock_w,
+                        per_core_N,
+                        program_config.out_subblock_h);
+                }
+            } else {
+                TT_FATAL(
+                    input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+                    "Input A memory layout must be INTERLEAVED, got: {}",
+                    input_tensor_a.memory_config().memory_layout());
+                TT_FATAL(
+                    input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+                    "Input B memory layout must be INTERLEAVED, got: {}",
+                    input_tensor_b.memory_config().memory_layout());
+                TT_FATAL(
+                    attributes.output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
+                    "Output memory layout must be INTERLEAVED, got: {}",
+                    attributes.output_mem_config.memory_layout());
+            }
+            if constexpr (
+                std::is_same_v<
+                    ProgramConfigType,
+                    operations::experimental::quasar::matmul::MatmulMultiCoreReuseProgramConfig> ||
+                std::is_same_v<
+                    ProgramConfigType,
+                    operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCastProgramConfig> ||
+                std::is_same_v<
+                    ProgramConfigType,
+                    operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
+                TT_FATAL(
+                    (a_shape_padded[-1] / in0_tile.get_width()) % program_config.in0_block_w == 0,
+                    "Kt must be divisible by in0_block_w");
+            }
+        },
+        chosen_program_config);
+
+    if (std::holds_alternative<operations::experimental::quasar::matmul::MatmulMultiCoreReuseProgramConfig>(
+            chosen_program_config)) {
+        operations::experimental::quasar::matmul::utilities::validate_matmul_reuse_work_split(
+            input_tensor_a,
+            input_tensor_b,
+            a_shape_padded,
+            b_shape_padded,
+            in0_tile,
+            in1_tile,
+            std::get<operations::experimental::quasar::matmul::MatmulMultiCoreReuseProgramConfig>(
+                chosen_program_config),
+            attributes.output_mem_config,
+            std::nullopt);
+    }
+}
+
+MatmulDeviceOperation::spec_return_value_t MatmulDeviceOperation::compute_output_specs(
+    const operation_attributes_t& attributes, const tensor_args_t& args) {
+    using namespace tt::tt_metal;
+    using namespace tt::constants;
+    warn_if_allowed_worker_cores_missing(attributes.program_config, "MatmulDeviceOperation::compute_output_specs");
+    const auto& optional_output_tensors = args.optional_output_tensors;
+    const auto& input_tensors = args.input_tensors;
+    const auto& optional_input_tensors = args.optional_input_tensors;
+
+    TT_FATAL(
+        optional_output_tensors.size() <= 1,
+        "None or One Optional output tensor can be passed when accessing it "
+        "for computing Matmul's output specs");
+
+    const bool is_optional_output_tensor =
+        !optional_output_tensors.empty() && optional_output_tensors.at(0).has_value();
+
+    if (is_optional_output_tensor) {
+        return {optional_output_tensors.at(0)->tensor_spec()};
+    }
+
+    const auto& input_tensor_a = input_tensors.at(0);
+    const auto& input_tensor_b = input_tensors.at(1);
+
+    // Use the compute_matmul_output_shape function to get the output shape
+    const auto output_shape = operations::experimental::quasar::matmul::utilities::compute_matmul_output_shape(
+        input_tensor_a, input_tensor_b, attributes.transpose_a, attributes.transpose_b);
+
+    const auto& a_shape_padded = operations::experimental::quasar::matmul::utilities::get_matmul_tensor_padded_shape(
+        input_tensor_a, attributes.transpose_a);
+    const auto& b_shape_padded = operations::experimental::quasar::matmul::utilities::get_matmul_tensor_padded_shape(
+        input_tensor_b, attributes.transpose_b);
+    auto in0_tile =
+        operations::experimental::quasar::matmul::utilities::get_matmul_tile(input_tensor_a, attributes.transpose_a);
+    auto in1_tile =
+        operations::experimental::quasar::matmul::utilities::get_matmul_tile(input_tensor_b, attributes.transpose_b);
+    auto output_tile = attributes.output_tile.value();
+    auto tile_width_ratio = output_tile.get_tile_shape()[1] / in1_tile.get_width();
+    auto output_layout = attributes.untilize_out ? Layout::ROW_MAJOR : Layout::TILE;
+
+    TT_FATAL(attributes.output_dtype.has_value(), "Error: output_dtype field should have been populated");
+    if (attributes.output_mem_config.is_sharded()) {
+        const auto& optional_bias = !optional_input_tensors.empty() && optional_input_tensors[0].has_value()
+                                        ? optional_input_tensors[0]
+                                        : std::nullopt;
+        uint32_t bias_single_tile_size = 0;
+        if (optional_bias.has_value()) {
+            auto bias_data_format = tt::tt_metal::datatype_to_dataformat_converter(optional_bias.value().dtype());
+            bias_single_tile_size = tt::tile_size(bias_data_format);
+        }
+        operations::experimental::quasar::matmul::MatmulProgramConfig chosen_program_config =
+            operations::experimental::quasar::matmul::get_program_config(
+                input_tensor_a,
+                input_tensor_b,
+                attributes.transpose_a,
+                attributes.transpose_b,
+                bias_single_tile_size,
+                attributes);
+        // Soft-normalize so downstream variant code can safely read allowed_worker_cores; the warning
+        // for missing allowed_worker_cores was emitted at the entry point above.
+        operations::experimental::quasar::matmul::normalize_program_config(
+            chosen_program_config, input_tensor_a.device()->compute_with_storage_grid_size());
+        return std::visit(
+            [&](const auto& program_config) -> MatmulDeviceOperation::spec_return_value_t {
+                using ProgramConfigType = std::decay_t<decltype(program_config)>;
+                if constexpr (std::is_same_v<
+                                  ProgramConfigType,
+                                  operations::experimental::quasar::matmul::
+                                      MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
+                    const auto M = operations::experimental::quasar::matmul::utilities::get_M_dim(
+                        a_shape_padded, in0_tile, program_config.fuse_batch);
+                    const auto N =
+                        operations::experimental::quasar::matmul::utilities::get_N_dim(b_shape_padded, in1_tile);
+                    uint32_t per_core_M = program_config.per_core_M;
+                    uint32_t per_core_N = program_config.per_core_N;
+
+                    TT_FATAL(
+                        per_core_N % tile_width_ratio == 0,
+                        "per_core_N must be divisible by override output tile width");
+                    auto mem_config = attributes.output_mem_config;
+                    if (!program_config.gather_in0) {
+                        // Check if BLOCK_SHARDED on 1D grid - if so, use user's shard spec with converted memory layout
+                        auto memory_layout = mem_config.memory_layout();
+                        bool is_block_sharded_1d = false;
+                        if (memory_layout == TensorMemoryLayout::BLOCK_SHARDED && mem_config.shard_spec().has_value()) {
+                            auto grid_bbox = mem_config.shard_spec()->grid.bounding_box();
+                            bool is_1d_column = (grid_bbox.end_coord.x == grid_bbox.start_coord.x);
+                            bool is_1d_row = (grid_bbox.end_coord.y == grid_bbox.start_coord.y);
+                            is_block_sharded_1d = is_1d_column || is_1d_row;
+                        }
+
+                        if (is_block_sharded_1d) {
+                            // Use user's shard spec with converted memory layout
+                            auto user_shard_spec = mem_config.shard_spec().value();
+                            auto grid_bbox = user_shard_spec.grid.bounding_box();
+                            bool is_1d_column = (grid_bbox.end_coord.x == grid_bbox.start_coord.x);
+                            memory_layout =
+                                is_1d_column ? TensorMemoryLayout::HEIGHT_SHARDED : TensorMemoryLayout::WIDTH_SHARDED;
+                            mem_config =
+                                tt::tt_metal::MemoryConfig{memory_layout, mem_config.buffer_type(), user_shard_spec};
+                        } else {
+                            // Compute shard spec from per_core values
+                            uint32_t num_blocks_y = ((M - 1) / per_core_M) + 1;
+                            uint32_t num_blocks_x = ((N - 1) / per_core_N) + 1;
+                            uint32_t num_cores = num_blocks_x * num_blocks_y;
+                            auto cwsg_1d = program_config.allowed_worker_cores.value().bounding_box().grid_size();
+                            CoreRangeSet all_cores = num_cores_to_corerangeset(num_cores, cwsg_1d, true);
+                            tt::tt_metal::ShardSpec shard_spec = tt::tt_metal::ShardSpec{
+                                all_cores,
+                                {per_core_M * in0_tile.get_height(), per_core_N * in1_tile.get_width()},
+                                ShardOrientation::ROW_MAJOR};
+                            mem_config = tt::tt_metal::MemoryConfig(
+                                mem_config.memory_layout(), mem_config.buffer_type(), shard_spec);
+                        }
+                    }
+                    // support for multi-tensor output
+                    const ttnn::TensorSpec tensor_spec(
+                        output_shape,
+                        tt::tt_metal::TensorLayout(
+                            attributes.output_dtype.value(),
+                            attributes.untilize_out ? tt::tt_metal::PageConfig(output_layout)
+                                                    : tt::tt_metal::PageConfig(output_layout, output_tile),
+                            mem_config));
+
+                    std::vector<ttnn::TensorSpec> output_tensor_specs(input_tensors.size() - 1, tensor_spec);
+                    return output_tensor_specs;
+                } else if constexpr (std::is_same_v<
+                                         ProgramConfigType,
+                                         operations::experimental::quasar::matmul::
+                                             MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>) {
+                    const auto M = operations::experimental::quasar::matmul::utilities::get_M_dim(
+                        a_shape_padded, in0_tile, /*fuse_batch=*/true);
+                    const auto K =
+                        operations::experimental::quasar::matmul::utilities::get_K_dim(a_shape_padded, in0_tile);
+                    const auto N =
+                        operations::experimental::quasar::matmul::utilities::get_N_dim(b_shape_padded, in1_tile);
+
+                    uint32_t per_core_M = program_config.per_core_M;
+                    uint32_t per_core_N = program_config.per_core_N;
+                    uint32_t per_core_K = input_tensor_a.shard_spec().value().shape[1] / in0_tile.get_width();
+
+                    TT_FATAL(
+                        K % per_core_K == 0,
+                        "in DRAM sharded Matmul we don't have support for un-even sharding currently. K: {}, "
+                        "per_core_K: {}.",
+                        K,
+                        per_core_K);
+
+                    TT_FATAL(
+                        per_core_N % tile_width_ratio == 0,
+                        "per_core_N must be divisible by override output tile width");
+
+                    uint32_t num_blocks_y = ((M - 1) / per_core_M) + 1;
+                    uint32_t num_blocks_x = ((N - 1) / per_core_N) + 1;
+                    uint32_t num_cores = num_blocks_x * num_blocks_y;
+                    auto grid_size = input_tensor_a.device()->compute_with_storage_grid_size();
+                    CoreRangeSet all_cores = num_cores_to_corerangeset(num_cores, grid_size, true);
+                    ShardSpec shard_spec = ShardSpec{
+                        all_cores,
+                        {per_core_M * in0_tile.get_height(), per_core_N * in1_tile.get_width()},
+                        ShardOrientation::ROW_MAJOR};
+                    auto mem_config = tt::tt_metal::MemoryConfig(
+                        attributes.output_mem_config.memory_layout(),
+                        attributes.output_mem_config.buffer_type(),
+                        shard_spec);
+                    return {TensorSpec(
+                        output_shape,
+                        TensorLayout(
+                            attributes.output_dtype.value(), PageConfig(output_layout, output_tile), mem_config))};
+                } else if constexpr (std::is_same_v<
+                                         ProgramConfigType,
+                                         operations::experimental::quasar::matmul::
+                                             MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>) {
+                    // For batched DRAM sharded matmul, use the user-provided output shard spec
+                    TT_FATAL(
+                        attributes.output_mem_config.shard_spec().has_value(),
+                        "Output memory config must have a shard spec for batched DRAM sharded matmul");
+
+                    uint32_t per_core_N = program_config.per_core_N;
+
+                    TT_FATAL(
+                        per_core_N % tile_width_ratio == 0,
+                        "per_core_N must be divisible by override output tile width");
+
+                    // Use the user-provided shard spec directly
+                    auto mem_config = attributes.output_mem_config;
+                    return {TensorSpec(
+                        output_shape,
+                        TensorLayout(
+                            attributes.output_dtype.value(), PageConfig(output_layout, output_tile), mem_config))};
+                } else if constexpr (std::is_same_v<
+                                         ProgramConfigType,
+                                         operations::experimental::quasar::matmul::
+                                             MatmulMultiCoreReuseMultiCastProgramConfig>) {
+                    const auto M = operations::experimental::quasar::matmul::utilities::get_M_dim(
+                        a_shape_padded, in0_tile, /*fuse_batch=*/true);
+                    const auto N =
+                        operations::experimental::quasar::matmul::utilities::get_N_dim(b_shape_padded, in1_tile);
+                    uint32_t per_core_M = program_config.per_core_M;
+                    uint32_t per_core_N = program_config.per_core_N;
+
+                    TT_FATAL(
+                        per_core_N % tile_width_ratio == 0,
+                        "per_core_N must be divisible by override output tile width");
+
+                    uint32_t num_blocks_y = ((M - 1) / per_core_M) + 1;
+                    uint32_t num_blocks_x = ((N - 1) / per_core_N) + 1;
+                    // The output CB is globally allocated against the output tensor on the factory's
+                    // work grid {start_core, start_core + num_blocks - 1}, so the output shard grid
+                    // computed here must match it exactly. Mirror the factory's start_core derivation
+                    // (allowed_worker_cores is the single source of truth for core placement) rather
+                    // than trusting a user-supplied output shard grid, which need not agree.
+                    const CoreCoord start_core =
+                        program_config.allowed_worker_cores.has_value()
+                            ? program_config.allowed_worker_cores.value().bounding_box().start_coord
+                            : CoreCoord{0, 0};
+                    CoreRangeSet all_cores;
+                    ShardOrientation shard_orientation;
+                    if (program_config.transpose_mcast) {
+                        all_cores = CoreRangeSet({CoreRange(
+                            start_core, {start_core.x + num_blocks_y - 1, start_core.y + num_blocks_x - 1})});
+                        shard_orientation = ShardOrientation::COL_MAJOR;
+                    } else {
+                        all_cores = CoreRangeSet({CoreRange(
+                            start_core, {start_core.x + num_blocks_x - 1, start_core.y + num_blocks_y - 1})});
+                        shard_orientation = ShardOrientation::ROW_MAJOR;
+                    }
+                    tt::tt_metal::ShardSpec shard_spec = tt::tt_metal::ShardSpec{
+                        all_cores,
+                        {per_core_M * in0_tile.get_height(), per_core_N * in1_tile.get_width()},
+                        shard_orientation};
+                    auto mem_config = tt::tt_metal::MemoryConfig(
+                        attributes.output_mem_config.memory_layout(),
+                        attributes.output_mem_config.buffer_type(),
+                        shard_spec);
+                    return {TensorSpec(
+                        output_shape,
+                        TensorLayout(
+                            attributes.output_dtype.value(), PageConfig(output_layout, output_tile), mem_config))};
+                } else if constexpr (std::is_same_v<
+                                         ProgramConfigType,
+                                         operations::experimental::quasar::matmul::MatmulMultiCoreReuseProgramConfig>) {
+                    const auto M = operations::experimental::quasar::matmul::utilities::get_M_dim(
+                        a_shape_padded, in0_tile, /*fuse_batch=*/true);
+                    const auto N =
+                        operations::experimental::quasar::matmul::utilities::get_N_dim(b_shape_padded, in1_tile);
+                    uint32_t per_core_M = program_config.per_core_M;
+                    uint32_t per_core_N = program_config.per_core_N;
+
+                    TT_FATAL(
+                        per_core_N % tile_width_ratio == 0,
+                        "per_core_N must be divisible by override output tile width");
+
+                    uint32_t num_blocks_y = ((M - 1) / per_core_M) + 1;
+                    uint32_t num_blocks_x = ((N - 1) / per_core_N) + 1;
+                    uint32_t num_cores = num_blocks_x * num_blocks_y;
+                    ShardOrientation shard_orientation = ShardOrientation::COL_MAJOR;
+                    if (input_tensor_a.is_sharded()) {
+                        shard_orientation = input_tensor_a.shard_spec().value().orientation;
+                    } else if (input_tensor_b.is_sharded()) {
+                        shard_orientation = input_tensor_b.shard_spec().value().orientation;
+                    }
+
+                    CoreRangeSet all_cores;
+                    if (attributes.output_mem_config.shard_spec().has_value()) {
+                        all_cores = attributes.output_mem_config.shard_spec()->grid;
+                    } else {
+                        auto cwsg_2d = program_config.allowed_worker_cores.value().bounding_box().grid_size();
+                        all_cores = num_cores_to_corerangeset(
+                            num_cores, cwsg_2d, shard_orientation == ShardOrientation::ROW_MAJOR);
+                    }
+                    tt::tt_metal::ShardSpec shard_spec = tt::tt_metal::ShardSpec{
+                        all_cores,
+                        {per_core_M * in0_tile.get_height(), per_core_N * in1_tile.get_width()},
+                        shard_orientation};
+                    auto mem_config = tt::tt_metal::MemoryConfig(
+                        attributes.output_mem_config.memory_layout(),
+                        attributes.output_mem_config.buffer_type(),
+                        shard_spec);
+                    return {TensorSpec(
+                        output_shape,
+                        TensorLayout(
+                            attributes.output_dtype.value(), PageConfig(output_layout, output_tile), mem_config))};
+                } else {
+                    TT_FATAL(
+                        in0_tile.get_height() == TILE_HEIGHT and in0_tile.get_width() == TILE_WIDTH,
+                        "matmul with non-optimized program config does not "
+                        "support tiny tile");
+                    TT_FATAL(
+                        in1_tile.get_height() == TILE_HEIGHT and in1_tile.get_width() == TILE_WIDTH,
+                        "matmul with non-optimized program config does not "
+                        "support tiny tile");
+                    if (attributes.output_tile.has_value()) {
+                        TT_FATAL(
+                            attributes.output_tile->get_tile_shape()[0] == TILE_HEIGHT and
+                                attributes.output_tile->get_tile_shape()[1] == TILE_WIDTH,
+                            "matmul with non-optimized program config does not "
+                            "support tiny tile");
+                    }
+                    TT_THROW("Unsupported op for output sharding");
+                    ttsl::unreachable();
+                }
+            },
+            chosen_program_config);
+    }
+
+    return {TensorSpec(
+        output_shape,
+        TensorLayout(
+            attributes.output_dtype.value(),
+            PageConfig(Layout::TILE, attributes.output_tile),
+            attributes.output_mem_config))};
+}
+
+MatmulDeviceOperation::tensor_return_value_t MatmulDeviceOperation::create_output_tensors(
+    const operation_attributes_t& attributes, const tensor_args_t& args) {
+    warn_if_allowed_worker_cores_missing(attributes.program_config, "MatmulDeviceOperation::create_output_tensors");
+    const auto& optional_output_tensors = args.optional_output_tensors;
+    const auto& input_tensors = args.input_tensors;
+    tensor_return_value_t output_tensors;
+
+    if (!optional_output_tensors.empty() and optional_output_tensors[0].has_value()) {
+        output_tensors.reserve(optional_output_tensors.size());
+        for (const auto& optional_output_tensor : optional_output_tensors) {
+            TT_FATAL(
+                optional_output_tensor.has_value(),
+                "If using optional output tensors, all output tensors must have a value");
+            output_tensors.emplace_back(optional_output_tensor.value());
+        }
+        return output_tensors;
+    }
+    const auto& device = input_tensors.at(0).device();
+    const auto& output_specs = compute_output_specs(attributes, args);
+    output_tensors.reserve(output_specs.size());
+    for (const auto& output_spec : output_specs) {
+        output_tensors.emplace_back(create_device_tensor(output_spec, device));
+    }
+    return output_tensors;
+}
+
+ttsl::hash::hash_t MatmulDeviceOperation::compute_program_hash(
+    const operation_attributes_t& attributes, const tensor_args_t& args) {
+    const auto& input_tensors = args.input_tensors;
+    const auto& input_tensor_a = input_tensors.at(0);
+    const auto& input_tensor_b = input_tensors.at(1);
+
+    auto factory = select_program_factory(attributes, args);
+
+    auto hash = tt::tt_metal::operation::hash_operation<MatmulDeviceOperation>(
+        attributes, factory.index(), input_tensor_a, input_tensor_b);
+
+    for (const auto& optional_input_tensor : args.optional_input_tensors) {
+        if (optional_input_tensor.has_value()) {
+            hash = ttsl::hash::hash_objects(hash, optional_input_tensor.value());
+        }
+    }
+
+    for (const auto& optional_output_tensor : args.optional_output_tensors) {
+        if (optional_output_tensor.has_value()) {
+            hash = ttsl::hash::hash_objects(hash, optional_output_tensor.value());
+        }
+    }
+    return hash;
+}
+
+tt::tt_metal::operation::OpPerformanceModelGeneral<MatmulDeviceOperation::tensor_return_value_t>
+MatmulDeviceOperation::create_op_performance_model(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output_tensors) {
+    using namespace tt::tt_metal;
+    const auto& input_tensor_a = tensor_args.input_tensors.at(0);
+    const auto& input_tensor_b = tensor_args.input_tensors.at(1);
+
+    const auto& in_a_shape = input_tensor_a.logical_shape();
+    const auto& out_shape = output_tensors.at(0).logical_shape();
+
+    const auto& t = output_tensors.at(0);
+    if (t.storage_type() != StorageType::DEVICE) {
+        log_warning(tt::LogOp, "Output tensor not on DEVICE?!");
+    }
+
+    const CoreCoord compute_grid = t.device()->compute_with_storage_grid_size();
+    const int num_cores = compute_grid.x * compute_grid.y;
+    // The Wormhole/Blackhole matrix engine performs 8x16 x 16x16 = 8x16 in a single cycle.
+    // This is 2*8*16*16 = 4096 muladds in a single cycle.
+    constexpr int tensix_mul_adds_per_cycle_lofi = 4096;
+
+    // Calculate number of mul/add operations
+    // TODO: add bias modeling
+    int64_t num_mul_adds_per_elem = in_a_shape[-1] * 2;  // 1 multiply and 1 add per element
+    uint32_t batch_size = get_batch_size(out_shape);
+    int64_t num_mul_adds = num_mul_adds_per_elem * out_shape[-2] * out_shape[-1] * batch_size;
+
+    MathFidelity math_fidelity = ttnn::get_math_fidelity(operation_attributes.compute_kernel_config);
+
+    int ideal_dev_clock_cycles = std::ceil(
+        ((float)num_mul_adds / (float)(num_cores * tensix_mul_adds_per_cycle_lofi)) *
+        (float)operation::OpPerformanceModel::fidelity_multiplier(math_fidelity));
+
+    operation::OpPerformanceModelGeneral<MatmulDeviceOperation::tensor_return_value_t> result(
+        {input_tensor_a, input_tensor_b}, output_tensors, ideal_dev_clock_cycles);
+
+    return result;
+}
+
+MatmulParams create_matmul_attributes(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const MatmulParams& parameters,
+    const std::vector<std::optional<Tensor>>& optional_output_tensors) {
+    tt::tt_metal::IDevice* device = input_tensor_a.device();
+    TT_FATAL(device != nullptr, "Operand to matmul must be on device");
+    auto arch = device->arch();
+    const bool has_user_grid = parameters.user_core_coord.has_value();
+    const bool has_program_config = parameters.program_config.has_value();
+    bool are_inputs_low_precision_df =
+        ((input_tensor_a.dtype() == DataType::BFLOAT8_B || input_tensor_a.dtype() == DataType::BFLOAT4_B) &&
+         (input_tensor_b.dtype() == DataType::BFLOAT8_B || input_tensor_b.dtype() == DataType::BFLOAT4_B));
+    const auto increase_fidelity = !has_program_config && !has_user_grid && !are_inputs_low_precision_df;
+    auto math_fidelity = increase_fidelity ? MathFidelity::HiFi2 : MathFidelity::LoFi;
+    bool are_inputs_32F = (input_tensor_a.dtype() == DataType::FLOAT32 && input_tensor_b.dtype() == DataType::FLOAT32);
+    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en can sometime produce incorrect results on Wormhole.
+    // When inputs are FLOAT32 (which drives fp32_dest_acc_en=True by default), use HiFi3 on Wormhole B0.
+    const auto is_wormhole = arch == tt::ARCH::WORMHOLE_B0;
+    math_fidelity = are_inputs_32F ? (is_wormhole ? MathFidelity::HiFi3 : MathFidelity::HiFi4) : math_fidelity;
+
+    bool broadcast_batch = parameters.bcast_batch.value_or(get_broadcast_batch(
+        input_tensor_a, input_tensor_b, parameters.transpose_a, parameters.transpose_b, parameters.program_config));
+    TT_FATAL(!(has_user_grid && has_program_config), "Cannot use both user core grid/coordinates and a program config");
+
+    const bool is_optional_output_tensor =
+        !optional_output_tensors.empty() && optional_output_tensors.at(0).has_value();
+    std::optional<DataType> output_dtype = parameters.output_dtype;
+    MemoryConfig output_mem_config = parameters.output_mem_config;
+
+    if (is_optional_output_tensor) {
+        const auto& optional_output_tensor = optional_output_tensors.at(0);
+        if (output_mem_config == tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {
+            output_mem_config = optional_output_tensor->memory_config();
+        } else {
+            TT_FATAL(
+                optional_output_tensor->memory_config() == output_mem_config,
+                "Memory config mismatch between optional output tensor {} & "
+                "output tensor {}",
+                optional_output_tensor->memory_config(),
+                output_mem_config);
+        }
+
+        if (output_dtype.has_value()) {
+            TT_FATAL(
+                optional_output_tensor->dtype() == output_dtype.value(),
+                "Type mismatch between optional output tensor {} & output tensor {}",
+                optional_output_tensor->dtype(),
+                output_dtype.value());
+        } else {
+            output_dtype = optional_output_tensor->dtype();
+        }
+    } else {
+        if (!output_dtype.has_value()) {
+            output_dtype = input_tensor_a.dtype();
+        }
+    }
+    bool is_float_32 = output_dtype == DataType::FLOAT32;
+    auto kernel_config_val = init_device_compute_kernel_config(
+        arch,
+        parameters.compute_kernel_config,
+        math_fidelity,
+        /*default_approx_mode=*/false,
+        /*default_fp32_acc=*/is_float_32,
+        /*default_l1_acc=*/!is_float_32);
+    ttnn::verify_numerical_configuration(arch, parameters.compute_kernel_config);
+    auto in0_tile =
+        operations::experimental::quasar::matmul::utilities::get_matmul_tile(input_tensor_a, parameters.transpose_a);
+    auto in1_tile =
+        operations::experimental::quasar::matmul::utilities::get_matmul_tile(input_tensor_b, parameters.transpose_b);
+
+    std::optional<tt::tt_metal::Tile> optional_output_tensor_tile = std::nullopt;
+    if (is_optional_output_tensor) {
+        optional_output_tensor_tile = optional_output_tensors.at(0)->tensor_spec().tile();
+    }
+    tt::tt_metal::Tile output_tile = operations::experimental::quasar::matmul::utilities::get_output_tile(
+        output_mem_config, in0_tile, in1_tile, parameters.output_tile, optional_output_tensor_tile);
+
+    return MatmulParams{
+        parameters.program_config,
+        broadcast_batch,
+        output_mem_config,
+        output_dtype,
+        kernel_config_val,
+        parameters.untilize_out,
+        parameters.user_core_coord,
+        parameters.user_fused_activation,
+        parameters.user_run_batched,
+        parameters.transpose_a,
+        parameters.transpose_b,
+        output_tile,
+        parameters.global_cb,
+        parameters.sub_device_id};
+}
+
+MatmulDeviceOperation::tensor_return_value_t matmul(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const std::optional<Tensor>& bias,
+    const std::optional<Tensor>& optional_output_tensor,
+    const MatmulParams& attributes) {
+    MatmulParams normalized_attributes = attributes;
+    if (!normalized_attributes.program_config.has_value()) {
+        uint32_t bias_single_tile_size = 0;
+        if (bias.has_value()) {
+            auto bias_data_format = tt::tt_metal::datatype_to_dataformat_converter(bias.value().dtype());
+            bias_single_tile_size = tt::tile_size(bias_data_format);
+        }
+
+        normalized_attributes.program_config = operations::experimental::quasar::matmul::get_program_config(
+            input_tensor_a,
+            input_tensor_b,
+            normalized_attributes.transpose_a,
+            normalized_attributes.transpose_b,
+            bias_single_tile_size,
+            normalized_attributes);
+    }
+    operations::experimental::quasar::matmul::normalize_program_config(
+        normalized_attributes.program_config.value(), input_tensor_a.device()->compute_with_storage_grid_size());
+    return ttnn::device_operation::launch<MatmulDeviceOperation>(
+        normalized_attributes, {{input_tensor_a, input_tensor_b}, {bias}, {optional_output_tensor}});
+}
+
+MatmulDeviceOperation::tensor_return_value_t matmul(
+    const std::vector<Tensor>& input_tensors,
+    const std::optional<Tensor>& optional_output_tensor,
+    const MatmulParams& attributes) {
+    MatmulParams normalized_attributes = attributes;
+    if (!normalized_attributes.program_config.has_value()) {
+        uint32_t bias_single_tile_size = 0;
+
+        normalized_attributes.program_config = operations::experimental::quasar::matmul::get_program_config(
+            input_tensors.at(0),
+            input_tensors.at(1),
+            normalized_attributes.transpose_a,
+            normalized_attributes.transpose_b,
+            bias_single_tile_size,
+            normalized_attributes);
+    }
+    operations::experimental::quasar::matmul::normalize_program_config(
+        normalized_attributes.program_config.value(), input_tensors.at(0).device()->compute_with_storage_grid_size());
+    return ttnn::device_operation::launch<MatmulDeviceOperation>(
+        normalized_attributes, {input_tensors, {}, {optional_output_tensor}});
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/matmul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/matmul_device_operation.hpp
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "ttnn/operation.hpp"
+
+#include "ttnn/operations/experimental/quasar/matmul/device/matmul_device_operation_types.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_program_factory.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct MatmulDeviceOperation {
+    using operation_attributes_t = MatmulParams;
+    using tensor_args_t = MatmulInputs;
+    using spec_return_value_t = std::vector<ttnn::TensorSpec>;
+    using tensor_return_value_t = std::vector<Tensor>;
+
+    using program_factory_t = std::variant<
+        MatmulMultiCoreProgramFactory,
+        MatmulMultiCoreReuseOptimizedProgramFactory,
+        MatmulMultiCoreReuseMcast1DProgramFactory,
+        MatmulMeshWorkloadMultiCoreReuseMcast1DProgramFactory,  // gather_in0 legacy path
+        MatmulMultiCoreReuseMcast2DProgramFactory,
+        MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory,
+        MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory>;
+
+    static program_factory_t select_program_factory(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static void validate_on_program_cache_miss(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static spec_return_value_t compute_output_specs(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static ttsl::hash::hash_t compute_program_hash(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
+        const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
+};
+
+MatmulParams create_matmul_attributes(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const MatmulParams& parameters,
+    const std::vector<std::optional<Tensor>>& optional_output_tensors);
+
+}  // namespace ttnn::prim::qsr
+
+namespace ttnn::prim::qsr {
+
+MatmulDeviceOperation::tensor_return_value_t matmul(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const std::optional<Tensor>& bias = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    const MatmulParams& attributes = MatmulParams());
+
+MatmulDeviceOperation::tensor_return_value_t matmul(
+    const std::vector<Tensor>& input_tensors,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    const MatmulParams& attributes = MatmulParams());
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/matmul_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/matmul_device_operation_types.hpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/operations/experimental/quasar/matmul/device/config/matmul_program_config_types.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "tt-metalium/global_circular_buffer.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operation.hpp"  // for DEFAULT_OUTPUT_MEMORY_CONFIG
+
+namespace ttnn::prim::qsr {
+
+struct MatmulParams {
+    std::optional<operations::experimental::quasar::matmul::MatmulProgramConfig> program_config = std::nullopt;
+    std::optional<bool> bcast_batch = std::nullopt;
+    tt::tt_metal::MemoryConfig output_mem_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG;
+    std::optional<tt::tt_metal::DataType> output_dtype = std::nullopt;
+    std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config = std::nullopt;
+    bool untilize_out = false;
+    std::optional<CoreCoord> user_core_coord = std::nullopt;
+    std::optional<ttnn::operations::unary::UnaryWithParam> user_fused_activation = std::nullopt;
+    bool user_run_batched = false;
+    bool transpose_a = false;
+    bool transpose_b = false;
+    std::optional<tt::tt_metal::Tile> output_tile = std::nullopt;
+    std::optional<tt::tt_metal::experimental::GlobalCircularBuffer> global_cb = std::nullopt;
+    std::optional<tt::tt_metal::SubDeviceId> sub_device_id = std::nullopt;
+};
+
+struct MatmulInputs {
+    std::vector<Tensor> input_tensors;                                // a,b, weights
+    std::vector<std::optional<const Tensor>> optional_input_tensors;  // bias
+    std::vector<std::optional<Tensor>> optional_output_tensors;       // output
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/sparse/factory/sparse_matmul_multicore_reuse_mcast_1d_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/sparse/factory/sparse_matmul_multicore_reuse_mcast_1d_optimized.cpp
@@ -1,0 +1,844 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/experimental/quasar/matmul/device/sparse/factory/sparse_matmul_multicore_reuse_mcast_1d_optimized.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/utilities/matmul_utilities.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/matmul_device_operation_types.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/config/matmul_program_config.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/config/matmul_program_config_types.hpp"
+
+#include "ttnn/operations/ccl/ccl_op_fusion.hpp"
+#include "tt-metalium/work_split.hpp"
+#include "tt-metalium/tensor_accessor_args.hpp"
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/tt_align.hpp>
+
+namespace ttnn::prim::qsr {
+
+SparseMatmulMultiCoreReuseMcast1DProgramFactory::cached_program_t
+SparseMatmulMultiCoreReuseMcast1DProgramFactory::create(
+    const ttnn::prim::qsr::SparseMatmulParams& operation_attributes,
+    const ttnn::prim::qsr::SparseMatmulInputs& tensor_args,
+    std::vector<Tensor>& tensor_return_value) {
+    tt::tt_metal::Program program{}; /* Create a program */
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler> empty_fused_op_signaler;
+    using namespace tt;
+    using namespace operations::experimental::quasar::matmul::utilities;
+
+    // from create_mesh-workload
+    auto matmul_attributes = ttnn::prim::qsr::MatmulParams{
+        operation_attributes.program_config,
+        /*bcast_batch=*/std::nullopt,
+        operation_attributes.output_mem_config,
+        operation_attributes.output_dtype,
+        operation_attributes.compute_kernel_config,
+        /*untilize_out=*/false,
+        operation_attributes.user_core_coord,
+        /*user_fused_activation=*/std::nullopt,
+        /*user_run_batched=*/false,
+        /*transpose_a=*/false,
+        /*transpose_b=*/false,
+        operation_attributes.output_tile,
+        operation_attributes.global_cb,
+        operation_attributes.sub_device_id};
+
+    auto chosen_program_config = operations::experimental::quasar::matmul::get_program_config(
+        tensor_args.input_tensors.at(0),
+        tensor_args.input_tensors.at(1),
+        /*transpose_a=*/false,
+        /*transpose_b=*/false,
+        /*bias_single_tile_size=*/0,
+        matmul_attributes);
+    operations::experimental::quasar::matmul::normalize_program_config(
+        chosen_program_config, tensor_args.input_tensors.at(0).device()->compute_with_storage_grid_size());
+
+    const auto& a = tensor_args.input_tensors.at(0);
+    const auto& b = tensor_args.input_tensors.at(1);
+    const auto& sparsity = tensor_args.input_tensors.at(2);
+    const auto& output_tensor = tensor_return_value.at(0);
+    auto program_config =
+        std::get<operations::experimental::quasar::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(
+            chosen_program_config);
+    auto compute_with_storage_grid_size = program_config.allowed_worker_cores.value().bounding_box().grid_size();
+    auto in0_block_w = program_config.in0_block_w;
+    auto out_subblock_h = program_config.out_subblock_h;
+    auto out_subblock_w = program_config.out_subblock_w;
+    auto out_block_h = program_config.out_block_h;
+    auto out_block_w = program_config.out_block_w;
+    auto per_core_M = program_config.per_core_M;
+    auto per_core_N = program_config.per_core_N;
+    auto mcast_in0 = program_config.mcast_in0;
+
+    auto nnz = operation_attributes.nnz;
+    auto is_input_a_sparse = operation_attributes.is_input_a_sparse;
+
+    const auto& ashape = get_matmul_tensor_padded_shape(a, /*transpose=*/false);
+    const auto& bshape = get_matmul_tensor_padded_shape(b, /*transpose=*/false);
+    const auto in0_tile = get_matmul_tile(a, /*transpose=*/false);
+    const auto in1_tile = get_matmul_tile(b, /*transpose=*/false);
+    // cannot use the output tensor tile directly as that might be changed by user override
+    const auto output_tile = tt::tt_metal::Tile({in0_tile.get_height(), in1_tile.get_width()});
+
+    // CB dataformats
+    const auto in0_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());
+    const auto in1_data_format = tt_metal::datatype_to_dataformat_converter(b.dtype());
+    const auto output_data_format = tt_metal::datatype_to_dataformat_converter(output_tensor.dtype());
+
+    auto* const device = a.device();
+
+    const auto in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    const auto in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    // Tiles whose size is not a multiple of the DRAM alignment (e.g. bfp8 32x16 = 544B on Blackhole's
+    // 64B alignment) are padded to it in DRAM. in0/in1 are interleaved here, so the reader copies
+    // tiles at the padded stride; the CBs must hold pages at the aligned stride and the unpacker
+    // walks tiles at the same stride. No-op when already aligned. Replaces the staging-CB workaround.
+    const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
+    const uint32_t in0_aligned_tile_size = tt::align(in0_single_tile_size, dram_alignment);
+    const uint32_t in1_aligned_tile_size = tt::align(in1_single_tile_size, dram_alignment);
+    const auto output_single_tile_size = output_tile.get_tile_size(output_data_format);
+    const auto interm0_single_tile_size = output_tile.get_tile_size(output_data_format);
+
+    auto* const in0_buffer = a.buffer();
+    auto* const in1_buffer = b.buffer();
+    auto* const sparsity_buffer = sparsity.buffer();
+    auto* const out_buffer = output_tensor.buffer();
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config.value());
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Matmul Parameters Setup
+    ////////////////////////////////////////////////////////////////////////////
+    const auto batchB = get_batch_size(bshape);
+
+    // When input A and input B are sparse, the batch dims are same.
+    // We pick batchB and set batchA to 1.
+    // When input A is sparse but B is not, both in0 and in1 need to loop over the "additional"
+    // batch dims in A that are not in B. So we divide by batchB and set that.
+    // In the default case (only input B is sparse), we set batchA to the batch dims of A.
+    uint32_t batchA;
+    if (operation_attributes.is_input_a_sparse && operation_attributes.is_input_b_sparse) {
+        batchA = 1;
+    } else if (operation_attributes.is_input_a_sparse) {
+        batchA = get_batch_size(ashape) / batchB;
+    } else {
+        batchA = get_batch_size(ashape);
+    }
+
+    const auto Mt = get_M_dim(ashape, in0_tile, /*fuse_batch=*/false);
+    const auto Kt = get_K_dim(ashape, in0_tile);
+    const auto Nt = get_N_dim(bshape, in1_tile);
+
+    TT_FATAL(Kt % in0_block_w == 0, "Kt ({}) must be divisible by in0_block_w ({})", Kt, in0_block_w);
+
+    // This should allocate a DRAM buffer on the device
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    uint32_t num_cores_available = num_cores_x * num_cores_y;
+
+    // Calculate number of blocks along x and y; tensor dims are padded up to 512
+    uint32_t num_blocks_y = ((Mt - 1) / per_core_M) + 1;
+    uint32_t num_blocks_x = ((Nt - 1) / per_core_N) + 1;
+    uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
+
+    TT_FATAL(
+        num_blocks_total <= num_cores_available,
+        "Number of blocks exceeds number of cores available: {} blocks > {} cores",
+        num_blocks_total,
+        num_cores_available);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Application Setup
+    ////////////////////////////////////////////////////////////////////////////
+    // Only support mcast_in0 for now
+    TT_FATAL(mcast_in0, "Only mcast_in0 is supported for sparse matmul");
+
+    using tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids;
+
+    uint32_t num_blocks = Kt / in0_block_w;
+    // Only enable packer l1 accumulation when there are spills, otherwise
+    // unnecessary overhead for reconfigs are added
+    bool packer_l1_acc_en = packer_l1_acc && num_blocks > 1;
+
+    // if fp32 enabled then we pack fp32 in l1, if not, then we pack fp16 in l1
+    const auto interm0_data_format = packer_l1_acc_en
+                                         ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)
+                                         : (fp32_dest_acc_en ? tt::DataFormat::Float32 : output_data_format);
+
+    uint32_t in0_block_h = out_block_h;
+    uint32_t in1_block_w = out_block_w;
+    uint32_t in0_num_blocks_y = per_core_M / out_block_h;
+    uint32_t in1_num_blocks_x = per_core_N / out_block_w;
+    uint32_t out_num_blocks_x = in1_num_blocks_x;
+    uint32_t out_num_blocks_y = in0_num_blocks_y;
+
+    uint32_t in0_block_tiles = in0_block_h * in0_block_w;
+    uint32_t in0_CB_tiles = in0_block_tiles;
+    if (batchA * batchB * num_blocks > 1) {
+        in0_CB_tiles *= ttnn::operations::experimental::quasar::matmul::utilities::MCAST_INPUT_BUFFERING_DEPTH;
+    }
+    uint32_t in0_CB_size = in0_CB_tiles * in0_aligned_tile_size;
+
+    uint32_t in1_block_tiles = out_block_w * in0_block_w;
+    uint32_t in1_CB_tiles = in1_block_tiles;
+    if (batchA * batchB * num_blocks > 1) {
+        in1_CB_tiles *= ttnn::operations::experimental::quasar::matmul::utilities::MCAST_INPUT_BUFFERING_DEPTH;
+    }
+
+    uint32_t in1_CB_size = in1_CB_tiles * in1_aligned_tile_size;
+
+    uint32_t out_block_tiles = out_block_h * out_block_w;
+    uint32_t out_CB_tiles = out_block_tiles;  // No double buffer
+
+    uint32_t out_CB_size = out_CB_tiles * output_single_tile_size;
+    uint32_t interm0_CB_tiles = out_block_tiles;  // No double buffer
+    uint32_t interm0_CB_size = interm0_CB_tiles * interm0_single_tile_size;
+
+    CoreCoord start_core = {0, 0};
+
+    // The matmul region is the rectangle of size `compute_with_storage_grid_size`
+    // anchored at `start_core`. The sparse 1D matmul path does not yet anchor at a sub-device
+    // start, but keeping the rectangle expression here keeps the API uniform with the dense 1D
+    // path and is safe (matmul_core_rect == full compute grid when start_core == (0, 0)).
+    CoreRangeSet matmul_core_rect(CoreRange(
+        start_core,
+        CoreCoord(
+            start_core.x + compute_with_storage_grid_size.x - 1, start_core.y + compute_with_storage_grid_size.y - 1)));
+
+    uint32_t num_cores_with_work = num_blocks_total;
+
+    uint32_t in0_sender_num_cores = 1;
+    uint32_t num_cores = num_cores_with_work;
+
+    constexpr bool row_major = true;
+    CoreRangeSet all_cores =
+        num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores, matmul_core_rect, row_major);
+
+    CoreRangeSet in0_mcast_sender_cores =
+        num_cores_to_corerangeset_in_subcoregrids(start_core, in0_sender_num_cores, matmul_core_rect, row_major);
+
+    CoreRangeSet all_cores_with_work =
+        num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores_with_work, matmul_core_rect, row_major);
+    CoreRange in0_mcast_receiver_cores_bounding_box = all_cores_with_work.bounding_box();
+    uint32_t in0_mcast_receiver_num_cores = in0_mcast_receiver_cores_bounding_box.size();  // always mcast to full grid
+
+    // There should not be any cores without work in the receiver grid. If a grid is
+    // not rectangular, then there will be some cores without work in the receiver grid.
+    // For example, if there are 12 blocks of work, it should be put into a 3x4 grid.
+    // If its laid out in row major with 8 cores in first row and 4 cores in second row,
+    // then there will be 4 cores without work in the receiver grid, causing a hang.
+    // We check for this below and error out.
+    TT_FATAL(
+        num_cores_with_work == in0_mcast_receiver_num_cores,
+        "num_cores_with_work ({}) must be equal to in0_mcast_receiver_num_cores ({}), please adjust the core grid to "
+        "make it rectangular.",
+        num_cores_with_work,
+        in0_mcast_receiver_num_cores);
+
+    CoreRangeSet in0_mcast_cores_with_work_and_in_receiver_grid;
+    CoreRangeSet in0_mcast_cores_without_work_and_in_receiver_grid;
+    CoreRangeSet in0_mcast_cores_without_work_and_not_in_receiver_grid;
+    CoreRangeSet in0_mcast_receivers;
+    std::vector<uint32_t> in0_mcast_noc_x;
+    std::vector<uint32_t> in0_mcast_noc_y;
+
+    in0_mcast_cores_with_work_and_in_receiver_grid = CoreRangeSet({CoreRange(start_core, start_core)});
+    if (in0_mcast_receiver_num_cores > 1) {
+        // Check against the actual rectangle width (instead of bare grid_size.x-1) so that
+        // sub-devices anchored away from (0, 0) would wrap correctly.
+        auto receiver_start_core = compute_with_storage_grid_size.x > 1 ? CoreCoord{start_core.x + 1, start_core.y}
+                                                                        : CoreCoord{start_core.x, start_core.y + 1};
+        in0_mcast_receivers =
+            num_cores_to_corerangeset_in_subcoregrids(receiver_start_core, num_cores - 1, matmul_core_rect, row_major);
+    }
+
+    // Mcast args
+    auto in0_mcast_sender_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto in0_mcast_receiver_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+
+    CoreCoord top_left_core = in0_mcast_receiver_cores_bounding_box.start_coord;
+    CoreCoord bottom_right_core = in0_mcast_receiver_cores_bounding_box.end_coord;
+    auto top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
+    auto bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
+
+    uint32_t num_batch_compute = nnz.value_or(sparsity.logical_volume());
+
+    uint32_t in0_num_subblocks = (out_block_h / out_subblock_h);
+    uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
+    const auto& a_shape_logical = get_matmul_tensor_logical_shape(a, /*transpose=*/false);
+    const auto in0_last_ktile_w = a_shape_logical[-1] % in0_tile.get_width();
+
+    // We don't support transpose for this program configuration. However, we retain the logic here
+    // to keep the code consistent with the other program configurations.
+    const auto transpose_a = false;
+    const auto transpose_b = false;
+    const auto in0_tensor_stride_w = transpose_a ? Mt : 1;
+    const auto in0_tensor_stride_h = transpose_a ? 1 : Kt;
+    const auto in0_tensor_next_block_stride = in0_block_w * in0_tensor_stride_w;
+    const auto in0_tensor_next_h_dim_block_stride = in0_block_h * in0_tensor_stride_h;
+
+    const auto in1_tensor_stride_w = transpose_b ? Kt : 1;
+    const auto in1_tensor_stride_h = transpose_b ? 1 : Nt;
+    const auto in1_tensor_next_block_stride = in0_block_w * in1_tensor_stride_h;
+    const auto in1_tensor_next_w_dim_block_stride = in1_block_w * in1_tensor_stride_w;
+
+    std::vector<uint32_t> in0_sender_compile_time_args;
+    in0_sender_compile_time_args = {
+        // in0 tensor args
+        (std::uint32_t)in0_tensor_stride_w,
+        (std::uint32_t)in0_tensor_stride_h,
+        (std::uint32_t)in0_tensor_next_block_stride,
+        (std::uint32_t)in0_tensor_next_h_dim_block_stride,
+        // in0 block args
+        (std::uint32_t)in0_block_w,          // in0_block_w
+        (std::uint32_t)in0_block_h,          // in0_block_h
+        (std::uint32_t)in0_block_num_tiles,  // in0_block_num_tiles
+        (std::uint32_t)in0_last_ktile_w,
+        (std::uint32_t)0,  // in0_last_ktile_h (transpose not supported for sparse)
+
+        (std::uint32_t)false,  // extract_shard_sub_blocks (not used for interleaved)
+        (std::uint32_t)0,      // shard_width_in_tiles (not used for interleaved)
+        (std::uint32_t)0,      // shard_height_in_tiles (not used for interleaved)
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,        // num_blocks
+        (std::uint32_t)out_num_blocks_x,  // num_blocks_x
+        (std::uint32_t)out_num_blocks_y,  // num_blocks_y
+        // in0 mcast args
+        (std::uint32_t)in0_mcast_sender_semaphore_id,
+        (std::uint32_t)in0_mcast_receiver_semaphore_id,
+        (std::uint32_t)num_cores - 1,                     // in0_mcast_num_dests
+        (std::uint32_t)in0_mcast_receiver_num_cores - 1,  // in0_mcast_num_cores
+        // batch args
+        (std::uint32_t)Mt * Kt,  // MtKt
+        (std::uint32_t)batchA,   // batchA
+        (std::uint32_t)batchA,   // batchA
+        (std::uint32_t)false,    // reuse_in0_in_CB
+        // sparsity args
+        (std::uint32_t)batchB,                                  // batchB
+        (std::uint32_t)sparsity.buffer()->aligned_page_size(),  // sparsity_pagesize
+        (std::uint32_t)!is_input_a_sparse,                      // bcast_A
+        (std::uint32_t)!nnz.has_value(),                        // get_batch_from_reader
+        // fuse op args
+        (std::uint32_t)false,  // fuse_op
+    };
+    tt::tt_metal::TensorAccessorArgs(*in0_buffer).append_to(in0_sender_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(*sparsity_buffer).append_to(in0_sender_compile_time_args);
+    // num_batch_compute (== nnz when supplied). The sender uses this to validate, on-device, that
+    // count_nonzero(sparsity) matches the loop count baked into the receiver/compute kernels, failing
+    // loudly instead of deadlocking. See https://github.com/tenstorrent/tt-metal/issues/45943.
+    in0_sender_compile_time_args.push_back((std::uint32_t)num_batch_compute);
+
+    std::vector<uint32_t> in1_sender_writer_compile_time_args = {
+        // READER
+        // in1 tensor args
+        (std::uint32_t)in1_tensor_stride_w,
+        (std::uint32_t)in1_tensor_stride_h,
+        (std::uint32_t)in1_tensor_next_block_stride,
+        (std::uint32_t)in1_tensor_next_w_dim_block_stride,
+        // in1 block args
+        (std::uint32_t)in1_block_w,                // in1_block_w
+        (std::uint32_t)in0_block_w,                // in1_block_h
+        (std::uint32_t)in1_block_w * in0_block_w,  // in1_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,        // num_blocks
+        (std::uint32_t)out_num_blocks_x,  // out_num_blocks_x
+        (std::uint32_t)out_num_blocks_y,  // out_num_blocks_y
+        // in1 mcast args
+        (std::uint32_t)0,
+        (std::uint32_t)0,
+        (std::uint32_t)0,  // in1_mcast_num_dests
+        (std::uint32_t)0,  // in1_mcast_num_cores
+        // batch args
+        (std::uint32_t)Kt * Nt,  // KtNt
+        (std::uint32_t)batchA,   // batchA
+        (std::uint32_t)true,     // bcast_B
+        // sparsity args
+        (std::uint32_t)batchB,                                  // batchB
+        (std::uint32_t)sparsity.buffer()->aligned_page_size(),  // sparsity_pagesize
+
+        // WRITER
+        // out tensor args
+        (std::uint32_t)1,                    // out_tensor_stride_w
+        (std::uint32_t)Nt,                   // out_tensor_stride_h
+        (std::uint32_t)out_subblock_w,       // out_tensor_next_subblock_stride_w
+        (std::uint32_t)out_subblock_h * Nt,  // out_tensor_next_subblock_stride_h
+        (std::uint32_t)out_block_w,          // out_tensor_next_w_dim_block_stride
+        (std::uint32_t)out_block_h * Nt,     // out_tensor_next_h_dim_block_stride
+        // out subblock args
+        (std::uint32_t)out_subblock_w,                     // out_subblock_w
+        (std::uint32_t)out_subblock_h,                     // out_subblock_h
+        (std::uint32_t)(out_subblock_w * out_subblock_h),  // out_subblocks_w * out_subblocks_h
+        // batch args
+        (std::uint32_t)Mt * Nt,  // MtNt
+        // bias args (placeholders)
+        (std::uint32_t)0,  // in3_tensor_stride_w
+        // fuse op args
+        (std::uint32_t)false,  // fuse_op
+        (std::uint32_t)false   // fuse_op_reduce_scatter
+    };
+
+    // Append TensorAccessorArgs
+    tt::tt_metal::TensorAccessorArgs(*in1_buffer).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(*sparsity_buffer).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(*out_buffer).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs().append_to(in1_sender_writer_compile_time_args);  // placeholder for bias
+
+    std::vector<uint32_t> in0_receiver_compile_time_args = {
+        // in0 block args
+        (std::uint32_t)in0_block_num_tiles,  // in0_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,        // num_blocks
+        (std::uint32_t)out_num_blocks_x,  // out_num_blocks_x
+        (std::uint32_t)out_num_blocks_y,  // out_num_blocks_y
+        // in0 mcast args
+        (std::uint32_t)in0_mcast_sender_semaphore_id,
+        (std::uint32_t)in0_mcast_receiver_semaphore_id,
+        // batch args
+        (std::uint32_t)num_batch_compute,  // batch
+        (std::uint32_t)!nnz.has_value(),   // get_batch_from_reader
+    };
+
+    std::map<std::string, std::string> mm_kernel_defines;
+    std::map<std::string, std::string> mm_kernel_in0_sender_writer_defines;
+    std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
+
+    mm_kernel_defines["FUSE_ACTIVATION"] = "0";
+    if (packer_l1_acc_en) {
+        mm_kernel_defines["PACKER_L1_ACC"] = "1";
+    }
+    if (fp32_dest_acc_en) {
+        mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+
+    ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
+        device->arch(), num_cores, mm_kernel_defines);
+    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
+        device->arch(),
+        num_cores,
+        mm_kernel_defines,
+        ttnn::get_throttle_level(operation_attributes.compute_kernel_config));
+
+    mm_kernel_in1_sender_writer_defines["SKIP_MCAST"] = "1";
+
+    // in1 is the reader of weights/output writer, and we choose to make it use the optimized reader noc
+    tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+    tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+
+    auto mm_kernel_in0_mcast_cores_with_work_and_in_receiver_grid_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+        "reader_bmm_tile_layout_in0_sender_padding.cpp",
+        in0_mcast_sender_cores,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = in0_noc,
+            .compile_args = in0_sender_compile_time_args,
+            .defines = mm_kernel_in0_sender_writer_defines,
+            .named_compile_args = {
+                {"cb_in0", tt::CBIndex::c_0},
+                {"cb_in0_sharded", tt::CBIndex::c_2},
+                {"cb_sparsity", tt::CBIndex::c_6},
+            }});
+
+    tt::tt_metal::KernelHandle mm_kernel_in0_receiver_id = 0;
+    if (in0_mcast_receivers.num_cores() > 0) {
+        mm_kernel_in0_receiver_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+            "reader_bmm_tile_layout_in0_receiver.cpp",
+            in0_mcast_receivers,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = in0_noc,
+                .compile_args = in0_receiver_compile_time_args,
+                .named_compile_args = {
+                    {"cb_in0", tt::CBIndex::c_0},
+                }});
+    }
+
+    auto mm_kernel_in1_sender_writer_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/"
+        "reader_bmm_tile_layout_in1_sender_writer_padding.cpp",
+        all_cores_with_work,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = in1_noc,
+            .compile_args = in1_sender_writer_compile_time_args,
+            .defines = mm_kernel_in1_sender_writer_defines,
+            .named_compile_args = {
+                {"cb_in1", tt::CBIndex::c_1},
+                {"cb_bias", tt::CBIndex::c_3},
+                {"cb_out", tt::CBIndex::c_4},
+                {"cb_sparsity", tt::CBIndex::c_7},
+            }});
+
+    // Compute kernel compile time args
+    uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
+
+    uint32_t in1_num_subblocks = (out_block_w / out_subblock_w);
+    uint32_t in1_block_num_tiles = out_subblock_w * in0_block_w * in1_num_subblocks;
+    uint32_t in1_per_core_w = out_subblock_w * in1_num_subblocks;
+
+    uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
+
+    std::vector<uint32_t> compute_kernel_args = {
+        in0_block_w,             // in0_block_w
+        in0_num_subblocks,       // in0_num_subblocks
+        in0_block_num_tiles,     // in0_block_num_tiles
+        in0_subblock_num_tiles,  // in0_subblock_num_tiles
+
+        in1_num_subblocks,    // in1_num_subblocks
+        in1_block_num_tiles,  // in1_block_num_tiles
+        in1_per_core_w,       // in1_per_core_w
+
+        num_blocks,        // num_blocks
+        out_num_blocks_x,  // out_num_blocks_x
+        out_num_blocks_y,  // out_num_blocks_y
+
+        out_subblock_h,          // out_subblock_h
+        out_subblock_w,          // out_subblock_w
+        out_subblock_num_tiles,  // out_subblock_num_tiles
+        num_batch_compute,       // batch_nnz
+        out_block_tiles,         // out_block_num_tiles
+
+        false,             // untilize_out
+        !nnz.has_value(),  // get_batch_from_reader
+        false,             // in0_transpose_tile
+    };
+
+    // Create compute kernel
+    // bool fp32_dest_acc_en = false;
+    // Gelu currently has better accuracy when run in approx mode
+    // bool math_approx_mode = false;
+    tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/"
+        "bmm_large_block_zm_fused_bias_activation.cpp",
+        all_cores_with_work,
+        tt_metal::ComputeConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .math_approx_mode = math_approx_mode,
+            .compile_args = compute_kernel_args,
+            .defines = mm_kernel_defines,
+            .named_compile_args = {
+                {"cb_in0", tt::CBIndex::c_0},
+                {"cb_in1", tt::CBIndex::c_1},
+                {"cb_bias", tt::CBIndex::c_3},
+                {"cb_out", tt::CBIndex::c_4},
+                {"cb_intermed0", tt::CBIndex::c_5},
+                {"cb_in0_transposed", tt::CBIndex::c_10},
+            }});
+
+    // Create circular buffers
+    uint32_t src0_cb_index = tt::CBIndex::c_0;
+    tt_metal::CircularBufferConfig src0_cb_config =
+        tt_metal::CircularBufferConfig(in0_CB_size, {{src0_cb_index, in0_data_format}})
+            .set_page_size(src0_cb_index, in0_aligned_tile_size)
+            .set_tile_dims(src0_cb_index, in0_tile);
+    tt_metal::CreateCircularBuffer(program, all_cores, src0_cb_config);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        src0_cb_index,
+        in0_single_tile_size,
+        in0_CB_size / in0_single_tile_size,
+        in0_CB_size);
+
+    uint32_t src1_cb_index = tt::CBIndex::c_1;
+    tt_metal::CircularBufferConfig src1_cb_config =
+        tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_data_format}})
+            .set_page_size(src1_cb_index, in1_aligned_tile_size)
+            .set_tile_dims(src1_cb_index, in1_tile);
+
+    auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        src1_cb_index,
+        in1_single_tile_size,
+        in1_CB_size / in1_single_tile_size,
+        in1_CB_size);
+
+    tt::tt_metal::CBHandle cb_src2 = 0;
+
+    uint32_t output_cb_index = tt::CBIndex::c_4;
+    uint32_t interm0_cb_index = tt::CBIndex::c_5;
+    tt_metal::CircularBufferConfig interm0_cb_config =
+        tt_metal::CircularBufferConfig(0, {{interm0_cb_index, interm0_data_format}});
+    tt_metal::CircularBufferConfig output_cb_config =
+        tt_metal::CircularBufferConfig(0, {{output_cb_index, output_data_format}});
+
+    uint32_t sparsity_cb_index0 = tt::CBIndex::c_6;
+    uint32_t sparsity_cb_index1 = tt::CBIndex::c_7;
+
+    uint32_t sparsity_cb_size = sparsity.buffer()->aligned_page_size();
+    tt_metal::CircularBufferConfig sparsity_cb_config0 =
+        tt_metal::CircularBufferConfig(
+            sparsity_cb_size, {{sparsity_cb_index0, tt::tt_metal::datatype_to_dataformat_converter(sparsity.dtype())}})
+            .set_page_size(sparsity_cb_index0, sparsity_cb_size);
+    tt_metal::CircularBufferConfig sparsity_cb_config1 =
+        tt_metal::CircularBufferConfig(
+            sparsity_cb_size, {{sparsity_cb_index1, tt::tt_metal::datatype_to_dataformat_converter(sparsity.dtype())}})
+            .set_page_size(sparsity_cb_index1, sparsity_cb_size);
+
+    tt_metal::CreateCircularBuffer(program, all_cores, sparsity_cb_config0);
+    tt_metal::CreateCircularBuffer(program, all_cores, sparsity_cb_config1);
+
+    if (interm0_data_format != output_data_format) {
+        // output
+        std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
+            {output_cb_index, output_data_format},
+        };
+        output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
+                               .set_page_size(output_cb_index, output_single_tile_size)
+                               .set_tile_dims(output_cb_index, output_tile);
+        // interm0
+        std::map<uint8_t, tt::DataFormat> interm0_cb_data_format_spec{
+            {interm0_cb_index, interm0_data_format},
+        };
+        interm0_cb_config = tt_metal::CircularBufferConfig(interm0_CB_size, interm0_cb_data_format_spec)
+                                .set_page_size(interm0_cb_index, interm0_single_tile_size)
+                                .set_tile_dims(interm0_cb_index, output_tile);
+
+        tt_metal::CreateCircularBuffer(program, CoreRangeSet({all_cores}), interm0_cb_config);
+        log_debug(
+            LogOp,
+            "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+            interm0_cb_index,
+            interm0_single_tile_size,
+            interm0_CB_size / interm0_single_tile_size,
+            interm0_CB_size);
+    } else {
+        // share buffer
+        std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
+            {output_cb_index, output_data_format}, {interm0_cb_index, interm0_data_format}};
+        output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
+                               .set_page_size(output_cb_index, output_single_tile_size)
+                               .set_page_size(interm0_cb_index, interm0_single_tile_size)
+                               .set_tile_dims(output_cb_index, output_tile)
+                               .set_tile_dims(interm0_cb_index, output_tile);
+    }
+
+    auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        output_cb_index,
+        output_single_tile_size,
+        out_CB_size / output_single_tile_size,
+        out_CB_size);
+
+    // Parameters for last row, col, or block, no need to re-calc h-dim since there's no split on height
+    uint32_t last_per_core_N = Nt % per_core_N == 0 ? per_core_N : Nt % per_core_N;
+    uint32_t last_out_block_w = last_per_core_N % out_block_w == 0 ? out_block_w : last_per_core_N % out_block_w;
+    uint32_t last_out_num_blocks_w = ((last_per_core_N - 1) / out_block_w) + 1;
+    uint32_t last_block_num_nonzero_subblocks_w = ((last_out_block_w - 1) / out_subblock_w) + 1;
+    uint32_t last_subblock_of_last_block_w =
+        last_out_block_w % out_subblock_w == 0 ? out_subblock_w : last_out_block_w % out_subblock_w;
+    uint32_t last_block_padded_subblock_tiles_addr_skip =
+        output_single_tile_size * (out_subblock_w - last_subblock_of_last_block_w);
+    uint32_t last_block_padded_block_tiles_w_skip =
+        (out_subblock_w * out_subblock_h) * (out_block_w / out_subblock_w - last_block_num_nonzero_subblocks_w);
+
+    CoreCoord start_core_noc = top_left_core_physical;
+    CoreCoord end_core_noc = bottom_right_core_physical;
+    if (in0_noc == tt::tt_metal::NOC::NOC_1) {
+        std::swap(start_core_noc, end_core_noc);
+    }
+
+    const auto& cores = corerange_to_cores(all_cores, std::nullopt, row_major);
+    for (uint32_t i = 0; i < num_cores; ++i) {
+        const auto& core = cores[i];
+        uint32_t output_idx_x = i % num_blocks_x;
+        uint32_t output_idx_y = i / num_blocks_x;
+
+        // in0 sender and in1 sender
+        if (core == start_core) {
+            std::vector<uint32_t> mm_in0_sender_args = {
+                // in0 tensor args
+                (std::uint32_t)in0_buffer->address(),
+                (std::uint32_t)Kt * per_core_M * output_idx_y,  // in0_tensor_start_tile_id
+                // in0 mcast args
+                (std::uint32_t)start_core_noc.x,  // in0_mcast_dest_noc_start_x
+                (std::uint32_t)start_core_noc.y,  // in0_mcast_dest_noc_start_y
+                (std::uint32_t)end_core_noc.x,    // in0_mcast_dest_noc_end_x
+                (std::uint32_t)end_core_noc.y,    // in0_mcast_dest_noc_end_y
+
+                // padding args
+                (std::uint32_t)out_block_h,  // last_block_h
+                // sparsity args
+                (std::uint32_t)sparsity_buffer->address()  // sparsity_addr
+            };
+
+            tt_metal::SetRuntimeArgs(
+                program,
+                mm_kernel_in0_mcast_cores_with_work_and_in_receiver_grid_id,
+                core,
+                mm_in0_sender_args);  // RISCV_0_default
+        }
+        // in0 receiver and in 1 sender
+        else {
+            std::vector<uint32_t> mm_in0_receiver_args = {
+                // in0 mcast args
+                (std::uint32_t)top_left_core_physical.x,  // in0_mcast_sender_noc_x
+                (std::uint32_t)top_left_core_physical.y   // in0_mcast_sender_noc_y
+            };
+            tt_metal::SetRuntimeArgs(program, mm_kernel_in0_receiver_id, core, mm_in0_receiver_args);
+        }
+        if (i < num_cores_with_work) {
+            std::vector<uint32_t> mm_in1_sender_writer_args = {
+                // READER
+                // in1 tensor args
+                (std::uint32_t)in1_buffer->address(),
+                (std::uint32_t)per_core_N * output_idx_x,  // in1_tensor_start_tile_id
+                // in1 mcast args
+                (std::uint32_t)0,  // in1_mcast_dest_noc_start_x
+                (std::uint32_t)0,  // in1_mcast_dest_noc_start_y
+                (std::uint32_t)0,  // in1_mcast_dest_noc_end_x
+                (std::uint32_t)0,  // in1_mcast_dest_noc_end_y
+
+                // sparsity args
+                (std::uint32_t)sparsity_buffer->address(),  // sparsity_addr
+
+                // WRITER
+                // out tensor args
+                (std::uint32_t)out_buffer->address(),
+                ((std::uint32_t)output_idx_x * per_core_N) +
+                    (output_idx_y * per_core_M * Nt)  // out_tensor_start_tile_id
+            };
+
+            if (output_idx_x == num_blocks_x - 1) {
+                // padding args (READER)
+                mm_in1_sender_writer_args.push_back(last_out_block_w);
+
+                // padding args (WRITER)
+                mm_in1_sender_writer_args.push_back(out_block_h / out_subblock_h);
+                mm_in1_sender_writer_args.push_back(out_subblock_h);
+                mm_in1_sender_writer_args.push_back(0);
+                mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);  // out_num_nonzero_subblocks_w
+                mm_in1_sender_writer_args.push_back(last_block_num_nonzero_subblocks_w);
+                mm_in1_sender_writer_args.push_back(last_subblock_of_last_block_w);
+                mm_in1_sender_writer_args.push_back(last_block_padded_subblock_tiles_addr_skip);
+                mm_in1_sender_writer_args.push_back(last_block_padded_block_tiles_w_skip);
+            } else {
+                // padding args (READER)
+                mm_in1_sender_writer_args.push_back(out_block_w);
+
+                // padding args (WRITER)
+                mm_in1_sender_writer_args.push_back(out_block_h / out_subblock_h);
+                mm_in1_sender_writer_args.push_back(out_subblock_h);
+                mm_in1_sender_writer_args.push_back(0);
+                mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);  // out_num_nonzero_subblocks_w
+                mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
+                mm_in1_sender_writer_args.push_back(out_subblock_w);
+                mm_in1_sender_writer_args.push_back(0);
+                mm_in1_sender_writer_args.push_back(0);
+            }
+
+            mm_in1_sender_writer_args.push_back(0);
+            mm_in1_sender_writer_args.push_back(0);
+
+            if (output_idx_x == num_blocks_x - 1) {
+                mm_in1_sender_writer_args.push_back(last_out_num_blocks_w);
+            } else {
+                mm_in1_sender_writer_args.push_back(out_num_blocks_x);
+            }
+
+            mm_in1_sender_writer_args.push_back(0);
+            mm_in1_sender_writer_args.push_back(0);
+            mm_in1_sender_writer_args.push_back(0);
+            mm_in1_sender_writer_args.push_back(0);
+            mm_in1_sender_writer_args.push_back(0);
+
+            tt_metal::SetRuntimeArgs(
+                program, mm_kernel_in1_sender_writer_id, core, mm_in1_sender_writer_args);  // RISCV_0_default
+        }
+    }
+
+    auto shared_vars = SparseMatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t{
+        {mm_kernel_in0_mcast_cores_with_work_and_in_receiver_grid_id, mm_kernel_in1_sender_writer_id},
+        {cb_src1, cb_src2, cb_output},
+        false,
+        start_core,
+        cores,
+        num_cores_with_work,
+        ttnn::prim::qsr::Matmul1DType::MCAST_IN0};
+
+    return {std::move(program), std::move(shared_vars)};
+}
+
+void SparseMatmulMultiCoreReuseMcast1DProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const ttnn::prim::qsr::SparseMatmulParams& /*operation_attributes*/,
+    const ttnn::prim::qsr::SparseMatmulInputs& tensor_args,
+    std::vector<Tensor>& tensor_return_value) {
+    auto& program = cached_program.program;
+    auto& shared_vars = cached_program.shared_variables;
+
+    auto* src_buffer_a = tensor_args.input_tensors.at(0).buffer();
+    auto* src_buffer_b = tensor_args.input_tensors.at(1).buffer();
+    auto* sparsity_buffer = tensor_args.input_tensors.at(2).buffer();
+    auto* dst_buffer = tensor_return_value.at(0).buffer();
+
+    // Manually unroll sender core
+    // in0 sender
+    auto& reader_sender_runtime_args = GetRuntimeArgs(program, shared_vars.kernels.at(0), shared_vars.start_core);
+    reader_sender_runtime_args[0] = src_buffer_a->address();
+    reader_sender_runtime_args[7] = sparsity_buffer->address();
+
+    auto& writer_runtime_args_by_core = GetRuntimeArgs(program, shared_vars.kernels.at(1));
+
+    for (uint32_t i = 0; i < shared_vars.num_cores_with_work; ++i) {
+        const auto& core = shared_vars.cores[i];
+
+        auto& writer_runtime_args = writer_runtime_args_by_core[core.x][core.y];
+
+        // in1 sender
+        writer_runtime_args[0] = src_buffer_b->address();
+        writer_runtime_args[6] = sparsity_buffer->address();
+        writer_runtime_args[7] = dst_buffer->address();
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////
+//                      Mesh Workload Setup
+////////////////////////////////////////////////////////////////////////////
+
+SparseMatmulMeshWorkloadMultiCoreReuseMcast1DFactory::cached_mesh_workload_t
+SparseMatmulMeshWorkloadMultiCoreReuseMcast1DFactory::create_mesh_workload(
+    const ttnn::prim::qsr::SparseMatmulParams& attributes,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const ttnn::prim::qsr::SparseMatmulInputs& tensor_args,
+    std::vector<Tensor>& output) {
+    tt::tt_metal::distributed::MeshWorkload workload;
+    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
+    for (const auto& mesh_coord_range : tensor_coords.ranges()) {
+        for (const auto& mesh_coord : mesh_coord_range) {
+            const ttnn::MeshCoordinateRange mesh_coord_range{mesh_coord, mesh_coord};
+            auto single_device_program =
+                SparseMatmulMultiCoreReuseMcast1DProgramFactory::create(attributes, tensor_args, output);
+            shared_variables[mesh_coord_range] = single_device_program.shared_variables;
+            workload.add_program(mesh_coord_range, std::move(single_device_program.program));
+        }
+    }
+    return {std::move(workload), std::move(shared_variables)};
+}
+
+void SparseMatmulMeshWorkloadMultiCoreReuseMcast1DFactory::override_runtime_arguments(
+    cached_mesh_workload_t& cached_workload,
+    const ttnn::prim::qsr::SparseMatmulParams& attributes,
+    const ttnn::prim::qsr::SparseMatmulInputs& tensor_args,
+    std::vector<Tensor>& tensor_return_value) {
+    for (auto& [mesh_coord_range, program] : cached_workload.workload.get_programs()) {
+        auto cached_program_proxy = SparseMatmulMultiCoreReuseMcast1DProgramFactory::cached_program_t::proxy(
+            program, cached_workload.shared_variables.at(mesh_coord_range));
+        SparseMatmulMultiCoreReuseMcast1DProgramFactory::override_runtime_arguments(
+            cached_program_proxy, attributes, tensor_args, tensor_return_value);
+    }
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/sparse/factory/sparse_matmul_multicore_reuse_mcast_1d_optimized.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/sparse/factory/sparse_matmul_multicore_reuse_mcast_1d_optimized.hpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/sparse/sparse_matmul_device_operation_types.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/matmul_1d_type.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct SparseMatmulMultiCoreReuseMcast1DProgramFactory {
+    struct shared_variables_t {
+        std::vector<tt::tt_metal::KernelHandle> kernels;
+        std::vector<tt::tt_metal::CBHandle> cbs;
+        bool extract_shard_sub_blocks{};
+        CoreCoord start_core;
+        std::vector<CoreCoord> cores;
+        uint32_t num_cores_with_work{};
+        ttnn::prim::qsr::Matmul1DType type{};
+    };
+
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const ttnn::prim::qsr::SparseMatmulParams& operation_attributes,
+        const ttnn::prim::qsr::SparseMatmulInputs& tensor_args,
+        std::vector<Tensor>& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const ttnn::prim::qsr::SparseMatmulParams& operation_attributes,
+        const ttnn::prim::qsr::SparseMatmulInputs& tensor_args,
+        std::vector<Tensor>& tensor_return_value);
+};
+
+struct SparseMatmulMeshWorkloadMultiCoreReuseMcast1DFactory {
+    using shared_variables_t = SparseMatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t;
+    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
+
+    static cached_mesh_workload_t create_mesh_workload(
+        const ttnn::prim::qsr::SparseMatmulParams& attributes,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
+        const ttnn::prim::qsr::SparseMatmulInputs& tensor_args,
+        std::vector<Tensor>& output);
+
+    static void override_runtime_arguments(
+        cached_mesh_workload_t& cached_workload,
+        const ttnn::prim::qsr::SparseMatmulParams& operation_attributes,
+        const ttnn::prim::qsr::SparseMatmulInputs& tensor_args,
+        std::vector<Tensor>& tensor_return_value);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/sparse/sparse_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/sparse/sparse_matmul_device_operation.cpp
@@ -1,0 +1,371 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/experimental/quasar/matmul/device/sparse/sparse_matmul_device_operation.hpp"
+#include "ttnn/operations/creation/creation.hpp"
+#include "ttnn/tensor/tensor_ops.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/utilities/matmul_utilities.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/matmul_device_operation_types.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/matmul_device_operation.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/config/matmul_program_config_types.hpp"
+
+#include <tt-metalium/work_split.hpp>
+
+namespace {
+
+/**
+ * @brief Computes the output shape of a sparse matmul operation given two input tensors.
+ *
+ * The output shape for a sparse matmul is the same as for a dense matmul, but allows for
+ * batching on both input tensors.
+ * The final output shape as batched dimensions from input B first (inner), then input A (outer).
+ * @param input_tensor_a First input tensor
+ * @param input_tensor_b Second input tensor
+ * @return Shape of the resulting tensor after sparse matmul
+ */
+ttnn::Shape compute_sparse_matmul_output_shape(
+    const ttnn::Tensor& input_tensor_a,
+    const ttnn::Tensor& input_tensor_b,
+    bool is_input_a_sparse,
+    bool is_input_b_sparse) {
+    const auto& input_shape_a = input_tensor_a.logical_shape();
+    const auto& input_shape_b = input_tensor_b.logical_shape();
+
+    const auto a_rank = input_shape_a.rank();
+    const auto b_rank = input_shape_b.rank();
+
+    // Decide the rank of the output shape based on batch dimensions in input tensors
+    // Find batched dimensions in both. Add batched dimensions from both to output rank and then add 2
+    // Batched dimensions are all dimensions except the last two
+    uint32_t a_batched_dims = ((is_input_a_sparse && is_input_b_sparse) || (a_rank <= 2)) ? 0 : (a_rank - 2);
+    uint32_t b_batched_dims = ((is_input_a_sparse && !is_input_b_sparse) || (b_rank <= 2)) ? 0 : (b_rank - 2);
+    uint32_t output_rank = a_batched_dims + b_batched_dims + 2;
+
+    // Initialize output shape with zeros based on the output rank
+    ttnn::Shape output_shape(std::vector<uint32_t>(output_rank, 0));
+
+    // First pick the M and N dimensions from the input tensors
+    output_shape[-2] = input_shape_a[-2];
+    output_shape[-1] = input_shape_b[-1];
+
+    // Add batched dims from input B to output shape
+    for (uint32_t i = 0; i < b_batched_dims; ++i) {
+        output_shape[-3 - i] = input_shape_b[-3 - i];
+    }
+
+    // Add batched dims from input A to output shape
+    for (uint32_t i = 0; i < a_batched_dims; ++i) {
+        output_shape[-3 - b_batched_dims - i] = input_shape_a[-3 - i];
+    }
+
+    return output_shape;
+}
+}  // namespace
+
+namespace ttnn::prim::qsr {
+
+void SparseMatmulDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    using namespace operations::experimental::quasar::matmul::utilities;
+    const auto& input_tensor_a = tensor_args.input_tensors.at(0);
+    const auto& input_tensor_b = tensor_args.input_tensors.at(1);
+    const auto& sparsity = tensor_args.input_tensors.at(2);
+
+    const auto& a_shape_padded = get_matmul_tensor_padded_shape(input_tensor_a, /*transpose=*/false);
+    const auto& b_shape_padded = get_matmul_tensor_padded_shape(input_tensor_b, /*transpose=*/false);
+    auto in0_tile = get_matmul_tile(input_tensor_a, /*transpose=*/false);
+    auto in1_tile = get_matmul_tile(input_tensor_b, /*transpose=*/false);
+
+    TT_FATAL(
+        a_shape_padded[-1] == b_shape_padded[-2],
+        "Dimension K (A.shape[-1] {}) and B.shape[-2] ({}) must match for A and B",
+        a_shape_padded[-1],
+        b_shape_padded[-2]);
+    TT_FATAL(
+        a_shape_padded[-2] % in0_tile.get_height() == 0,
+        "a_shape_padded[-2] (A's rows: {}) must be divisible by in0_tile.get_height() (A's tile height: {}) for "
+        "tilization. "
+        "a_shape_padded: {}, in0_tile: {}",
+        a_shape_padded[-2],
+        in0_tile.get_height(),
+        a_shape_padded,
+        in0_tile);
+    TT_FATAL(
+        a_shape_padded[-1] % in0_tile.get_width() == 0,
+        "a_shape_padded[-1] (A's cols: {}) must be divisible by in0_tile.get_width() (A's tile width: {}) for "
+        "tilization. "
+        "a_shape_padded: "
+        "{}, in0_tile: {}",
+        a_shape_padded[-1],
+        in0_tile.get_width(),
+        a_shape_padded,
+        in0_tile);
+    TT_FATAL(
+        b_shape_padded[-2] % in1_tile.get_height() == 0,
+        "b_shape_padded[-2] (B's rows: {}) must be divisible by in1_tile.get_height() (B's tile height: {}) for "
+        "tilization. "
+        "b_shape_padded: {}, in1_tile_shape: {}",
+        b_shape_padded[-2],
+        in1_tile.get_height(),
+        b_shape_padded,
+        in1_tile);
+    TT_FATAL(
+        b_shape_padded[-1] % in1_tile.get_width() == 0,
+        "b_shape_padded[-1] (B's cols: {}) must be divisible by in1_tile_shape[1] (B's tile width: {}) for tilization. "
+        "b_shape_padded: "
+        "{}, in1_tile: {}",
+        b_shape_padded[-1],
+        in1_tile.get_width(),
+        b_shape_padded,
+        in1_tile);
+    TT_FATAL(
+        operation_attributes.nnz.value_or(1) > 0, "nnz ({}) must be greater than 0", operation_attributes.nnz.value());
+
+    // Check that nnz is less than or equal to the length of all batch dimensions
+    uint32_t batch_length_A = 1;
+    if (a_shape_padded.rank() > 2) {
+        for (int i = 0; i < a_shape_padded.rank() - 2; ++i) {
+            batch_length_A *= a_shape_padded[i];
+        }
+    }
+
+    uint32_t batch_length_B = 1;
+    if (b_shape_padded.rank() > 2) {
+        for (int i = 0; i < b_shape_padded.rank() - 2; ++i) {
+            batch_length_B *= b_shape_padded[i];
+        }
+    }
+
+    uint32_t batch_length = 0;
+    if (operation_attributes.is_input_a_sparse && operation_attributes.is_input_b_sparse) {
+        batch_length = batch_length_B;
+    } else if (operation_attributes.is_input_a_sparse) {
+        batch_length = batch_length_A;
+    } else {
+        batch_length = batch_length_A * batch_length_B;
+    }
+
+    // Check that sparsity has enough entries
+    TT_FATAL(
+        sparsity.logical_volume() == batch_length,
+        "sparsity.logical_volume() ({}) must be equal to the product of all batch dimensions ({})",
+        sparsity.logical_volume(),
+        batch_length);
+
+    TT_FATAL(
+        operation_attributes.nnz.value_or(1) <= batch_length,
+        "nnz ({}) must be less than or equal to the length of all batch dimensions ({})",
+        operation_attributes.nnz,
+        batch_length);
+
+    // When nnz is supplied, the receiver and compute kernels loop exactly nnz times while the in0 sender
+    // only multicasts once per non-zero sparsity entry. The op therefore requires
+    // count_nonzero(sparsity) == nnz; a mismatch deadlocks the device (see issue #45943).
+    // count_nonzero(sparsity) is data-dependent and lives on device, so it cannot be checked here on the
+    // host -- it is the caller's responsibility to pass an exact nnz, and the contract is validated
+    // on-device in reader_bmm_tile_layout_in0_sender_padding.cpp (asserts loudly under watcher instead of
+    // hanging).
+}
+
+SparseMatmulDeviceOperation::spec_return_value_t SparseMatmulDeviceOperation::compute_output_specs(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    using namespace operations::experimental::quasar::matmul::utilities;
+    TT_FATAL(
+        tensor_args.optional_output_tensors.size() <= 1,
+        "None or One Optional output tensor can be passed when accessing it "
+        "for computing SparseMatmul's output specs");
+
+    const bool is_output_tensor_given =
+        !tensor_args.optional_output_tensors.empty() && tensor_args.optional_output_tensors.at(0).has_value();
+
+    if (is_output_tensor_given) {
+        return {tensor_args.optional_output_tensors.at(0)->tensor_spec()};
+    }
+
+    const auto& input_tensor_a = tensor_args.input_tensors.at(0);
+    const auto& input_tensor_b = tensor_args.input_tensors.at(1);
+
+    const auto output_shape = compute_sparse_matmul_output_shape(
+        input_tensor_a, input_tensor_b, operation_attributes.is_input_a_sparse, operation_attributes.is_input_b_sparse);
+
+    const auto output_dtype = operation_attributes.output_dtype.has_value() ? operation_attributes.output_dtype.value()
+                                                                            : input_tensor_a.dtype();
+
+    auto in0_tile = get_matmul_tile(input_tensor_a, /*transpose=*/false);
+    auto in1_tile = get_matmul_tile(input_tensor_b, /*transpose=*/false);
+
+    tt::tt_metal::Tile output_tile = operations::experimental::quasar::matmul::utilities::get_output_tile(
+        operation_attributes.output_mem_config,
+        in0_tile,
+        in1_tile,
+        operation_attributes.output_tile,
+        /*optional_output_tensor_tile=*/std::nullopt);
+
+    return {TensorSpec(
+        output_shape,
+        tt::tt_metal::TensorLayout(
+            output_dtype,
+            tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE, output_tile),
+            operation_attributes.output_mem_config))};
+}
+
+SparseMatmulDeviceOperation::tensor_return_value_t SparseMatmulDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    SparseMatmulDeviceOperation::tensor_return_value_t output_tensors;
+    const auto& optional_output_tensors = tensor_args.optional_output_tensors;
+    const auto& input_tensors = tensor_args.input_tensors;
+
+    if (!optional_output_tensors.empty() and optional_output_tensors[0].has_value()) {
+        output_tensors.reserve(optional_output_tensors.size());
+        for (const auto& optional_output_tensor : optional_output_tensors) {
+            TT_FATAL(
+                optional_output_tensor.has_value(),
+                "If using optional output tensors, all output tensors must have a value");
+            output_tensors.emplace_back(optional_output_tensor.value());
+        }
+        for (auto& output_tensor : output_tensors) {
+            output_tensor = ttnn::zeros_like(
+                output_tensor,
+                std::nullopt,
+                std::nullopt,
+                std::nullopt,
+                std::nullopt,
+                std::optional<Tensor>(output_tensor));
+        }
+        return output_tensors;
+    }
+    const auto& device = input_tensors.at(0).device();
+    const auto& output_specs = compute_output_specs(operation_attributes, tensor_args);
+    output_tensors.reserve(output_specs.size());
+    for (const auto& output_spec : output_specs) {
+        output_tensors.emplace_back(create_device_tensor(output_spec, device));
+    }
+    for (auto& output_tensor : output_tensors) {
+        output_tensor = ttnn::zeros_like(
+            output_tensor,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::optional<Tensor>(output_tensor));
+    }
+    return output_tensors;
+}
+
+// static ttsl::hash::hash_t SparseMatmulDeviceOperation::compute_program_hash(
+//     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+std::tuple<SparseMatmulParams, SparseMatmulInputs> sparse_matmul_build_operation_args(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const Tensor& sparsity,
+    const std::optional<Tensor>& optional_output_tensor,
+    std::optional<uint32_t> nnz,
+    bool is_input_a_sparse,
+    bool is_input_b_sparse,
+    const std::optional<const MemoryConfig>& memory_config,
+    std::optional<const DataType> dtype,
+    const std::optional<const operations::experimental::quasar::matmul::MatmulProgramConfig>& program_config,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
+    const std::optional<const CoreCoord>& user_core_coord,
+    const std::optional<const tt::tt_metal::Tile>& output_tile,
+    const std::optional<const GlobalCircularBuffer>& global_cb,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    auto sparse_matmul_attributes = SparseMatmulParams{
+        nnz,
+        is_input_a_sparse,
+        is_input_b_sparse,
+        program_config,
+        memory_config.has_value() ? memory_config.value() : ttnn::DRAM_MEMORY_CONFIG,
+        dtype,
+        compute_kernel_config,
+        user_core_coord,
+        output_tile,
+        global_cb,
+        sub_device_id};
+
+    auto parameters = create_sparse_matmul_attributes(
+        input_tensor_a, input_tensor_b, sparsity, sparse_matmul_attributes, {optional_output_tensor});
+
+    return {parameters, SparseMatmulInputs{{input_tensor_a, input_tensor_b, sparsity}, {}, {optional_output_tensor}}};
+}
+
+SparseMatmulDeviceOperation::tensor_return_value_t sparse_matmul(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const Tensor& sparsity,
+    const std::optional<Tensor>& optional_output_tensor,
+    std::optional<uint32_t> nnz,
+    bool is_input_a_sparse,
+    bool is_input_b_sparse,
+    const std::optional<const MemoryConfig>& memory_config,
+    std::optional<const DataType> dtype,
+    const std::optional<const operations::experimental::quasar::matmul::MatmulProgramConfig>& program_config,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
+    const std::optional<const CoreCoord>& user_core_coord,
+    const std::optional<const tt::tt_metal::Tile>& output_tile,
+    const std::optional<const GlobalCircularBuffer>& global_cb,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    auto [params, inputs] = sparse_matmul_build_operation_args(
+        input_tensor_a,
+        input_tensor_b,
+        sparsity,
+        optional_output_tensor,
+        nnz,
+        is_input_a_sparse,
+        is_input_b_sparse,
+        memory_config,
+        std::move(dtype),
+        program_config,
+        std::move(compute_kernel_config),
+        user_core_coord,
+        output_tile,
+        global_cb,
+        sub_device_id);
+    return ttnn::device_operation::launch<SparseMatmulDeviceOperation>(params, inputs);
+}
+
+SparseMatmulParams create_sparse_matmul_attributes(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const Tensor& /*sparsity*/,
+    const SparseMatmulParams& parameters,
+    const std::vector<std::optional<Tensor>>& optional_output_tensors) {
+    auto matmul_attributes = MatmulParams{
+        parameters.program_config,
+        /*bcast_batch=*/std::nullopt,
+        parameters.output_mem_config,
+        parameters.output_dtype,
+        parameters.compute_kernel_config,
+        /*untilize_out=*/false,
+        parameters.user_core_coord,
+        /*user_fused_activation=*/std::nullopt,
+        /*user_run_batched=*/false,
+        /*transpose_a=*/false,
+        /*transpose_b=*/false,
+        parameters.output_tile,
+        parameters.global_cb,
+        parameters.sub_device_id};
+
+    auto matmul_struct =
+        create_matmul_attributes(input_tensor_a, input_tensor_b, matmul_attributes, {optional_output_tensors.at(0)});
+    if (matmul_struct.program_config.has_value()) {
+        auto device_grid = input_tensor_a.device()->compute_with_storage_grid_size();
+        operations::experimental::quasar::matmul::normalize_program_config(
+            matmul_struct.program_config.value(), device_grid);
+    }
+    return SparseMatmulParams{
+        parameters.nnz,
+        parameters.is_input_a_sparse,
+        parameters.is_input_b_sparse,
+        matmul_struct.program_config,
+        matmul_struct.output_mem_config,
+        matmul_struct.output_dtype,
+        matmul_struct.compute_kernel_config,
+        matmul_struct.user_core_coord,
+        matmul_struct.output_tile,
+        matmul_struct.global_cb,
+        matmul_struct.sub_device_id};
+}
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/sparse/sparse_matmul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/sparse/sparse_matmul_device_operation.hpp
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <tuple>
+#include <vector>
+
+#include "ttnn/operations/experimental/quasar/matmul/device/sparse/sparse_matmul_device_operation_types.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/sparse/factory/sparse_matmul_multicore_reuse_mcast_1d_optimized.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/config/matmul_program_config_types.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct SparseMatmulDeviceOperation {
+    using operation_attributes_t = SparseMatmulParams;
+    using tensor_args_t = SparseMatmulInputs;
+    using spec_return_value_t = std::vector<ttnn::TensorSpec>;
+    using tensor_return_value_t = std::vector<Tensor>;
+
+    using program_factory_t = std::variant<SparseMatmulMultiCoreReuseMcast1DProgramFactory>;
+    static void validate_on_program_cache_miss(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static spec_return_value_t compute_output_specs(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    // static ttsl::hash::hash_t compute_program_hash(
+    //     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    // static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
+    //     const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
+};
+
+SparseMatmulParams create_sparse_matmul_attributes(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const Tensor& sparsity,
+    const SparseMatmulParams& parameters,
+    const std::vector<std::optional<Tensor>>& optional_output_tensors);
+
+std::tuple<SparseMatmulParams, SparseMatmulInputs> sparse_matmul_build_operation_args(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const Tensor& sparsity,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    std::optional<uint32_t> nnz = std::nullopt,
+    bool is_input_a_sparse = false,
+    bool is_input_b_sparse = true,
+    const std::optional<const MemoryConfig>& memory_config = std::nullopt,
+    std::optional<const DataType> dtype = std::nullopt,
+    const std::optional<const operations::experimental::quasar::matmul::MatmulProgramConfig>& program_config =
+        std::nullopt,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+    const std::optional<const CoreCoord>& user_core_coord = std::nullopt,
+    const std::optional<const tt::tt_metal::Tile>& output_tile = std::nullopt,
+    const std::optional<const GlobalCircularBuffer>& global_cb = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+
+SparseMatmulDeviceOperation::tensor_return_value_t sparse_matmul(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const Tensor& sparsity,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    std::optional<uint32_t> nnz = std::nullopt,
+    bool is_input_a_sparse = false,
+    bool is_input_b_sparse = true,
+    const std::optional<const MemoryConfig>& memory_config = std::nullopt,
+    std::optional<const DataType> dtype = std::nullopt,
+    const std::optional<const operations::experimental::quasar::matmul::MatmulProgramConfig>& program_config =
+        std::nullopt,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+    const std::optional<const CoreCoord>& user_core_coord = std::nullopt,
+    const std::optional<const tt::tt_metal::Tile>& output_tile = std::nullopt,
+    const std::optional<const GlobalCircularBuffer>& global_cb = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/sparse/sparse_matmul_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/sparse/sparse_matmul_device_operation_types.hpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/operations/experimental/quasar/matmul/device/config/matmul_program_config_types.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "tt-metalium/global_circular_buffer.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operation.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct SparseMatmulParams {
+    std::optional<uint32_t> nnz;
+    bool is_input_a_sparse;
+    bool is_input_b_sparse;
+    std::optional<const operations::experimental::quasar::matmul::MatmulProgramConfig> program_config = std::nullopt;
+    tt::tt_metal::MemoryConfig output_mem_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG;
+    std::optional<tt::tt_metal::DataType> output_dtype = std::nullopt;
+    std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt;
+    std::optional<const CoreCoord> user_core_coord = std::nullopt;
+    std::optional<const tt::tt_metal::Tile> output_tile;
+    std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer> global_cb;
+    std::optional<tt::tt_metal::SubDeviceId> sub_device_id;
+};
+
+struct SparseMatmulInputs {
+    std::vector<Tensor> input_tensors;
+    std::vector<std::optional<const Tensor>> optional_input_tensors;
+    std::vector<std::optional<Tensor>> optional_output_tensors;
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/utilities/matmul_utilities.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/utilities/matmul_utilities.cpp
@@ -1,0 +1,389 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/experimental/quasar/matmul/device/utilities/matmul_utilities.hpp"
+
+#include <algorithm>
+#include <set>
+
+#include "tt-metalium/allocator.hpp"
+#include "tt-metalium/buffer_types.hpp"
+#include "tt-metalium/work_split.hpp"
+#include "ttnn/tensor/shape/shape.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
+
+namespace ttnn::operations::experimental::quasar::matmul::utilities {
+
+uint32_t get_estimated_size_of_cbs(
+    uint32_t per_core_M,
+    uint32_t per_core_N,
+    uint32_t in0_block_w,
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const bool transpose_a,
+    const bool /*transpose_b*/,
+    uint32_t interm_single_tile_size,
+    uint32_t bias_single_tile_size) {
+    // Circular Buffer sizes:
+    // src0   CB: per_core_M * in0_block_w * 2 (for double buffer)
+    // src1   CB: per_core_N * in0_block_w * 2 (for double buffer)
+    // interm CB: per_core_M * per_core_N * interm_single_tile_size
+    // out    CB: per_core_M * per_core_N
+    // bias   CB: per_core_N
+    // Ignore optional intermediate CB because not needed when need to create a
+    // program config.
+    tt::DataFormat in0_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor_a.dtype());
+    tt::DataFormat in1_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor_b.dtype());
+    uint32_t in0_single_tile_size = tt::tile_size(in0_data_format);  // use as estimate for output as well
+    uint32_t in1_single_tile_size = tt::tile_size(in1_data_format);
+    uint32_t output_single_tile_size = in0_single_tile_size;
+    uint32_t in2_block_tiles = 0;
+    uint32_t in0_shard_width_in_tiles = 0;
+    if (input_tensor_a.is_sharded()) {
+        auto* in0_buffer = input_tensor_a.buffer();
+        const auto in0_tile = utilities::get_matmul_tile(input_tensor_a, transpose_a);
+        in0_shard_width_in_tiles = in0_buffer->shard_spec().shape()[1] / in0_tile.get_width();
+    }
+    in2_block_tiles = per_core_M * in0_shard_width_in_tiles;
+
+    // Calculate individual buffer sizes in bytes - use constant for buffering depth
+    uint32_t in0_size = per_core_M * in0_block_w * MCAST_INPUT_BUFFERING_DEPTH * in0_single_tile_size;
+    uint32_t in1_size = per_core_N * in0_block_w * MCAST_INPUT_BUFFERING_DEPTH * in1_single_tile_size;
+    uint32_t out_size = per_core_M * per_core_N * output_single_tile_size;
+    uint32_t in2_size = in2_block_tiles * in0_single_tile_size;
+    uint32_t interm_size = per_core_M * per_core_N * interm_single_tile_size;
+    uint32_t bias_size = per_core_N * bias_single_tile_size;
+
+    uint32_t in0_transpose_size = 0;
+    if (transpose_a) {
+        // An extra intermediate CB (c_10) is needed to hold the transposed A data
+        in0_transpose_size = input_tensor_a.is_sharded() ? in2_size : in0_size;
+    }
+    return in0_size + in1_size + out_size + interm_size + bias_size + in2_size + in0_transpose_size;
+}
+
+uint32_t estimate_interm_tile_size(
+    const std::optional<const ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
+    const tt::tt_metal::DataType output_dtype) {
+    if (get_fp32_dest_acc_en(compute_kernel_config)) {
+        return tt::tile_size(tt::DataFormat::Float32);
+    }
+    uint32_t result = tt::tile_size(tt::DataFormat::Float16_b);  // packer l1 acc
+    tt::DataFormat output_data_format = tt::tt_metal::datatype_to_dataformat_converter(output_dtype);
+    uint32_t output_tile_size = tt::tile_size(output_data_format);
+    result = std::max(output_tile_size, result);
+    return result;
+}
+
+uint32_t get_max_l1_space(const tt::tt_metal::Tensor& input_tensor_a) {
+    auto* device = input_tensor_a.device();
+    auto lowest_address = device->lowest_occupied_compute_l1_address();
+    uint32_t max_l1_space = lowest_address.has_value() ? lowest_address.value() : device->l1_size_per_core();
+    max_l1_space = max_l1_space - device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
+    return max_l1_space;
+}
+
+bool is_input_batched(const ttnn::Shape& shape) {
+    if (shape.rank() < 2) [[unlikely]] {
+        return false;
+    }
+
+    auto is_batched = false;
+    for (auto i = 0; i < shape.rank() - 2; ++i) {
+        if (shape[i] > 1) {
+            is_batched = true;
+            break;
+        }
+    }
+    return is_batched;
+}
+
+std::optional<ttnn::operations::unary::UnaryWithParam> get_fused_activation(
+    const std::optional<const Activation>& activation) {
+    if (!activation.has_value()) {
+        return std::nullopt;
+    }
+    const auto& act = activation.value();
+    if (std::holds_alternative<std::string>(act)) {
+        return ttnn::operations::unary::utils::string_to_unary_with_param(std::get<std::string>(act));
+    }
+    return std::get<ttnn::operations::unary::UnaryWithParam>(act);
+}
+
+ttnn::Shape compute_matmul_output_shape(
+    const Tensor& input_tensor_a, const Tensor& input_tensor_b, bool transpose_a, bool transpose_b) {
+    const auto& input_shape_a = get_matmul_tensor_logical_shape(input_tensor_a, transpose_a);
+    const auto& input_shape_b = get_matmul_tensor_logical_shape(input_tensor_b, transpose_b);
+
+    const auto a_rank = input_shape_a.rank();
+    const auto b_rank = input_shape_b.rank();
+
+    // Rank difference will be used to align batch dimensions
+    const int32_t out_rank = std::max<int32_t>(a_rank, b_rank) - (a_rank == 1 || b_rank == 1);
+    const int32_t rank_difference = std::max<int32_t>(0, out_rank - a_rank);
+
+    // Initialize output shape based on the tensor with higher rank
+    ttnn::Shape output_shape = (b_rank > a_rank) ? input_shape_b : input_shape_a;
+
+    // Handle batch dimensions for the case where b_rank > a_rank
+    for (auto index = 0; index < rank_difference; ++index) {
+        TT_FATAL(input_shape_b[index] == 1, "When in1 rank greater than in0 rank front dimensions need to be 1");
+        output_shape[index] = input_shape_b[index];
+    }
+
+    // Copy dimensions from input_shape_a except the last one
+    for (auto index = 0; index < a_rank - 1; ++index) {
+        output_shape[rank_difference + index] = input_shape_a[index];
+    }
+
+    // The last dimension comes from input_tensor_b
+    output_shape[-1] = input_shape_b[-1];
+
+    // Handle the vector matmul case: if a_rank == 1, remove the second-to-last dimension
+    if (a_rank == 1 && output_shape.rank() > 1) [[unlikely]] {
+        ttnn::SmallVector<uint32_t> new_shape(output_shape.rank() - 1);
+        // Copy all elements except the second-to-last dimension
+        size_t dst_idx = 0;
+        for (size_t src_idx = 0; src_idx < output_shape.rank(); ++src_idx) {
+            if (src_idx != output_shape.rank() - 2) {
+                new_shape[dst_idx++] = output_shape[src_idx];
+            }
+        }
+        output_shape = ttnn::Shape(new_shape);
+    }
+
+    // Handle the case where b_rank == 1, remove the last dimension
+    if (b_rank == 1) [[unlikely]] {
+        ttnn::SmallVector<uint32_t> new_shape(output_shape.rank() - 1);
+        for (auto index = 0; index < output_shape.rank() - 1; ++index) {
+            new_shape[index] = output_shape[index];
+        }
+        output_shape = ttnn::Shape(new_shape);
+    }
+
+    // Optimization: Reuse input A (in0) across batches when A's batch dimension is 1
+    // and B's batch dimension is > 1. For matmul shapes BxHaxMxK / BxHbxKxN where Ha=1 and Hb>1,
+    // the same A tensor can be reused for each batch element of B rather than reading A repeatedly.
+    // Restrict to rank-4 tensors to ensure dim 1 is correctly identified as the batch dimension
+    // and to prevent out-of-bounds indexing with lower-rank shapes.
+    if (a_rank == 4 && b_rank == 4 && input_shape_a[1] == 1 && input_shape_b[1] > 1) {
+        output_shape[1] = input_shape_b[1];
+    }
+    return output_shape;
+}
+
+ttnn::Shape compute_matmul_with_bias_output_shape(const ttnn::Shape& matmul_shape, const ttnn::Shape& bias_shape) {
+    int rank_a = static_cast<int>(matmul_shape.rank());
+    int rank_b = static_cast<int>(bias_shape.rank());
+    int max_rank = std::max(rank_a, rank_b);
+
+    std::vector<uint32_t> result_shape(max_rank);
+
+    for (int i = 0; i < max_rank; ++i) {
+        int idx_a = rank_a - max_rank + i;
+        int idx_b = rank_b - max_rank + i;
+
+        uint32_t dim_a = (idx_a >= 0) ? matmul_shape[idx_a] : 1;
+        uint32_t dim_b = (idx_b >= 0) ? bias_shape[idx_b] : 1;
+
+        TT_FATAL(dim_a == dim_b || dim_a == 1 || dim_b == 1, "Broadcast error: Invalid dimension");
+
+        result_shape[i] = std::max(dim_a, dim_b);
+    }
+
+    return ttnn::Shape(result_shape);
+}
+
+tt::tt_metal::Tile get_output_tile(
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const std::optional<const tt::tt_metal::Tile>& output_tile,
+    const std::optional<const tt::tt_metal::Tile>& optional_output_tensor_tile) {
+    using namespace tt;
+    if (output_tile.has_value() or optional_output_tensor_tile.has_value()) {
+        TT_FATAL(
+            !(optional_output_tensor_tile.has_value() && output_tile.has_value()),
+            "Matmul cannot have both an output_tile and an optional_output_tensor. Configure the tile type of the "
+            "output tensor instead if both are required.");
+        const auto& override_output_tile =
+            output_tile.has_value() ? output_tile.value() : optional_output_tensor_tile.value();
+        const auto& out_tile_shape = override_output_tile.get_tile_shape();
+
+        const uint32_t in0_tile_h = in0_tile.get_height();
+        const uint32_t in1_tile_w = in1_tile.get_width();
+
+        TT_FATAL(out_tile_shape[1] > 0, "the override output tile width needs to be greater than zero");
+        TT_FATAL(
+            out_tile_shape[1] % in1_tile_w == 0,
+            "the override output tile width ({}) must be a multiple of in1 tile width ({})",
+            out_tile_shape[1],
+            in1_tile_w);
+        TT_FATAL(out_tile_shape[0] > 0, "the override output tile height needs to be greater than zero");
+        TT_FATAL(
+            out_tile_shape[0] == in0_tile_h,
+            "the override output tile height ({}) must equal to the in0 tile height ({})",
+            out_tile_shape[0],
+            in0_tile_h);
+        if (out_tile_shape[1] != in1_tile_w) {
+            TT_FATAL(
+                out_tile_shape[0] <= constants::FACE_HEIGHT,
+                "the override output tile height ({}) must equal or less to face height ({})",
+                out_tile_shape[0],
+                constants::FACE_HEIGHT);
+        }
+        if (!output_mem_config.is_sharded()) {
+            TT_FATAL(
+                out_tile_shape[1] == in1_tile_w,
+                "the override output tile width ({}) must equal the in0 tile width ({})",
+                out_tile_shape[1],
+                in1_tile_w);
+        }
+
+        return override_output_tile;
+    }
+    return tt::tt_metal::Tile({in0_tile.get_height(), in1_tile.get_width()});
+}
+
+tt::tt_metal::Tile get_matmul_tile(const Tensor& input_tensor, bool transpose) {
+    auto curr_tile = input_tensor.tensor_spec().tile();
+    if (!transpose) {
+        return curr_tile;
+    }
+
+    // If the tile is already transposed and we are asked to transpose it again,
+    // the result should be the original orientation (double-transpose cancels out).
+    // Therefore, we negate the transpose flag.
+    const auto transpose_was_set = curr_tile.get_transpose_of_faces();
+    TT_FATAL(
+        (!transpose_was_set) || curr_tile.get_transpose_within_face(),
+        "The tile spec must have both transpose_within_face {} and transpose_of_faces {} set or neither set",
+        curr_tile.get_transpose_within_face(),
+        curr_tile.get_transpose_of_faces());
+    return tt::tt_metal::Tile({curr_tile.get_width(), curr_tile.get_height()}, !transpose_was_set);
+}
+
+void validate_matmul_reuse_work_split(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const ttnn::Shape& a_shape_padded,
+    const ttnn::Shape& b_shape_padded,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const MatmulMultiCoreReuseProgramConfig& program_config,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    const std::optional<tt::tt_metal::CoreRangeSet>& core_range_set) {
+    const uint32_t B = ttnn::get_batch_size(a_shape_padded);
+    const uint32_t Mt = get_M_dim(a_shape_padded, in0_tile, false);
+    const uint32_t Nt = get_N_dim(b_shape_padded, in1_tile);
+    const uint32_t per_core_M = program_config.per_core_M;
+    const uint32_t per_core_N = program_config.per_core_N;
+    TT_FATAL((B * Mt) % per_core_M == 0, "B * Mt ({}) must be divisible by per_core_M ({})", B * Mt, per_core_M);
+    TT_FATAL(Nt % per_core_N == 0, "Nt ({}) must be divisible by per_core_N ({})", Nt, per_core_N);
+    const uint32_t num_output_blocks_total = (B * Mt / per_core_M) * (Nt / per_core_N);
+    TT_FATAL(
+        num_output_blocks_total > 0,
+        "matmul reuse produced zero output blocks (B={}, Mt={}, Nt={}, per_core_M={}, per_core_N={})",
+        B,
+        Mt,
+        Nt,
+        per_core_M,
+        per_core_N);
+
+    std::optional<tt::tt_metal::ShardSpec> shard_spec = std::nullopt;
+    if (input_tensor_a.is_sharded()) {
+        shard_spec = input_tensor_a.shard_spec().value();
+    } else if (input_tensor_b.is_sharded()) {
+        shard_spec = input_tensor_b.shard_spec().value();
+    } else if (
+        output_mem_config.is_sharded() && output_mem_config.buffer_type() != tt::tt_metal::BufferType::DRAM &&
+        output_mem_config.shard_spec().has_value()) {
+        shard_spec = output_mem_config.shard_spec().value();
+    }
+
+    uint32_t num_cores = 0;
+    if (shard_spec.has_value()) {
+        num_cores = shard_spec->grid.num_cores();
+    } else if (core_range_set.has_value()) {
+        std::tie(num_cores, std::ignore, std::ignore, std::ignore, std::ignore, std::ignore) =
+            tt::tt_metal::split_work_to_cores(core_range_set.value(), num_output_blocks_total);
+    } else {
+        const tt::tt_metal::CoreCoord grid = program_config.compute_with_storage_grid_size;
+        std::tie(num_cores, std::ignore, std::ignore, std::ignore, std::ignore, std::ignore) =
+            tt::tt_metal::split_work_to_cores(grid, num_output_blocks_total);
+    }
+
+    TT_FATAL(
+        num_cores > 0,
+        "matmul reuse requires at least one active core, got 0 (num_output_blocks_total={})",
+        num_output_blocks_total);
+    const uint32_t num_evenly_divided_output_blocks = num_output_blocks_total / num_cores;
+    TT_FATAL(
+        num_evenly_divided_output_blocks > 0,
+        "num_output_blocks_total ({}) must be >= num_cores ({}); some cores would have no work",
+        num_output_blocks_total,
+        num_cores);
+}
+
+}  // namespace ttnn::operations::experimental::quasar::matmul::utilities
+
+namespace ttnn::prim::qsr::dram_sharded_helpers {
+
+tt::tt_metal::IDevice* get_device_for_dram_banks(const ttnn::Tensor& a, const ttnn::MeshCoordinate& coord) {
+    ttnn::distributed::MeshDevice* device = a.device();
+    const ttnn::distributed::MeshDeviceView& view = device->get_view();
+    if (!view.contains(coord) || !view.is_local(coord)) {
+        return device;
+    }
+    return a.device()->get_device(coord);
+}
+
+void get_max_page_size_and_num_pages(
+    tt::tt_metal::IDevice* device, uint32_t num_tiles, uint32_t tile_size, uint32_t& page_size, uint32_t& num_pages) {
+    uint64_t total_size = static_cast<uint64_t>(num_tiles) * tile_size;
+
+    // TODO(#32477): Remove hardcoding when NOC_MAX_BURST_SIZE is available from HAL
+    uint32_t noc_max_page_size;
+    if (device->arch() == tt::ARCH::WORMHOLE_B0) {
+        noc_max_page_size = 8192;
+    } else if (device->arch() == tt::ARCH::BLACKHOLE) {
+        noc_max_page_size = 16384;
+    } else {
+        TT_THROW(
+            "Unsupported architecture for DRAM sharded matmul. Only Wormhole and Blackhole are supported. Got: {}",
+            device->arch());
+    }
+
+    page_size = (noc_max_page_size / tile_size) * tile_size;
+    while (total_size % page_size != 0 && page_size >= tile_size) {
+        page_size -= tile_size;
+    }
+    num_pages = total_size / page_size;
+}
+
+void move_common_entries(std::vector<CoreCoord>& v1, std::vector<CoreCoord>& v2, std::vector<CoreCoord>& commons) {
+    for (const CoreCoord& item : v2) {
+        if (std::find(v1.begin(), v1.end(), item) != v1.end()) {
+            commons.push_back(item);
+        }
+    }
+
+    for (const CoreCoord& item : commons) {
+        v2.erase(std::remove(v2.begin(), v2.end(), item), v2.end());
+    }
+}
+
+void get_optimal_dram_bank_to_reader_assignment(
+    tt::tt_metal::IDevice* device,
+    std::vector<CoreCoord>& all_worker_cores_ordered,
+    CoreRangeSet& all_worker_cores,
+    tt::tt_metal::NOC noc) {
+    all_worker_cores_ordered = device->get_optimal_dram_bank_to_logical_worker_assignment(noc);
+    std::set<CoreRange> all_cores_set;
+    for (const auto& worker_core : all_worker_cores_ordered) {
+        all_cores_set.insert(CoreRange(worker_core));
+    }
+    all_worker_cores = CoreRangeSet(all_cores_set);
+}
+}  // namespace ttnn::prim::qsr::dram_sharded_helpers

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/utilities/matmul_utilities.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/utilities/matmul_utilities.hpp
@@ -1,0 +1,363 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <bit>
+#include <optional>
+#include <vector>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/distributed/types.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/shared_with_host/activation_type.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/config/matmul_program_config_types.hpp"
+
+namespace ttnn::operations::experimental::quasar::matmul::utilities {
+
+// Define the buffering depth for input CBs (0 and 1) for mcast variants.
+// 2 = double buffer, 3 = triple buffer, etc.
+// Allows easily changing buffering strategy in one place for relevant factories.
+constexpr uint32_t MCAST_INPUT_BUFFERING_DEPTH = 2;
+
+inline bool fused_matmul_bias_row_broadcastable(const std::optional<const Tensor>& bias) {
+    if (!bias.has_value()) {
+        return false;
+    }
+    const auto& shape = bias->logical_shape();
+    if (shape.rank() < 2) {
+        return true;
+    }
+    return shape[-2] == 1;
+}
+
+uint32_t get_estimated_size_of_cbs(
+    uint32_t per_core_M,
+    uint32_t per_core_N,
+    uint32_t in0_block_w,
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    bool transpose_a,
+    bool transpose_b,
+    uint32_t interm_single_tile_size,
+    uint32_t bias_single_tile_size);
+
+uint32_t estimate_interm_tile_size(
+    const std::optional<const ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
+    tt::tt_metal::DataType output_dtype);
+
+uint32_t get_max_l1_space(const tt::tt_metal::Tensor& input_tensor_a);
+
+bool is_input_batched(const ttnn::Shape& shape);
+
+/**
+ * @brief Computes the output shape of a matmul operation given two input tensors
+ *
+ * Determines the output shape based on the broadcasting rules for matrix multiplication:
+ * - For 2D tensors: [m, k] @ [k, n] -> [m, n]
+ * - For tensors with batch dimensions, the batch dimensions are broadcast
+ * - For vector-matrix multiplication (rank 1 @ rank 2), the result is a vector
+ *  Takes into account the transpose flags for the input tensors.
+ *
+ * @param input_tensor_a First input tensor
+ * @param input_tensor_b Second input tensor
+ * @param transpose_a Whether to transpose the first input tensor
+ * @param transpose_b Whether to transpose the second input tensor
+ * @return Shape of the resulting tensor after matmul
+ */
+ttnn::Shape compute_matmul_output_shape(
+    const Tensor& input_tensor_a, const Tensor& input_tensor_b, bool transpose_a, bool transpose_b);
+
+ttnn::Shape compute_matmul_with_bias_output_shape(const ttnn::Shape& matmul_shape, const ttnn::Shape& bias_shape);
+
+using Activation = std::variant<std::string, ttnn::operations::unary::UnaryWithParam>;
+std::optional<ttnn::operations::unary::UnaryWithParam> get_fused_activation(
+    const std::optional<const Activation>& activation);
+
+tt::tt_metal::Tile get_output_tile(
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const std::optional<const tt::tt_metal::Tile>& output_tile,
+    const std::optional<const tt::tt_metal::Tile>& optional_output_tensor_tile);
+
+/**
+ * @brief Calculate the M dimension for matmul operations
+ *
+ * @param padded_shape The padded shape of the tensor
+ * @param tile The tile for the tensor (optional)
+ * @param fuse_batch Whether to fuse batch dimensions
+ * @return uint32_t The calculated M dimension
+ */
+inline uint32_t get_M_dim(
+    const tt::tt_metal::Shape& padded_shape, const std::optional<tt::tt_metal::Tile>& tile, const bool fuse_batch) {
+    uint32_t tile_height = tile.has_value() ? tile.value().get_height() : 1;
+    if (fuse_batch) {
+        return padded_shape.volume() / padded_shape[-1] / tile_height;
+    }
+
+    // Batch dims not fused, so take the height dimension
+    return padded_shape[-2] / tile_height;
+}
+
+/**
+ * @brief Calculate the K dimension for matmul operations
+ *
+ * @param padded_shape The padded shape of the tensor
+ * @param tile The tile for the tensor (optional)
+ * @return uint32_t The calculated K dimension
+ */
+inline uint32_t get_K_dim(const tt::tt_metal::Shape& padded_shape, const std::optional<tt::tt_metal::Tile>& tile) {
+    return padded_shape[-1] / (tile.has_value() ? tile.value().get_width() : 1);
+}
+
+/**
+ * @brief Calculate the N dimension for matmul operations
+ *
+ * @param padded_shape The padded shape of the tensor
+ * @param tile The tile for the tensor (optional)
+ * @return uint32_t The calculated N dimension
+ */
+inline uint32_t get_N_dim(const tt::tt_metal::Shape& padded_shape, const std::optional<tt::tt_metal::Tile>& tile) {
+    return padded_shape[-1] / (tile.has_value() ? tile.value().get_width() : 1);
+}
+
+struct In0TransposeStrides {
+    uint32_t stride_w;
+    uint32_t stride_h;
+};
+
+/**
+ * @brief Compute in0 tensor strides for the reader kernel, handling transpose_a with fuse_batch.
+ *
+ * When transpose_a is true and batches are not fused (M == M_per_batch), the tile traversal
+ * order must be transposed: stride_w = M_per_batch, stride_h = 1. When batches are fused
+ * (M != M_per_batch) or transpose_a is false, normal strides apply: stride_w = 1, stride_h = K.
+ *
+ * The caller must ensure that transpose_a + fuse_batch + M_per_batch > 1 is not used; this
+ * unsupported combination is validated in MatmulDeviceOperation::validate_on_program_cache_miss.
+ *
+ * @param M Total M dimension in tiles (possibly fused across batches)
+ * @param M_per_batch M dimension in tiles for a single batch
+ * @param transpose_a Whether the A tensor is logically transposed
+ * @param K K dimension in tiles
+ * @return In0TransposeStrides with stride_w and stride_h
+ */
+inline In0TransposeStrides get_in0_transpose_strides(uint32_t M, uint32_t M_per_batch, bool transpose_a, uint32_t K) {
+    const bool batch_fused = (M != M_per_batch);
+    return {
+        .stride_w = (transpose_a && !batch_fused) ? M_per_batch : 1u,
+        .stride_h = (transpose_a && !batch_fused) ? 1u : K,
+    };
+}
+
+/**
+ * @brief Get the padded shape of a tensor, with optional transpose.
+ *
+ * Returns the padded shape of the tensor. If transpose is true, the padded shape dimensions are swapped.
+ *
+ * @param input_tensor The tensor whose padded shape is queried.
+ * @param transpose Whether to return the padded shape after transposing (swap height and width).
+ * @return ttnn::Shape The padded shape of the tensor, possibly transposed.
+ */
+inline ttnn::Shape get_matmul_tensor_padded_shape(const Tensor& input_tensor, bool transpose) {
+    auto padded_shape = input_tensor.padded_shape();
+    if (transpose) {
+        std::swap(padded_shape[-2], padded_shape[-1]);
+    }
+    return padded_shape;
+}
+
+/**
+ * @brief Get the tile shape of a tensor, with optional transpose.
+ *
+ * Returns a tuple representing the height and width of the tensor's tile. If transpose is true,
+ * the tile shape dimensions are swapped.
+ *
+ * @param input_tensor The tensor whose tile shape is queried.
+ * @param transpose Whether to return the tile shape after transposing (swap height and width).
+ * @return tt::tt_metal::Tile The tile shape of the tensor, possibly transposed.
+ */
+tt::tt_metal::Tile get_matmul_tile(const Tensor& input_tensor, bool transpose);
+
+/**
+ * @brief Get the shape of a tensor, with optional transpose.
+ *
+ * Returns the shape of the tensor. If transpose is true, the shape dimensions are swapped.
+ *
+ * @param input_tensor The tensor whose shape is queried.
+ * @param transpose Whether to return the shape after transposing (swap height and width).
+ * @return ttnn::Shape The shape of the tensor, possibly transposed.
+ */
+inline ttnn::Shape get_matmul_tensor_logical_shape(const Tensor& input_tensor, bool transpose) {
+    auto shape = input_tensor.logical_shape();
+    if (transpose) {
+        std::swap(shape[-2], shape[-1]);
+    }
+    return shape;
+}
+
+inline KernelActivation get_activation_type(ttnn::operations::unary::UnaryOpType opType) {
+    using ttnn::operations::unary::UnaryOpType;
+    switch (opType) {
+        case UnaryOpType::GELU: return KernelActivation::GELU;
+        case UnaryOpType::TANH: return KernelActivation::TANH;
+        case UnaryOpType::SILU: return KernelActivation::SILU;
+        case UnaryOpType::RELU6: return KernelActivation::RELU6;
+        case UnaryOpType::SIGMOID: return KernelActivation::SIGMOID;
+        case UnaryOpType::HARDSIGMOID: return KernelActivation::HARDSIGMOID;
+        case UnaryOpType::HARDTANH: return KernelActivation::HARDTANH;
+        case UnaryOpType::SELU: return KernelActivation::SELU;
+        case UnaryOpType::SOFTPLUS: return KernelActivation::SOFTPLUS;
+        default: TT_THROW("Unsupported UnaryOpType for fused activation: {}", opType);
+    };
+}
+
+/**
+ * @brief Consolidated activation parameters structure
+ *
+ * Contains the activation type and its associated parameters in a single struct
+ * These values are passed as compile time arguments to the kernel
+ */
+struct ActivationParams {
+    KernelActivation type = KernelActivation::NONE;
+    uint32_t param0 = 0;
+    uint32_t param1 = 0;
+    uint32_t param2 = 0;
+};
+
+/**
+ * @brief Extract activation parameters
+ *
+ * Extracts the activation type and both parameters. Prepares parameter values for the kernel.
+ *
+ * @param activation The UnaryWithParam containing the activation operation and parameters
+ * @return ActivationParams struct with type and activation specific param0, param1, param2
+ */
+inline ActivationParams get_activation_params(const ttnn::operations::unary::UnaryWithParam& activation) {
+    using ttnn::operations::unary::UnaryOpType;
+
+    // Activation parameters provided by the ttnn op.
+    std::span<const float> params = activation.get_params();
+    TT_FATAL(
+        params.size() <= 2, "Invalid number of activation parameters: {}. Expected no more than 2.", params.size());
+    const bool has_first = !params.empty();
+    const bool has_second = params.size() > 1;
+
+    // Activation parameters to be given to the kernel
+    ActivationParams result;
+
+    switch (activation.op_type) {
+        case UnaryOpType::GELU:
+            result.type = KernelActivation::GELU;
+            // param0 is vector mode (0=RC, 1=R, 2=C) or fast mode
+            result.param0 = has_first ? static_cast<uint32_t>(params[0]) : 0;
+            break;
+
+        case UnaryOpType::TANH:
+            result.type = KernelActivation::TANH;
+            // param0 is vector mode or fast mode
+            result.param0 = has_first ? static_cast<uint32_t>(params[0]) : 0;
+            break;
+
+        case UnaryOpType::SILU:
+            result.type = KernelActivation::SILU;
+            // No parameters currently
+            break;
+
+        case UnaryOpType::RELU6:
+            result.type = KernelActivation::RELU6;
+            // param0 is max value (default 6.0)
+            result.param0 = has_first ? std::bit_cast<uint32_t>(params[0]) : 0x40c00000u;
+            break;
+        case UnaryOpType::SIGMOID: {
+            result.type = KernelActivation::SIGMOID;
+            const uint32_t param0 = has_first ? static_cast<uint32_t>(params[0]) : 0;
+            TT_FATAL(param0 <= 4, "Invalid Vector mode value: {}", param0);
+            result.param0 = param0;
+            // param1 is fast_approximate flag
+            result.param1 = has_second ? static_cast<uint32_t>(params[1]) : 0;
+            break;
+        }
+
+        case UnaryOpType::HARDSIGMOID:
+            result.type = KernelActivation::HARDSIGMOID;
+            // param0 could support approximation mode
+            result.param0 = has_first ? static_cast<uint32_t>(params[0]) : 0;
+            break;
+
+        case UnaryOpType::HARDTANH:
+            result.type = KernelActivation::HARDTANH;
+            // param0 is min value (default -1.0)
+            result.param0 = has_first ? std::bit_cast<uint32_t>(params[0]) : 0xbf800000u;
+            // param1 is max value (default 1.0)
+            result.param1 = has_second ? std::bit_cast<uint32_t>(params[1]) : 0x3f800000u;
+            break;
+
+        case UnaryOpType::SELU:
+            result.type = KernelActivation::SELU;
+            // param0 is alpha (default 1.67326)
+            result.param0 = has_first ? std::bit_cast<uint32_t>(params[0]) : 0x3fd637bdu;
+            // param1 is lambda (default 1.05070)
+            result.param1 = has_second ? std::bit_cast<uint32_t>(params[1]) : 0x3f8674f5u;
+            break;
+
+        case UnaryOpType::SOFTPLUS:
+            result.type = KernelActivation::SOFTPLUS;
+            // param0 is beta (default 1.0)
+            // param1 is threshold (default 20.0)
+            // we also prepare beta reciprocal as a kernel compile arg,
+            // which is passed as param2
+            if (has_first) {
+                float beta = params[0];
+                TT_FATAL(beta != 0, "SOFTPLUS activation beta parameter cannot be zero");
+                float beta_reciprocal = 1.0f / params[0];
+                result.param0 = std::bit_cast<uint32_t>(beta);
+                result.param2 = std::bit_cast<uint32_t>(beta_reciprocal);
+            } else {
+                result.param0 = 0x3f800000u;
+                result.param2 = 0x3f800000u;
+            }
+            result.param1 = has_second ? std::bit_cast<uint32_t>(params[1]) : 0x41a00000u;
+            break;
+
+        default: TT_THROW("Unsupported UnaryOpType for fused activation: {}", activation.op_type);
+    }
+
+    return result;
+}
+
+void validate_matmul_reuse_work_split(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const ttnn::Shape& a_shape_padded,
+    const ttnn::Shape& b_shape_padded,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const MatmulMultiCoreReuseProgramConfig& program_config,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    const std::optional<tt::tt_metal::CoreRangeSet>& core_range_set = std::nullopt);
+
+}  // namespace ttnn::operations::experimental::quasar::matmul::utilities
+
+namespace ttnn::prim::qsr::dram_sharded_helpers {
+// This type of access pattern cannot be copied.
+// Treat it as a one off patch to restore functionality that
+// was adjusted to fix one P0 causing another P0.
+// TODO: Proper fix will be implemented in Issue #32205
+tt::tt_metal::IDevice* get_device_for_dram_banks(const ttnn::Tensor& a, const ttnn::MeshCoordinate& coord);
+
+void get_max_page_size_and_num_pages(
+    tt::tt_metal::IDevice* device, uint32_t num_tiles, uint32_t tile_size, uint32_t& page_size, uint32_t& num_pages);
+
+void move_common_entries(std::vector<CoreCoord>& v1, std::vector<CoreCoord>& v2, std::vector<CoreCoord>& commons);
+
+void get_optimal_dram_bank_to_reader_assignment(
+    tt::tt_metal::IDevice* device,
+    std::vector<CoreCoord>& all_worker_cores_ordered,
+    CoreRangeSet& all_worker_cores,
+    tt::tt_metal::NOC noc);
+
+}  // namespace ttnn::prim::qsr::dram_sharded_helpers

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/matmul.cpp
@@ -1,0 +1,564 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "matmul.hpp"
+
+#include <numeric>
+#include <variant>
+
+#include "device/config/matmul_program_config_types.hpp"
+#include "ttnn/operations/eltwise/unary/unary.hpp"
+#include "ttnn/operations/data_movement/transpose/transpose.hpp"
+#include "ttnn/operations/eltwise/binary/binary.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
+#include "ttnn/operations/creation/creation.hpp"
+
+#include "ttnn/operations/experimental/quasar/matmul/device/config/matmul_program_config.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/matmul_device_operation.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/utilities/matmul_utilities.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/sparse/sparse_matmul_device_operation.hpp"
+
+namespace ttnn::operations::experimental::quasar::matmul {
+
+namespace detail {
+
+bool is_input_batched(const ttnn::Shape& shape) {
+    if (shape.rank() < 2) [[unlikely]] {
+        return false;
+    }
+
+    auto is_batched = false;
+    for (auto i = 0; i < shape.rank() - 2; ++i) {
+        if (shape[i] > 1) {
+            is_batched = true;
+            break;
+        }
+    }
+    return is_batched;
+}
+
+/**
+ * @brief Handles matmul operations with zero volume inputs by creating a zero-filled output tensor
+ *
+ * When one of the input tensors has zero volume (a dimension with size 0), this function:
+ * 1. Computes the correct output shape using compute_matmul_output_shape
+ * 2. Creates an output tensor with that shape, filled with zeros
+ * 3. Optionally adds bias to the output tensor
+ *
+ * @param input_tensor_a First input tensor
+ * @param input_tensor_b Second input tensor
+ * @param transpose_a Whether to transpose the first input tensor
+ * @param transpose_b Whether to transpose the second input tensor
+ * @param memory_config Memory configuration for the output tensor
+ * @param dtype Data type for the output tensor
+ * @param bias Optional bias tensor to add to the result
+ * @return Zero-filled tensor with the appropriate output shape, with bias applied if provided
+ */
+Tensor handle_zero_volume_matmul(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const MemoryConfig& memory_config,
+    const std::optional<DataType>& dtype,
+    const bool transpose_a,
+    const bool transpose_b,
+    const std::optional<const ttnn::Tensor>& bias = std::nullopt) {
+    // Calculate the expected output shape
+    ttnn::Shape output_shape =
+        utilities::compute_matmul_output_shape(input_tensor_a, input_tensor_b, transpose_a, transpose_b);
+
+    // Use the appropriate data type (either from parameters or from input tensor)
+    DataType output_dtype = dtype.value_or(input_tensor_a.dtype());
+
+    // Create a tensor filled with zeros
+    auto output_tensor =
+        ttnn::full(output_shape, 0.0f, output_dtype, input_tensor_a.layout(), *input_tensor_a.device(), memory_config);
+
+    // Apply bias if provided
+    if (bias.has_value()) {
+        output_tensor = ttnn::add(output_tensor, bias.value(), std::nullopt, memory_config);
+    }
+
+    return output_tensor;
+}
+
+}  // namespace detail
+
+std::optional<UnaryWithParam> get_fused_activation(const std::optional<const Activation>& activation) {
+    if (!activation.has_value()) {
+        return std::nullopt;
+    }
+    const auto& act = activation.value();
+    if (std::holds_alternative<std::string>(act)) {
+        return ttnn::operations::unary::utils::string_to_unary_with_param(std::get<std::string>(act));
+    }
+    return std::get<UnaryWithParam>(act);
+}
+
+static bool get_post_process_bias(
+    const std::optional<const ttnn::Tensor>& bias,
+    const std::optional<const MatmulProgramConfig>& program_config,
+    const std::optional<const CoreCoord>& user_core_coord,
+    const MemoryConfig& output_mem_config,
+    const ttnn::Tensor& input_tensor_a_adjusted,
+    const ttnn::Tensor& input_tensor_b_adjusted,
+    const bool transpose_a) {
+    // Determine if we should post-process bias based on the program config
+    // MatmulMultiCoreProgramConfig doesn't support bias fusion, so we need to apply it as a post-process
+    bool post_process_bias = false;
+    if (bias.has_value()) {
+        // Fused matmul+bias does not support batched weights; apply bias via add().
+        if (detail::is_input_batched(input_tensor_b_adjusted.logical_shape())) {
+            return true;
+        }
+        const auto& bias_tensor = bias.value();
+        // Fused matmul+bias does not support batched bias; apply bias via add().
+        if (detail::is_input_batched(bias_tensor.logical_shape())) {
+            return true;
+        }
+        // Check if bias shape is compatible with kernel fusion
+        // Bias fusion requires bias_shape_aligned[-2] == tile_height
+        const auto& bias_padded_shape = bias_tensor.padded_shape();
+        const auto& tile_shape = input_tensor_a_adjusted.tensor_spec().tile().get_tile_shape();
+        uint32_t tile_height = transpose_a ? tile_shape[1] : tile_shape[0];
+
+        // If bias second-to-last dimension doesn't match tile height, must post-process
+        if (bias_padded_shape[-2] != tile_height) {
+            post_process_bias = true;
+        } else if (program_config.has_value()) {
+            // Check if the provided program config is MatmulMultiCoreProgramConfig
+            post_process_bias = std::holds_alternative<MatmulMultiCoreProgramConfig>(program_config.value());
+        } else if (!user_core_coord.has_value()) {
+            // When program_config and user_core_coord are not provided, config is auto-generated
+
+            // Special case: L1 memory often leads to MatmulMultiCoreProgramConfig
+            // Be conservative and post-process bias for non-DRAM outputs
+            if (output_mem_config.buffer_type() != BufferType::DRAM) {
+                post_process_bias = true;
+            } else if (!input_tensor_a_adjusted.is_sharded()) {
+                // For DRAM output, check if all tensors are DRAM interleaved
+                bool all_dram_interleaved =
+                    input_tensor_a_adjusted.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED &&
+                    input_tensor_b_adjusted.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED &&
+                    output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED &&
+                    input_tensor_a_adjusted.memory_config().buffer_type() == BufferType::DRAM &&
+                    input_tensor_b_adjusted.memory_config().buffer_type() == BufferType::DRAM;
+
+                // If not all DRAM interleaved, MatmulMultiCoreProgramConfig is more likely
+                if (!all_dram_interleaved) {
+                    post_process_bias = true;
+                }
+            }
+        }
+    }
+    return post_process_bias;
+}
+
+static ttnn::Tensor bound_matmul(
+    const ttnn::Tensor& input_tensor_a,
+    const ttnn::Tensor& input_tensor_b,
+    const std::optional<const ttnn::Tensor>& bias,
+    ttnn::prim::qsr::MatmulParams& parameters,
+    std::optional<ttnn::Tensor>& optional_output_tensor) {
+    if (input_tensor_a.logical_shape().rank() == 0 || input_tensor_b.logical_shape().rank() == 0) [[unlikely]] {
+        TT_THROW(
+            "ttnn.matmul: Both arguments to matmul need to be at least 1D, but got shapes {} and {}",
+            input_tensor_a.logical_shape(),
+            input_tensor_b.logical_shape());
+    }
+
+    if (input_tensor_a.is_sharded() || input_tensor_b.is_sharded()) {
+        TT_FATAL(
+            !parameters.user_fused_activation.has_value(),
+            "Sharded matmul run with {} activation: this should be placed in the program config's fused_activation "
+            "field",
+            parameters.user_fused_activation.value().op_type);
+    }
+
+    // Check for zero volume tensors
+    if (input_tensor_a.logical_volume() == 0 || input_tensor_b.logical_volume() == 0) [[unlikely]] {
+        return detail::handle_zero_volume_matmul(
+            input_tensor_a,
+            input_tensor_b,
+            parameters.output_mem_config,
+            parameters.output_dtype,
+            parameters.transpose_a,
+            parameters.transpose_b,
+            bias);
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // The following code is replicated from matmul_op.cpp and helps determine the program config
+    auto matmul_struct =
+        ttnn::prim::qsr::create_matmul_attributes(input_tensor_a, input_tensor_b, parameters, {optional_output_tensor});
+
+    uint32_t bias_single_tile_size = 0;
+    if (bias.has_value()) {
+        auto bias_data_format = datatype_to_dataformat_converter(bias.value().dtype());
+        bias_single_tile_size = tt::tile_size(bias_data_format);
+    }
+    MatmulProgramConfig chosen_program_config = get_program_config(
+        input_tensor_a,
+        input_tensor_b,
+        parameters.transpose_a,
+        parameters.transpose_b,
+        bias_single_tile_size,
+        matmul_struct);
+    //----------------------------------------------------------------------------------------------
+
+    // Decide if we need to manually transpose or if the program config will handle it
+    bool needs_manual_transpose =
+        !(std::holds_alternative<MatmulMultiCoreReuseMultiCast1DProgramConfig>(chosen_program_config) ||
+          std::holds_alternative<MatmulMultiCoreReuseMultiCastProgramConfig>(chosen_program_config) ||
+          std::holds_alternative<MatmulMultiCoreReuseProgramConfig>(chosen_program_config));
+    bool needs_manual_transpose_a = parameters.transpose_a && needs_manual_transpose;
+    bool needs_manual_transpose_b = parameters.transpose_b && needs_manual_transpose;
+
+    const auto& input_tensor_a_adjusted = needs_manual_transpose_a
+                                              ? ttnn::transpose(input_tensor_a, -1, -2, input_tensor_a.memory_config())
+                                              : input_tensor_a;
+
+    ttnn::Tensor input_tensor_b_adjusted = input_tensor_b;
+    if (input_tensor_b.logical_shape().rank() == 1) {
+        input_tensor_b_adjusted = ttnn::reshape(input_tensor_b, ttnn::Shape({input_tensor_b.logical_shape()[-1], 1}));
+    } else if (needs_manual_transpose_b) {
+        input_tensor_b_adjusted = ttnn::transpose(input_tensor_b, -1, -2, input_tensor_b.memory_config());
+    }
+
+    // We need to change the transpose_a and transpose_b flags if we manually transposed
+    // the input tensors
+    if (needs_manual_transpose_a) {
+        parameters.transpose_a = false;
+    }
+    if (needs_manual_transpose_b) {
+        parameters.transpose_b = false;
+    }
+
+    bool post_process_bias = get_post_process_bias(
+        bias,
+        parameters.program_config,
+        parameters.user_core_coord,
+        parameters.output_mem_config,
+        input_tensor_a_adjusted,
+        input_tensor_b_adjusted,
+        parameters.transpose_a);
+
+    auto attributes = ttnn::prim::qsr::create_matmul_attributes(
+        input_tensor_a_adjusted, input_tensor_b_adjusted, parameters, {optional_output_tensor});
+
+    auto output_tensor = ttnn::prim::qsr::matmul(
+                             input_tensor_a_adjusted,
+                             input_tensor_b_adjusted,
+                             post_process_bias ? std::nullopt : bias,
+                             optional_output_tensor,
+                             attributes)
+                             .at(0);
+
+    if (input_tensor_b.logical_shape().rank() == 1) [[unlikely]] {
+        output_tensor = ttnn::reshape(
+            output_tensor,
+            utilities::compute_matmul_output_shape(
+                input_tensor_a, input_tensor_b, attributes.transpose_a, attributes.transpose_b));
+    }
+
+    // Apply bias as post-processing if needed
+    if (post_process_bias) {
+        output_tensor = ttnn::add(
+            output_tensor,
+            bias.value(),
+            /*output_dtype=*/std::nullopt,
+            output_tensor.memory_config(),
+            optional_output_tensor);
+    }
+
+    const auto& matmul_shape = utilities::compute_matmul_output_shape(
+        input_tensor_a, input_tensor_b, attributes.transpose_a, attributes.transpose_b);
+
+    ttnn::Shape result_shape = (bias.has_value()) ? utilities::compute_matmul_with_bias_output_shape(
+                                                        matmul_shape, bias.value().logical_shape())
+                                                  : matmul_shape;
+
+    if (optional_output_tensor.has_value()) {
+        const auto& desired_shape = optional_output_tensor->logical_shape();
+        uint64_t desired_vol = optional_output_tensor->logical_shape().volume();
+        uint64_t current_vol = std::accumulate(result_shape.begin(), result_shape.end(), 1ULL, std::multiplies<>());
+
+        TT_FATAL(desired_vol == current_vol, "Invalid optional output tensor");
+
+        output_tensor = ttnn::reshape(output_tensor, desired_shape);
+
+    } else if (bias.has_value()) {
+        output_tensor = ttnn::reshape(output_tensor, result_shape);
+    }
+
+    if (parameters.user_fused_activation.has_value() && !parameters.user_core_coord.has_value()) {
+        const UnaryWithParam& activation = parameters.user_fused_activation.value();
+
+        output_tensor =
+            ttnn::unary_chain(output_tensor, {activation}, output_tensor.memory_config(), optional_output_tensor);
+    }
+
+    return output_tensor;
+}
+
+Tensor matmul(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const bool transpose_a,
+    const bool transpose_b,
+    const std::optional<const MemoryConfig>& memory_config,
+    const std::optional<const DataType> dtype,
+    const std::optional<const MatmulProgramConfig>& program_config,
+    const std::optional<const Activation>& activation,
+    const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
+    const std::optional<const CoreGrid> core_grid,
+    const std::optional<const tt::tt_metal::Tile>& output_tile,
+    std::optional<Tensor> optional_output_tensor,
+    const std::optional<const GlobalCircularBuffer>& global_cb,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    std::optional<CoreCoord> user_core_coord;
+    if (core_grid.has_value()) {
+        user_core_coord = CoreCoord(core_grid->x, core_grid->y);
+    }
+    bool user_run_batched = detail::is_input_batched(input_tensor_b.logical_shape());
+    const bool untilize_out =
+        program_config.has_value() &&
+                std::holds_alternative<MatmulMultiCoreReuseMultiCast1DProgramConfig>(program_config.value())
+            ? std::get<MatmulMultiCoreReuseMultiCast1DProgramConfig>(program_config.value()).untilize_out
+            : false;
+    auto matmul_params = ttnn::prim::qsr::MatmulParams{
+        program_config,
+        /*bcast_batch=*/std::nullopt,
+        memory_config.has_value() ? memory_config.value() : ttnn::DRAM_MEMORY_CONFIG,
+        dtype,
+        compute_kernel_config,
+        untilize_out,
+        user_core_coord,
+        get_fused_activation(activation),
+        user_run_batched,
+        transpose_a,
+        transpose_b,
+        output_tile,
+        global_cb,
+        sub_device_id};
+
+    return bound_matmul(
+        input_tensor_a,
+        input_tensor_b,
+        /*bias=*/std::nullopt,
+        matmul_params,
+        optional_output_tensor);
+}
+
+Tensor linear(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const std::optional<const Tensor>& bias,
+    const bool transpose_a,
+    const bool transpose_b,
+    const std::optional<const MemoryConfig>& memory_config,
+    const std::optional<const DataType> dtype,
+    const std::optional<const MatmulProgramConfig>& program_config,
+    const std::optional<const Activation>& activation,
+    const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
+    const std::optional<const CoreGrid> core_grid,
+    const std::optional<const tt::tt_metal::Tile>& output_tile,
+    std::optional<ttnn::Tensor> optional_output_tensor,
+    const std::optional<const GlobalCircularBuffer>& global_cb,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    std::optional<CoreCoord> user_core_coord;
+    if (core_grid.has_value()) {
+        user_core_coord = CoreCoord(core_grid->x, core_grid->y);
+    }
+    bool user_run_batched = detail::is_input_batched(input_tensor_b.logical_shape());
+
+    auto matmul_params = ttnn::prim::qsr::MatmulParams{
+        program_config,
+        /*bcast_batch=*/std::nullopt,
+        memory_config.has_value() ? memory_config.value() : ttnn::DRAM_MEMORY_CONFIG,
+        dtype,
+        compute_kernel_config,
+        /*untilize_out=*/false,
+        user_core_coord,
+        get_fused_activation(activation),
+        user_run_batched,
+        transpose_a,
+        transpose_b,
+        output_tile,
+        global_cb,
+        sub_device_id};
+    return bound_matmul(input_tensor_a, input_tensor_b, bias, matmul_params, optional_output_tensor);
+}
+
+std::vector<Tensor> matmul_batched_weights(
+    const Tensor& input_tensor_a,
+    const std::vector<Tensor>& input_tensors_b,
+    const bool transpose_a,
+    const bool transpose_b,
+    const std::optional<const MemoryConfig>& memory_config,
+    const std::optional<const DataType> dtype,
+    const std::optional<const MatmulProgramConfig>& program_config,
+    const std::optional<const Activation>& activation,
+    const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
+    const std::optional<const CoreGrid> core_grid,
+    const std::optional<const tt::tt_metal::Tile>& output_tile,
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<const GlobalCircularBuffer>& global_cb,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    TT_FATAL(transpose_a == false, "cannot transpose A in batched matmul");
+    TT_FATAL(transpose_b == false, "cannot transpose B in batched matmul");
+    TT_FATAL(memory_config.has_value(), "memory_config must be provided");
+    TT_FATAL(program_config.has_value(), "program_config must be provided");
+    TT_FATAL(!activation.has_value(), "activation must not be provided");
+    TT_FATAL(!core_grid.has_value(), "core_grid must not be provided");
+    TT_FATAL(!output_tile.has_value(), "output_tile must not be provided");
+    TT_FATAL(!optional_output_tensor.has_value(), "optional_output_tensor must not be provided");
+    TT_FATAL(global_cb.has_value(), "global_cb must be provided");
+    TT_FATAL(sub_device_id.has_value(), "sub_device_id must be provided");
+
+    std::vector<Tensor> input_tensors = input_tensors_b;
+    input_tensors.insert(input_tensors.begin(), input_tensor_a);
+
+    auto parameters = ttnn::prim::qsr::MatmulParams{
+        program_config,
+        /*bcast_batch=*/std::nullopt,
+        memory_config.has_value() ? memory_config.value() : ttnn::DRAM_MEMORY_CONFIG,
+        dtype,
+        compute_kernel_config,
+        /*untilize_out=*/false,
+        /*user_core_coord*/ std::nullopt,
+        get_fused_activation(activation),
+        /*user_run_batched=*/false,
+        transpose_a,
+        transpose_b,
+        output_tile,
+        global_cb,
+        sub_device_id};
+
+    return ttnn::prim::qsr::matmul(
+        input_tensors,
+        optional_output_tensor,
+        ttnn::prim::qsr::create_matmul_attributes(
+            input_tensor_a, input_tensors_b[0], parameters, {optional_output_tensor}));
+}
+
+void addmm_validate(
+    const Tensor& input_tensor, const Tensor& mat1_tensor, const Tensor& mat2_tensor, float alpha, float beta) {
+    TT_FATAL(alpha != 0.0, "alpha parameter cannot be 0");
+
+    if (beta != 0.0) {
+        const auto& input_shape = input_tensor.logical_shape();
+        const auto& mat1_shape = mat1_tensor.logical_shape();
+        const auto& mat2_shape = mat2_tensor.logical_shape();
+
+        TT_FATAL(
+            input_shape[0] == mat1_shape[0] && input_shape[1] == mat2_shape[1],
+            "input_tensor must have shape matching one of result of mat1_tensor @ mat2_tensor");
+
+        auto idtype = input_tensor.dtype();
+        TT_FATAL(
+            idtype == DataType::BFLOAT16 || idtype == DataType::FLOAT32 || idtype == DataType::BFLOAT8_B,
+            "only ttnn.bfloat16, ttnn.float32 and ttnn.bfloat8_b types are supported for input_tensor");
+    }
+
+    auto m1type = mat1_tensor.dtype();
+    TT_FATAL(
+        m1type == DataType::BFLOAT16 || m1type == DataType::FLOAT32 || m1type == DataType::BFLOAT8_B,
+        "only ttnn.bfloat16, ttnn.float32 and ttnn.bfloat8_b types are supported for mat1_tensor");
+
+    auto m2type = mat2_tensor.dtype();
+    TT_FATAL(
+        m2type == DataType::BFLOAT16 || m2type == DataType::FLOAT32 || m2type == DataType::BFLOAT8_B,
+        "only ttnn.bfloat16, ttnn.float32 and ttnn.bfloat8_b types are supported for mat2_tensor");
+}
+
+Tensor addmm(
+    const Tensor& input_tensor,
+    const Tensor& mat1_tensor,
+    const Tensor& mat2_tensor,
+    float alpha,
+    float beta,
+    const std::optional<const MemoryConfig>& memory_config,
+    std::optional<const DataType> dtype,
+    const std::optional<const MatmulProgramConfig>& program_config,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
+    std::optional<const CoreGrid> core_grid,
+    const std::optional<const tt::tt_metal::Tile>& output_tile,
+    std::optional<Tensor> optional_output_tensor) {
+    TT_FATAL(!output_tile.has_value(), "output_tile must not be provided");
+
+    std::optional<CoreCoord> user_core_coord;
+    if (core_grid.has_value()) {
+        user_core_coord = CoreCoord(core_grid->x, core_grid->y);
+    }
+
+    addmm_validate(input_tensor, mat1_tensor, mat2_tensor, alpha, beta);
+
+    auto matmul_params = ttnn::prim::qsr::MatmulParams{
+        program_config,
+        std::nullopt,
+        memory_config.has_value() ? memory_config.value() : ttnn::DRAM_MEMORY_CONFIG,
+        dtype,
+        compute_kernel_config,
+        /*untilize_out=*/false,
+        /*user_core_coord=*/user_core_coord,
+        /*user_fused_activation=*/std::nullopt,
+        /*user_run_batched=*/false,
+        /*transpose_a=*/false,
+        /*transpose_b=*/false,
+        output_tile,
+        /*global_cb=*/std::nullopt,
+        /*sub_device_id=*/std::nullopt};
+    auto out_tensor = bound_matmul(mat1_tensor, mat2_tensor, std::nullopt, matmul_params, optional_output_tensor);
+
+    if (alpha != 1.0) {
+        multiply_(out_tensor, alpha);
+    }
+
+    if (beta != 0.0) {
+        auto add_tensor = beta != 1.0 ? multiply(input_tensor, beta) : input_tensor;
+        add_(out_tensor, add_tensor);
+    }
+
+    return out_tensor;
+}
+
+Tensor sparse_matmul(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const Tensor& sparsity,
+    const MatmulProgramConfig& program_config,
+    const std::optional<uint32_t> nnz,
+    bool is_input_a_sparse,
+    bool is_input_b_sparse,
+    const std::optional<const MemoryConfig>& memory_config,
+    const std::optional<const DataType> dtype,
+    const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
+    const std::optional<const CoreGrid> core_grid,
+    const std::optional<const tt::tt_metal::Tile>& output_tile,
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<const GlobalCircularBuffer>& global_cb,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    std::optional<CoreCoord> user_core_coord =
+        core_grid.has_value() ? std::make_optional(CoreCoord(core_grid->x, core_grid->y)) : std::nullopt;
+
+    return ttnn::prim::qsr::sparse_matmul(
+               input_tensor_a,
+               input_tensor_b,
+               sparsity,
+               optional_output_tensor,
+               nnz,
+               is_input_a_sparse,
+               is_input_b_sparse,
+               memory_config,
+               dtype,
+               program_config,
+               compute_kernel_config,
+               user_core_coord,
+               output_tile,
+               global_cb,
+               sub_device_id)
+        .at(0);
+}
+
+}  // namespace ttnn::operations::experimental::quasar::matmul

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/matmul.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/matmul.hpp
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <variant>
+#include <tt-metalium/core_coord.hpp>
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/config/matmul_program_config_types.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn {
+
+using ttnn::operations::unary::UnaryOpType;
+using ttnn::operations::unary::UnaryWithParam;
+
+using Activation = std::variant<std::string, UnaryWithParam>;
+
+namespace operations::experimental::quasar::matmul {
+
+namespace detail {
+
+bool is_input_batched(const ttnn::Shape& logical_shape);
+
+}  // namespace detail
+
+std::optional<UnaryWithParam> get_fused_activation(const std::optional<const Activation>& activation);
+
+Tensor matmul(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    bool transpose_a = false,
+    bool transpose_b = false,
+    const std::optional<const MemoryConfig>& memory_config = std::nullopt,
+    std::optional<const DataType> dtype = std::nullopt,
+    const std::optional<const MatmulProgramConfig>& program_config = std::nullopt,
+    const std::optional<const Activation>& activation = std::nullopt,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+    std::optional<const CoreGrid> core_grid = std::nullopt,
+    const std::optional<const tt::tt_metal::Tile>& output_tile = std::nullopt,
+    std::optional<Tensor> optional_output_tensor = std::nullopt,
+    const std::optional<const GlobalCircularBuffer>& global_cb = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+
+std::vector<Tensor> matmul_batched_weights(
+    const Tensor& input_tensor_a,
+    const std::vector<Tensor>& input_tensors_b,
+    bool transpose_a = false,
+    bool transpose_b = false,
+    const std::optional<const MemoryConfig>& memory_config = std::nullopt,
+    std::optional<const DataType> dtype = std::nullopt,
+    const std::optional<const MatmulProgramConfig>& program_config = std::nullopt,
+    const std::optional<const Activation>& activation = std::nullopt,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+    std::optional<const CoreGrid> core_grid = std::nullopt,
+    const std::optional<const tt::tt_metal::Tile>& output_tile = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    const std::optional<const GlobalCircularBuffer>& global_cb = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+
+Tensor linear(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const std::optional<const Tensor>& bias = std::nullopt,
+    bool transpose_a = false,
+    bool transpose_b = false,
+    const std::optional<const MemoryConfig>& memory_config = std::nullopt,
+    std::optional<const DataType> dtype = std::nullopt,
+    const std::optional<const MatmulProgramConfig>& program_config = std::nullopt,
+    const std::optional<const Activation>& activation = std::nullopt,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+    std::optional<const CoreGrid> core_grid = std::nullopt,
+    const std::optional<const tt::tt_metal::Tile>& output_tile = std::nullopt,
+    std::optional<Tensor> optional_output_tensor = std::nullopt,
+    const std::optional<const GlobalCircularBuffer>& global_cb = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+
+void addmm_validate(
+    const Tensor& input_tensor, const Tensor& mat1_tensor, const Tensor& mat2_tensor, float alpha, float beta);
+
+Tensor addmm(
+    const Tensor& input_tensor,
+    const Tensor& mat1_tensor,
+    const Tensor& mat2_tensor,
+    float alpha = 1.0f,
+    float beta = 1.0f,
+    const std::optional<const MemoryConfig>& memory_config = std::nullopt,
+    std::optional<const DataType> dtype = std::nullopt,
+    const std::optional<const MatmulProgramConfig>& program_config = std::nullopt,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+    std::optional<const CoreGrid> core_grid = std::nullopt,
+    const std::optional<const tt::tt_metal::Tile>& output_tile = std::nullopt,
+    std::optional<Tensor> optional_output_tensor = std::nullopt);
+
+Tensor sparse_matmul(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const Tensor& sparsity,
+    const MatmulProgramConfig& program_config,
+    std::optional<uint32_t> nnz = std::nullopt,
+    bool is_input_a_sparse = false,
+    bool is_input_b_sparse = true,
+    const std::optional<const MemoryConfig>& memory_config = std::nullopt,
+    std::optional<const DataType> dtype = std::nullopt,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+    std::optional<const CoreGrid> core_grid = std::nullopt,
+    const std::optional<const tt::tt_metal::Tile>& output_tile = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    const std::optional<const GlobalCircularBuffer>& global_cb = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+
+}  // namespace operations::experimental::quasar::matmul
+
+// NOTE: Quasar copies are intentionally NOT exported to the ttnn:: namespace (that would
+// collide with the original ttnn::matmul/linear/etc). They are reached via
+// ttnn::operations::experimental::quasar::matmul and bound under ttnn.experimental.quasar.
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/matmul_nanobind.cpp
@@ -1,0 +1,1331 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "matmul_nanobind.hpp"
+
+#include <cstddef>
+#include <optional>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/variant.h>
+#include <nanobind/stl/vector.h>
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+#include <tt-metalium/core_coord.hpp>
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/config/matmul_program_config.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/matmul_device_operation.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.hpp"
+#include "ttnn-nanobind/bind_function.hpp"
+#include "ttnn-nanobind/json_class.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/matmul.hpp"
+#include "ttnn/types.hpp"
+
+// fmt formatter for UnaryWithParam to enable fmt::format("{}", unary_with_param)
+template <>
+struct fmt::formatter<ttnn::operations::unary::UnaryWithParam> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+    template <typename FormatContext>
+    auto format(const ttnn::operations::unary::UnaryWithParam& param, FormatContext& ctx) const {
+        if (param.params.empty()) {
+            return fmt::format_to(ctx.out(), "UnaryWithParam(op_type={})", param.op_type);
+        }
+        return fmt::format_to(
+            ctx.out(), "UnaryWithParam(op_type={}, params=[{}])", param.op_type, fmt::join(param.params, ", "));
+    }
+};
+
+namespace ttnn::operations::experimental::quasar::matmul {
+
+struct MatmulProgramConfigPlaceholder {};
+
+using ttnn::operations::unary::UnaryWithParam;
+
+void py_module(nb::module_& mod) {
+    auto matmul_program_config = nb::class_<MatmulProgramConfigPlaceholder>(mod, "MatmulProgramConfig", R"doc(
+        Variant defining matmul program config
+    )doc");
+
+    auto matmul_multi_core_reuse_program_config =
+        tt_serializable_class<MatmulMultiCoreReuseProgramConfig>(mod, "MatmulMultiCoreReuseProgramConfig", R"doc(
+        Configuration class for multi-core reusable matmul operations.
+
+        This program config is used for basic multi-core matmul operations that can reuse
+        intermediate results across cores for better performance.
+    )doc");
+
+    matmul_multi_core_reuse_program_config.def(
+        nb::init<
+            CoreCoord,
+            std::size_t,
+            std::size_t,
+            std::size_t,
+            std::size_t,
+            std::size_t,
+            std::optional<CoreRangeSet>>(),
+        nb::kw_only(),
+        nb::arg("compute_with_storage_grid_size"),
+        nb::arg("in0_block_w").noconvert(),
+        nb::arg("out_subblock_h").noconvert(),
+        nb::arg("out_subblock_w").noconvert(),
+        nb::arg("per_core_M").noconvert(),
+        nb::arg("per_core_N").noconvert(),
+        nb::arg("allowed_worker_cores") = nb::none());
+    matmul_multi_core_reuse_program_config.def_rw(
+        "compute_with_storage_grid_size", &MatmulMultiCoreReuseProgramConfig::compute_with_storage_grid_size, R"doc(
+        Grid size for compute cores with storage capability.
+
+        Specifies the 2D grid of cores (x, y) that will be used for computation and have
+        access to storage. This determines how the computation is distributed across cores.
+
+        **DEPRECATED**: Use ``allowed_worker_cores`` instead for finer control over the compute grid.
+    )doc");
+    matmul_multi_core_reuse_program_config.def_rw("in0_block_w", &MatmulMultiCoreReuseProgramConfig::in0_block_w, R"doc(
+        Block width for both input tensors along the K dimension (shared inner dimension).
+
+        This parameter determines the granularity of data blocks by specifying how many tiles wide
+        each block is along the K dimension. It affects the size of data chunks processed together
+        and impacts memory usage and compute efficiency for both tensors. Must be a divisor of the
+        K dimension. Suggested to be a multiple of 32 for tile alignment.
+    )doc");
+    matmul_multi_core_reuse_program_config.def_rw(
+        "out_subblock_h", &MatmulMultiCoreReuseProgramConfig::out_subblock_h, R"doc(
+        Height of output subblocks in tiles.
+
+        Controls the granularity of computation within each output block along the M dimension.
+        Smaller values can reduce memory usage but may decrease efficiency. Must divide evenly
+        into the output block height.
+    )doc");
+    matmul_multi_core_reuse_program_config.def_rw(
+        "out_subblock_w", &MatmulMultiCoreReuseProgramConfig::out_subblock_w, R"doc(
+        Width of output subblocks in tiles.
+
+        Controls the granularity of computation within each output block along the N dimension.
+        Smaller values can reduce memory usage but may decrease efficiency. Must divide evenly
+        into the output block width.
+    )doc");
+    matmul_multi_core_reuse_program_config.def_rw("per_core_M", &MatmulMultiCoreReuseProgramConfig::per_core_M, R"doc(
+        Number of output tiles each core processes along the M dimension.
+
+        Determines how the M dimension of the output is distributed across cores.
+        Larger values mean fewer cores are used but each core does more work.
+        Must be chosen such that (total_M / per_core_M) cores are available.
+    )doc");
+    matmul_multi_core_reuse_program_config.def_rw("per_core_N", &MatmulMultiCoreReuseProgramConfig::per_core_N, R"doc(
+        Number of output tiles each core processes along the N dimension.
+
+        Determines how the N dimension of the output is distributed across cores.
+        Larger values mean fewer cores are used but each core does more work.
+        Must be chosen such that (total_N / per_core_N) cores are available.
+    )doc");
+    matmul_multi_core_reuse_program_config.def_rw(
+        "allowed_worker_cores", &MatmulMultiCoreReuseProgramConfig::allowed_worker_cores, R"doc(
+        Optional set of worker cores to restrict the matmul computation to.
+
+        When set, overrides ``compute_with_storage_grid_size`` for determining the active
+        compute grid. Accepts a ``CoreRangeSet`` describing the exact cores to use.
+    )doc");
+    matmul_multi_core_reuse_program_config.def("__repr__", [](const MatmulMultiCoreReuseProgramConfig& config) {
+        return fmt::format(
+            "MatmulMultiCoreReuseProgramConfig(compute_with_storage_grid_size={}, in0_block_w={}, out_subblock_h={}, "
+            "out_subblock_w={}, per_core_M={}, per_core_N={}, allowed_worker_cores={})",
+            config.compute_with_storage_grid_size,
+            config.in0_block_w,
+            config.out_subblock_h,
+            config.out_subblock_w,
+            config.per_core_M,
+            config.per_core_N,
+            config.allowed_worker_cores.has_value() ? fmt::format("{}", config.allowed_worker_cores.value()) : "None");
+    });
+
+    auto matmul_multi_core_reuse_multicast_program_config =
+        tt_serializable_class<MatmulMultiCoreReuseMultiCastProgramConfig>(
+            mod, "MatmulMultiCoreReuseMultiCastProgramConfig", R"doc(
+        The "2D" matmul program config is used for block sharded tensors, and general interleaved tensors.
+    )doc");
+
+    matmul_multi_core_reuse_multicast_program_config.def(
+        "__init__",
+        [](MatmulMultiCoreReuseMultiCastProgramConfig* t,
+           CoreCoord compute_with_storage_grid_size,
+           std::size_t in0_block_w,
+           std::size_t out_subblock_h,
+           std::size_t out_subblock_w,
+           std::optional<std::size_t> out_block_h,
+           std::optional<std::size_t> out_block_w,
+           std::size_t per_core_M,
+           std::size_t per_core_N,
+           bool transpose_mcast,
+           std::optional<UnaryWithParam> fused_activation,
+           bool fuse_batch,
+           std::optional<CoreRangeSet> allowed_worker_cores) {
+            std::size_t actual_out_block_h = out_block_h.value_or(per_core_M);
+            std::size_t actual_out_block_w = out_block_w.value_or(per_core_N);
+
+            new (t) MatmulMultiCoreReuseMultiCastProgramConfig{
+                compute_with_storage_grid_size,
+                in0_block_w,
+                out_subblock_h,
+                out_subblock_w,
+                actual_out_block_h,
+                actual_out_block_w,
+                per_core_M,
+                per_core_N,
+                transpose_mcast,
+                std::move(fused_activation),
+                fuse_batch,
+                std::move(allowed_worker_cores)};
+        },
+        nb::kw_only(),
+        nb::arg("compute_with_storage_grid_size"),
+        nb::arg("in0_block_w").noconvert(),
+        nb::arg("out_subblock_h").noconvert(),
+        nb::arg("out_subblock_w").noconvert(),
+        nb::arg("out_block_h") = nb::none(),
+        nb::arg("out_block_w") = nb::none(),
+        nb::arg("per_core_M").noconvert(),
+        nb::arg("per_core_N").noconvert(),
+        nb::arg("transpose_mcast").noconvert(),
+        nb::arg("fused_activation") = nb::none(),
+        nb::arg("fuse_batch").noconvert() = true,
+        nb::arg("allowed_worker_cores") = nb::none());
+
+    matmul_multi_core_reuse_multicast_program_config.def_rw(
+        "compute_with_storage_grid_size",
+        &MatmulMultiCoreReuseMultiCastProgramConfig::compute_with_storage_grid_size,
+        R"doc(
+        Grid size for compute cores with storage capability.
+
+        Specifies the 2D grid of cores (x, y) that will be used for computation and have
+        access to storage. This determines how the computation is distributed across cores
+        and affects multicast communication patterns.
+
+        **DEPRECATED**: Use ``allowed_worker_cores`` instead for finer control over the compute grid.
+    )doc");
+
+    matmul_multi_core_reuse_multicast_program_config.def_rw(
+        "in0_block_w", &MatmulMultiCoreReuseMultiCastProgramConfig::in0_block_w, R"doc(
+        Block width for both input tensors along the K dimension (shared inner dimension).
+
+        Determines the data granularity by specifying how many tiles wide each block is along
+        the K dimension for both input_tensor_a and input_tensor_b in multicast operations.
+        Must be a divisor of the K dimension. Smaller blocks can improve load balancing but
+        may increase communication overhead in multicast scenarios.
+    )doc");
+
+    matmul_multi_core_reuse_multicast_program_config.def_rw(
+        "out_subblock_h", &MatmulMultiCoreReuseMultiCastProgramConfig::out_subblock_h, R"doc(
+        Height of output subblocks in tiles.
+
+        Controls the granularity of computation within each output block along the M dimension.
+        Must divide evenly into out_block_h. Affects memory usage and compute scheduling
+        in the multicast implementation.
+    )doc");
+
+    matmul_multi_core_reuse_multicast_program_config.def_rw(
+        "out_subblock_w", &MatmulMultiCoreReuseMultiCastProgramConfig::out_subblock_w, R"doc(
+        Width of output subblocks in tiles.
+
+        Controls the granularity of computation within each output block along the N dimension.
+        Must divide evenly into out_block_w. Affects memory usage and compute scheduling
+        in the multicast implementation.
+    )doc");
+
+    matmul_multi_core_reuse_multicast_program_config.def_rw(
+        "out_block_h", &MatmulMultiCoreReuseMultiCastProgramConfig::out_block_h, R"doc(
+        Height of output blocks in tiles.
+
+        Specifies the block size for output tensor along the M dimension. If not provided,
+        defaults to per_core_M. Must be divisible by out_subblock_h and should be chosen
+        to optimize multicast efficiency and memory usage.
+    )doc");
+
+    matmul_multi_core_reuse_multicast_program_config.def_rw(
+        "out_block_w", &MatmulMultiCoreReuseMultiCastProgramConfig::out_block_w, R"doc(
+        Width of output blocks in tiles.
+
+        Specifies the block size for output tensor along the N dimension. If not provided,
+        defaults to per_core_N. Must be divisible by out_subblock_w and should be chosen
+        to optimize multicast efficiency and memory usage.
+    )doc");
+
+    matmul_multi_core_reuse_multicast_program_config.def_rw(
+        "per_core_M", &MatmulMultiCoreReuseMultiCastProgramConfig::per_core_M, R"doc(
+        Number of output tiles each core processes along the M dimension.
+
+        Determines how the M dimension is distributed across cores in the multicast setup.
+        Used as the default value for out_block_h if not explicitly specified.
+    )doc");
+
+    matmul_multi_core_reuse_multicast_program_config.def_rw(
+        "per_core_N", &MatmulMultiCoreReuseMultiCastProgramConfig::per_core_N, R"doc(
+        Number of output tiles each core processes along the N dimension.
+
+        Determines how the N dimension is distributed across cores in the multicast setup.
+        Used as the default value for out_block_w if not explicitly specified.
+    )doc");
+
+    matmul_multi_core_reuse_multicast_program_config.def_rw(
+        "transpose_mcast", &MatmulMultiCoreReuseMultiCastProgramConfig::transpose_mcast, R"doc(
+        Whether to transpose the multicast communication pattern.
+
+        When true, the multicast direction is transposed, which can be beneficial for
+        certain tensor shapes and grid configurations. This affects how data is broadcast
+        across cores and can impact performance depending on the access patterns.
+    )doc");
+
+    matmul_multi_core_reuse_multicast_program_config.def_rw(
+        "fused_activation", &MatmulMultiCoreReuseMultiCastProgramConfig::fused_activation, R"doc(
+        Optional fused activation function to apply to the output.
+
+        If provided, the specified activation function (e.g., ReLU, GELU) is applied
+        directly during the matmul computation, avoiding the need for a separate activation
+        operation and improving performance.
+    )doc");
+
+    matmul_multi_core_reuse_multicast_program_config.def_rw(
+        "fuse_batch", &MatmulMultiCoreReuseMultiCastProgramConfig::fuse_batch, R"doc(
+        Whether to fuse batch dimensions into the matrix dimensions.
+
+        When true, batch dimensions are fused with the M dimension, allowing for more
+        efficient processing of batched matrix multiplications. This can improve performance
+        for operations with large batch sizes. Defaults to true.
+
+        Note: the batch dimensions need to all be 1 for the second input tensor when fuse_batch is true.
+    )doc");
+    matmul_multi_core_reuse_multicast_program_config.def_rw(
+        "allowed_worker_cores",
+        &MatmulMultiCoreReuseMultiCastProgramConfig::allowed_worker_cores,
+        R"doc(
+        Optional set of worker cores to restrict the matmul computation to.
+
+        When set, overrides ``compute_with_storage_grid_size`` for determining the active
+        compute grid. Accepts a ``CoreRangeSet`` describing the exact cores to use.
+    )doc");
+    matmul_multi_core_reuse_multicast_program_config.def(
+        "__repr__", [](const MatmulMultiCoreReuseMultiCastProgramConfig& config) {
+            return fmt::format(
+                "MatmulMultiCoreReuseMultiCastProgramConfig(compute_with_storage_grid_size={}, in0_block_w={}, "
+                "out_subblock_h={}, out_subblock_w={}, out_block_h={}, out_block_w={}, per_core_M={}, "
+                "per_core_N={}, transpose_mcast={}, fused_activation={}, fuse_batch={}, allowed_worker_cores={})",
+                config.compute_with_storage_grid_size,
+                config.in0_block_w,
+                config.out_subblock_h,
+                config.out_subblock_w,
+                config.out_block_h,
+                config.out_block_w,
+                config.per_core_M,
+                config.per_core_N,
+                config.transpose_mcast,
+                config.fused_activation,
+                config.fuse_batch,
+                config.allowed_worker_cores.has_value() ? fmt::format("{}", config.allowed_worker_cores.value())
+                                                        : "None");
+        });
+
+    auto matmul_multi_core_reuse_multicast_1d_program_config =
+        tt_serializable_class<MatmulMultiCoreReuseMultiCast1DProgramConfig>(
+            mod, "MatmulMultiCoreReuseMultiCast1DProgramConfig", R"doc(
+        Configuration class for 1D multicast matmul operations with advanced features.
+
+        This program config is for use with width and height sharded tensors, or very narrow interleaved tensors.
+
+        When ``gather_in0`` is False and the matmul op is invoked with a ``sub_device_id``,
+        ``compute_with_storage_grid_size`` is anchored at the sub-device's worker bounding-box start
+        instead of ``(0, 0)``. The 1D multicast targets a single bounding-box rectangle and the
+        per-core index math assumes a contiguous row-major rectangle, so the sub-device's worker
+        cores must themselves form a single rectangle. Non-rectangular sub-device worker grids are
+        rejected at validate time. When ``gather_in0`` is True, ``compute_with_storage_grid_size``
+        is ignored and the gather path can run on any sub-device worker layout.
+    )doc");
+
+    matmul_multi_core_reuse_multicast_1d_program_config
+        .def(
+            "__init__",
+            [](MatmulMultiCoreReuseMultiCast1DProgramConfig* t,
+               CoreCoord compute_with_storage_grid_size,
+               std::size_t in0_block_w,
+               std::size_t out_subblock_h,
+               std::size_t out_subblock_w,
+               std::optional<std::size_t> out_block_h,
+               std::optional<std::size_t> out_block_w,
+               std::size_t per_core_M,
+               std::size_t per_core_N,
+               bool fuse_batch,
+               std::optional<UnaryWithParam> fused_activation,
+               bool mcast_in0,
+               bool gather_in0,
+               CoreRangeSet hop_cores,
+               std::size_t num_global_cb_receivers,
+               bool untilize_out,
+               std::optional<CoreRangeSet> allowed_worker_cores) {
+                std::size_t actual_out_block_h = out_block_h.value_or(per_core_M);
+                std::size_t actual_out_block_w = out_block_w.value_or(per_core_N);
+
+                new (t) MatmulMultiCoreReuseMultiCast1DProgramConfig{
+                    compute_with_storage_grid_size,
+                    in0_block_w,
+                    out_subblock_h,
+                    out_subblock_w,
+                    actual_out_block_h,
+                    actual_out_block_w,
+                    per_core_M,
+                    per_core_N,
+                    fuse_batch,
+                    std::move(fused_activation),
+                    mcast_in0,
+                    gather_in0,
+                    std::move(hop_cores),
+                    num_global_cb_receivers,
+                    untilize_out,
+                    std::move(allowed_worker_cores)};
+            },
+            nb::kw_only(),
+            nb::arg("compute_with_storage_grid_size"),
+            nb::arg("in0_block_w").noconvert(),
+            nb::arg("out_subblock_h").noconvert(),
+            nb::arg("out_subblock_w").noconvert(),
+            nb::arg("out_block_h") = nb::none(),
+            nb::arg("out_block_w") = nb::none(),
+            nb::arg("per_core_M").noconvert(),
+            nb::arg("per_core_N").noconvert(),
+            nb::arg("fuse_batch").noconvert(),
+            nb::arg("fused_activation") = nb::none(),
+            nb::arg("mcast_in0").noconvert(),
+            nb::arg("gather_in0").noconvert() = false,
+            nb::arg("hop_cores").noconvert() = nb::cast(CoreRangeSet()),
+            nb::arg("num_global_cb_receivers").noconvert() = 1,
+            nb::arg("untilize_out").noconvert() = false,
+            nb::arg("allowed_worker_cores") = nb::none())
+        .def_rw(
+            "compute_with_storage_grid_size",
+            &MatmulMultiCoreReuseMultiCast1DProgramConfig::compute_with_storage_grid_size,
+            R"doc(
+            Grid size for compute cores with storage capability.
+
+            Defines the 2D grid of cores that will be used for computation. In 1D multicast,
+            this grid is used to determine the communication pattern for broadcasting data
+            along one dimension while distributing computation.
+
+            When the matmul op is invoked with a ``sub_device_id`` (and ``gather_in0`` is False),
+            this rectangle is anchored at the sub-device's worker bounding-box start (instead of
+            ``(0, 0)``) and must fit inside that bounding box. Ignored when ``gather_in0`` is True.
+
+            **DEPRECATED**: Use ``allowed_worker_cores`` instead for finer control over the compute grid.
+        )doc")
+        .def_rw("in0_block_w", &MatmulMultiCoreReuseMultiCast1DProgramConfig::in0_block_w, R"doc(
+            Block width for both input tensors along the K dimension (shared inner dimension).
+
+            Determines the data granularity by specifying how many tiles wide each block is
+            along the inner dimension for both input_tensor_a and input_tensor_b. This parameter
+            impacts 1D multicast performance as it affects the size of data chunks that
+            are broadcast across cores and memory access patterns for both tensors.
+        )doc")
+        .def_rw("out_subblock_h", &MatmulMultiCoreReuseMultiCast1DProgramConfig::out_subblock_h, R"doc(
+            Height of output subblocks in tiles.
+
+            Controls computation granularity within output blocks along the M dimension.
+            In 1D multicast, this affects how computation is scheduled and memory usage
+            patterns across the participating cores.
+        )doc")
+        .def_rw("out_subblock_w", &MatmulMultiCoreReuseMultiCast1DProgramConfig::out_subblock_w, R"doc(
+            Width of output subblocks in tiles.
+
+            Controls computation granularity within output blocks along the N dimension.
+            This parameter affects the efficiency of the 1D multicast communication pattern
+            and compute scheduling.
+        )doc")
+        .def_rw("out_block_h", &MatmulMultiCoreReuseMultiCast1DProgramConfig::out_block_h, R"doc(
+            Height of output blocks in tiles.
+
+            Defines the output block size along the M dimension. If not specified, defaults
+            to per_core_M. This parameter is important for optimizing the 1D multicast
+            pattern and memory access efficiency.
+        )doc")
+        .def_rw("out_block_w", &MatmulMultiCoreReuseMultiCast1DProgramConfig::out_block_w, R"doc(
+            Width of output blocks in tiles.
+
+            Defines the output block size along the N dimension. If not specified, defaults
+            to per_core_N. This affects the efficiency of data distribution in the 1D
+            multicast implementation.
+        )doc")
+        .def_rw("per_core_M", &MatmulMultiCoreReuseMultiCast1DProgramConfig::per_core_M, R"doc(
+            Number of output tiles each core processes along the M dimension.
+
+            Determines the workload distribution along the M dimension in the 1D multicast
+            pattern. This affects both load balancing and communication efficiency.
+        )doc")
+        .def_rw("per_core_N", &MatmulMultiCoreReuseMultiCast1DProgramConfig::per_core_N, R"doc(
+            Number of output tiles each core processes along the N dimension.
+
+            Determines the workload distribution along the N dimension in the 1D multicast
+            pattern. This parameter is crucial for achieving optimal performance in
+            1D multicast scenarios.
+        )doc")
+        .def_rw("fuse_batch", &MatmulMultiCoreReuseMultiCast1DProgramConfig::fuse_batch, R"doc(
+            Whether to fuse batch dimensions into matrix dimensions.
+
+            When true, batch dimensions are incorporated into the matrix computation,
+            allowing for more efficient processing of batched operations in the 1D
+            multicast implementation.
+
+            Note: the batch dimensions need to all be 1 for the second input tensor when fuse_batch is true.
+        )doc")
+        .def_rw("fused_activation", &MatmulMultiCoreReuseMultiCast1DProgramConfig::fused_activation, R"doc(
+            Optional fused activation function to apply during computation.
+
+            If specified, the activation function is applied directly during the matmul
+            operation, eliminating the need for a separate activation pass and improving
+            overall performance in 1D multicast scenarios.
+        )doc")
+        .def_rw("mcast_in0", &MatmulMultiCoreReuseMultiCast1DProgramConfig::mcast_in0, R"doc(
+            Whether to multicast the first input tensor (input_tensor_a).
+
+            When true, input_tensor_a is broadcast across cores using the 1D multicast
+            pattern, which can significantly reduce memory bandwidth requirements for
+            certain matrix shapes and improve performance.
+        )doc")
+        .def_rw("gather_in0", &MatmulMultiCoreReuseMultiCast1DProgramConfig::gather_in0, R"doc(
+            Defaults to false.
+            Used by ops that call matmul internally. Should not be specified or left as the default value for all other uses.
+        )doc")
+        .def_rw("hop_cores", &MatmulMultiCoreReuseMultiCast1DProgramConfig::hop_cores, R"doc(
+            Defaults to empty set.
+            Used by ops that call matmul internally. Should not be specified or left as the default value for all other uses.
+        )doc")
+        .def_rw(
+            "num_global_cb_receivers", &MatmulMultiCoreReuseMultiCast1DProgramConfig::num_global_cb_receivers, R"doc(
+            Defaults to 1.
+            Used by ops that call matmul internally. Should not be specified or left as the default value for all other uses.
+        )doc")
+        .def_rw("untilize_out", &MatmulMultiCoreReuseMultiCast1DProgramConfig::untilize_out, R"doc(
+            Whether to untilize the output tensor.
+
+            When true, the output is converted from tiled layout to row-major layout during
+            the operation. This can be useful when the subsequent operation expects row-major
+            data and can eliminate a separate untilization pass. Defaults to false.
+        )doc")
+        .def_rw(
+            "allowed_worker_cores",
+            &MatmulMultiCoreReuseMultiCast1DProgramConfig::allowed_worker_cores,
+            R"doc(
+            Optional set of worker cores to restrict the matmul computation to.
+
+            When set, overrides ``compute_with_storage_grid_size`` for determining the active
+            compute grid. Accepts a ``CoreRangeSet`` describing the exact cores to use.
+        )doc")
+        .def("__repr__", [](const MatmulMultiCoreReuseMultiCast1DProgramConfig& config) {
+            return fmt::format(
+                "MatmulMultiCoreReuseMultiCast1DProgramConfig(compute_with_storage_grid_size={}, in0_block_w={}, "
+                "out_block_h={}, out_block_w={}, out_subblock_h={}, out_subblock_w={}, per_core_M={}, per_core_N={}, "
+                "fuse_batch={}, fused_activation={}, mcast_in0={}, gather_in0={}, hop_cores={}, "
+                "num_global_cb_receivers={}, untilize_out={}, allowed_worker_cores={})",
+                config.compute_with_storage_grid_size,
+                config.in0_block_w,
+                config.out_block_h,
+                config.out_block_w,
+                config.out_subblock_h,
+                config.out_subblock_w,
+                config.per_core_M,
+                config.per_core_N,
+                config.fuse_batch,
+                config.fused_activation,
+                config.mcast_in0,
+                config.gather_in0,
+                config.hop_cores,
+                config.num_global_cb_receivers,
+                config.untilize_out,
+                config.allowed_worker_cores.has_value() ? fmt::format("{}", config.allowed_worker_cores.value())
+                                                        : "None");
+        });
+
+    auto matmul_multi_core_reuse_multicast_dram_sharded_program_config =
+        tt_serializable_class<MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>(
+            mod, "MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig", R"doc(
+        This program config is a specialized config for very narrow tensors stored in DRAM.
+    )doc");
+
+    matmul_multi_core_reuse_multicast_dram_sharded_program_config
+        .def(
+            nb::init<std::size_t, std::size_t, std::size_t, std::optional<UnaryWithParam>>(),
+            nb::kw_only(),
+            nb::arg("in0_block_w").noconvert(),
+            nb::arg("per_core_M").noconvert(),
+            nb::arg("per_core_N").noconvert(),
+            nb::arg("fused_activation") = nb::none())
+        .def_rw("in0_block_w", &MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig::in0_block_w, R"doc(
+            Block width for both input tensors along the K dimension (shared inner dimension).
+
+            Determines the data granularity by specifying how many tiles wide each block is
+            along the inner dimension for both input_tensor_a and input_tensor_b in DRAM-sharded
+            operations. This parameter must be chosen to align with the DRAM sharding
+            strategy and optimize memory bandwidth utilization for both tensors.
+        )doc")
+        .def_rw("per_core_M", &MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig::per_core_M, R"doc(
+            Number of output tiles each core processes along the M dimension.
+
+            Determines how the M dimension is distributed across cores in DRAM-sharded
+            scenarios. This must align with the DRAM sharding pattern to ensure optimal
+            performance and avoid memory access conflicts.
+        )doc")
+        .def_rw("per_core_N", &MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig::per_core_N, R"doc(
+            Number of output tiles each core processes along the N dimension.
+
+            Determines how the N dimension is distributed across cores in DRAM-sharded
+            scenarios. This parameter affects the multicast efficiency and must be
+            compatible with the DRAM sharding configuration.
+        )doc")
+        .def_rw("fused_activation", &MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig::fused_activation, R"doc(
+            Optional fused activation function to apply during computation.
+
+            If specified, the activation function is applied directly during the DRAM-sharded
+            matmul operation. This can provide significant performance benefits by avoiding
+            additional memory round-trips in DRAM-based operations.
+        )doc")
+        .def("__repr__", [](const MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig& config) {
+            // Include fused_activation in the repr for full visibility during tracing/debugging.
+            std::string fused_activation_repr =
+                config.fused_activation.has_value() ? fmt::format("{}", config.fused_activation.value()) : "None";
+            return fmt::format(
+                "MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(in0_block_w={}, per_core_M={}, per_core_N={}, "
+                "fused_activation={})",
+                config.in0_block_w,
+                config.per_core_M,
+                config.per_core_N,
+                fused_activation_repr);
+        });
+
+    auto matmul_multi_core_reuse_multicast_batched_dram_sharded_program_config =
+        tt_serializable_class<MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>(
+            mod, "MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig", R"doc(
+        This program config is a specialised config for batched DRAM sharded operations, where the inputs are sharded along the batch dimension.
+    )doc");
+
+    matmul_multi_core_reuse_multicast_batched_dram_sharded_program_config
+        .def(
+            nb::init<std::size_t, std::size_t, std::size_t, std::optional<UnaryWithParam>>(),
+            nb::kw_only(),
+            nb::arg("in0_block_w").noconvert(),
+            nb::arg("per_core_M").noconvert(),
+            nb::arg("per_core_N").noconvert(),
+            nb::arg("fused_activation") = nb::none())
+        .def_rw("in0_block_w", &MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig::in0_block_w, R"doc(
+            Block width for both input tensors along the K dimension (shared inner dimension).
+
+            Determines the data granularity by specifying how many tiles wide each block is
+            along the inner dimension for both input_tensor_a and input_tensor_b in batched DRAM-sharded
+            operations. This parameter must be chosen to align with the DRAM sharding
+            strategy and optimize memory bandwidth utilization for both tensors.
+        )doc")
+        .def_rw("per_core_M", &MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig::per_core_M, R"doc(
+            Number of output tiles each core processes along the M dimension.
+
+            Determines how the M dimension is distributed across cores in batched DRAM-sharded
+            scenarios. This must align with the DRAM sharding pattern to ensure optimal
+            performance and avoid memory access conflicts.
+        )doc")
+        .def_rw("per_core_N", &MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig::per_core_N, R"doc(
+            Number of output tiles each core processes along the N dimension.
+
+            Determines how the N dimension is distributed across cores in batched DRAM-sharded
+            scenarios. This parameter affects the multicast efficiency and must be
+            compatible with the DRAM sharding configuration.
+        )doc")
+        .def_rw(
+            "fused_activation", &MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig::fused_activation, R"doc(
+            Optional fused activation function to apply during computation.
+
+            If specified, the activation function is applied directly during the batched DRAM-sharded
+            matmul operation. This can provide significant performance benefits by avoiding
+            additional memory round-trips in DRAM-based operations.
+        )doc");
+
+    ttnn::bind_function<"matmul">(
+        mod,
+        R"doc(
+        Returns the matrix product of two tensors.
+
+        The input tensors need to be tiled and at least 1-dimensional.
+
+        - If both input tensors are 1-dimensional, then the operation is a dot product.
+        - If first input tensor is 1-dimensional and the other input tensor is at least 2-dimensional,
+          the batched vector-matrix multiplication is performed.
+        - If the first input tensor is at least 2-dimensional and the second input tensor is 1-dimensional,
+          the batched matrix-vector multiplication is performed.
+        - If both input tensors are at least 2-dimensional, then a batched matrix multiply is performed.
+
+        The following are the allowed possibilities for batch dimensions.
+        Examples below show concrete operations and tensor sizes.
+
+        - If all batch dimensions are of size 1, then there is no batched operation.
+
+        - If both inputs have batch dimensions that are not all of size 1, then the
+          batch dimensions of both inputs should be the same. If the dimensions are
+          not the same then, although there may be combinations that may work, in most
+          cases various errors will be reported.
+
+        - If the first input has batch dimensions that are not all of size 1, and the
+          second input has no batch dimensions or has batch dimensions all of size 1,
+          then the second input is broadcasted to align appropriately with the first
+          input.
+
+        - Matrix multiplication will not work if the first input has batch
+          dimensions that are all of size 1 and the second input has batch dimensions
+          that are not all of size 1.
+
+        - Note: In general, the number of dimensions between the two inputs should
+          match. There may be cases where they don't. In that case, if the inputs
+          are not valid based on the above criteria, the error messages may
+          be unexpected and refer to non-obvious issues.
+
+        - Note: There are various combinations of dimensions possible. The behaviour
+          is the same as PyTorch, except for two exceptions.
+          These exceptions are for the following scenarios related to batch
+          dimensions:
+
+              - The two batch dimensions are swapped. E.g. the first input has (`j` x `1`)
+                and the second input has (`1` x `j`)
+                or the first input has (`1` x `j`) and the second input has
+                (`j` x `1`)
+              - When a batch dimension is implicitly extended, the two patch dimensions are swapped.
+                E.g.  (`j` x `1`) and (`j`) which is treated as
+                (`j` x `1`) and (`1` x `j`)
+
+        - In order to leverage sharded matmul implementations we can shard both `input_tensor_a` and `input_tensor_b`. The sharding strategy used will be according
+          to the sharding strategy on the respective tensor. A sharded 1D matmul can be either HEIGHT or WIDTH sharded, 2D matmuls can be BLOCK sharded.
+
+          - For 1D sharded matmul variants (width- or height-sharded inputs), if a sharded :attr:`memory_config` is
+            provided for the output, its memory layout and buffer type must match those of :attr:`input_tensor_a`.
+
+          Note: the broadcasting logic only looks at the batch dimensions when determining if the inputs
+          are broadcastable, and not the matrix dimensions. For example, if :attr:`input_tensor_a` is a
+          (`j` x `1` x `n_size` x `m_size`) tensor and :attr:`input_tensor_b` is a (`k_size` x `m_size` x `p`)
+          tensor, these inputs are valid for broadcasting even though the final two dimensions (i.e. the
+          matrix dimensions) are different. The operation will return a (`j` x `k_size` x `n_size` x `p`) tensor.
+
+        - Note: there are various additional constraints related to specific program
+          configs chosen. Please look at the error messages carefully and fix
+          problems appropriately.
+        - Note: If optional output tensor is specified, then dtype and memory config need to be checked as follows:
+          - if they are default then they should be set based on optional output tensor
+          - if the are not default then they should be compared and if there is a difference an error is reported
+        - Note: Due to a hardware bug on Wormhole (fixed on Blackhole), when fp32_acc_to_dest is enabled in the
+          compute_kernel_config, output values can rarely be off by a negative power of two (e.g. -128).
+          This bug happens most frequently at HiFi4, and in decreasing frequency as math fidelity is reduced (e.g. HiFi3, HiFi2, LoFi).
+          This bug can happen when the original mantissa contains all 1.
+          If affected, consider either disabling fp32_acc_to_dest, if that does not impact numerical stability
+          in your use case, or decreasing fidelity.
+
+        Args:
+            input_tensor_a (ttnn.Tensor): the first tensor to be multiplied. Needs to be on the device.
+            input_tensor_b (ttnn.Tensor): the second tensor to be multiplied. Needs to be on the device.
+
+        Keyword Args:
+            transpose_a (bool, optional): Whether to transpose input_tensor_a. Defaults to `False`.
+            transpose_b (bool, optional): Whether to transpose input_tensor_b. Defaults to `False`.
+            memory_config(ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using ttnn.DRAM_MEMORY_CONFIG.
+            dtype (ttnn.DataType): the data type of the output tensor. Defaults to `None`.
+            program_config (ttnn.MatmulProgramConfig): the program configuration for the matmul operation. Defaults to `None`.
+            activation (str or ttnn.UnaryWithParam, optional): the activation function to be applied. When using sharded tensors, the :attr:`fused_activation` parameter of the :attr:`program_config` should be used instead. Defaults to `None`.
+            compute_kernel_config (ttnn.DeviceComputeKernelConfig): the compute kernel configuration for the matmul operation. Defaults to `None`.
+            core_grid (ttnn.CoreGrid): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.
+            output_tile (List of [int], optional): Specifies the output tile configuration. Defaults to `None`.
+            optional_output_tensor (ttnn.Tensor, optional): User provided on-device output tensor where the result of matmul is to be written. Defaults to `None`.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        Note:
+            The input tensors support the following data types and layouts:
+
+            .. list-table:: input_tensor_a
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
+                  - TILE
+
+            .. list-table:: input_tensor_b
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
+                  - TILE
+
+        Memory Support:
+            The supported memory configurations for the two input tensors are program config dependent, as described below:
+
+            .. list-table:: Supported Memory Configurations
+                :header-rows: 1
+
+                * - Config
+                  - Input A
+                  - Input B
+                * - MatmulMultiCoreReuseProgramConfig
+                  - Interleaved (L1/DRAM), Height Sharded (L1), or Block Sharded (L1)
+                  - Interleaved (L1/DRAM), Height Sharded (L1), or Block Sharded (L1)
+                * - MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig
+                  - Width Sharded (L1)
+                  - Width Sharded (DRAM)
+                * - MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig
+                  - Height Sharded (L1)
+                  - Height Sharded (DRAM)
+                * - MatmulMultiCoreReuseMultiCastProgramConfig
+                  - Interleaved (L1/DRAM), Block Sharded (L1)
+                  - Interleaved (L1/DRAM), Width Sharded (DRAM)
+                * - MatmulMultiCoreReuseMultiCastProgramConfig (only for row major orientation without transpose multicast)
+                  - Interleaved (L1/DRAM), Height Sharded (L1)
+                  - Interleaved (L1/DRAM), Width Sharded (L1/DRAM), Height Sharded (DRAM batched matmuls where each bank holds B/num_banks complete [K,N] matrices)
+                * - MatmulMultiCoreReuseMultiCast1DProgramConfig (mcast_in0=False)
+                  - Interleaved (L1/DRAM), Width Sharded (L1)
+                  - Interleaved (L1/DRAM), Width Sharded (L1)
+                * - MatmulMultiCoreReuseMultiCast1DProgramConfig (mcast_in0=True)
+                  - Interleaved (L1/DRAM), Height Sharded (L1)
+                  - Interleaved (L1/DRAM)
+
+            When sharded output tensors are provided, they should match :attr:`input_tensor_a`'s buffer type and memory layout.
+        )doc",
+        ttnn::overload_t(
+            &matmul,
+            nb::arg("input_tensor_a"),
+            nb::arg("input_tensor_b"),
+            nb::kw_only(),
+            nb::arg("transpose_a") = false,
+            nb::arg("transpose_b") = false,
+            nb::arg("memory_config") = nb::none(),
+            nb::arg("dtype") = nb::none(),
+            nb::arg("program_config") = nb::none(),
+            nb::arg("activation") = nb::none(),
+            nb::arg("compute_kernel_config") = nb::none(),
+            nb::arg("core_grid") = nb::none(),
+            nb::arg("output_tile") = nb::none(),
+            nb::arg("optional_output_tensor") = nb::none(),
+            nb::arg("global_cb") = nb::none(),
+            nb::arg("sub_device_id") = nb::none()));
+
+    ttnn::bind_function<"linear">(
+        mod,
+        R"doc(
+        Returns the linear transformation of the inputs.
+
+        The limitations and behaviours are the same as for matmul.
+
+        Note:
+            The tensors support the following data types and layouts:
+
+            .. list-table:: input_tensor_a
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
+                  - TILE
+
+            .. list-table:: input_tensor_b
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
+                  - TILE
+
+            .. list-table:: bias
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
+                  - TILE
+
+        Args:
+            input_tensor_a (ttnn.Tensor): the first tensor to be multiplied. Needs to be on the device.
+            input_tensor_b (ttnn.Tensor): the second tensor to be multiplied. Needs to be on the device.
+
+        Keyword Args:
+            bias (ttnn.Tensor, optional): the bias tensor to be added. If specified, needs to be on the device. Defaults to `None`.
+            transpose_a (bool, optional): Whether to transpose input_tensor_a. Defaults to `False`.
+            transpose_b (bool, optional): Whether to transpose input_tensor_b. Defaults to `False`.
+            memory_config (ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using `ttnn.DRAM_MEMORY_CONFIG`.
+            dtype (ttnn.DataType, optional): the data type of the output tensor. Defaults to `None`.
+            program_config (MatmulProgramConfig, optional): the program configuration for the matmul operation. Defaults to `None`.
+            activation (str or ttnn.UnaryWithParam, optional): the activation function to be applied. Defaults to `None`. When using sharded tensors, the :attr:`fused_activation` parameter of the :attr:`program_config` should be used instead.
+            compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): the compute kernel configuration for the matmul operation. Defaults to `None`.
+            core_grid (ttnn.CoreGrid, optional): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.
+            output_tile (List of [int], optional): Specifies the output tile configuration. Defaults to `None`.
+            optional_output_tensor (ttnn.Tensor, optional): User provided on-device output tensor where the result of linear is to be written. Defaults to `None`.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+        )doc",
+        ttnn::overload_t(
+            &linear,
+            nb::arg("input_tensor_a"),
+            nb::arg("input_tensor_b"),
+            nb::kw_only(),
+            nb::arg("bias") = nb::none(),
+            nb::arg("transpose_a") = false,
+            nb::arg("transpose_b") = false,
+            nb::arg("memory_config") = nb::none(),
+            nb::arg("dtype") = nb::none(),
+            nb::arg("program_config") = nb::none(),
+            nb::arg("activation") = nb::none(),
+            nb::arg("compute_kernel_config") = nb::none(),
+            nb::arg("core_grid") = nb::none(),
+            nb::arg("output_tile") = nb::none(),
+            nb::arg("optional_output_tensor") = nb::none(),
+            nb::arg("global_cb") = nb::none(),
+            nb::arg("sub_device_id") = nb::none()));
+
+    ttnn::bind_function<"matmul_batched_weights">(
+        mod,
+        R"doc(
+        DEPRECATED: This is for experimental internal use and is not supported.
+
+        Performs matrix multiplication for a single input tensor a with multiple tensors b, and returns a vector of output tensors.
+
+        Args:
+            input_tensor_a (ttnn.Tensor): the first tensor to be multiplied. Needs to be on the device.
+            input_tensors_b (List of ttnn.Tensor): the tensors to be multiplied. Needs to be on the device.
+
+        Note:
+            The tensors support the following data types and layouts:
+
+            .. list-table:: input_tensor_a
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
+                  - TILE
+
+            .. list-table:: input_tensors_b
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
+                  - TILE
+
+        Keyword Args:
+            bias (ttnn.Tensor, optional): the bias tensor to be added. If specified, needs to be on the device. Defaults to `None`.
+            transpose_a (bool, optional): Whether to transpose input_tensor_a. Defaults to `False`.
+            transpose_b (bool, optional): Whether to transpose input_tensor_b. Defaults to `False`.
+            memory_config (ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using `ttnn.DRAM_MEMORY_CONFIG`.
+            dtype (ttnn.DataType, optional): the data type of the output tensor. Defaults to `None`.
+            program_config (MatmulProgramConfig, optional): the program configuration for the matmul operation. Defaults to `None`.
+            activation (str or ttnn.UnaryWithParam, optional): the activation function to be applied. Defaults to `None`. When using sharded tensors, the :attr:`fused_activation` parameter of the :attr:`program_config` should be used instead.
+            compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): the compute kernel configuration for the matmul operation. Defaults to `None`.
+            core_grid (ttnn.CoreGrid, optional): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.
+            output_tile (List of [int], optional): Specifies the output tile configuration. Defaults to `None`.
+            optional_output_tensor (ttnn.Tensor, optional): User provided on-device output tensor where the result of linear is to be written. Defaults to `None`.
+            global_cb (ttnn.GlobalCircularBuffer, optional): the global circular buffer to be used for the matmul operation. Defaults to `None`.
+            sub_device_id (ttnn.SubDeviceId, optional): the sub device id to be used for the matmul operation. Defaults to `None`.
+
+        Returns:
+            List of ttnn.Tensor: the output tensors.
+        )doc",
+        ttnn::overload_t(
+            &matmul_batched_weights,
+            nb::arg("input_tensor_a"),
+            nb::arg("input_tensors_b"),
+            nb::kw_only(),
+            nb::arg("transpose_a") = false,
+            nb::arg("transpose_b") = false,
+            nb::arg("memory_config") = nb::none(),
+            nb::arg("dtype") = nb::none(),
+            nb::arg("program_config") = nb::none(),
+            nb::arg("activation") = nb::none(),
+            nb::arg("compute_kernel_config") = nb::none(),
+            nb::arg("core_grid") = nb::none(),
+            nb::arg("output_tile") = nb::none(),
+            nb::arg("optional_output_tensor") = nb::none(),
+            nb::arg("global_cb") = nb::none(),
+            nb::arg("sub_device_id") = nb::none()));
+
+    ttnn::bind_function<"addmm">(
+        mod,
+        R"doc(
+        Returns a matrix products of tensors mat1_tensor and mat2_tensor. Tensor input_tensor is added to the final result.
+
+        - If mat1_tensor has shape (n, m) and mat2_tensor has shape (m, p), input_tensor needs to be of shape (n, p) and
+          result will also be (n, p).
+
+        - If optional_output_tensor is provided, it needs to be of shape (n, p) and result will be stored there; all
+          previous content will be overwritten, reference to this object will also be returned.
+
+        - Arguments alpha and beta are scaling factors, result calculation look like this:
+
+            out = beta * input_tensor + alpha * (mat1_tensor @ mat2_tensor)
+
+        - If beta is 0, then content of input_tensor is ignored.
+
+        - Arguments beta and alpha should be real numbers;
+
+        Note:
+            The tensors support the following data types and layouts:
+
+            .. list-table:: input_tensor
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
+                  - TILE
+
+            .. list-table:: mat1_tensor
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
+                  - TILE
+
+            .. list-table:: mat2_tensor
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
+                  - TILE
+
+        Args:
+            input_tensor (ttnn.Tensor): tensor to be added to result of matrix multiplication of mat1_tensor and mat2_tensor
+            mat1_tensor (ttnn.Tensor): the first tensor to be matrix multiplied
+            mat2_tensor (ttnn.Tensor): the second tensor to be matrix multiplied
+
+        Keyword Args:
+            alpha (float): multiplier for mat1_tensor @ mat2_tensor
+            beta (float): multiplier for input_tensor
+            memory_config(ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using ttnn.DRAM_MEMORY_CONFIG.
+            dtype (ttnn.DataType): the data type of the output tensor. Supported types: `ttnn.bfloat16`, `ttnn.float32`, `ttnn.bfloat8_b`  Defaults to `None` which means it will default to the highest precision of `input_tensor`, `mat1_tensor` or `mat2_tensor`.
+            program_config (ttnn.MatmulProgramConfig): the program configuration for the matmul operation. Defaults to `None`.
+            compute_kernel_config (ttnn.DeviceComputeKernelConfig): the compute kernel configuration for the matmul operation. Defaults to `None`.
+            core_grid (ttnn.CoreGrid): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.
+            output_tile (List of [int], optional): Specifies the output tile configuration. Defaults to `None`.
+            optional_output_tensor (ttnn.Tensor, optional): User-provided on-device output tensor where the result of matmul is to be written. Defaults to `None`.
+            global_cb (ttnn.GlobalCircularBuffer): TBD
+            sub_device_id (ttnn.SubDeviceId): TBD
+
+        Returns:
+            ttnn.Tensor: output tensor of shape (n, p)
+
+        )doc",
+        ttnn::overload_t(
+            &addmm,
+            nb::arg("input_tensor"),
+            nb::arg("mat1_tensor"),
+            nb::arg("mat2_tensor"),
+            nb::kw_only(),
+            nb::arg("alpha") = 1.0,
+            nb::arg("beta") = 1.0,
+            nb::arg("memory_config") = nb::none(),
+            nb::arg("dtype") = nb::none(),
+            nb::arg("program_config") = nb::none(),
+            nb::arg("compute_kernel_config") = nb::none(),
+            nb::arg("core_grid") = nb::none(),
+            nb::arg("output_tile") = nb::none(),
+            nb::arg("optional_output_tensor") = nb::none()));
+
+    ttnn::bind_function<"sparse_matmul">(
+        mod,
+        R"doc(
+        Returns the matrix product of two tensors. Based on `is_input_a_sparse`, `is_input_b_sparse` and the sparsity tensor, some parts of the output computation is skipped.
+
+        The two input tensors must be be tiled and each have a rank of 4.
+        The sparsity tensor must be a rank 4 tensor in row major layout.
+
+        Based on the input tensor shapes and `is_input_a_sparse` and `is_input_b_sparse` values, the output tensor shape is computed. See the supported modes table below.
+
+        Args:
+            input_tensor_a (ttnn.Tensor): the first tensor to be multiplied. Needs to be on the device.
+            input_tensor_b (ttnn.Tensor): the second tensor to be multiplied. Needs to be on the device.
+        Keyword Args:
+            sparsity (ttnn.Tensor): the sparsity tensor containing the mask values. Needs to be on the device. The data type must be bfloat16.
+            program_config (ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig): the program configuration for the matmul operation. Only this config type is supported. ``mcast_in0`` must be set to True.
+            nnz (int, optional): the number of non-zero values in the sparsity tensor. If not provided, it will be inferred from the sparsity tensor at runtime. If provided, it **must** be exactly equal to the number of non-zero entries in `sparsity` (i.e. `nnz == count_nonzero(sparsity)`). It is the user's responsibility to set this value correctly. If the equality condition is not met, the kernel will hang (deadlock) on device, since the receiver and compute kernels loop exactly `nnz` times while the sender only multicasts once per non-zero sparsity entry. Because `count_nonzero(sparsity)` is data-dependent and only known at runtime, this cannot be validated on the host; the mismatch is asserted on-device (failing loudly under watcher) but otherwise results in a hang.
+            is_input_a_sparse (bool, optional): boolean indicating whether `input_tensor_a` is sparse. Defaults to `False`. Together with `is_input_b_sparse`, it determines how the sparsity tensor is interpreted. See the supported modes table below.
+            is_input_b_sparse (bool, optional): boolean indicating whether `input_tensor_b` is sparse. Defaults to `True`. Together with `is_input_a_sparse`, it determines how the sparsity tensor is interpreted. See the supported modes table below.
+            memory_config (ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using ttnn.DRAM_MEMORY_CONFIG.
+            dtype (ttnn.DataType, optional): the data type of the output tensor. Defaults to `None`.
+            compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): the compute kernel configuration for the matmul operation. Defaults to `None`.
+            core_grid (ttnn.CoreGrid, optional): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.
+            output_tile (List of [int], optional): Specifies the output tile configuration. Defaults to `None`.
+            optional_output_tensor (ttnn.Tensor, optional): User provided on-device output tensor where the result of matmul is to be written. Defaults to `None`.
+
+        Returns:
+            ttnn.Tensor: the output tensor with sparse results.
+
+        Supported Modes
+            .. list-table::
+                :header-rows: 1
+
+                * - is_input_a_sparse
+                  - is_input_b_sparse
+                  - input_tensor_a shape
+                  - input_tensor_b shape
+                  - sparsity shape
+                  - nnz
+                  - output shape
+                * - True
+                  - True
+                  - [1, E, M, K]
+                  - [1, E, K, N]
+                  - [1, 1, 1, E]
+                  - None or 0 ≤ nnz ≤ E
+                  - [1, E, M, N]
+                * - False
+                  - True
+                  - [A, B, M, K]
+                  - [1, E, K, N]
+                  - [A, B, 1, E]
+                  - None or 0 ≤ nnz ≤ A * B * E
+                  - [A, B, 1, E, M, N]
+                * - True
+                  - False
+                  - [A, E, M, K]
+                  - [1, E, K, N]
+                  - [1, 1, A, E]
+                  - None or 0 ≤ nnz ≤ A * E
+                  - [A, E, M, N]
+                * - False
+                  - False
+                  - Invalid
+                  - --
+                  - --
+                  - --
+                  - --
+
+        .. warning::
+            When `nnz` is provided, it **must** equal `count_nonzero(sparsity)` exactly. Passing an `nnz`
+            that does not match the actual number of non-zero entries in `sparsity` will cause the kernel to
+            **hang (deadlock)** on device. Setting `nnz` correctly is the user's responsibility. This
+            condition cannot be checked on the host because `count_nonzero(sparsity)` is data-dependent and
+            only known at runtime; it is validated on-device and will fail loudly (assert) when watcher is
+            enabled, but otherwise manifests as a hang. If you cannot guarantee the exact count, omit `nnz`
+            so it is inferred from the sparsity tensor at runtime.
+
+        Note:
+            The input tensors support the following data types and layouts:
+
+            .. list-table:: input_tensor_a
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - BFLOAT4_B, BFLOAT8_B, BFLOAT16, FLOAT32
+                  - TILE
+
+            .. list-table:: input_tensor_b
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - BFLOAT4_B, BFLOAT8_B, BFLOAT16, FLOAT32
+                  - TILE
+
+            .. list-table:: sparsity
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - BFLOAT16
+                  - ROW_MAJOR
+
+        Memory Support:
+            The supported memory configurations for the two input tensors are program config dependent, as described below:
+
+            .. list-table:: Supported Memory Configurations
+                :header-rows: 1
+
+                * - Config
+                  - Input A
+                  - Input B
+                * - ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig with (mcast_in0=True)
+                  - Interleaved (L1/DRAM)
+                  - Interleaved (L1/DRAM)
+        )doc",
+        ttnn::overload_t(
+            &sparse_matmul,
+            nb::arg("input_tensor_a"),
+            nb::arg("input_tensor_b"),
+            nb::kw_only(),
+            nb::arg("sparsity"),
+            nb::arg("program_config"),
+            nb::arg("nnz") = nb::none(),
+            nb::arg("is_input_a_sparse") = false,
+            nb::arg("is_input_b_sparse") = true,
+            nb::arg("memory_config") = nb::none(),
+            nb::arg("dtype") = nb::none(),
+            nb::arg("compute_kernel_config") = nb::none(),
+            nb::arg("core_grid") = nb::none(),
+            nb::arg("output_tile") = nb::none(),
+            nb::arg("optional_output_tensor") = nb::none(),
+            nb::arg("global_cb") = nb::none(),
+            nb::arg("sub_device_id") = nb::none()));
+
+    // Bind MatmulParams for descriptor-based operations
+    nb::class_<ttnn::prim::qsr::MatmulParams>(mod, "MatmulParams")
+        .def(nb::init<>())
+        .def_rw("program_config", &ttnn::prim::qsr::MatmulParams::program_config)
+        .def_rw("bcast_batch", &ttnn::prim::qsr::MatmulParams::bcast_batch)
+        .def_rw("output_mem_config", &ttnn::prim::qsr::MatmulParams::output_mem_config)
+        .def_rw("output_dtype", &ttnn::prim::qsr::MatmulParams::output_dtype)
+        .def_rw("compute_kernel_config", &ttnn::prim::qsr::MatmulParams::compute_kernel_config)
+        .def_rw("untilize_out", &ttnn::prim::qsr::MatmulParams::untilize_out)
+        .def_rw("transpose_a", &ttnn::prim::qsr::MatmulParams::transpose_a)
+        .def_rw("transpose_b", &ttnn::prim::qsr::MatmulParams::transpose_b);
+
+    // Bind MatmulInputs for descriptor-based operations
+    nb::class_<ttnn::prim::qsr::MatmulInputs>(mod, "MatmulInputs")
+        .def("__init__", [](ttnn::prim::qsr::MatmulInputs* t) { new (t) ttnn::prim::qsr::MatmulInputs{{}, {}, {}}; })
+        .def_rw("input_tensors", &ttnn::prim::qsr::MatmulInputs::input_tensors)
+        .def_rw("optional_input_tensors", &ttnn::prim::qsr::MatmulInputs::optional_input_tensors)
+        .def_rw("optional_output_tensors", &ttnn::prim::qsr::MatmulInputs::optional_output_tensors);
+
+    // Bind MatmulDeviceOperation for descriptor-based operations
+    nb::class_<ttnn::prim::qsr::MatmulDeviceOperation>(mod, "MatmulDeviceOperation")
+        .def_static(
+            "create_output_tensors",
+            &ttnn::prim::qsr::MatmulDeviceOperation::create_output_tensors,
+            nb::arg("operation_attributes"),
+            nb::arg("tensor_args"))
+        .def_static(
+            "compute_output_specs",
+            &ttnn::prim::qsr::MatmulDeviceOperation::compute_output_specs,
+            nb::arg("operation_attributes"),
+            nb::arg("tensor_args"))
+        .def_static(
+            "compute_program_hash",
+            &ttnn::prim::qsr::MatmulDeviceOperation::compute_program_hash,
+            nb::arg("operation_attributes"),
+            nb::arg("tensor_args"));
+
+    // Bind MatmulMultiCoreReuseOptimizedProgramFactory for descriptor creation
+    nb::class_<ttnn::prim::qsr::MatmulMultiCoreReuseOptimizedProgramFactory>(
+        mod, "MatmulMultiCoreReuseOptimizedProgramFactory")
+        .def_static(
+            "create_descriptor",
+            [](const ttnn::prim::qsr::MatmulParams& operation_attributes,
+               const ttnn::prim::qsr::MatmulInputs& tensor_args,
+               std::vector<ttnn::Tensor>& tensor_return_value,
+               const std::optional<CoreRangeSet>& core_range_set) {
+                return ttnn::prim::qsr::MatmulMultiCoreReuseOptimizedProgramFactory::create_descriptor(
+                    operation_attributes, tensor_args, tensor_return_value, core_range_set);
+            },
+            nb::arg("operation_attributes"),
+            nb::arg("tensor_args"),
+            nb::arg("tensor_return_value"),
+            nb::arg("core_range_set") = std::nullopt)
+        .def_static(
+            "default_core_range",
+            &ttnn::prim::qsr::MatmulMultiCoreReuseOptimizedProgramFactory::default_core_range,
+            nb::arg("device"));
+
+    // Bind MatmulMultiCoreProgramFactory for descriptor creation
+    nb::class_<ttnn::prim::qsr::MatmulMultiCoreProgramFactory>(mod, "MatmulMultiCoreProgramFactory")
+        .def_static(
+            "create_descriptor",
+            [](const ttnn::prim::qsr::MatmulParams& operation_attributes,
+               const ttnn::prim::qsr::MatmulInputs& tensor_args,
+               std::vector<ttnn::Tensor>& tensor_return_value,
+               const std::optional<CoreRangeSet>& core_range_set) {
+                return ttnn::prim::qsr::MatmulMultiCoreProgramFactory::create_descriptor(
+                    operation_attributes, tensor_args, tensor_return_value, core_range_set);
+            },
+            nb::arg("operation_attributes"),
+            nb::arg("tensor_args"),
+            nb::arg("tensor_return_value"),
+            nb::arg("core_range_set") = std::nullopt);
+
+    // Bind MatmulMultiCoreReuseMcast1DProgramFactory for descriptor creation
+    nb::class_<ttnn::prim::qsr::MatmulMultiCoreReuseMcast1DProgramFactory>(
+        mod, "MatmulMultiCoreReuseMcast1DProgramFactory")
+        .def_static(
+            "create_descriptor",
+            [](const ttnn::prim::qsr::MatmulParams& operation_attributes,
+               const ttnn::prim::qsr::MatmulInputs& tensor_args,
+               std::vector<ttnn::Tensor>& tensor_return_value,
+               const std::optional<CoreRangeSet>& core_range_set) {
+                return ttnn::prim::qsr::MatmulMultiCoreReuseMcast1DProgramFactory::create_descriptor(
+                    operation_attributes, tensor_args, tensor_return_value, core_range_set);
+            },
+            nb::arg("operation_attributes"),
+            nb::arg("tensor_args"),
+            nb::arg("tensor_return_value"),
+            nb::arg("core_range_set") = std::nullopt);
+
+    // Bind MatmulMultiCoreReuseMcast2DProgramFactory for descriptor creation
+    nb::class_<ttnn::prim::qsr::MatmulMultiCoreReuseMcast2DProgramFactory>(
+        mod, "MatmulMultiCoreReuseMcast2DProgramFactory")
+        .def_static(
+            "create_descriptor",
+            [](const ttnn::prim::qsr::MatmulParams& operation_attributes,
+               const ttnn::prim::qsr::MatmulInputs& tensor_args,
+               std::vector<ttnn::Tensor>& tensor_return_value,
+               const std::optional<CoreRangeSet>& core_range_set) {
+                return ttnn::prim::qsr::MatmulMultiCoreReuseMcast2DProgramFactory::create_descriptor(
+                    operation_attributes, tensor_args, tensor_return_value, core_range_set);
+            },
+            nb::arg("operation_attributes"),
+            nb::arg("tensor_args"),
+            nb::arg("tensor_return_value"),
+            nb::arg("core_range_set") = std::nullopt);
+
+    // Bind MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory for descriptor creation
+    nb::class_<ttnn::prim::qsr::MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory>(
+        mod, "MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory")
+        .def_static(
+            "create_descriptor",
+            [](const ttnn::prim::qsr::MatmulParams& operation_attributes,
+               const ttnn::prim::qsr::MatmulInputs& tensor_args,
+               std::vector<ttnn::Tensor>& tensor_return_value,
+               const std::optional<CoreRangeSet>& core_range_set) {
+                return ttnn::prim::qsr::MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory::create_descriptor(
+                    operation_attributes, tensor_args, tensor_return_value, core_range_set);
+            },
+            nb::arg("operation_attributes"),
+            nb::arg("tensor_args"),
+            nb::arg("tensor_return_value"),
+            nb::arg("core_range_set") = std::nullopt);
+
+    // Bind MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory for descriptor creation
+    nb::class_<ttnn::prim::qsr::MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory>(
+        mod, "MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory")
+        .def_static(
+            "create_descriptor",
+            [](const ttnn::prim::qsr::MatmulParams& operation_attributes,
+               const ttnn::prim::qsr::MatmulInputs& tensor_args,
+               std::vector<ttnn::Tensor>& tensor_return_value,
+               const std::optional<CoreRangeSet>& core_range_set) {
+                return ttnn::prim::qsr::MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory::create_descriptor(
+                    operation_attributes, tensor_args, tensor_return_value, core_range_set);
+            },
+            nb::arg("operation_attributes"),
+            nb::arg("tensor_args"),
+            nb::arg("tensor_return_value"),
+            nb::arg("core_range_set") = std::nullopt);
+
+    // Bind select_program_factory for Python-side factory dispatch
+    mod.def(
+        "matmul_select_program_factory",
+        &ttnn::prim::qsr::MatmulDeviceOperation::select_program_factory,
+        nb::arg("operation_attributes"),
+        nb::arg("tensor_args"));
+
+    // Bind create_matmul_attributes helper
+    mod.def(
+        "create_matmul_attributes",
+        &ttnn::prim::qsr::create_matmul_attributes,
+        nb::arg("input_tensor_a"),
+        nb::arg("input_tensor_b"),
+        nb::arg("parameters"),
+        nb::arg("optional_output_tensors"));
+}
+
+}  // namespace ttnn::operations::experimental::quasar::matmul

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/matmul_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/matmul_nanobind.hpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::experimental::quasar::matmul {
+
+namespace nb = nanobind;
+void py_module(nb::module_& mod);
+
+}  // namespace ttnn::operations::experimental::quasar::matmul

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/shared_with_host/activation_type.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/shared_with_host/activation_type.hpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+namespace ttnn::operations::experimental::quasar::matmul {
+
+enum class KernelActivation : uint32_t {
+    NONE,
+    GELU,
+    TANH,
+    SILU,
+    RELU6,
+    SIGMOID,
+    HARDSIGMOID,
+    HARDTANH,
+    SELU,
+    SOFTPLUS
+};
+
+}  // namespace ttnn::operations::experimental::quasar::matmul

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/kernels/dataflow/move_interleaved_with_overlap.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/kernels/dataflow/move_interleaved_with_overlap.cpp
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t dst_addr = get_arg_val<uint32_t>(1);
+    uint32_t start_id = get_arg_val<uint32_t>(2);
+    uint32_t num_tiles = get_arg_val<uint32_t>(3);
+    uint32_t semaphore_arg = get_arg_val<uint32_t>(4);
+    uint32_t controller_noc_x = get_arg_val<uint32_t>(5);
+    uint32_t controller_noc_y = get_arg_val<uint32_t>(6);
+    uint32_t control_value = get_arg_val<uint32_t>(7);
+    bool is_controller = get_arg_val<uint32_t>(8) == 1;
+    uint32_t range_0_start_noc_x = get_arg_val<uint32_t>(9);
+    uint32_t range_0_start_noc_y = get_arg_val<uint32_t>(10);
+    uint32_t range_0_end_noc_x = get_arg_val<uint32_t>(11);
+    uint32_t range_0_end_noc_y = get_arg_val<uint32_t>(12);
+    uint32_t range_0_size = get_arg_val<uint32_t>(13);
+    uint32_t range_1_start_noc_x = get_arg_val<uint32_t>(14);
+    uint32_t range_1_start_noc_y = get_arg_val<uint32_t>(15);
+    uint32_t range_1_end_noc_x = get_arg_val<uint32_t>(16);
+    uint32_t range_1_end_noc_y = get_arg_val<uint32_t>(17);
+    uint32_t range_1_size = get_arg_val<uint32_t>(18);
+    uint32_t range_2_start_noc_x = get_arg_val<uint32_t>(19);
+    uint32_t range_2_start_noc_y = get_arg_val<uint32_t>(20);
+    uint32_t range_2_end_noc_x = get_arg_val<uint32_t>(21);
+    uint32_t range_2_end_noc_y = get_arg_val<uint32_t>(22);
+    uint32_t range_2_size = get_arg_val<uint32_t>(23);
+    bool do_third_multicast = get_arg_val<uint32_t>(24) == 1;
+
+    constexpr uint32_t cb_id = get_compile_time_arg_val(0);
+    constexpr auto src_args = TensorAccessorArgs<1>();
+    constexpr auto dst_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
+
+    Noc noc;
+    CircularBuffer cb(cb_id);
+
+    // if controller core then this local address will be incremented by remote cores,
+    // otherwise controller core will set this to signal that write to dst can be done once controller core sees
+    // control_value locally
+    Semaphore<> sem(semaphore_arg);
+
+    // ublocks size defined in tiles
+    constexpr uint32_t ublock_size_tiles = 1;
+    uint32_t tile_bytes = get_tile_size(cb_id);
+
+    const auto src_addrgen = TensorAccessor(src_args, src_addr);
+    const auto dst_addrgen = TensorAccessor(dst_args, dst_addr);
+
+    // read a ublock of tiles from src to CB
+    cb.reserve_back(num_tiles);
+    uint32_t cb_write_offset = 0;
+    for (uint32_t i = start_id; i < start_id + num_tiles; i += ublock_size_tiles) {
+        noc.async_read(
+            src_addrgen, cb, tile_bytes, {.page_id = i, .offset_bytes = 0}, {.offset_bytes = cb_write_offset});
+        noc.async_read_barrier();
+        cb_write_offset += tile_bytes;
+    }
+    cb.push_back(num_tiles);
+
+    if (is_controller) {
+        sem.wait(control_value);
+
+        // signal to cores that write to dst can begin
+        sem.set_multicast<NocOptions::DEFAULT>(
+            noc, range_0_start_noc_x, range_0_start_noc_y, range_0_end_noc_x, range_0_end_noc_y, range_0_size);
+        sem.set_multicast<NocOptions::DEFAULT>(
+            noc, range_1_start_noc_x, range_1_start_noc_y, range_1_end_noc_x, range_1_end_noc_y, range_1_size);
+        if (do_third_multicast) {
+            sem.set_multicast<NocOptions::DEFAULT>(
+                noc, range_2_start_noc_x, range_2_start_noc_y, range_2_end_noc_x, range_2_end_noc_y, range_2_size);
+        }
+    } else {
+        // increment controller core semaphore
+        sem.up(noc, controller_noc_x, controller_noc_y, 1);
+        // wait for controller to signal write
+        sem.wait(control_value);
+    }
+
+    cb.wait_front(num_tiles);
+    uint32_t cb_read_offset = 0;
+    for (uint32_t i = start_id; i < start_id + num_tiles; i += ublock_size_tiles) {
+        noc.async_write(
+            cb, dst_addrgen, tile_bytes, {.offset_bytes = cb_read_offset}, {.page_id = i, .offset_bytes = 0});
+        noc.async_write_barrier();
+        cb_read_offset += tile_bytes;
+    }
+    cb.pop_front(num_tiles);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/kernels/dataflow/move_stick_layout_interleaved_with_overlap.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/kernels/dataflow/move_stick_layout_interleaved_with_overlap.cpp
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t dst_addr = get_arg_val<uint32_t>(1);
+    uint32_t start_id = get_arg_val<uint32_t>(2);
+    uint32_t num_pages = get_arg_val<uint32_t>(3);
+    uint32_t semaphore_arg = get_arg_val<uint32_t>(4);
+    uint32_t controller_noc_x = get_arg_val<uint32_t>(5);
+    uint32_t controller_noc_y = get_arg_val<uint32_t>(6);
+    uint32_t control_value = get_arg_val<uint32_t>(7);
+    bool is_controller = get_arg_val<uint32_t>(8) == 1;
+    uint32_t range_0_start_noc_x = get_arg_val<uint32_t>(9);
+    uint32_t range_0_start_noc_y = get_arg_val<uint32_t>(10);
+    uint32_t range_0_end_noc_x = get_arg_val<uint32_t>(11);
+    uint32_t range_0_end_noc_y = get_arg_val<uint32_t>(12);
+    uint32_t range_0_size = get_arg_val<uint32_t>(13);
+    uint32_t range_1_start_noc_x = get_arg_val<uint32_t>(14);
+    uint32_t range_1_start_noc_y = get_arg_val<uint32_t>(15);
+    uint32_t range_1_end_noc_x = get_arg_val<uint32_t>(16);
+    uint32_t range_1_end_noc_y = get_arg_val<uint32_t>(17);
+    uint32_t range_1_size = get_arg_val<uint32_t>(18);
+    uint32_t range_2_start_noc_x = get_arg_val<uint32_t>(19);
+    uint32_t range_2_start_noc_y = get_arg_val<uint32_t>(20);
+    uint32_t range_2_end_noc_x = get_arg_val<uint32_t>(21);
+    uint32_t range_2_end_noc_y = get_arg_val<uint32_t>(22);
+    uint32_t range_2_size = get_arg_val<uint32_t>(23);
+    bool do_third_multicast = get_arg_val<uint32_t>(24) == 1;
+    uint32_t aligned_page_size = get_arg_val<uint32_t>(25);
+
+    constexpr uint32_t cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t page_size = get_compile_time_arg_val(1);
+    constexpr auto src_args = TensorAccessorArgs<2>();
+    constexpr auto dst_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
+
+    Noc noc;
+    CircularBuffer cb(cb_id);
+
+    const auto src_addrgen = TensorAccessor(src_args, src_addr);
+    const auto dst_addrgen = TensorAccessor(dst_args, dst_addr);
+
+    // if controller core then this local address will be incremented by remote cores,
+    // otherwise controller core will set this to signal that write to dst can be done once controller core sees
+    // control_value locally
+    Semaphore<> sem(semaphore_arg);
+
+    // read a ublock of tiles from src to CB
+    cb.reserve_back(num_pages);
+    uint32_t l1_write_addr = cb.get_write_ptr();
+    for (uint32_t i = start_id; i < start_id + num_pages; ++i) {
+        CoreLocalMem<uint32_t> dst(l1_write_addr);
+        noc.async_read(src_addrgen, dst, page_size, {.page_id = i, .offset_bytes = 0}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        l1_write_addr += aligned_page_size;
+    }
+    cb.push_back(num_pages);
+
+    if (is_controller) {
+        sem.wait(control_value);
+
+        // signal to cores that write to dst can begin
+        sem.set_multicast<NocOptions::DEFAULT>(
+            noc, range_0_start_noc_x, range_0_start_noc_y, range_0_end_noc_x, range_0_end_noc_y, range_0_size);
+        sem.set_multicast<NocOptions::DEFAULT>(
+            noc, range_1_start_noc_x, range_1_start_noc_y, range_1_end_noc_x, range_1_end_noc_y, range_1_size);
+        if (do_third_multicast) {
+            sem.set_multicast<NocOptions::DEFAULT>(
+                noc, range_2_start_noc_x, range_2_start_noc_y, range_2_end_noc_x, range_2_end_noc_y, range_2_size);
+        }
+    } else {
+        // increment controller core semaphore
+        sem.up(noc, controller_noc_x, controller_noc_y, 1);
+        // wait for controller to signal write
+        sem.wait(control_value);
+    }
+
+    cb.wait_front(num_pages);
+    uint32_t l1_read_addr = cb.get_read_ptr();
+    for (uint32_t i = start_id; i < start_id + num_pages; ++i) {
+        CoreLocalMem<uint32_t> src(l1_read_addr);
+        noc.async_write(src, dst_addrgen, page_size, {.offset_bytes = 0}, {.page_id = i, .offset_bytes = 0});
+        noc.async_write_barrier();
+        l1_read_addr += aligned_page_size;
+    }
+    cb.pop_front(num_pages);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/kernels/dataflow/reader_unary_local_l1_copy_backwards.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/kernels/dataflow/reader_unary_local_l1_copy_backwards.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    uint32_t i = 0;
+    uint32_t total_size_bytes = get_arg_val<uint32_t>(i);
+    i += 1;
+    uint32_t num_chunks = get_arg_val<uint32_t>(i);
+    i += 1;
+    uint32_t chunk_size_bytes = get_arg_val<uint32_t>(i);
+    i += 1;
+    uint32_t remainder_chunk_size_bytes = get_arg_val<uint32_t>(i);
+    i += 1;
+    constexpr uint32_t src_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t dst_cb_id = get_compile_time_arg_val(1);
+
+    Noc noc;
+    CircularBuffer src_cb(src_cb_id);
+    CircularBuffer dst_cb(dst_cb_id);
+
+    uint32_t src_cb_base_addr = src_cb.get_read_ptr();
+    uint32_t dst_cb_base_addr = dst_cb.get_write_ptr();
+
+    // Copy from top of src cb to top of dst cb (backwards)
+    uint32_t src_cb_addr = src_cb_base_addr + total_size_bytes;
+    uint32_t dst_cb_addr = dst_cb_base_addr + total_size_bytes;
+    for (uint32_t i = 0; i < num_chunks; i += 1) {
+        src_cb_addr -= chunk_size_bytes;
+        dst_cb_addr -= chunk_size_bytes;
+        CoreLocalMem<uint32_t> dst(dst_cb_addr);
+        noc.async_read(
+            UnicastEndpoint{},
+            dst,
+            chunk_size_bytes,
+            {.noc_x = (uint32_t)my_x[noc.get_noc_id()], .noc_y = (uint32_t)my_y[noc.get_noc_id()], .addr = src_cb_addr},
+            {.offset_bytes = 0});
+        noc.async_read_barrier();
+    }
+    if (remainder_chunk_size_bytes > 0) {
+        src_cb_addr -= remainder_chunk_size_bytes;
+        dst_cb_addr -= remainder_chunk_size_bytes;
+        CoreLocalMem<uint32_t> dst(dst_cb_addr);
+        noc.async_read(
+            UnicastEndpoint{},
+            dst,
+            remainder_chunk_size_bytes,
+            {.noc_x = (uint32_t)my_x[noc.get_noc_id()], .noc_y = (uint32_t)my_y[noc.get_noc_id()], .addr = src_cb_addr},
+            {.offset_bytes = 0});
+        noc.async_read_barrier();
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_device_operation.cpp
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "move_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
+#include "ttnn/operations/data_movement/common/common.hpp"
+
+namespace ttnn::prim::qsr {
+
+MoveDeviceOperation::program_factory_t MoveDeviceOperation::select_program_factory(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& /*tensor_args*/) {
+    switch (operation_attributes.move_op_parallelization_strategy) {
+        case MoveOpParallelizationStrategy::MULTI_CORE_SHARDED: return MoveShardedProgramFactory{};
+        case MoveOpParallelizationStrategy::MULTI_CORE_OVERLAP: return MoveOverlapProgramFactory{};
+        case MoveOpParallelizationStrategy::MULTI_CORE: return MoveProgramFactory{};
+        default: TT_FATAL(false, "Invalid move operation parallelization strategy");
+    }
+}
+
+void MoveDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const Tensor& input_tensor = tensor_args.input_tensor;
+    const Tensor& output_tensor = tensor_args.output_tensor;
+
+    validate_on_program_cache_hit(operation_attributes, tensor_args);
+
+    TT_FATAL(
+        input_tensor.dtype() == output_tensor.dtype(),
+        "ttnn.move: input and output tensors must have the same dtype. Input dtype: {}, Output dtype: {}",
+        input_tensor.dtype(),
+        output_tensor.dtype());
+
+    if (operation_attributes.move_op_parallelization_strategy == MoveOpParallelizationStrategy::MULTI_CORE_SHARDED) {
+        TT_FATAL(
+            input_tensor.memory_config().is_sharded(),
+            "ttnn.move: MULTI_CORE_SHARDED strategy requires input tensor to be sharded. Got memory layout: {}",
+            input_tensor.memory_config().memory_layout());
+
+        TT_FATAL(
+            input_tensor.shard_spec().has_value(),
+            "ttnn.move: MULTI_CORE_SHARDED strategy requires input tensor to have shard spec");
+
+        TT_FATAL(
+            operation_attributes.output_mem_config.is_sharded(),
+            "ttnn.move: MULTI_CORE_SHARDED strategy requires output memory config to be sharded. Got memory layout: {}",
+            operation_attributes.output_mem_config.memory_layout());
+
+        TT_FATAL(
+            output_tensor.shard_spec().has_value(),
+            "ttnn.move: MULTI_CORE_SHARDED strategy requires output tensor to have shard spec");
+    }
+
+    if (operation_attributes.move_op_parallelization_strategy == MoveOpParallelizationStrategy::MULTI_CORE_OVERLAP) {
+        auto compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
+        TT_FATAL(
+            (compute_with_storage_grid_size.x > 1 and compute_with_storage_grid_size.y > 1),
+            "ttnn.move: MULTI_CORE_OVERLAP strategy requires at least 2x2 compute grid. Got: {}x{}",
+            compute_with_storage_grid_size.x,
+            compute_with_storage_grid_size.y);
+    }
+}
+
+void MoveDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& tensor_args) {
+    const Tensor& input_tensor = tensor_args.input_tensor;
+    const Tensor& output_tensor = tensor_args.output_tensor;
+
+    // Validate tensors are located on device with valid buffers
+    TT_FATAL(
+        input_tensor.storage_type() == StorageType::DEVICE,
+        "ttnn.move: input tensor must be on device on cache hit. Got storage type: {}",
+        input_tensor.storage_type());
+
+    TT_FATAL(input_tensor.buffer() != nullptr, "ttnn.move: input tensor buffer must be allocated on cache hit");
+
+    TT_FATAL(
+        output_tensor.storage_type() == StorageType::DEVICE,
+        "ttnn.move: output tensor must be on device on cache hit. Got storage type: {}",
+        output_tensor.storage_type());
+
+    TT_FATAL(output_tensor.buffer() != nullptr, "ttnn.move: output tensor buffer must be allocated on cache hit");
+}
+
+MoveDeviceOperation::spec_return_value_t MoveDeviceOperation::compute_output_specs(
+    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& tensor_args) {
+    // Output spec is same as output tensor spec
+    return tensor_args.output_tensor.tensor_spec();
+}
+
+MoveDeviceOperation::tensor_return_value_t MoveDeviceOperation::create_output_tensors(
+    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& tensor_args) {
+    // Output tensor is already created and passed in tensor_args
+    return tensor_args.output_tensor;
+}
+
+tt::tt_metal::operation::OpPerformanceModelGeneral<MoveDeviceOperation::tensor_return_value_t>
+MoveDeviceOperation::create_op_performance_model(
+    const operation_attributes_t& /*operation_attributes*/,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    const auto& input_tensor = tensor_args.input_tensor;
+    const auto& output_tensor = tensor_return_value;
+    const int ideal_dev_clock_cycles = operations::data_movement::common_tm_bw_model(input_tensor, output_tensor);
+    tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> result(
+        {input_tensor}, output_tensor, ideal_dev_clock_cycles);
+    return result;
+}
+
+}  // namespace ttnn::prim::qsr
+
+namespace ttnn::prim::qsr {
+ttnn::prim::qsr::MoveDeviceOperation::tensor_return_value_t move(
+    const Tensor& input_tensor,
+    const Tensor& output_tensor,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    const ttnn::prim::qsr::MoveOpParallelizationStrategy& move_op_parallelization_strategy) {
+    using OperationType = ttnn::prim::qsr::MoveDeviceOperation;
+    bool backwards = false;
+    if (move_op_parallelization_strategy == ttnn::prim::qsr::MoveOpParallelizationStrategy::MULTI_CORE) {
+        Buffer* src_buffer = input_tensor.buffer();
+        Buffer* dst_buffer = output_tensor.buffer();
+        const bool src_and_dst_in_l1 = src_buffer->buffer_type() == tt::tt_metal::BufferType::L1 &&
+                                       dst_buffer->buffer_type() == tt::tt_metal::BufferType::L1;
+        const uint32_t src_base = src_buffer->address();
+        const uint32_t dst_base = dst_buffer->address();
+        const uint32_t copy_size_bytes = dst_buffer->size();
+        const bool ranges_overlap = (src_base < dst_base + copy_size_bytes) && (dst_base < src_base + copy_size_bytes);
+        backwards = src_and_dst_in_l1 && ranges_overlap && (dst_base > src_base);
+    }
+    return ttnn::device_operation::launch<OperationType>(
+        OperationType::operation_attributes_t{
+            .output_mem_config = output_mem_config,
+            .move_op_parallelization_strategy = move_op_parallelization_strategy,
+            .backwards = backwards},
+        OperationType::tensor_args_t{.input_tensor = input_tensor, .output_tensor = output_tensor});
+}
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_device_operation.hpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <variant>
+#include "ttnn/tensor/tensor.hpp"
+#include "move_device_operation_types.hpp"
+#include "move_program_factory.hpp"
+#include "move_overlap_program_factory.hpp"
+#include "move_sharded_program_factory.hpp"
+#include "ttnn/operation.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct MoveDeviceOperation {
+    // Type aliases
+    using operation_attributes_t = ttnn::prim::qsr::MoveOperationAttributes;
+    using tensor_args_t = ttnn::prim::qsr::MoveTensorArgs;
+    using tensor_return_value_t = Tensor;
+    using spec_return_value_t = ttnn::TensorSpec;
+
+    using program_factory_t = std::variant<MoveProgramFactory, MoveOverlapProgramFactory, MoveShardedProgramFactory>;
+
+    static program_factory_t select_program_factory(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static void validate_on_program_cache_miss(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static void validate_on_program_cache_hit(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static spec_return_value_t compute_output_specs(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+};
+
+}  // namespace ttnn::prim::qsr
+
+namespace ttnn::prim::qsr {
+ttnn::prim::qsr::MoveDeviceOperation::tensor_return_value_t move(
+    const Tensor& input_tensor,
+    const Tensor& output_tensor,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    const ttnn::prim::qsr::MoveOpParallelizationStrategy& move_op_parallelization_strategy);
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_device_operation_types.hpp
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+#include <tt-metalium/constants.hpp>
+
+namespace ttnn::prim::qsr {
+
+enum class MoveOpParallelizationStrategy { MULTI_CORE, MULTI_CORE_OVERLAP, MULTI_CORE_SHARDED };
+
+// Operation attributes - non-tensor parameters
+struct MoveOperationAttributes {
+    tt::tt_metal::MemoryConfig output_mem_config;
+    MoveOpParallelizationStrategy move_op_parallelization_strategy;
+    bool backwards = false;
+};
+
+// Tensor arguments - tensor parameters
+struct MoveTensorArgs {
+    Tensor input_tensor;
+    Tensor output_tensor;
+};
+
+// Return types
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_overlap_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_overlap_program_factory.cpp
@@ -1,0 +1,206 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "move_device_operation_types.hpp"
+#include "move_overlap_program_factory.hpp"
+
+#include <cmath>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/tilize_utils.hpp>
+
+namespace ttnn::prim::qsr {
+
+using namespace tt::tt_metal;
+
+namespace {
+
+std::vector<CoreRange> get_multicast_regions(const CoreRangeSet& all_cores, const CoreCoord& logical_controller) {
+    TT_ASSERT(!all_cores.ranges().empty() and all_cores.ranges().size() <= 2);
+    const CoreCoord logical_zero = {0, 0};
+    TT_ASSERT(logical_controller == logical_zero);
+
+    std::vector<CoreRange> logical_core_ranges;
+    auto split_core_range_containing_controller = [&](const CoreRange& controller_core_range) {
+        TT_ASSERT(controller_core_range.start_coord == logical_controller);
+        CoreRange right_block(
+            CoreCoord(logical_controller.x + 1, logical_controller.y), controller_core_range.end_coord);
+        CoreRange remaining_stick = CoreRange(
+            CoreCoord(logical_controller.x, logical_controller.y + 1),
+            CoreCoord(logical_controller.x, controller_core_range.end_coord.y));
+
+        logical_core_ranges.push_back(right_block);
+        logical_core_ranges.push_back(remaining_stick);
+    };
+
+    CoreRange range_0 = *all_cores.ranges().begin();
+    if (all_cores.ranges().size() == 1) {
+        split_core_range_containing_controller(range_0);
+    } else {
+        CoreRange range_1 = *all_cores.ranges().rbegin();
+        if (range_0.start_coord == logical_controller) {
+            split_core_range_containing_controller(range_0);
+            logical_core_ranges.push_back(range_1);
+        } else if (range_1.start_coord == logical_controller) {
+            split_core_range_containing_controller(range_1);
+            logical_core_ranges.push_back(range_0);
+        } else {
+            TT_THROW("Core {} is not included in set of core ranges!", logical_controller.str());
+        }
+    }
+
+    TT_ASSERT(logical_core_ranges.size() == 2 or logical_core_ranges.size() == 3);
+    return logical_core_ranges;
+}
+
+}  // namespace
+
+ProgramDescriptor MoveOverlapProgramFactory::create_descriptor(
+    const MoveOperationAttributes& /*operation_attributes*/,
+    const MoveTensorArgs& tensor_args,
+    Tensor& tensor_return_value) {
+    using namespace tt::constants;
+
+    const Tensor& input = tensor_args.input_tensor;
+    const Tensor& output = tensor_return_value;
+
+    const tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input.dtype());
+    const bool tilized = input.layout() == Layout::TILE;
+    const uint32_t page_size = input.buffer()->page_size();
+
+    const uint32_t num_pages =
+        tilized ? (output.physical_volume() / TILE_HW) : (output.physical_volume() / output.padded_shape()[-1]);
+    const tt::tt_metal::IDevice* device = output.device();
+    const CoreCoord compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    const uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_pages_per_core_group_1, num_pages_per_core_group_2] =
+        tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_pages);
+
+    const auto num_l1_banks = compute_with_storage_grid_size.x * compute_with_storage_grid_size.y;
+    const uint32_t size_per_l1_bank = tt::tt_metal::detail::calculate_bank_size_spread(
+        output.buffer()->size(), output.buffer()->page_size(), num_l1_banks, tt::tt_metal::hal::get_l1_alignment());
+
+    Buffer* src_buffer = input.buffer();
+    Buffer* dst_buffer = output.buffer();
+
+    ProgramDescriptor desc;
+
+    // CB is being used as temp L1 buffer to copy src data into before writing to dst
+    const uint32_t cb_index = 0;
+    const uint32_t aligned_page_size = round_up_to_mul32(page_size);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = size_per_l1_bank,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_index),
+            .data_format = cb_data_format,
+            .page_size = aligned_page_size,
+        }}},
+    });
+
+    // Semaphore used by the controller core to coordinate multicast.
+    const uint32_t semaphore_id = 0;
+    desc.semaphores.push_back(SemaphoreDescriptor{
+        .id = semaphore_id,
+        .core_type = tt::CoreType::WORKER,
+        .core_ranges = all_cores,
+        .initial_value = 0,
+    });
+
+    std::vector<uint32_t> compile_time_args = {cb_index};
+    if (!tilized) {
+        compile_time_args.push_back(page_size);
+    }
+    TensorAccessorArgs(*src_buffer).append_to(compile_time_args);
+    TensorAccessorArgs(*dst_buffer).append_to(compile_time_args);
+
+    const std::string kernel_path = tilized
+                                        ? "ttnn/cpp/ttnn/operations/experimental/quasar/move/device/kernels/dataflow/"
+                                          "move_interleaved_with_overlap.cpp"
+                                        : "ttnn/cpp/ttnn/operations/experimental/quasar/move/device/kernels/dataflow/"
+                                          "move_stick_layout_interleaved_with_overlap.cpp";
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = kernel_path;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(compile_time_args);
+    reader_desc.config = DataMovementConfigDescriptor{};
+
+    const CoreCoord logical_controller = CoreCoord{0, 0};
+    const CoreCoord noc_controller = device->worker_core_from_logical_core(logical_controller);
+    std::vector<CoreRange> logical_multicast_regions = get_multicast_regions(all_cores, logical_controller);
+
+    std::vector<CoreRange> noc_multicast_regions;
+    noc_multicast_regions.reserve(logical_multicast_regions.size());
+    for (const auto& logical_cr : logical_multicast_regions) {
+        const CoreRange noc_cr(
+            device->worker_core_from_logical_core(logical_cr.start_coord),
+            device->worker_core_from_logical_core(logical_cr.end_coord));
+        noc_multicast_regions.push_back(noc_cr);
+    }
+
+    const CoreRange range_0_noc = noc_multicast_regions[0];
+    const CoreRange range_1_noc = noc_multicast_regions[1];
+    const bool do_third_multicast = (noc_multicast_regions.size() == 3);
+
+    for (uint32_t i = 0, pages_handled_per_core = 0; i < num_cores; i++) {
+        const CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        uint32_t num_pages_per_core = 0;
+        if (core_group_1.contains(core)) {
+            num_pages_per_core = num_pages_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_pages_per_core = num_pages_per_core_group_2;
+        } else {
+            TT_THROW("Core not in specified core ranges");
+        }
+
+        const bool is_controller = (i == 0);
+        // Buffer* entries register BufferBindings for src/dst addresses (positions 0/1);
+        // the framework patches them on cache hits without rebuilding the descriptor.
+        KernelDescriptor::RTArgList runtime_args;
+        runtime_args.reserve(tilized ? 25 : 26);
+        runtime_args.push_back(src_buffer);
+        runtime_args.push_back(dst_buffer);
+        runtime_args.push_back(pages_handled_per_core);
+        runtime_args.push_back(num_pages_per_core);
+        runtime_args.push_back(semaphore_id);
+        runtime_args.push_back(static_cast<uint32_t>(noc_controller.x));
+        runtime_args.push_back(static_cast<uint32_t>(noc_controller.y));
+        runtime_args.push_back(num_cores - 1);  // control_value
+        runtime_args.push_back(static_cast<uint32_t>(is_controller));
+        runtime_args.push_back(static_cast<uint32_t>(range_0_noc.start_coord.x));
+        runtime_args.push_back(static_cast<uint32_t>(range_0_noc.start_coord.y));
+        runtime_args.push_back(static_cast<uint32_t>(range_0_noc.end_coord.x));
+        runtime_args.push_back(static_cast<uint32_t>(range_0_noc.end_coord.y));
+        runtime_args.push_back(static_cast<uint32_t>(logical_multicast_regions[0].size()));
+        runtime_args.push_back(static_cast<uint32_t>(range_1_noc.start_coord.x));
+        runtime_args.push_back(static_cast<uint32_t>(range_1_noc.start_coord.y));
+        runtime_args.push_back(static_cast<uint32_t>(range_1_noc.end_coord.x));
+        runtime_args.push_back(static_cast<uint32_t>(range_1_noc.end_coord.y));
+        runtime_args.push_back(static_cast<uint32_t>(logical_multicast_regions[1].size()));
+        runtime_args.push_back(static_cast<uint32_t>(noc_multicast_regions.back().start_coord.x));
+        runtime_args.push_back(static_cast<uint32_t>(noc_multicast_regions.back().start_coord.y));
+        runtime_args.push_back(static_cast<uint32_t>(noc_multicast_regions.back().end_coord.x));
+        runtime_args.push_back(static_cast<uint32_t>(noc_multicast_regions.back().end_coord.y));
+        runtime_args.push_back(static_cast<uint32_t>(logical_multicast_regions.back().size()));
+        runtime_args.push_back(static_cast<uint32_t>(do_third_multicast));
+        if (!tilized) {
+            runtime_args.push_back(aligned_page_size);
+        }
+        reader_desc.emplace_runtime_args(core, runtime_args);
+        pages_handled_per_core += num_pages_per_core;
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_overlap_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_overlap_program_factory.hpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/program_descriptors.hpp>
+#include "move_device_operation_types.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::prim::qsr {
+
+// Program factory for MULTI_CORE_OVERLAP strategy
+struct MoveOverlapProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const MoveOperationAttributes& operation_attributes,
+        const MoveTensorArgs& tensor_args,
+        Tensor& tensor_return_value);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_program_factory.cpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "move_program_factory.hpp"
+
+#include "ttnn/operations/data_movement/copy/device/copy_device_operation.hpp"
+#include "ttnn/operations/data_movement/copy/device/copy_device_operation_types.hpp"
+
+namespace ttnn::prim::qsr {
+
+tt::tt_metal::ProgramDescriptor MoveProgramFactory::create_descriptor(
+    const MoveOperationAttributes& operation_attributes,
+    const MoveTensorArgs& tensor_args,
+    Tensor& tensor_return_value) {
+    const Tensor& input = tensor_args.input_tensor;
+    Tensor& output = tensor_return_value;
+    using copy_attrs_t = CopyDeviceOperation::operation_attributes_t;
+    using copy_args_t = CopyDeviceOperation::tensor_args_t;
+
+    const copy_attrs_t copy_attrs{
+        operation_attributes.output_mem_config, output.dtype(), operation_attributes.backwards};
+    const copy_args_t copy_args{input, std::make_optional(output)};
+
+    return CopyDeviceOperation::SameMemoryConfig::create_descriptor(copy_attrs, copy_args, output);
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_program_factory.hpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "move_device_operation_types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace ttnn::prim::qsr {
+
+// Program factory for MULTI_CORE and MULTI_CORE_OVERLAP strategies
+struct MoveProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const MoveOperationAttributes& operation_attributes,
+        const MoveTensorArgs& tensor_args,
+        Tensor& tensor_return_value);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_sharded_program_factory.cpp
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "move_sharded_program_factory.hpp"
+
+#include <cmath>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/hal.hpp>
+
+namespace ttnn::prim::qsr {
+
+using namespace tt::tt_metal;
+
+ProgramDescriptor MoveShardedProgramFactory::create_descriptor(
+    const MoveOperationAttributes& /*operation_attributes*/,
+    const MoveTensorArgs& tensor_args,
+    Tensor& tensor_return_value) {
+    using namespace tt::constants;
+    const Tensor& input = tensor_args.input_tensor;
+    Tensor& output = tensor_return_value;
+
+    const tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input.dtype());
+    const auto shard_spec = input.shard_spec().value();
+    const auto shard_shape = shard_spec.shape;
+    const auto shard_grid = shard_spec.grid;
+    const auto& input_shape = input.logical_shape();
+    const DataType input_dtype = input.dtype();
+    const Layout input_layout = input.layout();
+    TT_FATAL(
+        input_layout == output.layout() && input_dtype == output.dtype() &&
+            shard_shape == output.shard_spec().value().shape && input_shape == output.logical_shape(),
+        "Error");
+    const uint32_t src_cb_sharded = tt::CBIndex::c_0;
+    const uint32_t dst_cb_sharded = tt::CBIndex::c_1;
+
+    const uint32_t total_size_bytes = input.buffer()->aligned_size_per_bank();
+    const uint32_t page_size_bytes = input.buffer()->aligned_page_size();
+
+    Buffer* src_buffer = input.buffer();
+    Buffer* dst_buffer = output.buffer();
+
+    const uint32_t input_buffer_address = src_buffer->address();
+    const uint32_t output_buffer_address = dst_buffer->address();
+
+    const uint32_t move_chunk_size_bytes = output_buffer_address - input_buffer_address;
+    TT_FATAL(
+        src_buffer->alignment() == dst_buffer->alignment(),
+        "Expected input buffer alignment ({} B) and output buffer alignment ({} B) to be equal",
+        src_buffer->alignment(),
+        dst_buffer->alignment());
+    TT_FATAL(
+        move_chunk_size_bytes % src_buffer->alignment() == 0,
+        "Expected chunk size bytes to move to be {} byte aligned.",
+        src_buffer->alignment());
+    const uint32_t num_chunks = total_size_bytes / move_chunk_size_bytes;
+    const uint32_t remainder_chunk_size_bytes = total_size_bytes % move_chunk_size_bytes;
+
+    ProgramDescriptor desc;
+
+    // Sharded src CB: dynamic globally-allocated; framework rebinds on cache hit.
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = total_size_bytes,
+        .core_ranges = shard_grid,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src_cb_sharded),
+            .data_format = cb_data_format,
+            .page_size = page_size_bytes,
+        }}},
+        .buffer = src_buffer,
+    });
+
+    // Sharded dst CB: dynamic globally-allocated; framework rebinds on cache hit.
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = total_size_bytes,
+        .core_ranges = shard_grid,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(dst_cb_sharded),
+            .data_format = cb_data_format,
+            .page_size = page_size_bytes,
+        }}},
+        .buffer = dst_buffer,
+    });
+
+    std::vector<uint32_t> reader_compile_time_args = {src_cb_sharded, dst_cb_sharded};
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/move/device/kernels/dataflow/"
+        "reader_unary_local_l1_copy_backwards.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = shard_grid;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = DataMovementConfigDescriptor{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1};
+
+    // Runtime args derive from the address arithmetic (output_addr - input_addr) and
+    // therefore must be recomputed every call.  We deliberately emit them as plain
+    // scalars (no Buffer* / BufferBinding) so the adapter's resolved bindings stay
+    // empty and the slow cache-hit path runs create_descriptor() again — which
+    // recomputes move_chunk_size_bytes, num_chunks, remainder_chunk_size_bytes
+    // from the freshly-allocated buffer addresses.  CB addresses are still patched
+    // via desc.cbs[*].buffer in apply_descriptor_runtime_args().
+    const auto cores = corerange_to_cores(shard_grid, std::nullopt, true);
+    for (const auto& core : cores) {
+        reader_desc.emplace_runtime_args(
+            core, {total_size_bytes, num_chunks, move_chunk_size_bytes, remainder_chunk_size_bytes});
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_sharded_program_factory.hpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/program_descriptors.hpp>
+#include "move_device_operation_types.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct MoveShardedProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const MoveOperationAttributes& operation_attributes,
+        const MoveTensorArgs& tensor_args,
+        Tensor& tensor_return_value);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/move.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/move.cpp
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/data_movement/move/move.hpp"
+
+#include "device/move_device_operation.hpp"
+#include "ttnn/operation.hpp"
+#include "ttnn/distributed/api.hpp"
+#include "ttnn/tensor/tensor_ops.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
+
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/allocator.hpp>
+
+using namespace tt::tt_metal;
+
+namespace ttnn::operations::experimental::quasar {
+
+/**
+ * @brief Creates a ghost tensor (an allocated tensor that does not own the underlying device memory)
+ * before deallocation to avoid passing deallocated tensor through the TTNN infrastructure.
+ *
+ * @param input_tensor The input tensor to create a ghost copy from.
+ * @return Tensor The created ghost tensor.
+ */
+Tensor create_ghost_tensor(const Tensor& input_tensor) {
+    const auto& mesh_buffer = input_tensor.mesh_buffer();
+    auto ghost_mesh_buffer = tt::tt_metal::distributed::MeshBuffer::create(
+        mesh_buffer.global_config(), mesh_buffer.device_local_config(), mesh_buffer.device(), mesh_buffer.address());
+    return Tensor(MeshTensor(ghost_mesh_buffer, input_tensor.tensor_spec(), input_tensor.tensor_topology()));
+}
+
+inline Tensor move_impl(const Tensor& input_tensor, const std::optional<MemoryConfig>& mem_config) {
+    TT_ASSERT(input_tensor.is_allocated(), "Expected input tensor to be allocated");
+    const auto& input_mem_config = input_tensor.memory_config();
+    auto input_address = input_tensor.buffer()->address();
+    TensorSpec output_tensor_spec = input_tensor.tensor_spec();
+
+    // Construct a ghost tensor so we can pass an deallocated tensor through the TTNN infrastructure.
+    auto ghost_input_tensor = create_ghost_tensor(input_tensor);
+    const_cast<Tensor&>(input_tensor).deallocate(/* force = */ false);
+    if (input_tensor.is_allocated()) {
+        // TODO: Should this throw error?
+        return input_tensor;
+    }
+
+    if (mem_config) {
+        output_tensor_spec = TensorSpec(
+            output_tensor_spec.logical_shape(), output_tensor_spec.tensor_layout().with_memory_config(*mem_config));
+    }
+
+    auto output_tensor = create_device_tensor(output_tensor_spec, ghost_input_tensor.device());
+    auto output_mem_config = output_tensor.memory_config();
+
+    // get_parallelization_strategy
+    bool move_within_same_mem_space = input_mem_config.buffer_type() == output_mem_config.buffer_type();
+
+    // A tensor moved within L1 it is meant to reallocate at higher addresses and a tensor moved within DRAM is meant to
+    // reallocate at lower addresses If the tensor is not allocated in a new address, there is no need to move the data
+    if (move_within_same_mem_space and input_address == output_tensor.buffer()->address()) {
+        log_debug(
+            tt::LogOp,
+            "WARNING: No space to move the tensor. Move op's input address and output address are equal: {}",
+            input_address);
+        return output_tensor;
+    }
+
+    // Input and output addresses won't overlap if they are in different memory substrates
+    bool non_overlap = not move_within_same_mem_space;
+    const auto num_banks =
+        ghost_input_tensor.device()->allocator()->get_num_banks(output_tensor.buffer()->buffer_type());
+    uint32_t size_per_bank = tt::tt_metal::detail::calculate_bank_size_spread(
+        output_tensor.buffer()->size(),
+        output_tensor.buffer()->page_size(),
+        num_banks,
+        output_tensor.buffer()->alignment());
+
+    // If input and output buffers overlap, input has to be copied into circular buffer before writing to output
+    // Only compute with storage cores allow CBs to be created
+    auto compute_with_storage_grid_size = ghost_input_tensor.device()->compute_with_storage_grid_size();
+    const auto num_l1_banks = compute_with_storage_grid_size.x * compute_with_storage_grid_size.y;
+    uint32_t size_per_l1_bank = tt::tt_metal::detail::calculate_bank_size_spread(
+        output_tensor.buffer()->size(), output_tensor.buffer()->page_size(), num_l1_banks, hal::get_l1_alignment());
+
+    if (move_within_same_mem_space) {
+        switch (input_mem_config.buffer_type()) {
+            // If DRAM, inverse logic because memory is allocated bottom up
+            case tt::tt_metal::BufferType::DRAM: {
+                non_overlap = output_tensor.buffer()->address() + size_per_bank <= input_address;
+            } break;
+            case tt::tt_metal::BufferType::L1: {
+                non_overlap = input_address + size_per_bank <= output_tensor.buffer()->address();
+            } break;
+            default: break;
+        }
+    }
+
+    bool fits_in_cb =
+        (output_tensor.device()->allocator()->get_base_allocator_addr(HalMemType::L1) + size_per_l1_bank) <=
+        (output_mem_config.buffer_type() == tt::tt_metal::BufferType::L1 ? output_tensor.buffer()->address()
+                                                                         : output_tensor.device()->l1_size_per_core());
+
+    ttnn::prim::qsr::MoveOpParallelizationStrategy move_op_parallelization_strategy =
+        ttnn::prim::qsr::MoveOpParallelizationStrategy::MULTI_CORE;
+    if ((not non_overlap) and fits_in_cb and compute_with_storage_grid_size.x > 1 and
+        compute_with_storage_grid_size.y > 1) {
+        move_op_parallelization_strategy = ttnn::prim::qsr::MoveOpParallelizationStrategy::MULTI_CORE_OVERLAP;
+    }
+
+    return ttnn::prim::qsr::move(
+        ghost_input_tensor, output_tensor, output_mem_config, move_op_parallelization_strategy);
+}
+
+inline Tensor move_sharded(const Tensor& input_tensor, const std::optional<MemoryConfig>& mem_config) {
+    TT_ASSERT(input_tensor.is_allocated(), "Expected input tensor to be allocated");
+    TT_FATAL(input_tensor.memory_config().is_sharded(), "Expected input tensor to be sharded");
+    [[maybe_unused]] auto input_address = input_tensor.buffer()->address();
+    auto shard_spec = input_tensor.shard_spec().value();
+
+    // Construct a ghost tensor so we can pass an deallocated tensor through the TTNN infrastructure.
+    auto ghost_input_tensor = create_ghost_tensor(input_tensor);
+
+    const_cast<Tensor&>(input_tensor).deallocate(/* force = */ false);
+    if (input_tensor.is_allocated()) {
+        TT_FATAL(
+            false,
+            "Expect input tensor to be deallocated after move op. Cannot deallocate before there is probably "
+            "another consumer.");
+        // TODO: Should this throw error?
+        return {input_tensor};
+    }
+
+    auto output_tensor_spec = ghost_input_tensor.tensor_spec();
+    if (mem_config) {
+        TT_FATAL(mem_config->is_sharded(), "Expected output tensor memory config to be sharded");
+        auto output_mem_config = MemoryConfig(mem_config->memory_layout(), mem_config->buffer_type(), shard_spec);
+        output_tensor_spec = TensorSpec(
+            output_tensor_spec.logical_shape(),
+            output_tensor_spec.tensor_layout().with_memory_config(output_mem_config));
+    }
+
+    auto output_tensor = create_device_tensor(output_tensor_spec, ghost_input_tensor.device());
+    if (ghost_input_tensor.buffer()->address() == output_tensor.buffer()->address()) {
+        log_debug(
+            tt::LogOp,
+            "WARNING: No space to move the tensor. Move op's input address and output address are equal: {}",
+            input_address);
+        return {output_tensor};
+    }
+    ttnn::prim::qsr::MoveOpParallelizationStrategy move_op_parallelization_strategy =
+        ttnn::prim::qsr::MoveOpParallelizationStrategy::MULTI_CORE_SHARDED;
+    return ttnn::prim::qsr::move(
+        ghost_input_tensor, output_tensor, output_tensor.memory_config(), move_op_parallelization_strategy);
+}
+
+}  // namespace ttnn::operations::experimental::quasar
+
+namespace ttnn::operations::experimental::quasar {
+
+Tensor move(const Tensor& input_tensor, const std::optional<MemoryConfig>& output_mem_config) {
+    if (input_tensor.memory_config().is_sharded()) {
+        return move_sharded(input_tensor, output_mem_config);
+    }
+    return move_impl(input_tensor, output_mem_config);
+}
+
+}  // namespace ttnn::operations::experimental::quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/move.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/move.hpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::experimental::quasar {
+
+Tensor move(const Tensor& input_tensor, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
+
+}  // namespace ttnn::operations::experimental::quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/move_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/move_nanobind.cpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "move_nanobind.hpp"
+
+#include <optional>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
+
+#include "ttnn-nanobind/bind_function.hpp"
+
+#include "move.hpp"
+
+namespace ttnn::operations::experimental::quasar::detail {
+
+void bind_move(nb::module_& mod) {
+    const auto* doc = R"doc(
+            Moves the elements of the input tensor ``arg0`` to a location in memory with specified memory layout.
+
+            If no memory layout is specified, output memory will be the same as the input tensor memory config.
+
+            +----------+----------------------------+----------------------------+---------------------------------+----------+
+            | Argument | Description                | Data type                  | Valid range                     | Required |
+            +==========+============================+============================+=================================+==========+
+            | arg0     | Tensor to move             | Tensor                     | Tensor of shape [W, Z, Y, X]    | Yes      |
+            +----------+----------------------------+----------------------------+---------------------------------+----------+
+            | arg1     | MemoryConfig of tensor of  | tt_lib.tensor.MemoryConfig | Default is same as input tensor | No       |
+            |          | TT accelerator device      |                            |                                 |          |
+            +----------+----------------------------+----------------------------+---------------------------------+----------+
+        )doc";
+
+    ttnn::bind_function<"move">(
+        mod,
+        doc,
+        &ttnn::operations::experimental::quasar::move,
+        nb::arg("input_tensor").noconvert(),
+        nb::kw_only(),
+        nb::arg("memory_config") = nb::none());
+}
+
+}  // namespace ttnn::operations::experimental::quasar::detail

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/move_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/move_nanobind.hpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::experimental::quasar::detail {
+
+namespace nb = nanobind;
+void bind_move(nb::module_& mod);
+
+}  // namespace ttnn::operations::experimental::quasar::detail

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/common.hpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Takes in an id_per_dim and dims array, both of size ndims
+// Advances the id_per_dim by one, wrapping and carrying as needed
+static inline int advance_tensor_index(
+    volatile tt_l1_ptr uint32_t* idx, volatile tt_l1_ptr uint32_t* dims, uint32_t ndims) {
+    // increment least-significant dim first
+    for (int32_t d = ndims - 1; d >= 0; d--) {
+        uint32_t v = idx[d] + 1;
+        if (v < dims[d]) {
+            idx[d] = v;
+            return 1;
+        }
+        idx[d] = 0;  // wrap and carry
+    }
+    return 0;  // overflowed most-significant dim
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved.cpp
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+template <typename PadAccessor>
+inline __attribute__((always_inline)) void fill_with_val_async(
+    Noc& noc,
+    const PadAccessor& s_const,
+    const uint32_t begin_addr,
+    const uint32_t begin_addr_aligned,
+    uint32_t size_nbytes,
+    uint32_t chunk_nbytes,
+    uint16_t pad_value) {
+    uint32_t curr_addr = begin_addr;
+    while (curr_addr < begin_addr_aligned && size_nbytes > 0) {
+        reinterpret_cast<uint16_t*>(curr_addr)[0] = pad_value;
+        curr_addr += 2;
+        size_nbytes -= 2;
+    }
+    uint32_t nchunks = size_nbytes / chunk_nbytes;
+    uint32_t rem_nbytes = size_nbytes % chunk_nbytes;
+    for (uint32_t i = 0; i < nchunks; ++i) {
+        CoreLocalMem<uint32_t> dst(curr_addr);
+        noc.async_read(s_const, dst, chunk_nbytes, {.page_id = 0, .offset_bytes = 0}, {.offset_bytes = 0});
+        curr_addr += chunk_nbytes;
+    }
+    if (rem_nbytes > 0) {
+        CoreLocalMem<uint32_t> dst(curr_addr);
+        noc.async_read(s_const, dst, rem_nbytes, {.page_id = 0, .offset_bytes = 0}, {.offset_bytes = 0});
+    }
+}
+
+void kernel_main() {
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t num_unpadded_W = get_arg_val<uint32_t>(2);
+    const uint32_t num_total_W = get_arg_val<uint32_t>(3);
+    const uint32_t num_unpadded_Z = get_arg_val<uint32_t>(4);
+    const uint32_t num_total_Z = get_arg_val<uint32_t>(5);
+    const uint32_t num_unpadded_Y = get_arg_val<uint32_t>(6);
+    const uint32_t num_total_Y = get_arg_val<uint32_t>(7);
+    const uint32_t unpadded_X_nbytes = get_arg_val<uint32_t>(10);
+    const uint32_t padded_X_nbytes = get_arg_val<uint32_t>(11);
+    const uint32_t padded_X_diff_nbytes = get_arg_val<uint32_t>(12);
+    const uint32_t pad_value_const_buffer_addr = get_arg_val<uint32_t>(13);
+    const uint32_t pad_value_const_buffer_nbytes =
+        64;  // assumed to be 64 bytes, fails on BH when > 64. TODO: generalize? (Issue #21978)
+    const uint32_t pad_value_packed = get_arg_val<uint32_t>(15);
+    const uint32_t start_src_stick_id = get_arg_val<uint32_t>(16);
+    const uint32_t start_src_stick_wi = get_arg_val<uint32_t>(18);
+    const uint32_t start_src_stick_offset = get_arg_val<uint32_t>(20);  // == start_src_stick_wi * elem_size
+    const uint32_t num_local_Y = get_arg_val<uint32_t>(21);
+    const uint32_t num_local_unpadded_Y = get_arg_val<uint32_t>(22);
+    const uint32_t full_unpadded_X_nbytes = get_arg_val<uint32_t>(23);
+    const uint32_t num_local_W = get_arg_val<uint32_t>(26);
+
+    constexpr auto src_args = TensorAccessorArgs<2>();
+    constexpr auto dst_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
+    constexpr auto pad_tensor_args = TensorAccessorArgs<dst_args.next_compile_time_args_offset()>();
+
+    constexpr uint32_t cb_id = tt::CBIndex::c_0;
+    CircularBuffer cb(cb_id);
+    Noc noc;
+
+    // calculate the offset for alignment of padding in rows/sticks
+    uint32_t l1_addr_partial = cb.get_write_ptr() + unpadded_X_nbytes;
+    const uint32_t l1_addr_align_offset =
+        32 - l1_addr_partial % 32;  // NOTE: this is fine with double buffering since offset will be same for each page
+
+    const auto s0 = TensorAccessor(src_args, src_addr);
+
+    const auto s_const = TensorAccessor(pad_tensor_args, pad_value_const_buffer_addr);
+
+    uint16_t pad_value = pad_value_packed >> 16;
+
+    uint32_t src_stick_id = start_src_stick_id;
+    for (uint32_t w = 0; w < num_local_W; ++w) {
+        for (uint32_t z = 0; z < num_total_Z; ++z) {
+            for (uint32_t y = 0; y < num_local_Y; ++y) {
+                cb.reserve_back(1);
+                uint32_t l1_addr = cb.get_write_ptr();
+                if (y >= num_local_unpadded_Y || z >= num_unpadded_Z || w >= num_unpadded_W) {
+                    // this is fully padding
+                    fill_with_val_async(
+                        noc, s_const, l1_addr, l1_addr, padded_X_nbytes, pad_value_const_buffer_nbytes, pad_value);
+                } else {
+                    // this is a data row possibly with padding at end
+                    CoreLocalMem<uint32_t> dst(l1_addr);
+                    noc.async_read(
+                        s0,
+                        dst,
+                        unpadded_X_nbytes,
+                        {.page_id = src_stick_id, .offset_bytes = start_src_stick_offset},
+                        {.offset_bytes = 0});
+                    l1_addr_partial = l1_addr + unpadded_X_nbytes;
+                    fill_with_val_async(
+                        noc,
+                        s_const,
+                        l1_addr_partial,
+                        l1_addr_partial + l1_addr_align_offset,
+                        padded_X_diff_nbytes,
+                        pad_value_const_buffer_nbytes,
+                        pad_value);
+                    ++src_stick_id;
+                }
+                noc.async_read_barrier();
+                cb.push_back(1);
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved_v2.cpp
@@ -1,0 +1,187 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include <cstring>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+inline __attribute__((always_inline)) void fill_pad_cb_with_val(
+    const uint32_t cb_id, const uint32_t num_bytes, const uint32_t val) {
+    CircularBuffer cb(cb_id);
+    volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb.get_write_ptr());
+
+    for (uint32_t i = 0; i < num_bytes / 2; ++i) {
+        ptr[i] = val;
+    }
+}
+
+// Helper to read multiple input pages for a single stick into L1.
+// This encapsulates the common pattern of reading (num_pages - 1) full pages
+// followed by a final partially filled page, and advances i_page accordingly.
+template <typename StreamState>
+inline __attribute__((always_inline)) void read_input_pages_into_l1(
+    Noc& noc,
+    const StreamState& s,
+    uint32_t& i_page,
+    uint32_t l1_write_addr,
+    const uint32_t num_input_pages_in_row,
+    const uint32_t input_page_size,
+    const uint32_t size_of_valid_data_in_last_input_page_in_row) {
+    uint32_t write_addr = l1_write_addr;
+    for (uint32_t p = 0; p < num_input_pages_in_row - 1; ++p) {
+        CoreLocalMem<uint32_t> dst(write_addr);
+        noc.async_read(s, dst, input_page_size, {.page_id = i_page + p, .offset_bytes = 0}, {.offset_bytes = 0});
+        write_addr += input_page_size;
+    }
+    CoreLocalMem<uint32_t> dst(write_addr);
+    noc.async_read(
+        s,
+        dst,
+        size_of_valid_data_in_last_input_page_in_row,
+        {.page_id = i_page + num_input_pages_in_row - 1, .offset_bytes = 0},
+        {.offset_bytes = 0});
+    i_page += num_input_pages_in_row;
+}
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t num_sticks_per_core = get_arg_val<uint32_t>(1);
+    uint32_t num_sticks_per_barrier = get_arg_val<uint32_t>(2);
+    uint32_t start_page_id = get_arg_val<uint32_t>(3);
+    uint32_t front_pad_n = get_arg_val<uint32_t>(4);
+    uint32_t front_pad_c = get_arg_val<uint32_t>(5);
+    uint32_t front_pad_h = get_arg_val<uint32_t>(6);
+    tt_l1_ptr uint32_t* start_dim_offset = (tt_l1_ptr uint32_t*)(get_arg_addr(7));
+
+    constexpr uint32_t N = get_compile_time_arg_val(0);
+    constexpr uint32_t H = get_compile_time_arg_val(1);
+    constexpr uint32_t C = get_compile_time_arg_val(2);
+    constexpr uint32_t stick_size_bytes = get_compile_time_arg_val(3);
+    constexpr uint32_t N_padded = get_compile_time_arg_val(4);
+    constexpr uint32_t H_padded = get_compile_time_arg_val(5);
+    constexpr uint32_t C_padded = get_compile_time_arg_val(6);
+    constexpr uint32_t stick_size_padded = get_compile_time_arg_val(7);
+    constexpr uint32_t stick_size_padded_front = get_compile_time_arg_val(8);
+    constexpr uint32_t stick_size_padded_end = get_compile_time_arg_val(9);
+    constexpr uint32_t num_zero_pad_sticks_read = get_compile_time_arg_val(10);
+    constexpr uint32_t last_zero_stick_size = get_compile_time_arg_val(11);
+    constexpr uint32_t stick_size_padded_aligned = get_compile_time_arg_val(18);
+
+    constexpr bool not_pad_by_zero = get_compile_time_arg_val(12) == 1;
+    constexpr uint32_t front_padding = get_compile_time_arg_val(8);
+    constexpr bool unaligned = get_compile_time_arg_val(19) == 1;
+
+    constexpr uint32_t num_input_pages_in_row = get_compile_time_arg_val(20);
+    constexpr uint32_t input_page_size = get_compile_time_arg_val(21);
+    constexpr uint32_t size_of_valid_data_in_last_input_page_in_row = get_compile_time_arg_val(22);
+    constexpr auto src_args = TensorAccessorArgs<23>();
+
+    uint32_t packed_pad_value = 0;
+    if constexpr (not_pad_by_zero) {
+        packed_pad_value = kernel_compile_time_args[13];
+    }
+
+    constexpr uint32_t cb_in0 = tt::CBIndex::c_0;
+    constexpr uint32_t cb_pad = tt::CBIndex::c_1;
+    constexpr uint32_t cb_pad_align = tt::CBIndex::c_2;
+    CircularBuffer cb_in0_exp(cb_in0);
+    CircularBuffer cb_pad_exp(cb_pad);
+    CircularBuffer cb_pad_align_exp(cb_pad_align);
+
+    const auto s = TensorAccessor(src_args, src_addr);
+    Noc noc;
+
+    const uint32_t pad_val_addr = cb_pad_exp.get_read_ptr();
+    const uint32_t pad_align_addr = cb_pad_align_exp.get_read_ptr();
+
+    fill_pad_cb_with_val(cb_pad, stick_size_padded, packed_pad_value);
+
+    uint32_t i_page = start_page_id;
+    uint32_t curr_c = start_dim_offset[2], curr_h = start_dim_offset[1], curr_n = start_dim_offset[3];
+    for (uint32_t iter = 0; iter < num_sticks_per_core;) {
+        cb_in0_exp.reserve_back(num_sticks_per_barrier);
+        uint32_t l1_write_addr = cb_in0_exp.get_write_ptr();
+
+        for (uint32_t i = 0; i < num_sticks_per_barrier && iter < num_sticks_per_core; ++i, ++iter) {
+            bool read_stick = (curr_h >= front_pad_h and curr_h < H) and (curr_c >= front_pad_c and curr_c < C) and
+                              (curr_n >= front_pad_n and curr_n < N);
+            {
+                CoreLocalMem<uint32_t> dst(l1_write_addr);
+                noc.async_read(
+                    UnicastEndpoint{},
+                    dst,
+                    stick_size_padded,
+                    {.noc_x = (uint32_t)my_x[noc.get_noc_id()],
+                     .noc_y = (uint32_t)my_y[noc.get_noc_id()],
+                     .addr = pad_val_addr},
+                    {.offset_bytes = 0});
+                noc.async_read_barrier();
+            }
+            if (read_stick) {
+                if constexpr (front_padding) {  // Read noc into cb_pad_align l1
+                    uint32_t temp_addr = cb_pad_align_exp.get_write_ptr();
+                    read_input_pages_into_l1(
+                        noc,
+                        s,
+                        i_page,
+                        temp_addr,
+                        num_input_pages_in_row,
+                        input_page_size,
+                        size_of_valid_data_in_last_input_page_in_row);
+                    noc.async_read_barrier();
+                    memmove(
+                        (void*)(l1_write_addr + stick_size_padded_front),
+                        (void*)(cb_pad_align_exp.get_read_ptr()),
+                        (size_t)(stick_size_bytes));
+                } else if constexpr (unaligned) {
+                    uint32_t temp_addr = cb_pad_align_exp.get_write_ptr();
+                    read_input_pages_into_l1(
+                        noc,
+                        s,
+                        i_page,
+                        temp_addr,
+                        num_input_pages_in_row,
+                        input_page_size,
+                        size_of_valid_data_in_last_input_page_in_row);
+                    noc.async_read_barrier();
+                    CoreLocalMem<uint32_t> dst(l1_write_addr);
+                    noc.async_read(
+                        UnicastEndpoint{},
+                        dst,
+                        stick_size_bytes,
+                        {.noc_x = (uint32_t)my_x[noc.get_noc_id()],
+                         .noc_y = (uint32_t)my_y[noc.get_noc_id()],
+                         .addr = pad_align_addr},
+                        {.offset_bytes = 0});
+                } else {
+                    read_input_pages_into_l1(
+                        noc,
+                        s,
+                        i_page,
+                        l1_write_addr,
+                        num_input_pages_in_row,
+                        input_page_size,
+                        size_of_valid_data_in_last_input_page_in_row);
+                }
+            }
+            l1_write_addr += stick_size_padded_aligned;
+            curr_h++;
+            if (curr_h == H_padded) {
+                curr_c++;
+                curr_h = 0;
+                if (curr_c == C_padded) {
+                    curr_n++;
+                    curr_c = 0;
+                }
+            }
+        }
+        noc.async_read_barrier();
+        cb_in0_exp.push_back(num_sticks_per_barrier);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/reader_pad_dims_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/reader_pad_dims_rm_sharded.cpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    constexpr uint32_t stick_size_bytes = get_compile_time_arg_val(0);
+    constexpr uint32_t num_sticks_padded = get_compile_time_arg_val(1);
+
+    const uint32_t num_cores_read = get_arg_val<uint32_t>(0);
+    tt_l1_ptr uint32_t* read_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(1));
+    tt_l1_ptr uint32_t* read_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(2));
+    tt_l1_ptr uint32_t* num_stick_chunks = (tt_l1_ptr uint32_t*)(get_arg_addr(1 + num_cores_read * 2));
+    tt_l1_ptr uint32_t* chunk_start_id = (tt_l1_ptr uint32_t*)(get_arg_addr(1 + num_cores_read * 3));
+    tt_l1_ptr uint32_t* chunk_num_sticks = (tt_l1_ptr uint32_t*)(chunk_start_id + 1);
+
+    constexpr auto cb_in0 = tt::CBIndex::c_0;
+    constexpr auto cb_out0 = tt::CBIndex::c_16;
+    CircularBuffer cb_in0_exp(cb_in0);
+    CircularBuffer cb_out0_exp(cb_out0);
+
+    Noc noc;
+
+    cb_out0_exp.reserve_back(num_sticks_padded);
+    uint32_t l1_read_addr = cb_in0_exp.get_write_ptr();
+    uint32_t l1_write_addr = cb_out0_exp.get_write_ptr();
+
+    uint32_t chunk_ptr_offset = 0;
+    uint32_t read_noc_xy_ptr_offset = 0;
+
+    for (uint32_t curr_core = 0; curr_core < num_cores_read; ++curr_core) {
+        const uint32_t src_noc_x = read_noc_x[read_noc_xy_ptr_offset];
+        const uint32_t src_noc_y = read_noc_y[read_noc_xy_ptr_offset];
+
+        uint32_t curr_core_num_chunks = num_stick_chunks[curr_core];
+
+        for (uint32_t curr_chunk = 0; curr_chunk < curr_core_num_chunks; ++curr_chunk) {
+            uint32_t curr_start_id = chunk_start_id[chunk_ptr_offset];
+            uint32_t curr_num_sticks = chunk_num_sticks[chunk_ptr_offset];
+
+            uint32_t l1_read_offset = curr_start_id * stick_size_bytes;
+            uint32_t read_data_size_bytes = curr_num_sticks * stick_size_bytes;
+
+            if ((curr_start_id != (uint32_t)-1) and (curr_start_id != (uint32_t)-2)) {
+                CoreLocalMem<uint32_t> dst(l1_write_addr);
+                noc.async_read(
+                    UnicastEndpoint{},
+                    dst,
+                    read_data_size_bytes,
+                    {.noc_x = src_noc_x, .noc_y = src_noc_y, .addr = l1_read_addr + l1_read_offset},
+                    {.offset_bytes = 0});
+            }
+
+            l1_write_addr += read_data_size_bytes;
+            chunk_ptr_offset += 2;
+        }
+
+        read_noc_xy_ptr_offset += 2;
+    }
+
+    noc.async_read_barrier();
+    cb_out0_exp.push_back(num_sticks_padded);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/reader_pad_dims_rm_sharded_stickwise.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/reader_pad_dims_rm_sharded_stickwise.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include <cstring>
+#include "api/dataflow/dataflow_api.h"
+#include "api/debug/dprint_pages.h"
+#include "api/dataflow/circular_buffer.h"
+#define u8_l1_ptr volatile tt_l1_ptr uint8_t*
+#define u8_vol_ptr volatile uint8_t*
+#define u8_ptr uint8_t*
+
+void kernel_main() {
+    constexpr uint32_t unpadded_stick_bytes = get_compile_time_arg_val(0);
+    constexpr uint32_t padded_stick_bytes = get_compile_time_arg_val(1);
+    constexpr uint32_t unpadded_shard_height = get_compile_time_arg_val(2);
+    constexpr uint32_t padded_shard_height = get_compile_time_arg_val(3);
+    constexpr uint32_t W_front_pad_bytes = get_compile_time_arg_val(4);
+
+    constexpr uint32_t input_shard_cb = get_compile_time_arg_val(5);
+    constexpr uint32_t output_shard_cb = get_compile_time_arg_val(6);
+    constexpr uint32_t unpadded_stick_step = get_compile_time_arg_val(7);
+    constexpr uint32_t padded_stick_step = get_compile_time_arg_val(8);
+
+    CircularBuffer cb_input_shard(input_shard_cb);
+    CircularBuffer cb_output_shard(output_shard_cb);
+
+    uint32_t input_shard_base_addr = cb_input_shard.get_write_ptr();
+    uint32_t output_shard_base_addr = cb_output_shard.get_write_ptr();
+
+    auto input_stick_ptr = reinterpret_cast<u8_l1_ptr>(input_shard_base_addr);
+    auto output_stick_ptr = reinterpret_cast<u8_l1_ptr>(output_shard_base_addr);
+
+    // fill the sticks that aren't entirely padding with data from the input tensor
+    for (uint32_t h = 0; h < unpadded_shard_height; h++) {
+        cb_output_shard.wait_front(1);  // wait for writer to fill this stick with padding
+
+        // FIXME: this isn't aligned. we need to do a memcpy for now. we can try
+        // to do a noc_async_read later on with a trick.
+        //
+        // currently small noc transfers are slow, but once runtime drops an
+        // optimization (upcoming as of 12/12/2024) this might be worth
+        // investigating.
+
+        // paulk says that an optimized loop will still be faster.
+        // TODO(jkruer): get paul's help optimizing this.
+
+        // read the input stick into the padded output stick starting after the
+        // front padding
+        for (uint32_t i = 0; i < unpadded_stick_bytes; i++) {
+            output_stick_ptr[W_front_pad_bytes + i] = input_stick_ptr[i];
+        }
+
+        cb_output_shard.pop_front(1);
+
+        input_stick_ptr += unpadded_stick_step;
+        output_stick_ptr += padded_stick_step;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/reader_pad_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/reader_pad_tiled.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include <algorithm>
+#include "api/dataflow/dataflow_api.h"
+#include "common.hpp"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    constexpr uint32_t input_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t page_size = get_compile_time_arg_val(1);
+    constexpr uint32_t num_dims = get_compile_time_arg_val(2);
+
+    uint32_t rt_ind = 0;
+    const uint32_t input_addr = get_arg_val<uint32_t>(rt_ind++);
+    const uint32_t num_pages_to_write = get_arg_val<uint32_t>(rt_ind++);
+    const uint32_t start_offset = get_arg_val<uint32_t>(rt_ind++);
+    volatile tt_l1_ptr uint32_t* input_page_shape = (tt_l1_ptr uint32_t*)(get_arg_addr(rt_ind));
+    volatile tt_l1_ptr uint32_t* output_page_shape = input_page_shape + num_dims;
+    volatile tt_l1_ptr uint32_t* input_id_per_dim = output_page_shape + num_dims;
+    volatile tt_l1_ptr uint32_t* output_id_per_dim = input_id_per_dim + num_dims;
+
+    constexpr auto dst_args = TensorAccessorArgs<3>();
+
+    const auto s0 = TensorAccessor(dst_args, input_addr);
+    Noc noc;
+    CircularBuffer cb_input(input_cb_id);
+
+    bool within_input_region;
+    uint32_t input_page_offset = start_offset;
+
+    // This kernel keeps track of which page (tile) we are on from a logical tensor perspective
+    // and reads from the input tensor only when we are within the input region
+    // The writer will be waiting for the correct page to be available in the input circular buffer
+    // For example, if we are padding (2, 2, 32, 32) -> (4, 4, 64, 64), then we condense the inner dims to tiles:
+    // (2, 2, 1, 1) -> (4, 4, 2, 2) and as incrementing through writing the output, [0:2, 0:2, 0:1, 0:1] will be
+    // tiles read from input, and the rest will be padding. So for this reader kernel, we will only read when
+    // [0:2, 0:2, 0:1, 0:1] is reached, and skip reads otherwise.
+
+    for (uint32_t out_pages_written = 0; out_pages_written < num_pages_to_write; out_pages_written++) {
+        within_input_region = true;
+        for (uint32_t d = 0; d < num_dims; d++) {
+            if (input_id_per_dim[d] < output_id_per_dim[d]) {
+                within_input_region = false;
+                break;
+            }
+        }
+
+        if (within_input_region) {
+            cb_input.reserve_back(1);
+            noc.async_read(s0, cb_input, page_size, {.page_id = input_page_offset}, {.offset_bytes = 0});
+            noc.async_read_barrier();
+            cb_input.push_back(1);
+            input_page_offset++;
+            advance_tensor_index(input_id_per_dim, input_page_shape, num_dims);
+        }
+        advance_tensor_index(output_id_per_dim, output_page_shape, num_dims);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/writer_pad_dims_rm_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/writer_pad_dims_rm_interleaved.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    const uint32_t dst_addr = get_arg_val<uint32_t>(1);
+    const uint32_t num_total_W = get_arg_val<uint32_t>(3);
+    const uint32_t num_total_Z = get_arg_val<uint32_t>(5);
+    const uint32_t num_total_Y = get_arg_val<uint32_t>(7);
+    const uint32_t num_total_X = get_arg_val<uint32_t>(9);
+    const uint32_t padded_X_nbytes = get_arg_val<uint32_t>(11);
+    const uint32_t start_dst_stick_id = get_arg_val<uint32_t>(17);
+    const uint32_t start_dst_stick_wi = get_arg_val<uint32_t>(19);
+    const uint32_t num_local_Y = get_arg_val<uint32_t>(21);
+    const uint32_t num_local_unpadded_Y = get_arg_val<uint32_t>(22);
+    const uint32_t full_padded_X_nbytes = get_arg_val<uint32_t>(24);
+    const uint32_t dst_stick_offset = get_arg_val<uint32_t>(25);  // == start_src_stick_wi * elem_size
+    const uint32_t num_local_W = get_arg_val<uint32_t>(26);
+
+    constexpr auto src_args = TensorAccessorArgs<2>();
+    constexpr auto dst_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
+
+    constexpr uint32_t cb_id = tt::CBIndex::c_0;
+    CircularBuffer cb(cb_id);
+
+    const auto s1 = TensorAccessor(dst_args, dst_addr);
+    Noc noc;
+
+    uint32_t dst_stick_id = start_dst_stick_id;
+    uint32_t dst_stick_wi = start_dst_stick_wi;
+    for (uint32_t w = 0; w < num_local_W; ++w) {
+        for (uint32_t z = 0; z < num_total_Z; ++z) {
+            for (uint32_t y = 0; y < num_local_Y; ++y) {
+                // DPRINT("WR: w={} z={} y={}\n", w, z, y);
+                cb.wait_front(1);
+                noc.async_write(
+                    cb,
+                    s1,
+                    padded_X_nbytes,
+                    {.offset_bytes = 0},
+                    {.page_id = dst_stick_id, .offset_bytes = dst_stick_offset});
+                noc.async_write_barrier();
+                ++dst_stick_id;
+                cb.pop_front(1);
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/writer_pad_dims_rm_interleaved_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/writer_pad_dims_rm_interleaved_v2.cpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    uint32_t num_sticks_per_core = get_arg_val<uint32_t>(1);
+    uint32_t num_sticks_per_barrier = get_arg_val<uint32_t>(2);
+    uint32_t start_page_id = get_arg_val<uint32_t>(3);
+
+    constexpr uint32_t cb_out0 = get_compile_time_arg_val(0);
+    constexpr uint32_t stick_size_bytes = get_compile_time_arg_val(1);
+    constexpr uint32_t stick_size_padded_aligned = get_compile_time_arg_val(2);
+    constexpr uint32_t num_output_pages_in_row = get_compile_time_arg_val(3);
+    constexpr uint32_t output_page_size = get_compile_time_arg_val(4);
+    constexpr uint32_t size_of_valid_data_in_last_output_page_in_row = get_compile_time_arg_val(5);
+    constexpr auto dst_args = TensorAccessorArgs<6>();
+
+    const auto s = TensorAccessor(dst_args, dst_addr);
+    Noc noc;
+    CircularBuffer cb_out0_exp(cb_out0);
+
+    uint32_t i_page = start_page_id;
+    for (uint32_t iter = 0; iter < num_sticks_per_core;) {
+        cb_out0_exp.wait_front(num_sticks_per_barrier);
+
+        uint32_t l1_read_offset = 0;
+
+        for (uint32_t i = 0; i < num_sticks_per_barrier && iter < num_sticks_per_core; ++i, ++iter) {
+            uint32_t tmp_offset = l1_read_offset;
+            for (uint32_t p = 0; p < num_output_pages_in_row - 1; p++) {
+                noc.async_write(
+                    cb_out0_exp,
+                    s,
+                    output_page_size,
+                    {.offset_bytes = tmp_offset},
+                    {.page_id = i_page + p, .offset_bytes = 0});
+                tmp_offset += output_page_size;
+            }
+            noc.async_write(
+                cb_out0_exp,
+                s,
+                size_of_valid_data_in_last_output_page_in_row,
+                {.offset_bytes = tmp_offset},
+                {.page_id = i_page + num_output_pages_in_row - 1, .offset_bytes = 0});
+            l1_read_offset += stick_size_padded_aligned;
+            i_page += num_output_pages_in_row;
+        }
+        noc.async_write_barrier();
+        cb_out0_exp.pop_front(num_sticks_per_barrier);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded.cpp
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+inline __attribute__((always_inline)) void fill_pad_cb_with_val(
+    Noc& noc, const uint32_t cb_id, const uint32_t num_bytes_risc, uint32_t num_noc_transfer, const uint32_t val) {
+    CircularBuffer cb(cb_id);
+    volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb.get_write_ptr());
+
+    for (uint32_t i = 0; i < num_bytes_risc / 2; ++i) {
+        ptr[i] = val;
+    }
+
+    uint32_t pad_val_addr = cb.get_write_ptr();
+    uint32_t l1_write_addr = pad_val_addr;
+
+    for (uint32_t i = 0; i < num_noc_transfer; ++i) {
+        CoreLocalMem<uint32_t> dst(l1_write_addr);
+        noc.async_read(
+            UnicastEndpoint{},
+            dst,
+            num_bytes_risc,
+            {.noc_x = (uint32_t)my_x[noc.get_noc_id()],
+             .noc_y = (uint32_t)my_y[noc.get_noc_id()],
+             .addr = pad_val_addr},
+            {.offset_bytes = 0});
+        l1_write_addr += num_bytes_risc;
+    }
+    noc.async_read_barrier();
+}
+
+inline __attribute__((always_inline)) void fill_pad_cb_with_zero(
+    Noc& noc, const uint32_t cb_id, const uint32_t num_bytes_risc, uint32_t num_noc_transfer) {
+    CircularBuffer cb(cb_id);
+    noc.async_write_zeros(cb, num_bytes_risc * num_noc_transfer);
+    noc.write_zeros_l1_barrier();
+}
+
+void kernel_main() {
+    uint32_t num_sticks_per_core = get_arg_val<uint32_t>(0);
+    uint32_t start_id = get_arg_val<uint32_t>(1);
+    uint32_t front_pad_n = get_arg_val<uint32_t>(2);
+    uint32_t front_pad_c = get_arg_val<uint32_t>(3);
+    uint32_t front_pad_h = get_arg_val<uint32_t>(4);
+    tt_l1_ptr uint32_t* start_dim_offset = (tt_l1_ptr uint32_t*)(get_arg_addr(5));
+
+    constexpr uint32_t N = get_compile_time_arg_val(0);
+    constexpr uint32_t H = get_compile_time_arg_val(1);
+    constexpr uint32_t C = get_compile_time_arg_val(2);
+    constexpr uint32_t stick_size_bytes = get_compile_time_arg_val(3);
+    constexpr uint32_t N_padded = get_compile_time_arg_val(4);
+    constexpr uint32_t H_padded = get_compile_time_arg_val(5);
+    constexpr uint32_t C_padded = get_compile_time_arg_val(6);
+    constexpr uint32_t num_zero_pad_sticks_read = get_compile_time_arg_val(7);
+    constexpr uint32_t zero_pad_stick_size = get_compile_time_arg_val(8);
+
+    constexpr bool not_pad_by_zero = get_compile_time_arg_val(9) == 1;
+    uint32_t packed_pad_value = 0;
+    uint32_t row_major_min_bytes = 0;
+    uint32_t num_sticks_padded_read = 0;
+    if constexpr (not_pad_by_zero) {
+        packed_pad_value = kernel_compile_time_args[10];
+        row_major_min_bytes = kernel_compile_time_args[11];
+        num_sticks_padded_read = kernel_compile_time_args[12];
+    }
+
+    constexpr auto cb_pad = tt::CBIndex::c_1;
+    constexpr auto cb_out0 = tt::CBIndex::c_16;
+    CircularBuffer cb_pad_exp(cb_pad);
+    CircularBuffer cb_out0_exp(cb_out0);
+
+    Noc noc;
+
+    const uint32_t pad_val_addr = cb_pad_exp.get_read_ptr();
+
+    if constexpr (not_pad_by_zero) {
+        fill_pad_cb_with_val(noc, cb_pad, row_major_min_bytes, num_sticks_padded_read, packed_pad_value);
+    } else {
+        fill_pad_cb_with_zero(noc, cb_pad, zero_pad_stick_size, num_zero_pad_sticks_read);
+    }
+
+    uint32_t l1_write_addr = cb_out0_exp.get_write_ptr();
+
+    uint32_t i_stick = start_id;
+    uint32_t curr_c = start_dim_offset[2], curr_h = start_dim_offset[1], curr_n = start_dim_offset[3];
+    for (uint32_t iter = 0; iter < num_sticks_per_core; ++iter) {
+        bool read_stick = (curr_h >= front_pad_h and curr_h < H) and (curr_c >= front_pad_c and curr_c < C) and
+                          (curr_n >= front_pad_n and curr_n < N);
+
+        if (read_stick) {
+            l1_write_addr += stick_size_bytes;
+            i_stick++;
+
+        } else {
+            CoreLocalMem<uint32_t> dst(l1_write_addr);
+            noc.async_read(
+                UnicastEndpoint{},
+                dst,
+                stick_size_bytes,
+                {.noc_x = (uint32_t)my_x[noc.get_noc_id()],
+                 .noc_y = (uint32_t)my_y[noc.get_noc_id()],
+                 .addr = pad_val_addr},
+                {.offset_bytes = 0});
+            l1_write_addr += stick_size_bytes;
+        }
+
+        curr_h++;
+        if (curr_h == H_padded) {
+            curr_c++;
+            curr_h = 0;
+            if (curr_c == C_padded) {
+                curr_n++;
+                curr_c = 0;
+            }
+        }
+    }
+
+    noc.async_read_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded_stickwise.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded_stickwise.cpp
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include <cstring>
+#include "api/dataflow/dataflow_api.h"
+#include "api/debug/dprint_pages.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+#define u16_l1_ptr volatile tt_l1_ptr uint16_t*
+#define u32_l1_ptr volatile tt_l1_ptr uint32_t*
+
+template <uint32_t padding_value_num_bytes, uint32_t num_bytes>
+inline __attribute__((always_inline)) void fill_cb_with_padding_value(
+    const uint32_t cb_id, const uint32_t padding_value_as_u32) {
+    constexpr uint32_t num_elts =
+        num_bytes / padding_value_num_bytes;  // constexpr so that this division happens once on host
+    CircularBuffer cb(cb_id);
+    uint32_t cb_write_addr = cb.get_write_ptr();
+
+    if constexpr (padding_value_num_bytes == 4) {
+        u32_l1_ptr cb_write_addr_as_u32 = reinterpret_cast<u32_l1_ptr>(cb_write_addr);
+        for (uint32_t i = 0; i < num_elts; i++) {
+            cb_write_addr_as_u32[i] = padding_value_as_u32;
+        }
+    } else if constexpr (padding_value_num_bytes == 2) {
+        uint16_t padding_value_as_u16 = static_cast<uint16_t>(padding_value_as_u32);
+        u16_l1_ptr cb_write_addr_as_u16 = reinterpret_cast<u16_l1_ptr>(cb_write_addr);
+        for (uint32_t i = 0; i < num_elts; i++) {
+            cb_write_addr_as_u16[i] = padding_value_as_u16;
+        }
+    } else {
+        static_assert(
+            padding_value_num_bytes == 2 || padding_value_num_bytes == 4, "padding_value_num_bytes is not 2 or 4");
+    }
+}
+
+void kernel_main() {
+    constexpr uint32_t padded_stick_bytes = get_compile_time_arg_val(0);
+    constexpr uint32_t padded_shard_height = get_compile_time_arg_val(1);
+    constexpr uint32_t padding_value_as_u32 = get_compile_time_arg_val(2);
+    constexpr uint32_t padding_value_num_bytes = get_compile_time_arg_val(3);
+
+    constexpr auto output_shard_cb = get_compile_time_arg_val(4);
+    constexpr auto padding_value_cb = get_compile_time_arg_val(5);
+    CircularBuffer cb_output_shard(output_shard_cb);
+    CircularBuffer cb_padding_value(padding_value_cb);
+
+    Noc noc;
+
+    cb_output_shard.reserve_back(padded_shard_height);
+    uint32_t output_shard_base_addr = cb_output_shard.get_write_ptr();
+
+    fill_cb_with_padding_value<padding_value_num_bytes, padded_stick_bytes>(padding_value_cb, padding_value_as_u32);
+    uint32_t padding_value_base_addr = cb_padding_value.get_read_ptr();
+
+    CoreLocalMem<uint32_t> pad_src(padding_value_base_addr);
+    uint32_t output_stick_addr = output_shard_base_addr;
+    for (uint32_t h = 0; h < padded_shard_height; h++) {
+        noc.async_write(
+            pad_src,
+            UnicastEndpoint{},
+            padded_stick_bytes,
+            {.offset_bytes = 0},
+            {.noc_x = (uint32_t)my_x[noc.get_noc_id()],
+             .noc_y = (uint32_t)my_y[noc.get_noc_id()],
+             .addr = output_stick_addr});
+        noc.async_write_barrier();
+
+        cb_output_shard.push_back(1);
+
+        output_stick_addr += padded_stick_bytes;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/writer_pad_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/writer_pad_tiled.cpp
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include <algorithm>
+#include "api/dataflow/dataflow_api.h"
+#include "common.hpp"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+// This kernel keeps track of which page (tile) we are on from a logical tensor perspective, and fills the output with
+// either the input or padding respectively
+// For example, if we are padding (2, 2, 32, 32) -> (4, 4, 64, 64), then we condense the inner dims to tiles:
+// (2, 2, 1, 1) -> (4, 4, 2, 2) and as incrementing through writing the output, [0:2, 0:2, 0:1, 0:1] will be
+// tiles read from input, and the rest will be padding. So for this writer kernel, if we are within
+// [0:2, 0:2, 0:1, 0:1] we wait for the reader to send us the correct tile, and then write it, otherwise we
+// write padding.
+void kernel_main() {
+    constexpr uint32_t input_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t output_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t pad_val_cb_id = get_compile_time_arg_val(2);
+    constexpr uint32_t page_size = get_compile_time_arg_val(3);
+    constexpr uint32_t num_dims = get_compile_time_arg_val(4);
+    constexpr uint32_t pad_value = get_compile_time_arg_val(5);
+    constexpr uint32_t element_size = get_compile_time_arg_val(6);
+    constexpr uint32_t num_elements = page_size / element_size;
+
+    uint32_t rt_ind = 0;
+    const uint32_t output_addr = get_arg_val<uint32_t>(rt_ind++);
+    const uint32_t num_pages_to_write = get_arg_val<uint32_t>(rt_ind++);
+    const uint32_t start_offset = get_arg_val<uint32_t>(rt_ind++);
+    volatile tt_l1_ptr uint32_t* input_page_shape = (tt_l1_ptr uint32_t*)(get_arg_addr(rt_ind));
+    volatile tt_l1_ptr uint32_t* output_page_shape = input_page_shape + num_dims;
+    volatile tt_l1_ptr uint32_t* input_id_per_dim = output_page_shape + num_dims;
+    volatile tt_l1_ptr uint32_t* output_id_per_dim = input_id_per_dim + num_dims;
+
+    constexpr auto dst_args = TensorAccessorArgs<7>();
+
+    const auto s0 = TensorAccessor(dst_args, output_addr);
+    Noc noc;
+    CircularBuffer cb_input(input_cb_id);
+    CircularBuffer cb_pad_val(pad_val_cb_id);
+
+    // Reserve and push the pad value into the circular buffer, generalized for any contiguous dtype
+    cb_pad_val.reserve_back(1);
+    uint32_t l1_write_addr = cb_pad_val.get_write_ptr();
+    volatile tt_l1_ptr uint8_t* pad_val_page = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_addr);
+    const volatile tt_l1_ptr uint8_t* pad_val = reinterpret_cast<const volatile tt_l1_ptr uint8_t*>(&pad_value);
+    for (uint32_t i = 0; i < num_elements; i++) {
+        for (uint32_t b = 0; b < element_size; b++) {
+            pad_val_page[i * element_size + b] = pad_val[b];
+        }
+    }
+    cb_pad_val.push_back(1);
+    // Our scratchpad cb is now a tile full of padding.
+
+    bool within_input_region;
+    uint32_t output_page_offset = start_offset;
+
+    // Loop over all output pages to write
+    for (uint32_t out_pages_written = 0; out_pages_written < num_pages_to_write; out_pages_written++) {
+        within_input_region = true;
+        for (uint32_t d = 0; d < num_dims; d++) {
+            if (input_id_per_dim[d] < output_id_per_dim[d]) {
+                within_input_region = false;
+                break;
+            }
+        }
+
+        // We have two cases, if we are within the input region, we wait for the reader to send us the correct tile
+        // Otherwise we simply write the padding tile we have in our circular buffer
+        if (within_input_region) {
+            cb_input.wait_front(1);
+            noc.async_write(
+                cb_input, s0, page_size, {.offset_bytes = 0}, {.page_id = output_page_offset, .offset_bytes = 0});
+            noc.async_write_barrier();
+            advance_tensor_index(input_id_per_dim, input_page_shape, num_dims);
+            cb_input.pop_front(1);
+        } else {
+            CoreLocalMem<uint32_t> pad_src(l1_write_addr);
+            noc.async_write(
+                pad_src, s0, page_size, {.offset_bytes = 0}, {.page_id = output_page_offset, .offset_bytes = 0});
+            noc.async_write_barrier();
+        }
+        advance_tensor_index(output_id_per_dim, output_page_shape, num_dims);
+        output_page_offset++;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/writer_unary_pad_dims_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/writer_unary_pad_dims_interleaved.cpp
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    const uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    const uint32_t num_unpadded_W = get_arg_val<uint32_t>(1);
+    const uint32_t num_padded_Wt = get_arg_val<uint32_t>(2);
+    const uint32_t num_unpadded_Z = get_arg_val<uint32_t>(3);
+    const uint32_t num_padded_Zt = get_arg_val<uint32_t>(4);
+    const uint32_t num_unpadded_Yt = get_arg_val<uint32_t>(5);
+    const uint32_t num_padded_Yt = get_arg_val<uint32_t>(6);
+    const uint32_t num_unpadded_Xt = get_arg_val<uint32_t>(7);
+    const uint32_t num_padded_Xt = get_arg_val<uint32_t>(8);
+    const uint32_t pad_value = get_arg_val<uint32_t>(9);
+
+    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_id_out1 = get_compile_time_arg_val(1);
+    constexpr auto dst_args = TensorAccessorArgs<2>();
+
+    const uint32_t tile_size = get_tile_size(cb_id_out0);
+
+    const auto s1 = TensorAccessor(dst_args, dst_addr);
+    Noc noc;
+    CircularBuffer cb_out0(cb_id_out0);
+    CircularBuffer cb_out1(cb_id_out1);
+
+    cb_out1.reserve_back(1);  // in this kernel we are not pushing anything into CBs, just using the space
+
+    uint32_t pad_buffer_l1_addr = cb_out1.get_write_ptr();
+
+    // Fill pad tile with pad value
+    volatile tt_l1_ptr uint32_t* pad_buffer = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(pad_buffer_l1_addr);
+    const uint32_t num_elems = tile_size / sizeof(uint32_t);
+    for (uint32_t z = 0; z < num_elems; z++) {
+        pad_buffer[z] = pad_value;
+    }
+
+    uint32_t src_tile_id = 0;
+    uint32_t dst_tile_id = 0;
+
+    CoreLocalMem<uint32_t> pad_src(pad_buffer_l1_addr);
+    auto pad_tiles = [&](uint32_t num_tiles) {
+        for (uint32_t pad_tile = 0; pad_tile < num_tiles; pad_tile++) {
+            noc.async_write(pad_src, s1, tile_size, {.offset_bytes = 0}, {.page_id = dst_tile_id, .offset_bytes = 0});
+            dst_tile_id++;
+        }
+        noc.async_write_barrier();
+    };
+
+    for (uint32_t w = 0; w < num_unpadded_W; w++) {
+        for (uint32_t z = 0; z < num_unpadded_Z; z++) {
+            for (uint32_t yt = 0; yt < num_unpadded_Yt; yt++) {
+                for (uint32_t xt = 0; xt < num_unpadded_Xt; xt++) {
+                    cb_out0.wait_front(1);
+                    noc.async_write(
+                        cb_out0, s1, tile_size, {.offset_bytes = 0}, {.page_id = dst_tile_id, .offset_bytes = 0});
+                    noc.async_write_barrier();
+                    cb_out0.pop_front(1);
+                    dst_tile_id++;
+                }
+                pad_tiles(num_padded_Xt);
+            }
+            pad_tiles(num_padded_Yt);
+        }
+        pad_tiles(num_padded_Zt);
+    }
+    pad_tiles(num_padded_Wt);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_device_operation.cpp
@@ -1,0 +1,257 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/tt_align.hpp>
+#include "pad_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/data_movement/common/common.hpp"
+#include "ttnn/operations/full/device/full_device_operation.hpp"
+#include "ttnn/operations/creation/creation.hpp"
+
+#include "ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_multi_core_program_factory.hpp"
+#include "ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.hpp"
+#include "ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_program_factory.hpp"
+#include "ttnn/operations/experimental/quasar/pad/device/pad_rm_sharded_height_only_program_factory.hpp"
+#include "ttnn/operations/experimental/quasar/pad/device/pad_rm_sharded_width_only_program_factory.hpp"
+#include "ttnn/operations/experimental/quasar/pad/device/pad_tile_multicore_program_factory.hpp"
+#include "ttnn/operations/experimental/quasar/pad/device/pad_tile_program_factory.hpp"
+
+using namespace tt::tt_metal;
+namespace ttnn::prim::qsr {
+using ttnn::operations::data_movement::common_tm_bw_model;
+
+namespace {
+bool can_use_sharded_optimized_factory(const PadParams& operation_attributes, const Tensor& input_tensor) {
+    if (!input_tensor.shard_spec().has_value()) {
+        return false;
+    }
+    if (!input_tensor.memory_config().is_l1()) {
+        return false;
+    }
+    if (input_tensor.memory_config().memory_layout() != TensorMemoryLayout::HEIGHT_SHARDED) {
+        return false;
+    }
+    if (!operation_attributes.output_mem_config.is_sharded()) {
+        return false;
+    }
+    if (operation_attributes.output_mem_config.memory_layout() != TensorMemoryLayout::HEIGHT_SHARDED) {
+        return false;
+    }
+    if (operation_attributes.sub_core_grids.has_value()) {
+        return false;
+    }
+    if (operation_attributes.output_padded_shape[-1] != operation_attributes.output_mem_config.shard_spec()->shape[1]) {
+        return false;
+    }
+    if (operation_attributes.output_mem_config.shard_spec().value().shape[0] <
+        input_tensor.shard_spec().value().shape[0]) {
+        // Note this case causes the sharded optimized PadRmShardedWidthOnlyProgramFactory{} to hang.
+        return false;
+    }
+    return true;
+}
+}  // namespace
+
+tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>> PadDeviceOperation::create_op_performance_model(
+    const std::vector<Tensor>& input_tensors,
+    const std::vector<std::optional<const Tensor>>& /*optional_input_tensors*/,
+    std::vector<Tensor>& output_tensors) {
+    const auto& input_tensor = input_tensors.at(0);
+    const auto& output_tensor = output_tensors.at(0);
+    int ideal_dev_clock_cycles = common_tm_bw_model(input_tensor, output_tensor);
+    tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>> result(
+        input_tensors, output_tensors, ideal_dev_clock_cycles);
+    return result;
+}
+
+PadDeviceOperation::program_factory_t PadDeviceOperation::select_program_factory(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input;
+    if (input_tensor.layout() == Layout::ROW_MAJOR) {
+        if (input_tensor.is_sharded()) {
+            if (can_use_sharded_optimized_factory(operation_attributes, input_tensor)) {
+                uint32_t input_w = input_tensor.logical_shape()[3];
+                uint32_t output_w = operation_attributes.output_logical_shape[3];
+                uint32_t input_tot_h = std::accumulate(
+                    input_tensor.logical_shape().view().begin(),
+                    input_tensor.logical_shape().view().end() - 1,
+                    1,
+                    std::multiplies<uint32_t>());
+                uint32_t output_tot_h = std::accumulate(
+                    operation_attributes.output_logical_shape.view().begin(),
+                    operation_attributes.output_logical_shape.view().end() - 1,
+                    1,
+                    std::multiplies<uint32_t>());
+
+                if (input_w != output_w && input_tot_h == output_tot_h) {
+                    return PadRmShardedWidthOnlyProgramFactory{};
+                }
+                if (input_w == output_w) {
+                    return PadRmShardedHeightOnlyProgramFactory{};
+                }
+                // Combined width+height padding: fall through to the default factory
+            }
+            return PadRmReaderWriterMultiCoreDefaultProgramFactory{};
+        }
+        if (operation_attributes.use_multicore) {
+            return PadRmReaderWriterMultiCoreDefaultProgramFactory{};
+        }
+        return PadRmReaderWriterProgramFactory{};
+    }
+    if (input_tensor.layout() == Layout::TILE) {
+        if (operation_attributes.use_multicore) {
+            return PadTileMulticoreProgramFactory{};
+        }
+        return PadTileCoreProgramFactory{};
+    }
+    TT_THROW("Unsupported layout for pad");
+    return {};
+}
+
+void PadDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    using namespace tt::constants;
+    const auto& input_tensor = tensor_args.input;
+    auto logical_rank = input_tensor.logical_shape().rank();
+    auto padded_rank = input_tensor.padded_shape().rank();
+    TT_FATAL(logical_rank == padded_rank, "ttnn.pad: logical and padded shapes must have the same rank");
+    TT_FATAL(input_tensor.logical_shape().rank() <= 4, "ttnn.pad: input tensor rank currently must be 4 or less");
+    TT_FATAL(input_tensor.storage_type() == tt::tt_metal::StorageType::DEVICE, "Operand to pad needs to be on device!");
+    TT_FATAL(input_tensor.buffer() != nullptr, "Operand to pad needs to be allocated in a buffer on device!");
+    TT_FATAL(
+        input_tensor.layout() == tt::tt_metal::Layout::TILE || input_tensor.layout() == tt::tt_metal::Layout::ROW_MAJOR,
+        "Error");
+    if (input_tensor.layout() == Layout::TILE) {
+        TT_FATAL(
+            (operation_attributes.input_tensor_start[0] == 0 && operation_attributes.input_tensor_start[1] == 0 &&
+             operation_attributes.input_tensor_start[2] == 0 && operation_attributes.input_tensor_start[3] == 0),
+            "On device padding only supports padding at end of dims");
+    }
+    TT_FATAL(
+        input_tensor.logical_shape()[0] + operation_attributes.input_tensor_start[0] <=
+            operation_attributes.output_padded_shape[0],
+        "Output size cannot fit input with offset");
+    TT_FATAL(
+        input_tensor.logical_shape()[1] + operation_attributes.input_tensor_start[1] <=
+            operation_attributes.output_padded_shape[1],
+        "Output size cannot fit input with offset");
+    TT_FATAL(
+        input_tensor.logical_shape()[2] + operation_attributes.input_tensor_start[2] <=
+            operation_attributes.output_padded_shape[2],
+        "Output size cannot fit input with offset");
+    TT_FATAL(
+        input_tensor.logical_shape()[3] + operation_attributes.input_tensor_start[3] <=
+            operation_attributes.output_padded_shape[3],
+        "Output size cannot fit input with offset");
+
+    if (input_tensor.layout() == Layout::TILE) {
+        TT_FATAL(
+            (operation_attributes.output_padded_shape[2] % TILE_HEIGHT == 0),
+            "Can only pad tilized tensor with full tiles");
+        TT_FATAL(
+            (operation_attributes.output_padded_shape[3] % TILE_WIDTH == 0),
+            "Can only pad tilized tensor with full tiles");
+        TT_FATAL(
+            input_tensor.dtype() == DataType::FLOAT32 || input_tensor.dtype() == DataType::BFLOAT16 ||
+                input_tensor.dtype() == DataType::INT32 || input_tensor.dtype() == DataType::UINT32 ||
+                input_tensor.dtype() == DataType::UINT16 || input_tensor.dtype() == DataType::BFLOAT8_B,
+            "Cannot pad tilized tensor with specified format");
+    } else if (input_tensor.layout() == Layout::ROW_MAJOR) {
+        TT_FATAL(
+            input_tensor.dtype() == DataType::FLOAT32 || input_tensor.dtype() == DataType::BFLOAT16 ||
+                input_tensor.dtype() == DataType::INT32 || input_tensor.dtype() == DataType::UINT32 ||
+                input_tensor.dtype() == DataType::UINT16,
+            "Cannot pad RM tensor with specified format");
+    }
+
+    // Special conditions for sub_core_grids
+    if (operation_attributes.sub_core_grids.has_value()) {
+        TT_FATAL(
+            input_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+            "ttnn.pad: Input memory layout must be interleaved when sub_core_grids argument is provided");
+        TT_FATAL(
+            operation_attributes.output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
+            "ttnn.pad: Output memory layout must be interleaved when sub_core_grids argument is provided");
+        TT_FATAL(
+            operation_attributes.use_multicore,
+            "ttnn.pad: sub_core_grids is only supported when use_multicore is true");
+    }
+
+    if (input_tensor.is_sharded()) {
+        uint32_t shard_width = input_tensor.shard_spec().has_value()
+                                   ? input_tensor.shard_spec().value().shape[1]
+                                   : input_tensor.nd_shard_spec().value().shard_shape[-1];
+        const uint32_t page_size_bytes = input_tensor.buffer()->page_size();
+        const uint32_t alignment_requirement = hal::get_l1_alignment();
+        TT_FATAL(
+            page_size_bytes == input_tensor.buffer()->aligned_page_size(),
+            "Input row-major shard width {} gives page size {} bytes, which must be aligned to {} bytes",
+            shard_width,
+            page_size_bytes,
+            alignment_requirement);
+    }
+
+    if (operation_attributes.output_mem_config.is_sharded()) {
+        uint32_t output_shard_width =
+            operation_attributes.output_mem_config.shard_spec().has_value()
+                ? operation_attributes.output_mem_config.shard_spec().value().shape[1]
+                : operation_attributes.output_mem_config.nd_shard_spec().value().shard_shape[-1];
+        uint32_t output_page_size_bytes = output_shard_width * input_tensor.element_size();
+        const uint32_t alignment_requirement = hal::get_l1_alignment();
+        TT_FATAL(
+            output_page_size_bytes == tt::align(output_page_size_bytes, alignment_requirement),
+            "Output row-major shard width {} gives page size {} bytes, which must be aligned to {} bytes",
+            output_shard_width,
+            output_page_size_bytes,
+            alignment_requirement);
+    }
+}
+
+ttnn::TensorSpec PadDeviceOperation::compute_output_specs(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input;
+    return TensorSpec(
+        operation_attributes.output_logical_shape,
+        TensorLayout::fromPaddedShape(
+            input_tensor.dtype(),
+            PageConfig(input_tensor.layout()),
+            operation_attributes.output_mem_config,
+            operation_attributes.output_logical_shape,
+            operation_attributes.output_padded_shape));
+}
+
+Tensor PadDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    if (tensor_args.preallocated_output.has_value()) {
+        return tensor_args.preallocated_output.value();
+    }
+    const auto output_spec = compute_output_specs(operation_attributes, tensor_args);
+    return create_device_tensor(output_spec, tensor_args.input.device());
+}
+
+PadDeviceOperation::tensor_return_value_t pad(
+    const Tensor& input,
+    const ttnn::Shape& output_logical_shape,
+    const ttnn::Shape& output_padded_shape,
+    const ttnn::Shape& input_tensor_start,
+    float pad_value,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    bool use_multicore,
+    const std::optional<ttnn::Tensor>& preallocated_output,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
+    using OperationType = PadDeviceOperation;
+    return ttnn::device_operation::launch<OperationType>(
+        OperationType::operation_attributes_t{
+            output_logical_shape,
+            output_padded_shape,
+            input_tensor_start,
+            pad_value,
+            output_mem_config,
+            use_multicore,
+            sub_core_grids},
+        OperationType::tensor_args_t{input, preallocated_output});
+}
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_device_operation.hpp
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+#include <variant>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/shape/shape.hpp"
+#include "ttnn/operation.hpp"
+
+#include "ttnn/operations/experimental/quasar/pad/device/pad_device_operation_types.hpp"
+
+#include "ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_multi_core_program_factory.hpp"
+#include "ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.hpp"
+#include "ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_program_factory.hpp"
+#include "ttnn/operations/experimental/quasar/pad/device/pad_rm_sharded_height_only_program_factory.hpp"
+#include "ttnn/operations/experimental/quasar/pad/device/pad_rm_sharded_width_only_program_factory.hpp"
+#include "ttnn/operations/experimental/quasar/pad/device/pad_tile_multicore_program_factory.hpp"
+#include "ttnn/operations/experimental/quasar/pad/device/pad_tile_program_factory.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::prim::qsr {
+struct PadDeviceOperation {
+    using operation_attributes_t = PadParams;
+    using tensor_args_t = PadInputs;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
+    using program_factory_t = std::variant<
+        PadRmReaderWriterMultiCoreProgramFactory,
+        PadRmReaderWriterMultiCoreDefaultProgramFactory,
+        PadRmReaderWriterProgramFactory,
+        PadRmShardedHeightOnlyProgramFactory,
+        PadRmShardedWidthOnlyProgramFactory,
+        PadTileMulticoreProgramFactory,
+        PadTileCoreProgramFactory>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    static tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>> create_op_performance_model(
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+        std::vector<Tensor>& output_tensors);
+};
+}  // namespace ttnn::prim::qsr
+
+namespace ttnn::prim::qsr {
+PadDeviceOperation::tensor_return_value_t pad(
+    const Tensor& input,
+    const ttnn::Shape& output_logical_shape,
+    const ttnn::Shape& output_padded_shape,
+    const ttnn::Shape& input_tensor_start,
+    float pad_value,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    bool use_multicore,
+    const std::optional<ttnn::Tensor>& preallocated_output = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_device_operation_types.hpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operation.hpp"
+#include <tt-metalium/core_coord.hpp>
+
+namespace ttnn::prim::qsr {
+
+struct PadParams {
+    ttnn::Shape output_logical_shape;
+    ttnn::Shape output_padded_shape;
+    ttnn::Shape input_tensor_start;
+    float pad_value{};
+    tt::tt_metal::MemoryConfig output_mem_config;
+    bool use_multicore{};
+    std::optional<CoreRangeSet> sub_core_grids;
+};
+
+struct PadInputs {
+    Tensor input;
+    std::optional<Tensor> preallocated_output;
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.cpp
@@ -1,0 +1,291 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "pad_rm_reader_writer_multi_core_default_program_factory.hpp"
+
+#include <algorithm>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/tt_align.hpp>
+#include <tt-metalium/work_split.hpp>
+#include "ttnn/operations/data_movement/common/common.hpp"
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+static const uint32_t max_read_size = 2048;  // max read size in bytes for reader and writer kernels
+
+namespace ttnn::prim::qsr {
+using ttnn::operations::data_movement::float_to_uint16;
+using ttnn::operations::data_movement::pack_two_uint16_into_uint32;
+
+namespace {
+
+uint32_t get_num_stick_per_barrier(uint32_t stick_size_padded_aligned) {
+    return std::max(tt::div_up(max_read_size, stick_size_padded_aligned), 1u);
+}
+
+}  // namespace
+
+ProgramDescriptor PadRmReaderWriterMultiCoreDefaultProgramFactory::create_descriptor(
+    const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output) {
+    const auto& a = tensor_args.input;
+    const auto& pad_value = operation_attributes.pad_value;
+    const auto& output_padded_shape = operation_attributes.output_padded_shape;
+    const auto& input_tensor_start = operation_attributes.input_tensor_start;
+
+    const auto& a_shape = a.logical_shape();
+    uint32_t W = a_shape[3], H = a_shape[2], C = a_shape[1], N = a_shape[0];
+    uint32_t W_padded = output_padded_shape[3], H_padded = output_padded_shape[2], C_padded = output_padded_shape[1],
+             N_padded = output_padded_shape[0];
+    uint32_t NCH_padded = H_padded * C_padded * N_padded;
+
+    const auto& front_pad = input_tensor_start;
+
+    auto stick_size = W * a.element_size();
+    auto stick_size_padded = W_padded * a.element_size();
+    auto stick_size_padded_front = front_pad[-1] * a.element_size();
+    auto stick_size_padded_end = stick_size_padded - stick_size - stick_size_padded_front;
+    uint32_t stick_size_padded_aligned = tt::align(stick_size_padded, hal::get_l1_alignment());
+    uint32_t stick_size_padded_DRAM_aligned = tt::align(stick_size_padded, hal::get_dram_alignment());
+    uint32_t row_major_min_bytes = 16;
+
+    // Input page-based addressing
+    uint32_t num_input_pages_in_row = 1;
+    uint32_t input_page_size = a.buffer()->page_size();
+    uint32_t size_of_valid_data_in_last_input_page_in_row = a.buffer()->page_size();
+    if (a.is_sharded()) {
+        uint32_t shard_width =
+            a.shard_spec().has_value() ? a.shard_spec().value().shape[1] : a.nd_shard_spec().value().shard_shape[-1];
+        num_input_pages_in_row = tt::div_up(a.logical_shape()[-1], shard_width);
+        size_of_valid_data_in_last_input_page_in_row = stick_size - (num_input_pages_in_row - 1) * input_page_size;
+    }
+
+    // Output page-based addressing
+    uint32_t num_output_pages_in_row = 1;
+    uint32_t output_page_size = output.buffer()->page_size();
+    uint32_t size_of_valid_data_in_last_output_page_in_row = output.buffer()->page_size();
+    if (output.is_sharded()) {
+        uint32_t output_shard_width = output.shard_spec().has_value() ? output.shard_spec().value().shape[1]
+                                                                      : output.nd_shard_spec().value().shard_shape[-1];
+        num_output_pages_in_row = tt::div_up(W_padded, output_shard_width);
+        size_of_valid_data_in_last_output_page_in_row =
+            stick_size_padded - (num_output_pages_in_row - 1) * output_page_size;
+    }
+
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
+
+    IDevice* device = a.device();
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    const auto& sub_core_grids = operation_attributes.sub_core_grids;
+
+    auto
+        [num_cores,
+         all_cores,
+         core_group_1,
+         core_group_2,
+         num_sticks_padded_per_core_group_1,
+         num_sticks_padded_per_core_group_2] =
+            sub_core_grids.has_value() ? tt::tt_metal::split_work_to_cores(sub_core_grids.value(), NCH_padded)
+                                       : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, NCH_padded);
+
+    auto cores_in_order = corerange_to_cores(all_cores, num_cores, true);
+
+    uint32_t src0_cb_index = tt::CBIndex::c_0;
+
+    // construct const buffer with the pad_value
+    bool not_pad_by_zero = pad_value != 0;
+
+    Buffer* src0_buffer = a.buffer();
+    Buffer* dst_buffer = output.buffer();
+    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    uint32_t packed_pad_value;
+    if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
+        packed_pad_value = pad_value;
+    } else if (a.dtype() == DataType::UINT16) {
+        packed_pad_value = pack_two_uint16_into_uint32({float_to_uint16(pad_value), float_to_uint16(pad_value)});
+    } else {
+        packed_pad_value = pack_two_bfloat16_into_uint32({bfloat16(pad_value), bfloat16(pad_value)});
+    }
+
+    ProgramDescriptor desc;
+
+    // c_1 reused for pad-value scratch on every dispatch.
+    uint32_t src1_cb_index = tt::CBIndex::c_1;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = stick_size_padded_DRAM_aligned,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src1_cb_index),
+            .data_format = cb_data_format,
+            .page_size = stick_size_padded_DRAM_aligned,
+        }}},
+    });
+
+    bool unaligned = stick_size_padded_aligned % hal::get_dram_alignment() != 0;
+    if (stick_size_padded_front != 0 || unaligned) {
+        uint32_t src2_cb_index = tt::CBIndex::c_2;
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = stick_size_padded_DRAM_aligned,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(src2_cb_index),
+                .data_format = cb_data_format,
+                .page_size = stick_size_padded_DRAM_aligned,
+            }}},
+        });
+    }
+
+    std::vector<uint32_t> reader_ct_args = {
+        (std::uint32_t)N + front_pad[-4],
+        (std::uint32_t)H + front_pad[-2],
+        (std::uint32_t)C + front_pad[-3],
+        (std::uint32_t)stick_size,
+        (std::uint32_t)N_padded,
+        (std::uint32_t)H_padded,
+        (std::uint32_t)C_padded,
+        (std::uint32_t)stick_size_padded,
+        (std::uint32_t)stick_size_padded_front,
+        (std::uint32_t)stick_size_padded_end,
+        (std::uint32_t)tt::div_up(stick_size_padded, 512),  // max zero size is 512B
+        (std::uint32_t)(stick_size_padded % 512 == 0 ? 512 : stick_size_padded % 512),
+        (std::uint32_t)not_pad_by_zero,
+        (std::uint32_t)packed_pad_value,
+        (std::uint32_t)row_major_min_bytes,
+        (std::uint32_t)(stick_size_padded_front / row_major_min_bytes),
+        (std::uint32_t)(stick_size_padded_end / row_major_min_bytes),
+        (std::uint32_t)(stick_size_padded / row_major_min_bytes),
+        (std::uint32_t)stick_size_padded_aligned,
+        (std::uint32_t)unaligned,
+        (std::uint32_t)num_input_pages_in_row,
+        (std::uint32_t)input_page_size,
+        (std::uint32_t)size_of_valid_data_in_last_input_page_in_row};
+    TensorAccessorArgs(*src0_buffer).append_to(reader_ct_args);
+
+    std::vector<uint32_t> writer_ct_args = {
+        (std::uint32_t)src0_cb_index,
+        (std::uint32_t)stick_size_padded,
+        (std::uint32_t)stick_size_padded_aligned,
+        (std::uint32_t)num_output_pages_in_row,
+        (std::uint32_t)output_page_size,
+        (std::uint32_t)size_of_valid_data_in_last_output_page_in_row};
+    TensorAccessorArgs(*dst_buffer).append_to(writer_ct_args);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/"
+        "reader_pad_dims_rm_interleaved_v2.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/"
+        "writer_pad_dims_rm_interleaved_v2.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    // Build per-core runtime args inline (legacy path called get_runtime_args_rm()
+    // which produced the same data).  Slot 0 of both reader and writer is a raw
+    // buffer base address (no offset) — use Buffer* for BufferBinding so the
+    // framework patches addresses on cache hits.  Idle cores (num_sticks_per_core
+    // == 0) pass 0u to skip the binding since the kernel does nothing.
+    // The legacy helper used input_tensor.padded_shape() for the H/C/N bounds —
+    // mirror that here.  H_padded/C_padded already use the output padded shape.
+    auto input_padded_shape = a.padded_shape();
+    uint32_t H_in = input_padded_shape[2], C_in = input_padded_shape[1], N_in = input_padded_shape[0];
+    std::uint32_t num_dims = static_cast<std::uint32_t>(input_padded_shape.rank());
+    std::vector<uint32_t> start_dim_offset(num_dims, 0);
+
+    uint32_t num_sticks_per_barrier = get_num_stick_per_barrier(stick_size_padded_aligned);
+
+    uint32_t curr_c = 0, curr_h = 0, curr_n = 0;
+    uint32_t curr_sticks_read = 0;
+    uint32_t curr_sticks_write = 0;
+    for (const auto& core : cores_in_order) {
+        uint32_t num_sticks_per_core;
+        if (core_group_1.contains(core)) {
+            num_sticks_per_core = num_sticks_padded_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_sticks_per_core = num_sticks_padded_per_core_group_2;
+        } else {
+            // no-op
+            num_sticks_per_core = 0;
+        }
+
+        KernelDescriptor::RTArgList reader_rt_args;
+        KernelDescriptor::RTArgList writer_rt_args;
+        if (num_sticks_per_core != 0) {
+            reader_rt_args.push_back(src0_buffer);
+            writer_rt_args.push_back(dst_buffer);
+        } else {
+            reader_rt_args.push_back(0u);
+            writer_rt_args.push_back(0u);
+        }
+        reader_rt_args.push_back(num_sticks_per_core);
+        reader_rt_args.push_back(num_sticks_per_barrier);
+        reader_rt_args.push_back(curr_sticks_read * num_input_pages_in_row);
+        reader_rt_args.push_back(static_cast<uint32_t>(front_pad[-4]));
+        reader_rt_args.push_back(static_cast<uint32_t>(front_pad[-3]));
+        reader_rt_args.push_back(static_cast<uint32_t>(front_pad[-2]));
+        for (uint32_t v : start_dim_offset) {
+            reader_rt_args.push_back(v);
+        }
+
+        writer_rt_args.push_back(num_sticks_per_core);
+        writer_rt_args.push_back(num_sticks_per_barrier);
+        writer_rt_args.push_back(curr_sticks_write * num_output_pages_in_row);
+
+        reader_desc.emplace_runtime_args(core, reader_rt_args);
+        writer_desc.emplace_runtime_args(core, writer_rt_args);
+
+        curr_sticks_write += num_sticks_per_core;
+
+        for (uint32_t k = 0; k < num_sticks_per_core; ++k) {
+            if ((curr_h >= front_pad[-2] and curr_h < (H_in + front_pad[-2])) and
+                (curr_c >= front_pad[-3] and curr_c < (C_in + front_pad[-3])) and
+                (curr_n >= front_pad[-4] and curr_n < (N_in + front_pad[-4]))) {
+                curr_sticks_read++;
+            }
+
+            curr_h++;
+            if (curr_h == H_padded) {
+                curr_c++;
+                curr_h = 0;
+                if (curr_c == C_padded) {
+                    curr_n++;
+                    curr_c = 0;
+                }
+            }
+        }
+
+        start_dim_offset = {0, curr_h, curr_c, curr_n};
+    }
+
+    uint32_t cb_npages = get_num_stick_per_barrier(stick_size_padded_aligned);
+    const uint32_t buffer_reader_writer_async_factor = 16;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = buffer_reader_writer_async_factor * cb_npages * stick_size_padded_aligned,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = cb_data_format,
+            .page_size = stick_size_padded_aligned,
+        }}},
+    });
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.hpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+
+#include "ttnn/device_operation.hpp"
+#include "pad_device_operation_types.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct PadRmReaderWriterMultiCoreDefaultProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output);
+};
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_multi_core_program_factory.cpp
@@ -1,0 +1,433 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "pad_rm_reader_writer_multi_core_program_factory.hpp"
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
+#include "ttnn/operations/data_movement/common/common.hpp"
+
+using namespace tt::tt_metal;
+using namespace tt::constants;
+
+namespace ttnn::prim::qsr {
+using ttnn::operations::data_movement::float_to_uint16;
+using ttnn::operations::data_movement::pack_two_uint16_into_uint32;
+
+namespace {
+inline void log_rt_args(const CoreCoord& core, std::vector<uint32_t>& args) {
+    for (auto v : args) {
+        log_debug(tt::LogOp, "{},{} :: {}", core.x, core.y, v);
+    }
+}
+
+// This is currently mostly hardcoded for resnet shapes
+inline std::tuple<uint32_t, uint32_t, uint32_t, CoreRangeSet, CoreRangeSet, uint32_t, uint32_t, uint32_t, uint32_t>
+split_across_cores(CoreCoord grid_size, uint32_t nbatch, uint32_t ntiles_h, uint32_t ntiles_w) {
+    uint32_t ncores, ncores_h, ncores_w, ntiles_per_core_h, ntiles_per_core_w, nbatch_per_core_h, ncores_per_batch_h;
+
+    // each batch needs to be padded independently
+    switch (nbatch) {
+        case 1:
+            ncores_h = 1;
+            nbatch_per_core_h = 1;
+            ntiles_per_core_h = 1;
+            switch (ntiles_h) {
+                case 2:
+                    ncores_h = 2;
+                    ntiles_per_core_h = 1;
+                    break;
+                case 4:
+                    ncores_h = 4;
+                    ntiles_per_core_h = 1;
+                    break;
+                case 8:
+                    ncores_h = 8;
+                    ntiles_per_core_h = 1;
+                    break;
+                case 64:
+                    ncores_h = 8;
+                    ntiles_per_core_h = 8;
+                    break;
+                default: TT_THROW("Unsupported ntiles_h value {}", ntiles_h);
+            }
+            ncores_per_batch_h = ncores_h;
+            break;
+
+        case 2:
+            ncores_h = 1;
+            ncores_per_batch_h = 1;
+            nbatch_per_core_h = 1;
+            ntiles_per_core_h = 1;
+            switch (ntiles_h) {
+                case 2:
+                    ncores_per_batch_h = 2;
+                    ncores_h = ncores_per_batch_h * nbatch;
+                    ntiles_per_core_h = 1;
+                    break;
+                case 4:
+                    ncores_per_batch_h = 4;
+                    ncores_h = ncores_per_batch_h * nbatch;
+                    ntiles_per_core_h = 1;
+                    break;
+                case 8:
+                    ncores_per_batch_h = 4;
+                    ncores_h = ncores_per_batch_h * nbatch;
+                    ntiles_per_core_h = 2;
+                    break;
+                case 64:
+                    ncores_per_batch_h = 4;
+                    ncores_h = ncores_per_batch_h * nbatch;
+                    ntiles_per_core_h = 16;
+                    break;
+                default: TT_THROW("Unsupported ntiles_h value {}", ntiles_h);
+            }
+            break;
+
+        case 8:
+            ncores_h = 8;
+            ncores_per_batch_h = 1;
+            nbatch_per_core_h = 1;
+            ntiles_per_core_h = ntiles_h;
+            break;
+
+        default:
+            TT_THROW("Unsupported nbatch value {} for pad operation. Supported values are 1, 2, and 8.", nbatch);
+
+            // generic case -- TODO
+
+            // one of the following will be 0 when grid_size.y != nbatch
+            nbatch_per_core_h = nbatch / grid_size.y;   // floor
+            ncores_per_batch_h = grid_size.y / nbatch;  // floor
+            if (nbatch == grid_size.y) {
+                nbatch_per_core_h = 1;
+                ncores_per_batch_h = 1;
+            }
+
+            // currently uses hardcoded values for resnet50
+            // TT_ASSERT(ntiles_h == 1 || ntiles_h == 2 || ntiles_h == 4 || ntiles_h == 16, "Only Resnet50 shapes are
+            // supported in multicore version for now."); TT_ASSERT(ntiles_w == 64, "Only Resnet50 shapes are supported
+            // in multicore version for now.");
+
+            TT_ASSERT(nbatch <= grid_size.y, "Unsupported case with nbatch > grid_size.y!");
+
+            if (nbatch_per_core_h == 0) {
+                // there are multiple cores along h per batch
+                nbatch_per_core_h = 1;
+            } else if (ncores_per_batch_h == 0) {
+                // unsupported case. TODO.
+                TT_THROW(
+                    "Unsupported configuration: multiple batches per core along height dimension "
+                    "(nbatch={}, grid_size.y={})",
+                    nbatch,
+                    grid_size.y);
+                // there are multiple batch per core along h
+                // ncores_per_batch_h = 1;
+            } else {
+                TT_THROW("Something went terribly wrong in splitting across cores");
+            }
+            break;
+    }
+
+    switch (ntiles_w) {
+        case 2: ncores_w = 2; break;
+        case 4: ncores_w = 4; break;
+        case 8:
+        case 64: ncores_w = 8; break;
+        default: TT_THROW("Unsupported ntiles_w value {}", ntiles_w);
+    }
+    ncores = ncores_h * ncores_w;
+    ntiles_per_core_w = ntiles_w / ncores_w;
+    std::set<CoreRange> all_cores;
+    std::set<CoreRange> core_range;
+
+    all_cores.insert(CoreRange(CoreCoord(0, 0), CoreCoord(ncores_w - 1, ncores_h - 1)));
+    core_range.insert(CoreRange(CoreCoord(0, 0), CoreCoord(ncores_w - 1, ncores_h - 1)));
+
+    return std::make_tuple(
+        ncores,
+        ncores_h,
+        ncores_w,
+        all_cores,
+        core_range,
+        ntiles_per_core_h,
+        ntiles_per_core_w,
+        nbatch_per_core_h,
+        ncores_per_batch_h);
+}
+
+// Allocate the on-device pad-value const tensor.  Pulled out so
+// create_workload_descriptor() can build it once on cache miss and park it on
+// WorkloadDescriptor::buffers, deferring ~Tensor (which force-deallocates the
+// device memory) until the cached workload is evicted (see #44565).
+Tensor build_pad_value_const_tensor_mc(const PadInputs& tensor_args, float pad_value) {
+    MeshDevice* device = tensor_args.input.device();
+    uint32_t pad_value_const_buffer_size = 32;  // noc transfers in chunks of 32
+    auto pad_value_const_buffer =
+        tt::tt_metal::HostBuffer(std::vector<bfloat16>(pad_value_const_buffer_size, bfloat16(pad_value)));
+    // NOTE: The const buffer is always in L1
+    // TODO: make a local buffer for each core?
+    return Tensor(
+               std::move(pad_value_const_buffer),
+               ttnn::Shape({1, 1, 1, pad_value_const_buffer_size}),
+               DataType::BFLOAT16,
+               Layout::ROW_MAJOR)
+        .to_device(device, MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::L1});
+}
+
+ProgramDescriptor build_pad_rm_mc_program_descriptor(
+    const PadParams& operation_attributes,
+    const PadInputs& tensor_args,
+    Tensor& output,
+    Buffer* pad_value_const_buffer) {
+    const auto& a = tensor_args.input;
+    const auto& output_padded_shape = operation_attributes.output_padded_shape;
+    const auto& pad_value = operation_attributes.pad_value;
+
+    auto output_shape = output_padded_shape;
+
+    uint32_t unpadded_row_size_nbytes = a.padded_shape()[3] * a.element_size();
+    uint32_t padded_row_size_nbytes = output_shape[3] * a.element_size();  // Assuming output is same datatype as input
+    TT_ASSERT(
+        unpadded_row_size_nbytes <= padded_row_size_nbytes, "Padded output tensor size should be >= input tensor size");
+
+    distributed::MeshDevice* device = a.device();
+
+    uint32_t pad_value_const_buffer_size = 32;  // noc transfers in chunks of 32
+    uint32_t pad_value_const_buffer_nbytes = pad_value_const_buffer_size * a.element_size();
+
+    // uint32_t ntiles_h = output_tensor_shape[0] * output_tensor_shape[1] * output_tensor_shape[2] / TILE_HEIGHT;
+    uint32_t ntiles_h = output_padded_shape[2] / TILE_HEIGHT;
+    uint32_t ntiles_w = output_padded_shape[3] / TILE_WIDTH;
+
+    auto grid_size = device->compute_with_storage_grid_size();
+    uint32_t nbatch = output_padded_shape[0];
+    // first the batch dim is distributed along H, and within each batch then the tiles are distributed.
+    auto
+        [ncores,
+         ncores_h,
+         ncores_w,
+         all_cores,
+         core_range,
+         ntiles_per_core_h,
+         ntiles_per_core_w,
+         nbatch_per_core_h,
+         ncores_per_batch_h] = split_across_cores(grid_size, nbatch, ntiles_h, ntiles_w);
+
+    [[maybe_unused]] int32_t src_nbytes_per_core_w = ntiles_per_core_w * TILE_WIDTH * a.element_size();
+    int32_t dst_nbytes_per_core_w = ntiles_per_core_w * TILE_WIDTH * output.element_size();
+
+    Buffer* src0_buffer = a.buffer();
+    Buffer* dst_buffer = output.buffer();
+    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    ProgramDescriptor desc;
+
+    uint32_t cb_id = tt::CBIndex::c_0;
+    uint32_t cb_npages = 16;  // multibuffering for perf
+    // uint32_t cb_npages = 1; // multibuffering for perf
+    uint32_t cb_page_alignment = std::max(tt::constants::TILE_WIDTH, src0_buffer->alignment());
+    uint32_t cb_pagesize =
+        static_cast<uint32_t>(std::ceil((float)dst_nbytes_per_core_w / cb_page_alignment)) * cb_page_alignment;
+    tt::DataFormat in_df = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cb_npages * cb_pagesize,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_id),
+            .data_format = in_df,
+            .page_size = cb_pagesize,
+        }}},
+    });
+
+    std::vector<uint32_t> reader_ct_args = {unpadded_row_size_nbytes, padded_row_size_nbytes};
+    TensorAccessorArgs(*src0_buffer).append_to(reader_ct_args);
+    TensorAccessorArgs(*dst_buffer).append_to(reader_ct_args);
+    TensorAccessorArgs(*pad_value_const_buffer).append_to(reader_ct_args);
+    std::vector<uint32_t> writer_ct_args = reader_ct_args;
+
+    uint32_t packed_pad_value;
+    if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
+        packed_pad_value = pad_value;
+    } else if (a.dtype() == DataType::UINT16) {
+        packed_pad_value = pack_two_uint16_into_uint32({0, float_to_uint16(pad_value)});
+    } else {
+        packed_pad_value = pack_two_bfloat16_into_uint32({bfloat16(0.0f), bfloat16(pad_value)});
+    }
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/writer_pad_dims_rm_interleaved.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
+    // int32_t padded_row_diff_size_nbytes = padded_row_size_nbytes - unpadded_row_size_nbytes;
+    log_rt_args(CoreCoord{0, 0}, reader_desc.compile_time_args);
+
+#if 1
+    {
+        log_debug(tt::LogOp, "ncores: {}", ncores);
+        log_debug(tt::LogOp, "ncores_h: {}", ncores_h);
+        log_debug(tt::LogOp, "ncores_w: {}", ncores_w);
+        log_debug(tt::LogOp, "ntiles_per_core_h: {}", ntiles_per_core_h);
+        log_debug(tt::LogOp, "ntiles_per_core_w: {}", ntiles_per_core_w);
+        log_debug(tt::LogOp, "src0_buffer_addr: {}", src0_buffer->address());
+        log_debug(tt::LogOp, "dst_buffer_addr: {}", dst_buffer->address());
+        log_debug(tt::LogOp, "a.shape[0]: {}", a.padded_shape()[0]);
+        log_debug(tt::LogOp, "out.shape[0]: {}", output_shape[0]);
+        log_debug(tt::LogOp, "a.shape[1]: {}", a.padded_shape()[1]);
+        log_debug(tt::LogOp, "out.shape[1]: {}", output_shape[1]);
+        log_debug(tt::LogOp, "a.shape[2]: {}", a.padded_shape()[2]);
+        log_debug(tt::LogOp, "out.shape[2]: {}", output_shape[2]);
+        log_debug(tt::LogOp, "s.shape[3]: {}", a.padded_shape()[3]);
+        log_debug(tt::LogOp, "out.shape[3]: {}", output_shape[3]);
+        log_debug(tt::LogOp, "unpadded_row_size_nbytes: {}", unpadded_row_size_nbytes);
+        log_debug(tt::LogOp, "padded_row_size_nbytes: {}", padded_row_size_nbytes);
+        // log_debug(tt::LogOp, "padded_row_diff_size_nbytes: {}", padded_row_diff_size_nbytes);
+        log_debug(tt::LogOp, "pad_value_const_buffer_addr: {}", pad_value_const_buffer->address());
+        log_debug(tt::LogOp, "pad_value_const_buffer_nbytes: {}", pad_value_const_buffer_nbytes);
+        log_debug(tt::LogOp, "packed_pad_value: {}", packed_pad_value);
+        log_debug(tt::LogOp, "src_nbytes_per_core_w: {}", src_nbytes_per_core_w);
+        log_debug(tt::LogOp, "dst_nbytes_per_core_w: {}", dst_nbytes_per_core_w);
+        log_debug(tt::LogOp, "nbatch_per_core_h: {}", nbatch_per_core_h);
+        log_debug(tt::LogOp, "ncores_per_batch_h: {}", ncores_per_batch_h);
+    }
+#endif
+
+    uint32_t start_src_stick_id = 0;
+    uint32_t start_dst_stick_id = 0;
+    uint32_t start_src_stick_wi = 0;  // start of stick segment for 2d decomp
+    uint32_t start_dst_stick_wi = 0;
+    int32_t local_nsticks = ntiles_per_core_h * TILE_HEIGHT;
+    for (int32_t b = 0; b < nbatch; ++b) {
+        int32_t rem_src_nsticks = a.padded_shape()[2];
+        for (uint32_t j = 0; j < ncores_per_batch_h; ++j) {
+            uint32_t num_local_unpadded_nsticks = local_nsticks;
+            if (rem_src_nsticks - local_nsticks >= 0) {
+                // not reached padding sticks yet
+                rem_src_nsticks -= local_nsticks;
+            } else {
+                num_local_unpadded_nsticks = rem_src_nsticks;
+                rem_src_nsticks = 0;
+            }
+            start_src_stick_wi = 0;
+            start_dst_stick_wi = 0;
+            int32_t rem_src_stick_size_nbytes = unpadded_row_size_nbytes;
+            for (uint32_t i = 0; i < ncores_w; ++i) {
+                CoreCoord core = {i, (b * ncores_per_batch_h) + j};
+                uint32_t curr_stick_size_nbytes = 0;
+                int32_t curr_stick_diff_nbytes = 0;
+                if (rem_src_stick_size_nbytes - dst_nbytes_per_core_w >= 0) {
+                    // no padding on this core
+                    curr_stick_size_nbytes = dst_nbytes_per_core_w;
+                    rem_src_stick_size_nbytes -= dst_nbytes_per_core_w;
+                } else {
+                    // this core has padding
+                    curr_stick_size_nbytes = rem_src_stick_size_nbytes;
+                    curr_stick_diff_nbytes = dst_nbytes_per_core_w - curr_stick_size_nbytes;
+                    rem_src_stick_size_nbytes = 0;
+                }
+                // Slots 0 (src), 1 (dst) and 13 (pad-value const) are raw buffer base addresses;
+                // bind them as Buffer* so the framework patches the addresses on cache hits
+                // without rebuilding the descriptor.  The const tensor is owned by
+                // WorkloadDescriptor::buffers in create_workload_descriptor() so its address
+                // remains valid across cache hits.
+                KernelDescriptor::RTArgList reader_rt_args;
+                reader_rt_args.reserve(27);
+                reader_rt_args.push_back(src0_buffer);
+                reader_rt_args.push_back(dst_buffer);
+                reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[0]));
+                reader_rt_args.push_back(static_cast<uint32_t>(output_shape[0]));
+                reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[1]));
+                reader_rt_args.push_back(static_cast<uint32_t>(output_shape[1]));
+                reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[2]));
+                reader_rt_args.push_back(static_cast<uint32_t>(output_shape[2]));
+                reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[3]));
+                reader_rt_args.push_back(static_cast<uint32_t>(output_shape[3]));
+                reader_rt_args.push_back(curr_stick_size_nbytes);
+                reader_rt_args.push_back(static_cast<uint32_t>(dst_nbytes_per_core_w));
+                reader_rt_args.push_back(static_cast<uint32_t>(curr_stick_diff_nbytes));
+                reader_rt_args.push_back(pad_value_const_buffer);
+                reader_rt_args.push_back(pad_value_const_buffer_nbytes);
+                reader_rt_args.push_back(packed_pad_value);
+                reader_rt_args.push_back(start_src_stick_id);
+                reader_rt_args.push_back(start_dst_stick_id);
+                reader_rt_args.push_back(start_src_stick_wi);
+                reader_rt_args.push_back(start_dst_stick_wi);
+                reader_rt_args.push_back(start_src_stick_wi * a.element_size());
+                reader_rt_args.push_back(static_cast<uint32_t>(local_nsticks));
+                reader_rt_args.push_back(num_local_unpadded_nsticks);
+                reader_rt_args.push_back(unpadded_row_size_nbytes);
+                reader_rt_args.push_back(padded_row_size_nbytes);
+                reader_rt_args.push_back(start_dst_stick_wi * output.element_size());
+                reader_rt_args.push_back(nbatch_per_core_h);
+                // if (core.x == 0) log_rt_args(core, reader_rt_args);
+                // if (core.x == 0) {
+                //     log_debug(tt::LogOp, "{} :: start_src_stick_id: {}", core.y, start_src_stick_id);
+                //     log_debug(tt::LogOp, "{} :: start_dst_stick_id: {}", core.y, start_dst_stick_id);
+                //     log_debug(tt::LogOp, "{} :: local_nsticks: {}", core.y, local_nsticks);
+                //     log_debug(tt::LogOp, "{} :: num_local_unpadded_nsticks: {}", core.y, num_local_unpadded_nsticks);
+                //     log_debug(tt::LogOp, "{} :: nbatch_per_core_h: {}", core.y, nbatch_per_core_h);
+                //     log_debug(tt::LogOp, "{} :: ncores_per_batch_h: {}", core.y, ncores_per_batch_h);
+                // }
+                // Writer reads the same arg layout (slot 1 = dst addr, slot 13 = pad-value const).
+                KernelDescriptor::RTArgList writer_rt_args = reader_rt_args;
+                reader_desc.emplace_runtime_args(core, reader_rt_args);
+                writer_desc.emplace_runtime_args(core, writer_rt_args);
+                start_src_stick_wi += ntiles_per_core_w * TILE_WIDTH;
+                start_dst_stick_wi += ntiles_per_core_w * TILE_WIDTH;
+            }  // for ncores_w
+            start_src_stick_id += num_local_unpadded_nsticks;
+            start_dst_stick_id += local_nsticks;
+        }  // for ncores_h
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
+}
+
+}  // namespace
+
+WorkloadDescriptor PadRmReaderWriterMultiCoreProgramFactory::create_workload_descriptor(
+    const PadParams& operation_attributes,
+    const PadInputs& tensor_args,
+    Tensor& output,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    WorkloadDescriptor wd;
+
+    // Build the pad-value const tensor once on cache miss and park it on the
+    // WorkloadDescriptor.  Holding the SOURCE Tensor (not just a
+    // shared_ptr<MeshBuffer>) is required because ~Tensor force-deallocates the
+    // device memory through DeviceStorage::deallocate regardless of external
+    // shared_ptr<MeshBuffer> owners (see #44565).
+    Tensor pad_value_const_tensor = build_pad_value_const_tensor_mc(tensor_args, operation_attributes.pad_value);
+    auto pad_value_owner = std::make_shared<Tensor>(std::move(pad_value_const_tensor));
+    Buffer* pad_value_const_buffer = pad_value_owner->buffer();
+    wd.buffers.push_back({pad_value_owner, pad_value_const_buffer});
+
+    auto desc = build_pad_rm_mc_program_descriptor(operation_attributes, tensor_args, output, pad_value_const_buffer);
+
+    auto ranges = tensor_coords.ranges();
+    for (size_t i = 0; i + 1 < ranges.size(); ++i) {
+        wd.programs.push_back({ranges[i], desc});
+    }
+    if (!ranges.empty()) {
+        wd.programs.push_back({ranges.back(), std::move(desc)});
+    }
+    return wd;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_multi_core_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_multi_core_program_factory.hpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/distributed/types.hpp"
+#include "pad_device_operation_types.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct PadRmReaderWriterMultiCoreProgramFactory {
+    // Workload-scoped pad-value const tensor is allocated once on cache miss inside
+    // create_workload_descriptor() and parked on the returned WorkloadDescriptor::buffers
+    // so it outlives the cached workload via the program cache.  Holding the SOURCE
+    // Tensor (not just shared_ptr<MeshBuffer>) is required because ~Tensor force-deallocates
+    // the device memory through DeviceStorage::deallocate regardless of external
+    // shared_ptr<MeshBuffer> owners (see #44565).  emplace_runtime_args() with Buffer*
+    // lets the framework patch the const tensor's address on cache hits without rerunning
+    // this factory.
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
+        const PadParams& operation_attributes,
+        const PadInputs& tensor_args,
+        Tensor& output,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
+};
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_program_factory.cpp
@@ -1,0 +1,215 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "pad_rm_reader_writer_program_factory.hpp"
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
+#include "ttnn/operations/data_movement/common/common.hpp"
+
+using namespace tt::tt_metal;
+using namespace tt::constants;
+
+namespace ttnn::prim::qsr {
+using ttnn::operations::data_movement::float_to_uint16;
+using ttnn::operations::data_movement::pack_two_uint16_into_uint32;
+
+namespace {
+
+// Allocate the on-device pad-value const tensor.  Pulled out so
+// create_workload_descriptor() can build it once on cache miss and park it on
+// WorkloadDescriptor::buffers, deferring ~Tensor (which force-deallocates the
+// device memory) until the cached workload is evicted (see #44565).
+Tensor build_pad_value_const_tensor_sc(const PadInputs& tensor_args, float pad_value) {
+    MeshDevice* device = tensor_args.input.device();
+    uint32_t pad_value_const_buffer_size = 32;  // noc transfers in chunks of 32
+    auto pad_value_const_buffer =
+        tt::tt_metal::HostBuffer(std::vector<bfloat16>(pad_value_const_buffer_size, bfloat16(pad_value)));
+    return Tensor(
+               std::move(pad_value_const_buffer),
+               ttnn::Shape({1, 1, 1, pad_value_const_buffer_size}),
+               DataType::BFLOAT16,
+               Layout::ROW_MAJOR)
+        .to_device(device, MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::L1});
+}
+
+ProgramDescriptor build_pad_rm_sc_program_descriptor(
+    const PadParams& operation_attributes,
+    const PadInputs& tensor_args,
+    Tensor& output,
+    Buffer* pad_value_const_buffer) {
+    const auto& a = tensor_args.input;
+    const auto& pad_value = operation_attributes.pad_value;
+
+    auto output_shape = operation_attributes.output_padded_shape;
+
+    uint32_t unpadded_row_size_nbytes = tensor_args.input.padded_shape()[3] * tensor_args.input.element_size();
+    uint32_t padded_row_size_nbytes =
+        output_shape[3] * tensor_args.input.element_size();  // Assuming output is same datatype as input
+    TT_ASSERT(
+        unpadded_row_size_nbytes <= padded_row_size_nbytes, "Padded output tensor size should be >= input tensor size");
+
+    // construct const buffer with the pad_value
+    uint32_t pad_value_const_buffer_size = 32;  // noc transfers in chunks of 32
+    uint32_t pad_value_const_buffer_nbytes = pad_value_const_buffer_size * tensor_args.input.element_size();
+
+    Buffer* src0_buffer = a.buffer();
+    Buffer* dst_buffer = output.buffer();
+    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    CoreRange cores({0, 0}, {0, 0});
+
+    ProgramDescriptor desc;
+
+    uint32_t cb_id = tt::CBIndex::c_0;
+    uint32_t cb_npages = 16;  // multibuffering
+    uint32_t cb_pagesize =
+        tt::round_up(padded_row_size_nbytes, std::max(src0_buffer->alignment(), tt::constants::TILE_WIDTH));
+    tt::DataFormat in_df = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cb_npages * cb_pagesize,
+        .core_ranges = cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_id),
+            .data_format = in_df,
+            .page_size = cb_pagesize,
+        }}},
+    });
+
+    std::vector<uint32_t> reader_ct_args = {unpadded_row_size_nbytes, padded_row_size_nbytes};
+    TensorAccessorArgs(*src0_buffer).append_to(reader_ct_args);
+    TensorAccessorArgs(*dst_buffer).append_to(reader_ct_args);
+    TensorAccessorArgs(*pad_value_const_buffer).append_to(reader_ct_args);
+    std::vector<uint32_t> writer_ct_args = reader_ct_args;
+
+    uint32_t packed_pad_value;
+    if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
+        packed_pad_value = pad_value;
+    } else if (a.dtype() == DataType::UINT16) {
+        packed_pad_value = pack_two_uint16_into_uint32({0, float_to_uint16(pad_value)});
+    } else {
+        packed_pad_value = pack_two_bfloat16_into_uint32({bfloat16(0.0f), bfloat16(pad_value)});
+    }
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/writer_pad_dims_rm_interleaved.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
+    uint32_t padded_row_diff_size_nbytes = padded_row_size_nbytes - unpadded_row_size_nbytes;
+
+#if 0
+    {
+        log_debug(tt::LogOp, "src0_buffer_addr: {}", src0_buffer->address());
+        log_debug(tt::LogOp, "dst_buffer_addr: {}", dst_buffer->address());
+        log_debug(tt::LogOp, "a.shape[0]: {}", a.padded_shape()[0]);
+        log_debug(tt::LogOp, "out.shape[0]: {}", output_shape[0]);
+        log_debug(tt::LogOp, "a.shape[1]: {}", a.padded_shape()[1]);
+        log_debug(tt::LogOp, "out.shape[1]: {}", output_shape[1]);
+        log_debug(tt::LogOp, "a.shape[2]: {}", a.padded_shape()[2]);
+        log_debug(tt::LogOp, "out.shape[2]: {}", output_shape[2]);
+        log_debug(tt::LogOp, "s.shape[3]: {}", a.padded_shape()[3]);
+        log_debug(tt::LogOp, "out.shape[3]: {}", output_shape[3]);
+        log_debug(tt::LogOp, "unpadded_row_size_nbytes: {}", unpadded_row_size_nbytes);
+        log_debug(tt::LogOp, "padded_row_size_nbytes: {}", padded_row_size_nbytes);
+        log_debug(tt::LogOp, "padded_row_diff_size_nbytes: {}", padded_row_diff_size_nbytes);
+        log_debug(tt::LogOp, "pad_value_const_buffer_addr: {}", pad_value_const_buffer->address());
+        log_debug(tt::LogOp, "pad_value_const_buffer_nbytes: {}", pad_value_const_buffer_nbytes);
+        log_debug(tt::LogOp, "packed_pad_value: {}", packed_pad_value);
+    }
+#endif
+
+    uint32_t start_src_stick_id = 0;
+    uint32_t start_dst_stick_id = 0;
+    // Slots 0 (src), 1 (dst) and 13 (pad-value const) are raw buffer base addresses;
+    // bind them as Buffer* so the framework patches the addresses on cache hits
+    // without rebuilding the descriptor.  The const tensor is owned by
+    // WorkloadDescriptor::buffers in create_workload_descriptor() so its address
+    // remains valid across cache hits.
+    KernelDescriptor::RTArgList reader_rt_args;
+    reader_rt_args.reserve(27);
+    reader_rt_args.push_back(src0_buffer);
+    reader_rt_args.push_back(dst_buffer);
+    reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[0]));
+    reader_rt_args.push_back(static_cast<uint32_t>(output_shape[0]));
+    reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[1]));
+    reader_rt_args.push_back(static_cast<uint32_t>(output_shape[1]));
+    reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[2]));
+    reader_rt_args.push_back(static_cast<uint32_t>(output_shape[2]));
+    reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[3]));
+    reader_rt_args.push_back(static_cast<uint32_t>(output_shape[3]));
+    reader_rt_args.push_back(unpadded_row_size_nbytes);
+    reader_rt_args.push_back(padded_row_size_nbytes);
+    reader_rt_args.push_back(padded_row_diff_size_nbytes);
+    reader_rt_args.push_back(pad_value_const_buffer);
+    reader_rt_args.push_back(pad_value_const_buffer_nbytes);
+    reader_rt_args.push_back(packed_pad_value);
+    reader_rt_args.push_back(start_src_stick_id);
+    reader_rt_args.push_back(start_dst_stick_id);
+    reader_rt_args.push_back(std::uint32_t{0});
+    reader_rt_args.push_back(std::uint32_t{0});
+    reader_rt_args.push_back(std::uint32_t{0});
+    reader_rt_args.push_back(static_cast<uint32_t>(output_shape[2]));
+    reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[2]));
+    reader_rt_args.push_back(unpadded_row_size_nbytes);
+    reader_rt_args.push_back(padded_row_size_nbytes);
+    reader_rt_args.push_back(std::uint32_t{0});
+    reader_rt_args.push_back(static_cast<uint32_t>(output.padded_shape()[0]));
+
+    // Writer reads the same arg layout (slot 1 = dst addr, slot 13 = pad-value const).
+    KernelDescriptor::RTArgList writer_rt_args = reader_rt_args;
+
+    reader_desc.emplace_runtime_args(CoreCoord{0, 0}, reader_rt_args);
+    writer_desc.emplace_runtime_args(CoreCoord{0, 0}, writer_rt_args);
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
+}
+
+}  // namespace
+
+WorkloadDescriptor PadRmReaderWriterProgramFactory::create_workload_descriptor(
+    const PadParams& operation_attributes,
+    const PadInputs& tensor_args,
+    Tensor& tensor_return_value,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    WorkloadDescriptor wd;
+
+    // Build the pad-value const tensor once on cache miss and park it on the
+    // WorkloadDescriptor.  Holding the SOURCE Tensor (not just a
+    // shared_ptr<MeshBuffer>) is required because ~Tensor force-deallocates the
+    // device memory through DeviceStorage::deallocate regardless of external
+    // shared_ptr<MeshBuffer> owners (see #44565).
+    Tensor pad_value_const_tensor = build_pad_value_const_tensor_sc(tensor_args, operation_attributes.pad_value);
+    auto pad_value_owner = std::make_shared<Tensor>(std::move(pad_value_const_tensor));
+    Buffer* pad_value_const_buffer = pad_value_owner->buffer();
+    wd.buffers.push_back({pad_value_owner, pad_value_const_buffer});
+
+    auto desc = build_pad_rm_sc_program_descriptor(
+        operation_attributes, tensor_args, tensor_return_value, pad_value_const_buffer);
+
+    auto ranges = tensor_coords.ranges();
+    for (size_t i = 0; i + 1 < ranges.size(); ++i) {
+        wd.programs.push_back({ranges[i], desc});
+    }
+    if (!ranges.empty()) {
+        wd.programs.push_back({ranges.back(), std::move(desc)});
+    }
+    return wd;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_program_factory.hpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/distributed/types.hpp"
+#include "pad_device_operation_types.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct PadRmReaderWriterProgramFactory {
+    // Workload-scoped pad-value const tensor is allocated once on cache miss inside
+    // create_workload_descriptor() and parked on the returned WorkloadDescriptor::buffers
+    // so it outlives the cached workload via the program cache.  Holding the SOURCE
+    // Tensor (not just shared_ptr<MeshBuffer>) is required because ~Tensor force-deallocates
+    // the device memory through DeviceStorage::deallocate regardless of external
+    // shared_ptr<MeshBuffer> owners (see #44565).  emplace_runtime_args() with Buffer*
+    // lets the framework patch the const tensor's address on cache hits without rerunning
+    // this factory.
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
+        const PadParams& operation_attributes,
+        const PadInputs& tensor_args,
+        Tensor& tensor_return_value,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
+};
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_sharded_height_only_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_sharded_height_only_program_factory.cpp
@@ -1,0 +1,407 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "pad_rm_sharded_height_only_program_factory.hpp"
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/work_split.hpp>
+#include "ttnn/operations/data_movement/common/common.hpp"
+
+using namespace tt::tt_metal;
+using namespace tt::constants;
+
+namespace ttnn::prim::qsr {
+using ttnn::operations::data_movement::float_to_uint16;
+using ttnn::operations::data_movement::pack_two_uint16_into_uint32;
+
+namespace {
+inline std::vector<std::vector<uint32_t>> group_contiguous_and_repeated_values(std::vector<uint32_t>& values) {
+    std::vector<std::vector<uint32_t>> chunks;
+    if (values.empty()) {
+        return chunks;
+    }
+
+    // Initialize the first chunk
+    std::vector<uint32_t> current_chunk;
+    current_chunk.push_back(values[0]);
+
+    for (size_t i = 1; i < values.size(); ++i) {
+        if (values[i] == values[i - 1] + 1 or values[i] == values[i - 1]) {
+            current_chunk.push_back(values[i]);
+        } else {
+            chunks.push_back(current_chunk);
+            current_chunk.clear();
+            current_chunk.push_back(values[i]);
+        }
+    }
+    // Add the last chunk
+    chunks.push_back(current_chunk);
+    return chunks;
+}
+
+inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_pad_runtime_args_rm_sharded(
+    const Tensor& input_tensor,
+    Tensor& output_tensor,
+    const ttnn::Shape& input_tensor_start,
+    uint32_t num_cores_padded,
+    bool row_major,
+    uint32_t shard_height_padded,
+    uint32_t shard_height_unpadded,
+    const CoreCoord& unpadded_grid_start,
+    uint32_t num_cores_x_unpadded,
+    uint32_t num_cores_y_unpadded) {
+    tt::tt_metal::IDevice* device = input_tensor.device();
+
+    auto input_shape = input_tensor.padded_shape();
+    auto output_shape = output_tensor.padded_shape();
+
+    uint32_t H = input_shape[2], C = input_shape[1], N = input_shape[0];
+
+    uint32_t H_padded = output_shape[2], C_padded = output_shape[1];
+
+    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
+    std::vector<uint32_t> start_dim_offset(num_dims, 0);
+
+    std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> ret_val(num_cores_padded);
+
+    const auto& front_pad = input_tensor_start;
+    uint32_t curr_c = 0, curr_h = 0, curr_n = 0;
+    for (uint32_t i = 0, curr_sticks_read = 0; i < num_cores_padded; i++) {
+        uint32_t num_sticks_per_core_unpadded = shard_height_unpadded;
+        uint32_t num_sticks_per_core_padded = shard_height_padded;
+
+        // writer rt args, set on top here as interleaved version.
+        std::vector<uint32_t> writer_kernel_args = {
+            num_sticks_per_core_padded,
+            curr_sticks_read,
+            front_pad[-4],
+            front_pad[-3],
+            front_pad[-2],
+        };
+        writer_kernel_args.insert(writer_kernel_args.end(), start_dim_offset.begin(), start_dim_offset.end());
+
+        // figure out the start read stick id for each core, and the start id for each dim
+        std::vector<int> stick_ids_per_core;
+        int front_pad_stick_id = -2;
+        int pad_stick_id = -1;
+        for (uint32_t j = 0; j < num_sticks_per_core_padded; ++j) {
+            if ((curr_h >= front_pad[-2] and curr_h < (H + front_pad[-2])) and
+                (curr_c >= front_pad[-3] and curr_c < (C + front_pad[-3])) and
+                (curr_n >= front_pad[-4] and curr_n < (N + front_pad[-4]))) {
+                stick_ids_per_core.push_back(curr_sticks_read);
+                curr_sticks_read++;
+            } else {
+                if (curr_h < front_pad[-2] or curr_c < front_pad[-3] or curr_n < front_pad[-4]) {
+                    stick_ids_per_core.push_back(front_pad_stick_id);
+                } else {
+                    stick_ids_per_core.push_back(pad_stick_id);
+                }
+            }
+
+            curr_h++;
+            if (curr_h == H_padded) {
+                curr_c++;
+                curr_h = 0;
+                if (curr_c == C_padded) {
+                    curr_n++;
+                    curr_c = 0;
+                }
+            }
+        }
+
+        start_dim_offset = {0, curr_h, curr_c, curr_n};
+
+        // figure out the stick id in a shard, and the core id for the stick.
+        std::map<std::pair<uint32_t, uint32_t>, std::vector<uint32_t>> core_stick_map;
+        auto first_core = device->worker_core_from_logical_core(unpadded_grid_start);
+        std::pair<uint32_t, uint32_t> prev_xy_pair = std::make_pair(first_core.x, first_core.y);
+        for (uint32_t j = 0; j < num_sticks_per_core_padded; ++j) {
+            int stick_id = stick_ids_per_core[j];
+
+            // if it is pad stick, we need to leave a gap between the previous non-pad stick and next non-pad stick.
+            if (stick_id == -2 || stick_id == -1) {  // front or end padding
+                core_stick_map[prev_xy_pair].push_back(stick_id);
+            } else {
+                uint32_t shard_id = stick_id / num_sticks_per_core_unpadded;
+                uint32_t stick_id_in_shard = stick_id - (shard_id * num_sticks_per_core_unpadded);
+
+                uint32_t shard_grid_inner_dim = row_major ? num_cores_x_unpadded : num_cores_y_unpadded;
+                uint32_t shard_grid_outer_dim_id = shard_id / shard_grid_inner_dim;
+                uint32_t shard_grid_inner_dim_id = shard_id - (shard_grid_outer_dim_id * shard_grid_inner_dim);
+
+                uint32_t worker_y_logical =
+                    unpadded_grid_start.y + (row_major ? shard_grid_outer_dim_id : shard_grid_inner_dim_id);
+                uint32_t worker_x_logical =
+                    unpadded_grid_start.x + (row_major ? shard_grid_inner_dim_id : shard_grid_outer_dim_id);
+
+                // worker_*_logical are absolute logical coordinates. Compare against absolute unpadded-grid bounds.
+                uint32_t unpadded_grid_end_x = unpadded_grid_start.x + num_cores_x_unpadded;
+                uint32_t unpadded_grid_end_y = unpadded_grid_start.y + num_cores_y_unpadded;
+                if (worker_x_logical < unpadded_grid_end_x and worker_y_logical < unpadded_grid_end_y) {
+                    auto core_physical =
+                        device->worker_core_from_logical_core(CoreCoord{worker_x_logical, worker_y_logical});
+                    // save stick id in a shard, and core coord into a map
+                    std::pair<uint32_t, uint32_t> xy_pair = row_major
+                                                                ? std::make_pair(core_physical.y, core_physical.x)
+                                                                : std::make_pair(core_physical.x, core_physical.y);
+                    core_stick_map[xy_pair].push_back(stick_id_in_shard);
+                    prev_xy_pair = xy_pair;
+                }
+            }
+        }
+
+        // reader rt args
+        std::vector<uint32_t> reader_kernel_args;
+        reader_kernel_args.push_back(core_stick_map.size());  // num_cores
+
+        for (const auto& core_stick_pair : core_stick_map) {
+            auto xy_pair = core_stick_pair.first;
+            if (row_major) {
+                reader_kernel_args.push_back((std::uint32_t)xy_pair.second);  // noc x
+                reader_kernel_args.push_back((std::uint32_t)xy_pair.first);   // noc y
+            } else {
+                reader_kernel_args.push_back((std::uint32_t)xy_pair.first);   // noc x
+                reader_kernel_args.push_back((std::uint32_t)xy_pair.second);  // noc y
+            }
+        }
+
+        // coalesce the sticks into chunks
+        std::vector<std::vector<std::vector<uint32_t>>> stick_chunks_per_core;
+        for (auto core_stick_pair : core_stick_map) {
+            auto stick_chunks = group_contiguous_and_repeated_values(core_stick_pair.second);
+            stick_chunks_per_core.push_back(stick_chunks);
+            reader_kernel_args.push_back(stick_chunks.size());  // num_chunks for current core
+        }
+        for (const auto& stick_chunks : stick_chunks_per_core) {
+            for (auto chunk : stick_chunks) {
+                reader_kernel_args.push_back(chunk[0]);      // start id of a chunk
+                reader_kernel_args.push_back(chunk.size());  // length of a chunk
+            }
+        }
+
+        ret_val[i] = {reader_kernel_args, writer_kernel_args};
+    }
+
+    return ret_val;
+}
+}  // namespace
+
+ProgramDescriptor PadRmShardedHeightOnlyProgramFactory::create_descriptor(
+    const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value) {
+    const auto& a = tensor_args.input;
+    Tensor& output = tensor_return_value;
+    const auto& output_padded_shape = operation_attributes.output_padded_shape;
+    const auto& pad_value = operation_attributes.pad_value;
+    const auto& input_tensor_start = operation_attributes.input_tensor_start;
+
+    const auto& a_shape = a.logical_shape();
+    uint32_t W = a_shape[3], H = a_shape[2], C = a_shape[1], N = a_shape[0];
+    [[maybe_unused]] uint32_t num_unpadded_sticks = H * C * N;
+    uint32_t W_padded = output_padded_shape[3], H_padded = output_padded_shape[2], C_padded = output_padded_shape[1],
+             N_padded = output_padded_shape[0];
+
+    const auto& front_pad = operation_attributes.input_tensor_start;
+
+    log_debug(tt::LogOp, "H_padded: {}", H_padded);
+    log_debug(tt::LogOp, "front_pad: {}", front_pad);
+
+    // stick sizes
+    auto stick_size_unpadded = W * a.element_size();
+    auto stick_size_padded = W_padded * a.element_size();
+    uint32_t row_major_min_bytes = 16;
+
+    uint32_t zero_pad_stick_size = tt::tt_metal::find_max_divisor(stick_size_padded, 512);
+    uint32_t num_zero_pad_sticks_read = stick_size_padded / zero_pad_stick_size;
+
+    log_debug(tt::LogOp, "zero_pad_stick_size: {}", zero_pad_stick_size);
+    log_debug(tt::LogOp, "num_zero_pad_sticks_read: {}", num_zero_pad_sticks_read);
+
+    // TODO: add a general case, where we can pad on any dim.
+    TT_FATAL(
+        stick_size_unpadded == stick_size_padded,
+        "sharded pad does not support pad on last dim currently as that will cause perf degradation");
+
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
+    tt::DataFormat dst_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+
+    IDevice* device = a.device();
+
+    // input shard spec
+    auto shard_spec_unpadded = a.shard_spec().value();
+    uint32_t shard_height_unpadded = shard_spec_unpadded.shape[0];
+    bool row_major = shard_spec_unpadded.orientation == ShardOrientation::ROW_MAJOR;
+
+    [[maybe_unused]] auto& all_cores_unpadded = shard_spec_unpadded.grid;
+    [[maybe_unused]] uint32_t num_cores_unpadded = shard_spec_unpadded.num_cores();
+    auto bbox_unpadded = shard_spec_unpadded.grid.bounding_box();
+    CoreCoord grid_size_unpadded = {
+        bbox_unpadded.end_coord.x - bbox_unpadded.start_coord.x + 1,
+        bbox_unpadded.end_coord.y - bbox_unpadded.start_coord.y + 1};
+    uint32_t num_cores_x_unpadded = grid_size_unpadded.x;
+    uint32_t num_cores_y_unpadded = grid_size_unpadded.y;
+
+    log_debug(tt::LogOp, "num_unpadded_sticks: {}", num_unpadded_sticks);
+    log_debug(tt::LogOp, "shard_height_unpadded: {}", shard_height_unpadded);
+    log_debug(tt::LogOp, "all_cores_unpadded: {}", all_cores_unpadded);
+    log_debug(tt::LogOp, "num_cores_unpadded: {}", num_cores_unpadded);
+
+    // output shard spec
+    auto shard_spec_padded = output.shard_spec().value();
+    uint32_t shard_height_padded = shard_spec_padded.shape[0];
+
+    auto& all_cores_padded = shard_spec_padded.grid;
+    uint32_t num_cores_padded = shard_spec_padded.num_cores();
+    auto bbox_padded = shard_spec_padded.grid.bounding_box();
+    CoreCoord grid_size_padded = {
+        bbox_padded.end_coord.x - bbox_padded.start_coord.x + 1,
+        bbox_padded.end_coord.y - bbox_padded.start_coord.y + 1};
+    uint32_t num_cores_x_padded = grid_size_padded.x;
+    uint32_t num_cores_y_padded = grid_size_padded.y;
+
+    log_debug(tt::LogOp, "num_unpadded_sticks: {}", num_unpadded_sticks);
+    log_debug(tt::LogOp, "shard_height_unpadded: {}", shard_height_unpadded);
+    log_debug(tt::LogOp, "all_cores_unpadded: {}", all_cores_unpadded);
+    log_debug(tt::LogOp, "num_cores_unpadded: {}", num_cores_unpadded);
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+
+    Buffer* src_buffer = a.buffer();
+    Buffer* dst_buffer = output.buffer();
+
+    ProgramDescriptor desc;
+
+    // Sharded input CB — globally allocated to the input buffer; framework patches
+    // the CB address on cache hits via cb.buffer.
+    uint32_t src0_cb_index = 0;
+    {
+        CBDescriptor cb_src0;
+        cb_src0.total_size = shard_height_unpadded * stick_size_unpadded;
+        cb_src0.core_ranges = total_cores;
+        cb_src0.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = cb_data_format,
+            .page_size = stick_size_unpadded,
+        });
+        cb_src0.buffer = src_buffer;
+        desc.cbs.push_back(std::move(cb_src0));
+    }
+
+    // Sharded output CB — globally allocated to the output buffer.
+    uint32_t output_cb_index = tt::CBIndex::c_16;
+    {
+        CBDescriptor cb_output;
+        cb_output.total_size = shard_height_padded * stick_size_padded;
+        cb_output.core_ranges = total_cores;
+        cb_output.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = dst_cb_data_format,
+            .page_size = stick_size_padded,
+        });
+        cb_output.buffer = dst_buffer;
+        desc.cbs.push_back(std::move(cb_output));
+    }
+
+    // construct const buffer with the pad_value
+    bool not_pad_by_zero = pad_value != 0;
+    uint32_t src1_cb_index = 1;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = stick_size_padded,
+        .core_ranges = total_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src1_cb_index),
+            .data_format = cb_data_format,
+            .page_size = stick_size_padded,
+        }}},
+    });
+
+    uint32_t packed_pad_value;
+    if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
+        packed_pad_value = pad_value;
+    } else if (a.dtype() == DataType::UINT16) {
+        packed_pad_value = pack_two_uint16_into_uint32({float_to_uint16(pad_value), float_to_uint16(pad_value)});
+    } else {
+        packed_pad_value = pack_two_bfloat16_into_uint32({bfloat16(pad_value), bfloat16(pad_value)});
+    }
+
+    std::vector<uint32_t> reader_ct_args = {(std::uint32_t)stick_size_padded, (std::uint32_t)shard_height_padded};
+
+    std::vector<uint32_t> writer_ct_args = {
+        (std::uint32_t)N + front_pad[-4],
+        (std::uint32_t)H + front_pad[-2],
+        (std::uint32_t)C + front_pad[-3],
+        (std::uint32_t)stick_size_padded,
+        (std::uint32_t)N_padded,
+        (std::uint32_t)H_padded,
+        (std::uint32_t)C_padded,
+        (std::uint32_t)num_zero_pad_sticks_read,
+        (std::uint32_t)zero_pad_stick_size,
+        (std::uint32_t)not_pad_by_zero,
+        (std::uint32_t)packed_pad_value,
+        (std::uint32_t)row_major_min_bytes,
+        (std::uint32_t)(stick_size_padded / row_major_min_bytes)};
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/reader_pad_dims_rm_sharded.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores_padded;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores_padded;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    auto all_runtime_args = get_pad_runtime_args_rm_sharded(
+        a,
+        output,
+        input_tensor_start,
+        num_cores_padded,
+        row_major,
+        shard_height_padded,
+        shard_height_unpadded,
+        bbox_unpadded.start_coord,
+        num_cores_x_unpadded,
+        num_cores_y_unpadded);
+
+    // Sharded readers/writers consume only constant uint32_t per-core args; no
+    // BufferBinding is needed because the CBs themselves carry the buffer
+    // addresses (via cb.buffer).
+    for (uint32_t i = 0; i < num_cores_padded; i++) {
+        CoreCoord core;
+        if (row_major) {
+            core = {
+                bbox_padded.start_coord.x + i % num_cores_x_padded, bbox_padded.start_coord.y + i / num_cores_x_padded};
+        } else {
+            core = {
+                bbox_padded.start_coord.x + i / num_cores_y_padded, bbox_padded.start_coord.y + i % num_cores_y_padded};
+        }
+        KernelDescriptor::RTArgList reader_rt_args;
+        reader_rt_args.reserve(all_runtime_args[i].first.size());
+        for (uint32_t v : all_runtime_args[i].first) {
+            reader_rt_args.push_back(v);
+        }
+        KernelDescriptor::RTArgList writer_rt_args;
+        writer_rt_args.reserve(all_runtime_args[i].second.size());
+        for (uint32_t v : all_runtime_args[i].second) {
+            writer_rt_args.push_back(v);
+        }
+        reader_desc.emplace_runtime_args(core, reader_rt_args);
+        writer_desc.emplace_runtime_args(core, writer_rt_args);
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_sharded_height_only_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_sharded_height_only_program_factory.hpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+
+#include "ttnn/device_operation.hpp"
+#include "pad_device_operation_types.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct PadRmShardedHeightOnlyProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value);
+};
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_sharded_width_only_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_sharded_width_only_program_factory.cpp
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "pad_rm_sharded_width_only_program_factory.hpp"
+
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/operations/data_movement/common/common.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
+
+using namespace tt::tt_metal;
+using namespace tt::constants;
+
+namespace ttnn::prim::qsr {
+using ttnn::operations::data_movement::float_to_uint16;
+using ttnn::operations::data_movement::pack_two_uint16_into_uint32;
+
+ProgramDescriptor PadRmShardedWidthOnlyProgramFactory::create_descriptor(
+    const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value) {
+    const auto& input_tensor = tensor_args.input;
+    Tensor& output = tensor_return_value;
+    const auto& output_padded_shape = operation_attributes.output_padded_shape;
+    const auto& pad_value = operation_attributes.pad_value;
+    const auto& input_tensor_start = operation_attributes.input_tensor_start;
+
+    TT_ASSERT(
+        output.shard_spec().has_value() and output.shard_spec()->shape[1] == output_padded_shape[-1],
+        "ttnn.pad: pad_rm_sharded_width_only expects sharded output parameter with shard width equal to the width of "
+        "the requested output tensor. Ensure pad_impl is calling this program factory correctly.");
+
+    uint32_t W = input_tensor.logical_shape()[-1];
+    uint32_t W_padded = output_padded_shape[3];
+
+    auto unpadded_stick_bytes = W * input_tensor.element_size();
+    auto padded_stick_bytes = W_padded * input_tensor.element_size();
+
+    IDevice* device = input_tensor.device();
+
+    // input shard spec
+    auto input_shard_spec = input_tensor.shard_spec().value();
+    uint32_t shard_height_unpadded = input_shard_spec.shape[0];
+
+    // output shard spec
+    auto shard_spec_padded = output.shard_spec().value();
+    uint32_t shard_height_padded = shard_spec_padded.shape[0];
+
+    const auto& ordered_cores_with_data = get_optimal_worker_cores_for_sharded_tensor(output);
+    auto all_cores_padded = CoreRangeSet(ttsl::Span<const CoreCoord>(ordered_cores_with_data));
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+
+    Buffer* input_buffer = input_tensor.buffer();
+    Buffer* output_buffer = output.buffer();
+
+    ProgramDescriptor desc;
+
+    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    uint32_t input_shard_cb_index = tt::CBIndex::c_0;
+    {
+        // Sharded input CB — globally allocated to the input buffer; framework
+        // patches the CB address on cache hits via cb.buffer.
+        CBDescriptor cb_input;
+        cb_input.total_size = shard_height_unpadded * unpadded_stick_bytes;
+        cb_input.core_ranges = total_cores;
+        cb_input.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(input_shard_cb_index),
+            .data_format = input_cb_data_format,
+            .page_size = unpadded_stick_bytes,
+        });
+        cb_input.buffer = input_buffer;
+        desc.cbs.push_back(std::move(cb_input));
+    }
+
+    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    uint32_t output_shard_cb_index = tt::CBIndex::c_16;
+    {
+        // Sharded output CB — globally allocated to the output buffer.
+        CBDescriptor cb_output;
+        cb_output.total_size = shard_height_padded * padded_stick_bytes;
+        cb_output.core_ranges = total_cores;
+        cb_output.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_shard_cb_index),
+            .data_format = output_cb_data_format,
+            .page_size = padded_stick_bytes,
+        });
+        cb_output.buffer = output_buffer;
+        desc.cbs.push_back(std::move(cb_output));
+    }
+
+    // construct const buffer with the pad_value
+    tt::DataFormat pad_val_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    uint32_t pad_val_cb_index = tt::CBIndex::c_1;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = padded_stick_bytes,
+        .core_ranges = total_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(pad_val_cb_index),
+            .data_format = pad_val_cb_data_format,
+            .page_size = padded_stick_bytes,
+        }}},
+    });
+
+    uint32_t W_padding_front_bytes = input_tensor_start[-3] * input_tensor.element_size();
+
+    uint32_t padding_value_as_u32;
+    if (input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT16) {
+        uint16_t bfloat_pad_value_bits = std::bit_cast<uint16_t>(bfloat16(pad_value));
+        padding_value_as_u32 = *reinterpret_cast<uint32_t*>(&bfloat_pad_value_bits);
+    } else if (input_tensor.dtype() == tt::tt_metal::DataType::FLOAT32) {
+        padding_value_as_u32 = *reinterpret_cast<const uint32_t*>(&pad_value);
+    } else if (input_tensor.dtype() == tt::tt_metal::DataType::UINT16) {
+        padding_value_as_u32 = pack_two_uint16_into_uint32({0, float_to_uint16(pad_value)});
+    } else if (
+        input_tensor.dtype() == tt::tt_metal::DataType::INT32 ||
+        input_tensor.dtype() == tt::tt_metal::DataType::UINT32) {
+        padding_value_as_u32 = static_cast<uint32_t>(pad_value);  // for INT32 and UINT32
+    } else {
+        TT_THROW("ttnn.pad: unsupported data type for pad_rm_sharded_stickwise");
+    }
+
+    auto l1_alignment_bytes = hal::get_l1_alignment();
+    uint32_t padded_stick_step = tt::round_up(
+        padded_stick_bytes, l1_alignment_bytes);  // round padded_stick bytes to a multiple of l1_alignment_bytes
+    uint32_t unpadded_stick_step = tt::round_up(
+        unpadded_stick_bytes,
+        l1_alignment_bytes);  // round unpadded_stick bytes to a multiple of l1_alignment_bytes
+
+    std::vector<uint32_t> reader_ct_args = {
+        unpadded_stick_bytes,
+        padded_stick_bytes,
+        shard_height_unpadded,
+        shard_height_padded,
+        W_padding_front_bytes,
+        input_shard_cb_index,
+        output_shard_cb_index,
+        unpadded_stick_step,
+        padded_stick_step};
+
+    std::vector<uint32_t> writer_ct_args = {
+        padded_stick_bytes,
+        shard_height_padded,
+        padding_value_as_u32,
+        output.element_size(),
+        output_shard_cb_index,
+        pad_val_cb_index,
+        padded_stick_step};
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/"
+        "reader_pad_dims_rm_sharded_stickwise.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores_padded;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/"
+        "writer_pad_dims_rm_sharded_stickwise.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores_padded;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    // Sharded readers/writers don't consume per-core runtime args (legacy code
+    // called SetRuntimeArgs(..., {}) with empty arg lists).  CB addresses are
+    // patched via cb.buffer on cache hits.  Mirror the legacy behavior by
+    // emitting an empty rtarg list per active core so the kernel reserves slots.
+    for (const auto& core : ordered_cores_with_data) {
+        reader_desc.emplace_runtime_args(core, KernelDescriptor::RTArgList{});
+        writer_desc.emplace_runtime_args(core, KernelDescriptor::RTArgList{});
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_sharded_width_only_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_sharded_width_only_program_factory.hpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+
+#include "ttnn/device_operation.hpp"
+#include "pad_device_operation_types.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct PadRmShardedWidthOnlyProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value);
+};
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_tile_multicore_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_tile_multicore_program_factory.cpp
@@ -1,0 +1,284 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "pad_tile_multicore_program_factory.hpp"
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
+#include "ttnn/operations/data_movement/common/common.hpp"
+
+using namespace tt::tt_metal;
+using namespace tt::constants;
+
+namespace ttnn::prim::qsr {
+using ttnn::operations::data_movement::get_num_pages;
+
+static inline int advance_tensor_index(std::vector<uint32_t>& idx, const ttnn::Shape& dims, uint32_t ndims) {
+    // increment least-significant dim first
+    for (int32_t d = ndims - 1; d >= 0; d--) {
+        uint32_t v = idx[d] + 1;
+        if (v < dims[d]) {
+            idx[d] = v;
+            return 1;
+        }
+        idx[d] = 0;  // wrap and carry
+    }
+    return 0;  // overflowed most-significant dim
+}
+
+ProgramDescriptor PadTileMulticoreProgramFactory::create_descriptor(
+    const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output) {
+    const auto& a = tensor_args.input;
+    const auto& pad_value = operation_attributes.pad_value;
+    const auto& output_padded_shape = operation_attributes.output_padded_shape;
+
+    const auto& a_shape = a.logical_shape();
+    uint32_t num_pages = get_num_pages(output);
+
+    IDevice* device = a.device();
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    const auto& sub_core_grids = operation_attributes.sub_core_grids;
+
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_pages_per_core_group_1, num_pages_per_core_group_2] =
+        sub_core_grids.has_value() ? tt::tt_metal::split_work_to_cores(sub_core_grids.value(), num_pages)
+                                   : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_pages);
+
+    auto cores_in_order = corerange_to_cores(all_cores, num_cores, true);
+
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
+    uint32_t page_size = output.buffer()->page_size();
+    uint32_t multi_buffering_size = 2;
+    uint32_t input_cb_index = tt::CBIndex::c_0;
+    uint32_t output_cb_index = tt::CBIndex::c_1;
+    uint32_t pad_val_cb_index = tt::CBIndex::c_2;
+
+    ProgramDescriptor desc;
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = page_size * multi_buffering_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(input_cb_index),
+            .data_format = cb_data_format,
+            .page_size = page_size,
+        }}},
+    });
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = page_size * multi_buffering_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = cb_data_format,
+            .page_size = page_size,
+        }}},
+    });
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(pad_val_cb_index),
+            .data_format = cb_data_format,
+            .page_size = page_size,
+        }}},
+    });
+
+    Buffer* input_buffer = a.buffer();
+    Buffer* output_buffer = output.buffer();
+    TT_ASSERT(output_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    uint32_t packed_pad_value;
+    bfloat16 bfloat_pad_value = bfloat16(pad_value);
+    switch (a.dtype()) {
+        case DataType::INT32:
+        case DataType::UINT32: packed_pad_value = pad_value; break;
+        case DataType::BFLOAT16:
+            packed_pad_value = pack_two_bfloat16_into_uint32({bfloat_pad_value, bfloat_pad_value});
+            break;
+        case DataType::UINT16:
+            packed_pad_value = ttnn::operations::data_movement::pack_two_uint16_into_uint32(
+                {ttnn::operations::data_movement::float_to_uint16(pad_value),
+                 ttnn::operations::data_movement::float_to_uint16(pad_value)});
+            break;
+        case DataType::FLOAT32: packed_pad_value = std::bit_cast<uint32_t>(pad_value); break;
+        default:
+            packed_pad_value = 0;
+            TT_ASSERT(
+                false,
+                "Unsupported datatype for pad tile multicore, can only support INT32, UINT32, BFLOAT16, UINT16, "
+                "FLOAT32");
+    }
+
+    std::vector<uint32_t> reader_ct_args = {
+        (std::uint32_t)input_cb_index,
+        (std::uint32_t)page_size,
+        (std::uint32_t)output_padded_shape.rank(),
+    };
+    TensorAccessorArgs(*input_buffer).append_to(reader_ct_args);
+
+    std::vector<uint32_t> writer_ct_args = {
+        (std::uint32_t)input_cb_index,
+        (std::uint32_t)output_cb_index,
+        (std::uint32_t)pad_val_cb_index,
+        (std::uint32_t)page_size,
+        (std::uint32_t)output_padded_shape.rank(),
+        (std::uint32_t)packed_pad_value,
+        (std::uint32_t)output.element_size(),
+    };
+    TensorAccessorArgs(*output_buffer).append_to(writer_ct_args);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/reader_pad_tiled.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/writer_pad_tiled.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    /*
+    As an example, lets say we want to pad a [2, 1, 32, 32] tensor to [2, 3, 64, 64]
+    The input tensor exists as [2, 2, 1, 1] if we reduce by tile (page) size, and the output as [2, 3, 2, 2]
+    we increment through these shapes, and will write a total of 2 * 3 * 2 * 2 = 24 tiles, so we will utilize 24 cores
+    for each core, we calculate if we are within the "input region" of the output. this does a check of
+    if any element in the incremented input_id_per_dim is less than the output_id_per_dim, if so, we are outside
+    the input region, and we will write a padding tile, and we will not increment the input_id_per_dim for that tile.
+    if we are within the input region, we will write the tile from input to the output, and increment the
+    input_id_per_dim. This works because we increment the least-significant dim first, and the input region correctly
+    matches the output after the output wraps around. In this example:
+    Core 0: input_id_per_dim: [0,0,0,0] ; output_id_per_dim: [0,0,0,0], we copy the tile and increment both input and
+    output dims, next ->
+    Core 1: input_id_per_dim: [0,1,0,0] ; output_id_per_dim: [0,0,0,1], the last output dim is
+    greater than input, so we write the pad tile, and increment only output dim, next ->
+    Core 2: input_id_per_dim: [0,1,0,0] ; output_id_per_dim: [0,0,1,0], the second last output dim is greater than
+    input, so we write the pad tile, and increment only output dim, next ->
+    Core 3: input_id_per_dim: [0,1,0,0] ; output_id_per_dim: [0,0,1,1], the last 2 output dims is greater than input,
+    so we write the pad tile, and increment only output dim, next ->
+    Core 4: input_id_per_dim: [0,1,0,0] ; output_id_per_dim: [0,1,0,0], we copy the tile and increment, next ->
+    Core 5: input_id_per_dim: [1,0,0,0] ; output_id_per_dim: [0,1,0,1], Some output dims are greater
+    than input, so we write the pad tile, and increment only output dim. next ->
+    Core 6: input_id_per_dim: [1,0,0,0] ; output_id_per_dim: [0,1,1,0],
+    Core 7, 8, 9, 10, 11, we write pad tiles, incrementing only output dim each time, next ->
+    Core 12: input_id_per_dim: [1,0,0,0] ; output_id_per_dim: [1,0,0,0], we copy the tile and increment, next ->
+    Core 13: input_id_per_dim: [1,1,0,0] ; output_id_per_dim: [1,0,0,1], Core 13, 14, 15, we write pad tiles,
+    incrementing only output dim each time, next -> Core 16: input_id_per_dim: [1,1,0,0] ; output_id_per_dim: [1,1,0,0],
+    we copy the tile and increment, next ->
+    From now on, input_id_per_dim wraps around it's most significant dim, resulting in [0,0,0,0].
+    This means for every output_id_per_dim, an element will always be greater than
+    input_id_per_dim, so every core after core 16 will only write pad tiles, which is correct as we have filled all of
+    the input region, and will always be outside of it from now on.
+
+    As you can see, the input_id_per_dim only increments when we are within the input region of the output,
+    and the output_id_per_dim increments every time, this means that when the output wraps around, the input
+    will be correctly positioned for the next set of output tiles.
+    */
+
+    std::vector<uint32_t> input_id_per_dim, output_id_per_dim;  // input and output id_per_dims
+    // initialize id_per_dims to vectors of length num_dims filled with 0
+    input_id_per_dim.resize(a_shape.rank(), 0);
+    output_id_per_dim.resize(output_padded_shape.rank(), 0);
+    // instantiate the input and output tensor padded shapes
+    auto input_page_shape = a.padded_shape();
+    auto output_page_shape = output_padded_shape;
+    input_page_shape[-1] /= tt::constants::TILE_HEIGHT;
+    input_page_shape[-2] /= tt::constants::TILE_HEIGHT;
+    output_page_shape[-1] /= tt::constants::TILE_HEIGHT;
+    output_page_shape[-2] /= tt::constants::TILE_HEIGHT;
+    bool within_input_region;
+    uint32_t input_page_offset = 0;
+    uint32_t output_page_offset = 0;
+
+    for (uint32_t i = 0; i < num_cores; i++) {
+        CoreCoord core = cores_in_order[i];
+
+        uint32_t num_pages_per_core;
+        if (core_group_1.contains(core)) {
+            num_pages_per_core = num_pages_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_pages_per_core = num_pages_per_core_group_2;
+        } else {
+            num_pages_per_core = 0;  // no-op
+        }
+
+        // Slot 0 is a raw buffer base address (no offset).  Use Buffer* on active
+        // cores so the framework patches the address on cache hits.  Idle cores
+        // (num_pages_per_core == 0) pass 0u to skip BufferBinding registration —
+        // the kernel short-circuits and never dereferences the address.
+        KernelDescriptor::RTArgList reader_runtime_args;
+        KernelDescriptor::RTArgList writer_runtime_args;
+
+        if (num_pages_per_core != 0) {
+            reader_runtime_args.push_back(input_buffer);
+            writer_runtime_args.push_back(output_buffer);
+        } else {
+            reader_runtime_args.push_back(0u);
+            writer_runtime_args.push_back(0u);
+        }
+
+        reader_runtime_args.push_back(num_pages_per_core);
+        reader_runtime_args.push_back(input_page_offset);
+
+        writer_runtime_args.push_back(num_pages_per_core);
+        writer_runtime_args.push_back(output_page_offset);
+
+        // Every core should get the same input and output tile shapes.
+        for (auto v : input_page_shape) {
+            reader_runtime_args.push_back(v);
+            writer_runtime_args.push_back(v);
+        }
+        for (auto v : output_page_shape) {
+            reader_runtime_args.push_back(v);
+            writer_runtime_args.push_back(v);
+        }
+
+        // As well as where the core should start writing in the output tensor.
+        for (uint32_t v : input_id_per_dim) {
+            reader_runtime_args.push_back(v);
+            writer_runtime_args.push_back(v);
+        }
+        for (uint32_t v : output_id_per_dim) {
+            reader_runtime_args.push_back(v);
+            writer_runtime_args.push_back(v);
+        }
+
+        reader_desc.emplace_runtime_args(core, reader_runtime_args);
+        writer_desc.emplace_runtime_args(core, writer_runtime_args);
+
+        // We now need to increment the input and output id_per_dims by the number of pages this core is processing
+        // Similarly to in the kernel, we only increment the input id_per_dim if we are within the input region
+        for (uint32_t p = 0; p < num_pages_per_core; p++) {
+            within_input_region = true;
+            for (uint32_t d = 0; d < input_id_per_dim.size(); d++) {
+                if (input_id_per_dim[d] < output_id_per_dim[d]) {
+                    within_input_region = false;
+                    break;
+                }
+            }
+            if (within_input_region) {
+                advance_tensor_index(input_id_per_dim, input_page_shape, input_id_per_dim.size());
+                input_page_offset++;
+            }
+            advance_tensor_index(output_id_per_dim, output_page_shape, output_id_per_dim.size());
+            output_page_offset++;
+        }
+        // The input and output id_per_dim should now be set correctly for the next core
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_tile_multicore_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_tile_multicore_program_factory.hpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+
+#include "ttnn/device_operation.hpp"
+#include "pad_device_operation_types.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct PadTileMulticoreProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output);
+};
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_tile_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_tile_program_factory.cpp
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "pad_tile_program_factory.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include "ttnn/operations/data_movement/common/common.hpp"
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+using ttnn::operations::data_movement::float_to_uint16;
+using ttnn::operations::data_movement::pack_two_uint16_into_uint32;
+
+ProgramDescriptor PadTileCoreProgramFactory::create_descriptor(
+    const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value) {
+    const auto& a = tensor_args.input;
+    Tensor& output = tensor_return_value;
+    const auto& pad_value = operation_attributes.pad_value;
+    const auto& output_padded_shape = operation_attributes.output_padded_shape;
+
+    const CoreRangeSet core_ranges{CoreRange{{0, 0}, {0, 0}}};
+
+    // This should allocate a DRAM buffer on the device
+
+    const auto& output_shape = output_padded_shape;
+
+    Buffer* src0_buffer = a.buffer();
+    Buffer* dst_buffer = output.buffer();
+    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
+    uint32_t single_tile_size = tt::tile_size(cb_data_format);
+
+    log_debug(tt::LogOp, "pad_tile");
+    log_debug(tt::LogOp, "cb_data_format: {}", cb_data_format);
+    log_debug(tt::LogOp, "single_tile_size: {}", single_tile_size);
+    log_debug(tt::LogOp, "output_tensor_shape: {}", output_padded_shape);
+    log_debug(tt::LogOp, "input_tensor_start: {}", operation_attributes.input_tensor_start);
+    log_debug(tt::LogOp, "pad_value: {}", pad_value);
+
+    ProgramDescriptor desc;
+
+    const uint32_t src0_cb_index = 0;
+    const uint32_t num_input_tiles = 2;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * single_tile_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+    });
+
+    const uint32_t src1_cb_index = 1;  // For pad buffer
+    const uint32_t num_pad_tiles = 1;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_pad_tiles * single_tile_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src1_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+    });
+
+    uint32_t packed_pad_value;
+    if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
+        packed_pad_value = pad_value;
+    } else if (a.dtype() == DataType::UINT16) {
+        packed_pad_value = pack_two_uint16_into_uint32({float_to_uint16(pad_value), float_to_uint16(pad_value)});
+    } else {
+        packed_pad_value = pack_two_bfloat16_into_uint32({bfloat16(pad_value), bfloat16(pad_value)});
+    }
+
+    uint32_t num_unpadded_Xt = a.padded_shape()[3] / TILE_WIDTH;
+    uint32_t num_total_Xt = output_shape[3] / TILE_WIDTH;
+    uint32_t num_padded_Xt = num_total_Xt - num_unpadded_Xt;
+    uint32_t num_unpadded_Yt = a.padded_shape()[2] / TILE_HEIGHT;
+    uint32_t num_total_Yt = output_shape[2] / TILE_HEIGHT;
+    uint32_t num_padded_Yt = (num_total_Yt - num_unpadded_Yt) * num_total_Xt;
+    uint32_t num_unpadded_Z = a.padded_shape()[1];
+    uint32_t num_total_Z = output_shape[1];
+    uint32_t num_padded_Zt = (num_total_Z - num_unpadded_Z) * num_total_Yt * num_total_Xt;
+    uint32_t num_unpadded_W = a.padded_shape()[0];
+    uint32_t num_total_W = output_shape[0];
+    uint32_t num_padded_Wt = (num_total_W - num_unpadded_W) * num_total_Z * num_total_Yt * num_total_Xt;
+
+    uint32_t num_unpadded_tiles = a.physical_volume() / TILE_HW;
+
+    // Reader compile-time args
+    // Data is 32 byte aligned
+    std::vector<uint32_t> reader_compile_time_args;
+    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+    std::vector<uint32_t> writer_compile_time_args = {src0_cb_index, src1_cb_index};
+    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+
+    // Tilized reader
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = core_ranges;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/"
+        "writer_unary_pad_dims_interleaved.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = core_ranges;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    // Slot 0 of both kernels is a raw buffer base address (no offset).  Use Buffer*
+    // for BufferBinding so the framework patches addresses on cache hits without
+    // rebuilding the descriptor.
+    reader_desc.emplace_runtime_args(CoreCoord{0, 0}, {src0_buffer, num_unpadded_tiles, std::uint32_t{0}});
+
+    writer_desc.emplace_runtime_args(
+        CoreCoord{0, 0},
+        {dst_buffer,
+         num_unpadded_W,
+         num_padded_Wt,
+         num_unpadded_Z,
+         num_padded_Zt,
+         num_unpadded_Yt,
+         num_padded_Yt,
+         num_unpadded_Xt,
+         num_padded_Xt,
+         packed_pad_value});
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_tile_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_tile_program_factory.hpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+
+#include "ttnn/device_operation.hpp"
+#include "pad_device_operation_types.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct PadTileCoreProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value);
+};
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/pad.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/pad.cpp
@@ -1,0 +1,440 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/data_movement/common/common.hpp"
+#include "ttnn/operations/data_movement/fill_pad/fill_pad.hpp"
+#include "ttnn/operations/experimental/quasar/pad/device/pad_device_operation.hpp"
+#include "ttnn/operations/experimental/reshape/view.hpp"
+#include "ttnn/operations/copy/typecast/typecast.hpp"
+#include "ttnn/operation.hpp"
+#include <ttnn/tensor/types.hpp>
+
+#include "pad.hpp"
+
+namespace ttnn::operations::experimental::quasar::detail {
+
+// Shared data-movement helpers (defined in data_movement/common/common.hpp) used by this op.
+// They previously resolved via the enclosing data_movement namespace; bring them in explicitly
+// now that this op lives under the experimental::quasar namespace.
+using ttnn::operations::data_movement::compute_padded_shape;
+using ttnn::operations::data_movement::create_sharded_memory_config;
+using ttnn::operations::data_movement::ShardStrategy;
+using ttnn::operations::data_movement::squeeze_from_ND_to_4D;
+using ttnn::operations::data_movement::squeeze_or_unsqueeze_shape_to_ND;
+
+bool eq_spans(const auto a, const auto b) { return std::equal(a.begin(), a.end(), b.begin(), b.end()); }
+
+ttnn::Shape update_original_shape(const ttnn::Shape& padded_shape, const ttnn::Shape& input_shape) {
+    ttnn::SmallVector<uint32_t> updated_shape;
+    size_t input_rank = input_shape.rank();
+    for (size_t i = 0; i < input_rank - 2; i++) {
+        updated_shape.push_back(input_shape[i]);
+    }
+    updated_shape.push_back(padded_shape[-2]);
+    updated_shape.push_back(padded_shape[-1]);
+    return ttnn::Shape(std::move(updated_shape));
+}
+
+ttnn::Tensor pad_impl(
+    const ttnn::Tensor& input_tensor,
+    std::span<const uint32_t> output_padded_shape,
+    std::span<const uint32_t> input_tensor_start,
+    const float value,
+    const bool use_multicore,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt) {
+    auto input_logical_shape = input_tensor.logical_shape().view();
+    // on host
+    if (input_tensor.storage_type() != StorageType::DEVICE) {
+        if (eq_spans(input_logical_shape, output_padded_shape)) {
+            return input_tensor;
+        }
+        return input_tensor.pad(ttnn::Shape(output_padded_shape), ttnn::Shape{input_tensor_start}, value);
+    }
+
+    // on device
+    auto input_tensor_shape = input_tensor.logical_shape();
+    const auto rank = input_tensor_shape.rank();
+
+    TT_FATAL(rank == 4, "ttnn.pad: input tensor passed to pad_impl must have rank == 4, but got rank {}.", rank);
+    bool input_output_same = true;
+    for (size_t i = 0; i < rank; i++) {
+        if (input_tensor_shape[i] != output_padded_shape[i]) {
+            input_output_same = false;
+            break;
+        }
+    }
+    if (input_output_same) {
+        log_debug(tt::LogOp, "Pad Input and Output Shapes are the same. Skipping pad and returning input tensor.");
+        return input_tensor;
+    }
+    using ShardStrategy = ttnn::operations::data_movement::ShardStrategy;
+    using ShardOrientation = tt::tt_metal::ShardOrientation;
+
+    auto output_memory_config = memory_config_arg.value_or(input_tensor.memory_config());
+
+    if (input_tensor.is_sharded() && input_tensor.memory_config().memory_layout() != TensorMemoryLayout::ND_SHARDED &&
+        output_memory_config.memory_layout() != TensorMemoryLayout::ND_SHARDED &&
+        output_memory_config.memory_layout() != TensorMemoryLayout::INTERLEAVED) {
+        auto total_height = [](const auto& shape) {
+            return std::accumulate(shape.begin(), shape.end() - 1, 1, std::multiplies<uint32_t>());
+        };
+
+        auto height_distinct = [&total_height](const auto& shape, const auto& other_shape) {
+            return total_height(shape) != total_height(other_shape);
+        };
+
+        auto width_distinct = [](const auto& shape, const auto& other_shape) { return shape[3] != other_shape[3]; };
+
+        uint32_t output_w = output_padded_shape[3];
+
+        if (width_distinct(input_logical_shape, output_padded_shape)) {
+            std::array<uint32_t, 4> output_shape_width_padded{
+                input_logical_shape[0], input_logical_shape[1], input_logical_shape[2], output_w};
+            log_warning(
+                tt::LogOp,
+                "ttnn.pad: Input is HEIGHT_SHARDED and width padding is required. "
+                "Ignoring the provided output memory config and recomputing a HEIGHT_SHARDED config "
+                "with shard width equal to the padded output width.");
+            auto width_pad_memory_config = create_sharded_memory_config(
+                ttnn::Shape{output_shape_width_padded},
+                input_tensor.shard_spec()->grid,  // reuse input cores for now: FIXME: can we do better?
+                                                  // it's complicated because we need the input shards to be local
+                                                  // to the core holding the output shard currently.
+                ShardStrategy::HEIGHT,            // stay height sharded
+                ShardOrientation::ROW_MAJOR);
+            output_memory_config = width_pad_memory_config;
+
+            if (height_distinct(input_logical_shape, output_padded_shape)) {
+                // we will decompose the padding into two parts and run two
+                // separate pads.
+                ttnn::SmallVector<uint32_t> adjusted_input_tensor_start{0, 0, 0, input_tensor_start[3]};
+
+                TT_FATAL(
+                    not(height_distinct(input_logical_shape, output_shape_width_padded) and
+                        width_distinct(input_logical_shape, output_shape_width_padded)),
+                    "infinite recursion");
+
+                // pad width
+                auto output_tensor_width_padded = pad_impl(
+                    input_tensor,
+                    output_shape_width_padded,
+                    adjusted_input_tensor_start,
+                    value,
+                    use_multicore,
+                    width_pad_memory_config);
+
+                TT_FATAL(
+                    not(height_distinct(output_padded_shape, output_shape_width_padded) and
+                        width_distinct(output_padded_shape, output_shape_width_padded)),
+                    "infinite recursion");
+
+                auto height_pad_memory_config = create_sharded_memory_config(
+                    ttnn::Shape{output_padded_shape},
+                    input_tensor.shard_spec()->grid,
+                    ShardStrategy::HEIGHT,
+                    ShardOrientation::ROW_MAJOR);
+
+                // then pad height
+                auto output_tensor_height_padded = pad_impl(
+                    output_tensor_width_padded,
+                    output_padded_shape,
+                    input_tensor_start,
+                    value,
+                    use_multicore,
+                    memory_config_arg.value_or(height_pad_memory_config));
+                output_tensor_width_padded.deallocate();  // dealloc temporary width padded tensor
+                return output_tensor_height_padded;
+            }
+        }
+    }
+
+    ttnn::Shape output_shape{output_padded_shape};
+    return ttnn::prim::qsr::pad(
+        input_tensor,
+        output_shape,
+        output_shape,
+        ttnn::Shape{input_tensor_start},
+        value,
+        output_memory_config,
+        use_multicore,
+        std::nullopt,
+        sub_core_grids);
+}
+
+ttnn::Tensor pad_impl(
+    const ttnn::Tensor& input_tensor,
+    ttnn::SmallVector<PadSpecDim> padding,
+    const float value,
+    const bool use_multicore,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt) {
+    if (input_tensor.dtype() == DataType::BFLOAT8_B && input_tensor.layout() == Layout::TILE) {
+        auto bfloat16_tensor = ttnn::typecast(input_tensor, DataType::BFLOAT16);
+        auto padded_tensor =
+            pad_impl(bfloat16_tensor, padding, value, use_multicore, memory_config_arg, sub_core_grids);
+        return ttnn::typecast(padded_tensor, DataType::BFLOAT8_B);
+    }
+    const int original_rank = input_tensor.logical_shape().rank();
+
+    TT_FATAL(padding.size() == original_rank, "ttnn.pad: padding must be the same length as the input tensor rank");
+
+    // Unsqueeze Tensor to 4D if it is not already
+    ttnn::Tensor input_tensor_4D;
+    if (input_tensor.logical_shape().rank() < 4) {
+        input_tensor_4D = ttnn::unsqueeze_to_4D(input_tensor);
+    } else if (input_tensor.logical_shape().rank() > 4) {
+        input_tensor_4D = squeeze_from_ND_to_4D(input_tensor);
+    } else {
+        input_tensor_4D = input_tensor;
+    }
+    size_t padding_size = 4;
+    size_t extra_index = input_tensor.logical_shape().rank() - 4;
+    if (input_tensor.logical_shape().rank() < 4) {
+        padding.insert(padding.begin(), 4 - original_rank, {0, 0});
+        padding_size = padding.size();
+        extra_index = 0;
+    }
+    auto input_shape_with_tile_padding =
+        (input_tensor_4D.layout() == Layout::TILE) ? input_tensor_4D.padded_shape() : input_tensor_4D.logical_shape();
+    // For tilized tensors, we want the shape padded to the nearest tile. For row major, we just want the row size
+    // (logical shape).
+    std::vector<uint32_t> pad_front_array(padding_size, 0);
+    std::vector<uint32_t> output_padded_shape(padding_size, 0);
+    for (size_t i = 0; i < padding_size; i++) {
+        pad_front_array[i] = padding[i + extra_index].before_elements;
+        output_padded_shape[i] = padding[i + extra_index].before_elements + input_shape_with_tile_padding[i] +
+                                 padding[i + extra_index].after_elements;
+    }
+
+    if (input_tensor.layout() == ttnn::TILE_LAYOUT) {
+        const int target_height = output_padded_shape[padding_size - 2];
+        const int target_width = output_padded_shape[padding_size - 1];
+        TT_FATAL(
+            target_height % ttnn::TILE_SIZE == 0 && target_width % ttnn::TILE_SIZE == 0,
+            "ttnn.pad: for tiled tensors padding end must be a multiple of the tile size on height and width for a "
+            "tensor in tile layout");
+    }
+
+    return pad_impl(
+        input_tensor_4D, output_padded_shape, pad_front_array, value, use_multicore, memory_config_arg, sub_core_grids);
+}
+
+std::tuple<ttnn::Shape, ttnn::Shape> compute_requested_shape(
+    const ttnn::Shape& input_logical_shape, const ttnn::SmallVector<PadSpecDim>& pad_spec) {
+    if (std::all_of(pad_spec.begin(), pad_spec.end(), [](auto& p) {
+            return p.before_elements == 0 && p.after_elements == 0;
+        })) {
+        return std::make_tuple(compute_padded_shape(input_logical_shape), compute_padded_shape(input_logical_shape));
+    }
+
+    const auto rank = input_logical_shape.rank();
+    ttnn::SmallVector<uint32_t> requested_logical_shape_vec(rank, 0);
+
+    std::transform(
+        input_logical_shape.cbegin(),
+        input_logical_shape.cend(),
+        pad_spec.cbegin(),
+        requested_logical_shape_vec.begin(),
+        [](auto& a, auto& b) { return a + b.after_elements; });
+
+    const ttnn::Shape logical_shape(requested_logical_shape_vec);
+    return std::make_tuple(logical_shape, compute_padded_shape(logical_shape));
+}
+
+ttnn::Tensor invoke_rm(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::SmallVector<PadSpecDim>& padding_vec,
+    const float value,
+    const bool use_multicore,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt) {
+    const int original_rank = input_tensor.logical_shape().rank();
+
+    ttnn::Tensor output_tensor =
+        pad_impl(input_tensor, padding_vec, value, use_multicore, memory_config_arg, sub_core_grids);
+
+    // output_tensor is currently 4D. We have to squeeze back to the original rank
+    if (original_rank <= 4) {
+        auto to_vec = [](const auto& span) { return ttnn::SmallVector<uint32_t>{span.begin(), span.end()}; };
+        auto output_shape = to_vec(output_tensor.padded_shape().view());
+        auto padded_shape = to_vec(output_tensor.padded_shape().view());
+        if (const auto rank_diff = output_shape.size() - original_rank; rank_diff) {
+            auto remove_prefix = [](auto& source, size_t n) { source.erase(source.begin(), source.begin() + n); };
+            remove_prefix(output_shape, rank_diff);
+            remove_prefix(padded_shape, rank_diff);
+            output_tensor = ttnn::reshape(output_tensor, ttnn::Shape(output_shape), ttnn::Shape(padded_shape));
+            output_tensor = ttnn::reshape(output_tensor, ttnn::Shape(padded_shape));
+        }
+    } else {
+        output_tensor = ttnn::reshape(
+            output_tensor, update_original_shape(output_tensor.padded_shape(), input_tensor.logical_shape()));
+    }
+    return output_tensor;
+}
+
+ttnn::Tensor invoke_tile(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::SmallVector<PadSpecDim>& padding_vec,
+    const float value,
+    const bool use_multicore,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt) {
+    const bool front_padding_is_zero =
+        std::all_of(padding_vec.begin(), padding_vec.end(), [](auto& x) { return x.before_elements == 0; });
+    TT_FATAL(front_padding_is_zero, "ttnn.pad: on device tile padding does not support front padding");
+
+    const auto& input_logical_shape = input_tensor.logical_shape();
+    const auto& input_padded_shape = input_tensor.padded_shape();
+    const auto [requested_logical_shape, requested_padded_shape] =
+        compute_requested_shape(input_logical_shape, padding_vec);
+    const auto requested_rank = requested_logical_shape.rank();
+
+    // Consistent with behavior expected by callers
+    if (input_tensor.storage_type() != StorageType::DEVICE) {
+        ttnn::Shape zeros(ttnn::SmallVector<uint32_t>(input_logical_shape.rank(), 0));
+        return input_tensor.pad(requested_padded_shape, zeros, value);
+    }
+
+    const bool pad_upper_dims = !std::equal(
+        requested_logical_shape.view().rbegin() + 2,
+        requested_logical_shape.view().rend(),
+        input_logical_shape.view().rbegin() + 2,
+        input_logical_shape.view().rend());
+
+    auto pad_current_tile_dim = [&requested_padded_shape, &input_padded_shape](const int i) {
+        return requested_padded_shape[i] == input_padded_shape[i];
+    };
+
+    ttnn::Tensor output_tensor = ttnn::fill_implicit_tile_padding(input_tensor, value, memory_config_arg);
+    if (requested_rank == 1 || (!pad_upper_dims && pad_current_tile_dim(-1) && pad_current_tile_dim(-2))) {
+        output_tensor = ttnn::experimental::view(output_tensor, requested_logical_shape, requested_padded_shape);
+
+    } else {
+        // need to align the requested padding to tile size. Note that begin padding is not supported so now just
+        // set to zero
+        ttnn::SmallVector<PadSpecDim> padded_padding_vec;
+        padded_padding_vec.reserve(requested_rank);
+        std::transform(
+            requested_padded_shape.cbegin(),
+            requested_padded_shape.cend(),
+            input_padded_shape.cbegin(),
+            std::back_inserter(padded_padding_vec),
+            [](auto& a, auto& b) { return PadSpecDim{0, a - b}; });
+
+        // this tensor will be 4D
+        output_tensor = pad_impl(
+            output_tensor, std::move(padded_padding_vec), value, use_multicore, memory_config_arg, sub_core_grids);
+
+        // this is the padded shape
+        const auto output_shape = squeeze_or_unsqueeze_shape_to_ND(output_tensor.logical_shape(), requested_rank);
+
+        // "slice" down to logical shape
+        output_tensor = ttnn::experimental::view(output_tensor, requested_logical_shape, requested_padded_shape);
+    }
+    if (output_tensor.memory_config().shard_spec().has_value() !=
+        memory_config_arg.value_or(input_tensor.memory_config()).shard_spec().has_value()) {
+        if (memory_config_arg.has_value()) {
+            output_tensor = ttnn::to_memory_config(output_tensor, memory_config_arg.value(), std::nullopt);
+        } else {
+            // memory_config_arg is nullopt → condition can only be true if input is sharded
+            // (interleaved input + nullopt config → both sides false → condition false)
+            // so input_tensor.shard_spec()->grid is safe here.
+            const auto sharded_mem_config = create_sharded_memory_config(
+                ttnn::Shape{requested_logical_shape},
+                input_tensor.shard_spec()->grid,
+                ShardStrategy::HEIGHT,
+                ShardOrientation::ROW_MAJOR);
+            output_tensor = ttnn::to_memory_config(output_tensor, sharded_mem_config, std::nullopt);
+        }
+    }
+    return output_tensor;
+}
+}  // namespace ttnn::operations::experimental::quasar::detail
+
+namespace ttnn::operations::experimental::quasar {
+
+// This function signature is similar to pytorch's signature
+// Any rank tensor supported
+
+ttnn::Tensor pad(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::SmallVector<operations::experimental::quasar::PadSpecDim>& padding,
+    const float value,
+    const bool use_multicore,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
+    using PadSpecDim = operations::experimental::quasar::PadSpecDim;
+    const int original_rank = input_tensor.logical_shape().rank();
+
+    ttnn::SmallVector<PadSpecDim> working_padding = padding;
+
+    if (int diff = original_rank - padding.size(); diff != 0) {
+        TT_FATAL(diff > 0, "ttnn.pad: padding len can't be larger than input tensor rank");
+
+        working_padding.insert(working_padding.begin(), diff, {0, 0});
+    }
+
+    if (std::all_of(working_padding.begin(), working_padding.end(), [](auto& p) {
+            return p.before_elements == 0 && p.after_elements == 0;
+        })) {
+        return input_tensor;
+    }
+
+    if (original_rank > 4) {
+        const auto first_pad_idx =
+            std::find_if(
+                working_padding.begin(), working_padding.end(), [](auto& p) { return p.after_elements != 0; }) -
+            working_padding.begin();
+        TT_FATAL(
+            first_pad_idx >= original_rank - 3,
+            "ttnn::pad only supports padding on the lowest 3 dimensions for tensors with rank > 4 {}",
+            first_pad_idx);
+    }
+
+    if (input_tensor.layout() == ttnn::TILE_LAYOUT) {
+        return operations::experimental::quasar::detail::invoke_tile(
+            input_tensor, working_padding, value, use_multicore, memory_config_arg, sub_core_grids);
+    }
+    return operations::experimental::quasar::detail::invoke_rm(
+        input_tensor, working_padding, value, use_multicore, memory_config_arg, sub_core_grids);
+}
+
+ttnn::Tensor pad(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::SmallVector<std::array<uint32_t, 2>>& padding,
+    const float value,
+    const bool use_multicore,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
+    using PadSpecDim = operations::experimental::quasar::PadSpecDim;
+    ttnn::SmallVector<PadSpecDim> padding_impl;
+    std::transform(padding.begin(), padding.end(), std::back_inserter(padding_impl), [](auto& p) {
+        return PadSpecDim(p[0], p[1]);
+    });
+
+    return pad(input_tensor, padding_impl, value, use_multicore, memory_config_arg, sub_core_grids);
+}
+
+ttnn::Tensor pad(
+    const ttnn::Tensor& input_tensor,
+    const tt::tt_metal::Array4D& output_padded_shape,
+    const tt::tt_metal::Array4D& input_tensor_start,
+    const float value,
+    const bool use_multicore,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
+    using PadSpecDim = operations::experimental::quasar::PadSpecDim;
+    ttnn::SmallVector<PadSpecDim> padding_impl;
+    const auto& log_shape = input_tensor.logical_shape();
+    for (uint32_t i = 0; i < output_padded_shape.size(); ++i) {
+        padding_impl.emplace_back(
+            input_tensor_start.at(i), output_padded_shape.at(i) - log_shape[i] - input_tensor_start.at(i));
+    }
+
+    return pad(input_tensor, padding_impl, value, use_multicore, memory_config_arg, sub_core_grids);
+}
+
+}  // namespace ttnn::operations::experimental::quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/pad.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/pad.hpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/types.hpp"
+#include <ranges>
+#include <tt-metalium/core_coord.hpp>
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::experimental::quasar {
+
+struct PadSpecDim {
+    uint32_t before_elements;
+    uint32_t after_elements;
+};
+
+// This function signature is similar to pytorch's signature
+// Any rank tensor supported
+//
+// use_multicore defaults to true here to match the Python binding's default
+// (pad_nanobind.cpp). Aligned defaults prevent callers from silently routing
+// to a different code path than Python-driven tests cover.
+ttnn::Tensor pad(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::SmallVector<PadSpecDim>& padding,
+    float value,
+    bool use_multicore = true,
+    const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+
+ttnn::Tensor pad(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::SmallVector<std::array<uint32_t, 2>>& padding,
+    float value,
+    bool use_multicore = true,
+    const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+
+// legacy API
+ttnn::Tensor pad(
+    const ttnn::Tensor& input_tensor,
+    const tt::tt_metal::Array4D& output_padded_shape,
+    const tt::tt_metal::Array4D& input_tensor_start,
+    float value,
+    bool use_multicore = true,
+    const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+
+}  // namespace ttnn::operations::experimental::quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/pad_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/pad_nanobind.cpp
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "pad_nanobind.hpp"
+
+#include <array>
+#include <cstdint>
+#include <optional>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/array.h>
+#include <nanobind/stl/optional.h>
+
+#include "ttnn-nanobind/small_vector_caster.hpp"
+#include "ttnn-nanobind/bind_function.hpp"
+
+#include "pad.hpp"
+
+namespace ttnn::operations::experimental::quasar::detail {
+
+void bind_pad(nb::module_& mod) {
+    const auto* doc = R"doc(
+        Returns a padded tensor, with a specified value at the specified location. If the input tensor is on host, the pad will be performed on host, and if its on device it will be performed on device.
+        Any rank of tensor is supported, however tensors with rank > 4 can only apply padding to the lower 3 dimensions.
+
+        Args:
+            * :attr:`input_tensor`: (ttnn.Tensor): the input tensor.
+            * :attr:`padding`: (list[Tuple[int,int]]): padding to apply. Each element of padding should be a tuple of 2 integers, with the first integer specifying the number of values to add before the tensor and the second integer specifying the number of values to add after the tensor. Mutually exclusive to output_tensor_shape and input_tensor_start.
+            * :attr:`value`: (Union[float,int]): value to pad with.
+
+        Keyword Args:
+            * :attr:`use_multicore`: (Optional[bool]) switch to use multicore implementation
+            * :attr:`memory_config`: (Optional[ttnn.MemoryConfig]): Memory configuration for the operation. Defaults to `None`.
+            * :attr:`sub_core_grids`: (Optional[ttnn.CoreRangeSet]): Sub core grids to run the operation on. Defaults to `None`.
+
+        Returns:
+            List of ttnn.Tensor: the output tensor.
+    )doc";
+
+    ttnn::bind_function<"pad">(
+        mod,
+        doc,
+        ttnn::overload_t(
+            nb::overload_cast<
+                const ttnn::Tensor&,
+                const ttnn::SmallVector<std::array<uint32_t, 2>>&,
+                float,
+                bool,
+                const std::optional<MemoryConfig>&,
+                const std::optional<CoreRangeSet>&>(&ttnn::operations::experimental::quasar::pad),
+            nb::arg("input_tensor"),
+            nb::arg("padding"),
+            nb::arg("value"),
+            nb::kw_only(),
+            nb::arg("use_multicore") = true,
+            nb::arg("memory_config") = nb::none(),
+            nb::arg("sub_core_grids") = nb::none()),
+        ttnn::overload_t(
+            nb::overload_cast<
+                const ttnn::Tensor&,
+                const tt::tt_metal::Array4D&,
+                const tt::tt_metal::Array4D&,
+                float,
+                bool,
+                const std::optional<MemoryConfig>&,
+                const std::optional<CoreRangeSet>&>(&ttnn::operations::experimental::quasar::pad),
+            nb::arg("input_tensor"),
+            nb::arg("output_padded_shape"),
+            nb::arg("input_tensor_start"),
+            nb::arg("value"),
+            nb::kw_only(),
+            nb::arg("use_multicore") = true,
+            nb::arg("memory_config") = nb::none(),
+            nb::arg("sub_core_grids") = nb::none()));
+}
+}  // namespace ttnn::operations::experimental::quasar::detail

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/pad_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/pad_nanobind.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::experimental::quasar::detail {
+
+namespace nb = nanobind;
+void bind_pad(nb::module_& mod);
+}  // namespace ttnn::operations::experimental::quasar::detail

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/compute/compute_mpwi.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/compute/compute_mpwi.cpp
@@ -1,0 +1,299 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cfloat>
+#include <cstdint>
+
+#include "api/compute/pack_untilize.h"
+#include "api/compute/reduce.h"
+#include "api/compute/tilize.h"
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/pack.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/add_int_sfpu.h"
+#include "api/compute/copy_dest_values.h"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
+
+#define DEBUG_PRINT 0
+
+#if DEBUG_PRINT == 1
+#include "api/debug/dprint.h"
+#include "api/debug/dprint_pages.h"
+#include "api/debug/dprint_tensix.h"
+#include "tools/profiler/kernel_profiler.hpp"
+#endif
+
+#define ALWI inline __attribute__((always_inline))
+
+#define FACE_HEIGHT 16
+#define FACE_WIDTH 16
+#define TILE_HEIGHT 32
+#define TILE_WIDTH 32
+
+#define MPWI_TILES_PER_REDUCTION 1
+
+void kernel_main() {
+    // NOTE: here it is assumed that in_ntiles_hw == 1. General cases not handled yet. When ntiles_hw > 1 the large
+    // kernel is called
+    constexpr uint32_t in_ntiles_c = get_compile_time_arg_val(0);
+    constexpr uint32_t window_size_hw = get_compile_time_arg_val(1);
+
+    constexpr uint32_t max_out_sticks_per_core = get_compile_time_arg_val(3);
+    constexpr uint32_t in_c = get_compile_time_arg_val(4);
+    constexpr uint32_t in_nblocks_c = get_compile_time_arg_val(5);
+    constexpr uint32_t max_sticks_for_reduction = get_compile_time_arg_val(6);
+
+    constexpr uint32_t in_cb_id_0 = get_compile_time_arg_val(7);
+    constexpr uint32_t in_scalar_cb_id_0 = get_compile_time_arg_val(9);
+    constexpr uint32_t out_cb_id = get_compile_time_arg_val(11);
+    constexpr bool one_scalar_per_core = get_compile_time_arg_val(12);
+    constexpr uint32_t pre_tilize_cb_id = get_compile_time_arg_val(13);
+    constexpr bool is_output_tiled = get_compile_time_arg_val(14);  // 1 = TILED, 0 = ROW_MAJOR
+    constexpr bool is_output_block_format = (bool)get_compile_time_arg_val(15);
+    // ct_arg(16) is force_max_tiles_per_reduction_4 (consumed by compute_pool_2d.cpp only)
+    // MPWI-specific args start here
+    constexpr uint32_t in_idx_cb_id = get_compile_time_arg_val(17);
+    constexpr uint32_t pack_tmp_cb_id = get_compile_time_arg_val(18);
+    constexpr uint32_t pack_idx_tmp_cb_id = get_compile_time_arg_val(19);
+    constexpr uint32_t right_inc_cb_id = get_compile_time_arg_val(20);
+    constexpr uint32_t down_left_wrap_inc_cb_id = get_compile_time_arg_val(21);
+    constexpr uint32_t up_left_wrap_inc_cb_id = get_compile_time_arg_val(22);
+    constexpr uint32_t out_idx_cb_id = get_compile_time_arg_val(23);
+    constexpr uint32_t stride_h = get_compile_time_arg_val(24);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(25);
+    constexpr uint32_t in_h_padded = get_compile_time_arg_val(26);
+    constexpr uint32_t in_w_padded = get_compile_time_arg_val(27);
+    constexpr uint32_t eff_kernel_h = get_compile_time_arg_val(28);
+    constexpr uint32_t eff_kernel_w = get_compile_time_arg_val(29);
+    constexpr uint32_t pad_l = get_compile_time_arg_val(30);
+    constexpr uint32_t intra_kernel_right_inc_cb_id = get_compile_time_arg_val(31);
+    constexpr uint32_t intra_kernel_down_left_wrap_inc_cb_id = get_compile_time_arg_val(32);
+    constexpr uint32_t compute_tmp_idx_cb_id = get_compile_time_arg_val(33);
+    constexpr uint32_t clear_value_cb_id = get_compile_time_arg_val(34);
+    constexpr uint32_t kernel_h = get_compile_time_arg_val(35);
+    constexpr uint32_t kernel_w = get_compile_time_arg_val(36);
+    constexpr uint32_t indexes_32_bit = get_compile_time_arg_val(37);
+
+    // experimental::CB wrappers for CB operations
+    experimental::CB in_scalar_cb(in_scalar_cb_id_0);
+    experimental::CB in_idx_cb(in_idx_cb_id);
+    experimental::CB pack_tmp_cb(pack_tmp_cb_id);
+    experimental::CB pack_idx_tmp_cb(pack_idx_tmp_cb_id);
+    experimental::CB right_inc_cb(right_inc_cb_id);
+    experimental::CB down_left_wrap_inc_cb(down_left_wrap_inc_cb_id);
+    experimental::CB up_left_wrap_inc_cb(up_left_wrap_inc_cb_id);
+    experimental::CB out_idx_cb(out_idx_cb_id);
+    experimental::CB intra_kernel_right_inc_cb(intra_kernel_right_inc_cb_id);
+    experimental::CB intra_kernel_down_left_wrap_inc_cb(intra_kernel_down_left_wrap_inc_cb_id);
+    experimental::CB compute_tmp_idx_cb(compute_tmp_idx_cb_id);
+    experimental::CB clear_value_cb(clear_value_cb_id);
+    experimental::CB in_cb_0(in_cb_id_0);
+
+    constexpr DataFormat copy_format = indexes_32_bit ? DataFormat::UInt32 : DataFormat::UInt16;
+
+    constexpr uint32_t mpwi_cb_tile_idx = 0;
+    constexpr uint32_t data_dst_idx = 0;
+    constexpr uint32_t data_accum_dst_idx = 1;
+    constexpr uint32_t index_dst_idx = 2;
+    constexpr uint32_t index_accum_dst_idx = 3;
+    constexpr uint32_t inc_dst_idx = 4;
+    constexpr uint32_t index_scratch_out_dst_idx = 6;
+    constexpr uint32_t index_temp_dst_idx = 5;  // only used for large kernels
+
+    constexpr uint32_t face_r_dim = FACE_HEIGHT;
+    constexpr bool last_tile_is_partial = in_c % TILE_WIDTH != 0;
+    constexpr uint32_t num_faces_in_input_tile = 4;
+    constexpr uint32_t num_faces_in_output_tile = 2;
+    constexpr uint32_t num_faces_in_last_output_tile = last_tile_is_partial && in_c % TILE_WIDTH <= FACE_WIDTH ? 1 : 2;
+    constexpr uint32_t num_out_sticks = 1;
+
+    // MPWI requires 1 tile at a time for max reduction with indices
+    constexpr bool is_large_kernel = window_size_hw > max_sticks_for_reduction;
+    constexpr uint32_t max_tiles_per_iter =
+        in_ntiles_c < MPWI_TILES_PER_REDUCTION ? in_ntiles_c : MPWI_TILES_PER_REDUCTION;
+    constexpr uint32_t partial_iter_output_tiles =
+        in_ntiles_c % MPWI_TILES_PER_REDUCTION == 0 ? max_tiles_per_iter : in_ntiles_c % MPWI_TILES_PER_REDUCTION;
+
+    static_assert(REDUCE_OP == PoolType::MAX, "MPWI only supports REDUCE_OP = MAX");
+
+    constexpr uint32_t w_chunks = kernel_w % max_sticks_for_reduction == 0 ? kernel_w / max_sticks_for_reduction
+                                                                           : kernel_w / max_sticks_for_reduction + 1;
+    constexpr uint32_t interm_reduction_chunks = is_large_kernel ? w_chunks * kernel_h : 1;
+
+    in_scalar_cb.wait_front(1);
+
+    uint32_t current_idx_col;
+    uint32_t current_idx_row;
+    const uint32_t start_row = get_arg_val<uint32_t>(2);
+    const uint32_t start_col = get_arg_val<uint32_t>(3);
+    current_idx_col = start_col;
+    current_idx_row = start_row;
+
+    constexpr uint32_t sticks_per_chunk = kernel_w <= max_sticks_for_reduction ? kernel_w : max_sticks_for_reduction;
+    right_inc_cb.wait_front(1);
+    down_left_wrap_inc_cb.wait_front(1);
+    up_left_wrap_inc_cb.wait_front(1);
+    if constexpr (is_large_kernel) {
+        intra_kernel_right_inc_cb.wait_front(1);
+        intra_kernel_down_left_wrap_inc_cb.wait_front(1);
+        clear_value_cb.wait_front(1);
+    }
+
+    unary_op_init_common(in_cb_id_0, in_cb_id_0);
+    max_reduce_with_indices_init<ckernel::DataLayout::ROW_MAJOR>();
+
+    // if max out sticks is non-zero then this will be used as the number of out sticks for every core
+    // otherwise the runtime args are referenced for core-specific number of out sticks, for Pool2D
+    // runtime args are used while for grid sample the max out sticks is set
+    uint32_t num_out_sticks_this_core = max_out_sticks_per_core ? max_out_sticks_per_core : get_arg_val<uint32_t>(0);
+
+    bool first_iteration = true;
+    for (uint32_t n = 0; n < num_out_sticks_this_core; ++n) {
+        for (uint32_t c_i = 0; c_i < in_nblocks_c; c_i++) {
+            const bool last_c_block = c_i == in_nblocks_c - 1;
+
+            tile_regs_acquire();
+            uint32_t intra_kernel_h = 0;
+            uint32_t intra_kernel_w = 0;
+            reconfig_data_format_srca(compute_tmp_idx_cb_id);
+            copy_tile_to_dst_init_short(compute_tmp_idx_cb_id);
+            if (first_iteration) {  // move the initial indexes from the reader to DST
+                in_idx_cb.wait_front(1);
+                copy_tile(in_idx_cb_id, mpwi_cb_tile_idx, index_dst_idx);
+                in_idx_cb.pop_front(1);
+                first_iteration = false;
+            } else {  // move incremented indexes from compute back to DST
+                compute_tmp_idx_cb.wait_front(1);
+                copy_tile(compute_tmp_idx_cb_id, mpwi_cb_tile_idx, index_dst_idx);
+                compute_tmp_idx_cb.pop_front(1);
+            }
+            if constexpr (is_large_kernel) {
+                // clear the accumulation tiles since they will contain garbage data which is partially loaded
+                // since max SFPU offset if 62 DST rows, but 4 rows are loaded each time so we load 2 rows of
+                // DST tiles 1 and 3 during the reduction of tiles 0 and 2
+                reconfig_data_format_srca(clear_value_cb_id);
+                copy_tile_to_dst_init_short(clear_value_cb_id);
+                copy_tile(clear_value_cb_id, mpwi_cb_tile_idx, data_accum_dst_idx);
+
+                // make a copy of the initial indexes to be used for restoring between C blocks
+                copy_dest_values<copy_format>(index_dst_idx, index_temp_dst_idx);
+            }
+
+            for (uint32_t chunk = 0; chunk < interm_reduction_chunks; chunk++) {
+                bool last_chunk = chunk == interm_reduction_chunks - 1;
+
+                in_cb_0.wait_front(1);
+                reconfig_data_format_srca(in_cb_id_0);
+                copy_tile_to_dst_init_short(in_cb_id_0);
+                copy_tile(in_cb_id_0, mpwi_cb_tile_idx, data_dst_idx);
+
+                // increments happen between every chunk within a C block, and between C blocks
+                bool increment_needed = false;
+                if (last_c_block && last_chunk) {  // increment for the next kernel position
+                    increment_needed = true;
+                    reconfig_data_format_srca(compute_tmp_idx_cb_id);
+                    copy_tile_to_dst_init_short(compute_tmp_idx_cb_id);
+                    // update the current index column
+                    if (current_idx_col + stride_w + eff_kernel_w > in_w_padded) {
+                        // we reached the right edge, wrap down and to the left
+                        current_idx_col = 0;
+                        if (current_idx_row + stride_h + eff_kernel_h > in_h_padded) {
+                            // we reached the bottom right corner, wrap to the top and to the left
+                            current_idx_row = 0;
+                            copy_tile(up_left_wrap_inc_cb_id, mpwi_cb_tile_idx, inc_dst_idx);
+                        } else {
+                            current_idx_row += stride_h;
+                            copy_tile(down_left_wrap_inc_cb_id, mpwi_cb_tile_idx, inc_dst_idx);
+                        }
+                    } else {
+                        // we are still in the same row, move to the right
+                        current_idx_col += stride_w;
+                        copy_tile(right_inc_cb_id, mpwi_cb_tile_idx, inc_dst_idx);
+                    }
+                } else if (is_large_kernel) {  // only need to increment within C block if multiple chunks
+                    if (!last_chunk) {         // increment for the next chunk within the same C block
+                        increment_needed = true;
+                        reconfig_data_format_srca(compute_tmp_idx_cb_id);
+                        copy_tile_to_dst_init_short(compute_tmp_idx_cb_id);
+                        if (intra_kernel_w + sticks_per_chunk < kernel_w) {  // move right in this row
+                            intra_kernel_w += sticks_per_chunk;
+                            copy_tile(intra_kernel_right_inc_cb_id, mpwi_cb_tile_idx, inc_dst_idx);
+                        } else {  // move down to the next row
+                            intra_kernel_w = 0;
+                            intra_kernel_h += 1;
+                            copy_tile(intra_kernel_down_left_wrap_inc_cb_id, mpwi_cb_tile_idx, inc_dst_idx);
+                        }
+                    }
+                }
+                if (!increment_needed) {
+                    copy_dest_values<copy_format>(index_dst_idx, index_scratch_out_dst_idx);
+                } else {
+                    // we allow overflow here for negative values as this only occurs in padding regions
+                    add_int_tile_init();
+                    add_int_tile<copy_format>(index_dst_idx, inc_dst_idx, index_scratch_out_dst_idx);
+                    max_reduce_with_indices_init<ckernel::DataLayout::ROW_MAJOR>();
+                }
+
+                // TODO implement accumulation for <=9 MPWI SFPU so we can use this version for large kernels as well
+                constexpr uint32_t max_mpwi_kernel_size = window_size_hw <= 9 ? 9 : 32;
+                max_reduce_with_indices<max_mpwi_kernel_size, ckernel::DataLayout::ROW_MAJOR, is_large_kernel>(
+                    data_dst_idx, index_dst_idx, chunk);
+
+                if constexpr (is_large_kernel) {
+                    if (!last_chunk) {
+                        copy_dest_values<copy_format>(index_scratch_out_dst_idx, index_dst_idx);
+                    }
+                }
+
+                in_cb_0.pop_front(1);
+            }
+
+            // After all chunks: if not last C block, restore base indices for next C block
+            if constexpr (is_large_kernel) {
+                if (!last_c_block) {
+                    copy_dest_values<copy_format>(index_temp_dst_idx, index_scratch_out_dst_idx);
+                }
+            }
+
+            tile_regs_commit();
+            tile_regs_wait();
+
+            pack_tmp_cb.reserve_back(1);
+            pack_reconfig_data_format(pack_tmp_cb_id);
+            pack_tile<true>(data_dst_idx, pack_tmp_cb_id, mpwi_cb_tile_idx);  // for reader (output data)
+            pack_tmp_cb.push_back(1);
+
+            pack_idx_tmp_cb.reserve_back(1);
+            pack_reconfig_data_format(pack_idx_tmp_cb_id);
+            pack_tile<true>(index_dst_idx, pack_idx_tmp_cb_id, mpwi_cb_tile_idx);  // for reader (output indexes)
+            pack_idx_tmp_cb.push_back(1);
+
+            // Only push to compute_tmp_idx_cb_id if there's a next iteration that will consume it
+            // This prevents leaving stale data in the CB between program runs when using caching
+            bool is_last_iteration = (n == num_out_sticks_this_core - 1) && last_c_block;
+            if (!is_last_iteration) {
+                compute_tmp_idx_cb.reserve_back(1);
+                pack_reconfig_data_format(compute_tmp_idx_cb_id);
+                pack_tile<true>(
+                    index_scratch_out_dst_idx,
+                    compute_tmp_idx_cb_id,
+                    mpwi_cb_tile_idx);  // for compute (incremented indexes)
+                compute_tmp_idx_cb.push_back(1);
+            }
+
+            tile_regs_release();
+        }
+    }
+
+    // This prevents leaving stale data in the CB between program runs when using caching
+    in_scalar_cb.pop_front(1);
+    right_inc_cb.pop_front(1);
+    down_left_wrap_inc_cb.pop_front(1);
+    up_left_wrap_inc_cb.pop_front(1);
+    if constexpr (is_large_kernel) {
+        intra_kernel_right_inc_cb.pop_front(1);
+        intra_kernel_down_left_wrap_inc_cb.pop_front(1);
+        clear_value_cb.pop_front(1);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/compute/compute_pool_2d.cpp
@@ -1,0 +1,264 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/pack_untilize.h"
+#include "api/compute/reduce.h"
+#include "api/compute/tilize.h"
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/pack.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/add_int_sfpu.h"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
+
+#define DEBUG_PRINT 0
+
+#if DEBUG_PRINT == 1
+#include "api/debug/dprint.h"
+#include "api/debug/dprint_pages.h"
+#include "api/debug/dprint_tensix.h"
+#include "tools/profiler/kernel_profiler.hpp"
+#endif
+
+#define ALWI inline __attribute__((always_inline))
+
+#define FACE_HEIGHT 16
+#define FACE_WIDTH 16
+#define TILE_HEIGHT 32
+#define TILE_WIDTH 32
+
+void kernel_main() {
+    // NOTE: here it is assumed that in_ntiles_hw == 1. General cases not handled yet. When ntiles_hw > 1 the large
+    // kernel is called
+    constexpr uint32_t in_ntiles_c = get_compile_time_arg_val(0);
+    constexpr uint32_t window_size_hw = get_compile_time_arg_val(1);
+
+    constexpr uint32_t split_reader = get_compile_time_arg_val(2);
+
+    constexpr uint32_t max_out_sticks_per_core = get_compile_time_arg_val(3);
+    constexpr uint32_t in_c = get_compile_time_arg_val(4);
+    constexpr uint32_t in_nblocks_c = get_compile_time_arg_val(5);
+    constexpr uint32_t max_sticks_for_reduction = get_compile_time_arg_val(6);
+
+    constexpr uint32_t in_cb_id_0 = get_compile_time_arg_val(7);
+    constexpr uint32_t in_cb_id_1 = get_compile_time_arg_val(8);  // for split reader
+    constexpr uint32_t in_scalar_cb_id_0 = get_compile_time_arg_val(9);
+    constexpr uint32_t in_scalar_cb_id_1 = get_compile_time_arg_val(10);
+    constexpr uint32_t out_cb_id = get_compile_time_arg_val(11);
+    constexpr bool one_scalar_per_core = get_compile_time_arg_val(12);
+    constexpr uint32_t pre_tilize_cb_id = get_compile_time_arg_val(13);
+    constexpr bool is_output_tiled = get_compile_time_arg_val(14);  // 1 = TILED, 0 = ROW_MAJOR
+    constexpr bool is_output_block_format = (bool)get_compile_time_arg_val(15);
+    // fast_tilize_cb_id is a consumer-view alias of pre_tilize_cb_id (same L1 region,
+    // full-tile face_geometry = {face_r_dim=16, num_faces=4}). Used as the input operand
+    // to fast_tilize so the unpacker/math read the correct face count from CB metadata.
+    constexpr uint32_t fast_tilize_cb_id = get_compile_time_arg_val(38);
+
+    constexpr bool use_split_reader = split_reader;
+
+    constexpr bool last_tile_is_partial = in_c % TILE_WIDTH != 0;
+    constexpr uint32_t num_faces_in_input_tile =
+        (max_sticks_for_reduction < TILE_HEIGHT || window_size_hw <= FACE_HEIGHT) ? 2 : 4;
+    // "Single partial tile per core that fits in one face": when there is only one output tile
+    // per core (in_c < TILE_WIDTH) and it fits in a single face (in_c <= FACE_WIDTH), pack just
+    // one face for that tile. The host correspondingly aligns output_shard_width to FACE_WIDTH,
+    // so the per-shard layout has no internal padding and downstream consumers (e.g.
+    // sharded_to_interleaved) read contiguous data.
+    constexpr bool single_partial_fits_in_face = last_tile_is_partial && in_c <= FACE_WIDTH;
+    constexpr uint32_t num_faces_in_output_tile = single_partial_fits_in_face ? 1 : 2;
+    // When the last tile has exactly FACE_WIDTH valid channels (channels % 32 == 16) OR the only
+    // tile is partial-fits-in-one-face, pack 1 face for the last tile.
+    constexpr uint32_t num_faces_in_last_output_tile =
+        last_tile_is_partial && (in_c % TILE_WIDTH == FACE_WIDTH || single_partial_fits_in_face) ? 1 : 2;
+
+    constexpr bool is_avg_pool = REDUCE_OP == PoolType::AVG;
+    // average pool with large kernels requires fp32 accumulation so we can only reduce 4 tiles at a time,
+    // otherwise we can reduce 8 tiles at a time. Callers (e.g. grid_sample under fp32_dest_acc_en) can
+    // also force the 4-tile limit via ct_arg[16] so each chunk fits in half-sync DEST (= 4 fp32 tiles)
+    // without forcing dst_full_sync_en.
+    constexpr bool is_large_kernel = window_size_hw > max_sticks_for_reduction;
+    constexpr bool force_max_tiles_per_reduction_4 = get_compile_time_arg_val(16);
+    constexpr uint32_t MAX_TILES_PER_REDUCTION =
+        (force_max_tiles_per_reduction_4 || (is_avg_pool && is_large_kernel)) ? 4 : 8;
+    constexpr uint32_t max_tiles_per_iter =
+        in_ntiles_c < MAX_TILES_PER_REDUCTION ? in_ntiles_c : MAX_TILES_PER_REDUCTION;
+    constexpr uint32_t partial_iter_output_tiles =
+        in_ntiles_c % MAX_TILES_PER_REDUCTION == 0 ? max_tiles_per_iter : in_ntiles_c % MAX_TILES_PER_REDUCTION;
+
+    static_assert(REDUCE_OP == PoolType::MAX || REDUCE_OP == PoolType::AVG, "Only supports REDUCE_OP = MAX or AVG");
+    constexpr bool neginf_srca_maxpool = (REDUCE_OP == PoolType::MAX) ? true : false;
+    constexpr bool zero_srca_avgpool = (REDUCE_OP == PoolType::AVG) ? true : false;
+
+    // tilize reconfiguration can be beneficial when we have a wide tensor with a non MAX_TILES_PER_REDUCTION number of
+    // C tiles, but we only use it when the window size fits within a face such that the tilize can be done only on the
+    // rows populated with data, otherwise we need to call clear_out_tiles between reconfigs to avoid untilizing junk
+    // data which is much slower than just untilizing the entire MAX_TILES_PER_REDUCTION
+    constexpr bool tilize_reconfig = in_nblocks_c > 1 && in_ntiles_c % MAX_TILES_PER_REDUCTION != 0 &&
+                                     window_size_hw <= FACE_HEIGHT && !last_tile_is_partial;
+
+    constexpr uint32_t tilize_untilize_cb = is_output_tiled ? pre_tilize_cb_id : out_cb_id;
+
+    experimental::CB in_scalar_cb_0(in_scalar_cb_id_0);
+    experimental::CB in_scalar_cb_1(in_scalar_cb_id_1);
+    experimental::CB in_cb_0(in_cb_id_0);
+    experimental::CB in_cb_1(in_cb_id_1);
+    experimental::CB out_cb(out_cb_id);
+    experimental::CB pre_tilize_cb(pre_tilize_cb_id);
+    experimental::CB fast_tilize_cb(fast_tilize_cb_id);
+
+    tilizeA_B_reduce_init<neginf_srca_maxpool, zero_srca_avgpool>(
+        in_cb_id_0, in_scalar_cb_id_0, max_tiles_per_iter, tilize_untilize_cb);
+
+    pack_untilize_dest_init<max_tiles_per_iter>(tilize_untilize_cb);
+
+    constexpr uint32_t remaining_elems = window_size_hw % max_sticks_for_reduction;
+    constexpr uint32_t interm_reduction_chunks =
+        remaining_elems ? window_size_hw / max_sticks_for_reduction + 1 : window_size_hw / max_sticks_for_reduction;
+
+    // wait for initialization to complete
+    if constexpr (one_scalar_per_core) {
+        in_scalar_cb_0.wait_front(1);
+    }
+
+    // if max out sticks is non-zero then this will be used as the number of out sticks for every core
+    // otherwise the runtime args are referenced for core-specific number of out sticks, for Pool2D
+    // runtime args are used while for grid sample the max out sticks is set
+    uint32_t num_out_sticks_this_core = max_out_sticks_per_core ? max_out_sticks_per_core : get_arg_val<uint32_t>(0);
+    uint32_t last_tile_height =
+        num_out_sticks_this_core % TILE_HEIGHT == 0 ? TILE_HEIGHT : num_out_sticks_this_core % TILE_HEIGHT;
+
+    uint32_t tilize_stick_counter = 0;
+    uint32_t tilize_stick_total = 0;
+    for (uint32_t n = 0; n < num_out_sticks_this_core; ++n) {
+        const bool reader0 = !(use_split_reader && (n & 0x1));
+        const bool use_reader1_scalar = !reader0 && !one_scalar_per_core;
+        const uint32_t curr_scalar_cb_id = use_reader1_scalar ? in_scalar_cb_id_1 : in_scalar_cb_id_0;
+        const uint32_t curr_in_cb_id = !reader0 ? in_cb_id_1 : in_cb_id_0;
+        experimental::CB curr_scalar_cb = use_reader1_scalar ? in_scalar_cb_1 : in_scalar_cb_0;
+        experimental::CB curr_in_cb = reader0 ? in_cb_0 : in_cb_1;
+        if constexpr (!one_scalar_per_core) {
+            curr_scalar_cb.wait_front(1);
+        }
+        if (is_output_tiled && !tilize_stick_counter) {
+            out_cb.reserve_back(in_ntiles_c);
+        }
+        for (uint32_t c_i = 0; c_i < in_nblocks_c; c_i++) {
+            const bool last_c_block = c_i == in_nblocks_c - 1;
+            const bool first_c_block = c_i == 0;
+            const uint32_t tiles_to_reduce =
+                tilize_reconfig ? (last_c_block ? partial_iter_output_tiles : max_tiles_per_iter) : max_tiles_per_iter;
+            const uint32_t number_of_tiles = last_c_block ? partial_iter_output_tiles : max_tiles_per_iter;
+            const uint32_t output_faces =
+                (last_tile_is_partial && last_c_block &&
+                 (in_c % TILE_WIDTH == FACE_WIDTH || single_partial_fits_in_face))
+                    ? (number_of_tiles - 1) * num_faces_in_output_tile + num_faces_in_last_output_tile
+                    : number_of_tiles * num_faces_in_output_tile;
+            if constexpr (!is_output_tiled) {
+                out_cb.reserve_back(output_faces);
+            }
+            if constexpr (tilize_reconfig) {
+                if (first_c_block || last_c_block) {
+                    UNPACK((llk_unpack_tilizeA_B_init<neginf_srca_maxpool, true, false, zero_srca_avgpool>(
+                        in_cb_id_0, in_scalar_cb_id_0, tiles_to_reduce)));
+                }
+            }
+            tile_regs_acquire();
+            for (uint32_t chunk = 0; chunk < interm_reduction_chunks; chunk++) {
+                curr_in_cb.wait_front(1);
+                unpack_tilizeA_B_block<neginf_srca_maxpool, true, false, zero_srca_avgpool>(
+                    curr_in_cb_id,
+                    curr_scalar_cb_id,
+                    tiles_to_reduce,
+                    0 /*tile idx for Src b is 0 because only 1 tile of constants is loaded*/);
+                for (uint32_t math_tile_idx = 0; math_tile_idx < tiles_to_reduce; ++math_tile_idx) {
+                    reduce_tile_math<REDUCE_OP, REDUCE_DIM>(math_tile_idx, num_faces_in_input_tile);
+                }
+                curr_in_cb.pop_front(1);
+            }
+            tile_regs_commit();
+            tile_regs_wait();
+            if constexpr (is_output_tiled) {
+                // TILED output: accumulate sticks and perform tilization when needed
+                if (last_c_block) {
+                    pack_untilize_dest<partial_iter_output_tiles>(pre_tilize_cb_id, 1, 0);
+                    pre_tilize_cb.push_back(partial_iter_output_tiles);
+                    tilize_stick_counter++;
+                    tilize_stick_total++;
+                } else {
+                    pack_untilize_dest<max_tiles_per_iter>(pre_tilize_cb_id, 1, 0);
+                    pre_tilize_cb.push_back(max_tiles_per_iter);
+                }
+                tile_regs_release();
+
+                bool last_tile = num_out_sticks_this_core - tilize_stick_total < last_tile_height;
+                if (tilize_stick_counter == TILE_HEIGHT || (last_tile && tilize_stick_counter == last_tile_height)) {
+                    if (last_tile && last_tile_height != TILE_HEIGHT) {
+                        pre_tilize_cb.wait_front(last_tile_height * in_ntiles_c);
+                        // if the last tile is not whole we won't have pushed enough sticks, so we need to
+                        // push some filler sticks to reach TILE_HEIGHT to make sure the CB pointers are correct
+                        // before calling tilize
+                        uint32_t filler_stick_tiles =
+                            (TILE_HEIGHT - last_tile_height) *
+                            ((in_nblocks_c - 1) * max_tiles_per_iter + partial_iter_output_tiles);
+                        pre_tilize_cb.push_back(filler_stick_tiles);
+                    }
+                    PACK((pack_untilize_uninit(pre_tilize_cb_id)));
+
+                    unpack_tilizeA_B_uninit(curr_in_cb_id);
+                    pack_reconfig_data_format(out_cb_id);
+
+                    // Hand the freshly-written L1 region off to the consumer view of the
+                    // multi-format CB. pre_tilize_cb_id was pushed in TILE_HEIGHT*in_ntiles_c
+                    // stick-pages (page_size = TILE_WIDTH*nbytes); fast_tilize_cb_id sees the
+                    // same bytes as in_ntiles_c full tiles (page_size = tile_size). Both views
+                    // advance by the same number of bytes per round so their rd/wr pointers
+                    // stay aligned. The producer-view wait_front/pop_front/reserve_back below
+                    // continues to drive the producer pointer ledger.
+                    fast_tilize_cb.push_back(in_ntiles_c);
+                    fast_tilize_cb.wait_front(in_ntiles_c);
+
+                    fast_tilize_init(fast_tilize_cb_id, in_ntiles_c, out_cb_id);
+                    fast_tilize_block(fast_tilize_cb_id, in_ntiles_c, out_cb_id);
+                    fast_tilize_uninit(fast_tilize_cb_id, out_cb_id, in_ntiles_c);
+
+                    out_cb.push_back(in_ntiles_c);
+                    fast_tilize_cb.pop_front(in_ntiles_c);
+                    fast_tilize_cb.reserve_back(in_ntiles_c);
+                    pre_tilize_cb.pop_front(TILE_HEIGHT * in_ntiles_c);
+                    pre_tilize_cb.reserve_back(TILE_HEIGHT * in_ntiles_c);
+
+                    tilize_stick_counter = 0;
+
+                    UNPACK((llk_unpack_tilizeA_B_init<neginf_srca_maxpool, true, false, zero_srca_avgpool>(
+                        in_cb_id_0, in_scalar_cb_id_0, tiles_to_reduce)));
+                    // init math for reduction again since FPU gets reprogrammed by tilize
+                    MATH((llk_math_reduce_init<REDUCE_OP, REDUCE_DIM, DST_ACCUM_MODE, MATH_FIDELITY>()));
+#ifdef ARCH_BLACKHOLE
+                    // need this on BH to set swizzle bit before pack untilize dest
+                    MATH((llk_math_reconfig_remap(true)));
+#endif
+
+                    if constexpr (is_output_block_format) {
+                        pack_reconfig_data_format(pre_tilize_cb_id);
+                    }
+                    PACK((llk_pack_untilize_init<max_tiles_per_iter, max_tiles_per_iter, false, false, TILE_C_DIM>(
+                        pre_tilize_cb_id)));
+                }
+            } else {
+                // ROW_MAJOR output: pack directly to output CB
+                if (last_c_block) {
+                    pack_untilize_dest<partial_iter_output_tiles>(out_cb_id, 1, 0);
+                } else {
+                    pack_untilize_dest<max_tiles_per_iter>(out_cb_id, 1, 0);
+                }
+                out_cb.push_back(output_faces);
+                tile_regs_release();
+            }
+        }
+        if constexpr (!one_scalar_per_core) {
+            curr_scalar_cb.pop_front(1);
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/dataflow/reader_mpwi.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/dataflow/reader_mpwi.cpp
@@ -1,0 +1,541 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <sys/types.h>
+
+#include <cstdint>
+#include <api/dataflow/dataflow_api.h>
+#include <ttnn/cpp/ttnn/operations/pool/device/kernels/pool_kernels_common.hpp>
+
+#define ENABLE_DEBUG_PRINT 0
+
+#if ENABLE_DEBUG_PRINT == 1
+#include "api/debug/dprint.h"
+#include "api/debug/dprint_pages.h"
+#endif
+
+template <bool B>
+struct IndexType;
+
+template <>
+struct IndexType<true> {
+    using type = uint32_t;
+};
+
+template <>
+struct IndexType<false> {
+    using type = uint16_t;
+};
+
+template <
+    typename IndexType,
+    uint32_t kernel_h,
+    uint32_t kernel_w,
+    uint32_t fill_c,
+    uint32_t column_stride,
+    uint32_t row_stride,
+    bool is_large_kernel,
+    uint32_t sticks_per_chunk,
+    uint32_t in_idx_cb_id>
+void fill_indexes(uint32_t init_index) {
+    experimental::CB idx_cb(in_idx_cb_id);
+    volatile tt_l1_ptr IndexType* idx_ptr = reinterpret_cast<volatile tt_l1_ptr IndexType*>(idx_cb.get_write_ptr());
+    uint32_t kernel_idx = 0;
+
+    for (uint32_t h = 0; h < kernel_h; ++h) {
+        uint32_t hw = h * kernel_w;
+        for (uint32_t w = 0; w < kernel_w; ++w, ++hw) {
+            if (!is_large_kernel || hw < sticks_per_chunk) {
+                volatile tt_l1_ptr IndexType* base_ptr = &idx_ptr[hw * TILE_WIDTH];
+                IndexType index = static_cast<IndexType>(init_index + kernel_idx);
+
+                for (uint32_t c = 0; c < fill_c; ++c) {
+                    base_ptr[c] = index;
+                }
+            }
+            kernel_idx += column_stride;
+        }
+        kernel_idx += row_stride;
+    }
+}
+
+// Initialize indices and increment tiles for return_indices functionality
+template <
+    uint32_t kernel_h,
+    uint32_t kernel_w,
+    uint32_t in_w,
+    uint32_t in_c,
+    uint32_t pad_t,
+    uint32_t pad_l,
+    uint32_t dilation_h,
+    uint32_t dilation_w,
+    bool is_large_kernel,
+    uint32_t sticks_per_chunk,
+    uint32_t right_inc,
+    uint32_t down_left_wrap_inc,
+    uint32_t up_left_wrap_inc,
+    uint32_t intra_kernel_right_inc,
+    uint32_t intra_kernel_down_left_wrap_inc,
+    uint32_t in_idx_cb_id,
+    uint32_t right_inc_cb_id,
+    uint32_t down_left_wrap_inc_cb_id,
+    uint32_t up_left_wrap_inc_cb_id,
+    uint32_t intra_kernel_right_inc_cb_id,
+    uint32_t intra_kernel_down_left_wrap_inc_cb_id,
+    bool indexes_32_bit>
+ALWI void initialize_return_indices_data() {
+    // since kernels can start in padded regions we need to have "indexes" in these regions
+    // we choose a paradigm where we padding indexes must satisfy the following conditions:
+    //   1. they are 1 less than the index to the right (whether it's padding or not)
+    //   2. they are in_w less than the index below (whether it's padding or not)
+    // this results in repeat indexes, negative indexes and other such effects, but since
+    // padding is never chosen as a max index, validity of the padding index is unimportant
+    // we only care that when they are incremented they result in the correct index which
+    // this paradigm guarantees
+    // Note we also use unsigned integers and allow wrapping for negatives to preserve range
+    // and since all negative values correspond to padding indexes which will never be a max
+
+    // Calculate initial index based on padding conditions
+    uint32_t init_index = 0;
+    constexpr uint32_t window_size_hw = kernel_h * kernel_w;
+    constexpr uint32_t eff_kernel_w = (kernel_w - 1) * dilation_w + 1;
+    const uint32_t start_row = get_arg_val<uint32_t>(2);
+    const uint32_t start_col = get_arg_val<uint32_t>(3);
+
+    if (start_row <= pad_t) {
+        // top left is in top padding, we increment from the padding index in the top left
+        // of the padded tensor
+        uint32_t global_top_left_pad_idx = -pad_l - pad_t * in_w;
+        init_index = global_top_left_pad_idx + start_col + start_row * in_w;
+    } else if (start_col <= pad_l) {
+        // top left is in left padding, we increment from the padding index in the leftmost
+        // column of the starting row of the padded tensor
+        uint32_t leftmost_valid_index = (start_row - pad_t) * in_w;
+        uint32_t start_row_left_pad_idx = leftmost_valid_index - pad_l;
+        init_index = start_row_left_pad_idx + start_col;
+    } else {
+        // top left is in valid region, we choose the valid index
+        init_index = (start_row - pad_t) * in_w + (start_col - pad_l);
+    }
+
+    constexpr uint32_t fill_c = in_c <= TILE_WIDTH ? in_c : TILE_WIDTH;
+    constexpr uint32_t fill_c_32_bit = fill_c % 2 == 0 ? fill_c / 2 : (fill_c / 2) + 1;
+    constexpr uint32_t HALF_TILE_WIDTH = TILE_WIDTH / 2;
+    constexpr uint32_t column_stride = dilation_w;
+    constexpr uint32_t row_stride = dilation_h * in_w - eff_kernel_w - (dilation_w - 1);
+
+    // initialize the index CB
+    experimental::CB idx_cb(in_idx_cb_id);
+    idx_cb.reserve_back(1);
+    fill_indexes<
+        typename IndexType<indexes_32_bit>::type,
+        kernel_h,
+        kernel_w,
+        fill_c,
+        column_stride,
+        row_stride,
+        is_large_kernel,
+        sticks_per_chunk,
+        in_idx_cb_id>(init_index);
+    idx_cb.push_back(1);
+
+    // initialize the increment CBs
+    // TODO we used to fill the 16 bit values two at a time, but this technically resulted in overflow with odd
+    // c dimensions so for now we do it one at a time for both 16 and 32 bit indexes
+    if constexpr (indexes_32_bit) {
+        auto fill_inc_32 = [&](experimental::CB& inc_cb, uint32_t inc) __attribute__((always_inline)) {
+            volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(inc_cb.get_write_ptr());
+            for (uint32_t k = 0; k < window_size_hw; ++k) {
+                for (uint32_t c = 0; c < fill_c; ++c) {
+                    ptr[k * TILE_WIDTH + c] = inc;
+                }
+            }
+        };
+
+        experimental::CB right_inc_cb(right_inc_cb_id);
+        right_inc_cb.reserve_back(1);
+        fill_inc_32(right_inc_cb, right_inc);
+        right_inc_cb.push_back(1);
+
+        experimental::CB down_left_wrap_inc_cb(down_left_wrap_inc_cb_id);
+        down_left_wrap_inc_cb.reserve_back(1);
+        fill_inc_32(down_left_wrap_inc_cb, down_left_wrap_inc);
+        down_left_wrap_inc_cb.push_back(1);
+
+        experimental::CB up_left_wrap_inc_cb(up_left_wrap_inc_cb_id);
+        up_left_wrap_inc_cb.reserve_back(1);
+        fill_inc_32(up_left_wrap_inc_cb, up_left_wrap_inc);
+        up_left_wrap_inc_cb.push_back(1);
+
+        if constexpr (is_large_kernel) {
+            experimental::CB intra_kernel_right_inc_cb(intra_kernel_right_inc_cb_id);
+            intra_kernel_right_inc_cb.reserve_back(1);
+            fill_inc_32(intra_kernel_right_inc_cb, intra_kernel_right_inc);
+            intra_kernel_right_inc_cb.push_back(1);
+
+            experimental::CB intra_kernel_down_left_wrap_inc_cb(intra_kernel_down_left_wrap_inc_cb_id);
+            intra_kernel_down_left_wrap_inc_cb.reserve_back(1);
+            fill_inc_32(intra_kernel_down_left_wrap_inc_cb, intra_kernel_down_left_wrap_inc);
+            intra_kernel_down_left_wrap_inc_cb.push_back(1);
+        }
+    } else {
+        auto fill_inc = [&](experimental::CB& inc_cb, uint32_t inc) __attribute__((always_inline)) {
+            uint16_t inc_16 = (uint16_t)inc;
+            uint32_t inc_32_bit = (uint32_t)inc_16 | ((uint32_t)inc_16 << 16);
+            volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(inc_cb.get_write_ptr());
+            for (uint32_t k = 0; k < window_size_hw; ++k) {
+                for (uint32_t c = 0; c < fill_c_32_bit; ++c) {
+                    ptr[k * HALF_TILE_WIDTH + c] = inc_32_bit;
+                }
+            }
+        };
+
+        experimental::CB right_inc_cb(right_inc_cb_id);
+        right_inc_cb.reserve_back(1);
+        fill_inc(right_inc_cb, right_inc);
+        right_inc_cb.push_back(1);
+
+        experimental::CB down_left_wrap_inc_cb(down_left_wrap_inc_cb_id);
+        down_left_wrap_inc_cb.reserve_back(1);
+        fill_inc(down_left_wrap_inc_cb, down_left_wrap_inc);
+        down_left_wrap_inc_cb.push_back(1);
+
+        experimental::CB up_left_wrap_inc_cb(up_left_wrap_inc_cb_id);
+        up_left_wrap_inc_cb.reserve_back(1);
+        fill_inc(up_left_wrap_inc_cb, up_left_wrap_inc);
+        up_left_wrap_inc_cb.push_back(1);
+
+        if constexpr (is_large_kernel) {
+            experimental::CB intra_kernel_right_inc_cb(intra_kernel_right_inc_cb_id);
+            intra_kernel_right_inc_cb.reserve_back(1);
+            fill_inc(intra_kernel_right_inc_cb, intra_kernel_right_inc);
+            intra_kernel_right_inc_cb.push_back(1);
+
+            experimental::CB intra_kernel_down_left_wrap_inc_cb(intra_kernel_down_left_wrap_inc_cb_id);
+            intra_kernel_down_left_wrap_inc_cb.reserve_back(1);
+            fill_inc(intra_kernel_down_left_wrap_inc_cb, intra_kernel_down_left_wrap_inc);
+            intra_kernel_down_left_wrap_inc_cb.push_back(1);
+        }
+    }
+}
+
+// Read kernel data for MPWI (Max Pool With Indices)
+// This handles reading input data and managing index tracking for max pooling with index output
+template <
+    uint32_t in_nblocks_c,
+    uint32_t in_cb_id,
+    uint32_t kernel_h,
+    uint32_t kernel_w,
+    uint32_t in_w_padded,
+    uint32_t in_nbytes_leftover,
+    uint32_t in_c,
+    uint32_t sticks_per_chunk,
+    uint32_t total_elems_to_reduce,
+    bool wide_reduction,
+    uint32_t clear_value_cb_id,
+    uint32_t in_cb_ntiles,
+    uint32_t in_nbytes_c,
+    uint32_t shard_width_bytes,
+    bool is_large_kernel,
+    bool last_tile_is_partial,
+    uint32_t dilation_h,
+    uint32_t dilation_w,
+    bool zero_pages,
+    uint32_t out_cb_id,
+    uint32_t out_idx_cb_id,
+    uint32_t reader_id,
+    uint32_t pack_tmp_cb_id,
+    uint32_t pack_idx_tmp_cb_id,
+    uint32_t indexes_32_bit>
+ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base_addr) {
+    constexpr uint32_t BYTES_PER_ELEM = 2;
+    // MPWI requires 1 tile at a time for max reduction with indices
+    constexpr uint32_t MAX_TILES_PER_REDUCTION = 1;
+    constexpr uint32_t MAX_BYTES_PER_REDUCTION = MAX_TILES_PER_REDUCTION * TILE_WIDTH * BYTES_PER_ELEM;
+    constexpr uint32_t in_ntiles_c = (in_c + TILE_WIDTH - 1) / TILE_WIDTH;
+    static_assert(MAX_TILES_PER_REDUCTION == 1, "MAX_TILES_PER_REDUCTION must be 1 for MPWI");
+    constexpr uint32_t max_write_inc = TILE_WIDTH * BYTES_PER_ELEM;
+
+    experimental::CB in_cb(in_cb_id);
+    experimental::CB out_cb(out_cb_id);
+    experimental::CB out_idx_cb(out_idx_cb_id);
+    experimental::CB pack_tmp_cb(pack_tmp_cb_id);
+    experimental::CB pack_idx_tmp_cb(pack_idx_tmp_cb_id);
+    Noc noc;
+    UnicastEndpoint self_ep;
+
+    for (uint32_t c_i = 0; c_i < in_nblocks_c; c_i++) {
+        uint32_t read_bytes = in_nbytes_c;
+        if constexpr (wide_reduction) {
+            read_bytes =
+                (c_i == in_nblocks_c - 1) ? in_nbytes_c - c_i * MAX_BYTES_PER_REDUCTION : MAX_BYTES_PER_REDUCTION;
+        }
+
+        uint32_t write_offset = 0;
+        if constexpr (reader_id == 0) {
+            in_cb.reserve_back(1);
+        }
+        // page zeroing is only necessary for tiled block output format so that scale is not affected by
+        // junk/padding data
+        if constexpr (zero_pages && reader_id == 0) {
+            if (c_i == in_nblocks_c - 1 && last_tile_is_partial) {
+                zero_out_page(noc, in_cb);
+            }
+        }
+        for (uint32_t h = 0; h < kernel_h; ++h) {
+            auto process_h = [&](uint32_t w, uint32_t w_multiple) __attribute__((always_inline)) {
+                uint32_t w_offset = w * dilation_w;
+                if constexpr (reader_id == 0) {
+                    const uint32_t stick_offset = ind + w_offset + h * dilation_h * in_w_padded;
+                    const uint32_t read_offset =
+                        in_l1_read_base_addr + (stick_offset * shard_width_bytes + c_i * MAX_BYTES_PER_REDUCTION);
+                    noc.async_read(
+                        self_ep,
+                        in_cb,
+                        read_bytes * w_multiple,
+                        experimental::local_addr(read_offset),
+                        {.offset_bytes = write_offset});
+                    write_offset += max_write_inc * w_multiple;
+                }
+                bool kernel_complete = h == kernel_h - 1 && w == kernel_w - 1;
+                bool push_chunk =
+                    kernel_complete || (is_large_kernel && ((w + 1) % sticks_per_chunk == 0 || w == (kernel_w - 1)));
+                if (push_chunk) {
+                    if constexpr (reader_id == 0) {  // push a chunk
+                        noc.async_read_barrier();
+                        in_cb.push_back(1);
+                        if (!kernel_complete) {
+                            in_cb.reserve_back(1);
+                            write_offset = 0;
+                        }
+                    } else {
+                        if (kernel_complete) {  // write output once all chunks are done
+                            // Mirror compute_pool_2d.cpp: pack 1 face for "single partial tile
+                            // fits in one face" or "last tile has exactly FACE_WIDTH valid".
+                            constexpr bool single_partial_fits_in_face = last_tile_is_partial && in_c <= FACE_WIDTH;
+                            constexpr uint32_t num_faces_in_output_tile = single_partial_fits_in_face ? 1 : 2;
+                            constexpr uint32_t num_faces_in_last_output_tile =
+                                last_tile_is_partial && (in_c % TILE_WIDTH == FACE_WIDTH || single_partial_fits_in_face)
+                                    ? 1
+                                    : 2;
+                            uint32_t output_faces =
+                                c_i == in_nblocks_c - 1 ? num_faces_in_last_output_tile : num_faces_in_output_tile;
+
+                            out_cb.reserve_back(output_faces);
+                            out_idx_cb.reserve_back(output_faces);
+
+                            pack_tmp_cb.wait_front(1);
+                            noc.async_read(
+                                self_ep,
+                                out_cb,
+                                output_faces * FACE_WIDTH * BYTES_PER_ELEM,
+                                experimental::local_addr(pack_tmp_cb.get_read_ptr()),
+                                {});
+
+                            pack_idx_tmp_cb.wait_front(1);
+                            constexpr uint32_t BYTES_PER_ELEM_IDX = indexes_32_bit ? 4 : 2;
+                            noc.async_read(
+                                self_ep,
+                                out_idx_cb,
+                                output_faces * FACE_WIDTH * BYTES_PER_ELEM_IDX,
+                                experimental::local_addr(pack_idx_tmp_cb.get_read_ptr()),
+                                {});
+                            noc.async_read_barrier();
+                            pack_tmp_cb.pop_front(1);
+                            pack_idx_tmp_cb.pop_front(1);
+
+                            out_cb.push_back(output_faces);
+                            out_idx_cb.push_back(output_faces);
+                        }
+                    }
+                }
+            };
+
+            // TODO - contiguous reads for some cases
+            for (uint32_t w = 0; w < kernel_w; ++w) {
+                process_h(w, 1);
+            }
+        }
+    }
+}
+
+/**
+ * Pool 2D (Max pool 2D and Avg pool 2D)
+ */
+void kernel_main() {
+    constexpr uint32_t kernel_h = get_compile_time_arg_val(1);
+    constexpr uint32_t kernel_w = get_compile_time_arg_val(2);
+
+    constexpr int32_t pad_w = get_compile_time_arg_val(3);
+
+    // channel size in bytes
+    constexpr uint32_t in_nbytes_leftover = get_compile_time_arg_val(4);
+
+    // input tensor height / width / channels
+    constexpr int32_t in_w = get_compile_time_arg_val(5);
+
+    constexpr uint32_t in_c = get_compile_time_arg_val(6);
+
+    constexpr uint32_t reader_id = get_compile_time_arg_val(8);
+
+    constexpr uint32_t bf16_scalar = get_compile_time_arg_val(9);
+    constexpr uint32_t bf16_init_value = get_compile_time_arg_val(10);
+
+    constexpr uint32_t in_nblocks_c = get_compile_time_arg_val(11);
+    constexpr uint32_t in_cb_sz = get_compile_time_arg_val(12);
+    constexpr uint32_t max_sticks_for_reduction = get_compile_time_arg_val(13);
+    constexpr uint32_t ceil_pad_w = get_compile_time_arg_val(14);
+
+    constexpr uint32_t in_cb_id = (reader_id == 1) ? get_compile_time_arg_val(16) : get_compile_time_arg_val(15);
+    constexpr uint32_t in_shard_cb_id = get_compile_time_arg_val(17);
+    constexpr uint32_t in_reader_indices_cb_id = get_compile_time_arg_val(18);
+    constexpr uint32_t in_scalar_cb_id_0 = get_compile_time_arg_val(19);
+    constexpr uint32_t clear_value_cb_id = get_compile_time_arg_val(21);
+    constexpr bool is_avg_pool = (bool)get_compile_time_arg_val(22);
+    constexpr bool one_scalar_per_core = get_compile_time_arg_val(23);
+    constexpr uint32_t in_nbytes_c = get_compile_time_arg_val(25);
+    constexpr uint32_t shard_width_bytes = get_compile_time_arg_val(26);
+    constexpr uint32_t multi_buffering_factor = get_compile_time_arg_val(27);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(28);
+    constexpr uint32_t dilation_h = get_compile_time_arg_val(29);
+    constexpr uint32_t dilation_w = get_compile_time_arg_val(30);
+    constexpr bool zero_pages = (bool)get_compile_time_arg_val(31);
+    constexpr uint32_t config_in_dram = get_compile_time_arg_val(32);
+    constexpr uint32_t config_dram_addr = get_compile_time_arg_val(33);
+    constexpr uint32_t config_page_size = get_compile_time_arg_val(34);
+    constexpr uint32_t reader_dram_addr = get_compile_time_arg_val(35);
+    constexpr uint32_t reader_page_size = get_compile_time_arg_val(36);
+    // MPWI-specific args start here
+    constexpr uint32_t in_idx_cb_id = get_compile_time_arg_val(37);
+    constexpr uint32_t pack_tmp_cb_id = get_compile_time_arg_val(38);
+    constexpr uint32_t pack_idx_tmp_cb_id = get_compile_time_arg_val(39);
+    constexpr uint32_t right_inc_cb_id = get_compile_time_arg_val(40);
+    constexpr uint32_t down_left_wrap_inc_cb_id = get_compile_time_arg_val(41);
+    constexpr uint32_t up_left_wrap_inc_cb_id = get_compile_time_arg_val(42);
+    constexpr uint32_t pad_t = get_compile_time_arg_val(43);
+    constexpr uint32_t pad_l = get_compile_time_arg_val(44);
+    constexpr uint32_t right_inc = get_compile_time_arg_val(45);
+    constexpr uint32_t down_left_wrap_inc = get_compile_time_arg_val(46);
+    constexpr uint32_t up_left_wrap_inc = get_compile_time_arg_val(47);
+    constexpr uint32_t intra_kernel_right_inc = get_compile_time_arg_val(48);
+    constexpr uint32_t intra_kernel_down_left_wrap_inc = get_compile_time_arg_val(49);
+    constexpr uint32_t out_cb_id = get_compile_time_arg_val(50);
+    constexpr uint32_t out_idx_cb_id = get_compile_time_arg_val(51);
+    constexpr uint32_t intra_kernel_right_inc_cb_id = get_compile_time_arg_val(52);
+    constexpr uint32_t intra_kernel_down_left_wrap_inc_cb_id = get_compile_time_arg_val(53);
+    constexpr uint32_t indexes_32_bit = get_compile_time_arg_val(54);
+    constexpr uint32_t reader_tensor_args_index = 55;
+
+    constexpr uint32_t in_w_padded = in_w + pad_w + ceil_pad_w;
+    constexpr bool last_tile_is_partial = in_c % TILE_WIDTH != 0;
+    constexpr uint32_t window_size_hw = kernel_h * kernel_w;
+    constexpr bool is_large_kernel = window_size_hw > max_sticks_for_reduction;
+    constexpr uint32_t sticks_per_chunk = kernel_w <= max_sticks_for_reduction ? kernel_w : max_sticks_for_reduction;
+    constexpr bool wide_reduction = in_nblocks_c > 1;
+    constexpr uint32_t in_cb_ntiles = in_cb_sz / (TILE_WIDTH * TILE_HEIGHT);  // only use the non-multi buffering size
+
+    // fill the clear cb
+    if constexpr (reader_id == 0) {
+        experimental::CB clear_value_cb(clear_value_cb_id);
+        fill_with_val(clear_value_cb.get_write_ptr(), TILE_HEIGHT * TILE_WIDTH, bf16_init_value);
+        clear_value_cb.push_back(1);
+        clear_out_tiles<in_cb_id, clear_value_cb_id>(Noc(), experimental::CB(in_cb_id), clear_value_cb);
+    }
+
+    if constexpr (reader_id == 0) {
+        initialize_return_indices_data<
+            kernel_h,
+            kernel_w,
+            in_w,
+            in_c,
+            pad_t,
+            pad_l,
+            dilation_h,
+            dilation_w,
+            is_large_kernel,
+            sticks_per_chunk,
+            right_inc,
+            down_left_wrap_inc,
+            up_left_wrap_inc,
+            intra_kernel_right_inc,
+            intra_kernel_down_left_wrap_inc,
+            in_idx_cb_id,
+            right_inc_cb_id,
+            down_left_wrap_inc_cb_id,
+            up_left_wrap_inc_cb_id,
+            intra_kernel_right_inc_cb_id,
+            intra_kernel_down_left_wrap_inc_cb_id,
+            indexes_32_bit>();
+    }
+
+    // initialize the scalar CB
+    if constexpr (reader_id == 0) {
+        // Fill only the first FACE_WIDTH, since we set reload_srcB = true in unpack_tilizeA_B_block, meaning the values
+        // for the remaining faces will be reused from the first one. This is safe here because there’s no difference
+        // between the first and second face.
+        experimental::CB in_scalar_cb(in_scalar_cb_id_0);
+        fill_with_val(in_scalar_cb.get_write_ptr(), FACE_WIDTH, bf16_scalar >> 16);
+        in_scalar_cb.push_back(1);
+    }
+    const uint32_t core_nhw_index = get_arg_val<uint32_t>(1);
+
+    experimental::CB in_shard_cb(in_shard_cb_id);
+    const uint32_t in_l1_read_base_addr = in_shard_cb.get_read_ptr();
+    experimental::CB in_reader_indices_cb(in_reader_indices_cb_id);
+    if constexpr (config_in_dram) {
+        if (reader_id == 0) {
+            load_config_tensor_if_in_dram<
+                reader_dram_addr,
+                reader_page_size,
+                reader_tensor_args_index,
+                in_reader_indices_cb_id>(Noc(), in_reader_indices_cb, core_nhw_index);
+
+        } else {
+            in_reader_indices_cb.wait_front(1);
+        }
+    }
+    uint32_t reader_indices_l1_addr = in_reader_indices_cb.get_read_ptr();
+    volatile tt_l1_ptr uint32_t* reader_indices_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reader_indices_l1_addr);
+
+    uint32_t segments_counter = 1;
+    constexpr uint32_t total_elems_to_reduce = kernel_h * kernel_w;
+
+    uint16_t num_segments = reader_indices_ptr[0] & 0xffff;
+
+    while (num_segments--) {
+        uint32_t start_end_segment = reader_indices_ptr[segments_counter++];
+        uint16_t start = start_end_segment & 0xffff;
+        uint16_t end = start_end_segment >> 16;
+
+        constexpr uint32_t stride_multiple = 1;
+        for (uint16_t ind = start; ind <= end; ind += stride_multiple * stride_w) {
+            read_kernel_with_top_left_index<
+                in_nblocks_c,
+                in_cb_id,
+                kernel_h,
+                kernel_w,
+                in_w_padded,
+                in_nbytes_leftover,
+                in_c,
+                sticks_per_chunk,
+                total_elems_to_reduce,
+                wide_reduction,
+                clear_value_cb_id,
+                in_cb_ntiles,
+                in_nbytes_c,
+                shard_width_bytes,
+                is_large_kernel,
+                last_tile_is_partial,
+                dilation_h,
+                dilation_w,
+                zero_pages,
+                out_cb_id,
+                out_idx_cb_id,
+                reader_id,
+                pack_tmp_cb_id,
+                pack_idx_tmp_cb_id,
+                indexes_32_bit>(ind, in_l1_read_base_addr);
+        }
+    }
+}  // kernel_main()

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/dataflow/reader_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/dataflow/reader_pool_2d.cpp
@@ -1,0 +1,366 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <sys/types.h>
+
+#include <cstdint>
+#include <api/dataflow/dataflow_api.h>
+#include <ttnn/cpp/ttnn/operations/pool/device/kernels/pool_kernels_common.hpp>
+
+#define ENABLE_DEBUG_PRINT 0
+
+#if ENABLE_DEBUG_PRINT == 1
+#include "api/debug/dprint.h"
+#include "api/debug/dprint_pages.h"
+#endif
+
+// Read kernel data for normal max/average pooling (without indices)
+template <
+    uint32_t in_nblocks_c,
+    uint32_t in_cb_id,
+    uint32_t kernel_h,
+    uint32_t kernel_w,
+    uint32_t in_w_padded,
+    uint32_t in_nbytes_leftover,
+    uint32_t in_c,
+    uint32_t max_sticks_for_reduction,
+    uint32_t total_elems_to_reduce,
+    bool is_avg_pool,
+    bool wide_reduction,
+    uint32_t clear_value_cb_id,
+    uint32_t in_cb_ntiles,
+    uint32_t in_nbytes_c,
+    uint32_t shard_width_bytes,
+    bool is_large_kernel,
+    bool last_tile_is_partial,
+    uint32_t dilation_h,
+    uint32_t dilation_w,
+    bool zero_pages,
+    uint32_t in_cb_sz,
+    uint32_t bf16_init_value>
+ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base_addr) {
+    constexpr uint32_t BYTES_PER_ELEM = 2;
+    // average pool with large kernels requires fp32 accumulation so we can only reduce 4 tiles at a time,
+    // otherwise we can reduce 8 tiles at a time.
+    constexpr uint32_t MAX_TILES_PER_REDUCTION = (is_avg_pool && is_large_kernel) ? 4 : 8;
+    constexpr uint32_t MAX_BYTES_PER_REDUCTION = MAX_TILES_PER_REDUCTION * TILE_WIDTH * BYTES_PER_ELEM;
+    constexpr uint32_t in_ntiles_c = (in_c + TILE_WIDTH - 1) / TILE_WIDTH;
+    constexpr uint32_t num_tilized_rows =
+        wide_reduction ? (in_cb_sz / (MAX_TILES_PER_REDUCTION * TILE_WIDTH)) : (in_cb_sz / (in_ntiles_c * TILE_WIDTH));
+    constexpr bool tilize_reconfig = in_nblocks_c > 1 && in_ntiles_c % MAX_TILES_PER_REDUCTION != 0 &&
+                                     (kernel_h * kernel_w) <= 16 && !last_tile_is_partial;
+
+    experimental::CB in_cb(in_cb_id);
+    experimental::CB clear_cb(clear_value_cb_id);
+    Noc noc;
+    UnicastEndpoint self_ep;
+
+    uint32_t max_write_inc = wide_reduction ? MAX_BYTES_PER_REDUCTION : in_nbytes_leftover;
+    for (uint32_t c_i = 0; c_i < in_nblocks_c; c_i++) {
+        uint32_t read_bytes = in_nbytes_c;
+        if constexpr (wide_reduction) {
+            read_bytes =
+                (c_i == in_nblocks_c - 1) ? in_nbytes_c - c_i * MAX_BYTES_PER_REDUCTION : MAX_BYTES_PER_REDUCTION;
+        }
+
+        in_cb.reserve_back(1);
+        uint32_t write_offset = 0;
+        uint32_t processed_sticks = 0;
+        // page zeroing is only necessary for tiled block output format so that scale is not affected by
+        // junk/padding data
+        if constexpr (zero_pages) {
+            if (c_i == in_nblocks_c - 1 && last_tile_is_partial) {
+                zero_out_page(noc, in_cb);
+            }
+        }
+        // When the CB intentionally holds more rows than the kernel window (medium kernels,
+        // FACE_WIDTH < kernel_size_hw < TILE_HEIGHT), the rows in
+        // [total_elems_to_reduce, num_tilized_rows) are never overwritten by the async_reads
+        // below and would otherwise contribute junk to the reduce. Fill only that tail region
+        // with the init value -- the leading rows will be fully overwritten by process_h().
+        if constexpr (!is_large_kernel) {
+            if constexpr (num_tilized_rows > total_elems_to_reduce) {
+                constexpr uint32_t row_stride_elems =
+                    wide_reduction ? (MAX_TILES_PER_REDUCTION * TILE_WIDTH) : (in_ntiles_c * TILE_WIDTH);
+                constexpr uint32_t tail_offset_bytes = total_elems_to_reduce * row_stride_elems * BYTES_PER_ELEM;
+                constexpr uint32_t tail_elems = (num_tilized_rows - total_elems_to_reduce) * row_stride_elems;
+                fill_with_val(
+                    in_cb.get_write_ptr() + tail_offset_bytes, tail_elems, static_cast<uint16_t>(bf16_init_value));
+            }
+        }
+        for (uint32_t h = 0; h < kernel_h; ++h) {
+            auto process_h = [&](uint32_t w_offset, uint32_t w_multiple) __attribute__((always_inline)) {
+                const uint32_t stick_offset = ind + w_offset + h * dilation_h * in_w_padded;
+                const uint32_t read_offset =
+                    in_l1_read_base_addr + (stick_offset * shard_width_bytes + c_i * MAX_BYTES_PER_REDUCTION);
+                noc.async_read(
+                    self_ep,
+                    in_cb,
+                    read_bytes * w_multiple,
+                    experimental::local_addr(read_offset),
+                    {.offset_bytes = write_offset});
+                // if compute is using tilize_reconfig we will only untilize the needed number of tiles rather
+                // than the entire MAX_TILES_PER_REDUCTION, thus we use a different offset for the write address
+                if constexpr (tilize_reconfig) {
+                    write_offset += read_bytes * w_multiple;
+                } else {
+                    write_offset += max_write_inc * w_multiple;
+                }
+                processed_sticks += w_multiple;
+                if constexpr (is_large_kernel) {
+                    if ((processed_sticks % max_sticks_for_reduction) == 0 ||
+                        processed_sticks == total_elems_to_reduce) {
+                        noc.async_read_barrier();
+                        in_cb.push_back(1);
+                        in_cb.reserve_back(1);
+                        write_offset = 0;
+                        // If next is last chunk, fill whole buffer with the init_value. note for max pool we do
+                        // not need to fill the CB for the partial chunk since as long as we have N>1 chunks we
+                        // are guaranteed that the junk data remaining from chunk N-1 will fill the entire CB and
+                        // cannot contain values greater than the max value, and if we have N=1 chunks we already
+                        // initialized the entire CB with the init value, but for avg pool we need to fill the
+                        // entire CB with the init value since the junk data will contribute to the average.
+                        if constexpr (is_avg_pool) {
+                            // clear the in CB
+                            if ((total_elems_to_reduce - processed_sticks) < max_sticks_for_reduction &&
+                                processed_sticks != total_elems_to_reduce) {
+                                clear_out_tiles<clear_value_cb_id>(noc, in_cb, clear_cb, in_cb_ntiles);
+                            }
+                        }
+                    }
+                }
+            };
+
+            // Case where in_nbytes_leftover and in_nbytes_c is different is when we are dealing with
+            // tesnors that have last tile as partial. Cb page size is multiple of tile but when the last
+            // tile is partial we have to read the smaller stick width. Therefore we need to write out the next
+            // stick right below the previous one and this is when increment of the write pointer and the read
+            // stick size is not compliant.
+            bool use_contiguous_read = !wide_reduction && in_nbytes_leftover == in_nbytes_c &&
+                                       dilation_w == 1;  // read entire row as one chunk (only if no width dilation)
+            if constexpr (is_large_kernel) {
+                bool whole_row_remaining =
+                    kernel_w <= max_sticks_for_reduction - (processed_sticks % max_sticks_for_reduction);
+                use_contiguous_read &= whole_row_remaining;
+            }
+
+            if (use_contiguous_read) {
+                process_h(0, kernel_w);
+            } else {  // read rows stick by stick with dilation
+                for (uint32_t w = 0; w < kernel_w; ++w) {
+                    process_h(w * dilation_w, 1);
+                }
+            }
+        }
+        if constexpr (!is_large_kernel) {
+            noc.async_read_barrier();
+            in_cb.push_back(1);
+        }
+    }
+}
+
+/**
+ * Pool 2D (Max pool 2D and Avg pool 2D)
+ */
+void kernel_main() {
+    constexpr uint32_t reader_nindices = get_compile_time_arg_val(0);
+    constexpr uint32_t kernel_h = get_compile_time_arg_val(1);
+    constexpr uint32_t kernel_w = get_compile_time_arg_val(2);
+
+    constexpr int32_t pad_w = get_compile_time_arg_val(3);
+
+    // channel size in bytes
+    constexpr uint32_t in_nbytes_leftover = get_compile_time_arg_val(4);
+
+    // input tensor height / width / channels
+    constexpr int32_t in_w = get_compile_time_arg_val(5);
+
+    constexpr uint32_t in_c = get_compile_time_arg_val(6);
+
+    constexpr uint32_t split_reader = get_compile_time_arg_val(7);
+    constexpr uint32_t reader_id = get_compile_time_arg_val(8);
+
+    constexpr uint32_t bf16_scalar = get_compile_time_arg_val(9);
+    constexpr uint32_t bf16_init_value = get_compile_time_arg_val(10);
+
+    constexpr uint32_t in_nblocks_c = get_compile_time_arg_val(11);
+    constexpr uint32_t in_cb_sz = get_compile_time_arg_val(12);
+    constexpr uint32_t max_sticks_for_reduction = get_compile_time_arg_val(13);
+    constexpr uint32_t ceil_pad_w = get_compile_time_arg_val(14);
+
+    constexpr uint32_t in_cb_id = (reader_id == 1) ? get_compile_time_arg_val(16) : get_compile_time_arg_val(15);
+    constexpr uint32_t in_shard_cb_id = get_compile_time_arg_val(17);
+    constexpr uint32_t in_reader_indices_cb_id = get_compile_time_arg_val(18);
+    constexpr uint32_t in_scalar_cb_id_0 = get_compile_time_arg_val(19);
+    constexpr uint32_t in_scalar_cb_id_1 = get_compile_time_arg_val(20);
+    constexpr uint32_t clear_value_cb_id = get_compile_time_arg_val(21);
+    constexpr bool is_avg_pool = (bool)get_compile_time_arg_val(22);
+    constexpr bool one_scalar_per_core = get_compile_time_arg_val(23);
+    constexpr uint32_t config_cb_id = get_compile_time_arg_val(24);
+    constexpr uint32_t in_nbytes_c = get_compile_time_arg_val(25);
+    constexpr uint32_t shard_width_bytes = get_compile_time_arg_val(26);
+    constexpr uint32_t multi_buffering_factor = get_compile_time_arg_val(27);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(28);
+    constexpr uint32_t dilation_h = get_compile_time_arg_val(29);
+    constexpr uint32_t dilation_w = get_compile_time_arg_val(30);
+    constexpr bool zero_pages = (bool)get_compile_time_arg_val(31);
+    constexpr uint32_t config_in_dram = get_compile_time_arg_val(32);
+    constexpr uint32_t config_dram_addr = get_compile_time_arg_val(33);
+    constexpr uint32_t config_page_size = get_compile_time_arg_val(34);
+    constexpr uint32_t reader_dram_addr = get_compile_time_arg_val(35);
+    constexpr uint32_t reader_page_size = get_compile_time_arg_val(36);
+    constexpr uint32_t reader_tensor_args_index = 55;
+
+    constexpr bool use_split_reader = split_reader;
+
+    constexpr uint32_t in_w_padded = in_w + pad_w + ceil_pad_w;
+    constexpr bool last_tile_is_partial = in_c % TILE_WIDTH != 0;
+    constexpr uint32_t in_scalar_cb_id =
+        use_split_reader && reader_id == 1 && !one_scalar_per_core ? in_scalar_cb_id_1 : in_scalar_cb_id_0;
+
+    constexpr uint32_t window_size_hw = kernel_h * kernel_w;
+    constexpr uint32_t face_r_dim = window_size_hw < FACE_HEIGHT ? window_size_hw : FACE_HEIGHT;
+    constexpr uint32_t num_faces_in_input_tile =
+        (max_sticks_for_reduction < TILE_WIDTH || window_size_hw <= FACE_HEIGHT) ? 2 : 4;
+    constexpr bool is_large_kernel = window_size_hw > max_sticks_for_reduction;
+    constexpr bool wide_reduction = in_nblocks_c > 1;
+    constexpr uint32_t remaining_elems = window_size_hw % max_sticks_for_reduction;
+    constexpr uint32_t interm_reduction_chunks =
+        remaining_elems ? window_size_hw / max_sticks_for_reduction + 1 : window_size_hw / max_sticks_for_reduction;
+    // we only need to initialize the in_cb if we will not fill each reduction chunk with valid data
+    constexpr bool need_to_initialize_in_cb =
+        (remaining_elems && face_r_dim == FACE_HEIGHT && (num_faces_in_input_tile == 4 || last_tile_is_partial) &&
+         interm_reduction_chunks <= multi_buffering_factor);
+    constexpr uint32_t in_cb_ntiles = in_cb_sz / (TILE_WIDTH * TILE_HEIGHT);  // only use the non-multi buffering size
+
+    experimental::CB clear_value_cb(clear_value_cb_id);
+    experimental::CB in_scalar_cb(in_scalar_cb_id);
+    experimental::CB in_shard_cb(in_shard_cb_id);
+    experimental::CB reader_indices_cb(in_reader_indices_cb_id);
+    experimental::CB config_cb(config_cb_id);
+
+    // fill the clear cb
+    if constexpr (is_avg_pool || need_to_initialize_in_cb) {
+        if constexpr (reader_id == 0) {
+            fill_with_val(clear_value_cb.get_write_ptr(), TILE_HEIGHT * TILE_WIDTH, bf16_init_value);
+            clear_value_cb.push_back(1);
+        }
+        if constexpr (reader_id == 1) {
+            clear_value_cb.wait_front(1);
+        }
+        // for average pool clear out tiles runs in loop, no need to initialize here
+        if constexpr (!is_avg_pool || !is_large_kernel) {
+            clear_out_tiles<in_cb_id, clear_value_cb_id>(Noc(), experimental::CB(in_cb_id), clear_value_cb);
+        }
+    }
+
+    // initialize the scalar CB
+    if constexpr (reader_id == 0 && one_scalar_per_core) {
+        // Fill only the first FACE_WIDTH, since we set reload_srcB = true in unpack_tilizeA_B_block, meaning the values
+        // for the remaining faces will be reused from the first one. This is safe here because there’s no difference
+        // between the first and second face.
+        fill_with_val(in_scalar_cb.get_write_ptr(), FACE_WIDTH, bf16_scalar >> 16);
+        in_scalar_cb.push_back(1);
+    }
+    const uint32_t core_nhw_index = get_arg_val<uint32_t>(1);
+
+    const uint32_t in_l1_read_base_addr = in_shard_cb.get_read_ptr();
+    if constexpr (config_in_dram) {
+        if (reader_id == 0) {
+            load_config_tensor_if_in_dram<
+                reader_dram_addr,
+                reader_page_size,
+                reader_tensor_args_index,
+                in_reader_indices_cb_id>(Noc(), reader_indices_cb, core_nhw_index);
+
+        } else {
+            reader_indices_cb.wait_front(1);
+        }
+    }
+    uint32_t reader_indices_l1_addr = reader_indices_cb.get_read_ptr();
+    volatile tt_l1_ptr uint32_t* reader_indices_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reader_indices_l1_addr);
+
+    uint32_t segments_counter = 1;
+    constexpr uint32_t total_elems_to_reduce = kernel_h * kernel_w;
+
+    volatile tt_l1_ptr uint16_t* config_ptr;
+    uint32_t scalar_index = 0;
+    uint32_t scalar_start;
+    uint32_t scalar_value;
+    uint32_t scalar_end;
+    uint32_t counter = reader_id;
+    if constexpr (!one_scalar_per_core) {
+        uint32_t config_l1_addr = config_cb.get_read_ptr();
+        if constexpr (config_in_dram) {
+            if (reader_id == 0) {
+                constexpr uint32_t config_tensor_args_index =
+                    TensorAccessorArgs<reader_tensor_args_index>().next_compile_time_args_offset();
+                load_config_tensor_if_in_dram<
+                    config_dram_addr,
+                    config_page_size,
+                    config_tensor_args_index,
+                    config_cb_id>(Noc(), config_cb, core_nhw_index);
+            } else {
+                config_cb.wait_front(1);
+            }
+        }
+        config_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(config_l1_addr);
+        scalar_start = config_ptr[0];
+        scalar_value = config_ptr[1];
+        scalar_end = config_ptr[2];
+    }
+
+    uint16_t num_segments = reader_indices_ptr[0] & 0xffff;
+    bool first_row_value = reader_id == 0 || !use_split_reader;
+
+    while (num_segments--) {
+        uint32_t start_end_segment = reader_indices_ptr[segments_counter++];
+        uint16_t start = start_end_segment & 0xffff;
+        uint16_t end = start_end_segment >> 16;
+
+        if (!first_row_value) {
+            start += stride_w;
+            first_row_value = true;
+        }
+
+        constexpr uint32_t stride_multiple = use_split_reader ? 2 : 1;
+        for (uint16_t ind = start; ind <= end; ind += stride_multiple * stride_w) {
+            if constexpr (!one_scalar_per_core) {
+                fill_scalar<
+                    one_scalar_per_core,
+                    in_scalar_cb_id,
+                    reader_nindices,
+                    use_split_reader,
+                    multi_buffering_factor>(
+                    in_scalar_cb, scalar_start, scalar_end, scalar_value, scalar_index, counter, config_ptr);
+            }
+            read_kernel_with_top_left_index<
+                in_nblocks_c,
+                in_cb_id,
+                kernel_h,
+                kernel_w,
+                in_w_padded,
+                in_nbytes_leftover,
+                in_c,
+                max_sticks_for_reduction,
+                total_elems_to_reduce,
+                is_avg_pool,
+                wide_reduction,
+                clear_value_cb_id,
+                in_cb_ntiles,
+                in_nbytes_c,
+                shard_width_bytes,
+                is_large_kernel,
+                last_tile_is_partial,
+                dilation_h,
+                dilation_w,
+                zero_pages,
+                in_cb_sz,
+                bf16_init_value>(ind, in_l1_read_base_addr);
+            if (use_split_reader && ind == end) {
+                first_row_value = false;
+            }
+        }
+    }
+}  // kernel_main()

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/pool_multi_core_program_factory.cpp
@@ -1,0 +1,1286 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "pool_op.hpp"
+#include "tt-metalium/circular_buffer_config.hpp"
+#include "tt-metalium/constants.hpp"
+#include "tt-metalium/tensor_accessor_args.hpp"
+#include "tt-metalium/tt_backend_api_types.hpp"
+#include "ttnn/operations/cb_utils.hpp"
+#include "ttnn/operations/pool/pool_utils.hpp"
+#include "tt-metalium/host_buffer.hpp"
+#include "tt-metalium/buffer.hpp"
+#include "ttnn/tensor/types.hpp"
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include <tt-metalium/host_api.hpp>
+#include "ttnn/tensor/storage.hpp"
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <algorithm>
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+
+namespace ttnn::operations::pool::quasar {
+
+// Circular buffer ID used to indicate an unallocated/invalid CB
+constexpr uint32_t INVALID_CB_ID = 32;
+
+/**
+ * Generic pool implementation that uses the new sliding window infrastructure.
+ */
+struct ScalarInfo {
+    // Scalar Info is used to store the information about the scalar used in avg pool op
+    // start and end refer to indices of the output stick core is calculating.
+    // These are directly mapped to the for loop that can be found in reader and compute kernel of the pool op
+    // for (uint32_t i = 0; i < nsticks_per_core; ++i), start is first stick which should be reduced and multiplied by
+    // scalar value, end is the first stick which should not be reduced and multiplied by scalar value. So the interval
+    // [start, end) is the range of sticks that should be reduced and multiplied by scalar value.
+    uint16_t start;
+    uint16_t value;
+    uint16_t end;
+};
+
+// This function generates a vector of elements of type ScalarInfo. It is called once per core and generates the
+// adequate scalars for each output element that core should produce. It should be called only for avg pool operation
+// and only if the divisor_override is NOT set and the idea behind it is to generate config tensor in cases where one
+// scalar per core is not sufficient to create correct result. Those scenarios are ceil_mode == true and (ceil_pad_h > 0
+// || ceil_pad_w > 0) or count_include_pad == false || (pad_h > 0 || pad_w > 0). Both of these scenarios can be
+// irrelevant if the divisor_override is set, in which case we don't calculate the divisor since it is already passed as
+// an argument. It only adds scalars that are different than the scalar preceding it not to have duplicates of data,
+// this is why we use start and end indices to know how many sequential output elements should be multiplied by the same
+// scalar value.
+std::vector<ScalarInfo> get_bf16_avg_pool_config_scalars(
+    const AvgPoolConfig& config, uint32_t output_stick_x, uint32_t output_stick_y) {
+    TT_FATAL(
+        !is_pool_op_one_scalar_per_core(
+            Pool2DType::AVG_POOL2D,
+            config.ceil_mode,
+            config.ceil_h,
+            config.ceil_w,
+            config.count_include_pad,
+            config.pad_t + config.pad_b,
+            config.pad_l + config.pad_r,
+            config.divisor_override),
+        "Avg pool scalars config should be calculated only for ceil_mode == true and "
+        "(ceil_pad_h > 0 || ceil_pad_w > 0) or count_include_pad == false and (pad_h > 0 || pad_w > 0)");
+
+    std::vector<ScalarInfo> scalars;
+    bool first_scalar = true;
+    uint32_t last_pool_area = 0;
+
+    for (uint32_t i = 0; i < config.max_out_nhw_per_core; i++) {
+        // Compute starting and ending indices of the pooling window
+        int h_start = (output_stick_x * config.stride_h) - config.pad_t;
+        int w_start = (output_stick_y * config.stride_w) - config.pad_l;
+        // omit any ceiling mode related padding from end point calculations as these are not used in the
+        // calculation of the pool area even when count_include_pad is on
+        int h_end = std::min(h_start + static_cast<int>(config.kernel_h), static_cast<int>(config.in_h + config.pad_b));
+        int w_end = std::min(w_start + static_cast<int>(config.kernel_w), static_cast<int>(config.in_w + config.pad_r));
+
+        int pool_area = 0;
+        if (config.count_include_pad) {
+            pool_area = (h_end - h_start) * (w_end - w_start);
+        } else {
+            int valid_h_start = (h_start > 0) ? h_start : 0;
+            int valid_w_start = (w_start > 0) ? w_start : 0;
+            int valid_h_end = std::min(h_end, static_cast<int>(config.in_h));
+            int valid_w_end = std::min(w_end, static_cast<int>(config.in_w));
+
+            int effective_h = valid_h_end - valid_h_start;
+            int effective_w = valid_w_end - valid_w_start;
+            pool_area = (effective_h > 0 && effective_w > 0) ? effective_h * effective_w : 0;
+        }
+        float value = pool_area > 0 ? 1.f / static_cast<float>(pool_area) : 0.f;
+
+        // Add new scalar if padding config changes
+        if (first_scalar || static_cast<uint32_t>(pool_area) != last_pool_area) {
+            if (!scalars.empty()) {
+                scalars.back().end = i;
+            }
+            // TODO: #27672: Truncation should be removed once we figure a root cause of regression without it
+            scalars.push_back({i, std::bit_cast<uint16_t>(bfloat16::truncate(value)), i});
+            first_scalar = false;
+        }
+        last_pool_area = static_cast<uint32_t>(pool_area);
+
+        // Advance output element coordinates
+        output_stick_y = (output_stick_y + 1) % config.out_w;
+        if (output_stick_y == 0) {
+            output_stick_x = (output_stick_x + 1) % config.out_h;
+        }
+    }
+
+    scalars.back().end = config.max_out_nhw_per_core;
+    return scalars;
+}
+
+static void push_back_scalar_info_or_zero(
+    std::vector<uint16_t>& config_vector,
+    const std::vector<ScalarInfo>& scalars,
+    uint32_t max_scalars_cnt,
+    uint32_t repeats) {
+    for (uint32_t r = 0; r < repeats; ++r) {
+        for (uint32_t j = 0; j < max_scalars_cnt; ++j) {
+            if (j < scalars.size()) {
+                config_vector.insert(config_vector.end(), {scalars[j].start, scalars[j].value, scalars[j].end});
+            } else {
+                config_vector.insert(config_vector.end(), {0, 0, 0});
+            }
+        }
+    }
+}
+
+// This function creates a scalar config tensor for the AvgPool2D operation. It is entirely made of
+// a vector of ScalarInfo structs, which are used to configure the pooling operation. The config tensor
+// is filled with max_out_nhw_per_core number of ScalarInfos for each core and then sharded across the cores.
+// Since we don't usually have that many different scalars, we fill the rest of the config tensor with 0s.
+static Tensor create_scalar_config_tensor(
+    const AvgPoolConfig& config,
+    TensorMemoryLayout in_memory_layout,
+    uint32_t n_dim,
+    uint32_t num_shards_c,
+    uint32_t num_cores,
+    bool config_tensor_in_dram) {
+    std::vector<uint16_t> config_vector;
+
+    size_t max_scalars_cnt = 0;
+    std::vector<std::vector<ScalarInfo>> scalars_per_core = {};
+    uint32_t num_iterations = 0;
+
+    switch (in_memory_layout) {
+        case TensorMemoryLayout::HEIGHT_SHARDED: num_iterations = num_cores; break;
+        case TensorMemoryLayout::BLOCK_SHARDED: num_iterations = num_cores / num_shards_c; break;
+        case TensorMemoryLayout::WIDTH_SHARDED: num_iterations = 1; break;
+        default: break;
+    }
+
+    {
+        uint32_t nhw_linear = 0;
+        uint32_t output_stick_n = 0;
+        uint32_t output_stick_h = 0;
+        uint32_t output_stick_w = 0;
+        for (uint32_t i = 0; i < num_iterations; ++i) {
+            scalars_per_core.emplace_back(get_bf16_avg_pool_config_scalars(config, output_stick_h, output_stick_w));
+            max_scalars_cnt = std::max(max_scalars_cnt, scalars_per_core.back().size());
+
+            // Width sharded layout requires only one iteration, so we can break here
+            if (in_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED ||
+                in_memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
+                nhw_linear += config.max_out_nhw_per_core;
+                output_stick_w = nhw_linear % config.out_w;
+                output_stick_h = (nhw_linear / config.out_w) % config.out_h;
+                output_stick_n = nhw_linear / (config.out_w * config.out_h);
+
+                if (output_stick_n == n_dim) {
+                    nhw_linear -= output_stick_n * config.out_w * config.out_h;
+                    output_stick_h = 0;
+                    output_stick_w = 0;
+                }
+            }
+        }
+    }
+
+    constexpr uint32_t entry_size = 3;
+    const uint32_t entries_per_core = entry_size * max_scalars_cnt;
+
+    TT_FATAL(
+        entries_per_core != 0,
+        "entries_per_core cannot be zero. max_scalars_cnt: {}, num_iterations: {}, in_memory_layout: {}",
+        max_scalars_cnt,
+        num_iterations,
+        in_memory_layout);
+
+    switch (in_memory_layout) {
+        case TensorMemoryLayout::HEIGHT_SHARDED:
+        // With height sharded layout each scalar is unique and needs to be calculated
+        case TensorMemoryLayout::BLOCK_SHARDED: {
+            // With block sharded layout scalars across sequential channels shard repeat, so we use repeats variable not
+            // to recalculate scalars that we can reuse
+            for (const std::vector<ScalarInfo>& scalars : scalars_per_core) {
+                uint32_t repeats = config_tensor_in_dram ? 1 : num_shards_c;
+                push_back_scalar_info_or_zero(config_vector, scalars, max_scalars_cnt, repeats);
+            }
+            break;
+        }
+        case TensorMemoryLayout::WIDTH_SHARDED: {
+            // With width sharded layout scalars should be calculated only once, so we push them back num_shards_c times
+            // but have only one array of scalars
+            uint32_t repeats = config_tensor_in_dram ? 1 : num_shards_c;
+            push_back_scalar_info_or_zero(config_vector, scalars_per_core[0], max_scalars_cnt, repeats);
+            break;
+        }
+
+        default: break;
+    }
+
+    TT_FATAL(
+        config_vector.size() % entries_per_core == 0,
+        "Config vector size {} should be a multiple of {}",
+        config_vector.size(),
+        entries_per_core);
+
+    ttnn::Shape config_shape = ttnn::Shape({tt::div_up(config_vector.size(), entries_per_core), entries_per_core});
+    tt::tt_metal::HostBuffer buffer(std::move(config_vector));
+    return Tensor(std::move(buffer), config_shape, DataType::UINT16, Layout::ROW_MAJOR);
+}
+
+std::vector<uint32_t> generate_core_starting_indices(
+    const std::vector<uint32_t>& op_trace_metadata,
+    const std::vector<sliding_window::ShardBoundary>& shard_boundaries,
+    const tt::tt_metal::TensorMemoryLayout shard_scheme,
+    const uint32_t num_cores_x,
+    const uint32_t ncores) {
+    std::vector<uint32_t> starting_indices;
+    uint32_t repeat_factor = 0;
+    switch (shard_scheme) {
+        case tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED: repeat_factor = 1; break;
+        case tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED: repeat_factor = ncores; break;
+        case tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED: repeat_factor = num_cores_x; break;
+        default: TT_FATAL(false, "Unsupported shard scheme");
+    };
+    for (const auto& item : shard_boundaries) {
+        const auto& [output_shard_start, _] = item.output_range;
+        if (output_shard_start >= op_trace_metadata.size()) {
+            // this core has no output
+            starting_indices.push_back(0);
+            continue;
+        }
+        TT_ASSERT(item.input_range.start == op_trace_metadata[output_shard_start]);
+        for (uint32_t r = 0; r < repeat_factor; r++) {
+            starting_indices.push_back(op_trace_metadata[output_shard_start]);
+        }
+    }
+
+    return starting_indices;
+}
+
+static tt::tt_metal::ProgramDescriptor pool2d_multi_core_sharded_with_halo_v2_impl_new(
+    const Tensor& input,
+    tt::tt_metal::Buffer* reader_indices_buffer,
+    tt::tt_metal::Buffer* scalar_config_buffer,
+    uint32_t reader_indices_size,
+    std::vector<Tensor>& outputs,
+    Pool2DType pool_type,
+    uint32_t in_n,
+    uint32_t in_c,
+    uint32_t in_h,
+    uint32_t in_w,
+    uint32_t out_h,
+    uint32_t out_w,
+    uint32_t out_c,
+    uint32_t kernel_h,
+    uint32_t kernel_w,
+    uint32_t stride_h,
+    uint32_t stride_w,
+    uint32_t pad_t,
+    uint32_t pad_b,
+    uint32_t pad_l,
+    uint32_t pad_r,
+    uint32_t ceil_pad_h,
+    uint32_t ceil_pad_w,
+    bool ceil_mode,
+    bool return_indices,
+    std::vector<uint32_t> core_starting_indices,
+    bool count_include_pad,
+    uint32_t dilation_h,
+    uint32_t dilation_w,
+    uint32_t num_shards_c,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
+    std::optional<int32_t> divisor_override,
+    uint32_t memory_used,
+    const Layout& output_layout,
+    bool config_tensor_in_dram) {
+    using namespace tt::tt_metal;
+
+    TT_FATAL(
+        reader_indices_buffer != nullptr,
+        "Pool2D::MultiCore::create_workload_descriptor must populate the reader-indices buffer before building "
+        "programs");
+
+    const bool is_block_sharded = input.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
+    const bool is_width_sharded = input.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
+
+    // distributing out_hw across the grid
+    const auto all_cores = input.shard_spec().value().grid;
+    const uint32_t ncores = all_cores.num_cores();
+    const uint32_t num_cores_x = input.memory_config().shard_spec()->grid.bounding_box().grid_size().x;
+    const uint32_t rectangular_x = is_block_sharded ? all_cores.ranges()[0].end_coord.x + 1 : num_cores_x;
+    const uint32_t max_out_nhw_per_core = outputs[0].shard_spec()->shape[0];
+    const uint32_t max_in_nhw_per_core = input.shard_spec()->shape[0];
+    TT_FATAL(
+        max_in_nhw_per_core <= std::numeric_limits<uint16_t>::max(),
+        "Input nhw per core {} exceeds uint16_t limit, this will cause overflow because the reader indices are stored "
+        "as uint16_t",
+        max_in_nhw_per_core);
+
+    const uint32_t bf16_scalar = get_bf16_pool_scalar(pool_type, kernel_h, kernel_w, divisor_override);
+    const uint32_t bf16_init_value = get_bf16_pool_init_value(pool_type);
+    FactoryParameters params = get_factory_parameters(
+        num_shards_c,
+        input.dtype(),
+        outputs[0].dtype(),
+        kernel_h,
+        kernel_w,
+        in_c,
+        pool_type,
+        return_indices,
+        in_h,
+        in_w,
+        output_layout);
+    uint32_t eff_kernel_h = ((kernel_h - 1) * dilation_h) + 1;
+    uint32_t eff_kernel_w = ((kernel_w - 1) * dilation_w) + 1;
+    uint32_t pad_h = pad_t + pad_b;
+    uint32_t pad_w = pad_l + pad_r;
+    const uint32_t in_h_padded = in_h + pad_h + ceil_pad_h;
+    const uint32_t in_w_padded = in_w + pad_w + ceil_pad_w;
+    const bool one_scalar_per_core = is_pool_op_one_scalar_per_core(
+        pool_type, ceil_mode, ceil_pad_h, ceil_pad_w, count_include_pad, pad_h, pad_w, divisor_override);
+
+    // Compute CB sizes centrally - used for both CB creation and L1 validation.
+    // When the DRAM config-tensor path is active, the reader indices tensor is already built on
+    // host so we pass its real per-core page size. Auto-shard evaluation in pool_utils.cpp still
+    // falls back to the worst case because the buffers do not exist yet there. The scalar config
+    // tensor (only created for avg pool without one_scalar_per_core) is not yet known at this
+    // point, so its prediction remains the worst case; that matches how the CB is created below.
+    auto output_shard_shape = outputs[0].shard_spec().value().shape;
+    std::optional<uint32_t> reader_indices_actual_page_size;
+    if (config_tensor_in_dram) {
+        reader_indices_actual_page_size = reader_indices_buffer->page_size();
+    }
+    PoolCBSizes cb_sizes = calculate_pool_cb_sizes(
+        params,
+        one_scalar_per_core,
+        return_indices,
+        output_layout,
+        outputs[0].dtype(),
+        {output_shard_shape[0], output_shard_shape[1]},
+        config_tensor_in_dram,
+        reader_indices_actual_page_size);
+
+    const auto& input_shape = input.padded_shape();
+    const uint32_t shard_width = input.shard_spec()->shape[1];
+    const uint32_t in_c_per_shard_ceil = in_c % shard_width != 0 && num_shards_c > 1
+                                             ? (in_c - (in_c % shard_width)) / (num_shards_c - 1)
+                                             : in_c / num_shards_c;
+    const uint32_t in_nbytes_c = in_c_per_shard_ceil * params.nbytes;  // row of input (channels)
+    const uint32_t shard_width_bytes = input_shape[3] / num_shards_c * params.nbytes;
+
+    TT_FATAL(
+        input_shape[3] % num_shards_c == 0,
+        "Input channels {} should be divisible by number of shards {}",
+        input_shape[3],
+        num_shards_c);
+    const uint32_t in_nbytes_leftover =
+        params.is_wide_reduction &&
+                (input_shape[3] / num_shards_c) % (params.MAX_TILES_PER_REDUCTION * tt::constants::TILE_WIDTH) != 0
+            ? tt::round_up(
+                  (input_shape[3] / num_shards_c) % (params.MAX_TILES_PER_REDUCTION * tt::constants::TILE_WIDTH),
+                  tt::constants::TILE_WIDTH) *
+                  params.nbytes
+            : tt::round_up(input_shape[3] / num_shards_c, tt::constants::TILE_WIDTH) * params.nbytes;
+
+    ProgramDescriptor desc;
+
+    // Helper to add a non-globally-allocated (local) CB to desc with a single format.
+    auto add_local_cb = [&](uint32_t cb_id,
+                            uint32_t page_size,
+                            uint32_t num_pages,
+                            tt::DataFormat data_format,
+                            std::optional<FaceGeometry> face_geometry = std::nullopt,
+                            std::optional<TileDescriptor> tile = std::nullopt) {
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = page_size * num_pages,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(cb_id),
+                .data_format = data_format,
+                .page_size = page_size,
+                .tile = tile,
+                .face_geometry = face_geometry,
+            }}},
+        });
+    };
+    // Helper for sharded (globally-allocated) CBs whose address is patched on cache hit.
+    auto add_sharded_cb = [&](uint32_t cb_id,
+                              uint32_t page_size,
+                              uint32_t num_pages,
+                              tt::DataFormat data_format,
+                              tt::tt_metal::Buffer* buffer,
+                              std::optional<FaceGeometry> face_geometry = std::nullopt,
+                              std::optional<TileDescriptor> tile = std::nullopt) {
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = page_size * num_pages,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(cb_id),
+                .data_format = data_format,
+                .page_size = page_size,
+                .tile = tile,
+                .face_geometry = face_geometry,
+            }}},
+            .buffer = buffer,
+        });
+    };
+
+    uint32_t next_cb_index = tt::CBIndex::c_0;
+    const uint32_t in_scalar_cb_id_0 = next_cb_index++;
+    const uint32_t in_scalar_cb_pagesize = cb_sizes.scalar_cb_pagesize;
+    const uint32_t in_scalar_cb_npages = cb_sizes.scalar_cb_npages;
+    const auto scalar_face_geometry = FaceGeometry{.face_r_dim = 1, .num_faces = 4};
+    add_local_cb(
+        in_scalar_cb_id_0, in_scalar_cb_pagesize, in_scalar_cb_npages, params.data_format, scalar_face_geometry);
+    log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", in_scalar_cb_id_0, in_scalar_cb_pagesize, in_scalar_cb_npages);
+
+    uint32_t in_scalar_cb_id_1 = INVALID_CB_ID;
+    if (cb_sizes.has_second_scalar_cb) {
+        in_scalar_cb_id_1 = next_cb_index++;
+        add_local_cb(
+            in_scalar_cb_id_1, in_scalar_cb_pagesize, in_scalar_cb_npages, params.data_format, scalar_face_geometry);
+        log_debug(
+            tt::LogOp, "CB {} :: PS = {}, NP = {}", in_scalar_cb_id_1, in_scalar_cb_pagesize, in_scalar_cb_npages);
+    }
+
+    // CB storing just "clear value" (-inf for maxpool, 0 for avgpool)
+    uint32_t clear_value_cb_id = next_cb_index++;
+    add_local_cb(clear_value_cb_id, cb_sizes.clear_value_cb_size, 1, params.data_format);
+    log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", clear_value_cb_id, cb_sizes.clear_value_cb_size, 1);
+
+    // incoming data is the input cb instead of raw l1/dram addr
+    // this input shard has halo and padding inserted.
+    const uint32_t raw_in_cb_npages = input.shard_spec().value().shape[0];
+    const uint32_t raw_in_cb_pagesize = in_nbytes_c;
+    const uint32_t raw_in_cb_id = next_cb_index++;
+    add_sharded_cb(raw_in_cb_id, raw_in_cb_pagesize, raw_in_cb_npages, params.data_format, input.buffer());
+
+    log_debug(tt::LogOp, "Raw In CB {} :: PS = {}, NP = {}", raw_in_cb_id, raw_in_cb_pagesize, raw_in_cb_npages);
+
+    // reader indices
+    const uint32_t in_reader_indices_cb_id = next_cb_index++;
+    const uint32_t in_reader_indices_cb_pagesize =
+        tt::round_up(reader_indices_size, 4);  // pagesize needs to be multiple of 4
+    constexpr uint32_t in_reader_indices_cb_npages = 1;
+
+    const uint32_t max_reader_indices_size =
+        (max_out_nhw_per_core * 3 * sizeof(uint16_t)) + 2;  // worst case of 3 indices per output element
+    const uint32_t actual_reader_indices_buffer_page_size = reader_indices_buffer->page_size();
+    TT_FATAL(
+        actual_reader_indices_buffer_page_size <= max_reader_indices_size,
+        "Reader indices buffer page size {} exceeds max expected size {}",
+        actual_reader_indices_buffer_page_size,
+        max_reader_indices_size);
+
+    if (config_tensor_in_dram) {
+        // DRAM-backed reader indices buffer: the CB is purely local scratch; the kernel
+        // reads from DRAM via TensorAccessor and the CB is sized to the actual buffer
+        // page size (see PR #43193) to keep the L1 footprint tight. The worst-case
+        // value above is only used as an upper-bound check.
+        add_local_cb(
+            in_reader_indices_cb_id,
+            actual_reader_indices_buffer_page_size,
+            in_reader_indices_cb_npages,
+            tt::DataFormat::UInt16);
+    } else {
+        add_sharded_cb(
+            in_reader_indices_cb_id,
+            in_reader_indices_cb_pagesize,
+            in_reader_indices_cb_npages,
+            tt::DataFormat::UInt16,
+            reader_indices_buffer);
+    }
+
+    log_debug(
+        tt::LogOp,
+        "In Reader Indices CB {} :: PS = {}, NP = {}",
+        in_reader_indices_cb_id,
+        in_reader_indices_cb_pagesize,
+        in_reader_indices_cb_npages);
+    // in_nblocks_c is factory-specific (used for kernel args), derived from the shared in_cb_raw_size
+    uint32_t in_nblocks_c = 1;
+    if (return_indices || params.is_wide_reduction) {
+        in_nblocks_c =
+            static_cast<uint32_t>(std::ceil(static_cast<float>(params.in_ntiles_c) / params.MAX_TILES_PER_REDUCTION));
+    }
+
+    // reader output == input to tilize
+    const uint32_t in_cb_id_0 = next_cb_index++;  // input rows for "multiple (out_nelems)" output pixels
+    uint32_t in_cb_id_1 = INVALID_CB_ID;          // input rows for "multiple (out_nelems)" output pixels
+    const uint32_t in_cb_pagesize = cb_sizes.in_cb_pagesize;
+    const uint32_t in_cb_npages = cb_sizes.in_cb_npages;
+
+    const uint32_t window_size_hw = kernel_h * kernel_w;
+    const uint32_t raw_face_r = std::min(window_size_hw, 16u);
+    const uint32_t num_faces_in_input_tile_for_cb =
+        (params.max_rows_for_reduction < tt::constants::TILE_HEIGHT || window_size_hw <= tt::constants::FACE_HEIGHT)
+            ? 2u
+            : 4u;
+    const std::optional<FaceGeometry> input_face_geometry =
+        return_indices
+            ? std::nullopt
+            : std::optional{FaceGeometry{.face_r_dim = raw_face_r, .num_faces = num_faces_in_input_tile_for_cb}};
+
+    add_local_cb(in_cb_id_0, in_cb_pagesize, in_cb_npages, params.data_format, input_face_geometry);
+    log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", in_cb_id_0, in_cb_pagesize, in_cb_npages);
+
+    if (cb_sizes.has_split_reader) {
+        in_cb_id_1 = next_cb_index++;
+        add_local_cb(in_cb_id_1, in_cb_pagesize, in_cb_npages, params.data_format, input_face_geometry);
+        log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", in_cb_id_1, in_cb_pagesize, in_cb_npages);
+    }
+
+    uint32_t in_idx_cb_id = INVALID_CB_ID;
+    uint32_t pack_tmp_cb_id = INVALID_CB_ID;
+    uint32_t pack_idx_tmp_cb_id = INVALID_CB_ID;
+    uint32_t right_inc_cb_id = INVALID_CB_ID;
+    uint32_t down_left_wrap_inc_cb_id = INVALID_CB_ID;
+    uint32_t up_left_wrap_inc_cb_id = INVALID_CB_ID;
+    uint32_t intra_kernel_right_inc_cb_id = INVALID_CB_ID;
+    uint32_t intra_kernel_down_left_wrap_inc_cb_id = INVALID_CB_ID;
+    uint32_t compute_tmp_idx_cb_id = INVALID_CB_ID;
+    uint32_t right_inc = 0;
+    uint32_t down_left_wrap_inc = 0;
+    uint32_t up_left_wrap_inc = 0;
+    uint32_t intra_kernel_right_inc = 0;
+    uint32_t intra_kernel_down_left_wrap_inc = 0;
+    bool indexes_32_bit = false;
+    if (return_indices) {
+        indexes_32_bit = params.index_format == tt::DataFormat::UInt32;
+        uint32_t tile_elems = tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT;
+        in_idx_cb_id = next_cb_index++;
+        add_local_cb(in_idx_cb_id, params.index_nbytes * tile_elems, 1, params.index_format);
+        log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", in_idx_cb_id, params.index_nbytes * tile_elems, 1);
+        pack_tmp_cb_id = next_cb_index++;
+        add_local_cb(pack_tmp_cb_id, params.nbytes * tile_elems, 1, params.data_format);
+        log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", pack_tmp_cb_id, params.nbytes * tile_elems, 1);
+        pack_idx_tmp_cb_id = next_cb_index++;
+        add_local_cb(pack_idx_tmp_cb_id, params.index_nbytes * tile_elems, 1, params.index_format);
+        log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", pack_idx_tmp_cb_id, params.index_nbytes * tile_elems, 1);
+        right_inc_cb_id = next_cb_index++;
+        add_local_cb(right_inc_cb_id, params.index_nbytes * tile_elems, 1, params.index_format);
+        log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", right_inc_cb_id, params.index_nbytes * tile_elems, 1);
+        down_left_wrap_inc_cb_id = next_cb_index++;
+        add_local_cb(down_left_wrap_inc_cb_id, params.index_nbytes * tile_elems, 1, params.index_format);
+        log_debug(
+            tt::LogOp, "CB {} :: PS = {}, NP = {}", down_left_wrap_inc_cb_id, params.index_nbytes * tile_elems, 1);
+        up_left_wrap_inc_cb_id = next_cb_index++;
+        add_local_cb(up_left_wrap_inc_cb_id, params.index_nbytes * tile_elems, 1, params.index_format);
+        log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", up_left_wrap_inc_cb_id, params.index_nbytes * tile_elems, 1);
+
+        compute_tmp_idx_cb_id = next_cb_index++;
+        add_local_cb(compute_tmp_idx_cb_id, params.index_nbytes * tile_elems, 1, params.index_format);
+        log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", compute_tmp_idx_cb_id, params.index_nbytes * tile_elems, 1);
+
+        // compute increments for index tile population
+        right_inc = stride_w;
+        down_left_wrap_inc = in_w * stride_h + (1 - out_w) * stride_w;
+        up_left_wrap_inc =
+            (1 - out_h) * stride_h * in_w + (1 - out_w) * stride_w;  // allow overflow for negative values
+
+        // edit incs for large kernels
+        if (params.is_large_kernel) {
+            intra_kernel_right_inc_cb_id = next_cb_index++;
+            add_local_cb(intra_kernel_right_inc_cb_id, params.index_nbytes * tile_elems, 1, params.index_format);
+            log_debug(
+                tt::LogOp,
+                "CB {} :: PS = {}, NP = {}",
+                intra_kernel_right_inc_cb_id,
+                params.index_nbytes * tile_elems,
+                1);
+            intra_kernel_down_left_wrap_inc_cb_id = next_cb_index++;
+            add_local_cb(
+                intra_kernel_down_left_wrap_inc_cb_id, params.index_nbytes * tile_elems, 1, params.index_format);
+            log_debug(
+                tt::LogOp,
+                "CB {} :: PS = {}, NP = {}",
+                intra_kernel_down_left_wrap_inc_cb_id,
+                params.index_nbytes * tile_elems,
+                1);
+
+            // for large kernels we process row by row since inc's aren't consistent if we just process fixed-size
+            // batches this means we process multiple top left positions within the kernel for a single top left
+            // position in the tensor, so when we move the kernel to a new position in the tensor we need to subtract
+            // the difference between the first top left index in the kernel and the last one
+            uint32_t sticks_per_chunk =
+                kernel_w <= params.max_rows_for_reduction ? kernel_w : params.max_rows_for_reduction;
+            uint32_t w_chunks =
+                kernel_w % sticks_per_chunk == 0 ? kernel_w / sticks_per_chunk : (kernel_w / sticks_per_chunk) + 1;
+            uint32_t last_w_chunk_w_offset = (w_chunks - 1) * sticks_per_chunk * dilation_w;
+            uint32_t first_top_left_kernel_index = 0;
+            uint32_t last_top_left_kernel_index = ((kernel_h - 1) * dilation_h * in_w) + last_w_chunk_w_offset;
+            uint32_t index_correction = last_top_left_kernel_index - first_top_left_kernel_index;
+            right_inc -= index_correction;
+            down_left_wrap_inc -= index_correction;
+            up_left_wrap_inc -= index_correction;
+
+            intra_kernel_right_inc = dilation_w * sticks_per_chunk;
+            intra_kernel_down_left_wrap_inc = dilation_h * in_w - last_w_chunk_w_offset;
+        }
+    }
+
+    const bool is_output_tiled = output_layout == Layout::TILE;
+    const bool is_output_block_format = is_block_float(outputs[0].dtype());
+    const bool zero_pages = is_output_tiled && is_output_block_format;
+
+    // Conditionally allocate temporary CB - only needed for TILED output
+    uint32_t pre_tilize_cb_id = INVALID_CB_ID;
+    uint32_t fast_tilize_cb_id = INVALID_CB_ID;
+
+    constexpr uint32_t pack_untilize_face_r_dim = 1;
+    const bool last_tile_is_partial = in_c % tt::constants::TILE_WIDTH != 0;
+    const bool single_partial_fits_in_face = last_tile_is_partial && in_c <= tt::constants::FACE_WIDTH;
+    const uint32_t pack_untilize_num_faces = single_partial_fits_in_face ? 1u : 2u;
+    const auto pack_untilize_face_geometry =
+        FaceGeometry{.face_r_dim = pack_untilize_face_r_dim, .num_faces = pack_untilize_num_faces};
+    const std::optional<TileDescriptor> pack_untilize_tile =
+        single_partial_fits_in_face ? std::optional{TileDescriptor{1, tt::constants::FACE_WIDTH, false}} : std::nullopt;
+
+    if (cb_sizes.has_pre_tilize) {
+        pre_tilize_cb_id = next_cb_index++;
+        fast_tilize_cb_id = next_cb_index++;
+        // pre_tilize_cb is a multi-format CB: one L1 allocation backs two CB indices that
+        // present different face_geometry/page_size views of the same bytes.
+        //   * pre_tilize_cb_id  -- producer view, used by pack_untilize. Stick-packed
+        //                          (face_r_dim=1, num_faces<=2), pagesize=TILE_WIDTH*nbytes.
+        //   * fast_tilize_cb_id -- consumer view, used by fast_tilize. Full-tile
+        //                          (face_r_dim=16, num_faces=4), pagesize=tile_size.
+        // The kernel keeps both FIFOs in lock-step by pushing/popping the same byte amount
+        // per round, so their rd/wr pointers always point at matching L1 addresses.
+        const uint32_t pre_tilize_total_size = cb_sizes.pre_tilize_cb_pagesize * cb_sizes.pre_tilize_cb_npages;
+        const uint32_t fast_tilize_page_size = tt::tile_size(params.data_format);
+        TT_FATAL(
+            pre_tilize_total_size % fast_tilize_page_size == 0,
+            "pre_tilize_cb total size {} must be a multiple of fast_tilize tile size {}",
+            pre_tilize_total_size,
+            fast_tilize_page_size);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = pre_tilize_total_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{
+                CBFormatDescriptor{
+                    .buffer_index = static_cast<uint8_t>(pre_tilize_cb_id),
+                    .data_format = params.data_format,
+                    .page_size = cb_sizes.pre_tilize_cb_pagesize,
+                    .tile = pack_untilize_tile,
+                    .face_geometry = pack_untilize_face_geometry,
+                },
+                CBFormatDescriptor{
+                    .buffer_index = static_cast<uint8_t>(fast_tilize_cb_id),
+                    .data_format = params.data_format,
+                    .page_size = fast_tilize_page_size,
+                    // tile/face_geometry left nullopt -> default 32x32, 4 faces of 16x16.
+                },
+            }},
+        });
+        log_debug(
+            tt::LogOp,
+            "CB {} :: PS = {}, NP = {} (aliased as fast_tilize CB {} PS = {} NP = {})",
+            pre_tilize_cb_id,
+            cb_sizes.pre_tilize_cb_pagesize,
+            cb_sizes.pre_tilize_cb_npages,
+            fast_tilize_cb_id,
+            fast_tilize_page_size,
+            pre_tilize_total_size / fast_tilize_page_size);
+    }
+
+    const uint32_t out_cb_pagesize = cb_sizes.out_cb_pagesize;
+    const uint32_t out_cb_npages = cb_sizes.out_cb_npages;
+
+    const uint32_t out_cb_id = next_cb_index++;
+    add_sharded_cb(
+        out_cb_id,
+        out_cb_pagesize,
+        out_cb_npages,
+        params.output_data_format,
+        outputs[0].buffer(),
+        is_output_tiled ? std::nullopt : std::optional{pack_untilize_face_geometry},
+        is_output_tiled ? std::nullopt : pack_untilize_tile);
+
+    uint32_t out_idx_cb_id = INVALID_CB_ID;
+    if (cb_sizes.has_out_idx) {
+        TT_FATAL(
+            outputs.size() == 2,
+            "When return_indices is true, there should be two outputs, but got {}",
+            outputs.size());
+        out_idx_cb_id = next_cb_index++;
+        add_sharded_cb(
+            out_idx_cb_id,
+            cb_sizes.out_idx_cb_pagesize,
+            cb_sizes.out_idx_cb_npages,
+            params.index_format,
+            outputs[1].buffer());
+    }
+    log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", out_cb_id, out_cb_pagesize, out_cb_npages);
+
+    for (const auto& output : outputs) {
+        TT_FATAL(
+            output.memory_config().is_sharded(),
+            "Output memory config needs to be sharded, but got {}",
+            output.memory_config());
+    }
+
+    /**
+     * Reader Kernel: input rows -> input cb
+     */
+    uint32_t config_cb_id = INVALID_CB_ID;
+    tt::tt_metal::Buffer* config_buffer = nullptr;
+    if (!one_scalar_per_core) {
+        // The scalar config tensor was uploaded once in create_workload_descriptor
+        // and parked in WorkloadDescriptor::buffers; the framework keeps it
+        // alive for the cached workload's lifetime.  scalar_config_buffer must
+        // be non-null whenever !one_scalar_per_core (avg-pool with non-trivial
+        // scalar layout).
+        TT_FATAL(scalar_config_buffer != nullptr, "scalar config buffer must be populated when !one_scalar_per_core");
+
+        constexpr tt::DataFormat config_df = tt::DataFormat::RawUInt32;
+        config_buffer = scalar_config_buffer;
+        const uint32_t config_buffer_page_size = config_buffer->page_size();
+        uint32_t max_config_tensor_size =
+            max_out_nhw_per_core * 3 * sizeof(uint16_t);  // worst case of 3 entries per output element
+
+        TT_FATAL(
+            config_buffer->page_size() <= max_config_tensor_size,
+            "Config tensor buffer page size {} exceeds max expected size {}",
+            config_buffer->page_size(),
+            max_config_tensor_size);
+
+        config_cb_id = next_cb_index++;
+        if (config_tensor_in_dram) {
+            // DRAM-backed: kernel reads from DRAM via TensorAccessor; the CB is
+            // local scratch sized to the worst-case payload of one page.
+            add_local_cb(config_cb_id, max_config_tensor_size, 1, config_df);
+        } else {
+            add_sharded_cb(config_cb_id, config_buffer_page_size, 1, config_df, config_buffer);
+        }
+    }
+    KernelDescriptor::CompileTimeArgs reader0_ct_args = {
+        max_out_nhw_per_core,                                  // 0
+        kernel_h,                                              // 1
+        kernel_w,                                              // 2
+        pad_w,                                                 // 3
+        in_nbytes_leftover,                                    // 4
+        in_w,                                                  // 5
+        in_c_per_shard_ceil,                                   // 6
+        params.split_reader,                                   // enable split reader //7
+        0,                                                     // split reader id //8
+        bf16_scalar,                                           // 9
+        bf16_init_value,                                       // 10
+        in_nblocks_c,                                          // 11
+        cb_sizes.in_cb_raw_size,                               // 12
+        params.max_rows_for_reduction,                         // 13
+        ceil_pad_w,                                            // 14
+        in_cb_id_0,                                            // 15
+        in_cb_id_1,                                            // 16
+        raw_in_cb_id,                                          // 17
+        in_reader_indices_cb_id,                               // 18
+        in_scalar_cb_id_0,                                     // 19
+        in_scalar_cb_id_1,                                     // 20
+        clear_value_cb_id,                                     // 21
+        static_cast<uint32_t>(pool_type),                      // 22
+        one_scalar_per_core,                                   // 23
+        config_cb_id,                                          // 24
+        in_nbytes_c,                                           // 25
+        shard_width_bytes,                                     // 26
+        params.multi_buffering_factor,                         // 27
+        stride_w,                                              // 28
+        dilation_h,                                            // 29
+        dilation_w,                                            // 30
+        static_cast<uint32_t>(zero_pages),                     // 31
+        config_tensor_in_dram,                                 // 32
+        one_scalar_per_core ? 0 : config_buffer->address(),    // 33
+        one_scalar_per_core ? 0 : config_buffer->page_size(),  // 34
+        reader_indices_buffer->address(),                      // 35
+        reader_indices_buffer->page_size(),                    // 36
+        // MPWI-only args start here (for reader_mpwi.cpp, not used by reader_pool_2d.cpp)
+        in_idx_cb_id,                           // 37
+        pack_tmp_cb_id,                         // 38
+        pack_idx_tmp_cb_id,                     // 39
+        right_inc_cb_id,                        // 40
+        down_left_wrap_inc_cb_id,               // 41
+        up_left_wrap_inc_cb_id,                 // 42
+        pad_t,                                  // 43
+        pad_l,                                  // 44
+        right_inc,                              // 45
+        down_left_wrap_inc,                     // 46
+        up_left_wrap_inc,                       // 47
+        intra_kernel_right_inc,                 // 48
+        intra_kernel_down_left_wrap_inc,        // 49
+        out_cb_id,                              // 50
+        out_idx_cb_id,                          // 51
+        intra_kernel_right_inc_cb_id,           // 52
+        intra_kernel_down_left_wrap_inc_cb_id,  // 53
+        static_cast<uint32_t>(indexes_32_bit),  // 54
+    };
+
+    tt::tt_metal::TensorAccessorArgs(reader_indices_buffer).append_to(reader0_ct_args);
+    if (!one_scalar_per_core) {
+        tt::tt_metal::TensorAccessorArgs(config_buffer).append_to(reader0_ct_args);
+    }
+    KernelDescriptor::CompileTimeArgs reader1_ct_args = reader0_ct_args;
+    reader1_ct_args[8] = 1;  // split reader id for reader1
+
+    std::string reader_kernel_fname =
+        return_indices ? "ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/dataflow/"
+                         "reader_mpwi.cpp"
+                       : "ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/dataflow/"
+                         "reader_pool_2d.cpp";
+
+    KernelDescriptor reader0_desc;
+    reader0_desc.kernel_source = reader_kernel_fname;
+    reader0_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader0_desc.core_ranges = all_cores;
+    reader0_desc.compile_time_args = std::move(reader0_ct_args);
+    reader0_desc.config = DataMovementConfigDescriptor{
+        .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+        .noc = tt::tt_metal::NOC::RISCV_0_default,
+    };
+
+    std::optional<KernelDescriptor> reader1_desc;
+    if (params.split_reader) {
+        KernelDescriptor rd;
+        rd.kernel_source = reader_kernel_fname;
+        rd.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        rd.core_ranges = all_cores;
+        rd.compile_time_args = std::move(reader1_ct_args);
+        rd.config = DataMovementConfigDescriptor{
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = tt::tt_metal::NOC::RISCV_1_default,
+        };
+        reader1_desc = std::move(rd);
+    }
+
+    /**
+     * Compute Kernel: input cb -> tilize_block -> input tiles -> reduce_h max -> output tiles -> untilize_block ->
+     * output cb
+     */
+
+    KernelDescriptor::CompileTimeArgs compute_ct_args = {
+        params.in_ntiles_c,             // 0
+        kernel_h * kernel_w,            // 1
+        params.split_reader,            // 2
+        0,                              // 3 - max_out_nhw_per_core, used for grid sample but not for pool
+        in_c_per_shard_ceil,            // 4
+        in_nblocks_c,                   // 5
+        params.max_rows_for_reduction,  // 6
+        in_cb_id_0,                     // 7
+        in_cb_id_1,                     // 8
+        in_scalar_cb_id_0,              // 9
+        in_scalar_cb_id_1,              // 10
+        out_cb_id,                      // 11
+        one_scalar_per_core,            // 12
+        pre_tilize_cb_id,               // 13
+        is_output_tiled,                // 14
+        is_output_block_format,         // 15
+        0,                              // 16: force_max_tiles_per_reduction_4 (off for pool2d)
+        // MPWI-only args start here (for compute_mpwi.cpp, not used by compute_pool_2d.cpp)
+        in_idx_cb_id,                           // 17
+        pack_tmp_cb_id,                         // 18
+        pack_idx_tmp_cb_id,                     // 19
+        right_inc_cb_id,                        // 20
+        down_left_wrap_inc_cb_id,               // 21
+        up_left_wrap_inc_cb_id,                 // 22
+        out_idx_cb_id,                          // 23
+        stride_h,                               // 24
+        stride_w,                               // 25
+        in_h_padded,                            // 26
+        in_w_padded,                            // 27
+        eff_kernel_h,                           // 28
+        eff_kernel_w,                           // 29
+        pad_l,                                  // 30
+        intra_kernel_right_inc_cb_id,           // 31
+        intra_kernel_down_left_wrap_inc_cb_id,  // 32
+        compute_tmp_idx_cb_id,                  // 33
+        clear_value_cb_id,                      // 34
+        kernel_h,                               // 35
+        kernel_w,                               // 36
+        static_cast<uint32_t>(indexes_32_bit),  // 37
+        // compute_pool_2d.cpp-only arg (ignored by compute_mpwi.cpp)
+        fast_tilize_cb_id  // 38 - consumer-view alias of pre_tilize_cb_id (full-tile face_geometry)
+    };
+
+    // Get device arch for compute kernel config initialization
+    auto device_arch = input.device()->arch();
+
+    // Initialize device compute kernel config with user-provided config or defaults
+    auto device_compute_kernel_config = init_device_compute_kernel_config(
+        device_arch,
+        compute_kernel_config,
+        tt::tt_metal::MathFidelity::HiFi4,
+        false,                                                             // math_approx_mode
+        (params.is_avg_pool && params.is_large_kernel) || indexes_32_bit,  // fp32_dest_acc_en
+        false,                                                             // packer_l1_acc
+        (params.is_large_kernel && return_indices) || indexes_32_bit       // dst_full_sync_en
+    );
+
+    const auto pool_defines_map = get_defines(pool_type);
+    KernelDescriptor::Defines compute_defines(pool_defines_map.begin(), pool_defines_map.end());
+
+    std::string compute_kernel_fname =
+        return_indices
+            ? "ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/compute/compute_mpwi.cpp"
+            : "ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/compute/compute_pool_2d.cpp";
+
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source = compute_kernel_fname;
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = all_cores;
+    compute_desc.compile_time_args = std::move(compute_ct_args);
+    compute_desc.defines = std::move(compute_defines);
+    compute_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = get_math_fidelity(device_compute_kernel_config),
+        .fp32_dest_acc_en = get_fp32_dest_acc_en(device_compute_kernel_config),
+        .dst_full_sync_en = get_dst_full_sync_en(device_compute_kernel_config),
+        .math_approx_mode = false,
+    };
+
+    // set the starting indices for each core as runtime args
+    uint32_t total_out_nhw = in_n * out_h * out_w;
+    for (uint32_t core_i = 0; core_i < ncores; core_i++) {
+        const uint32_t core_x_i = core_i % rectangular_x;
+        const uint32_t core_y_i = core_i / rectangular_x;
+        const CoreCoord core(core_x_i, core_y_i);
+
+        uint32_t total_out_nhw_processed;
+        uint32_t core_nhw_index = 0;
+        if (is_block_sharded) {
+            total_out_nhw_processed = core_y_i * max_out_nhw_per_core;
+            core_nhw_index = core_y_i;
+        } else if (is_width_sharded) {
+            total_out_nhw_processed = 0;
+            core_nhw_index = 0;
+        } else {
+            total_out_nhw_processed = core_i * max_out_nhw_per_core;
+            core_nhw_index = core_i;
+        }
+        uint32_t remaining_out_nhw =
+            total_out_nhw_processed < total_out_nhw ? total_out_nhw - total_out_nhw_processed : 0;
+        uint32_t out_nhw_this_core = std::min(max_out_nhw_per_core, remaining_out_nhw);
+        KernelDescriptor::CoreRuntimeArgs args = {out_nhw_this_core, core_nhw_index};
+
+        if (return_indices) {
+            TT_FATAL(core_starting_indices.size() == ncores, "core starting indices size should match number of cores");
+            const uint32_t start_index = core_starting_indices[core_i];
+            const uint32_t start_mod_batch = start_index % (in_w_padded * in_h_padded);
+            const uint32_t start_row = start_mod_batch / in_w_padded;
+            const uint32_t start_col = start_mod_batch % in_w_padded;
+
+            args.push_back(start_row);
+            args.push_back(start_col);
+        }
+        reader0_desc.runtime_args.emplace_back(core, args);
+        if (params.split_reader) {
+            reader1_desc->runtime_args.emplace_back(core, args);
+        }
+        compute_desc.runtime_args.emplace_back(core, std::move(args));
+    }
+
+    // Push kernels in deterministic order: reader0 (BRISC), reader1 (NCRISC) when
+    // split_reader is enabled, then compute. The framework patches per-core runtime
+    // args by kernel index, so this ordering MUST match between every invocation.
+    desc.kernels.push_back(std::move(reader0_desc));
+    if (reader1_desc.has_value()) {
+        desc.kernels.push_back(std::move(*reader1_desc));
+    }
+    desc.kernels.push_back(std::move(compute_desc));
+
+    // Validate local and global CB sizes separately to prevent two errors from cancelling out.
+    // Note: local CBs are non-globally-allocated (computed by the program); global CBs are
+    // tensor-backed (sharded onto an existing buffer). We compute these directly from the
+    // descriptor's CBs rather than from a Program object since we no longer create one here.
+    uint32_t actual_local_cb_size = 0;
+    for (const auto& cb : desc.cbs) {
+        if (cb.buffer == nullptr) {
+            actual_local_cb_size += cb.total_size;
+        }
+    }
+
+    uint32_t post_allocate_size =
+        input.device()->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_allocated_bytes;
+    uint32_t actual_global_cb_size = post_allocate_size == 0 ? 0 : post_allocate_size - memory_used;
+
+    // For now assume that if post_op_l1_allocation_size == 0 op is being run
+    // in graph capture NO_DISPATCH mode.
+    bool is_graph_capture_no_dispatch_mode = post_allocate_size == 0;
+    TT_FATAL(
+        actual_local_cb_size == cb_sizes.local_cb_total() || is_graph_capture_no_dispatch_mode,
+        "Local CB size mismatch: actual {} != expected {}",
+        actual_local_cb_size,
+        cb_sizes.local_cb_total());
+    TT_FATAL(
+        actual_global_cb_size == cb_sizes.global_cb_total() || is_graph_capture_no_dispatch_mode,
+        "Global CB size mismatch: actual {} != expected {}",
+        actual_global_cb_size,
+        cb_sizes.global_cb_total());
+
+    {  // debug
+        log_debug(tt::LogOp, "raw_in_cb :: PS = {}, NP = {}", raw_in_cb_pagesize, raw_in_cb_npages);
+        log_debug(tt::LogOp, "in_cb :: PS = {}, NP = {}", in_cb_pagesize, in_cb_npages);
+        log_debug(
+            tt::LogOp,
+            "in_reader_indices_cb :: PS = {}, NP = {}",
+            in_reader_indices_cb_pagesize,
+            in_reader_indices_cb_npages);
+        log_debug(tt::LogOp, "in_scalar_cb :: PS = {}, NP = {}", in_scalar_cb_pagesize, in_scalar_cb_npages);
+        log_debug(tt::LogOp, "out_cb :: PS = {}, NP = {}", out_cb_pagesize, out_cb_npages);
+        log_debug(tt::LogOp, "in_reader_indices_addr: {}", reader_indices_buffer->address());
+        log_debug(
+            tt::LogOp,
+            "scalar_config_addr: {}",
+            config_buffer != nullptr ? std::to_string(config_buffer->address()) : "not set");
+        log_debug(tt::LogOp, "kernel_h: {}", kernel_h);
+        log_debug(tt::LogOp, "kernel_w: {}", kernel_w);
+        log_debug(tt::LogOp, "stride_h: {}", stride_h);
+        log_debug(tt::LogOp, "stride_w: {}", stride_w);
+        log_debug(tt::LogOp, "pad_h: {}", pad_h);
+        log_debug(tt::LogOp, "pad_w: {}", pad_w);
+        log_debug(tt::LogOp, "out_h: {}", out_h);
+        log_debug(tt::LogOp, "out_w: {}", out_w);
+        log_debug(tt::LogOp, "out_c: {}", out_c);
+        log_debug(tt::LogOp, "in_h: {}", in_h);
+        log_debug(tt::LogOp, "in_w: {}", in_w);
+        log_debug(tt::LogOp, "in_c: {}", in_c);
+        log_debug(tt::LogOp, "in_ntiles_c: {}", params.in_ntiles_c);
+        log_debug(tt::LogOp, "out_ntiles_c: {}", params.out_ntiles_c);
+        log_debug(tt::LogOp, "in_nblocks_c: {}", in_nblocks_c);
+        log_debug(tt::LogOp, "in_nbytes_c: {}", in_nbytes_c);
+        log_debug(tt::LogOp, "ncores: {}", ncores);
+        log_debug(tt::LogOp, "max_out_nhw_per_core: {}", max_out_nhw_per_core);
+        log_debug(tt::LogOp, "split_reader: {}", params.split_reader);
+        log_debug(tt::LogOp, "multi_buffering_factor: {}", params.multi_buffering_factor);
+        log_debug(tt::LogOp, "is_wide_reduction: {}", params.is_wide_reduction);
+        log_debug(tt::LogOp, "is_in_sharded: {}", input.memory_config().is_sharded());
+        log_debug(tt::LogOp, "is_out_sharded: {}", outputs[0].memory_config().is_sharded());
+    }
+
+    return desc;
+}
+
+namespace {
+// Common preamble shared between the resource-allocation phase and the
+// per-coord program build of create_workload_descriptor(): pulls per-op fields out
+// of the SlidingWindowConfig and computes the parallel config / output shape
+// pieces we need in both phases.  Lives in an anonymous namespace because it's
+// purely a local helper for this factory.
+struct PoolSetup {
+    sliding_window::ParallelConfig parallel_config;
+    bool is_block_sharded;
+    uint32_t out_h, out_w, out_c;
+    uint32_t in_n, in_c, in_h, in_w;
+    uint32_t kernel_h, kernel_w;
+    uint32_t stride_h, stride_w;
+    uint32_t pad_t, pad_b, pad_l, pad_r;
+    uint32_t ceil_pad_h, ceil_pad_w;
+    bool ceil_mode;
+    uint32_t dilation_h, dilation_w;
+    uint32_t num_shards_c;
+};
+
+PoolSetup compute_pool_setup(const Pool2D::operation_attributes_t& op_attr, const Tensor& input) {
+    const auto& sliding_window_config = op_attr.sliding_window_config_;
+    PoolSetup setup;
+    setup.parallel_config = sliding_window::ParallelConfig{
+        .grid = input.shard_spec().value().grid,
+        .shard_scheme = input.memory_config().memory_layout(),
+        .shard_orientation = input.shard_spec().value().orientation,
+    };
+
+    auto output_shape = sliding_window_config.get_output_shape();
+    setup.out_h = output_shape[1];
+    setup.out_w = output_shape[2];
+    setup.out_c = output_shape[3];
+
+    setup.is_block_sharded = input.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
+    setup.in_n = sliding_window_config.batch_size;
+    setup.in_c = sliding_window_config.channels;
+    setup.in_h = sliding_window_config.input_hw.first;
+    setup.in_w = sliding_window_config.input_hw.second;
+    setup.kernel_h = sliding_window_config.window_hw.first;
+    setup.kernel_w = sliding_window_config.window_hw.second;
+    setup.stride_h = sliding_window_config.stride_hw.first;
+    setup.stride_w = sliding_window_config.stride_hw.second;
+    setup.pad_t = sliding_window_config.get_pad_top();
+    setup.pad_b = sliding_window_config.get_pad_bottom();
+    setup.pad_l = sliding_window_config.get_pad_left();
+    setup.pad_r = sliding_window_config.get_pad_right();
+    setup.ceil_pad_h = sliding_window_config.get_ceil_pad_h();
+    setup.ceil_pad_w = sliding_window_config.get_ceil_pad_w();
+    setup.ceil_mode = sliding_window_config.ceil_mode;
+    setup.dilation_h = sliding_window_config.dilation_hw.first;
+    setup.dilation_w = sliding_window_config.dilation_hw.second;
+    setup.num_shards_c = sliding_window_config.num_cores_c;
+    return setup;
+}
+}  // namespace
+
+tt::tt_metal::WorkloadDescriptor Pool2D::MultiCore::create_workload_descriptor(
+    const operation_attributes_t& op_attr,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output_tensors,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    const auto& input = tensor_args.input_tensor_;
+    const auto& sliding_window_config = op_attr.sliding_window_config_;
+    PoolSetup setup = compute_pool_setup(op_attr, input);
+
+    // Build the per-core sliding-window halo lookup table on host, then upload it.
+    // The resulting MeshBuffer must outlive the program, so we park its
+    // shared_ptr on the WorkloadDescriptor (held by the program cache).
+    std::vector<uint32_t> op_trace_metadata =
+        ttnn::operations::sliding_window::generate_op_trace_metadata(sliding_window_config);
+    std::vector<sliding_window::ShardBoundary> shard_boundaries =
+        ttnn::operations::sliding_window::generate_shard_boundaries(sliding_window_config);
+    std::vector<std::vector<uint16_t>> top_left_indices =
+        sliding_window::generate_sliding_window_op_config(op_trace_metadata, shard_boundaries, setup.stride_w);
+
+    Tensor reader_indices_host = sliding_window::construct_on_host_config_tensor(
+        top_left_indices, setup.parallel_config, op_attr.config_tensor_in_dram);
+    Tensor reader_indices_on_device = sliding_window::move_config_tensor_to_device(
+        reader_indices_host,
+        setup.parallel_config,
+        setup.is_block_sharded,
+        input.device(),
+        op_attr.config_tensor_in_dram);
+
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
+    // Keep the source Tensor alive in the cached workload.  Holding only a
+    // shared_ptr<MeshBuffer> would not be enough: when the local Tensor went
+    // out of scope here, ~Tensor would call DeviceStorage::deallocate which
+    // force-frees the underlying device memory regardless of shared_ptr
+    // ownership (see is_sole_owner_of_device_memory).  Wrapping the Tensor in
+    // a shared_ptr held by WorkloadBuffer.owner defers ~Tensor until the
+    // cached workload itself is evicted.
+    auto reader_indices_tensor_owner = std::make_shared<Tensor>(std::move(reader_indices_on_device));
+    tt::tt_metal::Buffer* reader_indices_buffer = reader_indices_tensor_owner->buffer();
+    workload_descriptor.buffers.push_back({reader_indices_tensor_owner, reader_indices_buffer});
+
+    // For avg-pool, decide whether a single bf16 scalar per core is sufficient.  When it isn't
+    // (ceil_mode w/ ceil_pad, or !count_include_pad with non-zero padding, both with no
+    // divisor_override), we materialize the per-output-stick scalar config tensor and upload it.
+    const uint32_t pad_h = setup.pad_t + setup.pad_b;
+    const uint32_t pad_w = setup.pad_l + setup.pad_r;
+    const bool one_scalar_per_core = is_pool_op_one_scalar_per_core(
+        op_attr.pool_type_,
+        setup.ceil_mode,
+        setup.ceil_pad_h,
+        setup.ceil_pad_w,
+        op_attr.count_include_pad_,
+        pad_h,
+        pad_w,
+        op_attr.divisor_override_);
+
+    if (!one_scalar_per_core) {
+        const uint32_t max_out_nhw_per_core = output_tensors[0].shard_spec()->shape[0];
+        const uint32_t ncores = input.shard_spec().value().grid.num_cores();
+
+        AvgPoolConfig avg_pool_config = {
+            .kernel_h = setup.kernel_h,
+            .kernel_w = setup.kernel_w,
+            .in_h = setup.in_h,
+            .in_w = setup.in_w,
+            .out_h = setup.out_h,
+            .out_w = setup.out_w,
+            .stride_h = setup.stride_h,
+            .stride_w = setup.stride_w,
+            .ceil_mode = setup.ceil_mode,
+            .ceil_h = setup.ceil_pad_h,
+            .ceil_w = setup.ceil_pad_w,
+            .count_include_pad = op_attr.count_include_pad_,
+            .pad_t = setup.pad_t,
+            .pad_b = setup.pad_b,
+            .pad_l = setup.pad_l,
+            .pad_r = setup.pad_r,
+            .max_out_nhw_per_core = max_out_nhw_per_core,
+            .divisor_override = op_attr.divisor_override_};
+        Tensor config_tensor = create_scalar_config_tensor(
+            avg_pool_config,
+            input.memory_config().memory_layout(),
+            setup.in_n,
+            setup.num_shards_c,
+            ncores,
+            op_attr.config_tensor_in_dram);
+
+        const std::array<uint32_t, 2> shard_shape =
+            std::array<uint32_t, 2>({1, static_cast<uint32_t>(config_tensor.logical_shape()[-1])});
+        const tt::tt_metal::ShardOrientation config_tensor_shard_orientation = input.shard_spec().value().orientation;
+        const tt::tt_metal::ShardSpec config_shard_spec(
+            input.shard_spec().value().grid, shard_shape, config_tensor_shard_orientation);
+        const MemoryConfig l1_small_memory_config{
+            TensorMemoryLayout::HEIGHT_SHARDED, BufferType::L1_SMALL, config_shard_spec};
+
+        Tensor config_tensor_on_device = config_tensor.to_device(
+            input.device(), op_attr.config_tensor_in_dram ? DRAM_MEMORY_CONFIG : l1_small_memory_config);
+        auto scalar_config_tensor_owner = std::make_shared<Tensor>(std::move(config_tensor_on_device));
+        tt::tt_metal::Buffer* scalar_config_buf = scalar_config_tensor_owner->buffer();
+        workload_descriptor.buffers.push_back({std::move(scalar_config_tensor_owner), scalar_config_buf});
+    }
+    tt::tt_metal::Buffer* scalar_config_buffer =
+        workload_descriptor.buffers.size() > 1 ? workload_descriptor.buffers[1].buffer : nullptr;
+
+    // Single-device op: the kernel program is structurally identical for every
+    // coord in `tensor_coords` (Pool2D doesn't depend on cluster position).
+    // Build the per-coord ProgramDescriptor ONCE and copy it into each
+    // coord-range entry to avoid redundant work on multi-coord workloads.
+    const auto& pool_type = op_attr.pool_type_;
+    const auto& compute_kernel_config = op_attr.compute_kernel_config_;
+    const auto& output_layout = op_attr.output_layout_;
+    bool count_include_pad = op_attr.count_include_pad_;
+    std::optional<int32_t> divisor_override = op_attr.divisor_override_;
+    bool return_indices = op_attr.return_indices_;
+
+    std::vector<uint32_t> core_starting_indices;
+    if (return_indices) {
+        const uint32_t num_cores_x = input.memory_config().shard_spec()->grid.bounding_box().grid_size().x;
+        const uint32_t ncores = input.shard_spec().value().grid.num_cores();
+        const TensorMemoryLayout shard_scheme = input.memory_config().memory_layout();
+        core_starting_indices =
+            generate_core_starting_indices(op_trace_metadata, shard_boundaries, shard_scheme, num_cores_x, ncores);
+    }
+
+    tt::tt_metal::ProgramDescriptor desc = pool2d_multi_core_sharded_with_halo_v2_impl_new(
+        tensor_args.input_tensor_,
+        reader_indices_buffer,
+        scalar_config_buffer,
+        top_left_indices[0].size(),
+        output_tensors,
+        pool_type,
+        setup.in_n,
+        setup.in_c,
+        setup.in_h,
+        setup.in_w,
+        setup.out_h,
+        setup.out_w,
+        setup.out_c,
+        setup.kernel_h,
+        setup.kernel_w,
+        setup.stride_h,
+        setup.stride_w,
+        setup.pad_t,
+        setup.pad_b,
+        setup.pad_l,
+        setup.pad_r,
+        setup.ceil_pad_h,
+        setup.ceil_pad_w,
+        setup.ceil_mode,
+        return_indices,
+        core_starting_indices,
+        count_include_pad,
+        setup.dilation_h,
+        setup.dilation_w,
+        setup.num_shards_c,
+        compute_kernel_config,
+        divisor_override,
+        op_attr.memory_used,
+        output_layout,
+        op_attr.config_tensor_in_dram);
+    auto ranges = tensor_coords.ranges();
+    workload_descriptor.programs.reserve(ranges.size());
+    for (size_t i = 0; i + 1 < ranges.size(); ++i) {
+        workload_descriptor.programs.push_back({ranges[i], desc});
+    }
+    if (!ranges.empty()) {
+        workload_descriptor.programs.push_back({ranges.back(), std::move(desc)});
+    }
+    return workload_descriptor;
+}
+
+}  // namespace ttnn::operations::pool::quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/pool_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/pool_op.cpp
@@ -1,0 +1,254 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "pool_op.hpp"
+#include "ttnn/tensor/tensor_ops.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/pool/pool_utils.hpp"
+
+#include <tt-metalium/math.hpp>
+#include <utility>
+
+/**
+ * Generic pool implementation that uses the new sliding window infrastructure.
+ */
+
+namespace ttnn::operations::pool::quasar {
+
+void validate_pool2d(
+    const Tensor& input,
+    const Pool2DType pool_type,
+    const sliding_window::SlidingWindowConfig& sliding_window_config,
+    const MemoryConfig& out_mem_config,
+    const std::optional<const int32_t> /*divisor_override*/,
+    const bool return_indices,
+    const Layout& output_layout) {
+    // check the input tensor
+    TT_FATAL(input.storage_type() == StorageType::DEVICE, "Pool2D input must be on device!");
+    TT_FATAL(input.buffer() != nullptr, "Pool2D input must be allocated in buffers on device!");
+    TT_FATAL(input.dtype() == DataType::BFLOAT16, "Only BFLOAT16 supported for now");
+    TT_FATAL(input.layout() == Layout::ROW_MAJOR, "Only ROW_MAJOR supported for now. Tracked by issue #23338");
+
+    TT_FATAL(input.memory_config().is_sharded(), "Input needs to be sharded");
+
+    if (return_indices) {
+        TT_FATAL(pool_type == Pool2DType::MAX_POOL2D, "Return_indices is only supported for MAX pool type");
+
+        // generality constraints, see https://github.com/tenstorrent/tt-metal/issues/27845
+        auto input_h = sliding_window_config.input_hw.first;
+        auto input_w = sliding_window_config.input_hw.second;
+        TT_FATAL(
+            input_h * input_w <= std::numeric_limits<uint32_t>::max(),
+            "Input HW {} will overflow uint32 indices max {}",
+            input_h * input_w,
+            std::numeric_limits<uint32_t>::max());
+
+        TT_FATAL(output_layout == Layout::ROW_MAJOR, "Only ROW_MAJOR supported when return_indices is true");
+    }
+
+    TT_FATAL(out_mem_config.is_sharded(), "Output memory config needs to be sharded");
+
+    const auto& input_shape = input.padded_shape();
+
+    // check that C dimnenion is a multiple of num_shards_c for all but height sharding
+    TensorMemoryLayout in_memory_layout = input.memory_config().memory_layout();
+    if (in_memory_layout != TensorMemoryLayout::HEIGHT_SHARDED) {
+        uint32_t num_shards_c = sliding_window_config.num_cores_c;
+        TT_FATAL(
+            input_shape[3] % num_shards_c == 0,
+            "For width and block sharding, input channels ({}) should be divisible by num_shards ({})",
+            input_shape[3],
+            num_shards_c);
+    }
+}
+
+// Validation is the same for both cache hit and miss
+static void validate_pool2d_operation(
+    const Pool2D::operation_attributes_t& op_attr, const Pool2D::tensor_args_t& tensor) {
+    validate_pool2d(
+        tensor.input_tensor_,
+        op_attr.pool_type_,
+        op_attr.sliding_window_config_,
+        op_attr.memory_config_,
+        op_attr.divisor_override_,
+        op_attr.return_indices_,
+        op_attr.output_layout_);
+}
+
+void Pool2D::validate_on_program_cache_miss(const operation_attributes_t& op_attr, const tensor_args_t& tensor) {
+    validate_pool2d_operation(op_attr, tensor);
+}
+
+void Pool2D::validate_on_program_cache_hit(const operation_attributes_t& op_attr, const tensor_args_t& tensor) {
+    validate_pool2d_operation(op_attr, tensor);
+}
+
+Pool2D::spec_return_value_t Pool2D::compute_output_specs(
+    const operation_attributes_t& op_attr, const tensor_args_t& /*tensor*/) {
+    const auto& sliding_window_config = op_attr.sliding_window_config_;
+    const auto& out_mem_config = op_attr.memory_config_;
+    const auto& output_dtype = op_attr.output_dtype_;
+
+    uint32_t out_h = sliding_window_config.get_output_shape()[1];
+    uint32_t out_w = sliding_window_config.get_output_shape()[2];
+    uint32_t out_c = sliding_window_config.channels;
+    uint32_t batch_size = sliding_window_config.batch_size;
+    uint32_t out_nhw = batch_size * out_h * out_w;
+
+    bool is_out_tiled = op_attr.output_layout_ == Layout::TILE;
+    uint32_t tile_rows = is_out_tiled ? tt::constants::TILE_HEIGHT : 1;
+
+    uint32_t num_cores_nhw = sliding_window_config.num_cores_nhw;
+    uint32_t num_cores_c = sliding_window_config.num_cores_c;
+    TT_FATAL(num_cores_nhw > 0, "num_cores_nhw must be > 0");
+    TT_FATAL(num_cores_c > 0, "num_cores_c must be > 0");
+
+    auto mem_config = out_mem_config;
+    auto layout = mem_config.memory_layout();
+
+    uint32_t out_nhw_padded = tt::round_up(out_nhw, tile_rows * num_cores_nhw);
+    // When the last per-shard tile is strictly less than one full face wide (channels % 32 < 16),
+    // round up to TILE_WIDTH so the packer can always write 2 full faces without reconfiguring.
+    // When channels % 32 == FACE_WIDTH (e.g. 80, 48 …), the last tile is exactly one face wide
+    // and the old FACE_WIDTH alignment is correct — no extra padding needed.
+    // Use ceiling division so that for WIDTH/BLOCK sharding, where channels may not divide evenly,
+    // we check the maximum per-shard channel count and avoid false partial-tile detection.
+    uint32_t channels_per_shard = tt::div_up(out_c, num_cores_c);
+    uint32_t cps_mod_tile = channels_per_shard % tt::constants::TILE_WIDTH;
+    // Skip tile-padding when the only tile per core is partial and fits in one face (single
+    // partial tile, first==last). In that case the kernel packs just 1 face, so FACE_WIDTH
+    // alignment matches the kernel output. See compute_pool_2d.cpp for the matching kernel
+    // condition (single_partial_fits_in_face).
+    bool needs_tile_pad =
+        cps_mod_tile > 0 && cps_mod_tile < tt::constants::FACE_WIDTH && channels_per_shard > tt::constants::FACE_WIDTH;
+    uint32_t base_alignment = needs_tile_pad ? tt::constants::TILE_WIDTH : tt::constants::TILE_WIDTH / 2;
+    uint32_t out_c_padded = tt::round_up(out_c, base_alignment);
+    if (mem_config.is_sharded()) {
+        if (layout == TensorMemoryLayout::WIDTH_SHARDED || layout == TensorMemoryLayout::BLOCK_SHARDED) {
+            out_c_padded = tt::round_up(out_c, num_cores_c * base_alignment);
+        }
+    }
+
+    if (is_out_tiled) {
+        out_c_padded = tt::round_up(out_c, tt::constants::TILE_WIDTH * sliding_window_config.num_cores_c);
+        out_nhw_padded = tt::round_up(out_nhw_padded, tt::constants::TILE_HEIGHT * sliding_window_config.num_cores_nhw);
+    }
+
+    ttnn::Shape padded_output_shape({1, 1, out_nhw_padded, out_c_padded});
+    ttnn::Shape output_shape({1, 1, out_nhw, out_c});
+
+    return TensorSpec(
+        output_shape,
+        tt::tt_metal::TensorLayout::fromPaddedShape(
+            output_dtype, op_attr.output_layout_, mem_config, output_shape, padded_output_shape));
+}
+
+Pool2D::tensor_return_value_t Pool2D::create_output_tensors(
+    const operation_attributes_t& op_attr, const tensor_args_t& tensor) {
+    auto output_spec_data = compute_output_specs(op_attr, tensor);
+    if (op_attr.return_indices_) {
+        DataType index_dtype = get_index_data_type(
+            op_attr.sliding_window_config_.input_hw.first, op_attr.sliding_window_config_.input_hw.second);
+
+        // the index output spec is the same as the input spec just with a different data type
+        tt::tt_metal::TensorLayout output_layout_ind(
+            index_dtype,
+            output_spec_data.page_config(),
+            output_spec_data.memory_config(),
+            output_spec_data.tensor_layout().get_alignment());
+        auto output_spec_ind = TensorSpec(output_spec_data.logical_shape(), output_layout_ind);
+        return {
+            create_device_tensor(output_spec_data, tensor.input_tensor_.device()),
+            create_device_tensor(output_spec_ind, tensor.input_tensor_.device())};
+    }
+    return {create_device_tensor(output_spec_data, tensor.input_tensor_.device())};
+}
+
+ttsl::hash::hash_t Pool2D::compute_program_hash(const operation_attributes_t& op_attr, const tensor_args_t& tensor) {
+    auto input_mem_config = tensor.input_tensor_.memory_config();
+    auto in_dtype = tensor.input_tensor_.dtype();
+    auto out_dtype = op_attr.output_dtype_;
+    return tt::tt_metal::operation::hash_operation<Pool2D>(
+        op_attr.sliding_window_config_.get_hash(),
+        op_attr.pool_type_,
+        op_attr.output_layout_,
+        op_attr.memory_config_,
+        op_attr.compute_kernel_config_,
+        op_attr.divisor_override_,
+        op_attr.count_include_pad_,
+        op_attr.return_indices_,
+        op_attr.config_tensor_in_dram,
+        input_mem_config,
+        in_dtype,
+        out_dtype);
+}
+
+tt::tt_metal::operation::OpPerformanceModelGeneral<Pool2D::tensor_return_value_t> Pool2D::create_op_performance_model(
+    const operation_attributes_t& op_attr, const tensor_args_t& tensor, const tensor_return_value_t& outputs) {
+    const auto& input = tensor.input_tensor_;
+    const auto& input_shape = input.logical_shape();
+    auto sliding_window_config = op_attr.sliding_window_config_;
+    uint32_t batch_size = sliding_window_config.batch_size;
+    uint32_t channels = input_shape[3];
+
+    uint32_t filter_h = sliding_window_config.window_hw.first;
+    uint32_t filter_w = sliding_window_config.window_hw.second;
+
+    // Use sliding_window_config for output dimensions (accounts for dilation, ceil_mode, etc.)
+    auto output_shape = sliding_window_config.get_output_shape();
+    uint32_t output_height = output_shape[1];
+    uint32_t output_width = output_shape[2];
+
+    // Use actual core count from the operation's core range
+    int num_cores = static_cast<int>(sliding_window_config.num_cores_nhw * sliding_window_config.num_cores_c);
+    if (num_cores == 0) {
+        num_cores = 1;
+    }
+    int tensix_mul_adds_per_cycle_lofi = 2048;
+
+    // For pooling, each output element requires filter_h * filter_w operations per channel
+    // (comparisons for max pool, additions for avg pool), not cross-channel like convolution
+    int64_t num_ops_per_elem = filter_h * filter_w;
+    int64_t num_ops = num_ops_per_elem * output_height * output_width * channels * batch_size;
+
+    int ideal_dev_clock_cycles = std::ceil((float)num_ops / (float)(num_cores * tensix_mul_adds_per_cycle_lofi));
+
+    tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> result(
+        {input}, {outputs}, ideal_dev_clock_cycles);
+    return result;
+}
+
+}  // namespace ttnn::operations::pool::quasar
+
+namespace ttnn::prim::qsr {
+std::vector<ttnn::Tensor> pool2d(
+    const Tensor& input_tensor,
+    const ttnn::operations::sliding_window::SlidingWindowConfig& sliding_window_config,
+    ttnn::operations::pool::Pool2DType pool_type,
+    DataType output_dtype,
+    Layout output_layout,
+    MemoryConfig memory_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
+    bool count_include_pad,
+    std::optional<int32_t> divisor_override,
+    bool return_indices,
+    uint32_t memory_used,
+    bool config_tensor_in_dram) {
+    using OperationType = ttnn::operations::pool::quasar::Pool2D;
+    return ttnn::device_operation::launch<OperationType>(
+        OperationType::operation_attributes_t{
+            .sliding_window_config_ = sliding_window_config,
+            .pool_type_ = pool_type,
+            .output_dtype_ = output_dtype,
+            .output_layout_ = output_layout,
+            .memory_config_ = std::move(memory_config),
+            .compute_kernel_config_ = compute_kernel_config,
+            .count_include_pad_ = count_include_pad,
+            .divisor_override_ = divisor_override,
+            .return_indices_ = return_indices,
+            .memory_used = memory_used,
+            .config_tensor_in_dram = config_tensor_in_dram},
+        OperationType::tensor_args_t{input_tensor});
+}
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/pool_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/pool_op.hpp
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <variant>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/core.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/sliding_window/sliding_window.hpp"
+#include "ttnn/operations/pool/pool_utils.hpp"
+#include "ttnn/types.hpp"
+#include "ttnn/operation.hpp"
+#include "ttnn/distributed/types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
+#include <utility>
+
+namespace ttnn::operations::pool::quasar {
+// Generic pool uop -- called from the macro-ops
+struct Pool2D {
+    struct operation_attributes_t {
+        sliding_window::SlidingWindowConfig sliding_window_config_{};
+        Pool2DType pool_type_{};
+        DataType output_dtype_{};
+        Layout output_layout_{};
+        MemoryConfig memory_config_;
+        std::optional<DeviceComputeKernelConfig> compute_kernel_config_;
+        bool count_include_pad_{};
+        std::optional<int32_t> divisor_override_;
+        bool return_indices_{};
+        uint32_t memory_used{};
+        bool config_tensor_in_dram{};
+    };
+
+    struct tensor_args_t {
+        const Tensor& input_tensor_;
+    };
+
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = std::vector<Tensor>;
+
+    struct MultiCore {
+        // Builds the entire workload in one call (cache miss):
+        //   1. Uploads the halo lookup table (and, for avg-pool variants that
+        //      need it, the per-stick scalar config tensor) and parks the
+        //      backing MeshBuffers in the descriptor's `buffers` vector so
+        //      they outlive the cached workload.
+        //   2. Loops `tensor_coords` and pushes a ProgramDescriptor per coord
+        //      into `programs`.
+        static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
+            const operation_attributes_t& op_attr,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output_tensors,
+            const ttnn::MeshCoordinateRangeSet& tensor_coords);
+    };
+
+    using program_factory_t = std::variant<MultiCore>;
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
+        const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
+};
+
+}  // namespace ttnn::operations::pool::quasar
+
+namespace ttnn::prim::qsr {
+std::vector<ttnn::Tensor> pool2d(
+    const Tensor& input_tensor,
+    const ttnn::operations::sliding_window::SlidingWindowConfig& sliding_window_config,
+    ttnn::operations::pool::Pool2DType pool_type,
+    DataType output_dtype,
+    Layout output_layout,
+    MemoryConfig memory_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
+    bool count_include_pad,
+    std::optional<int32_t> divisor_override,
+    bool return_indices,
+    uint32_t memory_used,
+    bool config_tensor_in_dram);
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/generic_pools.cpp
@@ -1,0 +1,1305 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "generic_pools.hpp"
+
+#include "tt-metalium/constants.hpp"
+#include "ttnn/operations/experimental/quasar/pool_generic/device/pool_op.hpp"
+#include <cmath>
+#include <optional>
+#include <tt-metalium/buffer_types.hpp>
+#include "ttnn/operations/conv/conv2d/conv2d_utils.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/pool/pool_utils.hpp"
+#include "ttnn/operations/experimental/quasar/halo/halo.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/sliding_window/sliding_window.hpp"
+#include "ttnn/operations/data_movement/move/move.hpp"
+#include "ttnn/operations/functions.hpp"
+#include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
+#include "ttnn/operations/data_movement/pad/pad.hpp"
+#include "ttnn/operations/reduction/generic/generic_reductions.hpp"
+#include "ttnn/operations/experimental/reshape/view.hpp"
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/math.hpp>
+
+namespace ttnn::operations::pool::quasar {
+
+// Generic invoke function for both max and avg pool operations. Most of the arguments are shared except for the
+// dilation which is set to (1,1) for avg pool and count_include_pad and divisor_override which have no effect on
+// maxpool.
+
+static std::tuple<MemoryConfig, uint32_t, sliding_window::ParallelConfig> get_pool_input_memory_config(
+    const sliding_window::SlidingWindowConfig& sliding_window_config,
+    const std::optional<const TensorMemoryLayout> applied_shard_scheme,
+    uint32_t batch_size,
+    uint32_t channels,
+    const ttnn::Shape& input_shape,
+    const ttnn::Shape& output_shape,
+    const tt::tt_metal::CoreCoord& core_grid,
+    const DataType& input_dtype,
+    const Layout& input_layout,
+    const DataType& output_dtype,
+    const Layout& output_layout,
+    Pool2DType pool_type,
+    bool count_include_pad,
+    std::optional<int32_t> divisor_override,
+    bool return_indices,
+    bool config_tensor_in_dram) {
+    bool is_out_tiled = output_layout == ttnn::TILE_LAYOUT;
+    bool is_in_tiled = input_layout == ttnn::TILE_LAYOUT;
+    sliding_window::ParallelConfig parallel_config;
+
+    uint32_t smallest_RM_elem_size =
+        tt::datum_size(tt::tt_metal::datatype_to_dataformat_converter(DataType::BFLOAT16));  // Size of BFloat16
+    uint32_t input_channels_alignment =
+        is_in_tiled ? tt::constants::TILE_WIDTH : (tt::tt_metal::hal::get_l1_alignment() / smallest_RM_elem_size);
+    TensorMemoryLayout shard_layout = TensorMemoryLayout::HEIGHT_SHARDED;  // default to height sharding
+    if (applied_shard_scheme.has_value()) {
+        TT_FATAL(
+            (applied_shard_scheme.value() == TensorMemoryLayout::HEIGHT_SHARDED) ||
+                (applied_shard_scheme.value() == TensorMemoryLayout::WIDTH_SHARDED) ||
+                (applied_shard_scheme.value() == TensorMemoryLayout::BLOCK_SHARDED),
+            "Only height, width, or block sharding strategies are supported.");
+        shard_layout = applied_shard_scheme.value();
+        parallel_config = conv::determine_parallel_config(
+            shard_layout,
+            batch_size,
+            channels,
+            output_shape[1],
+            output_shape[2],
+            channels,
+            input_channels_alignment,
+            core_grid,
+            ShardOrientation::ROW_MAJOR,
+            false,
+            is_out_tiled,
+            is_in_tiled || is_out_tiled,  // if input/output is tiled we need to choose num_cores_c to make the
+                                          // shard width to be a tile multiple, it cannot be 16
+            0);
+    } else {  // auto-sharding
+        std::optional<sliding_window::ParallelConfig> sw_parallel_config = pool::determine_pool_config_for_auto_shard(
+            input_dtype,
+            input_layout,
+            core_grid,
+            sliding_window_config,
+            pool_type,
+            count_include_pad,
+            divisor_override,
+            return_indices,
+            output_layout,
+            output_dtype,
+            config_tensor_in_dram);
+        TT_FATAL(
+            sw_parallel_config.has_value(),
+            "autosharding could not determine valid shard scheme, please check tensor dimensions");
+        parallel_config = sw_parallel_config.value();
+    }
+
+    uint32_t num_cores_c = conv::get_num_cores_channels_from_parallel_config(parallel_config);
+
+    uint32_t input_tensor_width_snapped_to_channels_alignment =
+        tt::round_up(channels, num_cores_c * input_channels_alignment);
+
+    // Create target shape and apply sharding
+    Shape input_tensor_shape = conv::flatten_4d_shape(input_shape);
+    ttnn::Shape input_padded_shape = ttnn::Shape(
+        {input_tensor_shape[0],
+         input_tensor_shape[1],
+         input_tensor_shape[2],
+         input_tensor_width_snapped_to_channels_alignment});
+    auto input_tensor_memory_config = conv::create_sharded_memory_config_from_parallel_config(
+        input_padded_shape, parallel_config, is_in_tiled ? tt::constants::TILE_HEIGHT : 1);
+    log_trace(
+        tt::LogOp,
+        "Pool Input = {}, Output = {}, Memory Config = {}",
+        input_shape,
+        output_shape,
+        input_tensor_memory_config);
+    return {input_tensor_memory_config, input_tensor_width_snapped_to_channels_alignment, parallel_config};
+}
+
+static std::vector<Tensor> pool2d_L1(
+    const Tensor& input_tensor,
+    Pool2DType pool_type,
+    uint32_t batch_size,
+    uint32_t input_h,
+    uint32_t input_w,
+    uint32_t channels,
+    std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> stride,
+    std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding,
+    std::optional<std::array<uint32_t, 2>> dilation = std::nullopt,
+    bool ceil_mode = false,
+    bool count_include_pad = true,
+    std::optional<int32_t> divisor_override = std::nullopt,
+    const std::optional<const MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<const TensorMemoryLayout> applied_shard_scheme = std::nullopt,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
+    bool deallocate_input = false,
+    bool reallocate_halo_output = true,
+    bool return_indices = false,
+    const DataType dtype = DataType::BFLOAT16,
+    const Layout output_layout = Layout::ROW_MAJOR,
+    std::optional<std::array<uint32_t, 2>> ceil_pad = std::nullopt,
+    bool config_tensor_in_dram = false) {
+    std::array<uint32_t, 4> padding_4d = sliding_window::get_pair_n4_padding(padding);
+    bool is_out_tiled = output_layout == Layout::TILE;
+    bool is_in_tiled = input_tensor.layout() == ttnn::TILE_LAYOUT;
+    TT_FATAL(
+        dtype == DataType::BFLOAT16 || dtype == DataType::BFLOAT8_B || dtype == DataType::BFLOAT4_B,
+        "Currently only BFLOAT16, BFLOAT8_B, and BFLOAT4_B output data formats are supported");
+    TT_FATAL(
+        !((dtype == DataType::BFLOAT8_B || dtype == DataType::BFLOAT4_B) && output_layout == Layout::ROW_MAJOR),
+        "BFLOAT8_B/BFLOAT4_B output data format is not supported with ROW_MAJOR layout");
+    validate_input_params(
+        input_tensor,
+        batch_size,
+        input_h,
+        input_w,
+        channels,
+        kernel_size,
+        stride,
+        padding_4d[0],
+        padding_4d[1],
+        padding_4d[2],
+        padding_4d[3],
+        dilation.has_value() ? dilation.value()[0] : 1,
+        dilation.has_value() ? dilation.value()[1] : 1,
+        is_in_tiled);
+    uint32_t dilation_h = dilation.has_value() ? dilation.value().at(0) : 1;
+    uint32_t dilation_w = dilation.has_value() ? dilation.value().at(1) : 1;
+    sliding_window::SlidingWindowConfig sliding_window_config{
+        .batch_size = batch_size,
+        .channels = channels,
+        .input_hw = {input_h, input_w},
+        .window_hw = {kernel_size.at(0), kernel_size.at(1)},
+        .stride_hw = {stride.at(0), stride.at(1)},
+        .padding = padding_4d,
+        .dilation_hw = {dilation_h, dilation_w},
+        .ceil_pad_hw = ceil_pad.has_value()
+                           ? std::optional<sliding_window::uint32_pair_t>({ceil_pad->at(0), ceil_pad->at(1)})
+                           : std::nullopt,
+        .ceil_mode = ceil_mode,
+    };
+    auto output_shape = sliding_window_config.get_output_shape();
+    TT_FATAL(
+        output_shape[1] > 0 && output_shape[2] > 0,
+        "Pool2D: Computed output dimensions must be positive, got {}x{} "
+        "(input={}x{}, kernel={}x{}, stride={}x{}, dilation={}x{}, padding=[{},{},{},{}])",
+        output_shape[1],
+        output_shape[2],
+        input_h,
+        input_w,
+        kernel_size[0],
+        kernel_size[1],
+        stride[0],
+        stride[1],
+        dilation_h,
+        dilation_w,
+        padding_4d[0],
+        padding_4d[1],
+        padding_4d[2],
+        padding_4d[3]);
+    const bool is_input_tensor_in_dram = input_tensor.memory_config().is_dram();
+    sliding_window::ParallelConfig parallel_config;
+    MemoryConfig out_memory_config = input_tensor.memory_config();
+    uint32_t num_cores_nhw = 0;
+    uint32_t num_cores_c = 0;
+    Tensor input_tensor_sharded = input_tensor;
+    if (!out_memory_config.shard_spec().has_value()) {
+        // Input is not sharded. Perform sharding.
+
+        ttnn::Shape input_tensor_shape = input_tensor.padded_shape();
+
+        auto [in_memory_config, input_tensor_width_snapped_to_channels_alignment, calc_parallel_config] =
+            get_pool_input_memory_config(
+                sliding_window_config,
+                applied_shard_scheme,
+                batch_size,
+                channels,
+                input_tensor_shape,
+                output_shape,
+                input_tensor.device()->compute_with_storage_grid_size(),
+                input_tensor.dtype(),
+                input_tensor.layout(),
+                dtype,
+                output_layout,
+                pool_type,
+                count_include_pad,
+                divisor_override,
+                return_indices,
+                config_tensor_in_dram);
+        parallel_config = calc_parallel_config;
+        bool is_tensor_already_flattened = (input_tensor_shape[0] == 1 && input_tensor_shape[1] == 1);
+        Tensor input_tensor_flattened = input_tensor;
+        // If tensor is in (n,h,w,c) format, flatten it to (1,1,nhw,c) for optimal sharding
+        if (!is_tensor_already_flattened) {
+            const auto flattened_input_shape = conv::flatten_4d_shape(input_tensor.logical_shape());
+            const auto flattened_padded_input_shape = conv::flatten_4d_shape(input_tensor.padded_shape());
+            input_tensor_flattened = ttnn::reshape(input_tensor, flattened_input_shape, flattened_padded_input_shape);
+            input_tensor_shape = flattened_input_shape;
+        }
+        // Calculate padding needed for channels dimension
+        uint32_t input_channels = input_tensor_shape[3];
+        uint32_t padding_needed = input_tensor_width_snapped_to_channels_alignment - input_channels;
+
+        // Apply zero padding to channels if needed - we need it in case when output dtype is block float because if we
+        // have random values it would affect common exponent calculation
+        if (padding_needed > 0 && is_block_float(dtype)) {
+            ttnn::SmallVector<std::array<uint32_t, 2>> pad_spec = {{0, 0}, {0, 0}, {0, 0}, {0, padding_needed}};
+            input_tensor_flattened = ttnn::pad(input_tensor_flattened, pad_spec, 0.0f);
+        }
+        input_tensor_sharded = ttnn::to_memory_config(input_tensor_flattened, in_memory_config, std::nullopt);
+        out_memory_config = input_tensor_sharded.memory_config();
+
+    } else {
+        TT_FATAL(
+            !applied_shard_scheme.has_value(), "A sharding scheme should not be specified for a sharded input tensor.");
+        // input is already sharded, use it as is
+        TT_FATAL(
+            out_memory_config.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
+            "Only row major orientation is supported.");
+
+        parallel_config.grid = out_memory_config.shard_spec().value().grid;
+        parallel_config.shard_scheme = out_memory_config.memory_layout();
+        parallel_config.shard_orientation = out_memory_config.shard_spec().value().orientation;
+    }
+    num_cores_nhw = conv::get_num_cores_nhw_from_parallel_config(parallel_config);
+    num_cores_c = conv::get_num_cores_channels_from_parallel_config(parallel_config);
+
+    // update the shard spec to match the output shape
+    auto shard_spec = out_memory_config.shard_spec().value();
+    uint32_t output_nhw = output_shape[0] * output_shape[1] * output_shape[2];
+    uint32_t output_nhw_padded =
+        tt::round_up(output_nhw, num_cores_nhw * (is_out_tiled ? tt::constants::TILE_HEIGHT : 1));
+    uint32_t output_shard_height_padded = output_nhw_padded / num_cores_nhw;
+    uint32_t output_c = channels;
+    // When the last per-shard tile is strictly less than one full face wide (channels % 32 < 16),
+    // round up to TILE_WIDTH so the packer always writes 2 full faces without reconfiguring.
+    // When channels % 32 == FACE_WIDTH the last tile has exactly one face and no extra padding is needed.
+    // Use ceiling division so that for WIDTH/BLOCK sharding, where channels may not divide evenly,
+    // we check the maximum per-shard channel count and avoid false partial-tile detection.
+    // E.g. channels=290, num_cores_c=19: ceil(290/19)=16 = FACE_WIDTH → no tile pad needed.
+    //      channels=290, num_cores_c=1:  ceil(290/1)=290, 290%32=2 → tile pad needed.
+    uint32_t channels_per_shard = tt::div_up(output_c, num_cores_c);
+    uint32_t cps_mod_tile = channels_per_shard % tt::constants::TILE_WIDTH;
+    // For TILE output the shard width must be TILE_WIDTH-aligned regardless; for ROW_MAJOR we
+    // only round up to TILE_WIDTH when the partial last tile is strictly less than one full face
+    // wide (cps_mod_tile < FACE_WIDTH) AND there is at least one preceding full tile per core
+    // (channels_per_shard > FACE_WIDTH). When the only tile per core is partial and fits in one
+    // face, the kernel packs just 1 face — so FACE_WIDTH alignment matches the kernel output and
+    // avoids creating per-shard internal padding that breaks downstream consumers (e.g.
+    // sharded_to_interleaved, slice_write).
+    bool needs_tile_pad = !is_out_tiled && cps_mod_tile > 0 && cps_mod_tile < tt::constants::FACE_WIDTH &&
+                          channels_per_shard > tt::constants::FACE_WIDTH;
+    uint32_t base_alignment =
+        (is_out_tiled || needs_tile_pad) ? tt::constants::TILE_WIDTH : tt::constants::TILE_WIDTH / 2;
+    uint32_t output_c_padded = tt::round_up(output_c, num_cores_c * base_alignment);
+    uint32_t output_shard_width_padded = output_c_padded / num_cores_c;
+    log_debug(
+        tt::LogOp,
+        "output_nhw: {}, output_nhw_padded: {}, output_shard_height_padded: {}, output_shard_width_padded: {}",
+        output_nhw,
+        output_nhw_padded,
+        output_shard_height_padded,
+        output_shard_width_padded);
+    out_memory_config = tt::tt_metal::MemoryConfig(
+        out_memory_config.memory_layout(),
+        out_memory_config.buffer_type(),
+        tt::tt_metal::ShardSpec{
+            shard_spec.grid, {output_shard_height_padded, output_shard_width_padded}, ShardOrientation::ROW_MAJOR});
+    sliding_window_config = sliding_window::SlidingWindowConfig{
+        .batch_size = batch_size,
+        .channels = channels,
+        .input_hw = {input_h, input_w},
+        .window_hw = {kernel_size.at(0), kernel_size.at(1)},
+        .stride_hw = {stride.at(0), stride.at(1)},
+        .padding = {padding_4d.at(0), padding_4d.at(1), padding_4d.at(2), padding_4d.at(3)},
+        .dilation_hw = {dilation_h, dilation_w},
+        .ceil_pad_hw = ceil_pad.has_value()
+                           ? std::optional<sliding_window::uint32_pair_t>({ceil_pad->at(0), ceil_pad->at(1)})
+                           : std::nullopt,
+        .num_cores_nhw = num_cores_nhw,
+        .num_cores_c = num_cores_c,
+        .core_range_set = parallel_config.grid,
+        .snap_to_tile = is_out_tiled,
+        .ceil_mode = ceil_mode,
+    };
+
+    // call the halo uop
+    const auto resolved_compute_kernel_config = init_device_compute_kernel_config(
+        tt::tt_metal::hal::get_arch(),
+        compute_kernel_config,
+        tt::tt_metal::MathFidelity::HiFi4,
+        /*default_approx_mode=*/true,
+        /*default_fp32_acc=*/input_tensor_sharded.dtype() == DataType::FLOAT32,
+        /*default_l1_acc=*/false);
+    Tensor haloed_tensor = ttnn::operations::experimental::quasar::halo(
+        input_tensor_sharded,
+        sliding_window_config,
+        resolved_compute_kernel_config,
+        get_bf16_pool_init_value(pool_type),  // pad_val
+        false,
+        parallel_config.shard_orientation == ShardOrientation::COL_MAJOR,
+        is_out_tiled,
+        config_tensor_in_dram);
+
+    if (deallocate_input || is_input_tensor_in_dram) {
+        input_tensor_sharded.deallocate(/*force*/ true);
+    }
+
+    if (reallocate_halo_output) {
+        haloed_tensor = ttnn::move(haloed_tensor);
+    }
+
+    // NOLINTBEGIN(bugprone-use-after-move)
+    const uint32_t pre_allocate_size =
+        haloed_tensor.device()->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_allocated_bytes;
+    // NOLINTEND(bugprone-use-after-move)
+
+    // call the pool2d uop
+    std::vector<Tensor> output_tensors = ttnn::prim::qsr::pool2d(
+        haloed_tensor,
+        sliding_window_config,
+        pool_type,
+        dtype,
+        output_layout,
+        out_memory_config,
+        compute_kernel_config,
+        count_include_pad,
+        divisor_override,
+        return_indices,
+        pre_allocate_size,
+        config_tensor_in_dram);
+
+    // format and return the result
+    if (memory_config.has_value() && memory_config.value() != out_memory_config) {
+        for (auto& output_tensor : output_tensors) {
+            output_tensor = ttnn::to_memory_config(output_tensor, memory_config.value(), std::nullopt);
+        }
+    }
+
+    if (return_indices) {
+        TT_FATAL(
+            output_tensors.size() == 2,
+            "Expected two output tensors when return_indices is true, but got {}.",
+            output_tensors.size());
+        return output_tensors;
+    }
+    TT_FATAL(output_tensors.size() == 1, "Expected a single output tensor when return_indices is false.");
+    return output_tensors;
+}
+
+class Pool2dSliceAttr : public ttnn::operations::op_slicing::OpSliceAttr {
+    uint32_t batch_size;
+    IOShape input_shape;
+    uint32_t channels;
+    std::array<uint32_t, 2> kernel_size;
+    std::array<uint32_t, 2> stride;
+    std::array<uint32_t, 4> padding_n4;
+    std::array<uint32_t, 2> dilation;
+    std::array<uint32_t, 2> ceil_pad{};
+    sliding_window::SlidingWindowConfig sliding_window_config;
+    IOShape output_shape;
+    bool ceil_mode;
+    bool count_include_pad;
+    std::optional<int32_t> divisor_override;
+    bool return_indices;
+    Pool2DType pool_type;
+    DataType input_dtype;
+    DataType dtype;
+    TensorMemoryLayout shard_layout;
+    Layout input_layout;
+    Layout output_layout;
+    std::optional<DeviceComputeKernelConfig> compute_kernel_config;
+    bool config_tensor_in_dram;
+    MeshDevice* device;
+
+public:
+    Pool2dSliceAttr(
+        uint32_t batch_size,
+        IOShape input_shape,
+        uint32_t channels,
+        std::array<uint32_t, 2> kernel_size,
+        std::array<uint32_t, 2> stride,
+        std::array<uint32_t, 4> padding_n4,
+        std::array<uint32_t, 2> dilation,
+        bool ceil_mode,
+        bool count_include_pad,
+        std::optional<int32_t> divisor_override,
+        std::optional<const TensorMemoryLayout> applied_shard_scheme,
+        bool return_indices,
+        Pool2DType pool_type,
+        DataType input_dtype,
+        DataType dtype,
+        Layout input_layout,
+        Layout output_layout,
+        std::optional<DeviceComputeKernelConfig> compute_kernel_config,
+        bool config_tensor_in_dram,
+        MeshDevice* device) :
+        batch_size(batch_size),
+        input_shape(input_shape),
+        channels(channels),
+        kernel_size(kernel_size),
+        stride(stride),
+        padding_n4(padding_n4),
+        dilation(dilation),
+        ceil_mode(ceil_mode),
+        count_include_pad(count_include_pad),
+        divisor_override(divisor_override),
+        return_indices(return_indices),
+        pool_type(pool_type),
+        input_dtype(input_dtype),
+        dtype(dtype),
+        input_layout(input_layout),
+        output_layout(output_layout),
+        compute_kernel_config(compute_kernel_config),
+        config_tensor_in_dram(config_tensor_in_dram),
+        device(device) {
+        // Determine shard layout: use provided scheme, or auto-select the best one
+        if (applied_shard_scheme.has_value()) {
+            shard_layout = applied_shard_scheme.value();
+        } else {
+            // Use autosharding to determine the best scheme
+            sliding_window::SlidingWindowConfig temp_config{
+                .batch_size = batch_size,
+                .channels = channels,
+                .input_hw = {std::get<0>(input_shape), std::get<1>(input_shape)},
+                .window_hw = {kernel_size.at(0), kernel_size.at(1)},
+                .stride_hw = {stride.at(0), stride.at(1)},
+                .padding = padding_n4,
+                .dilation_hw = {dilation.at(0), dilation.at(1)},
+                .ceil_mode = ceil_mode,
+            };
+
+            auto parallel_config = pool::determine_pool_config_for_auto_shard(
+                dtype,
+                input_layout,
+                device->compute_with_storage_grid_size(),
+                temp_config,
+                pool_type,
+                count_include_pad,
+                divisor_override,
+                return_indices,
+                output_layout,
+                dtype,
+                config_tensor_in_dram);
+
+            if (parallel_config.has_value()) {
+                shard_layout = parallel_config->shard_scheme;
+            } else {
+                // Fallback to height sharding if autosharding fails
+                shard_layout = TensorMemoryLayout::HEIGHT_SHARDED;
+            }
+        }
+
+        sliding_window_config = sliding_window::SlidingWindowConfig{
+            .batch_size = batch_size,
+            .channels = channels,
+            .input_hw = {std::get<0>(input_shape), std::get<1>(input_shape)},
+            .window_hw = {kernel_size.at(0), kernel_size.at(1)},
+            .stride_hw = {stride.at(0), stride.at(1)},
+            .padding = padding_n4,
+            .dilation_hw = {dilation.at(0), dilation.at(1)},
+            .ceil_mode = ceil_mode,
+        };
+        auto full_output_shape = sliding_window_config.get_output_shape();
+        this->output_shape = IOShape{full_output_shape[1], full_output_shape[2]};
+        this->ceil_pad = {
+            sliding_window_config.get_ceil_pad_hw().first, sliding_window_config.get_ceil_pad_hw().second};
+    }
+
+    std::tuple<std::tuple<IOShape, IOShape>, std::array<uint32_t, 4>, std::array<uint32_t, 2>, uint32_t>
+    get_input_slice_and_padding(const IOShape& output_slice_start, const IOShape& output_slice_end) const {
+        auto [output_slice_height_start, output_slice_width_start] = output_slice_start;
+        auto [output_slice_height_end, output_slice_width_end] = output_slice_end;
+        int input_slice_height_start = (output_slice_height_start * stride[0]) - padding_n4[0];
+        int input_slice_height_end = ((output_slice_height_end - 1) * stride[0]) - padding_n4[0] +
+                                     ((kernel_size[0] - 1) * (dilation[0] - 1)) + kernel_size[0];
+        int input_slice_width_start = (output_slice_width_start * stride[1]) - padding_n4[2];
+        int input_slice_width_end = ((output_slice_width_end - 1) * stride[1]) - padding_n4[2] +
+                                    ((kernel_size[1] - 1) * (dilation[1] - 1)) + kernel_size[1];
+
+        int pad_top = std::max<int>(0, -input_slice_height_start);
+        int pad_bottom = std::max<int>(0, input_slice_height_end - std::get<0>(input_shape));
+        int pad_left = std::max<int>(0, -input_slice_width_start);
+        int pad_right = std::max<int>(0, input_slice_width_end - std::get<1>(input_shape));
+
+        input_slice_height_start = std::max<int>(0, input_slice_height_start);
+        input_slice_height_end = std::min<int>(std::get<0>(input_shape), input_slice_height_end);
+        input_slice_width_start = std::max<int>(0, input_slice_width_start);
+        input_slice_width_end = std::min<int>(std::get<1>(input_shape), input_slice_width_end);
+
+        std::array<uint32_t, 2> this_ceil_pad = {0, 0};
+        auto [output_height, output_width] = output_shape;
+        if (output_slice_height_start == 0) {
+            pad_top = padding_n4[0];
+            input_slice_height_start = 0;
+        }
+        if (output_slice_height_end == output_height) {
+            pad_bottom = padding_n4[1];
+            input_slice_height_end = std::get<0>(input_shape);
+            this_ceil_pad[0] = ceil_pad[0];
+        }
+        if (output_slice_width_start == 0) {
+            pad_left = padding_n4[2];
+            input_slice_width_start = 0;
+        }
+        if (output_slice_width_end == output_width) {
+            pad_right = padding_n4[3];
+            input_slice_width_end = std::get<1>(input_shape);
+            this_ceil_pad[1] = ceil_pad[1];
+        }
+        uint32_t width_rounding_value = (output_layout == tt::tt_metal::Layout::TILE) ? tt::constants::TILE_HEIGHT : 1;
+        uint32_t output_slice_width = output_slice_width_end - output_slice_width_start;
+        uint32_t input_slice_width = input_slice_width_end - input_slice_width_start;
+        if (output_slice_width % width_rounding_value != 0) {
+            uint32_t additional_padded_width = width_rounding_value - (output_slice_width % width_rounding_value);
+            log_trace(
+                tt::LogOp,
+                "Pool2d Slicing: Additional output width of {} added to the right side.",
+                additional_padded_width);
+
+            output_slice_width += additional_padded_width;
+            pad_right = (output_slice_width - 1) * stride[1] - input_slice_width +
+                        ((kernel_size[1] - 1) * (dilation[1] - 1)) + kernel_size[1];
+        }
+        return {
+            {{input_slice_height_start, input_slice_width_start}, {input_slice_height_end, input_slice_width_end}},
+            {pad_top, pad_bottom, pad_left, pad_right},
+            this_ceil_pad,
+            output_slice_width};
+    }
+
+    std::tuple<IOShape, IOShape> get_input_slice(
+        const IOShape& output_slice_start, const IOShape& output_slice_end) const override {
+        return std::get<0>(get_input_slice_and_padding(output_slice_start, output_slice_end));
+    }
+
+    uint32_t get_L1_usage(
+        const IOShape& output_slice_start,
+        const IOShape& output_slice_end,
+        const op_slicing::Op2DSliceConfig& /*slice_config*/) const override {
+        auto [input_slice, this_slice_padding, this_ceil_pad, this_output_width] =
+            get_input_slice_and_padding(output_slice_start, output_slice_end);
+        auto [input_slice_start, input_slice_end] = input_slice;
+        uint32_t input_slice_height = std::get<0>(input_slice_end) - std::get<0>(input_slice_start);
+        uint32_t input_slice_width = std::get<1>(input_slice_end) - std::get<1>(input_slice_start);
+        uint32_t output_slice_height = std::get<0>(output_slice_end) - std::get<0>(output_slice_start);
+
+        // Get the memory config for this slice
+        auto sliced_input_memory_config = get_input_memory_config(output_slice_start, output_slice_end);
+
+        // Calculate complete L1 usage for this slice
+        auto pool_l1_usage = pool::calculate_L1_usage_for_pool2d_slice(
+            input_slice_height,
+            input_slice_width,
+            output_slice_height,
+            this_output_width,
+            this_slice_padding,
+            this_ceil_pad,
+            return_indices,
+            pool_type,
+            count_include_pad,
+            divisor_override,
+            input_dtype,
+            dtype,
+            input_layout,
+            output_layout,
+            sliced_input_memory_config,
+            sliding_window_config,
+            config_tensor_in_dram);
+
+        log_trace(
+            tt::LogOp,
+            "Pool2D DRAM Auto slicing: L1 usage = {} for slice output {}x{} (input {}x{}), breakdown: "
+            "halo_input={}, halo_output={}, pool_cb={}, output_tensor={}",
+            pool_l1_usage.total_size,
+            output_slice_height,
+            this_output_width,
+            input_slice_height,
+            input_slice_width,
+            pool_l1_usage.halo_input_size,
+            pool_l1_usage.halo_output_size,
+            pool_l1_usage.pool_cb_size,
+            pool_l1_usage.output_tensor_size);
+
+        return pool_l1_usage.total_size;
+    }
+
+    tt::tt_metal::MemoryConfig get_input_memory_config(
+        const IOShape& output_slice_start, const IOShape& output_slice_end) const override {
+        auto [input_slice, this_slice_padding, this_ceil_pad, this_output_width] =
+            get_input_slice_and_padding(output_slice_start, output_slice_end);
+        auto [input_slice_start, input_slice_end] = input_slice;
+        uint32_t input_slice_height = std::get<0>(input_slice_end) - std::get<0>(input_slice_start);
+        uint32_t input_slice_width = std::get<1>(input_slice_end) - std::get<1>(input_slice_start);
+        uint32_t output_slice_height = std::get<0>(output_slice_end) - std::get<0>(output_slice_start);
+
+        uint32_t input_nhw_rounding_value =
+            (input_layout == tt::tt_metal::Layout::TILE) ? tt::constants::TILE_HEIGHT : 1;
+        uint32_t input_slice_nhw =
+            tt::round_up(batch_size * input_slice_height * input_slice_width, input_nhw_rounding_value);
+        auto sliced_input_tensor_memory_config = std::get<0>(get_pool_input_memory_config(
+            sliding_window_config,
+            shard_layout,
+            batch_size,
+            channels,
+            ttnn::Shape({1, 1, input_slice_nhw, channels}),
+            ttnn::Shape({batch_size, output_slice_height, this_output_width, channels}),
+            device->compute_with_storage_grid_size(),
+            dtype,
+            input_layout,
+            dtype,
+            output_layout,
+            pool_type,
+            count_include_pad,
+            divisor_override,
+            return_indices,
+            config_tensor_in_dram));
+
+        return sliced_input_tensor_memory_config;
+    }
+
+    std::vector<ttnn::Tensor> run_L1_op(
+        const ttnn::Tensor& sliced_input_tensor,
+        const IOShape& output_slice_start,
+        const IOShape& output_slice_end) override {
+        auto [input_slice, this_slice_padding, this_ceil_pad, this_output_width] =
+            get_input_slice_and_padding(output_slice_start, output_slice_end);
+        auto [input_slice_start, input_slice_end] = input_slice;
+        auto [input_slice_height_start, input_slice_width_start] = input_slice_start;
+        auto [input_slice_height_end, input_slice_width_end] = input_slice_end;
+
+        int input_slice_height = input_slice_height_end - input_slice_height_start;
+        int input_slice_width = input_slice_width_end - input_slice_width_start;
+        auto this_ceil_mode = ceil_mode;
+        if (this_ceil_pad[0] > 0 || this_ceil_pad[1] > 0) {
+            this_ceil_mode = true;
+        }
+
+        auto result = pool2d_L1(
+            sliced_input_tensor,
+            pool_type,
+            batch_size,
+            input_slice_height,
+            input_slice_width,
+            channels,
+            kernel_size,
+            stride,
+            this_slice_padding,
+            dilation,
+            this_ceil_mode,
+            count_include_pad,
+            divisor_override,
+            std::nullopt,
+            std::nullopt,
+            compute_kernel_config,
+            true, /* deallocate_input to save L1 */
+            true, /* reallocate_halo_output to save L1 */
+            return_indices,
+            dtype,
+            output_layout,
+            this_ceil_pad,
+            config_tensor_in_dram);
+
+        return result;
+    }
+
+    std::string name() const override { return "Pool2D"; }
+};
+
+static std::vector<Tensor> pool2d_DRAM(
+    const Tensor& input_tensor,
+    Pool2DType pool_type,
+    uint32_t batch_size,
+    uint32_t input_h,
+    uint32_t input_w,
+    uint32_t channels,
+    std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> stride,
+    std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding,
+    std::optional<std::array<uint32_t, 2>> dilation_ = std::nullopt,
+    bool ceil_mode = false,
+    bool count_include_pad = true,
+    std::optional<int32_t> divisor_override = std::nullopt,
+    const std::optional<const MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Op2DSliceConfig>& dram_slice_config_ = std::nullopt,
+    const std::optional<const TensorMemoryLayout> applied_shard_scheme = std::nullopt,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
+    bool deallocate_input = false,
+    bool reallocate_halo_output = true,
+    bool return_indices = false,
+    const DataType dtype = DataType::BFLOAT16,
+    const Layout output_layout = Layout::ROW_MAJOR,
+    bool config_tensor_in_dram = false) {
+    // Note: We allow return_indices=True to proceed here so we can check if it fits in a single slice.
+    // The verification happens after slice configuration is determined.
+    // The check for L1_FULL or manual num_slices==1 is now handled in determine_pool2d_execution_path.
+    std::array<uint32_t, 4> padding_4d = sliding_window::get_pair_n4_padding(padding);
+    auto dilation = dilation_.value_or(std::array<uint32_t, 2>{1, 1});
+    sliding_window::SlidingWindowConfig sliding_window_config{
+        .batch_size = batch_size,
+        .channels = channels,
+        .input_hw = {input_h, input_w},
+        .window_hw = {kernel_size.at(0), kernel_size.at(1)},
+        .stride_hw = {stride.at(0), stride.at(1)},
+        .padding = padding_4d,
+        .dilation_hw = {dilation.at(0), dilation.at(1)},
+        .ceil_mode = ceil_mode,
+    };
+    auto output_shape = sliding_window_config.get_output_shape();
+    uint32_t output_height = output_shape[1];
+    uint32_t output_width = output_shape[2];
+
+    // Create pool slice attribute for slice configuration
+    auto pool_slice_attr = Pool2dSliceAttr(
+        batch_size,
+        Pool2dSliceAttr::IOShape{input_h, input_w},
+        channels,
+        kernel_size,
+        stride,
+        sliding_window::get_pair_n4_padding(padding),
+        dilation,
+        ceil_mode,
+        count_include_pad,
+        divisor_override,
+        applied_shard_scheme,
+        return_indices,
+        pool_type,
+        input_tensor.dtype(),
+        dtype,
+        input_tensor.layout(),
+        output_layout,
+        compute_kernel_config,
+        config_tensor_in_dram,
+        input_tensor.device());
+
+    // Determine slice configuration (automatic if not provided or num_slices==0)
+    Op2DSliceConfig dram_slice_config;
+    if (dram_slice_config_.has_value() && dram_slice_config_.value().num_slices > 0) {
+        dram_slice_config = dram_slice_config_.value();
+    } else {
+        dram_slice_config = op_slicing::determine_slice_config(
+            &pool_slice_attr,
+            ttnn::Shape{batch_size, input_h, input_w, channels},
+            ttnn::Shape{batch_size, output_height, output_width, channels},
+            dram_slice_config_,
+            output_layout,
+            input_tensor.device());
+    }
+
+    // Validate that kernel size can fit in the slices
+    // We need to check that each slice (especially the smallest one) is large enough for the kernel
+    const uint32_t output_sliced_dim =
+        dram_slice_config.slice_type == op_slicing::Op2DSliceConfig::SliceType::DRAM_HEIGHT ? output_height
+                                                                                            : output_width;
+    const uint32_t kernel_sliced_dim =
+        dram_slice_config.slice_type == op_slicing::Op2DSliceConfig::SliceType::DRAM_HEIGHT ? kernel_size[0]
+                                                                                            : kernel_size[1];
+    const uint32_t stride_sliced_dim =
+        dram_slice_config.slice_type == op_slicing::Op2DSliceConfig::SliceType::DRAM_HEIGHT ? stride[0] : stride[1];
+    const uint32_t dilation_sliced_dim =
+        dram_slice_config.slice_type == op_slicing::Op2DSliceConfig::SliceType::DRAM_HEIGHT ? dilation[0] : dilation[1];
+    const uint32_t effective_kernel_size = (kernel_sliced_dim - 1) * dilation_sliced_dim + 1;
+
+    // Check each output slice to find the minimum input slice size
+    // Output slices are distributed as evenly as possible across num_slices
+    uint32_t min_input_slice_in_sliced_dim = UINT32_MAX;
+    for (uint32_t slice_idx = 0; slice_idx < dram_slice_config.num_slices; ++slice_idx) {
+        // Calculate output slice boundaries for this slice
+        uint32_t output_slice_start = (slice_idx * output_sliced_dim) / dram_slice_config.num_slices;
+        uint32_t output_slice_end = ((slice_idx + 1) * output_sliced_dim) / dram_slice_config.num_slices;
+
+        // Calculate required input slice size for this output slice
+        // input_slice_end = (output_slice_end - 1) * stride + effective_kernel_size - padding
+        // input_slice_start = output_slice_start * stride - padding
+        // But we need to consider actual clamping to input boundaries
+        int input_slice_start =
+            static_cast<int>(output_slice_start * stride_sliced_dim) -
+            static_cast<int>(
+                padding_4d
+                    [dram_slice_config.slice_type == op_slicing::Op2DSliceConfig::SliceType::DRAM_HEIGHT ? 0 : 2]);
+        int input_slice_end =
+            static_cast<int>((output_slice_end - 1) * stride_sliced_dim) -
+            static_cast<int>(
+                padding_4d
+                    [dram_slice_config.slice_type == op_slicing::Op2DSliceConfig::SliceType::DRAM_HEIGHT ? 0 : 2]) +
+            static_cast<int>(effective_kernel_size);
+
+        const uint32_t input_sliced_dim =
+            dram_slice_config.slice_type == op_slicing::Op2DSliceConfig::SliceType::DRAM_HEIGHT ? input_h : input_w;
+
+        // Clamp to actual input boundaries
+        input_slice_start = std::max(0, input_slice_start);
+        input_slice_end = std::min(static_cast<int>(input_sliced_dim), input_slice_end);
+
+        uint32_t input_slice_size = static_cast<uint32_t>(input_slice_end - input_slice_start);
+        min_input_slice_in_sliced_dim = std::min(min_input_slice_in_sliced_dim, input_slice_size);
+    }
+
+    TT_FATAL(
+        dram_slice_config.num_slices == 1 ||  // L1 path will handle this case
+            min_input_slice_in_sliced_dim >= effective_kernel_size,
+        "Cannot fit Pool2D operation in L1 memory with DRAM slicing. The smallest input slice (size={}) "
+        "in the {} dimension is smaller than the effective kernel size ({}). "
+        "Kernel: {}x{}, Stride: {}x{}, Dilation: {}x{}, Num slices: {}, Slicing dimension: {}. "
+        "Input shape: {}x{}, Output shape: {}x{}, Channels: {}. "
+        "This means the tensor cannot be processed even with DRAM slicing. "
+        "Consider: (1) reducing kernel size, (2) reducing dilation, (3) increasing stride, "
+        "or (4) if possible, increasing available L1 memory to reduce the number of slices needed.",
+        min_input_slice_in_sliced_dim,
+        dram_slice_config.slice_type == op_slicing::Op2DSliceConfig::SliceType::DRAM_HEIGHT ? "height" : "width",
+        effective_kernel_size,
+        kernel_size[0],
+        kernel_size[1],
+        stride[0],
+        stride[1],
+        dilation[0],
+        dilation[1],
+        dram_slice_config.num_slices,
+        dram_slice_config.slice_type == op_slicing::Op2DSliceConfig::SliceType::DRAM_HEIGHT ? "height" : "width",
+        input_h,
+        input_w,
+        output_height,
+        output_width,
+        channels);
+
+    // If automatic determination resulted in num_slices=1, use L1 path for efficiency
+    if (dram_slice_config.num_slices == 1) {
+        return pool2d_L1(
+            input_tensor,
+            pool_type,
+            batch_size,
+            input_h,
+            input_w,
+            channels,
+            kernel_size,
+            stride,
+            padding,
+            dilation_,
+            ceil_mode,
+            count_include_pad,
+            divisor_override,
+            memory_config,
+            applied_shard_scheme,
+            compute_kernel_config,
+            deallocate_input,
+            reallocate_halo_output,
+            return_indices,
+            dtype,
+            output_layout,
+            std::nullopt,
+            config_tensor_in_dram);
+    }
+
+    // Prepare input tensor for DRAM slicing path (only reshape if needed)
+    const auto unflattened_input_shape = ttnn::Shape{batch_size, input_h, input_w, channels};
+    Tensor input_tensor_for_slicing = input_tensor;
+
+    // Only reshape if the current shape doesn't match what we need
+    if (input_tensor.logical_shape() != unflattened_input_shape) {
+        input_tensor_for_slicing = ttnn::reshape(input_tensor, unflattened_input_shape, unflattened_input_shape);
+    }
+
+    // Create output tensors for DRAM slicing
+    Tensor dram_output_tensor = tt::tt_metal::create_device_tensor(
+        TensorSpec(
+            ttnn::Shape({batch_size, output_height, output_width, channels}),
+            tt::tt_metal::TensorLayout(
+                dtype,
+                tt::tt_metal::PageConfig(output_layout),
+                MemoryConfig{
+                    TensorMemoryLayout::INTERLEAVED,
+                    BufferType::DRAM,
+                })),
+        input_tensor_for_slicing.device());
+    std::vector<std::reference_wrapper<Tensor>> output_tensors = {std::ref(dram_output_tensor)};
+
+    ttnn::operations::op_slicing::run_sliced_op(
+        input_tensor_for_slicing, output_tensors, &pool_slice_attr, dram_slice_config);
+
+    return {dram_output_tensor};
+}
+
+// Enum to represent the execution path for pool2d operations
+enum class Pool2dExecutionPath {
+    L1,   // Execute Pool using L1 memory
+    DRAM  // Execute Pool using DRAM slicing
+};
+
+// Helper function to determine which pool2d execution path to take based on
+// slice configuration and input tensor properties
+Pool2dExecutionPath determine_pool2d_execution_path(
+    const ttnn::Tensor& input_tensor, const std::optional<const Op2DSliceConfig>& slice_config) {
+    bool is_l1 = input_tensor.memory_config().is_l1();
+
+    // If slice config explicitly specifies L1_FULL, use L1 path
+    if (slice_config.has_value() && slice_config->slice_type == Op2DSliceConfig::SliceType::L1_FULL) {
+        return Pool2dExecutionPath::L1;
+    }
+
+    // If slice config explicitly sets num_slices==1, use L1 path (user knows it fits)
+    if (slice_config.has_value() && slice_config->num_slices == 1) {
+        return Pool2dExecutionPath::L1;
+    }
+
+    // If input is in L1 (not DRAM), use L1 path - tensor already fits in L1
+    // We should never move an L1 tensor to DRAM just to slice it
+    if (is_l1) {
+        return Pool2dExecutionPath::L1;
+    }
+
+    // Otherwise, tensor is in DRAM, use DRAM slicing path
+    return Pool2dExecutionPath::DRAM;
+}
+
+static std::vector<Tensor> pool2d(
+    const Tensor& input_tensor,
+    Pool2DType pool_type,
+    uint32_t batch_size,
+    uint32_t input_h,
+    uint32_t input_w,
+    uint32_t channels,
+    std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> stride,
+    std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding,
+    std::optional<std::array<uint32_t, 2>> dilation = std::nullopt,
+    bool ceil_mode = false,
+    bool count_include_pad = true,
+    std::optional<int32_t> divisor_override = std::nullopt,
+    const std::optional<const MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Op2DSliceConfig>& dram_slice_config = std::nullopt,
+    const std::optional<const TensorMemoryLayout> applied_shard_scheme = std::nullopt,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
+    bool deallocate_input = false,
+    bool reallocate_halo_output = true,
+    bool return_indices = false,
+    const DataType dtype = DataType::BFLOAT16,
+    const Layout output_layout = Layout::ROW_MAJOR,
+    bool config_tensor_in_dram = false) {
+    // Handle rank 2 and 3 input tensors by reshaping to rank 4
+    Tensor input_tensor_4d = input_tensor;
+    const auto& logical_shape = input_tensor.logical_shape();
+    const auto& padded_shape = input_tensor.padded_shape();
+    uint32_t rank = logical_shape.rank();
+
+    if (rank == 3) {
+        // Rank-3 tensor: [H, W, C] -> [1, H, W, C]
+        log_debug(
+            tt::LogOp, "Pool2D: Rank-3 input tensor detected, assuming [H, W, C] format and reshaping to [1, H, W, C]");
+        TT_FATAL(batch_size == 1, "Pool2D: For rank-3 input [H, W, C], batch_size must be 1, got {}", batch_size);
+        TT_FATAL(
+            input_h == logical_shape[0] && input_w == logical_shape[1] && channels == logical_shape[2],
+            "Pool2D: For rank-3 input [H, W, C], dimensions must match: input_h={}, input_w={}, channels={}, but got "
+            "shape {}",
+            input_h,
+            input_w,
+            channels,
+            logical_shape);
+
+        ttnn::Shape reshaped_logical({1, input_h, input_w, channels});
+        ttnn::Shape reshaped_padded({1, padded_shape[0], padded_shape[1], padded_shape[2]});
+        input_tensor_4d = ttnn::reshape(input_tensor, reshaped_logical, reshaped_padded);
+    } else if (rank == 2) {
+        // Rank-2 tensor: [H, W] -> [1, H, W, 1]
+        log_debug(
+            tt::LogOp, "Pool2D: Rank-2 input tensor detected, assuming [H, W] format and reshaping to [1, H, W, 1]");
+        TT_FATAL(
+            batch_size == 1 && channels == 1,
+            "Pool2D: For rank-2 input [H, W], batch_size and channels must be 1, got batch_size={}, channels={}",
+            batch_size,
+            channels);
+        TT_FATAL(
+            input_h == logical_shape[0] && input_w == logical_shape[1],
+            "Pool2D: For rank-2 input [H, W], dimensions must match: input_h={}, input_w={}, but got shape {}",
+            input_h,
+            input_w,
+            logical_shape);
+
+        ttnn::Shape reshaped_logical({1, input_h, input_w, 1});
+        ttnn::Shape reshaped_padded({1, padded_shape[0], padded_shape[1], 1});
+        input_tensor_4d = ttnn::reshape(input_tensor, reshaped_logical, reshaped_padded);
+    } else if (rank != 4) {
+        TT_FATAL(false, "Pool2D: Input tensor must be rank 2, 3, or 4, got rank {}", rank);
+    }
+    // For rank-4, input_tensor_4d is already the input_tensor, no copy needed
+
+    // Global average pool fast path: kernel exactly covers spatial input with no padding/dilation.
+    // pool_sum reduction is much cheaper than the sliding-window pool kernels for this case
+    // (no halo, no scatter, single reduction per output element). We require strict equality
+    // (== rather than >=) so that oversized kernels still hit the regular path's validation.
+    //
+    // Gates:
+    //   - padded spatial extent splits evenly across batches. The canonical reshape to
+    //     (batch_size, 1, H*W, C) requires total_padded_spatial % batch_size == 0. Flat
+    //     (1, 1, N*H*W, C) conv2d outputs whose tile-padded W dim doesn't divide cleanly
+    //     by batch (e.g. MobileNetV2 batch=10: 10*7*7=490 → 512, 512%10!=0) fall through
+    //     to the sliding-window kernel, matching pre-#43820 behavior.
+    //   - applied_shard_scheme not set. When the caller pre-declares a shard scheme, they want
+    //     the sliding-window kernel to honor that layout exactly; pool_sum would re-route.
+    //   - block-float TILE inputs must have tile-aligned spatial. pool_sum needs ROW_MAJOR to
+    //     strip tile-padding garbage from non-aligned spatial, but to_layout(bf8 TILE → RM)
+    //     forces untilize+typecast-to-bfloat16 (~127us in the panoptic_deeplab ASPP case),
+    //     which exceeds the algorithmic win. Tile-aligned block-float TILE has no padding
+    //     rows to strip, so pool_sum runs natively (this is the EfficientNet B0 fast case).
+    //
+    // Sharded inputs *are* accepted — the fast-path body below routes them through
+    // to_memory_config(INTERLEAVED) since pool_sum's 1×1 output can't fit the input's shard
+    // spec. The legacy dedicated global_avg_pool2d device op (deleted in #43820) handled
+    // sharded inputs the same way.
+    std::array<uint32_t, 4> padding_check = sliding_window::get_pair_n4_padding(padding);
+    uint32_t dilation_h = dilation.has_value() ? dilation.value().at(0) : 1;
+    uint32_t dilation_w = dilation.has_value() ? dilation.value().at(1) : 1;
+    bool input_is_block_float_tile =
+        (input_tensor_4d.dtype() == DataType::BFLOAT8_B || input_tensor_4d.dtype() == DataType::BFLOAT4_B) &&
+        input_tensor_4d.layout() == Layout::TILE;
+    uint32_t hw_value = input_h * input_w;
+    bool spatial_is_tile_aligned = (hw_value % tt::constants::TILE_HEIGHT == 0);
+    bool block_float_tile_safe = !input_is_block_float_tile || spatial_is_tile_aligned;
+    const auto& gate_padded_shape = input_tensor_4d.padded_shape();
+    uint32_t gate_total_padded_spatial = gate_padded_shape[0] * gate_padded_shape[1] * gate_padded_shape[2];
+    bool batch_divisible_for_fast_path = (gate_total_padded_spatial % batch_size == 0);
+    bool is_global_pool =
+        (kernel_size[0] == input_h && kernel_size[1] == input_w) &&
+        (padding_check[0] == 0 && padding_check[1] == 0 && padding_check[2] == 0 && padding_check[3] == 0) &&
+        (dilation_h == 1 && dilation_w == 1) && !applied_shard_scheme.has_value() && batch_divisible_for_fast_path &&
+        block_float_tile_safe;
+
+    if (is_global_pool && pool_type == Pool2DType::AVG_POOL2D) {
+        // Reduction needs interleaved input/output. The output is a tiny (1×1 spatial) tensor;
+        // a shard spec sized for the full input cannot fit it, so we fall back to interleaved
+        // with the same buffer type (DRAM/L1) when either the caller asked for a sharded
+        // placement or the input is itself sharded. Callers that need a specific sharded layout
+        // for the output should re-shard explicitly.
+        MemoryConfig input_mem = input_tensor_4d.memory_config();
+        MemoryConfig requested_out_mem = memory_config.value_or(input_mem);
+        MemoryConfig reduce_mem = (requested_out_mem.is_sharded() || input_mem.is_sharded())
+                                      ? MemoryConfig{TensorMemoryLayout::INTERLEAVED, requested_out_mem.buffer_type()}
+                                      : requested_out_mem;
+        // If the caller's requested config is sharded, do not try to re-shard the small output.
+        bool honor_requested_out_mem = !requested_out_mem.is_sharded();
+        uint32_t hw = input_h * input_w;
+        // count_include_pad is irrelevant here: is_global_pool guarantees padding is zero in every
+        // direction, so every element of the kernel window corresponds to a real input value.
+        float scalar = divisor_override.has_value() ? 1.0f / float(divisor_override.value()) : 1.0f / float(hw);
+
+        // Re-route sharded → INTERLEAVED for the reduction (pool_sum's 1×1 spatial output can't
+        // fit the input's shard spec). For TILE inputs, skip the ROW_MAJOR conversion when it's
+        // safe (matches the deleted dedicated global_avg_pool2d device op):
+        //   - spatial tile-aligned (no tile-padding rows to strip), or
+        //   - block-float TILE (the gate above guarantees tile-aligned in this case; the
+        //     conversion would untilize+typecast and is more expensive than the algorithmic win).
+        Tensor input = input_tensor_4d;
+        if (input.memory_config() != reduce_mem) {
+            input = ttnn::to_memory_config(input, reduce_mem);
+        }
+        if (input.layout() != Layout::ROW_MAJOR && !spatial_is_tile_aligned && !input_is_block_float_tile) {
+            input = ttnn::to_layout(input, Layout::ROW_MAJOR);
+        }
+
+        // Canonicalize to (batch_size, 1, H*W, C) form using an explicit logical+padded reshape.
+        // This is format-agnostic: it accepts both flat (1, 1, N*H*W, C) input from direct
+        // avg_pool2d callers and NHWC (N, H, W, C) input from the global_avg_pool2d Python
+        // wrapper, and it preserves any pre-existing padding (e.g., legacy callers that
+        // pad_to_tile zero-pad the spatial dim) by carrying padded_shape through. The gate
+        // above ensures total_padded_spatial divides cleanly by batch_size.
+        const auto& post_padded = input.padded_shape();
+        uint32_t total_padded_spatial = post_padded[0] * post_padded[1] * post_padded[2];
+        uint32_t channels_padded = post_padded[3];
+        TT_FATAL(
+            total_padded_spatial % batch_size == 0,
+            "Global pool fast path: padded spatial elements ({}) must be divisible by batch_size ({})",
+            total_padded_spatial,
+            batch_size);
+        uint32_t hw_padded_per_batch = total_padded_spatial / batch_size;
+        ttnn::Shape canonical_logical({batch_size, 1, hw, channels});
+        ttnn::Shape canonical_padded({batch_size, 1, hw_padded_per_batch, channels_padded});
+        Tensor canonical = ttnn::reshape(input, canonical_logical, canonical_padded);
+
+        // ttnn::sum exposes a scalar parameter, but pool_sum is the only reduction entry point
+        // that accepts (N, 1, H*W, C) tensors with H*W padding without producing garbage.
+        // Replace once ttnn::sum gains equivalent handling.
+        Tensor output = ttnn::operations::reduction::pool_sum(canonical, 2, reduce_mem, compute_kernel_config, scalar);
+        // pool_sum returns (N, 1, 1, C). For batch=1 this is (1, 1, 1, C), the avg_pool2d output
+        // convention (1, 1, N*out_H*out_W, C) coincides. For batch>1 we reshape to (1, 1, N, C).
+        const auto& output_padded_shape = output.padded_shape();
+        if (batch_size == 1) {
+            // Set logical channel count (zero-copy view).
+            ttnn::Shape out_logical({1, 1, 1, channels});
+            ttnn::Shape out_padded({output_padded_shape[0], 1, 1, output_padded_shape[3]});
+            output = ttnn::experimental::view(output, out_logical, out_padded);
+        } else {
+            ttnn::Shape correct_logical({1, 1, batch_size, channels});
+            ttnn::Shape correct_padded({1, 1, output_padded_shape[0], output_padded_shape[3]});
+            output = ttnn::reshape(output, correct_logical, correct_padded);
+        }
+
+        if (output.layout() != output_layout) {
+            output = ttnn::to_layout(output, output_layout, std::nullopt, reduce_mem);
+        }
+        // Honor caller's requested output memory config when feasible. We skip re-sharding
+        // because a shard spec sized for the input H×W can't fit the 1×1 output.
+        if (honor_requested_out_mem && output.memory_config() != requested_out_mem) {
+            output = ttnn::to_memory_config(output, requested_out_mem);
+        }
+        return {output};
+    }
+
+    auto exec_path =
+        return_indices ? Pool2dExecutionPath::L1 : determine_pool2d_execution_path(input_tensor_4d, dram_slice_config);
+    if (exec_path == Pool2dExecutionPath::L1) {
+        auto result = pool2d_L1(
+            input_tensor_4d,
+            pool_type,
+            batch_size,
+            input_h,
+            input_w,
+            channels,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+            ceil_mode,
+            count_include_pad,
+            divisor_override,
+            memory_config,
+            applied_shard_scheme,
+            compute_kernel_config,
+            deallocate_input,
+            reallocate_halo_output,
+            return_indices,
+            dtype,
+            output_layout,
+            std::nullopt,
+            config_tensor_in_dram);
+        return result;
+    }
+    auto result = pool2d_DRAM(
+        input_tensor_4d,
+        pool_type,
+        batch_size,
+        input_h,
+        input_w,
+        channels,
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        ceil_mode,
+        count_include_pad,
+        divisor_override,
+        memory_config,
+        dram_slice_config,
+        applied_shard_scheme,
+        compute_kernel_config,
+        deallocate_input,
+        reallocate_halo_output,
+        return_indices,
+        dtype,
+        output_layout,
+        config_tensor_in_dram);
+    return result;
+}
+
+std::vector<Tensor> max_pool2d(
+    const Tensor& input_tensor,
+    uint32_t batch_size,
+    uint32_t input_h,
+    uint32_t input_w,
+    uint32_t channels,
+    std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> stride,
+    std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding,
+    std::array<uint32_t, 2> dilation,
+    bool ceil_mode,
+    const std::optional<const MemoryConfig>& memory_config,
+    const std::optional<Op2DSliceConfig>& dram_slice_config,
+    const std::optional<const TensorMemoryLayout> applied_shard_scheme,
+    bool deallocate_input,
+    bool reallocate_halo_output,
+    bool return_indices,
+    const DataType dtype,
+    const Layout output_layout,
+    bool config_tensor_in_dram) {
+    auto result = pool2d(
+        input_tensor,
+        Pool2DType::MAX_POOL2D,
+        batch_size,
+        input_h,
+        input_w,
+        channels,
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        ceil_mode,
+        true,          // count_include_pad
+        std::nullopt,  // divisor_override
+        memory_config,
+        dram_slice_config,
+        applied_shard_scheme,
+        std::nullopt,  // compute_kernel_config - not needed for max pool
+        deallocate_input,
+        reallocate_halo_output,
+        return_indices,
+        dtype,
+        output_layout,
+        config_tensor_in_dram);
+    return result;
+}
+
+Tensor avg_pool2d(
+    const Tensor& input_tensor,
+    uint32_t batch_size,
+    uint32_t input_h,
+    uint32_t input_w,
+    uint32_t channels,
+    std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> stride,
+    std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding,
+    bool ceil_mode,
+    bool count_include_pad,
+    std::optional<int32_t> divisor_override,
+    const std::optional<const MemoryConfig>& memory_config,
+    const std::optional<Op2DSliceConfig>& dram_slice_config,
+    const std::optional<const TensorMemoryLayout> applied_shard_scheme,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
+    bool deallocate_input,
+    bool reallocate_halo_output,
+    const DataType dtype,
+    const Layout output_layout,
+    bool config_tensor_in_dram) {
+    auto result = pool2d(
+        input_tensor,
+        Pool2DType::AVG_POOL2D,
+        batch_size,
+        input_h,
+        input_w,
+        channels,
+        kernel_size,
+        stride,
+        padding,
+        std::nullopt,  // dilation
+        ceil_mode,
+        count_include_pad,
+        divisor_override,
+        memory_config,
+        dram_slice_config,
+        applied_shard_scheme,
+        compute_kernel_config,
+        deallocate_input,
+        reallocate_halo_output,
+        false,  // return_indices
+        dtype,
+        output_layout,
+        config_tensor_in_dram);
+
+    // Average pool always returns just the tensor, never indices
+    return result.at(0);
+}
+
+}  // namespace ttnn::operations::pool::quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/generic_pools.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/generic_pools.hpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <variant>
+#include <vector>
+#include "ttnn/types.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/sliding_window/op_slicing/op_slicing.hpp"
+namespace ttnn::operations::pool::quasar {
+
+using op_slicing::Op2DSliceConfig;
+
+struct MaxPoolWithIndicesResult {
+    Tensor output;
+    Tensor indices;
+};
+
+std::vector<Tensor> max_pool2d(
+    const Tensor& input_tensor,
+    uint32_t batch_size,
+    uint32_t input_h,
+    uint32_t input_w,
+    uint32_t channels,
+    std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> stride,
+    std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding,
+    std::array<uint32_t, 2> dilation,
+    bool ceil_mode = false,
+    const std::optional<const MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Op2DSliceConfig>& dram_slice_config = std::nullopt,
+    std::optional<const TensorMemoryLayout> applied_shard_scheme = std::nullopt,
+    bool deallocate_input = false,
+    bool reallocate_halo_output = true,
+    bool return_indices = false,
+    DataType dtype = DataType::BFLOAT16,
+    Layout output_layout = Layout::ROW_MAJOR,
+    bool config_tensor_in_dram = false);
+
+Tensor avg_pool2d(
+    const Tensor& input_tensor,
+    uint32_t batch_size,
+    uint32_t input_h,
+    uint32_t input_w,
+    uint32_t channels,
+    std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> stride,
+    std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding,
+    bool ceil_mode = false,
+    bool count_include_pad = true,
+    std::optional<int32_t> divisor_override = std::nullopt,
+    const std::optional<const MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Op2DSliceConfig>& dram_slice_config = std::nullopt,
+    std::optional<const TensorMemoryLayout> applied_shard_scheme = std::nullopt,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
+    bool deallocate_input = false,
+    bool reallocate_halo_output = true,
+    DataType dtype = DataType::BFLOAT16,
+    Layout output_layout = Layout::ROW_MAJOR,
+    bool config_tensor_in_dram = false);
+
+}  // namespace ttnn::operations::pool::quasar
+// NOTE: original re-exported these into `namespace ttnn`; dropped in the Quasar copy to avoid
+// colliding with ttnn::max_pool2d / ttnn::avg_pool2d. Quasar funcs live in
+// ttnn::operations::pool::quasar and are exposed to Python as ttnn.experimental.quasar.*.

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/generic_pools_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/generic_pools_nanobind.cpp
@@ -1,0 +1,192 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/experimental/quasar/pool_generic/generic_pools_nanobind.hpp"
+#include "ttnn/operations/experimental/quasar/pool_generic/generic_pools.hpp"
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <variant>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/array.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/variant.h>
+#include <nanobind/stl/vector.h>
+
+#include "ttnn-nanobind/bind_function.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::pool::quasar {
+
+// Helper function for max_pool2d nanobind that handles the return type conversion.
+// Returns a std::variant whose nanobind caster does the Python conversion at the
+// wrapper boundary (GIL held); the body runs with the GIL released (call_guard
+// applied by bind_function) and returns only C++ values.
+static std::variant<ttnn::Tensor, std::vector<ttnn::Tensor>> max_pool2d_nanobind_wrapper(
+    const ttnn::Tensor& input_tensor,
+    uint32_t batch_size,
+    uint32_t input_h,
+    uint32_t input_w,
+    uint32_t channels,
+    std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> stride,
+    std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding,
+    std::array<uint32_t, 2> dilation,
+    bool ceil_mode,
+    const std::optional<const MemoryConfig>& memory_config,
+    const std::optional<Op2DSliceConfig>& dram_slice_config,
+    const std::optional<const ttnn::TensorMemoryLayout> applied_shard_scheme,
+    bool deallocate_input,
+    bool reallocate_halo_output,
+    bool return_indices,
+    const DataType dtype,
+    const Layout output_layout,
+    bool config_tensor_in_dram) {
+    auto result = ttnn::operations::pool::quasar::max_pool2d(
+        input_tensor,
+        batch_size,
+        input_h,
+        input_w,
+        channels,
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        ceil_mode,
+        memory_config,
+        dram_slice_config,
+        applied_shard_scheme,
+        deallocate_input,
+        reallocate_halo_output,
+        return_indices,
+        dtype,
+        output_layout,
+        config_tensor_in_dram);
+
+    if (result.size() == 1) {
+        return std::move(result[0]);
+    }
+    return std::move(result);
+}
+
+void bind_max_pool2d_operation(nb::module_& mod) {
+    ttnn::bind_function<"max_pool2d">(
+        mod,
+        R"doc(
+        Applies max pooling to the input tensor. Each output element contains the maximum value within a
+        sliding kernel window per channel. The input tensor is expected to be in [NHW, C] or [N, H, W, C]
+        format and should be on the device. Height, width and block sharding schemes are supported.
+
+        Args:
+            input_tensor (ttnn.Tensor): the input tensor.
+            batch_size (int): the number of batches (N).
+            input_h (int): the height of the input tensor (H).
+            input_w (int): the width of the input tensor (W).
+            channels (int): the number of channels (C).
+            kernel_size (List of [int]): the (h, w) size of the kernel window.
+            stride (List of [int]): the (h, w) stride of the kernel window.
+            padding (List of [int]): the (h, w) or (top, bottom, left, right) padding.
+            dilation (List of [int]): the (h, w) dilation of the kernel window.
+            ceil_mode (bool): whether to use ceil mode for the output shape. Defaults to `False`.
+
+        Keyword Args:
+            memory_config (ttnn.MemoryConfig, optional): the memory configuration for the output tensor. Defaults to `None`.
+            applied_shard_scheme (ttnn.TensorMemoryLayout, optional): the sharding scheme to apply to a non-pre-sharded input tensor. Defaults to `None`, which should be used with pre-sharded input tensors.
+            deallocate_input (bool, optional): whether to deallocate the input tensor after the operation. Defaults to `False`.
+            reallocate_halo_output (bool, optional): whether to reallocate the halo output tensor after the operation, ideally used with deallocate_activation = true. Defaults to `True`.
+            return_indices (bool, optional): whether to return both values and indices. When True, returns a tuple (values, indices). Defaults to `False`.
+            dtype (ttnn.DataType, optional): the data format for the output tensor. Defaults to `ttnn.bfloat16`.
+            output_layout (ttnn.Layout, optional): the layout for the output tensor. Defaults to `ttnn.ROW_MAJOR_LAYOUT`.
+
+        Returns:
+            ttnn.Tensor or tuple[ttnn.Tensor, ttnn.Tensor]: the output tensor, or a tuple of (values, indices) if return_indices is True.
+        )doc",
+        &max_pool2d_nanobind_wrapper,
+        nb::arg("input_tensor"),
+        nb::arg("batch_size"),
+        nb::arg("input_h"),
+        nb::arg("input_w"),
+        nb::arg("channels"),
+        nb::arg("kernel_size"),
+        nb::arg("stride"),
+        nb::arg("padding"),
+        nb::arg("dilation"),
+        nb::arg("ceil_mode") = false,
+        nb::kw_only(),
+        nb::arg("memory_config") = nb::none(),
+        nb::arg("dram_slice_config") = nb::none(),
+        nb::arg("applied_shard_scheme") = nb::none(),
+        nb::arg("deallocate_input") = false,
+        nb::arg("reallocate_halo_output") = true,
+        nb::arg("return_indices") = false,
+        nb::arg("dtype") = nb::cast(DataType::BFLOAT16),
+        nb::arg("output_layout") = nb::cast(Layout::ROW_MAJOR),
+        nb::arg("config_tensor_in_dram") = false);
+}
+
+void bind_avg_pool2d_operation(nb::module_& mod) {
+    ttnn::bind_function<"avg_pool2d">(
+        mod,
+        R"doc(
+        Applies average pooling to the input tensor. Each output element contains the average value within a
+        sliding kernel window per channel. The input tensor is expected to be in [NHW, C] or [N, H, W, C]
+        format and should be on the device. Height, width and block sharding schemes are supported.
+
+        Args:
+            input_tensor (ttnn.Tensor): the input tensor.
+            batch_size (int): the number of batches (N).
+            input_h (int): the height of the input tensor (H).
+            input_w (int): the width of the input tensor (W).
+            channels (int): the number of channels (C).
+            kernel_size (List of [int]): the (h, w) size of the kernel window.
+            stride (List of [int]): the (h, w) stride of the kernel window.
+            padding (List of [int]): the (h, w) or (top, bottom, left, right) padding.
+            ceil_mode (bool): When True, uses 'ceiling' instead of 'floor' to compute output shape. Default: False.
+            count_include_pad (bool): When True, includes zero-padding in the avg calculation. Default: True.
+            divisor_override (int, optional): If specified, it will be used as a divisor, otherwise size of the pooling region will be used. Default: None.
+
+        Keyword Args:
+            memory_config (ttnn.MemoryConfig, optional): the memory configuration for the output tensor. Defaults to `None`.
+            applied_shard_scheme (ttnn.TensorMemoryLayout, optional): the sharding scheme to apply to a non-pre-sharded input tensor. Defaults to `None`, which should be used with pre-sharded input tensors.
+            deallocate_input (bool, optional): whether to deallocate the input tensor after the operation. Defaults to `False`.
+            reallocate_halo_output (bool, optional): whether to reallocate the halo output tensor after the operation, ideally used with deallocate_activation = true. Defaults to `True`.
+            dtype (ttnn.DataType, optional): the data format for the output tensor. Defaults to `ttnn.bfloat16`.
+            output_layout (ttnn.Layout, optional): the layout for the output tensor. Defaults to `ttnn.ROW_MAJOR_LAYOUT`.
+            compute_kernel_config (DeviceComputeKernelConfig, optional): the device compute kernel configuration. Defaults to `None`.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+        )doc",
+        &ttnn::operations::pool::quasar::avg_pool2d,
+        nb::arg("input_tensor"),
+        nb::arg("batch_size"),
+        nb::arg("input_h"),
+        nb::arg("input_w"),
+        nb::arg("channels"),
+        nb::arg("kernel_size"),
+        nb::arg("stride"),
+        nb::arg("padding"),
+        nb::arg("ceil_mode") = false,
+        nb::arg("count_include_pad") = true,
+        nb::arg("divisor_override") = nb::none(),
+        nb::kw_only(),
+        nb::arg("memory_config") = nb::none(),
+        nb::arg("dram_slice_config") = nb::none(),
+        nb::arg("applied_shard_scheme") = nb::none(),
+        nb::arg("compute_kernel_config") = nb::none(),
+        nb::arg("deallocate_input") = false,
+        nb::arg("reallocate_halo_output") = true,
+        nb::arg("dtype") = nb::cast(DataType::BFLOAT16),
+        nb::arg("output_layout") = nb::cast(Layout::ROW_MAJOR),
+        nb::arg("config_tensor_in_dram") = false);
+}
+
+void py_module(nb::module_& mod) {
+    bind_max_pool2d_operation(mod);
+    bind_avg_pool2d_operation(mod);
+}
+
+}  // namespace ttnn::operations::pool::quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/generic_pools_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/generic_pools_nanobind.hpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::pool::quasar {
+
+namespace nb = nanobind;
+
+void bind_max_pool2d_operation(nb::module_& mod);
+void bind_avg_pool2d_operation(nb::module_& mod);
+void py_module(nb::module_& mod);
+
+}  // namespace ttnn::operations::pool::quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/quasar_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/quasar_nanobind.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "quasar_nanobind.hpp"
+
+#include <nanobind/nanobind.h>
+
+#include "ttnn/operations/experimental/quasar/pad/pad_nanobind.hpp"
+#include "ttnn/operations/experimental/quasar/tilize/tilize_nanobind.hpp"
+#include "ttnn/operations/experimental/quasar/move/move_nanobind.hpp"
+#include "ttnn/operations/experimental/quasar/untilize_with_unpadding/untilize_with_unpadding_nanobind.hpp"
+#include "ttnn/operations/experimental/quasar/slice/slice_nanobind.hpp"
+#include "ttnn/operations/experimental/quasar/transpose/transpose_nanobind.hpp"
+#include "ttnn/operations/experimental/quasar/reshard/reshard_nanobind.hpp"
+#include "ttnn/operations/experimental/quasar/pool_generic/generic_pools_nanobind.hpp"
+#include "ttnn/operations/experimental/quasar/conv2d/conv2d_nanobind.hpp"
+#include "ttnn/operations/experimental/quasar/matmul/matmul_nanobind.hpp"
+#include "ttnn/operations/experimental/quasar/binary/binary_nanobind.hpp"
+
+namespace ttnn::operations::experimental::quasar {
+
+void bind_quasar(nb::module_& mod) {
+    auto m_quasar = mod.def_submodule("quasar", "Quasar (metal 2.0) operations");
+
+    // Data-movement ops (host namespace ttnn::operations::experimental::quasar::detail).
+    detail::bind_pad(m_quasar);
+    detail::bind_tilize(m_quasar);
+    detail::bind_move(m_quasar);
+    detail::bind_untilize_with_unpadding(m_quasar);
+    detail::bind_slice(m_quasar);
+    detail::bind_slice_descriptor(m_quasar);
+    detail::bind_transpose(m_quasar);
+    detail::bind_reshard(m_quasar);
+
+    // conv2d.
+    detail::bind_conv2d(m_quasar);
+
+    // pool (host namespace ttnn::operations::pool::quasar).
+    ttnn::operations::pool::quasar::py_module(m_quasar);
+
+    // matmul (its own py_module binds matmul/linear/addmm/sparse_matmul + program-config classes).
+    matmul::py_module(m_quasar);
+
+    // binary front-end (add/subtract/multiply/... -> quasar binary_ng device op).
+    binary::py_module(m_quasar);
+
+    // NOTE: halo and binary_ng have no python binding (internal device backends).
+}
+
+}  // namespace ttnn::operations::experimental::quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/quasar_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/quasar_nanobind.hpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::experimental::quasar {
+
+namespace nb = nanobind;
+
+// Creates the `quasar` submodule under ttnn.experimental and binds the Quasar (metal 2.0) ops.
+void bind_quasar(nb::module_& mod);
+
+}  // namespace ttnn::operations::experimental::quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/kernels/nd_reshard_copy_local_shards.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/kernels/nd_reshard_copy_local_shards.cpp
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/tensor/tensor_accessor.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+// Kernel that:
+// if (is_reader) {
+//     iterate over local shards of sharded src tensor, and write them to the dst tensor.
+// } else {
+//     iterate over local shards of sharded dst tensor, and read them from the src tensor.
+// }
+
+void kernel_main() {
+    auto args_src = TensorAccessorArgs<0, 0>();
+    auto args_dst =
+        TensorAccessorArgs<args_src.next_compile_time_args_offset(), args_src.next_common_runtime_args_offset()>();
+    constexpr uint32_t base_idx_cta = args_dst.next_compile_time_args_offset();
+    constexpr uint32_t base_idx_crta = args_dst.next_common_runtime_args_offset();
+
+    constexpr uint32_t src_page_size = get_compile_time_arg_val(base_idx_cta);
+    constexpr uint32_t dst_page_size = get_compile_time_arg_val(base_idx_cta + 1);
+    constexpr uint32_t is_reader = get_compile_time_arg_val(base_idx_cta + 2);
+    constexpr uint32_t logical_width = get_compile_time_arg_val(base_idx_cta + 3);
+    constexpr uint32_t src_width = get_compile_time_arg_val(base_idx_cta + 4);
+    constexpr uint32_t dst_width = get_compile_time_arg_val(base_idx_cta + 5);
+    constexpr uint32_t transfer_size = get_compile_time_arg_val(base_idx_cta + 6);
+
+    const uint32_t bank_base_address_src = get_common_arg_val<uint32_t>(base_idx_crta);
+    const uint32_t bank_base_address_dst = get_common_arg_val<uint32_t>(base_idx_crta + 1);
+    const uint32_t num_shards = get_common_arg_val<uint32_t>(base_idx_crta + 2);
+    const uint32_t shard_id_stride = get_common_arg_val<uint32_t>(base_idx_crta + 3);
+
+    const uint32_t first_shard_id = get_arg_val<uint32_t>(0);
+
+    auto accessor_src = TensorAccessor(args_src, bank_base_address_src);
+    auto accessor_dst = TensorAccessor(args_dst, bank_base_address_dst);
+
+    Noc noc;
+
+    for (uint32_t shard_id = first_shard_id; shard_id < num_shards; shard_id += shard_id_stride) {
+        if constexpr (is_reader) {
+            auto shard_pages = accessor_src.shard_pages(shard_id);
+            for (const auto& src_page : shard_pages) {
+                auto src_page_id = src_page.page_id();
+                // Local shard page: low 32 bits of the noc_addr are the L1 address on this core.
+                const uint32_t src_l1_addr_base = static_cast<uint32_t>(src_page.noc_addr());
+                const uint32_t transfers_per_page = src_page_size / transfer_size;
+                for (uint32_t i = 0; i < transfers_per_page; i++) {
+                    const uint32_t src_offset = i * transfer_size;
+                    const uint32_t global_offset = src_page_id * src_page_size + src_offset;
+
+                    const uint32_t row_idx = global_offset / src_width;
+                    const uint32_t col_idx = global_offset % src_width;
+
+                    // Skip if we're in padding area at end of sharded row
+                    if (col_idx >= logical_width) {
+                        continue;
+                    }
+                    // Calculate destination using logical width
+                    uint32_t dst_global_offset = row_idx * dst_width + col_idx;
+
+                    const uint32_t dst_row_idx = dst_global_offset / dst_width;
+                    const uint32_t dst_col_idx = dst_global_offset % dst_width;
+                    if (dst_col_idx >= logical_width) {
+                        // update dst_global_offset to skip padding
+                        dst_global_offset = (row_idx + 1) * dst_width;
+                    }
+
+                    const uint32_t dst_page_id = dst_global_offset / dst_page_size;
+                    const uint32_t dst_offset = dst_global_offset % dst_page_size;
+
+                    CoreLocalMem<uint32_t> src_mem(src_l1_addr_base + src_offset);
+                    noc.async_write(
+                        src_mem,
+                        accessor_dst,
+                        transfer_size,
+                        {.offset_bytes = 0},
+                        {.page_id = dst_page_id, .offset_bytes = dst_offset});
+                }
+                noc.async_writes_flushed();
+            }
+        } else {
+            auto shard_pages = accessor_dst.shard_pages(shard_id);
+            for (const auto& page : shard_pages) {
+                // Local shard page: low 32 bits of the noc_addr are the L1 address on this core.
+                const uint32_t dst_l1_addr = static_cast<uint32_t>(page.noc_addr());
+                CoreLocalMem<uint32_t> dst_mem(dst_l1_addr);
+                noc.async_read(
+                    accessor_src,
+                    dst_mem,
+                    src_page_size,
+                    {.page_id = page.page_id(), .offset_bytes = 0},
+                    {.offset_bytes = 0});
+            }
+        }
+    }
+
+    if constexpr (is_reader) {
+        noc.async_write_barrier();
+    } else {
+        noc.async_read_barrier();
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/kernels/nd_reshard_copy_pages_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/kernels/nd_reshard_copy_pages_reader.cpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/tensor/tensor_accessor.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+// Simple kernel that copies [start_page, end_page) pages from src to dst.
+void kernel_main() {
+    auto args_src = TensorAccessorArgs<0, 0>();
+    constexpr uint32_t base_idx_cta = args_src.next_compile_time_args_offset();
+    constexpr uint32_t base_idx_crta = args_src.next_common_runtime_args_offset();
+
+    constexpr uint32_t cb_id = get_compile_time_arg_val(base_idx_cta);
+    constexpr uint32_t page_size = get_compile_time_arg_val(base_idx_cta + 1);
+
+    const uint32_t bank_base_address_src = get_common_arg_val<uint32_t>(base_idx_crta);
+
+    const uint32_t start_page = get_arg_val<uint32_t>(0);
+    const uint32_t end_page = get_arg_val<uint32_t>(1);
+
+    auto accessor_src = TensorAccessor(args_src, bank_base_address_src);
+
+    Noc noc;
+    CircularBuffer cb(cb_id);
+
+    constexpr uint32_t one_tile = 1;
+    auto pages = accessor_src.pages(start_page, end_page);
+    for (const auto& page : pages) {
+        cb.reserve_back(one_tile);
+        noc.async_read(
+            accessor_src, cb, page_size, {.page_id = page.page_id(), .offset_bytes = 0}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        cb.push_back(one_tile);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/kernels/nd_reshard_copy_pages_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/kernels/nd_reshard_copy_pages_writer.cpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/tensor/tensor_accessor.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+// Simple kernel that copies [start_page, end_page) pages from dst to dst.
+void kernel_main() {
+    auto args_dst = TensorAccessorArgs<0, 0>();
+    constexpr uint32_t base_idx_cta = args_dst.next_compile_time_args_offset();
+    constexpr uint32_t base_idx_crta = args_dst.next_common_runtime_args_offset();
+
+    constexpr uint32_t cb_id = get_compile_time_arg_val(base_idx_cta);
+    constexpr uint32_t page_size = get_compile_time_arg_val(base_idx_cta + 1);
+
+    const uint32_t bank_base_address_dst = get_common_arg_val<uint32_t>(base_idx_crta);
+
+    const uint32_t start_page = get_arg_val<uint32_t>(0);
+    const uint32_t end_page = get_arg_val<uint32_t>(1);
+
+    auto accessor_dst = TensorAccessor(args_dst, bank_base_address_dst);
+
+    Noc noc;
+    CircularBuffer cb(cb_id);
+
+    constexpr uint32_t one_tile = 1;
+    auto pages = accessor_dst.pages(start_page, end_page);
+    for (const auto& page : pages) {
+        cb.wait_front(one_tile);
+        noc.async_write(
+            cb, accessor_dst, page_size, {.offset_bytes = 0}, {.page_id = page.page_id(), .offset_bytes = 0});
+        noc.async_write_barrier();
+        cb.pop_front(one_tile);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/nd_reshard_program_factory_copy_local.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/nd_reshard_program_factory_copy_local.cpp
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/experimental/quasar/reshard/device/nd_reshard_program_factory_copy_local.hpp"
+
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include "tt-metalium/host_api.hpp"
+
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+
+template <bool local_is_input>
+ProgramDescriptor NdReshardCopyLocalShardFactory<local_is_input>::create_descriptor(
+    const ReshardParams& /*operation_attributes*/, const ReshardInputs& tensor_args, Tensor& output_tensor) {
+    const auto& input = tensor_args.input;
+    auto& output = output_tensor;
+
+    auto* input_buffer = input.buffer();
+    auto* output_buffer = output.buffer();
+
+    const auto input_accessor_args = TensorAccessorArgs(*input_buffer);
+    const auto output_accessor_args = TensorAccessorArgs(*output_buffer);
+
+    // Choose buffer and aligned page size based on local_is_input flag
+    auto* local_buffer = local_is_input ? input_buffer : output_buffer;
+    auto aligned_page_size = local_buffer->aligned_page_size();
+    auto other_aligned_page_size =
+        local_is_input ? output_buffer->aligned_page_size() : input_buffer->aligned_page_size();
+
+    // This implementation assumes that input and output grids are the same.
+    auto cores_vec = local_buffer->buffer_distribution_spec()->cores_with_data();
+    auto grid = CoreRangeSet(cores_vec);
+
+    uint32_t num_shards = static_cast<uint32_t>(local_buffer->buffer_distribution_spec()->num_shards());
+
+    // num cores with data * 2 because we have two kernels
+    uint32_t shard_id_stride =
+        static_cast<uint32_t>(local_buffer->buffer_distribution_spec()->num_cores_with_data()) * 2u;
+
+    // Prepare compile time arguments
+    auto logical_size = input.logical_shape();
+    uint32_t logical_width = static_cast<uint32_t>(logical_size[-1] * input.element_size());
+    uint32_t source_width = logical_width;
+    uint32_t destination_width = logical_width;
+    uint32_t base_page_size = aligned_page_size;
+
+    if (input.memory_config().shard_spec().has_value() && output.memory_config().shard_spec().has_value()) {
+        auto input_buffer_type = input.memory_config().memory_layout();
+        auto output_buffer_type = output.memory_config().memory_layout();
+
+        // for block sharded
+        CoreCoord input_shard_grid = input_buffer->shard_spec().grid().ranges()[0].grid_size();
+        uint32_t input_num_shard_cores = input_shard_grid.x;
+        if (input_buffer->shard_spec().orientation() == ShardOrientation::COL_MAJOR) {
+            input_num_shard_cores = input_shard_grid.y;
+        }
+
+        CoreCoord output_shard_grid = output_buffer->shard_spec().grid().ranges()[0].grid_size();
+        uint32_t output_num_shard_cores = output_shard_grid.x;
+        if (output_buffer->shard_spec().orientation() == ShardOrientation::COL_MAJOR) {
+            output_num_shard_cores = output_shard_grid.y;
+        }
+        // for width sharded
+        if (input_buffer_type == TensorMemoryLayout::WIDTH_SHARDED &&
+            output_buffer_type == TensorMemoryLayout::WIDTH_SHARDED) {
+            input_num_shard_cores = input_shard_grid.x == 1 ? input_shard_grid.y : input_shard_grid.x;
+            output_num_shard_cores = output_shard_grid.x == 1 ? output_shard_grid.y : output_shard_grid.x;
+        }
+
+        source_width =
+            static_cast<uint32_t>(input_buffer->shard_spec().shape()[1] * input.element_size() * input_num_shard_cores);
+        destination_width = static_cast<uint32_t>(
+            output_buffer->shard_spec().shape()[1] * output.element_size() * output_num_shard_cores);
+        uint32_t input_page_size = input_buffer->page_size();
+        uint32_t output_page_size = output_buffer->page_size();
+        base_page_size = std::gcd(input_page_size, output_page_size);
+    }
+    auto compile_time_args = input_accessor_args.get_compile_time_args();
+    output_accessor_args.append_to(compile_time_args);
+    compile_time_args.push_back(aligned_page_size);
+    compile_time_args.push_back(other_aligned_page_size);
+    compile_time_args.push_back(static_cast<uint32_t>(local_is_input));
+    compile_time_args.push_back(logical_width);
+    compile_time_args.push_back(source_width);
+    compile_time_args.push_back(destination_width);
+    compile_time_args.push_back(base_page_size);
+
+    ProgramDescriptor desc;
+
+    KernelDescriptor brisc_desc;
+    brisc_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    brisc_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/kernels/nd_reshard_copy_local_shards.cpp";
+    brisc_desc.core_ranges = grid;
+    brisc_desc.config = DataMovementConfigDescriptor{
+        .processor = DataMovementProcessor::RISCV_0,
+        .noc = NOC::RISCV_0_default,
+    };
+    brisc_desc.compile_time_args = compile_time_args;
+
+    KernelDescriptor ncrisc_desc;
+    ncrisc_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    ncrisc_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/kernels/nd_reshard_copy_local_shards.cpp";
+    ncrisc_desc.core_ranges = grid;
+    ncrisc_desc.config = DataMovementConfigDescriptor{
+        .processor = DataMovementProcessor::RISCV_1,
+        .noc = NOC::RISCV_1_default,
+    };
+    ncrisc_desc.compile_time_args = std::move(compile_time_args);
+
+    // Common runtime args: [input_addr, output_addr, num_shards, shard_id_stride]
+    // arg 0 / arg 1 are the buffer base addresses (binding via Buffer*).
+    brisc_desc.emplace_common_runtime_args({input_buffer, output_buffer, num_shards, shard_id_stride});
+    ncrisc_desc.emplace_common_runtime_args({input_buffer, output_buffer, num_shards, shard_id_stride});
+
+    // Per-core unique runtime args: [start_shard_id]
+    // brisc copies shards [0, num_data_cores*2, num_data_cores*4, num_data_cores*6, ...]
+    // ncrisc copies shards [num_data_cores, num_data_cores*3, num_data_cores*5, num_data_cores*7, ...]
+    uint32_t start_shard_id = 0;
+    for (const auto& core : cores_vec) {
+        brisc_desc.emplace_runtime_args(core, {start_shard_id});
+        ncrisc_desc.emplace_runtime_args(core, {start_shard_id + shard_id_stride / 2});
+        ++start_shard_id;
+    }
+
+    desc.kernels.push_back(std::move(brisc_desc));
+    desc.kernels.push_back(std::move(ncrisc_desc));
+
+    return desc;
+}
+
+// Explicit template instantiations
+template struct NdReshardCopyLocalShardFactory<true>;
+template struct NdReshardCopyLocalShardFactory<false>;
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/nd_reshard_program_factory_copy_local.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/nd_reshard_program_factory_copy_local.hpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/program_descriptors.hpp>
+
+#include "ttnn/device_operation.hpp"
+#include "reshard_device_operation_types.hpp"
+
+namespace ttnn::prim::qsr {
+
+// Factory for L1<->DRAM or L1->L1 nd reshard (read into local pages in L1)
+template <bool local_is_input>
+struct NdReshardCopyLocalShardFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const ReshardParams& operation_attributes, const ReshardInputs& tensor_args, Tensor& output_tensor);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/nd_reshard_program_factory_copy_pages.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/nd_reshard_program_factory_copy_pages.cpp
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/experimental/quasar/reshard/device/nd_reshard_program_factory_copy_pages.hpp"
+
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include "tt-metalium/host_api.hpp"
+
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+
+namespace {
+
+// Anonymous-namespace helper unique to nd_reshard_copy_pages to avoid unity-build collisions.
+void push_reshard_copy_pages_cb(
+    ProgramDescriptor& desc,
+    uint32_t cb_index,
+    tt::DataFormat data_format,
+    uint32_t total_size,
+    uint32_t page_size,
+    const CoreRangeSet& core_ranges) {
+    CBDescriptor cb;
+    cb.total_size = total_size;
+    cb.core_ranges = core_ranges;
+    cb.format_descriptors.push_back(CBFormatDescriptor{
+        .buffer_index = static_cast<uint8_t>(cb_index),
+        .data_format = data_format,
+        .page_size = page_size,
+    });
+    cb.buffer = nullptr;
+    desc.cbs.push_back(std::move(cb));
+}
+
+}  // namespace
+
+ProgramDescriptor NdReshardCopyPagesFactory::create_descriptor(
+    const ReshardParams& /*operation_attributes*/, const ReshardInputs& tensor_args, Tensor& output_tensor) {
+    const auto& input = tensor_args.input;
+    auto& output = output_tensor;
+
+    auto* input_buffer = input.buffer();
+    auto* output_buffer = output.buffer();
+
+    auto input_nd_shard_spec = input.memory_config().nd_shard_spec().value();
+
+    const auto input_accessor_args = TensorAccessorArgs(*input_buffer);
+    const auto output_accessor_args = TensorAccessorArgs(*output_buffer);
+
+    auto aligned_page_size = input_buffer->aligned_page_size();
+
+    // Create grid + cores
+    auto grid_size = input.device()->compute_with_storage_grid_size();
+    auto grid = CoreRangeSet({CoreRange(CoreCoord(0, 0), CoreCoord(grid_size.x - 1, grid_size.y - 1))});
+    auto cores = corerange_to_cores(grid, std::nullopt, input_nd_shard_spec.orientation == ShardOrientation::ROW_MAJOR);
+
+    // Create Circular Buffer
+    const auto data_format = datatype_to_dataformat_converter(input.dtype());
+    constexpr uint32_t num_tiles_in_cb = 1;  // TODO: Try double buffering
+    constexpr uint32_t cb_in0_idx = tt::CBIndex::c_0;
+
+    ProgramDescriptor desc;
+    push_reshard_copy_pages_cb(
+        desc, cb_in0_idx, data_format, aligned_page_size * num_tiles_in_cb, aligned_page_size, grid);
+
+    // Prepare compile time arguments
+    auto compile_time_args_reader = input_accessor_args.get_compile_time_args();
+    compile_time_args_reader.push_back(cb_in0_idx);  // Circular buffer index
+    compile_time_args_reader.push_back(aligned_page_size);
+
+    auto compile_time_args_writer = output_accessor_args.get_compile_time_args();
+    compile_time_args_writer.push_back(cb_in0_idx);
+    compile_time_args_writer.push_back(aligned_page_size);
+
+    // Create kernels
+    KernelDescriptor reader_desc;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/kernels/nd_reshard_copy_pages_reader.cpp";
+    reader_desc.core_ranges = grid;
+    reader_desc.config = ReaderConfigDescriptor{};
+    reader_desc.compile_time_args = std::move(compile_time_args_reader);
+
+    KernelDescriptor writer_desc;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/kernels/nd_reshard_copy_pages_writer.cpp";
+    writer_desc.core_ranges = grid;
+    writer_desc.config = WriterConfigDescriptor{};
+    writer_desc.compile_time_args = std::move(compile_time_args_writer);
+
+    // Common runtime args: arg 0 is the buffer base address (binding via Buffer*).
+    // emplace_common_runtime_args registers a CommonBufferBinding for the framework
+    // fast cache-hit path.
+    reader_desc.emplace_common_runtime_args({input_buffer});
+    writer_desc.emplace_common_runtime_args({output_buffer});
+
+    // Per-core unique runtime args: [start_page, end_page]
+    uint32_t start_page = 0;
+    uint32_t num_dev_pages =
+        static_cast<uint32_t>(input_buffer->buffer_distribution_spec()->tensor_shape_in_pages().volume());
+    uint32_t n_pages_per_core = num_dev_pages / static_cast<uint32_t>(cores.size());
+    uint32_t remainder = num_dev_pages % static_cast<uint32_t>(cores.size());
+
+    for (const auto& core : cores) {
+        uint32_t num_pages_for_core = n_pages_per_core;
+        if (remainder > 0) {
+            num_pages_for_core++;
+            remainder--;
+        }
+        reader_desc.emplace_runtime_args(core, {start_page, start_page + num_pages_for_core});
+        writer_desc.emplace_runtime_args(core, {start_page, start_page + num_pages_for_core});
+        start_page += num_pages_for_core;
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/nd_reshard_program_factory_copy_pages.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/nd_reshard_program_factory_copy_pages.hpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/program_descriptors.hpp>
+
+#include "ttnn/device_operation.hpp"
+#include "reshard_device_operation_types.hpp"
+
+namespace ttnn::prim::qsr {
+
+// Factory for DRAM->DRAM nd reshard (simple page by page copy)
+struct NdReshardCopyPagesFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const ReshardParams& operation_attributes, const ReshardInputs& tensor_args, Tensor& output_tensor);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_device_operation.cpp
@@ -1,0 +1,320 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/experimental/quasar/reshard/device/reshard_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/data_movement/common/common.hpp"
+#include "ttnn/tensor/tensor_ops.hpp"
+
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/tt_align.hpp>
+#include <tt-metalium/work_split.hpp>
+
+#include <enchantum/enchantum.hpp>
+
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+
+namespace CMAKE_UNIQUE_NAMESPACE {
+bool is_valid_for_legacy_reshard(const Tensor& input_tensor, const MemoryConfig& out_mem_config) {
+    auto inp_mem_layout = input_tensor.memory_config().memory_layout();
+    auto out_mem_layout = out_mem_config.memory_layout();
+
+    auto inp_buffer_type = input_tensor.memory_config().buffer_type();
+    auto out_buffer_type = out_mem_config.buffer_type();
+
+    if (!input_tensor.memory_config().shard_spec().has_value() || !out_mem_config.shard_spec().has_value()) {
+        // If shard_spec has no value, then we can only use nd resharding
+        return false;
+    }
+
+    if (inp_mem_layout == out_mem_layout && inp_mem_layout != TensorMemoryLayout::BLOCK_SHARDED &&
+        inp_mem_layout != TensorMemoryLayout::ND_SHARDED) {
+        // Resharding must have at least one buffer in L1
+        return inp_buffer_type == BufferType::L1 || out_buffer_type == BufferType::L1;
+    }  // Resharding requires output buffer to be in L1
+    return out_mem_config.buffer_type() == BufferType::L1;
+
+    if (input_tensor.layout() == Layout::ROW_MAJOR) {
+        if (inp_mem_layout == TensorMemoryLayout::WIDTH_SHARDED) {
+            // row major must have shard_spec[0] be the same on both input and output
+            return input_tensor.memory_config().shard_spec().value().shape[0] ==
+                   out_mem_config.shard_spec().value().shape[0];
+        }  // row major must have shard_spec[1] be the same on both input and output
+        return input_tensor.memory_config().shard_spec().value().shape[1] ==
+               out_mem_config.shard_spec().value().shape[1];
+    }
+    return true;
+}
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+
+ReshardDeviceOperation::program_factory_t ReshardDeviceOperation::select_program_factory(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input;
+    auto output_tensor_spec = compute_output_specs(args, tensor_args);
+    const auto& out_mem_config = output_tensor_spec.memory_config();
+
+    if (CMAKE_UNIQUE_NAMESPACE::is_valid_for_legacy_reshard(input_tensor, out_mem_config)) {
+        if (input_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED &&
+            out_mem_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
+            if (out_mem_config.buffer_type() == BufferType::L1) {
+                return ReshardSameWidthFactory</*local_is_output*/ true>{};
+            }
+            return ReshardSameWidthFactory</*local_is_output*/ false>{};
+        }
+        if (input_tensor.layout() == Layout::ROW_MAJOR &&
+            input_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED &&
+            out_mem_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED) {
+            if (out_mem_config.buffer_type() == BufferType::L1) {
+                bool has_padding = false;
+                CoreCoord input_shard_grid = input_tensor.buffer()->shard_spec().grid().ranges()[0].grid_size();
+                CoreCoord output_shard_grid = out_mem_config.shard_spec().value().grid.ranges()[0].grid_size();
+                uint32_t input_num_shard_cores = input_shard_grid.x == 1 ? input_shard_grid.y : input_shard_grid.x;
+                uint32_t output_num_shard_cores = output_shard_grid.x == 1 ? output_shard_grid.y : output_shard_grid.x;
+                uint32_t input_shard_width = input_tensor.buffer()->shard_spec().shape()[1];
+                uint32_t output_shard_width = out_mem_config.shard_spec().value().shape[1];
+                has_padding = input_num_shard_cores * input_shard_width > input_tensor.logical_shape()[-1];
+                has_padding =
+                    has_padding || output_num_shard_cores * output_shard_width > input_tensor.logical_shape()[-1];
+                if (has_padding) {
+                    return ReshardGenericFactory{};
+                }
+                return ReshardSameHeightFactory</*local_is_output*/ true>{};
+            }
+            return ReshardSameHeightFactory</*local_is_output*/ false>{};
+        }
+        return ReshardGenericFactory{};
+    }
+    auto input_buffer_type = input_tensor.memory_config().buffer_type();
+    auto output_buffer_type = out_mem_config.buffer_type();
+    auto input_page_size = input_tensor.buffer()->page_size();
+    auto output_page_size = output_tensor_spec.compute_page_size_bytes();
+
+    TT_FATAL(
+        input_buffer_type == BufferType::DRAM || input_buffer_type == BufferType::L1,
+        "Input buffer type must be DRAM or L1");
+    TT_FATAL(
+        output_buffer_type == BufferType::DRAM || output_buffer_type == BufferType::L1,
+        "Output buffer type must be DRAM or L1");
+
+    if (input_buffer_type == BufferType::DRAM && output_buffer_type == BufferType::DRAM) {
+        return NdReshardCopyPagesFactory{};
+    }
+    if (input_buffer_type == BufferType::L1 && output_buffer_type == BufferType::L1 &&
+        input_page_size != output_page_size) {
+        return NdReshardCopyLocalShardFactory</*local_is_input*/ true>{};
+    }
+
+    if (input_buffer_type == BufferType::DRAM) {
+        return NdReshardCopyLocalShardFactory</*local_is_input*/ false>{};
+    }
+    return NdReshardCopyLocalShardFactory</*local_is_input*/ true>{};
+}
+
+std::pair<bool, std::string> ReshardDeviceOperation::validate_inputs(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input;
+
+    if (input_tensor.storage_type() != StorageType::DEVICE) {
+        return {false, "Operands to shard need to be on device!"};
+    }
+    if (input_tensor.buffer() == nullptr) {
+        return {false, "Operands to shard need to be allocated in buffers on device!"};
+    }
+    if (!input_tensor.is_sharded()) {
+        return {false, "input must be sharded"};
+    }
+    if (tensor_args.preallocated_output.has_value()) {
+        const auto& output_tensor = tensor_args.preallocated_output.value();
+        if (input_tensor.logical_shape() != output_tensor.logical_shape()) {
+            return {
+                false,
+                fmt::format(
+                    "Input tensor logical shape ({}) must equal output tensor logical shape ({})",
+                    input_tensor.logical_shape(),
+                    output_tensor.logical_shape())};
+        }
+        if (input_tensor.dtype() != output_tensor.dtype()) {
+            return {
+                false,
+                fmt::format(
+                    "Input tensor dtype ({}) must equal output tensor dtype ({})",
+                    input_tensor.dtype(),
+                    output_tensor.dtype())};
+        }
+        if (input_tensor.layout() != output_tensor.layout()) {
+            return {
+                false,
+                fmt::format(
+                    "Input tensor layout ({}) must equal output tensor layout ({})",
+                    input_tensor.layout(),
+                    output_tensor.layout())};
+        }
+    }
+
+    const auto& out_mem_config = tensor_args.preallocated_output.has_value()
+                                     ? tensor_args.preallocated_output->memory_config()
+                                     : args.output_mem_config;
+    if (!out_mem_config.is_sharded()) {
+        return {false, "output must be sharded"};
+    }
+
+    // ReshardSameWidthFactory (height↔height) has explicit unaligned handling,
+    // but all other legacy and ND factories require L1-aligned shard widths for correct NOC transfers.
+    if (input_tensor.layout() == Layout::ROW_MAJOR) {
+        bool is_height_to_height = input_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED &&
+                                   out_mem_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
+
+        if (!is_height_to_height) {
+            const uint32_t alignment = hal::get_l1_alignment();
+
+            uint32_t input_page_size = input_tensor.buffer()->page_size();
+            uint32_t input_aligned_page_size = input_tensor.buffer()->aligned_page_size();
+            if (input_page_size != input_aligned_page_size) {
+                return {
+                    false,
+                    fmt::format(
+                        "Input row-major shard width {} with data type {} gives page size {} bytes, "
+                        "which must be aligned to {} bytes for reshard",
+                        input_tensor.memory_config().shard_spec().has_value()
+                            ? input_tensor.memory_config().shard_spec().value().shape[1]
+                            : 0,
+                        input_tensor.dtype(),
+                        input_page_size,
+                        alignment)};
+            }
+
+            uint32_t output_shard_width = out_mem_config.shard_spec().has_value()
+                                              ? out_mem_config.shard_spec().value().shape[1]
+                                              : out_mem_config.nd_shard_spec().value().shard_shape[-1];
+            uint32_t output_page_size = output_shard_width * input_tensor.element_size();
+            uint32_t output_aligned_page_size = tt::align(output_page_size, alignment);
+            if (output_page_size != output_aligned_page_size) {
+                return {
+                    false,
+                    fmt::format(
+                        "Output row-major shard width {} with data type {} gives page size {} bytes, "
+                        "which must be aligned to {} bytes for reshard",
+                        output_shard_width,
+                        input_tensor.dtype(),
+                        output_page_size,
+                        alignment)};
+            }
+        }
+    }
+
+    auto output_tensor_spec = compute_output_specs(args, tensor_args);
+    if (!CMAKE_UNIQUE_NAMESPACE::is_valid_for_legacy_reshard(input_tensor, output_tensor_spec.memory_config())) {
+        auto input_buffer_type = input_tensor.memory_config().buffer_type();
+        auto output_buffer_type = output_tensor_spec.memory_config().buffer_type();
+        if (input_buffer_type != BufferType::DRAM && input_buffer_type != BufferType::L1) {
+            return {false, "Input buffer type must be DRAM or L1 for ND sharded specialized reshard path"};
+        }
+        if (output_buffer_type != BufferType::DRAM && output_buffer_type != BufferType::L1) {
+            return {false, "Output buffer type must be DRAM or L1 for ND sharded specialized reshard path"};
+        }
+
+        auto out_distribution_spec = output_tensor_spec.compute_buffer_sharding_args().buffer_distribution_spec();
+        auto input_distribution_spec = input_tensor.buffer()->buffer_distribution_spec();
+
+        auto n_logical_input_pages = input_distribution_spec->tensor_shape_in_pages().volume();
+        auto n_logical_output_pages = out_distribution_spec->tensor_shape_in_pages().volume();
+
+        auto input_page_size = input_tensor.tensor_spec().compute_page_size_bytes();
+        auto output_page_size = output_tensor_spec.compute_page_size_bytes();
+
+        if (n_logical_input_pages != n_logical_output_pages) {
+            return {
+                false,
+                fmt::format(
+                    "Number of input ({}) and output ({}) pages must match",
+                    n_logical_input_pages,
+                    n_logical_output_pages)};
+        }
+        if (input_page_size != output_page_size) {
+            return {
+                false,
+                fmt::format(
+                    "Input and output tensors must have the same page size. Input page size: {}, Output page size: {}",
+                    input_page_size,
+                    output_page_size)};
+        }
+        if (input_tensor.layout() != output_tensor_spec.tensor_layout().get_layout()) {
+            return {
+                false,
+                fmt::format(
+                    "Input and output tensors must have the same layout. Input layout: {}, Output layout: {}",
+                    enchantum::to_string(input_tensor.layout()),
+                    enchantum::to_string(output_tensor_spec.tensor_layout().get_layout()))};
+        }
+    } else {
+        if (input_tensor.layout() == Layout::TILE) {
+            auto tile = input_tensor.tensor_spec().tile();
+            if (tile.get_height() != tt::constants::TILE_HEIGHT || tile.get_width() != tt::constants::TILE_WIDTH) {
+                return {
+                    false,
+                    fmt::format(
+                        "reshard requires standard 32x32 tiles, got {}x{}", tile.get_height(), tile.get_width())};
+            }
+            if (tensor_args.preallocated_output.has_value()) {
+                auto out_tile = tensor_args.preallocated_output.value().tensor_spec().tile();
+                if (out_tile != tile) {
+                    return {false, "Output tensor tile shape must match input tensor tile shape"};
+                }
+            }
+        }
+    }
+    return {true, ""};
+}
+
+void ReshardDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    auto [valid, msg] = validate_inputs(args, tensor_args);
+    TT_FATAL(valid, "{}", msg);
+}
+
+TensorSpec ReshardDeviceOperation::compute_output_specs(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    if (tensor_args.preallocated_output.has_value()) {
+        return tensor_args.preallocated_output->tensor_spec();
+    }
+
+    const auto& input_tensor = tensor_args.input;
+    return tt::tt_metal::TensorSpec(
+        input_tensor.logical_shape(),
+        tt::tt_metal::TensorLayout(
+            input_tensor.dtype(), tt::tt_metal::PageConfig(input_tensor.layout()), args.output_mem_config));
+}
+
+Tensor ReshardDeviceOperation::create_output_tensors(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    if (tensor_args.preallocated_output.has_value()) {
+        return tensor_args.preallocated_output.value();
+    }
+
+    return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input.device());
+}
+
+tt::tt_metal::operation::OpPerformanceModelGeneral<Tensor> ReshardDeviceOperation::create_op_performance_model(
+    const operation_attributes_t& /*operation_attributes*/,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output_tensor) const {
+    int ideal_dev_clock_cycles = ttnn::operations::data_movement::common_tm_bw_model(tensor_args.input, output_tensor);
+    tt::tt_metal::operation::OpPerformanceModelGeneral<Tensor> result(
+        {tensor_args.input}, {output_tensor}, ideal_dev_clock_cycles);
+    return result;
+}
+
+Tensor reshard(
+    const Tensor& input_tensor,
+    const tt::tt_metal::MemoryConfig& memory_config,
+    const std::optional<Tensor>& preallocated_output) {
+    return ttnn::device_operation::launch<ReshardDeviceOperation>(
+        ReshardParams{.output_mem_config = memory_config},
+        ReshardInputs{.input = input_tensor, .preallocated_output = preallocated_output});
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_device_operation.hpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/operations/experimental/quasar/reshard/device/reshard_device_operation_types.hpp"
+#include "ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_same_width.hpp"
+#include "ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_same_height.hpp"
+#include "ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_generic.hpp"
+#include "ttnn/operations/experimental/quasar/reshard/device/nd_reshard_program_factory_copy_pages.hpp"
+#include "ttnn/operations/experimental/quasar/reshard/device/nd_reshard_program_factory_copy_local.hpp"
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
+#include "ttnn/operation.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct ReshardDeviceOperation {
+    using operation_attributes_t = ReshardParams;
+    using tensor_args_t = ReshardInputs;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
+    using program_factory_t = std::variant<
+        ReshardSameWidthFactory</*local_is_output*/ true>,
+        ReshardSameWidthFactory</*local_is_output*/ false>,
+        ReshardSameHeightFactory</*local_is_output*/ true>,
+        ReshardSameHeightFactory</*local_is_output*/ false>,
+        ReshardGenericFactory,
+        NdReshardCopyPagesFactory,
+        NdReshardCopyLocalShardFactory</*local_is_input*/ true>,
+        NdReshardCopyLocalShardFactory</*local_is_input*/ false>>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+
+    static std::pair<bool, std::string> validate_inputs(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t& args, const tensor_args_t&);
+
+    tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& output_tensor) const;
+};
+
+Tensor reshard(
+    const Tensor& input_tensor,
+    const tt::tt_metal::MemoryConfig& memory_config,
+    const std::optional<Tensor>& preallocated_output);
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_device_operation_types.hpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct ReshardParams {
+    tt::tt_metal::MemoryConfig output_mem_config;
+};
+
+struct ReshardInputs {
+    Tensor input;
+    std::optional<Tensor> preallocated_output;
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_generic.cpp
@@ -1,0 +1,810 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_generic.hpp"
+
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/tensor/tensor_utils.hpp"
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+
+namespace {
+
+// Anonymous-namespace helper unique to reshard generic to avoid unity-build collisions.
+void push_reshard_generic_cb_pair(
+    ProgramDescriptor& desc,
+    uint32_t cb_index,
+    tt::DataFormat data_format,
+    uint32_t total_size,
+    uint32_t page_size,
+    const CoreRangeSet& core_ranges,
+    Buffer* bound_buffer) {
+    CBDescriptor cb;
+    cb.total_size = total_size;
+    cb.core_ranges = core_ranges;
+    cb.format_descriptors.push_back(CBFormatDescriptor{
+        .buffer_index = static_cast<uint8_t>(cb_index),
+        .data_format = data_format,
+        .page_size = page_size,
+    });
+    cb.buffer = bound_buffer;
+    desc.cbs.push_back(std::move(cb));
+}
+
+}  // namespace
+
+namespace detail {
+// start is inclusive, end is exclusive
+struct PageRange {
+    uint32_t start;
+    uint32_t end;
+};
+
+struct Stride {
+    CoreCoord core;
+    uint32_t data{};
+};
+
+struct PageStride {
+    CoreCoord start_core;
+    uint32_t start_data{};
+    uint32_t stride_size{};  // number of pages per stride
+    Stride stride;
+    uint32_t num_strides{};
+    bool skip{};
+};
+
+struct CompressedStrideBlock {
+    std::vector<PageStride> base_pattern;
+    std::vector<Stride> meta_strides;
+    uint32_t num_repeats = 0;
+};
+
+enum class ReshardStridesInRange { ALL_STRIDES, FIRST_HALF };
+
+std::unordered_map<CoreCoord, std::vector<detail::PageStride>> create_map_for_reshard(
+    std::vector<std::vector<std::optional<std::pair<CoreCoord, uint32_t>>>> output_core_to_vector_input_core_page,
+    Buffer* input_buffer,
+    Buffer* output_buffer) {
+    std::unordered_map<CoreCoord, std::vector<detail::PageStride>> ret_map;
+    auto output_cores = output_buffer->get_buffer_page_mapping()->all_cores;
+    ret_map.reserve(output_cores.size());
+
+    auto* device = input_buffer->device();
+    auto full_grid = device->compute_with_storage_grid_size();
+    uint32_t output_core_id = 0;
+    for (auto output_core : output_cores) {
+        ret_map.try_emplace(output_core, std::vector<PageStride>{});
+
+        const auto& input_cores_with_pages = output_core_to_vector_input_core_page[output_core_id];
+        auto it = input_cores_with_pages.begin();
+        const auto end = input_cores_with_pages.end();
+
+        while (it != end) {
+            // hit padding, will see how many consecutive pages has padding to make a padded range
+            if (!it->has_value()) {
+                auto consecutive_it = it + 1;
+                auto last_it_consec = it;
+                while (consecutive_it != end) {
+                    if (consecutive_it->has_value()) {
+                        break;
+                    }
+                    last_it_consec = consecutive_it;
+                    consecutive_it = consecutive_it + 1;
+                }
+                uint32_t stride_size = std::distance(it, last_it_consec) + 1;
+                ret_map[output_core].push_back(PageStride{
+                    .start_core = output_core,
+                    .start_data = 0,
+                    .stride_size = stride_size,
+                    .stride = Stride{.core = {0, 0}, .data = 0},
+                    .num_strides = 1,
+                    .skip = true});
+                it += stride_size;
+            } else {
+                const auto start_core = it->value().first;
+                Stride stride = Stride{.core = {0, 0}, .data = 0};
+                if ((it + 1) == end) {
+                    ret_map[output_core].push_back(PageStride{
+                        .start_core = start_core,
+                        .start_data = it->value().second,
+                        .stride_size = 1,
+                        .stride = stride,
+                        .num_strides = 1,
+                        .skip = false});
+                    it = end;
+                } else {
+                    // first get a single stride, go through the number of consecutive pages in the same core
+                    auto consecutive_it = it + 1;
+                    auto last_it_consec = it;
+                    while (consecutive_it != end and consecutive_it->has_value()) {
+                        auto next_input_page = *(consecutive_it);
+                        auto curr_input_page = *(last_it_consec);
+                        // diff core or not consecutive
+                        if (curr_input_page.value().first != next_input_page.value().first ||
+                            (curr_input_page.value().second + 1) != next_input_page.value().second) {
+                            break;
+                        }
+                        // next page is padding
+                        last_it_consec = consecutive_it;
+                        consecutive_it = consecutive_it + 1;
+                    }
+                    uint32_t stride_size = std::distance(it, last_it_consec) + 1;
+                    auto stride_it = it + stride_size;
+                    auto last_it_stride = it;
+
+                    // TT_ASSERT((stride_it == end) or stride_it->has_value());
+                    TT_ASSERT(last_it_stride->has_value());
+                    // if stride_range is within same core
+                    // the jump in data is end of curr - end last stride
+                    // if stride range is in diff core
+                    // jump in data is curr - beginning of last stride
+                    uint32_t data_stride;
+                    if ((stride_it != end) and (stride_it != it) and stride_it->has_value()) {
+                        // data stride within core
+                        if (stride_it->has_value() and stride_it->value().first == last_it_stride->value().first and
+                            (stride_it->value().second > last_it_stride->value().second)) {
+                            auto next_input_page = *(stride_it);
+                            auto prev_input_page = *(last_it_stride);
+                            TT_ASSERT(prev_input_page.has_value());
+                            TT_ASSERT(next_input_page.has_value());
+                            data_stride = next_input_page.value().second - prev_input_page.value().second - stride_size;
+                            stride = Stride{.core = {0, 0}, .data = data_stride};
+                        }
+                        // strided core but same data
+                        // currently only handling increasing cores within same stride
+                        // TODO : negative strides for cores
+                        else if (
+                            stride_it->has_value() and (stride_it->value().first != last_it_stride->value().first) and
+                            (stride_it->value().first.x >= it->value().first.x and
+                             stride_it->value().first.y >= it->value().first.y) and
+                            (stride_it->value().second == it->value().second)) {
+                            auto next_input_page = *(stride_it);
+                            auto prev_input_page = *it;
+                            TT_ASSERT(prev_input_page.has_value());
+                            TT_ASSERT(next_input_page.has_value());
+                            data_stride = 0;
+                            stride = Stride{
+                                .core =
+                                    {next_input_page.value().first.x - prev_input_page.value().first.x,
+                                     next_input_page.value().first.y - prev_input_page.value().first.y},
+                                .data = data_stride};
+                        }
+                        // diff data and diff core, not handled yet
+                        else {
+                            TT_ASSERT(it->has_value());
+                            ret_map[output_core].push_back(PageStride{
+                                .start_core = start_core,
+                                .start_data = it->value().second,
+                                .stride_size = stride_size,
+                                .stride = stride,
+                                .num_strides = 1,
+                                .skip = false});
+                            it = stride_it;
+                            continue;
+                        }
+                        // TODO add stride of data and core
+                    }
+                    // only single stride
+                    else {
+                        data_stride = 0;
+                    }
+
+                    TT_ASSERT(stride.core.x < full_grid.x and stride.core.y < full_grid.y);
+                    TT_ASSERT(data_stride < output_buffer->num_pages());
+                    uint32_t num_strides = 1;
+                    while (stride_it != end and stride_it->has_value()) {
+                        bool stride_not_complete = false;
+                        auto stride_it_inner = stride_it + 1;
+                        auto last_it_stride_inner = stride_it;
+                        for (uint32_t i = 0; i < stride_size - 1; i++) {
+                            auto next_input_page = *(stride_it_inner);
+                            auto curr_input_page = *(last_it_stride_inner);
+                            TT_ASSERT(curr_input_page.has_value());
+                            int increment = 1;
+                            if (!(next_input_page.has_value()) or
+                                (next_input_page.value().first != curr_input_page.value().first) or
+                                ((int)next_input_page.value().second !=
+                                 (int)(curr_input_page.value().second) + (int)increment)) {
+                                stride_not_complete = true;
+                                break;
+                            }
+                            last_it_stride_inner = stride_it_inner;
+                            stride_it_inner = stride_it_inner + 1;
+                        }
+                        if (stride_not_complete) {
+                            break;
+                        }
+                        num_strides++;
+                        last_it_stride = stride_it_inner - 1;
+                        stride_it = stride_it_inner;
+                        if (stride_it == end or !stride_it->has_value()) {
+                            break;
+                        }
+                        auto next_input_page = *(stride_it);
+                        auto curr_input_page = *(last_it_stride);
+                        // TT_ASSERT(curr_input_page.has_value());
+                        if (!curr_input_page.has_value() or !next_input_page.has_value() or
+                            (next_input_page.value().first.x - curr_input_page.value().first.x != stride.core.x) or
+                            (next_input_page.value().first.y - curr_input_page.value().first.y != stride.core.y) or
+                            (abs((int)next_input_page.value().second - (int)curr_input_page.value().second) !=
+                             (int)stride.data)) {
+                            break;
+                        }
+                    }
+                    TT_ASSERT(it->has_value());
+                    ret_map[output_core].push_back(PageStride{
+                        .start_core = start_core,
+                        .start_data = it->value().second,
+                        .stride_size = stride_size,
+                        .stride = stride,
+                        .num_strides = num_strides,
+                        .skip = false});
+                    it = stride_it;
+                }
+            }
+        }
+        output_core_id++;
+    }
+    return ret_map;
+}
+
+bool are_strides_structurally_equal(const PageStride& a, const PageStride& b) {
+    return a.stride_size == b.stride_size && a.stride.core == b.stride.core && a.stride.data == b.stride.data &&
+           a.num_strides == b.num_strides && a.skip == b.skip;
+}
+
+std::unordered_map<CoreCoord, std::vector<detail::CompressedStrideBlock>> create_stride_of_strides_ret_map(
+    const std::unordered_map<CoreCoord, std::vector<detail::PageStride>>& input_map) {
+    std::unordered_map<CoreCoord, std::vector<detail::CompressedStrideBlock>> ret_map;
+    ret_map.reserve(input_map.size());
+
+    for (const auto& [core, page_strides] : input_map) {
+        if (page_strides.empty()) {
+            continue;
+        }
+        std::vector<detail::CompressedStrideBlock> compressed_blocks;
+        auto it = page_strides.cbegin();
+        while (it != page_strides.cend()) {
+            size_t best_pattern_len = 0;
+            uint32_t best_num_repeats = 1;
+            std::vector<Stride> best_meta_strides;
+
+            // Find the longest repeating pattern starting at the current position `it`
+            for (size_t pattern_len = 1; it + pattern_len <= page_strides.cend(); ++pattern_len) {
+                auto pattern_begin = it;
+                uint32_t num_repeats = 1;
+
+                // First, find how many times the pattern is structurally repeated
+                while (true) {
+                    auto next_block_start = it + num_repeats * pattern_len;
+                    if (next_block_start + pattern_len > page_strides.cend()) {
+                        break;  // Not enough elements for another full repetition
+                    }
+
+                    bool structurally_equal = true;
+                    for (size_t i = 0; i < pattern_len; ++i) {
+                        if (!are_strides_structurally_equal(*(pattern_begin + i), *(next_block_start + i))) {
+                            structurally_equal = false;
+                            break;
+                        }
+                    }
+
+                    if (!structurally_equal) {
+                        break;
+                    }
+                    num_repeats++;
+                }
+
+                if (num_repeats <= 1) {
+                    continue;
+                }
+
+                // Now, validate that the start coords/data progress with a consistent stride
+                auto first_repeat_begin = it + pattern_len;
+                std::vector<Stride> meta_strides;
+                meta_strides.reserve(pattern_len);
+                for (size_t i = 0; i < pattern_len; i++) {
+                    const auto& base_ps = *(pattern_begin + i);
+                    const auto& repeat_ps = *(first_repeat_begin + i);
+                    meta_strides.push_back(
+                        {.core =
+                             {repeat_ps.start_core.x - base_ps.start_core.x,
+                              repeat_ps.start_core.y - base_ps.start_core.y},
+                         .data = repeat_ps.start_data - base_ps.start_data});
+                }
+
+                bool all_repeats_valid = true;
+                for (uint32_t r = 1; r < num_repeats; ++r) {
+                    auto current_block_start = it + r * pattern_len;
+                    for (size_t i = 0; i < pattern_len; ++i) {
+                        const auto& original_page_stride = *(pattern_begin + i);
+                        const auto& current_page_stride = *(current_block_start + i);
+                        const auto& pattern_meta_stride = meta_strides[i];
+
+                        CoreCoord expected_core = {
+                            original_page_stride.start_core.x + (r * pattern_meta_stride.core.x),
+                            original_page_stride.start_core.y + (r * pattern_meta_stride.core.y)};
+                        uint32_t expected_data = original_page_stride.start_data + (r * pattern_meta_stride.data);
+
+                        if (current_page_stride.start_core != expected_core ||
+                            current_page_stride.start_data != expected_data) {
+                            all_repeats_valid = false;
+                            num_repeats = r;  // This pattern is only valid for r repetitions
+                            break;
+                        }
+                    }
+                    if (!all_repeats_valid) {
+                        break;
+                    }
+                }
+
+                if (num_repeats > 1 && (pattern_len * num_repeats) > (best_pattern_len * best_num_repeats)) {
+                    best_pattern_len = pattern_len;
+                    best_num_repeats = num_repeats;
+                    best_meta_strides = meta_strides;
+                }
+            }
+
+            if (best_pattern_len > 0) {
+                // A compressible pattern was found.
+                std::vector<PageStride> base_pattern(it, it + best_pattern_len);
+                compressed_blocks.push_back(
+                    {.base_pattern = std::move(base_pattern),
+                     .meta_strides = std::move(best_meta_strides),
+                     .num_repeats = best_num_repeats});
+                it += best_pattern_len * best_num_repeats;
+            } else {
+                // No repeating pattern found, treat as a block of 1.
+                compressed_blocks.push_back({.base_pattern = {*it}, .meta_strides = {{}}, .num_repeats = 1});
+                it++;
+            }
+        }
+        ret_map.try_emplace(core, std::move(compressed_blocks));
+    }
+    return ret_map;
+}
+
+std::unordered_map<CoreCoord, std::vector<detail::PageStride>> get_core_page_ranges(
+    Buffer* input_buffer, Buffer* output_buffer) {
+    const auto& output_buffer_page_mapping = *output_buffer->get_buffer_page_mapping();
+    const auto& input_buffer_page_mapping = *input_buffer->get_buffer_page_mapping();
+
+    std::vector<std::pair<CoreCoord, uint32_t>> host_page_to_input_core_mapping(input_buffer->num_pages());
+    for (auto mapped_page : input_buffer_page_mapping) {
+        auto core = input_buffer_page_mapping.all_cores[mapped_page.core_id];
+        host_page_to_input_core_mapping[mapped_page.host_page] = {core, mapped_page.device_page};
+    }
+
+    auto output_cores = output_buffer_page_mapping.all_cores;
+
+    std::vector<std::vector<std::optional<std::pair<CoreCoord, uint32_t>>>> output_core_to_vector_input_core_page(
+        output_cores.size());
+
+    for (auto mapped_page : output_buffer_page_mapping) {
+        auto& cur_output_core_to_vector_input_core_page = output_core_to_vector_input_core_page[mapped_page.core_id];
+        auto [input_core, input_core_page] = host_page_to_input_core_mapping[mapped_page.host_page];
+        if (cur_output_core_to_vector_input_core_page.size() <= mapped_page.device_page) {
+            cur_output_core_to_vector_input_core_page.resize(mapped_page.device_page + 1);
+        }
+        cur_output_core_to_vector_input_core_page[mapped_page.device_page] = {input_core, input_core_page};
+    }
+    auto ret_map = create_map_for_reshard(output_core_to_vector_input_core_page, input_buffer, output_buffer);
+    return ret_map;
+}
+
+std::unordered_map<CoreCoord, std::vector<detail::CompressedStrideBlock>> get_core_page_ranges_diff_width(
+    Buffer* input_buffer, Buffer* output_buffer, const Tensor& input) {
+    const auto& output_buffer_page_mapping = *output_buffer->get_buffer_page_mapping();
+    const auto& input_buffer_page_mapping = *input_buffer->get_buffer_page_mapping();
+    uint32_t num_rows = 1;
+    for (uint32_t i = 0; i < input.logical_shape().rank() - 1; i++) {
+        num_rows *= input.logical_shape()[i];
+    }
+    // Find GCD of page sizes to use as the new base page size
+    uint32_t input_page_size = input_buffer->page_size();
+    uint32_t output_page_size = output_buffer->page_size();
+    uint32_t base_page_size = std::gcd(input_page_size, output_page_size);
+
+    // Calculate how many base pages make up an input/output page
+    uint32_t input_pages_per_original = input_page_size / base_page_size;
+    uint32_t output_pages_per_original = output_page_size / base_page_size;
+
+    auto input_width = input_buffer->shard_spec().shape()[1];
+    auto output_width = output_buffer->shard_spec().shape()[1];
+    auto total_width = input.logical_shape()[-1];
+
+    uint32_t total_page_number =
+        (input.logical_shape()[-1] * input.element_size() + base_page_size - 1) / base_page_size;
+    uint32_t num_input_pages_per_row = input_pages_per_original * ((total_width + input_width - 1) / input_width);
+    uint32_t num_output_pages_per_row = output_pages_per_original * ((total_width + output_width - 1) / output_width);
+
+    std::vector<std::pair<CoreCoord, uint32_t>> host_page_to_input_core_mapping(total_page_number * num_rows);
+
+    // data structure to account for padded base pages in the mapping
+    std::unordered_map<uint32_t, uint32_t> invalid_mapping_input;
+    std::unordered_map<uint32_t, uint32_t> invalid_mapping_output;
+    uint32_t num_invalid_pages_input = 0;
+    uint32_t num_invalid_pages_output = 0;
+    for (uint32_t i = 1; i <= num_rows; i++) {
+        invalid_mapping_input[total_page_number * i] = 0;
+        invalid_mapping_output[total_page_number * i] = 0;
+    }
+
+    // find input invalid base pages if applicable
+    for (auto mapped_page : input_buffer_page_mapping) {
+        auto core = input_buffer_page_mapping.all_cores[mapped_page.core_id];
+        CoreCoord shard_grid = input_buffer->shard_spec().grid().ranges()[0].grid_size();
+        bool is_last_in_row = (core.x == shard_grid.x - 1);
+        if (input_buffer->shard_spec().orientation() == ShardOrientation::COL_MAJOR) {
+            is_last_in_row = (core.y == shard_grid.y - 1);
+        }
+        uint32_t base_start_page = mapped_page.host_page * input_pages_per_original;
+        uint32_t valid_pages = input_pages_per_original;
+        if (is_last_in_row) {
+            uint32_t next_total =
+                ((base_start_page + num_input_pages_per_row) / num_input_pages_per_row) * total_page_number;
+            next_total = std::max(next_total, total_page_number);
+            valid_pages = std::min(next_total - base_start_page, input_pages_per_original);
+        }
+        if (input_pages_per_original - valid_pages > 0) {
+            num_invalid_pages_input = input_pages_per_original - valid_pages;
+            break;
+        }
+    }
+
+    // find output invalid base pages if applicable
+    for (auto mapped_page : output_buffer_page_mapping) {
+        auto core = output_buffer_page_mapping.all_cores[mapped_page.core_id];
+        CoreCoord shard_grid = output_buffer->shard_spec().grid().ranges()[0].grid_size();
+        bool is_last_in_row = (core.x == shard_grid.x - 1);
+        if (output_buffer->shard_spec().orientation() == ShardOrientation::COL_MAJOR) {
+            is_last_in_row = (core.y == shard_grid.y - 1);
+        }
+        uint32_t base_start_page = mapped_page.host_page * output_pages_per_original;
+        uint32_t valid_pages = output_pages_per_original;
+        if (is_last_in_row) {
+            uint32_t next_total =
+                ((base_start_page + num_output_pages_per_row) / num_output_pages_per_row) * total_page_number;
+            valid_pages = std::min(next_total - base_start_page, output_pages_per_original);
+        }
+        if (output_pages_per_original - valid_pages > 0) {
+            num_invalid_pages_output = output_pages_per_original - valid_pages;
+            break;
+        }
+    }
+
+    for (uint32_t i = 1; i <= num_rows; i++) {
+        invalid_mapping_input[total_page_number * i] = (i - 1) * num_invalid_pages_input;
+        invalid_mapping_output[total_page_number * i] = (i - 1) * num_invalid_pages_output;
+    }
+
+    // Create mapping of input base host pages to their cores
+    for (auto mapped_page : input_buffer_page_mapping) {
+        auto core = input_buffer_page_mapping.all_cores[mapped_page.core_id];
+        uint32_t base_start_page = mapped_page.host_page * input_pages_per_original;
+        uint32_t device_base_start = mapped_page.device_page * input_pages_per_original;
+        uint32_t next_total =
+            ((base_start_page + num_input_pages_per_row) / num_input_pages_per_row) * total_page_number;
+        next_total = std::max(next_total, total_page_number);
+        base_start_page = base_start_page - invalid_mapping_input[next_total];
+        uint32_t valid_pages = std::min(next_total - base_start_page, input_pages_per_original);
+        for (uint32_t i = 0; i < valid_pages; i++) {
+            host_page_to_input_core_mapping[base_start_page + i] = {core, device_base_start + i};
+        }
+    }
+
+    // Create similar mapping for output pages to their cores
+    std::vector<std::pair<CoreCoord, uint32_t>> host_page_to_output_core_mapping(total_page_number * num_rows);
+
+    for (auto mapped_page : output_buffer_page_mapping) {
+        auto core = output_buffer_page_mapping.all_cores[mapped_page.core_id];
+        uint32_t base_start_page = mapped_page.host_page * output_pages_per_original;
+        uint32_t device_base_start = mapped_page.device_page * output_pages_per_original;
+
+        uint32_t next_total =
+            ((base_start_page + num_output_pages_per_row) / num_output_pages_per_row) * total_page_number;
+        next_total = std::max(next_total, total_page_number);
+        base_start_page = base_start_page - invalid_mapping_output[next_total];
+        uint32_t valid_pages = std::min(next_total - base_start_page, output_pages_per_original);
+        for (uint32_t i = 0; i < valid_pages; i++) {
+            host_page_to_output_core_mapping[base_start_page + i] = {core, device_base_start + i};
+        }
+    }
+    // Create final mapping of output cores to input pages they need
+    auto output_cores = output_buffer_page_mapping.all_cores;
+    std::vector<std::vector<std::optional<std::pair<CoreCoord, uint32_t>>>> output_core_to_vector_input_core_page(
+        output_cores.size());
+
+    for (uint32_t core_id = 0; core_id < output_cores.size(); core_id++) {
+        auto& cur_output_core_pages = output_core_to_vector_input_core_page[core_id];
+
+        // Find all host pages that map to this output core
+        for (uint32_t host_page = 0; host_page < host_page_to_output_core_mapping.size(); host_page++) {
+            if (host_page_to_output_core_mapping[host_page].first == output_cores[core_id]) {
+                // This host page belongs to current output core
+                // Get corresponding input core and page
+                auto input_mapping = host_page_to_input_core_mapping[host_page];
+
+                // Add to vector if needed
+                uint32_t device_page = host_page_to_output_core_mapping[host_page].second;
+                if (cur_output_core_pages.size() <= device_page) {
+                    cur_output_core_pages.resize(device_page + 1);
+                }
+                cur_output_core_pages[device_page] = input_mapping;
+            }
+        }
+    }
+
+    auto ret_map = create_map_for_reshard(output_core_to_vector_input_core_page, input_buffer, output_buffer);
+
+    auto processed_ret_map = create_stride_of_strides_ret_map(ret_map);
+    return processed_ret_map;
+}
+
+std::vector<uint32_t> get_runtime_args_for_given_ranges_diff_width(
+    const std::vector<uint32_t>& physical_core_coords,
+    const std::vector<detail::CompressedStrideBlock>& compressed_stride_vector,
+    const uint32_t output_page_offset,
+    const uint32_t& input_addr,
+    const uint32_t starting_range,
+    const uint32_t ending_range) {
+    std::vector<uint32_t> runtime_args = physical_core_coords;
+    runtime_args.push_back(input_addr);
+    auto& num_output_pages_for_this_call = runtime_args.emplace_back(0);
+    runtime_args.push_back(ending_range - starting_range);
+    runtime_args.push_back(output_page_offset);
+
+    for (uint32_t block_id = starting_range; block_id < ending_range; block_id++) {
+        const auto& block = compressed_stride_vector[block_id];
+
+        runtime_args.push_back(block.num_repeats);
+        runtime_args.push_back(block.base_pattern.size());
+
+        uint32_t pages_in_base_pattern = 0;
+        for (size_t i = 0; i < block.base_pattern.size(); ++i) {
+            const auto& ps = block.base_pattern[i];
+            const auto& ms = block.meta_strides[i];
+
+            // Pack meta stride
+            uint32_t meta_stride_core = (static_cast<uint32_t>(ms.core.x) << 16) | static_cast<uint32_t>(ms.core.y);
+            runtime_args.push_back(meta_stride_core);
+            runtime_args.push_back(ms.data);
+
+            // Pack page stride
+            uint32_t core_start_stride =
+                (ps.start_core.x << 24) | (ps.start_core.y << 16) | (ps.stride.core.x << 8) | ps.stride.core.y;
+            runtime_args.push_back(core_start_stride);
+            uint32_t stride_data_start = (ps.stride.data << 16) | (ps.start_data);
+            runtime_args.push_back(stride_data_start);
+            uint32_t stride_size_num_strides = (ps.stride_size << 16) | (ps.num_strides << 8) | ((uint32_t)ps.skip);
+            runtime_args.push_back(stride_size_num_strides);
+
+            pages_in_base_pattern += ps.stride_size * ps.num_strides;
+        }
+        num_output_pages_for_this_call += pages_in_base_pattern * block.num_repeats;
+    }
+    return runtime_args;
+}
+
+std::vector<uint32_t> get_runtime_args_for_given_ranges(
+    const std::vector<uint32_t>& physical_core_coords,
+    const std::vector<PageStride>& page_stride_vector,
+    const uint32_t output_page_offset,
+    const uint32_t& input_addr,
+    const uint32_t starting_range,
+    const uint32_t ending_range,
+    const ReshardStridesInRange reshard_strides_in_range = ReshardStridesInRange::ALL_STRIDES) {
+    std::vector<uint32_t> runtime_args = physical_core_coords;
+    runtime_args.push_back(input_addr);
+    runtime_args.push_back(0);
+    runtime_args.push_back(ending_range - starting_range);
+    runtime_args.push_back(output_page_offset);
+    uint32_t num_output_pages = 0;
+    for (uint32_t range_id = starting_range; range_id < ending_range; range_id++) {
+        PageStride ps = page_stride_vector[range_id];
+        uint32_t num_strides;
+        uint32_t start_core_x;
+        uint32_t start_core_y;
+        uint32_t start_data;
+        if (reshard_strides_in_range == ReshardStridesInRange::ALL_STRIDES) {
+            num_strides = ps.num_strides;
+            start_core_x = ps.start_core.x;
+            start_core_y = ps.start_core.y;
+            start_data = ps.start_data;
+        } else {
+            if (reshard_strides_in_range == ReshardStridesInRange::FIRST_HALF) {
+                num_strides = ps.num_strides / 2;
+                start_core_x = ps.start_core.x;
+                start_core_y = ps.start_core.y;
+                start_data = ps.start_data;
+            } else {
+                uint32_t strides_in_first_half = ps.num_strides / 2;
+                num_strides = ps.num_strides - (strides_in_first_half);
+                start_core_x = ps.start_core.x + (strides_in_first_half * ps.stride.core.x);
+                start_core_y = ps.start_core.y + (strides_in_first_half * ps.stride.core.y);
+                start_data = ps.start_data + (strides_in_first_half * ps.start_data);
+            }
+        }
+        if (num_strides > 0) {
+            uint32_t core_start_stride =
+                (start_core_x << 24) | (start_core_y << 16) | (ps.stride.core.x << 8) | ps.stride.core.y;
+            runtime_args.push_back((uint32_t)core_start_stride);  // start_x
+            uint32_t stride_data_start = (ps.stride.data << 16) | (start_data);
+            runtime_args.push_back((uint32_t)stride_data_start);  // stride_data
+            uint32_t stride_size_num_strides = (ps.stride_size << 16) | (num_strides << 8) | ((uint32_t)ps.skip);
+            runtime_args.push_back((uint32_t)stride_size_num_strides);  // stride_size
+            num_output_pages += ps.stride_size * num_strides;
+        }
+    }
+    runtime_args[physical_core_coords.size() + 1] = num_output_pages;
+    return runtime_args;
+}
+
+}  // namespace detail
+
+ProgramDescriptor ReshardGenericFactory::create_descriptor(
+    const ReshardParams& /*operation_attributes*/, const ReshardInputs& tensor_args, Tensor& output_tensor) {
+    const auto& input = tensor_args.input;
+    auto& output = output_tensor;
+
+    auto* device = input.device();
+    auto* input_buffer = input.buffer();
+    auto* output_buffer = output.buffer();
+
+    auto grid = input_buffer->buffer_type() == BufferType::DRAM ? device->dram_grid_size()
+                                                                : device->compute_with_storage_grid_size();
+    auto input_core_type = input_buffer->core_type();
+    uint32_t dst_cb_index = 16;
+    auto cores = get_optimal_worker_cores_for_sharded_tensor(output);
+    auto all_cores = CoreRangeSet(ttsl::Span<const CoreCoord>(cores));
+
+    uint32_t total_size = 0;
+    uint32_t page_size = 0;
+    uint32_t unit_size = 0;
+    auto output_shard_shape = output.shard_spec().value().shape;
+    auto data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+
+    if (input.layout() == Layout::TILE) {
+        page_size = tt::tile_size(data_format);
+        unit_size = page_size;
+        total_size = static_cast<uint32_t>(output.shard_spec().value().numel() / TILE_HW) * unit_size;
+    } else {
+        // For ROW_MAJOR, use base page size from GCD calculation
+        uint32_t input_page_size = input_buffer->page_size();
+        uint32_t output_page_size = output_buffer->page_size();
+        uint32_t base_page_size = std::gcd(input_page_size, output_page_size);
+
+        unit_size = base_page_size;
+        page_size = base_page_size;
+        total_size = static_cast<uint32_t>(output_shard_shape[0] * output_shard_shape[1] * output.element_size());
+    }
+
+    ProgramDescriptor desc;
+
+    // Output sharded CB. Bind to output buffer for dynamic-CB rebinding on cache hits via cb.buffer.
+    push_reshard_generic_cb_pair(
+        desc,
+        dst_cb_index,
+        data_format,
+        total_size,
+        output_buffer->page_size(),
+        all_cores,
+        /*bound_buffer=*/output_buffer);
+
+    const std::string kernel_source = input_buffer->page_size() != output_buffer->page_size()
+                                          ? "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
+                                            "reshard_reader_diff_width.cpp"
+                                          : "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
+                                            "reshard_reader.cpp";
+
+    std::vector<uint32_t> compile_args = {
+        dst_cb_index, static_cast<uint32_t>(grid.x), static_cast<uint32_t>(grid.y), page_size, unit_size};
+
+    KernelDescriptor kernel_desc_0;
+    kernel_desc_0.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    kernel_desc_0.kernel_source = kernel_source;
+    kernel_desc_0.core_ranges = all_cores;
+    kernel_desc_0.config = ReaderConfigDescriptor{};
+    kernel_desc_0.compile_time_args = compile_args;
+
+    KernelDescriptor kernel_desc_1;
+    kernel_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    kernel_desc_1.kernel_source = kernel_source;
+    kernel_desc_1.core_ranges = all_cores;
+    kernel_desc_1.config = WriterConfigDescriptor{};
+    kernel_desc_1.compile_time_args = std::move(compile_args);
+
+    std::vector<uint32_t> physical_core_coords;
+    physical_core_coords.reserve(grid.x * grid.y);
+    for (uint32_t i = 0; i < grid.x; i++) {
+        auto physical_input_core = device->virtual_core_from_logical_core(CoreCoord(i, 0), input_core_type);
+        physical_core_coords.push_back(physical_input_core.x);
+    }
+    for (uint32_t i = 0; i < grid.y; i++) {
+        auto physical_input_core = device->virtual_core_from_logical_core(CoreCoord(0, i), input_core_type);
+        physical_core_coords.push_back(physical_input_core.y);
+    }
+
+    for (const auto& core : cores) {
+        std::vector<uint32_t> runtime_args_0;
+        std::vector<uint32_t> runtime_args_1;
+        if (input_buffer->page_size() != output_buffer->page_size()) {
+            auto output_core_to_page_range_pair =
+                detail::get_core_page_ranges_diff_width(input_buffer, output_buffer, input);
+            const auto& page_stride_vector = output_core_to_page_range_pair.at(core);
+            runtime_args_0 = detail::get_runtime_args_for_given_ranges_diff_width(
+                physical_core_coords,
+                page_stride_vector,
+                0,
+                input_buffer->address(),
+                0,
+                tt::div_up(static_cast<uint32_t>(page_stride_vector.size()), 2u));
+            auto output_page_offset = runtime_args_0[physical_core_coords.size() + 1];
+            runtime_args_1 = detail::get_runtime_args_for_given_ranges_diff_width(
+                physical_core_coords,
+                page_stride_vector,
+                output_page_offset,
+                input_buffer->address(),
+                tt::div_up(static_cast<uint32_t>(page_stride_vector.size()), 2u),
+                page_stride_vector.size());
+        } else {
+            auto output_core_to_page_range_pair = detail::get_core_page_ranges(input_buffer, output_buffer);
+            const auto& page_stride_vector = output_core_to_page_range_pair.at(core);
+            runtime_args_0 = detail::get_runtime_args_for_given_ranges(
+                physical_core_coords,
+                page_stride_vector,
+                0,
+                input_buffer->address(),
+                0,
+                tt::div_up(static_cast<uint32_t>(page_stride_vector.size()), 2u));
+            auto output_page_offset =
+                runtime_args_0[physical_core_coords.size() + 1];  // offset is equivalent to number of pages output in
+                                                                  // previous risc core
+            runtime_args_1 = detail::get_runtime_args_for_given_ranges(
+                physical_core_coords,
+                page_stride_vector,
+                output_page_offset,
+                input_buffer->address(),
+                tt::div_up(static_cast<uint32_t>(page_stride_vector.size()), 2u),
+                page_stride_vector.size());
+        }
+
+        // Patch arg index (grid.x + grid.y) to bind the input-buffer base address.
+        // The detail helpers already pre-compute physical_core_coords (size grid.x+grid.y) followed by input addr.
+        KernelDescriptor::RTArgList rt_args_0;
+        rt_args_0.reserve(runtime_args_0.size());
+        for (size_t i = 0; i < runtime_args_0.size(); ++i) {
+            if (i == grid.x + grid.y) {
+                rt_args_0.push_back(input_buffer);
+            } else {
+                rt_args_0.push_back(runtime_args_0[i]);
+            }
+        }
+        KernelDescriptor::RTArgList rt_args_1;
+        rt_args_1.reserve(runtime_args_1.size());
+        for (size_t i = 0; i < runtime_args_1.size(); ++i) {
+            if (i == grid.x + grid.y) {
+                rt_args_1.push_back(input_buffer);
+            } else {
+                rt_args_1.push_back(runtime_args_1[i]);
+            }
+        }
+
+        kernel_desc_0.emplace_runtime_args(core, rt_args_0);
+        kernel_desc_1.emplace_runtime_args(core, rt_args_1);
+    }
+
+    desc.kernels.push_back(std::move(kernel_desc_0));
+    desc.kernels.push_back(std::move(kernel_desc_1));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_generic.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_generic.hpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/program_descriptors.hpp>
+
+#include "ttnn/operations/experimental/quasar/reshard/device/reshard_device_operation_types.hpp"
+#include "ttnn/device_operation.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct ReshardGenericFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const ReshardParams& operation_attributes, const ReshardInputs& tensor_args, Tensor& output_tensor);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_same_height.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_same_height.cpp
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_same_height.hpp"
+#include "ttnn/operations/data_movement/sharded/sharded_common.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
+
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+
+namespace {
+
+// Anonymous-namespace helper unique to reshard same-height to avoid unity-build collisions.
+void push_reshard_same_height_cb_pair(
+    ProgramDescriptor& desc,
+    uint32_t cb_index,
+    tt::DataFormat data_format,
+    uint32_t total_size,
+    uint32_t page_size,
+    const CoreRangeSet& core_ranges,
+    Buffer* bound_buffer) {
+    CBDescriptor cb;
+    cb.total_size = total_size;
+    cb.core_ranges = core_ranges;
+    cb.format_descriptors.push_back(CBFormatDescriptor{
+        .buffer_index = static_cast<uint8_t>(cb_index),
+        .data_format = data_format,
+        .page_size = page_size,
+    });
+    cb.buffer = bound_buffer;
+    desc.cbs.push_back(std::move(cb));
+}
+
+}  // namespace
+
+template <bool local_is_output>
+ProgramDescriptor ReshardSameHeightFactory<local_is_output>::create_descriptor(
+    const ReshardParams& /*operation_attributes*/, const ReshardInputs& tensor_args, Tensor& output_tensor) {
+    const auto& input = tensor_args.input;
+    const auto& output = output_tensor;
+    const auto& local_tensor = local_is_output ? output : input;
+    const auto& remote_tensor = local_is_output ? input : output;
+    const auto local_shard_spec = local_tensor.shard_spec().value();
+    const auto remote_shard_spec = remote_tensor.shard_spec().value();
+
+    auto* device = input.device();
+
+    const auto remote_core_type = remote_tensor.buffer()->core_type();
+    bool interface_with_dram = (remote_core_type == tt::CoreType::DRAM);
+    auto local_cores = get_optimal_worker_cores_for_sharded_tensor(local_tensor);
+    auto all_cores = CoreRangeSet(ttsl::Span<const CoreCoord>(local_cores));
+    auto remote_cores = remote_tensor.buffer()->buffer_distribution_spec().value().cores_with_data();
+
+    const auto data_format = tt::tt_metal::datatype_to_dataformat_converter(local_tensor.dtype());
+    const uint32_t element_size = tt::datum_size(data_format);
+
+    TT_FATAL(local_tensor.layout() == Layout::ROW_MAJOR, "Expected row major tensor");
+    const uint32_t unit_size =
+        static_cast<uint32_t>(local_shard_spec.shape[1] * local_tensor.element_size());  // width * element size
+    const uint32_t remote_units_per_shard = remote_shard_spec.shape[0];                  // height
+    const uint32_t total_size = remote_units_per_shard * unit_size;
+
+    constexpr uint32_t cb_index = tt::CBIndex::c_0;
+
+    auto* local_buffer = local_tensor.buffer();
+    auto* remote_buffer = remote_tensor.buffer();
+
+    ProgramDescriptor desc;
+
+    // Local sharded CB. Bind to local buffer for dynamic-CB rebinding on cache hits via cb.buffer.
+    push_reshard_same_height_cb_pair(
+        desc, cb_index, data_format, total_size, unit_size, all_cores, /*bound_buffer=*/local_buffer);
+
+    const std::string kernel_name =
+        local_is_output
+            ? "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_height_reader.cpp"
+            : "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_height_writer.cpp";
+
+    KernelDescriptor reader_desc;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.kernel_source = kernel_name;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.config = ReaderConfigDescriptor{};
+    reader_desc.compile_time_args = {cb_index, static_cast<uint32_t>(interface_with_dram)};
+
+    KernelDescriptor writer_desc;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.kernel_source = kernel_name;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.config = WriterConfigDescriptor{};
+    writer_desc.compile_time_args = {cb_index, static_cast<uint32_t>(interface_with_dram)};
+
+    auto remote_buffer_type = remote_buffer->buffer_type();
+
+    // Generate all read/write offsets for each core
+    auto [runtime_args_for_each_core, total_num_sticks, local_stride_bytes, remote_stride_bytes] =
+        ttnn::operations::data_movement::detail::compute_width_sharding_reshard_segments(
+            local_shard_spec.shape,
+            remote_shard_spec.shape,
+            local_cores,
+            remote_cores,
+            remote_buffer_type,
+            remote_core_type,
+            device,
+            element_size);  // local_core_idx -> runtime args[]
+
+    // Split work across each kernel along tensor height since this is the best way to split work evenly
+    const uint32_t total_num_sticks_kernel_0 = total_num_sticks / 2;
+    const uint32_t total_num_sticks_kernel_1 = total_num_sticks - total_num_sticks_kernel_0;
+
+    // Here all we do is convert pre-computed offsets into vectors so they can be passed as runtime arguments
+    for (uint32_t core_idx = 0; core_idx < local_cores.size(); core_idx++) {
+        const auto& args_for_all_segments = runtime_args_for_each_core[core_idx];
+
+        // arg 3 is remote-buffer base address (binding via Buffer*).
+        KernelDescriptor::RTArgList runtime_args_0;
+        runtime_args_0.push_back(total_num_sticks_kernel_0);
+        runtime_args_0.push_back(local_stride_bytes);
+        runtime_args_0.push_back(remote_stride_bytes);
+        runtime_args_0.push_back(remote_buffer);
+        runtime_args_0.push_back(static_cast<uint32_t>(args_for_all_segments.size()));
+
+        KernelDescriptor::RTArgList runtime_args_1;
+        runtime_args_1.push_back(total_num_sticks_kernel_1);
+        runtime_args_1.push_back(local_stride_bytes);
+        runtime_args_1.push_back(remote_stride_bytes);
+        runtime_args_1.push_back(remote_buffer);
+        runtime_args_1.push_back(static_cast<uint32_t>(args_for_all_segments.size()));
+
+        for (const auto& args : args_for_all_segments) {
+            runtime_args_0.push_back(args.write_size);
+            runtime_args_0.push_back(args.read_offset);
+            runtime_args_0.push_back(args.bank_id);
+            runtime_args_0.push_back(args.write_offset);
+
+            // Adjust read and write offsets to the correct stick address because we are splitting work across 2 kernels
+            const uint32_t adjusted_read_offset = args.read_offset + (total_num_sticks_kernel_0 * local_stride_bytes);
+            const uint32_t adjusted_write_offset =
+                args.write_offset + (total_num_sticks_kernel_0 * remote_stride_bytes);
+
+            runtime_args_1.push_back(args.write_size);
+            runtime_args_1.push_back(adjusted_read_offset);
+            runtime_args_1.push_back(args.bank_id);
+            runtime_args_1.push_back(adjusted_write_offset);
+        }
+        reader_desc.emplace_runtime_args(local_cores[core_idx], runtime_args_0);
+        writer_desc.emplace_runtime_args(local_cores[core_idx], runtime_args_1);
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
+}
+
+// Explicit template instantiations
+template struct ReshardSameHeightFactory<true>;
+template struct ReshardSameHeightFactory<false>;
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_same_height.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_same_height.hpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/program_descriptors.hpp>
+
+#include "ttnn/operations/experimental/quasar/reshard/device/reshard_device_operation_types.hpp"
+#include "ttnn/device_operation.hpp"
+
+namespace ttnn::prim::qsr {
+
+// WIDTH_SHARDED -> WIDTH_SHARDED reshard
+template <bool local_is_output>
+struct ReshardSameHeightFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const ReshardParams& operation_attributes, const ReshardInputs& tensor_args, Tensor& output_tensor);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_same_width.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_same_width.cpp
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_same_width.hpp"
+
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/tt_align.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/tensor/tensor_utils.hpp"
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+
+namespace {
+
+// Anonymous-namespace helper unique to reshard same-width to avoid unity-build collisions.
+void push_reshard_same_width_cb_pair(
+    ProgramDescriptor& desc,
+    uint32_t cb_index,
+    tt::DataFormat data_format,
+    uint32_t total_size,
+    uint32_t page_size,
+    const CoreRangeSet& core_ranges,
+    Buffer* bound_buffer) {
+    CBDescriptor cb;
+    cb.total_size = total_size;
+    cb.core_ranges = core_ranges;
+    cb.format_descriptors.push_back(CBFormatDescriptor{
+        .buffer_index = static_cast<uint8_t>(cb_index),
+        .data_format = data_format,
+        .page_size = page_size,
+    });
+    cb.buffer = bound_buffer;
+    desc.cbs.push_back(std::move(cb));
+}
+
+}  // namespace
+
+template <bool local_is_output>
+ProgramDescriptor ReshardSameWidthFactory<local_is_output>::create_descriptor(
+    const ReshardParams& /*operation_attributes*/, const ReshardInputs& tensor_args, Tensor& output_tensor) {
+    const auto& input = tensor_args.input;
+    const auto& output = output_tensor;
+    const auto& local_tensor = local_is_output ? output : input;
+    const auto& remote_tensor = local_is_output ? input : output;
+
+    auto* device = input.device();
+
+    const auto local_shard_spec = local_tensor.shard_spec().value();
+    const auto remote_shard_spec = remote_tensor.shard_spec().value();
+
+    auto remote_core_type = remote_tensor.buffer()->core_type();
+    constexpr uint32_t cb_index = tt::CBIndex::c_0;
+    constexpr uint32_t cb_scratch_index = tt::CBIndex::c_1;
+    auto local_cores = get_optimal_worker_cores_for_sharded_tensor(local_tensor);
+    auto all_cores = CoreRangeSet(ttsl::Span<const CoreCoord>(local_cores));
+    auto remote_cores = remote_tensor.buffer()->buffer_distribution_spec().value().cores_with_data();
+
+    uint32_t unit_size = 0;
+    uint32_t local_units_per_shard = 0;
+    uint32_t remote_units_per_shard = 0;
+    auto data_format = tt::tt_metal::datatype_to_dataformat_converter(local_tensor.dtype());
+
+    uint32_t num_units = local_tensor.buffer()->num_pages();
+    if (local_tensor.layout() == Layout::TILE) {
+        unit_size = tt::tile_size(data_format);
+        local_units_per_shard = local_shard_spec.numel() / TILE_HW;
+        remote_units_per_shard = remote_shard_spec.numel() / TILE_HW;
+    } else {
+        unit_size = static_cast<uint32_t>(local_shard_spec.shape[1] * local_tensor.element_size());
+        local_units_per_shard = local_shard_spec.shape[0];
+        remote_units_per_shard = remote_shard_spec.shape[0];
+    }
+    uint32_t local_unit_size_padded = tt::align(unit_size, local_tensor.buffer()->alignment());
+    uint32_t remote_unit_size_padded = tt::align(unit_size, remote_tensor.buffer()->alignment());
+    bool unaligned = false;
+    if (remote_unit_size_padded != unit_size || local_unit_size_padded != unit_size) {
+        unaligned = true;
+    }
+    const uint32_t total_size = local_units_per_shard * unit_size;
+    const std::string kernel_name =
+        local_is_output
+            ? "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_width_reader.cpp"
+            : "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_width_writer.cpp";
+
+    bool interface_with_dram = (remote_core_type == tt::CoreType::DRAM);
+    auto* local_buffer = local_tensor.buffer();
+    auto* remote_buffer = remote_tensor.buffer();
+    auto remote_buffer_type = remote_buffer->buffer_type();
+
+    ProgramDescriptor desc;
+
+    // Local sharded CB. Bind to local buffer for dynamic-CB rebinding on cache hits via cb.buffer.
+    push_reshard_same_width_cb_pair(
+        desc, cb_index, data_format, total_size, unit_size, all_cores, /*bound_buffer=*/local_buffer);
+
+    if (unaligned) {
+        // Scratch CB used by kernels when local/remote alignments differ.
+        push_reshard_same_width_cb_pair(
+            desc,
+            cb_scratch_index,
+            data_format,
+            remote_units_per_shard * remote_unit_size_padded,
+            unit_size,
+            all_cores,
+            /*bound_buffer=*/nullptr);
+    }
+
+    // Reader/writer kernels share the same source and compile-time args.
+    std::vector<uint32_t> compile_args = {
+        cb_index,
+        static_cast<uint32_t>(interface_with_dram),
+        static_cast<uint32_t>(unaligned),
+        unit_size,
+        local_unit_size_padded,
+        remote_unit_size_padded,
+        cb_scratch_index};
+
+    KernelDescriptor reader_desc;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.kernel_source = kernel_name;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.config = ReaderConfigDescriptor{};
+    reader_desc.compile_time_args = compile_args;
+
+    KernelDescriptor writer_desc;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.kernel_source = kernel_name;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.config = WriterConfigDescriptor{};
+    writer_desc.compile_time_args = std::move(compile_args);
+
+    uint32_t remote_core_idx = 0;
+    uint32_t remote_core_units_rem = remote_units_per_shard;
+    auto bank_id =
+        device->allocator()->get_bank_ids_from_logical_core(remote_buffer_type, remote_cores[remote_core_idx])[0];
+
+    std::array<KernelDescriptor*, 2> kernels = {&reader_desc, &writer_desc};
+    uint32_t local_units_left = num_units;
+    for (const auto& core : local_cores) {
+        uint32_t local_units_per_core = std::min(local_units_left, local_units_per_shard);
+        local_units_left -= local_units_per_core;
+        uint32_t local_units_per_kernel = tt::div_up(local_units_per_core, static_cast<uint32_t>(kernels.size()));
+        uint32_t local_start_offset = 0;
+        for (auto* kernel : kernels) {
+            // arg 0 is remote-buffer base address (binding via Buffer*).
+            // RTArgList doesn't expose operator[] for back-patching, so we build
+            // a std::vector<variant> here and pass via the vector overload of
+            // emplace_runtime_args.
+            std::vector<std::variant<uint32_t, Buffer*>> kernel_args;
+            kernel_args.emplace_back(remote_buffer);
+            kernel_args.emplace_back(uint32_t{0});
+            kernel_args.emplace_back(uint32_t{0});
+            uint32_t local_units_to_transfer = std::min(local_units_per_core, local_units_per_kernel);
+            if (local_units_to_transfer != 0) {
+                uint32_t num_transfers = 0;
+                kernel_args[1] = local_start_offset;
+                local_start_offset += local_units_to_transfer * unit_size;
+                while (local_units_to_transfer > 0) {
+                    if (remote_core_units_rem == 0) {
+                        remote_core_idx++;
+                        remote_core_units_rem = remote_units_per_shard;
+                        bank_id = device->allocator()->get_bank_ids_from_logical_core(
+                            remote_buffer_type, remote_cores[remote_core_idx])[0];
+                    }
+                    uint32_t units_to_transfer = std::min(remote_core_units_rem, local_units_to_transfer);
+                    bank_id = device->allocator()->get_bank_ids_from_logical_core(
+                        remote_buffer_type, remote_cores[remote_core_idx])[0];
+                    kernel_args.emplace_back(bank_id);
+                    kernel_args.emplace_back(
+                        (remote_units_per_shard - remote_core_units_rem) * remote_unit_size_padded);
+                    kernel_args.emplace_back(units_to_transfer);
+                    local_units_per_core -= units_to_transfer;
+                    local_units_to_transfer -= units_to_transfer;
+                    remote_core_units_rem -= units_to_transfer;
+                    num_transfers++;
+                }
+                kernel_args[2] = num_transfers;
+            }
+            kernel->emplace_runtime_args(core, kernel_args);
+        }
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
+}
+
+// Explicit template instantiations
+template struct ReshardSameWidthFactory<true>;
+template struct ReshardSameWidthFactory<false>;
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_same_width.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_same_width.hpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/program_descriptors.hpp>
+
+#include "ttnn/operations/experimental/quasar/reshard/device/reshard_device_operation_types.hpp"
+#include "ttnn/device_operation.hpp"
+
+namespace ttnn::prim::qsr {
+
+// HEIGHT_SHARDED -> HEIGHT_SHARDED reshard
+template <bool local_is_output>
+struct ReshardSameWidthFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const ReshardParams& operation_attributes, const ReshardInputs& tensor_args, Tensor& output_tensor);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/reshard.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/reshard.cpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operation.hpp"
+#include "device/reshard_device_operation.hpp"
+#include "reshard.hpp"
+
+using namespace tt::tt_metal;
+
+namespace ttnn::operations::experimental::quasar {
+
+ttnn::Tensor reshard(
+    const ttnn::Tensor& input_tensor,
+    const MemoryConfig& memory_config,
+    const std::optional<Tensor>& optional_output_tensor) {
+    return ttnn::prim::qsr::reshard(input_tensor, memory_config, optional_output_tensor);
+}
+
+}  // namespace ttnn::operations::experimental::quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/reshard.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/reshard.hpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/core_coord.hpp>
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::experimental::quasar {
+
+ttnn::Tensor reshard(
+    const ttnn::Tensor& input_tensor,
+    const MemoryConfig& memory_config,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+
+}  // namespace ttnn::operations::experimental::quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/reshard_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/reshard_nanobind.cpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "reshard_nanobind.hpp"
+
+#include <optional>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
+
+#include "ttnn-nanobind/bind_function.hpp"
+#include "reshard.hpp"
+#include "ttnn/types.hpp"
+namespace ttnn::operations::experimental::quasar::detail {
+
+// TODO: Add more descriptions to the arguments
+void bind_reshard(nb::module_& mod) {
+    const auto* doc =
+        R"doc(
+        Converts a tensor from one sharded layout to another sharded layout
+
+        Args:
+            * :attr:`input_tensor` (ttnn.Tensor): input tensor
+            * :attr:`output_memory_config` (MemoryConfig): Memory config with shard spec of output tensor
+
+        Example:
+            >>> sharded_memory_config_dict = dict(
+                core_grid=ttnn.CoreRangeSet(
+                    {
+                        ttnn.CoreRange(
+                            ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1)
+                        ),
+                    }
+                ),
+                strategy=ttnn.ShardStrategy.BLOCK,
+            ),
+            >>> shard_memory_config = ttnn.create_sharded_memory_config(input_shape, **input_sharded_memory_config_args)
+            >>> sharded_tensor = ttnn.reshard(tensor, shard_memory_config)
+
+        )doc";
+
+    ttnn::bind_function<"reshard">(
+        mod,
+        doc,
+        &ttnn::operations::experimental::quasar::reshard,
+        nb::arg("input_tensor").noconvert(),
+        nb::arg("output_memory_config"),
+        nb::arg("output_tensor").noconvert() = nb::none());
+}
+
+}  // namespace ttnn::operations::experimental::quasar::detail

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/reshard_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/reshard_nanobind.hpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::experimental::quasar::detail {
+
+namespace nb = nanobind;
+void bind_reshard(nb::module_& mod);
+
+}  // namespace ttnn::operations::experimental::quasar::detail

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/reader_multicore_slice_4d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/reader_multicore_slice_4d.cpp
@@ -1,0 +1,198 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * TTNN Slice Operation - Multi-Core Reader Kernel (4D Support)
+ *
+ * This kernel handles the input data reading phase of the slice operation for multi-core
+ * execution, implementing slice logic for 1D, 2D, 3D, and 4D tensors with work distribution
+ * across multiple cores for improved performance.
+ *
+ * Key Responsibilities:
+ * - Read assigned portion of input tensor data from DRAM using TensorAccessor
+ * - Apply slice logic (start, end, step) for all dimensions (N, D, H, W)
+ * - Handle different data types with proper element size calculations
+ * - Process assigned rows for this core based on work distribution
+ * - Output sliced rows to circular buffer for writer kernel consumption
+ *
+ * Architecture:
+ * - Uses TensorAccessor for efficient DRAM address generation
+ * - Processes data row-by-row for optimal memory access patterns
+ * - Supports slicing with configurable start, end, and step parameters for all dimensions
+ * - Handles 1D (W), 2D (H,W), 3D (D,H,W), and 4D (N,D,H,W) tensors
+ * - Multi-core work distribution: each core processes a subset of output rows
+ *
+ * Memory Management:
+ * - DRAM alignment: 32-byte boundaries for memory controller optimization
+ * - L1 alignment: 16-byte boundaries for L1 cache efficiency
+ * - Circular buffer: Double buffering for continuous data flow
+ *
+ * Data Type Support:
+ * - Element size determined at compile time for performance
+ * - Dynamic element size passed as runtime argument for flexibility
+ *
+ * Performance Optimizations:
+ * - Minimal branching in inner loops for consistent execution
+ * - Efficient memory copy operations using NOC async transfers
+ * - Cache-friendly access patterns aligned to memory hierarchy
+ * - Parallel processing with load balancing across multiple cores
+ *
+ * Compatible with: TTNN framework, ROW_MAJOR_LAYOUT tensors, 1D-4D dimensions, multi-core execution
+ */
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    // Runtime arguments for 4D slice support with multi-core work distribution
+    uint32_t rt_args_idx = 0;
+    uint32_t src_addr = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t tensor_rank = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t input_w = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t input_h = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t input_d = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t input_n = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t output_w = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t output_h = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t output_d = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t output_n = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t slice_start_w = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t slice_end_w = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t slice_step_w = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t slice_start_h = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t slice_end_h = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t slice_step_h = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t slice_start_d = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t slice_end_d = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t slice_step_d = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t slice_start_n = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t slice_end_n = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t slice_step_n = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t element_size = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t num_rows_for_this_core = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t start_row_for_this_core = get_arg_val<uint32_t>(rt_args_idx++);
+
+    // Compile-time arguments
+    constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
+    constexpr uint32_t compile_time_element_size = get_compile_time_arg_val(1);
+    constexpr auto src_args = TensorAccessorArgs<2>();
+
+    // Calculate sizes - working with rows, not tiles
+    uint32_t input_bytes_per_row = input_w * element_size;  // Dynamic element size
+    uint32_t output_bytes_per_row = output_w * element_size;
+
+    // Set up TensorAccessor for input data - use row size as page size
+    const auto s0 = TensorAccessor(src_args, src_addr);
+
+    Noc noc;
+    // Create CircularBuffer for Device 2.0 API
+    CircularBuffer cb_out(cb_id_out);
+
+    // Multi-core work distribution: this core processes rows [start_row_for_this_core, start_row_for_this_core +
+    // num_rows_for_this_core) We need to map these logical output row indices back to the corresponding (n,d,h)
+    // coordinates
+
+    uint32_t rows_processed = 0;
+    uint32_t current_logical_row = 0;
+    bool found_start = false;
+
+    // Set loop bounds based on tensor rank
+    uint32_t n_start = (tensor_rank >= 4) ? slice_start_n : 0;
+    uint32_t n_end = (tensor_rank >= 4) ? slice_end_n : 1;
+    uint32_t n_step = (tensor_rank >= 4) ? slice_step_n : 1;
+
+    uint32_t d_start = (tensor_rank >= 3) ? slice_start_d : 0;
+    uint32_t d_end = (tensor_rank >= 3) ? slice_end_d : 1;
+    uint32_t d_step = (tensor_rank >= 3) ? slice_step_d : 1;
+
+    uint32_t h_start = (tensor_rank >= 2) ? slice_start_h : 0;
+    uint32_t h_end = (tensor_rank >= 2) ? slice_end_h : 1;
+    uint32_t h_step = (tensor_rank >= 2) ? slice_step_h : 1;
+
+    // Multi-dimensional slicing with nested loops
+    // 4D: Batch dimension loop
+    for (uint32_t n = n_start; n < n_end && rows_processed < num_rows_for_this_core; n += n_step) {
+        // 3D: Depth dimension loop
+        for (uint32_t d = d_start; d < d_end && rows_processed < num_rows_for_this_core; d += d_step) {
+            // 2D: Height dimension loop
+            for (uint32_t h = h_start; h < h_end && rows_processed < num_rows_for_this_core; h += h_step) {
+                // Check if this logical row should be processed by this core
+                if (!found_start) {
+                    if (current_logical_row == start_row_for_this_core) {
+                        found_start = true;
+                    } else {
+                        current_logical_row++;
+                        if (tensor_rank == 1) {
+                            break;  // For 1D, exit after checking once
+                        }
+                        continue;
+                    }
+                }
+
+                if (rows_processed >= num_rows_for_this_core) {
+                    break;
+                }
+
+                // Calculate input row index based on tensor rank
+                uint32_t input_row_idx;
+                if (tensor_rank == 1) {
+                    input_row_idx = 0;  // Single row for 1D
+                } else if (tensor_rank == 2) {
+                    input_row_idx = h;
+                } else if (tensor_rank == 3) {
+                    input_row_idx = d * input_h + h;
+                } else {  // 4D
+                    input_row_idx = n * input_d * input_h + d * input_h + h;
+                }
+
+                cb_out.reserve_back(1);
+                uint32_t l1_write_addr = cb_out.get_write_ptr();
+
+                // noc_async_read_sharded splits the read across shards for B/W-sharded inputs;
+                // falls through to a single noc_async_read for interleaved / HEIGHT-sharded.
+                tt::data_movement::common::noc_async_read_sharded(
+                    noc, l1_write_addr, s0, input_row_idx, /*offset=*/0, /*size=*/input_bytes_per_row);
+                noc.async_read_barrier();
+
+                // Now slice the row according to width slice parameters
+                // Copy sliced elements to the beginning of the buffer
+                if (slice_start_w != 0 || slice_step_w != 1 || slice_end_w != input_w) {
+                    // Need to reorganize the data in the buffer
+                    volatile tt_l1_ptr uint8_t* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_addr);
+                    volatile tt_l1_ptr uint8_t* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_addr);
+
+                    uint32_t out_col = 0;
+                    for (uint32_t input_col = slice_start_w; input_col < slice_end_w && out_col < output_w;
+                         input_col += slice_step_w) {
+                        // Copy element by element for the slice
+                        for (uint32_t byte_idx = 0; byte_idx < element_size; ++byte_idx) {
+                            dst_ptr[out_col * element_size + byte_idx] = src_ptr[input_col * element_size + byte_idx];
+                        }
+                        out_col++;
+                    }
+                }
+
+                cb_out.push_back(1);
+                rows_processed++;
+                current_logical_row++;
+
+                // Early exit for 1D tensors
+                if (tensor_rank == 1) {
+                    break;
+                }
+            }
+            // Early exit for 2D tensors
+            if (tensor_rank <= 2) {
+                break;
+            }
+        }
+        // Early exit for 3D tensors
+        if (tensor_rank <= 3) {
+            break;
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/reader_multicore_slice_nd.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/reader_multicore_slice_nd.cpp
@@ -1,0 +1,191 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * TTNN Slice Operation - Multi-Core Reader Kernel (N-Dimensional Support)
+ *
+ * This kernel handles the input data reading phase of the slice operation for multi-core
+ * execution, implementing slice logic for N-dimensional tensors (1D, 2D, 3D, 4D, 5D, etc.)
+ * with work distribution across multiple cores for improved performance.
+ *
+ * Key Responsibilities:
+ * - Read assigned portion of input tensor data from DRAM using TensorAccessor
+ * - Apply slice logic (start, end, step) for all dimensions dynamically
+ * - Handle different data types with proper element size calculations
+ * - Process assigned rows for this core based on work distribution
+ * - Output sliced rows to circular buffer for writer kernel consumption
+ *
+ * Architecture:
+ * - Uses TensorAccessor for efficient DRAM address generation
+ * - Processes data row-by-row for optimal memory access patterns
+ * - Supports slicing with configurable start, end, and step parameters for all dimensions
+ * - Handles 1D, 2D, 3D, 4D, 5D+ tensors with dynamic nested loops
+ * - Multi-core work distribution: each core processes a subset of output rows
+ *
+ * Memory Management:
+ * - DRAM alignment: 32-byte boundaries for memory controller optimization
+ * - L1 alignment: 16-byte boundaries for L1 cache efficiency
+ * - Circular buffer: Double buffering for continuous data flow
+ *
+ * Data Type Support:
+ * - Element size determined at compile time for performance
+ * - Dynamic element size passed as runtime argument for flexibility
+ *
+ * Performance Optimizations:
+ * - Minimal branching in inner loops for consistent execution
+ * - Efficient memory copy operations using NOC async transfers
+ * - Cache-friendly access patterns aligned to memory hierarchy
+ * - Parallel processing with load balancing across multiple cores
+ *
+ * N-Dimensional Processing:
+ * - Dynamic nested loops based on tensor rank
+ * - Generic address calculation using stride-based indexing
+ * - Row concept: for rank R, rows = product(dims[0:R-1]), width = dims[R-1]
+ *
+ * Compatible with: TTNN framework, ROW_MAJOR_LAYOUT tensors, 1D-ND dimensions, multi-core execution
+ */
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    // Runtime arguments - first get basic parameters
+    uint32_t rt_args_idx = 0;
+    uint32_t src_addr = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t tensor_rank = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t element_size = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t num_rows_for_this_core = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t start_row_for_this_core = get_arg_val<uint32_t>(rt_args_idx++);
+
+    // Compile-time arguments
+    constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
+    constexpr uint32_t compile_time_element_size = get_compile_time_arg_val(1);
+    constexpr auto src_args = TensorAccessorArgs<2>();
+
+    // Get dimension arrays from runtime arguments
+    // Layout: input_dims[rank], output_dims[rank], slice_starts[rank], slice_ends[rank], slice_steps[rank]
+    // Read input dimensions
+    volatile tt_l1_ptr uint32_t* input_dims = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(rt_args_idx));
+    rt_args_idx += tensor_rank;
+
+    // Read output dimensions
+    volatile tt_l1_ptr uint32_t* output_dims = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(rt_args_idx));
+    rt_args_idx += tensor_rank;
+
+    // Read slice parameters
+    volatile tt_l1_ptr uint32_t* slice_starts = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(rt_args_idx));
+    rt_args_idx += tensor_rank;
+
+    volatile tt_l1_ptr uint32_t* slice_ends = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(rt_args_idx));
+    rt_args_idx += tensor_rank;
+
+    volatile tt_l1_ptr uint32_t* slice_steps = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(rt_args_idx));
+
+    // Calculate sizes - working with rows, not tiles
+    uint32_t input_bytes_per_row = input_dims[tensor_rank - 1] * element_size;
+    uint32_t output_bytes_per_row = output_dims[tensor_rank - 1] * element_size;
+
+    // Set up TensorAccessor for input data - use row size as page size
+    const auto s0 = TensorAccessor(src_args, src_addr);
+
+    Noc noc;
+    // Create CircularBuffer for Device 2.0 API
+    CircularBuffer cb_out(cb_id_out);
+
+    // Multi-core work distribution using iterative approach with explicit coordinate tracking
+    // Track current position in N-dimensional space
+    uint32_t coords[16];  // Support up to 16 dimensions (reasonable limit)
+    for (uint32_t i = 0; i < tensor_rank; ++i) {
+        coords[i] = slice_starts[i];
+    }
+
+    uint32_t rows_processed = 0;
+    uint32_t current_logical_row = 0;
+    bool found_start = false;
+    bool more_iterations = true;
+
+    while (more_iterations && rows_processed < num_rows_for_this_core) {
+        // Check if this logical row should be processed by this core
+        bool should_process_row = false;
+        if (!found_start) {
+            if (current_logical_row == start_row_for_this_core) {
+                found_start = true;
+                should_process_row = true;
+            }
+        } else {
+            should_process_row = true;
+        }
+
+        if (should_process_row && rows_processed < num_rows_for_this_core) {
+            // Calculate input row index from coordinates (exclude last dimension)
+            uint32_t input_row_idx = 0;
+            if (tensor_rank > 1) {
+                for (int32_t dim = 0; dim < (int32_t)(tensor_rank - 1); ++dim) {
+                    uint32_t stride = 1;
+                    for (int32_t d = dim + 1; d < (int32_t)(tensor_rank - 1); ++d) {
+                        stride *= input_dims[d];
+                    }
+                    input_row_idx += coords[dim] * stride;
+                }
+            }
+
+            cb_out.reserve_back(1);
+            uint32_t l1_write_addr = cb_out.get_write_ptr();
+
+            // noc_async_read_sharded splits the read across shards for B/W-sharded inputs;
+            // falls through to a single noc_async_read for interleaved / HEIGHT-sharded.
+            tt::data_movement::common::noc_async_read_sharded(
+                noc, l1_write_addr, s0, input_row_idx, /*offset=*/0, /*size=*/input_bytes_per_row);
+            noc.async_read_barrier();
+
+            // Now slice the row according to width slice parameters (last dimension)
+            uint32_t last_dim = tensor_rank - 1;
+            if (slice_starts[last_dim] != 0 || slice_steps[last_dim] != 1 ||
+                slice_ends[last_dim] != input_dims[last_dim]) {
+                // Need to reorganize the data in the buffer
+                volatile tt_l1_ptr uint8_t* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_addr);
+                volatile tt_l1_ptr uint8_t* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_addr);
+
+                uint32_t out_col = 0;
+                for (uint32_t input_col = slice_starts[last_dim];
+                     input_col < slice_ends[last_dim] && out_col < output_dims[last_dim];
+                     input_col += slice_steps[last_dim]) {
+                    // Copy element by element for the slice
+                    for (uint32_t byte_idx = 0; byte_idx < element_size; ++byte_idx) {
+                        dst_ptr[out_col * element_size + byte_idx] = src_ptr[input_col * element_size + byte_idx];
+                    }
+                    out_col++;
+                }
+            }
+
+            cb_out.push_back(1);
+            rows_processed++;
+        }
+
+        current_logical_row++;
+
+        // Advance to next coordinate combination (skip last dimension)
+        bool carry = true;
+        for (int32_t dim = (int32_t)(tensor_rank - 2); dim >= 0 && carry; --dim) {
+            coords[dim] += slice_steps[dim];
+            if (coords[dim] < slice_ends[dim]) {
+                carry = false;
+            } else {
+                coords[dim] = slice_starts[dim];
+            }
+        }
+        if (carry) {
+            more_iterations = false;
+        }
+
+        // Early exit for 1D tensors
+        if (tensor_rank == 1) {
+            break;
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/reader_unary_unpad_dims_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/reader_unary_unpad_dims_interleaved_start_id.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    constexpr uint32_t cb_id_in0 = get_named_compile_time_arg_val("cb_in");
+    constexpr uint32_t num_dims = get_compile_time_arg_val(0);
+    constexpr auto src_args = TensorAccessorArgs<1>();
+    const uint32_t src_addr = get_common_arg_val<uint32_t>(0);
+
+    volatile tt_l1_ptr uint32_t* num_unpadded_tiles = (volatile tt_l1_ptr uint32_t*)(get_common_arg_addr(1));
+    volatile tt_l1_ptr uint32_t* num_padded_tiles = num_unpadded_tiles + num_dims;
+
+    const uint32_t start_id = get_arg_val<uint32_t>(0);
+    const uint32_t num_tiles = get_arg_val<uint32_t>(1);
+
+    tt_l1_ptr uint32_t* id_per_dim = (tt_l1_ptr uint32_t*)(get_arg_addr(2));
+
+    // In and out are assumed to be same dataformat
+    const auto s0 = TensorAccessor(src_args, src_addr);
+
+    // Create objects for Device 2.0 API
+    CircularBuffer cb_in0(cb_id_in0);
+    Noc noc;
+
+    // Get tile size from CB interface
+    const uint32_t tile_size = cb_in0.get_tile_size();
+
+    uint32_t src_tile_id = start_id;
+
+    for (uint32_t i = 0; i < num_tiles; ++i) {
+        // Copy Input
+        cb_in0.reserve_back(1);
+        noc.async_read(s0, cb_in0, tile_size, {.page_id = src_tile_id}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        cb_in0.push_back(1);
+        src_tile_id++;
+        for (uint32_t j = 0; j < num_dims; ++j) {
+            id_per_dim[j]++;
+            if (id_per_dim[j] == num_unpadded_tiles[j]) {
+                id_per_dim[j] = 0;
+                src_tile_id += num_padded_tiles[j];
+            } else {
+                break;
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_id_tensor = get_compile_time_arg_val(1);
+    constexpr uint32_t num_dims = get_compile_time_arg_val(2);
+    const uint32_t tile_width = get_compile_time_arg_val(3);
+    const uint32_t tile_height = get_compile_time_arg_val(4);
+    constexpr auto src_args = TensorAccessorArgs<5>();
+    constexpr auto start_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
+    constexpr auto end_args = TensorAccessorArgs<start_args.next_compile_time_args_offset()>();
+
+    const uint32_t src_addr = get_common_arg_val<uint32_t>(0);
+    const uint32_t start_addr = get_common_arg_val<uint32_t>(1);
+    const uint32_t end_addr = get_common_arg_val<uint32_t>(2);
+
+    volatile tt_l1_ptr uint32_t* num_unpadded_tiles = (volatile tt_l1_ptr uint32_t*)(get_common_arg_addr(3));
+    volatile tt_l1_ptr uint32_t* num_padded_tiles = num_unpadded_tiles + num_dims;
+
+    const uint32_t start_id = get_arg_val<uint32_t>(0);
+    const uint32_t num_tiles = get_arg_val<uint32_t>(1);
+
+    tt_l1_ptr uint32_t* id_per_dim = (tt_l1_ptr uint32_t*)(get_arg_addr(2));
+
+    const auto s0 = TensorAccessor(src_args, src_addr);
+
+    // Create objects for Device 2.0 API
+    CircularBuffer cb_in0(cb_id_in0);
+    CircularBuffer cb_tensor(cb_id_tensor);
+    Noc noc;
+
+    // Get tile size from CB interface
+    const uint32_t tile_size = cb_in0.get_tile_size();
+
+    // Create TensorAccessors for start and end tensors
+    const auto start_tensor_accessor = TensorAccessor(start_args, start_addr);
+    const auto end_tensor_accessor = TensorAccessor(end_args, end_addr);
+
+    // Read start and end indices from tensors using TensorAccessor
+    uint32_t start_indices[num_dims];
+    uint32_t end_indices[num_dims];
+
+    // Read start tensor data using separate circular buffer
+    cb_tensor.reserve_back(1);
+    uint32_t start_buffer_l1_addr = cb_tensor.get_write_ptr();
+    noc.async_read(start_tensor_accessor, cb_tensor, tile_size, {.page_id = 0}, {.offset_bytes = 0});
+    noc.async_read_barrier();
+
+    volatile tt_l1_ptr uint32_t* start_data = (volatile tt_l1_ptr uint32_t*)start_buffer_l1_addr;
+
+    for (uint32_t i = 0; i < num_dims; i++) {
+        start_indices[i] = start_data[i];
+    }
+    cb_tensor.pop_front(1);
+
+    // Read end tensor data using separate circular buffer
+    cb_tensor.reserve_back(1);
+    uint32_t end_buffer_l1_addr = cb_tensor.get_write_ptr();
+    noc.async_read(end_tensor_accessor, cb_tensor, tile_size, {.page_id = 0}, {.offset_bytes = 0});
+    noc.async_read_barrier();
+
+    volatile tt_l1_ptr uint32_t* end_data = (volatile tt_l1_ptr uint32_t*)end_buffer_l1_addr;
+
+    for (uint32_t i = 0; i < num_dims; i++) {
+        end_indices[i] = end_data[i];
+    }
+    cb_tensor.pop_front(1);
+
+    uint32_t start_offset = 0;
+
+    if (num_dims >= 2) {
+        uint32_t start_h_tiles = start_indices[num_dims - 2] / tile_height;
+        uint32_t start_w_tiles = start_indices[num_dims - 1] / tile_width;
+
+        volatile tt_l1_ptr uint32_t* input_shape_args =
+            (volatile tt_l1_ptr uint32_t*)(get_common_arg_addr(3 + 2 * num_dims));
+        uint32_t input_width = input_shape_args[num_dims - 1];
+        uint32_t input_height = input_shape_args[num_dims - 2];
+        uint32_t num_pages_width = input_width / tile_width;
+
+        start_offset += start_h_tiles * num_pages_width + start_w_tiles;
+
+        if (num_dims > 2) {
+            uint32_t upper_dims_offset = 0;
+            uint32_t multiplier = (input_height / tile_height) * num_pages_width;
+
+            for (int32_t i = num_dims - 3; i >= 0; i--) {
+                upper_dims_offset = upper_dims_offset * input_shape_args[i] + start_indices[i];
+            }
+            start_offset += upper_dims_offset * multiplier;
+        }
+    }
+
+    // Add the calculated offset to the base start_id
+    uint32_t src_tile_id = start_id + start_offset;
+
+    for (uint32_t i = 0; i < num_tiles; ++i) {
+        uint32_t old_src_tile_id = src_tile_id;
+
+        cb_in0.reserve_back(1);
+        noc.async_read(s0, cb_in0, tile_size, {.page_id = src_tile_id}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        cb_in0.push_back(1);
+
+        src_tile_id++;
+        for (uint32_t j = 0; j < num_dims; ++j) {
+            id_per_dim[j]++;
+            if (id_per_dim[j] == num_unpadded_tiles[j]) {
+                id_per_dim[j] = 0;
+                src_tile_id += num_padded_tiles[j];
+
+            } else {
+                break;
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t padded_stick_size = get_arg_val<uint32_t>(1);
+    const uint32_t unpadded_stick_size = get_arg_val<uint32_t>(2);
+    const uint32_t stick_size_offset = get_arg_val<uint32_t>(3);
+    const uint32_t num_dims = get_arg_val<uint32_t>(4);
+    const uint32_t misalignment = get_arg_val<uint32_t>(5);
+    const uint32_t start_id = get_arg_val<uint32_t>(6);
+    const uint32_t num_sticks_per_core = get_arg_val<uint32_t>(7);
+    const uint32_t num_sticks_per_core_read = get_arg_val<uint32_t>(8);
+    const uint32_t num_read_per_barrier = get_arg_val<uint32_t>(9);
+
+    tt_l1_ptr uint32_t* num_unpadded_sticks = (tt_l1_ptr uint32_t*)(get_arg_addr(10));
+    volatile tt_l1_ptr uint32_t* num_padded_sticks = num_unpadded_sticks + num_dims;
+    volatile tt_l1_ptr uint32_t* id_per_dim = num_padded_sticks + num_dims;
+
+    constexpr auto src_args = TensorAccessorArgs<0>();
+    uint32_t read_size = unpadded_stick_size + misalignment;
+
+    // padded_stick_size = per-shard page size (shard_W on B/W-sharded, full row otherwise);
+    // feeds `noc_async_read_sharded`'s multi-shard split via `get_aligned_page_size()`.
+    const auto s0 = TensorAccessor(src_args, src_addr, padded_stick_size);
+
+    constexpr uint32_t cb_id_in0 = 0;
+
+    Noc noc;
+    // Create CircularBuffer for Device 2.0 API
+    CircularBuffer cb_in0(cb_id_in0);
+
+    uint32_t src_stick_id = start_id;
+    uint32_t sticks_read = 0;
+    for (uint32_t iter = 0; iter < num_sticks_per_core_read and sticks_read < num_sticks_per_core; ++iter) {
+        cb_in0.reserve_back(num_read_per_barrier);
+        uint32_t src_buffer_l1_addr = cb_in0.get_write_ptr();
+
+        for (uint32_t i = 0; i < num_read_per_barrier and sticks_read < num_sticks_per_core; ++i) {
+            sticks_read++;
+            // noc_async_read_sharded splits the read across shards for B/W-sharded inputs;
+            // falls through to a single noc_async_read for interleaved / HEIGHT-sharded.
+            tt::data_movement::common::noc_async_read_sharded(
+                noc, src_buffer_l1_addr, s0, src_stick_id, /*offset=*/0, /*size=*/read_size);
+            if (misalignment != 0) {
+                noc.async_read_barrier();
+                tt::data_movement::common::tt_memmove<false, false, false, 0>(
+                    noc, src_buffer_l1_addr, src_buffer_l1_addr + misalignment, unpadded_stick_size);
+            }
+            src_buffer_l1_addr += stick_size_offset;
+            src_stick_id++;
+            for (uint32_t j = 0; j < num_dims; j++) {
+                id_per_dim[j]++;
+                if (id_per_dim[j] == num_unpadded_sticks[j]) {
+                    id_per_dim[j] = 0;
+                    src_stick_id += num_padded_sticks[j];
+                } else {
+                    break;
+                }
+            }
+        }
+        noc.async_read_barrier();
+        cb_in0.push_back(num_read_per_barrier);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_sharded.cpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    constexpr uint32_t stick_size_padded = get_compile_time_arg_val(0);
+    constexpr uint32_t stick_size_unpadded = get_compile_time_arg_val(1);
+    constexpr uint32_t num_sticks_unpadded = get_compile_time_arg_val(2);
+
+    const uint32_t num_cores_read = get_arg_val<uint32_t>(0);
+    tt_l1_ptr uint32_t* read_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(1));
+    tt_l1_ptr uint32_t* read_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(2));
+    tt_l1_ptr uint32_t* num_stick_chunks = (tt_l1_ptr uint32_t*)(get_arg_addr(1 + num_cores_read * 2));
+    tt_l1_ptr uint32_t* chunk_start_id = (tt_l1_ptr uint32_t*)(get_arg_addr(1 + num_cores_read * 3));
+    tt_l1_ptr uint32_t* chunk_num_sticks = (tt_l1_ptr uint32_t*)(chunk_start_id + 1);
+
+    constexpr auto cb_in0 = tt::CBIndex::c_0;
+    constexpr auto cb_out0 = tt::CBIndex::c_16;
+
+    Noc noc;
+    // Create CircularBuffers for Device 2.0 API
+    CircularBuffer cb_in(cb_in0);
+    CircularBuffer cb_out(cb_out0);
+
+    cb_out.reserve_back(num_sticks_unpadded);
+    uint32_t l1_read_addr = cb_in.get_write_ptr();
+    uint32_t l1_write_addr = cb_out.get_write_ptr();
+
+    uint32_t chunk_ptr_offset = 0;
+    uint32_t read_noc_xy_ptr_offset = 0;
+
+    for (uint32_t curr_core = 0; curr_core < num_cores_read; ++curr_core) {
+        const uint32_t src_noc_x = read_noc_x[read_noc_xy_ptr_offset];
+        const uint32_t src_noc_y = read_noc_y[read_noc_xy_ptr_offset];
+
+        uint32_t curr_core_num_chunks = num_stick_chunks[curr_core];
+
+        for (uint32_t curr_chunk = 0; curr_chunk < curr_core_num_chunks; ++curr_chunk) {
+            uint32_t curr_start_id = chunk_start_id[chunk_ptr_offset];
+            uint32_t curr_num_sticks = chunk_num_sticks[chunk_ptr_offset];
+
+            uint32_t l1_read_offset = curr_start_id * stick_size_unpadded;
+            uint32_t read_data_size_bytes = curr_num_sticks * stick_size_unpadded;
+
+            CoreLocalMem<uint32_t> dst(l1_write_addr);
+            noc.async_read(
+                UnicastEndpoint{},
+                dst,
+                read_data_size_bytes,
+                {.noc_x = src_noc_x, .noc_y = src_noc_y, .addr = l1_read_addr + l1_read_offset},
+                {.offset_bytes = 0});
+            l1_write_addr += read_data_size_bytes;
+            chunk_ptr_offset += 2;
+        }
+
+        read_noc_xy_ptr_offset += 2;
+    }
+
+    noc.async_read_barrier();
+    cb_out.push_back(num_sticks_unpadded);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/slice_writer_unary_stick_layout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/slice_writer_unary_stick_layout_interleaved_start_id.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    uint32_t stick_size = get_arg_val<uint32_t>(1);
+    uint32_t stick_size_offset = get_arg_val<uint32_t>(2);
+    uint32_t num_sticks_per_core = get_arg_val<uint32_t>(3);
+    uint32_t num_sticks_per_core_read = get_arg_val<uint32_t>(4);
+    uint32_t num_read_per_barrier = get_arg_val<uint32_t>(5);
+    uint32_t start_id = get_arg_val<uint32_t>(6);
+    // Per-shard page size: shard_W on B/W-sharded outputs, full row otherwise.
+    // Feeds `noc_async_write_sharded`'s multi-shard split via `get_aligned_page_size()`.
+    uint32_t page_size_override = get_arg_val<uint32_t>(7);
+
+    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
+    constexpr auto dst_args = TensorAccessorArgs<1>();
+
+    const auto s0 = TensorAccessor(dst_args, dst_addr, page_size_override);
+
+    Noc noc;
+    // Create CircularBuffer for Device 2.0 API
+    CircularBuffer cb_out0(cb_id_out0);
+
+    uint32_t i_stick = start_id;
+    uint32_t sticks_read = 0;
+    for (uint32_t iter = 0; iter < num_sticks_per_core_read and sticks_read < num_sticks_per_core; ++iter) {
+        cb_out0.wait_front(num_read_per_barrier);
+        uint32_t l1_read_addr = cb_out0.get_read_ptr();
+
+        for (uint32_t i = 0; i < num_read_per_barrier and sticks_read < num_sticks_per_core; ++i) {
+            sticks_read++;
+            // noc_async_write_sharded splits the write across shards for B/W-sharded outputs;
+            // falls through to a single noc_async_write for interleaved / HEIGHT-sharded.
+            tt::data_movement::common::noc_async_write_sharded(
+                noc, l1_read_addr, s0, i_stick, /*offset=*/0, /*size=*/stick_size);
+            l1_read_addr += stick_size_offset;
+            i_stick += 1;
+        }
+        noc.async_write_barrier();
+        cb_out0.pop_front(num_read_per_barrier);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/strided_slice_reader_rm_interleaved_nd.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/strided_slice_reader_rm_interleaved_nd.cpp
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    constexpr uint32_t dims = get_compile_time_arg_val(1);
+    constexpr uint32_t element_size = get_compile_time_arg_val(2);
+    constexpr auto src_args = TensorAccessorArgs<3>();
+
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+
+    // Initialize shape, starts, ends, strides
+    uint32_t shape[dims], starts[dims], ends[dims], strides[dims];
+    for (uint32_t i = 1; i <= dims; i++) {
+        shape[i - 1] = get_arg_val<uint32_t>(i);
+        starts[i - 1] = get_arg_val<uint32_t>(i + dims);
+        ends[i - 1] = get_arg_val<uint32_t>(i + 2 * dims);
+        strides[i - 1] = get_arg_val<uint32_t>(i + 3 * dims);
+    }
+
+    // Calculate the product array, excluding the last dimension
+    uint32_t prod[dims];
+    for (uint32_t i = 0; i < dims - 1; i++) {
+        prod[i] = 1;
+        for (uint32_t j = i + 1; j < dims - 1; j++) {  // Exclude the last dimension
+            prod[i] *= shape[j];
+        }
+    }
+    prod[dims - 1] = 1;  // Not used, but set to 1 for completeness
+
+    const auto s0 = TensorAccessor(src_args, src_addr);
+
+    constexpr uint32_t cb_id_in0 = 0;
+    constexpr uint32_t cb_id_out0 = 24;
+
+    Noc noc;
+    // Create CircularBuffers for Device 2.0 API
+    CircularBuffer cb_in0(cb_id_in0);
+    CircularBuffer cb_out0(cb_id_out0);
+
+    uint32_t src_buffer_l1_addr = cb_in0.get_write_ptr();
+    volatile tt_l1_ptr uint8_t* in_stick = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(src_buffer_l1_addr);
+
+    uint32_t index[dims];  // To hold current index in each of the first dims-1 dimensions
+    index[dims - 1] = 0;   // Initialize the last index to 0
+    for (uint32_t i = 0; i < dims - 1; i++) {
+        index[i] = starts[i];  // Initialize the index with the start values
+    }
+
+    // Flag to determine when to terminate the loop
+    bool done = false;
+
+    while (!done) {
+        // Calculate the base linear index based on the first dims-1 indices
+        uint32_t base_linear_index = 0;
+        for (uint32_t i = 0; i < dims - 1; i++) {
+            base_linear_index += index[i] * prod[i];
+        }
+
+        // Now iterate over the last dimension
+        uint32_t out_stick_id = 0;
+        // Perform the read operation
+        CoreLocalMem<uint32_t> scratch_dst(src_buffer_l1_addr);
+        noc.async_read(
+            s0,
+            scratch_dst,
+            s0.get_aligned_page_size(),
+            {.page_id = base_linear_index, .offset_bytes = 0},
+            {.offset_bytes = 0});
+        // Reserve space in the output buffer
+        cb_out0.reserve_back(1);
+        noc.async_read_barrier();
+        for (uint32_t l = starts[dims - 1]; l < ends[dims - 1]; l += strides[dims - 1]) {
+            // Write the element into the output buffer
+            volatile tt_l1_ptr uint8_t* out_stick =
+                reinterpret_cast<volatile tt_l1_ptr uint8_t*>(cb_out0.get_write_ptr());
+            uint32_t src_offset = l * element_size;
+            uint32_t dst_offset = out_stick_id * element_size;
+            for (uint32_t byte = 0; byte < element_size; byte++) {
+                out_stick[dst_offset + byte] = in_stick[src_offset + byte];
+            }
+            out_stick_id++;
+        }
+        cb_out0.push_back(1);
+        if constexpr (dims == 1) {
+            break;  // If there's only one dimension, we're done
+        } else {
+            // Increment the indices for the first dims-1 dimensions
+            for (int32_t i = dims - 2; i >= 0; i--) {  // Start from the last of the first dims-1
+                index[i] += strides[i];
+                if (index[i] < ends[i]) {
+                    break;  // Successfully incremented this dimension, no carry over
+                } else {
+                    index[i] = starts[i];  // Reset this dimension and carry over to the next
+                    if (i == 0) {
+                        done = true;  // If the first dimension is reset, we've completed all iterations
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/strided_slice_writer_rm_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/strided_slice_writer_rm_interleaved.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    constexpr uint32_t page_size = get_compile_time_arg_val(0);
+    constexpr auto dst_args = TensorAccessorArgs<1>();
+
+    uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    uint32_t num_sticks_per_core = get_arg_val<uint32_t>(1);
+
+    const auto s0 = TensorAccessor(dst_args, dst_addr);
+
+    constexpr uint32_t cb_id_out0 = 24;
+
+    Noc noc;
+    // Create CircularBuffer for Device 2.0 API
+    CircularBuffer cb_out0(cb_id_out0);
+    const uint32_t start_id = 0;
+    uint32_t i_stick = start_id;
+    uint32_t sticks_read = 0;
+
+    for (uint32_t iter = i_stick; iter < num_sticks_per_core; ++iter) {
+        cb_out0.wait_front(1);
+        noc.async_write(cb_out0, s0, page_size, {.offset_bytes = 0}, {.page_id = iter, .offset_bytes = 0});
+        noc.async_write_barrier();
+        cb_out0.pop_front(1);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/writer_multicore_slice_4d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/writer_multicore_slice_4d.cpp
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * TTNN Slice Operation - Multi-Core Writer Kernel (4D Support)
+ *
+ * This kernel handles the output data writing phase of the slice operation for multi-core
+ * execution, writing sliced tensor data from circular buffer to output tensor memory.
+ * Supports 1D, 2D, 3D, and 4D tensors with work distribution across cores.
+ *
+ * Key Responsibilities:
+ * - Read sliced data from circular buffer (produced by reader kernel)
+ * - Write assigned portion of output data to DRAM using TensorAccessor
+ * - Handle different tensor dimensions with proper address calculations
+ * - Support different data types with proper element size handling
+ * - Process assigned rows for this core based on work distribution
+ *
+ * Architecture:
+ * - Uses TensorAccessor for efficient DRAM address generation
+ * - Processes data row-by-row to match reader kernel output
+ * - Simple sequential write pattern for optimal memory controller utilization
+ * - Multi-core work distribution: each core writes a subset of output rows
+ *
+ * Memory Management:
+ * - DRAM alignment: 32-byte boundaries for memory controller optimization
+ * - L1 alignment: 16-byte boundaries for L1 cache efficiency
+ * - Circular buffer: Double buffering synchronized with reader kernel
+ *
+ * Data Type Support:
+ * - Element size determined at compile time for performance
+ * - Dynamic element size passed as runtime argument for flexibility
+ *
+ * Performance Optimizations:
+ * - Minimal synchronization overhead with reader kernel
+ * - Efficient memory write operations using NOC async transfers
+ * - Sequential access patterns optimized for DRAM controllers
+ * - Parallel processing with load balancing across multiple cores
+ *
+ * Compatible with: TTNN framework, ROW_MAJOR_LAYOUT tensors, 1D-4D dimensions, multi-core execution
+ */
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    // Runtime arguments for 4D slice support with multi-core work distribution
+    uint32_t rt_args_idx = 0;
+    uint32_t dst_addr = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t tensor_rank = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t output_w = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t output_h = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t output_d = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t output_n = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t element_size = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t num_rows_for_this_core = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t start_row_for_this_core = get_arg_val<uint32_t>(rt_args_idx++);
+
+    // Compile-time arguments
+    constexpr uint32_t cb_id_in = get_compile_time_arg_val(0);
+    constexpr uint32_t compile_time_element_size = get_compile_time_arg_val(1);
+    constexpr auto dst_args = TensorAccessorArgs<2>();
+
+    // Calculate sizes - working with rows, not tiles
+    uint32_t output_bytes_per_row = output_w * element_size;  // Dynamic element size
+
+    // Set up TensorAccessor for output data - use row size as page size
+    const auto s0 = TensorAccessor(dst_args, dst_addr);
+
+    Noc noc;
+    // Create CircularBuffer for Device 2.0 API
+    CircularBuffer cb_in(cb_id_in);
+
+    // Multi-core work distribution: this core writes rows starting from start_row_for_this_core
+    // Write each row from circular buffer to output tensor at the correct logical position
+    for (uint32_t local_row = 0; local_row < num_rows_for_this_core; ++local_row) {
+        cb_in.wait_front(1);
+        uint32_t l1_read_addr = cb_in.get_read_ptr();
+
+        // Calculate global output row index for this local row
+        uint32_t global_output_row = start_row_for_this_core + local_row;
+
+        // noc_async_write_sharded splits the write across shards for B/W-sharded outputs;
+        // falls through to a single noc_async_write for interleaved / HEIGHT-sharded.
+        tt::data_movement::common::noc_async_write_sharded(
+            noc, l1_read_addr, s0, global_output_row, /*offset=*/0, /*size=*/output_bytes_per_row);
+        noc.async_writes_flushed();
+
+        cb_in.pop_front(1);
+    }
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/writer_multicore_slice_nd.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/writer_multicore_slice_nd.cpp
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * TTNN Slice Operation - Multi-Core Writer Kernel (N-Dimensional Support)
+ *
+ * This kernel handles the output data writing phase of the slice operation for multi-core
+ * execution, writing sliced tensor data from circular buffer to output tensor memory.
+ * Supports 1D, 2D, 3D, 4D, 5D, etc. tensors with work distribution across cores.
+ *
+ * Key Responsibilities:
+ * - Read sliced data from circular buffer (produced by reader kernel)
+ * - Write assigned portion of output data to DRAM using TensorAccessor
+ * - Handle different tensor dimensions with proper address calculations
+ * - Support different data types with proper element size handling
+ * - Process assigned rows for this core based on work distribution
+ *
+ * Architecture:
+ * - Uses TensorAccessor for efficient DRAM address generation
+ * - Processes data row-by-row to match reader kernel output
+ * - Simple sequential write pattern for optimal memory controller utilization
+ * - Multi-core work distribution: each core writes a subset of output rows
+ *
+ * Memory Management:
+ * - DRAM alignment: 32-byte boundaries for memory controller optimization
+ * - L1 alignment: 16-byte boundaries for L1 cache efficiency
+ * - Circular buffer: Double buffering synchronized with reader kernel
+ *
+ * Data Type Support:
+ * - Element size determined at compile time for performance
+ * - Dynamic element size passed as runtime argument for flexibility
+ *
+ * Performance Optimizations:
+ * - Minimal synchronization overhead with reader kernel
+ * - Efficient memory write operations using NOC async transfers
+ * - Sequential access patterns optimized for DRAM controllers
+ * - Parallel processing with load balancing across multiple cores
+ *
+ * N-Dimensional Processing:
+ * - Row concept: for rank R, rows = product(dims[0:R-1]), width = dims[R-1]
+ * - Each core writes a contiguous range of logical output rows
+ * - Simple linear mapping from logical row index to physical address
+ *
+ * Compatible with: TTNN framework, ROW_MAJOR_LAYOUT tensors, 1D-ND dimensions, multi-core execution
+ */
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    // Runtime arguments - first get basic parameters
+    uint32_t rt_args_idx = 0;
+    uint32_t dst_addr = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t tensor_rank = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t element_size = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t num_rows_for_this_core = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t start_row_for_this_core = get_arg_val<uint32_t>(rt_args_idx++);
+
+    // Compile-time arguments
+    constexpr uint32_t cb_id_in = get_compile_time_arg_val(0);
+    constexpr uint32_t compile_time_element_size = get_compile_time_arg_val(1);
+    constexpr auto dst_args = TensorAccessorArgs<2>();
+
+    // Get dimension arrays from runtime arguments
+    // Layout: output_dims[rank]
+
+    // Read output dimensions
+    volatile tt_l1_ptr uint32_t* output_dims = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(rt_args_idx++));
+
+    // Calculate sizes - working with rows, not tiles
+    uint32_t output_bytes_per_row = output_dims[tensor_rank - 1] * element_size;
+
+    // Set up TensorAccessor for output data - use row size as page size
+    const auto s0 = TensorAccessor(dst_args, dst_addr);
+
+    Noc noc;
+    // Create CircularBuffer for Device 2.0 API
+    CircularBuffer cb_in(cb_id_in);
+
+    // Multi-core work distribution: this core writes rows starting from start_row_for_this_core
+    // Write each row from circular buffer to output tensor at the correct logical position
+    for (uint32_t local_row = 0; local_row < num_rows_for_this_core; ++local_row) {
+        cb_in.wait_front(1);
+        uint32_t l1_read_addr = cb_in.get_read_ptr();
+
+        // Calculate global output row index for this local row
+        uint32_t global_output_row = start_row_for_this_core + local_row;
+
+        // noc_async_write_sharded splits the write across shards for B/W-sharded outputs;
+        // falls through to a single noc_async_write for interleaved / HEIGHT-sharded.
+        tt::data_movement::common::noc_async_write_sharded(
+            noc, l1_read_addr, s0, global_output_row, /*offset=*/0, /*size=*/output_bytes_per_row);
+        noc.async_writes_flushed();
+
+        cb_in.pop_front(1);
+    }
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Slice-specific writer using named compile-time args for CB index.
+// Based on eltwise/unary writer but uses get_named_compile_time_arg_val("cb_out")
+// so the CB index can be remapped by the fusion infrastructure.
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    const uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    const uint32_t num_pages = get_arg_val<uint32_t>(1);
+    const uint32_t start_id = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t cb_id_out = get_named_compile_time_arg_val("cb_out");
+    constexpr auto dst_args = TensorAccessorArgs<0>();
+
+    // Create objects for Device 2.0 API
+    CircularBuffer cb_out(cb_id_out);
+
+    // Get page size from CB interface (works for both TILE and ROW_MAJOR layouts)
+    const uint32_t page_bytes = cb_out.get_tile_size();
+    Noc noc;
+
+#ifdef OUT_SHARDED
+    cb_out.wait_front(num_pages);
+#else
+
+    // single-page ublocks (works for both TILE and ROW_MAJOR layouts)
+    constexpr uint32_t onepage = 1;
+
+    const auto s = TensorAccessor(dst_args, dst_addr);
+
+#ifdef BACKWARDS
+    uint32_t end_id = start_id - num_pages;
+    for (uint32_t i = start_id; i != end_id; --i) {
+#else
+    uint32_t end_id = start_id + num_pages;
+    for (uint32_t i = start_id; i < end_id; ++i) {
+#endif
+        cb_out.wait_front(onepage);
+        noc.async_write(cb_out, s, page_bytes, {.offset_bytes = 0}, {.page_id = i});
+        noc.async_writes_flushed();
+        cb_out.pop_front(onepage);
+    }
+    noc.async_write_barrier();
+#endif
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_device_operation.cpp
@@ -1,0 +1,327 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/experimental/quasar/slice/device/slice_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/data_movement/common/common.hpp"
+#include "ttnn/tensor/tensor_ops.hpp"
+
+#include "ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm.hpp"
+#include "ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm_sharded.hpp"
+#include "ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm_stride.hpp"
+#include "ttnn/operations/experimental/quasar/slice/device/slice_program_factory_tile.hpp"
+#include "ttnn/operations/experimental/quasar/slice/device/slice_program_factory_tile_tensor_args.hpp"
+#include "ttnn/operations/data_movement/transpose/device/transpose_utils.hpp"
+
+#include <tt-metalium/constants.hpp>
+
+using namespace tt::tt_metal;
+
+namespace ttnn::operations::experimental::quasar {
+
+inline __attribute__((always_inline)) uint32_t get_upper_dims_compressed(const ttnn::Shape& shape) {
+    return std::accumulate(shape.cbegin(), shape.cend() - 2, 1, std::multiplies<uint32_t>{});
+}
+
+inline __attribute__((always_inline)) uint32_t
+get_upper_start_offset(const ttnn::Shape& shape, Layout layout, const ttnn::Shape& slice_start) {
+    // offset for every dim except last 2
+    uint32_t start_offset = 0;
+
+    uint32_t num_pages = shape.volume();
+    if (layout == Layout::TILE) {
+        num_pages /= tt::constants::TILE_HW;
+    } else {
+        uint32_t page_width = shape[-1];
+        num_pages /= page_width;
+    }
+
+    for (uint32_t dim_outer = 0; dim_outer < shape.rank() - 2; dim_outer++) {
+        uint32_t compressed_dims = 1;
+        for (uint32_t dim_inner = 0; dim_inner <= dim_outer; dim_inner++) {
+            compressed_dims *= shape[dim_inner];
+        }
+        start_offset += (num_pages / compressed_dims) * slice_start[dim_outer];
+    }
+    return start_offset;
+}
+
+inline __attribute__((always_inline)) uint32_t
+get_upper_start_offset(const Tensor& tensor, const ttnn::Shape& slice_start) {
+    return get_upper_start_offset(tensor.padded_shape(), tensor.layout(), slice_start);
+}
+
+// Returns the start offset for a tiled tensor, given the input tensor and the slice start shape.
+// If round_up is true, and the slice_start is not aligned to a tile boundary, it will round up to the next tile.
+uint32_t get_tiled_start_offset(const ttnn::Shape& input_shape, const ttnn::Shape& slice_start, bool round_up) {
+    using namespace tt::constants;
+    uint32_t num_input_pages = input_shape.volume() / (TILE_HW);
+    uint32_t upper_dims_compressed = get_upper_dims_compressed(input_shape);
+    uint32_t num_pages_width = num_input_pages / (upper_dims_compressed * tt::div_up(input_shape[-2], TILE_HEIGHT));
+
+    // offset for every dim except last 2
+    uint32_t start_offset = get_upper_start_offset(input_shape, Layout::TILE, slice_start);
+
+    if (round_up) {
+        start_offset +=
+            tt::div_up(slice_start[-2], TILE_HEIGHT) * num_pages_width + tt::div_up(slice_start[-1], TILE_WIDTH);
+    } else {
+        start_offset += slice_start[-2] / TILE_HEIGHT * num_pages_width + slice_start[-1] / TILE_WIDTH;
+    }
+    return start_offset;
+}
+
+uint32_t get_tiled_start_offset(const Tensor& input_tensor, const ttnn::Shape& slice_start, bool round_up) {
+    const auto& shape = input_tensor.padded_shape();
+    return get_tiled_start_offset(shape, slice_start, round_up);
+}
+
+uint32_t get_rm_start_offset(const Tensor& tensor, const ttnn::Shape& slice_start) {
+    uint32_t start_offset = 0;
+
+    if (tensor.padded_shape().rank() >= 2) {
+        start_offset = get_upper_start_offset(tensor, slice_start);
+        start_offset += slice_start[-2];
+    }
+
+    return start_offset;
+}
+
+}  // namespace ttnn::operations::experimental::quasar
+
+namespace ttnn::prim::qsr {
+
+void SliceDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    using namespace tt::constants;
+    const bool has_step = std::any_of(args.step.cbegin(), args.step.cend(), [](uint32_t s) { return s != 1; });
+    TT_FATAL(tensor_args.input.storage_type() == StorageType::DEVICE, "Operands to unpad need to be on device!");
+    TT_FATAL(tensor_args.input.buffer() != nullptr, "Operands to unpad need to be allocated in buffers on device!");
+    TT_FATAL(
+        tensor_args.input.layout() == Layout::TILE || tensor_args.input.layout() == Layout::ROW_MAJOR,
+        "Input tensor layout must be TILE or ROW_MAJOR but got {}",
+        tensor_args.input.layout());
+    TT_FATAL(
+        tensor_args.input.padded_shape().rank() == args.slice_start.rank() &&
+            args.slice_start.rank() == args.slice_end.rank(),
+        "Input tensor rank ({}), slice start rank ({}), and slice end rank ({}) must all be equal",
+        tensor_args.input.padded_shape().rank(),
+        args.slice_start.rank(),
+        args.slice_end.rank());
+    for (uint32_t i = 0; i < tensor_args.input.padded_shape().rank(); i++) {
+        TT_FATAL(
+            args.slice_start[i] < tensor_args.input.padded_shape()[i],
+            "Slice start[{}] ({}) must be less than input tensor shape[{}] ({})",
+            i,
+            args.slice_start[i],
+            i,
+            tensor_args.input.padded_shape()[i]);
+        TT_FATAL(
+            args.slice_end[i] <= tensor_args.input.padded_shape()[i],
+            "Ends {} must be less than or equal to the shape of the tensor {}",
+            args.slice_end[i],
+            tensor_args.input.padded_shape()[i]);
+        // Check if start shape is <= end shape
+        TT_FATAL(
+            args.slice_start[i] <= args.slice_end[i],
+            "Slice start[{}] ({}) must be <= slice end[{}] ({})",
+            i,
+            args.slice_start[i],
+            i,
+            args.slice_end[i]);
+    }
+    if (tensor_args.preallocated_output.has_value()) {
+        const auto output_shape_required = compute_output_specs(args, tensor_args).logical_shape();
+        const auto& out_tensor = tensor_args.preallocated_output.value();
+        TT_FATAL(
+            out_tensor.padded_shape() == output_shape_required,
+            "The preallocated output tensor needs a shape of {}, however it is {}",
+            output_shape_required,
+            out_tensor.padded_shape());
+    }
+    auto output_tensor_shape = compute_output_specs(args, tensor_args).logical_shape();
+    if (has_step) {  // if all ones modify before passing in to function
+        TT_FATAL(
+            tensor_args.input.layout() == Layout::ROW_MAJOR, "Strided slice is only supported for row major layout");
+        // Strided + sharded is natively supported: reader/writer kernels route per-row NOC calls
+        // through noc_async_*_sharded, which handles cross-shard splitting transparently.
+        TT_FATAL(
+            args.step.size() == args.slice_end.rank(),
+            "Number of steps {} must match number of ends/starts {}",
+            args.step.size(),
+            args.slice_end.rank());
+    }
+    if (tensor_args.input.layout() == Layout::TILE) {
+        TT_FATAL(
+            tensor_args.input.physical_volume() % TILE_HW == 0,
+            "Input tensor physical volume ({}) must be divisible by TILE_HW ({})",
+            tensor_args.input.physical_volume(),
+            TILE_HW);
+        TT_FATAL(
+            (output_tensor_shape[-2] % TILE_HEIGHT == 0) && (args.slice_start[-2] % TILE_HEIGHT == 0),
+            "Can only slice tilized tensor with height begin index aligned to tiles");
+        TT_FATAL(
+            (output_tensor_shape[-1] % TILE_WIDTH == 0) && (args.slice_start[-1] % TILE_WIDTH == 0),
+            "Can only slice tilized tensor with width begin index aligned to tiles");
+    } else if (tensor_args.input.layout() == Layout::ROW_MAJOR) {
+        if (has_step) {
+            for (uint32_t i = 0; i < tensor_args.input.padded_shape().rank(); i++) {
+                TT_FATAL(args.step[i] > 0, "Step({}) = {} should be positive", i, args.step[i]);
+            }
+        }
+    }
+}
+
+SliceDeviceOperation::spec_return_value_t SliceDeviceOperation::compute_output_specs(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input;
+    SmallVector<uint32_t> out_shape(input_tensor.logical_shape().rank());
+
+    if (args.use_tensor_args) {
+        TT_FATAL(
+            args.slice_dim.has_value() && args.num_devices.has_value(),
+            "slice_dim and num_devices must be provided for tensor args path");
+
+        uint32_t slice_dimension = args.slice_dim.value();
+        uint32_t num_parts = args.num_devices.value();
+
+        for (uint32_t i = 0; i < out_shape.size(); i++) {
+            out_shape[i] = input_tensor.logical_shape()[i];
+        }
+        TT_FATAL(
+            slice_dimension < out_shape.size(),
+            "slice_dim ({}) must be less than tensor rank ({})",
+            slice_dimension,
+            out_shape.size());
+
+        uint32_t original_size = out_shape[slice_dimension];
+        uint32_t slice_size = original_size / num_parts;
+
+        TT_FATAL(
+            original_size % num_parts == 0,
+            "Input dimension {} (size={}) must be evenly divisible by num_devices ({})",
+            slice_dimension,
+            original_size,
+            num_parts);
+
+        out_shape[slice_dimension] = slice_size;
+    } else {
+        // Regular path using slice_start, slice_end, step
+        auto output_dim_i = [&args](size_t i) {
+            return (args.slice_end[i] - args.slice_start[i] + args.step[i] - 1) / args.step[i];
+        };
+        for (uint32_t i = 0; i < out_shape.size(); i++) {
+            out_shape[i] = output_dim_i(i);
+        }
+    }
+    ttnn::Shape output_tensor_shape(std::move(out_shape));
+
+    // Synthesize shard spec for sharded-no-spec output: scale from input spec when layouts match,
+    // else fall back to generate_transpose_shard_spec for a fresh full-grid spec.
+    auto output_mem_config = args.output_mem_config;
+    if (output_mem_config.is_sharded() && !output_mem_config.shard_spec().has_value()) {
+        std::optional<tt::tt_metal::ShardSpec> derived;
+        if (input_tensor.is_sharded() && input_tensor.memory_config().shard_spec().has_value() &&
+            input_tensor.memory_config().memory_layout() == output_mem_config.memory_layout() &&
+            input_tensor.logical_shape().rank() == output_tensor_shape.rank()) {
+            auto adjusted = ttnn::operations::data_movement::transpose::adjust_shard_spec_to_shape(
+                *input_tensor.memory_config().shard_spec(), input_tensor.logical_shape(), output_tensor_shape);
+            if (adjusted.has_value()) {
+                // TILE factories require tile-aligned shards; sub-tile results from
+                // adjust_shard_spec_to_shape fall through to generate_transpose_shard_spec.
+                const bool tile_layout = input_tensor.layout() == Layout::TILE;
+                const bool tile_aligned = adjusted->shape[0] % tt::constants::TILE_HEIGHT == 0 &&
+                                          adjusted->shape[1] % tt::constants::TILE_WIDTH == 0;
+                if (!tile_layout || tile_aligned) {
+                    derived = std::move(adjusted);
+                }
+            }
+        }
+        if (!derived.has_value()) {
+            derived = ttnn::operations::data_movement::transpose::generate_transpose_shard_spec(
+                input_tensor, output_tensor_shape, output_mem_config.memory_layout());
+        }
+        output_mem_config =
+            tt::tt_metal::MemoryConfig(output_mem_config.memory_layout(), output_mem_config.buffer_type(), derived);
+    }
+
+    return ttnn::TensorSpec(
+        output_tensor_shape,
+        tt::tt_metal::TensorLayout(input_tensor.dtype(), PageConfig(input_tensor.layout()), output_mem_config));
+}
+
+Tensor SliceDeviceOperation::create_output_tensors(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    if (tensor_args.preallocated_output.has_value()) {
+        return tensor_args.preallocated_output.value();
+    }
+
+    const auto& input = tensor_args.input;
+    const auto output_spec = compute_output_specs(args, tensor_args);
+
+    return create_device_tensor(output_spec, input.device());
+}
+
+SliceDeviceOperation::program_factory_t SliceDeviceOperation::select_program_factory(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& input = tensor_args.input;
+
+    if (args.use_tensor_args) {
+        return SliceTileTensorArgsProgramFactory{};
+    }
+
+    // Check if we have step != 1
+    bool has_step = std::any_of(args.step.cbegin(), args.step.cend(), [](uint32_t s) { return s != 1; });
+
+    if (input.layout() == Layout::ROW_MAJOR) {
+        // HEIGHT→HEIGHT no-step: fast CB path, no NOC read needed.
+        // WIDTH/BLOCK-sharded RM: SliceRmProgramFactory with per-shard page size via noc_async_*_sharded.
+        const bool height_sharded_in_out_no_step =
+            input.is_sharded() &&
+            input.memory_config().memory_layout() == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED &&
+            args.output_mem_config.is_sharded() &&
+            args.output_mem_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED && !has_step;
+        if (height_sharded_in_out_no_step) {
+            return SliceRmShardedProgramFactory{};
+        }
+        if (has_step) {
+            return SliceRmStrideProgramFactory{};
+        }
+        return SliceRmProgramFactory{};
+    }
+    // Layout::TILE — TensorAccessor at tile granularity handles all sharded buffer types natively.
+    return SliceTileProgramFactory{};
+}
+
+tt::tt_metal::operation::OpPerformanceModelGeneral<SliceDeviceOperation::tensor_return_value_t>
+SliceDeviceOperation::create_op_performance_model(
+    const operation_attributes_t& /*args*/, const tensor_args_t& tensor_args, const Tensor& output) {
+    const auto& input_tensor = tensor_args.input;
+    const auto& output_tensor = output;
+    int ideal_dev_clock_cycles = ttnn::operations::data_movement::common_tm_bw_model(input_tensor, output_tensor, true);
+    tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> result(
+        {input_tensor}, {output}, ideal_dev_clock_cycles);
+    return result;
+}
+
+SliceDeviceOperation::tensor_return_value_t slice(
+    const Tensor& input,
+    const ttnn::Shape& slice_start,
+    const ttnn::Shape& slice_end,
+    const ttnn::Shape& step,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    bool use_tensor_args,
+    std::optional<Tensor> start_tensor,
+    std::optional<Tensor> end_tensor,
+    const std::optional<uint32_t>& slice_dim,
+    const std::optional<uint32_t>& num_devices,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<Tensor>& preallocated_output) {
+    using OperationType = ttnn::prim::qsr::SliceDeviceOperation;
+    return ttnn::device_operation::launch<OperationType>(
+        OperationType::operation_attributes_t{
+            slice_start, slice_end, step, output_mem_config, use_tensor_args, slice_dim, num_devices, sub_core_grids},
+        OperationType::tensor_args_t{input, std::move(start_tensor), std::move(end_tensor), preallocated_output});
+}
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_device_operation.hpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/operations/experimental/quasar/slice/device/slice_device_operation_types.hpp"
+#include "ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm.hpp"
+#include "ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm_sharded.hpp"
+#include "ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm_stride.hpp"
+#include "ttnn/operations/experimental/quasar/slice/device/slice_program_factory_tile.hpp"
+#include "ttnn/operations/experimental/quasar/slice/device/slice_program_factory_tile_tensor_args.hpp"
+
+#include "ttnn/tensor/tensor.hpp"
+
+#include <optional>
+#include <variant>
+#include "ttnn/types.hpp"
+#include "ttnn/operation.hpp"
+
+namespace ttnn::operations::experimental::quasar {
+
+uint32_t get_rm_start_offset(const Tensor& tensor, const ttnn::Shape& slice_start);
+uint32_t get_tiled_start_offset(const Tensor& input_tensor, const ttnn::Shape& slice_start, bool round_up = false);
+uint32_t get_tiled_start_offset(const ttnn::Shape& input_shape, const ttnn::Shape& slice_start, bool round_up = false);
+
+}  // namespace ttnn::operations::experimental::quasar
+
+namespace ttnn::prim::qsr {
+
+struct SliceDeviceOperation {
+    using operation_attributes_t = SliceParams;
+    using tensor_args_t = SliceInputs;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
+    using program_factory_t = std::variant<
+        SliceRmProgramFactory,
+        SliceRmShardedProgramFactory,
+        SliceRmStrideProgramFactory,
+        SliceTileProgramFactory,
+        SliceTileTensorArgsProgramFactory>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
+        const operation_attributes_t&, const tensor_args_t&, const Tensor&);
+};
+
+SliceDeviceOperation::tensor_return_value_t slice(
+    const Tensor& input,
+    const ttnn::Shape& slice_start,
+    const ttnn::Shape& slice_end,
+    const ttnn::Shape& step,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    bool use_tensor_args,
+    std::optional<Tensor> start_tensor = std::nullopt,
+    std::optional<Tensor> end_tensor = std::nullopt,
+    const std::optional<uint32_t>& slice_dim = std::nullopt,
+    const std::optional<uint32_t>& num_devices = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<Tensor>& preallocated_output = std::nullopt);
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_device_operation_types.hpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct SliceParams {
+    ttnn::Shape slice_start;
+    ttnn::Shape slice_end;
+    ttnn::Shape step;
+    tt::tt_metal::MemoryConfig output_mem_config;
+    bool use_tensor_args = false;
+    std::optional<uint32_t> slice_dim = std::nullopt;
+    std::optional<uint32_t> num_devices = std::nullopt;
+    std::optional<CoreRangeSet> sub_core_grids = std::nullopt;
+};
+
+struct SliceInputs {
+    Tensor input;
+    std::optional<Tensor> start_tensor;
+    std::optional<Tensor> end_tensor;
+    std::optional<Tensor> preallocated_output;
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm.cpp
@@ -1,0 +1,296 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/experimental/quasar/slice/device/slice_device_operation.hpp"
+#include "ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm.hpp"
+
+#include <optional>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::operations::experimental::quasar {
+
+namespace {
+
+inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_slice_runtime_args_rm(
+    const Tensor& input_tensor,
+    Tensor& output_tensor,
+    const ttnn::Shape& output_tensor_start,
+    uint32_t num_cores,
+    const std::vector<CoreCoord>& all_cores_vec,
+    const CoreRangeSet& core_group_1,
+    const CoreRangeSet& core_group_2,
+    uint32_t num_sticks_per_core_group_1,
+    uint32_t num_sticks_per_core_group_2,
+    uint32_t max_read_size) {
+    auto* output_buffer = output_tensor.buffer();
+    auto input_shape = input_tensor.padded_shape();
+    auto output_shape = output_tensor.padded_shape();
+
+    uint32_t padded_row_size_bytes = input_shape[-1] * input_tensor.element_size();
+    uint32_t unpadded_row_size_bytes = output_shape[-1] * input_tensor.element_size();
+
+    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
+    std::vector<uint32_t> num_unpadded_sticks_per_dim(num_dims);
+    std::vector<uint32_t> num_padded_sticks_per_dim(num_dims);
+    std::vector<uint32_t> id_per_dim(num_dims);
+
+    std::vector<uint32_t> accumulated_total_per_dim(num_dims);
+
+    // TODO: Remove first element of these arrays and update kernel accordingly
+    num_unpadded_sticks_per_dim[0] = 1;
+    num_padded_sticks_per_dim[0] = 0;
+    accumulated_total_per_dim[0] = 1;
+
+    for (int32_t i = 1; i < num_dims; i++) {
+        uint32_t num_unpadded_dim = output_shape[-(i + 1)];
+        uint32_t num_total_dim = input_shape[-(i + 1)];
+        uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
+        num_unpadded_sticks_per_dim[i] = num_unpadded_dim;
+        num_padded_sticks_per_dim[i] = num_padded_dim;
+        accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
+    }
+
+    auto src_buffer_alignment = input_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
+                                    ? ::hal::get_dram_alignment()
+                                    : ::hal::get_l1_alignment();
+    auto dst_buffer_alignment = output_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
+                                    ? ::hal::get_dram_alignment()
+                                    : ::hal::get_l1_alignment();
+    auto alignment = std::max(src_buffer_alignment, dst_buffer_alignment);
+    uint32_t begins_bytes = output_tensor_start[-1] * input_tensor.element_size();
+    uint32_t misalignment = begins_bytes % src_buffer_alignment;
+    uint32_t unpadded_row_size_bytes_offset = tt::round_up(unpadded_row_size_bytes, alignment);
+    uint32_t start_addr = input_tensor.buffer()->address();
+
+    // shard_W * elem_size for B/W-sharded (splits row across shards); full row otherwise.
+    // Fallback is padded for the reader tensor, unpadded for the writer tensor.
+    const auto per_shard_page_size_bytes = [&](const Tensor& t, uint32_t row_bytes) -> uint32_t {
+        const auto& mc = t.memory_config();
+        if (mc.is_sharded() && (mc.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ||
+                                mc.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED)) {
+            const auto& spec = mc.shard_spec().value();
+            return spec.shape[1] * t.element_size();
+        }
+        return row_bytes;
+    };
+    const uint32_t reader_page_size = per_shard_page_size_bytes(input_tensor, padded_row_size_bytes);
+
+    std::vector<uint32_t> common_reader_kernel_args = {
+        start_addr + begins_bytes - misalignment,  // read from nearest aligned address,
+        reader_page_size,
+        unpadded_row_size_bytes,
+        unpadded_row_size_bytes_offset,
+        num_dims,
+        misalignment,
+        0,
+        0,
+        0,
+        0};
+    common_reader_kernel_args.insert(
+        common_reader_kernel_args.end(), num_unpadded_sticks_per_dim.begin(), num_unpadded_sticks_per_dim.end());
+    common_reader_kernel_args.insert(
+        common_reader_kernel_args.end(), num_padded_sticks_per_dim.begin(), num_padded_sticks_per_dim.end());
+
+    std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> ret_val;
+    ret_val.reserve(num_cores);
+
+    uint32_t start_offset =
+        ttnn::operations::experimental::quasar::get_rm_start_offset(input_tensor, output_tensor_start);
+    uint32_t num_sticks_written = 0;
+    for (const auto& core : all_cores_vec) {
+        uint32_t num_sticks_per_core;
+        if (core_group_1.contains(core)) {
+            num_sticks_per_core = num_sticks_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_sticks_per_core = num_sticks_per_core_group_2;
+        } else {
+            num_sticks_per_core = 0;
+        }
+
+        uint32_t num_sticks_per_core_read = 0, num_read_per_barrier = 0;
+        if (num_sticks_per_core != 0) {
+            auto num_sticks_per_core_pad32 = num_sticks_per_core + ((32 - num_sticks_per_core % 32) % 32);
+            num_sticks_per_core_read = tt::tt_metal::merge_num_sticks_to_read(
+                num_sticks_per_core_pad32, unpadded_row_size_bytes_offset, max_read_size);
+            num_read_per_barrier = num_sticks_per_core_pad32 / num_sticks_per_core_read;
+        }
+
+        id_per_dim[0] = num_sticks_written % num_unpadded_sticks_per_dim[0];
+        uint32_t unpadded_written = num_sticks_written / num_unpadded_sticks_per_dim[0];
+        uint32_t start_id = id_per_dim[0] + start_offset;
+
+        for (uint32_t j = 1; j < num_dims; j++) {
+            id_per_dim[j] = unpadded_written % num_unpadded_sticks_per_dim[j];
+            unpadded_written = unpadded_written / num_unpadded_sticks_per_dim[j];
+            start_id += id_per_dim[j] * accumulated_total_per_dim[j - 1];
+        }
+        std::vector<uint32_t> reader_kernel_args = common_reader_kernel_args;
+        uint32_t addr_offset = 6;
+        reader_kernel_args[addr_offset++] = start_id;
+        reader_kernel_args[addr_offset++] = num_sticks_per_core;
+        reader_kernel_args[addr_offset++] = num_sticks_per_core_read;
+        reader_kernel_args[addr_offset] = num_read_per_barrier;
+        reader_kernel_args.insert(reader_kernel_args.end(), id_per_dim.begin(), id_per_dim.end());
+
+        const uint32_t writer_page_size = per_shard_page_size_bytes(output_tensor, unpadded_row_size_bytes);
+        std::vector<uint32_t> writer_kernel_args = {
+            output_buffer->address(),
+            unpadded_row_size_bytes,
+            unpadded_row_size_bytes_offset,
+            num_sticks_per_core,
+            num_sticks_per_core_read,
+            num_read_per_barrier,
+            num_sticks_written,
+            writer_page_size,
+        };
+        num_sticks_written += num_sticks_per_core;
+        ret_val.emplace_back(reader_kernel_args, writer_kernel_args);
+    }
+
+    return ret_val;
+}
+
+constexpr uint32_t MAX_READ_SIZE = 4096;
+
+std::tuple<uint32_t, uint32_t, uint32_t> compute_cb_size(
+    const Tensor& input,
+    const Tensor& output,
+    const Shape& output_tensor_start,
+    const uint32_t num_sticks_per_core_group_1,
+    const uint32_t num_sticks_per_core_group_2) {
+    auto src_buffer_alignment = input.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
+                                    ? ::hal::get_dram_alignment()
+                                    : ::hal::get_l1_alignment();
+    auto dst_buffer_alignment = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
+                                    ? ::hal::get_dram_alignment()
+                                    : ::hal::get_l1_alignment();
+    const auto single_alignment = std::max(src_buffer_alignment, dst_buffer_alignment);
+    auto alignment = single_alignment;
+
+    uint32_t begins_bytes = output_tensor_start[-1] * input.element_size();
+    uint32_t misalignment = begins_bytes % src_buffer_alignment;
+
+    if (misalignment != 0) {
+        alignment *= 2;
+    }
+    const uint32_t unpadded_row_size_bytes = output.padded_shape()[-1] * input.element_size();
+    const uint32_t cb_page_size = tt::round_up(unpadded_row_size_bytes, alignment);
+    const uint32_t stick_stride_for_merge = tt::round_up(unpadded_row_size_bytes, single_alignment);
+    const uint32_t num_input_pages = num_sticks_per_core_group_1 > num_sticks_per_core_group_2
+                                         ? num_sticks_per_core_group_1
+                                         : num_sticks_per_core_group_2;
+    uint32_t num_sticks_per_core_read = 0, num_read_per_barrier = 0;
+    if (num_input_pages != 0) {
+        auto num_sticks_per_core_pad32 = num_input_pages + ((32 - num_input_pages % 32) % 32);
+        num_sticks_per_core_read =
+            tt::tt_metal::merge_num_sticks_to_read(num_sticks_per_core_pad32, stick_stride_for_merge, MAX_READ_SIZE);
+        num_read_per_barrier = num_sticks_per_core_pad32 / num_sticks_per_core_read;
+    }
+
+    return std::make_tuple(cb_page_size, num_read_per_barrier, misalignment);
+}
+
+}  // namespace
+
+}  // namespace ttnn::operations::experimental::quasar
+
+namespace ttnn::prim::qsr {
+
+tt::tt_metal::ProgramDescriptor SliceRmProgramFactory::create_descriptor(
+    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const auto& input = tensor_args.input;
+    tt::tt_metal::IDevice* device = input.device();
+    ProgramDescriptor desc;
+
+    uint32_t num_unpadded_sticks = output.physical_volume() / output.padded_shape()[-1];
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_sticks_per_core_group_1, num_sticks_per_core_group_2] =
+        args.sub_core_grids.has_value()
+            ? tt::tt_metal::split_work_to_cores(args.sub_core_grids.value(), num_unpadded_sticks)
+            : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_unpadded_sticks);
+
+    tt::tt_metal::Buffer* src0_buffer = input.buffer();
+    tt::tt_metal::Buffer* dst_buffer = output.buffer();
+    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+
+    constexpr uint8_t src0_cb_index = 0;
+
+    // CB sizing varies with slice_start; padded_shape folds into compute_program_hash() so each
+    // unique CB layout gets its own cache entry (total_size/page_size are not patched on cache hit).
+    const auto [cb_page_size, num_read_per_barrier, misalignment] =
+        ttnn::operations::experimental::quasar::compute_cb_size(
+            input, output, args.slice_start, num_sticks_per_core_group_1, num_sticks_per_core_group_2);
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_read_per_barrier * 2 * cb_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = cb_data_format,
+            .page_size = cb_page_size,
+        }}},
+    });
+
+    std::vector<uint32_t> writer_compile_time_args_vec = {static_cast<uint32_t>(src0_cb_index)};
+    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args_vec);
+
+    std::vector<uint32_t> reader_compile_time_args_vec;
+    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args_vec);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/"
+        "slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args_vec);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/"
+        "slice_writer_unary_stick_layout_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args_vec);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    auto all_cores_vec = corerange_to_cores(all_cores);
+    auto all_runtime_args = ttnn::operations::experimental::quasar::get_slice_runtime_args_rm(
+        input,
+        output,
+        args.slice_start,
+        num_cores,
+        all_cores_vec,
+        core_group_1,
+        core_group_2,
+        num_sticks_per_core_group_1,
+        num_sticks_per_core_group_2,
+        ttnn::operations::experimental::quasar::MAX_READ_SIZE);
+
+    reader_desc.runtime_args.reserve(all_cores_vec.size());
+    writer_desc.runtime_args.reserve(all_cores_vec.size());
+    for (size_t i = 0; i < all_cores_vec.size(); ++i) {
+        reader_desc.runtime_args.emplace_back(all_cores_vec[i], std::move(all_runtime_args[i].first));
+        writer_desc.runtime_args.emplace_back(all_cores_vec[i], std::move(all_runtime_args[i].second));
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm.hpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/experimental/quasar/slice/device/slice_device_operation_types.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct SliceRmProgramFactory {
+    // Contract (1): per-coord ProgramDescriptor.  The src0 CB's total_size /
+    // page_size depend on slice_start (via misalignment / unpadded_row_size_bytes),
+    // so padded_shape is folded into compute_program_hash() — each unique CB
+    // sizing keeps its own cache entry.  On cache hit the framework copies
+    // runtime args and patches dynamic CB addresses; CB total_size/page_size
+    // are not re-applied (the cached descriptor already carries them).
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm_sharded.cpp
@@ -1,0 +1,324 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/experimental/quasar/slice/device/slice_device_operation.hpp"
+#include "ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm_sharded.hpp"
+
+#include <map>
+#include <optional>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::operations::experimental::quasar {
+
+namespace {
+
+inline std::vector<std::vector<uint32_t>> group_contiguous_values(std::vector<uint32_t>& values) {
+    std::vector<std::vector<uint32_t>> chunks;
+    if (values.empty()) {
+        return chunks;
+    }
+
+    // Initialize the first chunk
+    std::vector<uint32_t> current_chunk;
+    current_chunk.push_back(values[0]);
+
+    for (size_t i = 1; i < values.size(); ++i) {
+        if (values[i] == values[i - 1] + 1) {
+            current_chunk.push_back(values[i]);
+        } else {
+            chunks.push_back(current_chunk);
+            current_chunk.clear();
+            current_chunk.push_back(values[i]);
+        }
+    }
+    // Add the last chunk
+    chunks.push_back(current_chunk);
+    return chunks;
+}
+
+inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_slice_runtime_args_rm_sharded(
+    const Tensor& input_tensor,
+    Tensor& output_tensor,
+    const ttnn::Shape& output_tensor_start,
+    uint32_t num_cores_unpadded,
+    bool row_major,
+    uint32_t num_cores_x_unpadded,
+    uint32_t num_cores_y_unpadded,
+    uint32_t shard_height_unpadded,
+    uint32_t shard_height_padded,
+    uint32_t num_cores_x_padded,
+    uint32_t num_cores_y_padded) {
+    tt::tt_metal::IDevice* device = input_tensor.device();
+
+    auto input_shape = input_tensor.padded_shape();
+    auto output_shape = output_tensor.padded_shape();
+
+    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
+    std::vector<uint32_t> num_unpadded_sticks_per_dim(num_dims);
+    std::vector<uint32_t> num_padded_sticks_per_dim(num_dims);
+    std::vector<uint32_t> id_per_dim(num_dims);
+
+    std::vector<uint32_t> accumulated_total_per_dim(num_dims);
+
+    // TODO: Remove first element of these arrays and update kernel accordingly
+    // This currently just matches tile version where we iterate over the row as well
+    num_unpadded_sticks_per_dim[0] = 1;
+    num_padded_sticks_per_dim[0] = 0;
+    accumulated_total_per_dim[0] = 1;
+
+    for (int32_t i = 1; i < num_dims; i++) {
+        uint32_t num_unpadded_dim = output_shape[-(i + 1)];
+        uint32_t num_total_dim = input_shape[-(i + 1)];
+        uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
+        num_unpadded_sticks_per_dim[i] = num_unpadded_dim;
+        num_padded_sticks_per_dim[i] = num_padded_dim;
+        accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
+    }
+
+    std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> ret_val(num_cores_unpadded);
+
+    uint32_t start_offset =
+        ttnn::operations::experimental::quasar::get_rm_start_offset(input_tensor, output_tensor_start);
+    for (uint32_t i = 0, num_sticks_written = 0; i < num_cores_unpadded; i++) {
+        CoreCoord core;
+        if (row_major) {
+            core = {i % num_cores_x_unpadded, i / num_cores_x_unpadded};
+        } else {
+            core = {i / num_cores_y_unpadded, i % num_cores_y_unpadded};
+        }
+        uint32_t num_sticks_per_core_unpadded = shard_height_unpadded;
+        uint32_t num_sticks_per_core_padded = shard_height_padded;
+
+        // figure out the start read stick id for each core, and the start id for each dim
+        id_per_dim[0] = num_sticks_written % num_unpadded_sticks_per_dim[0];
+        uint32_t unpadded_written = num_sticks_written / num_unpadded_sticks_per_dim[0];
+        uint32_t start_id = id_per_dim[0] + start_offset;
+
+        for (uint32_t j = 1; j < num_dims; j++) {
+            id_per_dim[j] = unpadded_written % num_unpadded_sticks_per_dim[j];
+            unpadded_written = unpadded_written / num_unpadded_sticks_per_dim[j];
+            start_id += id_per_dim[j] * accumulated_total_per_dim[j - 1];
+        }
+
+        num_sticks_written += num_sticks_per_core_unpadded;
+
+        // stores all sticks id for a core
+        std::vector<uint32_t> stick_ids_per_core;
+        uint32_t src_stick_id = start_id;
+        for (uint32_t i = 0; i < num_sticks_per_core_unpadded; ++i) {
+            stick_ids_per_core.push_back(src_stick_id);
+            src_stick_id++;
+            for (uint32_t j = 0; j < num_dims; j++) {
+                id_per_dim[j]++;
+                if (id_per_dim[j] == num_unpadded_sticks_per_dim[j]) {
+                    id_per_dim[j] = 0;
+                    src_stick_id += num_padded_sticks_per_dim[j];
+                } else {
+                    break;
+                }
+            }
+        }
+
+        // figure out the stick id in a shard, and the core id for the stick.
+        std::map<std::pair<uint32_t, uint32_t>, std::vector<uint32_t>> core_stick_map;
+        for (uint32_t i = 0; i < num_sticks_per_core_unpadded; ++i) {
+            uint32_t stick_id = stick_ids_per_core[i];
+            uint32_t shard_id = stick_id / num_sticks_per_core_padded;
+            uint32_t stick_id_in_shard = stick_id - (shard_id * num_sticks_per_core_padded);
+
+            uint32_t shard_grid_inner_dim = row_major ? num_cores_x_padded : num_cores_y_padded;
+            uint32_t shard_grid_outer_dim_id = shard_id / shard_grid_inner_dim;
+            uint32_t shard_grid_inner_dim_id = shard_id - (shard_grid_outer_dim_id * shard_grid_inner_dim);
+
+            uint32_t worker_y_logical = row_major ? shard_grid_outer_dim_id : shard_grid_inner_dim_id;
+            uint32_t worker_x_logical = row_major ? shard_grid_inner_dim_id : shard_grid_outer_dim_id;
+
+            if (worker_x_logical < num_cores_x_padded and worker_y_logical < num_cores_y_padded) {
+                auto core_physical =
+                    device->worker_core_from_logical_core(CoreCoord{worker_x_logical, worker_y_logical});
+                // save stick id in a shard, and core coord into a map
+                std::pair<uint32_t, uint32_t> xy_pair = row_major ? std::make_pair(core_physical.y, core_physical.x)
+                                                                  : std::make_pair(core_physical.x, core_physical.y);
+                core_stick_map[xy_pair].push_back(stick_id_in_shard);
+            }
+        }
+
+        // reader rt args
+        std::vector<uint32_t> reader_kernel_args;
+        reader_kernel_args.push_back(core_stick_map.size());  // num_cores
+
+        for (const auto& core_stick_pair : core_stick_map) {
+            auto xy_pair = core_stick_pair.first;
+            if (row_major) {
+                reader_kernel_args.push_back(xy_pair.second);  // noc x
+                reader_kernel_args.push_back(xy_pair.first);   // noc y
+            } else {
+                reader_kernel_args.push_back(xy_pair.first);   // noc x
+                reader_kernel_args.push_back(xy_pair.second);  // noc y
+            }
+        }
+
+        // coalesce the sticks into chunks
+        std::vector<std::vector<std::vector<uint32_t>>> stick_chunks_per_core;
+        for (auto core_stick_pair : core_stick_map) {
+            auto stick_chunks = group_contiguous_values(core_stick_pair.second);
+            stick_chunks_per_core.push_back(stick_chunks);
+
+            reader_kernel_args.push_back(stick_chunks.size());  // num_chunks for current core
+        }
+        for (const auto& stick_chunks : stick_chunks_per_core) {
+            for (auto chunk : stick_chunks) {
+                reader_kernel_args.push_back(chunk[0]);      // start id of a chunk
+                reader_kernel_args.push_back(chunk.size());  // length of a chunk
+            }
+        }
+
+        std::vector<uint32_t> writer_kernel_args;
+        ret_val[i] = {reader_kernel_args, writer_kernel_args};
+    }
+
+    return ret_val;
+}
+
+}  // namespace
+
+}  // namespace ttnn::operations::experimental::quasar
+
+namespace ttnn::prim::qsr {
+
+tt::tt_metal::ProgramDescriptor SliceRmShardedProgramFactory::create_descriptor(
+    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const auto& input = tensor_args.input;
+    ProgramDescriptor desc;
+
+    [[maybe_unused]] uint32_t num_padded_sticks = input.physical_volume() / input.padded_shape()[-1];
+    [[maybe_unused]] uint32_t num_unpadded_sticks = output.physical_volume() / output.padded_shape()[-1];
+
+    // stick sizes
+    uint32_t W_padded = input.logical_shape()[-1];
+    uint32_t W_unpadded = output.logical_shape()[-1];
+    auto stick_size_padded = W_padded * input.element_size();
+    auto stick_size_unpadded = W_unpadded * output.element_size();
+
+    // input shard spec
+    auto shard_spec_padded = input.shard_spec().value();
+    uint32_t shard_height_padded = shard_spec_padded.shape[0];
+
+    [[maybe_unused]] auto& all_cores_padded = shard_spec_padded.grid;
+    [[maybe_unused]] uint32_t num_cores_padded = shard_spec_padded.num_cores();
+    auto bbox_padded = shard_spec_padded.grid.bounding_box();
+    CoreCoord grid_size_padded = {bbox_padded.end_coord.x + 1, bbox_padded.end_coord.y + 1};
+    uint32_t num_cores_x_padded = grid_size_padded.x;
+    uint32_t num_cores_y_padded = grid_size_padded.y;
+
+    if (args.sub_core_grids.has_value()) {
+        log_warning(tt::LogOp, "sub_core_grids is not used when input tensor is sharded");
+    }
+
+    log_debug(tt::LogOp, "num_padded_sticks: {}", num_padded_sticks);
+    log_debug(tt::LogOp, "shard_height_padded: {}", shard_height_padded);
+    log_debug(tt::LogOp, "all_cores_padded: {}", all_cores_padded);
+    log_debug(tt::LogOp, "num_cores_padded: {}", num_cores_padded);
+
+    // output shard spec
+    auto shard_spec_unpadded = output.shard_spec().value();
+    uint32_t shard_height_unpadded = shard_spec_unpadded.shape[0];
+    bool row_major = shard_spec_unpadded.orientation == ShardOrientation::ROW_MAJOR;
+
+    auto& all_cores_unpadded = shard_spec_unpadded.grid;
+    uint32_t num_cores_unpadded = shard_spec_unpadded.num_cores();
+    auto bbox_unpadded = all_cores_unpadded.bounding_box();
+    CoreCoord grid_size_unpadded = {bbox_unpadded.end_coord.x + 1, bbox_unpadded.end_coord.y + 1};
+    uint32_t num_cores_x_unpadded = grid_size_unpadded.x;
+    uint32_t num_cores_y_unpadded = grid_size_unpadded.y;
+
+    log_debug(tt::LogOp, "num_unpadded_sticks: {}", num_unpadded_sticks);
+    log_debug(tt::LogOp, "shard_height_unpadded: {}", shard_height_unpadded);
+    log_debug(tt::LogOp, "all_cores_unpadded: {}", all_cores_unpadded);
+    log_debug(tt::LogOp, "num_cores_unpadded: {}", num_cores_unpadded);
+
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    tt::DataFormat dst_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+
+    tt::tt_metal::Buffer* dst_buffer = output.buffer();
+    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    // Sharded CBs: total_size and page_size vary with shard shape / element size,
+    // so padded_shape is folded into compute_program_hash() to keep each unique
+    // sizing in its own cache entry.  On cache hit, the framework copies runtime
+    // args and patches dynamic CB addresses (.buffer is set below); CB sizing
+    // itself is not re-applied — it is carried by the cached descriptor.
+    constexpr uint8_t src0_cb_index = 0;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = shard_height_padded * stick_size_padded,
+        .core_ranges = all_cores_unpadded,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = cb_data_format,
+            .page_size = stick_size_padded,
+        }}},
+        .buffer = input.buffer(),
+    });
+
+    constexpr uint8_t output_cb_index = tt::CBIndex::c_16;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = shard_height_unpadded * stick_size_unpadded,
+        .core_ranges = all_cores_unpadded,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = dst_cb_data_format,
+            .page_size = stick_size_unpadded,
+        }}},
+        .buffer = output.buffer(),
+    });
+
+    std::vector<uint32_t> reader_ct_args = {
+        static_cast<uint32_t>(stick_size_padded),
+        static_cast<uint32_t>(stick_size_unpadded),
+        static_cast<uint32_t>(shard_height_unpadded)};
+
+    auto all_runtime_args = ttnn::operations::experimental::quasar::get_slice_runtime_args_rm_sharded(
+        input,
+        output,
+        args.slice_start,
+        num_cores_unpadded,
+        row_major,
+        num_cores_x_unpadded,
+        num_cores_y_unpadded,
+        shard_height_unpadded,
+        shard_height_padded,
+        num_cores_x_padded,
+        num_cores_y_padded);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/"
+        "slice_reader_unary_unpad_dims_rm_sharded.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores_unpadded;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    reader_desc.runtime_args.reserve(num_cores_unpadded);
+    for (uint32_t i = 0; i < num_cores_unpadded; ++i) {
+        CoreCoord core;
+        if (row_major) {
+            core = {i % num_cores_x_unpadded, i / num_cores_x_unpadded};
+        } else {
+            core = {i / num_cores_y_unpadded, i % num_cores_y_unpadded};
+        }
+        reader_desc.runtime_args.emplace_back(core, std::move(all_runtime_args[i].first));
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm_sharded.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm_sharded.hpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/experimental/quasar/slice/device/slice_device_operation_types.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct SliceRmShardedProgramFactory {
+    // Contract (1): per-coord ProgramDescriptor.  Both CBs are sharded
+    // (CBDescriptor::buffer bound to input/output buffers); the framework
+    // patches the dynamic CB addresses on cache hit via
+    // apply_descriptor_runtime_args.  CB total_size/page_size are NOT patched
+    // — padded_shape is folded into compute_program_hash() so each unique
+    // sizing gets its own cache entry.
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm_stride.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm_stride.cpp
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/experimental/quasar/slice/device/slice_device_operation.hpp"
+#include "ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm_stride.hpp"
+
+#include <optional>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+
+tt::tt_metal::ProgramDescriptor SliceRmStrideProgramFactory::create_descriptor(
+    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const auto& input_tensor = tensor_args.input;
+    tt::tt_metal::IDevice* device = input_tensor.device();
+    ProgramDescriptor desc;
+
+    const auto& input_shape = input_tensor.padded_shape();
+    const auto& output_shape = output.padded_shape();
+    uint32_t element_size = input_tensor.element_size();
+
+    // Calculate total output rows based on tensor rank
+    uint32_t total_output_rows = output_shape.volume() / output_shape[-1];
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_rows_per_core_group_1, num_rows_per_core_group_2] =
+        args.sub_core_grids.has_value()
+            ? tt::tt_metal::split_work_to_cores(args.sub_core_grids.value(), total_output_rows)
+            : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, total_output_rows);
+
+    // Select kernels based on tensor rank
+    std::string reader_kernel_path;
+    std::string writer_kernel_path;
+    if (input_shape.rank() <= 4) {
+        reader_kernel_path =
+            "ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/reader_multicore_slice_4d.cpp";
+        writer_kernel_path =
+            "ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/writer_multicore_slice_4d.cpp";
+    } else {
+        reader_kernel_path =
+            "ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/reader_multicore_slice_nd.cpp";
+        writer_kernel_path =
+            "ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/writer_multicore_slice_nd.cpp";
+    }
+
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    uint32_t actual_input_w = input_shape[-1];
+    uint32_t input_bytes_per_row = actual_input_w * element_size;
+    uint32_t cb_page_size = input_bytes_per_row;
+
+    auto src_buffer_alignment = input_tensor.buffer()->alignment();
+    auto dst_buffer_alignment = output.buffer()->alignment();
+    auto alignment = std::max(src_buffer_alignment, dst_buffer_alignment);
+
+    uint32_t cb_page_size_aligned = tt::round_up(cb_page_size, alignment);
+    uint32_t cb_total_size = 2 * cb_page_size_aligned;
+
+    constexpr uint8_t in_cb = 0;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cb_total_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = in_cb,
+            .data_format = cb_data_format,
+            .page_size = cb_page_size_aligned,
+        }}},
+    });
+
+    std::vector<uint32_t> reader_compile_time_args = {in_cb, element_size};
+    TensorAccessorArgs(*input_tensor.buffer()).append_to(reader_compile_time_args);
+
+    std::vector<uint32_t> writer_compile_time_args = {in_cb, element_size};
+    TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = reader_kernel_path;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = writer_kernel_path;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    // Calculate runtime arguments
+    uint32_t tensor_rank = input_shape.rank();
+    uint32_t base_rows_per_core = total_output_rows / num_cores;
+    uint32_t extra_rows = total_output_rows % num_cores;
+
+    const bool using_4d_kernels = input_shape.rank() <= 4;
+    const auto& slice_start = args.slice_start;
+    const auto& slice_end = args.slice_end;
+    const auto& slice_step = args.step;
+
+    auto all_cores_vec = corerange_to_cores(all_cores);
+    reader_desc.runtime_args.reserve(all_cores_vec.size());
+    writer_desc.runtime_args.reserve(all_cores_vec.size());
+
+    uint32_t row_start_id = 0;
+    uint32_t extra_rows_remaining = extra_rows;
+
+    auto* input_buffer = input_tensor.buffer();
+    auto* output_buffer = output.buffer();
+
+    for (const auto& core : all_cores_vec) {
+        uint32_t rows_for_this_core = base_rows_per_core;
+        if (extra_rows_remaining > 0) {
+            rows_for_this_core += 1;
+            extra_rows_remaining -= 1;
+        }
+
+        if (using_4d_kernels) {
+            reader_desc.emplace_runtime_args(
+                core, {input_buffer,    tensor_rank,      input_shape[-1],  input_shape[-2],    input_shape[-3],
+                       input_shape[-4], output_shape[-1], output_shape[-2], output_shape[-3],   output_shape[-4],
+                       slice_start[-1], slice_end[-1],    slice_step[-1],   slice_start[-2],    slice_end[-2],
+                       slice_step[-2],  slice_start[-3],  slice_end[-3],    slice_step[-3],     slice_start[-4],
+                       slice_end[-4],   slice_step[-4],   element_size,     rows_for_this_core, row_start_id});
+
+            writer_desc.emplace_runtime_args(
+                core,
+                {output_buffer,
+                 tensor_rank,
+                 output_shape[-1],
+                 output_shape[-2],
+                 output_shape[-3],
+                 output_shape[-4],
+                 element_size,
+                 rows_for_this_core,
+                 row_start_id});
+        } else {
+            KernelDescriptor::RTArgList reader_args;
+            reader_args.push_back(input_buffer);
+            reader_args.push_back(tensor_rank);
+            reader_args.push_back(element_size);
+            reader_args.push_back(rows_for_this_core);
+            reader_args.push_back(row_start_id);
+            reader_args.append(std::vector<uint32_t>(input_shape.cbegin(), input_shape.cend()));
+            reader_args.append(std::vector<uint32_t>(output_shape.cbegin(), output_shape.cend()));
+            reader_args.append(std::vector<uint32_t>(slice_start.cbegin(), slice_start.cend()));
+            reader_args.append(std::vector<uint32_t>(slice_end.cbegin(), slice_end.cend()));
+            reader_args.append(std::vector<uint32_t>(slice_step.cbegin(), slice_step.cend()));
+            reader_desc.emplace_runtime_args(core, reader_args);
+
+            KernelDescriptor::RTArgList writer_args;
+            writer_args.push_back(output_buffer);
+            writer_args.push_back(tensor_rank);
+            writer_args.push_back(element_size);
+            writer_args.push_back(rows_for_this_core);
+            writer_args.push_back(row_start_id);
+            writer_args.append(std::vector<uint32_t>(output_shape.cbegin(), output_shape.cend()));
+            writer_desc.emplace_runtime_args(core, writer_args);
+        }
+
+        row_start_id += rows_for_this_core;
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm_stride.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm_stride.hpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/experimental/quasar/slice/device/slice_device_operation_types.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct SliceRmStrideProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_tile.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_tile.cpp
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/experimental/quasar/slice/device/slice_device_operation.hpp"
+#include "ttnn/operations/experimental/quasar/slice/device/slice_program_factory_tile.hpp"
+
+#include <optional>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+
+tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
+    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const auto& input = tensor_args.input;
+    tt::tt_metal::IDevice* device = input.device();
+
+    uint32_t num_unpadded_tiles = output.physical_volume() / TILE_HW;
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+        args.sub_core_grids.has_value()
+            ? tt::tt_metal::split_work_to_cores(args.sub_core_grids.value(), num_unpadded_tiles)
+            : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_unpadded_tiles);
+
+    tt::tt_metal::Buffer* src0_buffer = input.buffer();
+    tt::tt_metal::Buffer* dst_buffer = output.buffer();
+    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    uint32_t single_tile_size = tt::tile_size(cb_data_format);
+
+    const auto& input_shape = input.padded_shape();
+    const auto& output_shape = output.padded_shape();
+    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
+
+    // --- CB Descriptor ---
+    uint32_t src0_cb_index = 0;
+    uint32_t num_input_tiles = 2;
+
+    tt::tt_metal::ProgramDescriptor program_descriptor;
+
+    tt::tt_metal::CBDescriptor cb_desc;
+    cb_desc.total_size = num_input_tiles * single_tile_size;
+    cb_desc.core_ranges = all_cores;
+    cb_desc.format_descriptors.push_back(tt::tt_metal::CBFormatDescriptor{
+        .buffer_index = static_cast<uint8_t>(src0_cb_index),
+        .data_format = cb_data_format,
+        .page_size = single_tile_size});
+    program_descriptor.cbs.push_back(std::move(cb_desc));
+
+    // --- Reader Kernel Descriptor ---
+    // CB index via named compile-time arg (essential for fusion CB remapping).
+    std::vector<uint32_t> reader_compile_time_args = {num_dims};
+    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+
+    // Reader common runtime args: [src_addr, num_unpadded_per_dim..., num_padded_per_dim...]
+    uint32_t num_unpadded_Xt = output_shape[-1] / TILE_WIDTH;
+    uint32_t num_total_Xt = input_shape[-1] / TILE_WIDTH;
+    uint32_t num_padded_Xt = num_total_Xt - num_unpadded_Xt;
+    uint32_t num_unpadded_Yt = output_shape[-2] / TILE_HEIGHT;
+    uint32_t num_total_Yt = input_shape[-2] / TILE_HEIGHT;
+    uint32_t num_padded_Yt = (num_total_Yt - num_unpadded_Yt) * num_total_Xt;
+
+    std::vector<uint32_t> accumulated_total_per_dim(num_dims);
+    accumulated_total_per_dim[0] = num_total_Xt;
+    accumulated_total_per_dim[1] = num_total_Yt * num_total_Xt;
+
+    std::vector<uint32_t> reader_common_args(1 + (num_dims * 2));
+    reader_common_args[0] = src0_buffer->address();
+    uint32_t* num_unpadded_tiles_per_dim = reader_common_args.data() + 1;
+    uint32_t* num_padded_tiles_per_dim = num_unpadded_tiles_per_dim + num_dims;
+    num_unpadded_tiles_per_dim[0] = num_unpadded_Xt;
+    num_unpadded_tiles_per_dim[1] = num_unpadded_Yt;
+    num_padded_tiles_per_dim[0] = num_padded_Xt;
+    num_padded_tiles_per_dim[1] = num_padded_Yt;
+    for (int32_t i = 2; i < static_cast<int32_t>(num_dims); ++i) {
+        uint32_t num_unpadded_dim = output_shape[-(i + 1)];
+        uint32_t num_total_dim = input_shape[-(i + 1)];
+        uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
+        num_unpadded_tiles_per_dim[i] = num_unpadded_dim;
+        num_padded_tiles_per_dim[i] = num_padded_dim;
+        accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
+    }
+
+    uint32_t start_offset = ttnn::operations::experimental::quasar::get_tiled_start_offset(input, args.slice_start);
+
+    // Reader per-core runtime args: [start_id, num_tiles, id_per_dim...]
+    tt::tt_metal::KernelDescriptor::RuntimeArgs reader_runtime_args;
+    uint32_t num_tiles_written = 0;
+    for (const auto& core : corerange_to_cores(all_cores)) {
+        uint32_t num_tiles_per_core;
+        if (core_group_1.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_2;
+        } else {
+            // no-op core
+            std::vector<uint32_t> reader_args(2 + num_dims, 0);
+            reader_runtime_args.emplace_back(core, std::move(reader_args));
+            continue;
+        }
+
+        std::vector<uint32_t> reader_args(2 + num_dims);
+        // Compute per-dim indices for this core's starting position
+        reader_args[2] = num_tiles_written % num_unpadded_tiles_per_dim[0];
+        uint32_t unpadded_written = num_tiles_written / num_unpadded_tiles_per_dim[0];
+        uint32_t start_id = reader_args[2] + start_offset;
+        for (uint32_t j = 1; j < num_dims; ++j) {
+            reader_args[2 + j] = unpadded_written % num_unpadded_tiles_per_dim[j];
+            unpadded_written = unpadded_written / num_unpadded_tiles_per_dim[j];
+            start_id += reader_args[2 + j] * accumulated_total_per_dim[j - 1];
+        }
+        reader_args[0] = start_id;
+        reader_args[1] = num_tiles_per_core;
+
+        reader_runtime_args.emplace_back(core, std::move(reader_args));
+        num_tiles_written += num_tiles_per_core;
+    }
+
+    tt::tt_metal::KernelDescriptor reader_kernel_desc;
+    reader_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/"
+        "reader_unary_unpad_dims_interleaved_start_id.cpp";
+    reader_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    reader_kernel_desc.core_ranges = all_cores;
+    reader_kernel_desc.compile_time_args = reader_compile_time_args;
+    reader_kernel_desc.named_compile_time_args = {{"cb_in", src0_cb_index}};
+    reader_kernel_desc.runtime_args = std::move(reader_runtime_args);
+    reader_kernel_desc.common_runtime_args = std::move(reader_common_args);
+    reader_kernel_desc.config = tt::tt_metal::ReaderConfigDescriptor{};
+    program_descriptor.kernels.push_back(std::move(reader_kernel_desc));
+
+    // --- Writer Kernel Descriptor ---
+    // CB index via named compile-time arg (essential for fusion CB remapping).
+    std::vector<uint32_t> writer_compile_time_args = {};
+    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+
+    // Writer per-core runtime args: [dst_addr, num_tiles, start_id]
+    tt::tt_metal::KernelDescriptor::RuntimeArgs writer_runtime_args;
+    num_tiles_written = 0;
+    for (const auto& core : corerange_to_cores(all_cores)) {
+        uint32_t num_tiles_per_core;
+        if (core_group_1.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_2;
+        } else {
+            // no-op core
+            writer_runtime_args.emplace_back(core, std::vector<uint32_t>{0, 0, 0});
+            continue;
+        }
+
+        writer_runtime_args.emplace_back(
+            core, std::vector<uint32_t>{dst_buffer->address(), num_tiles_per_core, num_tiles_written});
+        num_tiles_written += num_tiles_per_core;
+    }
+
+    tt::tt_metal::KernelDescriptor writer_kernel_desc;
+    writer_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/"
+        "writer_unary_interleaved_start_id.cpp";
+    writer_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    writer_kernel_desc.core_ranges = all_cores;
+    writer_kernel_desc.compile_time_args = writer_compile_time_args;
+    writer_kernel_desc.named_compile_time_args = {{"cb_out", src0_cb_index}};
+    writer_kernel_desc.runtime_args = std::move(writer_runtime_args);
+    writer_kernel_desc.config = tt::tt_metal::WriterConfigDescriptor{};
+    program_descriptor.kernels.push_back(std::move(writer_kernel_desc));
+
+    return program_descriptor;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_tile.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_tile.hpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/experimental/quasar/slice/device/slice_device_operation_types.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct SliceTileProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_tile_tensor_args.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_tile_tensor_args.cpp
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/experimental/quasar/slice/device/slice_device_operation.hpp"
+#include "ttnn/operations/experimental/quasar/slice/device/slice_program_factory_tile_tensor_args.hpp"
+
+#include <optional>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+
+tt::tt_metal::ProgramDescriptor SliceTileTensorArgsProgramFactory::create_descriptor(
+    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const auto& input_tensor = tensor_args.input;
+    const auto& start_tensor = tensor_args.start_tensor.value();
+    const auto& end_tensor = tensor_args.end_tensor.value();
+    tt::tt_metal::IDevice* device = input_tensor.device();
+    ProgramDescriptor desc;
+
+    uint32_t num_unpadded_tiles = output.physical_volume() / TILE_HW;
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+        args.sub_core_grids.has_value()
+            ? tt::tt_metal::split_work_to_cores(args.sub_core_grids.value(), num_unpadded_tiles)
+            : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_unpadded_tiles);
+
+    tt::tt_metal::Buffer* src_buffer = input_tensor.buffer();
+    tt::tt_metal::Buffer* start_buffer = start_tensor.buffer();
+    tt::tt_metal::Buffer* end_buffer = end_tensor.buffer();
+    tt::tt_metal::Buffer* dst_buffer = output.buffer();
+
+    TT_FATAL(src_buffer != nullptr, "Input buffer should be allocated on device!");
+    TT_FATAL(start_buffer != nullptr, "Start buffer should be allocated on device!");
+    TT_FATAL(end_buffer != nullptr, "End buffer should be allocated on device!");
+    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    uint32_t single_tile_size = tt::tile_size(cb_data_format);
+
+    constexpr uint8_t src0_cb_index = 0;
+    constexpr uint8_t tensor_cb_index = 1;
+    constexpr uint32_t num_input_tiles = 2;
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = tensor_cb_index,
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+    });
+
+    std::uint32_t num_dims = static_cast<std::uint32_t>(input_tensor.padded_shape().rank());
+    auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
+    uint32_t tile_width = tile_shape[1];
+    uint32_t tile_height = tile_shape[0];
+
+    std::vector<uint32_t> reader_compile_time_args = {
+        src0_cb_index, tensor_cb_index, num_dims, tile_width, tile_height};
+    TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*start_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*end_buffer).append_to(reader_compile_time_args);
+
+    std::vector<uint32_t> writer_compile_time_args = {src0_cb_index};
+    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+
+    // Reader common runtime args layout (matches kernel):
+    //   [src_addr, start_buf_addr, end_buf_addr,
+    //    num_unpadded_per_dim..., num_padded_per_dim..., input_shape...]
+    const auto& input_shape = input_tensor.padded_shape();
+    const auto& output_shape = output.padded_shape();
+    uint32_t num_unpadded_Xt = output_shape[-1] / TILE_WIDTH;
+    uint32_t num_total_Xt = input_shape[-1] / TILE_WIDTH;
+    uint32_t num_padded_Xt = num_total_Xt - num_unpadded_Xt;
+    uint32_t num_unpadded_Yt = output_shape[-2] / TILE_HEIGHT;
+    uint32_t num_total_Yt = input_shape[-2] / TILE_HEIGHT;
+    uint32_t num_padded_Yt = (num_total_Yt - num_unpadded_Yt) * num_total_Xt;
+
+    std::vector<uint32_t> accumulated_total_per_dim(num_dims);
+    accumulated_total_per_dim[0] = num_total_Xt;
+    accumulated_total_per_dim[1] = num_total_Yt * num_total_Xt;
+
+    std::vector<uint32_t> reader_common_args(3 + (num_dims * 3));
+    reader_common_args[0] = src_buffer->address();
+    reader_common_args[1] = start_buffer->address();
+    reader_common_args[2] = end_buffer->address();
+    uint32_t* num_unpadded_tiles_per_dim = reader_common_args.data() + 3;
+    uint32_t* num_padded_tiles_per_dim = num_unpadded_tiles_per_dim + num_dims;
+    uint32_t* input_shape_args = num_padded_tiles_per_dim + num_dims;
+    num_unpadded_tiles_per_dim[0] = num_unpadded_Xt;
+    num_unpadded_tiles_per_dim[1] = num_unpadded_Yt;
+    num_padded_tiles_per_dim[0] = num_padded_Xt;
+    num_padded_tiles_per_dim[1] = num_padded_Yt;
+    for (int32_t i = 2; i < static_cast<int32_t>(num_dims); ++i) {
+        uint32_t num_unpadded_dim = output_shape[-(i + 1)];
+        uint32_t num_total_dim = input_shape[-(i + 1)];
+        uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
+        num_unpadded_tiles_per_dim[i] = num_unpadded_dim;
+        num_padded_tiles_per_dim[i] = num_padded_dim;
+        accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
+    }
+    for (int32_t i = 0; i < static_cast<int32_t>(num_dims); ++i) {
+        input_shape_args[i] = input_shape[i];
+    }
+
+    // Reader per-core runtime args: [start_id, num_tiles, id_per_dim...]
+    // Writer per-core runtime args: [dst_addr, num_tiles, start_id]
+    constexpr uint32_t start_offset = 0;
+    KernelDescriptor::RuntimeArgs reader_runtime_args;
+    KernelDescriptor::RuntimeArgs writer_runtime_args;
+    uint32_t num_tiles_written = 0;
+    for (const auto& core : corerange_to_cores(all_cores)) {
+        uint32_t num_tiles_per_core;
+        if (core_group_1.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_2;
+        } else {
+            // no-op core
+            std::vector<uint32_t> reader_args(2 + num_dims, 0);
+            reader_runtime_args.emplace_back(core, std::move(reader_args));
+            writer_runtime_args.emplace_back(core, std::vector<uint32_t>{0, 0, 0});
+            continue;
+        }
+
+        std::vector<uint32_t> reader_args(2 + num_dims);
+        reader_args[2] = num_tiles_written % num_unpadded_tiles_per_dim[0];
+        uint32_t unpadded_written = num_tiles_written / num_unpadded_tiles_per_dim[0];
+        uint32_t start_id = reader_args[2] + start_offset;
+        for (uint32_t j = 1; j < num_dims; ++j) {
+            reader_args[2 + j] = unpadded_written % num_unpadded_tiles_per_dim[j];
+            unpadded_written = unpadded_written / num_unpadded_tiles_per_dim[j];
+            start_id += reader_args[2 + j] * accumulated_total_per_dim[j - 1];
+        }
+        reader_args[0] = start_id;
+        reader_args[1] = num_tiles_per_core;
+
+        reader_runtime_args.emplace_back(core, std::move(reader_args));
+        writer_runtime_args.emplace_back(
+            core, std::vector<uint32_t>{dst_buffer->address(), num_tiles_per_core, num_tiles_written});
+        num_tiles_written += num_tiles_per_core;
+    }
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/"
+        "reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.runtime_args = std::move(reader_runtime_args);
+    reader_desc.common_runtime_args = std::move(reader_common_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+    desc.kernels.push_back(std::move(reader_desc));
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.runtime_args = std::move(writer_runtime_args);
+    writer_desc.config = WriterConfigDescriptor{};
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_tile_tensor_args.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_tile_tensor_args.hpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "ttnn/operations/experimental/quasar/slice/device/slice_device_operation_types.hpp"
+#include "ttnn/device_operation.hpp"
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace ttnn::prim::qsr {
+
+struct SliceTileTensorArgsProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/slice.cpp
@@ -1,0 +1,562 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/experimental/quasar/slice/slice.hpp"
+#include "ttnn/operations/experimental/quasar/slice/device/slice_device_operation.hpp"
+#include "ttnn/operations/data_movement/common/common.hpp"
+#include "ttnn/operations/data_movement/copy/copy.hpp"
+#include "ttnn/operations/experimental/reshape/view.hpp"
+#include "ttnn/operations/data_movement/fill_pad/fill_pad.hpp"
+#include "ttnn/operations/data_movement/transpose/device/transpose_utils.hpp"
+#include "ttnn/operations/creation/creation.hpp"
+#include "ttnn/operations/core/core.hpp"
+
+#include <tt-metalium/constants.hpp>
+
+namespace ttnn::operations::experimental::quasar {
+
+namespace detail {
+
+inline bool is_rm_bw_sharded(const tt::tt_metal::MemoryConfig& mc) {
+    const auto layout = mc.memory_layout();
+    return mc.is_sharded() && (layout == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED ||
+                               layout == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED);
+}
+
+// RM constraint, not TILE: `noc_async_*_sharded` derives pages_per_row from the padded shape,
+// so non-tile-multiple H/W overshoots.
+inline bool has_nontile_hw(const ttnn::Tensor& input) {
+    const auto& s = input.logical_shape();
+    if (s.rank() < 2) {
+        return false;
+    }
+    return s[-1] % tt::constants::TILE_WIDTH != 0 || s[-2] % tt::constants::TILE_HEIGHT != 0;
+}
+
+// For B/W-sharded buffers the NOC helper splits by W only; irregular H alone is fine natively.
+inline bool has_nontile_w(const ttnn::Tensor& input) {
+    const auto& s = input.logical_shape();
+    return s.rank() >= 1 && s[-1] % tt::constants::TILE_WIDTH != 0;
+}
+
+// Route RM sharded input through composite when native isn't safe: nontile-aligned B/W,
+// B/W with non-zero width-begin, or nontile-aligned HEIGHT outside the sharded fast path.
+inline bool needs_rm_composite_input(
+    const ttnn::Tensor& input, const tt::tt_metal::MemoryConfig& output_mc, bool no_step, bool width_begin_nonzero) {
+    if (input.layout() != Layout::ROW_MAJOR || !input.is_sharded()) {
+        return false;
+    }
+    if (is_rm_bw_sharded(input.memory_config())) {
+        // Only W misalignment breaks the per-shard page split; irregular H is fine.
+        return has_nontile_w(input) || width_begin_nonzero;
+    }
+    // Require a spec: no-spec HEIGHT output triggers needs_sharded_output_reshard → composite anyway.
+    const bool stays_on_sharded_fast_path =
+        output_mc.is_sharded() && output_mc.shard_spec().has_value() &&
+        output_mc.memory_layout() == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED && no_step;
+    return has_nontile_hw(input) && !stays_on_sharded_fast_path;
+}
+
+// Compose RM B/W-sharded output only on nontile-aligned W (irregular H is fine natively).
+inline bool needs_rm_composite_output(const ttnn::Tensor& input, const tt::tt_metal::MemoryConfig& output_mc) {
+    if (input.layout() != Layout::ROW_MAJOR || !is_rm_bw_sharded(output_mc)) {
+        return false;
+    }
+    return has_nontile_w(input);
+}
+
+// Sharded-no-spec output that can't seed from the input (not sharded, or layout differs);
+// synthesize from the sliced shape.
+inline bool needs_sharded_output_reshard(const ttnn::Tensor& input, const tt::tt_metal::MemoryConfig& output_mc) {
+    if (!output_mc.is_sharded() || output_mc.shard_spec().has_value()) {
+        return false;
+    }
+    if (!input.is_sharded()) {
+        return true;
+    }
+    return input.memory_config().memory_layout() != output_mc.memory_layout();
+}
+
+}  // namespace detail
+
+template <typename T>
+ttnn::Tensor slice(
+    const ttnn::Tensor& input_tensor,
+    ttsl::Span<const T> begins,
+    ttsl::Span<const T> ends,
+    ttsl::Span<const T> step,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<float>& pad_value,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
+    // Ensure start and end vectors have matching sizes and correct tensor rank
+
+    const auto& input_shape = input_tensor.logical_shape();
+    uint32_t input_rank = input_shape.rank();
+    auto input_layout = input_tensor.layout();
+
+    if (input_rank == 0) {
+        return input_tensor;
+    }
+    TT_FATAL(
+        input_rank == begins.size(), "Input rank {} and begins {} must have the same size", input_rank, begins.size());
+    TT_FATAL(begins.size() == ends.size(), "Start {} and end {} must have the same size", begins.size(), ends.size());
+    TT_FATAL(
+        step.size() == begins.size(),
+        "Step {} must have the same size as start {} and end",
+        step.size(),
+        begins.size());
+
+    bool no_step = std::ranges::all_of(step, [](uint32_t s) { return s == 1; });
+    bool starts_zero = std::ranges::all_of(begins, [](uint32_t s) { return s == 0; });
+    bool ends_max = true;
+    for (size_t i = 0; i < ends.size(); ++i) {
+        ends_max &= ends[i] == input_shape[i];
+        if (!ends_max) {
+            break;
+        }
+    }
+
+    const auto& tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
+
+    auto memory_config = optional_output_tensor.has_value() ? optional_output_tensor.value().memory_config()
+                                                            : memory_config_arg.value_or(input_tensor.memory_config());
+    // memory_config: original (input-compatible) config, used by to_layout in the rm_only path.
+    // output_memory_config: may be rescaled below to match the sliced output dims.
+    auto output_memory_config = memory_config;
+
+    // Fill in a missing shard_spec on a sharded output: reuse source's if layouts match, else
+    // synthesize from the source shape.
+    auto resolve_mc = [&](const ttnn::Tensor& source) {
+        auto resolved_mc = output_memory_config;
+        if (resolved_mc.is_sharded() && !resolved_mc.shard_spec().has_value()) {
+            const auto& in_mc = source.memory_config();
+            if (in_mc.is_sharded() && in_mc.memory_layout() == resolved_mc.memory_layout() &&
+                in_mc.shard_spec().has_value()) {
+                resolved_mc =
+                    ttnn::MemoryConfig(resolved_mc.memory_layout(), resolved_mc.buffer_type(), in_mc.shard_spec());
+            } else {
+                auto spec = operations::data_movement::transpose::generate_transpose_shard_spec(
+                    source, source.padded_shape(), resolved_mc.memory_layout());
+                resolved_mc = ttnn::MemoryConfig(resolved_mc.memory_layout(), resolved_mc.buffer_type(), spec);
+            }
+        }
+        return resolved_mc;
+    };
+
+    // True when the next to_memory_config can land directly in the preallocated buffer: layouts
+    // must match (prim::copy validates equality) and source must not alias the preallocated.
+    auto can_land_in_preallocated = [&](const ttnn::Tensor& source) {
+        return optional_output_tensor.has_value() && source.storage_type() == StorageType::DEVICE &&
+               source.layout() == optional_output_tensor->layout() &&
+               source.buffer() != optional_output_tensor->buffer();
+    };
+    // Safety net for paths that bypass the device op (composite / no-op / rm_only layout fixup):
+    // short-circuits by buffer identity, falls back to ttnn::copy when result != preallocated.
+    auto finalize_into_preallocated = [&](const ttnn::Tensor& result) -> ttnn::Tensor {
+        if (!optional_output_tensor.has_value() || result.storage_type() != StorageType::DEVICE) {
+            return result;
+        }
+        const auto& dst = optional_output_tensor.value();
+        if (result.buffer() == dst.buffer()) {
+            return result;
+        }
+        return ttnn::copy(result, dst);
+    };
+
+    auto ret_adjustment([&](const ttnn::Tensor& source) {
+        if (source.storage_type() != StorageType::DEVICE) {
+            return source;
+        }
+        // source carries the correct shard spec (input for no-op, prim::slice result otherwise).
+        const auto resolved_mc = resolve_mc(source);
+        const auto target = can_land_in_preallocated(source) ? optional_output_tensor : std::nullopt;
+        auto tensor = ttnn::to_memory_config(source, resolved_mc, std::nullopt, target);
+        tensor = ttnn::to_layout(tensor, input_layout);
+        return tensor;
+    });
+
+    // No-op check
+    if (no_step && starts_zero && ends_max) {
+        return finalize_into_preallocated(ret_adjustment(input_tensor));
+    }
+
+    // Composite hop: unshard to L1 interleaved if needed, slice, then convert to the requested mc.
+    const bool width_begin_nonzero = !begins.empty() && begins.back() != 0;
+    const bool rm_in_bad =
+        detail::needs_rm_composite_input(input_tensor, output_memory_config, no_step, width_begin_nonzero);
+    const bool rm_out_bad = detail::needs_rm_composite_output(input_tensor, output_memory_config);
+    const bool out_no_spec = detail::needs_sharded_output_reshard(input_tensor, output_memory_config);
+    if (rm_in_bad || rm_out_bad || out_no_spec) {
+        const auto interleaved_l1 =
+            tt::tt_metal::MemoryConfig(tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::L1);
+        Tensor x = rm_in_bad ? ttnn::to_memory_config(input_tensor, interleaved_l1, std::nullopt) : input_tensor;
+        // Intermediate lives in L1 interleaved; to_memory_config lands the result in the caller's
+        // buffer. sub_core_grids is threaded through to bound the recursive slice's work split.
+        auto sliced = slice<T>(x, begins, ends, step, interleaved_l1, std::nullopt, pad_value, sub_core_grids);
+        // slice preserves layout and to_memory_config doesn't change it — no trailing to_layout needed.
+        // sliced is L1-interleaved so resolve_mc falls through to generate_transpose_shard_spec.
+        const auto final_mc = resolve_mc(sliced);
+        if (sliced.memory_config() == final_mc) {
+            return finalize_into_preallocated(sliced);
+        }
+        const auto target = can_land_in_preallocated(sliced) ? optional_output_tensor : std::nullopt;
+        return finalize_into_preallocated(ttnn::to_memory_config(sliced, final_mc, std::nullopt, target));
+    }
+
+    // Create modified vectors with wrapped indices and adjust them to match the tensor's rank
+    ttnn::SmallVector<uint32_t> modified_begins(input_rank, 0);
+    ttnn::SmallVector<uint32_t> modified_ends(input_rank, 0);
+    ttnn::SmallVector<uint32_t> modified_step(input_rank, 1);
+
+    // Wrap indices and adjust begins, ends, and step
+    for (size_t i = 0; i < begins.size(); ++i) {
+        if constexpr (std::is_signed_v<T>) {
+            modified_begins[i] = operations::data_movement::wrap_index(begins[i], input_shape[i]);
+            modified_ends[i] = operations::data_movement::wrap_index(ends[i], input_shape[i]);
+            modified_step[i] = static_cast<uint32_t>(step[i]);
+        } else {
+            modified_begins[i] = begins[i];
+            modified_ends[i] = ends[i];
+            modified_step[i] = step[i];
+        }
+    }
+
+    auto output_dim_i = [&modified_begins, &modified_step](size_t i, const ttnn::SmallVector<uint32_t>& modified_ends) {
+        return (modified_ends[i] - modified_begins[i] + modified_step[i] - 1) / modified_step[i];
+    };
+
+    auto check_handled_tile_alignment = [&modified_begins, &input_rank, &tile_shape]() -> bool {
+        return (
+            modified_begins[input_rank - 1] % tile_shape[1] == 0 &&
+            modified_begins[input_rank - 2] % tile_shape[0] == 0);
+    };
+
+    bool rm_only = false;
+    bool one_dimensional = input_rank == 1;
+    bool handled_tile_alignment = one_dimensional ? true : check_handled_tile_alignment();
+
+    Tensor input = input_tensor;
+    // Use the RM path when input isn't TILE, or TILE input has strided/1D/non-tile-aligned begins
+    // (ends are padded downstream, so only begin alignment matters).
+    rm_only = (input_tensor.layout() != Layout::TILE) || (!no_step || one_dimensional || !handled_tile_alignment);
+
+    // Implicit inheritance from a sharded input: rescale the shard spec to the sliced shape so the
+    // output doesn't reuse the input's (oversized) spec. Covers HEIGHT/WIDTH/BLOCK. (Issue #38016)
+    if (!memory_config_arg.has_value() && !optional_output_tensor.has_value() && input_tensor.is_sharded() &&
+        input_rank >= 2) {
+        const auto& mem_layout = output_memory_config.memory_layout();
+        if (mem_layout == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED ||
+            mem_layout == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED ||
+            mem_layout == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED) {
+            const auto& shard_spec_val = output_memory_config.shard_spec().value();
+
+            // Compute output dimensions, tile-aligned if using TILE path
+            ttnn::SmallVector<uint32_t> output_dims(input_rank);
+            for (size_t i = 0; i < input_rank; i++) {
+                output_dims[i] = output_dim_i(i, modified_ends);
+            }
+            if (!rm_only) {
+                output_dims[input_rank - 2] =
+                    std::max(tt::round_up(output_dims[input_rank - 2], tile_shape[0]), tile_shape[0]);
+                output_dims[input_rank - 1] =
+                    std::max(tt::round_up(output_dims[input_rank - 1], tile_shape[1]), tile_shape[1]);
+            }
+
+            // Flatten to 2D: height = product of all dims except last, width = last dim
+            uint32_t output_height = 1;
+            for (size_t i = 0; i + 1 < input_rank; i++) {
+                output_height *= output_dims[i];
+            }
+            uint32_t output_width = output_dims[input_rank - 1];
+
+            std::array<uint32_t, 2> new_shard_shape = shard_spec_val.shape;
+            if (mem_layout == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED) {
+                uint32_t num_cores = shard_spec_val.num_cores();
+                uint32_t new_shard_h = tt::div_up(output_height, num_cores);
+                if (!rm_only) {
+                    new_shard_h = std::max(tt::round_up(new_shard_h, tile_shape[0]), tile_shape[0]);
+                }
+                new_shard_shape = {new_shard_h, output_width};
+            } else if (mem_layout == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED) {
+                uint32_t num_cores = shard_spec_val.num_cores();
+                uint32_t new_shard_w = tt::div_up(output_width, num_cores);
+                if (!rm_only) {
+                    new_shard_w = std::max(tt::round_up(new_shard_w, tile_shape[1]), tile_shape[1]);
+                }
+                new_shard_shape = {output_height, new_shard_w};
+            } else {
+                // BLOCK_SHARDED requires a rectangular grid; bounding_box() is valid only then.
+                const auto bbox = shard_spec_val.grid.bounding_box();
+                const uint32_t grid_h = bbox.end_coord.y - bbox.start_coord.y + 1;
+                const uint32_t grid_w = bbox.end_coord.x - bbox.start_coord.x + 1;
+                TT_FATAL(
+                    shard_spec_val.num_cores() == grid_h * grid_w,
+                    "BLOCK_SHARDED grid must be a full rectangle; got {} cores for {}x{} bounding box",
+                    shard_spec_val.num_cores(),
+                    grid_h,
+                    grid_w);
+                uint32_t new_shard_h = tt::div_up(output_height, grid_h);
+                uint32_t new_shard_w = tt::div_up(output_width, grid_w);
+                if (!rm_only) {
+                    new_shard_h = std::max(tt::round_up(new_shard_h, tile_shape[0]), tile_shape[0]);
+                    new_shard_w = std::max(tt::round_up(new_shard_w, tile_shape[1]), tile_shape[1]);
+                }
+                new_shard_shape = {new_shard_h, new_shard_w};
+            }
+
+            if (new_shard_shape != shard_spec_val.shape) {
+                auto new_shard_spec =
+                    tt::tt_metal::ShardSpec(shard_spec_val.grid, new_shard_shape, shard_spec_val.orientation);
+                output_memory_config = MemoryConfig(
+                    output_memory_config.memory_layout(), output_memory_config.buffer_type(), new_shard_spec);
+            }
+        }
+    }
+
+    if (rm_only) {
+        if (!no_step) {
+            TT_FATAL(input.dtype() != DataType::BFLOAT8_B, "Strided slice is not supported for BFLOAT8 tensors");
+        }
+        input = ttnn::to_layout(input, Layout::ROW_MAJOR, std::nullopt, memory_config);
+    }
+
+    ttnn::SmallVector<uint32_t> padded_ends = modified_ends;
+    if (input.layout() == Layout::TILE) {
+        padded_ends[input_rank - 2] = std::max(tt::round_up(padded_ends[input_rank - 2], tile_shape[0]), tile_shape[0]);
+        padded_ends[input_rank - 1] = std::max(tt::round_up(padded_ends[input_rank - 1], tile_shape[1]), tile_shape[1]);
+    }
+
+    ttnn::SmallVector<uint32_t> actual_shape_vec, final_padded_shape_vec;
+    actual_shape_vec.reserve(input_rank);
+    final_padded_shape_vec.reserve(input_rank);
+    bool empty = false;
+
+    // Compute actual and padded shapes for the original input rank
+    for (size_t i = 0; i < input_rank; ++i) {
+        TT_FATAL(
+            modified_ends[i] >= modified_begins[i],
+            "End {} must be greater than or equal to start {}",
+            modified_ends[i],
+            modified_begins[i]);
+        auto val = output_dim_i(i, modified_ends);
+        if (val == 0) {
+            empty = true;
+        }
+        actual_shape_vec.push_back(val);
+        final_padded_shape_vec.push_back(std::max(output_dim_i(i, padded_ends), static_cast<uint32_t>(1)));
+    }
+    ttnn::Shape actual_shape(actual_shape_vec);
+    ttnn::Shape final_padded_shape(final_padded_shape_vec);
+
+    if (empty) {
+        TT_FATAL(
+            input.storage_type() == StorageType::DEVICE, "Host tensor slice cannot return a scalar or empty tensor");
+        if (optional_output_tensor.has_value()) {
+            return optional_output_tensor.value();
+        }
+        return ttnn::empty(
+            actual_shape,
+            input_tensor.dtype(),
+            input_tensor.layout(),
+            input_tensor.device(),
+            memory_config_arg.value_or(input_tensor.memory_config()));
+    }
+    auto res = ttnn::prim::qsr::slice(
+        input,
+        ttnn::Shape(modified_begins),
+        ttnn::Shape(padded_ends),
+        ttnn::Shape(modified_step),
+        output_memory_config,
+        /*use_tensor_args*/ false,
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        sub_core_grids,
+        optional_output_tensor);
+    res = ttnn::experimental::view(res, actual_shape, final_padded_shape);
+
+    auto dim_needs_fill = [&input_shape, &actual_shape, &final_padded_shape](int i) {
+        return ((actual_shape[i] != final_padded_shape[i]) && (input_shape[i] != actual_shape[i]));
+    };
+
+    if (pad_value.has_value() && (dim_needs_fill(-1) || dim_needs_fill(-2))) {
+        res = ttnn::fill_implicit_tile_padding(res, pad_value.value());
+    }
+
+    // ret_adjustment may re-allocate (rm_only-from-TILE); finalize guarantees the caller's buffer.
+    return finalize_into_preallocated(ret_adjustment(res));
+}
+
+template <typename T, std::size_t N>
+ttnn::Tensor slice(
+    const ttnn::Tensor& input_tensor,
+    const std::array<T, N>& output_tensor_start,
+    const std::array<T, N>& output_tensor_end,
+    const std::array<T, N>& step,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<float>& pad_value,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
+    ttsl::Span<const T> start(output_tensor_start.begin(), output_tensor_start.end());
+    ttsl::Span<const T> end(output_tensor_end.begin(), output_tensor_end.end());
+    ttsl::Span<const T> step_vec(step.begin(), step.end());
+    return slice<T>(
+        input_tensor, start, end, step_vec, memory_config_arg, optional_output_tensor, pad_value, sub_core_grids);
+}
+
+template <typename T>
+ttnn::Tensor slice(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& output_tensor_start,
+    const ttnn::Tensor& output_tensor_end,
+    const std::optional<ttnn::SmallVector<T>>& step,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<float>& pad_value,
+    const std::optional<uint32_t>& slice_dim,
+    const std::optional<uint32_t>& num_devices,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
+    TT_FATAL(
+        output_tensor_start.logical_shape().rank() == 1,
+        "The start tensor for slicing must be in 1D shape, but got {}D",
+        output_tensor_start.logical_shape().rank());
+    TT_FATAL(
+        output_tensor_end.logical_shape().rank() == 1,
+        "The end tensor for slicing must be in 1D shape, but got {}D",
+        output_tensor_end.logical_shape().rank());
+
+    // Check if we can use the device-only tensor args path
+    bool use_device_only_path = true;
+
+    // Check if layout is supported (only TILE layout for now)
+    if (input_tensor.layout() != Layout::TILE) {
+        use_device_only_path = false;
+    }
+
+    // Check if step > 1 (only step=1 supported for now)
+    if (step.has_value()) {
+        for (auto s : step.value()) {
+            if (s != 1) {
+                use_device_only_path = false;
+                break;
+            }
+        }
+    }
+
+    // Validate tensors are on device for both paths
+    TT_FATAL(
+        input_tensor.storage_type() == StorageType::DEVICE, "Input tensor must be on device for tensor args slice");
+
+    auto memory_config = optional_output_tensor.has_value() ? optional_output_tensor.value().memory_config()
+                                                            : memory_config_arg.value_or(input_tensor.memory_config());
+
+    if (use_device_only_path) {
+        // Validate required parameters for device-only path
+        TT_FATAL(
+            slice_dim.has_value() && num_devices.has_value(),
+            "slice_dim and num_devices must be provided for device-only tensor args slice");
+
+        TT_FATAL(
+            output_tensor_start.storage_type() == StorageType::DEVICE,
+            "Start tensor must be on device for tensor args slice");
+        TT_FATAL(
+            output_tensor_end.storage_type() == StorageType::DEVICE,
+            "End tensor must be on device for tensor args slice");
+
+        // Create dummy shapes for SliceDeviceOperation (will be ignored when use_tensor_args=true)
+        uint32_t input_rank = input_tensor.logical_shape().rank();
+        ttnn::SmallVector<uint32_t> dummy_shape(input_rank, 0);
+        ttnn::SmallVector<uint32_t> dummy_step_shape(input_rank, 1);
+        ttnn::Shape dummy_start(dummy_shape);
+        ttnn::Shape dummy_end(dummy_shape);
+        ttnn::Shape dummy_step(dummy_step_shape);
+
+        // Use slice device operation with tensor args flag
+        std::optional<Tensor> start_opt = output_tensor_start;
+        std::optional<Tensor> end_opt = output_tensor_end;
+
+        auto res = ttnn::prim::qsr::slice(
+            input_tensor,
+            dummy_start,
+            dummy_end,
+            dummy_step,
+            memory_config,
+            /*use_tensor_args*/ true,
+            start_opt,
+            end_opt,
+            slice_dim,
+            num_devices,
+            sub_core_grids,
+            optional_output_tensor);
+        return res;
+    }  // convert the Tensor to Vector
+    std::vector<T> output_tensor_start_vector = output_tensor_start.to_vector<T>();
+    std::vector<T> output_tensor_end_vector = output_tensor_end.to_vector<T>();
+
+    // convert the Vector to Span
+    ttsl::Span<const T> output_tensor_start_span(output_tensor_start_vector.data(), output_tensor_start_vector.size());
+    ttsl::Span<const T> output_tensor_end_span(output_tensor_end_vector.data(), output_tensor_end_vector.size());
+
+    // generate the step value if it is not provided
+    ttnn::SmallVector<T> step_value = step.value_or(ttnn::SmallVector<T>(output_tensor_start_span.size(), 1));
+
+    return slice<T>(
+        input_tensor,
+        output_tensor_start_span,
+        output_tensor_end_span,
+        ttsl::Span<const T>(step_value),
+        memory_config_arg,
+        optional_output_tensor,
+        pad_value,
+        sub_core_grids);
+}
+
+// Template instantiations for ttnn::slice
+template ttnn::Tensor slice<int32_t>(
+    const ttnn::Tensor& input_tensor,
+    ttsl::Span<const int32_t> begins,
+    ttsl::Span<const int32_t> ends,
+    ttsl::Span<const int32_t> step,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<float>& pad_value,
+    const std::optional<CoreRangeSet>& sub_core_grids);
+
+template ttnn::Tensor slice<uint32_t>(
+    const ttnn::Tensor& input_tensor,
+    ttsl::Span<const uint32_t> begins,
+    ttsl::Span<const uint32_t> ends,
+    ttsl::Span<const uint32_t> step,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<float>& pad_value,
+    const std::optional<CoreRangeSet>& sub_core_grids);
+
+// Template instantiations for std::array version
+template ttnn::Tensor slice<uint32_t, 4>(
+    const ttnn::Tensor& input_tensor,
+    const std::array<uint32_t, 4>& output_tensor_start,
+    const std::array<uint32_t, 4>& output_tensor_end,
+    const std::array<uint32_t, 4>& step,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<float>& pad_value,
+    const std::optional<CoreRangeSet>& sub_core_grids);
+
+// Template instantiations for Tensor version
+template ttnn::Tensor slice<uint32_t>(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& output_tensor_start,
+    const ttnn::Tensor& output_tensor_end,
+    const std::optional<ttnn::SmallVector<uint32_t>>& step,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<float>& pad_value,
+    const std::optional<uint32_t>& slice_dim,
+    const std::optional<uint32_t>& num_devices,
+    const std::optional<CoreRangeSet>& sub_core_grids);
+
+}  // namespace ttnn::operations::experimental::quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/slice.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/slice.hpp
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::experimental::quasar {
+
+// Primary template function declarations
+template <typename T>
+ttnn::Tensor slice(
+    const ttnn::Tensor& input_tensor,
+    ttsl::Span<const T> begins,
+    ttsl::Span<const T> ends,
+    ttsl::Span<const T> step,
+    const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    const std::optional<float>& pad_value = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+
+template <typename T>
+ttnn::Tensor slice(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::SmallVector<T>& begins,
+    const ttnn::SmallVector<T>& ends,
+    const ttnn::SmallVector<T>& step,
+    const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    const std::optional<float>& pad_value = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt) {
+    return slice(
+        input_tensor,
+        ttsl::Span<const T>(begins),
+        ttsl::Span<const T>(ends),
+        ttsl::Span<const T>(step),
+        memory_config_arg,
+        optional_output_tensor,
+        pad_value,
+        sub_core_grids);
+}
+
+template <typename T, std::size_t N>
+ttnn::Tensor slice(
+    const ttnn::Tensor& input_tensor,
+    const std::array<T, N>& output_tensor_start,
+    const std::array<T, N>& output_tensor_end,
+    const std::array<T, N>& step,
+    const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    const std::optional<float>& pad_value = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+
+template <typename T>
+ttnn::Tensor slice(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& output_tensor_start,
+    const ttnn::Tensor& output_tensor_end,
+    const std::optional<ttnn::SmallVector<T>>& step = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    const std::optional<float>& pad_value = std::nullopt,
+    const std::optional<uint32_t>& slice_dim = std::nullopt,
+    const std::optional<uint32_t>& num_devices = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+
+}  // namespace ttnn::operations::experimental::quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/slice_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/slice_nanobind.cpp
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "slice_nanobind.hpp"
+
+#include <array>
+#include <cstdint>
+#include <optional>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/array.h>
+#include <nanobind/stl/optional.h>
+
+#include "ttnn-nanobind/small_vector_caster.hpp"
+#include "ttnn-nanobind/bind_function.hpp"
+
+#include "slice.hpp"
+#include "ttnn/operations/experimental/quasar/slice/device/slice_device_operation.hpp"
+#include "ttnn/operations/experimental/quasar/slice/device/slice_program_factory_tile.hpp"
+
+namespace ttnn::operations::experimental::quasar::detail {
+
+namespace {
+
+ttnn::Tensor slice_small_vector_wrapper(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::SmallVector<int>& slice_start,
+    const ttnn::SmallVector<int>& slice_end,
+    const std::optional<ttnn::SmallVector<int>>& step,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<float>& pad_value,
+    const std::optional<CoreRangeSet>&& sub_core_grids) {
+    const auto step_value = step.value_or(ttnn::SmallVector<int>(slice_end.size(), 1));
+    return ttnn::operations::experimental::quasar::slice(
+        input_tensor,
+        slice_start,
+        slice_end,
+        step_value,
+        memory_config,
+        optional_output_tensor,
+        pad_value,
+        sub_core_grids);
+}
+
+}  // namespace
+
+void bind_slice(nb::module_& mod) {
+    const auto* doc = R"doc(
+        Returns a sliced tensor. If the input tensor is on host, the slice will be performed on host, and if its on device it will be performed on device.
+
+        Args:
+            input_tensor (ttnn.Tensor): Input tensor.
+            slice_start (List[int]): Start indices of input tensor. Values along each dim must be in ``[0, input_tensor_shape[i])``.
+            slice_end (List[int]): End indices of input tensor (exclusive). Values along each dim must be in ``(0, input_tensor_shape[i]]``.
+            slice_step (List[int], optional): Step size for each dim. Defaults to ``None`` (step = 1 for all dims).
+
+        Keyword Args:
+            memory_config (ttnn.MemoryConfig, optional): Memory configuration for the output tensor. Defaults to the input tensor's memory config.
+            output_tensor (ttnn.Tensor, optional): Pre-allocated output tensor. Its shape must match the slice output. Defaults to ``None``.
+            pad_value (float, optional): Fill value for implicit tile padding on tiled tensors. Padding is undefined by default.
+            sub_core_grids (ttnn.CoreRangeSet, optional): sub core grids for the operation. Defaults to `None`.
+
+        Note:
+            Strided slicing (``slice_step != 1``) is not supported for ``bfloat8_b`` tensors.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+    )doc";
+
+    // TODO: implementing the array version and overloading the nanobind with all the possible array sizes is better
+    // than a vector with a fixed size default value
+    ttnn::bind_function<"slice">(
+        mod,
+        doc,
+        // Overload 1: Tensor args version (uint32_t template parameter)
+        ttnn::overload_t(
+            nb::overload_cast<
+                const ttnn::Tensor&,
+                const ttnn::Tensor&,
+                const ttnn::Tensor&,
+                const std::optional<ttnn::SmallVector<uint32_t>>&,
+                const std::optional<MemoryConfig>&,
+                const std::optional<Tensor>&,
+                const std::optional<float>&,
+                const std::optional<uint32_t>&,
+                const std::optional<uint32_t>&,
+                const std::optional<CoreRangeSet>&>(&ttnn::operations::experimental::quasar::slice<uint32_t>),
+            nb::arg("input_tensor"),
+            nb::arg("starts"),
+            nb::arg("ends"),
+            nb::arg("slice_step") = nb::none(),
+            nb::kw_only(),
+            nb::arg("memory_config") = nb::none(),
+            nb::arg("output_tensor") = nb::none(),
+            nb::arg("pad_value") = nb::none(),
+            nb::arg("slice_dim") = nb::none(),
+            nb::arg("num_devices") = nb::none(),
+            nb::arg("sub_core_grids") = nb::none()),
+        // Overload 2: std::array version (uint32_t template parameter, size 4)
+        ttnn::overload_t(
+            nb::overload_cast<
+                const ttnn::Tensor&,
+                const std::array<uint32_t, 4>&,
+                const std::array<uint32_t, 4>&,
+                const std::array<uint32_t, 4>&,
+                const std::optional<MemoryConfig>&,
+                const std::optional<Tensor>&,
+                const std::optional<float>&,
+                const std::optional<CoreRangeSet>&>(&ttnn::operations::experimental::quasar::slice<uint32_t, 4>),
+            nb::arg("input_tensor"),
+            nb::arg("starts"),
+            nb::arg("ends"),
+            nb::arg("steps"),
+            nb::kw_only(),
+            nb::arg("memory_config") = nb::none(),
+            nb::arg("output_tensor") = nb::none(),
+            nb::arg("pad_value") = nb::none(),
+            nb::arg("sub_core_grids") = nb::none()),
+        // Overload 3: SmallVector<int> version (int32_t template parameter)
+        ttnn::overload_t(
+            &slice_small_vector_wrapper,
+            nb::arg("input_tensor"),
+            nb::arg("slice_start"),
+            nb::arg("slice_end"),
+            nb::arg("slice_step") = nb::none(),
+            nb::kw_only(),
+            nb::arg("memory_config") = nb::none(),
+            nb::arg("output_tensor") = nb::none(),
+            nb::arg("pad_value") = nb::none(),
+            nb::arg("sub_core_grids") = nb::none()));
+}
+void bind_slice_descriptor(nb::module_& mod) {
+    nb::class_<ttnn::prim::qsr::SliceParams>(mod, "SliceParams")
+        .def(nb::init<>())
+        .def_rw("slice_start", &ttnn::prim::qsr::SliceParams::slice_start)
+        .def_rw("slice_end", &ttnn::prim::qsr::SliceParams::slice_end)
+        .def_rw("step", &ttnn::prim::qsr::SliceParams::step)
+        .def_rw("output_mem_config", &ttnn::prim::qsr::SliceParams::output_mem_config)
+        .def_rw("sub_core_grids", &ttnn::prim::qsr::SliceParams::sub_core_grids);
+
+    nb::class_<ttnn::prim::qsr::SliceInputs>(mod, "SliceInputs")
+        .def(
+            "__init__",
+            [](ttnn::prim::qsr::SliceInputs* t, const ttnn::Tensor& input) {
+                new (t) ttnn::prim::qsr::SliceInputs{input, std::nullopt, std::nullopt, std::nullopt};
+            },
+            nb::arg("input"))
+        .def_rw("input", &ttnn::prim::qsr::SliceInputs::input)
+        .def_rw("preallocated_output", &ttnn::prim::qsr::SliceInputs::preallocated_output);
+
+    nb::class_<ttnn::prim::qsr::SliceDeviceOperation>(mod, "SliceDeviceOperation")
+        .def_static(
+            "create_output_tensors",
+            &ttnn::prim::qsr::SliceDeviceOperation::create_output_tensors,
+            nb::arg("operation_attributes"),
+            nb::arg("tensor_args"))
+        .def_static(
+            "compute_output_specs",
+            &ttnn::prim::qsr::SliceDeviceOperation::compute_output_specs,
+            nb::arg("operation_attributes"),
+            nb::arg("tensor_args"));
+
+    nb::class_<ttnn::prim::qsr::SliceTileProgramFactory>(mod, "SliceTileProgramFactory")
+        .def_static(
+            "create_descriptor",
+            [](const ttnn::prim::qsr::SliceParams& operation_attributes,
+               const ttnn::prim::qsr::SliceInputs& tensor_args,
+               Tensor& tensor_return_value) {
+                return ttnn::prim::qsr::SliceTileProgramFactory::create_descriptor(
+                    operation_attributes, tensor_args, tensor_return_value);
+            },
+            nb::arg("operation_attributes"),
+            nb::arg("tensor_args"),
+            nb::arg("tensor_return_value"));
+}
+
+}  // namespace ttnn::operations::experimental::quasar::detail

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/slice_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/slice_nanobind.hpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::experimental::quasar::detail {
+
+namespace nb = nanobind;
+void bind_slice(nb::module_& mod);
+void bind_slice_descriptor(nb::module_& mod);
+}  // namespace ttnn::operations::experimental::quasar::detail

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/sources.cmake
@@ -1,0 +1,123 @@
+# Source files for ttnn_op_experimental_quasar.
+# Module owners should update this file when adding/removing/renaming source files.
+#
+# This library holds standalone Quasar (metal 2.0) copies of selected ops. Each op is a
+# near-identical clone of its original, isolated in the ttnn::prim::qsr (device) and
+# ttnn::operations::experimental::quasar (host) namespaces so it can coexist with the original.
+# (pool_generic uses ttnn::operations::pool::quasar for the host side.)
+# Nanobind sources (*_nanobind.cpp) are compiled with the python module via ttnn/sources.cmake.
+
+set(TTNN_OP_EXPERIMENTAL_QUASAR_API_HEADERS
+    pad/pad.hpp
+    tilize/tilize.hpp
+    move/move.hpp
+    untilize_with_unpadding/untilize_with_unpadding.hpp
+    slice/slice.hpp
+    transpose/transpose.hpp
+    reshard/reshard.hpp
+    halo/halo.hpp
+    pool_generic/generic_pools.hpp
+    conv2d/conv2d.hpp
+    matmul/matmul.hpp
+    binary_ng/types.hpp
+    binary/binary.hpp
+    binary/binary_composite.hpp
+)
+
+set(TTNN_OP_EXPERIMENTAL_QUASAR_SRCS
+    # pad
+    pad/pad.cpp
+    pad/device/pad_device_operation.cpp
+    pad/device/pad_rm_reader_writer_multi_core_program_factory.cpp
+    pad/device/pad_rm_reader_writer_multi_core_default_program_factory.cpp
+    pad/device/pad_rm_reader_writer_program_factory.cpp
+    pad/device/pad_rm_sharded_height_only_program_factory.cpp
+    pad/device/pad_rm_sharded_width_only_program_factory.cpp
+    pad/device/pad_tile_multicore_program_factory.cpp
+    pad/device/pad_tile_program_factory.cpp
+    # tilize
+    tilize/tilize.cpp
+    tilize/device/tilize_device_operation.cpp
+    tilize/device/tilize_multi_core_block_program_factory.cpp
+    tilize/device/tilize_multi_core_default_program_factory.cpp
+    tilize/device/tilize_multi_core_sharded_program_factory.cpp
+    tilize/device/tilize_multi_core_width_sharded_program_factory.cpp
+    tilize/device/tilize_single_core_program_factory.cpp
+    # untilize_with_unpadding
+    untilize_with_unpadding/untilize_with_unpadding.cpp
+    untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp
+    untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.cpp
+    untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_col_interleaved_program_factory.cpp
+    untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_interleaved_program_factory.cpp
+    untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.cpp
+    untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.cpp
+    untilize_with_unpadding/device/factories/untilize_with_unpadding_single_core_program_factory.cpp
+    # slice
+    slice/slice.cpp
+    slice/device/slice_device_operation.cpp
+    slice/device/slice_program_factory_rm.cpp
+    slice/device/slice_program_factory_rm_sharded.cpp
+    slice/device/slice_program_factory_rm_stride.cpp
+    slice/device/slice_program_factory_tile.cpp
+    slice/device/slice_program_factory_tile_tensor_args.cpp
+    # transpose
+    transpose/transpose.cpp
+    transpose/device/transpose_device_operation.cpp
+    transpose/device/transpose_utils.cpp
+    transpose/device/transpose_cn_program_factory.cpp
+    transpose/device/transpose_hc_rm_program_factory.cpp
+    transpose/device/transpose_hc_sharded_program_factory.cpp
+    transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
+    transpose/device/transpose_hc_tiled_program_factory.cpp
+    transpose/device/transpose_wh_program_factory.cpp
+    transpose/device/transpose_wh_sharded_program_factory.cpp
+    transpose/device/transpose_wh_sharded_rm_program_factory.cpp
+    # reshard
+    reshard/reshard.cpp
+    reshard/device/reshard_device_operation.cpp
+    reshard/device/reshard_program_factory_generic.cpp
+    reshard/device/reshard_program_factory_same_height.cpp
+    reshard/device/reshard_program_factory_same_width.cpp
+    reshard/device/nd_reshard_program_factory_copy_pages.cpp
+    reshard/device/nd_reshard_program_factory_copy_local.cpp
+    # move
+    move/move.cpp
+    move/device/move_device_operation.cpp
+    move/device/move_overlap_program_factory.cpp
+    move/device/move_program_factory.cpp
+    move/device/move_sharded_program_factory.cpp
+    # halo (no nanobind; internal op)
+    halo/halo.cpp
+    halo/device/halo_device_operation.cpp
+    halo/device/untilize_with_halo_program_factory.cpp
+    # pool_generic
+    pool_generic/generic_pools.cpp
+    pool_generic/device/pool_op.cpp
+    pool_generic/device/pool_multi_core_program_factory.cpp
+    # conv2d
+    conv2d/conv2d.cpp
+    conv2d/device/conv2d_device_operation.cpp
+    conv2d/device/conv2d_op_sharded_program_factory.cpp
+    conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+    # binary_ng (device backend; no host op / no nanobind)
+    binary_ng/device/binary_ng_device_operation.cpp
+    binary_ng/device/binary_ng_program_factory.cpp
+    binary_ng/device/binary_ng_utils.cpp
+    # binary (host front-end: add/subtract/multiply/... -> quasar binary_ng device op)
+    binary/binary.cpp
+    binary/common/binary_op_utils.cpp
+    binary/device/binary_composite_op.cpp
+    # matmul
+    matmul/matmul.cpp
+    matmul/device/matmul_device_operation.cpp
+    matmul/device/config/matmul_program_config.cpp
+    matmul/device/utilities/matmul_utilities.cpp
+    matmul/device/sparse/sparse_matmul_device_operation.cpp
+    matmul/device/sparse/factory/sparse_matmul_multicore_reuse_mcast_1d_optimized.cpp
+    matmul/device/factory/matmul_multicore_program_factory.cpp
+    matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
+    matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+    matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+    matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
+    matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
+)

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/kernels/compute/tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/kernels/compute/tilize.cpp
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/tilize.h"
+#include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
+
+void kernel_main() {
+    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(1);
+    constexpr uint32_t per_core_block_cnt = get_compile_time_arg_val(2);
+    constexpr uint32_t per_core_block_tile_cnt = get_compile_time_arg_val(3);
+    compute_kernel_hw_startup(cb_id_in0, cb_id_out0);
+
+    constexpr auto fp32_mode = compute_kernel_lib::is_fp32_input_format<cb_id_in0>()
+                                   ? compute_kernel_lib::tilize_config::Fp32Mode::Lossless
+                                   : compute_kernel_lib::tilize_config::Fp32Mode::Fast;
+
+    compute_kernel_lib::tilize<
+        per_core_block_tile_cnt,
+        cb_id_in0,
+        cb_id_out0,
+        compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
+        compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
+        compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure,
+        fp32_mode>(per_core_block_cnt);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/kernels/compute/tilize_wh.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/kernels/compute/tilize_wh.cpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/tilize.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+// #include "api/debug/dprint.h"
+#include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
+
+void kernel_main() {
+    constexpr uint32_t block_size_col = get_compile_time_arg_val(0);
+    constexpr uint32_t block_size_row = get_compile_time_arg_val(1);
+    constexpr uint32_t third_dim = get_compile_time_arg_val(2);
+
+    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_16);
+
+    constexpr auto fp32_mode = compute_kernel_lib::is_fp32_input_format<tt::CBIndex::c_0>()
+                                   ? compute_kernel_lib::tilize_config::Fp32Mode::Lossless
+                                   : compute_kernel_lib::tilize_config::Fp32Mode::Fast;
+
+    compute_kernel_lib::tilize<
+        block_size_row,
+        tt::CBIndex::c_0,
+        tt::CBIndex::c_16,
+        compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
+        compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
+        compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure,
+        fp32_mode>(block_size_col * third_dim);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/kernels/dataflow/reader_unary_stick_layout_split_rows_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/kernels/dataflow/reader_unary_stick_layout_split_rows_multicore.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include <tt-metalium/constants.hpp>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0;
+    constexpr uint32_t tile_height = tt::constants::TILE_HEIGHT;
+
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t num_rows = get_arg_val<uint32_t>(1);
+    const uint32_t num_tiles_per_block = get_arg_val<uint32_t>(3);
+    const uint32_t block_width_size = get_arg_val<uint32_t>(4);
+    const uint32_t num_full_blocks_in_row = get_arg_val<uint32_t>(5);
+    const uint32_t start_page_id = get_arg_val<uint32_t>(8);
+
+    constexpr uint32_t num_pages_in_row =
+        get_compile_time_arg_val(1);  // For ND-sharded tensors, each row can have multiple pages.
+    constexpr uint32_t size_of_valid_data_in_last_page_in_row =
+        get_compile_time_arg_val(2);  // For uneven sharding along the width, the last page could contain padding data,
+                                      // so we need to specify the size of valid data we want to read in.
+
+    constexpr auto src_tensor_args = TensorAccessorArgs<3>();
+
+    const auto s = TensorAccessor(src_tensor_args, src_addr);
+
+    Noc noc;
+    CircularBuffer cb_in0(cb_id_in0);
+
+    auto read_tiles = [&](const uint32_t& num_tiles, uint32_t page_id) {
+        cb_in0.reserve_back(num_tiles);
+        uint32_t l1_write_addr = cb_in0.get_write_ptr();
+        for (uint32_t k = 0; k < tile_height; k++) {
+            // Need an inner loop for pages within row. Only relevant for ND-sharded case on multicore
+            // (otherwise this loop only has 1 iteration).
+            for (uint32_t l = 0; l < num_pages_in_row; l++) {
+                uint32_t width_size =
+                    (l == num_pages_in_row - 1) ? size_of_valid_data_in_last_page_in_row : block_width_size;
+                CoreLocalMem<uint32_t> dst(l1_write_addr);
+                noc.async_read(s, dst, width_size, {.page_id = page_id, .offset_bytes = 0}, {.offset_bytes = 0});
+                page_id++;
+                l1_write_addr += width_size;
+            }
+        }
+        noc.async_read_barrier();
+        cb_in0.push_back(num_tiles);
+    };
+
+    uint32_t page_id = start_page_id;
+    for (uint32_t i = 0; i < num_rows / tile_height; i++) {
+        for (uint32_t j = 0; j < num_full_blocks_in_row; j++) {
+            read_tiles(num_tiles_per_block, page_id);
+        }
+        page_id += tile_height * num_pages_in_row;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/kernels/dataflow/reader_unary_stick_layout_split_rows_singlecore.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/kernels/dataflow/reader_unary_stick_layout_split_rows_singlecore.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    // Constexpr
+    constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0;
+    constexpr uint32_t tile_height = 32;
+
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t num_sticks = get_arg_val<uint32_t>(1);
+    const uint32_t num_tiles_per_block = get_arg_val<uint32_t>(3);
+    const uint32_t block_width_size = get_arg_val<uint32_t>(4);
+    const uint32_t num_full_blocks_in_row = get_arg_val<uint32_t>(5);
+    const uint32_t start_stick_id = get_arg_val<uint32_t>(8);
+
+    constexpr auto src_tensor_args = TensorAccessorArgs<1>();
+
+    const auto s = TensorAccessor(src_tensor_args, src_addr);
+
+    Noc noc;
+    CircularBuffer cb_in0(cb_id_in0);
+
+    uint32_t stick_ids[tile_height];
+    uint32_t stick_offset = 0;
+
+    auto read_tiles = [&](const uint32_t& num_tiles, const uint32_t& width_size) {
+        cb_in0.reserve_back(num_tiles);
+        uint32_t l1_write_addr = cb_in0.get_write_ptr();
+        for (uint32_t k = 0; k < tile_height; k++) {
+            CoreLocalMem<uint32_t> dst(l1_write_addr);
+            noc.async_read(
+                s, dst, width_size, {.page_id = stick_ids[k], .offset_bytes = stick_offset}, {.offset_bytes = 0});
+            l1_write_addr += width_size;
+        }
+        stick_offset += width_size;
+        noc.async_read_barrier();
+        cb_in0.push_back(num_tiles);
+    };
+
+    uint32_t stick_id = start_stick_id;
+    for (uint32_t i = 0; i < num_sticks / tile_height; i++) {
+        // Get Base IDs
+        for (uint32_t j = 0; j < tile_height; j++) {
+            stick_ids[j] = stick_id;
+            stick_id++;
+        }
+        stick_offset = 0;
+
+        for (uint32_t j = 0; j < num_full_blocks_in_row; j++) {
+            read_tiles(num_tiles_per_block, block_width_size);
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation.cpp
@@ -1,0 +1,257 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tilize_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
+#include "tilize_multi_core_default_program_factory.hpp"
+#include "tilize_multi_core_block_program_factory.hpp"
+#include "tilize_single_core_program_factory.hpp"
+#include "tilize_multi_core_sharded_program_factory.hpp"
+#include "tilize_multi_core_width_sharded_program_factory.hpp"
+#include <tt-metalium/constants.hpp>
+#include <tt-logger/tt-logger.hpp>
+#include <tt-metalium/hal.hpp>
+#include "ttnn/operations/core/work_split/work_split_tilize.hpp"
+#include "ttnn/tensor/tensor_ops.hpp"
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+
+namespace {
+bool can_use_sharded_optimized_factories(
+    const TilizeDeviceOperation::operation_attributes_t& operation_attributes,
+    const TilizeDeviceOperation::tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input_tensor;
+
+    if (input_tensor.memory_config().memory_layout() == TensorMemoryLayout::ND_SHARDED) {
+        return false;
+    }
+
+    auto memory_layout = input_tensor.memory_config().memory_layout();
+    if (memory_layout != TensorMemoryLayout::HEIGHT_SHARDED && memory_layout != TensorMemoryLayout::WIDTH_SHARDED) {
+        return false;
+    }
+
+    if (memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
+        if (operation_attributes.output_mem_config.memory_layout() == TensorMemoryLayout::ND_SHARDED ||
+            operation_attributes.output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED) {
+            return false;
+        }
+        if (operation_attributes.output_mem_config.shard_spec().value().shape[1] % tt::constants::TILE_WIDTH != 0) {
+            return false;
+        }
+        if (operation_attributes.output_mem_config.shard_spec().value().shape[0] != tt::constants::TILE_HEIGHT) {
+            return false;
+        }
+        if (operation_attributes.output_mem_config.buffer_type() == BufferType::DRAM) {
+            return false;
+        }
+    }
+
+    if (memory_layout == TensorMemoryLayout::HEIGHT_SHARDED &&
+        operation_attributes.output_mem_config.buffer_type() == BufferType::DRAM) {
+        return false;
+    }
+
+    if (operation_attributes.output_mem_config.memory_layout() != memory_layout) {
+        return false;
+    }
+
+    if (input_tensor.shard_spec().value().orientation != ShardOrientation::ROW_MAJOR) {
+        return false;
+    }
+    if (operation_attributes.sub_core_grids.has_value()) {
+        return false;  // Sharded tilize does not support sub core grid specification
+    }
+
+    // The sharded factories place kernels on every core in the shard grid.
+    // If the grid extends beyond the compute grid (e.g. includes dispatch cores),
+    // kernel placement will fail.  Fall back to the default factory which
+    // distributes work across the compute grid and accesses shards via NoC.
+    auto* device = input_tensor.device();
+    auto grid_size = device->compute_with_storage_grid_size();
+    CoreRangeSet compute_grid(CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1}));
+    const auto& shard_grid = input_tensor.shard_spec().value().grid;
+    if (!compute_grid.contains(shard_grid)) {
+        log_debug(
+            tt::LogOp,
+            "ttnn::tilize: Shard grid {} extends beyond compute grid {}x{}, falling back to default factory",
+            shard_grid.str(),
+            grid_size.x,
+            grid_size.y);
+        return false;
+    }
+    if (operation_attributes.output_mem_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::ND_SHARDED) {
+        return false;  // ND_SHARDED output should take the default factory.
+    }
+    return true;
+}
+}  // namespace
+
+void TilizeDeviceOperation::validate_on_program_cache_miss(
+    const TilizeDeviceOperation::operation_attributes_t& operation_attributes,
+    const TilizeDeviceOperation::tensor_args_t& tensor_args) {
+    const auto& input_tensor_a = tensor_args.input_tensor;
+    TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to tilize need to be on device!");
+    TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands to tilize need to be allocated in buffers on device!");
+    TT_FATAL(input_tensor_a.layout() == Layout::ROW_MAJOR, "Can only tilize row major data");
+
+    TT_FATAL(
+        input_tensor_a.padded_shape()[-1] % tt::constants::TILE_WIDTH == 0,
+        "Input tensor width must be divisible by TILE_WIDTH");
+    TT_FATAL(
+        input_tensor_a.padded_shape()[-2] % tt::constants::TILE_HEIGHT == 0,
+        "Input tensor height must be divisible by TILE_HEIGHT");
+
+    auto width = input_tensor_a.padded_shape()[-1];
+    uint32_t stick_s = width;
+    TT_FATAL(
+        input_tensor_a.dtype() == DataType::BFLOAT16 or input_tensor_a.dtype() == DataType::FLOAT32 or
+            input_tensor_a.dtype() == DataType::UINT32 or input_tensor_a.dtype() == DataType::INT32 or
+            input_tensor_a.dtype() == DataType::UINT16 or input_tensor_a.dtype() == DataType::FP8_E4M3,
+        "data type must be bfloat16, float32, uint32, int32, uint16, or fp8_e4m3");
+    TT_FATAL(
+        input_tensor_a.dtype() != DataType::FP8_E4M3 || (operation_attributes.output_dtype == DataType::BFLOAT8_B),
+        "FP8_E4M3 input requires output_dtype=BFLOAT8_B for tilize; the default output dtype would produce an "
+        "invalid TILE output specification");
+
+    uint32_t stick_size = stick_s * input_tensor_a.element_size();  // Assuming bfloat16 dataformat
+
+    TT_FATAL((stick_size % 2) == 0, "Stick size must be divisible by 2");
+
+    if (input_tensor_a.memory_config().is_sharded()) {
+        TT_FATAL(operation_attributes.use_multicore == true, "Multicore must be enabled for sharded input");
+
+        const uint32_t shard_width =
+            (input_tensor_a.shard_spec().has_value() ? input_tensor_a.shard_spec().value().shape[1]
+                                                     : input_tensor_a.nd_shard_spec().value().shard_shape[-1]);
+        const uint32_t page_size_bytes = input_tensor_a.buffer()->page_size();
+        const uint32_t alignment_requirement = hal::get_l1_alignment();
+        TT_FATAL(
+            page_size_bytes == input_tensor_a.buffer()->aligned_page_size(),
+            "Input row-major shard width {} bytes gives page size {} bytes, which must be aligned to {} bytes L1 SRAM "
+            "buffer alignment "
+            "requirement",
+            shard_width,
+            page_size_bytes,
+            alignment_requirement);  // The shard width must be an aligned size, or we will face alignment issues
+                                     // when the reader tries to write to the CB.
+    }
+}
+
+TilizeDeviceOperation::spec_return_value_t TilizeDeviceOperation::compute_output_specs(
+    const TilizeDeviceOperation::operation_attributes_t& operation_attributes,
+    const TilizeDeviceOperation::tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input_tensor;
+    if (can_use_sharded_optimized_factories(operation_attributes, tensor_args)) {
+        log_warning(
+            tt::LogOp,
+            "ttnn::tilize: Using input shard spec for output tensor because the legacy sharded optimized program "
+            "factory is being used");
+        auto mem_config = tt::tt_metal::MemoryConfig(
+            input_tensor.memory_config().memory_layout(),
+            operation_attributes.output_mem_config.buffer_type(),
+            input_tensor.memory_config().shard_spec());  // If the input is using the legacy sharded optimized program
+                                                         // factory, the output has the same shard spec as the input.
+        return {TensorSpec(
+            input_tensor.logical_shape(),
+            TensorLayout::fromPaddedShape(
+                operation_attributes.output_dtype,
+                PageConfig(Layout::TILE),
+                mem_config,
+                input_tensor.logical_shape(),
+                input_tensor.padded_shape()))};
+    }
+
+    auto output_layout = TensorLayout(
+        operation_attributes.output_dtype, PageConfig(Layout::TILE), operation_attributes.output_mem_config);
+    return {TensorSpec(
+        input_tensor.logical_shape(),
+        TensorLayout(
+            operation_attributes.output_dtype, PageConfig(Layout::TILE), operation_attributes.output_mem_config))};
+}
+
+TilizeDeviceOperation::program_factory_t TilizeDeviceOperation::select_program_factory(
+    const TilizeDeviceOperation::operation_attributes_t& operation_attributes,
+    const TilizeDeviceOperation::tensor_args_t& tensor_args) {
+    const auto& input_tensor_a = tensor_args.input_tensor;
+
+    bool use_single_core = (operation_attributes.use_low_perf) || (!operation_attributes.use_multicore) ||
+                           (operation_attributes.sub_core_grids.has_value() &&
+                            (operation_attributes.sub_core_grids.value().num_cores() < 2));
+    if (use_single_core) {
+        return ttnn::prim::qsr::TilizeSingleCoreProgramFactory{};
+    }
+
+    if (input_tensor_a.memory_config().is_sharded()) {
+        if (can_use_sharded_optimized_factories(operation_attributes, tensor_args)) {
+            if (input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED) {
+                return ttnn::prim::qsr::TilizeMultiCoreWidthShardedProgramFactory{};
+            }
+            return ttnn::prim::qsr::TilizeMultiCoreShardedProgramFactory{};
+        }
+        return ttnn::prim::qsr::TilizeMultiCoreDefaultProgramFactory{};
+    }
+    if (!operation_attributes.enough_space_height) {
+        return ttnn::prim::qsr::TilizeMultiCoreBlockProgramFactory{};
+    }
+    auto sub_core_grids = operation_attributes.sub_core_grids;
+
+    uint32_t num_tiles_per_row = input_tensor_a.padded_shape()[-1] / tt::constants::TILE_WIDTH;
+
+    uint32_t num_tiles_per_col = input_tensor_a.padded_shape()[-2] / tt::constants::TILE_HEIGHT;
+
+    int32_t ntiles = input_tensor_a.physical_volume() / tt::constants::TILE_HW;
+    uint32_t ntiles_per_block = input_tensor_a.padded_shape()[-1] / tt::constants::TILE_WIDTH;
+    uint32_t nblocks = std::ceil(static_cast<float>(ntiles) / ntiles_per_block);
+
+    auto* device = input_tensor_a.device();
+    auto grid_size = device->compute_with_storage_grid_size();
+    CoreRange default_cores({0, 0}, {grid_size.x - 1, grid_size.y - 1});
+    CoreRangeSet default_grid(default_cores);
+    CoreRangeSet available_grid = sub_core_grids.has_value() ? sub_core_grids.value() : default_grid;
+
+    size_t grid_area = available_grid.num_cores();
+    auto [ncores, nblocks_per_core] = compute_ncores(grid_area, nblocks);
+    constexpr uint32_t threshold_row_block = 32;
+    if (num_tiles_per_row > threshold_row_block &&
+        (num_tiles_per_col > threshold_row_block || num_tiles_per_row > num_tiles_per_col)) {
+        uint32_t num_blocks_block = (input_tensor_a.padded_shape()[-1] * input_tensor_a.padded_shape()[-2]) /
+                                    (tt::constants::TILE_HEIGHT * tt::constants::TILE_WIDTH);
+        auto ncores_wh = compute_ncores_wh(grid_area, num_blocks_block, num_tiles_per_row, num_tiles_per_col);
+        if (ncores < ncores_wh.ncores) {
+            return ttnn::prim::qsr::TilizeMultiCoreBlockProgramFactory{};
+        }
+    }
+    return ttnn::prim::qsr::TilizeMultiCoreDefaultProgramFactory{};
+}
+
+TilizeDeviceOperation::tensor_return_value_t TilizeDeviceOperation::create_output_tensors(
+    const TilizeDeviceOperation::operation_attributes_t& args,
+    const TilizeDeviceOperation::tensor_args_t& tensor_args) {
+    return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input_tensor.device());
+}
+
+ttnn::Tensor tilize(
+    const Tensor& input_tensor,
+    const std::optional<MemoryConfig>& output_mem_config,
+    const std::optional<DataType>& output_dtype,
+    bool use_multicore,
+    bool enough_space_width,
+    bool enough_space_height,
+    bool use_low_perf,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
+    return ttnn::device_operation::launch<TilizeDeviceOperation>(
+        TilizeParams{
+            .output_mem_config = output_mem_config.value_or(input_tensor.memory_config()),
+            .output_dtype = output_dtype.value_or(input_tensor.dtype()),
+            .use_multicore = use_multicore,
+            .enough_space_width = enough_space_width,
+            .enough_space_height = enough_space_height,
+            .use_low_perf = use_low_perf,
+            .sub_core_grids = sub_core_grids,
+        },
+        TilizeInputs{input_tensor, std::nullopt});
+}
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation.hpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+#include "ttnn/tensor/tensor.hpp"
+#include "tilize_multi_core_default_program_factory.hpp"
+#include "tilize_multi_core_block_program_factory.hpp"
+#include "tilize_single_core_program_factory.hpp"
+#include "tilize_multi_core_sharded_program_factory.hpp"
+#include "tilize_multi_core_width_sharded_program_factory.hpp"
+#include "tilize_device_operation_types.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct TilizeDeviceOperation {
+    using operation_attributes_t = ttnn::prim::qsr::TilizeParams;
+    using tensor_args_t = ttnn::prim::qsr::TilizeInputs;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
+    using program_factory_t = std::variant<
+        TilizeMultiCoreDefaultProgramFactory,
+        TilizeMultiCoreBlockProgramFactory,
+        TilizeSingleCoreProgramFactory,
+        TilizeMultiCoreShardedProgramFactory,
+        TilizeMultiCoreWidthShardedProgramFactory>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t& args, const tensor_args_t& tensor_args);
+};
+
+ttnn::Tensor tilize(
+    const Tensor& input_tensors,
+    const std::optional<tt::tt_metal::MemoryConfig>& output_mem_config,
+    const std::optional<tt::tt_metal::DataType>& output_dtype,
+    bool use_multicore,
+    bool enough_space_width,
+    bool enough_space_height,
+    bool use_low_perf,
+    const std::optional<CoreRangeSet>& sub_core_grids);
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation_types.hpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+#include "tt-metalium/kernel_types.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct TilizeParams {
+    tt::tt_metal::MemoryConfig output_mem_config;
+    tt::tt_metal::DataType output_dtype;
+    bool use_multicore = false;
+    bool enough_space_width = false;
+    bool enough_space_height = false;
+    const bool use_low_perf = false;
+    const std::optional<CoreRangeSet> sub_core_grids = std::nullopt;
+};
+
+struct TilizeInputs {
+    Tensor input_tensor;
+    std::optional<Tensor> optional_input_tensor;
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_block_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_block_program_factory.cpp
@@ -1,0 +1,348 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tilize_multi_core_block_program_factory.hpp"
+
+#include "ttnn/operations/core/work_split/work_split_tilize.hpp"
+#include "ttnn/operations/data_movement/common/common.hpp"
+
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+
+namespace {
+
+// Helper: append a paired (input, output) CBDescriptor for a given core range.
+void push_cb_pair(
+    ProgramDescriptor& desc,
+    const CoreRangeSet& core_ranges,
+    uint32_t input_single_tile_size,
+    uint32_t output_single_tile_size,
+    uint32_t num_tiles,
+    tt::DataFormat input_cb_data_format,
+    tt::DataFormat output_cb_data_format,
+    uint32_t dram_alignment) {
+    // c_1 is a per-row staging buffer used by the reader when the DRAM source row and the
+    // L1 destination have different alignment offsets: the reader rounds the source address
+    // down to a dram_alignment boundary, issues one noc_async_read of (row_bytes + dram_alignment)
+    // into this buffer, then copies the correctly-offset slice into c_0.
+    //   row_bytes  = TILE_WIDTH * elt_size * num_tiles  (one row of a sub-block)
+    //              = input_single_tile_size / TILE_HEIGHT * num_tiles
+    //   + dram_alignment    : tail bytes from rounding the DRAM read down to alignment
+    //   + dram_alignment    : headroom for aligning the L1 write pointer up to dram_alignment
+    //                         (get_write_ptr only guarantees L1 alignment, not DRAM alignment)
+    uint32_t input_row_bytes = input_single_tile_size / TILE_HEIGHT;
+    uint32_t temp_cb_size = input_row_bytes * num_tiles + 2 * dram_alignment;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = temp_cb_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_1),
+            .data_format = input_cb_data_format,
+            .page_size = temp_cb_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles * input_single_tile_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_0),
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles * output_single_tile_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_16),
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
+}
+
+}  // namespace
+
+ProgramDescriptor TilizeMultiCoreBlockProgramFactory::create_descriptor(
+    const TilizeParams& operation_attributes, const TilizeInputs& tensor_args, Tensor& tensor_return_value) {
+    const auto& a = tensor_args.input_tensor;
+    const Tensor& output = tensor_return_value;
+    const auto& sub_core_grids = operation_attributes.sub_core_grids;
+
+    tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
+    uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
+    tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
+    uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
+
+    bool fp32_llk_acc = a.dtype() == DataType::FLOAT32 || a.dtype() == DataType::FP8_E4M3 ||
+                        output.dtype() == DataType::FP8_E4M3 || output.dtype() == DataType::BFLOAT8_B;
+
+    IDevice* device = a.device();
+    CoreCoord grid_size = device->compute_with_storage_grid_size();
+    CoreRange default_cores({0, 0}, {grid_size.x - 1, grid_size.y - 1});
+    CoreRangeSet default_grid(default_cores);
+    CoreRangeSet available_grid = sub_core_grids.has_value() ? sub_core_grids.value() : default_grid;
+
+    uint32_t max_l1_size = operations::data_movement::get_max_l1_space(a);
+    uint32_t num_tiles_per_col = output.padded_shape()[-2] / TILE_HEIGHT;
+    uint32_t num_tiles_per_row = output.padded_shape()[-1] / TILE_WIDTH;
+
+    uint32_t num_blocks = (output.padded_shape()[-1] * output.padded_shape()[-2]) / (TILE_HEIGHT * TILE_WIDTH);
+    uint32_t cb_block_size_limit = max_l1_size / (input_single_tile_size + output_single_tile_size);
+
+    auto
+        [ncores,
+         all_cores,
+         core_range,
+         cliff_row_core_range,
+         cliff_col_core_range,
+         cliff_col_row_core_range,
+         nblocks_per_core,
+         single_block_size,
+         single_block_size_cliff_row,
+         single_block_size_cliff_col,
+         has_cliff_row,
+         has_cliff_col,
+         full_cores_per_row,
+         full_cores_per_col,
+         single_sub_block_size] =
+            ttnn::split_blocks_for_tilize_wh(
+                available_grid, num_blocks, num_tiles_per_row, num_tiles_per_col, cb_block_size_limit);
+
+    if (single_sub_block_size > 0 && single_block_size % single_sub_block_size) {
+        TT_FATAL(false, "single_block_size is not divided by single_sub_block_size");
+    }
+
+    uint32_t total_tiles_per_row =
+        (full_cores_per_row * single_block_size) + (has_cliff_row * single_block_size_cliff_row);
+
+    uint32_t row_size_bytes = a.padded_shape()[-1] * a.element_size();  // Assuming bfloat16 dataformat
+
+    Buffer* src0_buffer = a.buffer();
+    Buffer* dst_buffer = output.buffer();
+    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
+
+    ProgramDescriptor desc;
+
+    if (!core_range.empty()) {
+        push_cb_pair(
+            desc,
+            core_range,
+            input_single_tile_size,
+            output_single_tile_size,
+            single_sub_block_size,
+            input_cb_data_format,
+            output_cb_data_format,
+            dram_alignment);
+    }
+    if (has_cliff_col && has_cliff_row) {
+        push_cb_pair(
+            desc,
+            cliff_col_row_core_range,
+            input_single_tile_size,
+            output_single_tile_size,
+            single_block_size_cliff_row,
+            input_cb_data_format,
+            output_cb_data_format,
+            dram_alignment);
+    }
+    if (has_cliff_row) {
+        push_cb_pair(
+            desc,
+            cliff_row_core_range,
+            input_single_tile_size,
+            output_single_tile_size,
+            single_block_size_cliff_row,
+            input_cb_data_format,
+            output_cb_data_format,
+            dram_alignment);
+    }
+    if (has_cliff_col) {
+        push_cb_pair(
+            desc,
+            cliff_col_core_range,
+            input_single_tile_size,
+            output_single_tile_size,
+            single_sub_block_size,
+            input_cb_data_format,
+            output_cb_data_format,
+            dram_alignment);
+    }
+
+    // reader
+    uint32_t num_tiles_2d = output.padded_shape()[-1] * output.padded_shape()[-2] / TILE_HW;
+
+    auto log_shape = output.logical_shape();
+    uint32_t third_dim = 1;
+    if (log_shape.rank() == 3) {
+        third_dim = log_shape[-3];
+    } else if (log_shape.rank() >= 4) {
+        third_dim = log_shape[-3] * log_shape[-4];
+    }
+
+    uint32_t tile_height = output.tensor_spec().tile().get_height();
+
+    uint32_t total_num_rows = a.logical_shape()[-2];
+
+    if (output.padded_shape()[-2] > tt::round_up(total_num_rows, tile_height)) {
+        total_num_rows = output.padded_shape()[-2];
+    }
+
+    std::vector<uint32_t> reader_compile_time_args = {
+        total_num_rows, third_dim, tile_height, a.element_size(), row_size_bytes, dram_alignment};
+    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/"
+        "reader_unary_pad_multicore_both_dims.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    // writer
+    std::vector<uint32_t> writer_compile_time_args = {tt::CBIndex::c_16, num_tiles_2d, third_dim, total_tiles_per_row};
+    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id_wh.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    // compute
+    uint32_t single_sub_block_wh = single_block_size * single_block_size / single_sub_block_size;
+    uint32_t single_sub_block_cliff_col_wh = single_block_size_cliff_col * single_block_size / single_sub_block_size;
+
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    if (fp32_llk_acc) {
+        unpack_to_dest_mode[tt::CBIndex::c_0] = UnpackToDestMode::UnpackToDestFp32;
+    }
+
+    const std::string compute_kernel_path =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/kernels/compute/tilize_wh.cpp";
+
+    auto make_compute_kernel = [&](const CoreRangeSet& cores, std::vector<uint32_t> compile_args) {
+        KernelDescriptor cd;
+        cd.kernel_source = compute_kernel_path;
+        cd.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        cd.core_ranges = cores;
+        cd.compile_time_args = std::move(compile_args);
+        cd.config = ComputeConfigDescriptor{
+            .fp32_dest_acc_en = fp32_llk_acc,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+        };
+        return cd;
+    };
+
+    std::vector<KernelDescriptor> compute_kernels;
+    if (!core_range.empty()) {
+        compute_kernels.push_back(
+            make_compute_kernel(core_range, {single_sub_block_wh, single_sub_block_size, third_dim}));
+    }
+    if (has_cliff_col && has_cliff_row) {
+        compute_kernels.push_back(make_compute_kernel(
+            cliff_col_row_core_range, {single_block_size_cliff_col, single_block_size_cliff_row, third_dim}));
+    }
+    if (has_cliff_row) {
+        compute_kernels.push_back(
+            make_compute_kernel(cliff_row_core_range, {single_block_size, single_block_size_cliff_row, third_dim}));
+    }
+    if (has_cliff_col) {
+        compute_kernels.push_back(make_compute_kernel(
+            cliff_col_core_range, {single_sub_block_cliff_col_wh, single_sub_block_size, third_dim}));
+    }
+
+    // RUNTIME ARGS
+    const auto& cores = corerange_to_cores(available_grid);
+    uint32_t start_row_id = 0;
+    uint32_t start_column_id = 0;
+    uint32_t tile_start_id = 0;
+    uint32_t single_block_size_row_arg;
+    uint32_t single_block_size_col_arg;
+    uint32_t single_sub_block_size_row_arg;
+
+    uint32_t total_row_cores = full_cores_per_row;
+    if (has_cliff_row) {
+        total_row_cores++;
+    }
+    uint32_t cores_col_count = 1;
+    for (uint32_t i = 0; i < ncores; ++i) {
+        const auto& core = cores[i];
+        if (has_cliff_col && has_cliff_row && i == ncores - 1) {
+            single_block_size_row_arg = single_block_size_cliff_row;
+            single_block_size_col_arg = single_block_size_cliff_col;
+            single_sub_block_size_row_arg = single_block_size_cliff_row;
+
+        } else if (has_cliff_row && i != 0 && ((i + 1) % (full_cores_per_row + 1)) == 0) {
+            single_block_size_row_arg = single_block_size_cliff_row;
+            single_block_size_col_arg = single_block_size;
+            single_sub_block_size_row_arg = single_block_size_cliff_row;
+
+        } else if (i < total_row_cores * full_cores_per_col) {
+            single_block_size_row_arg = single_block_size;
+            single_block_size_col_arg = single_block_size;
+            single_sub_block_size_row_arg = single_sub_block_size;
+
+        } else {
+            single_block_size_row_arg = single_block_size;
+            single_block_size_col_arg = single_block_size_cliff_col;
+            single_sub_block_size_row_arg = single_sub_block_size;
+        }
+
+        // reader runtime args — Buffer* slot auto-registers as a BufferBinding so the
+        // framework patches addresses on cache hits.
+        reader_desc.emplace_runtime_args(
+            core,
+            {src0_buffer,
+             std::uint32_t{0},
+             TILE_WIDTH * a.element_size() * single_block_size_row_arg,
+             start_row_id,
+             start_column_id,
+             single_block_size_row_arg,
+             single_block_size_col_arg,
+             TILE_WIDTH * a.element_size() * single_sub_block_size_row_arg,
+             single_sub_block_size_row_arg});
+
+        // writer runtime args
+        writer_desc.emplace_runtime_args(
+            core, {dst_buffer, tile_start_id, single_block_size_row_arg, single_block_size_col_arg});
+
+        uint32_t end_column_id = start_column_id + (single_block_size_row_arg * TILE_WIDTH * a.element_size());
+        start_column_id = end_column_id % row_size_bytes;
+        if (end_column_id % row_size_bytes == 0 && end_column_id != 0) {
+            start_row_id += single_block_size_col_arg * TILE_HEIGHT;
+        }
+
+        if (start_column_id == 0) {
+            tile_start_id = cores_col_count * single_block_size_col_arg * total_tiles_per_row;
+            cores_col_count++;
+        } else {
+            tile_start_id += single_block_size_row_arg;
+        }
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    for (auto& cd : compute_kernels) {
+        desc.kernels.push_back(std::move(cd));
+    }
+
+    return desc;
+}
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_block_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_block_program_factory.hpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/program_descriptors.hpp>
+#include "tilize_device_operation_types.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct TilizeMultiCoreBlockProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const TilizeParams& operation_attributes, const TilizeInputs& tensor_args, Tensor& tensor_return_value);
+};
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_default_program_factory.cpp
@@ -1,0 +1,227 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tilize_multi_core_default_program_factory.hpp"
+
+#include "ttnn/operations/core/work_split/work_split_tilize.hpp"
+
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+
+ProgramDescriptor TilizeMultiCoreDefaultProgramFactory::create_descriptor(
+    const TilizeParams& operation_attributes, const TilizeInputs& tensor_args, Tensor& tensor_return_value) {
+    const auto& a = tensor_args.input_tensor;
+    const Tensor& output = tensor_return_value;
+    const auto& sub_core_grids = operation_attributes.sub_core_grids;
+
+    tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
+    uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
+    tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
+    uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
+    bool fp32_llk_acc = a.dtype() == DataType::FLOAT32 || a.dtype() == DataType::FP8_E4M3 ||
+                        output.dtype() == DataType::FP8_E4M3 || output.dtype() == DataType::BFLOAT8_B;
+
+    Buffer* src0_buffer = a.buffer();
+    Buffer* dst_buffer = output.buffer();
+    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    auto logical_shape = a.logical_shape();
+    uint32_t logical_width = logical_shape[-1];
+    uint32_t ntiles_per_block = tt::div_up(logical_width, TILE_WIDTH);
+    uint32_t ntiles = dst_buffer->num_pages();
+    uint32_t nblocks = tt::div_up(ntiles, ntiles_per_block);
+    auto* device = a.device();
+    auto grid_size = device->compute_with_storage_grid_size();
+    CoreRange default_cores({0, 0}, {grid_size.x - 1, grid_size.y - 1});
+    CoreRangeSet default_grid(default_cores);
+    CoreRangeSet available_grid = sub_core_grids.has_value() ? sub_core_grids.value() : default_grid;
+
+    auto [ncores, all_cores, core_range, core_range_cliff, nblocks_per_core, nblocks_per_core_cliff] =
+        ttnn::split_blocks_for_tilize(available_grid, nblocks);
+
+    const uint32_t src0_cb_index = tt::CBIndex::c_0;
+    const uint32_t output_cb_index = tt::CBIndex::c_16;
+
+    ProgramDescriptor desc;
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = ntiles_per_block * input_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = ntiles_per_block * output_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
+
+    /** reader
+     */
+    uint32_t page_size = src0_buffer->page_size();
+    uint32_t aligned_page_size = src0_buffer->aligned_page_size();
+    uint32_t num_pages_in_row = 1;
+    uint32_t size_of_valid_data_in_last_page_in_row = page_size;
+    if (a.is_sharded()) {
+        uint32_t shard_width =
+            a.shard_spec().has_value() ? a.shard_spec().value().shape[1] : a.nd_shard_spec().value().shard_shape[-1];
+        num_pages_in_row = tt::div_up(logical_width,
+                                      shard_width);  // Compute number of pages in one tensor row.
+        uint32_t padding_size =
+            (num_pages_in_row * page_size) -
+            (a.logical_shape()[-1] * a.element_size());  // Compute padding size for the last page in the row.
+        size_of_valid_data_in_last_page_in_row = page_size - padding_size;
+    }
+    std::vector<uint32_t> reader_ct_args = {
+        aligned_page_size, num_pages_in_row, size_of_valid_data_in_last_page_in_row};
+    TensorAccessorArgs(*src0_buffer).append_to(reader_ct_args);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/kernels/dataflow/"
+        "reader_unary_stick_layout_split_rows_multicore.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    /** writer
+     */
+    std::vector<uint32_t> writer_ct_args = {output_cb_index};
+    TensorAccessorArgs(*dst_buffer).append_to(writer_ct_args);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    /** compute
+     */
+    std::vector<uint32_t> compute_args = {nblocks_per_core, ntiles_per_block};
+    std::vector<uint32_t> compute_args_cliff = {nblocks_per_core_cliff, ntiles_per_block};
+
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    if (fp32_llk_acc) {
+        unpack_to_dest_mode[tt::CBIndex::c_0] = UnpackToDestMode::UnpackToDestFp32;
+    }
+
+    std::optional<KernelDescriptor> compute_desc;
+    if (!core_range.ranges().empty()) {
+        KernelDescriptor cd;
+        cd.kernel_source = "ttnn/cpp/ttnn/kernel/compute/tilize.cpp";
+        cd.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        cd.core_ranges = core_range;
+        cd.compile_time_args = std::move(compute_args);
+        cd.config = ComputeConfigDescriptor{
+            .fp32_dest_acc_en = fp32_llk_acc,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+        };
+        compute_desc = std::move(cd);
+    }
+
+    std::optional<KernelDescriptor> compute_cliff_desc;
+    if (!core_range_cliff.empty()) {
+        KernelDescriptor cd;
+        cd.kernel_source = "ttnn/cpp/ttnn/kernel/compute/tilize.cpp";
+        cd.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        cd.core_ranges = core_range_cliff;
+        cd.compile_time_args = std::move(compute_args_cliff);
+        cd.config = ComputeConfigDescriptor{
+            .fp32_dest_acc_en = fp32_llk_acc,
+            .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+        };
+        compute_cliff_desc = std::move(cd);
+    }
+
+    // 1D distribution of blocks across cores
+    bool has_cliff = !core_range_cliff.empty();
+
+    uint32_t ncores_full = ncores - has_cliff;
+    uint32_t tile_start_id = 0;
+    uint32_t page_start_id = 0;
+    const auto& cores = corerange_to_cores(available_grid);
+    for (uint32_t i = 0; i < ncores_full; ++i) {
+        const CoreCoord& core = cores[i];
+
+        // reader runtime args — Buffer* slots auto-register as BufferBindings so the
+        // framework patches addresses on cache hits.
+        reader_desc.emplace_runtime_args(
+            core,
+            {src0_buffer,
+             nblocks_per_core * TILE_HEIGHT,
+             page_size,
+             ntiles_per_block,
+             page_size,
+             std::uint32_t{1},  // full blocks in row
+             std::uint32_t{0},  // num leftover tiles
+             std::uint32_t{0},  // leftover width in row
+             page_start_id});
+
+        // writer runtime args
+        writer_desc.emplace_runtime_args(
+            core,
+            {dst_buffer,
+             ntiles_per_block * nblocks_per_core,  // ntiles per core
+             tile_start_id});                      // start id
+
+        tile_start_id += ntiles_per_block * nblocks_per_core;
+        page_start_id += TILE_HEIGHT * nblocks_per_core * num_pages_in_row;
+    }
+    if (has_cliff) {
+        // the last core is a cliff core with nblocks_per_core_cliff blocks
+        const CoreCoord& core = cores[ncores_full];
+
+        // reader runtime args
+        reader_desc.emplace_runtime_args(
+            core,
+            {src0_buffer,
+             nblocks_per_core_cliff * TILE_HEIGHT,
+             page_size,
+             ntiles_per_block,
+             page_size,
+             std::uint32_t{1},  // full blocks in row
+             std::uint32_t{0},  // num leftover tiles
+             std::uint32_t{0},  // leftover width in row
+             page_start_id});
+
+        // writer runtime args
+        writer_desc.emplace_runtime_args(
+            core,
+            {dst_buffer,
+             ntiles_per_block * nblocks_per_core_cliff,  // ntiles per core
+             tile_start_id});                            // start id
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    if (compute_desc.has_value()) {
+        desc.kernels.push_back(std::move(*compute_desc));
+    }
+    if (compute_cliff_desc.has_value()) {
+        desc.kernels.push_back(std::move(*compute_cliff_desc));
+    }
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_default_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_default_program_factory.hpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/program_descriptors.hpp>
+#include "tilize_device_operation_types.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct TilizeMultiCoreDefaultProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const TilizeParams& operation_attributes, const TilizeInputs& tensor_args, Tensor& tensor_return_value);
+};
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_sharded_program_factory.cpp
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tilize_multi_core_sharded_program_factory.hpp"
+
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+
+ProgramDescriptor TilizeMultiCoreShardedProgramFactory::create_descriptor(
+    const TilizeParams& /*operation_attributes*/, const TilizeInputs& tensor_args, Tensor& tensor_return_value) {
+    const auto& input = tensor_args.input_tensor;
+    const Tensor& output = tensor_return_value;
+    tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(input.dtype());
+    uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
+    tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
+    uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
+    bool fp32_llk_acc = input.dtype() == DataType::FLOAT32 || input.dtype() == DataType::FP8_E4M3 ||
+                        output.dtype() == DataType::FP8_E4M3 || output.dtype() == DataType::BFLOAT8_B;
+
+    auto shard_spec = input.shard_spec().value();
+    uint32_t num_tiles_per_shard = shard_spec.shape[0] * shard_spec.shape[1] / TILE_HW;
+    uint32_t num_tiles_per_row = shard_spec.shape[1] / TILE_WIDTH;
+    const CoreRangeSet& all_cores = shard_spec.grid;
+
+    const uint32_t src0_cb_index = tt::CBIndex::c_0;
+    const uint32_t output_cb_index = tt::CBIndex::c_16;
+
+    Buffer* src_buffer = input.buffer();
+    Buffer* dst_buffer = output.buffer();
+
+    ProgramDescriptor desc;
+
+    // Sharded input CB — globally allocated to the input buffer; framework patches
+    // the CB address on cache hits via cb.buffer.
+    {
+        CBDescriptor cb_src0;
+        cb_src0.total_size = num_tiles_per_shard * input_single_tile_size;
+        cb_src0.core_ranges = all_cores;
+        cb_src0.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        });
+        cb_src0.buffer = src_buffer;
+        desc.cbs.push_back(std::move(cb_src0));
+    }
+
+    // Sharded output CB — globally allocated to the output buffer.
+    {
+        CBDescriptor cb_output;
+        cb_output.total_size = num_tiles_per_shard * output_single_tile_size;
+        cb_output.core_ranges = all_cores;
+        cb_output.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        });
+        cb_output.buffer = dst_buffer;
+        desc.cbs.push_back(std::move(cb_output));
+    }
+
+    std::vector<uint32_t> reader_compile_time_args = {src0_cb_index};
+    std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    // Sharded readers/writers consume only the (constant per-launch) num_tiles_per_shard
+    // count; no Buffer* slot is needed because the CB itself carries the buffer binding.
+    for (const auto& core : corerange_to_cores(all_cores)) {
+        reader_desc.emplace_runtime_args(core, {num_tiles_per_shard});
+        writer_desc.emplace_runtime_args(core, {num_tiles_per_shard});
+    }
+
+    std::vector<uint32_t> compute_args = {
+        uint32_t(num_tiles_per_shard / num_tiles_per_row), uint32_t(num_tiles_per_row)};
+
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    if (fp32_llk_acc) {
+        unpack_to_dest_mode[tt::CBIndex::c_0] = UnpackToDestMode::UnpackToDestFp32;
+    }
+
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source = "ttnn/cpp/ttnn/kernel/compute/tilize.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = all_cores;
+    compute_desc.compile_time_args = std::move(compute_args);
+    compute_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = fp32_llk_acc,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+    };
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_sharded_program_factory.hpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/program_descriptors.hpp>
+#include "tilize_device_operation_types.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct TilizeMultiCoreShardedProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const TilizeParams& operation_attributes, const TilizeInputs& tensor_args, Tensor& tensor_return_value);
+};
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_width_sharded_program_factory.cpp
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tilize_multi_core_width_sharded_program_factory.hpp"
+
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+
+ProgramDescriptor TilizeMultiCoreWidthShardedProgramFactory::create_descriptor(
+    const TilizeParams& /*operation_attributes*/, const TilizeInputs& tensor_args, Tensor& tensor_return_value) {
+    const auto& input = tensor_args.input_tensor;
+    const Tensor& output = tensor_return_value;
+
+    tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(input.dtype());
+    uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
+    tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
+    uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
+    bool fp32_llk_acc = input.dtype() == DataType::FLOAT32 || input.dtype() == DataType::FP8_E4M3 ||
+                        output.dtype() == DataType::FP8_E4M3 || output.dtype() == DataType::BFLOAT8_B;
+
+    auto shard_spec = input.shard_spec().value();
+    uint32_t num_tiles_per_shard = shard_spec.shape[0] * shard_spec.shape[1] / TILE_HW;
+    uint32_t num_tiles_per_row = shard_spec.shape[1] / TILE_WIDTH;
+    const CoreRangeSet& all_cores = shard_spec.grid;
+
+    const uint32_t src0_cb_index = tt::CBIndex::c_0;
+    const uint32_t output_cb_index = tt::CBIndex::c_16;
+
+    Buffer* src_buffer = input.buffer();
+    Buffer* dst_buffer = output.buffer();
+
+    ProgramDescriptor desc;
+
+    // Sharded input CB — globally allocated to the input buffer; framework patches
+    // the CB address on cache hits via cb.buffer.
+    {
+        CBDescriptor cb_src0;
+        cb_src0.total_size = num_tiles_per_shard * input_single_tile_size;
+        cb_src0.core_ranges = all_cores;
+        cb_src0.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        });
+        cb_src0.buffer = src_buffer;
+        desc.cbs.push_back(std::move(cb_src0));
+    }
+
+    // Sharded output CB — globally allocated to the output buffer.
+    {
+        CBDescriptor cb_output;
+        cb_output.total_size = num_tiles_per_shard * output_single_tile_size;
+        cb_output.core_ranges = all_cores;
+        cb_output.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        });
+        cb_output.buffer = dst_buffer;
+        desc.cbs.push_back(std::move(cb_output));
+    }
+
+    std::vector<uint32_t> reader_compile_time_args = {src0_cb_index};
+    std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    // Sharded readers/writers consume only num_tiles_per_shard (constant per launch);
+    // the CB itself carries the buffer binding.
+    for (const auto& core : corerange_to_cores(all_cores)) {
+        reader_desc.emplace_runtime_args(core, {num_tiles_per_shard});
+        writer_desc.emplace_runtime_args(core, {num_tiles_per_shard});
+    }
+
+    std::vector<uint32_t> compute_args = {
+        uint32_t(num_tiles_per_shard / num_tiles_per_row), uint32_t(num_tiles_per_row)};
+
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    if (fp32_llk_acc) {
+        unpack_to_dest_mode[tt::CBIndex::c_0] = UnpackToDestMode::UnpackToDestFp32;
+    }
+
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source = "ttnn/cpp/ttnn/kernel/compute/tilize.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = all_cores;
+    compute_desc.compile_time_args = std::move(compute_args);
+    compute_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = fp32_llk_acc,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+    };
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_width_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_width_sharded_program_factory.hpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/program_descriptors.hpp>
+#include "tilize_device_operation_types.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct TilizeMultiCoreWidthShardedProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const TilizeParams& operation_attributes, const TilizeInputs& tensor_args, Tensor& tensor_return_value);
+};
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_single_core_program_factory.cpp
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tilize_single_core_program_factory.hpp"
+
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+
+ProgramDescriptor TilizeSingleCoreProgramFactory::create_descriptor(
+    const TilizeParams& operation_attributes, const TilizeInputs& tensor_args, Tensor& tensor_return_value) {
+    const auto& a = tensor_args.input_tensor;
+    const Tensor& output = tensor_return_value;
+    const auto& sub_core_grids = operation_attributes.sub_core_grids;
+
+    CoreRange default_core({0, 0}, {0, 0});
+    CoreRange core = sub_core_grids.has_value() ? corerange_to_cores(sub_core_grids.value()).at(0) : default_core;
+    CoreRangeSet core_ranges{core};
+
+    Buffer* src0_buffer = a.buffer();
+
+    // This should allocate a DRAM buffer on the device
+
+    Buffer* dst_buffer = output.buffer();
+    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
+    uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
+
+    tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
+    uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
+
+    bool fp32_llk_acc = a.dtype() == DataType::FLOAT32 || a.dtype() == DataType::FP8_E4M3 ||
+                        output.dtype() == DataType::FP8_E4M3 || output.dtype() == DataType::BFLOAT8_B;
+
+    uint32_t num_tiles = a.physical_volume() / TILE_HW;
+
+    auto width = a.padded_shape()[-1];
+    uint32_t stick_s = width;
+    uint32_t num_sticks = a.physical_volume() / width;
+    uint32_t stick_size = stick_s * a.element_size();  // Assuming bfloat16 dataformat
+
+    uint32_t num_tiles_in_row = stick_s / TILE_WIDTH;
+    uint32_t num_tiles_per_block = 1;
+
+    if (!operation_attributes.use_low_perf) {
+        // Ensure we don't intrude into storage space
+        uint32_t max_l1_size =
+            (a.device()->l1_size_per_core() / 2) - a.device()->allocator()->get_base_allocator_addr(HalMemType::L1);
+        uint32_t max_tiles = max_l1_size / (input_single_tile_size + output_single_tile_size);  // 2 CBs
+        // Currently need the number of tiles in a row to be divisible by tiles in a block
+        if (num_tiles_in_row <= max_tiles) {
+            num_tiles_per_block = num_tiles_in_row;
+        } else {
+            for (uint32_t n_t = max_tiles; n_t > 0; n_t--) {
+                if (num_tiles_in_row % n_t == 0) {
+                    num_tiles_per_block = n_t;
+                    break;
+                }
+            }
+        }
+    }
+
+    uint32_t block_width_size = num_tiles_per_block * TILE_WIDTH * a.element_size();
+    uint32_t num_full_blocks_in_row = num_tiles_in_row / num_tiles_per_block;
+    uint32_t num_leftover_tiles = num_tiles_in_row % num_tiles_per_block;
+    uint32_t leftover_width_in_row = num_leftover_tiles * a.element_size();
+
+    const uint32_t src0_cb_index = 0;
+    const uint32_t output_cb_index = tt::CBIndex::c_16;
+    const uint32_t num_input_tiles = num_tiles_per_block;
+    const uint32_t num_output_tiles = num_tiles_per_block;
+
+    ProgramDescriptor desc;
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * input_single_tile_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_output_tiles * output_single_tile_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
+
+    // Reader compile-time args
+    std::vector<uint32_t> reader_compile_time_args = {stick_size};
+    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+
+    std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
+    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+
+    // Tilized reader
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/kernels/dataflow/"
+        "reader_unary_stick_layout_split_rows_singlecore.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = core_ranges;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    // Buffer* slots register BufferBindings so the framework patches addresses on cache hits.
+    reader_desc.emplace_runtime_args(
+        core.start_coord,
+        {src0_buffer,
+         num_sticks,
+         stick_size,
+         num_tiles_per_block,
+         block_width_size,
+         num_full_blocks_in_row,
+         num_leftover_tiles,
+         leftover_width_in_row,
+         std::uint32_t{0}});  // row_start_id
+
+    // Tilized writer
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = core_ranges;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+    writer_desc.emplace_runtime_args(core.start_coord, {dst_buffer, num_tiles, std::uint32_t{0}});
+
+    std::vector<uint32_t> compute_args = {
+        num_tiles / num_tiles_per_block,  // per_core_block_cnt
+        num_tiles_per_block               // per_core_block_tile_cnt
+    };
+
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    if (fp32_llk_acc) {
+        unpack_to_dest_mode[tt::CBIndex::c_0] = UnpackToDestMode::UnpackToDestFp32;
+    }
+
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source = "ttnn/cpp/ttnn/kernel/compute/tilize.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = core_ranges;
+    compute_desc.compile_time_args = std::move(compute_args);
+    compute_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = fp32_llk_acc,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+    };
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_single_core_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_single_core_program_factory.hpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/program_descriptors.hpp>
+#include "tilize_device_operation_types.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::prim::qsr {
+struct TilizeSingleCoreProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const TilizeParams& operation_attributes, const TilizeInputs& tensor_args, Tensor& tensor_return_value);
+};
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/tilize.cpp
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tilize.hpp"
+
+#include "device/tilize_device_operation.hpp"
+#include "ttnn/operations/data_movement/common/common.hpp"
+#include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
+
+using namespace tt::tt_metal;
+
+namespace ttnn::operations::experimental::quasar {
+// Shared data-movement helpers (data_movement/common/common.hpp, reshape_view/reshape.hpp) used
+// bare by this op; they previously resolved via the enclosing data_movement namespace.
+using ttnn::TileReshapeMapMode;
+using ttnn::operations::data_movement::MassagedOperation;
+using ttnn::operations::data_movement::MassagedOperationParams;
+using ttnn::operations::data_movement::squeeze_from_ND_to_4D;
+
+using OwnedTilizeArgs = std::tuple<ttnn::Tensor>;
+using BaseTilizeType = std::function<ttnn::Tensor(const ttnn::Tensor&)>;
+
+using MassagedTilize = MassagedOperation<ttnn::Tensor, const ttnn::Tensor&>;
+using MassagedTilizeParams = MassagedOperationParams<ttnn::Tensor, const ttnn::Tensor&>;
+
+MassagedTilize build_ndiml_tilize(BaseTilizeType base_tilize, const std::optional<CoreRangeSet>& sub_core_grids) {
+    auto original_shape = std::make_shared<Shape>();
+    return MassagedTilize(MassagedTilizeParams{
+        .predicate = [](const ttnn::Tensor& input_tensor) -> bool { return input_tensor.logical_shape().rank() > 4; },
+        .pre_transform = [=](const ttnn::Tensor& input_tensor) -> OwnedTilizeArgs {
+            *original_shape = input_tensor.logical_shape();
+            ttnn::Tensor squeezed_tensor = squeeze_from_ND_to_4D(input_tensor, sub_core_grids);
+            return std::make_tuple(squeezed_tensor);
+        },
+        .post_transform = [=](const ttnn::Tensor& output) -> ttnn::Tensor {
+            auto unsqueezed_tensor = ttnn::reshape(
+                output, *original_shape, std::nullopt, std::nullopt, TileReshapeMapMode::CACHE, sub_core_grids);
+            return unsqueezed_tensor;
+        },
+        .operation = std::move(base_tilize)});
+}
+
+}  // namespace ttnn::operations::experimental::quasar
+
+namespace ttnn::operations::experimental::quasar {
+
+ttnn::Tensor tilize(
+    const ttnn::Tensor& input_tensor,
+    const std::optional<MemoryConfig>& memory_config,
+    std::optional<DataType> output_dtype,
+    bool use_multicore,
+    bool use_low_perf,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
+    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
+    uint32_t output_single_tile_size =
+        output_dtype.has_value() ? tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(output_dtype.value()))
+                                 : input_single_tile_size;
+
+    uint32_t input_tile_width = input_tensor.tensor_spec().tile().get_width();
+    uint32_t input_tile_height = input_tensor.tensor_spec().tile().get_height();
+
+    uint32_t num_tiles_per_row = input_tensor.padded_shape()[-1] / input_tile_width;
+    uint32_t num_tiles_per_col = input_tensor.padded_shape()[-1] / input_tile_height;
+
+    bool enough_space_width = ttnn::operations::data_movement::is_enough_space(
+        input_tensor, input_single_tile_size, output_single_tile_size, num_tiles_per_col);
+    bool enough_space_height = ttnn::operations::data_movement::is_enough_space(
+        input_tensor, input_single_tile_size, output_single_tile_size, num_tiles_per_row);
+
+    auto base_tilize = [=](const ttnn::Tensor& input_tensor) {
+        return ttnn::prim::qsr::tilize(
+            input_tensor,
+            memory_config,
+            output_dtype,
+            use_multicore,
+            enough_space_width,
+            enough_space_height,
+            use_low_perf,
+            sub_core_grids);
+    };
+
+    return ttnn::operations::experimental::quasar::build_ndiml_tilize(base_tilize, sub_core_grids)(input_tensor);
+}
+
+}  // namespace ttnn::operations::experimental::quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/tilize.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/tilize.hpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::experimental::quasar {
+
+ttnn::Tensor tilize(
+    const ttnn::Tensor& input_tensor,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    std::optional<DataType> output_dtype = std::nullopt,
+    bool use_multicore = true,
+    bool use_low_perf = false,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+
+}  // namespace ttnn::operations::experimental::quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/tilize_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/tilize_nanobind.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tilize_nanobind.hpp"
+
+#include <optional>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
+
+#include "tilize.hpp"
+#include "ttnn-nanobind/bind_function.hpp"
+
+namespace ttnn::operations::experimental::quasar::detail {
+
+void bind_tilize(nb::module_& mod) {
+    const auto* doc = R"doc(
+        Changes data layout of input tensor to TILE.
+
+        Input tensor must be on TT accelerator device, in ROW_MAJOR layout, and have BFLOAT16 data type.
+
+        Output tensor will be on TT accelerator device, in TILE layout, and have BFLOAT16 data type.
+
+        Args:
+            input_tensor (ttnn.Tensor): the input tensor.
+
+        Keyword Args:
+            memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
+            dtype (data type, optional): Data type of the output tensor. Defaults to `None`.
+            use_multicore (bool, optional): Whether to use multicore. Defaults to `True`.
+            use_low_perf (bool, optional): Use a low performance version that uses less memory. USE ONLY IF ABSOLUTELY NEEDED IN MODELS. Defaults to `False`.
+            sub_core_grids (CoreRangeSet, optional): Used to restrict tilize to a set of cores, Defaults to using the entire device
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+    )doc";
+
+    ttnn::bind_function<"tilize">(
+        mod,
+        doc,
+        &ttnn::operations::experimental::quasar::tilize,
+        nb::arg("input_tensor"),
+        nb::kw_only(),
+        nb::arg("memory_config") = nb::none(),
+        nb::arg("dtype") = nb::none(),
+        nb::arg("use_multicore") = true,
+        nb::arg("use_low_perf") = false,
+        nb::arg("sub_core_grids") = nb::none());
+}
+}  // namespace ttnn::operations::experimental::quasar::detail

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/tilize_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/tilize_nanobind.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::experimental::quasar::detail {
+
+namespace nb = nanobind;
+void bind_tilize(nb::module_& mod);
+}  // namespace ttnn::operations::experimental::quasar::detail

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/compute/transpose_wh.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/compute/transpose_wh.cpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/transpose_wh.h"
+#include "api/dataflow/circular_buffer.h"
+
+void kernel_main() {
+    uint32_t NHtWt = get_arg_val<uint32_t>(0);
+
+    transpose_wh_init(tt::CBIndex::c_0, tt::CBIndex::c_16);
+
+    CircularBuffer cb_in(tt::CBIndex::c_0);
+    CircularBuffer cb_out(tt::CBIndex::c_16);
+
+    // transpose a row-major block:
+    // - assumes the tiles come in in column major order from reader
+    // - uses reader_unary_transpose_wh
+    // - transpose_wh each tile
+    for (uint32_t n = 0; n < NHtWt; n++) {
+        cb_in.wait_front(1);
+        cb_out.reserve_back(1);
+
+        tile_regs_acquire();
+        transpose_wh_tile(tt::CBIndex::c_0, 0, 0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, tt::CBIndex::c_16);
+        tile_regs_release();
+
+        cb_out.push_back(1);
+        cb_in.pop_front(1);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/compute/transpose_wh_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/compute/transpose_wh_rm.cpp
@@ -1,0 +1,180 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#include <cstdint>
+
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/transpose_wh.h"
+#include "api/compute/tilize.h"
+#include "api/compute/pack_untilize.h"
+#include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
+#include "api/dataflow/circular_buffer.h"
+
+template <
+    uint32_t Wt,
+    uint32_t Ht,
+    uint32_t HtWt,
+    bool use_narrow_row,
+    uint32_t row_size,
+    uint32_t pack_num_pages_last_col,
+    uint32_t pack_num_pages_last_row_col,
+    uint32_t cb_out>
+ALWI void transpose_with_pack_untilize_narrow_row(uint32_t cb_tilize, CircularBuffer& cb_out_buf) {
+    uint32_t tile_idx = 0;
+
+    transpose_wh_init_short(cb_tilize);
+    pack_untilize_dest_init<Ht, Ht, use_narrow_row, row_size>(cb_out);
+    for (uint32_t w = 0; w < Wt; ++w) {
+        tile_regs_acquire();
+        for (uint32_t h = 0; h < Ht; ++h) {
+            transpose_wh_tile(cb_tilize, tile_idx, h);
+            tile_idx += Wt;
+        }
+
+        tile_regs_commit();
+
+        if (w == Wt - 1) {  // last row
+            cb_out_buf.reserve_back(pack_num_pages_last_row_col);
+            tile_regs_wait();
+            pack_untilize_dest<Ht, Ht, false, use_narrow_row, row_size>(cb_out);
+            tile_regs_release();
+            cb_out_buf.push_back(pack_num_pages_last_row_col);
+        } else {
+            cb_out_buf.reserve_back(pack_num_pages_last_col);
+            tile_regs_wait();
+            pack_untilize_dest<Ht, Ht, false, use_narrow_row, row_size>(cb_out);
+            tile_regs_release();
+            cb_out_buf.push_back(pack_num_pages_last_col);
+        }
+        tile_idx = tile_idx - HtWt + 1;
+    }
+    pack_untilize_uninit(cb_out);
+}
+
+// Helper constexpr function to compute num_blocks_per_col
+constexpr uint32_t compute_num_blocks_per_col(uint32_t per_core_block_tile_cnt) {
+    const uint32_t max_bct = DST_ACCUM_MODE ? 4 : 8;
+
+    for (uint32_t bct = max_bct; bct >= 1; --bct) {
+        if (per_core_block_tile_cnt % bct == 0) {
+            return per_core_block_tile_cnt / bct;
+        }
+    }
+
+    return 1;
+}
+
+template <uint32_t Wt, uint32_t Ht, uint32_t HtWt, uint32_t cb_out>
+ALWI void transpose_with_pack_untilize(uint32_t cb_tilize, CircularBuffer& cb_out_buf) {
+    uint32_t tile_idx = 0;
+
+    transpose_wh_init_short(cb_tilize);
+    constexpr uint32_t num_blocks_per_col = compute_num_blocks_per_col(Ht);
+    constexpr uint32_t block_ct_dim = Ht / num_blocks_per_col;
+    constexpr uint32_t full_ct_dim = Ht;
+    pack_untilize_dest_init<block_ct_dim, full_ct_dim>(cb_out);
+    for (uint32_t w = 0; w < Wt; ++w) {
+        cb_out_buf.reserve_back(Ht);
+        for (uint32_t b = 0; b < num_blocks_per_col; ++b) {
+            tile_regs_acquire();
+            for (uint32_t h = 0; h < block_ct_dim; ++h) {
+                transpose_wh_tile(cb_tilize, tile_idx, h);
+                tile_idx += Wt;
+            }
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_untilize_dest<block_ct_dim, full_ct_dim>(cb_out, 1, b);
+            tile_regs_release();
+        }
+        cb_out_buf.push_back(Ht);
+        // NOTE: the former cb_out_buf.wait_front(Ht) was removed here. It was a no-op (compute owns
+        // c_27's CB state and never pop_front's, so wait_front was satisfied immediately) that only
+        // registered compute as an illegal second consumer of the c_27 DFB on Quasar. Backpressure is
+        // already provided by reserve_back(Ht) on the double-buffered c_27 (and the narrow_row variant
+        // omits this wait too). See issue #46791.
+        tile_idx = tile_idx - HtWt + 1;
+    }
+    pack_untilize_uninit(cb_out);
+}
+
+void kernel_main() {
+    constexpr uint32_t Ht = get_compile_time_arg_val(0);
+    constexpr uint32_t Wt = get_compile_time_arg_val(1);
+    constexpr uint32_t HtWt = get_compile_time_arg_val(2);
+#ifdef SHARDED
+    constexpr uint32_t num_hw_blocks_per_core = get_compile_time_arg_val(3);
+    constexpr uint32_t last_output_row_num_datums = get_compile_time_arg_val(4);
+    constexpr uint32_t pack_num_pages = get_compile_time_arg_val(5);
+    constexpr uint32_t pack_num_pages_last_col = get_compile_time_arg_val(6);
+    constexpr uint32_t pack_num_pages_last_row = get_compile_time_arg_val(7);
+    constexpr uint32_t pack_num_pages_last_row_col = get_compile_time_arg_val(8);
+    // In order to support full_ct_dim > block_ct_dim, we would need to change use_narrow_row and row_size conditions to
+    // be:
+    //
+    //     constexpr bool use_narrow_row = last_output_row_num_datums < FACE_WIDTH ? true : false;
+    //     constexpr uint32_t row_size = last_output_row_num_datums < FACE_WIDTH ? last_output_row_num_datums :
+    //     TILE_WIDTH;
+    //
+    // However, changing these conditions makes yolov4 and transpose tests fail with a PCC error. For the error to be
+    // present in BH, it needs to be run in the full model sweep, but for WH_B0 it can be seen in isolation.
+    constexpr bool use_narrow_row = last_output_row_num_datums < TILE_WIDTH ? true : false;
+    constexpr uint32_t row_size = last_output_row_num_datums < TILE_WIDTH ? last_output_row_num_datums : TILE_WIDTH;
+
+#else
+    uint32_t num_hw_blocks_per_core = get_arg_val<uint32_t>(0);
+#endif
+
+#ifdef SHARDED
+    constexpr auto cb_in = tt::CBIndex::c_24;
+    constexpr auto cb_tilize = tt::CBIndex::c_25;
+    constexpr auto cb_out_idx =
+        (Ht > 8) ? tt::CBIndex::c_27 : tt::CBIndex::c_16;  // temporary fix until pack_untilize is fully fixed
+#else
+    constexpr auto cb_in = tt::CBIndex::c_0;
+    constexpr auto cb_tilize = tt::CBIndex::c_24;
+    constexpr auto cb_out_idx = tt::CBIndex::c_16;
+#endif
+
+    CircularBuffer cb_tilize_buf(cb_tilize);
+    CircularBuffer cb_out(cb_out_idx);
+
+    unary_op_init_common(cb_in, cb_out_idx);
+
+    for (uint32_t n = 0; n < num_hw_blocks_per_core; n++) {
+        // Tilize input (Ht rows × Wt tiles). Fp32Mode::Lossless keeps the full
+        // Float32 mantissa through tilization; the default Fast mode would
+        // collapse it to tf32 precision before the transpose ever runs.
+        compute_kernel_lib::tilize<
+            Wt,
+            cb_in,
+            cb_tilize,
+            compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
+            compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
+            compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure,
+            compute_kernel_lib::tilize_config::Fp32Mode::Lossless>(Ht);
+
+        // transpose
+        cb_tilize_buf.wait_front(HtWt);
+        uint32_t tile_idx = 0;
+#ifdef SHARDED
+        if constexpr (use_narrow_row) {
+            transpose_with_pack_untilize_narrow_row<
+                Wt,
+                Ht,
+                HtWt,
+                use_narrow_row,
+                row_size,
+                pack_num_pages_last_col,
+                pack_num_pages_last_row_col,
+                cb_out_idx>(cb_tilize, cb_out);
+        } else {
+            transpose_with_pack_untilize<Wt, Ht, HtWt, cb_out_idx>(cb_tilize, cb_out);
+        }
+#else
+        transpose_with_pack_untilize<Wt, Ht, HtWt, cb_out_idx>(cb_tilize, cb_out);
+#endif
+
+        cb_tilize_buf.pop_front(HtWt);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/compute/transpose_wh_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/compute/transpose_wh_sharded.cpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/transpose_wh.h"
+#include "api/dataflow/circular_buffer.h"
+
+void kernel_main() {
+    uint32_t NHtWt = get_arg_val<uint32_t>(0);
+    uint32_t HtWt = get_arg_val<uint32_t>(1);
+    uint32_t N = get_arg_val<uint32_t>(2);
+    uint32_t Ht = get_arg_val<uint32_t>(3);
+    uint32_t Wt = get_arg_val<uint32_t>(4);
+
+    constexpr uint32_t cb_id_in = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_id_out = get_compile_time_arg_val(1);
+
+    transpose_wh_init(cb_id_in, cb_id_out);
+
+    CircularBuffer cb_in(cb_id_in);
+    CircularBuffer cb_out(cb_id_out);
+
+    // transpose a row-major block:
+    // - uses reader_unary_transpose_wh
+    // - transpose_wh each tile
+
+    uint32_t tile_idx = 0;
+    uint32_t tile_idx_N = 0;
+
+    cb_in.wait_front(NHtWt);
+    cb_out.reserve_back(NHtWt);
+    for (uint32_t n = 0; n < N; ++n) {
+        tile_idx = tile_idx_N;
+        for (uint32_t w = 0; w < Wt; ++w) {
+            for (uint32_t h = 0; h < Ht; ++h) {
+                tile_regs_acquire();
+                transpose_wh_tile(cb_id_in, tile_idx, 0);
+                tile_regs_commit();
+                tile_regs_wait();
+                pack_tile(0, cb_id_out);
+                tile_regs_release();
+                tile_idx += Wt;
+            }
+            tile_idx = tile_idx - HtWt + 1;
+        }
+        tile_idx_N += HtWt;
+    }
+    cb_out.push_back(NHtWt);
+    cb_in.pop_front(NHtWt);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/reader_unary_transpose_cn_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/reader_unary_transpose_cn_interleaved_start_id.cpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t N = get_arg_val<uint32_t>(1);
+    const uint32_t C = get_arg_val<uint32_t>(2);
+    const uint32_t HtWt = get_arg_val<uint32_t>(3);
+    const uint32_t batch_step = get_arg_val<uint32_t>(4);    // CHtWt - HtWt
+    const uint32_t channel_step = get_arg_val<uint32_t>(5);  // NCHtWt - HtWt
+    const uint32_t num_pages = get_arg_val<uint32_t>(6);
+    const uint32_t start_id = get_arg_val<uint32_t>(7);
+    uint32_t hw = get_arg_val<uint32_t>(8);
+    uint32_t n = get_arg_val<uint32_t>(9);
+
+    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
+    constexpr uint32_t page_size = get_compile_time_arg_val(1);
+    constexpr uint32_t read_size = get_compile_time_arg_val(2);
+    constexpr auto src_args = TensorAccessorArgs<3>();
+
+    // ublocks size defined in tiles
+    constexpr uint32_t onepage = 1;
+
+    const auto s = TensorAccessor(src_args, src_addr);
+
+    Noc noc;
+    CircularBuffer cb(cb_id_in0);
+
+    // read a ublock of tiles from src to CB, and then push the ublock to unpacker
+    uint32_t page_idx = start_id;
+    for (uint32_t i = 0; i < num_pages; ++i) {
+        cb.reserve_back(onepage);
+#ifdef CN_RM
+        // Restored native sharded multi-page split (see common.hpp helper).
+        // RM-only: the helper splits a logical "row page" across multiple shards laterally
+        // when the buffer is BLOCK/WIDTH-sharded. TILE-layout path below must keep the
+        // original single-page transfer since each tile is one indivisible NOC unit.
+        const uint32_t cb_write_ptr = cb.get_write_ptr();
+        tt::data_movement::common::noc_async_read_sharded(noc, cb_write_ptr, s, page_idx, 0, read_size);
+#else
+        noc.async_read(s, cb, page_size, {.page_id = page_idx}, {.offset_bytes = 0});
+#endif
+        noc.async_read_barrier();
+        cb.push_back(onepage);
+        page_idx++;
+        hw++;
+        if (hw == HtWt) {
+            hw = 0;
+            n++;
+            page_idx += batch_step;
+            if (n == N) {
+                n = 0;
+                page_idx -= channel_step;
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_partitioned.cpp
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+using uint32_t = std::uint32_t;
+
+// tile index to address
+inline uint32_t TADDR_FLOAT32(uint32_t ti) { return ti << 12; }
+inline uint32_t TADDR_BFLOAT16(uint32_t ti) { return ti << 11; }
+
+void kernel_main() {
+    uint32_t src0_addr = get_arg_val<uint32_t>(0);
+    uint32_t WT = get_arg_val<uint32_t>(1);
+    uint32_t H = get_arg_val<uint32_t>(2);
+    uint32_t CT = get_arg_val<uint32_t>(3);
+    uint32_t HW_bytes = get_arg_val<uint32_t>(4);
+    uint32_t CHW_bytes = get_arg_val<uint32_t>(5);
+    uint32_t start_id = get_arg_val<uint32_t>(6);
+    uint32_t num_tiles = get_arg_val<uint32_t>(7);
+    uint32_t batch_addr = get_arg_val<uint32_t>(8);
+    uint32_t h = get_arg_val<uint32_t>(9);
+    uint32_t htWT = get_arg_val<uint32_t>(10);
+    uint32_t ct = get_arg_val<uint32_t>(11);
+    uint32_t ctoffs = get_arg_val<uint32_t>(12);
+    uint32_t wt = get_arg_val<uint32_t>(13);
+
+    constexpr uint32_t SUBTILE_LINE_BYTES = get_compile_time_arg_val(0);
+    constexpr uint32_t FLOAT32_DTYPE = get_compile_time_arg_val(1);
+    constexpr uint32_t ALIGNMENT = get_compile_time_arg_val(2);
+    constexpr auto src_args = TensorAccessorArgs<3>();
+    constexpr bool MISALIGNED = ALIGNMENT > SUBTILE_LINE_BYTES;
+
+    constexpr uint32_t onetile = 1;
+    constexpr uint32_t cb_id_in0 = 0;
+
+    // The basic idea here is to iterate over output tiles (that will be over CT,WT) and H
+    // this will generate a linearly incremented output address in the inner loop
+    // we then reverse map this linear dest address to src address
+
+    const auto s0 = TensorAccessor(src_args, src0_addr);
+
+    Noc noc;
+    CircularBuffer cb(cb_id_in0);
+    CircularBuffer cb_scratch(1);
+
+    uint32_t intermed_l1_scratch = MISALIGNED ? cb_scratch.get_write_ptr() : 0;
+    volatile tt_l1_ptr uint8_t* intermed_l1_scratch_ptr = (volatile uint8_t*)intermed_l1_scratch;
+    for (uint32_t t = 0; t < num_tiles; t++) {
+        auto h32 = (h & 31);
+
+        cb.reserve_back(onetile);
+
+        uint32_t dest_tr0_l1 = cb.get_write_ptr();
+        // uint32_t save_dest = dest_tr0_l1;
+        uint32_t cSubtileOffs = 0;
+        for (uint32_t sub = 0; sub < 4; sub++) {
+            uint32_t c16offs = cSubtileOffs;
+            for (uint32_t c16 = 0; c16 < 16; c16++) {
+                // In this loop sub, c16 are source subtile, c16
+                // dest in this loop is varying h implicitly via dest address increment
+
+                // Dest is HCW
+                // We are iterating over it as H Ct Wt-tiles
+                // intra-tile FC16 for F going over 4-subtiles
+                // the source address is (bytes):
+                // src_addr = c*HW2 + (ht*Wt + wt)*1024*2 + f*256*2 + (h16*16 + w16)*2
+                // we have 512 bytes per subtile and 32 bytes per subtile row of 16 elems
+                // here sub<<9 is multiply by 512 which offset in bytes of a subtile
+                // note that dest h is decomposed as h = ht+h32 and htWT is incremented by WT in the outer H loop
+
+                // TODO(AP): not really trivial need better comments here
+                // auto sub_src_offs = (sub & 1) << 9; // if dest subtile w==16, add 512 to src subtile offset
+                uint32_t sub_src_offs;
+                uint32_t src_offs;
+                uint32_t bsrc_offs;
+                uint32_t batch_itile;
+                uint32_t rem;
+
+                if constexpr (FLOAT32_DTYPE) {
+                    sub_src_offs = (sub & 1) << 10;  // if dest subtile w==16, add 1024 to src subtile offset
+                    sub_src_offs +=
+                        (((h32 >> 4) << 1) << 10);  // if intra-tile source h is > 16, add 2*1024 to subtile offset
+                    // below we only use the lower 4 bits out of 5-bit range for h, shift by 5 because 4 bytes per
+                    // element
+                    src_offs =
+                        ctoffs + c16offs + TADDR_FLOAT32(htWT + wt) + sub_src_offs + ((h32 & 15) << 6);  // bytes offset
+                    bsrc_offs = batch_addr + src_offs;
+                    batch_itile = (bsrc_offs >> 12);
+                    rem = (bsrc_offs & 4095);
+                } else {
+                    sub_src_offs = (sub & 1) << 9;  // if dest subtile w==16, add 512 to src subtile offset
+                    sub_src_offs +=
+                        (((h32 >> 4) << 1) << 9);  // if intra-tile source h is > 16, add 2*512 to subtile offset
+                    // below we only use the lower 4 bits out of 5-bit range for h, shift by 5 because 2 bytes per
+                    // element
+                    src_offs = ctoffs + c16offs + TADDR_BFLOAT16(htWT + wt) + sub_src_offs +
+                               ((h32 & 15) << 5);  // bytes offset
+                    bsrc_offs = batch_addr + src_offs;
+                    batch_itile = (bsrc_offs >> 11);
+                    rem = (bsrc_offs & 2047);
+                }
+
+                if constexpr (MISALIGNED) {
+                    uint64_t banked_addr = s0.get_noc_addr(batch_itile, rem);
+                    uint32_t banked_alignment = banked_addr % ALIGNMENT;
+                    if (dest_tr0_l1 % ALIGNMENT != banked_alignment) {
+                        CoreLocalMem<uint32_t> scratch_dst(intermed_l1_scratch);
+                        noc.async_read(
+                            s0,
+                            scratch_dst,
+                            ALIGNMENT,
+                            {.page_id = batch_itile, .offset_bytes = rem - banked_alignment},
+                            {.offset_bytes = 0});
+                        volatile tt_l1_ptr uint8_t* dest_tr0_l1_ptr = (volatile uint8_t*)dest_tr0_l1;
+                        noc.async_read_barrier();
+                        for (uint32_t i = 0; i < SUBTILE_LINE_BYTES; i++) {
+                            dest_tr0_l1_ptr[i] = intermed_l1_scratch_ptr[i + banked_alignment];
+                        }
+                    } else {
+                        CoreLocalMem<uint32_t> dst(dest_tr0_l1);
+                        noc.async_read(
+                            s0,
+                            dst,
+                            SUBTILE_LINE_BYTES,
+                            {.page_id = batch_itile, .offset_bytes = rem},
+                            {.offset_bytes = 0});
+                    }
+                } else {
+                    CoreLocalMem<uint32_t> dst(dest_tr0_l1);
+                    noc.async_read(
+                        s0,
+                        dst,
+                        SUBTILE_LINE_BYTES,
+                        {.page_id = batch_itile, .offset_bytes = rem},
+                        {.offset_bytes = 0});
+                }
+
+                // the output address is just linearly incremented
+                dest_tr0_l1 += SUBTILE_LINE_BYTES;
+                c16offs += HW_bytes;
+            }
+            // subtiles are ordered like this:
+            // 0 1
+            // 2 3
+            // Here we offset C by 16 starting with subtile=2
+            if (sub == 1) {                       // after we are done with subtile 1, increment for sub=2
+                cSubtileOffs += (HW_bytes << 4);  // 16*HWbytes, which is subtile vertical size
+            }
+        }  // sub<4
+
+        // block on all outstanding noc DMA requests to complete
+        noc.async_read_barrier();
+
+        // notifies the unpacker that the buffer is populated
+        cb.push_back(onetile);
+        wt++;
+        if (wt == WT) {  // End of row
+            wt = 0;
+            ct++;
+            ctoffs += (HW_bytes << 5);  // since we increment ct, we need to multiply by 32
+            if (ct == CT) {             // End of column
+                ct = 0;
+                ctoffs = 0;
+                h++;
+                if (h == H) {  // End of batch
+                    batch_addr += CHW_bytes;
+                    h = 0;
+                    htWT = 0;
+                } else if (h32 == 31) {
+                    htWT += WT;
+                }
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_partitioned_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_partitioned_rm.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t num_sticks_per_core_read = get_arg_val<uint32_t>(1);
+    uint32_t num_read_per_barrier = get_arg_val<uint32_t>(2);
+    uint32_t start_id = get_arg_val<uint32_t>(3);
+    uint32_t curr_c = get_arg_val<uint32_t>(4);
+    uint32_t curr_h = get_arg_val<uint32_t>(5);
+    uint32_t curr_n = get_arg_val<uint32_t>(6);
+
+    constexpr uint32_t N = get_compile_time_arg_val(0);
+    constexpr uint32_t H = get_compile_time_arg_val(1);
+    constexpr uint32_t C = get_compile_time_arg_val(2);
+    constexpr uint32_t W_size_bytes = get_compile_time_arg_val(3);
+
+    constexpr uint32_t CH = C * H;
+
+    constexpr auto cb_in0 = tt::CBIndex::c_0;
+
+    const uint32_t stick_size_bytes = W_size_bytes;
+
+    constexpr auto src_args = TensorAccessorArgs<5>();
+    const auto s = TensorAccessor(src_args, src_addr);
+
+    Noc noc;
+    CircularBuffer cb(cb_in0);
+
+    uint32_t i_stick = start_id;
+    for (uint32_t iter = 0; iter < num_sticks_per_core_read; ++iter) {
+        cb.reserve_back(num_read_per_barrier);
+        const uint32_t cb_write_ptr = cb.get_write_ptr();
+        uint32_t l1_write_offset = 0;
+
+        for (uint32_t i = 0; i < num_read_per_barrier; ++i) {
+            // Restored native sharded multi-page split (see common.hpp helper).
+            tt::data_movement::common::noc_async_read_sharded(
+                noc, cb_write_ptr + l1_write_offset, s, i_stick, 0, stick_size_bytes);
+            l1_write_offset += stick_size_bytes;
+
+            curr_c++;
+            i_stick += H;
+            if (curr_c == C) {  // end of channel dim
+                curr_h++;
+                curr_c = 0;
+                if (curr_h == H) {  // end of H dim
+                    curr_n++;
+                    curr_c = 0;
+                    curr_h = 0;
+                    i_stick = i_stick - H + 1;
+                } else {
+                    i_stick = i_stick - CH + 1;
+                }
+            }
+        }
+        noc.async_read_barrier();
+        cb.push_back(num_read_per_barrier);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t num_tiles = get_arg_val<uint32_t>(1);
+    uint32_t start_id = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t num_writes = get_named_compile_time_arg_val("num_writes");
+    constexpr uint32_t padding_val_packed = get_named_compile_time_arg_val("padding_val_packed");
+    constexpr uint32_t needs_padding = get_named_compile_time_arg_val("needs_padding") == 1;
+    constexpr uint32_t swap_hw = get_named_compile_time_arg_val("swap_hw") == 1;
+    constexpr uint32_t H = get_named_compile_time_arg_val("H");
+    constexpr uint32_t W = get_named_compile_time_arg_val("W");
+    constexpr uint32_t accumulated_outer_dims = get_named_compile_time_arg_val("accumulated_outer_dims");
+    constexpr uint32_t TILE_HEIGHT = get_named_compile_time_arg_val("tile_height");
+    constexpr uint32_t TILE_WIDTH = get_named_compile_time_arg_val("tile_width");
+    constexpr auto src_args = TensorAccessorArgs<0>();
+
+    constexpr uint32_t H_p = tt::data_movement::common::round_up<H, TILE_HEIGHT>();
+    constexpr uint32_t W_p = tt::data_movement::common::round_up<W, TILE_WIDTH>();
+
+    constexpr uint32_t Wt = W_p / TILE_WIDTH;
+    constexpr uint32_t Ht = H_p / TILE_HEIGHT;
+
+    constexpr uint32_t HtWt = Ht * Wt;
+
+    constexpr uint32_t cb_id_in0 = 0;
+
+    // ublocks size defined in tiles
+    constexpr uint32_t onetile = 1;
+    const auto s = TensorAccessor(src_args, src_addr);
+
+    Noc noc;
+    CircularBuffer cb(cb_id_in0);
+    CircularBuffer cb_padding(tt::CBIndex::c_1);
+    const uint32_t tile_bytes = cb.get_tile_size();
+
+// read a ublock of tiles from src to CB, and then push the ublock to unpacker
+#ifdef BACKWARDS
+    uint32_t end_id = start_id - num_tiles;
+    for (uint32_t i = start_id; i != end_id; --i) {
+#else
+    uint32_t end_id = start_id + num_tiles;
+    for (uint32_t i = start_id; i < end_id; ++i) {
+#endif
+        uint32_t linear_tile_index = 0;
+        if constexpr (swap_hw) {
+            uint32_t rem = i;
+            uint32_t ht = rem % Ht;
+            rem /= Ht;
+            uint32_t wt = rem % Wt;
+            rem /= Wt;
+            uint32_t offset = rem % accumulated_outer_dims;
+            linear_tile_index = offset * HtWt + ht * Wt + wt;
+        } else {
+            linear_tile_index = i;
+        }
+        cb.reserve_back(onetile);
+        noc.async_read(s, cb, tile_bytes, {.page_id = linear_tile_index}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        cb.push_back(onetile);
+    }
+    if constexpr (needs_padding) {
+        // Add padding
+        cb_padding.reserve_back(1);
+        uint32_t l1_write_addr = cb_padding.get_write_ptr();
+        // Fill with padding value
+        // if bfloat16 num_writes = FACE_WIDTH / (sizeof(uint32_t))/(element_size)
+        tt::data_movement::common::fill_with_val(l1_write_addr, num_writes, padding_val_packed);
+        cb_padding.push_back(1);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/reader_unary_transpose_hc_sharded_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/reader_unary_transpose_hc_sharded_rm.cpp
@@ -1,0 +1,180 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+#ifdef USE_SPECIAL_CASE
+
+    bool read_single_h_block_per_core = get_arg_val<uint32_t>(0) == 1;
+    uint32_t num_C_blocks_per_core = get_arg_val<uint32_t>(1);
+    uint32_t num_sticks_per_shard_core = get_arg_val<uint32_t>(2);
+    uint32_t num_cores_read = get_arg_val<uint32_t>(3);
+    uint32_t read_stick_stride = get_arg_val<uint32_t>(4);
+    tt_l1_ptr uint32_t* read_stick_offset = (tt_l1_ptr uint32_t*)(get_arg_addr(5));
+    tt_l1_ptr uint32_t* noc_coord_x = (tt_l1_ptr uint32_t*)(get_arg_addr(5 + num_cores_read));
+    tt_l1_ptr uint32_t* noc_coord_y = (tt_l1_ptr uint32_t*)(get_arg_addr(5 + num_cores_read * 2));
+
+    constexpr uint32_t cb_in0 = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_out0 = get_compile_time_arg_val(1);
+    constexpr uint32_t stick_size_bytes = get_compile_time_arg_val(2);
+
+    Noc noc;
+    CircularBuffer cb_in(cb_in0);
+    CircularBuffer cb_out(cb_out0);
+
+    if (read_single_h_block_per_core) {
+        uint32_t write_stick_stride = stick_size_bytes * num_cores_read;
+        uint32_t l1_write_offset = 0;
+
+        for (uint32_t core = 0; core < num_cores_read; ++core) {
+            uint32_t src_addr = cb_in.get_read_ptr() + read_stick_offset[core];
+            uint32_t l1_write_addr = cb_out.get_write_ptr() + l1_write_offset;
+
+            noc.set_async_read_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+                UnicastEndpoint{},
+                stick_size_bytes,
+                {.noc_x = noc_coord_x[core], .noc_y = noc_coord_y[core], .addr = src_addr});
+
+            for (uint32_t i = 0; i < num_sticks_per_shard_core; ++i) {
+                CoreLocalMem<uint32_t> dst(l1_write_addr);
+                noc.async_read_with_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+                    UnicastEndpoint{},
+                    dst,
+                    stick_size_bytes,
+                    {.noc_x = noc_coord_x[core], .noc_y = noc_coord_y[core], .addr = src_addr},
+                    {.offset_bytes = 0});
+                src_addr += read_stick_stride;
+                l1_write_addr += write_stick_stride;
+            }
+            l1_write_offset += stick_size_bytes;
+            noc.async_read_barrier();
+        }
+    } else {
+        uint32_t l1_write_addr = cb_out.get_write_ptr();
+        uint32_t l1_read_addr = cb_in.get_read_ptr();
+
+        for (uint32_t c = 0; c < num_C_blocks_per_core; ++c) {
+            for (uint32_t core = 0; core < num_cores_read; ++core) {
+                uint32_t src_addr = l1_read_addr + read_stick_offset[core];
+
+                noc.set_async_read_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+                    UnicastEndpoint{},
+                    stick_size_bytes,
+                    {.noc_x = noc_coord_x[core], .noc_y = noc_coord_y[core], .addr = src_addr});
+
+                for (uint32_t i = 0; i < num_sticks_per_shard_core; ++i) {
+                    CoreLocalMem<uint32_t> dst(l1_write_addr);
+                    noc.async_read_with_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+                        UnicastEndpoint{},
+                        dst,
+                        stick_size_bytes,
+                        {.noc_x = noc_coord_x[core], .noc_y = noc_coord_y[core], .addr = src_addr},
+                        {.offset_bytes = 0});
+                    src_addr += read_stick_stride;
+                    l1_write_addr += stick_size_bytes;
+                }
+            }
+
+            l1_read_addr += stick_size_bytes;
+        }
+        noc.async_read_barrier();
+    }
+
+#else
+
+    constexpr uint32_t cb_in0 = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_out0 = get_compile_time_arg_val(1);
+    constexpr uint32_t N = get_compile_time_arg_val(2);
+    constexpr uint32_t H = get_compile_time_arg_val(3);
+    constexpr uint32_t C = get_compile_time_arg_val(4);
+    constexpr uint32_t W_size_bytes = get_compile_time_arg_val(5);
+    constexpr bool row_major = get_compile_time_arg_val(6) == 1;
+    constexpr uint32_t num_cores_x = get_compile_time_arg_val(7);
+    constexpr uint32_t num_cores_y = get_compile_time_arg_val(8);
+
+    uint32_t arg_idx = 0;
+    uint32_t num_sticks_per_core = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t start_id = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t curr_c = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t curr_h = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t curr_n = get_arg_val<uint32_t>(arg_idx++);
+
+    const uint32_t* const shard_grid_x_map = reinterpret_cast<const uint32_t* const>(get_arg_addr(arg_idx));
+    arg_idx += num_cores_x;
+    const uint32_t* const shard_grid_y_map = reinterpret_cast<const uint32_t* const>(get_arg_addr(arg_idx));
+    arg_idx += num_cores_y;
+
+    constexpr uint32_t CH = C * H;
+
+    const uint32_t stick_size_bytes = W_size_bytes;
+
+    Noc noc;
+    CircularBuffer cb_in(cb_in0);
+    CircularBuffer cb_out(cb_out0);
+
+    cb_out.reserve_back(num_sticks_per_core);
+    uint32_t l1_write_addr = cb_out.get_write_ptr();
+
+    uint32_t i_stick = start_id;
+    for (uint32_t iter = 0; iter < num_sticks_per_core; ++iter) {
+        uint32_t shard_id = i_stick / num_sticks_per_core;
+        uint32_t stick_id_in_shard = i_stick - (shard_id * num_sticks_per_core);
+
+        uint32_t shard_grid_inner_dim;
+        if constexpr (row_major) {
+            shard_grid_inner_dim = num_cores_x;
+        } else {
+            shard_grid_inner_dim = num_cores_y;
+        }
+        uint32_t shard_grid_outer_dim_id = shard_id / shard_grid_inner_dim;
+        uint32_t shard_grid_inner_dim_id = shard_id - (shard_grid_outer_dim_id * shard_grid_inner_dim);
+
+        uint32_t worker_x_physical, worker_y_physical;
+        if constexpr (row_major) {
+            worker_x_physical = shard_grid_x_map[shard_grid_inner_dim_id];
+            worker_y_physical = shard_grid_y_map[shard_grid_outer_dim_id];
+        } else {
+            worker_x_physical = shard_grid_x_map[shard_grid_outer_dim_id];
+            worker_y_physical = shard_grid_y_map[shard_grid_inner_dim_id];
+        }
+
+        uint32_t l1_read_addr = cb_in.get_read_ptr() + stick_id_in_shard * stick_size_bytes;
+
+        CoreLocalMem<uint32_t> dst(l1_write_addr);
+        noc.async_read(
+            UnicastEndpoint{},
+            dst,
+            stick_size_bytes,
+            {.noc_x = worker_x_physical, .noc_y = worker_y_physical, .addr = l1_read_addr},
+            {.offset_bytes = 0});
+        l1_write_addr += stick_size_bytes;
+
+        curr_c++;
+        i_stick += H;
+        if (curr_c == C) {  // end of channel dim
+            curr_h++;
+            curr_c = 0;
+            if (curr_h == H) {  // end of H dim
+                curr_n++;
+                curr_c = 0;
+                curr_h = 0;
+                i_stick = i_stick - H + 1;
+            } else {
+                i_stick = i_stick - CH + 1;
+            }
+        }
+    }
+
+    noc.async_read_barrier();
+    cb_out.push_back(num_sticks_per_core);
+
+#endif
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved.cpp
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t N = get_arg_val<uint32_t>(1);
+    uint32_t Ht = get_arg_val<uint32_t>(2);
+    uint32_t Wt = get_arg_val<uint32_t>(3);
+    uint32_t HtWt = get_arg_val<uint32_t>(4);
+
+    constexpr auto src_args = TensorAccessorArgs<0>();
+    constexpr uint32_t cb_id_in0 = 0;
+
+    // ublocks size defined in tiles
+    constexpr uint32_t onetile = 1;
+
+    Noc noc;
+    CircularBuffer cb(cb_id_in0);
+
+#ifdef REDUCE_SCALER
+    constexpr uint32_t cb_in_2 = 2;
+    constexpr uint32_t scaler = get_compile_time_arg_val(src_args.next_compile_time_args_offset());
+    CircularBuffer cb_scaler(cb_in_2);
+    cb_scaler.reserve_back(1);
+    if (scaler != 0) {
+        uint16_t u = uint16_t(scaler >> 16);
+        auto ptr = reinterpret_cast<uint16_t*>(cb_scaler.get_write_ptr());
+        for (int j = 0; j < 1024; j++) {
+            ptr[j] = uint16_t(0);
+        }
+
+        for (int k = 0; k < 4; k++) {
+            for (int j = 0; j < 16; j++) {
+                ptr[k * 256 + j] = u;
+            }
+        }
+    }
+    cb_scaler.push_back(1);
+#endif
+
+    uint32_t i_tile_N = 0;  // first tile in current batch
+    uint32_t i_tile = 0;
+
+    const uint32_t tile_bytes = cb.get_tile_size();
+    const auto s = TensorAccessor(src_args, src_addr);
+
+    // this reader will read a NHW tensor in NWH order
+    for (uint32_t n = 0; n < N; n++) {
+        i_tile = i_tile_N;
+        for (uint32_t w = 0; w < Wt; w++) {
+            for (uint32_t h = 0; h < Ht; h++) {
+                cb.reserve_back(onetile);
+                noc.async_read(s, cb, tile_bytes, {.page_id = i_tile}, {.offset_bytes = 0});
+                noc.async_read_barrier();
+
+                cb.push_back(onetile);
+                i_tile += Wt;  // stride in H
+            }  // Ht
+            i_tile -= HtWt;  // go back to H=0
+            i_tile += 1;     // increment Wt
+        }  // Wt
+        i_tile_N += HtWt;  // stride in batch/channel
+    }  // N
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_start_id.cpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t num_tiles = get_arg_val<uint32_t>(1);
+    uint32_t start_id = get_arg_val<uint32_t>(2);
+    uint32_t start_ht = get_arg_val<uint32_t>(3);
+    uint32_t start_wt = get_arg_val<uint32_t>(4);
+
+    uint32_t Ht = get_arg_val<uint32_t>(5);
+    uint32_t Wt = get_arg_val<uint32_t>(6);
+    uint32_t HtWt = get_arg_val<uint32_t>(7);
+
+    constexpr auto src_args = TensorAccessorArgs<0>();
+
+    constexpr uint32_t cb_id_in0 = 0;
+
+    // ublocks size defined in tiles
+    constexpr uint32_t onetile = 1;
+    CircularBuffer cb(cb_id_in0);
+    const uint32_t tile_bytes = cb.get_tile_size();
+    const auto s = TensorAccessor(src_args, src_addr);
+
+    Noc noc;
+
+    uint32_t ht = start_ht;
+    uint32_t wt = start_wt;
+    uint32_t i_tile = start_id;
+
+    // this reader will read a NHW tensor in NWH order
+    for (uint32_t i = 0; i < num_tiles; i++) {
+        cb.reserve_back(onetile);
+        noc.async_read(s, cb, tile_bytes, {.page_id = i_tile}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+
+        cb.push_back(onetile);
+        i_tile += Wt;  // stride in H
+        ht += 1;
+        if (ht == Ht) {
+            ht = 0;
+            i_tile += 1;
+            wt += 1;
+            if (wt == Wt) {
+                wt = 0;
+                i_tile -= Wt;  // Start of next batch
+            } else {
+                i_tile -= HtWt;  // Start of next col
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_start_id_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_start_id_rm.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t start_id = get_arg_val<uint32_t>(1);
+    uint32_t num_hw_blocks_per_core = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t Ht = get_compile_time_arg_val(0);
+    constexpr uint32_t H_per_tile = get_compile_time_arg_val(1);
+    constexpr uint32_t H_per_tile_last = get_compile_time_arg_val(2);
+    constexpr uint32_t Wt = get_compile_time_arg_val(3);
+    constexpr uint32_t W = get_compile_time_arg_val(4);
+    constexpr uint32_t HtWt = get_compile_time_arg_val(5);
+    constexpr uint32_t W_size_bytes = get_compile_time_arg_val(6);
+    constexpr uint32_t l1_write_offset_bytes = get_compile_time_arg_val(7);
+    constexpr auto src_args = TensorAccessorArgs<9>();
+
+    constexpr auto cb_in0 = tt::CBIndex::c_0;
+
+    const uint32_t stick_size_bytes = W_size_bytes;
+
+    const auto s = TensorAccessor(src_args, src_addr);
+
+    Noc noc;
+    CircularBuffer cb(cb_in0);
+
+    uint32_t i_stick = start_id;
+
+    // this reader will read a NHW tensor in NWH order
+    // Uses tt::data_movement::common::noc_async_read_sharded to restore the multi-page
+    // split that BLOCK/WIDTH-sharded RM buffers need (a logical row can span multiple
+    // shards laterally). PR #42130 had replaced these helpers with the
+    // single-NOC-transfer experimental::Noc::async_read primitive, which silently
+    // dropped the split logic for BLOCK/WIDTH-sharded RM inputs (24+ test cases).
+    for (uint32_t n = 0; n < num_hw_blocks_per_core; n++) {
+        for (uint32_t h = 0; h < Ht; ++h) {
+            cb.reserve_back(Wt);
+            const uint32_t cb_write_ptr = cb.get_write_ptr();
+            uint32_t l1_write_offset = 0;
+            uint32_t H_curr = h == Ht - 1 ? H_per_tile_last : H_per_tile;
+            for (uint32_t h_datum = 0; h_datum < H_curr; ++h_datum) {
+                tt::data_movement::common::noc_async_read_sharded(
+                    noc, cb_write_ptr + l1_write_offset, s, i_stick, 0, stick_size_bytes);
+                l1_write_offset += l1_write_offset_bytes;
+                i_stick += 1;
+            }
+            noc.async_read_barrier();
+            cb.push_back(Wt);
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/reader_unary_transpose_wh_sharded_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/reader_unary_transpose_wh_sharded_rm.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    constexpr uint32_t num_hw_blocks_per_core = get_compile_time_arg_val(0);
+    constexpr uint32_t Ht = get_compile_time_arg_val(1);
+    constexpr uint32_t H_per_tile = get_compile_time_arg_val(2);
+    constexpr uint32_t H_per_tile_last = get_compile_time_arg_val(3);
+    constexpr uint32_t Wt = get_compile_time_arg_val(4);
+    constexpr uint32_t W_size_bytes = get_compile_time_arg_val(5);
+    constexpr uint32_t l1_write_offset_bytes = get_compile_time_arg_val(6);
+
+    constexpr auto cb_in0 = tt::CBIndex::c_0;
+    constexpr auto cb_in = tt::CBIndex::c_24;
+
+    const uint32_t stick_size_bytes = W_size_bytes;
+
+    Noc noc;
+    CircularBuffer cb_src(cb_in0);
+    CircularBuffer cb_dst(cb_in);
+
+    uint32_t src_addr = cb_src.get_read_ptr();
+
+    noc.set_async_read_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+        UnicastEndpoint{},
+        stick_size_bytes,
+        {.noc_x = (uint32_t)my_x[noc.get_noc_id()], .noc_y = (uint32_t)my_y[noc.get_noc_id()], .addr = src_addr});
+
+    for (uint32_t n = 0; n < num_hw_blocks_per_core; n++) {
+        for (uint32_t h = 0; h < Ht; ++h) {
+            cb_dst.reserve_back(Wt);
+            uint32_t l1_write_addr = cb_dst.get_write_ptr();
+            uint32_t H_curr = h == Ht - 1 ? H_per_tile_last : H_per_tile;
+            for (uint32_t h_datum = 0; h_datum < H_curr; ++h_datum) {
+                CoreLocalMem<uint32_t> dst(l1_write_addr);
+                noc.async_read_with_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+                    UnicastEndpoint{},
+                    dst,
+                    stick_size_bytes,
+                    {.noc_x = (uint32_t)my_x[noc.get_noc_id()],
+                     .noc_y = (uint32_t)my_y[noc.get_noc_id()],
+                     .addr = src_addr},
+                    {.offset_bytes = 0});
+                l1_write_addr += l1_write_offset_bytes;
+                src_addr += stick_size_bytes;
+            }
+            noc.async_read_barrier();
+            cb_dst.push_back(Wt);
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/writer_unary_transpose_cn_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/writer_unary_transpose_cn_interleaved_start_id.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    uint32_t num_pages = get_arg_val<uint32_t>(1);
+    uint32_t start_id = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
+    constexpr uint32_t page_size = get_compile_time_arg_val(1);
+    constexpr uint32_t write_size = get_compile_time_arg_val(2);
+    constexpr auto dst_args = TensorAccessorArgs<3>();
+
+    constexpr uint32_t onepage = 1;
+
+    const auto s = TensorAccessor(dst_args, dst_addr);
+
+    Noc noc;
+    CircularBuffer cb(cb_id_out);
+
+    uint32_t end_id = start_id + num_pages;
+    for (uint32_t i = start_id; i < end_id; ++i) {
+        cb.wait_front(onepage);
+#ifdef CN_RM
+        // Restored native sharded multi-page split (see common.hpp helper).
+        // RM-only: see reader kernel for rationale; TILE-layout below uses original API.
+        const uint32_t cb_read_ptr = cb.get_read_ptr();
+        tt::data_movement::common::noc_async_write_sharded(noc, cb_read_ptr, s, i, 0, write_size);
+#else
+        noc.async_write(cb, s, page_size, {.offset_bytes = 0}, {.page_id = i});
+#endif
+        noc.async_write_barrier();
+        cb.pop_front(onepage);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_start_id_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_start_id_rm.cpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    uint32_t num_sticks_per_core_read = get_arg_val<uint32_t>(1);
+    uint32_t num_read_per_barrier = get_arg_val<uint32_t>(2);
+    uint32_t start_id = get_arg_val<uint32_t>(3);
+
+    constexpr uint32_t cb_out0 = get_compile_time_arg_val(0);
+    constexpr uint32_t W_size_bytes = get_compile_time_arg_val(1);
+
+    const uint32_t stick_size_bytes = W_size_bytes;
+
+    constexpr auto dst_args = TensorAccessorArgs<3>();
+    const auto s = TensorAccessor(dst_args, dst_addr);
+
+    Noc noc;
+    CircularBuffer cb(cb_out0);
+
+    uint32_t i_stick = start_id;
+    for (uint32_t iter = 0; iter < num_sticks_per_core_read; ++iter) {
+        cb.wait_front(num_read_per_barrier);
+        const uint32_t cb_read_ptr = cb.get_read_ptr();
+        uint32_t l1_read_offset = 0;
+
+        for (uint32_t i = 0; i < num_read_per_barrier; ++i) {
+            // Restored native sharded multi-page split (see common.hpp helper).
+            tt::data_movement::common::noc_async_write_sharded(
+                noc, cb_read_ptr + l1_read_offset, s, i_stick, 0, stick_size_bytes);
+            l1_read_offset += stick_size_bytes;
+            i_stick += 1;
+        }
+        noc.async_write_barrier();
+        cb.pop_front(num_read_per_barrier);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
@@ -1,0 +1,205 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    // Retrieve arguments
+    uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    uint32_t start_tile_idx = get_arg_val<uint32_t>(1);
+    uint32_t end_tile_idx = get_arg_val<uint32_t>(2);
+    uint32_t start_padding_tile_idx = get_arg_val<uint32_t>(3);
+    uint32_t end_padding_tile_idx = get_arg_val<uint32_t>(4);
+
+    // Compile-time constants
+    constexpr uint32_t element_size = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(1);
+    constexpr uint32_t C = get_compile_time_arg_val(2);
+    constexpr uint32_t H = get_compile_time_arg_val(3);
+    constexpr uint32_t W = get_compile_time_arg_val(4);
+    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(5);
+    constexpr uint32_t TILE_WIDTH = get_compile_time_arg_val(6);
+    constexpr uint32_t FACE_HEIGHT = get_compile_time_arg_val(7);
+    constexpr uint32_t FACE_WIDTH = get_compile_time_arg_val(8);
+    constexpr bool needs_padding = get_compile_time_arg_val(9) == 1;
+    constexpr auto dst_args = TensorAccessorArgs<10>();
+
+    // Derived compile-time constants
+    constexpr uint32_t TILE_HW = TILE_HEIGHT * TILE_WIDTH;
+    constexpr uint8_t NUM_FACES_H = TILE_HEIGHT / FACE_HEIGHT;
+    constexpr uint8_t NUM_FACES_W = TILE_WIDTH / FACE_WIDTH;
+
+    constexpr uint32_t C_p = tt::data_movement::common::round_up<C, TILE_HEIGHT>();
+    constexpr uint32_t H_p = tt::data_movement::common::round_up<H, TILE_HEIGHT>();
+    constexpr uint32_t W_p = tt::data_movement::common::round_up<W, TILE_WIDTH>();
+
+    constexpr uint32_t W_t = W_p / TILE_WIDTH;
+    constexpr uint32_t H_t = H_p / TILE_HEIGHT;
+    constexpr uint32_t C_t = C_p / TILE_HEIGHT;
+
+    constexpr uint32_t SUBTILE_LINE_BYTES = FACE_WIDTH * element_size;
+
+    // Initialize address generator
+    const auto s = TensorAccessor(dst_args, dst_addr);
+
+    Noc noc;
+    CircularBuffer cb(cb_id_out0);
+    CircularBuffer cb_padding(tt::CBIndex::c_1);
+
+    // Calculate actual data height in the last tile
+    constexpr uint32_t H_last_tile = H - (H_t - 1) * TILE_HEIGHT;
+
+    // Calculate real_faces_h
+    uint8_t remainder_faces_h = tt::data_movement::common::div_up<H_last_tile, FACE_HEIGHT>();
+
+    uint32_t remainder = H_last_tile % FACE_HEIGHT;
+    uint8_t sub_tile_lines_real = (remainder == 0) ? FACE_HEIGHT : static_cast<uint8_t>(remainder);
+
+    // Precompute constants used in inner loops
+    const uint32_t face_height_width = FACE_HEIGHT * FACE_WIDTH;
+    const uint32_t num_faces_wh = NUM_FACES_W * FACE_WIDTH;
+
+    // Main single loop over all tiles
+    for (uint32_t tile_idx = start_tile_idx; tile_idx < end_tile_idx; ++tile_idx) {
+        // Compute n, c, h, w from tile_idx
+        uint32_t w = tile_idx % W_t;
+        uint32_t temp = tile_idx / W_t;
+
+        uint32_t h = temp % H_t;
+        temp /= H_t;
+
+        uint32_t c = temp % C;
+        uint32_t n = temp / C;
+
+        // Recalculate variables from the original loops
+        uint32_t output_ct_index = c / TILE_HEIGHT;
+        uint32_t rem = c % TILE_HEIGHT;
+
+        // Calculate the index inside the face_matrix
+        uint32_t output_face_h = rem / FACE_HEIGHT;
+        uint32_t output_sub_tile_line = rem % FACE_HEIGHT;
+
+        // Precompute offset for the current face_h
+        uint32_t face_h_offset = output_face_h * NUM_FACES_W * face_height_width;
+
+        // Calculate the index along the channel dimension for the output tensor
+        uint32_t output_h = h * TILE_HEIGHT;
+
+        // Synchronization and read address retrieval
+        cb.wait_front(1);
+        uint32_t l1_read_addr = cb.get_read_ptr();
+
+        // Determine the number of faces in the height dimension
+        uint8_t num_faces_h = (h == H_t - 1) ? remainder_faces_h : NUM_FACES_H;
+
+        // Precompute parts of linear_idx that remain constant within the inner loops
+        // linear_idx = n * H * C_t * W_t + output_h_face_line * C_t * W_t + output_ct_index * W_t + w
+        // We can precompute n * H * C_t * W_t + output_ct_index * W_t + w
+        uint32_t base_linear_idx = n * H * C_t * W_t + output_ct_index * W_t + w;
+
+        // Iterate over faces in the height dimension
+        for (uint8_t face_h = 0; face_h < num_faces_h; ++face_h) {
+            // Compute output_h_face once per face_h
+            uint32_t output_h_face = output_h + face_h * FACE_HEIGHT;
+
+            // Precompute the additive factor for output_h_face_line
+            uint32_t base_output_h_face_line = output_h_face;
+
+            // Determine the number of sub-tile lines to process
+            bool is_last_sub_tile_line = (h == H_t - 1) && (face_h == num_faces_h - 1);
+            uint8_t sub_tile_lines = is_last_sub_tile_line ? sub_tile_lines_real : FACE_HEIGHT;
+
+            // Iterate over faces in the width dimension
+            for (uint8_t face_w = 0; face_w < NUM_FACES_W; ++face_w) {
+                // Compute output_w_face once per face_w
+                uint32_t output_w_face = w + face_w * FACE_WIDTH;
+
+                // Precompute the offset multiplier for the current face_w
+                uint32_t face_w_offset = face_w * face_height_width;
+
+                // Compute the offset
+                uint32_t offset = (face_h_offset + face_w_offset + output_sub_tile_line * FACE_WIDTH) * element_size;
+
+                // Iterate over sub-tile lines
+                for (uint8_t sub_tile_line = 0; sub_tile_line < sub_tile_lines; ++sub_tile_line) {
+                    // Compute the complete output_h_face_line
+                    uint32_t output_h_face_line = base_output_h_face_line + sub_tile_line;
+
+                    // Compute the linear index
+                    uint32_t linear_idx = base_linear_idx + output_h_face_line * C_t * W_t;
+
+                    // Perform asynchronous write
+                    CoreLocalMem<uint32_t> src(l1_read_addr);
+                    noc.async_write(
+                        src,
+                        s,
+                        SUBTILE_LINE_BYTES,
+                        {.offset_bytes = 0},
+                        {.page_id = linear_idx, .offset_bytes = offset});
+
+                    // Increment the read address
+                    l1_read_addr += SUBTILE_LINE_BYTES;
+                }
+
+                // Skip padding if not all lines are real
+                if (is_last_sub_tile_line) {
+                    l1_read_addr += (FACE_HEIGHT - sub_tile_lines) * SUBTILE_LINE_BYTES;
+                }
+            }
+        }
+
+        // Ensure all asynchronous writes are completed before proceeding
+        noc.async_write_barrier();
+
+        // Remove the processed tile from the front of the buffer
+        cb.pop_front(1);
+    }
+
+    // add padding
+    if constexpr (needs_padding) {
+        cb_padding.wait_front(1);
+
+        uint32_t l1_read_ptr = cb_padding.get_read_ptr();
+
+        constexpr uint32_t c_t = C_t - 1;
+        constexpr uint8_t C_in_tile = C % TILE_HEIGHT;
+        constexpr uint8_t face_c_start = C_in_tile / FACE_HEIGHT;
+
+        for (uint32_t tile_idx = start_padding_tile_idx; tile_idx < end_padding_tile_idx; ++tile_idx) {
+            // Map tile_idx to (n, h, w_t)
+            uint32_t n = tile_idx / (H * W_t);
+            uint32_t remainder1 = tile_idx % (H * W_t);
+            uint32_t h = remainder1 / W_t;
+            uint32_t w_t = remainder1 % W_t;
+
+            // Calculate linear_idx of padded tile inside output tensor buffer
+            uint32_t linear_idx = n * H * C_t * W_t + h * C_t * W_t + c_t * W_t + w_t;
+
+            for (uint8_t face_c = face_c_start; face_c < NUM_FACES_H; ++face_c) {
+                // Offset to the start of the current face along the channel dimension/height of the tile
+                uint32_t face_c_offset = face_c * NUM_FACES_W * face_height_width;
+
+                // Sub-tile/face line where our padded data starts
+                uint8_t sub_tile_line_start = face_c == face_c_start ? C_in_tile % FACE_HEIGHT : 0;
+
+                for (uint8_t face_w = 0; face_w < NUM_FACES_W; ++face_w) {
+                    // Offset to the start of the current face along the width of the tile
+                    uint32_t face_w_offset = face_w * face_height_width;
+                    uint32_t offset = (face_c_offset + face_w_offset + sub_tile_line_start * FACE_WIDTH) * element_size;
+                    uint32_t write_size = SUBTILE_LINE_BYTES * (FACE_HEIGHT - sub_tile_line_start);
+                    CoreLocalMem<uint32_t> pad_src(l1_read_ptr);
+                    noc.async_write(
+                        pad_src, s, write_size, {.offset_bytes = 0}, {.page_id = linear_idx, .offset_bytes = offset});
+                }
+            }
+        }
+        noc.async_write_barrier();
+        cb_padding.pop_front(1);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/writer_unary_transpose_hc_sharded_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/writer_unary_transpose_hc_sharded_rm.cpp
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    bool read_single_h_block_per_core = get_arg_val<uint32_t>(0) == 1;
+    uint32_t num_C_blocks_per_core = get_arg_val<uint32_t>(1);
+    uint32_t num_sticks_per_shard_core = get_arg_val<uint32_t>(2);
+    uint32_t num_cores_read = get_arg_val<uint32_t>(3);
+    uint32_t read_stick_stride = get_arg_val<uint32_t>(4);
+    uint32_t src_read_stick_offset = get_arg_val<uint32_t>(5);
+    uint32_t dst_write_stick_offset = get_arg_val<uint32_t>(6);
+    tt_l1_ptr uint32_t* read_stick_offset = (tt_l1_ptr uint32_t*)(get_arg_addr(7));
+    tt_l1_ptr uint32_t* noc_coord_x = (tt_l1_ptr uint32_t*)(get_arg_addr(7 + num_cores_read));
+    tt_l1_ptr uint32_t* noc_coord_y = (tt_l1_ptr uint32_t*)(get_arg_addr(7 + num_cores_read * 2));
+
+    constexpr uint32_t cb_in0 = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_out0 = get_compile_time_arg_val(1);
+    constexpr uint32_t stick_size_bytes = get_compile_time_arg_val(2);
+
+    Noc noc;
+    CircularBuffer cb_in(cb_in0);
+    CircularBuffer cb_out(cb_out0);
+
+    if (read_single_h_block_per_core) {
+        uint32_t write_stick_stride = stick_size_bytes * num_cores_read;
+
+        uint32_t l1_write_offset = 0;
+        for (uint32_t core = 0; core < num_cores_read; ++core) {
+            uint32_t src_addr = cb_in.get_read_ptr() + read_stick_offset[core] + src_read_stick_offset;
+            uint32_t l1_write_addr = cb_out.get_write_ptr() + l1_write_offset + dst_write_stick_offset;
+            for (uint32_t i = 0; i < num_sticks_per_shard_core; ++i) {
+                CoreLocalMem<uint32_t> dst(l1_write_addr);
+                noc.async_read<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+                    UnicastEndpoint{},
+                    dst,
+                    stick_size_bytes,
+                    {.noc_x = noc_coord_x[core], .noc_y = noc_coord_y[core], .addr = src_addr},
+                    {.offset_bytes = 0});
+                src_addr += read_stick_stride;
+                l1_write_addr += write_stick_stride;
+            }
+            l1_write_offset += stick_size_bytes;
+            noc.async_read_barrier();
+        }
+    } else {
+        uint32_t l1_write_addr = cb_out.get_write_ptr() + dst_write_stick_offset;
+        uint32_t l1_read_addr = cb_in.get_read_ptr() + src_read_stick_offset;
+
+        for (uint32_t c = 0; c < num_C_blocks_per_core; ++c) {
+            for (uint32_t core = 0; core < num_cores_read; ++core) {
+                uint32_t src_addr = l1_read_addr + read_stick_offset[core];
+
+                noc.set_async_read_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+                    UnicastEndpoint{},
+                    stick_size_bytes,
+                    {.noc_x = noc_coord_x[core], .noc_y = noc_coord_y[core], .addr = src_addr});
+
+                for (uint32_t i = 0; i < num_sticks_per_shard_core; ++i) {
+                    CoreLocalMem<uint32_t> dst(l1_write_addr);
+                    noc.async_read_with_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+                        UnicastEndpoint{},
+                        dst,
+                        stick_size_bytes,
+                        {.noc_x = noc_coord_x[core], .noc_y = noc_coord_y[core], .addr = src_addr},
+                        {.offset_bytes = 0});
+                    src_addr += read_stick_stride;
+                    l1_write_addr += stick_size_bytes;
+                }
+            }
+            l1_read_addr += stick_size_bytes;
+        }
+        noc.async_read_barrier();
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/writer_unary_transpose_wh_interleaved_start_id_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/writer_unary_transpose_wh_interleaved_start_id_rm.cpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    uint32_t start_id = get_arg_val<uint32_t>(1);
+    uint32_t num_hw_blocks_per_core = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t cb_out0 = get_compile_time_arg_val(0);
+    constexpr uint32_t Ht = get_compile_time_arg_val(1);
+    constexpr uint32_t H = get_compile_time_arg_val(2);
+    constexpr uint32_t Wt = get_compile_time_arg_val(3);
+    constexpr uint32_t W_per_tile = get_compile_time_arg_val(4);
+    constexpr uint32_t W_per_tile_last = get_compile_time_arg_val(5);
+    constexpr uint32_t HtWt = get_compile_time_arg_val(6);
+    constexpr uint32_t H_size_bytes = get_compile_time_arg_val(7);
+    constexpr uint32_t l1_read_offset_bytes = get_compile_time_arg_val(8);
+
+    // single-tile ublocks
+    const uint32_t stick_size_bytes = H_size_bytes;
+
+    constexpr auto dst_args = TensorAccessorArgs<10>();
+    const auto s = TensorAccessor(dst_args, dst_addr);
+
+    Noc noc;
+    CircularBuffer cb(cb_out0);
+
+    uint32_t i_stick = start_id;
+
+    // Uses tt::data_movement::common::noc_async_write_sharded for BLOCK/WIDTH-sharded
+    // RM outputs (see reader kernel comment). PR #42130 dropped this on the writer side
+    // too, silently regressing the same 24+ test cases for output sharding.
+    for (uint32_t n = 0; n < num_hw_blocks_per_core; n++) {
+        for (uint32_t w = 0; w < Wt; ++w) {
+            cb.wait_front(Ht);
+            const uint32_t cb_read_ptr = cb.get_read_ptr();
+            uint32_t l1_read_offset = 0;
+            uint32_t W_curr = w == Wt - 1 ? W_per_tile_last : W_per_tile;
+            for (uint32_t w_datum = 0; w_datum < W_curr; ++w_datum) {
+                tt::data_movement::common::noc_async_write_sharded(
+                    noc, cb_read_ptr + l1_read_offset, s, i_stick, 0, stick_size_bytes);
+                l1_read_offset += l1_read_offset_bytes;
+                i_stick += 1;
+            }
+            noc.async_write_barrier();
+            cb.pop_front(Ht);
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/writer_unary_transpose_wh_sharded_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/writer_unary_transpose_wh_sharded_rm.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    constexpr uint32_t num_hw_blocks_per_core = get_compile_time_arg_val(0);
+    constexpr uint32_t Ht = get_compile_time_arg_val(1);
+    constexpr uint32_t Wt = get_compile_time_arg_val(2);
+    constexpr uint32_t W_per_tile = get_compile_time_arg_val(3);
+    constexpr uint32_t W_per_tile_last = get_compile_time_arg_val(4);
+    constexpr uint32_t H_size_bytes = get_compile_time_arg_val(5);
+    constexpr uint32_t l1_read_offset_bytes = get_compile_time_arg_val(6);
+
+    constexpr auto cb_out = tt::CBIndex::c_27;
+    constexpr auto cb_out0 = tt::CBIndex::c_16;
+
+    const uint32_t stick_size_bytes = H_size_bytes;
+
+    Noc noc;
+    CircularBuffer cb_src(cb_out);
+    CircularBuffer cb_dst(cb_out0);
+
+    uint32_t dst_addr = cb_dst.get_write_ptr();
+
+    // temporary fix until pack_untilze is fully fixed
+    if constexpr (Ht > 8) {
+        noc.set_async_write_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+            UnicastEndpoint{},
+            stick_size_bytes,
+            {.noc_x = (uint32_t)my_x[noc.get_noc_id()], .noc_y = (uint32_t)my_y[noc.get_noc_id()], .addr = dst_addr});
+
+        for (uint32_t n = 0; n < num_hw_blocks_per_core; n++) {
+            for (uint32_t w = 0; w < Wt; ++w) {
+                cb_src.wait_front(Ht);
+                uint32_t l1_read_addr = cb_src.get_read_ptr();
+                uint32_t W_curr = w == Wt - 1 ? W_per_tile_last : W_per_tile;
+                for (uint32_t w_datum = 0; w_datum < W_curr; ++w_datum) {
+                    CoreLocalMem<uint32_t> src(l1_read_addr);
+                    noc.async_write_with_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+                        src,
+                        UnicastEndpoint{},
+                        stick_size_bytes,
+                        {.offset_bytes = 0},
+                        {.noc_x = (uint32_t)my_x[noc.get_noc_id()],
+                         .noc_y = (uint32_t)my_y[noc.get_noc_id()],
+                         .addr = dst_addr});
+                    l1_read_addr += l1_read_offset_bytes;
+                    dst_addr += stick_size_bytes;
+                }
+                noc.async_writes_flushed();
+                cb_src.pop_front(Ht);
+            }
+        }
+        noc.async_write_barrier();
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_cn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_cn_program_factory.cpp
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "transpose_cn_program_factory.hpp"
+#include "transpose_utils.hpp"
+
+#include <tt_stl/assert.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+
+tt::tt_metal::ProgramDescriptor TransposeCNProgramFactory::create_descriptor(
+    const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
+    const auto& input_tensor = tensor_args.input;
+    auto input_shape = input_tensor.padded_shape();
+    bool row_major = input_tensor.layout() == Layout::ROW_MAJOR;
+
+    TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_cn needs to be on device!");
+    TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_cn needs to be allocated in a buffer on device!");
+
+    ProgramDescriptor desc;
+
+    tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
+    uint32_t page_shape[2] = {TILE_WIDTH, TILE_HEIGHT};
+    if (input_tensor.layout() == Layout::ROW_MAJOR) {
+        page_shape[0] = 1;
+        page_shape[1] = input_shape[-1];
+    }
+    uint32_t page_size = page_shape[0] * page_shape[1];
+    uint32_t stick_size = (row_major) ? page_shape[1] * input_tensor.element_size() : tt::tile_size(cb_data_format);
+
+    Buffer* src0_buffer = input_tensor.buffer();
+    IDevice* device = input_tensor.device();
+
+    uint32_t num_tensor_pages = input_tensor.physical_volume() / page_size;
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    uint32_t num_cores_total = num_cores_x * num_cores_y;
+    CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_pages_per_core_group_1, num_pages_per_core_group_2] =
+        split_work_to_cores(compute_with_storage_grid_size, num_tensor_pages);
+
+    Buffer* dst_buffer = output_tensor.buffer();
+    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    uint32_t src0_cb_index = 0;
+    uint32_t num_input_pages = 2;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_pages * stick_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = cb_data_format,
+            .page_size = stick_size,
+        }}},
+    });
+
+    KernelDescriptor::Defines reader_defines;
+    std::vector<uint32_t> reader_compile_time_args = {
+        static_cast<uint32_t>(src0_cb_index), src0_buffer->aligned_page_size(), stick_size};
+    std::vector<uint32_t> reader_common_runtime_args;
+    TensorAccessorArgs(*src0_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(reader_compile_time_args, reader_common_runtime_args);
+    KernelDescriptor::Defines writer_defines;
+    std::vector<uint32_t> writer_compile_time_args = {
+        static_cast<uint32_t>(src0_cb_index), dst_buffer->aligned_page_size(), stick_size};
+    std::vector<uint32_t> writer_common_runtime_args;
+    TensorAccessorArgs(*dst_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(writer_compile_time_args, writer_common_runtime_args);
+
+    if (row_major) {
+        reader_defines.emplace_back("CN_RM", "1");
+        writer_defines.emplace_back("CN_RM", "1");
+    }
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/"
+        "reader_unary_transpose_cn_interleaved_start_id.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = total_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = std::move(reader_defines);
+    reader_desc.config = ReaderConfigDescriptor{};
+    reader_desc.common_runtime_args = std::move(reader_common_runtime_args);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/"
+        "writer_unary_transpose_cn_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = total_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.defines = std::move(writer_defines);
+    writer_desc.config = WriterConfigDescriptor{};
+    writer_desc.common_runtime_args = std::move(writer_common_runtime_args);
+
+    // Set runtime arguments for each core
+    uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1], N = input_shape[0];
+    uint32_t Wt = W / page_shape[1];
+    uint32_t Ht = H / page_shape[0];
+    uint32_t HtWt = Ht * Wt;
+    uint32_t CHtWt = C * HtWt;
+    uint32_t NCHtWt = num_tensor_pages;
+    uint32_t batch_step = CHtWt - HtWt;
+    uint32_t channel_step = NCHtWt - HtWt;
+
+    reader_desc.runtime_args.reserve(num_cores_total);
+    writer_desc.runtime_args.reserve(num_cores_total);
+    for (uint32_t i = 0, num_pages_read = 0; i < num_cores_total; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        uint32_t num_pages_per_core = 0;
+        if (core_group_1.contains(core)) {
+            num_pages_per_core = num_pages_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_pages_per_core = num_pages_per_core_group_2;
+        }
+
+        uint32_t hw = num_pages_read % HtWt;
+        uint32_t curr_c = num_pages_read / HtWt;
+        uint32_t n = curr_c % N;
+        uint32_t start_tile = num_pages_read + (curr_c * batch_step) - (curr_c / N * channel_step);
+
+        reader_desc.emplace_runtime_args(
+            core, {src0_buffer, N, C, HtWt, batch_step, channel_step, num_pages_per_core, start_tile, hw, n});
+        writer_desc.emplace_runtime_args(core, {dst_buffer, num_pages_per_core, num_pages_read});
+
+        num_pages_read += num_pages_per_core;
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_cn_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_cn_program_factory.hpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "transpose_device_operation_types.hpp"
+
+#include "ttnn/device_operation.hpp"
+
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace ttnn::prim::qsr {
+
+struct TransposeCNProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_device_operation.cpp
@@ -1,0 +1,256 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "transpose_device_operation.hpp"
+#include "transpose_utils.hpp"
+#include "ttnn/operations/data_movement/common/common.hpp"
+#include "ttnn/tensor/tensor_ops.hpp"
+
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/hal.hpp>
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+using ttnn::operations::experimental::quasar::transpose_op::adjust_shard_spec_to_shape;
+using ttnn::operations::experimental::quasar::transpose_op::generate_transpose_shard_spec;
+using ttnn::operations::experimental::quasar::transpose_op::is_native_transpose_sharding;
+
+namespace ttnn::prim::qsr {
+
+namespace {
+
+// Output logical+padded shapes per transpose dim. HC TILE: dim[1] = logical H (slot 1 isn't
+// tile-padded), dim[2] = round_up(logical C, TILE_HEIGHT). Shared by
+// derive_effective_output_memory_config and compute_output_specs.
+struct TransposedShapes {
+    ttnn::Shape logical;
+    ttnn::Shape padded;
+};
+
+TransposedShapes transposed_shapes(const Tensor& input_tensor, TransposeOpDim dim) {
+    auto output_shape = input_tensor.logical_shape();
+    auto output_padded_shape = input_tensor.padded_shape();
+    switch (dim) {
+        case TransposeOpDim::CN:
+            std::swap(output_shape[0], output_shape[1]);
+            std::swap(output_padded_shape[0], output_padded_shape[1]);
+            break;
+        case TransposeOpDim::HC:
+            if (input_tensor.layout() == Layout::ROW_MAJOR) {
+                std::swap(output_shape[1], output_shape[2]);
+                std::swap(output_padded_shape[1], output_padded_shape[2]);
+            } else {
+                const uint32_t C = output_shape[1];
+                const uint32_t C_p = tt::round_up(C, input_tensor.tensor_spec().tile().get_height());
+                const uint32_t H = output_shape[2];
+                output_shape[1] = H;
+                output_shape[2] = C;
+                output_padded_shape[1] = H;
+                output_padded_shape[2] = C_p;
+            }
+            break;
+        case TransposeOpDim::WH:
+            std::swap(output_shape[2], output_shape[3]);
+            std::swap(output_padded_shape[2], output_padded_shape[3]);
+            break;
+        default: TT_THROW("Unsupported transpose dim"); break;
+    }
+    return {output_shape, output_padded_shape};
+}
+
+// Synthesize a shard_spec when the user asks for sharded output without one, so downstream
+// (select_program_factory, compute_output_specs) sees a fully-specified config. Falls back to a
+// fresh full-grid spec when input shard can't be scaled exactly.
+MemoryConfig derive_effective_output_memory_config(
+    const TransposeDeviceOperation::operation_attributes_t& operation_attributes,
+    const TransposeDeviceOperation::tensor_args_t& tensor_args) {
+    auto output_mem_config = operation_attributes.output_mem_config;
+    if (!output_mem_config.is_sharded() || output_mem_config.shard_spec().has_value()) {
+        return output_mem_config;
+    }
+    const auto& input_tensor = tensor_args.input;
+    const auto output_padded_shape = transposed_shapes(input_tensor, operation_attributes.dim).padded;
+    // adjust_shard_spec_to_shape preserves the sharding style — only reuse input geometry when
+    // requested output layout matches input's; otherwise generate_transpose_shard_spec builds fresh.
+    if (input_tensor.is_sharded() && input_tensor.shard_spec().has_value() &&
+        input_tensor.memory_config().memory_layout() == output_mem_config.memory_layout()) {
+        auto adjusted = adjust_shard_spec_to_shape(
+            input_tensor.shard_spec().value(), input_tensor.padded_shape(), output_padded_shape);
+        if (adjusted.has_value()) {
+            // TILE sharded factories need tile-aligned shards; adjust_shard_spec_to_shape may now
+            // produce sub-tile when transpose legitimately shrinks a dim → fall through to
+            // generate_transpose_shard_spec rather than feeding an unusable spec.
+            const bool tile_layout = input_tensor.layout() == Layout::TILE;
+            const bool tile_aligned = adjusted->shape[0] % tt::constants::TILE_HEIGHT == 0 &&
+                                      adjusted->shape[1] % tt::constants::TILE_WIDTH == 0;
+            if (!tile_layout || tile_aligned) {
+                return MemoryConfig(
+                    output_mem_config.memory_layout(), output_mem_config.buffer_type(), std::move(adjusted));
+            }
+        }
+    }
+    auto shard_spec =
+        generate_transpose_shard_spec(input_tensor, output_padded_shape, output_mem_config.memory_layout());
+    return MemoryConfig(output_mem_config.memory_layout(), output_mem_config.buffer_type(), shard_spec);
+}
+
+}  // namespace
+
+TransposeDeviceOperation::program_factory_t TransposeDeviceOperation::select_program_factory(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input;
+    const auto output_memory_config = derive_effective_output_memory_config(operation_attributes, tensor_args);
+    const auto& dim = operation_attributes.dim;
+    bool is_row_major = input_tensor.layout() == Layout::ROW_MAJOR;
+
+    // !native → fall through to interleaved factories (TensorAccessorArgs handles sharded buffers
+    // transparently via NOC).
+    bool native = is_native_transpose_sharding(input_tensor.tensor_spec(), output_memory_config);
+
+    // shard_spec.shape is in padded terms; comparisons below use padded dims.
+    const auto& input_padded_shape = input_tensor.padded_shape();
+    const auto output_padded_shape = transposed_shapes(input_tensor, dim).padded;
+    uint32_t N = input_padded_shape[0], C = input_padded_shape[1];
+    uint32_t output_width = output_padded_shape[-1];
+    uint32_t output_height = output_padded_shape[-2];
+
+    bool input_height_sharded = native && input_tensor.is_sharded() && input_tensor.shard_spec().has_value() &&
+                                input_tensor.shard_spec()->shape[1] == input_padded_shape[-1];
+    bool input_width_and_height_fully_in_shard =
+        input_height_sharded && input_tensor.shard_spec()->shape[0] % input_padded_shape[-2] == 0;
+    bool output_height_sharded = native && output_memory_config.is_sharded() &&
+                                 output_memory_config.shard_spec().has_value() &&
+                                 output_memory_config.shard_spec()->shape[1] == output_width;
+    bool output_width_sharded = native && output_memory_config.is_sharded() &&
+                                output_memory_config.shard_spec().has_value() &&
+                                output_memory_config.shard_spec()->shape[0] == output_height;
+    bool output_width_and_height_fully_in_shard =
+        output_height_sharded && output_memory_config.shard_spec()->shape[0] % output_height == 0;
+    bool use_sharded_wh =
+        native && ((input_width_and_height_fully_in_shard && output_width_and_height_fully_in_shard) ||
+                   (N == 1 && C == 1 && input_height_sharded && output_width_sharded));
+    bool use_sharded_hc = native && input_height_sharded && output_height_sharded && is_row_major;
+
+    auto parallelization_strategy = get_parallelization_strategy(operation_attributes, tensor_args);
+
+    switch (parallelization_strategy) {
+        case TransposeOpParallelizationStrategy::MULTI_CORE_WH:
+            if (use_sharded_wh) {
+                if (is_row_major) {
+                    return TransposeWHShardedRMProgramFactory{};
+                }
+                return TransposeWHShardedProgramFactory{};
+            }
+            return TransposeWHProgramFactory{};
+
+        case TransposeOpParallelizationStrategy::MULTI_CORE_HC:
+            if (use_sharded_hc) {
+                return TransposeHCShardedProgramFactory{};
+            }
+            if (is_row_major) {
+                return TransposeHCRMProgramFactory{};
+            }
+            return TransposeHCTiledInterleavedProgramFactory{};
+
+        case TransposeOpParallelizationStrategy::MULTI_CORE_CN: return TransposeCNProgramFactory{};
+
+        default: TT_THROW("Unsupported parallelization strategy");
+    }
+}
+
+TransposeOpParallelizationStrategy TransposeDeviceOperation::get_parallelization_strategy(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& /*tensor_args*/) {
+    switch (operation_attributes.dim) {
+        case TransposeOpDim::WH: return TransposeOpParallelizationStrategy::MULTI_CORE_WH;
+        case TransposeOpDim::HC: return TransposeOpParallelizationStrategy::MULTI_CORE_HC;
+        case TransposeOpDim::CN: return TransposeOpParallelizationStrategy::MULTI_CORE_CN;
+        default: TT_THROW("Unsupported transpose dim for parallelization strategy");
+    }
+}
+
+void TransposeDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input;
+    const auto& dim = operation_attributes.dim;
+    const float pad_value = operation_attributes.pad_value;
+
+    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to transpose need to be on device!");
+    TT_FATAL(input_tensor.buffer() != nullptr, "Operands to transpose need to be allocated in buffers on device!");
+    TT_FATAL(
+        !(dim != TransposeOpDim::HC && pad_value != 0.0f),
+        "Non-zero padding {} is not supported for any transpose other than HC.",
+        pad_value);
+    TT_FATAL(
+        dim == TransposeOpDim::HC || dim == TransposeOpDim::WH || dim == TransposeOpDim::CN,
+        "Transpose HC, WH, CN are the only supported transpose operations. Transpose {} is not supported.",
+        static_cast<int>(dim));
+
+    const auto& shape = input_tensor.padded_shape();
+    bool row_major = input_tensor.layout() == Layout::ROW_MAJOR;
+    uint32_t W = shape[3], H = shape[2];
+
+    if (!row_major) {
+        TT_FATAL(
+            W % TILE_WIDTH == 0 && H % TILE_HEIGHT == 0,
+            "Tiled tensor H {} W {} must be a multiple of TILE HEIGHT {} and TILE WIDTH",
+            H,
+            W,
+            TILE_HEIGHT,
+            TILE_WIDTH);
+        TT_FATAL(
+            input_tensor.physical_volume() % TILE_HW == 0,
+            "Tiled tensor volume {} must be a multiple of TILE HEIGHT * TILE WIDTH",
+            input_tensor.physical_volume(),
+            TILE_HW);
+    }
+}
+
+TensorSpec TransposeDeviceOperation::compute_output_specs(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input;
+    const auto output_mem_config = derive_effective_output_memory_config(operation_attributes, tensor_args);
+    const auto [output_shape, output_padded_shape] = transposed_shapes(input_tensor, operation_attributes.dim);
+
+    return TensorSpec(
+        output_shape,
+        TensorLayout::fromPaddedShape(
+            input_tensor.dtype(),
+            PageConfig(input_tensor.layout()),
+            output_mem_config,
+            output_shape,
+            output_padded_shape));
+}
+
+Tensor TransposeDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
+}
+
+tt::tt_metal::operation::OpPerformanceModelGeneral<Tensor> TransposeDeviceOperation::create_op_performance_model(
+    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& tensor_args, const Tensor& output) {
+    const auto& input_tensor = tensor_args.input;
+    int ideal_dev_clock_cycles = ttnn::operations::data_movement::common_tm_bw_model(input_tensor, output);
+    tt::tt_metal::operation::OpPerformanceModelGeneral<Tensor> result({input_tensor}, {output}, ideal_dev_clock_cycles);
+    return result;
+}
+
+}  // namespace ttnn::prim::qsr
+
+namespace ttnn::prim::qsr {
+ttnn::Tensor transpose(
+    const Tensor& input_tensor,
+    ttnn::prim::qsr::TransposeOpDim dim,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    float pad_value) {
+    using OperationType = ttnn::prim::qsr::TransposeDeviceOperation;
+    return ttnn::device_operation::launch<OperationType>(
+        OperationType::operation_attributes_t{
+            .dim = dim,
+            .output_mem_config = output_mem_config,
+            .pad_value = pad_value,
+        },
+        TransposeInputs{
+            .input = input_tensor,
+        });
+}
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_device_operation.hpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "transpose_device_operation_types.hpp"
+#include "transpose_cn_program_factory.hpp"
+#include "transpose_hc_rm_program_factory.hpp"
+#include "transpose_hc_sharded_program_factory.hpp"
+#include "transpose_hc_tiled_interleaved_program_factory.hpp"
+#include "transpose_hc_tiled_program_factory.hpp"
+#include "transpose_wh_program_factory.hpp"
+#include "transpose_wh_sharded_program_factory.hpp"
+#include "transpose_wh_sharded_rm_program_factory.hpp"
+
+#include "ttnn/tensor/tensor.hpp"
+
+#include <variant>
+#include "ttnn/operation.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct TransposeDeviceOperation {
+    using operation_attributes_t = TransposeParams;
+    using tensor_args_t = TransposeInputs;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
+    using program_factory_t = std::variant<
+        TransposeWHProgramFactory,
+        TransposeWHShardedProgramFactory,
+        TransposeWHShardedRMProgramFactory,
+        TransposeHCTiledInterleavedProgramFactory,
+        TransposeHCTiledProgramFactory,
+        TransposeHCRMProgramFactory,
+        TransposeHCShardedProgramFactory,
+        TransposeCNProgramFactory>;
+
+    static program_factory_t select_program_factory(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static TransposeOpParallelizationStrategy get_parallelization_strategy(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static void validate_on_program_cache_miss(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static spec_return_value_t compute_output_specs(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, const Tensor& output);
+};
+
+}  // namespace ttnn::prim::qsr
+
+namespace ttnn::prim::qsr {
+ttnn::Tensor transpose(
+    const Tensor& input_tensor,
+    ttnn::prim::qsr::TransposeOpDim dim,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    float pad_value = 0.0f);
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_device_operation_types.hpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::prim::qsr {
+
+enum class TransposeOpDim { WH, HC, CN, NH, NW, CW };
+
+enum class TransposeOpParallelizationStrategy { MULTI_CORE_WH, MULTI_CORE_HC, MULTI_CORE_CN };
+
+struct TransposeParams {
+    TransposeOpDim dim{};
+    tt::tt_metal::MemoryConfig output_mem_config;
+    float pad_value = 0.0f;
+};
+
+struct TransposeInputs {
+    Tensor input;
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_rm_program_factory.cpp
@@ -1,0 +1,202 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "transpose_hc_rm_program_factory.hpp"
+#include "transpose_utils.hpp"
+
+#include <tt_stl/assert.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
+#include <tt-logger/tt-logger.hpp>
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+
+namespace {
+
+// Compute per-core runtime args (reader+writer) for HC RM transpose and append them to the
+// supplied KernelDescriptors. The traversal logic that advances (curr_c, curr_h, curr_n) was
+// previously shared between `create` and `override_runtime_arguments`; now it has a single home.
+void emit_runtime_args_hc_rm(
+    KernelDescriptor& reader_desc,
+    KernelDescriptor& writer_desc,
+    const Tensor& input_tensor,
+    Tensor& output_tensor,
+    uint32_t num_cores_total,
+    uint32_t num_cores_y,
+    const CoreRangeSet& core_group_1,
+    uint32_t num_sticks_per_core_group_1,
+    const CoreRangeSet& core_group_2,
+    uint32_t num_sticks_per_core_group_2) {
+    auto* input_buffer = input_tensor.buffer();
+    auto* output_buffer = output_tensor.buffer();
+    auto input_shape = input_tensor.padded_shape();
+
+    uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1];
+    uint32_t W_bytes = W * input_tensor.element_size();
+
+    uint32_t max_read_size = 2048;
+    uint32_t curr_c = 0, curr_h = 0, curr_n = 0;
+
+    reader_desc.runtime_args.reserve(num_cores_total);
+    writer_desc.runtime_args.reserve(num_cores_total);
+
+    for (uint32_t i = 0, curr_sticks_read = 0, curr_sticks_write = 0; i < num_cores_total; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        uint32_t num_sticks_per_core;
+
+        if (core_group_1.contains(core)) {
+            num_sticks_per_core = num_sticks_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_sticks_per_core = num_sticks_per_core_group_2;
+        } else {
+            num_sticks_per_core = 0;
+        }
+
+        uint32_t num_sticks_per_core_read = 0, num_read_per_barrier = 0;
+        if (num_sticks_per_core != 0) {
+            num_sticks_per_core_read = merge_num_sticks_to_read(num_sticks_per_core, W_bytes, max_read_size);
+            num_read_per_barrier = num_sticks_per_core / num_sticks_per_core_read;
+        }
+
+        reader_desc.emplace_runtime_args(
+            core,
+            {input_buffer, num_sticks_per_core_read, num_read_per_barrier, curr_sticks_read, curr_c, curr_h, curr_n});
+
+        writer_desc.emplace_runtime_args(
+            core, {output_buffer, num_sticks_per_core_read, num_read_per_barrier, curr_sticks_write});
+
+        curr_sticks_write += num_sticks_per_core;
+
+        for (uint32_t j = 0; j < num_sticks_per_core; ++j) {
+            curr_c++;
+            curr_sticks_read += H;
+            if (curr_c == C) {
+                curr_h++;
+                curr_c = 0;
+                if (curr_h == H) {
+                    curr_n++;
+                    curr_c = 0;
+                    curr_h = 0;
+                    curr_sticks_read = curr_sticks_read - H + 1;
+                } else {
+                    curr_sticks_read = curr_sticks_read - C * H + 1;
+                }
+            }
+        }
+    }
+}
+
+}  // namespace
+
+tt::tt_metal::ProgramDescriptor TransposeHCRMProgramFactory::create_descriptor(
+    const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
+    const auto& input_tensor = tensor_args.input;
+
+    TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_hc needs to be on device!");
+    TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_hc needs to be allocated in a buffer on device!");
+
+    const auto& a_shape = input_tensor.logical_shape();
+    uint32_t W = a_shape[3], H = a_shape[2], C = a_shape[1], N = a_shape[0];
+    uint32_t NCH = N * C * H;
+
+    ProgramDescriptor desc;
+
+    tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
+
+    log_debug(tt::LogOp, "transpose_hc_rm");
+    log_debug(tt::LogOp, "cb_data_format: {}", cb_data_format);
+
+    IDevice* device = input_tensor.device();
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    uint32_t num_cores_total = num_cores_x * num_cores_y;
+    CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_sticks_per_core_group_1, num_sticks_per_core_group_2] =
+        split_work_to_cores(compute_with_storage_grid_size, NCH);
+
+    Buffer* dst_buffer = output_tensor.buffer();
+    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    uint32_t src0_cb_index = 0;
+
+    auto num_sticks = num_sticks_per_core_group_1 > num_sticks_per_core_group_2 ? num_sticks_per_core_group_1
+                                                                                : num_sticks_per_core_group_2;
+
+    Buffer* src0_buffer = input_tensor.buffer();
+    uint32_t aligned_page = std::max(src0_buffer->aligned_page_size(), dst_buffer->aligned_page_size());
+    auto stick_size = std::max(W * input_tensor.element_size(), aligned_page);
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_sticks * stick_size,
+        .core_ranges = total_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = cb_data_format,
+            .page_size = stick_size,
+        }}},
+    });
+
+    std::vector<uint32_t> reader_compile_time_args;
+    std::vector<uint32_t> reader_common_runtime_args;
+    reader_compile_time_args.push_back(N);
+    reader_compile_time_args.push_back(H);
+    reader_compile_time_args.push_back(C);
+    reader_compile_time_args.push_back(stick_size);
+    reader_compile_time_args.push_back(src0_buffer->aligned_page_size());
+    TensorAccessorArgs(*src0_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(reader_compile_time_args, reader_common_runtime_args);
+
+    std::vector<uint32_t> writer_compile_time_args = {src0_cb_index};
+    std::vector<uint32_t> writer_common_runtime_args;
+    writer_compile_time_args.push_back(stick_size);
+    writer_compile_time_args.push_back(dst_buffer->aligned_page_size());
+    TensorAccessorArgs(*dst_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(writer_compile_time_args, writer_common_runtime_args);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/"
+        "reader_unary_transpose_hc_interleaved_partitioned_rm.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = total_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+    reader_desc.common_runtime_args = std::move(reader_common_runtime_args);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/"
+        "writer_unary_transpose_hc_interleaved_start_id_rm.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = total_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+    writer_desc.common_runtime_args = std::move(writer_common_runtime_args);
+
+    emit_runtime_args_hc_rm(
+        reader_desc,
+        writer_desc,
+        input_tensor,
+        output_tensor,
+        num_cores_total,
+        num_cores_y,
+        core_group_1,
+        num_sticks_per_core_group_1,
+        core_group_2,
+        num_sticks_per_core_group_2);
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_rm_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_rm_program_factory.hpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "transpose_device_operation_types.hpp"
+
+#include "ttnn/device_operation.hpp"
+
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace ttnn::prim::qsr {
+
+struct TransposeHCRMProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_sharded_program_factory.cpp
@@ -1,0 +1,429 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "transpose_hc_sharded_program_factory.hpp"
+
+#include <tt_stl/assert.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-logger/tt-logger.hpp>
+
+#include <map>
+#include <set>
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+
+namespace {
+
+std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime_args_hc_rm_sharded(
+    const Tensor& input_tensor, uint32_t num_cores, uint32_t num_cores_x, uint32_t num_cores_y) {
+    auto input_shape = input_tensor.padded_shape();
+
+    uint32_t H = input_shape[2], C = input_shape[1];
+
+    auto shard_spec = input_tensor.shard_spec().value();
+    uint32_t shard_height = shard_spec.shape[0];
+    bool row_major = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
+
+    IDevice* device = input_tensor.device();
+
+    std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> ret_val(num_cores);
+
+    std::vector<uint32_t> shard_grid_x_map;
+    for (uint32_t i = 0; i < num_cores_x; ++i) {
+        auto physical_core = device->worker_core_from_logical_core(CoreCoord(i, 0));
+        shard_grid_x_map.push_back(physical_core.x);
+    }
+    std::vector<uint32_t> shard_grid_y_map;
+    for (uint32_t i = 0; i < num_cores_y; ++i) {
+        auto physical_core = device->worker_core_from_logical_core(CoreCoord(0, i));
+        shard_grid_y_map.push_back(physical_core.y);
+    }
+
+    uint32_t curr_c = 0, curr_h = 0, curr_n = 0;
+    for (uint32_t i = 0, curr_sticks_read = 0; i < num_cores; i++) {
+        CoreCoord core;
+        if (row_major) {
+            core = {i % num_cores_x, i / num_cores_x};
+        } else {
+            core = {i / num_cores_y, i % num_cores_y};
+        }
+        uint32_t num_sticks_per_core = shard_height;
+
+        std::vector<uint32_t> reader_runtime_args = {num_sticks_per_core, curr_sticks_read, curr_c, curr_h, curr_n};
+        reader_runtime_args.insert(reader_runtime_args.end(), shard_grid_x_map.begin(), shard_grid_x_map.end());
+        reader_runtime_args.insert(reader_runtime_args.end(), shard_grid_y_map.begin(), shard_grid_y_map.end());
+
+        std::vector<uint32_t> writer_runtime_args;
+
+        ret_val[i] = {reader_runtime_args, writer_runtime_args};
+
+        for (uint32_t j = 0; j < num_sticks_per_core; ++j) {
+            curr_c++;
+            curr_sticks_read += H;
+            if (curr_c == C) {
+                curr_h++;
+                curr_c = 0;
+                if (curr_h == H) {
+                    curr_n++;
+                    curr_c = 0;
+                    curr_h = 0;
+                    curr_sticks_read = curr_sticks_read - H + 1;
+                } else {
+                    curr_sticks_read = curr_sticks_read - C * H + 1;
+                }
+            }
+        }
+    }
+
+    return ret_val;
+}
+
+std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime_args_hc_rm_sharded_special_case(
+    const Tensor& input_tensor, uint32_t num_cores, uint32_t num_cores_x, uint32_t num_cores_y) {
+    auto input_shape = input_tensor.padded_shape();
+
+    uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1], N = input_shape[0];
+    uint32_t total_height = N * C * H;
+    uint32_t stick_size_bytes = W * input_tensor.element_size();
+
+    auto shard_spec = input_tensor.shard_spec().value();
+    uint32_t shard_height = shard_spec.shape[0];
+    bool row_major = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
+
+    IDevice* device = input_tensor.device();
+
+    std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> ret_val(num_cores);
+
+    uint32_t height = 0;
+    std::vector<CoreCoord> cores;
+    for (uint32_t i = 0; i < num_cores; i++) {
+        CoreCoord core;
+        if (row_major) {
+            core = {i % num_cores_x, i / num_cores_x};
+        } else {
+            core = {i / num_cores_y, i % num_cores_y};
+        }
+        log_debug(tt::LogOp, "core: {}", core);
+
+        height += shard_height;
+
+        if (height <= total_height) {
+            cores.push_back(core);
+        }
+    }
+
+    uint32_t num_H_per_core = shard_height / H > 0 ? shard_height / H : 1;  // the number of H blocks in a shard
+    uint32_t num_C_blocks_per_core = shard_height > C ? shard_height / C : 1;
+
+    uint32_t curr_c = 0, curr_h = 0;
+    for (uint32_t i = 0, curr_sticks_read = 0; i < num_cores; i++) {
+        std::vector<uint32_t> read_cores_indices;
+        std::vector<uint32_t> read_cores_noc_x;
+        std::vector<uint32_t> read_cores_noc_y;
+        std::vector<uint32_t> read_stick_offset;
+
+        uint32_t num_sticks_per_core = shard_height;
+
+        std::vector<uint32_t> stick_ids_per_core;
+        for (uint32_t j = 0; j < num_sticks_per_core; ++j) {
+            stick_ids_per_core.push_back(curr_sticks_read);
+            curr_c++;
+            curr_sticks_read += H;
+            if (curr_c == C) {
+                curr_h++;
+                curr_c = 0;
+                if (curr_h == H) {
+                    curr_c = 0;
+                    curr_h = 0;
+                    curr_sticks_read = curr_sticks_read - H + 1;
+                } else {
+                    curr_sticks_read = curr_sticks_read - C * H + 1;
+                }
+            }
+        }
+
+        // figure out the stick id in a shard, and the core id for the stick.
+        std::map<std::pair<uint32_t, uint32_t>, std::vector<uint32_t>> core_stick_map;
+        for (uint32_t j = 0; j < num_sticks_per_core; ++j) {
+            uint32_t stick_id = stick_ids_per_core[j];
+            uint32_t shard_id = stick_id / num_sticks_per_core;
+            uint32_t stick_id_in_shard = stick_id - (shard_id * num_sticks_per_core);
+
+            uint32_t shard_grid_inner_dim = row_major ? num_cores_x : num_cores_y;
+            uint32_t shard_grid_outer_dim_id = shard_id / shard_grid_inner_dim;
+            uint32_t shard_grid_inner_dim_id = shard_id - (shard_grid_outer_dim_id * shard_grid_inner_dim);
+
+            uint32_t worker_y_logical = row_major ? shard_grid_outer_dim_id : shard_grid_inner_dim_id;
+            uint32_t worker_x_logical = row_major ? shard_grid_inner_dim_id : shard_grid_outer_dim_id;
+
+            if (worker_x_logical < num_cores_x && worker_y_logical < num_cores_y) {
+                auto core_physical =
+                    device->worker_core_from_logical_core(CoreCoord{worker_x_logical, worker_y_logical});
+
+                read_cores_indices.push_back(shard_id);
+                read_stick_offset.push_back(stick_id_in_shard * stick_size_bytes);
+                read_cores_noc_x.push_back(core_physical.x);
+                read_cores_noc_y.push_back(core_physical.y);
+            }
+        }
+
+        std::vector<uint32_t> non_repeat_stick_offset_values;
+        std::vector<uint32_t> non_repeat_noc_x_values;
+        std::vector<uint32_t> non_repeat_noc_y_values;
+
+        uint32_t num_sticks_per_shard_core_reader = 0, num_sticks_per_shard_core_writer = 0;
+        uint32_t writer_read_stick_offset = 0, writer_write_stick_offset = 0;
+        uint32_t num_C_blocks_per_core_reader = num_C_blocks_per_core, num_C_blocks_per_core_writer = 0;
+
+        uint32_t num_non_repeat_cores = read_cores_indices.size();
+        uint32_t read_stick_stride = read_stick_offset.size() > 1 ? read_stick_offset[1] - read_stick_offset[0] : 0;
+
+        if (num_H_per_core == 1) {  // each core only has one H block or part of H block
+            for (uint32_t k = 1; k < read_cores_indices.size(); ++k) {
+                if (read_cores_indices[k] == read_cores_indices[0]) {
+                    num_non_repeat_cores = k;
+                    read_stick_stride = read_stick_offset[k] - read_stick_offset[0];
+                    break;
+                }
+            }
+
+            uint32_t num_sticks_per_shard_core = shard_height / num_non_repeat_cores;
+            num_sticks_per_shard_core_reader = num_sticks_per_shard_core;
+            bool split_reader = num_sticks_per_shard_core > 2;
+            if (split_reader) {
+                num_sticks_per_shard_core_reader = num_sticks_per_shard_core / 2;
+                num_sticks_per_shard_core_writer = num_sticks_per_shard_core - num_sticks_per_shard_core_reader;
+                writer_read_stick_offset = num_sticks_per_shard_core_reader * read_stick_stride;
+                writer_write_stick_offset = writer_read_stick_offset * num_non_repeat_cores;
+            }
+
+            for (uint32_t k = 0; k < num_non_repeat_cores; ++k) {
+                non_repeat_stick_offset_values.push_back(read_stick_offset[k]);
+                non_repeat_noc_x_values.push_back(read_cores_noc_x[k]);
+                non_repeat_noc_y_values.push_back(read_cores_noc_y[k]);
+            }
+        } else {  // contains multiple H blocks
+            std::set<uint32_t> unique_values(read_cores_indices.begin(), read_cores_indices.end());
+            num_non_repeat_cores = unique_values.size();
+            read_stick_stride = read_stick_offset[1] - read_stick_offset[0];
+
+            // TODO: add the second batch args (num_non_repeat_cores, read_stick_offset, non_repeat_noc_x_values,
+            // non_repeat_noc_y_values) to support multiple batch in a shard
+            for (uint32_t k = 1; k < num_sticks_per_core; ++k) {
+                if ((read_cores_indices[k - 1] == read_cores_indices[k]) &&
+                    (read_stick_offset[k] == read_stick_offset[k - 1] + stick_size_bytes)) {
+                    break;
+                }
+            }
+
+            uint32_t num_sticks_per_shard_core = shard_height / num_non_repeat_cores / num_C_blocks_per_core;
+            num_sticks_per_shard_core_reader = num_sticks_per_shard_core;
+            num_sticks_per_shard_core_writer = num_sticks_per_shard_core;
+            bool split_reader = num_C_blocks_per_core > 2;
+            if (split_reader) {
+                num_C_blocks_per_core_reader = num_C_blocks_per_core / 2;
+                num_C_blocks_per_core_writer = num_C_blocks_per_core - num_C_blocks_per_core_reader;
+                writer_read_stick_offset = num_C_blocks_per_core_reader * stick_size_bytes;
+                writer_write_stick_offset =
+                    num_C_blocks_per_core_reader * num_non_repeat_cores * num_sticks_per_shard_core * stick_size_bytes;
+            }
+
+            for (uint32_t k = 0; k < num_non_repeat_cores; ++k) {
+                non_repeat_stick_offset_values.push_back(read_stick_offset[k * num_sticks_per_shard_core]);
+                non_repeat_noc_x_values.push_back(read_cores_noc_x[k * num_sticks_per_shard_core]);
+                non_repeat_noc_y_values.push_back(read_cores_noc_y[k * num_sticks_per_shard_core]);
+            }
+        }
+
+        bool read_single_h_block_per_core = num_H_per_core == 1;
+
+        std::vector<uint32_t> reader_runtime_args = {
+            static_cast<uint32_t>(read_single_h_block_per_core),
+            num_C_blocks_per_core_reader,
+            num_sticks_per_shard_core_reader,
+            num_non_repeat_cores,
+            read_stick_stride,
+        };
+
+        reader_runtime_args.insert(
+            reader_runtime_args.end(), non_repeat_stick_offset_values.begin(), non_repeat_stick_offset_values.end());
+        reader_runtime_args.insert(
+            reader_runtime_args.end(), non_repeat_noc_x_values.begin(), non_repeat_noc_x_values.end());
+        reader_runtime_args.insert(
+            reader_runtime_args.end(), non_repeat_noc_y_values.begin(), non_repeat_noc_y_values.end());
+
+        std::vector<uint32_t> writer_runtime_args = {
+            static_cast<uint32_t>(read_single_h_block_per_core),
+            num_C_blocks_per_core_writer,
+            num_sticks_per_shard_core_writer,
+            num_non_repeat_cores,
+            read_stick_stride,
+            writer_read_stick_offset,
+            writer_write_stick_offset,
+        };
+
+        writer_runtime_args.insert(
+            writer_runtime_args.end(), non_repeat_stick_offset_values.begin(), non_repeat_stick_offset_values.end());
+        writer_runtime_args.insert(
+            writer_runtime_args.end(), non_repeat_noc_x_values.begin(), non_repeat_noc_x_values.end());
+        writer_runtime_args.insert(
+            writer_runtime_args.end(), non_repeat_noc_y_values.begin(), non_repeat_noc_y_values.end());
+
+        ret_val[i] = {reader_runtime_args, writer_runtime_args};
+    }
+
+    return ret_val;
+}
+
+}  // namespace
+
+tt::tt_metal::ProgramDescriptor TransposeHCShardedProgramFactory::create_descriptor(
+    const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
+    const auto& input_tensor = tensor_args.input;
+
+    TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_hc needs to be on device!");
+    TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_hc needs to be allocated in a buffer on device!");
+
+    ProgramDescriptor desc;
+
+    tt::DataFormat src0_cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
+    tt::DataFormat dst_cb_data_format = datatype_to_dataformat_converter(output_tensor.dtype());
+
+    uint32_t W = input_tensor.logical_shape()[3], H = input_tensor.logical_shape()[2];
+    uint32_t C = input_tensor.logical_shape()[1], N = input_tensor.logical_shape()[0];
+    uint32_t stick_size_bytes = W * input_tensor.element_size();
+
+    auto shard_spec = input_tensor.shard_spec().value();
+    uint32_t shard_height = shard_spec.shape[0];
+    bool row_major_orientation = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
+
+    bool is_special_case = false;
+    if ((shard_spec.shape[0] % H == 0 || H % shard_spec.shape[0] == 0) &&
+        (shard_spec.shape[0] % C == 0 || C % shard_spec.shape[0] == 0) && (C % H == 0 || H % C == 0) &&
+        (shard_height <= C * H)) {
+        is_special_case = true;
+    }
+
+    auto& all_cores = shard_spec.grid;
+    uint32_t num_cores = shard_spec.num_cores();
+
+    log_debug(tt::LogOp, "all_cores: {}", all_cores);
+    log_debug(tt::LogOp, "num_cores: {}", num_cores);
+
+    auto bbox = shard_spec.grid.bounding_box();
+    CoreCoord grid_size = {bbox.end_coord.x + 1, bbox.end_coord.y + 1};
+    uint32_t num_cores_x = grid_size.x;
+    uint32_t num_cores_y = grid_size.y;
+
+    uint32_t src0_cb_index = tt::CBIndex::c_0;
+    // Sharded CBs bound to the input/output buffers: the framework re-applies
+    // UpdateDynamicCircularBufferAddress on cache hit via the .buffer member.
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = shard_height * stick_size_bytes,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = src0_cb_data_format,
+            .page_size = stick_size_bytes,
+        }}},
+        .buffer = input_tensor.buffer(),
+    });
+
+    uint32_t output_cb_index = tt::CBIndex::c_16;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = shard_height * stick_size_bytes,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = dst_cb_data_format,
+            .page_size = stick_size_bytes,
+        }}},
+        .buffer = output_tensor.buffer(),
+    });
+
+    std::vector<uint32_t> reader_compile_time_args;
+    if (is_special_case) {
+        reader_compile_time_args = {src0_cb_index, output_cb_index, stick_size_bytes};
+    } else {
+        reader_compile_time_args = {
+            src0_cb_index,
+            output_cb_index,
+            N,
+            H,
+            C,
+            stick_size_bytes,
+            static_cast<uint32_t>(row_major_orientation),
+            num_cores_x,
+            num_cores_y};
+    }
+
+    KernelDescriptor::Defines reader_defines;
+    if (is_special_case) {
+        reader_defines.emplace_back("USE_SPECIAL_CASE", "1");
+    }
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/"
+        "reader_unary_transpose_hc_sharded_rm.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = std::move(reader_defines);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    // Writer kernel only exists in the special case path; the generic path puts
+    // everything through the reader (writer args returned by the generic helper
+    // are empty, matching the legacy `KernelHandle writer_kernel_id{}` behavior).
+    std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> all_runtime_args;
+    if (is_special_case) {
+        all_runtime_args =
+            get_runtime_args_hc_rm_sharded_special_case(input_tensor, num_cores, num_cores_x, num_cores_y);
+    } else {
+        all_runtime_args = get_runtime_args_hc_rm_sharded(input_tensor, num_cores, num_cores_x, num_cores_y);
+    }
+
+    reader_desc.runtime_args.reserve(num_cores);
+    for (uint32_t i = 0; i < num_cores; i++) {
+        CoreCoord core;
+        if (row_major_orientation) {
+            core = {i % num_cores_x, i / num_cores_x};
+        } else {
+            core = {i / num_cores_y, i % num_cores_y};
+        }
+        reader_desc.runtime_args.emplace_back(core, all_runtime_args[i].first);
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+
+    if (is_special_case) {
+        KernelDescriptor writer_desc;
+        writer_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/"
+            "writer_unary_transpose_hc_sharded_rm.cpp";
+        writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        writer_desc.core_ranges = all_cores;
+        writer_desc.compile_time_args = {src0_cb_index, output_cb_index, stick_size_bytes};
+        writer_desc.config = WriterConfigDescriptor{};
+        writer_desc.runtime_args.reserve(num_cores);
+        for (uint32_t i = 0; i < num_cores; i++) {
+            CoreCoord core;
+            if (row_major_orientation) {
+                core = {i % num_cores_x, i / num_cores_x};
+            } else {
+                core = {i / num_cores_y, i % num_cores_y};
+            }
+            writer_desc.runtime_args.emplace_back(core, all_runtime_args[i].second);
+        }
+        desc.kernels.push_back(std::move(writer_desc));
+    }
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_sharded_program_factory.hpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "transpose_device_operation_types.hpp"
+
+#include "ttnn/device_operation.hpp"
+
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace ttnn::prim::qsr {
+
+struct TransposeHCShardedProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
@@ -1,0 +1,240 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "transpose_hc_tiled_interleaved_program_factory.hpp"
+#include "transpose_utils.hpp"
+
+#include "ttnn/operations/math.hpp"
+
+#include <tt_stl/assert.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
+#include "ttnn/operations/data_movement/common/common.hpp"
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+using ttnn::operations::data_movement::float_to_uint16;
+using ttnn::operations::data_movement::pack_two_uint16_into_uint32;
+
+namespace ttnn::prim::qsr {
+
+namespace {
+
+// Per-core runtime args for the reader + writer kernels. The work split uses
+// two parallel partitions (unpadded vs padded tile counts) so each core needs a
+// (start, end) pair from both. Writer also tracks the padded range; reader only
+// the unpadded count.
+void emit_runtime_args_hc_tiled_interleaved(
+    KernelDescriptor& reader_desc,
+    KernelDescriptor& writer_desc,
+    const Tensor& input_tensor,
+    Tensor& output_tensor,
+    const CoreRange& total_cores) {
+    auto* input_buffer = input_tensor.buffer();
+    auto* output_buffer = output_tensor.buffer();
+
+    auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
+    auto tile_hw = tile_shape[0] * tile_shape[1];
+    uint32_t num_tensor_tiles = input_tensor.physical_volume() / tile_hw;
+    uint32_t num_output_tiles = output_tensor.physical_volume() / tile_hw;
+    uint32_t padded_num_tensor_tiles = num_output_tiles / (output_tensor.padded_shape()[2] /
+                                                           tile_shape[0]);  // only last row of Ct should have padding
+
+    auto compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+        split_work_to_cores(compute_with_storage_grid_size, num_tensor_tiles);
+    auto
+        [padded_num_cores,
+         padded_all_cores,
+         padded_core_group_1,
+         padded_core_group_2,
+         padded_num_tiles_per_core_group_1,
+         padded_num_tiles_per_core_group_2] =
+            split_work_to_cores(compute_with_storage_grid_size, padded_num_tensor_tiles);
+
+    all_cores = num_cores > padded_num_cores ? all_cores : padded_all_cores;
+    auto cores = corerange_to_cores(all_cores, std::nullopt);
+
+    uint32_t start_idx = 0;
+    uint32_t padded_start_idx = 0;
+    // Need to set runtime args for all cores, not just the ones doing work.
+    for (const auto& core : total_cores) {
+        uint32_t num_tiles_per_core;
+        uint32_t padded_tiles_per_core;
+
+        if (core_group_1.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_2;
+        } else {
+            num_tiles_per_core = 0;
+        }
+
+        if (padded_core_group_1.contains(core)) {
+            padded_tiles_per_core = padded_num_tiles_per_core_group_1;
+        } else if (padded_core_group_2.contains(core)) {
+            padded_tiles_per_core = padded_num_tiles_per_core_group_2;
+        } else {
+            padded_tiles_per_core = 0;
+        }
+
+        uint32_t end_idx = start_idx + num_tiles_per_core;
+        uint32_t padded_end_idx = padded_start_idx + padded_tiles_per_core;
+
+        reader_desc.runtime_args.emplace_back(
+            core, std::vector<uint32_t>{input_buffer->address(), num_tiles_per_core, start_idx});
+        writer_desc.runtime_args.emplace_back(
+            core,
+            std::vector<uint32_t>{output_buffer->address(), start_idx, end_idx, padded_start_idx, padded_end_idx});
+
+        start_idx = end_idx;
+        padded_start_idx = padded_end_idx;
+    }
+}
+
+}  // namespace
+
+tt::tt_metal::ProgramDescriptor TransposeHCTiledInterleavedProgramFactory::create_descriptor(
+    const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor) {
+    const auto& input_tensor = tensor_args.input;
+    // pad_value is always defined at API level; padding is decided purely by shape
+    const float pad_value = operation_attributes.pad_value;
+
+    TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_hc needs to be on device!");
+    TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_hc needs to be allocated in a buffer on device!");
+
+    ProgramDescriptor desc;
+    auto tile = input_tensor.tensor_spec().tile();
+    auto tile_shape = tile.get_tile_shape();
+    auto face_shape = tile.get_face_shape();
+    uint32_t C = input_tensor.logical_shape()[1];
+    bool needs_padding = (C % tile_shape[1] != 0);
+
+    tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
+    uint32_t single_tile_size = tt::tile_size(cb_data_format);
+
+    auto compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+
+    uint32_t src0_cb_index = tt::CBIndex::c_0;
+    uint32_t padding_cb_index = tt::CBIndex::c_1;
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * single_tile_size,
+        .core_ranges = total_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+    });
+
+    auto max_padding_write = face_shape[0] * face_shape[1];
+    if (needs_padding) {
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = max_padding_write * input_tensor.element_size(),
+            .core_ranges = total_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(padding_cb_index),
+                .data_format = cb_data_format,
+                .page_size = max_padding_write * input_tensor.element_size(),
+            }}},
+        });
+    }
+
+    Buffer* src_buffer = input_tensor.buffer();
+    uint32_t element_size = input_tensor.element_size();
+    uint32_t padding_val_packed = 0;
+    uint32_t num_writes = 0;
+    uint32_t W = input_tensor.logical_shape()[3], H = input_tensor.logical_shape()[2];
+
+    if (C % tile_shape[1] != 0) {
+        uint32_t num_packed_values = sizeof(uint32_t) / element_size;
+        num_writes = max_padding_write / num_packed_values;
+        switch (input_tensor.dtype()) {
+            case DataType::INT32: padding_val_packed = std::bit_cast<uint32_t>(pad_value); break;
+            case DataType::UINT32: padding_val_packed = pad_value; break;
+            case DataType::BFLOAT16:
+                padding_val_packed = pack_two_bfloat16_into_uint32({bfloat16(pad_value), bfloat16(pad_value)});
+                break;
+            case DataType::UINT16:
+                padding_val_packed =
+                    pack_two_uint16_into_uint32({float_to_uint16(pad_value), float_to_uint16(pad_value)});
+                break;
+            case DataType::FLOAT32: padding_val_packed = std::bit_cast<uint32_t>(pad_value); break;
+            default:
+                padding_val_packed = 0;
+                TT_ASSERT(
+                    false,
+                    "Unsupported datatype for pad tile multicore, can only support INT32, UINT32, BFLOAT16, UINT16, "
+                    "FLOAT32");
+        }
+    }
+
+    std::vector<uint32_t> reader_compile_time_args = {};
+    std::vector<uint32_t> reader_common_runtime_args;
+    KernelDescriptor::NamedCompileTimeArgs reader_named_compile_time_args = {
+        {"num_writes", num_writes},
+        {"padding_val_packed", padding_val_packed},
+        {"needs_padding", needs_padding},
+        {"swap_hw", 0u},
+        {"H", 1u},
+        {"W", 1u},
+        {"accumulated_outer_dims", 1u},
+        {"tile_height", 1u},
+        {"tile_width", 1u},
+    };
+    TensorAccessorArgs(*src_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(reader_compile_time_args, reader_common_runtime_args);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/"
+        "reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = total_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.named_compile_time_args = std::move(reader_named_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+    reader_desc.common_runtime_args = std::move(reader_common_runtime_args);
+
+    Buffer* dst_buffer = output_tensor.buffer();
+    std::vector<uint32_t> writer_compile_time_args = {
+        element_size,
+        tt::CBIndex::c_0,
+        C,
+        H,
+        W,
+        tile_shape[0],
+        tile_shape[1],
+        face_shape[0],
+        face_shape[1],
+        static_cast<uint32_t>(needs_padding)};
+    std::vector<uint32_t> writer_common_runtime_args;
+    TensorAccessorArgs(*dst_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(writer_compile_time_args, writer_common_runtime_args);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/"
+        "writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = total_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+    writer_desc.common_runtime_args = std::move(writer_common_runtime_args);
+
+    emit_runtime_args_hc_tiled_interleaved(reader_desc, writer_desc, input_tensor, output_tensor, total_cores);
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_tiled_interleaved_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_tiled_interleaved_program_factory.hpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "transpose_device_operation_types.hpp"
+
+#include "ttnn/device_operation.hpp"
+
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace ttnn::prim::qsr {
+
+struct TransposeHCTiledInterleavedProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_tiled_program_factory.cpp
@@ -1,0 +1,208 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "transpose_hc_tiled_program_factory.hpp"
+
+#include <tt_stl/assert.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
+#include <tt-logger/tt-logger.hpp>
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+
+namespace {
+
+void emit_runtime_args_hc_tiled(
+    KernelDescriptor& reader_desc,
+    KernelDescriptor& writer_desc,
+    const Tensor& input_tensor,
+    Tensor& output_tensor,
+    uint32_t num_cores_total,
+    uint32_t num_cores_y,
+    const CoreRangeSet& core_group_1,
+    uint32_t num_tiles_per_core_group_1,
+    const CoreRangeSet& core_group_2,
+    uint32_t num_tiles_per_core_group_2) {
+    auto* input_buffer = input_tensor.buffer();
+    auto* output_buffer = output_tensor.buffer();
+    auto input_shape = input_tensor.padded_shape();
+
+    uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1];
+    uint32_t HW = H * W;
+    uint32_t HW_bytes = HW * input_tensor.element_size();
+    uint32_t CHW_bytes = C * HW * input_tensor.element_size();
+
+    uint32_t Wt = W / TILE_WIDTH;
+    uint32_t Ct = C / TILE_HEIGHT;
+    uint32_t CtHWt = Ct * H * Wt;
+    uint32_t CtWt = Ct * Wt;
+
+    reader_desc.runtime_args.reserve(num_cores_total);
+    writer_desc.runtime_args.reserve(num_cores_total);
+
+    for (uint32_t i = 0, num_tiles_read = 0; i < num_cores_total; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        uint32_t num_tiles_per_core;
+
+        if (core_group_1.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_2;
+        } else {
+            num_tiles_per_core = 0;
+        }
+
+        uint32_t h = num_tiles_read / CtWt % H;
+        uint32_t ct = num_tiles_read / Wt % Ct;
+
+        reader_desc.runtime_args.emplace_back(
+            core,
+            std::vector<uint32_t>{
+                input_buffer->address(),
+                Wt,
+                H,
+                Ct,
+                HW_bytes,
+                CHW_bytes,
+                num_tiles_read,
+                num_tiles_per_core,
+                num_tiles_read / CtHWt * CHW_bytes,
+                h,
+                h / TILE_HEIGHT * Wt,
+                ct,
+                ct * TILE_HEIGHT * HW_bytes,
+                num_tiles_read % Wt});
+
+        writer_desc.runtime_args.emplace_back(
+            core, std::vector<uint32_t>{output_buffer->address(), num_tiles_per_core, num_tiles_read});
+
+        num_tiles_read += num_tiles_per_core;
+    }
+}
+
+}  // namespace
+
+tt::tt_metal::ProgramDescriptor TransposeHCTiledProgramFactory::create_descriptor(
+    const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
+    const auto& input_tensor = tensor_args.input;
+
+    TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_hc needs to be on device!");
+    TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_hc needs to be allocated in a buffer on device!");
+
+    uint32_t sub_tile_line_bytes = 16 * input_tensor.element_size();
+    uint32_t num_tensor_tiles = input_tensor.physical_volume() / TILE_HW;
+
+    ProgramDescriptor desc;
+
+    tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
+    uint32_t single_tile_size = tt::tile_size(cb_data_format);
+
+    log_debug(tt::LogOp, "transpose_hc_tiled");
+    log_debug(tt::LogOp, "sub_tile_line_bytes: {}", sub_tile_line_bytes);
+    log_debug(tt::LogOp, "cb_data_format: {}", cb_data_format);
+    log_debug(tt::LogOp, "single_tile_size: {}", single_tile_size);
+
+    IDevice* device = input_tensor.device();
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    uint32_t num_cores_total = num_cores_x * num_cores_y;
+    CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+        split_work_to_cores(compute_with_storage_grid_size, num_tensor_tiles);
+
+    Buffer* dst_buffer = output_tensor.buffer();
+    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    uint32_t src0_cb_index = 0;
+    // check if we need to allocate a scratch buffer
+    // The kernel reads several 16 element face lines (32B for BFLOAT16) from different input tiles to form a single
+    // output tile, one output tile at a time Each face line is 32 bytes, so if our minimum read alignment is greater
+    // than that (64B for Blackhole) then we will have reads from unaligned face-lines into differently aligned
+    // destination face-lines
+    // TODO: noc_async_write only require 16B alignment for both DRAM and L1 for Blackhole, so instead of reading in
+    // face-lines from C tiles to form a single tile, we can load a single tile and then write out its face-lines to C
+    // tiles
+    uint32_t alignment = dst_buffer->alignment();
+    bool misaligned = alignment > sub_tile_line_bytes;
+
+    uint32_t num_input_tiles = 2;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * single_tile_size,
+        .core_ranges = total_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+    });
+
+    // need some scratch memory here - if we need data from a misaligned address then we need to read from the
+    // nearest aligned address and then copy the data to the correct location
+    if (misaligned) {
+        uint32_t src1_cb_index = 1;
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = alignment,
+            .core_ranges = total_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(src1_cb_index),
+                .data_format = cb_data_format,
+                .page_size = alignment,
+            }}},
+        });
+    }
+
+    Buffer* src0_buffer = input_tensor.buffer();
+    std::vector<uint32_t> reader_compile_time_args;
+    reader_compile_time_args.push_back(sub_tile_line_bytes);
+    reader_compile_time_args.push_back(cb_data_format == tt::DataFormat::Float32 ? 1 : 0);
+    reader_compile_time_args.push_back(alignment);
+    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+
+    std::vector<uint32_t> writer_compile_time_args = {src0_cb_index};
+    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/"
+        "reader_unary_transpose_hc_interleaved_partitioned.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = total_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = total_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    emit_runtime_args_hc_tiled(
+        reader_desc,
+        writer_desc,
+        input_tensor,
+        output_tensor,
+        num_cores_total,
+        num_cores_y,
+        core_group_1,
+        num_tiles_per_core_group_1,
+        core_group_2,
+        num_tiles_per_core_group_2);
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_tiled_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_tiled_program_factory.hpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "transpose_device_operation_types.hpp"
+
+#include "ttnn/device_operation.hpp"
+
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace ttnn::prim::qsr {
+
+struct TransposeHCTiledProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_utils.cpp
@@ -1,0 +1,173 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "transpose_utils.hpp"
+
+#include <tt-logger/tt-logger.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+
+namespace ttnn::operations::experimental::quasar::transpose_op {
+
+using namespace tt::tt_metal;
+
+namespace {
+
+// True if padded shape doesn't divide evenly into shard, or if the sharded config has no spec.
+// Conservatively true for rank < 2 so callers fall back to interleaved.
+bool is_unevenly_sharded(const TensorSpec& t) {
+    if (!t.memory_config().is_sharded()) {
+        return false;
+    }
+    const auto& shard_spec = t.memory_config().shard_spec();
+    if (!shard_spec.has_value()) {
+        return true;
+    }
+    const auto& shape = t.padded_shape();
+    const auto rank = shape.rank();
+    if (rank < 2) {
+        return true;
+    }
+    const auto& shard = shard_spec->shape;
+    uint64_t volume_except_last = 1;
+    for (int i = 0; i < static_cast<int>(rank) - 1; ++i) {
+        volume_except_last *= shape[i];
+    }
+    return (volume_except_last % shard[0]) != 0 || (shape[-1] % shard[1]) != 0;
+}
+
+// RM shard element count not a tile multiple → native kernels can't use it (whole-tile pages
+// only); the interleaved TensorAccessor path handles such shards.
+bool rm_shard_elements_not_tile_aligned(const MemoryConfig& mc) {
+    if (!mc.shard_spec().has_value()) {
+        return false;
+    }
+    constexpr uint64_t tile_hw =
+        static_cast<uint64_t>(tt::constants::TILE_HEIGHT) * static_cast<uint64_t>(tt::constants::TILE_WIDTH);
+    const auto& s = mc.shard_spec()->shape;
+    const uint64_t elems = static_cast<uint64_t>(s[0]) * static_cast<uint64_t>(s[1]);
+    return elems % tile_hw != 0;
+}
+
+// Per-side native eligibility: sharded, non-DRAM, non-BLOCK, and for RM: shard elements are a
+// tile_hw multiple.
+bool side_native(const MemoryConfig& mc, Layout layout) {
+    if (!mc.is_sharded()) {
+        return false;
+    }
+    if (mc.buffer_type() == BufferType::DRAM) {
+        return false;
+    }
+    if (mc.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
+        return false;
+    }
+    if (layout == Layout::ROW_MAJOR && rm_shard_elements_not_tile_aligned(mc)) {
+        return false;
+    }
+    return true;
+}
+
+}  // namespace
+
+bool is_native_transpose_sharding(
+    const TensorSpec& input_spec, const std::optional<MemoryConfig>& output_memory_config) {
+    if (!side_native(input_spec.memory_config(), input_spec.layout())) {
+        return false;
+    }
+    if (is_unevenly_sharded(input_spec)) {
+        return false;
+    }
+    if (!output_memory_config.has_value()) {
+        // Pre-derivation: output spec will be synthesized from input — input eligibility suffices.
+        return true;
+    }
+    if (!side_native(*output_memory_config, input_spec.layout())) {
+        return false;
+    }
+    // Sharded WH/HC factories require a single shared grid; only enforce when both specs concrete
+    // (a missing output spec implicitly inherits the input grid).
+    const auto& in_ss = input_spec.memory_config().shard_spec();
+    const auto& out_ss = output_memory_config->shard_spec();
+    return !(in_ss.has_value() && out_ss.has_value() && in_ss->grid != out_ss->grid);
+}
+
+std::optional<ShardSpec> adjust_shard_spec_to_shape(
+    const ShardSpec& shard_spec, const ttnn::Shape& from_shape, const ttnn::Shape& to_shape) {
+    // uint64 accumulators avoid overflow on large tensors; nullopt on non-exact division lets
+    // callers fall back gracefully. Transpose preserves rank — mismatched ranks would yield
+    // inconsistent volume math, so enforce equality.
+    TT_FATAL(
+        from_shape.rank() == to_shape.rank(),
+        "adjust_shard_spec_to_shape: from_shape rank ({}) and to_shape rank ({}) must match.",
+        from_shape.rank(),
+        to_shape.rank());
+    uint64_t from_volume_except_width = 1;
+    uint64_t to_volume_except_width = 1;
+    const auto rank = static_cast<int>(from_shape.rank());
+    for (int i = 0; i < rank - 1; ++i) {
+        from_volume_except_width *= static_cast<uint64_t>(from_shape[i]);
+        to_volume_except_width *= static_cast<uint64_t>(to_shape[i]);
+    }
+    const uint64_t from_width = static_cast<uint64_t>(from_shape[-1]);
+    const uint64_t to_width = static_cast<uint64_t>(to_shape[-1]);
+    if (from_volume_except_width == 0 || from_width == 0) {
+        return std::nullopt;
+    }
+
+    const uint64_t h_num = static_cast<uint64_t>(shard_spec.shape[0]) * to_volume_except_width;
+    const uint64_t w_num = static_cast<uint64_t>(shard_spec.shape[1]) * to_width;
+    if (h_num % from_volume_except_width != 0 || w_num % from_width != 0) {
+        return std::nullopt;
+    }
+
+    // Exact ratio scale, no tile-size clamp: clamping oversizes shards when transpose legitimately
+    // shrinks a dim sub-tile, causing silent correctness bugs. Callers that need tile alignment
+    // post-check shape[i] % TILE_* and fall back; RM callers tolerate sub-tile shards.
+    auto ret = shard_spec;
+    ret.shape[0] = static_cast<uint32_t>(h_num / from_volume_except_width);
+    ret.shape[1] = static_cast<uint32_t>(w_num / from_width);
+    return ret;
+}
+
+// Build a sharded spec over the full compute grid (used when no input shard_spec is available
+// to scale from, e.g. interleaved input + sharded output request).
+ShardSpec generate_transpose_shard_spec(
+    const Tensor& input_tensor, const ttnn::Shape& padded_out_shape, TensorMemoryLayout memory_layout) {
+    auto* device = input_tensor.device();
+    auto compute_grid_size = device->compute_with_storage_grid_size();
+    CoreRangeSet all_cores(CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1}));
+    uint32_t num_cores = all_cores.num_cores();
+
+    // uint64 intermediates avoid overflow when leading-dim product exceeds 2^32; final shard
+    // dims are still uint32 (the hardware representation).
+    uint64_t tensor_height = 1;
+    for (int i = 0; i < static_cast<int>(padded_out_shape.rank()) - 1; ++i) {
+        tensor_height *= static_cast<uint64_t>(padded_out_shape[i]);
+    }
+    uint64_t tensor_width = padded_out_shape[-1];
+
+    std::array<uint32_t, 2> shard_shape = {0, 0};
+    if (memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+        auto height_padded = tt::round_up(tensor_height, static_cast<uint64_t>(num_cores) * tt::constants::TILE_HEIGHT);
+        auto shard_height =
+            tt::round_up(tt::div_up(height_padded, static_cast<uint64_t>(num_cores)), tt::constants::TILE_HEIGHT);
+        shard_shape = {static_cast<uint32_t>(shard_height), static_cast<uint32_t>(tensor_width)};
+    } else if (memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
+        auto shard_width =
+            tt::round_up(tt::div_up(tensor_width, static_cast<uint64_t>(num_cores)), tt::constants::TILE_WIDTH);
+        shard_shape = {static_cast<uint32_t>(tensor_height), static_cast<uint32_t>(shard_width)};
+    } else {
+        CoreCoord grid_size = all_cores.bounding_box().grid_size();
+        auto height_padded =
+            tt::round_up(tensor_height, static_cast<uint64_t>(grid_size.y) * tt::constants::TILE_HEIGHT);
+        auto shard_height =
+            tt::round_up(tt::div_up(height_padded, static_cast<uint64_t>(grid_size.y)), tt::constants::TILE_HEIGHT);
+        auto shard_width =
+            tt::round_up(tt::div_up(tensor_width, static_cast<uint64_t>(grid_size.x)), tt::constants::TILE_WIDTH);
+        shard_shape = {static_cast<uint32_t>(shard_height), static_cast<uint32_t>(shard_width)};
+    }
+    log_debug(tt::LogOp, "Transpose: generated shard spec over full compute grid ({} cores)", num_cores);
+    return ShardSpec(all_cores, shard_shape, ShardOrientation::ROW_MAJOR);
+}
+
+}  // namespace ttnn::operations::experimental::quasar::transpose_op

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_utils.hpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/types.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::experimental::quasar::transpose_op {
+
+// Native-sharded eligibility probe. Single-arg form: input only (pre-derivation). Two-arg form:
+// also checks output side and (when both shard_specs are concrete) input/output grid match.
+bool is_native_transpose_sharding(
+    const TensorSpec& input_spec, const std::optional<tt::tt_metal::MemoryConfig>& output_memory_config = std::nullopt);
+
+// Scale shard_spec from `from_shape` to `to_shape`; nullopt when scaling isn't exact.
+std::optional<tt::tt_metal::ShardSpec> adjust_shard_spec_to_shape(
+    const tt::tt_metal::ShardSpec& shard_spec, const ttnn::Shape& from_shape, const ttnn::Shape& to_shape);
+
+tt::tt_metal::ShardSpec generate_transpose_shard_spec(
+    const Tensor& input_tensor, const ttnn::Shape& padded_out_shape, tt::tt_metal::TensorMemoryLayout memory_layout);
+
+}  // namespace ttnn::operations::experimental::quasar::transpose_op

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_program_factory.cpp
@@ -1,0 +1,344 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "transpose_wh_program_factory.hpp"
+#include "transpose_utils.hpp"
+
+#include <tt_stl/assert.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+
+namespace {
+
+void emit_runtime_args_wh_tiled(
+    KernelDescriptor& reader_desc,
+    KernelDescriptor& compute_desc,
+    KernelDescriptor& writer_desc,
+    const Tensor& input_tensor,
+    Tensor& output_tensor,
+    uint32_t num_cores_total,
+    uint32_t num_cores_y,
+    const CoreRangeSet& core_group_1,
+    uint32_t num_tiles_per_core_group_1,
+    const CoreRangeSet& core_group_2,
+    uint32_t num_tiles_per_core_group_2) {
+    auto input_shape = input_tensor.padded_shape();
+
+    uint32_t W = input_shape[3], H = input_shape[2];
+
+    uint32_t Wt = W / TILE_WIDTH;
+    uint32_t Ht = H / TILE_HEIGHT;
+
+    auto HtWt = Ht * Wt;
+
+    reader_desc.runtime_args.reserve(num_cores_total);
+    compute_desc.runtime_args.reserve(num_cores_total);
+    writer_desc.runtime_args.reserve(num_cores_total);
+
+    for (uint32_t i = 0, num_tiles_read = 0; i < num_cores_total; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        uint32_t num_tiles_per_core;
+
+        if (core_group_1.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_2;
+        } else {
+            num_tiles_per_core = 0;
+        }
+
+        uint32_t h = num_tiles_read % Ht;
+        uint32_t w = num_tiles_read / Ht % Wt;
+
+        reader_desc.emplace_runtime_args(
+            core,
+            {input_tensor.buffer(),
+             num_tiles_per_core,
+             tt::round_down(num_tiles_read, HtWt) + (h * Wt) + w,
+             h,
+             w,
+             Ht,
+             Wt,
+             HtWt});
+
+        compute_desc.emplace_runtime_args(core, {num_tiles_per_core});
+
+        writer_desc.emplace_runtime_args(core, {output_tensor.buffer(), num_tiles_per_core, num_tiles_read});
+
+        num_tiles_read += num_tiles_per_core;
+    }
+}
+
+void emit_runtime_args_wh_rm(
+    KernelDescriptor& reader_desc,
+    KernelDescriptor& compute_desc,
+    KernelDescriptor& writer_desc,
+    const Tensor& input_tensor,
+    Tensor& output_tensor,
+    uint32_t num_cores_total,
+    uint32_t num_cores_y,
+    const CoreRangeSet& core_group_1,
+    uint32_t num_hw_blocks_per_core_group_1,
+    const CoreRangeSet& core_group_2,
+    uint32_t num_hw_blocks_per_core_group_2) {
+    auto input_shape = input_tensor.logical_shape();
+
+    uint32_t W = input_shape[3], H = input_shape[2];
+
+    reader_desc.runtime_args.reserve(num_cores_total);
+    compute_desc.runtime_args.reserve(num_cores_total);
+    writer_desc.runtime_args.reserve(num_cores_total);
+
+    for (uint32_t i = 0, num_sticks_read = 0, num_sticks_write = 0; i < num_cores_total; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        uint32_t num_hw_blocks_per_core;
+
+        if (core_group_1.contains(core)) {
+            num_hw_blocks_per_core = num_hw_blocks_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_hw_blocks_per_core = num_hw_blocks_per_core_group_2;
+        } else {
+            num_hw_blocks_per_core = 0;
+        }
+
+        reader_desc.emplace_runtime_args(core, {input_tensor.buffer(), num_sticks_read, num_hw_blocks_per_core});
+
+        compute_desc.emplace_runtime_args(core, {num_hw_blocks_per_core});
+
+        writer_desc.emplace_runtime_args(core, {output_tensor.buffer(), num_sticks_write, num_hw_blocks_per_core});
+
+        num_sticks_read += num_hw_blocks_per_core * H;
+        num_sticks_write += num_hw_blocks_per_core * W;
+    }
+}
+
+}  // namespace
+
+tt::tt_metal::ProgramDescriptor TransposeWHProgramFactory::create_descriptor(
+    const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
+    const auto& input_tensor = tensor_args.input;
+
+    TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_wh needs to be on device!");
+    TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_wh needs to be allocated in a buffer on device!");
+
+    uint32_t num_tensor_tiles = input_tensor.physical_volume() / TILE_HW;
+    uint32_t W = input_tensor.logical_shape()[3], H = input_tensor.logical_shape()[2];
+    uint32_t NC = input_tensor.logical_shape()[1] * input_tensor.logical_shape()[0];
+    bool row_major = input_tensor.layout() == Layout::ROW_MAJOR;
+
+    uint32_t ht = (H + TILE_HEIGHT - 1) / TILE_HEIGHT;
+    uint32_t wt = (W + TILE_WIDTH - 1) / TILE_WIDTH;
+
+    ProgramDescriptor desc;
+
+    tt::DataFormat src0_cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
+    uint32_t src0_single_tile_size = tt::tile_size(src0_cb_data_format);
+    tt::DataFormat dst_cb_data_format = datatype_to_dataformat_converter(output_tensor.dtype());
+    uint32_t dst_single_tile_size = tt::tile_size(dst_cb_data_format);
+
+    Buffer* src0_buffer = input_tensor.buffer();
+    IDevice* device = input_tensor.device();
+
+    bool fp32_dest_acc_en = src0_cb_data_format == tt::DataFormat::Float32 ||
+                            src0_cb_data_format == tt::DataFormat::Int32 ||
+                            src0_cb_data_format == tt::DataFormat::UInt32;
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    uint32_t num_cores_total = num_cores_x * num_cores_y;
+    CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+        split_work_to_cores(compute_with_storage_grid_size, row_major ? NC : num_tensor_tiles);
+
+    Buffer* dst_buffer = output_tensor.buffer();
+    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    uint32_t src0_cb_index = 0;
+    uint32_t num_input_tiles = row_major ? wt * 2 : 2;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * src0_single_tile_size,
+        .core_ranges = total_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = src0_cb_data_format,
+            .page_size = src0_single_tile_size,
+        }}},
+    });
+
+    uint32_t output_cb_index = tt::CBIndex::c_16;
+    uint32_t num_output_tiles = row_major ? ht * 2 : 2;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_output_tiles * dst_single_tile_size,
+        .core_ranges = total_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = dst_cb_data_format,
+            .page_size = dst_single_tile_size,
+        }}},
+    });
+
+    if (row_major) {
+        uint32_t im_cb_index = 24;
+        uint32_t num_im_tiles = ht * wt;
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = num_im_tiles * src0_single_tile_size,
+            .core_ranges = total_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(im_cb_index),
+                .data_format = src0_cb_data_format,
+                .page_size = src0_single_tile_size,
+            }}},
+        });
+        // TODO REMOVE
+        uint32_t im2_cb_index = 25;
+        uint32_t num_im2_tiles = ht;
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = num_im2_tiles * dst_single_tile_size,
+            .core_ranges = total_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(im2_cb_index),
+                .data_format = dst_cb_data_format,
+                .page_size = dst_single_tile_size,
+            }}},
+        });
+    }
+
+    std::vector<uint32_t> reader_compile_time_args;
+    std::vector<uint32_t> reader_common_runtime_args;
+    if (row_major) {
+        reader_compile_time_args.push_back(ht);
+        reader_compile_time_args.push_back(H > TILE_HEIGHT ? TILE_HEIGHT : H % TILE_HEIGHT);
+        reader_compile_time_args.push_back(H % TILE_HEIGHT == 0 ? TILE_HEIGHT : H % TILE_HEIGHT);
+        reader_compile_time_args.push_back(wt);
+        reader_compile_time_args.push_back(W);
+        reader_compile_time_args.push_back(ht * wt);
+        reader_compile_time_args.push_back(W * input_tensor.element_size());
+        reader_compile_time_args.push_back(wt * input_tensor.element_size() * TILE_WIDTH);
+        reader_compile_time_args.push_back(src0_buffer->aligned_page_size());
+    }
+    TensorAccessorArgs(*src0_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(reader_compile_time_args, reader_common_runtime_args);
+
+    std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
+    std::vector<uint32_t> writer_common_runtime_args;
+    if (row_major) {
+        writer_compile_time_args.push_back(ht);
+        writer_compile_time_args.push_back(H);
+        writer_compile_time_args.push_back(wt);
+        writer_compile_time_args.push_back(W > TILE_WIDTH ? TILE_WIDTH : W % TILE_WIDTH);
+        writer_compile_time_args.push_back(W % TILE_WIDTH == 0 ? TILE_WIDTH : W % TILE_WIDTH);
+        writer_compile_time_args.push_back(ht * wt);
+        writer_compile_time_args.push_back(H * output_tensor.element_size());
+        writer_compile_time_args.push_back(ht * output_tensor.element_size() * TILE_HEIGHT);
+        writer_compile_time_args.push_back(dst_buffer->aligned_page_size());
+    }
+    TensorAccessorArgs(*dst_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(writer_compile_time_args, writer_common_runtime_args);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = row_major
+                                    ? "ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/"
+                                      "reader_unary_transpose_wh_interleaved_start_id_rm.cpp"
+                                    : "ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/"
+                                      "reader_unary_transpose_wh_interleaved_start_id.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = total_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+    reader_desc.common_runtime_args = std::move(reader_common_runtime_args);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        row_major
+            ? "ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/"
+              "writer_unary_transpose_wh_interleaved_start_id_rm.cpp"
+            : "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = total_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+    writer_desc.common_runtime_args = std::move(writer_common_runtime_args);
+
+    std::vector<uint32_t> compute_kernel_args = {};
+    if (row_major) {
+        compute_kernel_args.push_back(ht);
+        compute_kernel_args.push_back(wt);
+        compute_kernel_args.push_back(ht * wt);
+    }
+
+    KernelDescriptor::Defines compute_defines;
+    if (row_major && (input_tensor.dtype() == DataType::UINT32 || input_tensor.dtype() == DataType::INT32)) {
+        compute_defines.emplace_back("DST_ACCUM_MODE", "1");
+    }
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    if (src0_cb_data_format == tt::DataFormat::Float32) {
+        // Keep the source CB in full Float32 on the unpack-to-dest path. In
+        // the row-major kernel, the tile-formatted intermediate (c_24) also
+        // feeds the transpose, so it needs the same treatment.
+        unpack_to_dest_mode[src0_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        if (row_major) {
+            unpack_to_dest_mode[static_cast<std::size_t>(tt::CBIndex::c_24)] =
+                tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        }
+    }
+
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source =
+        row_major ? "ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/compute/transpose_wh_rm.cpp"
+                  : "ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/compute/transpose_wh.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = total_cores;
+    compute_desc.compile_time_args = std::move(compute_kernel_args);
+    compute_desc.defines = std::move(compute_defines);
+    compute_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+    };
+
+    if (row_major) {
+        emit_runtime_args_wh_rm(
+            reader_desc,
+            compute_desc,
+            writer_desc,
+            input_tensor,
+            output_tensor,
+            num_cores_total,
+            num_cores_y,
+            core_group_1,
+            num_tiles_per_core_group_1,
+            core_group_2,
+            num_tiles_per_core_group_2);
+    } else {
+        emit_runtime_args_wh_tiled(
+            reader_desc,
+            compute_desc,
+            writer_desc,
+            input_tensor,
+            output_tensor,
+            num_cores_total,
+            num_cores_y,
+            core_group_1,
+            num_tiles_per_core_group_1,
+            core_group_2,
+            num_tiles_per_core_group_2);
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_program_factory.hpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "transpose_device_operation_types.hpp"
+
+#include "ttnn/device_operation.hpp"
+
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace ttnn::prim::qsr {
+
+struct TransposeWHProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_sharded_program_factory.cpp
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "transpose_wh_sharded_program_factory.hpp"
+
+#include <tt_stl/assert.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+
+#include <algorithm>
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+
+tt::tt_metal::ProgramDescriptor TransposeWHShardedProgramFactory::create_descriptor(
+    const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
+    const auto& input_tensor = tensor_args.input;
+
+    TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_wh needs to be on device!");
+    TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_wh needs to be allocated in a buffer on device!");
+
+    ProgramDescriptor desc;
+
+    tt::DataFormat src0_cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
+    uint32_t src0_single_tile_size = tt::tile_size(src0_cb_data_format);
+    tt::DataFormat dst_cb_data_format = datatype_to_dataformat_converter(output_tensor.dtype());
+    uint32_t dst_single_tile_size = tt::tile_size(dst_cb_data_format);
+
+    const auto tile = input_tensor.tensor_spec().tile();
+    const uint32_t tile_hw = tile.get_tile_hw();
+
+    IDevice* device = input_tensor.device();
+
+    bool fp32_dest_acc_en = src0_cb_data_format == tt::DataFormat::Float32;
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+
+    auto shard_spec = input_tensor.shard_spec().value();
+    bool row_major = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
+
+    auto& all_cores = shard_spec.grid;
+    uint32_t num_tiles_per_shard = shard_spec.numel() / tile_hw;
+
+    // Sharded CBs: total_size depends on num_tiles_per_shard which can vary across
+    // cache hits; .buffer triggers UpdateDynamicCircularBufferAddress. total_size
+    // is not in the program hash so the framework re-applies the combined update
+    // via apply_descriptor_runtime_args.
+    uint32_t src0_cb_index = tt::CBIndex::c_0;
+    uint32_t num_input_tiles = num_tiles_per_shard;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * src0_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = src0_cb_data_format,
+            .page_size = src0_single_tile_size,
+        }}},
+        .buffer = input_tensor.buffer(),
+    });
+
+    uint32_t output_cb_index = tt::CBIndex::c_16;
+    uint32_t num_output_tiles = num_tiles_per_shard;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_output_tiles * dst_single_tile_size,
+        .core_ranges = total_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = dst_cb_data_format,
+            .page_size = dst_single_tile_size,
+        }}},
+        .buffer = output_tensor.buffer(),
+    });
+
+    std::vector<uint32_t> reader_compile_time_args = {src0_cb_index};
+    std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
+    std::vector<uint32_t> compute_compile_time_args = {src0_cb_index, output_cb_index};
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = total_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = total_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    if (src0_cb_data_format == tt::DataFormat::Float32) {
+        unpack_to_dest_mode[src0_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+    }
+
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/compute/transpose_wh_sharded.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = total_cores;
+    compute_desc.compile_time_args = std::move(compute_compile_time_args);
+    compute_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+    };
+
+    auto padded_shape = input_tensor.padded_shape();
+    auto shard_shape = shard_spec.shape;
+
+    uint32_t H = padded_shape[2];
+    uint32_t Hs = shard_shape[0], Ws = shard_shape[1];
+
+    uint32_t Hts = Hs / tile.get_height();
+    uint32_t Wts = Ws / tile.get_width();
+
+    uint32_t Ht = H / tile.get_height();
+    uint32_t Ht_per_shard = std::min(Ht, Hts);
+
+    uint32_t num_hw_blocks_per_shard = Hts > Ht ? Hts / Ht : 1;
+
+    uint32_t HtWt_tile_size = Ht_per_shard * Wts;
+    uint32_t num_blocks = num_hw_blocks_per_shard * HtWt_tile_size;
+
+    auto bbox = all_cores.bounding_box();
+    std::vector<CoreCoord> cores =
+        grid_to_cores_with_noop(bbox.end_coord.x, bbox.end_coord.y, num_cores_x, num_cores_y, row_major);
+
+    // Active shard cores get the real arg values; the trailing no-op cores keep the
+    // default-constructed slots (matching legacy std::fill behavior on cores.size()).
+    const std::vector<uint32_t> reader_rt = {num_blocks};
+    const std::vector<uint32_t> compute_rt = {num_blocks, HtWt_tile_size, num_hw_blocks_per_shard, Ht_per_shard, Wts};
+    const std::vector<uint32_t> writer_rt = {num_blocks};
+
+    const uint32_t num_active = all_cores.num_cores();
+    reader_desc.runtime_args.reserve(cores.size());
+    compute_desc.runtime_args.reserve(cores.size());
+    writer_desc.runtime_args.reserve(cores.size());
+    for (uint32_t i = 0; i < cores.size(); ++i) {
+        if (i < num_active) {
+            reader_desc.runtime_args.emplace_back(cores[i], reader_rt);
+            compute_desc.runtime_args.emplace_back(cores[i], compute_rt);
+            writer_desc.runtime_args.emplace_back(cores[i], writer_rt);
+        } else {
+            // No-op core: matches legacy std::vector<uint32_t>(1)/(5) zero-initialized rows.
+            reader_desc.runtime_args.emplace_back(cores[i], std::vector<uint32_t>(1));
+            compute_desc.runtime_args.emplace_back(cores[i], std::vector<uint32_t>(5));
+            writer_desc.runtime_args.emplace_back(cores[i], std::vector<uint32_t>(1));
+        }
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_sharded_program_factory.hpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "transpose_device_operation_types.hpp"
+
+#include "ttnn/device_operation.hpp"
+
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace ttnn::prim::qsr {
+
+struct TransposeWHShardedProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
@@ -1,0 +1,253 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "transpose_wh_sharded_rm_program_factory.hpp"
+
+#include <tt_stl/assert.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-logger/tt-logger.hpp>
+
+#include <algorithm>
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+
+tt::tt_metal::ProgramDescriptor TransposeWHShardedRMProgramFactory::create_descriptor(
+    const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
+    const auto& input_tensor = tensor_args.input;
+
+    TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_wh needs to be on device!");
+    TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_wh needs to be allocated in a buffer on device!");
+
+    ProgramDescriptor desc;
+
+    tt::DataFormat src0_cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
+    uint32_t src0_single_tile_size = tt::tile_size(src0_cb_data_format);
+    tt::DataFormat dst_cb_data_format = datatype_to_dataformat_converter(output_tensor.dtype());
+    uint32_t dst_single_tile_size = tt::tile_size(dst_cb_data_format);
+
+    uint32_t W = input_tensor.logical_shape()[3], H = input_tensor.logical_shape()[2];
+    uint32_t stick_size_bytes = W * input_tensor.element_size();
+    uint32_t ht = (H + TILE_HEIGHT - 1) / TILE_HEIGHT;
+    uint32_t wt = (W + TILE_WIDTH - 1) / TILE_WIDTH;
+
+    uint32_t output_page_size, pack_num_pages, pack_num_pages_last_col, pack_num_pages_last_row,
+        pack_num_pages_last_row_col;
+    if ((W % TILE_WIDTH) != 0 and (H % TILE_HEIGHT) != 0) {
+        output_page_size = (W % TILE_WIDTH) * (H % TILE_HEIGHT) * output_tensor.element_size();
+        pack_num_pages = dst_single_tile_size / output_page_size;
+        auto output_page_size_last_col = TILE_WIDTH * (H % TILE_HEIGHT) * output_tensor.element_size();
+        pack_num_pages_last_col = dst_single_tile_size / output_page_size_last_col;
+        auto output_page_size_last_row = TILE_HEIGHT * (W % TILE_WIDTH) * output_tensor.element_size();
+        pack_num_pages_last_row = dst_single_tile_size / output_page_size_last_row;
+        pack_num_pages_last_row_col = 1;
+    } else if ((W % TILE_WIDTH) != 0 and (H % TILE_HEIGHT) == 0) {
+        output_page_size = (W % TILE_WIDTH) * (TILE_HEIGHT)*output_tensor.element_size();
+        pack_num_pages = dst_single_tile_size / output_page_size;
+        pack_num_pages_last_col = pack_num_pages;
+        pack_num_pages_last_row = 1;
+        pack_num_pages_last_row_col = 1;
+    } else if ((W % TILE_WIDTH) == 0 and (H % TILE_HEIGHT) != 0) {
+        output_page_size = (TILE_WIDTH) * (H % TILE_HEIGHT) * output_tensor.element_size();
+        pack_num_pages = dst_single_tile_size / output_page_size;
+        pack_num_pages_last_col = 1;
+        pack_num_pages_last_row = pack_num_pages;
+        pack_num_pages_last_row_col = 1;
+    } else {
+        output_page_size = dst_single_tile_size;
+        pack_num_pages = 1;
+        pack_num_pages_last_col = 1;
+        pack_num_pages_last_row = 1;
+        pack_num_pages_last_row_col = 1;
+    }
+
+    log_debug(tt::LogOp, "output_page_size: {}", output_page_size);
+    log_debug(tt::LogOp, "pack_num_pages: {}", pack_num_pages);
+    log_debug(tt::LogOp, "pack_num_pages_last_col: {}", pack_num_pages_last_col);
+    log_debug(tt::LogOp, "pack_num_pages_last_row: {}", pack_num_pages_last_row);
+    log_debug(tt::LogOp, "pack_num_pages_last_row_col: {}", pack_num_pages_last_row_col);
+
+    auto shard_spec = input_tensor.shard_spec().value();
+    uint32_t shard_height = shard_spec.shape[0];
+    uint32_t num_hw_blocks_per_core = shard_height / H;
+
+    log_debug(tt::LogOp, "shard_height: {}", shard_height);
+    log_debug(tt::LogOp, "dst_single_tile_size: {}", dst_single_tile_size);
+
+    bool fp32_dest_acc_en = src0_cb_data_format == tt::DataFormat::Float32;
+
+    auto& all_cores = shard_spec.grid;
+    [[maybe_unused]] uint32_t num_cores = shard_spec.num_cores();
+
+    log_debug(tt::LogOp, "all_cores: {}", all_cores);
+    log_debug(tt::LogOp, "num_cores: {}", num_cores);
+
+    // sharded cb (input): .buffer triggers UpdateDynamicCircularBufferAddress on cache hit.
+    uint32_t src0_cb_index = tt::CBIndex::c_0;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = shard_height * stick_size_bytes,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = src0_cb_data_format,
+            .page_size = stick_size_bytes,
+        }}},
+        .buffer = input_tensor.buffer(),
+    });
+
+    // sharded cb (output): .buffer triggers UpdateDynamicCircularBufferAddress on cache hit.
+    uint32_t output_cb_index = tt::CBIndex::c_16;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = stick_size_bytes * shard_height,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = dst_cb_data_format,
+            .page_size = output_page_size,
+        }}},
+        .buffer = output_tensor.buffer(),
+    });
+
+    // cb_in (double-buffered intermediate)
+    uint32_t in_cb_index = tt::CBIndex::c_24;
+    uint32_t num_in_tiles = wt * 2;  // double buffer
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_in_tiles * src0_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(in_cb_index),
+            .data_format = src0_cb_data_format,
+            .page_size = src0_single_tile_size,
+        }}},
+    });
+
+    // tilize cb
+    uint32_t im_cb_index = tt::CBIndex::c_25;
+    uint32_t num_im_tiles = ht * wt;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_im_tiles * src0_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(im_cb_index),
+            .data_format = src0_cb_data_format,
+            .page_size = src0_single_tile_size,
+        }}},
+    });
+
+    // untilize cb (only when ht > 8) + matching output staging CB
+    if (ht > 8) {
+        uint32_t im2_cb_index = tt::CBIndex::c_26;
+        uint32_t num_im2_tiles = ht;
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = num_im2_tiles * dst_single_tile_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(im2_cb_index),
+                .data_format = dst_cb_data_format,
+                .page_size = dst_single_tile_size,
+            }}},
+        });
+
+        // compute_output_cb
+        uint32_t out_cb_index = tt::CBIndex::c_27;
+        uint32_t num_out_tiles = ht * 2;  // double buffer
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = num_out_tiles * dst_single_tile_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(out_cb_index),
+                .data_format = dst_cb_data_format,
+                .page_size = dst_single_tile_size,
+            }}},
+        });
+    }
+
+    std::vector<uint32_t> reader_compile_time_args = {
+        (std::uint32_t)num_hw_blocks_per_core,
+        (std::uint32_t)ht,
+        (std::uint32_t)H > TILE_HEIGHT ? TILE_HEIGHT : H % TILE_HEIGHT,
+        (std::uint32_t)H % TILE_HEIGHT == 0 ? TILE_HEIGHT : H % TILE_HEIGHT,
+        (std::uint32_t)wt,
+        (std::uint32_t)stick_size_bytes,
+        (std::uint32_t)wt * input_tensor.element_size() * TILE_WIDTH,
+    };
+    reader_compile_time_args.push_back(H > TILE_HEIGHT ? TILE_HEIGHT : H % TILE_HEIGHT);
+    reader_compile_time_args.push_back(H % TILE_HEIGHT == 0 ? TILE_HEIGHT : H % TILE_HEIGHT);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/"
+        "reader_unary_transpose_wh_sharded_rm.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    std::vector<uint32_t> writer_compile_time_args = {
+        (std::uint32_t)num_hw_blocks_per_core,
+        (std::uint32_t)ht,
+        (std::uint32_t)wt,
+        (std::uint32_t)W > TILE_WIDTH ? TILE_WIDTH : W % TILE_WIDTH,
+        (std::uint32_t)W % TILE_WIDTH == 0 ? TILE_WIDTH : W % TILE_WIDTH,
+        (std::uint32_t)H * output_tensor.element_size(),
+        (std::uint32_t)ht * output_tensor.element_size() * TILE_HEIGHT,
+    };
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/"
+        "writer_unary_transpose_wh_sharded_rm.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    std::vector<uint32_t> compute_compile_time_args = {
+        (std::uint32_t)ht,
+        (std::uint32_t)wt,
+        (std::uint32_t)ht * wt,
+        (std::uint32_t)num_hw_blocks_per_core,
+        (std::uint32_t)H % TILE_HEIGHT == 0 ? TILE_HEIGHT : H % TILE_HEIGHT,  // last_output_row_num_datums
+        (std::uint32_t)pack_num_pages,
+        (std::uint32_t)pack_num_pages_last_col,
+        (std::uint32_t)pack_num_pages_last_row,
+        (std::uint32_t)pack_num_pages_last_row_col,
+    };
+
+    KernelDescriptor::Defines compute_defines;
+    compute_defines.emplace_back("SHARDED", "1");
+
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    if (src0_cb_data_format == tt::DataFormat::Float32) {
+        // Keep both the tilize input (c_24) and its output (c_25, which feeds
+        // the transpose) in full Float32 on the unpack-to-dest path; otherwise
+        // the unpacker falls back to tf32 and drops the low mantissa bits.
+        unpack_to_dest_mode[in_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[im_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+    }
+
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/compute/transpose_wh_rm.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = all_cores;
+    compute_desc.compile_time_args = std::move(compute_compile_time_args);
+    compute_desc.defines = std::move(compute_defines);
+    compute_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+    };
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_sharded_rm_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_sharded_rm_program_factory.hpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "transpose_device_operation_types.hpp"
+
+#include "ttnn/device_operation.hpp"
+
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace ttnn::prim::qsr {
+
+struct TransposeWHShardedRMProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/transpose.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/transpose.cpp
@@ -1,0 +1,293 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "transpose.hpp"
+
+#include "ttnn/operations/data_movement/clone/clone.hpp"
+#include "device/transpose_device_operation.hpp"
+#include "device/transpose_utils.hpp"
+#include "ttnn/operations/copy/typecast/typecast.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/data_movement/common/common.hpp"
+#include "ttnn/operations/data_movement/permute/device/permute_device_operation.hpp"
+#include "ttnn/operations/data_movement/permute/permute.hpp"
+
+#include <tt-metalium/hal.hpp>
+
+namespace ttnn::operations::experimental::quasar::transpose_op {
+
+namespace detail {
+
+using namespace tt::tt_metal::experimental;
+using namespace tt;
+using tt::tt_metal::BufferType;
+using ttnn::operations::experimental::quasar::transpose_op::adjust_shard_spec_to_shape;
+using ttnn::operations::experimental::quasar::transpose_op::is_native_transpose_sharding;
+
+inline Tensor transpose_(
+    const Tensor& a,
+    ttnn::prim::qsr::TransposeOpDim transpose_dim,
+    const std::optional<MemoryConfig>& output_mem_config,
+    float pad_value = 0.0f) {
+    MemoryConfig output_mem_constructed;
+    if (!output_mem_config.has_value() ||
+        (output_mem_config.value().is_sharded() && !output_mem_config.value().shard_spec().has_value())) {
+        // Native sharded subset: derive output shard_spec from input's. Otherwise fall back to L1
+        // interleaved (the interleaved factories handle non-native via TensorAccessor).
+        const bool native = is_native_transpose_sharding(a.tensor_spec());
+        if (a.is_sharded() && native) {
+            // Seed: honor user's requested sharded layout (spec gets synthesized below); else
+            // inherit input config so downstream can promote (e.g. N=C=1 → WIDTH_SHARDED).
+            const bool user_requested_layout = output_mem_config.has_value() && output_mem_config.value().is_sharded();
+            output_mem_constructed = user_requested_layout ? output_mem_config.value() : a.memory_config();
+            // If shard geometry can't scale to a valid output shard, hand back a shard-spec-less
+            // sharded MemoryConfig (device op synthesizes via generate_transpose_shard_spec) when
+            // the user requested sharded; otherwise fall back to L1 interleaved.
+            const auto shard_derivation_fallback = [&]() {
+                if (user_requested_layout) {
+                    output_mem_constructed = MemoryConfig(
+                        output_mem_config.value().memory_layout(), output_mem_config.value().buffer_type());
+                } else {
+                    output_mem_constructed = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1);
+                }
+            };
+            const auto& input_padded_shape = a.padded_shape();
+            if (transpose_dim == ttnn::prim::qsr::TransposeOpDim::WH) {
+                const uint32_t W = input_padded_shape[3], C = input_padded_shape[1], N = input_padded_shape[0];
+                auto shard_spec = a.shard_spec().value();
+                // N=C=1 height-sharded-with-full-width → WIDTH_SHARDED (skip if user requested layout).
+                const bool can_promote_to_width_sharded =
+                    !user_requested_layout && N == 1 && C == 1 && shard_spec.shape[1] == W;
+                if (can_promote_to_width_sharded) {
+                    std::swap(shard_spec.shape[0], shard_spec.shape[1]);
+                    if (a.layout() == Layout::TILE && (shard_spec.shape[0] % tt::constants::TILE_HEIGHT != 0 ||
+                                                       shard_spec.shape[1] % tt::constants::TILE_WIDTH != 0)) {
+                        shard_derivation_fallback();
+                    } else {
+                        output_mem_constructed = MemoryConfig(
+                            TensorMemoryLayout::WIDTH_SHARDED, output_mem_constructed.buffer_type(), shard_spec);
+                    }
+                } else {
+                    auto output_padded_shape = input_padded_shape;
+                    std::swap(output_padded_shape[2], output_padded_shape[3]);
+                    auto adjusted = adjust_shard_spec_to_shape(shard_spec, input_padded_shape, output_padded_shape);
+                    if (!adjusted.has_value() ||
+                        (a.layout() == Layout::TILE && (adjusted->shape[0] % tt::constants::TILE_HEIGHT != 0 ||
+                                                        adjusted->shape[1] % tt::constants::TILE_WIDTH != 0))) {
+                        shard_derivation_fallback();
+                    } else {
+                        output_mem_constructed = MemoryConfig(
+                            output_mem_constructed.memory_layout(),
+                            output_mem_constructed.buffer_type(),
+                            std::move(adjusted));
+                    }
+                }
+            } else if (transpose_dim == ttnn::prim::qsr::TransposeOpDim::HC && a.layout() == Layout::TILE) {
+                auto shard_spec = a.shard_spec().value();
+                // HC TILE padded-shape contract: dim[1] = logical H, dim[2] = round_up(logical C, TILE_HEIGHT).
+                auto output_padded_shape = input_padded_shape;
+                output_padded_shape[1] = a.logical_shape()[2];
+                output_padded_shape[2] = tt::round_up(a.logical_shape()[1], tt::constants::TILE_HEIGHT);
+                auto adjusted = adjust_shard_spec_to_shape(shard_spec, input_padded_shape, output_padded_shape);
+                if (!adjusted.has_value() || adjusted->shape[0] % tt::constants::TILE_HEIGHT != 0 ||
+                    adjusted->shape[1] % tt::constants::TILE_WIDTH != 0) {
+                    shard_derivation_fallback();
+                } else {
+                    output_mem_constructed = MemoryConfig(
+                        output_mem_constructed.memory_layout(),
+                        output_mem_constructed.buffer_type(),
+                        std::move(adjusted));
+                }
+            }
+        } else if (output_mem_config.has_value()) {
+            // User-requested sharded output (no spec): honor the layout; device op will synthesize
+            // the spec. Must precede the non-native fallback below so it isn't overridden.
+            output_mem_constructed = output_mem_config.value();
+        } else if (a.is_sharded()) {
+            // Non-native sharded input → mirror input's memory_layout (no shard_spec, device op
+            // synthesizes via adjust_shard_spec_to_shape / generate_transpose_shard_spec)
+            output_mem_constructed = MemoryConfig(a.memory_config().memory_layout(), a.memory_config().buffer_type());
+        } else {
+            output_mem_constructed = a.memory_config();
+        }
+    } else {
+        output_mem_constructed = output_mem_config.value();
+    }
+
+    auto prim_permute = [&](const ttnn::Tensor& input, const ttnn::SmallVector<uint32_t>& dims) -> ttnn::Tensor {
+        return ttnn::prim::permute(input, dims, output_mem_constructed, std::nullopt, pad_value);
+    };
+
+    bool interleaved_rm = !a.is_sharded() && a.layout() == Layout::ROW_MAJOR;
+    switch (transpose_dim) {
+        case ttnn::prim::qsr::TransposeOpDim::HC:
+            if (interleaved_rm) {
+                return prim_permute(a, ttnn::SmallVector<uint32_t>{0, 2, 1, 3});
+            }
+            break;
+        case ttnn::prim::qsr::TransposeOpDim::NH:
+            return ttnn::permute(
+                (const ttnn::Tensor)a, ttnn::SmallVector<int64_t>({2, 1, 0, 3}), output_mem_config, pad_value);
+        case ttnn::prim::qsr::TransposeOpDim::NW:
+            return ttnn::permute(
+                (const ttnn::Tensor)a, ttnn::SmallVector<int64_t>({3, 1, 2, 0}), output_mem_config, pad_value);
+        case ttnn::prim::qsr::TransposeOpDim::CW:
+            return ttnn::permute(
+                (const ttnn::Tensor)a, ttnn::SmallVector<int64_t>({0, 3, 2, 1}), output_mem_config, pad_value);
+        case ttnn::prim::qsr::TransposeOpDim::CN:
+            if (interleaved_rm) {
+                return prim_permute(a, ttnn::SmallVector<uint32_t>({1, 0, 2, 3}));
+            }
+            break;
+        case ttnn::prim::qsr::TransposeOpDim::WH:
+            if (interleaved_rm) {
+                return prim_permute(a, ttnn::SmallVector<uint32_t>({0, 1, 3, 2}));
+            }
+            if (a.layout() == Layout::ROW_MAJOR) {
+                // Only compute the RM WH CB-vs-L1 budget when actually on the RM WH path:
+                // the allocator query and padded-shape arithmetic are wasted work otherwise.
+                const uint32_t W_padded = round_up(a.logical_shape()[3], tt::constants::TILE_WIDTH);
+                const uint32_t H_padded = round_up(a.logical_shape()[2], tt::constants::TILE_HEIGHT);
+                const uint32_t cb_size_for_rm = (2 * W_padded + 2 * H_padded + H_padded * W_padded) * a.element_size();
+                auto* device = a.device();
+                auto lowest_address = device->lowest_occupied_compute_l1_address();
+                uint32_t max_l1_space =
+                    lowest_address.has_value() ? lowest_address.value() : device->l1_size_per_core();
+                max_l1_space =
+                    max_l1_space - device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
+                if (cb_size_for_rm > max_l1_space) {
+                    return prim_permute(a, ttnn::SmallVector<uint32_t>({0, 1, 3, 2}));
+                }
+            }
+            break;
+        default: break;
+    }
+    return ttnn::prim::qsr::transpose(a, transpose_dim, output_mem_constructed, pad_value);
+}
+
+ttnn::Tensor transpose_nd(
+    const ttnn::Tensor& input_tensor,
+    uint32_t dim1,
+    uint32_t dim2,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    float pad_value = 0.0f) {
+    const auto rank = input_tensor.logical_shape().rank();
+    ttnn::SmallVector<int64_t> permutation;
+    permutation.reserve(rank);
+    for (uint32_t i = 0; i < rank; ++i) {
+        permutation.push_back(i);
+    }
+    std::swap(permutation[dim1], permutation[dim2]);
+    return ttnn::permute(input_tensor, permutation, memory_config_arg, pad_value);
+}
+
+inline bool is_block_or_width_sharded_mc(const tt::tt_metal::MemoryConfig& mc) {
+    return mc.is_sharded() && (mc.memory_layout() == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED ||
+                               mc.memory_layout() == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED);
+}
+
+}  // namespace detail
+
+ttnn::Tensor transpose_impl(
+    const ttnn::Tensor& input_tensor,
+    int64_t dim1,
+    int64_t dim2,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    float pad_value = 0.0f) {
+    {
+        // Irregular RM block/width sharded hits a pages_per_shard misread in noc_async_*_sharded.
+        // Unshard until the kernel-side helpers handle irregular RM geometries.
+        const bool rm = input_tensor.layout() == Layout::ROW_MAJOR;
+        const bool in_sharded = detail::is_block_or_width_sharded_mc(input_tensor.memory_config());
+        const auto& input_logical = input_tensor.logical_shape();
+        const bool irregular_hw = input_logical.rank() >= 2 && (input_logical[-1] % tt::constants::TILE_WIDTH != 0 ||
+                                                                input_logical[-2] % tt::constants::TILE_HEIGHT != 0);
+        if (rm && in_sharded && irregular_hw) {
+            const auto interleaved_l1 =
+                tt::tt_metal::MemoryConfig(tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::L1);
+            Tensor x = ttnn::to_memory_config(input_tensor, interleaved_l1, std::nullopt);
+            return transpose_impl(x, dim1, dim2, memory_config_arg, pad_value);
+        }
+    }
+    const auto& input_shape = input_tensor.logical_shape();
+    uint32_t normalized_dim1 = input_shape.get_normalized_index(dim1);
+    uint32_t normalized_dim2 = input_shape.get_normalized_index(dim2);
+
+    Tensor input_unsqueezed = input_tensor;
+    uint32_t initial_rank = input_shape.rank();
+    if (initial_rank < 4) {
+        input_unsqueezed = ttnn::unsqueeze_to_4D(input_tensor);
+        uint32_t rank_diff = 4 - initial_rank;
+        normalized_dim1 += rank_diff;
+        normalized_dim2 += rank_diff;
+    } else if (initial_rank > 4) {
+        return detail::transpose_nd(input_tensor, normalized_dim1, normalized_dim2, memory_config_arg, pad_value);
+    }
+
+    bool wh = (normalized_dim1 == 2 && normalized_dim2 == 3) || (normalized_dim2 == 2 && normalized_dim1 == 3);
+    bool cn = (normalized_dim1 == 0 && normalized_dim2 == 1) || (normalized_dim2 == 0 && normalized_dim1 == 1);
+    bool bfloat8_supported = cn || wh;
+    bool typecast = input_unsqueezed.dtype() == DataType::BFLOAT8_B and !bfloat8_supported;
+    Tensor input_typecasted = typecast ? ttnn::typecast(input_unsqueezed, DataType::BFLOAT16) : input_unsqueezed;
+
+    TT_FATAL(normalized_dim1 <= 3, "dimension has to be 0-3 only corresponding to N,C,H,W");
+    TT_FATAL(normalized_dim2 <= 3, "dimension has to be 0-3 only corresponding to N,C,H,W");
+
+    Tensor output;
+    if ((normalized_dim1 == normalized_dim2) || (input_typecasted.padded_shape()[normalized_dim1] == 1 &&
+                                                 input_typecasted.padded_shape()[normalized_dim2] == 1)) {
+        if (memory_config_arg.has_value() && input_typecasted.memory_config() != memory_config_arg.value()) {
+            output = ttnn::clone(
+                input_typecasted,
+                std::nullopt,
+                memory_config_arg.value_or(input_typecasted.memory_config()),
+                std::nullopt);
+        } else {
+            output = input_typecasted;
+        }
+    } else {
+        if (normalized_dim1 > normalized_dim2) {
+            std::swap(normalized_dim1, normalized_dim2);
+        }
+
+        ttnn::prim::qsr::TransposeOpDim transpose_dim = ttnn::prim::qsr::TransposeOpDim::NW;
+
+        if (normalized_dim2 == 3 && normalized_dim1 == 0) {
+            transpose_dim = ttnn::prim::qsr::TransposeOpDim::NW;
+        } else if (normalized_dim2 == 3 && normalized_dim1 == 1) {
+            transpose_dim = ttnn::prim::qsr::TransposeOpDim::CW;
+        } else if (normalized_dim2 == 3 && normalized_dim1 == 2) {
+            transpose_dim = ttnn::prim::qsr::TransposeOpDim::WH;
+        } else if (normalized_dim2 == 2 && normalized_dim1 == 0) {
+            transpose_dim = ttnn::prim::qsr::TransposeOpDim::NH;
+        } else if (normalized_dim2 == 2 && normalized_dim1 == 1) {
+            transpose_dim = ttnn::prim::qsr::TransposeOpDim::HC;
+        } else if (normalized_dim2 == 1 && normalized_dim1 == 0) {
+            transpose_dim = ttnn::prim::qsr::TransposeOpDim::CN;
+        } else {
+            TT_ASSERT(false, "Unsupported transpose dims");
+        }
+        output = detail::transpose_(input_typecasted, transpose_dim, memory_config_arg, pad_value);
+    }
+    output = initial_rank < 4u ? ttnn::squeeze_from_4D(output, initial_rank) : output;
+    return typecast ? ttnn::typecast(output, DataType::BFLOAT8_B) : output;
+}
+
+}  // namespace ttnn::operations::experimental::quasar::transpose_op
+
+namespace ttnn::operations::experimental::quasar {
+
+ttnn::Tensor transpose(
+    const ttnn::Tensor& input_tensor,
+    int64_t dim1,
+    int64_t dim2,
+    const std::optional<MemoryConfig>& memory_config,
+    float pad_value) {
+    return transpose_op::transpose_impl(input_tensor, dim1, dim2, memory_config, pad_value);
+}
+
+ttnn::Tensor transpose(const ttnn::Tensor& input_tensor, int64_t dim1, int64_t dim2, float pad_value) {
+    return transpose(input_tensor, dim1, dim2, std::nullopt, pad_value);
+}
+
+}  // namespace ttnn::operations::experimental::quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/transpose.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/transpose.hpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::experimental::quasar {
+
+ttnn::Tensor transpose(
+    const ttnn::Tensor& input_tensor,
+    int64_t dim1,
+    int64_t dim2,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    float pad_value = 0.0f);
+
+ttnn::Tensor transpose(const ttnn::Tensor& input_tensor, int64_t dim1, int64_t dim2, float pad_value = 0.0f);
+
+}  // namespace ttnn::operations::experimental::quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/transpose_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/transpose_nanobind.cpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "transpose_nanobind.hpp"
+
+#include <cstdint>
+#include <optional>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
+
+#include "ttnn-nanobind/bind_function.hpp"
+
+#include "transpose.hpp"
+
+namespace ttnn::operations::experimental::quasar::detail {
+
+void bind_transpose(nb::module_& mod) {
+    const auto* doc =
+        R"doc(
+            Returns a tensor that is transposed along dims dim1 and dim2
+
+            Equivalent pytorch code:
+
+            .. code-block:: python
+
+                output_tensor = torch.transpose(input_tensor, 0, 1)
+
+            Args:
+                * :attr:`input_tensor`: Input Tensor.
+                * :attr:`dim1`: First dim of transpose.
+                * :attr:`dim2`: Second dim of transpose.
+                * :attr:`pad_value` (float, optional): padding value for when tiles are broken in a transpose. Defaults to `0.0`.
+
+            Keyword Args:
+                * :attr:`memory_config`: Memory Config of the output tensor
+        )doc";
+
+    ttnn::bind_function<"transpose">(
+        mod,
+        doc,
+
+        // Overload 1: with memory_config
+        ttnn::overload_t(
+            nb::overload_cast<const ttnn::Tensor&, int64_t, int64_t, const std::optional<ttnn::MemoryConfig>&, float>(
+                &ttnn::operations::experimental::quasar::transpose),
+            nb::arg("input_tensor"),
+            nb::arg("dim1"),
+            nb::arg("dim2"),
+            nb::kw_only(),
+            nb::arg("memory_config") = nb::none(),
+            nb::arg("pad_value") = 0.0f),
+
+        // Overload 2: without memory_config
+        ttnn::overload_t(
+            nb::overload_cast<const ttnn::Tensor&, int64_t, int64_t, float>(
+                &ttnn::operations::experimental::quasar::transpose),
+            nb::arg("input_tensor"),
+            nb::arg("dim1"),
+            nb::arg("dim2"),
+            nb::arg("pad_value") = 0.0f));
+}
+}  // namespace ttnn::operations::experimental::quasar::detail

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/transpose_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/transpose_nanobind.hpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::experimental::quasar::detail {
+
+namespace nb = nanobind;
+
+void bind_transpose(nb::module_& mod);
+}  // namespace ttnn::operations::experimental::quasar::detail

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.cpp
@@ -1,0 +1,333 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "untilize_with_unpadding_multi_core_block_interleaved_program_factory.hpp"
+
+#include "ttnn/operations/cb_utils.hpp"
+#include "ttnn/operations/math.hpp"
+#include "ttnn/operations/core/work_split/work_split_tilize.hpp"
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include "ttnn/common/constants.hpp"
+#include "ttnn/operation.hpp"
+#include "ttnn/operations/data_movement/common/common.hpp"
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+
+namespace {
+
+inline void push_cb_pair(
+    ProgramDescriptor& desc,
+    const CoreRangeSet& core_ranges,
+    uint32_t num_tiles,
+    uint32_t input_single_tile_size,
+    uint32_t output_single_tile_size,
+    tt::DataFormat input_cb_data_format,
+    tt::DataFormat output_cb_data_format) {
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles * input_single_tile_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_0),
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles * output_single_tile_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_16),
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
+}
+
+}  // namespace
+
+tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreBlockInterleavedProgramFactory::create_descriptor(
+    const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output) {
+    const auto& a = input;
+    bool fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en;
+
+    ProgramDescriptor desc;
+
+    tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
+    uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
+    tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
+    uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
+
+    const auto& input_shape = a.padded_shape();
+    const auto& output_shape = output.padded_shape();
+    const auto& sub_core_grids = operation_attributes.sub_core_grids;
+
+    IDevice* device = a.device();
+    CoreCoord grid_size = device->compute_with_storage_grid_size();
+    CoreRange default_cores({0, 0}, {grid_size.x - 1, grid_size.y - 1});
+    CoreRangeSet default_grid(default_cores);
+    CoreRangeSet available_grid = sub_core_grids.has_value() ? sub_core_grids.value() : default_grid;
+
+    uint32_t max_l1_size = operations::data_movement::get_max_l1_space(a);
+    uint32_t num_tiles_per_row = a.padded_shape()[-1] / TILE_WIDTH;
+    uint32_t num_tiles_per_col = a.padded_shape()[-2] / TILE_HEIGHT;
+
+    uint32_t num_blocks = (a.padded_shape()[-1] * a.padded_shape()[-2]) / (TILE_HEIGHT * TILE_WIDTH);
+    uint32_t cb_block_size_limit = max_l1_size / (input_single_tile_size + output_single_tile_size);
+
+    auto
+        [ncores,
+         all_cores,
+         core_range,
+         cliff_row_core_range,
+         cliff_col_core_range,
+         cliff_col_row_core_range,
+         nblocks_per_core,
+         single_block_size,
+         single_block_size_cliff_row,
+         single_block_size_cliff_col,
+         has_cliff_row,
+         has_cliff_col,
+         full_cores_per_row,
+         full_cores_per_col,
+         single_sub_block_size] =
+            ttnn::split_blocks_for_tilize_wh(
+                available_grid, num_blocks, num_tiles_per_row, num_tiles_per_col, cb_block_size_limit);
+
+    if (single_sub_block_size > 0 && single_block_size % single_sub_block_size) {
+        TT_FATAL(false, "single_block_size is not divided by single_sub_block_size");
+    }
+
+    uint32_t total_tiles_per_row =
+        (full_cores_per_row * single_block_size) + (has_cliff_row * single_block_size_cliff_row);
+    uint32_t padded_row_size_bytes;
+    uint32_t unpadded_row_size_bytes;
+
+    uint32_t el_size;
+    if (a.dtype() == DataType::BFLOAT8_B) {
+        padded_row_size_bytes = input_shape[-1] * output.element_size();
+        unpadded_row_size_bytes = output_shape[-1] * output.element_size();
+        el_size = output.element_size();
+    } else {
+        padded_row_size_bytes = input_shape[-1] * a.element_size();
+        unpadded_row_size_bytes = output_shape[-1] * a.element_size();
+        el_size = a.element_size();
+    }
+
+    // CBs: emit a pair (input + output) per non-empty core sub-region. The legacy code
+    // created two CreateCircularBuffer calls on different core ranges — descriptors mirror
+    // this layout exactly.
+    if (!core_range.empty()) {
+        push_cb_pair(
+            desc,
+            core_range,
+            single_sub_block_size,
+            input_single_tile_size,
+            output_single_tile_size,
+            input_cb_data_format,
+            output_cb_data_format);
+    }
+    if (has_cliff_col && has_cliff_row) {
+        push_cb_pair(
+            desc,
+            cliff_col_row_core_range,
+            single_block_size_cliff_row,
+            input_single_tile_size,
+            output_single_tile_size,
+            input_cb_data_format,
+            output_cb_data_format);
+    }
+    if (has_cliff_row) {
+        push_cb_pair(
+            desc,
+            cliff_row_core_range,
+            single_block_size_cliff_row,
+            input_single_tile_size,
+            output_single_tile_size,
+            input_cb_data_format,
+            output_cb_data_format);
+    }
+    if (has_cliff_col) {
+        push_cb_pair(
+            desc,
+            cliff_col_core_range,
+            single_sub_block_size,
+            input_single_tile_size,
+            output_single_tile_size,
+            input_cb_data_format,
+            output_cb_data_format);
+    }
+
+    Buffer* src0_buffer = a.buffer();
+    Buffer* dst_buffer = output.buffer();
+    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    // reader
+
+    uint32_t num_tiles_2d = a.padded_shape()[-1] * a.padded_shape()[-2] / TILE_HW;
+
+    auto log_shape = output.logical_shape();
+    uint32_t third_dim = 1;
+    if (log_shape.rank() == 3) {
+        third_dim = log_shape[-3];
+    } else if (log_shape.rank() >= 4) {
+        third_dim = log_shape[-3] * log_shape[-4];
+    }
+
+    std::vector<uint32_t> reader_compile_time_args = {num_tiles_2d, third_dim, total_tiles_per_row};
+    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_wh_multicore.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    // writer
+    uint32_t total_num_rows = output.logical_shape()[-2];
+    std::vector<uint32_t> writer_ct_args = {total_num_rows, third_dim, TILE_HEIGHT, unpadded_row_size_bytes};
+    TensorAccessorArgs(*dst_buffer).append_to(writer_ct_args);
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/"
+        "writer_unary_stick_layout_wh_multicore.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    // compute
+    uint32_t single_sub_block_size_wh = single_block_size * single_block_size / single_sub_block_size;
+    uint32_t single_sub_block_size_cliff_col_wh =
+        single_block_size_cliff_col * single_block_size / single_sub_block_size;
+    KernelDescriptor::Defines compute_kernel_defines;
+    if (input_cb_data_format == tt::DataFormat::Int32 || input_cb_data_format == tt::DataFormat::UInt32 ||
+        input_cb_data_format == tt::DataFormat::Float32) {
+        compute_kernel_defines.emplace_back("DST_ACCUM_MODE", "1");
+    }
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    if (fp32_dest_acc_en) {
+        unpack_to_dest_mode[tt::CBIndex::c_0] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+    }
+
+    const std::string compute_kernel_path(
+        "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_wh.cpp");
+
+    auto push_compute = [&](const CoreRangeSet& cr, std::initializer_list<uint32_t> compile_args) {
+        KernelDescriptor compute_desc;
+        compute_desc.kernel_source = compute_kernel_path;
+        compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc.core_ranges = cr;
+        compute_desc.compile_time_args = std::vector<uint32_t>(compile_args.begin(), compile_args.end());
+        compute_desc.defines = compute_kernel_defines;
+        compute_desc.config = ComputeConfigDescriptor{
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+        };
+        desc.kernels.push_back(std::move(compute_desc));
+    };
+
+    if (!core_range.empty()) {
+        push_compute(core_range, {single_sub_block_size_wh, single_sub_block_size, third_dim});
+    }
+    if (has_cliff_col && has_cliff_row) {
+        push_compute(cliff_col_row_core_range, {single_block_size_cliff_col, single_block_size_cliff_row, third_dim});
+    }
+    if (has_cliff_row) {
+        push_compute(cliff_row_core_range, {single_block_size, single_block_size_cliff_row, third_dim});
+    }
+    if (has_cliff_col) {
+        push_compute(cliff_col_core_range, {single_sub_block_size_cliff_col_wh, single_sub_block_size, third_dim});
+    }
+
+    // RUNTIME ARGS
+    const auto& cores = corerange_to_cores(available_grid);
+    uint32_t start_row_id = 0;
+    uint32_t start_column_id = 0;
+    uint32_t tile_start_id = 0;
+    uint32_t single_block_size_row_arg;
+    uint32_t single_block_size_col_arg;
+    uint32_t single_sub_block_size_row_arg;
+
+    uint32_t total_row_cores = full_cores_per_row;
+    if (has_cliff_row) {
+        total_row_cores++;
+    }
+    uint32_t cores_col_count = 1;
+
+    reader_desc.runtime_args.reserve(ncores);
+    writer_desc.runtime_args.reserve(ncores);
+    for (uint32_t i = 0; i < ncores; ++i) {
+        const auto& core = cores[i];
+
+        if (has_cliff_col && has_cliff_row && i == ncores - 1) {
+            single_block_size_row_arg = single_block_size_cliff_row;
+            single_block_size_col_arg = single_block_size_cliff_col;
+            single_sub_block_size_row_arg = single_block_size_cliff_row;
+
+        } else if (has_cliff_row && i != 0 && ((i + 1) % (full_cores_per_row + 1)) == 0) {
+            single_block_size_row_arg = single_block_size_cliff_row;
+            single_block_size_col_arg = single_block_size;
+            single_sub_block_size_row_arg = single_block_size_cliff_row;
+
+        } else if (i < total_row_cores * full_cores_per_col) {
+            single_block_size_row_arg = single_block_size;
+            single_block_size_col_arg = single_block_size;
+            single_sub_block_size_row_arg = single_sub_block_size;
+
+        } else {
+            single_block_size_row_arg = single_block_size;
+            single_block_size_col_arg = single_block_size_cliff_col;
+            single_sub_block_size_row_arg = single_sub_block_size;
+        }
+
+        //  writer runtime args
+        std::vector<uint32_t> writer_rt_args = {
+            dst_buffer->address(),
+            TILE_WIDTH * el_size * single_block_size_row_arg,
+            start_row_id,
+            start_column_id,
+            single_block_size_row_arg,
+            single_block_size_col_arg,
+            TILE_WIDTH * el_size * single_sub_block_size_row_arg,
+            single_sub_block_size_row_arg};
+
+        // reader runtime args
+        reader_desc.runtime_args.emplace_back(
+            core,
+            std::vector<uint32_t>{
+                src0_buffer->address(), tile_start_id, single_block_size_row_arg, single_block_size_col_arg});
+        writer_desc.runtime_args.emplace_back(core, std::move(writer_rt_args));
+
+        uint32_t end_column_id = start_column_id + (single_block_size_row_arg * TILE_WIDTH * el_size);
+        start_column_id = end_column_id % padded_row_size_bytes;
+        if (end_column_id % padded_row_size_bytes == 0 && end_column_id != 0) {
+            start_row_id += single_block_size_col_arg * TILE_HEIGHT;
+        }
+
+        if (start_column_id == 0) {
+            tile_start_id = cores_col_count * single_block_size_col_arg * total_tiles_per_row;
+            cores_col_count++;
+        } else {
+            tile_start_id += single_block_size_row_arg;
+        }
+    }
+
+    // Insert reader+writer at the beginning so they occupy descriptor positions 0 and 1
+    // (compute kernels follow).
+    desc.kernels.insert(desc.kernels.begin(), std::move(writer_desc));
+    desc.kernels.insert(desc.kernels.begin(), std::move(reader_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.hpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/operations/experimental/quasar/untilize_with_unpadding/device/untilize_with_unpadding_device_operation_types.hpp"
+#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace ttnn::prim::qsr {
+
+struct UntilizeWithUnpaddingMultiCoreBlockInterleavedProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_col_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_col_interleaved_program_factory.cpp
@@ -1,0 +1,189 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "untilize_with_unpadding_multi_core_col_interleaved_program_factory.hpp"
+
+#include "ttnn/operations/cb_utils.hpp"
+#include "ttnn/operations/math.hpp"
+#include "ttnn/operations/core/work_split/work_split_tilize.hpp"
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include "ttnn/common/constants.hpp"
+#include "ttnn/operation.hpp"
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+
+tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreColInterleavedProgramFactory::create_descriptor(
+    const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output) {
+    const auto& a = input;
+    bool fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en;
+    const auto& sub_core_grids = operation_attributes.sub_core_grids;
+
+    ProgramDescriptor desc;
+
+    tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
+    uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
+    tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
+    uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
+
+    const auto& input_shape = a.padded_shape();
+    const auto& output_shape = output.padded_shape();
+
+    IDevice* device = a.device();
+    CoreCoord grid_size = device->compute_with_storage_grid_size();
+    CoreRange default_cores({0, 0}, {grid_size.x - 1, grid_size.y - 1});
+    CoreRangeSet default_grid(default_cores);
+    CoreRangeSet available_grid = sub_core_grids.has_value() ? sub_core_grids.value() : default_grid;
+
+    uint32_t num_blocks = input_shape[-1] / TILE_WIDTH;
+    uint32_t num_tiles_per_row = a.padded_shape()[-1] / TILE_WIDTH;
+    uint32_t num_tiles_per_col = a.padded_shape()[-2] / TILE_HEIGHT;
+
+    auto [ncores, all_cores, core_range, core_range_cliff, nblocks_per_core, nblocks_per_core_cliff] =
+        ttnn::split_blocks_for_tilize(available_grid, num_blocks);
+
+    bool has_cliff = !core_range_cliff.empty();
+
+    uint32_t unpadded_row_size_bytes;
+
+    uint32_t el_size;
+    if (a.dtype() == DataType::BFLOAT8_B) {
+        unpadded_row_size_bytes = output_shape[-1] * output.element_size();
+        el_size = output.element_size();
+    } else {
+        unpadded_row_size_bytes = output_shape[-1] * a.element_size();
+        el_size = a.element_size();
+    }
+
+    constexpr uint8_t src0_cb_index = tt::CBIndex::c_0;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles_per_col * input_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
+    constexpr uint8_t output_cb_index = tt::CBIndex::c_16;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles_per_col * output_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
+
+    Buffer* src0_buffer = a.buffer();
+    Buffer* dst_buffer = output.buffer();
+    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    // reader
+    uint32_t num_tiles_2d = a.padded_shape()[-1] * a.padded_shape()[-2] / TILE_HW;
+
+    auto log_shape = output.logical_shape();
+    uint32_t third_dim = 1;
+    if (log_shape.rank() == 3) {
+        third_dim = log_shape[-3];
+    } else if (log_shape.rank() >= 4) {
+        third_dim = log_shape[-3] * log_shape[-4];
+    }
+
+    std::vector<uint32_t> reader_compile_time_args = {num_tiles_2d, third_dim, nblocks_per_core};
+    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_col_multicore.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    // writer
+    uint32_t total_num_rows = output.logical_shape()[-2];
+
+    std::vector<uint32_t> writer_ct_args = {total_num_rows, ncores, third_dim, TILE_WIDTH, unpadded_row_size_bytes};
+    TensorAccessorArgs(*dst_buffer).append_to(writer_ct_args);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/"
+        "writer_unary_stick_layout_col_multicore.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    // compute
+    const std::string compute_kernel(
+        "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_w.cpp");
+
+    if (!core_range.empty()) {
+        KernelDescriptor compute_desc;
+        compute_desc.kernel_source = compute_kernel;
+        compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc.core_ranges = core_range;
+        compute_desc.compile_time_args = {nblocks_per_core, num_tiles_per_col, third_dim};
+        compute_desc.config = ComputeConfigDescriptor{.fp32_dest_acc_en = fp32_dest_acc_en};
+        desc.kernels.push_back(std::move(compute_desc));
+    }
+    if (has_cliff) {
+        KernelDescriptor cliff_desc;
+        cliff_desc.kernel_source = compute_kernel;
+        cliff_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        cliff_desc.core_ranges = core_range_cliff;
+        cliff_desc.compile_time_args = {nblocks_per_core_cliff, num_tiles_per_col, third_dim};
+        cliff_desc.config = ComputeConfigDescriptor{.fp32_dest_acc_en = fp32_dest_acc_en};
+        desc.kernels.push_back(std::move(cliff_desc));
+    }
+
+    // RUNTIME ARGS
+    const auto& cores = corerange_to_cores(available_grid);
+    reader_desc.runtime_args.reserve(ncores);
+    writer_desc.runtime_args.reserve(ncores);
+    uint32_t number_blocks_per_core;
+    for (uint32_t i = 0; i < ncores; ++i) {
+        const auto& core = cores[i];
+
+        if (has_cliff && i == ncores - 1) {
+            number_blocks_per_core = nblocks_per_core_cliff;
+        } else {
+            number_blocks_per_core = nblocks_per_core;
+        }
+        uint32_t size_per_row_per_block = nblocks_per_core * TILE_WIDTH * el_size;
+
+        //  writer runtime args
+        writer_desc.runtime_args.emplace_back(
+            core,
+            std::vector<uint32_t>{
+                dst_buffer->address(),
+                i,
+                size_per_row_per_block,
+                number_blocks_per_core,
+                TILE_WIDTH * el_size,
+            });
+
+        // reader runtime args
+        reader_desc.runtime_args.emplace_back(
+            core, std::vector<uint32_t>{src0_buffer->address(), i, num_tiles_per_row, number_blocks_per_core});
+    }
+
+    // Insert reader+writer at the start so kernel ordering matches the legacy program: reader is
+    // descriptor 0, writer is descriptor 1, compute kernels follow.
+    desc.kernels.insert(desc.kernels.begin(), std::move(writer_desc));
+    desc.kernels.insert(desc.kernels.begin(), std::move(reader_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_col_interleaved_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_col_interleaved_program_factory.hpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/operations/experimental/quasar/untilize_with_unpadding/device/untilize_with_unpadding_device_operation_types.hpp"
+#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace ttnn::prim::qsr {
+
+struct UntilizeWithUnpaddingMultiCoreColInterleavedProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_interleaved_program_factory.cpp
@@ -1,0 +1,233 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "untilize_with_unpadding_multi_core_interleaved_program_factory.hpp"
+
+#include "ttnn/operations/cb_utils.hpp"
+#include "ttnn/operations/math.hpp"
+#include "ttnn/operations/core/work_split/work_split_tilize.hpp"
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include "ttnn/common/constants.hpp"
+#include "ttnn/operation.hpp"
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+
+tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreInterleavedProgramFactory::create_descriptor(
+    const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output) {
+    const auto& a = input;
+    bool fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en;
+
+    ProgramDescriptor desc;
+
+    tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
+    uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
+    tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
+    uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
+
+    const auto& input_shape = a.padded_shape();
+    const auto& output_shape = output.padded_shape();
+    const auto& sub_core_grids = operation_attributes.sub_core_grids;
+
+    IDevice* device = a.device();
+    CoreCoord grid_size = device->compute_with_storage_grid_size();
+    CoreRange default_cores({0, 0}, {grid_size.x - 1, grid_size.y - 1});
+    CoreRangeSet default_grid(default_cores);
+    CoreRangeSet available_grid = sub_core_grids.has_value() ? sub_core_grids.value() : default_grid;
+
+    uint32_t num_blocks = input_shape[-1] == 0 ? 0 : a.physical_volume() / input_shape[-1] / TILE_HEIGHT;
+    uint32_t num_tiles_per_row = a.padded_shape()[-1] / TILE_WIDTH;
+
+    auto [ncores, all_cores, core_range, core_range_cliff, nblocks_per_core, nblocks_per_core_cliff] =
+        ttnn::split_blocks_for_tilize(available_grid, num_blocks);
+
+    bool has_cliff = !core_range_cliff.empty();
+
+    uint32_t padded_row_size_bytes;
+    uint32_t unpadded_row_size_bytes;
+
+    if (a.dtype() == DataType::BFLOAT8_B) {
+        padded_row_size_bytes = input_shape[-1] * output.element_size();
+        unpadded_row_size_bytes = output_shape[-1] * output.element_size();
+    } else {
+        padded_row_size_bytes = input_shape[-1] * a.element_size();
+        unpadded_row_size_bytes = output_shape[-1] * a.element_size();
+    }
+
+    constexpr uint8_t src0_cb_index = tt::CBIndex::c_0;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles_per_row * input_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
+    constexpr uint8_t output_cb_index = tt::CBIndex::c_16;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles_per_row * output_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
+
+    Buffer* src0_buffer = a.buffer();
+    Buffer* dst_buffer = output.buffer();
+    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    /** reader
+     */
+
+    std::vector<uint32_t> reader_compile_time_args;
+    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    /** writer
+     */
+    std::vector<uint32_t> writer_ct_args = {
+        (input_cb_data_format == tt::DataFormat::Float32 or input_cb_data_format == tt::DataFormat::UInt32 or
+         input_cb_data_format == tt::DataFormat::Int32),
+        unpadded_row_size_bytes};
+    TensorAccessorArgs(*dst_buffer).append_to(writer_ct_args);
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/"
+        "writer_unary_stick_layout_split_rows_multicore.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    /** compute
+     */
+    KernelDescriptor::Defines compute_kernel_defines;
+    if (input_cb_data_format == tt::DataFormat::Int32 || input_cb_data_format == tt::DataFormat::UInt32 ||
+        input_cb_data_format == tt::DataFormat::Float32) {
+        compute_kernel_defines.emplace_back("DST_ACCUM_MODE", "1");
+    }
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    if (fp32_dest_acc_en) {
+        unpack_to_dest_mode[tt::CBIndex::c_0] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+    }
+    const std::string compute_kernel(
+        "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp");
+
+    // Track compute kernel indices in case both full and cliff exist; we push them after the
+    // dataflow kernels so reader stays at index 0 and writer at index 1.
+    int full_compute_idx = -1;
+    int cliff_compute_idx = -1;
+
+    if (!core_range.empty()) {
+        KernelDescriptor compute_desc;
+        compute_desc.kernel_source = compute_kernel;
+        compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc.core_ranges = core_range;
+        compute_desc.compile_time_args = {nblocks_per_core, num_tiles_per_row, tt::CBIndex::c_0, tt::CBIndex::c_16};
+        compute_desc.defines = compute_kernel_defines;
+        compute_desc.config = ComputeConfigDescriptor{
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+        };
+        full_compute_idx = 2 + static_cast<int>(desc.kernels.size());  // reader at 0, writer at 1 once pushed
+        (void)full_compute_idx;
+        desc.kernels.push_back(std::move(compute_desc));
+    }
+    if (has_cliff) {
+        KernelDescriptor cliff_desc;
+        cliff_desc.kernel_source = compute_kernel;
+        cliff_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        cliff_desc.core_ranges = core_range_cliff;
+        cliff_desc.compile_time_args = {nblocks_per_core_cliff, num_tiles_per_row, tt::CBIndex::c_0, tt::CBIndex::c_16};
+        cliff_desc.defines = std::move(compute_kernel_defines);
+        cliff_desc.config = ComputeConfigDescriptor{
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+        };
+        cliff_compute_idx = 2 + static_cast<int>(desc.kernels.size());
+        (void)cliff_compute_idx;
+        desc.kernels.push_back(std::move(cliff_desc));
+    }
+
+    uint32_t tile_height = output.tensor_spec().tile().get_height();
+    auto core_assignments = ttnn::distribute_work(
+        output_shape, input_shape, ncores, nblocks_per_core, has_cliff, nblocks_per_core_cliff, tile_height);
+
+    uint32_t tile_start_id = 0;
+    uint32_t row_start_id = 0;
+
+    const auto& cores = corerange_to_cores(available_grid);
+    reader_desc.runtime_args.reserve(ncores);
+    writer_desc.runtime_args.reserve(ncores);
+    for (uint32_t i = 0; i < ncores; ++i) {
+        const auto& core = cores[i];
+        const std::vector<BlockRep>& assignment = core_assignments.at(i);
+
+        // writer runtime args
+        KernelDescriptor::RTArgList writer_rt_args;
+        writer_rt_args.push_back(dst_buffer);
+        writer_rt_args.push_back(padded_row_size_bytes);
+        writer_rt_args.push_back(row_start_id);
+        writer_rt_args.push_back(static_cast<uint32_t>(assignment.size()));
+
+        uint32_t nblocks_per_core_core = 0;
+
+        BlockRep ref_el = assignment[0];
+        uint32_t count_repeated = 0;  // will be incremented in first iteration of the loop
+        for (const auto& el : assignment) {
+            nblocks_per_core_core += el.block_count();
+            row_start_id += el.data_row_count();
+            if (compare_assignments(ref_el, el)) {
+                count_repeated++;
+            } else {
+                // push back information for previous elements
+                writer_rt_args.push_back(ref_el.n_data);
+                writer_rt_args.push_back(ref_el.n_mixed);
+                writer_rt_args.push_back(ref_el.n_pads);
+                writer_rt_args.push_back(ref_el.times);
+                writer_rt_args.push_back(count_repeated);
+                // Set up assignment for this element
+                ref_el = el;
+                count_repeated = 1;
+            }
+        }
+        writer_rt_args.push_back(ref_el.n_data);
+        writer_rt_args.push_back(ref_el.n_mixed);
+        writer_rt_args.push_back(ref_el.n_pads);
+        writer_rt_args.push_back(ref_el.times);
+        writer_rt_args.push_back(count_repeated);
+
+        uint32_t num_tiles_per_core = num_tiles_per_row * nblocks_per_core_core;
+
+        // reader runtime args
+        reader_desc.emplace_runtime_args(core, {src0_buffer, num_tiles_per_core, tile_start_id});
+        writer_desc.emplace_runtime_args(core, writer_rt_args);
+
+        tile_start_id += num_tiles_per_core;
+    }
+
+    // Insert reader+writer at the beginning so they occupy descriptor positions 0 and 1.
+    desc.kernels.insert(desc.kernels.begin(), std::move(writer_desc));
+    desc.kernels.insert(desc.kernels.begin(), std::move(reader_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_interleaved_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_interleaved_program_factory.hpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/operations/experimental/quasar/untilize_with_unpadding/device/untilize_with_unpadding_device_operation_types.hpp"
+#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace ttnn::prim::qsr {
+
+struct UntilizeWithUnpaddingMultiCoreInterleavedProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.cpp
@@ -1,0 +1,292 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operation.hpp"
+#include "ttnn/operations/cb_utils.hpp"
+#include "ttnn/operations/math.hpp"
+#include "ttnn/common/constants.hpp"
+#include "ttnn/operations/ccl/sharding_addrgen_helper.hpp"
+#include "ttnn/operations/core/work_split/work_split_tilize.hpp"
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/buffer_distribution_spec.hpp>
+#include "untilize_with_unpadding_multi_core_nd_sharded_program_factory.hpp"
+#include "ttnn/operations/data_movement/untilize/device/untilize_device_operation.hpp"
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+
+tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreNDShardedProgramFactory::create_descriptor(
+    const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output) {
+    ProgramDescriptor desc;
+
+    // const auto& a = input;
+    const auto& fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en;
+    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
+    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
+
+    tt::tt_metal::Buffer* src0_buffer = input.buffer();
+    tt::tt_metal::Buffer* dst_buffer = output.buffer();
+    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    uint32_t tensor_width = input.padded_shape()[-1];
+    uint32_t output_tensor_width = output.padded_shape()[-1];
+    uint32_t output_tensor_height = output.padded_shape()[-2];
+
+    const auto& tile_shape = input.tensor_spec().tile().get_tile_shape();
+    uint32_t tile_height = tile_shape[0];
+    uint32_t tile_width = tile_shape[1];
+
+    uint32_t num_tiles_per_input_row = tensor_width / tile_width;
+    uint32_t num_tiles_per_output_row = tt::div_up(output_tensor_width, tile_width);
+
+    const auto& nd_shard_spec = input.nd_shard_spec().value();
+    uint32_t input_shard_height = nd_shard_spec.shard_shape[-2];
+    uint32_t input_shard_width = nd_shard_spec.shard_shape[-1];
+
+    const auto distribution_spec = input.buffer()->buffer_distribution_spec().value();
+
+    uint32_t num_shards = distribution_spec.num_shards();
+    const auto page_mapping = distribution_spec.compute_page_mapping();
+    const auto& groups = distribution_spec.core_groups();
+    const auto& ordered_cores_with_data = distribution_spec.cores_with_data();
+    uint32_t num_compute_cores = ordered_cores_with_data.size();
+    const auto& compute_core_range = CoreRangeSet(ttsl::Span<const CoreCoord>(ordered_cores_with_data));
+
+    uint32_t num_tiles_per_input_block = input_shard_width / tile_width;
+    uint32_t num_blocks_per_shard_plane =
+        input_shard_height /
+        tile_height;  // Note: a "shard plane" here refers to a 2D plane the size of the last 2 dimensions of the shard.
+                      // For example, a shard of shape [b, c, h, w] has b * c planes each of shape [h, w].
+    const auto& shard_shape = nd_shard_spec.shard_shape;
+    size_t num_planes_per_shard = 1;
+    if (shard_shape.rank() > 2) {
+        for (int i = 0; i < static_cast<int>(shard_shape.rank()) - 2; ++i) {
+            num_planes_per_shard *= shard_shape[i];
+        }
+    }
+    uint32_t num_blocks_per_shard = num_planes_per_shard * num_blocks_per_shard_plane;
+    uint32_t num_input_blocks_per_full_core = groups.num_shards_per_core_in_group_1 * num_blocks_per_shard;
+
+    // Input CB
+    uint32_t input_cb_num_tiles;
+    if (num_input_blocks_per_full_core == 1) {
+        // No need to double buffer if the core is only processing a single block
+        input_cb_num_tiles = num_tiles_per_input_block;
+    } else {
+        // Double buffer if the core is processing 2+ blocks
+        input_cb_num_tiles = num_tiles_per_input_block * 2;
+    }
+    constexpr uint8_t src0_cb_index = tt::CBIndex::c_0;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = input_cb_num_tiles * input_single_tile_size,
+        .core_ranges = compute_core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
+
+    // Output CB
+    uint32_t output_cb_num_tiles;
+    if (num_input_blocks_per_full_core == 1) {
+        // No need to double buffer if the core is only processing a single block
+        output_cb_num_tiles = num_tiles_per_input_block;
+    } else {
+        // Double buffer if the core is processing 2+ blocks
+        output_cb_num_tiles = num_tiles_per_input_block * 2;
+    }
+    constexpr uint8_t output_cb_index = tt::CBIndex::c_16;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = output_cb_num_tiles * output_single_tile_size,
+        .core_ranges = compute_core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
+
+    // Reader compile-time args and kernel (sharded input)
+    std::vector<uint32_t> reader_compile_time_args = {
+        (uint32_t)src0_cb_index,
+        (uint32_t)num_tiles_per_input_block,
+        (uint32_t)num_shards,
+        (uint32_t)num_compute_cores};
+    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_nd_sharded_blocks.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = compute_core_range;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    // Writer compile-time args
+    uint32_t output_element_size = output.element_size();
+    uint32_t output_page_width =
+        output_tensor_width;  // In height-sharded and interleaved cases, the output page is the entire tensor row
+    uint32_t output_num_blocks_across_width = 1;
+    if (output.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED ||
+        output.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ||
+        output.memory_config().memory_layout() == TensorMemoryLayout::ND_SHARDED) {
+        if (output.shard_spec().has_value()) {
+            output_page_width = output.shard_spec().value().shape[1];
+        } else {
+            output_page_width = output.nd_shard_spec().value().shard_shape[-1];
+        }
+        output_num_blocks_across_width = tt::div_up(output_tensor_width, output_page_width);
+    }
+
+    uint32_t num_cols_per_input_block = num_tiles_per_input_block * tile_width;
+    uint32_t num_cols_per_output_block = output_page_width;
+    uint32_t output_stick_size = num_cols_per_output_block * output_element_size;
+    std::vector<uint32_t> writer_compile_time_args = {
+        (uint32_t)output_cb_index,
+        (uint32_t)output_stick_size,
+        (uint32_t)tile_height,
+        (uint32_t)num_tiles_per_input_block,
+        (uint32_t)output_num_blocks_across_width,
+        (uint32_t)output_element_size,
+        (uint32_t)num_cols_per_input_block,
+        (uint32_t)num_cols_per_output_block,
+        (uint32_t)input_single_tile_size,
+        (uint32_t)num_shards,
+        (uint32_t)num_compute_cores,
+        (uint32_t)num_tiles_per_input_row,
+        (uint32_t)num_tiles_per_output_row,
+        (uint32_t)tile_width,
+        (uint32_t)output_tensor_width,
+        (uint32_t)output_tensor_height,
+        (uint32_t)input.padded_shape().rank()
+
+    };
+    std::vector<uint32_t>
+        writer_common_runtime_args;  // Due to tensor squeezing from ND to 4D when the input tensor has rank > 4,
+                                     // writer_common_runtime_args will have at most 8 entries.
+    for (const auto dim : output.padded_shape()) {
+        writer_common_runtime_args.push_back(dim);
+    }
+    for (const auto dim : input.padded_shape()) {
+        writer_common_runtime_args.push_back(dim);
+    }
+
+    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+
+    TensorAccessorArgs(*src0_buffer)
+        .append_to(writer_compile_time_args);  // For ND sharded input, we need info on the input buffer distribution
+
+    // Writer kernel
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/"
+        "writer_unary_stick_layout_split_rows_multicore_nd_sharded.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = compute_core_range;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+    writer_desc.common_runtime_args = std::move(writer_common_runtime_args);
+
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    if (fp32_dest_acc_en) {
+        unpack_to_dest_mode[src0_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+    }
+
+    // Compute kernel file
+    const std::string compute_kernel(
+        "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_variable_num_blocks.cpp");
+
+    // Compute compile-time args and kernel
+    // Note: This condition is always true for sharded input
+    KernelDescriptor::Defines compute_kernel_defines;
+    if (input.dtype() == DataType::INT32 || input.dtype() == DataType::UINT32 || input.dtype() == DataType::FLOAT32) {
+        compute_kernel_defines.emplace_back("DST_ACCUM_MODE", "1");
+    }
+    KernelDescriptor compute_desc;
+    bool has_compute = !compute_core_range.ranges().empty();
+    if (has_compute) {
+        std::vector<uint32_t> compute_compile_time_args = {
+            (uint32_t)num_tiles_per_input_block, (uint32_t)src0_cb_index, (uint32_t)output_cb_index};
+        compute_desc.kernel_source = compute_kernel;
+        compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc.core_ranges = compute_core_range;
+        compute_desc.compile_time_args = std::move(compute_compile_time_args);
+        compute_desc.defines = std::move(compute_kernel_defines);
+        compute_desc.config = ComputeConfigDescriptor{
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+        };
+    }
+
+    // Run-time args
+    // Logic for ND sharding makes as few assumptions about page locations as possible. Padded pages will be handled
+    // in the writer kernel.
+    const auto& mapped_cores = page_mapping.all_cores;
+
+    // Use page_mapping to count non-padding blocks per core
+    // page_mapping.core_host_page_indices[core_id] contains host page indices for all device pages on that core,
+    // with UncompressedBufferPageMapping::PADDING indicating padding pages
+    uint32_t start_shard_id = 0;
+    reader_desc.runtime_args.reserve(ordered_cores_with_data.size());
+    writer_desc.runtime_args.reserve(ordered_cores_with_data.size());
+    if (has_compute) {
+        compute_desc.runtime_args.reserve(ordered_cores_with_data.size());
+    }
+    for (auto core : ordered_cores_with_data) {
+        auto core_it = std::find(mapped_cores.begin(), mapped_cores.end(), core);
+        uint32_t num_input_blocks_to_process = 0;
+
+        if (core_it != mapped_cores.end()) {
+            const size_t core_idx = std::distance(mapped_cores.begin(), core_it);
+            const auto& host_page_indices = page_mapping.core_host_page_indices[core_idx];
+
+            // Iterate through device pages in blocks of num_tiles_per_input_block.
+            uint32_t page_offset = 0;
+            const uint32_t total_pages = host_page_indices.size();
+
+            while (page_offset < total_pages) {
+                if (host_page_indices[page_offset] != UncompressedBufferPageMapping::PADDING) {
+                    num_input_blocks_to_process++;
+                } else if (page_offset == 0) {  // First page is PADDING means this core has no shards, no need to
+                                                // iterate further. This should never happen, as we are iterating over
+                                                // only cores with data.
+                    break;
+                }
+                // Advance by num_tiles_per_input_block
+                page_offset += num_tiles_per_input_block;
+            }
+        }
+        // Reader run-time args
+        reader_desc.emplace_runtime_args(core, {src0_buffer, start_shard_id});
+
+        // Writer run-time args
+        writer_desc.emplace_runtime_args(core, {dst_buffer, src0_buffer, start_shard_id});
+        start_shard_id++;
+
+        // Compute run-time args
+        if (has_compute) {
+            compute_desc.emplace_runtime_args(core, {num_input_blocks_to_process});
+        }
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    if (has_compute) {
+        desc.kernels.push_back(std::move(compute_desc));
+    }
+
+    return desc;
+}
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.hpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/operations/experimental/quasar/untilize_with_unpadding/device/untilize_with_unpadding_device_operation_types.hpp"
+#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace ttnn::prim::qsr {
+
+struct UntilizeWithUnpaddingMultiCoreNDShardedProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.cpp
@@ -1,0 +1,318 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "untilize_with_unpadding_multi_core_sharded_program_factory.hpp"
+
+#include <cmath>
+
+#include "ttnn/operations/cb_utils.hpp"
+#include "ttnn/operations/math.hpp"
+#include "ttnn/operations/core/work_split/work_split_tilize.hpp"
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include "ttnn/common/constants.hpp"
+#include "ttnn/operation.hpp"
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+
+tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreShardedProgramFactory::create_descriptor(
+    const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output) {
+    const auto& a = input;
+    bool fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en;
+
+    ProgramDescriptor desc;
+
+    bool src_sharded = a.memory_config().is_sharded();
+    bool out_sharded = output.memory_config().is_sharded();
+    // Special handling for tensors of W=16 and H%32==0
+    // In this case skip untilizing on compute and in writer kernel just copy face0 and face2,
+    // and skip face1 and face3.
+    bool unpad_tensor_w_16 = output.padded_shape()[-1] == 16 && output.padded_shape()[-2] % TILE_HEIGHT == 0;
+    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
+    uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
+    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
+
+    uint32_t num_rows_block = 0, block_row_size = 0, output_row_size = 0, last_block_row_size_unpadded = 0,
+             num_output_rows_unpadded = 0;
+    CoreCoord end_core;
+    uint32_t last_idx = 0;
+    auto shard_spec = a.shard_spec().value();
+
+    // I am not sure it is correct to ever use the shard_spec here.
+    auto out_shard_spec = output.shard_spec().has_value() ? output.shard_spec().value() : shard_spec;
+
+    bool row_major = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
+    auto all_cores = shard_spec.grid;
+    uint32_t ntiles_per_block = shard_spec.shape[1] / TILE_WIDTH;
+    uint32_t nblocks_per_core = shard_spec.shape[0] / TILE_HEIGHT;
+    uint32_t global_batch = a.physical_volume() / (a.padded_shape()[-2] * a.padded_shape()[-1]);
+    uint32_t batch =
+        a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED
+            ? std::max(1u, (shard_spec.shape[0] * shard_spec.shape[1]) / (a.padded_shape()[-2] * a.padded_shape()[-1]))
+            : global_batch;
+    uint32_t ntiles_per_batch = ntiles_per_block * nblocks_per_core / batch;
+
+    num_rows_block = out_shard_spec.shape[0];
+    block_row_size = out_shard_spec.shape[1] * output.element_size();     // in0_block_w * TILE_WIDTH * dtype_nbytes
+    output_row_size = output.padded_shape()[-1] * output.element_size();  // output row size bytes
+    last_block_row_size_unpadded = block_row_size - (tt::round_up(output.padded_shape()[-1], out_shard_spec.shape[1]) -
+                                                     output.padded_shape()[-1]) *
+                                                        output.element_size();
+    uint32_t num_output_rows = output.physical_volume() / output.padded_shape()[-1];
+    num_output_rows_unpadded =
+        num_rows_block - (tt::round_up(num_output_rows, out_shard_spec.shape[0]) - num_output_rows);
+    if (a.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED) {
+        last_idx = tt::div_up(output.padded_shape()[-1], out_shard_spec.shape[1]) - 1;
+    } else if (a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
+        last_idx = tt::div_up(num_output_rows, out_shard_spec.shape[0]) - 1;
+    } else {
+        end_core = {
+            tt::div_up(output.padded_shape()[-1], out_shard_spec.shape[1]) - 1,
+            tt::div_up(num_output_rows, out_shard_spec.shape[0]) - 1};
+    }
+    if (!row_major) {
+        std::swap(end_core.x, end_core.y);
+    }
+
+    constexpr uint8_t src0_cb_index = tt::CBIndex::c_0;
+    uint32_t num_input_tiles = ntiles_per_block * nblocks_per_core;
+    // Input CB: sharded → bind .buffer to the input buffer; framework re-applies
+    // UpdateDynamicCircularBufferAddress on cache hit.
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * input_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+        .buffer = src_sharded ? a.buffer() : nullptr,
+    });
+
+    uint32_t num_output_tiles = out_sharded ? (unpad_tensor_w_16 ? 16 : ntiles_per_batch * 2) : ntiles_per_block * 2;
+    uint32_t aligned_page_size = static_cast<uint32_t>(output.buffer()->aligned_page_size());
+    constexpr uint8_t output_cb_index = tt::CBIndex::c_16;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_output_tiles * output_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
+
+    constexpr uint8_t sharded_output_cb_index = tt::CBIndex::c_17;
+    if (out_sharded) {
+        // The kernel advances the write pointer by aligned_page_size (which may be
+        // larger than block_row_size due to buffer alignment padding), so the CB
+        // page size must match to avoid overflow.
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = num_output_rows_unpadded * aligned_page_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = sharded_output_cb_index,
+                .data_format = output_cb_data_format,
+                .page_size = aligned_page_size,
+            }}},
+            .buffer = output.buffer(),
+        });
+    }
+
+    Buffer* dst_buffer = output.buffer();
+    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    /** reader
+     */
+    std::vector<uint32_t> reader_ct_args;
+    reader_ct_args.push_back(src0_cb_index);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    /** writer
+     */
+    KernelDescriptor writer_desc;
+    if (out_sharded) {
+        std::vector<uint32_t> writer_ct_args{output_cb_index, sharded_output_cb_index, aligned_page_size};
+        writer_desc.kernel_source =
+            unpad_tensor_w_16
+                ? "ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/"
+                  "writer_unary_unpad_width_16_sharded.cpp"
+                : "ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/"
+                  "writer_unary_unpad_batch_rows_sharded.cpp";
+        writer_desc.compile_time_args = std::move(writer_ct_args);
+    } else {
+        std::vector<uint32_t> writer_ct_args = {
+            (input_cb_data_format == tt::DataFormat::Float32 or input_cb_data_format == tt::DataFormat::UInt32 or
+             input_cb_data_format == tt::DataFormat::Int32),
+            output_row_size};
+        TensorAccessorArgs(*dst_buffer).append_to(writer_ct_args);
+        writer_desc.kernel_source = "ttnn/cpp/ttnn/kernel/dataflow/writer_unary_stick_layout_interleaved_blocks.cpp";
+        writer_desc.compile_time_args = std::move(writer_ct_args);
+    }
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.config = WriterConfigDescriptor{};
+
+    /** compute
+     */
+    std::vector<uint32_t> compute_args = {
+        (uint32_t)nblocks_per_core,  // per_core_block_cnt
+        (uint32_t)ntiles_per_block,  // per_block_ntiles
+        (uint32_t)src0_cb_index,
+        (uint32_t)output_cb_index,
+    };
+
+    KernelDescriptor::Defines compute_kernel_defines;
+    if (input_cb_data_format == tt::DataFormat::Int32 || input_cb_data_format == tt::DataFormat::UInt32 ||
+        input_cb_data_format == tt::DataFormat::Float32) {
+        compute_kernel_defines.emplace_back("DST_ACCUM_MODE", "1");
+    }
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    if (fp32_dest_acc_en) {
+        unpack_to_dest_mode[tt::CBIndex::c_0] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+    }
+    std::string compute_kernel("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp");
+    if (unpad_tensor_w_16) {
+        // Use copy compute kernel just for a potential data type conversion.
+        compute_kernel = "ttnn/cpp/ttnn/kernel/compute/eltwise_copy.cpp";
+        compute_args[0] = (uint32_t)num_input_tiles;  // per_core_tile_cnt
+    }
+
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source = compute_kernel;
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = all_cores;
+    compute_desc.compile_time_args = std::move(compute_args);
+    compute_desc.defines = std::move(compute_kernel_defines);
+    compute_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+    };
+
+    // Runtime args: legacy code uses SetRuntimeArgs(program, kernel, all_cores, args) which broadcasts
+    // the same args to every core. The descriptor API needs per-core entries; enumerate cores and
+    // emit one runtime_args entry per core.
+    const std::vector<CoreCoord> all_core_coords = corerange_to_cores(all_cores, std::nullopt, row_major);
+
+    const std::vector<uint32_t> reader_rt_args = {ntiles_per_block * nblocks_per_core};
+    reader_desc.runtime_args.reserve(all_core_coords.size());
+    for (const auto& core : all_core_coords) {
+        reader_desc.runtime_args.emplace_back(core, reader_rt_args);
+    }
+
+    if (out_sharded) {
+        std::vector<uint32_t> writer_rt_args;
+        if (unpad_tensor_w_16) {
+            writer_rt_args = {num_output_rows_unpadded, num_input_tiles};
+        } else {
+            writer_rt_args = {
+                num_output_rows_unpadded,
+                ntiles_per_batch,
+                out_shard_spec.shape[0] / batch,
+                shard_spec.shape[1] * output.element_size(),
+                block_row_size,
+                batch};
+        }
+        writer_desc.runtime_args.reserve(all_core_coords.size());
+        for (const auto& core : all_core_coords) {
+            writer_desc.runtime_args.emplace_back(core, writer_rt_args);
+        }
+    } else {
+        writer_desc.runtime_args.reserve(all_core_coords.size());
+        for (uint32_t i = 0; i < all_core_coords.size(); ++i) {
+            CoreCoord core = all_core_coords[i];
+
+            // writer runtime args
+            uint32_t block_start_row_offset;
+            uint32_t block_start_row_id_offset;
+            uint32_t row_size_unpadded = block_row_size;
+            uint32_t num_rows_unpadded = num_rows_block;
+            if (a.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED) {
+                block_start_row_offset = i * block_row_size;
+                block_start_row_id_offset = 0;
+                if (i > last_idx) {
+                    row_size_unpadded = 0;
+                    num_rows_unpadded = 0;
+                } else {
+                    num_rows_unpadded = num_output_rows_unpadded;
+                    if (i == last_idx) {
+                        row_size_unpadded = last_block_row_size_unpadded;
+                    }
+                }
+            } else if (a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
+                block_start_row_offset = 0;
+                block_start_row_id_offset = i * num_rows_block;
+                if (i > last_idx) {
+                    row_size_unpadded = 0;
+                    num_rows_unpadded = 0;
+                } else {
+                    if (i == last_idx) {
+                        num_rows_unpadded = num_output_rows_unpadded;
+                    }
+                    row_size_unpadded = last_block_row_size_unpadded;
+                }
+            } else {
+                if (row_major) {
+                    block_start_row_offset = core.x * block_row_size;
+                    block_start_row_id_offset = core.y * num_rows_block;
+                    if (core.x == end_core.x) {
+                        row_size_unpadded = last_block_row_size_unpadded;
+                    }
+                    if (core.y == end_core.y) {
+                        num_rows_unpadded = num_output_rows_unpadded;
+                    }
+                } else {
+                    block_start_row_offset = core.y * block_row_size;
+                    block_start_row_id_offset = core.x * num_rows_block;
+                    if (core.y == end_core.y) {
+                        row_size_unpadded = last_block_row_size_unpadded;
+                    }
+                    if (core.x == end_core.x) {
+                        num_rows_unpadded = num_output_rows_unpadded;
+                    }
+                }
+                if (core.x > end_core.x || core.y > end_core.y) {
+                    row_size_unpadded = 0;
+                    num_rows_unpadded = 0;
+                }
+            }
+
+            writer_desc.emplace_runtime_args(
+                core,
+                {dst_buffer,  // dst_addr
+                 num_rows_block,
+                 block_row_size,
+                 std::uint32_t{1},
+                 std::uint32_t{1},
+                 std::uint32_t{1},
+                 row_size_unpadded,
+                 num_rows_unpadded,
+                 block_start_row_id_offset,
+                 block_start_row_offset});
+        }
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.hpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/operations/experimental/quasar/untilize_with_unpadding/device/untilize_with_unpadding_device_operation_types.hpp"
+#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace ttnn::prim::qsr {
+
+struct UntilizeWithUnpaddingMultiCoreShardedProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_shared_variables.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_shared_variables.hpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/host_api.hpp>
+#include <vector>
+
+namespace ttnn::prim::qsr {
+
+struct UntilizeWithUnpaddingMultiCoreSharedVariables {
+    tt::tt_metal::KernelHandle reader_kernel_id{};
+    tt::tt_metal::KernelHandle writer_kernel_id{};
+    std::vector<tt::tt_metal::CoreCoord> cores;
+    uint32_t ncores = 0;
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_single_core_program_factory.cpp
@@ -1,0 +1,213 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "untilize_with_unpadding_single_core_program_factory.hpp"
+
+#include <cmath>
+
+#include "ttnn/operations/cb_utils.hpp"
+#include "ttnn/operations/math.hpp"
+#include "ttnn/operations/core/work_split/work_split_tilize.hpp"
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include "ttnn/common/constants.hpp"
+#include "ttnn/operation.hpp"
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+
+tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingSingleCoreProgramFactory::create_descriptor(
+    const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output) {
+    const auto& a = input;
+    bool fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en;
+    const auto& sub_core_grids = operation_attributes.sub_core_grids;
+    const auto& input_shape = a.padded_shape();
+    const auto& output_shape = output.padded_shape();
+
+    ProgramDescriptor desc;
+
+    CoreRange default_core({0, 0}, {0, 0});
+    CoreRange core = sub_core_grids.has_value() ? corerange_to_cores(sub_core_grids.value()).at(0) : default_core;
+
+    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
+    uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
+    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
+
+    log_debug(tt::LogOp, "untilize_with_unpadding_single_core");
+    log_debug(tt::LogOp, "input_cb_data_format: {}", input_cb_data_format);
+    log_debug(tt::LogOp, "output_cb_data_format: {}", output_cb_data_format);
+
+    tt::tt_metal::Buffer* src0_buffer = a.buffer();
+
+    int32_t num_tiles = a.physical_volume() / TILE_HW;
+
+    // This should allocate a DRAM buffer on the device
+
+    tt::tt_metal::Buffer* dst_buffer = output.buffer();
+    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    auto input_w = input_shape.rank() >= 4 ? input_shape[-4] : 1;
+    auto input_z = input_shape.rank() >= 3 ? input_shape[-3] : 1;
+    auto input_y = input_shape.rank() >= 2 ? input_shape[-2] : 1;
+    auto input_x = input_shape[-1];
+
+    auto output_w = output_shape.rank() >= 4 ? output_shape[-4] : 1;
+    auto output_z = output_shape.rank() >= 3 ? output_shape[-3] : 1;
+    auto output_y = output_shape.rank() >= 2 ? output_shape[-2] : 1;
+    auto output_x = output_shape[-1];
+
+    uint32_t padded_stick_size = input_x * output.element_size();  // Assuming bfloat16 dataformat
+    uint32_t unpadded_stick_size = output_x * output.element_size();
+
+    constexpr uint32_t alignment = 32;
+
+    uint32_t num_tiles_in_row = input_x / TILE_WIDTH;
+    // Ensure we don't intrude into storage space
+    uint32_t max_l1_size =
+        (a.device()->l1_size_per_core() / 2) - a.device()->allocator()->get_base_allocator_addr(HalMemType::L1);
+    // Memory usage is 2 CBs of width W, plus buffer of size alignment + (W * datum size)
+    uint32_t max_X = (max_l1_size - alignment) / (output.element_size() * TILE_HEIGHT * 2 + output.element_size());
+    uint32_t max_tiles = max_X / TILE_WIDTH;
+
+    // Currently need the number of tiles in a row to be divisible by tiles in a block
+    uint32_t num_tiles_per_block = 1;
+    if (num_tiles_in_row <= max_tiles) {
+        num_tiles_per_block = num_tiles_in_row;
+    } else {
+        for (uint32_t n_t = max_tiles; n_t > 0; n_t--) {
+            if (num_tiles_in_row % n_t == 0) {
+                num_tiles_per_block = n_t;
+                break;
+            }
+        }
+    }
+    uint32_t block_width = num_tiles_per_block * TILE_WIDTH;
+    uint32_t block_row_size = block_width * output.element_size();
+    uint32_t num_blocks_w_output = unpadded_stick_size / block_row_size;
+    uint32_t num_blocks_w_input = padded_stick_size / block_row_size;
+    uint32_t block_row_leftover_size = unpadded_stick_size - (num_blocks_w_output * block_row_size);
+
+    // Number of blocks that differ between input and output
+    const uint32_t num_blocks_w_diff = num_blocks_w_input - num_blocks_w_output - (block_row_leftover_size > 0 ? 1 : 0);
+
+    const uint32_t padded_Y_diff_blocks = (input_y - output_y) / TILE_HEIGHT * num_blocks_w_input;
+    const uint32_t padded_Z_diff_blocks = (input_z - output_z) * input_y / TILE_HEIGHT * num_blocks_w_input;
+    const uint32_t padded_W_diff_blocks = (input_w - output_w) * input_z * input_y / TILE_HEIGHT * num_blocks_w_input;
+    const uint32_t num_leftover_Y = output_y - (output_y / TILE_HEIGHT * TILE_HEIGHT);
+
+    constexpr uint8_t src0_cb_index = 0;
+    uint32_t num_input_tiles = num_tiles_per_block;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * input_single_tile_size,
+        .core_ranges = core,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
+
+    constexpr uint8_t output_cb_index = tt::CBIndex::c_16;
+    uint32_t num_output_tiles = num_tiles_per_block;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_output_tiles * output_single_tile_size,
+        .core_ranges = core,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
+
+    std::vector<uint32_t> reader_compile_time_args;
+    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+
+    std::vector<uint32_t> writer_compile_time_args = {
+        (std::uint32_t)((
+            input_cb_data_format == tt::DataFormat::Float32 or input_cb_data_format == tt::DataFormat::UInt32 or
+            input_cb_data_format == tt::DataFormat::Int32)),
+        unpadded_stick_size};
+    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+
+    // Tilized reader
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = core;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    // Untilized writer
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/"
+        "writer_unary_unpad_dims_split_rows.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = core;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    std::vector<uint32_t> compute_args = {
+        uint32_t(num_tiles / num_tiles_per_block),
+        uint32_t(num_tiles_per_block),
+        uint32_t(src0_cb_index),
+        uint32_t(output_cb_index)};
+
+    KernelDescriptor::Defines compute_kernel_defines;
+    if (input_cb_data_format == tt::DataFormat::Int32 || input_cb_data_format == tt::DataFormat::UInt32 ||
+        input_cb_data_format == tt::DataFormat::Float32) {
+        compute_kernel_defines.emplace_back("DST_ACCUM_MODE", "1");
+    }
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    if (fp32_dest_acc_en) {
+        unpack_to_dest_mode[src0_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+    }
+
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source = "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = core;
+    compute_desc.compile_time_args = std::move(compute_args);
+    compute_desc.defines = std::move(compute_kernel_defines);
+    compute_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+    };
+
+    CoreCoord core_0 = corerange_to_cores(core).at(0);
+    reader_desc.emplace_runtime_args(core_0, {src0_buffer, uint32_t(num_tiles), 0u});
+    writer_desc.emplace_runtime_args(
+        core_0,
+        {dst_buffer,
+         output_w,
+         padded_W_diff_blocks,
+         output_z,
+         padded_Z_diff_blocks,
+         output_y,
+         padded_Y_diff_blocks,
+         num_leftover_Y,
+         output_x,
+         padded_stick_size,
+         num_blocks_w_input,
+         num_blocks_w_output,
+         num_blocks_w_diff,
+         block_row_size,
+         block_row_leftover_size});
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_single_core_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_single_core_program_factory.hpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/operations/experimental/quasar/untilize_with_unpadding/device/untilize_with_unpadding_device_operation_types.hpp"
+#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace ttnn::prim::qsr {
+
+struct UntilizeWithUnpaddingSingleCoreProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output);
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_col_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_col_multicore.cpp
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    constexpr uint32_t cb_id_out0 = 16;
+
+    constexpr uint32_t total_num_rows = get_compile_time_arg_val(0);
+    constexpr uint32_t ncores = get_compile_time_arg_val(1);
+    constexpr uint32_t third_dim = get_compile_time_arg_val(2);
+    constexpr uint32_t tile_width = get_compile_time_arg_val(3);
+    constexpr uint32_t unpadded_X_size = get_compile_time_arg_val(4);
+    constexpr auto dst_args = TensorAccessorArgs<5>();
+
+    const uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    const uint32_t core_number = get_arg_val<uint32_t>(1);
+
+    const auto s = TensorAccessor(dst_args, dst_addr);
+
+    Noc noc;
+    CircularBuffer cb_out0(cb_id_out0);
+
+    auto write_block = [&](uint32_t num_rows,
+                           uint32_t mul,
+                           uint32_t size_per_row_per_block,
+                           uint32_t start_id,
+                           uint32_t width_size,
+                           uint32_t size_2d) {
+        uint32_t onetile = 1;
+        bool has_rows = (num_rows) > 0;
+
+        cb_out0.wait_front(onetile * has_rows);
+        uint32_t l1_read_addr = cb_out0.get_write_ptr();
+
+        for (uint32_t k = 0; k < num_rows; k++) {
+            uint32_t total_size = mul * size_per_row_per_block + start_id + width_size;
+            uint32_t padded_size = total_size - unpadded_X_size;
+            uint32_t write_size = width_size;
+
+            if (mul == ncores - 1 && padded_size > 0) {
+                write_size = width_size - padded_size;
+            }
+
+            CoreLocalMem<uint32_t> src(l1_read_addr);
+            noc.async_write(
+                src,
+                s,
+                write_size,
+                {.offset_bytes = 0},
+                {.page_id = size_2d + k, .offset_bytes = start_id + mul * size_per_row_per_block});
+
+            noc.async_write_barrier();
+
+            if (k > 0 && (k % tile_width == 0)) {
+                cb_out0.pop_front(onetile * has_rows);
+                cb_out0.wait_front(onetile * has_rows);
+            }
+            l1_read_addr += width_size;
+        }
+
+        cb_out0.pop_front(onetile * has_rows);
+    };
+
+    const uint32_t size_per_row_per_block = get_arg_val<uint32_t>(3);
+    const uint32_t blocks_per_core = get_arg_val<uint32_t>(4);
+    const uint32_t width_size = get_arg_val<uint32_t>(5);
+
+    uint32_t size_2d = 0;
+    for (uint32_t dim3 = 0; dim3 < third_dim; dim3++) {
+        uint32_t start_id = 0;
+        for (uint32_t b = 0; b < blocks_per_core; b++) {
+            write_block(total_num_rows, core_number, size_per_row_per_block, start_id, width_size, size_2d);
+            start_id += width_size;
+        }
+        size_2d += total_num_rows;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_split_rows_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_split_rows_multicore.cpp
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    // Constexpr
+    constexpr uint32_t cb_id_out0 = 16;
+    constexpr uint32_t tile_height = 32;
+
+    const uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    const uint32_t padded_X_size = get_arg_val<uint32_t>(1);
+    const uint32_t start_stick_id = get_arg_val<uint32_t>(2);
+    const uint32_t n_block_reps = get_arg_val<uint32_t>(3);
+
+    constexpr bool FLOAT32_DTYPE = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t unpadded_X_size = get_compile_time_arg_val(1);
+    constexpr auto dst_args = TensorAccessorArgs<2>();
+
+    const uint32_t num_tiles_per_row = padded_X_size >> (FLOAT32_DTYPE ? 7 : 6);
+
+    const auto s = TensorAccessor(dst_args, dst_addr);
+
+    Noc noc;
+    CircularBuffer cb_out0(cb_id_out0);
+
+    auto pop_blocks = [&](uint32_t num_blocks) {
+        for (uint32_t i = 0; i < num_blocks; i++) {
+            cb_out0.wait_front(num_tiles_per_row);
+            cb_out0.pop_front(num_tiles_per_row);
+        }
+    };
+
+    auto write_block = [&](uint32_t base_stick_id, uint32_t num_rows) {
+        uint32_t padding_rows = (tile_height - num_rows) & 31;
+        bool has_rows = (num_rows + padding_rows) > 0;
+
+        cb_out0.wait_front(num_tiles_per_row * has_rows);
+        uint32_t l1_read_addr = cb_out0.get_read_ptr();
+        for (uint32_t k = 0; k < num_rows; k++) {
+            CoreLocalMem<uint32_t> src(l1_read_addr);
+            noc.async_write(
+                src, s, unpadded_X_size, {.offset_bytes = 0}, {.page_id = base_stick_id + k, .offset_bytes = 0});
+
+            noc.async_write_barrier();
+            l1_read_addr += padded_X_size;
+        }
+        cb_out0.pop_front(num_tiles_per_row * has_rows);
+    };
+
+    uint32_t stick_id = start_stick_id;
+    uint32_t rt_arg_idx = 4;
+    uint32_t count = 1;
+    constexpr int32_t n_mixed_idx = 1;
+    constexpr int32_t n_pad_idx = 2;
+    constexpr int32_t times_idx = 3;
+    constexpr uint32_t repeat_ct_idx = 4;
+    constexpr int32_t num_rt_idx = 5;
+
+    for (uint32_t block_rep_idx = 0; block_rep_idx < n_block_reps; ++block_rep_idx) {
+        const uint32_t repeat_count = get_arg_val<uint32_t>(rt_arg_idx + repeat_ct_idx);
+        const uint32_t n_data = get_arg_val<uint32_t>(rt_arg_idx);  // number of full tile-rows
+        const uint32_t n_mixed =
+            get_arg_val<uint32_t>(rt_arg_idx + n_mixed_idx);  // number of rows in a partially filled tile-row
+        const uint32_t n_pads = get_arg_val<uint32_t>(rt_arg_idx + n_pad_idx);  // number of padding tile-rows
+        const uint32_t times =
+            get_arg_val<uint32_t>(rt_arg_idx + times_idx);  // number of times the pattern of tile-rows repeats
+        if (count == repeat_count) {
+            rt_arg_idx = rt_arg_idx + num_rt_idx;
+            count = 1;
+        } else {
+            count++;
+        }
+
+        for (uint32_t t = 0; t < times; ++t) {
+            for (uint32_t y_t = 0; y_t < n_data; y_t++) {
+                write_block(stick_id, tile_height);
+                stick_id += tile_height;
+            }
+
+            write_block(stick_id, n_mixed);
+            stick_id += n_mixed;
+
+            pop_blocks(n_pads);
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_split_rows_multicore_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_split_rows_multicore_nd_sharded.cpp
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include <array>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+#include "api/debug/dprint.h"
+
+namespace {
+FORCE_INLINE uint32_t div_up(uint32_t x, uint32_t y) { return (x + y - 1) / y; }
+}  // namespace
+
+void kernel_main() {
+    // run-time args
+    const uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    const uint32_t src0_addr = get_arg_val<uint32_t>(1);
+    const uint32_t start_shard_id = get_arg_val<uint32_t>(2);
+
+    // compile-time args
+    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
+    constexpr uint32_t tile_height = get_compile_time_arg_val(2);
+    constexpr uint32_t num_tiles_per_input_block = get_compile_time_arg_val(3);
+    constexpr uint32_t num_output_blocks_across_width = get_compile_time_arg_val(4);
+    constexpr uint32_t output_element_size = get_compile_time_arg_val(5);
+    constexpr uint32_t num_cols_per_input_block = get_compile_time_arg_val(6);
+    constexpr uint32_t num_cols_per_output_block = get_compile_time_arg_val(7);
+    constexpr uint32_t num_shards = get_compile_time_arg_val(9);
+    constexpr uint32_t num_cores = get_compile_time_arg_val(10);
+    constexpr uint32_t num_tiles_per_input_row = get_compile_time_arg_val(11);
+    constexpr uint32_t num_tiles_per_output_row = get_compile_time_arg_val(12);
+    constexpr uint32_t tile_width = get_compile_time_arg_val(13);
+    constexpr uint32_t output_tensor_width = get_compile_time_arg_val(14);
+    constexpr uint32_t output_tensor_height = get_compile_time_arg_val(15);
+    constexpr uint32_t tensor_rank = get_compile_time_arg_val(16);
+    constexpr auto dst_args = TensorAccessorArgs<17>();
+    const auto accessor_dst = TensorAccessor(dst_args, dst_addr);
+    constexpr auto src0_args = TensorAccessorArgs<dst_args.next_compile_time_args_offset()>();
+    const auto accessor_src = TensorAccessor(src0_args, src0_addr);
+
+    Noc noc;
+    CircularBuffer cb_out(cb_id_out0);
+
+    auto write_tiles_in_current_block = [&](uint32_t start_row,
+                                            uint32_t width_wise_output_block_start_index,
+                                            uint32_t num_unpadded_cols_per_input_block,
+                                            uint32_t num_cols_already_processed_in_first_output_block,
+                                            uint32_t num_rows_to_write) {
+        cb_out.wait_front(num_tiles_per_input_block);
+
+        uint32_t base_l1_read_addr = cb_out.get_read_ptr();
+
+        for (uint32_t j = 0; j < num_rows_to_write; ++j) {
+            uint32_t current_l1_read_addr = base_l1_read_addr + j * num_cols_per_input_block * output_element_size;
+
+            uint32_t num_rows_already_processed = start_row + j;
+            uint32_t num_pages_already_processed_in_previous_rows =
+                num_rows_already_processed * num_output_blocks_across_width;
+            uint32_t output_page_id =
+                num_pages_already_processed_in_previous_rows + width_wise_output_block_start_index;
+
+            uint32_t num_cols_remaining_in_current_output_block =
+                num_cols_per_output_block - num_cols_already_processed_in_first_output_block;
+            uint32_t output_offset_within_page_in_bytes =
+                num_cols_already_processed_in_first_output_block * output_element_size;
+
+            uint32_t num_input_cols_processed = 0;
+            while (num_input_cols_processed < num_unpadded_cols_per_input_block) {
+                uint32_t num_cols_to_write = std::min(
+                    num_unpadded_cols_per_input_block - num_input_cols_processed,
+                    num_cols_remaining_in_current_output_block);
+                uint32_t num_bytes_to_write = num_cols_to_write * output_element_size;
+
+                CoreLocalMem<uint32_t> src(current_l1_read_addr);
+                noc.async_write(
+                    src,
+                    accessor_dst,
+                    num_bytes_to_write,
+                    {.offset_bytes = 0},
+                    {.page_id = output_page_id, .offset_bytes = output_offset_within_page_in_bytes});
+
+                num_input_cols_processed += num_cols_to_write;
+                current_l1_read_addr += num_bytes_to_write;
+                output_page_id++;
+                num_cols_remaining_in_current_output_block = num_cols_per_output_block;
+                output_offset_within_page_in_bytes = 0;
+            }
+        }
+
+        noc.async_write_barrier();
+        cb_out.pop_front(num_tiles_per_input_block);
+    };
+
+    uint32_t output_tensor_shape[tensor_rank];
+    uint32_t input_tensor_shape[tensor_rank];
+    for (uint32_t i = 0; i < tensor_rank; ++i) {
+        output_tensor_shape[i] = get_common_arg_val<uint32_t>(i);
+    }
+    for (uint32_t i = 0; i < tensor_rank; ++i) {
+        input_tensor_shape[i] = get_common_arg_val<uint32_t>(i + tensor_rank);
+    }
+
+    uint32_t global_coord[tensor_rank];
+
+    for (uint32_t shard_id = start_shard_id; shard_id < num_shards; shard_id += num_cores) {
+        auto shard_pages = accessor_src.shard_pages(shard_id);
+        for (auto page_iter = shard_pages.begin(); page_iter != shard_pages.end();
+             page_iter += num_tiles_per_input_block) {
+            uint32_t page_id = page_iter->page_id();
+            uint32_t global_element_start_row_input = page_id / num_tiles_per_input_row * tile_height;
+            uint32_t global_element_start_column_input = page_id % num_tiles_per_input_row * tile_width;
+            uint32_t element_id_input = global_element_start_row_input * input_tensor_shape[tensor_rank - 1] +
+                                        global_element_start_column_input;
+
+            bool block_is_in_output_tensor = true;
+            for (int i = tensor_rank - 1; i >= 0; --i) {
+                uint32_t curr_dim = element_id_input % input_tensor_shape[i];
+                global_coord[i] = curr_dim;
+                if (curr_dim >= output_tensor_shape[i]) {
+                    block_is_in_output_tensor = false;
+                    break;
+                }
+                element_id_input /= input_tensor_shape[i];
+            }
+
+            if (!block_is_in_output_tensor) {  // This input block is entirely outside the output tensor, so skip it
+                cb_out.wait_front(num_tiles_per_input_block);
+                cb_out.pop_front(num_tiles_per_input_block);
+                continue;
+            }
+
+            uint32_t num_output_tensor_planes_before_current_block = 0;
+            for (int i = 0; i <= static_cast<int>(tensor_rank - 3); ++i) {
+                num_output_tensor_planes_before_current_block =
+                    num_output_tensor_planes_before_current_block * output_tensor_shape[i] + global_coord[i];
+            }
+            uint32_t start_row = num_output_tensor_planes_before_current_block * output_tensor_shape[tensor_rank - 2] +
+                                 global_coord[tensor_rank - 2];
+
+            uint32_t tile_id_in_output = div_up(output_tensor_shape[tensor_rank - 2], tile_height) *
+                                             num_tiles_per_output_row * num_output_tensor_planes_before_current_block +
+                                         (global_coord[tensor_rank - 2] / tile_height) * num_tiles_per_output_row +
+                                         global_coord[tensor_rank - 1] / tile_width;
+            uint32_t tile_index_width = tile_id_in_output % num_tiles_per_output_row;
+            uint32_t width_wise_input_block_index = tile_index_width / num_tiles_per_input_block;
+
+            uint32_t num_unpadded_cols_per_input_block = num_cols_per_input_block;
+            uint32_t last_column_tensor_index_in_block =
+                (tile_index_width + num_tiles_per_input_block) * tile_width - 1;
+            if (last_column_tensor_index_in_block >= output_tensor_width) {
+                num_unpadded_cols_per_input_block = (output_tensor_width - tile_index_width * tile_width);
+            }
+            uint32_t last_row_tensor_index_in_block = global_coord[tensor_rank - 2] + tile_height - 1;
+            uint32_t num_rows_to_write = tile_height;
+            if (last_row_tensor_index_in_block >= output_tensor_height) {
+                num_rows_to_write = (output_tensor_height - global_coord[tensor_rank - 2]);
+            }
+            uint32_t input_block_global_col_index = width_wise_input_block_index * num_cols_per_input_block;
+            uint32_t width_wise_output_block_start_index = input_block_global_col_index / num_cols_per_output_block;
+            uint32_t num_cols_already_processed_in_first_output_block =
+                input_block_global_col_index % num_cols_per_output_block;
+            write_tiles_in_current_block(
+                start_row,
+                width_wise_output_block_start_index,
+                num_unpadded_cols_per_input_block,
+                num_cols_already_processed_in_first_output_block,
+                num_rows_to_write);
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_wh_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_wh_multicore.cpp
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    constexpr uint32_t cb_id_out0 = 16;
+
+    constexpr uint32_t total_num_rows = get_compile_time_arg_val(0);
+    constexpr uint32_t third_dim = get_compile_time_arg_val(1);
+    constexpr uint32_t tile_height = get_compile_time_arg_val(2);
+    constexpr uint32_t unpadded_X_size = get_compile_time_arg_val(3);
+    constexpr auto dst_args = TensorAccessorArgs<4>();
+
+    const uint32_t dst_addr = get_arg_val<uint32_t>(0);
+
+    const auto s = TensorAccessor(dst_args, dst_addr);
+    Noc noc;
+    CircularBuffer cb_out0(cb_id_out0);
+
+    auto write_block = [&](uint32_t num_rows,
+                           uint32_t start_row_id,
+                           uint32_t start_column_id,
+                           uint32_t width_size,
+                           uint32_t size_2d,
+                           uint32_t single_block_size) {
+        bool has_rows = (num_rows) > 0;
+
+        cb_out0.wait_front(single_block_size * has_rows);
+        uint32_t l1_read_addr = cb_out0.get_write_ptr();
+
+        for (uint32_t k = start_row_id; k < start_row_id + num_rows; k++) {
+            uint32_t total_size = start_column_id + width_size;
+            uint32_t write_size = width_size;
+
+            if (total_size > unpadded_X_size) {
+                uint32_t padded_size = total_size - unpadded_X_size;
+                write_size -= padded_size;
+            }
+
+            CoreLocalMem<uint32_t> src(l1_read_addr);
+            noc.async_write(
+                src, s, write_size, {.offset_bytes = 0}, {.page_id = size_2d + k, .offset_bytes = start_column_id});
+
+            noc.async_write_barrier();
+
+            l1_read_addr += width_size;
+        }
+
+        cb_out0.pop_front(single_block_size * has_rows);
+    };
+
+    const uint32_t width_size = get_arg_val<uint32_t>(1);
+
+    uint32_t size_2d = 0;
+    for (uint32_t dim3 = 0; dim3 < third_dim; dim3++) {
+        uint32_t start_row_id = get_arg_val<uint32_t>(2);
+        uint32_t start_column_id = get_arg_val<uint32_t>(3);
+        uint32_t single_block_size_row_arg = get_arg_val<uint32_t>(4);
+        uint32_t single_block_size_col_arg = get_arg_val<uint32_t>(5);
+        uint32_t sub_block_width_size = get_arg_val<uint32_t>(6);
+        uint32_t single_sub_block_size_row_arg = get_arg_val<uint32_t>(7);
+
+        for (uint32_t b = 0; b < single_block_size_col_arg; b++) {
+            uint32_t this_block_num_rows = tile_height;
+            if (start_row_id + tile_height > total_num_rows) {
+                this_block_num_rows = total_num_rows - start_row_id;
+            }
+            for (uint32_t m = 0; m < width_size; m += sub_block_width_size) {
+                uint32_t start_column_id_u = start_column_id + m;
+                if (this_block_num_rows > 0) {
+                    write_block(
+                        this_block_num_rows,
+                        start_row_id,
+                        start_column_id_u,
+                        sub_block_width_size,
+                        size_2d,
+                        single_sub_block_size_row_arg);
+                }
+            }
+            start_row_id += tile_height;
+        }
+        size_2d += total_num_rows;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/writer_unary_unpad_batch_rows_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/writer_unary_unpad_batch_rows_sharded.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    uint32_t num_unpadded_output_rows = get_arg_val<uint32_t>(0);
+    uint32_t num_padded_tiles_per_batch = get_arg_val<uint32_t>(1);
+    uint32_t num_unpadded_rows_per_batch = get_arg_val<uint32_t>(2);
+    uint32_t padded_block_row_size_bytes = get_arg_val<uint32_t>(3);
+    uint32_t unpadded_block_row_size_bytes = get_arg_val<uint32_t>(4);
+    uint32_t batch = get_arg_val<uint32_t>(5);
+
+    constexpr uint32_t cb_id_untilize_out = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_id_out = get_compile_time_arg_val(1);
+    constexpr uint32_t aligned_page_size = get_compile_time_arg_val(2);
+
+    Noc noc;
+    CircularBuffer cb_untilize_out(cb_id_untilize_out);
+    CircularBuffer cb_out(cb_id_out);
+
+    cb_out.reserve_back(num_unpadded_output_rows);
+    uint32_t l1_write_addr = cb_out.get_write_ptr();
+
+    for (uint32_t b = 0; b < batch; ++b) {
+        cb_untilize_out.wait_front(num_padded_tiles_per_batch);
+        uint32_t src_addr = cb_untilize_out.get_read_ptr();
+
+        for (uint32_t row = 0; row < num_unpadded_rows_per_batch; ++row) {
+            CoreLocalMem<uint32_t> dst(l1_write_addr);
+            noc.async_read(
+                UnicastEndpoint{},
+                dst,
+                unpadded_block_row_size_bytes,
+                {.noc_x = (uint32_t)my_x[noc.get_noc_id()],
+                 .noc_y = (uint32_t)my_y[noc.get_noc_id()],
+                 .addr = src_addr},
+                {.offset_bytes = 0});
+            src_addr += padded_block_row_size_bytes;
+            l1_write_addr += aligned_page_size;
+        }
+
+        noc.async_read_barrier();
+        cb_untilize_out.pop_front(num_padded_tiles_per_batch);
+    }
+    cb_out.push_back(num_unpadded_output_rows);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/writer_unary_unpad_dims_split_rows.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/writer_unary_unpad_dims_split_rows.cpp
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+inline uint64_t round_down_32(uint64_t a) { return (a >> 5) << 5; }
+
+void kernel_main() {
+    // Constexpr
+    constexpr uint32_t cb_id_out0 = 16;
+    constexpr uint32_t tile_height = 32;
+
+    const uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    const uint32_t num_unpadded_W = get_arg_val<uint32_t>(1);
+    const uint32_t padded_W_diff_blocks = get_arg_val<uint32_t>(2);
+    const uint32_t num_unpadded_Z = get_arg_val<uint32_t>(3);
+    const uint32_t padded_Z_diff_blocks = get_arg_val<uint32_t>(4);
+    const uint32_t num_unpadded_Y = get_arg_val<uint32_t>(5);
+    const uint32_t padded_Y_diff_blocks = get_arg_val<uint32_t>(6);
+    const uint32_t num_leftover_Y = get_arg_val<uint32_t>(7);
+    const uint32_t num_unpadded_X = get_arg_val<uint32_t>(8);
+    const uint32_t padded_X_size = get_arg_val<uint32_t>(9);
+    const uint32_t num_blocks_w_input = get_arg_val<uint32_t>(10);
+    const uint32_t num_blocks_w_output = get_arg_val<uint32_t>(11);
+    const uint32_t num_blocks_w_diff = get_arg_val<uint32_t>(12);
+    const uint32_t block_row_size = get_arg_val<uint32_t>(13);
+    const uint32_t block_row_leftover_size = get_arg_val<uint32_t>(14);
+
+    uint32_t stick_id = 0;
+
+    constexpr bool FLOAT32_DTYPE = get_compile_time_arg_val(0) == 1;
+    constexpr auto dst_args = TensorAccessorArgs<2>();
+
+    const uint32_t num_tiles_block_c =
+        FLOAT32_DTYPE ? block_row_size / 128
+                      : block_row_size / 64;  // Assuming 4 / 2 bytes per datum, there are 128 / 64 bytes per tile row
+
+    const auto s = TensorAccessor(dst_args, dst_addr);
+    Noc noc;
+    CircularBuffer cb_out0(cb_id_out0);
+
+    auto pop_blocks = [&](uint32_t num_blocks) {
+        for (uint32_t i = 0; i < num_blocks; i++) {
+            cb_out0.wait_front(num_tiles_block_c);
+            cb_out0.pop_front(num_tiles_block_c);
+        }
+    };
+
+    auto write_block = [&](uint32_t base_stick_id, uint32_t num_rows, uint32_t offset, uint32_t block_size) {
+        cb_out0.wait_front(num_tiles_block_c);
+        uint32_t l1_read_addr = cb_out0.get_read_ptr();
+        uint32_t curr_stick_id = base_stick_id;
+        for (uint32_t k = 0; k < num_rows; k++) {
+            CoreLocalMem<uint32_t> src(l1_read_addr);
+            noc.async_write(
+                src, s, block_size, {.offset_bytes = 0}, {.page_id = curr_stick_id, .offset_bytes = offset});
+
+            l1_read_addr += block_row_size;
+            curr_stick_id++;
+
+            // Block write
+            noc.async_write_barrier();
+        }
+        cb_out0.pop_front(num_tiles_block_c);
+    };
+
+    auto write_block_rows = [&](uint32_t num_rows_block, uint32_t base_stick_id) {
+        uint32_t block_row_offset = 0;
+        for (uint32_t block_w = 0; block_w < num_blocks_w_output; block_w++) {
+            write_block(base_stick_id, num_rows_block, block_row_offset, block_row_size);
+            block_row_offset += block_row_size;
+        }
+
+        // Change to define
+        if (block_row_leftover_size > 0) {
+            write_block(base_stick_id, num_rows_block, block_row_offset, block_row_leftover_size);
+            block_row_offset += block_row_leftover_size;
+        }
+    };
+
+    for (uint32_t w = 0; w < num_unpadded_W; w++) {
+        for (uint32_t z = 0; z < num_unpadded_Z; z++) {
+            for (uint32_t y_t = 0; y_t < num_unpadded_Y / tile_height; y_t++) {
+                write_block_rows(tile_height, stick_id);
+                pop_blocks(num_blocks_w_diff);
+                stick_id += tile_height;
+            }
+
+            // Change to define
+            if (num_leftover_Y > 0) {
+                write_block_rows(num_leftover_Y, stick_id);
+                pop_blocks(num_blocks_w_diff);
+                stick_id += num_leftover_Y;
+            }
+            pop_blocks(padded_Y_diff_blocks);
+        }
+        pop_blocks(padded_Z_diff_blocks);
+    }
+    pop_blocks(padded_W_diff_blocks);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/writer_unary_unpad_width_16_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/writer_unary_unpad_width_16_sharded.cpp
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+// Special case writer for unpad width 16 tensors
+// Skip untilize and just copy f0 and f2 from input tiles to output tiles
+void kernel_main() {
+    uint32_t num_unpadded_output_rows = get_arg_val<uint32_t>(0);
+    uint32_t num_padded_tiles_per_core = get_arg_val<uint32_t>(1);
+
+    constexpr uint32_t cb_id_untilize_out = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_id_out = get_compile_time_arg_val(1);
+
+    constexpr uint32_t tile_size_in_bytes = get_tile_size(cb_id_out);
+    constexpr uint32_t quarter_tile_size_in_bytes = tile_size_in_bytes / 4;
+
+    const uint32_t batches_of_8 = num_padded_tiles_per_core / 8;
+    const uint32_t remaining_tiles = num_padded_tiles_per_core % 8;
+
+    Noc noc;
+    CircularBuffer cb_untilize_out(cb_id_untilize_out);
+    CircularBuffer cb_out(cb_id_out);
+
+    cb_out.reserve_back(num_unpadded_output_rows);
+    uint32_t l1_write_addr = cb_out.get_write_ptr();
+
+    static_assert(quarter_tile_size_in_bytes <= NOC_MAX_BURST_SIZE);
+    // set_state uses just x/y from the noc addr, addr is ignored
+    noc.set_async_read_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+        UnicastEndpoint{},
+        quarter_tile_size_in_bytes,
+        {.noc_x = (uint32_t)my_x[noc.get_noc_id()], .noc_y = (uint32_t)my_y[noc.get_noc_id()], .addr = l1_write_addr});
+
+    for (uint32_t i = 0; i < batches_of_8; i++) {
+        cb_untilize_out.wait_front(8);
+        uint32_t src_addr = cb_untilize_out.get_read_ptr();
+
+        for (uint32_t j = 0; j < 8; j++) {
+            CoreLocalMem<uint32_t> dst0(l1_write_addr);
+            noc.async_read_with_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+                UnicastEndpoint{},
+                dst0,
+                quarter_tile_size_in_bytes,
+                {.noc_x = (uint32_t)my_x[noc.get_noc_id()],
+                 .noc_y = (uint32_t)my_y[noc.get_noc_id()],
+                 .addr = src_addr},
+                {.offset_bytes = 0});
+            src_addr += 2 * quarter_tile_size_in_bytes;
+            l1_write_addr += quarter_tile_size_in_bytes;
+
+            CoreLocalMem<uint32_t> dst1(l1_write_addr);
+            noc.async_read_with_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+                UnicastEndpoint{},
+                dst1,
+                quarter_tile_size_in_bytes,
+                {.noc_x = (uint32_t)my_x[noc.get_noc_id()],
+                 .noc_y = (uint32_t)my_y[noc.get_noc_id()],
+                 .addr = src_addr},
+                {.offset_bytes = 0});
+            src_addr += 2 * quarter_tile_size_in_bytes;
+            l1_write_addr += quarter_tile_size_in_bytes;
+        }
+
+        noc.async_read_barrier();
+        cb_untilize_out.pop_front(8);
+    }
+
+    cb_untilize_out.wait_front(remaining_tiles);
+    uint32_t src_addr = cb_untilize_out.get_read_ptr();
+    for (uint32_t i = 0; i < remaining_tiles; i++) {
+        CoreLocalMem<uint32_t> dst0(l1_write_addr);
+        noc.async_read_with_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+            UnicastEndpoint{},
+            dst0,
+            quarter_tile_size_in_bytes,
+            {.noc_x = (uint32_t)my_x[noc.get_noc_id()], .noc_y = (uint32_t)my_y[noc.get_noc_id()], .addr = src_addr},
+            {.offset_bytes = 0});
+        src_addr += 2 * quarter_tile_size_in_bytes;
+        l1_write_addr += quarter_tile_size_in_bytes;
+
+        CoreLocalMem<uint32_t> dst1(l1_write_addr);
+        noc.async_read_with_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+            UnicastEndpoint{},
+            dst1,
+            quarter_tile_size_in_bytes,
+            {.noc_x = (uint32_t)my_x[noc.get_noc_id()], .noc_y = (uint32_t)my_y[noc.get_noc_id()], .addr = src_addr},
+            {.offset_bytes = 0});
+        src_addr += 2 * quarter_tile_size_in_bytes;
+        l1_write_addr += quarter_tile_size_in_bytes;
+    }
+    noc.async_read_barrier();
+    cb_untilize_out.pop_front(remaining_tiles);
+
+    cb_out.push_back(num_unpadded_output_rows);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp
@@ -1,0 +1,305 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "untilize_with_unpadding_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
+
+#include "ttnn/tensor/tensor_utils.hpp"
+#include "ttnn/operations/data_movement/common/common.hpp"
+#include "ttnn/tensor/tensor_ops.hpp"
+#include <tt-metalium/constants.hpp>
+#include "ttnn/operations/core/work_split/work_split_tilize.hpp"
+
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::qsr {
+
+UntilizeWithUnpaddingDeviceOperation::program_factory_t UntilizeWithUnpaddingDeviceOperation::select_program_factory(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& input) {
+    if (input.memory_config().is_sharded()) {
+        TT_FATAL(
+            !operation_attributes.sub_core_grids.has_value(),
+            "Sharded untilize does not support sub core grid specification");
+        if (input.shard_spec().has_value()) {
+            return UntilizeWithUnpaddingMultiCoreShardedProgramFactory{};
+        }
+        return UntilizeWithUnpaddingMultiCoreNDShardedProgramFactory{};
+    }
+    if (!operation_attributes.use_multicore) {
+        return UntilizeWithUnpaddingSingleCoreProgramFactory{};
+    }
+    if (!operation_attributes.enough_space_height) {
+        return UntilizeWithUnpaddingMultiCoreBlockInterleavedProgramFactory{};
+    }
+    const auto& a = input;
+    const auto& input_shape = a.padded_shape();
+    auto* device = a.device();
+    CoreCoord grid_size = device->compute_with_storage_grid_size();
+    CoreRange default_cores({0, 0}, {grid_size.x - 1, grid_size.y - 1});
+    CoreRangeSet default_grid(default_cores);
+    CoreRangeSet available_grid =
+        operation_attributes.sub_core_grids.has_value() ? operation_attributes.sub_core_grids.value() : default_grid;
+
+    uint32_t num_blocks = input_shape[-1] == 0 ? 0 : a.physical_volume() / input_shape[-1] / tt::constants::TILE_HEIGHT;
+    uint32_t num_tiles_per_row = a.padded_shape()[-1] / tt::constants::TILE_WIDTH;
+
+    uint32_t num_tiles_per_col = a.padded_shape()[-2] / tt::constants::TILE_HEIGHT;
+
+    size_t grid_area = available_grid.num_cores();
+    auto [ncores, nblocks_per_core] = compute_ncores(grid_area, num_blocks);
+    constexpr uint32_t threshold_row_block = 32;
+    if (num_tiles_per_row > threshold_row_block &&
+        (num_tiles_per_col > threshold_row_block || num_tiles_per_row > num_tiles_per_col)) {
+        uint32_t num_blocks_block =
+            (a.padded_shape()[-1] * a.padded_shape()[-2]) / (tt::constants::TILE_HEIGHT * tt::constants::TILE_WIDTH);
+
+        auto ncores_wh = compute_ncores_wh(grid_area, num_blocks_block, num_tiles_per_row, num_tiles_per_col);
+        if (ncores < ncores_wh.ncores) {
+            return UntilizeWithUnpaddingMultiCoreBlockInterleavedProgramFactory{};
+        }
+    }
+    return UntilizeWithUnpaddingMultiCoreInterleavedProgramFactory{};
+}
+
+void UntilizeWithUnpaddingDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& input) {
+    const auto& input_tensor_a = input;
+
+    TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands need to be on device!");
+    TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands need to be allocated in buffers on device!");
+    TT_FATAL(input_tensor_a.layout() == Layout::TILE, "Can only untilize tile major data");
+
+    TT_FATAL(
+        input_tensor_a.physical_volume() % tt::constants::TILE_HW == 0,
+        "Input tensor physical volume ({}) must be divisible by TILE_HW ({})",
+        input_tensor_a.physical_volume(),
+        tt::constants::TILE_HW);
+
+    if (input_tensor_a.memory_config().is_sharded()) {
+        if (input_tensor_a.shard_spec().has_value()) {
+            TT_FATAL(
+                operation_attributes.output_mem_config.memory_layout() != tt::tt_metal::TensorMemoryLayout::ND_SHARDED,
+                "Output memory config layout must not be ND_SHARDED when input has a legacy 2d shard_spec");
+            if (input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
+                TT_FATAL(
+                    input_tensor_a.shard_spec().value().grid.ranges().size() == 1,
+                    "Expected single grid range and got {}",
+                    input_tensor_a.shard_spec().value().grid.ranges().size());
+                TT_FATAL(
+                    operation_attributes.output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
+                    "Output memory config layout must be INTERLEAVED for block sharded input but got {}",
+                    operation_attributes.output_mem_config.memory_layout());
+                TT_FATAL(
+                    input_tensor_a.physical_volume() /
+                            (input_tensor_a.padded_shape()[-2] * input_tensor_a.padded_shape()[-1]) ==
+                        1,
+                    "Can only write unbatched output interleaved");
+            } else if (input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
+                if (operation_attributes.output_mem_config.is_sharded()) {
+                    TT_FATAL(
+                        operation_attributes.output_mem_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED,
+                        "Output memory config layout must be HEIGHT_SHARDED when output is sharded but got {}",
+                        operation_attributes.output_mem_config.memory_layout());
+                } else {
+                    TT_FATAL(
+                        operation_attributes.output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
+                        "Output memory config layout must be INTERLEAVED but got {}",
+                        operation_attributes.output_mem_config.memory_layout());
+                    TT_FATAL(
+                        input_tensor_a.physical_volume() /
+                                (input_tensor_a.padded_shape()[-2] * input_tensor_a.padded_shape()[-1]) ==
+                            1,
+                        "Can only write unbatched output interleaved");
+                }
+                // What else?
+            } else if (input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED) {
+                auto output_shape = compute_output_specs(operation_attributes, input).padded_shape();
+                for (uint32_t i = 0; i < output_shape.rank() - 2; i++) {
+                    TT_FATAL(
+                        input_tensor_a.padded_shape()[i] == output_shape[i],
+                        "Input tensor padded shape[{}] ({}) must equal output shape[{}] ({})",
+                        i,
+                        input_tensor_a.padded_shape()[i],
+                        i,
+                        output_shape[i]);
+                }
+                if (operation_attributes.output_mem_config.is_sharded()) {
+                    TT_FATAL(
+                        operation_attributes.output_mem_config.memory_layout() ==
+                            input_tensor_a.memory_config().memory_layout(),
+                        "Output memory config layout ({}) must match input tensor memory layout ({})",
+                        operation_attributes.output_mem_config.memory_layout(),
+                        input_tensor_a.memory_config().memory_layout());
+                    TT_FATAL(
+                        input_tensor_a.padded_shape()[-1] == output_shape[-1] ||
+                            (tt::div_up(output_shape[-1], input_tensor_a.shard_spec().value().shape[1]) ==
+                             input_tensor_a.shard_spec().value().grid.num_cores()),
+                        "Input tensor width ({}) must equal output width ({}) or output width / shard width must equal "
+                        "num "
+                        "cores",
+                        input_tensor_a.padded_shape()[-1],
+                        output_shape[-1]);
+                } else {
+                    TT_FATAL(
+                        operation_attributes.output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
+                        "Output memory config layout must be INTERLEAVED but got {}",
+                        operation_attributes.output_mem_config.memory_layout());
+                    TT_FATAL(
+                        input_tensor_a.physical_volume() /
+                                (input_tensor_a.padded_shape()[-2] * input_tensor_a.padded_shape()[-1]) ==
+                            1,
+                        "Can only write unbatched output interleaved");
+                    TT_FATAL(
+                        input_tensor_a.padded_shape()[-1] - output_shape[-1] <
+                            input_tensor_a.shard_spec().value().shape[1],
+                        "Input tensor width difference ({}) must be less than shard width ({})",
+                        input_tensor_a.padded_shape()[-1] - output_shape[-1],
+                        input_tensor_a.shard_spec().value().shape[1]);
+                }
+            } else {
+                TT_THROW("Unsupported sharding scheme");
+            }
+        } else {
+            const auto& nd_spec = input_tensor_a.nd_shard_spec().value();
+            uint32_t input_shard_width = nd_spec.shard_shape[-1];
+            uint32_t input_shard_height = nd_spec.shard_shape[-2];
+            uint32_t tile_width = input_tensor_a.tensor_spec().tile().get_width();
+            uint32_t tile_height = input_tensor_a.tensor_spec().tile().get_height();
+            TT_FATAL(
+                input_shard_width % tile_width == 0,
+                "Input shard width {} must be a multiple of tile width",
+                input_shard_width);
+            TT_FATAL(
+                input_shard_height % tile_height == 0,
+                "Input shard height {} must be a multiple of tile height",
+                input_shard_height);
+            if (operation_attributes.output_mem_config.is_sharded()) {
+                TT_FATAL(
+                    operation_attributes.output_mem_config.shard_spec().has_value() ||
+                        operation_attributes.output_mem_config.nd_shard_spec().has_value(),
+                    "Output memory config is sharded but no shard spec or nd shard spec is provided");
+                uint32_t output_dtype_size = input_tensor_a.element_size();
+                if (input_tensor_a.dtype() == tt::tt_metal::DataType::BFLOAT8_B) {
+                    output_dtype_size = 2;
+                }
+                uint32_t output_shard_width;
+                if (operation_attributes.output_mem_config.shard_spec().has_value()) {
+                    output_shard_width = operation_attributes.output_mem_config.shard_spec().value().shape[1];
+                } else {
+                    output_shard_width = operation_attributes.output_mem_config.nd_shard_spec().value().shard_shape[-1];
+                }
+                uint32_t output_row_size_bytes = output_shard_width * output_dtype_size;
+                const auto& output_buffer_type = operation_attributes.output_mem_config.buffer_type();
+                uint32_t alignment_requirement =
+                    input_tensor_a.device()->allocator()->get_alignment(output_buffer_type);
+                TT_FATAL(
+                    output_row_size_bytes % alignment_requirement == 0,
+                    "Output shard row size {} bytes must be aligned to {} bytes buffer alignment requirement",
+                    output_row_size_bytes,
+                    alignment_requirement);
+            }
+        }
+    } else {
+        TT_FATAL(
+            input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+            "Input tensor memory layout must be INTERLEAVED but got {}",
+            input_tensor_a.memory_config().memory_layout());
+        TT_FATAL(
+            operation_attributes.output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
+            "Output memory config layout must be INTERLEAVED but got {}",
+            operation_attributes.output_mem_config.memory_layout());
+    }
+}
+
+TensorSpec UntilizeWithUnpaddingDeviceOperation::compute_output_specs(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& input) {
+    SmallVector<uint32_t> out_shape;
+    const auto& input_tensor_a = input;
+    size_t rank = input_tensor_a.logical_shape().rank();
+    out_shape.reserve(rank);
+    for (uint32_t i = 0; i < rank; i++) {
+        out_shape.push_back(operation_attributes.output_tensor_end[i] + 1);
+    }
+    Shape output_shape(std::move(out_shape));
+    DataType output_dtype = input_tensor_a.dtype() == DataType::BFLOAT8_B ? DataType::BFLOAT16 : input_tensor_a.dtype();
+    if (input_tensor_a.memory_config().is_sharded() && operation_attributes.output_mem_config.is_sharded() &&
+        input_tensor_a.shard_spec().has_value()) {
+        uint32_t fused_height = output_shape.volume() / output_shape[-1];
+        uint32_t num_cores = input_tensor_a.shard_spec().value().num_cores();
+        std::array<uint32_t, 2> shard_shape{};
+        ShardSpec shard_spec = input_tensor_a.shard_spec().value();
+        if (input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
+            const auto tile = input_tensor_a.tensor_spec().tile();
+            uint32_t tile_height = tile.get_height();
+            uint32_t shard_idx0 = tt::round_up(tt::div_up(fused_height, num_cores), tile_height);
+            shard_shape = {shard_idx0, output_shape[-1]};
+        } else {
+            shard_shape = {fused_height, shard_spec.shape[1]};
+        }
+        shard_spec.shape = shard_shape;
+        auto mem_config = tt::tt_metal::MemoryConfig(
+            input_tensor_a.memory_config().memory_layout(),
+            operation_attributes.output_mem_config.buffer_type(),
+            shard_spec);
+
+        return TensorSpec(output_shape, TensorLayout(output_dtype, PageConfig(Layout::ROW_MAJOR), mem_config));
+    }
+
+    return TensorSpec(
+        output_shape,
+        TensorLayout(output_dtype, PageConfig(Layout::ROW_MAJOR), operation_attributes.output_mem_config));
+}
+
+Tensor UntilizeWithUnpaddingDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& input) {
+    auto output_spec = compute_output_specs(operation_attributes, input);
+    return create_device_tensor(output_spec, input.device());
+}
+
+tt::tt_metal::operation::OpPerformanceModelGeneral<Tensor>
+UntilizeWithUnpaddingDeviceOperation::create_op_performance_model(
+    const operation_attributes_t& /*operation_attributes*/,
+    const tensor_args_t& input,
+    tensor_return_value_t& output_tensor) {
+    const auto& input_tensor = input;
+    uint32_t tile_width = input_tensor.tensor_spec().tile().get_width();
+    uint32_t tile_height = input_tensor.tensor_spec().tile().get_height();
+    uint32_t single_tile_size = tile_width * tile_height * input_tensor.element_size();
+    uint32_t num_tiles = std::ceil((float)input_tensor.physical_volume() / (float)single_tile_size);
+    int compute_cycles = 0;
+    const int max_tiles_per_row = 8;
+    const int latency_untilize = 390;      // measured latency for untilize_block
+    const int latency_pack_untilize = 80;  // measured latency for pack_untilize_block
+    if (std::ceil((float)input_tensor.padded_shape()[-1] / (float)tile_width) <= max_tiles_per_row) {
+        compute_cycles = num_tiles * latency_pack_untilize;
+    } else {
+        compute_cycles = num_tiles * latency_untilize;
+    }
+    int ideal_dev_clock_cycles =
+        operations::data_movement::common_tm_bw_model(input_tensor, output_tensor, false, compute_cycles);
+    tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> result(
+        {input_tensor}, output_tensor, ideal_dev_clock_cycles);
+    return result;
+}
+
+Tensor untilize_with_unpadding(
+    const Tensor& input_tensor,
+    const ttnn::Shape& output_tensor_end,
+    const std::optional<tt::tt_metal::MemoryConfig>& output_mem_config,
+    bool use_multicore,
+    bool fp32_dest_acc_en,
+    bool enough_space_height,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
+    return ttnn::device_operation::launch<UntilizeWithUnpaddingDeviceOperation>(
+        UntilizeWithUnpaddingParams{
+            .output_tensor_end = output_tensor_end,
+            .output_mem_config = output_mem_config.value_or(input_tensor.memory_config()),
+            .use_multicore = use_multicore,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .enough_space_height = enough_space_height,
+            .sub_core_grids = sub_core_grids},
+        input_tensor);
+}
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.hpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/operations/experimental/quasar/untilize_with_unpadding/device/untilize_with_unpadding_device_operation_types.hpp"
+#include "factories/untilize_with_unpadding_single_core_program_factory.hpp"
+#include "factories/untilize_with_unpadding_multi_core_interleaved_program_factory.hpp"
+#include "factories/untilize_with_unpadding_multi_core_sharded_program_factory.hpp"
+#include "factories/untilize_with_unpadding_multi_core_col_interleaved_program_factory.hpp"
+#include "factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.hpp"
+#include "factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.hpp"
+#include <variant>
+#include "ttnn/operation.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct UntilizeWithUnpaddingDeviceOperation {
+    using operation_attributes_t = UntilizeWithUnpaddingParams;
+    using tensor_args_t = Tensor;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
+
+    using program_factory_t = std::variant<
+        UntilizeWithUnpaddingSingleCoreProgramFactory,
+        UntilizeWithUnpaddingMultiCoreInterleavedProgramFactory,
+        UntilizeWithUnpaddingMultiCoreShardedProgramFactory,
+        UntilizeWithUnpaddingMultiCoreColInterleavedProgramFactory,
+        UntilizeWithUnpaddingMultiCoreBlockInterleavedProgramFactory,
+        UntilizeWithUnpaddingMultiCoreNDShardedProgramFactory>;
+
+    static program_factory_t select_program_factory(
+        const operation_attributes_t& operation_attributes, const Tensor& input);
+
+    static void validate_on_program_cache_miss(const operation_attributes_t& operation_attributes, const Tensor& input);
+
+    static spec_return_value_t compute_output_specs(
+        const operation_attributes_t& operation_attributes, const Tensor& input);
+
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t& operation_attributes, const Tensor& input);
+
+    static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
+        const operation_attributes_t& operation_attributes, const Tensor& input, tensor_return_value_t& output_tensor);
+};
+
+Tensor untilize_with_unpadding(
+    const Tensor& input_tensor,
+    const ttnn::Shape& output_tensor_end,
+    const std::optional<MemoryConfig>& output_mem_config,
+    bool use_multicore,
+    bool fp32_dest_acc_en,
+    bool enough_space_height,
+    const std::optional<CoreRangeSet>& sub_core_grids);
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/untilize_with_unpadding_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/untilize_with_unpadding_device_operation_types.hpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::prim::qsr {
+
+struct UntilizeWithUnpaddingParams {
+    ttnn::Shape output_tensor_end{};
+    tt::tt_metal::MemoryConfig output_mem_config;
+    bool use_multicore = false;
+    bool fp32_dest_acc_en = false;
+    bool enough_space_height = false;
+    std::optional<CoreRangeSet> sub_core_grids = std::nullopt;
+};
+
+}  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/untilize_with_unpadding.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/untilize_with_unpadding.cpp
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "untilize_with_unpadding.hpp"
+#include "ttnn/operation.hpp"
+#include "ttnn/operations/data_movement/common/common.hpp"
+#include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
+#include "ttnn/operations/experimental/quasar/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.hpp"
+
+using namespace tt::tt_metal;
+
+static ttnn::Shape squeeze_vector_shape(ttnn::Shape output_shape) {
+    if (output_shape.rank() > 4) {
+        ttnn::SmallVector<uint32_t> output_shape_4d(output_shape.rank());
+        output_shape_4d[0] = 1;
+        int extra_rank = output_shape.size() - 4;
+        for (int i = extra_rank; i >= 0; i--) {
+            output_shape_4d[0] *= (output_shape[i] + 1);
+        }
+        output_shape_4d[0]--;
+        output_shape_4d[1] = output_shape[1 + extra_rank];
+        output_shape_4d[2] = output_shape[2 + extra_rank];
+        output_shape_4d[3] = output_shape[3 + extra_rank];
+        return ttnn::Shape(std::move(output_shape_4d));
+    }
+    return output_shape;
+}
+
+namespace ttnn::operations::experimental::quasar {
+
+// Shared data-movement helpers used by this op; brought in explicitly now that it lives under
+// the experimental::quasar namespace (they previously resolved via the enclosing data_movement ns).
+using ttnn::operations::data_movement::MassagedOperation;
+using ttnn::operations::data_movement::MassagedOperationParams;
+using ttnn::operations::data_movement::squeeze_from_ND_to_4D;
+
+using OwnedUntilizeValArgs = std::tuple<ttnn::Tensor>;
+using BaseUntilizeValType = std::function<ttnn::Tensor(const ttnn::Tensor&)>;
+
+using MassagedUntilizeVal = MassagedOperation<ttnn::Tensor, const ttnn::Tensor&>;
+using MassagedUntilizeValParams = MassagedOperationParams<ttnn::Tensor, const ttnn::Tensor&>;
+
+MassagedUntilizeVal build_ndiml_untilize_val(
+    BaseUntilizeValType base_untilize, const std::optional<CoreRangeSet>& sub_core_grids) {
+    auto original_shape = std::make_shared<Shape>();
+
+    return MassagedUntilizeVal(MassagedUntilizeValParams{
+        .predicate = [](const ttnn::Tensor& input_tensor) -> bool { return input_tensor.logical_shape().rank() > 4; },
+        .pre_transform = [=](const ttnn::Tensor& input_tensor) -> OwnedUntilizeValArgs {
+            *original_shape = input_tensor.logical_shape();
+            ttnn::Tensor squeezed_tensor = squeeze_from_ND_to_4D(input_tensor, sub_core_grids);
+            return std::make_tuple(squeezed_tensor);
+        },
+        .post_transform = [=](const ttnn::Tensor& output) -> ttnn::Tensor {
+            auto unsqueezed_tensor = ttnn::reshape(
+                output,
+                *original_shape,
+                std::nullopt,              /*Memory Config*/
+                std::nullopt,              /*Pad value*/
+                TileReshapeMapMode::CACHE, /*Reshape map mode*/
+                sub_core_grids);
+            return unsqueezed_tensor;
+        },
+        .operation = std::move(base_untilize)});
+}
+
+}  // namespace ttnn::operations::experimental::quasar
+
+namespace ttnn::operations::experimental::quasar {
+
+Tensor untilize_with_unpadding(
+    const Tensor& input_tensor,
+    const Shape& output_tensor_end,
+    const std::optional<MemoryConfig>& memory_config,
+    bool use_multicore,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
+    bool fp32_dest_acc_en = input_tensor.dtype() == DataType::UINT32 || input_tensor.dtype() == DataType::FLOAT32;
+
+    ttnn::SmallVector<uint32_t> output_end_vector;
+    ttnn::Shape output_end;
+    const auto& input_shape = input_tensor.logical_shape();
+    if (input_shape.rank() > 4) {
+        for (auto index = 0; index < input_shape.rank(); ++index) {
+            output_end_vector.push_back(input_shape[index] - 1);
+        }
+        output_end = squeeze_vector_shape(ttnn::Shape(std::move(output_end_vector)));
+    } else {
+        for (auto index = 0; index < input_tensor.logical_shape().rank(); ++index) {
+            output_end_vector.push_back(output_tensor_end[index]);
+        }
+        output_end = ttnn::Shape(std::move(output_end_vector));
+    }
+
+    auto input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
+    uint32_t output_single_tile_size = input_single_tile_size;
+
+    uint32_t num_tiles_per_row = input_tensor.padded_shape()[-1] / tt::constants::TILE_WIDTH;
+
+    bool enough_space_height = operations::data_movement::is_enough_space(
+        input_tensor, input_single_tile_size, output_single_tile_size, num_tiles_per_row);
+
+    auto base_untilize = [=](const ttnn::Tensor& input_tensor) {
+        return ttnn::prim::qsr::untilize_with_unpadding(
+            input_tensor,
+            ttnn::Shape(output_end),
+            memory_config,
+            use_multicore,
+            fp32_dest_acc_en,
+            enough_space_height,
+            sub_core_grids);
+    };
+
+    return build_ndiml_untilize_val(base_untilize, sub_core_grids)(input_tensor);
+}
+
+}  // namespace ttnn::operations::experimental::quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/untilize_with_unpadding.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/untilize_with_unpadding.hpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::experimental::quasar {
+
+Tensor untilize_with_unpadding(
+    const Tensor& input_tensor,
+    const Shape& output_tensor_end,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    bool use_multicore = true,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+
+}  // namespace ttnn::operations::experimental::quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/untilize_with_unpadding_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/untilize_with_unpadding_nanobind.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "untilize_with_unpadding_nanobind.hpp"
+
+#include <optional>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
+
+#include "ttnn-nanobind/bind_function.hpp"
+#include "untilize_with_unpadding.hpp"
+
+namespace ttnn::operations::experimental::quasar::detail {
+
+void bind_untilize_with_unpadding(nb::module_& mod) {
+    const auto* doc =
+        R"doc(
+        Changes data layout of input tensor to ROW_MAJOR and unpads/removes elements from the tensor.
+
+        Input tensor must be on TT accelerator device, in TILE layout, and have BFLOAT16 data type.
+
+        Output tensor will be on TT accelerator device, in ROW_MAJOR layout, and have BFLOAT16 data type.
+
+        Args:
+            input_tensor (ttnn.Tensor): the input tensor
+            output_tensor_end (shape): End indices of input tensor in output tensor.
+
+        Keyword Args:
+            memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
+            use_multicore (bool, optional): Whether to use multicore. Defaults to `True`.
+            sub_core_grids (ttnn.CoreRangeSet, optional): Sub core grids. Defaults to `None`.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+    )doc";
+
+    ttnn::bind_function<"untilize_with_unpadding">(
+        mod,
+        doc,
+        &ttnn::operations::experimental::quasar::untilize_with_unpadding,
+        nb::arg("input_tensor"),
+        nb::arg("output_tensor_end"),
+        nb::kw_only(),
+        nb::arg("memory_config") = nb::none(),
+        nb::arg("use_multicore") = true,
+        nb::arg("sub_core_grids") = nb::none());
+}
+
+}  // namespace ttnn::operations::experimental::quasar::detail

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/untilize_with_unpadding_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/untilize_with_unpadding_nanobind.hpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::experimental::quasar::detail {
+
+namespace nb = nanobind;
+void bind_untilize_with_unpadding(nb::module_& mod);
+
+}  // namespace ttnn::operations::experimental::quasar::detail

--- a/ttnn/sources.cmake
+++ b/ttnn/sources.cmake
@@ -183,6 +183,18 @@ set(TTNN_SRC_PYBIND
     cpp/ttnn/operations/experimental/isin/isin_nanobind.cpp
     cpp/ttnn/operations/experimental/adaptive_pool/adaptive_pools_nanobind.cpp
     cpp/ttnn/operations/experimental/experimental_nanobind.cpp
+    cpp/ttnn/operations/experimental/quasar/quasar_nanobind.cpp
+    cpp/ttnn/operations/experimental/quasar/pad/pad_nanobind.cpp
+    cpp/ttnn/operations/experimental/quasar/tilize/tilize_nanobind.cpp
+    cpp/ttnn/operations/experimental/quasar/move/move_nanobind.cpp
+    cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/untilize_with_unpadding_nanobind.cpp
+    cpp/ttnn/operations/experimental/quasar/slice/slice_nanobind.cpp
+    cpp/ttnn/operations/experimental/quasar/transpose/transpose_nanobind.cpp
+    cpp/ttnn/operations/experimental/quasar/reshard/reshard_nanobind.cpp
+    cpp/ttnn/operations/experimental/quasar/pool_generic/generic_pools_nanobind.cpp
+    cpp/ttnn/operations/experimental/quasar/conv2d/conv2d_nanobind.cpp
+    cpp/ttnn/operations/experimental/quasar/matmul/matmul_nanobind.cpp
+    cpp/ttnn/operations/experimental/quasar/binary/binary_nanobind.cpp
     cpp/ttnn/operations/experimental/fusion/fusion_dispatch_op_nanobind.cpp
     cpp/ttnn/operations/experimental/deepseek_prefill/moe_grouped_topk/moe_grouped_topk_nanobind.cpp
     cpp/ttnn/operations/experimental/matmul/attn_matmul/attn_matmul_nanobind.cpp


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Feature

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #47433 
Need to copy the ops used by resnet to a separate quasar specific location. Copied them to experimental/quasar
Applied any outstanding device 2.0 migration PRs that are applicable
Applied a fix to an outstanding double consumer issue for transpose that would prevent proper DFB usage

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

This will allow porting resnet Quasar code for an extnal deliverable. The main factor is that this doesn't affect existing WH/BH code. Making the copied code work is for subsequent PRs.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-47433_experimental_qsr_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-47433_experimental_qsr_ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-47433_experimental_qsr_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-47433_experimental_qsr_ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-47433_experimental_qsr_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-47433_experimental_qsr_ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-47433_experimental_qsr_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-47433_experimental_qsr_ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-47433_experimental_qsr_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-47433_experimental_qsr_ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-47433_experimental_qsr_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-47433_experimental_qsr_ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-47433_experimental_qsr_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-47433_experimental_qsr_ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-47433_experimental_qsr_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-47433_experimental_qsr_ops)