### PR TITLE
ULP validation for scalar MSE/L1 loss checks in test_losses

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/test_losses.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/test_losses.py
@@ -8,7 +8,7 @@ import torch
 import torch.nn as nn
 import ttnn
 
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp
 
 
 @pytest.mark.parametrize(
@@ -47,7 +47,11 @@ def test_mse_loss(device, input_shapes, loss_mode):
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+    if loss_mode[0] in ("mean", "sum"):
+        # Reduced losses are scalars; PCC is undefined on constant tensors.
+        assert_with_ulp(torch_output_tensor, output_tensor, ulp_threshold=3)
+    else:
+        assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
 
 
 @pytest.mark.parametrize(
@@ -86,4 +90,8 @@ def test_l1_loss(device, input_shapes, loss_mode):
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+    if loss_mode[0] in ("mean", "sum"):
+        # Reduced losses are scalars; PCC is undefined on constant tensors.
+        assert_with_ulp(torch_output_tensor, output_tensor, ulp_threshold=3)
+    else:
+        assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-metal/issues/47585

### Summary

`test_mse_loss` and `test_l1_loss` used `assert_with_pcc` for all reduction modes. That is the wrong check for **mean** and **sum**:

- **Reduced output is a scalar** — mean/sum return a single 0-D value, not a tensor of per-element losses.
- **Golden is fp32, device path is bf16** — e.g. golden `1.9718` vs device `1.9688`; small rounding gap is expected.
- **Single-element PCC behaves like exact equality** — with one value, PCC is undefined (constant tensor / zero std dev). Stricter `comp_pcc` handling falls back to tight `allclose`, which rejects normal bf16 vs fp32 scalar differences.

This PR uses:
- **`assert_with_ulp(ulp_threshold=3)`** for `mean` and `sum` (scalar bf16 vs fp32 golden)
- **`assert_with_pcc(0.9999)`** for `none` (full tensor — many elements, PCC is meaningful)

### Pipeline status

- [x] Sanity
- [x] (Runtime) Sanity Test
- [x] BHPC
- [x] Nightly for eltwise category

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/fix_loss_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/fix_loss_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/fix_loss_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/fix_loss_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=virdhatchani/fix_loss_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:virdhatchani/fix_loss_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/fix_loss_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/fix_loss_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/fix_loss_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/fix_loss_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/fix_loss_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/fix_loss_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/fix_loss_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/fix_loss_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/fix_loss_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/fix_loss_test)