### PR TITLE
[Quasar] Enable square SFPU op 

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -69,6 +69,7 @@ const map<std::string, std::map<std::string, std::string>> sfpu_op_to_op_name = 
     {"sign", {{"SFPU_OP_CHAIN_0", "sign_tile_init(); sign_tile(0);"}}},
     {"rsqrt", {{"SFPU_OP_CHAIN_0", "rsqrt_tile_init(); rsqrt_tile(0);"}}},
     {"mul_unary", {{"SFPU_OP_CHAIN_0", "binop_with_scalar_tile_init(); mul_unary_tile(0, 0x40000000u);"}}},  // 2.0f
+    {"square", {{"SFPU_OP_CHAIN_0", "square_tile_init(); square_tile(0);"}}},
     // Comparison-to-zero family (unary): result = 1.0f if predicate(x, 0) else 0.0f.
     {"eqz", {{"SFPU_OP_CHAIN_0", "eqz_tile_init(); eqz_tile(0);"}}},
     {"nez", {{"SFPU_OP_CHAIN_0", "nez_tile_init(); nez_tile(0);"}}},
@@ -162,6 +163,9 @@ float sfpu_function(const std::string& op_name, float input) {
     }
     if (op_name == "mul_unary") {
         return bfloat16(static_cast<float>(input) * 2.0f);
+    }
+    if (op_name == "square") {
+        return bfloat16(static_cast<float>(input) * static_cast<float>(input));
     }
     if (op_name == "eqz") {
         return bfloat16(static_cast<float>(input) == 0.0f ? 1.0f : 0.0f);
@@ -1231,6 +1235,8 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple(4, "gtz"),
         std::make_tuple(4, "gez"),
         std::make_tuple(4, "lez"),
+        std::make_tuple(1, "square"),
+        std::make_tuple(4, "square"),
         std::make_tuple(1, "relu"),
         std::make_tuple(1, "exponential"),
         std::make_tuple(1, "reciprocal"),

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
@@ -17,9 +17,9 @@ namespace sfpu {
  *
  * Programs ADDR_MOD_6 with a dest increment of 2 (one SFPU pass writes 2 rows on Quasar).
  *
- * @note Call this before @ref _calculate_square_ to set up the address mode it relies on.
+ * @note Call this before @ref calculate_square to set up the address mode it relies on.
  */
-inline void _init_square_() {
+inline void init_square() {
     addr_mod_t{
         .srca = {.incr = 0},
         .srcb = {.incr = 0},
@@ -34,7 +34,7 @@ inline void _init_square_() {
  * Loads x from dest, multiplies it by itself, and stores the result back to dest using
  * ADDR_MOD_6 to advance to the next pair of rows.
  *
- * @note ADDR_MOD_6 must already be programmed by @ref _init_square_.
+ * @note ADDR_MOD_6 must already be programmed by @ref init_square.
  */
 inline void _calculate_square_sfp_rows_() {
     sfpi::vFloat v = sfpi::dst_reg[0];  // load x from dest (SFPLOAD)
@@ -45,10 +45,10 @@ inline void _calculate_square_sfp_rows_() {
  * @brief Square a full Dest tile in place: dest = x * x.
  *
  * @tparam ITERATIONS: Number of SFPU passes (each covers 2 rows) needed to span the tile.
- * @note Call @ref _init_square_ before this to program the address mode it depends on.
+ * @note Call @ref init_square before this to program the address mode it depends on.
  */
 template <int ITERATIONS = SFPU_ITERATIONS>
-inline void _calculate_square_() {
+inline void calculate_square() {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         _calculate_square_sfp_rows_();

--- a/tt_metal/hw/inc/api/compute/compute_kernel_api.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_api.h
@@ -55,6 +55,7 @@
 #include "ckernel_sfpu_sigmoid.h"
 #include "ckernel_sfpu_silu.h"
 #include "ckernel_sfpu_tanh.h"
+#include "ckernel_sfpu_square.h"
 #include "llk_math_eltwise_unary_sfpu_macros.h"
 #include "llk_math_eltwise_binary_sfpu_binop.h"
 #include "llk_math_eltwise_binary_sfpu_add_int.h"
@@ -222,6 +223,39 @@ ALWI void tanh_tile(uint32_t idst) {
 #else
     MATH(SFPU_UNARY_CALL(
         DST_SYNC_MODE, DST_ACCUM_MODE, calculate_tanh, (8 /* ITERATIONS */), idst, ::ckernel::VectorMode::RC));
+#endif
+}
+
+// clang-format off
+/**
+ * Performs element-wise computation of square value on each element of a tile
+ * in DST register at index tile_index. The DST register buffer must be in
+ * acquired state via *acquire_dst* call. This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
+ * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void square_tile(uint32_t idst) {
+#ifndef ARCH_QUASAR
+    MATH(SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_square, (APPROX), idst, VectorMode::RC));
+#else
+    MATH(SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_square, (SFPU_ITERATIONS), idst, VectorMode::RC));
+#endif
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void square_tile_init() {
+#ifndef ARCH_QUASAR
+    MATH(SFPU_UNARY_INIT(square));
+#else
+    MATH(SFPU_UNARY_INIT(square, sfpu::init_square));
 #endif
 }
 
@@ -451,29 +485,6 @@ ALWI void sign_tile(uint32_t idst) {
  * Please refer to documentation for any_init.
  */
 ALWI void sign_tile_init() { MATH(SFPU_UNARY_INIT(sign)); }
-
-// clang-format off
-/**
- * Performs element-wise computation of square value on each element of a tile
- * in DST register at index tile_index. The DST register buffer must be in
- * acquired state via *acquire_dst* call. This call is blocking and is only
- * available on the compute engine.
- *
- * Return value: None
- *
- * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
- * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
- */
-// clang-format on
-ALWI void square_tile(uint32_t idst) {
-    MATH(SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_square, (APPROX), idst, VectorMode::RC));
-}
-
-/**
- * Please refer to documentation for any_init.
- */
-ALWI void square_tile_init() { MATH(SFPU_UNARY_INIT(square)); }
 
 // clang-format off
 /**

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
@@ -80,7 +80,7 @@ void init_unary_sfpu_operation_quasar()
     }
     else if constexpr (OPERATION == SfpuType::square)
     {
-        _init_square_();
+        init_square();
     }
     else if constexpr (is_zero_comp_op(OPERATION))
     {
@@ -199,7 +199,7 @@ void call_unary_sfpu_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_f
     }
     else if constexpr (OPERATION == SfpuType::square)
     {
-        _llk_math_eltwise_unary_sfpu_params_(_calculate_square_<ITERATIONS>, dst_index);
+        _llk_math_eltwise_unary_sfpu_params_(calculate_square<ITERATIONS>, dst_index);
     }
     else if constexpr (is_zero_comp_op(OPERATION))
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_square_trisc3_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_square_trisc3_quasar_test.cpp
@@ -137,11 +137,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
 
     _llk_math_eltwise_sfpu_init_();
-    _init_square_();
+    init_square();
 
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {
-        SFPU_UNARY_CALL(dest_sync, is_fp32_dest_acc_en, _calculate_square_, (SFPU_ITERATIONS), params.DST_INDEX + i, VectorMode::RC);
+        SFPU_UNARY_CALL(dest_sync, is_fp32_dest_acc_en, calculate_square, (SFPU_ITERATIONS), params.DST_INDEX + i, VectorMode::RC);
     }
 
     _llk_math_set_dvalid_<p_cleardvalid::SFPU, dest_sync>();


### PR DESCRIPTION
Stacked on #47804 (base = `njokovic/eqz-compute-api`) so the diff shows only the square changes; will retarget to `main` once #47804 merges.

Enables `ckernel_sfpu_square.h` for the Quasar compute API:
- `square_tile`/`square_tile_init` route through the metal `_calculate_square_`/`_init_square_` functor on Quasar (carved out of the `#ifndef ARCH_QUASAR` block in `compute_kernel_api.h`).
- Added `square` to the unary SFPU test (`test_sfpu_compute.cpp`).

Verified on the Quasar emulator: `square_1tiles` and `square_4tiles` pass.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=njokovic/sfpu-square-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:njokovic/sfpu-square-compute-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=njokovic/sfpu-square-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:njokovic/sfpu-square-compute-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=njokovic/sfpu-square-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:njokovic/sfpu-square-compute-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=njokovic/sfpu-square-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:njokovic/sfpu-square-compute-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=njokovic/sfpu-square-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:njokovic/sfpu-square-compute-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=njokovic/sfpu-square-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:njokovic/sfpu-square-compute-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=njokovic/sfpu-square-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:njokovic/sfpu-square-compute-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=njokovic/sfpu-square-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:njokovic/sfpu-square-compute-api)