### PR TITLE
[indexer_score] Add persistent KV-cache features (indexed cache + runtime kv_len)

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -228,6 +228,238 @@ def test_indexer_score_shapes(device, heads, dim, sq, t, chunk_start, q_chunk, k
     _run_and_check(device, heads, dim, sq, t, chunk_start, q_chunk, k_chunk, head_group)
 
 
+# Indexed KV cache: k is a shared [B, 1, T, D] cache and cache_batch_idx selects the batch slot to score.
+# The slot is excluded from the program hash, so switching slots reuses one cached program (no recompile);
+# k may also be ND-sharded across DRAM banks; invalid inputs the hash does not pin are re-checked on a warm
+# cache (validate_on_program_cache_hit).
+IDX_CACHE = dict(heads=64, dim=128, sq=64, t=256, chunk_start=128)  # small all-resident shape, B slots
+
+
+def _indexed_inputs(num_slots, seed=11):
+    """q [1,Hi,Sq,D], a shared k cache [B,1,T,D], weights [1,Hi,Sq,1], all bf16. Slots differ so a
+    wrong-slot read would change the scores (and fail the per-slot reference)."""
+    c = IDX_CACHE
+    g = torch.Generator().manual_seed(seed)
+    q = torch.randn(1, c["heads"], c["sq"], c["dim"], generator=g, dtype=torch.bfloat16)
+    w = torch.randn(1, c["heads"], c["sq"], 1, generator=g, dtype=torch.bfloat16)
+    k_cache = torch.randn(num_slots, 1, c["t"], c["dim"], generator=g, dtype=torch.bfloat16)
+    return q, w, k_cache
+
+
+def _check_slot(out, q, k_cache, w, b):
+    """Compare a slot's device output against the reference computed on that [1,1,T,D] slice."""
+    c = IDX_CACHE
+    ref = indexer_score_ref(q, k_cache[b : b + 1], w, c["chunk_start"])
+    assert_indexer_match(out, ref, c["sq"], c["t"], check_neg=True)
+
+
+def _nd_sharded_dram_config(device, rows_per_shard):
+    """ND-shard a [.., T, D] cache across DRAM banks: each [1, 1, rows_per_shard, D] block is one shard,
+    round-robin over the banks."""
+    dim = IDX_CACHE["dim"]
+    num_banks = device.dram_grid_size().x
+    cores = [ttnn.CoreRange(ttnn.CoreCoord(b, 0), ttnn.CoreCoord(b, 0)) for b in range(num_banks)]
+    spec = ttnn.NdShardSpec(
+        shard_shape=[1, 1, rows_per_shard, dim],
+        grid=ttnn.CoreRangeSet(cores),
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        shard_distribution_strategy=ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
+    )
+    return ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM, nd_shard_spec=spec)
+
+
+def test_indexer_score_indexed_cache(device):
+    """cache_batch_idx selects a slot of a shared [B,1,T,D] cache; every slot scores correctly AND
+    switching slots on the same cache tensor does not recompile (the slot is excluded from the hash)."""
+    c = IDX_CACHE
+    B = 3
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=32, head_group_size=0)
+    q, w, k_cache = _indexed_inputs(B)
+    q_dev, w_dev = to_device(q, device), to_device(w, device)
+    k_dev = to_device(k_cache, device)  # tiled [B,1,T,D], DRAM interleaved
+
+    def run(b):
+        return ttnn.to_torch(
+            ttnn.experimental.indexer_score(
+                q_dev, k_dev, w_dev, chunk_start_idx=c["chunk_start"], program_config=cfg, cache_batch_idx=b
+            )
+        )
+
+    _check_slot(run(0), q, k_cache, w, 0)
+    entries_after_first = device.num_program_cache_entries()  # one program now cached for this shape/cfg
+    for b in range(1, B):
+        _check_slot(run(b), q, k_cache, w, b)
+    # Switching the indexed slot must NOT add a program (cache_batch_idx is a runtime arg, not in the hash).
+    assert device.num_program_cache_entries() == entries_after_first, "switching cache_batch_idx recompiled"
+
+
+def test_indexer_score_indexed_cache_nd_sharded_k(device):
+    """The indexed k cache may be ND-sharded across DRAM banks (each [1,1,T,D] slot is one shard); the
+    reader resolves it through a TensorAccessor, so every slot still scores correctly."""
+    c = IDX_CACHE
+    B = 2
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=32, head_group_size=0)
+    q, w, k_cache = _indexed_inputs(B)
+    q_dev, w_dev = to_device(q, device), to_device(w, device)
+    k_mem = _nd_sharded_dram_config(device, rows_per_shard=c["t"])  # each [1,1,T,D] slot is one shard
+    k_dev = ttnn.from_torch(k_cache, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=k_mem)
+    assert k_dev.memory_config().is_sharded()
+
+    for b in range(B):
+        out = ttnn.to_torch(
+            ttnn.experimental.indexer_score(
+                q_dev, k_dev, w_dev, chunk_start_idx=c["chunk_start"], program_config=cfg, cache_batch_idx=b
+            )
+        )
+        _check_slot(out, q, k_cache, w, b)
+
+
+def test_indexer_score_indexed_cache_rejects_oob(device):
+    """An out-of-range cache_batch_idx (>= B) is rejected -- including on a warm program cache, since the
+    slot is re-validated on a cache hit (validate_on_program_cache_hit), not only at miss time."""
+    c = IDX_CACHE
+    B = 2
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=32, head_group_size=0)
+    q, w, k_cache = _indexed_inputs(B)
+    q_dev, w_dev = to_device(q, device), to_device(w, device)
+    k_dev = to_device(k_cache, device)
+
+    # Warm the program cache with a valid slot; an OOB slot then hits the SAME program (same hash) and must
+    # still be rejected by the cache-hit validation.
+    ttnn.experimental.indexer_score(
+        q_dev, k_dev, w_dev, chunk_start_idx=c["chunk_start"], program_config=cfg, cache_batch_idx=0
+    )
+    with pytest.raises(RuntimeError, match="cache_batch_idx"):
+        ttnn.experimental.indexer_score(
+            q_dev, k_dev, w_dev, chunk_start_idx=c["chunk_start"], program_config=cfg, cache_batch_idx=B
+        )
+
+
+def test_indexer_score_indexed_cache_requires_idx_for_multislot(device):
+    """A multi-slot [B,1,T,D] k cache with NO cache_batch_idx is ambiguous (which slot?) and must be
+    rejected -- the non-indexed batch guard in validate_non_hashed. Pairs with the OOB-slot rejection to
+    cover the indexed-cache batch invariants the program hash does not pin."""
+    c = IDX_CACHE
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=32, head_group_size=0)
+    q, w, k_cache = _indexed_inputs(2)  # B=2 slots, but no cache_batch_idx supplied below
+    q_dev, w_dev, k_dev = to_device(q, device), to_device(w, device), to_device(k_cache, device)
+    with pytest.raises(RuntimeError, match="batch must be 1"):
+        ttnn.experimental.indexer_score(q_dev, k_dev, w_dev, chunk_start_idx=c["chunk_start"], program_config=cfg)
+
+
+def test_indexer_score_rejects_sharded_q(device):
+    """Only k may be sharded; q (and weights) must stay interleaved. A sharded q is refused by the input
+    validation (validate_non_hashed)."""
+    c = IDX_CACHE
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=32, head_group_size=0)
+    q, w, k_cache = _indexed_inputs(1)
+    q_mem = _nd_sharded_dram_config(device, rows_per_shard=32)  # shard q -> must be rejected (q stays interleaved)
+    q_dev = ttnn.from_torch(q, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=q_mem)
+    w_dev, k_dev = to_device(w, device), to_device(k_cache, device)
+    with pytest.raises(RuntimeError, match="interleaved"):
+        ttnn.experimental.indexer_score(q_dev, k_dev, w_dev, chunk_start_idx=c["chunk_start"], program_config=cfg)
+
+
+def test_indexer_score_nd_sharded_k_multi_T(device):
+    """ND-sharded k at two cache lengths with one FIXED shard shape. indexer_score scores all T keys, so T
+    is always hashed -- both T values build their own program -- but each must still read the sharded banks
+    correctly."""
+    c = IDX_CACHE
+    heads, dim, sq, chunk_start = c["heads"], c["dim"], c["sq"], c["chunk_start"]
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=32, head_group_size=0)
+    k_mem = _nd_sharded_dram_config(device, rows_per_shard=128)  # fixed shard shape, independent of T
+    device.clear_program_cache()
+    for t in (256, 512):  # multiples of 128: same shard spec, different T (different shard count)
+        q, k, w = make_inputs(heads, dim, sq, t)
+        q_dev, w_dev = to_device(q, device), to_device(w, device)
+        k_dev = ttnn.from_torch(k, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=k_mem)
+        out = ttnn.to_torch(
+            ttnn.experimental.indexer_score(q_dev, k_dev, w_dev, chunk_start_idx=chunk_start, program_config=cfg)
+        )
+        assert_indexer_match(out, indexer_score_ref(q, k, w, chunk_start), sq, t, check_neg=True)
+    assert device.num_program_cache_entries() == 2, "two distinct T must build two programs (T is hashed)"
+
+
+# Runtime KV length / oversized persistent cache: k is allocated at its full T (the persistent buffer,
+# which stays hashed -- it pins the grid/work-split) and kv_len selects the valid key prefix this dispatch.
+# kv_len is excluded from the program hash, so a serving loop growing kv_len (<= T) reuses one program -- no
+# recompile. Only output columns [0, kv_len) are written; the stale tail is sliced off.
+KV_LEN = dict(heads=64, dim=128, sq=64, t=512, chunk_start=0)  # oversized T=512 buffer, Sq=2 tiles
+
+
+def _kv_len_inputs(seed=23):
+    """q [1,Hi,Sq,D], an oversized k buffer [1,1,T,D], weights [1,Hi,Sq,1], all bf16."""
+    c = KV_LEN
+    g = torch.Generator().manual_seed(seed)
+    q = torch.randn(1, c["heads"], c["sq"], c["dim"], generator=g, dtype=torch.bfloat16)
+    w = torch.randn(1, c["heads"], c["sq"], 1, generator=g, dtype=torch.bfloat16)
+    k = torch.randn(1, 1, c["t"], c["dim"], generator=g, dtype=torch.bfloat16)
+    return q, w, k
+
+
+def _check_kv_len(out, q, k, w, kv_len):
+    """Only columns [0, kv_len) are valid; compare them to the reference on the first kv_len keys (the rest
+    of the [1,1,Sq,T] output is the stale tail and is sliced off)."""
+    c = KV_LEN
+    assert out.shape == (1, 1, c["sq"], c["t"])
+    ref = indexer_score_ref(q, k[:, :, :kv_len, :], w, c["chunk_start"])  # [1,1,Sq,kv_len]
+    assert_indexer_match(out[:, :, :, :kv_len], ref, c["sq"], kv_len, check_neg=True)
+
+
+@pytest.mark.parametrize(
+    "q_chunk, k_chunk, head_group",
+    [
+        (32, 32, 0),  # all heads resident, single-tile k chunks (the full-strip path)
+        (32, 32, 8),  # head streaming in groups of 8 (the per-column accumulate_row_streaming path)
+        (32, 128, 0),  # KC=4 chunked k: kv_len can land mid-chunk and zero whole trailing chunks
+        (64, 32, 16),  # QC=2 multi-row group, HB=16 of 64 resident
+    ],
+    ids=["resident", "stream", "chunked_k", "qc2"],
+)
+def test_indexer_score_runtime_kv_len(device, q_chunk, k_chunk, head_group):
+    """One oversized k buffer (T=512) scored at several kv_len <= T: each writes only [0, kv_len) and
+    matches the reference on the first kv_len keys, and growing kv_len on the SAME buffer does NOT recompile
+    (kv_len is a runtime arg excluded from the hash). This is the persistent-cache serving loop, swept over
+    the kernel paths (resident / head-streaming / chunked-k / multi-row group)."""
+    c = KV_LEN
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=q_chunk, k_chunk_size=k_chunk, head_group_size=head_group)
+    q, w, k = _kv_len_inputs()
+    q_dev, w_dev, k_dev = to_device(q, device), to_device(w, device), to_device(k, device)
+
+    def run(kv_len):
+        return ttnn.to_torch(
+            ttnn.experimental.indexer_score(
+                q_dev, k_dev, w_dev, chunk_start_idx=c["chunk_start"], program_config=cfg, kv_len=kv_len
+            )
+        )
+
+    _check_kv_len(run(64), q, k, w, 64)  # only the first 2 k-tiles valid; most work units are fully past kv_len
+    entries_after_first = device.num_program_cache_entries()
+    for kv_len in (128, 256, 512):  # grow the valid prefix within the same T=512 buffer
+        _check_kv_len(run(kv_len), q, k, w, kv_len)
+    assert device.num_program_cache_entries() == entries_after_first, "changing kv_len recompiled"
+
+
+def test_indexer_score_rejects_bad_kv_len(device):
+    """kv_len must be tile-aligned, within (0, T], and leave room for the causal window
+    (chunk_start + Sq <= kv_len). Each violation is rejected -- on a WARM cache too, since kv_len is excluded
+    from the hash and re-validated on a program-cache hit (validate_on_program_cache_hit)."""
+    c = KV_LEN
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=32, head_group_size=0)
+    q, w, k = _kv_len_inputs()
+    q_dev, w_dev, k_dev = to_device(q, device), to_device(w, device), to_device(k, device)
+
+    # Warm the program cache with a valid kv_len; each bad one then hits the SAME program and must still fail.
+    ttnn.experimental.indexer_score(
+        q_dev, k_dev, w_dev, chunk_start_idx=c["chunk_start"], program_config=cfg, kv_len=128
+    )
+    for bad, why in [(c["t"] + 32, "above T"), (100, "not tile-aligned"), (32, "causal window > kv_len")]:
+        with pytest.raises(RuntimeError, match="kv_len"):
+            ttnn.experimental.indexer_score(
+                q_dev, k_dev, w_dev, chunk_start_idx=c["chunk_start"], program_config=cfg, kv_len=bad
+            )
+
+
 @pytest.mark.parametrize("case_id, heads", GLX_CASES, ids=GLX_IDS)
 def test_indexer_score_determinism(device, case_id, heads):
     """Determinism on the production deployments (GLM5.1 8h, DSv32 16h, GLX chunked-prefill knobs at

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -314,7 +314,7 @@ def test_indexer_score_indexed_cache_nd_sharded_k(device):
         _check_slot(out, q, k_cache, w, b)
 
 
-def test_indexer_score_indexed_cache_rejects_oob(device):
+def test_indexer_score_indexed_cache_rejects_oob(device, expect_error):
     """An out-of-range cache_batch_idx (>= B) is rejected -- including on a warm program cache, since the
     slot is re-validated on a cache hit (validate_on_program_cache_hit), not only at miss time."""
     c = IDX_CACHE
@@ -329,13 +329,13 @@ def test_indexer_score_indexed_cache_rejects_oob(device):
     ttnn.experimental.indexer_score(
         q_dev, k_dev, w_dev, chunk_start_idx=c["chunk_start"], program_config=cfg, cache_batch_idx=0
     )
-    with pytest.raises(RuntimeError, match="cache_batch_idx"):
+    with expect_error(RuntimeError, "cache_batch_idx"):
         ttnn.experimental.indexer_score(
             q_dev, k_dev, w_dev, chunk_start_idx=c["chunk_start"], program_config=cfg, cache_batch_idx=B
         )
 
 
-def test_indexer_score_indexed_cache_requires_idx_for_multislot(device):
+def test_indexer_score_indexed_cache_requires_idx_for_multislot(device, expect_error):
     """A multi-slot [B,1,T,D] k cache with NO cache_batch_idx is ambiguous (which slot?) and must be
     rejected -- the non-indexed batch guard in validate_non_hashed. Pairs with the OOB-slot rejection to
     cover the indexed-cache batch invariants the program hash does not pin."""
@@ -343,11 +343,11 @@ def test_indexer_score_indexed_cache_requires_idx_for_multislot(device):
     cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=32, head_group_size=0)
     q, w, k_cache = _indexed_inputs(2)  # B=2 slots, but no cache_batch_idx supplied below
     q_dev, w_dev, k_dev = to_device(q, device), to_device(w, device), to_device(k_cache, device)
-    with pytest.raises(RuntimeError, match="batch must be 1"):
+    with expect_error(RuntimeError, "batch must be 1"):
         ttnn.experimental.indexer_score(q_dev, k_dev, w_dev, chunk_start_idx=c["chunk_start"], program_config=cfg)
 
 
-def test_indexer_score_rejects_sharded_q(device):
+def test_indexer_score_rejects_sharded_q(device, expect_error):
     """Only k may be sharded; q (and weights) must stay interleaved. A sharded q is refused by the input
     validation (validate_non_hashed)."""
     c = IDX_CACHE
@@ -356,7 +356,7 @@ def test_indexer_score_rejects_sharded_q(device):
     q_mem = _nd_sharded_dram_config(device, rows_per_shard=32)  # shard q -> must be rejected (q stays interleaved)
     q_dev = ttnn.from_torch(q, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=q_mem)
     w_dev, k_dev = to_device(w, device), to_device(k_cache, device)
-    with pytest.raises(RuntimeError, match="interleaved"):
+    with expect_error(RuntimeError, "interleaved"):
         ttnn.experimental.indexer_score(q_dev, k_dev, w_dev, chunk_start_idx=c["chunk_start"], program_config=cfg)
 
 
@@ -440,7 +440,7 @@ def test_indexer_score_runtime_kv_len(device, q_chunk, k_chunk, head_group):
     assert device.num_program_cache_entries() == entries_after_first, "changing kv_len recompiled"
 
 
-def test_indexer_score_rejects_bad_kv_len(device):
+def test_indexer_score_rejects_bad_kv_len(device, expect_error):
     """kv_len must be tile-aligned, within (0, T], and leave room for the causal window
     (chunk_start + Sq <= kv_len). Each violation is rejected -- on a WARM cache too, since kv_len is excluded
     from the hash and re-validated on a program-cache hit (validate_on_program_cache_hit)."""
@@ -454,7 +454,7 @@ def test_indexer_score_rejects_bad_kv_len(device):
         q_dev, k_dev, w_dev, chunk_start_idx=c["chunk_start"], program_config=cfg, kv_len=128
     )
     for bad, why in [(c["t"] + 32, "above T"), (100, "not tile-aligned"), (32, "causal window > kv_len")]:
-        with pytest.raises(RuntimeError, match="kv_len"):
+        with expect_error(RuntimeError, "kv_len"):
             ttnn.experimental.indexer_score(
                 q_dev, k_dev, w_dev, chunk_start_idx=c["chunk_start"], program_config=cfg, kv_len=bad
             )

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <tuple>
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
@@ -14,9 +15,84 @@
 
 namespace ttnn::operations::experimental::indexer_score {
 
+namespace {
+// Invariants the hash does NOT pin, so they can change on a cache hit and must be re-checked every dispatch
+// (miss AND hit): device residency/allocation, q/w layout, the indexed-cache slot, and runtime kv_len. The
+// hash keys k's full spec (shape incl. T/B, dtype, layout) + whether indexed -- but not the slot/kv_len
+// values (runtime args). Shared by validate_on_program_cache_miss/_hit.
+void validate_non_hashed(const operation_attributes_t& attrs, const tensor_args_t& t) {
+    const auto& q = t.q;
+    const auto& k = t.k;
+    const auto& w = t.weights;
+    // On device + allocated. q/weights interleaved; k may be interleaved OR ND-sharded DRAM (the reader's
+    // TensorAccessor handles both; a sharded k pins its bank mapping via the hashed spec).
+    for (const auto& [tp, name, allow_sharded] :
+         {std::tuple{&q, "q", false}, std::tuple{&k, "k", true}, std::tuple{&w, "weights", false}}) {
+        TT_FATAL(tp->storage_type() == StorageType::DEVICE, "indexer_score {} must be on device", name);
+        TT_FATAL(tp->buffer() != nullptr, "indexer_score {} must have an allocated buffer", name);
+        if (!allow_sharded) {
+            TT_FATAL(!tp->is_sharded(), "indexer_score {} must use interleaved memory", name);
+        }
+    }
+    TT_FATAL(
+        q.device() == k.device() && q.device() == w.device(), "indexer_score q, k, weights must be on the same device");
+
+    // Indexed KV cache: k is [B,1,T,D] with B slots, cache_batch_idx picks one (q/weights are batch 1). B is
+    // hashed, the slot is not -> re-checked on hit too. Non-indexed: k is [1,1,T,D].
+    const uint32_t kB = k.logical_shape()[0];
+    if (attrs.cache_batch_idx.has_value()) {
+        TT_FATAL(
+            attrs.cache_batch_idx.value() < kB,
+            "indexer_score cache_batch_idx ({}) must be < k batch slots ({})",
+            attrs.cache_batch_idx.value(),
+            kB);
+    } else {
+        TT_FATAL(kB == 1, "indexer_score k batch must be 1 unless cache_batch_idx is set (got {})", kB);
+    }
+
+    // Runtime KV length: k is a persistent buffer of (hashed) length T; kv_len <= T is the valid prefix this
+    // dispatch (value not hashed -> re-checked here). chunk_start+Sq <= kv_len keeps the causal window inside
+    // the valid keys, preserving the kernel's "stale-k tail -> -inf overwrite" invariant (no unwritten tile
+    // is ever accumulated).
+    if (attrs.kv_len.has_value()) {
+        const uint32_t T = k.logical_shape()[2];
+        const uint32_t Sq = q.logical_shape()[2];
+        const uint32_t kv_len = attrs.kv_len.value();
+        TT_FATAL(kv_len % tt::constants::TILE_WIDTH == 0, "indexer_score kv_len {} must be tile-aligned", kv_len);
+        TT_FATAL(
+            kv_len > 0 && kv_len <= T,
+            "indexer_score kv_len {} must be in (0, T={}] (the allocated k length)",
+            kv_len,
+            T);
+        TT_FATAL(
+            attrs.chunk_start_idx + Sq <= kv_len,
+            "indexer_score causal window [{}, {}+{}) exceeds kv_len={} (cannot attend past the valid keys)",
+            attrs.chunk_start_idx,
+            attrs.chunk_start_idx,
+            Sq,
+            kv_len);
+    }
+}
+}  // namespace
+
 IndexerScoreDeviceOperation::program_factory_t IndexerScoreDeviceOperation::select_program_factory(
     const operation_attributes_t&, const tensor_args_t&) {
     return program::IndexerScoreProgramFactory{};
+}
+
+ttsl::hash::hash_t IndexerScoreDeviceOperation::compute_program_hash(
+    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+    // Default reflection hash, except the two persistent-cache optionals contribute only has_value() (whether
+    // indexed / runtime-kv_len), not their values -- those are runtime args re-applied every dispatch, so
+    // switching slot/kv_len reuses one program. Everything else stays hashed (chunk_start_idx, configs, full
+    // q/k/w specs incl. k's T/B), so do NOT drop fields beyond those two values.
+    return tt::tt_metal::operation::hash_operation<IndexerScoreDeviceOperation>(
+        attrs.chunk_start_idx,
+        attrs.program_config,
+        attrs.compute_kernel_config,
+        attrs.has_indexed_kv_cache(),
+        attrs.has_runtime_kv_len(),
+        tensor_args);
 }
 
 void IndexerScoreDeviceOperation::validate_on_program_cache_miss(
@@ -44,15 +120,9 @@ void IndexerScoreDeviceOperation::validate_on_program_cache_miss(
         "indexer_score requires fp32_dest_acc_en=false (bf16 DEST; the custom LLK is not validated for fp32 DEST)");
     TT_FATAL(!dst_full_sync_en, "indexer_score requires dst_full_sync_en=false (the kernel is built half-sync)");
 
-    // On-device, allocated, interleaved, same-device: the factory dereferences each buffer's address
-    // in q's device address space and the kernels assume interleaved DRAM/L1 (mcast deal + TensorAccessor).
-    for (const auto& [t, name] : {std::pair{&q, "q"}, std::pair{&k, "k"}, std::pair{&w, "weights"}}) {
-        TT_FATAL(t->storage_type() == StorageType::DEVICE, "indexer_score {} must be on device", name);
-        TT_FATAL(t->buffer() != nullptr, "indexer_score {} must have an allocated buffer", name);
-        TT_FATAL(!t->is_sharded(), "indexer_score {} must use interleaved memory", name);
-    }
-    TT_FATAL(
-        q.device() == k.device() && q.device() == w.device(), "indexer_score q, k, weights must be on the same device");
+    // Placement, layout, same-device and the indexed-cache batch relationship live in validate_non_hashed
+    // (also re-run on cache hit, since the slot/kv_len values aren't hashed).
+    validate_non_hashed(attrs, tensor_args);
 
     // Shapes: q [B, Hi, Sq, D], k [B, 1, T, D] (single shared head), weights [B, Hi, Sq, 1].
     TT_FATAL(q_shape.rank() == 4 && k_shape.rank() == 4 && w_shape.rank() == 4, "q, k, weights must be rank 4");
@@ -61,8 +131,10 @@ void IndexerScoreDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(
         w_shape[1] == q_shape[1] && w_shape[2] == q_shape[2] && w_shape[3] == 1,
         "weights must be [B, Hi, Sq, 1] matching q [B, Hi, Sq, D]");
-    TT_FATAL(q_shape[0] == k_shape[0] && q_shape[0] == w_shape[0], "batch mismatch");
-    TT_FATAL(q_shape[0] == 1, "batch 1 only, got {}", q_shape[0]);
+    // q/weights are always batch 1; k's batch is the cache-slot count B (checked in validate_non_hashed), so
+    // it is intentionally NOT tied to q's batch here.
+    TT_FATAL(q_shape[0] == w_shape[0], "q/weights batch mismatch ({} vs {})", q_shape[0], w_shape[0]);
+    TT_FATAL(q_shape[0] == 1, "q/weights batch 1 only, got {}", q_shape[0]);
 
     // weights are bf16 tiles. q and k are matmul inputs (q is srcB, k is srcA), neither is ever
     // packed, so each may be bfp8_b (halves its BW). q+k both bfp8 drops the matmul to LoFi (1 phase);
@@ -125,6 +197,13 @@ void IndexerScoreDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(HB > 0 && Hi % HB == 0, "head_group_size {} must divide Hi {}", HB, Hi);
 }
 
+void IndexerScoreDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+    // Everything else is pinned by the hash (passed at miss time); only the non-hashed slot/kv_len values can
+    // change on a hit, so re-validate them against this dispatch's k.
+    validate_non_hashed(attrs, tensor_args);
+}
+
 IndexerScoreDeviceOperation::spec_return_value_t IndexerScoreDeviceOperation::compute_output_specs(
     const operation_attributes_t&, const tensor_args_t& tensor_args) {
     const auto& q_shape = tensor_args.q.logical_shape();
@@ -169,11 +248,13 @@ IndexerScoreDeviceOperation::create_op_performance_model(
     const uint32_t Tt = k_shape[2] / tt::constants::TILE_WIDTH;
     const uint32_t chunk_t = attrs.chunk_start_idx / tt::constants::TILE_WIDTH;
 
-    // Causal-valid output tiles V = sum over q-tile-rows of min(Tt, chunk_t + row + 1) -- the useful
-    // matmul work, masked future tiles excluded (matches the test's sp7_valid_tiles()).
+    // Causal-valid output tiles V = sum over q-tile-rows of min(kv_len_tiles, chunk_t + row + 1) -- useful
+    // matmul work, masked future/unwritten tiles excluded (matches the test's sp7_valid_tiles()). kv_len
+    // caps the per-row valid columns; nullopt == full Tt.
+    const uint32_t kv_len_tiles = attrs.kv_len.has_value() ? attrs.kv_len.value() / tt::constants::TILE_WIDTH : Tt;
     uint64_t valid_tiles = 0;
     for (uint32_t s = 0; s < Sqt; ++s) {
-        valid_tiles += std::min<uint64_t>(Tt, (uint64_t)chunk_t + s + 1);
+        valid_tiles += std::min<uint64_t>(kv_len_tiles, (uint64_t)chunk_t + s + 1);
     }
 
     // Per valid 32x32 output tile, per head: a 32x32 x D matmul = (32*32) outputs x 2*D FLOPs (2/FMA);
@@ -210,12 +291,16 @@ IndexerScoreDeviceOperation::invoke(
     const Tensor& weights,
     uint32_t chunk_start_idx,
     const IndexerScoreProgramConfig& program_config,
-    const DeviceComputeKernelConfig& compute_kernel_config) {
+    const DeviceComputeKernelConfig& compute_kernel_config,
+    std::optional<uint32_t> cache_batch_idx,
+    std::optional<uint32_t> kv_len) {
     return {
         operation_attributes_t{
             .chunk_start_idx = chunk_start_idx,
             .program_config = program_config,
-            .compute_kernel_config = compute_kernel_config},
+            .compute_kernel_config = compute_kernel_config,
+            .cache_batch_idx = cache_batch_idx,
+            .kv_len = kv_len},
         tensor_args_t{.q = q, .k = k, .weights = weights}};
 }
 
@@ -229,7 +314,9 @@ ttnn::Tensor indexer_score(
     const ttnn::Tensor& weights,
     uint32_t chunk_start_idx,
     const ttnn::operations::experimental::indexer_score::IndexerScoreProgramConfig& program_config,
-    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config) {
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
+    std::optional<uint32_t> cache_batch_idx,
+    std::optional<uint32_t> kv_len) {
     using OperationType = ttnn::operations::experimental::indexer_score::IndexerScoreDeviceOperation;
     // Default math_fidelity follows the matmul-input dtypes (both bfp8 -> LoFi for the 2x peak, else
     // HiFi2 to keep the bf16 mantissa); a caller-supplied config overrides per field. fp32-dest acc and
@@ -245,7 +332,7 @@ ttnn::Tensor indexer_score(
         /*default_dst_full_sync_en=*/false);
     // Reuse invoke() so attribute/tensor packing lives in one place.
     auto [operation_attributes, tensor_args] =
-        OperationType::invoke(q, k, weights, chunk_start_idx, program_config, resolved);
+        OperationType::invoke(q, k, weights, chunk_start_idx, program_config, resolved, cache_batch_idx, kv_len);
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -16,11 +16,11 @@
 namespace ttnn::operations::experimental::indexer_score {
 
 namespace {
-// Invariants the hash does NOT pin, so they can change on a cache hit and must be re-checked every dispatch
-// (miss AND hit): device residency/allocation, q/w layout, the indexed-cache slot, and runtime kv_len. The
-// hash keys k's full spec (shape incl. T/B, dtype, layout) + whether indexed -- but not the slot/kv_len
-// values (runtime args). Shared by validate_on_program_cache_miss/_hit.
-void validate_non_hashed(const operation_attributes_t& attrs, const tensor_args_t& t) {
+// Miss-only checks: either hash-pinned (placement, non-indexed k batch shape) so they can't differ on a
+// hit, or caller errors the framework rules out anyway (device residency, allocation, same-device) and
+// never checked on a hit pre-PR. The slot/kv_len values that do differ on a hit live in
+// validate_runtime_values.
+void validate_static(const operation_attributes_t& attrs, const tensor_args_t& t) {
     const auto& q = t.q;
     const auto& k = t.k;
     const auto& w = t.weights;
@@ -37,17 +37,29 @@ void validate_non_hashed(const operation_attributes_t& attrs, const tensor_args_
     TT_FATAL(
         q.device() == k.device() && q.device() == w.device(), "indexer_score q, k, weights must be on the same device");
 
-    // Indexed KV cache: k is [B,1,T,D] with B slots, cache_batch_idx picks one (q/weights are batch 1). B is
-    // hashed, the slot is not -> re-checked on hit too. Non-indexed: k is [1,1,T,D].
-    const uint32_t kB = k.logical_shape()[0];
+    // Non-indexed k must be single-slot [1,1,T,D]. has_value() and kB are both hashed, so this only fires on
+    // a miss (the indexed slot < B check is a runtime value -> validate_runtime_values).
+    if (!attrs.cache_batch_idx.has_value()) {
+        const uint32_t kB = k.logical_shape()[0];
+        TT_FATAL(kB == 1, "indexer_score k batch must be 1 unless cache_batch_idx is set (got {})", kB);
+    }
+}
+
+// The slot/kv_len values: hashed only by has_value(), so they can differ on a cache hit and feed kernel
+// addressing (page offset / read width). Cheap integer checks on shape metadata, run on miss AND hit.
+void validate_runtime_values(const operation_attributes_t& attrs, const tensor_args_t& t) {
+    const auto& q = t.q;
+    const auto& k = t.k;
+
+    // Indexed KV cache: k is [B,1,T,D]; cache_batch_idx picks a slot (q/weights are batch 1). An
+    // out-of-range slot offsets every k page id OOB.
     if (attrs.cache_batch_idx.has_value()) {
+        const uint32_t kB = k.logical_shape()[0];
         TT_FATAL(
             attrs.cache_batch_idx.value() < kB,
             "indexer_score cache_batch_idx ({}) must be < k batch slots ({})",
             attrs.cache_batch_idx.value(),
             kB);
-    } else {
-        TT_FATAL(kB == 1, "indexer_score k batch must be 1 unless cache_batch_idx is set (got {})", kB);
     }
 
     // Runtime KV length: k is a persistent buffer of (hashed) length T; kv_len <= T is the valid prefix this
@@ -120,9 +132,10 @@ void IndexerScoreDeviceOperation::validate_on_program_cache_miss(
         "indexer_score requires fp32_dest_acc_en=false (bf16 DEST; the custom LLK is not validated for fp32 DEST)");
     TT_FATAL(!dst_full_sync_en, "indexer_score requires dst_full_sync_en=false (the kernel is built half-sync)");
 
-    // Placement, layout, same-device and the indexed-cache batch relationship live in validate_non_hashed
-    // (also re-run on cache hit, since the slot/kv_len values aren't hashed).
-    validate_non_hashed(attrs, tensor_args);
+    // Placement, layout, same-device and the non-indexed k batch shape are hash-pinned (miss only). The
+    // slot/kv_len runtime values are re-checked on every dispatch (here and on a cache hit).
+    validate_static(attrs, tensor_args);
+    validate_runtime_values(attrs, tensor_args);
 
     // Shapes: q [B, Hi, Sq, D], k [B, 1, T, D] (single shared head), weights [B, Hi, Sq, 1].
     TT_FATAL(q_shape.rank() == 4 && k_shape.rank() == 4 && w_shape.rank() == 4, "q, k, weights must be rank 4");
@@ -131,8 +144,8 @@ void IndexerScoreDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(
         w_shape[1] == q_shape[1] && w_shape[2] == q_shape[2] && w_shape[3] == 1,
         "weights must be [B, Hi, Sq, 1] matching q [B, Hi, Sq, D]");
-    // q/weights are always batch 1; k's batch is the cache-slot count B (checked in validate_non_hashed), so
-    // it is intentionally NOT tied to q's batch here.
+    // q/weights are always batch 1; k's batch is the cache-slot count B (checked in validate_static /
+    // validate_runtime_values), so it is intentionally NOT tied to q's batch here.
     TT_FATAL(q_shape[0] == w_shape[0], "q/weights batch mismatch ({} vs {})", q_shape[0], w_shape[0]);
     TT_FATAL(q_shape[0] == 1, "q/weights batch 1 only, got {}", q_shape[0]);
 
@@ -199,9 +212,9 @@ void IndexerScoreDeviceOperation::validate_on_program_cache_miss(
 
 void IndexerScoreDeviceOperation::validate_on_program_cache_hit(
     const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-    // Everything else is pinned by the hash (passed at miss time); only the non-hashed slot/kv_len values can
-    // change on a hit, so re-validate them against this dispatch's k.
-    validate_non_hashed(attrs, tensor_args);
+    // Equal hash already pins everything else (placement, shapes, configs); only the slot/kv_len values can
+    // differ on a hit, so re-check just those. Static invariants stay miss-only (validate_static).
+    validate_runtime_values(attrs, tensor_args);
 }
 
 IndexerScoreDeviceOperation::spec_return_value_t IndexerScoreDeviceOperation::compute_output_specs(

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
@@ -29,8 +29,8 @@ struct IndexerScoreDeviceOperation {
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
-    // Re-checks the non-hashed invariants (placement/layout, slot < B, kv_len bounds) since the slot/kv_len
-    // values can change on a hit. See validate_non_hashed.
+    // Only re-checks the runtime values (slot < B, kv_len bounds) that can change on a hit; the hash pins
+    // everything else. See validate_runtime_values.
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
@@ -22,12 +22,16 @@ struct IndexerScoreDeviceOperation {
     using tensor_return_value_t = indexer_score::tensor_return_value_t;
     using program_factory_t = std::variant<program::IndexerScoreProgramFactory>;
 
-    // No custom compute_program_hash: operation_attributes_t (chunk_start_idx + every config field)
-    // is a reflectable aggregate, so the default reflection hash already keys distinct programs on all
-    // fields. Do not add a hand-rolled hash that drops fields.
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
 
+    // Custom hash so the cache_batch_idx / kv_len values do NOT recompile (only their has_value() is hashed);
+    // everything else keys as usual. See the definition for details.
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    // Re-checks the non-hashed invariants (placement/layout, slot < B, kv_len bounds) since the slot/kv_len
+    // values can change on a hit. See validate_non_hashed.
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
@@ -43,7 +47,9 @@ struct IndexerScoreDeviceOperation {
         const Tensor& weights,
         uint32_t chunk_start_idx,
         const IndexerScoreProgramConfig& program_config,
-        const DeviceComputeKernelConfig& compute_kernel_config);
+        const DeviceComputeKernelConfig& compute_kernel_config,
+        std::optional<uint32_t> cache_batch_idx,
+        std::optional<uint32_t> kv_len);
 };
 
 }  // namespace ttnn::operations::experimental::indexer_score
@@ -54,12 +60,22 @@ namespace ttnn::experimental {
 //   score[b, s, t] = sum_h relu(q[b,h,s,:] . k[b,t,:]) * weights[b,h,s]
 // q [B, Hi, Sq, D], k [B, 1, T, D], weights [B, Hi, Sq, 1] -> score [B, 1, Sq, T] (row-major bf16).
 // Causality from chunk_start_idx: key t visible to query s iff t <= chunk_start_idx + s.
+//
+// cache_batch_idx: when set, k is a shared [B, 1, T, D] cache and this selects the batch slot to score
+// against (k may then also be ND-sharded across DRAM banks).
+// kv_len: when set, only the first kv_len key positions of k are valid this dispatch (rest masked out);
+// must be tile-aligned, in (0, T], with chunk_start_idx + Sq <= kv_len. Output is still [B, 1, Sq, T] with
+// only columns [0, kv_len) written.
+// Both values are re-applied each dispatch and excluded from the program hash, so switching slot or growing
+// kv_len reuses ONE program -- no recompile.
 ttnn::Tensor indexer_score(
     const ttnn::Tensor& q,
     const ttnn::Tensor& k,
     const ttnn::Tensor& weights,
     uint32_t chunk_start_idx = 0,
     const ttnn::operations::experimental::indexer_score::IndexerScoreProgramConfig& program_config = {},
-    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt);
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
+    std::optional<uint32_t> cache_batch_idx = std::nullopt,
+    std::optional<uint32_t> kv_len = std::nullopt);
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstddef>
+#include <optional>
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
@@ -32,6 +33,16 @@ struct operation_attributes_t {
     // Resolved (not optional) so it is part of the reflected program-cache key; the public callable
     // fills it from the user's optional config, defaulting math_fidelity to the dtype-derived choice.
     DeviceComputeKernelConfig compute_kernel_config{};
+    // Indexed KV cache: selects the batch slot of a shared [B,1,T,D] k (page ids offset by
+    // cache_batch_idx * Tt * Dt). k may then also be ND-sharded across DRAM banks. Value is NOT hashed and
+    // is re-applied in override_runtime_arguments, so switching slots does NOT recompile.
+    std::optional<uint32_t> cache_batch_idx{std::nullopt};
+    bool has_indexed_kv_cache() const { return cache_batch_idx.has_value(); }
+    // Runtime KV length: the valid prefix this dispatch of a k allocated at its full T; the rest is
+    // masked out. Value is NOT hashed (re-applied per dispatch), so growing kv_len <= T reuses ONE program.
+    // grid/work-split/output width stay keyed on the hashed T. nullopt == T.
+    std::optional<uint32_t> kv_len{std::nullopt};
+    bool has_runtime_kv_len() const { return kv_len.has_value(); }
 };
 
 struct tensor_args_t {

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
@@ -23,18 +23,43 @@
 namespace ttnn::operations::experimental::indexer_score::program {
 
 // Runtime-arg slots, shared by create()/override_runtime_arguments() and matched positionally
-// by the kernels. Reader: q,k,w addrs; writer: out addr.
+// by the kernels. Reader: q,k,w addrs then schedule(6) + mcast(2x8); writer: out addr then schedule(6).
 namespace rt_arg {
 constexpr uint32_t reader_q_addr = 0;
 constexpr uint32_t reader_k_addr = 1;
 constexpr uint32_t reader_w_addr = 2;
 constexpr uint32_t writer_out_addr = 0;
+// Persistent-cache args, appended after the schedule/mcast args of each kernel (excluded from the hash,
+// re-patched on a cache hit). Reader: 3 addrs + 6 schedule + 2 mcast dirs * 8 = 25, then the two below.
+constexpr uint32_t reader_num_scalars = 3 + 6;   // q/k/w addrs + schedule {row_group0..max_bands}
+constexpr uint32_t mcast_args_per_dir = 8;       // role, rect (xs,ys,xe,ye), sender (sx,sy), ndst
+constexpr uint32_t reader_num_mcast_dirs = 2;    // K column, then Q/W row
+constexpr uint32_t reader_k_batch_offset = reader_num_scalars + reader_num_mcast_dirs * mcast_args_per_dir;  // 25
+constexpr uint32_t reader_kv_len_tiles = reader_k_batch_offset + 1;                                          // 26
+constexpr uint32_t compute_kv_len_tiles = 6;  // after the 6 schedule scalars {row_group0..max_bands}
+constexpr uint32_t writer_kv_len_tiles = 1 + 6;  // out_addr + the 6 schedule scalars {row_group0..max_bands}
 }  // namespace rt_arg
 
 // Patch one runtime-arg slot on a program-cache hit, asserting the slot exists.
 inline void patch_arg(tt::tt_metal::RuntimeArgsData& args, uint32_t index, uint32_t value, const char* name) {
     TT_FATAL(index < args.size(), "indexer_score override: {} index {} >= args size {}", name, index, args.size());
     args[index] = value;
+}
+
+// The two non-hashed runtime args derived from k's (hashed) shape + the optionals. Single source for both
+// create() (bakes them at miss) and override_runtime_arguments() (re-patches them on a hit) -- a divergence
+// would silently mis-patch the slot/kv_len on a cache hit.
+struct PersistentCacheArgs {
+    uint32_t k_batch_page_offset;  // cache_batch_idx * Tt * Dt; 0 when not indexed
+    uint32_t kv_len_tiles;         // valid key prefix in tiles; full Tt when kv_len unset
+};
+inline PersistentCacheArgs persistent_cache_args(const operation_attributes_t& attrs, const Tensor& k) {
+    const auto& shape = k.logical_shape();
+    const uint32_t Tt = shape[2] / tt::constants::TILE_WIDTH;
+    const uint32_t Dt = shape[3] / tt::constants::TILE_WIDTH;
+    return {
+        .k_batch_page_offset = attrs.cache_batch_idx.value_or(0) * Tt * Dt,
+        .kv_len_tiles = attrs.kv_len.value_or(shape[2]) / tt::constants::TILE_WIDTH};
 }
 
 // Banded-product schedule: the work space (group_count q-row-groups x band_count k-bands) tiles onto
@@ -277,6 +302,10 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create(
     // (xs,ys,xe,ye) + sender (sx,sy) are physical NoC; ndst = #receivers. mcast rects are fixed per core
     // (one column for k, one row for q); only the data changes per group/band phase.
     const auto u32 = [](auto v) { return static_cast<uint32_t>(v); };
+    // Indexed-cache k page offset and valid kv_len, baked here for the cache-miss build and re-applied each
+    // dispatch in override_runtime_arguments (both excluded from the hash). The grid/work-split above stay
+    // keyed on the hashed Tt; kv_len_tiles only narrows the per-cell columns the kernels touch.
+    const auto [k_batch_page_offset, kv_len_tiles] = persistent_cache_args(args, k);
     std::vector<CoreCoord> cores;
     cores.reserve(num_cores);
     for (uint32_t row = 0; row < rows_used; ++row) {
@@ -342,10 +371,17 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create(
                 q_py,
                 q_sender,
                 cols_used - 1);
+            // Persistent-cache args last (slots reader[25,26]): after the mcast tuples in both branches.
+            reader_rt.push_back(k_batch_page_offset);
+            reader_rt.push_back(kv_len_tiles);
             tt::tt_metal::SetRuntimeArgs(program, reader_id, core, reader_rt);
-            tt::tt_metal::SetRuntimeArgs(program, compute_id, core, std::vector<uint32_t>(sched.begin(), sched.end()));
+            // compute: schedule scalars then kv_len_tiles at slot [6].
+            std::vector<uint32_t> compute_rt(sched.begin(), sched.end());
+            compute_rt.push_back(kv_len_tiles);
+            tt::tt_metal::SetRuntimeArgs(program, compute_id, core, compute_rt);
             std::vector<uint32_t> writer_rt = {out.buffer()->address()};
             writer_rt.insert(writer_rt.end(), sched.begin(), sched.end());
+            writer_rt.push_back(kv_len_tiles);  // slot [7], after out_addr + the 6 schedule scalars
             tt::tt_metal::SetRuntimeArgs(program, writer_id, core, writer_rt);
         }
     }
@@ -360,16 +396,27 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create(
 }
 
 void IndexerScoreProgramFactory::override_runtime_arguments(
-    cached_program_t& cached, const operation_attributes_t&, const tensor_args_t& tensors, tensor_return_value_t& out) {
+    cached_program_t& cached,
+    const operation_attributes_t& args,
+    const tensor_args_t& tensors,
+    tensor_return_value_t& out) {
     auto& shared = cached.shared_variables;
     auto& reader_args = tt::tt_metal::GetRuntimeArgs(cached.program, shared.reader_kernel);
+    auto& compute_args = tt::tt_metal::GetRuntimeArgs(cached.program, shared.compute_kernel);
     auto& writer_args = tt::tt_metal::GetRuntimeArgs(cached.program, shared.writer_kernel);
+    // cache_batch_idx and kv_len are excluded from the hash, so a hit may carry new values against the same
+    // cached program -- re-apply both every dispatch (the analog of buffer-address patching).
+    const auto [k_batch_page_offset, kv_len_tiles] = persistent_cache_args(args, tensors.k);
     for (const auto& core : shared.worker_cores) {
         auto& reader_rt = reader_args[core.x][core.y];
         patch_arg(reader_rt, rt_arg::reader_q_addr, tensors.q.buffer()->address(), "reader.q_addr");
         patch_arg(reader_rt, rt_arg::reader_k_addr, tensors.k.buffer()->address(), "reader.k_addr");
         patch_arg(reader_rt, rt_arg::reader_w_addr, tensors.weights.buffer()->address(), "reader.w_addr");
+        patch_arg(reader_rt, rt_arg::reader_k_batch_offset, k_batch_page_offset, "reader.k_batch_offset");
+        patch_arg(reader_rt, rt_arg::reader_kv_len_tiles, kv_len_tiles, "reader.kv_len_tiles");
+        patch_arg(compute_args[core.x][core.y], rt_arg::compute_kv_len_tiles, kv_len_tiles, "compute.kv_len_tiles");
         patch_arg(writer_args[core.x][core.y], rt_arg::writer_out_addr, out.buffer()->address(), "writer.out_addr");
+        patch_arg(writer_args[core.x][core.y], rt_arg::writer_kv_len_tiles, kv_len_tiles, "writer.kv_len_tiles");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/compute_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/compute_indexer_score.cpp
@@ -304,6 +304,9 @@ void kernel_main() {
     const uint32_t band0 = get_arg_val<uint32_t>(3);
     const uint32_t num_bands = get_arg_val<uint32_t>(4);
     const uint32_t max_bands = get_arg_val<uint32_t>(5);  // row's widest column; streaming drains q to this
+    // Valid KV length in tiles: caps each cell's valid columns (the causal mask suffix grows to cover the
+    // unwritten tail). Full k_len_tiles when not set, so the dense path is unchanged. Excluded from the hash.
+    const uint32_t kv_len_tiles = get_arg_val<uint32_t>(6);
     if (num_groups == 0 || num_bands == 0) {
         return;
     }
@@ -318,6 +321,7 @@ void kernel_main() {
     CircularBuffer q(cb_q);
 
     WorkUnitSpan span;
+    span.set_valid_k_len_tiles(kv_len_tiles);
 
     constexpr uint32_t unit_strip = q_tiles_per_unit * k_tiles_per_unit;  // QC x KC accumulator slots
     constexpr uint32_t q_row_tiles = q_group_tiles / q_tiles_per_unit;    // heads_per_group * head_dim_tiles

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_common.hpp
@@ -59,20 +59,28 @@ inline uint32_t row_valid_prefix(uint32_t q_row_abs, uint32_t k_tile_start, uint
 /** (group, band) cell cursor. The generalized scheduler maps groups -> grid rows and k-bands ->
  *  grid columns; each core walks its own (group-phase x band) rectangle and sets the cursor per cell.
  *  group = absolute q-row-group index; band = absolute k-band index. The per-cell accessors below feed
- *  every per-unit body (matmul / mask / untilize) identically, independent of how the grid was tiled. */
+ *  every per-unit body (matmul / mask / untilize) identically, independent of how the grid was tiled.
+ *
+ *  The grid (bands per column, the host deal) stays keyed on the COMPILE-TIME k_len_tiles (the allocated
+ *  buffer), so it is fixed. valid_k_len_tiles (runtime, <= k_len_tiles, defaults to the full buffer) only
+ *  narrows the valid-column count per cell: bands entirely past it score nothing (k_tiles() == 0). */
 struct WorkUnitSpan {
     uint32_t group = 0;
     uint32_t band = 0;
+    uint32_t valid_k_len_tiles = k_len_tiles;  // populated key prefix this dispatch; default = full buffer
 
     void set(uint32_t g, uint32_t b) {
         group = g;
         band = b;
     }
+    /** Set the runtime valid KV length (in tiles). Pass kv_len/32, or k_len_tiles for the full buffer. */
+    void set_valid_k_len_tiles(uint32_t tiles) { valid_k_len_tiles = tiles; }
 
     uint32_t q_tile_start() const { return group * q_tiles_per_unit; }  // first q-tile-row of this cell
     uint32_t k_tile_start() const { return band * k_tiles_per_unit; }   // first k-tile of this cell
-    uint32_t k_tiles() const {                                          // valid k-tiles (< full on the edge band)
-        uint32_t left = k_len_tiles - k_tile_start();
+    uint32_t k_tiles() const {  // valid k-tiles in this cell: < full on the edge, 0 entirely past kv_len
+        const uint32_t start = k_tile_start();
+        const uint32_t left = valid_k_len_tiles > start ? valid_k_len_tiles - start : 0;
         return left < k_tiles_per_unit ? left : k_tiles_per_unit;
     }
 };

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
@@ -208,9 +208,15 @@ inline void read_w_group(Noc noc, const WAcc& w_acc, uint32_t q_row_start, const
  *  handshake to minimize startup rendezvous. */
 template <typename KAcc>
 inline void read_k_chunk(
-    Noc noc, const KAcc& k_acc, uint32_t k_tile_start, uint32_t k_tiles_in_unit, const McastDir& k_dir) {
+    Noc noc,
+    const KAcc& k_acc,
+    uint32_t k_tile_start,
+    uint32_t k_tiles_in_unit,
+    const McastDir& k_dir,
+    uint32_t k_batch_page_offset) {
     // Reserves/pushes the full k_chunk_tiles to keep the 2-chunk ring half-aligned, but reads only the
-    // k_tiles_in_unit valid columns (pad slots stay stale; compute masks them).
+    // k_tiles_in_unit valid columns (pad slots stay stale; compute masks them). k_batch_page_offset shifts
+    // every page into the indexed cache slot; 0 when not indexed.
     read_block_or_mcast<cb_k, k_mcast_on, k_send_sem, k_recv_sem, k_valid_sem>(
         noc, k_chunk_tiles, k_chunk_tiles * k_tile_bytes, k_dir, [&](uint32_t addr) {
             uint32_t ptr = addr;
@@ -220,7 +226,7 @@ inline void read_k_chunk(
                         k_acc,
                         CoreLocalMem<uint32_t>(ptr),
                         k_tile_bytes,
-                        {.page_id = (k_tile_start + k_col) * head_dim_tiles + dim_tile},
+                        {.page_id = k_batch_page_offset + (k_tile_start + k_col) * head_dim_tiles + dim_tile},
                         {});
                     ptr += k_tile_bytes;
                 }
@@ -242,6 +248,10 @@ void kernel_main() {
     const uint32_t max_bands = get_arg_val<uint32_t>(8);  // row's widest column; streaming pads q to this
     const McastDir k_dir = read_mcast_dir(9);             // K column mcast: args [9, 17)
     const McastDir q_dir = read_mcast_dir(17);            // Q/W row mcast: args [17, 25)
+    // Persistent-cache runtime args (excluded from the hash, re-applied each dispatch), after the mcast
+    // tuples so they never perturb the fixed read_mcast_dir() offsets.
+    const uint32_t k_batch_page_offset = get_arg_val<uint32_t>(25);  // indexed-cache k page offset; 0 when not indexed
+    const uint32_t kv_len_tiles = get_arg_val<uint32_t>(26);  // valid KV length in tiles (full k_len_tiles when unset)
 
     const auto q_acc = TensorAccessor(q_args, q_addr, q_tile_bytes);
     const auto k_acc = TensorAccessor(k_args, k_addr, k_tile_bytes);
@@ -252,6 +262,7 @@ void kernel_main() {
     build_mask_tiles(noc);
 
     WorkUnitSpan span;
+    span.set_valid_k_len_tiles(kv_len_tiles);
 
     // group-OUTER, band-INNER. Resident-heads order within a group: k -> q -> w (w/gates consumed only in
     // the mul phase, so read LAST behind latency-critical q/k). Streaming path reads w FIRST: compute's mul
@@ -275,7 +286,7 @@ void kernel_main() {
                 span.set(group, band0 + band);
                 // k FIRST: compute waits the whole k chunk before any row, so reading k ahead of q lets the
                 // split q-row0 push unblock the first matmul (else the k wait re-serializes it).
-                read_k_chunk(noc, k_acc, span.k_tile_start(), span.k_tiles(), k_dir);
+                read_k_chunk(noc, k_acc, span.k_tile_start(), span.k_tiles(), k_dir, k_batch_page_offset);
                 if (band == 0 && !stream_heads) {
                     read_q_rows(noc, q_acc, q_row_start, q_dir);   // per-row: compute starts on row 0
                     read_w_group(noc, w_acc, q_row_start, q_dir);  // gates deferred behind q/k

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/writer_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/writer_indexer_score.cpp
@@ -26,20 +26,22 @@ constexpr uint32_t frag_bytes = tt::constants::TILE_WIDTH * sizeof(uint16_t);  /
 template <typename OutAcc>
 inline void write_strip(Noc noc, const OutAcc& out_acc, uint32_t q_row, uint32_t k_tile_start, uint32_t valid_w) {
     CircularBuffer cb(cb_out_strip);
-    cb.wait_front(k_tiles_per_unit);
-    uint32_t src = cb.get_read_ptr();
-    const uint32_t row_pitch = k_tiles_per_unit * frag_bytes;  // strip row stride (full KC)
-    const uint32_t write_bytes = valid_w * frag_bytes;         // only the in-bounds columns
-    for (uint32_t rr = 0; rr < tt::constants::TILE_HEIGHT; ++rr) {
-        noc.async_write(
-            CoreLocalMem<uint32_t>(src),
-            out_acc,
-            write_bytes,
-            {},
-            {.page_id = q_row * tt::constants::TILE_HEIGHT + rr, .offset_bytes = k_tile_start * frag_bytes});
-        src += row_pitch;
+    cb.wait_front(k_tiles_per_unit);  // compute always pushes a full KC strip; pop it whether or not we write
+    if (valid_w != 0) {               // valid_w == 0 when the cell is entirely past the valid kv_len: nothing to write
+        uint32_t src = cb.get_read_ptr();
+        const uint32_t row_pitch = k_tiles_per_unit * frag_bytes;  // strip row stride (full KC)
+        const uint32_t write_bytes = valid_w * frag_bytes;         // only the in-bounds columns
+        for (uint32_t rr = 0; rr < tt::constants::TILE_HEIGHT; ++rr) {
+            noc.async_write(
+                CoreLocalMem<uint32_t>(src),
+                out_acc,
+                write_bytes,
+                {},
+                {.page_id = q_row * tt::constants::TILE_HEIGHT + rr, .offset_bytes = k_tile_start * frag_bytes});
+            src += row_pitch;
+        }
+        noc.async_write_barrier();
     }
-    noc.async_write_barrier();
     cb.pop_front(k_tiles_per_unit);
 }
 
@@ -51,6 +53,9 @@ void kernel_main() {
     const uint32_t num_groups = get_arg_val<uint32_t>(3);
     const uint32_t band0 = get_arg_val<uint32_t>(4);
     const uint32_t num_bands = get_arg_val<uint32_t>(5);
+    // Schedule arg [6] is max_bands (unused by the writer). Valid KV length in tiles follows at [7]: caps the
+    // columns written per cell (page width stays the full T). Full k_len_tiles when not set. Excluded from hash.
+    const uint32_t kv_len_tiles = get_arg_val<uint32_t>(7);
 
     constexpr auto out_args = TensorAccessorArgs<num_common_ct_args + 1>();
     const auto out_acc = TensorAccessor(out_args, out_addr, page_bytes);
@@ -58,6 +63,7 @@ void kernel_main() {
     Noc noc;
 
     WorkUnitSpan span;
+    span.set_valid_k_len_tiles(kv_len_tiles);
 
     for (uint32_t phase = 0; phase < num_groups; ++phase) {
         const uint32_t group = row_group0 + phase * group_stride;

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
@@ -41,6 +41,15 @@ void bind_indexer_score(nb::module_& mod) {
                 math_fidelity is honored (default: HiFi2, or LoFi when q and k
                 are both bfloat8_b); fp32_dest_acc_en / dst_full_sync_en must
                 stay false (the custom LLK is validated for bf16 DEST half-sync).
+            cache_batch_idx: optional int. Selects the batch slot of a shared
+                [B, 1, T, D] k cache (which may then be ND-sharded across DRAM
+                banks). Re-applied each dispatch, so switching slots does not
+                recompile.
+            kv_len: optional int. Valid prefix of a k allocated at its full T;
+                the rest is masked out. Tile-aligned, in (0, T], with
+                chunk_start_idx + Sq <= kv_len. Re-applied each dispatch, so a
+                serving loop growing kv_len (<= T) reuses one program -- no
+                recompile. Only output columns [0, kv_len) are written.
 
         Returns: score [B, 1, Sq, T] bf16 row-major; future/pad columns -inf.
         )doc",
@@ -51,7 +60,9 @@ void bind_indexer_score(nb::module_& mod) {
         nb::kw_only(),
         nb::arg("chunk_start_idx") = 0,
         nb::arg("program_config") = IndexerScoreProgramConfig{},
-        nb::arg("compute_kernel_config") = std::nullopt);
+        nb::arg("compute_kernel_config") = std::nullopt,
+        nb::arg("cache_batch_idx") = std::nullopt,
+        nb::arg("kv_len") = std::nullopt);
 }
 
 }  // namespace ttnn::operations::experimental::indexer_score::detail


### PR DESCRIPTION
## What

Persistent-cache-friendly KV-cache features for `ttnn.experimental.indexer_score`, so a shared/oversized k cache can be reused across dispatches without recompiling the kernels. Both new args (`cache_batch_idx`, `kv_len`) are optional and default to the previous behavior.

## KV-cache features (persistent-cache friendly — no recompile on reuse)

- **Indexed ND-sharded kv** — optional `cache_batch_idx` selects a slot of a shared `[B, 1, T, D]` cache (a runtime arg, not in the program hash, so switching slots does not recompile); k may also be ND-sharded across DRAM banks. (A sharded k hashes its shape, since its bank mapping is shape-derived; interleaved does not.)
- **Runtime kv length** — optional `kv_len` selects the valid key prefix this dispatch; its value is excluded from the program hash, so a serving loop growing `kv_len` reuses one program. Only output columns `[0, kv_len)` are written; the stale tail is sliced off. (indexer_score scores all `T` keys, so the allocated `T` itself stays hashed — `kv_len` is the no-recompile knob within it.)
- **Oversized persistent kv** — k is allocated at its full `T` (the persistent buffer, hashed so it pins the grid/work-split) and `kv_len <= T` selects the live prefix, so a max-size cache works as-is and the reader reads only the live columns.
- **Validation** — every input invariant not keyed by the hash (q/k/weights layout + placement, `cache_batch_idx < B`, `kv_len` bounds, same-device) is re-checked on a cache **hit** as well as miss (`validate_on_program_cache_hit`).

## Tests

Per-slot and per-`kv_len` correctness, no-recompile on slot/`kv_len` change, ND-sharded k, and the rejection paths (including on a warm cache). All pass on Blackhole alongside the existing accuracy/determinism suites.

## CI

L2 nightly (experimental, Blackhole): https://github.com/tenstorrent/tt-metal/actions/runs/27947466094

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/indexer-score-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/indexer-score-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/indexer-score-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/indexer-score-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/indexer-score-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skrstic/indexer-score-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/indexer-score-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/indexer-score-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/indexer-score-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/indexer-score-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/indexer-score-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/indexer-score-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/indexer-score-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/indexer-score-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/indexer-score-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/indexer-score-kv-cache)