### PR TITLE
[skip ci] Temporarily skip fabric ubench golden-comparison tests on wormhole_b0 T3K

### DIFF
--- a/tests/tt_metal/tt_fabric/test_infra/test_tt_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/test_infra/test_tt_fabric.cpp
@@ -173,6 +173,20 @@ int main(int argc, char** argv) {
             log_info(tt::LogTest, "Skipping Test Group: {} due to platform skip policy", test_config.name);
             continue;
         }
+        // Temporarily skip golden-comparison-failing tests on wormhole_b0 (T3K). See issue #FIXME.
+        {
+            static const std::unordered_set<std::string> wh_b0_skip_tests = {
+                "LinearMulticast", "UnidirLinearMulticast", "SingleSenderLinearUnicastAllDevices",
+                "NeighborExchangeLinear", "FullRingMulticast", "FullRingUnicast", "HalfRingMulticast",
+                "MeshMulticast", "SingleSenderMeshUnicastAllDevices",
+                "CustomMaxPacketSizeLinear3K", "CustomMaxPacketSizeMesh3K"
+            };
+            if (tt::tt_metal::hal::get_arch_name() == "wormhole_b0" &&
+                wh_b0_skip_tests.count(test_config.name)) {
+                log_info(tt::LogTest, "Skipping Test Group: {} on wormhole_b0 due to golden comparison failures", test_config.name);
+                continue;
+            }
+        }
         if (builder.should_skip_test_for_disabled_mesh_passthrough(test_config)) {
             log_info(
                 tt::LogTest,


### PR DESCRIPTION
Multiple fabric microbenchmark tests (LinearMulticast, UnidirLinearMulticast, SingleSenderLinearUnicastAllDevices, NeighborExchangeLinear, FullRingMulticast, FullRingUnicast, HalfRingMulticast, MeshMulticast, SingleSenderMeshUnicastAllDevices, CustomMaxPacketSizeLinear3K, CustomMaxPacketSizeMesh3K) have been failing golden comparison validation on the T3K (Wormhole B0) CI job 'T3K ubench - Fabric BW & Latency' since at least 2026-06-11.

The failure is at test_tt_fabric.cpp:349 with TT_THROW: Some tests failed golden comparison validation.

This PR adds a temporary source-level skip in the C++ harness (test_tt_fabric.cpp) for these specific test names on wormhole_b0 only, so CI is unblocked while the root cause is investigated.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-46873)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lifecycle/disable-issue-46873)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-46873)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lifecycle/disable-issue-46873)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=lifecycle/disable-issue-46873)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:lifecycle/disable-issue-46873)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lifecycle/disable-issue-46873)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lifecycle/disable-issue-46873)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lifecycle/disable-issue-46873)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lifecycle/disable-issue-46873)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lifecycle/disable-issue-46873)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lifecycle/disable-issue-46873)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lifecycle/disable-issue-46873)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lifecycle/disable-issue-46873)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lifecycle/disable-issue-46873)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lifecycle/disable-issue-46873)