### PR TITLE
feat: ROW_MAJOR + fp8_e4m3 support for update_padded_kv_cache

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_update_padded_kv_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_update_padded_kv_cache.py
@@ -16,16 +16,148 @@ import torch
 from loguru import logger
 
 import ttnn
+from models.common.utility_functions import is_blackhole
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
-from tests.ttnn.utils_for_testing import assert_with_pcc
 
-# MLA KVPE head dim (kv_lora_rank=512 + qk_rope_head_dim=64). The op is a pure tile
-# copy, so a gathered cache slot should match the data we sent (PCC, allowing for the
-# bfloat8_b cache round-trip).
+# MLA KVPE head dim (kv_lora_rank=512 + qk_rope_head_dim=64). The op is a pure page copy, so a
+# gathered cache slot must byte-match the input we sent (read back through the same dtype
+# encode/decode) -- the tests assert exact equality, not PCC.
 KVPE_HEAD_DIM = 576
 
 
+# (cache dtype, layout). bfloat8_b/bfloat4_b are block-float (TILE only); fp8_e4m3 is ROW_MAJOR only
+# (Blackhole); bf16 covers the row-major page math in a lossless dtype. The tests assert bit-exact
+# equality against the input read back, so no per-dtype tolerance is needed.
+DTYPE_LAYOUT_CASES = [
+    (ttnn.bfloat8_b, ttnn.TILE_LAYOUT),
+    (ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT),
+    (ttnn.fp8_e4m3, ttnn.ROW_MAJOR_LAYOUT),
+]
+DTYPE_LAYOUT_IDS = ["bfp8_tile", "bf16_rm", "fp8_rm"]
+
+
+def _make_input(torch_chunk, dtype, layout, mesh_device, mesh_mapper):
+    """Build a device input tensor. fp8_e4m3 cannot be constructed through the mesh-mapper path
+    (it forces TILE), so build bf16 and typecast on device — typecast preserves ROW_MAJOR."""
+    if dtype == ttnn.fp8_e4m3:
+        tt = ttnn.from_torch(
+            torch_chunk,
+            device=mesh_device,
+            dtype=ttnn.bfloat16,
+            layout=layout,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=mesh_mapper,
+        )
+        return ttnn.typecast(tt, ttnn.fp8_e4m3)
+    return ttnn.from_torch(
+        torch_chunk,
+        device=mesh_device,
+        dtype=dtype,
+        layout=layout,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=mesh_mapper,
+    )
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 1)], ids=["1x1"], indirect=True)
+@pytest.mark.parametrize("dtype, layout", DTYPE_LAYOUT_CASES, ids=DTYPE_LAYOUT_IDS)
+@pytest.mark.timeout(0)
+def test_update_padded_kv_cache_single_device(mesh_device, dtype, layout):
+    """Single-chip (1x1 mesh, sp=1) coverage that runs on a one-card box, so the op's per-dtype/layout
+    copy can be validated without a 4-32 chip mesh. Uses the production init_kvpe_cache (ND-sharded);
+    its DRAM-bank count is now device-derived, so it runs on harvested parts (e.g. 7 banks) too.
+
+    sp=1 degenerates the per-chip offset math (boundary_chip=0, one slab == whole cache), so this is a
+    plain per-slot KV fill: write a chunk-aligned slab per (user, layer) at offset 0.
+
+    The op is a pure byte copy, so we assert bit-EXACT equality (not PCC) against the data we actually
+    sent — i.e. the input read back, which has already been through the same dtype encode/decode. This
+    isolates the op: any dtype quantization is identical on both sides, so a perfect copy is exactly
+    equal. (Comparing against the original bf16 reference would instead measure the bfp8/fp8 round-trip.)"""
+    if dtype == ttnn.fp8_e4m3 and not is_blackhole():
+        pytest.skip("FP8_E4M3 is Blackhole-only")
+    sp_axis = 0
+    sp = mesh_device.shape[sp_axis]  # == 1
+    tile = ttnn.TILE_SIZE
+
+    num_users, num_layers = 2, 2
+    chunk_local = 4 * tile  # 128 tokens/dev
+    new_isl_global = chunk_local * sp
+    cache_tokens = 512
+    cache_global = cache_tokens * sp
+
+    torch.manual_seed(0)
+    sent = {
+        (u, l): torch.randn(new_isl_global, KVPE_HEAD_DIM, dtype=torch.bfloat16)
+        for u in range(num_users)
+        for l in range(num_layers)
+    }
+
+    kv_cache = init_kvpe_cache(
+        kvpe_cache_head_dim=KVPE_HEAD_DIM,
+        mesh_device=mesh_device,
+        seq_len=cache_global,
+        mesh_shape=list(mesh_device.shape),
+        sp_axis=sp_axis,
+        num_kvpe_cache_layers=num_users * num_layers,
+        dtype=dtype,
+        layout=layout,
+    )
+
+    input_shard_dims = [None, None]
+    input_shard_dims[sp_axis] = 2  # at sp=1 this keeps the whole chunk on the one chip
+
+    mesh_device.enable_program_cache()
+
+    # Capture each input read back to host (decoded the same way the cache will be) as the exact
+    # reference for the bytes the op should copy.
+    expected = {}
+    for u in range(num_users):
+        for l in range(num_layers):
+            tt_input = _make_input(
+                sent[(u, l)].reshape(1, 1, new_isl_global, KVPE_HEAD_DIM),
+                dtype,
+                layout,
+                mesh_device,
+                ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=input_shard_dims),
+            )
+            expected[(u, l)] = (
+                ttnn.to_torch(tt_input, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=2))
+                .to(torch.bfloat16)
+                .reshape(new_isl_global, KVPE_HEAD_DIM)
+            )
+            ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
+                kv_cache,
+                tt_input,
+                slot_idx=u,
+                layer_idx=l,
+                num_layers=num_layers,
+                kv_actual_global=0,
+                cluster_axis=sp_axis,
+            )
+
+    ttnn.synchronize_device(mesh_device)
+
+    # NOTE: the op's program-cache-reuse contract (one program per layer) is asserted by the
+    # multi-device tests; skipped here since the single-device from_torch/typecast path spins up
+    # auxiliary device programs (tilize / layout conversion) that would inflate the count.
+    cache_host = ttnn.to_torch(kv_cache, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0)).to(torch.bfloat16)
+    # ConcatMeshToTensor on a 1x1 mesh stacks the single shard on dim 0; recover [slots, 1, seq, head].
+    cache_host = cache_host.reshape(num_users * num_layers, 1, cache_tokens, KVPE_HEAD_DIM)
+
+    for u in range(num_users):
+        for l in range(num_layers):
+            batch_idx = u * num_layers + l
+            written = cache_host[batch_idx, 0, :chunk_local, :]
+            assert torch.equal(written, expected[(u, l)]), (
+                f"[{dtype}] user {u} layer {l}: cache slot does not byte-match the input sent "
+                f"(max abs diff {(written.float() - expected[(u, l)].float()).abs().max().item()})"
+            )
+            logger.info(f"  [{dtype}] user {u} layer {l}: exact match")
+
+
 @pytest.mark.parametrize("mesh_device", [(1, 4), (2, 4), (8, 4)], ids=["1x4", "2x4", "8x4"], indirect=True)
+@pytest.mark.parametrize("dtype, layout", DTYPE_LAYOUT_CASES, ids=DTYPE_LAYOUT_IDS)
 @pytest.mark.parametrize(
     "config_name, num_users, num_layers, new_isl_tiles_per_dev, cache_tokens_per_dev",
     [
@@ -42,11 +174,19 @@ def test_update_padded_kv_cache_single_iteration_prefill(
     num_layers,
     new_isl_tiles_per_dev,
     cache_tokens_per_dev,
+    dtype,
+    layout,
     is_ci_env,
     is_ci_v2_env,
 ):
     """Single-iteration (non-padded) prefill: write one chunk-aligned slab per (user, layer)
-    at offset 0, gather the whole cache, and PCC each slot's valid data against what was sent."""
+    at offset 0, gather the whole cache, and assert each slot's valid data byte-matches what was sent.
+
+    The op is a pure copy, so the reference is the input read back (already through the same dtype
+    encode/decode), and the check is bit-EXACT equality -- not PCC against the bf16 source, which would
+    only measure the bfp8/fp8 round-trip rather than the op."""
+    if dtype == ttnn.fp8_e4m3 and not is_blackhole():
+        pytest.skip("FP8_E4M3 is Blackhole-only")
     if is_ci_env or is_ci_v2_env:
         pytest.skip("CI runs only the small padded_partial case (multi-iteration); this is a subset of it")
     sp_axis, tp_axis = 0, 1
@@ -72,25 +212,37 @@ def test_update_padded_kv_cache_single_iteration_prefill(
         mesh_shape=list(mesh_device.shape),
         sp_axis=sp_axis,
         num_kvpe_cache_layers=num_users * num_layers,
+        dtype=dtype,
+        layout=layout,
     )
 
     input_shard_dims = [None, None]
     input_shard_dims[sp_axis] = 2  # split the chunk across sp devices
 
-    mesh_device.enable_program_cache()
+    # Composer to read a tensor back in natural order: concat sp shards on the seq dim, take one
+    # tp-replicated copy. Used both for the cache gather and to recover each input we sent.
+    concat_dims = [None, None]
+    concat_dims[sp_axis] = 2
+    concat_dims[tp_axis] = 1
+    composer = ttnn.ConcatMesh2dToTensor(mesh_device, dims=tuple(concat_dims), mesh_shape=mesh_device.shape)
 
+    mesh_device.enable_program_cache()
+    # init_kvpe_cache zeros the cache on device (DRAMZeroFill), which registers its own one-time
+    # program; snapshot the post-init count so the assert below measures only what the OP adds.
+    entries_after_init = mesh_device.num_program_cache_entries()
+
+    expected = {}
     for u in range(num_users):
         for l in range(num_layers):
-            tt_input = ttnn.from_torch(
+            tt_input = _make_input(
                 sent[(u, l)].reshape(1, 1, new_isl_global, KVPE_HEAD_DIM),
-                device=mesh_device,
-                dtype=ttnn.bfloat8_b,
-                layout=ttnn.TILE_LAYOUT,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                mesh_mapper=ttnn.ShardTensor2dMesh(
-                    mesh_device, mesh_shape=tuple(mesh_device.shape), dims=input_shard_dims
-                ),
+                dtype,
+                layout,
+                mesh_device,
+                ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=input_shard_dims),
             )
+            # Exact reference: the input read back in natural order (same encode/decode as the cache).
+            expected[(u, l)] = ttnn.to_torch(tt_input, mesh_composer=composer).to(torch.bfloat16)[0, 0]
             ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
                 kv_cache,
                 tt_input,
@@ -104,20 +256,18 @@ def test_update_padded_kv_cache_single_iteration_prefill(
     ttnn.synchronize_device(mesh_device)
 
     # slot_idx and kv_actual_global are device tensors (not in the program hash) and layer_idx is
-    # hashed, so exactly one cached program per layer is reused across all users — entries == num_layers.
-    assert mesh_device.num_program_cache_entries() == num_layers, (
-        f"op must reuse one cached program per layer across users; expected {num_layers} entries, "
-        f"got {mesh_device.num_program_cache_entries()}"
-    )
+    # hashed, so exactly one cached program per layer is reused across all users — the op adds
+    # num_layers entries on top of init's fixed overhead (entries_after_init). Skip for fp8: its
+    # tensors are built via ttnn.typecast, which adds its own cached programs and pollutes the global
+    # count. The op's per-layer reuse is already covered by the bf16/bfp8 cases.
+    if dtype != ttnn.fp8_e4m3:
+        assert mesh_device.num_program_cache_entries() == entries_after_init + num_layers, (
+            f"op must reuse one cached program per layer across users; expected "
+            f"{entries_after_init + num_layers} entries, got {mesh_device.num_program_cache_entries()}"
+        )
 
-    # Gather: concat sp shards on the seq dim, drop the tp-replicated head copies.
-    concat_dims = [None, None]
-    concat_dims[sp_axis] = 2
-    concat_dims[tp_axis] = 1
-    cache_host = ttnn.to_torch(
-        kv_cache,
-        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=tuple(concat_dims), mesh_shape=mesh_device.shape),
-    ).to(torch.bfloat16)
+    # Gather the cache the same way (concat sp shards on seq, one tp copy).
+    cache_host = ttnn.to_torch(kv_cache, mesh_composer=composer).to(torch.bfloat16)
     cache_host = cache_host[:, :1, :, :]  # [users*layers, 1, cache_global, KVPE_HEAD_DIM]
 
     for u in range(num_users):
@@ -132,8 +282,11 @@ def test_update_padded_kv_cache_single_iteration_prefill(
                 ],
                 dim=0,
             )
-            _, msg = assert_with_pcc(sent[(u, l)], written, 0.99)
-            logger.info(f"  user {u} layer {l}: valid-data PCC {msg}")
+            assert torch.equal(written, expected[(u, l)]), (
+                f"user {u} layer {l}: cache valid data does not byte-match the input sent "
+                f"(max abs diff {(written.float() - expected[(u, l)].float()).abs().max().item()})"
+            )
+            logger.info(f"  user {u} layer {l}: exact match")
 
     logger.info(f"program cache entries: {mesh_device.num_program_cache_entries()}")
 
@@ -163,6 +316,7 @@ def _rotated_chip_positions(kv_actual, sp, chunk_local):
 
 
 @pytest.mark.parametrize("mesh_device", [(2, 2), (2, 4), (8, 4)], ids=["2x2", "2x4", "8x4"], indirect=True)
+@pytest.mark.parametrize("dtype, layout", DTYPE_LAYOUT_CASES, ids=DTYPE_LAYOUT_IDS)
 @pytest.mark.parametrize(
     "config_name, num_users, num_layers, new_isl_tiles_per_dev, cache_tokens_per_dev",
     [
@@ -181,6 +335,8 @@ def test_update_padded_kv_cache_multi_iteration_prefill(
     new_isl_tiles_per_dev,
     cache_tokens_per_dev,
     scenario,
+    dtype,
+    layout,
     is_ci_env,
     is_ci_v2_env,
 ):
@@ -194,8 +350,11 @@ def test_update_padded_kv_cache_multi_iteration_prefill(
       chunk that enters at device 1's tile offset (a second straddle).
 
     Each iteration sends server-rotated input; afterwards the cache is gathered, natural order is
-    rebuilt, and every (user, layer) slot's valid prefix is PCC'd against the data sent.
+    rebuilt, and every (user, layer) slot's valid prefix is checked for bit-exact equality against
+    the inputs sent (read back through the same dtype encode/decode).
     """
+    if dtype == ttnn.fp8_e4m3 and not is_blackhole():
+        pytest.skip("FP8_E4M3 is Blackhole-only")
     if (is_ci_env or is_ci_v2_env) and not (config_name == "small" and scenario == "padded_partial"):
         pytest.skip("CI runs only the small padded_partial case; the others are subsets of it")
     sp_axis, tp_axis = 0, 1
@@ -238,12 +397,32 @@ def test_update_padded_kv_cache_multi_iteration_prefill(
         mesh_shape=list(mesh_device.shape),
         sp_axis=sp_axis,
         num_kvpe_cache_layers=num_users * num_layers,
+        dtype=dtype,
+        layout=layout,
     )
 
     input_shard_dims = [None, None]
     input_shard_dims[sp_axis] = 2
 
+    # Composer to read tensors back: concat sp shards on the seq dim (chip-concat order), one tp copy.
+    concat_dims = [None, None]
+    concat_dims[sp_axis] = 2
+    concat_dims[tp_axis] = 1
+    composer = ttnn.ConcatMesh2dToTensor(mesh_device, dims=tuple(concat_dims), mesh_shape=mesh_device.shape)
+
     mesh_device.enable_program_cache()
+    # init_kvpe_cache zeros the cache on device (DRAMZeroFill), which registers its own one-time
+    # program; snapshot the post-init count so the assert below measures only what the OP adds.
+    entries_after_init = mesh_device.num_program_cache_entries()
+
+    # Build the exact reference incrementally from the inputs we actually send (read back through the
+    # same dtype encode/decode), placed at their natural global positions. The op is a pure copy, so
+    # the gathered cache must byte-match this -- checked with exact equality, not PCC.
+    expected = {
+        (u, l): torch.zeros(cum_total, KVPE_HEAD_DIM, dtype=torch.bfloat16)
+        for u in range(num_users)
+        for l in range(num_layers)
+    }
 
     kv_actual = 0
     for it, new_actual_isl in enumerate(new_actual_isls):
@@ -256,20 +435,23 @@ def test_update_padded_kv_cache_multi_iteration_prefill(
         )
         gather_idx = torch.tensor([min(g, cum_total - 1) for g in flat], dtype=torch.long)
         pad_mask = torch.tensor([g >= valid_end for g in flat])
+        valid_rows = (~pad_mask).nonzero(as_tuple=True)[0]
+        flat_t = torch.tensor(flat, dtype=torch.long)
         for u in range(num_users):
             for l in range(num_layers):
                 chunk = sent[(u, l)][gather_idx].clone()  # [chunk_global, KVPE_HEAD_DIM]
                 chunk[pad_mask] = 0.0  # server pad rows
-                tt_input = ttnn.from_torch(
+                tt_input = _make_input(
                     chunk.reshape(1, 1, chunk_global, KVPE_HEAD_DIM),
-                    device=mesh_device,
-                    dtype=ttnn.bfloat8_b,
-                    layout=ttnn.TILE_LAYOUT,
-                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                    mesh_mapper=ttnn.ShardTensor2dMesh(
-                        mesh_device, mesh_shape=tuple(mesh_device.shape), dims=input_shard_dims
-                    ),
+                    dtype,
+                    layout,
+                    mesh_device,
+                    ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=input_shard_dims),
                 )
+                # Read the input back in chip-concat order (row r carries global position flat[r]) and
+                # scatter its valid rows into the natural-order reference.
+                inp_rb = ttnn.to_torch(tt_input, mesh_composer=composer).to(torch.bfloat16)[0, 0]
+                expected[(u, l)][flat_t[valid_rows]] = inp_rb[valid_rows]
                 ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
                     kv_cache,
                     tt_input,
@@ -284,20 +466,17 @@ def test_update_padded_kv_cache_multi_iteration_prefill(
     ttnn.synchronize_device(mesh_device)
 
     # kv_actual_global and slot_idx are device tensors (not in the program hash) and layer_idx is
-    # hashed, so exactly one cached program per layer is reused across all iterations and users —
-    # entries == num_layers.
-    assert mesh_device.num_program_cache_entries() == num_layers, (
-        f"op must reuse one cached program per layer across iterations/users; expected {num_layers} "
-        f"entries, got {mesh_device.num_program_cache_entries()}"
-    )
+    # hashed, so exactly one cached program per layer is reused across all iterations and users — the
+    # op adds num_layers entries on top of init's fixed overhead (entries_after_init). Skip for fp8:
+    # its tensors are built via ttnn.typecast, which adds its own cached programs and pollutes the
+    # global count. Per-layer reuse is covered by the bf16/bfp8 cases.
+    if dtype != ttnn.fp8_e4m3:
+        assert mesh_device.num_program_cache_entries() == entries_after_init + num_layers, (
+            f"op must reuse one cached program per layer across iterations/users; expected "
+            f"{entries_after_init + num_layers} entries, got {mesh_device.num_program_cache_entries()}"
+        )
 
-    concat_dims = [None, None]
-    concat_dims[sp_axis] = 2
-    concat_dims[tp_axis] = 1
-    cache_host = ttnn.to_torch(
-        kv_cache,
-        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=tuple(concat_dims), mesh_shape=mesh_device.shape),
-    ).to(torch.bfloat16)[
+    cache_host = ttnn.to_torch(kv_cache, mesh_composer=composer).to(torch.bfloat16)[
         :, :1, :, :
     ]  # [users*layers, 1, cache_global, KVPE_HEAD_DIM]
 
@@ -312,7 +491,10 @@ def test_update_padded_kv_cache_multi_iteration_prefill(
         for l in range(num_layers):
             batch_idx = u * num_layers + l
             recon = cache_host[batch_idx, 0, dim2_idx, :]  # [cum_total, KVPE_HEAD_DIM]
-            _, msg = assert_with_pcc(sent[(u, l)], recon, 0.99)
-            logger.info(f"  user {u} layer {l}: valid-prefix PCC {msg}")
+            assert torch.equal(recon, expected[(u, l)]), (
+                f"user {u} layer {l}: cache valid prefix does not byte-match the inputs sent "
+                f"(max abs diff {(recon.float() - expected[(u, l)].float()).abs().max().item()})"
+            )
+            logger.info(f"  user {u} layer {l}: exact match")
 
     logger.info(f"program cache entries: {mesh_device.num_program_cache_entries()}")

--- a/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
@@ -14,8 +14,20 @@ from models.demos.deepseek_v3_b1.micro_ops.dram_zero_fill.op import DRAMZeroFill
 
 # This is a predefined constant for the number of contiguous tokens in a DRAM bank
 NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK = 32
+# Nominal DRAM bank count for a full (unharvested) Blackhole part. Prefer get_num_dram_banks(device)
+# at runtime: harvested parts expose fewer banks (e.g. 7), and the cache ND-shard grid + the
+# disaggregation address-table striding must both use the device's actual count to stay consistent.
 BH_NUM_DRAM_BANKS = 8
 PREFILL_CHUNK_OUTPUT_TOKENS = 5 * 1024
+
+
+def get_num_dram_banks(mesh_device):
+    """Usable DRAM banks on this device. Full Blackhole = 8; harvested parts expose fewer (e.g. 7).
+
+    The KV cache ND-shards round-robin across these banks and the disaggregation address table replays
+    that exact striping (`curr_bank_id = (curr_bank_id + 1) % num_banks`), so both MUST derive the count
+    from the same device. dram_grid_size().x is the number of DRAM cores/banks the device exposes."""
+    return mesh_device.dram_grid_size().x
 
 
 def create_kv_chunk_address_table_ds(
@@ -114,6 +126,8 @@ def create_kv_chunk_address_table_ds(
 
     logger.debug(f"kvpe cache shape is: {tt_kvpe_cache.shape}")
     dram_bank_base_addr = tt_kvpe_cache.buffer_address()
+    # Must match the bank count the cache was ND-sharded across (see get_num_dram_banks).
+    num_dram_banks = get_num_dram_banks(mesh_device)
     for row in range(len(device_group_idx_per_row)):
         group_idx = device_group_idx_per_row[row]
         curr_bank_id = 0
@@ -138,7 +152,7 @@ def create_kv_chunk_address_table_ds(
                     f"Rank: {rank} Set location for (layer={layer}, pos={layer_current_position}, slot={slot}, bank_id={curr_bank_id}, curr_bank_offset = {curr_bank_offset} noc_addr = 0x{noc_addr:X})"
                 )
 
-                curr_bank_id = (curr_bank_id + 1) % BH_NUM_DRAM_BANKS
+                curr_bank_id = (curr_bank_id + 1) % num_dram_banks
                 # move to next chunk offset
                 if curr_bank_id == 0:
                     curr_bank_offset += chunk_size_bytes
@@ -218,6 +232,8 @@ def create_kv_chunk_address_table_kimi(
     ), f"cache batch dim {tt_kvpe_cache.shape[0]} != num_users({num_users}) * num_layers({num_layers})"
 
     dram_bank_base_addr = tt_kvpe_cache.buffer_address()
+    # Must match the bank count the cache was ND-sharded across (see get_num_dram_banks).
+    num_dram_banks = get_num_dram_banks(mesh_device)
     for local_idx, global_row in enumerate(range(rank_row_start, rank_row_end)):
         group_idx = device_group_idx_per_row[local_idx]
         curr_bank_id = 0
@@ -235,14 +251,24 @@ def create_kv_chunk_address_table_kimi(
                         location.device_group_index = group_idx
                         lookup_table.set(layer, position, slot, location)
 
-                        curr_bank_id = (curr_bank_id + 1) % BH_NUM_DRAM_BANKS
+                        curr_bank_id = (curr_bank_id + 1) % num_dram_banks
                         if curr_bank_id == 0:
                             curr_bank_offset += chunk_size_bytes
 
     return lookup_table
 
 
-def init_kvpe_cache(kvpe_cache_head_dim, mesh_device, seq_len, mesh_shape, sp_axis, num_kvpe_cache_layers, num_users=1):
+def init_kvpe_cache(
+    kvpe_cache_head_dim,
+    mesh_device,
+    seq_len,
+    mesh_shape,
+    sp_axis,
+    num_kvpe_cache_layers,
+    num_users=1,
+    dtype=ttnn.bfloat8_b,
+    layout=ttnn.TILE_LAYOUT,
+):
     """
     Initialize KVPE cache for MLA.
 
@@ -256,6 +282,8 @@ def init_kvpe_cache(kvpe_cache_head_dim, mesh_device, seq_len, mesh_shape, sp_ax
         num_users: Number of independent users sharing the cache. The batch dim
             is laid out user-major: slot index = user_id * num_kvpe_cache_layers + layer_idx,
             so each user's layers stay contiguous.
+        dtype: Cache element dtype (default bfloat8_b). Use fp8_e4m3 with ROW_MAJOR.
+        layout: Cache layout (default TILE_LAYOUT). ROW_MAJOR required for fp8_e4m3.
 
     Returns:
         tt_kvpe_cache: Initialized KVPE cache on device
@@ -264,8 +292,9 @@ def init_kvpe_cache(kvpe_cache_head_dim, mesh_device, seq_len, mesh_shape, sp_ax
     num_layers = num_kvpe_cache_layers
     seq_len_local = seq_len // mesh_shape[sp_axis]
 
+    num_dram_banks = get_num_dram_banks(mesh_device)
     core_ranges = [
-        ttnn.CoreRange(ttnn.CoreCoord(bank_id, 0), ttnn.CoreCoord(bank_id, 0)) for bank_id in range(BH_NUM_DRAM_BANKS)
+        ttnn.CoreRange(ttnn.CoreCoord(bank_id, 0), ttnn.CoreCoord(bank_id, 0)) for bank_id in range(num_dram_banks)
     ]
     grid = ttnn.CoreRangeSet(core_ranges)
 
@@ -282,15 +311,25 @@ def init_kvpe_cache(kvpe_cache_head_dim, mesh_device, seq_len, mesh_shape, sp_ax
 
     # Allocate + zero on device. The host from_torch path packs the full replicated
     # cache as bfp8 on host, overflowing pack_as_bfp8_tiles' 32-bit page index at high
-    # num_users; a device kernel zeros it instead with no host transfer.
+    # num_users; a device kernel zeros it instead with no host transfer. Allocating
+    # directly in the requested dtype/layout also sidesteps the mesh-mapper from_torch
+    # path that forces TILE for fp8_e4m3 (so fp8 rides on ROW_MAJOR).
+    #
+    # fp8_e4m3 can't be DRAMZeroFill'd directly: its compute kernel needs fp32_dest_acc_en
+    # whenever an 8-bit-float CB is on-core (Blackhole TT_FATAL), so for fp8 we allocate +
+    # zero in bf16 and typecast on device (still no host transfer; typecast keeps the
+    # ROW_MAJOR layout and the ND shard spec).
+    is_fp8 = dtype == ttnn.fp8_e4m3
     tt_kvpe_cache = ttnn.allocate_tensor_on_device(
         ttnn.Shape([num_users * num_layers, 1, seq_len_local, kvpe_cache_head_dim]),
-        ttnn.bfloat8_b,
-        ttnn.TILE_LAYOUT,
+        ttnn.bfloat16 if is_fp8 else dtype,
+        layout,
         mesh_device,
         kv_mem_config,
     )
     DRAMZeroFill.op(tt_kvpe_cache)
+    if is_fp8:
+        tt_kvpe_cache = ttnn.typecast(tt_kvpe_cache, ttnn.fp8_e4m3)
 
     # allocate_tensor_on_device assigns a default 2D fully-replicated topology, but the rest
     # of the model produces replicated tensors via ReplicateTensorToMesh, which is a 1D

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
@@ -35,7 +35,7 @@ constexpr auto kWriterKernelPath =
     "writer_update_padded_kv_cache.cpp";
 
 constexpr uint32_t kSrcCbIndex = 0;
-constexpr uint32_t kNumInputTilesDoubleBuffered = 2;
+constexpr uint32_t kNumInputPagesDoubleBuffered = 2;
 
 // Per-call scalar checks shared by the cache-miss and cache-hit paths. slot_idx and kv_actual_global
 // are now host-side scalars (common runtime args patched on cache hits), so the value-range checks
@@ -84,9 +84,21 @@ void UpdatePaddedKvCacheDeviceOperation::validate_on_program_cache_miss(
 
     TT_FATAL(cache.storage_type() == StorageType::DEVICE, "cache must be on device");
     TT_FATAL(input.storage_type() == StorageType::DEVICE, "input must be on device");
-    TT_FATAL(cache.layout() == Layout::TILE, "cache must be TILE layout");
-    TT_FATAL(input.layout() == Layout::TILE, "input must be TILE layout");
     TT_FATAL(cache.dtype() == input.dtype(), "cache and input dtype must match");
+
+    // Layout / dtype gating. The op is a pure page copy, so it supports both TILE and ROW_MAJOR;
+    // the page-unit math in create_descriptor branches on layout. The two formats are mutually
+    // exclusive per dtype family:
+    //   - block-float (bfloat8_b/bfloat4_b) carries a per-face shared exponent and is tile-only.
+    //   - fp8_e4m3 is ROW_MAJOR-only (Blackhole) in ttnn today.
+    TT_FATAL(cache.layout() == input.layout(), "cache and input layout must match");
+    TT_FATAL(input.layout() == Layout::TILE || input.layout() == Layout::ROW_MAJOR, "layout must be TILE or ROW_MAJOR");
+    if (tt::tt_metal::is_block_float(input.dtype())) {
+        TT_FATAL(input.layout() == Layout::TILE, "block-float dtypes (bfloat8_b/bfloat4_b) require TILE layout");
+    }
+    if (input.dtype() == DataType::FP8_E4M3) {
+        TT_FATAL(input.layout() == Layout::ROW_MAJOR, "FP8_E4M3 requires ROW_MAJOR layout");
+    }
 
     const auto& cache_shape = cache.padded_shape();
     const auto& input_shape = input.padded_shape();
@@ -97,7 +109,11 @@ void UpdatePaddedKvCacheDeviceOperation::validate_on_program_cache_miss(
 
     const uint32_t cache_seq = cache_shape[-2];
     const uint32_t input_seq = input_shape[-2];
+    // Seq / offset arithmetic stays tile-granular (multiples of 32) in BOTH layouts: the writer's
+    // update_idxt boundary math counts tile-rows even when ROW_MAJOR makes each page a single token
+    // row, so input/cache seq must be 32-aligned regardless of layout.
     TT_FATAL(input_seq % TILE_HEIGHT == 0, "input seq dim ({}) must be tile-aligned", input_seq);
+    TT_FATAL(cache_seq % TILE_HEIGHT == 0, "cache seq dim ({}) must be tile-aligned", cache_seq);
     TT_FATAL(cache_seq % input_seq == 0, "cache seq ({}) must be a multiple of input seq ({})", cache_seq, input_seq);
 
     TT_FATAL(args.num_layers > 0, "num_layers must be positive");
@@ -156,6 +172,7 @@ ttsl::hash::hash_t UpdatePaddedKvCacheDeviceOperation::compute_program_hash(
         args.num_layers,
         args.cluster_axis,
         input.dtype(),
+        input.layout(),  // TILE vs ROW_MAJOR drives the page-unit math; must not collide
         input.memory_config(),
         input.padded_shape(),
         cache.memory_config(),
@@ -180,11 +197,33 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
     const auto& input_shape = input.padded_shape();
 
     const tt::DataFormat data_format = datatype_to_dataformat_converter(input.dtype());
-    const uint32_t single_tile_size = tt::tile_size(data_format);
 
-    const uint32_t Wt = cache_shape[-1] / TILE_WIDTH;
-    const uint32_t input_Ht = input_shape[-2] / TILE_HEIGHT;
-    const uint32_t cache_HtWt = cache_shape[-2] * Wt / TILE_HEIGHT;
+    // The op moves the cache as opaque pages: in TILE layout a page is a 32x32 tile; in ROW_MAJOR a
+    // page is one token row (head_dim wide). All of the writer's start_id / update_idxt arithmetic is
+    // expressed in pages, so switching layout is purely a reinterpretation of these page-unit counts
+    // (plus the page byte size and the writer's tile_height compile arg). The seq/offset asserts keep
+    // everything 32-row-aligned in both layouts, so the boundary math is identical.
+    const bool is_row_major = input.layout() == Layout::ROW_MAJOR;
+
+    uint32_t single_page_size;  // bytes per page / CB page
+    uint32_t Wt;                // width pages per (head, seq-row)
+    uint32_t input_Ht;          // input seq in page-rows
+    uint32_t cache_HtWt;        // cache page-rows per head
+    uint32_t writer_tile_height;
+    if (is_row_major) {
+        // ROW_MAJOR: page = one token row; use the buffer's aligned page size (handles row padding).
+        single_page_size = cache.buffer()->aligned_page_size();
+        Wt = 1;
+        input_Ht = input_shape[-2];
+        cache_HtWt = cache_shape[-2];
+        writer_tile_height = 1;
+    } else {
+        single_page_size = tt::tile_size(data_format);
+        Wt = cache_shape[-1] / TILE_WIDTH;
+        input_Ht = input_shape[-2] / TILE_HEIGHT;
+        cache_HtWt = cache_shape[-2] * Wt / TILE_HEIGHT;
+        writer_tile_height = TILE_HEIGHT;
+    }
     const uint32_t cache_CHtWt = cache_shape[1] * cache_HtWt;
 
     // Per-chip kernel inputs: kernel does the update_idxt + start_id math itself from these.
@@ -202,14 +241,14 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
 
     tt::tt_metal::ProgramDescriptor desc;
 
-    // CB for the input tiles.
+    // CB for the input pages (a page is a tile in TILE layout, a token row in ROW_MAJOR).
     desc.cbs.push_back(CBDescriptor{
-        .total_size = kNumInputTilesDoubleBuffered * single_tile_size,
+        .total_size = kNumInputPagesDoubleBuffered * single_page_size,
         .core_ranges = all_cores,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = kSrcCbIndex,
             .data_format = data_format,
-            .page_size = single_tile_size,
+            .page_size = single_page_size,
         }}},
     });
 
@@ -224,9 +263,9 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
     reader_kernel.compile_time_args = std::move(reader_compile_args);
     reader_kernel.config = ReaderConfigDescriptor{};
 
-    // Writer kernel descriptor. Compile args: src CB (read), TILE_HEIGHT (divides kv tokens into
-    // tiles), then the cache tensor accessor.
-    KernelDescriptor::CompileTimeArgs writer_compile_args = {kSrcCbIndex, TILE_HEIGHT};
+    // Writer kernel descriptor. Compile args: src CB (read), tile_height (divides kv tokens into the
+    // page-row unit: TILE_HEIGHT for TILE, 1 for ROW_MAJOR), then the cache tensor accessor.
+    KernelDescriptor::CompileTimeArgs writer_compile_args = {kSrcCbIndex, writer_tile_height};
     TensorAccessorArgs(cache.buffer()).append_to(writer_compile_args);
 
     KernelDescriptor writer_kernel;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache.hpp
@@ -25,6 +25,10 @@ namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cac
 // cache hits, so their values stay out of the program hash and successive users/chunks reuse one
 // cached program (per layer).
 //
+// Supports TILE and ROW_MAJOR layouts (the op is a pure page copy; the per-chip offset math is
+// expressed in 32-row-aligned page units, identical for both). `cache` and `input` must share
+// layout and dtype: block-float (bfloat8_b/bfloat4_b) is TILE-only; FP8_E4M3 is ROW_MAJOR-only.
+//
 // In-place: returns a handle to `cache`.
 ttnn::Tensor update_padded_kv_cache(
     const ttnn::Tensor& cache,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache_nanobind.cpp
@@ -37,11 +37,13 @@ void bind_update_padded_kv_cache(nb::module_& mod) {
             users/chunks reuse one cached program (per layer).
 
             Args:
-                cache (ttnn.Tensor): 4D KV cache tensor on device, TILE layout. Sharded across
-                    `cluster_axis` with `sp_factor` slots per chip. Outermost dim equals
-                    ``num_slots * num_layers``.
-                input (ttnn.Tensor): 4D input slab on device, TILE layout, same dtype and head
-                    dim as cache. Per-chip seq length = chunk_local.
+                cache (ttnn.Tensor): 4D KV cache tensor on device, TILE or ROW_MAJOR layout. Sharded
+                    across `cluster_axis` with `sp_factor` slots per chip. Outermost dim equals
+                    ``num_slots * num_layers``. Layout/dtype must match ``input``: block-float
+                    (bfloat8_b/bfloat4_b) requires TILE; FP8_E4M3 requires ROW_MAJOR (Blackhole).
+                    Seq dims stay 32-aligned in both layouts.
+                input (ttnn.Tensor): 4D input slab on device, same layout, dtype and head dim as
+                    cache. Per-chip seq length = chunk_local.
                 slot_idx (int): user slot in the batched prefill cache.
                 layer_idx (int): Transformer layer index for this call. Structural (hashed): one
                     cached program per layer is reused across users and chunks.


### PR DESCRIPTION
## What

Adds ROW_MAJOR layout and `fp8_e4m3` dtype support to the `update_padded_kv_cache` deepseek_prefill op.

The op is a pure `TensorAccessor` page copy, so ROW_MAJOR is a page-unit reinterpretation: in TILE a page is a 32x32 tile; in ROW_MAJOR a page is one token row (head_dim wide). The descriptor branches on layout to set page byte size, width-pages (Wt), seq-in-pages and the writer's `tile_height` compile arg. The writer/reader kernels are unchanged — their `start_id` / `update_idxt` math is already page-generic. Seq and `kv_actual_global` stay 32-aligned in both layouts, so boundary math is identical. `fp8_e4m3` rides on ROW_MAJOR (it is ROW_MAJOR-only in ttnn).

## Details

- **Validation** now gates layout/dtype: block-float (bfloat8_b/bfloat4_b) is TILE-only, fp8_e4m3 is ROW_MAJOR-only, cache/input layout must match. `input.layout()` added to the program hash so TILE vs ROW_MAJOR never collide on one cached program.
- **kv_cache_utils**: derive DRAM bank count from the device (`get_num_dram_banks` = `dram_grid_size().x`) instead of hardcoding 8, in both the cache ND-shard grid and the disaggregation address tables. Identical layout on full 8-bank parts; also runs on harvested 7-bank parts.
- **Tests**: parametrize over (bfp8/TILE, bf16/RM, fp8/RM) and assert bit-exact equality against the input read back (the op is a copy, so the right check is equality, not PCC against the bf16 source). Adds a 1x1-mesh single-device test. `init_kvpe_cache` gains optional dtype/layout kwargs and builds fp8 via bf16 + on-device typecast (the mesh-mapper `from_torch` path forces TILE for fp8). Program-cache-count assert skipped for fp8 (typecast registers its own cached programs); fp8 cases gated to Blackhole via `is_blackhole()` so the T3K (Wormhole) op-test job stays green.

## Testing

Validated on a 4-chip Blackhole box: 21 passed / 36 skipped (8- and 32-chip meshes), including multi_iteration at 2x2 (sp=2) multi-chip rotation for bf16/bfp8/fp8, both non_padded and padded_partial, with exact equality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/update_padded_kv_cache_rm_fp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/update_padded_kv_cache_rm_fp8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/update_padded_kv_cache_rm_fp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/update_padded_kv_cache_rm_fp8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/update_padded_kv_cache_rm_fp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/update_padded_kv_cache_rm_fp8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/update_padded_kv_cache_rm_fp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/update_padded_kv_cache_rm_fp8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/update_padded_kv_cache_rm_fp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/update_padded_kv_cache_rm_fp8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/update_padded_kv_cache_rm_fp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/update_padded_kv_cache_rm_fp8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/update_padded_kv_cache_rm_fp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/update_padded_kv_cache_rm_fp8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/update_padded_kv_cache_rm_fp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/update_padded_kv_cache_rm_fp8)