### PR TITLE
[Bug fix] Update SDXL CLIP encoder perf baselines after transformers 5.10.2 bump

### DIFF
--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -140,12 +140,12 @@ DEVICE_PERF_EXPECTATIONS = {
         "blackhole": None,  # Only 1024x1024 tested on Blackhole
     },
     "clip_encoder_1": {
-        "wormhole": 40_479_595,  # Average of last 5 main CI runs (May 12-13, 2026); previous 40_995_000 was above observed range causing failures
-        "blackhole": 19_095_974,  # Average of 21 main CI runs (May 16-19, 2026)
+        "wormhole": 23_745_000,  # Average of 3 main CI runs (Jun 22, 2026); transformers 5.10.2 bump reduced CLIP encoder dispatch
+        "blackhole": 11_927_000,  # Average of 3 main CI runs (Jun 22, 2026)
     },
     "clip_encoder_2": {
-        "wormhole": 125_300_000,
-        "blackhole": 59_431_573,
+        "wormhole": 88_529_000,  # Average of 3 main CI runs (Jun 22, 2026)
+        "blackhole": 43_810_000,  # Average of 3 main CI runs (Jun 22, 2026)
     },
 }
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
The transformers 4.53.0→5.10.2 bump (PR #47218) restructured the CLIP API and state dict layout, resulting in significantly faster CLIP encoder inference:
- **clip_encoder_1**: ~41% faster (WH: 40.5M→23.7M ns, BH: 19.1M→11.9M ns)
- **clip_encoder_2**: ~30% faster (WH: 125.3M→88.5M ns, BH: 59.4M→43.8M ns)

New baselines are averages from 3 consecutive failing main CI runs (Jun 22, 2026): [27951308319](https://github.com/tenstorrent/tt-metal/actions/runs/27951308319), [27965065988](https://github.com/tenstorrent/tt-metal/actions/runs/27965065988), [27984016876](https://github.com/tenstorrent/tt-metal/actions/runs/27984016876).

### Notes for reviewers
This is a pure baseline update — the underlying perf improvement came from the transformers library bump. Values are very consistent across 3 runs (within ~0.5% for each encoder).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/fix-sdxl-clip-encoder-perf-baselines)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/fix-sdxl-clip-encoder-perf-baselines)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mbezulj/fix-sdxl-clip-encoder-perf-baselines)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mbezulj/fix-sdxl-clip-encoder-perf-baselines)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mbezulj/fix-sdxl-clip-encoder-perf-baselines)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mbezulj/fix-sdxl-clip-encoder-perf-baselines)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/fix-sdxl-clip-encoder-perf-baselines)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/fix-sdxl-clip-encoder-perf-baselines)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mbezulj/fix-sdxl-clip-encoder-perf-baselines)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mbezulj/fix-sdxl-clip-encoder-perf-baselines)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mbezulj/fix-sdxl-clip-encoder-perf-baselines)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mbezulj/fix-sdxl-clip-encoder-perf-baselines)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mbezulj/fix-sdxl-clip-encoder-perf-baselines)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mbezulj/fix-sdxl-clip-encoder-perf-baselines)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mbezulj/fix-sdxl-clip-encoder-perf-baselines)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mbezulj/fix-sdxl-clip-encoder-perf-baselines)