### PR TITLE
Fix LogProbsCalculator all-gather TP axis on 1×N meshes

### DIFF
--- a/models/common/sampling/tt_log_probs.py
+++ b/models/common/sampling/tt_log_probs.py
@@ -231,8 +231,6 @@ class LogProbsCalculator:
             if self._all_gather_cluster_axis is not None:
                 dims = (0, None) if self._all_gather_cluster_axis == 0 else (None, 0)
                 mesh_mapper = ttnn.ShardTensor2dMesh(self.mesh_device, dims=dims, mesh_shape=self.cluster_shape)
-            elif num_devices > 1:
-                mesh_mapper = ttnn.ShardTensorToMesh(self.mesh_device, dim=0)
             else:
                 mesh_mapper = ttnn.ReplicateTensorToMesh(self.mesh_device)
 

--- a/models/common/sampling/tt_log_probs.py
+++ b/models/common/sampling/tt_log_probs.py
@@ -178,19 +178,24 @@ class LogProbsCalculator:
 
         num_devices = self.mesh_device.get_num_devices()
 
-        # Determine the TP dimension: for 2D meshes, logits are sharded across
-        # the larger dimension (TP). For 1D or single-device, use all devices.
-        if self.cluster_shape[0] > 1 and self.cluster_shape[1] > 1:
-            # 2D mesh: TP axis is the larger dimension
-            tp_axis = 0 if self.cluster_shape[0] >= self.cluster_shape[1] else 1
-            num_devices_for_sharding = self.cluster_shape[tp_axis]
-            self._all_gather_cluster_axis = tp_axis
-        elif num_devices > 1:
-            # 1D mesh
-            num_devices_for_sharding = num_devices
-            self._all_gather_cluster_axis = None
+        # Determine the TP dimension: logits are sharded across the mesh axis that
+        # holds multiple devices. Handles 2D (e.g. 8×4), 1×N (T3K), and N×1 meshes.
+        if num_devices > 1:
+            if self.cluster_shape[0] > 1 and self.cluster_shape[1] > 1:
+                tp_axis = 0 if self.cluster_shape[0] >= self.cluster_shape[1] else 1
+            elif self.cluster_shape[0] > 1:
+                tp_axis = 0
+            elif self.cluster_shape[1] > 1:
+                tp_axis = 1
+            else:
+                tp_axis = None
+            if tp_axis is not None:
+                num_devices_for_sharding = self.cluster_shape[tp_axis]
+                self._all_gather_cluster_axis = tp_axis
+            else:
+                num_devices_for_sharding = num_devices
+                self._all_gather_cluster_axis = None
         else:
-            # Single device
             num_devices_for_sharding = num_devices
             self._all_gather_cluster_axis = None
 
@@ -228,7 +233,7 @@ class LogProbsCalculator:
                 torch.arange(num_devices_for_sharding).unsqueeze(1).expand(num_devices_for_sharding, batch_size)
             )
 
-            if self.cluster_shape[0] > 1 and self.cluster_shape[1] > 1:
+            if self._all_gather_cluster_axis is not None:
                 dims = (0, None) if self._all_gather_cluster_axis == 0 else (None, 0)
                 mesh_mapper = ttnn.ShardTensor2dMesh(self.mesh_device, dims=dims, mesh_shape=self.cluster_shape)
             elif num_devices > 1:

--- a/models/common/sampling/tt_log_probs.py
+++ b/models/common/sampling/tt_log_probs.py
@@ -185,16 +185,11 @@ class LogProbsCalculator:
                 tp_axis = 0 if self.cluster_shape[0] >= self.cluster_shape[1] else 1
             elif self.cluster_shape[0] > 1:
                 tp_axis = 0
-            elif self.cluster_shape[1] > 1:
+            else:
+                # num_devices > 1 implies at least one dim > 1; here dim0 == 1 → 1×N (T3K)
                 tp_axis = 1
-            else:
-                tp_axis = None
-            if tp_axis is not None:
-                num_devices_for_sharding = self.cluster_shape[tp_axis]
-                self._all_gather_cluster_axis = tp_axis
-            else:
-                num_devices_for_sharding = num_devices
-                self._all_gather_cluster_axis = None
+            num_devices_for_sharding = self.cluster_shape[tp_axis]
+            self._all_gather_cluster_axis = tp_axis
         else:
             num_devices_for_sharding = num_devices
             self._all_gather_cluster_axis = None

--- a/models/common/tests/modules/sampling/test_sampling_1d.py
+++ b/models/common/tests/modules/sampling/test_sampling_1d.py
@@ -169,14 +169,14 @@ class TestSampling1DDevice:
         ), f"Argmax mismatch: got {tokens_flat[:5]} vs expected {expected_flat[:5]}"
 
     @pytest.mark.parametrize("vocab_size", [1024])
-    def test_error_on_partial_params(self, ttnn_mesh_device, vocab_size):
+    def test_error_on_partial_params(self, ttnn_mesh_device, vocab_size, expect_error):
         """k provided but not p/temp → ValueError."""
         sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
         logits_host = torch.randn(1, 1, 32, vocab_size, dtype=torch.bfloat16)
         logits_tt = _make_logits_tt(logits_host, ttnn_mesh_device)
         k_tt = ttnn.from_torch(torch.ones(32), device=ttnn_mesh_device, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
 
-        with pytest.raises(ValueError, match="k, p, temp must all be provided"):
+        with expect_error(ValueError, "k, p, temp must all be provided"):
             sampler.decode_forward(logits_tt, k=k_tt)
 
     @pytest.mark.parametrize("vocab_size", [1024])
@@ -256,13 +256,13 @@ class TestSampling1DDevice:
     # ------------------------------------------------------------------
 
     @pytest.mark.parametrize("vocab_size", [1024])
-    def test_error_all_none_no_force_argmax(self, ttnn_mesh_device, vocab_size):
+    def test_error_all_none_no_force_argmax(self, ttnn_mesh_device, vocab_size, expect_error):
         """decode_forward with all-None k/p/temp when allow_force_argmax=False → ValueError (line 178)."""
         sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
         logits_host = torch.randn(1, 1, 32, vocab_size, dtype=torch.bfloat16)
         logits_tt = _make_logits_tt(logits_host, ttnn_mesh_device)
 
-        with pytest.raises(ValueError, match="allow_force_argmax is False"):
+        with expect_error(ValueError, "allow_force_argmax is False"):
             sampler.decode_forward(logits_tt)
 
     @pytest.mark.parametrize("vocab_size", [1024])
@@ -419,7 +419,7 @@ class TestSampling1DDevice:
         assert isinstance(resolved.index_offsets, LazyBuffer)
         assert resolved.index_offsets.device is ttnn_mesh_device  # filled in by resolve_lazy_buffer
 
-    def test_rejects_galaxy(self, ttnn_mesh_device):
+    def test_rejects_galaxy(self, ttnn_mesh_device, expect_error):
         """from_model_args should reject 2D (Galaxy) topologies."""
 
         class FakeMesh:
@@ -435,7 +435,7 @@ class TestSampling1DDevice:
             start_core = ttnn.CoreCoord(0, 0)
             max_top_k = 32
 
-        with pytest.raises(ValueError, match="1D mesh topologies"):
+        with expect_error(ValueError, "1D mesh topologies"):
             Sampling1D.from_model_args(FakeMesh(), None, MockArgs())
 
 
@@ -1425,8 +1425,9 @@ def test_sampling1d_logprobs_topk(ttnn_mesh_device):
 
     assert log_probs is not None, "logprobs must be computed on a 1×8 mesh when enabled"
 
-    # output_tensor is replicated across devices; read a single device copy → shape (1,1,1,B)
-    lp_host = ttnn.to_torch(ttnn.get_device_tensors(log_probs)[0]).reshape(-1)[:B].float()
+    # output_tensor shape (1,1,1,B), replicated across devices — match test_sampling.py read path
+    mesh_composer = ttnn.ConcatMeshToTensor(ttnn_mesh_device, dim=3)
+    lp_host = ttnn.to_torch(log_probs, mesh_composer=mesh_composer)[:, :, 0, :B].reshape(-1).float()
     tokens_host = to_torch_auto_compose(tokens_tt).flatten()[:B].long()
 
     # Reference: log_softmax over the full vocab (fp32), indexed at the sampled token.

--- a/models/common/tests/test_sampling.py
+++ b/models/common/tests/test_sampling.py
@@ -252,7 +252,14 @@ def test_log_probs_calculation_shard_tensor_2d_mesh_1x8(mesh_device):
     for i in range(batch_size):
         torch_tensor[:, :, i, :] = torch_tensor[:, :, i, torch.randperm(vocab_size)]
 
+    # Pin a few batch slots to tokens on different chips (4096 tokens/chip on 1×8).
+    pinned_tokens = [(0, 100), (1, 20000), (2, 30000), (3, 5000)]  # chips 0, 4, 7, 1
+    for batch_idx, token_id in pinned_tokens:
+        torch_tensor[:, :, batch_idx, token_id] = 10.0
+
     argmax_tensor = torch.argmax(torch_tensor.float(), dim=-1, keepdim=True)
+    for batch_idx, token_id in pinned_tokens:
+        assert argmax_tensor[0, 0, batch_idx, 0].item() == token_id
     indices_tensor = argmax_tensor.reshape(
         argmax_tensor.shape[0], argmax_tensor.shape[1], argmax_tensor.shape[-1], argmax_tensor.shape[-2]
     )

--- a/models/common/tests/test_sampling.py
+++ b/models/common/tests/test_sampling.py
@@ -208,6 +208,80 @@ def test_log_probs_calculation(shape, mesh_device):
     assert passing, f"Assertion failed, PCC={pcc}"
 
 
+def _shard_logits_2d_mesh(logits_host, mesh_device):
+    """Shard vocab along mesh TP axis (matches test_sampling_1d._make_logits_tt)."""
+    cluster_shape = tuple(mesh_device.shape)
+    if cluster_shape[-1] >= cluster_shape[-2]:
+        shard_dims = (None, -1)
+    else:
+        shard_dims = (-1, None)
+    return ttnn.from_torch(
+        logits_host,
+        device=mesh_device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=shard_dims, mesh_shape=cluster_shape),
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    indirect=["device_params"],
+    ids=["fabric_linear"],
+)
+def test_log_probs_calculation_shard_tensor_2d_mesh_1x8(mesh_device):
+    """LogProbsCalculator with ShardTensor2dMesh on 1×8 — the path Sampling1D uses.
+
+    test_log_probs_calculation shards via ShardTensorToMesh(dim=-1), which does not
+    exercise the 1×N _all_gather_cluster_axis bug fixed in tt_log_probs.py.
+    """
+    if mesh_device.get_num_devices() != 8:
+        pytest.skip(f"Test targets 1×8 mesh, got {mesh_device.get_num_devices()} devices")
+
+    batch_size = 32
+    vocab_size = 32768
+    shape = [1, 1, batch_size, vocab_size]
+
+    torch.manual_seed(42)
+    log_probs_calculator = LogProbsCalculator(mesh_device)
+
+    torch_tensor = torch.randn(shape, dtype=torch.bfloat16)
+    for i in range(batch_size):
+        torch_tensor[:, :, i, :] = torch_tensor[:, :, i, torch.randperm(vocab_size)]
+
+    argmax_tensor = torch.argmax(torch_tensor.float(), dim=-1, keepdim=True)
+    indices_tensor = argmax_tensor.reshape(
+        argmax_tensor.shape[0], argmax_tensor.shape[1], argmax_tensor.shape[-1], argmax_tensor.shape[-2]
+    )
+
+    logits_tensor = _shard_logits_2d_mesh(torch_tensor, mesh_device)
+    ttnn_indices_tensor = ttnn.from_torch(
+        indices_tensor,
+        device=mesh_device,
+        dtype=ttnn.int32,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    log_probs_calculator.set_log_probs_mode(True)
+    tt_log_probs = log_probs_calculator.calculate_log_probs(logits_tensor, ttnn_indices_tensor)
+    assert tt_log_probs is not None
+
+    log_probs_tt_host = ttnn.to_torch(tt_log_probs, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=3))
+    log_probs_tt_host = log_probs_tt_host[:, :, :1, :batch_size]
+
+    log_probs_torch = F.log_softmax(torch_tensor.float(), dim=-1)
+    log_probs_torch_argmax = torch.gather(log_probs_torch, dim=-1, index=argmax_tensor)
+    log_probs_torch_argmax = log_probs_torch_argmax.reshape(1, 1, 1, batch_size)
+
+    passing, pcc = comp_pcc(log_probs_torch_argmax, log_probs_tt_host, pcc=0.99)
+    assert passing, f"logprobs PCC below threshold: {pcc}"
+
+
 @pytest.mark.parametrize(
     "shape",
     [


### PR DESCRIPTION
### PR Category
Bug fix

### Issue
https://github.com/tenstorrent/tt-metal/issues/47902

### Summary

`test_sampling1d_logprobs_topk[1x8]` fails on T3K after stricter `comp_pcc` ([#42848](https://github.com/tenstorrent/tt-metal/pull/42848) / [#45299](https://github.com/tenstorrent/tt-metal/issues/45299)): device logprobs are wrong and often constant across batch slots; golden `torch.log_softmax` values vary per token.

This is not a PCC regression, it exposes a latent `LogProbsCalculator` bug that old `comp_pcc` masked with a false pass on constant tensors.

### Root cause

On T3K (`cluster_shape=(1, 8)`), logits are vocab-sharded along mesh axis 1. `LogProbsCalculator` must all-gather across that axis for distributed log-softmax (`_compute_global_stats`, `_prepare_relevant_logits`).

On main, `_all_gather_cluster_axis` was only set when **both** mesh dimensions are > 1. For 1×8 it fell through to `None`, so all-gather never ran across the 8 chips. Each chip used local max / sum-exp over its vocab slice instead of global log-softmax stats.

### What this PR does

- Set the correct TP / all-gather axis for 1×N (and N×1) meshes in `tt_log_probs.py`
- Align the integration test read path; add a calculator-level test with `ShardTensor2dMesh` (the path `Sampling1D` actually uses)

### File Changes

- `models/common/sampling/tt_log_probs.py`
  - Detect TP axis for all multi-device meshes: 2D (larger dim), N×1 (`tp_axis=0`), 1×N (`tp_axis=1`).
  - Set `_all_gather_cluster_axis` accordingly so `line_all_gather` / `ttnn.all_gather` runs on the correct mesh axis.
  - Gate `ShardTensor2dMesh` mask sharding on `_all_gather_cluster_axis is not None` instead of requiring both dims > 1.
- `models/common/tests/modules/sampling/test_sampling_1d.py`
  - Read logprobs via `ConcatMeshToTensor` (matches `test_sampling.py`).
  - Replace `pytest.raises` → `expect_error` in 3 tests (pre-commit requirement when editing this file).
- `models/common/tests/test_sampling.py`
  - `test_log_probs_calculation_shard_tensor_2d_mesh_1x8`: calculator-level test using `ShardTensor2dMesh` (same sharding as `Sampling1D`). Existing `test_log_probs_calculation` uses `ShardTensorToMesh` and did not catch the 1×N bug.

## Issue Validation on pipeline

Pipeline that showed this bug while running for PCC Branch : [Link](https://github.com/tenstorrent/tt-metal/actions/runs/27542651826/job/81410642319#step:7:3757)
Below pipelines were run as part of this branch
| Test | Pipeline | Result |
|------|----------|--------|
| `test_log_probs_calculation_shard_tensor_2d_mesh_1x8` (new) | [T3K unit `t3k_tttv2_fast`](https://github.com/tenstorrent/tt-metal/actions/runs/28040392216) | Passed |
| `test_sampling1d_logprobs_topk[1x8]` (integration) | [T3K E2E `models_tttv2_sampling_modules`](https://github.com/tenstorrent/tt-metal/actions/runs/28030609630/job/82973309156) | Passed |
| `test_sampling_1d.py` expect_error hooks (3 tests) | Same E2E job | Passed |

### Pipeline checks

- [x] Sanity
- [x] (Runtime) Sanity Tests
- [x] BHPC
- [x] Nightly

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/logprob_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/logprob_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/logprob_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/logprob_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=virdhatchani/logprob_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:virdhatchani/logprob_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/logprob_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/logprob_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/logprob_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/logprob_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/logprob_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/logprob_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/logprob_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/logprob_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/logprob_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/logprob_fix)