### PR TITLE
[fuser] Add fuser support for SDPA inner loop on BH and layernorm test

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/fpu/matmul_no_mop.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/fpu/matmul_no_mop.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import List
+
+from fuser.block_data import BlockData
+from fuser.fused_loop import FusedLoop, LoopBlock
+from fuser.fused_math import ComputeNode
+from fuser.fused_operation import FusedOperation
+from fuser.fuser_config import GlobalConfig
+
+from .matmul import MatmulFpu
+
+
+class MatmulNoMopFpu(MatmulFpu):
+    loop: FusedLoop = LoopBlock()
+    per_block_init = True
+
+    def get_headers(self) -> List[str]:
+        return [
+            "llk_math_common.h",
+            "llk_math_matmul.h",
+            "experimental/llk_math_matmul_custom_no_mop.h",
+        ]
+
+    def init(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: ComputeNode,
+        block: BlockData,
+    ) -> str:
+        stage = operation.stage_id
+        math_fidelity = compute_unit.math_fidelity.cpp_enum_value
+        transpose = "true" if compute_unit.unpack_transpose_faces.value else "false"
+        rt_dim = block.block_tiles_y
+        ct_dim = block.block_tiles_x
+
+        tile_r_dim_a = compute_unit.src_a.tile_shape.total_row_dim()
+        tile_c_dim_a = compute_unit.src_a.tile_shape.total_col_dim()
+        tile_r_dim_b = compute_unit.src_b.tile_shape.total_row_dim()
+        tile_c_dim_b = compute_unit.src_b.tile_shape.total_col_dim()
+        partial_face = compute_unit.src_a.partial_face.cpp_enum_value
+
+        return (
+            f"// Operation {stage}: MatmulNoMop FPU\n"
+            f"_llk_math_matmul_init_no_mop_<{math_fidelity}>(\n"
+            f"    {tile_r_dim_a}, {tile_c_dim_a}, {tile_r_dim_b}, {tile_c_dim_b}, {partial_face}, {transpose}, {ct_dim}, {rt_dim}\n"
+            f");\n"
+        )
+
+    def calculate(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: ComputeNode,
+        block: BlockData,
+    ) -> str:
+        math_fidelity = compute_unit.math_fidelity.cpp_enum_value
+        rt_dim = block.block_tiles_y
+        ct_dim = block.block_tiles_x
+        num_cols = compute_unit.src_a.tile_shape.total_col_dim()
+        kt_dim = compute_unit.src_a.dimensions[1] // num_cols
+
+        return (
+            f"for (std::uint32_t kt = 0; kt < {kt_dim}; kt++)\n"
+            f"{{\n"
+            f"    _llk_math_matmul_no_mop_<{math_fidelity}>({block.tile_id_block}, {ct_dim}, {rt_dim});\n"
+            f"}}\n"
+        )
+
+    def uninit(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: ComputeNode,
+        block: BlockData,
+    ) -> str:
+        return "_llk_math_matmul_uninit_no_mop_();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/fpu/reduce.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/fpu/reduce.py
@@ -69,6 +69,17 @@ class ReduceFpu(Fpu):
             tile_shape=operation.tile_shape,
         ).flatten()
 
+        if compute_unit.reduce_to_tile:
+            block_tiles = operation.block_tiles_x * operation.block_tiles_y
+            tiles = src_a_reduced_tensor.view(-1, tile_elements)
+            for b in range(0, tile_cnt, block_tiles):
+                block = tiles[b : b + block_tiles]
+                if pool_type == ReducePool.Max:
+                    tiles[b] = block.max(dim=0).values
+                else:
+                    tiles[b] = block.sum(dim=0)
+                tiles[b + 1 : b + block_tiles] = 0
+
         dest_golden_tensor = tilize_block(
             tensor_dst,
             dimensions,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/fpu/sub_bcast_col_custom.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/fpu/sub_bcast_col_custom.py
@@ -49,7 +49,7 @@ class SubBcastColCustomFpu(EltwiseFpu):
         block: BlockData,
     ) -> str:
         ct_dim = block.block_tiles_x
-        return f"_llk_math_sub_bcast_cols_reuse_custom_({ct_dim}, {block.tile_id_block});\n"
+        return f"_llk_math_sub_bcast_cols_reuse_custom_({ct_dim});\n"
 
     def uninit(
         self,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/fpu/sub_bcast_col_custom.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/fpu/sub_bcast_col_custom.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import List
+
+from fuser.block_data import BlockData
+from fuser.fused_loop import FusedLoop, LoopBlockRow
+from fuser.fused_math import ComputeNode
+from fuser.fused_operation import FusedOperation
+from fuser.fuser_config import GlobalConfig
+from helpers.llk_params import MathOperation
+
+from .eltwise import EltwiseFpu
+
+
+class SubBcastColCustomFpu(EltwiseFpu):
+    loop: FusedLoop = LoopBlockRow()
+    per_block_init = True
+
+    def __init__(self):
+        super().__init__(MathOperation.Elwsub)
+
+    def get_headers(self) -> List[str]:
+        return [
+            "llk_math_common.h",
+            "experimental/llk_math_eltwise_binary_custom.h",
+        ]
+
+    def init(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: ComputeNode,
+        block: BlockData,
+    ) -> str:
+        stage = operation.stage_id
+        num_faces = operation.tile_shape.total_num_faces()
+        return (
+            f"// Operation {stage}: SubBcastColCustom FPU\n"
+            f"_llk_math_eltwise_binary_init_custom_<ckernel::EltwiseBinaryType::ELWSUB, ckernel::BroadcastType::COL>({num_faces});\n"
+        )
+
+    def calculate(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: ComputeNode,
+        block: BlockData,
+    ) -> str:
+        ct_dim = block.block_tiles_x
+        return f"_llk_math_sub_bcast_cols_reuse_custom_({ct_dim}, {block.tile_id_block});\n"
+
+    def uninit(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: ComputeNode,
+        block: BlockData,
+    ) -> str:
+        return "_llk_math_eltwise_binary_uninit_custom_();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/parser.py
@@ -42,6 +42,7 @@ from .fpu.matmul import MatmulFpu
 from .fpu.reduce import ReduceFpu
 from .fpu.reduce_block_max import ReduceBlockMaxFpu
 from .fpu.reduce_block_max_runtime import ReduceBlockMaxRuntimeFpu
+from .fpu.sub_bcast_col_custom import SubBcastColCustomFpu
 from .packer.packer import Packer
 from .sfpu.binary import BinarySfpu
 from .sfpu.unary import UnarySfpu
@@ -49,6 +50,7 @@ from .unpacker.matmul import MatmulUnpacker
 from .unpacker.reduce import ReduceUnpacker
 from .unpacker.reduce_block_max import ReduceBlockMaxUnpacker
 from .unpacker.reduce_block_max_runtime import ReduceBlockMaxRuntimeUnpacker
+from .unpacker.sub_bcast_col_custom import SubBcastColCustomUnpacker
 from .unpacker.tilize_a import UnpackerTilizeA
 from .unpacker.unpack_a import UnpackerA
 from .unpacker.unpack_ab import UnpackerAB
@@ -113,6 +115,10 @@ UNPACKER_MAP = {
     ),
     "ReduceBlockMaxRuntimeUnpacker": (
         lambda s: ReduceBlockMaxRuntimeUnpacker(),
+        None,
+    ),
+    "SubBcastColCustomUnpacker": (
+        lambda s: SubBcastColCustomUnpacker(),
         None,
     ),
 }
@@ -271,6 +277,10 @@ FPU_MAP = {
             _unsupported_tile,
         ],
     ),
+    "SubBcastColCustom": (
+        lambda s: SubBcastColCustomFpu(),
+        [_no_reuse_dest, _forced_unpacker("SubBcastColCustomUnpacker")],
+    ),
 }
 
 _l1_acc_format = (
@@ -296,6 +306,7 @@ OUTPUT_DIMS = {
     "Reduce": _src_a_dims,
     "ReduceBlockMax": _src_a_dims,
     "ReduceBlockMaxRuntime": _src_a_dims,
+    "SubBcastColCustom": _src_a_dims,
 }
 
 UNARY_SFPU_OPS = {

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/parser.py
@@ -190,6 +190,11 @@ _eltwise_bcast_32x16 = (
     "32x16 tiles are not supported for eltwise with column/row broadcast",
 )
 
+_only_32x32_tile = (
+    lambda s, a, b: _tile_dims(a.tile_shape) != (32, 32),
+    "Only (32, 32) tiles are supported for this operation",
+)
+
 _datacopy_only_32x32 = (
     lambda s, a, b: _tile_dims(a.tile_shape) != (32, 32)
     and (
@@ -267,19 +272,23 @@ FPU_MAP = {
     ),
     "ReduceBlockMax": (
         lambda s: ReduceBlockMaxFpu(),
-        [_no_reuse_dest, _forced_unpacker("ReduceBlockMaxUnpacker"), _unsupported_tile],
+        [_no_reuse_dest, _forced_unpacker("ReduceBlockMaxUnpacker"), _only_32x32_tile],
     ),
     "ReduceBlockMaxRuntime": (
         lambda s: ReduceBlockMaxRuntimeFpu(),
         [
             _no_reuse_dest,
             _forced_unpacker("ReduceBlockMaxRuntimeUnpacker"),
-            _unsupported_tile,
+            _only_32x32_tile,
         ],
     ),
     "SubBcastColCustom": (
         lambda s: SubBcastColCustomFpu(),
-        [_no_reuse_dest, _forced_unpacker("SubBcastColCustomUnpacker")],
+        [
+            _no_reuse_dest,
+            _forced_unpacker("SubBcastColCustomUnpacker"),
+            _only_32x32_tile,
+        ],
     ),
 }
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/parser.py
@@ -39,6 +39,7 @@ from pydantic import Field
 from .fpu.datacopy import DatacopyFpu
 from .fpu.eltwise import EltwiseFpu
 from .fpu.matmul import MatmulFpu
+from .fpu.matmul_no_mop import MatmulNoMopFpu
 from .fpu.reduce import ReduceFpu
 from .fpu.reduce_block_max import ReduceBlockMaxFpu
 from .fpu.reduce_block_max_runtime import ReduceBlockMaxRuntimeFpu
@@ -261,6 +262,17 @@ FPU_MAP = {
             _matmul_inner_dims,
         ],
     ),
+    "MatmulNoMop": (
+        lambda s: MatmulNoMopFpu(),
+        [
+            _no_reuse_dest,
+            _matmul_dim_check,
+            _forced_unpacker("MatmulUnpacker"),
+            _matmul_in0_16x16,
+            _matmul_in1_tile,
+            _matmul_inner_dims,
+        ],
+    ),
     "Reduce": (
         lambda s: ReduceFpu(s.reduce_dim, s.reduce_pool),
         [
@@ -312,6 +324,7 @@ OUTPUT_DIMS = {
     "Elwsub": _eltwise_dims,
     "Datacopy": _src_a_dims,
     "Matmul": _matmul_dims,
+    "MatmulNoMop": _matmul_dims,
     "Reduce": _src_a_dims,
     "ReduceBlockMax": _src_a_dims,
     "ReduceBlockMaxRuntime": _src_a_dims,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/sub_bcast_col_custom.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/sub_bcast_col_custom.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import List, Tuple
+
+import torch
+from fuser.block_data import BlockData
+from fuser.compute_node import ComputeNode
+from fuser.fused_loop import FusedLoop, LoopBlockRow
+from fuser.fused_operation import FusedOperation
+from fuser.fused_unpacker import Unpacker
+from fuser.fuser_config import GlobalConfig
+from helpers.golden_generators import BroadcastGolden, get_golden_generator
+from helpers.llk_params import BroadcastType
+from helpers.tilize_untilize import tilize_block, untilize_block
+
+
+class SubBcastColCustomUnpacker(Unpacker):
+    loop: FusedLoop = LoopBlockRow()
+    per_block_init = True
+
+    def get_headers(self) -> List[str]:
+        return [
+            "llk_unpack_common.h",
+            "experimental/llk_unpack_AB_sub_bcast_col_custom.h",
+        ]
+
+    def golden(
+        self,
+        tensor_a: torch.Tensor,
+        tensor_b: torch.Tensor,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: ComputeNode,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        tile_count_x = compute_unit.src_b.tile_count_x
+        tile_count_y = compute_unit.src_b.tile_count_y
+        block_tiles_x = operation.block_tiles_x
+        num_faces = compute_unit.src_a.tile_shape.total_num_faces()
+        face_r_dim = compute_unit.src_a.tile_shape.face_r_dim
+
+        tilized_b = tilize_block(
+            tensor_b, compute_unit.src_b.dimensions, compute_unit.src_b.data_format
+        )
+        broadcast_golden = get_golden_generator(BroadcastGolden)
+
+        for ty in range(tile_count_y):
+            for bx in range(0, tile_count_x, block_tiles_x):
+                first_tile_idx = ty * tile_count_x + bx
+                ct_dim = min(block_tiles_x, tile_count_x - bx)
+                broadcast_tile = broadcast_golden(
+                    BroadcastType.Column,
+                    tilized_b[first_tile_idx],
+                    compute_unit.src_b.data_format,
+                    num_faces,
+                    1,
+                    face_r_dim,
+                )
+                for tx_offset in range(ct_dim):
+                    tilized_b[first_tile_idx + tx_offset] = broadcast_tile
+
+        tensor_b = untilize_block(
+            tilized_b,
+            compute_unit.src_b.data_format,
+            compute_unit.src_b.dimensions,
+        )
+
+        return tensor_a.flatten(), tensor_b.flatten()
+
+    def perf_set_valid(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: ComputeNode,
+        block: BlockData,
+    ) -> str:
+        ct_dim = block.block_tiles_x
+        return (
+            f"_perf_unpack_loop_set_valid<false, true>(1);\n"
+            f"_perf_unpack_loop_set_valid<true, false>({ct_dim});\n"
+        )
+
+    def perf_clear_valid(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: ComputeNode,
+        block: BlockData,
+    ) -> str:
+        ct_dim = block.block_tiles_x
+        return (
+            f"_perf_math_loop_clear_valid<true, false>({ct_dim});\n"
+            f"_perf_math_loop_clear_valid<false, true>(1);\n"
+        )
+
+    def init(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: ComputeNode,
+        block: BlockData,
+    ) -> str:
+        return "_llk_unpack_AB_sub_bcast_col_init_custom_();\n"
+
+    def unpack(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: ComputeNode,
+        block: BlockData,
+    ) -> str:
+        ct_dim = block.block_tiles_x
+        buffer_a = compute_unit.src_a.cpp_name
+        buffer_b = compute_unit.src_b.cpp_name
+        return (
+            f"_llk_unpack_AB_sub_bcast_col_custom_("
+            f"L1_ADDRESS({buffer_a}[{block.tile_id_global}]), "
+            f"L1_ADDRESS({buffer_b}[{block.tile_id_global}]), "
+            f"{ct_dim});\n"
+        )
+
+    def uninit(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: ComputeNode,
+        block: BlockData,
+    ) -> str:
+        return "_llk_unpack_AB_sub_bcast_col_uninit_custom_();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/compute_node.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/compute_node.py
@@ -48,6 +48,7 @@ class ComputeNode:
         clear_fp32_dst_acc: ClearFP32DstAcc = ClearFP32DstAcc.No,
         acc_to_dest: AccToDest = AccToDest.No,
         unpack_to_dest: UnpackToDest = UnpackToDest.No,
+        reduce_to_tile: bool = False,
     ):
         if fpu is None and sfpu is None:
             raise ValueError("Compute unit needs an fpu or sfpu unit")
@@ -68,6 +69,7 @@ class ComputeNode:
         self.clear_fp32_dst_acc = clear_fp32_dst_acc
         self.acc_to_dest = acc_to_dest
         self.unpack_to_dest = unpack_to_dest
+        self.reduce_to_tile = reduce_to_tile
         self.src_a = src_a
         self.src_b = src_b
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_loop.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_loop.py
@@ -125,7 +125,7 @@ class LoopBlockRow(FusedLoop):
         if config.perf_run_type == PerfRunType.PACK_ISOLATE:
             return code
         code += f"for (std::uint32_t tile_y = 0; tile_y < {block.block_tiles_y}; tile_y++) {{\n"
-        code += f"std::uint32_t tile_id = {block.tile_count_x} * ({block.block_y} + tile_y) + {block.block_x};\n"
+        code += f"[[maybe_unused]] std::uint32_t tile_id = {block.tile_count_x} * ({block.block_y} + tile_y) + {block.block_x};\n"
         block.tile_id_global = "tile_id"
         block.tile_id_block = f"tile_y * {block.block_tiles_x}"
         if config.perf_run_type == PerfRunType.MATH_ISOLATE:

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_loop.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_loop.py
@@ -206,7 +206,11 @@ class LoopTileByTile(FusedLoop):
         code += f"for (std::uint32_t tile_x = 0; tile_x < {block.block_tiles_x}; tile_x++) {{\n"
         code += f"for (std::uint32_t tile_y = 0; tile_y < {block.block_tiles_y}; tile_y++) {{\n"
         block.tile_id_global = f"{block.tile_count_x} * ({block.block_y} + tile_y) + ({block.block_x} + tile_x)"
-        block.tile_id_block = f"tile_y * {block.block_tiles_x} + tile_x"
+        tile_id_block = (
+            "0"
+            if compute_unit.reduce_to_tile
+            else f"tile_y * {block.block_tiles_x} + tile_x"
+        )
         if config.perf_run_type in (
             PerfRunType.UNPACK_ISOLATE,
             PerfRunType.L1_CONGESTION,
@@ -215,9 +219,7 @@ class LoopTileByTile(FusedLoop):
                 operation, config, compute_unit, block
             )
         else:
-            code += (
-                f"std::uint32_t tile_id = tile_y * {block.block_tiles_x} + tile_x;\n"
-            )
+            code += f"std::uint32_t tile_id = {tile_id_block};\n"
             block.tile_id_global = f"{block.tile_count_x} * ({block.block_y} + tile_y) + ({block.block_x} + tile_x)"
             block.tile_id_block = "tile_id"
             code += compute_unit.fpu.calculate(operation, config, compute_unit, block)

--- a/tt_metal/tt-llk/tests/python_tests/fuser/validator.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/validator.py
@@ -195,6 +195,7 @@ class FpuMathSchemaBase(BaseModel):
     unpack_transpose_faces: Transpose = Transpose.No
     math_fidelity: MathFidelity = MathFidelity.LoFi
     unpack_to_dest: UnpackToDest = UnpackToDest.No
+    reduce_to_tile: bool = False
     src_a: str = Field(..., min_length=1)
     src_b: str = Field(..., min_length=1)
 
@@ -261,6 +262,7 @@ class FpuMathSchemaBase(BaseModel):
             "clear_fp32_dst_acc": clear_fp32_dst_acc,
             "acc_to_dest": self.acc_to_dest,
             "unpack_to_dest": self.unpack_to_dest,
+            "reduce_to_tile": self.reduce_to_tile,
         }
         if self.unpacker is not None:
             unpacker_factory, _ = type(self)._unpacker_map[self.unpacker]

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/reduce.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/reduce.py
@@ -69,6 +69,17 @@ class ReduceFpu(Fpu):
             tile_shape=operation.tile_shape,
         ).flatten()
 
+        if compute_unit.reduce_to_tile:
+            block_tiles = operation.block_tiles_x * operation.block_tiles_y
+            tiles = src_a_reduced_tensor.view(-1, tile_elements)
+            for b in range(0, tile_cnt, block_tiles):
+                block = tiles[b : b + block_tiles]
+                if pool_type == ReducePool.Max:
+                    tiles[b] = block.max(dim=0).values
+                else:
+                    tiles[b] = block.sum(dim=0)
+                tiles[b + 1 : b + block_tiles] = 0
+
         dest_golden_tensor = tilize_block(
             tensor_dst,
             dimensions,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/parser.py
@@ -190,6 +190,11 @@ _eltwise_bcast_32x16 = (
     "32x16 tiles are not supported for eltwise with column/row broadcast",
 )
 
+_only_32x32_tile = (
+    lambda s, a, b: _tile_dims(a.tile_shape) != (32, 32),
+    "Only (32, 32) tiles are supported for this operation",
+)
+
 _datacopy_only_32x32 = (
     lambda s, a, b: _tile_dims(a.tile_shape) != (32, 32)
     and (
@@ -278,14 +283,14 @@ FPU_MAP = {
     ),
     "ReduceBlockMax": (
         lambda s: ReduceBlockMaxFpu(),
-        [_no_reuse_dest, _forced_unpacker("ReduceBlockMaxUnpacker"), _unsupported_tile],
+        [_no_reuse_dest, _forced_unpacker("ReduceBlockMaxUnpacker"), _only_32x32_tile],
     ),
     "ReduceBlockMaxRuntime": (
         lambda s: ReduceBlockMaxRuntimeFpu(),
         [
             _no_reuse_dest,
             _forced_unpacker("ReduceBlockMaxRuntimeUnpacker"),
-            _unsupported_tile,
+            _only_32x32_tile,
         ],
     ),
     "SubBcastColCustom": (
@@ -293,7 +298,7 @@ FPU_MAP = {
         [
             _no_reuse_dest,
             _forced_unpacker("SubBcastColCustomUnpacker"),
-            _unsupported_tile,
+            _only_32x32_tile,
         ],
     ),
 }

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_reduce_row_to_tile.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_reduce_row_to_tile.yaml
@@ -1,0 +1,27 @@
+operands:
+  - name: "input_A"
+    dims: [128, 128]
+    format: "Float16_b"
+  - name: "input_B"
+    dims: [128, 128]
+    format: "Float16_b"
+    const_value: 1.0
+  - name: "reduce_row_out"
+    dims: [128, 128]
+    format: "Float16_b"
+
+operations:
+  - math:
+      - type: "Fpu"
+        src_a: "input_A"
+        src_b: "input_B"
+        operation: "Reduce"
+        reduce_dim: "REDUCE_ROW"
+        reduce_pool: "SUM"
+        reduce_to_tile: true
+        unpacker: "ReduceUnpacker"
+        math_fidelity: "HiFi2"
+    block_size: [64, 128]
+    pack:
+      - output: "reduce_row_out"
+        packer: "Packer"

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/layernorm_sharded.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/layernorm_sharded.yaml
@@ -8,8 +8,6 @@
 # conditional control flow (is_allgather_worker, two_stage_reduce).
 # The global reduce result is modeled as a pre-reduced single-row operand.
 
-# dest_acc: true
-
 operands:
   # x: input tensor
   - name: "x"
@@ -88,6 +86,7 @@ operations:
         operation: "Reduce"
         reduce_dim: "REDUCE_ROW"
         reduce_pool: "AVG"
+        reduce_to_tile: true
         unpacker: "ReduceUnpacker"
         math_fidelity: "HiFi4"
     block_size: [64, 128]
@@ -130,6 +129,7 @@ operations:
         operation: "Reduce"
         reduce_dim: "REDUCE_ROW"
         reduce_pool: "AVG"
+        reduce_to_tile: true
         unpacker: "ReduceUnpacker"
         math_fidelity: "HiFi4"
     block_size: [64, 128]

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/layernorm_sharded.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/layernorm_sharded.yaml
@@ -1,0 +1,196 @@
+# LayerNorm sharded compute kernel — models the non-allgather portion of
+# ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
+#
+# Covers: partial row-reduce (AVG), sub_bcast_cols, self-multiply, add+rsqrt SFPU,
+# mul_bcast_cols, mul_bcast_rows, add_bcast_rows.
+#
+# Omitted: allgather global reduce (runtime-variable streaming CB loop),
+# conditional control flow (is_allgather_worker, two_stage_reduce).
+# The global reduce result is modeled as a pre-reduced single-row operand.
+
+# dest_acc: true
+
+operands:
+  # x: input tensor
+  - name: "x"
+    dims: [64, 128]
+    format: "Float16_b"
+
+  # scaler for partial reduce (1/W)
+  - name: "scaler"
+    dims: [64, 128]
+    format: "Float16_b"
+    const_value: 0.03125
+
+  # E[x] — pre-reduced mean (models allgather output), single row broadcast
+  - name: "ex_global"
+    dims: [64, 128]
+    format: "Float16_b"
+    const_value: 0.5
+
+  # eps — small constant for numerical stability
+  - name: "eps"
+    dims: [64, 128]
+    format: "Float16_b"
+    const_value: 0.001
+
+  # gamma — per-column scale
+  - name: "gamma"
+    dims: [64, 128]
+    format: "Float16_b"
+    const_value: 1.0
+
+  # beta — per-column bias
+  - name: "beta"
+    dims: [64, 128]
+    format: "Float16_b"
+    const_value: 0.0
+
+  # intermediates
+  - name: "ex_partial"
+    dims: [64, 128]
+    format: "Float16_b"
+
+  - name: "xmm"
+    dims: [64, 128]
+    format: "Float16_b"
+
+  - name: "xmm2"
+    dims: [64, 128]
+    format: "Float16_b"
+
+  - name: "var_partial"
+    dims: [64, 128]
+    format: "Float16_b"
+
+  - name: "ex2pe"
+    dims: [64, 128]
+    format: "Float16_b"
+
+  - name: "normalized"
+    dims: [64, 128]
+    format: "Float16_b"
+
+  - name: "gamma_out"
+    dims: [64, 128]
+    format: "Float16_b"
+
+  - name: "output"
+    dims: [64, 128]
+    format: "Float16_b"
+
+operations:
+  # Step 1: E[x] partial reduce — row-reduce(AVG) the input
+  - math:
+      - type: "Fpu"
+        src_a: "x"
+        src_b: "scaler"
+        operation: "Reduce"
+        reduce_dim: "REDUCE_ROW"
+        reduce_pool: "AVG"
+        unpacker: "ReduceUnpacker"
+        math_fidelity: "HiFi4"
+    block_size: [64, 128]
+    pack:
+      - output: "ex_partial"
+        packer: "Packer"
+
+  # Step 2: x - E[x] — subtract mean (broadcast col)
+  - math:
+      - type: "Fpu"
+        src_a: "x"
+        src_b: "ex_global"
+        operation: "Elwsub"
+        unpacker: "UnpackerAB"
+        broadcast_type: "COL"
+        math_fidelity: "LoFi"
+    block_size: [64, 128]
+    pack:
+      - output: "xmm"
+        packer: "Packer"
+
+  # Step 3: (x - E[x])^2 — self-multiply
+  - math:
+      - type: "Fpu"
+        src_a: "xmm"
+        src_b: "xmm"
+        operation: "Elwmul"
+        unpacker: "UnpackerAB"
+        math_fidelity: "LoFi"
+    block_size: [64, 128]
+    pack:
+      - output: "xmm2"
+        packer: "Packer"
+
+  # Step 4: Var(x) partial reduce — row-reduce(AVG) the squared deviations
+  - math:
+      - type: "Fpu"
+        src_a: "xmm2"
+        src_b: "scaler"
+        operation: "Reduce"
+        reduce_dim: "REDUCE_ROW"
+        reduce_pool: "AVG"
+        unpacker: "ReduceUnpacker"
+        math_fidelity: "HiFi4"
+    block_size: [64, 128]
+    pack:
+      - output: "var_partial"
+        packer: "Packer"
+
+  # Step 5: 1/sqrt(Var + eps) — add eps then rsqrt
+  - math:
+      - type: "Fpu"
+        src_a: "var_partial"
+        src_b: "eps"
+        operation: "Elwadd"
+        unpacker: "UnpackerAB"
+        math_fidelity: "LoFi"
+      - type: "UnarySfpu"
+        operation: "Rsqrt"
+        iterations: 8
+    block_size: [64, 128]
+    pack:
+      - output: "ex2pe"
+        packer: "Packer"
+
+  # Step 6: (x - E[x]) * 1/sqrt(Var+eps) — normalize (broadcast col)
+  - math:
+      - type: "Fpu"
+        src_a: "xmm"
+        src_b: "ex2pe"
+        operation: "Elwmul"
+        unpacker: "UnpackerAB"
+        broadcast_type: "COL"
+        math_fidelity: "LoFi"
+    block_size: [64, 128]
+    pack:
+      - output: "normalized"
+        packer: "Packer"
+
+  # Step 7: normalized * gamma — scale (broadcast row)
+  - math:
+      - type: "Fpu"
+        src_a: "normalized"
+        src_b: "gamma"
+        operation: "Elwmul"
+        unpacker: "UnpackerAB"
+        broadcast_type: "ROW"
+        math_fidelity: "LoFi"
+    block_size: [64, 128]
+    pack:
+      - output: "gamma_out"
+        packer: "Packer"
+
+  # Step 8: gamma_out + beta — bias (broadcast row)
+  - math:
+      - type: "Fpu"
+        src_a: "gamma_out"
+        src_b: "beta"
+        operation: "Elwadd"
+        unpacker: "UnpackerAB"
+        broadcast_type: "ROW"
+        math_fidelity: "LoFi"
+    block_size: [64, 128]
+    pack:
+      - output: "output"
+        packer: "Packer"

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/layernorm_sharded.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/layernorm_sharded.yaml
@@ -1,12 +1,12 @@
-# LayerNorm sharded compute kernel — models the non-allgather portion of
-# ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
+# Sharded layernorm compute kernel.
+# Reference: ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
 #
-# Covers: partial row-reduce (AVG), sub_bcast_cols, self-multiply, add+rsqrt SFPU,
-# mul_bcast_cols, mul_bcast_rows, add_bcast_rows.
+# Pipeline: E[x] partial reduce → x-E[x] → (x-E[x])² → Var partial reduce →
+#           Var+eps → rsqrt → normalize → gamma scale → beta bias.
 #
-# Omitted: allgather global reduce (runtime-variable streaming CB loop),
-# conditional control flow (is_allgather_worker, two_stage_reduce).
-# The global reduce result is modeled as a pre-reduced single-row operand.
+# Reduce stages use reduce_to_tile to accumulate all tiles into a single
+# dest tile per block, matching the metal kernel's cross tile reduce behavior.
+# The global allgather reduce is not modeled; ex_global is a pre reduced constant.
 
 operands:
   # x: input tensor

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/sdpa_inner_loop_step.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/sdpa_inner_loop_step.yaml
@@ -1,5 +1,3 @@
-supported_archs: ["wormhole"]
-
 # SDPA inner loop step — simplified single-iteration pipeline.
 # Models sdpa_inner_loop_step from compute_streaming.hpp without SALAD correction.
 # Exercises: multi-stage reconfigs, multi-pack with different formats,


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Test Only

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
This PR adds support for the kernels needed to model `sdpa_inner_loop_step.yaml` in the fuser on BH and a new `layernorm_sharded.yaml` test. For the layernorm test, a `reduce_to_tile` parameter was added that reduces and accumulates all tiles into tile 0 of the current dest bank.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=marko/fuser-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:marko/fuser-layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=marko/fuser-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:marko/fuser-layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=marko/fuser-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:marko/fuser-layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=marko/fuser-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:marko/fuser-layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=marko/fuser-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:marko/fuser-layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=marko/fuser-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:marko/fuser-layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=marko/fuser-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:marko/fuser-layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=marko/fuser-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:marko/fuser-layernorm)