### PR TITLE
[skip ci] Temporarily skip fabric ubench golden-comparison failures on wormhole_b0 T3K

### DIFF
--- a/tests/tt_metal/tt_fabric/test_infra/tt_fabric_test_config.cpp
+++ b/tests/tt_metal/tt_fabric/test_infra/tt_fabric_test_config.cpp
@@ -1095,6 +1095,26 @@ std::vector<TestConfig> TestConfigBuilder::build_tests(
 }
 
 bool TestConfigBuilder::should_skip_test_on_platform(const ParsedTestConfig& test_config) const {
+    // Temporarily skip benchmark tests that fail golden comparison on wormhole_b0 (T3K).
+    // TODO: re-enable once golden values are updated. See issue #FIXME.
+    static const std::unordered_set<std::string> wh_b0_skipped_benchmarks = {
+        "LinearMulticast",
+        "UnidirLinearMulticast",
+        "SingleSenderLinearUnicastAllDevices",
+        "NeighborExchangeLinear",
+        "FullRingMulticast",
+        "FullRingUnicast",
+        "HalfRingMulticast",
+        "MeshMulticast",
+        "SingleSenderMeshUnicastAllDevices",
+        "CustomMaxPacketSizeLinear3K",
+        "CustomMaxPacketSizeMesh3K",
+    };
+    if (wh_b0_skipped_benchmarks.count(test_config.name) &&
+        tt::tt_metal::hal::get_arch_name() == "wormhole_b0") {
+        log_info(LogTest, "Skipping test '{}' on wormhole_b0 (golden comparison failures, temporary skip)", test_config.name);
+        return true;
+    }
     // Skip if the test declares platforms to skip and this platform matches
     if (test_config.skip.has_value()) {
         // Determine current platform identifiers


### PR DESCRIPTION
Several fabric bandwidth benchmark tests in `test_fabric_ubench_at_least_2x2_mesh.yaml` have been failing golden comparison validation on the T3K (wormhole_b0) CI runner for 7+ days:

- LinearMulticast
- UnidirLinearMulticast
- SingleSenderLinearUnicastAllDevices
- NeighborExchangeLinear
- FullRingMulticast
- FullRingUnicast
- HalfRingMulticast
- MeshMulticast
- SingleSenderMeshUnicastAllDevices
- CustomMaxPacketSizeLinear3K
- CustomMaxPacketSizeMesh3K

The skip is implemented as a hardcoded guard in `should_skip_test_on_platform()` in the C++ test harness source, scoped to `wormhole_b0` only. This mirrors the existing `skip: [wormhole_b0]` mechanism already used by other tests in the same YAML, but is placed in source code so it is visible to developers reading the harness.

The golden values need to be updated or the underlying bandwidth regression investigated before re-enabling.