### PR TITLE
Bug fix: watcher accept RUN_MSG_REPLAY_TRACE and RUN_MSG_RESET_READ_PTR_FROM_HOST run states

### DIFF
--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -903,6 +903,10 @@ void WatcherDeviceReader::Core::DumpRunState(uint32_t state) const {
         code = 'D';
     } else if (state == dev_msgs::RUN_MSG_RESET_READ_PTR) {
         code = 'R';
+    } else if (state == dev_msgs::RUN_MSG_RESET_READ_PTR_FROM_HOST) {
+        code = 'H';
+    } else if (state == dev_msgs::RUN_MSG_REPLAY_TRACE) {
+        code = 'T';
     } else if (state == dev_msgs::RUN_SYNC_MSG_LOAD) {
         code = 'L';
     } else if (state == dev_msgs::RUN_SYNC_MSG_WAITING_FOR_RESET) {
@@ -913,14 +917,19 @@ void WatcherDeviceReader::Core::DumpRunState(uint32_t state) const {
     if (code == 'U') {
         LogRunningKernels();
         TT_THROW(
-            "Watcher data corruption, unexpected run state on core{}: {} (expected {}, {}, {}, {}, or {})",
+            "Watcher data corruption, unexpected run state on core{}: {} (expected {}, {}, {}, {}, {}, {}, {}, {}, or "
+            "{})",
             virtual_coord_.str(),
             state,
             dev_msgs::RUN_MSG_INIT,
             dev_msgs::RUN_MSG_GO,
             dev_msgs::RUN_MSG_DONE,
+            dev_msgs::RUN_MSG_RESET_READ_PTR,
+            dev_msgs::RUN_MSG_RESET_READ_PTR_FROM_HOST,
+            dev_msgs::RUN_MSG_REPLAY_TRACE,
             dev_msgs::RUN_SYNC_MSG_LOAD,
-            dev_msgs::RUN_SYNC_MSG_WAITING_FOR_RESET);
+            dev_msgs::RUN_SYNC_MSG_WAITING_FOR_RESET,
+            dev_msgs::RUN_SYNC_MSG_INIT_SYNC_REGISTERS);
     } else {
         fprintf(reader_.f, "%c", code);
     }


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`WatcherDeviceReader::Core::DumpRunState` maps each known go-message `signal` to a status character and throws a "Watcher data corruption" error for any unrecognized value. The recognized set omitted two signals that firmware legitimately writes to `go_messages[...].signal` during its go-message wait loop (`brisc.cc` / `dm.cc` / `erisc.cc` / `active_erisc.cc`):

- `RUN_MSG_REPLAY_TRACE` (0xf0)
- `RUN_MSG_RESET_READ_PTR_FROM_HOST` (0xe0)

As a result, any time watcher sampled a core while it was processing a trace-replay (or host read-ptr reset) signal, it false-positived a corruption throw and killed the run — i.e. watcher was incompatible with trace replay.

This adds both signals to the status-code mapping (`'T'` for replay-trace, `'H'` for reset-read-ptr-from-host) and corrects the throw's "expected ..." message, which had only listed 5 of the 7 then-handled states.

The host-side validator in `llrt.cpp` (`check_if_riscs_on_specified_core_done`) is generic — it compares against the caller-supplied `run_state` plus `RUN_MSG_DONE` — so it did not have the same hardcoded-list problem and needed no change.

### Notes for reviewers
The status character `'H'` chosen for `RUN_MSG_RESET_READ_PTR_FROM_HOST` is distinct from `'R'` (`RUN_MSG_RESET_READ_PTR`), but note `DumpLaunchMessage` already prints `H`/`D` for the dispatch *mode* (`rmsg:H...`) immediately before this run-state char. The run-state position is unambiguous by column, but if a non-overlapping glyph is preferred it's a trivial swap.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/watcher-allow-replay-trace-run-state)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/watcher-allow-replay-trace-run-state)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/watcher-allow-replay-trace-run-state)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/watcher-allow-replay-trace-run-state)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/watcher-allow-replay-trace-run-state)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/watcher-allow-replay-trace-run-state)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/watcher-allow-replay-trace-run-state)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/watcher-allow-replay-trace-run-state)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/watcher-allow-replay-trace-run-state)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/watcher-allow-replay-trace-run-state)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/watcher-allow-replay-trace-run-state)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/watcher-allow-replay-trace-run-state)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/watcher-allow-replay-trace-run-state)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/watcher-allow-replay-trace-run-state)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/watcher-allow-replay-trace-run-state)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/watcher-allow-replay-trace-run-state)