### PR TITLE
#47586: Fix up moreh op tensor buffer usage

### DIFF
--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_program_factory.cpp
@@ -305,13 +305,18 @@ ProgramDescriptor MorehGroupNormOperation::create_descriptor(
     ////////////////////////////////////////////////////////////////////////////
     //                      RuntimeArgs SetUp
     ////////////////////////////////////////////////////////////////////////////
+    // Pass tensor buffers as Buffer* (not raw ->address()) so the ProgramDescriptor framework
+    // registers them as buffer bindings and patches their addresses on program-cache hits. A raw
+    // address would be baked in on first dispatch and go stale when the tensor is reallocated.
+    // gamma/beta are input tensors and mean/rstd are output tensors of this op, so binding them is
+    // allowed by the framework. nullptr is fine for an absent optional (its CB/CT-arg is disabled).
     auto* const input_buf = input.buffer();
     auto* const output_buf = output.buffer();
-    const uint32_t mean_addr = mean_has_value ? mean.value().buffer()->address() : 0u;
-    const uint32_t rstd_addr = rstd_has_value ? rstd.value().buffer()->address() : 0u;
+    auto* const mean_buf = mean_has_value ? mean.value().buffer() : nullptr;
+    auto* const rstd_buf = rstd_has_value ? rstd.value().buffer() : nullptr;
 
-    const uint32_t gamma_addr = gamma_has_value ? gamma.value().buffer()->address() : 0u;
-    const uint32_t beta_addr = beta_has_value ? beta.value().buffer()->address() : 0u;
+    auto* const gamma_buf = gamma_has_value ? gamma.value().buffer() : nullptr;
+    auto* const beta_buf = beta_has_value ? beta.value().buffer() : nullptr;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores_to_be_used; ++i) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
@@ -325,17 +330,16 @@ ProgramDescriptor MorehGroupNormOperation::create_descriptor(
             TT_THROW("Core not in specified core ranges.");
         }
 
-        // BufferBinding fast cache-hit path is safe here because eps and the optional
-        // tensor presence flags are in compute_program_hash above — a cache hit
-        // guarantees identical attrs, so re-running create_descriptor() would just
-        // produce the same scalar values. The framework's fast path patches only the
-        // input/output buffer addresses (the only thing that legitimately changes
-        // call-to-call when the cache hits).
+        // On a program-cache hit the framework skips create_descriptor() and patches only the
+        // registered buffer bindings. The presence flags / eps being in the hash only guarantees
+        // identical SCALAR args — it does NOT keep the gamma/beta buffer addresses fresh. Those
+        // tensors can be reallocated call-to-call, so they must be bound as Buffer* (above) to be
+        // re-patched, not baked in as raw addresses.
         reader_desc.emplace_runtime_args(
             core,
             {input_buf,
-             gamma_addr,
-             beta_addr,
+             gamma_buf,
+             beta_buf,
              std::bit_cast<uint32_t>(scaler),
              std::bit_cast<uint32_t>(eps),
              tile_offset,
@@ -346,17 +350,10 @@ ProgramDescriptor MorehGroupNormOperation::create_descriptor(
              origin_w,
              block_size});
 
-        // writer
+        // writer — mean/rstd bound as Buffer* for the same cache-hit reason as gamma/beta above.
         writer_desc.emplace_runtime_args(
             core,
-            {output_buf,
-             mean_addr,
-             rstd_addr,
-             tile_offset,
-             num_rows_per_core,
-             num_inner_tiles,
-             num_groups,
-             block_size});
+            {output_buf, mean_buf, rstd_buf, tile_offset, num_rows_per_core, num_inner_tiles, num_groups, block_size});
 
         tile_offset += num_rows_per_core * num_inner_tiles;
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_program_factory.cpp
@@ -355,10 +355,16 @@ tt::tt_metal::ProgramDescriptor MorehLayerNormOperation::ProgramFactory::create_
     auto* const input_buf = input.buffer();
     auto* const output_buf = output->buffer();
 
-    const auto gamma_addr = gamma_has_value ? gamma.value().buffer()->address() : 0u;
-    const auto beta_addr = beta_has_value ? beta.value().buffer()->address() : 0u;
-    const auto mean_addr = mean_has_value ? mean.value().buffer()->address() : 0u;
-    const auto rstd_addr = rstd_has_value ? rstd.value().buffer()->address() : 0u;
+    // Pass tensor buffers as Buffer* (nullptr when the optional is absent) so the
+    // ProgramDescriptor framework registers them as BufferBindings and patches their
+    // addresses on program-cache hits. Raw uint32_t addresses here would be baked in on
+    // the first dispatch and go stale once these tensors are reallocated on a later call,
+    // because the presence of the input/output Buffer* bindings already puts this op on
+    // the fast cache-hit path (which skips create_descriptor() and only patches bindings).
+    auto* const gamma_buf = gamma_has_value ? gamma.value().buffer() : nullptr;
+    auto* const beta_buf = beta_has_value ? beta.value().buffer() : nullptr;
+    auto* const mean_buf = mean_has_value ? mean.value().buffer() : nullptr;
+    auto* const rstd_buf = rstd_has_value ? rstd.value().buffer() : nullptr;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; ++i) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
@@ -374,22 +380,13 @@ tt::tt_metal::ProgramDescriptor MorehLayerNormOperation::ProgramFactory::create_
 
         reader_desc.emplace_runtime_args(
             core,
-            {input_buf,
-             gamma_addr,
-             beta_addr,
-             num_rows_per_core,
-             num_inner,
-             tile_offset,
-             scaler_u,
-             e_u,
-             mask_h,
-             mask_w});
+            {input_buf, gamma_buf, beta_buf, num_rows_per_core, num_inner, tile_offset, scaler_u, e_u, mask_h, mask_w});
 
         writer_desc.emplace_runtime_args(
             core,
             {output_buf,
-             mean_addr,
-             rstd_addr,
+             mean_buf,
+             rstd_buf,
              num_rows_per_core,
              num_inner,
              tile_offset,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_program_factory.cpp
@@ -245,8 +245,11 @@ MorehLayerNormBackwardGammaBetaGradOperation::MorehLayerNormBackwardGammaBetaGra
     auto* const mean_buf = mean.buffer();
     auto* const rstd_buf = rstd.buffer();
 
-    const auto gamma_grad_addr = gamma_grad_has_value ? gamma_grad.value().buffer()->address() : 0u;
-    const auto beta_grad_addr = beta_grad_has_value ? beta_grad.value().buffer()->address() : 0u;
+    // Pass the output grad tensors as Buffer* (not raw ->address()) so the program-cache fast hit
+    // path patches their addresses when they are reallocated across calls. nullptr is valid for an
+    // absent optional output.
+    auto* const gamma_grad_buf = gamma_grad_has_value ? gamma_grad.value().buffer() : nullptr;
+    auto* const beta_grad_buf = beta_grad_has_value ? beta_grad.value().buffer() : nullptr;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; ++i) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
@@ -275,7 +278,7 @@ MorehLayerNormBackwardGammaBetaGradOperation::MorehLayerNormBackwardGammaBetaGra
              mean_rstd_height,
              mean_rstd_width});
 
-        writer_desc.emplace_runtime_args(core, {gamma_grad_addr, beta_grad_addr, num_cols_per_core, tile_offset});
+        writer_desc.emplace_runtime_args(core, {gamma_grad_buf, beta_grad_buf, num_cols_per_core, tile_offset});
 
         tile_offset += num_cols_per_core;
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_program_factory.cpp
@@ -284,7 +284,9 @@ MorehLayerNormBackwardInputGradOperation::MorehLayerNormBackwardInputGradFactory
     auto* const mean_buf = mean.buffer();
     auto* const rstd_buf = rstd.buffer();
 
-    const auto gamma_addr = gamma_has_value ? gamma.value().buffer()->address() : 0u;
+    // Pass gamma as Buffer* (not raw ->address()) so the program-cache fast hit path patches its
+    // address when gamma is reallocated across calls. nullptr is valid for the absent optional.
+    auto* const gamma_buf = gamma_has_value ? gamma.value().buffer() : nullptr;
 
     auto* const input_grad_buf = input_grad.buffer();
 
@@ -309,7 +311,7 @@ MorehLayerNormBackwardInputGradOperation::MorehLayerNormBackwardInputGradFactory
              input_buf,
              mean_buf,
              rstd_buf,
-             gamma_addr,
+             gamma_buf,
              num_rows_per_core,
              num_inner,
              tile_offset,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_program_factory.cpp
@@ -449,10 +449,10 @@ tt::tt_metal::ProgramDescriptor MorehMatmulOperation::MultiCoreProgramFactory::c
     ////////////////////////////////////////////////////////////////////////////
     //                      RuntimeArgs SetUp
     ////////////////////////////////////////////////////////////////////////////
-    const uint32_t input_addr = input.buffer()->address();
-    const uint32_t other_addr = other.buffer()->address();
+    auto* const input_buf = input.buffer();
+    auto* const other_buf = other.buffer();
     auto* const output_buf = output.buffer();
-    const uint32_t bias_addr = bias.has_value() ? bias.value().buffer()->address() : 0u;
+    auto* const bias_buf = bias.has_value() ? bias.value().buffer() : nullptr;
 
     for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
@@ -474,25 +474,27 @@ tt::tt_metal::ProgramDescriptor MorehMatmulOperation::MultiCoreProgramFactory::c
             TT_THROW("Core not in specified core ranges");
         }
 
-        std::vector<uint32_t> reader_rt_args;
-        reader_rt_args.push_back(input_addr);
-        reader_rt_args.push_back(other_addr);
+        // Pass buffers as Buffer* so the ProgramDescriptor framework registers them as
+        // BufferBindings and patches their addresses on program-cache hits. Raw uint32_t
+        // addresses would be baked in once and go stale when inputs are reallocated.
+        KernelDescriptor::RTArgList reader_rt_args;
+        reader_rt_args.push_back(input_buf);
+        reader_rt_args.push_back(other_buf);
         reader_rt_args.push_back(num_tiles_written);
         reader_rt_args.push_back(num_output_tiles_per_core);
 
         // TODO: move some to compile args
-        reader_rt_args.insert(reader_rt_args.end(), input_stride.begin(), input_stride.end());
-        reader_rt_args.insert(reader_rt_args.end(), other_stride.begin(), other_stride.end());
-        reader_rt_args.insert(reader_rt_args.end(), output_stride.begin(), output_stride.end());
-        reader_rt_args.insert(reader_rt_args.end(), input_not_bcast.begin(), input_not_bcast.end());
-        reader_rt_args.insert(reader_rt_args.end(), other_not_bcast.begin(), other_not_bcast.end());
+        reader_rt_args.append(std::vector<uint32_t>(input_stride.begin(), input_stride.end()));
+        reader_rt_args.append(std::vector<uint32_t>(other_stride.begin(), other_stride.end()));
+        reader_rt_args.append(std::vector<uint32_t>(output_stride.begin(), output_stride.end()));
+        reader_rt_args.append(std::vector<uint32_t>(input_not_bcast.begin(), input_not_bcast.end()));
+        reader_rt_args.append(std::vector<uint32_t>(other_not_bcast.begin(), other_not_bcast.end()));
 
         if (bias.has_value()) {
-            reader_rt_args.push_back(bias_addr);
+            reader_rt_args.push_back(bias_buf);
         }
 
-        reader_desc.runtime_args.emplace_back(
-            core, KernelDescriptor::CoreRuntimeArgs(reader_rt_args.begin(), reader_rt_args.end()));
+        reader_desc.emplace_runtime_args(core, reader_rt_args);
 
         writer_desc.emplace_runtime_args(core, {output_buf, num_tiles_written, num_output_tiles_per_core});
         num_tiles_written += num_output_tiles_per_core;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/moreh_nll_loss_step1_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/moreh_nll_loss_step1_program_factory.cpp
@@ -181,7 +181,9 @@ tt::tt_metal::ProgramDescriptor MorehNllLossStep1DeviceOperation::Factory::creat
     writer_desc.config = WriterConfigDescriptor{};
 
     auto* const target_buf = target.buffer();
-    const auto weight_addr = weight_has_value ? weight.value().buffer()->address() : 0u;
+    // Pass Buffer* (not a raw address) so the program-cache fast hit path re-patches the binding
+    // when the tensor is reallocated; nullptr is fine for an absent optional (framework emits 0u).
+    auto* const weight_buf = weight_has_value ? weight.value().buffer() : nullptr;
     auto* const output_buf = output.buffer();
 
     // Set Runtime Args
@@ -202,7 +204,7 @@ tt::tt_metal::ProgramDescriptor MorehNllLossStep1DeviceOperation::Factory::creat
             core,
             {
                 target_buf,
-                weight_addr,
+                weight_buf,
                 static_cast<uint32_t>(ignore_index),
                 num_units_per_core,
                 tile_offset,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/moreh_nll_loss_step2_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/moreh_nll_loss_step2_program_factory.cpp
@@ -189,8 +189,10 @@ tt::tt_metal::ProgramDescriptor moreh_nll_loss_step2_impl_2d(
 
     auto* const input_buf = input.buffer();
     auto* const target_buf = target.buffer();
-    const auto weight_addr = weight_has_value ? weight.value().buffer()->address() : 0u;
-    const auto divisor_addr = divisor_has_value ? divisor.value().buffer()->address() : 0u;
+    // Pass Buffer* (not a raw address) so the program-cache fast hit path re-patches the binding
+    // when the tensor is reallocated; nullptr is fine for an absent optional (framework emits 0u).
+    auto* const weight_buf = weight_has_value ? weight.value().buffer() : nullptr;
+    auto* const divisor_buf = divisor_has_value ? divisor.value().buffer() : nullptr;
     auto* const output_buf = output.buffer();
 
     // Set Runtime Args
@@ -210,8 +212,8 @@ tt::tt_metal::ProgramDescriptor moreh_nll_loss_step2_impl_2d(
             {
                 input_buf,
                 target_buf,
-                weight_addr,
-                divisor_addr,
+                weight_buf,
+                divisor_buf,
                 static_cast<uint32_t>(ignore_index),
                 units_per_core,
                 tile_offset,
@@ -398,8 +400,10 @@ tt::tt_metal::ProgramDescriptor moreh_nll_loss_step2_impl_3d(
 
     auto* const input_buf = input.buffer();
     auto* const target_buf = target.buffer();
-    const auto weight_addr = weight_has_value ? weight.value().buffer()->address() : 0u;
-    const auto divisor_addr = divisor_has_value ? divisor.value().buffer()->address() : 0u;
+    // Pass Buffer* (not a raw address) so the program-cache fast hit path re-patches the binding
+    // when the tensor is reallocated; nullptr is fine for an absent optional (framework emits 0u).
+    auto* const weight_buf = weight_has_value ? weight.value().buffer() : nullptr;
+    auto* const divisor_buf = divisor_has_value ? divisor.value().buffer() : nullptr;
     auto* const output_buf = output.buffer();
 
     // Set Runtime Args
@@ -419,8 +423,8 @@ tt::tt_metal::ProgramDescriptor moreh_nll_loss_step2_impl_3d(
             {
                 input_buf,
                 target_buf,
-                weight_addr,
-                divisor_addr,
+                weight_buf,
+                divisor_buf,
                 static_cast<uint32_t>(ignore_index),
                 units_per_core,
                 tile_offset,
@@ -626,8 +630,10 @@ tt::tt_metal::ProgramDescriptor moreh_nll_loss_step2_impl_4d(
 
     auto* const input_buf = input.buffer();
     auto* const target_buf = target.buffer();
-    const auto weight_addr = weight_has_value ? weight.value().buffer()->address() : 0u;
-    const auto divisor_addr = divisor_has_value ? divisor.value().buffer()->address() : 0u;
+    // Pass Buffer* (not a raw address) so the program-cache fast hit path re-patches the binding
+    // when the tensor is reallocated; nullptr is fine for an absent optional (framework emits 0u).
+    auto* const weight_buf = weight_has_value ? weight.value().buffer() : nullptr;
+    auto* const divisor_buf = divisor_has_value ? divisor.value().buffer() : nullptr;
     auto* const output_buf = output.buffer();
 
     // Set Runtime Args
@@ -647,8 +653,8 @@ tt::tt_metal::ProgramDescriptor moreh_nll_loss_step2_impl_4d(
             {
                 input_buf,
                 target_buf,
-                weight_addr,
-                divisor_addr,
+                weight_buf,
+                divisor_buf,
                 static_cast<uint32_t>(ignore_index),
                 units_per_core,
                 tile_offset,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/moreh_nll_loss_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/moreh_nll_loss_backward_program_factory.cpp
@@ -194,8 +194,10 @@ tt::tt_metal::ProgramDescriptor moreh_nll_loss_backward_impl_2d(
     }
 
     auto* const target_buf = target.buffer();
-    const auto weight_addr = weight_has_value ? weight.value().buffer()->address() : 0u;
-    const auto divisor_addr = divisor_has_value ? divisor.value().buffer()->address() : 0u;
+    // Pass Buffer* (not a raw address) so the program-cache fast hit path re-patches the binding
+    // when the tensor is reallocated; nullptr is fine for an absent optional (framework emits 0u).
+    auto* const weight_buf = weight_has_value ? weight.value().buffer() : nullptr;
+    auto* const divisor_buf = divisor_has_value ? divisor.value().buffer() : nullptr;
     auto* const output_grad_buf = output_grad.buffer();
     auto* const input_grad_buf = input_grad.buffer();
 
@@ -218,8 +220,8 @@ tt::tt_metal::ProgramDescriptor moreh_nll_loss_backward_impl_2d(
             {
                 target_buf,
                 output_grad_buf,
-                weight_addr,
-                divisor_addr,
+                weight_buf,
+                divisor_buf,
                 ignore_index,
                 units_per_core,
                 tile_offset,
@@ -406,8 +408,10 @@ tt::tt_metal::ProgramDescriptor moreh_nll_loss_backward_impl_3d(
     }
 
     auto* const target_buf = target.buffer();
-    const auto weight_addr = weight_has_value ? weight.value().buffer()->address() : 0u;
-    const auto divisor_addr = divisor_has_value ? divisor.value().buffer()->address() : 0u;
+    // Pass Buffer* (not a raw address) so the program-cache fast hit path re-patches the binding
+    // when the tensor is reallocated; nullptr is fine for an absent optional (framework emits 0u).
+    auto* const weight_buf = weight_has_value ? weight.value().buffer() : nullptr;
+    auto* const divisor_buf = divisor_has_value ? divisor.value().buffer() : nullptr;
     auto* const output_grad_buf = output_grad.buffer();
     auto* const input_grad_buf = input_grad.buffer();
 
@@ -430,8 +434,8 @@ tt::tt_metal::ProgramDescriptor moreh_nll_loss_backward_impl_3d(
             {
                 target_buf,
                 output_grad_buf,
-                weight_addr,
-                divisor_addr,
+                weight_buf,
+                divisor_buf,
                 ignore_index,
                 units_per_core,
                 tile_offset,
@@ -621,8 +625,10 @@ tt::tt_metal::ProgramDescriptor moreh_nll_loss_backward_impl_4d(
     }
 
     auto* const target_buf = target.buffer();
-    const auto weight_addr = weight_has_value ? weight.value().buffer()->address() : 0u;
-    const auto divisor_addr = divisor_has_value ? divisor.value().buffer()->address() : 0u;
+    // Pass Buffer* (not a raw address) so the program-cache fast hit path re-patches the binding
+    // when the tensor is reallocated; nullptr is fine for an absent optional (framework emits 0u).
+    auto* const weight_buf = weight_has_value ? weight.value().buffer() : nullptr;
+    auto* const divisor_buf = divisor_has_value ? divisor.value().buffer() : nullptr;
     auto* const output_grad_buf = output_grad.buffer();
     auto* const input_grad_buf = input_grad.buffer();
 
@@ -645,8 +651,8 @@ tt::tt_metal::ProgramDescriptor moreh_nll_loss_backward_impl_4d(
             {
                 target_buf,
                 output_grad_buf,
-                weight_addr,
-                divisor_addr,
+                weight_buf,
+                divisor_buf,
                 ignore_index,
                 units_per_core,
                 tile_offset,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_program_factory.cpp
@@ -129,7 +129,9 @@ tt::tt_metal::ProgramDescriptor moreh_nll_loss_unreduced_backward_impl_2d(
     writer_desc.config = WriterConfigDescriptor{};
 
     auto* const target_buf = target.buffer();
-    const auto weight_addr = weight_has_value ? weight.value().buffer()->address() : 0u;
+    // Pass Buffer* (not a raw address) so the program-cache fast hit path re-patches the binding
+    // when the tensor is reallocated; nullptr is fine for an absent optional (framework emits 0u).
+    auto* const weight_buf = weight_has_value ? weight.value().buffer() : nullptr;
     auto* const output_grad_buf = output_grad.buffer();
     auto* const input_grad_buf = input_grad.buffer();
 
@@ -150,7 +152,7 @@ tt::tt_metal::ProgramDescriptor moreh_nll_loss_unreduced_backward_impl_2d(
             {
                 target_buf,
                 output_grad_buf,
-                weight_addr,
+                weight_buf,
                 ignore_index,
                 units_per_core,
                 tile_offset,
@@ -257,7 +259,9 @@ tt::tt_metal::ProgramDescriptor moreh_nll_loss_unreduced_backward_impl_3d(
 
     auto* const target_buf = target.buffer();
     auto* const output_grad_buf = output_grad.buffer();
-    const auto weight_addr = weight_has_value ? weight.value().buffer()->address() : 0u;
+    // Pass Buffer* (not a raw address) so the program-cache fast hit path re-patches the binding
+    // when the tensor is reallocated; nullptr is fine for an absent optional (framework emits 0u).
+    auto* const weight_buf = weight_has_value ? weight.value().buffer() : nullptr;
     auto* const input_grad_buf = input_grad.buffer();
 
     // Set Runtime Args
@@ -277,7 +281,7 @@ tt::tt_metal::ProgramDescriptor moreh_nll_loss_unreduced_backward_impl_3d(
             {
                 target_buf,
                 output_grad_buf,
-                weight_addr,
+                weight_buf,
                 ignore_index,
                 units_per_core,
                 tile_offset,
@@ -387,7 +391,9 @@ tt::tt_metal::ProgramDescriptor moreh_nll_loss_unreduced_backward_impl_4d(
 
     auto* const target_buf = target.buffer();
     auto* const output_grad_buf = output_grad.buffer();
-    const auto weight_addr = weight_has_value ? weight.value().buffer()->address() : 0u;
+    // Pass Buffer* (not a raw address) so the program-cache fast hit path re-patches the binding
+    // when the tensor is reallocated; nullptr is fine for an absent optional (framework emits 0u).
+    auto* const weight_buf = weight_has_value ? weight.value().buffer() : nullptr;
     auto* const input_grad_buf = input_grad.buffer();
 
     // Set Runtime Args
@@ -407,7 +413,7 @@ tt::tt_metal::ProgramDescriptor moreh_nll_loss_unreduced_backward_impl_4d(
             {
                 target_buf,
                 output_grad_buf,
-                weight_addr,
+                weight_buf,
                 ignore_index,
                 units_per_core,
                 tile_offset,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_program_factory.cpp
@@ -249,18 +249,20 @@ ProgramDescriptor MorehNormBackwardOperation::create_descriptor(
         }
 
         // reader
-        KernelDescriptor::CoreRuntimeArgs reader_rt_args{
-            input.buffer()->address(),
-            output.buffer()->address(),
-            output_grad.buffer()->address(),
-            *reinterpret_cast<uint32_t*>(&decimal),
-            num_tiles_per_core,
-            tile_offset};
-        reader_rt_args.insert(reader_rt_args.end(), output_grad_dim.begin(), output_grad_dim.end());
-        reader_rt_args.insert(reader_rt_args.end(), input_grad_dim.begin(), input_grad_dim.end());
-        reader_rt_args.insert(reader_rt_args.end(), need_bcast_dim.begin(), need_bcast_dim.end());
+        // Pass tensor base addresses as Buffer* (not raw ->address()) so the program-cache fast
+        // hit path patches them when these tensors are reallocated across calls.
+        KernelDescriptor::RTArgList reader_rt_args;
+        reader_rt_args.push_back(input.buffer());
+        reader_rt_args.push_back(output.buffer());
+        reader_rt_args.push_back(output_grad.buffer());
+        reader_rt_args.push_back(*reinterpret_cast<uint32_t*>(&decimal));
+        reader_rt_args.push_back(num_tiles_per_core);
+        reader_rt_args.push_back(tile_offset);
+        reader_rt_args.append(std::vector<uint32_t>(output_grad_dim.begin(), output_grad_dim.end()));
+        reader_rt_args.append(std::vector<uint32_t>(input_grad_dim.begin(), input_grad_dim.end()));
+        reader_rt_args.append(std::vector<uint32_t>(need_bcast_dim.begin(), need_bcast_dim.end()));
 
-        reader_desc.runtime_args.emplace_back(core, std::move(reader_rt_args));
+        reader_desc.emplace_runtime_args(core, reader_rt_args);
 
         // writer
         writer_desc.emplace_runtime_args(core, {input_grad.buffer(), num_tiles_per_core, tile_offset});

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/moreh_sgd_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/moreh_sgd_program_factory.cpp
@@ -245,6 +245,13 @@ ProgramDescriptor MorehSgdOperation::create_descriptor(
     const uint32_t u_weight_decay = std::bit_cast<uint32_t>(weight_decay);
     const uint32_t u_one = std::bit_cast<uint32_t>(1.0f);
 
+    // Pass optional tensor buffers as Buffer* (not raw ->address()) so the framework registers them
+    // as buffer bindings and re-patches their addresses on program-cache hits. momentum_buffer_in is
+    // an input tensor and momentum_buffer_out is an output tensor of this op, so binding them is
+    // allowed. nullptr is fine when the optional is absent (the kernel is compiled without it).
+    auto* const momentum_in_buf = momentum_buffer_in.has_value() ? momentum_buffer_in.value().buffer() : nullptr;
+    auto* const momentum_out_buf = momentum_buffer_out.has_value() ? momentum_buffer_out.value().buffer() : nullptr;
+
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h, i % core_h};
         uint32_t num_tiles_per_core;
@@ -260,7 +267,7 @@ ProgramDescriptor MorehSgdOperation::create_descriptor(
             core,
             {param_in.buffer(),
              grad.buffer(),
-             momentum_buffer_in.has_value() ? momentum_buffer_in.value().buffer()->address() : 0u,
+             momentum_in_buf,
              num_tiles_per_core,
              tile_offset,
              u_lr,
@@ -269,12 +276,7 @@ ProgramDescriptor MorehSgdOperation::create_descriptor(
              u_weight_decay,
              u_one});
 
-        writer_desc.emplace_runtime_args(
-            core,
-            {param_out.buffer(),
-             momentum_buffer_out.has_value() ? momentum_buffer_out.value().buffer()->address() : 0u,
-             num_tiles_per_core,
-             tile_offset});
+        writer_desc.emplace_runtime_args(core, {param_out.buffer(), momentum_out_buf, num_tiles_per_core, tile_offset});
 
         tile_offset += num_tiles_per_core;
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_program_factory.cpp
@@ -245,16 +245,18 @@ ProgramDescriptor MorehSumBackwardOperation::create_descriptor(
             TT_THROW("Core not in specified core ranges.");
         }
 
-        // Build reader runtime args: addr, num_tiles, offset, then dim vectors
-        KernelDescriptor::CoreRuntimeArgs reader_rt_args;
-        reader_rt_args.push_back(output_grad.buffer()->address());
+        // Build reader runtime args: addr, num_tiles, offset, then dim vectors.
+        // Pass output_grad as Buffer* (not raw ->address()) so the program-cache fast hit path
+        // patches its address when the tensor is reallocated across calls.
+        KernelDescriptor::RTArgList reader_rt_args;
+        reader_rt_args.push_back(output_grad.buffer());
         reader_rt_args.push_back(num_tiles_per_core);
         reader_rt_args.push_back(tile_offset);
-        reader_rt_args.insert(reader_rt_args.end(), output_grad_dim.begin(), output_grad_dim.end());
-        reader_rt_args.insert(reader_rt_args.end(), input_grad_dim.begin(), input_grad_dim.end());
-        reader_rt_args.insert(reader_rt_args.end(), need_bcast_dim.begin(), need_bcast_dim.end());
+        reader_rt_args.append(std::vector<uint32_t>(output_grad_dim.begin(), output_grad_dim.end()));
+        reader_rt_args.append(std::vector<uint32_t>(input_grad_dim.begin(), input_grad_dim.end()));
+        reader_rt_args.append(std::vector<uint32_t>(need_bcast_dim.begin(), need_bcast_dim.end()));
 
-        reader_desc.runtime_args.emplace_back(core, std::move(reader_rt_args));
+        reader_desc.emplace_runtime_args(core, reader_rt_args);
 
         writer_desc.emplace_runtime_args(core, {input_grad.buffer(), num_tiles_per_core, tile_offset});
 


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #47586

There was some kind of interaction between multiple PRs. The end result is that some moreh ops were not passing in tensor buffer information. This has been fixed.

AI analysis:
  Moreh ops failing program-cache (callback) tests — root cause & fix

  Several moreh ops (moreh_bmm/moreh_matmul, moreh_layer_norm, and others)
  started failing their *_callback tests with garbage outputs (e.g. pcc≈-0.015,
  ATOL=inf, or wrong mean/rstd).

  Root cause: a latent bug in how these ProgramDescriptor factories pass tensor
  buffers to the kernels. An op takes the program-cache fast path (which patches
  buffer addresses but skips rebuilding the descriptor) as soon as it registers
  any buffer as a Buffer* via emplace_runtime_args. These factories bound some
  buffers as Buffer* but passed others as raw buffer()->address(). Those raw
  addresses are captured once and never updated on cache hits — so on the second
  run, after the tensors are reallocated, the kernel reads/writes stale 
  addresses → garbage.

  This is an interaction of two already-merged PRs (the fast-path mechanism +
  the moreh ProgramDescriptor migration), latent since ~May and only now exposed
  by a shift in allocation addresses between runs. It is not a single-commit
  regression, and not the matmul-init migration (#46346) — that only touches
  matmul compute kernels and can't explain the non-matmul failures.

  Fix: convert the raw tensor addresses to Buffer* bindings (with nullptr for
  absent optionals) so the framework re-patches them on every cache hit. Applied
  across 11 moreh factories (matmul, layer_norm, group_norm, sgd, the nll_loss
  family, several backward ops). Audited the rest —
  moreh_adam/moreh_clip_grad_norm are safe because they use no Buffer* bindings
  and fall back to the (correct) rebuild path.

AI did some subsequent checks for all ops and these are the only ops affected.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-47586_moreh_l2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-47586_moreh_l2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-47586_moreh_l2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-47586_moreh_l2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-47586_moreh_l2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-47586_moreh_l2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-47586_moreh_l2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-47586_moreh_l2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-47586_moreh_l2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-47586_moreh_l2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-47586_moreh_l2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-47586_moreh_l2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-47586_moreh_l2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-47586_moreh_l2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-47586_moreh_l2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-47586_moreh_l2)