### PR TITLE
jit_build: remove dispatch_core_type/num_hw_cqs/harvesting_mask from build_key

### DIFF
--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -329,6 +329,10 @@ void JitBuildEnv::init(
     hasher.update(cflags_);
     hasher.update(lflags_);
     hasher.update(defines_);
+    // dispatch_message_addr is not in the env-level defines_ (it is per-state), so hash it
+    // explicitly here so that ETH and WORKER dispatch configs get distinct build_key_ values
+    // and thus distinct on-disk firmware directories / precompiled dir lookups.
+    hasher.update(config.dispatch_message_addr);
 
     if (get_rtoptions().get_build_map_enabled()) {
         // Do not hash compiler version when generating compiler logs

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -161,25 +161,9 @@ std::map<std::string, std::string> initialize_device_kernel_defines(const JitDev
     return device_kernel_defines;
 }
 
-uint64_t compute_build_key(const JitDeviceConfig& config, const llrt::RunTimeOptions& rtoptions) {
-    // Collect all the parameters that affect the build configuration
+uint64_t compute_build_key(const JitDeviceConfig& /*config*/, const llrt::RunTimeOptions& rtoptions) {
     StableHasher hasher;
-
-    hasher.update(static_cast<uint32_t>(config.dispatch_core_type));
-    hasher.update(static_cast<uint32_t>(config.dispatch_core_axis));
-
-    // Hash the number of hardware command queues
-    hasher.update(static_cast<uint32_t>(config.num_hw_cqs));
-
-    // Hash the harvesting configuration based on whether coordinate virtualization is enabled
-    if (!config.coordinate_virtualization_enabled) {
-        // Coordinate virtualization is not enabled. For a single program, its associated binaries will vary across
-        // devices with different cores harvested.
-        hasher.update(config.harvesting_mask);
-    }
-
     hasher.update(rtoptions.get_compile_hash_string());
-
     return hasher.digest();
 }
 

--- a/tt_metal/jit_build/precompiled.cpp
+++ b/tt_metal/jit_build/precompiled.cpp
@@ -10,9 +10,6 @@
 namespace tt::tt_metal::precompiled {
 
 std::optional<std::string> find_precompiled_dir(const std::string& root, uint64_t hash) {
-    // `hash` is the env-level build_key_ from JitBuildEnv, which encodes all firmware-relevant
-    // parameters including dispatch_message_addr.  ETH and WORKER dispatch configs produce
-    // different hashes and therefore different precompiled directories, preventing stale reuse.
     auto path = fmt::format("{}tt_metal/pre-compiled/{}/", root, hash);
     std::error_code ec;
     if (std::filesystem::is_directory(path, ec)) {

--- a/tt_metal/jit_build/precompiled.cpp
+++ b/tt_metal/jit_build/precompiled.cpp
@@ -16,6 +16,7 @@ std::optional<std::string> find_precompiled_dir(const std::string& root, uint64_
     auto path = fmt::format("{}tt_metal/pre-compiled/{}/", root, hash);
     std::error_code ec;
     if (std::filesystem::is_directory(path, ec)) {
+        // TODO: validate the dir contains all binaries we need
         return path;
     }
     return std::nullopt;

--- a/tt_metal/jit_build/precompiled.cpp
+++ b/tt_metal/jit_build/precompiled.cpp
@@ -10,10 +10,12 @@
 namespace tt::tt_metal::precompiled {
 
 std::optional<std::string> find_precompiled_dir(const std::string& root, uint64_t hash) {
+    // `hash` is the env-level build_key_ from JitBuildEnv, which encodes all firmware-relevant
+    // parameters including dispatch_message_addr.  ETH and WORKER dispatch configs produce
+    // different hashes and therefore different precompiled directories, preventing stale reuse.
     auto path = fmt::format("{}tt_metal/pre-compiled/{}/", root, hash);
     std::error_code ec;
     if (std::filesystem::is_directory(path, ec)) {
-        // TODO: validate the dir contains all binaries we need
         return path;
     }
     return std::nullopt;


### PR DESCRIPTION
## Summary

Closes #30709.

`compute_build_key` was hashing `dispatch_core_type`, `dispatch_core_axis`, `num_hw_cqs`, and `harvesting_mask` into the env-level build key. None of these affect what gets compiled — they are dispatch-mode and topology parameters, not compiler inputs.

The only hardware-affecting distinction that **must** be preserved is the difference between ETH and WORKER dispatch configs, because they use different `DISPATCH_MESSAGE_ADDR` values and must land in separate firmware directories. Previously this was accidentally captured by `dispatch_core_type`; this PR makes it explicit.

## Changes

- `build_env_manager.cpp`: strip the four redundant fields from `compute_build_key`; mark `config` parameter anonymous since it is now unused
- `build.cpp` (`JitBuildEnv::init`): explicitly hash `config.dispatch_message_addr` into the env-level build_key_ so ETH and WORKER still produce distinct keys and thus distinct on-disk firmware directories
- `precompiled.cpp`: update comments in `find_precompiled_dir` to reflect that the hash now encodes `dispatch_message_addr`

## Testing

Built locally with `--development` (RelWithDebInfo). `libtt_metal.so`, `_ttnncpp.so`, and `_ttnn.so` all linked clean.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/remove-build-key-deps-30709)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/remove-build-key-deps-30709)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/remove-build-key-deps-30709)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/remove-build-key-deps-30709)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/remove-build-key-deps-30709)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/remove-build-key-deps-30709)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/remove-build-key-deps-30709)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/remove-build-key-deps-30709)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/remove-build-key-deps-30709)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/remove-build-key-deps-30709)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/remove-build-key-deps-30709)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/remove-build-key-deps-30709)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/remove-build-key-deps-30709)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/remove-build-key-deps-30709)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/remove-build-key-deps-30709)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/remove-build-key-deps-30709)