### PR TITLE
[Cleanup] Guarantee `DFBAccessor` implicit ID is carried by CTA across all architectures

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -2223,8 +2223,7 @@ TEST_F(ProgramSpecTestQuasar, UnpackToDestModePlacedAtDfbIdSlot) {
 //    when a DFB endpoint is bound by more than one KernelSpec.
 //
 //    NOTE: The plan is to lift this artificial constraint once LLK support is in
-//    place. DFB IDs will then be passed as implicit RTAs rather than implicit CTAs
-//    on Quasar only.
+//    place.
 
 // Category A: Order-Independence Test
 // This test verifies that the backtracking solver finds valid assignments,

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -2217,13 +2217,21 @@ TEST_F(ProgramSpecTestQuasar, UnpackToDestModePlacedAtDfbIdSlot) {
 //    NOTE: Our plan is to keep the simplifying assumption for now.
 //    We issue a clear message if the assumption is ever violated in the real world.
 //
-// C) KERNELS COUPLED THROUGH MULTI-DFB BINDINGS
-//    Until LLK APIs adopt DFBAccessor, we cannot specialize DFBs (multiple DFBs
-//    for a single DataflowBufferSpec). This induces additional DM solver constraints
-//    when a DFB endpoint is bound by more than one KernelSpec.
+//   C) KERNELS COUPLED THROUGH MULTI-DFB BINDINGS
+//    When a DFBSpec is bound by multiple KernelSpecs (which is legal, provided
+//    that the invariant that any given DFB instance has one one producer kernel
+//    instance and only one consumer kernel instance), the resulting cross-kernel
+//    coupling through the shared DFB binding induces additional DM solver constraints.
 //
-//    NOTE: The plan is to lift this artificial constraint once LLK support is in
-//    place.
+//    NOTE: The original plan called for lifting this artificial constraint once LLK adopted
+//    DFBAccessor using implicit RTAs. However, to realize performance gains, we're
+//    chosen instead to GUARANTEE using implicit CTAs for DFBAccessor. This
+//    constraint is therefore permanent.
+//
+//    If we were ever to start encountering serious unsolvable-Program issues as a result
+//    we might consider revisiting this decision. However, an unsolvable Program could
+//    can always be worked around by artificially dividing a KernelSpec (at the expense of
+//    dispatch overhead).
 
 // Category A: Order-Independence Test
 // This test verifies that the backtracking solver finds valid assignments,

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -43,19 +43,6 @@ using DFBSpecName = ttsl::StrongType<std::string, struct DFBSpecNameTag>;
 
 struct KernelAdvancedOptions {
     ////////////////////////////////////////////////////////////////////////////////
-    // Per-node thread count (Gen2)
-    ////////////////////////////////////////////////////////////////////////////////
-
-    // The default kernel threading is specified by KernelSpec::num_threads.
-    // However, you may override this on a per-node basis.
-    //
-    // NOTE: This feature is currently UNSUPPORTED!
-    //       (It's an open question if we EVER want to support it.)
-    //       It is included here just as a placeholder for use case feedback.
-    //       Attempting to use it will trigger a runtime error.
-    Table<Nodes, /* num_threads */ uint32_t> node_specific_thread_counts;
-
-    ////////////////////////////////////////////////////////////////////////////////
     // Enqueue-loop invariant kernel arguments
     ////////////////////////////////////////////////////////////////////////////////
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_args.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_args.hpp
@@ -154,7 +154,6 @@ struct ProgramRunArgsView {
     };
     // TODO: Better to just expose the multi-dim dispatch vectors directly?
     //       Would eliminate the lookup indirection.
-    //       ...But would mess up all the implicit RTAs....
     //       Look into this when implementing.
     Group<KernelRunArgsView> kernel_run_args;
 

--- a/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
@@ -41,10 +41,7 @@
 struct DFBAccessor {
     explicit constexpr DFBAccessor(uint16_t id) noexcept : id_(id) {}
 
-    // Constexpr behavior for ID extraction:
-    //  - On WH/BH, DFBAccessor is always constexpr. It's backed by a compile-time ID.
-    //  - On Quasar, we reserve the right to switch to a runtime-backed ID.
-    //    (Future-proofing workaround to a future problem with DM assignments.)
+    // DFBAccessor is backed by a compile-time ID (an implicit CTA).
 
     // Implicit conversion to uint32_t:
     // This lets a Metal 2.0 kernel pass a DFBAccessor directly to Gen1 (WH/BH) LLK
@@ -52,15 +49,8 @@ struct DFBAccessor {
     // This conversion is constexpr; it's intended for Gen1 use only.
     constexpr operator uint32_t() const noexcept { return id_; }
 
-    // Explicit ID accessor:
-    // This meant only for Quasar LLK APIs, which accept DFBAccessor directly.
-    // Intentionally NOT constexpr; since body could become an RTA retrieval.
-    // (If constexpr is needed by LLK, we could fix that for compute kernels.)
-    uint16_t resolve_id() const noexcept { return id_; }
-
 private:
     uint16_t id_;
-    // uint32_t rta_idx; // future-proofing option
 };
 
 class DataflowBuffer {
@@ -74,7 +64,7 @@ public:
     // Preferred constructor for Metal 2.0 / ProgramSpec kernels.
     // Pass the named binding constant from kernel_bindings_generated.h:
     //   DataflowBuffer dfb(my_dfb_name);
-    DataflowBuffer(DFBAccessor accessor) : DataflowBuffer(accessor.resolve_id()) {}
+    DataflowBuffer(DFBAccessor accessor) : DataflowBuffer(static_cast<uint16_t>(accessor)) {}
 
     // Low-level constructor: prefer DFBAccessor overload above for new kernel code.
     DataflowBuffer(uint16_t logical_dfb_id);

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -669,15 +669,6 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     // A Program needs at least one kernel
     TT_FATAL(!spec.kernels.empty(), "A ProgramSpec must have at least one KernelSpec");
 
-    // Validate no per-node thread maps are used (not yet implemented)
-    for (const auto& kernel : spec.kernels) {
-        const bool has_node_specific = !kernel.advanced_options.node_specific_thread_counts.empty();
-        TT_FATAL(
-            !has_node_specific,
-            "KernelSpec '{}' specifies node_specific_thread_counts, but per-node thread counts are not implemented.",
-            kernel.unique_id);
-    }
-
     // Validate named RTA/CRTA schema and named CTAs
     for (const auto& kernel : spec.kernels) {
         // All three kinds share the args:: namespace — their names must be mutually unique.

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -2590,9 +2590,7 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
 
     // Step 2b: For multi-binding DFBs, all KernelSpecs on the same role must end up with
     // identical risc_masks. The DFB has a single producer_risc_mask / consumer_risc_mask in
-    // its hardware config; per-node mask variation would require splitting the DFB at lowering
-    // time (deliberately not done yet -- awaiting LLK DFBAccessor API support before we can do
-    // 1:N DFBs, as doing so requires passing DFB IDs as implicit RTAs rather than implicit CTAs).
+    // its hardware config.
     //
     // Gen1: the mask is a deterministic function of the user's KernelSpec hw_config (compute
     //   placement is fixed; DM processor is user-specified via Gen1Config). A


### PR DESCRIPTION
## PR Category
Cleanup

## Summary

This PR ensures that the Metal 2.0 `DFBAccessor` is constexpr (i.e. CTA-like) across all platforms (Gen 1 and Gen 2). This new guarantee will enable select LLK performance optimizations.

However, this new guarantee comes at a cost:
 - We had plans to later enable per-node num_threads on Quasar, which was envisioned to have potential benefits for dispatch overhead for very simple DM kernels. This becomes impossible with constexpr `DFBAccessor`.
 - The Quasar DM kernel -> core assignment solver operates under artificial constraints, which could result in theoretically legal ProgramSpecs being unplaceable. Non-constexpr `DFBAccessor` (via implicit RTAs) was the escape hatch to fix those problems if they arose.

We are consciously trading off known and immediate benefits (LLK performance) for hypothetical future flexibility (solver fix) and hypothetical future performance benefits (per-node num_threads).

### Changes

The changes involves removal of following sites:
- `DFBAccessor` previously have a stub to get the dfb id via a non-constexpr `resolve_id` function, this function has been removed.
- `node_specific_thread_counts` AdvancedOption as `node_specific_thread_counts` would require implicit RTA (explained below).
- Comments related to implicit RTA for the solver escape hatch.

Added:
- Test to assert the DFBAccessor is constexpr.


## Notes for reviewers
Implicit RTA is required for dfb if we want to support per node thread count.

A single dfb configuration on the implementation side can only have a single pair of `riscv_masks` indicating the the producer/ receivership of cores enabled within individual nodes. This is currently uniform across all nodes. Supporting node specific thread counts will require splitting a dfb spec into multiple logical/ implementation dfb configurations with different `riscv_masks`.

CTA is node agnostic (a `KernelSpec` is only compiled once across nodes), the complications relating to which dfb configuration to resolve means `DFBAccessor` will need to be node dependent, this difference can only be bridged by RTA.

## CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/constexpr-dfb-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/constexpr-dfb-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/constexpr-dfb-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/constexpr-dfb-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/constexpr-dfb-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/constexpr-dfb-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/constexpr-dfb-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/constexpr-dfb-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/constexpr-dfb-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/constexpr-dfb-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/constexpr-dfb-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/constexpr-dfb-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/constexpr-dfb-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/constexpr-dfb-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/constexpr-dfb-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/constexpr-dfb-accessor)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/constexpr-dfb-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/constexpr-dfb-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/constexpr-dfb-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/constexpr-dfb-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/constexpr-dfb-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/constexpr-dfb-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/constexpr-dfb-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/constexpr-dfb-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/constexpr-dfb-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/constexpr-dfb-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/constexpr-dfb-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/constexpr-dfb-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/constexpr-dfb-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/constexpr-dfb-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/constexpr-dfb-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/constexpr-dfb-accessor)