### PR TITLE
cmake: suppress Tracy's RULE_LAUNCH_COMPILE to fix ccache hit rate

### DIFF
--- a/tt_metal/third_party/CMakeLists.txt
+++ b/tt_metal/third_party/CMakeLists.txt
@@ -96,6 +96,14 @@ set(BUILD_SHARED_LIBS OFF)
 # Disable Tracy's -march=native for portable CLI binaries in CI.
 set(NO_ISA_EXTENSIONS ON)
 
+# Tracy's csvexport/capture each include cmake/config.cmake, which sets
+# RULE_LAUNCH_COMPILE ccache as a GLOBAL property.  tt-metal already wires
+# ccache via CMAKE_CXX_COMPILER_LAUNCHER (cmake/ccache.cmake), so having both
+# active causes double-wrapping: the outer ccache sees the entire
+# "cmake -E env ... ccache clang++ -c file.cpp" as its argument list and
+# rejects every tt_metal translation unit as "Multiple source files".
+# Suppress Tracy's own ccache logic; ours handles it correctly.
+set(NO_CCACHE ON)
 add_subdirectory(tracy/csvexport)
 add_subdirectory(tracy/capture)
 


### PR DESCRIPTION
## Problem

Tracy's `csvexport` and `capture` subprojects each `include(cmake/config.cmake)`, which unconditionally sets:

```cmake
set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
```

This is a **GLOBAL** CMake property. Since `tt_metal/third_party` is processed before `tt_metal`, `ttnn`, and all tests in the top-level `CMakeLists.txt`, this property infects every subsequent target in the build.

tt-metal already wires ccache via `CMAKE_CXX_COMPILER_LAUNCHER` in `cmake/ccache.cmake`. When both mechanisms are active, CMake generates Ninja rules that **double-wrap** the compiler:

```
ccache  cmake -E env CCACHE_SLOPPINESS=... ccache clang++ -c file.cpp
```

The outer `ccache` sees `cmake` as the compiler and cannot parse the argument list — it rejects every tt_metal translation unit with **"Multiple source files"**. Observed: 1856 of 2248 compilations uncacheable (82.6%).

## Fix

Set `NO_CCACHE=ON` before the Tracy CLI `add_subdirectory` calls. Tracy's `config.cmake` guards its `RULE_LAUNCH_COMPILE` block behind this option, suppressing the global property while leaving `CMAKE_CXX_COMPILER_LAUNCHER` (tt-metal's mechanism) intact.

## Verification

`ccache -sv` after a full build should show near-zero "Multiple source files" rejections. Expected cacheable calls to jump from ~222 back to ~2000+ for a standard tt_metal build.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=wilder/tracy-fix-ccache-double-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:wilder/tracy-fix-ccache-double-wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=wilder/tracy-fix-ccache-double-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:wilder/tracy-fix-ccache-double-wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=wilder/tracy-fix-ccache-double-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:wilder/tracy-fix-ccache-double-wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=wilder/tracy-fix-ccache-double-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:wilder/tracy-fix-ccache-double-wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=wilder/tracy-fix-ccache-double-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:wilder/tracy-fix-ccache-double-wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=wilder/tracy-fix-ccache-double-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:wilder/tracy-fix-ccache-double-wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=wilder/tracy-fix-ccache-double-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:wilder/tracy-fix-ccache-double-wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=wilder/tracy-fix-ccache-double-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:wilder/tracy-fix-ccache-double-wrap)