### PR TITLE
fix hash collision 45821 all reduce create qkv heads device operation

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_device_operation.cpp
@@ -281,26 +281,6 @@ AllReduceCreateQkvHeadsDeviceOperation::create_output_tensors(
         .v = create_device_tensor(output_specs.v, device)};
 }
 
-ttsl::hash::hash_t AllReduceCreateQkvHeadsDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const auto& input_tensor = tensor_args.input_tensor;
-    auto input_shape = input_tensor.padded_shape();
-    auto input_memory_layout = input_tensor.layout();
-    auto input_dtype = input_tensor.dtype();
-    auto input_memory_config = input_tensor.memory_config();
-    // Hash individual fields to avoid hashing non-hashable types like GlobalSemaphore
-    return tt::tt_metal::operation::hash_operation<AllReduceCreateQkvHeadsDeviceOperation>(
-        operation_attributes.num_links,
-        operation_attributes.ring_size,
-        operation_attributes.all_reduce_mem_config,
-        operation_attributes.topology,
-        operation_attributes.cluster_axis,
-        input_shape,
-        input_memory_layout,
-        input_dtype,
-        input_memory_config);
-}
-
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_device_operation.hpp
@@ -24,8 +24,6 @@ struct AllReduceCreateQkvHeadsDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_device_operation_types.hpp
@@ -12,7 +12,6 @@
 #include <optional>
 #include <tuple>
 #include <utility>
-#include <vector>
 
 namespace ttnn::experimental::prim {
 
@@ -65,26 +64,6 @@ struct AllReduceCreateQkvHeadsParams {
         final_mem_config(std::move(final_mem_config)),
         dtype(dtype),
         cluster_axis(cluster_axis) {}
-
-    auto attributes() const {
-        using ttsl::reflection::Attribute;
-        std::vector<std::tuple<std::string, Attribute>> attrs;
-        attrs.emplace_back("num_links", num_links);
-        attrs.emplace_back("ring_size", ring_size);
-        attrs.emplace_back("all_reduce_mem_config", all_reduce_mem_config);
-        attrs.emplace_back("topology", topology);
-        attrs.emplace_back("semaphore", semaphore);
-        attrs.emplace_back("head_dim", head_dim);
-        attrs.emplace_back("use_noc1_only", use_noc1_only);
-        attrs.emplace_back("num_heads", num_heads);
-        attrs.emplace_back("num_kv_heads", num_kv_heads);
-        attrs.emplace_back("input_on_subcoregrids", input_on_subcoregrids);
-        attrs.emplace_back("slice_size", slice_size);
-        attrs.emplace_back("final_mem_config", final_mem_config);
-        attrs.emplace_back("dtype", dtype);
-        attrs.emplace_back("cluster_axis", cluster_axis);
-        return attrs;
-    }
 
     // Compile-time attributes drive the default program-cache hash and canonical key.
     // `semaphore` (GlobalSemaphore) is excluded: it is not hashable/canonical-key serializable and

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_device_operation_types.hpp
@@ -10,6 +10,8 @@
 #include <tt-metalium/sub_device_types.hpp>
 #include <cstdint>
 #include <optional>
+#include <tuple>
+#include <utility>
 #include <vector>
 
 namespace ttnn::experimental::prim {
@@ -82,6 +84,42 @@ struct AllReduceCreateQkvHeadsParams {
         attrs.emplace_back("dtype", dtype);
         attrs.emplace_back("cluster_axis", cluster_axis);
         return attrs;
+    }
+
+    // Compile-time attributes drive the default program-cache hash and canonical key.
+    // `semaphore` (GlobalSemaphore) is excluded: it is not hashable/canonical-key serializable and
+    // is used only for runtime args (semaphore.address()), so it does not affect program structure.
+    static constexpr auto attribute_names = std::forward_as_tuple(
+        "num_links",
+        "ring_size",
+        "all_reduce_mem_config",
+        "topology",
+        "sub_device_id",
+        "head_dim",
+        "use_noc1_only",
+        "num_heads",
+        "num_kv_heads",
+        "input_on_subcoregrids",
+        "slice_size",
+        "final_mem_config",
+        "dtype",
+        "cluster_axis");
+    auto attribute_values() const {
+        return std::forward_as_tuple(
+            num_links,
+            ring_size,
+            all_reduce_mem_config,
+            topology,
+            sub_device_id,
+            head_dim,
+            use_noc1_only,
+            num_heads,
+            num_kv_heads,
+            input_on_subcoregrids,
+            slice_size,
+            final_mem_config,
+            dtype,
+            cluster_axis);
     }
 };
 


### PR DESCRIPTION
### PR Category
hash calculation unification for operation AllReduceCreateQkvHeadsDeviceOperation
 
### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for AllReduceCreateQkvHeadsDeviceOperation

### Notes for reviewers
NA

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceCreateQkvHeadsDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceCreateQkvHeadsDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceCreateQkvHeadsDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceCreateQkvHeadsDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceCreateQkvHeadsDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceCreateQkvHeadsDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceCreateQkvHeadsDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceCreateQkvHeadsDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceCreateQkvHeadsDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceCreateQkvHeadsDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceCreateQkvHeadsDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceCreateQkvHeadsDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceCreateQkvHeadsDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceCreateQkvHeadsDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceCreateQkvHeadsDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_AllReduceCreateQkvHeadsDeviceOperation)