### PR TITLE
[Bugfix] Fixing undeterministic PCC in Kimi block test

### DIFF
--- a/models/demos/deepseek_v3_d_p/reference/kimi_k2_6/modeling_deepseek.py
+++ b/models/demos/deepseek_v3_d_p/reference/kimi_k2_6/modeling_deepseek.py
@@ -387,6 +387,10 @@ class MoEGate(nn.Module):
         import torch.nn.init as init
 
         init.kaiming_uniform_(self.weight, a=math.sqrt(5))
+        if self.topk_method == "noaux_tc":
+            # Without this the bias stays uninitialized (torch.empty), making gate routing —
+            # and therefore the whole layer — non-deterministic across runs with random weights.
+            init.zeros_(self.e_score_correction_bias)
 
     def forward(self, hidden_states):
         bsz, seq_len, h = hidden_states.shape

--- a/models/demos/deepseek_v3_d_p/tests/conftest.py
+++ b/models/demos/deepseek_v3_d_p/tests/conftest.py
@@ -192,7 +192,11 @@ def download_model_config_only(variant: TestVariant, cache_dir: Path) -> Path:
         # and then looks for its relative-import siblings (e.g. tool_declaration_ts.py) by name in
         # that same dir, which fails in blobs/. Copy into a flat dir of real files so relative
         # imports resolve by name.
-        flat_dir = cache_dir / "flat_config" / variant.hf_repo_id.replace("/", "__").replace(".", "_").replace("-", "_").replace("_", "-")
+        flat_dir = (
+            cache_dir
+            / "flat_config"
+            / variant.hf_repo_id.replace("/", "__").replace(".", "_").replace("-", "_").replace("_", "-")
+        )
         shutil.copytree(model_dir, flat_dir, symlinks=False, dirs_exist_ok=True)
 
         logger.success(f"✓ Config files downloaded to: {model_dir} (flattened to: {flat_dir})")

--- a/models/demos/deepseek_v3_d_p/tests/conftest.py
+++ b/models/demos/deepseek_v3_d_p/tests/conftest.py
@@ -10,6 +10,7 @@ Automatically downloads weights from HuggingFace if not available locally.
 
 import json
 import os
+import shutil
 from functools import lru_cache
 from pathlib import Path
 
@@ -186,8 +187,16 @@ def download_model_config_only(variant: TestVariant, cache_dir: Path) -> Path:
             ignore_patterns=["*.safetensors"],  # Don't download weight files
         )
 
-        logger.success(f"✓ Config files downloaded to: {model_dir}")
-        return Path(model_dir)
+        # The HF cache stores files as symlinks into blobs/ (content-hash names). With
+        # trust_remote_code=True, transformers resolves the remote module to its blob realpath
+        # and then looks for its relative-import siblings (e.g. tool_declaration_ts.py) by name in
+        # that same dir, which fails in blobs/. Copy into a flat dir of real files so relative
+        # imports resolve by name.
+        flat_dir = cache_dir / "flat_config" / variant.hf_repo_id.replace("/", "__").replace(".", "_").replace("-", "_").replace("_", "-")
+        shutil.copytree(model_dir, flat_dir, symlinks=False, dirs_exist_ok=True)
+
+        logger.success(f"✓ Config files downloaded to: {model_dir} (flattened to: {flat_dir})")
+        return flat_dir
 
     except Exception as e:
         logger.error(f"Failed to download {variant.hf_repo_id} config: {e}")

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
@@ -51,6 +51,24 @@ from models.demos.deepseek_v3_d_p.utils.transformer_helpers import (
 _PROMPT_PATHS = {"abc_1k": ABC_1K_PATH, "prompt_5k": PROMPT_5K_PATH, "prompt_25k": PROMPT_25K_PATH}
 from tests.ttnn.utils_for_testing import comp_pcc
 
+@pytest.fixture
+def model_path(variant):
+    """Block-test-scoped override of the shared ``model_path`` fixture.
+    Uses a local pretrained checkpoint if one is already present (env var / default / shared
+    location), but never triggers a multi-GB HuggingFace download. When no local checkpoint is
+    found it returns a path without weights, so ``weight_cache_path`` resolves to None and
+    ``run_model`` falls back to random weights (see the ``use_pretrained`` gate).
+    """
+    env_path = os.getenv(variant.env_var)
+    if env_path and (Path(env_path) / "model.safetensors.index.json").exists():
+        # Keep the env path un-resolved: resolve() would follow a dot-free symlink back to a
+        # dotted real dir, which trust_remote_code cannot import. Matches get_or_download_model.
+        return Path(env_path).absolute()
+    for candidate in (variant.default_local_path, variant.shared_path):
+        if candidate is not None and (candidate / "model.safetensors.index.json").exists():
+            return candidate.resolve()
+    return (variant.default_local_path or Path(f"/nonexistent/{variant.name}")).absolute()
+
 
 @dataclass(frozen=True)
 class PrefillBlockThresholds:

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
@@ -7,8 +7,9 @@ Test for TtPrefillBlock — verifies composition of norm → MLA → residual �
 
 Validates output shapes and PCC against torch reference.
 
-Uses HF DeepseekV3Model layer as the reference: creates a model with random weights,
-extracts those weights into our TT state_dict format, and compares forward passes.
+Reference: when a pretrained checkpoint is available the layer's input/output come from a real
+forward over layers 0..layer_idx (as in test_prefill_transformer); otherwise it falls back to a
+randomly-initialized HF reference layer so the test still runs without weights.
 """
 
 import os
@@ -43,6 +44,7 @@ from models.demos.deepseek_v3_d_p.utils.transformer_helpers import (
     create_hf_model,
     extract_layer_state_dict,
     get_4d_causal_mask,
+    load_and_compute_layer_by_layer,
     tokenize_prompt_to_isl,
 )
 
@@ -81,6 +83,8 @@ def run_model(
     pcc_validation,
     input_source,
     tokenizer,
+    model_path,
+    weight_cache_path,
     is_ci_env,
     is_ci_v2_env,
     thresholds: PrefillBlockThresholds,
@@ -124,106 +128,164 @@ def run_model(
         f"input_source={input_source}"
     )
 
-    # --- Cache setup ---
-    is_dense = layer_idx < config.first_k_dense_replace
-    cache_root = os.environ.get("TT_DS_PREFILL_HOST_REF_CACHE", "/tmp")
-    balanced_tag = "balanced" if is_balanced else "non_balanced"
-    gate_tag = gate_fallback_mode.value if gate_fallback_mode else "no_gate_fallback"
-    cache_dir = Path(
-        f"{cache_root}/{variant.name}_prefill_block/"
-        f"{layer_type}_{sp_factor}x{tp_factor}mesh_{isl_total}isl_{balanced_tag}_{gate_tag}"
-    )
-    cache_dir.mkdir(parents=True, exist_ok=True)
+    # Prefer real pretrained weights when a checkpoint is available (mirrors test_prefill_transformer):
+    # load_and_compute_layer_by_layer loads the real layers 0..layer_idx, builds the shared TTNN weight
+    # cache, and returns per-layer snapshots used as the block's input/output reference. Falls back to
+    # HEAD's random-weight path below when no checkpoint is present.
+    use_pretrained = variant.supports_pretrained and weight_cache_path is not None
 
-    init_checker(cache_dir)
-    ttnn_cache_complete = TtPrefillBlock.check_cache_complete(cache_dir, layer_idx, is_dense)
-    torch_ref_cache = cache_dir / f"torch_reference_{input_source}.pt"
+    if use_pretrained:
+        is_dense = layer_idx < config.first_k_dense_replace
+        num_layers = layer_idx + 1
+        torch_output = None
+        ref_kvpe = None
+        hf_model = None
 
-    ref_cache_loadable = torch_ref_cache.exists() and (pcc_validation or input_source in _PROMPT_PATHS)
-    need_hf_model = not ttnn_cache_complete or (
-        (pcc_validation or input_source in _PROMPT_PATHS) and not ref_cache_loadable
-    )
-    logger.info(
-        f"Cache status: TTNN={ttnn_cache_complete}, ref_cache={torch_ref_cache.exists()}, "
-        f"need_hf_model={need_hf_model}"
-    )
+        cache_dir = weight_cache_path / f"{sp_factor}x{tp_factor}"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        init_checker(cache_dir)
+        state_dict = {}  # weights come from the prebuilt cache
+        experts_per_chip = variant.model_config.NUM_ROUTED_EXPERTS // (sp_factor * tp_factor)
+        ttnn_cache_complete = TtPrefillBlock.check_cache_complete(cache_dir, layer_idx, is_dense, experts_per_chip)
 
-    # --- Build HF reference model and extract weights ---
-    num_layers = layer_idx + 1
-    hf_model = None
-    if need_hf_model:
-        profiler.start("weights_creation")
-        torch.manual_seed(42)
-        hf_model = create_hf_model(variant, config, num_layers)
-        hf_sd = hf_model.state_dict()
-        state_dict = extract_layer_state_dict(variant, hf_sd, layer_idx, hf_model.layers[layer_idx])
-        profiler.end("weights_creation")
-    else:
-        logger.info("TTNN cache complete, skipping torch weight creation")
-        state_dict = {}
-
-    # --- Resolve torch_input and torch reference (single decision point for ref_cache) ---
-    torch_output = None
-    ref_kvpe = None
-    if ref_cache_loadable:
-        logger.info(f"Loading cached reference from {torch_ref_cache}")
-        profiler.start("reference_loading")
-        ref_cached = torch.load(torch_ref_cache, weights_only=True)
-        torch_input = ref_cached["torch_input"]
-        if pcc_validation:
-            torch_output = ref_cached["torch_output"]
-            ref_kvpe = ref_cached["ref_kvpe"]
-        profiler.end("reference_loading")
-    elif input_source in _PROMPT_PATHS:
-        profiler.start("tokenization")
-        prompt_path = _PROMPT_PATHS[input_source]
-        prompts = load_prompts_from_json(str(prompt_path))
-        prompt_text = prompts[0] if isinstance(prompts, list) else prompts
-        token_ids, attention_mask, tokens = tokenize_prompt_to_isl(
-            tokenizer, max_isl=isl_total, prompt_text=prompt_text
-        )
-        attention_mask = get_4d_causal_mask(attention_mask, causal_only=True)
-        profiler.end("tokenization")
-        logger.info(
-            f"Tokenized {input_source} input shape: {token_ids.shape}, first 10 tokens: {token_ids[0, :10].tolist()}"
-        )
-        with torch.no_grad():
-            torch_input = hf_model.embed_tokens(token_ids).to(torch.bfloat16)
-        logger.info(f"Embedded input shape: {torch_input.shape}")
-    else:
-        torch.manual_seed(123)
-        torch_input = torch.randn(1, isl_total, emb_dim, dtype=torch.bfloat16)
-
-    if pcc_validation and torch_output is None:
-        profiler.start("torch_reference")
-        logger.info("Running torch reference forward...")
-        position_ids = torch.arange(isl_total, dtype=torch.long).unsqueeze(0)
-        attention_mask = get_4d_causal_mask(torch.ones(1, isl_total), causal_only=True).to(torch.bfloat16)
-        ref_cache = DynamicCache()
-        with torch.no_grad():
-            layer_out = hf_model.layers[layer_idx](
-                torch_input,
+        if pcc_validation or not ttnn_cache_complete:
+            if input_source in _PROMPT_PATHS:
+                prompts = load_prompts_from_json(str(_PROMPT_PATHS[input_source]))
+                prompt_text = prompts[0] if isinstance(prompts, list) else prompts
+                token_ids, attention_mask, _ = tokenize_prompt_to_isl(
+                    tokenizer, max_isl=isl_total, prompt_text=prompt_text
+                )
+            else:
+                token_ids = torch.randint(0, config.vocab_size, (1, isl_total), dtype=torch.int64)
+                attention_mask = torch.ones(1, isl_total, dtype=torch.int64)
+            result = load_and_compute_layer_by_layer(
+                variant=variant,
+                model_path=model_path,
+                config=config,
+                num_layers=num_layers,
+                token_ids=token_ids,
                 attention_mask=attention_mask,
-                position_ids=position_ids,
-                past_key_value=ref_cache,
-                use_cache=True,
+                compute_reference=pcc_validation,
+                build_ttnn_cache=not ttnn_cache_complete,
+                weight_cache_path=cache_dir,
+                mesh_device=mesh_device,
+                seq_len=isl_total,
+                num_links=num_links,
+                topology=topology,
+                sp_axis=sp_axis,
+                tp_axis=tp_axis,
+                gate_fallback_mode=gate_fallback_mode,
             )
-            torch_output = layer_out[0]
-        logger.info(f"Torch reference output shape: {torch_output.shape}")
-        if ref_cache is not None:
-            ref_kvpe = hf_cache_layer_kv(ref_cache, layer_idx)[0]
-            logger.info(f"Reference KVPE shape: {ref_kvpe.shape}")
-        profiler.end("torch_reference")
+            ttnn_cache_complete = True
+            if pcc_validation:
+                # snapshots are [embed, layer_0_out, ...]: input to layer L is snapshot[L], output snapshot[L+1].
+                torch_input = result.ref_snapshots[layer_idx].to(torch.bfloat16)
+                torch_output = result.ref_snapshots[layer_idx + 1]
+                ref_kvpe = result.ref_kvpe_list[layer_idx]
+        if not pcc_validation:
+            torch.manual_seed(123)
+            torch_input = torch.randn(1, isl_total, emb_dim, dtype=torch.bfloat16)
+    else:
+        # --- Cache setup ---
+        is_dense = layer_idx < config.first_k_dense_replace
+        cache_root = os.environ.get("TT_DS_PREFILL_HOST_REF_CACHE", "/tmp")
+        balanced_tag = "balanced" if is_balanced else "non_balanced"
+        gate_tag = gate_fallback_mode.value if gate_fallback_mode else "no_gate_fallback"
+        cache_dir = Path(
+            f"{cache_root}/{variant.name}_prefill_block/"
+            f"{layer_type}_{sp_factor}x{tp_factor}mesh_{isl_total}isl_{balanced_tag}_{gate_tag}"
+        )
+        cache_dir.mkdir(parents=True, exist_ok=True)
 
-        logger.info(f"Saving reference to {torch_ref_cache}")
-        torch.save(
-            {"torch_input": torch_input, "torch_output": torch_output, "ref_kvpe": ref_kvpe},
-            torch_ref_cache,
+        init_checker(cache_dir)
+        ttnn_cache_complete = TtPrefillBlock.check_cache_complete(cache_dir, layer_idx, is_dense)
+        torch_ref_cache = cache_dir / f"torch_reference_{input_source}.pt"
+
+        ref_cache_loadable = torch_ref_cache.exists() and (pcc_validation or input_source in _PROMPT_PATHS)
+        need_hf_model = not ttnn_cache_complete or (
+            (pcc_validation or input_source in _PROMPT_PATHS) and not ref_cache_loadable
+        )
+        logger.info(
+            f"Cache status: TTNN={ttnn_cache_complete}, ref_cache={torch_ref_cache.exists()}, "
+            f"need_hf_model={need_hf_model}"
         )
 
-    # Free HF model early
-    if hf_model is not None:
-        del hf_model
+        # --- Build HF reference model and extract weights ---
+        num_layers = layer_idx + 1
+        hf_model = None
+        if need_hf_model:
+            profiler.start("weights_creation")
+            torch.manual_seed(42)
+            hf_model = create_hf_model(variant, config, num_layers)
+            hf_sd = hf_model.state_dict()
+            state_dict = extract_layer_state_dict(variant, hf_sd, layer_idx, hf_model.layers[layer_idx])
+            profiler.end("weights_creation")
+        else:
+            logger.info("TTNN cache complete, skipping torch weight creation")
+            state_dict = {}
+
+        # --- Resolve torch_input and torch reference (single decision point for ref_cache) ---
+        torch_output = None
+        ref_kvpe = None
+        if ref_cache_loadable:
+            logger.info(f"Loading cached reference from {torch_ref_cache}")
+            profiler.start("reference_loading")
+            ref_cached = torch.load(torch_ref_cache, weights_only=True)
+            torch_input = ref_cached["torch_input"]
+            if pcc_validation:
+                torch_output = ref_cached["torch_output"]
+                ref_kvpe = ref_cached["ref_kvpe"]
+            profiler.end("reference_loading")
+        elif input_source in _PROMPT_PATHS:
+            profiler.start("tokenization")
+            prompt_path = _PROMPT_PATHS[input_source]
+            prompts = load_prompts_from_json(str(prompt_path))
+            prompt_text = prompts[0] if isinstance(prompts, list) else prompts
+            token_ids, attention_mask, tokens = tokenize_prompt_to_isl(
+                tokenizer, max_isl=isl_total, prompt_text=prompt_text
+            )
+            attention_mask = get_4d_causal_mask(attention_mask, causal_only=True)
+            profiler.end("tokenization")
+            logger.info(
+                f"Tokenized {input_source} input shape: {token_ids.shape}, first 10 tokens: {token_ids[0, :10].tolist()}"
+            )
+            with torch.no_grad():
+                torch_input = hf_model.embed_tokens(token_ids).to(torch.bfloat16)
+            logger.info(f"Embedded input shape: {torch_input.shape}")
+        else:
+            torch.manual_seed(123)
+            torch_input = torch.randn(1, isl_total, emb_dim, dtype=torch.bfloat16)
+
+        if pcc_validation and torch_output is None:
+            profiler.start("torch_reference")
+            logger.info("Running torch reference forward...")
+            position_ids = torch.arange(isl_total, dtype=torch.long).unsqueeze(0)
+            attention_mask = get_4d_causal_mask(torch.ones(1, isl_total), causal_only=True).to(torch.bfloat16)
+            ref_cache = DynamicCache()
+            with torch.no_grad():
+                layer_out = hf_model.layers[layer_idx](
+                    torch_input,
+                    attention_mask=attention_mask,
+                    position_ids=position_ids,
+                    past_key_value=ref_cache,
+                    use_cache=True,
+                )
+                torch_output = layer_out[0]
+            logger.info(f"Torch reference output shape: {torch_output.shape}")
+            if ref_cache is not None:
+                ref_kvpe = hf_cache_layer_kv(ref_cache, layer_idx)[0]
+                logger.info(f"Reference KVPE shape: {ref_kvpe.shape}")
+            profiler.end("torch_reference")
+
+            logger.info(f"Saving reference to {torch_ref_cache}")
+            torch.save(
+                {"torch_input": torch_input, "torch_output": torch_output, "ref_kvpe": ref_kvpe},
+                torch_ref_cache,
+            )
+
+        # Free HF model early
+        if hf_model is not None:
+            del hf_model
 
     # --- Build TTNN cache if needed ---
     if not ttnn_cache_complete:
@@ -504,6 +566,8 @@ def test_ds_prefill_block(
     pcc_validation,
     input_source,
     tokenizer,
+    model_path,
+    weight_cache_path,
     is_ci_env,
     is_ci_v2_env,
     determinism_check,
@@ -524,6 +588,8 @@ def test_ds_prefill_block(
         pcc_validation,
         input_source,
         tokenizer,
+        model_path,
+        weight_cache_path,
         is_ci_env,
         is_ci_v2_env,
         determinism_check=determinism_check,
@@ -587,6 +653,8 @@ def test_kimi_prefill_block(
     pcc_validation,
     input_source,
     tokenizer,
+    model_path,
+    weight_cache_path,
     is_ci_env,
     is_ci_v2_env,
     determinism_check,
@@ -607,6 +675,8 @@ def test_kimi_prefill_block(
         pcc_validation,
         input_source,
         tokenizer,
+        model_path,
+        weight_cache_path,
         is_ci_env,
         is_ci_v2_env,
         determinism_check=determinism_check,

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
@@ -51,6 +51,7 @@ from models.demos.deepseek_v3_d_p.utils.transformer_helpers import (
 _PROMPT_PATHS = {"abc_1k": ABC_1K_PATH, "prompt_5k": PROMPT_5K_PATH, "prompt_25k": PROMPT_25K_PATH}
 from tests.ttnn.utils_for_testing import comp_pcc
 
+
 @pytest.fixture
 def model_path(variant):
     """Block-test-scoped override of the shared ``model_path`` fixture.


### PR DESCRIPTION
### Summary

Kimi prefill block tests used random weights initialized by default in the Torch model. The problem was that the gate bias tensors are by default initialized with torch.empty which not only gave gibberish values causing low PCC but also is not subject to the RNG seed and caused the undeterminizm. 

### Fix

This pr introduces the use of real weights in the Block test and ensures the gate bias is initialized with torch.zeros by default if real weights are not found.


- [![(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=ddjekic/moe_pcc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:ddjekic/kimi_block_debug)

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ddjekic/kimi_block_debug)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ddjekic/kimi_block_debug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ddjekic/kimi_block_debug)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ddjekic/kimi_block_debug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ddjekic/kimi_block_debug)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ddjekic/kimi_block_debug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ddjekic/kimi_block_debug)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ddjekic/kimi_block_debug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ddjekic/kimi_block_debug)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ddjekic/kimi_block_debug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ddjekic/kimi_block_debug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ddjekic/kimi_block_debug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ddjekic/kimi_block_debug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ddjekic/kimi_block_debug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ddjekic/kimi_block_debug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ddjekic/kimi_block_debug)