### PR TITLE
WAN pipeline: emit per-step progress events + fix module loaded flag

### DIFF
--- a/models/tt_dit/layers/module.py
+++ b/models/tt_dit/layers/module.py
@@ -134,7 +134,11 @@ class Module(ABC):
         for name in state_dict:
             unexpected_keys.append(f"{module_key_prefix}{name}")
 
+    def _mark_loaded(self) -> None:
+        """Recursively mark this module and all descendants as loaded."""
         self._is_loaded = True
+        for _, child in self.named_children():
+            child._mark_loaded()  # noqa: SLF001
 
     def load_torch_state_dict(self, state_dict: Mapping[str, torch.Tensor], *, strict: bool = True) -> IncompatibleKeys:
         """Load PyTorch state dict into module parameters.
@@ -161,7 +165,7 @@ class Module(ABC):
                 parts.append("unexpected Torch state keys: " + ", ".join(unexpected_keys))
             raise ValueError("; ".join(parts))
 
-        self._is_loaded = True
+        self._mark_loaded()
         return IncompatibleKeys(missing_keys, unexpected_keys)
 
     @deprecated("Use load_torch_state_dict instead")

--- a/models/tt_dit/layers/module.py
+++ b/models/tt_dit/layers/module.py
@@ -134,6 +134,8 @@ class Module(ABC):
         for name in state_dict:
             unexpected_keys.append(f"{module_key_prefix}{name}")
 
+        self._is_loaded = True
+
     def load_torch_state_dict(self, state_dict: Mapping[str, torch.Tensor], *, strict: bool = True) -> IncompatibleKeys:
         """Load PyTorch state dict into module parameters.
 

--- a/models/tt_dit/pipelines/wan/pipeline_wan.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan.py
@@ -20,7 +20,7 @@ from models.tt_dit.models.transformers.wan2_2.transformer_wan import WanCheckpoi
 from models.tt_dit.models.vae.vae_wan2_1 import WanVAEDecoderAdapter
 from models.tt_dit.parallel.config import DiTParallelConfig, EncoderParallelConfig, VaeHWParallelConfig
 from models.tt_dit.parallel.manager import CCLManager
-from models.tt_dit.pipelines.events import PipelineEventCallback, SectionEnd, SectionStart, null_callback
+from models.tt_dit.pipelines.events import DenoiseStep, PipelineEventCallback, SectionEnd, SectionStart, null_callback
 from models.tt_dit.pipelines.pipeline_api import PipelineAPIMixin
 from models.tt_dit.pipelines.wan.text_encoder import TextEncoder
 from models.tt_dit.solvers import UniPCSolver, UniPCVariant
@@ -687,6 +687,7 @@ class WanPipeline(PipelineAPIMixin):
                 )
 
                 progress_bar.update()
+                on_event(DenoiseStep(step=i + 1, total=num_inference_steps, sigma=float(t)))
 
         self._current_timestep = None
 

--- a/models/tt_dit/pipelines/wan/pipeline_wan.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan.py
@@ -687,7 +687,7 @@ class WanPipeline(PipelineAPIMixin):
                 )
 
                 progress_bar.update()
-                on_event(DenoiseStep(step=i + 1, total=num_inference_steps, sigma=float(t)))
+                on_event(DenoiseStep(step=i + 1, total=num_inference_steps, sigma=float(self._scheduler.sigmas[i])))
 
         self._current_timestep = None
 


### PR DESCRIPTION
This adds a small progress signal to the WAN denoise loop so callers can track generation step-by-step. It emits a DenoiseStep event (current step, total steps, current sigma) on each iteration, using the event type that already exists in the pipeline.

It also fixes a small bug where a module wasn't marked as loaded after its weights were applied.

No behavior changes for existing callers — the progress event is opt-in via the existing callback.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=samt/pr-b-denoise-step)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:samt/pr-b-denoise-step)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=samt/pr-b-denoise-step)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:samt/pr-b-denoise-step)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=samt/pr-b-denoise-step)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:samt/pr-b-denoise-step)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=samt/pr-b-denoise-step)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:samt/pr-b-denoise-step)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=samt/pr-b-denoise-step)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:samt/pr-b-denoise-step)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=samt/pr-b-denoise-step)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:samt/pr-b-denoise-step)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=samt/pr-b-denoise-step)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:samt/pr-b-denoise-step)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=samt/pr-b-denoise-step)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:samt/pr-b-denoise-step)