### PR TITLE
[skip ci] Skip test_indexed_slice on Blackhole (bh_p150b_civ2)

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_non_zero.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_non_zero.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 import ttnn
 from tests.ttnn.utils_for_testing import tt_dtype_to_torch_dtype
+from models.common.utility_functions import skip_for_blackhole
 
 
 @pytest.mark.parametrize(
@@ -32,6 +33,7 @@ from tests.ttnn.utils_for_testing import tt_dtype_to_torch_dtype
         ttnn.uint32,
     ],
 )
+@skip_for_blackhole("test_indexed_slice fails on Blackhole P150b with BFLOAT16 dtype mismatch, refs #0")
 def test_indexed_slice(seed, B, b, tt_dtype, device):
     torch.manual_seed(seed)
 


### PR DESCRIPTION
The test `test_indexed_slice[DataType.BFLOAT16-16-3-0]` in `tests/tt_eager/python_api_testing/unit_testing/misc/test_non_zero.py` has been failing for 7+ days on the Blackhole P150b (`bh_p150b_civ2`) CI job. The assertion `torch.allclose(golden_output, a_pt)` fails due to a data layout/byte-order mismatch in the nonzero kernel output on Blackhole hardware (the returned indices tensor contains interleaved zero bytes, suggesting a uint32→int32 reinterpretation issue specific to Blackhole). Temporarily skipping on Blackhole until the underlying kernel bug is fixed.