### PR TITLE
[Cleanup] Reduce Row Major tile metadata access warning

### DIFF
--- a/tt_metal/impl/tensor/spec/layout/page_config.cpp
+++ b/tt_metal/impl/tensor/spec/layout/page_config.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt-logger/tt-logger.hpp>
 #include <tt_stl/fmt.hpp>
 #include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
 
@@ -146,7 +147,14 @@ Alignment TilePageConfig::get_required_shard_shape_alignment() const {
     return Alignment({tile_.get_height(), tile_.get_width()});
 }
 
-RowMajorPageConfig::RowMajorPageConfig(const Tile& tile) : tile_(tile) {}
+RowMajorPageConfig::RowMajorPageConfig(const Tile& tile) : tile_(tile) {
+    if (tile != Tile{}) {
+        log_warning(
+            LogMetal,
+            "Configuring a ROW MAJOR page config with a tile configuration, this will be rejected in the future. See "
+            "#18536");
+    }
+}
 
 Alignment RowMajorPageConfig::create_default_alignment(DataType /*dtype*/, const MemoryConfig& memory_config) const {
     if (memory_config.shard_spec().has_value()) {
@@ -210,7 +218,15 @@ size_t RowMajorPageConfig::get_page_size_bytes(const Shape2D& page_shape, DataTy
     return size;
 }
 
-const Tile& RowMajorPageConfig::get_tile() const { return tile_; }
+const Tile& RowMajorPageConfig::get_tile() const {
+    bool is_trivial = (tile_ == Tile{});
+    log_warning(
+        LogMetal,
+        "Attempting to extract tile information out of a ROW MAJOR layout, this will be rejected in the future. See "
+        "#18536. (trivial tile: {})",
+        is_trivial);
+    return tile_;
+}
 
 Alignment RowMajorPageConfig::get_required_shard_shape_alignment() const { return Alignment({1}); }
 

--- a/tt_metal/impl/tensor/spec/layout/page_config.cpp
+++ b/tt_metal/impl/tensor/spec/layout/page_config.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-logger/tt-logger.hpp>
 #include <tt_stl/fmt.hpp>
 #include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
 
@@ -147,14 +146,7 @@ Alignment TilePageConfig::get_required_shard_shape_alignment() const {
     return Alignment({tile_.get_height(), tile_.get_width()});
 }
 
-RowMajorPageConfig::RowMajorPageConfig(const Tile& tile) : tile_(tile) {
-    if (tile != Tile{}) {
-        log_warning(
-            LogMetal,
-            "Configuring a ROW MAJOR page config with a tile configuration, this will be rejected in the future. See "
-            "#18536");
-    }
-}
+RowMajorPageConfig::RowMajorPageConfig(const Tile& tile) : tile_(tile) {}
 
 Alignment RowMajorPageConfig::create_default_alignment(DataType /*dtype*/, const MemoryConfig& memory_config) const {
     if (memory_config.shard_spec().has_value()) {
@@ -218,15 +210,7 @@ size_t RowMajorPageConfig::get_page_size_bytes(const Shape2D& page_shape, DataTy
     return size;
 }
 
-const Tile& RowMajorPageConfig::get_tile() const {
-    bool is_trivial = (tile_ == Tile{});
-    log_warning(
-        LogMetal,
-        "Attempting to extract tile information out of a ROW MAJOR layout, this will be rejected in the future. See "
-        "#18536. (trivial tile: {})",
-        is_trivial);
-    return tile_;
-}
+const Tile& RowMajorPageConfig::get_tile() const { return tile_; }
 
 Alignment RowMajorPageConfig::get_required_shard_shape_alignment() const { return Alignment({1}); }
 

--- a/tt_metal/impl/tensor/spec/layout/page_config.cpp
+++ b/tt_metal/impl/tensor/spec/layout/page_config.cpp
@@ -219,12 +219,13 @@ size_t RowMajorPageConfig::get_page_size_bytes(const Shape2D& page_shape, DataTy
 }
 
 const Tile& RowMajorPageConfig::get_tile() const {
-    bool is_trivial = (tile_ == Tile{});
-    log_warning(
-        LogMetal,
-        "Attempting to extract tile information out of a ROW MAJOR layout, this will be rejected in the future. See "
-        "#18536. (trivial tile: {})",
-        is_trivial);
+    if (tile_ != Tile{}) {
+        log_warning(
+            LogMetal,
+            "Attempting to extract tile information out of a ROW MAJOR layout, this will be rejected in the future. "
+            "See "
+            "#18536.");
+    }
     return tile_;
 }
 

--- a/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
+++ b/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
@@ -124,19 +124,20 @@ void validate_alignment(const TensorLayout& tensor_layout) {
 
 std::optional<std::string> get_shard_align_error(
     const MemoryConfig& memory_config, const Layout& layout, const Tile& tile) {
-    if (memory_config.is_sharded() && layout == Layout::TILE) {
-        const auto& tile_shape = tile.get_tile_shape();
-        if (memory_config.shard_spec().has_value()) {
-            const auto& physical_shard_shape = Shape2D(memory_config.shard_spec().value().shape);
-            if (!(physical_shard_shape.height() % tile_shape[0] == 0 &&
-                  physical_shard_shape.width() % tile_shape[1] == 0)) {
-                return fmt::format("Physical shard shape {} must be tile {} sized!", physical_shard_shape, tile_shape);
-            }
-        } else {
-            const auto& shard_shape = memory_config.nd_shard_spec().value().shard_shape;
-            if (!(shard_shape[-2] % tile_shape[0] == 0 && shard_shape[-1] % tile_shape[1] == 0)) {
-                return fmt::format("Physical shard shape {} must be tile {} sized!", shard_shape, tile_shape);
-            }
+    if (!memory_config.is_sharded() || layout != Layout::TILE) {
+        return std::nullopt;
+    }
+    const auto& tile_shape = tile.get_tile_shape();
+    if (memory_config.shard_spec().has_value()) {
+        const auto& physical_shard_shape = Shape2D(memory_config.shard_spec().value().shape);
+        if (!(physical_shard_shape.height() % tile_shape[0] == 0 &&
+              physical_shard_shape.width() % tile_shape[1] == 0)) {
+            return fmt::format("Physical shard shape {} must be tile {} sized!", physical_shard_shape, tile_shape);
+        }
+    } else {
+        const auto& shard_shape = memory_config.nd_shard_spec().value().shard_shape;
+        if (!(shard_shape[-2] % tile_shape[0] == 0 && shard_shape[-1] % tile_shape[1] == 0)) {
+            return fmt::format("Physical shard shape {} must be tile {} sized!", shard_shape, tile_shape);
         }
     }
     return std::nullopt;
@@ -155,8 +156,11 @@ TensorLayout::TensorLayout(
     initialize_alignment();
     CMAKE_UNIQUE_NAMESPACE::validate_alignment(*this);
 
-    auto shard_align_error = CMAKE_UNIQUE_NAMESPACE::get_shard_align_error(memory_config_, get_layout(), get_tile());
-    TT_FATAL(!shard_align_error.has_value(), "{}", shard_align_error);
+    if (get_layout() == Layout::TILE) {
+        auto shard_align_error =
+            CMAKE_UNIQUE_NAMESPACE::get_shard_align_error(memory_config_, get_layout(), get_tile());
+        TT_FATAL(!shard_align_error.has_value(), "{}", shard_align_error);
+    }
 }
 
 TensorLayout TensorLayout::fromPaddedShape(

--- a/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
+++ b/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
@@ -124,20 +124,19 @@ void validate_alignment(const TensorLayout& tensor_layout) {
 
 std::optional<std::string> get_shard_align_error(
     const MemoryConfig& memory_config, const Layout& layout, const Tile& tile) {
-    if (!memory_config.is_sharded() || layout != Layout::TILE) {
-        return std::nullopt;
-    }
-    const auto& tile_shape = tile.get_tile_shape();
-    if (memory_config.shard_spec().has_value()) {
-        const auto& physical_shard_shape = Shape2D(memory_config.shard_spec().value().shape);
-        if (!(physical_shard_shape.height() % tile_shape[0] == 0 &&
-              physical_shard_shape.width() % tile_shape[1] == 0)) {
-            return fmt::format("Physical shard shape {} must be tile {} sized!", physical_shard_shape, tile_shape);
-        }
-    } else {
-        const auto& shard_shape = memory_config.nd_shard_spec().value().shard_shape;
-        if (!(shard_shape[-2] % tile_shape[0] == 0 && shard_shape[-1] % tile_shape[1] == 0)) {
-            return fmt::format("Physical shard shape {} must be tile {} sized!", shard_shape, tile_shape);
+    if (memory_config.is_sharded() && layout == Layout::TILE) {
+        const auto& tile_shape = tile.get_tile_shape();
+        if (memory_config.shard_spec().has_value()) {
+            const auto& physical_shard_shape = Shape2D(memory_config.shard_spec().value().shape);
+            if (!(physical_shard_shape.height() % tile_shape[0] == 0 &&
+                  physical_shard_shape.width() % tile_shape[1] == 0)) {
+                return fmt::format("Physical shard shape {} must be tile {} sized!", physical_shard_shape, tile_shape);
+            }
+        } else {
+            const auto& shard_shape = memory_config.nd_shard_spec().value().shard_shape;
+            if (!(shard_shape[-2] % tile_shape[0] == 0 && shard_shape[-1] % tile_shape[1] == 0)) {
+                return fmt::format("Physical shard shape {} must be tile {} sized!", shard_shape, tile_shape);
+            }
         }
     }
     return std::nullopt;
@@ -156,11 +155,8 @@ TensorLayout::TensorLayout(
     initialize_alignment();
     CMAKE_UNIQUE_NAMESPACE::validate_alignment(*this);
 
-    if (get_layout() == Layout::TILE) {
-        auto shard_align_error =
-            CMAKE_UNIQUE_NAMESPACE::get_shard_align_error(memory_config_, get_layout(), get_tile());
-        TT_FATAL(!shard_align_error.has_value(), "{}", shard_align_error);
-    }
+    auto shard_align_error = CMAKE_UNIQUE_NAMESPACE::get_shard_align_error(memory_config_, get_layout(), get_tile());
+    TT_FATAL(!shard_align_error.has_value(), "{}", shard_align_error);
 }
 
 TensorLayout TensorLayout::fromPaddedShape(


### PR DESCRIPTION
### Summary

Warning regarding accessing tile metadata from a row major tensor has been added in #47161 .
However, the impact area was underestimated and has thus caused more log generation than intended.
This PR reverts unconditional warning when tile information is accessed in a row major tensor.

### Notes for reviewers

The warning is left in for non-trivial Tile configuration and retrievals, as those access pattern is bug prone.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/revert-pr-47161)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/revert-pr-47161)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/revert-pr-47161)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/revert-pr-47161)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/revert-pr-47161)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/revert-pr-47161)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/revert-pr-47161)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/revert-pr-47161)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/revert-pr-47161)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/revert-pr-47161)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/revert-pr-47161)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/revert-pr-47161)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/revert-pr-47161)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/revert-pr-47161)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/revert-pr-47161)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/revert-pr-47161)