### PR TITLE
fabric topology SAT: conflict-cap host-minimization (unhang ring-into-larger-graph mappings)

### DIFF
--- a/tt_metal/fabric/topology_solver_sat.cpp
+++ b/tt_metal/fabric/topology_solver_sat.cpp
@@ -1492,6 +1492,13 @@ bool topology_sat_search(
         }
         if (num_host_groups >= 2 && max_group_capacity > 0) {
             const size_t k_min = (graph_data.n_target + max_group_capacity - 1) / max_group_capacity;
+            // Each tight host-budget solve is conflict-capped. Proving the minimum host count for a ring/chain
+            // embedded into a strictly larger physical graph (e.g. a 64-mesh decode ring on an 80-mesh / 20-host
+            // supercluster) is a Hamiltonian-cycle-with-cardinality search the SAT engine can spin on for minutes;
+            // the cap lets an intractable budget be abandoned so the loop (and then the unconstrained fall-through
+            // below) still returns a valid mapping quickly. Tractable budgets finish well within the cap and return
+            // the identical model they would unbounded, so existing golden mappings are unchanged.
+            static constexpr int kHostMinimizeConflictBudget = 300'000;
             for (size_t k = std::max<size_t>(k_min, 1); k < num_host_groups; ++k) {
                 TopologySatSolver solver;
                 TopologySatHardEncoding enc;
@@ -1501,7 +1508,8 @@ bool topology_sat_search(
                 if (!topology_sat_encode_host_group_budget(solver, constraint_data, enc, k)) {
                     continue;  // this budget is trivially unencodable; try a larger one
                 }
-                if (solver.solve() == TopologySatSolver::kSat && finalize_success(solver, enc)) {
+                if (solver.solve_limited(kHostMinimizeConflictBudget) == TopologySatSolver::kSat &&
+                    finalize_success(solver, enc)) {
                     if (!quiet_mode) {
                         log_info(
                             tt::LogFabric,
@@ -1512,7 +1520,7 @@ bool topology_sat_search(
                     return true;
                 }
             }
-            // No binding budget was satisfiable; fall through to the unconstrained solve below.
+            // No binding budget was satisfiable within the conflict cap; fall through to the unconstrained solve.
         }
     }
 

--- a/tt_metal/fabric/topology_solver_sat_solver.cpp
+++ b/tt_metal/fabric/topology_solver_sat_solver.cpp
@@ -28,6 +28,13 @@ struct TopologySatSolver::Impl {
 
     int solve() { return solver.solve(); }
 
+    int solve_limited(int max_conflicts) {
+        solver.limit("conflicts", max_conflicts);
+        const int r = solver.solve();
+        solver.limit("conflicts", -1);  // -1 == unlimited; clear so later solve() calls are unbounded
+        return r;
+    }
+
     int val(int lit) const {
         const int a = std::abs(lit);
         const int r = solver.val(a);
@@ -66,6 +73,8 @@ void TopologySatSolver::add(int lit) { impl_->add(lit); }
 void TopologySatSolver::assume(int lit) { impl_->assume(lit); }
 
 int TopologySatSolver::solve() { return impl_->solve(); }
+
+int TopologySatSolver::solve_limited(int max_conflicts) { return impl_->solve_limited(max_conflicts); }
 
 int TopologySatSolver::val(int lit) const { return impl_->val(lit); }
 

--- a/tt_metal/fabric/topology_solver_sat_solver.hpp
+++ b/tt_metal/fabric/topology_solver_sat_solver.hpp
@@ -32,6 +32,11 @@ struct TopologySatSolver {
     // that is sound for any instance: if the assumption makes it UNSAT, re-solve() without it.
     void assume(int lit);
     int solve();
+    // Solve capped at `max_conflicts` conflicts. Returns kSat / kUnsat, or 0 (IPASIR "unknown") when the budget
+    // is exhausted before a verdict. Lets a caller try an optional/expensive constraint (a tight host-budget
+    // minimization) without paying an unbounded proof when it is intractable -- on 0/kUnsat the caller falls back.
+    // The limit is cleared afterwards so subsequent solve() calls are unbounded.
+    int solve_limited(int max_conflicts);
     int val(int lit) const;
 
     /**


### PR DESCRIPTION
## Summary
(tt-metal **main** copy of the blaze-metal-main change in #47601.)

Conflict-caps the fabric topology SAT solver's **host-group minimization** so it no longer hangs when mapping a **ring/chain into a strictly larger physical graph** (e.g. a 64-mesh Blitz decode ring onto an 80-mesh / 20-host subtorus supercluster — previously ~minutes per inter-mesh mapping).

Adds `TopologySatSolver::solve_limited(max_conflicts)` (thin wrapper over CaDiCaL's `conflicts` limit) and uses it for each per-budget host-minimization solve. An intractable tight budget is abandoned at the cap and the loop falls through to the existing unconstrained solve. **Tractable budgets finish far inside the cap and return the identical model they would unbounded — so all existing golden mappings and SAT channel-fit behavior are unchanged** (no regoldening).

## Test plan
Full effect exercised by the stacked descriptor PR: all 14 CPU-only fabric groups pass (0 failures), incl. the 64-stage Blitz ring on the 20-host subtorus SC20 (110C) now solving on plain SAT instead of timing out, every golden green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rsong/pgd-sat-loop-mapping-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rsong/pgd-sat-loop-mapping-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rsong/pgd-sat-loop-mapping-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rsong/pgd-sat-loop-mapping-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rsong/pgd-sat-loop-mapping-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rsong/pgd-sat-loop-mapping-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rsong/pgd-sat-loop-mapping-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rsong/pgd-sat-loop-mapping-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rsong/pgd-sat-loop-mapping-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rsong/pgd-sat-loop-mapping-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rsong/pgd-sat-loop-mapping-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rsong/pgd-sat-loop-mapping-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rsong/pgd-sat-loop-mapping-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rsong/pgd-sat-loop-mapping-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rsong/pgd-sat-loop-mapping-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rsong/pgd-sat-loop-mapping-main)