### PR TITLE
emule: add `-I <src>/ttnn` to JIT include flags

### DIFF
--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -1088,6 +1088,9 @@ static std::string get_extra_include_flags() {
     const std::string project_src = TT_EMULE_PROJECT_SOURCE_DIR;
     std::string extra_inc;
     extra_inc += "-I\"" + project_src + "/ttnn/cpp\"";
+    // Resolves headers included with the repo-rooted `cpp/ttnn/...` prefix
+    // (e.g. the SDPA dataflow helper chain pulled in by the sampling writer).
+    extra_inc += " -I\"" + project_src + "/ttnn\"";
     extra_inc += " -I\"" + project_src + "\"";
     extra_inc += " -I\"" + project_src + "/tt_metal/hw/inc\"";
     extra_inc += " -I\"" + project_src + "/tt_metal/hostdevcommon/api\"";


### PR DESCRIPTION

The emulated JIT compile resolves project headers via a small set of `-I` paths in `get_extra_include_flags` (`emulated_program_runner.cpp`). The `ttnn.sampling` writer pulls in the SDPA dataflow helper chain, whose headers are included with the repo-rooted prefix `cpp/ttnn/...` (e.g. `dataflow_common.hpp` → `cpp/ttnn/.../q_chunk_remapping.hpp`). Those only resolve when the `ttnn` directory itself is on the include path.

This adds `-I "<src>/ttnn"` alongside the existing `-I "<src>/ttnn/cpp"`. It is additive and affects only emulated kernel JIT compilation. 

Required by the tt-emule `ttnn.moe` / `ttnn.sampling` [bring-up](https://github.com/tenstorrent/tt-emule/pull/204); the emule pin should bump to this commit.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sgholami/moe-sampling-pin)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sgholami/moe-sampling-pin)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sgholami/moe-sampling-pin)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sgholami/moe-sampling-pin)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sgholami/moe-sampling-pin)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sgholami/moe-sampling-pin)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sgholami/moe-sampling-pin)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sgholami/moe-sampling-pin)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sgholami/moe-sampling-pin)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sgholami/moe-sampling-pin)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sgholami/moe-sampling-pin)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sgholami/moe-sampling-pin)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sgholami/moe-sampling-pin)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sgholami/moe-sampling-pin)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sgholami/moe-sampling-pin)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sgholami/moe-sampling-pin)