### PR TITLE
[tt-train] Fix plot_training_comparison.py log parsing

### DIFF
--- a/tt-train/docs/TRAINING_LOG_COMPARISON.md
+++ b/tt-train/docs/TRAINING_LOG_COMPARISON.md
@@ -47,19 +47,17 @@ Use this when you've made changes to kernels (e.g., fusing operations) and want 
 
 ## Log Format
 
-The script expects log files from tt-train's main training binary (e.g., `nano_gpt`). The logs should contain lines in the following format:
+The script expects log files from tt-train's main training binary (e.g., `nano_gpt`) or `train_nanogpt.py`. The logs should contain lines in the following format:
 
 ```
-Step: 1, Loss: 11.0234375
-Full step time 703.141 ms
-Step: 2, Loss: 10.8765432
-Full step time 698.234 ms
+Step: 1, Loss: 11.0234375, Time: 703.14 ms, ...
+Step: 2, Loss: 10.8765432, Time: 698.23 ms, ...
 ...
 ```
 
-The script extracts:
-- **Loss values**: From lines matching `Step: \d+, Loss: ([\d.]+)`
-- **Step times**: From lines matching `Full step time ([\d.]+) ms`
+The script extracts loss and step time from the same line:
+- **Loss**: group 1 of `Step: \d+, Loss: ([\d.]+), Time: ([\d.]+) ms`
+- **Step time**: group 2 of the same pattern
 
 ---
 

--- a/tt-train/scripts/plot_training_comparison.py
+++ b/tt-train/scripts/plot_training_comparison.py
@@ -18,9 +18,8 @@ Usage:
         --labels baseline optimized fused --output-dir ./plots
 
 Expected log format:
-    The script expects log files containing lines like:
-        "Full step time 703.141 ms"
-        "Step: 1, Loss: 11.0234375"
+    Step lines from nano_gpt (C++) or train_nanogpt.py (Python), e.g.:
+        "Step: 1, Loss: 11.0234375, Time: 703.14 ms, ..."
 """
 
 import argparse
@@ -51,16 +50,13 @@ def parse_log(filepath: str, warmup_steps: int = 15) -> Tuple[List[float], List[
     step_times = []
     losses = []
 
-    for line in lines:
-        # Match full step time: "Full step time 703.141 ms"
-        step_time_match = re.search(r"Full step time ([\d.]+) ms", line)
-        if step_time_match:
-            step_times.append(float(step_time_match.group(1)))
+    step_line_re = re.compile(r"Step: \d+, Loss: ([\d.]+), Time: ([\d.]+) ms")
 
-        # Match losses: "Step: 1, Loss: 11.0234375"
-        loss_match = re.search(r"Step: \d+, Loss: ([\d.]+)", line)
-        if loss_match:
-            losses.append(float(loss_match.group(1)))
+    for line in lines:
+        match = step_line_re.search(line)
+        if match:
+            losses.append(float(match.group(1)))
+            step_times.append(float(match.group(2)))
 
     # Skip warmup steps for step time analysis
     step_times = step_times[warmup_steps:]
@@ -119,11 +115,7 @@ def plot_loss_comparison(
             losses = losses[:max_steps]
         plt.plot(losses, label=name, linewidth=2)
 
-    title = (
-        f"{title_prefix}Loss Comparison: All Runs"
-        if title_prefix
-        else "Loss Comparison: All Runs"
-    )
+    title = f"{title_prefix}Loss Comparison: All Runs" if title_prefix else "Loss Comparison: All Runs"
     plt.title(title, fontsize=20)
     plt.xlabel("Step", fontsize=16)
     plt.ylabel("Loss", fontsize=16)
@@ -146,9 +138,7 @@ def plot_loss_difference(
 ) -> None:
     """Plot loss differences relative to baseline."""
     if baseline_name not in all_data:
-        print(
-            f"Warning: Baseline '{baseline_name}' not found, skipping loss difference plot"
-        )
+        print(f"Warning: Baseline '{baseline_name}' not found, skipping loss difference plot")
         return
 
     baseline_losses = all_data[baseline_name]["losses"]
@@ -200,11 +190,7 @@ def plot_step_time(
             steps = range(len(step_times))
             plt.plot(steps, step_times, label=name, linewidth=2)
 
-    title = (
-        f"{title_prefix}Step Time Comparison"
-        if title_prefix
-        else "Step Time Comparison"
-    )
+    title = f"{title_prefix}Step Time Comparison" if title_prefix else "Step Time Comparison"
     plt.title(title, fontsize=20)
     plt.xlabel("Step (after warmup)", fontsize=16)
     plt.ylabel("Time (ms)", fontsize=16)
@@ -253,8 +239,7 @@ Examples:
     parser.add_argument(
         "--labels",
         nargs="+",
-        help="Labels for the runs (baseline first, then compare runs). "
-        "If not provided, filenames are used.",
+        help="Labels for the runs (baseline first, then compare runs). " "If not provided, filenames are used.",
     )
     parser.add_argument(
         "--output-dir",
@@ -287,10 +272,7 @@ Examples:
     # Generate labels
     if args.labels:
         if len(args.labels) != len(all_files):
-            print(
-                f"Error: Number of labels ({len(args.labels)}) must match "
-                f"number of files ({len(all_files)})"
-            )
+            print(f"Error: Number of labels ({len(args.labels)}) must match " f"number of files ({len(all_files)})")
             sys.exit(1)
         labels = args.labels
     else:
@@ -332,9 +314,7 @@ Examples:
     plot_step_time(all_data, output_path, args.title_prefix)
 
     if len(all_data) > 1:
-        plot_loss_difference(
-            all_data, baseline_label, output_path, args.title_prefix, args.max_steps
-        )
+        plot_loss_difference(all_data, baseline_label, output_path, args.title_prefix, args.max_steps)
 
     print("\nDone!")
 


### PR DESCRIPTION
## Summary

Updates `plot_training_comparison.py` and `TRAINING_LOG_COMPARISON.md` to parse the log format actually emitted by tt-train today. The script no longer looks for legacy `Full step time` lines, and instead extracts loss and step time from a single `Step:` line.

## Background

Training logs used to print step time on a separate line:

```
Step: 1, Loss: 11.0234375
Full step time 703.141 ms
```

That format was removed in [`b1f8deace90`](https://github.com/tenstorrent/tt-metal/commit/b1f8deace90) (`[tt-train] Add Python models to CI run`, #41778). C++ `nano_gpt` and Python `train_nanogpt.py` now emit loss and time together:

```
Step: 1, Loss: 11.0234375, Time: 703.14 ms, cache entries: 42
```

`plot_training_comparison.py` still parsed the old `Full step time` format, so step-time plots and statistics were empty for current training runs.

## Changes

### `tt-train/scripts/plot_training_comparison.py`

- Remove parsing of `Full step time ([\d.]+) ms`
- Parse loss and step time from one regex on the shared `Step:` line:
  `Step: \d+, Loss: ([\d.]+), Time: ([\d.]+) ms`
- Update module docstring to document the current log format

### `tt-train/docs/TRAINING_LOG_COMPARISON.md`

- Update log format examples to match C++/Python output
- Document that loss and step time come from the same line

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lgalasTT/fix_plot_training_for_py)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lgalasTT/fix_plot_training_for_py)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lgalasTT/fix_plot_training_for_py)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lgalasTT/fix_plot_training_for_py)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=lgalasTT/fix_plot_training_for_py)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:lgalasTT/fix_plot_training_for_py)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lgalasTT/fix_plot_training_for_py)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lgalasTT/fix_plot_training_for_py)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lgalasTT/fix_plot_training_for_py)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lgalasTT/fix_plot_training_for_py)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lgalasTT/fix_plot_training_for_py)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lgalasTT/fix_plot_training_for_py)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lgalasTT/fix_plot_training_for_py)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lgalasTT/fix_plot_training_for_py)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lgalasTT/fix_plot_training_for_py)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lgalasTT/fix_plot_training_for_py)