### PR TITLE
Better validation for matmul ops - Phase 2 (re-apply #45118 with MNIST fix)

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_linear.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_linear.py
@@ -243,6 +243,38 @@ def test_linear_with_compound_activation(device, batch_size, m_size, k_size, n_s
     )
 
 
+@pytest.mark.parametrize(
+    "activation",
+    [
+        ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU),
+        ttnn.UnaryWithParam(ttnn.UnaryOpType.GELU),
+        ttnn.UnaryWithParam(ttnn.UnaryOpType.TANH),
+        ttnn.UnaryWithParam(ttnn.UnaryOpType.SILU),
+        ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU6),
+        ttnn.UnaryWithParam(ttnn.UnaryOpType.SIGMOID),
+        ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDSIGMOID),
+        ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH, -1.0, 1.0),
+        ttnn.UnaryWithParam(ttnn.UnaryOpType.SELU, 1.6732632, 1.0507009),
+        ttnn.UnaryWithParam(ttnn.UnaryOpType.SOFTPLUS, 1.0, 20.0),
+    ],
+)
+def test_linear_fused_activation_numerical_stability(device, activation):
+    """Each supported fused activation must produce finite outputs (no NaN, no Inf)."""
+    torch.manual_seed(0)
+    m, k, n = 64, 128, 64
+    in0 = torch.randn(1, 1, m, k, dtype=torch.bfloat16)
+    in1 = torch.randn(1, 1, k, n, dtype=torch.bfloat16)
+
+    in0_t = ttnn.from_torch(in0, layout=ttnn.TILE_LAYOUT, device=device)
+    in1_t = ttnn.from_torch(in1, layout=ttnn.TILE_LAYOUT, device=device)
+
+    out = ttnn.linear(in0_t, in1_t, bias=None, activation=activation)
+    out_torch = ttnn.to_torch(out).to(torch.float32)
+
+    assert not torch.isnan(out_torch).any(), f"{activation.op_type} produced NaN"
+    assert not torch.isinf(out_torch).any(), f"{activation.op_type} produced Inf"
+
+
 @pytest.mark.parametrize("batch_size", [1, 8])
 @pytest.mark.parametrize("m_size", [32, 64])
 @pytest.mark.parametrize("k_size", [1024])
@@ -994,7 +1026,7 @@ def run_linear_bias_broadcast(device, a, b, bias=None, optional_output=None):
         ((32, 64), (64, 16), (1, 17, 16)),  # Broadcast error: Invalid dimension"
     ],
 )
-def test_linear_bias_broadcast(device, a_shape, b_shape, bias_shape):
+def test_linear_bias_broadcast(device, a_shape, b_shape, bias_shape, expect_error):
     torch.manual_seed(0)
 
     a = torch.randn(*a_shape, dtype=torch.bfloat16)
@@ -1016,7 +1048,7 @@ def test_linear_bias_broadcast(device, a_shape, b_shape, bias_shape):
         torch_failed = True
 
     if torch_failed:
-        with pytest.raises(Exception):
+        with expect_error(Exception, "."):
             run_linear_bias_broadcast(device, a, b, bias)
     else:
         result = run_linear_bias_broadcast(device, a, b, bias)
@@ -1033,7 +1065,7 @@ def test_linear_bias_broadcast(device, a_shape, b_shape, bias_shape):
         ((8, 64), (64, 4), (1, 1, 4), (1, 3, 8)),  # Invalid optional output tensor
     ],
 )
-def test_linear_bias_broadcast_with_optional_shape(device, a_shape, b_shape, bias_shape, optional_shape):
+def test_linear_bias_broadcast_with_optional_shape(device, a_shape, b_shape, bias_shape, optional_shape, expect_error):
     torch.manual_seed(0)
 
     a = torch.randn(*a_shape, dtype=torch.bfloat16)
@@ -1051,11 +1083,11 @@ def test_linear_bias_broadcast_with_optional_shape(device, a_shape, b_shape, bia
         torch_failed = True
 
     if torch_failed:
-        with pytest.raises(Exception):
+        with expect_error(Exception, "."):
             run_linear_bias_broadcast(device, a, b, bias, optional)
     else:
         if expected.numel() != optional.numel():
-            with pytest.raises(Exception):
+            with expect_error(Exception, "."):
                 run_linear_bias_broadcast(device, a, b, bias, optional)
         else:
             result = run_linear_bias_broadcast(device, a, b, bias, optional)
@@ -1064,6 +1096,27 @@ def test_linear_bias_broadcast_with_optional_shape(device, a_shape, b_shape, bia
                 assert result.shape == optional_shape
             else:
                 assert result.shape == expected.shape
+
+
+def test_linear_bias_rejected_on_multicore_reuse_program_config(device, expect_error):
+    """Bias is not supported for MatmulMultiCoreReuseProgramConfig — validate-time check."""
+    torch.manual_seed(0)
+    m, k, n = 64, 64, 64
+    in0 = ttnn.from_torch(torch.randn(1, 1, m, k, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    in1 = ttnn.from_torch(torch.randn(1, 1, k, n, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    bias = ttnn.from_torch(torch.randn(1, 1, 32, n, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+
+    program_config = ttnn.MatmulMultiCoreReuseProgramConfig(
+        compute_with_storage_grid_size=(1, 1),
+        in0_block_w=k // 32,
+        out_subblock_h=1,
+        out_subblock_w=1,
+        per_core_M=m // 32,
+        per_core_N=n // 32,
+    )
+
+    with expect_error(RuntimeError, "Bias is not supported for this matmul program config:"):
+        ttnn.linear(in0, in1, bias=bias, program_config=program_config)
 
 
 @pytest.mark.parametrize("bias_rank", [0, 1, 2, 3, 4])

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -1859,7 +1859,7 @@ def test_matmul_same_shape_and_valid(device, n_size, c, h, w):
         ([1.0,2.0,3.0],[3.0,4.0,5.0])
     ])
 # fmt: on
-def test_matmul_same_shape_but_invalid(device, input_a, input_b):
+def test_matmul_same_shape_but_invalid(device, input_a, input_b, expect_error):
     torch.manual_seed(0)
     # pad the lists with zeros to make it 32 so that it fits nicely on the device.
     input_a += [0.0] * (32 - len(input_a))
@@ -1868,18 +1868,17 @@ def test_matmul_same_shape_but_invalid(device, input_a, input_b):
     torch_input_tensor_a = torch.as_tensor(input_a, dtype=torch.bfloat16).reshape((1, 1, 1, len(input_a)))
     torch_input_tensor_b = torch.as_tensor(input_b, dtype=torch.bfloat16).reshape((1, 1, 1, len(input_b)))
 
-    with pytest.raises(RuntimeError) as exception:
+    with expect_error(
+        RuntimeError,
+        "Expected size for first two dimensions of batch2 tensor to be: \\[1, 32\\] but got: \\[1, 1\\]\\.",
+    ):
         torch.matmul(torch_input_tensor_a, torch_input_tensor_b)
-    assert "Expected size for first two dimensions of batch2 tensor to be: [1, 32] but got: [1, 1]." in str(
-        exception.value
-    )
 
     input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
     input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
 
-    with pytest.raises(RuntimeError) as exception:
+    with expect_error(RuntimeError, "The width of the first tensor must be equal to the height of the second tensor"):
         ttnn.matmul(input_tensor_a, input_tensor_b)
-    assert "The width of the first tensor must be equal to the height of the second tensor" in str(exception.value)
 
 
 def test_tutorial_matmul(device):
@@ -3606,26 +3605,26 @@ def test_matmul_column_wise_bfp_tilize_via_transpose_b(device, weight_dtype, pcc
         assert_numeric_metrics(result_conv, result_col, pcc_threshold=0.99)
 
 
-def test_from_torch_col_tilize_validation():
+def test_from_torch_col_tilize_validation(expect_error):
     torch.manual_seed(0)
     torch_tensor_2d = torch.randn(32, 64, dtype=torch.bfloat16)
     torch_tensor_1d = torch.randn(64, dtype=torch.bfloat16)
 
     # col_tilize requires BFP dtype
-    with pytest.raises(RuntimeError, match="col_tilize=True requires BFP dtype"):
+    with expect_error(RuntimeError, "col_tilize=True requires BFP dtype"):
         ttnn.from_torch(torch_tensor_2d, dtype=ttnn.bfloat16, col_tilize=True)
 
     # col_tilize requires ndim >= 2
-    with pytest.raises(RuntimeError, match="col_tilize=True requires tensor.ndim >= 2"):
+    with expect_error(RuntimeError, "col_tilize=True requires tensor.ndim >= 2"):
         ttnn.from_torch(torch_tensor_1d, dtype=ttnn.bfloat8_b, col_tilize=True)
 
     # col_tilize not supported with spec
     spec = ttnn.TensorSpec((32, 64), ttnn.bfloat8_b, ttnn.TILE_LAYOUT)
-    with pytest.raises(RuntimeError, match="col_tilize=True is not supported with spec"):
+    with expect_error(RuntimeError, "col_tilize=True is not supported with spec"):
         ttnn.from_torch(torch_tensor_2d, spec=spec, col_tilize=True)
 
     # col_tilize requires tile layout
-    with pytest.raises(RuntimeError, match="col_tilize=True requires layout to be None or ttnn.TILE_LAYOUT"):
+    with expect_error(RuntimeError, "col_tilize=True requires layout to be None or ttnn.TILE_LAYOUT"):
         ttnn.from_torch(torch_tensor_2d, dtype=ttnn.bfloat8_b, layout=ttnn.ROW_MAJOR_LAYOUT, col_tilize=True)
 
 
@@ -3915,3 +3914,51 @@ def test_matmul_2d_nd_sharded_in1(device, m, k, n, grid_size, k_splits, n_splits
     # Same weight, same matmul program; only in1's DRAM layout differs, so the ND
     # read must reproduce the interleaved read bit-for-bit.
     assert_equal(out_interleaved, out_nd)
+
+
+def test_matmul_activation_rejected_on_multicore_reuse_program_config(device, expect_error):
+    """Fused activation is not supported for MatmulMultiCoreReuseProgramConfig — validate-time check."""
+    torch.manual_seed(0)
+    m, k, n = 64, 64, 64
+    in0 = ttnn.from_torch(torch.randn(1, 1, m, k, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    in1 = ttnn.from_torch(torch.randn(1, 1, k, n, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+
+    program_config = ttnn.MatmulMultiCoreReuseProgramConfig(
+        compute_with_storage_grid_size=(1, 1),
+        in0_block_w=k // 32,
+        out_subblock_h=1,
+        out_subblock_w=1,
+        per_core_M=m // 32,
+        per_core_N=n // 32,
+    )
+
+    with expect_error(RuntimeError, "Fused activation is not supported for this matmul program config:"):
+        ttnn.matmul(
+            in0,
+            in1,
+            program_config=program_config,
+            activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU),
+        )
+
+
+def test_matmul_kt_not_divisible_by_in0_block_w_rejected(device, expect_error):
+    """Kt (K / tile_width) must be divisible by in0_block_w — error message must include both values."""
+    torch.manual_seed(0)
+    m, k, n = 64, 128, 64
+    in0 = ttnn.from_torch(torch.randn(1, 1, m, k, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    in1 = ttnn.from_torch(torch.randn(1, 1, k, n, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+
+    program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=(1, 1),
+        in0_block_w=3,
+        out_subblock_h=1,
+        out_subblock_w=1,
+        per_core_M=m // 32,
+        per_core_N=n // 32,
+        fuse_batch=True,
+        fused_activation=None,
+        mcast_in0=True,
+    )
+
+    with expect_error(RuntimeError, r"Kt \(4\) must be divisible by in0_block_w \(3\)"):
+        ttnn.matmul(in0, in1, program_config=program_config)

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -3916,31 +3916,6 @@ def test_matmul_2d_nd_sharded_in1(device, m, k, n, grid_size, k_splits, n_splits
     assert_equal(out_interleaved, out_nd)
 
 
-def test_matmul_activation_rejected_on_multicore_reuse_program_config(device, expect_error):
-    """Fused activation is not supported for MatmulMultiCoreReuseProgramConfig — validate-time check."""
-    torch.manual_seed(0)
-    m, k, n = 64, 64, 64
-    in0 = ttnn.from_torch(torch.randn(1, 1, m, k, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
-    in1 = ttnn.from_torch(torch.randn(1, 1, k, n, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
-
-    program_config = ttnn.MatmulMultiCoreReuseProgramConfig(
-        compute_with_storage_grid_size=(1, 1),
-        in0_block_w=k // 32,
-        out_subblock_h=1,
-        out_subblock_w=1,
-        per_core_M=m // 32,
-        per_core_N=n // 32,
-    )
-
-    with expect_error(RuntimeError, "Fused activation is not supported for this matmul program config:"):
-        ttnn.matmul(
-            in0,
-            in1,
-            program_config=program_config,
-            activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU),
-        )
-
-
 def test_matmul_kt_not_divisible_by_in0_block_w_rejected(device, expect_error):
     """Kt (K / tile_width) must be divisible by in0_block_w — error message must include both values."""
     torch.manual_seed(0)

--- a/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
@@ -623,3 +623,225 @@ def test_sparse_matmul_inputA_without_nnz(device, mkn, num_experts, num_batches,
             pcc_threshold=0.999,
             check_ulp=False,
         )
+
+
+def _make_sparse_inputs(device, b=1, s=4, m=32, k=128, n=512, num_experts=8, tile_h=32, tile_w=32):
+    torch.manual_seed(0)
+    in0 = ttnn.from_torch(
+        torch.randn((b, s, m, k), dtype=torch.bfloat16),
+        tile=ttnn.Tile((tile_h, 32)),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    in1 = ttnn.from_torch(
+        torch.randn((1, num_experts, k, n), dtype=torch.bfloat16),
+        tile=ttnn.Tile((32, tile_w)),
+        dtype=ttnn.bfloat8_b,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    sparsity = ttnn.from_torch(
+        torch.ones((b, s, 1, num_experts), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    nnz = b * s * num_experts
+    core_x, core_y = 4, 4
+    program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=ttnn.CoreCoord(core_x, core_y),
+        in0_block_w=1,
+        out_subblock_h=1,
+        out_subblock_w=1,
+        out_block_h=1,
+        out_block_w=1,
+        per_core_M=m // tile_h,
+        per_core_N=int(math.ceil(n / tile_w)) // (core_x * core_y),
+        fuse_batch=False,
+        fused_activation=None,
+        mcast_in0=True,
+    )
+    return in0, in1, sparsity, nnz, program_config, (m, k, n, num_experts, tile_h, tile_w)
+
+
+def test_sparse_matmul_requires_at_least_one_sparse_flag(device, expect_error):
+    """At least one of is_input_a_sparse / is_input_b_sparse must be true."""
+    in0, in1, sparsity, nnz, pc, dims = _make_sparse_inputs(device)
+    _, _, _, _, tile_h, tile_w = dims
+
+    with expect_error(
+        RuntimeError,
+        "sparse_matmul requires at least one of is_input_a_sparse or is_input_b_sparse to be true",
+    ):
+        ttnn.sparse_matmul(
+            in0,
+            in1,
+            sparsity=sparsity,
+            nnz=nnz,
+            is_input_a_sparse=False,
+            is_input_b_sparse=False,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            output_tile=ttnn.Tile([tile_h, tile_w]),
+            program_config=pc,
+        )
+
+
+def test_sparse_matmul_volume_must_match_batch_length(device, expect_error):
+    """sparsity logical_volume must equal product of all batch dimensions."""
+    in0, in1, _, nnz, pc, dims = _make_sparse_inputs(device)
+    _, _, _, num_experts, tile_h, tile_w = dims
+
+    wrong_sparsity = ttnn.from_torch(
+        torch.ones((1, 2, 1, num_experts), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    with expect_error(RuntimeError, "sparsity logical_volume"):
+        ttnn.sparse_matmul(
+            in0,
+            in1,
+            sparsity=wrong_sparsity,
+            nnz=nnz,
+            is_input_a_sparse=False,
+            is_input_b_sparse=True,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            output_tile=ttnn.Tile([tile_h, tile_w]),
+            program_config=pc,
+        )
+
+
+def test_sparse_matmul_inputA_wrong_layout(device, expect_error):
+    """Input tensor A must be TILE layout, ROW_MAJOR must be rejected."""
+    _, in1, sparsity, nnz, pc, dims = _make_sparse_inputs(device)
+    m, k, _, _, tile_h, tile_w = dims
+
+    in0_row_major = ttnn.from_torch(
+        torch.randn((1, 4, m, k), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    with expect_error(RuntimeError, "Input tensor A must be TILE layout"):
+        ttnn.sparse_matmul(
+            in0_row_major,
+            in1,
+            sparsity=sparsity,
+            nnz=nnz,
+            is_input_a_sparse=False,
+            is_input_b_sparse=True,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            output_tile=ttnn.Tile([tile_h, tile_w]),
+            program_config=pc,
+        )
+
+
+def test_sparse_matmul_inputB_wrong_layout(device, expect_error):
+    """Input tensor B must be TILE layout, ROW_MAJOR must be rejected."""
+    in0, _, sparsity, nnz, pc, dims = _make_sparse_inputs(device)
+    _, k, n, num_experts, tile_h, tile_w = dims
+
+    in1_row_major = ttnn.from_torch(
+        torch.randn((1, num_experts, k, n), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    with expect_error(RuntimeError, "Input tensor B must be TILE layout"):
+        ttnn.sparse_matmul(
+            in0,
+            in1_row_major,
+            sparsity=sparsity,
+            nnz=nnz,
+            is_input_a_sparse=False,
+            is_input_b_sparse=True,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            output_tile=ttnn.Tile([tile_h, tile_w]),
+            program_config=pc,
+        )
+
+
+def test_sparse_matmul_inputA_wrong_dtype(device, expect_error):
+    """Input tensor A must be floating point, integer types must be rejected."""
+    _, in1, sparsity, nnz, pc, dims = _make_sparse_inputs(device)
+    m, k, _, _, tile_h, tile_w = dims
+
+    in0_int = ttnn.from_torch(
+        torch.ones((1, 4, m, k), dtype=torch.int32),
+        dtype=ttnn.uint32,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    with expect_error(RuntimeError, "Input tensor A must be a floating point type"):
+        ttnn.sparse_matmul(
+            in0_int,
+            in1,
+            sparsity=sparsity,
+            nnz=nnz,
+            is_input_a_sparse=False,
+            is_input_b_sparse=True,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            output_tile=ttnn.Tile([tile_h, tile_w]),
+            program_config=pc,
+        )
+
+
+def test_sparse_matmul_inputB_wrong_dtype(device, expect_error):
+    """Input tensor B must be floating point, integer types must be rejected."""
+    in0, _, sparsity, nnz, pc, dims = _make_sparse_inputs(device)
+    _, k, n, num_experts, tile_h, tile_w = dims
+
+    in1_int = ttnn.from_torch(
+        torch.ones((1, num_experts, k, n), dtype=torch.int32),
+        dtype=ttnn.uint32,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    with expect_error(RuntimeError, "Input tensor B must be a floating point type"):
+        ttnn.sparse_matmul(
+            in0,
+            in1_int,
+            sparsity=sparsity,
+            nnz=nnz,
+            is_input_a_sparse=False,
+            is_input_b_sparse=True,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            output_tile=ttnn.Tile([tile_h, tile_w]),
+            program_config=pc,
+        )
+
+
+def test_sparse_matmul_sparsity_wrong_layout(device, expect_error):
+    """Sparsity tensor must be ROW_MAJOR, TILE layout must be rejected."""
+    in0, in1, _, nnz, pc, dims = _make_sparse_inputs(device)
+    _, _, _, _, tile_h, tile_w = dims
+
+    sparsity_tile = ttnn.from_torch(
+        torch.ones((1, 4, 32, 32), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    with expect_error(RuntimeError, "Sparsity tensor must be ROW_MAJOR layout"):
+        ttnn.sparse_matmul(
+            in0,
+            in1,
+            sparsity=sparsity_tile,
+            nnz=nnz,
+            is_input_a_sparse=False,
+            is_input_b_sparse=True,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            output_tile=ttnn.Tile([tile_h, tile_w]),
+            program_config=pc,
+        )

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -487,11 +487,11 @@ void validate_matmul_bias(
     std::visit(
         [&config_supports_bias](const auto& program_config) {
             using ProgramConfigType = std::decay_t<decltype(program_config)>;
-            // MatmulMultiCoreProgramConfig and MatmulMultiCoreReuseProgramConfig have no
-            // bias kernel path. Other configs support bias; gather_in0 on 1D multicast
-            // rejects bias separately in its dedicated check below.
+            // MatmulMultiCoreReuseProgramConfig has no bias kernel path and the wrapper
+            // does not post-process bias for it. All other configs either support bias in
+            // the kernel or have it handled by get_post_process_bias() in matmul.cpp.
+            // gather_in0 on 1D multicast rejects bias separately in its dedicated check.
             config_supports_bias =
-                !std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreProgramConfig> &&
                 !std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig>;
         },
         chosen_program_config);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -482,7 +482,8 @@ void validate_matmul_work_distribution_and_gather_ring_topology(
 void validate_matmul_fused_operations(
     const std::optional<const Tensor>& optional_bias,
     const std::optional<ttnn::operations::unary::UnaryWithParam>& fused_activation,
-    const operations::matmul::MatmulProgramConfig& chosen_program_config) {
+    const operations::matmul::MatmulProgramConfig& chosen_program_config,
+    const std::optional<CoreCoord>& user_core_coord) {
     // Determine which fused operations the chosen program config supports.
     bool config_supports_fused_ops = false;
     std::visit(
@@ -497,13 +498,15 @@ void validate_matmul_fused_operations(
         },
         chosen_program_config);
 
-    // Reject bias or activation if the selected config does not support them.
+    // Bias has no fallback path regardless of how the config was chosen.
     TT_FATAL(
         !optional_bias.has_value() || config_supports_fused_ops,
         "Bias is not supported for this matmul program config: {}",
         ttsl::get_active_type_name_in_variant(chosen_program_config));
+    // When user_core_coord is not set, the matmul wrapper applies activation separately
+    // via unary_chain after prim::matmul — the kernel does not need to fuse it here.
     TT_FATAL(
-        !fused_activation.has_value() || config_supports_fused_ops,
+        !fused_activation.has_value() || config_supports_fused_ops || !user_core_coord.has_value(),
         "Fused activation is not supported for this matmul program config: {}",
         ttsl::get_active_type_name_in_variant(chosen_program_config));
 }
@@ -906,7 +909,8 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
     validate_matmul_tile_constraints(input_tensor_a, input_tensor_b, in0_tile, in1_tile, chosen_program_config);
     validate_matmul_compute_grid_and_per_core_dims(input_tensor_a, chosen_program_config);
     validate_matmul_block_and_subblock_configuration(attributes, a_shape_padded, in0_tile, chosen_program_config);
-    validate_matmul_fused_operations(optional_bias, attributes.user_fused_activation, chosen_program_config);
+    validate_matmul_fused_operations(
+        optional_bias, attributes.user_fused_activation, chosen_program_config, attributes.user_core_coord);
     validate_matmul_sharded_operand_grids_within_program_compute_grid(
         input_tensor_a, input_tensor_b, chosen_program_config);
     validate_matmul_reuse_sharded_output_block_divisibility(

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -12,6 +12,7 @@
 #include "tt-metalium/hal_types.hpp"
 #include "tt-metalium/experimental/global_circular_buffer.hpp"
 #include "tt-metalium/work_split.hpp"
+#include "tt_stl/reflection.hpp"
 #include "tt_stl/unreachable.hpp"
 
 namespace ttnn::prim {
@@ -117,9 +118,12 @@ void validate_matmul_tile_constraints(
 }
 
 void validate_matmul_block_and_subblock_configuration(
-    const MatmulParams& attributes, const operations::matmul::MatmulProgramConfig& chosen_program_config) {
+    const MatmulParams& attributes,
+    const ttnn::Shape& a_shape_padded,
+    const tt::tt_metal::Tile& in0_tile,
+    const operations::matmul::MatmulProgramConfig& chosen_program_config) {
     std::visit(
-        [&attributes](const auto& program_config) {
+        [&attributes, &a_shape_padded, &in0_tile](const auto& program_config) {
             using ProgramConfigType = std::decay_t<decltype(program_config)>;
             if constexpr (
                 std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreProgramConfig> ||
@@ -135,6 +139,13 @@ void validate_matmul_block_and_subblock_configuration(
                 std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig> ||
                 std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig> ||
                 std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
+                TT_FATAL(program_config.in0_block_w != 0, "in0_block_w is 0, which is not valid");
+                const uint32_t Kt = a_shape_padded[-1] / in0_tile.get_width();
+                TT_FATAL(
+                    Kt % program_config.in0_block_w == 0,
+                    "Kt ({}) must be divisible by in0_block_w ({})",
+                    Kt,
+                    program_config.in0_block_w);
                 TT_FATAL(program_config.out_subblock_h != 0, "out_subblock_h is 0, which is not valid");
                 TT_FATAL(program_config.out_subblock_w != 0, "out_subblock_w is 0, which is not valid");
                 if constexpr (
@@ -466,6 +477,35 @@ void validate_matmul_work_distribution_and_gather_ring_topology(
             }
         },
         chosen_program_config);
+}
+
+void validate_matmul_fused_operations(
+    const std::optional<const Tensor>& optional_bias,
+    const std::optional<ttnn::operations::unary::UnaryWithParam>& fused_activation,
+    const operations::matmul::MatmulProgramConfig& chosen_program_config) {
+    // Determine which fused operations the chosen program config supports.
+    bool config_supports_fused_ops = false;
+    std::visit(
+        [&config_supports_fused_ops](const auto& program_config) {
+            using ProgramConfigType = std::decay_t<decltype(program_config)>;
+            // MatmulMultiCoreProgramConfig and MatmulMultiCoreReuseProgramConfig have no
+            // bias / fused_activation kernel paths. Other configs support both; gather_in0
+            // on 1D multicast rejects bias separately in its dedicated check below.
+            config_supports_fused_ops =
+                !std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreProgramConfig> &&
+                !std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig>;
+        },
+        chosen_program_config);
+
+    // Reject bias or activation if the selected config does not support them.
+    TT_FATAL(
+        !optional_bias.has_value() || config_supports_fused_ops,
+        "Bias is not supported for this matmul program config: {}",
+        ttsl::get_active_type_name_in_variant(chosen_program_config));
+    TT_FATAL(
+        !fused_activation.has_value() || config_supports_fused_ops,
+        "Fused activation is not supported for this matmul program config: {}",
+        ttsl::get_active_type_name_in_variant(chosen_program_config));
 }
 
 bool get_broadcast_batch(
@@ -864,9 +904,9 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
         chosen_program_config, input_tensor_a.device()->compute_with_storage_grid_size());
 
     validate_matmul_tile_constraints(input_tensor_a, input_tensor_b, in0_tile, in1_tile, chosen_program_config);
-    validate_matmul_block_and_subblock_configuration(attributes, chosen_program_config);
-
     validate_matmul_compute_grid_and_per_core_dims(input_tensor_a, chosen_program_config);
+    validate_matmul_block_and_subblock_configuration(attributes, a_shape_padded, in0_tile, chosen_program_config);
+    validate_matmul_fused_operations(optional_bias, attributes.user_fused_activation, chosen_program_config);
     validate_matmul_sharded_operand_grids_within_program_compute_grid(
         input_tensor_a, input_tensor_b, chosen_program_config);
     validate_matmul_reuse_sharded_output_block_divisibility(
@@ -1044,7 +1084,7 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
             std::holds_alternative<operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(
                 chosen_program_config),
             "Untilize out is not supported for this program config: {}",
-            typeid(chosen_program_config).name());
+            ttsl::get_active_type_name_in_variant(chosen_program_config));
     }
 
     using namespace tt;
@@ -1769,14 +1809,6 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
                     attributes.output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
                     "Output memory layout must be INTERLEAVED, got: {}",
                     attributes.output_mem_config.memory_layout());
-            }
-            if constexpr (
-                std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig> ||
-                std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig> ||
-                std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
-                TT_FATAL(
-                    (a_shape_padded[-1] / in0_tile.get_width()) % program_config.in0_block_w == 0,
-                    "Kt must be divisible by in0_block_w");
             }
         },
         chosen_program_config);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -479,35 +479,26 @@ void validate_matmul_work_distribution_and_gather_ring_topology(
         chosen_program_config);
 }
 
-void validate_matmul_fused_operations(
+void validate_matmul_bias(
     const std::optional<const Tensor>& optional_bias,
-    const std::optional<ttnn::operations::unary::UnaryWithParam>& fused_activation,
-    const operations::matmul::MatmulProgramConfig& chosen_program_config,
-    const std::optional<CoreCoord>& user_core_coord) {
-    // Determine which fused operations the chosen program config supports.
-    bool config_supports_fused_ops = false;
+    const operations::matmul::MatmulProgramConfig& chosen_program_config) {
+    // Determine which program configs support bias.
+    bool config_supports_bias = false;
     std::visit(
-        [&config_supports_fused_ops](const auto& program_config) {
+        [&config_supports_bias](const auto& program_config) {
             using ProgramConfigType = std::decay_t<decltype(program_config)>;
             // MatmulMultiCoreProgramConfig and MatmulMultiCoreReuseProgramConfig have no
-            // bias / fused_activation kernel paths. Other configs support both; gather_in0
-            // on 1D multicast rejects bias separately in its dedicated check below.
-            config_supports_fused_ops =
+            // bias kernel path. Other configs support bias; gather_in0 on 1D multicast
+            // rejects bias separately in its dedicated check below.
+            config_supports_bias =
                 !std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreProgramConfig> &&
                 !std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig>;
         },
         chosen_program_config);
 
-    // Bias has no fallback path regardless of how the config was chosen.
     TT_FATAL(
-        !optional_bias.has_value() || config_supports_fused_ops,
+        !optional_bias.has_value() || config_supports_bias,
         "Bias is not supported for this matmul program config: {}",
-        ttsl::get_active_type_name_in_variant(chosen_program_config));
-    // When user_core_coord is not set, the matmul wrapper applies activation separately
-    // via unary_chain after prim::matmul — the kernel does not need to fuse it here.
-    TT_FATAL(
-        !fused_activation.has_value() || config_supports_fused_ops || !user_core_coord.has_value(),
-        "Fused activation is not supported for this matmul program config: {}",
         ttsl::get_active_type_name_in_variant(chosen_program_config));
 }
 
@@ -909,8 +900,7 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
     validate_matmul_tile_constraints(input_tensor_a, input_tensor_b, in0_tile, in1_tile, chosen_program_config);
     validate_matmul_compute_grid_and_per_core_dims(input_tensor_a, chosen_program_config);
     validate_matmul_block_and_subblock_configuration(attributes, a_shape_padded, in0_tile, chosen_program_config);
-    validate_matmul_fused_operations(
-        optional_bias, attributes.user_fused_activation, chosen_program_config, attributes.user_core_coord);
+    validate_matmul_bias(optional_bias, chosen_program_config);
     validate_matmul_sharded_operand_grids_within_program_compute_grid(
         input_tensor_a, input_tensor_b, chosen_program_config);
     validate_matmul_reuse_sharded_output_block_divisibility(

--- a/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp
@@ -72,6 +72,41 @@ void SparseMatmulDeviceOperation::validate_on_program_cache_miss(
     const auto& input_tensor_b = tensor_args.input_tensors.at(1);
     const auto& sparsity = tensor_args.input_tensors.at(2);
 
+    TT_FATAL(
+        input_tensor_a.storage_type() == ttnn::StorageType::DEVICE &&
+            input_tensor_b.storage_type() == ttnn::StorageType::DEVICE &&
+            sparsity.storage_type() == ttnn::StorageType::DEVICE,
+        "All sparse matmul inputs must be on device");
+    TT_FATAL(
+        input_tensor_a.buffer() != nullptr && input_tensor_b.buffer() != nullptr && sparsity.buffer() != nullptr,
+        "All sparse matmul inputs must be allocated in buffers");
+    TT_FATAL(
+        input_tensor_a.device() == input_tensor_b.device() && input_tensor_a.device() == sparsity.device(),
+        "All sparse matmul inputs must be on the same device");
+    TT_FATAL(
+        input_tensor_a.layout() == ttnn::Layout::TILE,
+        "Input tensor A must be TILE layout, got {}",
+        input_tensor_a.layout());
+    TT_FATAL(
+        input_tensor_b.layout() == ttnn::Layout::TILE,
+        "Input tensor B must be TILE layout, got {}",
+        input_tensor_b.layout());
+    TT_FATAL(
+        is_floating_point(input_tensor_a.dtype()),
+        "Input tensor A must be a floating point type, got {}",
+        input_tensor_a.dtype());
+    TT_FATAL(
+        is_floating_point(input_tensor_b.dtype()),
+        "Input tensor B must be a floating point type, got {}",
+        input_tensor_b.dtype());
+    TT_FATAL(
+        sparsity.layout() == ttnn::Layout::ROW_MAJOR,
+        "Sparsity tensor must be ROW_MAJOR layout, got {}",
+        sparsity.layout());
+    TT_FATAL(
+        operation_attributes.is_input_a_sparse || operation_attributes.is_input_b_sparse,
+        "sparse_matmul requires at least one of is_input_a_sparse or is_input_b_sparse to be true");
+
     const auto& a_shape_padded = get_matmul_tensor_padded_shape(input_tensor_a, /*transpose=*/false);
     const auto& b_shape_padded = get_matmul_tensor_padded_shape(input_tensor_b, /*transpose=*/false);
     auto in0_tile = get_matmul_tile(input_tensor_a, /*transpose=*/false);
@@ -120,7 +155,9 @@ void SparseMatmulDeviceOperation::validate_on_program_cache_miss(
         b_shape_padded,
         in1_tile);
     TT_FATAL(
-        operation_attributes.nnz.value_or(1) > 0, "nnz ({}) must be greater than 0", operation_attributes.nnz.value());
+        operation_attributes.nnz.value_or(1) > 0,
+        "nnz ({}) must be greater than 0",
+        operation_attributes.nnz.value_or(1));
 
     // Check that nnz is less than or equal to the length of all batch dimensions
     uint32_t batch_length_A = 1;
@@ -149,14 +186,18 @@ void SparseMatmulDeviceOperation::validate_on_program_cache_miss(
     // Check that sparsity has enough entries
     TT_FATAL(
         sparsity.logical_volume() == batch_length,
-        "sparsity.logical_volume() ({}) must be equal to the product of all batch dimensions ({})",
+        "sparsity logical_volume ({}) must equal batch_length ({}) "
+        "[sparsity_shape={}, is_input_a_sparse={}, is_input_b_sparse={}]",
         sparsity.logical_volume(),
-        batch_length);
+        batch_length,
+        sparsity.logical_shape(),
+        operation_attributes.is_input_a_sparse,
+        operation_attributes.is_input_b_sparse);
 
     TT_FATAL(
         operation_attributes.nnz.value_or(1) <= batch_length,
         "nnz ({}) must be less than or equal to the length of all batch dimensions ({})",
-        operation_attributes.nnz,
+        operation_attributes.nnz.value_or(1),
         batch_length);
 
     // When nnz is supplied, the receiver and compute kernels loop exactly nnz times while the in0 sender


### PR DESCRIPTION
### Summary

Resolves #41958. 

Re-applies the reverted #45118 with the MNIST regression fixed.

### Problem description

Invalid matmul configurations reached the kernel factories before failing, producing opaque errors far from the actual cause. Phase 2 adds validate-time checks so bad configs fail early with clear, value-bearing messages.

This PR re-applies #45118, which was reverted because its fused-operations validator fired a false-positive `TT_FATAL` on MNIST (`ttnn.linear(..., activation="relu")` with no `core_grid` auto-selects `MatmulMultiCoreProgramConfig`, whose activation is legitimately handled post-matmul by the wrapper). Section 5 below is corrected accordingly.

### What's changed

**Section 5 - Bias validation (corrected vs #45118):**
`validate_matmul_bias` rejects bias only for `MatmulMultiCoreReuseProgramConfig`, the one config with neither a fused-bias kernel path nor a wrapper post-process fallback. Verified on hardware:
- `MatmulMultiCoreProgramConfig` + bias -> handled by `get_post_process_bias()` (`ttnn::add` post-step) -> no longer rejected.
- `MatmulMultiCoreReuseProgramConfig` + bias -> no fallback -> kept the `TT_FATAL`.
- For both `MatmulMultiCoreProgramConfig` and `MatmulMultiCoreReuseProgramConfig` + activation -> handled by `unary_chain` when `user_core_coord` is unset -> activation rejection removed entirely.


**Section 6 - Block/subblock configuration:**
- Centralized the `Kt % in0_block_w == 0` check with both values shown in the message, and ordered `in0_block_w != 0` ahead of the modulo check. 
- Removed the old vague `"Kt must be divisible by in0_block_w"` check from the large `std::visit`.

**Section 7 - Sparse matmul:**
- Added early input sanity checks for tensors A, B, and sparsity: storage type, buffer allocation, same-device, TILE layout (A/B), floating-point dtype (A/B), ROW_MAJOR sparsity layout, and at-least-one-of `is_input_a_sparse`/`is_input_b_sparse`. 
- Volume-mismatch error now includes sparsity shape and the sparse flags. 
- Fixed `nnz.value()` -> `nnz.value_or(1)` to avoid UB on an empty optional.

### Tests

- `test_linear_fused_activation_numerical_stability` - finite outputs across 10 fused activations.
- Negative validation tests: `test_linear_bias_rejected_on_multicore_reuse_program_config`, `test_matmul_kt_not_divisible_by_in0_block_w_rejected`, and seven sparse-matmul rejection tests (sparse-flag, volume, layout×2, dtype×2, sparsity-layout).
- Removed `test_matmul_activation_rejected_on_multicore_reuse_program_config` - it asserted a fatal that no longer exists.
- All negative tests use the repo `expect_error` fixture.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/matmul-validation-part2-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/matmul-validation-part2-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/matmul-validation-part2-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/matmul-validation-part2-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/matmul-validation-part2-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/matmul-validation-part2-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/matmul-validation-part2-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/matmul-validation-part2-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/matmul-validation-part2-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/matmul-validation-part2-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/matmul-validation-part2-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/matmul-validation-part2-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/matmul-validation-part2-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/matmul-validation-part2-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/matmul-validation-part2-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/matmul-validation-part2-fix)