### PR TITLE
llk_sfpu: fix recip API migration in digamma/tanhshrink kernels

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_digamma.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_digamma.h
@@ -83,9 +83,10 @@ inline void calculate_digamma() {
         v_if(x > 102.0f) {
             sfpi::vFloat inv_x = sfpu_reciprocal_iter<2>(x);
             sfpi::vFloat inv_x2 = inv_x * inv_x;
-            // ln(x) - inv_x*0.5 - inv_x2*(1/12 - inv_x2/120); 1/12 and 1/120 are in
-            // vConstFloatPrgm1/Prgm2 (programmed in digamma_init).
-            sfpi::vFloat bern = sfpi::vConstFloatPrgm1 - inv_x2 * sfpi::vConstFloatPrgm2;
+            // ln(x) - inv_x*0.5 - inv_x2*(1/12 - inv_x2/120). 1/12 and 1/120 are literals:
+            // the reciprocal owns vConstFloatPrgm0/1/2 for its Newton seed, so digamma has no
+            // free program-constant registers to hold them.
+            sfpi::vFloat bern = sfpi::vFloat(0.0833333333f) - inv_x2 * sfpi::vFloat(0.0083333333f);
             result = _calculate_log_body_no_init_(x) - inv_x * sfpi::vFloat(0.5f) - inv_x2 * bern;
             // digamma(+inf) = +inf; the log approximation clamps inf to a finite value, so
             // restore it explicitly (exp field all-ones, zero mantissa => infinity).
@@ -101,12 +102,9 @@ inline void calculate_digamma() {
 
 template <bool APPROXIMATION_MODE>
 void digamma_init() {
+    // sfpu_reciprocal_init programs vConstFloatPrgm0/1/2 with the reciprocal's Newton seed;
+    // all three stay reserved for it, so digamma must not repurpose Prgm1/Prgm2.
     sfpu_reciprocal_init();
-    // Bernoulli tail coefficients. Prgm0 is owned by the reciprocal above; Prgm1/Prgm2 are
-    // unused in the digamma path, so program them once here instead of materializing the
-    // literals on every loop iteration inside the large-x branch.
-    sfpi::vConstFloatPrgm1 = 0.0833333333f;  // 1/12
-    sfpi::vConstFloatPrgm2 = 0.0083333333f;  // 1/120
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_digamma.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_digamma.h
@@ -8,7 +8,7 @@
 #include "ckernel_defs.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 #include "sfpu/ckernel_sfpu_log.h"
-#include "sfpu/ckernel_sfpu_recip.h"
+#include "ckernel_sfpu_recip.h"
 
 #include "ckernel_sfpu_piecewise_rational.h"
 
@@ -81,7 +81,7 @@ inline void calculate_digamma() {
         // bf16-accurate. #45520 targets bf16 ULP; an fp32-accurate log here would collide
         // with the reciprocal's vConstFloatPrgm0, so fp32 large-x is intentionally left as-is.
         v_if(x > 102.0f) {
-            sfpi::vFloat inv_x = _sfpu_reciprocal_<2>(x);
+            sfpi::vFloat inv_x = sfpu_reciprocal_iter<2>(x);
             sfpi::vFloat inv_x2 = inv_x * inv_x;
             // ln(x) - inv_x*0.5 - inv_x2*(1/12 - inv_x2/120); 1/12 and 1/120 are in
             // vConstFloatPrgm1/Prgm2 (programmed in digamma_init).

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanhshrink.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanhshrink.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_sfpu_exp.h"
+#include "ckernel_sfpu_recip.h"
 #include "ckernel_sfpu_tanh.h"
 
 namespace ckernel::sfpu {
@@ -58,7 +59,7 @@ inline void calculate_tanhshrink() {
                 sfpi::vFloat clamp = 9.0f;
                 sfpi::vec_min_max(axc, clamp);  // axc = min(|x|, 9)
                 sfpi::vFloat e = _sfpu_exp_fp32_accurate_unsafe_(-2.f * axc);
-                sfpi::vFloat sig = _sfpu_reciprocal_<2>(sfpi::vConst1 + e);  // sigmoid(2|x|)
+                sfpi::vFloat sig = sfpu_reciprocal_iter<2>(sfpi::vConst1 + e);  // sigmoid(2|x|)
                 sfpi::vFloat tanh_ax = 2.f * sig - sfpi::vConst1;            // tanh(|x|)
                 result = sfpi::copysgn(ax - tanh_ax, x);
             } else {
@@ -76,7 +77,7 @@ inline void calculate_tanhshrink() {
         v_endif;
 
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);
         }
 
         sfpi::dst_reg[0] = result;
@@ -90,7 +91,7 @@ inline void tanhshrink_init() {
     if constexpr (is_fp32_dest_acc_en) {
         // The fp32 large-|x| path only needs the reciprocal Newton constants; the accurate
         // exp it uses is pure arithmetic (no LUT / programmable constants).
-        _init_sfpu_reciprocal_<false>();
+        sfpu_reciprocal_init<false>();
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_digamma.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_digamma.h
@@ -83,9 +83,10 @@ inline void calculate_digamma() {
         v_if(x > 102.0f) {
             sfpi::vFloat inv_x = sfpu_reciprocal_iter<2>(x);
             sfpi::vFloat inv_x2 = inv_x * inv_x;
-            // ln(x) - inv_x*0.5 - inv_x2*(1/12 - inv_x2/120); 1/12 and 1/120 are in
-            // vConstFloatPrgm1/Prgm2 (programmed in digamma_init).
-            sfpi::vFloat bern = sfpi::vConstFloatPrgm1 - inv_x2 * sfpi::vConstFloatPrgm2;
+            // ln(x) - inv_x*0.5 - inv_x2*(1/12 - inv_x2/120). 1/12 and 1/120 are literals:
+            // the reciprocal owns vConstFloatPrgm0/1/2 for its Newton seed, so digamma has no
+            // free program-constant registers to hold them.
+            sfpi::vFloat bern = sfpi::vFloat(0.0833333333f) - inv_x2 * sfpi::vFloat(0.0083333333f);
             result = _calculate_log_body_no_init_(x) - inv_x * sfpi::vFloat(0.5f) - inv_x2 * bern;
             // digamma(+inf) = +inf; the log approximation clamps inf to a finite value, so
             // restore it explicitly (exp field all-ones, zero mantissa => infinity).
@@ -101,12 +102,9 @@ inline void calculate_digamma() {
 
 template <bool APPROXIMATION_MODE>
 void digamma_init() {
+    // sfpu_reciprocal_init programs vConstFloatPrgm0/1/2 with the reciprocal's Newton seed;
+    // all three stay reserved for it, so digamma must not repurpose Prgm1/Prgm2.
     sfpu_reciprocal_init();
-    // Bernoulli tail coefficients. Prgm0 is owned by the reciprocal above; Prgm1/Prgm2 are
-    // unused in the digamma path, so program them once here instead of materializing the
-    // literals on every loop iteration inside the large-x branch.
-    sfpi::vConstFloatPrgm1 = 0.0833333333f;  // 1/12
-    sfpi::vConstFloatPrgm2 = 0.0083333333f;  // 1/120
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_digamma.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_digamma.h
@@ -8,7 +8,7 @@
 #include "ckernel_defs.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 #include "sfpu/ckernel_sfpu_log.h"
-#include "sfpu/ckernel_sfpu_recip.h"
+#include "ckernel_sfpu_recip.h"
 
 #include "ckernel_sfpu_piecewise_rational.h"
 
@@ -81,7 +81,7 @@ inline void calculate_digamma() {
         // bf16-accurate. #45520 targets bf16 ULP; an fp32-accurate log here would collide
         // with the reciprocal's vConstFloatPrgm0, so fp32 large-x is intentionally left as-is.
         v_if(x > 102.0f) {
-            sfpi::vFloat inv_x = _sfpu_reciprocal_<2>(x);
+            sfpi::vFloat inv_x = sfpu_reciprocal_iter<2>(x);
             sfpi::vFloat inv_x2 = inv_x * inv_x;
             // ln(x) - inv_x*0.5 - inv_x2*(1/12 - inv_x2/120); 1/12 and 1/120 are in
             // vConstFloatPrgm1/Prgm2 (programmed in digamma_init).

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanhshrink.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanhshrink.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_sfpu_exp.h"
+#include "ckernel_sfpu_recip.h"
 #include "ckernel_sfpu_tanh.h"
 
 namespace ckernel::sfpu {
@@ -58,7 +59,7 @@ inline void calculate_tanhshrink() {
                 sfpi::vFloat clamp = 9.0f;
                 sfpi::vec_min_max(axc, clamp);  // axc = min(|x|, 9)
                 sfpi::vFloat e = _sfpu_exp_fp32_accurate_unsafe_(-2.f * axc);
-                sfpi::vFloat sig = _sfpu_reciprocal_<2>(sfpi::vConst1 + e);  // sigmoid(2|x|)
+                sfpi::vFloat sig = sfpu_reciprocal_iter<2>(sfpi::vConst1 + e);  // sigmoid(2|x|)
                 sfpi::vFloat tanh_ax = 2.f * sig - sfpi::vConst1;            // tanh(|x|)
                 result = sfpi::copysgn(ax - tanh_ax, x);
             } else {
@@ -76,7 +77,7 @@ inline void calculate_tanhshrink() {
         v_endif;
 
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);
         }
 
         sfpi::dst_reg[0] = result;
@@ -90,7 +91,7 @@ inline void tanhshrink_init() {
     if constexpr (is_fp32_dest_acc_en) {
         // The fp32 large-|x| path only needs the reciprocal Newton constants; the accurate
         // exp it uses is pure arithmetic (no LUT / programmable constants).
-        _init_sfpu_reciprocal_<false>();
+        sfpu_reciprocal_init<false>();
     }
 }
 

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/tanhshrink.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/tanhshrink.h
@@ -13,10 +13,15 @@
 namespace ckernel {
 
 ALWI void tanhshrink_tile(uint32_t idst) {
-    MATH(SFPU_CALL_MODE(
-        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_tanhshrink, (DST_ACCUM_MODE, 8 /* ITERATIONS */), RC, idst));
+    MATH(SFPU_UNARY_CALL(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_tanhshrink,
+        (DST_ACCUM_MODE, 8 /* ITERATIONS */),
+        idst,
+        VectorMode::RC));
 }
 
-ALWI void tanhshrink_tile_init() { MATH(SFPU_INIT_CB(unused, sfpu::tanhshrink_init, (APPROX, DST_ACCUM_MODE))); }
+ALWI void tanhshrink_tile_init() { MATH(SFPU_UNARY_INIT_FN(unused, sfpu::tanhshrink_init, (APPROX, DST_ACCUM_MODE))); }
 
 }  // namespace ckernel


### PR DESCRIPTION
# [Bugfix] Fix eltwise red on main: digamma + tanhshrink (trisc compile + digamma reciprocal-seed corruption)

## Problem

`main` is red on the ttnn-eltwise sanity groups. There are **two** distinct
defects in the `digamma` / `tanhshrink` SFPU ops:

### 1. trisc JIT compile failure (API churn)

`digamma` and `tanhshrink` fail their **trisc JIT compile**. The cause is not a
defect in the op code itself — it is API churn from two intervening commits that
landed between when these ops were branched and when they merged. The host build
does not compile trisc kernels, so the staleness merged green and only surfaces
at device/CI runtime.

Two intervening renames/moves:

- **#46329** (`Rename SFPU_CALL*/SFPU_INIT → SFPU_UNARY_*`) renamed the SFPU
  tile-wrapper macros.
- **#46766** (`Move sfpu recip to L4`) moved `ckernel_sfpu_recip.h` out of the
  `sfpu/` include path and renamed `_sfpu_reciprocal_` / `_init_sfpu_reciprocal_`
  to `sfpu_reciprocal_iter` / `sfpu_reciprocal_init`.

Both landed on `main` after the digamma/tanhshrink branches were cut and before
they merged. The PRs were not rebased onto them, so the kernels and the
tanhshrink wrapper still reference the pre-rename names.

**Symptoms**

- **digamma** — fatal `sfpu/ckernel_sfpu_recip.h: No such file`, then stale
  `_sfpu_reciprocal_*` symbols.
- **tanhshrink** — stale `_sfpu_reciprocal_*` symbols; deprecated
  `sfpi::RoundMode::NearestEven` under `-Werror`; and its tile wrapper
  references the old macros `SFPU_CALL_MODE` / `SFPU_INIT_CB`.

### 2. digamma reciprocal-seed corruption (latent since #47324, exposed by fix 1)

Fixing the compile re-enabled digamma on device for the first time since the
churn, which exposed a latent numerical bug: `test_unary_composite_digamma_ttnn`
fails PCC on `[1,100]`.

`digamma_init` called `sfpu_reciprocal_init()` and then overwrote
`vConstFloatPrgm1` / `vConstFloatPrgm2` with the Bernoulli tail coefficients
`1/12` and `1/120`, on the assumption that those registers were free in the
digamma path. They are not: the reciprocal seeds its quadratic Newton estimate
from `vConstFloatPrgm0/1/2` (Sollya constants) — and this has been true on both
sides of #46766; the move did not change the register contract. The LUT path
ends in `numer * sfpu_reciprocal(denom)`, so **every** digamma element divides by
`Q(x)` through that reciprocal. With the seed clobbered, the reciprocal's
relative error reaches ~260% (e.g. `1/2.0 → 0.34`), which tanks PCC across the
whole `[0.01,102]` LUT range.

This bug originated in #47324 (the "hoist Bernoulli coeffs to program regs"
optimization) but was masked: the trisc compile has been broken on `main` since
that PR, so the corrupted path never executed under a reference-PCC test until
this PR makes it compile again.

## Fix

**Kernels** (Blackhole + Wormhole_b0), align with the moved/renamed reciprocal
(mechanical, no behavior change):

- **digamma** — drop the `sfpu/` prefix on the recip include;
  `_sfpu_reciprocal_<2>(x)` → `sfpu_reciprocal_iter<2>(x)`.
- **tanhshrink** — add `#include "ckernel_sfpu_recip.h"`;
  `_sfpu_reciprocal_<2>(...)` → `sfpu_reciprocal_iter<2>(...)`;
  `_init_sfpu_reciprocal_<false>()` → `sfpu_reciprocal_init<false>()`;
  deprecated `RoundMode::NearestEven` → `RoundMode::Nearest`.

**digamma reciprocal-seed fix** (Blackhole + Wormhole_b0) — **numerical
correction**: `digamma_init` no longer repurposes `vConstFloatPrgm1/2`; it just
calls `sfpu_reciprocal_init()` and leaves the seed intact. The `1/12` and `1/120`
Bernoulli coefficients are materialized as literals at their only use site (the
`x>102` asymptotic branch).

The `sfpu/ckernel_sfpu_log.h` include in digamma is intentionally **left
prefixed** — `_calculate_log_body_no_init_` (used in the large-x asymptotic
branch) is defined only in the core `sfpu/`-prefixed log header, which did not
move.

**Wrapper** (`api/compute/eltwise_unary/tanhshrink.h`): switch to the renamed
macros, matching the working digamma wrapper — `SFPU_CALL_MODE` →
`SFPU_UNARY_CALL` (with `DST_IDX, VECTOR_MODE` arg order), `SFPU_INIT_CB` →
`SFPU_UNARY_INIT_FN`.

## Perf

Reverting the program-register hoist costs ~3.214 → 3.303 cyc/datum on the
digamma large-x branch. The 3.214 figure was measured on the corrupted build, so
it was never a valid baseline; correctness over the micro-opt. There are no free
`Prgm` registers to hoist into while the reciprocal is live.

Relates to PRs raised by github bot, the PRs are similar but arent fully fixing the regression: https://github.com/tenstorrent/tt-metal/pull/47653, https://github.com/tenstorrent/tt-metal/pull/47654, https://github.com/tenstorrent/tt-metal/pull/47655, https://github.com/tenstorrent/tt-metal/pull/47656. We can close them once this goes in.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mmoscicki/fix-sfpu-recip-digamma-tanhshrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mmoscicki/fix-sfpu-recip-digamma-tanhshrink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mmoscicki/fix-sfpu-recip-digamma-tanhshrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mmoscicki/fix-sfpu-recip-digamma-tanhshrink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mmoscicki/fix-sfpu-recip-digamma-tanhshrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mmoscicki/fix-sfpu-recip-digamma-tanhshrink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mmoscicki/fix-sfpu-recip-digamma-tanhshrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mmoscicki/fix-sfpu-recip-digamma-tanhshrink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mmoscicki/fix-sfpu-recip-digamma-tanhshrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mmoscicki/fix-sfpu-recip-digamma-tanhshrink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mmoscicki/fix-sfpu-recip-digamma-tanhshrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mmoscicki/fix-sfpu-recip-digamma-tanhshrink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mmoscicki/fix-sfpu-recip-digamma-tanhshrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mmoscicki/fix-sfpu-recip-digamma-tanhshrink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mmoscicki/fix-sfpu-recip-digamma-tanhshrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mmoscicki/fix-sfpu-recip-digamma-tanhshrink)