### PR TITLE
[skip ci] Skip failing test_mux_bw_both_channel_types[32-1-4096-10000-8-8-8-8] on T3K

### DIFF
--- a/tests/tt_metal/microbenchmarks/ethernet/test_fabric_mux_bandwidth.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_fabric_mux_bandwidth.py
@@ -352,6 +352,17 @@ def test_mux_bw_both_channel_types(
     num_full_size_channel_iters,
     num_iters_between_teardown_checks,
 ):
+    if (
+        num_full_size_channels == 8
+        and num_header_only_channels == 8
+        and num_buffers_full_size_channel == 8
+        and num_buffers_header_only_channel == 8
+        and num_packets == 10000
+        and packet_payload_size_bytes == 4096
+        and num_full_size_channel_iters == 1
+        and num_iters_between_teardown_checks == 32
+    ):
+        pytest.skip("Skipping failing parametrization [32-1-4096-10000-8-8-8-8] on T3K, refs #46987")
     test_name = "both_channel_types"
     run_mux_benchmark_test(
         test_name,


### PR DESCRIPTION
The parametrization `test_mux_bw_both_channel_types[32-1-4096-10000-8-8-8-8]` has been failing for 7+ days on the T3K (Wormhole Galaxy) Fabric Mux BW microbenchmark job with a geomean speedup of 0.978863, which is outside the acceptable range [0.980000, 1.020000]. Temporarily skipping this specific parametrization (num_full_size_channels=8, num_header_only_channels=8, num_buffers_full_size_channel=8, num_buffers_header_only_channel=8, num_packets=10000, packet_payload_size_bytes=4096, num_full_size_channel_iters=1, num_iters_between_teardown_checks=32) until the underlying performance regression is fixed. refs #46987

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-46987)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lifecycle/disable-issue-46987)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-46987)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lifecycle/disable-issue-46987)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=lifecycle/disable-issue-46987)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:lifecycle/disable-issue-46987)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lifecycle/disable-issue-46987)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lifecycle/disable-issue-46987)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lifecycle/disable-issue-46987)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lifecycle/disable-issue-46987)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lifecycle/disable-issue-46987)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lifecycle/disable-issue-46987)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lifecycle/disable-issue-46987)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lifecycle/disable-issue-46987)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lifecycle/disable-issue-46987)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lifecycle/disable-issue-46987)