### PR TITLE
#47716: move resnet50/quasar to bf16 because bfb8 does not exist on Quasar

### DIFF
--- a/models/demos/vision/classification/resnet50/quasar/demo/demo.py
+++ b/models/demos/vision/classification/resnet50/quasar/demo/demo.py
@@ -40,7 +40,7 @@ def test_demo_sample(mesh_device, batch_size, input_loc, imagenet_label_dict, mo
 )
 @pytest.mark.parametrize(
     "batch_size, iterations, act_dtype, weight_dtype",
-    ((16, 100, ttnn.bfloat8_b, ttnn.bfloat8_b),),
+    ((16, 100, ttnn.bfloat16, ttnn.bfloat16),),
 )
 def test_demo_trace_with_imagenet(
     mesh_device,

--- a/models/demos/vision/classification/resnet50/quasar/demo/demo_runner.py
+++ b/models/demos/vision/classification/resnet50/quasar/demo/demo_runner.py
@@ -18,8 +18,8 @@ from models.demos.vision.classification.resnet50.quasar.tests.common.resnet50_te
 
 resnet_model_config = {
     "MATH_FIDELITY": ttnn.MathFidelity.LoFi,
-    "WEIGHTS_DTYPE": ttnn.bfloat8_b,
-    "ACTIVATIONS_DTYPE": ttnn.bfloat8_b,
+    "WEIGHTS_DTYPE": ttnn.bfloat16,
+    "ACTIVATIONS_DTYPE": ttnn.bfloat16,
 }
 
 ops_parallel_config = {}

--- a/models/demos/vision/classification/resnet50/quasar/tests/common/perf_e2e_resnet50.py
+++ b/models/demos/vision/classification/resnet50/quasar/tests/common/perf_e2e_resnet50.py
@@ -33,8 +33,8 @@ ttnn.read_device_profiler = read_device_profiler
 
 model_config = {
     "MATH_FIDELITY": ttnn.MathFidelity.LoFi,
-    "WEIGHTS_DTYPE": ttnn.bfloat8_b,
-    "ACTIVATIONS_DTYPE": ttnn.bfloat8_b,
+    "WEIGHTS_DTYPE": ttnn.bfloat16,
+    "ACTIVATIONS_DTYPE": ttnn.bfloat16,
 }
 
 

--- a/models/demos/vision/classification/resnet50/quasar/tests/common/resnet50_test_infra.py
+++ b/models/demos/vision/classification/resnet50/quasar/tests/common/resnet50_test_infra.py
@@ -34,6 +34,10 @@ def load_resnet50_model(model_location_generator):
 
 ## copied from ttlib version test:
 # golden pcc is ordered fidelity, weight dtype, activation dtype
+# Quasar has no bfloat8_b, so only the (fidelity, bfloat16, bfloat16) keys are reachable
+# now. The batch 16/20/32 thresholds (and the inline ATOL/RTOL deltas) are carried over
+# from the earlier bfloat8_b reference and predate the bfloat16 switch. This table is not
+# currently consumed by validate(), which checks against a fixed pcc instead.
 golden_pcc_obj = {
     8: {
         (
@@ -41,62 +45,16 @@ golden_pcc_obj = {
             ttnn.bfloat16,
             ttnn.bfloat16,
         ): 0.983301,  # PCC: 0.9833017469734239             TODO: NEED DEBUGGING WHY THIS IS SLIGHTLY LOWER THAN TTLIB
-        # ): 0.990804,  # Max ATOL Delta: 1.607335090637207, Max RTOL Delta: 115.62200164794922, PCC: 0.9908042840544742
-        (
-            ttnn.MathFidelity.HiFi4,
-            ttnn.bfloat16,
-            ttnn.bfloat16,
-        ): 0.986301,  # Max ATOL Delta: 1.5697126388549805, Max RTOL Delta: 21.3042049407959, PCC: 0.9863013351442654
-        (
-            ttnn.MathFidelity.HiFi4,
-            ttnn.bfloat16,
-            ttnn.bfloat16,
-        ): 0.973763,  # Max ATOL Delta: 2.455164909362793, Max RTOL Delta: inf, PCC: 0.9737631427307492
-        (
-            ttnn.MathFidelity.HiFi4,
-            ttnn.bfloat16,
-            ttnn.bfloat16,
-        ): 0.978099,  # Max ATOL Delta: 1.955164909362793, Max RTOL Delta: inf, PCC: 0.9780993165966628
         (
             ttnn.MathFidelity.HiFi2,
             ttnn.bfloat16,
             ttnn.bfloat16,
         ): 0.983400,  # Max ATOL Delta: 1.7310011386871338, Max RTOL Delta: 369.5689392089844, PCC: 0.9834004200555363
         (
-            ttnn.MathFidelity.HiFi2,
-            ttnn.bfloat16,
-            ttnn.bfloat16,
-        ): 0.984828,  # Max ATOL Delta: 1.6054553985595703, Max RTOL Delta: 59.124324798583984, PCC: 0.9848281996919587
-        (
-            ttnn.MathFidelity.HiFi2,
-            ttnn.bfloat16,
-            ttnn.bfloat16,
-        ): 0.934073,  # Max ATOL Delta: 4.330164909362793, Max RTOL Delta: inf, PCC: 0.9340735819578696
-        (
-            ttnn.MathFidelity.HiFi2,
-            ttnn.bfloat16,
-            ttnn.bfloat16,
-        ): 0.944435,  # Max ATOL Delta: 4.705164909362793, Max RTOL Delta: inf, PCC: 0.9444350983635019
-        (
             ttnn.MathFidelity.LoFi,
             ttnn.bfloat16,
             ttnn.bfloat16,
         ): 0.938909,  # Max ATOL Delta: 3.861414909362793, Max RTOL Delta: 240.63145446777344, PCC: 0.9389092547575272
-        (
-            ttnn.MathFidelity.LoFi,
-            ttnn.bfloat16,
-            ttnn.bfloat16,
-        ): 0.959609,  # Max ATOL Delta: 3.205164909362793, Max RTOL Delta: 141.7057342529297, PCC: 0.9596095155046113
-        (
-            ttnn.MathFidelity.LoFi,
-            ttnn.bfloat16,
-            ttnn.bfloat16,
-        ): 0.854903,  # Max ATOL Delta: 7.830164909362793, Max RTOL Delta: inf, PCC: 0.8549035869182201
-        (
-            ttnn.MathFidelity.LoFi,
-            ttnn.bfloat16,
-            ttnn.bfloat16,
-        ): 0.884609,  # Max ATOL Delta: 6.455164909362793, Max RTOL Delta: inf, PCC: 0.8846098380419433
     },
     16: {
         (

--- a/models/demos/vision/classification/resnet50/quasar/tests/common/resnet50_test_infra.py
+++ b/models/demos/vision/classification/resnet50/quasar/tests/common/resnet50_test_infra.py
@@ -44,18 +44,18 @@ golden_pcc_obj = {
         # ): 0.990804,  # Max ATOL Delta: 1.607335090637207, Max RTOL Delta: 115.62200164794922, PCC: 0.9908042840544742
         (
             ttnn.MathFidelity.HiFi4,
-            ttnn.bfloat8_b,
+            ttnn.bfloat16,
             ttnn.bfloat16,
         ): 0.986301,  # Max ATOL Delta: 1.5697126388549805, Max RTOL Delta: 21.3042049407959, PCC: 0.9863013351442654
         (
             ttnn.MathFidelity.HiFi4,
             ttnn.bfloat16,
-            ttnn.bfloat8_b,
+            ttnn.bfloat16,
         ): 0.973763,  # Max ATOL Delta: 2.455164909362793, Max RTOL Delta: inf, PCC: 0.9737631427307492
         (
             ttnn.MathFidelity.HiFi4,
-            ttnn.bfloat8_b,
-            ttnn.bfloat8_b,
+            ttnn.bfloat16,
+            ttnn.bfloat16,
         ): 0.978099,  # Max ATOL Delta: 1.955164909362793, Max RTOL Delta: inf, PCC: 0.9780993165966628
         (
             ttnn.MathFidelity.HiFi2,
@@ -64,18 +64,18 @@ golden_pcc_obj = {
         ): 0.983400,  # Max ATOL Delta: 1.7310011386871338, Max RTOL Delta: 369.5689392089844, PCC: 0.9834004200555363
         (
             ttnn.MathFidelity.HiFi2,
-            ttnn.bfloat8_b,
+            ttnn.bfloat16,
             ttnn.bfloat16,
         ): 0.984828,  # Max ATOL Delta: 1.6054553985595703, Max RTOL Delta: 59.124324798583984, PCC: 0.9848281996919587
         (
             ttnn.MathFidelity.HiFi2,
             ttnn.bfloat16,
-            ttnn.bfloat8_b,
+            ttnn.bfloat16,
         ): 0.934073,  # Max ATOL Delta: 4.330164909362793, Max RTOL Delta: inf, PCC: 0.9340735819578696
         (
             ttnn.MathFidelity.HiFi2,
-            ttnn.bfloat8_b,
-            ttnn.bfloat8_b,
+            ttnn.bfloat16,
+            ttnn.bfloat16,
         ): 0.944435,  # Max ATOL Delta: 4.705164909362793, Max RTOL Delta: inf, PCC: 0.9444350983635019
         (
             ttnn.MathFidelity.LoFi,
@@ -84,71 +84,71 @@ golden_pcc_obj = {
         ): 0.938909,  # Max ATOL Delta: 3.861414909362793, Max RTOL Delta: 240.63145446777344, PCC: 0.9389092547575272
         (
             ttnn.MathFidelity.LoFi,
-            ttnn.bfloat8_b,
+            ttnn.bfloat16,
             ttnn.bfloat16,
         ): 0.959609,  # Max ATOL Delta: 3.205164909362793, Max RTOL Delta: 141.7057342529297, PCC: 0.9596095155046113
         (
             ttnn.MathFidelity.LoFi,
             ttnn.bfloat16,
-            ttnn.bfloat8_b,
+            ttnn.bfloat16,
         ): 0.854903,  # Max ATOL Delta: 7.830164909362793, Max RTOL Delta: inf, PCC: 0.8549035869182201
         (
             ttnn.MathFidelity.LoFi,
-            ttnn.bfloat8_b,
-            ttnn.bfloat8_b,
+            ttnn.bfloat16,
+            ttnn.bfloat16,
         ): 0.884609,  # Max ATOL Delta: 6.455164909362793, Max RTOL Delta: inf, PCC: 0.8846098380419433
     },
     16: {
         (
             ttnn.MathFidelity.HiFi4,
-            ttnn.bfloat8_b,
-            ttnn.bfloat8_b,
+            ttnn.bfloat16,
+            ttnn.bfloat16,
         ): 0.978099,  # Max ATOL Delta: 1.955164909362793, Max RTOL Delta: inf, PCC: 0.9780993165966632
         (
             ttnn.MathFidelity.HiFi2,
-            ttnn.bfloat8_b,
-            ttnn.bfloat8_b,
+            ttnn.bfloat16,
+            ttnn.bfloat16,
         ): 0.941,  # PCC: 0.9414369437627494               TODO: NEED DEBUGGING WHY THIS IS SLIGHTLY LOWER THAN TTLIB
         # ): 0.944435,  # Max ATOL Delta: 4.705164909362793, Max RTOL Delta: inf, PCC: 0.9444350983635021
         (
             ttnn.MathFidelity.LoFi,
-            ttnn.bfloat8_b,
-            ttnn.bfloat8_b,
+            ttnn.bfloat16,
+            ttnn.bfloat16,
         ): 0.988,  # Max ATOL Delta: 6.455164909362793, Max RTOL Delta: inf, PCC: 0.8846098380419435
     },
     20: {
         (
             ttnn.MathFidelity.HiFi4,
-            ttnn.bfloat8_b,
-            ttnn.bfloat8_b,
+            ttnn.bfloat16,
+            ttnn.bfloat16,
         ): 0.978099,  # Max ATOL Delta: 1.955164909362793, Max RTOL Delta: inf, PCC: 0.9780993165966628
         (
             ttnn.MathFidelity.HiFi2,
-            ttnn.bfloat8_b,
-            ttnn.bfloat8_b,
+            ttnn.bfloat16,
+            ttnn.bfloat16,
         ): 0.941,  #   PCC: 0.9419975597174123             TODO: NEED DEBUGGING WHY THIS IS SLIGHTLY LOWER THAN TTLIB
         # ): 0.944435,  # Max ATOL Delta: 4.705164909362793, Max RTOL Delta: inf, PCC: 0.9444350983635021
         (
             ttnn.MathFidelity.LoFi,
-            ttnn.bfloat8_b,
-            ttnn.bfloat8_b,
+            ttnn.bfloat16,
+            ttnn.bfloat16,
         ): 0.884609,  # Max ATOL Delta: 6.455164909362793, Max RTOL Delta: inf, PCC: 0.8846098380419433
     },
     32: {
         (
             ttnn.MathFidelity.HiFi4,
-            ttnn.bfloat8_b,
-            ttnn.bfloat8_b,
+            ttnn.bfloat16,
+            ttnn.bfloat16,
         ): 0.97,
         (
             ttnn.MathFidelity.HiFi2,
-            ttnn.bfloat8_b,
-            ttnn.bfloat8_b,
+            ttnn.bfloat16,
+            ttnn.bfloat16,
         ): 0.95,
         (
             ttnn.MathFidelity.LoFi,
-            ttnn.bfloat8_b,
-            ttnn.bfloat8_b,
+            ttnn.bfloat16,
+            ttnn.bfloat16,
         ): 0.88,
     },
 }

--- a/models/demos/vision/classification/resnet50/quasar/tests/test_resnet50_functional.py
+++ b/models/demos/vision/classification/resnet50/quasar/tests/test_resnet50_functional.py
@@ -51,9 +51,9 @@ def run_resnet_50(
 @pytest.mark.parametrize(
     "batch_size, act_dtype, weight_dtype, math_fidelity",
     (
-        (16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.HiFi2),
-        (16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),
-        (32, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),
+        (16, ttnn.bfloat16, ttnn.bfloat16, ttnn.MathFidelity.HiFi2),
+        (16, ttnn.bfloat16, ttnn.bfloat16, ttnn.MathFidelity.LoFi),
+        (32, ttnn.bfloat16, ttnn.bfloat16, ttnn.MathFidelity.LoFi),
     ),
 )
 @pytest.mark.parametrize(

--- a/models/demos/vision/classification/resnet50/quasar/tests/test_resnet50_performant.py
+++ b/models/demos/vision/classification/resnet50/quasar/tests/test_resnet50_performant.py
@@ -16,7 +16,7 @@ from models.demos.vision.classification.resnet50.quasar.tests.common.resnet50_pe
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, act_dtype, weight_dtype, math_fidelity",
-    ((16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
+    ((16, ttnn.bfloat16, ttnn.bfloat16, ttnn.MathFidelity.LoFi),),
 )
 @pytest.mark.parametrize("skip_compile_run", [True, False])
 def test_run_resnet50_inference(
@@ -36,7 +36,7 @@ def test_run_resnet50_inference(
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576, "trace_region_size": 845824}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, act_dtype, weight_dtype, math_fidelity",
-    ((16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
+    ((16, ttnn.bfloat16, ttnn.bfloat16, ttnn.MathFidelity.LoFi),),
 )
 def test_run_resnet50_trace_inference(
     device,
@@ -59,7 +59,7 @@ def test_run_resnet50_trace_inference(
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576, "num_command_queues": 2}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, act_dtype, weight_dtype, math_fidelity",
-    ((16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
+    ((16, ttnn.bfloat16, ttnn.bfloat16, ttnn.MathFidelity.LoFi),),
 )
 def test_run_resnet50_2cqs_inference(
     device, batch_size, act_dtype, weight_dtype, math_fidelity, model_location_generator
@@ -72,7 +72,7 @@ def test_run_resnet50_2cqs_inference(
 )
 @pytest.mark.parametrize(
     "batch_size, act_dtype, weight_dtype, math_fidelity",
-    ((16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
+    ((16, ttnn.bfloat16, ttnn.bfloat16, ttnn.MathFidelity.LoFi),),
 )
 def test_run_resnet50_trace_2cqs_inference(
     device,

--- a/models/demos/vision/classification/resnet50/quasar/tests/test_resnet50_performant_imagenet.py
+++ b/models/demos/vision/classification/resnet50/quasar/tests/test_resnet50_performant_imagenet.py
@@ -22,7 +22,7 @@ NUM_VALIDATION_IMAGES_IMAGENET = 49920
 )
 @pytest.mark.parametrize(
     "batch_size_per_device, iterations, act_dtype, weight_dtype",
-    ((16, 100, ttnn.bfloat8_b, ttnn.bfloat8_b),),
+    ((16, 100, ttnn.bfloat16, ttnn.bfloat16),),
 )
 def test_run_resnet50_trace_2cqs_inference(
     mesh_device,
@@ -146,7 +146,7 @@ def test_run_resnet50_trace_2cqs_inference(
 )
 @pytest.mark.parametrize(
     "batch_size_per_device, iterations, act_dtype, weight_dtype",
-    ((16, 100, ttnn.bfloat8_b, ttnn.bfloat8_b),),
+    ((16, 100, ttnn.bfloat16, ttnn.bfloat16),),
 )
 @pytest.mark.parametrize("entire_imagenet_dataset", [True])
 @pytest.mark.parametrize("expected_accuracy", [0.7555288461538462])

--- a/models/demos/vision/classification/resnet50/quasar/tests/test_resnet50_stability.py
+++ b/models/demos/vision/classification/resnet50/quasar/tests/test_resnet50_stability.py
@@ -18,7 +18,7 @@ test_demo_trace_with_imagenet.__test__ = False
 )
 @pytest.mark.parametrize(
     "batch_size, iterations, act_dtype, weight_dtype",
-    ((16, 100, ttnn.bfloat8_b, ttnn.bfloat8_b),),
+    ((16, 100, ttnn.bfloat16, ttnn.bfloat16),),
 )
 @pytest.mark.parametrize("mesh_device", [1], indirect=True)
 @pytest.mark.parametrize("test_duration_seconds", [24 * 60 * 60, 10], ids=["long", "short"])

--- a/models/demos/vision/classification/resnet50/quasar/tt/ttnn_functional_resnet50.py
+++ b/models/demos/vision/classification/resnet50/quasar/tt/ttnn_functional_resnet50.py
@@ -121,12 +121,13 @@ class resnet50Bottleneck:
                         else ttnn.TensorMemoryLayout.BLOCK_SHARDED
                     ),
                     deallocate_activation=True,
-                    reallocate_halo_output=False,
+                    # bfloat16 doubles every tensor; mirror the large variant's minimal
+                    # downsample config (no double buffering / activation reuse / full
+                    # inner dim) and cap the activation block height at one tile so the
+                    # CBs fit alongside the pinned residual + the wide projection output.
+                    reallocate_halo_output=True,
+                    act_block_h_override=32,
                     reshard_if_not_optimal=reshard_if_not_optimal,
-                    enable_act_double_buffer=True if not (is_blackhole_p100(device) and batch_size > 16) else False,
-                    enable_weights_double_buffer=True if input_width < 56 else False,
-                    full_inner_dim=True,
-                    enable_activation_reuse=True if height_sharding and self.stride == 1 else False,
                 ),
             }
 
@@ -144,6 +145,10 @@ class resnet50Bottleneck:
                 return_weights_and_bias=True,
                 dtype=self.model_config["ACTIVATIONS_DTYPE"],
             )
+            # Mirror the large variant: free the residual input and defragment the
+            # downsample output so the following convs have contiguous L1.
+            ttnn.deallocate(x)
+            ds_out = ttnn.reallocate(ds_out)
         else:
             ds_out = x
         return ds_out
@@ -210,8 +215,34 @@ class resnet50Bottleneck:
             dtype=self.model_config["ACTIVATIONS_DTYPE"],
         )
 
-        act_block_h_override = 0
+        # bfloat16 doubles every tensor and the residual is pinned through conv2, so the
+        # bfloat8_b-tuned act_block_h overflows L1. Cap conv2 at one tile on every arch
+        # (one tile divides any per-core height); throughput is not a concern here.
+        act_block_h_override = 32
+
+        # Mirror the large resnet50 variant: run the downsample before conv2 for the
+        # projection/strided modules. bfloat16 doubles every tensor, so the pinned
+        # residual input can no longer co-reside in L1 with conv2's circular buffers.
+        # Running the downsample first lets the residual be consumed/freed before
+        # conv2. layer1_module1 (input 56, 64 in-channels) keeps the original order.
+        run_downsample_before_conv2 = not (ds_input_height == 56 and self.conv1_input_channels == 64)
         ds_out = None
+        if run_downsample_before_conv2:
+            if ds_input_height == 56 and self.conv1_input_channels == 256 and self.downsample:
+                # Defragment L1 before the projection conv so it fits alongside conv2.
+                x_rm = ttnn.to_layout(x, ttnn.ROW_MAJOR_LAYOUT)
+                ttnn.deallocate(x)
+                x = ttnn.reallocate(x_rm)
+            ds_out = self.run_downsample_if_req(
+                x,
+                device,
+                batch_size,
+                ds_input_height,
+                ds_input_width,
+                reshard_if_not_optimal,
+                height_sharding,
+                packer_l1_accum_enabled=packer_l1_acc,
+            )
 
         logger.debug(f"Running conv2")
 
@@ -237,27 +268,11 @@ class resnet50Bottleneck:
                     ttnn.TensorMemoryLayout.HEIGHT_SHARDED if height_sharding else ttnn.TensorMemoryLayout.BLOCK_SHARDED
                 ),
                 reshard_if_not_optimal=reshard_if_not_optimal,
-                enable_act_double_buffer=True,
-                enable_weights_double_buffer=True,
-                full_inner_dim=True,
-                enable_activation_reuse=True if height_sharding and self.stride == 1 else False,
+                # bfloat16 doubles every tensor; mirror the large variant's minimal
+                # conv2 config (no double buffering / activation reuse / full inner
+                # dim) so the CBs fit in L1.
             ),
         }
-
-        if is_blackhole():
-            if layer_module == "layer1_module3":
-                conv_kwargs_2["conv_config"].act_block_h_override = 16 * 32
-            if batch_size == 32 and is_blackhole_p100(device):
-                if (
-                    layer_module == "layer1_module2"
-                    or layer_module == "layer1_module3"
-                    or layer_module == "layer2_module1"
-                ):
-                    conv_kwargs_2["conv_config"].act_block_h_override = 32
-
-        if is_wormhole_b0():
-            if layer_module == "layer1_module2" or layer_module == "layer1_module3":
-                conv_kwargs_2["conv_config"].act_block_h_override = 14 * 32
 
         (
             out,
@@ -317,16 +332,17 @@ class resnet50Bottleneck:
             dtype=self.model_config["ACTIVATIONS_DTYPE"],
         )
 
-        ds_out = self.run_downsample_if_req(
-            x,
-            device,
-            batch_size,
-            ds_input_height,
-            ds_input_width,
-            reshard_if_not_optimal,
-            height_sharding,
-            packer_l1_accum_enabled=packer_l1_acc,
-        )
+        if not run_downsample_before_conv2:
+            ds_out = self.run_downsample_if_req(
+                x,
+                device,
+                batch_size,
+                ds_input_height,
+                ds_input_width,
+                reshard_if_not_optimal,
+                height_sharding,
+                packer_l1_accum_enabled=packer_l1_acc,
+            )
 
         if ds_out.memory_config() != out.memory_config():
             ds_out = ttnn.experimental.quasar.to_memory_config(ds_out, out.memory_config())
@@ -443,16 +459,17 @@ class resnet50:
         if is_blackhole() and self.batch_size == 32:
             act_block_h_override = 32 * 32 if is_blackhole_p100(device) else 49 * 32
 
+        # Mirror the large resnet50 variant's first-conv config: bfloat16 doubles the
+        # activation footprint, so activation reuse + double buffering no longer fit in
+        # L1. The large variant omits both and relies on reallocate_halo_output instead.
         self.conv1_config = ttnn.Conv2dConfig(
             weights_dtype=self.model_config["WEIGHTS_DTYPE"],
             activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU),
             deallocate_activation=dealloc_input,
+            reallocate_halo_output=True,
             act_block_h_override=act_block_h_override,
-            enable_act_double_buffer=True,
             shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             reshard_if_not_optimal=False,
-            # otherwise act block h is not big enough for the reuse
-            enable_activation_reuse=(not is_wormhole_b0() or device.get_num_devices() <= 8),
         )
         self.conv1_compute_config = ttnn.init_device_compute_kernel_config(
             device.arch(),
@@ -907,7 +924,7 @@ class resnet50:
             stride=[1, 1],
             padding=[0, 0, 0, 0],
             output_layout=ttnn.TILE_LAYOUT,
-            dtype=ttnn.bfloat8_b,
+            dtype=ttnn.bfloat16,
             compute_kernel_config=ttnn.init_device_compute_kernel_config(
                 self.device.arch(), math_fidelity=ttnn.MathFidelity.LoFi
             ),

--- a/models/demos/vision/classification/resnet50/quasar/tt/ttnn_functional_resnet50_large.py
+++ b/models/demos/vision/classification/resnet50/quasar/tt/ttnn_functional_resnet50_large.py
@@ -775,7 +775,7 @@ class resnet50:
             stride=[1, 1],
             padding=[0, 0, 0, 0],
             output_layout=ttnn.TILE_LAYOUT,
-            dtype=ttnn.bfloat8_b,
+            dtype=ttnn.bfloat16,
         )
 
         grid_size = (8, 4)
@@ -952,7 +952,7 @@ class resnet50:
             stride=[1, 1],
             padding=[0, 0, 0, 0],
             output_layout=ttnn.TILE_LAYOUT,
-            dtype=ttnn.bfloat8_b,
+            dtype=ttnn.bfloat16,
         )
 
         grid_size = (8, 4)


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Feature, test only

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #47716 

Move resnet50 quasar to bf16 from bfb8 because Quasar does not support bfb8. Need to adjust conv handling because by default bf16 tensors do not fit in L1.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-47716_resnet_bf16)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-47716_resnet_bf16)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-47716_resnet_bf16)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-47716_resnet_bf16)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-47716_resnet_bf16)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-47716_resnet_bf16)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-47716_resnet_bf16)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-47716_resnet_bf16)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-47716_resnet_bf16)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-47716_resnet_bf16)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-47716_resnet_bf16)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-47716_resnet_bf16)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-47716_resnet_bf16)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-47716_resnet_bf16)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-47716_resnet_bf16)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-47716_resnet_bf16)