### PR TITLE
[Cleanup] Surface reduction for Runtime Tensor specs

### DIFF
--- a/tests/tt_metal/tt_metal/api/tensor/common_tensor_test_utils.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/common_tensor_test_utils.cpp
@@ -15,6 +15,7 @@
 #include <tt-metalium/experimental/tensor/tensor_apis.hpp>
 #include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
 #include <tt-metalium/experimental/tensor/topology/tensor_topology.hpp>
+#include <tt_metal/impl/tensor/spec/layout/tensor_layout_impl.hpp>
 
 namespace test_utils {
 
@@ -24,7 +25,7 @@ void test_tensor_on_device(
     tt::tt_metal::distributed::MeshDevice& device) {
     using namespace tt::tt_metal;
 
-    const auto input_buf_size = layout.compute_packed_buffer_size_bytes(input_shape);
+    const auto input_buf_size = layout.impl().compute_packed_buffer_size_bytes(input_shape);
 
     std::vector<std::byte> host_data(input_buf_size);
     std::vector<std::byte> readback_data(input_buf_size);

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_spec_preservation.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_spec_preservation.cpp
@@ -14,6 +14,7 @@
 #include <tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp>
 #include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
 #include <tt-metalium/experimental/per_core_allocation/buffer.hpp>
+#include <tt-metalium/experimental/per_core_allocation/memory_config.hpp>
 #include <tt-metalium/host_buffer.hpp>
 #include <tt-metalium/shape.hpp>
 #include <tt-metalium/tile.hpp>

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_dtype.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_dtype.cpp
@@ -17,6 +17,7 @@
 #include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
 #include <tt-metalium/experimental/tensor/impl/tensor_impl.hpp>
 #include <tt-metalium/experimental/per_core_allocation/buffer.hpp>
+#include <tt-metalium/experimental/per_core_allocation/memory_config.hpp>
 #include <tt-metalium/host_buffer.hpp>
 #include <tt-metalium/shape.hpp>
 #include <tt-metalium/tile.hpp>

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_tensor_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_tensor_spec.cpp
@@ -19,6 +19,7 @@
 #include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
 #include <tt-metalium/experimental/tensor/impl/tensor_impl.hpp>
 #include <tt-metalium/experimental/per_core_allocation/buffer.hpp>
+#include <tt-metalium/experimental/per_core_allocation/memory_config.hpp>
 #include <tt-metalium/float8.hpp>
 #include <tt-metalium/host_buffer.hpp>
 #include <tt-metalium/shape.hpp>

--- a/tests/tt_metal/tt_metal/api/tensor/test_tensor_layout.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_tensor_layout.cpp
@@ -18,6 +18,7 @@
 #include <tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp>
 #include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
 #include <tt-metalium/experimental/tensor/tensor_types.hpp>
+#include <tt_metal/impl/tensor/spec/layout/tensor_layout_impl.hpp>
 
 namespace tt::tt_metal {
 namespace {
@@ -51,8 +52,8 @@ TEST_P(TensorLayoutComputeTests, TensorLayout_Generic) {
     TensorLayout layout(params.inputs.data_type, PageConfig(params.inputs.layout), DefaultMemoryConfig);
 
     EXPECT_EQ(layout.get_alignment(), params.expected.alignment);
-    EXPECT_EQ(layout.compute_physical_shape(params.inputs.shape), params.expected.physical_size);
-    EXPECT_EQ(layout.compute_strides(params.inputs.shape), params.expected.strides);
+    EXPECT_EQ(layout.impl().compute_physical_shape(params.inputs.shape), params.expected.physical_size);
+    EXPECT_EQ(layout.impl().compute_strides(params.inputs.shape), params.expected.strides);
 
     if (params.expected.tensor_creation_works) {
         ::test_utils::test_tensor_on_device(params.inputs.shape, layout);
@@ -282,8 +283,8 @@ TEST_P(TensorLayoutRowMajorPaddedShapeAlignmentTests, FromPaddedShape_ComputesFu
         DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), DefaultMemoryConfig, params.shape, params.padded_shape);
 
     EXPECT_EQ(layout.get_alignment(), params.expected_alignment);
-    EXPECT_EQ(layout.compute_physical_shape(params.shape), params.expected_physical_shape);
-    EXPECT_EQ(layout.compute_strides(params.shape), params.expected_strides);
+    EXPECT_EQ(layout.impl().compute_physical_shape(params.shape), params.expected_physical_shape);
+    EXPECT_EQ(layout.impl().compute_strides(params.shape), params.expected_strides);
     EXPECT_EQ(layout.compute_padded_shape(params.shape), params.padded_shape);
 }
 
@@ -341,7 +342,7 @@ TEST_P(TensorLayoutTilePaddedAlignmentTests, Tensor_TilePaddedAlignmentRegressio
     // dimension cumulative alignment correctly carrying the original padded
     // dims, not the substituted tile dims. A too-small physical shape is the
     // direct signature of the bug.
-    EXPECT_EQ(layout.compute_physical_shape(params.shape), params.expected_physical_shape);
+    EXPECT_EQ(layout.impl().compute_physical_shape(params.shape), params.expected_physical_shape);
 
     // The physical volume must cover the legacy padded volume,
     // otherwise a host buffer packed for the legacy padded shape would not
@@ -493,7 +494,7 @@ TEST_P(ConsumedMemoryBytesPerBankTests, TestConsumedMemoryBytesPerBank) {
     }
 
     EXPECT_EQ(
-        params.tensor_layout.compute_consumed_memory_bytes_per_bank(params.shape, page_alignment, num_banks),
+        params.tensor_layout.impl().compute_consumed_memory_bytes_per_bank(params.shape, page_alignment, num_banks),
         params.expected_consumed_memory_bytes_per_bank);
 }
 

--- a/tests/tt_metal/tt_metal/api/tensor/test_vector_conversion.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_vector_conversion.cpp
@@ -19,6 +19,7 @@
 #include <tt-metalium/tile.hpp>
 #include <tt_stl/span.hpp>
 
+#include <tt-metalium/experimental/per_core_allocation/memory_config.hpp>
 #include <tt-metalium/experimental/tensor/host_tensor.hpp>
 #include <tt-metalium/experimental/tensor/tensor_apis.hpp>
 #include <tt-metalium/experimental/tensor/tensor_types.hpp>

--- a/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
@@ -29,6 +29,7 @@
 #include "ttnn/tensor/host_buffer/functions.hpp"
 #include "ttnn/tensor/layout/page_config.hpp"
 #include "ttnn/tensor/layout/tensor_layout.hpp"
+#include <tt_metal/impl/tensor/spec/layout/tensor_layout_impl.hpp>
 #include "ttnn/tensor/shape/shape.hpp"
 #include "ttnn/tensor/storage.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -70,10 +71,11 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncPreallocatedOutputs) {
     // Running sum-reduce with preallocated output
     // Preallocate Input and Output Tensors on Device
     tt_metal::TensorLayout tensor_layout(DataType::BFLOAT16, PageConfig(Layout::TILE), mem_cfg);
-    ASSERT_EQ(input_buf_size_datums * datum_size_bytes, tensor_layout.compute_packed_buffer_size_bytes(input_shape));
+    ASSERT_EQ(
+        input_buf_size_datums * datum_size_bytes, tensor_layout.impl().compute_packed_buffer_size_bytes(input_shape));
     ASSERT_EQ(
         output_buf_size_datums * datum_size_bytes,
-        tensor_layout.compute_packed_buffer_size_bytes(np_out.padded_shape()));
+        tensor_layout.impl().compute_packed_buffer_size_bytes(np_out.padded_shape()));
     auto input_tensor = ttnn::create_device_tensor(TensorSpec(input_shape, tensor_layout), device);
     auto output_tensor = ttnn::create_device_tensor(TensorSpec(np_out.logical_shape(), tensor_layout), device);
     // Populate input_tensor with data
@@ -122,7 +124,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncRuntimeAllocatedBuffers) {
             }
 
             TensorLayout tensor_layout(DataType::BFLOAT16, PageConfig(Layout::TILE), mem_cfg);
-            ASSERT_EQ(buf_size_datums * datum_size_bytes, tensor_layout.compute_packed_buffer_size_bytes(shape));
+            ASSERT_EQ(buf_size_datums * datum_size_bytes, tensor_layout.impl().compute_packed_buffer_size_bytes(shape));
             auto input_tensor = ttnn::create_device_tensor(TensorSpec(shape, tensor_layout), device_);
             ttnn::write_buffer(io_cq, input_tensor, {host_data});            // Write using cq 1
             auto write_event = ttnn::record_event(device_->mesh_command_queue(*io_cq));  // Record write on cq 1

--- a/tests/ttnn/unit_tests/gtests/udm/test_udm_utils.hpp
+++ b/tests/ttnn/unit_tests/gtests/udm/test_udm_utils.hpp
@@ -13,6 +13,7 @@
 #include "tt_metal/api/tt-metalium/bfloat16.hpp"
 
 #include "ttnn/tensor/tensor.hpp"
+#include <tt_metal/impl/tensor/spec/layout/tensor_layout_impl.hpp>
 #include "ttnn/api/ttnn/distributed/api.hpp"
 #include "ttnn/api/ttnn/distributed/distributed_tensor.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
@@ -43,8 +44,8 @@ inline tt::tt_metal::Shape compute_tensor_shape_in_pages(
     TT_FATAL(rank >= 1, "Tensor must have at least 1 dimension");
 
     // Get physical shape and page shape from tensor layout
-    tt::tt_metal::Shape2D physical_shape = tensor_layout.compute_physical_shape(tensor_shape);
-    tt::tt_metal::Shape2D page_shape = tensor_layout.compute_page_shape(physical_shape);
+    tt::tt_metal::Shape2D physical_shape = tensor_layout.impl().compute_physical_shape(tensor_shape);
+    tt::tt_metal::Shape2D page_shape = tensor_layout.impl().compute_page_shape(physical_shape);
 
     std::vector<uint32_t> shape_in_pages;
 

--- a/tt_metal/api/tt-metalium/experimental/per_core_allocation/memory_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/per_core_allocation/memory_config.hpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp>
+
+namespace tt::tt_metal::experimental::per_core_allocation {
+
+// MemoryConfig free functions — access experimental per-core allocation state on MemoryConfigImpl.
+
+bool is_per_core_allocation(const MemoryConfig& config);
+void set_per_core_allocation(MemoryConfig& config, bool enable);
+
+}  // namespace tt::tt_metal::experimental::per_core_allocation

--- a/tt_metal/api/tt-metalium/experimental/tensor/spec/layout/page_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/spec/layout/page_config.hpp
@@ -4,7 +4,9 @@
 
 #pragma once
 
+#include <memory>
 #include <optional>
+#include <tuple>
 
 #include <tt-metalium/shape2d.hpp>
 #include <tt-metalium/tile.hpp>
@@ -76,6 +78,8 @@ private:
     Tile tile_;
 };
 
+class PageConfigImpl;
+
 class PageConfig {
 public:
     using Config = std::variant<RowMajorPageConfig, TilePageConfig>;
@@ -83,6 +87,12 @@ public:
     PageConfig(const Config& config);
     PageConfig(Layout layout);
     PageConfig(Layout layout, const std::optional<Tile>& tile);
+
+    ~PageConfig();
+    PageConfig(const PageConfig& other);
+    PageConfig& operator=(const PageConfig& other);
+    PageConfig(PageConfig&& other) noexcept;
+    PageConfig& operator=(PageConfig&& other) noexcept;
 
     // Alignment is applied to the tensor shape, to guarantee that it is divisible by page size.
     // For tile layout, the page size is the tile size, so alignment is also equal to the tile size.
@@ -112,14 +122,22 @@ public:
     /// maximum possible alignment is used.
     Alignment get_recommended_shard_shape_alignment(DataType dtype) const;
 
-    bool operator==(const PageConfig&) const = default;
-    bool operator!=(const PageConfig&) const = default;
+    bool operator==(const PageConfig& other) const;
+    bool operator!=(const PageConfig& other) const;
 
     static constexpr auto attribute_names = std::forward_as_tuple("config");
-    auto attribute_values() const { return std::forward_as_tuple(config_); }
+    std::tuple<const Config&> attribute_values() const;
 
 private:
-    Config config_;
+    // Access to the implementation.
+    //
+    // pre-condition: the PageConfig must not be in a moved-from state.
+    PageConfigImpl& impl();
+    const PageConfigImpl& impl() const;
+
+    // impl_ may be nullptr if the PageConfig is in a moved-from state.
+    // Avoid using impl_ directly; use the impl() accessor instead.
+    std::unique_ptr<PageConfigImpl> impl_;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/experimental/tensor/spec/layout/page_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/spec/layout/page_config.hpp
@@ -4,117 +4,54 @@
 
 #pragma once
 
-#include <memory>
 #include <optional>
 #include <tuple>
+#include <utility>
+#include <variant>
 
-#include <tt-metalium/shape2d.hpp>
 #include <tt-metalium/tile.hpp>
 
 #include <tt-metalium/experimental/tensor/spec/layout/alignment.hpp>
-#include <tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp>
 #include <tt-metalium/experimental/tensor/spec/layout/layout.hpp>
 #include <tt-metalium/experimental/tensor/tensor_types.hpp>
 
 namespace tt::tt_metal {
 
+// Empty page-config alternative for row-major tensors.
+// User-declared ctor keeps this non-aggregate so reflection uses attribute_names/values only
+// (avoids colliding with ttsl::concepts::Reflectable).
 class RowMajorPageConfig {
 public:
-    RowMajorPageConfig(const Tile& tile = Tile());
-
-    Alignment create_default_alignment(DataType dtype, const MemoryConfig& memory_config) const;
-    void validate_alignment(const Alignment& alignment, DataType dtype, const MemoryConfig& memory_config) const;
-
-    Shape2D get_page_shape(
-        const Shape2D& physical_size,
-        DataType dtype,
-        const MemoryConfig& memory_config,
-        const std::optional<Shape2D>& physical_shard_size) const;
-    size_t get_page_size_bytes(const Shape2D& page_shape, DataType dtype) const;
-
-    const Tile& get_tile() const;
-
-    Alignment get_required_shard_shape_alignment() const;
-    Alignment get_recommended_shard_shape_alignment(DataType dtype) const;
+    RowMajorPageConfig() = default;
 
     bool operator==(const RowMajorPageConfig&) const = default;
     bool operator!=(const RowMajorPageConfig&) const = default;
 
-    static constexpr auto attribute_names = std::forward_as_tuple("tile");
-    auto attribute_values() const { return std::forward_as_tuple(tile_); }
-
-private:
-    // This is currently needed for compatibility reasons.
-    // Each time tile is specified, a warning will be issued. This should be removed soon.
-    Tile tile_;
+    static constexpr auto attribute_names = std::forward_as_tuple();
+    auto attribute_values() const { return std::forward_as_tuple(); }
 };
 
 class TilePageConfig {
 public:
-    TilePageConfig(const Tile& tile = Tile());
+    TilePageConfig() = default;
+    explicit TilePageConfig(Tile tile) : tile(std::move(tile)) {}
 
-    Alignment create_default_alignment(DataType dtype, const MemoryConfig& memory_config) const;
-    void validate_alignment(const Alignment& alignment, DataType dtype, const MemoryConfig& memory_config) const;
-
-    Shape2D get_page_shape(
-        const Shape2D& physical_size,
-        DataType dtype,
-        const MemoryConfig& memory_config,
-        const std::optional<Shape2D>& physical_shard_size) const;
-    size_t get_page_size_bytes(const Shape2D& page_shape, DataType dtype) const;
-
-    const Tile& get_tile() const;
-
-    Alignment get_required_shard_shape_alignment() const;
-    Alignment get_recommended_shard_shape_alignment(DataType dtype) const;
+    Tile tile = Tile{};
 
     bool operator==(const TilePageConfig&) const = default;
     bool operator!=(const TilePageConfig&) const = default;
 
     static constexpr auto attribute_names = std::forward_as_tuple("tile");
-    auto attribute_values() const { return std::forward_as_tuple(tile_); }
-
-private:
-    Tile tile_;
+    auto attribute_values() const { return std::forward_as_tuple(tile); }
 };
-
-class PageConfigImpl;
 
 class PageConfig {
 public:
     using Config = std::variant<RowMajorPageConfig, TilePageConfig>;
 
-    PageConfig(const Config& config);
+    PageConfig(Config config);
     PageConfig(Layout layout);
     PageConfig(Layout layout, const std::optional<Tile>& tile);
-
-    ~PageConfig();
-    PageConfig(const PageConfig& other);
-    PageConfig& operator=(const PageConfig& other);
-    PageConfig(PageConfig&& other) noexcept;
-    PageConfig& operator=(PageConfig&& other) noexcept;
-
-    // Alignment is applied to the tensor shape, to guarantee that it is divisible by page size.
-    // For tile layout, the page size is the tile size, so alignment is also equal to the tile size.
-    // For row major layout, the page size is the width of the tensor, or the width of the shard (for sharded tensors).
-    // So for row major tensors, alignment is either [1] for interleaved tensors or shard width for sharded tensors.
-    // Note: alignment rules are different for logical sharding.
-    Alignment create_default_alignment(DataType dtype, const MemoryConfig& memory_config) const;
-    void validate_alignment(const Alignment& alignment, DataType dtype, const MemoryConfig& memory_config) const;
-
-    Shape2D get_page_shape(
-        const Shape2D& physical_size,
-        DataType dtype,
-        const MemoryConfig& memory_config,
-        const std::optional<Shape2D>& physical_shard_size) const;
-    size_t get_page_size_bytes(const Shape2D& page_shape, DataType dtype) const;
-
-    Tile get_tile() const;
-
-    Layout get_layout() const;
-
-    /// Returns the minimum required alignment for the shard shape.
-    Alignment get_required_shard_shape_alignment() const;
 
     /// Returns the recommended alignment for the shard shape.
     /// This takes into account device memory alignment requirements trying to optimize memory usage and read/write
@@ -122,22 +59,18 @@ public:
     /// maximum possible alignment is used.
     Alignment get_recommended_shard_shape_alignment(DataType dtype) const;
 
-    bool operator==(const PageConfig& other) const;
-    bool operator!=(const PageConfig& other) const;
+    Layout get_layout() const;
+    Tile get_tile() const;  // Tile{} for ROW_MAJOR
+    const Config& get_config() const { return config_; }
+
+    bool operator==(const PageConfig&) const = default;
+    bool operator!=(const PageConfig&) const = default;
 
     static constexpr auto attribute_names = std::forward_as_tuple("config");
-    std::tuple<const Config&> attribute_values() const;
+    auto attribute_values() const { return std::forward_as_tuple(config_); }
 
 private:
-    // Access to the implementation.
-    //
-    // pre-condition: the PageConfig must not be in a moved-from state.
-    PageConfigImpl& impl();
-    const PageConfigImpl& impl() const;
-
-    // impl_ may be nullptr if the PageConfig is in a moved-from state.
-    // Avoid using impl_ directly; use the impl() accessor instead.
-    std::unique_ptr<PageConfigImpl> impl_;
+    Config config_;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/experimental/tensor/spec/layout/page_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/spec/layout/page_config.hpp
@@ -6,7 +6,6 @@
 
 #include <optional>
 #include <tuple>
-#include <utility>
 #include <variant>
 
 #include <tt-metalium/tile.hpp>
@@ -17,32 +16,14 @@
 
 namespace tt::tt_metal {
 
-// Empty page-config alternative for row-major tensors.
-// User-declared ctor keeps this non-aggregate so reflection uses attribute_names/values only
-// (avoids colliding with ttsl::concepts::Reflectable).
-class RowMajorPageConfig {
-public:
-    RowMajorPageConfig() = default;
-
+struct RowMajorPageConfig {
     bool operator==(const RowMajorPageConfig&) const = default;
-    bool operator!=(const RowMajorPageConfig&) const = default;
-
-    static constexpr auto attribute_names = std::forward_as_tuple();
-    auto attribute_values() const { return std::forward_as_tuple(); }
 };
 
-class TilePageConfig {
-public:
-    TilePageConfig() = default;
-    explicit TilePageConfig(Tile tile) : tile(std::move(tile)) {}
-
-    Tile tile = Tile{};
+struct TilePageConfig {
+    Tile tile;
 
     bool operator==(const TilePageConfig&) const = default;
-    bool operator!=(const TilePageConfig&) const = default;
-
-    static constexpr auto attribute_names = std::forward_as_tuple("tile");
-    auto attribute_values() const { return std::forward_as_tuple(tile); }
 };
 
 class PageConfig {
@@ -60,7 +41,7 @@ public:
     Alignment get_recommended_shard_shape_alignment(DataType dtype) const;
 
     Layout get_layout() const;
-    Tile get_tile() const;  // Tile{} for ROW_MAJOR
+    Tile get_tile() const;
     const Config& get_config() const { return config_; }
 
     bool operator==(const PageConfig&) const = default;

--- a/tt_metal/api/tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp
@@ -9,6 +9,7 @@
 
 #include <tt-metalium/experimental/tensor/spec/layout/alignment.hpp>
 #include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
+#include <tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp>
 #include <tt-metalium/experimental/tensor/tensor_types.hpp>
 
 #include <memory>

--- a/tt_metal/api/tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp
@@ -22,7 +22,6 @@ namespace tt::tt_metal {
 // Returns true if the configuration is valid, false otherwise.
 bool can_shard_align(const MemoryConfig& memory_config, const Layout& layout, const Tile& tile = Tile{});
 
-// Implementation details for TensorLayout. Reachable from within tt_metal via impl(); not part of the public API.
 class TensorLayoutImpl;
 
 using Strides = std::vector<size_t>;

--- a/tt_metal/api/tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
 #include <tt-metalium/experimental/tensor/tensor_types.hpp>
 
+#include <memory>
 #include <optional>
 #include <string>
 
@@ -21,6 +22,9 @@ namespace tt::tt_metal {
 bool can_shard_align(const MemoryConfig& memory_config, const Layout& layout, const Tile& tile = Tile{});
 
 class IDevice;
+
+// Implementation details for TensorLayout. Reachable from within tt_metal via impl(); not part of the public API.
+class TensorLayoutImpl;
 
 using Strides = std::vector<size_t>;
 
@@ -35,6 +39,12 @@ public:
         const MemoryConfig& memory_config,
         const Alignment& alignment = {});
 
+    ~TensorLayout();
+    TensorLayout(const TensorLayout& other);
+    TensorLayout& operator=(const TensorLayout& other);
+    TensorLayout(TensorLayout&& other) noexcept;
+    TensorLayout& operator=(TensorLayout&& other) noexcept;
+
     // static method makes it easy to find and remove all of its usages in the codebase - that's why it is not a
     // constructor
     [[deprecated("Use of Padded Shape is deprecated")]] static TensorLayout fromPaddedShape(
@@ -44,23 +54,12 @@ public:
         const tt::tt_metal::Shape& logical_shape,
         const tt::tt_metal::Shape& padded_shape);
 
-    Layout get_layout() const { return page_config_.get_layout(); }
-    Tile get_tile() const { return page_config_.get_tile(); }
-    PageConfig get_page_config() const { return page_config_; }
-    DataType get_data_type() const { return dtype_; }
-    const MemoryConfig& get_memory_config() const { return memory_config_; }
-    const Alignment& get_alignment() const { return alignment_; }
-
-    Strides compute_strides(const tt::tt_metal::Shape& shape) const;
-
-    BufferShardingArgs compute_buffer_sharding_args(const tt::tt_metal::Shape& shape) const;
-
-    size_t compute_packed_buffer_size_bytes(const tt::tt_metal::Shape& shape) const;
-    size_t compute_page_size_bytes(const tt::tt_metal::Shape& shape) const;
-
-    size_t compute_consumed_memory_bytes_per_bank(const tt::tt_metal::Shape& shape, const IDevice& device) const;
-    size_t compute_consumed_memory_bytes_per_bank(
-        const tt::tt_metal::Shape& shape, size_t page_alignment, size_t num_banks) const;
+    Layout get_layout() const;
+    Tile get_tile() const;
+    PageConfig get_page_config() const;
+    DataType get_data_type() const;
+    const MemoryConfig& get_memory_config() const;
+    const Alignment& get_alignment() const;
 
     // This method is deprecated and should be replaced with get_strides() / get_physical_size()
     // It computes padded shape on the fly from shape and alignment
@@ -69,41 +68,28 @@ public:
         tt_metal::Shape
         compute_padded_shape(const tt::tt_metal::Shape& shape) const;
 
-    // Flattens input shape into height and width
-    // - Height is accumulated over all dims except last
-    // - Width is equal to the last dim
-    Shape2D compute_logical_2d_shape(const tt::tt_metal::Shape& shape) const;
+    TensorLayout with_memory_config(MemoryConfig memory_config) const;
 
-    // Returns number of elements laid out in physically memory across H:W dimensions
-    //  W is row width aligned to page width and shard width, depends on data type
-    //  H is all dimensions except W multiplied and aligned to tile and shard height
-    Shape2D compute_physical_shape(const tt::tt_metal::Shape& shape) const;
+    bool operator==(const TensorLayout& other) const;
+    bool operator!=(const TensorLayout& other) const;
 
-    // Returns logical shard shape from shard spec shape
-    Shape2D get_logical_shard_shape() const;
-
-    // Returns physical shard shape based on shard shape and alignment
-    Shape2D get_physical_shard_shape() const;
-
-    Shape2D compute_page_shape(const Shape2D& physical_size) const;
-    size_t compute_page_size_bytes(const Shape2D& page_size) const;
-
-    bool operator==(const TensorLayout&) const = default;
-    bool operator!=(const TensorLayout&) const = default;
 
     static constexpr auto attribute_names = std::forward_as_tuple("dtype", "page_config", "memory_config", "alignment");
-    auto attribute_values() const { return std::forward_as_tuple(dtype_, page_config_, memory_config_, alignment_); }
+    std::tuple<const DataType&, const PageConfig&, const MemoryConfig&, const Alignment&> attribute_values() const;
 
     static TensorLayout restore_from_serialized(
         DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config, const Alignment& alignment);
 
-private:
-    void initialize_alignment();
+    // Access to the implementation, which carries the internal layout-computation API.
+    //
+    // pre-condition: the TensorLayout must not be in a moved-from state.
+    TensorLayoutImpl& impl();
+    const TensorLayoutImpl& impl() const;
 
-    DataType dtype_ = DataType::BFLOAT16;
-    PageConfig page_config_;
-    MemoryConfig memory_config_;
-    Alignment alignment_;
+private:
+    // impl_ may be nullptr if the TensorLayout is in a moved-from state.
+    // Avoid using impl_ directly; use the impl() accessor instead.
+    std::unique_ptr<TensorLayoutImpl> impl_;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp
@@ -22,8 +22,6 @@ namespace tt::tt_metal {
 // Returns true if the configuration is valid, false otherwise.
 bool can_shard_align(const MemoryConfig& memory_config, const Layout& layout, const Tile& tile = Tile{});
 
-class IDevice;
-
 // Implementation details for TensorLayout. Reachable from within tt_metal via impl(); not part of the public API.
 class TensorLayoutImpl;
 

--- a/tt_metal/api/tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp
@@ -4,15 +4,10 @@
 
 #pragma once
 
+#include <memory>
 #include <optional>
-
-#include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/buffer.hpp>
-#include <tt-metalium/mesh_buffer.hpp>
-#include <tt-metalium/device.hpp>
-#include <tt-metalium/tt_backend_api_types.hpp>
-#include <tt_stl/span.hpp>
+#include <ostream>
+#include <tuple>
 
 #include <tt-metalium/experimental/tensor/tensor_types.hpp>
 
@@ -25,35 +20,27 @@ struct from_json_t;
 
 namespace tt::tt_metal {
 
-// Forward declarations for friended free functions in the experimental namespace.
-// These are used to access experimental config params, which are not part of the official public API.
-class MemoryConfig;
-namespace experimental::per_core_allocation {
-bool is_per_core_allocation(const MemoryConfig& config);
-void set_per_core_allocation(MemoryConfig& config, bool enable);
-}  // namespace experimental::per_core_allocation
+class MemoryConfigImpl;
 
 class MemoryConfig final {
 public:
-    MemoryConfig() = default;  // Interleaved DRAM
+    MemoryConfig();  // Interleaved DRAM
     explicit MemoryConfig(
         TensorMemoryLayout memory_layout,
         BufferType buffer_type = BufferType::DRAM,
         std::optional<ShardSpec> shard_spec = std::nullopt);
     explicit MemoryConfig(BufferType buffer_type, std::optional<NdShardSpec> nd_shard_spec = std::nullopt);
-    MemoryConfig(const MemoryConfig& other) = default;
-    MemoryConfig& operator=(const MemoryConfig& other) = default;
-    MemoryConfig(MemoryConfig&& other) noexcept = default;
-    MemoryConfig& operator=(MemoryConfig&& other) noexcept = default;
+    ~MemoryConfig();
+    MemoryConfig(const MemoryConfig& other);
+    MemoryConfig& operator=(const MemoryConfig& other);
+    MemoryConfig(MemoryConfig&& other) noexcept;
+    MemoryConfig& operator=(MemoryConfig&& other) noexcept;
 
-    TensorMemoryLayout memory_layout() const { return memory_layout_; }
-    BufferType buffer_type() const { return buffer_type_; }
-    const std::optional<ShardSpec>& shard_spec() const { return shard_spec_; }
-    const std::optional<NdShardSpec>& nd_shard_spec() const { return nd_shard_spec_; }
-    bool created_with_nd_shard_spec() const { return created_with_nd_shard_spec_; }
-    // per_core_allocation access is through experimental::per_core_allocation free functions
-    friend bool experimental::per_core_allocation::is_per_core_allocation(const MemoryConfig&);
-    friend void experimental::per_core_allocation::set_per_core_allocation(MemoryConfig&, bool);
+    TensorMemoryLayout memory_layout() const;
+    BufferType buffer_type() const;
+    const std::optional<ShardSpec>& shard_spec() const;
+    const std::optional<NdShardSpec>& nd_shard_spec() const;
+    bool created_with_nd_shard_spec() const;
 
     bool is_sharded() const;
     bool is_l1() const;
@@ -61,10 +48,13 @@ public:
 
     static constexpr auto attribute_names = std::forward_as_tuple(
         "memory_layout", "buffer_type", "shard_spec", "nd_shard_spec", "created_with_nd_shard_spec");
-    auto attribute_values() const {
-        return std::forward_as_tuple(
-            memory_layout_, buffer_type_, shard_spec_, nd_shard_spec_, created_with_nd_shard_spec_);
-    }
+    std::tuple<
+        const TensorMemoryLayout&,
+        const BufferType&,
+        const std::optional<ShardSpec>&,
+        const std::optional<NdShardSpec>&,
+        const bool&>
+    attribute_values() const;
 
     static MemoryConfig create_with_prepopulated_shard_specs(
         TensorMemoryLayout memory_layout,
@@ -75,6 +65,10 @@ public:
 
     friend std::ostream& operator<<(std::ostream& os, const MemoryConfig& config);
 
+    // pre-condition: the MemoryConfig must not be in a moved-from state.
+    MemoryConfigImpl& impl();
+    const MemoryConfigImpl& impl() const;
+
 private:
     MemoryConfig(
         TensorMemoryLayout memory_layout,
@@ -83,14 +77,9 @@ private:
         std::optional<NdShardSpec> nd_shard_spec,
         bool created_with_nd_shard_spec);
 
-    TensorMemoryLayout memory_layout_ = TensorMemoryLayout::INTERLEAVED;  // Interleave the data across multiple banks
-    BufferType buffer_type_ = BufferType::DRAM;                           // Can be either DRAM or L1
-    std::optional<ShardSpec> shard_spec_ = std::nullopt;
-    std::optional<NdShardSpec> nd_shard_spec_ = std::nullopt;
-    bool created_with_nd_shard_spec_ = false;
-    // per_core_allocation is experimental functionality
-    // access is through experimental::per_core_allocation free functions
-    bool per_core_allocation_ = false;
+    // impl_ may be nullptr if the MemoryConfig is in a moved-from state.
+    // Avoid using impl_ directly; use the impl() accessor instead.
+    std::unique_ptr<MemoryConfigImpl> impl_;
 };
 
 std::ostream& operator<<(std::ostream& os, const MemoryConfig& config);

--- a/tt_metal/api/tt-metalium/experimental/tensor/spec/tensor_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/spec/tensor_spec.hpp
@@ -86,21 +86,13 @@ public:
     /// Performs arbitrary sharding for TensorSpec using the specified shard spec and shard shape alignment.
     TensorSpec sharded(NdShardSpec nd_shard_spec, ShardShapeAlignment shard_alignment) const;
 
-    Strides compute_strides() const { return tensor_layout_.compute_strides(logical_shape_); }
-    BufferShardingArgs compute_buffer_sharding_args() const {
-        return tensor_layout_.compute_buffer_sharding_args(logical_shape_);
-    }
-    size_t compute_packed_buffer_size_bytes() const {
-        return tensor_layout_.compute_packed_buffer_size_bytes(logical_shape_);
-    }
-    size_t compute_page_size_bytes() const { return tensor_layout_.compute_page_size_bytes(logical_shape_); }
+    Strides compute_strides() const;
+    BufferShardingArgs compute_buffer_sharding_args() const;
+    size_t compute_packed_buffer_size_bytes() const;
+    size_t compute_page_size_bytes() const;
 
-    size_t compute_consumed_memory_bytes_per_bank(const IDevice& device) const {
-        return tensor_layout_.compute_consumed_memory_bytes_per_bank(logical_shape_, device);
-    }
-    size_t compute_consumed_memory_bytes_per_bank(size_t page_alignment, size_t num_banks) const {
-        return tensor_layout_.compute_consumed_memory_bytes_per_bank(logical_shape_, page_alignment, num_banks);
-    }
+    size_t compute_consumed_memory_bytes_per_bank(const IDevice& device) const;
+    size_t compute_consumed_memory_bytes_per_bank(size_t page_alignment, size_t num_banks) const;
 
     static constexpr auto attribute_names = std::forward_as_tuple("logical_shape", "tensor_layout");
     auto attribute_values() const { return std::forward_as_tuple(logical_shape_, tensor_layout_); }

--- a/tt_metal/api/tt-metalium/experimental/tensor/spec/tensor_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/spec/tensor_spec.hpp
@@ -91,7 +91,6 @@ public:
     size_t compute_packed_buffer_size_bytes() const;
     size_t compute_page_size_bytes() const;
 
-    size_t compute_consumed_memory_bytes_per_bank(const IDevice& device) const;
     size_t compute_consumed_memory_bytes_per_bank(size_t page_alignment, size_t num_banks) const;
 
     static constexpr auto attribute_names = std::forward_as_tuple("logical_shape", "tensor_layout");

--- a/tt_metal/impl/per_core_allocation/memory_config.cpp
+++ b/tt_metal/impl/per_core_allocation/memory_config.cpp
@@ -2,20 +2,22 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp>
+#include <tt-metalium/experimental/per_core_allocation/memory_config.hpp>
 #include <tt_stl/assert.hpp>
+
+#include "impl/tensor/spec/memory_config/memory_config_impl.hpp"
 
 namespace tt::tt_metal::experimental::per_core_allocation {
 
-bool is_per_core_allocation(const MemoryConfig& config) { return config.per_core_allocation_; }
+bool is_per_core_allocation(const MemoryConfig& config) { return config.impl().per_core_allocation_; }
 
 void set_per_core_allocation(MemoryConfig& config, bool enable) {
     if (enable) {
-        TT_FATAL(config.buffer_type_ == BufferType::L1, "per_core_allocation is only supported for L1 buffers");
+        TT_FATAL(config.buffer_type() == BufferType::L1, "per_core_allocation is only supported for L1 buffers");
         TT_FATAL(config.is_sharded(), "per_core_allocation requires a sharded memory layout");
-        TT_FATAL(!config.created_with_nd_shard_spec_, "per_core_allocation is not supported with NdShardSpec");
+        TT_FATAL(!config.created_with_nd_shard_spec(), "per_core_allocation is not supported with NdShardSpec");
     }
-    config.per_core_allocation_ = enable;
+    config.impl().per_core_allocation_ = enable;
 }
 
 }  // namespace tt::tt_metal::experimental::per_core_allocation

--- a/tt_metal/impl/tensor/host_tensor.cpp
+++ b/tt_metal/impl/tensor/host_tensor.cpp
@@ -5,6 +5,7 @@
 #include <tt-metalium/experimental/tensor/host_tensor.hpp>
 
 #include "host_tensor_impl.hpp"
+#include "spec/layout/tensor_layout_impl.hpp"
 
 namespace tt::tt_metal {
 
@@ -98,7 +99,7 @@ std::size_t HostTensor::element_size() const {
     }
 }
 
-Strides HostTensor::strides() const { return tensor_spec().tensor_layout().compute_strides(logical_shape()); }
+Strides HostTensor::strides() const { return tensor_spec().tensor_layout().impl().compute_strides(logical_shape()); }
 
 HostTensor HostTensor::transform(const std::function<HostBuffer(const HostBuffer&)>& callable) const {
     auto transformed_buffer =

--- a/tt_metal/impl/tensor/mesh_tensor.cpp
+++ b/tt_metal/impl/tensor/mesh_tensor.cpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/mesh_device.hpp>
 
 #include "mesh_tensor_impl.hpp"
+#include "spec/layout/tensor_layout_impl.hpp"
 
 namespace tt::tt_metal {
 
@@ -78,7 +79,7 @@ std::size_t MeshTensor::element_size() const {
     }
 }
 
-Strides MeshTensor::strides() const { return tensor_spec().tensor_layout().compute_strides(logical_shape()); }
+Strides MeshTensor::strides() const { return tensor_spec().tensor_layout().impl().compute_strides(logical_shape()); }
 
 void MeshTensor::update_tensor_topology(TensorTopology tensor_topology) {
     impl().update_topology(std::move(tensor_topology));

--- a/tt_metal/impl/tensor/spec/layout/page_config.cpp
+++ b/tt_metal/impl/tensor/spec/layout/page_config.cpp
@@ -7,138 +7,43 @@
 #include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
 
 #include <tt-metalium/shape2d.hpp>
-#include <memory>
 #include <numeric>
+#include <type_traits>
+#include <utility>
+#include <variant>
 
 #include "impl/tensor/spec/layout/page_config_impl.hpp"
 
 namespace tt::tt_metal {
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
 
-PageConfig::PageConfig(const Config& config) : impl_(std::make_unique<PageConfigImpl>(config)) {}
+size_t rm_element_size_bytes(DataType dtype) {
+    switch (dtype) {
+        case DataType::BFLOAT16: return sizeof(bfloat16);
+        case DataType::FLOAT32: return sizeof(float);
+        case DataType::INT32: return sizeof(int32_t);
+        case DataType::UINT32: return sizeof(uint32_t);
+        case DataType::UINT16: return sizeof(uint16_t);
+        case DataType::FP8_E4M3: return sizeof(float8_e4m3);
+        case DataType::UINT8: return sizeof(uint8_t);
+        case DataType::BFLOAT8_B:
+        case DataType::BFLOAT4_B:
+            // To store block floats in RowMajor layout, we use a fallback and store full floats instead
+            return sizeof(float);
 
-PageConfig::PageConfig(Layout layout) : PageConfig(layout, std::nullopt) {}
-
-PageConfig::PageConfig(Layout layout, const std::optional<Tile>& tile) :
-    impl_(std::make_unique<PageConfigImpl>(layout, tile)) {}
-
-PageConfig::~PageConfig() = default;
-
-PageConfig::PageConfig(const PageConfig& other) :
-    impl_(other.impl_ ? std::make_unique<PageConfigImpl>(*other.impl_) : nullptr) {}
-
-PageConfig& PageConfig::operator=(const PageConfig& other) {
-    if (this == &other) {
-        return *this;
+        default: TT_THROW("Unsupported data type!");
     }
-    impl_ = other.impl_ ? std::make_unique<PageConfigImpl>(*other.impl_) : nullptr;
-    return *this;
 }
 
-PageConfig::PageConfig(PageConfig&& other) noexcept = default;
-PageConfig& PageConfig::operator=(PageConfig&& other) noexcept = default;
+// Maximum possible device memory alignment for all devices and buffer types.
+constexpr uint32_t RECOMMENDED_MEMORY_ALIGNMENT_BYTES = 64;
 
-PageConfigImpl& PageConfig::impl() {
-    TT_FATAL(impl_ != nullptr, "PageConfig is in a moved-from state.");
-    return *impl_;
+Alignment create_default_alignment_tile(const TilePageConfig& config, DataType, const MemoryConfig&) {
+    return Alignment({config.tile.get_height(), config.tile.get_width()});
 }
 
-const PageConfigImpl& PageConfig::impl() const {
-    TT_FATAL(impl_ != nullptr, "PageConfig is in a moved-from state.");
-    return *impl_;
-}
-
-Alignment PageConfig::create_default_alignment(DataType dtype, const MemoryConfig& memory_config) const {
-    return impl().create_default_alignment(dtype, memory_config);
-}
-
-void PageConfig::validate_alignment(
-    const Alignment& alignment, DataType dtype, const MemoryConfig& memory_config) const {
-    impl().validate_alignment(alignment, dtype, memory_config);
-}
-
-Shape2D PageConfig::get_page_shape(
-    const Shape2D& physical_size,
-    DataType dtype,
-    const MemoryConfig& memory_config,
-    const std::optional<Shape2D>& physical_shard_size) const {
-    return impl().get_page_shape(physical_size, dtype, memory_config, physical_shard_size);
-}
-
-size_t PageConfig::get_page_size_bytes(const Shape2D& page_shape, DataType dtype) const {
-    return impl().get_page_size_bytes(page_shape, dtype);
-}
-
-Layout PageConfig::get_layout() const { return impl().get_layout(); }
-
-Tile PageConfig::get_tile() const { return impl().get_tile(); }
-
-Alignment PageConfig::get_required_shard_shape_alignment() const { return impl().get_required_shard_shape_alignment(); }
-
-Alignment PageConfig::get_recommended_shard_shape_alignment(DataType dtype) const {
-    return impl().get_recommended_shard_shape_alignment(dtype);
-}
-
-bool PageConfig::operator==(const PageConfig& other) const { return impl().config() == other.impl().config(); }
-bool PageConfig::operator!=(const PageConfig& other) const { return !(*this == other); }
-
-std::tuple<const PageConfig::Config&> PageConfig::attribute_values() const {
-    return std::forward_as_tuple(impl().config());
-}
-
-TilePageConfig::TilePageConfig(const Tile& tile) : tile_(tile) {}
-
-Alignment TilePageConfig::create_default_alignment(DataType /*dtype*/, const MemoryConfig& /*memory_config*/) const {
-    return Alignment({tile_.get_height(), tile_.get_width()});
-}
-
-void TilePageConfig::validate_alignment(const Alignment& alignment, DataType /*dtype*/, const MemoryConfig&) const {
-    TT_FATAL(alignment.size() >= 2, "Alignment should have at least 2 dimensions for Tile layout");
-    const auto widthAlignment = alignment[-1];
-    TT_FATAL(
-        widthAlignment % tile_.get_width() == 0,
-        "Wrong custom Tensor Layout alignment {}. For Tile layout innermost dimension should be multiple of tile width "
-        "{}.",
-        alignment,
-        tile_.get_width());
-    auto heightAlignment = alignment[-2];
-    TT_FATAL(
-        (heightAlignment % tile_.get_height()) == 0,
-        "Wrong custom Tensor Layout alignment {}. For Tile layout second innermost dimension should be multiple of "
-        "tile height {}.",
-        alignment,
-        tile_.get_height());
-}
-
-Shape2D TilePageConfig::get_page_shape(
-    const Shape2D& /*physical_size*/,
-    DataType /*dtype*/,
-    const MemoryConfig& /*memory_config*/,
-    const std::optional<Shape2D>&) const {
-    return Shape2D(tile_.get_height(), tile_.get_width());
-}
-
-size_t TilePageConfig::get_page_size_bytes(const Shape2D& page_shape, DataType dtype) const {
-    const auto tiles_count = page_shape.height() / tile_.get_height() * page_shape.width() / tile_.get_width();
-    const auto size = tiles_count * tile_.get_tile_size(datatype_to_dataformat_converter(dtype));
-    return size;
-}
-
-const Tile& TilePageConfig::get_tile() const { return tile_; }
-
-Alignment TilePageConfig::get_recommended_shard_shape_alignment(DataType) const {
-    return get_required_shard_shape_alignment();
-}
-
-Alignment TilePageConfig::get_required_shard_shape_alignment() const {
-    return Alignment({tile_.get_height(), tile_.get_width()});
-}
-
-RowMajorPageConfig::RowMajorPageConfig(const Tile& tile) : tile_(tile) {
-    TT_FATAL(
-        tile == Tile{}, "Configuring a ROW MAJOR page config with a custom tile configuration is not supported.");
-}
-
-Alignment RowMajorPageConfig::create_default_alignment(DataType /*dtype*/, const MemoryConfig& memory_config) const {
+Alignment create_default_alignment_rm(const RowMajorPageConfig&, DataType, const MemoryConfig& memory_config) {
     if (memory_config.shard_spec().has_value()) {
         const auto& shard_spec = memory_config.shard_spec().value();
         return Alignment({shard_spec.shape[1]});
@@ -150,8 +55,26 @@ Alignment RowMajorPageConfig::create_default_alignment(DataType /*dtype*/, const
     return Alignment({1});
 }
 
-void RowMajorPageConfig::validate_alignment(
-    const Alignment& alignment, DataType /*dtype*/, const MemoryConfig& memory_config) const {
+void validate_alignment_tile(const TilePageConfig& config, const Alignment& alignment, DataType, const MemoryConfig&) {
+    TT_FATAL(alignment.size() >= 2, "Alignment should have at least 2 dimensions for Tile layout");
+    const auto widthAlignment = alignment[-1];
+    TT_FATAL(
+        widthAlignment % config.tile.get_width() == 0,
+        "Wrong custom Tensor Layout alignment {}. For Tile layout innermost dimension should be multiple of tile width "
+        "{}.",
+        alignment,
+        config.tile.get_width());
+    auto heightAlignment = alignment[-2];
+    TT_FATAL(
+        (heightAlignment % config.tile.get_height()) == 0,
+        "Wrong custom Tensor Layout alignment {}. For Tile layout second innermost dimension should be multiple of "
+        "tile height {}.",
+        alignment,
+        config.tile.get_height());
+}
+
+void validate_alignment_rm(
+    const RowMajorPageConfig&, const Alignment& alignment, DataType, const MemoryConfig& memory_config) {
     TT_FATAL(!alignment.empty(), "Alignment must contain at least one dimension for Row Major layout.");
     const uint32_t width_alignment = alignment[-1];
 
@@ -169,13 +92,19 @@ void RowMajorPageConfig::validate_alignment(
     }
 }
 
-Shape2D RowMajorPageConfig::get_page_shape(
+Shape2D get_page_shape_tile(
+    const TilePageConfig& config, const Shape2D&, DataType, const MemoryConfig&, const std::optional<Shape2D>&) {
+    return Shape2D(config.tile.get_height(), config.tile.get_width());
+}
+
+Shape2D get_page_shape_rm(
+    const RowMajorPageConfig&,
     const Shape2D& physical_size,
     DataType dtype,
     const MemoryConfig& memory_config,
-    const std::optional<Shape2D>& physical_shard_size) const {
+    const std::optional<Shape2D>& physical_shard_size) {
     if (physical_size.height() == 0 || physical_size.width() == 0) {
-        return Shape2D(1, sizeof(uint32_t) / CMAKE_UNIQUE_NAMESPACE::rm_element_size_bytes(dtype));
+        return Shape2D(1, sizeof(uint32_t) / rm_element_size_bytes(dtype));
     }
 
     if (memory_config.shard_spec().has_value() && memory_config.memory_layout() != TensorMemoryLayout::HEIGHT_SHARDED) {
@@ -195,24 +124,152 @@ Shape2D RowMajorPageConfig::get_page_shape(
     return Shape2D(1, physical_size.width());
 }
 
-size_t RowMajorPageConfig::get_page_size_bytes(const Shape2D& page_shape, DataType dtype) const {
-    const auto size = page_shape.height() * page_shape.width() * CMAKE_UNIQUE_NAMESPACE::rm_element_size_bytes(dtype);
-    return size;
+size_t get_page_size_bytes_tile(const TilePageConfig& config, const Shape2D& page_shape, DataType dtype) {
+    const auto tiles_count =
+        page_shape.height() / config.tile.get_height() * page_shape.width() / config.tile.get_width();
+    return tiles_count * config.tile.get_tile_size(datatype_to_dataformat_converter(dtype));
 }
 
-const Tile& RowMajorPageConfig::get_tile() const {
-    TT_FATAL(
-        tile_ == Tile{},
-        "Attempting to extract tile information out of a ROW MAJOR layout is not supported.");
-    return tile_;
+size_t get_page_size_bytes_rm(const RowMajorPageConfig&, const Shape2D& page_shape, DataType dtype) {
+    return page_shape.height() * page_shape.width() * rm_element_size_bytes(dtype);
 }
 
-Alignment RowMajorPageConfig::get_required_shard_shape_alignment() const { return Alignment({1}); }
+Alignment get_required_shard_shape_alignment_tile(const TilePageConfig& config) {
+    return Alignment({config.tile.get_height(), config.tile.get_width()});
+}
 
-Alignment RowMajorPageConfig::get_recommended_shard_shape_alignment(DataType dtype) const {
-    auto element_size_bytes = CMAKE_UNIQUE_NAMESPACE::rm_element_size_bytes(dtype);
-    auto alignment_bytes = std::lcm(CMAKE_UNIQUE_NAMESPACE::RECOMMENDED_MEMORY_ALIGNMENT_BYTES, element_size_bytes);
+Alignment get_required_shard_shape_alignment_rm(const RowMajorPageConfig&) { return Alignment({1}); }
+
+Alignment get_recommended_shard_shape_alignment_tile(const TilePageConfig& config, DataType) {
+    return get_required_shard_shape_alignment_tile(config);
+}
+
+Alignment get_recommended_shard_shape_alignment_rm(const RowMajorPageConfig&, DataType dtype) {
+    auto element_size_bytes = rm_element_size_bytes(dtype);
+    auto alignment_bytes = std::lcm(RECOMMENDED_MEMORY_ALIGNMENT_BYTES, element_size_bytes);
     return Alignment({static_cast<uint32_t>(alignment_bytes / element_size_bytes)});
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+
+PageConfig::PageConfig(Config config) : config_(std::move(config)) {}
+
+PageConfig::PageConfig(Layout layout) : PageConfig(layout, std::nullopt) {}
+
+PageConfig::PageConfig(Layout layout, const std::optional<Tile>& tile) {
+    if (layout == Layout::ROW_MAJOR) {
+        TT_FATAL(
+            !tile.has_value() || *tile == Tile{},
+            "Configuring a ROW MAJOR page config with a custom tile configuration is not supported.");
+        config_ = RowMajorPageConfig{};
+    } else {
+        config_ = TilePageConfig{tile.value_or(Tile())};
+    }
+}
+
+Layout PageConfig::get_layout() const {
+    if (std::holds_alternative<RowMajorPageConfig>(config_)) {
+        return Layout::ROW_MAJOR;
+    }
+    return Layout::TILE;
+}
+
+Tile PageConfig::get_tile() const {
+    if (const auto* tile_config = std::get_if<TilePageConfig>(&config_)) {
+        return tile_config->tile;
+    }
+    return Tile{};
+}
+
+Alignment PageConfig::get_recommended_shard_shape_alignment(DataType dtype) const {
+    return tt::tt_metal::get_recommended_shard_shape_alignment(*this, dtype);
+}
+
+Alignment create_default_alignment(const PageConfig& page_config, DataType dtype, const MemoryConfig& memory_config) {
+    return std::visit(
+        [&](const auto& config) -> Alignment {
+            using T = std::decay_t<decltype(config)>;
+            if constexpr (std::is_same_v<T, TilePageConfig>) {
+                return CMAKE_UNIQUE_NAMESPACE::create_default_alignment_tile(config, dtype, memory_config);
+            } else {
+                return CMAKE_UNIQUE_NAMESPACE::create_default_alignment_rm(config, dtype, memory_config);
+            }
+        },
+        page_config.get_config());
+}
+
+void validate_alignment(
+    const PageConfig& page_config, const Alignment& alignment, DataType dtype, const MemoryConfig& memory_config) {
+    std::visit(
+        [&](const auto& config) {
+            using T = std::decay_t<decltype(config)>;
+            if constexpr (std::is_same_v<T, TilePageConfig>) {
+                CMAKE_UNIQUE_NAMESPACE::validate_alignment_tile(config, alignment, dtype, memory_config);
+            } else {
+                CMAKE_UNIQUE_NAMESPACE::validate_alignment_rm(config, alignment, dtype, memory_config);
+            }
+        },
+        page_config.get_config());
+}
+
+Shape2D get_page_shape(
+    const PageConfig& page_config,
+    const Shape2D& physical_size,
+    DataType dtype,
+    const MemoryConfig& memory_config,
+    const std::optional<Shape2D>& physical_shard_size) {
+    return std::visit(
+        [&](const auto& config) -> Shape2D {
+            using T = std::decay_t<decltype(config)>;
+            if constexpr (std::is_same_v<T, TilePageConfig>) {
+                return CMAKE_UNIQUE_NAMESPACE::get_page_shape_tile(
+                    config, physical_size, dtype, memory_config, physical_shard_size);
+            } else {
+                return CMAKE_UNIQUE_NAMESPACE::get_page_shape_rm(
+                    config, physical_size, dtype, memory_config, physical_shard_size);
+            }
+        },
+        page_config.get_config());
+}
+
+size_t get_page_size_bytes(const PageConfig& page_config, const Shape2D& page_shape, DataType dtype) {
+    return std::visit(
+        [&](const auto& config) -> size_t {
+            using T = std::decay_t<decltype(config)>;
+            if constexpr (std::is_same_v<T, TilePageConfig>) {
+                return CMAKE_UNIQUE_NAMESPACE::get_page_size_bytes_tile(config, page_shape, dtype);
+            } else {
+                return CMAKE_UNIQUE_NAMESPACE::get_page_size_bytes_rm(config, page_shape, dtype);
+            }
+        },
+        page_config.get_config());
+}
+
+Alignment get_required_shard_shape_alignment(const PageConfig& page_config) {
+    return std::visit(
+        [&](const auto& config) -> Alignment {
+            using T = std::decay_t<decltype(config)>;
+            if constexpr (std::is_same_v<T, TilePageConfig>) {
+                return CMAKE_UNIQUE_NAMESPACE::get_required_shard_shape_alignment_tile(config);
+            } else {
+                return CMAKE_UNIQUE_NAMESPACE::get_required_shard_shape_alignment_rm(config);
+            }
+        },
+        page_config.get_config());
+}
+
+Alignment get_recommended_shard_shape_alignment(const PageConfig& page_config, DataType dtype) {
+    return std::visit(
+        [&](const auto& config) -> Alignment {
+            using T = std::decay_t<decltype(config)>;
+            if constexpr (std::is_same_v<T, TilePageConfig>) {
+                return CMAKE_UNIQUE_NAMESPACE::get_recommended_shard_shape_alignment_tile(config, dtype);
+            } else {
+                return CMAKE_UNIQUE_NAMESPACE::get_recommended_shard_shape_alignment_rm(config, dtype);
+            }
+        },
+        page_config.get_config());
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/tensor/spec/layout/page_config.cpp
+++ b/tt_metal/impl/tensor/spec/layout/page_config.cpp
@@ -7,58 +7,53 @@
 #include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
 
 #include <tt-metalium/shape2d.hpp>
+#include <memory>
 #include <numeric>
+
+#include "impl/tensor/spec/layout/page_config_impl.hpp"
 
 namespace tt::tt_metal {
 
-namespace {
-namespace CMAKE_UNIQUE_NAMESPACE {
-size_t rm_element_size_bytes(DataType dtype) {
-    switch (dtype) {
-        case DataType::BFLOAT16: return sizeof(bfloat16);
-        case DataType::FLOAT32: return sizeof(float);
-        case DataType::INT32: return sizeof(int32_t);
-        case DataType::UINT32: return sizeof(uint32_t);
-        case DataType::UINT16: return sizeof(uint16_t);
-        case DataType::FP8_E4M3: return sizeof(float8_e4m3);
-        case DataType::UINT8: return sizeof(uint8_t);
-        case DataType::BFLOAT8_B:
-        case DataType::BFLOAT4_B:
-            // To store block floats in RowMajor layout, we use a fallback and store full floats instead
-            return sizeof(float);
-
-        default: TT_THROW("Unsupported data type!");
-    }
-}
-
-// Maximum possible device memory alignment for all devices and buffer types.
-constexpr uint32_t RECOMMENDED_MEMORY_ALIGNMENT_BYTES = 64;
-
-}  // namespace CMAKE_UNIQUE_NAMESPACE
-}  // namespace
-
-PageConfig::PageConfig(const Config& config) : config_(config) {}
+PageConfig::PageConfig(const Config& config) : impl_(std::make_unique<PageConfigImpl>(config)) {}
 
 PageConfig::PageConfig(Layout layout) : PageConfig(layout, std::nullopt) {}
 
-PageConfig::PageConfig(Layout layout, const std::optional<Tile>& tile) {
-    if (layout == Layout::ROW_MAJOR) {
-        // TODO: add TT_FATAL(!tile.has_value(), "Specifying tile shape for a row major layout is not supported")
-        config_ = RowMajorPageConfig(tile.value_or(Tile()));
-    } else {
-        config_ = TilePageConfig(tile.value_or(Tile()));
+PageConfig::PageConfig(Layout layout, const std::optional<Tile>& tile) :
+    impl_(std::make_unique<PageConfigImpl>(layout, tile)) {}
+
+PageConfig::~PageConfig() = default;
+
+PageConfig::PageConfig(const PageConfig& other) :
+    impl_(other.impl_ ? std::make_unique<PageConfigImpl>(*other.impl_) : nullptr) {}
+
+PageConfig& PageConfig::operator=(const PageConfig& other) {
+    if (this == &other) {
+        return *this;
     }
+    impl_ = other.impl_ ? std::make_unique<PageConfigImpl>(*other.impl_) : nullptr;
+    return *this;
+}
+
+PageConfig::PageConfig(PageConfig&& other) noexcept = default;
+PageConfig& PageConfig::operator=(PageConfig&& other) noexcept = default;
+
+PageConfigImpl& PageConfig::impl() {
+    TT_FATAL(impl_ != nullptr, "PageConfig is in a moved-from state.");
+    return *impl_;
+}
+
+const PageConfigImpl& PageConfig::impl() const {
+    TT_FATAL(impl_ != nullptr, "PageConfig is in a moved-from state.");
+    return *impl_;
 }
 
 Alignment PageConfig::create_default_alignment(DataType dtype, const MemoryConfig& memory_config) const {
-    return std::visit(
-        [&](const auto& config) constexpr { return config.create_default_alignment(dtype, memory_config); }, config_);
+    return impl().create_default_alignment(dtype, memory_config);
 }
 
 void PageConfig::validate_alignment(
     const Alignment& alignment, DataType dtype, const MemoryConfig& memory_config) const {
-    std::visit(
-        [&](const auto& config) constexpr { config.validate_alignment(alignment, dtype, memory_config); }, config_);
+    impl().validate_alignment(alignment, dtype, memory_config);
 }
 
 Shape2D PageConfig::get_page_shape(
@@ -66,37 +61,28 @@ Shape2D PageConfig::get_page_shape(
     DataType dtype,
     const MemoryConfig& memory_config,
     const std::optional<Shape2D>& physical_shard_size) const {
-    return std::visit(
-        [&](const auto& config) constexpr {
-            return config.get_page_shape(physical_size, dtype, memory_config, physical_shard_size);
-        },
-        config_);
+    return impl().get_page_shape(physical_size, dtype, memory_config, physical_shard_size);
 }
 
 size_t PageConfig::get_page_size_bytes(const Shape2D& page_shape, DataType dtype) const {
-    return std::visit(
-        [&](const auto& config) constexpr { return config.get_page_size_bytes(page_shape, dtype); }, config_);
+    return impl().get_page_size_bytes(page_shape, dtype);
 }
 
-Layout PageConfig::get_layout() const {
-    if (std::holds_alternative<RowMajorPageConfig>(config_)) {
-        return Layout::ROW_MAJOR;
-    }
-    return Layout::TILE;
-}
+Layout PageConfig::get_layout() const { return impl().get_layout(); }
 
-Tile PageConfig::get_tile() const {
-    return std::visit([&](const auto& config) { return config.get_tile(); }, config_);
-}
+Tile PageConfig::get_tile() const { return impl().get_tile(); }
 
-Alignment PageConfig::get_required_shard_shape_alignment() const {
-    return std::visit(
-        [&](const auto& config) constexpr { return config.get_required_shard_shape_alignment(); }, config_);
-}
+Alignment PageConfig::get_required_shard_shape_alignment() const { return impl().get_required_shard_shape_alignment(); }
 
 Alignment PageConfig::get_recommended_shard_shape_alignment(DataType dtype) const {
-    return std::visit(
-        [&](const auto& config) constexpr { return config.get_recommended_shard_shape_alignment(dtype); }, config_);
+    return impl().get_recommended_shard_shape_alignment(dtype);
+}
+
+bool PageConfig::operator==(const PageConfig& other) const { return impl().config() == other.impl().config(); }
+bool PageConfig::operator!=(const PageConfig& other) const { return !(*this == other); }
+
+std::tuple<const PageConfig::Config&> PageConfig::attribute_values() const {
+    return std::forward_as_tuple(impl().config());
 }
 
 TilePageConfig::TilePageConfig(const Tile& tile) : tile_(tile) {}

--- a/tt_metal/impl/tensor/spec/layout/page_config.cpp
+++ b/tt_metal/impl/tensor/spec/layout/page_config.cpp
@@ -153,7 +153,7 @@ Alignment get_recommended_shard_shape_alignment_rm(const RowMajorPageConfig&, Da
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
-PageConfig::PageConfig(Config config) : config_(std::move(config)) {}
+PageConfig::PageConfig(Config config) : config_(config) {}
 
 PageConfig::PageConfig(Layout layout) : PageConfig(layout, std::nullopt) {}
 

--- a/tt_metal/impl/tensor/spec/layout/page_config_impl.hpp
+++ b/tt_metal/impl/tensor/spec/layout/page_config_impl.hpp
@@ -4,12 +4,6 @@
 
 #pragma once
 
-/**
- * Internal page-config layout helpers for tt_metal.
- *
- * Not part of the installed public API. Callers visit via PageConfig::get_config().
- */
-
 #include <optional>
 
 #include <tt-metalium/shape2d.hpp>

--- a/tt_metal/impl/tensor/spec/layout/page_config_impl.hpp
+++ b/tt_metal/impl/tensor/spec/layout/page_config_impl.hpp
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-logger/tt-logger.hpp>
+#include <tt_stl/fmt.hpp>
+#include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
+
+#include <tt-metalium/shape2d.hpp>
+#include <memory>
+#include <numeric>
+
+namespace tt::tt_metal {
+
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+size_t rm_element_size_bytes(DataType dtype) {
+    switch (dtype) {
+        case DataType::BFLOAT16: return sizeof(bfloat16);
+        case DataType::FLOAT32: return sizeof(float);
+        case DataType::INT32: return sizeof(int32_t);
+        case DataType::UINT32: return sizeof(uint32_t);
+        case DataType::UINT16: return sizeof(uint16_t);
+        case DataType::FP8_E4M3: return sizeof(float8_e4m3);
+        case DataType::UINT8: return sizeof(uint8_t);
+        case DataType::BFLOAT8_B:
+        case DataType::BFLOAT4_B:
+            // To store block floats in RowMajor layout, we use a fallback and store full floats instead
+            return sizeof(float);
+
+        default: TT_THROW("Unsupported data type!");
+    }
+}
+
+// Maximum possible device memory alignment for all devices and buffer types.
+constexpr uint32_t RECOMMENDED_MEMORY_ALIGNMENT_BYTES = 64;
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+
+// ------------------------------------------------------------------------------------------------
+// PageConfigImpl: the internal page-config API, reachable from within tt_metal via impl().
+// ------------------------------------------------------------------------------------------------
+
+class PageConfigImpl {
+public:
+    explicit PageConfigImpl(const PageConfig::Config& config) : config_(config) {}
+
+    PageConfigImpl(Layout layout, const std::optional<Tile>& tile) {
+        if (layout == Layout::ROW_MAJOR) {
+            // TODO: add TT_FATAL(!tile.has_value(), "Specifying tile shape for a row major layout is not supported")
+            config_ = RowMajorPageConfig(tile.value_or(Tile()));
+        } else {
+            config_ = TilePageConfig(tile.value_or(Tile()));
+        }
+    }
+
+    bool operator==(const PageConfigImpl&) const = default;
+    bool operator!=(const PageConfigImpl&) const = default;
+
+    Alignment create_default_alignment(DataType dtype, const MemoryConfig& memory_config) const {
+        return std::visit(
+            [&](const auto& config) constexpr { return config.create_default_alignment(dtype, memory_config); },
+            config_);
+    }
+
+    void validate_alignment(const Alignment& alignment, DataType dtype, const MemoryConfig& memory_config) const {
+        std::visit(
+            [&](const auto& config) constexpr { config.validate_alignment(alignment, dtype, memory_config); }, config_);
+    }
+
+    Shape2D get_page_shape(
+        const Shape2D& physical_size,
+        DataType dtype,
+        const MemoryConfig& memory_config,
+        const std::optional<Shape2D>& physical_shard_size) const {
+        return std::visit(
+            [&](const auto& config) constexpr {
+                return config.get_page_shape(physical_size, dtype, memory_config, physical_shard_size);
+            },
+            config_);
+    }
+
+    size_t get_page_size_bytes(const Shape2D& page_shape, DataType dtype) const {
+        return std::visit(
+            [&](const auto& config) constexpr { return config.get_page_size_bytes(page_shape, dtype); }, config_);
+    }
+
+    Layout get_layout() const {
+        if (std::holds_alternative<RowMajorPageConfig>(config_)) {
+            return Layout::ROW_MAJOR;
+        }
+        return Layout::TILE;
+    }
+
+    Tile get_tile() const {
+        return std::visit([&](const auto& config) { return config.get_tile(); }, config_);
+    }
+
+    Alignment get_required_shard_shape_alignment() const {
+        return std::visit(
+            [&](const auto& config) constexpr { return config.get_required_shard_shape_alignment(); }, config_);
+    }
+
+    Alignment get_recommended_shard_shape_alignment(DataType dtype) const {
+        return std::visit(
+            [&](const auto& config) constexpr { return config.get_recommended_shard_shape_alignment(dtype); }, config_);
+    }
+
+    const PageConfig::Config& config() const { return config_; }
+
+private:
+    PageConfig::Config config_;
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/tensor/spec/layout/page_config_impl.hpp
+++ b/tt_metal/impl/tensor/spec/layout/page_config_impl.hpp
@@ -2,115 +2,35 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-logger/tt-logger.hpp>
-#include <tt_stl/fmt.hpp>
-#include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
+#pragma once
+
+/**
+ * Internal page-config layout helpers for tt_metal.
+ *
+ * Not part of the installed public API. Callers visit via PageConfig::get_config().
+ */
+
+#include <optional>
 
 #include <tt-metalium/shape2d.hpp>
-#include <memory>
-#include <numeric>
+#include <tt-metalium/experimental/tensor/spec/layout/alignment.hpp>
+#include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
+#include <tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp>
+#include <tt-metalium/experimental/tensor/tensor_types.hpp>
 
 namespace tt::tt_metal {
 
-namespace {
-namespace CMAKE_UNIQUE_NAMESPACE {
-size_t rm_element_size_bytes(DataType dtype) {
-    switch (dtype) {
-        case DataType::BFLOAT16: return sizeof(bfloat16);
-        case DataType::FLOAT32: return sizeof(float);
-        case DataType::INT32: return sizeof(int32_t);
-        case DataType::UINT32: return sizeof(uint32_t);
-        case DataType::UINT16: return sizeof(uint16_t);
-        case DataType::FP8_E4M3: return sizeof(float8_e4m3);
-        case DataType::UINT8: return sizeof(uint8_t);
-        case DataType::BFLOAT8_B:
-        case DataType::BFLOAT4_B:
-            // To store block floats in RowMajor layout, we use a fallback and store full floats instead
-            return sizeof(float);
-
-        default: TT_THROW("Unsupported data type!");
-    }
-}
-
-// Maximum possible device memory alignment for all devices and buffer types.
-constexpr uint32_t RECOMMENDED_MEMORY_ALIGNMENT_BYTES = 64;
-
-}  // namespace CMAKE_UNIQUE_NAMESPACE
-}  // namespace
-
-// ------------------------------------------------------------------------------------------------
-// PageConfigImpl: the internal page-config API, reachable from within tt_metal via impl().
-// ------------------------------------------------------------------------------------------------
-
-class PageConfigImpl {
-public:
-    explicit PageConfigImpl(const PageConfig::Config& config) : config_(config) {}
-
-    PageConfigImpl(Layout layout, const std::optional<Tile>& tile) {
-        if (layout == Layout::ROW_MAJOR) {
-            // TODO: add TT_FATAL(!tile.has_value(), "Specifying tile shape for a row major layout is not supported")
-            config_ = RowMajorPageConfig(tile.value_or(Tile()));
-        } else {
-            config_ = TilePageConfig(tile.value_or(Tile()));
-        }
-    }
-
-    bool operator==(const PageConfigImpl&) const = default;
-    bool operator!=(const PageConfigImpl&) const = default;
-
-    Alignment create_default_alignment(DataType dtype, const MemoryConfig& memory_config) const {
-        return std::visit(
-            [&](const auto& config) constexpr { return config.create_default_alignment(dtype, memory_config); },
-            config_);
-    }
-
-    void validate_alignment(const Alignment& alignment, DataType dtype, const MemoryConfig& memory_config) const {
-        std::visit(
-            [&](const auto& config) constexpr { config.validate_alignment(alignment, dtype, memory_config); }, config_);
-    }
-
-    Shape2D get_page_shape(
-        const Shape2D& physical_size,
-        DataType dtype,
-        const MemoryConfig& memory_config,
-        const std::optional<Shape2D>& physical_shard_size) const {
-        return std::visit(
-            [&](const auto& config) constexpr {
-                return config.get_page_shape(physical_size, dtype, memory_config, physical_shard_size);
-            },
-            config_);
-    }
-
-    size_t get_page_size_bytes(const Shape2D& page_shape, DataType dtype) const {
-        return std::visit(
-            [&](const auto& config) constexpr { return config.get_page_size_bytes(page_shape, dtype); }, config_);
-    }
-
-    Layout get_layout() const {
-        if (std::holds_alternative<RowMajorPageConfig>(config_)) {
-            return Layout::ROW_MAJOR;
-        }
-        return Layout::TILE;
-    }
-
-    Tile get_tile() const {
-        return std::visit([&](const auto& config) { return config.get_tile(); }, config_);
-    }
-
-    Alignment get_required_shard_shape_alignment() const {
-        return std::visit(
-            [&](const auto& config) constexpr { return config.get_required_shard_shape_alignment(); }, config_);
-    }
-
-    Alignment get_recommended_shard_shape_alignment(DataType dtype) const {
-        return std::visit(
-            [&](const auto& config) constexpr { return config.get_recommended_shard_shape_alignment(dtype); }, config_);
-    }
-
-    const PageConfig::Config& config() const { return config_; }
-
-private:
-    PageConfig::Config config_;
-};
+Alignment create_default_alignment(const PageConfig& page_config, DataType dtype, const MemoryConfig& memory_config);
+void validate_alignment(
+    const PageConfig& page_config, const Alignment& alignment, DataType dtype, const MemoryConfig& memory_config);
+Shape2D get_page_shape(
+    const PageConfig& page_config,
+    const Shape2D& physical_size,
+    DataType dtype,
+    const MemoryConfig& memory_config,
+    const std::optional<Shape2D>& physical_shard_size);
+size_t get_page_size_bytes(const PageConfig& page_config, const Shape2D& page_shape, DataType dtype);
+Alignment get_required_shard_shape_alignment(const PageConfig& page_config);
+Alignment get_recommended_shard_shape_alignment(const PageConfig& page_config, DataType dtype);
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
+++ b/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/experimental/per_core_allocation/buffer.hpp>
 #include <tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp>
 
+#include "page_config_impl.hpp"
 #include "tensor_layout_impl.hpp"
 
 namespace tt::tt_metal {
@@ -121,7 +122,7 @@ void validate_alignment(const TensorLayoutImpl& tensor_layout) {
 
     const auto& page_config = tensor_layout.get_page_config();
     const auto& dtype = tensor_layout.get_data_type();
-    page_config.validate_alignment(alignment, dtype, memory_config);
+    validate_alignment(page_config, alignment, dtype, memory_config);
 }
 
 std::optional<std::string> get_shard_align_error(
@@ -170,7 +171,7 @@ TensorLayoutImpl::TensorLayoutImpl(
 }
 
 void TensorLayoutImpl::initialize_alignment() {
-    auto default_alignment = page_config_.create_default_alignment(dtype_, memory_config_);
+    auto default_alignment = create_default_alignment(page_config_, dtype_, memory_config_);
     if (alignment_.empty()) {
         alignment_ = default_alignment;
         return;
@@ -281,7 +282,7 @@ size_t TensorLayoutImpl::compute_page_size_bytes(const tt::tt_metal::Shape& shap
 }
 
 size_t TensorLayoutImpl::compute_page_size_bytes(const Shape2D& page_size) const {
-    return page_config_.get_page_size_bytes(page_size, dtype_);
+    return get_page_size_bytes(page_config_, page_size, dtype_);
 }
 
 size_t TensorLayoutImpl::compute_consumed_memory_bytes_per_bank(
@@ -383,7 +384,7 @@ Shape2D TensorLayoutImpl::compute_page_shape(const Shape2D& physical_size) const
         physical_shard_shape = get_physical_shard_shape();
     }
 
-    return page_config_.get_page_shape(physical_size, dtype_, memory_config_, physical_shard_shape);
+    return get_page_shape(page_config_, physical_size, dtype_, memory_config_, physical_shard_shape);
 }
 
 Strides TensorLayoutImpl::compute_strides(const tt::tt_metal::Shape& logical_shape) const {

--- a/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
+++ b/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
@@ -5,8 +5,6 @@
 #include <tt_stl/fmt.hpp>
 #include <tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp>
 
-#include <tt-metalium/allocator.hpp>
-#include <tt-metalium/device.hpp>
 #include <tt-metalium/math.hpp>
 #include <tt-metalium/experimental/per_core_allocation/buffer.hpp>
 #include <tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp>
@@ -307,18 +305,6 @@ size_t TensorLayoutImpl::compute_consumed_memory_bytes_per_bank(
 
     const size_t aligned_page_size = round_up(compute_page_size_bytes(page_shape), page_alignment);
     return num_pages_per_bank * aligned_page_size;
-}
-
-size_t TensorLayoutImpl::compute_consumed_memory_bytes_per_bank(
-    const tt::tt_metal::Shape& shape, const IDevice& device) const {
-    const size_t page_alignment = device.allocator()->get_alignment(memory_config_.buffer_type());
-    size_t num_banks = 0;
-    if (memory_config_.is_l1()) {
-        num_banks = device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y;
-    } else {
-        num_banks = device.num_dram_channels();
-    }
-    return compute_consumed_memory_bytes_per_bank(shape, page_alignment, num_banks);
 }
 
 Shape2D TensorLayoutImpl::get_logical_shard_shape() const {

--- a/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
+++ b/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
@@ -7,6 +7,7 @@
 
 #include <tt-metalium/math.hpp>
 #include <tt-metalium/experimental/per_core_allocation/buffer.hpp>
+#include <tt-metalium/experimental/per_core_allocation/memory_config.hpp>
 #include <tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp>
 
 #include "page_config_impl.hpp"

--- a/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
+++ b/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
@@ -11,6 +11,8 @@
 #include <tt-metalium/experimental/per_core_allocation/buffer.hpp>
 #include <tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp>
 
+#include "tensor_layout_impl.hpp"
+
 namespace tt::tt_metal {
 
 namespace {
@@ -110,7 +112,7 @@ Alignment legacyShapeToAlignment(
     return result;
 }
 
-void validate_alignment(const TensorLayout& tensor_layout) {
+void validate_alignment(const TensorLayoutImpl& tensor_layout) {
     const auto& alignment = tensor_layout.get_alignment();
     const auto& memory_config = tensor_layout.get_memory_config();
     TT_FATAL(
@@ -150,7 +152,11 @@ bool can_shard_align(const MemoryConfig& memory_config, const Layout& layout, co
     return !CMAKE_UNIQUE_NAMESPACE::get_shard_align_error(memory_config, layout, tile).has_value();
 }
 
-TensorLayout::TensorLayout(
+// ------------------------------------------------------------------------------------------------
+// TensorLayoutImpl: the internal layout-computation API, reachable from within tt_metal via impl().
+// ------------------------------------------------------------------------------------------------
+
+TensorLayoutImpl::TensorLayoutImpl(
     DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config, const Alignment& alignment) :
     dtype_(dtype), page_config_(page_config), memory_config_(memory_config), alignment_(alignment) {
     initialize_alignment();
@@ -163,25 +169,7 @@ TensorLayout::TensorLayout(
     }
 }
 
-TensorLayout TensorLayout::fromPaddedShape(
-    DataType dtype,
-    const PageConfig& page_config,
-    const MemoryConfig& memory_config,
-    const tt::tt_metal::Shape& logical_shape,
-    const tt::tt_metal::Shape& padded_shape) {
-    return TensorLayout(
-        dtype,
-        page_config,
-        memory_config,
-        CMAKE_UNIQUE_NAMESPACE::legacyShapeToAlignment(logical_shape, padded_shape, page_config, memory_config));
-}
-
-TensorLayout TensorLayout::restore_from_serialized(
-    DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config, const Alignment& alignment) {
-    return TensorLayout(dtype, page_config, memory_config, alignment);
-}
-
-void TensorLayout::initialize_alignment() {
+void TensorLayoutImpl::initialize_alignment() {
     auto default_alignment = page_config_.create_default_alignment(dtype_, memory_config_);
     if (alignment_.empty()) {
         alignment_ = default_alignment;
@@ -199,7 +187,7 @@ void TensorLayout::initialize_alignment() {
     alignment_ = Alignment(std::move(result));
 }
 
-BufferShardingArgs TensorLayout::compute_buffer_sharding_args(const tt::tt_metal::Shape& shape) const {
+BufferShardingArgs TensorLayoutImpl::compute_buffer_sharding_args(const tt::tt_metal::Shape& shape) const {
     if (!memory_config_.is_sharded()) {
         return {};
     }
@@ -266,7 +254,7 @@ BufferShardingArgs TensorLayout::compute_buffer_sharding_args(const tt::tt_metal
     return sharding_args;
 }
 
-size_t TensorLayout::compute_packed_buffer_size_bytes(const tt::tt_metal::Shape& shape) const {
+size_t TensorLayoutImpl::compute_packed_buffer_size_bytes(const tt::tt_metal::Shape& shape) const {
     const Shape2D physical_size = compute_physical_shape(shape);
     const Shape2D page_shape = compute_page_shape(physical_size);
     const auto width_remainder = physical_size.width() % page_shape.width();
@@ -286,17 +274,17 @@ size_t TensorLayout::compute_packed_buffer_size_bytes(const tt::tt_metal::Shape&
     return page_count * page_size_bytes;
 }
 
-size_t TensorLayout::compute_page_size_bytes(const tt::tt_metal::Shape& shape) const {
+size_t TensorLayoutImpl::compute_page_size_bytes(const tt::tt_metal::Shape& shape) const {
     const auto physical_size = compute_physical_shape(shape);
     const auto page_shape = compute_page_shape(physical_size);
     return compute_page_size_bytes(page_shape);
 }
 
-size_t TensorLayout::compute_page_size_bytes(const Shape2D& page_size) const {
+size_t TensorLayoutImpl::compute_page_size_bytes(const Shape2D& page_size) const {
     return page_config_.get_page_size_bytes(page_size, dtype_);
 }
 
-size_t TensorLayout::compute_consumed_memory_bytes_per_bank(
+size_t TensorLayoutImpl::compute_consumed_memory_bytes_per_bank(
     const tt::tt_metal::Shape& shape, size_t page_alignment, size_t num_banks) const {
     const Shape2D physical_shape = compute_physical_shape(shape);
     const Shape2D page_shape = compute_page_shape(physical_shape);
@@ -320,7 +308,7 @@ size_t TensorLayout::compute_consumed_memory_bytes_per_bank(
     return num_pages_per_bank * aligned_page_size;
 }
 
-size_t TensorLayout::compute_consumed_memory_bytes_per_bank(
+size_t TensorLayoutImpl::compute_consumed_memory_bytes_per_bank(
     const tt::tt_metal::Shape& shape, const IDevice& device) const {
     const size_t page_alignment = device.allocator()->get_alignment(memory_config_.buffer_type());
     size_t num_banks = 0;
@@ -332,7 +320,7 @@ size_t TensorLayout::compute_consumed_memory_bytes_per_bank(
     return compute_consumed_memory_bytes_per_bank(shape, page_alignment, num_banks);
 }
 
-Shape2D TensorLayout::get_logical_shard_shape() const {
+Shape2D TensorLayoutImpl::get_logical_shard_shape() const {
     TT_FATAL(
         memory_config_.shard_spec().has_value(),
         "Shard spec must have value for TensorLayout::get_logical_shard_shape!");
@@ -342,7 +330,7 @@ Shape2D TensorLayout::get_logical_shard_shape() const {
     return Shape2D(memory_config_.shard_spec().value().shape);
 }
 
-Shape2D TensorLayout::get_physical_shard_shape() const {
+Shape2D TensorLayoutImpl::get_physical_shard_shape() const {
     TT_FATAL(
         memory_config_.shard_spec().has_value(),
         "Shard spec must have value for TensorLayout::get_physical_shard_shape!");
@@ -350,7 +338,7 @@ Shape2D TensorLayout::get_physical_shard_shape() const {
     return shard_spec.shape;
 }
 
-Shape2D TensorLayout::compute_logical_2d_shape(const tt::tt_metal::Shape& shape) const {
+Shape2D TensorLayoutImpl::compute_logical_2d_shape(const tt::tt_metal::Shape& shape) const {
     if (shape.rank() < 2) {
         return Shape2D{1, shape[-1]};
     }
@@ -362,7 +350,7 @@ Shape2D TensorLayout::compute_logical_2d_shape(const tt::tt_metal::Shape& shape)
     return Shape2D{height, width};
 }
 
-Shape2D TensorLayout::compute_physical_shape(const tt::tt_metal::Shape& shape) const {
+Shape2D TensorLayoutImpl::compute_physical_shape(const tt::tt_metal::Shape& shape) const {
     const int rank = static_cast<int>(shape.rank());
     const int alignment_rank = static_cast<int>(alignment_.size());
 
@@ -389,7 +377,7 @@ Shape2D TensorLayout::compute_physical_shape(const tt::tt_metal::Shape& shape) c
     return size;
 }
 
-Shape2D TensorLayout::compute_page_shape(const Shape2D& physical_size) const {
+Shape2D TensorLayoutImpl::compute_page_shape(const Shape2D& physical_size) const {
     std::optional<Shape2D> physical_shard_shape = std::nullopt;
     if (memory_config_.shard_spec().has_value()) {
         physical_shard_shape = get_physical_shard_shape();
@@ -398,7 +386,7 @@ Shape2D TensorLayout::compute_page_shape(const Shape2D& physical_size) const {
     return page_config_.get_page_shape(physical_size, dtype_, memory_config_, physical_shard_shape);
 }
 
-Strides TensorLayout::compute_strides(const tt::tt_metal::Shape& logical_shape) const {
+Strides TensorLayoutImpl::compute_strides(const tt::tt_metal::Shape& logical_shape) const {
     const int rank = static_cast<int>(logical_shape.rank());
     const int alignment_rank = static_cast<int>(alignment_.size());
     Strides strides(rank, 1);
@@ -412,7 +400,7 @@ Strides TensorLayout::compute_strides(const tt::tt_metal::Shape& logical_shape) 
     return strides;
 }
 
-tt::tt_metal::Shape TensorLayout::compute_padded_shape(const tt::tt_metal::Shape& shape) const {
+tt::tt_metal::Shape TensorLayoutImpl::compute_padded_shape(const tt::tt_metal::Shape& shape) const {
     ttsl::SmallVector<uint32_t> padded_shape(std::max(shape.rank(), alignment_.size()));
     int rank_index = static_cast<int>(shape.rank()) - 1;
     int alignment_index = static_cast<int>(alignment_.size()) - 1;
@@ -447,6 +435,83 @@ tt::tt_metal::Shape TensorLayout::compute_padded_shape(const tt::tt_metal::Shape
         padded_shape[padded_shape_index] = shape[rank_index];
     }
     return tt::tt_metal::Shape(std::move(padded_shape));
+}
+
+// ------------------------------------------------------------------------------------------------
+// TensorLayout: public facade forwarding to TensorLayoutImpl.
+// ------------------------------------------------------------------------------------------------
+
+TensorLayout::TensorLayout(
+    DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config, const Alignment& alignment) :
+    impl_(std::make_unique<TensorLayoutImpl>(dtype, page_config, memory_config, alignment)) {}
+
+TensorLayout::~TensorLayout() = default;
+
+TensorLayout::TensorLayout(const TensorLayout& other) :
+    impl_(other.impl_ ? std::make_unique<TensorLayoutImpl>(*other.impl_) : nullptr) {}
+
+TensorLayout& TensorLayout::operator=(const TensorLayout& other) {
+    if (this == &other) {
+        return *this;
+    }
+    impl_ = other.impl_ ? std::make_unique<TensorLayoutImpl>(*other.impl_) : nullptr;
+    return *this;
+}
+
+TensorLayout::TensorLayout(TensorLayout&& other) noexcept = default;
+TensorLayout& TensorLayout::operator=(TensorLayout&& other) noexcept = default;
+
+TensorLayoutImpl& TensorLayout::impl() {
+    TT_FATAL(impl_ != nullptr, "TensorLayout is in a moved-from state.");
+    return *impl_;
+}
+
+const TensorLayoutImpl& TensorLayout::impl() const {
+    TT_FATAL(impl_ != nullptr, "TensorLayout is in a moved-from state.");
+    return *impl_;
+}
+
+TensorLayout TensorLayout::fromPaddedShape(
+    DataType dtype,
+    const PageConfig& page_config,
+    const MemoryConfig& memory_config,
+    const tt::tt_metal::Shape& logical_shape,
+    const tt::tt_metal::Shape& padded_shape) {
+    return TensorLayout(
+        dtype,
+        page_config,
+        memory_config,
+        CMAKE_UNIQUE_NAMESPACE::legacyShapeToAlignment(logical_shape, padded_shape, page_config, memory_config));
+}
+
+TensorLayout TensorLayout::restore_from_serialized(
+    DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config, const Alignment& alignment) {
+    return TensorLayout(dtype, page_config, memory_config, alignment);
+}
+
+Layout TensorLayout::get_layout() const { return impl().get_layout(); }
+Tile TensorLayout::get_tile() const { return impl().get_tile(); }
+PageConfig TensorLayout::get_page_config() const { return impl().get_page_config(); }
+DataType TensorLayout::get_data_type() const { return impl().get_data_type(); }
+const MemoryConfig& TensorLayout::get_memory_config() const { return impl().get_memory_config(); }
+const Alignment& TensorLayout::get_alignment() const { return impl().get_alignment(); }
+
+tt::tt_metal::Shape TensorLayout::compute_padded_shape(const tt::tt_metal::Shape& shape) const {
+    return impl().compute_padded_shape(shape);
+}
+
+TensorLayout TensorLayout::with_memory_config(MemoryConfig memory_config) const {
+    TensorLayout result = *this;
+    result.impl().set_memory_config(std::move(memory_config));
+    return result;
+}
+
+bool TensorLayout::operator==(const TensorLayout& other) const { return impl() == other.impl(); }
+bool TensorLayout::operator!=(const TensorLayout& other) const { return impl() != other.impl(); }
+
+std::tuple<const DataType&, const PageConfig&, const MemoryConfig&, const Alignment&> TensorLayout::attribute_values()
+    const {
+    return impl().attribute_values();
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/tensor/spec/layout/tensor_layout_impl.hpp
+++ b/tt_metal/impl/tensor/spec/layout/tensor_layout_impl.hpp
@@ -19,8 +19,6 @@
 
 namespace tt::tt_metal {
 
-class IDevice;
-
 class TensorLayoutImpl {
 public:
     TensorLayoutImpl(
@@ -51,7 +49,6 @@ public:
     size_t compute_packed_buffer_size_bytes(const tt::tt_metal::Shape& shape) const;
     size_t compute_page_size_bytes(const tt::tt_metal::Shape& shape) const;
 
-    size_t compute_consumed_memory_bytes_per_bank(const tt::tt_metal::Shape& shape, const IDevice& device) const;
     size_t compute_consumed_memory_bytes_per_bank(
         const tt::tt_metal::Shape& shape, size_t page_alignment, size_t num_banks) const;
 

--- a/tt_metal/impl/tensor/spec/layout/tensor_layout_impl.hpp
+++ b/tt_metal/impl/tensor/spec/layout/tensor_layout_impl.hpp
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tuple>
+
+#include <tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp>
+#include <tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp>
+
+/**
+ * Internal implementation header for TensorLayout.
+ *
+ * This header exposes TensorLayoutImpl so that translation units within tt_metal (e.g. tensor_spec.cpp)
+ * can operate directly on the implementation without going through the public TensorLayout accessors.
+ * It is private to tt_metal and is not part of the installed public API.
+ */
+
+namespace tt::tt_metal {
+
+class IDevice;
+
+class TensorLayoutImpl {
+public:
+    TensorLayoutImpl(
+        DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config, const Alignment& alignment);
+
+    TensorLayoutImpl(const TensorLayoutImpl&) = default;
+    TensorLayoutImpl(TensorLayoutImpl&&) noexcept = default;
+    TensorLayoutImpl& operator=(const TensorLayoutImpl&) = default;
+    TensorLayoutImpl& operator=(TensorLayoutImpl&&) noexcept = default;
+    ~TensorLayoutImpl() = default;
+
+    bool operator==(const TensorLayoutImpl&) const = default;
+    bool operator!=(const TensorLayoutImpl&) const = default;
+
+    Layout get_layout() const { return page_config_.get_layout(); }
+    Tile get_tile() const { return page_config_.get_tile(); }
+    const PageConfig& get_page_config() const { return page_config_; }
+    DataType get_data_type() const { return dtype_; }
+    const MemoryConfig& get_memory_config() const { return memory_config_; }
+    const Alignment& get_alignment() const { return alignment_; }
+
+    void set_memory_config(MemoryConfig memory_config) { memory_config_ = std::move(memory_config); }
+
+    Strides compute_strides(const tt::tt_metal::Shape& shape) const;
+
+    BufferShardingArgs compute_buffer_sharding_args(const tt::tt_metal::Shape& shape) const;
+
+    size_t compute_packed_buffer_size_bytes(const tt::tt_metal::Shape& shape) const;
+    size_t compute_page_size_bytes(const tt::tt_metal::Shape& shape) const;
+
+    size_t compute_consumed_memory_bytes_per_bank(const tt::tt_metal::Shape& shape, const IDevice& device) const;
+    size_t compute_consumed_memory_bytes_per_bank(
+        const tt::tt_metal::Shape& shape, size_t page_alignment, size_t num_banks) const;
+
+    tt::tt_metal::Shape compute_padded_shape(const tt::tt_metal::Shape& shape) const;
+
+    Shape2D compute_logical_2d_shape(const tt::tt_metal::Shape& shape) const;
+
+    Shape2D compute_physical_shape(const tt::tt_metal::Shape& shape) const;
+
+    Shape2D get_logical_shard_shape() const;
+
+    Shape2D get_physical_shard_shape() const;
+
+    Shape2D compute_page_shape(const Shape2D& physical_size) const;
+    size_t compute_page_size_bytes(const Shape2D& page_size) const;
+
+    std::tuple<const DataType&, const PageConfig&, const MemoryConfig&, const Alignment&> attribute_values() const {
+        return std::forward_as_tuple(dtype_, page_config_, memory_config_, alignment_);
+    }
+
+private:
+    void initialize_alignment();
+
+    DataType dtype_ = DataType::BFLOAT16;
+    PageConfig page_config_;
+    MemoryConfig memory_config_;
+    Alignment alignment_;
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/tensor/spec/layout/tensor_layout_impl.hpp
+++ b/tt_metal/impl/tensor/spec/layout/tensor_layout_impl.hpp
@@ -9,14 +9,6 @@
 #include <tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp>
 #include <tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp>
 
-/**
- * Internal implementation header for TensorLayout.
- *
- * This header exposes TensorLayoutImpl so that translation units within tt_metal (e.g. tensor_spec.cpp)
- * can operate directly on the implementation without going through the public TensorLayout accessors.
- * It is private to tt_metal and is not part of the installed public API.
- */
-
 namespace tt::tt_metal {
 
 class TensorLayoutImpl {

--- a/tt_metal/impl/tensor/spec/memory_config/memory_config.cpp
+++ b/tt_metal/impl/tensor/spec/memory_config/memory_config.cpp
@@ -3,22 +3,48 @@
 
 #include <cstdint>
 
+#include <tt_stl/assert.hpp>
 #include <tt_stl/reflection.hpp>
 
 #include <tt-metalium/experimental/tensor/tensor_types.hpp>
 #include <tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp>
 
+#include "memory_config_impl.hpp"
+
 namespace tt::tt_metal {
+
+MemoryConfig::MemoryConfig() : impl_(std::make_unique<MemoryConfigImpl>()) {}
 
 MemoryConfig::MemoryConfig(
     TensorMemoryLayout memory_layout, BufferType buffer_type, std::optional<ShardSpec> shard_spec) :
-    memory_layout_(memory_layout), buffer_type_(buffer_type), shard_spec_(std::move(shard_spec)) {}
+    impl_(std::make_unique<MemoryConfigImpl>(
+        memory_layout, buffer_type, std::move(shard_spec), std::nullopt, /*created_with_nd_shard_spec=*/false)) {}
 
-MemoryConfig::MemoryConfig(BufferType buffer_type, std::optional<NdShardSpec> nd_shard_spec) :
-    memory_layout_(nd_shard_spec.has_value() ? TensorMemoryLayout::ND_SHARDED : TensorMemoryLayout::INTERLEAVED),
-    buffer_type_(buffer_type),
-    nd_shard_spec_(std::move(nd_shard_spec)),
-    created_with_nd_shard_spec_(nd_shard_spec_.has_value()) {}
+MemoryConfig::MemoryConfig(BufferType buffer_type, std::optional<NdShardSpec> nd_shard_spec) {
+    const bool created_with_nd_shard_spec = nd_shard_spec.has_value();
+    impl_ = std::make_unique<MemoryConfigImpl>(
+        created_with_nd_shard_spec ? TensorMemoryLayout::ND_SHARDED : TensorMemoryLayout::INTERLEAVED,
+        buffer_type,
+        std::nullopt,
+        std::move(nd_shard_spec),
+        created_with_nd_shard_spec);
+}
+
+MemoryConfig::~MemoryConfig() = default;
+
+MemoryConfig::MemoryConfig(const MemoryConfig& other) :
+    impl_(other.impl_ ? std::make_unique<MemoryConfigImpl>(*other.impl_) : nullptr) {}
+
+MemoryConfig& MemoryConfig::operator=(const MemoryConfig& other) {
+    if (this == &other) {
+        return *this;
+    }
+    impl_ = other.impl_ ? std::make_unique<MemoryConfigImpl>(*other.impl_) : nullptr;
+    return *this;
+}
+
+MemoryConfig::MemoryConfig(MemoryConfig&& other) noexcept = default;
+MemoryConfig& MemoryConfig::operator=(MemoryConfig&& other) noexcept = default;
 
 MemoryConfig::MemoryConfig(
     TensorMemoryLayout memory_layout,
@@ -26,11 +52,43 @@ MemoryConfig::MemoryConfig(
     std::optional<ShardSpec> shard_spec,
     std::optional<NdShardSpec> nd_shard_spec,
     bool created_with_nd_shard_spec) :
-    memory_layout_(memory_layout),
-    buffer_type_(buffer_type),
-    shard_spec_(std::move(shard_spec)),
-    nd_shard_spec_(std::move(nd_shard_spec)),
-    created_with_nd_shard_spec_(created_with_nd_shard_spec) {}
+    impl_(std::make_unique<MemoryConfigImpl>(
+        memory_layout, buffer_type, std::move(shard_spec), std::move(nd_shard_spec), created_with_nd_shard_spec)) {}
+
+MemoryConfigImpl& MemoryConfig::impl() {
+    TT_FATAL(impl_ != nullptr, "MemoryConfig is in a moved-from state.");
+    return *impl_;
+}
+
+const MemoryConfigImpl& MemoryConfig::impl() const {
+    TT_FATAL(impl_ != nullptr, "MemoryConfig is in a moved-from state.");
+    return *impl_;
+}
+
+TensorMemoryLayout MemoryConfig::memory_layout() const { return impl().memory_layout_; }
+
+BufferType MemoryConfig::buffer_type() const { return impl().buffer_type_; }
+
+const std::optional<ShardSpec>& MemoryConfig::shard_spec() const { return impl().shard_spec_; }
+
+const std::optional<NdShardSpec>& MemoryConfig::nd_shard_spec() const { return impl().nd_shard_spec_; }
+
+bool MemoryConfig::created_with_nd_shard_spec() const { return impl().created_with_nd_shard_spec_; }
+
+std::tuple<
+    const TensorMemoryLayout&,
+    const BufferType&,
+    const std::optional<ShardSpec>&,
+    const std::optional<NdShardSpec>&,
+    const bool&>
+MemoryConfig::attribute_values() const {
+    return std::forward_as_tuple(
+        impl().memory_layout_,
+        impl().buffer_type_,
+        impl().shard_spec_,
+        impl().nd_shard_spec_,
+        impl().created_with_nd_shard_spec_);
+}
 
 MemoryConfig MemoryConfig::create_with_prepopulated_shard_specs(
     TensorMemoryLayout memory_layout,
@@ -43,7 +101,7 @@ MemoryConfig MemoryConfig::create_with_prepopulated_shard_specs(
 }
 
 bool MemoryConfig::is_sharded() const {
-    switch (this->memory_layout_) {
+    switch (impl().memory_layout_) {
         case TensorMemoryLayout::HEIGHT_SHARDED:
         case TensorMemoryLayout::WIDTH_SHARDED:
         case TensorMemoryLayout::BLOCK_SHARDED:
@@ -52,9 +110,11 @@ bool MemoryConfig::is_sharded() const {
     }
 }
 
-bool MemoryConfig::is_l1() const { return buffer_type_ == BufferType::L1 or buffer_type_ == BufferType::L1_SMALL; }
+bool MemoryConfig::is_l1() const {
+    return impl().buffer_type_ == BufferType::L1 or impl().buffer_type_ == BufferType::L1_SMALL;
+}
 
-bool MemoryConfig::is_dram() const { return buffer_type_ == BufferType::DRAM; }
+bool MemoryConfig::is_dram() const { return impl().buffer_type_ == BufferType::DRAM; }
 
 bool operator==(const MemoryConfig& config_a, const MemoryConfig& config_b) {
     if (config_a.buffer_type() != config_b.buffer_type() || config_a.memory_layout() != config_b.memory_layout()) {

--- a/tt_metal/impl/tensor/spec/memory_config/memory_config_impl.hpp
+++ b/tt_metal/impl/tensor/spec/memory_config/memory_config_impl.hpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+
+#include <tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp>
+#include <tt-metalium/experimental/tensor/tensor_types.hpp>
+
+/**
+ * Internal implementation header for MemoryConfig.
+ *
+ * This header exposes MemoryConfigImpl so that translation units within tt_metal
+ * (e.g. experimental per-core allocation helpers) can operate on the private state
+ * without putting that state in the installed public API header.
+ */
+
+namespace tt::tt_metal {
+
+class MemoryConfigImpl {
+public:
+    MemoryConfigImpl() = default;
+
+    MemoryConfigImpl(
+        TensorMemoryLayout memory_layout,
+        BufferType buffer_type,
+        std::optional<ShardSpec> shard_spec,
+        std::optional<NdShardSpec> nd_shard_spec,
+        bool created_with_nd_shard_spec,
+        bool per_core_allocation = false) :
+        memory_layout_(memory_layout),
+        buffer_type_(buffer_type),
+        shard_spec_(std::move(shard_spec)),
+        nd_shard_spec_(std::move(nd_shard_spec)),
+        created_with_nd_shard_spec_(created_with_nd_shard_spec),
+        per_core_allocation_(per_core_allocation) {}
+
+    MemoryConfigImpl(const MemoryConfigImpl&) = default;
+    MemoryConfigImpl(MemoryConfigImpl&&) noexcept = default;
+    MemoryConfigImpl& operator=(const MemoryConfigImpl&) = default;
+    MemoryConfigImpl& operator=(MemoryConfigImpl&&) noexcept = default;
+    ~MemoryConfigImpl() = default;
+
+    TensorMemoryLayout memory_layout_ = TensorMemoryLayout::INTERLEAVED;
+    BufferType buffer_type_ = BufferType::DRAM;
+    std::optional<ShardSpec> shard_spec_ = std::nullopt;
+    std::optional<NdShardSpec> nd_shard_spec_ = std::nullopt;
+    bool created_with_nd_shard_spec_ = false;
+    // Experimental: access only via experimental::per_core_allocation free functions.
+    bool per_core_allocation_ = false;
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/tensor/spec/memory_config/memory_config_impl.hpp
+++ b/tt_metal/impl/tensor/spec/memory_config/memory_config_impl.hpp
@@ -9,14 +9,6 @@
 #include <tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp>
 #include <tt-metalium/experimental/tensor/tensor_types.hpp>
 
-/**
- * Internal implementation header for MemoryConfig.
- *
- * This header exposes MemoryConfigImpl so that translation units within tt_metal
- * (e.g. experimental per-core allocation helpers) can operate on the private state
- * without putting that state in the installed public API header.
- */
-
 namespace tt::tt_metal {
 
 class MemoryConfigImpl {

--- a/tt_metal/impl/tensor/spec/tensor_spec.cpp
+++ b/tt_metal/impl/tensor/spec/tensor_spec.cpp
@@ -6,6 +6,7 @@
 #include <tt-metalium/experimental/tensor/tensor_types.hpp>
 #include <tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp>
 
+#include "layout/page_config_impl.hpp"
 #include "layout/tensor_layout_impl.hpp"
 
 namespace tt::tt_metal {
@@ -237,7 +238,7 @@ TensorSpec TensorSpec::block_sharded(CoreRange grid, ShardOrientation orientatio
 TensorSpec TensorSpec::sharded(NdShardSpec nd_shard_spec, ShardShapeAlignment shard_alignment) const {
     if (shard_alignment != ShardShapeAlignment::NONE) {
         auto alignment = shard_alignment == ShardShapeAlignment::REQUIRED
-                             ? page_config().get_required_shard_shape_alignment()
+                             ? get_required_shard_shape_alignment(page_config())
                              : page_config().get_recommended_shard_shape_alignment(data_type());
         auto& shard_shape = nd_shard_spec.shard_shape;
         for (int dim = 1; dim <= alignment.size(); dim++) {

--- a/tt_metal/impl/tensor/spec/tensor_spec.cpp
+++ b/tt_metal/impl/tensor/spec/tensor_spec.cpp
@@ -6,6 +6,8 @@
 #include <tt-metalium/experimental/tensor/tensor_types.hpp>
 #include <tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp>
 
+#include "layout/tensor_layout_impl.hpp"
+
 namespace tt::tt_metal {
 
 namespace {
@@ -20,11 +22,11 @@ std::optional<std::string> get_shape_fits_shard_grid_error(
 
     // Sharding checks use physical shape and physical shard shape
     // TODO: Review and port to use logical shapes
-    const auto physical_shape = tensor_layout.compute_physical_shape(logical_shape);
+    const auto physical_shape = tensor_layout.impl().compute_physical_shape(logical_shape);
     const auto physical_height = physical_shape.height();
     const auto physical_width = physical_shape.width();
 
-    const auto physical_shard_shape = tensor_layout.get_physical_shard_shape();
+    const auto physical_shard_shape = tensor_layout.impl().get_physical_shard_shape();
     const auto physical_shard_height = physical_shard_shape.height();
     const auto physical_shard_width = physical_shard_shape.width();
 
@@ -146,13 +148,35 @@ bool can_shape_fits_shard_grid(const TensorLayout& tensor_layout, const Shape& l
 TensorSpec::TensorSpec(tt::tt_metal::Shape logical_shape, TensorLayout tensor_layout) :
     logical_shape_(std::move(logical_shape)),
     tensor_layout_(std::move(tensor_layout)),
-    cached_padded_shape_(tensor_layout_.compute_padded_shape(logical_shape_)),
-    cached_logical_2d_shape_(tensor_layout_.compute_logical_2d_shape(logical_shape_)),
-    cached_physical_shape_(tensor_layout_.compute_physical_shape(logical_shape_)) {
+    cached_padded_shape_(tensor_layout_.impl().compute_padded_shape(logical_shape_)),
+    cached_logical_2d_shape_(tensor_layout_.impl().compute_logical_2d_shape(logical_shape_)),
+    cached_physical_shape_(tensor_layout_.impl().compute_physical_shape(logical_shape_)) {
     auto shard_grid_fit_error = CMAKE_UNIQUE_NAMESPACE::get_shape_fits_shard_grid_error(tensor_layout_, logical_shape_);
     TT_FATAL(!shard_grid_fit_error.has_value(), "{}", shard_grid_fit_error);
     CMAKE_UNIQUE_NAMESPACE::validate_dtype_and_layout(data_type(), layout());
     populate_sharding_specs();
+}
+
+Strides TensorSpec::compute_strides() const { return tensor_layout_.impl().compute_strides(logical_shape_); }
+
+BufferShardingArgs TensorSpec::compute_buffer_sharding_args() const {
+    return tensor_layout_.impl().compute_buffer_sharding_args(logical_shape_);
+}
+
+size_t TensorSpec::compute_packed_buffer_size_bytes() const {
+    return tensor_layout_.impl().compute_packed_buffer_size_bytes(logical_shape_);
+}
+
+size_t TensorSpec::compute_page_size_bytes() const {
+    return tensor_layout_.impl().compute_page_size_bytes(logical_shape_);
+}
+
+size_t TensorSpec::compute_consumed_memory_bytes_per_bank(const IDevice& device) const {
+    return tensor_layout_.impl().compute_consumed_memory_bytes_per_bank(logical_shape_, device);
+}
+
+size_t TensorSpec::compute_consumed_memory_bytes_per_bank(size_t page_alignment, size_t num_banks) const {
+    return tensor_layout_.impl().compute_consumed_memory_bytes_per_bank(logical_shape_, page_alignment, num_banks);
 }
 
 TensorSpec TensorSpec::sharded_across_dims(

--- a/tt_metal/impl/tensor/spec/tensor_spec.cpp
+++ b/tt_metal/impl/tensor/spec/tensor_spec.cpp
@@ -172,10 +172,6 @@ size_t TensorSpec::compute_page_size_bytes() const {
     return tensor_layout_.impl().compute_page_size_bytes(logical_shape_);
 }
 
-size_t TensorSpec::compute_consumed_memory_bytes_per_bank(const IDevice& device) const {
-    return tensor_layout_.impl().compute_consumed_memory_bytes_per_bank(logical_shape_, device);
-}
-
 size_t TensorSpec::compute_consumed_memory_bytes_per_bank(size_t page_alignment, size_t num_banks) const {
     return tensor_layout_.impl().compute_consumed_memory_bytes_per_bank(logical_shape_, page_alignment, num_banks);
 }

--- a/tt_metal/impl/tensor/spec/tensor_spec.cpp
+++ b/tt_metal/impl/tensor/spec/tensor_spec.cpp
@@ -4,6 +4,7 @@
 
 #include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
 #include <tt-metalium/experimental/tensor/tensor_types.hpp>
+#include <tt-metalium/experimental/per_core_allocation/memory_config.hpp>
 #include <tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp>
 
 #include "layout/page_config_impl.hpp"

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -18,6 +18,7 @@
 #include <tt-metalium/experimental/tensor/tensor_apis.hpp>
 #include <tt-metalium/experimental/tensor/impl/tensor_impl.hpp>
 #include <tt-metalium/experimental/tensor/tensor_types.hpp>
+#include <tt-metalium/experimental/per_core_allocation/memory_config.hpp>
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/math.hpp>

--- a/ttnn/core/tensor/flatbuffer/tensor_spec_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_spec_flatbuffer.cpp
@@ -4,6 +4,8 @@
 
 #include "tensor/flatbuffer/tensor_spec_flatbuffer.hpp"
 
+#include <tt-metalium/experimental/per_core_allocation/memory_config.hpp>
+
 namespace ttnn {
 
 CoreRangeSet from_flatbuffer(const flatbuffer::CoreRangeSet* core_range_set) {

--- a/ttnn/cpp/ttnn-nanobind/tensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/tensor.cpp
@@ -37,6 +37,7 @@
 #include "ttnn/tensor/tensor_utils.hpp"
 #include <tt-metalium/base_types.hpp>
 #include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/experimental/per_core_allocation/memory_config.hpp>
 #include <tt-metalium/host_buffer.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "ttnn/tensor/types.hpp"


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Cleanup

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Runtime Tensor is getting ready for graduation. Given Tensor Spec contains heavy implementation facing functions, they need to be trimmed up to minimize surface area.

This PR reduces the surface area relating to Tensor configuration by pimpling `TensorLayout` and `PageConfig`.
`TensorSpec` was not pimpled as they do not create significant benefit (no functions could be hidden).

The criteria for function hidding is the same as general surface area reduction, a function is internal if no one outside of `tt_metal` is using them.

Close #18536 as a result of this cleanup, see #50277 of the plumbing side.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/suf-red-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/suf-red-tensor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/suf-red-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/suf-red-tensor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=riverwu/suf-red-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:riverwu/suf-red-tensor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/suf-red-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/suf-red-tensor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/suf-red-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/suf-red-tensor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/suf-red-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/suf-red-tensor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/suf-red-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/suf-red-tensor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/suf-red-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/suf-red-tensor)