### PR TITLE
[skip ci] Skip test_qwen25vl_encoder_pair[4x8_1x4] on Wormhole Galaxy

### DIFF
--- a/models/tt_dit/tests/encoders/qwen25vl/test_qwen25vl.py
+++ b/models/tt_dit/tests/encoders/qwen25vl/test_qwen25vl.py
@@ -232,6 +232,8 @@ def test_qwen25vl_text_encoder(
 def test_qwen25vl_encoder_pair(
     *, mesh_device: ttnn.MeshDevice, submesh_shape: tuple[int, int], prompts: list[str]
 ) -> None:
+    if tuple(mesh_device.shape) == (4, 8):
+        pytest.skip("Failing on Wormhole Galaxy (4x8) with PCC ~96% < threshold; refs #47204")
     # There is a bug in the HF implementation where the prompt_embeds_mask is incorrectly repeated
     # if num_images_per_prompt != 1.
     # https://github.com/huggingface/diffusers/blob/v0.35.2/src/diffusers/pipelines/qwenimage/pipeline_qwenimage.py#L262


### PR DESCRIPTION
The test `test_qwen25vl_encoder_pair[wormhole_b0-device_params0-prompts0-4x8_1x4]` has been failing for 7+ days on the Wormhole Galaxy (4x8 mesh) with PCC ~96.1% which is below the required threshold. The `2x4_1x4` parametrization is unaffected and continues to run. This PR adds a targeted `pytest.skip()` inside the test body, guarded on `mesh_device.shape == (4, 8)`, so only the failing Galaxy permutation is skipped. refs #47204

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47204)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lifecycle/disable-issue-47204)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47204)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lifecycle/disable-issue-47204)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=lifecycle/disable-issue-47204)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:lifecycle/disable-issue-47204)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lifecycle/disable-issue-47204)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lifecycle/disable-issue-47204)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47204)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lifecycle/disable-issue-47204)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lifecycle/disable-issue-47204)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lifecycle/disable-issue-47204)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lifecycle/disable-issue-47204)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lifecycle/disable-issue-47204)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lifecycle/disable-issue-47204)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lifecycle/disable-issue-47204)