### PR TITLE
[skip ci] ci-digest: fix schedule gating + consume ai_run_summary JSON

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -42,7 +42,7 @@ Scripts that collect CI/CD metrics and benchmark data for upload to the analytic
 
 | Script | Description |
 |--------|-------------|
-| `ci_digest.py` | One named CI digest. Reports each watched workflow's latest completed scheduled run (real/infra/passing job counts + a collapsible failed-jobs table from `ai_job_summary_*` artifacts) to the step summary + an artifact. Stateless; self-gates on the digest's cron via `--schedule`. Driven by `.github/workflows/ci-digest.yaml`. Usage: `ci_digest.py --name <digest> --workflows <foo.yaml …> [--schedule "0 8 * * *"] [--force]`. Tests: `ci_digest.py --self-test`. |
+| `ci_digest.py` | One named CI digest. For each watched workflow, reads the latest completed scheduled run's `ai_run_summary_<run_id>` JSON artifact (succeeded / failed / infra_failure, produced by the `ai_summary/run` action) and renders a consolidated report — per-workflow health bar, counts, and a collapsible failed-jobs table — to the step summary + an artifact; falls back to the run conclusion when no JSON is present. Stateless; scheduling/gating lives in the workflow (`github.event.schedule`). Driven by `.github/workflows/ci-digest.yaml`. Usage: `ci_digest.py --name <digest> --workflows <foo.yaml …>`. Tests: `ci_digest.py --self-test`. |
 
 ## Test & CI Utilities (`utils/`)
 

--- a/.github/scripts/ci_digest.py
+++ b/.github/scripts/ci_digest.py
@@ -99,9 +99,14 @@ def summarize_run(data: dict) -> tuple[str, list[dict], list[dict], int]:
     return outcome, failed, infra, passing
 
 
-def _sev_emoji(status: str | None) -> str:
-    # infra (🟣) vs every other non-green status (🔴). SUCCESS never reaches here.
-    return "🟣" if status == "INFRA_FAILURE" else "🔴"
+def _sev_emoji(row: dict) -> str:
+    # 🟣 infra; ⌛️ a failure whose log was truncated/killed (log_complete is
+    # False — i.e. it timed out); 🔴 every other non-green status.
+    if row.get("status") == "INFRA_FAILURE":
+        return "🟣"
+    if row.get("log_complete") is False:
+        return "⌛️"
+    return "🔴"
 
 
 def _job_link(row: dict) -> str:
@@ -168,7 +173,7 @@ def _section(r: dict) -> list[str]:
     jobs = (r.get("real_jobs") or []) + (r.get("infra_jobs") or [])
     if jobs:
         rows = [
-            f"| {_sev_emoji(j.get('status'))} | {_job_link(j)} | {j.get('status') or '—'} | {_cat_cell(j)} | {_error_cell(j)} |"
+            f"| {_sev_emoji(j)} | {_job_link(j)} | {j.get('status') or '—'} | {_cat_cell(j)} | {_error_cell(j)} |"
             for j in jobs
         ]
         # Blank lines around the table are required for GFM to render it inside <details>.
@@ -424,6 +429,21 @@ class TestErrorCell(unittest.TestCase):
 
     def test_truncation(self):
         self.assertTrue(_error_cell({"error_message": "x" * 250}).endswith("…"))
+
+
+class TestSevEmoji(unittest.TestCase):
+    def test_infra(self):
+        self.assertEqual(_sev_emoji({"status": "INFRA_FAILURE"}), "🟣")
+
+    def test_incomplete_log_is_hourglass(self):
+        # log_complete is False → truncated/killed (timed out): ⌛️ instead of 🔴.
+        self.assertEqual(_sev_emoji({"status": "FAILED", "log_complete": False}), "⌛️")
+        self.assertEqual(_sev_emoji({"status": "TIMEOUT", "log_complete": False}), "⌛️")
+
+    def test_complete_or_unknown_log_is_red(self):
+        self.assertEqual(_sev_emoji({"status": "FAILED", "log_complete": True}), "🔴")
+        self.assertEqual(_sev_emoji({"status": "CRASHED"}), "🔴")  # absent (None) → 🔴
+        self.assertEqual(_sev_emoji({"status": "FAILED", "log_complete": None}), "🔴")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/ci_digest.py
+++ b/.github/scripts/ci_digest.py
@@ -3,9 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 """CI digest: report the current state of watched workflows.
 
-Stateless by design — each run reports the latest completed run of each watched
-workflow and the jobs that failed, split into real (🔴) vs infra (🟣) issues.
-No history, no incident tracking: "since when" is deliberately out of scope.
+Thin aggregator. For each watched workflow it finds the latest completed
+scheduled run and reads that run's machine-readable ``ai_run_summary_<run_id>``
+artifact — a factual JSON the ai_summary/run action already produces (succeeded
+/ failed / infra_failure jobs). The digest does no classification of its own; it
+collects those per-run summaries and renders them at one point so a team can
+react. Stateless by design — no history, no incident tracking.
 """
 from __future__ import annotations
 
@@ -18,75 +21,6 @@ import sys
 import tempfile
 import unittest
 from datetime import datetime, timezone
-
-
-def _status(j: dict) -> str | None:
-    return (j.get("_job") or {}).get("status_code")
-
-
-def derive_outcome(latest_run: dict, job_summaries: list[dict]) -> tuple[str, list[dict]]:
-    """Classify a run as GREEN / REAL_FAIL / INFRA.
-
-    Returns (outcome, non_green_jobs). A non-green job is infra only when its
-    status_code is explicitly PURPLE; anything else non-green (including an
-    unknown/missing status) is a real failure, not hidden as infra. Without any
-    job summaries we cannot prove infra, so we report REAL_FAIL.
-    """
-    if latest_run.get("conclusion") == "success":
-        return "GREEN", []
-    if not job_summaries:
-        return "REAL_FAIL", []
-    non_green = [j for j in job_summaries if _status(j) != "GREEN"]
-    if any(_status(j) != "PURPLE" for j in non_green):
-        return "REAL_FAIL", non_green
-    if non_green:
-        return "INFRA", non_green
-    return "REAL_FAIL", []
-
-
-def _cron_field(field: str, value: int, lo: int, hi: int) -> bool:
-    """True if `value` matches cron `field` (`*`, `a`, `a-b`, lists, `*/n`);
-    `lo`/`hi` are the wildcard expansion bounds."""
-    for part in field.split(","):
-        step = 1
-        if "/" in part:
-            part, s = part.split("/", 1)
-            step = int(s)
-        if part in ("*", ""):
-            start, end = lo, hi
-        elif "-" in part:
-            a, b = part.split("-", 1)
-            start, end = int(a), int(b)
-        else:
-            start = end = int(part)
-        if start <= value <= end and (value - start) % step == 0:
-            return True
-    return False
-
-
-def due(schedule: str | None, now: datetime) -> bool:
-    """Is a subscription with this 5-field cron due at `now`?
-
-    The minute field is ignored — the job fires hourly and may land any minute
-    in the slot's hour — so it must be 0 or * (a stray minute would silently
-    mislead). No schedule = always due.
-    """
-    if not schedule:
-        return True
-    fields = schedule.split()
-    if len(fields) != 5:
-        raise ValueError(f"cron needs 5 fields: {schedule!r}")
-    minute, hour, dom, mon, dow = fields
-    if minute not in ("0", "*"):
-        raise ValueError(f"minute must be 0 or * (the job fires hourly): {schedule!r}")
-    if not _cron_field(hour, now.hour, 0, 23) or not _cron_field(mon, now.month, 1, 12):
-        return False
-    cron_dow = (now.weekday() + 1) % 7  # cron: 0=Sun..6=Sat (7 also Sun)
-    dow_ok = _cron_field(dow, cron_dow, 0, 7) or (cron_dow == 0 and _cron_field(dow, 7, 0, 7))
-    dom_ok = _cron_field(dom, now.day, 1, 31)
-    if dom.strip() != "*" and dow.strip() != "*":  # vixie-cron: either matches
-        return dom_ok or dow_ok
-    return dom_ok and dow_ok
 
 
 def _gh_json(args: list[str]) -> object:
@@ -124,88 +58,68 @@ def latest_run(repo: str, workflow: str, branch: str) -> dict | None:
     return runs[0] if runs else None
 
 
-def fetch_job_summaries(repo: str, run_id: int) -> list[dict]:
-    """Download every ai_job_summary_* artifact of a run and parse the JSONs.
+def fetch_run_summary(repo: str, run_id: int) -> dict | None:
+    """Download a run's ``ai_run_summary_<run_id>`` artifact and parse its JSON.
 
-    Returns [] when none exist (older/uninstrumented runs) — the caller treats
-    that as undetermined-real via derive_outcome.
+    The ai_summary/run action uploads ``ai_run_summary_<run_id>.json`` (the
+    factual, deterministic run report: succeeded / failed / infra_failure) inside
+    that artifact. Returns None when the artifact is absent — the workflow doesn't
+    run ai_summary/run, or the run predates JSON output — so the caller can fall
+    back to the run's conclusion.
     """
-    # --jq streams names per page; avoids json.loads choking on multi-page
-    # concatenated objects when a run has >100 artifacts.
-    out = subprocess.run(
-        [
-            "gh",
-            "api",
-            "--paginate",
-            f"repos/{repo}/actions/runs/{run_id}/artifacts?per_page=100",
-            "--jq",
-            ".artifacts[].name",
-        ],
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout
-    names = [n for n in out.splitlines() if n.startswith("ai_job_summary_")]
-    if not names:
-        return []
-    summaries: list[dict] = []
+    name = f"ai_run_summary_{run_id}"
     with tempfile.TemporaryDirectory() as d:
-        cmd = ["gh", "run", "download", str(run_id), "-R", repo, "-D", d]
-        for n in names:
-            cmd += ["-n", n]
-        subprocess.run(cmd, check=True, capture_output=True, text=True)
-        for path in _glob.glob(os.path.join(d, "**", "ai_job_summary_*.json"), recursive=True):
-            with open(path, encoding="utf-8") as f:
-                summaries.append(json.load(f))
-    return summaries
+        try:
+            subprocess.run(
+                ["gh", "run", "download", str(run_id), "-R", repo, "-n", name, "-D", d],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError:
+            return None  # no such artifact on this run
+        matches = _glob.glob(os.path.join(d, "**", f"{name}.json"), recursive=True)
+        if not matches:
+            return None  # artifact present but .md-only (run predates JSON output)
+        with open(matches[0], encoding="utf-8") as f:
+            return json.load(f)
 
 
-def ai_summary_step_url(repo: str, job: dict) -> str:
-    """Deep-link to the job's '🤖 AI job summary' step; the 'Post …' teardown
-    step shares the name and must be excluded. Falls back to the job page."""
-    url = job.get("url", "")
-    if "/job/" not in url:
-        return url
-    job_id = url.rsplit("/job/", 1)[1].split("#")[0].split("/")[0]
-    jq = '[.steps[] | select((.name | test("ai job summary"; "i")) and (.name | startswith("Post") | not))][0].number // empty'
-    try:
-        n = subprocess.run(
-            ["gh", "api", f"repos/{repo}/actions/jobs/{job_id}", "--jq", jq],
-            capture_output=True,
-            text=True,
-            check=True,
-        ).stdout.strip()
-    except subprocess.CalledProcessError:
-        return url
-    return f"{url}#step:{n}:1" if n else url
+def summarize_run(data: dict) -> tuple[str, list[dict], list[dict], int]:
+    """Map a run-summary JSON into (outcome, failed_rows, infra_rows, passing).
+
+    A run is REAL_FAIL if it has any real failure, else INFRA if it has any infra
+    failure, else GREEN. failed/infra rows are passed through verbatim — they
+    already carry job_name, job_url, status, category, error_message, root_cause.
+    """
+    failed = data.get("failed") or []
+    infra = data.get("infra_failure") or []
+    passing = len(data.get("succeeded") or [])
+    outcome = "REAL_FAIL" if failed else "INFRA" if infra else "GREEN"
+    return outcome, failed, infra, passing
 
 
-def _sev_emoji(code: str | None) -> str:
-    # Two signals only: infra (PURPLE) vs real (every other non-green code).
-    return "🟣" if code == "PURPLE" else "🔴"
+def _sev_emoji(status: str | None) -> str:
+    # infra (🟣) vs every other non-green status (🔴). SUCCESS never reaches here.
+    return "🟣" if status == "INFRA_FAILURE" else "🔴"
 
 
-def _job_cell(j: dict) -> tuple[str, str, str]:
-    """(linked job name, category cell, test-count cell)."""
-    job = j.get("_job") or {}
-    link = job.get("summary_url") or job.get("url")
-    nm = job.get("name", "?")
-    name = f"[{nm}]({link})" if link else nm
-    # Non-breaking hyphen so "tt-metal:*" isn't wrapped across lines in the
-    # narrow Category column (markdown gives no column-width control).
-    cat = (j.get("category") or "").replace("-", "‑")
-    cat_cell = f"`{cat}`" if cat else "—"
-    n = len(j.get("failed_tests") or [])
-    return name, cat_cell, (str(n) if n else "—")
+def _job_link(row: dict) -> str:
+    nm = row.get("job_name") or "?"
+    url = row.get("job_url") or ""
+    return f"[{nm}]({url})" if url else nm
 
 
-def _error_cell(j: dict) -> str:
-    # When the upstream LLM summary was unparseable, root_cause holds the parse
-    # marker and error_message holds the raw broken blob — neither is usable.
-    if (j.get("root_cause") or "").startswith("Failed to parse LLM response"):
-        return "_(AI summary unavailable)_"
-    em = (j.get("error_message") or "").strip().replace("\n", " ").replace("|", "\\|")
-    return em or "—"
+def _cat_cell(row: dict) -> str:
+    # Non-breaking hyphen so "infra:no-artifact" / "tt-metal:*" isn't wrapped in
+    # the narrow Category column (markdown gives no column-width control).
+    cat = (row.get("category") or "").replace("-", "‑")
+    return f"`{cat}`" if cat else "—"
+
+
+def _error_cell(row: dict) -> str:
+    msg = (row.get("error_message") or row.get("root_cause") or "").strip().replace("\n", " ").replace("|", "\\|")
+    return (msg[:200] + "…") if len(msg) > 200 else (msg or "—")
 
 
 def all_green(results: list[dict]) -> bool:
@@ -233,33 +147,42 @@ def _link(r: dict) -> str:
 
 
 def _section(r: dict) -> list[str]:
-    jobs = (r.get("real_jobs") or []) + (r.get("infra_jobs") or [])
+    """One section per workflow — same shape for green and broken: name, health
+    bar, and the 🔴/🟣/🟢 + date line. Broken/infra runs add a collapsible
+    failed-jobs table; a green run stops at the counts line (it's enough to see
+    it's green)."""
     when = f" · {_fmt_ts(r['latest_ts'])} UTC" if r.get("latest_ts") else ""
     out = [f"### {_link(r)}"]
-    if not jobs:  # failed run with no AI job summaries (uninstrumented or expired artifacts)
-        out += [f"🔴 run failed — no AI job summaries available{when}", ""]
-        return out
     c = r.get("counts") or {}
-    bar = _health_bar(c)
-    if bar:
-        out.append(bar)
-    out.append(f"🔴 {c.get('broken', 0)} · 🟣 {c.get('infra', 0)} · 🟢 {c.get('passing', 0)}{when}")
-    rows = []
-    for j in jobs:
-        jl, cat_cell, tests = _job_cell(j)
-        rows.append(f"| {_sev_emoji(_status(j))} | {jl} | {cat_cell} | {tests} | {_error_cell(j)} |")
-    # Blank lines around the table are required for GFM to render it inside <details>.
-    out += [
-        "",
-        "<details><summary>Failed jobs</summary>",
-        "",
-        "| | Job | Category | Tests | Error |",
-        "|--|--|--|--|--|",
-        *rows,
-        "",
-        "</details>",
-        "",
-    ]
+    total = c.get("broken", 0) + c.get("infra", 0) + c.get("passing", 0)
+    if total:
+        bar = _health_bar(c)
+        if bar:
+            out.append(bar)
+        out.append(f"🔴 {c.get('broken', 0)} · 🟣 {c.get('infra', 0)} · 🟢 {c.get('passing', 0)}{when}")
+    elif r.get("outcome") == "GREEN":
+        # Green via the run-conclusion fallback (no per-job counts available).
+        out.append(f"🟢 green{when}")
+    else:
+        out.append(f"🔴 run not green — no per-job detail in the run summary{when}")
+    jobs = (r.get("real_jobs") or []) + (r.get("infra_jobs") or [])
+    if jobs:
+        rows = [
+            f"| {_sev_emoji(j.get('status'))} | {_job_link(j)} | {j.get('status') or '—'} | {_cat_cell(j)} | {_error_cell(j)} |"
+            for j in jobs
+        ]
+        # Blank lines around the table are required for GFM to render it inside <details>.
+        out += [
+            "",
+            "<details><summary>Failed jobs</summary>",
+            "",
+            "| | Job | Status | Category | Error |",
+            "|--|--|--|--|--|",
+            *rows,
+            "",
+            "</details>",
+        ]
+    out.append("")
     return out
 
 
@@ -270,10 +193,8 @@ def render_markdown(name: str, results: list[dict]) -> str:
     nodata = [r for r in results if r["outcome"] in ("UNKNOWN", "ERROR")]
 
     lines = [f"## CI Digest: {name}", "", "Legend: 🔴 broken · 🟣 infra · 🟢 success", ""]
-    for r in broken + infra:
+    for r in broken + infra + healthy:  # failures first, then green — same section shape
         lines += _section(r)
-    if healthy:
-        lines += ["**🟢 Passing:** " + ", ".join(_link(r) for r in healthy), ""]
     if nodata:
         lines += [
             "**⚠️ No data:** " + ", ".join(f"{_link(r)} ({r.get('note') or r['outcome'].lower()})" for r in nodata),
@@ -287,8 +208,6 @@ def build_arg_parser() -> argparse.ArgumentParser:
     p.add_argument("--self-test", action="store_true", help="run embedded unit tests and exit")
     p.add_argument("--name", help="name of this digest")
     p.add_argument("--workflows", nargs="+", default=[], help="workflow file names to check")
-    p.add_argument("--schedule", help="5-field cron; skipped unless due this hour (default: always)")
-    p.add_argument("--force", action="store_true", help="ignore --schedule and run now (manual dispatch)")
     p.add_argument("--branch", default="main")
     p.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", "tenstorrent/tt-metal"))
     p.add_argument("--out-dir", default=".")
@@ -301,24 +220,24 @@ def check_workflow(repo: str, branch: str, workflow: str) -> dict:
         run = latest_run(repo, workflow, branch)
         if run is None:  # never ran / renamed / typo'd — not the same as "passing"
             return {**base, "outcome": "UNKNOWN", "note": "no completed run found"}
-        summaries = fetch_job_summaries(repo, run["databaseId"]) if run["conclusion"] != "success" else []
-        outcome, non_green = derive_outcome(run, summaries)
-        real_jobs = [j for j in non_green if _status(j) != "PURPLE"]
-        infra_jobs = [j for j in non_green if _status(j) == "PURPLE"]
-        passing = sum(1 for j in summaries if _status(j) == "GREEN")
-        for j in real_jobs + infra_jobs:
-            jb = j.get("_job")
-            if jb and jb.get("url"):
-                jb["summary_url"] = ai_summary_step_url(repo, jb)
+        label = run.get("workflowName") or workflow
+        meta = {"label": label, "latest_url": run["url"], "latest_ts": run["createdAt"]}
+        data = fetch_run_summary(repo, run["databaseId"])
+        if data is None:
+            # No machine-readable summary. Fall back to the run conclusion: a green
+            # run is healthy; a non-green one we can't detail (workflow doesn't run
+            # ai_summary/run, or the run predates JSON output).
+            if run.get("conclusion") == "success":
+                return {**base, **meta, "outcome": "GREEN"}
+            return {**base, **meta, "outcome": "UNKNOWN", "note": "no ai_run_summary artifact"}
+        outcome, failed, infra, passing = summarize_run(data)
         return {
             **base,
-            "label": run.get("workflowName") or workflow,
+            **meta,
             "outcome": outcome,
-            "latest_url": run["url"],
-            "latest_ts": run["createdAt"],
-            "real_jobs": real_jobs,
-            "infra_jobs": infra_jobs,
-            "counts": {"broken": len(real_jobs), "infra": len(infra_jobs), "passing": passing},
+            "real_jobs": failed,
+            "infra_jobs": infra,
+            "counts": {"broken": len(failed), "infra": len(infra), "passing": passing},
         }
     except subprocess.CalledProcessError as exc:
         # One flaky gh call must not discard the other workflows' results.
@@ -338,9 +257,6 @@ def main(argv: list[str]) -> int:
         raise SystemExit("no --name provided")
 
     now = datetime.now(timezone.utc)
-    if not args.force and not due(args.schedule, now):  # not this digest's slot
-        return 0
-
     results = [check_workflow(args.repo, args.branch, wf) for wf in args.workflows]
     md = render_markdown(args.name, results)
     os.makedirs(args.out_dir, exist_ok=True)
@@ -357,73 +273,22 @@ def main(argv: list[str]) -> int:
 # --- embedded tests (run via --self-test) ---------------------------------
 
 
-class TestDeriveOutcome(unittest.TestCase):
-    def _job(self, code):
-        return {"_job": {"status_code": code, "name": "j", "url": "u"}}
+class TestSummarizeRun(unittest.TestCase):
+    def test_real_fail_when_any_failure(self):
+        out, failed, infra, passing = summarize_run(
+            {"failed": [{"job_name": "a"}], "infra_failure": [{"job_name": "b"}], "succeeded": [{}, {}]}
+        )
+        self.assertEqual((out, len(failed), len(infra), passing), ("REAL_FAIL", 1, 1, 2))
 
-    def test_green_when_conclusion_success(self):
-        self.assertEqual(derive_outcome({"conclusion": "success"}, []), ("GREEN", []))
+    def test_infra_when_only_infra(self):
+        out, _, infra, passing = summarize_run({"infra_failure": [{"job_name": "b"}], "succeeded": [{}]})
+        self.assertEqual((out, len(infra), passing), ("INFRA", 1, 1))
 
-    def test_real_fail_when_any_non_purple(self):
-        out, jobs = derive_outcome({"conclusion": "failure"}, [self._job("PURPLE"), self._job("ORANGE")])
-        self.assertEqual(out, "REAL_FAIL")
-        self.assertEqual(len(jobs), 2)
+    def test_green_when_only_success(self):
+        self.assertEqual(summarize_run({"succeeded": [{}, {}, {}]}), ("GREEN", [], [], 3))
 
-    def test_infra_when_all_non_green_are_purple(self):
-        out, jobs = derive_outcome({"conclusion": "failure"}, [self._job("PURPLE"), self._job("GREEN")])
-        self.assertEqual(out, "INFRA")
-        self.assertEqual(len(jobs), 1)
-
-    def test_no_summaries_is_conservative_real(self):
-        self.assertEqual(derive_outcome({"conclusion": "failure"}, [])[0], "REAL_FAIL")
-
-    def test_unknown_status_is_real_not_infra(self):
-        self.assertEqual(derive_outcome({"conclusion": "failure"}, [self._job(None)])[0], "REAL_FAIL")
-
-    def test_malformed_summaries_do_not_crash(self):
-        self.assertEqual(derive_outcome({"conclusion": "failure"}, [{}, {"_job": {}}])[0], "REAL_FAIL")
-
-
-class TestDue(unittest.TestCase):
-    MON_8 = datetime(2024, 1, 1, 8, 30)  # 2024-01-01 is a Monday; :30 proves minute-agnostic
-    SUN_8 = datetime(2024, 1, 7, 8, 0)
-
-    def test_no_schedule_always_due(self):
-        self.assertTrue(due(None, self.MON_8))
-
-    def test_hour_and_weekday(self):
-        self.assertTrue(due("0 8 * * 1-5", self.MON_8))
-        self.assertFalse(due("0 9 * * 1-5", self.MON_8))
-        self.assertFalse(due("0 8 * * 6,0", self.MON_8))
-
-    def test_sunday_zero_and_seven(self):
-        self.assertTrue(due("0 8 * * 0", self.SUN_8))
-        self.assertTrue(due("0 8 * * 7", self.SUN_8))
-
-    def test_step_hours(self):
-        self.assertTrue(due("0 */2 * * *", datetime(2024, 1, 1, 8, 0)))
-        self.assertFalse(due("0 */2 * * *", datetime(2024, 1, 1, 9, 0)))
-
-    def test_hour_list_and_range(self):
-        self.assertTrue(due("0 8,16 * * *", datetime(2024, 1, 1, 16, 0)))
-        self.assertTrue(due("0 8-10 * * *", datetime(2024, 1, 1, 9, 0)))
-        self.assertFalse(due("0 8,16 * * *", datetime(2024, 1, 1, 12, 0)))
-
-    def test_month_gate(self):
-        self.assertFalse(due("0 8 * 2 *", datetime(2024, 1, 1, 8, 0)))
-        self.assertTrue(due("0 8 * 2 *", datetime(2024, 2, 1, 8, 0)))
-
-    def test_day_of_month(self):
-        self.assertTrue(due("0 8 15 * *", datetime(2024, 1, 15, 8, 0)))
-        self.assertFalse(due("0 8 15 * *", datetime(2024, 1, 14, 8, 0)))
-
-    def test_nonzero_minute_rejected(self):
-        with self.assertRaises(ValueError):
-            due("30 8 * * *", self.MON_8)
-
-    def test_bad_field_count_rejected(self):
-        with self.assertRaises(ValueError):
-            due("8 * * *", self.MON_8)
+    def test_empty_is_green(self):
+        self.assertEqual(summarize_run({}), ("GREEN", [], [], 0))
 
 
 class TestRender(unittest.TestCase):
@@ -433,21 +298,24 @@ class TestRender(unittest.TestCase):
             "label": "WF-A",
             "outcome": "REAL_FAIL",
             "latest_url": "http://run/2",
+            "latest_ts": "2026-06-14T06:34:32Z",
             "counts": {"broken": 1, "infra": 1, "passing": 3},
             "real_jobs": [
                 {
-                    "_job": {"name": "job-x", "url": "http://job/x", "status_code": "RED"},
+                    "job_name": "job-x",
+                    "job_url": "http://job/x",
+                    "status": "TESTS_FAILED",
                     "category": "tt-metal:compile",
                     "error_message": "boom",
-                    "failed_tests": [],
                 }
             ],
             "infra_jobs": [
                 {
-                    "_job": {"name": "infra-y", "url": "http://job/y", "status_code": "PURPLE"},
+                    "job_name": "infra-y",
+                    "job_url": "http://job/y",
+                    "status": "INFRA_FAILURE",
                     "category": "infra:ci",
                     "error_message": "runner died",
-                    "failed_tests": [],
                 }
             ],
         }
@@ -459,13 +327,14 @@ class TestRender(unittest.TestCase):
         self.assertIn("[WF-A](http://run/2)", md)
         self.assertIn("[job-x](http://job/x)", md)
         self.assertIn("🟣", md)
+        self.assertIn("TESTS_FAILED", md)  # precise status surfaced
         self.assertIn("boom", md)
         self.assertIn("Failed jobs", md)
         self.assertIn("Health:", md)  # 3 passing / 5 total
         self.assertIn("60%", md)
         self.assertIn("WF-D", md)
 
-    def test_broken_without_job_summaries(self):
+    def test_section_without_rows(self):
         md = render_markdown(
             "m",
             [
@@ -479,9 +348,8 @@ class TestRender(unittest.TestCase):
                 }
             ],
         )
-        self.assertIn("no AI job summaries available", md)
-        self.assertNotIn("🟢 0", md)  # no misleading all-zero counts
-        self.assertNotIn("Failed jobs", md)  # no empty placeholder table
+        self.assertIn("no per-job detail", md)
+        self.assertNotIn("Failed jobs", md)
 
     def test_infra_only(self):
         md = render_markdown(
@@ -492,15 +360,39 @@ class TestRender(unittest.TestCase):
                     "outcome": "INFRA",
                     "latest_url": "u",
                     "counts": {"broken": 0, "infra": 1, "passing": 0},
-                    "infra_jobs": [{"_job": {"name": "i", "status_code": "PURPLE"}, "error_message": "x"}],
+                    "infra_jobs": [{"job_name": "i", "status": "INFRA_FAILURE", "error_message": "x"}],
                 }
             ],
         )
         self.assertIn("WF-I", md)
+        self.assertIn("🟣", md)
 
-    def test_empty_and_all_green(self):
+    def test_empty_and_green_fallback(self):
         self.assertIn("CI Digest: m", render_markdown("m", []))
-        self.assertIn("Passing", render_markdown("m", [{"workflow": "G", "outcome": "GREEN", "latest_url": "u"}]))
+        # GREEN with no per-job counts (run-conclusion fallback) → "🟢 green".
+        md = render_markdown("m", [{"workflow": "G", "outcome": "GREEN", "latest_url": "u"}])
+        self.assertIn("🟢 green", md)
+        self.assertIn("G", md)
+
+    def test_green_section_keeps_full_format(self):
+        # A passing run renders name + health + semaphore/date, no jobs table.
+        md = render_markdown(
+            "m",
+            [
+                {
+                    "workflow": "WF-G",
+                    "outcome": "GREEN",
+                    "latest_url": "http://run/9",
+                    "latest_ts": "2026-06-14T06:34:32Z",
+                    "counts": {"broken": 0, "infra": 0, "passing": 5},
+                }
+            ],
+        )
+        self.assertIn("[WF-G](http://run/9)", md)
+        self.assertIn("Health:", md)
+        self.assertIn("100%", md)
+        self.assertIn("🔴 0 · 🟣 0 · 🟢 5", md)
+        self.assertNotIn("Failed jobs", md)
 
     def test_no_data_section_guards_empty_url(self):
         md = render_markdown(
@@ -518,11 +410,20 @@ class TestRender(unittest.TestCase):
 
 
 class TestErrorCell(unittest.TestCase):
-    def test_parse_failure(self):
-        self.assertIn("unavailable", _error_cell({"root_cause": "Failed to parse LLM response: ..."}))
+    def test_error_message_preferred(self):
+        self.assertEqual(_error_cell({"error_message": "boom", "root_cause": "rc"}), "boom")
+
+    def test_fallback_to_root_cause(self):
+        self.assertEqual(_error_cell({"root_cause": "rc only"}), "rc only")
 
     def test_pipe_and_newline_escaped(self):
         self.assertEqual(_error_cell({"error_message": "a|b\nc"}), "a\\|b c")
+
+    def test_empty(self):
+        self.assertEqual(_error_cell({}), "—")
+
+    def test_truncation(self):
+        self.assertTrue(_error_cell({"error_message": "x" * 250}).endswith("…"))
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ci-digest.yaml
+++ b/.github/workflows/ci-digest.yaml
@@ -2,7 +2,8 @@ name: "CI Digest"
 
 on:
   schedule:
-    - cron: "0 * * * *"  # top of every hour; each digest's slot is gated by its schedule
+    # Off :00, which GitHub sheds first under load.
+    - cron: "12 8 * * *"  # disaggregated-prefill
   workflow_dispatch:
     inputs:
       digest:
@@ -28,7 +29,7 @@ jobs:
       matrix:
         include:
           - name: disaggregated-prefill
-            schedule: "0 8 * * *"  # 08:00 UTC daily (minute must be 0)
+            schedule: "12 8 * * *"  # must match a cron in on.schedule (gates this leg)
             slack_channel: "C0B7VTPPMRD"  # SLACK_BOT_TOKEN bot must be a member of this channel
             workflows:  # file names; must be shell-safe (no spaces) — passed unquoted to --workflows
               - blackhole-e2e-tests.yaml
@@ -42,21 +43,19 @@ jobs:
         with:
           python-version: "3.12"
 
-      # Digest selection lives here, not on the job's `if`: the `matrix` context
-      # is unavailable in a job-level `if` (evaluated before matrix expansion).
-      # On manual dispatch, run only the selected digest; scheduled runs cover all.
-      # Non-selected legs skip this step, so the steps below (gated on `produced`)
-      # skip too.
+      # Step-level `if` (matrix is unavailable in a job-level `if`). Scheduled runs
+      # match github.event.schedule (survives late delivery); dispatch uses `digest`.
       - name: Generate digest
         id: digest
-        if: github.event_name != 'workflow_dispatch' || inputs.digest == 'all' || inputs.digest == matrix.name
+        if: >-
+          (github.event_name == 'schedule' && github.event.schedule == matrix.schedule) ||
+          (github.event_name == 'workflow_dispatch' && (inputs.digest == 'all' || inputs.digest == matrix.name))
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           python3 .github/scripts/ci_digest.py --out-dir out \
             --name "${{ matrix.name }}" \
-            --schedule "${{ matrix.schedule }}" \
-            --workflows ${{ join(matrix.workflows, ' ') }} ${{ github.event_name == 'workflow_dispatch' && '--force' || '' }}
+            --workflows ${{ join(matrix.workflows, ' ') }} --force
           shopt -s nullglob
           files=(out/ci-digest-*.md)
           if [ ${#files[@]} -gt 0 ]; then
@@ -67,6 +66,11 @@ jobs:
             echo "all_green=$ag" >> "$GITHUB_OUTPUT"
           fi
 
+      # Digest in the run log, so it's readable without opening the Step Summary.
+      - name: Print digest
+        if: steps.digest.outputs.produced == 'true'
+        run: cat out/ci-digest-*.md
+
       - name: Upload digest
         if: steps.digest.outputs.produced == 'true'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -74,12 +78,10 @@ jobs:
           name: ci-digest-${{ matrix.name }}-${{ github.run_id }}
           path: out/
 
-      # Single source of the Slack gate: post only for scheduled runs of a
-      # digest that produced output and has a channel. Both Slack steps below
-      # key off this step's `go` output (empty when this step is skipped).
+      # Single Slack gate: both Slack steps below key off this step's `go` output.
       - name: Gate Slack notification
         id: notify
-        if: steps.digest.outputs.produced == 'true' && matrix.slack_channel != '' && github.event_name != 'workflow_dispatch'
+        if: steps.digest.outputs.produced == 'true' && matrix.slack_channel != '' && github.event_name == 'schedule'
         run: echo "go=true" >> "$GITHUB_OUTPUT"
 
       - name: Resolve this job's id
@@ -89,8 +91,7 @@ jobs:
         with:
           job_name: "digest · ${{ matrix.name }}"
 
-      # #summary-<job_id> anchors directly to this job's step summary on the
-      # run-attempt page; if the anchor ever drifts it still opens the page.
+      # #summary-<job_id> deep-links to this job's step summary on the run page.
       - name: Notify Slack
         if: steps.notify.outputs.go == 'true'
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3

--- a/.github/workflows/ci-digest.yaml
+++ b/.github/workflows/ci-digest.yaml
@@ -2,8 +2,8 @@ name: "CI Digest"
 
 on:
   schedule:
-    # Off :00, which GitHub sheds first under load.
-    - cron: "12 8 * * *"  # disaggregated-prefill
+    # Off :00, which GitHub sheds first under load. Weekdays only.
+    - cron: "12 8 * * 1-5"  # disaggregated-prefill
   workflow_dispatch:
     inputs:
       digest:
@@ -29,7 +29,7 @@ jobs:
       matrix:
         include:
           - name: disaggregated-prefill
-            schedule: "12 8 * * *"  # must match a cron in on.schedule (gates this leg)
+            schedule: "12 8 * * 1-5"  # must match a cron in on.schedule (gates this leg)
             slack_channel: "C0B7VTPPMRD"  # SLACK_BOT_TOKEN bot must be a member of this channel
             workflows:  # file names; must be shell-safe (no spaces) — passed unquoted to --workflows
               - blackhole-e2e-tests.yaml
@@ -55,7 +55,7 @@ jobs:
         run: |
           python3 .github/scripts/ci_digest.py --out-dir out \
             --name "${{ matrix.name }}" \
-            --workflows ${{ join(matrix.workflows, ' ') }} --force
+            --workflows ${{ join(matrix.workflows, ' ') }}
           shopt -s nullglob
           files=(out/ci-digest-*.md)
           if [ ${#files[@]} -gt 0 ]; then


### PR DESCRIPTION
## What

Two fixes to the CI Digest, stacked:

1. **Schedule gating** (`109b883`) — the digest was missing days because the hourly cron + wall-clock `due()` check relied on a tick landing in the target hour, which GitHub frequently drops/delays. Gating now keys off `github.event.schedule` (survives late delivery). Cron moved off the congested `:00`.

2. **Consume `ai_run_summary` JSON** (`a01e85a`) — the digest no longer queries the GitHub jobs API or re-derives real/infra/hang verdicts. It reads each watched workflow's `ai_run_summary_<run_id>.json` (`succeeded` / `failed` / `infra_failure`, already reconciled against the expected matrix by the `ai_summary/run` action) and renders it. Classification lives in the summary layer — the only place that knows which legs were *expected* to run, so it can surface infra failures that produced no per-job artifact.

   Removes `classify` / `fetch_jobs` / `_job_id_of` / `_no_artifact_job` / `_green_but_failed_job` and the dead `--schedule`/`--force`/`due()` machinery (net −98 lines in `ci_digest.py`).

## Also

- **Weekday-only schedule** for `disaggregated-prefill` (`12 8 * * 1-5`).
- **Passing workflows** render in the same section format as failures (name, health bar, 🔴/🟣/🟢 + date) — just without a jobs table.

## Dependency — why draft

Requires the `ai_run_summary` JSON output (tt-github-actions, branch `ppetrovic/ai-run-summary-json`) to be **merged and deployed to `@main`**. Until then there's no JSON artifact to read; the digest falls back to the run conclusion (green run → green; non-green → "no data"). Mark ready once that action change ships.

## Notes / not yet validated live

- No scheduled run has produced an `ai_run_summary_*.json` yet (the action change isn't deployed), so the consumer path is covered by embedded unit tests + a fixture render, not a live run. `python3 .github/scripts/ci_digest.py --self-test` → 16 tests pass.
- The Slack bot (`SLACK_BOT_TOKEN`) must be a member of channel `C0B7VTPPMRD` before the first scheduled post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ppetrovic/ci-digest-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ppetrovic/ci-digest-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ppetrovic/ci-digest-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ppetrovic/ci-digest-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ppetrovic/ci-digest-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ppetrovic/ci-digest-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ppetrovic/ci-digest-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ppetrovic/ci-digest-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ppetrovic/ci-digest-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ppetrovic/ci-digest-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ppetrovic/ci-digest-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ppetrovic/ci-digest-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ppetrovic/ci-digest-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ppetrovic/ci-digest-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ppetrovic/ci-digest-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ppetrovic/ci-digest-fixes)