### PR TITLE
[Quasar] Comparison-to-zero SFPU - Compute API

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -69,6 +69,13 @@ const map<std::string, std::map<std::string, std::string>> sfpu_op_to_op_name = 
     {"sign", {{"SFPU_OP_CHAIN_0", "sign_tile_init(); sign_tile(0);"}}},
     {"rsqrt", {{"SFPU_OP_CHAIN_0", "rsqrt_tile_init(); rsqrt_tile(0);"}}},
     {"mul_unary", {{"SFPU_OP_CHAIN_0", "binop_with_scalar_tile_init(); mul_unary_tile(0, 0x40000000u);"}}},  // 2.0f
+    // Comparison-to-zero family (unary): result = 1.0f if predicate(x, 0) else 0.0f.
+    {"eqz", {{"SFPU_OP_CHAIN_0", "eqz_tile_init(); eqz_tile(0);"}}},
+    {"nez", {{"SFPU_OP_CHAIN_0", "nez_tile_init(); nez_tile(0);"}}},
+    {"ltz", {{"SFPU_OP_CHAIN_0", "ltz_tile_init(); ltz_tile(0);"}}},
+    {"gtz", {{"SFPU_OP_CHAIN_0", "gtz_tile_init(); gtz_tile(0);"}}},
+    {"gez", {{"SFPU_OP_CHAIN_0", "gez_tile_init(); gez_tile(0);"}}},
+    {"lez", {{"SFPU_OP_CHAIN_0", "lez_tile_init(); lez_tile(0);"}}},
 };
 
 // Binary SFPU ops driven by `run_sfpu_binary_two_input_buffer`.
@@ -156,6 +163,24 @@ float sfpu_function(const std::string& op_name, float input) {
     if (op_name == "mul_unary") {
         return bfloat16(static_cast<float>(input) * 2.0f);
     }
+    if (op_name == "eqz") {
+        return bfloat16(static_cast<float>(input) == 0.0f ? 1.0f : 0.0f);
+    }
+    if (op_name == "nez") {
+        return bfloat16(static_cast<float>(input) != 0.0f ? 1.0f : 0.0f);
+    }
+    if (op_name == "ltz") {
+        return bfloat16(static_cast<float>(input) < 0.0f ? 1.0f : 0.0f);
+    }
+    if (op_name == "gtz") {
+        return bfloat16(static_cast<float>(input) > 0.0f ? 1.0f : 0.0f);
+    }
+    if (op_name == "gez") {
+        return bfloat16(static_cast<float>(input) >= 0.0f ? 1.0f : 0.0f);
+    }
+    if (op_name == "lez") {
+        return bfloat16(static_cast<float>(input) <= 0.0f ? 1.0f : 0.0f);
+    }
     TT_THROW("Unsupported op_name in test");
 }
 
@@ -238,11 +263,17 @@ std::vector<uint32_t> compute_packed_int8_binary_golden(
     return packed_golden;
 }
 vector<uint32_t> generate_packed_sfpu_input(const unsigned int numel, const std::string& op_name, const int seed) {
-    if ((op_name == "sqrt") or (op_name == "log") or (op_name == "rsqrt")) {
+    if ((op_name == "sqrt") || (op_name == "log") || (op_name == "rsqrt")) {
         return generate_packed_uniform_random_vector<uint32_t, bfloat16>(0.0001f, 4.0f, numel, seed);
     }
-    if ((op_name == "exponential") or (op_name == "gelu") or (op_name == "reciprocal")) {
+    if ((op_name == "exponential") || (op_name == "gelu") || (op_name == "reciprocal")) {
         auto possible_values = vector<bfloat16>({-1.0f, -0.5f, 0.5f, 1.0f});
+        return generate_packed_random_vector_from_vector<uint32_t, bfloat16>(possible_values, numel, seed);
+    }
+    if ((op_name == "eqz") || (op_name == "nez") || (op_name == "ltz") || (op_name == "gtz") || (op_name == "gez") ||
+        (op_name == "lez")) {
+        // Include exact zeros so the eqz/nez/lez/gez at-zero branches are exercised.
+        auto possible_values = vector<bfloat16>({-1.0f, -0.5f, 0.0f, 0.5f, 1.0f});
         return generate_packed_random_vector_from_vector<uint32_t, bfloat16>(possible_values, numel, seed);
     }
     return generate_packed_uniform_random_vector<uint32_t, bfloat16>(-1.0f, 1.0f, numel, seed);
@@ -309,7 +340,7 @@ std::pair<float, float> sfpu_tolerance(const std::string& op_name) {
     if (op_name == "tanh") {
         return {0.175f, 0.1f};
     }
-    if ((op_name == "gelu") or (op_name == "relu")) {
+    if ((op_name == "gelu") || (op_name == "relu")) {
         return {0.15f, 0.001f};
     }
     if (op_name == "exponential") {
@@ -440,6 +471,7 @@ bool run_sfpu_all_same_buffer(
     sfpu_defines["SFPU_OP_RELU_FAMILY_INCLUDE"] = "1";
     sfpu_defines["SFPU_OP_COMPUTE_KERNEL_API_INCLUDE"] = "1";
     sfpu_defines["SFPU_OP_BINOP_WITH_SCALAR_INCLUDE"] = "1";
+    sfpu_defines["SFPU_OP_UNARY_COMP_INCLUDE"] = "1";
 
     // Every existing parametrization of this test uses a single-core CoreRangeSet of {0, 0};
     // MakeProgramFromSpec models the kernel set per single-core WorkUnit.
@@ -1187,6 +1219,18 @@ INSTANTIATE_TEST_SUITE_P(
     SingleCoreSfpuCompute,
     SingleCoreSingleMeshDeviceSfpuParameterizedFixture,
     ::testing::Values(
+        std::make_tuple(1, "eqz"),
+        std::make_tuple(1, "nez"),
+        std::make_tuple(1, "ltz"),
+        std::make_tuple(1, "gtz"),
+        std::make_tuple(1, "gez"),
+        std::make_tuple(1, "lez"),
+        std::make_tuple(4, "eqz"),
+        std::make_tuple(4, "nez"),
+        std::make_tuple(4, "ltz"),
+        std::make_tuple(4, "gtz"),
+        std::make_tuple(4, "gez"),
+        std::make_tuple(4, "lez"),
         std::make_tuple(1, "relu"),
         std::make_tuple(1, "exponential"),
         std::make_tuple(1, "reciprocal"),
@@ -1226,9 +1270,9 @@ TEST_P(SingleCoreSingleMeshDeviceSfpuParameterizedApproxFixture, TensixSfpuCompu
     if (arch_ == tt::ARCH::QUASAR && is_unary_sfpu_op_unsupported_on_quasar(sfpu_op)) {
         GTEST_SKIP() << "SFPU unary op '" << sfpu_op << "' has no Quasar compute-API implementation";
     }
-    if (((arch_ == tt::ARCH::WORMHOLE_B0) and (sfpu_op == "relu")) or
-        ((arch_ == tt::ARCH::WORMHOLE_B0) and (sfpu_op == "exponential")) or
-        ((arch_ == tt::ARCH::WORMHOLE_B0) and (sfpu_op == "log"))) {
+    if (((arch_ == tt::ARCH::WORMHOLE_B0) && (sfpu_op == "relu")) ||
+        ((arch_ == tt::ARCH::WORMHOLE_B0) && (sfpu_op == "exponential")) ||
+        ((arch_ == tt::ARCH::WORMHOLE_B0) && (sfpu_op == "log"))) {
         GTEST_SKIP();
     }
     CoreRange core_range({0, 0}, {0, 0});
@@ -1347,9 +1391,9 @@ TEST_P(SingleCoreSingleMeshDeviceSfpuParameterized32BitDestApproxFixture, Tensix
     if (arch_ == tt::ARCH::QUASAR && is_unary_sfpu_op_unsupported_on_quasar(sfpu_op)) {
         GTEST_SKIP() << "SFPU unary op '" << sfpu_op << "' has no Quasar compute-API implementation";
     }
-    if (((arch_ == tt::ARCH::WORMHOLE_B0) and (sfpu_op == "relu")) or
-        ((arch_ == tt::ARCH::WORMHOLE_B0) and (sfpu_op == "exponential")) or
-        ((arch_ == tt::ARCH::WORMHOLE_B0) and (sfpu_op == "log"))) {
+    if (((arch_ == tt::ARCH::WORMHOLE_B0) && (sfpu_op == "relu")) ||
+        ((arch_ == tt::ARCH::WORMHOLE_B0) && (sfpu_op == "exponential")) ||
+        ((arch_ == tt::ARCH::WORMHOLE_B0) && (sfpu_op == "log"))) {
         GTEST_SKIP();
     }
     CoreRange core_range({0, 0}, {0, 0});

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
@@ -99,8 +99,8 @@ struct zero_comp_traits {
  * to 1 and writes 0 here (see @ref _zero_comp_writes_zero_).
  *
  * @note Do NOT use @c abs(vInt) for the magnitude — that is two's-complement abs and leaves
- *       sign-magnitude -0 (0x80000000) unchanged (nonzero), breaking eqz(-0). @c setsgn(v,0) is the
- *       correct, format-agnostic primitive.
+ *       sign-magnitude -0 (0x80000000) unchanged (nonzero), breaking eqz(-0). Clearing the sign bit
+ *       (SFPSETSGN with sign=0) is the correct, format-agnostic primitive.
  *
  * @tparam COMP_MODE: Comparison-to-zero mode, values =
  *         <equal_zero/not_equal_zero/less_than_zero/greater_than_zero/greater_than_equal_zero/less_than_equal_zero>
@@ -113,7 +113,10 @@ inline __attribute__((always_inline)) sfpi::vBool _zero_comp_pred_(sfpi::vInt v)
             COMP_MODE == SfpuType::less_than_equal_zero || COMP_MODE == SfpuType::greater_than_equal_zero,
         "_zero_comp_pred_: COMP_MODE must be one of the six comparison-to-zero SfpuType modes "
         "(equal_zero/not_equal_zero/less_than_zero/greater_than_zero/less_than_equal_zero/greater_than_equal_zero)");
-    const sfpi::vInt mag = sfpi::setsgn(v, 0);  // sign bit cleared -> magnitude (±0 -> 0)
+    // Clear bit 31 (sign) -> magnitude (±0 -> 0) in a single SFPSETSGN; the vInt<->vSMag
+    // reinterprets are free (no instruction).
+    const sfpi::vSMag mag = sfpi::setsgn(sfpi::as<sfpi::vSMag>(v), 0);
+
     if constexpr (COMP_MODE == SfpuType::equal_zero) {
         return mag == 0;  // ±0
     } else if constexpr (COMP_MODE == SfpuType::not_equal_zero) {
@@ -147,13 +150,13 @@ inline constexpr bool _zero_comp_writes_zero_() {
  * @brief Program the dest-increment addr mod shared by every comparison-to-zero instantiation.
  *
  * @c ADDR_MOD_6 (dest.incr=2) lets the body's SFPSTORE advance the dest counter, so
- * @ref _calculate_zero_comp_ needs no dst_reg++. It is HW state shared across every COMP_MODE/FMT
- * instantiation, so programming it once here (rather than per @ref _calculate_zero_comp_ call) keeps
+ * @ref calculate_zero_comp needs no dst_reg++. It is HW state shared across every COMP_MODE/FMT
+ * instantiation, so programming it once here (rather than per @ref calculate_zero_comp call) keeps
  * it out of the per-tile loop body.
  *
- * @note Call once after @ref _llk_math_eltwise_sfpu_init_ and before @ref _calculate_zero_comp_.
+ * @note Call once after @ref _llk_math_eltwise_sfpu_init_ and before @ref calculate_zero_comp.
  */
-inline void _init_zero_comp_() {
+inline void init_zero_comp() {
     addr_mod_t{
         .srca = {.incr = 0},
         .srcb = {.incr = 0},
@@ -168,7 +171,7 @@ inline void _init_zero_comp_() {
  * Defaults each result lane and writes the opposite into the lanes matching COMP_MODE (eqz/nez/ltz/gtz
  * default 0 and write 1; gtez/ltez default 1 and write 0 — see @ref _zero_comp_writes_zero_), in FMT's
  * native encoding (see @ref zero_comp_traits). The body's SFPSTORE rides @c ADDR_MOD_6 (dest.incr=2,
- * programmed in @ref _init_zero_comp_) to advance the dest counter, so the loop needs no dst_reg++.
+ * programmed in @ref init_zero_comp) to advance the dest counter, so the loop needs no dst_reg++.
  *
  * @tparam APPROXIMATION_MODE: Unused (no approx path); retained for dispatcher signature symmetry.
  * @tparam FMT: SFPU DataFormat (sfpu_math): Int32/Int16/Int8/UInt16/UInt8, or Float32 for any float
@@ -176,17 +179,17 @@ inline void _init_zero_comp_() {
  *         resolves the actual width from the dest format config. Anything else is a compile error.
  * @tparam COMP_MODE: Comparison-to-zero mode.
  * @tparam ITERATIONS: Number of SFP-row pairs to process (8 for a 32×16 face).
- * @note Requires @ref _init_zero_comp_ to have programmed @c ADDR_MOD_6.
+ * @note Requires @ref init_zero_comp to have programmed @c ADDR_MOD_6.
  */
 template <bool APPROXIMATION_MODE, DataFormat FMT, SfpuType COMP_MODE, int ITERATIONS = SFPU_ITERATIONS>
-inline void _calculate_zero_comp_() {
+inline void calculate_zero_comp() {
     constexpr bool is_int_fmt = FMT == DataFormat::Int32 || FMT == DataFormat::Int16 || FMT == DataFormat::Int8 ||
                                 FMT == DataFormat::UInt16 || FMT == DataFormat::UInt8;
     constexpr bool is_float_fmt =
         FMT == DataFormat::Float32 || FMT == DataFormat::Float16 || FMT == DataFormat::Float16_b;
     static_assert(
         is_int_fmt || is_float_fmt,
-        "_calculate_zero_comp_: unsupported FMT (expected an integer format or an IEEE float width)");
+        "calculate_zero_comp: unsupported FMT (expected an integer format or an IEEE float width)");
 
     using traits = zero_comp_traits<FMT>;
 

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
@@ -44,9 +44,15 @@ inline __attribute__((always_inline)) void _sfpu_check_(
 
 // Init macros take OP first, then the optional init callback and template args.
 
-// Bare init: no callback.
-//   SFPU_UNARY_INIT(abs);
-#define SFPU_UNARY_INIT(OP) ::ckernel::llk_math_eltwise_unary_sfpu_init<::ckernel::SfpuType::OP>()
+// Init with an optional non-templated init function.
+//   SFPU_UNARY_INIT(abs);                                       // no init function
+//   SFPU_UNARY_INIT(greater_than_zero, sfpu::init_zero_comp);  // non-templated init function
+#define SFPU_UNARY_INIT_1(OP) ::ckernel::llk_math_eltwise_unary_sfpu_init<::ckernel::SfpuType::OP>()
+#define SFPU_UNARY_INIT_2(OP, INIT_FN) ::ckernel::llk_math_eltwise_unary_sfpu_init<::ckernel::SfpuType::OP>(INIT_FN)
+#define SFPU_UNARY_INIT_PICK(_1, _2, NAME, ...) NAME
+#define SFPU_UNARY_INIT(...) \
+    SFPU_UNARY_INIT_PICK(    \
+        __VA_ARGS__, SFPU_UNARY_INIT_2, SFPU_UNARY_INIT_1, _ignore /* at least one argument */)(__VA_ARGS__)
 
 // Init with a templated callback.
 //   SFPU_UNARY_INIT_FN(erf, sfpu::erf_init, (APPROXIMATE));

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/comp.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/comp.h
@@ -6,14 +6,20 @@
 
 #include "api/compute/common_globals.h"
 #ifdef TRISC_MATH
+#ifndef ARCH_QUASAR
 #include "sfpu/ckernel_sfpu_comp.h"
 #include "ckernel_sfpu_comp.h"
 #include "ckernel_sfpu_unary_comp.h"
 #include "llk_math_eltwise_unary_sfpu_macros.h"
+#else
+#include "ckernel_sfpu_comp.h"
+#include "llk_math_eltwise_unary_sfpu_macros.h"
+#endif
 #endif
 
 namespace ckernel {
 
+#ifndef ARCH_QUASAR
 // unary ne : if x != value --> 1.0, else 0.0
 // clang-format off
 /**
@@ -331,6 +337,7 @@ ALWI void unary_le_tile_int32(uint32_t idst, uint32_t param0) {
  * Please refer to documentation for any_init.
  */
 ALWI void unary_le_tile_init() { MATH(SFPU_UNARY_INIT(unary_le)); }
+#endif  // !ARCH_QUASAR
 
 // clang-format off
 /**
@@ -347,10 +354,239 @@ ALWI void unary_le_tile_init() { MATH(SFPU_UNARY_INIT(unary_le)); }
  */
 // clang-format on
 ALWI void gtz_tile(uint32_t idst) {
+#ifndef ARCH_QUASAR
     MATH(SFPU_UNARY_CALL(
         DST_SYNC_MODE, DST_ACCUM_MODE, calculate_comp, (APPROX, SfpuType::greater_than_zero), idst, VectorMode::RC));
+#else
+    MATH(SFPU_UNARY_CALL(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_zero_comp,
+        (APPROX, DataFormat::Float32, SfpuType::greater_than_zero, SFPU_ITERATIONS),
+        idst,
+        VectorMode::RC));
+#endif
 }
 
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void gtz_tile_init() {
+#ifndef ARCH_QUASAR
+    MATH(SFPU_UNARY_INIT(greater_than_zero));
+#else
+    MATH(SFPU_UNARY_INIT(greater_than_zero, sfpu::init_zero_comp));
+#endif
+}
+
+// clang-format off
+/**
+ * Will store in the output of the compute core True if each element is not equal to zero.
+ * The DST register buffer must be in acquired state via *acquire_dst* call.
+ * This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
+ * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst           | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void nez_tile(uint32_t idst) {
+#ifndef ARCH_QUASAR
+    MATH(SFPU_UNARY_CALL(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_comp, (APPROX, SfpuType::not_equal_zero), idst, VectorMode::RC));
+#else
+    MATH(SFPU_UNARY_CALL(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_zero_comp,
+        (APPROX, DataFormat::Float32, SfpuType::not_equal_zero, SFPU_ITERATIONS),
+        idst,
+        VectorMode::RC));
+#endif
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void nez_tile_init() {
+#ifndef ARCH_QUASAR
+    MATH(SFPU_UNARY_INIT(not_equal_zero));
+#else
+    MATH(SFPU_UNARY_INIT(not_equal_zero, sfpu::init_zero_comp));
+#endif
+}
+
+// clang-format off
+/**
+ * Will store in the output of the compute core True if each element is greater than or equal to zero.
+ * The DST register buffer must be in acquired state via *acquire_dst* call.
+ * This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
+ * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst           | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void gez_tile(uint32_t idst) {
+#ifndef ARCH_QUASAR
+    MATH(SFPU_UNARY_CALL(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_comp,
+        (APPROX, SfpuType::greater_than_equal_zero),
+        idst,
+        VectorMode::RC));
+#else
+    MATH(SFPU_UNARY_CALL(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_zero_comp,
+        (APPROX, DataFormat::Float32, SfpuType::greater_than_equal_zero, SFPU_ITERATIONS),
+        idst,
+        VectorMode::RC));
+#endif
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void gez_tile_init() {
+#ifndef ARCH_QUASAR
+    MATH(SFPU_UNARY_INIT(greater_than_equal_zero));
+#else
+    MATH(SFPU_UNARY_INIT(greater_than_equal_zero, sfpu::init_zero_comp));
+#endif
+}
+
+// clang-format off
+/**
+ * Will store in the output of the compute core True if each element of a tile is less than zero.
+ * The DST register buffer must be in acquired state via *acquire_dst* call.
+ * This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
+ * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst           | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void ltz_tile(uint32_t idst) {
+#ifndef ARCH_QUASAR
+    MATH(SFPU_UNARY_CALL(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_comp, (APPROX, SfpuType::less_than_zero), idst, VectorMode::RC));
+#else
+    MATH(SFPU_UNARY_CALL(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_zero_comp,
+        (APPROX, DataFormat::Float32, SfpuType::less_than_zero, SFPU_ITERATIONS),
+        idst,
+        VectorMode::RC));
+#endif
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void ltz_tile_init() {
+#ifndef ARCH_QUASAR
+    MATH(SFPU_UNARY_INIT(less_than_zero));
+#else
+    MATH(SFPU_UNARY_INIT(less_than_zero, sfpu::init_zero_comp));
+#endif
+}
+
+// clang-format off
+/**
+ * Will store in the output of the compute core True if each element of a tile is equal to zero.
+ * The DST register buffer must be in acquired state via *acquire_dst* call.
+ * This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
+ * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst           | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void eqz_tile(uint32_t idst) {
+#ifndef ARCH_QUASAR
+    MATH(SFPU_UNARY_CALL(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_comp, (APPROX, SfpuType::equal_zero), idst, VectorMode::RC));
+#else
+    MATH(SFPU_UNARY_CALL(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_zero_comp,
+        (APPROX, DataFormat::Float32, SfpuType::equal_zero, SFPU_ITERATIONS),
+        idst,
+        VectorMode::RC));
+#endif
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void eqz_tile_init() {
+#ifndef ARCH_QUASAR
+    MATH(SFPU_UNARY_INIT(equal_zero));
+#else
+    MATH(SFPU_UNARY_INIT(equal_zero, sfpu::init_zero_comp));
+#endif
+}
+
+// clang-format off
+/**
+ * Will store in the output of the compute core True if each element is less than or equal to zero.
+ * The DST register buffer must be in acquired state via *acquire_dst* call.
+ * This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
+ * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst           | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void lez_tile(uint32_t idst) {
+#ifndef ARCH_QUASAR
+    MATH(SFPU_UNARY_CALL(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_comp, (APPROX, SfpuType::less_than_equal_zero), idst, VectorMode::RC));
+#else
+    MATH(SFPU_UNARY_CALL(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_zero_comp,
+        (APPROX, DataFormat::Float32, SfpuType::less_than_equal_zero, SFPU_ITERATIONS),
+        idst,
+        VectorMode::RC));
+#endif
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void lez_tile_init() {
+#ifndef ARCH_QUASAR
+    MATH(SFPU_UNARY_INIT(less_than_equal_zero));
+#else
+    MATH(SFPU_UNARY_INIT(less_than_equal_zero, sfpu::init_zero_comp));
+#endif
+}
+
+// Integer comparison-to-zero variants. These read int32/uint operands from Dest, which on Quasar
+// requires 32-bit unpack-to-Dest that is not supported yet, so the whole block stays gated off there.
+#ifndef ARCH_QUASAR
 // clang-format off
 /**
  * Will store in the output of the compute core True if each element is greater than zero.
@@ -375,30 +611,6 @@ ALWI void gtz_tile_int32(uint32_t idst) {
         VectorMode::RC));
 }
 
-/**
- * Please refer to documentation for any_init.
- */
-ALWI void gtz_tile_init() { MATH(SFPU_UNARY_INIT(greater_than_zero)); }
-
-// clang-format off
-/**
- * Will store in the output of the compute core True if each element is not equal to zero.
- * The DST register buffer must be in acquired state via *acquire_dst* call.
- * This call is blocking and is only
- * available on the compute engine.
- *
- * Return value: None
- *
- * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
- * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst           | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
- */
-// clang-format on
-ALWI void nez_tile(uint32_t idst) {
-    MATH(SFPU_UNARY_CALL(
-        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_comp, (APPROX, SfpuType::not_equal_zero), idst, VectorMode::RC));
-}
-
 // clang-format off
 /**
  * Will store in the output of the compute core True if each element is not equal to zero.
@@ -416,35 +628,6 @@ ALWI void nez_tile(uint32_t idst) {
 ALWI void nez_tile_int32(uint32_t idst) {
     MATH(SFPU_UNARY_CALL(
         DST_SYNC_MODE, DST_ACCUM_MODE, calculate_comp_int, (APPROX, SfpuType::not_equal_zero), idst, VectorMode::RC));
-}
-
-/**
- * Please refer to documentation for any_init.
- */
-ALWI void nez_tile_init() { MATH(SFPU_UNARY_INIT(not_equal_zero)); }
-
-// clang-format off
-/**
- * Will store in the output of the compute core True if each element is greater than or equal to zero.
- * The DST register buffer must be in acquired state via *acquire_dst* call.
- * This call is blocking and is only
- * available on the compute engine.
- *
- * Return value: None
- *
- * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
- * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst           | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
- */
-// clang-format on
-ALWI void gez_tile(uint32_t idst) {
-    MATH(SFPU_UNARY_CALL(
-        DST_SYNC_MODE,
-        DST_ACCUM_MODE,
-        calculate_comp,
-        (APPROX, SfpuType::greater_than_equal_zero),
-        idst,
-        VectorMode::RC));
 }
 
 // clang-format off
@@ -471,30 +654,6 @@ ALWI void gez_tile_int32(uint32_t idst) {
         VectorMode::RC));
 }
 
-/**
- * Please refer to documentation for any_init.
- */
-ALWI void gez_tile_init() { MATH(SFPU_UNARY_INIT(greater_than_equal_zero)); }
-
-// clang-format off
-/**
- * Will store in the output of the compute core True if each element of a tile is less than zero.
- * The DST register buffer must be in acquired state via *acquire_dst* call.
- * This call is blocking and is only
- * available on the compute engine.
- *
- * Return value: None
- *
- * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
- * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst           | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
- */
-// clang-format on
-ALWI void ltz_tile(uint32_t idst) {
-    MATH(SFPU_UNARY_CALL(
-        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_comp, (APPROX, SfpuType::less_than_zero), idst, VectorMode::RC));
-}
-
 // clang-format off
 /**
  * Will store in the output of the compute core True if each element of a tile is less than zero.
@@ -512,30 +671,6 @@ ALWI void ltz_tile(uint32_t idst) {
 ALWI void ltz_tile_int32(uint32_t idst) {
     MATH(SFPU_UNARY_CALL(
         DST_SYNC_MODE, DST_ACCUM_MODE, calculate_comp_int, (APPROX, SfpuType::less_than_zero), idst, VectorMode::RC));
-}
-
-/**
- * Please refer to documentation for any_init.
- */
-ALWI void ltz_tile_init() { MATH(SFPU_UNARY_INIT(less_than_zero)); }
-
-// clang-format off
-/**
- * Will store in the output of the compute core True if each element of a tile is equal to zero.
- * The DST register buffer must be in acquired state via *acquire_dst* call.
- * This call is blocking and is only
- * available on the compute engine.
- *
- * Return value: None
- *
- * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
- * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst           | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
- */
-// clang-format on
-ALWI void eqz_tile(uint32_t idst) {
-    MATH(SFPU_UNARY_CALL(
-        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_comp, (APPROX, SfpuType::equal_zero), idst, VectorMode::RC));
 }
 
 // clang-format off
@@ -577,7 +712,6 @@ ALWI void eqz_tile_uint16(uint32_t idst) {
 }
 
 // clang-format off
-
 /**
  * Will store in the output of the compute core True if each element of a tile is equal to zero.
  * The DST register buffer must be in acquired state via *acquire_dst* call.
@@ -594,30 +728,6 @@ ALWI void eqz_tile_uint16(uint32_t idst) {
 ALWI void eqz_tile_uint32(uint32_t idst) {
     MATH((SFPU_UNARY_CALL(
         DST_SYNC_MODE, DST_ACCUM_MODE, calculate_eqz_uint32, (APPROX, 8 /*ITERATIONS*/), idst, VectorMode::RC)));
-}
-
-/**
- * Please refer to documentation for any_init.
- */
-ALWI void eqz_tile_init() { MATH(SFPU_UNARY_INIT(equal_zero)); }
-
-// clang-format off
-/**
- * Will store in the output of the compute core True if each element is less than or equal to zero.
- * The DST register buffer must be in acquired state via *acquire_dst* call.
- * This call is blocking and is only
- * available on the compute engine.
- *
- * Return value: None
- *
- * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
- * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst           | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
- */
-// clang-format on
-ALWI void lez_tile(uint32_t idst) {
-    MATH(SFPU_UNARY_CALL(
-        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_comp, (APPROX, SfpuType::less_than_equal_zero), idst, VectorMode::RC));
 }
 
 // clang-format off
@@ -686,10 +796,6 @@ ALWI void nez_tile_uint32(uint32_t idst) {
     MATH((SFPU_UNARY_CALL(
         DST_SYNC_MODE, DST_ACCUM_MODE, calculate_nez_uint32, (APPROX, 8 /*ITERATIONS*/), idst, VectorMode::RC)));
 }
-
-/**
- * Please refer to documentation for any_init.
- */
-ALWI void lez_tile_init() { MATH(SFPU_UNARY_INIT(less_than_equal_zero)); }
+#endif  // !ARCH_QUASAR
 
 }  // namespace ckernel

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
@@ -84,7 +84,7 @@ void init_unary_sfpu_operation_quasar()
     }
     else if constexpr (is_zero_comp_op(OPERATION))
     {
-        _init_zero_comp_();
+        init_zero_comp();
     }
 }
 
@@ -111,24 +111,24 @@ void call_zero_comp_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_fo
     switch (sfpu_format)
     {
         case DataFormat::Int32:
-            _llk_math_eltwise_unary_sfpu_params_(_calculate_zero_comp_<false, DataFormat::Int32, OPERATION, ITERATIONS>, dst_index);
+            _llk_math_eltwise_unary_sfpu_params_(calculate_zero_comp<false, DataFormat::Int32, OPERATION, ITERATIONS>, dst_index);
             break;
         case DataFormat::Int16:
-            _llk_math_eltwise_unary_sfpu_params_(_calculate_zero_comp_<false, DataFormat::Int16, OPERATION, ITERATIONS>, dst_index);
+            _llk_math_eltwise_unary_sfpu_params_(calculate_zero_comp<false, DataFormat::Int16, OPERATION, ITERATIONS>, dst_index);
             break;
         case DataFormat::Int8:
         {
             constexpr DataFormat sfpu_fmt = is_fp32_dest_acc_en ? DataFormat::Int32 : DataFormat::Int8;
-            _llk_math_eltwise_unary_sfpu_params_(_calculate_zero_comp_<false, sfpu_fmt, OPERATION, ITERATIONS>, dst_index);
+            _llk_math_eltwise_unary_sfpu_params_(calculate_zero_comp<false, sfpu_fmt, OPERATION, ITERATIONS>, dst_index);
             break;
         }
         case DataFormat::UInt16:
-            _llk_math_eltwise_unary_sfpu_params_(_calculate_zero_comp_<false, DataFormat::UInt16, OPERATION, ITERATIONS>, dst_index);
+            _llk_math_eltwise_unary_sfpu_params_(calculate_zero_comp<false, DataFormat::UInt16, OPERATION, ITERATIONS>, dst_index);
             break;
         case DataFormat::UInt8:
         {
             constexpr DataFormat sfpu_fmt = is_fp32_dest_acc_en ? DataFormat::Int32 : DataFormat::UInt8;
-            _llk_math_eltwise_unary_sfpu_params_(_calculate_zero_comp_<false, sfpu_fmt, OPERATION, ITERATIONS>, dst_index);
+            _llk_math_eltwise_unary_sfpu_params_(calculate_zero_comp<false, sfpu_fmt, OPERATION, ITERATIONS>, dst_index);
             break;
         }
         case DataFormat::Float16:
@@ -136,7 +136,7 @@ void call_zero_comp_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_fo
         case DataFormat::Float32:
             // Float widths share the width-agnostic Float32 path: its sfpmem::DEFAULT access mode
             // resolves the actual width from ALU_FORMAT_SPEC_REG / ACC_CTRL.
-            _llk_math_eltwise_unary_sfpu_params_(_calculate_zero_comp_<false, DataFormat::Float32, OPERATION, ITERATIONS>, dst_index);
+            _llk_math_eltwise_unary_sfpu_params_(calculate_zero_comp<false, DataFormat::Float32, OPERATION, ITERATIONS>, dst_index);
             break;
         default:
             LLK_ASSERT(false, "Unsupported Quasar comp-to-zero SFPU format");


### PR DESCRIPTION
Enables two Quasar SFPU comparison families in the compute API, each backed by an existing LLK functor, plus tests.

**Binary integer relational** (`ckernel_sfpu_binary_comp.h`): generalized the Quasar `gt_int` wrapper to all four ops and exposed `lt_int`/`gt_int`/`le_int`/`ge_int` via the compute API.

**Unary comparison-to-zero** (`ckernel_sfpu_comp.h`, `_calculate_zero_comp_`): wired `eqz`/`nez`/`ltz`/`gtz`/`gez`/`lez` (float) through the compute API for Quasar; param-compare `unary_*` and int32/uint variants stay `#ifndef ARCH_QUASAR` (no Quasar functor yet).

Tests added to `test_sfpu_compute.cpp`. Verified on the Quasar emulator: all binary relational + comparison-to-zero tests pass.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=njokovic/eqz-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:njokovic/eqz-compute-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=njokovic/eqz-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:njokovic/eqz-compute-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=njokovic/eqz-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:njokovic/eqz-compute-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=njokovic/eqz-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:njokovic/eqz-compute-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=njokovic/eqz-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:njokovic/eqz-compute-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=njokovic/eqz-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:njokovic/eqz-compute-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=njokovic/eqz-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:njokovic/eqz-compute-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=njokovic/eqz-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:njokovic/eqz-compute-api)