### PR TITLE
[skip ci] Skip test_qwen25vl_encoder_pair on wormhole_b0 due to PCC regression

### DIFF
--- a/models/tt_dit/tests/encoders/qwen25vl/test_qwen25vl.py
+++ b/models/tt_dit/tests/encoders/qwen25vl/test_qwen25vl.py
@@ -10,6 +10,7 @@ import transformers.models.qwen2_5_vl.modeling_qwen2_5_vl
 from loguru import logger
 
 import ttnn
+from models.common.utility_functions import skip_for_wormhole_b0
 
 from ....encoders.qwen25vl.encoder_pair import Qwen25VlTokenizerEncoderPair
 from ....encoders.qwen25vl.model_qwen25vl import (
@@ -209,6 +210,7 @@ def test_qwen25vl_text_encoder(
         assert_quality(prompt_embeds, tt_prompt_embeds_torch, pcc=0.991, relative_rmse=0.14)
 
 
+@skip_for_wormhole_b0("PCC regression on wh_llmbox T3000, see GH issue")
 @pytest.mark.parametrize(
     "mesh_device , submesh_shape",
     [[(2, 4), (1, 4)], [(4, 8), (1, 4)]],


### PR DESCRIPTION
test_qwen25vl_encoder_pair[wormhole_b0-device_params0-prompts0-2x4_1x4] has been failing for 7+ days on the T3000 wh_llmbox integration job with PCC = 96.14% < 98.30% threshold. Temporarily skip the test on wormhole_b0 until the numerical accuracy issue is resolved.