### PR TITLE
#45821: migrate AllGatherMinimalMatmulAsyncOp to default program-cache hash

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_device_operation.cpp
@@ -394,33 +394,6 @@ AllGatherMinimalMatmulAsyncOp::tensor_return_value_t AllGatherMinimalMatmulAsync
     return output_tensors;
 }
 
-tt::tt_metal::operation::Hash AllGatherMinimalMatmulAsyncOp::compute_program_hash(
-    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-    log_trace(tt::LogOp, "AllGatherMinimalMatmulAsyncOp::compute_program_hash is called");
-
-    auto program_factory = select_program_factory(attributes, tensor_args);
-
-    return tt::tt_metal::operation::hash_operation<AllGatherMinimalMatmulAsyncOp>(
-        attributes.num_links,
-        attributes.ring_size,
-        attributes.output_mem_config,
-        attributes.topology,
-        attributes.cluster_axis,
-        attributes.force_transpose,
-        attributes.num_workers_per_link,
-        attributes.num_buffers_per_channel,
-        attributes.config.value().M_block_size,
-        attributes.config.value().K_block_size,
-        attributes.config.value().N_block_size,
-        attributes.config.value().subblock_h,
-        attributes.config.value().subblock_w,
-        attributes.fsdp_cluster_axis,
-        attributes.fsdp_ring_size,
-        attributes.using_persistent_weight_buffer,
-        tensor_args,
-        program_factory.index());
-}
-
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_device_operation.hpp
@@ -36,8 +36,6 @@ struct AllGatherMinimalMatmulAsyncOp {
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static tt::tt_metal::operation::Hash compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_device_operation_types.hpp
@@ -91,12 +91,7 @@ struct AllGatherMinimalMatmulAsyncParams {
         using_persistent_weight_buffer(using_persistent_weight_buffer),
         fsdp_topology(fsdp_topology) {}
 
-    // Structural fields that affect program-cache key. Mirrors the set the former custom
-    // compute_program_hash hashed: runtime-only fields (GlobalSemaphores, persistent-buffer
-    // presence flags, dtype/activation only used for runtime args) are intentionally excluded.
-    // `config` covers the matmul block/subblock sizes; `output_mem_config` is the output memory
-    // layout. The tensor_args (input/weight/optional tensors) are hashed structurally by the
-    // default reflection path.
+    // Structural fields that affect program-cache key.
     static constexpr auto attribute_names = std::make_tuple(
         "num_links",
         "ring_size",

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_device_operation_types.hpp
@@ -91,44 +91,40 @@ struct AllGatherMinimalMatmulAsyncParams {
         using_persistent_weight_buffer(using_persistent_weight_buffer),
         fsdp_topology(fsdp_topology) {}
 
+    // Structural fields that affect program-cache key. Mirrors the set the former custom
+    // compute_program_hash hashed: runtime-only fields (GlobalSemaphores, persistent-buffer
+    // presence flags, dtype/activation only used for runtime args) are intentionally excluded.
+    // `config` covers the matmul block/subblock sizes; `output_mem_config` is the output memory
+    // layout. The tensor_args (input/weight/optional tensors) are hashed structurally by the
+    // default reflection path.
     static constexpr auto attribute_names = std::make_tuple(
         "num_links",
         "ring_size",
+        "output_mem_config",
         "topology",
-        "barrier_semaphore",
-        "using_persistent_buffers",
         "cluster_axis",
-        "semaphore",
         "force_transpose",
         "num_workers_per_link",
         "num_buffers_per_channel",
-        "chunks",
-        "dim",
+        "config",
         "fsdp_cluster_axis",
         "fsdp_ring_size",
-        "fsdp_semaphore",
-        "using_persistent_weight_buffer",
-        "fsdp_topology");
+        "using_persistent_weight_buffer");
 
     auto attribute_values() const {
         return std::forward_as_tuple(
             this->num_links,
             this->ring_size,
+            this->output_mem_config,
             this->topology,
-            this->barrier_semaphore,
-            this->using_persistent_buffers,
             this->cluster_axis,
-            this->semaphore,
             this->force_transpose,
             this->num_workers_per_link,
             this->num_buffers_per_channel,
-            this->chunks,
-            this->dim,
+            this->config,
             this->fsdp_cluster_axis,
             this->fsdp_ring_size,
-            this->fsdp_semaphore,
-            this->using_persistent_weight_buffer,
-            this->fsdp_topology);
+            this->using_persistent_weight_buffer);
     }
 };
 


### PR DESCRIPTION
### PR Category
hash calculation unification for operation AllGatherMinimalMatmulAsyncOp

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for AllGatherMinimalMatmulAsyncOp

### Notes for reviewers
NA

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_AllGatherMinimalMatmulAsyncOp)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_AllGatherMinimalMatmulAsyncOp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_AllGatherMinimalMatmulAsyncOp)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_AllGatherMinimalMatmulAsyncOp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_AllGatherMinimalMatmulAsyncOp)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_AllGatherMinimalMatmulAsyncOp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_AllGatherMinimalMatmulAsyncOp)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_AllGatherMinimalMatmulAsyncOp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_AllGatherMinimalMatmulAsyncOp)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_AllGatherMinimalMatmulAsyncOp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_AllGatherMinimalMatmulAsyncOp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_AllGatherMinimalMatmulAsyncOp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_AllGatherMinimalMatmulAsyncOp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_AllGatherMinimalMatmulAsyncOp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_AllGatherMinimalMatmulAsyncOp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_AllGatherMinimalMatmulAsyncOp)
