### PR TITLE
Optimize Routed Expert for Short Sequences

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
@@ -44,7 +44,10 @@ def test_deepseek_v3_moe_perf_loudbox():
         expected_ns_8x1=36_272_143,
         model_name_8x1="deepseek_v3_moe_lb_8x1_dispatch_combine",
         command_2x4=_CMD_2X4,
-        expected_ns_2x4=39_194_517,
+        # Recalibrated 2026-06-21 on BH LoudBox 2x4 after the unified_routed_expert_ffn
+        # two-RISC (UP_SPLIT) read overlap sped up the gate/up weight stream (~10% MoE
+        # device-time drop, bit-exact). Was 39_194_517.
+        expected_ns_2x4=35_127_772,
         model_name_2x4="deepseek_v3_moe_lb_2x4_gate",
         subdir="deepseek_v3_moe",
         margin=0.03,

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
@@ -41,7 +41,10 @@ def test_deepseek_v3_moe_perf_loudbox():
     """
     run_moe_perf_with_approximation(
         command_8x1=_CMD_8X1,
-        expected_ns_8x1=36_272_143,
+        # Recalibrated 2026-06-23 on BH LoudBox 8x1 after the unified_routed_expert_ffn
+        # changes; measured device time dropped below the prior lower bound (35.08 ms vs
+        # the old 36.27 ms target's 35.18 ms floor). Was 36_272_143.
+        expected_ns_8x1=35_082_637,
         model_name_8x1="deepseek_v3_moe_lb_8x1_dispatch_combine",
         command_2x4=_CMD_2X4,
         # Recalibrated 2026-06-21 on BH LoudBox 2x4 after the unified_routed_expert_ffn

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
@@ -54,7 +54,12 @@ _TEST_PATH = "models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py"
         ),
         (
             f"pytest {_TEST_PATH} -k 'mesh-2x4-2link and layer3 and gate_device and no_ref and isl_6k4'",
-            56_857_362,  # Recalibrated 2026-06-22 on BH LoudBox 2x4; FABRIC_1D. Direct-write FFN fusion (#46800) drops the per-expert insert DRAM round-trip (~3.2% faster).
+            53_000_000,  # Recalibrated for the stacked optimizations on BH LoudBox 2x4; FABRIC_1D.
+            # Was 58_750_603. Two compounding speedups now both land here: direct-write FFN
+            # fusion (#46800, ~3.2% on its own -> 56_857_362) AND unified_routed_expert_ffn
+            # two-RISC (UP_SPLIT) read overlap (~53 ms measured for UP_SPLIT alone, bit-exact).
+            # Combined is <= the UP_SPLIT number; 53 ms is the best pre-rebase estimate and must
+            # be reconfirmed against a CI run on the 2x4-2link box (margin 0.03).
             "deepseek_v3_prefill_block",
             "deepseek_v3_prefill_block_2x4_layer3_moe",
             1,
@@ -87,7 +92,9 @@ _TEST_PATH = "models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py"
         ),
         (
             f"pytest {_TEST_PATH} -k 'fabric2d-mesh-2x4 and layer3 and gate_device and no_ref and isl_6k4'",
-            72_463_075,  # Recalibrated 2026-06-10 on BH LoudBox 2x4; FABRIC_2D.
+            67_000_000,  # Recalibrated 2026-06-21 on BH LoudBox 2x4; FABRIC_2D. Was 72_463_075;
+            # unified_routed_expert_ffn two-RISC (UP_SPLIT) read overlap dropped the MoE block
+            # device time (~67 ms measured, bit-exact).
             "deepseek_v3_prefill_block",
             "deepseek_v3_prefill_block_2x4_layer3_moe_fabric2d",
             1,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
@@ -76,9 +76,18 @@ void kernel_main() {
     const uint32_t act_ready_sem_addr = get_semaphore(act_ready_sem_id);
     const uint32_t act_valid_sem_addr = get_semaphore(act_valid_sem_id);
 
-    // M-row NoC coord table: GRID_X (x, y) pairs starting at runtime arg 31.
+    // UP_SPLIT local handshake (reader <-> writer): up_go = slot reserved,
+    // up_done = up block landed in L1. Monotonic; gy=0 in1-sender cores only.
+    const uint32_t up_go_sem_id = get_arg_val<uint32_t>(31);
+    const uint32_t up_done_sem_id = get_arg_val<uint32_t>(32);
+    volatile tt_l1_ptr uint32_t* up_go_local =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(up_go_sem_id));
+    volatile tt_l1_ptr uint32_t* up_done_local =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(up_done_sem_id));
+
+    // M-row NoC coord table: GRID_X (x, y) pairs starting at runtime arg 33.
     // Used to resolve the sender's NoC addr per phase-4 K-block kb (= gx).
-    constexpr uint32_t M_ROW_NOC_RT_OFFSET = 31;
+    constexpr uint32_t M_ROW_NOC_RT_OFFSET = 33;
 
     // -------------------------- compile-time args -------------------------
     constexpr uint32_t cb_in0_x = get_compile_time_arg_val(0);
@@ -105,6 +114,13 @@ void kernel_main() {
     constexpr uint32_t cb_activated = get_compile_time_arg_val(20);
     constexpr uint32_t GRID_X_NOC = get_compile_time_arg_val(21);  // M-row mcast group size
     constexpr uint32_t K_down_tiles_padded = get_compile_time_arg_val(22);
+    // `up` read mode: reader_reads_up = reader does the DRAM read (LEGACY);
+    // reader_mcasts_up = reader NoC-0 mcasts up (UP_SPLIT: writer reads it on
+    // NoC 1 into cb_in1_up); both 0 = UP_WRITER_MCAST, reader skips up.
+    constexpr uint32_t reader_reads_up = get_compile_time_arg_val(23);
+    constexpr uint32_t reader_mcasts_up = get_compile_time_arg_val(24);
+    // UP_SPLIT iff the reader multicasts up but does not read it from DRAM.
+    constexpr bool up_split = (reader_mcasts_up != 0) && (reader_reads_up == 0);
 
     constexpr uint32_t g_in0_block_num_tiles = per_core_M * in0_block_w_gu;
     constexpr uint32_t g_in1_block_num_tiles = per_core_N_gu * in0_block_w_gu;
@@ -113,7 +129,7 @@ void kernel_main() {
     constexpr uint32_t num_blocks_gu = K_gate_tiles / in0_block_w_gu;
     constexpr uint32_t num_blocks_d = K_down_tiles_padded / in0_block_w_d;
 
-    constexpr uint32_t x_accessor_offset = 23;
+    constexpr uint32_t x_accessor_offset = 25;
     constexpr auto x_args = TensorAccessorArgs<x_accessor_offset>();
     const auto x_acc = TensorAccessor(x_args, x_addr, get_tile_size(cb_in0_x));
 
@@ -215,6 +231,9 @@ void kernel_main() {
     const uint64_t in0_mcast_valid_noc = get_noc_multicast_addr(
         in0_mcast_nx_start, in0_mcast_ny_start, in0_mcast_nx_end, in0_mcast_ny_end, in0_valid_sem_addr);
 
+    // UP_SPLIT handshake counter, kept in lockstep with the writer's.
+    uint32_t up_seq = 0;
+
     // Bound the chunk loop by effective_chunks (= ceil_div(count, chunk_M_tiles))
     // so this expert only does work proportional to its actual token count,
     // not the max-tokens-padded shape of the input. Eliminates the host-side
@@ -258,7 +277,18 @@ void kernel_main() {
         for (uint32_t kb = 0; kb < num_blocks_gu; ++kb) {
             cb_reserve_back(cb_in0_x, g_in0_block_num_tiles);
             cb_reserve_back(cb_in1_gate, g_in1_block_num_tiles);
-            cb_reserve_back(cb_in1_up, g_in1_block_num_tiles);
+            if constexpr (reader_mcasts_up) {
+                cb_reserve_back(cb_in1_up, g_in1_block_num_tiles);
+            }
+
+            // UP_SPLIT: slot reserved -> release writer to read `up` on NoC 1,
+            // concurrent with the reader's NoC-0 `gate` read below.
+            if constexpr (up_split) {
+                if (is_in1_sender) {
+                    ++up_seq;
+                    *up_go_local = up_seq;
+                }
+            }
 
             // Step 1: receivers ack BOTH senders upfront so both senders can
             // proceed in parallel. The senders are usually disjoint sets of
@@ -344,48 +374,75 @@ void kernel_main() {
                         l1_w_gate += gate_tile_bytes;
                     }
                 }
-                uint32_t l1_w_up = get_write_ptr(cb_in1_up);
-                const uint32_t up_block_start = l1_w_up;
-                for (uint32_t k = 0; k < in0_block_w_gu; ++k) {
-                    for (uint32_t n = 0; n < per_core_N_gu; ++n) {
-                        const uint32_t row = kb * in0_block_w_gu + k;
-                        const uint32_t col = my_nt_gu * per_core_N_gu + n;
-                        if (col < N_gate_tiles_full) {
-                            const uint32_t tile_idx = row * N_gate_tiles_full + col;
-                            noc_async_read_page(tile_idx, up_acc, l1_w_up, /*offset=*/0, /*noc=*/0);
-                        } else {
-                            volatile tt_l1_ptr uint64_t* p = reinterpret_cast<volatile tt_l1_ptr uint64_t*>(l1_w_up);
-                            for (uint32_t i = 0; i < up_tile_bytes / 8; ++i) {
-                                p[i] = 0;
+                // `up` slot. LEGACY: reader reads it on NoC 0. UP_SPLIT: writer
+                // already read it on NoC 1; reader just takes the L1 start and
+                // waits on up_done (below) before mcasting.
+                uint32_t up_block_start = 0;
+                if constexpr (reader_mcasts_up) {
+                    up_block_start = get_write_ptr(cb_in1_up);
+                }
+                if constexpr (reader_reads_up) {
+                    uint32_t l1_w_up = up_block_start;
+                    for (uint32_t k = 0; k < in0_block_w_gu; ++k) {
+                        for (uint32_t n = 0; n < per_core_N_gu; ++n) {
+                            const uint32_t row = kb * in0_block_w_gu + k;
+                            const uint32_t col = my_nt_gu * per_core_N_gu + n;
+                            if (col < N_gate_tiles_full) {
+                                const uint32_t tile_idx = row * N_gate_tiles_full + col;
+                                noc_async_read_page(tile_idx, up_acc, l1_w_up, /*offset=*/0, /*noc=*/0);
+                            } else {
+                                volatile tt_l1_ptr uint64_t* p =
+                                    reinterpret_cast<volatile tt_l1_ptr uint64_t*>(l1_w_up);
+                                for (uint32_t i = 0; i < up_tile_bytes / 8; ++i) {
+                                    p[i] = 0;
+                                }
                             }
+                            l1_w_up += up_tile_bytes;
                         }
-                        l1_w_up += up_tile_bytes;
                     }
                 }
                 noc_async_read_barrier(/*noc=*/0);
 
-                const uint64_t gate_mcast_noc = get_noc_multicast_addr(
-                    in1_mcast_nx_start, in1_mcast_ny_start, in1_mcast_nx_end, in1_mcast_ny_end, gate_block_start);
-                const uint32_t gate_block_bytes = g_in1_block_num_tiles * gate_tile_bytes;
-                // linked=true on gate, linked=false on up — chains the two
-                // mcasts so they share NoC path setup, saving a few cycles
-                // of programming overhead per K-block.
-                noc_async_write_multicast(
-                    gate_block_start, gate_mcast_noc, gate_block_bytes, in1_num_receivers, /*linked=*/true);
+                // UP_SPLIT: wait for the writer's NoC-1 `up` read before mcast.
+                if constexpr (up_split) {
+                    noc_semaphore_wait_min(up_done_local, up_seq);
+                }
 
-                const uint64_t up_mcast_noc = get_noc_multicast_addr(
-                    in1_mcast_nx_start, in1_mcast_ny_start, in1_mcast_nx_end, in1_mcast_ny_end, up_block_start);
-                const uint32_t up_block_bytes = g_in1_block_num_tiles * up_tile_bytes;
-                noc_async_write_multicast(
-                    up_block_start, up_mcast_noc, up_block_bytes, in1_num_receivers, /*linked=*/false);
+                // GRID_Y == 1: no column receivers — skip mcast/valid-sem; the
+                // locally-read weights go straight to compute via cb_push_back.
+                if (in1_num_receivers > 0) {
+                    const uint64_t gate_mcast_noc = get_noc_multicast_addr(
+                        in1_mcast_nx_start, in1_mcast_ny_start, in1_mcast_nx_end, in1_mcast_ny_end, gate_block_start);
+                    const uint32_t gate_block_bytes = g_in1_block_num_tiles * gate_tile_bytes;
+                    // Link gate to the up mcast that follows when up is mcast;
+                    // unlinked in UP_WRITER_MCAST (no up mcast).
+                    noc_async_write_multicast(
+                        gate_block_start,
+                        gate_mcast_noc,
+                        gate_block_bytes,
+                        in1_num_receivers,
+                        /*linked=*/reader_mcasts_up != 0);
+
+                    if constexpr (reader_mcasts_up) {
+                        const uint64_t up_mcast_noc = get_noc_multicast_addr(
+                            in1_mcast_nx_start, in1_mcast_ny_start, in1_mcast_nx_end, in1_mcast_ny_end, up_block_start);
+                        const uint32_t up_block_bytes = g_in1_block_num_tiles * up_tile_bytes;
+                        noc_async_write_multicast(
+                            up_block_start, up_mcast_noc, up_block_bytes, in1_num_receivers, /*linked=*/false);
+                    }
+                }
 
                 cb_push_back(cb_in1_gate, g_in1_block_num_tiles);
-                cb_push_back(cb_in1_up, g_in1_block_num_tiles);
+                if constexpr (reader_mcasts_up) {
+                    cb_push_back(cb_in1_up, g_in1_block_num_tiles);
+                }
 
-                noc_async_writes_flushed();
+                if (in1_num_receivers > 0) {
+                    noc_async_writes_flushed();
 
-                *in1_valid_local = IN1_VALID;
-                noc_semaphore_set_multicast(in1_valid_sem_addr, in1_mcast_valid_noc, in1_num_receivers);
+                    *in1_valid_local = IN1_VALID;
+                    noc_semaphore_set_multicast(in1_valid_sem_addr, in1_mcast_valid_noc, in1_num_receivers);
+                }
             }
 
             // Step 3: receivers wait for both valid semaphores and push.
@@ -396,7 +453,9 @@ void kernel_main() {
             if (!is_in1_sender) {
                 noc_semaphore_wait(in1_valid_local, IN1_VALID);
                 cb_push_back(cb_in1_gate, g_in1_block_num_tiles);
-                cb_push_back(cb_in1_up, g_in1_block_num_tiles);
+                if constexpr (reader_mcasts_up) {
+                    cb_push_back(cb_in1_up, g_in1_block_num_tiles);
+                }
             }
         }
 
@@ -516,18 +575,22 @@ void kernel_main() {
             // in flight during step 3 activated mcast on NoC 1), then mcast.
             if (is_in1_sender) {
                 noc_async_read_barrier(/*noc=*/0);
-                const uint64_t mcast_data_noc = get_noc_multicast_addr(
-                    in1_mcast_nx_start, in1_mcast_ny_start, in1_mcast_nx_end, in1_mcast_ny_end, in1_block_start);
-                const uint32_t block_bytes = d_in1_block_num_tiles * down_tile_bytes;
-                // linked=true so the in1_valid-sem multicast is ordered behind
-                // the weight data on the same reserved path (see the activated
-                // mcast above for the full rationale).
-                noc_async_write_multicast(
-                    in1_block_start, mcast_data_noc, block_bytes, in1_num_receivers, /*linked=*/true);
-                noc_async_writes_flushed();
+                // GRID_Y == 1: no column receivers — skip mcast/valid-sem; this
+                // core consumes the locally-read down weight directly.
+                if (in1_num_receivers > 0) {
+                    const uint64_t mcast_data_noc = get_noc_multicast_addr(
+                        in1_mcast_nx_start, in1_mcast_ny_start, in1_mcast_nx_end, in1_mcast_ny_end, in1_block_start);
+                    const uint32_t block_bytes = d_in1_block_num_tiles * down_tile_bytes;
+                    // linked=true so the in1_valid-sem multicast is ordered behind
+                    // the weight data on the same reserved path (see the activated
+                    // mcast above for the full rationale).
+                    noc_async_write_multicast(
+                        in1_block_start, mcast_data_noc, block_bytes, in1_num_receivers, /*linked=*/true);
+                    noc_async_writes_flushed();
 
-                *in1_valid_local = IN1_VALID;
-                noc_semaphore_set_multicast(in1_valid_sem_addr, in1_mcast_valid_noc, in1_num_receivers);
+                    *in1_valid_local = IN1_VALID;
+                    noc_semaphore_set_multicast(in1_valid_sem_addr, in1_mcast_valid_noc, in1_num_receivers);
+                }
             }
 
             // Step 5: receivers wait for both valid sems and push.

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
@@ -342,8 +342,17 @@ void kernel_main() {
                 const uint64_t mcast_data_noc = get_noc_multicast_addr(
                     in0_mcast_nx_start, in0_mcast_ny_start, in0_mcast_nx_end, in0_mcast_ny_end, block_start);
                 const uint32_t block_bytes = g_in0_block_num_tiles * x_tile_bytes;
-                noc_async_write_multicast(
-                    block_start, mcast_data_noc, block_bytes, in0_num_receivers, /*linked=*/false);
+                // linked=true keeps the multicast path RESERVED so the in0_valid
+                // sem multicast below travels the SAME path and is delivered
+                // AFTER the data at every receiver. With linked=false the path is
+                // released and the (posted) valid-sem multicast can overtake the
+                // bulk data multicast at a receiver under NoC contention (heavy
+                // fabric load) -> the receiver observes in0_valid, pushes
+                // cb_in0_x, and compute reads STALE x from L1 -> wrong gate/up
+                // matmul output for that core (rare, timing-dependent). A write
+                // barrier does NOT fix this on Blackhole (multicast writes are
+                // posted; no completion ack). Mirrors the phase-4 activated mcast.
+                noc_async_write_multicast(block_start, mcast_data_noc, block_bytes, in0_num_receivers, /*linked=*/true);
                 cb_push_back(cb_in0_x, g_in0_block_num_tiles);
 
                 noc_async_writes_flushed();
@@ -414,21 +423,32 @@ void kernel_main() {
                     const uint64_t gate_mcast_noc = get_noc_multicast_addr(
                         in1_mcast_nx_start, in1_mcast_ny_start, in1_mcast_nx_end, in1_mcast_ny_end, gate_block_start);
                     const uint32_t gate_block_bytes = g_in1_block_num_tiles * gate_tile_bytes;
-                    // Link gate to the up mcast that follows when up is mcast;
-                    // unlinked in UP_WRITER_MCAST (no up mcast).
+                    // The LAST in1 data multicast before the in1_valid sem must
+                    // be linked=true so the (posted) valid-sem multicast travels
+                    // the SAME reserved path and lands AFTER the data at every
+                    // receiver. Otherwise, under NoC contention (heavy fabric
+                    // load), the valid sem can overtake the weight data -> the
+                    // receiver pushes cb_in1_{gate,up} and compute reads STALE
+                    // weights -> wrong matmul output (rare, timing-dependent;
+                    // a flush/barrier does not fix posted multicast writes on
+                    // Blackhole). Mirrors the phase-4 activated mcast. When `up`
+                    // is mcast (LEGACY/UP_SPLIT) it is the last write, so gate
+                    // links into it and up holds the path for the sem; in the
+                    // retired UP_WRITER_MCAST mode (no up mcast) gate is last and
+                    // holds the path itself.
                     noc_async_write_multicast(
                         gate_block_start,
                         gate_mcast_noc,
                         gate_block_bytes,
                         in1_num_receivers,
-                        /*linked=*/reader_mcasts_up != 0);
+                        /*linked=*/true);
 
                     if constexpr (reader_mcasts_up) {
                         const uint64_t up_mcast_noc = get_noc_multicast_addr(
                             in1_mcast_nx_start, in1_mcast_ny_start, in1_mcast_nx_end, in1_mcast_ny_end, up_block_start);
                         const uint32_t up_block_bytes = g_in1_block_num_tiles * up_tile_bytes;
                         noc_async_write_multicast(
-                            up_block_start, up_mcast_noc, up_block_bytes, in1_num_receivers, /*linked=*/false);
+                            up_block_start, up_mcast_noc, up_block_bytes, in1_num_receivers, /*linked=*/true);
                     }
                 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_writer.cpp
@@ -4,24 +4,35 @@
 
 // Writer kernel for unified_routed_expert_ffn.
 //
-// Single responsibility: pop `cb_out` (the down matmul's per-core final
-// block, packed one subblock at a time) and write tiles to the DRAM-
-// interleaved output tensor at this core's (mt, nt_d) tile region, looped
-// over `effective_chunks` chunks. Reads the device-side counts/idx
-// scratch CBs to compute effective_chunks. The activated tiles are
-// distributed across the M-row by the READER via L1 multicast — there is
-// no DRAM scratch round-trip or cross-core barrier.
+// Two responsibilities, both handled by this writer kernel:
 //
-// Output placement has two modes (selected by the `direct_write` CT flag):
-//   * direct_write == 0: writes start at tile row 0. The FFN op writes to
-//     a per-expert output tensor; a separate ttnn::insert handles placement
-//     into any shared destination buffer.
-//   * direct_write == 1: this expert's output is written directly into a
-//     shared destination buffer at the expert's region offset. The kernel
-//     reads start[global_expert_id] from `start` (= expert_region_offsets)
-//     device-side and adds (start / TILE_HEIGHT) tile-rows to every output
-//     row — fusing what ttnn::insert would otherwise do as a separate op
-//     (no temp-buffer DRAM round-trip).
+// 1. Output drain + placement. Pop `cb_out` (the down matmul's per-core
+//    final block, packed one subblock at a time) and write tiles to the
+//    DRAM-interleaved output tensor at this core's (mt, nt_d) tile region,
+//    looped over `effective_chunks` chunks (computed from the device-side
+//    counts/idx scratch CBs). Activated tiles are distributed across the
+//    M-row by the READER via L1 multicast — no DRAM scratch round-trip or
+//    cross-core barrier. Placement has two modes (the `direct_write` CT flag):
+//      * direct_write == 0: writes start at tile row 0. The FFN op writes to
+//        a per-expert output tensor; a separate ttnn::insert handles
+//        placement into any shared destination buffer.
+//      * direct_write == 1: this expert's output is written directly into a
+//        shared destination buffer at the expert's region offset. The kernel
+//        reads start[global_expert_id] from `start` (= expert_region_offsets)
+//        device-side and adds (start / TILE_HEIGHT) tile-rows to every output
+//        row — fusing what ttnn::insert would otherwise do (no temp-buffer
+//        DRAM round-trip).
+//
+// 2. Two-RISC `up`-weight read (UP_SPLIT). The writer (NCRISC) reads `up`
+//    from DRAM on NoC 1 concurrent with the reader's NoC-0 `gate` read. The
+//    program factory selects UP_SPLIT (writer_split_up) for ALL layouts: the
+//    writer reads `up` into the gy=0 sender's cb_in1_up slot and the reader
+//    multicasts it on NoC 0, ordered by a local up_go/up_done handshake. Only
+//    a NoC-1 DRAM read happens here — no worker multicast and no NoC-1 atomics
+//    — so it is safe beside the fabric CCL ops. The legacy writer-side NoC-1
+//    multicast mode (UP_WRITER_MCAST / writer_mcasts_up) is retired and never
+//    selected. Per chunk the writer produces all `up` K-blocks, then drains
+//    `cb_out`.
 
 #include <cstdint>
 
@@ -36,16 +47,27 @@ void kernel_main() {
     const uint32_t my_nt_d = get_arg_val<uint32_t>(2);
     // start (= expert_region_offsets) address. Only read when direct_write.
     const uint32_t start_addr = get_arg_val<uint32_t>(3);
+    // UP_SPLIT up-weight read args: up tensor base, this core's N-column, and
+    // whether this core is the gy=0 sender (only senders read `up`).
+    const uint32_t up_addr = get_arg_val<uint32_t>(4);
+    const uint32_t my_nt_gu = get_arg_val<uint32_t>(5);
+    const bool is_up_sender = get_arg_val<uint32_t>(6) != 0;
+    // UP_SPLIT local handshake sems (see reader): up_go = slot reserved,
+    // up_done = up landed.
+    const uint32_t up_go_sem_id = get_arg_val<uint32_t>(7);
+    const uint32_t up_done_sem_id = get_arg_val<uint32_t>(8);
 
     constexpr uint32_t cb_out = get_compile_time_arg_val(1);
     constexpr uint32_t per_core_M = get_compile_time_arg_val(2);
+    constexpr uint32_t per_core_N_gu = get_compile_time_arg_val(3);
     constexpr uint32_t per_core_N_d = get_compile_time_arg_val(4);
     constexpr uint32_t d_out_subblock_h = get_compile_time_arg_val(7);
     constexpr uint32_t d_out_subblock_w = get_compile_time_arg_val(8);
+    constexpr uint32_t N_gate_tiles_full = get_compile_time_arg_val(9);
     constexpr uint32_t N_down_tiles_full = get_compile_time_arg_val(10);
     constexpr uint32_t num_chunks = get_compile_time_arg_val(11);
     constexpr uint32_t chunk_M_tiles = get_compile_time_arg_val(12);
-    // NEW: device-side count read.
+    // device-side count read.
     constexpr uint32_t cb_counts_scratch = get_compile_time_arg_val(13);
     constexpr uint32_t cb_idx_scratch = get_compile_time_arg_val(14);
     constexpr uint32_t local_expert_id = get_compile_time_arg_val(15);
@@ -62,18 +84,35 @@ void kernel_main() {
     // direct-write mode (used to bound destination writes).
     constexpr uint32_t dst_M_tiles = get_compile_time_arg_val(18);
     constexpr uint32_t cb_start_scratch = get_compile_time_arg_val(19);
+    // UP_SPLIT up-weight read (see header): the writer reads `up` on NoC 1 into
+    // the gy=0 sender's cb_in1_up slot; the reader mcasts it on NoC 0.
+    // writer_split_up gates it (1 = UP_SPLIT, 0 = LEGACY: reader owns `up`).
+    constexpr uint32_t cb_in1_up = get_compile_time_arg_val(20);
+    constexpr uint32_t in0_block_w_gu = get_compile_time_arg_val(21);
+    constexpr uint32_t K_gate_tiles = get_compile_time_arg_val(22);
+    constexpr uint32_t writer_split_up = get_compile_time_arg_val(23);
 
     constexpr uint32_t d_out_subblock_num_tiles = d_out_subblock_h * d_out_subblock_w;
     constexpr uint32_t d_in1_num_subblocks_M = per_core_M / d_out_subblock_h;
     constexpr uint32_t d_in1_num_subblocks_N = per_core_N_d / d_out_subblock_w;
+    constexpr uint32_t num_blocks_gu = K_gate_tiles / in0_block_w_gu;
+    constexpr uint32_t g_in1_block_num_tiles = per_core_N_gu * in0_block_w_gu;
 
-    constexpr uint32_t out_accessor_offset = 20;
+    // Accessor compile-arg stream order (host appends in this exact order):
+    // out, then start (direct-write), then up (UP_SPLIT). The accessors are
+    // constructed unconditionally; start_acc is used only when direct_write,
+    // up_acc only when writer_split_up.
+    constexpr uint32_t out_accessor_offset = 24;
     constexpr auto out_args = TensorAccessorArgs<out_accessor_offset>();
     const auto out_acc = TensorAccessor(out_args, output_addr, get_tile_size(cb_out));
 
     constexpr uint32_t start_accessor_offset = out_args.next_compile_time_args_offset();
     constexpr auto start_args = TensorAccessorArgs<start_accessor_offset>();
     const auto start_acc = TensorAccessor(start_args, start_addr);
+
+    constexpr uint32_t up_accessor_offset = start_args.next_compile_time_args_offset();
+    constexpr auto up_args = TensorAccessorArgs<up_accessor_offset>();
+    const auto up_acc = TensorAccessor(up_args, up_addr, get_tile_size(cb_in1_up));
 
     const uint32_t out_tile_bytes = get_tile_size(cb_out);
 
@@ -108,7 +147,66 @@ void kernel_main() {
         row_offset_tiles = start_value / TILE_HEIGHT;
     }
 
+    // ---- UP_SPLIT up-weight read setup ----
+    // The writer reads `up` from DRAM on NoC 1 (kUpNoc) concurrent with the
+    // reader's NoC-0 `gate` read, into the gy=0 sender's cb_in1_up slot; the
+    // reader multicasts it on NoC 0. A local same-core (BRISC reader <-> NCRISC
+    // writer) handshake orders the two: up_go (reader: slot reserved) and
+    // up_done (writer: up landed in L1), monotonic counters.
+    constexpr uint8_t kUpNoc = 1;
+    const uint32_t up_tile_bytes = get_tile_size(cb_in1_up);
+    volatile tt_l1_ptr uint32_t* up_go_local =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(up_go_sem_id));
+    volatile tt_l1_ptr uint32_t* up_done_local =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(up_done_sem_id));
+    uint32_t up_seq = 0;
+
     for (uint32_t chunk = 0; chunk < effective_chunks; ++chunk) {
+        // ---- Phase 1/2 weight feed: writer reads `up` on NoC 1 (UP_SPLIT) ----
+        // Streams `up` from DRAM concurrent with the reader's NoC-0 `gate` read.
+        // Runs before the cb_out drain.
+        if constexpr (writer_split_up) {
+            // UP_SPLIT: only gy=0 in1-sender cores read `up`. Per K-block: wait
+            // for the reader to reserve the slot (up_go), read this column's
+            // `up` slice on NoC 1 into it, then signal up_done so the reader
+            // mcasts on NoC 0. Only a NoC-1 DRAM read here (fabric-safe); the
+            // reader owns cb_in1_up reserve/push.
+            if (is_up_sender) {
+                // The CB write pointer is PER-RISC and the reader owns push, so
+                // the writer's get_write_ptr never advances. Replicate the
+                // reader's cadence: cb_in1_up is double-buffered, one push per
+                // K-block, so the live slot is base + (up_seq-1)%2 * slot.
+                constexpr uint32_t kUpNumSlots = 2;
+                const uint32_t up_cb_base = get_write_ptr(cb_in1_up);
+                const uint32_t up_slot_bytes = g_in1_block_num_tiles * up_tile_bytes;
+                for (uint32_t kb = 0; kb < num_blocks_gu; ++kb) {
+                    ++up_seq;
+                    noc_semaphore_wait_min(up_go_local, up_seq);
+                    uint32_t l1_w_up = up_cb_base + ((up_seq - 1) % kUpNumSlots) * up_slot_bytes;
+                    for (uint32_t k = 0; k < in0_block_w_gu; ++k) {
+                        for (uint32_t n = 0; n < per_core_N_gu; ++n) {
+                            const uint32_t row = kb * in0_block_w_gu + k;
+                            const uint32_t col = my_nt_gu * per_core_N_gu + n;
+                            if (col < N_gate_tiles_full) {
+                                const uint32_t tile_idx = row * N_gate_tiles_full + col;
+                                noc_async_read_page(tile_idx, up_acc, l1_w_up, /*offset=*/0, kUpNoc);
+                            } else {
+                                volatile tt_l1_ptr uint64_t* p =
+                                    reinterpret_cast<volatile tt_l1_ptr uint64_t*>(l1_w_up);
+                                for (uint32_t i = 0; i < up_tile_bytes / 8; ++i) {
+                                    p[i] = 0;
+                                }
+                            }
+                            l1_w_up += up_tile_bytes;
+                        }
+                    }
+                    noc_async_read_barrier(kUpNoc);
+                    *up_done_local = up_seq;
+                }
+            }
+        }
+
+        // ---- Drain cb_out (down matmul output) to DRAM ----
         const uint32_t row0 = chunk * chunk_M_tiles + my_mt * per_core_M;
         const uint32_t col0 = my_nt_d * per_core_N_d;
         for (uint32_t sb_m = 0; sb_m < d_in1_num_subblocks_M; ++sb_m) {
@@ -164,4 +262,7 @@ void kernel_main() {
     // Ensure all outstanding writes complete at the destination before the
     // kernel returns (the next dispatched op may read this output).
     noc_async_write_barrier();
+    // UP_SPLIT issues only per-K-block-barriered NoC-1 `up` reads (no NoC-1
+    // worker multicast and no NoC-1 atomics), so no extra NoC-1 drain is needed
+    // here — which is exactly why it is safe beside the fabric CCL ops.
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
@@ -78,17 +78,39 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     // covers exactly per_core_N_gu cols per step; activated cols past
     // actual_hidden are 0 (gate/up weight OOB zero-fill propagates through
     // silu and multiply).
-    constexpr uint32_t GRID_X = 11;
-    constexpr uint32_t GRID_Y = 8;
+    constexpr uint32_t kMaxGridX = 11;
+    constexpr uint32_t MAX_GRID_Y = 8;
+    // Short-sequence regime: for small allocated M the 2D layout is stall-bound
+    // (FPU idle), dominated by the gate/up weight DRAM read and by per_core_M.
+    // Both shrink with the grid (pure host config): more N-columns parallelise
+    // the read, and maximising GRID_Y drives per_core_M down to 1-2 for the cost
+    // of a cheap weight multicast. So: GRID_X tuned below, GRID_Y =
+    // min(8, M_tiles_full), single chunk; GRID_Y == 1 drops the multicast.
+    //
+    // Branches purely on ALLOCATED M (x.padded_shape); the runtime token count
+    // still bounds the chunk loop device-side. Production keeps M_tiles_full
+    // large, so it stays on the unchanged 2D path.
+    constexpr uint32_t kShortSeqMaxMTiles = 32;  // <= 1024 tokens
+    uint32_t GRID_X = kMaxGridX;
+    uint32_t GRID_Y = MAX_GRID_Y;
+    uint32_t chunk_M_tiles = op.chunk_M_tiles;
+    uint32_t in0_block_w_gu = 16;
+    const bool short_seq = M_tiles_full <= kShortSeqMaxMTiles;
+    if (short_seq) {
+        // Maximise rows to minimise per_core_M (1 for M <= 8, 2 for M <= 16, ...).
+        GRID_Y = std::min(MAX_GRID_Y, M_tiles_full);
+        GRID_Y = std::max<uint32_t>(GRID_Y, 1);
+        const uint32_t per_core_M_short = (M_tiles_full + GRID_Y - 1) / GRID_Y;
+        chunk_M_tiles = per_core_M_short * GRID_Y;  // single chunk (>= M_tiles_full)
+    }
     const auto grid_size = t.x.device()->compute_with_storage_grid_size();
     TT_FATAL(
-        grid_size.x >= GRID_X && grid_size.y >= GRID_Y,
+        grid_size.x >= kMaxGridX && grid_size.y >= MAX_GRID_Y,
         "unified_routed_expert_ffn: expected at least {}x{} compute grid, got {}x{}",
-        GRID_X,
-        GRID_Y,
+        kMaxGridX,
+        MAX_GRID_Y,
         grid_size.x,
         grid_size.y);
-    const uint32_t chunk_M_tiles = op.chunk_M_tiles;
     const uint32_t per_core_M = chunk_M_tiles / GRID_Y;
     TT_FATAL(
         per_core_M * GRID_Y == chunk_M_tiles,
@@ -102,15 +124,76 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     // pad/slice round-trip in the composite for non-aligned M.
     const uint32_t num_chunks = (M_tiles_full + chunk_M_tiles - 1) / chunk_M_tiles;
 
+    // Per-core L1 footprint estimator, mirroring the CreateCircularBuffer sizes
+    // below. Bounds the short-seq GRID_X search to the known-good 2D footprint
+    // so we never risk an L1 OOM.
+    const uint32_t x_ts = tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(t.x.dtype()));
+    const uint32_t w_ts = tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(t.gate_proj.dtype()));
+    const uint32_t p_ts = tt::tile_size(tt::DataFormat::Float16_b);
+    const uint32_t im_ts = tt::tile_size(tt::DataFormat::Bfp8_b);
+    const uint32_t out_ts = tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(tensor_return_value.dtype()));
+    auto est_l1_bytes = [&](uint32_t gx, uint32_t pcM, uint32_t ibw_gu) -> uint64_t {
+        const uint32_t pcN_gu = (N_gate_tiles_full + gx - 1) / gx;
+        const uint32_t pcN_d = (N_down_tiles_full + gx - 1) / gx;
+        const uint32_t ibw_d = pcN_gu;
+        uint64_t b = 0;
+        b += 2ull * pcM * ibw_gu * x_ts;     // CB_IN0_X (double-buffered)
+        b += 2ull * ibw_gu * pcN_gu * w_ts;  // CB_IN1_GATE
+        b += 2ull * ibw_gu * pcN_gu * w_ts;  // CB_IN1_UP
+        b += 2ull * ibw_d * pcN_d * w_ts;    // CB_IN1_DOWN
+        b += 1ull * pcM * pcN_gu * im_ts;    // CB_GATE_INT
+        b += 1ull * pcM * pcN_gu * im_ts;    // CB_ACTIVATED
+        b += 1ull * pcM * pcN_gu * p_ts;     // CB_PARTIALS_GU
+        b += 1ull * pcM * pcN_gu * p_ts;     // CB_PARTIALS_UP
+        b += 1ull * pcM * pcN_d * p_ts;      // CB_PARTIALS_D
+        b += 2ull * 8 * out_ts;              // CB_OUT (subblock <= 8 tiles, staged x2)
+        b += 2ull * pcM * ibw_d * im_ts;     // CB_IN0_DOWN_FULL
+        b += 8192;                           // counts + idx scratch
+        return b;
+    };
+
+    if (short_seq) {
+        // Reference footprint: the largest 2D config (GRID_X=11, per_core_M=8,
+        // in0_block_w_gu=16) is known to fit, so any smaller config fits too.
+        constexpr uint32_t kMax2dPerCoreM = 8;
+        const uint64_t budget = est_l1_bytes(kMaxGridX, kMax2dPerCoreM, 16);
+        // gate/up K-block widths to try (descending = fewest handshakes),
+        // restricted to divisors of K_gate_tiles.
+        const uint32_t ibw_candidates[] = {56, 32, 28, 16, 8, 4, 2, 1};
+        uint32_t best_gx = kMaxGridX;
+        uint32_t best_ibw = 16;
+        bool found = false;
+        // Candidate GRID_X: more N-columns parallelise the dominant weight read,
+        // so prefer gx=8, then 11, then 4. Restricted to values whose
+        // per_core_N_gu has a large (<=8) output-subblock divisor — gx 5/6/7
+        // give per_core_N_gu with only divisor 1, forcing 1-wide pack subblocks
+        // that erase the saving.
+        const uint32_t gx_candidates[] = {8, kMaxGridX, 4};
+        for (uint32_t gx : gx_candidates) {
+            if (found) {
+                break;
+            }
+            for (uint32_t ibw : ibw_candidates) {
+                if (ibw > K_gate_tiles || (K_gate_tiles % ibw) != 0) {
+                    continue;
+                }
+                if (est_l1_bytes(gx, per_core_M, ibw) <= budget) {
+                    best_gx = gx;
+                    best_ibw = ibw;
+                    found = true;
+                    break;  // largest fitting ibw for this gx
+                }
+            }
+        }
+        GRID_X = best_gx;
+        in0_block_w_gu = best_ibw;
+    }
+
     const uint32_t per_core_N_gu = (N_gate_tiles_full + GRID_X - 1) / GRID_X;
     const uint32_t per_core_N_d = (N_down_tiles_full + GRID_X - 1) / GRID_X;
     const uint32_t N_gate_tiles_padded = per_core_N_gu * GRID_X;
     const uint32_t K_down_tiles_padded = N_gate_tiles_padded;  // down K = gate N
 
-    // With 11x8 = 88 cores, per_core_N_gu (= 6) and per_core_N_d (= 21) leave
-    // ~250KB of headroom per core vs an 8x8 layout. Use it to double
-    // in0_block_w_gu, halving the gate / up K-loop iteration count.
-    const uint32_t in0_block_w_gu = 16;
     const uint32_t in0_block_w_d = per_core_N_gu;
     TT_FATAL(
         K_gate_tiles % in0_block_w_gu == 0,
@@ -247,6 +330,32 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     // a turn as sender exactly once per chunk.
     const uint32_t act_ready_sem_id = tt::tt_metal::CreateSemaphore(program, core_range_set, 0);
     const uint32_t act_valid_sem_id = tt::tt_metal::CreateSemaphore(program, core_range_set, 0);
+    // Two-RISC weight read: use the writer (NCRISC, idle until the down output)
+    // as a second read engine for `up`, read on NoC 1 concurrent with the
+    // reader's NoC-0 `gate` read. Two delivery schemes:
+    //
+    //   * UP_WRITER_MCAST (mode 1): writer also NoC-1 multicasts `up` down its
+    //     N-column. Bandwidth-optimal, but the NoC-1 worker multicast + posted
+    //     atomics collide with fabric CCL ops on NoC 1 and hang the run.
+    //     Short-seq is NOT fabric-disabled (it triggers on small dispatch
+    //     buffers in real fabric-enabled runs), so this scheme is retired.
+    //   * UP_SPLIT (mode 2): writer only reads `up` on NoC 1 (same kind as its
+    //     cb_out NoC-1 writes — fabric-safe) into the gy=0 sender's cb_in1_up
+    //     slot; the reader multicasts it on NoC 0 alongside `gate`. A local
+    //     same-core L1 handshake orders the two. Used on all layouts.
+    //
+    // up_mode: 0 = LEGACY (reader reads + mcasts `up` on NoC 0), 2 = UP_SPLIT
+    // (writer reads `up` on NoC 1, reader mcasts on NoC 0). The retired
+    // UP_WRITER_MCAST scheme (writer NoC-1-multicasts `up`) is no longer
+    // selectable. kEnableSplitUp picks UP_SPLIT for all layouts.
+    constexpr bool kEnableSplitUp = true;
+    uint32_t up_mode = kEnableSplitUp ? 2 : 0;
+    const bool reader_reads_up = (up_mode == 0);                   // reader issues up DRAM read
+    const bool reader_mcasts_up = (up_mode == 0 || up_mode == 2);  // reader NoC-0 mcasts up
+    // Local same-core handshake sems (UP_SPLIT only): up_go (reader -> writer:
+    // slot reserved) and up_done (writer -> reader: up in L1). Monotonic.
+    const uint32_t up_go_sem_id = (up_mode == 2) ? tt::tt_metal::CreateSemaphore(program, core_range_set, 0) : 0;
+    const uint32_t up_done_sem_id = (up_mode == 2) ? tt::tt_metal::CreateSemaphore(program, core_range_set, 0) : 0;
 
     // -------------------------- circular buffers --------------------------
     // Double-buffered DRAM-streamed inputs.
@@ -393,6 +502,10 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         // K_down_tiles_padded — phase-4 K-loop bound. K dim of down is
         // padded to N_gate_padded so per-K-block sender = gx == kb holds.
         K_down_tiles_padded,
+        // reader_reads_up — 1 only in LEGACY (reader issues the up DRAM read).
+        static_cast<uint32_t>(reader_reads_up),
+        // reader_mcasts_up — 1 in LEGACY and UP_SPLIT (reader NoC-0 mcasts up).
+        static_cast<uint32_t>(reader_mcasts_up),
     };
     tt::tt_metal::TensorAccessorArgs(x_buffer).append_to(reader_ct_args);
     tt::tt_metal::TensorAccessorArgs(gate_buffer).append_to(reader_ct_args);
@@ -441,9 +554,19 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         // for the per-expert output; the shared buffer's rows in direct mode).
         dst_M_tiles,       // 18
         CB_START_SCRATCH,  // 19
+        // UP_SPLIT up-weight read: CB + dims let the writer replicate the gate
+        // read on NoC 1, and writer_split_up gates it (1 = UP_SPLIT).
+        CB_IN1_UP,                            // 20
+        in0_block_w_gu,                       // 21
+        K_gate_tiles,                         // 22
+        static_cast<uint32_t>(up_mode == 2),  // 23 writer_split_up
     };
+    // Accessor compile-arg stream order MUST match the writer kernel:
+    // out, then start (direct-write), then up (UP_SPLIT).
     tt::tt_metal::TensorAccessorArgs(out_buffer).append_to(writer_ct_args);
     tt::tt_metal::TensorAccessorArgs(start_buffer).append_to(writer_ct_args);
+    // up accessor follows start; used only when the writer handles `up`.
+    tt::tt_metal::TensorAccessorArgs(up_buffer).append_to(writer_ct_args);
 
     auto writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
@@ -564,8 +687,12 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         // those receiver rows.
         const bool is_in1_sender = (gy == 0);
         const auto sender_noc = device->worker_core_from_logical_core(CoreCoord{gx, 0});
-        const auto first_recv_noc = device->worker_core_from_logical_core(CoreCoord{gx, 1});
-        const auto last_recv_noc = device->worker_core_from_logical_core(CoreCoord{gx, GRID_Y - 1});
+        // GRID_Y == 1: no receivers — point the unused receiver coords at the
+        // sender row (gy=1 doesn't exist); the reader skips the mcast.
+        const CoreCoord first_recv_logical = (GRID_Y > 1) ? CoreCoord{gx, 1} : CoreCoord{gx, 0};
+        const CoreCoord last_recv_logical = (GRID_Y > 1) ? CoreCoord{gx, GRID_Y - 1} : CoreCoord{gx, 0};
+        const auto first_recv_noc = device->worker_core_from_logical_core(first_recv_logical);
+        const auto last_recv_noc = device->worker_core_from_logical_core(last_recv_logical);
         const uint32_t in1_num_receivers = GRID_Y - 1;
         const uint32_t in1_mcast_nx_start = first_recv_noc.x;
         const uint32_t in1_mcast_ny_start = first_recv_noc.y;
@@ -595,9 +722,9 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         //   8: my_nt_d
         //   9..18: in1 multicast args
         //  19..28: in0 multicast args
-        //  29: act_ready_sem_id
-        //  30: act_valid_sem_id
-        //  31+: M-row NoC coord table (GRID_X pairs of x, y)
+        //  29: act_ready_sem_id  30: act_valid_sem_id
+        //  31: up_go_sem_id  32: up_done_sem_id
+        //  33+: M-row NoC coord table (GRID_X pairs of x, y)
         std::vector<uint32_t> reader_args = {
             x_buffer->address(),
             gate_buffer->address(),
@@ -630,6 +757,9 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
             in0_sender_ny,
             act_ready_sem_id,
             act_valid_sem_id,
+            // UP_SPLIT local same-core handshake sems (0 when unused).
+            up_go_sem_id,
+            up_done_sem_id,
         };
         // M-row NoC coord table: for our M-row (gy=my_mt), the NoC (x, y) of
         // each of the GRID_X cores (gx=0..GRID_X-1). Reader uses this per
@@ -643,16 +773,21 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
 
         // Writer runtime arg layout (must match unified_routed_expert_ffn_writer.cpp):
-        //   0: output_addr
-        //   1: my_mt
-        //   2: my_nt_d
+        //   0: output_addr  1: my_mt  2: my_nt_d
         //   3: start_addr (expert_region_offsets in direct-write mode; else
         //      out_buffer, unused by the kernel)
+        //   4: up_addr  5: my_nt_gu  6: is_up_sender (gy==0)
+        //   7: up_go_sem_id  8: up_done_sem_id  (UP_SPLIT local same-core handshake)
         std::vector<uint32_t> writer_args = {
-            out_buffer->address(),
-            my_mt,
-            my_nt_d,
-            start_buffer->address(),
+            out_buffer->address(),                 // 0
+            my_mt,                                 // 1
+            my_nt_d,                               // 2
+            start_buffer->address(),               // 3
+            up_buffer->address(),                  // 4
+            my_nt_gu,                              // 5
+            static_cast<uint32_t>(is_in1_sender),  // 6 is_up_sender
+            up_go_sem_id,                          // 7
+            up_done_sem_id,                        // 8
         };
         tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
     }
@@ -698,6 +833,7 @@ void UnifiedRoutedExpertFfnProgramFactory::override_runtime_arguments(
         auto& writer_args = tt::tt_metal::GetRuntimeArgs(program, writer_id, core);
         writer_args[0] = out_addr;
         writer_args[3] = start_addr;
+        writer_args[4] = up_addr;  // two-RISC up-weight read base address
     }
 }
 


### PR DESCRIPTION
## Summary
Speeds up `unified_routed_expert_ffn` across allsequence lengths. Two changes:
- **Short-sequence layout.** For small token counts, collapse the grid to the minimum
  worker rows that fit L1 and pick a read-parallel column count, removing the fixed
  per-chunk weight-multicast floor that made 32–1024 tokens all cost the same.
- **Two-RISC weight read (UP_SPLIT).** The writer (NCRISC) reads `up` on NoC 1 in
  parallel with the reader's (BRISC) NoC-0 `gate` read; the reader still multicasts it on
  NoC 0 (no writer-side NoC-1 multicast -> fabric-safe). Applies to all layouts.

Affects only cases where number of dispatched tokens is smaller. Not cases where token count buffer contains small number of tokens. In the latter case, performance will remain unchanged.

Major notes:
- **PCC unchanged (≥ 0.978). Verified single-chip, all 8-device mesh topologies, and the full
32-chip / 61-layer e2e run.**
- Full e2e prefill test run as:`TT_DS_PREFILL_INFINITEBENCH_CACHE=/tmp/kgrujcic/deepseek_v3_transformer_inputs PYTHONPATH=/data/kgrujcic/tt-metal-main TT_METAL_HOME=/data/kgrujcic/tt-metal-main TT_DS_PREFILL_TTNN_CACHE=/mnt/models/DeepSeek-R1-0528-Cache/DeepSeek-R1-0528-Cache-prefill_secure TT_DS_PREFILL_HOST_REF_CACHE=/mnt/models/deepseek-prefill-cache/golden/ DEEPSEEK_V3_HF_MODEL=/mnt/models/deepseek-ai/DeepSeek-R1-0528 /data/kgrujcic/tt-metal-main/python_env/bin/python /data/kgrujcic/.vscode/run_and_report.py --test_path models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py --test_args "blackhole-deepseek_v3-mesh-8x4-iter25-no_determinism-e256_device_fp32-61_layers-25600-8-balanced-smoke-longbook_qa_eng-pretrained-kv_cache-temp_sweep-right_pad"`.
- **Average iteration duration on 25k ISL (longbook_qa_en) is now 3.96s.** Dropped from 4.3s.

## Background
The 2D layout was a flat ~625 µs from 32 to 1024 tokens, independent of token count. FPU
util was 0% the whole op (stall-bound, not compute-bound): a matmul over even 1 token row
reads the full gate/up/down weights (~24.8 MB bf4), so short sequences pay the full weight
movement, and the per-K-block cross-core handshake/multicast latency was the floor.

## Results
| tokens | baseline (µs) | now (µs) |
|------:|----:|----:|
| 32 | 625 | 173 |
| 64 | 625 | 211 |
| 128 | 625 | 220 |
| 256 | 624 | 231 |
| 512 | 614 | 279 |
| 1024 | 629 | 371 |
| 2048 | 693 | 590 |
| 4096 | 1349 | 1162 |
| 8192 | 2702 | 2315 |
| 25600 | 8640 | 7450 |

## CIs
- https://github.com/tenstorrent/tt-metal/actions/runs/28011208284 and https://github.com/tenstorrent/tt-metal/actions/runs/28004519319. Relevant jobs passed, others have remained the same.
- https://github.com/tenstorrent/tt-metal/actions/runs/28004526854. Relevant jobs passed, others have remained the same.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kgrujcic/47551)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kgrujcic/47551)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kgrujcic/47551)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kgrujcic/47551)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kgrujcic/47551)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kgrujcic/47551)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kgrujcic/47551)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kgrujcic/47551)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kgrujcic/47551)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kgrujcic/47551)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kgrujcic/47551)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kgrujcic/47551)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kgrujcic/47551)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kgrujcic/47551)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kgrujcic/47551)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kgrujcic/47551)