### PR TITLE
Fix failing sfpu reduction tests on CI

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -1579,14 +1579,19 @@ inline void calculate_reduce(std::uint32_t block_ct_dim = 1, std::uint32_t block
         is_supported_reduce_format(format),
         "Unsupported data format. Supported formats: Int32, UInt32, UInt16, Float32, Float16_b");
 
-    // Int32 load/store mode per reduction. Operands are two's-complement in DEST.
-    //   SUM: plain INT32 so SFPIADD (a two's-complement adder) gets the word unchanged; the reduce code's
-    //        explicit sign-magnitude<->two's-complement cast only runs under INT32_2S_COMP, so plain INT32
-    //        skips it.
-    //   AVG: INT32_2S_COMP, which its divide-by-32 step assumes.
-    //   MAX/MIN column reduce: INT32_2S_COMP. On Blackhole the load/store conversion is a no-op, so the
-    //        column path casts explicitly around a sign-magnitude SFPSWAP. Scoped to REDUCE_COL so the
-    //        row-MAX path keeps plain INT32.
+    // Int32 DEST representation and load/store mode per reduction. On Blackhole INT32_2S_COMP is a no-op
+    // (tt-isa SFPLOAD.md: MOD0_FMT_INT32_SM is deprecated and performs no conversion), so any
+    // sign-magnitude<->two's-complement change is done explicitly via SFPCAST. The DEST encoding the test
+    // and ttnn feed differs per pool (SUM/MAX/MIN are two's-complement; AVG is sign-magnitude):
+    //   SUM (two's-complement): plain INT32 so SFPIADD (a two's-complement adder) gets the word unchanged;
+    //        the explicit cast only runs under INT32_2S_COMP, so plain INT32 skips it.
+    //   MAX/MIN column reduce (two's-complement): INT32_2S_COMP, but the column path casts each operand
+    //        two's-complement->sign-magnitude around the sign-magnitude SFPSWAP and back. Scoped to
+    //        REDUCE_COL so the row-MAX path keeps plain INT32.
+    //   Row MAX (sign-magnitude): plain INT32; SFPSWAP already compares in sign-magnitude, so no cast.
+    //   AVG (sign-magnitude): INT32_2S_COMP. The path casts sign-magnitude->two's-complement for the
+    //        SFPIADD accumulate and back before the store, and perform_int_average's divide-by-32 is wired
+    //        for this mode, so the DEST word stays sign-magnitude (unlike SUM).
     constexpr bool int32_avg = (format == DataFormat::Int32 && pool_type == PoolType::AVG);
     constexpr bool int32_max_min_col =
         (format == DataFormat::Int32 && (pool_type == PoolType::MAX || pool_type == PoolType::MIN) &&

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -55,17 +55,16 @@ inline void load_and_clear_high_bits(
 // Helper Functions
 // ============================================================================
 
-// Int32 SUM/AVG keep their data in dest as sign-magnitude (matching the MAX/MIN path and the packer),
-// but SFPIADD is a two's-complement adder. Wormhole bridges this with the INT32_2S_COMP load/store mode,
-// which converts sign-magnitude<->two's-complement in hardware; on Blackhole that conversion is a no-op
-// (tenstorrent/tt-llk-bh#16), so we must do it explicitly: convert each operand to two's-complement right
-// after load, and convert results back to sign-magnitude right before store.
+// SFPIADD adds in two's-complement while SFPSWAP compares in sign-magnitude, so the Int32 reduce paths
+// have to move operands between the two encodings. Wormhole does this in the INT32_2S_COMP load/store
+// mode; on Blackhole that mode is deprecated and does not convert (BlackholeA0 SFPLOAD.md), so the reduce
+// code converts explicitly with this helper.
 //
-// We use the same SFPCAST+SFPSETSGN primitive as the proven element-wise int kernels (see _add_int_): it is
-// direction-neutral (the same cast mode converts both ways) and, crucially, uses no condition codes, so it is
-// robust regardless of SFPABS/cc interaction. It requires one free GPR (LREG0-7) as scratch; LREG8-15 are
-// constant/config registers that SFPCAST cannot write.
-// "Representation swap": converts an integer between its sign-magnitude and two's-complement representations.
+// It uses the same SFPCAST+SFPSETSGN primitive as the element-wise int kernels (see _add_int_): the cast
+// is direction-neutral (one mode converts both ways) and uses no condition codes, so it is robust against
+// SFPABS/cc interaction. It needs one free GPR (LREG0-7) as scratch; LREG8-15 are constant/config
+// registers that SFPCAST cannot write.
+// "Representation swap": converts an integer between sign-magnitude and two's-complement.
 constexpr InstrModCast REDUCE_INT_REPRESENTATION_SWAP_CAST = InstrModCast::INT_SIGN_MAGN_TO_INT32_2S_COMP;
 
 // Convert one int operand between sign-magnitude and two's-complement, in place. `scratch_gpr` must be a free
@@ -1226,29 +1225,25 @@ inline void calculate_reduce_max_min_uint16() {
 }
 
 /**
- * @brief Column-wise maximum/minimum reduction kernel for Int32 (issue #47647, Blackhole).
+ * @brief Column-wise Int32 MAX/MIN reduction for Blackhole.
  *
- * Int32 MAX/MIN column reduce receives its operands in two's-complement (both the real data and the
- * dim=0/dim=1 pad sentinels 0x80000001 / 0x7FFFFFFF that ttnn/tt-llk inject), but SFPSWAP(VEC_MIN_MAX)
- * is a sign-magnitude comparator (tt-isa SFPSWAP.md): two's-complement negatives and the sentinels are
- * mis-ordered by it, which is the #47647 regression. On Wormhole the INT32_2S_COMP load/store mode (12)
- * converts two's-complement<->sign-magnitude in hardware, so the float/UInt32 LOADMACRO path
- * (calculate_reduce_max_min) just works; on Blackhole that mode is a deprecated no-op (tt-isa
- * SFPLOAD.md / tt-llk-bh#16), so the conversion must be done explicitly with SFPCAST+SFPSETSGN.
+ * Int32 operands reach DEST as two's-complement (real data plus the dim=0/dim=1 pad sentinels
+ * 0x80000001 / 0x7FFFFFFF), but SFPSWAP(VEC_MIN_MAX) compares in sign-magnitude, so it mis-orders
+ * two's-complement negatives and the sentinels. On Wormhole the INT32_2S_COMP load/store mode converts
+ * between the two encodings in hardware and the float/UInt32 LOADMACRO path handles it for free; on
+ * Blackhole that mode is deprecated and does not convert, so we cast explicitly with SFPCAST+SFPSETSGN.
  *
- * Because CAST and SWAP are both SIMPLE instructions they cannot be fused inside a LOADMACRO, so we use
- * the same manual load/swap structure as calculate_reduce_max_min_uint16() (which exists for the
- * analogous "mask cannot live inside a LOADMACRO" reason), substituting the UInt16 high-bit masks with
- * representation casts: convert each operand two's-complement -> sign-magnitude after load, run the
- * sign-magnitude compare-and-swap reduce, then convert the winners sign-magnitude -> two's-complement
- * before the packer-visible store. Reuses init_reduce_max_min_int32()'s 3-swap replay buffer and
- * swap-direction config. Single 32x32 tile per call (block height 1), matching the column-reduce driver.
+ * CAST and SWAP are both SIMPLE instructions and cannot be fused into a LOADMACRO, so this mirrors the
+ * manual load/swap structure of calculate_reduce_max_min_uint16(): load each operand, cast it
+ * two's-complement -> sign-magnitude, run the compare-and-swap reduce, then cast the winners back to
+ * two's-complement before the store. Reuses init_reduce_max_min_int32()'s 3-swap replay buffer and
+ * swap-direction config. One 32x32 tile per call (block height 1), matching the column-reduce driver.
  *
- * @tparam pool_type The pool type (MAX or MIN) to determine swap direction
- * @tparam reduce_dim The reduction dimension (currently only REDUCE_COL is supported)
- * @tparam INSTRUCTION_MODE INT32_2S_COMP (raw no-op load/store on Blackhole)
- * @tparam clear_high_bits Unused for Int32 (always false); kept for signature symmetry
- * @tparam pack_low16 Unused for Int32 (always false); kept for signature symmetry
+ * @tparam pool_type MAX or MIN (sets swap direction)
+ * @tparam reduce_dim Only REDUCE_COL is supported
+ * @tparam INSTRUCTION_MODE INT32_2S_COMP (a raw no-op load/store on Blackhole)
+ * @tparam clear_high_bits Unused for Int32; kept for signature symmetry
+ * @tparam pack_low16 Unused for Int32; kept for signature symmetry
  */
 template <
     PoolType pool_type,
@@ -1277,10 +1272,9 @@ inline void calculate_reduce_max_min_int32() {
     // packer-visible two's-complement result. Both use the plain (raw, no-op on Blackhole) instruction mode.
     constexpr std::uint32_t STORE_MODE = static_cast<std::uint32_t>(INSTRUCTION_MODE);
 
-    // Establish the manual compare-and-swap setup here rather than relying on init_reduce(): the shared
-    // reduce init cannot tell a column reduce from a row-MAX reduce, and the two need opposite SFPSWAP
-    // directions. This records the 3-swap replay buffer (slots 0-2) and sets the swap-direction config for
-    // the sign-magnitude manual path (the same setup the UInt16 manual path gets from its paired init).
+    // Record the 3-swap replay buffer (slots 0-2) and swap-direction config here rather than in
+    // init_reduce(): the shared init cannot tell a column reduce from a row-MAX reduce, which need
+    // opposite SFPSWAP directions.
     init_reduce_max_min_int32<INSTRUCTION_MODE, pool_type>();
 
     for (std::uint32_t j = 0; j < 2; j++) {
@@ -1498,13 +1492,13 @@ inline void init_reduce(std::uint32_t block_ct_dim = 1) {
         is_supported_reduce_format(format),
         "Unsupported data format. Supported formats: Int32, UInt32, UInt16, Float32, Float16_b");
 
-    // Int32 SUM loads with plain INT32. The dest word is already two's-complement and SFPIADD adds in
-    // two's-complement. The explicit sign-magnitude<->two's-complement cast in the reduce code only runs
-    // under INT32_2S_COMP, so plain INT32 skips it; otherwise the cast would mangle the already-two's-
-    // complement operand and break negatives. AVG keeps INT32_2S_COMP (its divide-by-32 step relies on it),
-    // and MAX/MIN keep INT32_2S_COMP to match the column-reduce path. init_reduce has no reduce_dim, but the
-    // row-MAX path re-records its own replay buffer, so picking INT32_2S_COMP for every Int32 MAX/MIN here
-    // does no harm.
+    // Int32 reduce operands are two's-complement in DEST. SUM loads with plain INT32 so the word reaches
+    // SFPIADD (a two's-complement adder) unchanged; the reduce code's explicit sign-magnitude<->two's-
+    // complement cast only runs under INT32_2S_COMP, so plain INT32 skips it. MAX/MIN use INT32_2S_COMP so
+    // SFPSWAP (a sign-magnitude comparator) gets sign-magnitude operands, the cast being applied in the
+    // manual column path. AVG keeps INT32_2S_COMP; its divide-by-32 step assumes that mode. init_reduce has
+    // no reduce_dim, so every Int32 MAX/MIN takes INT32_2S_COMP here; the row-MAX path re-records its own
+    // replay buffer regardless.
     constexpr bool int32_2s_comp =
         (format == DataFormat::Int32 &&
          (pool_type == PoolType::AVG || pool_type == PoolType::MAX || pool_type == PoolType::MIN));
@@ -1527,11 +1521,10 @@ inline void init_reduce(std::uint32_t block_ct_dim = 1) {
             // replay buffer and swap-direction config (the body is format-agnostic).
             init_reduce_max_min_int32<INSTRUCTION_MODE, pool_type>();
         } else {
-            // Int32 column MAX/MIN (issue #47647) records its own 3-swap buffer and swap-direction config
-            // inside calculate_reduce_max_min_int32() because the shared init cannot distinguish a column
-            // reduce (needs the manual sign-magnitude swap setup) from a row-MAX reduce (needs the default
-            // direction). For Int32 this LOADMACRO setup is therefore overwritten and harmless; row-MAX
-            // re-records its own buffer too.
+            // Int32 column MAX/MIN records its own 3-swap buffer and swap direction inside
+            // calculate_reduce_max_min_int32(), since the shared init cannot tell a column reduce (manual
+            // sign-magnitude swap) from a row-MAX reduce (default direction). This LOADMACRO setup is
+            // overwritten for Int32; the row-MAX path re-records its own buffer too.
             init_reduce_max_min<INSTRUCTION_MODE, pool_type, false>(block_ct_dim);
         }
     } else if constexpr (pool_type == PoolType::SUM || pool_type == PoolType::AVG) {
@@ -1576,15 +1569,14 @@ inline void calculate_reduce(std::uint32_t block_ct_dim = 1, std::uint32_t block
         is_supported_reduce_format(format),
         "Unsupported data format. Supported formats: Int32, UInt32, UInt16, Float32, Float16_b");
 
-    // Pick the load/store mode for each Int32 reduction:
-    //   * SUM uses plain INT32. The dest word is already two's-complement and SFPIADD adds in two's-complement,
-    //     so it has to reach the adder untouched. The explicit sign-magnitude<->two's-complement cast in the
-    //     reduce code only runs under INT32_2S_COMP, so plain INT32 skips it; otherwise it would mangle the
-    //     already-two's-complement operand and break negatives.
-    //   * AVG uses INT32_2S_COMP, which its divide-by-32 step depends on.
-    //   * MAX/MIN column reduce uses INT32_2S_COMP. On Blackhole the load/store conversion is a no-op, so the
-    //     column path casts explicitly around a sign-magnitude SFPSWAP. Scoped to REDUCE_COL so the row-MAX
-    //     path stays on plain sign-magnitude INT32.
+    // Int32 load/store mode per reduction. Operands are two's-complement in DEST.
+    //   SUM: plain INT32 so SFPIADD (a two's-complement adder) gets the word unchanged; the reduce code's
+    //        explicit sign-magnitude<->two's-complement cast only runs under INT32_2S_COMP, so plain INT32
+    //        skips it.
+    //   AVG: INT32_2S_COMP, which its divide-by-32 step assumes.
+    //   MAX/MIN column reduce: INT32_2S_COMP. On Blackhole the load/store conversion is a no-op, so the
+    //        column path casts explicitly around a sign-magnitude SFPSWAP. Scoped to REDUCE_COL so the
+    //        row-MAX path keeps plain INT32.
     constexpr bool int32_avg = (format == DataFormat::Int32 && pool_type == PoolType::AVG);
     constexpr bool int32_max_min_col =
         (format == DataFormat::Int32 && (pool_type == PoolType::MAX || pool_type == PoolType::MIN) &&
@@ -1615,9 +1607,9 @@ inline void calculate_reduce(std::uint32_t block_ct_dim = 1, std::uint32_t block
             // UInt16 in 32-bit dest: manual load/mask/swap path (LOADMACRO cannot mask between load and swap).
             calculate_reduce_max_min_uint16<pool_type, reduce_dim, INSTRUCTION_MODE, clear_high_bits, pack_low16>();
         } else if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP) {
-            // Int32 column reduce (issue #47647): manual load/cast/swap path. The cast cannot live inside a
-            // LOADMACRO, and on Blackhole the mode-12 load/store does not convert two's-complement<->sign-
-            // magnitude, so we convert explicitly around a sign-magnitude SFPSWAP reduce.
+            // Int32 column reduce: manual load/cast/swap path. The cast cannot live inside a LOADMACRO, and
+            // on Blackhole INT32_2S_COMP does not convert two's-complement<->sign-magnitude, so we cast
+            // explicitly around a sign-magnitude SFPSWAP reduce.
             calculate_reduce_max_min_int32<pool_type, reduce_dim, INSTRUCTION_MODE, false, pack_low16>();
         } else {
             calculate_reduce_max_min<pool_type, reduce_dim, INSTRUCTION_MODE, false, pack_low16>(block_rt_dim);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -1387,10 +1387,14 @@ inline void init_reduce(std::uint32_t block_ct_dim = 1) {
     // sign-magnitude<->two's-complement explicitly). Int32 MAX/MIN keep plain INT32 (sign-magnitude):
     // SFPSWAP(VEC_MIN_MAX) is a float/sign-magnitude comparator that orders sign-magnitude integers
     // correctly, whereas two's-complement negatives would be mis-ordered.
-    constexpr bool int32_sum_avg =
-        (format == DataFormat::Int32 && (pool_type == PoolType::SUM || pool_type == PoolType::AVG));
+    // Option A (issue #47647): Int32 MAX/MIN revert to INT32_2S_COMP to match the column-reduce calculate
+    // path. init_reduce has no reduce_dim template arg; the row-MAX path re-records its own replay buffer
+    // and ignores this LOADMACRO setup, so selecting INT32_2S_COMP for all Int32 MAX/MIN is safe here.
+    constexpr bool int32_2s_comp =
+        (format == DataFormat::Int32 && (pool_type == PoolType::SUM || pool_type == PoolType::AVG ||
+                                         pool_type == PoolType::MAX || pool_type == PoolType::MIN));
     constexpr InstrModLoadStore INSTRUCTION_MODE =
-        int32_sum_avg ? InstrModLoadStore::INT32_2S_COMP : GetSfpLoadStoreInstrMod<format, is_fp32_dest_acc_en>();
+        int32_2s_comp ? InstrModLoadStore::INT32_2S_COMP : GetSfpLoadStoreInstrMod<format, is_fp32_dest_acc_en>();
 
     // Garbage high bits needs to be cleared when loading UInt16 data
     constexpr bool clear_high_bits = (is_fp32_dest_acc_en && format == DataFormat::UInt16);
@@ -1458,10 +1462,17 @@ inline void calculate_reduce(std::uint32_t block_ct_dim = 1, std::uint32_t block
     // explicitly). Int32 MAX/MIN (both dims) keep plain INT32 (sign-magnitude): SFPSWAP(VEC_MIN_MAX) is a
     // float/sign-magnitude comparator that orders sign-magnitude integers correctly; two's-complement
     // negatives are mis-ordered (min of negatives would return the least-negative value).
+    // Option A (issue #47647): Int32 MAX/MIN column reduce reverts to INT32_2S_COMP (pre-#46231). Scoped
+    // to REDUCE_COL so the row-MAX path keeps plain sign-magnitude INT32 (its static_assert below requires
+    // FP32/INT32/FP16B). On Blackhole the mode-12 load/store conversion is a no-op, so this is benign here.
     constexpr bool int32_sum_avg =
         (format == DataFormat::Int32 && (pool_type == PoolType::SUM || pool_type == PoolType::AVG));
-    constexpr InstrModLoadStore INSTRUCTION_MODE =
-        int32_sum_avg ? InstrModLoadStore::INT32_2S_COMP : GetSfpLoadStoreInstrMod<format, is_fp32_dest_acc_en>();
+    constexpr bool int32_max_min_col =
+        (format == DataFormat::Int32 && (pool_type == PoolType::MAX || pool_type == PoolType::MIN) &&
+         reduce_dim == ReduceDim::REDUCE_COL);
+    constexpr InstrModLoadStore INSTRUCTION_MODE = (int32_sum_avg || int32_max_min_col)
+                                                       ? InstrModLoadStore::INT32_2S_COMP
+                                                       : GetSfpLoadStoreInstrMod<format, is_fp32_dest_acc_en>();
 
     // Garbage high bits needs to be cleared when loading UInt16 data (driven by INPUT format).
     constexpr bool clear_high_bits = (is_fp32_dest_acc_en && format == DataFormat::UInt16);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -1226,6 +1226,122 @@ inline void calculate_reduce_max_min_uint16() {
 }
 
 /**
+ * @brief Column-wise maximum/minimum reduction kernel for Int32 (issue #47647, Blackhole).
+ *
+ * Int32 MAX/MIN column reduce receives its operands in two's-complement (both the real data and the
+ * dim=0/dim=1 pad sentinels 0x80000001 / 0x7FFFFFFF that ttnn/tt-llk inject), but SFPSWAP(VEC_MIN_MAX)
+ * is a sign-magnitude comparator (tt-isa SFPSWAP.md): two's-complement negatives and the sentinels are
+ * mis-ordered by it, which is the #47647 regression. On Wormhole the INT32_2S_COMP load/store mode (12)
+ * converts two's-complement<->sign-magnitude in hardware, so the float/UInt32 LOADMACRO path
+ * (calculate_reduce_max_min) just works; on Blackhole that mode is a deprecated no-op (tt-isa
+ * SFPLOAD.md / tt-llk-bh#16), so the conversion must be done explicitly with SFPCAST+SFPSETSGN.
+ *
+ * Because CAST and SWAP are both SIMPLE instructions they cannot be fused inside a LOADMACRO, so we use
+ * the same manual load/swap structure as calculate_reduce_max_min_uint16() (which exists for the
+ * analogous "mask cannot live inside a LOADMACRO" reason), substituting the UInt16 high-bit masks with
+ * representation casts: convert each operand two's-complement -> sign-magnitude after load, run the
+ * sign-magnitude compare-and-swap reduce, then convert the winners sign-magnitude -> two's-complement
+ * before the packer-visible store. Reuses init_reduce_max_min_int32()'s 3-swap replay buffer and
+ * swap-direction config. Single 32x32 tile per call (block height 1), matching the column-reduce driver.
+ *
+ * @tparam pool_type The pool type (MAX or MIN) to determine swap direction
+ * @tparam reduce_dim The reduction dimension (currently only REDUCE_COL is supported)
+ * @tparam INSTRUCTION_MODE INT32_2S_COMP (raw no-op load/store on Blackhole)
+ * @tparam clear_high_bits Unused for Int32 (always false); kept for signature symmetry
+ * @tparam pack_low16 Unused for Int32 (always false); kept for signature symmetry
+ */
+template <
+    PoolType pool_type,
+    ReduceDim reduce_dim,
+    InstrModLoadStore INSTRUCTION_MODE,
+    bool clear_high_bits,
+    bool pack_low16>
+inline void calculate_reduce_max_min_int32() {
+    static_assert(reduce_dim == ReduceDim::REDUCE_COL, "Only column reduction (REDUCE_COL) is currently supported");
+    static_assert(
+        pool_type == PoolType::MAX || pool_type == PoolType::MIN,
+        "Only MAX and MIN pool types are supported for this function");
+
+    constexpr std::uint32_t ODD_COLUMNS = 2;
+    constexpr std::uint32_t COLUMN_OFFSETS[4] = {0, 2, 0, 2};  // even, odd, even, odd
+    constexpr std::uint32_t FACE_ADDRS[2][4] = {
+        {0, 0, 32, 32},   // j=0: Face 0 and Face 2
+        {16, 16, 48, 48}  // j=1: Face 1 and Face 3
+    };
+    constexpr std::uint32_t FINAL_REDUCE_ADDRS[2][2] = {
+        {0, 32},  // j=0: Face 0 and Face 2
+        {16, 48}  // j=1: Face 1 and Face 3
+    };
+
+    // Intermediate stores hold sign-magnitude partials reloaded below; the final row-0 stores write the
+    // packer-visible two's-complement result. Both use the plain (raw, no-op on Blackhole) instruction mode.
+    constexpr std::uint32_t STORE_MODE = static_cast<std::uint32_t>(INSTRUCTION_MODE);
+
+    // Establish the manual compare-and-swap setup here rather than relying on init_reduce(): the shared
+    // reduce init cannot tell a column reduce from a row-MAX reduce, and the two need opposite SFPSWAP
+    // directions. This records the 3-swap replay buffer (slots 0-2) and sets the swap-direction config for
+    // the sign-magnitude manual path (the same setup the UInt16 manual path gets from its paired init).
+    init_reduce_max_min_int32<INSTRUCTION_MODE, pool_type>();
+
+    for (std::uint32_t j = 0; j < 2; j++) {
+        std::uint32_t top_face_addr = FINAL_REDUCE_ADDRS[j][0];     // face 0 & 1 dst indices
+        std::uint32_t bottom_face_addr = FINAL_REDUCE_ADDRS[j][1];  // face 2 & 3 dst indices
+
+        // Reduce each of the four vertically adjacent faces within itself; its max/min of 16 rows is left
+        // in the top 4 rows.
+        for (std::uint32_t i = 0; i < NUM_FACES; i++) {
+            // Raw-load 16 rows of the face straight into LREG4-7 (two's-complement; mode-12 load is a no-op).
+            load_face_data<INSTRUCTION_MODE, false, p_sfpu::LREG4>(FACE_ADDRS[j][i], COLUMN_OFFSETS[i]);
+
+            // Convert each operand two's-complement -> sign-magnitude so the sign-magnitude SFPSWAP
+            // comparator orders negatives and the two's-complement pad sentinels correctly. LREG0-3 are free.
+            convert_int_representation_inplace(p_sfpu::LREG4, p_sfpu::LREG0);
+            convert_int_representation_inplace(p_sfpu::LREG5, p_sfpu::LREG1);
+            convert_int_representation_inplace(p_sfpu::LREG6, p_sfpu::LREG2);
+            convert_int_representation_inplace(p_sfpu::LREG7, p_sfpu::LREG3);
+
+            lltt::replay(0, 3);  // compare-and-swap reduce LREG4-7 -> LREG4 (sign-magnitude)
+
+            // Store the sign-magnitude partial back to dest; reloaded below for the cross-face reduce.
+            TT_SFPSTORE(p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_7, FACE_ADDRS[j][i] + COLUMN_OFFSETS[i]);
+        }
+
+        // Reload the partial max/min (top 4 rows) of the two vertically adjacent faces. They were stored
+        // as sign-magnitude, so a raw load keeps them sign-magnitude (no cast needed here).
+        load_and_clear_high_bits<false>(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, top_face_addr);
+        load_and_clear_high_bits<false>(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, bottom_face_addr);
+        load_and_clear_high_bits<false>(p_sfpu::LREG2, INSTRUCTION_MODE, ADDR_MOD_7, top_face_addr + ODD_COLUMNS);
+        load_and_clear_high_bits<false>(p_sfpu::LREG3, INSTRUCTION_MODE, ADDR_MOD_7, bottom_face_addr + ODD_COLUMNS);
+
+        // Move into LREG4-7 for the transpose + cross-row reduction.
+        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG4, 0);
+        TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG5, 0);
+        TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG6, 0);
+        TTI_SFPMOV(0, p_sfpu::LREG3, p_sfpu::LREG7, 0);
+
+        // Transpose so the 4 partial results of each column sit in one register, reduce, transpose back.
+        TTI_SFPTRANSP(0, 0, 0, 0);
+        lltt::replay(0, 3);
+        TTI_SFPTRANSP(0, 0, 0, 0);
+
+        // Swap to combine the two vertically adjacent faces (even and odd columns).
+        TTI_SFPSWAP(0, p_sfpu::LREG7, p_sfpu::LREG6, 1);  // odd columns of face pair
+        TTI_SFPSWAP(0, p_sfpu::LREG5, p_sfpu::LREG4, 1);  // even columns of face pair
+
+        TTI_SFPMOV(0, p_sfpu::LREG4, p_sfpu::LREG0, 0);
+        TTI_SFPMOV(0, p_sfpu::LREG6, p_sfpu::LREG1, 0);
+
+        // Convert the sign-magnitude winners back to two's-complement before the packer-visible store, so
+        // the packer / to_torch read standard two's-complement int32. LREG2-7 are free scratch here.
+        convert_int_representation_inplace(p_sfpu::LREG0, p_sfpu::LREG2);
+        convert_int_representation_inplace(p_sfpu::LREG1, p_sfpu::LREG3);
+
+        TT_SFPSTORE(p_sfpu::LREG0, STORE_MODE, ADDR_MOD_7, top_face_addr);
+        TT_SFPSTORE(p_sfpu::LREG1, STORE_MODE, ADDR_MOD_7, top_face_addr + ODD_COLUMNS);
+    }
+}
+
+/**
  * @brief Column-wise maximum/minimum reduction kernel for SFPU reduce MAX/MIN operation.
  *        Processes a block of tiles vertically (block_height tiles stacked) and computes the maximum or minimum value
  *        for each of the columns across all rows in the block. The maximum/minimum values are placed into
@@ -1412,6 +1528,11 @@ inline void init_reduce(std::uint32_t block_ct_dim = 1) {
             // replay buffer and swap-direction config (the body is format-agnostic).
             init_reduce_max_min_int32<INSTRUCTION_MODE, pool_type>();
         } else {
+            // Int32 column MAX/MIN (issue #47647) records its own 3-swap buffer and swap-direction config
+            // inside calculate_reduce_max_min_int32() because the shared init cannot distinguish a column
+            // reduce (needs the manual sign-magnitude swap setup) from a row-MAX reduce (needs the default
+            // direction). For Int32 this LOADMACRO setup is therefore overwritten and harmless; row-MAX
+            // re-records its own buffer too.
             init_reduce_max_min<INSTRUCTION_MODE, pool_type, false>(block_ct_dim);
         }
     } else if constexpr (pool_type == PoolType::SUM || pool_type == PoolType::AVG) {
@@ -1495,6 +1616,11 @@ inline void calculate_reduce(std::uint32_t block_ct_dim = 1, std::uint32_t block
         } else if constexpr (clear_high_bits) {
             // UInt16 in 32-bit dest: manual load/mask/swap path (LOADMACRO cannot mask between load and swap).
             calculate_reduce_max_min_uint16<pool_type, reduce_dim, INSTRUCTION_MODE, clear_high_bits, pack_low16>();
+        } else if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP) {
+            // Int32 column reduce (issue #47647): manual load/cast/swap path. The cast cannot live inside a
+            // LOADMACRO, and on Blackhole the mode-12 load/store does not convert two's-complement<->sign-
+            // magnitude, so we convert explicitly around a sign-magnitude SFPSWAP reduce.
+            calculate_reduce_max_min_int32<pool_type, reduce_dim, INSTRUCTION_MODE, false, pack_low16>();
         } else {
             calculate_reduce_max_min<pool_type, reduce_dim, INSTRUCTION_MODE, false, pack_low16>(block_rt_dim);
         }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -35,6 +35,24 @@ constexpr std::uint32_t AVG_SHIFT_MASK = 0xfff;  // Mask for shift instruction e
 constexpr std::uint32_t ROWS_PER_TILE = 64;
 constexpr std::uint32_t ROWS_PER_FACE = 16;
 
+// Tile-layout address tables shared by the manual column MAX/MIN reduce paths
+// (calculate_reduce_max_min_uint16 / calculate_reduce_max_min_int32). Hoisted to file scope so the two
+// paths cannot drift out of sync if the tile layout changes.
+//   COL_REDUCE_ODD_COLUMNS:    dest-word offset between the even- and odd-column halves of a face.
+//   COL_REDUCE_COLUMN_OFFSETS: even/odd column-half selector per face index (even, odd, even, odd).
+//   COL_REDUCE_FACE_ADDRS:     per-face load addresses for the two vertically adjacent face pairs.
+//   COL_REDUCE_FINAL_ADDRS:    top/bottom face dst indices used by the cross-face reduce.
+constexpr std::uint32_t COL_REDUCE_ODD_COLUMNS = 2;
+constexpr std::uint32_t COL_REDUCE_COLUMN_OFFSETS[NUM_FACES] = {0, 2, 0, 2};  // even, odd, even, odd
+constexpr std::uint32_t COL_REDUCE_FACE_ADDRS[2][NUM_FACES] = {
+    {0, 0, 32, 32},   // j=0: Face 0 and Face 2
+    {16, 16, 48, 48}  // j=1: Face 1 and Face 3
+};
+constexpr std::uint32_t COL_REDUCE_FINAL_ADDRS[2][2] = {
+    {0, 32},  // j=0: Face 0 and Face 2
+    {16, 48}  // j=1: Face 1 and Face 3
+};
+
 // Register holding the 0x0000FFFF mask used to clear garbage high bits when loading UInt16 data
 // from a 32-bit (fp32 dest accumulation) dest word. Maps to sfpi::vConstIntPrgm0 on Blackhole.
 constexpr std::uint32_t CLEAR_REG = p_sfpu::LREG12;
@@ -1158,16 +1176,8 @@ inline void calculate_reduce_max_min_uint16() {
         pool_type == PoolType::MAX || pool_type == PoolType::MIN,
         "Only MAX and MIN pool types are supported for this function");
 
-    constexpr std::uint32_t ODD_COLUMNS = 2;
-    constexpr std::uint32_t COLUMN_OFFSETS[4] = {0, 2, 0, 2};  // even, odd, even, odd
-    constexpr std::uint32_t FACE_ADDRS[2][4] = {
-        {0, 0, 32, 32},   // j=0: Face 0 and Face 2
-        {16, 16, 48, 48}  // j=1: Face 1 and Face 3
-    };
-    constexpr std::uint32_t FINAL_REDUCE_ADDRS[2][2] = {
-        {0, 32},  // j=0: Face 0 and Face 2
-        {16, 48}  // j=1: Face 1 and Face 3
-    };
+    // Shared tile-layout address tables live at file scope (COL_REDUCE_*), so the UInt16 and Int32
+    // column MAX/MIN paths stay in lockstep.
 
     // The intermediate stores below land in non-row-0 dest slots that we reload, so they use the
     // plain (full 32-bit) instruction mode. Only the final row-0 stores are packer-visible and use
@@ -1177,8 +1187,8 @@ inline void calculate_reduce_max_min_uint16() {
         pack_low16 ? 9u /* SFPSTORE_MOD0_FMT_LO16 */ : static_cast<std::uint32_t>(INSTRUCTION_MODE);
 
     for (std::uint32_t j = 0; j < 2; j++) {
-        std::uint32_t top_face_addr = FINAL_REDUCE_ADDRS[j][0];     // face 0 & 1 dst indices
-        std::uint32_t bottom_face_addr = FINAL_REDUCE_ADDRS[j][1];  // face 2 & 3 dst indices
+        std::uint32_t top_face_addr = COL_REDUCE_FINAL_ADDRS[j][0];     // face 0 & 1 dst indices
+        std::uint32_t bottom_face_addr = COL_REDUCE_FINAL_ADDRS[j][1];  // face 2 & 3 dst indices
 
         // Reduce each of the four vertically adjacent faces (f0,f2 then f1,f3) within itself; the
         // max/min of its 16 rows is left in the top 4 rows.
@@ -1186,20 +1196,25 @@ inline void calculate_reduce_max_min_uint16() {
             // Masked load straight into LREG4-7, where the recorded swap buffer reduces them. Loading
             // directly into the target registers eliminates the four LREG0-3 -> LREG4-7 moves (and the
             // post-reduce LREG4 -> LREG0 move) that the previous LREG0-3 load required.
-            load_face_data<INSTRUCTION_MODE, clear_high_bits, p_sfpu::LREG4>(FACE_ADDRS[j][i], COLUMN_OFFSETS[i]);
+            load_face_data<INSTRUCTION_MODE, clear_high_bits, p_sfpu::LREG4>(
+                COL_REDUCE_FACE_ADDRS[j][i], COL_REDUCE_COLUMN_OFFSETS[i]);
 
             lltt::replay(0, 3);  // compare-and-swap reduce LREG4-7 -> LREG4
 
-            TT_SFPSTORE(p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_7, FACE_ADDRS[j][i] + COLUMN_OFFSETS[i]);
+            TT_SFPSTORE(
+                p_sfpu::LREG4,
+                INSTRUCTION_MODE,
+                ADDR_MOD_7,
+                COL_REDUCE_FACE_ADDRS[j][i] + COL_REDUCE_COLUMN_OFFSETS[i]);
         }
 
         // Load the partial max/min (top 4 rows) of the two vertically adjacent faces into LREG0-3.
         load_and_clear_high_bits<clear_high_bits>(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, top_face_addr);
         load_and_clear_high_bits<clear_high_bits>(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, bottom_face_addr);
         load_and_clear_high_bits<clear_high_bits>(
-            p_sfpu::LREG2, INSTRUCTION_MODE, ADDR_MOD_7, top_face_addr + ODD_COLUMNS);
+            p_sfpu::LREG2, INSTRUCTION_MODE, ADDR_MOD_7, top_face_addr + COL_REDUCE_ODD_COLUMNS);
         load_and_clear_high_bits<clear_high_bits>(
-            p_sfpu::LREG3, INSTRUCTION_MODE, ADDR_MOD_7, bottom_face_addr + ODD_COLUMNS);
+            p_sfpu::LREG3, INSTRUCTION_MODE, ADDR_MOD_7, bottom_face_addr + COL_REDUCE_ODD_COLUMNS);
 
         // Move into LREG4-7 for the transpose + cross-row reduction.
         TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG4, 0);
@@ -1220,7 +1235,7 @@ inline void calculate_reduce_max_min_uint16() {
         TTI_SFPMOV(0, p_sfpu::LREG6, p_sfpu::LREG1, 0);
 
         TT_SFPSTORE(p_sfpu::LREG0, STORE_MODE, ADDR_MOD_7, top_face_addr);
-        TT_SFPSTORE(p_sfpu::LREG1, STORE_MODE, ADDR_MOD_7, top_face_addr + ODD_COLUMNS);
+        TT_SFPSTORE(p_sfpu::LREG1, STORE_MODE, ADDR_MOD_7, top_face_addr + COL_REDUCE_ODD_COLUMNS);
     }
 }
 
@@ -1257,16 +1272,8 @@ inline void calculate_reduce_max_min_int32() {
         pool_type == PoolType::MAX || pool_type == PoolType::MIN,
         "Only MAX and MIN pool types are supported for this function");
 
-    constexpr std::uint32_t ODD_COLUMNS = 2;
-    constexpr std::uint32_t COLUMN_OFFSETS[4] = {0, 2, 0, 2};  // even, odd, even, odd
-    constexpr std::uint32_t FACE_ADDRS[2][4] = {
-        {0, 0, 32, 32},   // j=0: Face 0 and Face 2
-        {16, 16, 48, 48}  // j=1: Face 1 and Face 3
-    };
-    constexpr std::uint32_t FINAL_REDUCE_ADDRS[2][2] = {
-        {0, 32},  // j=0: Face 0 and Face 2
-        {16, 48}  // j=1: Face 1 and Face 3
-    };
+    // Shared tile-layout address tables live at file scope (COL_REDUCE_*), so the UInt16 and Int32
+    // column MAX/MIN paths stay in lockstep.
 
     // Intermediate stores hold sign-magnitude partials reloaded below; the final row-0 stores write the
     // packer-visible two's-complement result. Both use the plain (raw, no-op on Blackhole) instruction mode.
@@ -1278,14 +1285,15 @@ inline void calculate_reduce_max_min_int32() {
     init_reduce_max_min_int32<INSTRUCTION_MODE, pool_type>();
 
     for (std::uint32_t j = 0; j < 2; j++) {
-        std::uint32_t top_face_addr = FINAL_REDUCE_ADDRS[j][0];     // face 0 & 1 dst indices
-        std::uint32_t bottom_face_addr = FINAL_REDUCE_ADDRS[j][1];  // face 2 & 3 dst indices
+        std::uint32_t top_face_addr = COL_REDUCE_FINAL_ADDRS[j][0];     // face 0 & 1 dst indices
+        std::uint32_t bottom_face_addr = COL_REDUCE_FINAL_ADDRS[j][1];  // face 2 & 3 dst indices
 
         // Reduce each of the four vertically adjacent faces within itself; its max/min of 16 rows is left
         // in the top 4 rows.
         for (std::uint32_t i = 0; i < NUM_FACES; i++) {
             // Raw-load 16 rows of the face straight into LREG4-7 (two's-complement; mode-12 load is a no-op).
-            load_face_data<INSTRUCTION_MODE, false, p_sfpu::LREG4>(FACE_ADDRS[j][i], COLUMN_OFFSETS[i]);
+            load_face_data<INSTRUCTION_MODE, false, p_sfpu::LREG4>(
+                COL_REDUCE_FACE_ADDRS[j][i], COL_REDUCE_COLUMN_OFFSETS[i]);
 
             // Convert each operand two's-complement -> sign-magnitude so the sign-magnitude SFPSWAP
             // comparator orders negatives and the two's-complement pad sentinels correctly. LREG0-3 are free.
@@ -1297,15 +1305,21 @@ inline void calculate_reduce_max_min_int32() {
             lltt::replay(0, 3);  // compare-and-swap reduce LREG4-7 -> LREG4 (sign-magnitude)
 
             // Store the sign-magnitude partial back to dest; reloaded below for the cross-face reduce.
-            TT_SFPSTORE(p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_7, FACE_ADDRS[j][i] + COLUMN_OFFSETS[i]);
+            TT_SFPSTORE(
+                p_sfpu::LREG4,
+                INSTRUCTION_MODE,
+                ADDR_MOD_7,
+                COL_REDUCE_FACE_ADDRS[j][i] + COL_REDUCE_COLUMN_OFFSETS[i]);
         }
 
         // Reload the partial max/min (top 4 rows) of the two vertically adjacent faces. They were stored
         // as sign-magnitude, so a raw load keeps them sign-magnitude (no cast needed here).
         load_and_clear_high_bits<false>(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, top_face_addr);
         load_and_clear_high_bits<false>(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, bottom_face_addr);
-        load_and_clear_high_bits<false>(p_sfpu::LREG2, INSTRUCTION_MODE, ADDR_MOD_7, top_face_addr + ODD_COLUMNS);
-        load_and_clear_high_bits<false>(p_sfpu::LREG3, INSTRUCTION_MODE, ADDR_MOD_7, bottom_face_addr + ODD_COLUMNS);
+        load_and_clear_high_bits<false>(
+            p_sfpu::LREG2, INSTRUCTION_MODE, ADDR_MOD_7, top_face_addr + COL_REDUCE_ODD_COLUMNS);
+        load_and_clear_high_bits<false>(
+            p_sfpu::LREG3, INSTRUCTION_MODE, ADDR_MOD_7, bottom_face_addr + COL_REDUCE_ODD_COLUMNS);
 
         // Move into LREG4-7 for the transpose + cross-row reduction.
         TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG4, 0);
@@ -1331,7 +1345,7 @@ inline void calculate_reduce_max_min_int32() {
         convert_int_representation_inplace(p_sfpu::LREG1, p_sfpu::LREG3);
 
         TT_SFPSTORE(p_sfpu::LREG0, STORE_MODE, ADDR_MOD_7, top_face_addr);
-        TT_SFPSTORE(p_sfpu::LREG1, STORE_MODE, ADDR_MOD_7, top_face_addr + ODD_COLUMNS);
+        TT_SFPSTORE(p_sfpu::LREG1, STORE_MODE, ADDR_MOD_7, top_face_addr + COL_REDUCE_ODD_COLUMNS);
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -1312,20 +1312,16 @@ inline void calculate_reduce_max_min_int32() {
                 COL_REDUCE_FACE_ADDRS[j][i] + COL_REDUCE_COLUMN_OFFSETS[i]);
         }
 
-        // Reload the partial max/min (top 4 rows) of the two vertically adjacent faces. They were stored
-        // as sign-magnitude, so a raw load keeps them sign-magnitude (no cast needed here).
-        load_and_clear_high_bits<false>(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, top_face_addr);
-        load_and_clear_high_bits<false>(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, bottom_face_addr);
+        // Reload the partial max/min (top 4 rows) of the two vertically adjacent faces straight into
+        // LREG4-7, where the recorded swap buffer reduces them. They were stored as sign-magnitude, so a
+        // raw load keeps them sign-magnitude (no cast needed here). Loading directly into the target
+        // registers (as the inner loop does) avoids the four LREG0-3 -> LREG4-7 moves.
+        load_and_clear_high_bits<false>(p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_7, top_face_addr);
+        load_and_clear_high_bits<false>(p_sfpu::LREG5, INSTRUCTION_MODE, ADDR_MOD_7, bottom_face_addr);
         load_and_clear_high_bits<false>(
-            p_sfpu::LREG2, INSTRUCTION_MODE, ADDR_MOD_7, top_face_addr + COL_REDUCE_ODD_COLUMNS);
+            p_sfpu::LREG6, INSTRUCTION_MODE, ADDR_MOD_7, top_face_addr + COL_REDUCE_ODD_COLUMNS);
         load_and_clear_high_bits<false>(
-            p_sfpu::LREG3, INSTRUCTION_MODE, ADDR_MOD_7, bottom_face_addr + COL_REDUCE_ODD_COLUMNS);
-
-        // Move into LREG4-7 for the transpose + cross-row reduction.
-        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG4, 0);
-        TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG5, 0);
-        TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG6, 0);
-        TTI_SFPMOV(0, p_sfpu::LREG3, p_sfpu::LREG7, 0);
+            p_sfpu::LREG7, INSTRUCTION_MODE, ADDR_MOD_7, bottom_face_addr + COL_REDUCE_ODD_COLUMNS);
 
         // Transpose so the 4 partial results of each column sit in one register, reduce, transpose back.
         TTI_SFPTRANSP(0, 0, 0, 0);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -1498,17 +1498,16 @@ inline void init_reduce(std::uint32_t block_ct_dim = 1) {
         is_supported_reduce_format(format),
         "Unsupported data format. Supported formats: Int32, UInt32, UInt16, Float32, Float16_b");
 
-    // Determine InstrModLoadStore from llk_defs. Int32 SUM/AVG use INT32_2S_COMP so SFPIADD operates on
-    // two's-complement values (on Blackhole the load/store conversion is a no-op, so the reduce code casts
-    // sign-magnitude<->two's-complement explicitly). Int32 MAX/MIN keep plain INT32 (sign-magnitude):
-    // SFPSWAP(VEC_MIN_MAX) is a float/sign-magnitude comparator that orders sign-magnitude integers
-    // correctly, whereas two's-complement negatives would be mis-ordered.
-    // Option A (issue #47647): Int32 MAX/MIN revert to INT32_2S_COMP to match the column-reduce calculate
-    // path. init_reduce has no reduce_dim template arg; the row-MAX path re-records its own replay buffer
-    // and ignores this LOADMACRO setup, so selecting INT32_2S_COMP for all Int32 MAX/MIN is safe here.
+    // Int32 SUM loads with plain INT32. The dest word is already two's-complement and SFPIADD adds in
+    // two's-complement. The explicit sign-magnitude<->two's-complement cast in the reduce code only runs
+    // under INT32_2S_COMP, so plain INT32 skips it; otherwise the cast would mangle the already-two's-
+    // complement operand and break negatives. AVG keeps INT32_2S_COMP (its divide-by-32 step relies on it),
+    // and MAX/MIN keep INT32_2S_COMP to match the column-reduce path. init_reduce has no reduce_dim, but the
+    // row-MAX path re-records its own replay buffer, so picking INT32_2S_COMP for every Int32 MAX/MIN here
+    // does no harm.
     constexpr bool int32_2s_comp =
-        (format == DataFormat::Int32 && (pool_type == PoolType::SUM || pool_type == PoolType::AVG ||
-                                         pool_type == PoolType::MAX || pool_type == PoolType::MIN));
+        (format == DataFormat::Int32 &&
+         (pool_type == PoolType::AVG || pool_type == PoolType::MAX || pool_type == PoolType::MIN));
     constexpr InstrModLoadStore INSTRUCTION_MODE =
         int32_2s_comp ? InstrModLoadStore::INT32_2S_COMP : GetSfpLoadStoreInstrMod<format, is_fp32_dest_acc_en>();
 
@@ -1577,21 +1576,20 @@ inline void calculate_reduce(std::uint32_t block_ct_dim = 1, std::uint32_t block
         is_supported_reduce_format(format),
         "Unsupported data format. Supported formats: Int32, UInt32, UInt16, Float32, Float16_b");
 
-    // Determine InstrModLoadStore from llk_defs.
-    // Int32 SUM/AVG use INT32_2S_COMP so SFPIADD operates on two's-complement values (on Blackhole the
-    // load/store conversion is a no-op, so the reduce code casts sign-magnitude<->two's-complement
-    // explicitly). Int32 MAX/MIN (both dims) keep plain INT32 (sign-magnitude): SFPSWAP(VEC_MIN_MAX) is a
-    // float/sign-magnitude comparator that orders sign-magnitude integers correctly; two's-complement
-    // negatives are mis-ordered (min of negatives would return the least-negative value).
-    // Option A (issue #47647): Int32 MAX/MIN column reduce reverts to INT32_2S_COMP (pre-#46231). Scoped
-    // to REDUCE_COL so the row-MAX path keeps plain sign-magnitude INT32 (its static_assert below requires
-    // FP32/INT32/FP16B). On Blackhole the mode-12 load/store conversion is a no-op, so this is benign here.
-    constexpr bool int32_sum_avg =
-        (format == DataFormat::Int32 && (pool_type == PoolType::SUM || pool_type == PoolType::AVG));
+    // Pick the load/store mode for each Int32 reduction:
+    //   * SUM uses plain INT32. The dest word is already two's-complement and SFPIADD adds in two's-complement,
+    //     so it has to reach the adder untouched. The explicit sign-magnitude<->two's-complement cast in the
+    //     reduce code only runs under INT32_2S_COMP, so plain INT32 skips it; otherwise it would mangle the
+    //     already-two's-complement operand and break negatives.
+    //   * AVG uses INT32_2S_COMP, which its divide-by-32 step depends on.
+    //   * MAX/MIN column reduce uses INT32_2S_COMP. On Blackhole the load/store conversion is a no-op, so the
+    //     column path casts explicitly around a sign-magnitude SFPSWAP. Scoped to REDUCE_COL so the row-MAX
+    //     path stays on plain sign-magnitude INT32.
+    constexpr bool int32_avg = (format == DataFormat::Int32 && pool_type == PoolType::AVG);
     constexpr bool int32_max_min_col =
         (format == DataFormat::Int32 && (pool_type == PoolType::MAX || pool_type == PoolType::MIN) &&
          reduce_dim == ReduceDim::REDUCE_COL);
-    constexpr InstrModLoadStore INSTRUCTION_MODE = (int32_sum_avg || int32_max_min_col)
+    constexpr InstrModLoadStore INSTRUCTION_MODE = (int32_avg || int32_max_min_col)
                                                        ? InstrModLoadStore::INT32_2S_COMP
                                                        : GetSfpLoadStoreInstrMod<format, is_fp32_dest_acc_en>();
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -1223,8 +1223,12 @@ inline void init_reduce(std::uint32_t block_ct_dim = 1) {
     // on two's-complement values. Int32 MAX/MIN keep plain INT32 (sign-magnitude): SFPSWAP(VEC_MIN_MAX)
     // is a float/sign-magnitude comparator and orders sign-magnitude integers correctly, whereas
     // two's-complement negatives would be mis-ordered.
+    // Option A (issue #47647): Int32 MAX/MIN revert to INT32_2S_COMP to match the column-reduce calculate
+    // path. init_reduce has no reduce_dim template arg; the row-MAX path re-records its own replay buffer
+    // and ignores this LOADMACRO setup, so selecting INT32_2S_COMP for all Int32 MAX/MIN is safe here.
     constexpr InstrModLoadStore INSTRUCTION_MODE =
-        (format == DataFormat::Int32 && (pool_type == PoolType::SUM || pool_type == PoolType::AVG))
+        (format == DataFormat::Int32 && (pool_type == PoolType::SUM || pool_type == PoolType::AVG ||
+                                         pool_type == PoolType::MAX || pool_type == PoolType::MIN))
             ? InstrModLoadStore::INT32_2S_COMP
         : (format == DataFormat::Float16_b) ? InstrModLoadStore::DEFAULT
                                             : GetSfpLoadStoreInstrMod<format, is_fp32_dest_accum_en>();
@@ -1297,10 +1301,16 @@ inline void calculate_reduce(std::uint32_t block_ct_dim = 1, std::uint32_t block
     // mis-ordered (max of negatives would return the most-negative value).
     constexpr bool int32_sum_avg =
         (format == DataFormat::Int32 && (pool_type == PoolType::SUM || pool_type == PoolType::AVG));
-    constexpr InstrModLoadStore INSTRUCTION_MODE = int32_sum_avg ? InstrModLoadStore::INT32_2S_COMP
-                                                   : (format == DataFormat::Float16_b)
-                                                       ? InstrModLoadStore::DEFAULT
-                                                       : GetSfpLoadStoreInstrMod<format, is_fp32_dest_accum_en>();
+    // Option A (issue #47647): Int32 MAX/MIN column reduce reverts to INT32_2S_COMP (pre-#46231 behavior).
+    // The transpose-based dim=0/dim=1 path feeds the column reduce sentinel-padded tiles; plain
+    // sign-magnitude INT32 mis-handles those lanes, so restore the two's-complement column-reduce mode.
+    constexpr bool int32_max_min_col =
+        (format == DataFormat::Int32 && (pool_type == PoolType::MAX || pool_type == PoolType::MIN) &&
+         reduce_dim == ReduceDim::REDUCE_COL);
+    constexpr InstrModLoadStore INSTRUCTION_MODE =
+        (int32_sum_avg || int32_max_min_col) ? InstrModLoadStore::INT32_2S_COMP
+        : (format == DataFormat::Float16_b)  ? InstrModLoadStore::DEFAULT
+                                             : GetSfpLoadStoreInstrMod<format, is_fp32_dest_accum_en>();
 
     // Garbage high bits need to be cleared when loading UInt16 data from a 32-bit (fp32) dest word
     // (driven by INPUT format).

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -1219,12 +1219,12 @@ inline void init_reduce(std::uint32_t block_ct_dim = 1) {
         is_supported_reduce_format(format),
         "Unsupported data format. Supported formats: Int32, UInt32, UInt16, Float32, Float16_b");
 
-    // Int32 SUM loads with plain INT32. The dest word is already two's-complement and SFPIADD is a
-    // two's-complement adder, so it has to reach the adder untouched; INT32_2S_COMP would convert it on
-    // load and mangle negative values. AVG and MAX/MIN stay on INT32_2S_COMP: AVG's divide-by-32 relies on
-    // it, and MAX/MIN's SFPSWAP needs sign-magnitude operands. init_reduce has no reduce_dim, but the
-    // row-MAX path re-records its own replay buffer, so picking INT32_2S_COMP for every Int32 MAX/MIN here
-    // does no harm.
+    // Int32 reduce operands are two's-complement in DEST. SUM loads with plain INT32 so the word reaches
+    // SFPIADD (a two's-complement adder) unchanged; INT32_2S_COMP applies SignMagToTwosComp on load and
+    // would corrupt negatives. MAX/MIN load with INT32_2S_COMP so the word becomes sign-magnitude, which
+    // is the order SFPSWAP compares in. AVG keeps INT32_2S_COMP; its divide-by-32 step assumes that mode.
+    // init_reduce has no reduce_dim, so every Int32 MAX/MIN takes INT32_2S_COMP here; the row-MAX path
+    // re-records its own replay buffer regardless.
     constexpr InstrModLoadStore INSTRUCTION_MODE =
         (format == DataFormat::Int32 &&
          (pool_type == PoolType::AVG || pool_type == PoolType::MAX || pool_type == PoolType::MIN))
@@ -1293,13 +1293,12 @@ inline void calculate_reduce(std::uint32_t block_ct_dim = 1, std::uint32_t block
         is_supported_reduce_format(format),
         "Unsupported data format. Supported formats: Int32, UInt32, UInt16, Float32, Float16_b");
 
-    // Pick the load/store mode for each Int32 reduction:
-    //   * SUM uses plain INT32. The dest word is already two's-complement and SFPIADD adds in two's-complement,
-    //     so it has to reach the adder untouched; INT32_2S_COMP would convert it on load and mangle negatives.
-    //   * AVG uses INT32_2S_COMP, which its divide-by-32 step (perform_int_average) depends on.
-    //   * MAX/MIN column reduce uses INT32_2S_COMP: the column path is fed transpose-padded tiles whose pad
-    //     sentinel assumes two's-complement, while SFPSWAP orders operands as sign-magnitude. Scoped to
-    //     REDUCE_COL so the row-MAX path stays on plain sign-magnitude INT32.
+    // Int32 load/store mode per reduction. Operands are two's-complement in DEST.
+    //   SUM: plain INT32 so SFPIADD (a two's-complement adder) gets the word unchanged; INT32_2S_COMP
+    //        applies SignMagToTwosComp on load and would corrupt negatives.
+    //   AVG: INT32_2S_COMP, which perform_int_average's divide-by-32 step assumes.
+    //   MAX/MIN column reduce: INT32_2S_COMP so the word becomes sign-magnitude for SFPSWAP, which
+    //        compares in sign-magnitude. Scoped to REDUCE_COL so the row-MAX path keeps plain INT32.
     constexpr bool int32_avg = (format == DataFormat::Int32 && pool_type == PoolType::AVG);
     constexpr bool int32_max_min_col =
         (format == DataFormat::Int32 && (pool_type == PoolType::MAX || pool_type == PoolType::MIN) &&

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -1219,13 +1219,11 @@ inline void init_reduce(std::uint32_t block_ct_dim = 1) {
         is_supported_reduce_format(format),
         "Unsupported data format. Supported formats: Int32, UInt32, UInt16, Float32, Float16_b");
 
-    // Determine InstrModLoadStore from llk_defs. Int32 SUM/AVG use INT32_2S_COMP so SFPIADD operates
-    // on two's-complement values. Int32 MAX/MIN keep plain INT32 (sign-magnitude): SFPSWAP(VEC_MIN_MAX)
-    // is a float/sign-magnitude comparator and orders sign-magnitude integers correctly, whereas
-    // two's-complement negatives would be mis-ordered.
-    // Option A (issue #47647): Int32 MAX/MIN revert to INT32_2S_COMP to match the column-reduce calculate
-    // path. init_reduce has no reduce_dim template arg; the row-MAX path re-records its own replay buffer
-    // and ignores this LOADMACRO setup, so selecting INT32_2S_COMP for all Int32 MAX/MIN is safe here.
+    // Determine InstrModLoadStore from llk_defs. Int32 SUM/AVG use INT32_2S_COMP so SFPIADD operates on
+    // two's-complement values. Option A (issue #47647): Int32 MAX/MIN also use INT32_2S_COMP to match the
+    // column-reduce calculate path. init_reduce has no reduce_dim template arg; the row-MAX path re-records
+    // its own replay buffer and ignores this LOADMACRO setup, so selecting INT32_2S_COMP for all Int32
+    // MAX/MIN is safe here.
     constexpr InstrModLoadStore INSTRUCTION_MODE =
         (format == DataFormat::Int32 && (pool_type == PoolType::SUM || pool_type == PoolType::AVG ||
                                          pool_type == PoolType::MAX || pool_type == PoolType::MIN))
@@ -1295,15 +1293,14 @@ inline void calculate_reduce(std::uint32_t block_ct_dim = 1, std::uint32_t block
         "Unsupported data format. Supported formats: Int32, UInt32, UInt16, Float32, Float16_b");
 
     // Determine InstrModLoadStore from llk_defs.
-    // Int32 SUM/AVG use INT32_2S_COMP so SFPIADD operates on two's-complement values. Int32 MAX/MIN
-    // (both dims) keep plain INT32 (sign-magnitude): SFPSWAP(VEC_MIN_MAX) is a float/sign-magnitude
-    // comparator that orders sign-magnitude integers correctly; two's-complement negatives are
-    // mis-ordered (max of negatives would return the most-negative value).
+    //   * SUM/AVG use SFPIADD (two's-complement adder) -> INT32_2S_COMP (mode 12) converts on load.
+    //   * Int32 MAX/MIN column reduce (REDUCE_COL) also uses INT32_2S_COMP (Option A, issue #47647):
+    //     this is the pre-#46231 behavior. The dim=0/dim=1 path (reduce_nd_loop) feeds the column reduce
+    //     transpose-padded tiles whose sentinel pad value assumes the two's-complement interpretation, so
+    //     plain sign-magnitude INT32 (mode 4) mis-handles those lanes. Scoped to REDUCE_COL so the row-MAX
+    //     path keeps plain sign-magnitude INT32.
     constexpr bool int32_sum_avg =
         (format == DataFormat::Int32 && (pool_type == PoolType::SUM || pool_type == PoolType::AVG));
-    // Option A (issue #47647): Int32 MAX/MIN column reduce reverts to INT32_2S_COMP (pre-#46231 behavior).
-    // The transpose-based dim=0/dim=1 path feeds the column reduce sentinel-padded tiles; plain
-    // sign-magnitude INT32 mis-handles those lanes, so restore the two's-complement column-reduce mode.
     constexpr bool int32_max_min_col =
         (format == DataFormat::Int32 && (pool_type == PoolType::MAX || pool_type == PoolType::MIN) &&
          reduce_dim == ReduceDim::REDUCE_COL);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -1219,14 +1219,15 @@ inline void init_reduce(std::uint32_t block_ct_dim = 1) {
         is_supported_reduce_format(format),
         "Unsupported data format. Supported formats: Int32, UInt32, UInt16, Float32, Float16_b");
 
-    // Determine InstrModLoadStore from llk_defs. Int32 SUM/AVG use INT32_2S_COMP so SFPIADD operates on
-    // two's-complement values. Option A (issue #47647): Int32 MAX/MIN also use INT32_2S_COMP to match the
-    // column-reduce calculate path. init_reduce has no reduce_dim template arg; the row-MAX path re-records
-    // its own replay buffer and ignores this LOADMACRO setup, so selecting INT32_2S_COMP for all Int32
-    // MAX/MIN is safe here.
+    // Int32 SUM loads with plain INT32. The dest word is already two's-complement and SFPIADD is a
+    // two's-complement adder, so it has to reach the adder untouched; INT32_2S_COMP would convert it on
+    // load and mangle negative values. AVG and MAX/MIN stay on INT32_2S_COMP: AVG's divide-by-32 relies on
+    // it, and MAX/MIN's SFPSWAP needs sign-magnitude operands. init_reduce has no reduce_dim, but the
+    // row-MAX path re-records its own replay buffer, so picking INT32_2S_COMP for every Int32 MAX/MIN here
+    // does no harm.
     constexpr InstrModLoadStore INSTRUCTION_MODE =
-        (format == DataFormat::Int32 && (pool_type == PoolType::SUM || pool_type == PoolType::AVG ||
-                                         pool_type == PoolType::MAX || pool_type == PoolType::MIN))
+        (format == DataFormat::Int32 &&
+         (pool_type == PoolType::AVG || pool_type == PoolType::MAX || pool_type == PoolType::MIN))
             ? InstrModLoadStore::INT32_2S_COMP
         : (format == DataFormat::Float16_b) ? InstrModLoadStore::DEFAULT
                                             : GetSfpLoadStoreInstrMod<format, is_fp32_dest_accum_en>();
@@ -1292,22 +1293,21 @@ inline void calculate_reduce(std::uint32_t block_ct_dim = 1, std::uint32_t block
         is_supported_reduce_format(format),
         "Unsupported data format. Supported formats: Int32, UInt32, UInt16, Float32, Float16_b");
 
-    // Determine InstrModLoadStore from llk_defs.
-    //   * SUM/AVG use SFPIADD (two's-complement adder) -> INT32_2S_COMP (mode 12) converts on load.
-    //   * Int32 MAX/MIN column reduce (REDUCE_COL) also uses INT32_2S_COMP (Option A, issue #47647):
-    //     this is the pre-#46231 behavior. The dim=0/dim=1 path (reduce_nd_loop) feeds the column reduce
-    //     transpose-padded tiles whose sentinel pad value assumes the two's-complement interpretation, so
-    //     plain sign-magnitude INT32 (mode 4) mis-handles those lanes. Scoped to REDUCE_COL so the row-MAX
-    //     path keeps plain sign-magnitude INT32.
-    constexpr bool int32_sum_avg =
-        (format == DataFormat::Int32 && (pool_type == PoolType::SUM || pool_type == PoolType::AVG));
+    // Pick the load/store mode for each Int32 reduction:
+    //   * SUM uses plain INT32. The dest word is already two's-complement and SFPIADD adds in two's-complement,
+    //     so it has to reach the adder untouched; INT32_2S_COMP would convert it on load and mangle negatives.
+    //   * AVG uses INT32_2S_COMP, which its divide-by-32 step (perform_int_average) depends on.
+    //   * MAX/MIN column reduce uses INT32_2S_COMP: the column path is fed transpose-padded tiles whose pad
+    //     sentinel assumes two's-complement, while SFPSWAP orders operands as sign-magnitude. Scoped to
+    //     REDUCE_COL so the row-MAX path stays on plain sign-magnitude INT32.
+    constexpr bool int32_avg = (format == DataFormat::Int32 && pool_type == PoolType::AVG);
     constexpr bool int32_max_min_col =
         (format == DataFormat::Int32 && (pool_type == PoolType::MAX || pool_type == PoolType::MIN) &&
          reduce_dim == ReduceDim::REDUCE_COL);
-    constexpr InstrModLoadStore INSTRUCTION_MODE =
-        (int32_sum_avg || int32_max_min_col) ? InstrModLoadStore::INT32_2S_COMP
-        : (format == DataFormat::Float16_b)  ? InstrModLoadStore::DEFAULT
-                                             : GetSfpLoadStoreInstrMod<format, is_fp32_dest_accum_en>();
+    constexpr InstrModLoadStore INSTRUCTION_MODE = (int32_avg || int32_max_min_col) ? InstrModLoadStore::INT32_2S_COMP
+                                                   : (format == DataFormat::Float16_b)
+                                                       ? InstrModLoadStore::DEFAULT
+                                                       : GetSfpLoadStoreInstrMod<format, is_fp32_dest_accum_en>();
 
     // Garbage high bits need to be cleared when loading UInt16 data from a 32-bit (fp32) dest word
     // (driven by INPUT format).

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -1219,12 +1219,13 @@ inline void init_reduce(std::uint32_t block_ct_dim = 1) {
         is_supported_reduce_format(format),
         "Unsupported data format. Supported formats: Int32, UInt32, UInt16, Float32, Float16_b");
 
-    // Int32 reduce operands are two's-complement in DEST. SUM loads with plain INT32 so the word reaches
-    // SFPIADD (a two's-complement adder) unchanged; INT32_2S_COMP applies SignMagToTwosComp on load and
-    // would corrupt negatives. MAX/MIN load with INT32_2S_COMP so the word becomes sign-magnitude, which
-    // is the order SFPSWAP compares in. AVG keeps INT32_2S_COMP; its divide-by-32 step assumes that mode.
-    // init_reduce has no reduce_dim, so every Int32 MAX/MIN takes INT32_2S_COMP here; the row-MAX path
-    // re-records its own replay buffer regardless.
+    // Int32 DEST representation per reduction: SUM and MAX/MIN are two's-complement; AVG is sign-magnitude.
+    // SUM loads with plain INT32 so the word reaches SFPIADD (a two's-complement adder) unchanged;
+    // INT32_2S_COMP applies SignMagToTwosComp on load and would corrupt two's-complement negatives. MAX/MIN
+    // load with INT32_2S_COMP so the word becomes sign-magnitude, which is the order SFPSWAP compares in.
+    // AVG keeps INT32_2S_COMP; its operands sit in DEST as sign-magnitude and its divide-by-32 step assumes
+    // that mode. init_reduce has no reduce_dim, so every Int32 MAX/MIN takes INT32_2S_COMP here; the row-MAX
+    // path re-records its own replay buffer regardless.
     constexpr InstrModLoadStore INSTRUCTION_MODE =
         (format == DataFormat::Int32 &&
          (pool_type == PoolType::AVG || pool_type == PoolType::MAX || pool_type == PoolType::MIN))
@@ -1293,12 +1294,14 @@ inline void calculate_reduce(std::uint32_t block_ct_dim = 1, std::uint32_t block
         is_supported_reduce_format(format),
         "Unsupported data format. Supported formats: Int32, UInt32, UInt16, Float32, Float16_b");
 
-    // Int32 load/store mode per reduction. Operands are two's-complement in DEST.
-    //   SUM: plain INT32 so SFPIADD (a two's-complement adder) gets the word unchanged; INT32_2S_COMP
-    //        applies SignMagToTwosComp on load and would corrupt negatives.
-    //   AVG: INT32_2S_COMP, which perform_int_average's divide-by-32 step assumes.
-    //   MAX/MIN column reduce: INT32_2S_COMP so the word becomes sign-magnitude for SFPSWAP, which
-    //        compares in sign-magnitude. Scoped to REDUCE_COL so the row-MAX path keeps plain INT32.
+    // Int32 load/store mode per reduction. DEST encoding is two's-complement for SUM and MAX/MIN, and
+    // sign-magnitude for AVG.
+    //   SUM (two's-complement): plain INT32 so SFPIADD (a two's-complement adder) gets the word unchanged;
+    //        INT32_2S_COMP applies SignMagToTwosComp on load and would corrupt negatives.
+    //   MAX/MIN column reduce (two's-complement): INT32_2S_COMP so the word becomes sign-magnitude for
+    //        SFPSWAP, which compares in sign-magnitude. Scoped to REDUCE_COL so the row-MAX path keeps
+    //        plain INT32.
+    //   AVG (sign-magnitude): INT32_2S_COMP, which perform_int_average's divide-by-32 step assumes.
     constexpr bool int32_avg = (format == DataFormat::Int32 && pool_type == PoolType::AVG);
     constexpr bool int32_max_min_col =
         (format == DataFormat::Int32 && (pool_type == PoolType::MAX || pool_type == PoolType::MIN) &&

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_reduce.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_reduce.py
@@ -62,6 +62,96 @@ def get_supported_reduce_axioms(reduce_pool: ReducePool) -> list[MathOperation]:
     return [MathOperation.ReduceColumn]
 
 
+def use_int32_twos_complement(
+    formats: InputOutputFormat, reduce_pool: ReducePool
+) -> bool:
+    """Whether Int32 stimuli/results must use two's-complement (not sign-magnitude) L1 encoding.
+
+    The Int32 MAX/MIN *column* reduce kernel loads DEST with SFPLOAD mode ``INT32_2S_COMP``
+    (``MOD0_FMT_INT32_SM``), which applies ``SignMagToTwosComp`` on load, while the MAX/MIN
+    comparator ``SFPSWAP(VEC_MIN_MAX)`` orders its operands as *sign-magnitude* (tt-isa
+    ``SFPLOAD.md`` / ``SFPSWAP.md``). The two only agree when DEST already holds
+    two's-complement: the load conversion then undoes itself into sign-magnitude for the
+    comparator. This is exactly how the ttnn op feeds the path, so the test must encode
+    Int32 MAX/MIN operands as two's-complement to match the shipped (ttnn-green) kernel.
+
+    SUM/AVG keep sign-magnitude: there mode ``INT32_2S_COMP`` feeds genuine two's-complement
+    into ``SFPIADD`` (which needs it), so the standard sign-magnitude L1 contract is correct.
+    """
+    return formats.input_format == DataFormat.Int32 and reduce_pool in (
+        ReducePool.Max,
+        ReducePool.Min,
+    )
+
+
+def get_reduce_pad_value(reduce_pool: ReducePool, input_format: DataFormat):
+    """Identity fill for the padded (non-data) rows of a sub-tile column reduce.
+
+    Mirrors ttnn's ``get_pad_value``: the padding must never win the reduction, so the
+    device result over the full 32-row tile equals the golden over just the real rows.
+    For Int32 MAX/MIN the operands are two's-complement (see ``use_int32_twos_complement``),
+    so the sentinels are the ordinary two's-complement reduction identities.
+    """
+    if reduce_pool == ReducePool.Max:
+        if input_format == DataFormat.Int32:
+            return (
+                -2147483647
+            )  # INT32_MIN + 1 (ttnn get_pad_value); avoids INT32_MIN (#44750)
+        if input_format.is_integer():
+            return 0  # unsigned formats: 0 is the smallest representable value
+        return -3.0e30  # float "-inf"-ish, finite so PCC stays well-defined
+    if reduce_pool == ReducePool.Min:
+        if input_format == DataFormat.Int32:
+            return 2147483647  # 0x7FFFFFFF == INT32_MAX
+        if input_format == DataFormat.UInt32:
+            # The device MAX/MIN comparator (SFPSWAP) is a *sign-magnitude* comparator (tt-isa
+            # SFPSWAP.md), so it can only order unsigned values whose bit 31 is clear, i.e. [0, 2^31).
+            # The natural unsigned-MIN identity 0xFFFFFFFF (UINT32_MAX) has bit 31 set and is read as
+            # the most-negative sign-magnitude value, so it would wrongly win the MIN. The largest
+            # value the comparator ranks as maximal is 0x7FFFFFFF; with stimuli in [0, 1000] this is a
+            # valid (never-winning) MIN identity. UInt32 reduce is therefore only correct for [0, 2^31).
+            return 2147483647  # 0x7FFFFFFF (largest sign-magnitude-orderable value)
+        if input_format == DataFormat.UInt16:
+            return 65535  # 0xFFFF (UInt16 fits in the 31-bit sign-magnitude positive range)
+        if input_format.is_integer():
+            return 2147483647
+        return 3.0e30  # float "+inf"-ish
+    # Sum (Average is excluded from the sub-tile sweep): additive identity.
+    return 0
+
+
+def get_reduce_extents(
+    mathop: MathOperation,
+    reduce_pool: ReducePool,
+    formats: InputOutputFormat,
+    dimension_combinations: list[int],
+) -> list[int]:
+    """Number of real (unpadded) rows on the column-reduce axis.
+
+    ``TILE_DIM`` (32) is the original full-tile behavior. Smaller values keep only the
+    first N rows as real data and pad the rest with the reduction identity, exercising
+    the padded column-reduce path that ttnn takes for ``dim=0``/``dim=1`` and that the
+    #47647 regression breaks. The sub-tile sweep is restricted to:
+      * ``ReduceColumn`` (only the column reduce has a paddable 32-row axis),
+      * a single tile column ``[32, 32]`` (padding is independent of the column-tile
+        count, so sweeping every dimension combo would only add redundant cases), and
+      * Max/Min/Sum (identity padding is exact; Average's divisor would not match a
+        golden reduced over only the real rows).
+    The fail bands reported in the issue (small extents) are covered for Int32; the
+    other formats get a thin sanity slice so the padding path itself stays guarded.
+    """
+    full = [TILE_DIM]
+    if (
+        mathop != MathOperation.ReduceColumn
+        or dimension_combinations != [TILE_DIM, TILE_DIM]
+        or reduce_pool == ReducePool.Average
+    ):
+        return full
+    if formats.input_format == DataFormat.Int32:
+        return [1, 13, 15, 16, 17, 30, 31, TILE_DIM]
+    return [15, TILE_DIM]  # thin sanity slice for non-Int32 formats
+
+
 # Base data formats exercised by the reduce suite.
 REDUCE_BASE_FORMATS = [
     DataFormat.Float32,
@@ -169,6 +259,7 @@ def is_valid_reduce_dimension(mathop, dest_acc, formats, dim):
         for dim in dimension_combinations
         if is_valid_reduce_dimension(mathop, dest_acc, formats, dim)
     ],
+    reduced_extent=get_reduce_extents,
 )
 def test_sfpu_reduce(
     formats,
@@ -177,6 +268,7 @@ def test_sfpu_reduce(
     reduce_pool,
     input_bounds,
     dimension_combinations,
+    reduced_extent,
 ):
 
     if reduce_pool in [ReducePool.Average, ReducePool.Min] and TestConfig.WITH_COVERAGE:
@@ -232,6 +324,17 @@ def test_sfpu_reduce(
         )
     src_B = torch.zeros_like(src_A)
 
+    # Sub-tile column reduce: keep only the first `reduced_extent` rows of the 32-row
+    # reduce axis as real data and fill the remaining rows with the reduction identity
+    # (mirrors the padding ttnn injects when folding dim=0/dim=1 onto H). A correct
+    # kernel must let the real data win so the result matches a golden reduced over
+    # only the real rows; the #47647 regression lets the padded sentinel win instead.
+    if mathop == MathOperation.ReduceColumn and reduced_extent < TILE_DIM:
+        pad_value = get_reduce_pad_value(reduce_pool, formats.input_format)
+        src_A = src_A.view(TILE_DIM, tile_cnt * TILE_DIM)
+        src_A[reduced_extent:, :] = pad_value
+        src_A = src_A.flatten()
+
     # Max Reduction can do block and single tile reduction whereas Sum/Avg only do single tile reduction, convert Sum/Avg golden to do block reduction by retilizing input to src_A
     # Dimensions for Max reduction work column wise, for Sum/Avg processing tiles independently is same as column reduction on dst block dimension [32, num_tiles * 32] where num rows is 32 i.e RT_DIM=1 (same as a single tile)
     dst_dim = (
@@ -247,9 +350,14 @@ def test_sfpu_reduce(
         src_A, formats.input_format, dst_dim
     )  # Passed into golden since PyTorch library has no concept of tilization
 
+    # Reduce only over the real rows; the padded rows must not contribute to the golden.
+    golden_input = src_A_untilized
+    if mathop == MathOperation.ReduceColumn and reduced_extent < TILE_DIM:
+        golden_input = src_A_untilized[:reduced_extent]
+
     golden_tensor = get_golden_generator(UnarySFPUGolden)(
         mathop,
-        src_A_untilized,
+        golden_input,
         formats.output_format,
         dest_acc,
         formats.input_format,
@@ -279,6 +387,7 @@ def test_sfpu_reduce(
             tile_count_A=tile_cnt,
             tile_count_B=1,
             tile_count_res=tile_cnt,
+            twos_complement=use_int32_twos_complement(formats, reduce_pool),
         ),
         dest_acc=dest_acc,
         unpack_to_dest=True,

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_reduce.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_reduce.py
@@ -65,23 +65,20 @@ def get_supported_reduce_axioms(reduce_pool: ReducePool) -> list[MathOperation]:
 def use_int32_twos_complement(
     formats: InputOutputFormat, reduce_pool: ReducePool
 ) -> bool:
-    """Whether Int32 stimuli/results must use two's-complement (not sign-magnitude) L1 encoding.
+    """Whether Int32 stimuli/results use two's-complement (not sign-magnitude) L1 encoding.
 
-    The Int32 MAX/MIN *column* reduce kernel loads DEST with SFPLOAD mode ``INT32_2S_COMP``
-    (``MOD0_FMT_INT32_SM``), which applies ``SignMagToTwosComp`` on load, while the MAX/MIN
-    comparator ``SFPSWAP(VEC_MIN_MAX)`` orders its operands as *sign-magnitude* (tt-isa
-    ``SFPLOAD.md`` / ``SFPSWAP.md``). The two only agree when DEST already holds
-    two's-complement: the load conversion then undoes itself into sign-magnitude for the
-    comparator. This is exactly how the ttnn op feeds the path, so the test must encode
-    Int32 MAX/MIN operands as two's-complement to match the shipped (ttnn-green) kernel.
+    This matches how ttnn feeds the device: Int32 reduce operands sit in DEST as two's-complement.
 
-    SUM is two's-complement as well. Int32 is stored in two's-complement and ``SFPIADD`` adds in
-    two's-complement, so the SUM kernel loads with plain ``INT32`` and the word reaches the adder
-    untouched. Feeding sign-magnitude here would mask the i32 SUM bug where ``INT32_2S_COMP``
-    corrupts negative operands, so SUM operands must be two's-complement too.
+    MAX/MIN load with ``INT32_2S_COMP``, which applies ``SignMagToTwosComp`` on load (tt-isa
+    ``SFPLOAD.md``), turning the two's-complement word into the sign-magnitude operand that
+    ``SFPSWAP(VEC_MIN_MAX)`` compares in (tt-isa ``SFPSWAP.md``).
 
-    AVG is left out: it still loads with ``INT32_2S_COMP`` (its divide-by-32 step depends on that
-    mode), so its sign-magnitude contract is still the right match.
+    SUM loads with plain ``INT32`` so the word reaches ``SFPIADD`` (a two's-complement adder)
+    unchanged. Sign-magnitude stimuli would hide the SUM bug where ``INT32_2S_COMP`` corrupts
+    negatives, so SUM operands are two's-complement too.
+
+    AVG is excluded: it still loads with ``INT32_2S_COMP`` (its divide-by-32 step assumes that
+    mode), so sign-magnitude remains the right encoding for it.
     """
     return formats.input_format == DataFormat.Int32 and reduce_pool in (
         ReducePool.Max,
@@ -93,16 +90,16 @@ def use_int32_twos_complement(
 def get_reduce_pad_value(reduce_pool: ReducePool, input_format: DataFormat):
     """Identity fill for the padded (non-data) rows of a sub-tile column reduce.
 
-    Mirrors ttnn's ``get_pad_value``: the padding must never win the reduction, so the
-    device result over the full 32-row tile equals the golden over just the real rows.
-    For Int32 MAX/MIN the operands are two's-complement (see ``use_int32_twos_complement``),
-    so the sentinels are the ordinary two's-complement reduction identities.
+    Mirrors ttnn's ``get_pad_value``: the pad must never win the reduction, so the device result
+    over the full 32-row tile equals the golden over just the real rows. For Int32 MAX/MIN the
+    operands are two's-complement (see ``use_int32_twos_complement``), so the sentinels are the
+    ordinary two's-complement reduction identities.
     """
     if reduce_pool == ReducePool.Max:
         if input_format == DataFormat.Int32:
             return (
                 -2147483647
-            )  # INT32_MIN + 1 (ttnn get_pad_value); avoids INT32_MIN (#44750)
+            )  # INT32_MIN + 1 (matches ttnn get_pad_value; avoids INT32_MIN)
         if input_format.is_integer():
             return 0  # unsigned formats: 0 is the smallest representable value
         return -3.0e30  # float "-inf"-ish, finite so PCC stays well-defined
@@ -110,13 +107,11 @@ def get_reduce_pad_value(reduce_pool: ReducePool, input_format: DataFormat):
         if input_format == DataFormat.Int32:
             return 2147483647  # 0x7FFFFFFF == INT32_MAX
         if input_format == DataFormat.UInt32:
-            # The device MAX/MIN comparator (SFPSWAP) is a *sign-magnitude* comparator (tt-isa
-            # SFPSWAP.md), so it can only order unsigned values whose bit 31 is clear, i.e. [0, 2^31).
-            # The natural unsigned-MIN identity 0xFFFFFFFF (UINT32_MAX) has bit 31 set and is read as
-            # the most-negative sign-magnitude value, so it would wrongly win the MIN. The largest
-            # value the comparator ranks as maximal is 0x7FFFFFFF; with stimuli in [0, 1000] this is a
-            # valid (never-winning) MIN identity. UInt32 reduce is therefore only correct for [0, 2^31).
-            return 2147483647  # 0x7FFFFFFF (largest sign-magnitude-orderable value)
+            # SFPSWAP compares in sign-magnitude (tt-isa SFPSWAP.md), so it only orders UInt32 values
+            # with bit 31 clear, i.e. [0, 2^31). The usual MIN identity 0xFFFFFFFF has bit 31 set and
+            # reads as the most-negative sign-magnitude value, so it would wrongly win. 0x7FFFFFFF is
+            # the largest value the comparator ranks as maximal and never wins for stimuli in [0, 1000].
+            return 2147483647  # 0x7FFFFFFF
         if input_format == DataFormat.UInt16:
             return 65535  # 0xFFFF (UInt16 fits in the 31-bit sign-magnitude positive range)
         if input_format.is_integer():
@@ -134,17 +129,15 @@ def get_reduce_extents(
 ) -> list[int]:
     """Number of real (unpadded) rows on the column-reduce axis.
 
-    ``TILE_DIM`` (32) is the original full-tile behavior. Smaller values keep only the
-    first N rows as real data and pad the rest with the reduction identity, exercising
-    the padded column-reduce path that ttnn takes for ``dim=0``/``dim=1`` and that the
-    #47647 regression breaks. The sub-tile sweep is restricted to:
+    ``TILE_DIM`` (32) is the full-tile case. Smaller values keep only the first N rows as real data
+    and pad the rest with the reduction identity, exercising the padded column-reduce path ttnn
+    takes for ``dim=0``/``dim=1``. The sub-tile sweep is restricted to:
       * ``ReduceColumn`` (only the column reduce has a paddable 32-row axis),
-      * a single tile column ``[32, 32]`` (padding is independent of the column-tile
-        count, so sweeping every dimension combo would only add redundant cases), and
-      * Max/Min/Sum (identity padding is exact; Average's divisor would not match a
-        golden reduced over only the real rows).
-    The fail bands reported in the issue (small extents) are covered for Int32; the
-    other formats get a thin sanity slice so the padding path itself stays guarded.
+      * a single tile column ``[32, 32]`` (padding is independent of the column-tile count, so
+        sweeping every dimension combo only adds redundant cases), and
+      * Max/Min/Sum (identity padding is exact; Average's divisor would not match a golden reduced
+        over only the real rows).
+    Int32 sweeps the small extents; other formats get a thin slice to keep the padding path guarded.
     """
     full = [TILE_DIM]
     if (
@@ -330,11 +323,10 @@ def test_sfpu_reduce(
         )
     src_B = torch.zeros_like(src_A)
 
-    # Sub-tile column reduce: keep only the first `reduced_extent` rows of the 32-row
-    # reduce axis as real data and fill the remaining rows with the reduction identity
-    # (mirrors the padding ttnn injects when folding dim=0/dim=1 onto H). A correct
-    # kernel must let the real data win so the result matches a golden reduced over
-    # only the real rows; the #47647 regression lets the padded sentinel win instead.
+    # Sub-tile column reduce: keep only the first `reduced_extent` rows of the 32-row reduce axis as
+    # real data and fill the rest with the reduction identity (mirrors the padding ttnn injects when
+    # folding dim=0/dim=1 onto H). The real data must win so the result matches a golden reduced over
+    # only the real rows.
     if mathop == MathOperation.ReduceColumn and reduced_extent < TILE_DIM:
         pad_value = get_reduce_pad_value(reduce_pool, formats.input_format)
         src_A = src_A.view(TILE_DIM, tile_cnt * TILE_DIM)

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_reduce.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_reduce.py
@@ -39,6 +39,16 @@ from helpers.utils import passed_test
 
 max_tiles = 4
 
+# Integer reduction-identity sentinels used to pad sub-tile column reduces
+# (see get_reduce_pad_value). Sourced from torch.iinfo so the limits are named
+# rather than hard-coded hex/decimal literals.
+INT32_MAX = torch.iinfo(torch.int32).max  # 0x7FFFFFFF
+INT32_MIN = torch.iinfo(torch.int32).min  # 0x80000000
+# MAX-reduce identity for two's-complement Int32: INT32_MIN would also work as the
+# additive-order minimum, but ttnn's get_pad_value uses INT32_MIN + 1, so we match it.
+INT32_PAD_MIN = INT32_MIN + 1  # -0x7FFFFFFF
+UINT16_MAX = torch.iinfo(torch.uint16).max  # 0xFFFF
+
 dimension_combinations = [
     [m, n]
     for m in range(TILE_DIM, max_tiles * TILE_DIM + 1, TILE_DIM)
@@ -57,34 +67,45 @@ def get_format_input_bounds(formats: InputOutputFormat) -> list[tuple[int, int]]
 
 
 def get_supported_reduce_axioms(reduce_pool: ReducePool) -> list[MathOperation]:
-    if reduce_pool == ReducePool.Sum:
+    # Row reduce (REDUCE_ROW) is only implemented in the kernel for SUM and MAX
+    # (see ckernel_sfpu_reduce.h::calculate_reduce static_assert); MIN/AVG are column-only.
+    if reduce_pool in (ReducePool.Sum, ReducePool.Max):
         return [MathOperation.ReduceRow, MathOperation.ReduceColumn]
     return [MathOperation.ReduceColumn]
 
 
 def use_int32_twos_complement(
-    formats: InputOutputFormat, reduce_pool: ReducePool
+    formats: InputOutputFormat, reduce_pool: ReducePool, mathop: MathOperation
 ) -> bool:
     """Whether Int32 stimuli/results use two's-complement (not sign-magnitude) L1 encoding.
 
     This matches how ttnn feeds the device: Int32 reduce operands sit in DEST as two's-complement.
 
-    MAX/MIN load with ``INT32_2S_COMP``, which applies ``SignMagToTwosComp`` on load (tt-isa
-    ``SFPLOAD.md``), turning the two's-complement word into the sign-magnitude operand that
-    ``SFPSWAP(VEC_MIN_MAX)`` compares in (tt-isa ``SFPSWAP.md``).
+    Column MAX/MIN load with ``INT32_2S_COMP``. On Blackhole that mode is a no-op, so the column
+    path casts two's-complement -> sign-magnitude explicitly around the sign-magnitude
+    ``SFPSWAP(VEC_MIN_MAX)`` comparator (tt-isa ``SFPSWAP.md``); on Wormhole the mode-12 load does
+    the same conversion in hardware. Either way the column path expects two's-complement operands.
+
+    Row MAX is different: it loads with plain ``INT32`` (sign-magnitude) and runs the comparator
+    directly on sign-magnitude data with no conversion (see ``perform_reduce_row_max_int32_tile``).
+    Feeding it two's-complement stimuli would miscompare negatives (e.g. ``-5`` reads as a large
+    positive), so row MAX must stay sign-magnitude. Hence the gate on ``ReduceColumn`` below.
 
     SUM loads with plain ``INT32`` so the word reaches ``SFPIADD`` (a two's-complement adder)
     unchanged. Sign-magnitude stimuli would hide the SUM bug where ``INT32_2S_COMP`` corrupts
-    negatives, so SUM operands are two's-complement too.
+    negatives, so SUM operands are two's-complement too (for both row and column SUM).
 
     AVG is excluded: it still loads with ``INT32_2S_COMP`` (its divide-by-32 step assumes that
     mode), so sign-magnitude remains the right encoding for it.
     """
-    return formats.input_format == DataFormat.Int32 and reduce_pool in (
-        ReducePool.Max,
-        ReducePool.Min,
-        ReducePool.Sum,
-    )
+    if formats.input_format != DataFormat.Int32:
+        return False
+    if reduce_pool == ReducePool.Sum:
+        return True
+    if reduce_pool in (ReducePool.Max, ReducePool.Min):
+        # Only the column MAX/MIN path takes two's-complement; row MAX stays sign-magnitude.
+        return mathop == MathOperation.ReduceColumn
+    return False
 
 
 def get_reduce_pad_value(reduce_pool: ReducePool, input_format: DataFormat):
@@ -97,25 +118,26 @@ def get_reduce_pad_value(reduce_pool: ReducePool, input_format: DataFormat):
     """
     if reduce_pool == ReducePool.Max:
         if input_format == DataFormat.Int32:
-            return (
-                -2147483647
-            )  # INT32_MIN + 1 (matches ttnn get_pad_value; avoids INT32_MIN)
+            # INT32_MIN + 1 (matches ttnn get_pad_value; avoids INT32_MIN).
+            return INT32_PAD_MIN
         if input_format.is_integer():
             return 0  # unsigned formats: 0 is the smallest representable value
         return -3.0e30  # float "-inf"-ish, finite so PCC stays well-defined
     if reduce_pool == ReducePool.Min:
         if input_format == DataFormat.Int32:
-            return 2147483647  # 0x7FFFFFFF == INT32_MAX
+            return INT32_MAX
         if input_format == DataFormat.UInt32:
             # SFPSWAP compares in sign-magnitude (tt-isa SFPSWAP.md), so it only orders UInt32 values
             # with bit 31 clear, i.e. [0, 2^31). The usual MIN identity 0xFFFFFFFF has bit 31 set and
-            # reads as the most-negative sign-magnitude value, so it would wrongly win. 0x7FFFFFFF is
-            # the largest value the comparator ranks as maximal and never wins for stimuli in [0, 1000].
-            return 2147483647  # 0x7FFFFFFF
+            # reads as the most-negative sign-magnitude value, so it would wrongly win. INT32_MAX
+            # (0x7FFFFFFF) is the largest value the comparator ranks as maximal and never wins for
+            # stimuli in [0, 1000].
+            return INT32_MAX
         if input_format == DataFormat.UInt16:
-            return 65535  # 0xFFFF (UInt16 fits in the 31-bit sign-magnitude positive range)
+            # 0xFFFF fits in the 31-bit sign-magnitude positive range the comparator orders.
+            return UINT16_MAX
         if input_format.is_integer():
-            return 2147483647
+            return INT32_MAX
         return 3.0e30  # float "+inf"-ish
     # Sum (Average is excluded from the sub-tile sweep): additive identity.
     return 0
@@ -279,6 +301,18 @@ def test_sfpu_reduce(
         )
 
     if (
+        mathop == MathOperation.ReduceRow
+        and reduce_pool == ReducePool.Max
+        and formats.input_format == DataFormat.UInt16
+    ):
+        pytest.skip(
+            reason="UInt16 row MAX is unsupported by the kernel: without a 32-bit dest it loads with "
+            "LO16 (rejected by the row-MAX static_assert), and with a 32-bit dest it routes through "
+            "the INT32 sign-magnitude row path, which does not mask UInt16's high bits and returns "
+            "garbage. Column UInt16 MAX (the ttnn-exercised path) is still covered."
+        )
+
+    if (
         formats.input_format == DataFormat.UInt16
         and formats.output_format.is_32_bit()
         and dest_acc == DestAccumulation.No
@@ -385,7 +419,7 @@ def test_sfpu_reduce(
             tile_count_A=tile_cnt,
             tile_count_B=1,
             tile_count_res=tile_cnt,
-            twos_complement=use_int32_twos_complement(formats, reduce_pool),
+            twos_complement=use_int32_twos_complement(formats, reduce_pool, mathop),
         ),
         dest_acc=dest_acc,
         unpack_to_dest=True,
@@ -412,31 +446,6 @@ def test_sfpu_reduce(
         formats.output_format, reduce_pool, mathop, input_dimensions, input_bounds
     )
 
-    passed = passed_test(
+    assert passed_test(
         golden_slice, res_slice, formats.output_format, custom_atol=reduce_atol
     )
-
-    if not passed:
-        # Dump the exact input/golden/result to the (CI) console so a non-reproducible-locally
-        # failure can be replayed. Print the full tensors (torch truncates by default) and the
-        # tilized src_A bytes that were actually sent to L1 so the case can be hardcoded.
-        torch.set_printoptions(
-            threshold=1_000_000, precision=6, sci_mode=False, linewidth=200
-        )
-        print("\n================= SFPU REDUCE FAILURE DEBUG =================")
-        print(
-            f"formats={formats} mathop={mathop} dest_acc={dest_acc} "
-            f"reduce_pool={reduce_pool} input_bounds={input_bounds} dims={input_dimensions}"
-        )
-        print(
-            f"num_blocks={num_blocks} num_tiles_in_block={num_tiles_in_block} tile_cnt={tile_cnt}"
-        )
-        print(f"src_A (tilized, sent to L1):\n{src_A.tolist()}")
-        print(f"src_A_untilized (golden input):\n{src_A_untilized}")
-        print(f"golden_slice:\n{golden_slice}")
-        print(f"res_slice:\n{res_slice}")
-        mism = (golden_slice != res_slice).nonzero().flatten().tolist()
-        print(f"mismatch indices ({len(mism)}): {mism}")
-        print("============================================================\n")
-
-    assert passed

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_reduce.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_reduce.py
@@ -75,12 +75,18 @@ def use_int32_twos_complement(
     comparator. This is exactly how the ttnn op feeds the path, so the test must encode
     Int32 MAX/MIN operands as two's-complement to match the shipped (ttnn-green) kernel.
 
-    SUM/AVG keep sign-magnitude: there mode ``INT32_2S_COMP`` feeds genuine two's-complement
-    into ``SFPIADD`` (which needs it), so the standard sign-magnitude L1 contract is correct.
+    SUM is two's-complement as well. Int32 is stored in two's-complement and ``SFPIADD`` adds in
+    two's-complement, so the SUM kernel loads with plain ``INT32`` and the word reaches the adder
+    untouched. Feeding sign-magnitude here would mask the i32 SUM bug where ``INT32_2S_COMP``
+    corrupts negative operands, so SUM operands must be two's-complement too.
+
+    AVG is left out: it still loads with ``INT32_2S_COMP`` (its divide-by-32 step depends on that
+    mode), so its sign-magnitude contract is still the right match.
     """
     return formats.input_format == DataFormat.Int32 and reduce_pool in (
         ReducePool.Max,
         ReducePool.Min,
+        ReducePool.Sum,
     )
 
 


### PR DESCRIPTION
### PR Category
Ops 

### Summary
Solve provlem with LLk sfpu reduce failing on CI as descibed in https://github.com/tenstorrent/tt-metal/issues/47647
While removing bit 11 from sfpu some changes in LLKs or sfpu reduce were done where usage of instr_mod for 2s complement was removed. The errors reported by ops team were exactly these ones, so this PR is mainly about restoring that state. In BH we need to manually convert between representations 

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ljdurovic/fix_reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ljdurovic/fix_reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ljdurovic/fix_reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ljdurovic/fix_reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ljdurovic/fix_reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ljdurovic/fix_reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ljdurovic/fix_reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ljdurovic/fix_reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ljdurovic/fix_reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ljdurovic/fix_reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ljdurovic/fix_reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ljdurovic/fix_reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ljdurovic/fix_reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ljdurovic/fix_reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ljdurovic/fix_reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ljdurovic/fix_reduce)