### PR TITLE
Fix fast untilize wide strided pack

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_pack_fast_untilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_pack_fast_untilize_api.h
@@ -59,8 +59,9 @@ inline void llk_pack_fast_untilize_block_strided(
     const std::uint32_t output_row_address =
         get_output_tile_address<true, PackMode::Default>(output_id, output_tile_index);
     const std::uint32_t chunk_offset = SCALE_DATUM_SIZE(pack_dst_format[output_id], tile_offset * TILE_C_DIM) / 16;
+    const std::uint32_t output_row_stride = SCALE_DATUM_SIZE(pack_dst_format[output_id], full_ct_dim * TILE_C_DIM) / 16;
     ckernel::_llk_pack_fast_untilize_block_strided_<block_ct_dim, full_ct_dim>(
-        output_row_address + chunk_offset, unit_dim, prev_unit_dim);
+        output_row_address + chunk_offset, unit_dim, prev_unit_dim, output_row_stride);
 }
 
 template <std::uint32_t block_ct_dim, std::uint32_t full_ct_dim>

--- a/tt_metal/tt-llk/tests/python_tests/test_fast_untilize.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_fast_untilize.py
@@ -29,9 +29,9 @@ from fast_untilize_common import (
     fast_untilize_formats,
 )
 from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
-from helpers.format_config import DataFormat
+from helpers.format_config import DataFormat, InputOutputFormat
 from helpers.golden_generators import UntilizeGolden, get_golden_generator
-from helpers.llk_params import PerfRunType, format_dict
+from helpers.llk_params import DestAccumulation, DestSync, PerfRunType, format_dict
 from helpers.param_config import parametrize
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import StimuliSpec, generate_stimuli
@@ -107,14 +107,9 @@ def make_fast_untilize_test_config(
     )
 
 
-@parametrize(
-    formats=fast_untilize_formats(),
-    dest_acc=fast_untilize_dest_acc_modes,
-    dimensions=FAST_UNTILIZE_DIMS,
-    dest_sync=FAST_UNTILIZE_DEST_SYNC_MODES,
-    stimulus_kind=["row_id", "random"],
-)
-def test_fast_untilize(formats, dest_acc, dimensions, dest_sync, stimulus_kind):
+def _run_fast_untilize_correctness(
+    formats, dest_acc, dimensions, dest_sync, stimulus_kind, allocate_src_b=True
+):
     if get_chip_architecture() != ChipArchitecture.BLACKHOLE:
         pytest.skip("BH only")
 
@@ -139,6 +134,9 @@ def test_fast_untilize(formats, dest_acc, dimensions, dest_sync, stimulus_kind):
         src_A = generate_tile_face_row_ids(
             tile_count, dtype=format_dict[formats.input_format]
         )
+    if not allocate_src_b:
+        src_B = torch.empty(0, dtype=format_dict[formats.input_format_B])
+        tile_cnt_B = 0
 
     generate_golden = get_golden_generator(UntilizeGolden)
     golden_tensor = generate_golden(
@@ -202,6 +200,71 @@ def test_fast_untilize(formats, dest_acc, dimensions, dest_sync, stimulus_kind):
             f"result_context={res_tensor[context_start:context_end].tolist()} "
             f"golden_context={golden_tensor[context_start:context_end].tolist()}"
         )
+
+
+@parametrize(
+    formats=fast_untilize_formats(),
+    dest_acc=fast_untilize_dest_acc_modes,
+    dimensions=FAST_UNTILIZE_DIMS,
+    dest_sync=FAST_UNTILIZE_DEST_SYNC_MODES,
+    stimulus_kind=["row_id", "random"],
+)
+def test_fast_untilize(formats, dest_acc, dimensions, dest_sync, stimulus_kind):
+    _run_fast_untilize_correctness(
+        formats, dest_acc, dimensions, dest_sync, stimulus_kind
+    )
+
+
+def test_fast_untilize_wide_full_ct_dim_133_bf16():
+    _run_fast_untilize_correctness(
+        InputOutputFormat(DataFormat.Float16_b, DataFormat.Float16_b),
+        DestAccumulation.No,
+        (1, 133),
+        DestSync.Half,
+        "row_id",
+        allocate_src_b=False,
+    )
+
+
+def test_fast_untilize_wide_full_ct_dim_256_bf16():
+    _run_fast_untilize_correctness(
+        InputOutputFormat(DataFormat.Float16_b, DataFormat.Float16_b),
+        DestAccumulation.No,
+        (1, 256),
+        DestSync.Half,
+        "row_id",
+        allocate_src_b=False,
+    )
+
+
+# fp32 output doubles the byte row-stride vs bf16, so the carried output-Y
+# window (256 KiB) is reached at half the row width. The phase-2 rebase fires at
+# ct >= 67; the row still fits inside a single 16-row phase (15 * stride < window)
+# up to ct = 136, so this width is in the rebase-fixable band.
+def test_fast_untilize_wide_full_ct_dim_133_fp32():
+    _run_fast_untilize_correctness(
+        InputOutputFormat(DataFormat.Float32, DataFormat.Float32),
+        DestAccumulation.Yes,
+        (1, 133),
+        DestSync.Half,
+        "row_id",
+        allocate_src_b=False,
+    )
+
+
+# At ct = 137 a single 16-row phase overflows the carried output-Y window
+# (15 * output_row_stride >= 256 KiB), so the strided pack splits each phase into
+# sub-runs (rows_per_run = 8 here) and rebases the L1 base per sub-run. Without
+# the sub-run rebase this corrupts on silicon (golden 8768 vs 13073.57).
+def test_fast_untilize_wide_full_ct_dim_137_fp32():
+    _run_fast_untilize_correctness(
+        InputOutputFormat(DataFormat.Float32, DataFormat.Float32),
+        DestAccumulation.Yes,
+        (1, 137),
+        DestSync.Half,
+        "row_id",
+        allocate_src_b=False,
+    )
 
 
 @parametrize(

--- a/tt_metal/tt-llk/tests/sources/fast_untilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/fast_untilize_test.cpp
@@ -23,8 +23,8 @@ std::uint32_t unp_cfg_context          = 0;
 std::uint32_t pack_sync_tile_dst_ptr   = 0;
 std::uint32_t math_sync_tile_dst_index = 0;
 
-constexpr std::uint32_t MAX_UNITS_PER_ROW            = 16;
 constexpr bool FAST_UNTILIZE_SINGLE_UNIT             = FULL_CT_DIM <= ckernel::FAST_UNTILIZE_MAX_UNIT_DIM;
+constexpr std::uint32_t MAX_UNITS_PER_ROW            = (FULL_CT_DIM + ckernel::FAST_UNTILIZE_MAX_UNIT_DIM - 1) / ckernel::FAST_UNTILIZE_MAX_UNIT_DIM;
 constexpr std::uint32_t FAST_UNTILIZE_FIRST_UNIT_DIM = ckernel::fast_untilize_next_unit_dim(FULL_CT_DIM);
 constexpr bool FAST_UNTILIZE_BFP_B_INPUT =
     UNPACK_A_IN == ckernel::to_underlying(DataFormat::Bfp8_b) || UNPACK_A_IN == ckernel::to_underlying(DataFormat::Bfp4_b);
@@ -296,6 +296,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             std::uint32_t unit_dims[MAX_UNITS_PER_ROW];
             const std::uint32_t units_per_row = ckernel::fast_untilize_decompose_row(FULL_CT_DIM, unit_dims);
             std::uint32_t prev_pack_unit_dim  = 0;
+            const std::uint32_t output_row_stride_16B = SCALE_DATUM_SIZE(formats.pack_dst, FULL_CT_DIM * TILE_C_DIM) / 16;
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
                 for (std::uint32_t rt = 0; rt < FULL_RT_DIM; rt++)
@@ -314,7 +315,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                             _llk_packer_wait_for_math_done_();
                         }
                         ckernel::_llk_pack_fast_untilize_block_strided_<ckernel::FAST_UNTILIZE_MAX_UNIT_DIM, FULL_CT_DIM>(
-                            chunk_address, unit_dim, prev_pack_unit_dim);
+                            chunk_address, unit_dim, prev_pack_unit_dim, output_row_stride_16B);
                         if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
                         {
                             _llk_pack_dest_section_done_<FAST_UNTILIZE_INTERNAL_DEST_SYNC, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_pack_fast_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_pack_fast_untilize.h
@@ -179,11 +179,14 @@ inline void _llk_pack_fast_untilize_reset_output_row_counter_()
     TTI_SETADCXY(p_setadc::PAC, 0, 0, 0, 0, 0b1000);
 }
 
-inline void _llk_pack_fast_untilize_strided_mop_config_(const std::uint32_t unit_dim)
+inline void _llk_pack_fast_untilize_strided_mop_config_(const std::uint32_t unit_dim, const std::uint32_t rows_per_run)
 {
     LLK_ASSERT(unit_dim >= 2 && unit_dim <= 4, "fast_untilize strided pack supports unit_dim 2, 3, or 4");
 
-    constexpr std::uint32_t MOP_OUTER_LOOP = FAST_UNTILIZE_PHASE_ROWS;
+    // One MOP run emits rows_per_run output rows. A phase is split into
+    // FAST_UNTILIZE_PHASE_ROWS / rows_per_run runs so the carried output-Y
+    // offset stays inside the packer window (see _llk_pack_fast_untilize_block_strided_).
+    const std::uint32_t MOP_OUTER_LOOP     = rows_per_run;
     constexpr std::uint32_t MOP_INNER_LOOP = 1;
 
     if (unit_dim == 2)
@@ -347,32 +350,93 @@ inline void _llk_pack_fast_untilize_block_(const std::uint32_t address, const st
     _llk_pack_fast_untilize_restore_pack_counters_<false>();
 }
 
+// The packer carries the destination Y offset (ADC.Y * Ystride) relative to the
+// last-programmed L1 base. On BH silicon that carried offset is only reliably
+// preserved inside a ~256 KiB window; beyond it the high address bits are
+// dropped and rows overwrite each other (verified on silicon: BF16 full_ct_dim
+// 133/256 corrupt without a rebase, FP32 corrupts from ~ct 137). The window is
+// not pinned down in the public BH ISA docs (see
+// _llk_pack_fast_untilize_program_output_row_stride_); 256 KiB is the
+// silicon-characterized bound used here.
+constexpr std::uint32_t PACKER_CARRIED_OUTPUT_Y_OFFSET_WINDOW_16B = 256 * 1024 / 16;
+
+// Emit one phase (16 output rows) as `runs_per_phase` runs of `rows_per_run`
+// rows. Each run reprograms the L1 base and resets the destination Y counter so
+// the carried offset within a run never leaves the window, while the source
+// counters advance continuously across runs (only the dst Y counter is reset).
+template <std::uint32_t phase_offset>
+inline void _llk_pack_fast_untilize_emit_phase_(
+    const std::uint32_t address,
+    const std::uint32_t phase_base_row,
+    const std::uint32_t runs_per_phase,
+    const std::uint32_t rows_per_run,
+    const std::uint32_t output_row_stride_16B)
+{
+    _llk_pack_fast_untilize_select_phase_<phase_offset>();
+    _llk_pack_fast_untilize_reset_src_counters_();
+    for (std::uint32_t run = 0; run < runs_per_phase; run++)
+    {
+        const std::uint32_t out_row = phase_base_row + run * rows_per_run;
+        _llk_pack_fast_untilize_reset_output_row_counter_();
+        program_packer_destination(address + out_row * output_row_stride_16B);
+        ckernel_template::run();
+    }
+}
+
 // One call processes one 2/3/4-tile chunk inside a wider row.
 // Output address points at this chunk's row-0 column in the row-major tensor.
 template <std::uint32_t block_ct_dim, std::uint32_t full_ct_dim>
-inline void _llk_pack_fast_untilize_block_strided_(const std::uint32_t address, const std::uint32_t unit_dim, std::uint32_t& prev_unit_dim)
+inline void _llk_pack_fast_untilize_block_strided_(
+    const std::uint32_t address, const std::uint32_t unit_dim, std::uint32_t& prev_unit_dim, const std::uint32_t output_row_stride_16B = 0)
 {
     static_assert(block_ct_dim >= 2 && block_ct_dim <= FAST_UNTILIZE_MAX_UNIT_DIM, "BH fast untilize strided path supports block_ct_dim 2, 3, or 4");
     static_assert(full_ct_dim > block_ct_dim, "Use the contiguous fast_untilize block when the chunk is the full row");
     LLK_ASSERT(unit_dim >= 2 && unit_dim <= block_ct_dim, "fast_untilize pack unit_dim must be in [2, block_ct_dim]");
 
+    constexpr std::uint32_t MAX_CARRIED_OUTPUT_Y_ROW = 2 * FAST_UNTILIZE_PHASE_ROWS - 1;
+
+    // Fast path: the packer can carry y_dst across all 32 rows of the chunk from
+    // a single base without leaving the window. output_row_stride_16B == 0 means
+    // a legacy caller that did not supply the stride; keep the old carry behavior.
+    const bool carry_full_chunk = output_row_stride_16B == 0 || MAX_CARRIED_OUTPUT_Y_ROW * output_row_stride_16B < PACKER_CARRIED_OUTPUT_Y_OFFSET_WINDOW_16B;
+
+    // Otherwise rebase every rows_per_run rows. rows_per_run is the largest
+    // power-of-two divisor of FAST_UNTILIZE_PHASE_ROWS whose top row stays inside
+    // the window: (rows_per_run - 1) * stride < window. It bottoms out at 1 (one
+    // base reprogram per row), so arbitrarily wide rows / FP32 are handled.
+    std::uint32_t rows_per_run = FAST_UNTILIZE_PHASE_ROWS;
+    if (!carry_full_chunk)
+    {
+        while (rows_per_run > 1 && (rows_per_run - 1) * output_row_stride_16B >= PACKER_CARRIED_OUTPUT_Y_OFFSET_WINDOW_16B)
+        {
+            rows_per_run >>= 1;
+        }
+    }
+
     if (unit_dim != prev_unit_dim)
     {
-        _llk_pack_fast_untilize_strided_mop_config_(unit_dim);
+        _llk_pack_fast_untilize_strided_mop_config_(unit_dim, carry_full_chunk ? FAST_UNTILIZE_PHASE_ROWS : rows_per_run);
         prev_unit_dim = unit_dim;
     }
 
-    program_packer_destination(address);
+    if (carry_full_chunk)
+    {
+        // Single base; phase 1 leaves the stream open and phase 2 continues the
+        // y_dst carry into output rows 16..31. Matches the original strided path.
+        program_packer_destination(address);
+        _llk_pack_fast_untilize_select_phase_<FAST_UNTILIZE_PACK_TOP_STRIP_DEST_TARGET_OFFSET>();
+        ckernel_template::run();
+        _llk_pack_fast_untilize_select_phase_<FAST_UNTILIZE_PACK_BOTTOM_STRIP_DEST_TARGET_OFFSET>();
+        _llk_pack_fast_untilize_reset_src_counters_();
+        ckernel_template::run();
+        _llk_pack_fast_untilize_restore_pack_counters_<true>();
+        return;
+    }
 
-    _llk_pack_fast_untilize_select_phase_<FAST_UNTILIZE_PACK_TOP_STRIP_DEST_TARGET_OFFSET>();
-    ckernel_template::run();
-
-    // The row-close MOP has already advanced L1_Dest_addr to output row 16.
-    // Phase selection and counter restore are consumed by later PACRs, matching
-    // the contiguous path's no-wait sequence.
-    _llk_pack_fast_untilize_select_phase_<FAST_UNTILIZE_PACK_BOTTOM_STRIP_DEST_TARGET_OFFSET>();
-    _llk_pack_fast_untilize_reset_src_counters_();
-    ckernel_template::run();
+    const std::uint32_t runs_per_phase = FAST_UNTILIZE_PHASE_ROWS / rows_per_run;
+    _llk_pack_fast_untilize_emit_phase_<FAST_UNTILIZE_PACK_TOP_STRIP_DEST_TARGET_OFFSET>(address, 0, runs_per_phase, rows_per_run, output_row_stride_16B);
+    _llk_pack_fast_untilize_emit_phase_<FAST_UNTILIZE_PACK_BOTTOM_STRIP_DEST_TARGET_OFFSET>(
+        address, FAST_UNTILIZE_PHASE_ROWS, runs_per_phase, rows_per_run, output_row_stride_16B);
     _llk_pack_fast_untilize_restore_pack_counters_<true>();
 }
 


### PR DESCRIPTION
## Summary
Fix BH fast-untilize strided (wide-row) pack for large `full_ct_dim`. The pack now keeps the carried packer output-Y offset inside the reliable ~256 KiB hardware window by rebasing the L1 destination per sub-run, instead of relying on the cross-phase MOP address carry. Wide **BF16 and FP32** rows are now correct for arbitrary widths.

## Root Cause
The strided path streams a wide row as two 16-row phases and advances the L1 address through the packer destination-Y counter (`ADC.Y * Ystride`) carried from a single programmed base. On BH silicon that carried output-Y offset is only reliably preserved inside a ~256 KiB window — past it the high address bits are dropped, so rows overwrite each other or are left stale.

The window is reached by wide rows, sooner for FP32 (it doubles the byte stride):
- BF16: corrupts from `full_ct_dim` ~133 (carry across both phases); a single 16-row phase overflows from ~273
- FP32: corrupts from `full_ct_dim` ~67; a single phase overflows from ~137

Reproduced on silicon — FP32 `ct=137`: golden `8768` vs result `13073.57`.

## Fix
Rebase the pack base inside the window instead of carrying across it. Each 16-row phase is split into `16/R` sub-runs of `R` rows, where `R` is the largest power-of-two with `(R-1)*stride < window`. Between sub-runs the L1 base is reprogrammed and the destination-Y counter is reset, while the source counters advance continuously. `R` bottoms out at 1 (one base reprogram per row), so any row width / FP32 output is handled. When the whole 32-row chunk fits the window, the original single-base carry path is taken unchanged — the common small-`ct` case is byte-identical.

Supporting changes:
- thread the output row stride from the pack API into the LLK helper
- size the host-side `unit_dims[]` array by `full_ct_dim` (was a fixed 16, overflowing past `ct=64`)
- document the silicon-characterized 256 KiB carry-window constant

## Testing (BH silicon)
- `test_fast_untilize.py` full suite: **2164 correctness variants pass**
- wide regression added: BF16 `ct=133/256`, FP32 `ct=133` (single-run rebase) and FP32 `ct=137` (multi-sub-run); FP32 `ct=137` corrupted before this fix
- perf (PACK_ISOLATE / L1_TO_L1, `ct 2..16`, before vs after): within **+/-0.4%** run-to-run noise (bidirectional), pack code size flat

Addresses #47293.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-fast-untilize-wide-ct-dim)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fix-fast-untilize-wide-ct-dim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-fast-untilize-wide-ct-dim)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fix-fast-untilize-wide-ct-dim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/fix-fast-untilize-wide-ct-dim)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/fix-fast-untilize-wide-ct-dim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix-fast-untilize-wide-ct-dim)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix-fast-untilize-wide-ct-dim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fix-fast-untilize-wide-ct-dim)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fix-fast-untilize-wide-ct-dim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fix-fast-untilize-wide-ct-dim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fix-fast-untilize-wide-ct-dim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fix-fast-untilize-wide-ct-dim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fix-fast-untilize-wide-ct-dim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fix-fast-untilize-wide-ct-dim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fix-fast-untilize-wide-ct-dim)
