### PR TITLE
[skip ci] Temporarily disable test_demo_text ci-eval-32 performance on Wormhole (ethernet timeout)

### DIFF
--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -869,6 +869,8 @@ def test_demo_text(
     num_devices = mesh_device.get_num_devices() if isinstance(mesh_device, ttnn.MeshDevice) else 1
 
     test_id = request.node.callspec.id
+    if "ci-eval-32" in test_id and "performance" in test_id and is_wormhole_b0():
+        pytest.skip("Temporarily skipping ci-eval-32 performance on Wormhole due to ethernet timeout, refs #47126")
     if is_ci_env:
         if not ci_only:
             pytest.skip("CI only runs the CI-only tests")

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -869,8 +869,6 @@ def test_demo_text(
     num_devices = mesh_device.get_num_devices() if isinstance(mesh_device, ttnn.MeshDevice) else 1
 
     test_id = request.node.callspec.id
-    if "ci-eval-32" in test_id and "performance" in test_id and is_wormhole_b0():
-        pytest.skip("Temporarily skipping ci-eval-32 performance on Wormhole due to ethernet timeout, refs #47126")
     if is_ci_env:
         if not ci_only:
             pytest.skip("CI only runs the CI-only tests")

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -147,13 +147,26 @@
     export HF_MODEL=meta-llama/Llama-3.3-70B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.3-70B-Instruct
     pytest --timeout 4200 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-token-matching"
     pytest --timeout 1800 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-eval-32"
+  model: llama3.3-70b
+  skus:
+    bh_quietbox_2:
+      timeout: 30
+      tier: 2
+  owner_id: U03PUAKE719 # Miguel Tairum Cruz
+  team: models
 
+# wh_llmbox_perf is split into its own entry because the performance-ci-eval-32
+# case is temporarily disabled there: it fails with "RuntimeError: Timeout
+# waiting for Ethernet core service remote IO request" on the 8-device Wormhole
+# mesh. https://github.com/tenstorrent/tt-metal/issues/47126
+- name: Llama 3.3-70B e2e tests
+  cmd: |
+    export HF_MODEL=meta-llama/Llama-3.3-70B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.3-70B-Instruct
+    pytest --timeout 4200 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-token-matching"
+    # pytest --timeout 1800 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-eval-32"  # disabled, refs #47126
   model: llama3.3-70b
   skus:
     wh_llmbox_perf:
-      timeout: 30
-      tier: 2
-    bh_quietbox_2:
       timeout: 30
       tier: 2
   owner_id: U03PUAKE719 # Miguel Tairum Cruz

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -142,6 +142,9 @@
   owner_id: U07RY6B5FLJ # Gongyu Wang
   team: models
 
+# Not running on wh_llmbox_perf: performance-ci-eval-32 fails there with
+# "RuntimeError: Timeout waiting for Ethernet core service remote IO request"
+# on the 8-device Wormhole mesh. https://github.com/tenstorrent/tt-metal/issues/47126
 - name: Llama 3.3-70B e2e tests
   cmd: |
     export HF_MODEL=meta-llama/Llama-3.3-70B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.3-70B-Instruct
@@ -150,23 +153,6 @@
   model: llama3.3-70b
   skus:
     bh_quietbox_2:
-      timeout: 30
-      tier: 2
-  owner_id: U03PUAKE719 # Miguel Tairum Cruz
-  team: models
-
-# wh_llmbox_perf is split into its own entry because the performance-ci-eval-32
-# case is temporarily disabled there: it fails with "RuntimeError: Timeout
-# waiting for Ethernet core service remote IO request" on the 8-device Wormhole
-# mesh. https://github.com/tenstorrent/tt-metal/issues/47126
-- name: Llama 3.3-70B e2e tests
-  cmd: |
-    export HF_MODEL=meta-llama/Llama-3.3-70B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.3-70B-Instruct
-    pytest --timeout 4200 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-token-matching"
-    # pytest --timeout 1800 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-eval-32"  # disabled, refs #47126
-  model: llama3.3-70b
-  skus:
-    wh_llmbox_perf:
       timeout: 30
       tier: 2
   owner_id: U03PUAKE719 # Miguel Tairum Cruz


### PR DESCRIPTION
Temporarily skipping `test_demo_text[wormhole_b0-8-device_params0-False-performance-ci-eval-32]` on Wormhole hardware due to a recurring `RuntimeError: Timeout waiting for Ethernet core service remote IO request` that has been failing for 7+ days on the `wh_llmbox_perf` job.

refs #47126

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47126)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lifecycle/disable-issue-47126)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47126)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lifecycle/disable-issue-47126)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=lifecycle/disable-issue-47126)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:lifecycle/disable-issue-47126)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lifecycle/disable-issue-47126)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lifecycle/disable-issue-47126)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47126)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lifecycle/disable-issue-47126)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lifecycle/disable-issue-47126)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lifecycle/disable-issue-47126)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lifecycle/disable-issue-47126)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lifecycle/disable-issue-47126)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lifecycle/disable-issue-47126)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lifecycle/disable-issue-47126)