### PR TITLE
[Cleanup] Remove mesh_device_ stub from ttnn::Tensor

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_deallocation.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_deallocation.cpp
@@ -58,21 +58,18 @@ TEST_F(DeallocateTest, SharedTensorDeallocateForce) {
         << "Shared tensor should be able to be deallocated when deallocated with force=true";
 }
 
-TEST_F(DeallocateTest, DeallocatedTensorHasDevice) {
-    // We should think about eventually making all these `.device()` return null on deallocated tensor
-
+TEST_F(DeallocateTest, DeallocatedTensorHasNoDevice) {
     Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
     tensor.deallocate(/*force = */ true);
     EXPECT_FALSE(tensor.is_allocated());
 
-    EXPECT_NE(tensor.device(), nullptr) << "Deallocated tensor should have valid device";
+    EXPECT_EQ(tensor.device(), nullptr) << "Deallocated tensor should have no device";
 
-    // Here the device field is copied over, we might want to clean this up eventually.
     Tensor tensor2 = tensor;
-    EXPECT_NE(tensor2.device(), nullptr) << "Copy of deallocated tensor should have valid device";
+    EXPECT_EQ(tensor2.device(), nullptr) << "Copy of deallocated tensor should have no device";
 
     Tensor tensor3(tensor.device_storage());
-    EXPECT_EQ(tensor3.device(), nullptr) << "Tensor constructed from deallocated storage should not have valid device";
+    EXPECT_EQ(tensor3.device(), nullptr) << "Tensor constructed from deallocated storage should have no device";
 }
 
 TEST_F(DeallocateTest, DeallocatedTensorDoesNOTHaveMeshTensor) {

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -264,11 +264,6 @@ public:
     static std::uint64_t next_tensor_id();
 
 private:
-    // Shorthand for checking if this Tensor is allocated on MeshDevice. If set, is never nullptr.
-    // If not set, the tensor can either be on host or allocated on a single device.
-    // TODO: #21099 - This won't be needed after the migration to MeshDevice is complete.
-    std::optional<distributed::MeshDevice*> mesh_device_ = std::nullopt;
-
     void deallocate_impl(bool force);
 };
 

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -245,7 +245,7 @@ public:
     const distributed::MeshBuffer& mesh_buffer() const;
 
     // Returns the device the tensor is allocated on.
-    // Throws if the tensor is not allocated on a device.
+    // Returns nullptr if the tensor is not allocated on a device (on host/ deallocated).
     distributed::MeshDevice* device() const;
 
     bool is_sharded() const;

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -45,9 +45,9 @@ public:
     //                                  Hi Level APIs
     // ======================================================================================
     [[nodiscard]] explicit Tensor() = default;
-    [[nodiscard]] Tensor(const Tensor& other);
+    [[nodiscard]] Tensor(const Tensor& other) = default;
     [[nodiscard]] Tensor(Tensor&& other) noexcept = default;
-    Tensor& operator=(const Tensor& other);
+    Tensor& operator=(const Tensor& other) = default;
     Tensor& operator=(Tensor&& other) noexcept;
     ~Tensor();
 

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -13,7 +13,6 @@
 #include "ttnn/tensor/layout/tensor_layout.hpp"
 #include "ttnn/distributed/api.hpp"
 
-#include <tt-metalium/mesh_device_view.hpp>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/float8.hpp>
 #include <tt-metalium/buffer.hpp>
@@ -87,11 +86,7 @@ Tensor::Tensor(HostTensor tensor) :
 Tensor::Tensor(MeshTensor tensor) : Tensor::Tensor(DeviceStorage(std::move(tensor))) {}
 
 Tensor::Tensor(DeviceStorage storage) :
-    tensor_id(Tensor::next_tensor_id()), tensor_attributes(std::make_shared<TensorAttributes>(std::move(storage))) {
-    if (device_storage().is_allocated()) {
-        mesh_device_ = &device_storage().get_mesh_tensor().mutable_device();
-    }
-}
+    tensor_id(Tensor::next_tensor_id()), tensor_attributes(std::make_shared<TensorAttributes>(std::move(storage))) {}
 
 Tensor& Tensor::operator=(const Tensor& other) {
     if (this == &other) {
@@ -101,7 +96,6 @@ Tensor& Tensor::operator=(const Tensor& other) {
     if (this->tensor_attributes != other.tensor_attributes) {
         this->tensor_attributes = other.tensor_attributes;
     }
-    this->mesh_device_ = other.mesh_device_;
     return *this;
 }
 
@@ -111,7 +105,6 @@ Tensor& Tensor::operator=(Tensor&& other) noexcept {
     if (this->tensor_attributes != other.tensor_attributes) {
         this->tensor_attributes = std::move(other.tensor_attributes);
     }
-    this->mesh_device_ = other.mesh_device_;
     return *this;
 }
 
@@ -485,10 +478,10 @@ const MeshTensor& Tensor::mesh_tensor() const& {
 }
 
 distributed::MeshDevice* Tensor::device() const {
-    if (this->mesh_device_.has_value()) {
-        return this->mesh_device_.value();
+    if (storage_type() != StorageType::DEVICE) {
+        return nullptr;
     }
-    return nullptr;
+    return device_storage().get_device_bypass_deallocate_check();
 }
 
 const distributed::MeshBuffer& Tensor::mesh_buffer() const { return device_storage().get_mesh_buffer(); }

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -88,17 +88,6 @@ Tensor::Tensor(MeshTensor tensor) : Tensor::Tensor(DeviceStorage(std::move(tenso
 Tensor::Tensor(DeviceStorage storage) :
     tensor_id(Tensor::next_tensor_id()), tensor_attributes(std::make_shared<TensorAttributes>(std::move(storage))) {}
 
-Tensor& Tensor::operator=(const Tensor& other) {
-    if (this == &other) {
-        return *this;
-    }
-    this->tensor_id = other.tensor_id;
-    if (this->tensor_attributes != other.tensor_attributes) {
-        this->tensor_attributes = other.tensor_attributes;
-    }
-    return *this;
-}
-
 Tensor& Tensor::operator=(Tensor&& other) noexcept {
     this->tensor_id = other.tensor_id;
     other.tensor_id = INVALID_TENSOR_ID;
@@ -107,8 +96,6 @@ Tensor& Tensor::operator=(Tensor&& other) noexcept {
     }
     return *this;
 }
-
-Tensor::Tensor(const Tensor& other) = default;
 
 Tensor::~Tensor() { this->deallocate_impl(/*force=*/false); }
 

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -478,10 +478,10 @@ const MeshTensor& Tensor::mesh_tensor() const& {
 }
 
 distributed::MeshDevice* Tensor::device() const {
-    if (storage_type() != StorageType::DEVICE) {
+    if (storage_type() != StorageType::DEVICE || !is_allocated()) {
         return nullptr;
     }
-    return device_storage().get_device_bypass_deallocate_check();
+    return device_storage().get_mesh_buffer().device();
 }
 
 const distributed::MeshBuffer& Tensor::mesh_buffer() const { return device_storage().get_mesh_buffer(); }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -579,6 +579,10 @@ ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t bina
         "Input tensor B must be on device, got storage type: {}",
         input_tensor_b.storage_type());
 
+    // Valid input is allocated
+    TT_FATAL(input_tensor_a.is_allocated(), "Input Tensor is not allocated");
+    TT_FATAL(input_tensor_b.is_allocated(), "Input Tensor is not allocated");
+
     // Resolve sub_device_id to sub_core_grids if provided (after device validation)
     auto resolved_sub_core_grids = sub_core_grids;
     if (sub_device_id.has_value()) {
@@ -717,6 +721,9 @@ ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t bina
         input_tensor_a.storage_type() == StorageType::DEVICE,
         "Input tensor A must be on device, got storage type: {}",
         input_tensor_a.storage_type());
+
+    // Valid input is allocated
+    TT_FATAL(input_tensor_a.is_allocated(), "Input Tensor is not allocated");
 
     // Resolve sub_device_id to sub_core_grids if provided (after device validation)
     auto resolved_sub_core_grids = sub_core_grids;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -580,8 +580,8 @@ ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t bina
         input_tensor_b.storage_type());
 
     // Valid input is allocated
-    TT_FATAL(input_tensor_a.is_allocated(), "Input Tensor is not allocated");
-    TT_FATAL(input_tensor_b.is_allocated(), "Input Tensor is not allocated");
+    TT_FATAL(input_tensor_a.is_allocated(), "Input Tensor A is not allocated");
+    TT_FATAL(input_tensor_b.is_allocated(), "Input Tensor B is not allocated");
 
     // Resolve sub_device_id to sub_core_grids if provided (after device validation)
     auto resolved_sub_core_grids = sub_core_grids;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.cpp
@@ -678,6 +678,10 @@ ttnn::operations::experimental::quasar::binary_ng::BinaryNgDeviceOperation::tens
         "Input tensor B must be on device, got storage type: {}",
         input_tensor_b.storage_type());
 
+    // Valid input is allocated
+    TT_FATAL(input_tensor_a.is_allocated(), "Input Tensor is not allocated");
+    TT_FATAL(input_tensor_b.is_allocated(), "Input Tensor is not allocated");
+
     // Resolve sub_device_id to sub_core_grids if provided (after device validation)
     auto resolved_sub_core_grids = sub_core_grids;
     if (sub_device_id.has_value()) {
@@ -816,6 +820,9 @@ ttnn::operations::experimental::quasar::binary_ng::BinaryNgDeviceOperation::tens
         input_tensor_a.storage_type() == StorageType::DEVICE,
         "Input tensor A must be on device, got storage type: {}",
         input_tensor_a.storage_type());
+
+    // Valid input is allocated
+    TT_FATAL(input_tensor_a.is_allocated(), "Input Tensor is not allocated");
 
     // Resolve sub_device_id to sub_core_grids if provided (after device validation)
     auto resolved_sub_core_grids = sub_core_grids;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.cpp
@@ -679,8 +679,8 @@ ttnn::operations::experimental::quasar::binary_ng::BinaryNgDeviceOperation::tens
         input_tensor_b.storage_type());
 
     // Valid input is allocated
-    TT_FATAL(input_tensor_a.is_allocated(), "Input Tensor is not allocated");
-    TT_FATAL(input_tensor_b.is_allocated(), "Input Tensor is not allocated");
+    TT_FATAL(input_tensor_a.is_allocated(), "Input Tensor A is not allocated");
+    TT_FATAL(input_tensor_b.is_allocated(), "Input Tensor B is not allocated");
 
     // Resolve sub_device_id to sub_core_grids if provided (after device validation)
     auto resolved_sub_core_grids = sub_core_grids;


### PR DESCRIPTION
### Summary

During migration to `MeshDevice`, a cached `mesh_device_` stub was left in `ttnn::Tensor`.

This stub was not removed after the integration was finished. 

This causes weird `Tensor::device()` behavior surrounding deallocated tensor as `MeshDevice` is cached but propagated inconsistently.

See: https://github.com/tenstorrent/tt-metal/blob/c48dd125b4328ab4956482b8b56405171f652b3f/tests/ttnn/unit_tests/gtests/tensor/test_tensor_deallocation.cpp#L61-L76

This PR removes the `mesh_device_` stub, now `device()` will always return nullptr when the tensor is deallocated.

### CI failures
I have manually scraped through the failing pipelines to ensure that no behaviors are depending on the stale `MeshDevice` state.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/rm-tensor-mesh-device-field)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/rm-tensor-mesh-device-field)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/rm-tensor-mesh-device-field)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/rm-tensor-mesh-device-field)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=riverwu/rm-tensor-mesh-device-field)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:riverwu/rm-tensor-mesh-device-field)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/rm-tensor-mesh-device-field)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/rm-tensor-mesh-device-field)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/rm-tensor-mesh-device-field)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/rm-tensor-mesh-device-field)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/rm-tensor-mesh-device-field)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/rm-tensor-mesh-device-field)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/rm-tensor-mesh-device-field)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/rm-tensor-mesh-device-field)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/rm-tensor-mesh-device-field)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/rm-tensor-mesh-device-field)