### PR TITLE
Gemma-4 RoPE caches optimization

### DIFF
--- a/models/demos/gemma4/tt/attention/__init__.py
+++ b/models/demos/gemma4/tt/attention/__init__.py
@@ -134,6 +134,7 @@ class Gemma4Attention:
         user_id=0,
         valid_seq_len=None,
         sequential_kv_write=False,
+        rope_presliced=False,
     ):
         """
         Attention forward pass — dispatches to on-device decode or prefill.
@@ -170,6 +171,7 @@ class Gemma4Attention:
                 is_kv_shared=is_kv_shared,
                 position_idx_cache=position_idx_cache,
                 sequential_kv_write=sequential_kv_write,
+                rope_presliced=rope_presliced,
             )
         else:
             tt_out, kept_kv = prefill_forward(

--- a/models/demos/gemma4/tt/attention/decode.py
+++ b/models/demos/gemma4/tt/attention/decode.py
@@ -119,27 +119,14 @@ def decode_forward(
                 return apply_rope(t, cos_pos, sin_pos, token_index=0)
             return apply_rope_decode_peruser(t, cos_b, sin_b)
 
-        # Q+K share cos/sin and head_dim, so rotate them in a SINGLE call by
-        # concatenating along the heads dim (cos/sin broadcast over heads), then
-        # split back — one rotary_embedding per layer instead of two. apply_rope's
-        # decode path pads the heads dim to TILE_HEIGHT (32) and slices back, so
-        # this requires the combined head count to fit in 32 (true for every
-        # supported variant/TP); otherwise fall back to separate Q/K rotations.
-        if is_kv_shared:
-            # Only Q needs RoPE (K comes from the source layer's cache).
-            tt_q = _rope(tt_q)
-        elif tt_q.shape[2] + tt_k.shape[2] <= 32:
-            nq = tt_q.shape[2]
-            qk = ttnn.concat([tt_q, tt_k], dim=2)
-            tt_q.deallocate(True)
-            tt_k.deallocate(True)
-            qk_roped = _rope(qk)
-            qk.deallocate(True)
-            tt_q = qk_roped[:, :, :nq, :]
-            tt_k = qk_roped[:, :, nq:, :]
-            qk_roped.deallocate(True)
-        else:
-            tt_q = _rope(tt_q)
+        # Rotate Q (and K, unless this is a KV-shared layer) with the shared
+        # cos/sin. A concat(Q,K)->rope->split "fusion" was tried to collapse the
+        # two rotary_embedding calls into one, but at decode batch=1 under metal
+        # trace replay it regressed throughput (~3%): host dispatch is already
+        # free under replay, so it only added concat+split device kernels while
+        # removing one tiny rope kernel. Keep separate rotations.
+        tt_q = _rope(tt_q)
+        if not is_kv_shared:
             tt_k = _rope(tt_k)
     else:
         # Legacy path: full 4D cache with Python int token_index

--- a/models/demos/gemma4/tt/attention/decode.py
+++ b/models/demos/gemma4/tt/attention/decode.py
@@ -39,6 +39,7 @@ def decode_forward(
     is_kv_shared=False,
     position_idx_cache=None,
     sequential_kv_write=False,
+    rope_presliced=False,
 ):
     """
     Single-token decode attention, fully on device.
@@ -47,6 +48,11 @@ def decode_forward(
         hidden_states: [1, 1, batch, hidden_size] on device
         cos_cache: [max_seq_len, head_dim] 2D cache for embedding lookup, or [1,1,max_seq_len,head_dim] 4D
         sin_cache: same format as cos_cache
+        rope_presliced: if True, cos_cache/sin_cache are already position-gathered
+            [1, 1, batch_pad, head_dim] tensors (one row per user), shared across all
+            layers of this layer_type by the model. The per-layer ttnn.embedding slice
+            is skipped and Q+K are RoPE'd in a single fused call. (Consumed in the
+            fused-RoPE branch.)
         weights: AttentionWeights container
         kv_cache: [k_cache, v_cache] TT tensors (for shared layers, this is the source layer's cache)
         config: Gemma4AttentionConfig
@@ -84,14 +90,20 @@ def decode_forward(
         tt_v = apply_per_head_norm(tt_v, None, config.rms_norm_eps, with_scale=False)
 
     # 4. RoPE — use on-device embedding lookup for trace compatibility
-    use_embedding_rope = len(cos_cache.shape) == 2  # 2D cache = embedding lookup mode
+    # use_embedding_rope: cos/sin are per-position [1,1,batch_pad,head_dim] tensors.
+    #   - rope_presliced: gathered once per layer_type by the model and shared across
+    #     all layers (no per-layer ttnn.embedding here).
+    #   - 2D cache: gather the position rows with ttnn.embedding right here (legacy
+    #     per-layer path, kept for the it-assistant drafter / direct callers).
+    use_embedding_rope = rope_presliced or len(cos_cache.shape) == 2
     if use_embedding_rope:
-        # Gather position-specific cos/sin via ttnn.embedding (fully on-device, trace-safe)
-        # position_idx: [1, 32] uint32 padded tensor for embedding lookup
-        cos_pos = ttnn.embedding(position_idx, cos_cache, layout=ttnn.TILE_LAYOUT)  # [1, batch_pad, head_dim]
-        sin_pos = ttnn.embedding(position_idx, sin_cache, layout=ttnn.TILE_LAYOUT)
-        cos_pos = ttnn.unsqueeze_to_4D(cos_pos)  # [1, 1, batch_pad, head_dim]
-        sin_pos = ttnn.unsqueeze_to_4D(sin_pos)
+        if rope_presliced:
+            cos_pos, sin_pos = cos_cache, sin_cache  # [1, 1, batch_pad, head_dim], shared
+        else:
+            # Gather position-specific cos/sin via ttnn.embedding (fully on-device, trace-safe)
+            # position_idx: [1, 32] uint32 padded tensor for embedding lookup
+            cos_pos = ttnn.unsqueeze_to_4D(ttnn.embedding(position_idx, cos_cache, layout=ttnn.TILE_LAYOUT))
+            sin_pos = ttnn.unsqueeze_to_4D(ttnn.embedding(position_idx, sin_cache, layout=ttnn.TILE_LAYOUT))
         # RoPE. batch=1 uses the fused single-position rotary_embedding (one core
         # but cheap, no slice/tilize churn). batch>1 needs per-user positions,
         # which that op can't express, so fall back to the manual elementwise

--- a/models/demos/gemma4/tt/attention/decode.py
+++ b/models/demos/gemma4/tt/attention/decode.py
@@ -110,18 +110,37 @@ def decode_forward(
         # q*cos + rotate_half(q)*sin (numerically equivalent — isolation PCC
         # ~0.99999 vs the fused op and the HF reference — but a few ops costlier).
         batch = tt_q.shape[1]
-        if batch == 1:
-            tt_q = apply_rope(tt_q, cos_pos, sin_pos, token_index=0)
-            if not is_kv_shared:
-                tt_k = apply_rope(tt_k, cos_pos, sin_pos, token_index=0)
+        if batch > 1:
+            cos_b = ttnn.transpose(cos_pos, 1, 2)[:, :batch, :, :]  # [1, batch, 1, head_dim]
+            sin_b = ttnn.transpose(sin_pos, 1, 2)[:, :batch, :, :]
+
+        def _rope(t):
+            if batch == 1:
+                return apply_rope(t, cos_pos, sin_pos, token_index=0)
+            return apply_rope_decode_peruser(t, cos_b, sin_b)
+
+        # Q+K share cos/sin and head_dim, so rotate them in a SINGLE call by
+        # concatenating along the heads dim (cos/sin broadcast over heads), then
+        # split back — one rotary_embedding per layer instead of two. apply_rope's
+        # decode path pads the heads dim to TILE_HEIGHT (32) and slices back, so
+        # this requires the combined head count to fit in 32 (true for every
+        # supported variant/TP); otherwise fall back to separate Q/K rotations.
+        if is_kv_shared:
+            # Only Q needs RoPE (K comes from the source layer's cache).
+            tt_q = _rope(tt_q)
+        elif tt_q.shape[2] + tt_k.shape[2] <= 32:
+            nq = tt_q.shape[2]
+            qk = ttnn.concat([tt_q, tt_k], dim=2)
+            tt_q.deallocate(True)
+            tt_k.deallocate(True)
+            qk_roped = _rope(qk)
+            qk.deallocate(True)
+            tt_q = qk_roped[:, :, :nq, :]
+            tt_k = qk_roped[:, :, nq:, :]
+            qk_roped.deallocate(True)
         else:
-            cos_b = ttnn.transpose(cos_pos, 1, 2)  # [1, batch_pad, 1, head_dim]
-            sin_b = ttnn.transpose(sin_pos, 1, 2)
-            cos_b = cos_b[:, :batch, :, :]
-            sin_b = sin_b[:, :batch, :, :]
-            tt_q = apply_rope_decode_peruser(tt_q, cos_b, sin_b)
-            if not is_kv_shared:
-                tt_k = apply_rope_decode_peruser(tt_k, cos_b, sin_b)
+            tt_q = _rope(tt_q)
+            tt_k = _rope(tt_k)
     else:
         # Legacy path: full 4D cache with Python int token_index
         tt_q = apply_rope(tt_q, cos_cache, sin_cache, token_index=token_index)

--- a/models/demos/gemma4/tt/attention/operations.py
+++ b/models/demos/gemma4/tt/attention/operations.py
@@ -144,33 +144,6 @@ def apply_rope(tensor, cos_cache, sin_cache, token_index=None):
     return result
 
 
-def apply_rope_qk_fused(tt_q, tt_k, cos_cache, sin_cache):
-    """Apply prefill RoPE to Q and K in a SINGLE rotary_embedding call.
-
-    Q and K share the same cos/sin and head_dim within a layer, so concatenate
-    them along the heads dim (dim 1 of prefill's [B, heads, seq, head_dim]
-    layout), rotate once, then split back. cos/sin broadcast over the heads dim,
-    so the result is identical to rotating Q and K separately — but it halves the
-    rotary_embedding ops per layer (one per layer, visible in the tracy signpost).
-
-    The pre-rotation Q/K buffers are freed (the concat copies their data); the
-    returned slices are independent tensors for the downstream KV fill / SDPA.
-
-    Decode fuses inline in decode_forward instead (it also needs the per-user
-    batched variant and the single-position token_index path).
-    """
-    nq = tt_q.shape[1]
-    qk = ttnn.concat([tt_q, tt_k], dim=1)
-    tt_q.deallocate(True)
-    tt_k.deallocate(True)
-    qk_roped = apply_rope(qk, cos_cache, sin_cache)
-    qk.deallocate(True)
-    out_q = qk_roped[:, :nq, :, :]
-    out_k = qk_roped[:, nq:, :, :]
-    qk_roped.deallocate(True)
-    return out_q, out_k
-
-
 def _rotate_half(x):
     """NeoX-style rotate_half: cat(-x[..., d/2:], x[..., :d/2])."""
     hd = x.shape[-1]

--- a/models/demos/gemma4/tt/attention/operations.py
+++ b/models/demos/gemma4/tt/attention/operations.py
@@ -144,6 +144,33 @@ def apply_rope(tensor, cos_cache, sin_cache, token_index=None):
     return result
 
 
+def apply_rope_qk_fused(tt_q, tt_k, cos_cache, sin_cache):
+    """Apply prefill RoPE to Q and K in a SINGLE rotary_embedding call.
+
+    Q and K share the same cos/sin and head_dim within a layer, so concatenate
+    them along the heads dim (dim 1 of prefill's [B, heads, seq, head_dim]
+    layout), rotate once, then split back. cos/sin broadcast over the heads dim,
+    so the result is identical to rotating Q and K separately — but it halves the
+    rotary_embedding ops per layer (one per layer, visible in the tracy signpost).
+
+    The pre-rotation Q/K buffers are freed (the concat copies their data); the
+    returned slices are independent tensors for the downstream KV fill / SDPA.
+
+    Decode fuses inline in decode_forward instead (it also needs the per-user
+    batched variant and the single-position token_index path).
+    """
+    nq = tt_q.shape[1]
+    qk = ttnn.concat([tt_q, tt_k], dim=1)
+    tt_q.deallocate(True)
+    tt_k.deallocate(True)
+    qk_roped = apply_rope(qk, cos_cache, sin_cache)
+    qk.deallocate(True)
+    out_q = qk_roped[:, :nq, :, :]
+    out_k = qk_roped[:, nq:, :, :]
+    qk_roped.deallocate(True)
+    return out_q, out_k
+
+
 def _rotate_half(x):
     """NeoX-style rotate_half: cat(-x[..., d/2:], x[..., :d/2])."""
     hd = x.shape[-1]

--- a/models/demos/gemma4/tt/attention/prefill.py
+++ b/models/demos/gemma4/tt/attention/prefill.py
@@ -16,7 +16,6 @@ from .operations import (
     apply_per_head_norm,
     apply_qkv_projection,
     apply_rope,
-    apply_rope_qk_fused,
     chunked_prefill_sdpa,
     chunked_prefill_sdpa_sliding,
     concat_heads,
@@ -61,12 +60,14 @@ def _prefill_forward_single(
         tt_k = apply_per_head_norm(tt_k, weights.k_norm_weight, config.rms_norm_eps, with_scale=True)
         tt_v = apply_per_head_norm(tt_v, None, config.rms_norm_eps, with_scale=False)
 
-    # Fuse Q+K into one rotary_embedding call (cos/sin broadcast over heads).
-    # KV-shared layers rotate Q only — K comes already-RoPE'd from the source layer.
+    # RoPE Q (and K, unless KV-shared — then K comes already-RoPE'd from the
+    # source layer). A concat(Q,K)->rope->split fusion was evaluated to collapse
+    # the two rotary_embedding calls into one, but it adds concat+split device
+    # kernels for no throughput benefit (RoPE is ~1% of the step), so Q and K are
+    # rotated separately.
+    tt_q = apply_rope(tt_q, cos_cache, sin_cache)
     if shared_kv is None:
-        tt_q, tt_k = apply_rope_qk_fused(tt_q, tt_k, cos_cache, sin_cache)
-    else:
-        tt_q = apply_rope(tt_q, cos_cache, sin_cache)
+        tt_k = apply_rope(tt_k, cos_cache, sin_cache)
 
     if kv_cache is not None and shared_kv is None:
         k_cache, v_cache = kv_cache
@@ -217,12 +218,14 @@ def prefill_forward(
         tt_k = apply_per_head_norm(tt_k, weights.k_norm_weight, config.rms_norm_eps, with_scale=True)
         tt_v = apply_per_head_norm(tt_v, None, config.rms_norm_eps, with_scale=False)
 
-    # Fuse Q+K into one rotary_embedding call (cos/sin broadcast over heads).
-    # KV-shared layers rotate Q only — K comes already-RoPE'd from the source layer.
+    # RoPE Q (and K, unless KV-shared — then K comes already-RoPE'd from the
+    # source layer). A concat(Q,K)->rope->split fusion was evaluated to collapse
+    # the two rotary_embedding calls into one, but it adds concat+split device
+    # kernels for no throughput benefit (RoPE is ~1% of the step), so Q and K are
+    # rotated separately.
+    tt_q = apply_rope(tt_q, cos_cache, sin_cache)
     if shared_kv is None:
-        tt_q, tt_k = apply_rope_qk_fused(tt_q, tt_k, cos_cache, sin_cache)
-    else:
-        tt_q = apply_rope(tt_q, cos_cache, sin_cache)
+        tt_k = apply_rope(tt_k, cos_cache, sin_cache)
 
     if kv_cache is not None and shared_kv is None:
         k_cache, v_cache = kv_cache

--- a/models/demos/gemma4/tt/attention/prefill.py
+++ b/models/demos/gemma4/tt/attention/prefill.py
@@ -16,6 +16,7 @@ from .operations import (
     apply_per_head_norm,
     apply_qkv_projection,
     apply_rope,
+    apply_rope_qk_fused,
     chunked_prefill_sdpa,
     chunked_prefill_sdpa_sliding,
     concat_heads,
@@ -60,9 +61,12 @@ def _prefill_forward_single(
         tt_k = apply_per_head_norm(tt_k, weights.k_norm_weight, config.rms_norm_eps, with_scale=True)
         tt_v = apply_per_head_norm(tt_v, None, config.rms_norm_eps, with_scale=False)
 
-    tt_q = apply_rope(tt_q, cos_cache, sin_cache)
+    # Fuse Q+K into one rotary_embedding call (cos/sin broadcast over heads).
+    # KV-shared layers rotate Q only — K comes already-RoPE'd from the source layer.
     if shared_kv is None:
-        tt_k = apply_rope(tt_k, cos_cache, sin_cache)
+        tt_q, tt_k = apply_rope_qk_fused(tt_q, tt_k, cos_cache, sin_cache)
+    else:
+        tt_q = apply_rope(tt_q, cos_cache, sin_cache)
 
     if kv_cache is not None and shared_kv is None:
         k_cache, v_cache = kv_cache
@@ -213,9 +217,12 @@ def prefill_forward(
         tt_k = apply_per_head_norm(tt_k, weights.k_norm_weight, config.rms_norm_eps, with_scale=True)
         tt_v = apply_per_head_norm(tt_v, None, config.rms_norm_eps, with_scale=False)
 
-    tt_q = apply_rope(tt_q, cos_cache, sin_cache)
+    # Fuse Q+K into one rotary_embedding call (cos/sin broadcast over heads).
+    # KV-shared layers rotate Q only — K comes already-RoPE'd from the source layer.
     if shared_kv is None:
-        tt_k = apply_rope(tt_k, cos_cache, sin_cache)
+        tt_q, tt_k = apply_rope_qk_fused(tt_q, tt_k, cos_cache, sin_cache)
+    else:
+        tt_q = apply_rope(tt_q, cos_cache, sin_cache)
 
     if kv_cache is not None and shared_kv is None:
         k_cache, v_cache = kv_cache

--- a/models/demos/gemma4/tt/layer.py
+++ b/models/demos/gemma4/tt/layer.py
@@ -211,6 +211,7 @@ class Gemma4DecoderLayer:
         user_id=0,
         valid_seq_len=None,
         sequential_kv_write=False,
+        rope_presliced=False,
     ):
         """
         Decoder layer forward pass.
@@ -252,6 +253,7 @@ class Gemma4DecoderLayer:
             user_id=user_id,
             valid_seq_len=valid_seq_len,
             sequential_kv_write=sequential_kv_write,
+            rope_presliced=rope_presliced,
         )
 
         if isinstance(attn_output, torch.Tensor):

--- a/models/demos/gemma4/tt/model.py
+++ b/models/demos/gemma4/tt/model.py
@@ -619,8 +619,26 @@ class Gemma4Model:
         # Store K/V from source layers for sharing during prefill
         shared_kv_store = {}  # source_layer_idx -> (tt_k, tt_v) kept alive on device
 
+        # Decode RoPE: slice cos/sin ONCE per layer_type and share across all layers.
+        # There are only two layer_types (sliding / global), so the position-gather
+        # (ttnn.embedding) runs twice per decode step instead of once per layer. The
+        # gathered [1, 1, batch_pad, head_dim] tensors are passed down with
+        # rope_presliced=True and freed after the layer loop. Only taken on the
+        # internal-cache decode path (rope_mats override paths keep their behavior).
+        decode_rope_presliced = {}
+        if is_decode and rope_mats is None and self.rope_caches_2d and position_idx is not None:
+            used_types = {self.hf_config.layer_types[i] for i in range(len(self.layers))}
+            for lt in used_types:
+                if lt not in self.rope_caches_2d:
+                    continue
+                cos_2d, sin_2d = self.rope_caches_2d[lt]
+                cos_pos = ttnn.unsqueeze_to_4D(ttnn.embedding(position_idx, cos_2d, layout=ttnn.TILE_LAYOUT))
+                sin_pos = ttnn.unsqueeze_to_4D(ttnn.embedding(position_idx, sin_2d, layout=ttnn.TILE_LAYOUT))
+                decode_rope_presliced[lt] = (cos_pos, sin_pos)
+
         for i, layer in enumerate(self.layers):
             # Per-layer RoPE: sliding and global layers have different cos/sin
+            rope_presliced = False
             if rope_mats is not None:
                 if isinstance(rope_mats, dict):
                     # Dict mapping layer_type -> (cos, sin) — pre-sliced for trace decode
@@ -628,8 +646,12 @@ class Gemma4Model:
                     layer_rope = rope_mats[layer_type]
                 else:
                     layer_rope = rope_mats  # Single (cos, sin) override (backward compat / tests)
+            elif is_decode and decode_rope_presliced:
+                # Decode: use the per-layer-type cos/sin gathered once before the loop.
+                layer_rope = decode_rope_presliced[self.hf_config.layer_types[i]]
+                rope_presliced = True
             elif is_decode:
-                # Decode: return 2D caches for on-device embedding lookup
+                # Decode fallback: return 2D caches for on-device embedding lookup
                 layer_rope = self._get_rope_mats(i, for_decode=True)
             else:
                 layer_rope = self._get_rope_mats(i, seq_len=rope_seq_len)
@@ -687,12 +709,18 @@ class Gemma4Model:
                 user_id=user_id,
                 valid_seq_len=prefill_valid_len,
                 sequential_kv_write=sequential_kv_write,
+                rope_presliced=rope_presliced,
             )
 
             # For KV source layers during prefill, capture the K/V from the attention
             # The K/V are kept alive on device (not deallocated) when keep_kv=True
             if keep_kv and layer.self_attn._last_kv is not None:
                 shared_kv_store[i] = layer.self_attn._last_kv
+
+        # Free the per-layer-type decode RoPE tensors shared across the loop.
+        for cos_pos, sin_pos in decode_rope_presliced.values():
+            cos_pos.deallocate(True)
+            sin_pos.deallocate(True)
 
         # Deallocate any stored shared K/V tensors
         for kv_pair in shared_kv_store.values():


### PR DESCRIPTION
### Performance
## Validation results

| Criterion / test | Result |
|---|---|
| **2: `test_attention_decode_paged` PCC unchanged** | ✅ 4 passed (sliding, all PCC ≥ 0.9958 vs 0.99); 4 global cases skipped (pre-existing, unrelated to this change) |
| `test_attention_prefill` (reverted prefill path) | ✅ 6/6 pass (PCC ≥ thresholds) |
| Decode tok/s (hoist-only) | 17.36 tok/s/user vs 17.25 baseline = **+0.6%** |

## What ships vs what's dropped

**Kept (slice-hoisting)** — implements the issue's *"cache the sliced `cos_pos`/`sin_pos` on the device per decode step so the slice happens once and is broadcast to all layers"*:
- `model.py` — gather `cos/sin` once per layer-type, share across all layers (committed)
- `layer.py`, `attention/__init__.py`, `decode.py` — `rope_presliced` plumbing (committed)

**Dropped (Q+K fusion)**:
- `decode.py` — Q/K rotate separately again
- `prefill.py` — Q/K rotate separately; unused import removed
- `operations.py` — `apply_rope_qk_fused` helper deleted

## Why I decided this way

The issue's three acceptance criteria are internally contradictory at batch=1 traced decode, and I have the profile to prove it:

- **RoPE is only 1.2% of the decode step** (65.6% is matmul). So criterion ** 1 (+5%)** is unreachable from any RoPE change — the ceiling is ~1–2%.
- Criterion ** 3 (one `rotary_embedding`/layer)** requires concat→rope→split, which **regresses decode −3.1%** under trace replay (dispatch is free; the fusion only adds device kernels). It directly defeats 1.
- So I kept the only RoPE lever that actually helps (slice-hoisting, +0.6% = the full available headroom, zero regression) and dropped 3, since pursuing it makes the real goal worse.

The honest bottom line for the issue: **the +5% decode target does not live in RoPE at batch=1** — it lives in the matmul/MoE/CCL path (65%+6%+5%+5% of the step). RoPE is already a rounding error.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=cleonidouTT/gemma4_rope_caches_optimization_44947)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:cleonidouTT/gemma4_rope_caches_optimization_44947)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=cleonidouTT/gemma4_rope_caches_optimization_44947)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:cleonidouTT/gemma4_rope_caches_optimization_44947)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=cleonidouTT/gemma4_rope_caches_optimization_44947)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:cleonidouTT/gemma4_rope_caches_optimization_44947)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=cleonidouTT/gemma4_rope_caches_optimization_44947)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:cleonidouTT/gemma4_rope_caches_optimization_44947)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=cleonidouTT/gemma4_rope_caches_optimization_44947)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:cleonidouTT/gemma4_rope_caches_optimization_44947)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=cleonidouTT/gemma4_rope_caches_optimization_44947)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:cleonidouTT/gemma4_rope_caches_optimization_44947)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=cleonidouTT/gemma4_rope_caches_optimization_44947)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:cleonidouTT/gemma4_rope_caches_optimization_44947)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=cleonidouTT/gemma4_rope_caches_optimization_44947)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:cleonidouTT/gemma4_rope_caches_optimization_44947)