### PR TITLE
[DCAMP-886] add --num-packets to adjust the length of run_fabric_tests.sh runs

### DIFF
--- a/tools/scaleout/exabox/run_fabric_tests.sh
+++ b/tools/scaleout/exabox/run_fabric_tests.sh
@@ -53,6 +53,13 @@ Optional:
                                         (4x8z/2x4x4z/4x32z/8x4x4z default: test_fabric_multi_mesh_sanity_common.yaml, whose
                                          neighbor_exchange/all_to_all patterns route across mesh boundaries / Z links)
     --filter <pattern>                  Filter pattern passed to test_tt_fabric --filter
+    --num-packets <N>                   Number of packets each sender sends (test_tt_fabric --num-packets).
+                                        This is the knob to shorten a run: the heavy all_to_all tests
+                                        (the bulk of the runtime) scale ~linearly with it, and every
+                                        sender stays active so all cables are still exercised. The script
+                                        reads the config's baseline counts and prints what fraction of the
+                                        default per-sender packet volume you're running. e.g. 1000 for a
+                                        quick run.
     --mpi-if <interface>                Network interface for MPI TCP transport
                                         (auto-detected if not specified)
     --mpi-args <args>                   Extra arguments passed directly to mpirun (quoted string)
@@ -100,6 +107,7 @@ TEST_CONFIG_EXPLICIT=false
 # datamover buffer-index assert), so it must not be the default here.
 TEST_CONFIG_Z="tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_multi_mesh_sanity_common.yaml"
 FILTER=""
+NUM_PACKETS=""
 MPI_IF=""
 MPI_IF_EXPLICIT=false
 MPI_EXTRA_ARGS=()
@@ -178,6 +186,18 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             FILTER="$2"
+            shift 2
+            ;;
+        --num-packets)
+            if [[ -z "$2" ]] || [[ "$2" == --* ]]; then
+                echo "Error: --num-packets requires a non-empty value"
+                exit 1
+            fi
+            if [[ ! "$2" =~ ^[1-9][0-9]*$ ]]; then
+                echo "Error: --num-packets must be a positive integer (got '$2')"
+                exit 1
+            fi
+            NUM_PACKETS="$2"
             shift 2
             ;;
         --mpi-if)
@@ -406,6 +426,22 @@ echo "Test config: $TEST_CONFIG"
 if [[ -n "$FILTER" ]]; then
     echo "Filter: $FILTER"
 fi
+if [[ -n "$NUM_PACKETS" ]]; then
+    echo "Num packets per sender: $NUM_PACKETS"
+    # Read the config's baseline num_packets so the operator sees how much shorter
+    # this run is. Counts are per-sender; sender/iteration counts are unchanged, so
+    # runtime scales ~linearly with the per-sender packet volume.
+    if [[ -f "$TEST_CONFIG" ]]; then
+        mapfile -t _baselines < <(grep -oE 'num_packets:[[:space:]]*[0-9]+' "$TEST_CONFIG" | grep -oE '[0-9]+$')
+        if [[ ${#_baselines[@]} -gt 0 ]]; then
+            _baseline_sum=0
+            for _b in "${_baselines[@]}"; do _baseline_sum=$((_baseline_sum + _b)); done
+            _new_sum=$((NUM_PACKETS * ${#_baselines[@]}))
+            _pct=$(awk -v n="$_new_sum" -v o="$_baseline_sum" 'BEGIN { if (o > 0) printf "%.1f", 100.0 * n / o; else printf "n/a" }')
+            echo "  -> ~${_pct}% of the default per-sender packet volume across ${#_baselines[@]} pattern group(s) (baseline sum ${_baseline_sum} -> ${_new_sum})"
+        fi
+    fi
+fi
 echo "MPI interface: $MPI_IF"
 if [[ "${#MPI_EXTRA_ARGS[@]}" -gt 0 ]]; then
     echo "MPI extra args: ${MPI_EXTRA_ARGS[*]}"
@@ -423,6 +459,9 @@ if [[ "$TEST_BINARY" == *test_tt_fabric ]]; then
 fi
 if [[ -n "$FILTER" ]]; then
     EXTRA_BINARY_ARGS+=(--filter "$FILTER")
+fi
+if [[ -n "$NUM_PACKETS" ]]; then
+    EXTRA_BINARY_ARGS+=(--num-packets "$NUM_PACKETS")
 fi
 
 # Non-Z multi-host configs are a single mesh (TT_MESH_ID=0) that spans several


### PR DESCRIPTION
### PR Category
Feature

### Summary
Quick convenience for operators to tune a fabric run on the fly without editing or creating YAML files. Adds `--num-packets <N>` to `run_fabric_tests.sh`, which forwards the existing `test_tt_fabric --num-packets` to cap the per-sender packet count and shorten a run. The script reads the config's baseline and prints what fraction of the default volume you're running (e.g. `1000 -> ~5.0% across 4 pattern group(s)`).

### Notes for reviewers
Shell-only; no binary/product changes. `--num-packets` is the existing flag in test_tt_fabric, this just exposes it and reports the ratio.

Sample output:
```
Num packets per sender: 1000
  -> ~5.0% of the default per-sender packet volume across 4 pattern group(s) (baseline sum 80000 -> 4000)
...
```

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/fabric_packet_constraining)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/fabric_packet_constraining)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jpanasiuk/fabric_packet_constraining)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jpanasiuk/fabric_packet_constraining)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jpanasiuk/fabric_packet_constraining)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jpanasiuk/fabric_packet_constraining)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/fabric_packet_constraining)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/fabric_packet_constraining)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jpanasiuk/fabric_packet_constraining)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jpanasiuk/fabric_packet_constraining)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/fabric_packet_constraining)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/fabric_packet_constraining)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/fabric_packet_constraining)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/fabric_packet_constraining)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/fabric_packet_constraining)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/fabric_packet_constraining)