### PR TITLE
Zero KV cache on device - resolve OOM on host for high concurrency

### DIFF
--- a/models/demos/deepseek_v3_b1/micro_ops/dram_zero_fill/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/dram_zero_fill/op.py
@@ -5,9 +5,9 @@
 """
 DRAM Zero Fill micro op.
 
-Writes zeros to all pages of a DRAM tensor using a kernel on the 12x10 compute
-grid.  Each core zeroes a single L1 tile and then writes it to its assigned
-slice of DRAM pages via noc_async_write_page + TensorAccessor.
+Writes zeros to all pages of a DRAM tensor using a kernel on the device's full
+compute grid.  Each core zeroes a single L1 tile and then writes it to its
+assigned slice of DRAM pages via noc_async_write_page + TensorAccessor.
 
 This replaces the host-side ttnn.from_torch / ttnn.zeros pattern for
 zero-initialization, avoiding the host-to-device transfer entirely.
@@ -20,10 +20,6 @@ from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import FlashMLADecode
 from models.demos.deepseek_v3_b1.unified_kernel_descriptor import UnifiedKernelDescriptor
 
 KERNEL_PATH = "models/demos/deepseek_v3_b1/micro_ops/dram_zero_fill/kernels/dram_zero_fill_kernel.cpp"
-
-GRID_X = 12
-GRID_Y = 10
-NUM_CORES = GRID_X * GRID_Y  # 120
 
 OUTPUT_CB = 0
 TILE_32x32 = ttnn.Tile((32, 32))
@@ -125,12 +121,15 @@ class DRAMZeroFill:
         """
         page_size = TILE_32x32.get_tile_size(output_tensor.dtype)
 
+        # Use the device's full compute grid.  The kernel partitions pages
+        # across whatever rectangle it is given, so this adapts to harvested
+        # parts (e.g. 11x10) without any kernel change.
         device_grid = output_tensor.device().compute_with_storage_grid_size()
-        if device_grid.x < GRID_X or device_grid.y < GRID_Y:
-            raise ValueError(
-                "DRAMZeroFill requires at least a 12x10 compute grid: "
-                f"required=({GRID_X}, {GRID_Y}), actual=({device_grid.x}, {device_grid.y})"
-            )
+        grid_x = device_grid.x
+        grid_y = device_grid.y
+        num_cores = grid_x * grid_y
+        if num_cores == 0:
+            raise ValueError(f"DRAMZeroFill requires a non-empty compute grid: actual=({grid_x}, {grid_y})")
 
         shape = output_tensor.shape
         if shape[-2] % 32 != 0 or shape[-1] % 32 != 0:
@@ -144,9 +143,9 @@ class DRAMZeroFill:
         for d in range(len(shape) - 2):
             batch_tiles *= shape[d]
         total_pages = batch_tiles * tile_rows * tile_cols
-        pages_per_core = math.ceil(total_pages / NUM_CORES)
+        pages_per_core = math.ceil(total_pages / num_cores)
 
-        core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(GRID_X - 1, GRID_Y - 1))])
+        core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_x - 1, grid_y - 1))])
 
         tensor_accessor_args = ttnn.TensorAccessorArgs(output_tensor)
         ncrisc_compile_time_args = tensor_accessor_args.get_compile_time_args()
@@ -158,8 +157,8 @@ class DRAMZeroFill:
             ("page_size", page_size),
             ("grid_start_x", 0),
             ("grid_start_y", 0),
-            ("grid_end_x", GRID_X - 1),
-            ("grid_end_y", GRID_Y - 1),
+            ("grid_end_x", grid_x - 1),
+            ("grid_end_y", grid_y - 1),
         ]
 
         cb_format = ttnn.CBFormatDescriptor(

--- a/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
@@ -7,10 +7,10 @@ Utilities for KVPE cache initialization and management.
 
 import socket
 
-import torch
 from loguru import logger
 
 import ttnn
+from models.demos.deepseek_v3_b1.micro_ops.dram_zero_fill.op import DRAMZeroFill
 
 # This is a predefined constant for the number of contiguous tokens in a DRAM bank
 NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK = 32
@@ -263,7 +263,6 @@ def init_kvpe_cache(kvpe_cache_head_dim, mesh_device, seq_len, mesh_shape, sp_ax
     # hack in num_users * num_layers into batch size, so each user's layers are contiguous in memory
     num_layers = num_kvpe_cache_layers
     seq_len_local = seq_len // mesh_shape[sp_axis]
-    torch_kvpe_cache = torch.zeros(num_users * num_layers, 1, seq_len_local, kvpe_cache_head_dim)
 
     core_ranges = [
         ttnn.CoreRange(ttnn.CoreCoord(bank_id, 0), ttnn.CoreCoord(bank_id, 0)) for bank_id in range(BH_NUM_DRAM_BANKS)
@@ -281,13 +280,26 @@ def init_kvpe_cache(kvpe_cache_head_dim, mesh_device, seq_len, mesh_shape, sp_ax
         nd_shard_spec=kv_nd_shard_spec,
     )
 
-    tt_kvpe_cache = ttnn.from_torch(
-        torch_kvpe_cache,
-        dtype=ttnn.bfloat8_b,
-        device=mesh_device,
-        layout=ttnn.TILE_LAYOUT,
-        memory_config=kv_mem_config,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    # Allocate + zero on device. The host from_torch path packs the full replicated
+    # cache as bfp8 on host, overflowing pack_as_bfp8_tiles' 32-bit page index at high
+    # num_users; a device kernel zeros it instead with no host transfer.
+    tt_kvpe_cache = ttnn.allocate_tensor_on_device(
+        ttnn.Shape([num_users * num_layers, 1, seq_len_local, kvpe_cache_head_dim]),
+        ttnn.bfloat8_b,
+        ttnn.TILE_LAYOUT,
+        mesh_device,
+        kv_mem_config,
     )
+    DRAMZeroFill.op(tt_kvpe_cache)
+
+    # allocate_tensor_on_device leaves topology unset; reproduce ReplicateTensorToMesh,
+    # which is a 1D MeshShape(num_devices) with a single Replicate placement.
+    num_devices = mesh_device.shape[0] * mesh_device.shape[1]
+    dist_shape = ttnn.MeshShape([num_devices])
+    placements = [ttnn.PlacementReplicate()]
+    coords = [
+        ttnn.MeshCoordinate([coord[i] for i in range(coord.dims())]) for coord in ttnn.MeshCoordinateRange(dist_shape)
+    ]
+    tt_kvpe_cache.update_tensor_topology(ttnn.TensorTopology(dist_shape, placements, coords))
 
     return tt_kvpe_cache

--- a/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
@@ -292,14 +292,16 @@ def init_kvpe_cache(kvpe_cache_head_dim, mesh_device, seq_len, mesh_shape, sp_ax
     )
     DRAMZeroFill.op(tt_kvpe_cache)
 
-    # allocate_tensor_on_device leaves topology unset; reproduce ReplicateTensorToMesh,
-    # which is a 1D MeshShape(num_devices) with a single Replicate placement.
+    # allocate_tensor_on_device assigns a default 2D fully-replicated topology, but the rest
+    # of the model produces replicated tensors via ReplicateTensorToMesh, which is a 1D
+    # MeshShape(num_devices) with a single Replicate placement. Reproduce that exactly: a 1D
+    # distribution_shape + single Replicate, with mesh_coords being the 2D physical device
+    # coordinates (row-major), matching what the ReplicateTensorToMesh mapper emits.
     num_devices = mesh_device.shape[0] * mesh_device.shape[1]
     dist_shape = ttnn.MeshShape([num_devices])
     placements = [ttnn.PlacementReplicate()]
-    coords = [
-        ttnn.MeshCoordinate([coord[i] for i in range(coord.dims())]) for coord in ttnn.MeshCoordinateRange(dist_shape)
-    ]
+    physical_mesh_shape = ttnn.MeshShape(mesh_device.shape[0], mesh_device.shape[1])
+    coords = list(ttnn.MeshCoordinateRange(physical_mesh_shape))
     tt_kvpe_cache.update_tensor_topology(ttnn.TensorTopology(dist_shape, placements, coords))
 
     return tt_kvpe_cache


### PR DESCRIPTION
### PR Category
Feature/Bugfix

### Summary
- `init_kvpe_cache` for DS/Kimi Prefill currently relies on `torch.zeros` -> TTNN Device Tensor -> TTNN Device Tensor
- This leads to OOM on host for high concurrency values (anything above 8 users crashes when converting the Torch Tensor to TTNN)
- This data-path is also extremely slow, which leads to a high model initialization cost
- Since the KV cache must be cleared before the Model is run (stale NaN's/Infs can leads to attention outputs exploding), use the `DRAMZeroFill` Op from TTNN, specifically designed for the purposes of Zero Initializing DRAM Tensors with minimal host overhead

### Notes for reviewers
- We ran into the exact same issue for Blitz Decode and used the `DRAMZeroFill` op to bypass it
- fyi @ljovanovicTT - I think this PR provides the best of both worlds: Zero Initializing the KV cache and minimal host overhead. Thoughts in terms of replacing https://github.com/tenstorrent/tt-metal/pull/47623?

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=asaigal/prefill_kv_cache_oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:asaigal/prefill_kv_cache_oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=asaigal/prefill_kv_cache_oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:asaigal/prefill_kv_cache_oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=asaigal/prefill_kv_cache_oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:asaigal/prefill_kv_cache_oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=asaigal/prefill_kv_cache_oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:asaigal/prefill_kv_cache_oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=asaigal/prefill_kv_cache_oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:asaigal/prefill_kv_cache_oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=asaigal/prefill_kv_cache_oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:asaigal/prefill_kv_cache_oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=asaigal/prefill_kv_cache_oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:asaigal/prefill_kv_cache_oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=asaigal/prefill_kv_cache_oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:asaigal/prefill_kv_cache_oom)