### PR TITLE
Bind get_physical_mesh_shapes to Python

### DIFF
--- a/ttnn/cpp/ttnn-nanobind/fabric.cpp
+++ b/ttnn/cpp/ttnn-nanobind/fabric.cpp
@@ -5,9 +5,11 @@
 #include "fabric.hpp"
 
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/array.h>
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/pair.h>
 #include <nanobind/stl/string.h>
+#include <nanobind/stl/unordered_map.h>
 #include <nanobind/stl/vector.h>
 
 #include <tt-metalium/core_coord.hpp>
@@ -357,6 +359,25 @@ void bind_fabric_api(nb::module_& mod) {
 
             Unlike get_user_physical_mesh_ids (which is scoped to the local rank's meshes),
             this enumerates peer meshes as well, enabling multi-mesh topology discovery.
+        )");
+
+    mod.def(
+        "get_physical_mesh_shapes",
+        []() {
+            // Return plain ints ({mesh_id: (rows, cols)}) to avoid MeshId/MeshShape
+            // Python-type friction -- callers just need the open shape per local mesh.
+            std::unordered_map<uint32_t, std::array<uint32_t, 2>> out;
+            for (const auto& [mid, shape] : tt::tt_fabric::get_physical_mesh_shapes()) {
+                out[*mid] = {shape[0], shape[1]};
+            }
+            return out;
+        },
+        R"(
+            Physical shape of each mesh local to this rank, read from the active mesh graph descriptor.
+
+            Returns a {mesh_id: (rows, cols)} map scoped to get_user_physical_mesh_ids() -- i.e. only
+            this rank's local mesh(es). This is exactly the shape to pass to open_mesh_device, so it is
+            safe to call before the device is opened (the control plane lazily inits from the MGD).
         )");
 }
 

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -176,6 +176,7 @@ from ttnn._ttnn.fabric import (
     get_tt_fabric_max_payload_size_bytes,
     get_eth_forwarding_direction,
     get_all_fabric_mesh_ids,
+    get_physical_mesh_shapes,
     MeshId,
     FabricNodeId,
     setup_fabric_connection,


### PR DESCRIPTION
Exposes the existing tt::tt_fabric::get_physical_mesh_shapes() through ttnn so Python can read each local mesh's physical shape directly from the active mesh graph descriptor, instead of inferring it from process count.

- ttnn.get_physical_mesh_shapes() returns {mesh_id: [rows, cols]}, scoped (like get_user_physical_mesh_ids) to this rank's local mesh(es).
- Returns plain ints to avoid MeshId/MeshShape Python-type friction.
- Same control-plane access path as the already-bound get_all_fabric_mesh_ids, so no new init behavior.


This lets the blaze pipeline-builder derive the mesh open shape from the MGD rather than a hardcoded num_procs to MeshShape table (needed for the superpod multi-mesh case to open 4x 4x32 instead of 64x 4x2).

Test: built RelWithDebInfo; verified on a single BH galaxy -- ttnn.get_physical_mesh_shapes() returns {0: [8, 4]}, matching the MGD device_topology [8,4].

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkodkani/bind-get-physical-mesh-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkodkani/bind-get-physical-mesh-shapes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkodkani/bind-get-physical-mesh-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkodkani/bind-get-physical-mesh-shapes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nkodkani/bind-get-physical-mesh-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nkodkani/bind-get-physical-mesh-shapes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkodkani/bind-get-physical-mesh-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkodkani/bind-get-physical-mesh-shapes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkodkani/bind-get-physical-mesh-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkodkani/bind-get-physical-mesh-shapes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkodkani/bind-get-physical-mesh-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkodkani/bind-get-physical-mesh-shapes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkodkani/bind-get-physical-mesh-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkodkani/bind-get-physical-mesh-shapes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkodkani/bind-get-physical-mesh-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkodkani/bind-get-physical-mesh-shapes)