### PR TITLE
Add forward_metadata_size_bytes override to PipelineBlock

### DIFF
--- a/models/demos/deepseek_v3_b1/micro_ops/pipeline_block/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/pipeline_block/op.py
@@ -211,6 +211,7 @@ class PipelineBlock:
         stages_metadata=None,
         pipeline_config=None,
         forward_metadata=False,
+        forward_metadata_size_bytes=None,
         io_socket_descriptor_prefix=None,
         second_pipeline_core_coord=None,
     ):
@@ -358,7 +359,9 @@ class PipelineBlock:
                     entry_node_downstream,
                     exit_node_upstream,
                     exit_upstream_page_size,
-                    DeepseekMetadata.aligned_size_bytes() if forward_metadata else 0,
+                    forward_metadata_size_bytes
+                    if forward_metadata_size_bytes is not None
+                    else (DeepseekMetadata.aligned_size_bytes() if forward_metadata else 0),
                 )
 
     def _init_first_stage(


### PR DESCRIPTION
### PR Category
Feature/Perf

### Summary
Allow callers to explicitly size the forwarded metadata bytes for the forwarding stage, falling back to `DeepseekMetadata.aligned_size_bytes()` (or 0) when not provided. Needed by blaze PR https://github.com/tenstorrent/tt-blaze/pull/1192 since blaze metadata size differs from blitz (64 B vs 256 B). Backwards-compatible with metal DS blitz

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ssundaram/metadata)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ssundaram/metadata)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ssundaram/metadata)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ssundaram/metadata)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ssundaram/metadata)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ssundaram/metadata)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ssundaram/metadata)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ssundaram/metadata)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ssundaram/metadata)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ssundaram/metadata)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ssundaram/metadata)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ssundaram/metadata)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ssundaram/metadata)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ssundaram/metadata)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ssundaram/metadata)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ssundaram/metadata)