### PR TITLE
[skip ci] Fix crash test results dropped from sweep summary

### DIFF
--- a/.github/workflows/ttnn-run-sweeps-impl.yaml
+++ b/.github/workflows/ttnn-run-sweeps-impl.yaml
@@ -237,6 +237,8 @@ jobs:
           if [[ $rc_col -ne 0 ]]; then echo "[two-pass] col pass exited $rc_col"; exit $rc_col; fi
           if [[ $rc_row -ne 0 ]]; then echo "[two-pass] row pass exited $rc_row"; exit $rc_row; fi
       - name: Compute artifact suffix
+        # Must run even when the sweep step fails so the upload step gets a unique
+        # BATCH_SUFFIX; without it the artifact name is incomplete and results may collide.
         if: ${{ always() }}
         shell: bash
         run: |

--- a/.github/workflows/ttnn-run-sweeps-impl.yaml
+++ b/.github/workflows/ttnn-run-sweeps-impl.yaml
@@ -237,6 +237,7 @@ jobs:
           if [[ $rc_col -ne 0 ]]; then echo "[two-pass] col pass exited $rc_col"; exit $rc_col; fi
           if [[ $rc_row -ne 0 ]]; then echo "[two-pass] row pass exited $rc_row"; exit $rc_row; fi
       - name: Compute artifact suffix
+        if: ${{ always() }}
         shell: bash
         run: |
           DISPLAY_LABEL="${{ matrix.batch_display }}"

--- a/tests/sweep_framework/sweeps_runner.py
+++ b/tests/sweep_framework/sweeps_runner.py
@@ -602,6 +602,7 @@ def _execute_vector_with_retry(
                 p = None
                 result["status"] = TestStatus.FAIL_CRASH_HANG
                 result["exception"] = str(result.get("message", "DEVICE HANG"))
+                result["end_time_ts"] = dt.datetime.now(dt.timezone.utc)
                 reset_util.reset()
                 if child_mode:
                     p = Process(target=run, args=(module_name, input_queue, output_queue, config))

--- a/tests/sweep_framework/sweeps_runner.py
+++ b/tests/sweep_framework/sweeps_runner.py
@@ -536,6 +536,7 @@ def _set_crash_hang_defaults(result):
     """Populate result fields for a FAIL_CRASH_HANG outcome."""
     result["status"] = TestStatus.FAIL_CRASH_HANG
     result["exception"] = "TEST TIMED OUT (CRASH / HANG)"
+    result["end_time_ts"] = dt.datetime.now(dt.timezone.utc)
     result["e2e_perf"] = None
     result["peak_l1_memory_per_core"] = None
     result["peak_cb_per_core"] = None


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
When a sweep test crashes/hangs, `_set_crash_hang_defaults()` left `end_time_ts` as `None`. The `OpTest` pydantic model requires `test_end_ts` to be a valid datetime, so `export_results()` threw a validation error — and the **entire module suite's results** (including all passing tests from the same suite) were silently dropped.

This caused the sweep job summary to show 0 failures and 100% pass rate even when tests crashed, because the crash test's result never made it into the exported JSON files.

### Root cause trace
```
sweeps_runner → _set_crash_hang_defaults(result)  # end_time_ts = None
  → export_results(header_info, results, ...)
    → OpTest(test_end_ts=None)  # pydantic validation error
      → "1 validation error for OpTest: test_end_ts - Input should be a valid datetime"
  → except Exception: logger.exception(...)  # entire suite's results dropped
    → continue with other suites
```

### Fix
1. **`sweeps_runner.py`**: Set `end_time_ts = dt.datetime.now(dt.timezone.utc)` in `_set_crash_hang_defaults()` — the crash detection timestamp is the correct test end time.

2. **`ttnn-run-sweeps-impl.yaml`**: Add `if: always()` to `Compute artifact suffix` step so the artifact gets a proper unique name even when the sweep step fails (prevents empty BATCH_SUFFIX).

### Notes for reviewers
One-line fix in `_set_crash_hang_defaults` + one-line `if: always()` in the impl workflow. The pydantic validation error was caught by the existing try/except but silently dropped all results for the affected suite.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=Aswinmcw/fix-crash-result-export)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/fix-crash-result-export)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=Aswinmcw/fix-crash-result-export)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:Aswinmcw/fix-crash-result-export)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=Aswinmcw/fix-crash-result-export)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:Aswinmcw/fix-crash-result-export)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/fix-crash-result-export)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/fix-crash-result-export)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=Aswinmcw/fix-crash-result-export)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:Aswinmcw/fix-crash-result-export)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/fix-crash-result-export)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/fix-crash-result-export)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/fix-crash-result-export)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/fix-crash-result-export)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/fix-crash-result-export)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/fix-crash-result-export)