### PR TITLE
[skip ci] Disable load_prefetcher_test benchmark on wormhole_b0 due to trace region overflow

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
@@ -777,6 +777,11 @@ static int pgm_dispatch(T& state, TestInfo info) {
 
 static void BM_pgm_dispatch(benchmark::State& state, TestInfo info) {
     info.kernel_size = state.range(0);
+    // Skip load_prefetcher_test on wormhole_b0: trace buffer exceeds allocated region, refs #46983
+    if (info.load_prefetcher && tt::tt_metal::hal::get_arch_name() == std::string("wormhole_b0")) {
+        state.SkipWithError("Skipped: load_prefetcher_test exceeds trace region size on wormhole_b0, refs #46983");
+        return;
+    }
     pgm_dispatch(state, info);
 }
 


### PR DESCRIPTION
The `BM_pgm_dispatch/load_prefetcher_test` benchmark fails on wh_n300_civ2 (Wormhole N300) because the trace buffer size required (1031446528B) exceeds the allocated trace region (1000000000B), causing a TT_FATAL in `tt_metal/distributed/mesh_trace.cpp:78`. This adds a targeted skip inside `BM_pgm_dispatch` that fires only when `load_prefetcher` is true and the arch is `wormhole_b0`, leaving all other benchmarks and all other hardware unaffected. refs #46983

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-46983)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lifecycle/disable-issue-46983)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-46983)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lifecycle/disable-issue-46983)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=lifecycle/disable-issue-46983)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:lifecycle/disable-issue-46983)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lifecycle/disable-issue-46983)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lifecycle/disable-issue-46983)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lifecycle/disable-issue-46983)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lifecycle/disable-issue-46983)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lifecycle/disable-issue-46983)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lifecycle/disable-issue-46983)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lifecycle/disable-issue-46983)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lifecycle/disable-issue-46983)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lifecycle/disable-issue-46983)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lifecycle/disable-issue-46983)