### PR TITLE
feat: add Compiler Explorer configuration for Tensix RISC-V

### DIFF
--- a/docs/compiler-explorer-tensix.properties
+++ b/docs/compiler-explorer-tensix.properties
@@ -1,0 +1,71 @@
+# Tenstorrent Tensix / RISC-V compiler configuration for Compiler Explorer.
+#
+# tt-metal compiles kernels to RISC-V (Tensix cores) and SFPU microcode.
+# This configuration exposes the cross-compiler toolchain on Compiler
+# Explorer so that generated assembly can be investigated interactively.
+#
+# Installation:
+#   1. Copy this file to etc/config/c/tenstorrent.tensix.properties
+#   2. Add "&tenstorrent" to the compilers= line in c.defaults.properties
+#   3. Ensure riscv32-unknown-elf-g++ is in $PATH (or set absolute path below)
+#
+# References:
+#   https://github.com/compiler-explorer/compiler-explorer
+#   docs/AddingACompiler.md
+#   docs/AddingALanguage.md (if adding SFPU asm language support)
+
+# ── Compiler group ───────────────────────────────────────────────────
+group.tenstorrent.groupName=Tenstorrent Tensix
+group.tenstorrent.baseName=RV32 Tensix
+group.tenstorrent.compilerType=clang     # treated as GNU-compatible
+group.tenstorrent.supportsBinary=true
+group.tenstorrent.supportsExecute=false  # cannot execute on CE server (no Tensix hw)
+group.tenstorrent.instructionSet=riscv32
+group.tenstorrent.compilers=tensix-gcc13:tensix-opt:tensix-size
+group.tenstorrent.versionFlag=--version
+group.tenstorrent.versionRe=^riscv32-unknown-elf-g\\+\\+ \\(Tenstorrent Tensix\\) ([\\d.]+).*
+
+# ── GCC 13 (RISC-V cross-compiler, Tensix flavour) ──────────────────
+compiler.tensix-gcc13.name=TT Tensix GCC 13.2 (RISC-V rv32imafdzfh)
+compiler.tensix-gcc13.exe=/opt/tenstorrent/riscv/bin/riscv32-unknown-elf-g++
+compiler.tensix-gcc13.semver=13.2.0
+compiler.tensix-gcc13.options=-O2 -march=rv32imafdzfh -mabi=ilp32d -Wall -Wextra
+compiler.tensix-gcc13.objdumper=/opt/tenstorrent/riscv/bin/riscv32-unknown-elf-objdump
+compiler.tensix-gcc13.demangler=/opt/tenstorrent/riscv/bin/riscv32-unknown-elf-c++filt
+
+# Optimisation variants
+compiler.tensix-gcc13.optFlags=-O0
+compiler.tensix-gcc13.optFlag.O0=-O0
+compiler.tensix-gcc13.optFlag.O1=-O1
+compiler.tensix-gcc13.optFlag.O2=-O2
+compiler.tensix-gcc13.optFlag.O3=-O3
+compiler.tensix-gcc13.optFlag.Os=-Os-sized
+
+# Target variants (Tensix core ISA extensions)
+compiler.tensix-gcc13.targetFlag=-march=rv32imafdzfh
+compiler.tensix-gcc13.targetFlag.rv32i=-march=rv32i
+compiler.tensix-gcc13.targetFlag.rv32im=-march=rv32im
+compiler.tensix-gcc13.targetFlag.rv32imafd=-march=rv32imafd
+
+# Stdlib (Tenstorrent uses newlib for bare-metal)
+compiler.tensix-gcc13.stdlib=-nostdlib
+compiler.tensix-gcc13.stdlibFlag=-nostdlib
+compiler.tensix-gcc13.notification=Tenstorrent Tensix RISC-V cross-compiler. **Note:** bare-metal kernel code; standard library is unavailable.
+
+# ── Compilation options for SFPU / kernel inspection ─────────────────
+compiler.tensix-opt.name=TT Tensix GCC (SFPU inspect, -O3 -fverbose-asm)
+compiler.tensix-opt.exe=/opt/tenstorrent/riscv/bin/riscv32-unknown-elf-g++
+compiler.tensix-opt.semver=13.2.0
+compiler.tensix-opt.options=-O3 -march=rv32imafdzfh -mabi=ilp32d -fverbose-asm -fno-inline -nostdlib
+compiler.tensix-opt.objdumper=/opt/tenstorrent/riscv/bin/riscv32-unknown-elf-objdump
+compiler.tensix-opt.demangler=/opt/tenstorrent/riscv/bin/riscv32-unknown-elf-c++filt
+compiler.tensix-opt.notification=**SFPU development profile.** Compiles with -O3, no inlining, verbose asm. Useful for inspecting individual SFPU kernel functions.
+
+# ── Code size inspection ─────────────────────────────────────────────
+compiler.tensix-size.name=TT Tensix GCC (-Os, code size analysis)
+compiler.tensix-size.exe=/opt/tenstorrent/riscv/bin/riscv32-unknown-elf-g++
+compiler.tensix-size.semver=13.2.0
+compiler.tensix-size.options=-Os -march=rv32imafdzfh -mabi=ilp32d -fno-exceptions -fno-rtti -nostdlib
+compiler.tensix-size.objdumper=/opt/tenstorrent/riscv/bin/riscv32-unknown-elf-objdump
+compiler.tensix-size.demangler=/opt/tenstorrent/riscv/bin/riscv32-unknown-elf-c++filt
+compiler.tensix-size.notification=**Code size analysis.** Emulates LLK kernel compilation with -Os and no RTTI/exceptions — closest to production kernel builds.


### PR DESCRIPTION
## Summary
Adds Compiler Explorer configuration exposing the Tensix RISC-V cross-compiler for interactive assembly investigation.

### What's included
- 3 compiler profiles: standard GCC 13.2, SFPU inspect (-O3 + verbose), code size (-Os)
- RISC-V rv32imafdzfh target
- objdump + demangler integration

### Usage
Copy `docs/compiler-explorer-tensix.properties` to Compiler Explorer `etc/config/c/` directory.

Fixes #46364