### PR TITLE
[Cleanup] Migrate eltwise/conv experimental ops to Device 2.0 API

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/convert_to_chw.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/convert_to_chw.cpp
@@ -6,24 +6,27 @@
 
 #include "api/compute/pack_untilize.h"
 #include "api/compute/transpose_wh.h"
+#include "api/dataflow/circular_buffer.h"
 
 template <int BATCH_SIZE>
 FORCE_INLINE void transpose(uint32_t cb_in, uint32_t cb_out) {
-    cb_wait_front(cb_in, BATCH_SIZE);
+    CircularBuffer cb_in_cb(cb_in);
+    CircularBuffer cb_out_cb(cb_out);
+    cb_in_cb.wait_front(BATCH_SIZE);
 
     tile_regs_acquire();
     for (uint32_t i = 0; i < BATCH_SIZE; i++) {
         transpose_wh_tile(cb_in, i, i);
     }
     tile_regs_commit();
-    cb_pop_front(cb_in, BATCH_SIZE);
+    cb_in_cb.pop_front(BATCH_SIZE);
 
-    cb_reserve_back(cb_out, BATCH_SIZE);
+    cb_out_cb.reserve_back(BATCH_SIZE);
     tile_regs_wait();
     pack_untilize_dest<1>(cb_out, BATCH_SIZE);
     tile_regs_release();
 
-    cb_push_back(cb_out, BATCH_SIZE);
+    cb_out_cb.push_back(BATCH_SIZE);
 }
 void kernel_main() {
     constexpr int BATCH_SIZE = 8;

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/convert_to_hwc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/convert_to_hwc.cpp
@@ -8,10 +8,13 @@
 #include "api/compute/transpose_wh.h"
 #include "api/compute/tilize.h"
 #include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
+#include "api/dataflow/circular_buffer.h"
 
 template <uint32_t BatchSize = 1>
 FORCE_INLINE void transpose(uint32_t cb_in, uint32_t cb_out) {
-    cb_wait_front(cb_in, BatchSize);
+    CircularBuffer cb_in_cb(cb_in);
+    CircularBuffer cb_out_cb(cb_out);
+    cb_in_cb.wait_front(BatchSize);
 
     tile_regs_acquire();
     tile_regs_wait();
@@ -21,14 +24,14 @@ FORCE_INLINE void transpose(uint32_t cb_in, uint32_t cb_out) {
         transpose_wh_tile(cb_in, i, i);
     }
 
-    cb_reserve_back(cb_out, BatchSize);
+    cb_out_cb.reserve_back(BatchSize);
     pack_untilize_dest<1>(cb_out, BatchSize);
 
     tile_regs_commit();
     tile_regs_release();
 
-    cb_push_back(cb_out, BatchSize);
-    cb_pop_front(cb_in, BatchSize);
+    cb_out_cb.push_back(BatchSize);
+    cb_in_cb.pop_front(BatchSize);
 }
 
 void kernel_main() {

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/compute.cpp
@@ -13,6 +13,7 @@
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/reconfig_data_format.h"
+#include "api/dataflow/circular_buffer.h"
 #include "ttnn/cpp/ttnn/kernel_lib/dest_helpers.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp"
@@ -44,6 +45,8 @@ void matmul_blocks(
 
     reconfig_data_format(in1_cb, in0_cb);
 
+    CircularBuffer out_cb_obj(out_cb);
+
     for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; ++in0_subblock) {
         uint32_t in1_index_offset = 0;
         for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; ++in1_subblock) {
@@ -61,12 +64,12 @@ void matmul_blocks(
             }
             tile_regs_commit();
 
-            cb_reserve_back(out_cb, out_subblock_num_tiles);
+            out_cb_obj.reserve_back(out_subblock_num_tiles);
             tile_regs_wait();
             for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
                 pack_tile(i, out_cb);
             }
-            cb_push_back(out_cb, out_subblock_num_tiles);
+            out_cb_obj.push_back(out_subblock_num_tiles);
             tile_regs_release();
             in1_index_offset += subblock_w;
         }
@@ -90,9 +93,12 @@ template <uint32_t rows, uint32_t cols, uint32_t add_dst_tiles>
 void add_bias_inplace(uint32_t inout_cb, uint32_t bias_cb) {
     constexpr uint32_t num_tiles = rows * cols;
 
+    CircularBuffer inout_cb_obj(inout_cb);
+    CircularBuffer bias_cb_obj(bias_cb);
+
     add_bcast_rows_init_short(inout_cb, bias_cb);
-    cb_wait_front(inout_cb, num_tiles);
-    cb_wait_front(bias_cb, cols);
+    inout_cb_obj.wait_front(num_tiles);
+    bias_cb_obj.wait_front(cols);
     for (uint32_t i = 0; i < rows; ++i) {
         for (uint32_t col_start = 0; col_start < cols; col_start += add_dst_tiles) {
             const uint32_t cols_cur = std::min(add_dst_tiles, cols - col_start);
@@ -102,12 +108,12 @@ void add_bias_inplace(uint32_t inout_cb, uint32_t bias_cb) {
             }
             tile_regs_commit();
             tile_regs_wait();
-            cb_pop_front(inout_cb, cols_cur);
-            cb_reserve_back(inout_cb, cols_cur);
+            inout_cb_obj.pop_front(cols_cur);
+            inout_cb_obj.reserve_back(cols_cur);
             for (uint32_t j = 0; j < cols_cur; ++j) {
                 pack_tile_with_wh_destination_wait(j, inout_cb, i * cols + col_start + j);
             }
-            cb_push_back(inout_cb, cols_cur);
+            inout_cb_obj.push_back(cols_cur);
             tile_regs_release();
         }
     }
@@ -115,6 +121,9 @@ void add_bias_inplace(uint32_t inout_cb, uint32_t bias_cb) {
 
 template <uint32_t num_tiles, uint32_t add_dst_tiles>
 void add_block_inplace_math(uint32_t inout_cb, uint32_t add_cb) {
+    CircularBuffer inout_cb_obj(inout_cb);
+    CircularBuffer add_cb_obj(add_cb);
+
     add_tiles_init(inout_cb, add_cb);
     for (uint32_t i = 0; i < num_tiles; i += add_dst_tiles) {
         const uint32_t tiles_cur = std::min(add_dst_tiles, num_tiles - i);
@@ -124,13 +133,13 @@ void add_block_inplace_math(uint32_t inout_cb, uint32_t add_cb) {
         }
         tile_regs_commit();
         tile_regs_wait();
-        cb_pop_front(inout_cb, tiles_cur);
-        cb_pop_front(add_cb, tiles_cur);
-        cb_reserve_back(inout_cb, tiles_cur);
+        inout_cb_obj.pop_front(tiles_cur);
+        add_cb_obj.pop_front(tiles_cur);
+        inout_cb_obj.reserve_back(tiles_cur);
         for (uint32_t tile = 0; tile < tiles_cur; ++tile) {
             pack_tile_with_wh_destination_wait(tile, inout_cb, i + tile);
         }
-        cb_push_back(inout_cb, tiles_cur);
+        inout_cb_obj.push_back(tiles_cur);
         tile_regs_release();
     }
 }
@@ -159,7 +168,8 @@ template <
     uint32_t bias_cb,
     uint32_t out_cb>
 void bias_untilize_fullblock_math() {
-    cb_wait_front(inout_cb, rows * cols);
+    CircularBuffer inout_cb_obj(inout_cb);
+    inout_cb_obj.wait_front(rows * cols);
     if constexpr (use_bias) {
         if constexpr (use_fp32_partials) {
             reconfig_data_format(inout_cb, bias_cb);
@@ -173,14 +183,17 @@ template <uint32_t rows, uint32_t cols, bool use_fp32_partials, uint32_t local_c
 void reduce_fullblock_inplace_math(uint32_t num_workers) {
     constexpr uint32_t num_tiles = rows * cols;
 
-    cb_wait_front(local_cb, num_tiles);
+    CircularBuffer local_cb_obj(local_cb);
+    CircularBuffer remote_cb_obj(remote_cb);
+
+    local_cb_obj.wait_front(num_tiles);
 
     if constexpr (use_fp32_partials) {
         reconfig_data_format(local_cb, remote_cb);
         pack_reconfig_data_format(local_cb);
     }
     for (uint32_t i = 0; i < num_workers; i++) {
-        cb_wait_front(remote_cb, num_tiles);
+        remote_cb_obj.wait_front(num_tiles);
         add_block_inplace_math<num_tiles, compute_kernel_lib::DEST_AUTO_LIMIT>(local_cb, remote_cb);
     }
 }
@@ -243,6 +256,15 @@ void kernel_main() {
     constexpr uint32_t batch_tiles = subblock_h * matmul_K_t;
     constexpr uint32_t subblock_tiles = subblock_h * matmul_N_t;
 
+    CircularBuffer cb_vol2col_rm_cb(cb_vol2col_rm);
+    CircularBuffer cb_vol2col_tiled_cb(cb_vol2col_tiled);
+    CircularBuffer cb_weight_tiled_cb(cb_weight_tiled);
+    CircularBuffer cb_bias_tiled_cb(cb_bias_tiled);
+    CircularBuffer cb_matmul_interm_tiled_cb(cb_matmul_interm_tiled);
+    CircularBuffer cb_matmul_result_rm_cb(cb_matmul_result_rm);
+    CircularBuffer cb_reduction_tiled_cb(cb_reduction_tiled);
+    CircularBuffer cb_worker_ack_back_cb(cb_worker_ack_back);
+
     compute_kernel_hw_startup<SrcOrder::Reverse>(cb_vol2col_tiled, cb_weight_tiled, cb_matmul_interm_tiled);
     matmul_init(cb_vol2col_tiled, cb_weight_tiled);
     MATH((llk_math_reconfig_remap(true)));
@@ -272,7 +294,7 @@ void kernel_main() {
                 // tilize overlaps with BRISC's DRAM weight read.
                 if constexpr (use_bias) {
                     if (is_reducer) {
-                        cb_wait_front(cb_bias_tiled, matmul_N_t);
+                        cb_bias_tiled_cb.wait_front(matmul_N_t);
                     }
                 }
 
@@ -314,10 +336,10 @@ void kernel_main() {
                                     }
 
                                     // Wait for weights — deferred so tilize overlaps with BRISC's DRAM read.
-                                    cb_wait_front(cb_weight_tiled, weight_tiles);
+                                    cb_weight_tiled_cb.wait_front(weight_tiles);
 
                                     // Phase 2: matmul the batch
-                                    cb_wait_front(cb_vol2col_tiled, batch_tiles);
+                                    cb_vol2col_tiled_cb.wait_front(batch_tiles);
                                     matmul_blocks(
                                         cb_vol2col_tiled,
                                         cb_weight_tiled,
@@ -331,12 +353,12 @@ void kernel_main() {
                                         subblock_h,
                                         subblock_w,
                                         false /* transpose */);
-                                    cb_pop_front(cb_vol2col_tiled, batch_tiles);
+                                    cb_vol2col_tiled_cb.pop_front(batch_tiles);
 
                                     if constexpr (enable_streaming_output) {
                                         // Streaming emits subblocks before cb_matmul_interm_tiled is physically full,
                                         // so bias uses math add and untilizes immediately.
-                                        cb_wait_front(cb_matmul_interm_tiled, subblock_tiles);
+                                        cb_matmul_interm_tiled_cb.wait_front(subblock_tiles);
 
                                         if constexpr (use_bias) {
                                             if constexpr (use_fp32_partials) {
@@ -369,22 +391,22 @@ void kernel_main() {
 
                             if constexpr (!enable_streaming_output) {
                                 // Stall on matmul/bias to finish
-                                cb_wait_front(cb_matmul_interm_tiled, output_tiles);
+                                cb_matmul_interm_tiled_cb.wait_front(output_tiles);
 
                                 if (!is_reducer) {
                                     // not reducer implies that we are a worker and there are multiple workers in this
                                     // reduction group
 
                                     // Signal to writer that we have partial results
-                                    cb_reserve_back(cb_reduction_tiled, output_tiles);
-                                    cb_push_back(cb_reduction_tiled, output_tiles);
+                                    cb_reduction_tiled_cb.reserve_back(output_tiles);
+                                    cb_reduction_tiled_cb.push_back(output_tiles);
 
                                     // Wait for writer to ack that our data has been used
-                                    cb_wait_front(cb_worker_ack_back, 1);
-                                    cb_pop_front(cb_worker_ack_back, 1);
+                                    cb_worker_ack_back_cb.wait_front(1);
+                                    cb_worker_ack_back_cb.pop_front(1);
 
                                     // Clear our partial results and continue
-                                    cb_pop_front(cb_matmul_interm_tiled, output_tiles);
+                                    cb_matmul_interm_tiled_cb.pop_front(output_tiles);
                                 } else {
                                     // We are a reducer core.
                                     reduce_bias_untilize_fullblock<
@@ -402,10 +424,10 @@ void kernel_main() {
                     }
                 }
                 // Free space for next block of weights
-                cb_pop_front(cb_weight_tiled, weight_tiles);
+                cb_weight_tiled_cb.pop_front(weight_tiles);
                 if constexpr (use_bias) {
                     if (is_reducer) {
-                        cb_pop_front(cb_bias_tiled, matmul_N_t);
+                        cb_bias_tiled_cb.pop_front(matmul_N_t);
                     }
                 }
             }

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/kernels/compute/dropout_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/kernels/compute/dropout_kernel.cpp
@@ -8,6 +8,7 @@
 #include "api/compute/eltwise_unary/dropout.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/eltwise_unary/sfpu_split_includes.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
     uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
@@ -17,15 +18,18 @@ void kernel_main() {
 
     uint32_t seed = get_arg_val<uint32_t>(0);
 
+    CircularBuffer cb_in(tt::CBIndex::c_0);
+    CircularBuffer cb_out(tt::CBIndex::c_2);
+
     init_sfpu(tt::CBIndex::c_0, tt::CBIndex::c_2);
     dropout_kernel_init(seed);
     for (uint32_t block_index = 0; block_index < per_core_block_cnt; block_index++) {
-        cb_reserve_back(tt::CBIndex::c_2, per_core_block_dim);
+        cb_out.reserve_back(per_core_block_dim);
         for (uint32_t tile_index = 0; tile_index < per_core_block_dim; ++tile_index) {
             tile_regs_acquire();
 
             // Pop tile after tile, copy to DST and pack
-            cb_wait_front(tt::CBIndex::c_0, 1);
+            cb_in.wait_front(1);
 
             copy_tile(tt::CBIndex::c_0, 0, 0);
 
@@ -37,10 +41,10 @@ void kernel_main() {
 
             pack_tile(0, tt::CBIndex::c_2);
 
-            cb_pop_front(tt::CBIndex::c_0, 1);
+            cb_in.pop_front(1);
 
             tile_regs_release();
         }
-        cb_push_back(tt::CBIndex::c_2, per_core_block_dim);
+        cb_out.push_back(per_core_block_dim);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/kernels/dataflow/reader_dropout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/kernels/dataflow/reader_dropout_interleaved_start_id.cpp
@@ -4,8 +4,14 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
+    Noc noc;
+
     uint32_t src_addr = get_arg_val<uint32_t>(0);
     uint32_t num_tiles = get_arg_val<uint32_t>(1);
     uint32_t start_id = get_arg_val<uint32_t>(2);
@@ -17,6 +23,8 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
     const auto s = TensorAccessor(src_args, src_addr);
 
+    CircularBuffer cb_in0(cb_id_in0);
+
 // read a ublock of tiles from src to CB, and then push the ublock to unpacker
 #ifdef BACKWARDS
     uint32_t end_id = start_id - num_tiles;
@@ -25,10 +33,10 @@ void kernel_main() {
     uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id; ++i) {
 #endif
-        cb_reserve_back(cb_id_in0, onetile);
-        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
-        noc_async_read_page(i, s, l1_write_addr);
-        noc_async_read_barrier();
-        cb_push_back(cb_id_in0, onetile);
+        cb_in0.reserve_back(onetile);
+        uint32_t l1_write_addr = cb_in0.get_write_ptr();
+        noc.async_read(s, CoreLocalMem<uint32_t>(l1_write_addr), get_tile_size(cb_id_in0), {.page_id = i}, {});
+        noc.async_read_barrier();
+        cb_in0.push_back(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/kernels/dataflow/writer_dropout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/kernels/dataflow/writer_dropout_interleaved_start_id.cpp
@@ -3,8 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
+    Noc noc;
+
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
     uint32_t num_tiles = get_arg_val<uint32_t>(1);
     uint32_t start_id = get_arg_val<uint32_t>(2);
@@ -12,8 +18,10 @@ void kernel_main() {
     constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
     constexpr auto dst_args = TensorAccessorArgs<1>();
 
+    CircularBuffer cb_out(cb_id_out);
+
 #ifdef OUT_SHARDED
-    cb_wait_front(cb_id_out, num_tiles);
+    cb_out.wait_front(num_tiles);
 #else
 
     // single-tile ublocks
@@ -27,11 +35,11 @@ void kernel_main() {
     uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id; ++i) {
 #endif
-        cb_wait_front(cb_id_out, onetile);
-        uint32_t l1_read_addr = get_read_ptr(cb_id_out);
-        noc_async_write_page(i, s, l1_read_addr);
-        noc_async_write_barrier();
-        cb_pop_front(cb_id_out, onetile);
+        cb_out.wait_front(onetile);
+        uint32_t l1_read_addr = cb_out.get_read_ptr();
+        noc.async_write(CoreLocalMem<uint32_t>(l1_read_addr), s, get_tile_size(cb_id_out), {.page_id = i}, {});
+        noc.async_write_barrier();
+        cb_out.pop_front(onetile);
     }
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/kernels/dataflow/writer_dropout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/kernels/dataflow/writer_dropout_interleaved_start_id.cpp
@@ -37,7 +37,7 @@ void kernel_main() {
 #endif
         cb_out.wait_front(onetile);
         uint32_t l1_read_addr = cb_out.get_read_ptr();
-        noc.async_write(CoreLocalMem<uint32_t>(l1_read_addr), s, get_tile_size(cb_id_out), {.page_id = i}, {});
+        noc.async_write(CoreLocalMem<uint32_t>(l1_read_addr), s, get_tile_size(cb_id_out), {}, {.page_id = i});
         noc.async_write_barrier();
         cb_out.pop_front(onetile);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/isin/device/kernels/dataflow/isin_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/isin/device/kernels/dataflow/isin_common.hpp
@@ -4,6 +4,11 @@
 
 #pragma once
 
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
 // choose the right C++ POD type at compile-time
 template <DataFormat df>
 struct df_to_std {
@@ -97,16 +102,19 @@ FORCE_INLINE void load_to_cb(
     const uint32_t& offset,
     const uint32_t& subchunk_size,
     const uint32_t& datum_size) {
-    cb_reserve_back(cb, ONE_PAGE);
+    Noc noc;
+    CircularBuffer cb_obj(cb);
+    cb_obj.reserve_back(ONE_PAGE);
 
     const uint64_t source_noc_address = addr_gtor.get_noc_addr(FIRST_STICK);
-    const uint32_t l1_write_address = get_write_ptr(cb);
+    const uint32_t l1_write_address = cb_obj.get_write_ptr();
     const uint32_t subchunk_size_bytes = subchunk_size * datum_size;
     const uint32_t offset_bytes = offset * datum_size;
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
     noc_async_read(source_noc_address + offset_bytes, l1_write_address, subchunk_size_bytes);
-    noc_async_read_barrier();
+    noc.async_read_barrier();
 
-    cb_push_back(cb, ONE_PAGE);
+    cb_obj.push_back(ONE_PAGE);
 }
 
 // write from L1 to DRAM
@@ -117,14 +125,17 @@ FORCE_INLINE void write_to_dram(
     const uint32_t& offset,
     const uint32_t& subchunk_size,
     const uint32_t& datum_size) {
-    cb_wait_front(cb, ONE_PAGE);
+    Noc noc;
+    CircularBuffer cb_obj(cb);
+    cb_obj.wait_front(ONE_PAGE);
 
     const uint64_t destination_noc_address = addr_gtor.get_noc_addr(FIRST_STICK);
-    const uint32_t l1_read_address = get_read_ptr(cb);
+    const uint32_t l1_read_address = cb_obj.get_read_ptr();
     const uint32_t subchunk_size_bytes = subchunk_size * datum_size;
     const uint32_t offset_bytes = offset * datum_size;
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
     noc_async_write(l1_read_address, destination_noc_address + offset_bytes, subchunk_size_bytes);
-    noc_async_write_barrier();
+    noc.async_write_barrier();
 
-    cb_pop_front(cb, ONE_PAGE);
+    cb_obj.pop_front(ONE_PAGE);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/kernels/reader_ssm_1d_sum_reduce.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/kernels/reader_ssm_1d_sum_reduce.cpp
@@ -4,9 +4,15 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 
 void kernel_main() {
+    Noc noc;
+
     uint32_t src_addr = get_arg_val<uint32_t>(0);
     uint32_t input_num_blocks_w_per_core = get_arg_val<uint32_t>(1);
     uint32_t start_id = get_arg_val<uint32_t>(2);
@@ -18,6 +24,7 @@ void kernel_main() {
         calculate_and_prepare_reduce_scaler<cb_id_in2, ckernel::PoolType::SUM, ckernel::ReduceDim::REDUCE_COL>();
 
     constexpr uint32_t cb_id_in0 = 0;
+    CircularBuffer cb_in0(cb_id_in0);
 
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
@@ -28,11 +35,16 @@ void kernel_main() {
     for (uint32_t block_h_id = 0; block_h_id < input_num_blocks_h; block_h_id++) {
         uint32_t end_id = start_id + input_num_blocks_w_per_core;
         for (uint32_t i = start_id; i < end_id; i++) {
-            cb_reserve_back(cb_id_in0, onetile);
-            uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
-            noc_async_read_page((block_h_id * input_total_blocks_w) + i, s, l1_write_addr);
-            noc_async_read_barrier();
-            cb_push_back(cb_id_in0, onetile);
+            cb_in0.reserve_back(onetile);
+            uint32_t l1_write_addr = cb_in0.get_write_ptr();
+            noc.async_read(
+                s,
+                CoreLocalMem<uint32_t>(l1_write_addr),
+                get_tile_size(cb_id_in0),
+                {.page_id = (block_h_id * input_total_blocks_w) + i},
+                {});
+            noc.async_read_barrier();
+            cb_in0.push_back(onetile);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/kernels/ssm_1d_sum_reduce.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/kernels/ssm_1d_sum_reduce.cpp
@@ -6,12 +6,15 @@
 
 #include "api/compute/reduce.h"
 #include "api/compute/transpose_wh.h"
+#include "api/dataflow/circular_buffer.h"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 
 constexpr uint32_t ONE_TILE = 1;
 
 FORCE_INLINE void transpose(uint32_t cb_in, uint32_t cb_out) {
-    cb_wait_front(cb_in, ONE_TILE);
+    CircularBuffer cb_in_obj(cb_in);
+    CircularBuffer cb_out_obj(cb_out);
+    cb_in_obj.wait_front(ONE_TILE);
 
     tile_regs_acquire();
     tile_regs_wait();
@@ -19,14 +22,14 @@ FORCE_INLINE void transpose(uint32_t cb_in, uint32_t cb_out) {
     transpose_wh_init_short(cb_in);
     transpose_wh_tile(cb_in, 0, 0);
 
-    cb_reserve_back(cb_out, ONE_TILE);
+    cb_out_obj.reserve_back(ONE_TILE);
     pack_tile(0, cb_out);
 
     tile_regs_commit();
     tile_regs_release();
 
-    cb_push_back(cb_out, ONE_TILE);
-    cb_pop_front(cb_in, ONE_TILE);
+    cb_out_obj.push_back(ONE_TILE);
+    cb_in_obj.pop_front(ONE_TILE);
 }
 
 void kernel_main() {
@@ -40,10 +43,12 @@ void kernel_main() {
     constexpr uint32_t intermed_cb_id2 = get_compile_time_arg_val(4);
     constexpr uint32_t output_cb_id = get_compile_time_arg_val(5);
 
+    CircularBuffer cb_scalar(scalar_cb_id);
+
     compute_kernel_hw_startup(input_cb_id, scalar_cb_id, intermed_cb_id1);
 
     for (uint32_t block_h_id = 0; block_h_id < input_num_blocks_h; block_h_id++) {
-        cb_wait_front(scalar_cb_id, ONE_TILE);
+        cb_scalar.wait_front(ONE_TILE);
 
         for (uint32_t output_idx = 0; output_idx < num_blocks; output_idx++) {
             for (uint32_t slice_idx = 0; slice_idx < TILE_WIDTH; slice_idx++) {

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/kernels/writer_ssm_1d_sum_reduce.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/kernels/writer_ssm_1d_sum_reduce.cpp
@@ -3,8 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
+    Noc noc;
+
     constexpr uint32_t DATA_FORMAT_BYTES = 2;
     constexpr uint32_t FACE_WIDTH = 16;
     constexpr uint32_t FACE_WIDTH_BYTES = FACE_WIDTH * DATA_FORMAT_BYTES;
@@ -21,6 +27,10 @@ void kernel_main() {
     constexpr uint32_t intermed_cb_id2 = get_compile_time_arg_val(1);
     constexpr uint32_t output_cb_id = get_compile_time_arg_val(2);
 
+    CircularBuffer cb_intermed1(intermed_cb_id1);
+    CircularBuffer cb_intermed2(intermed_cb_id2);
+    CircularBuffer cb_output(output_cb_id);
+
     constexpr uint32_t onetile = 1;
     constexpr auto dst_args = TensorAccessorArgs<3>();
     const auto s = TensorAccessor(dst_args, dst_addr);
@@ -29,19 +39,21 @@ void kernel_main() {
 
     for (uint32_t block_h_id = 0; block_h_id < out_num_blocks_h; block_h_id++) {
         for (uint32_t i = start_id; i < end_id; ++i) {
-            cb_reserve_back(intermed_cb_id2, onetile);
-            uint32_t dst = get_write_ptr(intermed_cb_id2);
+            cb_intermed2.reserve_back(onetile);
+            uint32_t dst = cb_intermed2.get_write_ptr();
 
             // Manually unroll copying into destination face 1+2 and 3+4 to avoid conditional inside loop
             for (uint32_t j = 0; j < FACE_WIDTH; ++j) {
-                cb_wait_front(intermed_cb_id1, onetile);
-                uint64_t src = get_noc_addr(get_read_ptr(intermed_cb_id1));
+                cb_intermed1.wait_front(onetile);
+                uint64_t src = get_noc_addr(cb_intermed1.get_read_ptr());
 
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
                 noc_async_read(src, dst, FACE_WIDTH_BYTES);
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
                 noc_async_read(src + FACE_SIZE_BYTES, dst + FACE_SIZE_BYTES, FACE_WIDTH_BYTES);
-                noc_async_read_barrier();
+                noc.async_read_barrier();
 
-                cb_pop_front(intermed_cb_id1, onetile);
+                cb_intermed1.pop_front(onetile);
 
                 dst += FACE_WIDTH_BYTES;
             }
@@ -49,24 +61,31 @@ void kernel_main() {
 
             // Copy face 3/4 into the destination
             for (uint32_t j = 0; j < FACE_WIDTH; ++j) {
-                cb_wait_front(intermed_cb_id1, onetile);
-                uint64_t src = get_noc_addr(get_read_ptr(intermed_cb_id1));
+                cb_intermed1.wait_front(onetile);
+                uint64_t src = get_noc_addr(cb_intermed1.get_read_ptr());
 
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
                 noc_async_read(src, dst, FACE_WIDTH_BYTES);
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
                 noc_async_read(src + FACE_SIZE_BYTES, dst + FACE_SIZE_BYTES, FACE_WIDTH_BYTES);
-                noc_async_read_barrier();
+                noc.async_read_barrier();
 
-                cb_pop_front(intermed_cb_id1, onetile);
+                cb_intermed1.pop_front(onetile);
 
                 dst += FACE_WIDTH_BYTES;
             }
-            cb_push_back(intermed_cb_id2, onetile);
+            cb_intermed2.push_back(onetile);
 
-            cb_wait_front(output_cb_id, onetile);
-            uint32_t l1_read_addr = get_read_ptr(output_cb_id);
-            noc_async_write_page((block_h_id * out_num_blocks_w) + i, s, l1_read_addr);
-            noc_async_write_barrier();
-            cb_pop_front(output_cb_id, onetile);
+            cb_output.wait_front(onetile);
+            uint32_t l1_read_addr = cb_output.get_read_ptr();
+            noc.async_write(
+                CoreLocalMem<uint32_t>(l1_read_addr),
+                s,
+                get_tile_size(output_cb_id),
+                {},
+                {.page_id = (block_h_id * out_num_blocks_w) + i});
+            noc.async_write_barrier();
+            cb_output.pop_front(onetile);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/ssm_prefix_scan.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/ssm_prefix_scan.cpp
@@ -8,6 +8,7 @@
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/tilize.h"
 #include "api/compute/pack_untilize.h"
+#include "api/dataflow/circular_buffer.h"
 
 constexpr uint32_t NUM_TILES_IN_TILIZED_CHUNK = 32;
 
@@ -23,23 +24,26 @@ static_assert(UNTILIZE_FULL_CT % UNTILIZE_SUBBLOCK_CT == 0);
 
 // Staging CB always has NUM_TILES_IN_TILIZED_CHUNK tiles; pop the full chunk to keep it clean.
 FORCE_INLINE void pack_block_rows_into_tiles(uint32_t cb_in, uint32_t cb_out) {
+    CircularBuffer cb_in_obj(cb_in);
+    CircularBuffer cb_out_obj(cb_out);
+
     reconfig_data_format_srca(cb_in);
     pack_reconfig_data_format(cb_out);
 
     pack_untilize_init<UNTILIZE_SUBBLOCK_CT, UNTILIZE_FULL_CT>(cb_in, cb_out);
 
-    cb_wait_front(cb_in, NUM_TILES_IN_TILIZED_CHUNK);
-    cb_reserve_back(cb_out, NUM_TILES_IN_TILIZED_CHUNK);
+    cb_in_obj.wait_front(NUM_TILES_IN_TILIZED_CHUNK);
+    cb_out_obj.reserve_back(NUM_TILES_IN_TILIZED_CHUNK);
 
     // pack_untilize_block does not offset its input read by block_c_index, so pop the input
     // incrementally; each sub-block reads the next UNTILIZE_SUBBLOCK_CT tiles (32 popped total).
     for (uint32_t b = 0; b < UNTILIZE_NUM_SUBBLOCKS; ++b) {
         pack_untilize_block<UNTILIZE_SUBBLOCK_CT, UNTILIZE_FULL_CT>(
             cb_in, /*block_rt_dim=*/1, cb_out, /*block_c_index=*/b);
-        cb_pop_front(cb_in, UNTILIZE_SUBBLOCK_CT);
+        cb_in_obj.pop_front(UNTILIZE_SUBBLOCK_CT);
     }
 
-    cb_push_back(cb_out, NUM_TILES_IN_TILIZED_CHUNK);
+    cb_out_obj.push_back(NUM_TILES_IN_TILIZED_CHUNK);
 
     pack_untilize_uninit(cb_out);
 }
@@ -48,31 +52,38 @@ FORCE_INLINE void pack_block_rows_into_tiles(uint32_t cb_in, uint32_t cb_out) {
 // The tilize must always process the full NUM_TILES_IN_TILIZED_CHUNK block to correctly
 // reconstruct the tile layout from row-major format (inverse of pack_block_rows_into_tiles, i.e. the 32-tile untilize).
 FORCE_INLINE void pack_block_tiles_into_rows(uint32_t cb_in, uint32_t cb_out, uint32_t num_valid_tiles) {
+    CircularBuffer cb_in_obj(cb_in);
+    CircularBuffer cb_out_obj(cb_out);
+
     reconfig_data_format_srca(cb_in);
     pack_reconfig_data_format(cb_out);
 
     tilize_init(cb_in, NUM_TILES_IN_TILIZED_CHUNK, cb_out);
 
-    cb_wait_front(cb_in, NUM_TILES_IN_TILIZED_CHUNK);
-    cb_reserve_back(cb_out, num_valid_tiles);
+    cb_in_obj.wait_front(NUM_TILES_IN_TILIZED_CHUNK);
+    cb_out_obj.reserve_back(num_valid_tiles);
 
     tilize_block(cb_in, NUM_TILES_IN_TILIZED_CHUNK, cb_out);
 
-    cb_push_back(cb_out, num_valid_tiles);
-    cb_pop_front(cb_in, NUM_TILES_IN_TILIZED_CHUNK);
+    cb_out_obj.push_back(num_valid_tiles);
+    cb_in_obj.pop_front(NUM_TILES_IN_TILIZED_CHUNK);
 
     tilize_uninit(cb_in, cb_out);
 }
 
 FORCE_INLINE void mul(uint32_t cb_a, uint32_t cb_b, uint32_t cb_out) {
+    CircularBuffer cb_a_obj(cb_a);
+    CircularBuffer cb_b_obj(cb_b);
+    CircularBuffer cb_out_obj(cb_out);
+
     reconfig_data_format(cb_a, cb_b);
     pack_reconfig_data_format(cb_out);
 
     mul_tiles_init(cb_a, cb_b);
 
-    cb_wait_front(cb_a, 1);
-    cb_wait_front(cb_b, 1);
-    cb_reserve_back(cb_out, 1);
+    cb_a_obj.wait_front(1);
+    cb_b_obj.wait_front(1);
+    cb_out_obj.reserve_back(1);
 
     tile_regs_acquire();
     mul_tiles(cb_a, cb_b, 0, 0, 0);
@@ -81,20 +92,24 @@ FORCE_INLINE void mul(uint32_t cb_a, uint32_t cb_b, uint32_t cb_out) {
     pack_tile(0, cb_out);
     tile_regs_release();
 
-    cb_push_back(cb_out, 1);
-    cb_pop_front(cb_a, 1);
-    cb_pop_front(cb_b, 1);
+    cb_out_obj.push_back(1);
+    cb_a_obj.pop_front(1);
+    cb_b_obj.pop_front(1);
 }
 
 FORCE_INLINE void sum(uint32_t cb_a, uint32_t cb_b, uint32_t cb_out) {
+    CircularBuffer cb_a_obj(cb_a);
+    CircularBuffer cb_b_obj(cb_b);
+    CircularBuffer cb_out_obj(cb_out);
+
     reconfig_data_format(cb_a, cb_b);
     pack_reconfig_data_format(cb_out);
 
     add_tiles_init(cb_a, cb_b);
 
-    cb_wait_front(cb_a, 1);
-    cb_wait_front(cb_b, 1);
-    cb_reserve_back(cb_out, 1);
+    cb_a_obj.wait_front(1);
+    cb_b_obj.wait_front(1);
+    cb_out_obj.reserve_back(1);
 
     tile_regs_acquire();
     add_tiles(cb_a, cb_b, 0, 0, 0);
@@ -103,19 +118,22 @@ FORCE_INLINE void sum(uint32_t cb_a, uint32_t cb_b, uint32_t cb_out) {
     pack_tile(0, cb_out);
     tile_regs_release();
 
-    cb_push_back(cb_out, 1);
-    cb_pop_front(cb_a, 1);
-    cb_pop_front(cb_b, 1);
+    cb_out_obj.push_back(1);
+    cb_a_obj.pop_front(1);
+    cb_b_obj.pop_front(1);
 }
 
 FORCE_INLINE void copy(uint32_t cb_in, uint32_t cb_out, uint32_t num_input_units = 1) {
+    CircularBuffer cb_in_obj(cb_in);
+    CircularBuffer cb_out_obj(cb_out);
+
     reconfig_data_format_srca(cb_in);
     pack_reconfig_data_format(cb_out);
 
     copy_tile_to_dst_init_short(cb_in);
 
-    cb_wait_front(cb_in, num_input_units);
-    cb_reserve_back(cb_out, 1);
+    cb_in_obj.wait_front(num_input_units);
+    cb_out_obj.reserve_back(1);
 
     tile_regs_acquire();
     copy_tile(cb_in, 0, 0);
@@ -125,7 +143,7 @@ FORCE_INLINE void copy(uint32_t cb_in, uint32_t cb_out, uint32_t num_input_units
     tile_regs_release();
 
     // Don't pop the copied tile - caller can do it
-    cb_push_back(cb_out, 1);
+    cb_out_obj.push_back(1);
 }
 
 FORCE_INLINE void compute_ht(
@@ -137,18 +155,20 @@ FORCE_INLINE void compute_ht(
     uint32_t cb_h,
     uint32_t cb_h_acc,
     uint32_t num_tiles) {
+    CircularBuffer cb_h_obj(cb_h);
+    CircularBuffer cb_h_prev_obj(cb_h_prev);
     for (uint32_t idx = 0; idx < num_tiles; idx++) {
         mul(cb_a, cb_h_prev, cb_ah);
         sum(cb_ah, cb_bx, cb_h);
         copy(cb_h, cb_h_prev);
         copy(cb_h, cb_out);  // TODO: Get rid of this extraneous copy
-        cb_pop_front(cb_h, 1);
+        cb_h_obj.pop_front(1);
     }
     copy(cb_h_prev, cb_h_acc);  // Store the last row of this tile for the next iteration
 
     // Make sure to remove the last hidden state
-    cb_wait_front(cb_h_prev, 1);
-    cb_pop_front(cb_h_prev, 1);
+    cb_h_prev_obj.wait_front(1);
+    cb_h_prev_obj.pop_front(1);
 }
 
 void kernel_main() {
@@ -169,6 +189,9 @@ void kernel_main() {
     const uint32_t total_tiles_per_col = get_arg_val<uint32_t>(2);
     const uint32_t num_chunks_per_row = get_arg_val<uint32_t>(3);
 
+    CircularBuffer cb_h_in_obj(cb_h_in);
+    CircularBuffer cb_h_acc_obj(cb_h_acc);
+
     binary_op_init_common(cb_a_in, cb_bx_in, cb_out);
     const uint32_t num_tiles_last_chunk = total_tiles_per_row % NUM_TILES_IN_TILIZED_CHUNK == 0
                                               ? NUM_TILES_IN_TILIZED_CHUNK
@@ -179,7 +202,7 @@ void kernel_main() {
         const uint32_t remaining_tiles_in_chunk =
             tilized_chunk_idx == num_chunks_per_row - 1 ? num_tiles_last_chunk : NUM_TILES_IN_TILIZED_CHUNK;
         copy(cb_h_in, cb_h_acc, remaining_tiles_in_chunk);
-        cb_pop_front(cb_h_in, remaining_tiles_in_chunk);
+        cb_h_in_obj.pop_front(remaining_tiles_in_chunk);
     }
 
     // For each row of tiles we want to tilize chunks of 32 tiles to pack the rows into tiles
@@ -187,7 +210,7 @@ void kernel_main() {
         for (uint32_t tilized_chunk_idx = 0; tilized_chunk_idx < num_chunks_per_row; tilized_chunk_idx++) {
             // Load the last row from the hidden state above this row
             copy(cb_h_acc, cb_h_prev);
-            cb_pop_front(cb_h_acc, 1);
+            cb_h_acc_obj.pop_front(1);
 
             // If we don't have a full chunk (NUM_TILES_IN_TILIZED_CHUNK tiles) we should figure out how many tiles we
             // have left. This only runs 2-3 tiles per shard so no need to unroll.

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/writer_ssm_prefix_scan.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/writer_ssm_prefix_scan.cpp
@@ -3,6 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 constexpr uint32_t NUM_TILES_IN_TILIZED_CHUNK = 32;
 constexpr uint32_t NUM_BYTES_IN_BFLOAT16 = 2;
@@ -10,6 +14,8 @@ constexpr uint32_t TILE_WIDTH = 32;
 constexpr uint32_t NUM_BYTES_IN_TILIZED_CHUNK = NUM_TILES_IN_TILIZED_CHUNK * TILE_WIDTH * NUM_BYTES_IN_BFLOAT16;
 
 void kernel_main() {
+    Noc noc;
+
     uint32_t num_tiles_per_core = get_arg_val<uint32_t>(0);
     const uint32_t hidden_state_len = get_arg_val<uint32_t>(1);
     const uint32_t h_shard_l1_addr = get_arg_val<uint32_t>(2);
@@ -17,13 +23,17 @@ void kernel_main() {
     constexpr uint32_t cb_out = get_compile_time_arg_val(0);
     constexpr uint32_t cb_h_acc = get_compile_time_arg_val(1);
 
+    CircularBuffer cb_out_obj(cb_out);
+    CircularBuffer cb_h_acc_obj(cb_h_acc);
+
     const uint32_t hidden_state_len_bytes = hidden_state_len * NUM_BYTES_IN_BFLOAT16;
 
-    cb_wait_front(cb_out, num_tiles_per_core);
+    cb_out_obj.wait_front(num_tiles_per_core);
 
     // Write accumulated hidden state back to the h_prev shard (in-place update)
-    uint32_t src_addr = get_read_ptr(cb_h_acc);
+    uint32_t src_addr = cb_h_acc_obj.get_read_ptr();
     uint64_t dst_addr = get_noc_addr(h_shard_l1_addr);
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
     noc_async_write(src_addr, dst_addr, hidden_state_len_bytes);
-    noc_async_write_barrier();
+    noc.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/reader_ssm_eltwise_mul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/reader_ssm_eltwise_mul.cpp
@@ -4,8 +4,13 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
+    Noc noc;
+
     uint32_t src0_addr = get_arg_val<uint32_t>(0);
     uint32_t src1_addr = get_arg_val<uint32_t>(1);
     uint32_t in1_num_blocks = get_arg_val<uint32_t>(2);
@@ -19,13 +24,19 @@ void kernel_main() {
     constexpr uint32_t cb_in1_transposed = get_compile_time_arg_val(2);
     constexpr uint32_t cb_in1_bcast_row = get_compile_time_arg_val(3);
 
-    uint32_t l1_write_addr_in0;
     constexpr auto src0_args = TensorAccessorArgs<4>();
     const auto s0 = TensorAccessor(src0_args, src0_addr);
 
-    uint32_t l1_write_addr_in1;
     constexpr auto src1_args = TensorAccessorArgs<src0_args.next_compile_time_args_offset()>();
     const auto s1 = TensorAccessor(src1_args, src1_addr);
+
+    CircularBuffer cb_in0(cb_id_in0);
+    CircularBuffer cb_in1(cb_id_in1);
+    CircularBuffer cb_in1_transposed_buf(cb_in1_transposed);
+    CircularBuffer cb_in1_bcast_row_buf(cb_in1_bcast_row);
+
+    const uint32_t in0_tile_bytes = get_tile_size(cb_id_in0);
+    const uint32_t in1_tile_bytes = get_tile_size(cb_id_in1);
 
     constexpr uint32_t onetile = 1;
     constexpr uint32_t num_rows_in_face = 16;
@@ -36,50 +47,58 @@ void kernel_main() {
     for (uint32_t block_h_id = 0; block_h_id < in1_num_blocks_h; block_h_id++) {
 #ifdef REPEAT_IN0
         // in0 only has one tile and read in only once
-        cb_reserve_back(cb_id_in0, onetile);
-        l1_write_addr_in0 = get_write_ptr(cb_id_in0);
-        noc_async_read_page(block_h_id, s0, l1_write_addr_in0);
-        noc_async_read_barrier();
-        cb_push_back(cb_id_in0, onetile);
+        cb_in0.reserve_back(onetile);
+        noc.async_read(s0, cb_in0, in0_tile_bytes, {.page_id = block_h_id, .offset_bytes = 0}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        cb_in0.push_back(onetile);
 #endif
 
         for (uint32_t i = in1_start_id; i < in1_start_id + in1_num_blocks; i++) {
-            cb_reserve_back(cb_id_in1, onetile);
-            l1_write_addr_in1 = get_write_ptr(cb_id_in1);
-            noc_async_read_page(block_h_id * in1_num_blocks_w + i, s1, l1_write_addr_in1);
+            cb_in1.reserve_back(onetile);
+            noc.async_read(
+                s1,
+                cb_in1,
+                in1_tile_bytes,
+                {.page_id = block_h_id * in1_num_blocks_w + i, .offset_bytes = 0},
+                {.offset_bytes = 0});
 
-            noc_async_read_barrier();
-            cb_push_back(cb_id_in1, onetile);
+            noc.async_read_barrier();
+            cb_in1.push_back(onetile);
 
 #ifdef REPEAT_INTERLEAVE_IN1
-            cb_wait_front(cb_in1_transposed, onetile);
-            uint64_t cb_in1_transposed_read_ptr = get_noc_addr(get_read_ptr(cb_in1_transposed));
+            cb_in1_transposed_buf.wait_front(onetile);
+            // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
+            uint64_t cb_in1_transposed_read_ptr = get_noc_addr(cb_in1_transposed_buf.get_read_ptr());
 
             // Manually unroll iterating across the tile to eliminate unnecessary conditional checking
             // First + second face
             for (uint32_t tile_row_id = 0; tile_row_id < num_rows_in_face; tile_row_id++) {
-                cb_reserve_back(cb_in1_bcast_row, onetile);
-                uint32_t cb_in1_bcast_row_write_ptr = get_write_ptr(cb_in1_bcast_row);
+                cb_in1_bcast_row_buf.reserve_back(onetile);
+                uint32_t cb_in1_bcast_row_write_ptr = cb_in1_bcast_row_buf.get_write_ptr();
 
 #ifndef REPEAT_IN0
-                cb_reserve_back(cb_id_in0, onetile);
-                l1_write_addr_in0 = get_write_ptr(cb_id_in0);
-                noc_async_read_page(
-                    block_h_id * in0_num_blocks_w + (i * in0_blocks_per_in1_block + tile_row_id),
+                cb_in0.reserve_back(onetile);
+                noc.async_read(
                     s0,
-                    l1_write_addr_in0);
+                    cb_in0,
+                    in0_tile_bytes,
+                    {.page_id = block_h_id * in0_num_blocks_w + (i * in0_blocks_per_in1_block + tile_row_id),
+                     .offset_bytes = 0},
+                    {.offset_bytes = 0});
 #endif
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
                 noc_async_read(cb_in1_transposed_read_ptr, cb_in1_bcast_row_write_ptr, bfloat16_one_row_in_face_bytes);
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
                 noc_async_read(
                     cb_in1_transposed_read_ptr + bfloat16_one_face_bytes,
                     cb_in1_bcast_row_write_ptr + bfloat16_one_face_bytes,
                     bfloat16_one_row_in_face_bytes);
-                noc_async_read_barrier();
+                noc.async_read_barrier();
 
 #ifndef REPEAT_IN0
-                cb_push_back(cb_id_in0, onetile);
+                cb_in0.push_back(onetile);
 #endif
-                cb_push_back(cb_in1_bcast_row, onetile);
+                cb_in1_bcast_row_buf.push_back(onetile);
 
                 cb_in1_transposed_read_ptr += bfloat16_one_row_in_face_bytes;
             }
@@ -87,30 +106,35 @@ void kernel_main() {
             cb_in1_transposed_read_ptr += bfloat16_one_face_bytes;
             // Third + fourth face
             for (uint32_t tile_row_id = num_rows_in_face; tile_row_id < 2 * num_rows_in_face; tile_row_id++) {
-                cb_reserve_back(cb_in1_bcast_row, onetile);
-                uint32_t cb_in1_bcast_row_write_ptr = get_write_ptr(cb_in1_bcast_row);
+                cb_in1_bcast_row_buf.reserve_back(onetile);
+                uint32_t cb_in1_bcast_row_write_ptr = cb_in1_bcast_row_buf.get_write_ptr();
 
 #ifndef REPEAT_IN0
-                cb_reserve_back(cb_id_in0, onetile);
-                l1_write_addr_in0 = get_write_ptr(cb_id_in0);
-                noc_async_read_page(
-                    block_h_id * 5120 + (i * in0_blocks_per_in1_block + tile_row_id), s0, l1_write_addr_in0);
+                cb_in0.reserve_back(onetile);
+                noc.async_read(
+                    s0,
+                    cb_in0,
+                    in0_tile_bytes,
+                    {.page_id = block_h_id * 5120 + (i * in0_blocks_per_in1_block + tile_row_id), .offset_bytes = 0},
+                    {.offset_bytes = 0});
 #endif
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
                 noc_async_read(cb_in1_transposed_read_ptr, cb_in1_bcast_row_write_ptr, bfloat16_one_row_in_face_bytes);
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
                 noc_async_read(
                     cb_in1_transposed_read_ptr + bfloat16_one_face_bytes,
                     cb_in1_bcast_row_write_ptr + bfloat16_one_face_bytes,
                     bfloat16_one_row_in_face_bytes);
-                noc_async_read_barrier();
+                noc.async_read_barrier();
 
 #ifndef REPEAT_IN0
-                cb_push_back(cb_id_in0, onetile);
+                cb_in0.push_back(onetile);
 #endif
-                cb_push_back(cb_in1_bcast_row, onetile);
+                cb_in1_bcast_row_buf.push_back(onetile);
 
                 cb_in1_transposed_read_ptr += bfloat16_one_row_in_face_bytes;
             }
-            cb_pop_front(cb_in1_transposed, onetile);
+            cb_in1_transposed_buf.pop_front(onetile);
 
 #endif
         }

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/ssm_eltwise_mul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/ssm_eltwise_mul.cpp
@@ -7,6 +7,7 @@
 #include "api/compute/bcast.h"
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/transpose_wh.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
     uint32_t in1_num_blocks = get_arg_val<uint32_t>(0);
@@ -30,10 +31,18 @@ void kernel_main() {
     binary_op_init_common(cb_id_in0, cb_id_in1, cb_id_out);
 #endif
 
+    CircularBuffer cb_in0(cb_id_in0);
+    CircularBuffer cb_in1(cb_id_in1);
+    CircularBuffer cb_out(cb_id_out);
+    CircularBuffer cb_in0_transposed_buf(cb_in0_transposed);
+    CircularBuffer cb_in1_transposed_buf(cb_in1_transposed);
+    CircularBuffer cb_in1_bcast_row_buf(cb_in1_bcast_row);
+    CircularBuffer cb_out_transposed_buf(cb_out_transposed);
+
     for (uint32_t block_h_id = 0; block_h_id < in1_num_blocks_h; block_h_id++) {
 #ifdef REPEAT_IN0
         // Transpose in0
-        cb_wait_front(cb_id_in0, onetile);
+        cb_in0.wait_front(onetile);
 // No need to transpose in0 if in1 is not repeat_interleaved
 #ifdef REPEAT_INTERLEAVE_IN1
         tile_regs_acquire();
@@ -44,21 +53,21 @@ void kernel_main() {
         pack_reconfig_data_format(cb_id_out, cb_in0_transposed);
         transpose_wh_tile(cb_id_in0, 0, 0);
 
-        cb_reserve_back(cb_in0_transposed, onetile);
+        cb_in0_transposed_buf.reserve_back(onetile);
         pack_tile(0, cb_in0_transposed);
 
         tile_regs_commit();
         tile_regs_release();
-        cb_push_back(cb_in0_transposed, onetile);
-        cb_pop_front(cb_id_in0, onetile);
+        cb_in0_transposed_buf.push_back(onetile);
+        cb_in0.pop_front(onetile);
 
-        cb_wait_front(cb_in0_transposed, onetile);
+        cb_in0_transposed_buf.wait_front(onetile);
 #endif
 #endif
 
         for (uint32_t in1_block = 0; in1_block < in1_num_blocks; in1_block++) {
             // Transpose in1
-            cb_wait_front(cb_id_in1, onetile);
+            cb_in1.wait_front(onetile);
             tile_regs_acquire();
             tile_regs_wait();
 
@@ -69,32 +78,32 @@ void kernel_main() {
             pack_reconfig_data_format(cb_in0_transposed, cb_id_out);
             mul_tiles(cb_id_in0, cb_id_in1, 0, 0, 0);
 
-            cb_reserve_back(cb_id_out, onetile);
+            cb_out.reserve_back(onetile);
             pack_tile(0, cb_id_out);
 
             tile_regs_commit();
             tile_regs_release();
-            cb_push_back(cb_id_out, onetile);
-            cb_pop_front(cb_id_in1, onetile);
+            cb_out.push_back(onetile);
+            cb_in1.pop_front(onetile);
 #else
             transpose_wh_init_short(cb_id_in1);
             reconfig_data_format_srca(cb_id_in1);
             pack_reconfig_data_format(cb_in1_transposed);
             transpose_wh_tile(cb_id_in1, 0, 0);
 
-            cb_reserve_back(cb_in1_transposed, onetile);
+            cb_in1_transposed_buf.reserve_back(onetile);
             pack_tile(0, cb_in1_transposed);
 
             tile_regs_commit();
             tile_regs_release();
-            cb_push_back(cb_in1_transposed, onetile);
-            cb_pop_front(cb_id_in1, onetile);
+            cb_in1_transposed_buf.push_back(onetile);
+            cb_in1.pop_front(onetile);
 
             // Receive in1 as single rows to bcast mul with in0
             for (uint32_t tile_row_id = 0; tile_row_id < num_rows_in_one_tile; tile_row_id++) {
 #ifndef REPEAT_IN0
                 // Transpose in0
-                cb_wait_front(cb_id_in0, onetile);
+                cb_in0.wait_front(onetile);
                 tile_regs_acquire();
                 tile_regs_wait();
 
@@ -103,18 +112,18 @@ void kernel_main() {
                 pack_reconfig_data_format(cb_in0_transposed);
                 transpose_wh_tile(cb_id_in0, 0, 0);
 
-                cb_reserve_back(cb_in0_transposed, onetile);
+                cb_in0_transposed_buf.reserve_back(onetile);
                 pack_tile(0, cb_in0_transposed);
 
                 tile_regs_commit();
                 tile_regs_release();
-                cb_push_back(cb_in0_transposed, onetile);
-                cb_pop_front(cb_id_in0, onetile);
+                cb_in0_transposed_buf.push_back(onetile);
+                cb_in0.pop_front(onetile);
 
-                cb_wait_front(cb_in0_transposed, onetile);
+                cb_in0_transposed_buf.wait_front(onetile);
 #endif
 
-                cb_wait_front(cb_in1_bcast_row, onetile);
+                cb_in1_bcast_row_buf.wait_front(onetile);
                 tile_regs_acquire();
                 tile_regs_wait();
 
@@ -123,19 +132,19 @@ void kernel_main() {
                 pack_reconfig_data_format(cb_out_transposed);
                 mul_tiles_bcast_rows(cb_in0_transposed, cb_in1_bcast_row, 0, 0, 0);
 
-                cb_reserve_back(cb_out_transposed, onetile);
+                cb_out_transposed_buf.reserve_back(onetile);
                 pack_tile(0, cb_out_transposed);
 
                 tile_regs_commit();
                 tile_regs_release();
-                cb_push_back(cb_out_transposed, onetile);
+                cb_out_transposed_buf.push_back(onetile);
 #ifndef REPEAT_IN0
-                cb_pop_front(cb_in0_transposed, onetile);
+                cb_in0_transposed_buf.pop_front(onetile);
 #endif
-                cb_pop_front(cb_in1_bcast_row, onetile);
+                cb_in1_bcast_row_buf.pop_front(onetile);
 
                 // Transpose output back
-                cb_wait_front(cb_out_transposed, onetile);
+                cb_out_transposed_buf.wait_front(onetile);
                 tile_regs_acquire();
                 tile_regs_wait();
 
@@ -144,13 +153,13 @@ void kernel_main() {
                 pack_reconfig_data_format(cb_out_transposed, cb_id_out);
                 transpose_wh_tile(cb_out_transposed, 0, 0);
 
-                cb_reserve_back(cb_id_out, onetile);
+                cb_out.reserve_back(onetile);
                 pack_tile(0, cb_id_out);
 
                 tile_regs_commit();
                 tile_regs_release();
-                cb_push_back(cb_id_out, onetile);
-                cb_pop_front(cb_out_transposed, onetile);
+                cb_out.push_back(onetile);
+                cb_out_transposed_buf.pop_front(onetile);
 
                 /* TODO: Transpose directly on tiles in DST; is something like this possible?
                 cb_reserve_back(cb_id_out, onetile);
@@ -172,14 +181,14 @@ void kernel_main() {
                 */
             }
 
-            cb_pop_front(cb_in1_transposed, onetile);
+            cb_in1_transposed_buf.pop_front(onetile);
 #endif
         }
 #ifdef REPEAT_IN0
 #ifdef REPEAT_INTERLEAVE_IN1
-        cb_pop_front(cb_in0_transposed, onetile);
+        cb_in0_transposed_buf.pop_front(onetile);
 #else
-        cb_pop_front(cb_id_in0, onetile);
+        cb_in0.pop_front(onetile);
 #endif
 #endif
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/writer_ssm_eltwise_mul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/writer_ssm_eltwise_mul.cpp
@@ -3,8 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
+    Noc noc;
+
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
     uint32_t out_num_blocks_w_per_core = get_arg_val<uint32_t>(1);
     uint32_t start_id = get_arg_val<uint32_t>(2);
@@ -15,17 +20,24 @@ void kernel_main() {
 
     // single-tile ublocks
     constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes = get_tile_size(cb_id_out);
     constexpr auto dst_args = TensorAccessorArgs<1>();
     const auto s = TensorAccessor(dst_args, dst_addr);
+
+    CircularBuffer cb_out(cb_id_out);
 
     for (uint32_t block_h_id = 0; block_h_id < out_num_blocks_h; block_h_id++) {
         uint32_t end_id = start_id + out_num_blocks_w_per_core;
         for (uint32_t i = start_id; i < end_id; ++i) {
-            cb_wait_front(cb_id_out, onetile);
-            uint32_t l1_read_addr = get_read_ptr(cb_id_out);
-            noc_async_write_page((block_h_id * out_total_blocks_w) + i, s, l1_read_addr);
-            noc_async_write_barrier();
-            cb_pop_front(cb_id_out, onetile);
+            cb_out.wait_front(onetile);
+            noc.async_write(
+                cb_out,
+                s,
+                tile_bytes,
+                {.offset_bytes = 0},
+                {.page_id = (block_h_id * out_total_blocks_w) + i, .offset_bytes = 0});
+            noc.async_write_barrier();
+            cb_out.pop_front(onetile);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/kernels/compute/eltwise_bw_gelu_approx_tanh.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/kernels/compute/eltwise_bw_gelu_approx_tanh.cpp
@@ -15,6 +15,7 @@
 #include "api/compute/compute_kernel_api.h"
 #include "api/compute/copy_dest_values.h"
 #include "api/compute/eltwise_unary/fill.h"
+#include "api/dataflow/circular_buffer.h"
 
 #define M_SQRT2 1.41421356237309504880f    /* sqrt(2) */
 #define M_2_SQRTPI 1.12837916709551257390f /* 2/sqrt(pi) */
@@ -25,6 +26,10 @@ void kernel_main() {
     constexpr auto cb_grad_out = tt::CBIndex::c_0;
     constexpr auto cb_input = tt::CBIndex::c_1;
     constexpr auto cb_grad_in = tt::CBIndex::c_2;
+
+    CircularBuffer cb_grad_out_cb(cb_grad_out);
+    CircularBuffer cb_input_cb(cb_input);
+    CircularBuffer cb_grad_in_cb(cb_grad_in);
 
     constexpr float kBeta = M_SQRT2 * M_2_SQRTPI * 0.5;
     constexpr float kKappa = 0.044715;
@@ -37,9 +42,9 @@ void kernel_main() {
     sub_binary_tile_init();
 
     for (uint32_t i = 0; i < num_tiles; ++i) {
-        cb_reserve_back(cb_grad_in, 1);
-        cb_wait_front(cb_grad_out, 1);
-        cb_wait_front(cb_input, 1);
+        cb_grad_in_cb.reserve_back(1);
+        cb_grad_out_cb.wait_front(1);
+        cb_input_cb.wait_front(1);
 
         tile_regs_acquire();
 
@@ -108,8 +113,8 @@ void kernel_main() {
 
         tile_regs_release();
 
-        cb_pop_front(cb_grad_out, 1);
-        cb_pop_front(cb_input, 1);
-        cb_push_back(cb_grad_in, 1);
+        cb_grad_out_cb.pop_front(1);
+        cb_input_cb.pop_front(1);
+        cb_grad_in_cb.push_back(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/kernels/compute/eltwise_bw_gelu_poly.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/kernels/compute/eltwise_bw_gelu_poly.cpp
@@ -16,6 +16,7 @@
 #include "api/compute/binary_shift.h"
 #include "api/compute/compute_kernel_api.h"
 #include "api/compute/eltwise_unary/gelu.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
@@ -24,14 +25,18 @@ void kernel_main() {
     constexpr auto cb_input = tt::CBIndex::c_1;
     constexpr auto cb_grad_in = tt::CBIndex::c_2;
 
+    CircularBuffer cb_grad_out_cb(cb_grad_out);
+    CircularBuffer cb_input_cb(cb_input);
+    CircularBuffer cb_grad_in_cb(cb_grad_in);
+
     unary_op_init_common(cb_grad_out, cb_grad_in);
     gelu_derivative_tile_init<false>();
     mul_binary_tile_init();
 
     for (uint32_t i = 0; i < num_tiles; ++i) {
-        cb_reserve_back(cb_grad_in, 1);
-        cb_wait_front(cb_grad_out, 1);
-        cb_wait_front(cb_input, 1);
+        cb_grad_in_cb.reserve_back(1);
+        cb_grad_out_cb.wait_front(1);
+        cb_input_cb.wait_front(1);
 
         tile_regs_acquire();
 
@@ -47,8 +52,8 @@ void kernel_main() {
 
         tile_regs_release();
 
-        cb_pop_front(cb_grad_out, 1);
-        cb_pop_front(cb_input, 1);
-        cb_push_back(cb_grad_in, 1);
+        cb_grad_out_cb.pop_front(1);
+        cb_input_cb.pop_front(1);
+        cb_grad_in_cb.push_back(1);
     }
 }


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

Contributes to #45003. Migrates the eltwise / conv / ssm small ops under `experimental/` onto the Device 2.0 kernel API (dataflow + compute):
- `cnn/convert_to_chw` and `cnn/convert_to_hwc` (2 files)
- `conv3d` (1 file: compute, partial-D2 with matmul preserved)
- `dropout` (3 files: compute + reader + writer)
- `isin/isin_common.hpp` (1 header-only shared file; includers unchanged)
- `ssm/hc_sum_reduce` (3 files: reader + compute + writer)
- `ssm/prefix_scan` (2 files: compute + writer)
- `ssm/repeat_and_interleave_eltwise_mul` (3 files: reader + compute + writer)
- `unary_backward/gelu_backward` (2 files: 2 pure-CB compute kernels)

Total: 17 files, +379/-196.

### Notes for reviewers


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/experimental-d2-eltwise-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/experimental-d2-eltwise-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/experimental-d2-eltwise-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/experimental-d2-eltwise-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/experimental-d2-eltwise-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/experimental-d2-eltwise-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/experimental-d2-eltwise-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/experimental-d2-eltwise-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/experimental-d2-eltwise-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/experimental-d2-eltwise-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/experimental-d2-eltwise-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/experimental-d2-eltwise-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/experimental-d2-eltwise-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/experimental-d2-eltwise-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/experimental-d2-eltwise-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/experimental-d2-eltwise-small)
