### PR TITLE
[Fix] matmul: fix batch broadcast when A batch=1 and B batch>1

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_batch_mismatch.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_batch_mismatch.py
@@ -2,15 +2,51 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Regression test for matmul with batch dimension mismatch (in0_B > 1, in1_B = 1).
+Regression tests for matmul with batch dimension mismatch.
 
-This tests the path that was previously causing hangs when the input tensor had batch > 1 and the weight tensor had batch = 1.
+test_matmul_a_batch1_b_batched: A batch=1, B batch>1 (issue #12834)
+test_matmul_batch_mismatch:     A batch>1, B batch=1 (prior regression)
 """
 
 import pytest
 import torch
 import ttnn
 from models.common.utility_functions import comp_pcc
+
+
+@pytest.mark.parametrize(
+    "a_shape, b_shape",
+    [
+        ((1, 1, 128, 2048), (1, 7, 2048, 256)),  # rank-4: exact shape from issue #12834
+        ((1, 1, 64, 512), (1, 4, 512, 128)),  # rank-4
+        ((1, 128, 2048), (7, 2048, 256)),  # rank-3: original issue shape
+        ((1, 64, 512), (4, 512, 128)),  # rank-3
+    ],
+)
+def test_matmul_a_batch1_b_batched(a_shape, b_shape, device):
+    """
+    Test ttnn.matmul where A has batch=1 and B has batch>1 (issue #12834).
+    Previously crashed with "bmm expects input tensors of shapes BCMK*BCKN=BCMN".
+    The auto-selector should now pick 1D mcast config and use in0_reuse.
+    """
+    torch.manual_seed(0)
+    a_torch = torch.randn(*a_shape)
+    b_torch = torch.randn(*b_shape)
+
+    a_ttnn = ttnn.from_torch(a_torch, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+    b_ttnn = ttnn.from_torch(b_torch, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+
+    output = ttnn.matmul(a_ttnn, b_ttnn)
+    ttnn.synchronize_device(device)
+
+    expected_shape = list(torch.matmul(a_torch, b_torch).shape)
+    assert list(output.shape) == expected_shape
+
+    output_torch = ttnn.to_torch(output).to(torch.float32)
+    expected = torch.matmul(a_torch, b_torch)
+
+    pcc_passed, pcc_message = comp_pcc(expected, output_torch, 0.99)
+    assert pcc_passed, f"PCC check failed: {pcc_message}"
 
 
 @pytest.mark.parametrize(
@@ -22,41 +58,25 @@ from models.common.utility_functions import comp_pcc
 def test_matmul_batch_mismatch(batch, M, K, N, device):
     """
     Test ttnn.linear with batch dimension mismatch (input batch >= 1, weight batch = 1).
-
-    This specifically tests the case where:
-    - Input: [batch, M, K]
-    - Weight: [K, N] (no batch dimension, implicitly batch=1)
-
-    Previously, batch=6 would hang in the matmul kernel due to incorrect argument passed to the in1 reader receiver kernel.
+    Previously, batch=6 would hang in the matmul kernel.
     """
     torch.manual_seed(0)
-    # Create input tensor [batch, M, K]
     input_torch = torch.randn(batch, M, K)
     input_ttnn = ttnn.from_torch(input_torch, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
 
-    # Create weight tensor [K, N]
     weight_torch = torch.randn(K, N)
     weight_ttnn = ttnn.from_torch(weight_torch, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
 
-    # Create bias tensor [N]
     bias_torch = torch.randn(N)
     bias_ttnn = ttnn.from_torch(bias_torch, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
 
-    # Run ttnn.linear (internally uses matmul)
     output = ttnn.linear(input_ttnn, weight_ttnn, bias=bias_ttnn)
-
-    # Ensure operation completes (this was the hang point for batch=6)
     ttnn.synchronize_device(device)
 
-    # Verify output shape
     assert list(output.shape) == [batch, M, N]
 
-    # Convert back to torch for correctness check
     output_torch = ttnn.to_torch(output).to(torch.float32)
-
-    # Compute reference
     expected = torch.matmul(input_torch, weight_torch) + bias_torch
 
-    # Verify correctness using PCC (allow for numerical differences due to bfloat16)
     pcc_passed, pcc_message = comp_pcc(expected, output_torch, 0.99)
     assert pcc_passed, f"PCC check failed: {pcc_message}"

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_batch_mismatch.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_batch_mismatch.py
@@ -58,25 +58,41 @@ def test_matmul_a_batch1_b_batched(a_shape, b_shape, device):
 def test_matmul_batch_mismatch(batch, M, K, N, device):
     """
     Test ttnn.linear with batch dimension mismatch (input batch >= 1, weight batch = 1).
-    Previously, batch=6 would hang in the matmul kernel.
+
+    This specifically tests the case where:
+    - Input: [batch, M, K]
+    - Weight: [K, N] (no batch dimension, implicitly batch=1)
+
+    Previously, batch=6 would hang in the matmul kernel due to incorrect argument passed to the in1 reader receiver kernel.
     """
     torch.manual_seed(0)
+    # Create input tensor [batch, M, K]
     input_torch = torch.randn(batch, M, K)
     input_ttnn = ttnn.from_torch(input_torch, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
 
+    # Create weight tensor [K, N]
     weight_torch = torch.randn(K, N)
     weight_ttnn = ttnn.from_torch(weight_torch, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
 
+    # Create bias tensor [N]
     bias_torch = torch.randn(N)
     bias_ttnn = ttnn.from_torch(bias_torch, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
 
+    # Run ttnn.linear (internally uses matmul)
     output = ttnn.linear(input_ttnn, weight_ttnn, bias=bias_ttnn)
+
+    # Ensure operation completes (this was the hang point for batch=6)
     ttnn.synchronize_device(device)
 
+    # Verify output shape
     assert list(output.shape) == [batch, M, N]
 
+    # Convert back to torch for correctness check
     output_torch = ttnn.to_torch(output).to(torch.float32)
+
+    # Compute reference
     expected = torch.matmul(input_torch, weight_torch) + bias_torch
 
+    # Verify correctness using PCC (allow for numerical differences due to bfloat16)
     pcc_passed, pcc_message = comp_pcc(expected, output_torch, 0.99)
     assert pcc_passed, f"PCC check failed: {pcc_message}"

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_batch_mismatch.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_batch_mismatch.py
@@ -17,10 +17,10 @@ from models.common.utility_functions import comp_pcc
 @pytest.mark.parametrize(
     "a_shape, b_shape",
     [
-        ((1, 1, 128, 2048), (1, 7, 2048, 256)),  # rank-4: exact shape from issue #12834
-        ((1, 1, 64, 512), (1, 4, 512, 128)),  # rank-4
-        ((1, 128, 2048), (7, 2048, 256)),  # rank-3: original issue shape
-        ((1, 64, 512), (4, 512, 128)),  # rank-3
+        ((1, 1, 128, 2048), (1, 7, 2048, 256)),
+        ((1, 64, 768), (5, 768, 192)),
+        ((1, 1, 256, 512), (1, 3, 512, 64)),
+        ((1, 192, 384), (6, 384, 96)),
     ],
 )
 def test_matmul_a_batch1_b_batched(a_shape, b_shape, device):

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_batch_mismatch.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_batch_mismatch.py
@@ -21,6 +21,8 @@ from models.common.utility_functions import comp_pcc
         ((1, 128, 2048), (7, 2048, 256)),
         ((1, 1, 256, 512), (1, 3, 512, 64)),
         ((1, 64, 768), (5, 768, 192)),
+        ((1, 1, 1, 128, 512), (2, 3, 4, 512, 64)),
+        ((1, 1, 1, 1, 64, 512), (2, 3, 4, 5, 512, 128)),
     ],
 )
 def test_matmul_a_batch1_b_batched(a_shape, b_shape, device):

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_batch_mismatch.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_batch_mismatch.py
@@ -18,9 +18,9 @@ from models.common.utility_functions import comp_pcc
     "a_shape, b_shape",
     [
         ((1, 1, 128, 2048), (1, 7, 2048, 256)),
-        ((1, 64, 768), (5, 768, 192)),
+        ((1, 128, 2048), (7, 2048, 256)),
         ((1, 1, 256, 512), (1, 3, 512, 64)),
-        ((1, 192, 384), (6, 384, 96)),
+        ((1, 64, 768), (5, 768, 192)),
     ],
 )
 def test_matmul_a_batch1_b_batched(a_shape, b_shape, device):

--- a/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
@@ -452,6 +452,24 @@ MatmulProgramConfig create_matmul_program_config(
     uint32_t k_tiles_per_core;
     if (input_b_is_batched) {
         TT_FATAL(!fused_activation.has_value(), "Cannot use activation with batched input b");
+        // When A batch=1 and B batch>1, route to 1D mcast config so the in0_reuse
+        // optimization fires: A is loaded into L1 once and reused across all B batches.
+        if (batch_size_a == 1 && !a_is_sharded && !input_tensor_b.is_sharded()) {
+            return get_mcast_1d_config(
+                input_tensor_a,
+                input_tensor_b,
+                transpose_a,
+                transpose_b,
+                bias_single_tile_size,
+                /*fuse_batch=*/false,
+                fused_activation,
+                /*mcast_in0=*/false,
+                /*out_sharded=*/false,
+                core_coord,
+                compute_kernel_config,
+                output_dtype,
+                /*all_dram_interleaved=*/false);
+        }
         if (!a_is_sharded && !input_tensor_b.is_sharded()) {
             m_tiles_per_core = div_up(m_size, ttnn::TILE_SIZE);
             n_tiles_per_core = div_up(n_size, ttnn::TILE_SIZE);
@@ -1103,6 +1121,24 @@ MatmulProgramConfig create_simple_matmul_program_config(
                           mem_config.buffer_type() == BufferType::DRAM;
 
     const bool all_dram_interleaved = all_dram && all_interleaved;
+
+    // A batch=1 with B batched: route to 1D mcast so in0_reuse fires (A stays in L1, B batches loop)
+    if (get_batch_size(a_shape_padded) == 1 && get_batch_size(b_shape_padded) > 1 && all_interleaved) {
+        return get_mcast_1d_config(
+            input_tensor_a,
+            input_tensor_b,
+            transpose_a,
+            transpose_b,
+            bias_single_tile_size,
+            /*fuse_batch=*/false,
+            std::nullopt,
+            /*mcast_in0=*/false,
+            /*out_sharded=*/false,
+            compute_with_storage_grid_size,
+            compute_kernel_config,
+            output_dtype,
+            all_dram_interleaved);
+    }
 
     uint32_t height = a_shape_padded[-2];
     uint32_t width = b_shape_padded[-1];

--- a/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
@@ -452,24 +452,6 @@ MatmulProgramConfig create_matmul_program_config(
     uint32_t k_tiles_per_core;
     if (input_b_is_batched) {
         TT_FATAL(!fused_activation.has_value(), "Cannot use activation with batched input b");
-        // When A batch=1 and B batch>1, route to 1D mcast config so the in0_reuse
-        // optimization fires: A is loaded into L1 once and reused across all B batches.
-        if (batch_size_a == 1 && !a_is_sharded && !input_tensor_b.is_sharded()) {
-            return get_mcast_1d_config(
-                input_tensor_a,
-                input_tensor_b,
-                transpose_a,
-                transpose_b,
-                bias_single_tile_size,
-                /*fuse_batch=*/false,
-                fused_activation,
-                /*mcast_in0=*/false,
-                /*out_sharded=*/false,
-                core_coord,
-                compute_kernel_config,
-                output_dtype,
-                /*all_dram_interleaved=*/false);
-        }
         if (!a_is_sharded && !input_tensor_b.is_sharded()) {
             m_tiles_per_core = div_up(m_size, ttnn::TILE_SIZE);
             n_tiles_per_core = div_up(n_size, ttnn::TILE_SIZE);

--- a/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
@@ -1182,20 +1182,29 @@ MatmulProgramConfig create_simple_matmul_program_config(
             }
         }
 
+        // When A has batch=1 and B has batch>1, in0_reuse keeps A in L1 and iterates over B
+        // batches without re-reading A from DRAM. This requires mcast_in0=false (B broadcasts
+        // spatially, A is locally owned per core). We must prevent mcast_in0=true from being
+        // selected even for wide shapes (N>M) or single-row grids, where it would normally be
+        // the spatial optimum. Forcing mcast_in0=false here trades spatial broadcast efficiency
+        // (B is larger to multicast when N>M) for correctness — mcast_in0=true has no batch
+        // reuse mechanism and would FATAL in the validator.
+        const bool a_batch_broadcast =
+            all_interleaved and get_batch_size(a_shape_padded) == 1 and get_batch_size(b_shape_padded) > 1;
+
         bool use_mcast_1d_in0_config =
-            is_wide or
+            (is_wide and not a_batch_broadcast) or
             (core_range.y == 0 and mem_config.is_sharded() and
              (mem_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED or block_sharded_on_1d_row_grid));
         bool use_mcast_1d_in1_config =
-            is_tall or
-            (all_interleaved and get_batch_size(a_shape_padded) == 1 and get_batch_size(b_shape_padded) > 1) or
+            is_tall or a_batch_broadcast or
             (core_range.y == 0 and mem_config.is_sharded() and
              (mem_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED or block_sharded_on_1d_column_grid));
         bool use_mcast_2d_config =
             all_dram_interleaved or (core_range.y == 0 and mem_config.is_sharded() and
                                      mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED and
                                      not block_sharded_on_1d_column_grid and not block_sharded_on_1d_row_grid);
-        if (core_range.y == 1 or use_mcast_1d_in0_config) {
+        if ((core_range.y == 1 and not a_batch_broadcast) or use_mcast_1d_in0_config) {
             // Pass user's shard_spec when BLOCK_SHARDED on 1D row grid
             std::optional<tt::tt_metal::ShardSpec> user_shard_spec =
                 (block_sharded_on_1d_row_grid && mem_config.shard_spec().has_value())

--- a/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
@@ -1104,24 +1104,6 @@ MatmulProgramConfig create_simple_matmul_program_config(
 
     const bool all_dram_interleaved = all_dram && all_interleaved;
 
-    // A batch=1 with B batched: route to 1D mcast so in0_reuse fires (A stays in L1, B batches loop)
-    if (get_batch_size(a_shape_padded) == 1 && get_batch_size(b_shape_padded) > 1 && all_interleaved) {
-        return get_mcast_1d_config(
-            input_tensor_a,
-            input_tensor_b,
-            transpose_a,
-            transpose_b,
-            bias_single_tile_size,
-            /*fuse_batch=*/false,
-            std::nullopt,
-            /*mcast_in0=*/false,
-            /*out_sharded=*/false,
-            compute_with_storage_grid_size,
-            compute_kernel_config,
-            output_dtype,
-            all_dram_interleaved);
-    }
-
     uint32_t height = a_shape_padded[-2];
     uint32_t width = b_shape_padded[-1];
     const bool is_narrow = is_narrow_shape(height, width, all_dram);
@@ -1206,6 +1188,7 @@ MatmulProgramConfig create_simple_matmul_program_config(
              (mem_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED or block_sharded_on_1d_row_grid));
         bool use_mcast_1d_in1_config =
             is_tall or
+            (all_interleaved and get_batch_size(a_shape_padded) == 1 and get_batch_size(b_shape_padded) > 1) or
             (core_range.y == 0 and mem_config.is_sharded() and
              (mem_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED or block_sharded_on_1d_column_grid));
         bool use_mcast_2d_config =

--- a/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
@@ -1182,13 +1182,8 @@ MatmulProgramConfig create_simple_matmul_program_config(
             }
         }
 
-        // When A has batch=1 and B has batch>1, in0_reuse keeps A in L1 and iterates over B
-        // batches without re-reading A from DRAM. This requires mcast_in0=false (B broadcasts
-        // spatially, A is locally owned per core). We must prevent mcast_in0=true from being
-        // selected even for wide shapes (N>M) or single-row grids, where it would normally be
-        // the spatial optimum. Forcing mcast_in0=false here trades spatial broadcast efficiency
-        // (B is larger to multicast when N>M) for correctness — mcast_in0=true has no batch
-        // reuse mechanism and would FATAL in the validator.
+        // A batch=1, B batch>1: force mcast_in0=false so in0_reuse can keep A in L1 across all
+        // B batches. mcast_in0=true has no batch-reuse path and would FATAL in the validator.
         const bool a_batch_broadcast =
             all_interleaved and get_batch_size(a_shape_padded) == 1 and get_batch_size(b_shape_padded) > 1;
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -907,10 +907,10 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
             if (config.fuse_batch || config.fused_activation.has_value() || config.mcast_in0) {
                 return false;
             }
-            if (a_shape.rank() != 4 || b_shape.rank() != 4) {
+            if (a_shape.rank() != b_shape.rank() || a_shape.rank() < 3) {
                 return false;
             }
-            if (a_shape[1] != 1) {
+            if (a_shape[static_cast<int>(a_shape.rank()) - 3] != 1) {
                 return false;
             }
             if (input_tensor_a.is_sharded() || input_tensor_b.is_sharded()) {
@@ -921,11 +921,11 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
 
         for (auto i = 0; i < a_shape.rank() - 2; i++) {
             TT_FATAL(
-                a_shape[i] == b_shape[i] || (i == 1 && in0_reuse()),
+                a_shape[i] == b_shape[i] || (i == static_cast<int>(a_shape.rank()) - 3 && in0_reuse()),
                 "bmm (non-bcast matmul) expects input tensors of shapes "
-                "BCMK*BCKN=BCMN or batch dimension {} mismatch: a={} vs b={} (dimension mismatch only allowed on dim 1 "
-                "for rank-4 tensors when a[1]=1 and using MatmulMultiCoreReuseMultiCast1DProgramConfig with "
-                "fuse_batch=false, fused_activation=none, mcast_in0=false, and non-sharded inputs for in0 reuse "
+                "BCMK*BCKN=BCMN or batch dimension {} mismatch: a={} vs b={} (dimension mismatch only allowed on "
+                "the broadcast batch dim when a[batch_dim]=1 and using MatmulMultiCoreReuseMultiCast1DProgramConfig "
+                "with fuse_batch=false, fused_activation=none, mcast_in0=false, and non-sharded inputs for in0 reuse "
                 "optimization)",
                 i,
                 a_shape[i],

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -907,10 +907,10 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
             if (config.fuse_batch || config.fused_activation.has_value() || config.mcast_in0) {
                 return false;
             }
-            if (a_shape.rank() != b_shape.rank() || a_shape.rank() < 3) {
+            if (a_shape.rank() != 4 || b_shape.rank() != 4) {
                 return false;
             }
-            if (a_shape[static_cast<int>(a_shape.rank()) - 3] != 1) {
+            if (a_shape[1] != 1) {
                 return false;
             }
             if (input_tensor_a.is_sharded() || input_tensor_b.is_sharded()) {
@@ -921,11 +921,11 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
 
         for (auto i = 0; i < a_shape.rank() - 2; i++) {
             TT_FATAL(
-                a_shape[i] == b_shape[i] || (i == static_cast<int>(a_shape.rank()) - 3 && in0_reuse()),
+                a_shape[i] == b_shape[i] || (i == 1 && in0_reuse()),
                 "bmm (non-bcast matmul) expects input tensors of shapes "
-                "BCMK*BCKN=BCMN or batch dimension {} mismatch: a={} vs b={} (dimension mismatch only allowed on "
-                "the broadcast batch dim when a[batch_dim]=1 and using MatmulMultiCoreReuseMultiCast1DProgramConfig "
-                "with fuse_batch=false, fused_activation=none, mcast_in0=false, and non-sharded inputs for in0 reuse "
+                "BCMK*BCKN=BCMN or batch dimension {} mismatch: a={} vs b={} (dimension mismatch only allowed on dim 1 "
+                "for rank-4 tensors when a[1]=1 and using MatmulMultiCoreReuseMultiCast1DProgramConfig with "
+                "fuse_batch=false, fused_activation=none, mcast_in0=false, and non-sharded inputs for in0 reuse "
                 "optimization)",
                 i,
                 a_shape[i],

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -894,8 +894,8 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
         // Check if in0 reuse optimization can be applied
         // This optimization keeps input A (batch=1) in L1 and reuses it across all input B batches
         // 1. Program config requirements: must use 1D mcast with specific settings
-        // 2. Shape requirements: must be rank-4 tensors (to ensure dim 1 is the batch dimension)
-        // 3. Batch dimension requirement: input A must have batch size 1 on dim 1
+        // 2. Shape requirements: must be rank >= 3 (to have at least one batch dimension)
+        // 3. Batch dimension requirement: all batch dimensions of input A must be size 1
         // 4. Memory layout requirement: inputs must not be sharded
         auto in0_reuse = [&]() {
             if (!std::holds_alternative<operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(
@@ -907,11 +907,13 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
             if (config.fuse_batch || config.fused_activation.has_value() || config.mcast_in0) {
                 return false;
             }
-            if (a_shape.rank() != 4 || b_shape.rank() != 4) {
+            if (a_shape.rank() < 3 || b_shape.rank() < 3) {
                 return false;
             }
-            if (a_shape[1] != 1) {
-                return false;
+            for (auto j = 0; j < static_cast<int>(a_shape.rank()) - 2; j++) {
+                if (a_shape[j] != 1) {
+                    return false;
+                }
             }
             if (input_tensor_a.is_sharded() || input_tensor_b.is_sharded()) {
                 return false;
@@ -921,12 +923,12 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
 
         for (auto i = 0; i < a_shape.rank() - 2; i++) {
             TT_FATAL(
-                a_shape[i] == b_shape[i] || (i == 1 && in0_reuse()),
+                a_shape[i] == b_shape[i] || (a_shape[i] == 1 && in0_reuse()),
                 "bmm (non-bcast matmul) expects input tensors of shapes "
-                "BCMK*BCKN=BCMN or batch dimension {} mismatch: a={} vs b={} (dimension mismatch only allowed on dim 1 "
-                "for rank-4 tensors when a[1]=1 and using MatmulMultiCoreReuseMultiCast1DProgramConfig with "
-                "fuse_batch=false, fused_activation=none, mcast_in0=false, and non-sharded inputs for in0 reuse "
-                "optimization)",
+                "BCMK*BCKN=BCMN or batch dimension {} mismatch: a={} vs b={} (dimension mismatch only allowed "
+                "when all batch dimensions of a are size 1 and using MatmulMultiCoreReuseMultiCast1DProgramConfig "
+                "with fuse_batch=false, fused_activation=none, mcast_in0=false, and non-sharded inputs for in0 "
+                "reuse optimization)",
                 i,
                 a_shape[i],
                 b_shape[i]);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -915,10 +915,7 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
                     return false;
                 }
             }
-            if (input_tensor_a.is_sharded() || input_tensor_b.is_sharded()) {
-                return false;
-            }
-            return true;
+            return !input_tensor_a.is_sharded() && !input_tensor_b.is_sharded();
         };
 
         for (auto i = 0; i < a_shape.rank() - 2; i++) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
@@ -162,13 +162,16 @@ ttnn::Shape compute_matmul_output_shape(
         output_shape = ttnn::Shape(new_shape);
     }
 
-    // Optimization: Reuse input A (in0) across batches when A's batch dimension is 1
-    // and B's batch dimension is > 1. For matmul shapes BxHaxMxK / BxHbxKxN where Ha=1 and Hb>1,
-    // the same A tensor can be reused for each batch element of B rather than reading A repeatedly.
-    // Restrict to rank-4 tensors to ensure dim 1 is correctly identified as the batch dimension
-    // and to prevent out-of-bounds indexing with lower-rank shapes.
-    if (a_rank == 4 && b_rank == 4 && input_shape_a[1] == 1 && input_shape_b[1] > 1) {
-        output_shape[1] = input_shape_b[1];
+    // Optimization: Reuse input A (in0) across batches when A's batch dimensions are all 1
+    // and B's corresponding batch dimensions are > 1. The same A tensor is reused for each
+    // batch element of B rather than reading A repeatedly. Supported for rank >= 3 tensors
+    // with matching ranks and interleaved (non-sharded) memory layout.
+    if (a_rank >= 3 && b_rank == a_rank) {
+        for (int i = 0; i < static_cast<int>(a_rank) - 2; i++) {
+            if (input_shape_a[i] == 1 && input_shape_b[i] > 1) {
+                output_shape[i] = input_shape_b[i];
+            }
+        }
     }
     return output_shape;
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
@@ -163,12 +163,13 @@ ttnn::Shape compute_matmul_output_shape(
     }
 
     // Optimization: Reuse input A (in0) across batches when A's batch dimension is 1
-    // and B's batch dimension is > 1. For matmul shapes BxHaxMxK / BxHbxKxN where Ha=1 and Hb>1,
-    // the same A tensor can be reused for each batch element of B rather than reading A repeatedly.
-    // Restrict to rank-4 tensors to ensure dim 1 is correctly identified as the batch dimension
-    // and to prevent out-of-bounds indexing with lower-rank shapes.
-    if (a_rank == 4 && b_rank == 4 && input_shape_a[1] == 1 && input_shape_b[1] > 1) {
-        output_shape[1] = input_shape_b[1];
+    // and B's batch dimension is > 1. The "broadcast batch dim" is the last dim before [M,K]:
+    // rank-3 → dim[0], rank-4 → dim[1], etc. (index = rank - 3).
+    if (a_rank >= 3 && b_rank == a_rank) {
+        const int batch_dim = static_cast<int>(a_rank) - 3;
+        if (input_shape_a[batch_dim] == 1 && input_shape_b[batch_dim] > 1) {
+            output_shape[batch_dim] = input_shape_b[batch_dim];
+        }
     }
     return output_shape;
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
@@ -163,13 +163,12 @@ ttnn::Shape compute_matmul_output_shape(
     }
 
     // Optimization: Reuse input A (in0) across batches when A's batch dimension is 1
-    // and B's batch dimension is > 1. The "broadcast batch dim" is the last dim before [M,K]:
-    // rank-3 → dim[0], rank-4 → dim[1], etc. (index = rank - 3).
-    if (a_rank >= 3 && b_rank == a_rank) {
-        const int batch_dim = static_cast<int>(a_rank) - 3;
-        if (input_shape_a[batch_dim] == 1 && input_shape_b[batch_dim] > 1) {
-            output_shape[batch_dim] = input_shape_b[batch_dim];
-        }
+    // and B's batch dimension is > 1. For matmul shapes BxHaxMxK / BxHbxKxN where Ha=1 and Hb>1,
+    // the same A tensor can be reused for each batch element of B rather than reading A repeatedly.
+    // Restrict to rank-4 tensors to ensure dim 1 is correctly identified as the batch dimension
+    // and to prevent out-of-bounds indexing with lower-rank shapes.
+    if (a_rank == 4 && b_rank == 4 && input_shape_a[1] == 1 && input_shape_b[1] > 1) {
+        output_shape[1] = input_shape_b[1];
     }
     return output_shape;
 }

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
@@ -673,9 +673,11 @@ void py_module(nb::module_& mod) {
           then the second input is broadcasted to align appropriately with the first
           input.
 
-        - Matrix multiplication will not work if the first input has batch
-          dimensions that are all of size 1 and the second input has batch dimensions
-          that are not all of size 1.
+        - If the first input has batch dimensions that are all of size 1 and the
+          second input has batch dimensions that are not all of size 1, the first
+          input is reused across all batches of the second input. Both inputs must
+          be rank 3 or higher with matching ranks, interleaved (L1 or DRAM), and
+          non-sharded.
 
         - Note: In general, the number of dimensions between the two inputs should
           match. There may be cases where they don't. In that case, if the inputs


### PR DESCRIPTION
## Summary

-Resolves: #12834 

This PR fixes `ttnn.matmul` for the case where `A` has batch size `1` and `B` has batch size `>1`

## Problem Description

`ttnn.matmul` failed for shapes like `A(1,128,2048) x B(7,2048,256)` with:

`bmm (non-bcast matmul) expects input tensors of shapes BCMK*BCKN=BCMN`

Root causes:
- Routing selected a config that cannot handle `A batch=1` reuse when `B` is batched.
- Validator rejected valid `A batch dim = 1` / `B batch dim > 1` combinations.
- Output shape logic did not broadcast `A` batch dims to match `B`.

## What's Changed

- `ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp`
  - Added `a_batch_broadcast` routing guard.
  - For `A batch=1, B batch>1`, forces `mcast_in0=false` path (in0 reuse-capable path).

- `ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp`
  - Extended batch validation to allow `a_shape[i] == 1` under in0-reuse constraints.
  - Supports rank `>=3` batch-dim handling (not only rank-4).

- `ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp`
  - Updated output shape logic to broadcast `A` batch dims to `B` where applicable.

- `ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp`
  - Updated `matmul` docstring to reflect supported `A batch=1, B batch>1` behavior and constraints.

- `tests/ttnn/unit_tests/operations/matmul/test_matmul_batch_mismatch.py`
  - Added/extended positive cases across rank-3 and rank-4 shapes.

## Test Plan

- `pytest tests/ttnn/unit_tests/operations/matmul/test_matmul_batch_mismatch.py`
- Result: `All passed`


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/fix-matmul-batch-broadcast-12834)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/fix-matmul-batch-broadcast-12834)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/fix-matmul-batch-broadcast-12834)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/fix-matmul-batch-broadcast-12834)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/fix-matmul-batch-broadcast-12834)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/fix-matmul-batch-broadcast-12834)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/fix-matmul-batch-broadcast-12834)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/fix-matmul-batch-broadcast-12834)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/fix-matmul-batch-broadcast-12834)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/fix-matmul-batch-broadcast-12834)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/fix-matmul-batch-broadcast-12834)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/fix-matmul-batch-broadcast-12834)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/fix-matmul-batch-broadcast-12834)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/fix-matmul-batch-broadcast-12834)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/fix-matmul-batch-broadcast-12834)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/fix-matmul-batch-broadcast-12834)