### PR TITLE
Simplify DEVICE_PRINT callstack API

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_output.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_output.cpp
@@ -556,3 +556,10 @@ TEST_F(DevicePrintOutputFixture, PrintCallstackSkipUnderflow) {
         /* present */ {"CALLSTACK_BEGIN", "...", "CALLSTACK_END"},
         /* absent */ {"inner", "middle", "kernel_main"});
 }
+
+TEST_F(DevicePrintOutputFixture, PrintCallstackCurrent) {
+    TestCallstack(
+        "tests/tt_metal/tt_metal/test_kernels/device_print/print_callstack_helper.cpp",
+        /* present */ {"CALLSTACK_BEGIN", "kernel_main", "CALLSTACK_END"},
+        /* absent */ {"current"});
+}

--- a/tests/tt_metal/tt_metal/test_kernels/device_print/print_callstack_helper.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/device_print/print_callstack_helper.cpp
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/debug/device_print.h"
+
+void kernel_main() {
+    DEVICE_PRINT(
+        "CALLSTACK_BEGIN\n"
+        "{}\n"
+        "CALLSTACK_END\n",
+        dp_top_callstack_t::current(0));
+}

--- a/tt_metal/hw/inc/api/debug/device_print.h
+++ b/tt_metal/hw/inc/api/debug/device_print.h
@@ -120,6 +120,15 @@ struct dp_top_callstack_t {
         this->ra = ra == UINTPTR_MAX ? ra : (ra - kernel_offset - 1);
         this->skip_frames = skip_frames;
     }
+
+    __attribute__((always_inline)) static inline dp_top_callstack_t current(std::uintptr_t skip_frames) {
+        std::uintptr_t pc;
+        asm volatile("auipc %[pc], 0\n" : [pc] "=r"(pc));
+        std::uintptr_t ra = reinterpret_cast<std::uintptr_t>(__builtin_return_address(0));
+
+        // the +1 is to ignore the current frame
+        return dp_top_callstack_t(pc, ra, skip_frames + 1);
+    }
 };
 
 #ifdef UCK_CHLKC_UNPACK


### PR DESCRIPTION
Simplifies the DEVICE_PRINT callstack API.

This is the base of a stacked pair:
- **this PR** → `main`
- `llk/san/pr/test-tail` (Add tests for Tail Call unwinding) → this branch

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk/san/pr/dprint-current)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk/san/pr/dprint-current)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk/san/pr/dprint-current)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk/san/pr/dprint-current)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=llk/san/pr/dprint-current)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:llk/san/pr/dprint-current)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk/san/pr/dprint-current)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk/san/pr/dprint-current)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk/san/pr/dprint-current)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk/san/pr/dprint-current)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk/san/pr/dprint-current)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk/san/pr/dprint-current)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk/san/pr/dprint-current)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk/san/pr/dprint-current)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk/san/pr/dprint-current)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk/san/pr/dprint-current)