### PR TITLE
experimental(indexer_score): generalized banded-product multicast (resident + streaming)

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -508,3 +508,72 @@ def test_indexer_score_perf_check(case_id, heads, expected_util):
         f"Math utilization {utilization:.2f}% outside band [{lower:.2f}, {upper:.2f}] "
         f"(expected {expected_util:.2f}%, margin +/- {INDEXER_PERF_MARGIN * 100:.1f}%)"
     )
+
+
+# ---------------------------------------------------------------------------
+# Generalized-multicast regime coverage (accuracy): exercises the banded-product scheduler paths the
+# small knobs/shapes tests miss -- chiefly G > grid.y (groups phase-stacked onto rows, the case that
+# would deadlock the k-mcast column if rows took uneven group counts), G prime > grid.y (rows_used==1,
+# k-mcast off but still correct), uneven k-band split across columns (U not a multiple of grid.x),
+# partial last band, and phase-stacking under head streaming. Same exact -inf + PCC + negative-gate
+# check as the deployments. q_chunk/k_chunk are in ELEMENTS (tiles*32); head_group 0 = all resident.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "heads, dim, sq, t, chunk_start, q_chunk, k_chunk, head_group",
+    [
+        # G>gy, uniform groups/row (G=12 -> rows_used=6, 2 groups/row), U==grid.x (k-mcast on)
+        (8, 128, 384, 704, 128, 32, 64, 0),
+        # G>gy with U NOT a multiple of grid.x=11 (G=20 -> rows_used=10, 2 groups/row; U=50, uneven cols)
+        (8, 128, 640, 1600, 256, 32, 32, 0),
+        # G prime > gy (Sqt=11, QC=1 -> G=11 -> rows_used=1, k-mcast off): correctness without mcast
+        (8, 128, 352, 512, 128, 32, 32, 0),
+        # G>gy + KC does not divide Tt (partial last band) + U<grid.x (G=12, U=7)
+        (8, 128, 384, 608, 64, 32, 96, 0),
+        # G>gy + head streaming (HB=8<16): q-mcast + k-mcast on, phase-stacked groups
+        (16, 128, 384, 704, 128, 32, 64, 8),
+        # G>gy big (G=40 -> rows_used=10, 4 groups/row) + uneven U
+        (8, 128, 1280, 1600, 256, 32, 32, 0),
+    ],
+    ids=[
+        "Ggy_uniform",
+        "Ggy_uneven_U",
+        "Ggy_prime",
+        "Ggy_partial_kc",
+        "Ggy_stream",
+        "Ggy_big",
+    ],
+)
+def test_indexer_score_genmcast_regimes(device, heads, dim, sq, t, chunk_start, q_chunk, k_chunk, head_group):
+    """Banded-product scheduler regimes beyond the original knobs/shapes coverage: G>grid.y phase
+    stacking, prime G, uneven k-band columns, partial bands, and streaming -- all checked for exact
+    causality + PCC like the deployments."""
+    _run_and_check(device, heads, dim, sq, t, chunk_start, q_chunk, k_chunk, head_group)
+
+
+def test_indexer_score_streaming_qmcast_uneven_bands(device):
+    """Streaming (HB<Hi) q-mcast with an UNEVEN k-band split across a grid row -- the situation a naive
+    per-output-tile q-mcast would deadlock on: cores in the same row own different band counts, so they
+    would issue different numbers of q reads / mcast rendezvous and the row's sender would wait forever
+    on receivers that already finished.
+
+    The dummy-pad scheduler fixes this by padding every core's streaming band loop to max_bands (the
+    row's widest column) with phantom q-only bands, so the q-mcast handshake count is uniform per row.
+    This test pins that the op stays correct (no hang, exact -inf + PCC) on that shape. U=23 is prime,
+    so min(U, grid.x) never divides it -> the band split is uneven (max_bands > min band count) on any
+    Blackhole grid width.
+    """
+    heads, dim, sq, t = 16, 128, 128, 736  # Hi=16, Sqt=4, Tt=23
+    chunk_start, q_chunk, k_chunk, head_group = 128, 32, 32, 8  # QC=1, KC=1, HB=8 (< Hi -> streaming)
+
+    grid = device.compute_with_storage_grid_size()
+    QC, KC = q_chunk // 32, k_chunk // 32
+    G, U = (sq // 32) // QC, ((t // 32) + KC - 1) // KC
+    cols_used = min(U, grid.x)
+    max_bands = (U + cols_used - 1) // cols_used
+    min_bands = U // cols_used
+    # Precondition: this really is the deadlock-prone shape (streaming, >1 column, uneven bands).
+    assert head_group < heads, "must be streaming (HB < Hi)"
+    assert cols_used > 1, f"need >1 column for q-mcast: cols_used={cols_used}"
+    assert max_bands > min_bands, f"need an uneven band split: U={U}, cols_used={cols_used}"
+
+    _run_and_check(device, heads, dim, sq, t, chunk_start, q_chunk, k_chunk, head_group)

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -10,6 +10,8 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
 
+#include "kernels/indexer_score_work_split.hpp"  // shared banded grid mapping (rows_for_groups / cols_for_bands)
+
 namespace ttnn::operations::experimental::indexer_score {
 
 IndexerScoreDeviceOperation::program_factory_t IndexerScoreDeviceOperation::select_program_factory(
@@ -179,13 +181,15 @@ IndexerScoreDeviceOperation::create_op_performance_model(
     const uint64_t num_mul_adds =
         2ull * valid_tiles * Hi * B * static_cast<uint64_t>(tt::constants::TILE_HEIGHT * tt::constants::TILE_WIDTH) * D;
 
-    // Actual cores used: total_units = groups x ceil(Tt/KC), clamped to the grid (matches the factory),
-    // so the perf model's core count equals tracy's CORE COUNT and the utilization ratio lines up.
+    // Cores used: the banded schedule's rows_for_groups x cols_for_bands rectangle. Shares the mapping
+    // with the factory, so this count equals the factory's (and tracy's CORE COUNT).
     const uint32_t QC = attrs.program_config.q_chunk_size / tt::constants::TILE_HEIGHT;
     const uint32_t KC = attrs.program_config.k_chunk_size / tt::constants::TILE_WIDTH;
-    const uint64_t total_units = static_cast<uint64_t>(Sqt / QC) * ((Tt + KC - 1) / KC);
+    const uint32_t group_count = Sqt / QC;
+    const uint32_t band_count = units_in_group(KC, Tt);  // ceil(Tt/KC); shared with the factory
     const auto grid = q.device()->compute_with_storage_grid_size();
-    const uint64_t num_cores = std::min<uint64_t>(total_units, static_cast<uint64_t>(grid.x) * grid.y);
+    const uint64_t num_cores =
+        static_cast<uint64_t>(rows_for_groups(group_count, grid.y)) * cols_for_bands(band_count, grid.x);
 
     // Blackhole matmul peak: 4096 mul-adds/cycle/core at LoFi, scaled by the fidelity multiplier (the
     // test's peak table is 4096 / multiplier). Fidelity comes from the resolved compute config.

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
@@ -170,9 +170,9 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create(
 
     const bool stream_heads = HB < Hi;
 
-    // One-line schedule/mcast summary (per program-cache miss) so tests and profiling can read the
-    // active multicast directions without decoding compile-time args.
-    log_info(
+    // One-line schedule/mcast summary (per program-cache miss) so profiling can read the active
+    // multicast directions without decoding compile-time args.
+    log_debug(
         tt::LogOp,
         "indexer_score schedule: G={} U={} grid={}x{} rows_used={} cols_used={} num_groups={} "
         "max_bands={} stream_heads={} k_mcast={} q_mcast={}",

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
+#include <tt-logger/tt-logger.hpp>         // log_info: per-program schedule/mcast summary
 #include "hostdevcommon/kernel_structs.h"  // tt::CBIndex
 
 #include "ttnn/operations/transformer/sdpa/device/sdpa_subblock_utils.hpp"
@@ -36,72 +37,11 @@ inline void patch_arg(tt::tt_metal::RuntimeArgsData& args, uint32_t index, uint3
     args[index] = value;
 }
 
-// Dense deal landed exactly on the grid (q/w mcast along rows, k down columns) and each direction's
-// lines form contiguous NoC rects. 0 = direction off (per-core DRAM read); see call-site block.
-struct McastPlan {
-    bool grid_aligned = false;
-    uint32_t k_mcast_on = 0;  // K columns are vertical NoC rects
-    uint32_t q_mcast_on = 0;  // Q/W rows are single horizontal NoC rects (covers q and w)
-};
-
-// Pure analysis of the physical core coords: grid alignment + per-line NoC-rect contiguity for the
-// two mcast directions. phys is indexed row-major (y * grid.x + x).
-inline McastPlan compute_mcast_plan(
-    CoreCoord grid,
-    const std::vector<CoreCoord>& phys,
-    uint32_t groups,
-    uint32_t num_cores,
-    uint32_t base,
-    uint32_t rem,
-    uint64_t total_units,
-    uint32_t HB,
-    uint32_t Hi) {
-    const auto cidx = [&](uint32_t x, uint32_t y) { return y * grid.x + x; };
-    // grid-aligned iff group g == grid row y and the row's grid_x cores evenly split its k-chunks
-    // (units_per_group == grid.x * base, no remainder, full grid).
-    const uint32_t units_per_group = groups > 0 ? (uint32_t)(total_units / groups) : 0;
-    const bool grid_aligned =
-        groups == grid.y && num_cores == (uint32_t)(grid.x * grid.y) && rem == 0 && units_per_group == grid.x * base;
-
-    // K columns must be vertical NoC rects: shared x down the column, contiguous y spanning the grid.
-    bool k_cols_ok = grid_aligned;
-    for (uint32_t x = 0; x < grid.x && k_cols_ok; ++x) {
-        const uint32_t px = phys[cidx(x, 0)].x;
-        uint32_t ymin = phys[cidx(x, 0)].y, ymax = ymin;
-        for (uint32_t y = 0; y < grid.y; ++y) {
-            const auto& p = phys[cidx(x, y)];
-            if (p.x != px) {
-                k_cols_ok = false;
-            }
-            ymin = std::min<uint32_t>(ymin, p.y);
-            ymax = std::max<uint32_t>(ymax, p.y);
-        }
-        if (ymax - ymin + 1 != grid.y) {
-            k_cols_ok = false;
-        }
-    }
-    // Q/W row-mcast needs every core in a logical row on ONE physical NoC row (mcast = the row's
-    // horizontal bounding-box rect) and all heads resident (one q block). x-contiguity not required
-    // (the NoC routes the bbox rect); only a row spanning multiple physical NoC rows disables it.
-    // grid.x >= grid.y guards the diagonal sender lookup phys[cidx(y, y)] at the call site: cidx(y, y)
-    // is in-bounds only while y < grid.x, which holds for every row iff the grid is at least as wide as
-    // tall (always true on Blackhole's 14x10 grid; the guard keeps a narrower grid safe).
-    bool q_rows_ok = grid_aligned && HB == Hi && grid.x >= grid.y;
-    for (uint32_t y = 0; y < grid.y && q_rows_ok; ++y) {
-        const uint32_t py = phys[cidx(0, y)].y;
-        for (uint32_t x = 0; x < grid.x; ++x) {
-            if (phys[cidx(x, y)].y != py) {
-                q_rows_ok = false;
-            }
-        }
-    }
-    return {grid_aligned, k_cols_ok ? 1u : 0u, q_rows_ok ? 1u : 0u};
-}
-
-// Output-stationary flat deal of causal-valid work units. One unit = QC q-tile-rows x up-to-KC
-// k-tiles, dealt evenly across cores row-major (kernels invert the flat index). Heads stream in
-// HB-head groups; fully-future tiles get the full -inf mask, row tails -inf-filled by the writer
-// (zeros unsafe: gates can be negative).
+// Banded-product schedule: the work space (group_count q-row-groups x band_count k-bands) tiles onto
+// a rows_used x cols_used core rectangle -- groups -> rows (q/w multicast along a row), bands ->
+// columns (k multicast down a column). One (group, band) cell = one work unit of QC q-tile-rows x
+// up-to-KC k-tiles. Heads stream in HB-head groups; the causal masked suffix is stamped to -inf by
+// compute (zeros unsafe: gates can be negative). See indexer_score_work_split.hpp for the grid map.
 IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create(
     const operation_attributes_t& args, const tensor_args_t& tensors, tensor_return_value_t& out) {
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
@@ -144,52 +84,53 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create(
     // QC/KC/HB are verbatim from the config -- no auto-tune; the caller owns the perf trade-off (see
     // glx_config() in the test). An oversized config is not clamped; it fails at CB allocation.
 
-    // total work units V = groups x the per-group unit count (uniform under the dense schedule; groups
-    // exact since validate guarantees QC divides Sqt). units_in_group is the shared formula the kernels'
-    // WorkUnitSpan inverts.
-    const uint32_t groups = Sqt / QC;
-    const uint64_t total_units = (uint64_t)groups * units_in_group(KC, Tt);
-
+    // ---- banded-product schedule -------------------------------------------------------------
+    // Work space = group_count q-row-groups x band_count k-bands, tiled onto a rows_used x cols_used
+    // rectangle: groups -> rows (q/w mcast along a row), bands -> columns (k mcast down a column). Rows
+    // phase-stack groups when group_count > grid_y; each column owns a contiguous chunk of bands.
+    const uint32_t group_count = Sqt / QC;
+    const uint32_t band_count = units_in_group(KC, Tt);  // ceil(Tt/KC)
     const auto grid = q.device()->compute_with_storage_grid_size();
-    const uint32_t num_cores = std::min<uint64_t>(total_units, (uint64_t)grid.x * grid.y);
-    const auto core_ranges = tt::tt_metal::num_cores_to_corerangeset(num_cores, grid, true);
-    const auto cores = tt::tt_metal::corerange_to_cores(core_ranges, num_cores, true);
+    const uint32_t grid_x = grid.x, grid_y = grid.y;
 
-    const uint32_t base = total_units / num_cores;
-    const uint32_t rem = total_units % num_cores;
+    const uint32_t rows_used = rows_for_groups(group_count, grid_y);
+    const uint32_t cols_used = cols_for_bands(band_count, grid_x);
+    const uint32_t num_cores = rows_used * cols_used;
 
-    // ---- grid-aligned multicast (decoupled Q/W along rows, K down columns) -------------------
-    // When the dense deal lands exactly on the grid, a grid ROW shares identical q/w and a grid COLUMN
-    // shares the identical k-band: one core per row mcasts q/w along it, one per column mcasts k down
-    // it, killing ~grid_x q/w re-reads + ~grid_y k re-reads. Each direction is independent, enabled only
-    // if its lines are contiguous NoC rects; else that input falls back to per-core DRAM reads.
-    std::vector<CoreCoord> phys(num_cores);
-    for (uint32_t i = 0; i < num_cores; ++i) {
-        phys[i] = q.device()->worker_core_from_logical_core(cores[i]);
+    // Even band split across the used columns: the first (band_count % cols_used) columns get one extra.
+    std::vector<uint32_t> col_band_start(cols_used), col_band_size(cols_used);
+    {
+        const uint32_t bands_per_col = band_count / cols_used, extra = band_count % cols_used;
+        uint32_t off = 0;
+        for (uint32_t col = 0; col < cols_used; ++col) {
+            col_band_size[col] = bands_per_col + (col < extra ? 1u : 0u);
+            col_band_start[col] = off;
+            off += col_band_size[col];
+        }
     }
-    const McastPlan plan = compute_mcast_plan(grid, phys, groups, num_cores, base, rem, total_units, HB, Hi);
-    const bool grid_aligned = plan.grid_aligned;
-    const uint32_t k_mcast_on = plan.k_mcast_on;
-    const uint32_t q_mcast_on = plan.q_mcast_on;
+    // rows_used divides group_count, so every row runs the same num_groups (group = y + p*rows_used).
+    // Uniformity keeps every column's k-mcast in lockstep.
+    const uint32_t num_groups = group_count / rows_used;
+    // Widest column's band count: the streaming q-mcast pad target. Streaming re-reads q per output tile,
+    // so the uneven per-column band counts would desync the row's q-mcast; the kernels pad each row to
+    // max_bands with dummy q-only "phantom" bands (band-independent data) to keep the rendezvous uniform.
+    const uint32_t max_bands = (band_count + cols_used - 1) / cols_used;
 
-    auto cidx = [&](uint32_t x, uint32_t y) { return y * grid.x + x; };
-    // Physical NoC bounding box of one grid column / row, used to build the multicast rects below.
-    auto phys_col_y_range = [&](uint32_t x) {  // [min y, max y] down grid column x
-        uint32_t lo = static_cast<uint32_t>(phys[cidx(x, 0)].y), hi = lo;
-        for (uint32_t y = 0; y < grid.y; ++y) {
-            lo = std::min<uint32_t>(lo, static_cast<uint32_t>(phys[cidx(x, y)].y));
-            hi = std::max<uint32_t>(hi, static_cast<uint32_t>(phys[cidx(x, y)].y));
+    const CoreRange core_rect(CoreCoord{0, 0}, CoreCoord{cols_used - 1, rows_used - 1});
+    const CoreRangeSet core_ranges(core_rect);
+
+    // Physical coords of the used rectangle, indexed [row][col], for the mcast bounding boxes below.
+    std::vector<std::vector<CoreCoord>> phys(rows_used, std::vector<CoreCoord>(cols_used));
+    for (uint32_t row = 0; row < rows_used; ++row) {
+        for (uint32_t col = 0; col < cols_used; ++col) {
+            phys[row][col] = q.device()->worker_core_from_logical_core(CoreCoord{col, row});
         }
-        return std::pair<uint32_t, uint32_t>{lo, hi};
-    };
-    auto phys_row_x_range = [&](uint32_t y) {  // [min x, max x] across grid row y
-        uint32_t lo = static_cast<uint32_t>(phys[cidx(0, y)].x), hi = lo;
-        for (uint32_t x = 0; x < grid.x; ++x) {
-            lo = std::min<uint32_t>(lo, static_cast<uint32_t>(phys[cidx(x, y)].x));
-            hi = std::max<uint32_t>(hi, static_cast<uint32_t>(phys[cidx(x, y)].x));
-        }
-        return std::pair<uint32_t, uint32_t>{lo, hi};
-    };
+    }
+
+    // k-mcast needs >1 row down a column; q/w-mcast needs >1 column along a row. Both are HB-independent:
+    // streaming keeps q-mcast via the phantom-band pad (see max_bands above), so neither gates on HB.
+    const uint32_t k_mcast_on = (rows_used > 1) ? 1u : 0u;
+    const uint32_t q_mcast_on = (cols_used > 1) ? 1u : 0u;
 
     // 3 semaphores per active direction: send (receivers ready), recv (sender relays valid in), valid
     // (constant 1, relay source). Mirrors SDPA chain_link's handshake.
@@ -228,6 +169,24 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create(
     };
 
     const bool stream_heads = HB < Hi;
+
+    // One-line schedule/mcast summary (per program-cache miss) so tests and profiling can read the
+    // active multicast directions without decoding compile-time args.
+    log_info(
+        tt::LogOp,
+        "indexer_score schedule: G={} U={} grid={}x{} rows_used={} cols_used={} num_groups={} "
+        "max_bands={} stream_heads={} k_mcast={} q_mcast={}",
+        group_count,
+        band_count,
+        grid_x,
+        grid_y,
+        rows_used,
+        cols_used,
+        num_groups,
+        max_bands,
+        stream_heads ? 1 : 0,
+        k_mcast_on,
+        q_mcast_on);
 
     // Allocate each CB by its CbArg slot; make_cb assigns the next continuous index.
     make_cb(cb_q_arg, (stream_heads ? 2 : 1) * HB * QC * Dt, q_fmt, q_tile);
@@ -313,21 +272,49 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create(
             .math_approx_mode = math_approx_mode,
             .compile_args = compute_ct});
 
-    // Per-core multicast runtime args: K column then Q/W row, each an 8-tuple (push_mcast_dir below); the two
-    // together are what the non-grid-aligned fallback zero-fills.
-    constexpr uint32_t mcast_args_per_dir = 8;
-    constexpr uint32_t reader_mcast_args = 2 * mcast_args_per_dir;
+    // Per-core args: schedule {row_group0, group_stride, num_groups, band0, num_bands, max_bands} then
+    // (reader only) the K-column + Q/W-row mcast 8-tuples. role is a McastRole (none = per-core DRAM read); rect
+    // (xs,ys,xe,ye) + sender (sx,sy) are physical NoC; ndst = #receivers. mcast rects are fixed per core
+    // (one column for k, one row for q); only the data changes per group/band phase.
+    const auto u32 = [](auto v) { return static_cast<uint32_t>(v); };
+    std::vector<CoreCoord> cores;
+    cores.reserve(num_cores);
+    for (uint32_t row = 0; row < rows_used; ++row) {
+        // physical bbox of this row across the used columns (q/w mcast rect); py constant along the row.
+        uint32_t q_xs = u32(phys[row][0].x), q_xe = u32(phys[row][0].x);
+        for (uint32_t bbox_col = 0; bbox_col < cols_used; ++bbox_col) {
+            q_xs = std::min<uint32_t>(q_xs, u32(phys[row][bbox_col].x));
+            q_xe = std::max<uint32_t>(q_xe, u32(phys[row][bbox_col].x));
+        }
+        const uint32_t q_py = u32(phys[row][0].y);
+        const uint32_t q_diag = std::min<uint32_t>(row, cols_used - 1);  // diagonal sender column
+        const CoreCoord q_sender = phys[row][q_diag];
+        for (uint32_t col = 0; col < cols_used; ++col) {
+            // physical bbox of this column down the used rows (k mcast rect); px constant down the column.
+            uint32_t k_ys = u32(phys[0][col].y), k_ye = u32(phys[0][col].y);
+            for (uint32_t bbox_row = 0; bbox_row < rows_used; ++bbox_row) {
+                k_ys = std::min<uint32_t>(k_ys, u32(phys[bbox_row][col].y));
+                k_ye = std::max<uint32_t>(k_ye, u32(phys[bbox_row][col].y));
+            }
+            const uint32_t k_px = u32(phys[0][col].x);
+            const CoreCoord k_sender = phys[0][col];
 
-    uint32_t flat = 0;
-    for (uint32_t i = 0; i < num_cores; ++i) {
-        const uint32_t count = base + (i < rem ? 1 : 0);
-        std::vector<uint32_t> reader_rt = {
-            q.buffer()->address(), k.buffer()->address(), w.buffer()->address(), flat, count};
-        // Per-core mcast args: K column (8) then Q/W row (8). role is a McastRole (none = per-core DRAM
-        // read); rect (xs,ys,xe,ye) + sender (sx,sy) are physical NoC; ndst = #receivers.
-        const auto u32 = [](auto v) { return static_cast<uint32_t>(v); };
-        const auto push_mcast_dir =
-            [&](uint32_t role, uint32_t xs, uint32_t ys, uint32_t xe, uint32_t ye, const CoreCoord& s, uint32_t ndst) {
+            const CoreCoord core{col, row};
+            cores.push_back(core);
+            // {row_group0, group_stride, num_groups, band0, num_bands, max_bands}. max_bands is uniform
+            // (the row's widest column); the streaming reader/compute pad their band loop to it.
+            const std::array<uint32_t, 6> sched = {
+                row, rows_used, num_groups, col_band_start[col], col_band_size[col], max_bands};
+
+            std::vector<uint32_t> reader_rt = {q.buffer()->address(), k.buffer()->address(), w.buffer()->address()};
+            reader_rt.insert(reader_rt.end(), sched.begin(), sched.end());
+            const auto push_mcast_dir = [&](uint32_t role,
+                                            uint32_t xs,
+                                            uint32_t ys,
+                                            uint32_t xe,
+                                            uint32_t ye,
+                                            const CoreCoord& s,
+                                            uint32_t ndst) {
                 reader_rt.push_back(role);
                 reader_rt.push_back(xs);
                 reader_rt.push_back(ys);
@@ -337,44 +324,30 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create(
                 reader_rt.push_back(u32(s.y));
                 reader_rt.push_back(ndst);
             };
-        if (grid_aligned) {
-            const uint32_t x = i % grid.x, y = i / grid.x;
-            // K column x: sender on row 0, receivers down the column; vertical rect spanning the column.
-            const auto [kys, kye] = phys_col_y_range(x);
+            // K column: sender row 0, receivers rows [1, rows_used); vertical rect spanning the column.
             push_mcast_dir(
-                k_mcast_on ? (y == 0 ? mcast_role_sender : mcast_role_receiver) : mcast_role_none,
-                u32(phys[cidx(x, 0)].x),
-                kys,
-                u32(phys[cidx(x, 0)].x),
-                kye,
-                phys[cidx(x, 0)],
-                u32(grid.y) - 1);
-            // Q/W row y: same shape as the K column; the ONLY difference is the sender sits on the grid
-            // DIAGONAL (logical x == y) instead of row 0 -- any core in the row can send (all share q/w),
-            // and the diagonal fans senders across distinct columns rather than stacking in one. The
-            // diagonal lookup phys[cidx(y, y)] is in-bounds only when q_mcast_on held (q_rows_ok requires
-            // grid.x >= grid.y); with q-mcast off the role is none and the rect/sender are unused, so fall
-            // back to this core's own coord to keep the index valid.
-            const auto [qxs, qxe] = phys_row_x_range(y);
-            const CoreCoord q_sender = q_mcast_on ? phys[cidx(y, y)] : phys[i];
-            const uint32_t qpy = u32(q_sender.y);  // sender's row == every core's py in this grid row
+                k_mcast_on ? (row == 0 ? mcast_role_sender : mcast_role_receiver) : mcast_role_none,
+                k_px,
+                k_ys,
+                k_px,
+                k_ye,
+                k_sender,
+                rows_used - 1);
+            // Q/W row: sender on the diagonal column, receivers the rest of the row; horizontal rect.
             push_mcast_dir(
-                q_mcast_on ? (x == y ? mcast_role_sender : mcast_role_receiver) : mcast_role_none,
-                qxs,
-                qpy,
-                qxe,
-                qpy,
+                q_mcast_on ? (col == q_diag ? mcast_role_sender : mcast_role_receiver) : mcast_role_none,
+                q_xs,
+                q_py,
+                q_xe,
+                q_py,
                 q_sender,
-                u32(grid.x) - 1);
-        } else {
-            for (uint32_t z = 0; z < reader_mcast_args; ++z) {
-                reader_rt.push_back(0);
-            }
+                cols_used - 1);
+            tt::tt_metal::SetRuntimeArgs(program, reader_id, core, reader_rt);
+            tt::tt_metal::SetRuntimeArgs(program, compute_id, core, std::vector<uint32_t>(sched.begin(), sched.end()));
+            std::vector<uint32_t> writer_rt = {out.buffer()->address()};
+            writer_rt.insert(writer_rt.end(), sched.begin(), sched.end());
+            tt::tt_metal::SetRuntimeArgs(program, writer_id, core, writer_rt);
         }
-        tt::tt_metal::SetRuntimeArgs(program, reader_id, cores[i], reader_rt);
-        tt::tt_metal::SetRuntimeArgs(program, compute_id, cores[i], {flat, count});
-        tt::tt_metal::SetRuntimeArgs(program, writer_id, cores[i], {out.buffer()->address(), flat, count});
-        flat += count;
     }
 
     return {

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/compute_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/compute_indexer_score.cpp
@@ -55,18 +55,18 @@ inline void set_matmul_mode() {
     pack_relu_config(ReluConfig::zero());  // relu in the packer for the whole matmul phase
 }
 
-/** Matmul one DEST pass of relu(q.kT): HP head-rows of q row r vs k col c, left in DEST (caller packs).
- *  q blocks are [QC][HG][Dt] so head rows stride head_dim_tiles. Assumes set_matmul_mode() ran. */
+/** Matmul one DEST pass of relu(q.kT): HP head-rows of q-row q_row vs k-col k_col, left in DEST (caller
+ *  packs). q blocks are [QC][HG][Dt] so head rows stride head_dim_tiles. Assumes set_matmul_mode() ran. */
 template <uint32_t q_cb, uint32_t k_cb>
-inline void emit_qk_matmul_block(uint32_t head_in_group, uint32_t r, uint32_t c) {
+inline void emit_qk_matmul_block(uint32_t head_in_group, uint32_t q_row, uint32_t k_col) {
     tile_regs_acquire();
-    const uint32_t q_base = (r * heads_per_group + head_in_group) * head_dim_tiles;
-    for (uint32_t d = 0; d < head_dim_tiles; ++d) {
+    const uint32_t q_base = (q_row * heads_per_group + head_in_group) * head_dim_tiles;
+    for (uint32_t dim_tile = 0; dim_tile < head_dim_tiles; ++dim_tile) {
         matmul_block(
             q_cb,
             k_cb,
-            q_base + d,
-            c * head_dim_tiles + d,
+            q_base + dim_tile,
+            k_col * head_dim_tiles + dim_tile,
             0,
             1 /*transpose k*/,
             1,
@@ -76,11 +76,11 @@ inline void emit_qk_matmul_block(uint32_t head_in_group, uint32_t r, uint32_t c)
     tile_regs_commit();
 }
 
-/** One matmul-phase DEST pass: relu(q row r @ k col c^T) block-packed into cb_qk front (tile-major). */
+/** One matmul-phase DEST pass: relu(q-row q_row @ k-col k_col^T) block-packed into cb_qk front. */
 template <uint32_t q_cb, uint32_t k_cb, uint32_t qk_cb>
-void matmul_relu_pass(uint32_t head_in_group, uint32_t r, uint32_t c) {
+void matmul_relu_pass(uint32_t head_in_group, uint32_t q_row, uint32_t k_col) {
     CircularBuffer qk(qk_cb);
-    emit_qk_matmul_block<q_cb, k_cb>(head_in_group, r, c);
+    emit_qk_matmul_block<q_cb, k_cb>(head_in_group, q_row, k_col);
     qk.reserve_back(heads_per_dest_pass);
     tile_regs_wait();
     pack_tile_block(0, qk_cb, heads_per_dest_pass);
@@ -117,8 +117,8 @@ void mul_accum_chunk(uint32_t w_base, uint32_t chunk_heads, bool first, uint32_t
     CircularBuffer qk(qk_cb);
     qk.wait_front(chunk_heads);
     tile_regs_acquire();
-    for (uint32_t h = 0; h < chunk_heads; ++h) {
-        mul_tiles_bcast_cols(qk_cb, w_cb, h, w_base + h, 0);
+    for (uint32_t head = 0; head < chunk_heads; ++head) {
+        mul_tiles_bcast_cols(qk_cb, w_cb, head, w_base + head, 0);
     }
     tile_regs_commit();
     tile_regs_wait();
@@ -132,12 +132,13 @@ void mul_accum_chunk(uint32_t w_base, uint32_t chunk_heads, bool first, uint32_t
  *  (head+d)*cols + col_in_batch), the layout the blocked mul streams as SrcA. Uses llk_matmul_pack
  *  out_of_order (generic pack misreads the matmul DEST layout). Caller reserves cols*num_heads once. */
 template <uint32_t q_cb, uint32_t k_cb, uint32_t qk_cb>
-void matmul_relu_pass_headmajor(uint32_t head_in_group, uint32_t r, uint32_t c, uint32_t col_in_batch, uint32_t cols) {
-    emit_qk_matmul_block<q_cb, k_cb>(head_in_group, r, c);
+void matmul_relu_pass_headmajor(
+    uint32_t head_in_group, uint32_t q_row, uint32_t k_col, uint32_t col_in_batch, uint32_t cols) {
+    emit_qk_matmul_block<q_cb, k_cb>(head_in_group, q_row, k_col);
     tile_regs_wait();
-    for (uint32_t d = 0; d < heads_per_dest_pass; ++d) {
+    for (uint32_t dim_tile = 0; dim_tile < heads_per_dest_pass; ++dim_tile) {
         PACK((llk_matmul_pack<DST_ACCUM_MODE, true /*out_of_order*/, PackMode::Default>(
-            d, qk_cb, 1 /*ntiles*/, (head_in_group + d) * cols + col_in_batch)));  // relu(q.kT), head-major slot
+            dim_tile, qk_cb, 1 /*ntiles*/, (head_in_group + dim_tile) * cols + col_in_batch)));  // head-major slot
     }
     tile_regs_release();
 }
@@ -150,11 +151,11 @@ inline void set_mul_mode_custom() {
     mul_bcast_cols_init_short_custom(qk_cb, w_cb);
 }
 
-/** Per-column (qk_col_batch==1) head reduction for output tile (r,c): acc_cb[acc_slot] =
- *  sum_h relu(q[h,r].k[c]^T)*w[h,r], MAC'd in DEST per chunk, L1-acc only across chunks. Caller
- *  owns acc_cb. */
+/** Per-column (qk_col_batch==1) head reduction for output tile (q_row, k_col): acc_cb[acc_slot] =
+ *  sum_h relu(q[h,q_row].k[k_col]^T)*w[h,q_row], MAC'd in DEST per chunk, L1-acc only across chunks.
+ *  Caller owns acc_cb. */
 template <uint32_t acc_cb>
-inline void accumulate_heads(uint32_t r, uint32_t c, uint32_t acc_slot) {
+inline void accumulate_heads(uint32_t q_row, uint32_t k_col, uint32_t acc_slot) {
     CircularBuffer q(cb_q);
     bool first = true;
     for (uint32_t group_start = 0; group_start < num_heads; group_start += heads_per_group) {
@@ -167,11 +168,11 @@ inline void accumulate_heads(uint32_t r, uint32_t c, uint32_t acc_slot) {
             const uint32_t chunk_end = chunk + qk_batch_heads;
             set_matmul_mode<cb_q, cb_k, cb_qk>();
             for (uint32_t head = chunk; head < chunk_end; head += heads_per_dest_pass) {
-                matmul_relu_pass<cb_q, cb_k, cb_qk>(head, r, c);
+                matmul_relu_pass<cb_q, cb_k, cb_qk>(head, q_row, k_col);
             }
             set_mul_mode<cb_qk, cb_w, acc_cb>();
             // w is laid out [q_tiles_per_unit][num_heads] (see reader read_w_group)
-            const uint32_t w_base = r * num_heads + group_start + chunk;
+            const uint32_t w_base = q_row * num_heads + group_start + chunk;
             mul_accum_chunk<cb_qk, cb_w, acc_cb>(w_base, qk_batch_heads, first, acc_slot);
             first = false;
         }
@@ -212,16 +213,16 @@ inline void stamp_mask_tile(uint32_t slot, uint32_t k_tile, uint32_t diag_tile) 
 // (qk_col_batch=2 < KC) interleaves per 2-column batch.
 // ---------------------------------------------------------------------------------------------------
 
-/** PHASE 1 -- fill cb_qk HEAD-MAJOR with relu(q[:,r].k[col_base..]^T) for one k-col batch of row r.
+/** PHASE 1 -- fill cb_qk HEAD-MAJOR with relu(q[:,q_row].k[col_base..]^T) for one k-col batch of q_row.
  *  One set_matmul_mode for the batch (reinit hoisted out of the col loop), one cb_qk reserve/push. */
-inline void matmul_phase(uint32_t r, uint32_t col_base, uint32_t cols) {
+inline void matmul_phase(uint32_t q_row, uint32_t col_base, uint32_t cols) {
     const uint32_t batch_tiles = cols * num_heads;
     CircularBuffer qk(cb_qk);
     set_matmul_mode<cb_q, cb_k, cb_qk>();
     qk.reserve_back(batch_tiles);
     for (uint32_t col_in_batch = 0; col_in_batch < cols; ++col_in_batch) {
         for (uint32_t head = 0; head < num_heads; head += heads_per_dest_pass) {
-            matmul_relu_pass_headmajor<cb_q, cb_k, cb_qk>(head, r, col_base + col_in_batch, col_in_batch, cols);
+            matmul_relu_pass_headmajor<cb_q, cb_k, cb_qk>(head, q_row, col_base + col_in_batch, col_in_batch, cols);
         }
     }
     qk.push_back(batch_tiles);
@@ -232,9 +233,9 @@ inline void matmul_phase(uint32_t r, uint32_t col_base, uint32_t cols) {
  *  is one unpack context (w[h] once + ct_dim cols) that MACs onto dest[0..n_cols), so unpack-context
  *  sync is per head, not per (col, head). ELWMUL accumulates in dest -> one pack per column. cb_qk is
  *  head-major (head h's cols contiguous); whole batch shares one set_mul_mode (w is column-independent). */
-inline void mul_phase(uint32_t r, uint32_t slot_base, uint32_t col_base, uint32_t cols) {
+inline void mul_phase(uint32_t q_row, uint32_t slot_base, uint32_t col_base, uint32_t cols) {
     const uint32_t batch_tiles = cols * num_heads;
-    const uint32_t w_base = r * num_heads;  // single chunk (group_start = 0); gate per (head, row)
+    const uint32_t w_base = q_row * num_heads;  // single chunk (group_start = 0); gate per (head, q_row)
     // gates consumed only here: wait now (after this batch's matmuls) so the reader reads w behind the
     // latency-critical q/k. Cumulative wait -> no-op once the resident group is in.
     CircularBuffer qk(cb_qk);
@@ -244,13 +245,13 @@ inline void mul_phase(uint32_t r, uint32_t slot_base, uint32_t col_base, uint32_
     for (uint32_t sub_base = 0; sub_base < cols; sub_base += mul_ct_dim) {
         const uint32_t n_cols = (sub_base + mul_ct_dim <= cols) ? mul_ct_dim : (cols - sub_base);
         tile_regs_acquire();
-        for (uint32_t h = 0; h < num_heads; ++h) {
-            mul_tiles_bcast_cols_custom(cb_qk, cb_w, h * cols + sub_base, w_base + h, 0, n_cols);
+        for (uint32_t head = 0; head < num_heads; ++head) {
+            mul_tiles_bcast_cols_custom(cb_qk, cb_w, head * cols + sub_base, w_base + head, 0, n_cols);
         }
         tile_regs_commit();
         tile_regs_wait();
-        for (uint32_t j = 0; j < n_cols; ++j) {
-            pack_tile(j, cb_acc_strip, slot_base + col_base + sub_base + j);
+        for (uint32_t out_col = 0; out_col < n_cols; ++out_col) {
+            pack_tile(out_col, cb_acc_strip, slot_base + col_base + sub_base + out_col);
         }
         tile_regs_release();
     }
@@ -260,28 +261,50 @@ inline void mul_phase(uint32_t r, uint32_t slot_base, uint32_t col_base, uint32_
 /** PHASE 1+2 fallback for head-streaming / KC==1 (qk_col_batch == 1): each k-col runs accumulate_heads
  *  (matmul + STANDARD bcast-mul interleaved per head group). It reads cb_w by index, so wait the gates
  *  here (k already waited in kernel_main). */
-inline void accumulate_row_streaming(uint32_t r, uint32_t slot_base) {
+inline void accumulate_row_streaming(uint32_t q_row, uint32_t slot_base) {
     CircularBuffer(cb_w).wait_front(w_group_tiles);
-    for (uint32_t c = 0; c < k_tiles_per_unit; ++c) {
-        accumulate_heads<cb_acc_strip>(r, c, slot_base + c);  // head reduction -> cb_acc_strip slot
+    for (uint32_t k_col = 0; k_col < k_tiles_per_unit; ++k_col) {
+        accumulate_heads<cb_acc_strip>(q_row, k_col, slot_base + k_col);  // head reduction -> cb_acc_strip slot
     }
 }
 
-/** Stamp the causal -inf mask onto row r's masked suffix [valid, KC) in place, so the strip still
+/** Streaming pad: a phantom band carries no k / no output -- it exists only to keep the row's q-mcast
+ *  in lockstep (the reader re-issues the band-independent q reads on the short columns). Drain exactly
+ *  the q blocks the reader pushed for one band -- QC*KC tiles x (Hi/HB) head groups -- consuming them
+ *  without compute. Must mirror the reader's streaming q loop and accumulate_heads' q wait/pop count. */
+inline void drain_phantom_band_q() {
+    CircularBuffer q(cb_q);
+    for (uint32_t tile_idx = 0; tile_idx < q_tiles_per_unit * k_tiles_per_unit; ++tile_idx) {
+        for (uint32_t group_start = 0; group_start < num_heads; group_start += heads_per_group) {
+            q.wait_front(q_group_tiles);
+            q.pop_front(q_group_tiles);
+        }
+    }
+}
+
+/** Stamp the causal -inf mask onto q_row's masked suffix [valid, KC) in place, so the strip still
  *  untilizes via the fast W=KC path (empty loop when the row is fully valid). */
-inline void stamp_masked_suffix(const WorkUnitSpan& span, uint32_t r, uint32_t slot_base, uint32_t k_tiles_in_unit) {
+inline void stamp_masked_suffix(
+    const WorkUnitSpan& span, uint32_t q_row, uint32_t slot_base, uint32_t k_tiles_in_unit) {
     const uint32_t k_tile0 = span.k_tile_start();
-    const uint32_t diag_tile = chunk_start_tiles + span.q_tile_start() + r;
-    const uint32_t valid = row_valid_prefix(span.q_tile_start() + r, k_tile0, k_tiles_in_unit);
-    for (uint32_t c = valid; c < k_tiles_per_unit; ++c) {
-        stamp_mask_tile<cb_acc_strip, cb_mask>(slot_base + c, k_tile0 + c, diag_tile);
+    const uint32_t diag_tile = chunk_start_tiles + span.q_tile_start() + q_row;
+    const uint32_t valid = row_valid_prefix(span.q_tile_start() + q_row, k_tile0, k_tiles_in_unit);
+    for (uint32_t k_col = valid; k_col < k_tiles_per_unit; ++k_col) {
+        stamp_mask_tile<cb_acc_strip, cb_mask>(slot_base + k_col, k_tile0 + k_col, diag_tile);
     }
 }
 
 void kernel_main() {
-    const uint32_t flat_start = get_arg_val<uint32_t>(0);
-    const uint32_t flat_count = get_arg_val<uint32_t>(1);
-    if (flat_count == 0) {
+    // Generalized banded schedule: this core owns a (group-phase x band) rectangle. groups stream in
+    // num_groups phases (absolute group = row_group0 + p*group_stride); within each it walks num_bands
+    // contiguous k-bands (absolute band = band0 + j). One (group, band) cell == one QC x KC work unit.
+    const uint32_t row_group0 = get_arg_val<uint32_t>(0);
+    const uint32_t group_stride = get_arg_val<uint32_t>(1);
+    const uint32_t num_groups = get_arg_val<uint32_t>(2);
+    const uint32_t band0 = get_arg_val<uint32_t>(3);
+    const uint32_t num_bands = get_arg_val<uint32_t>(4);
+    const uint32_t max_bands = get_arg_val<uint32_t>(5);  // row's widest column; streaming drains q to this
+    if (num_groups == 0 || num_bands == 0) {
         return;
     }
 
@@ -295,55 +318,67 @@ void kernel_main() {
     CircularBuffer q(cb_q);
 
     WorkUnitSpan span;
-    span.start(flat_start);
 
     constexpr uint32_t unit_strip = q_tiles_per_unit * k_tiles_per_unit;  // QC x KC accumulator slots
     constexpr uint32_t q_row_tiles = q_group_tiles / q_tiles_per_unit;    // heads_per_group * head_dim_tiles
 
-    // One QC x KC unit per iteration. Every unit spans KC k-tiles; the dense schedule may leave a
-    // partial last unit (valid < KC), masked in stamp_masked_suffix.
+    // group-OUTER, band-INNER: q/w resident for a group's whole band run (reader pushes one q+w block per
+    // group); each band is one QC x KC unit. The dense schedule may leave a partial last band (valid < KC),
+    // masked in stamp_masked_suffix.
     //
-    // No whole-block q/w wait here: resident q is waited PER ROW below (reader pushes a row at a time, so
-    // row 0 runs while row 1 drains); w is waited in the mul phase. Only k is waited up front.
-    for (uint32_t i = 0; i < flat_count; ++i) {
-        k.wait_front(k_chunk_tiles);
-        const uint32_t k_tiles_in_unit = span.k_tiles();
-
-        acc.reserve_back(unit_strip);
-        for (uint32_t r = 0; r < q_tiles_per_unit; ++r) {
-            // wait q rows 0..r only (reader pushes per row): row r reads only its row, so row 0 runs
-            // while row 1 arrives. Cumulative + non-consuming -> immediate once q is resident.
-            if constexpr (!stream_heads) {
-                q.wait_front((r + 1) * q_row_tiles);
-            }
-            const uint32_t slot_base = r * k_tiles_per_unit;
-
-            // PHASE 1 (matmul) + PHASE 2 (mul) per k-col batch. cb_qk holds one batch, so they
-            // alternate; GLM5/DSv32 (heads8/16) = one of each per row.
-            if constexpr (qk_col_batch > 1) {
-                for (uint32_t col_base = 0; col_base < k_tiles_per_unit; col_base += qk_col_batch) {
-                    const uint32_t cols =
-                        (col_base + qk_col_batch <= k_tiles_per_unit) ? qk_col_batch : (k_tiles_per_unit - col_base);
-                    matmul_phase(r, col_base, cols);          // PHASE 1: relu(q.kT) -> cb_qk (head-major)
-                    mul_phase(r, slot_base, col_base, cols);  // PHASE 2: gate-mul + head-reduce -> cb_acc_strip
+    // Streaming pads the band loop to max_bands to match the reader's q-mcast lockstep across the row: a
+    // phantom band [num_bands, max_bands) only drains the (band-independent) q the reader re-issued -- no
+    // k, no compute, no output. Resident never pads (band_iters == num_bands).
+    const uint32_t band_iters = stream_heads ? max_bands : num_bands;
+    for (uint32_t phase = 0; phase < num_groups; ++phase) {
+        const uint32_t group = row_group0 + phase * group_stride;
+        for (uint32_t band = 0; band < band_iters; ++band) {
+            if constexpr (stream_heads) {
+                if (band >= num_bands) {
+                    drain_phantom_band_q();  // padded q-mcast rendezvous only; no compute/output
+                    continue;
                 }
-            } else {
-                accumulate_row_streaming(r, slot_base);  // PHASE 1+2 head-streaming / KC==1 fallback
             }
+            span.set(group, band0 + band);
+            k.wait_front(k_chunk_tiles);
+            const uint32_t k_tiles_in_unit = span.k_tiles();
 
-            stamp_masked_suffix(span, r, slot_base, k_tiles_in_unit);  // causal -inf on the row's masked suffix
+            acc.reserve_back(unit_strip);
+            for (uint32_t q_row = 0; q_row < q_tiles_per_unit; ++q_row) {
+                // wait q rows 0..q_row only (reader pushes per row): row q_row reads only its row, so row 0
+                // runs while row 1 arrives. Cumulative + non-consuming -> immediate once q is resident.
+                if constexpr (!stream_heads) {
+                    q.wait_front((q_row + 1) * q_row_tiles);
+                }
+                const uint32_t slot_base = q_row * k_tiles_per_unit;
+
+                // PHASE 1 (matmul) + PHASE 2 (mul) per k-col batch. cb_qk holds one batch, so they
+                // alternate; GLM5/DSv32 (heads8/16) = one of each per row.
+                if constexpr (qk_col_batch > 1) {
+                    for (uint32_t col_base = 0; col_base < k_tiles_per_unit; col_base += qk_col_batch) {
+                        const uint32_t cols = (col_base + qk_col_batch <= k_tiles_per_unit)
+                                                  ? qk_col_batch
+                                                  : (k_tiles_per_unit - col_base);
+                        matmul_phase(q_row, col_base, cols);          // PHASE 1: relu(q.kT) -> cb_qk (head-major)
+                        mul_phase(q_row, slot_base, col_base, cols);  // PHASE 2: gate-mul + head-reduce
+                    }
+                } else {
+                    accumulate_row_streaming(q_row, slot_base);  // PHASE 1+2 head-streaming / KC==1 fallback
+                }
+
+                stamp_masked_suffix(span, q_row, slot_base, k_tiles_in_unit);  // causal -inf on masked suffix
+            }
+            acc.push_back(unit_strip);
+
+            // PHASE 3 -- untilize all QC strips in ONE pack_untilize bracket (cost amortizes over QC*KC).
+            compute_kernel_lib::untilize<k_tiles_per_unit, cb_acc_strip, cb_out_strip>(q_tiles_per_unit);
+
+            k.pop_front(k_chunk_tiles);
         }
-        acc.push_back(unit_strip);
-
-        // PHASE 3 -- untilize all QC strips in ONE pack_untilize bracket (cost amortizes over QC*KC).
-        compute_kernel_lib::untilize<k_tiles_per_unit, cb_acc_strip, cb_out_strip>(q_tiles_per_unit);
-
-        k.pop_front(k_chunk_tiles);
-        if (span.advance()) {
-            CircularBuffer(cb_w).pop_front(w_group_tiles);  // single use; gates waited in the mul phase
-            if constexpr (!stream_heads) {
-                q.pop_front(q_group_tiles);
-            }
+        // group's bands done: release this group's resident q/w (one block was pushed per group).
+        CircularBuffer(cb_w).pop_front(w_group_tiles);  // gates waited in the mul phase
+        if constexpr (!stream_heads) {
+            q.pop_front(q_group_tiles);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_common.hpp
@@ -4,7 +4,7 @@
 
 // Shared by indexer_score reader / compute / writer: common compile-time dims (args
 // 0..7), CB indices, derived group/chunk tile counts, and WorkUnitSpan (this core's
-// walk over its flat span of units). One unit = QC q-tile-rows x up-to-KC k-tiles.
+// cursor over its (group-phase x k-band) rectangle). One cell = QC q-tile-rows x up-to-KC k-tiles.
 
 #pragma once
 
@@ -50,42 +50,28 @@ constexpr uint32_t q_group_tiles = heads_per_group * q_tiles_per_unit * head_dim
 constexpr uint32_t w_group_tiles = num_heads * q_tiles_per_unit;                         // [QC][Hi]
 constexpr uint32_t k_chunk_tiles = k_tiles_per_unit * head_dim_tiles;                    // [KC][Dt]
 
-// Thin wrappers binding the shared work-split formula to this kernel's CT dims.
-namespace ws = ttnn::operations::experimental::indexer_score;
-
-/** Unmasked prefix k-tiles of absolute q-tile-row q_row_abs in a unit (bound to this kernel's
- *  chunk_start_tiles). */
+// Thin wrapper binding the shared work-split formula to this kernel's CT dims: unmasked prefix
+// k-tiles of absolute q-tile-row q_row_abs in a unit (bound to this kernel's chunk_start_tiles).
 inline uint32_t row_valid_prefix(uint32_t q_row_abs, uint32_t k_tile_start, uint32_t k_tiles_in_unit) {
-    return ws::valid_prefix_tiles(q_row_abs, k_tile_start, k_tiles_in_unit, chunk_start_tiles);
+    return iscore::valid_prefix_tiles(q_row_abs, k_tile_start, k_tiles_in_unit, chunk_start_tiles);
 }
 
-// Work units per q-row-group: the full k rectangle over the k chunk, uniform across groups (dense
-// schedule), so the flat<->(group, unit) map is a plain divide/modulo.
-constexpr uint32_t units_per_group = ws::units_in_group(k_tiles_per_unit, k_len_tiles);
-
-/** (group, unit) cursor over work units, starting at a flat index. */
+/** (group, band) cell cursor. The generalized scheduler maps groups -> grid rows and k-bands ->
+ *  grid columns; each core walks its own (group-phase x band) rectangle and sets the cursor per cell.
+ *  group = absolute q-row-group index; band = absolute k-band index. The per-cell accessors below feed
+ *  every per-unit body (matmul / mask / untilize) identically, independent of how the grid was tiled. */
 struct WorkUnitSpan {
     uint32_t group = 0;
-    uint32_t unit = 0;
+    uint32_t band = 0;
 
-    void start(uint32_t flat) {
-        group = flat / units_per_group;
-        unit = flat % units_per_group;
+    void set(uint32_t g, uint32_t b) {
+        group = g;
+        band = b;
     }
 
-    /** Advance one unit; true when a new q-row-group begins. */
-    bool advance() {
-        if (++unit == units_per_group) {
-            ++group;
-            unit = 0;
-            return true;
-        }
-        return false;
-    }
-
-    uint32_t q_tile_start() const { return group * q_tiles_per_unit; }  // first q-tile-row of this unit
-    uint32_t k_tile_start() const { return unit * k_tiles_per_unit; }   // first k-tile of this unit
-    uint32_t k_tiles() const {                                          // valid k-tiles in this unit (< full on edge)
+    uint32_t q_tile_start() const { return group * q_tiles_per_unit; }  // first q-tile-row of this cell
+    uint32_t k_tile_start() const { return band * k_tiles_per_unit; }   // first k-tile of this cell
+    uint32_t k_tiles() const {                                          // valid k-tiles (< full on the edge band)
         uint32_t left = k_len_tiles - k_tile_start();
         return left < k_tiles_per_unit ? left : k_tiles_per_unit;
     }

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_work_split.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_work_split.hpp
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Work-split arithmetic for indexer_score, shared by the host factory (deals units across
-// cores) and the kernels (WorkUnitSpan inverts a flat index to group/unit).
+// Work-split arithmetic for indexer_score, shared by the host factory (maps groups/bands onto the
+// core grid) and the kernels (WorkUnitSpan walks each core's (group, band) cells).
 // Single-sourcing stops host/device desync (else cores overlap or miss output tiles).
 // Pure uint32_t math (no std::, no CT args) so it includes cleanly on both sides.
 
@@ -14,9 +14,9 @@
 namespace ttnn::operations::experimental::indexer_score {
 
 // Schedule: every q-row-group is dealt the full [0, k_len_tiles) k rectangle (not just its causal
-// prefix), so the flat deal is perfectly uniform across groups -- which is what lets the grid-aligned
-// multicast path apply. Future/diagonal tiles are computed and masked to -inf in-band (see
-// valid_prefix_tiles); cost is negligible at high sp_rank (~2x only near sp~0).
+// prefix), so the deal is uniform across groups -- which is what lets the banded multicast apply.
+// Future/diagonal tiles are computed and masked to -inf in-band (see valid_prefix_tiles); cost is
+// negligible at high sp_rank (~2x only near sp~0).
 
 /** Unmasked prefix k-tiles of q-tile-row q_row_abs in a unit (start k_tile_start, k_tiles_in_unit
  *  valid). Tiles [0, this) are below the diagonal (no mask); diagonal and beyond are masked. */
@@ -32,5 +32,27 @@ constexpr uint32_t valid_prefix_tiles(
 constexpr uint32_t units_in_group(uint32_t k_tiles_per_unit, uint32_t k_len_tiles) {
     return (k_len_tiles + k_tiles_per_unit - 1) / k_tiles_per_unit;
 }
+
+// ---- banded-product grid mapping (shared by factory + perf model so their core counts agree) -------
+// G groups -> grid rows (q-mcast along a row); U k-bands -> grid columns (k-mcast down a column).
+
+/** Largest divisor of n that is <= cap (always >= 1; n <= cap returns n). */
+constexpr uint32_t largest_divisor_leq(uint32_t n, uint32_t cap) {
+    uint32_t best = 1;
+    for (uint32_t divisor = 2; divisor <= cap && divisor <= n; ++divisor) {
+        if (n % divisor == 0) {
+            best = divisor;
+        }
+    }
+    return best;
+}
+
+/** Grid rows for G groups: the largest divisor of G <= grid_y, so every used row carries the same
+ *  G/rows groups. Uniformity keeps a column's k-mcast in lockstep; a prime G > grid_y falls back to 1
+ *  row (k-mcast off, still correct). */
+constexpr uint32_t rows_for_groups(uint32_t groups, uint32_t grid_y) { return largest_divisor_leq(groups, grid_y); }
+
+/** Grid columns for U k-bands: min(U, grid_x); spare columns idle when U < grid_x. */
+constexpr uint32_t cols_for_bands(uint32_t bands, uint32_t grid_x) { return bands < grid_x ? bands : grid_x; }
 
 }  // namespace ttnn::operations::experimental::indexer_score

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
@@ -2,13 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Reader for indexer_score (DMA bottleneck). Walks this core's flat span of work units
-// (QC q-rows x up-to-KC k-tiles): per group pushes resident w + (if all heads fit) q,
-// per unit pushes the k chunk. Builds the [diag, full] -inf mask tiles once.
+// Reader for indexer_score (DMA bottleneck). Walks this core's (group-phase x k-band) rectangle
+// (each cell = QC q-rows x up-to-KC k-tiles): per group pushes resident w + (if all heads fit) q,
+// per band pushes the k chunk. Builds the [diag, full] -inf mask tiles once.
 //
-// Grid-aligned multicast: grid ROW shares q/w, grid COLUMN shares the k-band. role 1
-// (sender) reads DRAM + mcasts; role 2 (receiver) takes the L1->L1 copy; role 0 plain
-// DRAM read. Q/W (row) and K (column) mcast are independent; either may be off (role 0).
+// Banded-product multicast: a grid ROW shares q/w (q-mcast), a grid COLUMN shares the k-band
+// (k-mcast). role sender reads DRAM + mcasts; role receiver takes the L1->L1 copy; role none is a
+// plain DRAM read. Q/W (row) and K (column) mcast are independent; either may be off (role none).
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
@@ -131,10 +131,10 @@ inline void build_mask_tiles(Noc noc) {
  *  page layout is [Hi][q_len_tiles][head_dim_tiles]. */
 template <typename QAcc>
 inline uint32_t read_q_row_into(Noc noc, const QAcc& q_acc, uint32_t ptr, uint32_t q_row_abs, uint32_t first_head) {
-    for (uint32_t h = first_head; h < first_head + heads_per_group; ++h) {
-        const uint32_t base = h * q_len_tiles * head_dim_tiles + q_row_abs * head_dim_tiles;
-        for (uint32_t d = 0; d < head_dim_tiles; ++d) {
-            noc.async_read(q_acc, CoreLocalMem<uint32_t>(ptr), q_tile_bytes, {.page_id = base + d}, {});
+    for (uint32_t head = first_head; head < first_head + heads_per_group; ++head) {
+        const uint32_t base = head * q_len_tiles * head_dim_tiles + q_row_abs * head_dim_tiles;
+        for (uint32_t dim_tile = 0; dim_tile < head_dim_tiles; ++dim_tile) {
+            noc.async_read(q_acc, CoreLocalMem<uint32_t>(ptr), q_tile_bytes, {.page_id = base + dim_tile}, {});
             ptr += q_tile_bytes;
         }
     }
@@ -149,8 +149,8 @@ inline void read_q_block(Noc noc, const QAcc& q_acc, uint32_t q_row_start, uint3
     read_block_or_mcast<cb_q, q_mcast_on, q_send_sem, q_recv_sem, q_valid_sem>(
         noc, q_group_tiles, q_group_tiles * q_tile_bytes, q_dir, [&](uint32_t addr) {
             uint32_t ptr = addr;
-            for (uint32_t r = 0; r < q_tiles_per_unit; ++r) {
-                ptr = read_q_row_into(noc, q_acc, ptr, q_row_start + r, first_head);
+            for (uint32_t q_row = 0; q_row < q_tiles_per_unit; ++q_row) {
+                ptr = read_q_row_into(noc, q_acc, ptr, q_row_start + q_row, first_head);
             }
         });
 }
@@ -164,8 +164,8 @@ inline void read_q_rows(Noc noc, const QAcc& q_acc, uint32_t q_row_start, const 
     CircularBuffer cb(cb_q);
     cb.reserve_back(q_group_tiles);
     const uint32_t base = cb.get_write_ptr();
-    for (uint32_t r = 0; r < q_tiles_per_unit; ++r) {
-        const uint32_t row_addr = base + r * row_tiles * q_tile_bytes;
+    for (uint32_t q_row = 0; q_row < q_tiles_per_unit; ++q_row) {
+        const uint32_t row_addr = base + q_row * row_tiles * q_tile_bytes;
         if constexpr (q_mcast_on) {
             if (q_dir.role == iscore::mcast_role_receiver) {  // one mcast handshake per row -> row_addr
                 mcast_recv<q_send_sem, q_recv_sem>(noc, q_dir);
@@ -173,7 +173,7 @@ inline void read_q_rows(Noc noc, const QAcc& q_acc, uint32_t q_row_start, const 
                 continue;
             }
         }
-        read_q_row_into(noc, q_acc, row_addr, q_row_start + r, /*first_head=*/0);
+        read_q_row_into(noc, q_acc, row_addr, q_row_start + q_row, /*first_head=*/0);
         noc.async_read_barrier();
         if constexpr (q_mcast_on) {
             if (q_dir.role == iscore::mcast_role_sender) {  // broadcast this row to the rest of the grid row
@@ -190,13 +190,13 @@ inline void read_w_group(Noc noc, const WAcc& w_acc, uint32_t q_row_start, const
     read_block_or_mcast<cb_w, q_mcast_on, q_send_sem, q_recv_sem, q_valid_sem>(
         noc, w_group_tiles, w_group_tiles * bf16_tile_bytes, q_dir, [&](uint32_t addr) {
             uint32_t ptr = addr;
-            for (uint32_t r = 0; r < q_tiles_per_unit; ++r) {
-                for (uint32_t h = 0; h < num_heads; ++h) {
+            for (uint32_t q_row = 0; q_row < q_tiles_per_unit; ++q_row) {
+                for (uint32_t head = 0; head < num_heads; ++head) {
                     noc.async_read(
                         w_acc,
                         CoreLocalMem<uint32_t>(ptr),
                         bf16_tile_bytes,
-                        {.page_id = h * q_len_tiles + q_row_start + r},
+                        {.page_id = head * q_len_tiles + q_row_start + q_row},
                         {});
                     ptr += bf16_tile_bytes;
                 }
@@ -214,13 +214,13 @@ inline void read_k_chunk(
     read_block_or_mcast<cb_k, k_mcast_on, k_send_sem, k_recv_sem, k_valid_sem>(
         noc, k_chunk_tiles, k_chunk_tiles * k_tile_bytes, k_dir, [&](uint32_t addr) {
             uint32_t ptr = addr;
-            for (uint32_t c = 0; c < k_tiles_in_unit; ++c) {
-                for (uint32_t d = 0; d < head_dim_tiles; ++d) {
+            for (uint32_t k_col = 0; k_col < k_tiles_in_unit; ++k_col) {
+                for (uint32_t dim_tile = 0; dim_tile < head_dim_tiles; ++dim_tile) {
                     noc.async_read(
                         k_acc,
                         CoreLocalMem<uint32_t>(ptr),
                         k_tile_bytes,
-                        {.page_id = (k_tile_start + c) * head_dim_tiles + d},
+                        {.page_id = (k_tile_start + k_col) * head_dim_tiles + dim_tile},
                         {});
                     ptr += k_tile_bytes;
                 }
@@ -232,10 +232,16 @@ void kernel_main() {
     const uint32_t q_addr = get_arg_val<uint32_t>(0);
     const uint32_t k_addr = get_arg_val<uint32_t>(1);
     const uint32_t w_addr = get_arg_val<uint32_t>(2);
-    const uint32_t flat_start = get_arg_val<uint32_t>(3);
-    const uint32_t flat_count = get_arg_val<uint32_t>(4);
-    const McastDir k_dir = read_mcast_dir(5);   // K column mcast: args [5, 13)
-    const McastDir q_dir = read_mcast_dir(13);  // Q/W row mcast: args [13, 21)
+    // Generalized banded schedule: this core owns a (group-phase x band) rectangle. groups -> grid rows
+    // (q/w shared along a row = q_dir mcast), k-bands -> grid columns (k shared down a column = k_dir mcast).
+    const uint32_t row_group0 = get_arg_val<uint32_t>(3);
+    const uint32_t group_stride = get_arg_val<uint32_t>(4);
+    const uint32_t num_groups = get_arg_val<uint32_t>(5);
+    const uint32_t band0 = get_arg_val<uint32_t>(6);
+    const uint32_t num_bands = get_arg_val<uint32_t>(7);
+    const uint32_t max_bands = get_arg_val<uint32_t>(8);  // row's widest column; streaming pads q to this
+    const McastDir k_dir = read_mcast_dir(9);             // K column mcast: args [9, 17)
+    const McastDir q_dir = read_mcast_dir(17);            // Q/W row mcast: args [17, 25)
 
     const auto q_acc = TensorAccessor(q_args, q_addr, q_tile_bytes);
     const auto k_acc = TensorAccessor(k_args, k_addr, k_tile_bytes);
@@ -246,37 +252,47 @@ void kernel_main() {
     build_mask_tiles(noc);
 
     WorkUnitSpan span;
-    span.start(flat_start);
 
-    // Resident-heads path order: k -> q -> w. w (gates) is consumed only in the mul phase, so read it
-    // LAST behind the latency-critical q/k. Streaming path reads w FIRST: compute's mul drains streamed
-    // q, so w must be present or compute blocks on w while the reader blocks on the full q CB => deadlock.
-    bool need_group = true;
-    for (uint32_t i = 0; i < flat_count; ++i) {
-        const bool group_start = need_group;
-        if (group_start && stream_heads) {
-            read_w_group(noc, w_acc, span.q_tile_start(), q_dir);  // gates before the streamed q
-        }
-        // k FIRST: compute waits the whole k chunk before any row, so reading k ahead of q lets the
-        // split q-row0 push unblock the first matmul (else the k wait re-serializes it).
-        read_k_chunk(noc, k_acc, span.k_tile_start(), span.k_tiles(), k_dir);
-        if (group_start && !stream_heads) {
-            read_q_rows(noc, q_acc, span.q_tile_start(), q_dir);  // per-row: compute starts on row 0
-        }
+    // group-OUTER, band-INNER. Resident-heads order within a group: k -> q -> w (w/gates consumed only in
+    // the mul phase, so read LAST behind latency-critical q/k). Streaming path reads w FIRST: compute's mul
+    // drains streamed q, so w must be present or both kernels block => deadlock. q/w are read once per
+    // group (j==0); k-mcast fires every band down the column, q/w-mcast once per group along the row.
+    //
+    // Streaming pads the band loop to max_bands so every core in a row issues the SAME number of q reads
+    // (hence q-mcast rendezvous): columns own uneven band counts, but a phantom band [num_bands, max_bands)
+    // re-issues only the band-independent q reads -- no k (k-mcast is per column, already balanced) and no
+    // output -- keeping the row's q-mcast in lockstep. Resident reads q once per group, so it never pads.
+    const uint32_t band_iters = stream_heads ? max_bands : num_bands;
+    for (uint32_t phase = 0; phase < num_groups; ++phase) {
+        const uint32_t group = row_group0 + phase * group_stride;
+        const uint32_t q_row_start = group * q_tiles_per_unit;
         if constexpr (stream_heads) {
-            // one q-block per (r, c) output tile per head group; must match compute's tile order, which
-            // walks the FULL k_tiles_per_unit columns (compute masks the padded tail of a partial last
-            // unit). Using span.k_tiles() here would under-produce q blocks on a partial unit and hang
-            // compute, which still waits/pops a q block for every padded column.
-            for (uint32_t tile_idx = 0; tile_idx < q_tiles_per_unit * k_tiles_per_unit; ++tile_idx) {
-                for (uint32_t first_head = 0; first_head < num_heads; first_head += heads_per_group) {
-                    read_q_block(noc, q_acc, span.q_tile_start(), first_head, q_dir);
+            read_w_group(noc, w_acc, q_row_start, q_dir);  // gates before the streamed q (once per group)
+        }
+        for (uint32_t band = 0; band < band_iters; ++band) {
+            const bool real_band = band < num_bands;  // phantom bands (streaming pad) carry q-mcast only
+            if (real_band) {
+                span.set(group, band0 + band);
+                // k FIRST: compute waits the whole k chunk before any row, so reading k ahead of q lets the
+                // split q-row0 push unblock the first matmul (else the k wait re-serializes it).
+                read_k_chunk(noc, k_acc, span.k_tile_start(), span.k_tiles(), k_dir);
+                if (band == 0 && !stream_heads) {
+                    read_q_rows(noc, q_acc, q_row_start, q_dir);   // per-row: compute starts on row 0
+                    read_w_group(noc, w_acc, q_row_start, q_dir);  // gates deferred behind q/k
+                }
+            }
+            if constexpr (stream_heads) {
+                // one q-block per (q_row, k_col) output tile per head group; must match compute's order, which
+                // walks the FULL k_tiles_per_unit columns (compute masks the padded tail of a partial last
+                // band). Using span.k_tiles() here would under-produce q blocks on a partial band and hang
+                // compute, which still waits/pops a q block for every padded column. q is band-independent,
+                // so the phantom band re-issues this identical sequence purely to keep the row in lockstep.
+                for (uint32_t tile_idx = 0; tile_idx < q_tiles_per_unit * k_tiles_per_unit; ++tile_idx) {
+                    for (uint32_t first_head = 0; first_head < num_heads; first_head += heads_per_group) {
+                        read_q_block(noc, q_acc, q_row_start, first_head, q_dir);
+                    }
                 }
             }
         }
-        if (group_start && !stream_heads) {
-            read_w_group(noc, w_acc, span.q_tile_start(), q_dir);  // gates deferred behind q/k
-        }
-        need_group = span.advance();
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/writer_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/writer_indexer_score.cpp
@@ -45,8 +45,12 @@ inline void write_strip(Noc noc, const OutAcc& out_acc, uint32_t q_row, uint32_t
 
 void kernel_main() {
     const uint32_t out_addr = get_arg_val<uint32_t>(0);
-    const uint32_t flat_start = get_arg_val<uint32_t>(1);
-    const uint32_t flat_count = get_arg_val<uint32_t>(2);
+    // Generalized banded schedule (matches reader/compute): group-phase x band rectangle.
+    const uint32_t row_group0 = get_arg_val<uint32_t>(1);
+    const uint32_t group_stride = get_arg_val<uint32_t>(2);
+    const uint32_t num_groups = get_arg_val<uint32_t>(3);
+    const uint32_t band0 = get_arg_val<uint32_t>(4);
+    const uint32_t num_bands = get_arg_val<uint32_t>(5);
 
     constexpr auto out_args = TensorAccessorArgs<num_common_ct_args + 1>();
     const auto out_acc = TensorAccessor(out_args, out_addr, page_bytes);
@@ -54,15 +58,17 @@ void kernel_main() {
     Noc noc;
 
     WorkUnitSpan span;
-    span.start(flat_start);
 
-    for (uint32_t i = 0; i < flat_count; ++i) {
-        const uint32_t k_tile0 = span.k_tile_start();
-        const uint32_t valid_w = span.k_tiles();  // == KC for interior units, < KC for a partial last unit
-        // One KC-wide strip per row; masked suffix already stamped by compute. Write only valid_w columns.
-        for (uint32_t r = 0; r < q_tiles_per_unit; ++r) {
-            write_strip(noc, out_acc, span.q_tile_start() + r, k_tile0, valid_w);
+    for (uint32_t phase = 0; phase < num_groups; ++phase) {
+        const uint32_t group = row_group0 + phase * group_stride;
+        for (uint32_t band = 0; band < num_bands; ++band) {
+            span.set(group, band0 + band);
+            const uint32_t k_tile0 = span.k_tile_start();
+            const uint32_t valid_w = span.k_tiles();  // == KC for interior bands, < KC for a partial last band
+            // One KC-wide strip per row; masked suffix already stamped by compute. Write only valid_w columns.
+            for (uint32_t q_row = 0; q_row < q_tiles_per_unit; ++q_row) {
+                write_strip(noc, out_acc, span.q_tile_start() + q_row, k_tile0, valid_w);
+            }
         }
-        span.advance();
     }
 }


### PR DESCRIPTION
## Summary

Replaces the rigid **grid-aligned** multicast in `indexer_score` with a generalized **banded-product** scheduler, so *any* `QC`/`KC` config gets full-grid placement **and** multicast on both operands — and extends q-multicast to the head-streaming path. The op is reader/DMA-bound, so turning redundant DRAM re-reads of shared `q`/`k` into one read + an on-chip L1→L1 broadcast is what moves the needle.

## What's supported now that wasn't

Before, multicast only engaged when the work happened to tile the grid exactly (group count == grid height, k-bands a multiple of grid width). Most knob settings fell back to plain per-core DRAM reads, and the head-streaming path (`head_group < num_heads`) had q-multicast **forced off**.

Now:
- **Any `QC`/`KC`** gets full-grid + multicast (no alignment requirement).
- **Streaming (`HB < Hi`)** gets q-multicast too, via a phantom-band pad that keeps each grid row's q rendezvous count uniform even when columns own uneven k-band counts (the case a naive scheduler would deadlock on).
- A prime group count `> grid.y` (and other unfactorable shapes) **degrade cleanly to no-multicast but stay correct**, instead of being unsupported.

## How the multicast conditions are relaxed (and how they're done)

The work space is `G` q-row-groups × `U` k-bands, where `G = Sqt/QC` and `U = ceil(Tt/KC)`. It tiles onto a `rows_used × cols_used` core rectangle:

- **Groups → grid rows**, so a row shares `q`/`w` ⇒ **q-multicast** along the row (sender on the diagonal column, receivers the rest of the row; one rendezvous per group).
- **k-bands → grid columns**, so a column shares the k-band ⇒ **k-multicast** down the column (sender row 0, receivers rows below; one rendezvous per band).

Enable conditions:

| direction | shares | on when | how it degrades |
|---|---|---|---|
| **k-mcast** | k-band down a column | `rows_used > 1`, where `rows_used = largest divisor of G ≤ grid.y` | prime `G > grid.y` → `rows_used = 1` → off, still correct |
| **q-mcast** (covers q + w) | q/w along a row | `cols_used > 1`, where `cols_used = min(U, grid.x)` | single k-band (`U == 1`) → off |

`rows_used` is constrained to *divide* `G` so every row carries the same group count — this keeps a column's k-multicast in lockstep (uneven counts would let a column's row-0 sender wait forever on receivers that already finished). For real prefill shapes (deployed: `Sqt=20`, `Tt=1760`, grid `11×10`) both conditions hold for every sane knob, so **both multicasts are effectively always on**; the off-paths are correctness safety nets for pathological shapes.

## Less data-movement bound (measured, GLX sp7, bf16 q + bfp8 k, HiFi2)

Multicast cuts the dominant cost — redundant DRAM reads of shared operands — so matmul math-utilization climbs accordingly.

**Deployed controls — unchanged (no regression; verified within the ±2% perf gate):**

| config | device | math-util |
|---|---|---|
| GLM5 (8h) | 0.345 ms | **70.1%** |
| DSv32 (16h) | 0.635 ms | **76.0%** |

**Configs that previously got NO multicast — large gains:**

| config | before | after |
|---|---|---|
| glm5 qc1/kc16 | 36.2% | **71.4%** |
| glm5 qc4/kc16 | 49.4% | **71.7%** |
| glm5 qc1/kc32 | 35.7% | **69.5%** |
| dsv32 qc1/kc8 | 64.1% | **75.6%** |

i.e. several configs roughly **double** their utilization (~36% → ~71%), landing in the same ~70% band as the hand-tuned deployed defaults — so the op is far less reader-bound across the knob space.

## Testing

- All existing accuracy / determinism / fidelity / knob / shape tests pass (controls unchanged).
- New `test_indexer_score_genmcast_regimes` covers the scheduler topologies the prior tests missed: `G > grid.y` phase-stacking, prime `G` (no-mcast fallback), uneven k-band columns, partial last band, and streaming — each checked for exact causal `-inf` + PCC, and implicitly for no-deadlock.
- New `test_indexer_score_streaming_qmcast_uneven_bands` pins the deadlock-prone uneven-band streaming shape stays live + correct.
- Deployed perf gate (`test_indexer_score_perf_check`, ±2%) passes for both GLM5 and DSv32.

## CI runs (this branch)

[![L2 nightly (experimental)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/indexer_score_genmcast)](https://github.com/tenstorrent/tt-metal/actions/runs/27902644501)
[![Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/indexer_score_genmcast)](https://github.com/tenstorrent/tt-metal/actions/runs/27902647290)

| pipeline | scope | run |
|---|---|---|
| **Nightly tt-metal L2** | experimental category, Blackhole | [#27902644501](https://github.com/tenstorrent/tt-metal/actions/runs/27902644501) |
| **Blackhole post-commit** (bhpc) | whole suite (P150) | [#27902647290](https://github.com/tenstorrent/tt-metal/actions/runs/27902647290) |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/indexer_score_genmcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/indexer_score_genmcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/indexer_score_genmcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/indexer_score_genmcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/indexer_score_genmcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skrstic/indexer_score_genmcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/indexer_score_genmcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/indexer_score_genmcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/indexer_score_genmcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/indexer_score_genmcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/indexer_score_genmcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/indexer_score_genmcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/indexer_score_genmcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/indexer_score_genmcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/indexer_score_genmcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/indexer_score_genmcast)