### PR TITLE
mock allocator: output AllocationRecords + MockAllocatorState::with_allocations

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_query_op_constraints_mock_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_query_op_constraints_mock_device.cpp
@@ -481,6 +481,87 @@ TEST_F(QueryOpConstraintsMockDevice, OptionalStateWithValueMatchesStatefulCore) 
         via_core.new_state.total_allocated_size(BufferType::L1));
 }
 
+TEST_F(QueryOpConstraintsMockDevice, WithAllocationsReproducesQueryPlacement) {
+    const auto spec = ttnn::TensorSpec(
+        ttnn::Shape(Array4D{1, 1, 64, 128}),
+        TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), ttnn::L1_MEMORY_CONFIG));
+    auto relu = [](auto&&... args) { return ttnn::relu(std::forward<decltype(args)>(args)...); };
+    const auto mem_cfg = spec.tensor_layout().get_memory_config();
+
+    auto empty_template = experimental::extract_mock_allocator_state(*mock_device_);
+    auto out =
+        ttnn::graph::query_op_constraints_with_initial_state(relu, mock_device_.get(), empty_template, spec, mem_cfg);
+    ASSERT_EQ(out.response.status, ttnn::graph::ExecutionStatus::Success)
+        << "Error: " << out.response.error_message.value_or("none");
+    ASSERT_EQ(out.output_allocations.size(), 1u);
+    EXPECT_EQ(out.output_allocations[0].buffer_type, BufferType::L1);
+    EXPECT_GT(out.output_allocations[0].size_per_bank, 0u);
+
+    // Rebuilding the state from the output's record must reproduce the allocator's real placement.
+    auto built = empty_template.with_allocations(out.output_allocations);
+    EXPECT_EQ(built.total_allocated_size(BufferType::L1), out.new_state.total_allocated_size(BufferType::L1));
+    EXPECT_EQ(built.lowest_occupied(BufferType::L1), out.new_state.lowest_occupied(BufferType::L1));
+}
+
+TEST_F(QueryOpConstraintsMockDevice, WithAllocationsDropRecordFreesSpace) {
+    const auto spec = ttnn::TensorSpec(
+        ttnn::Shape(Array4D{1, 1, 64, 128}),
+        TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), ttnn::L1_MEMORY_CONFIG));
+    auto relu = [](auto&&... args) { return ttnn::relu(std::forward<decltype(args)>(args)...); };
+    const auto mem_cfg = spec.tensor_layout().get_memory_config();
+
+    auto empty_template = experimental::extract_mock_allocator_state(*mock_device_);
+
+    // Collect two live records by threading op 2 on op 1's state.
+    auto out1 =
+        ttnn::graph::query_op_constraints_with_initial_state(relu, mock_device_.get(), empty_template, spec, mem_cfg);
+    ASSERT_EQ(out1.response.status, ttnn::graph::ExecutionStatus::Success);
+    auto out2 =
+        ttnn::graph::query_op_constraints_with_initial_state(relu, mock_device_.get(), out1.new_state, spec, mem_cfg);
+    ASSERT_EQ(out2.response.status, ttnn::graph::ExecutionStatus::Success);
+
+    const auto rec1 = out1.output_allocations[0];
+    const auto rec2 = out2.output_allocations[0];
+
+    auto both = empty_template.with_allocations({rec1, rec2});
+    auto dropped = empty_template.with_allocations({rec2});  // "evict" op 1 = drop its record
+
+    EXPECT_EQ(both.total_allocated_size(BufferType::L1), rec1.size_per_bank + rec2.size_per_bank);
+    EXPECT_EQ(dropped.total_allocated_size(BufferType::L1), rec2.size_per_bank);
+    EXPECT_FALSE(dropped.is_empty(BufferType::L1));
+}
+
+TEST_F(QueryOpConstraintsMockDevice, WithAllocationsFreedSlotIsReused) {
+    // Proves build-from-records ≡ regular dealloc placement: after dropping a record, a fresh
+    // allocation reuses the freed slot exactly as it would on a real device.
+    const auto spec = ttnn::TensorSpec(
+        ttnn::Shape(Array4D{1, 1, 64, 128}),
+        TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), ttnn::L1_MEMORY_CONFIG));
+    auto relu = [](auto&&... args) { return ttnn::relu(std::forward<decltype(args)>(args)...); };
+    const auto mem_cfg = spec.tensor_layout().get_memory_config();
+
+    auto empty_template = experimental::extract_mock_allocator_state(*mock_device_);
+
+    auto out1 =
+        ttnn::graph::query_op_constraints_with_initial_state(relu, mock_device_.get(), empty_template, spec, mem_cfg);
+    ASSERT_EQ(out1.response.status, ttnn::graph::ExecutionStatus::Success);
+    auto out2 =
+        ttnn::graph::query_op_constraints_with_initial_state(relu, mock_device_.get(), out1.new_state, spec, mem_cfg);
+    ASSERT_EQ(out2.response.status, ttnn::graph::ExecutionStatus::Success);
+    const auto rec1 = out1.output_allocations[0];
+    const auto rec2 = out2.output_allocations[0];
+
+    // Drop rec1, then run a new op against the rebuilt state: its output reuses rec1's freed slot.
+    auto after_drop = empty_template.with_allocations({rec2});
+    auto out3 =
+        ttnn::graph::query_op_constraints_with_initial_state(relu, mock_device_.get(), after_drop, spec, mem_cfg);
+    ASSERT_EQ(out3.response.status, ttnn::graph::ExecutionStatus::Success);
+    const auto rec3 = out3.output_allocations[0];
+
+    EXPECT_EQ(rec3.address, rec1.address) << "freed slot should be reused";
+    EXPECT_EQ(rec3.size_per_bank, rec1.size_per_bank);
+}
+
 TEST_F(QueryOpConstraintsMockDevice, WithInitialStateReportsOomAsError) {
     // An L1 output far larger than total L1 cannot be allocated in Phase 2 -> Error.
     const auto huge = ttnn::TensorSpec(

--- a/tt_metal/api/tt-metalium/experimental/mock_device/mock_allocator.hpp
+++ b/tt_metal/api/tt-metalium/experimental/mock_device/mock_allocator.hpp
@@ -21,6 +21,7 @@
 
 #include <memory>
 #include <optional>
+#include <vector>
 
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/hal_types.hpp>
@@ -36,6 +37,13 @@ namespace tt::tt_metal::experimental {
 
 class MockAllocator;
 class MockAllocatorState;
+
+// Identifies a single allocation within a MockAllocatorState.
+struct AllocationRecord {
+    BufferType buffer_type = BufferType::L1;
+    DeviceAddr address = 0;
+    DeviceAddr size_per_bank = 0;
+};
 
 // Returns MockAllocator* if device is in mock mode, nullptr otherwise.
 MockAllocator* get_mock_allocator(distributed::MeshDevice& device);
@@ -55,6 +63,9 @@ public:
     DeviceAddr total_allocated_size(BufferType buffer_type) const;
     bool is_empty(BufferType buffer_type) const;
     std::optional<DeviceAddr> lowest_occupied(BufferType buffer_type) const;
+
+    // Return a state with this state's allocator (bank) config but its allocations replaced by `live`.
+    MockAllocatorState with_allocations(const std::vector<AllocationRecord>& live) const;
 
 private:
     struct Impl;

--- a/tt_metal/impl/device/mock_allocator.cpp
+++ b/tt_metal/impl/device/mock_allocator.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <enchantum/enchantum.hpp>
+
 #include <tt-metalium/experimental/mock_device/mock_allocator.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <tt_stl/assert.hpp>
@@ -79,6 +81,33 @@ void override_mock_allocator_state(distributed::MeshDevice& device, const MockAl
     MockAllocator* allocator = get_mock_allocator(device);
     TT_FATAL(allocator != nullptr, "override_mock_allocator_state requires a mock device");
     allocator->override_state(state.impl_->state);
+}
+
+MockAllocatorState MockAllocatorState::with_allocations(const std::vector<AllocationRecord>& live) const {
+    // Replace regions with the live records' intervals.
+    auto states = impl_->state.get_states_per_buffer_type();  // copy: config kept, regions reset below
+    for (auto& [buffer_type, bts] : states) {
+        bts.allocated_regions.clear();
+        bts.region_source_allocator_ids.clear();
+    }
+
+    for (const auto& record : live) {
+        auto it = states.find(record.buffer_type);
+        TT_FATAL(
+            it != states.end(),
+            "with_allocations: state has no bank config for buffer type {}; the template must come from a device "
+            "extract (which always carries DRAM/L1/L1_SMALL/TRACE)",
+            enchantum::to_string(record.buffer_type));
+        it->second.allocated_regions.emplace_back(record.address, record.address + record.size_per_bank);
+    }
+
+    for (auto& [buffer_type, bts] : states) {
+        bts.normalize();  // canonical form: sort + coalesce, matching a real extract_state
+    }
+
+    MockAllocatorState result;
+    result.impl_->state = AllocatorState(std::move(states), /*all_allocated_buffers=*/{});
+    return result;
 }
 
 }  // namespace tt::tt_metal::experimental

--- a/ttnn/api/ttnn/graph/graph_query_op_constraints.hpp
+++ b/ttnn/api/ttnn/graph/graph_query_op_constraints.hpp
@@ -142,9 +142,13 @@ struct ConstraintQueryResponse {
 
 // Result of the pure, state-threading query. `new_state` is the allocator state
 // after the op's outputs are allocated on top of the caller-supplied initial state.
+// `output_allocations` records each output buffer's placement (one per output). The caller keeps
+// the records of still-live tensors and rebuilds the state via MockAllocatorState::with_allocations;
+// "evicting" a tensor is just dropping its record. Empty on the stateless path (outputs not allocated).
 struct QueryOutput {
     ConstraintQueryResponse response;
     tt::tt_metal::experimental::MockAllocatorState new_state;
+    std::vector<tt::tt_metal::experimental::AllocationRecord> output_allocations;
 };
 
 namespace detail {
@@ -297,9 +301,17 @@ QueryOutput query_op_constraints_with_initial_state(
     try {
         auto outputs = detail::extract_output_tensors(detail::invoke_op(op, transformed_args));
         auto op_trace = phase2.end_graph_capture();
-        // Snapshot while the output buffers are alive (after they are allocated, before they drop).
+        // Snapshot + record output placements while the output buffers are alive (after they are
+        // allocated, before they drop). Each record locates an output in new_state for later eviction.
         auto new_state = tt::tt_metal::experimental::extract_mock_allocator_state(*device);
-        return QueryOutput{detail::build_success_response(op_trace, outputs), std::move(new_state)};
+        std::vector<tt::tt_metal::experimental::AllocationRecord> output_allocations;
+        output_allocations.reserve(outputs.size());
+        for (const auto& output : outputs) {
+            const auto& buffer = output.buffer();
+            output_allocations.push_back({buffer->buffer_type(), buffer->address(), buffer->aligned_size_per_bank()});
+        }
+        return QueryOutput{
+            detail::build_success_response(op_trace, outputs), std::move(new_state), std::move(output_allocations)};
     } catch (const std::exception& e) {
         log_debug(tt::LogOp, "Error during stateful graph capture: {}", e.what());
         return QueryOutput{


### PR DESCRIPTION
Follow-up to #46198. Adds the metal-side pieces for op-by-op L1 planning where the caller (tt-mlir's op model) owns the live set of allocations and rebuilds allocator state from it, instead of threading/evicting incrementally.

- **`experimental::AllocationRecord {buffer_type, address, size_per_bank}`** — opaque handle to a single allocation (`size_per_bank` is the allocator's real padded per-bank footprint).
- **`QueryOutput::output_allocations`** — the stateful query returns one record per output buffer, captured while outputs are alive in Phase 2.
- **`MockAllocatorState::with_allocations(live)`** — pure, no device. Returns a state with this state's bank config but allocations replaced by `live` (its own regions are ignored; it's only a config donor). The caller obtains a new state by dropping the records of evicted tensors and rebuilding — "evicting" is just dropping a record.

Equivalent, for future allocation decisions, to reaching the same live set via real allocation/deallocation: the BestFit allocator's placement is a pure function of the free regions, so build-from-records reproduces real placement/fragmentation/OOM.

**Tests** (`unit_tests_ttnn_mock_allocator`): `with_allocations` reproduces the real query placement; dropping a record frees exactly its space; a freed slot is reused at the same address by a subsequent allocation (build-from-records == real dealloc placement).

No in-repo consumer yet — this is the metal-side API for the upcoming tt-mlir L1-planning integration.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rpavlovic/mock-allocator-records)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rpavlovic/mock-allocator-records)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rpavlovic/mock-allocator-records)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rpavlovic/mock-allocator-records)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rpavlovic/mock-allocator-records)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rpavlovic/mock-allocator-records)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rpavlovic/mock-allocator-records)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rpavlovic/mock-allocator-records)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rpavlovic/mock-allocator-records)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rpavlovic/mock-allocator-records)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rpavlovic/mock-allocator-records)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rpavlovic/mock-allocator-records)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rpavlovic/mock-allocator-records)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rpavlovic/mock-allocator-records)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rpavlovic/mock-allocator-records)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rpavlovic/mock-allocator-records)