### PR TITLE
[skip ci] Add host-load-sidecar for runner resource utilization

### DIFF
--- a/.github/actions/llk-compile-quasar/action.yml
+++ b/.github/actions/llk-compile-quasar/action.yml
@@ -30,11 +30,15 @@ runs:
         CHIP_ARCH: quasar
       run: |
         echo "Compiling Quasar (group ${{ inputs.test-group }}/${{ inputs.test-splits }})..."
-        pytest -q --compile-producer -n 10 \
-              -m "${{ inputs.pytest-markers }}" \
-              --splits ${{ inputs.test-splits }} --group ${{ inputs.test-group }} \
-              --override-ini=log_cli=false --tb=short --timeout=60 \
-              --junitxml=pytest-report-quasar-compile.xml .
+        "$GITHUB_WORKSPACE/.github/scripts/utils/host-load-sidecar.sh" \
+          --interval 1 \
+          --label "Quasar compile (group ${{ inputs.test-group }}/${{ inputs.test-splits }})" \
+          --output "$GITHUB_STEP_SUMMARY" \
+          -- pytest -q --compile-producer -n 10 \
+                -m "${{ inputs.pytest-markers }}" \
+                --splits ${{ inputs.test-splits }} --group ${{ inputs.test-group }} \
+                --override-ini=log_cli=false --tb=short --timeout=60 \
+                --junitxml=pytest-report-quasar-compile.xml .
 
     - name: Upload JUnit report for compiling elfs
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/scripts/utils/find-changed-files.sh
+++ b/.github/scripts/utils/find-changed-files.sh
@@ -82,7 +82,7 @@ while IFS= read -r FILE; do
         tt_metal/tt-llk/tests/**)
             LLK_TESTS_CHANGED=true
             ;;
-        .github/workflows/llk-*.yaml|.github/scripts/llk-*.sh|.github/actions/llk-compile-quasar/**|tests/pipeline_reorg/llk_unit_tests.yaml|tests/pipeline_reorg/llk_smoke_merge_gate_tests.yaml)
+        .github/workflows/llk-*.yaml|.github/scripts/llk-*.sh|tests/pipeline_reorg/llk_unit_tests.yaml|tests/pipeline_reorg/llk_smoke_merge_gate_tests.yaml)
             LLK_CI_CHANGED=true
             ;;
         tt_metal/**/*.@(h|hpp|c|cpp|cc|py))

--- a/.github/scripts/utils/find-changed-files.sh
+++ b/.github/scripts/utils/find-changed-files.sh
@@ -82,7 +82,7 @@ while IFS= read -r FILE; do
         tt_metal/tt-llk/tests/**)
             LLK_TESTS_CHANGED=true
             ;;
-        .github/workflows/llk-*.yaml|.github/scripts/llk-*.sh|tests/pipeline_reorg/llk_unit_tests.yaml|tests/pipeline_reorg/llk_smoke_merge_gate_tests.yaml)
+        .github/workflows/llk-*.yaml|.github/scripts/llk-*.sh|.github/actions/llk-compile-quasar/**|tests/pipeline_reorg/llk_unit_tests.yaml|tests/pipeline_reorg/llk_smoke_merge_gate_tests.yaml)
             LLK_CI_CHANGED=true
             ;;
         tt_metal/**/*.@(h|hpp|c|cpp|cc|py))

--- a/.github/scripts/utils/host-load-sidecar.sh
+++ b/.github/scripts/utils/host-load-sidecar.sh
@@ -531,7 +531,11 @@ emit_summary() {
 
     cat "$summary_tmp" >&2
     if [[ -n "$summary_file" ]]; then
-        cat "$summary_tmp" >> "$summary_file"
+        {
+            printf '\n```\n'
+            cat "$summary_tmp"
+            printf '```\n'
+        } >> "$summary_file"
     fi
 }
 

--- a/.github/scripts/utils/host-load-sidecar.sh
+++ b/.github/scripts/utils/host-load-sidecar.sh
@@ -19,6 +19,8 @@ Environment:
   HOST_LOAD_SUMMARY_FILE      Default file to append the summary to.
   HOST_LOAD_DISK_DEVICES      Comma-separated /sys/block device names to include.
                              Defaults to whole non-loop, non-ram, non-dm block devices.
+                             Disk metrics are physical block-device I/O; cached
+                             filesystem reads are not counted as disk reads.
   HOST_LOAD_NET_INTERFACES    Comma-separated network interface names to include.
                              Defaults to all interfaces except lo.
 
@@ -195,6 +197,8 @@ read_disk_bytes() {
     local write_sectors=0
     local stat_file device_read_sectors device_write_sectors
 
+    # /sys/block/*/stat reports block-layer sectors, so this is physical device
+    # I/O. It intentionally does not count filesystem reads served from cache.
     while IFS= read -r stat_file; do
         read -r _ _ device_read_sectors _ _ _ device_write_sectors _ _ < "$stat_file" || continue
         read_sectors=$((read_sectors + device_read_sectors))
@@ -446,16 +450,6 @@ format_rate() {
     printf "%s/s\n" "$(format_bytes "$1")"
 }
 
-sar_context() {
-    if command -v sar >/dev/null 2>&1; then
-        local version
-        version="$(sar -V 2>&1 | awk 'NR == 1 { print; exit }')"
-        printf "available (%s); summary uses /proc counters for dependency-free command wrapping\n" "$version"
-    else
-        printf "not found; install sysstat for sar, but this wrapper does not require it\n"
-    fi
-}
-
 emit_summary() {
     local command_status="$1"
     summarize_samples
@@ -514,7 +508,6 @@ emit_summary() {
         echo "Command: $command_display"
         echo "Exit code: $command_status"
         echo "Samples: $samples over ${duration_s}s (target interval: ${interval}s)"
-        echo "sar: $(sar_context)"
         echo ""
         echo "CPU utilization (capacity: ${cpu_cores} cores):"
         echo "  min: ${cpu_min}% | max: ${cpu_max}% | mean: ${cpu_mean}%"
@@ -522,10 +515,10 @@ emit_summary() {
         echo "  min: ${mem_min}% | max: ${mem_max}% | mean: ${mem_mean}%"
         echo "Swap utilization (capacity: ${swap_total} swap):"
         echo "  min: ${swap_min}% | max: ${swap_max}% | mean: ${swap_mean}%"
-        echo "Disk reads:"
+        echo "Physical disk reads:"
         echo "  total: ${disk_read_total_h} | average rate: ${disk_read_avg_h}"
         echo "  sample rate min: ${disk_read_min_h} | max: ${disk_read_max_h} | mean: ${disk_read_mean_h}"
-        echo "Disk writes:"
+        echo "Physical disk writes:"
         echo "  total: ${disk_write_total_h} | average rate: ${disk_write_avg_h}"
         echo "  sample rate min: ${disk_write_min_h} | max: ${disk_write_max_h} | mean: ${disk_write_mean_h}"
         echo "Network receive:"

--- a/.github/scripts/utils/host-load-sidecar.sh
+++ b/.github/scripts/utils/host-load-sidecar.sh
@@ -1,0 +1,579 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: host-load-sidecar.sh [options] [--] <command> [args...]
+
+Wrap a command and print a host load summary after it exits.
+
+Options:
+  --interval SECONDS  Sampling interval. Defaults to HOST_LOAD_INTERVAL_SECONDS or 1.
+  --label LABEL       Label shown in the summary. Defaults to HOST_LOAD_LABEL or "host load".
+  --output FILE       Also append the summary to FILE.
+  -h, --help          Show this help.
+
+Environment:
+  HOST_LOAD_INTERVAL_SECONDS  Default sampling interval.
+  HOST_LOAD_LABEL             Default summary label.
+  HOST_LOAD_SUMMARY_FILE      Default file to append the summary to.
+  HOST_LOAD_DISK_DEVICES      Comma-separated /sys/block device names to include.
+                             Defaults to whole non-loop, non-ram, non-dm block devices.
+  HOST_LOAD_NET_INTERFACES    Comma-separated network interface names to include.
+                             Defaults to all interfaces except lo.
+
+Examples:
+  host-load-sidecar.sh -- make -j32
+  host-load-sidecar.sh --interval 2 --label build --output "$GITHUB_STEP_SUMMARY" -- pytest tests/
+EOF
+}
+
+die() {
+    echo "host-load-sidecar: $*" >&2
+    exit 2
+}
+
+interval="${HOST_LOAD_INTERVAL_SECONDS:-1}"
+label="${HOST_LOAD_LABEL:-host load}"
+summary_file="${HOST_LOAD_SUMMARY_FILE:-}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --interval)
+            [[ $# -ge 2 ]] || die "--interval requires a value"
+            interval="$2"
+            shift 2
+            ;;
+        --label)
+            [[ $# -ge 2 ]] || die "--label requires a value"
+            label="$2"
+            shift 2
+            ;;
+        --output)
+            [[ $# -ge 2 ]] || die "--output requires a value"
+            summary_file="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --)
+            shift
+            break
+            ;;
+        --*)
+            die "unknown option: $1"
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+[[ $# -gt 0 ]] || {
+    usage >&2
+    exit 2
+}
+
+if ! awk -v value="$interval" 'BEGIN { exit !(value ~ /^[0-9]+([.][0-9]+)?$/ && value + 0 > 0) }'; then
+    die "--interval must be a positive number"
+fi
+
+for required_file in /proc/stat /proc/meminfo /proc/net/dev /proc/uptime; do
+    [[ -r "$required_file" ]] || die "$required_file is required; this script is intended for Ubuntu/Linux hosts"
+done
+[[ -d /sys/block ]] || die "/sys/block is required; this script is intended for Ubuntu/Linux hosts"
+
+command_to_run=("$@")
+tmp_dir="$(mktemp -d)"
+samples_file="$tmp_dir/samples.tsv"
+stats_file="$tmp_dir/stats.env"
+summary_tmp="$tmp_dir/summary.txt"
+stop_file="$tmp_dir/stop"
+ready_file="$tmp_dir/ready"
+monitor_pid=""
+command_pid=""
+
+# shellcheck disable=SC2329  # Invoked by the EXIT trap.
+cleanup() {
+    rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+now_seconds() {
+    awk '{ print $1 }' /proc/uptime
+}
+
+cpu_capacity() {
+    getconf _NPROCESSORS_ONLN 2>/dev/null \
+        || nproc --all 2>/dev/null \
+        || awk -F: '/^processor[[:space:]]*:/ { n++ } END { print n ? n : "unknown" }' /proc/cpuinfo
+}
+
+memory_capacity_bytes() {
+    awk '/^MemTotal:/ { printf "%.0f\n", $2 * 1024 }' /proc/meminfo
+}
+
+swap_capacity_bytes() {
+    awk '/^SwapTotal:/ { printf "%.0f\n", $2 * 1024 }' /proc/meminfo
+}
+
+read_cpu_jiffies() {
+    local user nice system idle iowait irq softirq steal guest guest_nice
+    read -r _ user nice system idle iowait irq softirq steal guest guest_nice < /proc/stat
+
+    iowait="${iowait:-0}"
+    irq="${irq:-0}"
+    softirq="${softirq:-0}"
+    steal="${steal:-0}"
+    guest="${guest:-0}"
+    guest_nice="${guest_nice:-0}"
+
+    local total=$((user + nice + system + idle + iowait + irq + softirq + steal + guest + guest_nice))
+    local idle_total=$((idle + iowait))
+
+    printf "%s %s\n" "$total" "$idle_total"
+}
+
+read_memory_percent() {
+    awk '
+        /^MemTotal:/ { total = $2 }
+        /^MemAvailable:/ { available = $2 }
+        END {
+            if (total > 0) {
+                printf "%.2f\n", ((total - available) * 100) / total
+            } else {
+                print "0.00"
+            }
+        }
+    ' /proc/meminfo
+}
+
+read_swap_percent() {
+    awk '
+        /^SwapTotal:/ { total = $2 }
+        /^SwapFree:/ { free = $2 }
+        END {
+            if (total > 0) {
+                printf "%.2f\n", ((total - free) * 100) / total
+            } else {
+                print "0.00"
+            }
+        }
+    ' /proc/meminfo
+}
+
+selected_disk_stat_files() {
+    if [[ -n "${HOST_LOAD_DISK_DEVICES:-}" ]]; then
+        local -a configured_devices
+        local device
+        IFS=',' read -r -a configured_devices <<< "$HOST_LOAD_DISK_DEVICES"
+        for device in "${configured_devices[@]}"; do
+            device="${device#/dev/}"
+            [[ -r "/sys/block/$device/stat" ]] && printf "%s\n" "/sys/block/$device/stat"
+        done
+        return
+    fi
+
+    local stat_file device
+    for stat_file in /sys/block/*/stat; do
+        [[ -r "$stat_file" ]] || continue
+        device="${stat_file%/stat}"
+        device="${device##*/}"
+        case "$device" in
+            loop*|ram*|zram*|fd*|sr*|dm-*)
+                continue
+                ;;
+        esac
+        printf "%s\n" "$stat_file"
+    done
+}
+
+read_disk_bytes() {
+    local read_sectors=0
+    local write_sectors=0
+    local stat_file device_read_sectors device_write_sectors
+
+    while IFS= read -r stat_file; do
+        read -r _ _ device_read_sectors _ _ _ device_write_sectors _ _ < "$stat_file" || continue
+        read_sectors=$((read_sectors + device_read_sectors))
+        write_sectors=$((write_sectors + device_write_sectors))
+    done < <(selected_disk_stat_files)
+
+    printf "%s %s\n" "$((read_sectors * 512))" "$((write_sectors * 512))"
+}
+
+read_network_bytes() {
+    awk -v configured_interfaces="${HOST_LOAD_NET_INTERFACES:-}" '
+        BEGIN {
+            if (configured_interfaces != "") {
+                split(configured_interfaces, configured, ",")
+                for (i in configured) {
+                    wanted[configured[i]] = 1
+                }
+                use_wanted = 1
+            }
+        }
+        NR > 2 {
+            split($0, parts, ":")
+            iface = parts[1]
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", iface)
+
+            if (use_wanted) {
+                if (!(iface in wanted)) {
+                    next
+                }
+            } else if (iface == "lo") {
+                next
+            }
+
+            split(parts[2], fields)
+            rx += fields[1]
+            tx += fields[9]
+        }
+        END {
+            printf "%.0f %.0f\n", rx, tx
+        }
+    ' /proc/net/dev
+}
+
+sleep_until_interval_or_stop() {
+    local target_interval="$1"
+    local slept="0"
+    local chunk
+
+    while awk -v slept="$slept" -v target="$target_interval" 'BEGIN { exit !(slept < target) }'; do
+        [[ -f "$stop_file" ]] && break
+        chunk="$(
+            awk -v slept="$slept" -v target="$target_interval" '
+                BEGIN {
+                    remaining = target - slept
+                    if (remaining > 0.2) {
+                        remaining = 0.2
+                    }
+                    if (remaining < 0.01) {
+                        remaining = 0.01
+                    }
+                    printf "%.3f\n", remaining
+                }
+            '
+        )"
+        sleep "$chunk"
+        slept="$(awk -v slept="$slept" -v chunk="$chunk" 'BEGIN { printf "%.6f\n", slept + chunk }')"
+    done
+}
+
+monitor_load() {
+    printf "elapsed_s\tcpu_pct\tmem_pct\tswap_pct\tdisk_read_bps\tdisk_write_bps\tnet_rx_bps\tnet_tx_bps\tdisk_read_bytes\tdisk_write_bytes\tnet_rx_bytes\tnet_tx_bytes\n" > "$samples_file"
+
+    local previous_time previous_cpu_total previous_cpu_idle previous_disk_read previous_disk_write
+    local previous_net_rx previous_net_tx
+
+    previous_time="$(now_seconds)"
+    read -r previous_cpu_total previous_cpu_idle < <(read_cpu_jiffies)
+    read -r previous_disk_read previous_disk_write < <(read_disk_bytes)
+    read -r previous_net_rx previous_net_tx < <(read_network_bytes)
+    : > "$ready_file"
+
+    while true; do
+        sleep_until_interval_or_stop "$interval"
+
+        local current_time current_cpu_total current_cpu_idle current_disk_read current_disk_write
+        local current_net_rx current_net_tx elapsed_s cpu_delta idle_delta cpu_pct mem_pct swap_pct
+        local disk_read_delta disk_write_delta net_rx_delta net_tx_delta
+        local disk_read_bps disk_write_bps net_rx_bps net_tx_bps
+
+        current_time="$(now_seconds)"
+        read -r current_cpu_total current_cpu_idle < <(read_cpu_jiffies)
+        read -r current_disk_read current_disk_write < <(read_disk_bytes)
+        read -r current_net_rx current_net_tx < <(read_network_bytes)
+
+        elapsed_s="$(awk -v current="$current_time" -v previous="$previous_time" 'BEGIN { elapsed = current - previous; if (elapsed <= 0) elapsed = 0.001; printf "%.6f\n", elapsed }')"
+        cpu_delta=$((current_cpu_total - previous_cpu_total))
+        idle_delta=$((current_cpu_idle - previous_cpu_idle))
+        cpu_pct="$(
+            awk -v total="$cpu_delta" -v idle="$idle_delta" '
+                BEGIN {
+                    if (total > 0) {
+                        printf "%.2f\n", ((total - idle) * 100) / total
+                    } else {
+                        print "0.00"
+                    }
+                }
+            '
+        )"
+        mem_pct="$(read_memory_percent)"
+        swap_pct="$(read_swap_percent)"
+
+        disk_read_delta=$((current_disk_read - previous_disk_read))
+        disk_write_delta=$((current_disk_write - previous_disk_write))
+        net_rx_delta=$((current_net_rx - previous_net_rx))
+        net_tx_delta=$((current_net_tx - previous_net_tx))
+
+        disk_read_bps="$(awk -v bytes="$disk_read_delta" -v elapsed="$elapsed_s" 'BEGIN { printf "%.2f\n", bytes / elapsed }')"
+        disk_write_bps="$(awk -v bytes="$disk_write_delta" -v elapsed="$elapsed_s" 'BEGIN { printf "%.2f\n", bytes / elapsed }')"
+        net_rx_bps="$(awk -v bytes="$net_rx_delta" -v elapsed="$elapsed_s" 'BEGIN { printf "%.2f\n", bytes / elapsed }')"
+        net_tx_bps="$(awk -v bytes="$net_tx_delta" -v elapsed="$elapsed_s" 'BEGIN { printf "%.2f\n", bytes / elapsed }')"
+
+        printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+            "$elapsed_s" "$cpu_pct" "$mem_pct" "$swap_pct" "$disk_read_bps" "$disk_write_bps" \
+            "$net_rx_bps" "$net_tx_bps" "$disk_read_delta" "$disk_write_delta" \
+            "$net_rx_delta" "$net_tx_delta" >> "$samples_file"
+
+        previous_time="$current_time"
+        previous_cpu_total="$current_cpu_total"
+        previous_cpu_idle="$current_cpu_idle"
+        previous_disk_read="$current_disk_read"
+        previous_disk_write="$current_disk_write"
+        previous_net_rx="$current_net_rx"
+        previous_net_tx="$current_net_tx"
+
+        [[ -f "$stop_file" ]] && break
+    done
+}
+
+summarize_samples() {
+    awk '
+        BEGIN { FS = "\t" }
+        NR == 1 { next }
+        {
+            n++
+            elapsed += $1
+
+            cpu = $2
+            mem = $3
+            swap = $4
+            disk_read_bps = $5
+            disk_write_bps = $6
+            net_rx_bps = $7
+            net_tx_bps = $8
+            disk_read_bytes += $9
+            disk_write_bytes += $10
+            net_rx_bytes += $11
+            net_tx_bytes += $12
+
+            if (n == 1) {
+                cpu_min = cpu_max = cpu
+                mem_min = mem_max = mem
+                swap_min = swap_max = swap
+                disk_read_bps_min = disk_read_bps_max = disk_read_bps
+                disk_write_bps_min = disk_write_bps_max = disk_write_bps
+                net_rx_bps_min = net_rx_bps_max = net_rx_bps
+                net_tx_bps_min = net_tx_bps_max = net_tx_bps
+            }
+
+            if (cpu < cpu_min) cpu_min = cpu
+            if (cpu > cpu_max) cpu_max = cpu
+            if (mem < mem_min) mem_min = mem
+            if (mem > mem_max) mem_max = mem
+            if (swap < swap_min) swap_min = swap
+            if (swap > swap_max) swap_max = swap
+            if (disk_read_bps < disk_read_bps_min) disk_read_bps_min = disk_read_bps
+            if (disk_read_bps > disk_read_bps_max) disk_read_bps_max = disk_read_bps
+            if (disk_write_bps < disk_write_bps_min) disk_write_bps_min = disk_write_bps
+            if (disk_write_bps > disk_write_bps_max) disk_write_bps_max = disk_write_bps
+            if (net_rx_bps < net_rx_bps_min) net_rx_bps_min = net_rx_bps
+            if (net_rx_bps > net_rx_bps_max) net_rx_bps_max = net_rx_bps
+            if (net_tx_bps < net_tx_bps_min) net_tx_bps_min = net_tx_bps
+            if (net_tx_bps > net_tx_bps_max) net_tx_bps_max = net_tx_bps
+
+            cpu_sum += cpu
+            mem_sum += mem
+            swap_sum += swap
+            disk_read_bps_sum += disk_read_bps
+            disk_write_bps_sum += disk_write_bps
+            net_rx_bps_sum += net_rx_bps
+            net_tx_bps_sum += net_tx_bps
+        }
+        END {
+            if (n == 0) {
+                print "samples=0"
+                print "duration_s=0.00"
+                print "cpu_min=0.00"; print "cpu_max=0.00"; print "cpu_mean=0.00"
+                print "mem_min=0.00"; print "mem_max=0.00"; print "mem_mean=0.00"
+                print "swap_min=0.00"; print "swap_max=0.00"; print "swap_mean=0.00"
+                print "disk_read_bps_min=0.00"; print "disk_read_bps_max=0.00"; print "disk_read_bps_mean=0.00"
+                print "disk_write_bps_min=0.00"; print "disk_write_bps_max=0.00"; print "disk_write_bps_mean=0.00"
+                print "net_rx_bps_min=0.00"; print "net_rx_bps_max=0.00"; print "net_rx_bps_mean=0.00"
+                print "net_tx_bps_min=0.00"; print "net_tx_bps_max=0.00"; print "net_tx_bps_mean=0.00"
+                print "disk_read_total=0"; print "disk_write_total=0"; print "net_rx_total=0"; print "net_tx_total=0"
+                print "disk_read_avg_bps=0.00"; print "disk_write_avg_bps=0.00"; print "net_rx_avg_bps=0.00"; print "net_tx_avg_bps=0.00"
+                exit
+            }
+
+            printf "samples=%d\n", n
+            printf "duration_s=%.2f\n", elapsed
+            printf "cpu_min=%.2f\ncpu_max=%.2f\ncpu_mean=%.2f\n", cpu_min, cpu_max, cpu_sum / n
+            printf "mem_min=%.2f\nmem_max=%.2f\nmem_mean=%.2f\n", mem_min, mem_max, mem_sum / n
+            printf "swap_min=%.2f\nswap_max=%.2f\nswap_mean=%.2f\n", swap_min, swap_max, swap_sum / n
+            printf "disk_read_bps_min=%.2f\ndisk_read_bps_max=%.2f\ndisk_read_bps_mean=%.2f\n", disk_read_bps_min, disk_read_bps_max, disk_read_bps_sum / n
+            printf "disk_write_bps_min=%.2f\ndisk_write_bps_max=%.2f\ndisk_write_bps_mean=%.2f\n", disk_write_bps_min, disk_write_bps_max, disk_write_bps_sum / n
+            printf "net_rx_bps_min=%.2f\nnet_rx_bps_max=%.2f\nnet_rx_bps_mean=%.2f\n", net_rx_bps_min, net_rx_bps_max, net_rx_bps_sum / n
+            printf "net_tx_bps_min=%.2f\nnet_tx_bps_max=%.2f\nnet_tx_bps_mean=%.2f\n", net_tx_bps_min, net_tx_bps_max, net_tx_bps_sum / n
+            printf "disk_read_total=%.0f\n", disk_read_bytes
+            printf "disk_write_total=%.0f\n", disk_write_bytes
+            printf "net_rx_total=%.0f\n", net_rx_bytes
+            printf "net_tx_total=%.0f\n", net_tx_bytes
+            printf "disk_read_avg_bps=%.2f\n", disk_read_bytes / elapsed
+            printf "disk_write_avg_bps=%.2f\n", disk_write_bytes / elapsed
+            printf "net_rx_avg_bps=%.2f\n", net_rx_bytes / elapsed
+            printf "net_tx_avg_bps=%.2f\n", net_tx_bytes / elapsed
+        }
+    ' "$samples_file" > "$stats_file"
+}
+
+format_bytes() {
+    awk -v bytes="$1" '
+        BEGIN {
+            split("B KiB MiB GiB TiB PiB", units, " ")
+            value = bytes + 0
+            unit = 1
+            while (value >= 1024 && unit < 6) {
+                value /= 1024
+                unit++
+            }
+            if (unit == 1) {
+                printf "%.0f %s\n", value, units[unit]
+            } else {
+                printf "%.2f %s\n", value, units[unit]
+            }
+        }
+    '
+}
+
+format_rate() {
+    printf "%s/s\n" "$(format_bytes "$1")"
+}
+
+sar_context() {
+    if command -v sar >/dev/null 2>&1; then
+        local version
+        version="$(sar -V 2>&1 | awk 'NR == 1 { print; exit }')"
+        printf "available (%s); summary uses /proc counters for dependency-free command wrapping\n" "$version"
+    else
+        printf "not found; install sysstat for sar, but this wrapper does not require it\n"
+    fi
+}
+
+emit_summary() {
+    local command_status="$1"
+    summarize_samples
+
+    local samples duration_s cpu_min cpu_max cpu_mean mem_min mem_max mem_mean
+    local swap_min swap_max swap_mean
+    local disk_read_bps_min disk_read_bps_max disk_read_bps_mean disk_write_bps_min
+    local disk_write_bps_max disk_write_bps_mean net_rx_bps_min net_rx_bps_max
+    local net_rx_bps_mean net_tx_bps_min net_tx_bps_max net_tx_bps_mean
+    local disk_read_total disk_write_total net_rx_total net_tx_total
+    local disk_read_avg_bps disk_write_avg_bps net_rx_avg_bps net_tx_avg_bps
+
+    # shellcheck disable=SC1090
+    source "$stats_file"
+
+    local cpu_cores ram_total swap_total command_display
+    local disk_read_total_h disk_write_total_h net_rx_total_h net_tx_total_h
+    local disk_read_avg_h disk_write_avg_h net_rx_avg_h net_tx_avg_h
+    local disk_read_min_h disk_read_max_h disk_read_mean_h
+    local disk_write_min_h disk_write_max_h disk_write_mean_h
+    local net_rx_min_h net_rx_max_h net_rx_mean_h
+    local net_tx_min_h net_tx_max_h net_tx_mean_h
+
+    cpu_cores="$(cpu_capacity)"
+    ram_total="$(format_bytes "$(memory_capacity_bytes)")"
+    swap_total="$(format_bytes "$(swap_capacity_bytes)")"
+    command_display="$(printf "%q " "${command_to_run[@]}")"
+    command_display="${command_display% }"
+
+    disk_read_total_h="$(format_bytes "$disk_read_total")"
+    disk_write_total_h="$(format_bytes "$disk_write_total")"
+    net_rx_total_h="$(format_bytes "$net_rx_total")"
+    net_tx_total_h="$(format_bytes "$net_tx_total")"
+
+    disk_read_avg_h="$(format_rate "$disk_read_avg_bps")"
+    disk_write_avg_h="$(format_rate "$disk_write_avg_bps")"
+    net_rx_avg_h="$(format_rate "$net_rx_avg_bps")"
+    net_tx_avg_h="$(format_rate "$net_tx_avg_bps")"
+
+    disk_read_min_h="$(format_rate "$disk_read_bps_min")"
+    disk_read_max_h="$(format_rate "$disk_read_bps_max")"
+    disk_read_mean_h="$(format_rate "$disk_read_bps_mean")"
+    disk_write_min_h="$(format_rate "$disk_write_bps_min")"
+    disk_write_max_h="$(format_rate "$disk_write_bps_max")"
+    disk_write_mean_h="$(format_rate "$disk_write_bps_mean")"
+    net_rx_min_h="$(format_rate "$net_rx_bps_min")"
+    net_rx_max_h="$(format_rate "$net_rx_bps_max")"
+    net_rx_mean_h="$(format_rate "$net_rx_bps_mean")"
+    net_tx_min_h="$(format_rate "$net_tx_bps_min")"
+    net_tx_max_h="$(format_rate "$net_tx_bps_max")"
+    net_tx_mean_h="$(format_rate "$net_tx_bps_mean")"
+
+    {
+        echo ""
+        echo "=== Host Load Sidecar: $label ==="
+        echo "Command: $command_display"
+        echo "Exit code: $command_status"
+        echo "Samples: $samples over ${duration_s}s (target interval: ${interval}s)"
+        echo "sar: $(sar_context)"
+        echo ""
+        echo "CPU utilization (capacity: ${cpu_cores} cores):"
+        echo "  min: ${cpu_min}% | max: ${cpu_max}% | mean: ${cpu_mean}%"
+        echo "Memory utilization (capacity: ${ram_total} RAM):"
+        echo "  min: ${mem_min}% | max: ${mem_max}% | mean: ${mem_mean}%"
+        echo "Swap utilization (capacity: ${swap_total} swap):"
+        echo "  min: ${swap_min}% | max: ${swap_max}% | mean: ${swap_mean}%"
+        echo "Disk reads:"
+        echo "  total: ${disk_read_total_h} | average rate: ${disk_read_avg_h}"
+        echo "  sample rate min: ${disk_read_min_h} | max: ${disk_read_max_h} | mean: ${disk_read_mean_h}"
+        echo "Disk writes:"
+        echo "  total: ${disk_write_total_h} | average rate: ${disk_write_avg_h}"
+        echo "  sample rate min: ${disk_write_min_h} | max: ${disk_write_max_h} | mean: ${disk_write_mean_h}"
+        echo "Network receive:"
+        echo "  total: ${net_rx_total_h} | average rate: ${net_rx_avg_h}"
+        echo "  sample rate min: ${net_rx_min_h} | max: ${net_rx_max_h} | mean: ${net_rx_mean_h}"
+        echo "Network transmit:"
+        echo "  total: ${net_tx_total_h} | average rate: ${net_tx_avg_h}"
+        echo "  sample rate min: ${net_tx_min_h} | max: ${net_tx_max_h} | mean: ${net_tx_mean_h}"
+    } > "$summary_tmp"
+
+    cat "$summary_tmp" >&2
+    if [[ -n "$summary_file" ]]; then
+        cat "$summary_tmp" >> "$summary_file"
+    fi
+}
+
+# shellcheck disable=SC2329  # Invoked by INT/TERM traps.
+forward_signal() {
+    local signal="$1"
+    : > "$stop_file"
+    if [[ -n "$command_pid" ]] && kill -0 "$command_pid" 2>/dev/null; then
+        kill "-$signal" "$command_pid" 2>/dev/null || true
+    fi
+}
+trap 'forward_signal INT' INT
+trap 'forward_signal TERM' TERM
+
+monitor_load &
+monitor_pid="$!"
+while [[ ! -f "$ready_file" ]]; do
+    if ! kill -0 "$monitor_pid" 2>/dev/null; then
+        wait "$monitor_pid" || true
+        die "monitor failed to start"
+    fi
+    sleep 0.05
+done
+
+"${command_to_run[@]}" &
+command_pid="$!"
+
+if wait "$command_pid"; then
+    command_status=0
+else
+    command_status="$?"
+fi
+
+: > "$stop_file"
+wait "$monitor_pid" || true
+
+emit_summary "$command_status"
+exit "$command_status"

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -574,7 +574,11 @@ jobs:
         timeout-minutes: 90
         run: |
           # --target install is for the tarball that should get replaced by proper packaging later
-          cmake --build build --target install
+          "$GITHUB_WORKSPACE/.github/scripts/utils/host-load-sidecar.sh" \
+            --interval 1 \
+            --label "cmake build (install target)" \
+            --output "$GITHUB_STEP_SUMMARY" \
+            -- cmake --build build --target install
 
       - name: 🛠️ Profile
         if: ${{ inputs.profile }}


### PR DESCRIPTION
### PR Category

Feature

### Summary

Adds a `host-load-sidecar.sh` script that wraps a CI command and samples host resource utilization (CPU, memory, disk I/O, network) while the command runs, then appends a markdown summary to `$GITHUB_STEP_SUMMARY` when it exits.

Motivation: we have no visibility into resource pressure on CI runners during long-running build and compile steps. This makes it hard to correlate OOMs, I/O stalls, or over-subscribed cores with flaky or slow jobs. The sidecar collects the data at effectively zero overhead — it's a background `sleep`-loop reading `/proc` and `/sys/block` — and surfaces it directly in the GitHub Actions step summary without requiring any external tooling.

Changes:
- `.github/scripts/utils/host-load-sidecar.sh` — new script. Forks a background sampler, runs the wrapped command to completion, kills the sampler, computes min/mean/max per metric, and appends a preformatted summary. Configurable via `--interval`, `--label`, `--output`, and environment variables. Requires only `/proc/stat`, `/proc/meminfo`, `/proc/net/dev`, `/proc/uptime`, and `/sys/block` — Linux-only, no extra dependencies.
- `build-artifact.yaml` — wraps `cmake --build build --target install` with the sidecar (1s interval, step summary output).

```
=== Host Load Sidecar: cmake build (install target) ===
Command: cmake --build build --target install
Exit code: 0
Samples: 784 over 1162.09s (target interval: 1s)
sar: not found; install sysstat for sar, but this wrapper does not require it
CPU utilization (capacity: 16 cores):
  min: 5.61% | max: 100.00% | mean: 98.76%
Memory utilization (capacity: 31.34 GiB RAM):
  min: 3.48% | max: 44.26% | mean: 24.95%
Swap utilization (capacity: 0 B swap):
  min: 0.00% | max: 0.00% | mean: 0.00%
Disk reads:
  total: 172.00 KiB | average rate: 152 B/s
  sample rate min: 0 B/s | max: 81.63 KiB/s | mean: 151 B/s
Disk writes:
  total: 8.66 GiB | average rate: 7.63 MiB/s
  sample rate min: 0 B/s | max: 308.35 MiB/s | mean: 7.62 MiB/s
Network receive:
  total: 263.34 MiB | average rate: 232.05 KiB/s
  sample rate min: 0 B/s | max: 45.87 MiB/s | mean: 233.32 KiB/s
Network transmit:
  total: 1.40 MiB | average rate: 1.23 KiB/s
  sample rate min: 0 B/s | max: 173.49 KiB/s | mean: 1.24 KiB/s

```

quasar n = 10
```
416309 passed, 2 skipped in 1161.76s (0:19:21)

CPU utilization (capacity: 40 cores):
  min: 2.50% | max: 97.76% | mean: 48.98%
Memory utilization (capacity: 78.53 GiB RAM):
  min: 1.86% | max: 55.58% | mean: 47.62%
Swap utilization (capacity: 0 B swap):
  min: 0.00% | max: 0.00% | mean: 0.00%
Disk reads:
  total: 464.00 KiB | average rate: 390 B/s
  sample rate min: 0 B/s | max: 165.14 KiB/s | mean: 389 B/s
Disk writes:
  total: 20.53 GiB | average rate: 17.27 MiB/s
  sample rate min: 0 B/s | max: 569.65 MiB/s | mean: 17.84 MiB/s
```
quasar n = 14
```
416309 passed, 2 skipped in 1113.77s (0:18:33)

Samples: 979 over 1156.18s (target interval: 1s)
CPU utilization (capacity: 40 cores):
  min: 2.49% | max: 99.79% | mean: 50.68%
Memory utilization (capacity: 78.53 GiB RAM):
  min: 1.86% | max: 73.10% | mean: 64.12%
Swap utilization (capacity: 0 B swap):
  min: 0.00% | max: 0.00% | mean: 0.00%
Physical disk reads:
  total: 472.00 KiB | average rate: 418 B/s
  sample rate min: 0 B/s | max: 160.71 KiB/s | mean: 439 B/s
Physical disk writes:
  total: 20.52 GiB | average rate: 18.17 MiB/s
  sample rate min: 0 B/s | max: 262.84 MiB/s | mean: 17.24 MiB/s


```
quasar n = 15
```
416309 passed, 2 skipped in 1135.71s (0:18:55)

CPU utilization (capacity: 40 cores):
  min: 2.68% | max: 99.81% | mean: 49.24%
Memory utilization (capacity: 78.53 GiB RAM):
  min: 1.86% | max: 77.68% | mean: 67.79%
Swap utilization (capacity: 0 B swap):
  min: 0.00% | max: 0.00% | mean: 0.00%
Physical disk reads:
  total: 368.00 KiB | average rate: 317 B/s
  sample rate min: 0 B/s | max: 162.16 KiB/s | mean: 331 B/s
Physical disk writes:
  total: 20.52 GiB | average rate: 17.69 MiB/s
  sample rate min: 0 B/s | max: 447.06 MiB/s | mean: 16.47 MiB/s


```

### Notes for reviewers

- The sidecar runs as a background subshell; signal handling and `EXIT` trap ensure cleanup even if the wrapped command is killed or errors out.
- Exit code is propagated faithfully — the sidecar exits with the wrapped command's exit code.
- `/proc`-based sampling is intentionally lightweight: no `top`, `iostat`, `vmstat`, or external binaries required.
- The step summary output is markdown so it renders natively in the GitHub Actions UI.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsexton/0-resource-sidecar)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsexton/0-resource-sidecar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsexton/0-resource-sidecar)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsexton/0-resource-sidecar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsexton/0-resource-sidecar)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsexton/0-resource-sidecar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsexton/0-resource-sidecar)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsexton/0-resource-sidecar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsexton/0-resource-sidecar)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsexton/0-resource-sidecar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsexton/0-resource-sidecar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsexton/0-resource-sidecar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsexton/0-resource-sidecar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsexton/0-resource-sidecar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsexton/0-resource-sidecar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsexton/0-resource-sidecar)
