### PR TITLE
Fix FP32 fuse-add path (FPU add to SFPU add) in pre-allgather Welford layernorm

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
@@ -942,10 +942,6 @@ def test_layernorm_pre_all_gather_welford_fp32_precision(device, inp_shape, offs
     ULP (~512) dwarfs the underlying randn variation (~1), so the variance signal is destroyed
     inside the add before welford runs.
     """
-    if use_residual:
-        pytest.xfail(
-            "FUSE_PRE_ADD TF32 floor on add_tiles: variance signal is destroyed inside the add before welford runs. Issue #45231."
-        )
 
     torch.manual_seed(0)
     torch_input = torch.randn(inp_shape, dtype=torch.float32) + offset

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
@@ -664,7 +664,7 @@ def test_layernorm_pre_all_gather_residual_mismatched_dtype(device, inp_dtype, r
     "op_name",
     ["layer_norm_pre_all_gather", "layer_norm"],
 )
-def test_residual_logical_shape_mismatch_rejected(device, op_name, inp_shape, res_shape):
+def test_residual_logical_shape_mismatch_rejected(device, op_name, inp_shape, res_shape, expect_error):
     """Residual with a different logical shape from the input must be rejected.
 
     If validation compares padded_shape, which is tile-aligned and can therefore
@@ -697,7 +697,7 @@ def test_residual_logical_shape_mismatch_rejected(device, op_name, inp_shape, re
         tt_memory_config=dram_memcfg,
     )
 
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "Input and residual logical and padded shapes must match"):
         if op_name == "layer_norm_pre_all_gather":
             ttnn.layer_norm_pre_all_gather(
                 tt_inp, residual_input_tensor=tt_res, dtype=ttnn.bfloat16, memory_config=dram_memcfg

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_pre_allgather_welford.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_pre_allgather_welford.cpp
@@ -17,6 +17,7 @@
 #include "api/compute/reduce.h"
 #include "api/compute/bcast.h"
 #include "api/compute/eltwise_binary.h"
+#include "api/compute/eltwise_binary_sfpu.h"
 #include "api/compute/layernorm.h"
 #include "api/compute/transpose.h"
 #include "api/compute/welford.h"
@@ -102,21 +103,39 @@ void kernel_main() {
             // --- Pre-add: cb_in0 + cb_res -> cb_inp (block tiles in one tile_regs scope) ---
             reconfig_data_format(cb_in0, cb_res);
             pack_reconfig_data_format(cb_inp);
-            add_tiles_init(cb_in0, cb_res);
             cb_wait_front(cb_in0, block.size());
             cb_wait_front(cb_res, block.size());
             cb_reserve_back(cb_inp, block.size());
-            tile_regs_acquire();
-            for (auto i : block.local()) {
-                add_tiles(cb_in0, cb_res, i, i, i);
-            }
-            tile_regs_commit();
-            tile_regs_wait();
-            for (auto i : block.local()) {
-                pack_tile(i, cb_inp);
+            if constexpr (welford_unpack_fp32_active) {
+                // SFPU path: copy_tile bypasses SrcA via UnpackToDestEn, preserving full FP32
+                copy_tile_to_dst_init_short(cb_in0);
+                for (auto i : block.local()) {
+                    tile_regs_acquire();
+                    copy_tile(cb_in0, i, 0);
+                    copy_tile_to_dst_init_short_with_dt(cb_in0, cb_res);
+                    copy_tile(cb_res, i, 1);
+                    add_binary_tile_init();
+                    add_binary_tile(0, 1, 0);
+                    tile_regs_commit();
+                    tile_regs_wait();
+                    pack_tile(0, cb_inp);
+                    tile_regs_release();
+                    copy_tile_to_dst_init_short_with_dt(cb_res, cb_in0);
+                }
+            } else {
+                add_tiles_init(cb_in0, cb_res);
+                tile_regs_acquire();
+                for (auto i : block.local()) {
+                    add_tiles(cb_in0, cb_res, i, i, i);
+                }
+                tile_regs_commit();
+                tile_regs_wait();
+                for (auto i : block.local()) {
+                    pack_tile(i, cb_inp);
+                }
+                tile_regs_release();
             }
             cb_push_back(cb_inp, block.size());
-            tile_regs_release();
             cb_pop_front(cb_in0, block.size());
             cb_pop_front(cb_res, block.size());
 
@@ -133,9 +152,17 @@ void kernel_main() {
             welford_restore_state(dst1);
 
             reconfig_data_format_srca(cb_m2_spill, cb_inp);
-            transpose_init(cb_inp);
+            if constexpr (!welford_unpack_fp32_active) {
+                transpose_init(cb_inp);
+            }
             for (auto i : block.local()) {
+                if constexpr (welford_unpack_fp32_active) {
+                    transpose_init(cb_inp);
+                }
                 transpose_tile(cb_inp, i, dst0);
+                if constexpr (welford_unpack_fp32_active) {
+                    welford_init<WelfordInitMode::PreserveStats>();
+                }
                 if (block.to_global(i) < Wt - 1) {
                     welford_update<W>(dst0, start_N, *p_reciprocals);
                 } else {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_welford_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_welford_program_factory.cpp
@@ -245,13 +245,14 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGatherWelfordProgramFactory::crea
     //   cb_inp).
     std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
         NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
-    if (welford_unpack_fp32_active && !fuse_pre_add) {
+    if (welford_unpack_fp32_active) {
         unpack_to_dest_mode[static_cast<uint32_t>(tt::CBIndex::c_0)] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
-    }
-    if (welford_unpack_fp32_active && fuse_pre_add) {
-        unpack_to_dest_mode[static_cast<uint32_t>(tt::CBIndex::c_0)] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
-        unpack_to_dest_mode[static_cast<uint32_t>(tt::CBIndex::c_5)] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
-        unpack_to_dest_mode[static_cast<uint32_t>(tt::CBIndex::c_3)] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        if (fuse_pre_add) {
+            unpack_to_dest_mode[static_cast<uint32_t>(tt::CBIndex::c_5)] =
+                tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+            unpack_to_dest_mode[static_cast<uint32_t>(tt::CBIndex::c_3)] =
+                tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        }
     }
 
     // Intermediate scratch CB (c_1) holds data only for the final transpose operation,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_welford_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_welford_program_factory.cpp
@@ -138,19 +138,14 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGatherWelfordProgramFactory::crea
     compute_defines["FUSE_PRE_ADD"] = fuse_pre_add ? "1" : "0";
 
     // UnpackToDestFp32 routes the unpack to DEST instead of SrcA, preserving FP32 precision.
-    // Unfortunately, that path also uses the math-thread replay buffer, which
-    // collides with Welford's recurrence slots; welford_unpack_fp32_active gates the
-    // post-transpose welford_init<WelfordInitMode::PreserveStats>() that the non-FUSE compute
-    // kernel branch
-    // needs to re-record the SFPU replay buffer with the welford recurrence. The bf16/SrcA
-    // path leaves the replay buffer alone, so the recovery is unnecessary there.
-    // The flag is only set on the non-FUSE kernel branch. In the FUSE_PRE_ADD path, c_0 is
-    // consumed by add_tiles which reads via SrcA/SrcB, and per UnpackToDestMode's contract
-    // setting UnpackToDestFp32 on a CB makes it incompatible with SrcA/B unpacking.
-    // Setting UnpackToDestFp32 on the post-add CB (c_3) would not help either because add_tiles
-    // already truncated the inputs to TF32 on the way into c_3. Therefore, both c_0 (input) and
-    // c_3 (post-add) stay in default mode on the FUSE path.
-    bool welford_unpack_fp32_active = (in_data_format == tt::DataFormat::Float32 && fp32_dest_acc_en && !fuse_pre_add);
+    // That path uses the math-thread replay buffer, which collides with Welford's recurrence
+    // slots; welford_unpack_fp32_active gates welford_init<WelfordInitMode::PreserveStats>()
+    // after each transpose_tile to re-record the SFPU replay buffer.
+    //
+    // On the FUSE path, pre-add uses copy_tile + add_binary_tile (SFPU), not add_tiles, so
+    // c_0/c_5 can use UnpackToDestFp32 for the copy_tile unpack and c_3 for Welford's
+    // transpose_tile read of the post-add result.
+    bool welford_unpack_fp32_active = (in_data_format == tt::DataFormat::Float32 && fp32_dest_acc_en);
     std::vector<uint32_t> compute_args = {Wt, W, block_size};
     KernelDescriptor::NamedCompileTimeArgs compute_named_args = {
         {"welford_unpack_fp32_active", welford_unpack_fp32_active ? 1u : 0u},
@@ -244,11 +239,19 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGatherWelfordProgramFactory::crea
         "compute kernel config; otherwise precision is silently lost in the unpacker format "
         "conversion.");
 
-    // Set UnpackToDestFp32 on c_0 when welford_unpack_fp32_active is true.
+    // When welford_unpack_fp32_active:
+    //   !fuse_pre_add -> Set UnpackToDestFp32 on c_0 only (input read by transpose_tile in the Welford loop).
+    //   fuse_pre_add  -> Set UnpackToDestFp32 on c_0, c_5, c_3 (copy_tile pre-add unpack + transpose_tile on post-add
+    //   cb_inp).
     std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
         NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
-    if (welford_unpack_fp32_active) {
+    if (welford_unpack_fp32_active && !fuse_pre_add) {
         unpack_to_dest_mode[static_cast<uint32_t>(tt::CBIndex::c_0)] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+    }
+    if (welford_unpack_fp32_active && fuse_pre_add) {
+        unpack_to_dest_mode[static_cast<uint32_t>(tt::CBIndex::c_0)] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[static_cast<uint32_t>(tt::CBIndex::c_5)] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[static_cast<uint32_t>(tt::CBIndex::c_3)] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
     }
 
     // Intermediate scratch CB (c_1) holds data only for the final transpose operation,
@@ -302,7 +305,7 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGatherWelfordProgramFactory::crea
 
     if (fuse_pre_add) {
         // c_5 -> residual b. Sized in residual's own data format so a residual with a different
-        // dtype than the input is read correctly; add_tiles handles the per-operand format.
+        // dtype than the input is read correctly.
         program_descriptor.cbs.push_back(CBDescriptor{
             .total_size = res_tiles * inb_single_tile_size,
             .core_ranges = all_cores,


### PR DESCRIPTION
### Ticket

- #45231

### Problem Description
When LayerNorm runs with residual input enabled, the residual pre-add path uses add_tiles, where FPU SrcA reads data in TF32 precision (10-bit mantissa). For large-offset inputs (e.g. 1e6), TF32 has a coarse ULP (~512), causing nearby values to round to the same representable value during pre-add.
This precision loss happens before downstream high-precision variance computation, collapsing meaningful input variation.


### What's Changed
**1.`layernorm_pre_allgather_welford.cpp`**
- In **Fuse-add (input + residual)** path: changed FPU add_tiles to SFPU copy_tile + add_binary_tile when fp32 unpack is active.
- Welford loop (fuse path): per-tile transpose_wh_init_short + welford_init<PreserveStats>() when fp32 unpack is active (replay-buffer fix after transpose).
- bf16 / non-fp32-unpack path unchanged (still uses add_tiles)

**2.`layernorm_pre_all_gather_welford_program_factory.cpp`**
- welford_unpack_fp32_active enabled for fuse path too
- Made Circular buffer as UnpackToDestFp32 on c_0 (input), c_5 (residual), and c_3 (post-add) when fuse_add enabled + FP32 input.

**3.`test_distributed_layernorm_pre_allgather.py`**
- Removed xfail on use_residual=True in test_layernorm_pre_all_gather_welford_fp32_precision.

### Perf-report (FPU vs SFPU)

| Shape | Offset | Use Residual | OP Code | FPU Device Time (ns) | SPFU Device Time (ns) | Diff (ns) | Diff % |
|--------|--------|--------------|---------|----------------------|-----------------------|------------|--------|
| (1, 1, 32, 128) | 0 | FALSE | LayerNormPreAllGatherDeviceOperation | 7807 | 7791 | 16 | 0.20% |
| (1, 1, 32, 128) | 0 | TRUE | LayerNormPreAllGatherDeviceOperation | 11253 | 13944 | -2691 | -23.91% |
| (1, 1, 32, 128) | 1000000 | FALSE | LayerNormPreAllGatherDeviceOperation | 7790 | 7804 | -14 | -0.18% |
| (1, 1, 32, 128) | 1000000 | TRUE | LayerNormPreAllGatherDeviceOperation | 11260 | 14259 | -2999 | -26.63% |
| (1, 5, 30, 72) | 0 | FALSE | LayerNormPreAllGatherDeviceOperation | 6702 | 6706 | -4 | -0.06% |
| (1, 5, 30, 72) | 0 | FALSE | LayerNormPreAllGatherDeviceOperation | 6569 | 6551 | 18 | 0.27% |
| (1, 5, 30, 72) | 0 | TRUE | LayerNormPreAllGatherDeviceOperation | 9255 | 11475 | -2220 | -23.99% |
| (1, 5, 30, 72) | 0 | TRUE | LayerNormPreAllGatherDeviceOperation | 9198 | 11226 | -2028 | -22.05% |
| (1, 5, 30, 72) | 1000000 | FALSE | LayerNormPreAllGatherDeviceOperation | 6667 | 6627 | 40 | 0.60% |
| (1, 5, 30, 72) | 1000000 | FALSE | LayerNormPreAllGatherDeviceOperation | 6457 | 6467 | -10 | -0.15% |
| (1, 5, 30, 72) | 1000000 | TRUE | LayerNormPreAllGatherDeviceOperation | 9251 | 11260 | -2009 | -21.72% |
| (1, 5, 30, 72) | 1000000 | TRUE | LayerNormPreAllGatherDeviceOperation | 9187 | 11239 | -2052 | -22.34% |
| (4, 1, 64, 128) | 0 | FALSE | LayerNormPreAllGatherDeviceOperation | 8295 | 8215 | 80 | 0.96% |
| (4, 1, 64, 128) | 0 | TRUE | LayerNormPreAllGatherDeviceOperation | 12145 | 15095 | -2950 | -24.29% |
| (4, 1, 64, 128) | 1000000 | FALSE | LayerNormPreAllGatherDeviceOperation | 8180 | 8244 | -64 | -0.78% |
| (4, 1, 64, 128) | 1000000 | TRUE | LayerNormPreAllGatherDeviceOperation | 12085 | 15206 | -3121 | -25.83% |

### Note
- **Mean stagnation** occurs for l**arge offset values** during mean calculation in the Welford kernel due to FP32 precision limitations (ULP increases to ~0.0625 at higher magnitudes). Since variance computation depends on the accumulated mean, this precision loss propagates and leads to variance error accumulation, resulting in **PCC degradation**. This behavior is **independent of residual input** and is consistently observed for both `residual_input = true` and `residual_input = false`.
- Refer below for test results and welford replication results.

## Test Results

**Test:**  
`tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py::test_layernorm_pre_all_gather_welford_fp32_precision`  
**Note:  var_pcc_threshold = 0.95**
 
| Input Shape | Offset | Use Residual | Mean Status | Variance Status | Var PCC |
|------------|--------|--------------|-------------|-----------------|---------|
| (1, 1, 32, 384)  | 1000000 | FALSE | PASSED | FAILED | 0.929945 |
| (1, 1, 32, 384)  | 1000000 | TRUE  | PASSED | FAILED | 0.929945 |
| (1, 1, 32, 512)  | 1000000 | FALSE | PASSED | FAILED | 0.925210 |
| (1, 1, 32, 512)  | 1000000 | TRUE  | PASSED | FAILED | 0.925210 |
| (1, 1, 32, 576)  | 1000000 | FALSE | PASSED | FAILED | 0.928660 |
| (1, 1, 32, 576)  | 1000000 | TRUE  | PASSED | FAILED | 0.928660 |
| (1, 1, 32, 640)  | 1000000 | FALSE | PASSED | FAILED | 0.804922 |
| (1, 1, 32, 640)  | 1000000 | TRUE  | PASSED | FAILED | 0.804922 |
| (1, 1, 32, 704)  | 1000000 | FALSE | PASSED | FAILED | 0.942954 |
| (1, 1, 32, 704)  | 1000000 | TRUE  | PASSED | FAILED | 0.942954 |
| (1, 1, 32, 768)  | 1000000 | FALSE | PASSED | FAILED | 0.923002 |
| (1, 1, 32, 768)  | 1000000 | TRUE  | PASSED | FAILED | 0.923002 |
| (1, 1, 32, 832)  | 1000000 | FALSE | PASSED | FAILED | 0.928021 |
| (1, 1, 32, 832)  | 1000000 | TRUE  | PASSED | FAILED | 0.928021 |
| (1, 1, 32, 896)  | 1000000 | FALSE | PASSED | FAILED | 0.758836 |
| (1, 1, 32, 896)  | 1000000 | TRUE  | PASSED | FAILED | 0.758836 |
| (1, 1, 32, 960)  | 1000000 | FALSE | PASSED | FAILED | 0.809166 |
| (1, 1, 32, 960)  | 1000000 | TRUE  | PASSED | FAILED | 0.809166 |
| (1, 1, 32, 1024) | 1000000 | FALSE | PASSED | FAILED | 0.870284 |
| (1, 1, 32, 1024) | 1000000 | TRUE  | PASSED | FAILED | 0.870284 |

## FP32 Limitation verified using Python Welford Replication

To verify this FP32 precision limitation, similar Welford steps were replicated for the **shape** **(1, 1, 32, 1024)** with **offset = 1e6** in Python for `mean and variance` calculation. The experiment shows the same numerical behavior as observed in TTNN, confirming that the issue originates from **FP32 precision limitations at large offset values**.

### Welford Replication - Mean

| Row | Welford FP32 Mean (W) | FP64 Mean Ref (torch.mean) | \|W-FP64\| Deviation | TTNN Welford FP32 Mean |
|------|------------------------|----------------------------|----------------------|-------------------------|
| 0  | 1000000.188 | 1000000.032 | 0.15564  | 1000000.188 |
| 1  | 999999.8125 | 999999.9938 | 0.181274 | 999999.8125 |
| 2  | 1000000.063 | 999999.9687 | 0.093811 | 1000000 |
| 3  | 999999.8125 | 999999.9664 | 0.15387  | 999999.8125 |
| 4  | 1000000.063 | 1000000.001 | 0.061462 | 1000000.063 |
| 5  | 999999.625 | 999999.9445 | 0.319519 | 999999.5625 |
| 6  | 1000000.25 | 1000000.03 | 0.220459 | 1000000.25 |
| 7  | 1000000 | 999999.999 | 0.000977 | 1000000 |
| 8  | 999999.9375 | 999999.9789 | 0.041382 | 999999.9375 |
| 9  | 999999.9375 | 999999.9892 | 0.051697 | 999999.9375 |
| 10 | 999999.875 | 999999.9249 | 0.049866 | 999999.875 |
| 11 | 999999.8125 | 1000000.022 | 0.209106 | 999999.75 |
| 12 | 999999.75 | 999999.9858 | 0.235779 | 999999.75 |
| 13 | 999999.9375 | 1000000.017 | 0.079834 | 999999.9375 |
| 14 | 1000000.063 | 999999.9965 | 0.06604 | 1000000.063 |
| 15 | 1000000 | 1000000.03 | 0.030212 | 1000000 |
| 16 | 1000000 | 999999.9776 | 0.0224 | 1000000 |
| 17 | 1000000 | 999999.9512 | 0.048828 | 1000000 |
| 18 | 1000000.25 | 999999.9897 | 0.260254 | 1000000.25 |
| 19 | 999999.9375 | 999999.9421 | 0.004639 | 999999.9375 |
| 20 | 1000000.188 | 999999.9955 | 0.192017 | 1000000.188 |
| 21 | 999999.8125 | 999999.9996 | 0.187073 | 999999.8125 |
| 22 | 1000000.063 | 1000000.03 | 0.032104 | 1000000.125 |
| 23 | 999999.75 | 1000000.029 | 0.279358 | 999999.75 |
| 24 | 999999.8125 | 999999.9656 | 0.153137 | 999999.8125 |
| 25 | 1000000.063 | 999999.9488 | 0.113708 | 1000000.063 |
| 26 | 1000000.125 | 999999.9677 | 0.157288 | 1000000.125 |
| 27 | 1000000.25 | 999999.9462 | 0.303833 | 1000000.25 |
| 28 | 999999.9375 | 999999.9307 | 0.006775 | 999999.9375 |
| 29 | 1000000 | 1000000.007 | 0.006592 | 999999.9375 |
| 30 | 1000000 | 1000000.021 | 0.020508 | 1000000 |
| 31 | 999999.6875 | 1000000.015 | 0.327759 | 999999.6875 |

### Welford Replication - Variance
### Welford Replication — Variance Comparison

| Row | Welford Variance (V) | FP64 Variance Ref (`torch.var`) | \|V - FP64\| Deviation | TTNN Welford Variance |
|------|----------------------|---------------------------------|------------------------|-----------------------|
| 0  | 1.079624176 | 1.056503 | 0.023121 | 1.079624176 |
| 1  | 1.053043365 | 1.021118 | 0.031926 | 1.053421021 |
| 2  | 0.945835114 | 0.936966 | 0.008869 | 0.938907623 |
| 3  | 0.959018707 | 0.934328 | 0.024691 | 0.959018707 |
| 4  | 1.000488281 | 0.993800 | 0.006688 | 1.000488281 |
| 5  | 1.184204102 | 1.080071 | 0.104133 | 1.226741791 |
| 6  | 1.051025391 | 1.002545 | 0.048480 | 1.051025391 |
| 7  | 1.002117157 | 1.002295 | 0.000178 | 1.001949310 |
| 8  | 1.032112122 | 1.030545 | 0.001567 | 1.032112122 |
| 9  | 0.938587189 | 0.935732 | 0.002856 | 0.938587189 |
| 10 | 1.007045746 | 1.004765 | 0.002281 | 1.007022858 |
| 11 | 1.112564087 | 1.069884 | 0.042680 | 1.142005920 |
| 12 | 1.109966278 | 1.053657 | 0.056309 | 1.109966278 |
| 13 | 1.069297791 | 1.062467 | 0.006831 | 1.069026947 |
| 14 | 0.950500488 | 0.947673 | 0.002828 | 0.950500488 |
| 15 | 1.000347137 | 0.999373 | 0.000974 | 0.999832153 |
| 16 | 1.011714935 | 1.011793 | 0.000078 | 1.011013031 |
| 17 | 1.039279938 | 1.037769 | 0.001511 | 1.039279938 |
| 18 | 1.079402924 | 1.010660 | 0.068743 | 1.079402924 |
| 19 | 0.953636169 | 0.952760 | 0.000876 | 0.953140259 |
| 20 | 0.986377716 | 0.949504 | 0.036874 | 0.986377716 |
| 21 | 1.011386871 | 0.976009 | 0.035378 | 1.011386871 |
| 22 | 0.984100342 | 0.982917 | 0.001183 | 0.991550446 |
| 23 | 1.117027283 | 1.040882 | 0.076145 | 1.116874695 |
| 24 | 0.993057251 | 0.969213 | 0.023844 | 0.993057251 |
| 25 | 1.044605255 | 1.032530 | 0.012075 | 1.044605255 |
| 26 | 1.027927399 | 1.001044 | 0.026883 | 1.027927399 |
| 27 | 1.071846008 | 0.977868 | 0.093978 | 1.071846008 |
| 28 | 0.941421509 | 0.942211 | 0.000790 | 0.941421509 |
| 29 | 1.009067535 | 1.009699 | 0.000632 | 1.014041901 |
| 30 | 0.993480682 | 0.993194 | 0.000287 | 0.993480682 |
| 31 | 1.151145935 | 1.043300 | 0.107845 | 1.151145935 |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/fix_layernorm_pre_allgather_welford_45231)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/fix_layernorm_pre_allgather_welford_45231)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/fix_layernorm_pre_allgather_welford_45231)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/fix_layernorm_pre_allgather_welford_45231)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ign/fix_layernorm_pre_allgather_welford_45231)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ign/fix_layernorm_pre_allgather_welford_45231)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/fix_layernorm_pre_allgather_welford_45231)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/fix_layernorm_pre_allgather_welford_45231)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/fix_layernorm_pre_allgather_welford_45231)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/fix_layernorm_pre_allgather_welford_45231)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/fix_layernorm_pre_allgather_welford_45231)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/fix_layernorm_pre_allgather_welford_45231)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/fix_layernorm_pre_allgather_welford_45231)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/fix_layernorm_pre_allgather_welford_45231)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/fix_layernorm_pre_allgather_welford_45231)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/fix_layernorm_pre_allgather_welford_45231)