### PR TITLE
[Cleanup] Migrate all-gather + send/recv CCL ops to Device 2.0 API

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/broadcast_rm_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/broadcast_rm_reader.cpp
@@ -3,7 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/core_local_mem.h"
 #include <cstdint>
+#include "api/tensor/noc_traits.h"
 
 using address_t = uint32_t;
 
@@ -30,21 +35,28 @@ void kernel_main() {
 
     auto tensor0_addrgen = TensorAccessor(tensor0_args, tensor_address0);
 
+    Noc noc_obj;
+    CircularBuffer cb0(cb0_id);
+
     for (uint32_t page_id = input_page_id_start; page_id < input_page_id_end;) {
-        cb_reserve_back(cb0_id, 1);
-        uint32_t l1_write_addr = get_write_ptr(cb0_id);
+        cb0.reserve_back(1);
+        uint32_t l1_write_addr = cb0.get_write_ptr();
 
         // fill CB page
         for (uint32_t input = 0; input < inputs_per_cb_page; input++) {
             if (page_id + input >= input_page_id_end) [[unlikely]] {
                 break;
             }
-            auto tensor_src_addr = tensor0_addrgen.get_noc_addr(page_id + input, 0);
             auto cb_input_page = l1_write_addr + input * input_page_size;
-            noc_async_read(tensor_src_addr, cb_input_page, input_page_size);
+            noc_obj.async_read(
+                tensor0_addrgen,
+                CoreLocalMem<uint8_t>(cb_input_page),
+                input_page_size,
+                {.page_id = page_id + input},
+                {});
         }
         page_id += inputs_per_cb_page;
-        noc_async_read_barrier();
-        cb_push_back(cb0_id, 1);
+        noc_obj.async_read_barrier();
+        cb0.push_back(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/broadcast_rm_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/broadcast_rm_writer.cpp
@@ -3,6 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/core_local_mem.h"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "tt_metal/fabric/hw/inc/packet_header_pool.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/routing_plane_connection_manager.hpp"
@@ -12,6 +16,7 @@
 #include <cstdint>
 #include <array>
 #include <type_traits>
+#include "api/tensor/noc_traits.h"
 
 using address_t = uint32_t;
 using namespace tt::tt_fabric::linear::experimental;
@@ -57,12 +62,12 @@ public:
             fabric_connection, unicast_route_id, starts.data(), ranges.data(), nullptr, packet_size);
     }
 
-    void send(uint32_t cb_out_page_start, uint64_t tensor_page_addr) {
+    void send(Noc& noc, uint32_t cb_out_page_start, uint64_t tensor_page_addr) {
         auto packet_read_addr = cb_out_page_start;
         auto dest_addr = tensor_page_addr;
         constexpr uint32_t packets_per_outpage = out_page_size / packet_size;
         for (uint32_t packet = 0; packet < packets_per_outpage; packet++) {
-            noc_async_writes_flushed();
+            noc.async_writes_flushed();
             fabric_multicast_noc_unicast_write_with_state<UnicastWriteUpdateMask::DstAddr>(
                 fabric_connection,
                 unicast_route_id,
@@ -110,7 +115,7 @@ public:
             fabric_connection, scatter_route_id, starts.data(), ranges.data(), default_scatter_header, packet_size);
     }
 
-    void send(uint32_t cb_out_page_start, uint64_t tensor_page_addr) {
+    void send(Noc& noc, uint32_t cb_out_page_start, uint64_t tensor_page_addr) {
         if (scatter_header.chunk_count == 0) {
             // save the address of the first chunk in packet
             // write function will start reading here
@@ -119,7 +124,7 @@ public:
         scatter_header.noc_address[scatter_header.chunk_count++] = tensor_page_addr;
 
         if (scatter_header.chunk_count == num_out_pages_per_packet) {
-            noc_async_writes_flushed();
+            noc.async_writes_flushed();
             fabric_multicast_noc_scatter_write_with_state<UnicastScatterWriteUpdateMask::DstAddrs>(
                 fabric_connection,
                 scatter_route_id,
@@ -146,6 +151,8 @@ void kernel_main() {
     size_t arg_idx = 0;
     // Load the input tensor spec
     address_t tensor_address0 = get_arg_val<address_t>(arg_idx++);
+    // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr, barrier_sem is a GlobalSemaphore
+    // address.
     const address_t out_ready_sem_bank_addr = get_arg_val<uint32_t>(arg_idx++);
     size_t barrier_sem = get_arg_val<uint32_t>(arg_idx++);
     uint32_t output_page_id_start = get_arg_val<uint32_t>(arg_idx++);
@@ -191,7 +198,11 @@ void kernel_main() {
         sem_route_id,
         tt::tt_fabric::NocUnicastAtomicIncCommandHeader{barrier_sem_noc_addr_in_pkt, 0});
 
+    Noc noc_obj;
+    CircularBuffer cb0(cb0_id);
+
     uint32_t num_total_targets = num_targets_forward_direction + num_targets_backward_direction;
+    // Device 2.0 migration: legacy primitive retained: barrier_sem is a GlobalSemaphore address.
     noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), num_total_targets);
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
 
@@ -201,24 +212,28 @@ void kernel_main() {
     FabricWriter writer(fabric_connection, starts, ranges, num_connections);
 
     for (uint32_t page_id = output_page_id_start; page_id < output_page_id_end;) {
-        cb_wait_front(cb0_id, 1);
-        auto l1_read_addr = get_read_ptr(cb0_id);
+        cb0.wait_front(1);
+        auto l1_read_addr = cb0.get_read_ptr();
 
         for (uint32_t output = 0u; output < outputs_per_cb_page; output++) {
             if (page_id + output >= output_page_id_end) [[unlikely]] {
                 break;
             };
             auto out_page_start = l1_read_addr + output * out_page_size;
-            auto local_tensor_page_addr = tensor0_addrgen.get_noc_addr(page_id + output, 0);
             auto fabric_tensor_page_addr =
                 tt::tt_fabric::linear::addrgen_detail::get_noc_address(tensor0_addrgen, page_id + output, 0);
-            writer.send(out_page_start, fabric_tensor_page_addr);
-            noc_async_write(out_page_start, local_tensor_page_addr, out_page_size);
+            writer.send(noc_obj, out_page_start, fabric_tensor_page_addr);
+            noc_obj.async_write(
+                CoreLocalMem<uint8_t>(out_page_start),
+                tensor0_addrgen,
+                out_page_size,
+                {},
+                {.page_id = page_id + output});
         }
         page_id += outputs_per_cb_page;
 
-        noc_async_writes_flushed();
-        cb_pop_front(cb0_id, 1);
+        noc_obj.async_writes_flushed();
+        cb0.pop_front(1);
     }
 
     // 2. mcast output ready semaphore
@@ -232,20 +247,23 @@ void kernel_main() {
     // increment locally
     uint64_t out_ready_sem_noc_addr =
         safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr);
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
     noc_semaphore_inc(out_ready_sem_noc_addr, 1);
 
     // 3. wait for mcast output ready semaphore
     if (wait_output_semaphore) {
         volatile tt_l1_ptr uint32_t* sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr);
+        // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
         noc_semaphore_wait(sem_ptr, out_ready_sem_wait_value);
     }
 
     // 4. global semaphore reset
     if (reset_global_semaphore) {
+        // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr), 0);
     }
 
     close_connections(fabric_connection);
 
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/broadcast_rm_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/broadcast_rm_writer.cpp
@@ -151,8 +151,6 @@ void kernel_main() {
     size_t arg_idx = 0;
     // Load the input tensor spec
     address_t tensor_address0 = get_arg_val<address_t>(arg_idx++);
-    // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr, barrier_sem is a GlobalSemaphore
-    // address.
     const address_t out_ready_sem_bank_addr = get_arg_val<uint32_t>(arg_idx++);
     size_t barrier_sem = get_arg_val<uint32_t>(arg_idx++);
     uint32_t output_page_id_start = get_arg_val<uint32_t>(arg_idx++);
@@ -202,7 +200,6 @@ void kernel_main() {
     CircularBuffer cb0(cb0_id);
 
     uint32_t num_total_targets = num_targets_forward_direction + num_targets_backward_direction;
-    // Device 2.0 migration: legacy primitive retained: barrier_sem is a GlobalSemaphore address.
     noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), num_total_targets);
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
 
@@ -247,19 +244,16 @@ void kernel_main() {
     // increment locally
     uint64_t out_ready_sem_noc_addr =
         safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr);
-    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
     noc_semaphore_inc(out_ready_sem_noc_addr, 1);
 
     // 3. wait for mcast output ready semaphore
     if (wait_output_semaphore) {
         volatile tt_l1_ptr uint32_t* sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr);
-        // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
         noc_semaphore_wait(sem_ptr, out_ready_sem_wait_value);
     }
 
     // 4. global semaphore reset
     if (reset_global_semaphore) {
-        // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr), 0);
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_reader.cpp
@@ -3,6 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 #include <tt-metalium/buffer_types.hpp>
 #include <cstdint>
 #include <utility>
@@ -40,21 +45,28 @@ void kernel_main() {
 
     // interleaved addrgen
 
+    Noc noc_obj;
+    CircularBuffer cb0(cb0_id);
+
     uint32_t tiles_read = 0;
     uint32_t shard_tile_id = first_core_tile_start_offset;
     uint32_t core_id = 0;
     while (tiles_read < num_tiles_to_read) {
         uint32_t num_tiles_to_read_this_core =
             std::min(num_tiles_per_core - shard_tile_id, num_tiles_to_read - tiles_read);
-        cb_reserve_back(cb0_id, num_tiles_to_read_this_core);
-        const uint32_t l1_write_addr = get_write_ptr(cb0_id);
-        uint64_t read_addr = get_noc_addr(core_noc_x[core_id], core_noc_y[core_id], tensor_address0);
-        read_addr += shard_tile_id * tensor0_page_size;
+        cb0.reserve_back(num_tiles_to_read_this_core);
+        const uint32_t l1_write_addr = cb0.get_write_ptr();
+        const uint32_t shard_addr = tensor_address0 + shard_tile_id * tensor0_page_size;
 
-        noc_async_read(read_addr, l1_write_addr, num_tiles_to_read_this_core * tensor0_page_size);
-        noc_async_read_barrier();
+        noc_obj.async_read(
+            UnicastEndpoint{},
+            CoreLocalMem<uint8_t>(l1_write_addr),
+            num_tiles_to_read_this_core * tensor0_page_size,
+            {.noc_x = core_noc_x[core_id], .noc_y = core_noc_y[core_id], .addr = shard_addr},
+            {});
+        noc_obj.async_read_barrier();
 
-        cb_push_back(cb0_id, num_tiles_to_read_this_core);
+        cb0.push_back(num_tiles_to_read_this_core);
         tiles_read += num_tiles_to_read_this_core;
         shard_tile_id = 0;
         core_id++;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_writer.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include <tt-metalium/buffer_types.hpp>
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
@@ -46,6 +49,7 @@ void kernel_main() {
     size_t arg_idx = 0;
     // Load the input tensor spec
     address_t tensor_address0 = get_arg_val<address_t>(arg_idx++);
+    // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
     const size_t out_ready_sem_bank_addr = get_arg_val<uint32_t>(arg_idx++);
     uint32_t num_tiles_per_core = get_arg_val<uint32_t>(arg_idx++);
     uint32_t num_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
@@ -56,6 +60,7 @@ void kernel_main() {
     const uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
     uint32_t out_ready_sem_wait_value = get_arg_val<uint32_t>(arg_idx++);
+    // Device 2.0 migration: legacy primitive retained: barrier_sem is a GlobalSemaphore address.
     size_t barrier_sem = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t barrier_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t barrier_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
@@ -69,16 +74,20 @@ void kernel_main() {
         FabricConnectionManager::build_from_args<FabricConnectionManager::BUILD_AND_OPEN_CONNECTION_START_ONLY>(
             arg_idx);
 
+    Noc noc_obj;
+    CircularBuffer cb_packet_header(reserved_packet_header_cb_id);
+    CircularBuffer cb0(cb0_id);
+
     // packet header cb
-    cb_reserve_back(reserved_packet_header_cb_id, 1);
-    auto packet_header_buffer_addr_forward = get_write_ptr(reserved_packet_header_cb_id);
-    cb_push_back(reserved_packet_header_cb_id, 1);
-    cb_reserve_back(reserved_packet_header_cb_id, 1);
-    auto packet_header_buffer_addr_backward = get_write_ptr(reserved_packet_header_cb_id);
-    cb_push_back(reserved_packet_header_cb_id, 1);
-    cb_reserve_back(reserved_packet_header_cb_id, 1);
-    auto packet_header_buffer_seminc = get_write_ptr(reserved_packet_header_cb_id);
-    cb_push_back(reserved_packet_header_cb_id, 1);
+    cb_packet_header.reserve_back(1);
+    auto packet_header_buffer_addr_forward = cb_packet_header.get_write_ptr();
+    cb_packet_header.push_back(1);
+    cb_packet_header.reserve_back(1);
+    auto packet_header_buffer_addr_backward = cb_packet_header.get_write_ptr();
+    cb_packet_header.push_back(1);
+    cb_packet_header.reserve_back(1);
+    auto packet_header_buffer_seminc = cb_packet_header.get_write_ptr();
+    cb_packet_header.push_back(1);
 
     // pre-populate packet headers
     volatile PACKET_HEADER_TYPE* pkt_hdr_forward =
@@ -114,6 +123,7 @@ void kernel_main() {
                 packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
         }
 
+        // Device 2.0 migration: legacy primitive retained: barrier_sem is a GlobalSemaphore address.
         noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), ring_size - 1);
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
     }
@@ -125,8 +135,8 @@ void kernel_main() {
     while (tiles_read < num_tiles_to_read) {
         uint32_t num_tiles_to_read_this_core = std::min(num_tiles_per_core - shard_tile_id, packet_size_in_pages);
         num_tiles_to_read_this_core = std::min(num_tiles_to_read - tiles_read, num_tiles_to_read_this_core);
-        cb_wait_front(cb0_id, num_tiles_to_read_this_core);
-        size_t l1_read_addr = get_read_ptr(cb0_id);
+        cb0.wait_front(num_tiles_to_read_this_core);
+        size_t l1_read_addr = cb0.get_read_ptr();
 
         uint64_t noc0_dest_noc_addr =
             get_noc_addr(core_noc_x[core_id], core_noc_y[core_id], tensor_address0, 0 /*noc_id*/);
@@ -141,7 +151,7 @@ void kernel_main() {
             l1_read_addr,
             num_tiles_to_read_this_core * tensor0_page_size);
 
-        cb_pop_front(cb0_id, num_tiles_to_read_this_core);
+        cb0.pop_front(num_tiles_to_read_this_core);
         tiles_read += num_tiles_to_read_this_core;
         shard_tile_id += num_tiles_to_read_this_core;
         if (shard_tile_id >= num_tiles_per_core) {
@@ -173,18 +183,21 @@ void kernel_main() {
     // increment locally
     uint64_t out_ready_sem_noc_addr =
         safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr);
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
     noc_semaphore_inc(out_ready_sem_noc_addr, 1);
 
     // 3. wait for mcast output ready semaphore
     if (wait_output_semaphore) {
+        // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address
         noc_semaphore_wait_min(
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr), out_ready_sem_wait_value);
     }
 
     // 4. global semaphore reset
     if (reset_global_semaphore) {
+        // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr), 0);
     }
 
-    noc_async_full_barrier();
+    noc_obj.async_full_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_writer.cpp
@@ -49,7 +49,6 @@ void kernel_main() {
     size_t arg_idx = 0;
     // Load the input tensor spec
     address_t tensor_address0 = get_arg_val<address_t>(arg_idx++);
-    // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
     const size_t out_ready_sem_bank_addr = get_arg_val<uint32_t>(arg_idx++);
     uint32_t num_tiles_per_core = get_arg_val<uint32_t>(arg_idx++);
     uint32_t num_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
@@ -60,7 +59,6 @@ void kernel_main() {
     const uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
     uint32_t out_ready_sem_wait_value = get_arg_val<uint32_t>(arg_idx++);
-    // Device 2.0 migration: legacy primitive retained: barrier_sem is a GlobalSemaphore address.
     size_t barrier_sem = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t barrier_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t barrier_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
@@ -123,7 +121,6 @@ void kernel_main() {
                 packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
         }
 
-        // Device 2.0 migration: legacy primitive retained: barrier_sem is a GlobalSemaphore address.
         noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), ring_size - 1);
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
     }
@@ -183,19 +180,16 @@ void kernel_main() {
     // increment locally
     uint64_t out_ready_sem_noc_addr =
         safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr);
-    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
     noc_semaphore_inc(out_ready_sem_noc_addr, 1);
 
     // 3. wait for mcast output ready semaphore
     if (wait_output_semaphore) {
-        // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address
         noc_semaphore_wait_min(
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr), out_ready_sem_wait_value);
     }
 
     // 4. global semaphore reset
     if (reset_global_semaphore) {
-        // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr), 0);
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp
@@ -48,7 +48,6 @@ void kernel_main() {
     uint32_t arg_idx = 0;
     address_t input_tensor_address = get_arg_val<address_t>(arg_idx++);
     address_t output_tensor_address = get_arg_val<address_t>(arg_idx++);
-    // Device 2.0 migration: legacy primitive retained: out_ready_sem is a GlobalSemaphore address.
     size_t out_ready_sem = get_arg_val<uint32_t>(arg_idx++);
     const bool direction = get_arg_val<uint32_t>(arg_idx++);  // 0 is forward, 1 is backward
     const auto input_tile_id_start = get_arg_val<uint32_t>(arg_idx++);
@@ -129,8 +128,6 @@ void kernel_main() {
             size_t l1_write_addr = cb_output.get_write_ptr();
             for (uint32_t j = 0; j < num_tiles_to_read; ++j) {
                 uint32_t tile_id = output_tile_id_start + tiles_read;
-                // Device 2.0 migration: legacy primitive retained: ShardedAddrGen has no noc_traits_t
-                // specialization, so Noc::async_read rejects it at compile time.
                 uint64_t noc_read_addr = input_tensor_addrgen.get_noc_addr(tile_id);
                 noc_async_read(noc_read_addr, l1_write_addr, page_size);
 
@@ -300,7 +297,6 @@ void kernel_main() {
                 while (sem_iter_pos < input_tile_id_end) {
                     // Wait for semaphore (sender's full slice pattern)
                     if (chunk_count % chunks_per_sync == 0) {
-                        // Device 2.0 migration: legacy primitive retained: out_ready_sem is a GlobalSemaphore address.
                         noc_semaphore_wait_min(
                             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), sem_target + 1);
                         sem_target++;
@@ -322,8 +318,6 @@ void kernel_main() {
 
                             for (uint32_t j = 0; j < num_tiles_to_read; ++j) {
                                 uint32_t tile_id = output_tile_id_start + cb_row_offset + cb_pages_read_in_row;
-                                // Device 2.0 migration: legacy primitive retained: ShardedAddrGen has no
-                                // noc_traits_t specialization, so Noc::async_read rejects it at compile time.
                                 uint64_t noc_read_addr = output_tensor_addrgen.get_noc_addr(tile_id);
                                 noc_async_read(noc_read_addr, l1_write_addr, page_size);
 
@@ -379,7 +373,6 @@ void kernel_main() {
 
                 while (tiles_read < tiles_to_read) {
                     if (chunk_count % chunks_per_sync == 0) {
-                        // Device 2.0 migration: legacy primitive retained: out_ready_sem is a GlobalSemaphore address.
                         noc_semaphore_wait_min(
                             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), sem_target + 1);
                         sem_target++;
@@ -404,6 +397,5 @@ void kernel_main() {
         }
     }
 
-    // Device 2.0 migration: legacy primitive retained: out_ready_sem is a GlobalSemaphore address.
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), 0);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp
@@ -3,11 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/core_local_mem.h"
 #include "ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
 #include "ttnn/operations/ccl/ccl_host_types.hpp"
 #include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 #include <cstdint>
 #include <utility>
+#include "api/tensor/noc_traits.h"
 
 using address_t = uint32_t;
 using ttnn::ccl::Topology;
@@ -43,6 +48,7 @@ void kernel_main() {
     uint32_t arg_idx = 0;
     address_t input_tensor_address = get_arg_val<address_t>(arg_idx++);
     address_t output_tensor_address = get_arg_val<address_t>(arg_idx++);
+    // Device 2.0 migration: legacy primitive retained: out_ready_sem is a GlobalSemaphore address.
     size_t out_ready_sem = get_arg_val<uint32_t>(arg_idx++);
     const bool direction = get_arg_val<uint32_t>(arg_idx++);  // 0 is forward, 1 is backward
     const auto input_tile_id_start = get_arg_val<uint32_t>(arg_idx++);
@@ -100,10 +106,13 @@ void kernel_main() {
     const auto output_tensor_addrgen = TensorAccessor(output_tensor_args, output_tensor_address);
 #endif
 
+    Noc noc_obj;
+    CircularBuffer cb_output(cb_output_id);
+
     OpSignaler op_signaler;
-    uint32_t self_write_done_semaphore_addr;
+    uint32_t self_write_done_sem_id = 0;
     if constexpr (fuse_op) {
-        self_write_done_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+        self_write_done_sem_id = get_arg_val<uint32_t>(arg_idx++);
         op_signaler = OpSignaler(arg_idx);
     }
 
@@ -116,19 +125,19 @@ void kernel_main() {
             uint32_t tiles_remaining_to_read = tiles_to_read - tiles_read;
             uint32_t num_tiles_to_read = std::min(tiles_remaining_to_read, num_tiles_to_write_per_packet);
 
-            cb_reserve_back(cb_output_id, num_tiles_to_write_per_packet);
-            size_t l1_write_addr = get_write_ptr(cb_output_id);
+            cb_output.reserve_back(num_tiles_to_write_per_packet);
+            size_t l1_write_addr = cb_output.get_write_ptr();
             for (uint32_t j = 0; j < num_tiles_to_read; ++j) {
                 uint32_t tile_id = output_tile_id_start + tiles_read;
-                uint64_t noc_read_addr = input_tensor_addrgen.get_noc_addr(tile_id);
-                noc_async_read(noc_read_addr, l1_write_addr, page_size);
+                noc_obj.async_read(
+                    input_tensor_addrgen, CoreLocalMem<uint8_t>(l1_write_addr), page_size, {.page_id = tile_id}, {});
 
                 l1_write_addr += page_size;
                 tiles_read++;
             }
 
-            noc_async_read_barrier();
-            cb_push_back(cb_output_id, num_tiles_to_write_per_packet);
+            noc_obj.async_read_barrier();
+            cb_output.push_back(num_tiles_to_write_per_packet);
         }
         tiles_read = input_tile_id_start;
         tiles_to_read = input_tile_id_end;
@@ -289,6 +298,7 @@ void kernel_main() {
                 while (sem_iter_pos < input_tile_id_end) {
                     // Wait for semaphore (sender's full slice pattern)
                     if (chunk_count % chunks_per_sync == 0) {
+                        // Device 2.0 migration: legacy primitive retained: out_ready_sem is a GlobalSemaphore address.
                         noc_semaphore_wait_min(
                             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), sem_target + 1);
                         sem_target++;
@@ -305,13 +315,17 @@ void kernel_main() {
 
                         // Check if all tiles for this CB entry are ready
                         if (cb_tiles_pushed + num_tiles_to_read <= sem_iter_pos) {
-                            cb_reserve_back(cb_output_id, num_tiles_to_write_per_packet);
-                            size_t l1_write_addr = get_write_ptr(cb_output_id);
+                            cb_output.reserve_back(num_tiles_to_write_per_packet);
+                            size_t l1_write_addr = cb_output.get_write_ptr();
 
                             for (uint32_t j = 0; j < num_tiles_to_read; ++j) {
                                 uint32_t tile_id = output_tile_id_start + cb_row_offset + cb_pages_read_in_row;
-                                uint64_t noc_read_addr = output_tensor_addrgen.get_noc_addr(tile_id);
-                                noc_async_read(noc_read_addr, l1_write_addr, page_size);
+                                noc_obj.async_read(
+                                    output_tensor_addrgen,
+                                    CoreLocalMem<uint8_t>(l1_write_addr),
+                                    page_size,
+                                    {.page_id = tile_id},
+                                    {});
 
                                 l1_write_addr += page_size;
                                 cb_pages_read_in_row++;
@@ -321,8 +335,8 @@ void kernel_main() {
                                 }
                             }
 
-                            noc_async_read_barrier();
-                            cb_push_back(cb_output_id, num_tiles_to_write_per_packet);
+                            noc_obj.async_read_barrier();
+                            cb_output.push_back(num_tiles_to_write_per_packet);
                             cb_tiles_pushed += num_tiles_to_read;
                         } else {
                             // Need more semaphores before we can push this CB entry
@@ -365,6 +379,7 @@ void kernel_main() {
 
                 while (tiles_read < tiles_to_read) {
                     if (chunk_count % chunks_per_sync == 0) {
+                        // Device 2.0 migration: legacy primitive retained: out_ready_sem is a GlobalSemaphore address.
                         noc_semaphore_wait_min(
                             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), sem_target + 1);
                         sem_target++;
@@ -381,13 +396,14 @@ void kernel_main() {
         if constexpr (fuse_op) {
             // Signal matmul to go
             if (direction == 1 && slices_received == 1) {
-                noc_semaphore_wait_min(
-                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(self_write_done_semaphore_addr), 1);
-                noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(self_write_done_semaphore_addr), 0);
+                Semaphore<> self_write_done_sem(self_write_done_sem_id);
+                self_write_done_sem.wait_min(1);
+                self_write_done_sem.set(0);
             }
             op_signaler.synchronize_workers_and_signal_op(actual_sender_chip_id);
         }
     }
 
+    // Device 2.0 migration: legacy primitive retained: out_ready_sem is a GlobalSemaphore address.
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), 0);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp
@@ -129,8 +129,10 @@ void kernel_main() {
             size_t l1_write_addr = cb_output.get_write_ptr();
             for (uint32_t j = 0; j < num_tiles_to_read; ++j) {
                 uint32_t tile_id = output_tile_id_start + tiles_read;
-                noc_obj.async_read(
-                    input_tensor_addrgen, CoreLocalMem<uint8_t>(l1_write_addr), page_size, {.page_id = tile_id}, {});
+                // Device 2.0 migration: legacy primitive retained: ShardedAddrGen has no noc_traits_t
+                // specialization, so Noc::async_read rejects it at compile time.
+                uint64_t noc_read_addr = input_tensor_addrgen.get_noc_addr(tile_id);
+                noc_async_read(noc_read_addr, l1_write_addr, page_size);
 
                 l1_write_addr += page_size;
                 tiles_read++;
@@ -320,12 +322,10 @@ void kernel_main() {
 
                             for (uint32_t j = 0; j < num_tiles_to_read; ++j) {
                                 uint32_t tile_id = output_tile_id_start + cb_row_offset + cb_pages_read_in_row;
-                                noc_obj.async_read(
-                                    output_tensor_addrgen,
-                                    CoreLocalMem<uint8_t>(l1_write_addr),
-                                    page_size,
-                                    {.page_id = tile_id},
-                                    {});
+                                // Device 2.0 migration: legacy primitive retained: ShardedAddrGen has no
+                                // noc_traits_t specialization, so Noc::async_read rejects it at compile time.
+                                uint64_t noc_read_addr = output_tensor_addrgen.get_noc_addr(tile_id);
+                                noc_async_read(noc_read_addr, l1_write_addr, page_size);
 
                                 l1_write_addr += page_size;
                                 cb_pages_read_in_row++;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
@@ -109,12 +109,9 @@ void kernel_main() {
     address_t output_address = get_arg_val<address_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
-    // Device 2.0 migration: legacy primitive retained: out_ready_sem is a GlobalSemaphore address.
-    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
     size_t out_ready_sem = get_arg_val<uint32_t>(arg_idx++);
 
     bool use_barrier_sem = get_arg_val<uint32_t>(arg_idx++);
-    // Device 2.0 migration: legacy primitive retained: barrier_sem is a GlobalSemaphore address.
     size_t barrier_sem = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t opposite_core_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t opposite_core_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
@@ -137,7 +134,6 @@ void kernel_main() {
     const size_t fabric_mux_buffer_index_address = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t fabric_mux_channel_id = get_arg_val<uint32_t>(arg_idx++);
 
-    // Device 2.0 migration: legacy primitive retained: fabric-mux sync address (raw L1 pointer, not a program id)
     uint32_t termination_sync_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_fabric_mux_status_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_flow_control_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
@@ -280,7 +276,7 @@ void kernel_main() {
                 ASSERT(false);
             }
         }
-        // Device 2.0 migration: legacy primitive retained: barrier_sem is a GlobalSemaphore address.
+
         noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), ring_size - 1);
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
     }
@@ -361,6 +357,7 @@ void kernel_main() {
 
                 uint16_t chunk_sizes[3] = {page_size, page_size, page_size};
                 uint64_t noc_addrs[4] = {0, 0, 0, 0};
+                uint64_t local_noc_addrs[4] = {0, 0, 0, 0};
                 for (uint32_t i = 0; i < tiles_to_put_in_current_packet; i++) {
                     uint32_t tile_id = tile_id_start + row_offset + pages_read_in_row;
                     pages_read_in_row++;
@@ -370,6 +367,7 @@ void kernel_main() {
                     }
 
                     noc_addrs[i] = tt::tt_fabric::linear::addrgen_detail::get_noc_address(output_addrgen, tile_id, 0);
+                    local_noc_addrs[i] = output_addrgen.get_noc_addr(tile_id);
                 }
 
             if (direction == 1) {
@@ -393,10 +391,7 @@ void kernel_main() {
                 }
 
                 for (uint32_t i = 0; i < tiles_to_put_in_current_packet; i++) {
-                    // Device 2.0 migration: legacy primitive retained: ShardedAddrGen has no noc_traits_t
-                    // specialization, so Noc::async_write rejects it at compile time. Reuse the
-                    // precomposed noc_addrs[] above to avoid recomputing per-tile NoC addresses.
-                    noc_async_write(l1_read_addr + i * page_size, noc_addrs[i], page_size);
+                    noc_async_write(l1_read_addr + i * page_size, local_noc_addrs[i], page_size);
                 }
                 noc_obj.async_write_barrier();
             } else {
@@ -472,7 +467,6 @@ void kernel_main() {
             op_signaler_sender.synchronize_workers_and_signal_op(my_chip_id);
             uint64_t self_write_done_semaphore_noc_addr =
                 safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, self_write_done_semaphore_addr, 0);
-            // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
             noc_semaphore_inc(self_write_done_semaphore_noc_addr, 1);
         }
     }
@@ -680,8 +674,6 @@ void kernel_main() {
 
         if (is_termination_master) {
             auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
-            // Device 2.0 migration: legacy primitive retained: fabric-mux sync address (raw L1 pointer, not a program
-            // id)
             noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
             tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
         } else {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
@@ -361,7 +361,6 @@ void kernel_main() {
 
                 uint16_t chunk_sizes[3] = {page_size, page_size, page_size};
                 uint64_t noc_addrs[4] = {0, 0, 0, 0};
-                uint32_t local_tile_ids[4] = {0, 0, 0, 0};
                 for (uint32_t i = 0; i < tiles_to_put_in_current_packet; i++) {
                     uint32_t tile_id = tile_id_start + row_offset + pages_read_in_row;
                     pages_read_in_row++;
@@ -371,7 +370,6 @@ void kernel_main() {
                     }
 
                     noc_addrs[i] = tt::tt_fabric::linear::addrgen_detail::get_noc_address(output_addrgen, tile_id, 0);
-                    local_tile_ids[i] = tile_id;
                 }
 
             if (direction == 1) {
@@ -395,12 +393,10 @@ void kernel_main() {
                 }
 
                 for (uint32_t i = 0; i < tiles_to_put_in_current_packet; i++) {
-                    noc_obj.async_write(
-                        CoreLocalMem<uint8_t>(l1_read_addr + i * page_size),
-                        output_addrgen,
-                        page_size,
-                        {},
-                        {.page_id = local_tile_ids[i]});
+                    // Device 2.0 migration: legacy primitive retained: ShardedAddrGen has no noc_traits_t
+                    // specialization, so Noc::async_write rejects it at compile time. Reuse the
+                    // precomposed noc_addrs[] above to avoid recomputing per-tile NoC addresses.
+                    noc_async_write(l1_read_addr + i * page_size, noc_addrs[i], page_size);
                 }
                 noc_obj.async_write_barrier();
             } else {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
@@ -3,6 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/core_local_mem.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "tt_metal/fabric/hw/inc/packet_header_pool.h"
@@ -15,6 +19,7 @@
 #include <cstdint>
 #include <utility>
 #include "tt_metal/fabric/hw/inc/linear/api.h"
+#include "api/tensor/noc_traits.h"
 
 using address_t = uint32_t;
 using ttnn::ccl::Topology;
@@ -104,9 +109,12 @@ void kernel_main() {
     address_t output_address = get_arg_val<address_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
+    // Device 2.0 migration: legacy primitive retained: out_ready_sem is a GlobalSemaphore address.
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
     size_t out_ready_sem = get_arg_val<uint32_t>(arg_idx++);
 
     bool use_barrier_sem = get_arg_val<uint32_t>(arg_idx++);
+    // Device 2.0 migration: legacy primitive retained: barrier_sem is a GlobalSemaphore address.
     size_t barrier_sem = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t opposite_core_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t opposite_core_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
@@ -129,6 +137,7 @@ void kernel_main() {
     const size_t fabric_mux_buffer_index_address = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t fabric_mux_channel_id = get_arg_val<uint32_t>(arg_idx++);
 
+    // Device 2.0 migration: legacy primitive retained: fabric-mux sync address (raw L1 pointer, not a program id)
     uint32_t termination_sync_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_fabric_mux_status_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_flow_control_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
@@ -195,6 +204,9 @@ void kernel_main() {
     size_t arg_for_fab = arg_idx;
     auto fabric_connection = FabricConnectionManager::build_from_args(arg_for_fab);
 #endif
+    Noc noc_obj;
+    CircularBuffer cb_output(cb_output_id);
+
     /* Args for overlapped all gather */
     OpSignaler op_signaler_sender;
     uint32_t self_write_done_semaphore_addr;
@@ -268,6 +280,7 @@ void kernel_main() {
                 ASSERT(false);
             }
         }
+        // Device 2.0 migration: legacy primitive retained: barrier_sem is a GlobalSemaphore address.
         noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), ring_size - 1);
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
     }
@@ -343,23 +356,23 @@ void kernel_main() {
                 uint32_t tiles_to_put_in_current_packet =
                     std::min(tiles_remaining_to_read, num_tiles_to_write_per_packet);
 
-            cb_wait_front(cb_output_id, num_tiles_to_write_per_packet);
-            size_t l1_read_addr = get_read_ptr(cb_output_id);
+                cb_output.wait_front(num_tiles_to_write_per_packet);
+                size_t l1_read_addr = cb_output.get_read_ptr();
 
-            uint16_t chunk_sizes[3] = {page_size, page_size, page_size};
-            uint64_t noc_addrs[4] = {0, 0, 0, 0};
-            uint64_t local_noc_addrs[4] = {0, 0, 0, 0};
-            for (uint32_t i = 0; i < tiles_to_put_in_current_packet; i++) {
-                uint32_t tile_id = tile_id_start + row_offset + pages_read_in_row;
-                pages_read_in_row++;
-                if (pages_read_in_row >= input_tensor_Wt) {
-                    row_offset += output_tensor_Wt;
-                    pages_read_in_row = 0;
+                uint16_t chunk_sizes[3] = {page_size, page_size, page_size};
+                uint64_t noc_addrs[4] = {0, 0, 0, 0};
+                uint32_t local_tile_ids[4] = {0, 0, 0, 0};
+                for (uint32_t i = 0; i < tiles_to_put_in_current_packet; i++) {
+                    uint32_t tile_id = tile_id_start + row_offset + pages_read_in_row;
+                    pages_read_in_row++;
+                    if (pages_read_in_row >= input_tensor_Wt) {
+                        row_offset += output_tensor_Wt;
+                        pages_read_in_row = 0;
+                    }
+
+                    noc_addrs[i] = tt::tt_fabric::linear::addrgen_detail::get_noc_address(output_addrgen, tile_id, 0);
+                    local_tile_ids[i] = tile_id;
                 }
-
-                noc_addrs[i] = tt::tt_fabric::linear::addrgen_detail::get_noc_address(output_addrgen, tile_id, 0);
-                local_noc_addrs[i] = output_addrgen.get_noc_addr(tile_id);
-            }
 
             if (direction == 1) {
                 if constexpr (num_targets_backward_direction) {
@@ -382,9 +395,14 @@ void kernel_main() {
                 }
 
                 for (uint32_t i = 0; i < tiles_to_put_in_current_packet; i++) {
-                    noc_async_write(l1_read_addr + i * page_size, local_noc_addrs[i], page_size);
+                    noc_obj.async_write(
+                        CoreLocalMem<uint8_t>(l1_read_addr + i * page_size),
+                        output_addrgen,
+                        page_size,
+                        {},
+                        {.page_id = local_tile_ids[i]});
                 }
-                noc_async_write_barrier();
+                noc_obj.async_write_barrier();
             } else {
                 if constexpr (num_targets_forward_direction) {
                     if (tiles_to_put_in_current_packet > 1) {
@@ -407,9 +425,9 @@ void kernel_main() {
             }
             tiles_read += tiles_to_put_in_current_packet;
 
-                noc_async_writes_flushed();
+            noc_obj.async_writes_flushed();
 
-                cb_pop_front(cb_output_id, num_tiles_to_write_per_packet);
+            cb_output.pop_front(num_tiles_to_write_per_packet);
 
             chunk_count++;
             if (chunk_count % chunks_per_sync == 0) {
@@ -421,7 +439,7 @@ void kernel_main() {
                         tt::tt_fabric::NocUnicastAtomicIncCommandHeader{out_ready_sem_noc_addr_in_pkt, 0});
                 }
             }
-            noc_async_writes_flushed();
+            noc_obj.async_writes_flushed();
         }
 
         if (chunk_count % chunks_per_sync != 0) {
@@ -458,6 +476,7 @@ void kernel_main() {
             op_signaler_sender.synchronize_workers_and_signal_op(my_chip_id);
             uint64_t self_write_done_semaphore_noc_addr =
                 safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, self_write_done_semaphore_addr, 0);
+            // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
             noc_semaphore_inc(self_write_done_semaphore_noc_addr, 1);
         }
     }
@@ -560,8 +579,8 @@ void kernel_main() {
                 uint32_t tiles_to_put_in_current_packet =
                     std::min(tiles_remaining_to_read, num_tiles_to_write_per_packet);
 
-                cb_wait_front(cb_output_id, num_tiles_to_write_per_packet);
-                size_t l1_read_addr = get_read_ptr(cb_output_id);
+                cb_output.wait_front(num_tiles_to_write_per_packet);
+                size_t l1_read_addr = cb_output.get_read_ptr();
 
                 uint16_t chunk_sizes[3] = {page_size, page_size, page_size};
                 uint64_t noc_addrs[4] = {0, 0, 0, 0};
@@ -593,9 +612,9 @@ void kernel_main() {
 
                 tiles_read += tiles_to_put_in_current_packet;
 
-                noc_async_writes_flushed();
+                noc_obj.async_writes_flushed();
 
-                cb_pop_front(cb_output_id, num_tiles_to_write_per_packet);
+                cb_output.pop_front(num_tiles_to_write_per_packet);
 
                 chunk_count++;
                 if (chunk_count % chunks_per_sync == 0) {
@@ -605,7 +624,7 @@ void kernel_main() {
                         pkt_hdr_sem_inc,
                         tt::tt_fabric::NocUnicastAtomicIncCommandHeader{out_ready_sem_noc_addr_in_pkt, 0});
                 }
-                noc_async_writes_flushed();
+                noc_obj.async_writes_flushed();
             }
 
             if (chunk_count % chunks_per_sync != 0) {
@@ -657,21 +676,23 @@ void kernel_main() {
         slice_writes++;
     }
 
-    noc_async_write_barrier();
-    noc_async_atomic_barrier();
+    noc_obj.async_write_barrier();
+    noc_obj.async_atomic_barrier();
 #ifdef USE_WORKER_MUX
     if (mux_connection_valid) {
         tt::tt_fabric::fabric_client_disconnect(*fabric_direction_connection);
 
         if (is_termination_master) {
             auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
+            // Device 2.0 migration: legacy primitive retained: fabric-mux sync address (raw L1 pointer, not a program
+            // id)
             noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
             tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
         } else {
             uint64_t dest_addr =
                 safe_get_noc_addr(termination_master_noc_x, termination_master_noc_y, termination_sync_address, 0);
             noc_semaphore_inc(dest_addr, 1);
-            noc_async_atomic_barrier();
+            noc_obj.async_atomic_barrier();
         }
     }
 #else
@@ -679,5 +700,5 @@ void kernel_main() {
         fabric_connection.close();
     }
 #endif
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
@@ -8,6 +8,7 @@
 #include "api/compute/compute_kernel_hw_startup.h"
 #include "api/compute/pack_untilize.h"
 #include "api/compute/tile_move_copy.h"
+#include "api/dataflow/circular_buffer.h"
 #include "internal/mod_div_lib.h"
 
 #include "api/compute/eltwise_unary/sfpu_split_includes.h"
@@ -18,21 +19,22 @@ enum class CORE_TYPE : uint8_t { IDLE_CORE = 0, WORKER_CORE = 1, HOP_CORE = 2 };
 FORCE_INLINE void reload_from_cb_to_dst(
     uint32_t in0_cb_id,
     uint32_t in1_cb_id,
-    uint32_t mm_partials_cb_id,
+    CircularBuffer& cb_mm_partials,
     bool in1_transpose_tile,
     uint32_t out_subblock_num_tiles,
     uint32_t out_subblock_w,
     uint32_t out_subblock_h,
     uint32_t in0_block_w) {
+    const uint32_t mm_partials_cb_id = cb_mm_partials.get_cb_id();
     // Reconfigure input
     copy_tile_to_dst_init_short_with_dt(in1_cb_id, mm_partials_cb_id);
-    cb_wait_front(mm_partials_cb_id, out_subblock_num_tiles);
+    cb_mm_partials.wait_front(out_subblock_num_tiles);
 
     uint32_t start_dst_index = 0;
     uint32_t start_tile_index = 0;
     copy_block_matmul_partials(mm_partials_cb_id, start_tile_index, start_dst_index, out_subblock_num_tiles);
 
-    cb_pop_front(mm_partials_cb_id, out_subblock_num_tiles);
+    cb_mm_partials.pop_front(out_subblock_num_tiles);
     // Reconfigure srcA back
     reconfig_data_format_srca(mm_partials_cb_id, in1_cb_id);
     matmul_block_init(in0_cb_id, in1_cb_id, in1_transpose_tile, out_subblock_w, out_subblock_h, in0_block_w);
@@ -179,6 +181,11 @@ void kernel_main() {
     const uint32_t* unpadded_in0_shard_widths_in_tiles = (uint32_t*)get_arg_addr(rt_args_idx);
     rt_args_idx += ring_size;
 
+    CircularBuffer cb_in0(in0_cb_id);
+    CircularBuffer cb_in1(in1_cb_id);
+    CircularBuffer cb_sync(sync_cb);
+    CircularBuffer cb_sync2(sync_cb2);
+
     constexpr uint32_t out_block_w = out_subblock_w * in1_num_subblocks;
 
 #ifdef SFPU_OP_INIT_ACTIVATION
@@ -212,6 +219,8 @@ void kernel_main() {
 #endif
         const uint32_t mm_out_cb_id = mm_out_cb_ids[b];
         const uint32_t mm_partials_cb_id = mm_partials_cb_ids[b];
+        CircularBuffer cb_mm_out(mm_out_cb_id);
+        CircularBuffer cb_mm_partials(mm_partials_cb_id);
 
         bool enable_reload = false;
         uint32_t out_num_tiles_to_wait = out_subblock_num_tiles;
@@ -228,8 +237,8 @@ void kernel_main() {
         }
 
         // Wait to receive in1
-        cb_wait_front(sync_cb2, 1);
-        cb_pop_front(sync_cb2, 1);
+        cb_sync2.wait_front(1);
+        cb_sync2.pop_front(1);
 
         for (uint32_t block = 0; block < num_blocks; block++) {
             const uint32_t curr_ring_idx = (ring_idx - block + ring_size) % ring_size;
@@ -238,7 +247,7 @@ void kernel_main() {
 
             // Wait for in1 block
             if constexpr (in1_is_dram) {
-                cb_wait_front(in1_cb_id, in1_block_num_tiles);
+                cb_in1.wait_front(in1_block_num_tiles);
             }
 
             // const uint32_t input0_cb_id = block == 0 ? in0_cb_id : in2_cb_id;
@@ -253,7 +262,8 @@ void kernel_main() {
 #endif
 
             // Wait to receive in0 block
-            cb_wait_front(input0_cb_id, in0_block_num_tiles);
+            // input0_cb_id == in0_cb_id (see assignment above).
+            cb_in0.wait_front(in0_block_num_tiles);
 
 #ifdef ENABLE_GLOBAL_CB
             UNPACK((calculate_next_block_index_and_update_rd_ptr(
@@ -282,7 +292,7 @@ void kernel_main() {
                         reload_from_cb_to_dst(
                             input0_cb_id,
                             in1_cb_id,
-                            mm_partials_cb_id,
+                            cb_mm_partials,
                             in1_transpose_tile,
                             out_subblock_num_tiles,
                             out_subblock_w,
@@ -329,7 +339,7 @@ void kernel_main() {
                         }
                         tile_regs_commit();
                         // Pack out to output buffer
-                        cb_reserve_back(mm_out_cb_id, out_subblock_num_tiles);
+                        cb_mm_out.reserve_back(out_subblock_num_tiles);
                         tile_regs_wait();
 
 #if defined FP32_DEST_ACC_EN or defined PACKER_L1_ACC
@@ -352,12 +362,12 @@ void kernel_main() {
                         if constexpr (untilize_out) {
                             pack_untilize_uninit(mm_out_cb_id);
                         }
-                        cb_push_back(mm_out_cb_id, out_subblock_num_tiles);
+                        cb_mm_out.push_back(out_subblock_num_tiles);
 
                     } else if (spill) {
                         tile_regs_commit();
                         // Move partial result to interm buffer
-                        cb_reserve_back(mm_partials_cb_id, out_subblock_num_tiles);
+                        cb_mm_partials.reserve_back(out_subblock_num_tiles);
                         tile_regs_wait();
 
 #ifdef PACKER_L1_ACC
@@ -372,7 +382,7 @@ void kernel_main() {
                         pack_tile_block(start_dst_index, mm_partials_cb_id, out_subblock_num_tiles);
 
                         tile_regs_release();
-                        cb_push_back(mm_partials_cb_id, out_subblock_num_tiles);
+                        cb_mm_partials.push_back(out_subblock_num_tiles);
                     }
 
                     in1_index_subblock_offset += out_subblock_w;
@@ -384,8 +394,8 @@ void kernel_main() {
 
             // Last iteration does spill and reload to output buffer
             if (block < num_blocks - 2 && spill) {
-                cb_wait_front(mm_partials_cb_id, out_block_num_tiles);
-                cb_pop_front(mm_partials_cb_id, out_block_num_tiles);
+                cb_mm_partials.wait_front(out_block_num_tiles);
+                cb_mm_partials.pop_front(out_block_num_tiles);
             }
             if (block == num_blocks - 2 && spill) {
                 enable_reload = true;
@@ -396,9 +406,10 @@ void kernel_main() {
             }
 #endif
 
-            cb_pop_front(input0_cb_id, in0_block_num_tiles);
+            // input0_cb_id == in0_cb_id (see assignment above).
+            cb_in0.pop_front(in0_block_num_tiles);
             if constexpr (in1_is_dram) {
-                cb_pop_front(in1_cb_id, in1_block_num_tiles);
+                cb_in1.pop_front(in1_block_num_tiles);
             }
 #ifdef ENABLE_GLOBAL_CB
             curr_in1_block_index = next_in1_block_index;
@@ -408,8 +419,8 @@ void kernel_main() {
 
 #ifdef ENABLE_GLOBAL_CB
         // Release in1
-        cb_reserve_back(sync_cb, 1);
-        cb_push_back(sync_cb, 1);
+        cb_sync.reserve_back(1);
+        cb_sync.push_back(1);
         UNPACK((update_local_cb_rd_ptr(in1_cb_id, in1_rd_ptr_start_addr)));  // reset rd_ptr back to the initial addr
         UNPACK((update_rd_ptr_to_ring_index(
             in1_cb_id, in1_block_size_bytes, ring_size, in1_tensor_split)));  // update to next tensor addr

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in0_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in0_ring_all_gather.cpp
@@ -5,6 +5,8 @@
 #include <stdint.h>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "hostdevcommon/common_values.hpp"
 #include "api/debug/dprint.h"
 
@@ -56,14 +58,19 @@ void kernel_main() {
     constexpr uint32_t multicast_chunk_size_in_tiles = multicast_chunk_width_in_tiles * shard_height_in_tiles;
     constexpr uint32_t multicast_chunk_size_bytes = multicast_chunk_size_in_tiles * in0_single_tile_size_bytes;
 
-    cb_reserve_back(cb_id_in0, multicast_chunk_size_in_tiles * num_multicast_steps);
+    CircularBuffer cb_in0(cb_id_in0);
+
+    cb_in0.reserve_back(multicast_chunk_size_in_tiles * num_multicast_steps);
     for (uint32_t istep = 0; istep < num_multicast_steps; istep++) {
+        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
+        // (fused_op_receiver_signal_semaphore_addr[] is a runtime-indexed array of L1 semaphore addresses
+        // already resolved via get_semaphore(id); Semaphore<> wraps a single id, not an array of addresses.)
         volatile tt_l1_ptr uint32_t* fused_op_receiver_signal_semaphore_addr_ptr =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
                 fused_op_receiver_signal_semaphore_addr[chunk_indices[istep]]);
 
         noc_semaphore_wait_min(fused_op_receiver_signal_semaphore_addr_ptr, 1);
         noc_semaphore_set(fused_op_receiver_signal_semaphore_addr_ptr, 0);
-        cb_push_back(cb_id_in0, multicast_chunk_size_in_tiles);
+        cb_in0.push_back(multicast_chunk_size_in_tiles);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in0_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in0_ring_all_gather.cpp
@@ -62,9 +62,6 @@ void kernel_main() {
 
     cb_in0.reserve_back(multicast_chunk_size_in_tiles * num_multicast_steps);
     for (uint32_t istep = 0; istep < num_multicast_steps; istep++) {
-        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
-        // (fused_op_receiver_signal_semaphore_addr[] is a runtime-indexed array of L1 semaphore addresses
-        // already resolved via get_semaphore(id); Semaphore<> wraps a single id, not an array of addresses.)
         volatile tt_l1_ptr uint32_t* fused_op_receiver_signal_semaphore_addr_ptr =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
                 fused_op_receiver_signal_semaphore_addr[chunk_indices[istep]]);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -46,7 +46,6 @@ void do_signaling(Noc& noc, uint32_t& rt_args_idx) {
     const uint32_t pv_core_x = get_arg_val<uint32_t>(rt_args_idx++);
     const uint32_t pv_core_y = get_arg_val<uint32_t>(rt_args_idx++);
     const uint32_t pv_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
-    const uint32_t pv_semaphore = get_semaphore(pv_semaphore_id);
     Semaphore<> pv_sem(pv_semaphore_id);
     const bool is_privilaged = get_arg_val<uint32_t>(rt_args_idx++) == 1;
     if (is_privilaged) {
@@ -56,16 +55,21 @@ void do_signaling(Noc& noc, uint32_t& rt_args_idx) {
         const uint32_t multicast_end_x = get_arg_val<uint32_t>(rt_args_idx++);
         const uint32_t multicast_end_y = get_arg_val<uint32_t>(rt_args_idx++);
         const uint32_t num_signalling_semaphores = get_arg_val<uint32_t>(rt_args_idx++);
-        const uint32_t signalling_semaphore = get_semaphore(get_arg_val<uint32_t>(rt_args_idx++));
-        const uint64_t signalling_semaphore_address =
-            get_noc_multicast_addr(multicast_start_x, multicast_start_y, multicast_end_x, multicast_end_y, 0) |
-            signalling_semaphore;
+        Semaphore<> rs_sem(get_arg_val<uint32_t>(rt_args_idx++));
         pv_sem.wait(target_sem_value);
         pv_sem.set(1);
-        noc_semaphore_set_multicast(pv_semaphore, signalling_semaphore_address, num_signalling_semaphores);
+        // Relay pv_sem's value into the (different) rs_sem over the reduce-scatter core range.
+        // noc is the reader's NoC (NOC_0)
+        pv_sem.relay_multicast(
+            noc,
+            rs_sem,
+            multicast_start_x,
+            multicast_start_y,
+            multicast_end_x,
+            multicast_end_y,
+            num_signalling_semaphores);
     } else {
-        const uint64_t sem_addr = get_noc_addr(pv_core_x, pv_core_y, pv_semaphore);
-        noc_semaphore_inc(sem_addr, 1);
+        pv_sem.up(noc, pv_core_x, pv_core_y, 1);
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -5,16 +5,22 @@
 #include <stdint.h>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/core_local_mem.h"
 #include "hostdevcommon/common_values.hpp"
 #include "api/remote_circular_buffer.h"
 #include "api/debug/dprint.h"
 #include "api/debug/dprint_tile.h"
+#include "api/tensor/noc_traits.h"
 
 enum class CORE_TYPE : uint8_t { IDLE_CORE = 0, WORKER_CORE = 1, HOP_CORE = 2 };
 
 template <typename TensorAccessorType>
 void read_block_from_dram(
-    uint32_t cb_id,
+    Noc& noc,
+    CircularBuffer& cb,
     const TensorAccessorType& s1,
     uint32_t tensor_width_in_tiles,
     uint32_t block_w_idx,
@@ -22,25 +28,26 @@ void read_block_from_dram(
     uint32_t block_w_t,
     uint32_t block_h_t,
     uint32_t tile_size_bytes) {
-    uint32_t l1_write_addr = get_write_ptr(cb_id);
+    uint32_t l1_write_addr = cb.get_write_ptr();
 
     // Horizontal idx + vertical idx * width = row major index
     uint32_t block_tile_id = block_w_idx * block_w_t + (block_h_idx * block_h_t) * tensor_width_in_tiles;
     for (uint32_t h = 0; h < block_h_t; ++h) {
         uint32_t tile_id = block_tile_id + h * tensor_width_in_tiles;
         for (uint32_t w = 0; w < block_w_t; ++w) {
-            noc_async_read_page(tile_id + w, s1, l1_write_addr);
+            noc.async_read(s1, CoreLocalMem<uint8_t>(l1_write_addr), tile_size_bytes, {.page_id = tile_id + w}, {});
             l1_write_addr += tile_size_bytes;
         }
     }
-    noc_async_read_barrier();
+    noc.async_read_barrier();
 }
 
-void do_signaling(uint32_t& rt_args_idx) {
+void do_signaling(Noc& noc, uint32_t& rt_args_idx) {
     const uint32_t pv_core_x = get_arg_val<uint32_t>(rt_args_idx++);
     const uint32_t pv_core_y = get_arg_val<uint32_t>(rt_args_idx++);
-    const uint32_t pv_semaphore = get_semaphore(get_arg_val<uint32_t>(rt_args_idx++));
-    volatile tt_l1_ptr uint32_t* pv_semaphore_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(pv_semaphore);
+    const uint32_t pv_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t pv_semaphore = get_semaphore(pv_semaphore_id);
+    Semaphore<> pv_sem(pv_semaphore_id);
     const bool is_privilaged = get_arg_val<uint32_t>(rt_args_idx++) == 1;
     if (is_privilaged) {
         const uint32_t target_sem_value = get_arg_val<uint32_t>(rt_args_idx++);
@@ -50,13 +57,17 @@ void do_signaling(uint32_t& rt_args_idx) {
         const uint32_t multicast_end_y = get_arg_val<uint32_t>(rt_args_idx++);
         const uint32_t num_signalling_semaphores = get_arg_val<uint32_t>(rt_args_idx++);
         const uint32_t signalling_semaphore = get_semaphore(get_arg_val<uint32_t>(rt_args_idx++));
+        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
         const uint64_t signalling_semaphore_address =
             get_noc_multicast_addr(multicast_start_x, multicast_start_y, multicast_end_x, multicast_end_y, 0) |
             signalling_semaphore;
-        noc_semaphore_wait(pv_semaphore_ptr, target_sem_value);
-        noc_semaphore_set(pv_semaphore_ptr, 1);
+        pv_sem.wait(target_sem_value);
+        pv_sem.set(1);
+        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
+        // (noc_semaphore_set_multicast has no Device 2.0 wrapper equivalent.)
         noc_semaphore_set_multicast(pv_semaphore, signalling_semaphore_address, num_signalling_semaphores);
     } else {
+        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
         const uint64_t sem_addr = get_noc_addr(pv_core_x, pv_core_y, pv_semaphore);
         noc_semaphore_inc(sem_addr, 1);
     }
@@ -81,8 +92,9 @@ void kernel_main() {
     uint32_t core_type = get_arg_val<uint32_t>(rt_args_idx++);
     if (core_type == (uint32_t)CORE_TYPE::IDLE_CORE || core_type == (uint32_t)CORE_TYPE::HOP_CORE) {
         if constexpr (needs_signaler) {
-            do_signaling(rt_args_idx);
-            noc_async_write_barrier();
+            Noc noc_obj_early;
+            do_signaling(noc_obj_early, rt_args_idx);
+            noc_obj_early.async_write_barrier();
         }
         return;
     }
@@ -102,6 +114,11 @@ void kernel_main() {
     constexpr uint32_t sync_cb = get_compile_time_arg_val(12);
     constexpr uint32_t sync_cb2 = get_compile_time_arg_val(13);
     constexpr uint32_t remote_cb_id = get_compile_time_arg_val(14);
+
+    Noc noc_obj;
+    CircularBuffer cb_in1(cb_id_in1);
+    CircularBuffer cb_sync(sync_cb);
+    CircularBuffer cb_sync2(sync_cb2);
 
     constexpr auto src_args = TensorAccessorArgs<16>();
 
@@ -126,20 +143,21 @@ void kernel_main() {
     }
 
     for (uint32_t b = 0; b < batch; ++b) {
-        cb_reserve_back(sync_cb2, 1);
+        cb_sync2.reserve_back(1);
 #ifdef ENABLE_GLOBAL_CB
         experimental::remote_cb_wait_front(remote_cb_id, num_blocks);
 #endif
 
-        cb_push_back(sync_cb2, 1);
+        cb_sync2.push_back(1);
 
         if constexpr (in1_is_dram_interleaved) {
             for (uint32_t block = 0; block < num_blocks; ++block) {
                 uint32_t block_idx = (ring_idx + block) % num_blocks;
 
-                cb_reserve_back(cb_id_in1, in1_block_num_tiles);
+                cb_in1.reserve_back(in1_block_num_tiles);
                 read_block_from_dram(
-                    cb_id_in1,
+                    noc_obj,
+                    cb_in1,
                     s1,
                     in1_tensor_width_in_tiles,
                     ring_idx,
@@ -147,7 +165,7 @@ void kernel_main() {
                     in1_block_width_in_tiles,
                     in1_block_height_in_tiles,
                     in1_single_tile_size_bytes);
-                cb_push_back(cb_id_in1, in1_block_num_tiles);
+                cb_in1.push_back(in1_block_num_tiles);
             }
         } else if constexpr (in1_is_dram_sharded) {  // when in1 is sharded in DRAM, each core reads from its own bank,
                                                      // two cores on the same row share one bank.
@@ -155,9 +173,11 @@ void kernel_main() {
                 uint32_t block_idx = (ring_idx + block) % num_blocks;
                 l1_read_addr_in1 = block_idx * in1_dram_shard_block_size_bytes + dram_read_offset_bytes;
                 // Operand 1
-                cb_reserve_back(cb_id_in1, in1_block_num_tiles);
-                l1_write_addr_in1 = get_write_ptr(cb_id_in1);
+                cb_in1.reserve_back(in1_block_num_tiles);
+                l1_write_addr_in1 = cb_in1.get_write_ptr();
 
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
+                // (noc_async_read_one_packet_set_state / with_state state-machine has no Device 2.0 wrapper.)
                 for (uint32_t h = 0; h < in1_block_height_in_tiles; ++h) {
                     uint32_t curr_l1_read_addr_in1 = l1_read_addr_in1;
                     for (uint32_t w = 0; w < in1_block_width_num_pages; ++w) {
@@ -173,27 +193,27 @@ void kernel_main() {
                     l1_read_addr_in1 += in1_shard_width_offset_bytes;
                 }
 
-                noc_async_read_barrier();
-                cb_push_back(cb_id_in1, in1_block_num_tiles);
+                noc_obj.async_read_barrier();
+                cb_in1.push_back(in1_block_num_tiles);
             }
         }
 
 #ifdef ENABLE_GLOBAL_CB
-        cb_wait_front(sync_cb, 1);
+        cb_sync.wait_front(1);
         experimental::remote_cb_pop_front(remote_cb_id, num_blocks);
-        cb_pop_front(sync_cb, 1);
+        cb_sync.pop_front(1);
 #endif
         // Signal Here
         if constexpr (needs_signaler) {
             if (b == 0) {
-                do_signaling(rt_args_idx);
+                do_signaling(noc_obj, rt_args_idx);
             }
         }
     }
 
 #ifdef ENABLE_GLOBAL_CB
     experimental::update_remote_cb_config_in_l1(remote_cb_id);
-    noc_async_atomic_barrier();
+    noc_obj.async_atomic_barrier();
 #endif
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -57,17 +57,13 @@ void do_signaling(Noc& noc, uint32_t& rt_args_idx) {
         const uint32_t multicast_end_y = get_arg_val<uint32_t>(rt_args_idx++);
         const uint32_t num_signalling_semaphores = get_arg_val<uint32_t>(rt_args_idx++);
         const uint32_t signalling_semaphore = get_semaphore(get_arg_val<uint32_t>(rt_args_idx++));
-        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
         const uint64_t signalling_semaphore_address =
             get_noc_multicast_addr(multicast_start_x, multicast_start_y, multicast_end_x, multicast_end_y, 0) |
             signalling_semaphore;
         pv_sem.wait(target_sem_value);
         pv_sem.set(1);
-        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
-        // (noc_semaphore_set_multicast has no Device 2.0 wrapper equivalent.)
         noc_semaphore_set_multicast(pv_semaphore, signalling_semaphore_address, num_signalling_semaphores);
     } else {
-        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
         const uint64_t sem_addr = get_noc_addr(pv_core_x, pv_core_y, pv_semaphore);
         noc_semaphore_inc(sem_addr, 1);
     }
@@ -176,8 +172,6 @@ void kernel_main() {
                 cb_in1.reserve_back(in1_block_num_tiles);
                 l1_write_addr_in1 = cb_in1.get_write_ptr();
 
-                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
-                // (noc_async_read_one_packet_set_state / with_state state-machine has no Device 2.0 wrapper.)
                 for (uint32_t h = 0; h < in1_block_height_in_tiles; ++h) {
                     uint32_t curr_l1_read_addr_in1 = l1_read_addr_in1;
                     for (uint32_t w = 0; w < in1_block_width_num_pages; ++w) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -87,14 +87,15 @@ void kernel_main() {
     constexpr uint32_t in1_block_width_num_pages = get_compile_time_arg_val(9);
     constexpr uint32_t in1_shard_width_in_dram = get_compile_time_arg_val(10);
 
+    Noc noc_obj;
+
     uint32_t rt_args_idx = 0;
     constexpr bool needs_signaler = get_compile_time_arg_val(15) == 1;
     uint32_t core_type = get_arg_val<uint32_t>(rt_args_idx++);
     if (core_type == (uint32_t)CORE_TYPE::IDLE_CORE || core_type == (uint32_t)CORE_TYPE::HOP_CORE) {
         if constexpr (needs_signaler) {
-            Noc noc_obj_early;
-            do_signaling(noc_obj_early, rt_args_idx);
-            noc_obj_early.async_write_barrier();
+            do_signaling(noc_obj, rt_args_idx);
+            noc_obj.async_write_barrier();
         }
         return;
     }
@@ -115,7 +116,6 @@ void kernel_main() {
     constexpr uint32_t sync_cb2 = get_compile_time_arg_val(13);
     constexpr uint32_t remote_cb_id = get_compile_time_arg_val(14);
 
-    Noc noc_obj;
     CircularBuffer cb_in1(cb_id_in1);
     CircularBuffer cb_sync(sync_cb);
     CircularBuffer cb_sync2(sync_cb2);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/worker_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/worker_reader.cpp
@@ -3,6 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 #include <tt-metalium/buffer_types.hpp>
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include <cstdint>
@@ -37,6 +42,7 @@ void kernel_main() {
     uint32_t intermediate_first_core_tile_start_offset = get_arg_val<uint32_t>(arg_idx++);
     uint32_t num_cores = get_arg_val<uint32_t>(arg_idx++);
     uint32_t ring_index = get_arg_val<uint32_t>(arg_idx++);
+    // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
     const size_t out_ready_sem_bank_addr = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
@@ -52,20 +58,27 @@ void kernel_main() {
 
     // interleaved addrgen
 
+    Noc noc_obj;
+    CircularBuffer cb0(cb0_id);
+
     uint32_t tiles_read = 0;
     uint32_t shard_tile_id = first_core_tile_start_offset;
     uint32_t core_id = 0;
-    cb_reserve_back(cb0_id, num_tiles_to_read);
-    uint32_t l1_write_addr = get_write_ptr(cb0_id);
+    cb0.reserve_back(num_tiles_to_read);
+    uint32_t l1_write_addr = cb0.get_write_ptr();
     while (tiles_read < num_tiles_to_read) {
         uint32_t num_tiles_to_read_this_core =
             std::min(num_tiles_per_core - shard_tile_id, num_tiles_to_read - tiles_read);
         // cb_reserve_back(cb0_id, num_tiles_to_read_this_core);
         // const uint32_t l1_write_addr = get_write_ptr(cb0_id);
-        uint64_t read_addr = get_noc_addr(core_noc_x[core_id], core_noc_y[core_id], tensor_address0);
-        read_addr += shard_tile_id * tensor0_page_size;
+        const uint32_t shard_addr = tensor_address0 + shard_tile_id * tensor0_page_size;
 
-        noc_async_read(read_addr, l1_write_addr, num_tiles_to_read_this_core * tensor0_page_size);
+        noc_obj.async_read(
+            UnicastEndpoint{},
+            CoreLocalMem<uint8_t>(l1_write_addr),
+            num_tiles_to_read_this_core * tensor0_page_size,
+            {.noc_x = core_noc_x[core_id], .noc_y = core_noc_y[core_id], .addr = shard_addr},
+            {});
         // noc_async_read_barrier();
 
         // cb_push_back(cb0_id, num_tiles_to_read_this_core);
@@ -74,21 +87,26 @@ void kernel_main() {
         shard_tile_id = 0;
         core_id++;
     }
-    noc_async_read_barrier();
-    cb_push_back(cb0_id, num_tiles_to_read);
+    noc_obj.async_read_barrier();
+    cb0.push_back(num_tiles_to_read);
     core_id = 0;
-    uint64_t noc0_dest_noc_addr = get_noc_addr(
-        core_noc_x_to_write_to[core_id], core_noc_y_to_write_to[core_id], intermediate_tensor_address0, 0 /*noc_id*/);
-    uint32_t l1_read_addr = get_read_ptr(cb0_id);
-    noc_async_write(
-        l1_read_addr,
-        noc0_dest_noc_addr + intermediate_first_core_tile_start_offset * tensor0_page_size,
-        num_tiles_to_read * tensor0_page_size);
+    const uint32_t intermediate_dest_addr =
+        intermediate_tensor_address0 + intermediate_first_core_tile_start_offset * tensor0_page_size;
+    uint32_t l1_read_addr = cb0.get_read_ptr();
+    noc_obj.async_write(
+        CoreLocalMem<uint8_t>(l1_read_addr),
+        UnicastEndpoint{},
+        num_tiles_to_read * tensor0_page_size,
+        {},
+        {.noc_x = core_noc_x_to_write_to[core_id],
+         .noc_y = core_noc_y_to_write_to[core_id],
+         .addr = intermediate_dest_addr});
 
     // notify local receiver core
     uint64_t out_ready_sem_noc_addr =
         safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr);
+    // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
     noc_semaphore_inc(out_ready_sem_noc_addr, 1);
-    noc_async_write_barrier();
-    noc_async_atomic_barrier();
+    noc_obj.async_write_barrier();
+    noc_obj.async_atomic_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/worker_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/worker_reader.cpp
@@ -42,7 +42,6 @@ void kernel_main() {
     uint32_t intermediate_first_core_tile_start_offset = get_arg_val<uint32_t>(arg_idx++);
     uint32_t num_cores = get_arg_val<uint32_t>(arg_idx++);
     uint32_t ring_index = get_arg_val<uint32_t>(arg_idx++);
-    // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
     const size_t out_ready_sem_bank_addr = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
@@ -105,7 +104,6 @@ void kernel_main() {
     // notify local receiver core
     uint64_t out_ready_sem_noc_addr =
         safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr);
-    // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
     noc_semaphore_inc(out_ready_sem_noc_addr, 1);
     noc_obj.async_write_barrier();
     noc_obj.async_atomic_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/worker_receiver.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/worker_receiver.cpp
@@ -44,20 +44,14 @@ void kernel_main() {
     Noc noc_obj;
     CircularBuffer cb_inter(inter_cb_index);
 
-    // Device 2.0 migration: legacy primitive retained: signal_semaphore_addr is a precomposed L1 semaphore
-    // address passed via a runtime arg (not a per-program id Semaphore<> can wrap)
     volatile tt_l1_ptr uint32_t* signal_semaphore_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(signal_semaphore_addr);
 
     // Set up for mcasting to mm workers
-    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
-    // (fused_op_receiver_signal_semaphore_addr[] is a runtime-indexed array of L1 semaphore addresses
-    // already resolved via get_semaphore(id); Semaphore<> wraps a single id, not an array of addresses.)
     volatile tt_l1_ptr uint32_t* fused_op_receiver_signal_semaphore_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(fused_op_receiver_signal_semaphore_addr[core_id]);
     noc_semaphore_set(fused_op_receiver_signal_semaphore_addr_ptr, VALID);
 
-    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
     volatile tt_l1_ptr uint32_t* fused_op_receiver_signal_semaphore_addr_ptr_next_core_right =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(fused_op_receiver_signal_semaphore_addr[next_core_id_to_right]);
 
@@ -81,14 +75,10 @@ void kernel_main() {
         (uint64_t)aggregated_tensor_addr + mm_core_offset * intermediate_tensor_shard_num_pages * tensor0_page_size;
     const uint64_t multicast_addr = multicast_addr_noc | aggregated_tensor_addr_this_core;
 
-    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
-    // (noc_async_write_multicast_loopback_src has no Device 2.0 wrapper equivalent.)
     noc_async_write_multicast_loopback_src(
         l1_read_addr, multicast_addr, intermediate_tensor_shard_num_pages * tensor0_page_size, bbox_size, true);
 
     uint64_t multicast_sema_addr = multicast_addr_noc | (uint64_t)fused_op_receiver_signal_semaphore_addr[core_id];
-    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
-    // (noc_semaphore_set_multicast_loopback_src has no Device 2.0 wrapper equivalent.)
     noc_semaphore_set_multicast_loopback_src(
         fused_op_receiver_signal_semaphore_addr[core_id], multicast_sema_addr, bbox_size, false);
     noc_obj.async_write_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/worker_receiver.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/worker_receiver.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "api/debug/dprint.h"
 #include "ckernel.h"
 
@@ -38,14 +41,23 @@ void kernel_main() {
     const uint32_t next_core_id_to_left = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t next_core_id_to_right = get_arg_val<uint32_t>(arg_idx++);
 
+    Noc noc_obj;
+    CircularBuffer cb_inter(inter_cb_index);
+
+    // Device 2.0 migration: legacy primitive retained: signal_semaphore_addr is a precomposed L1 semaphore
+    // address passed via a runtime arg (not a per-program id Semaphore<> can wrap)
     volatile tt_l1_ptr uint32_t* signal_semaphore_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(signal_semaphore_addr);
 
     // Set up for mcasting to mm workers
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
+    // (fused_op_receiver_signal_semaphore_addr[] is a runtime-indexed array of L1 semaphore addresses
+    // already resolved via get_semaphore(id); Semaphore<> wraps a single id, not an array of addresses.)
     volatile tt_l1_ptr uint32_t* fused_op_receiver_signal_semaphore_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(fused_op_receiver_signal_semaphore_addr[core_id]);
     noc_semaphore_set(fused_op_receiver_signal_semaphore_addr_ptr, VALID);
 
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
     volatile tt_l1_ptr uint32_t* fused_op_receiver_signal_semaphore_addr_ptr_next_core_right =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(fused_op_receiver_signal_semaphore_addr[next_core_id_to_right]);
 
@@ -63,17 +75,21 @@ void kernel_main() {
         noc_semaphore_set(fused_op_receiver_signal_semaphore_addr_ptr_next_core_right, 0);
     }
 
-    size_t l1_read_addr = get_read_ptr(inter_cb_index);
+    size_t l1_read_addr = cb_inter.get_read_ptr();
     const uint64_t multicast_addr_noc = get_noc_multicast_addr(bbox_start_x, bbox_start_y, bbox_end_x, bbox_end_y, 0);
     uint64_t aggregated_tensor_addr_this_core =
         (uint64_t)aggregated_tensor_addr + mm_core_offset * intermediate_tensor_shard_num_pages * tensor0_page_size;
     const uint64_t multicast_addr = multicast_addr_noc | aggregated_tensor_addr_this_core;
 
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
+    // (noc_async_write_multicast_loopback_src has no Device 2.0 wrapper equivalent.)
     noc_async_write_multicast_loopback_src(
         l1_read_addr, multicast_addr, intermediate_tensor_shard_num_pages * tensor0_page_size, bbox_size, true);
 
     uint64_t multicast_sema_addr = multicast_addr_noc | (uint64_t)fused_op_receiver_signal_semaphore_addr[core_id];
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
+    // (noc_semaphore_set_multicast_loopback_src has no Device 2.0 wrapper equivalent.)
     noc_semaphore_set_multicast_loopback_src(
         fused_op_receiver_signal_semaphore_addr[core_id], multicast_sema_addr, bbox_size, false);
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/worker_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/worker_writer.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 #include <tt-metalium/buffer_types.hpp>
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
@@ -12,6 +14,7 @@
 
 using address_t = uint32_t;
 FORCE_INLINE void advance_local_read_address_for_fabric_write(
+    Noc& noc,
     uint64_t noc0_dest_noc_addr,
     volatile PACKET_HEADER_TYPE* pkt_hdr_forward,
     volatile PACKET_HEADER_TYPE* pkt_hdr_backward,
@@ -44,7 +47,7 @@ FORCE_INLINE void advance_local_read_address_for_fabric_write(
             (uint32_t)pkt_hdr_backward, sizeof(PACKET_HEADER_TYPE));
     }
 
-    noc_async_writes_flushed();
+    noc.async_writes_flushed();
 
     l1_read_addr += payload_size_bytes;
 }
@@ -96,16 +99,20 @@ void kernel_main() {
         FabricConnectionManager::build_from_args<FabricConnectionManager::BUILD_AND_OPEN_CONNECTION_START_ONLY>(
             arg_idx);
 
+    Noc noc_obj;
+    CircularBuffer cb_pkt_hdr(reserved_packet_header_cb_id);
+    CircularBuffer cb0(cb0_id);
+
     // packet header cb
-    cb_reserve_back(reserved_packet_header_cb_id, 1);
-    auto packet_header_buffer_addr_forward = get_write_ptr(reserved_packet_header_cb_id);
-    cb_push_back(reserved_packet_header_cb_id, 1);
-    cb_reserve_back(reserved_packet_header_cb_id, 1);
-    auto packet_header_buffer_addr_backward = get_write_ptr(reserved_packet_header_cb_id);
-    cb_push_back(reserved_packet_header_cb_id, 1);
-    cb_reserve_back(reserved_packet_header_cb_id, 1);
-    auto packet_header_buffer_seminc = get_write_ptr(reserved_packet_header_cb_id);
-    cb_push_back(reserved_packet_header_cb_id, 1);
+    cb_pkt_hdr.reserve_back(1);
+    auto packet_header_buffer_addr_forward = cb_pkt_hdr.get_write_ptr();
+    cb_pkt_hdr.push_back(1);
+    cb_pkt_hdr.reserve_back(1);
+    auto packet_header_buffer_addr_backward = cb_pkt_hdr.get_write_ptr();
+    cb_pkt_hdr.push_back(1);
+    cb_pkt_hdr.reserve_back(1);
+    auto packet_header_buffer_seminc = cb_pkt_hdr.get_write_ptr();
+    cb_pkt_hdr.push_back(1);
 
     // pre-populate packet headers
     volatile PACKET_HEADER_TYPE* pkt_hdr_forward =
@@ -126,15 +133,17 @@ void kernel_main() {
     while (tiles_read < num_tiles_to_read) {
         uint32_t num_tiles_to_read_this_core = std::min(num_tiles_per_core - shard_tile_id, packet_size_in_pages);
         num_tiles_to_read_this_core = std::min(num_tiles_to_read - tiles_read, num_tiles_to_read_this_core);
-        cb_wait_front(cb0_id, num_tiles_to_read_this_core);
-        size_t l1_read_addr = get_read_ptr(cb0_id);
+        cb0.wait_front(num_tiles_to_read_this_core);
+        size_t l1_read_addr = cb0.get_read_ptr();
 
+        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
         uint64_t noc0_dest_noc_addr =
             get_noc_addr(core_noc_x[core_id], core_noc_y[core_id], tensor_address0, 0 /*noc_id*/);
         noc0_dest_noc_addr += shard_tile_id * tensor0_page_size;
 
         // This issues a flush barrier
         advance_local_read_address_for_fabric_write(
+            noc_obj,
             noc0_dest_noc_addr,
             pkt_hdr_forward,
             pkt_hdr_backward,
@@ -147,7 +156,7 @@ void kernel_main() {
             std::swap(pkt_hdr_forward, pkt_hdr_backward);
         }
 
-        cb_pop_front(cb0_id, num_tiles_to_read_this_core);
+        cb0.pop_front(num_tiles_to_read_this_core);
         tiles_read += num_tiles_to_read_this_core;
         shard_tile_id += num_tiles_to_read_this_core;
         if (shard_tile_id >= num_tiles_per_core) {
@@ -181,5 +190,5 @@ void kernel_main() {
     }
 
     fabric_connection.close();
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/worker_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/worker_writer.cpp
@@ -136,7 +136,6 @@ void kernel_main() {
         cb0.wait_front(num_tiles_to_read_this_core);
         size_t l1_read_addr = cb0.get_read_ptr();
 
-        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
         uint64_t noc0_dest_noc_addr =
             get_noc_addr(core_noc_x[core_id], core_noc_y[core_id], tensor_address0, 0 /*noc_id*/);
         noc0_dest_noc_addr += shard_tile_id * tensor0_page_size;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/kernels/compute/reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/kernels/compute/reduction.cpp
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include "api/compute/eltwise_binary.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
     // Define all compile-time arguments at the beginning
@@ -17,15 +18,18 @@ void kernel_main() {
     constexpr uint32_t total_pages = num_devices * num_pages_per_packet;
     constexpr uint32_t num_device_pairs = num_devices / 2;  // num_devices is always even
 
+    CircularBuffer cb_fabric_receiver(fabric_receiver_cb_id);
+    CircularBuffer cb_accumulator(accumulator_cb_id);
+
     // Initialize binary operations - use the same constants consistently
     binary_op_init_common(fabric_receiver_cb_id, fabric_receiver_cb_id, accumulator_cb_id);
     add_tiles_init(fabric_receiver_cb_id, fabric_receiver_cb_id, true);
 
     // Wait for input data once before beginning processing
-    cb_wait_front(fabric_receiver_cb_id, total_pages);
+    cb_fabric_receiver.wait_front(total_pages);
 
     // Reserve output space once before processing
-    cb_reserve_back(accumulator_cb_id, num_pages_per_packet);
+    cb_accumulator.reserve_back(num_pages_per_packet);
 
     // Process tiles in pairs for efficient addition
     tile_regs_acquire();
@@ -54,6 +58,6 @@ void kernel_main() {
     }
     tile_regs_release();
 
-    cb_pop_front(fabric_receiver_cb_id, total_pages);
-    cb_push_back(accumulator_cb_id, num_pages_per_packet);
+    cb_fabric_receiver.pop_front(total_pages);
+    cb_accumulator.push_back(num_pages_per_packet);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/kernels/dataflow/reader_llama_reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/kernels/dataflow/reader_llama_reduce_scatter.cpp
@@ -67,7 +67,6 @@ void kernel_main() {
     constexpr uint32_t total_senders = num_sender_cores * other_devices;
 
     // Runtime arguments
-    // Device 2.0 migration: legacy primitive retained: receiver_semaphore_address is a GlobalSemaphore address.
     uint32_t receiver_semaphore_address = get_arg_val<uint32_t>(rt_arg_idx++);
     Semaphore<> local_sem(get_arg_val<uint32_t>(rt_arg_idx++));
     bool sender_core = (bool)get_arg_val<uint32_t>(rt_arg_idx++);
@@ -119,7 +118,6 @@ void kernel_main() {
                 const uint32_t transfer_size = read_size * page_size_bytes;
 
                 cb_fabric_sender.reserve_back(num_pages_reserve_push);
-                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
                 noc_async_read(shard_noc_addr, sender_read_addr, transfer_size);
 
                 if (num_pages_reserve_push >= curr_packet_num_pages) {
@@ -154,11 +152,9 @@ void kernel_main() {
             const uint64_t output_noc_address = get_noc_addr(core_x, core_y, base_input_tensor_addr + tile_offset);
             const uint32_t receiver_l1_address = base_receiver_l1_addresses + i * page_size_bytes;
 
-            // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
             noc_async_read(output_noc_address, receiver_l1_address, page_size_bytes);
         }
 
-        // Device 2.0 migration: legacy primitive retained: receiver_semaphore_address is a GlobalSemaphore address.
         noc_semaphore_wait((uint32_t*)receiver_semaphore_address, other_devices);
 
         noc_obj.async_read_barrier();
@@ -212,6 +208,5 @@ void kernel_main() {
         noc_obj.async_write_barrier();
     }
     local_sem.set(INVALID);
-    // Device 2.0 migration: legacy primitive retained: receiver_semaphore_address is a GlobalSemaphore address.
     noc_semaphore_set((uint32_t*)receiver_semaphore_address, INVALID);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/kernels/dataflow/reader_llama_reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/kernels/dataflow/reader_llama_reduce_scatter.cpp
@@ -4,6 +4,11 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 #include "ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp"
 #include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 
@@ -62,8 +67,9 @@ void kernel_main() {
     constexpr uint32_t total_senders = num_sender_cores * other_devices;
 
     // Runtime arguments
+    // Device 2.0 migration: legacy primitive retained: receiver_semaphore_address is a GlobalSemaphore address.
     uint32_t receiver_semaphore_address = get_arg_val<uint32_t>(rt_arg_idx++);
-    uint32_t local_semaphore_address = get_semaphore(get_arg_val<uint32_t>(rt_arg_idx++));
+    Semaphore<> local_sem(get_arg_val<uint32_t>(rt_arg_idx++));
     bool sender_core = (bool)get_arg_val<uint32_t>(rt_arg_idx++);
     bool worker_core = (bool)get_arg_val<uint32_t>(rt_arg_idx++);
     uint32_t linear_output_page_start_idx = get_arg_val<uint32_t>(rt_arg_idx++);
@@ -76,10 +82,16 @@ void kernel_main() {
     uint32_t k_base_addr = get_arg_val<uint32_t>(rt_arg_idx++);
     uint32_t v_base_addr = get_arg_val<uint32_t>(rt_arg_idx++);
 
-    // Bank base addresses (compute once)
-    const uint32_t bank_base_address = get_write_ptr(input_tensor_cb_id);
+    Noc noc_obj;
+    CircularBuffer cb_input_tensor(input_tensor_cb_id);
+    CircularBuffer cb_fabric_sender(fabric_sender_cb_id);
+    CircularBuffer cb_fabric_receiver(fabric_receiver_cb_id);
+    CircularBuffer cb_accumulator(accumulator_cb_id);
 
-    uint32_t sender_read_addr = get_write_ptr(fabric_sender_cb_id);
+    // Bank base addresses (compute once)
+    const uint32_t bank_base_address = cb_input_tensor.get_write_ptr();
+
+    uint32_t sender_read_addr = cb_fabric_sender.get_write_ptr();
 
     if (sender_core) {
         for (uint32_t target_device_id : device_order) {
@@ -106,12 +118,13 @@ void kernel_main() {
                 const uint64_t shard_noc_addr = get_noc_addr(x, y, offset_address);
                 const uint32_t transfer_size = read_size * page_size_bytes;
 
-                cb_reserve_back(fabric_sender_cb_id, num_pages_reserve_push);
+                cb_fabric_sender.reserve_back(num_pages_reserve_push);
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
                 noc_async_read(shard_noc_addr, sender_read_addr, transfer_size);
 
                 if (num_pages_reserve_push >= curr_packet_num_pages) {
-                    noc_async_read_barrier();
-                    cb_push_back(fabric_sender_cb_id, num_pages_reserve_push);
+                    noc_obj.async_read_barrier();
+                    cb_fabric_sender.push_back(num_pages_reserve_push);
                     num_pages_reserve_push = 0;
                 }
 
@@ -122,8 +135,8 @@ void kernel_main() {
         }
     } else if (worker_core) {
         // Calculate base addresses once
-        const uint32_t base_input_tensor_addr = get_read_ptr(input_tensor_cb_id);
-        const uint32_t base_receiver_l1_addresses = get_read_ptr(fabric_receiver_cb_id) + chip_id_offset;
+        const uint32_t base_input_tensor_addr = cb_input_tensor.get_read_ptr();
+        const uint32_t base_receiver_l1_addresses = cb_fabric_receiver.get_read_ptr() + chip_id_offset;
 
         for (uint32_t i = 0; i < num_pages_per_packet; i++) {
             const uint32_t rem = linear_input_packet_start_idx + i;
@@ -141,52 +154,64 @@ void kernel_main() {
             const uint64_t output_noc_address = get_noc_addr(core_x, core_y, base_input_tensor_addr + tile_offset);
             const uint32_t receiver_l1_address = base_receiver_l1_addresses + i * page_size_bytes;
 
+            // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
             noc_async_read(output_noc_address, receiver_l1_address, page_size_bytes);
         }
 
+        // Device 2.0 migration: legacy primitive retained: receiver_semaphore_address is a GlobalSemaphore address.
         noc_semaphore_wait((uint32_t*)receiver_semaphore_address, other_devices);
 
-        noc_async_read_barrier();
-        cb_push_back(fabric_receiver_cb_id, num_pages_per_packet * num_devices);
+        noc_obj.async_read_barrier();
+        cb_fabric_receiver.push_back(num_pages_per_packet * num_devices);
 
         uint32_t head_idx = linear_output_page_start_idx / 2;  // each head has 2 pages/blocks
-        cb_wait_front(accumulator_cb_id, num_pages_per_packet);
-        auto accumulator_l1_addr = get_read_ptr(accumulator_cb_id);
+        cb_accumulator.wait_front(num_pages_per_packet);
+        auto accumulator_l1_addr = cb_accumulator.get_read_ptr();
         if (head_idx < q_heads) {  // write q heads
             for (uint32_t iblock = 1; iblock < num_pages_per_packet;
                  iblock += 2) {  // increment by 2 so that we can handle 1 head each time.
                 for (uint32_t istick = 0; istick < num_sticks_per_block; istick++) {
-                    uint64_t noc_address = get_noc_addr(
-                        q_output_core_xy[istick][x_index],
-                        q_output_core_xy[istick][y_index],
-                        q_base_addr + head_idx * head_dim_bytes + stick_size_byte);
                     uint32_t l1_read_addr = accumulator_l1_addr + iblock * page_size_bytes + istick * stick_size_byte;
-                    noc_async_write(l1_read_addr, noc_address, stick_size_byte);
+                    noc_obj.async_write(
+                        CoreLocalMem<uint8_t>(l1_read_addr),
+                        UnicastEndpoint{},
+                        stick_size_byte,
+                        {},
+                        {.noc_x = q_output_core_xy[istick][x_index],
+                         .noc_y = q_output_core_xy[istick][y_index],
+                         .addr = q_base_addr + head_idx * head_dim_bytes + stick_size_byte});
                 }
                 head_idx++;  // next head as each packet has 2 heads = 4 blocks
             }
         } else {  // write kv heads
             uint32_t iblock1 = 1, iblock2 = 3;
             for (uint32_t istick = 0; istick < num_sticks_per_block; istick++) {
-                uint64_t noc_address = get_noc_addr(
-                    k_output_core_xy[istick][x_index],
-                    k_output_core_xy[istick][y_index],
-                    k_base_addr + stick_size_byte);
                 uint32_t l1_read_addr = accumulator_l1_addr + iblock1 * page_size_bytes + istick * stick_size_byte;
-                noc_async_write(l1_read_addr, noc_address, stick_size_byte);
+                noc_obj.async_write(
+                    CoreLocalMem<uint8_t>(l1_read_addr),
+                    UnicastEndpoint{},
+                    stick_size_byte,
+                    {},
+                    {.noc_x = k_output_core_xy[istick][x_index],
+                     .noc_y = k_output_core_xy[istick][y_index],
+                     .addr = k_base_addr + stick_size_byte});
             }
 
             for (uint32_t istick = 0; istick < num_sticks_per_block; istick++) {
-                uint64_t noc_address = get_noc_addr(
-                    v_output_core_xy[istick][x_index],
-                    v_output_core_xy[istick][y_index],
-                    v_base_addr + stick_size_byte);
                 uint32_t l1_read_addr = accumulator_l1_addr + iblock2 * page_size_bytes + istick * stick_size_byte;
-                noc_async_write(l1_read_addr, noc_address, stick_size_byte);
+                noc_obj.async_write(
+                    CoreLocalMem<uint8_t>(l1_read_addr),
+                    UnicastEndpoint{},
+                    stick_size_byte,
+                    {},
+                    {.noc_x = v_output_core_xy[istick][x_index],
+                     .noc_y = v_output_core_xy[istick][y_index],
+                     .addr = v_base_addr + stick_size_byte});
             }
         }
-        noc_async_write_barrier();
+        noc_obj.async_write_barrier();
     }
-    noc_semaphore_set((uint32_t*)local_semaphore_address, INVALID);
+    local_sem.set(INVALID);
+    // Device 2.0 migration: legacy primitive retained: receiver_semaphore_address is a GlobalSemaphore address.
     noc_semaphore_set((uint32_t*)receiver_semaphore_address, INVALID);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/kernels/dataflow/writer_llama_reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/kernels/dataflow/writer_llama_reduce_scatter.cpp
@@ -64,7 +64,6 @@ void kernel_main() {
     constexpr uint32_t other_devices = num_devices - 1;
 
     // Runtime arguments
-    // Device 2.0 migration: legacy primitive retained: receiver_semaphore_address is a GlobalSemaphore address.
     uint32_t receiver_semaphore_address = get_arg_val<uint32_t>(rt_arg_idx++);
     Semaphore<> local_sem(get_arg_val<uint32_t>(rt_arg_idx++));
     bool sender_core = (bool)get_arg_val<uint32_t>(rt_arg_idx++);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/kernels/dataflow/writer_llama_reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/kernels/dataflow/writer_llama_reduce_scatter.cpp
@@ -4,6 +4,11 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
@@ -59,8 +64,9 @@ void kernel_main() {
     constexpr uint32_t other_devices = num_devices - 1;
 
     // Runtime arguments
+    // Device 2.0 migration: legacy primitive retained: receiver_semaphore_address is a GlobalSemaphore address.
     uint32_t receiver_semaphore_address = get_arg_val<uint32_t>(rt_arg_idx++);
-    uint32_t local_semaphore_address = get_semaphore(get_arg_val<uint32_t>(rt_arg_idx++));
+    Semaphore<> local_sem(get_arg_val<uint32_t>(rt_arg_idx++));
     bool sender_core = (bool)get_arg_val<uint32_t>(rt_arg_idx++);
     bool worker_core = (bool)get_arg_val<uint32_t>(rt_arg_idx++);
     uint32_t linear_output_page_start_idx = get_arg_val<uint32_t>(rt_arg_idx++);
@@ -71,6 +77,12 @@ void kernel_main() {
     uint32_t k_base_addr = get_arg_val<uint32_t>(rt_arg_idx++);
     uint32_t v_base_addr = get_arg_val<uint32_t>(rt_arg_idx++);
 
+    Noc noc_obj;
+    CircularBuffer cb_fabric_sender(fabric_sender_cb_id);
+    CircularBuffer cb_packet_header(packet_header_cb_id);
+    CircularBuffer cb_fabric_receiver(fabric_receiver_cb_id);
+    CircularBuffer cb_accumulator(accumulator_cb_id);
+
     if (sender_core) {
         auto fabric_connection =
             FabricConnectionManager::build_from_args<FabricConnectionManager::BUILD_AND_OPEN_CONNECTION_START_ONLY>(
@@ -79,8 +91,8 @@ void kernel_main() {
         constexpr uint8_t device_order[other_devices] =
             DEVICE_ORDER;  // this is code gen'd in the program factory using the defines
         constexpr uint8_t packet_worker_cores[num_packet_worker_cores][2] = PACKET_WORKER_CORES;
-        cb_reserve_back(packet_header_cb_id, buffering_factor * num_packet_headers_storable);
-        const auto packet_header_buffer_addr = get_read_ptr(packet_header_cb_id);
+        cb_packet_header.reserve_back(buffering_factor * num_packet_headers_storable);
+        const auto packet_header_buffer_addr = cb_packet_header.get_read_ptr();
         auto* unicast_packet_header = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr);
         auto* sem_inc_packet_header =
             reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr + packet_header_size);
@@ -89,7 +101,7 @@ void kernel_main() {
         sem_inc_packet_header->to_noc_unicast_atomic_inc(
             tt::tt_fabric::NocUnicastAtomicIncCommandHeader{sem_noc_addr, static_cast<uint32_t>(1)});  // increment 1
 
-        const uint32_t base_receiver_l1_addr = get_read_ptr(fabric_receiver_cb_id);
+        const uint32_t base_receiver_l1_addr = cb_fabric_receiver.get_read_ptr();
 
         // Precompute the packet offset once
         const uint32_t packet_offset = base_receiver_l1_addr + chip_id_offset;
@@ -129,8 +141,8 @@ void kernel_main() {
                 const uint32_t receiver_core_y = packet_worker_cores[packet][y_index];
                 const uint64_t noc0_dest_noc_addr = get_noc_addr(receiver_core_x, receiver_core_y, packet_offset, 0);
 
-                cb_wait_front(fabric_sender_cb_id, curr_packet_num_pages);
-                const auto sender_l1_addr = get_read_ptr(fabric_sender_cb_id);
+                cb_fabric_sender.wait_front(curr_packet_num_pages);
+                const auto sender_l1_addr = cb_fabric_sender.get_read_ptr();
 
                 const uint64_t sem_noc_addr =
                     get_noc_addr(receiver_core_x, receiver_core_y, receiver_semaphore_address, 0);
@@ -146,7 +158,7 @@ void kernel_main() {
                 fabric_conn.send_payload_flush_blocking_from_address(
                     (uint32_t)unicast_packet_header, packet_header_size);
 
-                cb_pop_front(fabric_sender_cb_id, curr_packet_num_pages);
+                cb_fabric_sender.pop_front(curr_packet_num_pages);
 
                 num_pages_sent += curr_packet_num_pages;
                 packet++;
@@ -162,38 +174,51 @@ void kernel_main() {
         constexpr uint8_t v_output_core_xy[output_cores_per_device][2] = V_OUTPUT_CORE_XY;
 
         uint32_t head_idx = linear_output_page_start_idx / 2;  // each head has 2 pages/blocks
-        cb_wait_front(accumulator_cb_id, num_pages_per_packet);
+        cb_accumulator.wait_front(num_pages_per_packet);
 
-        auto accumulator_l1_addr = get_read_ptr(accumulator_cb_id);
+        auto accumulator_l1_addr = cb_accumulator.get_read_ptr();
         if (head_idx < q_heads) {  // write q heads
             for (uint32_t iblock = 0; iblock < num_pages_per_packet;
                  iblock += 2) {  // increment by 2 so that we can handle 1 head each time.
                 for (uint32_t istick = 0; istick < num_sticks_per_block; istick++) {
-                    uint64_t noc_address = get_noc_addr(
-                        q_output_core_xy[istick][x_index],
-                        q_output_core_xy[istick][y_index],
-                        q_base_addr + head_idx * head_dim_bytes);
                     uint32_t l1_read_addr = accumulator_l1_addr + iblock * page_size_bytes + istick * stick_size_byte;
-                    noc_async_write(l1_read_addr, noc_address, stick_size_byte);
+                    noc_obj.async_write(
+                        CoreLocalMem<uint8_t>(l1_read_addr),
+                        UnicastEndpoint{},
+                        stick_size_byte,
+                        {},
+                        {.noc_x = q_output_core_xy[istick][x_index],
+                         .noc_y = q_output_core_xy[istick][y_index],
+                         .addr = q_base_addr + head_idx * head_dim_bytes});
                 }
                 head_idx++;  // next head as each packet has 2 heads = 4 blocks
             }
         } else {  // write kv heads
             uint32_t iblock1 = 0, iblock2 = 2;
             for (uint32_t istick = 0; istick < num_sticks_per_block; istick++) {
-                uint64_t noc_address =
-                    get_noc_addr(k_output_core_xy[istick][x_index], k_output_core_xy[istick][y_index], k_base_addr);
                 uint32_t l1_read_addr = accumulator_l1_addr + iblock1 * page_size_bytes + istick * stick_size_byte;
-                noc_async_write(l1_read_addr, noc_address, stick_size_byte);
+                noc_obj.async_write(
+                    CoreLocalMem<uint8_t>(l1_read_addr),
+                    UnicastEndpoint{},
+                    stick_size_byte,
+                    {},
+                    {.noc_x = k_output_core_xy[istick][x_index],
+                     .noc_y = k_output_core_xy[istick][y_index],
+                     .addr = k_base_addr});
             }
 
             for (uint32_t istick = 0; istick < num_sticks_per_block; istick++) {
-                uint64_t noc_address =
-                    get_noc_addr(v_output_core_xy[istick][x_index], v_output_core_xy[istick][y_index], v_base_addr);
                 uint32_t l1_read_addr = accumulator_l1_addr + iblock2 * page_size_bytes + istick * stick_size_byte;
-                noc_async_write(l1_read_addr, noc_address, stick_size_byte);
+                noc_obj.async_write(
+                    CoreLocalMem<uint8_t>(l1_read_addr),
+                    UnicastEndpoint{},
+                    stick_size_byte,
+                    {},
+                    {.noc_x = v_output_core_xy[istick][x_index],
+                     .noc_y = v_output_core_xy[istick][y_index],
+                     .addr = v_base_addr});
             }
         }
-        noc_async_write_barrier();
+        noc_obj.async_write_barrier();
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/compute/rms_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/compute/rms_compute.cpp
@@ -10,6 +10,7 @@
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/layernorm.h"
 #include "api/compute/tile_move_copy.h"
+#include "api/dataflow/circular_buffer.h"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 
 // SPLIT REDUCE across Cores
@@ -66,6 +67,20 @@ void kernel_main() {
 
     constexpr uint32_t cb_x2 = cb_x;  // x^2
 
+    CircularBuffer cb_in_obj(cb_in);
+    CircularBuffer cb_x2_obj(cb_x2);
+    CircularBuffer cb_scaler_obj(cb_scaler);
+    CircularBuffer cb_ex_partial2_obj(cb_ex_partial2);
+    CircularBuffer cb_signaling(signaling_cb);
+    CircularBuffer cb_stats_obj(cb_stats);
+    CircularBuffer cb_var_obj(cb_var);
+    CircularBuffer cb_eps_obj(cb_eps);
+    CircularBuffer cb_stats_reduced_obj(cb_stats_reduced);
+    CircularBuffer cb_im_obj(cb_im);
+    CircularBuffer cb_ex_global_obj(cb_ex_global);
+    CircularBuffer cb_xmm_obj(cb_xmm);
+    CircularBuffer cb_gamma_obj(cb_gamma);
+
     const uint32_t subblock_w = (block_w <= 2) ? subblock_w_volatile : subblock_w_const;
 
     int index_subblock_w_offset = 0;
@@ -79,7 +94,7 @@ void kernel_main() {
     pack_reconfig_data_format(cb_in);
     reconfig_data_format(cb_in0, cb_in1);
     add_tiles_init(cb_in0, cb_in1);
-    cb_reserve_back(cb_in, num_tiles_per_block);
+    cb_in_obj.reserve_back(num_tiles_per_block);
     index_subblock_w_offset = 0;
     for (uint32_t j = 0; j < num_subblocks_w; j++) {
         tile_regs_acquire();
@@ -96,8 +111,8 @@ void kernel_main() {
         index_subblock_w_offset += subblock_w;
     }
     index_h_offset += block_w;
-    cb_push_back(cb_in, num_tiles_per_block);
-    cb_wait_front(cb_in, num_tiles_per_block);
+    cb_in_obj.push_back(num_tiles_per_block);
+    cb_in_obj.wait_front(num_tiles_per_block);
     pack_reconfig_data_format(cb_in, cb_x2);
     reconfig_data_format(cb_in0, cb_in, cb_in1, cb_in);
 #else
@@ -107,7 +122,7 @@ void kernel_main() {
     // X^2
     mul_tiles_init(cb_in, cb_in);
     index_h_offset = 0;
-    cb_reserve_back(cb_x2, num_tiles_per_block);
+    cb_x2_obj.reserve_back(num_tiles_per_block);
     index_subblock_w_offset = 0;
     for (uint32_t j = 0; j < num_subblocks_w; j++) {
         tile_regs_acquire();
@@ -124,15 +139,15 @@ void kernel_main() {
         index_subblock_w_offset += subblock_w;
     }
     index_h_offset += block_w;
-    cb_push_back(cb_x2, num_tiles_per_block);
+    cb_x2_obj.push_back(num_tiles_per_block);
 
     // E(x^2)
     reconfig_data_format(cb_scaler, cb_x2);
 
-    cb_wait_front(cb_x2, num_tiles_per_block);
-    cb_wait_front(cb_scaler, 1);
+    cb_x2_obj.wait_front(num_tiles_per_block);
+    cb_scaler_obj.wait_front(1);
 
-    cb_reserve_back(cb_ex_partial2, 1);  // RMS E(x2) #Layernorm //E(x) and E(x^2)
+    cb_ex_partial2_obj.reserve_back(1);  // RMS E(x2) #Layernorm //E(x) and E(x^2)
 
     reduce_init<PoolType::AVG, ReduceDim::REDUCE_ROW>(cb_x2, cb_scaler, cb_ex_partial2);
     index_h_offset = 0;
@@ -149,8 +164,8 @@ void kernel_main() {
     tile_regs_release();
     index_h_offset += block_w;
     reduce_uninit();
-    cb_pop_front(cb_x2, num_tiles_per_block);
-    cb_push_back(cb_ex_partial2, 1);
+    cb_x2_obj.pop_front(num_tiles_per_block);
+    cb_ex_partial2_obj.push_back(1);
 
     // global reduce, cb_ex <-- cb_ex_external2, cb_ex_partial2
     if constexpr (is_allgather_worker) {
@@ -184,8 +199,8 @@ void kernel_main() {
     }
 
     // Waits for stats tensor to have valid data
-    cb_wait_front(signaling_cb, 1);
-    cb_pop_front(signaling_cb, 1);
+    cb_signaling.wait_front(1);
+    cb_signaling.pop_front(1);
     constexpr uint32_t post_dst0 = 0;
     constexpr uint32_t post_scaler0 = 0;
     binary_op_init_common(cb_stats, post_cb_scaler_global, cb_var);
@@ -194,6 +209,7 @@ void kernel_main() {
     index = 0;
 
     constexpr uint32_t cb_outgamma = cb_out;
+    CircularBuffer cb_outgamma_obj(cb_outgamma);
     if constexpr (is_allgather_worker) {
         const bool enable_sqrt = get_arg_val<uint32_t>(4) == 1;
         if (enable_sqrt) {
@@ -208,13 +224,13 @@ void kernel_main() {
                 compute_kernel_lib::ReduceInputPolicy::NoWaitNoPop,
                 compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT>(
                 compute_kernel_lib::ReduceInputBlockShape::row(num_distributed_blocks));
-            cb_pop_front(cb_stats, num_distributed_blocks);
+            cb_stats_obj.pop_front(num_distributed_blocks);
 
             // 1/[sqrt(Var + eps)],
             reconfig_data_format(cb_var, cb_eps);  // cb_var is cb_stats in case of RMS norm
             pack_reconfig_data_format(cb_stats_reduced);
-            cb_wait_front(cb_var, 1);
-            cb_wait_front(cb_eps, 1);
+            cb_var_obj.wait_front(1);
+            cb_eps_obj.wait_front(1);
 
             add_tiles_init(cb_var, cb_eps);
             tile_regs_acquire();
@@ -224,12 +240,12 @@ void kernel_main() {
             rsqrt_tile<true>(post_dst0);
             tile_regs_commit();
             tile_regs_wait();
-            cb_reserve_back(cb_stats_reduced, 1);
+            cb_stats_reduced_obj.reserve_back(1);
             pack_tile(post_dst0, cb_stats_reduced);
             tile_regs_release();
-            cb_pop_front(cb_var, 1);
-            cb_pop_front(cb_eps, 1);
-            cb_push_back(cb_stats_reduced, 1);
+            cb_var_obj.pop_front(1);
+            cb_eps_obj.pop_front(1);
+            cb_stats_reduced_obj.push_back(1);
         }
     }
     pack_reconfig_data_format(cb_im);
@@ -237,9 +253,9 @@ void kernel_main() {
     reconfig_data_format(cb_xmm, cb_ex_global);
     mul_bcast_cols_init_short(cb_xmm, cb_ex_global);
     index_h_offset = 0;
-    cb_reserve_back(cb_im, num_tiles_per_block);
+    cb_im_obj.reserve_back(num_tiles_per_block);
     index_subblock_w_offset = 0;
-    cb_wait_front(cb_ex_global, 1);
+    cb_ex_global_obj.wait_front(1);
     for (uint32_t j = 0; j < num_subblocks_w; j++) {
         tile_regs_acquire();
         for (uint32_t w = 0; w < subblock_w; w++) {
@@ -257,18 +273,18 @@ void kernel_main() {
         index_subblock_w_offset += subblock_w;
     }
     index_h_offset += block_w;
-    cb_pop_front(cb_ex_global, 1);
-    cb_push_back(cb_im, num_tiles_per_block);
+    cb_ex_global_obj.pop_front(1);
+    cb_im_obj.push_back(num_tiles_per_block);
 
-    cb_pop_front(cb_xmm, num_tiles_per_block);
-    cb_wait_front(cb_im, num_tiles_per_block);
+    cb_xmm_obj.pop_front(num_tiles_per_block);
+    cb_im_obj.wait_front(num_tiles_per_block);
 
     reconfig_data_format(cb_im, cb_gamma);
     pack_reconfig_data_format(cb_out);
     mul_bcast_rows_init_short(cb_im, cb_gamma);
-    cb_wait_front(cb_gamma, block_w);
+    cb_gamma_obj.wait_front(block_w);
     index_h_offset = 0;
-    cb_reserve_back(cb_outgamma, num_tiles_per_block);
+    cb_outgamma_obj.reserve_back(num_tiles_per_block);
     index_subblock_w_offset = 0;
     for (uint32_t j = 0; j < num_subblocks_w; j++) {
         tile_regs_acquire();
@@ -283,8 +299,8 @@ void kernel_main() {
         }
         tile_regs_release();
         index_subblock_w_offset += subblock_w;
-        cb_push_back(cb_outgamma, subblock_w);
+        cb_outgamma_obj.push_back(subblock_w);
     }
     index_h_offset += block_w;
-    cb_pop_front(cb_im, num_tiles_per_block);
+    cb_im_obj.pop_front(num_tiles_per_block);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/reshard_writer.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/reshard_writer.hpp
@@ -6,6 +6,10 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 
 template <
     uint32_t cb_out,
@@ -13,13 +17,18 @@ template <
     uint32_t worker_core_stride_w_bytes,
     uint32_t storage_core_stride_w_bytes>
 inline void write_minimal_resharded_data(
-    uint32_t num_segments_to_write_back, uint32_t storage_core_start_offset, tt_l1_ptr uint32_t* segment_args) {
+    Noc& noc,
+    uint32_t num_segments_to_write_back,
+    uint32_t storage_core_start_offset,
+    tt_l1_ptr uint32_t* segment_args) {
+    CircularBuffer cb_out_obj(cb_out);
+    CircularBuffer cb_out_resharded_obj(cb_out_resharded);
     const uint32_t out_single_tile_size_bytes = get_tile_size(cb_out);
     uint32_t args_idx = 0;
     uint32_t worker_core_read_offset = 0;
 
-    uint32_t cb_out_read_base_addr = get_read_ptr(cb_out);
-    uint32_t cb_out_reshard_write_base_addr = get_write_ptr(cb_out_resharded);
+    uint32_t cb_out_read_base_addr = cb_out_obj.get_read_ptr();
+    uint32_t cb_out_reshard_write_base_addr = cb_out_resharded_obj.get_write_ptr();
 
     for (uint32_t i = 0; i < num_segments_to_write_back; ++i) {
         uint32_t write_size = segment_args[args_idx++];
@@ -35,19 +44,21 @@ inline void write_minimal_resharded_data(
             local_storage_core_write_addr += storage_core_start_offset;
         }
 
-        uint64_t remote_storage_core_write_addr =
-            get_noc_addr(storage_core_x, storage_core_y, local_storage_core_write_addr);
-
         for (uint32_t w = 0; w < num_tiles_to_write_in_current_segment; ++w) {
-            cb_wait_front(cb_out, 1);
-            noc_async_write(worker_core_read_addr, remote_storage_core_write_addr, out_single_tile_size_bytes);
+            cb_out_obj.wait_front(1);
+            noc.async_write(
+                CoreLocalMem<uint8_t>(worker_core_read_addr),
+                UnicastEndpoint{},
+                out_single_tile_size_bytes,
+                {},
+                {.noc_x = storage_core_x, .noc_y = storage_core_y, .addr = local_storage_core_write_addr});
             worker_core_read_addr += out_single_tile_size_bytes;
-            remote_storage_core_write_addr += out_single_tile_size_bytes;
-            cb_pop_front(cb_out, 1);
+            local_storage_core_write_addr += out_single_tile_size_bytes;
+            cb_out_obj.pop_front(1);
         }
         worker_core_read_addr += worker_core_stride_w_bytes;
-        remote_storage_core_write_addr += storage_core_stride_w_bytes;
+        local_storage_core_write_addr += storage_core_stride_w_bytes;
         worker_core_read_offset += write_size * out_single_tile_size_bytes;
     }
-    noc_async_write_barrier();
+    noc.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_receiver_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_receiver_reader.cpp
@@ -50,9 +50,7 @@ void kernel_main() {
 
     const DataFormat data_format = get_dataformat(cb_ex_partial2);  // data format
 
-    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
     uint64_t remote_noc_addrs_first_stage[is_all_to_all_worker ? num_blocks_first_stage : 1];
-    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
     uint64_t remote_noc_addrs_second_stage[is_all_to_all_worker ? num_blocks_second_stage : 1];
     if constexpr (is_all_to_all_worker) {
         if constexpr (use_two_stage_reduce) {
@@ -113,7 +111,6 @@ void kernel_main() {
         uint32_t l1_write_addr_external = cb_ex_external2_obj.get_write_ptr();
 
         for (uint32_t block = 0; block < num_blocks_first_stage; block++) {
-            // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
             uint64_t noc_addr_ex_par =
                 remote_noc_addrs_first_stage[block] | (l1_read_addr_ex_par);  // Updating read address for reading
                                                                               // SUm(X) and Sum(X2) per core
@@ -131,7 +128,6 @@ void kernel_main() {
                 reduce_second_stage_sem.set(0);
                 // read data from other cores - second stage reduce
                 for (uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {
-                    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
                     uint64_t noc_addr_ex = remote_noc_addrs_second_stage[block + 1] | l1_read_addr_ex;
                     noc_async_read_one_packet(noc_addr_ex, l1_write_addr_external, single_tile_size_bytes);
                     l1_write_addr_external += single_tile_size_bytes;
@@ -144,7 +140,6 @@ void kernel_main() {
 
         // sync with the gather worker
         cb_ex2_obj.wait_front(1);
-        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
         const uint64_t reduce_second_stage_receiver_semaphore_noc_addr =
             remote_noc_addrs_second_stage[0] | get_semaphore(reduce_second_stage_semaphore_id);
         noc_semaphore_inc(reduce_second_stage_receiver_semaphore_noc_addr, 1);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_receiver_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_receiver_reader.cpp
@@ -4,6 +4,9 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "hostdevcommon/common_values.hpp"
 
 // split REDUCE across cores
@@ -24,10 +27,19 @@ void kernel_main() {
     constexpr uint32_t cb_ex_external2 = get_compile_time_arg_val(13);
     constexpr uint32_t post_semaphore_id = get_compile_time_arg_val(14);
     constexpr uint32_t cb_ex_global = get_compile_time_arg_val(15);  // [E[x], E[X^2]] global to all cores
-    uint32_t post_reduce_sender_semaphore_addr = get_semaphore(post_semaphore_id);
-    volatile tt_l1_ptr uint32_t* post_reduce_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(post_reduce_sender_semaphore_addr);
-    noc_semaphore_set(post_reduce_sender_semaphore_addr_ptr, INVALID);
+
+    Noc noc_obj;
+    CircularBuffer cb_ex_partial2_obj(cb_ex_partial2);
+    CircularBuffer cb_ex2_obj(cb_ex2);
+    CircularBuffer cb_ex_external2_obj(cb_ex_external2);
+    CircularBuffer cb_ex_global_obj(cb_ex_global);
+
+    Semaphore<> post_reduce_sender_sem(post_semaphore_id);
+    Semaphore<> reduce_second_stage_sem(reduce_second_stage_semaphore_id);
+    Semaphore<> reduce_receiver_sem(reduce_receiver_semaphore_id);
+    Semaphore<> reduce_sender_sem(reduce_sender_semaphore_id);
+
+    post_reduce_sender_sem.set(INVALID);
 
     const uint32_t all_to_all_tile_offset_bytes = get_arg_val<uint32_t>(0);
     const bool is_second_stage_reader = get_arg_val<uint32_t>(1);
@@ -38,11 +50,9 @@ void kernel_main() {
 
     const DataFormat data_format = get_dataformat(cb_ex_partial2);  // data format
 
-    uint32_t reduce_second_stage_semaphore_addr = get_semaphore(reduce_second_stage_semaphore_id);
-    uint32_t reduce_receiver_semaphore_addr = get_semaphore(reduce_receiver_semaphore_id);
-    uint32_t reduce_sender_semaphore_addr = get_semaphore(reduce_sender_semaphore_id);
-
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
     uint64_t remote_noc_addrs_first_stage[is_all_to_all_worker ? num_blocks_first_stage : 1];
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
     uint64_t remote_noc_addrs_second_stage[is_all_to_all_worker ? num_blocks_second_stage : 1];
     if constexpr (is_all_to_all_worker) {
         if constexpr (use_two_stage_reduce) {
@@ -79,42 +89,31 @@ void kernel_main() {
         remote_noc_addrs_second_stage[0] = get_noc_addr(in0_remote_noc_x[0], in0_remote_noc_y[0], 0);
     }
 
-    volatile tt_l1_ptr uint32_t* reduce_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_receiver_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* reduce_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_sender_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* reduce_second_stage_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_second_stage_semaphore_addr);
-
-    const uint64_t reduce_receiver_semaphore_noc_addr =
-        get_noc_addr(in0_remote_noc_x[0], in0_remote_noc_y[0], reduce_receiver_semaphore_addr);
-    const uint64_t reduce_second_stage_receiver_semaphore_noc_addr =
-        remote_noc_addrs_second_stage[0] | reduce_second_stage_semaphore_addr;
-
     // global reduce
     // wait for local data ready
-    cb_wait_front(cb_ex_partial2, 1);
+    cb_ex_partial2_obj.wait_front(1);
 
     // inc mcast sender
-    noc_semaphore_set(reduce_sender_semaphore_addr_ptr, INVALID);
-    noc_semaphore_inc(reduce_receiver_semaphore_noc_addr, 1);
-    noc_semaphore_wait(reduce_sender_semaphore_addr_ptr, VALID);
+    reduce_sender_sem.set(INVALID);
+    reduce_receiver_sem.up(noc_obj, in0_remote_noc_x[0], in0_remote_noc_y[0], 1);
+    reduce_sender_sem.wait(VALID);
 
     if constexpr (is_all_to_all_worker) {
         // read data from other cores - reduce first stage
-        uint32_t l1_read_addr_ex_par = get_read_ptr(cb_ex_partial2);
+        uint32_t l1_read_addr_ex_par = cb_ex_partial2_obj.get_read_ptr();
         l1_read_addr_ex_par += all_to_all_tile_offset_bytes;
         // read data from other cores - second stage reduce
         uint32_t l1_read_addr_ex = 0;
         uint32_t block_index_stride = 0;
         if constexpr (use_two_stage_reduce) {
-            l1_read_addr_ex = get_read_ptr(cb_ex2);
+            l1_read_addr_ex = cb_ex2_obj.get_read_ptr();
             block_index_stride = num_x;
         }
-        cb_reserve_back(cb_ex_external2, num_blocks_first_stage);
-        uint32_t l1_write_addr_external = get_write_ptr(cb_ex_external2);
+        cb_ex_external2_obj.reserve_back(num_blocks_first_stage);
+        uint32_t l1_write_addr_external = cb_ex_external2_obj.get_write_ptr();
 
         for (uint32_t block = 0; block < num_blocks_first_stage; block++) {
+            // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
             uint64_t noc_addr_ex_par =
                 remote_noc_addrs_first_stage[block] | (l1_read_addr_ex_par);  // Updating read address for reading
                                                                               // SUm(X) and Sum(X2) per core
@@ -122,34 +121,38 @@ void kernel_main() {
             l1_write_addr_external += single_tile_size_bytes;
         }
         l1_read_addr_ex_par += single_tile_size_bytes;
-        noc_async_read_barrier();
-        cb_push_back(cb_ex_external2, num_blocks_first_stage);
+        noc_obj.async_read_barrier();
+        cb_ex_external2_obj.push_back(num_blocks_first_stage);
 
         // read data from other cores - reduce first stage
         if constexpr (use_two_stage_reduce) {
             if (is_second_stage_reader) {  // gather data from a column of cores (if row major)
-                noc_semaphore_wait(reduce_second_stage_semaphore_addr_ptr, num_blocks_second_stage - 1);
-                noc_semaphore_set(reduce_second_stage_semaphore_addr_ptr, 0);
+                reduce_second_stage_sem.wait(num_blocks_second_stage - 1);
+                reduce_second_stage_sem.set(0);
                 // read data from other cores - second stage reduce
                 for (uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {
+                    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
                     uint64_t noc_addr_ex = remote_noc_addrs_second_stage[block + 1] | l1_read_addr_ex;
                     noc_async_read_one_packet(noc_addr_ex, l1_write_addr_external, single_tile_size_bytes);
                     l1_write_addr_external += single_tile_size_bytes;
                 }
                 l1_read_addr_ex += single_tile_size_bytes;
-                noc_async_read_barrier();
-                cb_push_back(cb_ex_external2, num_blocks_second_stage - 1);
+                noc_obj.async_read_barrier();
+                cb_ex_external2_obj.push_back(num_blocks_second_stage - 1);
             }
         }
 
         // sync with the gather worker
-        cb_wait_front(cb_ex2, 1);
+        cb_ex2_obj.wait_front(1);
+        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
+        const uint64_t reduce_second_stage_receiver_semaphore_noc_addr =
+            remote_noc_addrs_second_stage[0] | get_semaphore(reduce_second_stage_semaphore_id);
         noc_semaphore_inc(reduce_second_stage_receiver_semaphore_noc_addr, 1);
     }
-    cb_pop_front(cb_ex_partial2, 1);
+    cb_ex_partial2_obj.pop_front(1);
     // Signal the compute kernel cb_ex_global ready
-    cb_reserve_back(cb_ex_global, 1);
-    noc_semaphore_wait(post_reduce_sender_semaphore_addr_ptr, VALID);
-    cb_push_back(cb_ex_global, 1);
-    cb_pop_front(cb_ex2, 1);
+    cb_ex_global_obj.reserve_back(1);
+    post_reduce_sender_sem.wait(VALID);
+    cb_ex_global_obj.push_back(1);
+    cb_ex2_obj.pop_front(1);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_sender_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_sender_reader.cpp
@@ -143,7 +143,7 @@ void kernel_main() {
 
         // num_dests counts the multicast bounding-box cells (loopback includes
         // self), not the worker count.
-        post_reduce_sender_sem.set_multicast<Noc::McastMode::INCLUDE_SRC>(
+        post_reduce_sender_sem.set_multicast<NocOptions::MCAST_INCL_SRC>(
             noc_obj,
             mcast_dest_noc_start_x,
             mcast_dest_noc_start_y,
@@ -159,7 +159,7 @@ void kernel_main() {
                                                     uint32_t l1_read_addr_ex_global = cb_ex_global_arg.get_read_ptr();
                                                     // num_dests counts the multicast bounding-box cells
                                                     // (loopback includes self), not the worker count.
-                                                    noc_obj.async_write_multicast<Noc::McastMode::INCLUDE_SRC>(
+                                                    noc_obj.async_write_multicast<NocOptions::MCAST_INCL_SRC>(
                                                         CoreLocalMem<uint8_t>(l1_read_addr_ex),
                                                         MulticastEndpoint{},
                                                         single_tile_size_bytes,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_sender_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_sender_reader.cpp
@@ -4,6 +4,11 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 #include "hostdevcommon/common_values.hpp"
 
 // split REDUCE across cores
@@ -30,7 +35,18 @@ void kernel_main() {
     // rectangle size or noc_async_write_barrier() will wait forever.
     constexpr uint32_t num_mcast_dests = get_compile_time_arg_val(16);
 
-    uint32_t post_reduce_sender_semaphore_addr = get_semaphore(post_reduce_sender_semaphore_id);
+    Noc noc_obj;
+    CircularBuffer cb_ex_partial2_obj(cb_ex_partial2);
+    CircularBuffer cb_ex2_obj(cb_ex2);
+    CircularBuffer cb_ex_external2_obj(cb_ex_external2);
+    CircularBuffer cb_stats_reduced_obj(cb_stats_reduced);
+    CircularBuffer cb_ex_global_obj(cb_ex_global);
+
+    Semaphore<> post_reduce_sender_sem(post_reduce_sender_semaphore_id);
+    Semaphore<> reduce_receiver_sem(reduce_receiver_semaphore_id);
+    Semaphore<> reduce_sender_sem(reduce_sender_semaphore_id);
+    Semaphore<> reduce_second_stage_sem(reduce_second_stage_semaphore_id);
+
     const uint32_t mcast_dest_noc_start_x = get_arg_val<uint32_t>(0);
     const uint32_t mcast_dest_noc_start_y = get_arg_val<uint32_t>(1);
     const uint32_t mcast_dest_noc_end_x = get_arg_val<uint32_t>(2);
@@ -41,12 +57,9 @@ void kernel_main() {
     tt_l1_ptr uint32_t* in0_remote_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(6));
     tt_l1_ptr uint32_t* in0_remote_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(6 + num_x));
 
-    uint32_t reduce_receiver_semaphore_addr = get_semaphore(reduce_receiver_semaphore_id);
-    uint32_t reduce_sender_semaphore_addr = get_semaphore(reduce_sender_semaphore_id);
-    uint32_t reduce_second_stage_semaphore_addr = get_semaphore(reduce_second_stage_semaphore_id);
-
     const DataFormat data_format = get_dataformat(cb_ex_partial2);
 
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
     uint64_t remote_noc_addrs[num_blocks];
 
     uint32_t x = start_x, y = start_y;
@@ -62,107 +75,108 @@ void kernel_main() {
         }
     }
 
-    const uint64_t multicast_data_noc = get_noc_multicast_addr(
-        mcast_dest_noc_start_x, mcast_dest_noc_start_y, mcast_dest_noc_end_x, mcast_dest_noc_end_y, 0);
-
-    const uint64_t reduce_sender_semaphore_noc_addr = multicast_data_noc | reduce_sender_semaphore_addr;
-
-    volatile tt_l1_ptr uint32_t* reduce_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_sender_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* reduce_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_receiver_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* reduce_second_stage_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_second_stage_semaphore_addr);
-
-    const auto& global_reduce_sender = [&](const uint32_t cb_partial,
-                                           const uint32_t cb_external,
-                                           const uint32_t cb_reduce_first_stage) __attribute__((always_inline)) {
+    const auto& global_reduce_sender = [&](CircularBuffer& cb_partial,
+                                           CircularBuffer& cb_external,
+                                           CircularBuffer& cb_reduce_first_stage) __attribute__((always_inline)) {
         // global reduce
         // wait for local data ready
-        cb_wait_front(cb_partial, 1);  // TODO test for layernorm
+        cb_partial.wait_front(1);  // TODO test for layernorm
 
         // inc semaphore of other cores, tell other all-to-all workers to start
         if constexpr (num_blocks > 1) {
-            *reduce_sender_semaphore_addr_ptr = VALID;
-            noc_semaphore_wait(reduce_receiver_semaphore_addr_ptr, num_blocks - 1);
-            noc_semaphore_set(reduce_receiver_semaphore_addr_ptr, 0);
+            reduce_sender_sem.set(VALID);
+            reduce_receiver_sem.wait(num_blocks - 1);
+            reduce_receiver_sem.set(0);
             // num_dests counts the multicast bounding-box cells excluding self,
             // not the worker count.
-            noc_semaphore_set_multicast(
-                reduce_sender_semaphore_addr, reduce_sender_semaphore_noc_addr, num_mcast_dests - 1);
+            reduce_sender_sem.set_multicast(
+                noc_obj,
+                mcast_dest_noc_start_x,
+                mcast_dest_noc_start_y,
+                mcast_dest_noc_end_x,
+                mcast_dest_noc_end_y,
+                num_mcast_dests - 1);
         }
 
         // read data from other cores - first stage reduce
-        uint32_t l1_read_addr_ex_par = get_read_ptr(cb_partial);
+        uint32_t l1_read_addr_ex_par = cb_partial.get_read_ptr();
         // read from both stage
         // first stage
-        cb_reserve_back(cb_external, num_blocks_first_stage);
-        uint32_t l1_write_addr_external = get_write_ptr(cb_external);
+        cb_external.reserve_back(num_blocks_first_stage);
+        uint32_t l1_write_addr_external = cb_external.get_write_ptr();
         for (uint32_t block = 0; block < num_blocks_first_stage; ++block) {
+            // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
             uint64_t noc_addr_ex_par = remote_noc_addrs[block] | (l1_read_addr_ex_par);
             noc_async_read_one_packet(noc_addr_ex_par, l1_write_addr_external, single_tile_size_bytes);
             l1_write_addr_external += single_tile_size_bytes;
         }
         l1_read_addr_ex_par += single_tile_size_bytes;
-        noc_async_read_barrier();
-        cb_push_back(cb_external, num_blocks_first_stage);
+        noc_obj.async_read_barrier();
+        cb_external.push_back(num_blocks_first_stage);
 
         // sync with second-stage all-to-all workers
         if constexpr (use_two_stage_reduce) {
-            uint32_t l1_read_addr_ex = get_read_ptr(cb_reduce_first_stage);
+            uint32_t l1_read_addr_ex = cb_reduce_first_stage.get_read_ptr();
             uint32_t block_index_stride = num_x;
-            noc_semaphore_wait(reduce_second_stage_semaphore_addr_ptr, num_blocks_second_stage - 1);
-            noc_semaphore_set(reduce_second_stage_semaphore_addr_ptr, 0);
+            reduce_second_stage_sem.wait(num_blocks_second_stage - 1);
+            reduce_second_stage_sem.set(0);
 
             uint32_t curr_block_index = block_index_stride;
             for (uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
                 uint64_t noc_addr_ex = remote_noc_addrs[curr_block_index] | (l1_read_addr_ex);
                 noc_async_read_one_packet(noc_addr_ex, l1_write_addr_external, single_tile_size_bytes);
                 l1_write_addr_external += single_tile_size_bytes;
                 curr_block_index += block_index_stride;
             }
             l1_read_addr_ex += single_tile_size_bytes;
-            noc_async_read_barrier();
-            cb_push_back(
-                cb_external,
+            noc_obj.async_read_barrier();
+            cb_external.push_back(
                 (num_blocks_second_stage - 1));  // push back partials from all cores -> compute can start reducing now
         }
-        cb_pop_front(cb_partial, 1);
+        cb_partial.pop_front(1);
     };
-    global_reduce_sender(cb_ex_partial2, cb_ex_external2, cb_ex2);
+    global_reduce_sender(cb_ex_partial2_obj, cb_ex_external2_obj, cb_ex2_obj);
 
-    const uint64_t post_reduce_sender_semaphore_noc_addr = multicast_data_noc | post_reduce_sender_semaphore_addr;
-
-    volatile tt_l1_ptr uint32_t* post_reduce_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(post_reduce_sender_semaphore_addr);
     const auto& global_semaphore_set = [&]() __attribute__((always_inline)) {
-        *post_reduce_sender_semaphore_addr_ptr = VALID;
+        post_reduce_sender_sem.set(VALID);
 
         // num_dests counts the multicast bounding-box cells (loopback includes
         // self), not the worker count.
-        noc_semaphore_set_multicast_loopback_src(
-            post_reduce_sender_semaphore_addr, post_reduce_sender_semaphore_noc_addr, num_mcast_dests, false);
-        noc_async_write_barrier();
+        post_reduce_sender_sem.set_multicast<Noc::McastMode::INCLUDE_SRC>(
+            noc_obj,
+            mcast_dest_noc_start_x,
+            mcast_dest_noc_start_y,
+            mcast_dest_noc_end_x,
+            mcast_dest_noc_end_y,
+            num_mcast_dests);
+        noc_obj.async_write_barrier();
     };
 
-    const auto& post_global_reduce_sender = [&](const uint32_t cb_ex, const uint32_t cb_ex_global)
+    const auto& post_global_reduce_sender = [&](CircularBuffer& cb_ex, CircularBuffer& cb_ex_global_arg)
                                                 __attribute__((always_inline)) {
-                                                    uint32_t l1_read_addr_ex = get_read_ptr(cb_ex);
-                                                    uint32_t l1_read_addr_ex_global = get_read_ptr(cb_ex_global);
+                                                    uint32_t l1_read_addr_ex = cb_ex.get_read_ptr();
+                                                    uint32_t l1_read_addr_ex_global = cb_ex_global_arg.get_read_ptr();
                                                     // num_dests counts the multicast bounding-box cells
                                                     // (loopback includes self), not the worker count.
-                                                    noc_async_write_multicast_loopback_src(
-                                                        l1_read_addr_ex,
-                                                        multicast_data_noc | l1_read_addr_ex_global,
+                                                    noc_obj.async_write_multicast<Noc::McastMode::INCLUDE_SRC>(
+                                                        CoreLocalMem<uint8_t>(l1_read_addr_ex),
+                                                        MulticastEndpoint{},
                                                         single_tile_size_bytes,
                                                         num_mcast_dests,
+                                                        {},
+                                                        {.noc_x_start = mcast_dest_noc_start_x,
+                                                         .noc_y_start = mcast_dest_noc_start_y,
+                                                         .noc_x_end = mcast_dest_noc_end_x,
+                                                         .noc_y_end = mcast_dest_noc_end_y,
+                                                         .addr = l1_read_addr_ex_global},
                                                         false);
-                                                    noc_async_write_barrier();
+                                                    noc_obj.async_write_barrier();
                                                 };
-    cb_wait_front(cb_stats_reduced, 1);
-    cb_reserve_back(cb_ex_global, 1);
-    post_global_reduce_sender(cb_stats_reduced, cb_ex_global);
-    cb_push_back(cb_ex_global, 1);
-    cb_pop_front(cb_stats_reduced, 1);
+    cb_stats_reduced_obj.wait_front(1);
+    cb_ex_global_obj.reserve_back(1);
+    post_global_reduce_sender(cb_stats_reduced_obj, cb_ex_global_obj);
+    cb_ex_global_obj.push_back(1);
+    cb_stats_reduced_obj.pop_front(1);
     global_semaphore_set();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_sender_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_sender_reader.cpp
@@ -59,7 +59,6 @@ void kernel_main() {
 
     const DataFormat data_format = get_dataformat(cb_ex_partial2);
 
-    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
     uint64_t remote_noc_addrs[num_blocks];
 
     uint32_t x = start_x, y = start_y;
@@ -105,7 +104,6 @@ void kernel_main() {
         cb_external.reserve_back(num_blocks_first_stage);
         uint32_t l1_write_addr_external = cb_external.get_write_ptr();
         for (uint32_t block = 0; block < num_blocks_first_stage; ++block) {
-            // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
             uint64_t noc_addr_ex_par = remote_noc_addrs[block] | (l1_read_addr_ex_par);
             noc_async_read_one_packet(noc_addr_ex_par, l1_write_addr_external, single_tile_size_bytes);
             l1_write_addr_external += single_tile_size_bytes;
@@ -123,7 +121,6 @@ void kernel_main() {
 
             uint32_t curr_block_index = block_index_stride;
             for (uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {
-                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
                 uint64_t noc_addr_ex = remote_noc_addrs[curr_block_index] | (l1_read_addr_ex);
                 noc_async_read_one_packet(noc_addr_ex, l1_write_addr_external, single_tile_size_bytes);
                 l1_write_addr_external += single_tile_size_bytes;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_writer.cpp
@@ -107,7 +107,6 @@ void kernel_main() {
     const uint32_t eps = get_arg_val<uint32_t>(base_post_rt + 1);
     generate_bcast_col_scalar(CircularBuffer(eps_cb_id), eps);
     const uint32_t iteration_number = get_arg_val<uint32_t>(arg_idx++);
-    // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
     const size_t out_ready_sem_bank_addr = get_arg_val<uint32_t>(arg_idx++);
     uint32_t out_ready_sem_wait_value = get_arg_val<uint32_t>(arg_idx++);
     ttnn::ccl::address_t tensor_address0 = get_arg_val<ttnn::ccl::address_t>(arg_idx++);
@@ -181,20 +180,16 @@ void kernel_main() {
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr);
         if constexpr (num_links == 1) {
             // We deduct the local increment from the target semaphore value as we don't need internal synchronization
-            // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
             noc_semaphore_wait(out_ready_sem_bank_addr_ptr, out_ready_sem_wait_value - 1);
         } else {
             // if multiple links then we need to also ensure the local ones have completed by having them also
             // increment the semaphore and including them in the total
-            // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
             noc_semaphore_inc(out_ready_sem_noc_addr, 1);
-            // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
             noc_semaphore_wait(
                 reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr), out_ready_sem_wait_value);
         }
 
         // 4. global semaphore reset
-        // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
         noc_semaphore_set(out_ready_sem_bank_addr_ptr, 0);
         // Signal the other local cores that the semaphore has returned
 
@@ -232,8 +227,6 @@ void kernel_main() {
             uint32_t tile_id = gamma_tile_start_id + w;
             noc_obj.async_read(
                 gamma, CoreLocalMem<uint8_t>(l1_write_addr_gamma), bytes_in_two_facelines, {.page_id = tile_id}, {});
-            // Device 2.0 migration: legacy primitive retained: local-L1 self-read via get_noc_addr(local_l1_addr); no
-            // LocalL1 source endpoint on main
             uint64_t gamma_noc_addr = get_noc_addr(l1_write_addr_gamma + bytes_in_faceline);
             noc_obj.async_read_barrier();  // might be faster to do two separate read instead of barrier.
             noc_async_read(gamma_noc_addr, l1_write_addr_gamma + mask_read_tile_offset_bytes, bytes_in_faceline);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_writer.cpp
@@ -4,6 +4,10 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/core_local_mem.h"
 #include "hostdevcommon/common_values.hpp"
 #include <tt-metalium/buffer_types.hpp>
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
@@ -15,6 +19,7 @@
 #include "reshard_writer.hpp"
 #include <cstdint>
 #include <utility>
+#include "api/tensor/noc_traits.h"
 void kernel_main() {
     constexpr bool is_all_to_all_worker = get_compile_time_arg_val(0) == 1;
     constexpr uint32_t cb_in_2 = get_compile_time_arg_val(1);
@@ -54,7 +59,14 @@ void kernel_main() {
     constexpr uint32_t num_mcast_dests = get_compile_time_arg_val(24);
     constexpr auto gamma_args = TensorAccessorArgs<25>();
 
-    uint32_t stats_set_semaphore_addr = get_semaphore(stats_set_semaphore_id);
+    Noc noc_obj;
+    CircularBuffer cb_packet_header(reserved_packet_header_cb_id);
+    CircularBuffer cb_to_allgather_writer_obj(cb_to_allgather_writer);
+    CircularBuffer cb_signaling(signaling_cb);
+    CircularBuffer cb_gamma_obj(cb_gamma);
+
+    Semaphore<> stats_set_sem(stats_set_semaphore_id);
+
     size_t arg_idx = 0;
     const uint32_t base_post_rt =
         get_arg_val<uint32_t>(arg_idx++);  // RT 0 holds how many pre RTs there are (which can vary core by core)
@@ -95,14 +107,10 @@ void kernel_main() {
     const uint32_t eps = get_arg_val<uint32_t>(base_post_rt + 1);
     generate_bcast_col_scalar(CircularBuffer(eps_cb_id), eps);
     const uint32_t iteration_number = get_arg_val<uint32_t>(arg_idx++);
+    // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
     const size_t out_ready_sem_bank_addr = get_arg_val<uint32_t>(arg_idx++);
     uint32_t out_ready_sem_wait_value = get_arg_val<uint32_t>(arg_idx++);
     ttnn::ccl::address_t tensor_address0 = get_arg_val<ttnn::ccl::address_t>(arg_idx++);
-    const uint64_t multicast_data_noc = get_noc_multicast_addr(
-        mcast_dest_noc_start_x, mcast_dest_noc_start_y, mcast_dest_noc_end_x, mcast_dest_noc_end_y, 0);
-    const uint64_t stats_set_semaphore_noc_addr = multicast_data_noc | stats_set_semaphore_addr;
-    volatile tt_l1_ptr uint32_t* stats_set_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(stats_set_semaphore_addr);
     // Start the all gather part
     if (iteration_number == 0) {
         // Do this only on one of the cores
@@ -121,15 +129,15 @@ void kernel_main() {
                 arg_idx);
 
         // packet header cb
-        cb_reserve_back(reserved_packet_header_cb_id, 1);
-        auto packet_header_buffer_addr_forward = get_write_ptr(reserved_packet_header_cb_id);
-        cb_push_back(reserved_packet_header_cb_id, 1);
-        cb_reserve_back(reserved_packet_header_cb_id, 1);
-        auto packet_header_buffer_addr_backward = get_write_ptr(reserved_packet_header_cb_id);
-        cb_push_back(reserved_packet_header_cb_id, 1);
-        cb_reserve_back(reserved_packet_header_cb_id, 1);
-        auto packet_header_buffer_seminc = get_write_ptr(reserved_packet_header_cb_id);
-        cb_push_back(reserved_packet_header_cb_id, 1);
+        cb_packet_header.reserve_back(1);
+        auto packet_header_buffer_addr_forward = cb_packet_header.get_write_ptr();
+        cb_packet_header.push_back(1);
+        cb_packet_header.reserve_back(1);
+        auto packet_header_buffer_addr_backward = cb_packet_header.get_write_ptr();
+        cb_packet_header.push_back(1);
+        cb_packet_header.reserve_back(1);
+        auto packet_header_buffer_seminc = cb_packet_header.get_write_ptr();
+        cb_packet_header.push_back(1);
         // pre-populate packet headers
         volatile PACKET_HEADER_TYPE* pkt_hdr_forward =
             reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr_forward);
@@ -149,8 +157,8 @@ void kernel_main() {
             safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr, 0);
         // Send data and the semaphore with the last tile
         uint32_t num_tiles_to_read_this_core = 1;
-        cb_wait_front(cb_to_allgather_writer, num_tiles_to_read_this_core);
-        size_t l1_read_addr = get_read_ptr(cb_to_allgather_writer);
+        cb_to_allgather_writer_obj.wait_front(num_tiles_to_read_this_core);
+        size_t l1_read_addr = cb_to_allgather_writer_obj.get_read_ptr();
         uint64_t noc0_dest_noc_addr = safe_get_noc_addr(core_noc_x[core_id], core_noc_y[core_id], tensor_address0, 0);
         noc0_dest_noc_addr += shard_tile_id * tensor0_page_size;
         fused_write_atomic_and_advance_local_read_address_for_fabric_write(
@@ -165,7 +173,7 @@ void kernel_main() {
             false);
 
         fabric_connection.close_start();
-        cb_pop_front(cb_to_allgather_writer, num_tiles_to_read_this_core);
+        cb_to_allgather_writer_obj.pop_front(num_tiles_to_read_this_core);
         // increment locally
         uint64_t out_ready_sem_noc_addr =
             safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr);
@@ -173,33 +181,42 @@ void kernel_main() {
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr);
         if constexpr (num_links == 1) {
             // We deduct the local increment from the target semaphore value as we don't need internal synchronization
+            // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
             noc_semaphore_wait(out_ready_sem_bank_addr_ptr, out_ready_sem_wait_value - 1);
         } else {
             // if multiple links then we need to also ensure the local ones have completed by having them also
             // increment the semaphore and including them in the total
+            // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
             noc_semaphore_inc(out_ready_sem_noc_addr, 1);
+            // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
             noc_semaphore_wait(
                 reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr), out_ready_sem_wait_value);
         }
 
         // 4. global semaphore reset
+        // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
         noc_semaphore_set(out_ready_sem_bank_addr_ptr, 0);
         // Signal the other local cores that the semaphore has returned
 
-        noc_semaphore_set(stats_set_semaphore_addr_ptr, VALID);
+        stats_set_sem.set(VALID);
         // num_dests counts the multicast bounding-box cells (loopback includes
         // self), not the worker count.
-        noc_semaphore_set_multicast_loopback_src(
-            stats_set_semaphore_addr, stats_set_semaphore_noc_addr, num_mcast_dests, false);
-        noc_async_write_barrier();
+        stats_set_sem.set_multicast<Noc::McastMode::INCLUDE_SRC>(
+            noc_obj,
+            mcast_dest_noc_start_x,
+            mcast_dest_noc_start_y,
+            mcast_dest_noc_end_x,
+            mcast_dest_noc_end_y,
+            num_mcast_dests);
+        noc_obj.async_write_barrier();
         fabric_connection.close_finish();  // Includes a noc async write barrier
     } else {
         // Wait for the signal that the stats semaphore was written in the all gather core
-        noc_semaphore_wait(stats_set_semaphore_addr_ptr, VALID);
+        stats_set_sem.wait(VALID);
     }
     // Tell the compute kernel it is ok to proceed
-    cb_reserve_back(signaling_cb, 1);
-    cb_push_back(signaling_cb, 1);
+    cb_signaling.reserve_back(1);
+    cb_signaling.push_back(1);
 
     if constexpr (fuse_gamma) {
         const uint32_t gamma_tile_bytes = get_tile_size(cb_gamma);
@@ -209,23 +226,25 @@ void kernel_main() {
         constexpr uint32_t bytes_in_two_facelines = bytes_in_faceline * 2;
         constexpr uint32_t mask_read_tile_offset_bytes = FLOAT32_DTYPE_GAMMA ? 1024 : 512;
 
-        uint32_t l1_write_addr_gamma = get_write_ptr(cb_gamma);
-        cb_reserve_back(cb_gamma, block_w);
+        uint32_t l1_write_addr_gamma = cb_gamma_obj.get_write_ptr();
+        cb_gamma_obj.reserve_back(block_w);
         for (uint32_t w = 0; w < block_w; w++) {
             uint32_t tile_id = gamma_tile_start_id + w;
-            uint64_t gamma_noc_addr = gamma.get_noc_addr(tile_id);
-            noc_async_read(gamma_noc_addr, l1_write_addr_gamma, bytes_in_two_facelines);
-            gamma_noc_addr = get_noc_addr(l1_write_addr_gamma + bytes_in_faceline);
-            noc_async_read_barrier();  // might be faster to do two separate read instead of barrier.
+            noc_obj.async_read(
+                gamma, CoreLocalMem<uint8_t>(l1_write_addr_gamma), bytes_in_two_facelines, {.page_id = tile_id}, {});
+            // Device 2.0 migration: legacy primitive retained: local-L1 self-read via get_noc_addr(local_l1_addr); no
+            // LocalL1 source endpoint on main
+            uint64_t gamma_noc_addr = get_noc_addr(l1_write_addr_gamma + bytes_in_faceline);
+            noc_obj.async_read_barrier();  // might be faster to do two separate read instead of barrier.
             noc_async_read(gamma_noc_addr, l1_write_addr_gamma + mask_read_tile_offset_bytes, bytes_in_faceline);
             l1_write_addr_gamma += gamma_tile_bytes;
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_gamma, block_w);
+        noc_obj.async_read_barrier();
+        cb_gamma_obj.push_back(block_w);
     }
 
 #ifndef SKIP_WRITE_BACK
     write_minimal_resharded_data<cb_out, cb_out_resharded, worker_core_stride_w_bytes, storage_core_stride_w_bytes>(
-        num_segments_to_write_back, storage_core_start_offset, segment_args);
+        noc_obj, num_segments_to_write_back, storage_core_start_offset, segment_args);
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_writer.cpp
@@ -201,7 +201,7 @@ void kernel_main() {
         stats_set_sem.set(VALID);
         // num_dests counts the multicast bounding-box cells (loopback includes
         // self), not the worker count.
-        stats_set_sem.set_multicast<Noc::McastMode::INCLUDE_SRC>(
+        stats_set_sem.set_multicast<NocOptions::MCAST_INCL_SRC>(
             noc_obj,
             mcast_dest_noc_start_x,
             mcast_dest_noc_start_y,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/kernels/receiver_inplace_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/kernels/receiver_inplace_writer.cpp
@@ -6,8 +6,12 @@
 #include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
 #include "api/socket_api.h"
 #include "api/tensor/tensor_accessor.h"
+#include "api/tensor/noc_traits.h"
 ///////////////////////////////////////////////////
 // COMPILE TIME ARGS
 ///////////////////////////////////////////////////
@@ -36,11 +40,14 @@ void kernel_main() {
     tt::tt_fabric::WorkerToFabricEdmSender fabric_connection =
         tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(rt_args_idx);
 
+    Noc noc_obj;
+    CircularBuffer cb_fabric_packet_header(fabric_packet_header_cb_id);
+
     // This kernel relies on two fabric headers stored in fabric_packet_header_cb:
     //  - data_packet_header: Used for issuing reads from upstream data cores
     //  - socket_packet_header: Used by socket APIs for control flow
     volatile tt_l1_ptr PACKET_HEADER_TYPE* socket_packet_header_addr =
-        reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(get_write_ptr(fabric_packet_header_cb_id));
+        reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(cb_fabric_packet_header.get_write_ptr());
     fabric_connection.open();
 
     // Create Socket Interface
@@ -58,13 +65,17 @@ void kernel_main() {
             socket_wait_for_pages(receiver_socket, 1);
             uint32_t l1_read_addr = receiver_socket.read_ptr;
             for (uint32_t j = 0; j < num_pages_per_packet; ++j) {
-                auto noc_write_addr = output_addr_gen.get_noc_addr(page_index);
-                noc_async_write<output_page_size>(l1_read_addr, noc_write_addr, output_page_size);
+                noc_obj.async_write(
+                    CoreLocalMem<uint8_t>(l1_read_addr),
+                    output_addr_gen,
+                    output_page_size,
+                    {},
+                    {.page_id = page_index});
                 page_index++;
                 l1_read_addr += socket_page_size;
             }
             socket_pop_pages(receiver_socket, 1);
-            noc_async_writes_flushed();
+            noc_obj.async_writes_flushed();
             fabric_socket_notify_sender(receiver_socket, fabric_connection, socket_packet_header_addr);
         }
 
@@ -72,13 +83,17 @@ void kernel_main() {
             socket_wait_for_pages(receiver_socket, 1);
             uint32_t l1_read_addr = receiver_socket.read_ptr;
             for (uint32_t j = 0; j < num_pages_remainder; ++j) {
-                auto noc_write_addr = output_addr_gen.get_noc_addr(page_index);
-                noc_async_write<output_page_size>(l1_read_addr, noc_write_addr, output_page_size);
+                noc_obj.async_write(
+                    CoreLocalMem<uint8_t>(l1_read_addr),
+                    output_addr_gen,
+                    output_page_size,
+                    {},
+                    {.page_id = page_index});
                 page_index++;
                 l1_read_addr += socket_page_size;
             }
             socket_pop_pages(receiver_socket, 1);
-            noc_async_writes_flushed();
+            noc_obj.async_writes_flushed();
             fabric_socket_notify_sender(receiver_socket, fabric_connection, socket_packet_header_addr);
         }
 
@@ -86,12 +101,16 @@ void kernel_main() {
     // Large pages. We write page chunks from multiple packets.
     else {
         for (uint32_t i = 0; i < num_pages; ++i) {
-            auto noc_write_addr = output_addr_gen.get_noc_addr(page_index);
             socket_wait_for_pages(receiver_socket, 1);
-            noc_async_write<output_page_size>(receiver_socket.read_ptr, noc_write_addr, output_page_size);
+            noc_obj.async_write(
+                CoreLocalMem<uint8_t>(receiver_socket.read_ptr),
+                output_addr_gen,
+                output_page_size,
+                {},
+                {.page_id = page_index});
             page_index++;
             socket_pop_pages(receiver_socket, 1);
-            noc_async_writes_flushed();
+            noc_obj.async_writes_flushed();
             fabric_socket_notify_sender(receiver_socket, fabric_connection, socket_packet_header_addr);
         }
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/kernels/receiver_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/kernels/receiver_reader.cpp
@@ -6,6 +6,8 @@
 #include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 #include "api/socket_api.h"
 #include "api/tensor/tensor_accessor.h"
 ///////////////////////////////////////////////////
@@ -17,8 +19,10 @@ constexpr uint32_t socket_block_size = get_compile_time_arg_val(2);  // This is 
 constexpr uint32_t socket_page_size = get_compile_time_arg_val(3);
 constexpr bool is_dram = get_compile_time_arg_val(4);
 
-template <uint32_t page_size, uint32_t cb_id, bool is_dram>
+template <uint32_t page_size, bool is_dram>
 FORCE_INLINE void read_data_from_remote_core(
+    Noc& noc_obj,
+    CircularBuffer& cb,
     SocketReceiverInterface& receiver_socket,
     tt::tt_fabric::WorkerToFabricEdmSender& fabric_connection,
     uint32_t bank_id,
@@ -26,12 +30,13 @@ FORCE_INLINE void read_data_from_remote_core(
     uint32_t num_pages_per_block) {
     uint32_t block_size = num_pages_per_block * page_size;
     socket_wait_for_pages(receiver_socket, 1);
-    cb_reserve_back(cb_id, num_pages_per_block);
+    cb.reserve_back(num_pages_per_block);
     auto remote_read_addr = get_noc_addr_from_bank_id<is_dram>(bank_id, receiver_socket.read_ptr);
-    auto l1_write_addr = get_write_ptr(cb_id);
+    auto l1_write_addr = cb.get_write_ptr();
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
     noc_async_read(remote_read_addr, l1_write_addr, block_size);
-    noc_async_read_barrier();
-    cb_push_back(cb_id, num_pages_per_block);
+    noc_obj.async_read_barrier();
+    cb.push_back(num_pages_per_block);
     socket_pop_pages(receiver_socket, 1);
     fabric_socket_notify_sender(receiver_socket, fabric_connection, socket_packet_header_addr);
 }
@@ -52,11 +57,15 @@ void kernel_main() {
     tt::tt_fabric::WorkerToFabricEdmSender fabric_connection =
         tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(rt_args_idx);
 
+    Noc noc_obj;
+    CircularBuffer cb_fabric_packet_header(fabric_packet_header_cb_id);
+    CircularBuffer cb_scratch_buffer(scratch_buffer_cb_id);
+
     // This kernel relies on two fabric headers stored in fabric_packet_header_cb:
     //  - data_packet_header: Used for issuing reads from upstream data cores
     //  - socket_packet_header: Used by socket APIs for control flow
     volatile tt_l1_ptr PACKET_HEADER_TYPE* socket_packet_header_addr =
-        reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(get_write_ptr(fabric_packet_header_cb_id));
+        reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(cb_fabric_packet_header.get_write_ptr());
     fabric_connection.open();
 
     // Create Socket Interface
@@ -64,13 +73,25 @@ void kernel_main() {
     set_receiver_socket_page_size(receiver_socket, socket_block_size);
 
     for (uint32_t i = 0; i < num_blocks; ++i) {
-        read_data_from_remote_core<socket_page_size, scratch_buffer_cb_id, is_dram>(
-            receiver_socket, fabric_connection, bank_id, socket_packet_header_addr, num_pages_per_block);
+        read_data_from_remote_core<socket_page_size, is_dram>(
+            noc_obj,
+            cb_scratch_buffer,
+            receiver_socket,
+            fabric_connection,
+            bank_id,
+            socket_packet_header_addr,
+            num_pages_per_block);
     }
 
     if (block_remainder_pages > 0) {
-        read_data_from_remote_core<socket_page_size, scratch_buffer_cb_id, is_dram>(
-            receiver_socket, fabric_connection, bank_id, socket_packet_header_addr, block_remainder_pages);
+        read_data_from_remote_core<socket_page_size, is_dram>(
+            noc_obj,
+            cb_scratch_buffer,
+            receiver_socket,
+            fabric_connection,
+            bank_id,
+            socket_packet_header_addr,
+            block_remainder_pages);
     }
     update_socket_config(receiver_socket);
     fabric_connection.close();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/kernels/receiver_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/kernels/receiver_reader.cpp
@@ -33,7 +33,6 @@ FORCE_INLINE void read_data_from_remote_core(
     cb.reserve_back(num_pages_per_block);
     auto remote_read_addr = get_noc_addr_from_bank_id<is_dram>(bank_id, receiver_socket.read_ptr);
     auto l1_write_addr = cb.get_write_ptr();
-    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
     noc_async_read(remote_read_addr, l1_write_addr, block_size);
     noc_obj.async_read_barrier();
     cb.push_back(num_pages_per_block);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/kernels/receiver_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/kernels/receiver_writer.cpp
@@ -6,7 +6,10 @@
 #include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 #include "api/tensor/tensor_accessor.h"
+#include "api/tensor/noc_traits.h"
 ///////////////////////////////////////////////////
 // COMPILE TIME ARGS
 ///////////////////////////////////////////////////
@@ -29,13 +32,14 @@ void kernel_main() {
     auto output_addr_gen_args = TensorAccessorArgs<output_args_cta_idx, output_args_crta_idx>();
     auto output_addr_gen = TensorAccessor(output_addr_gen_args, output_base_addr);
 
+    Noc noc_obj;
+    CircularBuffer cb_scratch_buffer(scratch_buffer_cb_id);
+
     for (uint32_t page_index = start_page_index; page_index < start_page_index + num_pages; ++page_index) {
-        cb_wait_front(scratch_buffer_cb_id, 1);
-        uint32_t l1_read_addr = get_read_ptr(scratch_buffer_cb_id);
-        auto noc_write_addr = output_addr_gen.get_noc_addr(page_index);
-        noc_async_write<page_size>(l1_read_addr, noc_write_addr, page_size);
-        noc_async_writes_flushed();
-        cb_pop_front(scratch_buffer_cb_id, 1);
+        cb_scratch_buffer.wait_front(1);
+        noc_obj.async_write(cb_scratch_buffer, output_addr_gen, page_size, {}, {.page_id = page_index});
+        noc_obj.async_writes_flushed();
+        cb_scratch_buffer.pop_front(1);
     }
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/kernels/sender_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/kernels/sender_reader.cpp
@@ -5,7 +5,11 @@
 #include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
 #include "api/tensor/tensor_accessor.h"
+#include "api/tensor/noc_traits.h"
 ///////////////////////////////////////////////////
 // COMPILE TIME ARGS
 ///////////////////////////////////////////////////
@@ -32,35 +36,38 @@ void kernel_main() {
     auto input_addr_gen_args = TensorAccessorArgs<input_args_cta_idx, input_args_crta_idx>();
     auto input_addr_gen = TensorAccessor(input_addr_gen_args, input_base_addr);
 
+    Noc noc_obj;
+    CircularBuffer cb0(cb0_id);
+
     // TODO #24995: Instead of page by page transfers, we can transfer bank by bank
 
     // Small pages. We pack multiple pages into a single packet.
     uint32_t page_index = page_start_offset;
     if constexpr (num_pages_per_packet > 0) {
         for (uint32_t i = 0; i < num_whole_packets; ++i) {
-            cb_reserve_back(cb0_id, 1);
-            auto l1_write_addr = get_write_ptr(cb0_id);
+            cb0.reserve_back(1);
+            auto l1_write_addr = cb0.get_write_ptr();
             for (uint32_t j = 0; j < num_pages_per_packet; ++j) {
-                auto noc_read_addr = input_addr_gen.get_noc_addr(page_index);
-                noc_async_read<input_page_size>(noc_read_addr, l1_write_addr, input_page_size);
+                noc_obj.async_read(
+                    input_addr_gen, CoreLocalMem<uint8_t>(l1_write_addr), input_page_size, {.page_id = page_index}, {});
                 page_index++;
                 l1_write_addr += socket_page_size;
             }
-            noc_async_read_barrier();
-            cb_push_back(cb0_id, 1);
+            noc_obj.async_read_barrier();
+            cb0.push_back(1);
         }
 
         if (num_pages_remainder > 0) {
-            cb_reserve_back(cb0_id, 1);
-            auto l1_write_addr = get_write_ptr(cb0_id);
+            cb0.reserve_back(1);
+            auto l1_write_addr = cb0.get_write_ptr();
             for (uint32_t j = 0; j < num_pages_remainder; ++j) {
-                auto noc_read_addr = input_addr_gen.get_noc_addr(page_index);
-                noc_async_read<input_page_size>(noc_read_addr, l1_write_addr, input_page_size);
+                noc_obj.async_read(
+                    input_addr_gen, CoreLocalMem<uint8_t>(l1_write_addr), input_page_size, {.page_id = page_index}, {});
                 page_index++;
                 l1_write_addr += socket_page_size;
             }
-            noc_async_read_barrier();
-            cb_push_back(cb0_id, 1);
+            noc_obj.async_read_barrier();
+            cb0.push_back(1);
         }
 
     }
@@ -70,19 +77,21 @@ void kernel_main() {
         for (uint32_t i = 0; i < num_pages; ++i) {
             auto noc_read_addr = input_addr_gen.get_noc_addr(page_index);
             for (uint32_t j = 0; j < num_whole_packets_per_page; ++j) {
-                cb_reserve_back(cb0_id, 1);
-                auto l1_write_addr = get_write_ptr(cb0_id);
+                cb0.reserve_back(1);
+                auto l1_write_addr = cb0.get_write_ptr();
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
                 noc_async_read<whole_packet_size>(noc_read_addr, l1_write_addr, whole_packet_size);
                 noc_read_addr += whole_packet_size;
-                noc_async_read_barrier();
-                cb_push_back(cb0_id, 1);
+                noc_obj.async_read_barrier();
+                cb0.push_back(1);
             }
             if constexpr (partial_packet_size > 0) {
-                cb_reserve_back(cb0_id, 1);
-                auto l1_write_addr = get_write_ptr(cb0_id);
+                cb0.reserve_back(1);
+                auto l1_write_addr = cb0.get_write_ptr();
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
                 noc_async_read<partial_packet_size>(noc_read_addr, l1_write_addr, partial_packet_size);
-                noc_async_read_barrier();
-                cb_push_back(cb0_id, 1);
+                noc_obj.async_read_barrier();
+                cb0.push_back(1);
             }
             page_index++;
         }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/kernels/sender_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/kernels/sender_reader.cpp
@@ -79,7 +79,6 @@ void kernel_main() {
             for (uint32_t j = 0; j < num_whole_packets_per_page; ++j) {
                 cb0.reserve_back(1);
                 auto l1_write_addr = cb0.get_write_ptr();
-                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
                 noc_async_read<whole_packet_size>(noc_read_addr, l1_write_addr, whole_packet_size);
                 noc_read_addr += whole_packet_size;
                 noc_obj.async_read_barrier();
@@ -88,7 +87,6 @@ void kernel_main() {
             if constexpr (partial_packet_size > 0) {
                 cb0.reserve_back(1);
                 auto l1_write_addr = cb0.get_write_ptr();
-                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
                 noc_async_read<partial_packet_size>(noc_read_addr, l1_write_addr, partial_packet_size);
                 noc_obj.async_read_barrier();
                 cb0.push_back(1);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/kernels/sender_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/kernels/sender_writer.cpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/circular_buffer.h"
 #include "api/socket_api.h"
 
 ///////////////////////////////////////////////////
@@ -21,20 +22,21 @@ constexpr uint32_t aligned_partial_packet_size = get_compile_time_arg_val(6);
 constexpr uint32_t whole_packet_size = get_compile_time_arg_val(7);
 constexpr bool is_dram = get_compile_time_arg_val(8);
 
-template <uint32_t cb_id, bool is_dram>
+template <bool is_dram>
 FORCE_INLINE void write_data_to_remote_core(
+    CircularBuffer& cb,
     tt::tt_fabric::WorkerToFabricEdmSender& fabric_connection,
     uint64_t dst_addr,
     uint32_t packet_size,
     volatile tt_l1_ptr PACKET_HEADER_TYPE* data_packet_header_addr) {
-    cb_wait_front(cb_id, 1);
-    auto l1_read_addr = get_read_ptr(cb_id);
+    cb.wait_front(1);
+    auto l1_read_addr = cb.get_read_ptr();
     data_packet_header_addr->to_noc_unicast_write(NocUnicastCommandHeader{dst_addr}, packet_size);
     fabric_connection.wait_for_empty_write_slot();
     fabric_connection.send_payload_without_header_non_blocking_from_address(l1_read_addr, packet_size);
     fabric_connection.send_payload_flush_blocking_from_address(
         (uint32_t)data_packet_header_addr, sizeof(PACKET_HEADER_TYPE));
-    cb_pop_front(cb_id, 1);
+    cb.pop_front(1);
 }
 
 void kernel_main() {
@@ -53,14 +55,17 @@ void kernel_main() {
     tt::tt_fabric::WorkerToFabricEdmSender fabric_connection =
         tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(rt_args_idx);
 
+    CircularBuffer cb_fabric_packet_header(fabric_packet_header_cb_id);
+    CircularBuffer cb_data(data_cb_id);
+
     // This kernel relies on two fabric headers stored in fabric_packet_header_cb:
     //  - data_packet_header: Used for issuing writes to downstream data cores
     //  - socket_packet_header: Used by socket APIs for control flow
     volatile tt_l1_ptr PACKET_HEADER_TYPE* data_packet_header_addr =
-        reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(get_write_ptr(fabric_packet_header_cb_id));
+        reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(cb_fabric_packet_header.get_write_ptr());
     volatile tt_l1_ptr PACKET_HEADER_TYPE* socket_packet_header_addr =
         reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(
-            get_write_ptr(fabric_packet_header_cb_id) + sizeof(PACKET_HEADER_TYPE));
+            cb_fabric_packet_header.get_write_ptr() + sizeof(PACKET_HEADER_TYPE));
     fabric_connection.open();
 
     // Create Socket Interface
@@ -81,8 +86,8 @@ void kernel_main() {
         for (uint32_t i = 0; i < num_whole_packets; ++i) {
             socket_reserve_pages(sender_socket, 1);
             uint64_t dst_addr = receiver_noc_coord_addr + sender_socket.write_ptr + sender_socket.downstream_fifo_addr;
-            write_data_to_remote_core<data_cb_id, is_dram>(
-                fabric_connection, dst_addr, full_packet_size, data_packet_header_addr);
+            write_data_to_remote_core<is_dram>(
+                cb_data, fabric_connection, dst_addr, full_packet_size, data_packet_header_addr);
             socket_push_pages(sender_socket, 1);
             fabric_socket_notify_receiver(sender_socket, fabric_connection, socket_packet_header_addr);
         }
@@ -90,8 +95,8 @@ void kernel_main() {
         if (num_pages_remainder > 0) {
             socket_reserve_pages(sender_socket, 1);
             uint64_t dst_addr = receiver_noc_coord_addr + sender_socket.write_ptr + sender_socket.downstream_fifo_addr;
-            write_data_to_remote_core<data_cb_id, is_dram>(
-                fabric_connection, dst_addr, remainder_packet_size, data_packet_header_addr);
+            write_data_to_remote_core<is_dram>(
+                cb_data, fabric_connection, dst_addr, remainder_packet_size, data_packet_header_addr);
             socket_push_pages(sender_socket, 1);
             fabric_socket_notify_receiver(sender_socket, fabric_connection, socket_packet_header_addr);
         }
@@ -103,13 +108,13 @@ void kernel_main() {
             socket_reserve_pages(sender_socket, 1);
             uint64_t dst_addr = receiver_noc_coord_addr + sender_socket.write_ptr + sender_socket.downstream_fifo_addr;
             for (uint32_t j = 0; j < num_whole_packets_per_page; ++j) {
-                write_data_to_remote_core<data_cb_id, is_dram>(
-                    fabric_connection, dst_addr, whole_packet_size, data_packet_header_addr);
+                write_data_to_remote_core<is_dram>(
+                    cb_data, fabric_connection, dst_addr, whole_packet_size, data_packet_header_addr);
                 dst_addr += whole_packet_size;
             }
             if constexpr (aligned_partial_packet_size > 0) {
-                write_data_to_remote_core<data_cb_id, is_dram>(
-                    fabric_connection, dst_addr, aligned_partial_packet_size, data_packet_header_addr);
+                write_data_to_remote_core<is_dram>(
+                    cb_data, fabric_connection, dst_addr, aligned_partial_packet_size, data_packet_header_addr);
             }
             socket_push_pages(sender_socket, 1);
             fabric_socket_notify_receiver(sender_socket, fabric_connection, socket_packet_header_addr);


### PR DESCRIPTION
### PR Category
  Cleanup

### Summary
  Contributes to #45003 (item 4)

  Migrate five CCL ops under experimental/ccl/ onto the Device 2.0 kernel API :
  - send_recv_async
  - llama_reduce_scatter_create_heads
  - rms_allgather
  - all_gather_async
  - llama_all_gather_matmul_async

### Notes for reviewers

  - Per-op migration is mechanical: add Device 2.0 headers, declare Noc noc_obj; / CircularBuffer cb_<name>(cb_<name>_id); / Semaphore<> <name>_sem(<name>_id); near the top of kernel_main(), route noc_async_* / cb_* / noc_semaphore_* through the matching wrapper method.
  - One non-mechanical merge: rms_allgather's sender_reader/writer
  - Fabric calls are left on the legacy free-function API
  - Follow-up PRs from other CCL ops will land separately and reference this one

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/ccl-d2-pr-a-gather)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/ccl-d2-pr-a-gather)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/ccl-d2-pr-a-gather)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/ccl-d2-pr-a-gather)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=iwrosz/ccl-d2-pr-a-gather)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:iwrosz/ccl-d2-pr-a-gather)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/ccl-d2-pr-a-gather)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/ccl-d2-pr-a-gather)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/ccl-d2-pr-a-gather)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/ccl-d2-pr-a-gather)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/ccl-d2-pr-a-gather)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/ccl-d2-pr-a-gather)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/ccl-d2-pr-a-gather)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/ccl-d2-pr-a-gather)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/ccl-d2-pr-a-gather)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/ccl-d2-pr-a-gather)