### PR TITLE
[fabric] Skip galaxy corner-pinning for mock/emulated clusters

### DIFF
--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -446,8 +446,11 @@ void ControlPlane::init_control_plane(
         // Generate corner pinning for full host galaxy systems
         std::vector<std::pair<FabricNodeId, std::vector<AsicPosition>>> fixed_asic_position_pinnings;
 
-        // Apply galaxy pinnings to each mesh separately if it has 32 chips and is not 1D
-        if (cluster.is_ubb_galaxy()) {
+        // Apply galaxy pinnings to each mesh separately if it has 32 chips and is not 1D.
+        // Skip for mock/emulated clusters: they have no physical rack, so the corner ASIC
+        // positions {1,1}..{4,1} are derived host-dependently from the get_ubb_id decode and
+        // may be absent from the synthesized topology.
+        if (cluster.is_ubb_galaxy() && !cluster.is_mock_or_emulated()) {
             for (const auto& mesh_id : this->mesh_graph_->get_all_mesh_ids()) {
                 const auto& mesh_shape = this->mesh_graph_->get_mesh_shape(mesh_id);
                 const bool is_1d = mesh_shape[0] == 1 || mesh_shape[1] == 1;
@@ -559,8 +562,11 @@ void ControlPlane::init_control_plane_auto_discovery() {
     // bisect a device.
     std::vector<std::pair<FabricNodeId, std::vector<AsicPosition>>> fixed_asic_position_pinnings;
 
-    // Apply galaxy pinnings to each mesh separately if it has 32 chips and is not 1D
-    if (cluster.is_ubb_galaxy()) {
+    // Apply galaxy pinnings to each mesh separately if it has 32 chips and is not 1D.
+    // Skip for mock/emulated clusters: they have no physical rack, so the corner ASIC
+    // positions {1,1}..{4,1} are derived host-dependently from the get_ubb_id decode and
+    // may be absent from the synthesized topology.
+    if (cluster.is_ubb_galaxy() && !cluster.is_mock_or_emulated()) {
         for (const auto& mesh_id : this->mesh_graph_->get_all_mesh_ids()) {
             const auto& mesh_shape = this->mesh_graph_->get_mesh_shape(mesh_id);
             const bool is_1d = mesh_shape[0] == 1 || mesh_shape[1] == 1;


### PR DESCRIPTION
## Problem
Galaxy corner-pinning (`get_galaxy_fixed_asic_position_pinnings_for_mesh` → `add_pinning_constraints`) was gated only on `is_ubb_galaxy() && chips % 32 == 0`, so it also ran for a 32-chip **mock** galaxy. It pins mesh corners to physical rack tray positions `{1,1}..{4,1}`; a mock has no physical rack, and for UBB chips the tray comes from the `get_ubb_id` decode, so whether the corners resolve is **host-dependent**. On hosts where a corner position is absent from the synthesized topology, control-plane init aborted with `Failed to add pinning constraints`.

## Fix
Gate both call sites on `!cluster.is_mock_or_emulated()`. Corner pinning is a perf/orientation optimization, not a mapping feasibility requirement, and is meaningless on a mock.

## Validation
- Real galaxy silicon unaffected (`is_mock_or_emulated()` is false there).
- Mock galaxy still maps all 32 chips, opens (8×4), and an `all_gather` `query_op_constraints` over FABRIC_1D succeeds with an empty pinning set.
- Fabric unit-test pass/fail set identical with and without the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rpavlovic/skip-galaxy-corner-pinning-for-mock)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rpavlovic/skip-galaxy-corner-pinning-for-mock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rpavlovic/skip-galaxy-corner-pinning-for-mock)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rpavlovic/skip-galaxy-corner-pinning-for-mock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rpavlovic/skip-galaxy-corner-pinning-for-mock)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rpavlovic/skip-galaxy-corner-pinning-for-mock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rpavlovic/skip-galaxy-corner-pinning-for-mock)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rpavlovic/skip-galaxy-corner-pinning-for-mock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rpavlovic/skip-galaxy-corner-pinning-for-mock)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rpavlovic/skip-galaxy-corner-pinning-for-mock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rpavlovic/skip-galaxy-corner-pinning-for-mock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rpavlovic/skip-galaxy-corner-pinning-for-mock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rpavlovic/skip-galaxy-corner-pinning-for-mock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rpavlovic/skip-galaxy-corner-pinning-for-mock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rpavlovic/skip-galaxy-corner-pinning-for-mock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rpavlovic/skip-galaxy-corner-pinning-for-mock)