### PR TITLE
Bug fix: round trace per-bank reservation up to max trace page size

### DIFF
--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -18,6 +18,7 @@
 #include "buffer_types.hpp"
 #include "impl/allocator/bank_manager.hpp"
 #include "impl/allocator/allocator_types.hpp"
+#include "impl/trace/trace_buffer.hpp"
 #include <tt-metalium/math.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <umd/device/types/xy_pair.hpp>
@@ -37,14 +38,16 @@ void AllocatorImpl::validate_bank_assignments() const {
 void AllocatorImpl::init_one_bank_per_channel() {
     // DRAM bank is between unreserved start and trace_region start: UNRESERVED | DRAM BANK | TRACE REGION
     // trace_region_size is the TOTAL trace budget across all DRAM banks (not per-bank). Trace buffers are
-    // interleaved evenly across banks, so each bank reserves ceil(trace_region_size / num_banks), rounded up
-    // to dram_alignment. The aggregate reserved capacity (per_bank_trace_size * num_banks) is therefore >=
-    // trace_region_size, so a trace whose total size fits the budget also fits per-bank after interleaving.
+    // interleaved evenly across banks, so each bank reserves ceil(trace_region_size / num_banks). This is
+    // rounded up to a whole multiple of the max trace buffer page size (rather than just dram_alignment) so
+    // that the per-bank reservation always holds a whole number of trace pages: a trace whose total size fits
+    // the budget but whose pages skew onto a subset of banks (interleaving biases the leading pages toward the
+    // low banks) still fits per-bank. The aggregate reserved capacity (per_bank_trace_size * num_banks) is
+    // therefore >= trace_region_size.
     DeviceAddr per_bank_trace_size = 0;
     if (config_->trace_region_size > 0) {
         per_bank_trace_size = round_up(
-            div_up(config_->trace_region_size, static_cast<size_t>(config_->num_dram_channels)),
-            config_->dram_alignment);
+            div_up(config_->trace_region_size, static_cast<size_t>(config_->num_dram_channels)), kMaxTraceBufPageSize);
     }
     DeviceAddr dram_bank_size = config_->dram_bank_size - config_->dram_unreserved_base - per_bank_trace_size;
     std::vector<int64_t> bank_offsets(config_->num_dram_channels);

--- a/tt_metal/impl/trace/dispatch.cpp
+++ b/tt_metal/impl/trace/dispatch.cpp
@@ -226,8 +226,8 @@ std::size_t compute_interleaved_trace_buf_page_size(uint32_t buf_size, const uin
     // to maximize read bandwidth.
     // Min size is bounded by NOC transfer efficiency
     // Max size is bounded by Prefetcher CmdDatQ size
-    constexpr uint32_t kExecBufPageMin = 1024;
-    constexpr uint32_t kExecBufPageMax = 8192;
+    constexpr uint32_t kExecBufPageMin = kMinTraceBufPageSize;
+    constexpr uint32_t kExecBufPageMax = kMaxTraceBufPageSize;
     // If the trace buffer uses at least 2 pages per bank (for a specific page size), require using that page size or
     // larger to improve prefetcher read performance. This limits wasted space to at most 33% or the page size * the
     // number of banks, whichever is smaller.

--- a/tt_metal/impl/trace/trace_buffer.hpp
+++ b/tt_metal/impl/trace/trace_buffer.hpp
@@ -17,6 +17,11 @@
 
 namespace tt::tt_metal {
 
+// Bounds on the interleaved trace buffer page size (see compute_interleaved_trace_buf_page_size).
+// Min is bounded by NOC transfer efficiency; max by the prefetcher CmdDatQ size.
+inline constexpr uint32_t kMinTraceBufPageSize = 1024;
+inline constexpr uint32_t kMaxTraceBufPageSize = 8192;
+
 // Forward decl to avoid including header
 class Buffer;
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes a trace-buffer OOM regression introduced by #47122 (Relates to #47122), which made `trace_region_size` the **total** trace budget across DRAM banks. Each bank reserves `ceil(trace_region_size / num_banks)` rounded up only to `dram_alignment`. For a small `trace_region_size`, that per-bank reservation can be smaller than a single trace page, so a trace whose total size fits the budget still fails to allocate: interleaving biases a trace's leading pages onto the low banks, and an occupied bank must hold a whole page.

This regressed `MeshEndToEnd2x4TraceTests.EltwiseAddTest` on `wh_llmbox` (T3K): with `trace_region_size = 3072` and 12 DRAM banks, per-bank reservation was `round_up(256, dram_alignment) = 256 B`, smaller than the 1024 B trace page → `Out of Memory: ... bank size is 256 B`.

Fix: round the per-bank reservation up to a whole multiple of the **max trace buffer page size** instead of `dram_alignment`, so each bank always holds a whole number of trace pages. The aggregate reservation (`per_bank_trace_size * num_banks`) stays `>= trace_region_size`. Large budgets (e.g. 64 MB) are unchanged.

The trace page-size bounds are exposed as `kMinTraceBufPageSize` / `kMaxTraceBufPageSize` in `trace_buffer.hpp` so the allocator and `compute_interleaved_trace_buf_page_size` share a single definition.

### Notes for reviewers
- The behavioral change is one line in `AllocatorImpl::init_one_bank_per_channel`: the `round_up` granularity for `per_bank_trace_size` goes from `config_->dram_alignment` to `kMaxTraceBufPageSize`. `kMaxTraceBufPageSize` (8192) is a multiple of `dram_alignment` on all supported archs, so alignment is preserved.
- `dispatch.cpp` is a no-op refactor: the local `kExecBufPageMin/Max` now alias the shared constants.
- Verified on Blackhole: `MeshTraceTestSuite.Sanity` (64 MB region) and `MeshTraceDynamicAllocationTestSuite` (`trace_region_size=0`) pass. The exact 2x4 WH T3K test could not be reproduced locally — the 8-card mesh fails fabric topology mapping in `SetUp()` on the available Blackhole box (unrelated to this change); CI on `t3000-unit-tests` should confirm.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/fix-trace-per-bank-rounding)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/fix-trace-per-bank-rounding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/fix-trace-per-bank-rounding)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/fix-trace-per-bank-rounding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/fix-trace-per-bank-rounding)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/fix-trace-per-bank-rounding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/fix-trace-per-bank-rounding)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/fix-trace-per-bank-rounding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/fix-trace-per-bank-rounding)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/fix-trace-per-bank-rounding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/fix-trace-per-bank-rounding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/fix-trace-per-bank-rounding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/fix-trace-per-bank-rounding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/fix-trace-per-bank-rounding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/fix-trace-per-bank-rounding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/fix-trace-per-bank-rounding)