### PR TITLE
tt_dit: add standalone media inference server (SDXL + Wan2.2 T2V) for ComfyUI

### DIFF
--- a/models/tt_dit/server/media/SDXL_SERVER_README.md
+++ b/models/tt_dit/server/media/SDXL_SERVER_README.md
@@ -1,0 +1,268 @@
+# SDXL Standalone Server - Quick Start Guide
+
+A standalone SDXL inference server that reproduces tt-media-server functionality using only tt-metal components.
+
+## Quick Start
+
+### 1. Start the Server
+
+```bash
+cd /home/tt-admin/tt-metal
+./launch_sdxl_server.sh
+```
+
+**Wait 5-10 minutes** for warmup. Server is ready when you see:
+```
+All workers ready. Server is accepting requests.
+```
+
+### 2. Generate an Image
+
+In a **new terminal**:
+
+```bash
+cd /home/tt-admin/tt-metal
+python image_test.py "Photograph of an orange Volcano on a tropical island while someone suntans on a beach with a friendly dinosaur"
+```
+
+Output saved to: `output.jpg`
+
+### 3. Validate Against Reference
+
+```bash
+python image_test.py \
+  "Photograph of an orange Volcano on a tropical island while someone suntans on a beach with a friendly dinosaur" \
+  --compare /home/tt-admin/tt-inference-server/reference_image.jpg \
+  --output test_output.jpg
+```
+
+Expected output:
+```
+MSE: ~400-500
+SSIM: ~0.92-0.95
+✓ Images are similar (SSIM >= 0.9)
+```
+
+---
+
+## Files Created
+
+### Configuration & Utilities
+- `sdxl_config.py` - Central configuration (T3K settings, device params)
+- `utils/logger.py` - Structured logging
+- `utils/image_utils.py` - Image encoding/decoding
+- `utils/validation_utils.py` - MSE/SSIM comparison
+
+### Core Components
+- `sdxl_runner.py` - TtSDXLPipeline wrapper with device management
+- `sdxl_worker.py` - Multiprocessing worker
+- `sdxl_server.py` - FastAPI server
+
+### Launcher & Client
+- `launch_sdxl_server.sh` - Environment setup + launcher
+- `image_test.py` - Test client with validation
+
+---
+
+## API Endpoints
+
+### Generate Image
+```bash
+curl -X POST http://127.0.0.1:8000/image/generations \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "A sunset over mountains",
+    "negative_prompt": "low quality",
+    "num_inference_steps": 50,
+    "guidance_scale": 5.0
+  }'
+```
+
+### Health Check
+```bash
+curl http://127.0.0.1:8000/health
+```
+
+Response:
+```json
+{
+  "status": "healthy",
+  "workers_alive": 1,
+  "workers_total": 1,
+  "queue_size": 0
+}
+```
+
+### Metrics
+```bash
+curl http://127.0.0.1:8000/metrics
+```
+
+---
+
+## image_test.py Usage
+
+### Basic Usage
+```bash
+python image_test.py "Your prompt here"
+```
+
+### With Options
+```bash
+python image_test.py "Your prompt" \
+  --output my_image.jpg \
+  --steps 30 \
+  --guidance 7.5 \
+  --server http://127.0.0.1:8000
+```
+
+### With Validation
+```bash
+python image_test.py "Your prompt" \
+  --compare reference.jpg \
+  --output test.jpg
+```
+
+**Exit codes:**
+- `0` - Success (SSIM >= 0.85)
+- `1` - Failure (SSIM < 0.85 or error)
+
+---
+
+## Configuration
+
+### Environment Variables (Set by launch script)
+```bash
+PYTHONPATH=/home/tt-admin/tt-metal
+TT_VISIBLE_DEVICES=0,1,2,3
+TT_METAL_HOME=/home/tt-admin/tt-metal
+TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE=7,7
+HF_HOME=/mnt/MLPerf/tt_dnn-models/hf_home
+TT_MM_THROTTLE_PERF=5
+```
+
+### Customize Settings
+
+Edit `sdxl_config.py`:
+
+```python
+@dataclass
+class SDXLConfig:
+    server_port: int = 8000              # Server port
+    num_inference_steps: int = 50        # Denoising steps (12-100)
+    guidance_scale: float = 5.0          # CFG scale (1.0-20.0)
+    vae_on_device: bool = True           # VAE on TT hardware
+    encoders_on_device: bool = True      # Encoders on TT hardware
+    capture_trace: bool = True           # Enable tracing
+    # ... more options
+```
+
+---
+
+## Performance
+
+- **Startup Time**: 5-10 minutes (model loading + warmup)
+- **Inference Time**: 3-5 seconds per image (50 steps)
+- **Memory Usage**: 40-60 GB RAM
+- **Device Utilization**: All 4 T3K devices
+
+---
+
+## Troubleshooting
+
+### Server won't start
+
+**Error**: `Python environment not found`
+```bash
+cd /home/tt-admin/tt-metal
+./create_venv.sh
+```
+
+**Error**: `No TTNN devices available`
+```bash
+tt-smi          # Check devices
+tt-smi -r       # Reset if needed
+```
+
+### Can't connect to server
+
+**Check if server is running:**
+```bash
+curl http://127.0.0.1:8000/health
+```
+
+**Check logs:**
+- Look for errors in server terminal
+- Check: "All workers ready" message appeared
+
+### Images differ from reference
+
+**Note**: Generative models have natural variation
+- SSIM >= 0.9: Excellent similarity
+- SSIM 0.85-0.9: Good similarity (expected)
+- SSIM < 0.85: Significant difference
+
+**For exact reproduction**: Use same seed in both generations
+
+### Worker timeout during warmup
+
+**Increase timeout** in `sdxl_server.py:80`:
+```python
+timeout = time.time() + 900  # 15 minutes instead of 10
+```
+
+---
+
+## Architecture
+
+```
+HTTP Request → FastAPI → Task Queue → Worker → TtSDXLPipeline → Result Queue → HTTP Response
+```
+
+**Components:**
+- **FastAPI Server**: Handles HTTP requests, manages queues
+- **Worker Process**: Runs inference on TT devices
+- **SDXLRunner**: Wraps TtSDXLPipeline with device management
+- **TtSDXLPipeline**: tt-metal core (UNet, VAE, Scheduler, Encoders)
+
+---
+
+## Dependencies
+
+Most dependencies come from tt-metal's `python_env`:
+- `diffusers` - SDXL pipeline
+- `transformers` - CLIP encoders
+- `torch` - PyTorch
+- `pydantic` - Validation
+- `scikit-image` - SSIM calculation
+- `Pillow` - Image processing
+
+Server-only dependencies live in `requirements-server.txt` (kept out of tt-metal's
+`requirements-dev.txt` so this server is a zero-edit overlay on the upstream env).
+The launch scripts install them automatically; to install manually:
+
+```bash
+pip install -r requirements-server.txt
+```
+
+- `fastapi` - Web framework
+- `uvicorn` - ASGI server
+
+---
+
+## Success Criteria
+
+✓ Server starts and completes warmup within 10 minutes
+✓ Health endpoint returns "healthy" status
+✓ `image_test.py` successfully generates images
+✓ Generated images have SSIM >= 0.9 vs reference
+✓ Inference time is 3-5 seconds per image
+✓ Server handles multiple sequential requests
+
+---
+
+## Additional Documentation
+
+- **SDXL_PIPELINE_ARCHITECTURE.md** - Detailed pipeline architecture
+- **ORIGINAL_METAL_SDXL.md** - tt-metal vs tt-media-server comparison
+- Plan file: `.claude/plans/glistening-jumping-mountain.md` - Full implementation plan

--- a/models/tt_dit/server/media/device_specs.py
+++ b/models/tt_dit/server/media/device_specs.py
@@ -1,0 +1,289 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+"""
+Explicit Tenstorrent board / device-class specification for the standalone
+SDXL and Wan2.2 media servers.
+
+The taxonomy mirrors tt-inference-server/workflows/workflow_types.py so that
+this module can later be unified with that one.
+
+- DeviceClass : enum of supported board / cluster identities
+- BoardSpec   : per-board static facts (descriptor file, arch, env vars,
+                which models are supported)
+- DeploymentSpec : per-(model, board) deployment shape (num_workers, mesh
+                   shape, device ids, fabric config)
+
+Only boards that have a concrete deployment row in DEPLOYMENTS are declared
+in BOARD_SPECS. Asking for a DeviceClass without a BoardSpec entry raises
+"not supported yet" — this keeps the registry honest.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from enum import IntEnum, auto
+from typing import Dict, FrozenSet, Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# DeviceClass — full taxonomy mirrored from tt-inference-server
+# ---------------------------------------------------------------------------
+
+
+class DeviceClass(IntEnum):
+    """Tenstorrent board / cluster identity.
+
+    Mirrors tt-inference-server/workflows/workflow_types.py:DeviceTypes so
+    `DeviceClass.from_string("p300")` resolves the same names a user would
+    pass on the inference-server CLI.
+    """
+
+    # Wormhole_B0
+    N150 = auto()
+    N300 = auto()
+    T3K = auto()
+    GALAXY_T3K = auto()
+    GALAXY = auto()
+    DUAL_GALAXY = auto()
+    QUAD_GALAXY = auto()
+
+    # Blackhole
+    P100 = auto()
+    P150 = auto()
+    P150X2 = auto()
+    P150X4 = auto()
+    P150X8 = auto()
+    P300 = auto()
+    P300X2 = auto()
+
+    @classmethod
+    def from_string(cls, name: str) -> "DeviceClass":
+        """Parse 'p300', 'P300', 'p300x2', 'P300X2' etc."""
+        try:
+            return cls[name.upper()]
+        except KeyError:
+            valid = ", ".join(m.name.lower() for m in cls)
+            raise ValueError(f"Unknown device class '{name}'. Valid: {valid}")
+
+
+GALAXY_BOARDS: FrozenSet[DeviceClass] = frozenset(
+    {DeviceClass.GALAXY, DeviceClass.GALAXY_T3K, DeviceClass.DUAL_GALAXY, DeviceClass.QUAD_GALAXY}
+)
+
+
+def is_galaxy(board: DeviceClass) -> bool:
+    return board in GALAXY_BOARDS
+
+
+# ---------------------------------------------------------------------------
+# BoardSpec — static, per-board facts
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BoardSpec:
+    """Static facts about a Tenstorrent board.
+
+    Fields are intentionally narrow: anything that varies by *model* (mesh
+    shape, num_workers, fabric config) lives in DeploymentSpec instead.
+
+    `core_grid_override` is the value for TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE;
+    None means do not set the env var (use the device's native compute grid).
+    Mirrors tt-inference-server/tt-media-server/utils/runner_utils.py:112-122.
+
+    `l1_small_size` matches SDXL_L1_SMALL_SIZE / SDXL_L1_SMALL_SIZE_BH from
+    models/demos/stable_diffusion_xl_base/tests/test_common.py:26-27.
+    """
+
+    descriptor_filename: str
+    arch: str  # "wormhole_b0" | "blackhole"
+    chip_count: int
+    extra_env_vars: Dict[str, str] = field(default_factory=dict)
+    supports_models: FrozenSet[str] = field(default_factory=frozenset)
+    core_grid_override: Optional[str] = None
+    l1_small_size: int = 32000
+    trace_region_size: int = 34541598  # Wormhole-tuned default (matches tt-media-server)
+
+
+BOARD_SPECS: Dict[DeviceClass, BoardSpec] = {
+    DeviceClass.T3K: BoardSpec(
+        descriptor_filename="t3k_mesh_graph_descriptor.textproto",
+        arch="wormhole_b0",
+        chip_count=8,
+        supports_models=frozenset({"sdxl", "wan22"}),
+        core_grid_override="7,7",  # Wormhole-tuned SDXL configs use (5,8)=40 cores; 8x8=64 fits.
+        l1_small_size=32000,  # SDXL_L1_SMALL_SIZE
+    ),
+    DeviceClass.P150: BoardSpec(
+        descriptor_filename="p150_mesh_graph_descriptor.textproto",
+        arch="blackhole",
+        chip_count=1,
+        supports_models=frozenset({"sdxl"}),
+        core_grid_override=None,  # Native BH grid; model_configs_1024x1024BH.py wants (10,8)=80 cores.
+        l1_small_size=38000,  # SDXL_L1_SMALL_SIZE_BH
+        trace_region_size=56_000_000,  # BH SDXL trace ~41MB measured; round up for headroom.
+    ),
+    DeviceClass.P150X4: BoardSpec(
+        descriptor_filename="p150_x4_mesh_graph_descriptor.textproto",
+        arch="blackhole",
+        chip_count=4,
+        supports_models=frozenset({"wan22"}),
+        core_grid_override=None,
+        l1_small_size=38000,
+        trace_region_size=30_000_000,  # per model_spec.py wan22 override.
+    ),
+    DeviceClass.P150X8: BoardSpec(
+        descriptor_filename="p150_x8_mesh_graph_descriptor.textproto",
+        arch="blackhole",
+        chip_count=8,
+        supports_models=frozenset({"wan22"}),
+        core_grid_override=None,
+        l1_small_size=38000,
+        trace_region_size=30_000_000,
+    ),
+    DeviceClass.P300: BoardSpec(
+        descriptor_filename="p300_mesh_graph_descriptor.textproto",
+        arch="blackhole",
+        chip_count=2,
+        supports_models=frozenset({"sdxl"}),
+        core_grid_override=None,
+        l1_small_size=38000,
+        trace_region_size=56_000_000,  # BH SDXL trace ~41MB measured; round up for headroom.
+    ),
+    DeviceClass.P300X2: BoardSpec(
+        descriptor_filename="p300_x2_mesh_graph_descriptor.textproto",
+        arch="blackhole",
+        chip_count=4,
+        supports_models=frozenset({"sdxl", "wan22"}),
+        core_grid_override=None,
+        l1_small_size=38000,
+        trace_region_size=56_000_000,  # BH SDXL trace ~41MB measured; round up for headroom.
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# DeploymentSpec — per-(model, board) deployment shape
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DeploymentSpec:
+    num_workers: int
+    mesh_shape: Tuple[int, int]  # passed to ttnn.MeshShape per worker
+    device_ids: Tuple[int, ...]
+    fabric_config: Optional[str] = None  # e.g. "FABRIC_1D"
+
+
+# Keyed by (model_name, board). Model names match server.py --model choices.
+DEPLOYMENTS: Dict[Tuple[str, DeviceClass], DeploymentSpec] = {
+    ("sdxl", DeviceClass.T3K): DeploymentSpec(
+        num_workers=4,
+        mesh_shape=(1, 1),
+        device_ids=(0, 1, 2, 3),
+    ),
+    ("sdxl", DeviceClass.P150): DeploymentSpec(
+        num_workers=1,
+        mesh_shape=(1, 1),
+        device_ids=(0,),
+    ),
+    ("sdxl", DeviceClass.P300): DeploymentSpec(
+        num_workers=1,
+        # (TP, DP) — multi-chip SDXL must use TP layout so cfg_parallel kicks in.
+        # Mirrors tt-media-server convention (config/constants.py: N300/T3K = (2,1)).
+        mesh_shape=(2, 1),
+        device_ids=(0, 1),
+        fabric_config="FABRIC_1D",
+    ),
+    ("sdxl", DeviceClass.P300X2): DeploymentSpec(
+        num_workers=1,
+        # 4-chip BH host: SDXL uses TP=2 only (matches tt-media-server T3K
+        # convention). DP=2 (mesh (2,2)) trips a CLIP-token shard mismatch
+        # in distributed_tensor.cpp:77 — TtSDXLPipeline doesn't support
+        # data-parallel for the text encoder shard layout.
+        mesh_shape=(2, 1),
+        device_ids=(0, 1),
+        fabric_config="FABRIC_1D",
+    ),
+    # Wan2.2 mesh shapes mirror tt-media-server/config/constants.py and are
+    # validated against tt-metal's WanPipeline.create_pipeline default_config
+    # (pipelines/wan/pipeline_wan.py:383-419).
+    ("wan22", DeviceClass.T3K): DeploymentSpec(
+        num_workers=1,
+        mesh_shape=(2, 4),
+        device_ids=(0, 1, 2, 3),  # PCIe L chips; R chips auto-discovered via fabric.
+        fabric_config="FABRIC_1D",
+    ),
+    ("wan22", DeviceClass.P150X4): DeploymentSpec(
+        num_workers=1,
+        mesh_shape=(1, 4),
+        device_ids=(0, 1, 2, 3),
+        fabric_config="FABRIC_1D",
+    ),
+    ("wan22", DeviceClass.P150X8): DeploymentSpec(
+        num_workers=1,
+        mesh_shape=(2, 4),
+        device_ids=(0, 1, 2, 3, 4, 5, 6, 7),
+        fabric_config="FABRIC_1D",
+    ),
+    ("wan22", DeviceClass.P300X2): DeploymentSpec(
+        num_workers=1,
+        mesh_shape=(2, 2),
+        device_ids=(0, 1, 2, 3),
+        fabric_config="FABRIC_1D",
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def get_board_spec(board: DeviceClass) -> BoardSpec:
+    """Return the BoardSpec for `board`, or raise with a useful message."""
+    spec = BOARD_SPECS.get(board)
+    if spec is None:
+        supported = ", ".join(b.name.lower() for b in BOARD_SPECS)
+        raise ValueError(
+            f"Board '{board.name.lower()}' is recognized but not supported yet. " f"Supported boards: {supported}"
+        )
+    return spec
+
+
+def get_deployment(model: str, board: DeviceClass) -> DeploymentSpec:
+    """Return the DeploymentSpec for (model, board), or raise."""
+    dep = DEPLOYMENTS.get((model, board))
+    if dep is None:
+        valid_for_model = sorted(b.name.lower() for (m, b) in DEPLOYMENTS if m == model)
+        raise ValueError(
+            f"No deployment defined for model={model!r} board={board.name.lower()!r}. "
+            f"Valid boards for {model!r}: {valid_for_model or '(none)'}"
+        )
+    return dep
+
+
+def descriptor_path(board: DeviceClass) -> str:
+    """Resolve absolute path to the mesh-graph descriptor for `board`.
+
+    Anchored on TT_METAL_HOME (matching the existing convention in worker.py),
+    falling back to the current working directory.
+    """
+    spec = get_board_spec(board)
+    tt_metal_home = os.environ.get("TT_METAL_HOME") or os.getcwd()
+    return os.path.join(tt_metal_home, "tt_metal", "fabric", "mesh_graph_descriptors", spec.descriptor_filename)
+
+
+def validate_model_board(model: str, board: DeviceClass) -> None:
+    """Fail fast with a clear message if (model, board) isn't supported."""
+    spec = get_board_spec(board)
+    if model not in spec.supports_models:
+        supported = ", ".join(sorted(spec.supports_models)) or "(none)"
+        raise ValueError(
+            f"Model {model!r} is not supported on board {board.name.lower()!r}. "
+            f"Supported models for this board: {supported}"
+        )
+    # Also require an explicit deployment row.
+    get_deployment(model, board)

--- a/models/tt_dit/server/media/launch_server.sh
+++ b/models/tt_dit/server/media/launch_server.sh
@@ -66,7 +66,17 @@ source "${TT_METAL_HOME}/python_env/bin/activate"
 # ---------------------------------------------------------------------------
 if ! python -c "import fastapi, uvicorn" 2>/dev/null; then
     echo "Installing server dependencies from requirements-server.txt..."
-    pip install -q -r "${SCRIPT_DIR}/requirements-server.txt"
+    VENV_PY="${TT_METAL_HOME}/python_env/bin/python"
+    REQ_FILE="${SCRIPT_DIR}/requirements-server.txt"
+    # python_env is created by uv and has no pip, so install with uv. Fall back to
+    # bootstrapping pip via ensurepip only if uv is unavailable.
+    UV_BIN="$(command -v uv || echo "${HOME}/.local/bin/uv")"
+    if [ -x "${UV_BIN}" ]; then
+        "${UV_BIN}" pip install --python "${VENV_PY}" -r "${REQ_FILE}"
+    else
+        "${VENV_PY}" -m ensurepip --upgrade >/dev/null 2>&1 || true
+        "${VENV_PY}" -m pip install -r "${REQ_FILE}"
+    fi
 fi
 
 # ---------------------------------------------------------------------------

--- a/models/tt_dit/server/media/launch_server.sh
+++ b/models/tt_dit/server/media/launch_server.sh
@@ -1,0 +1,256 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# Exit on error
+set -e
+
+echo "=== Unified Media Generation Server Launcher ==="
+
+# ---------------------------------------------------------------------------
+# Parse --model flag (must be done before any environment setup)
+# ---------------------------------------------------------------------------
+MODEL="sdxl"
+for arg in "$@"; do
+    if [ "$arg" = "--model" ]; then
+        # Next argument will be the model name — handled by the loop below
+        NEXT_IS_MODEL=true
+    elif [ "${NEXT_IS_MODEL:-false}" = "true" ]; then
+        MODEL="$arg"
+        NEXT_IS_MODEL=false
+    fi
+done
+
+if [ "$MODEL" != "sdxl" ] && [ "$MODEL" != "wan22" ]; then
+    echo "Error: --model must be 'sdxl' or 'wan22' (got: '$MODEL')"
+    exit 1
+fi
+
+echo "Model: $MODEL"
+
+# ---------------------------------------------------------------------------
+# Setup logging
+# ---------------------------------------------------------------------------
+LOG_FILE="${MODEL}_server_$(date +%Y%m%d_%H%M%S).log"
+exec 1> >(tee -a "$LOG_FILE")
+exec 2>&1
+echo "Logging to: $LOG_FILE"
+
+# ---------------------------------------------------------------------------
+# Resolve script directory
+# ---------------------------------------------------------------------------
+# This script lives at models/tt_dit/server/media/ — the repo root (TT_METAL_HOME)
+# is four levels up. server.py and its sibling modules live alongside this script.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export TT_METAL_HOME="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+# Run from the repo root so the worker's TT_METAL_HOME=os.getcwd() resolves correctly.
+cd "${TT_METAL_HOME}"
+
+# ---------------------------------------------------------------------------
+# Activate Python environment
+# ---------------------------------------------------------------------------
+echo "Activating Python environment..."
+if [ ! -f "${TT_METAL_HOME}/python_env/bin/activate" ]; then
+    echo "Error: Python environment not found at ${TT_METAL_HOME}/python_env"
+    echo "Please run: ./create_venv.sh"
+    exit 1
+fi
+
+source "${TT_METAL_HOME}/python_env/bin/activate"
+
+# ---------------------------------------------------------------------------
+# Install server-only dependencies (kept out of tt-metal's requirements-dev.txt
+# so this server is a zero-edit overlay on the upstream environment)
+# ---------------------------------------------------------------------------
+if ! python -c "import fastapi, uvicorn" 2>/dev/null; then
+    echo "Installing server dependencies from requirements-server.txt..."
+    pip install -q -r "${SCRIPT_DIR}/requirements-server.txt"
+fi
+
+# ---------------------------------------------------------------------------
+# Common environment variables (both models)
+# ---------------------------------------------------------------------------
+export PYTHONPATH="${TT_METAL_HOME}:${SCRIPT_DIR}"
+export LD_LIBRARY_PATH="${TT_METAL_HOME}/build/lib:${LD_LIBRARY_PATH}"
+export HF_HOME="${HOME}/.cache/huggingface"
+export TTNN_CONFIG_OVERRIDES='{"enable_model_cache": true, "model_cache_path": "'${HOME}'/.cache/ttnn/models"}'
+export LOG_LEVEL="${LOG_LEVEL:-INFO}"
+
+# ---------------------------------------------------------------------------
+# Detect available TT devices via tt-smi, set TT_VISIBLE_DEVICES, and validate
+# ---------------------------------------------------------------------------
+echo ""
+echo "Detecting TT devices..."
+TT_SMI_VENV="/home/tt-admin/tt-smi/venv"
+DETECTED_DEVICE_COUNT=0
+DETECTED_DEVICE_IDS=""
+
+if [ ! -f "${TT_SMI_VENV}/bin/activate" ]; then
+    echo "Warning: tt-smi venv not found at ${TT_SMI_VENV}, skipping device detection"
+else
+    source "${TT_SMI_VENV}/bin/activate"
+
+    DEVICE_INFO=$(tt-smi -s --snapshot_no_tty 2>/dev/null | python3 -c '
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    # Count ALL devices: PCIe-attached (n300 L) and remote (n300 R).
+    # On a LoudBox, 4 n300 boards each have L (PCIe) + R (ethernet) chip = 8 total.
+    # The R chips have bus_id="N/A" but are still valid TT devices.
+    devices = data.get("device_info", [])
+    pcie_ids = [str(i) for i, dev in enumerate(devices)
+                if dev.get("board_info", {}).get("bus_id", "N/A") != "N/A"]
+    ids = ",".join(pcie_ids)
+    print(f"{len(devices)}:{ids}")
+    for i, dev in enumerate(devices):
+        board_info = dev.get("board_info", {})
+        bus = board_info.get("bus_id", "N/A")
+        btype = board_info.get("board_type", "Unknown")
+        loc = "(PCIe)" if bus != "N/A" else "(remote)"
+        print(f"  Device {i}: {btype} {loc} bus={bus}", file=sys.stderr)
+except Exception as e:
+    print(f"0:", file=sys.stdout)
+    print(f"  Error: {e}", file=sys.stderr)
+' 2>/tmp/tt_device_info_$$.txt)
+
+    cat /tmp/tt_device_info_$$.txt  # Print device list to stdout
+    rm -f /tmp/tt_device_info_$$.txt
+
+    DETECTED_DEVICE_COUNT=$(echo "$DEVICE_INFO" | cut -d: -f1)
+    DETECTED_DEVICE_IDS=$(echo "$DEVICE_INFO" | cut -d: -f2)
+
+    echo "Detected ${DETECTED_DEVICE_COUNT} TT device(s) (PCIe + remote)"
+
+    deactivate
+fi
+
+# ---------------------------------------------------------------------------
+# Set TT_VISIBLE_DEVICES based on detected devices (not hardcoded)
+# SDXL requires at least 1 device. Wan2.2 topology is board-derived.
+# ---------------------------------------------------------------------------
+if [ "$MODEL" = "sdxl" ]; then
+    if [ "${DETECTED_DEVICE_COUNT}" -gt 0 ] 2>/dev/null && [ -n "$DETECTED_DEVICE_IDS" ]; then
+        # Use detected IDs, capped at 4 for SDXL (T3K: 4 devices)
+        SDXL_IDS=$(echo "$DETECTED_DEVICE_IDS" | python3 -c "
+import sys
+ids = sys.stdin.read().strip().split(',')
+print(','.join(ids[:4]))
+")
+        export TT_VISIBLE_DEVICES="$SDXL_IDS"
+        export TT_METAL_VISIBLE_DEVICES="$SDXL_IDS"
+    else
+        # Fall back to assuming 4 devices (T3K default)
+        export TT_VISIBLE_DEVICES="0,1,2,3"
+        export TT_METAL_VISIBLE_DEVICES="0,1,2,3"
+    fi
+    export TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="7,7"
+    export TT_MM_THROTTLE_PERF=5
+
+elif [ "$MODEL" = "wan22" ]; then
+    # Wan2.2 T2V is board-aware: a single worker owns the full mesh and the
+    # worker process (setup_wan_worker_environment in worker.py) derives
+    # TT_VISIBLE_DEVICES, TT_MESH_GRAPH_DESC_PATH, and per-board env vars from
+    # --board via device_specs. No shell-level device pinning is needed here;
+    # --board is required and is passed through to server.py.
+    echo "Wan2.2: topology is board-derived (--board). No shell-level device pinning."
+fi
+
+# ---------------------------------------------------------------------------
+# Handle --clear-cache flag
+# ---------------------------------------------------------------------------
+for arg in "$@"; do
+    if [ "$arg" = "--clear-cache" ]; then
+        echo ""
+        echo "Clearing caches..."
+        rm -rf "${HOME}/.cache/tt-metal-cache"
+        rm -rf "${HOME}/.cache/ttnn/models"
+        echo "Caches cleared (this will trigger recompilation on next startup)"
+        break
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Handle --dev flag
+# ---------------------------------------------------------------------------
+DEV_MODE=false
+for arg in "$@"; do
+    if [ "$arg" = "--dev" ]; then
+        DEV_MODE=true
+        if [ "$MODEL" = "sdxl" ]; then
+            # SDXL dev mode: single device only
+            export SDXL_DEV_MODE=true
+            export TT_VISIBLE_DEVICES="0"
+            export TT_METAL_VISIBLE_DEVICES="0"
+            echo ""
+            echo "*** SDXL DEV MODE: Single worker, fast startup ***"
+        elif [ "$MODEL" = "wan22" ]; then
+            # Wan2.2 dev mode (WAN_DEV_MODE) is set by server.py from --dev;
+            # it reduces steps/frames and disables trace. Nothing to set here.
+            echo ""
+            echo "*** Wan2.2 DEV MODE: Reduced steps/frames, no trace capture ***"
+        fi
+        break
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Print effective environment
+# ---------------------------------------------------------------------------
+echo ""
+echo "Environment configured:"
+echo "  MODEL:           $MODEL"
+echo "  TT_METAL_HOME:   $TT_METAL_HOME"
+echo "  PYTHONPATH:      $PYTHONPATH"
+echo "  TT_VISIBLE_DEVICES: $TT_VISIBLE_DEVICES"
+echo "  HF_HOME:         $HF_HOME"
+echo "  LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
+
+# ---------------------------------------------------------------------------
+# Build Python argument list (strip script-only flags)
+# ---------------------------------------------------------------------------
+PYTHON_ARGS=()
+SKIP_NEXT=false
+for arg in "$@"; do
+    if [ "${SKIP_NEXT}" = "true" ]; then
+        SKIP_NEXT=false
+        continue
+    fi
+    if [ "$arg" = "--clear-cache" ]; then
+        # Handled above, not passed to Python
+        continue
+    fi
+    if [ "$arg" = "--model" ]; then
+        # --model is consumed here; pass it along to server.py too
+        PYTHON_ARGS+=("$arg")
+        SKIP_NEXT=false  # Next value will be appended naturally
+        continue
+    fi
+    PYTHON_ARGS+=("$arg")
+done
+
+# ---------------------------------------------------------------------------
+# Start server
+# ---------------------------------------------------------------------------
+echo ""
+if [ "$DEV_MODE" = "true" ]; then
+    echo "Starting ${MODEL} server in DEV MODE..."
+    if [ "$MODEL" = "wan22" ]; then
+        echo "This will take 2-5 minutes (no trace capture in dev mode)."
+    else
+        echo "This will take 5-8 minutes for initial warmup."
+    fi
+else
+    echo "Starting ${MODEL} server..."
+    if [ "$MODEL" = "wan22" ]; then
+        echo "This will take 15-25 minutes for first-run trace capture."
+    else
+        echo "This will take 5-10 minutes for initial warmup."
+    fi
+fi
+echo "Server will be ready when you see: 'All workers ready. ${MODEL} server is accepting requests.'"
+echo "Press Ctrl+C to stop the server."
+echo ""
+
+"${TT_METAL_HOME}/python_env/bin/python" "${SCRIPT_DIR}/server.py" "${PYTHON_ARGS[@]}"

--- a/models/tt_dit/server/media/requirements-server.txt
+++ b/models/tt_dit/server/media/requirements-server.txt
@@ -1,0 +1,8 @@
+# Python dependencies for the standalone media inference server (server.py).
+#
+# These are intentionally kept OUT of tt_metal/python_env/requirements-dev.txt so
+# this server stays a purely additive overlay on tt-metal with zero edits to the
+# upstream environment. launch_server.sh installs these into the active python_env
+# on startup.
+fastapi==0.115.12
+uvicorn==0.34.0

--- a/models/tt_dit/server/media/sdxl_config.py
+++ b/models/tt_dit/server/media/sdxl_config.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import os
+from dataclasses import dataclass, field
+from typing import Tuple
+
+from device_specs import DeviceClass, get_board_spec, get_deployment, is_galaxy
+
+
+@dataclass
+class SDXLConfig:
+    """Configuration for SDXL standalone server.
+
+    Topology fields (num_workers, device_mesh_shape, device_ids) are derived
+    from device_specs.DEPLOYMENTS based on `board`. They are filled in during
+    __post_init__ — do not set them manually.
+    """
+
+    # Required: which Tenstorrent board this server is running on.
+    board: DeviceClass = None  # set explicitly via CLI; validated in __post_init__
+
+    # Server settings
+    server_host: str = "127.0.0.1"
+    server_port: int = 8000
+
+    # Topology — derived from device_specs.get_deployment("sdxl", board) in __post_init__.
+    num_workers: int = 0
+    device_ids: Tuple[int, ...] = ()
+    device_mesh_shape: Tuple[int, int] = (0, 0)
+
+    # Device parameters — l1_small_size and trace_region_size are derived from
+    # BoardSpec in __post_init__. Pass a non-zero value at construction time to
+    # override (ad-hoc tuning).
+    l1_small_size: int = 0
+    trace_region_size: int = 0
+
+    # Model settings
+    model_name: str = "stabilityai/stable-diffusion-xl-base-1.0"
+    hf_home: str = os.getenv("HF_HOME", os.path.expanduser("~/.cache/huggingface"))
+
+    # Pipeline settings
+    num_inference_steps: int = 50
+    guidance_scale: float = 5.0
+    capture_trace: bool = True  # Re-enabled - trace is required for performance
+    vae_on_device: bool = True
+    encoders_on_device: bool = True
+    use_cfg_parallel: bool = False
+
+    # Queue settings
+    max_queue_size: int = 64
+    max_batch_size: int = 1  # Stable for (1,1) mesh
+    inference_timeout_seconds: int = 300
+
+    # Development mode settings
+    dev_mode: bool = field(default_factory=lambda: os.getenv("SDXL_DEV_MODE", "false").lower() == "true")
+
+    def __post_init__(self):
+        """Resolve topology from board, then apply dev_mode overrides."""
+        if self.board is None:
+            raise ValueError("SDXLConfig.board is required (pass --board on the CLI)")
+
+        dep = get_deployment("sdxl", self.board)
+        self.num_workers = dep.num_workers
+        self.device_mesh_shape = dep.mesh_shape
+        self.device_ids = dep.device_ids
+
+        # Derive use_cfg_parallel from mesh layout. Mirrors tt-media-server's
+        # base_device_runner.is_tensor_parallel = device_mesh_shape[0] > 1
+        # and sdxl_generate_runner_trace.py: use_cfg_parallel=is_tensor_parallel.
+        # Multi-chip TP layouts must run in cfg_parallel mode; otherwise the
+        # text_embeds reshape gate at test_common.py:944 fires with the wrong
+        # batch size.
+        self.use_cfg_parallel = self.device_mesh_shape[0] > 1
+
+        # Per-board L1 / trace region sizes (WH vs BH differ); explicit non-zero overrides.
+        spec = get_board_spec(self.board)
+        if not self.l1_small_size:
+            self.l1_small_size = spec.l1_small_size
+        if not self.trace_region_size:
+            self.trace_region_size = spec.trace_region_size
+
+        if self.dev_mode:
+            self.num_workers = 1  # Single worker for faster startup
+            self.num_inference_steps = 20  # Fewer steps for faster warmup
+            self.device_ids = (self.device_ids[0],) if self.device_ids else (0,)
+
+    @property
+    def is_galaxy(self) -> bool:
+        """Derived from `board`. Preserved as a property so existing call
+        sites (e.g. sdxl_runner.py passing into TtSDXLPipelineConfig) keep
+        working without changes."""
+        return is_galaxy(self.board)

--- a/models/tt_dit/server/media/sdxl_runner.py
+++ b/models/tt_dit/server/media/sdxl_runner.py
@@ -1,0 +1,435 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import os
+from typing import List
+
+import numpy as np
+import torch
+from diffusers import DiffusionPipeline
+from PIL import Image
+from sdxl_config import SDXLConfig
+from utils.image_utils import tensor_to_pil
+from utils.logger import setup_logger
+
+import ttnn
+from models.demos.stable_diffusion_xl_base.tests.test_common import SDXL_FABRIC_CONFIG
+from models.demos.stable_diffusion_xl_base.tt.tt_sdxl_pipeline import TtSDXLPipeline, TtSDXLPipelineConfig
+
+
+class SDXLRunner:
+    """
+    Wrapper for TtSDXLPipeline that handles device initialization,
+    model loading, warmup, and inference execution.
+
+    Based on:
+    - /home/tt-admin/tt-inference-server/tt-media-server/tt_model_runners/sdxl_generate_runner_trace.py
+    - /home/tt-admin/tt-metal/models/demos/stable_diffusion_xl_base/demo/demo.py
+    """
+
+    def __init__(self, worker_id: int, config: SDXLConfig):
+        self.worker_id = worker_id
+        self.config = config
+        self.logger = setup_logger(f"SDXLRunner-{worker_id}")
+        self.ttnn_device = None
+        self.pipeline = None
+        self.tt_sdxl = None
+        # Currently fused LoRA, tracked as (lora_path, scale_unet, scale_clip). None = base
+        # weights. Lets repeated requests with the same adapter skip the
+        # unload/reload/fuse cycle.
+        self._current_lora = None
+        # Status of the most recently applied LoRA (surfaced to the client so the
+        # UI can warn when an adapter is skipped/partial). None = no LoRA active.
+        self._last_lora_status = None
+
+    def initialize_device(self):
+        """Initialize mesh device with proper configuration"""
+        self.logger.info(f"Initializing device for worker {self.worker_id}")
+
+        # Skip validation - launch script already validated devices
+        # ttnn will handle device availability during initialization
+
+        # When num_workers > 1 (e.g. T3K: 4 workers × 1×1 mesh), each worker
+        # owns one chip and we re-pin TT_VISIBLE_DEVICES to that single chip.
+        # When num_workers == 1, the worker uses all chips in config.device_ids
+        # for its mesh — leave the visibility env vars as worker.py set them.
+        if self.config.num_workers > 1:
+            worker_device_id = str(self.config.device_ids[self.worker_id % len(self.config.device_ids)])
+            os.environ["TT_VISIBLE_DEVICES"] = worker_device_id
+            os.environ["TT_METAL_VISIBLE_DEVICES"] = worker_device_id
+            self.logger.info(f"Worker {self.worker_id} pinned to device {worker_device_id}")
+        else:
+            self.logger.info(
+                f"Worker {self.worker_id} using all devices "
+                f"{self.config.device_ids} for {self.config.device_mesh_shape} mesh"
+            )
+
+        # Per-board compute-grid override. Wormhole-tuned boards (T3K) need
+        # the legacy "7,7" cap; Blackhole P-series must use the device's
+        # native compute grid so model_configs_1024x1024BH.py's (10,8)=80-core
+        # matmul sharding fits. Mirrors tt-inference-server's
+        # tt-media-server/utils/runner_utils.py:_setup_grid_override.
+        from device_specs import get_board_spec
+
+        override = get_board_spec(self.config.board).core_grid_override
+        if override:
+            os.environ["TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE"] = override
+            self.logger.info(f"Set TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE={override}")
+        else:
+            os.environ.pop("TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE", None)
+            self.logger.info("Using native compute grid (no TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE)")
+
+        dispatch_core_config = ttnn.DispatchCoreConfig()  # Uses system defaults
+        rows, cols = self.config.device_mesh_shape
+
+        # Multi-chip tensor-parallel layouts (rows > 1) need fabric for the
+        # all_gather_async ops inside cfg_parallel mode. Mirrors
+        # tt-media-server/tt_model_runners/base_sdxl_runner.py:35-58 +
+        # base_metal_device_runner.py: ttnn.set_fabric_config(SDXL_FABRIC_CONFIG)
+        # when is_tensor_parallel.
+        if rows > 1:
+            ttnn.set_fabric_config(SDXL_FABRIC_CONFIG)
+            self.logger.info(f"Set fabric config: {SDXL_FABRIC_CONFIG}")
+
+        self.ttnn_device = ttnn.open_mesh_device(
+            mesh_shape=ttnn.MeshShape(rows, cols),
+            l1_small_size=self.config.l1_small_size,
+            trace_region_size=self.config.trace_region_size,
+            dispatch_core_config=dispatch_core_config,
+        )
+
+        self.logger.info(f"Device initialized with mesh shape {self.config.device_mesh_shape}")
+        return self.ttnn_device
+
+    def load_model(self, kernel_ready_queue=None):
+        """Load HuggingFace pipeline and create TtSDXLPipeline with warmup
+
+        Args:
+            kernel_ready_queue: Optional queue to signal when kernel compilation is complete
+                               (allows next worker to start before program cache warmup finishes)
+        """
+        self.logger.info("Loading SDXL model...")
+
+        # Load torch pipeline (auto-downloads if not cached)
+        self.pipeline = DiffusionPipeline.from_pretrained(
+            self.config.model_name,
+            torch_dtype=torch.float32,
+            use_safetensors=True,
+            cache_dir=self.config.hf_home,
+        )
+        self.logger.info("HuggingFace pipeline loaded")
+
+        # Create TtSDXLPipeline
+        self.tt_sdxl = TtSDXLPipeline(
+            ttnn_device=self.ttnn_device,
+            torch_pipeline=self.pipeline,
+            pipeline_config=TtSDXLPipelineConfig(
+                encoders_on_device=self.config.encoders_on_device,
+                num_inference_steps=self.config.num_inference_steps,
+                guidance_scale=self.config.guidance_scale,
+                is_galaxy=self.config.is_galaxy,
+                capture_trace=self.config.capture_trace,
+                vae_on_device=self.config.vae_on_device,
+                use_cfg_parallel=self.config.use_cfg_parallel,
+            ),
+        )
+        self.logger.info("TtSDXLPipeline created")
+
+        # Compile text encoders
+        self.logger.info("Compiling text encoders...")
+        self.tt_sdxl.compile_text_encoding()
+
+        # Signal that kernel compilation is complete - next worker can start
+        # Program cache warmup below can run in parallel with other workers
+        if kernel_ready_queue is not None:
+            self.logger.info(f"Worker {self.worker_id} kernel compilation complete, signaling...")
+            kernel_ready_queue.put(self.worker_id)
+
+        # Warmup inference — mirror tt-media-server's _warmup_inference_block
+        # (sdxl_generate_runner_trace.py:45-62 + base_sdxl_runner.py:198-212).
+        # The reference applies request settings (steps=1, guidance=5.0,
+        # rescale=0.7, crop=(0,0)) and encodes prompt_2/negative_prompt_2
+        # BEFORE compile_image_processing captures the trace. Diverging from
+        # this baked stale values into the trace and produced SSIM ~0 images.
+        self.logger.info("Performing warmup inference...")
+        self.tt_sdxl.set_num_inference_steps(1)
+        self.tt_sdxl.set_guidance_scale(5.0)
+        self.tt_sdxl.set_guidance_rescale(0.7)
+        self.tt_sdxl.set_crop_coords_top_left((0, 0))
+
+        prompt_embeds, text_embeds = self.tt_sdxl.encode_prompts(
+            ["Sunrise on a beach"],
+            ["low resolution"],
+            prompt_2=["Mountains in the background"],
+            negative_prompt_2=["blurry"],
+        )
+
+        tt_latents, tt_prompts, tt_texts = self.tt_sdxl.generate_input_tensors(prompt_embeds, text_embeds)
+
+        self.tt_sdxl.prepare_input_tensors([tt_latents, tt_prompts[0], tt_texts[0]])
+
+        self.logger.info("Compiling image processing...")
+        self.tt_sdxl.compile_image_processing()
+
+        self.logger.info("Model loaded and warmed up successfully")
+
+    def run_inference(self, requests: List[dict]) -> List[Image.Image]:
+        """
+        Run inference for batch of requests
+
+        Args:
+            requests: List of request dictionaries with 'prompt', 'negative_prompt', etc.
+
+        Returns:
+            List of PIL Images
+        """
+        prompts = [req["prompt"] for req in requests]
+        prompts_2_raw = [req.get("prompt_2") for req in requests]
+        prompts_2 = (
+            None
+            if all(p in (None, "") for p in prompts_2_raw)
+            else [(p if (p is not None and p != "") else "") for p in prompts_2_raw]
+        )
+        neg_raw = [req.get("negative_prompt") for req in requests]
+        negative_prompts = (
+            None
+            if all(np in (None, "") for np in neg_raw)
+            else [(np if (np is not None and np != "") else "") for np in neg_raw]
+        )
+        neg2_raw = [req.get("negative_prompt_2") for req in requests]
+        negative_prompts_2 = (
+            None
+            if all(np in (None, "") for np in neg2_raw)
+            else [(np if (np is not None and np != "") else "") for np in neg2_raw]
+        )
+
+        # Update num_inference_steps if specified in request
+        if requests[0].get("num_inference_steps") is not None:
+            self.tt_sdxl.set_num_inference_steps(requests[0]["num_inference_steps"])
+
+        # Update guidance_scale if specified in request
+        if requests[0].get("guidance_scale") is not None:
+            self.tt_sdxl.set_guidance_scale(requests[0]["guidance_scale"])
+
+        # Update guidance_rescale if specified in request
+        if requests[0].get("guidance_rescale") is not None:
+            self.tt_sdxl.set_guidance_rescale(requests[0]["guidance_rescale"])
+
+        # Reset scheduler state for new inference run (fixes progress bar and ensures correct timesteps)
+        self.tt_sdxl.tt_scheduler.set_begin_index(0)
+
+        # Mirror reference's per-request defensive call (idempotent in SDK).
+        self.tt_sdxl.compile_text_encoding()
+
+        # Encode prompts (including prompt_2 for SDXL's dual text encoder)
+        prompt_embeds, text_embeds = self.tt_sdxl.encode_prompts(
+            prompts, negative_prompts, prompt_2=prompts_2, negative_prompt_2=negative_prompts_2
+        )
+
+        # Extract seed from request for reproducibility
+        seed = requests[0].get("seed")
+
+        # Generate tensors with seed
+        tt_latents, tt_prompts, tt_texts = self.tt_sdxl.generate_input_tensors(
+            prompt_embeds, text_embeds, start_latent_seed=seed
+        )
+
+        self.tt_sdxl.prepare_input_tensors([tt_latents, tt_prompts[0], tt_texts[0]])
+        img_tensors = self.tt_sdxl.generate_images()
+
+        images = []
+        for img_tensor in img_tensors:
+            pil_img = tensor_to_pil(img_tensor, self.pipeline.image_processor)
+            images.append(pil_img)
+        return images
+
+    # ------------------------------------------------------------------
+    # Staged operations (additive — used by the ComfyUI HTTP nodes).
+    # The full-pipeline run_inference() path above is left untouched.
+    # ------------------------------------------------------------------
+
+    def _apply_request_lora(self, request: dict):
+        """Apply the per-request LoRA adapter on device (load + fuse), caching the
+        currently-fused adapter so repeated requests skip the reload.
+
+        The adapter is validated and fused into the base UNet weights via the
+        pipeline's TtLoRAWeightsManager. Switching adapters first unloads the
+        previous one (restoring base weights) so deltas never stack. An empty
+        ``lora_path`` restores base weights.
+        """
+        lora_path = (request.get("lora_path") or "").strip()
+
+        # Resolve per-component scales. Split values always win; each falls back
+        # to the legacy single lora_scale; absent everything defaults to 1.0.
+        # is not None checks are intentional — 0.0 is a valid "skip this component" value.
+        legacy_raw = request.get("lora_scale")
+        legacy = float(legacy_raw) if legacy_raw is not None else 1.0
+        su = request.get("lora_scale_unet")
+        sc = request.get("lora_scale_clip")
+        scale_unet = float(su) if su is not None else legacy
+        scale_clip = float(sc) if sc is not None else legacy
+
+        if not lora_path:
+            if self._current_lora is not None:
+                self.logger.info("Clearing active LoRA (request has no adapter)")
+                self.tt_sdxl.unload_lora_weights()
+                self._current_lora = None
+            self._last_lora_status = None
+            return
+
+        key = (lora_path, scale_unet, scale_clip)
+        if key == self._current_lora:
+            return  # already fused on device; keep the existing status
+
+        # Switching adapters (or changing scale): restore base weights first so
+        # the new delta is applied to the unmodified base, not a stacked weight.
+        if self._current_lora is not None:
+            self.tt_sdxl.unload_lora_weights()
+            self._current_lora = None
+
+        self.logger.info(
+            f"Loading LoRA lora_path={lora_path!r}, " f"lora_scale_unet={scale_unet}, lora_scale_clip={scale_clip}"
+        )
+        self.tt_sdxl.load_lora_weights(lora_path)
+        self.tt_sdxl.fuse_lora(lora_scale_unet=scale_unet, lora_scale_clip=scale_clip)
+
+        status = self.tt_sdxl.get_lora_status()
+        applied = bool(status.get("unet") or status.get("text_encoder"))
+        self._last_lora_status = {
+            "requested": lora_path,
+            "scale_unet": scale_unet,
+            "scale_clip": scale_clip,
+            "scale": scale_unet,  # deprecated alias — kept for one release
+            "applied": applied,
+            "unet": bool(status.get("unet")),
+            "text_encoder": bool(status.get("text_encoder")),
+            "skipped_reason": status.get("skipped_reason"),
+        }
+        if not applied:
+            self.logger.warning(f"LoRA {lora_path!r} had no effect (skipped_reason={status.get('skipped_reason')})")
+        elif status.get("skipped_reason"):
+            self.logger.warning(f"LoRA {lora_path!r} partially applied: {status.get('skipped_reason')}")
+        self._current_lora = key
+
+    def _prompt_lists(self, request: dict):
+        """Build the (prompts, negative, prompt_2, negative_2) lists from one request,
+        mirroring run_inference()'s normalization."""
+        prompts = [request.get("prompt", "")]
+        p2 = request.get("prompt_2")
+        prompts_2 = None if p2 in (None, "") else [p2]
+        neg = request.get("negative_prompt")
+        negative_prompts = None if neg in (None, "") else [neg]
+        neg2 = request.get("negative_prompt_2")
+        negative_prompts_2 = None if neg2 in (None, "") else [neg2]
+        return prompts, negative_prompts, prompts_2, negative_prompts_2
+
+    def _apply_request_settings(self, request: dict):
+        """Apply per-request scheduler/guidance settings (subset of run_inference)."""
+        if request.get("num_inference_steps") is not None:
+            self.tt_sdxl.set_num_inference_steps(request["num_inference_steps"])
+        if request.get("guidance_scale") is not None:
+            self.tt_sdxl.set_guidance_scale(request["guidance_scale"])
+        if request.get("guidance_rescale") is not None:
+            self.tt_sdxl.set_guidance_rescale(request["guidance_rescale"])
+        self.tt_sdxl.tt_scheduler.set_begin_index(0)
+        self.tt_sdxl.compile_text_encoding()
+
+    def _latents_to_numpy(self, latents) -> np.ndarray:
+        """Convert device/host latents to standard diffusers layout [B, C, H, W] float32.
+
+        generate_images(return_latents=True) returns the raw scheduler latents (NOT
+        divided by the VAE scaling factor) in the TT layout [N, 1, H*W, C].
+        """
+        if not torch.is_tensor(latents):
+            latents = ttnn.to_torch(latents, mesh_composer=ttnn.ConcatMeshToTensor(self.ttnn_device, dim=0)).float()
+        else:
+            latents = latents.float()
+
+        c = self.tt_sdxl.num_in_channels_unet
+        h = self.tt_sdxl.height // self.pipeline.vae_scale_factor
+        w = self.tt_sdxl.width // self.pipeline.vae_scale_factor
+        n = latents.shape[0]
+        latents = latents.reshape(n, h, w, c).permute(0, 3, 1, 2).contiguous()
+        latents = latents[: self.tt_sdxl.batch_size]
+        return latents.cpu().numpy()
+
+    def denoise(self, request: dict, on_event=None) -> np.ndarray:
+        """Staged: encode prompts + run the (traced) UNet denoise loop on device.
+
+        Returns raw scheduler latents as numpy [B, C, H, W] (consumed by vae_decode).
+
+        If ``on_event`` is provided, a DenoiseStep event is emitted once per
+        denoise iteration so the server can stream per-step progress.
+        """
+        self._apply_request_lora(request)
+        self._apply_request_settings(request)
+        prompts, negative_prompts, prompts_2, negative_prompts_2 = self._prompt_lists(request)
+        prompt_embeds, text_embeds = self.tt_sdxl.encode_prompts(
+            prompts, negative_prompts, prompt_2=prompts_2, negative_prompt_2=negative_prompts_2
+        )
+        seed = request.get("seed")
+        tt_latents, tt_prompts, tt_texts = self.tt_sdxl.generate_input_tensors(
+            prompt_embeds, text_embeds, start_latent_seed=seed
+        )
+        self.tt_sdxl.prepare_input_tensors([tt_latents, tt_prompts[0], tt_texts[0]])
+
+        on_step = None
+        if on_event is not None:
+            from models.tt_dit.pipelines.events import DenoiseStep
+
+            def on_step(step, total):
+                on_event(DenoiseStep(step=step, total=total, sigma=0.0))
+
+        latents = self.tt_sdxl.generate_images(return_latents=True, on_step=on_step)
+        return self._latents_to_numpy(latents)
+
+    def vae_decode(self, latents_np: np.ndarray) -> np.ndarray:
+        """Staged: decode raw scheduler latents [B, C, H, W] -> image [B, H, W, C] in [0, 1].
+
+        POC uses the host torch VAE for a stable, additive contract; on-device VAE
+        decode of arbitrary latents is a follow-up optimization.
+        """
+        latents = torch.from_numpy(np.ascontiguousarray(latents_np)).float()
+        vae = self.pipeline.vae
+        latents = latents / vae.config.scaling_factor
+        with torch.no_grad():
+            image = vae.decode(latents.to(vae.dtype)).sample
+        image = (image / 2 + 0.5).clamp(0.0, 1.0)
+        image = image.permute(0, 2, 3, 1).contiguous().float()
+        return image.cpu().numpy()
+
+    def vae_encode(self, image_np: np.ndarray) -> np.ndarray:
+        """Staged: encode image [B, H, W, C] in [0, 1] -> raw scheduler latents [B, C, H, W].
+
+        Output matches the denoise() latent contract (scaled by the VAE scaling factor).
+        """
+        image = torch.from_numpy(np.ascontiguousarray(image_np)).float()
+        if image.ndim != 4:
+            raise ValueError(f"vae_encode expects [B, H, W, C], got shape {tuple(image.shape)}")
+        image = image.permute(0, 3, 1, 2).contiguous()
+        image = 2.0 * image - 1.0
+        vae = self.pipeline.vae
+        with torch.no_grad():
+            latents = vae.encode(image.to(vae.dtype)).latent_dist.sample()
+        latents = latents * vae.config.scaling_factor
+        return latents.float().cpu().numpy()
+
+    def close_device(self):
+        """Close device and cleanup"""
+        # Release traces BEFORE closing the device to prevent a segfault.
+        # main's TtSDXLPipeline has no public release_traces(); trace cleanup runs
+        # in __del__ -> __release_trace (ttnn.release_trace for the unet/vae tids).
+        # Drop our only reference and force collection so that runs now,
+        # deterministically, before close_mesh_device.
+        if self.tt_sdxl is not None:
+            self.logger.info("Releasing SDXL pipeline (trace cleanup) before device closure")
+            self.tt_sdxl = None
+            import gc
+
+            gc.collect()
+
+        if self.ttnn_device:
+            # Always use close_mesh_device since we always use open_mesh_device
+            self.logger.info("Closing mesh device")
+            ttnn.close_mesh_device(self.ttnn_device)

--- a/models/tt_dit/server/media/server.py
+++ b/models/tt_dit/server/media/server.py
@@ -1,0 +1,751 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import argparse
+import asyncio
+import base64
+import io
+import json
+import multiprocessing as mp
+import os
+import queue
+import time
+import uuid
+from contextlib import asynccontextmanager
+from typing import Any, Dict, List, Optional
+
+from device_specs import DeviceClass, validate_model_board
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+from utils.cache_utils import log_cache_info, validate_cache
+from utils.image_utils import b64npy_to_ndarray, ndarray_to_b64npy, pil_to_base64
+from utils.logger import setup_logger
+
+
+def parse_args():
+    """Parse command-line arguments for the unified inference server"""
+    parser = argparse.ArgumentParser(description="Unified Inference Server (SDXL / Wan2.2 T2V)")
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="sdxl",
+        choices=["sdxl", "wan22"],
+        help="Model to serve: 'sdxl' or 'wan22'",
+    )
+    parser.add_argument(
+        "--board",
+        type=str,
+        default=None,
+        help="Tenstorrent board / cluster (e.g. t3k, p150, p300, p300x2, p150x4, p150x8). "
+        "Required for --model sdxl and --model wan22.",
+    )
+    parser.add_argument(
+        "--dev",
+        action="store_true",
+        help="Enable dev mode (SDXL: 1 worker; WAN: fewer steps, no trace)",
+    )
+    parser.add_argument("--workers", type=int, help="Override number of workers")
+    parser.add_argument("--steps", type=int, help="Override number of inference steps")
+    parser.add_argument("--guidance", type=float, help="Override guidance scale")
+    parser.add_argument("--port", type=int, help="Override server port")
+    parser.add_argument("--host", type=str, help="Override server host")
+    args = parser.parse_args()
+
+    # --board is required for both SDXL and Wan2.2.
+    if args.board is None:
+        parser.error(f"--board is required when --model {args.model} (e.g. --board p300x2)")
+    try:
+        args.board = DeviceClass.from_string(args.board)
+    except ValueError as e:
+        parser.error(str(e))
+    try:
+        validate_model_board(args.model, args.board)
+    except ValueError as e:
+        parser.error(str(e))
+
+    return args
+
+
+# Parse arguments and propagate dev-mode environment variables before config
+# objects are created (config reads env vars at instantiation time).
+args = parse_args()
+if args.dev:
+    if args.model == "sdxl":
+        os.environ["SDXL_DEV_MODE"] = "true"
+    elif args.model == "wan22":
+        os.environ["WAN_DEV_MODE"] = "true"
+
+# Build the appropriate config
+if args.model == "wan22":
+    from wan_config import WanConfig
+
+    config = WanConfig(board=args.board)
+    model_label = "Wan2.2 T2V"
+    model_kind = "video"
+else:
+    from sdxl_config import SDXLConfig
+
+    config = SDXLConfig(board=args.board)
+    model_label = "SDXL"
+    model_kind = "image"
+
+# Apply CLI overrides after config is constructed
+if args.workers is not None:
+    config.num_workers = args.workers
+if args.steps is not None:
+    config.num_inference_steps = args.steps
+if args.guidance is not None:
+    config.guidance_scale = args.guidance
+if args.port is not None:
+    config.server_port = args.port
+if args.host is not None:
+    config.server_host = args.host
+
+logger = setup_logger("Server")
+if config.dev_mode:
+    logger.info(f"DEV MODE ENABLED ({model_label})")
+
+# ---------------------------------------------------------------------------
+# Pydantic models — SDXL image-generation fields
+# ---------------------------------------------------------------------------
+
+
+class ImageRequest(BaseModel):
+    """Image generation request (SDXL)."""
+
+    prompt: str
+    negative_prompt: Optional[str] = ""
+
+    # SDXL dual text-encoder fields
+    prompt_2: Optional[str] = None
+    negative_prompt_2: Optional[str] = None
+    guidance_rescale: Optional[float] = Field(default=0.0, ge=0.0, le=1.0)
+
+    # Shared generation parameters
+    num_inference_steps: Optional[int] = Field(default=None, ge=1, le=200)
+    guidance_scale: Optional[float] = Field(default=None, ge=1.0, le=20.0)
+    seed: Optional[int] = None
+
+
+class ImageResponse(BaseModel):
+    """Image generation response"""
+
+    images: List[str]  # Base64-encoded JPEG images
+    inference_time: float
+    model: str  # Model label for client-side detection (e.g. "SDXL")
+
+
+class VideoRequest(BaseModel):
+    """Wan2.2 T2V request."""
+
+    prompt: str
+    negative_prompt: Optional[str] = ""
+    num_inference_steps: Optional[int] = Field(default=None, ge=1, le=200)
+    num_frames: Optional[int] = Field(default=None, ge=5, le=257)
+    height: Optional[int] = Field(default=None, ge=64, le=2048)
+    width: Optional[int] = Field(default=None, ge=64, le=2048)
+    guidance_scale: Optional[float] = Field(default=None, ge=1.0, le=20.0)
+    guidance_scale_2: Optional[float] = Field(default=None, ge=1.0, le=20.0)
+    flow_shift: Optional[float] = Field(default=None, ge=0.0, le=30.0)
+    boundary_ratio: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    seed: Optional[int] = None
+    # LoRA passthrough — Wan2.2 has two experts, so adapters are specified per
+    # expert: high_lora_path -> high-noise (transformer), low_lora_path -> low-noise
+    # (transformer_2). Either or both may be set; lora_scale applies to both.
+    high_lora_path: Optional[str] = None
+    low_lora_path: Optional[str] = None
+    lora_scale: Optional[float] = Field(default=None, ge=0.0, le=2.0)
+
+
+class VideoResponse(BaseModel):
+    """Wan2.2 T2V response — frames as base64-encoded PNGs (T frames)."""
+
+    frames: List[str]  # base64 PNG per frame
+    width: int
+    height: int
+    num_frames: int
+    inference_time: float
+    model: str
+
+
+# ---------------------------------------------------------------------------
+# Staged-op request/response models (additive — used by the ComfyUI HTTP nodes)
+#
+# Tensors cross as base64 NumPy .npy payloads: {"b64": str, "shape": [...], "dtype": str}.
+# These endpoints currently target the SDXL runner only.
+# ---------------------------------------------------------------------------
+
+
+class DenoiseRequest(BaseModel):
+    """Staged denoise (KSampler) request — returns latents, not images."""
+
+    prompt: str
+    negative_prompt: Optional[str] = ""
+    prompt_2: Optional[str] = None
+    negative_prompt_2: Optional[str] = None
+    num_inference_steps: Optional[int] = Field(default=None, ge=1, le=200)
+    guidance_scale: Optional[float] = Field(default=None, ge=1.0, le=30.0)
+    guidance_rescale: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    seed: Optional[int] = None
+    # LoRA passthrough (mirrors tt-media-server image request fields)
+    lora_path: Optional[str] = None
+    # Legacy single scale — kept as backward-compat fallback. Per-component fields
+    # below take precedence when present (split values always win).
+    lora_scale: Optional[float] = Field(default=None, ge=0.0, le=2.0)
+    # Per-component scales mirroring ComfyUI LoraLoader (strength_model / strength_clip).
+    # lora_scale_clip=0.0 skips text-encoder fusion entirely.
+    lora_scale_unet: Optional[float] = Field(default=None, ge=0.0, le=2.0)
+    lora_scale_clip: Optional[float] = Field(default=None, ge=0.0, le=2.0)
+
+
+class TensorResponse(BaseModel):
+    """A single tensor payload plus timing/model metadata."""
+
+    latent: Optional[Dict[str, Any]] = None
+    image: Optional[Dict[str, Any]] = None
+    inference_time: float
+    model: str
+    # Optional LoRA application status (SDXL denoise). None when no adapter was
+    # requested. When present, reports whether the adapter was applied and why it
+    # may have been skipped/partially applied.
+    lora: Optional[Dict[str, Any]] = None
+
+
+class VaeDecodeRequest(BaseModel):
+    latent: Dict[str, Any]  # base64 .npy payload, [B, C, H, W]
+
+
+class VaeEncodeRequest(BaseModel):
+    image: Dict[str, Any]  # base64 .npy payload, [B, H, W, C]
+
+
+# Video-staged models (wan22): mirror the SDXL staged contract but carry the wan
+# generation knobs. The split maps to WanRunner.denoise / WanRunner.vae_decode.
+
+
+class VideoDenoiseRequest(BaseModel):
+    """Staged wan22 denoise (Wan Sampler) request — returns latents, not frames."""
+
+    prompt: str
+    negative_prompt: Optional[str] = ""
+    num_inference_steps: Optional[int] = Field(default=None, ge=1, le=200)
+    guidance_scale: Optional[float] = Field(default=None, ge=1.0, le=20.0)
+    guidance_scale_2: Optional[float] = Field(default=None, ge=1.0, le=20.0)
+    flow_shift: Optional[float] = Field(default=None, ge=0.0, le=30.0)
+    boundary_ratio: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    seed: Optional[int] = None
+    # LoRA passthrough — per-expert adapters (see VideoRequest for semantics).
+    high_lora_path: Optional[str] = None
+    low_lora_path: Optional[str] = None
+    lora_scale: Optional[float] = Field(default=None, ge=0.0, le=2.0)
+    # No-op: accepted for API consistency with DenoiseRequest; WAN uses per-expert
+    # scale, not a UNet/CLIP split.
+    lora_scale_clip: Optional[float] = Field(default=None, ge=0.0, le=2.0)
+
+
+class VideoVaeDecodeRequest(BaseModel):
+    latent: Dict[str, Any]  # base64 .npy payload, [B, z_dim, F, H, W]
+
+
+# ---------------------------------------------------------------------------
+# Global server state
+# ---------------------------------------------------------------------------
+
+task_queue = None
+result_queue = None
+error_queue = None
+progress_queue = None
+workers = []
+
+
+# ---------------------------------------------------------------------------
+# Lifespan: start workers, wait for warmup, yield, shutdown
+# ---------------------------------------------------------------------------
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Manage server lifespan — start workers, wait for warmup, then shutdown cleanly.
+
+    Overlapped initialization strategy (SDXL):
+      - Start worker 0, wait for kernel compilation signal, then start worker 1, etc.
+      - Kernel compilation must be sequential (shared write to program cache).
+      - Program-cache warmup can overlap between workers (per-device, no shared writes).
+      - Reduces T3K startup from ~18-20 min → ~10-12 min for 4 workers.
+
+    For single-worker configs (num_workers=1):
+      - The kernel_ready loop (range(0)) is a no-op — no interleaving required.
+      - The warmup wait still applies to the single worker.
+    """
+    global task_queue, result_queue, error_queue, progress_queue, workers
+
+    logger.info(f"Starting {model_label} server...")
+
+    # Log and validate HuggingFace / model cache state
+    log_cache_info(logger)
+    is_valid, issues = validate_cache()
+    if not is_valid:
+        logger.warning("Cache integrity issues detected:")
+        for issue in issues:
+            logger.warning(f"  - {issue}")
+        logger.warning("If startup fails, consider running with --clear-cache")
+    else:
+        logger.info("Cache validation passed")
+
+    # Deferred import: must not initialize ttnn in the main process
+    from worker import device_worker_process
+
+    # Create inter-process queues
+    task_queue = mp.Queue(maxsize=config.max_queue_size)
+    result_queue = mp.Queue()
+    warmup_signal_queue = mp.Queue()
+    kernel_ready_queue = mp.Queue()
+    error_queue = mp.Queue()
+    # Carries per-task progress events (DenoiseStep/Section) from workers to the
+    # streaming endpoints. Unbounded so a slow HTTP consumer never blocks a worker.
+    progress_queue = mp.Queue()
+
+    logger.info(f"Starting {config.num_workers} worker(s) with overlapped initialization...")
+
+    for i in range(config.num_workers):
+        logger.info(f"Starting worker {i}...")
+        worker = mp.Process(
+            target=device_worker_process,
+            args=(
+                i,
+                task_queue,
+                result_queue,
+                warmup_signal_queue,
+                kernel_ready_queue,
+                error_queue,
+                config,
+                progress_queue,
+            ),
+            daemon=False,
+        )
+        worker.start()
+        workers.append(worker)
+
+        # Wait for kernel compilation before launching the next worker.
+        # For single-worker configs (num_workers=1) this loop body never executes (range(0)).
+        if i < config.num_workers - 1:
+            logger.info(f"Waiting for worker {i} kernel compilation before starting next worker...")
+            timeout = time.time() + 300  # 5-minute per-worker kernel compilation limit
+            kernel_ready_received = False
+
+            while time.time() < timeout:
+                try:
+                    worker_id = kernel_ready_queue.get(timeout=1)
+                    logger.info(f"Worker {worker_id} kernel compilation complete, starting next worker...")
+                    kernel_ready_received = True
+                    break
+                except Exception:
+                    if not worker.is_alive():
+                        logger.error(f"Worker {i} died during kernel compilation")
+                        raise RuntimeError(f"Worker {i} died during kernel compilation")
+
+            if not kernel_ready_received:
+                logger.error(f"Worker {i} kernel compilation timeout!")
+                raise RuntimeError(f"Worker {i} kernel compilation timeout")
+
+    # Wait for ALL workers to complete full warmup (kernel compile + trace capture)
+    logger.info("All workers started. Waiting for warmup completion...")
+    warmups_received = 0
+    # 1200s = 20 min — trace capture can take ~10-15 min on cold start
+    timeout = time.time() + 1200
+
+    while warmups_received < config.num_workers and time.time() < timeout:
+        try:
+            worker_id = warmup_signal_queue.get(timeout=1)
+            warmups_received += 1
+            logger.info(f"Worker {worker_id} warmup complete ({warmups_received}/{config.num_workers})")
+        except Exception:
+            # Check for crashed workers
+            for idx, w in enumerate(workers):
+                if not w.is_alive():
+                    logger.error(f"Worker {idx} died during warmup")
+                    raise RuntimeError(f"Worker {idx} died during warmup")
+
+    if warmups_received < config.num_workers:
+        logger.error(f"Warmup timeout! Only {warmups_received}/{config.num_workers} workers ready")
+        raise RuntimeError("Warmup timeout")
+
+    logger.info(f"All workers ready. {model_label} server is accepting requests.")
+
+    yield
+
+    # Graceful shutdown: send None sentinel to each worker
+    logger.info("Shutting down workers...")
+    for _ in range(config.num_workers):
+        task_queue.put(None)
+
+    for worker in workers:
+        worker.join(timeout=10)
+        if worker.is_alive():
+            worker.terminate()
+
+    logger.info("Server shutdown complete")
+
+
+# ---------------------------------------------------------------------------
+# FastAPI app
+# ---------------------------------------------------------------------------
+
+app = FastAPI(title=f"{model_label} Inference Server", lifespan=lifespan)
+
+
+def _frames_to_base64_pngs(frames):
+    """Convert numpy uint8 frames (T,H,W,3) to a list of base64-encoded PNGs."""
+    from PIL import Image
+
+    out = []
+    for i in range(frames.shape[0]):
+        img = Image.fromarray(frames[i], mode="RGB")
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        out.append(base64.b64encode(buf.getvalue()).decode("ascii"))
+    return out
+
+
+@app.post("/video/generations", response_model=VideoResponse)
+async def generate_video(request: VideoRequest):
+    """Generate a video from a text prompt (Wan2.2)."""
+    if model_kind != "video":
+        raise HTTPException(status_code=400, detail=f"This server is serving '{model_label}', not a video model")
+
+    task_id = str(uuid.uuid4())
+    try:
+        task_queue.put((task_id, request.dict()), timeout=5)
+    except Exception:
+        raise HTTPException(status_code=503, detail="Task queue is full")
+
+    start_time = time.time()
+    timeout = start_time + config.inference_timeout_seconds
+
+    while time.time() < timeout:
+        try:
+            result = result_queue.get(timeout=1)
+            if result["task_id"] == task_id:
+                frames_np = result["images"][0]  # (T,H,W,3) uint8
+                T, H, W, _ = frames_np.shape
+                frames_b64 = _frames_to_base64_pngs(frames_np)
+                return VideoResponse(
+                    frames=frames_b64,
+                    width=W,
+                    height=H,
+                    num_frames=T,
+                    inference_time=result["inference_time"],
+                    model=model_label,
+                )
+            else:
+                result_queue.put(result)
+        except Exception:
+            try:
+                error = error_queue.get_nowait()
+                logger.error(f"Worker error: {error}")
+            except Exception:
+                pass
+
+    raise HTTPException(status_code=408, detail="Request timeout")
+
+
+@app.post("/image/generations", response_model=ImageResponse)
+async def generate_image(request: ImageRequest):
+    """Generate an image from a text prompt.
+
+    Returns a base64-encoded JPEG along with inference time and the model label.
+    """
+    if model_kind != "image":
+        raise HTTPException(status_code=400, detail=f"This server is serving '{model_label}', use /video/generations")
+
+    task_id = str(uuid.uuid4())
+
+    try:
+        task_queue.put((task_id, request.dict()), timeout=5)
+    except Exception:
+        raise HTTPException(status_code=503, detail="Task queue is full")
+
+    # Poll result queue until our task_id comes back or we time out
+    start_time = time.time()
+    timeout = start_time + config.inference_timeout_seconds
+
+    while time.time() < timeout:
+        try:
+            result = result_queue.get(timeout=1)
+
+            if result["task_id"] == task_id:
+                base64_images = [pil_to_base64(img) for img in result["images"]]
+                return ImageResponse(
+                    images=base64_images,
+                    inference_time=result["inference_time"],
+                    model=model_label,
+                )
+            else:
+                # Result belongs to a different task — put it back
+                result_queue.put(result)
+
+        except Exception:
+            # Check error queue on timeout
+            try:
+                error = error_queue.get_nowait()
+                logger.error(f"Worker error: {error}")
+            except Exception:
+                pass
+
+    raise HTTPException(status_code=408, detail="Request timeout")
+
+
+def _submit_and_wait(request_dict: dict, timeout_seconds: Optional[float] = None) -> dict:
+    """Enqueue a task and poll result_queue for its matching result.
+
+    Shared by the staged endpoints. Mirrors the polling/error-handling pattern of
+    the image/video handlers. Returns the worker's result dict.
+    """
+    task_id = str(uuid.uuid4())
+    request_dict["op"] = request_dict.get("op", "generate")
+    try:
+        task_queue.put((task_id, request_dict), timeout=5)
+    except Exception:
+        raise HTTPException(status_code=503, detail="Task queue is full")
+
+    deadline = time.time() + (timeout_seconds or config.inference_timeout_seconds)
+    while time.time() < deadline:
+        try:
+            result = result_queue.get(timeout=1)
+            if result.get("task_id") == task_id:
+                return result
+            else:
+                result_queue.put(result)  # belongs to another task
+        except Exception:
+            try:
+                error = error_queue.get_nowait()
+                logger.error(f"Worker error: {error}")
+                raise HTTPException(status_code=500, detail=f"Worker error: {error.get('error', error)}")
+            except HTTPException:
+                raise
+            except Exception:
+                pass
+    raise HTTPException(status_code=408, detail="Request timeout")
+
+
+def _stream_denoise_response(req: dict, *, timeout_seconds: float = None):
+    """Enqueue a denoise task and stream progress events as NDJSON.
+
+    Shared by /video/denoise_stream and /latent/denoise_stream. Sets
+    stream_progress=True so the worker publishes DenoiseStep/Section events to
+    progress_queue; the blocking endpoints leave it unset and never drain it.
+
+    Yields one JSON object per line:
+      - progress events: {"type": "section_start"|"section_end"|"denoise_step", ...}
+      - terminal event:  {"type": "result", "latent": <b64npy>, "inference_time": float}
+      - on failure:      {"type": "error", "detail": str}
+    """
+    task_id = str(uuid.uuid4())
+    req["op"] = "denoise"
+    req["stream_progress"] = True
+    try:
+        task_queue.put((task_id, req), timeout=5)
+    except Exception:
+        raise HTTPException(status_code=503, detail="Task queue is full")
+
+    deadline = time.time() + max(timeout_seconds or config.inference_timeout_seconds, 3600.0)
+
+    async def event_stream():
+        while time.time() < deadline:
+            drained_any = False
+
+            # 1) Forward any progress events for this task.
+            while True:
+                try:
+                    ev = progress_queue.get_nowait()
+                except queue.Empty:
+                    break
+                drained_any = True
+                if ev.get("task_id") == task_id:
+                    yield json.dumps(ev) + "\n"
+
+            # 2) Check for the terminal result.
+            try:
+                result = result_queue.get_nowait()
+            except queue.Empty:
+                result = None
+
+            if result is not None:
+                if result.get("task_id") == task_id:
+                    yield json.dumps(
+                        {
+                            "type": "result",
+                            "latent": ndarray_to_b64npy(result["tensor"]),
+                            "inference_time": result.get("inference_time", 0.0),
+                            "model": model_label,
+                            "lora": result.get("lora"),
+                        }
+                    ) + "\n"
+                    return
+                else:
+                    # Belongs to another task — put it back for its handler.
+                    result_queue.put(result)
+
+            # 3) Surface worker errors.
+            try:
+                err = error_queue.get_nowait()
+                logger.error(f"Worker error: {err}")
+                yield json.dumps({"type": "error", "detail": f"Worker error: {err.get('error', err)}"}) + "\n"
+                return
+            except queue.Empty:
+                pass
+
+            if not drained_any:
+                # Nothing pending; yield control so we don't busy-spin the event loop.
+                await asyncio.sleep(0.05)
+
+        yield json.dumps({"type": "error", "detail": "Request timeout"}) + "\n"
+
+    return StreamingResponse(event_stream(), media_type="application/x-ndjson")
+
+
+def _require_staged_support():
+    """Staged ops are currently implemented for the SDXL runner only."""
+    if args.model != "sdxl":
+        raise HTTPException(
+            status_code=400,
+            detail=f"Staged ops (denoise/vae) are only supported for --model sdxl, not '{args.model}'. "
+            f"Use /image/generations for the full pipeline.",
+        )
+
+
+@app.post("/latent/denoise", response_model=TensorResponse)
+async def latent_denoise(request: DenoiseRequest):
+    """Staged denoise (KSampler): run encode + UNet loop, return latents."""
+    _require_staged_support()
+    req = request.dict()
+    req["op"] = "denoise"
+    result = _submit_and_wait(req)
+    return TensorResponse(
+        latent=ndarray_to_b64npy(result["tensor"]),
+        inference_time=result.get("inference_time", 0.0),
+        model=model_label,
+        lora=result.get("lora"),
+    )
+
+
+@app.post("/latent/denoise_stream")
+async def latent_denoise_stream(request: DenoiseRequest):
+    """Staged SDXL denoise (KSampler) with streaming per-step progress (NDJSON).
+
+    Mirrors /video/denoise_stream. The blocking /latent/denoise endpoint is
+    preserved for older clients.
+    """
+    _require_staged_support()
+    return _stream_denoise_response(request.dict())
+
+
+@app.post("/vae/decode", response_model=TensorResponse)
+async def vae_decode(request: VaeDecodeRequest):
+    """Staged VAE decode: latents [B, C, H, W] -> image [B, H, W, C] in [0, 1]."""
+    _require_staged_support()
+    latents = b64npy_to_ndarray(request.latent)
+    result = _submit_and_wait({"op": "vae_decode", "latent": latents})
+    return TensorResponse(
+        image=ndarray_to_b64npy(result["tensor"]),
+        inference_time=result.get("inference_time", 0.0),
+        model=model_label,
+    )
+
+
+@app.post("/vae/encode", response_model=TensorResponse)
+async def vae_encode(request: VaeEncodeRequest):
+    """Staged VAE encode: image [B, H, W, C] in [0, 1] -> latents [B, C, H, W]."""
+    _require_staged_support()
+    images = b64npy_to_ndarray(request.image)
+    result = _submit_and_wait({"op": "vae_encode", "image": images})
+    return TensorResponse(
+        latent=ndarray_to_b64npy(result["tensor"]),
+        inference_time=result.get("inference_time", 0.0),
+        model=model_label,
+    )
+
+
+def _require_video_staged_support():
+    """Staged video ops (denoise/vae) are served only by a video model (wan22)."""
+    if model_kind != "video":
+        raise HTTPException(
+            status_code=400,
+            detail=f"Staged video ops (denoise/vae) require a video model, not '{model_label}'.",
+        )
+
+
+@app.post("/video/denoise", response_model=TensorResponse)
+async def video_denoise(request: VideoDenoiseRequest):
+    """Staged wan22 denoise (Wan Sampler): encode + denoise loop, return latents."""
+    _require_video_staged_support()
+    req = request.dict()
+    req["op"] = "denoise"
+    # Video denoise runs the full sampling loop — allow the long video timeout.
+    result = _submit_and_wait(req, timeout_seconds=max(config.inference_timeout_seconds, 3600.0))
+    return TensorResponse(
+        latent=ndarray_to_b64npy(result["tensor"]),
+        inference_time=result.get("inference_time", 0.0),
+        model=model_label,
+    )
+
+
+@app.post("/video/denoise_stream")
+async def video_denoise_stream(request: VideoDenoiseRequest):
+    """Staged wan22 denoise with streaming progress (NDJSON).
+
+    Yields one JSON object per line:
+      - progress events: {"type": "section_start"|"section_end"|"denoise_step", ...}
+      - terminal event:  {"type": "result", "latent": <b64npy>, "inference_time": float}
+      - on failure:      {"type": "error", "detail": str}
+
+    The blocking /video/denoise endpoint is preserved for older clients.
+    """
+    _require_video_staged_support()
+    return _stream_denoise_response(request.dict())
+
+
+@app.post("/video/vae_decode", response_model=TensorResponse)
+async def video_vae_decode(request: VideoVaeDecodeRequest):
+    """Staged wan22 VAE decode: latents [B, z_dim, F, H, W] -> frames [T, H, W, C] in [0, 1]."""
+    _require_video_staged_support()
+    latents = b64npy_to_ndarray(request.latent)
+    result = _submit_and_wait({"op": "vae_decode", "latent": latents})
+    return TensorResponse(
+        image=ndarray_to_b64npy(result["tensor"]),
+        inference_time=result.get("inference_time", 0.0),
+        model=model_label,
+    )
+
+
+@app.get("/health")
+async def health_check():
+    """Server health check — includes model label for client-side detection"""
+    alive_workers = sum(1 for w in workers if w.is_alive())
+    return {
+        "status": "healthy" if alive_workers > 0 else "unhealthy",
+        "model": model_label,
+        "workers_alive": alive_workers,
+        "workers_total": config.num_workers,
+        "queue_size": task_queue.qsize() if task_queue else 0,
+    }
+
+
+@app.get("/metrics")
+async def get_metrics():
+    """Server metrics endpoint"""
+    return {
+        "model": model_label,
+        "task_queue_size": task_queue.qsize() if task_queue else 0,
+        "result_queue_size": result_queue.qsize() if result_queue else 0,
+        "error_queue_size": error_queue.qsize() if error_queue else 0,
+        "workers_alive": sum(1 for w in workers if w.is_alive()),
+    }
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host=config.server_host, port=config.server_port, log_level="info")

--- a/models/tt_dit/server/media/stop_server.sh
+++ b/models/tt_dit/server/media/stop_server.sh
@@ -1,0 +1,228 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# Unified stop script for the standalone media inference server (server.py).
+#
+# Supersedes kill_sdxl_server.sh, which only matched the legacy sdxl_server.py /
+# sdxl_worker.py process names and therefore never found the unified server.
+#
+# Shutdown strategy (preserves device cleanup):
+#   1. Find the running server.py process tree (main uvicorn process + its
+#      multiprocessing worker children — they share the `server.py` cmdline).
+#   2. Send SIGTERM to the ROOT process only. uvicorn turns this into FastAPI's
+#      lifespan shutdown, which puts a None sentinel on each worker's queue so the
+#      workers run `runner.close_device()` and release the mesh/fabric cleanly
+#      (identical to pressing Ctrl+C in the launcher terminal).
+#   3. Wait GRACEFUL_TIMEOUT for the whole tree to exit.
+#   4. SIGKILL any stragglers (last resort — skips device cleanup; a tt-smi reset
+#      may then be required).
+#
+# Usage:
+#   ./stop_server.sh                 # graceful stop (recommended)
+#   ./stop_server.sh --force         # skip the graceful phase, SIGKILL immediately
+#   ./stop_server.sh --timeout 30    # override graceful wait (default 15s)
+
+set -o pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration / args
+# ---------------------------------------------------------------------------
+GRACEFUL_TIMEOUT=15   # seconds to wait for graceful shutdown (device close can be slow)
+FORCE=false
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --force)
+            FORCE=true
+            shift
+            ;;
+        --timeout)
+            GRACEFUL_TIMEOUT="$2"
+            shift 2
+            ;;
+        -h|--help)
+            grep '^#' "$0" | grep -vE '^#!|SPDX' | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1 (try --help)"
+            exit 2
+            ;;
+    esac
+done
+
+# Match the unified server.py invocation, but NOT the legacy sdxl_server.py:
+# the char immediately before "server.py" must be a space or slash, so
+# ".../sdxl_server.py" (preceded by '_') is excluded.
+SERVER_PATTERN='python.*[ /]server\.py'
+
+SCRIPT_NAME="$(basename "$0")"
+LOG_PREFIX="[${SCRIPT_NAME}]"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_info() { echo -e "${GREEN}${LOG_PREFIX} INFO:${NC} $1"; }
+log_warn() { echo -e "${YELLOW}${LOG_PREFIX} WARN:${NC} $1"; }
+log_error() { echo -e "${RED}${LOG_PREFIX} ERROR:${NC} $1"; }
+
+# ---------------------------------------------------------------------------
+# Process discovery
+# ---------------------------------------------------------------------------
+
+# All server.py PIDs (main + worker children), excluding this script's own PID.
+find_server_pids() {
+    pgrep -f "$SERVER_PATTERN" 2>/dev/null | grep -v "^$$\$" | sort -u
+}
+
+# The root server process: the one whose parent is NOT itself a server.py
+# process (i.e. its parent is the launcher/shell). That's the uvicorn main
+# process whose graceful shutdown cascades to the workers.
+find_root_pid() {
+    local all_pids="$1"
+    local pid ppid
+    for pid in $all_pids; do
+        ppid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+        if [ -z "$ppid" ]; then
+            continue
+        fi
+        # If the parent is not in our server set, this is a root.
+        if ! echo "$all_pids" | grep -q "^${ppid}\$"; then
+            echo "$pid"
+            return 0
+        fi
+    done
+    return 1
+}
+
+get_process_info() {
+    ps -p "$1" -o pid,ppid,state,etime,cmd 2>/dev/null | tail -n 1
+}
+
+wait_for_all_exit() {
+    local pids="$1"
+    local timeout="$2"
+    local elapsed=0 pid still
+    while [ "$elapsed" -lt "$timeout" ]; do
+        still=""
+        for pid in $pids; do
+            if kill -0 "$pid" 2>/dev/null; then
+                still="$still $pid"
+            fi
+        done
+        if [ -z "$still" ]; then
+            return 0
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+    log_info "Searching for unified media server (server.py) processes..."
+
+    local pids
+    pids=$(find_server_pids)
+
+    if [ -z "$pids" ]; then
+        log_info "No server.py processes found — nothing to stop."
+        exit 0
+    fi
+
+    local count
+    count=$(echo "$pids" | wc -w)
+    log_info "Found ${count} server process(es):"
+    local pid
+    for pid in $pids; do
+        echo "  $(get_process_info "$pid")"
+    done
+    echo ""
+
+    local used_sigkill=false
+
+    if [ "$FORCE" = "true" ]; then
+        log_warn "--force: skipping graceful shutdown, sending SIGKILL to all server processes."
+        log_warn "Device cleanup (close_device) is bypassed — a 'tt-smi -r' reset may be required."
+        for pid in $pids; do
+            kill -KILL "$pid" 2>/dev/null && log_info "Sent SIGKILL to $pid"
+        done
+        used_sigkill=true
+    else
+        # Phase 1: graceful SIGTERM to the root process (cascades to workers).
+        local root_pid
+        root_pid=$(find_root_pid "$pids")
+
+        if [ -n "$root_pid" ]; then
+            log_info "Phase 1: graceful shutdown — SIGTERM to root process $root_pid"
+            log_info "(uvicorn lifespan will signal workers to close devices cleanly)"
+            kill -TERM "$root_pid" 2>/dev/null \
+                || log_warn "Failed to SIGTERM $root_pid (may have already exited)"
+        else
+            log_warn "Could not identify a root process (orphaned workers?); SIGTERM-ing all."
+            for pid in $pids; do
+                kill -TERM "$pid" 2>/dev/null
+            done
+        fi
+
+        log_info "Waiting up to ${GRACEFUL_TIMEOUT}s for graceful shutdown..."
+        if wait_for_all_exit "$pids" "$GRACEFUL_TIMEOUT"; then
+            log_info "All server processes exited gracefully."
+            log_info "Shutdown complete."
+            exit 0
+        fi
+
+        # Phase 2: SIGKILL stragglers.
+        local stuck=""
+        for pid in $pids; do
+            if kill -0 "$pid" 2>/dev/null; then
+                stuck="$stuck $pid"
+            fi
+        done
+        log_warn "Processes still alive after ${GRACEFUL_TIMEOUT}s:${stuck}"
+        log_info "Phase 2: force killing stragglers (SIGKILL)..."
+        for pid in $stuck; do
+            local state
+            state=$(ps -o state= -p "$pid" 2>/dev/null | tr -d ' ')
+            if [ "$state" = "D" ]; then
+                log_warn "Process $pid is in uninterruptible sleep (stuck in kernel/driver)."
+            fi
+            kill -KILL "$pid" 2>/dev/null && log_info "Sent SIGKILL to $pid"
+        done
+        used_sigkill=true
+    fi
+
+    # Final check.
+    sleep 2
+    local remaining=""
+    for pid in $pids; do
+        if kill -0 "$pid" 2>/dev/null; then
+            remaining="$remaining $pid"
+        fi
+    done
+
+    if [ -n "$remaining" ]; then
+        log_error "Failed to stop:${remaining}"
+        log_error "May be stuck in kernel space. Consider 'tt-smi -r' and/or a reboot."
+        exit 1
+    fi
+
+    if [ "$used_sigkill" = "true" ]; then
+        log_warn "Server stopped via SIGKILL — device cleanup was skipped."
+        log_warn "If a relaunch fails to open the mesh, reset the chips with: tt-smi -r"
+    fi
+    log_info "Shutdown complete."
+    exit 0
+}
+
+trap 'log_warn "Interrupted"; exit 130' INT TERM
+
+main

--- a/models/tt_dit/server/media/utils/cache_utils.py
+++ b/models/tt_dit/server/media/utils/cache_utils.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import glob
+import os
+import shutil
+from typing import List, Tuple
+
+
+def get_cache_dirs() -> List[str]:
+    """Get list of cache directories used by SDXL server"""
+    # Use default tt-metal cache (shared with tt-media-server) unless TT_METAL_CACHE is set
+    tt_metal_cache = os.environ.get("TT_METAL_CACHE", os.path.expanduser("~/.cache/tt-metal-cache"))
+    return [
+        tt_metal_cache,
+        os.path.expanduser("~/.cache/ttnn/models"),
+    ]
+
+
+def validate_cache() -> Tuple[bool, List[str]]:
+    """
+    Validate cache integrity by checking for corruption indicators
+
+    Returns:
+        Tuple of (is_valid, list_of_issues)
+    """
+    issues = []
+
+    for cache_dir in get_cache_dirs():
+        if not os.path.exists(cache_dir):
+            continue
+
+        # Check for incomplete files (tmp files)
+        tmp_files = glob.glob(f"{cache_dir}/**/*.tmp", recursive=True)
+        if tmp_files:
+            issues.append(f"Found {len(tmp_files)} incomplete .tmp files in {cache_dir}")
+
+        # Check for zero-size files (incomplete writes)
+        for root, dirs, files in os.walk(cache_dir):
+            for file in files:
+                filepath = os.path.join(root, file)
+                try:
+                    if os.path.isfile(filepath) and os.path.getsize(filepath) == 0:
+                        issues.append(f"Found empty file: {filepath}")
+                except OSError:
+                    # File might have been deleted or inaccessible
+                    continue
+
+    return len(issues) == 0, issues
+
+
+def clear_cache(logger=None) -> None:
+    """
+    Clear all SDXL cache directories
+
+    Args:
+        logger: Optional logger for output
+    """
+    for cache_dir in get_cache_dirs():
+        if os.path.exists(cache_dir):
+            if logger:
+                logger.info(f"Clearing cache: {cache_dir}")
+            else:
+                print(f"Clearing cache: {cache_dir}")
+
+            try:
+                shutil.rmtree(cache_dir)
+                if logger:
+                    logger.info(f"  ✓ Cleared {cache_dir}")
+                else:
+                    print(f"  ✓ Cleared {cache_dir}")
+            except Exception as e:
+                if logger:
+                    logger.error(f"  ✗ Failed to clear {cache_dir}: {e}")
+                else:
+                    print(f"  ✗ Failed to clear {cache_dir}: {e}")
+
+
+def log_cache_info(logger) -> None:
+    """
+    Log information about cache directories
+
+    Args:
+        logger: Logger instance
+    """
+    logger.info("Cache directories:")
+    for cache_dir in get_cache_dirs():
+        if os.path.exists(cache_dir):
+            try:
+                # Get directory size
+                total_size = 0
+                file_count = 0
+                for root, dirs, files in os.walk(cache_dir):
+                    for file in files:
+                        filepath = os.path.join(root, file)
+                        try:
+                            total_size += os.path.getsize(filepath)
+                            file_count += 1
+                        except OSError:
+                            continue
+
+                size_mb = total_size / (1024 * 1024)
+                logger.info(f"  {cache_dir}: {file_count} files, {size_mb:.1f} MB")
+            except Exception as e:
+                logger.info(f"  {cache_dir}: (error reading: {e})")
+        else:
+            logger.info(f"  {cache_dir}: (not created yet)")

--- a/models/tt_dit/server/media/utils/image_utils.py
+++ b/models/tt_dit/server/media/utils/image_utils.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import base64
+from io import BytesIO
+from typing import Any, Dict
+
+import numpy as np
+import torch
+from PIL import Image
+
+
+def ndarray_to_b64npy(arr: np.ndarray) -> Dict[str, Any]:
+    """Serialize a NumPy array to a base64 ``.npy`` payload (JSON-friendly).
+
+    Used by the staged HTTP endpoints to ship latents / images to ComfyUI.
+    """
+    buf = BytesIO()
+    np.save(buf, np.ascontiguousarray(arr), allow_pickle=False)
+    return {
+        "b64": base64.b64encode(buf.getvalue()).decode("ascii"),
+        "shape": list(arr.shape),
+        "dtype": str(arr.dtype),
+    }
+
+
+def b64npy_to_ndarray(payload: Dict[str, Any]) -> np.ndarray:
+    """Deserialize a base64 ``.npy`` payload (as produced by ``ndarray_to_b64npy``)."""
+    raw = base64.b64decode(payload["b64"])
+    return np.load(BytesIO(raw), allow_pickle=False)
+
+
+def pil_to_base64(image: Image.Image, format: str = "JPEG") -> str:
+    """
+    Convert PIL image to base64 string
+
+    Args:
+        image: PIL Image
+        format: Output format (JPEG, PNG)
+
+    Returns:
+        Base64-encoded string
+    """
+    buffered = BytesIO()
+    image.save(buffered, format=format)
+    img_bytes = buffered.getvalue()
+    return base64.b64encode(img_bytes).decode("utf-8")
+
+
+def base64_to_pil(base64_str: str) -> Image.Image:
+    """
+    Convert base64 string to PIL image
+
+    Args:
+        base64_str: Base64-encoded image string
+
+    Returns:
+        PIL Image
+    """
+    img_bytes = base64.b64decode(base64_str)
+    return Image.open(BytesIO(img_bytes))
+
+
+def tensor_to_pil(tensor: torch.Tensor, image_processor) -> Image.Image:
+    """
+    Convert tensor to PIL image using pipeline's processor
+
+    Args:
+        tensor: PyTorch tensor from SDXL pipeline
+        image_processor: Image processor from DiffusionPipeline
+
+    Returns:
+        PIL Image
+    """
+    tensor = tensor.unsqueeze(0)
+    return image_processor.postprocess(tensor, output_type="pil")[0]

--- a/models/tt_dit/server/media/utils/logger.py
+++ b/models/tt_dit/server/media/utils/logger.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import logging
+import sys
+
+
+def setup_logger(name: str, level: str = "INFO") -> logging.Logger:
+    """
+    Setup structured logger for SDXL components
+
+    Args:
+        name: Logger name (e.g., "Worker-0", "SDXLServer")
+        level: Logging level (DEBUG, INFO, WARNING, ERROR)
+
+    Returns:
+        Configured logger instance
+    """
+    logger = logging.getLogger(name)
+    logger.setLevel(getattr(logging, level.upper()))
+
+    # Avoid duplicate handlers
+    if logger.handlers:
+        return logger
+
+    handler = logging.StreamHandler(sys.stdout)
+    formatter = logging.Formatter(f"%(asctime)s - {name} - %(levelname)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+
+    return logger

--- a/models/tt_dit/server/media/wan_config.py
+++ b/models/tt_dit/server/media/wan_config.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import os
+from dataclasses import dataclass, field
+from typing import Tuple
+
+from device_specs import DeviceClass, get_board_spec, get_deployment
+
+
+@dataclass
+class WanConfig:
+    """Configuration for Wan2.2 T2V standalone server.
+
+    Topology fields (num_workers, device_mesh_shape, device_ids, fabric) are
+    derived from device_specs.DEPLOYMENTS based on `board`.
+    """
+
+    # Required: which Tenstorrent board this server is running on.
+    board: DeviceClass = None  # set explicitly via CLI; validated in __post_init__
+
+    # Server settings
+    server_host: str = "127.0.0.1"
+    server_port: int = 8000
+
+    # Topology — derived from device_specs.get_deployment("wan22", board) in __post_init__.
+    num_workers: int = 1
+    device_ids: Tuple[int, ...] = ()
+    device_mesh_shape: Tuple[int, int] = (0, 0)
+    fabric_config_name: str = "FABRIC_1D"
+
+    # Device parameters. l1_small_size is filled from BoardSpec; trace_region_size
+    # must hold the full T2V pipeline's captured traces. Empirically on p300x2 at
+    # 832x480/81f the two-stage pipeline captures two expert traces (~64.7MB each,
+    # ~129.4MB total) plus a VAE-decode trace; 200MB gives headroom. (The reference
+    # perf test uses 120MB with a quantized/FSDP config that yields smaller traces.)
+    l1_small_size: int = 0
+    trace_region_size: int = 200_000_000
+
+    # Model settings
+    model_name: str = "Wan-AI/Wan2.2-T2V-A14B-Diffusers"
+    hf_home: str = field(default_factory=lambda: os.getenv("HF_HOME", os.path.expanduser("~/.cache/huggingface")))
+
+    # Pipeline / generation defaults
+    num_inference_steps: int = 40
+    num_frames: int = 81
+    height: int = 480
+    width: int = 832
+    guidance_scale: float = 4.0
+    guidance_scale_2: float = 3.0
+    use_trace: bool = True
+
+    # LoRA: build the pipeline with LoRA-aware Linears so per-request adapters
+    # can be hot-swapped on a running server. Fuse mode keeps forward/trace
+    # overhead at zero, so non-LoRA requests behave identically.
+    lora_enabled: bool = True
+
+    # Queue settings
+    max_queue_size: int = 4
+    inference_timeout_seconds: int = 1800  # video gen is slow
+
+    # Development mode: WAN_DEV_MODE=true → fewer steps, fewer frames, no trace.
+    dev_mode: bool = field(default_factory=lambda: os.getenv("WAN_DEV_MODE", "false").lower() == "true")
+
+    def __post_init__(self):
+        if self.board is None:
+            raise ValueError("WanConfig.board is required (pass --board on the CLI)")
+
+        dep = get_deployment("wan22", self.board)
+        self.num_workers = dep.num_workers
+        self.device_mesh_shape = dep.mesh_shape
+        self.device_ids = dep.device_ids
+        if dep.fabric_config:
+            self.fabric_config_name = dep.fabric_config
+
+        spec = get_board_spec(self.board)
+        if self.l1_small_size == 0:
+            self.l1_small_size = spec.l1_small_size
+
+        if self.dev_mode:
+            self.num_inference_steps = 4
+            self.use_trace = False
+            # NOTE: num_frames is fixed at pipeline creation: WanPipeline.__init__
+            # internally calls warmup_buffers(num_frames=81), which allocates
+            # self.latent_buffer at the 81-frame latent size. Subsequent calls
+            # with a different num_frames break ttnn.copy(latent_buffer). So we
+            # leave num_frames=81 even in dev mode.

--- a/models/tt_dit/server/media/wan_runner.py
+++ b/models/tt_dit/server/media/wan_runner.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+from typing import List
+
+import numpy as np
+from utils.logger import setup_logger
+from wan_config import WanConfig
+
+import ttnn
+
+
+class WanRunner:
+    """Wrapper for tt-metal WanPipeline (Wan2.2 T2V).
+
+    Mirrors the runner contract: initialize_device → load_model → run_inference → close_device.
+    Returns numpy uint8 frames of shape (T, H, W, 3) per request.
+    """
+
+    def __init__(self, worker_id: int, config: WanConfig):
+        self.worker_id = worker_id
+        self.config = config
+        self.logger = setup_logger(f"WanRunner-{worker_id}")
+        self.mesh_device = None
+        self.pipeline = None
+        self._fabric_config = None
+        # Per-worker LoRA adapter cache: (high_path, low_path, scale) -> registered name.
+        # Repeated requests with the same adapter skip the (slow) reload/register and
+        # only re-bind. ``_active_lora_key`` tracks what is currently fused on device.
+        self._lora_cache: dict = {}
+        self._active_lora_key = None
+
+    def initialize_device(self):
+        rows, cols = self.config.device_mesh_shape
+        self.logger.info(
+            f"Initializing {rows}x{cols} mesh device for worker {self.worker_id} "
+            f"on board {self.config.board.name.lower()}"
+        )
+
+        fabric_config = getattr(ttnn.FabricConfig, self.config.fabric_config_name)
+        ttnn.set_fabric_config(
+            fabric_config,
+            ttnn.FabricReliabilityMode.STRICT_INIT,
+            None,
+            ttnn.FabricTensixConfig.DISABLED,
+        )
+        self._fabric_config = fabric_config
+
+        self.mesh_device = ttnn.open_mesh_device(
+            mesh_shape=ttnn.MeshShape(rows, cols),
+            l1_small_size=self.config.l1_small_size,
+            trace_region_size=self.config.trace_region_size,
+            dispatch_core_config=ttnn.DispatchCoreConfig(),
+        )
+        self.logger.info(
+            f"Mesh device initialized: shape={tuple(self.mesh_device.shape)}, "
+            f"fabric={self.config.fabric_config_name}, "
+            f"l1_small_size={self.config.l1_small_size}, "
+            f"trace_region_size={self.config.trace_region_size}"
+        )
+        return self.mesh_device
+
+    def load_model(self, kernel_ready_queue=None):
+        # When LoRA is enabled the transformer is built with LoRA-aware Linears so
+        # adapters can be hot-swapped per request. Fuse mode keeps forward/trace
+        # overhead at zero, so non-LoRA requests are unaffected.
+        if self.config.lora_enabled:
+            from models.tt_dit.experimental.pipelines.pipeline_wan_runtime_lora import WanPipelineRuntimeLoRA
+
+            pipeline_cls = WanPipelineRuntimeLoRA
+        else:
+            from models.tt_dit.pipelines.wan.pipeline_wan import WanPipeline
+
+            pipeline_cls = WanPipeline
+
+        self.logger.info("Creating Wan2.2 T2V pipeline...")
+        self.logger.info(f"  model_name: {self.config.model_name}")
+        self.logger.info(f"  size: {self.config.width}x{self.config.height}, frames: {self.config.num_frames}")
+        self.logger.info(f"  steps: {self.config.num_inference_steps}, use_trace: {self.config.use_trace}")
+        self.logger.info(f"  lora_enabled: {self.config.lora_enabled}")
+
+        # Geometry (height/width/num_frames) and CFG are fixed at creation; guidance_scale
+        # is applied per call. Enable CFG so per-request guidance_scale > 1 is accepted.
+        self.pipeline = pipeline_cls.create_pipeline(
+            mesh_device=self.mesh_device,
+            checkpoint_name=self.config.model_name,
+            height=self.config.height,
+            width=self.config.width,
+            num_frames=self.config.num_frames,
+            cfg_enabled=self.config.guidance_scale > 1,
+        )
+        self.logger.info("Wan2.2 pipeline created")
+
+        self.logger.info("Running warmup inference (compiles kernels / captures trace)...")
+        # num_frames/height/width are fixed at creation; __call__ does not accept them.
+        self.pipeline(
+            prompts=["A golden sunrise over mountain peaks"],
+            num_inference_steps=2,
+            guidance_scale=self.config.guidance_scale,
+            guidance_scale_2=self.config.guidance_scale_2,
+            seed=42,
+            output_type="uint8",
+            traced=self.config.use_trace,
+        )
+        self.logger.info("Warmup complete")
+
+        if kernel_ready_queue is not None:
+            kernel_ready_queue.put(self.worker_id)
+
+    def _apply_request_lora(self, request: dict) -> None:
+        """Register (if new) and bind the per-request LoRA adapter on both experts.
+
+        ``high_lora_path`` targets the high-noise expert (transformer) and
+        ``low_lora_path`` the low-noise expert (transformer_2); either or both may
+        be supplied. Adapters are cached per (high, low, scale) so repeated requests
+        with the same adapter only re-bind (sub-second) rather than reload weights.
+        Passing no LoRA fields restores the base weights.
+        """
+        if not hasattr(self.pipeline, "register_lora"):
+            if request.get("high_lora_path") or request.get("low_lora_path"):
+                self.logger.warning(
+                    "LoRA requested but pipeline was built without lora_enabled; ignoring. "
+                    "Restart the server with WanConfig.lora_enabled=True to use adapters."
+                )
+            return
+
+        high = request.get("high_lora_path") or None
+        low = request.get("low_lora_path") or None
+        scale = request.get("lora_scale")
+        scale = float(scale) if scale is not None else 1.0
+        self.logger.info(f"_apply_request_lora: high={high!r}, low={low!r}, scale={scale}")
+
+        if (not high and not low) or scale == 0.0:
+            if self._active_lora_key is not None:
+                reason = "lora_scale=0.0" if scale == 0.0 else "request has no adapter"
+                self.logger.info(f"Clearing active LoRA ({reason})")
+                self.pipeline.set_active_lora(None)
+                self._active_lora_key = None
+            return
+
+        key = (high, low, scale)
+        if key == self._active_lora_key:
+            return  # already fused on device — no work
+
+        name = self._lora_cache.get(key)
+        if name is None:
+            name = f"lora_{len(self._lora_cache)}"
+            self.pipeline.register_lora(name, high_path=high, low_path=low, scale=scale)
+            self._lora_cache[key] = name
+            self.logger.info(f"Registered LoRA '{name}': high={high}, low={low}, scale={scale}")
+
+        self.pipeline.set_active_lora(name)
+        self._active_lora_key = key
+        self.logger.info(f"Activated LoRA '{name}'")
+
+    def run_inference(self, requests: List[dict]) -> List[np.ndarray]:
+        request = requests[0]
+        self._apply_request_lora(request)
+
+        prompt = request["prompt"]
+        negative_prompt = request.get("negative_prompt") or None
+        num_inference_steps = request.get("num_inference_steps") or self.config.num_inference_steps
+        # num_frames / height / width are fixed at pipeline creation; __call__ reads
+        # self._num_frames/_height/_width and does not accept per-request overrides.
+        guidance_scale = request.get("guidance_scale") or self.config.guidance_scale
+        guidance_scale_2 = request.get("guidance_scale_2") or self.config.guidance_scale_2
+        # flow_shift / boundary_ratio are host-side schedule/expert-selection knobs; pass
+        # through only when supplied so the pipeline keeps its construction-time defaults.
+        flow_shift = request.get("flow_shift")
+        boundary_ratio = request.get("boundary_ratio")
+        seed = request.get("seed")
+
+        self.logger.info(
+            f"Running inference: prompt='{prompt[:80]}', steps={num_inference_steps}, "
+            f"frames={self.config.num_frames}, size={self.config.width}x{self.config.height}, seed={seed}"
+        )
+
+        kwargs = dict(
+            prompts=[prompt],
+            num_inference_steps=num_inference_steps,
+            guidance_scale=guidance_scale,
+            guidance_scale_2=guidance_scale_2,
+            seed=int(seed) if seed is not None else 0,
+            output_type="uint8",
+            traced=self.config.use_trace,
+        )
+        if negative_prompt:
+            kwargs["negative_prompts"] = [negative_prompt]
+        if flow_shift is not None:
+            kwargs["flow_shift"] = float(flow_shift)
+        if boundary_ratio is not None:
+            kwargs["boundary_ratio"] = float(boundary_ratio)
+
+        output = self.pipeline(**kwargs)
+        # WanPipelineOutput.frames: numpy uint8 of shape (B, T, H, W, C). Strip batch.
+        frames = output.frames if hasattr(output, "frames") else output
+        if frames.ndim == 5:
+            frames = frames[0]
+        return [frames]
+
+    # -- staged ops (mirror SDXLRunner.denoise / vae_decode) ---------------
+    #
+    # The Wan pipeline already separates the two stages: __call__(output_type="latent")
+    # runs the (traced) denoise loop and returns host latents without VAE; _decode_latents
+    # runs the VAE decode independently. Both are warmed during load_model's full-pipeline
+    # warmup. Geometry (height/width/num_frames) stays fixed at construction time.
+
+    def _build_call_kwargs(self, request: dict) -> dict:
+        """Shared kwarg builder for run_inference / denoise (everything but output_type)."""
+        prompt = request["prompt"]
+        negative_prompt = request.get("negative_prompt") or None
+        num_inference_steps = request.get("num_inference_steps") or self.config.num_inference_steps
+        guidance_scale = request.get("guidance_scale") or self.config.guidance_scale
+        guidance_scale_2 = request.get("guidance_scale_2") or self.config.guidance_scale_2
+        flow_shift = request.get("flow_shift")
+        boundary_ratio = request.get("boundary_ratio")
+        seed = request.get("seed")
+
+        kwargs = dict(
+            prompts=[prompt],
+            num_inference_steps=num_inference_steps,
+            guidance_scale=guidance_scale,
+            guidance_scale_2=guidance_scale_2,
+            seed=int(seed) if seed is not None else 0,
+            traced=self.config.use_trace,
+        )
+        if negative_prompt:
+            kwargs["negative_prompts"] = [negative_prompt]
+        if flow_shift is not None:
+            kwargs["flow_shift"] = float(flow_shift)
+        if boundary_ratio is not None:
+            kwargs["boundary_ratio"] = float(boundary_ratio)
+        return kwargs
+
+    def denoise(self, request: dict, on_event=None) -> np.ndarray:
+        """Staged: encode prompt (umT5) + run the (traced) denoise loop on device.
+
+        Returns raw denoised latents as numpy [B, z_dim, F, H, W] (consumed by vae_decode).
+        ``on_event`` is an optional PipelineEventCallback used to stream progress
+        (SectionStart/SectionEnd/DenoiseStep) back to the caller.
+        """
+        self._apply_request_lora(request)
+        kwargs = self._build_call_kwargs(request)
+        kwargs["output_type"] = "latent"
+        if on_event is not None:
+            kwargs["on_event"] = on_event
+        self.logger.info(
+            f"Staged denoise: prompt='{request['prompt'][:80]}', steps={kwargs['num_inference_steps']}, "
+            f"size={self.config.width}x{self.config.height}, seed={kwargs['seed']}"
+        )
+        latents = self.pipeline(**kwargs)  # torch tensor on host
+        return latents.float().cpu().numpy()
+
+    def vae_decode(self, latents_np: np.ndarray) -> np.ndarray:
+        """Staged: decode raw latents [B, z_dim, F, H, W] -> frames [T, H, W, C] in [0, 1].
+
+        Mirrors the SDXL contract (float32 image in [0, 1]); reuses the pipeline's own VAE
+        decode path so device/trace setup from warmup is shared.
+        """
+        import torch
+
+        from models.tt_dit.pipelines.events import null_callback
+
+        latents = torch.from_numpy(np.ascontiguousarray(latents_np)).float()
+        video = self.pipeline._decode_latents(latents, output_type="uint8", on_event=null_callback)
+        # _decode_latents("uint8") returns numpy (B, T, H, W, C) uint8. Strip batch + normalize.
+        if video.ndim == 5:
+            video = video[0]
+        return video.astype(np.float32) / 255.0
+
+    def close_device(self):
+        if self.pipeline is not None and hasattr(self.pipeline, "synchronize_devices"):
+            self.logger.info("Synchronizing submesh devices before closure")
+            try:
+                self.pipeline.synchronize_devices()
+            except Exception as e:
+                self.logger.warning(f"synchronize_devices failed: {e}")
+
+        if self.mesh_device is not None:
+            self.logger.info("Closing mesh device")
+            ttnn.close_mesh_device(self.mesh_device)
+            self.mesh_device = None
+            if self._fabric_config is not None:
+                ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
+                self._fabric_config = None

--- a/models/tt_dit/server/media/worker.py
+++ b/models/tt_dit/server/media/worker.py
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import multiprocessing as mp
+import os
+import queue
+import time
+
+from utils.logger import setup_logger
+
+
+def _serialize_pipeline_event(event) -> dict:
+    """Map a tt_dit pipeline event dataclass to a JSON-friendly progress dict.
+
+    Imported lazily by callers (the events module pulls in tt_dit). Returns None
+    for event types we do not forward.
+    """
+    from models.tt_dit.pipelines.events import DenoiseStep, SectionEnd, SectionStart
+
+    if isinstance(event, DenoiseStep):
+        return {"type": "denoise_step", "step": int(event.step), "total": int(event.total)}
+    if isinstance(event, SectionStart):
+        return {"type": "section_start", "name": event.name}
+    if isinstance(event, SectionEnd):
+        return {"type": "section_end", "name": event.name}
+    return None
+
+
+def setup_sdxl_worker_environment(worker_id: int, config):
+    """
+    Set worker-specific environment variables for SDXL.
+
+    Topology and descriptor wiring are driven by `config.board` via
+    device_specs.BOARD_SPECS — every supported board sets
+    TT_MESH_GRAPH_DESC_PATH unconditionally so the runtime never falls back
+    to a CUSTOM cluster type missing its descriptor.
+    """
+    from device_specs import descriptor_path, get_board_spec
+
+    os.environ["TT_METAL_HOME"] = os.getcwd()
+    os.environ["PYTHONPATH"] = os.getcwd()
+
+    # Set device visibility EARLY (before any ttnn operations)
+    device_ids_str = ",".join(map(str, config.device_ids))
+    os.environ["TT_VISIBLE_DEVICES"] = device_ids_str
+    os.environ["TT_METAL_VISIBLE_DEVICES"] = device_ids_str
+
+    # Mesh-graph descriptor — required by tt-metal whenever the cluster
+    # falls back to CUSTOM (Blackhole P-series, partial-pop boards).
+    os.environ["TT_MESH_GRAPH_DESC_PATH"] = descriptor_path(config.board)
+
+    # Per-board extras (e.g. Galaxy's TT_MM_THROTTLE_PERF=5).
+    os.environ.update(get_board_spec(config.board).extra_env_vars)
+
+
+def setup_wan_worker_environment(worker_id: int, config):
+    """Wan2.2: a single worker owns the full mesh. Topology is board-derived
+    via device_specs (descriptor_path + extra_env_vars).
+    """
+    from device_specs import descriptor_path, get_board_spec
+
+    os.environ["TT_METAL_HOME"] = os.getcwd()
+    os.environ["PYTHONPATH"] = os.getcwd()
+
+    device_ids_str = ",".join(map(str, config.device_ids))
+    os.environ["TT_VISIBLE_DEVICES"] = device_ids_str
+    os.environ["TT_METAL_VISIBLE_DEVICES"] = device_ids_str
+
+    os.environ["TT_MESH_GRAPH_DESC_PATH"] = descriptor_path(config.board)
+    os.environ.update(get_board_spec(config.board).extra_env_vars)
+
+
+def device_worker_process(
+    worker_id: int,
+    task_queue: mp.Queue,
+    result_queue: mp.Queue,
+    warmup_signal_queue: mp.Queue,
+    kernel_ready_queue: mp.Queue,
+    error_queue: mp.Queue,
+    config,
+    progress_queue: mp.Queue = None,
+):
+    """
+    Main worker process function that handles image generation inference tasks.
+
+    Supports SDXL and Wan2.2 via config type dispatch:
+    - WanConfig   → WanRunner   (single worker owns the full mesh)
+    - SDXLConfig  → SDXLRunner  (1x1 mesh, one worker per device)
+
+    All runner/ttnn imports are deferred to this function so the main server
+    process never initializes ttnn (which would conflict with the child
+    processes' device ownership).
+
+    Args:
+        worker_id: Worker process ID
+        task_queue: Queue for incoming tasks — each item is (task_id, request_dict)
+        result_queue: Queue for results — each item is a dict with task_id/images/inference_time
+        warmup_signal_queue: Queue to signal warmup completion to the server
+        kernel_ready_queue: Queue to signal kernel compilation complete (overlapped startup)
+        error_queue: Queue for error reporting to the server
+        config: SDXLConfig or WanConfig instance
+    """
+    logger = setup_logger(f"Worker-{worker_id}")
+    logger.info(f"Worker {worker_id} starting...")
+
+    try:
+        # Determine model type and set up environment + runner
+        # Imports are deferred here to avoid ttnn initialization in the main process
+        from wan_config import WanConfig
+
+        if isinstance(config, WanConfig):
+            setup_wan_worker_environment(worker_id, config)
+            from wan_runner import WanRunner
+
+            runner = WanRunner(worker_id, config)
+        else:
+            setup_sdxl_worker_environment(worker_id, config)
+            from sdxl_runner import SDXLRunner
+
+            runner = SDXLRunner(worker_id, config)
+
+        # Initialize device and load model with optional overlapped startup signal
+        runner.initialize_device()
+        runner.load_model(kernel_ready_queue=kernel_ready_queue)
+
+        # Signal to server that this worker has completed full warmup
+        warmup_signal_queue.put(worker_id)
+        logger.info(f"Worker {worker_id} ready for inference")
+
+        # Main processing loop
+        while True:
+            try:
+                # Block with timeout so we can detect shutdown cleanly
+                task = task_queue.get(timeout=1)
+
+                if task is None:  # Shutdown signal
+                    logger.info(f"Worker {worker_id} received shutdown signal")
+                    break
+
+                task_id, request = task
+                op = request.get("op", "generate") if isinstance(request, dict) else "generate"
+                logger.info(f"Worker {worker_id} processing task {task_id} (op={op})")
+
+                # Run inference and measure wall-clock time
+                start_time = time.time()
+
+                if op == "generate":
+                    # Existing full-pipeline path (unchanged behavior).
+                    images = runner.run_inference([request])
+                    inference_time = time.time() - start_time
+                    result_queue.put({"task_id": task_id, "op": op, "images": images, "inference_time": inference_time})
+                elif op in ("denoise", "vae_decode", "vae_encode"):
+                    # Additive staged ops (currently SDXL only).
+                    if not hasattr(runner, op):
+                        raise RuntimeError(f"Runner {type(runner).__name__} does not support staged op '{op}'")
+                    if op == "denoise":
+                        denoise_kwargs = {}
+                        # Stream progress events only when the request opted in (the
+                        # streaming endpoint sets stream_progress=True) AND the runner's
+                        # denoise accepts on_event (WAN). The blocking /video/denoise path
+                        # never drains progress_queue, so we must not emit for it.
+                        if progress_queue is not None and request.get("stream_progress"):
+                            import inspect
+
+                            if "on_event" in inspect.signature(runner.denoise).parameters:
+
+                                def _on_event(event, _tid=task_id):
+                                    ev = _serialize_pipeline_event(event)
+                                    if ev is None:
+                                        return
+                                    ev["task_id"] = _tid
+                                    try:
+                                        progress_queue.put_nowait(ev)
+                                    except Exception:
+                                        pass
+
+                                denoise_kwargs["on_event"] = _on_event
+                        tensor = runner.denoise(request, **denoise_kwargs)
+                    elif op == "vae_decode":
+                        tensor = runner.vae_decode(request["latent"])
+                    else:  # vae_encode
+                        tensor = runner.vae_encode(request["image"])
+                    inference_time = time.time() - start_time
+                    result_queue.put(
+                        {
+                            "task_id": task_id,
+                            "op": op,
+                            "tensor": tensor,
+                            "inference_time": inference_time,
+                            "lora": getattr(runner, "_last_lora_status", None),
+                        }
+                    )
+                else:
+                    raise RuntimeError(f"Unknown op '{op}'")
+
+                logger.info(f"Task {task_id} completed in {inference_time:.2f}s")
+
+            except queue.Empty:
+                # Normal timeout — no task available, loop again
+                continue
+            except Exception as e:
+                import traceback
+
+                logger.error(f"Error processing task: {e}")
+                logger.error(f"Traceback: {traceback.format_exc()}")
+                error_queue.put({"worker_id": worker_id, "error": str(e)})
+
+        # Cleanup
+        runner.close_device()
+        logger.info(f"Worker {worker_id} shutdown complete")
+
+    except Exception as e:
+        import traceback
+
+        logger.error(f"Worker {worker_id} fatal error: {e}")
+        logger.error(f"Traceback: {traceback.format_exc()}")
+        error_queue.put({"worker_id": worker_id, "error": f"Fatal: {str(e)}"})


### PR DESCRIPTION
## PR Category
Feature

## Summary

Adds the standalone FastAPI media-inference server that ComfyUI's Tenstorrent custom
nodes drive over HTTP. ComfyUI launches `launch_server.sh` and calls `server.py`'s REST
endpoints (staged SDXL `/latent/denoise` + `/vae/{decode,encode}`, Wan2.2
`/video/{denoise,vae_decode}`, plus streaming variants). Pure HTTP — no tt-metal Python
is imported into ComfyUI.

Lives under **`models/tt_dit/server/media/`** (tt_dit ownership) rather than the repo root.

**Scope is exactly what ComfyUI exercises:**
- **SDXL** (p150) and **Wan2.2 T2V** (p300x2) only. The unused **SD3.5** path is stripped
  from `server.py` / `worker.py` / `launch_server.sh` (and `sd35_config.py`/`sd35_runner.py`
  are not included).
- Excludes legacy/dev-only files: `sdxl_server.py`, `sdxl_worker.py`,
  `launch_sdxl_server.sh`, `image_test.py`, `validation_utils.py`.

## Notes for reviewers

- **Relocation mechanics:** `launch_server.sh` derives `TT_METAL_HOME` four levels up from
  its new location and `cd`s to the repo root before launching, so worker processes
  (`os.getcwd()` → `TT_METAL_HOME`) resolve correctly. The media dir is added to
  `PYTHONPATH` and is `sys.path[0]` (script dir) so the flat sibling imports
  (`import device_specs`, `from utils.logger …`, `from wan_config …`) resolve; workers
  inherit `sys.path` via the default fork start method.
- **Companion ComfyUI change (separate, must land in lockstep):** ComfyUI's
  `custom_nodes/tenstorrent_nodes/server_manager.py` must point at
  `$TT_METAL_DIR/models/tt_dit/server/media/launch_server.sh` instead of the old root path.
- Additive only — no existing tt-metal files change.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=stisi/tt-media-server)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:stisi/tt-media-server)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=stisi/tt-media-server)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:stisi/tt-media-server)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=stisi/tt-media-server)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:stisi/tt-media-server)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=stisi/tt-media-server)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:stisi/tt-media-server)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=stisi/tt-media-server)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:stisi/tt-media-server)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=stisi/tt-media-server)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:stisi/tt-media-server)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=stisi/tt-media-server)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:stisi/tt-media-server)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=stisi/tt-media-server)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:stisi/tt-media-server)