### PR TITLE
[Bug Fix] Fix alternating PCC issue for Deepseek SDPA

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
@@ -3792,15 +3792,6 @@ void kernel_main() {
             unified_kernels::reconfig_cb_interfaces(mla_cb_config);
             setup_mla_sharded_buffers();
         }
-        {
-            volatile tt_l1_ptr uint32_t* risc_sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
-                get_named_compile_time_arg_val("risc_sync_semaphore_addr"));
-            unified_kernels::sync_riscs_enter(risc_sync_sem);
-            unified_kernels::sync_riscs_exit(risc_sync_sem);
-        }
-#if defined(COMPILE_FOR_TRISC)
-        deepseek_compute_kernel_init();
-#endif
 #ifdef ENABLE_REDUCE_TO_ONE
 #if defined(COMPILE_FOR_NCRISC)
         if constexpr (Core::is_sender_core) {

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_sdpa_custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_sdpa_custom_mm.h
@@ -109,7 +109,9 @@ inline void _llk_math_sdpa_custom_mm_mask_dest_(
         TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD);
     } else {
         // Zero Dest
-        uint32_t dst_face = dst_offset / 16;
+        // ZEROACC auto-detects the DEST bank, so its tile index must be bank-relative (dst_index, not
+        // dst_offset which already includes the bank base -> would double-count the bank on bank 1).
+        uint32_t dst_face = dst_index / 16;
         // A tile is 2 faces of 8x16, so clearing 16 rows per tile is equivalent to clearing the tile
         for (uint32_t i = 0; i < ct_dim; i++) {
             TT_ZEROACC(p_zeroacc::CLR_16, 0, 0, ADDR_MOD_7, dst_face);


### PR DESCRIPTION
### PR Category
Bug Fix https://github.com/tenstorrent/tt-metal/issues/43562

### Summary
Alternating PCC for even, odd iterations of the full Deepseek decoder was observed.
A workaround was originally added to reset the dest offset at the start of each decoder iteration.
The root cause was found to be that TT_ZEROACC takes a relative dest offset for BH, but the SDPA op was using the absolute offset, so was not correctly zeroing the dest.
Fix is to switch to passing the relative offset.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=aho/pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:aho/pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=aho/pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:aho/pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/pcc)