### PR TITLE
Alexey zaytsev epam/fix hash collision 45821 reduce scatter minimal async device operation

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op_device_operation.cpp
@@ -150,36 +150,6 @@ std::vector<tt::tt_metal::TensorTopology> ReduceScatterMinimalAsyncDeviceOperati
     return {input_topology, std::move(output_topology)};
 }
 
-ttsl::hash::hash_t ReduceScatterMinimalAsyncDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    log_trace(tt::LogOp, "ReduceScatterMinimalAsyncDeviceOperation::compute_program_hash is called");
-
-    auto subdevice_id = operation_attributes.sub_device_id;
-    auto* mesh_device = tensor_args.input_tensor.device();
-    auto sd_id = subdevice_id.value_or(mesh_device->get_sub_device_ids().at(0));
-    auto subdevice_core_range_set = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sd_id);
-
-    auto program_factory = select_program_factory(operation_attributes, tensor_args);
-
-    return tt::tt_metal::operation::hash_operation<ReduceScatterMinimalAsyncDeviceOperation>(
-        operation_attributes.dim,
-        operation_attributes.num_links,
-        operation_attributes.ring_size,
-        operation_attributes.output_mem_config,
-        operation_attributes.optional_intermediate_mem_config,
-        operation_attributes.topology,
-        operation_attributes.barrier_semaphore.has_value(),
-        operation_attributes.using_persistent_buffers,
-        operation_attributes.cluster_axis,
-        operation_attributes.chunks_per_sync,
-        operation_attributes.num_workers_per_link,
-        operation_attributes.num_buffers_per_channel,
-        operation_attributes.compute_kernel_config,
-        subdevice_core_range_set,
-        tensor_args,
-        program_factory.index());
-}
-
 tt::tt_metal::operation::OpPerformanceModelGeneral<ReduceScatterMinimalAsyncDeviceOperation::tensor_return_value_t>
 ReduceScatterMinimalAsyncDeviceOperation::create_op_performance_model(
     const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensors) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op_device_operation.hpp
@@ -30,8 +30,6 @@ struct ReduceScatterMinimalAsyncDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
-
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensors);
 };

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op_device_operation_types.hpp
@@ -49,19 +49,6 @@ struct ReduceScatterMinimalAsyncParams {
     std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config;
 
     // Compile-time attributes drive the default program-cache reflection hash and the canonical key
-    // (ttsl::hash::hash_objects_with_default_seed + ttsl::hash::canonical_key). They list exactly the
-    // structure-affecting fields, mirroring the set the (now-removed) custom compute_program_hash used:
-    //   - `semaphore` (std::vector<GlobalSemaphore>) is excluded: it is runtime-only (semaphore
-    //     addresses are passed to runtime args) and was never part of the old custom hash.
-    //   - `barrier_semaphore` (std::optional<GlobalSemaphore>) is reduced to its presence bool: the old
-    //     hash hashed only `barrier_semaphore.has_value()`, since only the presence (not the runtime
-    //     address) affects program structure.
-    //   - `sub_device_id` is included: the old hash hashed the derived subdevice worker-core range
-    //     (mesh_device->worker_cores(TENSIX, sub_device_id...)), which is per-device-constant given the
-    //     sub-device id. `sub_device_id` is the structural input of that computation (the program cache
-    //     is per-device, so the derived core range need not be re-encoded).
-    // The program-factory selection (Ring vs Line) is a pure function of `topology`, which is included,
-    // so the default path (which does not encode program_factory.index()) stays correct.
     static constexpr auto attribute_names = std::forward_as_tuple(
         "dim",
         "num_links",

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op_device_operation_types.hpp
@@ -48,27 +48,6 @@ struct ReduceScatterMinimalAsyncParams {
     std::optional<uint32_t> num_buffers_per_channel;
     std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config;
 
-    // Add attributes method for reflection
-    auto attributes() const {
-        using ttsl::reflection::Attribute;
-        std::vector<std::tuple<std::string, Attribute>> attrs;
-        attrs.emplace_back("dim", dim);
-        attrs.emplace_back("num_links", num_links);
-        attrs.emplace_back("ring_size", ring_size);
-        attrs.emplace_back("output_mem_config", output_mem_config);
-        attrs.emplace_back("optional_intermediate_mem_config", optional_intermediate_mem_config);
-        attrs.emplace_back("topology", topology);
-        attrs.emplace_back("semaphore", semaphore);
-        attrs.emplace_back("barrier_semaphore", barrier_semaphore);
-        attrs.emplace_back("using_persistent_buffers", using_persistent_buffers);
-        attrs.emplace_back("cluster_axis", cluster_axis);
-        attrs.emplace_back("chunks_per_sync", chunks_per_sync);
-        attrs.emplace_back("num_workers_per_link", num_workers_per_link);
-        attrs.emplace_back("num_buffers_per_channel", num_buffers_per_channel);
-        attrs.emplace_back("compute_kernel_config", compute_kernel_config);
-        return attrs;
-    }
-
     // Compile-time attributes drive the default program-cache reflection hash and the canonical key
     // (ttsl::hash::hash_objects_with_default_seed + ttsl::hash::canonical_key). They list exactly the
     // structure-affecting fields, mirroring the set the (now-removed) custom compute_program_hash used:

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op_device_operation_types.hpp
@@ -68,6 +68,53 @@ struct ReduceScatterMinimalAsyncParams {
         attrs.emplace_back("compute_kernel_config", compute_kernel_config);
         return attrs;
     }
+
+    // Compile-time attributes drive the default program-cache reflection hash and the canonical key
+    // (ttsl::hash::hash_objects_with_default_seed + ttsl::hash::canonical_key). They list exactly the
+    // structure-affecting fields, mirroring the set the (now-removed) custom compute_program_hash used:
+    //   - `semaphore` (std::vector<GlobalSemaphore>) is excluded: it is runtime-only (semaphore
+    //     addresses are passed to runtime args) and was never part of the old custom hash.
+    //   - `barrier_semaphore` (std::optional<GlobalSemaphore>) is reduced to its presence bool: the old
+    //     hash hashed only `barrier_semaphore.has_value()`, since only the presence (not the runtime
+    //     address) affects program structure.
+    //   - `sub_device_id` is included: the old hash hashed the derived subdevice worker-core range
+    //     (mesh_device->worker_cores(TENSIX, sub_device_id...)), which is per-device-constant given the
+    //     sub-device id. `sub_device_id` is the structural input of that computation (the program cache
+    //     is per-device, so the derived core range need not be re-encoded).
+    // The program-factory selection (Ring vs Line) is a pure function of `topology`, which is included,
+    // so the default path (which does not encode program_factory.index()) stays correct.
+    static constexpr auto attribute_names = std::forward_as_tuple(
+        "dim",
+        "num_links",
+        "ring_size",
+        "output_mem_config",
+        "optional_intermediate_mem_config",
+        "topology",
+        "has_barrier_semaphore",
+        "using_persistent_buffers",
+        "sub_device_id",
+        "cluster_axis",
+        "chunks_per_sync",
+        "num_workers_per_link",
+        "num_buffers_per_channel",
+        "compute_kernel_config");
+    auto attribute_values() const {
+        return std::make_tuple(
+            dim,
+            num_links,
+            ring_size,
+            output_mem_config,
+            optional_intermediate_mem_config,
+            topology,
+            barrier_semaphore.has_value(),
+            using_persistent_buffers,
+            sub_device_id,
+            cluster_axis,
+            chunks_per_sync,
+            num_workers_per_link,
+            num_buffers_per_channel,
+            compute_kernel_config);
+    }
 };
 
 struct ReduceScatterMinimalAsyncInputs {


### PR DESCRIPTION
### PR Category
hash calculation unification for operation ReduceScatterMinimalAsyncDeviceOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for ReduceScatterMinimalAsyncDeviceOperation

### Notes for reviewers
NA

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_ReduceScatterMinimalAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_ReduceScatterMinimalAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_ReduceScatterMinimalAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_ReduceScatterMinimalAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_ReduceScatterMinimalAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_ReduceScatterMinimalAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_ReduceScatterMinimalAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_ReduceScatterMinimalAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_ReduceScatterMinimalAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_ReduceScatterMinimalAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_ReduceScatterMinimalAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_ReduceScatterMinimalAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_ReduceScatterMinimalAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_ReduceScatterMinimalAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_ReduceScatterMinimalAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_ReduceScatterMinimalAsyncDeviceOperation)
