### PR TITLE
sweep: device-perf via modern Tracy C++ post-process API (multi-chip support)

### DIFF
--- a/tests/sweep_framework/sweep_utils/perf_utils.py
+++ b/tests/sweep_framework/sweep_utils/perf_utils.py
@@ -1,3 +1,5 @@
+import os
+
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
 # SPDX-License-Identifier: Apache-2.0
@@ -18,9 +20,12 @@ from sweep_utils.roofline_utils import get_updated_message
 DEVICE_PERF_KEYS = [
     "DEVICE FW DURATION [ns]",
     "DEVICE KERNEL DURATION [ns]",
-    "OP TO OP LATENCY [ns]",
-    "DEVICE BRISC FW DURATION [ns]",
-    "DEVICE NCRISC FW DURATION [ns]",
+    "DEVICE BRISC KERNEL DURATION [ns]",
+    "DEVICE NCRISC KERNEL DURATION [ns]",
+    "DEVICE TRISC0 KERNEL DURATION [ns]",
+    "DEVICE TRISC1 KERNEL DURATION [ns]",
+    "DEVICE TRISC2 KERNEL DURATION [ns]",
+    "CORE COUNT",
 ]
 
 
@@ -45,55 +50,68 @@ def clear_disk_kernel_cache() -> None:
         logger.warning(f"Failed to clear disk kernel cache: {e}")
 
 
+def _resolve_perf_device(device, test_module):
+    # model_traced ops open their own mesh device inside run() (fixture yields
+    # None); fall back to the device the module opened so the profiler read
+    # targets the real device.
+    if device is not None:
+        return device
+    for _name in ("_CUR_DEVICE", "_CONV_DEV"):
+        d = getattr(test_module, _name, None)
+        if d is not None:
+            return d
+    return None
+
+
 def gather_single_test_perf(device, test_passed):
-    if device is None or device.get_num_devices() > 1:
-        logger.error("Multi-device perf is not supported. Failing.")
+    if device is None:
+        logger.error("Device perf: no device available. Failing.")
+        return None
+    if os.environ.get("TT_METAL_DEVICE_PROFILER") != "1":
         return None
 
-    # Read profiler data from device
-    logger.info("Reading profiler data from device")
     import ttnn
 
+    # Modern Tracy flow: ReadDeviceProfiler triggers the C++ post-process
+    # (TT_METAL_PROFILER_CPP_POST_PROCESS=1), then get_latest_programs_perf_data()
+    # returns per-chip analysis results in memory (no CSV). Works on multi-chip
+    # meshes (T3K / galaxy); the legacy CSV path only worked single-chip and host-
+    # read remote chips mid-run -> inter-chip ethernet timeout.
+    logger.info("Reading profiler data from device")
     ttnn.ReadDeviceProfiler(device)
     logger.info("Reading profiler data from device done")
-    try:
-        opPerfData = get_device_data_generate_report(
-            PROFILER_LOGS_DIR, None, None, None, export_csv=False, cleanup_device_log=True
-        )
-    except Exception as e:
-        logger.warning(f"Failed to get device profiler data: {e}")
-        opPerfData = []
 
     if not test_passed:
         return None
-    elif opPerfData == []:
-        logger.warning("No profiling data available. Using dummy data for testing purposes.")
 
-        dummy_data = {
-            "DEVICE FW DURATION [ns]": 0,
-            "DEVICE KERNEL DURATION [ns]": 0,
-            "OP TO OP LATENCY [ns]": 0,
-            "DEVICE BRISC FW DURATION [ns]": 0,
-            "DEVICE NCRISC FW DURATION [ns]": 0,
-        }
-        return dummy_data
-    elif len(opPerfData) > 1:
-        logger.info("Composite op detected in device perf measurement. Will aggregate results.")
-        try:
-            for key in opPerfData[0].keys():
-                value = opPerfData[0][key]
-                for i in range(1, len(opPerfData)):
-                    if key in opPerfData[i]:
-                        if type(value) == str:
-                            opPerfData[0][key] = str(float(value) + float(opPerfData[i][key]))
-                        else:
-                            opPerfData[0][key] = value + opPerfData[i][key]
-            return opPerfData[0]
-        except Exception as e:
-            logger.info(e)
-            return None
-    else:
-        return opPerfData[0]
+    try:
+        from ttnn._ttnn import profiler as _ttnn_profiler
+
+        perf_by_chip = _ttnn_profiler.get_latest_programs_perf_data()
+    except Exception as e:
+        logger.warning(f"Failed to get device profiler data: {e}")
+        return None
+
+    if not perf_by_chip:
+        logger.warning("No profiling data available.")
+        return None
+
+    # The op is replicated/sharded across the mesh; aggregate each analysis as the
+    # max across chips (the bottleneck chip = the real op latency).
+    aggregated = {}
+    core_count = 0
+    for _chip, programs in perf_by_chip.items():
+        for program in programs:
+            core_count = max(core_count, int(getattr(program, "core_count", 0) or 0))
+            for name, result in program.program_analyses_results.items():
+                aggregated[name] = max(aggregated.get(name, 0), int(result.duration))
+
+    if not aggregated:
+        logger.warning("No profiling analyses available.")
+        return None
+
+    aggregated["CORE COUNT"] = core_count
+    return aggregated
 
 
 def prepare_program_cache_for_comparison(device) -> None:
@@ -186,7 +204,7 @@ def run_with_cache_comparison(
 
     device_perf_uncached = None
     if getattr(config, "measure_device_perf", False):
-        device_perf_uncached = gather_single_test_perf(device, status_uncached)
+        device_perf_uncached = gather_single_test_perf(_resolve_perf_device(device, test_module), status_uncached)
         # Clear the profiler log file for the next run to isolate device perf measurements
         from tracy.common import PROFILER_LOGS_DIR, PROFILER_DEVICE_SIDE_LOG
         import os as _os
@@ -200,7 +218,7 @@ def run_with_cache_comparison(
 
     device_perf_cached = None
     if getattr(config, "measure_device_perf", False):
-        device_perf_cached = gather_single_test_perf(device, status_cached)
+        device_perf_cached = gather_single_test_perf(_resolve_perf_device(device, test_module), status_cached)
 
     # Determine combined status and message
     if not status_uncached:
@@ -258,7 +276,7 @@ def run_single(
         peak_memory = capture_peak_memory(test_module, test_vector, device, use_no_dispatch=True)
 
     if getattr(config, "measure_device_perf", False):
-        perf_result = gather_single_test_perf(device, status)
+        perf_result = gather_single_test_perf(_resolve_perf_device(device, test_module), status)
         message = get_updated_message(message, perf_result)
         simplified_perf = simplify_device_perf(perf_result)
         return status, message, e2e_ms, simplified_perf, peak_memory

--- a/tests/sweep_framework/sweep_utils/perf_utils.py
+++ b/tests/sweep_framework/sweep_utils/perf_utils.py
@@ -1,9 +1,8 @@
-import os
-
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import inspect
 import subprocess
 import shutil

--- a/tests/sweep_framework/sweep_utils/perf_utils.py
+++ b/tests/sweep_framework/sweep_utils/perf_utils.py
@@ -48,16 +48,12 @@ def clear_disk_kernel_cache() -> None:
 
 
 def _resolve_perf_device(device, test_module):
-    # model_traced ops open their own mesh device inside run() (fixture yields
-    # None); fall back to the device the module opened so the profiler read
-    # targets the real device.
+    # Some model_traced ops (e.g. paged SDPA) open their own mesh device inside
+    # run() (the fixture yields None); fall back to the module's _CUR_DEVICE so
+    # the profiler read targets the real device.
     if device is not None:
         return device
-    for _name in ("_CUR_DEVICE", "_CONV_DEV"):
-        d = getattr(test_module, _name, None)
-        if d is not None:
-            return d
-    return None
+    return getattr(test_module, "_CUR_DEVICE", None)
 
 
 def gather_single_test_perf(device, test_passed):
@@ -82,9 +78,7 @@ def gather_single_test_perf(device, test_passed):
         return None
 
     try:
-        from ttnn._ttnn import profiler as _ttnn_profiler
-
-        perf_by_chip = _ttnn_profiler.get_latest_programs_perf_data()
+        perf_by_chip = ttnn.get_latest_programs_perf_data()
     except Exception as e:
         logger.warning(f"Failed to get device profiler data: {e}")
         return None
@@ -93,15 +87,26 @@ def gather_single_test_perf(device, test_passed):
         logger.warning("No profiling data available.")
         return None
 
-    # The op is replicated/sharded across the mesh; aggregate each analysis as the
-    # max across chips (the bottleneck chip = the real op latency).
-    aggregated = {}
+    # Aggregate per distinct device program, keyed by its execution uid. Each
+    # program is replicated across the mesh, so take the max across chips (the
+    # bottleneck chip = that program's real latency). A single op may decompose
+    # into several device programs (composite op), so sum each analysis across the
+    # distinct programs -- matching the legacy CSV path's composite-op summation.
+    per_program: Dict[Any, Dict[str, int]] = {}
     core_count = 0
     for _chip, programs in perf_by_chip.items():
         for program in programs:
             core_count = max(core_count, int(getattr(program, "core_count", 0) or 0))
+            uid = program.program_execution_uid
+            key = (uid.runtime_id, uid.trace_id, uid.trace_id_counter)
+            slot = per_program.setdefault(key, {})
             for name, result in program.program_analyses_results.items():
-                aggregated[name] = max(aggregated.get(name, 0), int(result.duration))
+                slot[name] = max(slot.get(name, 0), int(result.duration))
+
+    aggregated: Dict[str, int] = {}
+    for slot in per_program.values():
+        for name, duration in slot.items():
+            aggregated[name] = aggregated.get(name, 0) + duration
 
     if not aggregated:
         logger.warning("No profiling analyses available.")

--- a/tests/sweep_framework/sweep_utils/perf_utils.py
+++ b/tests/sweep_framework/sweep_utils/perf_utils.py
@@ -11,8 +11,6 @@ from pathlib import Path
 from typing import Any, Optional, Tuple, Dict
 
 from framework.sweeps_logger import sweeps_logger as logger
-from tracy.common import PROFILER_LOGS_DIR
-from tracy.process_ops_logs import get_device_data_generate_report
 from sweep_utils.roofline_utils import get_updated_message
 
 
@@ -204,14 +202,10 @@ def run_with_cache_comparison(
 
     device_perf_uncached = None
     if getattr(config, "measure_device_perf", False):
+        # Each gather's ttnn.ReadDeviceProfiler refreshes the in-memory "latest"
+        # program perf data, so the cached run below reads its own data with no
+        # legacy CSV-log clearing needed.
         device_perf_uncached = gather_single_test_perf(_resolve_perf_device(device, test_module), status_uncached)
-        # Clear the profiler log file for the next run to isolate device perf measurements
-        from tracy.common import PROFILER_LOGS_DIR, PROFILER_DEVICE_SIDE_LOG
-        import os as _os
-
-        device_log_path = _os.path.join(PROFILER_LOGS_DIR, PROFILER_DEVICE_SIDE_LOG)
-        if _os.path.exists(device_log_path):
-            _os.remove(device_log_path)
 
     # Second run (with cache)
     status_cached, message_cached, e2e_cached_ms = execute_test(test_module, test_vector, device)

--- a/tests/sweep_framework/sweep_utils/perf_utils.py
+++ b/tests/sweep_framework/sweep_utils/perf_utils.py
@@ -48,12 +48,18 @@ def clear_disk_kernel_cache() -> None:
 
 
 def _resolve_perf_device(device, test_module):
-    # Some model_traced ops (e.g. paged SDPA) open their own mesh device inside
-    # run() (the fixture yields None); fall back to the module's _CUR_DEVICE so
-    # the profiler read targets the real device.
+    # Some model_traced ops (add/sdpa/paged_sdpa, conv2d) open their own mesh
+    # device inside run() (the fixture yields None) and cache it in a persistent
+    # module global that stays open across vectors. The global's name varies by
+    # module -- _CUR_DEVICE (add, sdpa, paged_sdpa) or _CONV_DEV (conv2d) -- so
+    # fall back through the known names to find the live device for the read.
     if device is not None:
         return device
-    return getattr(test_module, "_CUR_DEVICE", None)
+    for _name in ("_CUR_DEVICE", "_CONV_DEV"):
+        d = getattr(test_module, _name, None)
+        if d is not None:
+            return d
+    return None
 
 
 def gather_single_test_perf(device, test_passed):

--- a/tests/sweep_framework/sweeps_runner.py
+++ b/tests/sweep_framework/sweeps_runner.py
@@ -1088,6 +1088,10 @@ def enable_profiler():
     os.environ["TT_METAL_DEVICE_PROFILER"] = "1"
     os.environ["ENABLE_TRACY"] = "1"
     os.environ["TT_METAL_PROFILER_MID_RUN_DUMP"] = "1"
+    # C++ post-process exposes per-chip perf in memory via
+    # ttnn._ttnn.profiler.get_latest_programs_perf_data(); required for the
+    # modern (multi-chip-safe) device-perf read in perf_utils.gather_single_test_perf.
+    os.environ["TT_METAL_PROFILER_CPP_POST_PROCESS"] = "1"
     # TT_METAL_PROFILER_SYNC skipped: triggers syncAllDevices() on ETH cores,
     # which deadlocks on Galaxy due to residual fabric state between test iterations.
 
@@ -1097,6 +1101,7 @@ def disable_profiler():
     os.environ.pop("TT_METAL_DEVICE_PROFILER", None)
     os.environ.pop("ENABLE_TRACY", None)
     os.environ.pop("TT_METAL_PROFILER_MID_RUN_DUMP", None)
+    os.environ.pop("TT_METAL_PROFILER_CPP_POST_PROCESS", None)
     os.environ.pop("TT_METAL_PROFILER_SYNC", None)
 
 

--- a/tests/sweep_framework/sweeps_runner.py
+++ b/tests/sweep_framework/sweeps_runner.py
@@ -1092,8 +1092,6 @@ def enable_profiler():
     # ttnn._ttnn.profiler.get_latest_programs_perf_data(); required for the
     # modern (multi-chip-safe) device-perf read in perf_utils.gather_single_test_perf.
     os.environ["TT_METAL_PROFILER_CPP_POST_PROCESS"] = "1"
-    # TT_METAL_PROFILER_SYNC skipped: triggers syncAllDevices() on ETH cores,
-    # which deadlocks on Galaxy due to residual fabric state between test iterations.
 
 
 def disable_profiler():
@@ -1102,7 +1100,6 @@ def disable_profiler():
     os.environ.pop("ENABLE_TRACY", None)
     os.environ.pop("TT_METAL_PROFILER_MID_RUN_DUMP", None)
     os.environ.pop("TT_METAL_PROFILER_CPP_POST_PROCESS", None)
-    os.environ.pop("TT_METAL_PROFILER_SYNC", None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What
Migrate the sweep framework's device-perf measurement from the legacy CSV path to the modern Tracy C++ post-process API, which adds **multi-chip (T3K / galaxy) support**, and remove the now-dead legacy Tracy cruft.

### Why
The legacy path (`ttnn.ReadDeviceProfiler` → `tracy.process_ops_logs.get_device_data_generate_report`) is single-chip oriented:
- With `MID_RUN_DUMP` it host-reads remote chips' cores **mid-run** over the inter-chip ethernet → `Timeout waiting for Ethernet core service remote IO request` (SIGABRT) on T3K/galaxy.
- It produced no multi-chip numbers (empty CSV → dummy zeros).
- It was broken for `model_traced` ops, which open their own device inside `run()` (the fixture yields `None`) → `gather_single_test_perf` received `device=None` and bailed.

### How
- `enable_profiler` sets `TT_METAL_PROFILER_CPP_POST_PROCESS=1` (with `DEVICE_PROFILER` + `MID_RUN_DUMP`). The C++ post-process exposes per-chip results in memory, multi-chip-safe (no ethernet hang).
- `gather_single_test_perf` reads `ttnn._ttnn.profiler.get_latest_programs_perf_data()` (`map<chip,[ProgramAnalysisData]>`) instead of the CSV, aggregating each analysis as the max across chips (bottleneck chip = op latency).
- `_resolve_perf_device()` falls back to the module's self-opened device (`_CUR_DEVICE`/`_CONV_DEV`) when the fixture device is `None`.
- **Removed legacy Tracy cruft**: the dead `tracy.process_ops_logs` / `PROFILER_LOGS_DIR` imports, the obsolete CSV-clear block, and the `TT_METAL_PROFILER_SYNC` references (no longer a registered `rtoption`). Only current profiler env vars remain.

### `DEVICE_PERF_KEYS` change
Updated to the analysis names the modern in-memory API actually emits (per `tt_metal/tools/profiler/cpp_device_analyses.json`):
- **Added**: `DEVICE BRISC/NCRISC KERNEL DURATION`, `DEVICE TRISC0/1/2 KERNEL DURATION`, `CORE COUNT`.
- **Removed** (legacy-CSV-only, never produced by `get_latest_programs_perf_data()`):
  - `OP TO OP LATENCY [ns]` — a CSV column computed across consecutive rows at CSV-generation time, not a per-program analysis (and meaningless in a one-op-per-test sweep).
  - `DEVICE BRISC FW DURATION` / `DEVICE NCRISC FW DURATION` — the modern API has no per-RISC *FW* duration; the per-RISC **KERNEL** durations are the equivalent.

Note: `DEVICE_PERF_KEYS` is only the simplified-output filter — `gather_single_test_perf` already aggregates every analysis name into the full perf dict.

### Validation (T3K / config-t3000)
`conv2d --device-perf` returns real per-chip device kernel durations with **no hang**:
- 1x1: `DEVICE KERNEL DURATION 1286 ns`, CORE COUNT 1
- 1x8: `DEVICE KERNEL DURATION ~6.0 ms`, CORE COUNT 56 (≈ a 309 GFLOP 1024² conv → ~51 TFLOP/s effective), PCC 0.9998
- Post-cleanup re-validation on T3K 1x8 mesh via `run_with_cache_comparison`: real per-RISC numbers for both uncached and cached runs, CORE COUNT 64, no hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=Aswinmcw/sweep-device-perf-tracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/sweep-device-perf-tracy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=Aswinmcw/sweep-device-perf-tracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:Aswinmcw/sweep-device-perf-tracy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=Aswinmcw/sweep-device-perf-tracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:Aswinmcw/sweep-device-perf-tracy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/sweep-device-perf-tracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/sweep-device-perf-tracy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=Aswinmcw/sweep-device-perf-tracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:Aswinmcw/sweep-device-perf-tracy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/sweep-device-perf-tracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/sweep-device-perf-tracy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/sweep-device-perf-tracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/sweep-device-perf-tracy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/sweep-device-perf-tracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/sweep-device-perf-tracy)
