### PR TITLE
[skip ci] Skip tile-padded Topology.Linear cases in test_nd on 2x4 WH mesh

### DIFF
--- a/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
@@ -1404,6 +1404,11 @@ def test_nd(mesh_device, input_shape, dim, cluster_axis, dtype, memory_config, t
         or (gather_dim_normalized == rank - 1 and tt_input.shape[-1] % tile_size != 0)
     )
 
+    if is_tile_padded and topology == ttnn.Topology.Linear:
+        pytest.skip(
+            "Tile-padded shapes with Topology.Linear produce wrong output TensorTopology on 2x4 mesh (PlacementReplicate instead of PlacementShard), refs #47181"
+        )
+
     input_topology = tt_input.tensor_topology()
 
     # Create expected topology based on which all-gather path was used


### PR DESCRIPTION
The `test_nd` parametrizations with tile-padded input shapes (last-two-dim size not divisible by 32) and `Topology.Linear` on a 2×4 Wormhole mesh have been failing for 7+ days. The output tensor's placement is `PlacementReplicate()` on the gather axis where `PlacementShard(0)` is expected.

This PR adds a targeted `pytest.skip()` inside `test_nd` guarded by `is_tile_padded and topology == ttnn.Topology.Linear`, which is the exact condition that triggers the bug. Only the 6 failing parametrizations are affected; all 79 passing cases continue to run.

Failing parametrizations (all on wormhole_b0 Galaxy 4×8 tray, mesh_device=(2,4)):
- `test_nd[...-Topology.Linear-1-0-...-input_shape7-...]`
- `test_nd[...-Topology.Linear-1-1-...-input_shape6-...]`
- `test_nd[...-Topology.Linear-1-1-...-input_shape7-...]`
- `test_nd[...-Topology.Linear-1-2-...-input_shape6-...]`
- `test_nd[...-Topology.Linear-1-3-...-input_shape5-...]`
- `test_nd[...-Topology.Linear-1-4-...-input_shape5-...]`

refs #47181

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47181)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lifecycle/disable-issue-47181)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47181)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lifecycle/disable-issue-47181)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=lifecycle/disable-issue-47181)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:lifecycle/disable-issue-47181)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lifecycle/disable-issue-47181)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lifecycle/disable-issue-47181)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47181)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lifecycle/disable-issue-47181)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lifecycle/disable-issue-47181)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lifecycle/disable-issue-47181)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lifecycle/disable-issue-47181)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lifecycle/disable-issue-47181)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lifecycle/disable-issue-47181)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lifecycle/disable-issue-47181)