### PR TITLE
ttnn aligned dest_acc and unpack_to_dest generation in typecast test

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_typecast.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_typecast.py
@@ -112,22 +112,32 @@ def _whole_number_float_spec(high: int) -> StimuliSpec:
     return StimuliSpec(distribution=dist, seed=0)
 
 
+def _preserve_fp32_precision(formats: InputOutputFormat) -> bool:
+    """preserve_fp32_precision exactly as ttnn.typecast computes it.
+
+    ttnn uses this single flag for two things: it forces fp32 dest acc (see
+    _production_dest_acc) and it selects UnpackToDestFp32 in the program
+    factories, so the test reuses it for both.
+    """
+    in_fmt = formats.input_format
+    out_fmt = formats.output_format
+    # bf16 / block-float inputs that promote to 32-bit Dest when packed to UInt8.
+    bf_family = (DataFormat.Float16_b, DataFormat.Bfp8_b, DataFormat.Bfp4_b)
+    return (
+        in_fmt == DataFormat.Float32
+        or (out_fmt == DataFormat.UInt8 and in_fmt in bf_family)
+        or (in_fmt == DataFormat.UInt16 and out_fmt == DataFormat.UInt8)
+        or (in_fmt == DataFormat.UInt8 and out_fmt != DataFormat.Float16_b)
+    )
+
+
 def _production_dest_acc(formats: InputOutputFormat) -> list[DestAccumulation]:
     """Pick dest_acc the way ttnn.typecast does."""
 
     in_fmt = formats.input_format
     out_fmt = formats.output_format
-
-    # bf16 / block-float inputs that promote to 32-bit Dest when packed to UInt8.
-    _bf_family = (DataFormat.Float16_b, DataFormat.Bfp8_b, DataFormat.Bfp4_b)
-    preserve_fp32_precision = (
-        in_fmt == DataFormat.Float32
-        or (out_fmt == DataFormat.UInt8 and in_fmt in _bf_family)
-        or (in_fmt == DataFormat.UInt16 and out_fmt == DataFormat.UInt8)
-        or (in_fmt == DataFormat.UInt8 and out_fmt != DataFormat.Float16_b)
-    )
     fp32_dest_acc_en = (
-        preserve_fp32_precision
+        _preserve_fp32_precision(formats)
         or out_fmt in (DataFormat.UInt32, DataFormat.Int32, DataFormat.Float32)
         or in_fmt in (DataFormat.UInt32, DataFormat.Int32)
         or out_fmt == DataFormat.Fp8_e4m3
@@ -182,9 +192,16 @@ def test_eltwise_unary_typecast(
         input_dimensions,
     )
 
-    # 32-bit inputs are unpacked straight into Dest (no Src-register staging).
-    unpack_to_dest = (
-        formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
+    # Unpack straight into Dest when either:
+    #  * the input is 32-bit -- the unpacker has no SrcA/SrcB path for
+    #    Int32/UInt32/Float32, so is_unpacker_format_conversion_supported_dest
+    #    (cunpack_common.h) asserts unpack_to_dest for them; or
+    #  * production would, i.e. preserve_fp32_precision drives UnpackToDestFp32 in
+    #    the ttnn program factories.
+    # For non-32-bit inputs the unpack MOP still gates on is_32bit_input(), so the
+    # flag only actually changes the datapath for genuine 32-bit inputs.
+    unpack_to_dest = formats.input_format.is_32_bit() or _preserve_fp32_precision(
+        formats
     )
 
     num_blocks, num_tiles_in_block = get_num_blocks_and_num_tiles_in_block(

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_typecast.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_typecast.py
@@ -112,35 +112,33 @@ def _whole_number_float_spec(high: int) -> StimuliSpec:
     return StimuliSpec(distribution=dist, seed=0)
 
 
-def _valid_dest_acc_options(formats: InputOutputFormat) -> list[DestAccumulation]:
-    """Dest-accumulation modes worth exercising for a given format pair.
+def _production_dest_acc(formats: InputOutputFormat) -> list[DestAccumulation]:
+    """Pick dest_acc the way ttnn.typecast does."""
 
-    32-bit Dest is mandatory whenever the SFPU integer datapath is used: the
-    SFPU typecast computes the result into Dest before the packer reads it, and
-    the integer datapath always operates on 32-bit Dest data. So any integer
-    input or output (not just the 32-bit ones) requires ``dest_acc=Yes`` —
-    otherwise pack_src stays 16-bit and ``is_packer_to_L1_conversion_supported``
-    rejects the pack (LLK assert in configure_pack). 32-bit float formats also
-    require 32-bit Dest.
-
-    For the remaining (16-bit float / block-float) pairs both modes are valid,
-    so we sweep both to widen coverage.
-    """
     in_fmt = formats.input_format
     out_fmt = formats.output_format
-    if (
-        in_fmt.is_integer()
-        or out_fmt.is_integer()
-        or in_fmt.is_32_bit()
-        or out_fmt.is_32_bit()
-    ):
-        return [DestAccumulation.Yes]
-    return [DestAccumulation.No, DestAccumulation.Yes]
+
+    # bf16 / block-float inputs that promote to 32-bit Dest when packed to UInt8.
+    _bf_family = (DataFormat.Float16_b, DataFormat.Bfp8_b, DataFormat.Bfp4_b)
+    preserve_fp32_precision = (
+        in_fmt == DataFormat.Float32
+        or (out_fmt == DataFormat.UInt8 and in_fmt in _bf_family)
+        or (in_fmt == DataFormat.UInt16 and out_fmt == DataFormat.UInt8)
+        or (in_fmt == DataFormat.UInt8 and out_fmt != DataFormat.Float16_b)
+    )
+    fp32_dest_acc_en = (
+        preserve_fp32_precision
+        or out_fmt in (DataFormat.UInt32, DataFormat.Int32, DataFormat.Float32)
+        or in_fmt in (DataFormat.UInt32, DataFormat.Int32)
+        or out_fmt == DataFormat.Fp8_e4m3
+        or in_fmt == DataFormat.Fp8_e4m3
+    )
+    return [DestAccumulation.Yes if fp32_dest_acc_en else DestAccumulation.No]
 
 
 @parametrize(
     formats=TYPECAST_PAIRS,
-    dest_acc=_valid_dest_acc_options,
+    dest_acc=_production_dest_acc,
     approx_mode=[ApproximationMode.No],
     input_dimensions=[
         [32, 32]
@@ -228,6 +226,28 @@ def test_eltwise_unary_typecast(
         dest_acc=dest_acc,
         unpack_to_dest=unpack_to_dest,
     )
+
+    # pack_src fix for the SFPU typecast.
+    #
+    # The generic format inference models pack_src from the *input* (what the
+    # unpacker writes to Dest). For a typecast the SFPU overwrites Dest with the
+    # *output* value, so the packer must read the output's register
+    # representation, not the input's. In 16-bit Dest mode (dest_acc=No) the
+    # inferred pack_src would stay equal to the input format and the pack would
+    # be rejected (e.g. UInt16 -> Float16_b is not a supported packer
+    # conversion). Patch pack_src to the format the SFPU actually leaves in Dest:
+    # block-float outputs are produced as Float16_b and compressed by the packer;
+    # every other output is already in its packable register form. (For
+    # dest_acc=Yes the 32-bit gasket converts from Dest, and the inference
+    # already yields the output format, so no patch is needed there.)
+    if dest_acc == DestAccumulation.No:
+        pack_src = (
+            DataFormat.Float16_b
+            if _is_block_float(formats.output_format)
+            else formats.output_format
+        )
+        for fmt_config in configuration.formats_config:
+            fmt_config.pack_src = pack_src
 
     res_from_L1 = configuration.run().result
 

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_typecast_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_typecast_test.cpp
@@ -80,21 +80,15 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    // Copy SrcA to Dest (datacopy A2D). Integer inputs always run with 32-bit
-    // Dest (dest_acc=Yes), which already routes the copy so the raw bits land in
-    // Dest unmodified; no separate integer-FPU flag is needed here.
+    // Copy SrcA to Dest (datacopy A2D). The A2D copy preserves the raw datum
+    // bits in Dest (the SFPU below interprets/converts them), so no separate
+    // integer-FPU flag is needed here. dest_acc follows production
+    // (fp32_dest_acc_en): integer pairs that production runs in 16-bit Dest stay
+    // in 16-bit Dest here too.
     _llk_math_eltwise_unary_datacopy_init_wrapper_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false /* is_int_fpu_en */, PackMode::Default>(
         TILE_NUM_FACES, formats.math);
     _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
     _llk_math_pack_sync_init_<DST_SYNC, is_fp32_dest_acc_en>();
-
-    // The typecast SFPU integer datapath relies on debug feature bit 11 (32-bit
-    // dest mode) being set. In production this is owned by the LLK API; here we
-    // set it explicitly around the compute and clear it again below.
-    if constexpr (is_fp32_dest_acc_en)
-    {
-        _llk_math_dbg_feature_disable_();
-    }
 
     // Program the SFPU for this specific typecast pair (no-op for pairs handled
     // purely by unpacker/packer format conversion). Goes through the shared
@@ -138,12 +132,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 TYPECAST_OUT_FORMAT>(block_tile);
         }
         _llk_math_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
-    }
-
-    // Clear debug feature bit 11, restoring default FPU behavior.
-    if constexpr (is_fp32_dest_acc_en)
-    {
-        _llk_math_dbg_feature_enable_();
     }
 }
 


### PR DESCRIPTION

### Summary
As @amahmudTT  pointed out to me `_valid_dest_acc_options` in `tt-metal/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_typecast.py ` was setting dst_acc to yes even when it shouldn't be set.
Idea of this PR is to be aligned to TTNN in a way it decides if dst_acc should be se to yes or no

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ldjurovic/fix_typecast_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ldjurovic/fix_typecast_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ldjurovic/fix_typecast_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ldjurovic/fix_typecast_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ldjurovic/fix_typecast_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ldjurovic/fix_typecast_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ldjurovic/fix_typecast_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ldjurovic/fix_typecast_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ldjurovic/fix_typecast_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ldjurovic/fix_typecast_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ldjurovic/fix_typecast_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ldjurovic/fix_typecast_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ldjurovic/fix_typecast_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ldjurovic/fix_typecast_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ldjurovic/fix_typecast_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ldjurovic/fix_typecast_tests)