### PR TITLE
[Models-CI] GPT-OSS: migrate to transformers 5.10.2 (unpin model-specific version)

### DIFF
--- a/models/demos/gpt_oss/README.md
+++ b/models/demos/gpt_oss/README.md
@@ -15,9 +15,6 @@ Inference implementation for GPT-OSS models on Tenstorrent Wormhole accelerators
 ## Quick Start
 
 ```bash
-# Bump up transformers version
-pip install -r models/demos/gpt_oss/requirements.txt
-
 # Set model path using HF_MODEL environment variable
 export HF_MODEL="/mnt/MLPerf/tt_dnn-models/openai/gpt-oss-20b"
 

--- a/models/demos/gpt_oss/requirements.txt
+++ b/models/demos/gpt_oss/requirements.txt
@@ -1,1 +1,0 @@
-transformers==4.57.0

--- a/models/demos/gpt_oss/tests/fused_op_unit_tests/test_gpt_oss_router.py
+++ b/models/demos/gpt_oss/tests/fused_op_unit_tests/test_gpt_oss_router.py
@@ -91,8 +91,10 @@ def gpt_oss_router_reference(
     """
     with torch.no_grad():
         # Reference router returns (routing_weights, routing_indices)
-        router_scores, router_indices = reference_router(hidden_states)
-
+        # transformers 5.x GptOssTopKRouter.forward returns (router_logits, router_scores, router_indices);
+        # <5 returned (router_scores, router_indices). Unpack version-tolerantly.
+        _router_out = reference_router(hidden_states)
+        router_scores, router_indices = (_router_out[1], _router_out[2]) if len(_router_out) == 3 else _router_out
     if use_throughput_experts:
         # When using throughput experts, convert sparse router_scores to dense router_weights
         # (reorder weights to match the order of the indices)

--- a/models/demos/gpt_oss/tests/unit/test_modules.py
+++ b/models/demos/gpt_oss/tests/unit/test_modules.py
@@ -215,11 +215,13 @@ def run_topk_router_component(
     indices_passing, indices_output = compare_tensors(
         sorted_tt_indices, sorted_ref_indices, mesh_device, pcc_threshold=pcc_threshold
     )
+    # Reorder each token's weights into ascending-expert-id order so the two sides line up even when
+    # TT (bf16) and the reference (fp32) emit the same top-k experts in a different (value-sorted) order.
+    # gather along the top_k axis is the correct reorder; `weights.squeeze()[order]` indexes dim 0 and
+    # mangles the comparison for batch > 1.
     weights_passing, weights_output = compare_tensors(
-        tt_router_weights_torch.squeeze()[
-            sorted_tt_indices_order
-        ],  # we have to squeeze here because it breaks the indexing otherwise
-        router_scores.squeeze()[sorted_ref_indices_order],
+        torch.gather(tt_router_weights_torch, -1, sorted_tt_indices_order),
+        torch.gather(router_scores, -1, sorted_ref_indices_order),
         mesh_device,
         pcc_threshold=pcc_threshold,
     )

--- a/models/demos/gpt_oss/tests/unit/test_modules.py
+++ b/models/demos/gpt_oss/tests/unit/test_modules.py
@@ -164,26 +164,18 @@ def run_topk_router_component(
 
     # Extract reference TopK router from reference layer
     reference_router = reference_layer.mlp.router
-    # transformers 5.x GptOssTopKRouter.forward returns (router_logits, router_scores, router_indices);
-    # <5 returned (router_scores, router_indices). Unpack version-tolerantly.
-    # 5.x computes router_scores = softmax(top_k_logits, dim=1); GptOssMLP flattens (batch,seq,hidden)
-    # -> (num_tokens, hidden) first, so dim=1 is the top_k axis. Passing 3D hidden_states here would make
-    # softmax run over the seq dim (degenerate -> all ~1.0). Flatten to match (also matches the TT router,
-    # which operates on flattened tokens).
+    # transformers 5.x GptOssTopKRouter.forward returns (router_logits, router_scores, router_indices) with
+    # router_scores already SPARSE [num_tokens, top_k] (softmax over the top_k logits, in top-k order);
+    # <5 returned (router_scores_dense, router_indices) with router_scores DENSE [num_tokens, num_experts].
+    # GptOssMLP flattens (batch,seq,hidden) -> (num_tokens, hidden) before the router, so flatten here too
+    # (also matches the TT router, which operates on flattened tokens) and normalise both versions to a
+    # sparse [num_tokens, top_k] weight tensor aligned to router_indices.
     _router_out = reference_router(hidden_states.reshape(-1, hidden_size))
-    router_scores, router_indices = (_router_out[1], _router_out[2]) if len(_router_out) == 3 else _router_out
-    if decoder_layer.mlp.use_throughput_experts:
-        # When using throughput experts, we return a dense tensor of router_scores. Convert sparse reference router_scores to dense router_weights (note: this requires reorder the weights to match the order of the indices)
-        dense_router_scores = torch.concat(
-            [
-                torch.tensor(
-                    [router_scores[user, router_indices[user, i]] for i in range(router_indices.shape[1])]
-                ).reshape(1, -1)
-                for user in range(router_scores.shape[0])
-            ],
-            dim=0,
-        )
-        router_scores = dense_router_scores
+    if len(_router_out) == 3:
+        router_scores, router_indices = _router_out[1], _router_out[2]
+    else:
+        router_scores_dense, router_indices = _router_out
+        router_scores = torch.gather(router_scores_dense, 1, router_indices)
 
     # Convert to TTNN tensors
     mesh_mapper = (
@@ -204,8 +196,17 @@ def run_topk_router_component(
     tt_router = decoder_layer.mlp.router
     tt_router_indices, tt_router_weights = tt_router(tt_hidden_states, decoder_layer.mlp.use_throughput_experts)
     mesh_composer = ttnn.ConcatMesh2dToTensor(mesh_device, dims=(0, 1), mesh_shape=tuple(mesh_device.shape))
-    tt_router_indices_torch = ttnn.to_torch(tt_router_indices, mesh_composer=mesh_composer)[:batch, :4]
-    tt_router_weights_torch = ttnn.to_torch(tt_router_weights, mesh_composer=mesh_composer)[:batch, :4]
+    top_k = router_indices.shape[1]
+    tt_router_indices_torch = ttnn.to_torch(tt_router_indices, mesh_composer=mesh_composer)[:batch, :top_k]
+    tt_router_weights_full = ttnn.to_torch(tt_router_weights, mesh_composer=mesh_composer)[:batch]
+    if decoder_layer.mlp.use_throughput_experts:
+        # throughput path returns sparse [batch, top_k] weights (top-k order)
+        tt_router_weights_torch = tt_router_weights_full[:, :top_k]
+    else:
+        # non-throughput path returns DENSE [batch, num_experts] (ttnn.scatter of the top_k weights at the
+        # selected expert ids); gather the weights at the selected indices so both sides are sparse
+        # [batch, top_k] aligned to their indices. Reading [:, :top_k] here would grab unselected experts.
+        tt_router_weights_torch = torch.gather(tt_router_weights_full, 1, tt_router_indices_torch.long())
 
     # Compare outputs
     # We will sort the indices here as the order of the indices is not guaranteed to be the same in the reference and TT implementation.

--- a/models/demos/gpt_oss/tests/unit/test_modules.py
+++ b/models/demos/gpt_oss/tests/unit/test_modules.py
@@ -164,7 +164,14 @@ def run_topk_router_component(
 
     # Extract reference TopK router from reference layer
     reference_router = reference_layer.mlp.router
-    router_scores, router_indices = reference_router(hidden_states)
+    # transformers 5.x GptOssTopKRouter.forward returns (router_logits, router_scores, router_indices);
+    # <5 returned (router_scores, router_indices). Unpack version-tolerantly.
+    # 5.x computes router_scores = softmax(top_k_logits, dim=1); GptOssMLP flattens (batch,seq,hidden)
+    # -> (num_tokens, hidden) first, so dim=1 is the top_k axis. Passing 3D hidden_states here would make
+    # softmax run over the seq dim (degenerate -> all ~1.0). Flatten to match (also matches the TT router,
+    # which operates on flattened tokens).
+    _router_out = reference_router(hidden_states.reshape(-1, hidden_size))
+    router_scores, router_indices = (_router_out[1], _router_out[2]) if len(_router_out) == 3 else _router_out
     if decoder_layer.mlp.use_throughput_experts:
         # When using throughput experts, we return a dense tensor of router_scores. Convert sparse reference router_scores to dense router_weights (note: this requires reorder the weights to match the order of the indices)
         dense_router_scores = torch.concat(
@@ -459,17 +466,29 @@ def run_experts_component(mesh_device, hidden_shape, config, reference_layer, de
 
     router_indices = torch.zeros(batch_size * seq_len, config.num_experts_per_tok, dtype=torch.long)
     routing_weights = torch.zeros(batch_size * seq_len, config.num_local_experts)
+    # transformers 5.x GptOssExperts indexes routing_weights[token_idx, top_k_pos] — i.e. it expects a
+    # by-position [num_tokens, top_k] layout, not the dense [num_tokens, num_experts] by-expert layout.
+    # Build both: the dense one for the TT experts (unchanged), the by-position one for the 5.x reference.
+    routing_weights_topk = torch.zeros(batch_size * seq_len, config.num_experts_per_tok)
 
     for b, s in itertools.product(range(batch_size), range(seq_len)):
         active_experts = torch.randperm(config.num_local_experts)[: config.num_experts_per_tok]
         router_indices[b * seq_len + s, :] = active_experts
         weights = torch.rand(config.num_experts_per_tok)
         weights = weights / weights.sum()  # Normalize
-        routing_weights[b * seq_len + s, active_experts] = weights
+        routing_weights[b * seq_len + s, active_experts] = weights  # dense, by expert id (TT)
+        routing_weights_topk[b * seq_len + s, :] = weights  # by top-k position (5.x reference)
 
     # Extract reference experts from reference layer
     reference_experts = reference_layer.mlp.experts.eval()  # Set to eval mode for inference
-    reference_output = reference_experts(hidden_states, router_indices=router_indices, routing_weights=routing_weights)
+    # transformers 5.x GptOssExperts expects flattened [num_tokens, hidden] (GptOssMLP reshapes
+    # (batch,seq,hidden)->(-1,hidden) before calling experts), and indexes hidden_states[token_idx] and
+    # routing_weights[token_idx, top_k_pos]. Flatten hidden_states and pass by-position routing weights;
+    # output is then [batch*seq, hidden], matching the flat tt_output below. For transformers <5 the
+    # reference used the dense by-expert layout — GPT-OSS is now unpinned to 5.x so we target 5.x.
+    reference_output = reference_experts(
+        hidden_states.reshape(-1, hidden_size), router_indices=router_indices, routing_weights=routing_weights_topk
+    )
 
     # Convert to TTNN tensors
     tt_hidden_states = ttnn.from_torch(
@@ -549,6 +568,11 @@ def setup_reference_layer(setup, layer_idx=0):
     logger.info("Setting up reference layer...")
     from transformers.models.gpt_oss.modeling_gpt_oss import GptOssDecoderLayer
 
+    # transformers 5.x dispatches MoE experts via config._experts_implementation; a standalone layer
+    # leaves it None, so GptOssExperts uses the default flat-token forward that indexes
+    # hidden_states[token_idx] and IndexErrors on batched hidden_states. Pin it to eager (mirrors the
+    # existing _attn_implementation="eager" the decoder setup uses).
+    setup["config"]._experts_implementation = "eager"
     reference_layer = GptOssDecoderLayer(setup["config"], layer_idx=layer_idx)
     with torch.no_grad():
         for name, param in reference_layer.named_parameters():
@@ -684,6 +708,8 @@ def test_decoder(
     # Set attention implementation for transformers compatibility
     config = setup["config"]
     config._attn_implementation = "eager"
+    # transformers 5.x also needs the MoE experts dispatch pinned for standalone reference layers.
+    config._experts_implementation = "eager"
 
     if batch_size > 32:
         if mesh_device.shape[0] == 1:

--- a/models/demos/gpt_oss/tests/unit/test_modules.py
+++ b/models/demos/gpt_oss/tests/unit/test_modules.py
@@ -164,18 +164,28 @@ def run_topk_router_component(
 
     # Extract reference TopK router from reference layer
     reference_router = reference_layer.mlp.router
-    # transformers 5.x GptOssTopKRouter.forward returns (router_logits, router_scores, router_indices) with
-    # router_scores already SPARSE [num_tokens, top_k] (softmax over the top_k logits, in top-k order);
-    # <5 returned (router_scores_dense, router_indices) with router_scores DENSE [num_tokens, num_experts].
-    # GptOssMLP flattens (batch,seq,hidden) -> (num_tokens, hidden) before the router, so flatten here too
-    # (also matches the TT router, which operates on flattened tokens) and normalise both versions to a
-    # sparse [num_tokens, top_k] weight tensor aligned to router_indices.
+    # transformers 5.x GptOssTopKRouter.forward returns (router_logits, router_scores, router_indices);
+    # <5 returned (router_scores_dense, router_indices). Reconstruct the DENSE [num_tokens, num_experts]
+    # router_scores so the comparison below matches the pre-5.x behaviour. (The corrected router-weights
+    # comparison + the fp32 router-gate fix it surfaced are tracked separately in #47970 — kept out of this
+    # unpin PR so it stays at parity with main, which does not validate the router gate weights either.)
     _router_out = reference_router(hidden_states.reshape(-1, hidden_size))
     if len(_router_out) == 3:
-        router_scores, router_indices = _router_out[1], _router_out[2]
+        router_logits, _sparse_scores, router_indices = _router_out
+        router_scores = torch.zeros_like(router_logits).scatter_(-1, router_indices, _sparse_scores)
     else:
-        router_scores_dense, router_indices = _router_out
-        router_scores = torch.gather(router_scores_dense, 1, router_indices)
+        router_scores, router_indices = _router_out
+    if decoder_layer.mlp.use_throughput_experts:
+        dense_router_scores = torch.concat(
+            [
+                torch.tensor(
+                    [router_scores[user, router_indices[user, i]] for i in range(router_indices.shape[1])]
+                ).reshape(1, -1)
+                for user in range(router_scores.shape[0])
+            ],
+            dim=0,
+        )
+        router_scores = dense_router_scores
 
     # Convert to TTNN tensors
     mesh_mapper = (
@@ -196,17 +206,8 @@ def run_topk_router_component(
     tt_router = decoder_layer.mlp.router
     tt_router_indices, tt_router_weights = tt_router(tt_hidden_states, decoder_layer.mlp.use_throughput_experts)
     mesh_composer = ttnn.ConcatMesh2dToTensor(mesh_device, dims=(0, 1), mesh_shape=tuple(mesh_device.shape))
-    top_k = router_indices.shape[1]
-    tt_router_indices_torch = ttnn.to_torch(tt_router_indices, mesh_composer=mesh_composer)[:batch, :top_k]
-    tt_router_weights_full = ttnn.to_torch(tt_router_weights, mesh_composer=mesh_composer)[:batch]
-    if decoder_layer.mlp.use_throughput_experts:
-        # throughput path returns sparse [batch, top_k] weights (top-k order)
-        tt_router_weights_torch = tt_router_weights_full[:, :top_k]
-    else:
-        # non-throughput path returns DENSE [batch, num_experts] (ttnn.scatter of the top_k weights at the
-        # selected expert ids); gather the weights at the selected indices so both sides are sparse
-        # [batch, top_k] aligned to their indices. Reading [:, :top_k] here would grab unselected experts.
-        tt_router_weights_torch = torch.gather(tt_router_weights_full, 1, tt_router_indices_torch.long())
+    tt_router_indices_torch = ttnn.to_torch(tt_router_indices, mesh_composer=mesh_composer)[:batch, :4]
+    tt_router_weights_torch = ttnn.to_torch(tt_router_weights, mesh_composer=mesh_composer)[:batch, :4]
 
     # Compare outputs
     # We will sort the indices here as the order of the indices is not guaranteed to be the same in the reference and TT implementation.
@@ -215,13 +216,11 @@ def run_topk_router_component(
     indices_passing, indices_output = compare_tensors(
         sorted_tt_indices, sorted_ref_indices, mesh_device, pcc_threshold=pcc_threshold
     )
-    # Reorder each token's weights into ascending-expert-id order so the two sides line up even when
-    # TT (bf16) and the reference (fp32) emit the same top-k experts in a different (value-sorted) order.
-    # gather along the top_k axis is the correct reorder; `weights.squeeze()[order]` indexes dim 0 and
-    # mangles the comparison for batch > 1.
     weights_passing, weights_output = compare_tensors(
-        torch.gather(tt_router_weights_torch, -1, sorted_tt_indices_order),
-        torch.gather(router_scores, -1, sorted_ref_indices_order),
+        tt_router_weights_torch.squeeze()[
+            sorted_tt_indices_order
+        ],  # we have to squeeze here because it breaks the indexing otherwise
+        router_scores.squeeze()[sorted_ref_indices_order],
         mesh_device,
         pcc_threshold=pcc_threshold,
     )

--- a/models/demos/gpt_oss/tests/unit/test_rope.py
+++ b/models/demos/gpt_oss/tests/unit/test_rope.py
@@ -907,7 +907,9 @@ def test_rope_yarn_values_match_hf(mesh_device, device_params, reset_seeds):
     rope_ours = rotary_embedding_factory(
         dim=hf_config.head_dim,
         max_position_embeddings=hf_config.max_position_embeddings,
-        base=hf_config.rope_theta,
+        # transformers 5.x folds rope_theta into rope_parameters (GptOssConfig has no rope_theta attr).
+        base=getattr(hf_config, "rope_theta", None)
+        or (getattr(hf_config, "rope_parameters", None) or {}).get("rope_theta", 150000.0),
         rope_scaling=rope_scaling,
     )
 

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -519,7 +519,6 @@
 
 - name: GPT-OSS 20B e2e tests
   cmd: |
-    uv pip install -r models/demos/gpt_oss/requirements.txt
     export TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/openai--gpt-oss-20b/ HF_MODEL=openai/gpt-oss-20b
     pytest models/demos/gpt_oss/demo/text_demo.py --timeout 600
   model: gpt-oss-20b
@@ -538,7 +537,6 @@
 
 - name: GPT-OSS 120B e2e tests
   cmd: |
-    uv pip install -r models/demos/gpt_oss/requirements.txt
     export HF_MODEL=openai/gpt-oss-120b TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/openai--gpt-oss-120b/ TT_MM_THROTTLE_PERF=2
     # Tensor cache is pre-built on the NAS — skip loading model weights by default.
     # Check mlperf-write-access in the workflow to load weights and regenerate the cache.

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -440,7 +440,6 @@
 # covers N150 (1x1), T3K/llmbox (1x8), and Galaxy (4x8) without per-SKU -k filters.
 - name: GPT-OSS 20B unit tests
   cmd: |
-    uv pip install -r models/demos/gpt_oss/requirements.txt
     export HF_MODEL=models/demos/gpt_oss/configs/gpt-oss-20b
     pytest --timeout 600 models/demos/gpt_oss/tests/unit/
   model: gpt-oss-20b
@@ -461,7 +460,6 @@
 
 - name: GPT-OSS 120B unit tests
   cmd: |
-    uv pip install -r models/demos/gpt_oss/requirements.txt
     export HF_MODEL=models/demos/gpt_oss/configs/gpt-oss-120b TT_MM_THROTTLE_PERF=2
     # Tensor cache is pre-built on the NAS — skip loading model weights by default.
     # Check mlperf-write-access in the workflow to load weights and regenerate the cache.

--- a/tests/pipeline_reorg/release_tests.yaml
+++ b/tests/pipeline_reorg/release_tests.yaml
@@ -450,7 +450,6 @@
 
 - name: Galaxy GPT-OSS 120B unit tests (high batch)
   cmd: |
-    uv pip install -r models/demos/gpt_oss/requirements.txt
     export HF_MODEL=openai/gpt-oss-120b TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/openai--gpt-oss-120b/
     pytest --timeout 1500 models/demos/gpt_oss/tests/unit -k "decode_high_throughput"
   model-name: gpt-oss-120b-high-batch-galaxy
@@ -497,7 +496,6 @@
 
 - name: Galaxy GPT-OSS 120B e2e tests (high batch)
   cmd: |
-    uv pip install -r models/demos/gpt_oss/requirements.txt
     export HF_MODEL=openai/gpt-oss-120b TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/openai--gpt-oss-120b/
     pytest models/demos/gpt_oss/demo/text_demo.py -k "batch128" --timeout 1200
   model-name: gpt-oss-120b-high-batch-galaxy


### PR DESCRIPTION
## Summary
Unpins GPT-OSS from its model-specific transformers version (the repo-wide pin in `requirements-dev.txt` is now 5.10.2) and fixes the 5.x incompatibilities surfaced by its unit / fused-op tests.

> **Note:** this PR was split from the original combined unpin branch. Qwen3-VL → #47818, gemma4 → #47817. This one is **GPT-OSS only**.

## 5.x migration fixes
- **MoE forward**: in 5.x the experts operate on **flattened** `[num_tokens, hidden]` tokens and the router returns a **3-tuple** `(router_logits, router_scores, router_indices)`; experts index `routing_weights` **by position** (`[num_tokens, top_k]`) rather than dense by-expert. `test_modules.py`: flatten `hidden_states`, 3-tuple router unpack, by-position `routing_weights_topk`, set `config._experts_implementation = "eager"`.
- `test_gpt_oss_router.py`: same 3-tuple router unpack.
- `test_rope.py`: `rope_theta` now lives under `rope_parameters` — read it version-tolerantly.
- Delete `models/demos/gpt_oss/requirements.txt` (it only pinned transformers) and drop its now-empty `uv pip install` lines from the `models_unit` / `models_e2e` / `release` pipeline configs; remove the "Bump up transformers" step from the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/unpin-transformers-5.10.2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/unpin-transformers-5.10.2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/unpin-transformers-5.10.2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/unpin-transformers-5.10.2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mtairum/unpin-transformers-5.10.2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mtairum/unpin-transformers-5.10.2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/unpin-transformers-5.10.2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/unpin-transformers-5.10.2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/unpin-transformers-5.10.2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/unpin-transformers-5.10.2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/unpin-transformers-5.10.2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/unpin-transformers-5.10.2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/unpin-transformers-5.10.2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/unpin-transformers-5.10.2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/unpin-transformers-5.10.2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/unpin-transformers-5.10.2)
## Final validation
Rebased on latest `main`; runs at **parity with main** (20B + 120B unit green). The 120B `decode_low_latency` router-weights sub-check uses the original comparison (same as main).
- **GPT-OSS 20B + 120B unit (Tiers 1+2, all SKUs):** https://github.com/tenstorrent/tt-metal/actions/runs/28115849129

## Scope note — 120B router gate fix split out → #47970
This PR is the **transformers 5.10.2 unpin only**. The corrected router-weights comparison (which surfaced a pre-existing, transformers-independent TT bf16 router-gate precision issue — top-2 gate weights collapse to 0.5/0.5 vs fp32 0.95/0.05 because `ttnn.topk` is bf16-only and the logits are large) and its `topk.py` fp32 fix are tracked separately in **#47970**, so this unpin stays at parity with main (which does not validate the router gate weights either). Full diagnosis + the 4×4 evidence matrix are in the PR comments.

