### PR TITLE
[tt-train] Update tiny deepseek config to fit it on a singel bh

### DIFF
--- a/tt-train/configs/training_configs/training_shakespeare_tiny_deepseek_char.yaml
+++ b/tt-train/configs/training_configs/training_shakespeare_tiny_deepseek_char.yaml
@@ -10,13 +10,14 @@ training_config:
   data_path: "data/shakespeare.txt"
   model_config: "${TT_METAL_RUNTIME_ROOT}/tt-train/configs/model_configs/moe/tiny_deepseek_char.yaml"
   optimizer:
-    type: AdamWFullPrecision
-    lr: 0.0001
-    beta1: 0.9
-    beta2: 0.999
-    epsilon: 1.0e-8
-    weight_decay: 0.01
-    amsgrad: false
+      type: AdamW
+      lr: 0.0003
+      beta1: 0.9
+      beta2: 0.999
+      epsilon: 1.0e-8
+      weight_decay: 0.01
+      amsgrad: false
+      stochastic_rounding: true
 
 device_config:
   enable_ddp: false

--- a/tt-train/configs/training_configs/training_shakespeare_tiny_deepseek_char.yaml
+++ b/tt-train/configs/training_configs/training_shakespeare_tiny_deepseek_char.yaml
@@ -10,14 +10,14 @@ training_config:
   data_path: "data/shakespeare.txt"
   model_config: "${TT_METAL_RUNTIME_ROOT}/tt-train/configs/model_configs/moe/tiny_deepseek_char.yaml"
   optimizer:
-      type: AdamW
-      lr: 0.0003
-      beta1: 0.9
-      beta2: 0.999
-      epsilon: 1.0e-8
-      weight_decay: 0.01
-      amsgrad: false
-      stochastic_rounding: true
+    type: AdamW
+    lr: 0.0003
+    beta1: 0.9
+    beta2: 0.999
+    epsilon: 1.0e-8
+    weight_decay: 0.01
+    amsgrad: false
+    stochastic_rounding: true
 
 device_config:
   enable_ddp: false


### PR DESCRIPTION

## Summary

Updates `training_shakespeare_tiny_deepseek_char.yaml` so tiny DeepSeek char-level training fits on a **single Blackhole (BH) device**.

With `AdamWFullPrecision`, training OOMs at the normal sequence length of **2048**. Even after reducing sequence length to **512**, it only barely fits on one BH (~27.6 GB DRAM peak vs ~28.5 GB available). This PR switches to **`AdamW`** with **`stochastic_rounding: true`** to cut optimizer memory while keeping reasonable numerical stability.

## Problem: `AdamWFullPrecision` does not fit on single BH

`AdamWFullPrecision` keeps **FP32 master weights and optimizer state**, which roughly doubles optimizer memory vs the default fused `AdamW` (bf16 state). For tiny DeepSeek on one BH, that overhead is too large.

Evidence from a run with `AdamWFullPrecision` at **seq_len=512** (reduced from the normal **2048**):

```
Training for 100 steps (step 0 to 100)...
  - Batch size: 4
  - Sequence length: 512
  - Training data: 1114882 samples
  - Scheduler: identity
  - Gradient accumulation steps: 1
  - Dropout: 0.0
  - Gradient clipping: max_norm=1.0

  - Mesh peak: 148.5 TFLOPS (bf16, 1 devices)
  - Available Device Memory: 28,520.96 MB

=== Memory Usage Summary ===

--- MODEL_CREATION ---
  DRAM: Segment Peak 3352.74 MB, Allocations 6698.00 MB, Deallocations 3346.94 MB, Segment Change +3351.06 MB
  DRAM: Cumulative Peak 3352.74 MB, Cumulative Current 3351.06 MB
  L1: Peak CB 0.09 MB, Peak Buffer 0.00 MB, Peak Total 0.09 MB
--- OPTIMIZER_CREATION ---
  DRAM: Segment Peak 20104.50 MB, Allocations 20104.50 MB, Deallocations 0.00 MB, Segment Change +20104.50 MB
  DRAM: Cumulative Peak 23455.56 MB, Cumulative Current 23455.56 MB
  L1: Peak CB 0.01 MB, Peak Buffer 0.00 MB, Peak Total 0.01 MB
--- FORWARD_PASS ---
  DRAM: Segment Peak 242.42 MB, Allocations 16886.25 MB, Deallocations 16764.86 MB, Segment Change +121.39 MB
  DRAM: Cumulative Peak 23697.98 MB, Cumulative Current 23576.95 MB
  L1: Peak CB 0.79 MB, Peak Buffer 0.00 MB, Peak Total 0.79 MB
--- BACKWARD_PASS ---
  DRAM: Segment Peak 3988.68 MB, Allocations 43106.17 MB, Deallocations 39849.56 MB, Segment Change +3256.61 MB
  DRAM: Cumulative Peak 27565.63 MB, Cumulative Current 26833.56 MB
  L1: Peak CB 0.87 MB, Peak Buffer 0.00 MB, Peak Total 0.87 MB
--- FIRST_ITERATION_COMPLETE ---
  DRAM: Segment Peak 9.56 MB, Allocations 3355.12 MB, Deallocations 3358.24 MB, Segment Change -3.12 MB
  DRAM: Cumulative Peak 27565.63 MB, Cumulative Current 26830.44 MB
  L1: Peak CB 0.08 MB, Peak Buffer 0.00 MB, Peak Total 0.08 MB

=== Final Totals ===
Overall DRAM Peak: 27565.63 MB, Final DRAM Usage: 26830.44 MB
```

Optimizer creation alone uses **~20 GB**. Total DRAM peak (**27,566 MB**) is within ~1 GB of available device memory (**28,521 MB**) — and only after cutting sequence length to **512**. At the intended **2048** sequence length, training does not fit.

## Changes

- `optimizer.type`: `AdamWFullPrecision` → `AdamW`
- `optimizer.stochastic_rounding`: `true` (new)
- `optimizer.lr`: `0.0001` → `0.0003`
- `device_config.mesh_shape` remains `[1, 1]` (single device)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lgalasTT/update_training_tiny_deepseek_on_bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lgalasTT/update_training_tiny_deepseek_on_bh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lgalasTT/update_training_tiny_deepseek_on_bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lgalasTT/update_training_tiny_deepseek_on_bh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=lgalasTT/update_training_tiny_deepseek_on_bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:lgalasTT/update_training_tiny_deepseek_on_bh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lgalasTT/update_training_tiny_deepseek_on_bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lgalasTT/update_training_tiny_deepseek_on_bh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lgalasTT/update_training_tiny_deepseek_on_bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lgalasTT/update_training_tiny_deepseek_on_bh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lgalasTT/update_training_tiny_deepseek_on_bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lgalasTT/update_training_tiny_deepseek_on_bh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lgalasTT/update_training_tiny_deepseek_on_bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lgalasTT/update_training_tiny_deepseek_on_bh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lgalasTT/update_training_tiny_deepseek_on_bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lgalasTT/update_training_tiny_deepseek_on_bh)