### PR TITLE
universal input support for roll op

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_roll.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_roll.py
@@ -1,0 +1,416 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Universal I/O tests for ttnn.roll — comprehensive sharded matrix.
+
+Covers:
+  - ROW_MAJOR interleaved (DRAM/L1) — backward compatibility
+  - TILE interleaved (DRAM/L1)
+  - HEIGHT / WIDTH / BLOCK sharded, ROW_MAJOR (native gather kernel)
+  - HEIGHT / WIDTH / BLOCK sharded, TILE tile-aligned (native whole-tile gather)
+  - HEIGHT / WIDTH / BLOCK sharded, TILE non-tile-aligned (sharded untilize→roll→tilize)
+  - Multi-dim rolls, higher-dim (batch/channel) rolls, last-dim within-row rolls
+  - DRAM-sharded ROW_MAJOR: full-shard L1 staging (read DRAM→L1, assemble, write L1→DRAM)
+  - DRAM-sharded TILE: per-tile NOC read/write (tile-size naturally DRAM-aligned)
+  - Program-cache hash correctness: distinct shifts produce distinct programs
+  - Optional output memory_config parameter (sharded → interleaved and vice versa)
+  - COL_MAJOR shard orientation (HEIGHT and BLOCK)
+"""
+
+import pytest
+import torch
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+_PCC = 0.9999
+
+
+# ─── shard-config helpers ─────────────────────────────────────────────────────
+
+
+def _explicit_height_shard(device, ncores, sh, sw):
+    compute_grid = device.compute_with_storage_grid_size()
+    if ncores > compute_grid.x * compute_grid.y:
+        pytest.skip(f"Device has {compute_grid.x * compute_grid.y} cores, test needs {ncores}")
+    spec = ttnn.ShardSpec(
+        ttnn.num_cores_to_corerangeset(ncores, compute_grid, True),
+        (sh, sw),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, spec)
+
+
+def _explicit_width_shard(device, ncores, sh, sw):
+    compute_grid = device.compute_with_storage_grid_size()
+    if ncores > compute_grid.x * compute_grid.y:
+        pytest.skip(f"Device has {compute_grid.x * compute_grid.y} cores, test needs {ncores}")
+    spec = ttnn.ShardSpec(
+        ttnn.num_cores_to_corerangeset(ncores, compute_grid, True),
+        (sh, sw),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, spec)
+
+
+def _explicit_block_shard(device, grid_y, grid_x, sh, sw):
+    compute_grid = device.compute_with_storage_grid_size()
+    if grid_y > compute_grid.y or grid_x > compute_grid.x:
+        pytest.skip(f"Device grid ({compute_grid.y}x{compute_grid.x}) too small for {grid_y}x{grid_x}")
+    spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_x - 1, grid_y - 1))}),
+        (sh, sw),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1, spec)
+
+
+# ─── runner ───────────────────────────────────────────────────────────────────
+
+
+def run_roll(device, torch_input, layout, mem_config, shifts, dims):
+    ttnn_input = ttnn.from_torch(
+        torch_input, dtype=ttnn.bfloat16, layout=layout, device=device, memory_config=mem_config
+    )
+    ttnn_output = ttnn.roll(ttnn_input, list(shifts), list(dims))
+    got = ttnn.to_torch(ttnn_output.cpu())
+    ref = torch.roll(torch_input, list(shifts), list(dims))
+    assert_with_pcc(ref.float(), got.float(), _PCC)
+
+
+# ─── DRAM / L1 interleaved — backward compatibility ──────────────────────────
+
+
+@pytest.mark.parametrize(
+    "shape,shifts,dims,layout,mem_config",
+    [
+        ([1, 1, 4, 8], [2], [3], ttnn.ROW_MAJOR_LAYOUT, ttnn.DRAM_MEMORY_CONFIG),
+        ([6, 4, 5, 1], [1, -2], [0, 2], ttnn.ROW_MAJOR_LAYOUT, ttnn.DRAM_MEMORY_CONFIG),
+        ([4, 4, 8, 8], [3], [1], ttnn.ROW_MAJOR_LAYOUT, ttnn.DRAM_MEMORY_CONFIG),
+        ([1, 1, 32, 64], [16], [3], ttnn.TILE_LAYOUT, ttnn.DRAM_MEMORY_CONFIG),
+        ([2, 1, 64, 64], [32, -32], [2, 3], ttnn.TILE_LAYOUT, ttnn.DRAM_MEMORY_CONFIG),
+        ([1, 1, 4, 8], [2], [3], ttnn.ROW_MAJOR_LAYOUT, ttnn.L1_MEMORY_CONFIG),
+        ([1, 2, 64, 64], [32, -16], [2, 3], ttnn.TILE_LAYOUT, ttnn.L1_MEMORY_CONFIG),
+    ],
+)
+def test_roll_interleaved(device, shape, shifts, dims, layout, mem_config):
+    torch.manual_seed(0)
+    run_roll(device, torch.randn(shape, dtype=torch.bfloat16), layout, mem_config, shifts, dims)
+
+
+# ─── HEIGHT_SHARDED + ROW_MAJOR (native gather kernel) ───────────────────────
+
+
+@pytest.mark.parametrize(
+    "shape,ncores,sh,sw,shifts,dims",
+    [
+        # last-dim within-row rotation
+        ([1, 1, 4, 8], 4, 1, 8, [2], [3]),
+        ([1, 1, 8, 16], 4, 2, 16, [4], [3]),
+        ([1, 1, 8, 16], 4, 2, 16, [7], [3]),  # non-power-of-2 shift
+        # height-dim page permutation
+        ([1, 1, 8, 16], 4, 2, 16, [2], [2]),
+        ([1, 1, 16, 8], 4, 4, 8, [3], [2]),
+        # batch-dim roll
+        ([2, 2, 8, 8], 4, 8, 8, [1], [0]),  # total_rows=32, sh=32//4=8
+        ([4, 1, 4, 8], 4, 4, 8, [2], [0]),
+        # multi-dim roll
+        ([1, 1, 8, 16], 4, 2, 16, [2, 4], [2, 3]),
+        # negative shift
+        ([1, 1, 8, 16], 4, 2, 16, [-3], [3]),
+    ],
+)
+def test_roll_height_sharded_row_major(device, shape, ncores, sh, sw, shifts, dims):
+    torch.manual_seed(1)
+    mem_config = _explicit_height_shard(device, ncores, sh, sw)
+    run_roll(device, torch.randn(shape, dtype=torch.bfloat16), ttnn.ROW_MAJOR_LAYOUT, mem_config, shifts, dims)
+
+
+# ─── HEIGHT_SHARDED + TILE, tile-aligned shifts (native whole-tile gather) ───
+
+
+@pytest.mark.parametrize(
+    "shape,ncores,sh,sw,shifts,dims",
+    [
+        ([1, 1, 64, 32], 2, 32, 32, [32], [3]),
+        ([1, 1, 64, 64], 2, 32, 64, [32], [2]),
+        ([1, 1, 128, 64], 4, 32, 64, [64], [2]),
+        ([1, 1, 64, 128], 2, 32, 128, [64], [3]),
+        ([1, 1, 64, 64], 2, 32, 64, [32, 32], [2, 3]),  # multi-dim tile-aligned
+    ],
+)
+def test_roll_height_sharded_tile_aligned(device, shape, ncores, sh, sw, shifts, dims):
+    torch.manual_seed(2)
+    mem_config = _explicit_height_shard(device, ncores, sh, sw)
+    run_roll(device, torch.randn(shape, dtype=torch.bfloat16), ttnn.TILE_LAYOUT, mem_config, shifts, dims)
+
+
+# ─── HEIGHT_SHARDED + TILE, non-tile-aligned (sharded untilize→roll→tilize) ──
+
+
+@pytest.mark.parametrize(
+    "shape,ncores,sh,sw,shifts,dims",
+    [
+        ([1, 1, 64, 64], 2, 32, 64, [5], [3]),
+        ([1, 1, 64, 64], 2, 32, 64, [7], [2]),
+        ([1, 1, 128, 64], 4, 32, 64, [13], [3]),
+    ],
+)
+def test_roll_height_sharded_tile_non_aligned(device, shape, ncores, sh, sw, shifts, dims):
+    torch.manual_seed(3)
+    mem_config = _explicit_height_shard(device, ncores, sh, sw)
+    run_roll(device, torch.randn(shape, dtype=torch.bfloat16), ttnn.TILE_LAYOUT, mem_config, shifts, dims)
+
+
+# ─── WIDTH_SHARDED + ROW_MAJOR (native gather kernel, cross-shard boundary) ──
+
+
+@pytest.mark.parametrize(
+    "shape,ncores,sh,sw,shifts,dims",
+    [
+        # cross-shard last-dim roll
+        ([1, 1, 1, 32], 2, 1, 16, [8], [3]),
+        ([1, 1, 1, 64], 4, 1, 16, [16], [3]),
+        ([1, 1, 1, 32], 2, 1, 16, [7], [3]),  # non-power-of-2
+        # height-dim page permutation
+        ([1, 1, 4, 32], 2, 4, 16, [2], [2]),
+        ([1, 1, 8, 32], 2, 8, 16, [3], [2]),
+        # negative shift
+        ([1, 1, 1, 64], 4, 1, 16, [-5], [3]),
+    ],
+)
+def test_roll_width_sharded_row_major(device, shape, ncores, sh, sw, shifts, dims):
+    torch.manual_seed(4)
+    mem_config = _explicit_width_shard(device, ncores, sh, sw)
+    run_roll(device, torch.randn(shape, dtype=torch.bfloat16), ttnn.ROW_MAJOR_LAYOUT, mem_config, shifts, dims)
+
+
+# ─── WIDTH_SHARDED + TILE, tile-aligned (native whole-tile gather) ────────────
+
+
+@pytest.mark.parametrize(
+    "shape,ncores,sh,sw,shifts,dims",
+    [
+        ([1, 1, 32, 64], 2, 32, 32, [32], [3]),
+        ([1, 1, 32, 128], 4, 32, 32, [32], [3]),
+        ([1, 1, 64, 128], 4, 64, 32, [64], [3]),
+    ],
+)
+def test_roll_width_sharded_tile_aligned(device, shape, ncores, sh, sw, shifts, dims):
+    torch.manual_seed(5)
+    mem_config = _explicit_width_shard(device, ncores, sh, sw)
+    run_roll(device, torch.randn(shape, dtype=torch.bfloat16), ttnn.TILE_LAYOUT, mem_config, shifts, dims)
+
+
+# ─── WIDTH_SHARDED + TILE, non-tile-aligned (sharded untilize→roll→tilize) ───
+
+
+@pytest.mark.parametrize(
+    "shape,ncores,sh,sw,shifts,dims",
+    [
+        ([1, 1, 32, 128], 4, 32, 32, [13], [3]),
+        ([1, 1, 32, 128], 4, 32, 32, [7], [3]),
+    ],
+)
+def test_roll_width_sharded_tile_non_aligned(device, shape, ncores, sh, sw, shifts, dims):
+    torch.manual_seed(6)
+    mem_config = _explicit_width_shard(device, ncores, sh, sw)
+    run_roll(device, torch.randn(shape, dtype=torch.bfloat16), ttnn.TILE_LAYOUT, mem_config, shifts, dims)
+
+
+# ─── BLOCK_SHARDED + ROW_MAJOR (native gather kernel) ────────────────────────
+
+
+@pytest.mark.parametrize(
+    "shape,grid_y,grid_x,sh,sw,shifts,dims",
+    [
+        # last-dim within-row rotation
+        ([1, 1, 4, 8], 2, 2, 2, 4, [2], [3]),
+        ([1, 1, 8, 16], 2, 2, 4, 8, [4], [3]),
+        ([1, 1, 8, 16], 2, 2, 4, 8, [3], [3]),  # non-power-of-2
+        # height-dim roll
+        ([1, 1, 8, 16], 2, 2, 4, 8, [2], [2]),
+        ([1, 1, 16, 16], 2, 2, 8, 8, [4], [2]),
+        # negative shift
+        ([1, 1, 8, 16], 2, 2, 4, 8, [-3], [3]),
+    ],
+)
+def test_roll_block_sharded_row_major(device, shape, grid_y, grid_x, sh, sw, shifts, dims):
+    torch.manual_seed(7)
+    mem_config = _explicit_block_shard(device, grid_y, grid_x, sh, sw)
+    run_roll(device, torch.randn(shape, dtype=torch.bfloat16), ttnn.ROW_MAJOR_LAYOUT, mem_config, shifts, dims)
+
+
+# ─── BLOCK_SHARDED + TILE, tile-aligned (native whole-tile gather) ────────────
+
+
+@pytest.mark.parametrize(
+    "shape,grid_y,grid_x,sh,sw,shifts,dims",
+    [
+        ([1, 1, 64, 64], 2, 2, 32, 32, [32], [3]),
+        ([1, 1, 64, 128], 2, 2, 32, 64, [32], [2]),
+        ([1, 1, 128, 64], 2, 2, 64, 32, [64], [2]),
+        ([1, 1, 64, 128], 2, 2, 32, 64, [64], [3]),
+        ([1, 1, 64, 64], 2, 2, 32, 32, [32, 32], [2, 3]),  # multi-dim tile-aligned
+    ],
+)
+def test_roll_block_sharded_tile_aligned(device, shape, grid_y, grid_x, sh, sw, shifts, dims):
+    torch.manual_seed(8)
+    mem_config = _explicit_block_shard(device, grid_y, grid_x, sh, sw)
+    run_roll(device, torch.randn(shape, dtype=torch.bfloat16), ttnn.TILE_LAYOUT, mem_config, shifts, dims)
+
+
+# ─── BLOCK_SHARDED + TILE, non-tile-aligned (sharded untilize→roll→tilize) ───
+
+
+@pytest.mark.parametrize(
+    "shape,grid_y,grid_x,sh,sw,shifts,dims",
+    [
+        ([1, 1, 64, 64], 2, 2, 32, 32, [5], [3]),
+        ([1, 1, 64, 64], 2, 2, 32, 32, [7], [2]),
+        ([1, 1, 64, 128], 2, 2, 32, 64, [13], [3]),
+    ],
+)
+def test_roll_block_sharded_tile_non_aligned(device, shape, grid_y, grid_x, sh, sw, shifts, dims):
+    torch.manual_seed(9)
+    mem_config = _explicit_block_shard(device, grid_y, grid_x, sh, sw)
+    run_roll(device, torch.randn(shape, dtype=torch.bfloat16), ttnn.TILE_LAYOUT, mem_config, shifts, dims)
+
+
+# ─── DRAM-sharded inputs: native support via DRAM bank NOC transfers ─────────
+
+
+@pytest.mark.parametrize(
+    "shape,sh,sw,shifts,dims",
+    [
+        ([1, 1, 8, 16], 2, 16, [4], [3]),  # last-dim within-row rotation
+        ([1, 1, 8, 16], 2, 16, [2], [2]),  # height-dim page permutation
+        ([1, 1, 16, 32], 4, 32, [8], [3]),  # larger shard
+    ],
+)
+def test_roll_dram_sharded_row_major_native(device, shape, sh, sw, shifts, dims):
+    """DRAM-sharded ROW_MAJOR roll — mode 2: full-shard L1 staging.
+    Reads entire source shard from DRAM into L1, assembles the rolled result in L1 via
+    element-level local copies, then writes the complete shard from L1 back to DRAM.
+    All DRAM NOC transfers are shard-sized (32-byte aligned) — no sub-alignment issue.
+    """
+    torch.manual_seed(10)
+    compute_grid = device.compute_with_storage_grid_size()
+    total_h = shape[0] * shape[1] * shape[2]
+    ncores = total_h // sh
+    if ncores > compute_grid.x * compute_grid.y:
+        pytest.skip(f"Device has insufficient cores ({ncores} needed)")
+    shard_spec = ttnn.ShardSpec(
+        ttnn.num_cores_to_corerangeset(ncores, compute_grid, True),
+        [sh, sw],
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, shard_spec)
+    run_roll(device, torch.randn(shape, dtype=torch.bfloat16), ttnn.ROW_MAJOR_LAYOUT, mem_config, shifts, dims)
+
+
+@pytest.mark.parametrize(
+    "shape,sh,sw,shifts,dims",
+    [
+        ([1, 1, 64, 64], 32, 64, [32], [2]),  # height-dim tile permutation
+        ([1, 1, 64, 128], 32, 128, [64], [3]),  # last-dim tile rotation
+    ],
+)
+def test_roll_dram_sharded_tile_native(device, shape, sh, sw, shifts, dims):
+    """DRAM-sharded TILE roll — mode 1: per-tile NOC read+write.
+    Tiles are 2048 bytes (bf16), naturally satisfying the 32-byte DRAM NOC write
+    alignment requirement — no full-shard staging needed.
+    """
+    torch.manual_seed(10)
+    compute_grid = device.compute_with_storage_grid_size()
+    total_h = shape[0] * shape[1] * shape[2]
+    ncores = total_h // sh
+    if ncores > compute_grid.x * compute_grid.y:
+        pytest.skip(f"Device has insufficient cores ({ncores} needed)")
+    shard_spec = ttnn.ShardSpec(
+        ttnn.num_cores_to_corerangeset(ncores, compute_grid, True),
+        [sh, sw],
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, shard_spec)
+    run_roll(device, torch.randn(shape, dtype=torch.bfloat16), ttnn.TILE_LAYOUT, mem_config, shifts, dims)
+
+
+# ─── Program-cache hash: distinct shifts must produce distinct programs ──────
+
+
+@pytest.mark.parametrize("shift", [2, 5, 7])
+def test_roll_program_cache_distinct_shifts(device, shift):
+    """Rolls with different shifts on the same shape must produce correct results."""
+    torch.manual_seed(11)
+    shape = [1, 1, 8, 16]
+    shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
+        [2, 16],
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
+    run_roll(device, torch.randn(shape, dtype=torch.bfloat16), ttnn.ROW_MAJOR_LAYOUT, mem_config, [shift], [3])
+
+
+# ─── Optional output memory_config ──────────────────────────────────────────
+
+
+def test_roll_output_memory_config_dram(device):
+    """Roll a sharded input and request DRAM interleaved output."""
+    torch.manual_seed(12)
+    shape = [1, 1, 8, 16]
+    shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
+        [2, 16],
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    input_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
+    x = torch.randn(shape, dtype=torch.bfloat16)
+    t = ttnn.from_torch(x, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=input_mc)
+    out = ttnn.roll(t, [3], [3], memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    assert out.memory_config().buffer_type == ttnn.BufferType.DRAM
+    assert_with_pcc(torch.roll(x, [3], [3]).float(), ttnn.to_torch(out.cpu()).float(), _PCC)
+
+
+def test_roll_output_memory_config_l1_interleaved(device):
+    """Roll an interleaved input and request L1 interleaved output."""
+    torch.manual_seed(13)
+    shape = [1, 1, 32, 64]
+    x = torch.randn(shape, dtype=torch.bfloat16)
+    t = ttnn.from_torch(
+        x, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    out = ttnn.roll(t, [16], [3], memory_config=ttnn.L1_MEMORY_CONFIG)
+    assert out.memory_config().buffer_type == ttnn.BufferType.L1
+    assert_with_pcc(torch.roll(x, [16], [3]).float(), ttnn.to_torch(out.cpu()).float(), _PCC)
+
+
+# ─── COL_MAJOR shard orientation ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "shape,sh,sw,shifts,dims,layout",
+    [
+        ([1, 1, 8, 16], 2, 16, [2], [3], ttnn.ROW_MAJOR_LAYOUT),  # last-dim rotation
+        ([1, 1, 8, 16], 2, 16, [2], [2], ttnn.ROW_MAJOR_LAYOUT),  # height-dim permutation
+        ([1, 1, 64, 64], 32, 64, [32], [3], ttnn.TILE_LAYOUT),  # tile-aligned, last-dim; sh=32 for tile alignment
+        ([1, 1, 64, 64], 32, 64, [32], [2], ttnn.TILE_LAYOUT),  # tile-aligned, height-dim
+    ],
+)
+def test_roll_col_major_height_sharded(device, shape, sh, sw, shifts, dims, layout):
+    """HEIGHT_SHARDED with COL_MAJOR orientation — native kernel."""
+    torch.manual_seed(14)
+    compute_grid = device.compute_with_storage_grid_size()
+    total_rows = shape[0] * shape[1] * shape[2]
+    ncores = total_rows // sh
+    if ncores > compute_grid.x * compute_grid.y:
+        pytest.skip(f"Device has insufficient cores for this test ({ncores} needed)")
+    shard_spec = ttnn.ShardSpec(
+        ttnn.num_cores_to_corerangeset(ncores, compute_grid, True),
+        [sh, sw],
+        ttnn.ShardOrientation.COL_MAJOR,
+    )
+    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
+    run_roll(device, torch.randn(shape, dtype=torch.bfloat16), layout, mem_config, shifts, dims)

--- a/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
@@ -33,6 +33,7 @@ file(
     permute/device/kernels/*
     reshape_on_device/device/kernels/*
     repeat/device/kernels/*
+    roll/device/kernels/*
     reshape_view/device/device/*
     scatter/device/kernels/*
     sharded/device/kernels/*
@@ -195,6 +196,9 @@ target_sources(
             # roll/
             roll/roll.hpp
             roll/roll_nanobind.hpp
+            roll/device/roll_device_operation.hpp
+            roll/device/roll_device_operation_types.hpp
+            roll/device/roll_program_factory.hpp
             # scatter/
             scatter/scatter.hpp
             scatter/scatter_nanobind.hpp

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/device/kernels/dataflow/roll_sharded_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/device/kernels/dataflow/roll_sharded_reader.cpp
@@ -65,7 +65,9 @@ void kernel_main() {
     if constexpr (mode == 2) {
         // DRAM RM mode: read full source shard(s) from DRAM into L1 staging, assemble the
         // rolled result in L1 via local element copies, then write full shard to DRAM dst.
-        // All DRAM NOC transfers are shard-sized (validated 32-byte aligned) — no sub-alignment issue.
+        // All DRAM NOC transfers are shard-sized (validated DRAM-alignment aligned) — no
+        // sub-alignment issue. The host computes the staging row pitch using the DRAM alignment
+        // (64B on Blackhole, 32B on Wormhole) so the staged layout matches the in-DRAM layout.
         CircularBuffer src_cbs[2] = {CircularBuffer(dram_src0_cb_id), CircularBuffer(dram_src1_cb_id)};
         CircularBuffer dst_cb(dram_dst_cb_id);
         const uint32_t src_base[2] = {src_cbs[0].get_write_ptr(), src_cbs[1].get_write_ptr()};

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/device/kernels/dataflow/roll_sharded_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/device/kernels/dataflow/roll_sharded_reader.cpp
@@ -1,0 +1,187 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/circular_buffer.h"
+
+// Native sharded roll copy kernel — supports both L1-sharded and DRAM-sharded tensors.
+//
+// Roll is realised as a gather: the host computes, per destination core, a list of
+// segment-copy descriptors. Each descriptor copies a contiguous run of `copy_size` bytes
+// from a source shard (possibly on another core/bank) into the local output shard.
+//
+// L1 mode: segment offsets can be arbitrary (a within-row rotation produces unaligned runs),
+// so every segment is staged through a scratch CB: we NOC-read an alignment-padded superset
+// of the run into the scratch buffer, then copy the exact bytes out locally. The scratch CB
+// is double-buffered so reads overlap copies.
+//
+// DRAM mode: source data is read from DRAM via get_noc_addr_from_bank_id; the result is
+// staged in scratch L1. The destination is also DRAM, written back via NOC async write.
+// DRAM transfers are tile-aligned so no sub-alignment padding is needed.
+
+// Local copy of `copy_size` bytes. Prefers 32-bit word copies; falls back to bytes.
+inline void local_copy(uint32_t src_addr, uint32_t dst_addr, uint32_t copy_size) {
+    if (((src_addr | dst_addr) & 3u) == 0) {
+        const uint32_t words = copy_size >> 2;
+        volatile tt_l1_ptr uint32_t* s32 = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(src_addr);
+        volatile tt_l1_ptr uint32_t* d32 = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dst_addr);
+        for (uint32_t w = 0; w < words; w++) {
+            d32[w] = s32[w];
+        }
+        volatile tt_l1_ptr uint8_t* s8 = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(src_addr);
+        volatile tt_l1_ptr uint8_t* d8 = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(dst_addr);
+        for (uint32_t b = words << 2; b < copy_size; b++) {
+            d8[b] = s8[b];
+        }
+    } else {
+        volatile tt_l1_ptr uint8_t* s8 = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(src_addr);
+        volatile tt_l1_ptr uint8_t* d8 = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(dst_addr);
+        for (uint32_t b = 0; b < copy_size; b++) {
+            d8[b] = s8[b];
+        }
+    }
+}
+
+void kernel_main() {
+    constexpr uint32_t output_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t scratch_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t alignment = get_compile_time_arg_val(2);
+    constexpr uint32_t scratch_half = get_compile_time_arg_val(3);
+    constexpr uint32_t mode = get_compile_time_arg_val(4);             // 0=L1, 1=DRAM_TILE, 2=DRAM_RM
+    constexpr uint32_t shard_size = get_compile_time_arg_val(5);       // DRAM_RM: full shard bytes
+    constexpr uint32_t dram_src0_cb_id = get_compile_time_arg_val(6);  // DRAM_RM: staging slot 0
+    constexpr uint32_t dram_src1_cb_id = get_compile_time_arg_val(7);  // DRAM_RM: staging slot 1
+    constexpr uint32_t dram_dst_cb_id = get_compile_time_arg_val(8);   // DRAM_RM: dst assembly
+
+    // Scratch CB is used by L1 mode (alignment padding) and DRAM TILE mode (staging).
+    // Declared here so both branches can access it.
+    CircularBuffer scratch_cb(scratch_cb_id);
+    const uint32_t scratch_base = scratch_cb.get_write_ptr();
+
+    uint32_t arg_idx = 0;
+
+    if constexpr (mode == 2) {
+        // DRAM RM mode: read full source shard(s) from DRAM into L1 staging, assemble the
+        // rolled result in L1 via local element copies, then write full shard to DRAM dst.
+        // All DRAM NOC transfers are shard-sized (validated 32-byte aligned) — no sub-alignment issue.
+        CircularBuffer src_cbs[2] = {CircularBuffer(dram_src0_cb_id), CircularBuffer(dram_src1_cb_id)};
+        CircularBuffer dst_cb(dram_dst_cb_id);
+        const uint32_t src_base[2] = {src_cbs[0].get_write_ptr(), src_cbs[1].get_write_ptr()};
+        const uint32_t dst_base = dst_cb.get_write_ptr();
+
+        const uint32_t dst_bank_id = get_arg_val<uint32_t>(arg_idx++);
+        const uint32_t dst_bank_base = get_arg_val<uint32_t>(arg_idx++);
+        const uint32_t num_src = get_arg_val<uint32_t>(arg_idx++);
+
+        for (uint32_t s = 0; s < num_src; s++) {
+            const uint32_t bank_id = get_arg_val<uint32_t>(arg_idx++);
+            const uint32_t bank_addr = get_arg_val<uint32_t>(arg_idx++);
+            noc_async_read(get_noc_addr_from_bank_id<true>(bank_id, bank_addr), src_base[s], shard_size);
+        }
+        noc_async_read_barrier();
+
+        const uint32_t num_transfers = get_arg_val<uint32_t>(arg_idx++);
+        for (uint32_t t = 0; t < num_transfers; t++) {
+            const uint32_t src_slot = get_arg_val<uint32_t>(arg_idx++);
+            uint32_t src_off = get_arg_val<uint32_t>(arg_idx++);
+            uint32_t dst_off = get_arg_val<uint32_t>(arg_idx++);
+            const uint32_t copy_sz = get_arg_val<uint32_t>(arg_idx++);
+            const uint32_t src_str = get_arg_val<uint32_t>(arg_idx++);
+            const uint32_t dst_str = get_arg_val<uint32_t>(arg_idx++);
+            const uint32_t num_rows = get_arg_val<uint32_t>(arg_idx++);
+            for (uint32_t row = 0; row < num_rows; row++) {
+                local_copy(src_base[src_slot] + src_off, dst_base + dst_off, copy_sz);
+                src_off += src_str;
+                dst_off += dst_str;
+            }
+        }
+
+        noc_async_write(dst_base, get_noc_addr_from_bank_id<true>(dst_bank_id, dst_bank_base), shard_size);
+        noc_async_write_barrier();
+
+    } else if constexpr (mode == 1) {
+        // DRAM mode: source is a DRAM bank, destination is a DRAM bank.
+        // Per-core header: dst_bank_id, dst_bank_base_addr.
+        const uint32_t dst_bank_id = get_arg_val<uint32_t>(arg_idx++);
+        const uint32_t dst_bank_base = get_arg_val<uint32_t>(arg_idx++);
+        const uint32_t num_transfers = get_arg_val<uint32_t>(arg_idx++);
+
+        for (uint32_t t = 0; t < num_transfers; t++) {
+            const uint32_t src_bank_id = get_arg_val<uint32_t>(arg_idx++);
+            uint32_t src_bank_addr = get_arg_val<uint32_t>(arg_idx++);  // bank_base + intra_shard_offset
+            uint32_t dst_offset = get_arg_val<uint32_t>(arg_idx++);
+            const uint32_t copy_size = get_arg_val<uint32_t>(arg_idx++);
+            const uint32_t src_stride = get_arg_val<uint32_t>(arg_idx++);
+            const uint32_t dst_stride = get_arg_val<uint32_t>(arg_idx++);
+            const uint32_t num_rows = get_arg_val<uint32_t>(arg_idx++);
+
+            for (uint32_t row = 0; row < num_rows; row++) {
+                // Read tile-sized chunk from DRAM source into L1 scratch.
+                const uint64_t src_noc = get_noc_addr_from_bank_id<true>(src_bank_id, src_bank_addr);
+                noc_async_read(src_noc, scratch_base, copy_size);
+                noc_async_read_barrier();
+
+                // Write from L1 scratch to DRAM destination.
+                const uint64_t dst_noc = get_noc_addr_from_bank_id<true>(dst_bank_id, dst_bank_base + dst_offset);
+                noc_async_write(scratch_base, dst_noc, copy_size);
+                noc_async_write_barrier();
+
+                src_bank_addr += src_stride;
+                dst_offset += dst_stride;
+            }
+        }
+    } else {
+        // L1 mode: source is an L1 shard on another core, destination is this core's L1.
+        CircularBuffer output_cb(output_cb_id);
+        const uint32_t dst_base = output_cb.get_write_ptr();
+        const uint32_t num_transfers = get_arg_val<uint32_t>(arg_idx++);
+
+        for (uint32_t t = 0; t < num_transfers; t++) {
+            const uint32_t src_noc_x = get_arg_val<uint32_t>(arg_idx++);
+            const uint32_t src_noc_y = get_arg_val<uint32_t>(arg_idx++);
+            const uint32_t src_cb_id = get_arg_val<uint32_t>(arg_idx++);
+            uint32_t src_l1_offset = get_arg_val<uint32_t>(arg_idx++);
+            uint32_t dst_offset = get_arg_val<uint32_t>(arg_idx++);
+            const uint32_t copy_size = get_arg_val<uint32_t>(arg_idx++);
+            const uint32_t src_stride = get_arg_val<uint32_t>(arg_idx++);
+            const uint32_t dst_stride = get_arg_val<uint32_t>(arg_idx++);
+            const uint32_t num_rows = get_arg_val<uint32_t>(arg_idx++);
+
+            CircularBuffer src_cb(src_cb_id);
+            const uint32_t src_cb_base = src_cb.get_read_ptr();
+
+            // Double-buffered pipeline: prefetch row+1 while copying row.
+            auto issue_read = [&](uint32_t off, uint32_t half_base) -> uint32_t {
+                const uint32_t pre_pad = off & (alignment - 1);
+                uint32_t read_size = pre_pad + copy_size;
+                read_size = (read_size + alignment - 1) & ~(alignment - 1);
+                const uint64_t noc_addr = get_noc_addr(src_noc_x, src_noc_y, src_cb_base + (off - pre_pad));
+                noc_async_read(noc_addr, half_base, read_size);
+                return pre_pad;
+            };
+
+            uint32_t buf = 0;
+            uint32_t pre = issue_read(src_l1_offset, scratch_base);
+            noc_async_read_barrier();
+            for (uint32_t row = 0; row < num_rows; row++) {
+                const uint32_t cur_half = scratch_base + buf * scratch_half;
+                const bool has_next = (row + 1) < num_rows;
+                const uint32_t next_buf = buf ^ 1u;
+                uint32_t next_pre = 0;
+                if (has_next) {
+                    next_pre = issue_read(src_l1_offset + src_stride, scratch_base + next_buf * scratch_half);
+                }
+                local_copy(cur_half + pre, dst_base + dst_offset, copy_size);
+                if (has_next) {
+                    noc_async_read_barrier();
+                }
+                src_l1_offset += src_stride;
+                dst_offset += dst_stride;
+                pre = next_pre;
+                buf = next_buf;
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_device_operation.cpp
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "roll_device_operation.hpp"
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/data_movement/common/common.hpp"
+
+namespace ttnn::prim {
+
+RollDeviceOperation::program_factory_t RollDeviceOperation::select_program_factory(
+    const operation_attributes_t&, const tensor_args_t&) {
+    return RollShardedProgramFactory{};
+}
+
+namespace {
+
+void validate_roll(const RollParams& operation_attributes, const RollInputs& tensor_args) {
+    const Tensor& input = tensor_args.input;
+    TT_FATAL(input.storage_type() == tt::tt_metal::StorageType::DEVICE, "Operands to roll need to be on device!");
+    TT_FATAL(input.buffer() != nullptr, "Operands need to be allocated in buffers on device!");
+    TT_FATAL(input.is_sharded(), "Native sharded roll requires a sharded input");
+    TT_FATAL(operation_attributes.output_mem_config.is_sharded(), "Native sharded roll requires a sharded output");
+    // The program factory enumerates a single rectangular grid row-major; a multi-range grid
+    // would map cells to the wrong cores.
+    TT_FATAL(
+        input.shard_spec().value().grid.ranges().size() == 1,
+        "Native sharded roll requires a single contiguous rectangular CoreRange");
+}
+
+}  // namespace
+
+void RollDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    validate_roll(operation_attributes, tensor_args);
+}
+
+void RollDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    validate_roll(operation_attributes, tensor_args);
+}
+
+ttsl::hash::hash_t RollDeviceOperation::compute_program_hash(
+    const operation_attributes_t& attrs, const tensor_args_t& args) {
+    return tt::tt_metal::operation::hash_operation<RollDeviceOperation>(
+        attrs.shift, attrs.dim, args.input.memory_config(), args.input.dtype(), args.input.layout());
+}
+
+RollDeviceOperation::spec_return_value_t RollDeviceOperation::compute_output_specs(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& input = tensor_args.input;
+    // Roll preserves shape and the input's sharded layout.
+    return TensorSpec(
+        input.logical_shape(),
+        tt::tt_metal::TensorLayout(
+            input.dtype(), tt::tt_metal::PageConfig(input.layout()), operation_attributes.output_mem_config));
+}
+
+RollDeviceOperation::tensor_return_value_t RollDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
+}
+
+tt::tt_metal::operation::OpPerformanceModelGeneral<Tensor> RollDeviceOperation::create_op_performance_model(
+    const operation_attributes_t&, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensor) {
+    const auto& input_tensor = tensor_args.input;
+    int ideal_dev_clock_cycles = operations::data_movement::common_tm_bw_model(input_tensor, output_tensor);
+    return tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t>(
+        {input_tensor}, output_tensor, ideal_dev_clock_cycles);
+}
+
+RollDeviceOperation::tensor_return_value_t roll_sharded(
+    const Tensor& input, uint32_t shift, int32_t dim, const tt::tt_metal::MemoryConfig& output_mem_config) {
+    using OperationType = RollDeviceOperation;
+    return ttnn::device_operation::launch<OperationType>(
+        OperationType::operation_attributes_t{.shift = shift, .dim = dim, .output_mem_config = output_mem_config},
+        OperationType::tensor_args_t{.input = input});
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_device_operation.hpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <variant>
+
+#include "ttnn/operation.hpp"
+#include "ttnn/operations/data_movement/roll/device/roll_device_operation_types.hpp"
+#include "ttnn/operations/data_movement/roll/device/roll_program_factory.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::prim {
+
+struct RollDeviceOperation {
+    using operation_attributes_t = RollParams;
+    using tensor_args_t = RollInputs;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
+    using program_factory_t = std::variant<RollShardedProgramFactory>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
+        const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
+};
+
+// Single-dim native sharded roll. shift is normalized to [0, dim_size); dim is absolute.
+RollDeviceOperation::tensor_return_value_t roll_sharded(
+    const Tensor& input, uint32_t shift, int32_t dim, const tt::tt_metal::MemoryConfig& output_mem_config);
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_device_operation_types.hpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::prim {
+
+// Single-dimension native sharded roll. The composite wrapper (roll.cpp) loops over dims,
+// feeding each sharded result into the next, so the device op only handles one (shift, dim).
+struct RollParams {
+    uint32_t shift{};  // normalized to [0, dim_size)
+    int32_t dim{};     // absolute (non-negative) dim index
+    tt::tt_metal::MemoryConfig output_mem_config;
+};
+
+struct RollInputs {
+    Tensor input;
+};
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_program_factory.cpp
@@ -1,0 +1,473 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "roll_program_factory.hpp"
+
+#include <algorithm>
+#include <vector>
+
+#include "ttnn/tensor/tensor.hpp"
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/hal.hpp>
+
+// Why ROW_MAJOR sharded roll needs a dedicated kernel instead of the slice + concat composite
+// used for interleaved roll:
+//
+//   * slice cuts a tensor into two unequal halves (e.g. widths W-shift and shift). Re-sharding
+//     those odd-shaped halves with the original shard spec produces invalid shards — the shard
+//     dims no longer divide the sliced shape ("page size must equal buffer size").
+//   * concat's sharded program factories only accept specific (axis, layout) pairs (width concat
+//     on height/block-sharded, height concat on width/block-sharded, ...). The slice→concat
+//     decomposition of an arbitrary roll does not fit those combinations across HEIGHT/WIDTH/
+//     BLOCK sharding and every dim.
+//
+// So a roll on a sharded tensor cannot be expressed as composite slice + concat for the general
+// case. This factory instead performs the roll as a single per-core gather directly over the
+// sharded buffers: it stays in one shard spec (no intermediate slices) and is not bound by
+// slice's or concat's sharded constraints.
+
+namespace ttnn::prim {
+
+using namespace tt::tt_metal;
+
+namespace {
+
+struct RollTransferDesc {
+    // L1 mode: source identified by (src_physical_core, src_l1_offset).
+    // DRAM mode: source identified by (src_dram_shard_idx, src_l1_offset used as intra-shard offset).
+    CoreCoord src_physical_core;  // L1 mode only; zeroed in DRAM mode
+    uint32_t src_dram_shard_idx;  // DRAM mode only; the linear shard index of the source
+    uint32_t src_l1_offset;
+    uint32_t dst_offset;
+    uint32_t copy_size;
+    uint32_t src_stride;
+    uint32_t dst_stride;
+    uint32_t num_rows;
+};
+
+// A contiguous cell-column run: dst cells [dst_col, dst_col+len) <- src cells [src_col, ...).
+// The same column structure repeats for every cell-row, so it is computed once.
+struct ColPiece {
+    uint32_t dst_col;
+    uint32_t src_col;
+    uint32_t len;
+};
+
+}  // namespace
+
+ProgramDescriptor RollShardedProgramFactory::create_descriptor(
+    const RollParams& operation_attributes, const RollInputs& tensor_args, Tensor& tensor_return_value) {
+    const Tensor& input = tensor_args.input;
+    Tensor& output = tensor_return_value;
+
+    TT_FATAL(input.is_sharded() && output.is_sharded(), "Native sharded roll requires sharded input and output");
+
+    const bool is_dram = input.memory_config().buffer_type() == BufferType::DRAM;
+    const bool is_dram_rm = is_dram && input.layout() == Layout::ROW_MAJOR;
+    // DRAM-RM mode uses full-shard L1 staging: read whole source shard(s) from DRAM into L1,
+    // assemble the rolled result in L1 via element-level local copies (no DRAM alignment
+    // constraint on L1 ops), then write the complete shard from L1 back to DRAM.
+    // This avoids the NOC DRAM write alignment problem (32-byte minimum) that would arise
+    // from per-row/per-element NOC writes. The write is always one full shard = shard_size
+    // bytes, which we validate is 32-byte aligned below.
+    if (is_dram_rm) {
+        const uint32_t shard_size_check =
+            (input.shard_spec().value().shape[0] * tt::tt_metal::hal::get_l1_alignment() *
+             ((input.shard_spec().value().shape[1] * input.element_size() + tt::tt_metal::hal::get_l1_alignment() - 1) /
+              tt::tt_metal::hal::get_l1_alignment()));
+        TT_FATAL(
+            shard_size_check % 32 == 0,
+            "DRAM-sharded RM roll requires shard_size ({} bytes) to be 32-byte aligned for NOC DRAM writes. "
+            "Adjust shard dimensions so shard_h × align_up(shard_w × elem_size, 16) is a multiple of 32.",
+            shard_size_check);
+    }
+
+    const auto& shape = input.padded_shape();
+    const uint32_t rank = shape.rank();
+    const uint32_t shift = operation_attributes.shift;
+    const int32_t dim = operation_attributes.dim;
+    const bool is_last_dim = (static_cast<uint32_t>(dim) == rank - 1);
+
+    // The gather works in "cells": a cell is one element for ROW_MAJOR, one tile for TILE.
+    // Tile cells are contiguous in L1 and naturally aligned, so a tile-aligned roll is just a
+    // permutation/rotation of whole tiles — identical to the row-major element gather.
+    const bool is_tile = input.layout() == Layout::TILE;
+    const tt::DataFormat cb_data_format = datatype_to_dataformat_converter(output.dtype());
+    const uint32_t cell_h = is_tile ? tt::constants::TILE_HEIGHT : 1;
+    const uint32_t cell_w = is_tile ? tt::constants::TILE_WIDTH : 1;
+    const uint32_t cell_size = is_tile ? tt::tile_size(cb_data_format) : input.element_size();
+
+    // Tile-aligned shift is required along the last two dims when tilized.
+    if (is_tile) {
+        if (is_last_dim) {
+            TT_FATAL(shift % cell_w == 0, "Native tilized roll on the width dim requires a tile-aligned shift");
+        } else if (static_cast<uint32_t>(dim) == rank - 2) {
+            TT_FATAL(shift % cell_h == 0, "Native tilized roll on the height dim requires a tile-aligned shift");
+        }
+    }
+
+    const uint32_t W_cells = shape[rank - 1] / cell_w;
+
+    const auto& out_ss = output.shard_spec().value();
+    const auto& in_ss = input.shard_spec().value();
+    const uint32_t shard_cells_h = out_ss.shape[0] / cell_h;
+    const uint32_t shard_cells_w = out_ss.shape[1] / cell_w;
+    TT_FATAL(
+        in_ss.shape[0] == out_ss.shape[0] && in_ss.shape[1] == out_ss.shape[1],
+        "Native sharded roll expects identical input/output shard shapes");
+    TT_FATAL(W_cells % shard_cells_w == 0, "Shard width must evenly divide the tensor");
+
+    // Cell-row dim sizes (dims 0..rank-2 collapsed): the height dim is measured in tile-rows.
+    std::vector<uint32_t> rd(rank, 1);
+    uint32_t H_cells = 1;
+    for (uint32_t i = 0; i + 1 < rank; i++) {
+        rd[i] = (i == rank - 2) ? shape[i] / cell_h : shape[i];
+        H_cells *= rd[i];
+    }
+    TT_FATAL(H_cells % shard_cells_h == 0, "Shard height must evenly divide the tensor");
+
+    auto* device = input.device();
+
+    // Support both ROW_MAJOR and COL_MAJOR shard orientations.
+    // ROW_MAJOR: tensor height → grid y-axis, tensor width → grid x-axis.
+    // COL_MAJOR: tensor height → grid x-axis, tensor width → grid y-axis.
+    // This mirrors the pattern in concat_block_sharded_program_factory.cpp lines 63–66.
+    const bool row_major_orient = out_ss.orientation == ShardOrientation::ROW_MAJOR;
+    TT_FATAL(
+        out_ss.grid.ranges().size() == 1, "Native sharded roll requires a single contiguous rectangular CoreRange");
+    const auto& grid_range = *out_ss.grid.ranges().begin();
+    const uint32_t grid_cols = grid_range.end_coord.x - grid_range.start_coord.x + 1;
+    const uint32_t grid_rows = grid_range.end_coord.y - grid_range.start_coord.y + 1;
+
+    // Number of shard positions in the tensor width direction (used in shard_linear).
+    const uint32_t n_shard_cols = W_cells / shard_cells_w;
+
+    // Pre-compute physical core map indexed by [gy][gx]. Cores enumerated y-outer, x-inner.
+    std::vector<std::vector<CoreCoord>> physical_cores(grid_rows, std::vector<CoreCoord>(grid_cols));
+    for (uint32_t gy = 0; gy < grid_rows; gy++) {
+        for (uint32_t gx = 0; gx < grid_cols; gx++) {
+            physical_cores[gy][gx] = device->worker_core_from_logical_core(
+                CoreCoord(grid_range.start_coord.x + gx, grid_range.start_coord.y + gy));
+        }
+    }
+
+    // shard_linear maps (cell_row, cell_col) → core enumeration index c.
+    // The core enumeration is y-outer, x-inner, so c = gy * grid_cols + gx.
+    // ROW_MAJOR: shard (sr,sc) → (gy=sr, gx=sc) → c = sr*n_shard_cols + sc.
+    // COL_MAJOR: shard (sr,sc) → (gx=sr, gy=sc) → c = sc*grid_cols + sr.
+    auto shard_linear = [&](uint32_t row, uint32_t col) -> uint32_t {
+        const uint32_t sr = row / shard_cells_h;
+        const uint32_t sc = col / shard_cells_w;
+        return row_major_orient ? sr * n_shard_cols + sc : sc * grid_cols + sr;
+    };
+
+    const uint32_t num_cores = grid_rows * grid_cols;
+
+    const uint32_t l1_alignment = tt::tt_metal::hal::get_l1_alignment();
+    // Sharded buffers store one shard cell-row per page, padded up to the L1 alignment.
+    const uint32_t row_pitch_bytes = ((shard_cells_w * cell_size + l1_alignment - 1) / l1_alignment) * l1_alignment;
+
+    auto local_offset = [&](uint32_t row, uint32_t col) {
+        const uint32_t local_r = row % shard_cells_h;
+        const uint32_t local_c = col % shard_cells_w;
+        return local_r * row_pitch_bytes + local_c * cell_size;
+    };
+
+    // Strides over the cell-row dims (all dims except the last), row-major, for higher-dim rolls.
+    std::vector<uint32_t> row_stride(rank, 0);
+    if (!is_last_dim) {
+        uint32_t s = 1;
+        for (int32_t k = static_cast<int32_t>(rank) - 2; k >= 0; k--) {
+            row_stride[k] = s;
+            s *= rd[k];
+        }
+    }
+    // Coordinate shift for the rolled dim, in cell-row units (tile-rows for the height dim).
+    const uint32_t dim_size_cells = (static_cast<uint32_t>(dim) == rank - 2) ? rd[dim] : shape[dim];
+    const uint32_t shift_cells = (static_cast<uint32_t>(dim) == rank - 2) ? shift / cell_h : shift;
+
+    auto rolled_src_row = [&](uint32_t r) -> uint32_t {
+        // Decrement the dim-th coordinate by shift (mod dim_size); other coords unchanged.
+        const uint32_t coord_d = (r / row_stride[dim]) % dim_size_cells;
+        const uint32_t src_coord_d = (coord_d + dim_size_cells - (shift_cells % dim_size_cells)) % dim_size_cells;
+        return r + (src_coord_d - coord_d) * row_stride[dim];
+    };
+
+    // --- Column-piece structure (identical for every cell-row) ---
+    // Last-dim roll rotates columns within a row; higher-dim rolls keep columns identity.
+    auto split_into_pieces = [&](uint32_t dst_col0, uint32_t src_col0, uint32_t len, std::vector<ColPiece>& out) {
+        uint32_t done = 0;
+        while (done < len) {
+            const uint32_t dcol = dst_col0 + done;
+            const uint32_t scol = src_col0 + done;
+            const uint32_t dst_boundary = (dcol / shard_cells_w + 1) * shard_cells_w;
+            const uint32_t src_boundary = (scol / shard_cells_w + 1) * shard_cells_w;
+            const uint32_t piece = std::min({len - done, dst_boundary - dcol, src_boundary - scol});
+            out.push_back(ColPiece{.dst_col = dcol, .src_col = scol, .len = piece});
+            done += piece;
+        }
+    };
+
+    std::vector<ColPiece> col_pieces;
+    if (is_last_dim) {
+        const uint32_t s = (shift / cell_w) % W_cells;
+        if (s > 0) {
+            split_into_pieces(0, W_cells - s, s, col_pieces);  // out[:, 0:s)   <- in[:, W-s:W)
+        }
+        split_into_pieces(s, 0, W_cells - s, col_pieces);  // out[:, s:W)   <- in[:, 0:W-s)
+    } else {
+        split_into_pieces(0, 0, W_cells, col_pieces);  // identity columns, permuted rows
+    }
+
+    // --- Build transfers, coalescing consecutive cell-rows into strided runs ---
+    std::vector<std::vector<RollTransferDesc>> all_transfers(num_cores);
+
+    for (const auto& p : col_pieces) {
+        const uint32_t copy_bytes = p.len * cell_size;
+        bool have_run = false;
+        uint32_t run_dst_core = 0, run_src_core = 0;
+        uint32_t run_src_off = 0, run_dst_off = 0, run_num = 0;
+        auto flush = [&]() {
+            if (!have_run) {
+                return;
+            }
+            all_transfers[run_dst_core].push_back(RollTransferDesc{
+                .src_physical_core = physical_cores[run_src_core / grid_cols][run_src_core % grid_cols],
+                .src_dram_shard_idx = run_src_core,
+                .src_l1_offset = run_src_off,
+                .dst_offset = run_dst_off,
+                .copy_size = copy_bytes,
+                .src_stride = row_pitch_bytes,
+                .dst_stride = row_pitch_bytes,
+                .num_rows = run_num,
+            });
+            have_run = false;
+        };
+        for (uint32_t r = 0; r < H_cells; r++) {
+            const uint32_t src_row = is_last_dim ? r : rolled_src_row(r);
+            const uint32_t dst_core = shard_linear(r, p.dst_col);
+            const uint32_t src_core = shard_linear(src_row, p.src_col);
+            const uint32_t src_off = local_offset(src_row, p.src_col);
+            const uint32_t dst_off = local_offset(r, p.dst_col);
+            // Extend the run only if cores match and both offsets advance by exactly one pitch.
+            if (have_run && dst_core == run_dst_core && src_core == run_src_core &&
+                dst_off == run_dst_off + run_num * row_pitch_bytes &&
+                src_off == run_src_off + run_num * row_pitch_bytes) {
+                run_num++;
+            } else {
+                flush();
+                have_run = true;
+                run_dst_core = dst_core;
+                run_src_core = src_core;
+                run_src_off = src_off;
+                run_dst_off = dst_off;
+                run_num = 1;
+            }
+        }
+        flush();
+    }
+
+    // --- Circular buffers ---
+    // L1 mode: cb0 backed by input buffer, cb16 backed by output buffer, cb1 scratch.
+    // DRAM mode: only the scratch cb1 is allocated in L1. Input/output CBs are not used
+    // because DRAM data is addressed via bank IDs in the runtime args, not CB read ptrs.
+    constexpr uint32_t input_cb_id = 0;
+    constexpr uint32_t output_cb_id = 16;
+    constexpr uint32_t scratch_cb_id = 1;
+    const uint32_t cb_page_size = is_tile ? cell_size : row_pitch_bytes;
+
+    ProgramDescriptor desc;
+    const uint32_t shard_l1_size = shard_cells_h * row_pitch_bytes;
+    if (!is_dram) {
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = shard_l1_size,
+            .core_ranges = out_ss.grid,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(input_cb_id),
+                .data_format = cb_data_format,
+                .page_size = cb_page_size,
+            }}},
+            .buffer = input.buffer(),
+        });
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = shard_l1_size,
+            .core_ranges = out_ss.grid,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(output_cb_id),
+                .data_format = cb_data_format,
+                .page_size = cb_page_size,
+            }}},
+            .buffer = output.buffer(),
+        });
+    }
+    // Scratch CB: L1 mode uses it double-buffered; DRAM TILE uses it single-buffered.
+    // DRAM RM allocates separate staging CBs (2/3/4) instead, so scratch is L1-only.
+    const uint32_t scratch_half = row_pitch_bytes + 2 * l1_alignment;
+    const uint32_t scratch_size = (is_dram && !is_dram_rm) ? shard_l1_size : 2 * scratch_half;
+    if (!is_dram_rm) {
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = scratch_size,
+            .core_ranges = out_ss.grid,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(scratch_cb_id),
+                .data_format = cb_data_format,
+                .page_size = scratch_size,
+            }}},
+        });
+    }
+
+    // DRAM RM staging CBs: two source slots + one destination, each = full shard size.
+    constexpr uint32_t dram_rm_src0_cb_id = 2;
+    constexpr uint32_t dram_rm_src1_cb_id = 3;
+    constexpr uint32_t dram_rm_dst_cb_id = 4;
+    if (is_dram_rm) {
+        for (uint8_t cb_id : {dram_rm_src0_cb_id, dram_rm_src1_cb_id, dram_rm_dst_cb_id}) {
+            desc.cbs.push_back(CBDescriptor{
+                .total_size = shard_l1_size,
+                .core_ranges = out_ss.grid,
+                .format_descriptors = {{CBFormatDescriptor{
+                    .buffer_index = cb_id,
+                    .data_format = cb_data_format,
+                    .page_size = shard_l1_size,
+                }}},
+            });
+        }
+    }
+
+    // --- DRAM shard address helpers ---
+    const uint32_t num_dram_banks = device->num_dram_channels();
+    const uint32_t dram_shard_size = shard_cells_h * row_pitch_bytes;
+    auto dram_bank_id = [&](uint32_t shard_idx) { return shard_idx % num_dram_banks; };
+    auto dram_bank_base = [&](const Buffer* buf, uint32_t shard_idx) {
+        return static_cast<uint32_t>(buf->address()) + (shard_idx / num_dram_banks) * dram_shard_size;
+    };
+
+    // --- Kernel ---
+    uint32_t max_num_transfers = 0;
+    for (const auto& t : all_transfers) {
+        max_num_transfers = std::max(max_num_transfers, static_cast<uint32_t>(t.size()));
+    }
+    constexpr uint32_t runtime_args_limit = 256;
+    // L1 mode:       1 + 9*N args.
+    // DRAM TILE:     3 + 7*N args (dst_bank_id, dst_bank_base, count, then 7 per transfer).
+    // DRAM RM:       3 + max_4_src_info + 1 + 7*N args (dst, num_src≤2, src0, src1?, count, 7*N).
+    //                worst case: 3 + 4 + 1 + 7*N = 8 + 7*N.
+    const uint32_t args_per_transfer = is_dram_rm ? 7u : (is_dram ? 7u : 9u);
+    const uint32_t args_overhead = is_dram_rm ? 8u : (is_dram ? 3u : 1u);
+    TT_FATAL(
+        args_overhead + max_num_transfers * args_per_transfer <= runtime_args_limit,
+        "Native sharded roll: too many copy segments per core ({}). Reduce grid/shape.",
+        max_num_transfers);
+
+    // mode: 0=L1, 1=DRAM_TILE, 2=DRAM_RM
+    const uint32_t mode = is_dram_rm ? 2u : (is_dram ? 1u : 0u);
+    const std::vector<uint32_t> compile_time_args = {
+        output_cb_id,
+        scratch_cb_id,
+        l1_alignment,
+        scratch_half,
+        mode,
+        shard_l1_size,
+        dram_rm_src0_cb_id,
+        dram_rm_src1_cb_id,
+        dram_rm_dst_cb_id};
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/roll/device/kernels/dataflow/roll_sharded_reader.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = out_ss.grid;
+    reader_desc.compile_time_args = compile_time_args;
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    auto build_runtime_args_l1 = [&](const std::vector<RollTransferDesc>& descs) {
+        KernelDescriptor::CoreRuntimeArgs args;
+        args.reserve(1 + descs.size() * 9);
+        args.push_back(static_cast<uint32_t>(descs.size()));
+        for (const auto& td : descs) {
+            args.push_back(td.src_physical_core.x);
+            args.push_back(td.src_physical_core.y);
+            args.push_back(input_cb_id);
+            args.push_back(td.src_l1_offset);
+            args.push_back(td.dst_offset);
+            args.push_back(td.copy_size);
+            args.push_back(td.src_stride);
+            args.push_back(td.dst_stride);
+            args.push_back(td.num_rows);
+        }
+        return args;
+    };
+
+    auto build_runtime_args_dram = [&](uint32_t dst_core_idx, const std::vector<RollTransferDesc>& descs) {
+        KernelDescriptor::CoreRuntimeArgs args;
+        args.reserve(3 + descs.size() * 7);
+        args.push_back(dram_bank_id(dst_core_idx));
+        args.push_back(dram_bank_base(output.buffer(), dst_core_idx));
+        args.push_back(static_cast<uint32_t>(descs.size()));
+        for (const auto& td : descs) {
+            // src_bank_id, src_bank_addr (= bank_base + intra_shard_offset), dst_offset,
+            // copy_size, src_stride, dst_stride, num_rows
+            args.push_back(dram_bank_id(td.src_dram_shard_idx));
+            args.push_back(dram_bank_base(input.buffer(), td.src_dram_shard_idx) + td.src_l1_offset);
+            args.push_back(td.dst_offset);
+            args.push_back(td.copy_size);
+            args.push_back(td.src_stride);
+            args.push_back(td.dst_stride);
+            args.push_back(td.num_rows);
+        }
+        return args;
+    };
+
+    // DRAM RM mode: full-shard L1 staging.
+    // Per core: [dst_bank_id, dst_bank_base, num_src, (src0_bank_id, src0_addr)..., num_xfers,
+    //            (src_slot, src_off, dst_off, copy_size, src_stride, dst_stride, num_rows) x N]
+    auto build_runtime_args_dram_rm = [&](uint32_t dst_core_idx, const std::vector<RollTransferDesc>& descs) {
+        // Collect unique source shards (at most 2) and assign them to staging slots 0/1.
+        std::vector<uint32_t> src_shards;
+        std::unordered_map<uint32_t, uint32_t> src_to_slot;
+        for (const auto& td : descs) {
+            if (!src_to_slot.contains(td.src_dram_shard_idx)) {
+                src_to_slot[td.src_dram_shard_idx] = static_cast<uint32_t>(src_shards.size());
+                src_shards.push_back(td.src_dram_shard_idx);
+            }
+        }
+        KernelDescriptor::CoreRuntimeArgs args;
+        args.push_back(dram_bank_id(dst_core_idx));
+        args.push_back(dram_bank_base(output.buffer(), dst_core_idx));
+        args.push_back(static_cast<uint32_t>(src_shards.size()));
+        for (uint32_t s : src_shards) {
+            args.push_back(dram_bank_id(s));
+            args.push_back(dram_bank_base(input.buffer(), s));
+        }
+        args.push_back(static_cast<uint32_t>(descs.size()));
+        for (const auto& td : descs) {
+            args.push_back(src_to_slot.at(td.src_dram_shard_idx));
+            args.push_back(td.src_l1_offset);
+            args.push_back(td.dst_offset);
+            args.push_back(td.copy_size);
+            args.push_back(td.src_stride);
+            args.push_back(td.dst_stride);
+            args.push_back(td.num_rows);
+        }
+        return args;
+    };
+
+    for (uint32_t c = 0; c < num_cores; c++) {
+        CoreCoord logical(grid_range.start_coord.x + c % grid_cols, grid_range.start_coord.y + c / grid_cols);
+        KernelDescriptor::CoreRuntimeArgs args;
+        if (is_dram_rm) {
+            args = build_runtime_args_dram_rm(c, all_transfers[c]);
+        } else if (is_dram) {
+            args = build_runtime_args_dram(c, all_transfers[c]);
+        } else {
+            args = build_runtime_args_l1(all_transfers[c]);
+        }
+        reader_desc.runtime_args.emplace_back(logical, std::move(args));
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    return desc;
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_program_factory.cpp
@@ -72,15 +72,23 @@ ProgramDescriptor RollShardedProgramFactory::create_descriptor(
     // from per-row/per-element NOC writes. The write is always one full shard = shard_size
     // bytes, which we validate is 32-byte aligned below.
     if (is_dram_rm) {
+        // Each shard cell-row is a buffer page padded up to the backing memory's alignment.
+        // For DRAM this is the DRAM alignment (64B on Blackhole, 32B on Wormhole), NOT the L1
+        // alignment — using the wrong alignment here desyncs the staged layout from the actual
+        // in-DRAM layout and corrupts the gather.
+        const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
         const uint32_t shard_size_check =
-            (input.shard_spec().value().shape[0] * tt::tt_metal::hal::get_l1_alignment() *
-             ((input.shard_spec().value().shape[1] * input.element_size() + tt::tt_metal::hal::get_l1_alignment() - 1) /
-              tt::tt_metal::hal::get_l1_alignment()));
+            (input.shard_spec().value().shape[0] *
+             ((input.shard_spec().value().shape[1] * input.element_size() + dram_alignment - 1) / dram_alignment) *
+             dram_alignment);
         TT_FATAL(
-            shard_size_check % 32 == 0,
-            "DRAM-sharded RM roll requires shard_size ({} bytes) to be 32-byte aligned for NOC DRAM writes. "
-            "Adjust shard dimensions so shard_h × align_up(shard_w × elem_size, 16) is a multiple of 32.",
-            shard_size_check);
+            shard_size_check % dram_alignment == 0,
+            "DRAM-sharded RM roll requires shard_size ({} bytes) to be {}-byte aligned for NOC DRAM writes. "
+            "Adjust shard dimensions so shard_h × align_up(shard_w × elem_size, {}) is a multiple of {}.",
+            shard_size_check,
+            dram_alignment,
+            dram_alignment,
+            dram_alignment);
     }
 
     const auto& shape = input.padded_shape();
@@ -165,8 +173,13 @@ ProgramDescriptor RollShardedProgramFactory::create_descriptor(
     const uint32_t num_cores = grid_rows * grid_cols;
 
     const uint32_t l1_alignment = tt::tt_metal::hal::get_l1_alignment();
-    // Sharded buffers store one shard cell-row per page, padded up to the L1 alignment.
-    const uint32_t row_pitch_bytes = ((shard_cells_w * cell_size + l1_alignment - 1) / l1_alignment) * l1_alignment;
+    // Sharded buffers store one shard cell-row per page, padded up to the backing memory's
+    // alignment. DRAM pages use the (larger) DRAM alignment — 64B on Blackhole, 32B on Wormhole —
+    // whereas L1 pages use the L1 alignment. The row pitch must match whichever memory actually
+    // holds the data, otherwise the staged copy and the host-computed offsets disagree.
+    const uint32_t page_alignment = is_dram ? tt::tt_metal::hal::get_dram_alignment() : l1_alignment;
+    const uint32_t row_pitch_bytes =
+        ((shard_cells_w * cell_size + page_alignment - 1) / page_alignment) * page_alignment;
 
     auto local_offset = [&](uint32_t row, uint32_t col) {
         const uint32_t local_r = row % shard_cells_h;

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_program_factory.hpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "roll_device_operation_types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace ttnn::prim {
+
+// Native single-dim roll for ROW_MAJOR sharded tensors (HEIGHT / WIDTH / BLOCK).
+// Implemented as a per-core gather of segment copies over the sharded buffers.
+struct RollShardedProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const RollParams& operation_attributes, const RollInputs& tensor_args, Tensor& tensor_return_value);
+};
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/roll.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/roll.cpp
@@ -1,18 +1,25 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #include "roll.hpp"
 #include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/core/to_memory_config/to_memory_config_op.hpp"
 #include "ttnn/operations/data_movement/slice/slice.hpp"
 #include "ttnn/operations/data_movement/concat/concat.hpp"
+#include "ttnn/operations/data_movement/tilize/tilize.hpp"
+#include "ttnn/operations/data_movement/untilize/untilize.hpp"
+#include "ttnn/operations/data_movement/roll/device/roll_device_operation.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
 
 namespace ttnn {
 
 ttnn::Tensor roll(
-    const ttnn::Tensor& input_tensor, const ttnn::SmallVector<int>& shifts, const ttnn::SmallVector<int>& input_dims) {
+    const ttnn::Tensor& input_tensor,
+    const ttnn::SmallVector<int>& shifts,
+    const ttnn::SmallVector<int>& input_dims,
+    const std::optional<MemoryConfig>& memory_config) {
     ttnn::Tensor result = input_tensor;
     auto size = result.logical_shape();
     int num_dims = size.rank();
@@ -44,6 +51,63 @@ ttnn::Tensor roll(
 
     const ttnn::SmallVector<int> stride_vector(num_dims, 1);
 
+    // Sharded inputs use the native sharded roll device op, applied one dim at a time. A
+    // tilized roll is native only when shifts on the last two dims are tile-aligned (a
+    // whole-tile permutation); otherwise untilize/roll/tilize while staying sharded.
+    const bool is_sharded = input_tensor.is_sharded();
+    const bool is_tile = input_tensor.layout() == ttnn::TILE_LAYOUT;
+    // Preserve input layout by default; caller may override with an explicit memory_config.
+    const auto& native_mem_config = input_tensor.memory_config();
+    const auto output_mem_config = memory_config.value_or(native_mem_config);
+
+    if (is_sharded) {
+        bool native_ok = true;
+        if (is_tile) {
+            constexpr int tile_dim = 32;
+            for (size_t i = 0; i < adjusted_shifts.size(); ++i) {
+                int dim = input_dims[i];
+                if (dim < 0) {
+                    dim += num_dims;
+                }
+                if ((dim == num_dims - 1 || dim == num_dims - 2) && (adjusted_shifts[i] % tile_dim) != 0) {
+                    native_ok = false;
+                    break;
+                }
+            }
+        }
+
+        if (native_ok) {
+            for (size_t i = 0; i < adjusted_shifts.size(); ++i) {
+                int dim = input_dims[i];
+                if (dim < 0) {
+                    dim += num_dims;
+                }
+                // adjusted_shifts[i] is already normalized to [0, shape[dim]).
+                const int shift = adjusted_shifts[i];
+                if (shift == 0) {
+                    continue;
+                }
+                result = ttnn::prim::roll_sharded(
+                    result, static_cast<uint32_t>(shift), static_cast<int32_t>(dim), native_mem_config);
+            }
+            // Apply requested output memory config if different from the input's.
+            if (output_mem_config != native_mem_config) {
+                result = ttnn::to_memory_config(result, output_mem_config, std::nullopt);
+            }
+            return result;
+        }
+
+        // Sub-tile rotation must move elements inside tiles: untilize, roll, tilize, all
+        // staying sharded in L1.
+        ttnn::Tensor rm = ttnn::untilize(input_tensor, native_mem_config);
+        ttnn::Tensor rolled = roll(rm, shifts, input_dims);
+        ttnn::Tensor retiled = ttnn::tilize(rolled, native_mem_config, input_tensor.dtype());
+        if (output_mem_config != native_mem_config) {
+            return ttnn::to_memory_config(retiled, output_mem_config, std::nullopt);
+        }
+        return retiled;
+    }
+
     for (size_t i = 0; i < adjusted_shifts.size(); ++i) {
         int dim = input_dims[i];
 
@@ -51,7 +115,8 @@ ttnn::Tensor roll(
             dim += num_dims;
         }
 
-        int shift = adjusted_shifts[i] % size[dim];
+        // adjusted_shifts[i] is already normalized to [0, shape[dim]).
+        const int shift = adjusted_shifts[i];
         if (shift == 0) {
             continue;
         }
@@ -75,10 +140,18 @@ ttnn::Tensor roll(
         result = ttnn::concat(tensors_to_concat, dim);
     }
 
+    if (output_mem_config != result.memory_config()) {
+        result = ttnn::to_memory_config(result, output_mem_config, std::nullopt);
+    }
     return result;
 }
 
-ttnn::Tensor roll(const ttnn::Tensor& input_tensor, const int shift) {
+ttnn::Tensor roll(const ttnn::Tensor& input_tensor, const int shift, const std::optional<MemoryConfig>& memory_config) {
+    // The flatten reshape to [1, total_elements] does not preserve sharding.
+    TT_FATAL(
+        !input_tensor.is_sharded(),
+        "ttnn::roll without dims does not support sharded inputs. Convert to interleaved first.");
+
     ttnn::SmallVector<int> shifts = {shift};
     ttnn::SmallVector<int> dims = {1};  // Rolling will happen on dimension 1 after flattening
 
@@ -93,18 +166,22 @@ ttnn::Tensor roll(const ttnn::Tensor& input_tensor, const int shift) {
     // Flatten the input tensor to shape [1, total_elements]
     ttnn::Tensor result = ttnn::reshape(input_tensor, ttnn::Shape({1, total_elements}));
 
-    result = roll(result, shifts, dims);
+    result = roll(result, shifts, dims, memory_config);
     // Reshape back to the original shape
     result = ttnn::reshape(result, ttnn::Shape(original_shape));
 
     return result;
 }
 
-ttnn::Tensor roll(const ttnn::Tensor& input_tensor, const int shift, const int dim) {
+ttnn::Tensor roll(
+    const ttnn::Tensor& input_tensor,
+    const int shift,
+    const int dim,
+    const std::optional<MemoryConfig>& memory_config) {
     ttnn::SmallVector<int> shifts = {shift};
     ttnn::SmallVector<int> dims = {dim};
 
-    return roll(input_tensor, shifts, dims);
+    return roll(input_tensor, shifts, dims, memory_config);
 }
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/roll.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/roll.hpp
@@ -7,10 +7,18 @@
 namespace ttnn {
 
 ttnn::Tensor roll(
-    const ttnn::Tensor& input_tensor, const ttnn::SmallVector<int>& shifts, const ttnn::SmallVector<int>& input_dims);
+    const ttnn::Tensor& input_tensor,
+    const ttnn::SmallVector<int>& shifts,
+    const ttnn::SmallVector<int>& input_dims,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt);
 
-ttnn::Tensor roll(const ttnn::Tensor& input_tensor, int shifts);
+ttnn::Tensor roll(
+    const ttnn::Tensor& input_tensor, int shifts, const std::optional<MemoryConfig>& memory_config = std::nullopt);
 
-ttnn::Tensor roll(const ttnn::Tensor& input_tensor, int shifts, int dim);
+ttnn::Tensor roll(
+    const ttnn::Tensor& input_tensor,
+    int shifts,
+    int dim,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/roll_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/roll_nanobind.cpp
@@ -28,20 +28,31 @@ void bind_roll(nb::module_& mod) {
         mod,
         doc,
         ttnn::overload_t(
-            nb::overload_cast<const ttnn::Tensor&, const ttnn::SmallVector<int>&, const ttnn::SmallVector<int>&>(
-                &ttnn::roll),
+            nb::overload_cast<
+                const ttnn::Tensor&,
+                const ttnn::SmallVector<int>&,
+                const ttnn::SmallVector<int>&,
+                const std::optional<MemoryConfig>&>(&ttnn::roll),
             nb::arg("input_tensor"),
             nb::arg("shifts"),
-            nb::arg("dim")),
+            nb::arg("dim"),
+            nb::kw_only(),
+            nb::arg("memory_config") = nb::none()),
 
         ttnn::overload_t(
-            nb::overload_cast<const ttnn::Tensor&, int, int>(&ttnn::roll),
+            nb::overload_cast<const ttnn::Tensor&, int, int, const std::optional<MemoryConfig>&>(&ttnn::roll),
             nb::arg("input_tensor"),
             nb::arg("shifts"),
-            nb::arg("dim")),
+            nb::arg("dim"),
+            nb::kw_only(),
+            nb::arg("memory_config") = nb::none()),
 
         ttnn::overload_t(
-            nb::overload_cast<const ttnn::Tensor&, int>(&ttnn::roll), nb::arg("input_tensor"), nb::arg("shifts")));
+            nb::overload_cast<const ttnn::Tensor&, int, const std::optional<MemoryConfig>&>(&ttnn::roll),
+            nb::arg("input_tensor"),
+            nb::arg("shifts"),
+            nb::kw_only(),
+            nb::arg("memory_config") = nb::none()));
 }
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -525,6 +525,16 @@ template ttnn::Tensor slice<int32_t>(
     const std::optional<float>& pad_value,
     const std::optional<CoreRangeSet>& sub_core_grids);
 
+template ttnn::Tensor slice<int64_t>(
+    const ttnn::Tensor& input_tensor,
+    ttsl::Span<const int64_t> begins,
+    ttsl::Span<const int64_t> ends,
+    ttsl::Span<const int64_t> step,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<float>& pad_value,
+    const std::optional<CoreRangeSet>& sub_core_grids);
+
 template ttnn::Tensor slice<uint32_t>(
     const ttnn::Tensor& input_tensor,
     ttsl::Span<const uint32_t> begins,

--- a/ttnn/cpp/ttnn/operations/data_movement/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/data_movement/sources.cmake
@@ -85,6 +85,8 @@ set(TTNN_OP_DATA_MOVEMENT_SRCS
     reshape_view/device/reshape_tiled_program_factory.cpp
     reshape_view/device/reshape_device_operation.cpp
     reshape_view/reshape.cpp
+    roll/device/roll_device_operation.cpp
+    roll/device/roll_program_factory.cpp
     roll/roll.cpp
     scatter/scatter.cpp
     scatter/tosa_scatter.cpp


### PR DESCRIPTION
### PR Category
Feature

## Ticket
[#47410](https://github.com/tenstorrent/tt-metal/issues/47410), #48420

## Problem Description

`ttnn::roll` was a pure composite op (no device kernels of its own): it decomposed every roll into `ttnn::slice` + `ttnn::concat` per rolled dim. That decomposition cannot serve sharded inputs:

- **No native sharded support**: passing the sharded memory config through `slice`/`concat` fails because the roll decomposition produces shard specs and concat axis/layout combinations those ops don't support:
  - `slice` cuts the tensor into two *unequal* halves; re-sharding the odd-shaped halves with the original shard spec yields invalid shards (`page size N must equal buffer size M`).
  - `concat`'s sharded factories only accept specific (axis, layout) pairs, which the slice→concat roll decomposition cannot satisfy across HEIGHT/WIDTH/BLOCK sharding and all dims.
- As a result, sharded roll either errored or silently fell back to incorrect behavior.

## What This PR Does

Adds a dedicated **native sharded roll device op** (`ttnn::prim::roll_sharded`) and routes the composite wrapper to it, covering every memory layout and buffer type natively — no sharded↔interleaved conversion anywhere.

---

### Native sharded roll device op (`roll/device/`)

A new `RollDeviceOperation` + `RollShardedProgramFactory` (declarative `ProgramDescriptor`) that performs roll as a **per-core gather** directly over the sharded buffers. The kernel operates in three modes selected by compile-time argument:

**Mode 0 — L1-sharded (ROW_MAJOR or tile-aligned TILE)**
Works in "cells" — one element for RM, one tile for TILE. Computes per-core segment-copy descriptors; consecutive cell-rows are coalesced into strided runs. Source segments are staged through a double-buffered scratch L1 CB (alignment-padded for RM, naturally aligned for tiles), so reads overlap copies. Local copy uses 32-bit word stores where aligned.

**Mode 1 — DRAM-sharded TILE**
Tile transfers are 2048 bytes — naturally satisfying the 32-byte DRAM NOC write alignment requirement. Each per-tile transfer is a direct NOC read from DRAM → scratch L1, then NOC write from scratch L1 → DRAM destination.

**Mode 2 — DRAM-sharded ROW_MAJOR**
RM roll produces sub-32-byte copies (as small as 2 bytes for bf16), which cannot be written atomically to DRAM via NOC. Solution: **full-shard L1 staging** — read the entire source shard(s) from DRAM into L1, assemble the rolled result in L1 via element-level local copies (no DRAM alignment constraint on L1 ops), then write the complete shard from L1 back to DRAM in one 32-byte-aligned NOC write. The factory validates `shard_size % 32 == 0`.

---

### Kernel (`roll_sharded_reader.cpp`)
- Single source file; compile-time `mode` selects L1/DRAM_TILE/DRAM_RM path.
- Modes 0 and 1 use a shared scratch L1 CB; mode 2 uses three dedicated staging CBs (src_slot_0, src_slot_1, dst_assembly).
- Uses `get_noc_addr_from_bank_id<true>()` for DRAM bank addressing (no pre-computed NOC coords needed).

---

### Wrapper routing (`roll.cpp`)
- **ROW_MAJOR sharded (L1/DRAM)** → native device op, applied one dim at a time.
- **TILE sharded, tile-aligned shifts (L1/DRAM)** → native device op (whole-tile gather, mode 0 or 1).
- **TILE sharded, non-tile-aligned shift** → sharded `untilize` → native RM roll → sharded `tilize`, all staying in L1 (no interleaved detour).
- **Interleaved** → existing slice + concat path (unchanged).
- **No-dim `roll(input, shift)`** flatten variant guards against sharded inputs (reshape cannot preserve sharding).
- Optional `memory_config` parameter added to all three overloads for explicit output layout control.

---

### Additional improvements
- **`compute_program_hash`** — hashes `shift`, `dim`, `memory_config`, `dtype`, `layout` so distinct roll calls never collide in the program cache.
- **`validate_on_program_cache_hit`** — re-validates sharded/orientation/CoreRange preconditions on cache hits.
- **COL_MAJOR shard orientation** — supported natively; the factory uses an orientation-aware `shard_linear` formula (`sr * n_shard_cols + sc` for ROW_MAJOR, `sc * grid_cols + sr` for COL_MAJOR).
- **Optional output `memory_config`** — all three Python/C++ overloads accept `memory_config=` as a keyword argument (parity with `repeat`, `concat`, `slice`).

---

### Tests (`tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_roll.py`)
- HEIGHT / WIDTH / BLOCK sharded × ROW_MAJOR (native gather)
- HEIGHT / WIDTH / BLOCK sharded × TILE tile-aligned (native whole-tile gather)
- HEIGHT / WIDTH / BLOCK sharded × TILE non-tile-aligned (sharded untilize→roll→tilize)
- DRAM-sharded × ROW_MAJOR (mode 2 full-shard staging)
- DRAM-sharded × TILE (mode 1 per-tile NOC)
- COL_MAJOR orientation
- Program-cache hash correctness (distinct shifts)
- Optional `memory_config` output (sharded → DRAM interleaved and vice versa)
- DRAM/L1 interleaved backward compatibility
- The existing `tests/ttnn/unit_tests/base_functionality/test_roll.py` regression suite also continues to pass.

## Notes for Reviewers

- The native op handles a **single dim** per launch; the wrapper loops over dims feeding each result into the next.
- Tile sub-rotation (non-tile-aligned shift on TILE layout) genuinely requires detiling to move sub-tile elements — untilize/roll/tilize while staying sharded in L1 is the correct path; no interleaved detour.
- DRAM shard address formula: `bank_id = shard_idx % num_dram_banks`, `bank_addr = buffer.address() + (shard_idx / num_dram_banks) * shard_size_bytes`.
- Single contiguous rectangular CoreRange and ROW_MAJOR shard orientation are validated before program compilation (`validate_on_program_cache_miss/hit`).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abdulla/universal_support_for_roll)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abdulla/universal_support_for_roll)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=abdulla/universal_support_for_roll)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:abdulla/universal_support_for_roll)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=abdulla/universal_support_for_roll)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:abdulla/universal_support_for_roll)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abdulla/universal_support_for_roll)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abdulla/universal_support_for_roll)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=abdulla/universal_support_for_roll)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:abdulla/universal_support_for_roll)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=abdulla/universal_support_for_roll)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abdulla/universal_support_for_roll)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=abdulla/universal_support_for_roll)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abdulla/universal_support_for_roll)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=abdulla/universal_support_for_roll)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abdulla/universal_support_for_roll)
