### PR TITLE
ds_prefill - Combine operator changing layout of data processing to be expert-centric

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
@@ -54,15 +54,15 @@ _DISPATCH_REAL_INDICES_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
     ("ring", 2, 28, 1): 5_595_338,
 }
 _COMBINE_REAL_INDICES_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
-    # Re-centered to observed midpoint (same 16-run / 5-runner sample as dispatch above).
-    ("linear", 2, 27, 2): 12_015_238,
-    ("linear", 2, 38, 0): 8_353_550,
-    ("linear", 2, 50, 0): 8_515_742,
-    ("linear", 2, 28, 1): 12_191_696,
-    ("ring", 2, 27, 2): 11_506_808,
-    ("ring", 2, 38, 0): 6_168_426,
-    ("ring", 2, 50, 0): 6_306_488,
-    ("ring", 2, 28, 1): 10_286_688,
+    # Re-baselined to the 2026-06-24 measurement after a combine-kernel speedup.
+    ("linear", 2, 27, 2): 7_642_103,
+    ("linear", 2, 38, 0): 7_139_837,
+    ("linear", 2, 50, 0): 7_341_465,
+    ("linear", 2, 28, 1): 9_219_651,
+    ("ring", 2, 27, 2): 8_294_634,
+    ("ring", 2, 38, 0): 5_308_695,
+    ("ring", 2, 50, 0): 5_711_088,
+    ("ring", 2, 28, 1): 7_746_036,
 }
 
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -273,7 +273,7 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
     // + 2 fabric sems for middle chips, totaling 6 + k_s.  Excess untilizers assigned by the
     // initial split above are dropped: their row cores stay in the worker grid but get no
     // untilizer kernels.  k_s[i] = min(k_s[i], MAX_UNTILIZERS_PER_SENDER).
-    constexpr uint32_t MAX_UNTILIZERS_PER_SENDER = 5;
+    constexpr uint32_t MAX_UNTILIZERS_PER_SENDER = 4;
     {
         std::vector<CoreCoord> trimmed_all_untilizer_cores;
         std::vector<uint32_t> trimmed_untilizer_sender_map;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -777,15 +777,13 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
     {
         // Compile-time args layout for reader_untilize (matching reader_untilize.cpp):
         //   0-11: shared base (below, includes max_dispatch_buffer_token_size at 11)
-        //   12:   core_id   — local index within sender s's untilizer group (0..k_s-1)
-        //   13:   num_untilizer_cores — per-sender count k_s (for round-robin batch assignment)
-        //   14:   aligned_output_page_size
-        //   15:   aligned_experts_tok_counter_page_size
-        //   16:   cb_metadata_batch_id — CB this kernel pushes per-batch metadata pages into
-        //   17:   aligned_dispatched_metadata_page_size
-        //   18:   block_ct_dim — tiles per chunk pushed to cb_dispatched_buffer_id (matches the
+        //   12:   aligned_output_page_size
+        //   13:   aligned_experts_tok_counter_page_size
+        //   14:   cb_metadata_batch_id — CB this kernel pushes per-batch metadata pages into
+        //   15:   aligned_dispatched_metadata_page_size
+        //   16:   block_ct_dim — tiles per chunk pushed to cb_dispatched_buffer_id (matches the
         //                       compute kernel's per-block consumption)
-        //   19+:  TensorAccessorArgs for dispatched_buffer, then TensorAccessorArgs for
+        //   17+:  TensorAccessorArgs for dispatched_buffer, then TensorAccessorArgs for
         //         dispatched_metadata (no num_senders — single-sender kernel)
         // ROW_MAJOR dispatched_buffer has no tile spec; use the hardware tile dims so the
         // tile-aligned per-expert region math (start_token / tiles_per_batch) in reader_untilize
@@ -810,8 +808,8 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
         };
 
         // Partitioned untilizer cores: each sender s owns a dedicated group of k_s untilizer cores.
-        // core_id is LOCAL within the sender's group (0..k_s-1) for round-robin batch assignment.
-        // num_untilizer_cores baked in as k_s so the kernel only considers its own group.
+        // The global round-robin (untilizer_global_pos / total_untilizers, passed as runtime args)
+        // drives batch assignment, so the kernel no longer needs core_id / num_untilizer_cores.
         // No num_senders arg — each kernel is bound to a single sender.
         reader_untilize_kernel_ids.reserve(num_untilizer_cores);
 
@@ -820,18 +818,16 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
             uint32_t k_s = static_cast<uint32_t>(sender_untilizer_groups[s].size());
             for (uint32_t j = 0; j < k_s; j++, global_untilizer_idx++) {
                 auto per_core_args = reader_untilize_compile_time_args_base;
-                per_core_args.push_back(j);    // 12: core_id (local to sender s's group)
-                per_core_args.push_back(k_s);  // 13: num_untilizer_cores (per-sender)
-                per_core_args.push_back(detail::get_aligned_page_size(output_tensor));        // 14
-                per_core_args.push_back(detail::get_aligned_page_size(expert_token_counts));  // 15
-                per_core_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_9));  // 16: cb_metadata_batch_id
-                per_core_args.push_back(detail::get_aligned_page_size(dispatched_metadata));  // 17
-                per_core_args.push_back(block_ct_dim);                                        // 18: block_ct_dim
-                // 19: cb_counter_total_pages = full page capacity of c_1 on the untilizer
+                per_core_args.push_back(detail::get_aligned_page_size(output_tensor));        // 12
+                per_core_args.push_back(detail::get_aligned_page_size(expert_token_counts));  // 13
+                per_core_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_9));  // 14: cb_metadata_batch_id
+                per_core_args.push_back(detail::get_aligned_page_size(dispatched_metadata));  // 15
+                per_core_args.push_back(block_ct_dim);                                        // 16: block_ct_dim
+                // 17: cb_counter_total_pages = full page capacity of c_1 on the untilizer
                 // (counter pages + trailer page). Passed so reader_untilize can reserve / push /
                 // wait the entire CB, not just the counter slice.
                 per_core_args.push_back(detail::get_num_pages(expert_token_counts) + 1);  // cb_counter_total_pages
-                // 20+: TensorAccessorArgs for dispatched_buffer + dispatched_metadata
+                // 18+: TensorAccessorArgs for dispatched_buffer + dispatched_metadata
                 tt::tt_metal::TensorAccessorArgs(dispatched_buffer.buffer()).append_to(per_core_args);
                 tt::tt_metal::TensorAccessorArgs(dispatched_metadata.buffer()).append_to(per_core_args);
 
@@ -1133,7 +1129,6 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
             // forward c_2 rows to the sender, so these args are always pushed.
             {
                 uint32_t s = untilizer_sender_map[untilizer_idx];
-                uint32_t k_s = static_cast<uint32_t>(sender_untilizer_groups[s].size());
                 // Every sender now processes EVERY expert (full range); the per-expert work is
                 // split across senders by data instead — sender s handles batch-chunk s of each
                 // expert (see sender_idx / num_senders below).
@@ -1152,7 +1147,6 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
                 writer_untilize_runtime_args.push_back(data_ready_semaphore_ids[s][local_core_id]);
                 writer_untilize_runtime_args.push_back(credits_semaphore_ids[s][local_core_id]);
                 writer_untilize_runtime_args.push_back(local_core_id);
-                writer_untilize_runtime_args.push_back(k_s);           // num_untilizer_cores
                 writer_untilize_runtime_args.push_back(expert_start);  // expert_start_idx
                 writer_untilize_runtime_args.push_back(expert_end);    // expert_end_idx
                 writer_untilize_runtime_args.push_back(untilizer_global_pos[untilizer_idx]);  // global batch start

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -1101,8 +1101,11 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
             {
                 uint32_t s = untilizer_sender_map[untilizer_idx];
                 uint32_t k_s = static_cast<uint32_t>(sender_untilizer_groups[s].size());
-                uint32_t expert_start = s * experts_per_core_range;
-                uint32_t expert_end = std::min((s + 1) * experts_per_core_range, operation_attributes.experts_per_chip);
+                // Every sender now processes EVERY expert (full range); the per-expert work is
+                // split across senders by data instead — sender s handles batch-chunk s of each
+                // expert (see sender_idx / num_senders below).
+                uint32_t expert_start = 0;
+                uint32_t expert_end = operation_attributes.experts_per_chip;
                 // core_id = this untilizer core's local index within sender s's group (0..k_s-1).
                 uint32_t local_core_id = 0;
                 for (uint32_t j = 0; j < untilizer_idx; j++) {
@@ -1119,6 +1122,8 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
                 writer_untilize_runtime_args.push_back(k_s);           // num_untilizer_cores
                 writer_untilize_runtime_args.push_back(expert_start);  // expert_start_idx
                 writer_untilize_runtime_args.push_back(expert_end);    // expert_end_idx
+                writer_untilize_runtime_args.push_back(s);             // sender_idx (this group's data chunk)
+                writer_untilize_runtime_args.push_back(num_cores);     // num_senders (data chunks per expert)
             }
 
             desc.kernels[writer_untilize_kernel_id].emplace_runtime_args(
@@ -1128,8 +1133,11 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
 
     uint32_t core_idx = 0;
     for (const auto& sender_core : sender_cores) {
-        uint32_t expert_start = core_idx * experts_per_core_range;
-        uint32_t expert_end = std::min((core_idx + 1) * experts_per_core_range, operation_attributes.experts_per_chip);
+        // Sender kernels (reader_combine / writer_combine) are expert-range agnostic — they only
+        // poll their untilizer group's receive_buf and fabric-forward whatever rows arrive — so
+        // they get the full expert range now that the per-expert split is by data, not by expert.
+        uint32_t expert_start = 0;
+        uint32_t expert_end = operation_attributes.experts_per_chip;
 
         // Reader RT args.  Tensor buffer addresses are pushed as Buffer* so the
         // framework records BufferBindings for the O(1) cache-hit fast path.
@@ -1269,8 +1277,11 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
         for (uint32_t j = 0; j < num_untilizer_cores; j++) {
             uint32_t s = untilizer_sender_map[j];
             uint32_t k_s = static_cast<uint32_t>(sender_untilizer_groups[s].size());
-            uint32_t expert_start = s * experts_per_core_range;
-            uint32_t expert_end = std::min((s + 1) * experts_per_core_range, operation_attributes.experts_per_chip);
+            // Full expert range on every untilizer core; the per-expert work is split across
+            // senders by data — sender s's group handles batch-chunk s of each expert (sender_idx /
+            // num_senders below), then round-robins those batches across its k_s untilizer cores.
+            uint32_t expert_start = 0;
+            uint32_t expert_end = operation_attributes.experts_per_chip;
             // local_core_id: this untilizer's index within sender s's group, found by counting prior
             // untilizer_idxs that map to the same sender (untilizer_row_cores is grouped by sender).
             uint32_t local_core_id = 0;
@@ -1279,9 +1290,9 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
                     local_core_id++;
                 }
             }
-            // Reader_untilize RT args (5):
+            // Reader_untilize RT args (7):
             //   [0]: counter_ready_sem, [1]: dispatched_buffer*, [2]: expert_start,
-            //   [3]: expert_end,        [4]: dispatched_metadata*.
+            //   [3]: expert_end,        [4]: dispatched_metadata*, [5]: sender_idx, [6]: num_senders.
             // Buffers pushed as Buffer* so the framework records BufferBindings for the
             // cache-hit fast path.
             tt::tt_metal::KernelDescriptor::RTArgList untilizer_rt_args;
@@ -1290,19 +1301,24 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
             untilizer_rt_args.push_back(expert_start);
             untilizer_rt_args.push_back(expert_end);
             untilizer_rt_args.push_back(dispatched_metadata.buffer());
+            untilizer_rt_args.push_back(s);          // sender_idx (this group's data chunk)
+            untilizer_rt_args.push_back(num_cores);  // num_senders (data chunks per expert)
             desc.kernels[reader_untilize_kernel_ids[j]].emplace_runtime_args(
                 untilizer_row_cores[j], untilizer_rt_args);
 
             // Compute kernel walks the same expert/batch iteration as reader_untilize and
             // writer_untilize (no per-batch signal CB).  Per-sender k_s + local_core_id drive
-            // round-robin batch assignment within the group.  TILE_LAYOUT only — ROW_MAJOR has
-            // no compute kernel (reader_untilize writes rows straight into c_2).
+            // round-robin batch assignment within the group; sender_idx / num_senders select this
+            // group's data chunk within each expert.  TILE_LAYOUT only — ROW_MAJOR has no compute
+            // kernel (reader_untilize writes rows straight into c_2).
             if (is_tile_layout) {
                 tt::tt_metal::KernelDescriptor::RTArgList compute_rt_args;
                 compute_rt_args.push_back(expert_start);
                 compute_rt_args.push_back(expert_end);
                 compute_rt_args.push_back(local_core_id);
                 compute_rt_args.push_back(k_s);
+                compute_rt_args.push_back(s);          // sender_idx (this group's data chunk)
+                compute_rt_args.push_back(num_cores);  // num_senders (data chunks per expert)
                 desc.kernels[untilize_compute_kernel_id].emplace_runtime_args(untilizer_row_cores[j], compute_rt_args);
             }
         }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -1065,6 +1065,39 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
         sender_noc_coords.emplace_back(noc_coord.x, noc_coord.y);
     }
 
+    // Global interleaved position of each untilizer core in rank-major / sender-minor order
+    // [S0.U0, S1.U0, S0.U1, S1.U1, …]: every untilizer core processes batches global_pos, +G,
+    // +2G, … of every expert (G = num_untilizer_cores, the total untilizer-core count).  Spreading
+    // consecutive batches of an expert across senders keeps either sender's forwarder from getting
+    // a monopoly of local (or remote) rows regardless of how dispatch clustered them; each sender's
+    // batch share is proportional to its untilizer-core count.  Indexed by untilizer idx so both
+    // the writer_untilize loop and the reader_untilize/compute loop below agree on the same value.
+    std::vector<uint32_t> untilizer_global_pos(num_untilizer_cores, 0);
+    {
+        uint32_t max_k = 0;
+        for (uint32_t s = 0; s < num_cores; s++) {
+            max_k = std::max(max_k, static_cast<uint32_t>(sender_untilizer_groups[s].size()));
+        }
+        std::vector<std::vector<uint32_t>> pos_by_sender_rank(num_cores);
+        for (uint32_t s = 0; s < num_cores; s++) {
+            pos_by_sender_rank[s].resize(sender_untilizer_groups[s].size());
+        }
+        uint32_t pos = 0;
+        for (uint32_t r = 0; r < max_k; r++) {
+            for (uint32_t s = 0; s < num_cores; s++) {
+                if (r < sender_untilizer_groups[s].size()) {
+                    pos_by_sender_rank[s][r] = pos++;
+                }
+            }
+        }
+        std::vector<uint32_t> rank_counter(num_cores, 0);
+        for (uint32_t idx = 0; idx < num_untilizer_cores; idx++) {
+            uint32_t s = untilizer_sender_map[idx];
+            uint32_t r = rank_counter[s]++;
+            untilizer_global_pos[idx] = pos_by_sender_rank[s][r];
+        }
+    }
+
     // Set runtime args for hybrid untilizer row cores.  Three layouts are possible:
     //   init_zeros && tile_layout: [output_addr, page_start, page_end, output_init_done_sem,
     //                               (sender_noc_x, sender_noc_y) * num_cores,
@@ -1122,8 +1155,8 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
                 writer_untilize_runtime_args.push_back(k_s);           // num_untilizer_cores
                 writer_untilize_runtime_args.push_back(expert_start);  // expert_start_idx
                 writer_untilize_runtime_args.push_back(expert_end);    // expert_end_idx
-                writer_untilize_runtime_args.push_back(s);             // sender_idx (this group's data chunk)
-                writer_untilize_runtime_args.push_back(num_cores);     // num_senders (data chunks per expert)
+                writer_untilize_runtime_args.push_back(untilizer_global_pos[untilizer_idx]);  // global batch start
+                writer_untilize_runtime_args.push_back(num_untilizer_cores);                  // global batch stride (G)
             }
 
             desc.kernels[writer_untilize_kernel_id].emplace_runtime_args(
@@ -1301,8 +1334,8 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
             untilizer_rt_args.push_back(expert_start);
             untilizer_rt_args.push_back(expert_end);
             untilizer_rt_args.push_back(dispatched_metadata.buffer());
-            untilizer_rt_args.push_back(s);          // sender_idx (this group's data chunk)
-            untilizer_rt_args.push_back(num_cores);  // num_senders (data chunks per expert)
+            untilizer_rt_args.push_back(untilizer_global_pos[j]);  // global batch start
+            untilizer_rt_args.push_back(num_untilizer_cores);      // global batch stride (G)
             desc.kernels[reader_untilize_kernel_ids[j]].emplace_runtime_args(
                 untilizer_row_cores[j], untilizer_rt_args);
 
@@ -1317,8 +1350,8 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
                 compute_rt_args.push_back(expert_end);
                 compute_rt_args.push_back(local_core_id);
                 compute_rt_args.push_back(k_s);
-                compute_rt_args.push_back(s);          // sender_idx (this group's data chunk)
-                compute_rt_args.push_back(num_cores);  // num_senders (data chunks per expert)
+                compute_rt_args.push_back(untilizer_global_pos[j]);  // global batch start
+                compute_rt_args.push_back(num_untilizer_cores);      // global batch stride (G)
                 desc.kernels[untilize_compute_kernel_id].emplace_runtime_args(untilizer_row_cores[j], compute_rt_args);
             }
         }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/compute/untilize_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/compute/untilize_combine.cpp
@@ -39,8 +39,9 @@
 //   1: expert_end_idx                  - one past the last expert handled (now experts_per_chip)
 //   2: core_id                         - local index in the owning sender's untilizer group (0..k_s-1)
 //   3: num_untilizer_cores                  - k_s, size of the owning sender's untilizer group
-//   4: sender_idx                      - owning-sender index; selects this group's batch-chunk per expert
-//   5: num_senders                     - number of senders (data chunks each expert is split into)
+//   4: untilizer_global_pos            - this core's position in the global interleaved untilizer
+//                                        ordering; its batches are global_pos, +G, +2G, … per expert
+//   5: total_untilizers                - G, total untilizer cores across all senders (global stride)
 void kernel_main() {
     constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(0);
     constexpr uint32_t cb_in_id = get_compile_time_arg_val(1);
@@ -63,8 +64,11 @@ void kernel_main() {
     uint32_t expert_end_idx = get_arg_val<uint32_t>(rt_idx++);
     uint32_t core_id = get_arg_val<uint32_t>(rt_idx++);
     uint32_t num_untilizer_cores = get_arg_val<uint32_t>(rt_idx++);
-    uint32_t sender_idx = get_arg_val<uint32_t>(rt_idx++);
-    uint32_t num_senders = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t untilizer_global_pos = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t total_untilizers = get_arg_val<uint32_t>(rt_idx++);
+    // core_id / num_untilizer_cores no longer drive batch assignment under the global round-robin.
+    (void)core_id;
+    (void)num_untilizer_cores;
 
     compute_kernel_hw_startup(cb_in_id, cb_untilize_id);
     pack_untilize_init<block_ct_dim, full_ct_dim>(cb_in_id, cb_untilize_id);
@@ -103,21 +107,10 @@ void kernel_main() {
 
         uint32_t actual_batches = (expert_tokens + read_batch_size - 1) / read_batch_size;
 
-        // Data split across senders: this group processes only its contiguous batch-chunk
-        // [sender_batch_start, sender_batch_end) of every expert (chunk sender_idx of num_senders).
-        // Must match reader_untilize / writer_untilize exactly so the c_0 / c_2 producer-consumer
-        // protocol stays in lockstep.
-        uint32_t batches_per_sender = (actual_batches + num_senders - 1) / num_senders;
-        uint32_t sender_batch_start = sender_idx * batches_per_sender;
-        uint32_t sender_batch_end = sender_batch_start + batches_per_sender;
-        if (sender_batch_end > actual_batches) {
-            sender_batch_end = actual_batches;
-        }
-
-        // Round-robin within the owning sender's untilizer group over the chunk's batches:
-        // this core handles {sender_batch_start + core_id, + k_s, + 2k_s, ...}.
-        for (uint32_t batch_idx = sender_batch_start + core_id; batch_idx < sender_batch_end;
-             batch_idx += num_untilizer_cores) {
+        // Global round-robin: this core handles batches untilizer_global_pos, +G, +2G, … of every
+        // expert (G = total_untilizers across all senders).  Must match reader_untilize /
+        // writer_untilize exactly so the c_0 / c_2 producer-consumer protocol stays in lockstep.
+        for (uint32_t batch_idx = untilizer_global_pos; batch_idx < actual_batches; batch_idx += total_untilizers) {
             cb_reserve_back(cb_untilize_id, read_batch_size);
             for (uint32_t block = 0; block < num_blocks; block++) {
                 cb_wait_front(cb_in_id, block_ct_dim);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/compute/untilize_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/compute/untilize_combine.cpp
@@ -35,10 +35,12 @@
 //                                        for cb_wait_front on the multicasted CB
 //
 // Runtime args (per untilizer core):
-//   0: expert_start_idx                - first expert handled by the owning sender
-//   1: expert_end_idx                  - one past the last expert handled by the owning sender
+//   0: expert_start_idx                - first expert handled (now 0; every group handles all experts)
+//   1: expert_end_idx                  - one past the last expert handled (now experts_per_chip)
 //   2: core_id                         - local index in the owning sender's untilizer group (0..k_s-1)
 //   3: num_untilizer_cores                  - k_s, size of the owning sender's untilizer group
+//   4: sender_idx                      - owning-sender index; selects this group's batch-chunk per expert
+//   5: num_senders                     - number of senders (data chunks each expert is split into)
 void kernel_main() {
     constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(0);
     constexpr uint32_t cb_in_id = get_compile_time_arg_val(1);
@@ -61,6 +63,8 @@ void kernel_main() {
     uint32_t expert_end_idx = get_arg_val<uint32_t>(rt_idx++);
     uint32_t core_id = get_arg_val<uint32_t>(rt_idx++);
     uint32_t num_untilizer_cores = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t sender_idx = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t num_senders = get_arg_val<uint32_t>(rt_idx++);
 
     compute_kernel_hw_startup(cb_in_id, cb_untilize_id);
     pack_untilize_init<block_ct_dim, full_ct_dim>(cb_in_id, cb_untilize_id);
@@ -99,9 +103,21 @@ void kernel_main() {
 
         uint32_t actual_batches = (expert_tokens + read_batch_size - 1) / read_batch_size;
 
-        // Round-robin within the owning sender's untilizer group:
-        // this core handles batches {core_id, core_id + k_s, core_id + 2k_s, ...}.
-        for (uint32_t batch_idx = core_id; batch_idx < actual_batches; batch_idx += num_untilizer_cores) {
+        // Data split across senders: this group processes only its contiguous batch-chunk
+        // [sender_batch_start, sender_batch_end) of every expert (chunk sender_idx of num_senders).
+        // Must match reader_untilize / writer_untilize exactly so the c_0 / c_2 producer-consumer
+        // protocol stays in lockstep.
+        uint32_t batches_per_sender = (actual_batches + num_senders - 1) / num_senders;
+        uint32_t sender_batch_start = sender_idx * batches_per_sender;
+        uint32_t sender_batch_end = sender_batch_start + batches_per_sender;
+        if (sender_batch_end > actual_batches) {
+            sender_batch_end = actual_batches;
+        }
+
+        // Round-robin within the owning sender's untilizer group over the chunk's batches:
+        // this core handles {sender_batch_start + core_id, + k_s, + 2k_s, ...}.
+        for (uint32_t batch_idx = sender_batch_start + core_id; batch_idx < sender_batch_end;
+             batch_idx += num_untilizer_cores) {
             cb_reserve_back(cb_untilize_id, read_batch_size);
             for (uint32_t block = 0; block < num_blocks; block++) {
                 cb_wait_front(cb_in_id, block_ct_dim);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_untilize.cpp
@@ -8,11 +8,15 @@
 // The owning sender multicasts the expert token counts + its receive_buf_addr to this untilizer
 // core's group, then each untilizer core untilizes the tiles for its assigned expert batches.
 //
-// Expert range: each untilizer group handles experts [expert_start_idx, expert_end_idx) which maps
-// 1:1 to the owning sender's expert range.
+// Expert range: every untilizer group now handles EVERY expert [expert_start_idx, expert_end_idx) =
+// [0, experts_per_chip).  The work is split across senders by DATA: each expert's batches are
+// divided into num_senders contiguous chunks and the owning sender (sender_idx) handles chunk
+// sender_idx (e.g. with 2 senders, sender 0 does the first half of every expert, sender 1 the
+// second half).
 //
-// Batch splitting within the group: batches are distributed round-robin across the k_s untilizer
-// cores in the group.  Core i (local 0-based) processes batches i, i+k_s, i+2*k_s, …
+// Batch splitting within the group: the chunk's batches are distributed round-robin across the
+// k_s untilizer cores in the group.  Core i (local 0-based) processes the chunk's batches
+// i, i+k_s, i+2*k_s, …
 //
 // For each assigned batch:
 //   1. Read this batch's metadata pages from DRAM into cb_metadata_batch_id (consumed by
@@ -99,6 +103,9 @@ void kernel_main() {
     //   4: dispatched_metadata_addr    - DRAM base of the dispatched_metadata tensor; this kernel
     //                                    reads it locally so the sender no longer has to unicast
     //                                    per-batch metadata to this core
+    //   5: sender_idx                  - this untilizer group's owning-sender index; selects which
+    //                                    contiguous batch-chunk of each expert this group processes
+    //   6: num_senders                 - number of senders (data chunks each expert is split into)
     // (sender NOC coords, data_ready and start semaphores are now consumed by the
     //  writer_untilize kernel on the same core — they no longer belong here.)
     uint32_t rt_idx = 0;
@@ -107,6 +114,8 @@ void kernel_main() {
     uint32_t expert_start_idx = get_arg_val<uint32_t>(rt_idx++);
     uint32_t expert_end_idx = get_arg_val<uint32_t>(rt_idx++);
     uint32_t dispatched_metadata_addr = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t sender_idx = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t num_senders = get_arg_val<uint32_t>(rt_idx++);
 
     // ===== Step 1: Wait for the owning sender to multicast expert token counts + receive_buf_addr =====
     // Note: don't reset counter_ready_sem — writer_untilize on this same core also waits on it
@@ -167,14 +176,26 @@ void kernel_main() {
 
         uint32_t actual_batches = (expert_tokens + read_batch_size - 1) / read_batch_size;
 
-        // Round-robin batch assignment across the untilizer cores in this sender's group.
-        // Each untilizer core starts at its own core_id and strides by num_untilizer_cores, so:
-        //   core 0 processes batches 0, k, 2k, ...
-        //   core 1 processes batches 1, k+1, 2k+1, ...
-        //   core j processes batches j, j+k, j+2k, ...
-        // where k = num_untilizer_cores.  This spreads the work evenly and ensures the
-        // owning sender can predict which untilizer core handles each batch (batch_idx % k).
-        for (uint32_t batch_idx = core_id; batch_idx < actual_batches; batch_idx += num_untilizer_cores) {
+        // Data split across senders: every sender's group processes EVERY expert, but only a
+        // contiguous chunk of that expert's batches.  Split the batches into num_senders chunks
+        // (sender 0 -> first chunk, sender 1 -> next, ...) so sender_idx owns
+        // [sender_batch_start, sender_batch_end).
+        uint32_t batches_per_sender = (actual_batches + num_senders - 1) / num_senders;
+        uint32_t sender_batch_start = sender_idx * batches_per_sender;
+        uint32_t sender_batch_end = sender_batch_start + batches_per_sender;
+        if (sender_batch_end > actual_batches) {
+            sender_batch_end = actual_batches;
+        }
+
+        // Round-robin batch assignment WITHIN this sender's chunk across the untilizer cores in
+        // its group.  Each untilizer core starts at sender_batch_start + core_id and strides by
+        // num_untilizer_cores, so within the chunk:
+        //   core 0 processes the chunk's batches 0, k, 2k, ...
+        //   core 1 processes the chunk's batches 1, k+1, 2k+1, ...
+        // where k = num_untilizer_cores.  This spreads the work evenly and ensures the owning
+        // sender can predict which untilizer core handles each batch.
+        for (uint32_t batch_idx = sender_batch_start + core_id; batch_idx < sender_batch_end;
+             batch_idx += num_untilizer_cores) {
             uint32_t batch_tile_start = start_page_tiled + batch_idx * tiles_per_batch;
             uint32_t batch_token_start = batch_idx * read_batch_size;
             uint32_t batch_count = ((batch_token_start + read_batch_size) <= expert_tokens)

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_untilize.cpp
@@ -9,14 +9,12 @@
 // core's group, then each untilizer core untilizes the tiles for its assigned expert batches.
 //
 // Expert range: every untilizer group now handles EVERY expert [expert_start_idx, expert_end_idx) =
-// [0, experts_per_chip).  The work is split across senders by DATA: each expert's batches are
-// divided into num_senders contiguous chunks and the owning sender (sender_idx) handles chunk
-// sender_idx (e.g. with 2 senders, sender 0 does the first half of every expert, sender 1 the
-// second half).
-//
-// Batch splitting within the group: the chunk's batches are distributed round-robin across the
-// k_s untilizer cores in the group.  Core i (local 0-based) processes the chunk's batches
-// i, i+k_s, i+2*k_s, …
+// [0, experts_per_chip).  The work is split across ALL untilizer cores by DATA via one global
+// round-robin: each core has a global interleaved position (rank-major, sender-minor:
+// [S0.U0, S1.U0, S0.U1, S1.U1, …]) and processes batches global_pos, +G, +2G, … of every expert,
+// where G = total untilizer cores.  Consecutive batches of an expert thus fan out across senders,
+// so neither sender's forwarder gets a monopoly of local (or remote) rows however dispatch
+// clustered them; a sender's batch share is proportional to its untilizer-core count.
 //
 // For each assigned batch:
 //   1. Read this batch's metadata pages from DRAM into cb_metadata_batch_id (consumed by
@@ -103,9 +101,9 @@ void kernel_main() {
     //   4: dispatched_metadata_addr    - DRAM base of the dispatched_metadata tensor; this kernel
     //                                    reads it locally so the sender no longer has to unicast
     //                                    per-batch metadata to this core
-    //   5: sender_idx                  - this untilizer group's owning-sender index; selects which
-    //                                    contiguous batch-chunk of each expert this group processes
-    //   6: num_senders                 - number of senders (data chunks each expert is split into)
+    //   5: untilizer_global_pos        - this core's position in the global interleaved untilizer
+    //                                    ordering; its batches are global_pos, +G, +2G, … per expert
+    //   6: total_untilizers            - G, total untilizer cores across all senders (global stride)
     // (sender NOC coords, data_ready and start semaphores are now consumed by the
     //  writer_untilize kernel on the same core — they no longer belong here.)
     uint32_t rt_idx = 0;
@@ -114,8 +112,12 @@ void kernel_main() {
     uint32_t expert_start_idx = get_arg_val<uint32_t>(rt_idx++);
     uint32_t expert_end_idx = get_arg_val<uint32_t>(rt_idx++);
     uint32_t dispatched_metadata_addr = get_arg_val<uint32_t>(rt_idx++);
-    uint32_t sender_idx = get_arg_val<uint32_t>(rt_idx++);
-    uint32_t num_senders = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t untilizer_global_pos = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t total_untilizers = get_arg_val<uint32_t>(rt_idx++);
+    // core_id / num_untilizer_cores (CT args 12/13) are no longer used for batch assignment under
+    // the global round-robin; kept as compile-time args so the arg layout stays stable.
+    (void)core_id;
+    (void)num_untilizer_cores;
 
     // ===== Step 1: Wait for the owning sender to multicast expert token counts + receive_buf_addr =====
     // Note: don't reset counter_ready_sem — writer_untilize on this same core also waits on it
@@ -176,26 +178,11 @@ void kernel_main() {
 
         uint32_t actual_batches = (expert_tokens + read_batch_size - 1) / read_batch_size;
 
-        // Data split across senders: every sender's group processes EVERY expert, but only a
-        // contiguous chunk of that expert's batches.  Split the batches into num_senders chunks
-        // (sender 0 -> first chunk, sender 1 -> next, ...) so sender_idx owns
-        // [sender_batch_start, sender_batch_end).
-        uint32_t batches_per_sender = (actual_batches + num_senders - 1) / num_senders;
-        uint32_t sender_batch_start = sender_idx * batches_per_sender;
-        uint32_t sender_batch_end = sender_batch_start + batches_per_sender;
-        if (sender_batch_end > actual_batches) {
-            sender_batch_end = actual_batches;
-        }
-
-        // Round-robin batch assignment WITHIN this sender's chunk across the untilizer cores in
-        // its group.  Each untilizer core starts at sender_batch_start + core_id and strides by
-        // num_untilizer_cores, so within the chunk:
-        //   core 0 processes the chunk's batches 0, k, 2k, ...
-        //   core 1 processes the chunk's batches 1, k+1, 2k+1, ...
-        // where k = num_untilizer_cores.  This spreads the work evenly and ensures the owning
-        // sender can predict which untilizer core handles each batch.
-        for (uint32_t batch_idx = sender_batch_start + core_id; batch_idx < sender_batch_end;
-             batch_idx += num_untilizer_cores) {
+        // Global round-robin: this core handles batches untilizer_global_pos, +G, +2G, … of every
+        // expert (G = total_untilizers across all senders) — disjoint across cores, covering
+        // [0, actual_batches) exactly.  Must match writer_untilize / compute exactly so the
+        // c_0 / c_2 producer-consumer protocol stays in lockstep.
+        for (uint32_t batch_idx = untilizer_global_pos; batch_idx < actual_batches; batch_idx += total_untilizers) {
             uint32_t batch_tile_start = start_page_tiled + batch_idx * tiles_per_batch;
             uint32_t batch_token_start = batch_idx * read_batch_size;
             uint32_t batch_count = ((batch_token_start + read_batch_size) <= expert_tokens)

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_untilize.cpp
@@ -53,19 +53,17 @@ void kernel_main() {
     //   9: tile_height                           - tile height in rows (e.g. 32)
     //  10: tile_width                            - tile width in columns (e.g. 32)
     //  11: max_dispatch_buffer_token_size        - total per-chip dispatch buffer capacity (overflow guard)
-    //  12: core_id                               - local index within the owning sender's untilizer group (0-based)
-    //  13: num_untilizer_cores                        - size of the owning sender's untilizer group (k_s)
-    //  14: aligned_output_page_size              - aligned page size of output tensor (bytes per untilized row)
-    //  15: aligned_experts_tok_counter_page_size - aligned page size of expert_token_counts tensor
-    //  16: cb_metadata_batch_id                  - CB this kernel pushes per-batch metadata pages into
+    //  12: aligned_output_page_size              - aligned page size of output tensor (bytes per untilized row)
+    //  13: aligned_experts_tok_counter_page_size - aligned page size of expert_token_counts tensor
+    //  14: cb_metadata_batch_id                  - CB this kernel pushes per-batch metadata pages into
     //                                              (consumed by writer_untilize on the same core)
-    //  17: aligned_dispatched_metadata_page_size - aligned page size of dispatched_metadata tensor
-    //  18: block_ct_dim                          - tiles per chunk pushed to cb_dispatched_buffer_id;
+    //  15: aligned_dispatched_metadata_page_size - aligned page size of dispatched_metadata tensor
+    //  16: block_ct_dim                          - tiles per chunk pushed to cb_dispatched_buffer_id;
     //                                              matches the compute kernel's per-block consumption
     //                                              size so producer/consumer line up 1:1
-    //  19: cb_counter_total_pages                - full page capacity of c_1 (counter + trailer)
+    //  17: cb_counter_total_pages                - full page capacity of c_1 (counter + trailer)
     //                                              used for cb_reserve_back / cb_push_back / cb_wait_front
-    //  20+: TensorAccessorArgs for dispatched_buffer, then TensorAccessorArgs for dispatched_metadata
+    //  18+: TensorAccessorArgs for dispatched_buffer, then TensorAccessorArgs for dispatched_metadata
     constexpr uint32_t cb_experts_tok_counter_id = get_compile_time_arg_val(0);
     constexpr uint32_t experts_tok_counter_pages = get_compile_time_arg_val(1);
     constexpr uint32_t experts_per_chip = get_compile_time_arg_val(2);
@@ -78,15 +76,13 @@ void kernel_main() {
     constexpr uint32_t tile_height = get_compile_time_arg_val(9);
     constexpr uint32_t tile_width = get_compile_time_arg_val(10);
     constexpr uint32_t max_dispatch_buffer_token_size = get_compile_time_arg_val(11);
-    constexpr uint32_t core_id = get_compile_time_arg_val(12);
-    constexpr uint32_t num_untilizer_cores = get_compile_time_arg_val(13);
-    constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(14);
-    constexpr uint32_t aligned_experts_tok_counter_page_size = get_compile_time_arg_val(15);
-    constexpr uint32_t cb_metadata_batch_id = get_compile_time_arg_val(16);
-    constexpr uint32_t aligned_dispatched_metadata_page_size = get_compile_time_arg_val(17);
-    constexpr uint32_t block_ct_dim = get_compile_time_arg_val(18);
-    constexpr uint32_t cb_counter_total_pages = get_compile_time_arg_val(19);
-    constexpr auto dispatched_buffer_args = TensorAccessorArgs<20>();
+    constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(12);
+    constexpr uint32_t aligned_experts_tok_counter_page_size = get_compile_time_arg_val(13);
+    constexpr uint32_t cb_metadata_batch_id = get_compile_time_arg_val(14);
+    constexpr uint32_t aligned_dispatched_metadata_page_size = get_compile_time_arg_val(15);
+    constexpr uint32_t block_ct_dim = get_compile_time_arg_val(16);
+    constexpr uint32_t cb_counter_total_pages = get_compile_time_arg_val(17);
+    constexpr auto dispatched_buffer_args = TensorAccessorArgs<18>();
     constexpr auto dispatched_metadata_args =
         TensorAccessorArgs<dispatched_buffer_args.next_compile_time_args_offset()>();
 
@@ -114,10 +110,6 @@ void kernel_main() {
     uint32_t dispatched_metadata_addr = get_arg_val<uint32_t>(rt_idx++);
     uint32_t untilizer_global_pos = get_arg_val<uint32_t>(rt_idx++);
     uint32_t total_untilizers = get_arg_val<uint32_t>(rt_idx++);
-    // core_id / num_untilizer_cores (CT args 12/13) are no longer used for batch assignment under
-    // the global round-robin; kept as compile-time args so the arg layout stays stable.
-    (void)core_id;
-    (void)num_untilizer_cores;
 
     // ===== Step 1: Wait for the owning sender to multicast expert token counts + receive_buf_addr =====
     // Note: don't reset counter_ready_sem — writer_untilize on this same core also waits on it

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_untilize.cpp
@@ -144,10 +144,11 @@ void kernel_main() {
     //                                  back, atomically suck the value, and dec(-N).
     //   core_id                      - this untilizer's local index (0..k_s-1) inside the sender's
     //                                  group; used to pick our k_s-way slice of receive_buf.
-    //   num_untilizer_cores               - k_s, size of the owning sender's untilizer group (for round-robin)
+    //   num_untilizer_cores               - k_s, size of the owning sender's untilizer group
     //   expert_start_idx / expert_end_idx - expert range (now [0, experts_per_chip); every group does all experts)
-    //   sender_idx                        - owning-sender index; selects this group's batch-chunk per expert
-    //   num_senders                       - number of senders (data chunks each expert is split into)
+    //   untilizer_global_pos              - this core's position in the global interleaved untilizer
+    //                                       ordering; its batches are global_pos, +G, +2G, … per expert
+    //   total_untilizers                  - G, total untilizer cores across all senders (global stride)
     uint32_t counter_ready_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t sender_noc_x = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t sender_noc_y = get_arg_val<uint32_t>(rt_args_idx++);
@@ -157,8 +158,11 @@ void kernel_main() {
     uint32_t num_untilizer_cores = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t expert_start_idx = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t expert_end_idx = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t sender_idx = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t num_senders = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t untilizer_global_pos = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t total_untilizers = get_arg_val<uint32_t>(rt_args_idx++);
+    // num_untilizer_cores (k_s) no longer drives batch assignment under the global round-robin;
+    // core_id still selects this core's slice of the sender's receive_buf below.
+    (void)num_untilizer_cores;
 
     uint64_t sender_data_ready_noc_addr =
         get_noc_addr(sender_noc_x, sender_noc_y, get_semaphore(data_ready_semaphore_id));
@@ -231,19 +235,11 @@ void kernel_main() {
 
         uint32_t actual_batches = (expert_tokens + read_batch_size - 1) / read_batch_size;
 
-        // Data split across senders: this group processes only its contiguous batch-chunk
-        // [sender_batch_start, sender_batch_end) of every expert (chunk sender_idx of num_senders).
-        // Must match reader_untilize / compute exactly so the c_2 / c_9 producer-consumer protocol
-        // and the per-row routing stay in lockstep.
-        uint32_t batches_per_sender = (actual_batches + num_senders - 1) / num_senders;
-        uint32_t sender_batch_start = sender_idx * batches_per_sender;
-        uint32_t sender_batch_end = sender_batch_start + batches_per_sender;
-        if (sender_batch_end > actual_batches) {
-            sender_batch_end = actual_batches;
-        }
-
-        for (uint32_t batch_idx = sender_batch_start + core_id; batch_idx < sender_batch_end;
-             batch_idx += num_untilizer_cores) {
+        // Global round-robin: this core handles batches untilizer_global_pos, +G, +2G, … of every
+        // expert (G = total_untilizers across all senders).  Must match reader_untilize / compute
+        // exactly so the c_2 / c_9 producer-consumer protocol and the per-row routing stay in
+        // lockstep.
+        for (uint32_t batch_idx = untilizer_global_pos; batch_idx < actual_batches; batch_idx += total_untilizers) {
             uint32_t batch_token_start = batch_idx * read_batch_size;
             uint32_t batch_count = ((batch_token_start + read_batch_size) <= expert_tokens)
                                        ? read_batch_size

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_untilize.cpp
@@ -145,7 +145,9 @@ void kernel_main() {
     //   core_id                      - this untilizer's local index (0..k_s-1) inside the sender's
     //                                  group; used to pick our k_s-way slice of receive_buf.
     //   num_untilizer_cores               - k_s, size of the owning sender's untilizer group (for round-robin)
-    //   expert_start_idx / expert_end_idx - expert range owned by the sender (drives batch iteration)
+    //   expert_start_idx / expert_end_idx - expert range (now [0, experts_per_chip); every group does all experts)
+    //   sender_idx                        - owning-sender index; selects this group's batch-chunk per expert
+    //   num_senders                       - number of senders (data chunks each expert is split into)
     uint32_t counter_ready_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t sender_noc_x = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t sender_noc_y = get_arg_val<uint32_t>(rt_args_idx++);
@@ -155,6 +157,8 @@ void kernel_main() {
     uint32_t num_untilizer_cores = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t expert_start_idx = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t expert_end_idx = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t sender_idx = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t num_senders = get_arg_val<uint32_t>(rt_args_idx++);
 
     uint64_t sender_data_ready_noc_addr =
         get_noc_addr(sender_noc_x, sender_noc_y, get_semaphore(data_ready_semaphore_id));
@@ -227,7 +231,19 @@ void kernel_main() {
 
         uint32_t actual_batches = (expert_tokens + read_batch_size - 1) / read_batch_size;
 
-        for (uint32_t batch_idx = core_id; batch_idx < actual_batches; batch_idx += num_untilizer_cores) {
+        // Data split across senders: this group processes only its contiguous batch-chunk
+        // [sender_batch_start, sender_batch_end) of every expert (chunk sender_idx of num_senders).
+        // Must match reader_untilize / compute exactly so the c_2 / c_9 producer-consumer protocol
+        // and the per-row routing stay in lockstep.
+        uint32_t batches_per_sender = (actual_batches + num_senders - 1) / num_senders;
+        uint32_t sender_batch_start = sender_idx * batches_per_sender;
+        uint32_t sender_batch_end = sender_batch_start + batches_per_sender;
+        if (sender_batch_end > actual_batches) {
+            sender_batch_end = actual_batches;
+        }
+
+        for (uint32_t batch_idx = sender_batch_start + core_id; batch_idx < sender_batch_end;
+             batch_idx += num_untilizer_cores) {
             uint32_t batch_token_start = batch_idx * read_batch_size;
             uint32_t batch_count = ((batch_token_start + read_batch_size) <= expert_tokens)
                                        ? read_batch_size

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_untilize.cpp
@@ -144,7 +144,6 @@ void kernel_main() {
     //                                  back, atomically suck the value, and dec(-N).
     //   core_id                      - this untilizer's local index (0..k_s-1) inside the sender's
     //                                  group; used to pick our k_s-way slice of receive_buf.
-    //   num_untilizer_cores               - k_s, size of the owning sender's untilizer group
     //   expert_start_idx / expert_end_idx - expert range (now [0, experts_per_chip); every group does all experts)
     //   untilizer_global_pos              - this core's position in the global interleaved untilizer
     //                                       ordering; its batches are global_pos, +G, +2G, … per expert
@@ -155,14 +154,10 @@ void kernel_main() {
     uint32_t data_ready_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t credits_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t core_id = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t num_untilizer_cores = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t expert_start_idx = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t expert_end_idx = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t untilizer_global_pos = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t total_untilizers = get_arg_val<uint32_t>(rt_args_idx++);
-    // num_untilizer_cores (k_s) no longer drives batch assignment under the global round-robin;
-    // core_id still selects this core's slice of the sender's receive_buf below.
-    (void)num_untilizer_cores;
 
     uint64_t sender_data_ready_noc_addr =
         get_noc_addr(sender_noc_x, sender_noc_y, get_semaphore(data_ready_semaphore_id));


### PR DESCRIPTION
### Ticket 
https://github.com/tenstorrent/tt-metal/issues/47650

### What's changed
- **Before**: when there was more than one sender core, the experts on a chip were partitioned across senders — each sender processed a disjoint subset of experts in full. With 8 experts and 2 senders, sender 0 handled experts 0–3 and sender 1 handled experts 4–7. A single hot expert then landed entirely on one sender, leaving the other sender (and its untilizer cores) idle for most of the run.
- **Now**: every sender processes every expert, and each expert's data is spread across all untilizer cores (across both senders) by a single global round-robin. Each expert's tokens are grouped into batches; every untilizer core is given a global interleaved position p in [0, G) — rank-major, sender-minor ordering [S0.U0, S1.U0, S0.U1, S1.U1, …], where G is the total untilizer-core count — and processes batches p, p+G, p+2G, … of every expert. Consecutive batches of an expert therefore alternate across senders, so each sender forwards an interleaved sample of every expert's rows (its share is proportional to its untilizer-core count).
- This data-parallel split (rather than expert-parallel) is required to overlap combine with the routed-expert stage, and it removes two distinct sources of imbalance: a hot expert no longer pins work to one sender, and — unlike a contiguous per-sender slice of each expert — neither sender's forwarder can end up with a monopoly of local (or remote) rows when dispatch clusters same-destination tokens within an expert region. Untilize compute and per-expert loop overhead are spread evenly across all untilizer cores as well.

### Combine perf
`CombineDeviceOperation`, LB 8×1, 2 links. Δ vs committed `main` baseline (lower is faster):

| config | measured ns | baseline ns | Δ |
|---|--:|--:|--:|
| linear l27-col2 | 8,517,834 | 12,015,238 | −29.1% |
| linear l28-col1 | 9,018,851 | 12,191,696 | −26.0% |
| linear l50-col0 | 7,320,666 | 8,515,742 | −14.0% |
| linear l38-col0 | 7,240,485 | 8,353,550 | −13.3% |
| ring l28-col1 | 7,217,052 | 10,286,688 | −29.8% |
| ring l27-col2 | 8,387,019 | 11,506,808 | −27.1% |
| ring l50-col0 | 5,446,098 | 6,306,488 | −13.6% |
| ring l38-col0 | 5,425,495 | 6,168,426 | −12.0% |



### DeepSeek CI

- [x] [![(T3K) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=pmilojevic/combine-experts-change)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:pmilojevic/combine-experts-change)
- [x] [![(BH) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pmilojevic/combine-experts-change)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pmilojevic/combine-experts-change)
- [x] [![Demo SP
Release](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=pmilojevic/combine-experts-change)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:pmilojevic/combine-experts-change)
- [x] [![(Galaxy) DeepSeek Prefill
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=pmilojevic/combine-experts-change)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:pmilojevic/combine-experts-change)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pmilojevic/combine-experts-change)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pmilojevic/combine-experts-change)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pmilojevic/combine-experts-change)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pmilojevic/combine-experts-change)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pmilojevic/combine-experts-change)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pmilojevic/combine-experts-change)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilojevic/combine-experts-change)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilojevic/combine-experts-change)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pmilojevic/combine-experts-change)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pmilojevic/combine-experts-change)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pmilojevic/combine-experts-change)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pmilojevic/combine-experts-change)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pmilojevic/combine-experts-change)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pmilojevic/combine-experts-change)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pmilojevic/combine-experts-change)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pmilojevic/combine-experts-change)