### PR TITLE
[skip ci] Skip test_pipeline_inference[wh_4x8sp1tp0-resolution_720p] on Wormhole Galaxy due to TLB alloc failure

### DIFF
--- a/models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py
@@ -79,6 +79,10 @@ def test_pipeline_inference(
     quant_config_name,
     no_prompt,
 ):
+    # Temporarily skip the wh_4x8sp1tp0 + resolution_720p combination on Wormhole Galaxy
+    # due to TLB allocation failure (tt_tlb_alloc error -12). refs #47184
+    if mesh_shape == (4, 8) and sp_axis == 1 and tp_axis == 0 and topology == ttnn.Topology.Ring and is_fsdp and height == 720:
+        pytest.skip("Skipping wh_4x8sp1tp0 resolution_720p on Wormhole Galaxy: TLB allocation failure, refs #47184")
     parent_mesh = mesh_device
     mesh_device = parent_mesh.create_submesh(ttnn.MeshShape(*mesh_shape))
 


### PR DESCRIPTION
The parametrized test `test_pipeline_inference[wormhole_b0-resolution_720p-wh_4x8sp1tp0-True]` has been failing for 7+ days on the Wormhole Galaxy CI runner with a `RuntimeError: Failed to allocate TLB window` (tt_tlb_alloc error -12). This PR adds a narrowly-scoped `pytest.skip()` inside the test body, guarded on exactly the failing parameter combination (mesh_shape=(4,8), sp_axis=1, tp_axis=0, Ring topology, is_fsdp=True, height=720) so that no other parametrizations or hardware targets are affected. refs #47184

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47184)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lifecycle/disable-issue-47184)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47184)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lifecycle/disable-issue-47184)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=lifecycle/disable-issue-47184)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:lifecycle/disable-issue-47184)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lifecycle/disable-issue-47184)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lifecycle/disable-issue-47184)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47184)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lifecycle/disable-issue-47184)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lifecycle/disable-issue-47184)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lifecycle/disable-issue-47184)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lifecycle/disable-issue-47184)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lifecycle/disable-issue-47184)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lifecycle/disable-issue-47184)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lifecycle/disable-issue-47184)