### PR TITLE
[Bug fix] Fix non-compliant CB usage in kernels

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/writer_reshape_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/writer_reshape_tiled.cpp
@@ -40,10 +40,6 @@ void kernel_main() {
         uint32_t input_base_addr, previous_input_page_idx = std::numeric_limits<uint32_t>::max();
         for (uint32_t seg_idx = 0; seg_idx < Max_Map_Entries; ++seg_idx) {
             if (map_ptr[seg_idx].num_elements == 0) {
-                if (output_page_idx == end_output_page - 1 && seg_idx == Max_Map_Entries - 1) {
-                    noc_async_write_barrier();
-                    cb_pop_front(cb_id_input, 1);
-                }
                 continue;
             }
 
@@ -73,6 +69,13 @@ void kernel_main() {
         noc_async_write_barrier();
 
         cb_pop_front(cb_id_mapping, 1);
+    }
+    // The per-transition pop only releases the previous input page's tile, so the final input
+    // tile waited inside the loop is still held here. Pop it once to leave the input CB balanced.
+    // Gated on `first` so a core that processed no segments does not pop a tile it never waited.
+    if (!first) {
+        noc_async_write_barrier();
+        cb_pop_front(cb_id_input, 1);
     }
     cb_push_back(cb_id_working, 1);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
@@ -123,6 +123,10 @@ void kernel_main() {
                 }
             }
         }
+
+        // cb_in1 is reserved once as an alignment scratchpad (no downstream consumer);
+        // commit the reservation so the CB is left balanced.
+        cb_in1.push_back(num_trids);
     }
     // Reset the sticky NOC_PACKET_TAG register for downstream untagged reads
     UnicastEndpoint self_ep;

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp
@@ -14,4 +14,7 @@ void kernel_main() {
     CircularBuffer cb_out(cb_id_out);
 
     cb_out.wait_front(num_units);
+    // Output is sharded in place, so the data is already where it needs to be; the
+    // wait above is only a readiness handshake. Pop to leave the CB balanced.
+    cb_out.pop_front(num_units);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp
@@ -53,6 +53,10 @@ void kernel_main() {
     uint32_t start_buffer_l1_addr = cb_tensor.get_write_ptr();
     noc.async_read(start_tensor_accessor, cb_tensor, tile_size, {.page_id = 0}, {.offset_bytes = 0});
     noc.async_read_barrier();
+    // Complete the producer/consumer handshake (reserve -> push -> wait -> pop) so the scratch CB
+    // is left balanced after this single-tile staging read.
+    cb_tensor.push_back(1);
+    cb_tensor.wait_front(1);
 
     volatile tt_l1_ptr uint32_t* start_data = (volatile tt_l1_ptr uint32_t*)start_buffer_l1_addr;
 
@@ -66,6 +70,10 @@ void kernel_main() {
     uint32_t end_buffer_l1_addr = cb_tensor.get_write_ptr();
     noc.async_read(end_tensor_accessor, cb_tensor, tile_size, {.page_id = 0}, {.offset_bytes = 0});
     noc.async_read_barrier();
+    // Complete the producer/consumer handshake (reserve -> push -> wait -> pop) so the scratch CB
+    // is left balanced after this single-tile staging read.
+    cb_tensor.push_back(1);
+    cb_tensor.wait_front(1);
 
     volatile tt_l1_ptr uint32_t* end_data = (volatile tt_l1_ptr uint32_t*)end_buffer_l1_addr;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp
@@ -89,7 +89,6 @@ ALWI void transpose_with_pack_untilize(uint32_t cb_tilize, CircularBuffer& cb_ou
         }
         cb_out_buf.push_back(Ht);
 
-        cb_out_buf.wait_front(Ht);
         tile_idx = tile_idx - HtWt + 1;
     }
     pack_untilize_uninit(cb_out);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary.cpp
@@ -18,7 +18,10 @@ void kernel_main() {
     CircularBuffer cb_dst(cb_id_dst);
 
 #if DST_SHARDED
+    // Output is sharded in place; the wait is only a readiness handshake. Pop to
+    // leave the CB balanced.
     cb_dst.wait_front(num_pages);
+    cb_dst.pop_front(num_pages);
 #else
     constexpr uint32_t onepage = 1;
     constexpr auto dst_args = TensorAccessorArgs<0, 0>();

--- a/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embedding_ind_tilized.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embedding_ind_tilized.cpp
@@ -123,4 +123,7 @@ void kernel_main() {
             }
         }
     }
+    // cb_in1 is reserved once as an index scratch buffer (no downstream consumer); commit the
+    // reservation so the CB is left balanced.
+    cb_in1.push_back(1);
 }

--- a/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings.cpp
@@ -91,4 +91,7 @@ void kernel_main() {
             read_indices = true;
         }
     }
+    // cb_in1 is reserved once as an index scratch buffer (no downstream consumer); commit the
+    // reservation so the CB is left balanced.
+    cb_in1.push_back(1);
 }

--- a/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_tilize.cpp
@@ -86,4 +86,7 @@ void kernel_main() {
             curr_row++;
         }
     }
+    // cb_in1 is reserved once as an index scratch buffer (no downstream consumer); commit the
+    // reservation so the CB is left balanced.
+    cb_in1.push_back(1);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_fused_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_fused_update_cache_interleaved_start_id.cpp
@@ -108,6 +108,8 @@ void kernel_main() {
                 const uint32_t block_offset = block_row_tile * Wt;
                 cache_id = block_start_id + block_offset;
 
+                // Page-table pages consumed; pop the same count waited above to balance the CB.
+                cb_page_table.pop_front(num_pages_to_read);
             } else {
                 const uint32_t cache_batch_tile_offset = my_batch_idx * cache_batch_num_tiles;
                 const uint32_t cache_start_id = cache_batch_tile_offset + (update_idx / TILE_HEIGHT) * Wt;
@@ -115,6 +117,9 @@ void kernel_main() {
             }
             cache_tile_offset_B = update_idx % TILE_HEIGHT * Wbytes;
         }
+        // The index value is consumed on both the skip and update paths; the reader pushes
+        // cb_index unconditionally, so pop it here (outside the skip branch) to balance the wait.
+        cb_index.pop_front(1);
     }
 
     cb_untilized_input.wait_front(Wt);  // input tensor

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
@@ -97,6 +97,8 @@ void kernel_main() {
                 const uint32_t block_offset = block_row_tile * Wt;
                 cache_id = block_start_id + block_offset;
 
+                // Page-table value consumed; pop to balance the wait above.
+                cb_page_table.pop_front(1);
             } else {
                 const uint32_t cache_batch_tile_offset = my_batch_idx * cache_batch_num_tiles;
                 const uint32_t cache_start_id = cache_batch_tile_offset + (update_idx / TILE_HEIGHT) * Wt;
@@ -104,6 +106,9 @@ void kernel_main() {
             }
             cache_tile_offset_B = update_idx % TILE_HEIGHT * Wbytes;
         }
+        // The index value is consumed on both the skip and update paths; the reader pushes
+        // cb_index unconditionally, so pop it here (outside the skip branch) to balance the wait.
+        cb_index.pop_front(1);
     }
 
     cb_untilized_input.wait_front(Wt);  // input tensor

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/kernels/reduce_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/kernels/reduce_nc.cpp
@@ -52,4 +52,7 @@ void kernel_main() {
         tile_regs_release();
         cb_out0_obj.push_back(onetile);
     }
+    // cb_in1 holds a single broadcast tile waited once and reused across all output tiles;
+    // pop it at the end so the CB is left balanced.
+    cb_in1_obj.pop_front(onetile);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_writer_interleaved_strided.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_writer_interleaved_strided.cpp
@@ -150,5 +150,10 @@ void kernel_main() {
         }
         noc.async_write_barrier();
         cb_in.pop_front(num_read_per_barrier);
+#ifdef LAST_DIM_STRIDED
+        // cb_out is filled, read back, and written out within this iteration; pop it (after the
+        // write barrier) so the scratch CB is balanced each iteration.
+        cb_out.pop_front(num_read_per_barrier);
+#endif
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/writer_ssm_prefix_scan.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/writer_ssm_prefix_scan.cpp
@@ -36,4 +36,8 @@ void kernel_main() {
     // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
     noc_async_write(src_addr, dst_addr, hidden_state_len_bytes);
     noc.async_write_barrier();
+
+    // cb_out is waited only as an output-ready handshake (the write above sources from cb_h_acc);
+    // pop it so the CB is left balanced.
+    cb_out_obj.pop_front(num_tiles_per_core);
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -577,4 +577,13 @@ void kernel_main() {
             }
         }
     }
+#ifdef FUSE_BIAS
+    // For num_blocks_w_dim == 1 the reader pushes bias once and the kernel holds it resident,
+    // reusing it across all batch/bh/block iterations without popping. Pop it once here, after the
+    // last use, so the CB is balanced. (For num_blocks_w_dim > 1 the per-block pop above already
+    // balances each re-pushed bias block.)
+    if constexpr (num_blocks_w_dim == 1) {
+        bias_cb.pop_front(bias_ntiles);
+    }
+#endif
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/kernels/moreh_dot.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/kernels/moreh_dot.cpp
@@ -15,6 +15,7 @@ void kernel_main() {
 
     CircularBuffer cb_c0(tt::CBIndex::c_0);
     CircularBuffer cb_c1(tt::CBIndex::c_1);
+    CircularBuffer cb_c2(tt::CBIndex::c_2);
     CircularBuffer cb_c24(tt::CBIndex::c_24);
 
     for (uint32_t block = 0; block < per_core_block_cnt; ++block) {
@@ -66,4 +67,7 @@ void kernel_main() {
                 compute_kernel_lib::Accumulate::at(tt::CBIndex::c_25, block));
         }
     }
+    // The reduce helper waits on the scaler CB (c_2) each block but never pops it; the single
+    // scaler tile is reused across all blocks. Pop it once at the end to balance the CB.
+    cb_c2.pop_front(onetile);
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm.cpp
@@ -395,4 +395,10 @@ void kernel_main() {
         untilize_all_blocks_from_cb<block_size>(cb_out, cb_out_rm, Wt);
 #endif
     }  // NCHt loop
+    // The reduce scaler is generated once by the reader and reused (waited inside row_wise_mean)
+    // across every NCHt iteration but never popped. Pop the producer's tile count once here to
+    // balance the CB. The reader pushes a second scaler tile only when the last column tile is
+    // partial (W not a multiple of tile_width), matching row_wise_mean's wait count.
+    constexpr uint32_t num_scaler_tiles = (W % tile_width > 0) ? 2 : 1;
+    CircularBuffer(cb_scaler).pop_front(num_scaler_tiles);
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor_welford.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor_welford.cpp
@@ -698,4 +698,7 @@ void kernel_main() {
         cb_ex2pe_obj.pop_front(onetile);
         cb_ex_obj.pop_front(onetile);
     }  // NCHt loop
+    // The single eps tile is waited once and reused across all NCHt iterations; pop it at the end
+    // so the CB is left balanced.
+    cb_eps_obj.pop_front(onetile);
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
@@ -468,5 +468,5 @@ void kernel_main() {
     }
     // The single scaler tile is waited by both reductions (E[x] and Var[x]) but never popped;
     // pop it once at the end so the CB is left balanced.
-    cb_scaler_obj.pop_front(1);
+    cb_scaler.pop_front(1);
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
@@ -466,4 +466,7 @@ void kernel_main() {
         cb_fusion.pop_front(num_tiles_per_block);
         cb_out.wait_front(num_tiles_per_block);
     }
+    // The single scaler tile is waited by both reductions (E[x] and Var[x]) but never popped;
+    // pop it once at the end so the CB is left balanced.
+    cb_scaler_obj.pop_front(1);
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln.cpp
@@ -240,6 +240,9 @@ void kernel_main() {
             cb_ex_global_obj.push_back(num_tiles * num_tiles_scaler);
         }
 
+        // The partial-reduction buffer is waited up front and read (locally and by remote cores)
+        // during the combine; by here all those reads have completed, so pop it to leave the CB
+        // balanced.
         cb_partial_obj.pop_front(block_h * num_tiles_scaler);
     };
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp
@@ -285,6 +285,10 @@ void kernel_main() {
                 noc.async_write_barrier();
             }
         }
+
+        // The partial-reduction buffer is waited up front and read during the combine; by here
+        // all those reads have completed, so pop it to leave the CB balanced.
+        cb_partial_obj.pop_front(block_h * num_tiles_scaler);
     };
 
     if constexpr (!rms_norm) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp
@@ -285,10 +285,6 @@ void kernel_main() {
                 noc.async_write_barrier();
             }
         }
-
-        // The partial-reduction buffer is waited up front and read during the combine; by here
-        // all those reads have completed, so pop it to leave the CB balanced.
-        cb_partial_obj.pop_front(block_h * num_tiles_scaler);
     };
 
     if constexpr (!rms_norm) {

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax.cpp
@@ -318,6 +318,11 @@ void kernel_main() {
         cb_recipsumexps_obj.pop_front(1);
         cb_exps_obj.pop_front(Wt);
     }  // NCHt loop
-    // cb_pop_front(cb_max_scaler, 1); // we don't actually have to do this
-    // cb_pop_front(cb_fused_scale, 1); // we don't actually have to do this
+    // The scaler tiles are each waited once and reused across the whole NCHt loop; pop them at
+    // the end so the CBs are left balanced.
+    cb_max_scaler_obj.pop_front(1);
+    cb_sum_scaler_obj.pop_front(1);
+#if FUSED_SCALE_MASK
+    cb_fused_scale_obj.pop_front(1);
+#endif
 }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce.cpp
@@ -7,6 +7,7 @@
 // FPU/GMPOOL. MIN on Int32 is dispatched separately via reduce_{h,w}_neg.
 
 #include <cstdint>
+#include "api/compute/cb_api.h"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 
 void kernel_main() {
@@ -40,4 +41,8 @@ void kernel_main() {
         compute_kernel_lib::NoOp{}
 #endif
     );
+
+    // The reduce helper waits on the scaler CB but never pops it (the single scaler tile is
+    // reused for the whole reduction). Pop it here so the CB is left balanced.
+    cb_pop_front(tt::CBIndex::c_2, 1);
 }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w_neg.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w_neg.cpp
@@ -103,6 +103,9 @@ void kernel_main() {
         }
 
         PACK((llk_pack_reduce_mask_clear()));
+        // The scaler tile is waited once and reused for the whole reduction; pop it at the
+        // end so the CB is left balanced.
+        cb_pop_front(cb_scaler, onetile);
         return;
     }
 
@@ -184,4 +187,7 @@ void kernel_main() {
             cb_output_obj.push_back(onetile);
         }  // ht
     }  // nc
+    // The scaler tile is waited once and reused for the whole reduction; pop it at the
+    // end so the CB is left balanced.
+    cb_scaler_obj.pop_front(onetile);
 }

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/compute/prod_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/compute/prod_nc.cpp
@@ -59,4 +59,7 @@ void kernel_main() {
             enable_reload = true;
         }
     }
+    // cb_in1 holds a single broadcast scaler tile waited once and reused across all output
+    // tiles; pop it at the end so the CB is left balanced.
+    cb_in1_obj.pop_front(onetile);
 }

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather.cpp
@@ -336,7 +336,13 @@ void kernel_main() {
         }
     }
 
-    if constexpr (skip_untilize) {
+    // src_cb is the resident input shard, read in place by both split readers. Only the
+    // block_start_offset == 0 reader does the reserve/push bookkeeping that marks it ready, so only
+    // that reader waits on (and later pops) it; the other reader reads the already-resident shard
+    // directly. Confining the wait/pop to the single producing reader keeps the shared input CB's
+    // received/acked counts balanced and avoids a cross-reader race on the shared read pointer (a
+    // pop from one reader must not retire pages the other reader is still waiting on).
+    if constexpr (skip_untilize && block_start_offset == 0) {
         src_cb.wait_front(in_nsticks);
     }
 
@@ -357,4 +363,11 @@ void kernel_main() {
 
     noc.async_read_barrier();
     noc.async_write_barrier();
+
+    // Balance the reserve/push + wait above on the single producing reader. The other split
+    // reader never waited src_cb, so it has nothing to pop and the shared read pointer is only
+    // advanced once, after this reader's reads are complete.
+    if constexpr (skip_untilize && block_start_offset == 0) {
+        src_cb.pop_front(in_nsticks);
+    }
 }

--- a/ttnn/cpp/ttnn/operations/uniform/device/kernels/writer_uniform.cpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/kernels/writer_uniform.cpp
@@ -72,4 +72,8 @@ void kernel_main() {
         noc.async_write_barrier();
 #endif
     }
+
+    // dst_cb is reserved once as a conversion-staging region (consumed only by direct NOC
+    // writes, never streamed to a consumer); commit the reservation so the CB is left balanced.
+    cb_dst.push_back(1);
 }


### PR DESCRIPTION
### Summary
New ASAN checks caught a number of violations of CB conventions in kernels.
This PR fixes all violations pointed out in #46791

Verified using usual CI suites, plus (Runtime) Integration Tests to exercise `test_transpose_wh_sharded_program_cache`, which was touched in this PR.
https://github.com/tenstorrent/tt-metal/actions/runs/27801639316

### Notes for reviewers
Given the current state of tt-emule and checks, it's not possible to rerun checks to verify that they are all clean now.
Given that this is blocking development, all issues are supposed to be addressed and CI shows no new failures, propose to merge this now and perform final validation once tt-emule/checks are again stable.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fplavec/46791_cb_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fplavec/46791_cb_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fplavec/46791_cb_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fplavec/46791_cb_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fplavec/46791_cb_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fplavec/46791_cb_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fplavec/46791_cb_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fplavec/46791_cb_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fplavec/46791_cb_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fplavec/46791_cb_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fplavec/46791_cb_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fplavec/46791_cb_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fplavec/46791_cb_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fplavec/46791_cb_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fplavec/46791_cb_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fplavec/46791_cb_fixes)