### PR TITLE
Alexey zaytsev epam/fix hash collision 45821 slice reshard async device operation

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation.cpp
@@ -44,21 +44,6 @@ Tensor SliceReshardAsyncDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.device());
 }
 
-ttsl::hash::hash_t SliceReshardAsyncDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    log_trace(tt::LogOp, "SliceReshardAsyncDeviceOperation::compute_program_hash is called");
-    return tt::tt_metal::operation::hash_operation<SliceReshardAsyncDeviceOperation>(
-        args.dim,
-        args.output_dim_offset,
-        args.output_dim_shape,
-        args.cluster_axis,
-        args.num_links,
-        args.output_mem_config,
-        args.topology,
-        args.ring_size,
-        tensor_args);
-}
-
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation.hpp
@@ -32,7 +32,6 @@ struct SliceReshardAsyncDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation_types.hpp
@@ -60,24 +60,6 @@ struct SliceReshardAsyncParams {
         topology(topology),
         ring_size(ring_size) {}
 
-    // Add attributes method for reflection
-    auto attributes() const {
-        using ttsl::reflection::Attribute;
-        std::vector<std::tuple<std::string, Attribute>> attrs;
-
-        attrs.emplace_back("dim", dim);
-        attrs.emplace_back("output_dim_offset", output_dim_offset);
-        attrs.emplace_back("output_dim_shape", output_dim_shape);
-        attrs.emplace_back("cluster_axis", cluster_axis);
-        attrs.emplace_back("final_semaphore", final_semaphore);
-        attrs.emplace_back("barrier_semaphore", barrier_semaphore);
-        attrs.emplace_back("num_links", num_links);
-        attrs.emplace_back("output_mem_config", output_mem_config);
-        attrs.emplace_back("topology", topology);
-        attrs.emplace_back("ring_size", ring_size);
-        return attrs;
-    }
-
     // Program-cache hash / canonical-key fields. Lists exactly the structural fields the former
     // custom compute_program_hash included; `devices` (raw IDevice* pointers) and the two
     // GlobalSemaphore members are runtime-only and intentionally excluded.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation_types.hpp
@@ -60,9 +60,7 @@ struct SliceReshardAsyncParams {
         topology(topology),
         ring_size(ring_size) {}
 
-    // Program-cache hash / canonical-key fields. Lists exactly the structural fields the former
-    // custom compute_program_hash included; `devices` (raw IDevice* pointers) and the two
-    // GlobalSemaphore members are runtime-only and intentionally excluded.
+    // Program-cache hash / canonical-key fields.
     static constexpr auto attribute_names = std::make_tuple(
         "dim",
         "output_dim_offset",

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation_types.hpp
@@ -77,6 +77,31 @@ struct SliceReshardAsyncParams {
         attrs.emplace_back("ring_size", ring_size);
         return attrs;
     }
+
+    // Program-cache hash / canonical-key fields. Lists exactly the structural fields the former
+    // custom compute_program_hash included; `devices` (raw IDevice* pointers) and the two
+    // GlobalSemaphore members are runtime-only and intentionally excluded.
+    static constexpr auto attribute_names = std::make_tuple(
+        "dim",
+        "output_dim_offset",
+        "output_dim_shape",
+        "cluster_axis",
+        "num_links",
+        "output_mem_config",
+        "topology",
+        "ring_size");
+
+    auto attribute_values() const {
+        return std::forward_as_tuple(
+            this->dim,
+            this->output_dim_offset,
+            this->output_dim_shape,
+            this->cluster_axis,
+            this->num_links,
+            this->output_mem_config,
+            this->topology,
+            this->ring_size);
+    }
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation_types.hpp
@@ -93,14 +93,7 @@ struct SliceReshardAsyncParams {
 
     auto attribute_values() const {
         return std::forward_as_tuple(
-            this->dim,
-            this->output_dim_offset,
-            this->output_dim_shape,
-            this->cluster_axis,
-            this->num_links,
-            this->output_mem_config,
-            this->topology,
-            this->ring_size);
+            dim, output_dim_offset, output_dim_shape, cluster_axis, num_links, output_mem_config, topology, ring_size);
     }
 };
 


### PR DESCRIPTION
### PR Category
hash calculation unification for operation SliceReshardAsyncDeviceOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for SliceReshardAsyncDeviceOperation

### Notes for reviewers
NA

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_SliceReshardAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_SliceReshardAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_SliceReshardAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_SliceReshardAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_SliceReshardAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_SliceReshardAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_SliceReshardAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_SliceReshardAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_SliceReshardAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_SliceReshardAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_SliceReshardAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_SliceReshardAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_SliceReshardAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_SliceReshardAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_SliceReshardAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_SliceReshardAsyncDeviceOperation)
