### PR TITLE
[LLK] [SAN] Remove redundant settings

### DIFF
--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -275,12 +275,6 @@ void JitBuildEnv::init(
     if (san.enabled) {
         this->defines_ += "-DLLK_SAN_ENABLE ";
 
-        if (san.method == tt::llrt::SanitizerReportMethod::Assert) {
-            this->defines_ += "-DLLK_SAN_SETTING_ASSERT ";
-        } else if (san.method == tt::llrt::SanitizerReportMethod::Print) {
-            this->defines_ += "-DLLK_SAN_SETTING_PRINT ";
-        }
-
         auto add_sanitizer_toggle = [&](const std::optional<bool>& opt, std::string_view name) {
             if (opt.has_value()) {
                 this->defines_ += "-DLLK_SAN_SETTING_" + std::string(name) + "=" + std::to_string(*opt) + " ";

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -213,8 +213,7 @@ enum class EnvVarID {
     // LLK SANITIZER
     // For detailed description look at tt-llk/sanitizer/settings.h
     // ========================================
-    TT_METAL_LLK_SANITIZER,         // Enable LLK sanitizer (master switch)
-    TT_METAL_LLK_SANITIZER_METHOD,  // Report method: "assert" or "print"
+    TT_METAL_LLK_SANITIZER,  // Enable LLK sanitizer (master switch)
     TT_METAL_LLK_SANITIZER_PEDANTIC,
     TT_METAL_LLK_SANITIZER_WARN,
     TT_METAL_LLK_SANITIZER_ERROR,
@@ -1475,21 +1474,6 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
             break;
         }
 
-        // TT_METAL_LLK_SANITIZER_METHOD
-        // Sets the sanitizer report method: "assert" or "print".
-        // Usage: export TT_METAL_LLK_SANITIZER_METHOD=print
-        case EnvVarID::TT_METAL_LLK_SANITIZER_METHOD: {
-            std::string_view method(value);
-            if (method == "assert") {
-                this->sanitizer_settings.method = SanitizerReportMethod::Assert;
-            } else if (method == "print") {
-                this->sanitizer_settings.method = SanitizerReportMethod::Print;
-            } else {
-                TT_THROW("Invalid TT_METAL_LLK_SANITIZER_METHOD: '{}'. Valid values: assert, print", value);
-            }
-            break;
-        }
-
         // TT_METAL_LLK_SANITIZER_PEDANTIC
         // Usage: export TT_METAL_LLK_SANITIZER_PEDANTIC=1
         case EnvVarID::TT_METAL_LLK_SANITIZER_PEDANTIC:
@@ -2140,7 +2124,6 @@ std::string RunTimeOptions::get_sanitizer_hash() const {
     const auto& san = get_sanitizer_settings();
     std::string hash_str;
     hash_str += std::to_string(san.enabled);
-    hash_str += std::to_string(static_cast<int>(san.method));
     hash_str += optional_hash(san.pedantic);
     hash_str += optional_hash(san.warn);
     hash_str += optional_hash(san.error);

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -151,15 +151,8 @@ struct FabricTelemetrySettings {
     }
 };
 
-enum class SanitizerReportMethod {
-    Default,
-    Assert,
-    Print,
-};
-
 struct SanitizerSettings {
     bool enabled = false;
-    SanitizerReportMethod method = SanitizerReportMethod::Default;
 
     std::optional<bool> pedantic = std::nullopt;
     std::optional<bool> warn = std::nullopt;

--- a/tt_metal/tt-llk/common/sanitizer/output.h
+++ b/tt_metal/tt-llk/common/sanitizer/output.h
@@ -17,20 +17,20 @@
 
 #ifndef LLK_SAN_ENABLE
 
-#elif defined(LLK_SAN_SETTING_ASSERT)
+#elif defined(ENABLE_LLK_ASSERT)
 
 #include "llk_assert.h"
 
-#elif defined(LLK_SAN_SETTING_PRINT)
+#elif defined(DEBUG_PRINT_ENABLED)
 
 #ifdef ENV_LLK_INFRA
-#error "llk::san | fault   | LLK_SAN_SETTING_PRINT is not supported in LLK INFRA, only in metal"
+#error "llk::san | fault   | DEBUG_PRINT_ENABLED is not supported in LLK INFRA, only in metal"
 #endif
 
 #include "api/debug/device_print.h"
 
 #else
-#error "llk::san | fault   | terrible failure :D"
+#error "llk::san | fault   | LLK_SAN_ENABLE is set but neither ENABLE_LLK_ASSERT nor DEBUG_PRINT_ENABLED is defined"
 #endif
 
 namespace llk::san

--- a/tt_metal/tt-llk/common/sanitizer/settings.h
+++ b/tt_metal/tt-llk/common/sanitizer/settings.h
@@ -4,9 +4,10 @@
 
 // LLK_SAN_ENABLE : Master switch. Enable/Disable sanitizer completely. Default DISABLED
 
-// If none of the below two are set, defaults to ASSERT. Mutually exclusive.
-// LLK_SAN_SETTING_ASSERT   : Once sanitizer is tripped, causes an LLK_ASSERT, stops execution
-// LLK_SAN_SETTING_PRINT    : Once sanitizer is tripped, causes a DEVICE_PRINT, continues execution
+// The report method is implicit and depends on which of the following are enabled:
+// ENABLE_LLK_ASSERT   : Once sanitizer is tripped, causes an LLK_ASSERT, stops execution
+// DEBUG_PRINT_ENABLED : Once sanitizer is tripped, causes a DEVICE_PRINT, continues execution
+// At least one of the two must be enabled whenever the sanitizer is enabled.
 
 // LLK_SAN_SETTING_PEDANTIC : Breaks LLK Contract, won't cause incorrect behavior, or check is redundant. Default FALSE.
 // LLK_SAN_SETTING_WARN     : Breaks LLK Contract, might cause incorrect behavior, or performance degradation. Default TRUE.
@@ -20,16 +21,6 @@
 #pragma once
 
 #ifndef LLK_SAN_ENABLE
-
-#if defined(LLK_SAN_SETTING_ASSERT)
-#error "llk::san | fault   | LLK_SAN_SETTING_ASSERT is set but LLK_SAN_ENABLE is not defined"
-#endif
-#define LLK_SAN_SETTING_ASSERT 0
-
-#if defined(LLK_SAN_SETTING_PRINT)
-#error "llk::san | fault   | LLK_SAN_SETTING_PRINT is set but LLK_SAN_ENABLE is not defined"
-#endif
-#define LLK_SAN_SETTING_PRINT 0
 
 #if defined(LLK_SAN_SETTING_PEDANTIC)
 #error "llk::san | fault   | LLK_SAN_SETTING_PEDANTIC is set but LLK_SAN_ENABLE is not defined"
@@ -62,14 +53,6 @@
 #define LLK_SAN_SETTING_INTERNAL 0
 
 #else
-
-#if defined(LLK_SAN_SETTING_ASSERT) && defined(LLK_SAN_SETTING_PRINT)
-#error "llk::san | fault   | LLK_SAN_SETTING_ASSERT and LLK_SAN_SETTING_PRINT cannot both be defined"
-#endif
-
-#if !defined(LLK_SAN_SETTING_ASSERT) && !defined(LLK_SAN_SETTING_PRINT)
-#define LLK_SAN_SETTING_ASSERT 1
-#endif
 
 #if !defined(LLK_SAN_SETTING_PEDANTIC)
 #define LLK_SAN_SETTING_PEDANTIC 0


### PR DESCRIPTION
Removes the explicit `LLK_SAN_SETTING_ASSERT` / `LLK_SAN_SETTING_PRINT` report-method selection. The report path is now implicit, derived from which debug feature is already enabled:

- `ENABLE_LLK_ASSERT` → sanitizer trips cause an `LLK_ASSERT` (stops execution)
- `DEBUG_PRINT_ENABLED` → sanitizer trips cause a `DEVICE_PRINT` (continues execution)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk/san/pr/simplify-settings)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk/san/pr/simplify-settings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk/san/pr/simplify-settings)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk/san/pr/simplify-settings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=llk/san/pr/simplify-settings)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:llk/san/pr/simplify-settings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk/san/pr/simplify-settings)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk/san/pr/simplify-settings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk/san/pr/simplify-settings)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk/san/pr/simplify-settings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk/san/pr/simplify-settings)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk/san/pr/simplify-settings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk/san/pr/simplify-settings)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk/san/pr/simplify-settings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk/san/pr/simplify-settings)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk/san/pr/simplify-settings)