### PR TITLE
[LLK] [SAN] Reenable LLK_ASSERT support

### DIFF
--- a/tt_metal/tt-llk/common/sanitizer/output.h
+++ b/tt_metal/tt-llk/common/sanitizer/output.h
@@ -7,6 +7,7 @@
 #include <cstring>
 
 #include "ckernel.h"
+#include "llk_assert.h"
 #include "sanitizer/settings.h"
 #include "sanitizer/types.h"
 
@@ -139,6 +140,8 @@ TT_ALWAYS_INLINE void operand_assert(const State<T> expected, const State<T> act
     _print_compute_info(current);
 
     DEVICE_PRINT("└─────────────────────────────\n");
+
+    LLK_ASSERT(false, "Operand assertion, look at Sanitizer log");
 }
 
 template <Trigger level>
@@ -171,6 +174,8 @@ NOINLINE NOCLONE bool operation_assert(const Operation expected, const Operation
     _print_compute_info(current);
 
     DEVICE_PRINT("└─────────────────────────────\n");
+
+    LLK_ASSERT(false, "Operation assertion, look at Sanitizer log");
 
     return false;
 }
@@ -206,6 +211,8 @@ NOINLINE NOCLONE void operation_argument_assert(
     _print_compute_info(current);
 
     DEVICE_PRINT("└─────────────────────────────\n");
+
+    LLK_ASSERT(false, "Operation argument assertion, look at Sanitizer log");
 }
 
 static inline ct_string fsm_state_name(const FsmState state)
@@ -274,6 +281,8 @@ NOINLINE NOCLONE void fsm_assert(
     _print_compute_info(current);
 
     DEVICE_PRINT("└─────────────────────────────\n");
+
+    LLK_ASSERT(false, "FSM assertion, look at Sanitizer log");
 }
 
 } // namespace llk::san


### PR DESCRIPTION
Re-enables `LLK_ASSERT` as the failure path for the LLK sanitizer. Each sanitizer assertion handler in `output.h` now fires an `LLK_ASSERT(false, ...)` after printing its compute info, so a tripped sanitizer halts execution instead of only logging:

- `operand_assert` → "Operand assertion, look at Sanitizer log"
- `operation_assert` → "Operation assertion, look at Sanitizer log"
- `operation_argument_assert` → "Operation argument assertion, look at Sanitizer log"
- `fsm_assert` → "FSM assertion, look at Sanitizer log"

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk/san/pr/llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk/san/pr/llk-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk/san/pr/llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk/san/pr/llk-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=llk/san/pr/llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:llk/san/pr/llk-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk/san/pr/llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk/san/pr/llk-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk/san/pr/llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk/san/pr/llk-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk/san/pr/llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk/san/pr/llk-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk/san/pr/llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk/san/pr/llk-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk/san/pr/llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk/san/pr/llk-assert)