### PR TITLE
[Cleanup] Migrate experimental/transformer rotary + rotate_half kernels to Device 2.0 API

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/compute/rotary_embedding.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/compute/rotary_embedding.cpp
@@ -8,13 +8,17 @@
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/bcast.h"
 #include "api/compute/tilize.h"
+#include "api/dataflow/circular_buffer.h"
 #include "ttnn/kernel_lib/tilize_helpers.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp"
 
 ALWI void MUL_TILES(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t num_tiles, uint32_t in1_idx) {
+    CircularBuffer cb_in0(in0_cb);
+    CircularBuffer cb_in1(in1_cb);
+    CircularBuffer cb_out(out_cb);
     // Multiply input by cos
-    cb_wait_front(in0_cb, num_tiles);
-    cb_wait_front(in1_cb, in1_idx + 1);
+    cb_in0.wait_front(num_tiles);
+    cb_in1.wait_front(in1_idx + 1);
 
     tile_regs_acquire();
 #ifdef DECODE_MODE
@@ -26,19 +30,19 @@ ALWI void MUL_TILES(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t 
 #endif
     tile_regs_commit();
 
-    cb_pop_front(in0_cb, num_tiles);
+    cb_in0.pop_front(num_tiles);
 #ifndef DECODE_MODE
     // We don't pop in1 in decode which is sin/cos since we don't stream
-    cb_pop_front(in1_cb, num_tiles);
+    cb_in1.pop_front(num_tiles);
 #endif
 
-    cb_reserve_back(out_cb, num_tiles);
+    cb_out.reserve_back(num_tiles);
 
     tile_regs_wait();
     pack_tile(0, out_cb);
     tile_regs_release();
 
-    cb_push_back(out_cb, num_tiles);
+    cb_out.push_back(num_tiles);
 }
 
 template <uint32_t num_tiles, uint32_t in0_cb, uint32_t out_cb>
@@ -54,7 +58,8 @@ ALWI void UNTILIZE_TILES() {
 
 template <uint32_t num_tiles, uint32_t in0_cb, uint32_t out_cb>
 ALWI void TILIZE_ROWS(uint32_t sync_cb) {
-    cb_wait_front(sync_cb, num_tiles);
+    CircularBuffer cb_sync(sync_cb);
+    cb_sync.wait_front(num_tiles);
     compute_kernel_lib::tilize<
         num_tiles,
         in0_cb,
@@ -62,7 +67,7 @@ ALWI void TILIZE_ROWS(uint32_t sync_cb) {
         compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
         compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
         compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(1);
-    cb_pop_front(sync_cb, num_tiles);
+    cb_sync.pop_front(num_tiles);
 }
 
 void kernel_main() {
@@ -81,7 +86,15 @@ void kernel_main() {
     constexpr uint32_t Wt = get_compile_time_arg_val(10);
     constexpr uint32_t half_Wt = get_compile_time_arg_val(11);
 
-    cb_wait_front(scalar_cb, onetile);
+    CircularBuffer cb_in(in_cb);
+    CircularBuffer cb_rotated_in(rotated_in_cb);
+    CircularBuffer cb_scalar(scalar_cb);
+    CircularBuffer cb_rotated_in_interm(rotated_in_interm_cb);
+    CircularBuffer cb_cos_interm(cos_interm_cb);
+    CircularBuffer cb_sin_interm(sin_interm_cb);
+    CircularBuffer cb_out(out_cb);
+
+    cb_scalar.wait_front(onetile);
 
     uint32_t updated_cos_cb = cos_cb;
     uint32_t updated_sin_cb = sin_cb;
@@ -115,22 +128,22 @@ void kernel_main() {
                 // Multiply half of the rotated input by scalar (-1)
                 reconfig_data_format(rotated_in_cb, scalar_cb);
                 pack_reconfig_data_format(rotated_in_interm_cb);
-                cb_wait_front(rotated_in_cb, onetile);
+                cb_rotated_in.wait_front(onetile);
 
                 tile_regs_acquire();
                 mul_tiles_bcast_scalar_init_short(rotated_in_cb, scalar_cb);
                 mul_tiles_bcast_scalar(rotated_in_cb, scalar_cb, 0, 0, 0);
                 tile_regs_commit();
 
-                cb_pop_front(rotated_in_cb, onetile);
+                cb_rotated_in.pop_front(onetile);
 
-                cb_reserve_back(rotated_in_interm_cb, onetile);
+                cb_rotated_in_interm.reserve_back(onetile);
 
                 tile_regs_wait();
                 pack_tile(0, rotated_in_interm_cb);
                 tile_regs_release();
 
-                cb_push_back(rotated_in_interm_cb, onetile);
+                cb_rotated_in_interm.push_back(onetile);
                 reconfig_data_format_srcb(scalar_cb, updated_sin_cb);
                 pack_reconfig_data_format(rotated_in_interm_cb, sin_interm_cb);
                 // Multiply rotated input by sin
@@ -146,8 +159,8 @@ void kernel_main() {
             MUL_TILES(in_cb, updated_cos_cb, cos_interm_cb, onetile, in1_idx);
 
             // Add applied sin/cos tensors
-            cb_wait_front(cos_interm_cb, onetile);
-            cb_wait_front(sin_interm_cb, onetile);
+            cb_cos_interm.wait_front(onetile);
+            cb_sin_interm.wait_front(onetile);
 
             reconfig_data_format_srca(rotated_in_cb, cos_interm_cb);
             pack_reconfig_data_format(cos_interm_cb, out_cb);
@@ -157,16 +170,16 @@ void kernel_main() {
             add_tiles(cos_interm_cb, sin_interm_cb, 0, 0, 0);
             tile_regs_commit();
 
-            cb_pop_front(cos_interm_cb, onetile);
-            cb_pop_front(sin_interm_cb, onetile);
+            cb_cos_interm.pop_front(onetile);
+            cb_sin_interm.pop_front(onetile);
 
-            cb_reserve_back(out_cb, onetile);
+            cb_out.reserve_back(onetile);
 
             tile_regs_wait();
             pack_tile(0, out_cb);
             tile_regs_release();
 
-            cb_push_back(out_cb, onetile);
+            cb_out.push_back(onetile);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/compute/rotary_embedding_single_tile.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/compute/rotary_embedding_single_tile.cpp
@@ -14,6 +14,7 @@
 #include "api/compute/bcast.h"
 #include "api/compute/matmul.h"
 #include "api/compute/tilize.h"
+#include "api/dataflow/circular_buffer.h"
 #include "ttnn/kernel_lib/tilize_helpers.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp"
 
@@ -30,7 +31,8 @@ ALWI void UNTILIZE_ONE_TILE() {
 
 template <uint32_t in0_cb, uint32_t out_cb>
 ALWI void TILIZE_ONE_TILE(uint32_t sync_cb) {
-    cb_wait_front(sync_cb, 1);
+    CircularBuffer cb_sync(sync_cb);
+    cb_sync.wait_front(1);
     compute_kernel_lib::tilize<
         1,
         in0_cb,
@@ -38,7 +40,7 @@ ALWI void TILIZE_ONE_TILE(uint32_t sync_cb) {
         compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
         compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
         compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(1);
-    cb_pop_front(sync_cb, 1);
+    cb_sync.pop_front(1);
 }
 
 void kernel_main() {
@@ -53,6 +55,13 @@ void kernel_main() {
     constexpr uint32_t sin_interm_cb = get_compile_time_arg_val(6);
     constexpr uint32_t out_cb = get_compile_time_arg_val(7);
     constexpr uint32_t num_rows = get_compile_time_arg_val(8);
+
+    CircularBuffer cb_in(in_cb);
+    CircularBuffer cb_trans_mat(trans_mat_cb);
+    CircularBuffer cb_rotated_in_interm(rotated_in_interm_cb);
+    CircularBuffer cb_cos_interm(cos_interm_cb);
+    CircularBuffer cb_sin_interm(sin_interm_cb);
+    CircularBuffer cb_out(out_cb);
 
     uint32_t updated_cos_cb = cos_cb;
     uint32_t updated_sin_cb = sin_cb;
@@ -76,12 +85,12 @@ void kernel_main() {
     updated_sin_cb = retilized_sin_cb;
 #endif
 
-    cb_wait_front(trans_mat_cb, onetile);
+    cb_trans_mat.wait_front(onetile);
     binary_op_init_common(rotated_in_interm_cb, updated_sin_cb, sin_interm_cb);
 
     for (uint32_t i = 0; i < num_rows; ++i) {
         // rotated = in @ trans_mat  (HF rotate_half on a single 32x32 tile)
-        cb_wait_front(in_cb, onetile);
+        cb_in.wait_front(onetile);
         reconfig_data_format(in_cb, trans_mat_cb);
         pack_reconfig_data_format(rotated_in_interm_cb);
         matmul_init(in_cb, trans_mat_cb);
@@ -90,17 +99,18 @@ void kernel_main() {
         matmul_tiles(in_cb, trans_mat_cb, 0, 0, 0);
         tile_regs_commit();
 
-        cb_reserve_back(rotated_in_interm_cb, onetile);
+        cb_rotated_in_interm.reserve_back(onetile);
 
         tile_regs_wait();
         pack_tile(0, rotated_in_interm_cb);
         tile_regs_release();
 
-        cb_push_back(rotated_in_interm_cb, onetile);
+        cb_rotated_in_interm.push_back(onetile);
 
         // sin_interim = rotated * sin
-        cb_wait_front(rotated_in_interm_cb, onetile);
-        cb_wait_front(updated_sin_cb, onetile);
+        CircularBuffer cb_updated_sin(updated_sin_cb);
+        cb_rotated_in_interm.wait_front(onetile);
+        cb_updated_sin.wait_front(onetile);
         reconfig_data_format(rotated_in_interm_cb, updated_sin_cb);
         pack_reconfig_data_format(sin_interm_cb);
 
@@ -114,21 +124,22 @@ void kernel_main() {
 #endif
         tile_regs_commit();
 
-        cb_pop_front(rotated_in_interm_cb, onetile);
+        cb_rotated_in_interm.pop_front(onetile);
 #ifndef DECODE_MODE
-        cb_pop_front(updated_sin_cb, onetile);
+        cb_updated_sin.pop_front(onetile);
 #endif
 
-        cb_reserve_back(sin_interm_cb, onetile);
+        cb_sin_interm.reserve_back(onetile);
 
         tile_regs_wait();
         pack_tile(0, sin_interm_cb);
         tile_regs_release();
 
-        cb_push_back(sin_interm_cb, onetile);
+        cb_sin_interm.push_back(onetile);
 
         // cos_interim = in * cos
-        cb_wait_front(updated_cos_cb, onetile);
+        CircularBuffer cb_updated_cos(updated_cos_cb);
+        cb_updated_cos.wait_front(onetile);
         reconfig_data_format(in_cb, updated_cos_cb);
         pack_reconfig_data_format(cos_interm_cb);
 
@@ -142,22 +153,22 @@ void kernel_main() {
 #endif
         tile_regs_commit();
 
-        cb_pop_front(in_cb, onetile);
+        cb_in.pop_front(onetile);
 #ifndef DECODE_MODE
-        cb_pop_front(updated_cos_cb, onetile);
+        cb_updated_cos.pop_front(onetile);
 #endif
 
-        cb_reserve_back(cos_interm_cb, onetile);
+        cb_cos_interm.reserve_back(onetile);
 
         tile_regs_wait();
         pack_tile(0, cos_interm_cb);
         tile_regs_release();
 
-        cb_push_back(cos_interm_cb, onetile);
+        cb_cos_interm.push_back(onetile);
 
         // out = cos_interim + sin_interim
-        cb_wait_front(cos_interm_cb, onetile);
-        cb_wait_front(sin_interm_cb, onetile);
+        cb_cos_interm.wait_front(onetile);
+        cb_sin_interm.wait_front(onetile);
         reconfig_data_format(cos_interm_cb, sin_interm_cb);
         pack_reconfig_data_format(out_cb);
         add_tiles_init(cos_interm_cb, sin_interm_cb);
@@ -166,15 +177,15 @@ void kernel_main() {
         add_tiles(cos_interm_cb, sin_interm_cb, 0, 0, 0);
         tile_regs_commit();
 
-        cb_pop_front(cos_interm_cb, onetile);
-        cb_pop_front(sin_interm_cb, onetile);
+        cb_cos_interm.pop_front(onetile);
+        cb_sin_interm.pop_front(onetile);
 
-        cb_reserve_back(out_cb, onetile);
+        cb_out.reserve_back(onetile);
 
         tile_regs_wait();
         pack_tile(0, out_cb);
         tile_regs_release();
 
-        cb_push_back(out_cb, onetile);
+        cb_out.push_back(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/dataflow/reader_rotary_embedding_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/dataflow/reader_rotary_embedding_interleaved_start_id.cpp
@@ -4,8 +4,14 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
+    Noc noc;
+
     uint32_t src_addr = get_arg_val<uint32_t>(0);
     uint32_t cos_addr = get_arg_val<uint32_t>(1);
     uint32_t sin_addr = get_arg_val<uint32_t>(2);
@@ -29,6 +35,7 @@ void kernel_main() {
     constexpr auto sin_args = TensorAccessorArgs<cos_args.next_compile_time_args_offset()>();
 
     constexpr uint32_t onetile = 1;
+    const uint32_t input_tile_bytes = get_tile_size(input_cb_id);
     const auto s0 = TensorAccessor(src_args, src_addr);
 
     const uint32_t cos_tile_bytes = get_tile_size(cos_cb_id);
@@ -37,14 +44,20 @@ void kernel_main() {
     const uint32_t sin_tile_bytes = get_tile_size(sin_cb_id);
     const auto s2 = TensorAccessor(sin_args, sin_addr);
 
+    CircularBuffer cb_input(input_cb_id);
+    CircularBuffer cb_rotated_input(rotated_input_cb_id);
+    CircularBuffer cb_cos(cos_cb_id);
+    CircularBuffer cb_sin(sin_cb_id);
+    CircularBuffer cb_scalar(scalar_cb_id);
+
     // Fill tile with zeros
     const uint32_t scalar_tile_bytes = get_tile_size(scalar_cb_id);
-    cb_reserve_back(scalar_cb_id, onetile);
-    uint32_t l1_zeros_addr_in_scalar = get_write_ptr(scalar_cb_id);
+    cb_scalar.reserve_back(onetile);
+    uint32_t l1_zeros_addr_in_scalar = cb_scalar.get_write_ptr();
     volatile tt_l1_ptr uint16_t* scalar_buffer =
         reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_zeros_addr_in_scalar);
     scalar_buffer[0] = scalar_value;
-    cb_push_back(scalar_cb_id, onetile);
+    cb_scalar.push_back(onetile);
 
     uint32_t input_curr_id = start_id;
     uint32_t rotated_input_curr_id = start_id + half_Wt;
@@ -52,53 +65,61 @@ void kernel_main() {
     uint32_t ht = start_row_id;
 
 #ifdef DECODE_MODE
-    cb_reserve_back(sin_cb_id, Wt);
-    cb_reserve_back(cos_cb_id, Wt);
-    uint32_t sin_l1_write_addr = get_write_ptr(sin_cb_id);
-    uint32_t cos_l1_write_addr = get_write_ptr(cos_cb_id);
+    cb_sin.reserve_back(Wt);
+    cb_cos.reserve_back(Wt);
+    uint32_t sin_l1_write_addr = cb_sin.get_write_ptr();
+    uint32_t cos_l1_write_addr = cb_cos.get_write_ptr();
     for (uint32_t i = 0; i < Wt; i++) {
-        noc_async_read_page(cos_sin_curr_id, s2, sin_l1_write_addr);
-        noc_async_read_page(cos_sin_curr_id, s1, cos_l1_write_addr);
+        noc.async_read(s2, CoreLocalMem<uint32_t>(sin_l1_write_addr), sin_tile_bytes, {.page_id = cos_sin_curr_id}, {});
+        noc.async_read(s1, CoreLocalMem<uint32_t>(cos_l1_write_addr), cos_tile_bytes, {.page_id = cos_sin_curr_id}, {});
         cos_sin_curr_id++;
         sin_l1_write_addr += sin_tile_bytes;
         cos_l1_write_addr += cos_tile_bytes;
     }
-    noc_async_read_barrier();
-    cb_push_back(sin_cb_id, Wt);
-    cb_push_back(cos_cb_id, Wt);
+    noc.async_read_barrier();
+    cb_sin.push_back(Wt);
+    cb_cos.push_back(Wt);
 #endif
 
     // read a ublock of tiles from src to CB, and then push the ublock to unpacker
     for (uint32_t i = 0; i < num_rows; ++i) {
         for (uint32_t j = 0; j < Wt; ++j) {
-            cb_reserve_back(rotated_input_cb_id, onetile);
-            uint32_t rotated_input_l1_write_addr = get_write_ptr(rotated_input_cb_id);
-            noc_async_read_page(rotated_input_curr_id, s0, rotated_input_l1_write_addr);
-            noc_async_read_barrier();
-            cb_push_back(rotated_input_cb_id, onetile);
+            cb_rotated_input.reserve_back(onetile);
+            uint32_t rotated_input_l1_write_addr = cb_rotated_input.get_write_ptr();
+            noc.async_read(
+                s0,
+                CoreLocalMem<uint32_t>(rotated_input_l1_write_addr),
+                input_tile_bytes,
+                {.page_id = rotated_input_curr_id},
+                {});
+            noc.async_read_barrier();
+            cb_rotated_input.push_back(onetile);
             rotated_input_curr_id++;
 
 #ifndef DECODE_MODE
-            cb_reserve_back(sin_cb_id, onetile);
-            uint32_t sin_l1_write_addr = get_write_ptr(sin_cb_id);
-            noc_async_read_page(cos_sin_curr_id, s2, sin_l1_write_addr);
-            noc_async_read_barrier();
-            cb_push_back(sin_cb_id, onetile);
+            cb_sin.reserve_back(onetile);
+            uint32_t sin_l1_write_addr = cb_sin.get_write_ptr();
+            noc.async_read(
+                s2, CoreLocalMem<uint32_t>(sin_l1_write_addr), sin_tile_bytes, {.page_id = cos_sin_curr_id}, {});
+            noc.async_read_barrier();
+            cb_sin.push_back(onetile);
 #endif
 
-            cb_reserve_back(input_cb_id, onetile);
-            uint32_t input_l1_write_addr = get_write_ptr(input_cb_id);
-            noc_async_read_page(input_curr_id, s0, input_l1_write_addr);
-            noc_async_read_barrier();
-            cb_push_back(input_cb_id, onetile);
+            cb_input.reserve_back(onetile);
+            uint32_t input_l1_write_addr = cb_input.get_write_ptr();
+            noc.async_read(
+                s0, CoreLocalMem<uint32_t>(input_l1_write_addr), input_tile_bytes, {.page_id = input_curr_id}, {});
+            noc.async_read_barrier();
+            cb_input.push_back(onetile);
             input_curr_id++;
 
 #ifndef DECODE_MODE
-            cb_reserve_back(cos_cb_id, onetile);
-            uint32_t cos_l1_write_addr = get_write_ptr(cos_cb_id);
-            noc_async_read_page(cos_sin_curr_id, s1, cos_l1_write_addr);
-            noc_async_read_barrier();
-            cb_push_back(cos_cb_id, onetile);
+            cb_cos.reserve_back(onetile);
+            uint32_t cos_l1_write_addr = cb_cos.get_write_ptr();
+            noc.async_read(
+                s1, CoreLocalMem<uint32_t>(cos_l1_write_addr), cos_tile_bytes, {.page_id = cos_sin_curr_id}, {});
+            noc.async_read_barrier();
+            cb_cos.push_back(onetile);
             cos_sin_curr_id++;
 #endif
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/dataflow/reader_rotary_embedding_interleaved_start_id_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/dataflow/reader_rotary_embedding_interleaved_start_id_sharded.cpp
@@ -4,8 +4,14 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
+    Noc noc;
+
     uint32_t cos_addr = get_arg_val<uint32_t>(0);
     uint32_t sin_addr = get_arg_val<uint32_t>(1);
     uint32_t num_rows = get_arg_val<uint32_t>(2);
@@ -27,9 +33,16 @@ void kernel_main() {
 
     constexpr uint32_t onetile = 1;
 
-    cb_reserve_back(input_cb_id, num_rows * Wt);
-    cb_push_back(input_cb_id, num_rows * Wt);
-    uint64_t input_l1_read_addr = get_noc_addr(get_read_ptr(input_cb_id));
+    CircularBuffer cb_input(input_cb_id);
+    CircularBuffer cb_rotated_input(rotated_input_cb_id);
+    CircularBuffer cb_cos(cos_cb_id);
+    CircularBuffer cb_sin(sin_cb_id);
+    CircularBuffer cb_scalar(scalar_cb_id);
+
+    cb_input.reserve_back(num_rows * Wt);
+    cb_input.push_back(num_rows * Wt);
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address.
+    uint64_t input_l1_read_addr = get_noc_addr(cb_input.get_read_ptr());
 
     const uint32_t cos_tile_bytes = get_tile_size(cos_cb_id);
     const auto s1 = TensorAccessor(cos_args, cos_addr);
@@ -39,30 +52,30 @@ void kernel_main() {
 
     // Fill tile with zeros
     const uint32_t scalar_tile_bytes = get_tile_size(scalar_cb_id);
-    cb_reserve_back(scalar_cb_id, onetile);
-    uint32_t l1_zeros_addr_in_scalar = get_write_ptr(scalar_cb_id);
+    cb_scalar.reserve_back(onetile);
+    uint32_t l1_zeros_addr_in_scalar = cb_scalar.get_write_ptr();
     volatile tt_l1_ptr uint16_t* scalar_buffer =
         reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_zeros_addr_in_scalar);
     scalar_buffer[0] = scalar_value;
-    cb_push_back(scalar_cb_id, onetile);
+    cb_scalar.push_back(onetile);
 
     uint32_t cos_sin_curr_id = cos_sin_start_id;
 
 #ifdef DECODE_MODE
-    cb_reserve_back(sin_cb_id, Wt);
-    cb_reserve_back(cos_cb_id, Wt);
-    uint32_t sin_l1_write_addr = get_write_ptr(sin_cb_id);
-    uint32_t cos_l1_write_addr = get_write_ptr(cos_cb_id);
+    cb_sin.reserve_back(Wt);
+    cb_cos.reserve_back(Wt);
+    uint32_t sin_l1_write_addr = cb_sin.get_write_ptr();
+    uint32_t cos_l1_write_addr = cb_cos.get_write_ptr();
     for (uint32_t i = 0; i < Wt; i++) {
-        noc_async_read_page(cos_sin_curr_id, s2, sin_l1_write_addr);
-        noc_async_read_page(cos_sin_curr_id, s1, cos_l1_write_addr);
+        noc.async_read(s2, CoreLocalMem<uint32_t>(sin_l1_write_addr), sin_tile_bytes, {.page_id = cos_sin_curr_id}, {});
+        noc.async_read(s1, CoreLocalMem<uint32_t>(cos_l1_write_addr), cos_tile_bytes, {.page_id = cos_sin_curr_id}, {});
         cos_sin_curr_id++;
         sin_l1_write_addr += sin_tile_bytes;
         cos_l1_write_addr += cos_tile_bytes;
     }
-    noc_async_read_barrier();
-    cb_push_back(sin_cb_id, Wt);
-    cb_push_back(cos_cb_id, Wt);
+    noc.async_read_barrier();
+    cb_sin.push_back(Wt);
+    cb_cos.push_back(Wt);
 #else
     uint32_t ht = start_row_id;
 #endif
@@ -70,27 +83,31 @@ void kernel_main() {
     uint32_t Wt_size = half_Wt_size + half_Wt_size;
     // read a ublock of tiles from src to CB, and then push the ublock to unpacker
     for (uint32_t i = 0; i < num_rows; ++i) {
-        cb_reserve_back(rotated_input_cb_id, Wt);
-        uint32_t rotated_input_l1_write_addr = get_write_ptr(rotated_input_cb_id);
+        cb_rotated_input.reserve_back(Wt);
+        uint32_t rotated_input_l1_write_addr = cb_rotated_input.get_write_ptr();
+        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address.
         noc_async_read(input_l1_read_addr + half_Wt_size, rotated_input_l1_write_addr, half_Wt_size);
+        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address.
         noc_async_read(input_l1_read_addr, rotated_input_l1_write_addr + half_Wt_size, half_Wt_size);
         input_l1_read_addr += Wt_size;
-        noc_async_read_barrier();
-        cb_push_back(rotated_input_cb_id, Wt);
+        noc.async_read_barrier();
+        cb_rotated_input.push_back(Wt);
 
 #ifndef DECODE_MODE
         for (uint32_t j = 0; j < Wt; ++j) {
-            cb_reserve_back(sin_cb_id, onetile);
-            uint32_t sin_l1_write_addr = get_write_ptr(sin_cb_id);
-            noc_async_read_page(cos_sin_curr_id, s2, sin_l1_write_addr);
-            noc_async_read_barrier();
-            cb_push_back(sin_cb_id, onetile);
+            cb_sin.reserve_back(onetile);
+            uint32_t sin_l1_write_addr = cb_sin.get_write_ptr();
+            noc.async_read(
+                s2, CoreLocalMem<uint32_t>(sin_l1_write_addr), sin_tile_bytes, {.page_id = cos_sin_curr_id}, {});
+            noc.async_read_barrier();
+            cb_sin.push_back(onetile);
 
-            cb_reserve_back(cos_cb_id, onetile);
-            uint32_t cos_l1_write_addr = get_write_ptr(cos_cb_id);
-            noc_async_read_page(cos_sin_curr_id, s1, cos_l1_write_addr);
-            noc_async_read_barrier();
-            cb_push_back(cos_cb_id, onetile);
+            cb_cos.reserve_back(onetile);
+            uint32_t cos_l1_write_addr = cb_cos.get_write_ptr();
+            noc.async_read(
+                s1, CoreLocalMem<uint32_t>(cos_l1_write_addr), cos_tile_bytes, {.page_id = cos_sin_curr_id}, {});
+            noc.async_read_barrier();
+            cb_cos.push_back(onetile);
             cos_sin_curr_id++;
         }
         ht++;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/dataflow/reader_rotary_embedding_single_tile_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/dataflow/reader_rotary_embedding_single_tile_interleaved_start_id.cpp
@@ -9,6 +9,10 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 // HF rotate_half on a single 32-wide vector x produces y where:
 //   y[0..16]  = -x[16..32]
@@ -29,8 +33,9 @@
 // decodes to +1.0 and 0xC0 decodes to -1.0.
 inline void fill_rotate_half_trans_mat_bfp8(uint32_t cb_id) {
     constexpr uint32_t onetile = 1;
-    cb_reserve_back(cb_id, onetile);
-    volatile tt_l1_ptr uint8_t* p = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(get_write_ptr(cb_id));
+    CircularBuffer cb(cb_id);
+    cb.reserve_back(onetile);
+    volatile tt_l1_ptr uint8_t* p = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(cb.get_write_ptr());
     // Zero the whole tile (1088 bytes).
     for (uint32_t i = 0; i < 1088; ++i) {
         p[i] = 0;
@@ -45,7 +50,7 @@ inline void fill_rotate_half_trans_mat_bfp8(uint32_t cb_id) {
         p[32 + r] = 127;
         p[576 + r * 16 + r] = 0xC0;
     }
-    cb_push_back(cb_id, onetile);
+    cb.push_back(onetile);
 }
 
 inline void fill_rotate_half_trans_mat_bf16(uint32_t cb_id) {
@@ -54,8 +59,9 @@ inline void fill_rotate_half_trans_mat_bf16(uint32_t cb_id) {
     constexpr uint16_t neg_one_bf16 = 0xBF80;  // bf16 -1.0
     constexpr uint32_t face_elems = 16 * 16;   // 256
 
-    cb_reserve_back(cb_id, onetile);
-    volatile tt_l1_ptr uint16_t* tile = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_write_ptr(cb_id));
+    CircularBuffer cb(cb_id);
+    cb.reserve_back(onetile);
+    volatile tt_l1_ptr uint16_t* tile = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(cb.get_write_ptr());
     // Zero whole tile (4 faces x 256 elems)
     for (uint32_t i = 0; i < 4 * face_elems; ++i) {
         tile[i] = 0;
@@ -68,10 +74,12 @@ inline void fill_rotate_half_trans_mat_bf16(uint32_t cb_id) {
     for (uint32_t r = 0; r < 16; ++r) {
         tile[2 * face_elems + r * 16 + r] = neg_one_bf16;
     }
-    cb_push_back(cb_id, onetile);
+    cb.push_back(onetile);
 }
 
 void kernel_main() {
+    Noc noc;
+
     uint32_t src_addr = get_arg_val<uint32_t>(0);
     uint32_t cos_addr = get_arg_val<uint32_t>(1);
     uint32_t sin_addr = get_arg_val<uint32_t>(2);
@@ -100,6 +108,10 @@ void kernel_main() {
     const uint32_t sin_tile_bytes = get_tile_size(sin_cb_id);
     const auto s2 = TensorAccessor(sin_args, sin_addr, sin_tile_bytes);
 
+    CircularBuffer cb_input(input_cb_id);
+    CircularBuffer cb_cos(cos_cb_id);
+    CircularBuffer cb_sin(sin_cb_id);
+
     if (get_tile_size(trans_mat_cb_id) == 2048) {
         fill_rotate_half_trans_mat_bf16(trans_mat_cb_id);
     } else {
@@ -111,43 +123,46 @@ void kernel_main() {
     uint32_t ht = start_row_id;
 
 #ifdef DECODE_MODE
-    cb_reserve_back(sin_cb_id, onetile);
-    cb_reserve_back(cos_cb_id, onetile);
+    cb_sin.reserve_back(onetile);
+    cb_cos.reserve_back(onetile);
     {
-        uint32_t sin_l1_write_addr = get_write_ptr(sin_cb_id);
-        uint32_t cos_l1_write_addr = get_write_ptr(cos_cb_id);
-        noc_async_read_page(cos_sin_curr_id, s2, sin_l1_write_addr);
-        noc_async_read_page(cos_sin_curr_id, s1, cos_l1_write_addr);
-        noc_async_read_barrier();
+        uint32_t sin_l1_write_addr = cb_sin.get_write_ptr();
+        uint32_t cos_l1_write_addr = cb_cos.get_write_ptr();
+        noc.async_read(s2, CoreLocalMem<uint32_t>(sin_l1_write_addr), sin_tile_bytes, {.page_id = cos_sin_curr_id}, {});
+        noc.async_read(s1, CoreLocalMem<uint32_t>(cos_l1_write_addr), cos_tile_bytes, {.page_id = cos_sin_curr_id}, {});
+        noc.async_read_barrier();
     }
-    cb_push_back(sin_cb_id, onetile);
-    cb_push_back(cos_cb_id, onetile);
+    cb_sin.push_back(onetile);
+    cb_cos.push_back(onetile);
 #endif
 
     for (uint32_t i = 0; i < num_rows; ++i) {
-        cb_reserve_back(input_cb_id, onetile);
-        uint32_t input_l1_write_addr = get_write_ptr(input_cb_id);
-        noc_async_read_page(input_curr_id, s0, input_l1_write_addr);
-        noc_async_read_barrier();
-        cb_push_back(input_cb_id, onetile);
+        cb_input.reserve_back(onetile);
+        uint32_t input_l1_write_addr = cb_input.get_write_ptr();
+        noc.async_read(
+            s0, CoreLocalMem<uint32_t>(input_l1_write_addr), input_tile_bytes, {.page_id = input_curr_id}, {});
+        noc.async_read_barrier();
+        cb_input.push_back(onetile);
         input_curr_id++;
 
 #ifndef DECODE_MODE
-        cb_reserve_back(sin_cb_id, onetile);
+        cb_sin.reserve_back(onetile);
         {
-            uint32_t sin_l1_write_addr = get_write_ptr(sin_cb_id);
-            noc_async_read_page(cos_sin_curr_id, s2, sin_l1_write_addr);
-            noc_async_read_barrier();
+            uint32_t sin_l1_write_addr = cb_sin.get_write_ptr();
+            noc.async_read(
+                s2, CoreLocalMem<uint32_t>(sin_l1_write_addr), sin_tile_bytes, {.page_id = cos_sin_curr_id}, {});
+            noc.async_read_barrier();
         }
-        cb_push_back(sin_cb_id, onetile);
+        cb_sin.push_back(onetile);
 
-        cb_reserve_back(cos_cb_id, onetile);
+        cb_cos.reserve_back(onetile);
         {
-            uint32_t cos_l1_write_addr = get_write_ptr(cos_cb_id);
-            noc_async_read_page(cos_sin_curr_id, s1, cos_l1_write_addr);
-            noc_async_read_barrier();
+            uint32_t cos_l1_write_addr = cb_cos.get_write_ptr();
+            noc.async_read(
+                s1, CoreLocalMem<uint32_t>(cos_l1_write_addr), cos_tile_bytes, {.page_id = cos_sin_curr_id}, {});
+            noc.async_read_barrier();
         }
-        cb_push_back(cos_cb_id, onetile);
+        cb_cos.push_back(onetile);
         cos_sin_curr_id++;
 
         ht++;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/dataflow/reader_rotary_embedding_single_tile_interleaved_start_id_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/dataflow/reader_rotary_embedding_single_tile_interleaved_start_id_sharded.cpp
@@ -9,6 +9,10 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 // Same tile encodes [[0, I_16], [-I_16, 0]] in BFP8_B layout. Tile bytes:
 //   0..63   : 4 face exponent sections, 16 bytes each (face0, face1, face2, face3)
@@ -18,8 +22,9 @@
 // decodes to +1.0 and 0xC0 decodes to -1.0.
 inline void fill_rotate_half_trans_mat_bfp8(uint32_t cb_id) {
     constexpr uint32_t onetile = 1;
-    cb_reserve_back(cb_id, onetile);
-    volatile tt_l1_ptr uint8_t* p = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(get_write_ptr(cb_id));
+    CircularBuffer cb(cb_id);
+    cb.reserve_back(onetile);
+    volatile tt_l1_ptr uint8_t* p = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(cb.get_write_ptr());
     // Zero the whole tile (1088 bytes).
     for (uint32_t i = 0; i < 1088; ++i) {
         p[i] = 0;
@@ -34,7 +39,7 @@ inline void fill_rotate_half_trans_mat_bfp8(uint32_t cb_id) {
         p[32 + r] = 127;
         p[576 + r * 16 + r] = 0xC0;
     }
-    cb_push_back(cb_id, onetile);
+    cb.push_back(onetile);
 }
 
 inline void fill_rotate_half_trans_mat_bf16(uint32_t cb_id) {
@@ -43,8 +48,9 @@ inline void fill_rotate_half_trans_mat_bf16(uint32_t cb_id) {
     constexpr uint16_t neg_one_bf16 = 0xBF80;
     constexpr uint32_t face_elems = 16 * 16;
 
-    cb_reserve_back(cb_id, onetile);
-    volatile tt_l1_ptr uint16_t* tile = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_write_ptr(cb_id));
+    CircularBuffer cb(cb_id);
+    cb.reserve_back(onetile);
+    volatile tt_l1_ptr uint16_t* tile = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(cb.get_write_ptr());
     for (uint32_t i = 0; i < 4 * face_elems; ++i) {
         tile[i] = 0;
     }
@@ -54,10 +60,12 @@ inline void fill_rotate_half_trans_mat_bf16(uint32_t cb_id) {
     for (uint32_t r = 0; r < 16; ++r) {
         tile[2 * face_elems + r * 16 + r] = neg_one_bf16;
     }
-    cb_push_back(cb_id, onetile);
+    cb.push_back(onetile);
 }
 
 void kernel_main() {
+    Noc noc;
+
     uint32_t cos_addr = get_arg_val<uint32_t>(0);
     uint32_t sin_addr = get_arg_val<uint32_t>(1);
     uint32_t num_rows = get_arg_val<uint32_t>(2);
@@ -75,9 +83,13 @@ void kernel_main() {
 
     constexpr uint32_t onetile = 1;
 
+    CircularBuffer cb_input(input_cb_id);
+    CircularBuffer cb_cos(cos_cb_id);
+    CircularBuffer cb_sin(sin_cb_id);
+
     // Sharded input: present in L1 already; just publish to the consumer.
-    cb_reserve_back(input_cb_id, num_rows);
-    cb_push_back(input_cb_id, num_rows);
+    cb_input.reserve_back(num_rows);
+    cb_input.push_back(num_rows);
 
     const uint32_t cos_tile_bytes = get_tile_size(cos_cb_id);
     const auto s1 = TensorAccessor(cos_args, cos_addr, cos_tile_bytes);
@@ -94,35 +106,37 @@ void kernel_main() {
     uint32_t cos_sin_curr_id = cos_sin_start_id;
 
 #ifdef DECODE_MODE
-    cb_reserve_back(sin_cb_id, onetile);
-    cb_reserve_back(cos_cb_id, onetile);
+    cb_sin.reserve_back(onetile);
+    cb_cos.reserve_back(onetile);
     {
-        uint32_t sin_l1_write_addr = get_write_ptr(sin_cb_id);
-        uint32_t cos_l1_write_addr = get_write_ptr(cos_cb_id);
-        noc_async_read_page(cos_sin_curr_id, s2, sin_l1_write_addr);
-        noc_async_read_page(cos_sin_curr_id, s1, cos_l1_write_addr);
-        noc_async_read_barrier();
+        uint32_t sin_l1_write_addr = cb_sin.get_write_ptr();
+        uint32_t cos_l1_write_addr = cb_cos.get_write_ptr();
+        noc.async_read(s2, CoreLocalMem<uint32_t>(sin_l1_write_addr), sin_tile_bytes, {.page_id = cos_sin_curr_id}, {});
+        noc.async_read(s1, CoreLocalMem<uint32_t>(cos_l1_write_addr), cos_tile_bytes, {.page_id = cos_sin_curr_id}, {});
+        noc.async_read_barrier();
     }
-    cb_push_back(sin_cb_id, onetile);
-    cb_push_back(cos_cb_id, onetile);
+    cb_sin.push_back(onetile);
+    cb_cos.push_back(onetile);
 #else
     uint32_t ht = start_row_id;
     for (uint32_t i = 0; i < num_rows; ++i) {
-        cb_reserve_back(sin_cb_id, onetile);
+        cb_sin.reserve_back(onetile);
         {
-            uint32_t sin_l1_write_addr = get_write_ptr(sin_cb_id);
-            noc_async_read_page(cos_sin_curr_id, s2, sin_l1_write_addr);
-            noc_async_read_barrier();
+            uint32_t sin_l1_write_addr = cb_sin.get_write_ptr();
+            noc.async_read(
+                s2, CoreLocalMem<uint32_t>(sin_l1_write_addr), sin_tile_bytes, {.page_id = cos_sin_curr_id}, {});
+            noc.async_read_barrier();
         }
-        cb_push_back(sin_cb_id, onetile);
+        cb_sin.push_back(onetile);
 
-        cb_reserve_back(cos_cb_id, onetile);
+        cb_cos.reserve_back(onetile);
         {
-            uint32_t cos_l1_write_addr = get_write_ptr(cos_cb_id);
-            noc_async_read_page(cos_sin_curr_id, s1, cos_l1_write_addr);
-            noc_async_read_barrier();
+            uint32_t cos_l1_write_addr = cb_cos.get_write_ptr();
+            noc.async_read(
+                s1, CoreLocalMem<uint32_t>(cos_l1_write_addr), cos_tile_bytes, {.page_id = cos_sin_curr_id}, {});
+            noc.async_read_barrier();
         }
-        cb_push_back(cos_cb_id, onetile);
+        cb_cos.push_back(onetile);
         cos_sin_curr_id++;
 
         ht++;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/dataflow/writer_rotary_embedding_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/dataflow/writer_rotary_embedding_interleaved_start_id.cpp
@@ -67,12 +67,13 @@ void kernel_main() {
 #ifdef OUT_SHARDED
     cb_out.wait_front(num_tiles);
 #else
+    constexpr uint32_t out_tile_size = get_tile_size(cb_id_out);
     uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id; ++i) {
         cb_out.wait_front(onetile);
         uint32_t l1_read_addr = cb_out.get_read_ptr();
 
-        noc.async_write(CoreLocalMem<uint32_t>(l1_read_addr), s, get_tile_size(cb_id_out), {}, {.page_id = i});
+        noc.async_write(CoreLocalMem<uint32_t>(l1_read_addr), s, out_tile_size, {}, {.page_id = i});
 
         noc.async_write_barrier();
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/dataflow/writer_rotary_embedding_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/dataflow/writer_rotary_embedding_interleaved_start_id.cpp
@@ -3,8 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
+    Noc noc;
+
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
     uint32_t num_tiles = get_arg_val<uint32_t>(1);
     uint32_t start_id = get_arg_val<uint32_t>(2);
@@ -14,6 +20,8 @@ void kernel_main() {
 
     // single-tile ublocks
     constexpr uint32_t onetile = 1;
+
+    CircularBuffer cb_out(cb_id_out);
 
 #ifndef OUT_SHARDED
     const auto s = TensorAccessor(dst_args, dst_addr);
@@ -29,36 +37,46 @@ void kernel_main() {
     constexpr uint32_t untilized_cos_sync_cb_id = get_compile_time_arg_val(decode_cta_offset + 1);
     constexpr uint32_t untilized_sin_cb_id = get_compile_time_arg_val(decode_cta_offset + 2);
     constexpr uint32_t untilized_sin_sync_cb_id = get_compile_time_arg_val(decode_cta_offset + 3);
-    cb_wait_front(untilized_sin_cb_id, Wt);
-    cb_reserve_back(untilized_sin_sync_cb_id, Wt);
-    uint64_t sin_l1_read_addr = get_noc_addr(get_read_ptr(untilized_sin_cb_id)) + cos_sin_offset;
-    uint32_t sin_l1_write_addr = get_read_ptr(untilized_sin_cb_id);
-    noc_async_read(sin_l1_read_addr, sin_l1_write_addr, Wbytes);
-    noc_async_read_barrier();
-    cb_push_back(untilized_sin_sync_cb_id, Wt);
 
-    cb_wait_front(untilized_cos_cb_id, Wt);
-    cb_reserve_back(untilized_cos_sync_cb_id, Wt);
-    uint64_t cos_l1_read_addr = get_noc_addr(get_read_ptr(untilized_cos_cb_id)) + cos_sin_offset;
-    uint32_t cos_l1_write_addr = get_read_ptr(untilized_cos_cb_id);
+    CircularBuffer cb_untilized_cos(untilized_cos_cb_id);
+    CircularBuffer cb_untilized_cos_sync(untilized_cos_sync_cb_id);
+    CircularBuffer cb_untilized_sin(untilized_sin_cb_id);
+    CircularBuffer cb_untilized_sin_sync(untilized_sin_sync_cb_id);
+
+    cb_untilized_sin.wait_front(Wt);
+    cb_untilized_sin_sync.reserve_back(Wt);
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address.
+    uint64_t sin_l1_read_addr = get_noc_addr(cb_untilized_sin.get_read_ptr()) + cos_sin_offset;
+    uint32_t sin_l1_write_addr = cb_untilized_sin.get_read_ptr();
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address.
+    noc_async_read(sin_l1_read_addr, sin_l1_write_addr, Wbytes);
+    noc.async_read_barrier();
+    cb_untilized_sin_sync.push_back(Wt);
+
+    cb_untilized_cos.wait_front(Wt);
+    cb_untilized_cos_sync.reserve_back(Wt);
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address.
+    uint64_t cos_l1_read_addr = get_noc_addr(cb_untilized_cos.get_read_ptr()) + cos_sin_offset;
+    uint32_t cos_l1_write_addr = cb_untilized_cos.get_read_ptr();
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address.
     noc_async_read(cos_l1_read_addr, cos_l1_write_addr, Wbytes);
-    noc_async_read_barrier();
-    cb_push_back(untilized_cos_sync_cb_id, Wt);
+    noc.async_read_barrier();
+    cb_untilized_cos_sync.push_back(Wt);
 #endif
 
 #ifdef OUT_SHARDED
-    cb_wait_front(cb_id_out, num_tiles);
+    cb_out.wait_front(num_tiles);
 #else
     uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id; ++i) {
-        cb_wait_front(cb_id_out, onetile);
-        uint32_t l1_read_addr = get_read_ptr(cb_id_out);
+        cb_out.wait_front(onetile);
+        uint32_t l1_read_addr = cb_out.get_read_ptr();
 
-        noc_async_write_page(i, s, l1_read_addr);
+        noc.async_write(CoreLocalMem<uint32_t>(l1_read_addr), s, get_tile_size(cb_id_out), {}, {.page_id = i});
 
-        noc_async_write_barrier();
+        noc.async_write_barrier();
 
-        cb_pop_front(cb_id_out, onetile);
+        cb_out.pop_front(onetile);
     }
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/compute/rotary_embedding_hf.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/compute/rotary_embedding_hf.cpp
@@ -10,6 +10,7 @@
 #include "api/dataflow/circular_buffer.h"
 
 ALWI void MUL_TILES(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t out_cb_id, uint32_t num_tiles) {
+    // Multiply input by cos or sin
     CircularBuffer in0_cb(in0_cb_id);
     CircularBuffer in1_cb(in1_cb_id);
     CircularBuffer out_cb(out_cb_id);
@@ -63,6 +64,7 @@ void kernel_main() {
     for (uint32_t i = 0; i < num_rows; ++i) {
         for (uint32_t j = 0; j < Wt; ++j) {
             if (j < half_Wt) {
+                // Multiply half of the rotated input by scalar (-1)
                 reconfig_data_format(rotated_in_cb_id, scalar_cb_id);
                 pack_reconfig_data_format(rotated_in_interm_cb_id);
                 rotated_in_cb.wait_front(onetile);
@@ -78,15 +80,19 @@ void kernel_main() {
                 rotated_in_cb.pop_front(onetile);
                 reconfig_data_format_srcb(scalar_cb_id, sin_cb_id);
                 pack_reconfig_data_format(rotated_in_interm_cb_id, sin_interm_cb_id);
+                // Multiply rotated input by sin
                 MUL_TILES(rotated_in_interm_cb_id, sin_cb_id, sin_interm_cb_id, onetile);
             } else {
                 reconfig_data_format(rotated_in_cb_id, sin_cb_id);
                 pack_reconfig_data_format(out_cb_id, sin_interm_cb_id);
+                // Multiply rotated input by sin
                 MUL_TILES(rotated_in_cb_id, sin_cb_id, sin_interm_cb_id, onetile);
             }
 
+            // Multiply input by cos
             MUL_TILES(in_cb_id, cos_cb_id, cos_interm_cb_id, onetile);
 
+            // Add applied sin/cos tensors
             cos_interm_cb.wait_front(onetile);
             sin_interm_cb.wait_front(onetile);
             out_cb.reserve_back(onetile);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/compute/rotary_embedding_hf.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/compute/rotary_embedding_hf.cpp
@@ -7,94 +7,103 @@
 #include "api/compute/common.h"
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/bcast.h"
+#include "api/dataflow/circular_buffer.h"
 
-ALWI void MUL_TILES(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t num_tiles) {
-    // Multiply input by cos or sin
-    cb_wait_front(in0_cb, num_tiles);
-    cb_wait_front(in1_cb, num_tiles);
-    cb_reserve_back(out_cb, num_tiles);
+ALWI void MUL_TILES(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t out_cb_id, uint32_t num_tiles) {
+    CircularBuffer in0_cb(in0_cb_id);
+    CircularBuffer in1_cb(in1_cb_id);
+    CircularBuffer out_cb(out_cb_id);
+
+    in0_cb.wait_front(num_tiles);
+    in1_cb.wait_front(num_tiles);
+    out_cb.reserve_back(num_tiles);
 
     tile_regs_acquire();
-    mul_tiles_init(in0_cb, in1_cb);
-    mul_tiles(in0_cb, in1_cb, 0, 0, 0);
+    mul_tiles_init(in0_cb_id, in1_cb_id);
+    mul_tiles(in0_cb_id, in1_cb_id, 0, 0, 0);
     tile_regs_commit();
     tile_regs_wait();
-    pack_tile(0, out_cb);
+    pack_tile(0, out_cb_id);
     tile_regs_release();
-    cb_push_back(out_cb, num_tiles);
-    cb_pop_front(in0_cb, num_tiles);
-    cb_pop_front(in1_cb, num_tiles);
+    out_cb.push_back(num_tiles);
+    in0_cb.pop_front(num_tiles);
+    in1_cb.pop_front(num_tiles);
 }
 
 void kernel_main() {
     constexpr uint32_t onetile = 1;
 
-    constexpr uint32_t in_cb = get_compile_time_arg_val(0);
-    constexpr uint32_t rotated_in_cb = get_compile_time_arg_val(1);
-    constexpr uint32_t cos_cb = get_compile_time_arg_val(2);
-    constexpr uint32_t sin_cb = get_compile_time_arg_val(3);
-    constexpr uint32_t scalar_cb = get_compile_time_arg_val(4);
-    constexpr uint32_t rotated_in_interm_cb = get_compile_time_arg_val(5);
-    constexpr uint32_t cos_interm_cb = get_compile_time_arg_val(6);
-    constexpr uint32_t sin_interm_cb = get_compile_time_arg_val(7);
-    constexpr uint32_t out_cb = get_compile_time_arg_val(8);
+    constexpr uint32_t in_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t rotated_in_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t cos_cb_id = get_compile_time_arg_val(2);
+    constexpr uint32_t sin_cb_id = get_compile_time_arg_val(3);
+    constexpr uint32_t scalar_cb_id = get_compile_time_arg_val(4);
+    constexpr uint32_t rotated_in_interm_cb_id = get_compile_time_arg_val(5);
+    constexpr uint32_t cos_interm_cb_id = get_compile_time_arg_val(6);
+    constexpr uint32_t sin_interm_cb_id = get_compile_time_arg_val(7);
+    constexpr uint32_t out_cb_id = get_compile_time_arg_val(8);
     constexpr uint32_t num_rows = get_compile_time_arg_val(9);
     constexpr uint32_t Wt = get_compile_time_arg_val(10);
     constexpr uint32_t half_Wt = get_compile_time_arg_val(11);
 
-    cb_wait_front(scalar_cb, onetile);
+    CircularBuffer in_cb(in_cb_id);
+    CircularBuffer rotated_in_cb(rotated_in_cb_id);
+    CircularBuffer cos_cb(cos_cb_id);
+    CircularBuffer sin_cb(sin_cb_id);
+    CircularBuffer scalar_cb(scalar_cb_id);
+    CircularBuffer rotated_in_interm_cb(rotated_in_interm_cb_id);
+    CircularBuffer cos_interm_cb(cos_interm_cb_id);
+    CircularBuffer sin_interm_cb(sin_interm_cb_id);
+    CircularBuffer out_cb(out_cb_id);
 
-    binary_op_init_common(rotated_in_cb, scalar_cb, rotated_in_interm_cb);
+    scalar_cb.wait_front(onetile);
+
+    binary_op_init_common(rotated_in_cb_id, scalar_cb_id, rotated_in_interm_cb_id);
 
     for (uint32_t i = 0; i < num_rows; ++i) {
         for (uint32_t j = 0; j < Wt; ++j) {
             if (j < half_Wt) {
-                // Multiply half of the rotated input by scalar (-1)
-                reconfig_data_format(rotated_in_cb, scalar_cb);
-                pack_reconfig_data_format(rotated_in_interm_cb);
-                cb_wait_front(rotated_in_cb, onetile);
-                cb_reserve_back(rotated_in_interm_cb, onetile);
+                reconfig_data_format(rotated_in_cb_id, scalar_cb_id);
+                pack_reconfig_data_format(rotated_in_interm_cb_id);
+                rotated_in_cb.wait_front(onetile);
+                rotated_in_interm_cb.reserve_back(onetile);
                 tile_regs_acquire();
-                mul_tiles_bcast_scalar_init_short(rotated_in_cb, scalar_cb);
-                mul_tiles_bcast_scalar(rotated_in_cb, scalar_cb, 0, 0, 0);
+                mul_tiles_bcast_scalar_init_short(rotated_in_cb_id, scalar_cb_id);
+                mul_tiles_bcast_scalar(rotated_in_cb_id, scalar_cb_id, 0, 0, 0);
                 tile_regs_commit();
                 tile_regs_wait();
-                pack_tile(0, rotated_in_interm_cb);
+                pack_tile(0, rotated_in_interm_cb_id);
                 tile_regs_release();
-                cb_push_back(rotated_in_interm_cb, onetile);
-                cb_pop_front(rotated_in_cb, onetile);
-                reconfig_data_format_srcb(scalar_cb, sin_cb);
-                pack_reconfig_data_format(rotated_in_interm_cb, sin_interm_cb);
-                // Multiply rotated input by sin
-                MUL_TILES(rotated_in_interm_cb, sin_cb, sin_interm_cb, onetile);
+                rotated_in_interm_cb.push_back(onetile);
+                rotated_in_cb.pop_front(onetile);
+                reconfig_data_format_srcb(scalar_cb_id, sin_cb_id);
+                pack_reconfig_data_format(rotated_in_interm_cb_id, sin_interm_cb_id);
+                MUL_TILES(rotated_in_interm_cb_id, sin_cb_id, sin_interm_cb_id, onetile);
             } else {
-                reconfig_data_format(rotated_in_cb, sin_cb);
-                pack_reconfig_data_format(out_cb, sin_interm_cb);
-                // Multiply rotated input by sin
-                MUL_TILES(rotated_in_cb, sin_cb, sin_interm_cb, onetile);
+                reconfig_data_format(rotated_in_cb_id, sin_cb_id);
+                pack_reconfig_data_format(out_cb_id, sin_interm_cb_id);
+                MUL_TILES(rotated_in_cb_id, sin_cb_id, sin_interm_cb_id, onetile);
             }
 
-            // Multiply input by cos
-            MUL_TILES(in_cb, cos_cb, cos_interm_cb, onetile);
+            MUL_TILES(in_cb_id, cos_cb_id, cos_interm_cb_id, onetile);
 
-            // Add applied sin/cos tensors
-            cb_wait_front(cos_interm_cb, onetile);
-            cb_wait_front(sin_interm_cb, onetile);
-            cb_reserve_back(out_cb, onetile);
+            cos_interm_cb.wait_front(onetile);
+            sin_interm_cb.wait_front(onetile);
+            out_cb.reserve_back(onetile);
 
-            reconfig_data_format_srca(rotated_in_cb, cos_interm_cb);
-            pack_reconfig_data_format(cos_interm_cb, out_cb);
+            reconfig_data_format_srca(rotated_in_cb_id, cos_interm_cb_id);
+            pack_reconfig_data_format(cos_interm_cb_id, out_cb_id);
             tile_regs_acquire();
-            add_tiles_init(cos_interm_cb, sin_interm_cb);
-            add_tiles(cos_interm_cb, sin_interm_cb, 0, 0, 0);
+            add_tiles_init(cos_interm_cb_id, sin_interm_cb_id);
+            add_tiles(cos_interm_cb_id, sin_interm_cb_id, 0, 0, 0);
             tile_regs_commit();
             tile_regs_wait();
-            pack_tile(0, out_cb);
+            pack_tile(0, out_cb_id);
             tile_regs_release();
 
-            cb_push_back(out_cb, onetile);
-            cb_pop_front(cos_interm_cb, onetile);
-            cb_pop_front(sin_interm_cb, onetile);
+            out_cb.push_back(onetile);
+            cos_interm_cb.pop_front(onetile);
+            sin_interm_cb.pop_front(onetile);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/compute/rotary_embedding_hf_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/compute/rotary_embedding_hf_sharded.cpp
@@ -22,7 +22,7 @@ void kernel_main() {
     constexpr uint32_t sin_interm_cb_id = get_compile_time_arg_val(6);
     constexpr uint32_t out_cb_id = get_compile_time_arg_val(7);
     constexpr uint32_t Wt = get_compile_time_arg_val(8);
-    constexpr uint32_t Ht = get_compile_time_arg_val(9);
+    constexpr uint32_t Ht = get_compile_time_arg_val(9);  // Total rows (tiles) owned by this core
     constexpr uint32_t heads_per_batch_t = get_compile_time_arg_val(10);
     constexpr uint32_t batch_per_core = get_compile_time_arg_val(11);
     constexpr uint32_t half_Wt = Wt / 2;
@@ -37,11 +37,15 @@ void kernel_main() {
     CircularBuffer sin_interm_cb(sin_interm_cb_id);
     CircularBuffer out_cb(out_cb_id);
 
-    binary_op_init_common(in_cb_id, sin_cb_id, sin_interm_cb_id);
+    binary_op_init_common(in_cb_id, sin_cb_id, sin_interm_cb_id);  // General Init for all binary ops
 
+    // Wait for the reader kernel (reader_rotary_embedding_hf_sharded.cpp) to
+    // write -1.0 into the scalar CB and push it.
     scalar_cb.wait_front(onetile);
 
     for (uint32_t batch_idx = 0; batch_idx < batch_per_core; ++batch_idx) {
+        // For decode mode, cos/sin are [1, batch, 1, head_dim] and this core's shard
+        // may contain multiple batch rows. Push one row at a time and advance the CB.
         sin_cb.reserve_back(Wt);
         cos_cb.reserve_back(Wt);
         sin_cb.push_back(Wt);
@@ -53,10 +57,12 @@ void kernel_main() {
             cos_interm_cb.reserve_back(Wt);
             out_cb.reserve_back(Wt);
 
+            // Get the input
             in_cb.reserve_back(Wt);
             in_cb.push_back(Wt);
             in_cb.wait_front(Wt);
 
+            // Process second half: multiply by -1 and store in rotated buffer
             mul_tiles_bcast_scalar_init_short(in_cb_id, scalar_cb_id);
             tile_regs_acquire();
             for (uint32_t j = 0; j < half_Wt; ++j) {
@@ -69,6 +75,7 @@ void kernel_main() {
             }
             tile_regs_release();
 
+            // Copy first half to second half of rotated buffer
             tile_regs_acquire();
             for (uint32_t j = 0; j < half_Wt; ++j) {
                 copy_tile_init_with_dt(in_cb_id);
@@ -84,6 +91,7 @@ void kernel_main() {
             rotated_in_interm_cb.push_back(Wt);
             rotated_in_interm_cb.wait_front(Wt);
 
+            // sin_interim = rotated * sin (broadcast rows)
             mul_bcast_rows_init_short(rotated_in_interm_cb_id, sin_cb_id);
             tile_regs_acquire();
             for (uint32_t j = 0; j < Wt; ++j) {
@@ -111,6 +119,7 @@ void kernel_main() {
             cos_interm_cb.push_back(Wt);
             in_cb.pop_front(Wt);
 
+            // out = cos_interim + sin_interim
             sin_interm_cb.wait_front(Wt);
             cos_interm_cb.wait_front(Wt);
             add_tiles_init(cos_interm_cb_id, sin_interm_cb_id);
@@ -133,5 +142,6 @@ void kernel_main() {
         cos_cb.pop_front(Wt);
     }
 
+    // Done with the scalar, so remove from CB
     scalar_cb.pop_front(onetile);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/compute/rotary_embedding_hf_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/compute/rotary_embedding_hf_sharded.cpp
@@ -7,132 +7,131 @@
 #include "api/compute/common.h"
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/bcast.h"
+#include "api/dataflow/circular_buffer.h"
 #include "ttnn/kernel/compute/dest_format_helpers.hpp"
 
 void kernel_main() {
     constexpr uint32_t onetile = 1;
-    constexpr uint32_t in_cb = get_compile_time_arg_val(0);
-    constexpr uint32_t cos_cb = get_compile_time_arg_val(1);
-    constexpr uint32_t sin_cb = get_compile_time_arg_val(2);
-    constexpr uint32_t scalar_cb = get_compile_time_arg_val(3);
+    constexpr uint32_t in_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t cos_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t sin_cb_id = get_compile_time_arg_val(2);
+    constexpr uint32_t scalar_cb_id = get_compile_time_arg_val(3);
 
-    constexpr uint32_t rotated_in_interm_cb = get_compile_time_arg_val(4);
-    constexpr uint32_t cos_interm_cb = get_compile_time_arg_val(5);
-    constexpr uint32_t sin_interm_cb = get_compile_time_arg_val(6);
-    constexpr uint32_t out_cb = get_compile_time_arg_val(7);
+    constexpr uint32_t rotated_in_interm_cb_id = get_compile_time_arg_val(4);
+    constexpr uint32_t cos_interm_cb_id = get_compile_time_arg_val(5);
+    constexpr uint32_t sin_interm_cb_id = get_compile_time_arg_val(6);
+    constexpr uint32_t out_cb_id = get_compile_time_arg_val(7);
     constexpr uint32_t Wt = get_compile_time_arg_val(8);
-    constexpr uint32_t Ht = get_compile_time_arg_val(9);  // Total rows (tiles) owned by this core
+    constexpr uint32_t Ht = get_compile_time_arg_val(9);
     constexpr uint32_t heads_per_batch_t = get_compile_time_arg_val(10);
     constexpr uint32_t batch_per_core = get_compile_time_arg_val(11);
     constexpr uint32_t half_Wt = Wt / 2;
     (void)Ht;
 
-    binary_op_init_common(in_cb, sin_cb, sin_interm_cb);  // General Init for all binary ops
+    CircularBuffer in_cb(in_cb_id);
+    CircularBuffer cos_cb(cos_cb_id);
+    CircularBuffer sin_cb(sin_cb_id);
+    CircularBuffer scalar_cb(scalar_cb_id);
+    CircularBuffer rotated_in_interm_cb(rotated_in_interm_cb_id);
+    CircularBuffer cos_interm_cb(cos_interm_cb_id);
+    CircularBuffer sin_interm_cb(sin_interm_cb_id);
+    CircularBuffer out_cb(out_cb_id);
 
-    // Wait for the reader kernel (reader_rotary_embedding_hf_sharded.cpp) to
-    // write -1.0 into the scalar CB and push it.
-    cb_wait_front(scalar_cb, onetile);
+    binary_op_init_common(in_cb_id, sin_cb_id, sin_interm_cb_id);
+
+    scalar_cb.wait_front(onetile);
 
     for (uint32_t batch_idx = 0; batch_idx < batch_per_core; ++batch_idx) {
-        // For decode mode, cos/sin are [1, batch, 1, head_dim] and this core's shard
-        // may contain multiple batch rows. Push one row at a time and advance the CB.
-        cb_reserve_back(sin_cb, Wt);
-        cb_reserve_back(cos_cb, Wt);
-        cb_push_back(sin_cb, Wt);
-        cb_push_back(cos_cb, Wt);
+        sin_cb.reserve_back(Wt);
+        cos_cb.reserve_back(Wt);
+        sin_cb.push_back(Wt);
+        cos_cb.push_back(Wt);
 
         for (uint32_t ht = 0; ht < heads_per_batch_t; ++ht) {
-            cb_reserve_back(rotated_in_interm_cb, Wt);
-            cb_reserve_back(sin_interm_cb, Wt);
-            cb_reserve_back(cos_interm_cb, Wt);
-            cb_reserve_back(out_cb, Wt);
+            rotated_in_interm_cb.reserve_back(Wt);
+            sin_interm_cb.reserve_back(Wt);
+            cos_interm_cb.reserve_back(Wt);
+            out_cb.reserve_back(Wt);
 
-            // Get the input
-            cb_reserve_back(in_cb, Wt);
-            cb_push_back(in_cb, Wt);
-            cb_wait_front(in_cb, Wt);
+            in_cb.reserve_back(Wt);
+            in_cb.push_back(Wt);
+            in_cb.wait_front(Wt);
 
-            // Process second half: multiply by -1 and store in rotated buffer
-            mul_tiles_bcast_scalar_init_short(in_cb, scalar_cb);
+            mul_tiles_bcast_scalar_init_short(in_cb_id, scalar_cb_id);
             tile_regs_acquire();
             for (uint32_t j = 0; j < half_Wt; ++j) {
-                mul_tiles_bcast_scalar(in_cb, scalar_cb, j + half_Wt, 0, j);
+                mul_tiles_bcast_scalar(in_cb_id, scalar_cb_id, j + half_Wt, 0, j);
             }
             tile_regs_commit();
             tile_regs_wait();
             for (uint32_t j = 0; j < half_Wt; ++j) {
-                pack_tile(j, rotated_in_interm_cb, j);
+                pack_tile(j, rotated_in_interm_cb_id, j);
             }
             tile_regs_release();
 
-            // Copy first half to second half of rotated buffer
             tile_regs_acquire();
             for (uint32_t j = 0; j < half_Wt; ++j) {
-                copy_tile_init_with_dt(in_cb);
-                copy_tile(in_cb, j, j + half_Wt);
+                copy_tile_init_with_dt(in_cb_id);
+                copy_tile(in_cb_id, j, j + half_Wt);
             }
             tile_regs_commit();
             tile_regs_wait();
             for (uint32_t j = 0; j < half_Wt; ++j) {
-                pack_tile(j + half_Wt, rotated_in_interm_cb, j + half_Wt);
+                pack_tile(j + half_Wt, rotated_in_interm_cb_id, j + half_Wt);
             }
             tile_regs_release();
 
-            cb_push_back(rotated_in_interm_cb, Wt);
-            cb_wait_front(rotated_in_interm_cb, Wt);
+            rotated_in_interm_cb.push_back(Wt);
+            rotated_in_interm_cb.wait_front(Wt);
 
-            // sin_interim = rotated * sin (broadcast rows)
-            mul_bcast_rows_init_short(rotated_in_interm_cb, sin_cb);
+            mul_bcast_rows_init_short(rotated_in_interm_cb_id, sin_cb_id);
             tile_regs_acquire();
             for (uint32_t j = 0; j < Wt; ++j) {
-                mul_tiles_bcast<BroadcastType::ROW>(rotated_in_interm_cb, sin_cb, j, j, j);
+                mul_tiles_bcast<BroadcastType::ROW>(rotated_in_interm_cb_id, sin_cb_id, j, j, j);
             }
             tile_regs_commit();
             tile_regs_wait();
             for (uint32_t j = 0; j < Wt; ++j) {
-                pack_tile(j, sin_interm_cb, j);
+                pack_tile(j, sin_interm_cb_id, j);
             }
             tile_regs_release();
-            cb_push_back(sin_interm_cb, Wt);
-            cb_pop_front(rotated_in_interm_cb, Wt);
+            sin_interm_cb.push_back(Wt);
+            rotated_in_interm_cb.pop_front(Wt);
 
-            // cos_interim = x * cos (broadcast rows)
             tile_regs_acquire();
             for (uint32_t j = 0; j < Wt; ++j) {
-                mul_tiles_bcast<BroadcastType::ROW>(in_cb, cos_cb, j, j, j);
+                mul_tiles_bcast<BroadcastType::ROW>(in_cb_id, cos_cb_id, j, j, j);
             }
             tile_regs_commit();
             tile_regs_wait();
             for (uint32_t j = 0; j < Wt; ++j) {
-                pack_tile(j, cos_interm_cb, j);
+                pack_tile(j, cos_interm_cb_id, j);
             }
             tile_regs_release();
-            cb_push_back(cos_interm_cb, Wt);
-            cb_pop_front(in_cb, Wt);  // Done with input
+            cos_interm_cb.push_back(Wt);
+            in_cb.pop_front(Wt);
 
-            // out = cos_interim + sin_interim
-            cb_wait_front(sin_interm_cb, Wt);
-            cb_wait_front(cos_interm_cb, Wt);
-            add_tiles_init(cos_interm_cb, sin_interm_cb);
+            sin_interm_cb.wait_front(Wt);
+            cos_interm_cb.wait_front(Wt);
+            add_tiles_init(cos_interm_cb_id, sin_interm_cb_id);
             tile_regs_acquire();
             for (uint32_t j = 0; j < Wt; ++j) {
-                add_tiles(cos_interm_cb, sin_interm_cb, j, j, j);
+                add_tiles(cos_interm_cb_id, sin_interm_cb_id, j, j, j);
             }
             tile_regs_commit();
             tile_regs_wait();
             for (uint32_t j = 0; j < Wt; ++j) {
-                pack_tile(j, out_cb, j);
+                pack_tile(j, out_cb_id, j);
             }
             tile_regs_release();
-            cb_push_back(out_cb, Wt);
-            cb_pop_front(sin_interm_cb, Wt);
-            cb_pop_front(cos_interm_cb, Wt);
+            out_cb.push_back(Wt);
+            sin_interm_cb.pop_front(Wt);
+            cos_interm_cb.pop_front(Wt);
         }
 
-        cb_pop_front(sin_cb, Wt);
-        cb_pop_front(cos_cb, Wt);
+        sin_cb.pop_front(Wt);
+        cos_cb.pop_front(Wt);
     }
 
-    // Done with the scalar, so remove from CB
-    cb_pop_front(scalar_cb, onetile);
+    scalar_cb.pop_front(onetile);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/compute/rotary_embedding_hf_single_tile_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/compute/rotary_embedding_hf_single_tile_sharded.cpp
@@ -9,97 +9,107 @@
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/matmul.h"
 #include "api/compute/compute_kernel_hw_startup.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
     constexpr uint32_t onetile = 1;
 
-    constexpr uint32_t in_cb = get_compile_time_arg_val(0);
-    constexpr uint32_t cos_cb = get_compile_time_arg_val(1);
-    constexpr uint32_t sin_cb = get_compile_time_arg_val(2);
-    constexpr uint32_t trans_mat_cb = get_compile_time_arg_val(3);
-    constexpr uint32_t rotated_in_interm_cb = get_compile_time_arg_val(4);
-    constexpr uint32_t cos_interm_cb = get_compile_time_arg_val(5);
-    constexpr uint32_t sin_interm_cb = get_compile_time_arg_val(6);
-    constexpr uint32_t out_cb = get_compile_time_arg_val(7);
+    constexpr uint32_t in_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t cos_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t sin_cb_id = get_compile_time_arg_val(2);
+    constexpr uint32_t trans_mat_cb_id = get_compile_time_arg_val(3);
+    constexpr uint32_t rotated_in_interm_cb_id = get_compile_time_arg_val(4);
+    constexpr uint32_t cos_interm_cb_id = get_compile_time_arg_val(5);
+    constexpr uint32_t sin_interm_cb_id = get_compile_time_arg_val(6);
+    constexpr uint32_t out_cb_id = get_compile_time_arg_val(7);
     constexpr uint32_t heads_per_batch_t = get_compile_time_arg_val(8);
     constexpr uint32_t batch_per_core = get_compile_time_arg_val(9);
 
-    cb_wait_front(trans_mat_cb, onetile);
-    compute_kernel_hw_startup<SrcOrder::Reverse>(in_cb, trans_mat_cb, rotated_in_interm_cb);
-    matmul_init(in_cb, trans_mat_cb);
-    binary_op_init_common(rotated_in_interm_cb, sin_cb, sin_interm_cb);
+    CircularBuffer in_cb(in_cb_id);
+    CircularBuffer cos_cb(cos_cb_id);
+    CircularBuffer sin_cb(sin_cb_id);
+    CircularBuffer trans_mat_cb(trans_mat_cb_id);
+    CircularBuffer rotated_in_interm_cb(rotated_in_interm_cb_id);
+    CircularBuffer cos_interm_cb(cos_interm_cb_id);
+    CircularBuffer sin_interm_cb(sin_interm_cb_id);
+    CircularBuffer out_cb(out_cb_id);
+
+    trans_mat_cb.wait_front(onetile);
+    compute_kernel_hw_startup<SrcOrder::Reverse>(in_cb_id, trans_mat_cb_id, rotated_in_interm_cb_id);
+    matmul_init(in_cb_id, trans_mat_cb_id);
+    binary_op_init_common(rotated_in_interm_cb_id, sin_cb_id, sin_interm_cb_id);
 
     for (uint32_t batch_idx = 0; batch_idx < batch_per_core; ++batch_idx) {
-        cb_reserve_back(sin_cb, onetile);
-        cb_reserve_back(cos_cb, onetile);
-        cb_push_back(sin_cb, onetile);
-        cb_push_back(cos_cb, onetile);
+        sin_cb.reserve_back(onetile);
+        cos_cb.reserve_back(onetile);
+        sin_cb.push_back(onetile);
+        cos_cb.push_back(onetile);
 
         for (uint32_t ht = 0; ht < heads_per_batch_t; ++ht) {
-            cb_reserve_back(rotated_in_interm_cb, onetile);
-            cb_reserve_back(sin_interm_cb, onetile);
-            cb_reserve_back(cos_interm_cb, onetile);
-            cb_reserve_back(out_cb, onetile);
+            rotated_in_interm_cb.reserve_back(onetile);
+            sin_interm_cb.reserve_back(onetile);
+            cos_interm_cb.reserve_back(onetile);
+            out_cb.reserve_back(onetile);
 
-            cb_reserve_back(in_cb, onetile);
-            cb_push_back(in_cb, onetile);
-            cb_wait_front(in_cb, onetile);
+            in_cb.reserve_back(onetile);
+            in_cb.push_back(onetile);
+            in_cb.wait_front(onetile);
 
-            reconfig_data_format(in_cb, trans_mat_cb);
-            pack_reconfig_data_format(rotated_in_interm_cb);
-            matmul_init(in_cb, trans_mat_cb);
+            reconfig_data_format(in_cb_id, trans_mat_cb_id);
+            pack_reconfig_data_format(rotated_in_interm_cb_id);
+            matmul_init(in_cb_id, trans_mat_cb_id);
             tile_regs_acquire();
-            matmul_tiles(in_cb, trans_mat_cb, 0, 0, 0);
+            matmul_tiles(in_cb_id, trans_mat_cb_id, 0, 0, 0);
             tile_regs_commit();
             tile_regs_wait();
-            pack_tile(0, rotated_in_interm_cb);
+            pack_tile(0, rotated_in_interm_cb_id);
             tile_regs_release();
-            cb_push_back(rotated_in_interm_cb, onetile);
+            rotated_in_interm_cb.push_back(onetile);
 
-            cb_wait_front(rotated_in_interm_cb, onetile);
-            cb_wait_front(sin_cb, onetile);
-            reconfig_data_format(rotated_in_interm_cb, sin_cb);
-            pack_reconfig_data_format(sin_interm_cb);
+            rotated_in_interm_cb.wait_front(onetile);
+            sin_cb.wait_front(onetile);
+            reconfig_data_format(rotated_in_interm_cb_id, sin_cb_id);
+            pack_reconfig_data_format(sin_interm_cb_id);
             tile_regs_acquire();
-            mul_bcast_rows_init_short(rotated_in_interm_cb, sin_cb);
-            mul_tiles_bcast_rows(rotated_in_interm_cb, sin_cb, 0, 0, 0);
+            mul_bcast_rows_init_short(rotated_in_interm_cb_id, sin_cb_id);
+            mul_tiles_bcast_rows(rotated_in_interm_cb_id, sin_cb_id, 0, 0, 0);
             tile_regs_commit();
             tile_regs_wait();
-            pack_tile(0, sin_interm_cb);
+            pack_tile(0, sin_interm_cb_id);
             tile_regs_release();
-            cb_push_back(sin_interm_cb, onetile);
-            cb_pop_front(rotated_in_interm_cb, onetile);
+            sin_interm_cb.push_back(onetile);
+            rotated_in_interm_cb.pop_front(onetile);
 
-            cb_wait_front(cos_cb, onetile);
-            reconfig_data_format(in_cb, cos_cb);
-            pack_reconfig_data_format(cos_interm_cb);
+            cos_cb.wait_front(onetile);
+            reconfig_data_format(in_cb_id, cos_cb_id);
+            pack_reconfig_data_format(cos_interm_cb_id);
             tile_regs_acquire();
-            mul_bcast_rows_init_short(in_cb, cos_cb);
-            mul_tiles_bcast_rows(in_cb, cos_cb, 0, 0, 0);
+            mul_bcast_rows_init_short(in_cb_id, cos_cb_id);
+            mul_tiles_bcast_rows(in_cb_id, cos_cb_id, 0, 0, 0);
             tile_regs_commit();
             tile_regs_wait();
-            pack_tile(0, cos_interm_cb);
+            pack_tile(0, cos_interm_cb_id);
             tile_regs_release();
-            cb_push_back(cos_interm_cb, onetile);
-            cb_pop_front(in_cb, onetile);
+            cos_interm_cb.push_back(onetile);
+            in_cb.pop_front(onetile);
 
-            cb_wait_front(cos_interm_cb, onetile);
-            cb_wait_front(sin_interm_cb, onetile);
-            reconfig_data_format(cos_interm_cb, sin_interm_cb);
-            pack_reconfig_data_format(out_cb);
-            add_tiles_init(cos_interm_cb, sin_interm_cb);
+            cos_interm_cb.wait_front(onetile);
+            sin_interm_cb.wait_front(onetile);
+            reconfig_data_format(cos_interm_cb_id, sin_interm_cb_id);
+            pack_reconfig_data_format(out_cb_id);
+            add_tiles_init(cos_interm_cb_id, sin_interm_cb_id);
             tile_regs_acquire();
-            add_tiles(cos_interm_cb, sin_interm_cb, 0, 0, 0);
+            add_tiles(cos_interm_cb_id, sin_interm_cb_id, 0, 0, 0);
             tile_regs_commit();
             tile_regs_wait();
-            pack_tile(0, out_cb);
+            pack_tile(0, out_cb_id);
             tile_regs_release();
-            cb_push_back(out_cb, onetile);
-            cb_pop_front(cos_interm_cb, onetile);
-            cb_pop_front(sin_interm_cb, onetile);
+            out_cb.push_back(onetile);
+            cos_interm_cb.pop_front(onetile);
+            sin_interm_cb.pop_front(onetile);
         }
 
-        cb_pop_front(sin_cb, onetile);
-        cb_pop_front(cos_cb, onetile);
+        sin_cb.pop_front(onetile);
+        cos_cb.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/reader_rotary_embedding_hf_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/reader_rotary_embedding_hf_interleaved.cpp
@@ -4,8 +4,14 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
+    Noc noc;
+
     uint32_t src_addr = get_arg_val<uint32_t>(0);
     uint32_t cos_addr = get_arg_val<uint32_t>(1);
     uint32_t sin_addr = get_arg_val<uint32_t>(2);
@@ -38,14 +44,20 @@ void kernel_main() {
     const uint32_t sin_tile_bytes = get_tile_size(sin_cb_id);
     const auto s2 = TensorAccessor(sin_args, sin_addr, sin_tile_bytes);
 
+    CircularBuffer cb_input(input_cb_id);
+    CircularBuffer cb_rotated_input(rotated_input_cb_id);
+    CircularBuffer cb_cos(cos_cb_id);
+    CircularBuffer cb_sin(sin_cb_id);
+    CircularBuffer cb_scalar(scalar_cb_id);
+
     // Fill tile with scalar value (-1)
     const uint32_t scalar_tile_bytes = get_tile_size(scalar_cb_id);
-    cb_reserve_back(scalar_cb_id, onetile);
-    uint32_t l1_zeros_addr_in_scalar = get_write_ptr(scalar_cb_id);
+    cb_scalar.reserve_back(onetile);
+    uint32_t l1_zeros_addr_in_scalar = cb_scalar.get_write_ptr();
     volatile tt_l1_ptr uint16_t* scalar_buffer =
         reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_zeros_addr_in_scalar);
     scalar_buffer[0] = scalar_value;
-    cb_push_back(scalar_cb_id, onetile);
+    cb_scalar.push_back(onetile);
 
     uint32_t input_curr_id = start_id;
     uint32_t rotated_input_curr_id = start_id + half_Wt;
@@ -55,31 +67,39 @@ void kernel_main() {
     // read a ublock of tiles from src to CB, and then push the ublock to unpacker
     for (uint32_t i = 0; i < num_rows; ++i) {
         for (uint32_t j = 0; j < Wt; ++j) {
-            cb_reserve_back(rotated_input_cb_id, onetile);
-            uint32_t rotated_input_l1_write_addr = get_write_ptr(rotated_input_cb_id);
-            noc_async_read_page(rotated_input_curr_id, s0, rotated_input_l1_write_addr);
-            noc_async_read_barrier();
-            cb_push_back(rotated_input_cb_id, onetile);
+            cb_rotated_input.reserve_back(onetile);
+            uint32_t rotated_input_l1_write_addr = cb_rotated_input.get_write_ptr();
+            noc.async_read(
+                s0,
+                CoreLocalMem<uint32_t>(rotated_input_l1_write_addr),
+                input_tile_bytes,
+                {.page_id = rotated_input_curr_id},
+                {});
+            noc.async_read_barrier();
+            cb_rotated_input.push_back(onetile);
             rotated_input_curr_id++;
 
-            cb_reserve_back(sin_cb_id, onetile);
-            uint32_t sin_l1_write_addr = get_write_ptr(sin_cb_id);
-            noc_async_read_page(cos_sin_curr_id, s2, sin_l1_write_addr);
-            noc_async_read_barrier();
-            cb_push_back(sin_cb_id, onetile);
+            cb_sin.reserve_back(onetile);
+            uint32_t sin_l1_write_addr = cb_sin.get_write_ptr();
+            noc.async_read(
+                s2, CoreLocalMem<uint32_t>(sin_l1_write_addr), sin_tile_bytes, {.page_id = cos_sin_curr_id}, {});
+            noc.async_read_barrier();
+            cb_sin.push_back(onetile);
 
-            cb_reserve_back(input_cb_id, onetile);
-            uint32_t input_l1_write_addr = get_write_ptr(input_cb_id);
-            noc_async_read_page(input_curr_id, s0, input_l1_write_addr);
-            noc_async_read_barrier();
-            cb_push_back(input_cb_id, onetile);
+            cb_input.reserve_back(onetile);
+            uint32_t input_l1_write_addr = cb_input.get_write_ptr();
+            noc.async_read(
+                s0, CoreLocalMem<uint32_t>(input_l1_write_addr), input_tile_bytes, {.page_id = input_curr_id}, {});
+            noc.async_read_barrier();
+            cb_input.push_back(onetile);
             input_curr_id++;
 
-            cb_reserve_back(cos_cb_id, onetile);
-            uint32_t cos_l1_write_addr = get_write_ptr(cos_cb_id);
-            noc_async_read_page(cos_sin_curr_id, s1, cos_l1_write_addr);
-            noc_async_read_barrier();
-            cb_push_back(cos_cb_id, onetile);
+            cb_cos.reserve_back(onetile);
+            uint32_t cos_l1_write_addr = cb_cos.get_write_ptr();
+            noc.async_read(
+                s1, CoreLocalMem<uint32_t>(cos_l1_write_addr), cos_tile_bytes, {.page_id = cos_sin_curr_id}, {});
+            noc.async_read_barrier();
+            cb_cos.push_back(onetile);
             cos_sin_curr_id++;
 
             if (j == half_Wt - 1) {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/reader_rotary_embedding_hf_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/reader_rotary_embedding_hf_sharded.cpp
@@ -4,6 +4,10 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 // Minimal BRISC reader for the sharded decode RoPE path.
 // The compute kernel (rotary_embedding_hf_sharded.cpp) relies on a scalar CB that
@@ -16,9 +20,11 @@ void kernel_main() {
     // bfloat16 representation of -1.0f, passed as uint32 from the factory.
     constexpr uint16_t scalar_value = (uint16_t)get_compile_time_arg_val(1);
 
-    cb_reserve_back(scalar_cb_id, 1);
-    uint32_t l1_write_addr = get_write_ptr(scalar_cb_id);
+    CircularBuffer cb_scalar(scalar_cb_id);
+
+    cb_scalar.reserve_back(1);
+    uint32_t l1_write_addr = cb_scalar.get_write_ptr();
     volatile tt_l1_ptr uint16_t* scalar_buf = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_addr);
     scalar_buf[0] = scalar_value;
-    cb_push_back(scalar_cb_id, 1);
+    cb_scalar.push_back(1);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/reader_rotary_embedding_hf_single_tile_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/reader_rotary_embedding_hf_single_tile_interleaved_start_id.cpp
@@ -4,11 +4,15 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
-inline void fill_rotate_half_trans_mat_bfp8(uint32_t cb_id) {
+inline void fill_rotate_half_trans_mat_bfp8(CircularBuffer& cb) {
     constexpr uint32_t onetile = 1;
-    cb_reserve_back(cb_id, onetile);
-    volatile tt_l1_ptr uint8_t* p = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(get_write_ptr(cb_id));
+    cb.reserve_back(onetile);
+    volatile tt_l1_ptr uint8_t* p = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(cb.get_write_ptr());
     for (uint32_t i = 0; i < 1088; ++i) {
         p[i] = 0;
     }
@@ -20,17 +24,17 @@ inline void fill_rotate_half_trans_mat_bfp8(uint32_t cb_id) {
         p[32 + r] = 127;
         p[576 + r * 16 + r] = 0xC0;
     }
-    cb_push_back(cb_id, onetile);
+    cb.push_back(onetile);
 }
 
-inline void fill_rotate_half_trans_mat_bf16(uint32_t cb_id) {
+inline void fill_rotate_half_trans_mat_bf16(CircularBuffer& cb) {
     constexpr uint32_t onetile = 1;
     constexpr uint16_t one_bf16 = 0x3F80;
     constexpr uint16_t neg_one_bf16 = 0xBF80;
     constexpr uint32_t face_elems = 16 * 16;
 
-    cb_reserve_back(cb_id, onetile);
-    volatile tt_l1_ptr uint16_t* tile = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_write_ptr(cb_id));
+    cb.reserve_back(onetile);
+    volatile tt_l1_ptr uint16_t* tile = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(cb.get_write_ptr());
     for (uint32_t i = 0; i < 4 * face_elems; ++i) {
         tile[i] = 0;
     }
@@ -40,17 +44,17 @@ inline void fill_rotate_half_trans_mat_bf16(uint32_t cb_id) {
     for (uint32_t r = 0; r < 16; ++r) {
         tile[2 * face_elems + r * 16 + r] = neg_one_bf16;
     }
-    cb_push_back(cb_id, onetile);
+    cb.push_back(onetile);
 }
 
-inline void fill_rotate_half_trans_mat_fp32(uint32_t cb_id) {
+inline void fill_rotate_half_trans_mat_fp32(CircularBuffer& cb) {
     constexpr uint32_t onetile = 1;
     constexpr uint32_t one_fp32 = 0x3F800000;
     constexpr uint32_t neg_one_fp32 = 0xBF800000;
     constexpr uint32_t face_elems = 16 * 16;
 
-    cb_reserve_back(cb_id, onetile);
-    volatile tt_l1_ptr uint32_t* tile = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
+    cb.reserve_back(onetile);
+    volatile tt_l1_ptr uint32_t* tile = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb.get_write_ptr());
     for (uint32_t i = 0; i < 4 * face_elems; ++i) {
         tile[i] = 0;
     }
@@ -60,10 +64,12 @@ inline void fill_rotate_half_trans_mat_fp32(uint32_t cb_id) {
     for (uint32_t r = 0; r < 16; ++r) {
         tile[2 * face_elems + r * 16 + r] = neg_one_fp32;
     }
-    cb_push_back(cb_id, onetile);
+    cb.push_back(onetile);
 }
 
 void kernel_main() {
+    Noc noc;
+
     uint32_t src_addr = get_arg_val<uint32_t>(0);
     uint32_t cos_addr = get_arg_val<uint32_t>(1);
     uint32_t sin_addr = get_arg_val<uint32_t>(2);
@@ -92,13 +98,18 @@ void kernel_main() {
     const uint32_t sin_tile_bytes = get_tile_size(sin_cb_id);
     const auto s2 = TensorAccessor(sin_args, sin_addr, sin_tile_bytes);
 
+    CircularBuffer cb_input(input_cb_id);
+    CircularBuffer cb_cos(cos_cb_id);
+    CircularBuffer cb_sin(sin_cb_id);
+    CircularBuffer cb_trans_mat(trans_mat_cb_id);
+
     const uint32_t trans_mat_tile_size = get_tile_size(trans_mat_cb_id);
     if (trans_mat_tile_size == 4096) {
-        fill_rotate_half_trans_mat_fp32(trans_mat_cb_id);
+        fill_rotate_half_trans_mat_fp32(cb_trans_mat);
     } else if (trans_mat_tile_size == 2048) {
-        fill_rotate_half_trans_mat_bf16(trans_mat_cb_id);
+        fill_rotate_half_trans_mat_bf16(cb_trans_mat);
     } else {
-        fill_rotate_half_trans_mat_bfp8(trans_mat_cb_id);
+        fill_rotate_half_trans_mat_bfp8(cb_trans_mat);
     }
 
     uint32_t input_curr_id = start_id;
@@ -106,28 +117,31 @@ void kernel_main() {
     uint32_t ht = start_row_id;
 
     for (uint32_t i = 0; i < num_rows; ++i) {
-        cb_reserve_back(input_cb_id, onetile);
-        uint32_t input_l1_write_addr = get_write_ptr(input_cb_id);
-        noc_async_read_page(input_curr_id, s0, input_l1_write_addr);
-        noc_async_read_barrier();
-        cb_push_back(input_cb_id, onetile);
+        cb_input.reserve_back(onetile);
+        uint32_t input_l1_write_addr = cb_input.get_write_ptr();
+        noc.async_read(
+            s0, CoreLocalMem<uint32_t>(input_l1_write_addr), input_tile_bytes, {.page_id = input_curr_id}, {});
+        noc.async_read_barrier();
+        cb_input.push_back(onetile);
         input_curr_id++;
 
-        cb_reserve_back(sin_cb_id, onetile);
+        cb_sin.reserve_back(onetile);
         {
-            uint32_t sin_l1_write_addr = get_write_ptr(sin_cb_id);
-            noc_async_read_page(cos_sin_curr_id, s2, sin_l1_write_addr);
-            noc_async_read_barrier();
+            uint32_t sin_l1_write_addr = cb_sin.get_write_ptr();
+            noc.async_read(
+                s2, CoreLocalMem<uint32_t>(sin_l1_write_addr), sin_tile_bytes, {.page_id = cos_sin_curr_id}, {});
+            noc.async_read_barrier();
         }
-        cb_push_back(sin_cb_id, onetile);
+        cb_sin.push_back(onetile);
 
-        cb_reserve_back(cos_cb_id, onetile);
+        cb_cos.reserve_back(onetile);
         {
-            uint32_t cos_l1_write_addr = get_write_ptr(cos_cb_id);
-            noc_async_read_page(cos_sin_curr_id, s1, cos_l1_write_addr);
-            noc_async_read_barrier();
+            uint32_t cos_l1_write_addr = cb_cos.get_write_ptr();
+            noc.async_read(
+                s1, CoreLocalMem<uint32_t>(cos_l1_write_addr), cos_tile_bytes, {.page_id = cos_sin_curr_id}, {});
+            noc.async_read_barrier();
         }
-        cb_push_back(cos_cb_id, onetile);
+        cb_cos.push_back(onetile);
         cos_sin_curr_id++;
 
         ht++;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/reader_rotary_embedding_hf_single_tile_interleaved_start_id_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/reader_rotary_embedding_hf_single_tile_interleaved_start_id_sharded.cpp
@@ -4,11 +4,15 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
-inline void fill_rotate_half_trans_mat_bfp8(uint32_t cb_id) {
+inline void fill_rotate_half_trans_mat_bfp8(CircularBuffer& cb) {
     constexpr uint32_t onetile = 1;
-    cb_reserve_back(cb_id, onetile);
-    volatile tt_l1_ptr uint8_t* p = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(get_write_ptr(cb_id));
+    cb.reserve_back(onetile);
+    volatile tt_l1_ptr uint8_t* p = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(cb.get_write_ptr());
     for (uint32_t i = 0; i < 1088; ++i) {
         p[i] = 0;
     }
@@ -20,17 +24,17 @@ inline void fill_rotate_half_trans_mat_bfp8(uint32_t cb_id) {
         p[32 + r] = 127;
         p[576 + r * 16 + r] = 0xC0;
     }
-    cb_push_back(cb_id, onetile);
+    cb.push_back(onetile);
 }
 
-inline void fill_rotate_half_trans_mat_bf16(uint32_t cb_id) {
+inline void fill_rotate_half_trans_mat_bf16(CircularBuffer& cb) {
     constexpr uint32_t onetile = 1;
     constexpr uint16_t one_bf16 = 0x3F80;
     constexpr uint16_t neg_one_bf16 = 0xBF80;
     constexpr uint32_t face_elems = 16 * 16;
 
-    cb_reserve_back(cb_id, onetile);
-    volatile tt_l1_ptr uint16_t* tile = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_write_ptr(cb_id));
+    cb.reserve_back(onetile);
+    volatile tt_l1_ptr uint16_t* tile = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(cb.get_write_ptr());
     for (uint32_t i = 0; i < 4 * face_elems; ++i) {
         tile[i] = 0;
     }
@@ -40,17 +44,17 @@ inline void fill_rotate_half_trans_mat_bf16(uint32_t cb_id) {
     for (uint32_t r = 0; r < 16; ++r) {
         tile[2 * face_elems + r * 16 + r] = neg_one_bf16;
     }
-    cb_push_back(cb_id, onetile);
+    cb.push_back(onetile);
 }
 
-inline void fill_rotate_half_trans_mat_fp32(uint32_t cb_id) {
+inline void fill_rotate_half_trans_mat_fp32(CircularBuffer& cb) {
     constexpr uint32_t onetile = 1;
     constexpr uint32_t one_fp32 = 0x3F800000;
     constexpr uint32_t neg_one_fp32 = 0xBF800000;
     constexpr uint32_t face_elems = 16 * 16;
 
-    cb_reserve_back(cb_id, onetile);
-    volatile tt_l1_ptr uint32_t* tile = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
+    cb.reserve_back(onetile);
+    volatile tt_l1_ptr uint32_t* tile = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb.get_write_ptr());
     for (uint32_t i = 0; i < 4 * face_elems; ++i) {
         tile[i] = 0;
     }
@@ -60,10 +64,12 @@ inline void fill_rotate_half_trans_mat_fp32(uint32_t cb_id) {
     for (uint32_t r = 0; r < 16; ++r) {
         tile[2 * face_elems + r * 16 + r] = neg_one_fp32;
     }
-    cb_push_back(cb_id, onetile);
+    cb.push_back(onetile);
 }
 
 void kernel_main() {
+    Noc noc;
+
     uint32_t cos_addr = get_arg_val<uint32_t>(0);
     uint32_t sin_addr = get_arg_val<uint32_t>(1);
     uint32_t num_rows = get_arg_val<uint32_t>(2);
@@ -81,8 +87,13 @@ void kernel_main() {
 
     constexpr uint32_t onetile = 1;
 
-    cb_reserve_back(input_cb_id, num_rows);
-    cb_push_back(input_cb_id, num_rows);
+    CircularBuffer cb_input(input_cb_id);
+    CircularBuffer cb_cos(cos_cb_id);
+    CircularBuffer cb_sin(sin_cb_id);
+    CircularBuffer cb_trans_mat(trans_mat_cb_id);
+
+    cb_input.reserve_back(num_rows);
+    cb_input.push_back(num_rows);
 
     const uint32_t cos_tile_bytes = get_tile_size(cos_cb_id);
     const auto s1 = TensorAccessor(cos_args, cos_addr, cos_tile_bytes);
@@ -92,31 +103,33 @@ void kernel_main() {
 
     const uint32_t trans_mat_tile_size = get_tile_size(trans_mat_cb_id);
     if (trans_mat_tile_size == 4096) {
-        fill_rotate_half_trans_mat_fp32(trans_mat_cb_id);
+        fill_rotate_half_trans_mat_fp32(cb_trans_mat);
     } else if (trans_mat_tile_size == 2048) {
-        fill_rotate_half_trans_mat_bf16(trans_mat_cb_id);
+        fill_rotate_half_trans_mat_bf16(cb_trans_mat);
     } else {
-        fill_rotate_half_trans_mat_bfp8(trans_mat_cb_id);
+        fill_rotate_half_trans_mat_bfp8(cb_trans_mat);
     }
 
     uint32_t cos_sin_curr_id = cos_sin_start_id;
     uint32_t ht = start_row_id;
     for (uint32_t i = 0; i < num_rows; ++i) {
-        cb_reserve_back(sin_cb_id, onetile);
+        cb_sin.reserve_back(onetile);
         {
-            uint32_t sin_l1_write_addr = get_write_ptr(sin_cb_id);
-            noc_async_read_page(cos_sin_curr_id, s2, sin_l1_write_addr);
-            noc_async_read_barrier();
+            uint32_t sin_l1_write_addr = cb_sin.get_write_ptr();
+            noc.async_read(
+                s2, CoreLocalMem<uint32_t>(sin_l1_write_addr), sin_tile_bytes, {.page_id = cos_sin_curr_id}, {});
+            noc.async_read_barrier();
         }
-        cb_push_back(sin_cb_id, onetile);
+        cb_sin.push_back(onetile);
 
-        cb_reserve_back(cos_cb_id, onetile);
+        cb_cos.reserve_back(onetile);
         {
-            uint32_t cos_l1_write_addr = get_write_ptr(cos_cb_id);
-            noc_async_read_page(cos_sin_curr_id, s1, cos_l1_write_addr);
-            noc_async_read_barrier();
+            uint32_t cos_l1_write_addr = cb_cos.get_write_ptr();
+            noc.async_read(
+                s1, CoreLocalMem<uint32_t>(cos_l1_write_addr), cos_tile_bytes, {.page_id = cos_sin_curr_id}, {});
+            noc.async_read_barrier();
         }
-        cb_push_back(cos_cb_id, onetile);
+        cb_cos.push_back(onetile);
         cos_sin_curr_id++;
 
         ht++;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/reader_rotary_embedding_hf_single_tile_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/reader_rotary_embedding_hf_single_tile_sharded.cpp
@@ -4,11 +4,15 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
-inline void fill_rotate_half_trans_mat_bfp8(uint32_t cb_id) {
+inline void fill_rotate_half_trans_mat_bfp8(CircularBuffer& cb) {
     constexpr uint32_t onetile = 1;
-    cb_reserve_back(cb_id, onetile);
-    volatile tt_l1_ptr uint8_t* p = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(get_write_ptr(cb_id));
+    cb.reserve_back(onetile);
+    volatile tt_l1_ptr uint8_t* p = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(cb.get_write_ptr());
     for (uint32_t i = 0; i < 1088; ++i) {
         p[i] = 0;
     }
@@ -20,17 +24,17 @@ inline void fill_rotate_half_trans_mat_bfp8(uint32_t cb_id) {
         p[32 + r] = 127;
         p[576 + r * 16 + r] = 0xC0;
     }
-    cb_push_back(cb_id, onetile);
+    cb.push_back(onetile);
 }
 
-inline void fill_rotate_half_trans_mat_bf16(uint32_t cb_id) {
+inline void fill_rotate_half_trans_mat_bf16(CircularBuffer& cb) {
     constexpr uint32_t onetile = 1;
     constexpr uint16_t one_bf16 = 0x3F80;
     constexpr uint16_t neg_one_bf16 = 0xBF80;
     constexpr uint32_t face_elems = 16 * 16;
 
-    cb_reserve_back(cb_id, onetile);
-    volatile tt_l1_ptr uint16_t* tile = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_write_ptr(cb_id));
+    cb.reserve_back(onetile);
+    volatile tt_l1_ptr uint16_t* tile = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(cb.get_write_ptr());
     for (uint32_t i = 0; i < 4 * face_elems; ++i) {
         tile[i] = 0;
     }
@@ -40,17 +44,17 @@ inline void fill_rotate_half_trans_mat_bf16(uint32_t cb_id) {
     for (uint32_t r = 0; r < 16; ++r) {
         tile[2 * face_elems + r * 16 + r] = neg_one_bf16;
     }
-    cb_push_back(cb_id, onetile);
+    cb.push_back(onetile);
 }
 
-inline void fill_rotate_half_trans_mat_fp32(uint32_t cb_id) {
+inline void fill_rotate_half_trans_mat_fp32(CircularBuffer& cb) {
     constexpr uint32_t onetile = 1;
     constexpr uint32_t one_fp32 = 0x3F800000;
     constexpr uint32_t neg_one_fp32 = 0xBF800000;
     constexpr uint32_t face_elems = 16 * 16;
 
-    cb_reserve_back(cb_id, onetile);
-    volatile tt_l1_ptr uint32_t* tile = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
+    cb.reserve_back(onetile);
+    volatile tt_l1_ptr uint32_t* tile = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb.get_write_ptr());
     for (uint32_t i = 0; i < 4 * face_elems; ++i) {
         tile[i] = 0;
     }
@@ -60,18 +64,20 @@ inline void fill_rotate_half_trans_mat_fp32(uint32_t cb_id) {
     for (uint32_t r = 0; r < 16; ++r) {
         tile[2 * face_elems + r * 16 + r] = neg_one_fp32;
     }
-    cb_push_back(cb_id, onetile);
+    cb.push_back(onetile);
 }
 
 void kernel_main() {
     constexpr uint32_t trans_mat_cb_id = get_compile_time_arg_val(0);
 
+    CircularBuffer cb_trans_mat(trans_mat_cb_id);
+
     const uint32_t trans_mat_tile_size = get_tile_size(trans_mat_cb_id);
     if (trans_mat_tile_size == 4096) {
-        fill_rotate_half_trans_mat_fp32(trans_mat_cb_id);
+        fill_rotate_half_trans_mat_fp32(cb_trans_mat);
     } else if (trans_mat_tile_size == 2048) {
-        fill_rotate_half_trans_mat_bf16(trans_mat_cb_id);
+        fill_rotate_half_trans_mat_bf16(cb_trans_mat);
     } else {
-        fill_rotate_half_trans_mat_bfp8(trans_mat_cb_id);
+        fill_rotate_half_trans_mat_bfp8(cb_trans_mat);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/writer_rotary_embedding_hf_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/writer_rotary_embedding_hf_interleaved.cpp
@@ -4,8 +4,14 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
+    Noc noc;
+
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
     uint32_t num_tiles = get_arg_val<uint32_t>(1);
     uint32_t start_id = get_arg_val<uint32_t>(2);
@@ -16,17 +22,19 @@ void kernel_main() {
     const uint32_t output_tile_bytes = get_tile_size(output_cb_id);
     const auto s = TensorAccessor(dst_args, dst_addr, output_tile_bytes);
 
+    CircularBuffer cb_output(output_cb_id);
+
     uint32_t output_curr_id = start_id;
 
 #ifdef OUT_SHARDED
-    cb_wait_front(output_cb_id, num_tiles);
+    cb_output.wait_front(num_tiles);
 #else
     for (uint32_t i = 0; i < num_tiles; ++i) {
-        cb_wait_front(output_cb_id, 1);
-        uint32_t l1_read_addr = get_read_ptr(output_cb_id);
-        noc_async_write_page(output_curr_id, s, l1_read_addr);
-        noc_async_write_barrier();
-        cb_pop_front(output_cb_id, 1);
+        cb_output.wait_front(1);
+        uint32_t l1_read_addr = cb_output.get_read_ptr();
+        noc.async_write(CoreLocalMem<uint32_t>(l1_read_addr), s, output_tile_bytes, {}, {.page_id = output_curr_id});
+        noc.async_write_barrier();
+        cb_output.pop_front(1);
         output_curr_id++;
     }
 #endif

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/kernels/dataflow/reader_rotate_half_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/kernels/dataflow/reader_rotate_half_interleaved_start_id.cpp
@@ -23,6 +23,7 @@ void kernel_main() {
     constexpr uint16_t scalar_value = get_compile_time_arg_val(3);
     constexpr auto src_args = TensorAccessorArgs<4>();
 
+    // in_no_mul, in_mul are from same tensor, so same sizes
     const uint32_t tile_bytes = get_tile_size(cb_id_in_no_mul);
 
     constexpr uint32_t onetile = 1;
@@ -32,6 +33,7 @@ void kernel_main() {
     CircularBuffer cb_in_mul(cb_id_in_mul);
     CircularBuffer cb_in_scalar(cb_id_in_scalar);
 
+    // Fill tile with zeros
     cb_in_scalar.reserve_back(onetile);
     uint32_t l1_zeros_addr_in_scalar = cb_in_scalar.get_write_ptr();
     volatile tt_l1_ptr uint16_t* scalar_buffer =
@@ -41,6 +43,7 @@ void kernel_main() {
 
     uint32_t in_no_mul_curr_id = start_id;
     uint32_t in_mul_curr_id = start_id + half_row_size;
+    // read a ublock of tiles from src to CB, and then push the ublock to unpacker
     for (uint32_t i = 0; i < num_rows; i++) {
         for (uint32_t j = 0; j < half_row_size; j++) {
             cb_in_no_mul.reserve_back(onetile);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/kernels/dataflow/reader_rotate_half_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/kernels/dataflow/reader_rotate_half_interleaved_start_id.cpp
@@ -4,10 +4,14 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
-
-// #include "api/debug/dprint.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
+    Noc noc;
+
     uint32_t src_addr = get_arg_val<uint32_t>(0);
     uint32_t num_rows = get_arg_val<uint32_t>(1);
     uint32_t half_row_size = get_arg_val<uint32_t>(2);
@@ -19,35 +23,39 @@ void kernel_main() {
     constexpr uint16_t scalar_value = get_compile_time_arg_val(3);
     constexpr auto src_args = TensorAccessorArgs<4>();
 
-    // in_no_mul, in_mul are from same tensor, so same sizes
+    const uint32_t tile_bytes = get_tile_size(cb_id_in_no_mul);
+
     constexpr uint32_t onetile = 1;
     const auto s = TensorAccessor(src_args, src_addr);
 
-    // Fill tile with zeros
-    cb_reserve_back(cb_id_in_scalar, onetile);
-    uint32_t l1_zeros_addr_in_scalar = get_write_ptr(cb_id_in_scalar);
+    CircularBuffer cb_in_no_mul(cb_id_in_no_mul);
+    CircularBuffer cb_in_mul(cb_id_in_mul);
+    CircularBuffer cb_in_scalar(cb_id_in_scalar);
+
+    cb_in_scalar.reserve_back(onetile);
+    uint32_t l1_zeros_addr_in_scalar = cb_in_scalar.get_write_ptr();
     volatile tt_l1_ptr uint16_t* scalar_buffer =
         reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_zeros_addr_in_scalar);
     scalar_buffer[0] = scalar_value;
-    cb_push_back(cb_id_in_scalar, onetile);
+    cb_in_scalar.push_back(onetile);
 
     uint32_t in_no_mul_curr_id = start_id;
     uint32_t in_mul_curr_id = start_id + half_row_size;
-    // read a ublock of tiles from src to CB, and then push the ublock to unpacker
     for (uint32_t i = 0; i < num_rows; i++) {
         for (uint32_t j = 0; j < half_row_size; j++) {
-            cb_reserve_back(cb_id_in_no_mul, onetile);
-            uint32_t in_no_mul_l1_write_addr = get_write_ptr(cb_id_in_no_mul);
-            noc_async_read_page(in_no_mul_curr_id, s, in_no_mul_l1_write_addr);
-            noc_async_read_barrier();
-            cb_push_back(cb_id_in_no_mul, onetile);
+            cb_in_no_mul.reserve_back(onetile);
+            uint32_t in_no_mul_l1_write_addr = cb_in_no_mul.get_write_ptr();
+            noc.async_read(
+                s, CoreLocalMem<uint32_t>(in_no_mul_l1_write_addr), tile_bytes, {.page_id = in_no_mul_curr_id}, {});
+            noc.async_read_barrier();
+            cb_in_no_mul.push_back(onetile);
             in_no_mul_curr_id++;
 
-            cb_reserve_back(cb_id_in_mul, onetile);
-            uint32_t in1_l1_write_addr = get_write_ptr(cb_id_in_mul);
-            noc_async_read_page(in_mul_curr_id, s, in1_l1_write_addr);
-            noc_async_read_barrier();
-            cb_push_back(cb_id_in_mul, onetile);
+            cb_in_mul.reserve_back(onetile);
+            uint32_t in1_l1_write_addr = cb_in_mul.get_write_ptr();
+            noc.async_read(s, CoreLocalMem<uint32_t>(in1_l1_write_addr), tile_bytes, {.page_id = in_mul_curr_id}, {});
+            noc.async_read_barrier();
+            cb_in_mul.push_back(onetile);
             in_mul_curr_id++;
         }
         in_no_mul_curr_id += half_row_size;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/kernels/dataflow/writer_rotate_half_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/kernels/dataflow/writer_rotate_half_interleaved_start_id.cpp
@@ -4,10 +4,14 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
-
-// #include "api/debug/dprint.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
+    Noc noc;
+
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
     uint32_t num_rows = get_arg_val<uint32_t>(1);
     uint32_t half_row_width = get_arg_val<uint32_t>(2);
@@ -17,27 +21,32 @@ void kernel_main() {
     constexpr uint32_t cb_id_out_mul = get_compile_time_arg_val(1);
     constexpr auto dst_args = TensorAccessorArgs<2>();
 
-    // ublocks size defined in tiles
+    const uint32_t tile_bytes = get_tile_size(cb_id_out_no_mul);
+
     constexpr uint32_t onetile = 1;
     const auto s = TensorAccessor(dst_args, dst_addr);
 
+    CircularBuffer cb_out_no_mul(cb_id_out_no_mul);
+    CircularBuffer cb_out_mul(cb_id_out_mul);
+
     uint32_t out_no_mul_curr_id = start_id + half_row_width;
     uint32_t out_mul_curr_id = start_id;
-    // read a ublock of tiles from src to CB, and then push the ublock to unpacker
     for (uint32_t i = 0; i < num_rows; i++) {
         for (uint32_t j = 0; j < half_row_width; j++) {
-            cb_wait_front(cb_id_out_no_mul, onetile);
-            uint32_t out_no_mul_l1_read_addr = get_read_ptr(cb_id_out_no_mul);
-            noc_async_write_page(out_no_mul_curr_id, s, out_no_mul_l1_read_addr);
-            noc_async_write_barrier();
-            cb_pop_front(cb_id_out_no_mul, onetile);
+            cb_out_no_mul.wait_front(onetile);
+            uint32_t out_no_mul_l1_read_addr = cb_out_no_mul.get_read_ptr();
+            noc.async_write(
+                CoreLocalMem<uint32_t>(out_no_mul_l1_read_addr), s, tile_bytes, {}, {.page_id = out_no_mul_curr_id});
+            noc.async_write_barrier();
+            cb_out_no_mul.pop_front(onetile);
             out_no_mul_curr_id++;
 
-            cb_wait_front(cb_id_out_mul, onetile);
-            uint32_t out_mul_l1_read_addr = get_read_ptr(cb_id_out_mul);
-            noc_async_write_page(out_mul_curr_id, s, out_mul_l1_read_addr);
-            noc_async_write_barrier();
-            cb_pop_front(cb_id_out_mul, onetile);
+            cb_out_mul.wait_front(onetile);
+            uint32_t out_mul_l1_read_addr = cb_out_mul.get_read_ptr();
+            noc.async_write(
+                CoreLocalMem<uint32_t>(out_mul_l1_read_addr), s, tile_bytes, {}, {.page_id = out_mul_curr_id});
+            noc.async_write_barrier();
+            cb_out_mul.pop_front(onetile);
             out_mul_curr_id++;
         }
         out_no_mul_curr_id += half_row_width;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/kernels/dataflow/writer_rotate_half_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/kernels/dataflow/writer_rotate_half_interleaved_start_id.cpp
@@ -21,6 +21,7 @@ void kernel_main() {
     constexpr uint32_t cb_id_out_mul = get_compile_time_arg_val(1);
     constexpr auto dst_args = TensorAccessorArgs<2>();
 
+    // ublocks size defined in tiles
     const uint32_t tile_bytes = get_tile_size(cb_id_out_no_mul);
 
     constexpr uint32_t onetile = 1;
@@ -31,6 +32,7 @@ void kernel_main() {
 
     uint32_t out_no_mul_curr_id = start_id + half_row_width;
     uint32_t out_mul_curr_id = start_id;
+    // read a ublock of tiles from src to CB, and then push the ublock to unpacker
     for (uint32_t i = 0; i < num_rows; i++) {
         for (uint32_t j = 0; j < half_row_width; j++) {
             cb_out_no_mul.wait_front(onetile);


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

Contributes to #45003. Migrates the rotary / rotate_half kernels under `experimental/transformer/` onto the Device 2.0 kernel API (dataflow + compute):
- `rotary_embedding` (7 files)
- `rotary_embedding_hf` (9 files)
- `rotate_half` (2 files)

### Notes for reviewers

- `Noc noc;` declared at the top of `kernel_main` (dataflow)
- Each runtime/compile-time CB id wrapped once as `CircularBuffer cb_x(cb_id_x);`, then accessed via object methods
- `noc_async_read_page` / `noc_async_write_page` rewritten to `noc.async_read(...)` / `noc.async_write(...)` against the existing `TensorAccessor`
- `noc_async_{read,write}_barrier()` rewritten as `noc.async_{read,write}_barrier()`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/transformer-d2-rotary)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/transformer-d2-rotary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/transformer-d2-rotary)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/transformer-d2-rotary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/transformer-d2-rotary)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/transformer-d2-rotary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/transformer-d2-rotary)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/transformer-d2-rotary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/transformer-d2-rotary)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/transformer-d2-rotary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/transformer-d2-rotary)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/transformer-d2-rotary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/transformer-d2-rotary)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/transformer-d2-rotary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/transformer-d2-rotary)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/transformer-d2-rotary)