### PR TITLE
[ring_mla] Gather only the logical_n-valid KV prefix in ring-attention all-gather

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
@@ -124,6 +124,13 @@ void kernel_main() {
         input_tile_id_start[input_idx] = get_arg_val<uint32_t>(arg_idx++);
         input_tile_id_end[input_idx] = get_arg_val<uint32_t>(arg_idx++);
         input_batch_base[input_idx] = get_arg_val<uint32_t>(arg_idx++);
+        // valid_pages_per_batch_head: clamp the gather to the logical_n-valid slab prefix so only
+        // kv_actual-sized data moves. Uniform across cores/devices, so producer/consumer page counts
+        // and the ring slice protocol stay matched. Default (full input) leaves the range unchanged.
+        const uint32_t valid_pages = get_arg_val<uint32_t>(arg_idx++);
+        if (valid_pages < input_tile_id_end[input_idx]) {
+            input_tile_id_end[input_idx] = valid_pages;
+        }
     }
 
     auto inputs_tuple = make_tensor_accessor_tuple(inputs_args, arg_idx);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
@@ -73,6 +73,13 @@ void kernel_main() {
         // input_batch_base: reader-only (phase-1 input offset). The writer always targets output
         // slot 0, so it reads the arg here only for alignment.
         (void)get_arg_val<uint32_t>(arg_idx++);
+        // valid_pages_per_batch_head: clamp the gather to the logical_n-valid slab prefix (must match
+        // the reader's clamp so cb_output producer/consumer page counts stay aligned). Default
+        // (full input) leaves the range unchanged.
+        const uint32_t valid_pages = get_arg_val<uint32_t>(arg_idx++);
+        if (valid_pages < input_tile_id_end[input_idx]) {
+            input_tile_id_end[input_idx] = valid_pages;
+        }
     }
 
     auto outputs_tuple = make_tensor_accessor_tuple(outputs_args, arg_idx);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
@@ -124,7 +124,8 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     std::optional<ttnn::experimental::ccl::AllGatherFusedOpSignaler>& fused_op_signaler,
     const CoreCoord core_grid_offset,
     ttnn::ccl::CoreAllocationStrategy core_allocation_strategy,
-    std::optional<uint32_t> input_batch_slice_idx) {
+    std::optional<uint32_t> input_batch_slice_idx,
+    std::optional<uint32_t> gather_valid_Ht) {
     using tt::tt_metal::CBDescriptor;
     using tt::tt_metal::CBFormatDescriptor;
     using tt::tt_metal::KernelDescriptor;
@@ -481,6 +482,15 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
             tensor_descriptor_args.push_back(input_tile_id_start);  // 5 == input_tile_id_start
             tensor_descriptor_args.push_back(input_tile_id_end);    // 6 == input_tile_id_end
             tensor_descriptor_args.push_back(input_batch_base);     // 7 == input_batch_base (phase-1 input page offset)
+            // 8 == valid pages per (batch,head) to gather. Default: full input slab (no clamp). When
+            // gather_valid_Ht is set (fused ring_joint_sdpa with an oversized cache), bound it to the
+            // first gather_valid_Ht tile-rows so only kv_actual-sized data moves. The fused path also
+            // re-patches this per dispatch on cache hits (apply_ring_joint_scalar_runtime_args); setting
+            // it here makes the cache-miss (first) dispatch bounded too.
+            const uint32_t valid_pages_per_batch_head =
+                gather_valid_Ht.has_value() ? std::min(*gather_valid_Ht, input_tensor_Ht) * input_tensor_Wt
+                                            : single_batch_head_num_pages;
+            tensor_descriptor_args.push_back(valid_pages_per_batch_head);  // 8 == valid_pages_per_batch_head
         }
 
         KernelDescriptor::RTArgList reader_forward_rt_args;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
@@ -452,9 +452,9 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
             const uint32_t input_tile_id_end = ((link + 1) * base_pages_per_worker) + std::min(link + 1, remainder);
 
             const uint32_t input_tensor_Wt = input_tensor_shape[3] / tt::constants::TILE_WIDTH;
-            const uint32_t input_tensor_Ht = input_tensor_shape[2] / tt::constants::TILE_WIDTH;
+            const uint32_t input_tensor_Ht = input_tensor_shape[2] / tt::constants::TILE_HEIGHT;
             const uint32_t output_tensor_Wt = output_tensor_shape[3] / tt::constants::TILE_WIDTH;
-            const uint32_t output_tensor_Ht = output_tensor_shape[2] / tt::constants::TILE_WIDTH;
+            const uint32_t output_tensor_Ht = output_tensor_shape[2] / tt::constants::TILE_HEIGHT;
             TT_ASSERT(!(input_tensor_shape[3] % tt::constants::TILE_WIDTH));
             TT_ASSERT(!(output_tensor_shape[3] % tt::constants::TILE_WIDTH));
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.hpp
@@ -37,8 +37,15 @@ namespace ring_attention_all_gather_async_detail {
 // All-gather reader runtime-arg layout: [0]=dim, [1]=ring_size, [2]=out_ready_sem,
 // followed by one tensor-descriptor block per gathered input.
 constexpr uint32_t kReaderRuntimeArgHeaderCount = 3;
-constexpr uint32_t kTensorDescriptorFieldCount = 8;
+// All-gather writer runtime-arg layout: [0]=dim, [1]=sem_noc0_x, [2]=sem_noc0_y, [3]=ring_size,
+// [4]=out_ready_sem, followed by one tensor-descriptor block per gathered input.
+constexpr uint32_t kWriterRuntimeArgHeaderCount = 5;
+constexpr uint32_t kTensorDescriptorFieldCount = 9;
 constexpr uint32_t kInputBatchBaseFieldOffset = 7;
+// Per-(batch,head) page count each worker is allowed to gather. Defaults to the full input
+// (input_Ht * input_Wt); the fused ring_joint_sdpa path patches it down to the logical_n-valid
+// slab prefix so the gather moves only kv_actual-sized data, not the whole oversized cache.
+constexpr uint32_t kValidPagesFieldOffset = 8;
 
 inline uint32_t input_batch_base_pages(
     uint32_t batch_idx, uint32_t num_heads, uint32_t tensor_height_tiles, uint32_t tensor_width_tiles) {
@@ -75,6 +82,12 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     // When set, gather only this batch slot (dim-0 index) of `input_tensor` into slot 0 of
     // `output_tensor` — lets a consumer keep a full KV cache as input with a batch-1 gathered buffer
     // (a full-batch output also works; only slot 0 is written). std::nullopt => full batch (default).
-    std::optional<uint32_t> input_batch_slice_idx = std::nullopt);
+    std::optional<uint32_t> input_batch_slice_idx = std::nullopt,
+    // When set, gather only the first `gather_valid_Ht` tile-rows per (batch,head) instead of the
+    // full input height — lets a consumer keep an oversized (growing) KV cache as input while moving
+    // only the valid (e.g. logical_n-sized) prefix. Capped to the input height per gathered tensor.
+    // std::nullopt => gather the full input (default). The fused ring_joint_sdpa path also re-patches
+    // this per dispatch on cache hits (see apply_ring_joint_scalar_runtime_args).
+    std::optional<uint32_t> gather_valid_Ht = std::nullopt);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -118,7 +118,9 @@ constexpr uint32_t kComputeKernelIndex = 2;
 // The helper appends 4 kernels after the 3 SDPA kernels above, in order: reader_forward (3),
 // writer_forward (4), reader_backward (5), writer_backward (6) (helper desc.kernels.push_back order).
 constexpr uint32_t kAllGatherReaderForwardKernelIndex = 3;
+constexpr uint32_t kAllGatherWriterForwardKernelIndex = 4;
 constexpr uint32_t kAllGatherReaderBackwardKernelIndex = 5;
+constexpr uint32_t kAllGatherWriterBackwardKernelIndex = 6;
 
 // Compute runtime args 0/1 are global_q_start/global_q_end (see ring_joint_sdpa.cpp kernel_main).
 // A core with global_q_start == global_q_end got no Q chunks at emplace time and is idle.
@@ -447,6 +449,23 @@ void write_runtime_arg(RuntimeArgsData& args, uint32_t index, uint32_t value, co
     args[index] = value;
 }
 
+// Tile-rows of the latent KV the fused all-gather must move for this chunk: the first
+// ceil(logical_n / chunk_global) block-cyclic slabs (a contiguous per-device page prefix), so an
+// oversized (growing) KV cache only moves kv_actual-sized data. Returns nullopt when KV-pad rotation
+// is off (gather the full input). Shared by the descriptor-create path (so the first / cache-miss
+// dispatch is bounded) and the cache-hit override path.
+std::optional<uint32_t> compute_gather_valid_Ht(
+    const ttnn::prim::RingJointSDPAParams& args, const ttnn::prim::RingJointSDPAInputs& tensor_args) {
+    if (!args.has_kv_pad_rotation()) {
+        return std::nullopt;
+    }
+    const uint32_t ring_size = static_cast<uint32_t>(args.all_gather_operation_attributes.ring_size);
+    const uint32_t n_local_q = tensor_args.input_q.padded_shape()[2];  // per-device Q slab (chunk_local)
+    const uint32_t chunk_global = n_local_q * ring_size;
+    const uint32_t valid_slabs = (static_cast<uint32_t>(args.logical_n) + chunk_global - 1) / chunk_global;
+    return valid_slabs * (n_local_q / tt::constants::TILE_HEIGHT);
+}
+
 void apply_ring_joint_scalar_runtime_args(
     Program& program,
     const ttnn::prim::RingJointSDPAParams& args,
@@ -465,15 +484,17 @@ void apply_ring_joint_scalar_runtime_args(
     const uint32_t num_cores = layout.grid_size.x * layout.grid_size.y;
     const uint32_t kv_cache_batch_idx = args.kv_cache_batch_idx.value_or(0);
 
+    // Gather inputs (K, plus V when it isn't the latent-V alias of K). Shared by the indexed-slot
+    // and valid-pages patches below.
+    const Tensor& input_k = tensor_args.input_k;
+    const uint32_t num_ag_inputs = tensor_args.has_latent_v() ? 1u : (tensor_args.input_v.has_value() ? 2u : 1u);
+    const std::array<const Tensor*, 2> ag_inputs = {
+        &input_k, tensor_args.input_v.has_value() ? &tensor_args.input_v.value() : &input_k};
+
     // Re-patch the fused all-gather readers to gather the single cache slot `kv_cache_batch_idx`.
     // input_batch_base is uniform across all gather cores/links, so patch every core that runs the
     // reader. Mirrors the helper's create-time arithmetic so miss and hit paths agree.
     if (patch_indexed_kv_cache) {
-        const Tensor& input_k = tensor_args.input_k;
-        const bool v_shares_k = tensor_args.has_latent_v();
-        const uint32_t num_ag_inputs = v_shares_k ? 1u : (tensor_args.input_v.has_value() ? 2u : 1u);
-        const std::array<const Tensor*, 2> ag_inputs = {
-            &input_k, tensor_args.input_v.has_value() ? &tensor_args.input_v.value() : &input_k};
         const auto patch_all_gather_reader = [&](uint32_t kernel_id) {
             auto& grid_args = GetRuntimeArgs(program, kernel_id);  // [x][y] per-core args
             for (auto& col_args : grid_args) {
@@ -497,6 +518,40 @@ void apply_ring_joint_scalar_runtime_args(
         };
         patch_all_gather_reader(kAllGatherReaderForwardKernelIndex);
         patch_all_gather_reader(kAllGatherReaderBackwardKernelIndex);
+    }
+
+    // Bound the fused all-gather to the logical_n-valid slab prefix so an oversized (growing) KV
+    // cache only moves kv_actual-sized data instead of the whole physical buffer. The cache is
+    // block-cyclic / slab-major per device, so the valid tokens are the first
+    // ceil(logical_n / chunk_global) slabs == a contiguous page prefix. valid_pages is uniform
+    // across cores/links/devices, so producer/consumer page counts and the ring slice protocol stay
+    // matched (the AG kernels clamp input_tile_id_end to it). Patch readers AND writers — both key
+    // their loops off input_tile_id_end — at their respective header offsets (3 vs 5).
+    const std::optional<uint32_t> gather_valid_Ht = compute_gather_valid_Ht(args, tensor_args);
+    if (gather_valid_Ht.has_value()) {
+        const auto patch_all_gather_valid_pages = [&](uint32_t kernel_id, uint32_t header_count) {
+            auto& grid_args = GetRuntimeArgs(program, kernel_id);  // [x][y] per-core args
+            for (auto& col_args : grid_args) {
+                for (auto& core_args : col_args) {
+                    for (uint32_t in = 0; in < num_ag_inputs; ++in) {
+                        const auto& shape = ag_inputs[in]->padded_shape();
+                        const uint32_t Ht = shape[2] / tt::constants::TILE_HEIGHT;
+                        const uint32_t Wt = shape[3] / tt::constants::TILE_WIDTH;
+                        const uint32_t valid_Ht = std::min(*gather_valid_Ht, Ht);
+                        const uint32_t valid_pages = valid_Ht * Wt;
+                        const uint32_t idx =
+                            header_count + in * ag_rt::kTensorDescriptorFieldCount + ag_rt::kValidPagesFieldOffset;
+                        if (core_args.size() > idx) {  // skip cores that don't run this kernel
+                            write_runtime_arg(core_args, idx, valid_pages, "all_gather.valid_pages");
+                        }
+                    }
+                }
+            }
+        };
+        patch_all_gather_valid_pages(kAllGatherReaderForwardKernelIndex, ag_rt::kReaderRuntimeArgHeaderCount);
+        patch_all_gather_valid_pages(kAllGatherReaderBackwardKernelIndex, ag_rt::kReaderRuntimeArgHeaderCount);
+        patch_all_gather_valid_pages(kAllGatherWriterForwardKernelIndex, ag_rt::kWriterRuntimeArgHeaderCount);
+        patch_all_gather_valid_pages(kAllGatherWriterBackwardKernelIndex, ag_rt::kWriterRuntimeArgHeaderCount);
     }
 
     for (uint32_t i = 0; i < num_cores; ++i) {
@@ -2181,7 +2236,11 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         all_gather_fused_op_signaler,
         args.ccl_core_grid_offset,
         args.all_gather_operation_attributes.core_allocation_strategy,
-        args.kv_cache_batch_idx);
+        args.kv_cache_batch_idx,
+        // Bound the gather to the logical_n-valid prefix at create time so the first (cache-miss)
+        // dispatch moves only kv_actual-sized data, not the whole oversized cache. Re-patched per
+        // dispatch on cache hits in apply_ring_joint_scalar_runtime_args.
+        compute_gather_valid_Ht(args, tensor_args));
 
     return desc;
 }


### PR DESCRIPTION
## Problem

The fused all-gather inside `ring_mla` / `ring_joint_scaled_dot_product_attention` moves the **entire physical KV cache** on every call: its send volume is derived from the input tensor's seq dim (`local_kv_seq_len * ring_size`), independent of `logical_n`. Chunked prefill keeps one stable, oversized cache buffer, so every chunk gathered the whole cache — inflating the gather and the SDPA device kernel time even when only a small valid prefix was populated (e.g. the first 5k-token chunk against a 50k+5k-sized cache gathered ~11× more data than needed).

## Fix

Bound the gather to the `logical_n`-valid prefix. The block-cyclic KV cache is slab-major per device, so the valid tokens are the first `ceil(logical_n / chunk_global)` slabs — a contiguous per-`(batch,head)` page prefix. A new uniform per-input **valid-pages** runtime field clamps `input_tile_id_end` in the all-gather reader and writer kernels.

Because the clamp value is uniform across cores, links, and devices:
- producer/consumer (reader/writer CB) page counts stay matched,
- the ring slice/semaphore protocol is unchanged (it counts ring positions, not pages),

so there is no deadlock risk.

The bound is applied in **both** places, mirroring how the compute side handles `logical_nt`:
- at **descriptor-create** time (new optional `gather_valid_Ht` arg threaded into the all-gather helper) so the first / cache-miss dispatch is bounded too — fixes the iter-0 "full gather" kernel-time spike;
- re-patched **per dispatch** on cache hits in `apply_ring_joint_scalar_runtime_args` (`logical_n` grows per chunk).

When unset, the field defaults to the full input, so the standalone `ring_attention_all_gather_async` op is unchanged.

## Correctness

Output is unchanged — the compute side already masks by `logical_n` and skips pad slabs, so this only reduces **data movement**, not results.

## Testing

Validated on an 8x4 Galaxy: ring_mla chunked-prefill PCC unchanged, and the per-iteration device kernel time now reflects the kv_actual-sized gather (including iteration 0, which previously ran the full-cache gather).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [x] [![galaxy-deepseek-prefill-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=ipotkonjak/ring_mla_gather_kv_actual_bound)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:ipotkonjak/ring_mla_gather_kv_actual_bound) 
- [x] [![blackhole-e2e-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=ipotkonjak/ring_mla_gather_kv_actual_bound)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:ipotkonjak/ring_mla_gather_kv_actual_bound) -> failure unrelated to the change
- [x] [![demo-sp-release](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=ipotkonjak/ring_mla_gather_kv_actual_bound)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:ipotkonjak/ring_mla_gather_kv_actual_bound) -> failure unrelated to the change
- [x] [![blackhole-post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ipotkonjak/ring_mla_gather_kv_actual_bound)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ipotkonjak/ring_mla_gather_kv_actual_bound) -> failure unrelated to the change

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/ring_mla_gather_kv_actual_bound)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/ring_mla_gather_kv_actual_bound)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/ring_mla_gather_kv_actual_bound)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/ring_mla_gather_kv_actual_bound)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ipotkonjak/ring_mla_gather_kv_actual_bound)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ipotkonjak/ring_mla_gather_kv_actual_bound)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/ring_mla_gather_kv_actual_bound)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/ring_mla_gather_kv_actual_bound)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/ring_mla_gather_kv_actual_bound)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/ring_mla_gather_kv_actual_bound)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/ring_mla_gather_kv_actual_bound)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/ring_mla_gather_kv_actual_bound)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/ring_mla_gather_kv_actual_bound)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/ring_mla_gather_kv_actual_bound)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/ring_mla_gather_kv_actual_bound)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/ring_mla_gather_kv_actual_bound)