### PR TITLE
[Cleanup] Migrate experimental/reduction kernels to Device 2.0 API

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_grouped_gate/device/kernels/compute/deepseek_grouped_gate.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_grouped_gate/device/kernels/compute/deepseek_grouped_gate.cpp
@@ -15,15 +15,18 @@
 #include "api/compute/eltwise_unary/recip.h"
 #include "api/compute/bcast.h"
 #include "api/compute/eltwise_binary_sfpu.h"
+#include "api/dataflow/circular_buffer.h"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 
 
 namespace blocks {
 void sigmoid(uint32_t cb_in_scores, uint32_t cb_sigmoid_scores, uint32_t width_tiles) {
+    CircularBuffer cb_scores(cb_in_scores);
+    CircularBuffer cb_sigmoid(cb_sigmoid_scores);
     // Perform sigmoid on scores
     // Reconfigure pack/unpack for bfloat16 after topk operations used UInt16
     for (uint32_t width_tile = 0; width_tile < width_tiles; width_tile++) {
-        cb_wait_front(cb_in_scores, 1);
+        cb_scores.wait_front(1);
         tile_regs_acquire();
         reconfig_data_format_srca(cb_in_scores);
         // copy tile from scores cb to destination register 0
@@ -33,33 +36,36 @@ void sigmoid(uint32_t cb_in_scores, uint32_t cb_sigmoid_scores, uint32_t width_t
         sigmoid_tile_init();
         sigmoid_tile(0);
         tile_regs_commit();
-        cb_pop_front(cb_in_scores, 1);
+        cb_scores.pop_front(1);
 
-        cb_reserve_back(cb_sigmoid_scores, 1);
+        cb_sigmoid.reserve_back(1);
         tile_regs_wait();
         pack_reconfig_data_format(cb_sigmoid_scores);
         pack_tile(0, cb_sigmoid_scores);
         tile_regs_release();
-        cb_push_back(cb_sigmoid_scores, 1);
+        cb_sigmoid.push_back(1);
     }
 }
 
 void add_bias(uint32_t cb_sigmoid_scores, uint32_t cb_in_bias, uint32_t cb_biased_scores, uint32_t width_tiles) {
+    CircularBuffer cb_sigmoid(cb_sigmoid_scores);
+    CircularBuffer cb_bias(cb_in_bias);
+    CircularBuffer cb_biased(cb_biased_scores);
     // Perform add bias on sigmoid scores
     add_tiles_init(cb_sigmoid_scores, cb_in_bias, false);
-    cb_wait_front(cb_sigmoid_scores, width_tiles);
+    cb_sigmoid.wait_front(width_tiles);
     for (uint32_t width_tile = 0; width_tile < width_tiles; width_tile++) {
-        cb_wait_front(cb_in_bias, 1);
+        cb_bias.wait_front(1);
         tile_regs_acquire();
         add_tiles(cb_sigmoid_scores, cb_in_bias, width_tile, 0, 0);
         tile_regs_commit();
-        cb_pop_front(cb_in_bias, 1);
+        cb_bias.pop_front(1);
 
-        cb_reserve_back(cb_biased_scores, 1);
+        cb_biased.reserve_back(1);
         tile_regs_wait();
         pack_tile(0, cb_biased_scores);
         tile_regs_release();
-        cb_push_back(cb_biased_scores, 1);
+        cb_biased.push_back(1);
     }
 }
 
@@ -72,10 +78,14 @@ void process_and_sort_tiles(
     bool switch_dir,
     bool ascending,
     int end_phase) {
+    CircularBuffer cb_biased(cb_biased_scores);
+    CircularBuffer cb_expert_index(cb_expert_index_template);
+    CircularBuffer cb_sorted_scores(cb_sorted_group_scores);
+    CircularBuffer cb_sorted_indices_temp(cb_sorted_expert_indices_temp);
     topk_tile_init();
     // streaming in input and index tiles to transpose and bitonic local sort them, two tiles at a time
-    cb_wait_front(cb_expert_index_template, Wt);
-    cb_wait_front(cb_biased_scores, Wt);
+    cb_expert_index.wait_front(Wt);
+    cb_biased.wait_front(Wt);
     for (uint32_t wt = 0; wt < Wt; wt += 2) {
         tile_regs_acquire();
         // transpose and unpack into dest regs
@@ -97,26 +107,26 @@ void process_and_sort_tiles(
         tile_regs_wait();
         // pack sorted score tiles
         pack_reconfig_data_format(cb_sorted_group_scores);
-        cb_reserve_back(cb_sorted_group_scores, 1);
+        cb_sorted_scores.reserve_back(1);
         pack_tile(0, cb_sorted_group_scores);
-        cb_push_back(cb_sorted_group_scores, 1);
+        cb_sorted_scores.push_back(1);
 
-        cb_reserve_back(cb_sorted_group_scores, 1);
+        cb_sorted_scores.reserve_back(1);
         pack_tile(1, cb_sorted_group_scores);
-        cb_push_back(cb_sorted_group_scores, 1);
+        cb_sorted_scores.push_back(1);
 
         // pack sorted index tiles
         pack_reconfig_data_format(cb_sorted_expert_indices_temp);
-        cb_reserve_back(cb_sorted_expert_indices_temp, 1);
+        cb_sorted_indices_temp.reserve_back(1);
         pack_tile(2, cb_sorted_expert_indices_temp);
-        cb_push_back(cb_sorted_expert_indices_temp, 1);
+        cb_sorted_indices_temp.push_back(1);
 
-        cb_reserve_back(cb_sorted_expert_indices_temp, 1);
+        cb_sorted_indices_temp.reserve_back(1);
         pack_tile(3, cb_sorted_expert_indices_temp);
-        cb_push_back(cb_sorted_expert_indices_temp, 1);
+        cb_sorted_indices_temp.push_back(1);
 
-        cb_wait_front(cb_sorted_expert_indices_temp, 2);
-        cb_pop_front(cb_sorted_expert_indices_temp, 2);
+        cb_sorted_indices_temp.wait_front(2);
+        cb_sorted_indices_temp.pop_front(2);
 
         tile_regs_release();
         ascending = switch_dir ? !ascending : ascending;
@@ -125,10 +135,12 @@ void process_and_sort_tiles(
 
 void sum_top_experts_per_group(
     const uint32_t cb_top_experts_per_group, const uint32_t cb_group_summed_scores, uint32_t summed_experts_per_group) {
+    CircularBuffer cb_top_experts(cb_top_experts_per_group);
+    CircularBuffer cb_group_summed(cb_group_summed_scores);
     // sum the top experts_per_group rows for each group
     binary_op_init_common(cb_top_experts_per_group, cb_top_experts_per_group, cb_group_summed_scores);
     add_tiles_init(cb_top_experts_per_group, cb_top_experts_per_group, true);
-    cb_wait_front(cb_top_experts_per_group, summed_experts_per_group);
+    cb_top_experts.wait_front(summed_experts_per_group);
 
     tile_regs_acquire();
     for (uint32_t i = 0; i < summed_experts_per_group; i += 2) {
@@ -136,15 +148,15 @@ void sum_top_experts_per_group(
     }
     tile_regs_commit();
 
-    cb_pop_front(cb_top_experts_per_group, summed_experts_per_group);
+    cb_top_experts.pop_front(summed_experts_per_group);
 
-    cb_reserve_back(cb_group_summed_scores, 1);
+    cb_group_summed.reserve_back(1);
 
     tile_regs_wait();
     pack_tile(0, cb_group_summed_scores);
     tile_regs_release();
 
-    cb_push_back(cb_group_summed_scores, 1);
+    cb_group_summed.push_back(1);
 }
 
 void topk_group_scores(
@@ -154,12 +166,15 @@ void topk_group_scores(
     bool switch_dir,
     bool ascending,
     int log_topk_groups) {
+    CircularBuffer cb_group_summed(cb_group_summed_scores);
+    CircularBuffer cb_group_index(cb_group_index_template);
+    CircularBuffer cb_sorted_order(cb_sorted_group_order);
     topk_tile_init();
 
     // Sort single input and index tile that have already ben transposed.
     // local sort into k groups
-    cb_wait_front(cb_group_summed_scores, 1);
-    cb_wait_front(cb_group_index_template, 1);
+    cb_group_summed.wait_front(1);
+    cb_group_index.wait_front(1);
 
     tile_regs_acquire();
     // copy scores tiles to dest reg 0 and index tiles to dest reg 2
@@ -173,10 +188,10 @@ void topk_group_scores(
 
     tile_regs_commit();
 
-    cb_pop_front(cb_group_summed_scores, 1);
+    cb_group_summed.pop_front(1);
     // don't pop group indices as it gets reused for the next tile heights
 
-    cb_reserve_back(cb_sorted_group_order, 1);
+    cb_sorted_order.reserve_back(1);
 
     tile_regs_wait();
     // pack index tile into cb_sorted_group_order
@@ -184,29 +199,31 @@ void topk_group_scores(
     pack_tile(2, cb_sorted_group_order);
     tile_regs_release();
 
-    cb_push_back(cb_sorted_group_order, 1);
+    cb_sorted_order.push_back(1);
 }
 
 void transpose_and_pack(const uint32_t input_cb_index, const uint32_t output_cb_index, const uint32_t tiles) {
+    CircularBuffer cb_input(input_cb_index);
+    CircularBuffer cb_output(output_cb_index);
     reconfig_data_format_srca(input_cb_index);
     transpose_wh_init_short(input_cb_index);
     pack_reconfig_data_format(output_cb_index);
     for (uint32_t i = 0; i < tiles; i++) {
-        cb_wait_front(input_cb_index, 1);
+        cb_input.wait_front(1);
 
         tile_regs_acquire();
         transpose_wh_tile(input_cb_index, 0, 0);
         tile_regs_commit();
 
-        cb_pop_front(input_cb_index, 1);
+        cb_input.pop_front(1);
 
-        cb_reserve_back(output_cb_index, 1);
+        cb_output.reserve_back(1);
 
         tile_regs_wait();
         pack_tile(0, output_cb_index);
         tile_regs_release();
 
-        cb_push_back(output_cb_index, 1);
+        cb_output.push_back(1);
     }
 }
 
@@ -219,13 +236,16 @@ void topk(
     const uint32_t log_tiles,
     const uint32_t k,
     const uint32_t logk) {
+    CircularBuffer cb_winning_scores(cb_winning_group_scores);
+    CircularBuffer cb_winning_indices(cb_winning_group_indices);
+    CircularBuffer cb_final_indices(cb_final_indices_transposed);
     bool switch_dir = (k == 64);
     bool ascending = false;
     int end_phase = (tiles <= 2) ? log_tiles - 1 : 5;
 
     topk_tile_init();
-    cb_wait_front(cb_winning_group_scores, tiles);
-    cb_wait_front(cb_winning_group_indices, tiles);
+    cb_winning_scores.wait_front(tiles);
+    cb_winning_indices.wait_front(tiles);
 
     tile_regs_acquire();
     // local sort first two tiles:
@@ -262,17 +282,17 @@ void topk(
     ckernel::topk_rebuild(0, (int)ascending, 0, 32, 5, true);
     tile_regs_commit();
 
-    cb_pop_front(cb_winning_group_scores, tiles);
-    cb_pop_front(cb_winning_group_indices, tiles);
+    cb_winning_scores.pop_front(tiles);
+    cb_winning_indices.pop_front(tiles);
 
-    cb_reserve_back(cb_final_indices_transposed, 1);
+    cb_final_indices.reserve_back(1);
 
     tile_regs_wait();
     pack_reconfig_data_format(cb_final_indices_transposed);
     pack_tile(2, cb_final_indices_transposed);
     tile_regs_release();
 
-    cb_push_back(cb_final_indices_transposed, 1);
+    cb_final_indices.push_back(1);
 
     transpose_and_pack(cb_final_indices_transposed, cb_out_indices, 1);
 }
@@ -285,6 +305,11 @@ template <
     uint32_t cb_epsilon_scalar,
     uint32_t cb_normalized_scores>
 void normalize_scores() {
+    CircularBuffer cb_gathered(cb_gathered_sigmoid);
+    CircularBuffer cb_reduce_inter(cb_reduce_intermediate);
+    CircularBuffer cb_epsilon(cb_epsilon_scalar);
+    CircularBuffer cb_reciprocal(cb_reciprocal_sums);
+    CircularBuffer cb_normalized(cb_normalized_scores);
     // 1. Sum row (experts) to get row vector of sums [1, 32]
     compute_kernel_lib::reduce<
         PoolType::SUM,
@@ -295,8 +320,8 @@ void normalize_scores() {
         compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop>(compute_kernel_lib::ReduceInputBlockShape::single());
 
     // 2. Add epsilon to intermediate results
-    cb_wait_front(cb_epsilon_scalar, 1);
-    cb_wait_front(cb_reduce_intermediate, 1);
+    cb_epsilon.wait_front(1);
+    cb_reduce_inter.wait_front(1);
 
     reconfig_data_format(cb_reduce_intermediate, cb_epsilon_scalar);
 
@@ -309,9 +334,9 @@ void normalize_scores() {
     recip_tile(0);
     tile_regs_commit();
 
-    cb_pop_front(cb_reduce_intermediate, 1);
+    cb_reduce_inter.pop_front(1);
 
-    cb_reserve_back(cb_reciprocal_sums, 1);
+    cb_reciprocal.reserve_back(1);
 
     // 5. Pack reciprocals
     tile_regs_wait();
@@ -319,47 +344,50 @@ void normalize_scores() {
     pack_tile(0, cb_reciprocal_sums);
     tile_regs_release();
 
-    cb_push_back(cb_reciprocal_sums, 1);
+    cb_reciprocal.push_back(1);
 
     // 6. Broadcast multiply
-    cb_wait_front(cb_reciprocal_sums, 1);
+    cb_reciprocal.wait_front(1);
 
     tile_regs_acquire();
     mul_bcast_cols_init_short(cb_gathered_sigmoid, cb_reciprocal_sums);
     mul_tiles_bcast<BroadcastType::COL>(cb_gathered_sigmoid, cb_reciprocal_sums, 0, 0, 0);  // tile *= 1/(sum_col(tile))
     tile_regs_commit();
 
-    cb_pop_front(cb_reciprocal_sums, 1);
-    cb_pop_front(cb_gathered_sigmoid, 1);
+    cb_reciprocal.pop_front(1);
+    cb_gathered.pop_front(1);
 
-    cb_reserve_back(cb_normalized_scores, 1);
+    cb_normalized.reserve_back(1);
 
     tile_regs_wait();
     pack_reconfig_data_format(cb_normalized_scores);
     pack_tile(0, cb_normalized_scores);
     tile_regs_release();
 
-    cb_push_back(cb_normalized_scores, 1);
+    cb_normalized.push_back(1);
 }
 
 void scale(const uint32_t cb_normalized_scores, const uint32_t cb_route_scale_scalar, const uint32_t cb_out_weights) {
-    cb_wait_front(cb_normalized_scores, 1);
-    cb_wait_front(cb_route_scale_scalar, 1);
+    CircularBuffer cb_normalized(cb_normalized_scores);
+    CircularBuffer cb_route_scale(cb_route_scale_scalar);
+    CircularBuffer cb_out(cb_out_weights);
+    cb_normalized.wait_front(1);
+    cb_route_scale.wait_front(1);
     mul_tiles_bcast_scalar_init_short(cb_normalized_scores, cb_route_scale_scalar);
 
     tile_regs_acquire();
     mul_tiles_bcast<BroadcastType::SCALAR>(cb_normalized_scores, cb_route_scale_scalar, 0, 0, 0);
     tile_regs_commit();
 
-    cb_pop_front(cb_normalized_scores, 1);
+    cb_normalized.pop_front(1);
 
-    cb_reserve_back(cb_out_weights, 1);
+    cb_out.reserve_back(1);
 
     tile_regs_wait();
     pack_tile(0, cb_out_weights);
     tile_regs_release();
 
-    cb_push_back(cb_out_weights, 1);
+    cb_out.push_back(1);
 }
 
 }  // namespace blocks

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_grouped_gate/device/kernels/dataflow/reader_deepseek_grouped_gate.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_grouped_gate/device/kernels/dataflow/reader_deepseek_grouped_gate.cpp
@@ -3,11 +3,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
+    Noc noc;
+
     constexpr uint32_t cb_in_scores = get_named_compile_time_arg_val("cb_in_scores");
     constexpr uint32_t cb_in_bias = get_named_compile_time_arg_val("cb_in_bias");
     constexpr uint32_t width_tiles = get_named_compile_time_arg_val("width_tiles");
+
+    CircularBuffer cb_scores(cb_in_scores);
+    CircularBuffer cb_bias(cb_in_bias);
 
     // Get scores and bias tensor accessors
     constexpr auto scores_args = TensorAccessorArgs<0>();
@@ -21,17 +31,26 @@ void kernel_main() {
     const auto scores_accessor = TensorAccessor(scores_args, scores_addr);
     const auto bias_accessor = TensorAccessor(bias_args, bias_addr);
 
+    const uint32_t scores_tile_bytes = get_tile_size(cb_in_scores);
+    const uint32_t bias_tile_bytes = get_tile_size(cb_in_bias);
+
     for (uint32_t height_tile = start_height_tile; height_tile < end_height_tile; height_tile++) {
         uint32_t base_page = height_tile * width_tiles;
         for (uint32_t width_tile = 0; width_tile < width_tiles; width_tile++) {
             uint32_t page = base_page + width_tile;
-            cb_reserve_back(cb_in_scores, 1);
-            cb_reserve_back(cb_in_bias, 1);
-            noc_async_read_page(page, scores_accessor, get_write_ptr(cb_in_scores));
-            noc_async_read_page(page, bias_accessor, get_write_ptr(cb_in_bias));
-            noc_async_read_barrier();
-            cb_push_back(cb_in_scores, 1);
-            cb_push_back(cb_in_bias, 1);
+            cb_scores.reserve_back(1);
+            cb_bias.reserve_back(1);
+            noc.async_read(
+                scores_accessor,
+                CoreLocalMem<uint32_t>(cb_scores.get_write_ptr()),
+                scores_tile_bytes,
+                {.page_id = page},
+                {});
+            noc.async_read(
+                bias_accessor, CoreLocalMem<uint32_t>(cb_bias.get_write_ptr()), bias_tile_bytes, {.page_id = page}, {});
+            noc.async_read_barrier();
+            cb_scores.push_back(1);
+            cb_bias.push_back(1);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_grouped_gate/device/kernels/dataflow/writer_deepseek_grouped_gate.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_grouped_gate/device/kernels/dataflow/writer_deepseek_grouped_gate.cpp
@@ -3,6 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 
 // Tile geometry constants for bf16 32x32 tiles with 16x16 faces
@@ -23,8 +28,10 @@ using namespace tile_constants;
 
 FORCE_INLINE void generate_index_tile(
     const uint32_t cb_expert_index_template, const uint32_t index_write_addr, uint32_t start_expert_index) {
+    Noc noc;
+    CircularBuffer cb_expert_index(cb_expert_index_template);
     // Create the top two faces by writing 1 face line, then using noc to write the rest of the face
-    cb_reserve_back(cb_expert_index_template, 1);
+    cb_expert_index.reserve_back(1);
     for (uint32_t width_face = 0; width_face < 2; width_face++) {
         uint32_t current_index = start_expert_index + width_face * columns_per_face;
         uint32_t index_write_face_offset = index_write_addr + width_face * face_size_bytes;
@@ -41,32 +48,37 @@ FORCE_INLINE void generate_index_tile(
         // then use noc to write the rest of the face
         uint32_t dm_engine_index_write_offset = index_write_face_offset + face_line_bytes;
         for (uint32_t i = 1; i < rows_per_face; i++) {
+            // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
             noc_async_read(base_index_noc_addr, dm_engine_index_write_offset, face_line_bytes);
             dm_engine_index_write_offset += face_line_bytes;
         }
     }
 
     uint64_t index_noc_addr_base = get_noc_addr(index_write_addr);
-    noc_async_read_barrier();
+    noc.async_read_barrier();
 
     // Create the bottom two faces by doing a noc copy of the top two faces
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
     noc_async_read(index_noc_addr_base, index_write_addr + 2 * face_size_bytes, 2 * face_size_bytes);
-    noc_async_read_barrier();
-    cb_push_back(cb_expert_index_template, 1);
+    noc.async_read_barrier();
+    cb_expert_index.push_back(1);
 }
 
 FORCE_INLINE void generate_index_tiles(
     const uint32_t cb_expert_index_template, uint32_t width_tiles, uint32_t page_size) {
+    CircularBuffer cb_expert_index(cb_expert_index_template);
     for (uint32_t i = 0; i < width_tiles; i++) {
-        generate_index_tile(cb_expert_index_template, get_write_ptr(cb_expert_index_template), columns_per_tile * i);
+        generate_index_tile(cb_expert_index_template, cb_expert_index.get_write_ptr(), columns_per_tile * i);
     }
 }
 
 // Vertically along each tile, write index 0, ..., n_groups - 1
 FORCE_INLINE void generate_group_indices_tiles(
     const uint32_t cb_group_index_template, uint32_t width_tiles, uint32_t n_groups) {
-    cb_reserve_back(cb_group_index_template, 1);  // max of 32 groups
-    uint32_t base_write_addr = get_write_ptr(cb_group_index_template);
+    Noc noc;
+    CircularBuffer cb_group_index(cb_group_index_template);
+    cb_group_index.reserve_back(1);  // max of 32 groups
+    uint32_t base_write_addr = cb_group_index.get_write_ptr();
     // G x W x T slice of the tile is written
     // G x T subset of the tile is written, where G is the n_groups and T is the tokens
     // handle first face line
@@ -96,11 +108,13 @@ FORCE_INLINE void generate_group_indices_tiles(
     // copy face 1 to face 2 and face 3 to face 4
     uint32_t face_2_l1_write_addr = base_write_addr + face_size_bytes;
     uint32_t face_4_l1_write_addr = base_write_addr + 3 * face_size_bytes;
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
     noc_async_read(dm_engine_index_write_offset_face_1, face_2_l1_write_addr, face_size_bytes);
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
     noc_async_read(dm_engine_index_write_offset_face_3, face_4_l1_write_addr, face_size_bytes);
     uint32_t tile_write_addr = base_write_addr + tile_size_bytes;
-    noc_async_read_barrier();
-    cb_push_back(cb_group_index_template, 1);
+    noc.async_read_barrier();
+    cb_group_index.push_back(1);
 }
 
 FORCE_INLINE void generate_summed_experts_tiles(
@@ -109,6 +123,9 @@ FORCE_INLINE void generate_summed_experts_tiles(
     uint32_t width_tiles,
     uint32_t summed_experts_per_group,
     uint32_t tokens_per_tile) {
+    Noc noc;
+    CircularBuffer cb_top_experts(cb_top_experts_per_group);
+    CircularBuffer cb_sorted_scores(cb_sorted_group_scores);
     // copy 0,...,summed_experts_per_group-1 rows from cb_sorted_group_scores to 0,...,summed_experts_per_group-1 tile
     // in cb_top_experts_per_group for each width_tile
     // for each group, copy the top experts_per_group rows to cb_top_experts_per_group
@@ -116,28 +133,30 @@ FORCE_INLINE void generate_summed_experts_tiles(
     // in our case, for now, width_tiles = n_groups
 
     // for each group, copy the top experts_per_group rows to cb_top_experts_per_group
-    cb_reserve_back(cb_top_experts_per_group, summed_experts_per_group);
+    cb_top_experts.reserve_back(summed_experts_per_group);
     for (uint32_t width_tile = 0; width_tile < width_tiles; width_tile++) {
         // get one width tile
-        cb_wait_front(cb_sorted_group_scores, 1);
+        cb_sorted_scores.wait_front(1);
         // offset to relevant tile in cb_sorted_group_scores
-        uint64_t group_sorted_tile_ptr = get_noc_addr(get_read_ptr(cb_sorted_group_scores));
+        uint64_t group_sorted_tile_ptr = get_noc_addr(cb_sorted_scores.get_read_ptr());
 
         if (width_tile % 2 == 0) {
             // even width tiles are sorted descending, best at row 0
             for (uint32_t i = 0; i < summed_experts_per_group; i++) {
                 // Source: Face 0 row i (tokens 0-15 after transpose)
                 // Dest: Face 0 of tile i, row = width_tile
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
                 noc_async_read(
                     group_sorted_tile_ptr + i * face_line_bytes,
-                    get_write_ptr(cb_top_experts_per_group) + i * tile_size_bytes + width_tile * face_line_bytes,
+                    cb_top_experts.get_write_ptr() + i * tile_size_bytes + width_tile * face_line_bytes,
                     face_line_bytes);
                 if (tokens_per_tile > rows_per_face) {
                     // Source: Face 1 row i (tokens 16-31 after transpose)
                     // Dest: Face 1 of tile i, row = width_tile (layout is [groups, tokens])
+                    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
                     noc_async_read(
                         group_sorted_tile_ptr + face_size_bytes + i * face_line_bytes,
-                        get_write_ptr(cb_top_experts_per_group) + face_size_bytes + i * tile_size_bytes +
+                        cb_top_experts.get_write_ptr() + face_size_bytes + i * tile_size_bytes +
                             width_tile * face_line_bytes,
                         face_line_bytes);
                 }
@@ -149,25 +168,27 @@ FORCE_INLINE void generate_summed_experts_tiles(
             for (uint32_t i = 0; i < summed_experts_per_group; i++) {
                 // Source: Face 2 row (15-i) for tokens 0-15
                 // Dest: Face 0 of tile i, row = width_tile
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
                 noc_async_read(
                     group_sorted_tile_ptr + (rows_per_face - 1 - i) * face_line_bytes,
-                    get_write_ptr(cb_top_experts_per_group) + i * tile_size_bytes + width_tile * face_line_bytes,
+                    cb_top_experts.get_write_ptr() + i * tile_size_bytes + width_tile * face_line_bytes,
                     face_line_bytes);
                 if (tokens_per_tile > rows_per_face) {
                     // Source: Face 3 row (15-i) for tokens 16-31
                     // Dest: Face 1 of tile i, row = width_tile (layout is [groups, tokens])
+                    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
                     noc_async_read(
                         group_sorted_tile_ptr + face_size_bytes + (rows_per_face - 1 - i) * face_line_bytes,
-                        get_write_ptr(cb_top_experts_per_group) + face_size_bytes + i * tile_size_bytes +
+                        cb_top_experts.get_write_ptr() + face_size_bytes + i * tile_size_bytes +
                             width_tile * face_line_bytes,
                         face_line_bytes);
                 }
             }
         }
-        noc_async_read_barrier();
-        cb_pop_front(cb_sorted_group_scores, 1);
+        noc.async_read_barrier();
+        cb_sorted_scores.pop_front(1);
     }
-    cb_push_back(cb_top_experts_per_group, summed_experts_per_group);
+    cb_top_experts.push_back(summed_experts_per_group);
 }
 
 template <
@@ -180,22 +201,28 @@ template <
     uint32_t topk_groups,
     uint32_t num_group_tiles>
 FORCE_INLINE void generate_winning_group_tiles(uint32_t tokens_per_tile) {
-    cb_wait_front(cb_biased_scores, width_tiles);
-    cb_wait_front(cb_expert_index_template, width_tiles);
-    cb_wait_front(cb_sorted_group_order, num_group_tiles);
+    Noc noc;
+    CircularBuffer cb_biased(cb_biased_scores);
+    CircularBuffer cb_expert_index(cb_expert_index_template);
+    CircularBuffer cb_sorted_order(cb_sorted_group_order);
+    CircularBuffer cb_winning_scores(cb_winning_group_scores);
+    CircularBuffer cb_winning_indices(cb_winning_group_indices);
+    cb_biased.wait_front(width_tiles);
+    cb_expert_index.wait_front(width_tiles);
+    cb_sorted_order.wait_front(num_group_tiles);
 
-    cb_reserve_back(cb_winning_group_scores, topk_groups);
-    cb_reserve_back(cb_winning_group_indices, topk_groups);
+    cb_winning_scores.reserve_back(topk_groups);
+    cb_winning_indices.reserve_back(topk_groups);
 
     // Pointers
-    uint64_t scores_base_noc_addr = get_noc_addr(get_read_ptr(cb_biased_scores));
-    uint64_t indices_base_noc_addr = get_noc_addr(get_read_ptr(cb_expert_index_template));
-    uint32_t scores_dest_base_addr = get_write_ptr(cb_winning_group_scores);
-    uint32_t indices_dest_base_addr = get_write_ptr(cb_winning_group_indices);
+    uint64_t scores_base_noc_addr = get_noc_addr(cb_biased.get_read_ptr());
+    uint64_t indices_base_noc_addr = get_noc_addr(cb_expert_index.get_read_ptr());
+    uint32_t scores_dest_base_addr = cb_winning_scores.get_write_ptr();
+    uint32_t indices_dest_base_addr = cb_winning_indices.get_write_ptr();
 
     // Indices pointer (in L1)
     volatile tt_l1_ptr uint16_t* sorted_indices_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_read_ptr(cb_sorted_group_order));
+        reinterpret_cast<volatile tt_l1_ptr uint16_t*>(cb_sorted_order.get_read_ptr());
 
     for (uint32_t k = 0; k < topk_groups; k++) {
         uint32_t dest_tile_offset = k * tile_size_bytes;
@@ -224,18 +251,22 @@ FORCE_INLINE void generate_winning_group_tiles(uint32_t tokens_per_tile) {
             uint32_t row_faceline1 = t * face_line_bytes;
             uint32_t row_faceline2 = face_size_bytes + row_faceline1;
 
+            // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
             noc_async_read(
                 scores_base_noc_addr + src_tile_offset + row_faceline1,
                 scores_dest_addr + row_faceline1,
                 face_line_bytes);
+            // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
             noc_async_read(
                 indices_base_noc_addr + src_tile_offset + row_faceline1,
                 indices_dest_addr + row_faceline1,
                 face_line_bytes);
+            // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
             noc_async_read(
                 scores_base_noc_addr + src_tile_offset + row_faceline2,
                 scores_dest_addr + row_faceline2,
                 face_line_bytes);
+            // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
             noc_async_read(
                 indices_base_noc_addr + src_tile_offset + row_faceline2,
                 indices_dest_addr + row_faceline2,
@@ -253,18 +284,22 @@ FORCE_INLINE void generate_winning_group_tiles(uint32_t tokens_per_tile) {
                 uint32_t row_faceline1 = 2 * face_size_bytes + t_off;
                 uint32_t row_faceline2 = 3 * face_size_bytes + t_off;
 
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
                 noc_async_read(
                     scores_base_noc_addr + src_tile_offset + row_faceline1,
                     scores_dest_addr + row_faceline1,
                     face_line_bytes);
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
                 noc_async_read(
                     indices_base_noc_addr + src_tile_offset + row_faceline1,
                     indices_dest_addr + row_faceline1,
                     face_line_bytes);
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
                 noc_async_read(
                     scores_base_noc_addr + src_tile_offset + row_faceline2,
                     scores_dest_addr + row_faceline2,
                     face_line_bytes);
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
                 noc_async_read(
                     indices_base_noc_addr + src_tile_offset + row_faceline2,
                     indices_dest_addr + row_faceline2,
@@ -273,21 +308,22 @@ FORCE_INLINE void generate_winning_group_tiles(uint32_t tokens_per_tile) {
         }
     }
 
-    noc_async_read_barrier();
+    noc.async_read_barrier();
 
-    cb_pop_front(cb_biased_scores, width_tiles);
-    cb_pop_front(cb_sorted_group_order, num_group_tiles);
+    cb_biased.pop_front(width_tiles);
+    cb_sorted_order.pop_front(num_group_tiles);
 
-    cb_push_back(cb_winning_group_scores, topk_groups);
-    cb_push_back(cb_winning_group_indices, topk_groups);
+    cb_winning_scores.push_back(topk_groups);
+    cb_winning_indices.push_back(topk_groups);
 }
 
 void write_single_scalar(const uint32_t cb_scalar, const uint32_t packed_scalar) {
-    cb_reserve_back(cb_scalar, 1);
-    uint32_t write_addr = get_write_ptr(cb_scalar);
+    CircularBuffer cb_scalar_buf(cb_scalar);
+    cb_scalar_buf.reserve_back(1);
+    uint32_t write_addr = cb_scalar_buf.get_write_ptr();
     tt_l1_ptr uint16_t* write_ptr = reinterpret_cast<tt_l1_ptr uint16_t*>(write_addr);
     write_ptr[0] = packed_scalar >> 16;
-    cb_push_back(cb_scalar, 1);
+    cb_scalar_buf.push_back(1);
 }
 
 template <
@@ -298,15 +334,18 @@ template <
     uint32_t n_activated_experts,
     uint32_t n_activated_expert_tiles>
 FORCE_INLINE void gather(uint32_t tokens_per_tile) {
-    cb_wait_front(cb_sigmoid_scores, width_tiles);
-    cb_wait_front(cb_out_indices, 1);
+    CircularBuffer cb_sigmoid(cb_sigmoid_scores);
+    CircularBuffer cb_indices(cb_out_indices);
+    CircularBuffer cb_gathered(cb_gathered_sigmoid);
+    cb_sigmoid.wait_front(width_tiles);
+    cb_indices.wait_front(1);
 
-    cb_reserve_back(cb_gathered_sigmoid, n_activated_expert_tiles);
+    cb_gathered.reserve_back(n_activated_expert_tiles);
 
     // Get base addresses
-    uint32_t sigmoid_base_addr = get_read_ptr(cb_sigmoid_scores);
-    uint32_t indices_addr = get_read_ptr(cb_out_indices);
-    uint32_t gathered_addr = get_write_ptr(cb_gathered_sigmoid);
+    uint32_t sigmoid_base_addr = cb_sigmoid.get_read_ptr();
+    uint32_t indices_addr = cb_indices.get_read_ptr();
+    uint32_t gathered_addr = cb_gathered.get_write_ptr();
 
     volatile tt_l1_ptr uint16_t* indices_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(indices_addr);
     volatile tt_l1_ptr uint16_t* sigmoid_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(sigmoid_base_addr);
@@ -352,9 +391,9 @@ FORCE_INLINE void gather(uint32_t tokens_per_tile) {
     }
 
     // Pop the sigmoid scores now that we're done gathering from them
-    cb_pop_front(cb_sigmoid_scores, width_tiles);
+    cb_sigmoid.pop_front(width_tiles);
 
-    cb_push_back(cb_gathered_sigmoid, n_activated_expert_tiles);
+    cb_gathered.push_back(n_activated_expert_tiles);
 }
 
 void kernel_main() {
@@ -393,6 +432,10 @@ void kernel_main() {
     constexpr uint32_t remainder_tokens_per_tile = get_named_compile_time_arg_val("remainder_tokens_per_tile");
     constexpr uint32_t cb_gathered_sigmoid = get_named_compile_time_arg_val("cb_gathered_sigmoid");
 
+    Noc noc;
+    CircularBuffer cb_out_indices_buf(cb_out_indices);
+    CircularBuffer cb_out_weights_buf(cb_out_weights);
+
     const uint32_t weights_addr = get_arg_val<uint32_t>(0);
     const uint32_t indices_addr = get_arg_val<uint32_t>(1);
     const uint32_t start_height_tile = get_arg_val<uint32_t>(2);
@@ -403,6 +446,9 @@ void kernel_main() {
 
     const auto weights_accessor = TensorAccessor(weights_args, weights_addr);
     const auto indices_accessor = TensorAccessor(indices_args, indices_addr);
+
+    const uint32_t weights_tile_bytes = get_tile_size(cb_out_weights);
+    const uint32_t indices_tile_bytes = get_tile_size(cb_out_indices);
 
     // while reader and compute kernels are applying the sigmoid, we can create the topk indices
     // I see no performance difference generating these internally inside the writer kernel
@@ -431,7 +477,7 @@ void kernel_main() {
             topk_groups,
             num_group_tiles>(tokens_per_tile);
 
-        cb_wait_front(cb_out_indices, 1);
+        cb_out_indices_buf.wait_front(1);
 
         // Gather unbiased sigmoid scores using the final expert indices
         gather<
@@ -442,12 +488,22 @@ void kernel_main() {
             n_activated_experts,
             n_activated_expert_tiles>(tokens_per_tile);
 
-        noc_async_write_page(height_tile, indices_accessor, get_read_ptr(cb_out_indices));
-        cb_wait_front(cb_out_weights, 1);
-        noc_async_write_page(height_tile, weights_accessor, get_read_ptr(cb_out_weights));
-        noc_async_writes_flushed();
-        cb_pop_front(cb_out_indices, 1);
-        cb_pop_front(cb_out_weights, 1);
+        noc.async_write(
+            CoreLocalMem<uint32_t>(cb_out_indices_buf.get_read_ptr()),
+            indices_accessor,
+            indices_tile_bytes,
+            {},
+            {.page_id = height_tile});
+        cb_out_weights_buf.wait_front(1);
+        noc.async_write(
+            CoreLocalMem<uint32_t>(cb_out_weights_buf.get_read_ptr()),
+            weights_accessor,
+            weights_tile_bytes,
+            {},
+            {.page_id = height_tile});
+        noc.async_writes_flushed();
+        cb_out_indices_buf.pop_front(1);
+        cb_out_weights_buf.pop_front(1);
     }
-    noc_async_write_barrier();
+    noc.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc/device/kernels/deepseek_moe_fast_reduce_nc_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc/device/kernels/deepseek_moe_fast_reduce_nc_reader.cpp
@@ -3,6 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 #include "ttnn/cpp/ttnn/kernel_lib/l1_helpers.hpp"
 
 constexpr uint32_t compute_input_cb_id_0 = get_compile_time_arg_val(0);
@@ -18,6 +22,11 @@ constexpr uint32_t reduction_num_tiles = get_compile_time_arg_val(8);
 constexpr uint32_t initial_ct_idx = 9;
 
 void kernel_main() {
+    Noc noc;
+
+    CircularBuffer cb_compute_input_0(compute_input_cb_id_0);
+    CircularBuffer cb_compute_input_1(compute_input_cb_id_1);
+
     uint32_t arg_idx = 0;
 
     uint32_t input_address = get_arg_val<uint32_t>(arg_idx++);
@@ -50,18 +59,19 @@ void kernel_main() {
         // 64+130, 64+260, 64+390, 128, 128+130, 128+260, and 128+390.
         for (uint32_t j = 0; j < reduction_dim_size; ++j) {
             if (input_granularity_index == 0) {
-                cb_reserve_back(compute_input_cb_id_0, input_granularity);
-                l1_write_addr = get_write_ptr(compute_input_cb_id_0);
+                cb_compute_input_0.reserve_back(input_granularity);
+                l1_write_addr = cb_compute_input_0.get_write_ptr();
             }
-            noc_async_read_page(read_tile_id, tensor_accessor, l1_write_addr);
+            noc.async_read(
+                tensor_accessor, CoreLocalMem<uint32_t>(l1_write_addr), page_size, {.page_id = read_tile_id}, {});
 
             l1_write_addr += page_size;
             read_tile_id += inner_num_tiles;
             input_granularity_index++;
 
             if (input_granularity_index == input_granularity) {
-                noc_async_read_barrier();
-                cb_push_back(compute_input_cb_id_0, input_granularity);
+                noc.async_read_barrier();
+                cb_compute_input_0.push_back(input_granularity);
                 input_granularity_index = 0;
             }
         }

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc/device/kernels/deepseek_moe_fast_reduce_nc_reduce.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc/device/kernels/deepseek_moe_fast_reduce_nc_reduce.cpp
@@ -4,6 +4,7 @@
 
 #include "api/compute/common.h"
 #include "api/compute/eltwise_binary.h"
+#include "api/dataflow/circular_buffer.h"
 
 constexpr uint32_t num_output_tiles_to_process = get_compile_time_arg_val(0);
 constexpr uint32_t reduction_dim_size = get_compile_time_arg_val(1);
@@ -18,12 +19,16 @@ void kernel_main() {
     constexpr uint32_t one_tile = 1;
     constexpr uint32_t first_tile = 0;
 
+    CircularBuffer cb_compute_input_0(compute_input_cb_id_0);
+    CircularBuffer cb_compute_input_1(compute_input_cb_id_1);
+    CircularBuffer cb_compute_output(compute_output_cb_id);
+
     binary_op_init_common(compute_input_cb_id_0, compute_input_cb_id_1, compute_output_cb_id);
 
     // For each assigned output tile, process the input tiles in a doubly nested loop.
     // The inner loop processes the number of tiles specified by input_granularity.
     // The outer loop executes reduction_dim_size / input_granularity times.
-    cb_wait_front(compute_input_cb_id_1, one_tile);
+    cb_compute_input_1.wait_front(one_tile);
     for (uint32_t i = 0; i < num_output_tiles_to_process; i++) {
         add_tiles_init(compute_input_cb_id_0, compute_input_cb_id_1, true);
         reconfig_data_format(compute_input_cb_id_0, compute_input_cb_id_1);
@@ -31,19 +36,19 @@ void kernel_main() {
 
         constexpr uint32_t num_input_tiles_iter = reduction_dim_size / input_granularity;
         for (uint32_t j = 0; j < num_input_tiles_iter; ++j) {
-            cb_wait_front(compute_input_cb_id_0, input_granularity);
+            cb_compute_input_0.wait_front(input_granularity);
             for (uint32_t k = 0; k < input_granularity; ++k) {
                 add_tiles(compute_input_cb_id_0, compute_input_cb_id_1, k, first_tile, dst0);
             }
-            cb_pop_front(compute_input_cb_id_0, input_granularity);
+            cb_compute_input_0.pop_front(input_granularity);
         }
 
         tile_regs_commit();
-        cb_reserve_back(compute_output_cb_id, one_tile);
+        cb_compute_output.reserve_back(one_tile);
         pack_reconfig_data_format(compute_output_cb_id);
         tile_regs_wait();
         pack_tile(dst0, compute_output_cb_id);
         tile_regs_release();
-        cb_push_back(compute_output_cb_id, one_tile);
+        cb_compute_output.push_back(one_tile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc/device/kernels/deepseek_moe_fast_reduce_nc_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc/device/kernels/deepseek_moe_fast_reduce_nc_writer.cpp
@@ -3,6 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 constexpr uint32_t compute_output_cb_id = get_compile_time_arg_val(0);
 constexpr uint32_t page_size = get_compile_time_arg_val(1);
@@ -14,6 +18,10 @@ constexpr uint32_t num_output_tensors = get_compile_time_arg_val(5);
 constexpr uint32_t initial_ct_idx = 6;
 
 void kernel_main() {
+    Noc noc;
+
+    CircularBuffer cb_compute_output(compute_output_cb_id);
+
     uint32_t arg_idx = 0;
 
     const uint32_t start_tiles_read = get_arg_val<uint32_t>(arg_idx++);
@@ -44,11 +52,12 @@ void kernel_main() {
         uint32_t normalized_page_id = slice_row_offset + intra_slice_offset;
         uint64_t noc_addr = output_slice_tensor_accessors[slice_id].get_noc_addr(normalized_page_id);
 
-        cb_wait_front(compute_output_cb_id, one_tile);
-        uint32_t l1_read_addr = get_read_ptr(compute_output_cb_id);
+        cb_compute_output.wait_front(one_tile);
+        uint32_t l1_read_addr = cb_compute_output.get_read_ptr();
+        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
         noc_async_write(l1_read_addr, noc_addr, page_size);
-        noc_async_writes_flushed();
-        cb_pop_front(compute_output_cb_id, one_tile);
+        noc.async_writes_flushed();
+        cb_compute_output.pop_front(one_tile);
 
         tiles_read += num_cores_to_be_used;
 
@@ -67,5 +76,5 @@ void kernel_main() {
             slice_row_offset += slice_Wt;
         }
     }
-    noc_async_write_barrier();
+    noc.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/kernels/deepseek_moe_fast_reduce_nc_fused_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/kernels/deepseek_moe_fast_reduce_nc_fused_compute.cpp
@@ -20,6 +20,7 @@
 // first MAC (expert 0) correctly seeds the accumulator.
 
 #include "api/compute/bcast.h"
+#include "api/dataflow/circular_buffer.h"
 
 using namespace ckernel;
 
@@ -31,6 +32,10 @@ constexpr uint32_t compute_input_cb_id_1 = get_compile_time_arg_val(4);
 constexpr uint32_t compute_output_cb_id = get_compile_time_arg_val(5);
 
 void kernel_main() {
+    CircularBuffer cb_in0(compute_input_cb_id_0);
+    CircularBuffer cb_in1(compute_input_cb_id_1);
+    CircularBuffer cb_out(compute_output_cb_id);
+
     constexpr uint32_t dst0 = 0;
     constexpr uint32_t one_tile = 1;
     constexpr uint32_t num_input_tiles_iter = reduction_dim_size / input_granularity;
@@ -48,12 +53,12 @@ void kernel_main() {
 
     // Wait for all score tiles — they are pre-loaded once by the reader prologue
     // and remain resident for the entire kernel invocation.
-    cb_wait_front(compute_input_cb_id_1, reduction_dim_size);
+    cb_in1.wait_front(reduction_dim_size);
     for (uint32_t i = 0; i < num_output_tiles; ++i) {
         tile_regs_acquire();
 
         for (uint32_t j = 0; j < num_input_tiles_iter; ++j) {
-            cb_wait_front(compute_input_cb_id_0, input_granularity);
+            cb_in0.wait_front(input_granularity);
 
             for (uint32_t k = 0; k < input_granularity; ++k) {
                 // expert_tile = linear expert index for this tile
@@ -61,18 +66,18 @@ void kernel_main() {
                 // dst0 += act_tile[k] * score_col[expert_tile]  (single MAC)
                 mul_tiles_bcast_cols(compute_input_cb_id_0, compute_input_cb_id_1, k, expert_tile, dst0);
             }
-            cb_pop_front(compute_input_cb_id_0, input_granularity);
+            cb_in0.pop_front(input_granularity);
         }
 
         tile_regs_commit();
-        cb_reserve_back(compute_output_cb_id, one_tile);
+        cb_out.reserve_back(one_tile);
         pack_reconfig_data_format(compute_output_cb_id);
         tile_regs_wait();
         pack_tile(dst0, compute_output_cb_id);
         tile_regs_release();
-        cb_push_back(compute_output_cb_id, one_tile);
+        cb_out.push_back(one_tile);
     }
 
     // Release all score tiles
-    cb_pop_front(compute_input_cb_id_1, reduction_dim_size);
+    cb_in1.pop_front(reduction_dim_size);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/kernels/deepseek_moe_fast_reduce_nc_fused_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/kernels/deepseek_moe_fast_reduce_nc_fused_reader.cpp
@@ -3,6 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 #include "api/debug/dprint_pages.h"
 
 // Compile-time args
@@ -49,6 +53,13 @@ constexpr uint32_t initial_ct_idx_expert_mapping =
     TensorAccessorArgs<initial_ct_idx_expert_indices>::next_compile_time_args_offset();
 
 void kernel_main() {
+    Noc noc;
+    CircularBuffer cb_in_act(cb_in_act_id);
+    CircularBuffer cb_scores(cb_scores_id);
+    CircularBuffer cb_scores_rm(cb_scores_rm_id);
+    CircularBuffer cb_expert_indices(cb_expert_indices_id);
+    CircularBuffer cb_expert_mapping(cb_expert_mapping_id);
+
     uint32_t arg_idx = 0;
     const uint32_t input_address = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t scores_address = get_arg_val<uint32_t>(arg_idx++);
@@ -83,20 +94,30 @@ void kernel_main() {
     // slot per DRAM page (host-side sizing in the program factory).
     ////////////////////////////////////////////////////////////////////////////
 
-    cb_reserve_back(cb_expert_indices_id, expert_indices_num_pages);
-    uint32_t expert_indices_ptr = get_write_ptr(cb_expert_indices_id);
+    cb_expert_indices.reserve_back(expert_indices_num_pages);
+    uint32_t expert_indices_ptr = cb_expert_indices.get_write_ptr();
     for (uint32_t p = 0; p < expert_indices_num_pages; ++p) {
-        noc_async_read_page(p, expert_indices_accessor, expert_indices_ptr + p * expert_indices_cb_page_size);
+        noc.async_read(
+            expert_indices_accessor,
+            CoreLocalMem<uint32_t>(expert_indices_ptr + p * expert_indices_cb_page_size),
+            expert_indices_page_size,
+            {.page_id = p},
+            {});
     }
 
-    cb_reserve_back(cb_expert_mapping_id, expert_mapping_num_pages);
-    uint32_t expert_mapping_ptr = get_write_ptr(cb_expert_mapping_id);
+    cb_expert_mapping.reserve_back(expert_mapping_num_pages);
+    uint32_t expert_mapping_ptr = cb_expert_mapping.get_write_ptr();
     for (uint32_t p = 0; p < expert_mapping_num_pages; ++p) {
-        noc_async_read_page(p, expert_mapping_accessor, expert_mapping_ptr + p * expert_mapping_cb_page_size);
+        noc.async_read(
+            expert_mapping_accessor,
+            CoreLocalMem<uint32_t>(expert_mapping_ptr + p * expert_mapping_cb_page_size),
+            expert_mapping_page_size,
+            {.page_id = p},
+            {});
     }
-    noc_async_read_barrier();
-    cb_push_back(cb_expert_indices_id, expert_indices_num_pages);
-    cb_push_back(cb_expert_mapping_id, expert_mapping_num_pages);
+    noc.async_read_barrier();
+    cb_expert_indices.push_back(expert_indices_num_pages);
+    cb_expert_mapping.push_back(expert_mapping_num_pages);
 
     ////////////////////////////////////////////////////////////////////////////
     // Prologue: Load all raw RM scores into scratch CB, then build
@@ -121,16 +142,21 @@ void kernel_main() {
     ////////////////////////////////////////////////////////////////////////////
 
     // Step 1: Read all token rows from DRAM into scratch staging buffer
-    cb_reserve_back(cb_scores_rm_id, num_tokens);
-    uint32_t scores_rm_ptr = get_write_ptr(cb_scores_rm_id);
+    cb_scores_rm.reserve_back(num_tokens);
+    uint32_t scores_rm_ptr = cb_scores_rm.get_write_ptr();
     for (uint32_t t = 0; t < num_tokens; ++t) {
-        noc_async_read_page(t, scores_accessor, scores_rm_ptr + t * cb_scores_rm_page_size);
+        noc.async_read(
+            scores_accessor,
+            CoreLocalMem<uint32_t>(scores_rm_ptr + t * cb_scores_rm_page_size),
+            scores_page_size,
+            {.page_id = t},
+            {});
     }
-    noc_async_read_barrier();
+    noc.async_read_barrier();
 
     // Step 2: Permute and to_layout scores; rm [token][expert] in uint16 units, row stride = reduction_dim_size
-    cb_reserve_back(cb_scores_id, reduction_dim_size);
-    uint32_t scores_write_ptr = get_write_ptr(cb_scores_id);
+    cb_scores.reserve_back(reduction_dim_size);
+    uint32_t scores_write_ptr = cb_scores.get_write_ptr();
 
     volatile tt_l1_ptr uint16_t* scores_rm_u16 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(scores_rm_ptr);
     volatile tt_l1_ptr uint16_t* scores_tile_u16 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(scores_write_ptr);
@@ -223,8 +249,8 @@ void kernel_main() {
     }
 
     // Step 3: Release scores to compute kernel
-    cb_push_back(cb_scores_id, reduction_dim_size);
-    cb_push_back(cb_scores_rm_id, num_tokens);
+    cb_scores.push_back(reduction_dim_size);
+    cb_scores_rm.push_back(num_tokens);
 
     ////////////////////////////////////////////////////////////////////////////
     // Main loop: stream activation tiles into cb_in_act (same as original op)
@@ -248,18 +274,19 @@ void kernel_main() {
         // 64+130, 64+260, 64+390, 128, 128+130, 128+260, and 128+390.
         for (uint32_t j = 0; j < reduction_dim_size; ++j) {
             if (input_granularity_index == 0) {
-                cb_reserve_back(cb_in_act_id, input_granularity);
-                l1_write_addr = get_write_ptr(cb_in_act_id);
+                cb_in_act.reserve_back(input_granularity);
+                l1_write_addr = cb_in_act.get_write_ptr();
             }
-            noc_async_read_page(read_tile_id, act_accessor, l1_write_addr);
+            noc.async_read(
+                act_accessor, CoreLocalMem<uint32_t>(l1_write_addr), act_page_size, {.page_id = read_tile_id}, {});
 
             l1_write_addr += act_page_size;
             read_tile_id += inner_num_tiles;
             input_granularity_index++;
 
             if (input_granularity_index == input_granularity) {
-                noc_async_read_barrier();
-                cb_push_back(cb_in_act_id, input_granularity);
+                noc.async_read_barrier();
+                cb_in_act.push_back(input_granularity);
                 input_granularity_index = 0;
             }
         }

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/kernels/common.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "api/dataflow/circular_buffer.h"
+
 constexpr uint32_t ONE_TILE{1};
 constexpr uint32_t FIRST_TILE{0};
 constexpr uint32_t WORKING_REG{0};
@@ -77,8 +79,8 @@ class ReadCBGuard {
     uint32_t tiles;
 
 public:
-    ReadCBGuard(uint32_t cb, uint32_t tiles) : cb{cb}, tiles{tiles} { cb_wait_front(cb, tiles); }
-    ~ReadCBGuard() { cb_pop_front(cb, tiles); }
+    ReadCBGuard(uint32_t cb, uint32_t tiles) : cb{cb}, tiles{tiles} { CircularBuffer(cb).wait_front(tiles); }
+    ~ReadCBGuard() { CircularBuffer(cb).pop_front(tiles); }
 
     ReadCBGuard(const ReadCBGuard&) = delete;  // can not allow to touch the object anyhow
     ReadCBGuard(ReadCBGuard&&) = delete;
@@ -117,8 +119,8 @@ class WriteCBGuard {
     uint32_t tiles;
 
 public:
-    WriteCBGuard(uint32_t cb, uint32_t tiles) : cb{cb}, tiles{tiles} { cb_reserve_back(cb, tiles); }
-    ~WriteCBGuard() { cb_push_back(cb, tiles); }
+    WriteCBGuard(uint32_t cb, uint32_t tiles) : cb{cb}, tiles{tiles} { CircularBuffer(cb).reserve_back(tiles); }
+    ~WriteCBGuard() { CircularBuffer(cb).push_back(tiles); }
 
     WriteCBGuard(const WriteCBGuard&) = delete;  // can not allow to touch the object anyhow
     WriteCBGuard(WriteCBGuard&&) = delete;

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/kernels/intimg_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/kernels/intimg_compute.cpp
@@ -22,6 +22,8 @@
 
 #include "api/compute/bcast.h"
 
+#include "api/dataflow/circular_buffer.h"
+
 #include "common.hpp"
 
 namespace {
@@ -80,6 +82,8 @@ FORCE_INLINE void cumsum_cube_axis_2(
     uint32_t cb_axis_2_buffer,
     bool save_last_tile,
     uint32_t block_depth) {
+    CircularBuffer input_cb(cb_input);
+    CircularBuffer acc_cb(cb_acc);
     ReadCBGuard start_cb_read_guard{cb_start, ONE_TILE};
 
     bool enable_reload = false;
@@ -89,29 +93,29 @@ FORCE_INLINE void cumsum_cube_axis_2(
         WriteCBGuard cumsum_stage_cb_write_guard{cb_cumsum_stage_0, ONE_TILE};
         tile_regs_acquire();
         const uint32_t cb_op = enable_reload ? cb_acc : cb_start;
-        cb_wait_front(cb_input, ONE_TILE);
+        input_cb.wait_front(ONE_TILE);
 
         add_tiles_init(cb_input, cb_op);
         add_tiles(cb_input, cb_op, FIRST_TILE, FIRST_TILE, WORKING_REG);
 
-        cb_pop_front(cb_input, ONE_TILE);
+        input_cb.pop_front(ONE_TILE);
         if (enable_reload) {
-            cb_pop_front(cb_acc, ONE_TILE);
+            acc_cb.pop_front(ONE_TILE);
         }
 
         tile_regs_commit();
         tile_regs_wait();
 
-        cb_reserve_back(cb_acc, ONE_TILE);
+        acc_cb.reserve_back(ONE_TILE);
         pack_reconfig_data_format(cb_acc);
         pack_tile(WORKING_REG, cb_acc);
-        cb_push_back(cb_acc, ONE_TILE);
+        acc_cb.push_back(ONE_TILE);
 
         tile_regs_release();
 
         tile_regs_acquire();
 
-        cb_wait_front(cb_acc, ONE_TILE);
+        acc_cb.wait_front(ONE_TILE);
         copy_tile_init(cb_acc);
         copy_tile(cb_acc, FIRST_TILE, WORKING_REG);
 
@@ -132,7 +136,7 @@ FORCE_INLINE void cumsum_cube_axis_2(
         enable_reload = true;
     }
 
-    cb_pop_front(cb_acc, ONE_TILE);
+    acc_cb.pop_front(ONE_TILE);
 }
 
 FORCE_INLINE void cumsum_cube_axis_3(uint32_t cb_cumsum_stage_wip, uint32_t cb_cumsum_output, uint32_t block_depth) {
@@ -162,7 +166,8 @@ FORCE_INLINE void propagate_tile_into_cube(
     uint32_t cb_cumsum_stage_b,
     bool save_last_tile,
     uint32_t block_depth) {
-    cb_wait_front(cb_axis_2_buffer, ONE_TILE);
+    CircularBuffer axis_2_buffer_cb(cb_axis_2_buffer);
+    axis_2_buffer_cb.wait_front(ONE_TILE);
     for (uint32_t tile_i = 0; tile_i < block_depth; ++tile_i) {
         ReadCBGuard cb_cumsum_stage_0_guard{cb_cumsum_stage_a, ONE_TILE};
         WriteCBGuard cb_cumsum_stage_1_guard{cb_cumsum_stage_b, ONE_TILE};
@@ -179,7 +184,7 @@ FORCE_INLINE void propagate_tile_into_cube(
         if ((tile_i == block_depth - 1)) {  // when last tile in block gets propagated on, finally release the axis 2
                                             // buffer CB and save last tile only when there's a specific request. it
                                             // must be released to get ready for the processing of the next row chunk.
-            cb_pop_front(cb_axis_2_buffer, ONE_TILE);
+            axis_2_buffer_cb.pop_front(ONE_TILE);
             if (save_last_tile) {
                 WriteCBGuard axis_2_buffer_cb_guard{cb_axis_2_buffer, ONE_TILE};
                 pack_reconfig_data_format(cb_axis_2_buffer);


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

Contributes to #45003. Migrates the `experimental/reduction/` kernels onto the Device 2.0 kernel API (dataflow + compute):
- `deepseek_grouped_gate` (3 files: 1 compute + 2 dataflow)
- `deepseek_moe_fast_reduce_nc` (3 files: 1 compute + 2 dataflow, flat layout)
- `deepseek_moe_fast_reduce_nc_fused` (2 files: 1 compute + 1 dataflow, flat layout)
- `integral_image` (2 files: `common.hpp` header + `intimg_compute.cpp`)

### Notes for reviewers

Total: 10 files, +338/-172.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/experimental-d2-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/experimental-d2-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/experimental-d2-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/experimental-d2-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/experimental-d2-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/experimental-d2-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/experimental-d2-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/experimental-d2-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/experimental-d2-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/experimental-d2-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/experimental-d2-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/experimental-d2-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/experimental-d2-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/experimental-d2-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/experimental-d2-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/experimental-d2-reduction)
