### PR TITLE
fix: correct SFPU compile errors from tanhshrink + digamma large-x PRs (#47323, #47324)

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_digamma.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_digamma.h
@@ -81,7 +81,7 @@ inline void calculate_digamma() {
         // bf16-accurate. #45520 targets bf16 ULP; an fp32-accurate log here would collide
         // with the reciprocal's vConstFloatPrgm0, so fp32 large-x is intentionally left as-is.
         v_if(x > 102.0f) {
-            sfpi::vFloat inv_x = _sfpu_reciprocal_<2>(x);
+            sfpi::vFloat inv_x = sfpu_reciprocal_iter<2>(x);
             sfpi::vFloat inv_x2 = inv_x * inv_x;
             // ln(x) - inv_x*0.5 - inv_x2*(1/12 - inv_x2/120); 1/12 and 1/120 are in
             // vConstFloatPrgm1/Prgm2 (programmed in digamma_init).

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanhshrink.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanhshrink.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_sfpu_exp.h"
+#include "ckernel_sfpu_recip.h"
 #include "ckernel_sfpu_tanh.h"
 
 namespace ckernel::sfpu {
@@ -58,7 +59,7 @@ inline void calculate_tanhshrink() {
                 sfpi::vFloat clamp = 9.0f;
                 sfpi::vec_min_max(axc, clamp);  // axc = min(|x|, 9)
                 sfpi::vFloat e = _sfpu_exp_fp32_accurate_unsafe_(-2.f * axc);
-                sfpi::vFloat sig = _sfpu_reciprocal_<2>(sfpi::vConst1 + e);  // sigmoid(2|x|)
+                sfpi::vFloat sig = sfpu_reciprocal_iter<2>(sfpi::vConst1 + e);  // sigmoid(2|x|)
                 sfpi::vFloat tanh_ax = 2.f * sig - sfpi::vConst1;            // tanh(|x|)
                 result = sfpi::copysgn(ax - tanh_ax, x);
             } else {
@@ -90,7 +91,7 @@ inline void tanhshrink_init() {
     if constexpr (is_fp32_dest_acc_en) {
         // The fp32 large-|x| path only needs the reciprocal Newton constants; the accurate
         // exp it uses is pure arithmetic (no LUT / programmable constants).
-        _init_sfpu_reciprocal_<false>();
+        sfpu_reciprocal_init<false>();
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
@@ -163,5 +163,6 @@ enum class SfpuType {
     lgamma,
     polygamma,
     mish,
+    tanhshrink,
     ne,
 };

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_digamma.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_digamma.h
@@ -81,7 +81,7 @@ inline void calculate_digamma() {
         // bf16-accurate. #45520 targets bf16 ULP; an fp32-accurate log here would collide
         // with the reciprocal's vConstFloatPrgm0, so fp32 large-x is intentionally left as-is.
         v_if(x > 102.0f) {
-            sfpi::vFloat inv_x = _sfpu_reciprocal_<2>(x);
+            sfpi::vFloat inv_x = sfpu_reciprocal_iter<2>(x);
             sfpi::vFloat inv_x2 = inv_x * inv_x;
             // ln(x) - inv_x*0.5 - inv_x2*(1/12 - inv_x2/120); 1/12 and 1/120 are in
             // vConstFloatPrgm1/Prgm2 (programmed in digamma_init).

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanhshrink.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanhshrink.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_sfpu_exp.h"
+#include "ckernel_sfpu_recip.h"
 #include "ckernel_sfpu_tanh.h"
 
 namespace ckernel::sfpu {
@@ -58,7 +59,7 @@ inline void calculate_tanhshrink() {
                 sfpi::vFloat clamp = 9.0f;
                 sfpi::vec_min_max(axc, clamp);  // axc = min(|x|, 9)
                 sfpi::vFloat e = _sfpu_exp_fp32_accurate_unsafe_(-2.f * axc);
-                sfpi::vFloat sig = _sfpu_reciprocal_<2>(sfpi::vConst1 + e);  // sigmoid(2|x|)
+                sfpi::vFloat sig = sfpu_reciprocal_iter<2>(sfpi::vConst1 + e);  // sigmoid(2|x|)
                 sfpi::vFloat tanh_ax = 2.f * sig - sfpi::vConst1;            // tanh(|x|)
                 result = sfpi::copysgn(ax - tanh_ax, x);
             } else {
@@ -90,7 +91,7 @@ inline void tanhshrink_init() {
     if constexpr (is_fp32_dest_acc_en) {
         // The fp32 large-|x| path only needs the reciprocal Newton constants; the accurate
         // exp it uses is pure arithmetic (no LUT / programmable constants).
-        _init_sfpu_reciprocal_<false>();
+        sfpu_reciprocal_init<false>();
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -163,5 +163,6 @@ enum class SfpuType {
     lgamma,
     polygamma,
     mish,
+    tanhshrink,
     ne,
 };

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/tanhshrink.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/tanhshrink.h
@@ -13,10 +13,10 @@
 namespace ckernel {
 
 ALWI void tanhshrink_tile(uint32_t idst) {
-    MATH(SFPU_CALL_MODE(
-        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_tanhshrink, (DST_ACCUM_MODE, 8 /* ITERATIONS */), RC, idst));
+    MATH(SFPU_UNARY_CALL(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_tanhshrink, (DST_ACCUM_MODE, 8 /* ITERATIONS */), idst, VectorMode::RC));
 }
 
-ALWI void tanhshrink_tile_init() { MATH(SFPU_INIT_CB(unused, sfpu::tanhshrink_init, (APPROX, DST_ACCUM_MODE))); }
+ALWI void tanhshrink_tile_init() { MATH(SFPU_UNARY_INIT_FN(tanhshrink, sfpu::tanhshrink_init, (false, DST_ACCUM_MODE))); }
 
 }  // namespace ckernel


### PR DESCRIPTION
## Root cause

Two PRs merged on 2026-06-22 both introduced `_sfpu_reciprocal_<N>` — a function name that does not exist. This causes **trisc1 JIT compile failures** (kernel never reaches hardware).

- PR #47323 (`e5b2e5db1f4`) — tanhshrink SFPU op → broke eltwise groups 1 & 4
- PR #47324 (`1a3822fa65d`) — digamma large-x accuracy fix → additionally broke eltwise group 3

Diagnosed by comparing CI runs 27942875579 (LESS broke, after #47323) and 27944055448 (MORE broke, after #47324).

---

## Bugs fixed

### Bug 1 — Wrong compute API macros (`tanhshrink.h`, from #47323)

`SFPU_CALL_MODE` and `SFPU_INIT_CB` are not declared anywhere in the codebase. The correct macros (matching `mish.h`) are `SFPU_UNARY_CALL` and `SFPU_UNARY_INIT_FN`, with different argument layout:
- `SFPU_UNARY_CALL`: `idst` before `VectorMode::RC` (not after)
- `SFPU_UNARY_INIT_FN`: op enum name (`tanhshrink`) as first arg, not `unused`

### Bug 2 — Non-existent reciprocal function names (`ckernel_sfpu_tanhshrink.h` WH + BH, from #47323)

`_sfpu_reciprocal_<N>` and `_init_sfpu_reciprocal_<>` do not exist. The correct API (from `ckernel_sfpu_recip.h`) is:
- `sfpu_reciprocal_iter<2>(...)`
- `sfpu_reciprocal_init<false>()`

The include for `ckernel_sfpu_recip.h` was also missing.

### Bug 3 — Missing `SfpuType` enum entry (`llk_sfpu_types.h` WH + BH, from #47323)

`SFPU_UNARY_INIT_FN` dispatches on `SfpuType::tanhshrink` but `tanhshrink` was never added to the enum. Added after `mish` in both WH and BH.

### Bug 4 — Same wrong reciprocal name in digamma large-x path (`ckernel_sfpu_digamma.h` WH + BH, from #47324)

The asymptotic correction block added by #47324 uses `_sfpu_reciprocal_<2>`. Same fix: `sfpu_reciprocal_iter<2>`. (`ckernel_sfpu_recip.h` was already included in digamma.)

---

## Files changed

| File | Change |
|------|--------|
| `tt_metal/hw/inc/api/compute/eltwise_unary/tanhshrink.h` | Fix macro names + arg order |
| `tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanhshrink.h` | Add recip include; fix function names |
| `tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanhshrink.h` | Same |
| `tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h` | Add `tanhshrink` enum entry |
| `tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h` | Same |
| `tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_digamma.h` | Fix `_sfpu_reciprocal_<2>` → `sfpu_reciprocal_iter<2>` |
| `tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_digamma.h` | Same |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/tanhshrink-sfpu-compile-errors)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/tanhshrink-sfpu-compile-errors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/tanhshrink-sfpu-compile-errors)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/tanhshrink-sfpu-compile-errors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/tanhshrink-sfpu-compile-errors)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/tanhshrink-sfpu-compile-errors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/tanhshrink-sfpu-compile-errors)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/tanhshrink-sfpu-compile-errors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/tanhshrink-sfpu-compile-errors)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/tanhshrink-sfpu-compile-errors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/tanhshrink-sfpu-compile-errors)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/tanhshrink-sfpu-compile-errors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/tanhshrink-sfpu-compile-errors)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/tanhshrink-sfpu-compile-errors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/tanhshrink-sfpu-compile-errors)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/tanhshrink-sfpu-compile-errors)