### PR TITLE
[Cleanup] Migrate remaining CCL kernels (AGMM + tail) to Device 2.0 API

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_writer.cpp
@@ -5,6 +5,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include <tt-metalium/buffer_types.hpp>
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
@@ -56,8 +57,8 @@ void kernel_main() {
     uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
 
-    const uint32_t concat_semaphore_send_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
-    const uint32_t concat_semaphore_send_addr2 = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    Semaphore<> concat_sem(get_arg_val<uint32_t>(arg_idx++));
+    Semaphore<> concat_sem2(get_arg_val<uint32_t>(arg_idx++));
 
     tt_l1_ptr uint32_t* core_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
     arg_idx += num_cores;
@@ -165,34 +166,31 @@ void kernel_main() {
             packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
     }
     // increment locally
-    // Device 2.0 migration: legacy primitive retained — out_ready_sem_bank_addr is a GlobalSemaphore
-    // address, and Semaphore<> binds to per-program ids (no GlobalSemaphore wrapper exists).
+    // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
     uint64_t out_ready_sem_noc_addr =
         safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr);
     noc_semaphore_inc(out_ready_sem_noc_addr, 1);
 
     // 3. wait for mcast output ready semaphore
     if (wait_output_semaphore) {
+        // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
         noc_semaphore_wait(
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr), out_ready_sem_wait_value);
     }
 
     // Set up for mcasting to concat workers
-    // Device 2.0 migration: legacy primitives retained: set + raw L1 read pattern does not map to
-    // Semaphore<>, which exposes set/wait but not raw-pointer value reads.
     if (wait_output_semaphore) {
-        volatile tt_l1_ptr uint32_t* concat_semaphore_send_addr_ptr =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(concat_semaphore_send_addr);
-        volatile tt_l1_ptr uint32_t* concat_semaphore_send_addr_ptr2 =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(concat_semaphore_send_addr2);
+        auto* concat_semaphore_send_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(concat_sem.get_l1_addr());
+        auto* concat_semaphore_send_addr_ptr2 =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(concat_sem2.get_l1_addr());
 
-        noc_semaphore_set(concat_semaphore_send_addr_ptr, 1);
-        noc_semaphore_set(concat_semaphore_send_addr_ptr2, 1);
+        concat_sem.set(1);
+        concat_sem2.set(1);
         if (concat_semaphore_send_addr_ptr[0] != 1) {
-            noc_semaphore_set(concat_semaphore_send_addr_ptr, 1);
+            concat_sem.set(1);
         }
         if (concat_semaphore_send_addr_ptr2[0] != 1) {
-            noc_semaphore_set(concat_semaphore_send_addr_ptr2, 1);
+            concat_sem2.set(1);
         }
     }
 
@@ -204,30 +202,20 @@ void kernel_main() {
             } else if (i == 2) {
                 mcast_dest_num = 8;
             }
-            const uint64_t concat_sem_rcv_addr = get_noc_multicast_addr(
+            concat_sem.set_multicast(
+                noc_obj,
                 mcast_dest_noc_start_x[i],
                 mcast_dest_noc_start_y[i],
                 mcast_dest_noc_end_x[i],
                 mcast_dest_noc_end_y[i],
-                concat_semaphore_send_addr);
-            noc_semaphore_set_multicast(
-                concat_semaphore_send_addr,
-                concat_sem_rcv_addr,
-                mcast_dest_num,
-                false);  // linked = false
-
-            const uint64_t concat_sem_rcv_addr2 = get_noc_multicast_addr(
+                mcast_dest_num);
+            concat_sem2.set_multicast(
+                noc_obj,
                 mcast_dest_noc_start_x[i],
                 mcast_dest_noc_start_y[i],
                 mcast_dest_noc_end_x[i],
                 mcast_dest_noc_end_y[i],
-                concat_semaphore_send_addr2);
-
-            noc_semaphore_set_multicast(
-                concat_semaphore_send_addr2,
-                concat_sem_rcv_addr2,
-                mcast_dest_num,
-                false);  // linked = false
+                mcast_dest_num);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_writer.cpp
@@ -180,18 +180,8 @@ void kernel_main() {
 
     // Set up for mcasting to concat workers
     if (wait_output_semaphore) {
-        auto* concat_semaphore_send_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(concat_sem.get_l1_addr());
-        auto* concat_semaphore_send_addr_ptr2 =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(concat_sem2.get_l1_addr());
-
         concat_sem.set(1);
         concat_sem2.set(1);
-        if (concat_semaphore_send_addr_ptr[0] != 1) {
-            concat_sem.set(1);
-        }
-        if (concat_semaphore_send_addr_ptr2[0] != 1) {
-            concat_sem2.set(1);
-        }
     }
 
     if (wait_output_semaphore) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_writer.cpp
@@ -166,14 +166,12 @@ void kernel_main() {
             packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
     }
     // increment locally
-    // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
     uint64_t out_ready_sem_noc_addr =
         safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr);
     noc_semaphore_inc(out_ready_sem_noc_addr, 1);
 
     // 3. wait for mcast output ready semaphore
     if (wait_output_semaphore) {
-        // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
         noc_semaphore_wait(
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr), out_ready_sem_wait_value);
     }
@@ -214,7 +212,6 @@ void kernel_main() {
     }
 
     if (reset_global_semaphore) {
-        // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr), 0);
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/compute.cpp
@@ -13,28 +13,29 @@
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/eltwise_unary/binop_with_scalar.h"
 #include "api/compute/eltwise_binary_sfpu.h"
+#include "api/dataflow/circular_buffer.h"
 
-void copy_block(uint32_t in_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {
-    copy_tile_to_dst_init_short(in_cb);
-    reconfig_data_format_srca(in_cb);
-    pack_reconfig_data_format(out_cb);
+void copy_block(CircularBuffer& in_cb, CircularBuffer& out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {
+    copy_tile_to_dst_init_short(in_cb.get_cb_id());
+    reconfig_data_format_srca(in_cb.get_cb_id());
+    pack_reconfig_data_format(out_cb.get_cb_id());
     uint32_t fused_act_dst_id = 0;
 
     uint32_t tile_id = 0;
     for (uint32_t m = 0; m < M_block_tiles; m++) {
         for (uint32_t n = 0; n < N_block_tiles; n++) {
             tile_regs_acquire();
-            copy_tile(in_cb, tile_id, fused_act_dst_id /*dst*/);
+            copy_tile(in_cb.get_cb_id(), tile_id, fused_act_dst_id /*dst*/);
 #ifdef SFPU_OP_INIT_ACTIVATION
             SFPU_OP_FUNC_ACTIVATION
 #endif
             tile_regs_commit();
             tile_regs_wait();
-            pack_tile(fused_act_dst_id, out_cb);
+            pack_tile(fused_act_dst_id, out_cb.get_cb_id());
             tile_regs_release();
             tile_id++;
         }
-        cb_push_back(out_cb, N_block_tiles);
+        out_cb.push_back(N_block_tiles);
     }
 }
 
@@ -47,37 +48,43 @@ void copy_block(uint32_t in_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_
  *   - true: Pushes tiles one row at a time (for intermediate output to next stage)
  *   - false: Pushes all tiles at end (for final output)
  */
-void add_bias_block(uint32_t in_cb, uint32_t bias_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {
-    add_bcast_rows_init_short(in_cb, bias_cb);
-    reconfig_data_format(in_cb, bias_cb);
-    pack_reconfig_data_format(out_cb);
+void add_bias_block(
+    CircularBuffer& in_cb,
+    CircularBuffer& bias_cb,
+    CircularBuffer& out_cb,
+    uint32_t M_block_tiles,
+    uint32_t N_block_tiles) {
+    add_bcast_rows_init_short(in_cb.get_cb_id(), bias_cb.get_cb_id());
+    reconfig_data_format(in_cb.get_cb_id(), bias_cb.get_cb_id());
+    pack_reconfig_data_format(out_cb.get_cb_id());
     uint32_t fused_act_dst_id = 0;
 
     uint32_t tile_id = 0;
     for (uint32_t m = 0; m < M_block_tiles; m++) {
         for (uint32_t n = 0; n < N_block_tiles; n++) {
             tile_regs_acquire();
-            add_tiles_bcast<BroadcastType::ROW>(in_cb, bias_cb, tile_id, n, fused_act_dst_id /*dst*/);
+            add_tiles_bcast<BroadcastType::ROW>(
+                in_cb.get_cb_id(), bias_cb.get_cb_id(), tile_id, n, fused_act_dst_id /*dst*/);
 #ifdef SFPU_OP_INIT_ACTIVATION
             SFPU_OP_FUNC_ACTIVATION
 #endif
             tile_regs_commit();
             tile_regs_wait();
-            pack_tile(fused_act_dst_id, out_cb);
+            pack_tile(fused_act_dst_id, out_cb.get_cb_id());
             tile_regs_release();
             tile_id++;
         }
-        cb_push_back(out_cb, N_block_tiles);
+        out_cb.push_back(N_block_tiles);
     }
 }
 
 void add_bias_and_addcmul_block(
-    uint32_t intermediate_cb,
-    uint32_t bias_cb,
-    uint32_t ternary_a_cb,
-    uint32_t ternary_b_cb,
+    CircularBuffer& intermediate_cb,
+    CircularBuffer& bias_cb,
+    CircularBuffer& ternary_a_cb,
+    CircularBuffer& ternary_b_cb,
     uint32_t scalar_value,
-    uint32_t out_cb,
+    CircularBuffer& out_cb,
     uint32_t M_block_tiles,
     uint32_t N_block_tiles,
     uint32_t broadcast_ternary_b) {
@@ -93,40 +100,40 @@ void add_bias_and_addcmul_block(
     // Read from intermediate_cb and write back to intermediate_cb
     // ============================================
 
-    add_bcast_rows_init_short(intermediate_cb, bias_cb);
-    reconfig_data_format(intermediate_cb, bias_cb);
-    pack_reconfig_data_format(intermediate_cb);
+    add_bcast_rows_init_short(intermediate_cb.get_cb_id(), bias_cb.get_cb_id());
+    reconfig_data_format(intermediate_cb.get_cb_id(), bias_cb.get_cb_id());
+    pack_reconfig_data_format(intermediate_cb.get_cb_id());
 
     // Wait for ALL input data ONCE at the beginning
-    cb_wait_front(bias_cb, N_block_tiles);
+    bias_cb.wait_front(N_block_tiles);
 
     // Unpacker waits for intermediate_cb to be ready
-    cb_wait_front(intermediate_cb, out_block_num_tiles);
+    intermediate_cb.wait_front(out_block_num_tiles);
 
     for (uint32_t m = 0; m < M_block_tiles; m++) {
         for (uint32_t n = 0; n < N_block_tiles; n++) {
             uint32_t tile_id = m * N_block_tiles + n;
 
             tile_regs_acquire();
-            add_tiles_bcast<BroadcastType::ROW>(intermediate_cb, bias_cb, tile_id, n, DST_ID);
+            add_tiles_bcast<BroadcastType::ROW>(intermediate_cb.get_cb_id(), bias_cb.get_cb_id(), tile_id, n, DST_ID);
 
             tile_regs_commit();
             tile_regs_wait();
-            pack_tile(DST_ID, intermediate_cb);
+            pack_tile(DST_ID, intermediate_cb.get_cb_id());
             tile_regs_release();
         }
     }
 
     // Pop input and push output ONCE at the end
-    // cb_wait_front(intermediate_cb, out_block_num_tiles); // Unpacker-Packer sync
-    // cb_pop_front(intermediate_cb, out_block_num_tiles);
-    cb_pop_front(bias_cb, N_block_tiles);
+    // intermediate_cb.wait_front(out_block_num_tiles); // Unpacker-Packer sync
+    // intermediate_cb.pop_front(out_block_num_tiles);
+    bias_cb.pop_front(N_block_tiles);
 
-    cb_pop_front(intermediate_cb, out_block_num_tiles);
+    intermediate_cb.pop_front(out_block_num_tiles);
 
     // Restore intermediate_cb to ready (+ sync packer/unpacker)
-    cb_reserve_back(intermediate_cb, out_block_num_tiles);
-    cb_push_back(intermediate_cb, out_block_num_tiles);
+    intermediate_cb.reserve_back(out_block_num_tiles);
+    intermediate_cb.push_back(out_block_num_tiles);
 #endif  // FUSE_BIAS
 
     // ============================================
@@ -135,23 +142,23 @@ void add_bias_and_addcmul_block(
     // broadcast_ternary_b: 1 = single row broadcast, 0 = row-by-row streaming
     // ============================================
 
-    cb_wait_front(intermediate_cb, out_block_num_tiles);
+    intermediate_cb.wait_front(out_block_num_tiles);
 
     uint32_t tile_id = 0;
 
     if (broadcast_ternary_b) {
         // === BROADCAST: single row, wait/pop once ===
-        cb_wait_front(ternary_b_cb, N_block_tiles);
+        ternary_b_cb.wait_front(N_block_tiles);
 
 #ifndef TERNARY_B_IS_FLOAT32
-        mul_bcast_rows_init_short(intermediate_cb, ternary_b_cb);
+        mul_bcast_rows_init_short(intermediate_cb.get_cb_id(), ternary_b_cb.get_cb_id());
 #else
-        unary_bcast_init<BroadcastType::ROW>(ternary_b_cb, intermediate_cb);
+        unary_bcast_init<BroadcastType::ROW>(ternary_b_cb.get_cb_id(), intermediate_cb.get_cb_id());
 #endif  // TERNARY_B_IS_FLOAT32
 
         binop_with_scalar_tile_init();
-        reconfig_data_format(intermediate_cb, ternary_b_cb);
-        pack_reconfig_data_format(intermediate_cb);
+        reconfig_data_format(intermediate_cb.get_cb_id(), ternary_b_cb.get_cb_id());
+        pack_reconfig_data_format(intermediate_cb.get_cb_id());
 
         tile_id = 0;
         for (uint32_t m = 0; m < M_block_tiles; m++) {
@@ -166,14 +173,15 @@ void add_bias_and_addcmul_block(
                 // - mul_tiles_bcast for bfloat16 (LLK bug workaround).
 
                 // ternary_b_cb is [1, N], broadcast across M rows
-                mul_tiles_bcast<BroadcastType::ROW>(intermediate_cb, ternary_b_cb, tile_id, n, DST_ID);
+                mul_tiles_bcast<BroadcastType::ROW>(
+                    intermediate_cb.get_cb_id(), ternary_b_cb.get_cb_id(), tile_id, n, DST_ID);
 #else
                 constexpr uint32_t TERNARY_B_DST_ID = 1;
-                unary_bcast_init<BroadcastType::ROW>(ternary_b_cb, intermediate_cb);
-                unary_bcast<BroadcastType::ROW>(ternary_b_cb, n, TERNARY_B_DST_ID);
+                unary_bcast_init<BroadcastType::ROW>(ternary_b_cb.get_cb_id(), intermediate_cb.get_cb_id());
+                unary_bcast<BroadcastType::ROW>(ternary_b_cb.get_cb_id(), n, TERNARY_B_DST_ID);
 
-                copy_tile_to_dst_init_short(intermediate_cb);
-                copy_tile(intermediate_cb, tile_id, DST_ID);
+                copy_tile_to_dst_init_short(intermediate_cb.get_cb_id());
+                copy_tile(intermediate_cb.get_cb_id(), tile_id, DST_ID);
 
                 mul_binary_tile_init();
                 mul_binary_tile(DST_ID, TERNARY_B_DST_ID, DST_ID);
@@ -183,37 +191,37 @@ void add_bias_and_addcmul_block(
 
                 tile_regs_commit();
                 tile_regs_wait();
-                pack_tile(DST_ID, intermediate_cb);
+                pack_tile(DST_ID, intermediate_cb.get_cb_id());
                 tile_regs_release();
                 tile_id++;
             }
         }
 
-        cb_pop_front(ternary_b_cb, N_block_tiles);
+        ternary_b_cb.pop_front(N_block_tiles);
     } else {
         // === NO BROADCAST: row-by-row, wait/pop per M row ===
 #ifndef TERNARY_B_IS_FLOAT32
-        mul_tiles_init(intermediate_cb, ternary_b_cb);
+        mul_tiles_init(intermediate_cb.get_cb_id(), ternary_b_cb.get_cb_id());
 #endif
         binop_with_scalar_tile_init();
-        reconfig_data_format(intermediate_cb, ternary_b_cb);
-        pack_reconfig_data_format(intermediate_cb);
+        reconfig_data_format(intermediate_cb.get_cb_id(), ternary_b_cb.get_cb_id());
+        pack_reconfig_data_format(intermediate_cb.get_cb_id());
 
         tile_id = 0;
         for (uint32_t m = 0; m < M_block_tiles; m++) {
-            cb_wait_front(ternary_b_cb, N_block_tiles);
+            ternary_b_cb.wait_front(N_block_tiles);
             for (uint32_t n = 0; n < N_block_tiles; n++) {
                 tile_regs_acquire();
 
 #ifndef TERNARY_B_IS_FLOAT32
-                mul_tiles(intermediate_cb, ternary_b_cb, tile_id, n, DST_ID);
+                mul_tiles(intermediate_cb.get_cb_id(), ternary_b_cb.get_cb_id(), tile_id, n, DST_ID);
 #else
                 constexpr uint32_t TERNARY_B_DST_ID = 1;
-                copy_tile_to_dst_init_short(ternary_b_cb);
-                copy_tile(ternary_b_cb, n, TERNARY_B_DST_ID);
+                copy_tile_to_dst_init_short(ternary_b_cb.get_cb_id());
+                copy_tile(ternary_b_cb.get_cb_id(), n, TERNARY_B_DST_ID);
 
-                copy_tile_to_dst_init_short(intermediate_cb);
-                copy_tile(intermediate_cb, tile_id, DST_ID);
+                copy_tile_to_dst_init_short(intermediate_cb.get_cb_id());
+                copy_tile(intermediate_cb.get_cb_id(), tile_id, DST_ID);
 
                 mul_binary_tile_init();
                 mul_binary_tile(DST_ID, TERNARY_B_DST_ID, DST_ID);
@@ -223,56 +231,56 @@ void add_bias_and_addcmul_block(
 
                 tile_regs_commit();
                 tile_regs_wait();
-                pack_tile(DST_ID, intermediate_cb);
+                pack_tile(DST_ID, intermediate_cb.get_cb_id());
                 tile_regs_release();
                 tile_id++;
             }
-            cb_pop_front(ternary_b_cb, N_block_tiles);
+            ternary_b_cb.pop_front(N_block_tiles);
         }
     }
 
-    cb_pop_front(intermediate_cb, out_block_num_tiles);
+    intermediate_cb.pop_front(out_block_num_tiles);
 
     // 'refill' intermediate_cb (also synchronize packer/unpacker)
-    cb_reserve_back(intermediate_cb, out_block_num_tiles);
-    cb_push_back(intermediate_cb, out_block_num_tiles);
+    intermediate_cb.reserve_back(out_block_num_tiles);
+    intermediate_cb.push_back(out_block_num_tiles);
 
-    cb_wait_front(intermediate_cb, out_block_num_tiles);
+    intermediate_cb.wait_front(out_block_num_tiles);
 
-    add_tiles_init(intermediate_cb, ternary_a_cb);
-    reconfig_data_format(intermediate_cb, ternary_a_cb);
-    pack_reconfig_data_format(out_cb);
+    add_tiles_init(intermediate_cb.get_cb_id(), ternary_a_cb.get_cb_id());
+    reconfig_data_format(intermediate_cb.get_cb_id(), ternary_a_cb.get_cb_id());
+    pack_reconfig_data_format(out_cb.get_cb_id());
 
     tile_id = 0;
     for (uint32_t m = 0; m < M_block_tiles; m++) {
         // Wait for one row of ternary_a tiles
-        cb_wait_front(ternary_a_cb, N_block_tiles);
+        ternary_a_cb.wait_front(N_block_tiles);
 
         for (uint32_t n = 0; n < N_block_tiles; n++) {
             tile_regs_acquire();
 
             // ternary_a_cb is pushed one row at a time, so use column index n
-            add_tiles(intermediate_cb, ternary_a_cb, tile_id, n, DST_ID);
+            add_tiles(intermediate_cb.get_cb_id(), ternary_a_cb.get_cb_id(), tile_id, n, DST_ID);
 
             tile_regs_commit();
             tile_regs_wait();
-            pack_tile(DST_ID, out_cb);
+            pack_tile(DST_ID, out_cb.get_cb_id());
             tile_regs_release();
             tile_id++;
         }
 
-        cb_pop_front(ternary_a_cb, N_block_tiles);
-        cb_push_back(out_cb, N_block_tiles);
+        ternary_a_cb.pop_front(N_block_tiles);
+        out_cb.push_back(N_block_tiles);
     }
 
-    cb_pop_front(intermediate_cb, out_block_num_tiles);
+    intermediate_cb.pop_front(out_block_num_tiles);
 }
 
 // Slightly modified from compute_common.hpp
 void matmul_blocks(
-    const uint32_t in0_cb,
-    const uint32_t in1_cb,
-    const uint32_t out_cb,
+    CircularBuffer& in0_cb,
+    CircularBuffer& in1_cb,
+    CircularBuffer& out_cb,
     const uint32_t M_block_tiles,
     const uint32_t N_block_tiles,
     const uint32_t full_N_block_tiles,
@@ -292,8 +300,8 @@ void matmul_blocks(
 
             for (uint32_t inner_dim = 0; inner_dim < K_block_tiles; inner_dim++) {
                 matmul_block(
-                    in0_cb,
-                    in1_cb,
+                    in0_cb.get_cb_id(),
+                    in1_cb.get_cb_id(),
                     in0_index,
                     in1_index,
                     dst_index,
@@ -312,7 +320,7 @@ void matmul_blocks(
                 for (uint32_t w = 0; w < subblock_w; w++) {
                     uint32_t w_tile_id = N_start + w;
                     uint32_t out_tile_id = h_tile_id * full_N_block_tiles + w_tile_id;
-                    pack_tile<true>(write_dst_index, out_cb, out_tile_id);
+                    pack_tile<true>(write_dst_index, out_cb.get_cb_id(), out_tile_id);
                     write_dst_index++;
                     dst_index++;
                 }
@@ -350,20 +358,28 @@ void kernel_main() {
     constexpr uint32_t broadcast_ternary_b = 1;
 #endif
 
-    constexpr uint32_t in0_cb = tt::CBIndex::c_0;
-    constexpr uint32_t in1_cb = tt::CBIndex::c_1;
-    constexpr uint32_t out_cb = tt::CBIndex::c_2;
-    constexpr uint32_t intermediate_cb = tt::CBIndex::c_3;
-    constexpr uint32_t in2_cb = tt::CBIndex::c_4;
-    constexpr uint32_t ternary_a_cb = tt::CBIndex::c_5;
-    constexpr uint32_t ternary_b_cb = tt::CBIndex::c_6;
+    constexpr uint32_t in0_cb_id = tt::CBIndex::c_0;
+    constexpr uint32_t in1_cb_id = tt::CBIndex::c_1;
+    constexpr uint32_t out_cb_id = tt::CBIndex::c_2;
+    constexpr uint32_t intermediate_cb_id = tt::CBIndex::c_3;
+    constexpr uint32_t in2_cb_id = tt::CBIndex::c_4;
+    constexpr uint32_t ternary_a_cb_id = tt::CBIndex::c_5;
+    constexpr uint32_t ternary_b_cb_id = tt::CBIndex::c_6;
+
+    CircularBuffer in0_cb(in0_cb_id);
+    CircularBuffer in1_cb(in1_cb_id);
+    CircularBuffer out_cb(out_cb_id);
+    CircularBuffer intermediate_cb(intermediate_cb_id);
+    CircularBuffer in2_cb(in2_cb_id);
+    CircularBuffer ternary_a_cb(ternary_a_cb_id);
+    CircularBuffer ternary_b_cb(ternary_b_cb_id);
 
 #ifdef SFPU_OP_INIT_ACTIVATION
     SFPU_OP_INIT_ACTIVATION
 #endif
 
-    compute_kernel_hw_startup<SrcOrder::Reverse>(in0_cb, in1_cb, intermediate_cb);
-    matmul_init(in0_cb, in1_cb);
+    compute_kernel_hw_startup<SrcOrder::Reverse>(in0_cb_id, in1_cb_id, intermediate_cb_id);
+    matmul_init(in0_cb_id, in1_cb_id);
 
     constexpr uint32_t in0_block_num_tiles = M_block_tiles * K_block_tiles;
     constexpr uint32_t in1_block_num_tiles = K_block_tiles * N_block_tiles;
@@ -392,19 +408,19 @@ void kernel_main() {
             current_subblock_w = std::min(current_N_block_tiles, subblock_w);
 
             matmul_block_init(
-                in0_cb,
-                in1_cb,
+                in0_cb_id,
+                in1_cb_id,
                 false /*transpose*/,
                 current_subblock_w /*ct_dim*/,
                 current_subblock_h /*rt_dim*/,
                 K_block_tiles /*kt_dim*/);
-            reconfig_data_format(in1_cb, in0_cb);
-            pack_reconfig_data_format(intermediate_cb);
+            reconfig_data_format(in1_cb_id, in0_cb_id);
+            pack_reconfig_data_format(intermediate_cb_id);
             // Accumulation buffer
-            cb_reserve_back(intermediate_cb, out_block_num_tiles);
+            intermediate_cb.reserve_back(out_block_num_tiles);
             for (uint32_t k_block = 0; k_block < K_num_blocks; k_block++) {
-                cb_wait_front(in0_cb, in0_block_num_tiles);
-                cb_wait_front(in1_cb, in1_block_num_tiles);
+                in0_cb.wait_front(in0_block_num_tiles);
+                in1_cb.wait_front(in1_block_num_tiles);
 
                 matmul_blocks(
                     in0_cb,
@@ -433,29 +449,29 @@ void kernel_main() {
 #endif
                 }
                 if (!reuse_in0_block) {
-                    cb_pop_front(in0_cb, in0_block_num_tiles);
+                    in0_cb.pop_front(in0_block_num_tiles);
                 }
-                cb_pop_front(in1_cb, in1_block_num_tiles);
+                in1_cb.pop_front(in1_block_num_tiles);
                 reuse_in0_block = false;
                 if (k_block == 0) {
                     PACK((llk_pack_reconfig_l1_acc(1)));
                 }
             }
 
-            cb_push_back(intermediate_cb, out_block_num_tiles);
+            intermediate_cb.push_back(out_block_num_tiles);
             PACK((llk_pack_reconfig_l1_acc(0)));
 
-            cb_reserve_back(out_cb, out_block_num_tiles);
+            out_cb.reserve_back(out_block_num_tiles);
 #ifndef FUSE_TERNARY
-            cb_wait_front(intermediate_cb, out_block_num_tiles);
+            intermediate_cb.wait_front(out_block_num_tiles);
 #ifndef FUSE_BIAS
             copy_block(intermediate_cb, out_cb, M_block_tiles, N_block_tiles);
 #else
-            cb_wait_front(in2_cb, N_block_tiles);
+            in2_cb.wait_front(N_block_tiles);
             add_bias_block(intermediate_cb, in2_cb, out_cb, M_block_tiles, N_block_tiles);
-            cb_pop_front(in2_cb, N_block_tiles);
+            in2_cb.pop_front(N_block_tiles);
 #endif  // FUSE_BIAS
-            cb_pop_front(intermediate_cb, out_block_num_tiles);
+            intermediate_cb.pop_front(out_block_num_tiles);
 
 #else   // FUSE_TERNARY is set
             add_bias_and_addcmul_block(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in0_sender.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in0_sender.cpp
@@ -4,6 +4,10 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/core_local_mem.h"
 #include "matmul_dataflow_common.hpp"
 
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
@@ -118,9 +122,16 @@ void kernel_main() {
     const uint32_t in0_dest_noc_y = get_arg_val<uint32_t>(argidx++);
     const uint32_t in0_sender_noc_x = get_arg_val<uint32_t>(argidx++);
     const uint32_t in0_sender_noc_y = get_arg_val<uint32_t>(argidx++);
-    uint32_t in0_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(argidx++));
-    uint32_t in0_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(argidx++));
-    uint32_t in0_valid_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(argidx++));
+    const uint32_t in0_sender_semaphore_id = get_arg_val<uint32_t>(argidx++);
+    const uint32_t in0_receiver_semaphore_id = get_arg_val<uint32_t>(argidx++);
+    const uint32_t in0_valid_semaphore_id = get_arg_val<uint32_t>(argidx++);
+    Semaphore<> in0_sender_sem(in0_sender_semaphore_id);
+    Semaphore<> in0_receiver_sem(in0_receiver_semaphore_id);
+    Semaphore<> in0_valid_sem(in0_valid_semaphore_id);
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
+    uint32_t in0_valid_semaphore_addr = get_semaphore(in0_valid_semaphore_id);
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
+    uint32_t in0_receiver_semaphore_addr = get_semaphore(in0_receiver_semaphore_id);
     const uint32_t M_start_tile = get_arg_val<uint32_t>(argidx++);
     const uint32_t M_end_tile = get_arg_val<uint32_t>(argidx++);
     const uint32_t N_start_tile = get_arg_val<uint32_t>(argidx++);
@@ -194,6 +205,13 @@ void kernel_main() {
     constexpr uint32_t cb_id_in2 = tt::CBIndex::c_4;
 #endif
 
+    Noc noc_obj;
+    CircularBuffer cb_in0(cb_id_in0);
+    CircularBuffer cb_out(cb_id_out);
+#ifdef FUSE_BIAS
+    CircularBuffer cb_in2(cb_id_in2);
+#endif
+
 #ifdef READ_FROM_LOCAL_INPUT
 #ifdef FUSE_BIAS
     constexpr auto in3_args = TensorAccessorArgs<in2_args.next_compile_time_args_offset()>();
@@ -221,6 +239,8 @@ void kernel_main() {
 
     constexpr uint32_t cb_id_ternary_a = tt::CBIndex::c_5;
     constexpr uint32_t cb_id_ternary_b = tt::CBIndex::c_6;
+    CircularBuffer cb_ternary_a(cb_id_ternary_a);
+    CircularBuffer cb_ternary_b(cb_id_ternary_b);
 
     constexpr uint32_t ternary_a_tile_size = get_tile_size(cb_id_ternary_a);
     constexpr uint32_t ternary_b_tile_size = get_tile_size(cb_id_ternary_b);
@@ -229,16 +249,12 @@ void kernel_main() {
     const auto ternary_b_reader = TensorAccessor(ternary_b_args, ternary_b_addr);
 #endif
 
-    volatile tt_l1_ptr uint32_t* in0_valid_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_valid_semaphore_addr);
-    *(in0_valid_semaphore_addr_ptr) = VALID;
-    volatile tt_l1_ptr uint32_t* in0_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_receiver_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* in0_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_sender_semaphore_addr);
+    in0_valid_sem.set(VALID);
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
     const uint64_t in0_sender_semaphore_noc_addr =
-        get_noc_addr(in0_sender_noc_x, in0_sender_noc_y, in0_sender_semaphore_addr);
+        get_noc_addr(in0_sender_noc_x, in0_sender_noc_y, get_semaphore(in0_sender_semaphore_id));
 
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
     const uint64_t in0_receiver_semaphore_noc_addr =
         get_noc_addr(in0_dest_noc_x, in0_dest_noc_y, in0_receiver_semaphore_addr);
     // all gather
@@ -299,13 +315,14 @@ void kernel_main() {
             for (uint32_t k_block_iter = 0; k_block_iter < K_num_blocks; k_block_iter++) {
                 if (defer_write && k_block_iter == defer_write_k_block) {
                     if constexpr (is_output_writer) {
-                        cb_wait_front(cb_id_out, out_block_num_tiles);
-                        uint32_t out_read_ptr = get_read_ptr(cb_id_out);
+                        cb_out.wait_front(out_block_num_tiles);
+                        uint32_t out_read_ptr = cb_out.get_read_ptr();
 
                         // write_block_sync_split is more generic (support multiple output tensors)
                         // But for N_chunks == 1 (non-split minimal_matmul), write_block_sync should be faster
                         if constexpr (N_chunks == 1) {
                             write_block_sync<M_block_tiles, N_block_tiles>(
+                                noc_obj,
                                 std::get<0>(outputs_tuple),
                                 out_shape,
                                 out_read_ptr,
@@ -316,6 +333,7 @@ void kernel_main() {
                                 defer_write_n_tile_end);
                         } else {
                             write_block_sync_split<M_block_tiles, N_block_tiles, N_chunks, N_tiles_per_chunk>(
+                                noc_obj,
                                 outputs_tuple,
                                 out0_shape,
                                 out_read_ptr,
@@ -325,7 +343,7 @@ void kernel_main() {
                                 defer_write_n_tile,
                                 defer_write_n_tile_end);
                         }
-                        cb_pop_front(cb_id_out, out_block_num_tiles);
+                        cb_out.pop_front(out_block_num_tiles);
                     }
                 }
                 if (reuse_block && k_block_iter == 0) {
@@ -333,9 +351,9 @@ void kernel_main() {
                     reuse_block = false;
                     continue;
                 }
-                cb_reserve_back(cb_id_in0, in0_block_num_tiles);
+                cb_in0.reserve_back(in0_block_num_tiles);
 
-                uint32_t in0_start_address = get_write_ptr(cb_id_in0);
+                uint32_t in0_start_address = cb_in0.get_write_ptr();
 
                 uint32_t k_block_left_tile = 0;
                 uint32_t k_block_right_tile = 0;
@@ -386,9 +404,10 @@ void kernel_main() {
                 }
                 if (is_injector_core) {
                     read_in0_block_sync<M_block_tiles, K_block_tiles>(
+                        noc_obj,
                         in0_reader,
                         in0_shape,
-                        cb_id_in0,
+                        cb_in0,
                         in0_tile_size,
 #ifdef READ_FROM_LOCAL_INPUT
                         in3_reader,
@@ -406,17 +425,18 @@ void kernel_main() {
                         k_right_tiles);
                 } else {
                     // Get from previous device
-                    noc_semaphore_set(in0_receiver_semaphore_addr_ptr, INVALID);
+                    in0_receiver_sem.set(INVALID);
+                    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
                     noc_semaphore_inc(in0_sender_semaphore_noc_addr, 1);
-                    noc_semaphore_wait(in0_receiver_semaphore_addr_ptr, VALID);
+                    in0_receiver_sem.wait(VALID);
                 }
 
                 // Critical to performance for sender to push data to compute before mcasting
                 // This frees sender to start next read earlier
-                cb_push_back(cb_id_in0, in0_block_num_tiles);
+                cb_in0.push_back(in0_block_num_tiles);
                 if (!is_sink_core) {
-                    noc_semaphore_wait(in0_sender_semaphore_addr_ptr, 1);
-                    noc_semaphore_set(in0_sender_semaphore_addr_ptr, 0);
+                    in0_sender_sem.wait(1);
+                    in0_sender_sem.set(0);
 
                     uint64_t in0_unicast_data_addr = get_noc_addr(in0_dest_noc_x, in0_dest_noc_y, in0_start_address);
 
@@ -424,12 +444,15 @@ void kernel_main() {
                      * in0 is M_block_tiles x K_block_tiles. When M block is partial, we don't need to write the
                      * padded tiles. Use `current_block_bytes`.
                      */
+                    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
                     noc_async_write(in0_start_address, in0_unicast_data_addr, current_block_bytes);
 
 #ifdef ARCH_BLACKHOLE
-                    noc_async_writes_flushed();
+                    noc_obj.async_writes_flushed();
 #endif
 
+                    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address (src/dst sems
+                    // have different L1 offsets in this chain-mcast, so Semaphore<>::set_multicast can't be used)
                     noc_semaphore_set_remote(in0_valid_semaphore_addr, in0_receiver_semaphore_noc_addr);
                 }
 #ifdef USE_MUX
@@ -455,6 +478,7 @@ void kernel_main() {
                                     in0_core_order_index < forward_in0_core_order_index &&
                                     k_block_iter < (K_num_blocks - K_blocks_per_device)) {
                                     forward_half_block_to_fabric_neighbor(
+                                        noc_obj,
                                         m_tile,
                                         k_block_left_tile,
                                         current_M_block_tiles,
@@ -478,6 +502,7 @@ void kernel_main() {
                             if (in0_core_order_index >= forward_in0_core_order_index &&
                                 k_block_iter < (K_num_blocks - K_blocks_per_device)) {
                                 forward_half_block_to_fabric_neighbor(
+                                    noc_obj,
                                     m_tile,
                                     k_block_left_tile,
                                     current_M_block_tiles,
@@ -504,6 +529,7 @@ void kernel_main() {
                             if constexpr (num_targets_backward_direction > 0) {
                                 if (in0_core_order_index >= forward_in0_core_order_index) {
                                     forward_half_block_to_fabric_neighbor(
+                                        noc_obj,
                                         m_tile,
                                         k_block_left_tile,
                                         current_M_block_tiles,
@@ -526,6 +552,7 @@ void kernel_main() {
                                 if (in0_core_order_index >= backward_in0_core_order_index &&
                                     in0_core_order_index < forward_in0_core_order_index) {
                                     forward_half_block_to_fabric_neighbor(
+                                        noc_obj,
                                         m_tile,
                                         k_block_right_tile,
                                         current_M_block_tiles,
@@ -551,27 +578,33 @@ void kernel_main() {
             }
 #ifdef FUSE_BIAS
             if constexpr (!is_output_writer) {
-                cb_reserve_back(cb_id_in2, N_block_tiles);
+                cb_in2.reserve_back(N_block_tiles);
 
-                uint32_t l1_write_addr_in2 = get_write_ptr(cb_id_in2);
+                uint32_t l1_write_addr_in2 = cb_in2.get_write_ptr();
                 for (uint32_t n_tile_id = n_tile; n_tile_id < n_tile_end; n_tile_id++) {
-                    noc_async_read_page(n_tile_id, in2_reader, l1_write_addr_in2);
+                    noc_obj.async_read(
+                        in2_reader,
+                        CoreLocalMem<uint8_t>(l1_write_addr_in2),
+                        in2_tile_size,
+                        {.page_id = n_tile_id},
+                        {});
                     l1_write_addr_in2 += in2_tile_size;
                 }
-                noc_async_read_barrier();
+                noc_obj.async_read_barrier();
 
-                cb_push_back(cb_id_in2, N_block_tiles);
+                cb_in2.push_back(N_block_tiles);
             }
 #endif
 
 #ifdef FUSE_TERNARY
             if constexpr (!is_output_writer) {
                 read_ternary_blocks_sync<M_block_tiles, N_block_tiles>(
+                    noc_obj,
                     ternary_a_reader,
                     ternary_b_reader,
                     out_shape,
-                    cb_id_ternary_a,
-                    cb_id_ternary_b,
+                    cb_ternary_a,
+                    cb_ternary_b,
                     ternary_a_tile_size,
                     ternary_b_tile_size,
                     broadcast_ternary_b,
@@ -609,9 +642,10 @@ void kernel_main() {
                     // But for N_chunks == 1 (non-split minimal_matmul), write_block_sync_granular should be faster
                     if constexpr (N_chunks == 1) {
                         write_block_sync_granular<M_block_tiles, N_block_tiles>(
+                            noc_obj,
                             std::get<0>(outputs_tuple),
                             out_shape,
-                            cb_id_out,
+                            cb_out,
                             out_tile_size,
                             m_tile,
                             m_tile_end,
@@ -619,9 +653,10 @@ void kernel_main() {
                             n_tile_end);
                     } else {
                         write_block_sync_granular_split<M_block_tiles, N_block_tiles, N_chunks, N_tiles_per_chunk>(
+                            noc_obj,
                             outputs_tuple,
                             out0_shape,
-                            cb_id_out,
+                            cb_out,
                             out_tile_size,
                             m_tile,
                             m_tile_end,
@@ -633,12 +668,13 @@ void kernel_main() {
         }
     }
 
-    noc_async_write_barrier();
-    noc_async_atomic_barrier();
+    noc_obj.async_write_barrier();
+    noc_obj.async_atomic_barrier();
 
 #ifdef USE_MUX
     if (mux_backward.connection_valid) {
         close_mux(
+            noc_obj,
             mux_connection_handle_backward,
             mux_backward.is_termination_master,
             mux_backward.termination_sync_address,
@@ -651,6 +687,7 @@ void kernel_main() {
     }
     if (mux_forward.connection_valid) {
         close_mux(
+            noc_obj,
             mux_connection_handle_forward,
             mux_forward.is_termination_master,
             mux_forward.termination_sync_address,
@@ -663,8 +700,12 @@ void kernel_main() {
     }
 #endif  // USE_MUX
 
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 
+    // Device 2.0 migration: legacy primitive retained: GlobalSemaphore address (common runtime arg, not a per-program
+    // id)
     noc_semaphore_set(out_ready_sem_backward_addr_ptr, 0);
+    // Device 2.0 migration: legacy primitive retained: GlobalSemaphore address (common runtime arg, not a per-program
+    // id)
     noc_semaphore_set(out_ready_sem_forward_addr_ptr, 0);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in0_sender.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in0_sender.cpp
@@ -250,9 +250,6 @@ void kernel_main() {
 #endif
 
     in0_valid_sem.set(VALID);
-    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
-    const uint64_t in0_sender_semaphore_noc_addr =
-        get_noc_addr(in0_sender_noc_x, in0_sender_noc_y, get_semaphore(in0_sender_semaphore_id));
 
     // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
     const uint64_t in0_receiver_semaphore_noc_addr =
@@ -426,8 +423,7 @@ void kernel_main() {
                 } else {
                     // Get from previous device
                     in0_receiver_sem.set(INVALID);
-                    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
-                    noc_semaphore_inc(in0_sender_semaphore_noc_addr, 1);
+                    in0_sender_sem.up(noc_obj, in0_sender_noc_x, in0_sender_noc_y, 1);
                     in0_receiver_sem.wait(VALID);
                 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in0_sender.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in0_sender.cpp
@@ -128,9 +128,7 @@ void kernel_main() {
     Semaphore<> in0_sender_sem(in0_sender_semaphore_id);
     Semaphore<> in0_receiver_sem(in0_receiver_semaphore_id);
     Semaphore<> in0_valid_sem(in0_valid_semaphore_id);
-    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
     uint32_t in0_valid_semaphore_addr = get_semaphore(in0_valid_semaphore_id);
-    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
     uint32_t in0_receiver_semaphore_addr = get_semaphore(in0_receiver_semaphore_id);
     const uint32_t M_start_tile = get_arg_val<uint32_t>(argidx++);
     const uint32_t M_end_tile = get_arg_val<uint32_t>(argidx++);
@@ -251,7 +249,6 @@ void kernel_main() {
 
     in0_valid_sem.set(VALID);
 
-    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
     const uint64_t in0_receiver_semaphore_noc_addr =
         get_noc_addr(in0_dest_noc_x, in0_dest_noc_y, in0_receiver_semaphore_addr);
     // all gather
@@ -440,15 +437,12 @@ void kernel_main() {
                      * in0 is M_block_tiles x K_block_tiles. When M block is partial, we don't need to write the
                      * padded tiles. Use `current_block_bytes`.
                      */
-                    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
                     noc_async_write(in0_start_address, in0_unicast_data_addr, current_block_bytes);
 
 #ifdef ARCH_BLACKHOLE
                     noc_obj.async_writes_flushed();
 #endif
 
-                    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address (src/dst sems
-                    // have different L1 offsets in this chain-mcast, so Semaphore<>::set_multicast can't be used)
                     noc_semaphore_set_remote(in0_valid_semaphore_addr, in0_receiver_semaphore_noc_addr);
                 }
 #ifdef USE_MUX
@@ -698,10 +692,6 @@ void kernel_main() {
 
     noc_obj.async_write_barrier();
 
-    // Device 2.0 migration: legacy primitive retained: GlobalSemaphore address (common runtime arg, not a per-program
-    // id)
     noc_semaphore_set(out_ready_sem_backward_addr_ptr, 0);
-    // Device 2.0 migration: legacy primitive retained: GlobalSemaphore address (common runtime arg, not a per-program
-    // id)
     noc_semaphore_set(out_ready_sem_forward_addr_ptr, 0);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in1_sender_out.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in1_sender_out.cpp
@@ -4,6 +4,9 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "matmul_dataflow_common.hpp"
 #include "ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/fused_receiver_utils.hpp"
 #include "cpp/ttnn/operations/ccl/ccl_host_types.hpp"
@@ -98,9 +101,16 @@ void kernel_main() {
     const uint32_t in1_dest_noc_y = get_arg_val<uint32_t>(argidx++);
     const uint32_t in1_sender_noc_x = get_arg_val<uint32_t>(argidx++);
     const uint32_t in1_sender_noc_y = get_arg_val<uint32_t>(argidx++);
-    uint32_t in1_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(argidx++));
-    uint32_t in1_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(argidx++));
-    uint32_t in1_valid_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(argidx++));
+    const uint32_t in1_sender_semaphore_id = get_arg_val<uint32_t>(argidx++);
+    const uint32_t in1_receiver_semaphore_id = get_arg_val<uint32_t>(argidx++);
+    const uint32_t in1_valid_semaphore_id = get_arg_val<uint32_t>(argidx++);
+    Semaphore<> in1_sender_sem(in1_sender_semaphore_id);
+    Semaphore<> in1_receiver_sem(in1_receiver_semaphore_id);
+    Semaphore<> in1_valid_sem(in1_valid_semaphore_id);
+    // Device 2.0 migration: legacy primitive retained: local L1 offset, source for noc_semaphore_set_remote
+    const uint32_t in1_valid_semaphore_addr = get_semaphore(in1_valid_semaphore_id);
+    // Device 2.0 migration: legacy primitive retained: local L1 offset, consumed by precomposed-NoC destination
+    const uint32_t in1_receiver_semaphore_addr = get_semaphore(in1_receiver_semaphore_id);
     const uint32_t M_start_tile = get_arg_val<uint32_t>(argidx++);
     const uint32_t M_end_tile = get_arg_val<uint32_t>(argidx++);
     const uint32_t N_start_tile = get_arg_val<uint32_t>(argidx++);
@@ -163,6 +173,8 @@ void kernel_main() {
 
     constexpr uint32_t cb_id_ternary_a = tt::CBIndex::c_5;
     constexpr uint32_t cb_id_ternary_b = tt::CBIndex::c_6;
+    CircularBuffer cb_ternary_a(cb_id_ternary_a);
+    CircularBuffer cb_ternary_b(cb_id_ternary_b);
 
     constexpr uint32_t ternary_a_tile_size = get_tile_size(cb_id_ternary_a);
     constexpr uint32_t ternary_b_tile_size = get_tile_size(cb_id_ternary_b);
@@ -189,16 +201,19 @@ void kernel_main() {
     constexpr uint32_t cb_id_in2 = tt::CBIndex::c_4;
 #endif
 
-    volatile tt_l1_ptr uint32_t* in1_valid_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in1_valid_semaphore_addr);
-    *(in1_valid_semaphore_addr_ptr) = VALID;
-    volatile tt_l1_ptr uint32_t* in1_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in1_receiver_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* in1_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in1_sender_semaphore_addr);
-    const uint64_t in1_sender_semaphore_noc_addr =
-        get_noc_addr(in1_sender_noc_x, in1_sender_noc_y, in1_sender_semaphore_addr);
+    Noc noc_obj;
+    CircularBuffer cb_in1(cb_id_in1);
+    CircularBuffer cb_out(cb_id_out);
+#ifdef FUSE_BIAS
+    CircularBuffer cb_in2(cb_id_in2);
+#endif
 
+    in1_valid_sem.set(VALID);
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address consumed by raw NoC primitives
+    const uint64_t in1_sender_semaphore_noc_addr =
+        get_noc_addr(in1_sender_noc_x, in1_sender_noc_y, get_semaphore(in1_sender_semaphore_id));
+
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address consumed by raw NoC primitives
     const uint64_t in1_receiver_semaphore_noc_addr =
         get_noc_addr(in1_dest_noc_x, in1_dest_noc_y, in1_receiver_semaphore_addr);
 
@@ -237,6 +252,8 @@ void kernel_main() {
     }
 
     // FSDP semaphores (forward + backward counters incremented by remote fabric sends).
+    // Device 2.0 migration: legacy primitive retained: GlobalSemaphore-style raw L1 address from common args,
+    // passed by ptr into compute_actual_k_block helper that consumes it with noc_semaphore_wait_min
     volatile tt_l1_ptr uint32_t* fsdp_sem_forward_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(fsdp_sem_forward);
     volatile tt_l1_ptr uint32_t* fsdp_sem_backward_ptr =
@@ -296,12 +313,13 @@ void kernel_main() {
             for (uint32_t k_block_iter = 0; k_block_iter < K_num_blocks; k_block_iter++) {
                 if (defer_write && k_block_iter == defer_write_k_block) {
                     if constexpr (is_output_writer) {
-                        cb_wait_front(cb_id_out, out_block_num_tiles);
-                        uint32_t out_read_ptr = get_read_ptr(cb_id_out);
+                        cb_out.wait_front(out_block_num_tiles);
+                        uint32_t out_read_ptr = cb_out.get_read_ptr();
                         // write_block_sync_split is more generic (support multiple output tensors)
                         // But for N_chunks == 1 (non-split minimal_matmul), write_block_sync should be faster
                         if constexpr (N_chunks == 1) {
                             write_block_sync<M_block_tiles, N_block_tiles>(
+                                noc_obj,
                                 std::get<0>(outputs_tuple),
                                 out_shape,
                                 out_read_ptr,
@@ -312,6 +330,7 @@ void kernel_main() {
                                 defer_write_n_tile_end);
                         } else {
                             write_block_sync_split<M_block_tiles, N_block_tiles, N_chunks, N_tiles_per_chunk>(
+                                noc_obj,
                                 outputs_tuple,
                                 out0_shape,
                                 out_read_ptr,
@@ -321,13 +340,13 @@ void kernel_main() {
                                 defer_write_n_tile,
                                 defer_write_n_tile_end);
                         }
-                        cb_pop_front(cb_id_out, out_block_num_tiles);
+                        cb_out.pop_front(out_block_num_tiles);
                     }
                 }
 
-                cb_reserve_back(cb_id_in1, in1_block_num_tiles);
+                cb_in1.reserve_back(in1_block_num_tiles);
 
-                uint32_t in1_start_address = get_write_ptr(cb_id_in1);
+                uint32_t in1_start_address = cb_in1.get_write_ptr();
 #ifdef FSDP_FUSED
                 // Remembered for fabric send (the NOC-chain block below increments in1_start_address).
                 uint32_t in1_send_l1_addr = in1_start_address;
@@ -398,9 +417,9 @@ void kernel_main() {
                     const uint32_t local_k_start = my_rank * K_tiles_per_device;
                     const uint32_t local_k_end = local_k_start + K_tiles_per_device;
                     {
-                        Noc noc;
-                        CircularBuffer cb(cb_id_in1);
                         uint32_t write_ptr = in1_start_address;
+                        // Device 2.0 migration: legacy primitive retained: TensorAccessor-based read API matches
+                        // helper functions' internal idiom; no D2 equivalent in matmul_dataflow_common.hpp helpers
                         // Left half (real data: local weight DRAM if this is our stripe, else PWB).
                         for (uint32_t k = 0; k < k_left_tiles; k++) {
                             uint32_t global_k_tile = k_block_left_tile + k;
@@ -430,7 +449,7 @@ void kernel_main() {
                                     continue;
                                 }
                                 if (global_k_tile >= K_tiles) {
-                                    fill_zeros_async(noc, cb, in1_tile_size, write_ptr - in1_start_address);
+                                    fill_zeros_async(noc_obj, cb_in1, in1_tile_size, write_ptr - in1_start_address);
                                 } else if (local) {
                                     noc_async_read_tile(
                                         (global_k_tile - local_k_start) * N_tiles + n, local_weight_reader, write_ptr);
@@ -441,13 +460,14 @@ void kernel_main() {
                             }
                             write_ptr += (N_block_tiles - (n_tile_end - n_tile)) * in1_tile_size;
                         }
-                        noc_async_read_barrier();
+                        noc_obj.async_read_barrier();
                     }
 #else
                     read_in1_block_sync<K_block_tiles, N_block_tiles>(
+                        noc_obj,
                         in1_reader,
                         in1_shape,
-                        cb_id_in1,
+                        cb_in1,
                         in1_tile_size,
                         k_block_left_tile,
                         k_block_left_tile + k_left_tiles,
@@ -457,18 +477,18 @@ void kernel_main() {
                         n_tile_end);
 #endif
                 } else {
-                    noc_semaphore_set(in1_receiver_semaphore_addr_ptr, INVALID);
-                    noc_semaphore_inc(in1_sender_semaphore_noc_addr, 1);
-                    noc_semaphore_wait(in1_receiver_semaphore_addr_ptr, VALID);
+                    in1_receiver_sem.set(INVALID);
+                    in1_sender_sem.up(noc_obj, in1_sender_noc_x, in1_sender_noc_y, 1);
+                    in1_receiver_sem.wait(VALID);
                 }
 
                 // Critical to performance for sender to push data to compute before mcasting
                 // This frees sender to start next read earlier
-                cb_push_back(cb_id_in1, in1_block_num_tiles);
+                cb_in1.push_back(in1_block_num_tiles);
 
                 if (!is_sink_core) {
-                    noc_semaphore_wait(in1_sender_semaphore_addr_ptr, 1);
-                    noc_semaphore_set(in1_sender_semaphore_addr_ptr, 0);
+                    in1_sender_sem.wait(1);
+                    in1_sender_sem.set(0);
 
                     /**
                      * in1 is K_block_tiles x N_block_tiles. When N block is partial, we don't need to write the
@@ -477,14 +497,17 @@ void kernel_main() {
                      */
                     for (uint32_t i = 0; i < K_block_tiles; i++) {
                         uint64_t in1_unicast_data_addr = in1_unicast_data_base_addr | in1_start_address;
+                        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC destination
                         noc_async_write(in1_start_address, in1_unicast_data_addr, current_N_tiles_bytes);
                         in1_start_address += full_N_tiles_bytes;
                     }
 
 #ifdef ARCH_BLACKHOLE
-                    noc_async_writes_flushed();
+                    noc_obj.async_writes_flushed();
 #endif
 
+                    // Device 2.0 migration: legacy primitive retained: src/dst sems use different L1 ids, so
+                    // Semaphore<>::set_multicast cannot be substituted (writes remote at sender's L1 offset)
                     noc_semaphore_set_remote(in1_valid_semaphore_addr, in1_receiver_semaphore_noc_addr);
                 }
 #ifdef FSDP_FUSED
@@ -505,6 +528,7 @@ void kernel_main() {
                                 if (in1_core_order_index == fsdp_backward_in1_core_order_index &&
                                     k_block_iter < (K_num_blocks - K_blocks_per_device)) {
                                     forward_in1_half_block_to_fabric_neighbor(
+                                        noc_obj,
                                         k_block_left_tile,
                                         n_tile,
                                         k_left_tiles,
@@ -528,6 +552,7 @@ void kernel_main() {
                             if (in1_core_order_index == fsdp_forward_in1_core_order_index &&
                                 k_block_iter < (K_num_blocks - K_blocks_per_device)) {
                                 forward_in1_half_block_to_fabric_neighbor(
+                                    noc_obj,
                                     k_block_left_tile,
                                     n_tile,
                                     k_left_tiles,
@@ -552,27 +577,30 @@ void kernel_main() {
             }
 #ifdef FUSE_BIAS
             if constexpr (!is_output_writer) {
-                cb_reserve_back(cb_id_in2, N_block_tiles);
+                cb_in2.reserve_back(N_block_tiles);
 
-                uint32_t l1_write_addr_in2 = get_write_ptr(cb_id_in2);
+                uint32_t l1_write_addr_in2 = cb_in2.get_write_ptr();
                 for (uint32_t n_tile_id = n_tile; n_tile_id < n_tile_end; n_tile_id++) {
+                    // Device 2.0 migration: legacy primitive retained: matches helper internal idiom in
+                    // matmul_dataflow_common.hpp (TensorAccessor-based per-page reads)
                     noc_async_read_page(n_tile_id, in2_reader, l1_write_addr_in2);
                     l1_write_addr_in2 += in2_tile_size;
                 }
-                noc_async_read_barrier();
+                noc_obj.async_read_barrier();
 
-                cb_push_back(cb_id_in2, N_block_tiles);
+                cb_in2.push_back(N_block_tiles);
             }
 #endif
 
 #ifdef FUSE_TERNARY
             if constexpr (!is_output_writer) {
                 read_ternary_blocks_sync<M_block_tiles, N_block_tiles>(
+                    noc_obj,
                     ternary_a_reader,
                     ternary_b_reader,
                     out_shape,
-                    cb_id_ternary_a,
-                    cb_id_ternary_b,
+                    cb_ternary_a,
+                    cb_ternary_b,
                     ternary_a_tile_size,
                     ternary_b_tile_size,
                     broadcast_ternary_b,
@@ -605,9 +633,10 @@ void kernel_main() {
                     // But for N_chunks == 1 (non-split minimal_matmul), write_block_sync_granular should be faster
                     if constexpr (N_chunks == 1) {
                         write_block_sync_granular<M_block_tiles, N_block_tiles>(
+                            noc_obj,
                             std::get<0>(outputs_tuple),
                             out_shape,
-                            cb_id_out,
+                            cb_out,
                             out_tile_size,
                             m_tile,
                             m_tile_end,
@@ -615,9 +644,10 @@ void kernel_main() {
                             n_tile_end);
                     } else {
                         write_block_sync_granular_split<M_block_tiles, N_block_tiles, N_chunks, N_tiles_per_chunk>(
+                            noc_obj,
                             outputs_tuple,
                             out0_shape,
-                            cb_id_out,
+                            cb_out,
                             out_tile_size,
                             m_tile,
                             m_tile_end,
@@ -628,12 +658,13 @@ void kernel_main() {
             }
         }
     }
-    noc_async_write_barrier();
-    noc_async_atomic_barrier();
+    noc_obj.async_write_barrier();
+    noc_obj.async_atomic_barrier();
 
 #ifdef FSDP_FUSED
     if (fsdp_mux_backward.connection_valid) {
         close_mux(
+            noc_obj,
             fsdp_mux_handle_backward,
             fsdp_mux_backward.is_termination_master,
             fsdp_mux_backward.termination_sync_address,
@@ -646,6 +677,7 @@ void kernel_main() {
     }
     if (fsdp_mux_forward.connection_valid) {
         close_mux(
+            noc_obj,
             fsdp_mux_handle_forward,
             fsdp_mux_forward.is_termination_master,
             fsdp_mux_forward.termination_sync_address,
@@ -657,9 +689,10 @@ void kernel_main() {
             fsdp_mux_forward.termination_master_noc_y);
     }
 
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 
     // Reset FSDP semaphores so the next op-launch starts clean (matches the in0 pattern).
+    // Device 2.0 migration: legacy primitive retained: GlobalSemaphore-style raw L1 ptr, no Semaphore<> id available
     noc_semaphore_set(fsdp_sem_forward_ptr, 0);
     noc_semaphore_set(fsdp_sem_backward_ptr, 0);
 #endif

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in1_sender_out.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in1_sender_out.cpp
@@ -209,9 +209,6 @@ void kernel_main() {
 #endif
 
     in1_valid_sem.set(VALID);
-    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address consumed by raw NoC primitives
-    const uint64_t in1_sender_semaphore_noc_addr =
-        get_noc_addr(in1_sender_noc_x, in1_sender_noc_y, get_semaphore(in1_sender_semaphore_id));
 
     // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address consumed by raw NoC primitives
     const uint64_t in1_receiver_semaphore_noc_addr =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in1_sender_out.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in1_sender_out.cpp
@@ -107,9 +107,7 @@ void kernel_main() {
     Semaphore<> in1_sender_sem(in1_sender_semaphore_id);
     Semaphore<> in1_receiver_sem(in1_receiver_semaphore_id);
     Semaphore<> in1_valid_sem(in1_valid_semaphore_id);
-    // Device 2.0 migration: legacy primitive retained: local L1 offset, source for noc_semaphore_set_remote
     const uint32_t in1_valid_semaphore_addr = get_semaphore(in1_valid_semaphore_id);
-    // Device 2.0 migration: legacy primitive retained: local L1 offset, consumed by precomposed-NoC destination
     const uint32_t in1_receiver_semaphore_addr = get_semaphore(in1_receiver_semaphore_id);
     const uint32_t M_start_tile = get_arg_val<uint32_t>(argidx++);
     const uint32_t M_end_tile = get_arg_val<uint32_t>(argidx++);
@@ -210,7 +208,6 @@ void kernel_main() {
 
     in1_valid_sem.set(VALID);
 
-    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address consumed by raw NoC primitives
     const uint64_t in1_receiver_semaphore_noc_addr =
         get_noc_addr(in1_dest_noc_x, in1_dest_noc_y, in1_receiver_semaphore_addr);
 
@@ -249,8 +246,6 @@ void kernel_main() {
     }
 
     // FSDP semaphores (forward + backward counters incremented by remote fabric sends).
-    // Device 2.0 migration: legacy primitive retained: GlobalSemaphore-style raw L1 address from common args,
-    // passed by ptr into compute_actual_k_block helper that consumes it with noc_semaphore_wait_min
     volatile tt_l1_ptr uint32_t* fsdp_sem_forward_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(fsdp_sem_forward);
     volatile tt_l1_ptr uint32_t* fsdp_sem_backward_ptr =
@@ -415,8 +410,6 @@ void kernel_main() {
                     const uint32_t local_k_end = local_k_start + K_tiles_per_device;
                     {
                         uint32_t write_ptr = in1_start_address;
-                        // Device 2.0 migration: legacy primitive retained: TensorAccessor-based read API matches
-                        // helper functions' internal idiom; no D2 equivalent in matmul_dataflow_common.hpp helpers
                         // Left half (real data: local weight DRAM if this is our stripe, else PWB).
                         for (uint32_t k = 0; k < k_left_tiles; k++) {
                             uint32_t global_k_tile = k_block_left_tile + k;
@@ -494,7 +487,6 @@ void kernel_main() {
                      */
                     for (uint32_t i = 0; i < K_block_tiles; i++) {
                         uint64_t in1_unicast_data_addr = in1_unicast_data_base_addr | in1_start_address;
-                        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC destination
                         noc_async_write(in1_start_address, in1_unicast_data_addr, current_N_tiles_bytes);
                         in1_start_address += full_N_tiles_bytes;
                     }
@@ -503,8 +495,6 @@ void kernel_main() {
                     noc_obj.async_writes_flushed();
 #endif
 
-                    // Device 2.0 migration: legacy primitive retained: src/dst sems use different L1 ids, so
-                    // Semaphore<>::set_multicast cannot be substituted (writes remote at sender's L1 offset)
                     noc_semaphore_set_remote(in1_valid_semaphore_addr, in1_receiver_semaphore_noc_addr);
                 }
 #ifdef FSDP_FUSED
@@ -578,8 +568,6 @@ void kernel_main() {
 
                 uint32_t l1_write_addr_in2 = cb_in2.get_write_ptr();
                 for (uint32_t n_tile_id = n_tile; n_tile_id < n_tile_end; n_tile_id++) {
-                    // Device 2.0 migration: legacy primitive retained: matches helper internal idiom in
-                    // matmul_dataflow_common.hpp (TensorAccessor-based per-page reads)
                     noc_async_read_page(n_tile_id, in2_reader, l1_write_addr_in2);
                     l1_write_addr_in2 += in2_tile_size;
                 }
@@ -689,7 +677,6 @@ void kernel_main() {
     noc_obj.async_write_barrier();
 
     // Reset FSDP semaphores so the next op-launch starts clean (matches the in0 pattern).
-    // Device 2.0 migration: legacy primitive retained: GlobalSemaphore-style raw L1 ptr, no Semaphore<> id available
     noc_semaphore_set(fsdp_sem_forward_ptr, 0);
     noc_semaphore_set(fsdp_sem_backward_ptr, 0);
 #endif

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in1_sender_out.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in1_sender_out.cpp
@@ -420,10 +420,19 @@ void kernel_main() {
                                     continue;
                                 }
                                 if (local) {
-                                    noc_async_read_tile(
-                                        (global_k_tile - local_k_start) * N_tiles + n, local_weight_reader, write_ptr);
+                                    noc_obj.async_read(
+                                        local_weight_reader,
+                                        CoreLocalMem<uint8_t>(write_ptr),
+                                        in1_tile_size,
+                                        {.page_id = (global_k_tile - local_k_start) * N_tiles + n},
+                                        {});
                                 } else {
-                                    noc_async_read_tile(global_k_tile * pwb_N_Wt + n, in1_reader, write_ptr);
+                                    noc_obj.async_read(
+                                        in1_reader,
+                                        CoreLocalMem<uint8_t>(write_ptr),
+                                        in1_tile_size,
+                                        {.page_id = global_k_tile * pwb_N_Wt + n},
+                                        {});
                                 }
                                 write_ptr += in1_tile_size;
                             }
@@ -441,10 +450,19 @@ void kernel_main() {
                                 if (global_k_tile >= K_tiles) {
                                     fill_zeros_async(noc_obj, cb_in1, in1_tile_size, write_ptr - in1_start_address);
                                 } else if (local) {
-                                    noc_async_read_tile(
-                                        (global_k_tile - local_k_start) * N_tiles + n, local_weight_reader, write_ptr);
+                                    noc_obj.async_read(
+                                        local_weight_reader,
+                                        CoreLocalMem<uint8_t>(write_ptr),
+                                        in1_tile_size,
+                                        {.page_id = (global_k_tile - local_k_start) * N_tiles + n},
+                                        {});
                                 } else {
-                                    noc_async_read_tile(global_k_tile * pwb_N_Wt + n, in1_reader, write_ptr);
+                                    noc_obj.async_read(
+                                        in1_reader,
+                                        CoreLocalMem<uint8_t>(write_ptr),
+                                        in1_tile_size,
+                                        {.page_id = global_k_tile * pwb_N_Wt + n},
+                                        {});
                                 }
                                 write_ptr += in1_tile_size;
                             }
@@ -568,7 +586,12 @@ void kernel_main() {
 
                 uint32_t l1_write_addr_in2 = cb_in2.get_write_ptr();
                 for (uint32_t n_tile_id = n_tile; n_tile_id < n_tile_end; n_tile_id++) {
-                    noc_async_read_page(n_tile_id, in2_reader, l1_write_addr_in2);
+                    noc_obj.async_read(
+                        in2_reader,
+                        CoreLocalMem<uint8_t>(l1_write_addr_in2),
+                        in2_tile_size,
+                        {.page_id = n_tile_id},
+                        {});
                     l1_write_addr_in2 += in2_tile_size;
                 }
                 noc_obj.async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/matmul_dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/matmul_dataflow_common.hpp
@@ -7,7 +7,10 @@
 #include <tuple>
 #include <utility>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/core_local_mem.h"
 
 namespace detail {
 template <typename... Args, uint32_t... Indexes>
@@ -157,20 +160,24 @@ void compute_actual_k_block(
             if constexpr (IsLinear) {
                 // Linear uni-ring: one slice per iter from "successor" (Dev k+1 normally; for
                 // Dev N-1, from Dev 0 via long send). All sends use out_ready_semaphore_forward
-                // at the receiver — single sem per iter.
+                // at the receiver -- single sem per iter.
                 //
                 // The sender skips the redundant final relay lap (the last K_blocks_per_device
                 // iters; see dm_in0_sender), so it fires exactly (N-1)*K_blocks_per_device sem
-                // incs per m_block — precisely the count the receiver waits on here. sem ends each
+                // incs per m_block -- precisely the count the receiver waits on here. sem ends each
                 // m_block exactly at sem_target with nothing left in flight, so no compensation
                 // (and no end-of-op drain) is needed.
                 if (device_iter > 0) {
+                    // Device 2.0 migration: legacy primitive retained: out_ready_semaphore_forward is a
+                    // GlobalSemaphore address (raw L1 pointer); Semaphore<> binds to per-program ids.
                     noc_semaphore_wait_min(out_ready_semaphore_forward, sem_target_forward + 1);
                     sem_target_forward += 1;
                 }
             } else if (device_iter > 0) {
                 // Ring: both halves arrive simultaneously from both directions
                 // (both neighbors always exist for Ring topology by construction).
+                // Device 2.0 migration: legacy primitive retained: out_ready_semaphore_forward/backward are
+                // GlobalSemaphore addresses (raw L1 pointer); Semaphore<> binds to per-program ids.
                 noc_semaphore_wait_min(out_ready_semaphore_forward, sem_target_forward + core_order_size);
                 sem_target_forward += core_order_size;
                 noc_semaphore_wait_min(out_ready_semaphore_backward, sem_target_backward + core_order_size);
@@ -190,6 +197,7 @@ struct PacketHeaders {
 
 template <typename TensorAccessorType, typename ConnectionHandleType>
 FORCE_INLINE void forward_half_block_to_fabric_neighbor(
+    Noc noc,
     uint32_t m_tile_start,
     uint32_t k_tile_start,  // this is the k_tile_index in the output
     uint32_t m_block_tiles,
@@ -255,7 +263,7 @@ FORCE_INLINE void forward_half_block_to_fabric_neighbor(
                     mux_connection_handle, pkt_unicast_hdr, l1_read_addr, NocUnicastCommandHeader{noc_addrs[0]});
             }
 
-            noc_async_writes_flushed();
+            noc.async_writes_flushed();
             tiles_read += tiles_to_put_in_current_packet;
             l1_read_addr += (tiles_to_put_in_current_packet * page_size);
             if (reached_half_block_end) {
@@ -270,15 +278,16 @@ FORCE_INLINE void forward_half_block_to_fabric_neighbor(
         pkt_hdr_sem_inc,
         tt::tt_fabric::NocUnicastAtomicIncCommandHeader{out_ready_sem_noc_addr_in_pkt, 0});
 
-    noc_async_writes_flushed();
+    noc.async_writes_flushed();
 }
 
 // Sibling of forward_half_block_to_fabric_neighbor for in1 (FSDP weight gather).
 // Splits the same K dimension as in0 so left/right halves stay K-aligned across both operands,
-// but walks (half_k_block_tiles rows × N_block_tiles per-row tiles) instead of (m_block_tiles × half_k).
-// In1 L1 layout is K_block_tiles rows × N_block_tiles cols of tiles; PWB layout is [K_full, N_local].
+// but walks (half_k_block_tiles rows x N_block_tiles per-row tiles) instead of (m_block_tiles x half_k).
+// In1 L1 layout is K_block_tiles rows x N_block_tiles cols of tiles; PWB layout is [K_full, N_local].
 template <typename TensorAccessorType, typename ConnectionHandleType>
 FORCE_INLINE void forward_in1_half_block_to_fabric_neighbor(
+    Noc noc,
     uint32_t k_tile_start,  // K-tile index in PWB at the start of the full K-block
     uint32_t n_tile_start,  // N-tile index in PWB at the start of the current N-block
     uint32_t k_left_tiles,
@@ -341,7 +350,7 @@ FORCE_INLINE void forward_in1_half_block_to_fabric_neighbor(
                     mux_connection_handle, pkt_unicast_hdr, l1_read_addr, NocUnicastCommandHeader{noc_addrs[0]});
             }
 
-            noc_async_writes_flushed();
+            noc.async_writes_flushed();
             tiles_read += tiles_to_put_in_current_packet;
             l1_read_addr += (tiles_to_put_in_current_packet * page_size);
             if (reached_row_end) {
@@ -356,7 +365,7 @@ FORCE_INLINE void forward_in1_half_block_to_fabric_neighbor(
         pkt_hdr_sem_inc,
         tt::tt_fabric::NocUnicastAtomicIncCommandHeader{out_ready_sem_noc_addr_in_pkt, 0});
 
-    noc_async_writes_flushed();
+    noc.async_writes_flushed();
 }
 #endif
 
@@ -366,7 +375,7 @@ bool is_backward_k_block_iter(uint32_t k_block_iter, uint32_t k_blocks_per_devic
     return (device_iter % 2);
 }
 
-inline void fill_zeros_async(const Noc& noc, const CircularBuffer& cb, uint32_t bytes, uint32_t offset_bytes = 0) {
+inline void fill_zeros_async(Noc noc, CircularBuffer cb, uint32_t bytes, uint32_t offset_bytes = 0) {
     noc.async_write_zeros(cb, bytes, {.offset_bytes = offset_bytes});
 }
 
@@ -400,9 +409,10 @@ template <
 #endif
     >
 void read_in0_block_sync(
+    Noc noc,
     const TensorAccessorType& tensor_accessor,
     const TensorShape2D& shape,
-    uint32_t cb_id,
+    CircularBuffer cb,
     uint32_t tile_size_bytes,
 #ifdef READ_FROM_LOCAL_INPUT
     const LocalTensorAccessorType& in3_accessor,
@@ -425,8 +435,6 @@ void read_in0_block_sync(
     // inverted range would still be a bug, hence >=.
     ASSERT(d1_end_right >= d1_start_right);
 
-    Noc noc;
-    CircularBuffer cb(cb_id);
     const uint32_t cb_base_write_ptr = cb.get_write_ptr();
     uint32_t write_ptr = cb_base_write_ptr;
     for (uint32_t i = d0_start; i < d0_end; i++) {
@@ -439,11 +447,13 @@ void read_in0_block_sync(
                 if (local_k_start <= j && j <= local_k_end) {
                     // read from self_tensor_accessor
                     uint32_t tile_id = i * input_tensor_Wt + (j - local_k_start);
-                    noc_async_read_page(tile_id, in3_accessor, write_ptr);
+                    noc.async_read(
+                        in3_accessor, CoreLocalMem<uint8_t>(write_ptr), tile_size_bytes, {.page_id = tile_id}, {});
                 } else {
 #endif
                     uint32_t tile_id = i * shape.logical_d1 + j;
-                    noc_async_read_page(tile_id, tensor_accessor, write_ptr);
+                    noc.async_read(
+                        tensor_accessor, CoreLocalMem<uint8_t>(write_ptr), tile_size_bytes, {.page_id = tile_id}, {});
 #ifdef READ_FROM_LOCAL_INPUT
                 }
 #endif
@@ -460,11 +470,13 @@ void read_in0_block_sync(
                 if (local_k_start <= j && j <= local_k_end) {
                     // read from self_tensor_accessor
                     uint32_t tile_id = i * input_tensor_Wt + (j - local_k_start);
-                    noc_async_read_page(tile_id, in3_accessor, write_ptr);
+                    noc.async_read(
+                        in3_accessor, CoreLocalMem<uint8_t>(write_ptr), tile_size_bytes, {.page_id = tile_id}, {});
                 } else {
 #endif
                     uint32_t tile_id = i * shape.logical_d1 + j;
-                    noc_async_read_page(tile_id, tensor_accessor, write_ptr);
+                    noc.async_read(
+                        tensor_accessor, CoreLocalMem<uint8_t>(write_ptr), tile_size_bytes, {.page_id = tile_id}, {});
 #ifdef READ_FROM_LOCAL_INPUT
                 }
 #endif
@@ -476,7 +488,7 @@ void read_in0_block_sync(
         // finish up incrementing write_ptr if (d1_end - d1_start) < K_block_tiles
         write_ptr += (d1_tiles_right - (d1_end_right - d1_start_right)) * tile_size_bytes;
     }
-    noc_async_read_barrier();
+    noc.async_read_barrier();
     noc.write_zeros_l1_barrier();
 }
 
@@ -487,9 +499,10 @@ void read_in0_block_sync(
  */
 template <uint32_t K_block_tiles, uint32_t N_block_tiles, typename TensorAccessorType>
 void read_in1_block_sync(
+    Noc noc,
     const TensorAccessorType& tensor_accessor,
     const TensorShape2D& shape,
-    uint32_t cb_id,
+    CircularBuffer cb,
     uint32_t tile_size_bytes,
     uint32_t d0_start_left,
     uint32_t d0_end_left,
@@ -501,8 +514,6 @@ void read_in1_block_sync(
     // Linear topology is unidirectional: the "right" (backward) half is legitimately empty.
     ASSERT(d0_end_right >= d0_start_right);
     ASSERT(d1_end > d1_start);
-    Noc noc;
-    CircularBuffer cb(cb_id);
     const uint32_t cb_base_write_ptr = cb.get_write_ptr();
     uint32_t write_ptr = cb_base_write_ptr;
     for (uint32_t i = d0_start_left; i < d0_end_left; i++) {
@@ -513,7 +524,8 @@ void read_in1_block_sync(
             }
             if (i < shape.logical_d0) {
                 uint32_t tile_id = i * shape.logical_d1 + j;
-                noc_async_read_page(tile_id, tensor_accessor, write_ptr);
+                noc.async_read(
+                    tensor_accessor, CoreLocalMem<uint8_t>(write_ptr), tile_size_bytes, {.page_id = tile_id}, {});
             } else {
                 fill_zeros_async(noc, cb, tile_size_bytes, write_ptr - cb_base_write_ptr);
             }
@@ -530,7 +542,8 @@ void read_in1_block_sync(
             }
             if (i < shape.logical_d0) {
                 uint32_t tile_id = i * shape.logical_d1 + j;
-                noc_async_read_page(tile_id, tensor_accessor, write_ptr);
+                noc.async_read(
+                    tensor_accessor, CoreLocalMem<uint8_t>(write_ptr), tile_size_bytes, {.page_id = tile_id}, {});
             } else {
                 fill_zeros_async(noc, cb, tile_size_bytes, write_ptr - cb_base_write_ptr);
             }
@@ -539,7 +552,7 @@ void read_in1_block_sync(
         // finish up incrementing write_ptr if (d1_end - d1_start) < N_block_tiles
         write_ptr += (N_block_tiles - (d1_end - d1_start)) * tile_size_bytes;
     }
-    noc_async_read_barrier();
+    noc.async_read_barrier();
     noc.write_zeros_l1_barrier();
 }
 
@@ -549,6 +562,7 @@ void read_in1_block_sync(
  */
 template <uint32_t M_block_tiles, uint32_t N_block_tiles, typename TensorAccessorType>
 void write_block_sync(
+    Noc noc,
     const TensorAccessorType& tensor_accessor,
     const TensorShape2D& shape,
     uint32_t read_ptr,
@@ -570,13 +584,14 @@ void write_block_sync(
                 continue;
             }
             uint32_t tile_id = i * shape.logical_d1 + j;
-            noc_async_write_page(tile_id, tensor_accessor, read_ptr);
+            noc.async_write(
+                CoreLocalMem<uint8_t>(read_ptr), tensor_accessor, tile_size_bytes, {}, {.page_id = tile_id});
             read_ptr += tile_size_bytes;
         }
         // finish up incrementing read_ptr if (d1_end - d1_start) < N_block_tiles
         read_ptr += (N_block_tiles - (d1_end - d1_start)) * tile_size_bytes;
     }
-    noc_async_writes_flushed();
+    noc.async_writes_flushed();
 }
 
 /**
@@ -594,11 +609,12 @@ void write_block_sync(
  */
 template <uint32_t M_block_tiles, uint32_t N_block_tiles, typename TensorAccessorType>
 void read_ternary_blocks_sync(
+    Noc noc,
     const TensorAccessorType& ternary_a_accessor,
     const TensorAccessorType& ternary_b_accessor,
     const TensorShape2D& shape,
-    uint32_t ternary_a_cb,
-    uint32_t ternary_b_cb,
+    CircularBuffer ternary_a_cb,
+    CircularBuffer ternary_b_cb,
     uint32_t a_tile_size_bytes,
     uint32_t b_tile_size_bytes,
     uint32_t broadcast_ternary_b,
@@ -611,49 +627,59 @@ void read_ternary_blocks_sync(
 
     if (broadcast_ternary_b) {
         // Broadcast: read single row, push all at once
-        cb_reserve_back(ternary_b_cb, N_block_tiles);
-        uint32_t ternary_b_write_ptr = get_write_ptr(ternary_b_cb);
+        ternary_b_cb.reserve_back(N_block_tiles);
+        uint32_t ternary_b_write_ptr = ternary_b_cb.get_write_ptr();
         for (uint32_t n_tile_id = d1_start; n_tile_id < d1_end; n_tile_id++) {
             if (n_tile_id >= shape.logical_d1) {
                 break;
             }
-            noc_async_read_page(n_tile_id, ternary_b_accessor, ternary_b_write_ptr);
+            noc.async_read(
+                ternary_b_accessor,
+                CoreLocalMem<uint8_t>(ternary_b_write_ptr),
+                b_tile_size_bytes,
+                {.page_id = n_tile_id},
+                {});
             ternary_b_write_ptr += b_tile_size_bytes;
         }
-        noc_async_read_barrier();
-        cb_push_back(ternary_b_cb, N_block_tiles);
+        noc.async_read_barrier();
+        ternary_b_cb.push_back(N_block_tiles);
     } else {
         // No broadcast: read row-by-row (matches ternary_a pattern)
         uint32_t b_m_id = 0;
         uint32_t b_i = d0_start;
         for (; b_i < d0_end; b_i++, b_m_id++) {
-            cb_reserve_back(ternary_b_cb, N_block_tiles);
-            uint32_t ternary_b_write_ptr = get_write_ptr(ternary_b_cb);
+            ternary_b_cb.reserve_back(N_block_tiles);
+            uint32_t ternary_b_write_ptr = ternary_b_cb.get_write_ptr();
             for (uint32_t j = d1_start; j < d1_end; j++) {
                 if (j >= shape.logical_d1) {
                     break;
                 }
                 if (b_i < shape.logical_d0) {
                     uint32_t tile_id = b_i * shape.logical_d1 + j;
-                    noc_async_read_page(tile_id, ternary_b_accessor, ternary_b_write_ptr);
+                    noc.async_read(
+                        ternary_b_accessor,
+                        CoreLocalMem<uint8_t>(ternary_b_write_ptr),
+                        b_tile_size_bytes,
+                        {.page_id = tile_id},
+                        {});
                 }
                 ternary_b_write_ptr += b_tile_size_bytes;
             }
-            noc_async_read_barrier();
-            cb_push_back(ternary_b_cb, N_block_tiles);
+            noc.async_read_barrier();
+            ternary_b_cb.push_back(N_block_tiles);
         }
         for (; b_m_id < M_block_tiles; b_m_id++) {
-            cb_reserve_back(ternary_b_cb, N_block_tiles);
-            cb_push_back(ternary_b_cb, N_block_tiles);
+            ternary_b_cb.reserve_back(N_block_tiles);
+            ternary_b_cb.push_back(N_block_tiles);
         }
     }
 
     uint32_t m_id = 0;
     uint32_t i = d0_start;
     for (; i < d0_end; i++, m_id++) {
-        cb_reserve_back(ternary_a_cb, N_block_tiles);
+        ternary_a_cb.reserve_back(N_block_tiles);
 
-        uint32_t ternary_a_write_ptr = get_write_ptr(ternary_a_cb);
+        uint32_t ternary_a_write_ptr = ternary_a_cb.get_write_ptr();
         for (uint32_t j = d1_start; j < d1_end; j++) {
             if (j >= shape.logical_d1) {
                 // Do not move tile data into CB if tile is outside ternary/output tensor.
@@ -664,17 +690,22 @@ void read_ternary_blocks_sync(
             }
             if (i < shape.logical_d0) {
                 uint32_t tile_id = i * shape.logical_d1 + j;
-                noc_async_read_page(tile_id, ternary_a_accessor, ternary_a_write_ptr);
+                noc.async_read(
+                    ternary_a_accessor,
+                    CoreLocalMem<uint8_t>(ternary_a_write_ptr),
+                    a_tile_size_bytes,
+                    {.page_id = tile_id},
+                    {});
             }
             ternary_a_write_ptr += a_tile_size_bytes;
         }
-        noc_async_read_barrier();
+        noc.async_read_barrier();
 
-        cb_push_back(ternary_a_cb, N_block_tiles);
+        ternary_a_cb.push_back(N_block_tiles);
     }
     for (; m_id < M_block_tiles; m_id++) {
-        cb_reserve_back(ternary_a_cb, N_block_tiles);
-        cb_push_back(ternary_a_cb, N_block_tiles);
+        ternary_a_cb.reserve_back(N_block_tiles);
+        ternary_a_cb.push_back(N_block_tiles);
     }
 }
 
@@ -684,43 +715,56 @@ void read_ternary_blocks_sync(
  */
 template <uint32_t M_block_tiles, uint32_t N_block_tiles, typename TensorAccessorType>
 void write_block_sync_granular(
+    Noc noc,
     const TensorAccessorType& tensor_accessor,
     const TensorShape2D& shape,
-    uint32_t cb_id_out,
+    CircularBuffer cb_out,
     uint32_t tile_size_bytes,
     uint32_t d0_start,
     uint32_t d0_end,
     uint32_t d1_start,
     uint32_t d1_end) {
     for (uint32_t m_id = 0; m_id < M_block_tiles; m_id++) {
-        cb_wait_front(cb_id_out, N_block_tiles);
+        cb_out.wait_front(N_block_tiles);
         uint32_t m_tile = d0_start + m_id;
         if (m_tile < d0_end && m_tile < shape.logical_d0) {
-            uint32_t out_read_ptr = get_read_ptr(cb_id_out);
+            uint32_t out_read_ptr = cb_out.get_read_ptr();
             for (uint32_t n_tile_id = d1_start; n_tile_id < d1_end; n_tile_id++) {
                 if (n_tile_id >= shape.logical_d1) {
                     break;
                 }
                 uint32_t tile_id = m_tile * shape.logical_d1 + n_tile_id;
-                noc_async_write_page(tile_id, tensor_accessor, out_read_ptr);
+                noc.async_write(
+                    CoreLocalMem<uint8_t>(out_read_ptr), tensor_accessor, tile_size_bytes, {}, {.page_id = tile_id});
                 out_read_ptr += tile_size_bytes;
             }
         }
-        cb_pop_front(cb_id_out, N_block_tiles);
+        cb_out.pop_front(N_block_tiles);
     }
-    noc_async_writes_flushed();
+    noc.async_writes_flushed();
 }
 
 /**
  * Helper: dispatch to correct tuple element using fold expression.
- * Each branch calls noc_async_write_page with the concrete TensorAccessor type.
+ * Each branch calls noc.async_write with the concrete TensorAccessor type.
  */
 template <typename Tuple, size_t... Is>
 FORCE_INLINE void write_tile_to_chunk(
-    const Tuple& accessors, uint32_t chunk_idx, uint32_t tile_id, uint32_t read_ptr, std::index_sequence<Is...>) {
+    Noc noc,
+    const Tuple& accessors,
+    uint32_t chunk_idx,
+    uint32_t tile_id,
+    uint32_t read_ptr,
+    uint32_t tile_size_bytes,
+    std::index_sequence<Is...>) {
     // Fold expression: expands to if/else chain at compile time
-    // Each branch calls noc_async_write_page with the concrete type
-    ((chunk_idx == Is ? (noc_async_write_page(tile_id, std::get<Is>(accessors), read_ptr), void()) : void()), ...);
+    // Each branch calls noc.async_write with the concrete TensorAccessor type
+    ((chunk_idx == Is
+          ? (noc.async_write(
+                 CoreLocalMem<uint8_t>(read_ptr), std::get<Is>(accessors), tile_size_bytes, {}, {.page_id = tile_id}),
+             void())
+          : void()),
+     ...);
 }
 
 /**
@@ -736,6 +780,7 @@ template <
     uint32_t N_tiles_per_chunk,
     typename... Accessors>
 void write_block_sync_split(
+    Noc noc,
     const std::tuple<Accessors...>& accessors,
     const TensorShape2D& chunk_shape,
     uint32_t read_ptr,
@@ -776,18 +821,24 @@ void write_block_sync_split(
 
             // Compile-time dispatch preserving concrete types
             write_tile_to_chunk(
-                accessors, chunk_idx, tile_id_in_chunk, read_ptr, std::index_sequence_for<Accessors...>{});
+                noc,
+                accessors,
+                chunk_idx,
+                tile_id_in_chunk,
+                read_ptr,
+                tile_size_bytes,
+                std::index_sequence_for<Accessors...>{});
             read_ptr += tile_size_bytes;
         }
         // finish up incrementing read_ptr if (d1_end - d1_start) < N_block_tiles
         read_ptr += (N_block_tiles - (d1_end - d1_start)) * tile_size_bytes;
     }
-    noc_async_writes_flushed();
+    noc.async_writes_flushed();
 }
 
 /**
  * Variadic write method for split operation with N output tensors.
- * Takes the tuple directly, preserving concrete TensorAccessor<DSpec> types for noc_async_write_tile.
+ * Takes the tuple directly, preserving concrete TensorAccessor<DSpec> types for noc.async_write.
  */
 template <
     uint32_t M_block_tiles,
@@ -796,9 +847,10 @@ template <
     uint32_t N_tiles_per_chunk,
     typename... Accessors>
 void write_block_sync_granular_split(
+    Noc noc,
     const std::tuple<Accessors...>& accessors,
     const TensorShape2D& chunk_shape,
-    uint32_t cb_id_out,
+    CircularBuffer cb_out,
     uint32_t tile_size_bytes,
     uint32_t d0_start,
     uint32_t d0_end,
@@ -808,10 +860,10 @@ void write_block_sync_granular_split(
     const uint32_t tile_idx_in_chunk_start = d1_start % N_tiles_per_chunk;
 
     for (uint32_t m_id = 0; m_id < M_block_tiles; m_id++) {
-        cb_wait_front(cb_id_out, N_block_tiles);
+        cb_out.wait_front(N_block_tiles);
         uint32_t m_tile = d0_start + m_id;
         if (m_tile < d0_end && m_tile < chunk_shape.logical_d0) {
-            uint32_t out_read_ptr = get_read_ptr(cb_id_out);
+            uint32_t out_read_ptr = cb_out.get_read_ptr();
 
             uint32_t chunk_idx = chunk_idx_start;
             uint32_t tile_idx_in_chunk = tile_idx_in_chunk_start;
@@ -830,14 +882,20 @@ void write_block_sync_granular_split(
                 uint32_t tile_id = m_tile * chunk_shape.logical_d1 + tile_idx_in_chunk;
                 // Compile-time dispatch preserving concrete types
                 write_tile_to_chunk(
-                    accessors, chunk_idx, tile_id, out_read_ptr, std::index_sequence_for<Accessors...>{});
+                    noc,
+                    accessors,
+                    chunk_idx,
+                    tile_id,
+                    out_read_ptr,
+                    tile_size_bytes,
+                    std::index_sequence_for<Accessors...>{});
 
                 out_read_ptr += tile_size_bytes;
             }
         }
-        cb_pop_front(cb_id_out, N_block_tiles);
+        cb_out.pop_front(N_block_tiles);
     }
-    noc_async_writes_flushed();
+    noc.async_writes_flushed();
 }
 
 #ifdef USE_MUX
@@ -977,6 +1035,7 @@ FORCE_INLINE PacketHeaders allocate_and_init_packet_headers(
 
 template <typename ConnectionHandleType>
 FORCE_INLINE void close_mux(
+    Noc noc,
     ConnectionHandleType mux_connection_handle,
     bool is_termination_master,
     uint32_t termination_sync_address,
@@ -989,13 +1048,15 @@ FORCE_INLINE void close_mux(
     tt::tt_fabric::fabric_client_disconnect(*mux_connection_handle);
     if (is_termination_master) {
         auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
+        // Device 2.0 migration: legacy primitive retained: fabric-mux sync address (raw L1 pointer, not a program id).
         noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
         tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
     } else {
         uint64_t dest_addr =
             safe_get_noc_addr(termination_master_noc_x, termination_master_noc_y, termination_sync_address, 0);
+        // Device 2.0 migration: legacy primitive retained: fabric-mux sync address (raw L1 pointer, not a program id).
         noc_semaphore_inc(dest_addr, 1);
-        noc_async_atomic_barrier();
+        noc.async_atomic_barrier();
     }
 }
 #endif

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/matmul_dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/matmul_dataflow_common.hpp
@@ -168,16 +168,12 @@ void compute_actual_k_block(
                 // m_block exactly at sem_target with nothing left in flight, so no compensation
                 // (and no end-of-op drain) is needed.
                 if (device_iter > 0) {
-                    // Device 2.0 migration: legacy primitive retained: out_ready_semaphore_forward is a
-                    // GlobalSemaphore address (raw L1 pointer); Semaphore<> binds to per-program ids.
                     noc_semaphore_wait_min(out_ready_semaphore_forward, sem_target_forward + 1);
                     sem_target_forward += 1;
                 }
             } else if (device_iter > 0) {
                 // Ring: both halves arrive simultaneously from both directions
                 // (both neighbors always exist for Ring topology by construction).
-                // Device 2.0 migration: legacy primitive retained: out_ready_semaphore_forward/backward are
-                // GlobalSemaphore addresses (raw L1 pointer); Semaphore<> binds to per-program ids.
                 noc_semaphore_wait_min(out_ready_semaphore_forward, sem_target_forward + core_order_size);
                 sem_target_forward += core_order_size;
                 noc_semaphore_wait_min(out_ready_semaphore_backward, sem_target_backward + core_order_size);
@@ -1048,13 +1044,11 @@ FORCE_INLINE void close_mux(
     tt::tt_fabric::fabric_client_disconnect(*mux_connection_handle);
     if (is_termination_master) {
         auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
-        // Device 2.0 migration: legacy primitive retained: fabric-mux sync address (raw L1 pointer, not a program id).
         noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
         tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
     } else {
         uint64_t dest_addr =
             safe_get_noc_addr(termination_master_noc_x, termination_master_noc_y, termination_sync_address, 0);
-        // Device 2.0 migration: legacy primitive retained: fabric-mux sync address (raw L1 pointer, not a program id).
         noc_semaphore_inc(dest_addr, 1);
         noc.async_atomic_barrier();
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/reduction_receiver.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/reduction_receiver.cpp
@@ -33,5 +33,6 @@ void kernel_main() {
 
     // 2. Signal compute kernel to start processing
     cb.push_back(total_num_reduction_tiles);
+    // Device 2.0 migration: legacy primitive retained: same absolute-L1-address sem as above; Semaphore<> binds ids.
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr), 0);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/reduction_receiver.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/reduction_receiver.cpp
@@ -27,12 +27,9 @@ void kernel_main() {
     CircularBuffer cb(cb_id);
 
     // 1. Wait for signal from All-Gather worker
-    // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is an absolute L1 address from the
-    // program factory, which is a target of a remote atomic increment over fabric. Semaphore<> binds to ids only.
     noc_semaphore_wait(out_ready_sema, out_ready_sem_wait_value);
 
     // 2. Signal compute kernel to start processing
     cb.push_back(total_num_reduction_tiles);
-    // Device 2.0 migration: legacy primitive retained: same absolute-L1-address sem as above; Semaphore<> binds ids.
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr), 0);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_writer.cpp
@@ -52,6 +52,8 @@ void write_data(
             // than a semaphore id, so Semaphore<> does not apply.
             noc_semaphore_inc(output_semaphore_noc_addr_in_pkt, 1);
         }
+        // Device 2.0 migration: legacy primitive retained: dest_addrs are precomposed uint64_t NoC addresses, not
+        // tensor accessors; Noc::async_write requires a typed endpoint.
         for (uint32_t part = 0; part < parts_count; ++part) {
             noc_async_write(l1_read_addr, dest_addrs[part], payload_sizes[part]);
             l1_read_addr += payload_sizes[part];
@@ -243,6 +245,8 @@ void kernel_main() {
         }
     }
 
+    // Device 2.0 migration: legacy primitives retained: global_init_semaphore_addr is a GlobalSemaphore address
+    // (no id()), so Semaphore<>::wait / set cannot wrap it.
     noc_semaphore_wait(global_init_semaphore_addr_ptr, num_devices - 1);
     noc_semaphore_set(global_init_semaphore_addr_ptr, 0);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_writer.cpp
@@ -48,12 +48,8 @@ void write_data(
     bool local = device_offset == 0;
     if (local) {
         if (last) {
-            // Device 2.0 migration: legacy primitive retained: semaphore inc targets a precomposed NoC address rather
-            // than a semaphore id, so Semaphore<> does not apply.
             noc_semaphore_inc(output_semaphore_noc_addr_in_pkt, 1);
         }
-        // Device 2.0 migration: legacy primitive retained: dest_addrs are precomposed uint64_t NoC addresses, not
-        // tensor accessors; Noc::async_write requires a typed endpoint.
         for (uint32_t part = 0; part < parts_count; ++part) {
             noc_async_write(l1_read_addr, dest_addrs[part], payload_sizes[part]);
             l1_read_addr += payload_sizes[part];
@@ -233,11 +229,6 @@ void kernel_main() {
         uint32_t local_init_semaphore_addr_ptr = reinterpret_cast<uint32_t>(global_init_semaphore_addr_ptr);
 
         if (mcast_size > 1) {
-            // Device 2.0 migration: legacy primitives retained, global_init_semaphore_addr is a GlobalSemaphore address
-            // (init_barrier_semaphore in the program factory). GlobalSemaphore exposes only address() — no id().
-            // Semaphore<>::wait cannot wrap it. Additionally, set_multicast_loopback_src writes the destination
-            // semaphore at a different L1 offset than the local source semaphore, which Semaphore<>::set_multicast
-            // does not support (it reuses the sender's L1 offset).
             noc_semaphore_wait(global_init_semaphore_addr_ptr, num_devices - 1);
             noc_semaphore_set_multicast_loopback_src(
                 local_init_semaphore_addr_ptr, local_set_semaphore_noc_addr, mcast_size, false);
@@ -245,8 +236,6 @@ void kernel_main() {
         }
     }
 
-    // Device 2.0 migration: legacy primitives retained: global_init_semaphore_addr is a GlobalSemaphore address
-    // (no id()), so Semaphore<>::wait / set cannot wrap it.
     noc_semaphore_wait(global_init_semaphore_addr_ptr, num_devices - 1);
     noc_semaphore_set(global_init_semaphore_addr_ptr, 0);
 
@@ -339,7 +328,6 @@ void kernel_main() {
     noc_obj.async_write_barrier();
     fabric_connection.close();
     if (core_id == 0 && link_id == 0) {
-        // Device 2.0 migration: legacy primitives retained, global_semaphore_addr is a GlobalSemaphore address.
         noc_semaphore_wait(global_semaphore_addr_ptr, semaphore_expected_value);
         noc_semaphore_set(global_semaphore_addr_ptr, 0);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/kernels/deepseek_moe_reduce_scatter_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/kernels/deepseek_moe_reduce_scatter_reader.cpp
@@ -76,7 +76,7 @@ void kernel_main() {
         uint32_t tiles_to_read = start_tiles_to_read;
         while (tiles_read < tiles_to_read) {
             if (do_reduce) {
-                // Device 2.0 migration: legacy primitive retained, op_semaphore is a GlobalSemaphore address.
+                // Device 2.0 migration: legacy primitive retained: op_semaphore is a GlobalSemaphore address (no id()).
                 noc_semaphore_wait_min(
                     reinterpret_cast<volatile tt_l1_ptr uint32_t*>(op_semaphore), semaphore_target_val + 1);
                 semaphore_target_val++;
@@ -99,6 +99,6 @@ void kernel_main() {
     }
 
     // reset the semaphore
-    // Device 2.0 migration: legacy primitive retained, op_semaphore is a GlobalSemaphore address.
+    // Device 2.0 migration: legacy primitive retained: op_semaphore is a GlobalSemaphore address (no id()).
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(op_semaphore), 0);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/kernels/deepseek_moe_reduce_scatter_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/kernels/deepseek_moe_reduce_scatter_reader.cpp
@@ -76,7 +76,6 @@ void kernel_main() {
         uint32_t tiles_to_read = start_tiles_to_read;
         while (tiles_read < tiles_to_read) {
             if (do_reduce) {
-                // Device 2.0 migration: legacy primitive retained: op_semaphore is a GlobalSemaphore address (no id()).
                 noc_semaphore_wait_min(
                     reinterpret_cast<volatile tt_l1_ptr uint32_t*>(op_semaphore), semaphore_target_val + 1);
                 semaphore_target_val++;
@@ -99,6 +98,5 @@ void kernel_main() {
     }
 
     // reset the semaphore
-    // Device 2.0 migration: legacy primitive retained: op_semaphore is a GlobalSemaphore address (no id()).
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(op_semaphore), 0);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
@@ -13,6 +13,7 @@
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/eltwise_unary/fill.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/dataflow/circular_buffer.h"
 
 // Need these headers for running SFPU on PACK thread
 #ifdef TRISC_PACK
@@ -167,21 +168,32 @@ void kernel_main() {
     [[maybe_unused]] const auto ring_neighbor_physical_x = get_arg_val<uint32_t>(argidx++);
     [[maybe_unused]] const auto ring_neighbor_physical_y = get_arg_val<uint32_t>(argidx++);
 
-    // CBs
-    constexpr auto cb_s2c_in = tt::CBIndex::c_0;     // tilize_output_cb_id
-    constexpr auto cb_r2c_w0_w1 = tt::CBIndex::c_3;  // cb_r2c_w0
-    constexpr auto cb_c2w_rdy = tt::CBIndex::c_4;
-    constexpr auto cb_w2c_rdy = tt::CBIndex::c_5;
-    constexpr auto cb_s2c_in2 = tt::CBIndex::c_6;
-    constexpr auto cb_w2c_md = tt::CBIndex::c_7;
+    // CB ids
+    constexpr auto cb_s2c_in_id = tt::CBIndex::c_0;     // tilize_output_cb_id
+    constexpr auto cb_r2c_w0_w1_id = tt::CBIndex::c_3;  // cb_r2c_w0
+    constexpr auto cb_c2w_rdy_id = tt::CBIndex::c_4;
+    constexpr auto cb_w2c_rdy_id = tt::CBIndex::c_5;
+    constexpr auto cb_s2c_in2_id = tt::CBIndex::c_6;
+    constexpr auto cb_w2c_md_id = tt::CBIndex::c_7;
 
-    constexpr auto cb_c2s_out = tt::CBIndex::c_1;  // matmul_writer_cb_id
+    constexpr auto cb_c2s_out_id = tt::CBIndex::c_1;  // matmul_writer_cb_id
     // c_8 is unused on matmul cores when bias is off (CB not allocated); when has_bias, tilize uses c_8 only on
     // tilize cores. Only referenced in if constexpr(has_bias) branches below.
-    constexpr auto cb_c2c_ones_tile = tt::CBIndex::c_8;
+    constexpr auto cb_c2c_ones_tile_id = tt::CBIndex::c_8;
 
     // CB Aliases
-    constexpr auto cb_r2c_w2 = tt::CBIndex::c_3;  // reuse cb_r2c_w0_w1
+    constexpr auto cb_r2c_w2_id = tt::CBIndex::c_3;  // reuse cb_r2c_w0_w1
+
+    // CircularBuffer typed wrappers
+    CircularBuffer cb_s2c_in(cb_s2c_in_id);
+    CircularBuffer cb_r2c_w0_w1(cb_r2c_w0_w1_id);
+    CircularBuffer cb_c2w_rdy(cb_c2w_rdy_id);
+    CircularBuffer cb_w2c_rdy(cb_w2c_rdy_id);
+    CircularBuffer cb_s2c_in2(cb_s2c_in2_id);
+    CircularBuffer cb_w2c_md(cb_w2c_md_id);
+    CircularBuffer cb_c2s_out(cb_c2s_out_id);
+    CircularBuffer cb_c2c_ones_tile(cb_c2c_ones_tile_id);
+    CircularBuffer cb_r2c_w2(cb_r2c_w2_id);
 
     // Pre-computed shard lookup tables — avoids runtime div/mod in inner loops.
     // ring_core_id is a runtime arg, but Nt/Ht/num_cores are compile-time.
@@ -232,30 +244,30 @@ void kernel_main() {
     if constexpr (has_bias) {
         // Create a ones-tile for bias addition (matmul with ones × bias_row = bias).
         // Same sequence as moe_gpt compute.cpp for GPT-OSS compatibility.
-        unary_op_init_common(cb_c2c_ones_tile, cb_c2c_ones_tile);
+        unary_op_init_common(cb_c2c_ones_tile_id, cb_c2c_ones_tile_id);
         tile_regs_acquire();
         fill_tile_init();
         constexpr uint32_t dst0 = 0;
         fill_tile(dst0, 1.f);
         tile_regs_commit();
         tile_regs_wait();
-        cb_reserve_back(cb_c2c_ones_tile, 1);
-        pack_tile(dst0, cb_c2c_ones_tile);
+        cb_c2c_ones_tile.reserve_back(1);
+        pack_tile(dst0, cb_c2c_ones_tile_id);
         tile_regs_release();
-        cb_push_back(cb_c2c_ones_tile, 1);
+        cb_c2c_ones_tile.push_back(1);
         // Synchronize: UNPACK must wait for PACK to finish writing before the first
         // matmul_block read. The tile is never popped so one cb_wait_front suffices.
-        cb_wait_front(cb_c2c_ones_tile, 1);
+        cb_c2c_ones_tile.wait_front(1);
     }
 
     // Pack is always configured to Float16_b
-    pack_reconfig_data_format(cb_s2c_in2);
+    pack_reconfig_data_format(cb_s2c_in2_id);
 
     // Unpacker B is for input/activation and eltiwse inputs, so Float16_b
-    reconfig_data_format_srcb(cb_s2c_in);
+    reconfig_data_format_srcb(cb_s2c_in_id);
 
     // Unpacker A is for W0,W1 and W2, so Bf4_b
-    reconfig_data_format_srca(cb_r2c_w0_w1);
+    reconfig_data_format_srca(cb_r2c_w0_w1_id);
 
     //-------------------------------------------------------------------------
     // Init synchronization with tilize cores
@@ -265,10 +277,10 @@ void kernel_main() {
     // We also use this CB to transfer (from the writer to compute) 2 semaphore addresses:
     // - 0: address of semaphore used to send metadata (number of tokens per expert)
     // - 1: address of semaphore used to notify matmuls cores that tilized chunks have arrived
-    cb_wait_front(cb_w2c_md, 2);
-    cb_pop_front(cb_w2c_md, 2);
+    cb_w2c_md.wait_front(2);
+    cb_w2c_md.pop_front(2);
     volatile tt_l1_ptr uint32_t* cb_w2c_md_read_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_tile_address(cb_w2c_md, 0));
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_tile_address(cb_w2c_md_id, 0));
 
     // Read per-expert token counts from CB
     volatile tt_l1_ptr uint32_t* num_tokens_per_expert_ptr =
@@ -300,11 +312,15 @@ void kernel_main() {
             detail::pack_init_activation<activation_type>();
 
             // Initialize matmul for W0
-            matmul_block_init(cb_s2c_in, cb_r2c_w0_w1, /*transpose=*/false, /*ct_dim=*/4, /*rt_dim=*/1, /*kt_dim=*/1);
+            matmul_block_init(
+                cb_s2c_in_id, cb_r2c_w0_w1_id, /*transpose=*/false, /*ct_dim=*/4, /*rt_dim=*/1, /*kt_dim=*/1);
 
             // Wait for next chunk of tiles to arrive from the tilize cores
             // Min to allow tilize cores to send increment for second expert
             // while first expert still being processed
+            // Device 2.0 migration: legacy primitive retained: matmul_chunk_ready_semaphore_addr is a runtime-resolved
+            // L1 semaphore address (delivered via cb_w2c_md), not a per-program id, so it cannot be wrapped in
+            // Semaphore<> (which binds via get_semaphore<>(id)).
             detail::noc_semaphore_wait_min(
                 reinterpret_cast<volatile tt_l1_ptr uint32_t*>(matmul_chunk_ready_semaphore_addr),
                 matmul_chunk_ready_semaphore_wait_value++);
@@ -324,15 +340,15 @@ void kernel_main() {
                 tile_regs_acquire();
                 [[maybe_unused]] uint32_t k_tracker = 0;
                 for (uint32_t block_id = 0; block_id < Cfg::w0_w1_blocks_per_col; ++block_id) {
-                    cb_wait_front(cb_r2c_w0_w1, w0_w1_tiles_per_block);
+                    cb_r2c_w0_w1.wait_front(w0_w1_tiles_per_block);
 
                     for (uint32_t k = 0; k < w0_w1_tiles_per_block; k += 4) {
                         if constexpr (has_bias) {
                             if (k_tracker == num_w0_w1_tiles_h) {
                                 // Bias addition: matmul(ones_tile, bias_row)
                                 matmul_block(
-                                    cb_c2c_ones_tile,
-                                    cb_r2c_w0_w1,
+                                    cb_c2c_ones_tile_id,
+                                    cb_r2c_w0_w1_id,
                                     0,
                                     /*in1_index=*/k,
                                     /*idst=*/0,
@@ -348,8 +364,8 @@ void kernel_main() {
                             }
                         }
                         matmul_block(
-                            cb_s2c_in,
-                            cb_r2c_w0_w1,
+                            cb_s2c_in_id,
+                            cb_r2c_w0_w1_id,
                             in0_index++,
                             /*in1_index=*/k,
                             /*idst=*/0,
@@ -361,7 +377,7 @@ void kernel_main() {
                             k_tracker++;
                         }
                     }
-                    cb_pop_front(cb_r2c_w0_w1, w0_w1_tiles_per_block);
+                    cb_r2c_w0_w1.pop_front(w0_w1_tiles_per_block);
                 }
 
                 tile_regs_commit();
@@ -383,8 +399,8 @@ void kernel_main() {
 
                 PACK(TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::WAIT_SFPU));
 
-                pack_tile</*out_of_order_output=*/true>(0, cb_s2c_in2, /*output_tile_index=*/tile_id);
-                pack_tile</*out_of_order_output=*/true>(2, cb_s2c_in2, /*output_tile_index=*/tile_id + 1);
+                pack_tile</*out_of_order_output=*/true>(0, cb_s2c_in2_id, /*output_tile_index=*/tile_id);
+                pack_tile</*out_of_order_output=*/true>(2, cb_s2c_in2_id, /*output_tile_index=*/tile_id + 1);
                 tile_regs_release();
             }
 
@@ -398,20 +414,20 @@ void kernel_main() {
                 tile_regs_commit();
                 tile_regs_wait();
                 for (uint32_t tile_id = prod_tiles_per_step; tile_id < tiles_per_step; ++tile_id) {
-                    pack_tile</*out_of_order_output=*/true>(0, cb_s2c_in2, /*output_tile_index=*/tile_id);
+                    pack_tile</*out_of_order_output=*/true>(0, cb_s2c_in2_id, /*output_tile_index=*/tile_id);
                 }
                 tile_regs_release();
             }
 
             // Signal to DM1 that the output from this core is ready
-            cb_reserve_back(cb_c2w_rdy, 1);
-            cb_push_back(cb_c2w_rdy, 1);
+            cb_c2w_rdy.reserve_back(1);
+            cb_c2w_rdy.push_back(1);
 
             //---------------------------------------------------------------------
             // Compute in2 @ W2 (in pairs of 4)
             //---------------------------------------------------------------------
 
-            cb_reserve_back(cb_c2s_out, num_w0_w1_tiles_h);
+            cb_c2s_out.reserve_back(num_w0_w1_tiles_h);
 
             // Init pack_untilize ONCE before the iter loop (hoisted, mirrors moe_gpt pattern).
             // Cycling init/uninit per-iter triggers BH's MATH reconfig_remap workaround
@@ -419,12 +435,12 @@ void kernel_main() {
             // execution and produces garbage output (NaN/Inf) on BH silicon.
             pack_untilize_dest_init<
                 /*block_ct_dim=*/w2_tiles_per_iter_w,
-                /*full_ct_dim=*/Cfg::w2_tiles_per_expert_w>(cb_c2s_out);
+                /*full_ct_dim=*/Cfg::w2_tiles_per_expert_w>(cb_c2s_out_id);
 
             for (uint32_t iter = 0; iter < Cfg::num_a2a_iters; ++iter) {
                 uint32_t src_core = ring_core_id;
                 uint32_t dm1_tiles_remaining = shard_tiles_lut[ring_core_id];
-                cb_wait_front(cb_w2c_rdy, 1);
+                cb_w2c_rdy.wait_front(1);
 
                 uint32_t in2_offset = 0, in2_index = 0;
 
@@ -432,14 +448,14 @@ void kernel_main() {
 
                 uint32_t w2_k_tracker = 0;
                 for (uint32_t block_id = 0; block_id < w2_blocks_per_a2a_iter; ++block_id) {
-                    cb_wait_front(cb_r2c_w2, w2_tiles_per_block);
+                    cb_r2c_w2.wait_front(w2_tiles_per_block);
                     for (uint32_t k = 0; k < w2_tiles_per_block; k += w2_tiles_per_iter_w) {
                         if constexpr (has_bias) {
                             if (w2_k_tracker == num_w2_tiles_h) {
                                 // Bias addition: matmul(ones_tile, bias_row); padding K slots do not consume in2/dm1.
                                 matmul_block(
-                                    cb_c2c_ones_tile,
-                                    cb_r2c_w2,
+                                    cb_c2c_ones_tile_id,
+                                    cb_r2c_w2_id,
                                     0,
                                     /*in1_index=*/k,
                                     /*idst=*/0,
@@ -455,8 +471,8 @@ void kernel_main() {
                             continue;  // skip padding K slots (bias: after bias tile; no_bias: at/past logical K)
                         }
                         if (dm1_tiles_remaining == 0) {
-                            cb_pop_front(cb_w2c_rdy, 1);
-                            cb_wait_front(cb_w2c_rdy, 1);
+                            cb_w2c_rdy.pop_front(1);
+                            cb_w2c_rdy.wait_front(1);
                             src_core = (src_core == 0) ? num_cores - 1 : src_core - 1;
                             dm1_tiles_remaining = shard_tiles_lut[src_core];
                             in2_offset += tiles_per_step;
@@ -465,8 +481,8 @@ void kernel_main() {
                         dm1_tiles_remaining--;
 
                         matmul_block(
-                            cb_s2c_in2,
-                            cb_r2c_w2,
+                            cb_s2c_in2_id,
+                            cb_r2c_w2_id,
                             in2_index++,
                             /*in1_index=*/k,
                             /*idst=*/0,
@@ -476,33 +492,33 @@ void kernel_main() {
                             /*kt_dim=*/1);
                         w2_k_tracker++;
                     }
-                    cb_pop_front(cb_r2c_w2, w2_tiles_per_block);
+                    cb_r2c_w2.pop_front(w2_tiles_per_block);
                 }
-                cb_pop_front(cb_w2c_rdy, 1);
+                cb_w2c_rdy.pop_front(1);
 
                 tile_regs_commit();
 
                 tile_regs_wait();
                 pack_untilize_dest</*block_ct_dim=*/w2_tiles_per_iter_w, /*full_ct_dim=*/Cfg::w2_tiles_per_expert_w>(
-                    cb_c2s_out, /*block_rt_dim=*/1, /*block_c_index=*/iter);
+                    cb_c2s_out_id, /*block_rt_dim=*/1, /*block_c_index=*/iter);
 
                 tile_regs_release();
             }
 
             // Uninit pack_untilize ONCE after the iter loop (hoisted, mirrors moe_gpt pattern).
-            pack_untilize_uninit(cb_c2s_out);
+            pack_untilize_uninit(cb_c2s_out_id);
 
-            cb_push_back(cb_c2s_out, num_w0_w1_tiles_h);
+            cb_c2s_out.push_back(num_w0_w1_tiles_h);
 
             // Toggle the buffer to use
             use_second_half_buffer = !use_second_half_buffer;
             // Restore packer data format for next chunk's activation pipeline (mirrors moe_gpt:342).
-            pack_reconfig_data_format(cb_s2c_in2);
+            pack_reconfig_data_format(cb_s2c_in2_id);
 
         }  // end for (chunk)
     }  // end for (expert_id)
 
     // Drain the pipeline - the last dummy push
-    cb_wait_front(cb_r2c_w2, w2_tiles_per_block);
-    cb_pop_front(cb_r2c_w2, w2_tiles_per_block);
+    cb_r2c_w2.wait_front(w2_tiles_per_block);
+    cb_r2c_w2.pop_front(w2_tiles_per_block);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
@@ -318,9 +318,6 @@ void kernel_main() {
             // Wait for next chunk of tiles to arrive from the tilize cores
             // Min to allow tilize cores to send increment for second expert
             // while first expert still being processed
-            // Device 2.0 migration: legacy primitive retained: matmul_chunk_ready_semaphore_addr is a runtime-resolved
-            // L1 semaphore address (delivered via cb_w2c_md), not a per-program id, so it cannot be wrapped in
-            // Semaphore<> (which binds via get_semaphore<>(id)).
             detail::noc_semaphore_wait_min(
                 reinterpret_cast<volatile tt_l1_ptr uint32_t*>(matmul_chunk_ready_semaphore_addr),
                 matmul_chunk_ready_semaphore_wait_value++);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async_h2d/device/kernels/h2d_receiver_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async_h2d/device/kernels/h2d_receiver_writer.cpp
@@ -5,8 +5,11 @@
 #include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
 #include "api/socket_api.h"
+#include "api/core_local_mem.h"
 #include "api/tensor/tensor_accessor.h"
+#include "api/tensor/noc_traits.h"
 
 ///////////////////////////////////////////////////
 // COMPILE TIME ARGS
@@ -44,6 +47,7 @@ void kernel_main() {
     uint32_t output_base_addr = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t num_pages = get_arg_val<uint32_t>(rt_args_idx++);
 
+    // Device 2.0 migration: legacy primitive retained: PCIe write command buffer state setup has no typed D2 endpoint.
     // socket_notify_sender for H2D sockets posts the local bytes_acked counter back to the
     // host via a PCIe NOC write, which itself uses noc_wwrite_with_state. Initialize the
     // write command buffer state up front so the in-loop notifications hit a hot path.
@@ -60,6 +64,8 @@ void kernel_main() {
     auto output_addr_gen_args = TensorAccessorArgs<output_args_cta_idx, output_args_crta_idx>();
     auto output_addr_gen = TensorAccessor(output_addr_gen_args, output_base_addr);
 
+    Noc noc_obj;
+
     for (uint32_t page_index = 0; page_index < num_pages; ++page_index) {
         // Block until the host has signaled (via bytes_sent) that a page of data is ready
         // in the FIFO (HOST_PUSH) or that a page worth of bytes has been reserved in the
@@ -72,13 +78,13 @@ void kernel_main() {
                 pcie_data_addr_base + receiver_socket.read_ptr - receiver_socket.fifo_addr,
                 receiver_socket.read_ptr,
                 page_size);
-            noc_async_read_barrier();
+            noc_obj.async_read_barrier();
         }
 
-        auto noc_write_addr = output_addr_gen.get_noc_addr(page_index);
-        noc_async_write<page_size>(receiver_socket.read_ptr, noc_write_addr, page_size);
+        noc_obj.async_write(
+            CoreLocalMem<uint8_t>(receiver_socket.read_ptr), output_addr_gen, page_size, {}, {.page_id = page_index});
         // Flush so the FIFO slot can be released and reused before the write retires globally.
-        noc_async_writes_flushed();
+        noc_obj.async_writes_flushed();
 
         socket_pop_pages(receiver_socket, 1);
         socket_notify_sender(receiver_socket);
@@ -86,5 +92,5 @@ void kernel_main() {
     }
 
     update_socket_config(receiver_socket);
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async_h2d/device/kernels/h2d_receiver_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async_h2d/device/kernels/h2d_receiver_writer.cpp
@@ -47,7 +47,6 @@ void kernel_main() {
     uint32_t output_base_addr = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t num_pages = get_arg_val<uint32_t>(rt_args_idx++);
 
-    // Device 2.0 migration: legacy primitive retained: PCIe write command buffer state setup has no typed D2 endpoint.
     // socket_notify_sender for H2D sockets posts the local bytes_acked counter back to the
     // host via a PCIe NOC write, which itself uses noc_wwrite_with_state. Initialize the
     // write command buffer state up front so the in-loop notifications hit a hot path.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async_d2h/device/kernels/d2h_sender_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async_d2h/device/kernels/d2h_sender_reader.cpp
@@ -5,8 +5,12 @@
 #include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
 #include "api/socket_api.h"
 #include "api/tensor/tensor_accessor.h"
+#include "api/tensor/noc_traits.h"
 
 ///////////////////////////////////////////////////
 // COMPILE TIME ARGS
@@ -43,6 +47,7 @@ void kernel_main() {
     uint32_t input_base_addr = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t num_pages = get_arg_val<uint32_t>(rt_args_idx++);
 
+    // Device 2.0 migration: legacy primitive retained: PCIe write command buffer state setup has no typed D2 endpoint.
     // socket_notify_receiver for D2H sockets posts the local bytes_sent counter to the
     // host via a PCIe NOC write, which itself uses noc_wwrite_with_state. We also use
     // noc_wwrite_with_state for the page-data PCIe writes below, so initialize the
@@ -60,24 +65,26 @@ void kernel_main() {
     auto input_addr_gen_args = TensorAccessorArgs<input_args_cta_idx, input_args_crta_idx>();
     auto input_addr_gen = TensorAccessor(input_addr_gen_args, input_base_addr);
 
+    Noc noc_obj;
+    CircularBuffer cb_scratch(scratch_cb_id);
+
     // The scratch CB is reserved once at kernel startup; nothing else produces/consumes
     // it so we treat it as a single-page L1 staging region.
-    uint32_t scratch_addr = get_write_ptr(scratch_cb_id);
+    uint32_t scratch_addr = cb_scratch.get_write_ptr();
 
     for (uint32_t page_index = 0; page_index < num_pages; ++page_index) {
         // Block until the host has freed space in the FIFO for one page worth of data.
         socket_reserve_pages(sender_socket, 1);
 
         // Read this page of the input tensor (L1 or DRAM) into the local L1 scratch.
-        auto src_noc_addr = input_addr_gen.get_noc_addr(page_index);
-        noc_async_read<page_size>(src_noc_addr, scratch_addr, page_size);
-        noc_async_read_barrier();
+        noc_obj.async_read(input_addr_gen, CoreLocalMem<uint8_t>(scratch_addr), page_size, {.page_id = page_index}, {});
+        noc_obj.async_read_barrier();
 
         // Push the staged page out to pinned host memory via PCIe.
         write_page_to_pcie(pcie_xy_enc, scratch_addr, pcie_data_addr_base + sender_socket.write_ptr, page_size);
         // Flush so the bytes_sent update below is observed by host after the data has
         // committed to the PCIe ordering domain.
-        noc_async_writes_flushed();
+        noc_obj.async_writes_flushed();
 
         socket_push_pages(sender_socket, 1);
         socket_notify_receiver(sender_socket);
@@ -85,5 +92,5 @@ void kernel_main() {
     }
 
     update_socket_config(sender_socket);
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async_d2h/device/kernels/d2h_sender_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async_d2h/device/kernels/d2h_sender_reader.cpp
@@ -47,7 +47,6 @@ void kernel_main() {
     uint32_t input_base_addr = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t num_pages = get_arg_val<uint32_t>(rt_args_idx++);
 
-    // Device 2.0 migration: legacy primitive retained: PCIe write command buffer state setup has no typed D2 endpoint.
     // socket_notify_receiver for D2H sockets posts the local bytes_sent counter to the
     // host via a PCIe NOC write, which itself uses noc_wwrite_with_state. We also use
     // noc_wwrite_with_state for the page-data PCIe writes below, so initialize the

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/fused_receiver_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/fused_receiver_utils.hpp
@@ -217,6 +217,8 @@ struct MinimalMatmulOpReceiver {
                 if (wait_for_op_signal && !(read_local_slice_from_input && (curr_k_block_dir == 2))) {
                     volatile tt_l1_ptr uint32_t* semaphore = signal_op_semaphore_addr_ptrs[curr_k_block_dir];
                     uint32_t sem_target = sem_targets[curr_k_block_dir];
+                    // Device 2.0 migration: legacy primitive retained: raw L1 semaphore pointer loaded from
+                    // signal_op_semaphore_addr_ptrs[]; Semaphore<> wraps program-local ids only
                     noc_semaphore_wait_min(semaphore, sem_target + 1);
                     sem_targets[curr_k_block_dir]++;
                 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/fused_receiver_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/fused_receiver_utils.hpp
@@ -217,8 +217,6 @@ struct MinimalMatmulOpReceiver {
                 if (wait_for_op_signal && !(read_local_slice_from_input && (curr_k_block_dir == 2))) {
                     volatile tt_l1_ptr uint32_t* semaphore = signal_op_semaphore_addr_ptrs[curr_k_block_dir];
                     uint32_t sem_target = sem_targets[curr_k_block_dir];
-                    // Device 2.0 migration: legacy primitive retained: raw L1 semaphore pointer loaded from
-                    // signal_op_semaphore_addr_ptrs[]; Semaphore<> wraps program-local ids only
                     noc_semaphore_wait_min(semaphore, sem_target + 1);
                     sem_targets[curr_k_block_dir]++;
                 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_reader.cpp
@@ -143,7 +143,8 @@ void kernel_main() {
                 input_chunk_start_tile = global_tile_index;
                 for (uint32_t chunk_idx = 0; chunk_idx < device_k_block_counts[actual_sender_chip_id]; chunk_idx++) {
                     // Receive the next chunk of data
-                    // Device 2.0: legacy primitive retained: out_ready_sem is the address of a GlobalSemaphore.
+                    // Device 2.0 migration: legacy primitive retained: out_ready_sem is a GlobalSemaphore L1 address,
+                    // not a program-local id wrappable by Semaphore<>
                     noc_semaphore_wait_min(
                         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), sem_target + 1);
                     sem_target++;
@@ -186,6 +187,7 @@ void kernel_main() {
         }
         batch_input_tile_offset += tiles_per_batch;
     }
-    // Device 2.0 migration: legacy primitive retained, out_ready_sem is a GlobalSemaphore address.
+    // Device 2.0 migration: legacy primitive retained: out_ready_sem is a GlobalSemaphore L1 address, not a
+    // program-local id wrappable by Semaphore<>
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), 0);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_reader.cpp
@@ -143,8 +143,6 @@ void kernel_main() {
                 input_chunk_start_tile = global_tile_index;
                 for (uint32_t chunk_idx = 0; chunk_idx < device_k_block_counts[actual_sender_chip_id]; chunk_idx++) {
                     // Receive the next chunk of data
-                    // Device 2.0 migration: legacy primitive retained: out_ready_sem is a GlobalSemaphore L1 address,
-                    // not a program-local id wrappable by Semaphore<>
                     noc_semaphore_wait_min(
                         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), sem_target + 1);
                     sem_target++;
@@ -187,7 +185,5 @@ void kernel_main() {
         }
         batch_input_tile_offset += tiles_per_batch;
     }
-    // Device 2.0 migration: legacy primitive retained: out_ready_sem is a GlobalSemaphore L1 address, not a
-    // program-local id wrappable by Semaphore<>
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), 0);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_writer.cpp
@@ -297,15 +297,16 @@ void kernel_main() {
         tt::tt_fabric::fabric_client_disconnect(*mux_connection_handle);
 
         if constexpr (is_termination_master) {
-            // Device 2.0: legacy primitive retained, termination_sync_address is used both
-            // as a local L1 pointer here and as a remote noc target via safe_get_noc_addr below.
             auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
+            // Device 2.0 migration: legacy primitive retained: termination_sync_address is a raw L1 pointer from
+            // get_semaphore(), not a program-local id wrappable by Semaphore<>
             noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
             tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
         } else {
             uint64_t dest_addr =
                 safe_get_noc_addr(termination_master_noc_x, termination_master_noc_y, termination_sync_address, 0);
-            // Legacy primitive retained: precomposed uint64_t dst addr.
+            // Device 2.0 migration: legacy primitive retained: dest_addr is a precomposed uint64_t remote noc address,
+            // not a program-local id wrappable by Semaphore<>
             noc_semaphore_inc(dest_addr, 1);
             noc_obj.async_atomic_barrier();
         }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_writer.cpp
@@ -298,15 +298,11 @@ void kernel_main() {
 
         if constexpr (is_termination_master) {
             auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
-            // Device 2.0 migration: legacy primitive retained: termination_sync_address is a raw L1 pointer from
-            // get_semaphore(), not a program-local id wrappable by Semaphore<>
             noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
             tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
         } else {
             uint64_t dest_addr =
                 safe_get_noc_addr(termination_master_noc_x, termination_master_noc_y, termination_sync_address, 0);
-            // Device 2.0 migration: legacy primitive retained: dest_addr is a precomposed uint64_t remote noc address,
-            // not a program-local id wrappable by Semaphore<>
             noc_semaphore_inc(dest_addr, 1);
             noc_obj.async_atomic_barrier();
         }


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

Relates to #45003 (item 4). Fourth part of experimental CCLs migration after #47537, #47547, and #47555.

Migrates the remaining CCL kernel files under `experimental/ccl/` onto the Device 2.0 kernel API:
- `all_gather_minimal_matmul_async` (4 files)
- `strided_all_gather_async` (3 files)
- `all_gather_concat_heads_fused` (1 file)
- `all_reduce_async` (1 file)
- `deepseek_moe_reduce_scatter` (1 file)
- `all_to_all_async_generic` (1 file)
- `send_recv_async/recv_async_h2d` (1 file)
- `send_recv_async/send_async_d2h` (1 file)
- `moe_compute` (1 file)

### Notes for reviewers

Helpers in `matmul_dataflow_common.hpp` now take `Noc` / `CircularBuffer` parameters by value instead of raw NoC index / CB id integers. Call sites in `dm_in0_sender.cpp` and `dm_in1_sender_out.cpp` were updated to match.

Retained-legacy primitives are annotated with the canonical `// Device 2.0 migration: legacy primitive retained: <reason>` comment. The standard cases:
- `GlobalSemaphore` addresses (only expose `address()`, not `id()`, so `Semaphore<>` can't wrap them)
- raw L1 semaphore pointers loaded from common runtime args
- precomposed `uint64_t` NoC addresses (no D2 endpoint accepts a raw multicast/unicast dst)
- PCIe state-machine primitives in the h2d / d2h kernels (no typed D2 endpoint for chunked PCIe command-buffer state)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/ccl-d2-pr-d-tail)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/ccl-d2-pr-d-tail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/ccl-d2-pr-d-tail)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/ccl-d2-pr-d-tail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/ccl-d2-pr-d-tail)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/ccl-d2-pr-d-tail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/ccl-d2-pr-d-tail)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/ccl-d2-pr-d-tail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/ccl-d2-pr-d-tail)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/ccl-d2-pr-d-tail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/ccl-d2-pr-d-tail)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/ccl-d2-pr-d-tail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/ccl-d2-pr-d-tail)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/ccl-d2-pr-d-tail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/ccl-d2-pr-d-tail)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/ccl-d2-pr-d-tail)