### PR TITLE
DS Prefill :: LB Dispatch and Combine tests baselines and margin update

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
@@ -40,26 +40,29 @@ _REAL_INDICES_TOPOS = [("linear", 2), ("ring", 2)]
 # are developed separately, so each is asserted against its own baseline —
 # a regression localizes to the responsible kernel.
 _DISPATCH_REAL_INDICES_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
-    # (topo, nlinks, layer, col): expected_ns. Averaged over 3 CI runs on LB
-    # against LONGBOOK_QA_ENG_25600/expert_routing.safetensors.
-    ("linear", 2, 27, 2): 12_097_001,  # 43.2%
-    ("linear", 2, 38, 0): 7_133_901,  # 41.2%
-    ("linear", 2, 50, 0): 8_486_784,  # 39.9%
-    ("linear", 2, 28, 1): 11_040_680,  # 39.5%
-    ("ring", 2, 27, 2): 7_176_132,
-    ("ring", 2, 38, 0): 5_160_985,
-    ("ring", 2, 50, 0): 4_932_906,
-    ("ring", 2, 28, 1): 5_612_649,
+    # (topo, nlinks, layer, col): expected_ns. Re-centered to the midpoint of the observed
+    # min/max across 16 main-branch CI runs (2026-06-13..18) spanning 5 LB runners
+    # (f01cs01/02/08, f04cs03/04), against LONGBOOK_QA_ENG_25600/expert_routing.safetensors.
+    # Percent comment = dispatch-group in-col share for that layer/col.
+    ("linear", 2, 27, 2): 12_129_621,  # 43.2%
+    ("linear", 2, 38, 0): 7_158_222,  # 41.2%
+    ("linear", 2, 50, 0): 8_484_394,  # 39.9%
+    ("linear", 2, 28, 1): 11_039_234,  # 39.5%
+    ("ring", 2, 27, 2): 7_216_744,
+    ("ring", 2, 38, 0): 5_130_980,
+    ("ring", 2, 50, 0): 4_848_732,
+    ("ring", 2, 28, 1): 5_595_338,
 }
 _COMBINE_REAL_INDICES_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
-    ("linear", 2, 27, 2): 11_953_557,
-    ("linear", 2, 38, 0): 8_342_082,
-    ("linear", 2, 50, 0): 8_468_503,
-    ("linear", 2, 28, 1): 12_180_094,
-    ("ring", 2, 27, 2): 11_521_053,
-    ("ring", 2, 38, 0): 6_168_482,
-    ("ring", 2, 50, 0): 6_372_161,
-    ("ring", 2, 28, 1): 10_628_641,
+    # Re-centered to observed midpoint (same 16-run / 5-runner sample as dispatch above).
+    ("linear", 2, 27, 2): 12_015_238,
+    ("linear", 2, 38, 0): 8_353_550,
+    ("linear", 2, 50, 0): 8_515_742,
+    ("linear", 2, 28, 1): 12_191_696,
+    ("ring", 2, 27, 2): 11_506_808,
+    ("ring", 2, 38, 0): 6_168_426,
+    ("ring", 2, 50, 0): 6_306_488,
+    ("ring", 2, 28, 1): 10_286_688,
 }
 
 
@@ -122,7 +125,7 @@ _DISPATCH_COMBINE_PERF_PARAMS = [
             "DispatchDeviceOperation": _DISPATCH_REAL_INDICES_EXPECTED_NS[(topo, nlinks, layer, col)],
             "CombineDeviceOperation": _COMBINE_REAL_INDICES_EXPECTED_NS[(topo, nlinks, layer, col)],
         },
-        margin=0.05 if topo == "ring" else 0.03,
+        margin=0.045 if topo == "ring" else 0.03,
         captured_layer=layer,
         captured_col=col,
         worker_dir="models/demos/deepseek_v3_d_p/tests/perf",

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
@@ -40,26 +40,26 @@ _REAL_INDICES_TOPOS = [("linear", 2), ("ring", 2)]
 # are developed separately, so each is asserted against its own baseline —
 # a regression localizes to the responsible kernel.
 _DISPATCH_REAL_INDICES_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
-    # (topo, nlinks, layer, col): expected_ns. Averaged over 2 CI runs on LB
+    # (topo, nlinks, layer, col): expected_ns. Averaged over 3 CI runs on LB
     # against LONGBOOK_QA_ENG_25600/expert_routing.safetensors.
-    ("linear", 2, 27, 2): 12_124_899,  # 43.2%
-    ("linear", 2, 38, 0): 7_208_142,  # 41.2%
-    ("linear", 2, 50, 0): 8_441_255,  # 39.9%
-    ("linear", 2, 28, 1): 11_078_364,  # 39.5%
-    ("ring", 2, 27, 2): 7_212_175,
-    ("ring", 2, 38, 0): 5_184_732,
-    ("ring", 2, 50, 0): 4_928_074,
-    ("ring", 2, 28, 1): 5_538_430,
+    ("linear", 2, 27, 2): 12_097_001,  # 43.2%
+    ("linear", 2, 38, 0): 7_133_901,  # 41.2%
+    ("linear", 2, 50, 0): 8_486_784,  # 39.9%
+    ("linear", 2, 28, 1): 11_040_680,  # 39.5%
+    ("ring", 2, 27, 2): 7_176_132,
+    ("ring", 2, 38, 0): 5_160_985,
+    ("ring", 2, 50, 0): 4_932_906,
+    ("ring", 2, 28, 1): 5_612_649,
 }
 _COMBINE_REAL_INDICES_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
-    ("linear", 2, 27, 2): 11_847_122,
-    ("linear", 2, 38, 0): 8_407_743,
-    ("linear", 2, 50, 0): 8_494_661,
-    ("linear", 2, 28, 1): 12_075_174,
-    ("ring", 2, 27, 2): 11_487_846,
-    ("ring", 2, 38, 0): 6_160_595,
-    ("ring", 2, 50, 0): 6_367_849,
-    ("ring", 2, 28, 1): 10_622_806,
+    ("linear", 2, 27, 2): 11_953_557,
+    ("linear", 2, 38, 0): 8_342_082,
+    ("linear", 2, 50, 0): 8_468_503,
+    ("linear", 2, 28, 1): 12_180_094,
+    ("ring", 2, 27, 2): 11_521_053,
+    ("ring", 2, 38, 0): 6_168_482,
+    ("ring", 2, 50, 0): 6_372_161,
+    ("ring", 2, 28, 1): 10_628_641,
 }
 
 
@@ -122,6 +122,7 @@ _DISPATCH_COMBINE_PERF_PARAMS = [
             "DispatchDeviceOperation": _DISPATCH_REAL_INDICES_EXPECTED_NS[(topo, nlinks, layer, col)],
             "CombineDeviceOperation": _COMBINE_REAL_INDICES_EXPECTED_NS[(topo, nlinks, layer, col)],
         },
+        margin=0.05 if topo == "ring" else 0.03,
         captured_layer=layer,
         captured_col=col,
         worker_dir="models/demos/deepseek_v3_d_p/tests/perf",


### PR DESCRIPTION
### PR Category
Performance

Addresses https://github.com/tenstorrent/tt-metal/issues/46830 

### Summary
## What
Recalibrate the real-indices dispatch/combine device-perf baselines and set per-topo margins: **3% for linear, 4.5% for ring**.

## Why
The `test_device_perf_dispatch_combine` baselines were calibrated on a subset of the LoudBox runner pool, but the machines differ enough to flake the gate. Across 16 main-branch runs (2026-06-13 - 06-18) on 5 LB runners (f01cs01/02/08, f04cs03/04):
- **f01cs08** runs several ring cases ~4-8% *faster* -> trips the **lower** bound (ring-l50 dispatch/combine, ring-l28 combine).
- **f01cs01** runs ring-l28 dispatch ~4% *slower* -> trips the **upper** bound.
- f04cs03/f04cs04 are the stable pack the old numbers were tuned on.

This is machine-to-machine variance, not a regression (separate [infra/fabric issue](https://github.com/tenstorrent/tt-metal/issues/47287) tracks this anomaly).

## How
- Re-centered every baseline to the **midpoint of observed min/max, so the band is symmetric around the real spread instead of one machine's number.
- Sized margins from the measured spread: linear cases span <=2.5% (3% covers all with
  headroom); ring cases span up to 4.0% (4.5% covers all). 

## Validation
All 16 observed runs pass with the new baselines + margins. Tightest remaining headroom is ring-l28 combine flagged in the fabric issue, can be bumped to 5% on that single case if it flakes.

### CI
Passing perf runs per runner:
[f04cs03 ](https://github.com/tenstorrent/tt-metal/actions/runs/27763752191/job/82159623128) 
[f04cs04](https://github.com/tenstorrent/tt-metal/actions/runs/27763768997/job/82160391848)
[f01cs08](https://github.com/tenstorrent/tt-metal/actions/runs/27763783405/job/82160188507)
[f01cs02](https://github.com/tenstorrent/tt-metal/actions/runs/27792885464/job/82253575789)
[f01cs01](https://github.com/tenstorrent/tt-metal/actions/runs/27792900783/job/82253432881)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nmilicevic/ds-bump-perf-margin)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nmilicevic/ds-bump-perf-margin)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nmilicevic/ds-bump-perf-margin)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nmilicevic/ds-bump-perf-margin)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nmilicevic/ds-bump-perf-margin)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nmilicevic/ds-bump-perf-margin)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmilicevic/ds-bump-perf-margin)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmilicevic/ds-bump-perf-margin)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nmilicevic/ds-bump-perf-margin)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nmilicevic/ds-bump-perf-margin)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmilicevic/ds-bump-perf-margin)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmilicevic/ds-bump-perf-margin)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmilicevic/ds-bump-perf-margin)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmilicevic/ds-bump-perf-margin)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmilicevic/ds-bump-perf-margin)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmilicevic/ds-bump-perf-margin)