### PR TITLE
Add tests for Tail Call unwinding

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_output.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_output.cpp
@@ -563,3 +563,30 @@ TEST_F(DevicePrintOutputFixture, PrintCallstackCurrent) {
         /* present */ {"CALLSTACK_BEGIN", "kernel_main", "CALLSTACK_END"},
         /* absent */ {"current"});
 }
+
+TEST_F(DevicePrintOutputFixture, PrintCallstackTailCallUnambiguous) {
+    GTEST_SKIP() << "Fix unwinding of tail calls #47666";
+
+    TestCallstack(
+        "tests/tt_metal/tt_metal/test_kernels/device_print/print_callstack_tailcall_unambiguous.cpp",
+        /* present */ {"CALLSTACK_BEGIN", "leaf", "mid", "top", "kernel_main", "CALLSTACK_END"},
+        /* absent */ {"..."});
+}
+
+TEST_F(DevicePrintOutputFixture, PrintCallstackTailCallResolvable) {
+    GTEST_SKIP() << "Fix unwinding of tail calls #47666";
+
+    TestCallstack(
+        "tests/tt_metal/tt_metal/test_kernels/device_print/print_callstack_tailcall_resolvable.cpp",
+        /* present */ {"CALLSTACK_BEGIN", "left_top", "left", "fork_func", "kernel_main", "CALLSTACK_END"},
+        /* absent */ {"right", "right_top", "..."});
+}
+
+TEST_F(DevicePrintOutputFixture, PrintCallstackTailCallUnresolvable) {
+    GTEST_SKIP() << "Fix unwinding of tail calls #47666";
+
+    TestCallstack(
+        "tests/tt_metal/tt_metal/test_kernels/device_print/print_callstack_tailcall_unresolvable.cpp",
+        /* present */ {"CALLSTACK_BEGIN", "leaf", "...", "kernel_main", "CALLSTACK_END"},
+        /* absent */ {"left", "right"});
+}

--- a/tests/tt_metal/tt_metal/test_kernels/device_print/print_callstack_tailcall_resolvable.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/device_print/print_callstack_tailcall_resolvable.cpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/debug/device_print.h"
+
+// Tail-call reconstruction: AMBIGUOUS, RESOLVABLE case.
+//
+// kernel_main -> fork_func -> left -> left_top
+// The flow is the following:
+// - kernel_main makes an actual call to fork_func()
+// - fork_func makes a tail call to left()
+// - left makes a tail call to left_top()
+//
+// At DEVICE_PRINT position:
+// - PC resolves to left_top()
+// - RA resolves to kernel_main()
+//
+// The missing frames are RESOLVABLE, because only the left tail call path ends up at left_top()
+[[gnu::noinline]] void left_top() {
+    std::uintptr_t pc;
+    asm volatile("auipc %[pc], 0\n" : [pc] "=r"(pc));
+    std::uintptr_t ra = reinterpret_cast<std::uintptr_t>(__builtin_return_address(0));
+
+    DEVICE_PRINT(
+        "CALLSTACK_BEGIN\n"
+        "{}\n"
+        "CALLSTACK_END\n",
+        dp_top_callstack_t(pc, ra, 0));
+}
+
+[[gnu::noinline]] void left() { [[gnu::musttail]] return left_top(); }
+
+[[gnu::noinline]] void right_top() {
+    // this would be an empty function,
+    // but that would allow the compiler to optimize away the call,
+    // leading to the tail call in fork_func() frame being UNAMBIGUOUS.
+    volatile bool prevent_dce = true;
+    prevent_dce;
+}
+
+[[gnu::noinline]] void right() { [[gnu::musttail]] return right_top(); }
+
+[[gnu::noinline]] void fork_func() {
+    volatile bool take_left = true;
+    if (take_left) {
+        [[gnu::musttail]] return left();
+    } else {
+        [[gnu::musttail]] return right();
+    }
+}
+
+void kernel_main() {
+    volatile int force_real_call = 0;
+    fork_func();
+    force_real_call;  // prevent tail-call of fork_func() from kernel_main()
+}

--- a/tests/tt_metal/tt_metal/test_kernels/device_print/print_callstack_tailcall_unambiguous.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/device_print/print_callstack_tailcall_unambiguous.cpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/debug/device_print.h"
+
+// Tail-call reconstruction: UNAMBIGUOUS case.
+//
+// kernel_main -> top -> mid -> leaf
+// The flow is the following:
+// - kernel_main makes an actual call to top()
+// - top makes a tail call to mid()
+// - mid makes a tail call to leaf()
+//
+// At DEVICE_PRINT position:
+// - PC resolves to leaf()
+// - RA resolves to kernel_main()
+//
+// The missing frames will be reconstructed from the DWARF call graph.
+[[gnu::noinline]] void leaf() {
+    std::uintptr_t pc;
+    asm volatile("auipc %[pc], 0\n" : [pc] "=r"(pc));
+    std::uintptr_t ra = reinterpret_cast<std::uintptr_t>(__builtin_return_address(0));
+
+    DEVICE_PRINT(
+        "CALLSTACK_BEGIN\n"
+        "{}\n"
+        "CALLSTACK_END\n",
+        dp_top_callstack_t(pc, ra, 0));
+}
+
+[[gnu::noinline]] void mid() { [[gnu::musttail]] return leaf(); }
+
+[[gnu::noinline]] void top() { [[gnu::musttail]] return mid(); }
+
+void kernel_main() {
+    volatile int force_real_call = 0;
+    top();
+    force_real_call;  // prevent tail-call of top() from kernel_main()
+}

--- a/tests/tt_metal/tt_metal/test_kernels/device_print/print_callstack_tailcall_unresolvable.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/device_print/print_callstack_tailcall_unresolvable.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/debug/device_print.h"
+
+// Tail-call reconstruction: AMBIGUOUS, UNRESOLVABLE case.
+//
+// kernel_main -> fork_func -> {left, right} -> leaf
+// The flow is the following:
+// - kernel_main makes an actual call to fork_func()
+// - fork_func makes a tail call to either left() or right()
+// - both left() and right() make a tail call to the same leaf()
+//
+// At DEVICE_PRINT position:
+// - PC resolves to leaf()
+// - RA resolves to kernel_main()
+//
+// The missing frames are UNRESOLVABLE
+// because the left/right path can't be inferred from leaf
+[[gnu::noinline]] void leaf() {
+    std::uintptr_t pc;
+    asm volatile("auipc %[pc], 0\n" : [pc] "=r"(pc));
+    std::uintptr_t ra = reinterpret_cast<std::uintptr_t>(__builtin_return_address(0));
+
+    DEVICE_PRINT(
+        "CALLSTACK_BEGIN\n"
+        "{}\n"
+        "CALLSTACK_END\n",
+        dp_top_callstack_t(pc, ra, 0));
+}
+
+[[gnu::noinline]] void left() {
+    // we prevent identical code folding between left() and right()
+    // to ensure that the calls in fork_func() are ambiguous,
+    // and don't optimize into a single tail call.
+    volatile int prevent_icf = 0;
+    prevent_icf;
+    [[gnu::musttail]] return leaf();
+}
+
+[[gnu::noinline]] void right() {
+    volatile int prevent_icf = 1;
+    prevent_icf;
+    [[gnu::musttail]] return leaf();
+}
+
+[[gnu::noinline]] void fork_func() {
+    volatile bool take_left = true;
+    if (take_left) {
+        [[gnu::musttail]] return left();
+    } else {
+        [[gnu::musttail]] return right();
+    }
+}
+
+void kernel_main() {
+    volatile int force_real_call = 0;
+    fork_func();
+    force_real_call;  // prevent tail-call of fork_func() from kernel_main()
+}


### PR DESCRIPTION
Adds device-print callstack tests covering tail-call unwinding:
- `print_callstack_tailcall_unambiguous.cpp` — straight tail-call chain, fully reconstructed.
- `print_callstack_tailcall_resolvable.cpp` — branching tail calls where only one path reaches the observed PC, so reconstruction is unique.
- `print_callstack_tailcall_unresolvable.cpp` — both branches converge on the same leaf, so the intermediate frames are reported as an unresolved gap rather than guessed.

Stacked on top of #47670 (Simplify DEVICE_PRINT callstack API). Review/merge that one first.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk/san/pr/test-tail)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk/san/pr/test-tail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk/san/pr/test-tail)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk/san/pr/test-tail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=llk/san/pr/test-tail)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:llk/san/pr/test-tail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk/san/pr/test-tail)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk/san/pr/test-tail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk/san/pr/test-tail)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk/san/pr/test-tail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk/san/pr/test-tail)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk/san/pr/test-tail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk/san/pr/test-tail)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk/san/pr/test-tail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk/san/pr/test-tail)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk/san/pr/test-tail)