### PR TITLE
mock device: add Blackhole Galaxy (UBB) 32-chip cluster descriptor

### DIFF
--- a/tt_metal/impl/device/mock_device_util.cpp
+++ b/tt_metal/impl/device/mock_device_util.cpp
@@ -27,9 +27,7 @@ std::optional<std::string> get_mock_cluster_desc_name(tt::ARCH arch, uint32_t nu
                 case 2: return "blackhole_P300_both_mmio.yaml";
                 case 4: return "blackhole_4xP150.yaml";
                 case 8: return "blackhole_8xP150.yaml";
-                // 32-chip BH cluster descriptor is not yet available in
-                // cluster_descriptor_examples/; add a "blackhole_32xP*.yaml" entry
-                // here once one is checked in.
+                case 32: return "blackhole_galaxy.yaml";  // Blackhole Galaxy (UBB), 32 chips
                 default: return std::nullopt;
             }
         case tt::ARCH::QUASAR:


### PR DESCRIPTION
Wire up `blackhole_galaxy.yaml` as the 32-chip Blackhole mock cluster descriptor, mirroring the 32-chip Wormhole (6U) entry.

The file is already in the pinned UMD submodule (`v0.9.6-42`), so no submodule bump is needed. Replaces the prior TODO placeholder for this case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)