### PR TITLE
[skip ci] Skip bge_m3 test_model_full_end_to_end[S4096] on N300 due to PCC failure

### DIFF
--- a/models/demos/wormhole/bge_m3/tests/pcc/test_model.py
+++ b/models/demos/wormhole/bge_m3/tests/pcc/test_model.py
@@ -36,6 +36,8 @@ def model_artifacts(model_location_generator):
 @pytest.mark.slow
 @pytest.mark.parametrize("seq_len", SEQUENCE_LENGTHS, ids=[f"S{seq_len}" for seq_len in SEQUENCE_LENGTHS])
 def test_model_full_end_to_end(device, model_artifacts, seq_len, reset_seeds):
+    if seq_len == 4096:
+        pytest.skip("Skipping S4096: PCC check fails on N300 Wormhole (PCC=0.84 < 0.94); see GH issue")
     require_single_device(device)
     backbone, state_dict, model_id_or_path = model_artifacts
 


### PR DESCRIPTION
The parametrized case `test_model_full_end_to_end[S4096]` has been failing for 7+ days on the Nightly N300 bge_m3 CI job with a PCC check failure (PCC=0.84 < threshold 0.94, Max ATOL Delta=7.1875). S128/S1024/S2048 all pass; only S4096 regresses. This adds an in-body `pytest.skip` guarded on `seq_len == 4096` so only that parametrized case is skipped, leaving all other sequence lengths running. The wrapping `test_ci_dispatch[bge_m3]` will automatically pass once the inner failure is removed. Temporarily disabled pending a fix to the numerical accuracy regression at seq_len=4096.