### PR TITLE
[skip ci] Skip test_model_full_end_to_end[S4096] on Wormhole N150 due to PCC failure

### DIFF
--- a/models/demos/wormhole/bge_m3/tests/pcc/test_model.py
+++ b/models/demos/wormhole/bge_m3/tests/pcc/test_model.py
@@ -37,6 +37,8 @@ def model_artifacts(model_location_generator):
 @pytest.mark.parametrize("seq_len", SEQUENCE_LENGTHS, ids=[f"S{seq_len}" for seq_len in SEQUENCE_LENGTHS])
 def test_model_full_end_to_end(device, model_artifacts, seq_len, reset_seeds):
     require_single_device(device)
+    if seq_len == 4096:
+        pytest.skip("Skipping S4096: PCC check fails on N150 (Wormhole), refs #46975")
     backbone, state_dict, model_id_or_path = model_artifacts
 
     model_args, tt_model, _ = create_tt_model(


### PR DESCRIPTION
The test `models/demos/wormhole/bge_m3/tests/pcc/test_model.py::test_model_full_end_to_end[S4096]` has been failing for 7+ days on the Nightly N150 bge_m3 job with a PCC check failure (PCC=0.839, threshold=0.94). This PR adds a targeted `pytest.skip` inside the test body guarded on `seq_len == 4096` so only that specific parametrization is skipped on Wormhole N150, leaving all other sequence lengths unaffected. The parent dispatcher `test_ci_dispatch[bge_m3]` will also stop failing once the inner test no longer fails. refs #46975

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-46975)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lifecycle/disable-issue-46975)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-46975)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lifecycle/disable-issue-46975)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=lifecycle/disable-issue-46975)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:lifecycle/disable-issue-46975)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lifecycle/disable-issue-46975)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lifecycle/disable-issue-46975)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lifecycle/disable-issue-46975)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lifecycle/disable-issue-46975)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lifecycle/disable-issue-46975)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lifecycle/disable-issue-46975)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lifecycle/disable-issue-46975)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lifecycle/disable-issue-46975)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lifecycle/disable-issue-46975)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lifecycle/disable-issue-46975)