### PR TITLE
[Performance] Re-enable SFPLOADMACRO for SFPU typecasts on Blackhole & Wormhole (#46751)

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -57,6 +57,12 @@ inline void calculate_typecast_fp32_to_uint16() {
         // 1 | ...  |                   |     | [v] L16 = rnd(v) |         |
         // 0 | ...  |                   |     |                  | [v] L16 |
 
+        // SFPLOADMACRO operand encoding: operand0 = (macro_select << 2) | (VD & 3) and the
+        // trailing operand = VD >> 2, so the hardware reconstructs the value-register index
+        // VD = (trailing << 2) | (operand0 & 3) -- a 3-bit index spanning LREG0..LREG7 -- while
+        // operand0[3:2] selects which armed macro fires. Here VD is 0/1 and macro_select 0, so
+        // the mask/shift are no-ops, but the same idiom addresses VD >= 4 elsewhere (e.g.
+        // calculate_typecast_uint32_to_fp32 fires macro 2 with VD = LREG7).
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
             int v = d & 1;  // alternate between p_sfpu::LREG0 and p_sfpu::LREG1

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -31,12 +31,21 @@ constexpr std::uint32_t SFPGT_MOD1_SET_ALL_ONES = 8;
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool DST_ACCUM_MODE>
 inline void calculate_typecast_fp32_to_uint16() {
-#ifndef DISABLE_SFPLOADMACRO
+#ifdef DISABLE_SFPLOADMACRO
+#pragma GCC unroll 0
+    for (int d = 0; d < ITERATIONS; d++) {
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+        TTI_SFPSWAP(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 9);
+        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
+        if (DST_ACCUM_MODE) {
+            TTI_SFPSTORE(p_sfpu::LREG0, SFPSTORE_MODE_SWAP_HI_LO16, ADDR_MOD_6, 0);
+        } else {
+            TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_6, 0);
+        }
+    }
+#else
     if constexpr (!DST_ACCUM_MODE) {
-        // This uses SFPLOADMACRO to achieve a throughput of 2 cycles per input row.
-        // It is only used for the 16-bit Dest (LO16 store) case; the 32-bit Dest case
-        // needs the swap-hi-lo16 store, which the init-time macro store mode cannot
-        // express, so it falls through to the plain loop below.
+        // 16-bit Dest: SFPLOADMACRO fast path, throughput of 2 cycles per input row.
         //
         // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
         //
@@ -57,20 +66,18 @@ inline void calculate_typecast_fp32_to_uint16() {
         TTI_SFPNOP;
         TTI_SFPNOP;
         TTI_SFPNOP;
-        return;
-    }
-#endif
+    } else {
+        // 32-bit Dest: the swap-hi-lo16 store cannot be expressed by the init-time macro store
+        // mode, so this case uses the plain loop instead of SFPLOADMACRO.
 #pragma GCC unroll 0
-    for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
-        TTI_SFPSWAP(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 9);
-        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
-        if (DST_ACCUM_MODE) {
+        for (int d = 0; d < ITERATIONS; d++) {
+            TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+            TTI_SFPSWAP(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 9);
+            TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
             TTI_SFPSTORE(p_sfpu::LREG0, SFPSTORE_MODE_SWAP_HI_LO16, ADDR_MOD_6, 0);
-        } else {
-            TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_6, 0);
         }
     }
+#endif
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
@@ -249,15 +256,19 @@ inline void calculate_typecast_fp32_to_fp16b() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool DST_ACCUM_MODE>
 inline void calculate_typecast_uint16_to_fp32() {
-#ifndef DISABLE_SFPLOADMACRO
+#ifdef DISABLE_SFPLOADMACRO
+#pragma GCC unroll 0
+    for (int d = 0; d < ITERATIONS; d++) {
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+        TTI_SFPAND(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
+        TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
+        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_6, 0);
+    }
+#else
     if constexpr (!DST_ACCUM_MODE) {
-        // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
-        // It is only used for the 16-bit Dest case; the 32-bit Dest (DST_ACCUM_MODE)
-        // case needs the INT32 load + 0xFFFF mask addressing, which the macro's LO16
-        // load schedule does not reproduce, so it falls through to the plain loop below.
-        //
-        // The LO16 load keeps only the low 16 bits (the UInt16 value), so casting it
-        // produces the same result as the plain loop's INT32 load + 0xFFFF mask + cast.
+        // 16-bit Dest: SFPLOADMACRO fast path, throughput of 1 cycle per input row. The LO16 load
+        // keeps only the low 16 bits (the UInt16 value), so casting it matches the plain loop's
+        // INT32 load + 0xFFFF mask + cast.
         //
         // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
         //
@@ -275,16 +286,18 @@ inline void calculate_typecast_uint16_to_fp32() {
         }
         TTI_SFPNOP;
         TTI_SFPNOP;
-        return;
+    } else {
+        // 32-bit Dest: the macro's LO16 load cannot reproduce the INT32 + 0xFFFF mask path, so
+        // this case uses the plain loop instead of SFPLOADMACRO.
+#pragma GCC unroll 0
+        for (int d = 0; d < ITERATIONS; d++) {
+            TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+            TTI_SFPAND(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
+            TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
+            TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_6, 0);
+        }
     }
 #endif
-#pragma GCC unroll 0
-    for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
-        TTI_SFPAND(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
-        TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_6, 0);
-    }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
@@ -453,16 +466,18 @@ inline void calculate_typecast_uint32_to_fp32() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool DST_ACCUM_MODE>
 inline void calculate_typecast_uint16_to_uint32() {
-#ifndef DISABLE_SFPLOADMACRO
+#ifdef DISABLE_SFPLOADMACRO
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+        TTI_SFPAND(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
+        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_6, 0);
+    }
+#else
     if constexpr (!DST_ACCUM_MODE) {
-        // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
-        // It is only used for the 16-bit Dest case; the 32-bit Dest (DST_ACCUM_MODE)
-        // case needs the INT32 load + 0xFFFF mask addressing, which the macro's LO16
-        // load schedule does not reproduce, so it falls through to the plain loop below.
-        //
-        // The LO16 load keeps only the low 16 bits (the UInt16 value) and zero-extends
-        // them, so the INT32 store writes the same result as the plain loop's INT32
-        // load + 0xFFFF mask.
+        // 16-bit Dest: SFPLOADMACRO fast path, throughput of 1 cycle per input row. The LO16 load
+        // keeps only the low 16 bits (the UInt16 value) and zero-extends them, so the INT32 store
+        // matches the plain loop's INT32 load + 0xFFFF mask.
         //
         // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
         //
@@ -476,15 +491,17 @@ inline void calculate_typecast_uint16_to_uint32() {
             TTI_SFPLOADMACRO((0 << 2) | 0, InstrModLoadStore::LO16, ADDR_MOD_6, 0);
         }
         TTI_SFPNOP;
-        return;
+    } else {
+        // 32-bit Dest: the macro's LO16 load cannot reproduce the INT32 + 0xFFFF mask path, so
+        // this case uses the plain loop instead of SFPLOADMACRO.
+#pragma GCC unroll 8
+        for (int d = 0; d < ITERATIONS; d++) {
+            TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+            TTI_SFPAND(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
+            TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_6, 0);
+        }
     }
 #endif
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
-        TTI_SFPAND(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_6, 0);
-    }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -161,7 +161,7 @@ inline void calculate_typecast_int32_to_fp16b() {
         int v = 2 + (d & 1);  // alternate between p_sfpu::LREG2 and p_sfpu::LREG3
         TT_SFPLOADMACRO((0 << 2) | (v & 3), InstrModLoadStore::INT32, ADDR_MOD_6, v >> 2);
         TT_SFPABS(0, v, t, 0);
-        TTI_SFPSHFT2(t, p_sfpu::LREG12, p_sfpu::LREG7, 5);  // SFPSHFT2_MOD1_SHFT_LREG
+        TTI_SFPSHFT2(t, p_sfpu::LREG12, p_sfpu::LREG7, sfpi::SFPSHFT2_MOD1_SHFT_LREG);
         TTI_SFPCAST(t, t, 0);
     }
     TTI_SFPNOP;
@@ -346,7 +346,7 @@ inline void calculate_typecast_int32_to_fp32() {
         int v = 2 + (d & 1);  // alternate between p_sfpu::LREG2 and p_sfpu::LREG3
         TT_SFPLOADMACRO((0 << 2) | (v & 3), InstrModLoadStore::INT32, ADDR_MOD_6, v >> 2);
         TT_SFPABS(0, v, t, 0);
-        TTI_SFPSHFT2(t, p_sfpu::LREG12, p_sfpu::LREG7, 5);  // SFPSHFT2_MOD1_SHFT_LREG
+        TTI_SFPSHFT2(t, p_sfpu::LREG12, p_sfpu::LREG7, sfpi::SFPSHFT2_MOD1_SHFT_LREG);
         TTI_SFPCAST(t, t, 0);
     }
     TTI_SFPNOP;
@@ -399,7 +399,7 @@ inline void calculate_typecast_uint32_to_fp16b() {
     for (int d = 0; d < ITERATIONS; d++) {
         int v = 2 + (d & 1);  // alternate between p_sfpu::LREG2 and p_sfpu::LREG3
         TT_SFPLOADMACRO((0 << 2) | (v & 3), InstrModLoadStore::INT32, ADDR_MOD_6, v >> 2);
-        TT_SFPSHFT2(v, p_sfpu::LREG12, p_sfpu::LREG7, 5);  // SFPSHFT2_MOD1_SHFT_LREG
+        TT_SFPSHFT2(v, p_sfpu::LREG12, p_sfpu::LREG7, sfpi::SFPSHFT2_MOD1_SHFT_LREG);
         TT_SFPSETSGN(0, v, v, 1);
     }
     TTI_SFPNOP;
@@ -606,13 +606,16 @@ inline void init_typecast_uint16_to_uint32() {
 #endif
 }
 
+// SFPCAST interprets its input as sign-magnitude, so bit 31 of the source flags the case
+// that needs a post-cast fixup. vConstIntPrgm0 (LREG12) is preloaded with -31 -- the shift
+// amount the int/uint -> float macro inits (init_typecast_{uint32,int32}_to_fp32 / _to_fp16b)
+// use to extract that bit.
+inline void preload_sign_magnitude_cast_fixup() { sfpi::vConstIntPrgm0 = -31; }
+
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint32_to_fp32() {
 #ifndef DISABLE_SFPLOADMACRO
-    // SFPCAST interprets its input as sign-magnitude, so bit 31 of the source
-    // flags the case that needs a post-cast fixup. vConstIntPrgm0 (LREG12) is
-    // preloaded with -31 -- the shift amount used to extract that bit.
-    sfpi::vConstIntPrgm0 = -31;
+    preload_sign_magnitude_cast_fixup();
 
     constexpr int a = p_sfpu::LREG2;
 
@@ -623,7 +626,7 @@ inline void init_typecast_uint32_to_fp32() {
     TTI_SFPCAST(a, 13, 0);
 
     // InstructionTemplate[2]
-    TTI_SFPSHFT2(0, p_sfpu::LREG12, 14, 5);  // SFPSHFT2_MOD1_SHFT_LREG
+    TTI_SFPSHFT2(0, p_sfpu::LREG12, 14, sfpi::SFPSHFT2_MOD1_SHFT_LREG);
 
     // InstructionTemplate[3]
     TTI_SFPMAD(0, p_sfpu::LCONST_1, 0, 15, 4);  // SFPMAD_MOD1_INDIRECT_VA
@@ -668,10 +671,7 @@ inline void init_typecast_int32_to_fp32() {
 #ifndef DISABLE_SFPLOADMACRO
     constexpr int t = p_sfpu::LREG4;
 
-    // SFPCAST interprets its input as sign-magnitude, so bit 31 of the source
-    // flags the case that needs a post-cast fixup. vConstIntPrgm0 (LREG12) is
-    // preloaded with -31 -- the shift amount used to extract that bit.
-    sfpi::vConstIntPrgm0 = -31;
+    preload_sign_magnitude_cast_fixup();
 
     // InstructionTemplate[0]
     TTI_SFPSETSGN(0, t, 12, 0);
@@ -705,10 +705,7 @@ inline void init_typecast_int32_to_fp16b() {
 #ifndef DISABLE_SFPLOADMACRO
     constexpr int t = p_sfpu::LREG4;
 
-    // SFPCAST interprets its input as sign-magnitude, so bit 31 of the source
-    // flags the case that needs a post-cast fixup. vConstIntPrgm0 (LREG12) is
-    // preloaded with -31 -- the shift amount used to extract that bit.
-    sfpi::vConstIntPrgm0 = -31;
+    preload_sign_magnitude_cast_fixup();
 
     // InstructionTemplate[0]
     TTI_SFPSETSGN(0, t, 12, 0);
@@ -808,10 +805,7 @@ inline void init_typecast_uint16_to_fp16b() {
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint32_to_fp16b() {
 #ifndef DISABLE_SFPLOADMACRO
-    // SFPCAST interprets its input as sign-magnitude, so bit 31 of the source
-    // flags the case that needs a post-cast fixup. vConstIntPrgm0 (LREG12) is
-    // preloaded with -31 -- the shift amount used to extract that bit.
-    sfpi::vConstIntPrgm0 = -31;
+    preload_sign_magnitude_cast_fixup();
 
     // InstructionTemplate[0]
     TTI_SFPCAST(0, 12, 0);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -486,9 +486,11 @@ inline void calculate_typecast_uint16_to_uint32() {
         // 0 | [v]  |        |     |       |       |
         // 0 | ...  |        |     |       | [v]   |
 
+        constexpr int v = p_sfpu::LREG0;
+
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
-            TTI_SFPLOADMACRO((0 << 2) | 0, InstrModLoadStore::LO16, ADDR_MOD_6, 0);
+            TTI_SFPLOADMACRO((0 << 2) | (v & 3), InstrModLoadStore::LO16, ADDR_MOD_6, v >> 2);
         }
         TTI_SFPNOP;
     } else {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -31,7 +31,35 @@ constexpr std::uint32_t SFPGT_MOD1_SET_ALL_ONES = 8;
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool DST_ACCUM_MODE>
 inline void calculate_typecast_fp32_to_uint16() {
-    // TODO: Attempt to use LOADMACRO #46751
+#ifndef DISABLE_SFPLOADMACRO
+    if constexpr (!DST_ACCUM_MODE) {
+        // This uses SFPLOADMACRO to achieve a throughput of 2 cycles per input row.
+        // It is only used for the 16-bit Dest (LO16 store) case; the 32-bit Dest case
+        // needs the swap-hi-lo16 store, which the init-time macro store mode cannot
+        // express, so it falls through to the plain loop below.
+        //
+        // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
+        //
+        // t | Load | Simple            | MAD | Round            | Store   |
+        // - | ---- | ----------------- | --- | ---------------- | ------- |
+        // 0 | [v]  |                   |     |                  |         |
+        // 1 | nop  | [v] = max(v, 0.0) |     |                  |         |
+        // 0 | ...  | (must be idle)    |     | (must be idle)   |         |
+        // 1 | ...  |                   |     | [v] L16 = rnd(v) |         |
+        // 0 | ...  |                   |     |                  | [v] L16 |
+
+#pragma GCC unroll 8
+        for (int d = 0; d < ITERATIONS; d++) {
+            int v = d & 1;  // alternate between p_sfpu::LREG0 and p_sfpu::LREG1
+            TT_SFPLOADMACRO((0 << 2) | (v & 3), InstrModLoadStore::DEFAULT, ADDR_MOD_6, v >> 2);
+            TTI_SFPNOP;
+        }
+        TTI_SFPNOP;
+        TTI_SFPNOP;
+        TTI_SFPNOP;
+        return;
+    }
+#endif
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
@@ -203,7 +231,10 @@ inline void calculate_typecast_fp32_to_uint32() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_fp32_to_fp16b() {
-    // TODO: Attempt to use LOADMACRO #46751
+    // Kept as a plain loop (no SFPLOADMACRO): #46231 rewrote this to round, mask off the
+    // low 16 bits (&0xFFFF0000), and store FP32 for 32-bit-Dest correctness. The historical
+    // macro relied on a FP16B store to truncate and does not reproduce the masked-FP32 result,
+    // so it is not equivalent and is not restored here. See #46751.
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
@@ -216,9 +247,37 @@ inline void calculate_typecast_fp32_to_fp16b() {
     }
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool DST_ACCUM_MODE>
 inline void calculate_typecast_uint16_to_fp32() {
-    // TODO: Attempt to use LOADMACRO #46751
+#ifndef DISABLE_SFPLOADMACRO
+    if constexpr (!DST_ACCUM_MODE) {
+        // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
+        // It is only used for the 16-bit Dest case; the 32-bit Dest (DST_ACCUM_MODE)
+        // case needs the INT32 load + 0xFFFF mask addressing, which the macro's LO16
+        // load schedule does not reproduce, so it falls through to the plain loop below.
+        //
+        // The LO16 load keeps only the low 16 bits (the UInt16 value), so casting it
+        // produces the same result as the plain loop's INT32 load + 0xFFFF mask + cast.
+        //
+        // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
+        //
+        // t | Load | Simple            | MAD | Round | Store   |
+        // - | ---- | ----------------- | --- | ----- | ------- |
+        // 0 | [v]  |                   |     |       |         |
+        // 0 | ...  | [v] L16 = cast(v) |     |       |         |
+        // 0 | ...  |                   |     |       | [v] L16 |
+
+        constexpr int v = p_sfpu::LREG0;
+
+#pragma GCC unroll 8
+        for (int d = 0; d < ITERATIONS; d++) {
+            TTI_SFPLOADMACRO((0 << 2) | (v & 3), InstrModLoadStore::LO16, ADDR_MOD_6, v >> 2);
+        }
+        TTI_SFPNOP;
+        TTI_SFPNOP;
+        return;
+    }
+#endif
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
@@ -286,7 +345,7 @@ inline void calculate_typecast_int32_to_fp32() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_uint32_to_fp16b() {
-    // TODO: Attempt to use LOADMACRO #46751
+#ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
@@ -298,6 +357,44 @@ inline void calculate_typecast_uint32_to_fp16b() {
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG1, p_sfpu::LREG1, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
         TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::FP32, ADDR_MOD_6, 0);
     }
+#else
+    // This uses SFPLOADMACRO to achieve a throughput of 3 cycles per input row.
+    //
+    // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
+    //
+    // Note: L0=0.0 and L1=2**31.  The sign bit is stored in L7 and used to pick L0 or L1
+    // for SFPMAD's VA:
+    //
+    // - if sign bit is 0, then compute L0*1.0 + v = v
+    // - if sign bit is 1, then compute L1*1.0 + v = 2**31 + v
+    //
+    // t | Load | Simple             | MAD                     | Round            | Store   |
+    // - | ---- | ------------------ | ----------------------- | ---------------- | ------- |
+    // 0 | [v]  |                    |                         |                  |         |
+    // 1 |      |                    |                         | L7 = v >> 31     |         |
+    // 2 |      | v = setsgn(v, 0)   |                         |                  |         |
+    // 0 | ...  | [v] = cast(v)      |                         |                  |         |
+    // 1 | ...  |                    | [v] v = L[L7]*1.0 + v   |                  |         |
+    // 2 | ...  |                    |                         |                  |         |
+    // 0 | ...  |                    |                         | [v] L16 = rnd(v) |         |
+    // 1 | ...  |                    |                         |                  | [v] L16 |
+
+    TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_USHORT, 0);
+    TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_FLOATB, 0x4f00);  // 2**31
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        int v = 2 + (d & 1);  // alternate between p_sfpu::LREG2 and p_sfpu::LREG3
+        TT_SFPLOADMACRO((0 << 2) | (v & 3), InstrModLoadStore::INT32, ADDR_MOD_6, v >> 2);
+        TT_SFPSHFT2(v, p_sfpu::LREG12, p_sfpu::LREG7, 5);  // SFPSHFT2_MOD1_SHFT_LREG
+        TT_SFPSETSGN(0, v, v, 1);
+    }
+    TTI_SFPNOP;
+    TTI_SFPNOP;
+    TTI_SFPNOP;
+    TTI_SFPNOP;
+    TTI_SFPNOP;
+#endif
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
@@ -354,9 +451,34 @@ inline void calculate_typecast_uint32_to_fp32() {
 #endif
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool DST_ACCUM_MODE>
 inline void calculate_typecast_uint16_to_uint32() {
-    // TODO: Attempt to use LOADMACRO #46751
+#ifndef DISABLE_SFPLOADMACRO
+    if constexpr (!DST_ACCUM_MODE) {
+        // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
+        // It is only used for the 16-bit Dest case; the 32-bit Dest (DST_ACCUM_MODE)
+        // case needs the INT32 load + 0xFFFF mask addressing, which the macro's LO16
+        // load schedule does not reproduce, so it falls through to the plain loop below.
+        //
+        // The LO16 load keeps only the low 16 bits (the UInt16 value) and zero-extends
+        // them, so the INT32 store writes the same result as the plain loop's INT32
+        // load + 0xFFFF mask.
+        //
+        // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
+        //
+        // t | Load | Simple | MAD | Round | Store |
+        // - | ---- | ------ | --- | ----- | ----- |
+        // 0 | [v]  |        |     |       |       |
+        // 0 | ...  |        |     |       | [v]   |
+
+#pragma GCC unroll 8
+        for (int d = 0; d < ITERATIONS; d++) {
+            TTI_SFPLOADMACRO((0 << 2) | 0, InstrModLoadStore::LO16, ADDR_MOD_6, 0);
+        }
+        TTI_SFPNOP;
+        return;
+    }
+#endif
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
@@ -367,7 +489,10 @@ inline void calculate_typecast_uint16_to_uint32() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_uint32_to_uint16() {
-    // TODO: Attempt to use LOADMACRO #46751
+    // Kept as a plain loop (no SFPLOADMACRO): #46231 rewrote this to shift the value right by 16
+    // and saturate via SFPGT on the *high* bits before the swap-hi-lo16 store. The historical
+    // macro tested the low 16 bits instead and computes a different result, so it is not
+    // equivalent and is not restored here. See #46751.
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
@@ -381,7 +506,7 @@ inline void calculate_typecast_uint32_to_uint16() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_int32_to_uint16() {
-    // TODO: Attempt to use LOADMACRO #46751
+#ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
@@ -390,6 +515,39 @@ inline void calculate_typecast_int32_to_uint16() {
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
         TTI_SFPSTORE(p_sfpu::LREG0, SFPSTORE_MODE_SWAP_HI_LO16, ADDR_MOD_6, 0);
     }
+#else
+    // This uses SFPLOADMACRO to achieve a throughput of 3 cycles per input row.
+    //
+    // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
+    //
+    // t | Load | Simple            | MAD | Round            | Store   |
+    // - | ---- | ----------------- | --- | ---------------- | ------- |
+    // 0 | [a]  |                   |     |                  |         |
+    // 1 |      | a = cast_fp32(a)  |     |                  |         |
+    // 2 | nop  | [a] = max(0.0, a) |     |                  |         |
+    // 0 | ...  | (must be idle)    |     |                  |         |
+    // 1 | ...  |                   |     | [a] L16 = rnd(a) |         |
+    // 2 | ...  |                   |     |                  | [a] swap|
+    //
+    // Simple/Round sub-units can be used simultaneously if one has VD=16 and
+    // the other VD!=16.  The following steps clamp the input value to 0-65535:
+    //
+    // a = cast_fp32(a); this allows us to use SFPSTOCHRND later to convert to uint16, clamping to 65535.
+    // swap_minmax(0.0, a); since SFPSTOCHRND takes the absolute value before clamping, we use SFPSWAP to clamp negative
+    // values to 0.0. L16 = rnd(a); finally, we use SFPSTOCHRND to clamp large values to 65535, using VD=16. The macro
+    // Store uses SFPSTORE_MODE_SWAP_HI_LO16, matching the plain-loop store that lands the uint16 in the high 16 bits.
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        int a = d & 1;  // alternate between p_sfpu::LREG0 and p_sfpu::LREG1
+        TT_SFPLOADMACRO((0 << 2) | (a & 3), InstrModLoadStore::INT32, ADDR_MOD_6, a >> 2);
+        TT_SFPCAST(a, a, 0);
+        TTI_SFPNOP;
+    }
+    TTI_SFPNOP;
+    TTI_SFPNOP;
+    TTI_SFPNOP;
+#endif
 }
 
 template <bool APPROXIMATION_MODE>
@@ -401,7 +559,34 @@ inline void init_typecast_fp32_to_fp16b() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint16_to_uint32() {
+#ifdef DISABLE_SFPLOADMACRO
     TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, UINT16_LOW_MASK);
+#else
+    // The 32-bit Dest (DST_ACCUM_MODE) path of calculate_typecast_uint16_to_uint32 falls
+    // back to the plain loop, which masks the loaded word with LREG1. Load the mask here
+    // so that path is correct; the macro-programming below only targets LREG0, so LREG1
+    // survives. The 16-bit Dest macro path does not read LREG1.
+    TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, UINT16_LOW_MASK);
+
+    // Macro 0: store only (the LO16 load already zero-extends the UInt16 value).
+    {
+        constexpr std::uint32_t simple_bits = 0;
+        constexpr std::uint32_t mad_bits = 0;
+        constexpr std::uint32_t round_bits = 0;
+        constexpr std::uint32_t store_bits = 0x00 | 0x00 | (0 << 3) | 3;
+
+        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
+        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
+        TTI_SFPCONFIG(0, 4 + 0, 0);
+    }
+
+    // Misc: {
+    //   StoreMod0: INT32,
+    //   UsesLoadMod0ForStore: {0},
+    //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
+    // }
+    TTI_SFPCONFIG(0x100 | InstrModLoadStore::INT32, 8, 1);
+#endif
 }
 
 template <bool APPROXIMATION_MODE>
@@ -540,7 +725,37 @@ inline void init_typecast_int32_to_fp16b() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint16_to_fp32() {
+#ifdef DISABLE_SFPLOADMACRO
     TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, UINT16_LOW_MASK);
+#else
+    // The 32-bit Dest (DST_ACCUM_MODE) path of calculate_typecast_uint16_to_fp32 falls
+    // back to the plain loop, which masks the loaded word with LREG1. Load the mask here
+    // so that path is correct; the macro-programming below only targets LREG0, so LREG1
+    // survives. The 16-bit Dest macro path does not read LREG1.
+    TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, UINT16_LOW_MASK);
+
+    // InstructionTemplate[0]
+    TTI_SFPCAST(0, 12, 0);
+
+    // Macro 0
+    {
+        constexpr std::uint32_t simple_bits = 0x00 | 0x40 | (0 << 3) | (4 + 0);
+        constexpr std::uint32_t mad_bits = 0;
+        constexpr std::uint32_t round_bits = 0;
+        constexpr std::uint32_t store_bits = 0x00 | 0x40 | (1 << 3) | 3;
+
+        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
+        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
+        TTI_SFPCONFIG(0, 4 + 0, 0);
+    }
+
+    // Misc: {
+    //   StoreMod0: FP32,
+    //   UsesLoadMod0ForStore: {0},
+    //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
+    // }
+    TTI_SFPCONFIG(0x100 | InstrModLoadStore::FP32, 8, 1);
+#endif
 }
 
 template <bool APPROXIMATION_MODE>
@@ -574,16 +789,108 @@ inline void init_typecast_uint16_to_fp16b() {
 }
 
 template <bool APPROXIMATION_MODE>
-inline void init_typecast_uint32_to_fp16b() {}
+inline void init_typecast_uint32_to_fp16b() {
+#ifndef DISABLE_SFPLOADMACRO
+    // SFPCAST interprets its input as sign-magnitude, so bit 31 of the source
+    // flags the case that needs a post-cast fixup. vConstIntPrgm0 (LREG12) is
+    // preloaded with -31 -- the shift amount used to extract that bit.
+    sfpi::vConstIntPrgm0 = -31;
+
+    // InstructionTemplate[0]
+    TTI_SFPCAST(0, 12, 0);
+
+    // InstructionTemplate[1]
+    TTI_SFPMAD(0, p_sfpu::LCONST_1, 0, 13, 4);  // SFPMAD_MOD1_INDIRECT_VA
+
+    // InstructionTemplate[2]
+    TTI_SFP_STOCH_RND(0, 0, 0, 0, 14, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
+
+    // Macro 0
+    {
+        constexpr std::uint32_t simple_bits = 0x00 | 0x00 | (2 << 3) | (4 + 0);
+        constexpr std::uint32_t mad_bits = 0x00 | 0x00 | (3 << 3) | (4 + 1);
+        constexpr std::uint32_t round_bits = 0x00 | 0x40 | (5 << 3) | (4 + 2);
+        constexpr std::uint32_t store_bits = 0x00 | 0x40 | (6 << 3) | 3;
+
+        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
+        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
+        TTI_SFPCONFIG(0, 4 + 0, 0);
+    }
+
+    // Misc: {
+    //   StoreMod0: FP32,
+    //   UsesLoadMod0ForStore: {0},
+    //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
+    // }
+    TTI_SFPCONFIG(0x100 | InstrModLoadStore::FP32, 8, 1);
+#endif
+}
 
 template <bool APPROXIMATION_MODE>
-inline void init_typecast_fp32_to_uint16() {}
+inline void init_typecast_fp32_to_uint16() {
+#ifndef DISABLE_SFPLOADMACRO
+    // Programs the macro used by the 16-bit Dest (LO16 store) path of
+    // calculate_typecast_fp32_to_uint16. The 32-bit Dest path uses the plain loop.
+
+    // InstructionTemplate[0]
+    TTI_SFPSWAP(0, p_sfpu::LCONST_0, 12, 0xf);  // L[VD] = max(0, L[VD])
+
+    // InstructionTemplate[1]
+    TTI_SFP_STOCH_RND(0, 0, 0, 0, 13, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
+
+    // Macro 0
+    {
+        constexpr std::uint32_t simple_bits = 0x80 | 0x00 | (0 << 3) | (4 + 0);
+        constexpr std::uint32_t mad_bits = 0;
+        constexpr std::uint32_t round_bits = 0x00 | 0x40 | (2 << 3) | (4 + 1);
+        constexpr std::uint32_t store_bits = 0x00 | 0x40 | (3 << 3) | 3;
+
+        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
+        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
+        TTI_SFPCONFIG(0, 4 + 0, 0);
+    }
+
+    // Misc: {
+    //   StoreMod0: LO16,
+    //   UsesLoadMod0ForStore: {0},
+    //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
+    // }
+    TTI_SFPCONFIG(0x100 | InstrModLoadStore::LO16, 8, 1);
+#endif
+}
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint32_to_uint16() {}
 
 template <bool APPROXIMATION_MODE>
-inline void init_typecast_int32_to_uint16() {}
+inline void init_typecast_int32_to_uint16() {
+#ifndef DISABLE_SFPLOADMACRO
+    // InstructionTemplate[0]
+    TTI_SFPSWAP(0, p_sfpu::LCONST_0, 12, 0xf);  // L[VD] = max(0, L[VD])
+
+    // InstructionTemplate[1]
+    TTI_SFP_STOCH_RND(0, 0, 0, 0, 13, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
+
+    // Macro 0
+    {
+        constexpr std::uint32_t simple_bits = 0x80 | 0x00 | (1 << 3) | (4 + 0);
+        constexpr std::uint32_t mad_bits = 0;
+        constexpr std::uint32_t round_bits = 0x00 | 0x40 | (3 << 3) | (4 + 1);
+        constexpr std::uint32_t store_bits = 0x00 | 0x40 | (4 << 3) | 3;
+
+        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
+        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
+        TTI_SFPCONFIG(0, 4 + 0, 0);
+    }
+
+    // Misc: {
+    //   StoreMod0: SFPSTORE_MODE_SWAP_HI_LO16 (swap hi/lo 16 before write),
+    //   UsesLoadMod0ForStore: {0},
+    //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
+    // }
+    TTI_SFPCONFIG(0x100 | SFPSTORE_MODE_SWAP_HI_LO16, 8, 1);
+#endif
+}
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_fp32_to_uint8() {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -502,9 +502,11 @@ inline void calculate_typecast_uint16_to_uint32() {
         // 0 | [v]  |        |     |       |       |
         // 0 | ...  |        |     |       | [v]   |
 
+        constexpr int v = p_sfpu::LREG0;
+
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
-            TTI_SFPLOADMACRO((0 << 2) | 0, InstrModLoadStore::LO16, ADDR_MOD_2, 0);
+            TTI_SFPLOADMACRO((0 << 2) | (v & 3), InstrModLoadStore::LO16, ADDR_MOD_2, v >> 2);
         }
         TTI_SFPNOP;
     } else {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -68,6 +68,12 @@ inline void calculate_typecast_fp32_to_uint16() {
         // 1 | ...  |                   |     | [v] L16 = rnd(v) |         |
         // 0 | ...  |                   |     |                  | [v] L16 |
 
+        // SFPLOADMACRO operand encoding: operand0 = (macro_select << 2) | (VD & 3) and the
+        // trailing operand = VD >> 2, so the hardware reconstructs the value-register index
+        // VD = (trailing << 2) | (operand0 & 3) -- a 3-bit index spanning LREG0..LREG7 -- while
+        // operand0[3:2] selects which armed macro fires. Here VD is 0/1 and macro_select 0, so
+        // the mask/shift are no-ops, but the same idiom addresses VD >= 4 elsewhere (e.g.
+        // calculate_typecast_uint32_to_fp32 fires macro 2 with VD = LREG7).
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
             int v = d & 1;  // alternate between p_sfpu::LREG0 and p_sfpu::LREG1

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -174,7 +174,7 @@ inline void calculate_typecast_int32_to_fp16b() {
         int v = 2 + (d & 1);  // alternate between p_sfpu::LREG2 and p_sfpu::LREG3
         TT_SFPLOADMACRO((0 << 2) | (v & 3), InstrModLoadStore::INT32, ADDR_MOD_2, v >> 2);
         TT_SFPABS(0, v, t, 0);
-        TTI_SFPSHFT2(t, p_sfpu::LREG12, p_sfpu::LREG7, 5);  // SFPSHFT2_MOD1_SHFT_LREG
+        TTI_SFPSHFT2(t, p_sfpu::LREG12, p_sfpu::LREG7, sfpi::SFPSHFT2_MOD1_SHFT_LREG);
         TTI_SFPCAST(t, t, 0);
     }
     TTI_SFPNOP;
@@ -362,7 +362,7 @@ inline void calculate_typecast_int32_to_fp32() {
         int v = 2 + (d & 1);  // alternate between p_sfpu::LREG2 and p_sfpu::LREG3
         TT_SFPLOADMACRO((0 << 2) | (v & 3), InstrModLoadStore::INT32, ADDR_MOD_2, v >> 2);
         TT_SFPABS(0, v, t, 0);
-        TTI_SFPSHFT2(t, p_sfpu::LREG12, p_sfpu::LREG7, 5);  // SFPSHFT2_MOD1_SHFT_LREG
+        TTI_SFPSHFT2(t, p_sfpu::LREG12, p_sfpu::LREG7, sfpi::SFPSHFT2_MOD1_SHFT_LREG);
         TTI_SFPCAST(t, t, 0);
     }
     TTI_SFPNOP;
@@ -415,7 +415,7 @@ inline void calculate_typecast_uint32_to_fp16b() {
     for (int d = 0; d < ITERATIONS; d++) {
         int v = 2 + (d & 1);  // alternate between p_sfpu::LREG2 and p_sfpu::LREG3
         TT_SFPLOADMACRO((0 << 2) | (v & 3), InstrModLoadStore::INT32, ADDR_MOD_2, v >> 2);
-        TT_SFPSHFT2(v, p_sfpu::LREG12, p_sfpu::LREG7, 5);  // SFPSHFT2_MOD1_SHFT_LREG
+        TT_SFPSHFT2(v, p_sfpu::LREG12, p_sfpu::LREG7, sfpi::SFPSHFT2_MOD1_SHFT_LREG);
         TT_SFPSETSGN(0, v, v, 1);
     }
     TTI_SFPNOP;
@@ -628,13 +628,16 @@ inline void init_typecast_uint16_to_uint32() {
 #endif
 }
 
+// SFPCAST interprets its input as sign-magnitude, so bit 31 of the source flags the case
+// that needs a post-cast fixup. vConstIntPrgm0 (LREG12) is preloaded with -31 -- the shift
+// amount the int/uint -> float macro inits (init_typecast_{uint32,int32}_to_fp32 / _to_fp16b)
+// use to extract that bit.
+inline void preload_sign_magnitude_cast_fixup() { sfpi::vConstIntPrgm0 = -31; }
+
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint32_to_fp32() {
 #ifndef DISABLE_SFPLOADMACRO
-    // SFPCAST interprets its input as sign-magnitude, so bit 31 of the source
-    // flags the case that needs a post-cast fixup. vConstIntPrgm0 (LREG12) is
-    // preloaded with -31 -- the shift amount used to extract that bit.
-    sfpi::vConstIntPrgm0 = -31;
+    preload_sign_magnitude_cast_fixup();
 
     constexpr int a = p_sfpu::LREG2;
 
@@ -645,7 +648,7 @@ inline void init_typecast_uint32_to_fp32() {
     TTI_SFPCAST(a, 13, 0);
 
     // InstructionTemplate[2]
-    TTI_SFPSHFT2(0, p_sfpu::LREG12, 14, 5);  // SFPSHFT2_MOD1_SHFT_LREG
+    TTI_SFPSHFT2(0, p_sfpu::LREG12, 14, sfpi::SFPSHFT2_MOD1_SHFT_LREG);
 
     // InstructionTemplate[3]
     TTI_SFPMAD(0, p_sfpu::LCONST_1, 0, 15, 4);  // SFPMAD_MOD1_INDIRECT_VA
@@ -690,10 +693,7 @@ inline void init_typecast_int32_to_fp32() {
 #ifndef DISABLE_SFPLOADMACRO
     constexpr int t = p_sfpu::LREG4;
 
-    // SFPCAST interprets its input as sign-magnitude, so bit 31 of the source
-    // flags the case that needs a post-cast fixup. vConstIntPrgm0 (LREG12) is
-    // preloaded with -31 -- the shift amount used to extract that bit.
-    sfpi::vConstIntPrgm0 = -31;
+    preload_sign_magnitude_cast_fixup();
 
     // InstructionTemplate[0]
     TTI_SFPSETSGN(0, t, 12, 0);
@@ -727,10 +727,7 @@ inline void init_typecast_int32_to_fp16b() {
 #ifndef DISABLE_SFPLOADMACRO
     constexpr int t = p_sfpu::LREG4;
 
-    // SFPCAST interprets its input as sign-magnitude, so bit 31 of the source
-    // flags the case that needs a post-cast fixup. vConstIntPrgm0 (LREG12) is
-    // preloaded with -31 -- the shift amount used to extract that bit.
-    sfpi::vConstIntPrgm0 = -31;
+    preload_sign_magnitude_cast_fixup();
 
     // InstructionTemplate[0]
     TTI_SFPSETSGN(0, t, 12, 0);
@@ -832,10 +829,7 @@ inline void init_typecast_uint16_to_fp16b() {
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint32_to_fp16b() {
 #ifndef DISABLE_SFPLOADMACRO
-    // SFPCAST interprets its input as sign-magnitude, so bit 31 of the source
-    // flags the case that needs a post-cast fixup. vConstIntPrgm0 (LREG12) is
-    // preloaded with -31 -- the shift amount used to extract that bit.
-    sfpi::vConstIntPrgm0 = -31;
+    preload_sign_magnitude_cast_fixup();
 
     // InstructionTemplate[0]
     TTI_SFPCAST(0, 12, 0);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -42,12 +42,21 @@ inline void disarm_sfploadmacro_misc() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool DST_ACCUM_MODE>
 inline void calculate_typecast_fp32_to_uint16() {
-#ifndef DISABLE_SFPLOADMACRO
+#ifdef DISABLE_SFPLOADMACRO
+#pragma GCC unroll 0
+    for (int d = 0; d < ITERATIONS; d++) {
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+        TTI_SFPSWAP(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 9);
+        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
+        if (DST_ACCUM_MODE) {
+            TTI_SFPSTORE(p_sfpu::LREG0, SFPSTORE_MODE_SWAP_HI_LO16, ADDR_MOD_2, 0);
+        } else {
+            TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_2, 0);
+        }
+    }
+#else
     if constexpr (!DST_ACCUM_MODE) {
-        // This uses SFPLOADMACRO to achieve a throughput of 2 cycles per input row.
-        // It is only used for the 16-bit Dest (LO16 store) case; the 32-bit Dest case
-        // needs the swap-hi-lo16 store, which the init-time macro store mode cannot
-        // express, so it falls through to the plain loop below.
+        // 16-bit Dest: SFPLOADMACRO fast path, throughput of 2 cycles per input row.
         //
         // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
         //
@@ -68,23 +77,20 @@ inline void calculate_typecast_fp32_to_uint16() {
         TTI_SFPNOP;
         TTI_SFPNOP;
         TTI_SFPNOP;
-        return;
-    }
-    // 32-bit Dest path: the init armed the macro but this plain loop never issues SFPLOADMACRO.
-    // Disarm the leftover Misc/WaitForElapsedInstructions state first (WH hangs otherwise, #46751).
-    disarm_sfploadmacro_misc();
-#endif
+    } else {
+        // 32-bit Dest: the swap-hi-lo16 store cannot be expressed by the init-time macro store
+        // mode, so this case uses the plain loop. The init still armed the macro Misc word, so
+        // disarm the leftover state first (WH hangs otherwise running a plain loop with it, #46751).
+        disarm_sfploadmacro_misc();
 #pragma GCC unroll 0
-    for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
-        TTI_SFPSWAP(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 9);
-        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
-        if (DST_ACCUM_MODE) {
+        for (int d = 0; d < ITERATIONS; d++) {
+            TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+            TTI_SFPSWAP(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 9);
+            TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
             TTI_SFPSTORE(p_sfpu::LREG0, SFPSTORE_MODE_SWAP_HI_LO16, ADDR_MOD_2, 0);
-        } else {
-            TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_2, 0);
         }
     }
+#endif
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
@@ -264,15 +270,19 @@ inline void calculate_typecast_fp32_to_fp16b() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool DST_ACCUM_MODE>
 inline void calculate_typecast_uint16_to_fp32() {
-#ifndef DISABLE_SFPLOADMACRO
+#ifdef DISABLE_SFPLOADMACRO
+#pragma GCC unroll 0
+    for (int d = 0; d < ITERATIONS; d++) {
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
+        TTI_SFPAND(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
+        TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
+        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_2, 0);
+    }
+#else
     if constexpr (!DST_ACCUM_MODE) {
-        // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
-        // It is only used for the 16-bit Dest case; the 32-bit Dest (DST_ACCUM_MODE)
-        // case needs the INT32 load + 0xFFFF mask addressing, which the macro's LO16
-        // load schedule does not reproduce, so it falls through to the plain loop below.
-        //
-        // The LO16 load keeps only the low 16 bits (the UInt16 value), so casting it
-        // produces the same result as the plain loop's INT32 load + 0xFFFF mask + cast.
+        // 16-bit Dest: SFPLOADMACRO fast path, throughput of 1 cycle per input row. The LO16 load
+        // keeps only the low 16 bits (the UInt16 value), so casting it matches the plain loop's
+        // INT32 load + 0xFFFF mask + cast.
         //
         // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
         //
@@ -290,19 +300,20 @@ inline void calculate_typecast_uint16_to_fp32() {
         }
         TTI_SFPNOP;
         TTI_SFPNOP;
-        return;
-    }
-    // 32-bit Dest path: the init armed the macro but this plain loop never issues SFPLOADMACRO.
-    // Disarm the leftover Misc/WaitForElapsedInstructions state first (WH hangs otherwise, #46751).
-    disarm_sfploadmacro_misc();
-#endif
+    } else {
+        // 32-bit Dest: the macro's LO16 load cannot reproduce the INT32 + 0xFFFF mask path, so
+        // this case uses the plain loop. The init still armed the macro Misc word, so disarm the
+        // leftover state first (WH hangs otherwise running a plain loop with it, #46751).
+        disarm_sfploadmacro_misc();
 #pragma GCC unroll 0
-    for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
-        TTI_SFPAND(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
-        TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_2, 0);
+        for (int d = 0; d < ITERATIONS; d++) {
+            TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
+            TTI_SFPAND(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
+            TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
+            TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_2, 0);
+        }
     }
+#endif
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
@@ -471,16 +482,18 @@ inline void calculate_typecast_uint32_to_fp32() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool DST_ACCUM_MODE>
 inline void calculate_typecast_uint16_to_uint32() {
-#ifndef DISABLE_SFPLOADMACRO
+#ifdef DISABLE_SFPLOADMACRO
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
+        TTI_SFPAND(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
+        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_2, 0);
+    }
+#else
     if constexpr (!DST_ACCUM_MODE) {
-        // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
-        // It is only used for the 16-bit Dest case; the 32-bit Dest (DST_ACCUM_MODE)
-        // case needs the INT32 load + 0xFFFF mask addressing, which the macro's LO16
-        // load schedule does not reproduce, so it falls through to the plain loop below.
-        //
-        // The LO16 load keeps only the low 16 bits (the UInt16 value) and zero-extends
-        // them, so the INT32 store writes the same result as the plain loop's INT32
-        // load + 0xFFFF mask.
+        // 16-bit Dest: SFPLOADMACRO fast path, throughput of 1 cycle per input row. The LO16 load
+        // keeps only the low 16 bits (the UInt16 value) and zero-extends them, so the INT32 store
+        // matches the plain loop's INT32 load + 0xFFFF mask.
         //
         // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
         //
@@ -494,18 +507,19 @@ inline void calculate_typecast_uint16_to_uint32() {
             TTI_SFPLOADMACRO((0 << 2) | 0, InstrModLoadStore::LO16, ADDR_MOD_2, 0);
         }
         TTI_SFPNOP;
-        return;
-    }
-    // 32-bit Dest path: the init armed the macro but this plain loop never issues SFPLOADMACRO.
-    // Disarm the leftover Misc/WaitForElapsedInstructions state first (WH hangs otherwise, #46751).
-    disarm_sfploadmacro_misc();
-#endif
+    } else {
+        // 32-bit Dest: the macro's LO16 load cannot reproduce the INT32 + 0xFFFF mask path, so
+        // this case uses the plain loop. The init still armed the macro Misc word, so disarm the
+        // leftover state first (WH hangs otherwise running a plain loop with it, #46751).
+        disarm_sfploadmacro_misc();
 #pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
-        TTI_SFPAND(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_2, 0);
+        for (int d = 0; d < ITERATIONS; d++) {
+            TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
+            TTI_SFPAND(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
+            TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_2, 0);
+        }
     }
+#endif
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -23,9 +23,57 @@ constexpr std::uint16_t UINT16_LOW_MASK = 0xFFFF;
 // lands in the high 16 bits where the packer reads UInt16 out of a 32-bit dest word.
 constexpr std::uint32_t SFPSTORE_MODE_SWAP_HI_LO16 = 9;
 
+// Disarms the SFPLOADMACRO "Misc" / Load-Macro-Control config that the typecast init functions program
+// unconditionally (the init dispatch passes only APPROX, so it cannot see DST_ACCUM_MODE and always arms
+// the macro). The 32-bit Dest (DST_ACCUM_MODE) typecast paths fall back to a plain TTI_ loop that never
+// issues an SFPLOADMACRO. On Wormhole, leaving the Misc word armed with UnitDelayKind=WaitForElapsedInstructions
+// and then running plain SFP instructions hard-hangs the SFPU (all three Tensix threads enter but never
+// complete) -- see #46751. Blackhole tolerates the un-consumed macro state, so this is a WH-specific quirk.
+// A full overwrite of the Load-Macro-Control register (config_dest=8) with imm16=0 zeroes StoreMod0 and
+// clears UnitDelayKind, removing the hazard. The plain loop sets its own per-instruction store mode, so this
+// is correctness-neutral. The two SFPNOPs let the SFPCONFIG settle (matching the topk restore idiom).
+inline void disarm_sfploadmacro_misc() {
+#ifndef DISABLE_SFPLOADMACRO
+    TTI_SFPCONFIG(0x000, 8, 1);  // imm16=0, config_dest=8 (Load Macro Control / Misc), mod=1 (immediate overwrite)
+    TTI_SFPNOP;
+    TTI_SFPNOP;
+#endif
+}
+
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool DST_ACCUM_MODE>
 inline void calculate_typecast_fp32_to_uint16() {
-    // TODO: Attempt to use LOADMACRO #46751
+#ifndef DISABLE_SFPLOADMACRO
+    if constexpr (!DST_ACCUM_MODE) {
+        // This uses SFPLOADMACRO to achieve a throughput of 2 cycles per input row.
+        // It is only used for the 16-bit Dest (LO16 store) case; the 32-bit Dest case
+        // needs the swap-hi-lo16 store, which the init-time macro store mode cannot
+        // express, so it falls through to the plain loop below.
+        //
+        // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
+        //
+        // t | Load | Simple            | MAD | Round            | Store   |
+        // - | ---- | ----------------- | --- | ---------------- | ------- |
+        // 0 | [v]  |                   |     |                  |         |
+        // 1 | nop  | [v] = max(v, 0.0) |     |                  |         |
+        // 0 | ...  | (must be idle)    |     | (must be idle)   |         |
+        // 1 | ...  |                   |     | [v] L16 = rnd(v) |         |
+        // 0 | ...  |                   |     |                  | [v] L16 |
+
+#pragma GCC unroll 8
+        for (int d = 0; d < ITERATIONS; d++) {
+            int v = d & 1;  // alternate between p_sfpu::LREG0 and p_sfpu::LREG1
+            TT_SFPLOADMACRO((0 << 2) | (v & 3), InstrModLoadStore::DEFAULT, ADDR_MOD_2, v >> 2);
+            TTI_SFPNOP;
+        }
+        TTI_SFPNOP;
+        TTI_SFPNOP;
+        TTI_SFPNOP;
+        return;
+    }
+    // 32-bit Dest path: the init armed the macro but this plain loop never issues SFPLOADMACRO.
+    // Disarm the leftover Misc/WaitForElapsedInstructions state first (WH hangs otherwise, #46751).
+    disarm_sfploadmacro_misc();
+#endif
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
@@ -197,7 +245,10 @@ inline void calculate_typecast_fp32_to_uint32() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_fp32_to_fp16b() {
-    // TODO: Attempt to use LOADMACRO #46751
+    // Kept as a plain loop (no SFPLOADMACRO): #46231 rewrote this to round, mask off the
+    // low 16 bits (&0xFFFF0000), and store FP32 for 32-bit-Dest correctness. The historical
+    // macro relied on a FP16B store to truncate and does not reproduce the masked-FP32 result,
+    // so it is not equivalent and is not restored here. See #46751.
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
@@ -211,9 +262,40 @@ inline void calculate_typecast_fp32_to_fp16b() {
     }
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool DST_ACCUM_MODE>
 inline void calculate_typecast_uint16_to_fp32() {
-    // TODO: Attempt to use LOADMACRO #46751
+#ifndef DISABLE_SFPLOADMACRO
+    if constexpr (!DST_ACCUM_MODE) {
+        // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
+        // It is only used for the 16-bit Dest case; the 32-bit Dest (DST_ACCUM_MODE)
+        // case needs the INT32 load + 0xFFFF mask addressing, which the macro's LO16
+        // load schedule does not reproduce, so it falls through to the plain loop below.
+        //
+        // The LO16 load keeps only the low 16 bits (the UInt16 value), so casting it
+        // produces the same result as the plain loop's INT32 load + 0xFFFF mask + cast.
+        //
+        // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
+        //
+        // t | Load | Simple            | MAD | Round | Store   |
+        // - | ---- | ----------------- | --- | ----- | ------- |
+        // 0 | [v]  |                   |     |       |         |
+        // 0 | ...  | [v] L16 = cast(v) |     |       |         |
+        // 0 | ...  |                   |     |       | [v] L16 |
+
+        constexpr int v = p_sfpu::LREG0;
+
+#pragma GCC unroll 8
+        for (int d = 0; d < ITERATIONS; d++) {
+            TTI_SFPLOADMACRO((0 << 2) | (v & 3), InstrModLoadStore::LO16, ADDR_MOD_2, v >> 2);
+        }
+        TTI_SFPNOP;
+        TTI_SFPNOP;
+        return;
+    }
+    // 32-bit Dest path: the init armed the macro but this plain loop never issues SFPLOADMACRO.
+    // Disarm the leftover Misc/WaitForElapsedInstructions state first (WH hangs otherwise, #46751).
+    disarm_sfploadmacro_misc();
+#endif
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
@@ -281,7 +363,7 @@ inline void calculate_typecast_int32_to_fp32() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_uint32_to_fp16b() {
-    // TODO: Attempt to use LOADMACRO #46751
+#ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
@@ -293,6 +375,44 @@ inline void calculate_typecast_uint32_to_fp16b() {
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG1, p_sfpu::LREG1, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
         TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::FP32, ADDR_MOD_2, 0);
     }
+#else
+    // This uses SFPLOADMACRO to achieve a throughput of 3 cycles per input row.
+    //
+    // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
+    //
+    // Note: L0=0.0 and L1=2**31.  The sign bit is stored in L7 and used to pick L0 or L1
+    // for SFPMAD's VA:
+    //
+    // - if sign bit is 0, then compute L0*1.0 + v = v
+    // - if sign bit is 1, then compute L1*1.0 + v = 2**31 + v
+    //
+    // t | Load | Simple             | MAD                     | Round            | Store   |
+    // - | ---- | ------------------ | ----------------------- | ---------------- | ------- |
+    // 0 | [v]  |                    |                         |                  |         |
+    // 1 |      |                    |                         | L7 = v >> 31     |         |
+    // 2 |      | v = setsgn(v, 0)   |                         |                  |         |
+    // 0 | ...  | [v] = cast(v)      |                         |                  |         |
+    // 1 | ...  |                    | [v] v = L[L7]*1.0 + v   |                  |         |
+    // 2 | ...  |                    |                         |                  |         |
+    // 0 | ...  |                    |                         | [v] L16 = rnd(v) |         |
+    // 1 | ...  |                    |                         |                  | [v] L16 |
+
+    TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_USHORT, 0);
+    TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_FLOATB, 0x4f00);  // 2**31
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        int v = 2 + (d & 1);  // alternate between p_sfpu::LREG2 and p_sfpu::LREG3
+        TT_SFPLOADMACRO((0 << 2) | (v & 3), InstrModLoadStore::INT32, ADDR_MOD_2, v >> 2);
+        TT_SFPSHFT2(v, p_sfpu::LREG12, p_sfpu::LREG7, 5);  // SFPSHFT2_MOD1_SHFT_LREG
+        TT_SFPSETSGN(0, v, v, 1);
+    }
+    TTI_SFPNOP;
+    TTI_SFPNOP;
+    TTI_SFPNOP;
+    TTI_SFPNOP;
+    TTI_SFPNOP;
+#endif
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
@@ -349,9 +469,37 @@ inline void calculate_typecast_uint32_to_fp32() {
 #endif
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool DST_ACCUM_MODE>
 inline void calculate_typecast_uint16_to_uint32() {
-    // TODO: Attempt to use LOADMACRO #46751
+#ifndef DISABLE_SFPLOADMACRO
+    if constexpr (!DST_ACCUM_MODE) {
+        // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
+        // It is only used for the 16-bit Dest case; the 32-bit Dest (DST_ACCUM_MODE)
+        // case needs the INT32 load + 0xFFFF mask addressing, which the macro's LO16
+        // load schedule does not reproduce, so it falls through to the plain loop below.
+        //
+        // The LO16 load keeps only the low 16 bits (the UInt16 value) and zero-extends
+        // them, so the INT32 store writes the same result as the plain loop's INT32
+        // load + 0xFFFF mask.
+        //
+        // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
+        //
+        // t | Load | Simple | MAD | Round | Store |
+        // - | ---- | ------ | --- | ----- | ----- |
+        // 0 | [v]  |        |     |       |       |
+        // 0 | ...  |        |     |       | [v]   |
+
+#pragma GCC unroll 8
+        for (int d = 0; d < ITERATIONS; d++) {
+            TTI_SFPLOADMACRO((0 << 2) | 0, InstrModLoadStore::LO16, ADDR_MOD_2, 0);
+        }
+        TTI_SFPNOP;
+        return;
+    }
+    // 32-bit Dest path: the init armed the macro but this plain loop never issues SFPLOADMACRO.
+    // Disarm the leftover Misc/WaitForElapsedInstructions state first (WH hangs otherwise, #46751).
+    disarm_sfploadmacro_misc();
+#endif
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
@@ -362,7 +510,10 @@ inline void calculate_typecast_uint16_to_uint32() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_uint32_to_uint16() {
-    // TODO: Attempt to use LOADMACRO #46751
+    // Kept as a plain loop (no SFPLOADMACRO): #46231 rewrote this to shift the value right by 16
+    // and renormalize (2's-complement + shift + OR) before the swap-hi-lo16 store. The historical
+    // macro used a LO16-load 2-macro pipeline on a different bit layout and computes a different
+    // result, so it is not equivalent and is not restored here. See #46751.
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
@@ -378,7 +529,7 @@ inline void calculate_typecast_uint32_to_uint16() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_int32_to_uint16() {
-    // TODO: Attempt to use LOADMACRO #46751
+#ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
@@ -387,6 +538,39 @@ inline void calculate_typecast_int32_to_uint16() {
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
         TTI_SFPSTORE(p_sfpu::LREG0, SFPSTORE_MODE_SWAP_HI_LO16, ADDR_MOD_2, 0);
     }
+#else
+    // This uses SFPLOADMACRO to achieve a throughput of 3 cycles per input row.
+    //
+    // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
+    //
+    // t | Load | Simple            | MAD | Round            | Store   |
+    // - | ---- | ----------------- | --- | ---------------- | ------- |
+    // 0 | [a]  |                   |     |                  |         |
+    // 1 |      | a = cast_fp32(a)  |     |                  |         |
+    // 2 | nop  | [a] = max(0.0, a) |     |                  |         |
+    // 0 | ...  | (must be idle)    |     |                  |         |
+    // 1 | ...  |                   |     | [a] L16 = rnd(a) |         |
+    // 2 | ...  |                   |     |                  | [a] swap|
+    //
+    // Simple/Round sub-units can be used simultaneously if one has VD=16 and
+    // the other VD!=16.  The following steps clamp the input value to 0-65535:
+    //
+    // a = cast_fp32(a); this allows us to use SFPSTOCHRND later to convert to uint16, clamping to 65535.
+    // swap_minmax(0.0, a); since SFPSTOCHRND takes the absolute value before clamping, we use SFPSWAP to clamp negative
+    // values to 0.0. L16 = rnd(a); finally, we use SFPSTOCHRND to clamp large values to 65535, using VD=16. The macro
+    // Store uses SFPSTORE_MODE_SWAP_HI_LO16, matching the plain-loop store that lands the uint16 in the high 16 bits.
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        int a = d & 1;  // alternate between p_sfpu::LREG0 and p_sfpu::LREG1
+        TT_SFPLOADMACRO((0 << 2) | (a & 3), InstrModLoadStore::INT32, ADDR_MOD_2, a >> 2);
+        TT_SFPCAST(a, a, 0);
+        TTI_SFPNOP;
+    }
+    TTI_SFPNOP;
+    TTI_SFPNOP;
+    TTI_SFPNOP;
+#endif
 }
 
 template <bool APPROXIMATION_MODE>
@@ -398,7 +582,36 @@ inline void init_typecast_fp32_to_fp16b() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint16_to_uint32() {
+#ifdef DISABLE_SFPLOADMACRO
     TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, UINT16_LOW_MASK);
+#else
+    // The 32-bit Dest (DST_ACCUM_MODE) path of calculate_typecast_uint16_to_uint32 falls
+    // back to the plain loop, which masks the loaded word with LREG1. Load the mask here
+    // so that path is correct; the macro-programming below only targets LREG0, so LREG1
+    // survives. The 16-bit Dest macro path does not read LREG1. The init cannot see
+    // DST_ACCUM_MODE (the dispatch passes only APPROX), so the 32-bit Dest calc disarms the
+    // macro before its plain loop (see disarm_sfploadmacro_misc / #46751).
+    TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, UINT16_LOW_MASK);
+
+    // Macro 0: store only (the LO16 load already zero-extends the UInt16 value).
+    {
+        constexpr std::uint32_t simple_bits = 0;
+        constexpr std::uint32_t mad_bits = 0;
+        constexpr std::uint32_t round_bits = 0;
+        constexpr std::uint32_t store_bits = 0x00 | 0x00 | (0 << 3) | 3;
+
+        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
+        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
+        TTI_SFPCONFIG(0, 4 + 0, 0);
+    }
+
+    // Misc: {
+    //   StoreMod0: INT32,
+    //   UsesLoadMod0ForStore: {0},
+    //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
+    // }
+    TTI_SFPCONFIG(0x100 | InstrModLoadStore::INT32, 8, 1);
+#endif
 }
 
 template <bool APPROXIMATION_MODE>
@@ -537,7 +750,39 @@ inline void init_typecast_int32_to_fp16b() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint16_to_fp32() {
+#ifdef DISABLE_SFPLOADMACRO
     TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, UINT16_LOW_MASK);
+#else
+    // The 32-bit Dest (DST_ACCUM_MODE) path of calculate_typecast_uint16_to_fp32 falls
+    // back to the plain loop, which masks the loaded word with LREG1. Load the mask here
+    // so that path is correct; the macro-programming below only targets LREG0, so LREG1
+    // survives. The 16-bit Dest macro path does not read LREG1. The init cannot see
+    // DST_ACCUM_MODE (the dispatch passes only APPROX), so the 32-bit Dest calc disarms the
+    // macro before its plain loop (see disarm_sfploadmacro_misc / #46751).
+    TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, UINT16_LOW_MASK);
+
+    // InstructionTemplate[0]
+    TTI_SFPCAST(0, 12, 0);
+
+    // Macro 0
+    {
+        constexpr std::uint32_t simple_bits = 0x00 | 0x40 | (0 << 3) | (4 + 0);
+        constexpr std::uint32_t mad_bits = 0;
+        constexpr std::uint32_t round_bits = 0;
+        constexpr std::uint32_t store_bits = 0x00 | 0x40 | (1 << 3) | 3;
+
+        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
+        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
+        TTI_SFPCONFIG(0, 4 + 0, 0);
+    }
+
+    // Misc: {
+    //   StoreMod0: FP32,
+    //   UsesLoadMod0ForStore: {0},
+    //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
+    // }
+    TTI_SFPCONFIG(0x100 | InstrModLoadStore::FP32, 8, 1);
+#endif
 }
 
 template <bool APPROXIMATION_MODE>
@@ -571,16 +816,110 @@ inline void init_typecast_uint16_to_fp16b() {
 }
 
 template <bool APPROXIMATION_MODE>
-inline void init_typecast_uint32_to_fp16b() {}
+inline void init_typecast_uint32_to_fp16b() {
+#ifndef DISABLE_SFPLOADMACRO
+    // SFPCAST interprets its input as sign-magnitude, so bit 31 of the source
+    // flags the case that needs a post-cast fixup. vConstIntPrgm0 (LREG12) is
+    // preloaded with -31 -- the shift amount used to extract that bit.
+    sfpi::vConstIntPrgm0 = -31;
+
+    // InstructionTemplate[0]
+    TTI_SFPCAST(0, 12, 0);
+
+    // InstructionTemplate[1]
+    TTI_SFPMAD(0, p_sfpu::LCONST_1, 0, 13, 4);  // SFPMAD_MOD1_INDIRECT_VA
+
+    // InstructionTemplate[2]
+    TTI_SFP_STOCH_RND(0, 0, 0, 0, 14, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
+
+    // Macro 0
+    {
+        constexpr std::uint32_t simple_bits = 0x00 | 0x00 | (2 << 3) | (4 + 0);
+        constexpr std::uint32_t mad_bits = 0x00 | 0x00 | (3 << 3) | (4 + 1);
+        constexpr std::uint32_t round_bits = 0x00 | 0x40 | (5 << 3) | (4 + 2);
+        constexpr std::uint32_t store_bits = 0x00 | 0x40 | (6 << 3) | 3;
+
+        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
+        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
+        TTI_SFPCONFIG(0, 4 + 0, 0);
+    }
+
+    // Misc: {
+    //   StoreMod0: FP32,  (changed from the historical DEFAULT to match the plain loop's FP32 store)
+    //   UsesLoadMod0ForStore: {0},
+    //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
+    // }
+    TTI_SFPCONFIG(0x100 | InstrModLoadStore::FP32, 8, 1);
+#endif
+}
 
 template <bool APPROXIMATION_MODE>
-inline void init_typecast_fp32_to_uint16() {}
+inline void init_typecast_fp32_to_uint16() {
+#ifndef DISABLE_SFPLOADMACRO
+    // Programs the macro used by the 16-bit Dest (LO16 store) path of
+    // calculate_typecast_fp32_to_uint16. The 32-bit Dest path uses the plain loop and
+    // disarms this macro first (the init cannot see DST_ACCUM_MODE; see #46751).
+
+    // InstructionTemplate[0]
+    TTI_SFPSWAP(0, p_sfpu::LCONST_0, 12, 0xf);  // L[VD] = max(0, L[VD])
+
+    // InstructionTemplate[1]
+    TTI_SFP_STOCH_RND(0, 0, 0, 0, 13, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
+
+    // Macro 0
+    {
+        constexpr std::uint32_t simple_bits = 0x80 | 0x00 | (0 << 3) | (4 + 0);
+        constexpr std::uint32_t mad_bits = 0;
+        constexpr std::uint32_t round_bits = 0x00 | 0x40 | (2 << 3) | (4 + 1);
+        constexpr std::uint32_t store_bits = 0x00 | 0x40 | (3 << 3) | 3;
+
+        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
+        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
+        TTI_SFPCONFIG(0, 4 + 0, 0);
+    }
+
+    // Misc: {
+    //   StoreMod0: LO16,
+    //   UsesLoadMod0ForStore: {0},
+    //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
+    // }
+    TTI_SFPCONFIG(0x100 | InstrModLoadStore::LO16, 8, 1);
+#endif
+}
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint32_to_uint16() {}
 
 template <bool APPROXIMATION_MODE>
-inline void init_typecast_int32_to_uint16() {}
+inline void init_typecast_int32_to_uint16() {
+#ifndef DISABLE_SFPLOADMACRO
+    // InstructionTemplate[0]
+    TTI_SFPSWAP(0, p_sfpu::LCONST_0, 12, 0xf);  // L[VD] = max(0, L[VD])
+
+    // InstructionTemplate[1]
+    TTI_SFP_STOCH_RND(0, 0, 0, 0, 13, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
+
+    // Macro 0
+    {
+        constexpr std::uint32_t simple_bits = 0x80 | 0x00 | (1 << 3) | (4 + 0);
+        constexpr std::uint32_t mad_bits = 0;
+        constexpr std::uint32_t round_bits = 0x00 | 0x40 | (3 << 3) | (4 + 1);
+        constexpr std::uint32_t store_bits = 0x00 | 0x40 | (4 << 3) | 3;
+
+        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
+        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
+        TTI_SFPCONFIG(0, 4 + 0, 0);
+    }
+
+    // Misc: {
+    //   StoreMod0: SFPSTORE_MODE_SWAP_HI_LO16 (swap hi/lo 16 before write; changed from the
+    //              historical LO16 to match the plain loop's swap-hi-lo16 store),
+    //   UsesLoadMod0ForStore: {0},
+    //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
+    // }
+    TTI_SFPCONFIG(0x100 | SFPSTORE_MODE_SWAP_HI_LO16, 8, 1);
+#endif
+}
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_fp32_to_uint8() {

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/typecast.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/typecast.h
@@ -113,7 +113,7 @@ ALWI void typecast_tile(uint32_t idst) {
             DST_SYNC_MODE,
             DST_ACCUM_MODE,
             calculate_typecast_uint16_to_fp32,
-            (APPROX, 8 /* ITERATIONS */),
+            (APPROX, 8 /* ITERATIONS */, DST_ACCUM_MODE),
             idst,
             VectorMode::RC));
     } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::Int32) {
@@ -217,7 +217,7 @@ ALWI void typecast_tile(uint32_t idst) {
             DST_SYNC_MODE,
             DST_ACCUM_MODE,
             calculate_typecast_uint16_to_uint32,
-            (APPROX, 8 /* ITERATIONS */),
+            (APPROX, 8 /* ITERATIONS */, DST_ACCUM_MODE),
             idst,
             VectorMode::RC));
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Int32) {
@@ -226,7 +226,7 @@ ALWI void typecast_tile(uint32_t idst) {
             DST_SYNC_MODE,
             DST_ACCUM_MODE,
             calculate_typecast_uint16_to_uint32,
-            (APPROX, 8 /* ITERATIONS */),
+            (APPROX, 8 /* ITERATIONS */, DST_ACCUM_MODE),
             idst,
             VectorMode::RC));
     } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::UInt16) {

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
@@ -172,7 +172,7 @@ void call_unary_typecast_operation(std::uint32_t dst_index)
     }
     else if constexpr (IN == DataFormat::UInt16 && OUT == DataFormat::Float32)
     {
-        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_typecast_uint16_to_fp32, (APPROX_MODE, ITERATIONS), dst_index, VectorMode::RC);
+        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_typecast_uint16_to_fp32, (APPROX_MODE, ITERATIONS, DST_ACCUM_MODE), dst_index, VectorMode::RC);
     }
     else if constexpr (IN == DataFormat::Float32 && OUT == DataFormat::Int32)
     {
@@ -224,12 +224,12 @@ void call_unary_typecast_operation(std::uint32_t dst_index)
     }
     else if constexpr (IN == DataFormat::UInt16 && OUT == DataFormat::UInt32)
     {
-        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_typecast_uint16_to_uint32, (APPROX_MODE, ITERATIONS), dst_index, VectorMode::RC);
+        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_typecast_uint16_to_uint32, (APPROX_MODE, ITERATIONS, DST_ACCUM_MODE), dst_index, VectorMode::RC);
     }
     else if constexpr (IN == DataFormat::UInt16 && OUT == DataFormat::Int32)
     {
         // Calls same kernel as the UInt32 case.
-        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_typecast_uint16_to_uint32, (APPROX_MODE, ITERATIONS), dst_index, VectorMode::RC);
+        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_typecast_uint16_to_uint32, (APPROX_MODE, ITERATIONS, DST_ACCUM_MODE), dst_index, VectorMode::RC);
     }
     else if constexpr (IN == DataFormat::UInt32 && OUT == DataFormat::UInt16)
     {

--- a/tt_metal/tt-llk/tests/python_tests/perf_eltwise_typecast.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_eltwise_typecast.py
@@ -49,21 +49,23 @@ from helpers.test_variant_parameters import (
 )
 
 # The five (IN, OUT, dest_acc) typecast cases that exercise the SFPLOADMACRO path
-# re-introduced by issue #46751. Each tuple is (input_format, output_format,
-# dest_acc). The dest_acc choice mirrors the production/functional typecast wiring
-# (32-bit dtypes require 32-bit Dest -> dest_acc=Yes).
+# re-introduced by issue #46751.
+#
+# dest_acc is the production setting EXCEPT for the two rows marked below: their
+# macro fast path is gated !DST_ACCUM_MODE, but ttnn.typecast forces dest_acc=Yes
+# for 32-bit outputs (typecast.cpp:38-41), so production takes the plain loop. Those
+# rows measure the macro in isolation and their speedup is not production-realized.
 _TYPECAST_PERF_CASES = [
-    # Float16_b -> UInt16 routes through calculate_typecast_fp32_to_uint16: the
-    # Compute API maps the Float16_b-in-Dest -> UInt16 cast to that kernel (it does
-    # not load FP32 from L1). Macro on !DST_ACCUM_MODE (16-bit Dest).
+    # Float16_b -> UInt16: routes through calculate_typecast_fp32_to_uint16 (the
+    # Compute API maps Float16_b-in-Dest -> UInt16 to it, no FP32 load from L1).
     (DataFormat.Float16_b, DataFormat.UInt16, DestAccumulation.No),
-    # calculate_typecast_uint16_to_fp32, macro on !DST_ACCUM_MODE (16-bit Dest).
+    # uint16_to_fp32 -- NOT production-reachable (Float32 out -> dest_acc=Yes).
     (DataFormat.UInt16, DataFormat.Float32, DestAccumulation.No),
-    # calculate_typecast_uint32_to_fp16b, macro mode-agnostic; UInt32 needs 32-bit Dest.
+    # uint32_to_fp16b, macro mode-agnostic; UInt32 needs 32-bit Dest.
     (DataFormat.UInt32, DataFormat.Float16_b, DestAccumulation.Yes),
-    # calculate_typecast_uint16_to_uint32, macro on !DST_ACCUM_MODE (16-bit Dest).
+    # uint16_to_uint32 -- NOT production-reachable (UInt32 out -> dest_acc=Yes).
     (DataFormat.UInt16, DataFormat.UInt32, DestAccumulation.No),
-    # calculate_typecast_int32_to_uint16, macro mode-agnostic; Int32 needs 32-bit Dest.
+    # int32_to_uint16, macro mode-agnostic; Int32 needs 32-bit Dest.
     (DataFormat.Int32, DataFormat.UInt16, DestAccumulation.Yes),
 ]
 

--- a/tt_metal/tt-llk/tests/python_tests/perf_eltwise_typecast.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_eltwise_typecast.py
@@ -53,7 +53,9 @@ from helpers.test_variant_parameters import (
 # dest_acc). The dest_acc choice mirrors the production/functional typecast wiring
 # (32-bit dtypes require 32-bit Dest -> dest_acc=Yes).
 _TYPECAST_PERF_CASES = [
-    # calculate_typecast_fp32_to_uint16, macro on !DST_ACCUM_MODE (16-bit Dest).
+    # Float16_b -> UInt16 routes through calculate_typecast_fp32_to_uint16: the
+    # Compute API maps the Float16_b-in-Dest -> UInt16 cast to that kernel (it does
+    # not load FP32 from L1). Macro on !DST_ACCUM_MODE (16-bit Dest).
     (DataFormat.Float16_b, DataFormat.UInt16, DestAccumulation.No),
     # calculate_typecast_uint16_to_fp32, macro on !DST_ACCUM_MODE (16-bit Dest).
     (DataFormat.UInt16, DataFormat.Float32, DestAccumulation.No),

--- a/tt_metal/tt-llk/tests/python_tests/perf_eltwise_typecast.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_eltwise_typecast.py
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+On-silicon perf benchmark for the SFPU typecast op (issue #46751).
+
+Measures cycles/tile for the typecast variants whose SFPLOADMACRO fast path was
+re-introduced for Blackhole. The macro fast path in the calculate_typecast_*
+primitives is gated `#ifndef DISABLE_SFPLOADMACRO`; compiling with
+TT_METAL_DISABLE_SFPLOADMACRO=1 selects the plain-loop fallback (pre-fix
+baseline). Running this module twice -- once without the env (macro ON,
+optimized) and once with TT_METAL_DISABLE_SFPLOADMACRO=1 (macro OFF, baseline)
+-- gives a clean A/B on the same tree.
+
+Unlike test_perf_eltwise_unary_sfpu (which dispatches a single MathOperation),
+typecast is selected by the (IN, OUT) DataFormat pair via typecast_tile<IN, OUT>
+/ the shared SfpuType::typecast dispatch, so this module uses the dedicated
+typecast perf kernel sources/eltwise_unary_typecast_perf.cpp with the
+TYPECAST_FORMATS(in, out) template.
+"""
+
+import pytest
+from helpers.format_config import DataFormat, InputOutputFormat
+from helpers.llk_params import (
+    ApproximationMode,
+    DestAccumulation,
+    FastMode,
+    MathOperation,
+    PerfRunType,
+    StableSort,
+    Transpose,
+)
+from helpers.param_config import parametrize
+from helpers.perf import PerfConfig
+from helpers.stimuli_config import StimuliConfig
+from helpers.stimuli_generator import calculate_tile_and_face_counts
+from helpers.test_variant_parameters import (
+    APPROX_MODE,
+    FAST_MODE,
+    ITERATIONS,
+    LOOP_FACTOR,
+    MATH_OP,
+    NUM_FACES,
+    STABLE_SORT,
+    TILE_COUNT,
+    TYPECAST_FORMATS,
+    UNPACK_TRANS_FACES,
+    UNPACK_TRANS_WITHIN_FACE,
+)
+
+# The five (IN, OUT, dest_acc) typecast cases that exercise the SFPLOADMACRO path
+# re-introduced by issue #46751. Each tuple is (input_format, output_format,
+# dest_acc). The dest_acc choice mirrors the production/functional typecast wiring
+# (32-bit dtypes require 32-bit Dest -> dest_acc=Yes).
+_TYPECAST_PERF_CASES = [
+    # calculate_typecast_fp32_to_uint16, macro on !DST_ACCUM_MODE (16-bit Dest).
+    (DataFormat.Float16_b, DataFormat.UInt16, DestAccumulation.No),
+    # calculate_typecast_uint16_to_fp32, macro on !DST_ACCUM_MODE (16-bit Dest).
+    (DataFormat.UInt16, DataFormat.Float32, DestAccumulation.No),
+    # calculate_typecast_uint32_to_fp16b, macro mode-agnostic; UInt32 needs 32-bit Dest.
+    (DataFormat.UInt32, DataFormat.Float16_b, DestAccumulation.Yes),
+    # calculate_typecast_uint16_to_uint32, macro on !DST_ACCUM_MODE (16-bit Dest).
+    (DataFormat.UInt16, DataFormat.UInt32, DestAccumulation.No),
+    # calculate_typecast_int32_to_uint16, macro mode-agnostic; Int32 needs 32-bit Dest.
+    (DataFormat.Int32, DataFormat.UInt16, DestAccumulation.Yes),
+]
+
+
+def _is_block_float(fmt: DataFormat) -> bool:
+    return fmt in (DataFormat.Bfp8_b, DataFormat.Bfp4_b, DataFormat.Bfp2_b)
+
+
+@pytest.mark.perf
+@parametrize(
+    typecast_case=_TYPECAST_PERF_CASES,
+    approx_mode=[ApproximationMode.No],
+    loop_factor=[
+        16,
+    ],  # Number of iterations to run the test in order to minimize profiler overhead in measurement
+    iterations=[
+        8,
+    ],  # SFPU iteration count; the typecast dispatch hardcodes 8 ITERATIONS internally
+    input_dimensions=[
+        [128, 64],  # tile_cnt: 8
+    ],
+)
+def test_perf_eltwise_typecast(
+    perf_report,
+    typecast_case,
+    approx_mode,
+    loop_factor,
+    iterations,
+    input_dimensions,
+):
+    input_format, output_format, dest_acc = typecast_case
+    formats = InputOutputFormat(input_format, output_format)
+
+    # Calculate tile count from input dimensions
+    tile_count_A, tile_count_B, faces_to_generate = calculate_tile_and_face_counts(
+        input_dimensions, input_dimensions, face_r_dim=16, num_faces=4
+    )
+
+    # Unpack straight into Dest when the input is 32-bit: the unpacker has no
+    # SrcA/SrcB path for Int32/UInt32/Float32, so cunpack_common asserts
+    # unpack_to_dest for them (matches the functional typecast test). The perf
+    # kernel keeps the unpack-A acc_to_dest template arg false so this is legal
+    # even when dest_acc=Yes. For 16-bit inputs the data is copied SrcA -> Dest
+    # by the math datacopy A2D before the SFPU typecast runs.
+    unpack_to_dest = input_format.is_32_bit()
+
+    configuration = PerfConfig(
+        "sources/eltwise_unary_typecast_perf.cpp",
+        formats,
+        run_types=[
+            PerfRunType.L1_TO_L1,
+            PerfRunType.MATH_ISOLATE,
+        ],
+        templates=[
+            # Emits SFPU_UNARY_OPERATION = SfpuType::typecast so the kernel goes
+            # through the shared unary-SFPU dispatch; TYPECAST_FORMATS supplies the
+            # (input, output) pair that selects the concrete typecast kernel.
+            MATH_OP(mathop=MathOperation.Typecast),
+            TYPECAST_FORMATS(input_format, output_format),
+            APPROX_MODE(approx_mode),
+            ITERATIONS(iterations),
+            FAST_MODE(FastMode.No),
+            STABLE_SORT(StableSort.No),
+        ],
+        runtimes=[
+            TILE_COUNT(tile_count_A),
+            LOOP_FACTOR(loop_factor),
+            NUM_FACES(num_faces=faces_to_generate),
+            UNPACK_TRANS_FACES(Transpose.No),
+            UNPACK_TRANS_WITHIN_FACE(Transpose.No),
+        ],
+        variant_stimuli=StimuliConfig(
+            None,
+            input_format,
+            None,
+            input_format,
+            output_format,
+            tile_count_A=tile_count_A,
+            tile_count_B=tile_count_B,
+            tile_count_res=tile_count_A,
+        ),
+        unpack_to_dest=unpack_to_dest,
+        dest_acc=dest_acc,
+    )
+
+    # pack_src fix for the SFPU typecast (mirrors test_eltwise_unary_typecast).
+    #
+    # The generic format inference models pack_src from the *input* (what the
+    # unpacker writes to Dest). For a typecast the SFPU overwrites Dest with the
+    # *output* value, so the packer must read the output's register
+    # representation, not the input's. In 16-bit Dest mode (dest_acc=No) the
+    # inferred pack_src would otherwise stay equal to the input format and the
+    # pack would be rejected (e.g. UInt16 -> UInt32 is not a supported packer
+    # conversion). For dest_acc=Yes the 32-bit gasket converts from Dest and the
+    # inference already yields the output format, so no patch is needed there.
+    if dest_acc == DestAccumulation.No:
+        pack_src = (
+            DataFormat.Float16_b if _is_block_float(output_format) else output_format
+        )
+        for fmt_config in configuration.formats_config:
+            fmt_config.pack_src = pack_src
+
+    configuration.run(perf_report)

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_typecast_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_typecast_perf.cpp
@@ -96,7 +96,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             // So we just set/clear valid bits here - which is unavoidable hardware synchronization.
             // When unpack_to_dest is used, we assume the data is immediately ready in destination register.
             // Otherwise, we assume the data is immediately ready in source A/B registers.
-            if (!unpack_to_dest)
+            if constexpr (!unpack_to_dest)
             {
                 // Set valid for source A always.
                 // Set valid for source B only if dest_acc is enabled.
@@ -146,9 +146,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         START_PERF_MEASURE("INIT")
 
+        _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
         _llk_math_eltwise_unary_datacopy_init_<data_copy_type, is_fp32_dest_acc_en>(num_faces, formats.math);
         _llk_math_pack_sync_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
-        _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
 
         // Program the SFPU for this specific typecast pair, mirroring the
         // functional typecast kernel and production typecast_tile_init<IN, OUT>:

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_typecast_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_typecast_perf.cpp
@@ -1,0 +1,394 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//
+// LLK SFPU typecast PERF kernel.
+//
+// Structurally identical to sources/eltwise_unary_sfpu_perf.cpp (same profiler
+// zones, run-type handling, unpack/datacopy/pack flow, LOOP_FACTOR loop), but
+// the MATH-isolate / L1-to-L1 measured loop performs the SFPU *typecast* op
+// instead of a generic SFPU unary op.
+//
+// The typecast op is dispatched by the (IN, OUT) DataFormat pair via the shared
+// unary-SFPU entry points (call_unary_sfpu_operation under SfpuType::typecast),
+// exactly as the functional kernel sources/eltwise_unary_typecast_test.cpp does
+// and as the production compute API typecast_tile<IN, OUT> does. That routes to
+// the same calculate_typecast_* primitives whose SFPLOADMACRO fast path is
+// gated by DISABLE_SFPLOADMACRO, so this kernel measures the macro vs plain-loop
+// cost per tile.
+//
+// Compile-time configuration emitted by the Python harness:
+//   SFPU_UNARY_OPERATION : SfpuType::typecast   (from MATH_OP(Typecast))
+//   TYPECAST_IN_FORMAT   : DataFormat of the typecast input  (typecast IN_DTYPE)
+//   TYPECAST_OUT_FORMAT  : DataFormat of the typecast output (typecast OUT_DTYPE)
+//   APPROX_MODE          : SFPU approximation mode
+//   ITERATIONS           : SFPU iteration count (typecast dispatch uses 8)
+//
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <type_traits>
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_ops.h"
+#include "counters.h"
+#include "llk_defs.h"
+#include "params.h"
+#include "perf.h"
+#include "profiler.h"
+
+// Globals
+std::uint32_t unp_cfg_context                          = 0;
+std::uint32_t pack_sync_tile_dst_ptr                   = 0;
+std::uint32_t math_sync_tile_dst_index                 = 0;
+static constexpr std::uint32_t MAX_TILES_DEST          = is_fp32_dest_acc_en ? 4 : 8;
+static constexpr ckernel::DstSync DST_SYNC_MODE        = ckernel::DstSync::SyncHalf;
+static constexpr ckernel::BroadcastType BROADCAST_TYPE = ckernel::BroadcastType::NONE;
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "llk_unpack_A.h"
+#include "llk_unpack_common.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
+    const std::uint32_t num_faces   = params.num_faces;
+
+    const std::uint32_t TILE_CNT = params.TILE_CNT;
+
+    const bool UNPACK_TRANSPOSE_FACES       = params.UNPACK_TRANSPOSE_FACES;
+    const bool UNPACK_TRANSPOSE_WITHIN_FACE = params.UNPACK_TRANSPOSE_WITHIN_FACE;
+#endif
+    const EltwiseBinaryReuseDestType reuse_dest_type = EltwiseBinaryReuseDestType::NONE;
+    // acc_to_dest for the unpack-A datapath. Unlike the generic SFPU perf kernel
+    // (which ties this to is_fp32_dest_acc_en), the typecast kernel keeps it
+    // false -- mirroring the functional typecast kernel -- so a 32-bit input can
+    // unpack straight into Dest even when dest_acc=Yes. llk_unpack_A asserts
+    // !(acc_to_dest && unpack_to_dest); tying acc_to_dest to is_fp32_dest_acc_en
+    // would make the 32-bit-input + dest_acc=Yes typecasts uncompilable.
+    const bool UNPACK_ACC_TO_DEST = false;
+
+    {
+        START_PERF_MEASURE("INIT")
+
+        _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
+            formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, num_faces, num_faces);
+
+        _llk_unpack_A_init_<BROADCAST_TYPE, UNPACK_ACC_TO_DEST, reuse_dest_type, unpack_to_dest>(
+            UNPACK_TRANSPOSE_FACES, UNPACK_TRANSPOSE_WITHIN_FACE, FACE_R_DIM, num_faces, formats.unpack_A_src, formats.unpack_A_dst);
+        PROFILER_SYNC();
+    }
+    {
+        START_PERF_MEASURE("TILE_LOOP")
+
+        if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
+        {
+            // In case of math isolate, we don't want any software synchronization from unpack to math.
+            // So we just set/clear valid bits here - which is unavoidable hardware synchronization.
+            // When unpack_to_dest is used, we assume the data is immediately ready in destination register.
+            // Otherwise, we assume the data is immediately ready in source A/B registers.
+            if (!unpack_to_dest)
+            {
+                // Set valid for source A always.
+                // Set valid for source B only if dest_acc is enabled.
+                // Works only when unpacking to dest is not used.
+                _perf_unpack_loop_set_valid<
+                    /* src A */ true,
+                    /* src B */ is_fp32_dest_acc_en>(
+                    /* iterations*/ num_faces * TILE_CNT * LOOP_FACTOR);
+            }
+        }
+        else if constexpr (PERF_RUN_TYPE != PerfRunType::PACK_ISOLATE) // UNPACK_ISOLATE, L1_TO_L1, L1_CONGESTION
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; ++loop)
+            {
+                for (std::uint32_t i = 0; i < TILE_CNT; ++i)
+                {
+                    _llk_unpack_A_<BROADCAST_TYPE, UNPACK_ACC_TO_DEST, reuse_dest_type, unpack_to_dest>(
+                        PERF_ADDRESS(PERF_INPUT_A, /* tile_idx */ i), formats.unpack_A_src, formats.unpack_A_dst);
+                }
+            }
+        }
+        PROFILER_SYNC();
+    }
+}
+
+#endif // LLK_TRISC_UNPACK
+
+#ifdef LLK_TRISC_MATH
+#include "llk_math_common.h"
+#include "llk_math_eltwise_unary_datacopy.h"
+#include "llk_math_eltwise_unary_sfpu.h"
+#include "sfpu_operations.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
+    const std::uint32_t num_faces   = params.num_faces;
+    const std::uint32_t TILE_CNT    = params.TILE_CNT;
+#endif
+    const DataCopyType data_copy_type = DataCopyType::A2D;
+
+    {
+        START_PERF_MEASURE("INIT")
+
+        _llk_math_eltwise_unary_datacopy_init_<data_copy_type, is_fp32_dest_acc_en>(num_faces, formats.math);
+        _llk_math_pack_sync_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
+        _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
+
+        // Program the SFPU for this specific typecast pair, mirroring the
+        // functional typecast kernel and production typecast_tile_init<IN, OUT>:
+        // SFPU_UNARY_OPERATION is SfpuType::typecast and the concrete init is
+        // selected from the (IN, OUT) format pair supplied as the trailing
+        // template parameters.
+        test_utils::call_unary_sfpu_operation_init<
+            SFPU_UNARY_OPERATION,
+            APPROX_MODE,
+            is_fp32_dest_acc_en,
+            ITERATIONS,
+            FAST_MODE,
+            STABLE_SORT,
+            false /* CLAMP_NEGATIVE */,
+            TYPECAST_IN_FORMAT,
+            TYPECAST_OUT_FORMAT>();
+        PROFILER_SYNC();
+    }
+    {
+        START_PERF_MEASURE("TILE_LOOP")
+
+        if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; ++loop)
+            {
+                for (std::uint32_t i = 0; i < TILE_CNT; ++i)
+                {
+                    // For unpack isolate scenario, math should only perform necessary synchronization and nothing else.
+                    if constexpr (unpack_to_dest)
+                    {
+                        // In this case, unpacker needs software synchronization from math - to acknowledge that destination register is
+                        // "consumed" and can be overwritten with new data.
+                        // Due to the fact that BROADCAST_TYPE is always NONE in the test and combination of unpack_to_dest and 32b data is always set,
+                        // this method will perform synchronization only and no actual data copy.
+                        _llk_math_eltwise_unary_datacopy_<data_copy_type, DST_SYNC_MODE, is_fp32_dest_acc_en, BROADCAST_TYPE, unpack_to_dest>(
+                            i % MAX_TILES_DEST, formats.math, formats.math);
+                    }
+                    else
+                    {
+                        // Perform only necessary hardware synchronization to indicate that source registers are consumed.
+                        _perf_math_loop_clear_valid<
+                            /* src A */ true,
+                            /* src B */ true>(
+                            /* iterations*/ num_faces);
+                    }
+                }
+            }
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; ++loop)
+            {
+                for (std::uint32_t block_start = 0; block_start < TILE_CNT; block_start += MAX_TILES_DEST)
+                {
+                    std::uint32_t block_tiles = std::min(TILE_CNT - block_start, MAX_TILES_DEST);
+
+                    _llk_math_wait_for_dest_available_<DST_SYNC_MODE>();
+
+                    for (std::uint32_t block_tile = 0; block_tile < block_tiles; ++block_tile)
+                    {
+                        if constexpr (unpack_to_dest)
+                        {
+                            // In this case, unpacker needs software synchronization from math - to acknowledge that destination register is
+                            // "consumed" and can be overwritten with new data.
+                            // Due to the fact that BROADCAST_TYPE is always NONE in the test and combination of unpack_to_dest and 32b data is always set,
+                            // this method will perform synchronization only and no actual data copy.
+                            _llk_math_eltwise_unary_datacopy_<data_copy_type, DST_SYNC_MODE, is_fp32_dest_acc_en, BROADCAST_TYPE, unpack_to_dest>(
+                                block_tile, formats.math, formats.math);
+                        }
+                        else
+                        {
+                            // Perform only necessary hardware synchronization to indicate that source registers are consumed.
+                            _perf_math_loop_clear_valid<
+                                /* src A */ true,
+                                /* src B */ true>(
+                                /* iterations*/ num_faces);
+                        }
+                    }
+
+                    _llk_math_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
+                }
+            }
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; ++loop)
+            {
+                for (std::uint32_t block_start = 0; block_start < TILE_CNT; block_start += MAX_TILES_DEST)
+                {
+                    std::uint32_t block_tiles = std::min(TILE_CNT - block_start, MAX_TILES_DEST);
+
+                    for (std::uint32_t block_tile = 0; block_tile < block_tiles; ++block_tile)
+                    {
+                        // When data is not unpacked to dest, math needs to copy data from srcA to dest before starting SFPU operation.
+                        // Otherwise, data is immediately ready in destination register.
+                        if constexpr (!unpack_to_dest)
+                        {
+                            LLK_ASSERT(
+                                (block_tile < get_dest_max_tiles<DST_SYNC_MODE, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
+                                "block_tile exceeds max dest tiles");
+                            _llk_math_eltwise_unary_datacopy_<data_copy_type, DST_SYNC_MODE, is_fp32_dest_acc_en, BROADCAST_TYPE, unpack_to_dest>(
+                                block_tile, formats.math, formats.math);
+                        }
+
+                        // In-place numeric typecast of the tile sitting in Dest.
+                        test_utils::call_unary_sfpu_operation<
+                            DST_SYNC_MODE,
+                            is_fp32_dest_acc_en,
+                            SFPU_UNARY_OPERATION,
+                            APPROX_MODE,
+                            is_fp32_dest_acc_en,
+                            ITERATIONS,
+                            FAST_MODE,
+                            STABLE_SORT,
+                            false /* CLAMP_NEGATIVE */,
+                            TYPECAST_IN_FORMAT,
+                            TYPECAST_OUT_FORMAT>(block_tile);
+                    }
+                }
+            }
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; ++loop)
+            {
+                for (std::uint32_t block_start = 0; block_start < TILE_CNT; block_start += MAX_TILES_DEST)
+                {
+                    std::uint32_t block_tiles = std::min(TILE_CNT - block_start, MAX_TILES_DEST);
+
+                    _llk_math_wait_for_dest_available_<DST_SYNC_MODE>();
+
+                    // Copy from srcA to dest
+                    for (std::uint32_t block_tile = 0; block_tile < block_tiles; ++block_tile)
+                    {
+                        LLK_ASSERT(
+                            (block_tile < get_dest_max_tiles<DST_SYNC_MODE, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
+                            "block_tile exceeds max dest tiles");
+
+                        _llk_math_eltwise_unary_datacopy_<data_copy_type, DST_SYNC_MODE, is_fp32_dest_acc_en, BROADCAST_TYPE, unpack_to_dest>(
+                            block_tile, formats.math, formats.math);
+
+                        // Start SFPU typecast operation
+                        test_utils::call_unary_sfpu_operation<
+                            DST_SYNC_MODE,
+                            is_fp32_dest_acc_en,
+                            SFPU_UNARY_OPERATION,
+                            APPROX_MODE,
+                            is_fp32_dest_acc_en,
+                            ITERATIONS,
+                            FAST_MODE,
+                            STABLE_SORT,
+                            false /* CLAMP_NEGATIVE */,
+                            TYPECAST_IN_FORMAT,
+                            TYPECAST_OUT_FORMAT>(block_tile);
+                    }
+
+                    _llk_math_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
+                }
+            }
+        }
+        PROFILER_SYNC();
+    }
+}
+
+#endif // LLK_TRISC_MATH
+
+#ifdef LLK_TRISC_PACK
+
+#include "llk_lib_pack_wrappers.h"
+#include "llk_pack_common.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
+    const std::uint32_t num_faces   = params.num_faces;
+    const std::uint32_t TILE_CNT    = params.TILE_CNT;
+#endif
+    {
+        START_PERF_MEASURE("INIT")
+
+        // Configure packer hardware
+        _llk_pack_hw_configure_<is_fp32_dest_acc_en, ckernel::PackMode::Default>(formats.pack_src, formats.pack_dst, FACE_R_DIM * FACE_C_DIM * num_faces);
+
+        _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, num_faces);
+        // Initialize destination for packing
+        _llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
+
+        PROFILER_SYNC();
+    }
+    {
+        START_PERF_MEASURE("TILE_LOOP")
+
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; ++loop)
+            {
+                for (std::uint32_t block_start = 0; block_start < TILE_CNT; block_start += MAX_TILES_DEST)
+                {
+                    std::uint32_t block_tiles = std::min(TILE_CNT - block_start, MAX_TILES_DEST);
+
+                    for (std::uint32_t block_tile = 0; block_tile < block_tiles; ++block_tile)
+                    {
+                        LLK_ASSERT(
+                            (block_tile < get_dest_max_tiles<DST_SYNC_MODE, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
+                            "block_tile exceeds max dest tiles");
+                        _llk_pack_<DST_SYNC_MODE, is_fp32_dest_acc_en, ckernel::PackMode::Default>(
+                            block_tile, PERF_ADDRESS(PERF_OUTPUT, block_start + block_tile));
+                    }
+                }
+            }
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; ++loop)
+            {
+                for (std::uint32_t block_start = 0; block_start < TILE_CNT; block_start += MAX_TILES_DEST)
+                {
+                    std::uint32_t block_tiles = std::min(TILE_CNT - block_start, MAX_TILES_DEST);
+
+                    _llk_packer_wait_for_math_done_();
+                    for (std::uint32_t block_tile = 0; block_tile < block_tiles; ++block_tile)
+                    {
+                        LLK_ASSERT(
+                            (block_tile < get_dest_max_tiles<DST_SYNC_MODE, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
+                            "block_tile exceeds max dest tiles");
+                        _llk_pack_<DST_SYNC_MODE, is_fp32_dest_acc_en, ckernel::PackMode::Default>(
+                            block_tile, PERF_ADDRESS(PERF_OUTPUT, block_start + block_tile));
+                    }
+                    _llk_pack_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
+                }
+            }
+        }
+
+        PROFILER_SYNC();
+    }
+}
+
+#endif // LLK_TRISC_PACK


### PR DESCRIPTION

### PR Category

Performance

### Summary

Re-introduces the `SFPLOADMACRO` scheduling for the SFPU `typecast` kernels on **Blackhole and Wormhole**, **without** re-introducing debug feature bit 11.

**Background / motivation.** #46231 ("Remove dependency on debug bit 11 for typecast") removed the `_llk_math_dbg_feature_disable_` (debug-feature-bit-11) dependency from the typecast datapath. To do that it replaced the `SFPLOADMACRO`-scheduled typecast kernels with plain per-row SFPU loops, which regressed typecast throughput. This PR restores the macro fast path on top of the corrected (bit-11-free) #46231 algorithm, so we keep the correctness fix *and* recover the lost performance. Closes #46751.

**What changed.** Of the 7 typecast variants that carried a `// TODO: Attempt to use LOADMACRO #46751` marker, **5 are converted** to `SFPLOADMACRO`; **2 are deliberately left as plain loops** (documented inline) because #46231 changed their algorithm and the historical macro is not result-equivalent:

| Variant | BH | WH | Status |
|---|---|---|---|
| `fp32_to_uint16` | ✅ | ✅ | macro (16-bit Dest path) |
| `uint16_to_fp32` | ✅ | ✅ | macro (16-bit Dest path) |
| `uint32_to_fp16b` | ✅ | ✅ | macro |
| `uint16_to_uint32` | ✅ | ✅ | macro (16-bit Dest path) |
| `int32_to_uint16` | ✅ | ✅ | macro |
| `fp32_to_fp16b` | — | — | **deferred** (algorithm changed by #46231) |
| `uint32_to_uint16` | — | — | **deferred** (algorithm changed by #46231) |

The macro runs only on the 16-bit-Dest (`!DST_ACCUM_MODE`) path for the three variants whose 32-bit-Dest store differs; the 32-bit-Dest path keeps the plain loop. This is how the optimization avoids debug bit 11: the old macros relied on bit 11 to cover 32-bit Dest, whereas here 32-bit Dest simply falls back to the (correct) plain loop.

## Performance — before vs. after this change

Measured on silicon, **MATH-isolate cycles/tile** (lower is better), via an A/B on the same build toggled with `TT_METAL_DISABLE_SFPLOADMACRO` (OFF = the plain-loop state this PR starts from; ON = this PR). A dedicated typecast perf test was added to measure this (see below).

**Blackhole** (p100a):

| Typecast (IN → OUT) | Before (plain loop) | After (this PR) | Speedup |
|---|---|---|---|
| Float16_b → UInt16 | 196.30 | 109.34 | **1.80× (−44.3%)** |
| UInt16 → Float32 | 166.97 | 73.77 | **2.26× (−55.8%)** |
| UInt32 → Float16_b | 271.55 | 139.57 | **1.95× (−48.6%)** |
| UInt16 → UInt32 | 130.77 | 70.25 | **1.86× (−46.3%)** |
| Int32 → UInt16 | 207.48 | 127.84 | **1.62× (−38.4%)** |

**Wormhole** (n300):

| Typecast (IN → OUT) | Before (plain loop) | After (this PR) | Speedup |
|---|---|---|---|
| Float16_b → UInt16 | 246.11 | 110.82 | **2.22× (−55.0%)** |
| UInt16 → Float32 | 246.04 | 74.92 | **3.28× (−69.5%)** |
| UInt32 → Float16_b | 373.26 | 157.30 | **2.37× (−57.9%)** |
| UInt16 → UInt32 | 130.89 | 70.90 | **1.85× (−45.8%)** |
| Int32 → UInt16 | 209.69 | 141.24 | **1.48× (−32.6%)** |

No variant regressed; functional correctness is preserved (`test_eltwise_unary_typecast.py` is **54/54 on both arches**).

### Context: this recovers exactly what the bit-11 removal cost

To confirm the regression originated in #46231 (and that bit 11 itself was never the source of the speed), we also measured the *original* macro implementation **with** bit 11 (commit `987c7451ded~1`) on Wormhole. Three points, MATH-isolate cycles/tile:

| Typecast (IN → OUT) | A — orig macro **+ bit 11** (pre-#46231) | B — plain loop (post-#46231) | C — **this PR** (macro, no bit 11) |
|---|---|---|---|
| Float16_b → UInt16 | 110.66 | 246.11 | 110.82 |
| UInt16 → Float32 | 74.56 | 246.04 | 74.92 |
| UInt32 → Float16_b | 157.30 | 373.26 | 157.30 |
| UInt16 → UInt32 | 70.59 | 130.89 | 70.90 |
| Int32 → UInt16 | 141.32 | 209.69 | 141.24 |

**A ≈ C (within ~0.3 cyc/tile), and both are ~1.5–3.3× faster than B.** The #46231 bit-11 removal caused the regression by swapping macros for plain loops; this PR recovers essentially all of the original performance **without** depending on debug bit 11. The speed comes from `SFPLOADMACRO` throughput, not from bit 11.

### Notes for reviewers

- **No debug bit 11.** Verified: no added line references `_llk_math_dbg_feature_disable_/enable_`, "bit 11", or any debug-feature mechanism; the typecast path never toggles it. The macros are programmed purely via `TTI_SFPCONFIG` / `TTI_SFPLOADI` instruction templates.
- **The restored macro instruction schedules are the pre-removal ones** (recovered from `987c7451ded~1`), per arch: BH uses `ADDR_MOD_7/6`, WH uses `ADDR_MOD_3/2`. The deltas vs. history are intentional: (a) macro gated to `!DST_ACCUM_MODE` instead of using bit 11 for 32-bit Dest, and (b) two `StoreMod0` fixups (`uint32_to_fp16b` → FP32, `int32_to_uint16` → swap-hi-lo16) to match the store semantics #46231 corrected.
- **Wormhole-specific `disarm_sfploadmacro_misc()`.** The typecast `init` arms the macro Misc word (`UnitDelayKind=WaitForElapsedInstructions`) unconditionally. On WH silicon, running the 32-bit-Dest *plain-loop* fallback with that armed-but-never-consumed state **hard-hangs the SFPU** (TENSIX TIMED OUT); BH tolerates it. The fix issues a one-time `TTI_SFPCONFIG(0x000, 8, 1)` + 2 `SFPNOP` to disarm it at the top of the 32-bit-Dest fallback in the three gated variants. Please sanity-check this is the cleanest place to do it.
- **Two deferred variants.** `fp32_to_fp16b` (now masks `&0xFFFF0000` + FP32 store) and `uint32_to_uint16` (now saturates on the high bits before a swap store) were re-algorithmed by #46231; the old macros compute different results, so they remain plain loops with an explanatory comment. A correct macro for these would be a separate follow-up.
- **Cross-arch coupling — must land together.** The shared dispatch (`tt_metal/hw/inc/api/compute/eltwise_unary/typecast.h` and the LLK test harness `tests/helpers/include/sfpu_operations.h`) now passes a `DST_ACCUM_MODE` template arg to `uint16_to_fp32` / `uint16_to_uint32`. Both the BH and WH calc signatures are updated to match, so the arches are coupled in this PR (neither header compiles without the dispatch change, and vice-versa).
- **New perf harness (`Test`/tooling).** There was no cycle test for typecast (the generic `eltwise_unary_sfpu_perf` kernel dispatches by a single `MathOperation` and can't run typecast). Added `tests/sources/eltwise_unary_typecast_perf.cpp` + `tests/python_tests/perf_eltwise_typecast.py` (arch-generic). To reproduce the A/B: run that perf test once normally and once with `TT_METAL_DISABLE_SFPLOADMACRO=1`; the flag is **not** in the build hash, so wipe the build cache for the perf `.cpp` between passes (verify the math `.elf` TEXT size changed).
- **Verification:** BH `test_eltwise_unary_typecast.py` 54/54 (silicon); WH 54/54 (silicon); BH cross-compile + WH compile both clean on the combined branch.

---

<!-- Files changed: 6
  tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
  tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
  tt_metal/hw/inc/api/compute/eltwise_unary/typecast.h
  tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
  tt_metal/tt-llk/tests/python_tests/perf_eltwise_typecast.py        (new)
  tt_metal/tt-llk/tests/sources/eltwise_unary_typecast_perf.cpp      (new)
-->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstamatovic/issue_46751)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstamatovic/issue_46751)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nstamatovic/issue_46751)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nstamatovic/issue_46751)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nstamatovic/issue_46751)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nstamatovic/issue_46751)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstamatovic/issue_46751)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstamatovic/issue_46751)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nstamatovic/issue_46751)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nstamatovic/issue_46751)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstamatovic/issue_46751)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstamatovic/issue_46751)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstamatovic/issue_46751)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstamatovic/issue_46751)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstamatovic/issue_46751)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstamatovic/issue_46751)