### PR TITLE
tt_dit/experimental: runtime LoRA adapter loader + Wan2.2 runtime-LoRA pipeline

### DIFF
--- a/models/tt_dit/experimental/lora/__init__.py
+++ b/models/tt_dit/experimental/lora/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0

--- a/models/tt_dit/experimental/lora/adapter_loader.py
+++ b/models/tt_dit/experimental/lora/adapter_loader.py
@@ -1,0 +1,381 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Adapter loader for the runtime-LoRA Wan 2.2 pipeline.
+
+Reads a LoRA safetensors file, parses A/B pairs using the same key
+normalization as ``pipeline_wan_lora.py``, and uploads them into the
+LoRA-aware Linear modules of a `WanTransformer3DModel` constructed with
+``lora_enabled=True``.
+
+Fused-QKV handling (the hard part):
+  Wan attention uses a fused ``to_qkv`` (self-attn) and ``to_kv``
+  (cross-attn) projection. The adapter ships separate ``to_q``,
+  ``to_k``, ``to_v`` LoRA pairs. We combine them into a single LoRA
+  pair on the fused module by:
+
+    - stacking A along the rank dim:  A_fused = [A_q; A_k; A_v]  → [3r, in]
+    - building a block-diagonal B with rank=3r and head-interleaving
+      it the same way the base weight is head-interleaved:
+        B_fused = head_interleave([B_q | 0 | 0,  0 | B_k | 0,  0 | 0 | B_v])
+
+  This triples the LoRA matmul cost on those layers (rank=3r) but keeps
+  the math exact and shippable in v0. A follow-up could split this into
+  3 independent adapters at the layer level for ~3x lower cost.
+
+`.diff` / `.diff_b` direct deltas are out of scope for v0 — the loader
+warns and skips them.
+"""
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+from loguru import logger
+from safetensors.torch import load_file
+
+from models.tt_dit.experimental.utils.lightx2v_loader import wan_lightx2v_to_diffusers_key
+
+# Reused from pipeline_wan_lora.py — kept inline so this module is self-contained.
+_STRIP_PREFIXES = ("diffusion_model.", "transformer.", "unet.", "model.")
+_LOW_RANK_RE = re.compile(r"^(?P<base>.*)\.lora_(?P<slot>A|B|down|up)(?:\.[^.]+)?\.weight$")
+_SLOT_MAP = {"A": "A", "down": "A", "B": "B", "up": "B"}
+
+
+def _strip_known_prefixes(key: str) -> str:
+    for prefix in _STRIP_PREFIXES:
+        if key.startswith(prefix):
+            return key[len(prefix) :]
+    return key
+
+
+def _kohya_to_lightx2v(key: str) -> str:
+    if not key.startswith("lora_unet_"):
+        return key
+    parts = key.split(".", 1)
+    module_path = parts[0][len("lora_unet_") :]
+    suffix = f".{parts[1]}" if len(parts) > 1 else ""
+    m = re.match(r"blocks_(\d+)_(cross_attn|self_attn)_([a-z]+)", module_path)
+    if m:
+        return f"blocks.{m.group(1)}.{m.group(2)}.{m.group(3)}{suffix}"
+    m = re.match(r"blocks_(\d+)_(ffn)_(\d+)", module_path)
+    if m:
+        return f"blocks.{m.group(1)}.{m.group(2)}.{m.group(3)}{suffix}"
+    logger.warning(f"unrecognized kohya key structure: {key}")
+    return key
+
+
+def _normalize_key(raw: str) -> str:
+    return _kohya_to_lightx2v(_strip_known_prefixes(raw))
+
+
+# --------------------------------------------------------------------
+# Public API
+# --------------------------------------------------------------------
+@dataclass(frozen=True)
+class AdapterHandle:
+    name: str
+    rank: int  # the "expected bound rank" — may be 3r for fused-QKV targets
+    target_indices: dict[str, int]
+    """Map from a stable target identifier (e.g. ``'blocks.0.attn1.to_qkv'``)
+    to the bank index returned by `register_lora` on that module."""
+
+
+def load_adapter_into(
+    transformer,  # WanTransformer3DModel constructed with lora_enabled=True
+    path: str,
+    *,
+    scale: float = 1.0,
+    name: str = "",
+) -> AdapterHandle:
+    """Load a single LoRA safetensors file into `transformer`.
+
+    Returns an `AdapterHandle` recording the bank index assigned to each
+    LoRA-targeted Linear. Use it later with
+    ``pipeline.set_active_lora(handle)``.
+    """
+    raw = load_file(str(path))
+    if not any(_is_lora_key(k) for k in raw):
+        raise RuntimeError(f"no LoRA-style keys (lora_A/lora_B, lora_down/lora_up) in {path}")
+
+    pairs, alphas, skipped_direct = _collect_pairs(raw)
+    if skipped_direct:
+        logger.warning(
+            f"{path}: skipping {skipped_direct} direct (.diff/.diff_b) deltas "
+            "— runtime-LoRA pipeline does not support these yet."
+        )
+
+    # Group targets
+    fused_qkv: dict[tuple[int, str], dict[str, dict[str, torch.Tensor]]] = {}
+    singletons: list[tuple[str, dict[str, torch.Tensor]]] = []  # (diffusers_path, ab)
+    skipped_unmapped = 0
+
+    for base_path, ab in pairs.items():
+        diff_path = _diffusers_path(base_path)
+        if diff_path is None:
+            skipped_unmapped += 1
+            continue
+        m = re.match(r"blocks\.(\d+)\.(attn1|attn2)\.to_([qkv])$", diff_path)
+        if m:
+            block_idx, attn, qkv = int(m.group(1)), m.group(2), m.group(3)
+            # attn1 (self-attn): Q/K/V all fold into to_qkv.
+            # attn2 (cross-attn): Q is its own singleton; K/V fold into to_kv.
+            if attn == "attn1" or qkv in ("k", "v"):
+                fused_qkv.setdefault((block_idx, attn), {})[qkv] = ab
+                continue
+            # attn2.to_q is a real singleton — fall through.
+        # Everything else: 1:1 mapping
+        singletons.append((diff_path, ab))
+
+    if skipped_unmapped:
+        logger.warning(
+            f"{path}: {skipped_unmapped} pairs unmapped — adapter targets a module "
+            "that doesn't exist in the tt-dit name map."
+        )
+
+    target_indices: dict[str, int] = {}
+    fused_ranks: list[int] = []
+    singleton_ranks: list[int] = []
+
+    # Fused QKV / KV
+    for (block_idx, attn_name), qkvs in fused_qkv.items():
+        attn = getattr(transformer.blocks[block_idx], attn_name)
+        bank_idx, fused_rank = _register_fused_qkv(attn, qkvs, alphas, scale, name)
+        if bank_idx is None:
+            continue
+        key = f"blocks.{block_idx}.{attn_name}.{'to_qkv' if attn.is_self else 'to_kv'}"
+        target_indices[key] = bank_idx
+        fused_ranks.append(fused_rank)
+
+    # Singletons
+    for diff_path, ab in singletons:
+        target, canonical = _resolve_singleton(transformer, diff_path)
+        if target is None:
+            logger.warning(f"unmapped singleton LoRA target: {diff_path}")
+            continue
+        A = ab["A"]
+        B = ab["B"]
+        rank = A.shape[0]
+        alpha = alphas.get(_lightx2v_for_path(diff_path), float(rank))
+        eff_scale = scale * (alpha / rank)
+        idx = target.register_lora(A, B, scale=eff_scale, name=name)
+        target_indices[canonical] = idx
+        singleton_ranks.append(rank)
+
+    # Sanity: every LoRA module in this adapter should have the same
+    # bound rank, but fused_QKV produces a 3x larger rank than singletons.
+    # The bound-tensor system handles per-module ranks independently, so
+    # we just record both for reporting.
+    all_ranks = fused_ranks + singleton_ranks
+    if not all_ranks:
+        raise RuntimeError(f"{path}: no LoRA targets registered")
+    logger.info(
+        f"LoRA '{name or Path(path).stem}': registered {len(target_indices)} target(s) "
+        f"({len(fused_ranks)} fused-QKV, {len(singleton_ranks)} singleton, "
+        f"rank={max(all_ranks)})"
+    )
+    representative_rank = max(all_ranks)
+    return AdapterHandle(name=name or Path(path).stem, rank=representative_rank, target_indices=target_indices)
+
+
+# --------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------
+def _is_lora_key(raw: str) -> bool:
+    key = _normalize_key(raw)
+    return bool(_LOW_RANK_RE.match(key)) or key.endswith((".diff", ".diff_b"))
+
+
+def _collect_pairs(raw: dict[str, torch.Tensor]):
+    """Returns ({base_path: {'A': T, 'B': T}}, {base_path: alpha}, num_skipped_direct)."""
+    pairs: dict[str, dict[str, torch.Tensor]] = {}
+    alphas: dict[str, float] = {}
+    skipped_direct = 0
+
+    for raw_key, tensor in raw.items():
+        key = _normalize_key(raw_key)
+        m = _LOW_RANK_RE.match(key)
+        if m:
+            pairs.setdefault(m.group("base"), {})[_SLOT_MAP[m.group("slot")]] = tensor
+        elif key.endswith(".alpha"):
+            alphas[key[: -len(".alpha")]] = float(tensor.item())
+        elif key.endswith(".diff") or key.endswith(".diff_b"):
+            skipped_direct += 1
+
+    return pairs, alphas, skipped_direct
+
+
+def _diffusers_path(lightx2v_base: str) -> str | None:
+    """Map a lightx2v base path to its diffusers-canonical equivalent
+    (without ``.weight``). Returns None if mapping fails."""
+    try:
+        key = wan_lightx2v_to_diffusers_key(f"{lightx2v_base}.weight")
+    except Exception:  # noqa: BLE001
+        return None
+    if not key.endswith(".weight"):
+        return None
+    return key[: -len(".weight")]
+
+
+def _lightx2v_for_path(diffusers_path: str) -> str:
+    """Reverse-map (best-effort) a diffusers path back to lightx2v for alpha
+    lookups — alphas are keyed in the source naming."""
+    # Simple cases that the existing map covers:
+    rev = {
+        "attn1.to_q": "self_attn.q",
+        "attn1.to_k": "self_attn.k",
+        "attn1.to_v": "self_attn.v",
+        "attn1.to_out.0": "self_attn.o",
+        "attn2.to_q": "cross_attn.q",
+        "attn2.to_k": "cross_attn.k",
+        "attn2.to_v": "cross_attn.v",
+        "attn2.to_out.0": "cross_attn.o",
+        "ffn.net.0.proj": "ffn.0",
+        "ffn.net.2": "ffn.2",
+    }
+    for diff_seg, lx_seg in rev.items():
+        if diff_seg in diffusers_path:
+            return diffusers_path.replace(diff_seg, lx_seg)
+    return diffusers_path
+
+
+def _resolve_singleton(transformer, diff_path: str):
+    """Resolve a diffusers-style path to (module, tt_dit_dotted_path).
+
+    Returns (None, None) when no match. The tt-dit path is the one
+    consumed by the pipeline mixin's bind/unbind walker — it skips
+    diffusers-only segments like the trailing ``.0`` in ``to_out.0``.
+    """
+    m = re.match(r"blocks\.(\d+)\.(attn1|attn2)\.to_q$", diff_path)
+    if m:
+        block_idx, attn_name = int(m.group(1)), m.group(2)
+        attn = getattr(transformer.blocks[block_idx], attn_name)
+        if not attn.is_self:
+            return attn.to_q, f"blocks.{block_idx}.{attn_name}.to_q"
+        return None, None  # self-attn to_q shouldn't arrive here
+    m = re.match(r"blocks\.(\d+)\.(attn1|attn2)\.to_out\.0$", diff_path)
+    if m:
+        block_idx, attn_name = int(m.group(1)), m.group(2)
+        return getattr(transformer.blocks[block_idx], attn_name).to_out, (f"blocks.{block_idx}.{attn_name}.to_out")
+    m = re.match(r"blocks\.(\d+)\.ffn\.net\.0\.proj$", diff_path)
+    if m:
+        block_idx = int(m.group(1))
+        return transformer.blocks[block_idx].ffn.ff1, f"blocks.{block_idx}.ffn.ff1"
+    m = re.match(r"blocks\.(\d+)\.ffn\.net\.2$", diff_path)
+    if m:
+        block_idx = int(m.group(1))
+        return transformer.blocks[block_idx].ffn.ff2, f"blocks.{block_idx}.ffn.ff2"
+    return None, None
+
+
+def _register_fused_qkv(
+    attn,
+    qkvs: dict[str, dict[str, torch.Tensor]],
+    alphas: dict[str, float],
+    scale: float,
+    name: str,
+) -> tuple[int | None, int]:
+    """Stack Q/K/V (or K/V for cross-attn) LoRA pairs onto attn.to_qkv (or
+    attn.to_kv). Returns (bank_idx, fused_rank) or (None, 0) on skip."""
+    if attn.is_self:
+        required = ["q", "k", "v"]
+        target = attn.to_qkv
+    else:
+        required = ["k", "v"]
+        target = attn.to_kv
+
+    missing = [r for r in required if r not in qkvs]
+    if missing:
+        logger.warning(
+            f"fused QKV LoRA on {target.__class__.__name__} is missing {missing}; "
+            "skipping this group (need all of "
+            f"{required}, got {list(qkvs)})."
+        )
+        return None, 0
+
+    A_per = [qkvs[r]["A"] for r in required]
+    B_per = [qkvs[r]["B"] for r in required]
+    ranks = [A.shape[0] for A in A_per]
+    if len(set(ranks)) != 1:
+        raise ValueError(f"QKV LoRA ranks must match; got {ranks}")
+    r = ranks[0]
+    n = len(required)
+    in_dim = attn.dim
+    out_per = attn.dim  # each of Q/K/V has out=dim
+
+    # A stacked on rank dim → [n*r, in]
+    A_fused = torch.cat(A_per, dim=0)
+    assert A_fused.shape == (n * r, in_dim), f"A_fused {A_fused.shape}"
+
+    # B: each per-source B is [out_per=dim, r]. We embed each into a
+    # [out_per, n*r] tile (zeros for other-source rank columns). Then
+    # head-interleave the list of [out_per, n*r] tiles into a single
+    # [n*out_per, n*r] tensor — matching the head layout of the fused
+    # to_qkv / to_kv base weight.
+    n_dev = attn.parallel_config.tensor_parallel.factor
+    n_local_heads = attn.n_local_heads
+    head_dim = attn.head_dim
+
+    B_per_padded: list[torch.Tensor] = []
+    for i, B in enumerate(B_per):
+        pad = torch.zeros(out_per, n * r, dtype=B.dtype)
+        pad[:, i * r : (i + 1) * r] = B
+        B_per_padded.append(pad)
+
+    B_fused = _head_interleave_lora_B(B_per_padded, n_dev=n_dev, n_local_heads=n_local_heads, head_dim=head_dim)
+    assert B_fused.shape == (n * out_per, n * r), f"B_fused {B_fused.shape}"
+
+    # Effective scale: pick the first source's alpha (alphas are usually
+    # identical across Q/K/V in a single adapter; if not, the choice is
+    # safe-ish because we apply scale to all three the same way).
+    alpha_keys = [_lightx2v_qkv_key(attn, r_name) for r_name in required]
+    alpha = next((alphas[k] for k in alpha_keys if k in alphas), float(r))
+    eff_scale = scale * (alpha / r)
+
+    bank_idx = target.register_lora(A_fused, B_fused, scale=eff_scale, name=name)
+    return bank_idx, n * r
+
+
+def _lightx2v_qkv_key(attn, qkv: str) -> str:
+    """Build the lightx2v alpha key for a Q/K/V projection inside a
+    given WanAttention. The block index is reconstructed from
+    `attn.parent`-ish info we don't have here — so callers pass attn
+    only for ``is_self``."""
+    side = "self_attn" if attn.is_self else "cross_attn"
+    return f"{side}.{qkv}"
+
+
+def _head_interleave_lora_B(
+    tensors: Sequence[torch.Tensor],
+    *,
+    n_dev: int,
+    n_local_heads: int,
+    head_dim: int,
+) -> torch.Tensor:
+    """Mirror of WanAttention._interleave_heads for LoRA B tensors.
+
+    Each input is [out_per_source=num_heads*head_dim, rank_fused].
+    Returns a concatenated [N*out_per, rank_fused] tensor with the out
+    dim head-interleaved so column-parallel sharding lines up with the
+    fused base weight's layout.
+    """
+    out_per = n_dev * n_local_heads * head_dim
+    fused_rank = tensors[0].shape[1]
+    assert all(t.shape == (out_per, fused_rank) for t in tensors), (
+        f"all B tensors must be [{out_per}, {fused_rank}]; got " f"{[tuple(t.shape) for t in tensors]}"
+    )
+    n = len(tensors)
+    # Transpose each to [fused_rank, out_per]
+    transposed = [t.T for t in tensors]
+    # Reshape out dim to [fused_rank, n_dev, n_local_heads, head_dim]
+    reshaped = [t.reshape(fused_rank, n_dev, n_local_heads, head_dim) for t in transposed]
+    # Concat on heads sub-dim → [fused_rank, n_dev, N*n_local_heads, head_dim]
+    merged = torch.cat(reshaped, dim=2)
+    # Flatten back → [fused_rank, N*n_dev*n_local_heads*head_dim] = [fused_rank, N*out_per]
+    merged = merged.reshape(fused_rank, n * out_per)
+    # Transpose to [N*out_per, fused_rank]
+    return merged.T

--- a/models/tt_dit/experimental/pipelines/pipeline_wan_runtime_lora.py
+++ b/models/tt_dit/experimental/pipelines/pipeline_wan_runtime_lora.py
@@ -1,0 +1,257 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Wan 2.2 pipeline with runtime-swappable LoRA adapters.
+
+Constructs the transformer with ``lora_enabled=True`` so every attention
+and FFN Linear is a LoRA-aware variant. Exposes a small API for
+registering and switching adapters at runtime:
+
+  pipeline.register_lora(name, high_path, low_path, scale)  → AdapterHandle
+  pipeline.set_active_lora(handle | None)
+  pipeline.unregister_lora(handle)
+  pipeline.list_loras()
+
+Adapter swap merges the active LoRA delta directly into the base weight:
+``W += scale * A.T @ B.T`` per LoRA Linear, on device, with W's sharding.
+Forward-time LoRA overhead is zero — the captured trace runs the
+un-modified base path. Swap cost is bounded to ~one small matmul + an
+in-place add per LoRA Linear; sub-second end to end. See
+``models/tt_dit/layers/lora.py`` for the merge details.
+
+Out of scope for v0:
+  - Stacking multiple adapters into a single bound slot (callers wanting
+    stacked LoRAs should pre-merge offline, or use the older CPU-fusion
+    pipeline at ``pipeline_wan_lora.py``).
+  - ``.diff`` / ``.diff_b`` direct deltas (the loader warns and skips).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from loguru import logger
+
+from models.tt_dit.experimental.lora.adapter_loader import AdapterHandle, load_adapter_into
+from models.tt_dit.layers.lora import LoRAMixin
+from models.tt_dit.pipelines.wan.pipeline_wan import WanPipeline
+from models.tt_dit.pipelines.wan.pipeline_wan_i2v import WanPipelineI2V
+
+
+@dataclass
+class _RegisteredLoRA:
+    """Per-pipeline record of a registered adapter pair."""
+
+    name: str
+    handle_high: AdapterHandle | None
+    handle_low: AdapterHandle | None
+
+
+@dataclass
+class CombinedAdapterHandle:
+    """Returned by `register_lora`. Knows about both experts."""
+
+    name: str
+    high: AdapterHandle | None
+    low: AdapterHandle | None
+    rank: int = field(init=False)
+
+    def __post_init__(self):
+        ranks = [h.rank for h in (self.high, self.low) if h is not None]
+        if not ranks:
+            raise ValueError(f"adapter '{self.name}' loaded for neither expert")
+        self.rank = max(ranks)
+
+
+def _iter_lora_modules(module):
+    """Yield every LoRAMixin-bearing submodule of `module`, recursively."""
+    if isinstance(module, LoRAMixin):
+        yield module
+    for _, child in module.named_children():
+        yield from _iter_lora_modules(child)
+
+
+class _LoRAPipelineMixin:
+    """Implements the LoRA swap API on top of a WanPipeline subclass.
+
+    Assumes the host pipeline was constructed with ``lora_enabled=True``
+    so both ``self.transformer`` and ``self.transformer_2`` have LoRA-aware
+    Linear modules throughout.
+    """
+
+    def __init__(self, *args, lora_enabled: bool = True, **kwargs):
+        # Initialize LoRA state *before* super().__init__() because the base
+        # pipeline init calls self._prepare_transformer() during warmup, and
+        # our override below reads self._active_adapter_name.
+        self._lora_registry: dict[str, _RegisteredLoRA] = {}
+        self._active_adapter_name: str | None = None
+        super().__init__(*args, lora_enabled=lora_enabled, **kwargs)
+
+    def _prepare_transformer(self, idx: int):
+        """Re-apply any active LoRA delta after the transformer is reloaded.
+
+        Under dynamic_load the two transformers swap in and out of DRAM
+        between uses; each reload restores the cached *base* weights, so
+        the merged LoRA delta is wiped. We walk this transformer's LoRA
+        modules and re-merge their active adapter (no-op for modules that
+        already have the delta applied, e.g., the first load).
+        """
+        super()._prepare_transformer(idx)
+        if self._active_adapter_name is None:
+            return
+        transformer = self.transformer_states[idx].model
+        for mod in _iter_lora_modules(transformer):
+            mod.reapply_after_load()
+
+    # ---- public API ----
+    def register_lora(
+        self,
+        name: str,
+        *,
+        high_path: str | Path | None = None,
+        low_path: str | Path | None = None,
+        scale: float = 1.0,
+    ) -> CombinedAdapterHandle:
+        """Load a LoRA adapter for one or both experts.
+
+        Both ``high_path`` and ``low_path`` are independently optional — pass
+        either or both. Adapter weights are parsed from disk and stored on the
+        host LoRA bank of every applicable Linear in the respective transformer;
+        device-side merge happens later in ``set_active_lora`` (fuse mode) or
+        in the layer's forward (runtime mode). Device-OOM therefore surfaces
+        at ``set_active_lora`` time, not here.
+        """
+        if not high_path and not low_path:
+            raise ValueError("register_lora requires high_path and/or low_path")
+        if name in self._lora_registry:
+            raise ValueError(f"LoRA name '{name}' already registered")
+
+        high_handle = None
+        low_handle = None
+
+        if high_path is not None:
+            logger.info(f"loading LoRA '{name}' high-noise from {high_path} (scale={scale})")
+            high_handle = load_adapter_into(self.transformer, str(high_path), scale=scale, name=name)
+        if low_path is not None:
+            logger.info(f"loading LoRA '{name}' low-noise from {low_path} (scale={scale})")
+            low_handle = load_adapter_into(self.transformer_2, str(low_path), scale=scale, name=name)
+
+        combined = CombinedAdapterHandle(name=name, high=high_handle, low=low_handle)
+        self._lora_registry[name] = _RegisteredLoRA(name=name, handle_high=high_handle, handle_low=low_handle)
+        return combined
+
+    def unregister_lora(self, handle: CombinedAdapterHandle | str) -> None:
+        name = handle if isinstance(handle, str) else handle.name
+        rec = self._lora_registry.pop(name, None)
+        if rec is None:
+            return
+        if self._active_adapter_name == name:
+            self.set_active_lora(None)
+        # Walk and unregister bank entries
+        for transformer, handle_ in (
+            (self.transformer, rec.handle_high),
+            (self.transformer_2, rec.handle_low),
+        ):
+            if handle_ is None:
+                continue
+            self._unregister_handle(transformer, handle_)
+
+    def set_active_lora(self, handle: CombinedAdapterHandle | str | None) -> None:
+        """Bind the named adapter as the active LoRA for both experts.
+
+        Each LoRA Linear's bind merges the new delta into the base weight
+        in-place. If a different adapter is currently active, its delta is
+        subtracted first. Passing ``None`` removes the active delta (W is
+        restored to its base value).
+        """
+        if handle is None:
+            self._unbind_all()
+            self._active_adapter_name = None
+            return
+
+        name = handle if isinstance(handle, str) else handle.name
+        rec = self._lora_registry.get(name)
+        if rec is None:
+            raise KeyError(f"no LoRA registered with name '{name}'")
+
+        self._bind_per_module(self.transformer, rec.handle_high)
+        self._bind_per_module(self.transformer_2, rec.handle_low)
+        self._active_adapter_name = name
+
+    def list_loras(self) -> list[str]:
+        return list(self._lora_registry)
+
+    def deallocate_all_loras(self) -> None:
+        """Unbind every active adapter and clear the LoRA bank on every layer.
+
+        Releases host-side adapter records across both transformers. Use this
+        on a long-running server to reset state between unrelated jobs.
+        """
+        self._unbind_all()
+        self._active_adapter_name = None
+        self._lora_registry.clear()
+        for transformer in (self.transformer, self.transformer_2):
+            for mod in _iter_lora_modules(transformer):
+                mod.deallocate_lora()
+
+    # ---- internals ----
+    def _path_to_module(self, transformer, dotted: str):
+        """Resolve a dotted path like ``blocks.0.attn1.to_qkv`` to a child module."""
+        cur = transformer
+        for part in dotted.split("."):
+            if part.isdigit():
+                cur = cur[int(part)]
+            else:
+                cur = getattr(cur, part)
+        return cur
+
+    def _bind_per_module(self, transformer, handle: AdapterHandle | None):
+        addressed: set[int] = set()
+        if handle is not None:
+            for dotted, bank_idx in handle.target_indices.items():
+                mod = self._path_to_module(transformer, dotted)
+                mod.bind_active(bank_idx)
+                addressed.add(id(mod))
+
+        # Any LoRA module not touched by this adapter (including the all-orphan
+        # case where handle is None, e.g. switching to an adapter that only
+        # covers the other expert) but currently active from a previous bind
+        # must have its delta removed.
+        for mod in _iter_lora_modules(transformer):
+            if id(mod) in addressed:
+                continue
+            if mod.is_lora_active:
+                mod.unbind_active()
+
+    def _unbind_all(self):
+        for transformer in (self.transformer, self.transformer_2):
+            for mod in _iter_lora_modules(transformer):
+                if mod.is_lora_active:
+                    mod.unbind_active()
+
+    def _unregister_handle(self, transformer, handle: AdapterHandle):
+        for dotted, bank_idx in handle.target_indices.items():
+            mod = self._path_to_module(transformer, dotted)
+            mod.unregister_lora(bank_idx)
+
+
+# --------------------------------------------------------------------
+# Public pipeline classes
+# --------------------------------------------------------------------
+class WanPipelineRuntimeLoRA(_LoRAPipelineMixin, WanPipeline):
+    """T2V pipeline with runtime LoRA support."""
+
+    @staticmethod
+    def create_pipeline(*args, **kwargs):
+        kwargs["checkpoint_name"] = kwargs.get("checkpoint_name") or "Wan-AI/Wan2.2-T2V-A14B-Diffusers"
+        return WanPipeline.create_pipeline(*args, pipeline_class=WanPipelineRuntimeLoRA, **kwargs)
+
+
+class WanPipelineI2VRuntimeLoRA(_LoRAPipelineMixin, WanPipelineI2V):
+    """I2V pipeline with runtime LoRA support."""
+
+    @staticmethod
+    def create_pipeline(*args, **kwargs):
+        kwargs["checkpoint_name"] = kwargs.get("checkpoint_name") or "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
+        return WanPipeline.create_pipeline(*args, pipeline_class=WanPipelineI2VRuntimeLoRA, **kwargs)

--- a/models/tt_dit/experimental/tests/test_adapter_loader.py
+++ b/models/tt_dit/experimental/tests/test_adapter_loader.py
@@ -1,0 +1,224 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Integration tests for the runtime-LoRA adapter loader.
+
+Builds a tiny WanTransformer3DModel (1 block) with ``lora_enabled=True``,
+writes a synthetic LoRA safetensors file, runs ``load_adapter_into``, and
+checks that:
+
+  - every LoRA-aware Linear in the block got an adapter registered
+  - ``bind_active`` marks the right modules active across all paths
+  - ``unbind_active`` clears the active state
+
+The forward math is covered by ``test_lora_variants.py``; this file
+exercises the loader's key-mapping logic and the pipeline-mixin bind
+flow against the default (``fuse``) mode.
+
+Run with:
+    pytest -xvs models/tt_dit/experimental/tests/test_adapter_loader.py
+"""
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+import torch
+
+import ttnn
+from models.tt_dit.experimental.lora.adapter_loader import load_adapter_into
+from models.tt_dit.layers.lora import LoRAMixin
+from models.tt_dit.models.transformers.wan2_2.transformer_wan import WanTransformer3DModel
+from models.tt_dit.parallel.config import DiTParallelConfig, ParallelFactor
+from models.tt_dit.parallel.manager import CCLManager
+
+
+def _save_synthetic_adapter(
+    path: Path,
+    *,
+    num_blocks: int = 1,
+    dim: int = 128,
+    ffn_dim: int = 256,
+    rank: int = 8,
+) -> None:
+    """Write a fake LoRA safetensors that covers all 6 LoRA-targeted Linears
+    per block, using the lightx2v naming convention."""
+    from safetensors.torch import save_file
+
+    state: dict[str, torch.Tensor] = {}
+    dtype = torch.bfloat16
+
+    def add_pair(base: str, in_dim: int, out_dim: int):
+        state[f"{base}.lora_A.weight"] = torch.randn(rank, in_dim, dtype=dtype) * 0.02
+        state[f"{base}.lora_B.weight"] = torch.randn(out_dim, rank, dtype=dtype) * 0.02
+
+    for i in range(num_blocks):
+        # self-attn Q, K, V, O
+        add_pair(f"blocks.{i}.self_attn.q", dim, dim)
+        add_pair(f"blocks.{i}.self_attn.k", dim, dim)
+        add_pair(f"blocks.{i}.self_attn.v", dim, dim)
+        add_pair(f"blocks.{i}.self_attn.o", dim, dim)
+        # cross-attn Q, K, V, O
+        add_pair(f"blocks.{i}.cross_attn.q", dim, dim)
+        add_pair(f"blocks.{i}.cross_attn.k", dim, dim)
+        add_pair(f"blocks.{i}.cross_attn.v", dim, dim)
+        add_pair(f"blocks.{i}.cross_attn.o", dim, dim)
+        # ffn ff1, ff2 (lightx2v naming: ffn.0 = ff1, ffn.2 = ff2)
+        add_pair(f"blocks.{i}.ffn.0", dim, ffn_dim)
+        add_pair(f"blocks.{i}.ffn.2", ffn_dim, dim)
+
+    save_file(state, str(path))
+
+
+def _count_registered(transformer) -> int:
+    """Count LoRA modules with at least one entry in their bank."""
+    n = 0
+    for mod in _iter_lora_modules(transformer):
+        if any(a is not None for a in mod.lora_bank):
+            n += 1
+    return n
+
+
+def _iter_lora_modules(module):
+    if isinstance(module, LoRAMixin):
+        yield module
+    for _, child in module.named_children():
+        yield from _iter_lora_modules(child)
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+def test_adapter_loader_registers_all_lora_linears(mesh_device: ttnn.MeshDevice) -> None:
+    """Loader picks up Q/K/V/O for both attn1/attn2 plus ff1/ff2 per block."""
+    num_heads = 4
+    head_dim = 32
+    dim = num_heads * head_dim
+    ffn_dim = 2 * dim
+    rank = 8
+    num_blocks = 1
+
+    parallel_config = DiTParallelConfig(
+        cfg_parallel=ParallelFactor(factor=1, mesh_axis=0),
+        tensor_parallel=ParallelFactor(factor=1, mesh_axis=1),
+        sequence_parallel=ParallelFactor(factor=1, mesh_axis=0),
+    )
+    ccl_manager = CCLManager(mesh_device, topology=ttnn.Topology.Linear)
+
+    transformer = WanTransformer3DModel(
+        patch_size=(1, 2, 2),
+        num_heads=num_heads,
+        dim=dim,
+        in_channels=16,
+        out_channels=16,
+        text_dim=128,
+        freq_dim=64,
+        ffn_dim=ffn_dim,
+        num_layers=num_blocks,
+        mesh_device=mesh_device,
+        ccl_manager=ccl_manager,
+        parallel_config=parallel_config,
+        is_fsdp=False,
+        lora_enabled=True,
+    )
+
+    # Every block should have 5 LoRA-aware Linears wired in: to_qkv (self),
+    # to_q (cross), to_kv (cross), to_out for each attention (×2), ff1, ff2.
+    # That's 1 + 1 + 1 + 2 + 1 + 1 = 7 modules per block.
+    expected_per_block = 7
+    n_modules = sum(1 for _ in _iter_lora_modules(transformer))
+    assert (
+        n_modules == num_blocks * expected_per_block
+    ), f"expected {num_blocks * expected_per_block} LoRA modules; got {n_modules}"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        adapter_path = Path(tmp) / "synthetic.safetensors"
+        _save_synthetic_adapter(adapter_path, num_blocks=num_blocks, dim=dim, ffn_dim=ffn_dim, rank=rank)
+
+        handle = load_adapter_into(transformer, str(adapter_path), scale=1.0, name="synthetic")
+
+    # All 7 LoRA modules per block should have a registered adapter.
+    registered = _count_registered(transformer)
+    assert (
+        registered == num_blocks * expected_per_block
+    ), f"expected {num_blocks * expected_per_block} registered adapters; got {registered}"
+
+    # Fused-QKV (to_qkv self-attn): rank should be 3*r. Fused KV (cross-attn
+    # to_kv): rank should be 2*r. Singletons: rank = r.
+    block0 = transformer.blocks[0]
+    assert block0.attn1.to_qkv.lora_bank[0].rank == 3 * rank
+    assert block0.attn2.to_kv.lora_bank[0].rank == 2 * rank
+    assert block0.attn2.to_q.lora_bank[0].rank == rank
+    assert block0.attn1.to_out.lora_bank[0].rank == rank
+    assert block0.attn2.to_out.lora_bank[0].rank == rank
+    assert block0.ffn.ff1.lora_bank[0].rank == rank
+    assert block0.ffn.ff2.lora_bank[0].rank == rank
+
+    # handle.rank tracks the max rank across targets (3*rank for the fused-QKV group).
+    assert handle.rank == 3 * rank
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+def test_pipeline_bind_unbind_walks_all_modules(mesh_device: ttnn.MeshDevice) -> None:
+    """The pipeline mixin's bind/unbind walks every LoRA module on each set_active_lora."""
+    from models.tt_dit.experimental.pipelines.pipeline_wan_runtime_lora import _iter_lora_modules as pipeline_iter
+
+    num_heads = 4
+    head_dim = 32
+    dim = num_heads * head_dim
+    ffn_dim = 2 * dim
+    rank = 8
+
+    parallel_config = DiTParallelConfig(
+        cfg_parallel=ParallelFactor(factor=1, mesh_axis=0),
+        tensor_parallel=ParallelFactor(factor=1, mesh_axis=1),
+        sequence_parallel=ParallelFactor(factor=1, mesh_axis=0),
+    )
+    ccl_manager = CCLManager(mesh_device, topology=ttnn.Topology.Linear)
+
+    transformer = WanTransformer3DModel(
+        patch_size=(1, 2, 2),
+        num_heads=num_heads,
+        dim=dim,
+        in_channels=16,
+        out_channels=16,
+        text_dim=128,
+        freq_dim=64,
+        ffn_dim=ffn_dim,
+        num_layers=1,
+        mesh_device=mesh_device,
+        ccl_manager=ccl_manager,
+        parallel_config=parallel_config,
+        is_fsdp=False,
+        lora_enabled=True,
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        adapter_path = Path(tmp) / "synthetic.safetensors"
+        _save_synthetic_adapter(adapter_path, num_blocks=1, dim=dim, ffn_dim=ffn_dim, rank=rank)
+        handle = load_adapter_into(transformer, str(adapter_path), name="synthetic")
+
+    # Simulate the bind path the pipeline mixin runs.
+    for dotted, bank_idx in handle.target_indices.items():
+        cur = transformer
+        for part in dotted.split("."):
+            cur = cur[int(part)] if part.isdigit() else getattr(cur, part)
+        cur.bind_active(bank_idx)
+
+    # All modules covered by the handle should be active (delta merged).
+    for dotted in handle.target_indices:
+        cur = transformer
+        for part in dotted.split("."):
+            cur = cur[int(part)] if part.isdigit() else getattr(cur, part)
+        assert cur.is_lora_active, f"{dotted} not active after bind_active"
+
+    # Unbind everything → delta subtracted, is_lora_active False.
+    for mod in pipeline_iter(transformer):
+        if mod.is_lora_active:
+            mod.unbind_active()
+    for dotted in handle.target_indices:
+        cur = transformer
+        for part in dotted.split("."):
+            cur = cur[int(part)] if part.isdigit() else getattr(cur, part)
+        assert not cur.is_lora_active
+        assert cur.active_idx is None

--- a/models/tt_dit/experimental/tests/test_lora_variants.py
+++ b/models/tt_dit/experimental/tests/test_lora_variants.py
@@ -1,0 +1,262 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Parity tests for the three LoRA-aware Linear subclasses, each exercised
+under both ``lora_mode`` options:
+
+  fuse     — bind merges ``scale * A.T @ B.T`` into the base weight in-place.
+             Forward runs the un-modified base path.
+  runtime  — bind uploads A, B to device; forward adds
+             ``scale * (x @ A) @ B`` on top of the base output.
+
+The unbind branch is checked in both modes — for ``fuse`` it subtracts
+the delta back out of W; for ``runtime`` it frees the A/B tensors so the
+forward path collapses to the base.
+
+Mesh shape is 1x1 so sharding collapses to the replicated case for all
+three variants. The tests still exercise the LoRA-specific upload and
+forward code paths and catch class-level bugs in shape handling,
+fused-activation fallback, and chunked-output handling.
+
+Run with:
+    pytest -xvs models/tt_dit/experimental/tests/test_lora_variants.py
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+
+import ttnn
+from models.tt_dit.layers.linear import LoRAColParallelLinear, LoRALinear, LoRARowParallelLinear
+from models.tt_dit.utils.check import assert_quality
+from models.tt_dit.utils.tensor import bf16_tensor
+
+
+def _make_pair(in_features: int, out_features: int, rank: int, dtype: torch.dtype):
+    A = torch.randn(rank, in_features, dtype=dtype) * 0.02
+    B = torch.randn(out_features, rank, dtype=dtype) * 0.02
+    return A, B
+
+
+def _ref_lora(x, W, b, A, B, scale):
+    """y = x @ (W + scale * B @ A).T + b"""
+    W_eff = W + scale * (B @ A)
+    return torch.nn.functional.linear(x, W_eff, b)
+
+
+# --------------------------------------------------------------------
+# LoRALinear (replicated)
+# --------------------------------------------------------------------
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+@pytest.mark.parametrize("lora_mode", ["fuse", "runtime"])
+@pytest.mark.parametrize(
+    ("seq_len", "in_features", "out_features", "rank"),
+    [
+        (128, 256, 256, 8),
+        (256, 512, 1024, 16),
+    ],
+)
+def test_lora_linear_variant(
+    mesh_device: ttnn.MeshDevice,
+    lora_mode: str,
+    seq_len: int,
+    in_features: int,
+    out_features: int,
+    rank: int,
+) -> None:
+    torch.manual_seed(0)
+    dtype = torch.bfloat16
+    scale = 0.6
+
+    torch_lin = torch.nn.Linear(in_features, out_features, bias=True).to(dtype=dtype)
+    torch_lin.eval()
+    A_t, B_t = _make_pair(in_features, out_features, rank, dtype)
+    x_t = torch.randn(1, 1, seq_len, in_features, dtype=dtype)
+
+    with torch.no_grad():
+        y_base = torch_lin(x_t)
+        y_lora = _ref_lora(x_t, torch_lin.weight, torch_lin.bias, A_t, B_t, scale)
+
+    tt = LoRALinear(in_features, out_features, bias=True, mesh_device=mesh_device, lora_mode=lora_mode)
+    tt.load_torch_state_dict(torch_lin.state_dict())
+    idx = tt.register_lora(A_t, B_t, scale=scale)
+    x_tt = bf16_tensor(x_t, device=mesh_device)
+
+    # 1) no adapter bound → base behavior
+    y = tt(x_tt)
+    for t in ttnn.get_device_tensors(y):
+        assert_quality(y_base, ttnn.to_torch(t), pcc=0.999_5)
+
+    # 2) bind active → LoRA effect applied
+    tt.bind_active(idx, scale=scale)
+    y = tt(x_tt)
+    for t in ttnn.get_device_tensors(y):
+        assert_quality(y_lora, ttnn.to_torch(t), pcc=0.999_0)
+
+    # 3) unbind collapses back to base
+    tt.unbind_active()
+    y = tt(x_tt)
+    for t in ttnn.get_device_tensors(y):
+        assert_quality(y_base, ttnn.to_torch(t), pcc=0.999_5)
+
+    tt.deallocate_lora()
+
+
+# --------------------------------------------------------------------
+# LoRAColParallelLinear — single output and chunked output
+# --------------------------------------------------------------------
+# Chunked configs run fuse-only: the runtime delta path doesn't split
+# its delta into the same chunk layout as the base output.
+_COL_PARALLEL_PARAMS = [
+    # (label, lora_mode, seq, in, out, rank, chunks, activation_fn)
+    ("plain_fuse", "fuse", 128, 256, 512, 8, None, None),
+    ("plain_runtime", "runtime", 128, 256, 512, 8, None, None),
+    ("gelu_fuse", "fuse", 128, 256, 1024, 8, None, "gelu"),
+    ("gelu_runtime", "runtime", 128, 256, 1024, 8, None, "gelu"),
+    ("chunked_qkv_fuse", "fuse", 128, 256, 3 * 256, 8, 3, None),
+]
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+@pytest.mark.parametrize(
+    ("lora_mode", "seq_len", "in_features", "out_features", "rank", "chunks", "activation_fn"),
+    [params[1:] for params in _COL_PARALLEL_PARAMS],
+    ids=[params[0] for params in _COL_PARALLEL_PARAMS],
+)
+def test_lora_col_parallel_variant(
+    mesh_device: ttnn.MeshDevice,
+    lora_mode: str,
+    seq_len: int,
+    in_features: int,
+    out_features: int,
+    rank: int,
+    chunks: int | None,
+    activation_fn: str | None,
+) -> None:
+    torch.manual_seed(0)
+    dtype = torch.bfloat16
+    scale = 0.5
+
+    torch_lin = torch.nn.Linear(in_features, out_features, bias=True).to(dtype=dtype)
+    torch_lin.eval()
+    A_t, B_t = _make_pair(in_features, out_features, rank, dtype)
+    x_t = torch.randn(1, 1, seq_len, in_features, dtype=dtype)
+
+    def torch_act(y):
+        if activation_fn == "gelu":
+            return torch.nn.functional.gelu(y)
+        return y
+
+    with torch.no_grad():
+        y_base = torch_act(torch_lin(x_t))
+        y_lora = torch_act(_ref_lora(x_t, torch_lin.weight, torch_lin.bias, A_t, B_t, scale))
+
+    tt = LoRAColParallelLinear(
+        in_features,
+        out_features,
+        bias=True,
+        mesh_device=mesh_device,
+        mesh_axis=0,
+        activation_fn=activation_fn,
+        chunks=chunks,
+        lora_mode=lora_mode,
+    )
+    tt.load_torch_state_dict(torch_lin.state_dict())
+    idx = tt.register_lora(A_t, B_t, scale=scale)
+    x_tt = bf16_tensor(x_t, device=mesh_device)
+
+    def _join(out):
+        """Concat chunked outputs along last dim; pass through single tensors."""
+        if isinstance(out, list):
+            torch_chunks = [ttnn.to_torch(ttnn.get_device_tensors(o)[0]) for o in out]
+            return torch.cat(torch_chunks, dim=-1)
+        return ttnn.to_torch(ttnn.get_device_tensors(out)[0])
+
+    # 1) no adapter bound → base behavior
+    assert_quality(y_base, _join(tt(x_tt)), pcc=0.999_5)
+
+    # 2) bind active → LoRA effect applied
+    tt.bind_active(idx, scale=scale)
+    assert_quality(y_lora, _join(tt(x_tt)), pcc=0.999_0)
+
+    # 3) unbind collapses to base
+    tt.unbind_active()
+    assert_quality(y_base, _join(tt(x_tt)), pcc=0.999_0)
+
+    tt.deallocate_lora()
+
+
+# --------------------------------------------------------------------
+# LoRARowParallelLinear — N_tp=1 (1x1 mesh) sanity
+# --------------------------------------------------------------------
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+@pytest.mark.parametrize("lora_mode", ["fuse", "runtime"])
+@pytest.mark.parametrize(
+    ("seq_len", "in_features", "out_features", "rank"),
+    [
+        (128, 512, 256, 8),
+        (256, 1024, 512, 16),
+    ],
+)
+def test_lora_row_parallel_variant(
+    mesh_device: ttnn.MeshDevice,
+    lora_mode: str,
+    seq_len: int,
+    in_features: int,
+    out_features: int,
+    rank: int,
+) -> None:
+    from models.tt_dit.parallel.manager import CCLManager
+
+    torch.manual_seed(0)
+    dtype = torch.bfloat16
+    scale = 0.4
+
+    torch_lin = torch.nn.Linear(in_features, out_features, bias=True).to(dtype=dtype)
+    torch_lin.eval()
+    A_t, B_t = _make_pair(in_features, out_features, rank, dtype)
+    x_t = torch.randn(1, 1, seq_len, in_features, dtype=dtype)
+
+    with torch.no_grad():
+        y_base = torch_lin(x_t)
+        y_lora = _ref_lora(x_t, torch_lin.weight, torch_lin.bias, A_t, B_t, scale)
+
+    ccl_manager = CCLManager(mesh_device, topology=ttnn.Topology.Linear)
+    tt = LoRARowParallelLinear(
+        in_features,
+        out_features,
+        bias=True,
+        mesh_device=mesh_device,
+        mesh_axis=0,
+        ccl_manager=ccl_manager,
+        lora_mode=lora_mode,
+    )
+    tt.load_torch_state_dict(torch_lin.state_dict())
+    idx = tt.register_lora(A_t, B_t, scale=scale)
+    x_tt = bf16_tensor(x_t, device=mesh_device)
+
+    # baseline
+    y = tt(x_tt)
+    assert_quality(y_base, ttnn.to_torch(ttnn.get_device_tensors(y)[0]), pcc=0.999_5)
+
+    # bind active
+    tt.bind_active(idx, scale=scale)
+    y = tt(x_tt)
+    assert_quality(y_lora, ttnn.to_torch(ttnn.get_device_tensors(y)[0]), pcc=0.999_0)
+
+    # unbind
+    tt.unbind_active()
+    y = tt(x_tt)
+    assert_quality(y_base, ttnn.to_torch(ttnn.get_device_tensors(y)[0]), pcc=0.999_5)
+
+    tt.deallocate_lora()
+
+
+# --------------------------------------------------------------------
+# Construction-time validation
+# --------------------------------------------------------------------
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+def test_invalid_lora_mode_raises(mesh_device: ttnn.MeshDevice) -> None:
+    with pytest.raises(ValueError, match="lora_mode"):
+        LoRALinear(64, 64, bias=False, mesh_device=mesh_device, lora_mode="bogus")


### PR DESCRIPTION
## PR Category
Feature

## Summary

Experimental **runtime (hot-swappable) LoRA** for Wan2.2:

- `experimental/lora/adapter_loader.py` — load/convert LoRA safetensors into device-ready
  handles (lightx2v + diffusers key conventions).
- `experimental/pipelines/pipeline_wan_runtime_lora.py` — `WanPipeline` subclass that
  registers and binds adapters **per request** via the `LoRAMixin` runtime path.
- `experimental/tests/{test_adapter_loader,test_lora_variants}.py` — coverage.

Additive, under `models/tt_dit/experimental/` — no existing files change.

## Notes for reviewers

**Draft — depends on two other PRs and should land after them:**
- LoRA layer primitives PR (`LoRAMixin`) — #47508
- Wan2.2 `lora_enabled` wiring PR (forthcoming, stacks on #47265)

Will be marked ready once both have merged.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=stisi/wan-runtime-lora-experimental)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:stisi/wan-runtime-lora-experimental)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=stisi/wan-runtime-lora-experimental)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:stisi/wan-runtime-lora-experimental)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=stisi/wan-runtime-lora-experimental)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:stisi/wan-runtime-lora-experimental)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=stisi/wan-runtime-lora-experimental)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:stisi/wan-runtime-lora-experimental)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=stisi/wan-runtime-lora-experimental)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:stisi/wan-runtime-lora-experimental)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=stisi/wan-runtime-lora-experimental)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:stisi/wan-runtime-lora-experimental)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=stisi/wan-runtime-lora-experimental)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:stisi/wan-runtime-lora-experimental)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=stisi/wan-runtime-lora-experimental)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:stisi/wan-runtime-lora-experimental)