### PR TITLE
[SDPA] Remove SDPA tests from Blackhole e2e pipeline

### DIFF
--- a/.github/workflows/blackhole-e2e-tests-impl.yaml
+++ b/.github/workflows/blackhole-e2e-tests-impl.yaml
@@ -24,7 +24,7 @@ on:
         required: false
         type: string
         default: "all"
-        description: "Filter test rows by id, or by the sdpa tag group"
+        description: "Filter test rows by id"
 
 jobs:
   load-test-matrix:
@@ -78,27 +78,17 @@ jobs:
           with open(tests_path, "r") as f:
               tests = yaml.safe_load(f) or []
 
-          if selection == "sdpa":
-              matches = any(selection in (test.get("tags") or []) for test in tests)
-          else:
-              matches = any(test.get("id") == selection for test in tests)
+          matches = any(test.get("id") == selection for test in tests)
 
           print("true" if matches else "false")
           PY
           )
             if [[ "$selection_exists" != "true" ]]; then
-              echo "::error::Unknown e2e test-selection '$TEST_SELECTION'. Use 'all', 'sdpa', or an id from $TESTS_YAML_PATH."
+              echo "::error::Unknown e2e test-selection '$TEST_SELECTION'. Use 'all' or an id from $TESTS_YAML_PATH."
               exit 1
             fi
 
-            case "$TEST_SELECTION" in
-              sdpa)
-                selected=$(echo "$selected" | jq -c '[.[] | select((.tags // []) | index("sdpa"))]')
-                ;;
-              *)
-                selected=$(echo "$selected" | jq -c --arg id "$TEST_SELECTION" '[.[] | select(.id == $id)]')
-                ;;
-            esac
+            selected=$(echo "$selected" | jq -c --arg id "$TEST_SELECTION" '[.[] | select(.id == $id)]')
           fi
 
           filtered="$selected"

--- a/.github/workflows/blackhole-e2e-tests.yaml
+++ b/.github/workflows/blackhole-e2e-tests.yaml
@@ -31,14 +31,12 @@ on:
           - all
           - deepseek_prefill
       test-selection:
-        description: 'Select e2e tests to run: all tests, all SDPA tests, or one test id'
+        description: 'Select e2e tests to run: all tests, or one test id'
         required: false
         default: 'all'
         type: choice
         options:
           - all
-          - sdpa
-          - bh-sdpa-nightly-integration
       build-type:
         required: false
         type: choice
@@ -71,7 +69,7 @@ on:
         required: false
         type: string
         default: 'all'
-        description: "Select all tests, the sdpa tag group, or one test id from tests/pipeline_reorg/blackhole_e2e_tests.yaml"
+        description: "Select all tests, or one test id from tests/pipeline_reorg/blackhole_e2e_tests.yaml"
       platform:
         required: false
         type: string

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -56,18 +56,6 @@
   owner_id: U05ACKAJTHS # Naif Tarafdar
   team: ttnn
 
-- id: bh-sdpa-nightly-integration
-  name: sdpa nightly tests
-  tags: [sdpa]
-  cmd: pytest tests/nightly/blackhole/sdpa/ -svv
-  skus:
-    bh_loudbox:
-      timeout: 60
-    bh_p300:
-      timeout: 60
-  owner_id: U07RD9YRFT9 # Slavko Krstic
-  team: ttnn
-
 - id: bh-grid-110-cores-panoptic-deeplab
   name: 110 cores panoptic-deeplab
   cmd: TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="10,9" pytest models/experimental/panoptic_deeplab/tests/pcc/


### PR DESCRIPTION
## Summary

Removes the SDPA test run from the **Blackhole e2e** pipeline.

- Drops the `bh-sdpa-nightly-integration` row (`pytest tests/nightly/blackhole/sdpa/`) from `blackhole_e2e_tests.yaml` — was gated to `bh_loudbox` and `bh_p300`.
- Removes the now-dead `sdpa` tag-group selection wiring from the e2e workflows (`workflow_dispatch` choices, descriptions, and the impl-side tag filter).

No other pipeline is affected; the underlying tests still live in `tests/nightly/blackhole/sdpa/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Blackhole e2e run

[![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=skrstic/remove-sdpa-from-bh-e2e)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch%3Askrstic%2Fremove-sdpa-from-bh-e2e)

Triggered run: https://github.com/tenstorrent/tt-metal/actions/runs/27818149111

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/remove-sdpa-from-bh-e2e)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/remove-sdpa-from-bh-e2e)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/remove-sdpa-from-bh-e2e)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/remove-sdpa-from-bh-e2e)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/remove-sdpa-from-bh-e2e)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skrstic/remove-sdpa-from-bh-e2e)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/remove-sdpa-from-bh-e2e)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/remove-sdpa-from-bh-e2e)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/remove-sdpa-from-bh-e2e)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/remove-sdpa-from-bh-e2e)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/remove-sdpa-from-bh-e2e)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/remove-sdpa-from-bh-e2e)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/remove-sdpa-from-bh-e2e)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/remove-sdpa-from-bh-e2e)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/remove-sdpa-from-bh-e2e)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/remove-sdpa-from-bh-e2e)
