### PR TITLE
fix hash collision 45821 all reduce async device operation

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_device_operation.cpp
@@ -102,27 +102,6 @@ AllReduceAsyncDeviceOperation::topology_return_value_t AllReduceAsyncDeviceOpera
         input_topology.distribution_shape(), std::move(output_placements), input_topology.mesh_coords())};
 }
 
-ttsl::hash::hash_t AllReduceAsyncDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    log_trace(tt::LogOp, "AllReduceAsyncDeviceOperation::compute_program_hash is called");
-
-    auto subdevice_id = args.sub_device_id;
-    auto* mesh_device = tensor_args.input_tensor.device();
-    auto sd_id = subdevice_id.value_or(mesh_device->get_sub_device_ids().at(0));
-    auto subdevice_core_range_set = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sd_id);
-    return tt::tt_metal::operation::hash_operation<AllReduceAsyncDeviceOperation>(
-        args.num_links,
-        args.ring_size,
-        args.dtype,
-        args.output_mem_config,
-        args.topology,
-        args.use_noc1_only,
-        args.use_optimal_ccl_for_llama,
-        args.cluster_axis,
-        subdevice_core_range_set,
-        tensor_args);
-}
-
 tt::tt_metal::operation::OpPerformanceModelGeneral<AllReduceAsyncDeviceOperation::tensor_return_value_t>
 AllReduceAsyncDeviceOperation::create_op_performance_model(
     const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensors) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_device_operation.hpp
@@ -25,8 +25,6 @@ struct AllReduceAsyncDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
-
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensors);
 };

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_device_operation_types.hpp
@@ -73,15 +73,7 @@ struct AllReduceAsyncParams {
     }
 
     // Compile-time attributes drive the default program-cache reflection hash and the canonical key
-    // (ttsl::hash::hash_objects_with_default_seed + ttsl::hash::canonical_key). They list exactly the
-    // structure-affecting fields, mirroring the set the (now-removed) custom compute_program_hash used:
-    //   - `semaphore` (GlobalSemaphore) is excluded: it is runtime-only (its address is passed to
-    //     runtime args) and was never part of the old custom hash.
-    //   - `mesh_device` (raw MeshDevice*) is excluded: a runtime pointer; the program cache is per-device.
-    //   - `sub_device_id` is included: the old hash hashed the derived subdevice worker-core range
-    //     (mesh_device->worker_cores(TENSIX, sub_device_id...)), which is per-device-constant given the
-    //     sub-device id. `sub_device_id` is the structural input of that computation (see
-    //     all_reduce_async_program_factory.cpp worker-core selection).
+    // (ttsl::hash::hash_objects_with_default_seed + ttsl::hash::canonical_key)
     static constexpr auto attribute_names = std::forward_as_tuple(
         "num_links",
         "ring_size",

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_device_operation_types.hpp
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <optional>
+#include <tuple>
 #include <vector>
 
 #include <tt-metalium/sub_device_types.hpp>
@@ -69,6 +70,39 @@ struct AllReduceAsyncParams {
         attrs.emplace_back("use_optimal_ccl_for_llama", use_optimal_ccl_for_llama);
         attrs.emplace_back("cluster_axis", cluster_axis);
         return attrs;
+    }
+
+    // Compile-time attributes drive the default program-cache reflection hash and the canonical key
+    // (ttsl::hash::hash_objects_with_default_seed + ttsl::hash::canonical_key). They list exactly the
+    // structure-affecting fields, mirroring the set the (now-removed) custom compute_program_hash used:
+    //   - `semaphore` (GlobalSemaphore) is excluded: it is runtime-only (its address is passed to
+    //     runtime args) and was never part of the old custom hash.
+    //   - `mesh_device` (raw MeshDevice*) is excluded: a runtime pointer; the program cache is per-device.
+    //   - `sub_device_id` is included: the old hash hashed the derived subdevice worker-core range
+    //     (mesh_device->worker_cores(TENSIX, sub_device_id...)), which is per-device-constant given the
+    //     sub-device id. `sub_device_id` is the structural input of that computation (see
+    //     all_reduce_async_program_factory.cpp worker-core selection).
+    static constexpr auto attribute_names = std::forward_as_tuple(
+        "num_links",
+        "ring_size",
+        "dtype",
+        "output_mem_config",
+        "topology",
+        "use_noc1_only",
+        "use_optimal_ccl_for_llama",
+        "cluster_axis",
+        "sub_device_id");
+    auto attribute_values() const {
+        return std::make_tuple(
+            num_links,
+            ring_size,
+            dtype,
+            output_mem_config,
+            topology,
+            use_noc1_only,
+            use_optimal_ccl_for_llama,
+            cluster_axis,
+            sub_device_id);
     }
 };
 


### PR DESCRIPTION
### PR Category
hash calculation unification for operation AllReduceAsyncDeviceOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for AllReduceAsyncDeviceOperation

### Notes for reviewers
NA

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceAsyncDeviceOperation)