### PR TITLE
[skip ci] [Models CI] gemma4: drop redundant transformers pin (use repo-wide 5.10.2)

### DIFF
--- a/models/demos/gemma4/requirements.txt
+++ b/models/demos/gemma4/requirements.txt
@@ -1,2 +1,1 @@
 sentencepiece
-transformers==5.10.2


### PR DESCRIPTION
## Summary
`models/demos/gemma4/requirements.txt` pinned `transformers==5.10.2`, duplicating the repo-wide pin in `tt_metal/python_env/requirements-dev.txt`. Remove the model-specific pin so gemma4 follows the repo pin (avoids lock-step drift on future bumps). It's a **no-op for the installed version** (already 5.10.2).

## CI confirmation
Full Gemma-4 matrix is **green** on transformers 5.10.2 — [All Model Tests run 27964886121](https://github.com/tenstorrent/tt-metal/actions/runs/27964886121): `Tiers[1,2,3] Tests[unit,e2e] Model[gemma-4] SKUs[all]` → **success**. Every variant passed both unit + e2e, no failures:

| Tier | SKU(s) | Variants (unit + e2e) |
|------|--------|------------------------|
| 1 | bh_quietbox_2 | Gemma-4-12B, Gemma-4-26B-A4B, Gemma-4-31B |
| 2 | wh_llmbox / wh_llmbox_perf | Gemma-4-26B-A4B, Gemma-4-31B |
| 3 | wh_n150, bh_p150, bh_p300, bh_quietbox_2 | Gemma-4-E2B, Gemma-4-E4B |

🤖 Generated with [Claude Code](https://claude.com/claude-code)