### PR TITLE
[skip ci] Skip WH Galaxy 4x8 720p t2v pipeline perf test, refs #46875

### DIFF
--- a/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
@@ -11,7 +11,7 @@ from loguru import logger
 from PIL import Image
 
 import ttnn
-from models.common.utility_functions import is_blackhole
+from models.common.utility_functions import is_blackhole, is_wormhole_b0
 from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
 from models.tt_dit.parallel.config import DiTParallelConfig, EncoderParallelConfig, VaeHWParallelConfig
 from models.tt_dit.pipelines.events import profiler_event_callback
@@ -196,6 +196,10 @@ def test_pipeline_performance(
 
     benchmark_profiler = BenchmarkProfiler()
     traced = mesh_shape == (4, 32)  # trace only for quadx32
+
+    # Skip WH 4x8 720p t2v - failing on Wormhole Galaxy, refs #46875
+    if is_wormhole_b0() and mesh_shape == (4, 8) and height == 720 and model_type == "t2v":
+        pytest.skip("Temporarily skipped on Wormhole Galaxy for 4x8 720p t2v, refs #46875")
 
     # Skip 4U.
     if galaxy_type == "4U":


### PR DESCRIPTION
The test `test_pipeline_performance[wormhole_b0-t2v-resolution_720p-wh_4x8_sp1tp0]` has been failing on the Wormhole Galaxy perf CI job for 7+ days. This PR adds a narrowly-scoped `pytest.skip()` inside the test body, guarded on `is_wormhole_b0() and mesh_shape == (4, 8) and height == 720 and model_type == "t2v"`, so only the exact failing parametrization on Wormhole hardware is skipped. All other parametrizations and hardware boards are unaffected. refs #46875

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-46875)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lifecycle/disable-issue-46875)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-46875)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lifecycle/disable-issue-46875)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=lifecycle/disable-issue-46875)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:lifecycle/disable-issue-46875)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lifecycle/disable-issue-46875)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lifecycle/disable-issue-46875)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lifecycle/disable-issue-46875)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lifecycle/disable-issue-46875)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lifecycle/disable-issue-46875)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lifecycle/disable-issue-46875)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lifecycle/disable-issue-46875)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lifecycle/disable-issue-46875)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lifecycle/disable-issue-46875)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lifecycle/disable-issue-46875)