### PR TITLE
[skip ci] Temporarily skip test_wan_decoder f32/2x4/T=1 on Wormhole (PCC below threshold)

### DIFF
--- a/models/tt_dit/tests/models/wan2_2/test_vae_wan2_1.py
+++ b/models/tt_dit/tests/models/wan2_2/test_vae_wan2_1.py
@@ -1414,6 +1414,17 @@ def test_wan_decoder(
 ):
     from diffusers.models.autoencoders.autoencoder_kl_wan import AutoencoderKLWan as TorchAutoencoderKLWan
 
+    # Temporarily skip f32 + 2x4 mesh + T=1 + check_output + real_weights on Wormhole: PCC slightly below threshold, refs #47005
+    if (
+        dtype == ttnn.DataType.FLOAT32
+        and tuple(mesh_device.shape) == (2, 4)
+        and T == 1
+        and not skip_check
+        and real_weights
+        and t_chunk_size == 1
+    ):
+        pytest.skip("f32 decoder PCC below threshold on 2x4 Wormhole mesh for T=1, refs #47005")
+
     torch.manual_seed(0)
     tt_input_dtype = ttnn.bfloat16 if dtype == ttnn.DataType.BFLOAT16 else ttnn.float32
 


### PR DESCRIPTION
The parametrized test `test_wan_decoder` with `dtype=f32`, `mesh_device=(2,4)` (both `h0_w1` and `h1_w0`), `T=1` (`_1f`), `check_output`, `real_weights`, and `t_chunk_size=1` has been failing on the T3000 Wormhole LLM-box CI for 7+ days. The achieved PCC (99.9928% at 480p, 99.9918% at 720p) is marginally below the required threshold of 99.9945%. All bf16 variants and other parametrizations continue to pass. This PR adds a narrowly-scoped `pytest.skip()` inside the function body, guarded on exactly the failing parameter combination, to unblock CI while the root cause is investigated. refs #47005

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47005)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lifecycle/disable-issue-47005)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47005)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lifecycle/disable-issue-47005)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=lifecycle/disable-issue-47005)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:lifecycle/disable-issue-47005)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lifecycle/disable-issue-47005)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lifecycle/disable-issue-47005)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47005)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lifecycle/disable-issue-47005)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lifecycle/disable-issue-47005)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lifecycle/disable-issue-47005)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lifecycle/disable-issue-47005)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lifecycle/disable-issue-47005)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lifecycle/disable-issue-47005)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lifecycle/disable-issue-47005)