### PR TITLE
[skip ci] Temporarily skip test_rope_1d_decode_forward_vs_reference on Wormhole

### DIFF
--- a/models/common/tests/modules/rope/test_rope_1d.py
+++ b/models/common/tests/modules/rope/test_rope_1d.py
@@ -27,7 +27,6 @@ from models.common.modules.lazy_weight import LazyWeight
 from models.common.modules.rope.rope_1d import Rope1DConfig, RotarySetup1D, prepare_rot_idxs
 from models.common.tensor_utils import get_rot_transformation_mat
 from models.common.utility_functions import comp_pcc, skip_for_wormhole_b0
-from models.common.utility_functions import is_galaxy
 
 # ============================================================================
 # Pure-torch RoPE reference (no TTTv1 dependency)

--- a/models/common/tests/modules/rope/test_rope_1d.py
+++ b/models/common/tests/modules/rope/test_rope_1d.py
@@ -291,7 +291,7 @@ def _list_init_test_cases() -> list[pytest.param]:
     "mesh_shape,batch_size,head_dim,max_seq_len,rope_theta,rope_scaling_str,use_qk_fused",
     _list_init_test_cases(),
 )
-@skip_for_wormhole_b0("Failing on wh_llmbox for 7+ days; refs #FIXME")
+@skip_for_wormhole_b0("Failing on wh_llmbox for 7+ days; refs #46879")
 def test_rope_1d_decode_forward_vs_reference(
     ttnn_mesh_device: ttnn.MeshDevice,
     mesh_shape,

--- a/models/common/tests/modules/rope/test_rope_1d.py
+++ b/models/common/tests/modules/rope/test_rope_1d.py
@@ -26,7 +26,8 @@ from models.common.auto_compose import to_torch_auto_compose
 from models.common.modules.lazy_weight import LazyWeight
 from models.common.modules.rope.rope_1d import Rope1DConfig, RotarySetup1D, prepare_rot_idxs
 from models.common.tensor_utils import get_rot_transformation_mat
-from models.common.utility_functions import comp_pcc
+from models.common.utility_functions import comp_pcc, skip_for_wormhole_b0
+from models.common.utility_functions import is_galaxy
 
 # ============================================================================
 # Pure-torch RoPE reference (no TTTv1 dependency)
@@ -291,6 +292,7 @@ def _list_init_test_cases() -> list[pytest.param]:
     "mesh_shape,batch_size,head_dim,max_seq_len,rope_theta,rope_scaling_str,use_qk_fused",
     _list_init_test_cases(),
 )
+@skip_for_wormhole_b0("Failing on wh_llmbox for 7+ days; refs #FIXME")
 def test_rope_1d_decode_forward_vs_reference(
     ttnn_mesh_device: ttnn.MeshDevice,
     mesh_shape,


### PR DESCRIPTION
The test `test_rope_1d_decode_forward_vs_reference` (and its parametrized variants) has been failing on the `wh_llmbox` (T3000 Wormhole) CI job for 7+ days (first observed at commit 039767d00b9a, 2026-06-12). This PR temporarily skips the test on Wormhole B0 hardware using the existing `skip_for_wormhole_b0` helper until the root cause is investigated and fixed.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-46879)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lifecycle/disable-issue-46879)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-46879)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lifecycle/disable-issue-46879)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=lifecycle/disable-issue-46879)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:lifecycle/disable-issue-46879)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lifecycle/disable-issue-46879)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lifecycle/disable-issue-46879)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lifecycle/disable-issue-46879)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lifecycle/disable-issue-46879)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lifecycle/disable-issue-46879)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lifecycle/disable-issue-46879)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lifecycle/disable-issue-46879)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lifecycle/disable-issue-46879)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lifecycle/disable-issue-46879)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lifecycle/disable-issue-46879)