### PR TITLE
[skip ci] Temporarily disable fabric ubench golden-comparison tests on T3K (wormhole_b0)

### DIFF
--- a/tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_ubench_at_least_2x2_mesh.yaml
+++ b/tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_ubench_at_least_2x2_mesh.yaml
@@ -24,6 +24,7 @@ Tests:
 
   ### LINEAR BANDWIDTH TESTS ###
   - name: "LinearMulticast"
+    skip: [wormhole_b0]
     benchmark_mode: true
     sync: true
     fabric_setup:
@@ -43,6 +44,7 @@ Tests:
         iterations: 3
 
   - name: "UnidirLinearMulticast"
+    skip: [wormhole_b0]
     benchmark_mode: true
     sync: true
     fabric_setup:
@@ -62,6 +64,7 @@ Tests:
         iterations: 3
 
   - name: "SingleSenderLinearUnicastAllDevices"
+    skip: [wormhole_b0]
     benchmark_mode: true
     sync: true
     fabric_setup:
@@ -81,6 +84,7 @@ Tests:
         iterations: 3
 
   - name: "NeighborExchangeLinear"
+    skip: [wormhole_b0]
     benchmark_mode: true
     sync: true
     fabric_setup:
@@ -120,6 +124,7 @@ Tests:
   ### RING BANDWIDTH TESTS ###
   # Full Ring Multicast and Unicast tests have more variation in bandwidth, so we run them for extra iterations
   - name: "FullRingMulticast"
+    skip: [wormhole_b0]
     benchmark_mode: true
     sync: true
     fabric_setup:
@@ -139,6 +144,7 @@ Tests:
         iterations: 3
 
   - name: "FullRingUnicast"
+    skip: [wormhole_b0]
     benchmark_mode: true
     sync: true
     fabric_setup:
@@ -158,6 +164,7 @@ Tests:
         iterations: 3
 
   - name: "HalfRingMulticast"
+    skip: [wormhole_b0]
     benchmark_mode: true
     sync: true
     fabric_setup:
@@ -196,6 +203,7 @@ Tests:
 
   ### MESH BANDWIDTH TESTS ###
   - name: "MeshMulticast"
+    skip: [wormhole_b0]
     benchmark_mode: true
     sync: true
     fabric_setup:
@@ -215,6 +223,7 @@ Tests:
         iterations: 3
 
   - name: "SingleSenderMeshUnicastAllDevices"
+    skip: [wormhole_b0]
     benchmark_mode: true
     sync: true
     fabric_setup:
@@ -253,6 +262,7 @@ Tests:
 
   ### CUSTOM MAX PACKET SIZE LINEAR BANDWIDTH TESTS ###
   - name: "CustomMaxPacketSizeLinear3K"
+    skip: [wormhole_b0]
     benchmark_mode: true
     sync: true
     fabric_setup:
@@ -356,6 +366,7 @@ Tests:
 
   ### CUSTOM MAX PACKET SIZE MESH BANDWIDTH TESTS ###
   - name: "CustomMaxPacketSizeMesh3K"
+    skip: [wormhole_b0]
     benchmark_mode: true
     sync: true
     fabric_setup:

--- a/tests/tt_metal/tt_fabric/test_infra/tt_fabric_test_config.cpp
+++ b/tests/tt_metal/tt_fabric/test_infra/tt_fabric_test_config.cpp
@@ -1108,6 +1108,27 @@ bool TestConfigBuilder::should_skip_test_on_platform(const ParsedTestConfig& tes
             }
         }
     }
+    // Temporarily skip golden-comparison-failing benchmark tests on wormhole_b0 (T3K), refs #46873
+    static const std::unordered_set<std::string> skipped_on_wormhole_b0 = {
+        "LinearMulticast",
+        "UnidirLinearMulticast",
+        "SingleSenderLinearUnicastAllDevices",
+        "NeighborExchangeLinear",
+        "FullRingMulticast",
+        "FullRingUnicast",
+        "HalfRingMulticast",
+        "MeshMulticast",
+        "SingleSenderMeshUnicastAllDevices",
+        "CustomMaxPacketSizeLinear3K",
+        "CustomMaxPacketSizeMesh3K",
+    };
+    {
+        auto arch_name = tt::tt_metal::hal::get_arch_name();
+        if (arch_name == "wormhole_b0" && skipped_on_wormhole_b0.count(test_config.name)) {
+            log_info(LogTest, "Skipping test '{}' on wormhole_b0 due to golden comparison failures, refs #46873", test_config.name);
+            return true;
+        }
+    }
     if (device_info_provider_.is_multi_mesh() && (test_config.fabric_setup.topology == Topology::Linear ||
                                                   test_config.fabric_setup.topology == Topology::Ring)) {
         log_info(

--- a/tests/tt_metal/tt_fabric/test_infra/tt_fabric_test_config.cpp
+++ b/tests/tt_metal/tt_fabric/test_infra/tt_fabric_test_config.cpp
@@ -1108,27 +1108,6 @@ bool TestConfigBuilder::should_skip_test_on_platform(const ParsedTestConfig& tes
             }
         }
     }
-    // Temporarily skip golden-comparison-failing benchmark tests on wormhole_b0 (T3K), refs #46873
-    static const std::unordered_set<std::string> skipped_on_wormhole_b0 = {
-        "LinearMulticast",
-        "UnidirLinearMulticast",
-        "SingleSenderLinearUnicastAllDevices",
-        "NeighborExchangeLinear",
-        "FullRingMulticast",
-        "FullRingUnicast",
-        "HalfRingMulticast",
-        "MeshMulticast",
-        "SingleSenderMeshUnicastAllDevices",
-        "CustomMaxPacketSizeLinear3K",
-        "CustomMaxPacketSizeMesh3K",
-    };
-    {
-        auto arch_name = tt::tt_metal::hal::get_arch_name();
-        if (arch_name == "wormhole_b0" && skipped_on_wormhole_b0.count(test_config.name)) {
-            log_info(LogTest, "Skipping test '{}' on wormhole_b0 due to golden comparison failures, refs #46873", test_config.name);
-            return true;
-        }
-    }
     if (device_info_provider_.is_multi_mesh() && (test_config.fabric_setup.topology == Topology::Linear ||
                                                   test_config.fabric_setup.topology == Topology::Ring)) {
         log_info(


### PR DESCRIPTION
Several fabric microbenchmark tests in `test_fabric_ubench_at_least_2x2_mesh.yaml` have been failing golden comparison validation on the T3K (wormhole_b0) CI runner for 7+ days (since at least 2026-06-11). The failing tests are: LinearMulticast, UnidirLinearMulticast, SingleSenderLinearUnicastAllDevices, NeighborExchangeLinear, FullRingMulticast, FullRingUnicast, HalfRingMulticast, MeshMulticast, SingleSenderMeshUnicastAllDevices, CustomMaxPacketSizeLinear3K, CustomMaxPacketSizeMesh3K.

This PR adds a source-level skip in `should_skip_test_on_platform()` scoped to `wormhole_b0` only, so the same tests continue to run on the BH Quietbox (Blackhole) runner.

refs #46873

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-46873)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lifecycle/disable-issue-46873)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-46873)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lifecycle/disable-issue-46873)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=lifecycle/disable-issue-46873)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:lifecycle/disable-issue-46873)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lifecycle/disable-issue-46873)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lifecycle/disable-issue-46873)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lifecycle/disable-issue-46873)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lifecycle/disable-issue-46873)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lifecycle/disable-issue-46873)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lifecycle/disable-issue-46873)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lifecycle/disable-issue-46873)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lifecycle/disable-issue-46873)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lifecycle/disable-issue-46873)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lifecycle/disable-issue-46873)