### PR TITLE
[skip ci] Release notes: clean up per-PR changelog line format (MINFRA-977)

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -242,6 +242,7 @@ jobs:
         uses: mikepenz/release-changelog-builder-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          configuration: infra/release-changelog-config.json
           fromTag: ${{ steps.get-previous-tag.outputs.previous-tag }}
           toTag: ${{ needs.create-tag.outputs.version }}
           failOnError: true

--- a/infra/release-changelog-config.json
+++ b/infra/release-changelog-config.json
@@ -1,0 +1,10 @@
+{
+  "pr_template": "- #{{TITLE}} [PR #{{NUMBER}}](#{{URL}})",
+  "transformers": [
+    {
+      "pattern": "^(- )(?:\\[[^\\]]*\\]\\s*)+[:\\-–—]?\\s*",
+      "target": "$1",
+      "flags": "gi"
+    }
+  ]
+}


### PR DESCRIPTION
Cleans up the per-PR lines in the generated release notes (MINFRA-977).

The changelog is built by `mikepenz/release-changelog-builder-action` in `package-and-release.yaml`, which was running with no config (default template). This adds an explicit config so each line:

- drops the `by @author` reference
- shows the PR as a linked `[PR 12345]` instead of `in #12345`
- strips leading bracketed prefixes like `[skip ci]`, `[Cleanup]`, `[Bug fix]`, `[Conv3D]`

Only `pr_template` and `transformers` are overridden; everything else (categories, template) falls back to the action defaults, so categorization is unchanged.

Before / after:
```
- [Bug fix] emule: faithful per-NOC bank tables...   ->  - emule: faithful per-NOC bank tables... [PR 46492]
- [Conv3D] Fix near-zero PCC from inconsistent...    ->  - Fix near-zero PCC from inconsistent... [PR 47343]
- [skip ci] Update codeowners for time budget...     ->  - Update codeowners for time budget... [PR 47451]
```

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgnidash/minfra-977-release-notes-pr-line-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgnidash/minfra-977-release-notes-pr-line-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgnidash/minfra-977-release-notes-pr-line-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgnidash/minfra-977-release-notes-pr-line-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgnidash/minfra-977-release-notes-pr-line-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgnidash/minfra-977-release-notes-pr-line-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgnidash/minfra-977-release-notes-pr-line-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgnidash/minfra-977-release-notes-pr-line-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgnidash/minfra-977-release-notes-pr-line-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgnidash/minfra-977-release-notes-pr-line-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgnidash/minfra-977-release-notes-pr-line-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgnidash/minfra-977-release-notes-pr-line-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgnidash/minfra-977-release-notes-pr-line-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgnidash/minfra-977-release-notes-pr-line-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgnidash/minfra-977-release-notes-pr-line-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgnidash/minfra-977-release-notes-pr-line-cleanup)