### PR TITLE
[skip ci] Improve error handling for mpi interface selection

### DIFF
--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -293,7 +293,11 @@ if [[ "$MPI_IF_EXPLICIT" == "true" ]]; then
     validate_mpi_interface "$MPI_IF" "true" "$FIRST_HOST"
 else
     MPI_IF=$(validate_mpi_interface "" "false" "$FIRST_HOST")
-    echo "Auto-detected MPI interface: $MPI_IF"
+    # Check if validation failed (command substitution only exits subshell, not parent)
+    if [[ -z "$MPI_IF" ]]; then
+        echo "Error: MPI interface auto-detection failed" >&2
+        exit 1
+    fi
 fi
 
 # Set log file path inside output directory (captures actual start time).

--- a/tools/scaleout/exabox/run_dispatch_tests.sh
+++ b/tools/scaleout/exabox/run_dispatch_tests.sh
@@ -114,7 +114,11 @@ if [[ "$MPI_IF_EXPLICIT" == "true" ]]; then
     validate_mpi_interface "$MPI_IF" "true" "$FIRST_HOST"
 else
     MPI_IF=$(validate_mpi_interface "" "false" "$FIRST_HOST")
-    echo "Auto-detected MPI interface: $MPI_IF"
+    # Check if validation failed (command substitution only exits subshell, not parent)
+    if [[ -z "$MPI_IF" ]]; then
+        echo "Error: MPI interface auto-detection failed" >&2
+        exit 1
+    fi
 fi
 
 # Create output directory if it doesn't exist

--- a/tools/scaleout/exabox/run_fabric_tests.sh
+++ b/tools/scaleout/exabox/run_fabric_tests.sh
@@ -236,7 +236,11 @@ if [[ "$MPI_IF_EXPLICIT" == "true" ]]; then
     validate_mpi_interface "$MPI_IF" "true" "$FIRST_HOST"
 else
     MPI_IF=$(validate_mpi_interface "" "false" "$FIRST_HOST")
-    echo "Auto-detected MPI interface: $MPI_IF"
+    # Check if validation failed (command substitution only exits subshell, not parent)
+    if [[ -z "$MPI_IF" ]]; then
+        echo "Error: MPI interface auto-detection failed" >&2
+        exit 1
+    fi
 fi
 
 # For the Nx32x4 family, capture the mesh/host count N (empty for all other configs).

--- a/tools/scaleout/exabox/run_validation.sh
+++ b/tools/scaleout/exabox/run_validation.sh
@@ -221,7 +221,11 @@ if [[ "$MPI_IF_EXPLICIT" == "true" ]]; then
     validate_mpi_interface "$MPI_IF" "true" "$FIRST_HOST"
 else
     MPI_IF=$(validate_mpi_interface "" "false" "$FIRST_HOST")
-    echo "Auto-detected MPI interface: $MPI_IF"
+    # Check if validation failed (command substitution only exits subshell, not parent)
+    if [[ -z "$MPI_IF" ]]; then
+        echo "Error: MPI interface auto-detection failed" >&2
+        exit 1
+    fi
 fi
 
 run_cluster_validation() {


### PR DESCRIPTION
### Fix: Added improved error handling for MPI interface auto-detection failures across exabox validation scripts

### Summary
Relates to: [DCAMP-741](https://tenstorrent.atlassian.net/browse/DCAMP-741)

Previous PR #47158 introduced an automatic mpi interface detection for the exabox validation scripts with explicit error messages when a valid interface can't be found. Noticed that for certain errors, tests with multiple iterations would keep running, the validation function's exit call only terminated the subshell, not the parent script itself.

This adds a critical error check to the wrapper scripts that:
- Detects when MPI interface auto-detection fails (returns empty string)
- Exits immediately with error code 1 instead of continuing with an invalid/empty MPI_IF value
- Prints a clear error message to stderr for debugging
