### PR TITLE
[Models-CI] Qwen3-VL: migrate to transformers 5.10.2 + move to tier-2 models pipelines

### DIFF
--- a/models/demos/qwen3_vl/demo/combined.py
+++ b/models/demos/qwen3_vl/demo/combined.py
@@ -121,7 +121,9 @@ def test_qwen_vl_end_to_end(
     if use_tt_vision:
         # Create the TorchVisionTransformer wrapper using the original vision model as reference
         model_args = VisionModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=max_new_tokens)
-        model.model.visual = DropInVisionTransformer(model.visual, model_args, debug=True)  # show PCC
+        # transformers 5.x nests the vision tower under model.model.visual; 4.x exposed model.visual.
+        _orig_visual = model.visual if hasattr(model, "visual") else model.model.visual
+        model.model.visual = DropInVisionTransformer(_orig_visual, model_args, debug=True)  # show PCC
 
     # Run inference
     logger.info("Running model generation...")

--- a/models/demos/qwen3_vl/demo/combined.py
+++ b/models/demos/qwen3_vl/demo/combined.py
@@ -15,6 +15,7 @@ from transformers import AutoProcessor
 from transformers.models.qwen3_vl.modeling_qwen3_vl import Qwen3VLForConditionalGeneration
 
 import ttnn
+from models.demos.qwen3_vl.tt.common import get_hf_visual
 from models.demos.qwen3_vl.tt.model import DropInVisionTransformer
 from models.demos.qwen3_vl.tt.model_config import VisionModelArgs
 
@@ -121,9 +122,7 @@ def test_qwen_vl_end_to_end(
     if use_tt_vision:
         # Create the TorchVisionTransformer wrapper using the original vision model as reference
         model_args = VisionModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=max_new_tokens)
-        # transformers 5.x nests the vision tower under model.model.visual; 4.x exposed model.visual.
-        _orig_visual = model.visual if hasattr(model, "visual") else model.model.visual
-        model.model.visual = DropInVisionTransformer(_orig_visual, model_args, debug=True)  # show PCC
+        model.model.visual = DropInVisionTransformer(get_hf_visual(model), model_args, debug=True)  # show PCC
 
     # Run inference
     logger.info("Running model generation...")

--- a/models/demos/qwen3_vl/demo/demo.py
+++ b/models/demos/qwen3_vl/demo/demo.py
@@ -578,12 +578,13 @@ def test_demo(
 
         # Start decoding
         iteration = 0
-        # Greedy decode samples on the HOST (full-precision argmax), not on-device. The on-device decode
-        # sampler introduced by the #45166 sampling-separation refactor selects wrong tokens for qwen3-vl
-        # (sporadic garbage during greedy decode, BERTScore F1 collapse); a host fp32 argmax over the same
-        # logits is correct and restores quality. See #47818. TODO: re-enable on-device sampling once the
-        # shared tt_transformers on-device decode sampler is fixed (tracked in #48222).
-        argmax_on_device = False
+        # Diagnostic A/B toggle (#48037). The actual gibberish fix is on the model side
+        # (Transformer in tt/model.py: force-argmax sampling path + always-refresh + eager sampling),
+        # which keeps on-device sampling. Setting TT_QWEN_FORCE_HOST_SAMPLING=1 forces host argmax
+        # instead: a known-good reference (correct output) but slower (per-step logits read-back),
+        # useful to compare against the on-device path locally.
+        force_host_sampling = os.environ.get("TT_QWEN_FORCE_HOST_SAMPLING", "0") == "1"
+        argmax_on_device = model._supports_on_device_sampling and not force_host_sampling
         if argmax_on_device:
             device_sampling_params = SamplingParams(temperature=0.0, top_k=-1, top_p=1.0)
         else:

--- a/models/demos/qwen3_vl/demo/demo.py
+++ b/models/demos/qwen3_vl/demo/demo.py
@@ -579,7 +579,12 @@ def test_demo(
 
         # Start decoding
         iteration = 0
-        argmax_on_device = sampling_params["temperature"] == 0
+        # Greedy decode samples on the HOST (full-precision argmax), not on-device. The on-device decode
+        # sampler introduced by the #45166 sampling-separation refactor selects wrong tokens for qwen3-vl
+        # (sporadic garbage during greedy decode, BERTScore F1 collapse); a host fp32 argmax over the same
+        # logits is correct and restores quality. See #47818. TODO: re-enable on-device sampling once the
+        # shared tt_transformers on-device decode sampler is fixed (tracked in #48222).
+        argmax_on_device = False
         if argmax_on_device:
             device_sampling_params = SamplingParams(temperature=0.0, top_k=-1, top_p=1.0)
         else:
@@ -629,6 +634,9 @@ def test_demo(
                     top_p=sampling_params["top_p"],
                     on_host=True,
                 )
+                # Normalize to the device-path feedback shape [batch, 1] so the next decode_forward and
+                # the out_tok[user].item() reads below behave identically to the on-device path.
+                out_tok = out_tok.reshape(batch_size, 1)
 
             if iteration == 0:  # First iteration will account the compile time
                 profiler.end(f"compile_decode", iteration=batch_idx)

--- a/models/demos/qwen3_vl/demo/demo.py
+++ b/models/demos/qwen3_vl/demo/demo.py
@@ -385,7 +385,9 @@ def test_demo(
             optimizations=DecodersPrecision.accuracy(config.vision_config.depth, ref_model_name),
         )
         vision_model_args.hf_config.vision_config.depth = config.vision_config.depth
-        visual_model = DropInVisionTransformer(get_hf_visual(reference_model), vision_model_args, debug=False)  # show PCC
+        visual_model = DropInVisionTransformer(
+            get_hf_visual(reference_model), vision_model_args, debug=False
+        )  # show PCC
     else:
         visual_model = get_hf_visual(reference_model)
     processor = AutoProcessor.from_pretrained(ref_model_name)

--- a/models/demos/qwen3_vl/demo/demo.py
+++ b/models/demos/qwen3_vl/demo/demo.py
@@ -384,9 +384,11 @@ def test_demo(
             optimizations=DecodersPrecision.accuracy(config.vision_config.depth, ref_model_name),
         )
         vision_model_args.hf_config.vision_config.depth = config.vision_config.depth
-        visual_model = DropInVisionTransformer(reference_model.visual, vision_model_args, debug=False)  # show PCC
+        # transformers 5.x nests the vision tower under model.model.visual; 4.x exposed model.visual.
+        _ref_visual = reference_model.visual if hasattr(reference_model, "visual") else reference_model.model.visual
+        visual_model = DropInVisionTransformer(_ref_visual, vision_model_args, debug=False)  # show PCC
     else:
-        visual_model = reference_model.visual
+        visual_model = reference_model.visual if hasattr(reference_model, "visual") else reference_model.model.visual
     processor = AutoProcessor.from_pretrained(ref_model_name)
     num_tokens_generated_decode = []
     num_image_tokens = []

--- a/models/demos/qwen3_vl/demo/demo.py
+++ b/models/demos/qwen3_vl/demo/demo.py
@@ -16,6 +16,7 @@ import ttnn
 from models.common.sampling import SamplingParams
 from models.demos.qwen3_vl.tt.common import (
     PagedAttentionConfig,
+    get_hf_visual,
     get_pad_embedding,
     merge_vision_tokens_single_user_ttnn,
     multimodal_rope_single_user_from_hf,
@@ -384,11 +385,9 @@ def test_demo(
             optimizations=DecodersPrecision.accuracy(config.vision_config.depth, ref_model_name),
         )
         vision_model_args.hf_config.vision_config.depth = config.vision_config.depth
-        # transformers 5.x nests the vision tower under model.model.visual; 4.x exposed model.visual.
-        _ref_visual = reference_model.visual if hasattr(reference_model, "visual") else reference_model.model.visual
-        visual_model = DropInVisionTransformer(_ref_visual, vision_model_args, debug=False)  # show PCC
+        visual_model = DropInVisionTransformer(get_hf_visual(reference_model), vision_model_args, debug=False)  # show PCC
     else:
-        visual_model = reference_model.visual if hasattr(reference_model, "visual") else reference_model.model.visual
+        visual_model = get_hf_visual(reference_model)
     processor = AutoProcessor.from_pretrained(ref_model_name)
     num_tokens_generated_decode = []
     num_image_tokens = []
@@ -732,8 +731,8 @@ def test_demo(
 
     if is_ci_env and "bert-score" in test_id:
         expected_output = load_expected_text(model_args.base_model_name)
-        from bert_score import score as bert_score
         import bert_score.utils as _bert_score_utils
+        from bert_score import score as bert_score
 
         # transformers 5.x leaves some tokenizers' model_max_length at the VERY_LARGE_INTEGER sentinel
         # (~1e30); bert_score forwards it straight into the fast tokenizer's truncation, which overflows

--- a/models/demos/qwen3_vl/demo/demo.py
+++ b/models/demos/qwen3_vl/demo/demo.py
@@ -725,6 +725,21 @@ def test_demo(
     if is_ci_env and "bert-score" in test_id:
         expected_output = load_expected_text(model_args.base_model_name)
         from bert_score import score as bert_score
+        import bert_score.utils as _bert_score_utils
+
+        # transformers 5.x leaves some tokenizers' model_max_length at the VERY_LARGE_INTEGER sentinel
+        # (~1e30); bert_score forwards it straight into the fast tokenizer's truncation, which overflows
+        # the Rust usize ("OverflowError: int too big to convert"). Clamp to the model's real limit so the
+        # metric runs (deberta-xlarge-mnli supports 512 positions; demo outputs are far shorter, so this
+        # never actually truncates).
+        _orig_sent_encode = _bert_score_utils.sent_encode
+
+        def _sent_encode_clamped(tokenizer, sent):
+            if getattr(tokenizer, "model_max_length", 0) and tokenizer.model_max_length > 1_000_000:
+                tokenizer.model_max_length = 512
+            return _orig_sent_encode(tokenizer, sent)
+
+        _bert_score_utils.sent_encode = _sent_encode_clamped
 
         candidates = text_outputs_all_users_all_batches
         references = [expected_output] * len(candidates)

--- a/models/demos/qwen3_vl/requirements.txt
+++ b/models/demos/qwen3_vl/requirements.txt
@@ -2,6 +2,5 @@
 accelerate >= 0.27.2
 torch>=2.6.0
 torchvision>=0.21.0
-transformers==4.57.0
 qwen-vl-utils
 nltk

--- a/models/demos/qwen3_vl/tests/test_model.py
+++ b/models/demos/qwen3_vl/tests/test_model.py
@@ -144,7 +144,15 @@ def test_vision_model_inference(
     tt_input = tt_model.prepare_input(patch_input, seq_len)
 
     # Run reference model
-    reference_output, reference_deepstack_visual_embeds = reference_model(pt_pixel_values, image_grid_thw)
+    # transformers 5.x Qwen3VLVisionModel returns BaseModelOutputWithDeepstackFeatures, not a
+    # (last_hidden_state, deepstack_features) tuple. Unpack version-tolerantly.
+    _vis_out = reference_model(pt_pixel_values, image_grid_thw)
+    if isinstance(_vis_out, tuple):
+        reference_output, reference_deepstack_visual_embeds = _vis_out
+    else:
+        # 5.x merged image embeds are in pooler_output (the merger output); last_hidden_state is the
+        # pre-merger patch features. The LM itself consumes vision_output.pooler_output.
+        reference_output, reference_deepstack_visual_embeds = _vis_out.pooler_output, _vis_out.deepstack_features
 
     # Run TT model
     tt_out, tt_deepstack_visual_embeds = tt_model(

--- a/models/demos/qwen3_vl/tests/test_wrapped_model.py
+++ b/models/demos/qwen3_vl/tests/test_wrapped_model.py
@@ -72,7 +72,15 @@ def test_wrapped_vision_model_inference(
     torch_model = DropInVisionTransformer(reference_model, model_args)
 
     # Run reference model
-    reference_output, deepstack_visual_embeds = reference_model(pt_pixel_values, image_grid_thw)
+    # transformers 5.x Qwen3VLVisionModel returns BaseModelOutputWithDeepstackFeatures, not a
+    # (last_hidden_state, deepstack_features) tuple. Unpack version-tolerantly.
+    _vis_out = reference_model(pt_pixel_values, image_grid_thw)
+    if isinstance(_vis_out, tuple):
+        reference_output, deepstack_visual_embeds = _vis_out
+    else:
+        # 5.x merged image embeds are in pooler_output (the merger output); last_hidden_state is the
+        # pre-merger patch features. The LM itself consumes vision_output.pooler_output.
+        reference_output, deepstack_visual_embeds = _vis_out.pooler_output, _vis_out.deepstack_features
     tt_output, tt_deepstack_visual_embeds = torch_model(pt_pixel_values, image_grid_thw)
 
     # Reassemble the hidden dimension that was mesh-partitioned by the wrapper.

--- a/models/demos/qwen3_vl/tt/common.py
+++ b/models/demos/qwen3_vl/tt/common.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+import inspect
 import math
 import os
 from types import SimpleNamespace
@@ -428,12 +429,18 @@ def multimodal_rope_single_user_from_hf(
     padded_attention_mask = torch.ones_like(padded_inputs, dtype=torch.int64)
 
     # Qwen3VLForConditionalGeneration.forward:
-    position_ids, rope_deltas = reference_model.model.get_rope_index(
-        padded_inputs,
-        image_grid_thw,
-        video_grid_thw=None,
-        attention_mask=padded_attention_mask,
-    )
+    rope_index_kwargs = dict(image_grid_thw=image_grid_thw, video_grid_thw=None, attention_mask=padded_attention_mask)
+    # transformers >=5.x get_rope_index added a required `mm_token_type_ids` arg (0=text, 1=image,
+    # 2=video) that the processor normally produces; reconstruct it from the placeholder token ids.
+    if "mm_token_type_ids" in inspect.signature(reference_model.model.get_rope_index).parameters:
+        config = reference_model.config
+        mm_token_type_ids = torch.zeros_like(padded_inputs, dtype=torch.int32)
+        if getattr(config, "image_token_id", None) is not None:
+            mm_token_type_ids[padded_inputs == config.image_token_id] = 1
+        if getattr(config, "video_token_id", None) is not None:
+            mm_token_type_ids[padded_inputs == config.video_token_id] = 2
+        rope_index_kwargs["mm_token_type_ids"] = mm_token_type_ids
+    position_ids, rope_deltas = reference_model.model.get_rope_index(padded_inputs, **rope_index_kwargs)
 
     # Qwen3VLModel.forward:
     x = SimpleNamespace(device=SimpleNamespace(type="cpu"), dtype=torch.bfloat16)

--- a/models/demos/qwen3_vl/tt/common.py
+++ b/models/demos/qwen3_vl/tt/common.py
@@ -13,6 +13,15 @@ import ttnn
 from models.tt_transformers.tt.load_checkpoints import convert_rope_style_hf_to_meta
 
 
+def get_hf_visual(model):
+    """Return the HF vision tower.
+
+    transformers 5.x nests the vision tower under ``model.model.visual`` (``Qwen3VLModel``);
+    4.x exposed it directly as ``model.visual``. Accept either.
+    """
+    return model.visual if hasattr(model, "visual") else model.model.visual
+
+
 def merge_vision_tokens(
     input_ids,
     input_embeds,

--- a/models/demos/qwen3_vl/tt/common.py
+++ b/models/demos/qwen3_vl/tt/common.py
@@ -385,7 +385,10 @@ def multimodal_rope_from_hf(
     )
 
     # Qwen3VLModel.forward:
-    x = SimpleNamespace(device=SimpleNamespace(type="cpu"), dtype=torch.bfloat16)
+    # transformers 5.x Qwen3VLTextRotaryEmbedding.forward calls inv_freq.to(x.device), so x.device must be
+    # a real torch.device (a SimpleNamespace there makes tensor.to() raise TypeError). x only needs .device
+    # and .dtype, so a SimpleNamespace with a real device is enough without materializing a tensor.
+    x = SimpleNamespace(device=torch.device("cpu"), dtype=torch.bfloat16)
     cos, sin = reference_model.model.language_model.rotary_emb(x, position_ids)
     # apply_multimodal_rotary_pos_emb:
     unsqueeze_dim = 1
@@ -443,7 +446,10 @@ def multimodal_rope_single_user_from_hf(
     position_ids, rope_deltas = reference_model.model.get_rope_index(padded_inputs, **rope_index_kwargs)
 
     # Qwen3VLModel.forward:
-    x = SimpleNamespace(device=SimpleNamespace(type="cpu"), dtype=torch.bfloat16)
+    # transformers 5.x Qwen3VLTextRotaryEmbedding.forward calls inv_freq.to(x.device), so x.device must be
+    # a real torch.device (a SimpleNamespace there makes tensor.to() raise TypeError). x only needs .device
+    # and .dtype, so a SimpleNamespace with a real device is enough without materializing a tensor.
+    x = SimpleNamespace(device=torch.device("cpu"), dtype=torch.bfloat16)
     cos, sin = reference_model.model.language_model.rotary_emb(x, position_ids)
     # apply_multimodal_rotary_pos_emb:
     unsqueeze_dim = 1

--- a/models/demos/qwen3_vl/tt/generator_vllm.py
+++ b/models/demos/qwen3_vl/tt/generator_vllm.py
@@ -21,6 +21,7 @@ from vllm.multimodal import MULTIMODAL_REGISTRY
 
 import ttnn
 from models.demos.qwen3_vl.tt.common import (
+    get_hf_visual,
     get_pad_embedding,
     merge_vision_tokens_single_user_ttnn,
     multimodal_rope_single_user_from_hf,
@@ -160,9 +161,7 @@ class Qwen3VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
             optimizations=DecodersPrecision.performance(config.vision_config.depth, ref_model_name),
         )
         vision_model_args.hf_config.vision_config.depth = config.vision_config.depth
-        # transformers 5.x nests the vision tower under model.model.visual; 4.x exposed model.visual.
-        _ref_visual = reference_model.visual if hasattr(reference_model, "visual") else reference_model.model.visual
-        visual_model = DropInVisionTransformer(_ref_visual, vision_model_args)
+        visual_model = DropInVisionTransformer(get_hf_visual(reference_model), vision_model_args)
 
         return cls(
             model,

--- a/models/demos/qwen3_vl/tt/generator_vllm.py
+++ b/models/demos/qwen3_vl/tt/generator_vllm.py
@@ -160,7 +160,9 @@ class Qwen3VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
             optimizations=DecodersPrecision.performance(config.vision_config.depth, ref_model_name),
         )
         vision_model_args.hf_config.vision_config.depth = config.vision_config.depth
-        visual_model = DropInVisionTransformer(reference_model.visual, vision_model_args)
+        # transformers 5.x nests the vision tower under model.model.visual; 4.x exposed model.visual.
+        _ref_visual = reference_model.visual if hasattr(reference_model, "visual") else reference_model.model.visual
+        visual_model = DropInVisionTransformer(_ref_visual, vision_model_args)
 
         return cls(
             model,

--- a/models/demos/qwen3_vl/tt/model.py
+++ b/models/demos/qwen3_vl/tt/model.py
@@ -456,6 +456,12 @@ class DropInVisionTransformer(torch.nn.Module):
 
 
 class Transformer(TTTransformer):
+    # Decode re-stages host token IDs every step, so the on-device decode-trace token buffer
+    # (device_inputs[0]) is not a valid preallocated ttnn.sampling output — feeding the sampled token back
+    # into it corrupts decode (degenerate generation) after the #45166 sampling-separation refactor. Mirror
+    # gemma4: don't reuse that buffer for sampling; refresh the trace inputs from host each step.
+    _tt_vllm_always_refresh_decode_trace_inputs = True
+
     def __init__(
         self,
         args,

--- a/models/demos/qwen3_vl/tt/model.py
+++ b/models/demos/qwen3_vl/tt/model.py
@@ -456,11 +456,21 @@ class DropInVisionTransformer(torch.nn.Module):
 
 
 class Transformer(TTTransformer):
-    # Decode re-stages host token IDs every step, so the on-device decode-trace token buffer
-    # (device_inputs[0]) is not a valid preallocated ttnn.sampling output — feeding the sampled token back
-    # into it corrupts decode (degenerate generation) after the #45166 sampling-separation refactor. Mirror
-    # gemma4: don't reuse that buffer for sampling; refresh the trace inputs from host each step.
+    # --- On-device greedy decode correctness on batch-32 (#48037) ---
+    # Symptom: on-device sampling produced gibberish at batch-32 (BERTScore F1 ~0.34)
+    # but is correct at batch-1, and host argmax of the same batch-32 run is correct
+    # (F1 0.79) -> the decode forward is fine; only the on-device sampling path is wrong
+    # at batch-32. Root cause: with allow_force_argmax disabled (the non-Galaxy default),
+    # greedy decode (temperature=0 -> k=1,p=0,temp=1) goes through the heavy top-k/top-p
+    # multi-all-gather sampling pipeline, which is what corrupts at batch-32, rather than
+    # the simple single-gather argmax path.
+    #
+    # Fix: route greedy decode through the force-argmax path (enabled in __init__ below),
+    # and re-stage the decode trace inputs from host every step + run the sampling op
+    # eagerly so the all-gather re-acquires a fresh multi_device_global_semaphore each
+    # step instead of reusing a stale one frozen into a captured trace.
     _tt_vllm_always_refresh_decode_trace_inputs = True
+    _tt_disable_sampling_trace = True
 
     def __init__(
         self,
@@ -472,6 +482,14 @@ class Transformer(TTTransformer):
         paged_attention_config=None,
         use_paged_kv_cache=False,
     ):
+        # Enable the single-gather force-argmax sampling path for greedy decode. The
+        # non-Galaxy default (default_sampling_force_argmax) sets allow_force_argmax=False,
+        # which forces greedy decode onto the heavy top-k/top-p pipeline that corrupts at
+        # batch-32 (#48037). Must be set before super().__init__ builds the sampling module.
+        ag_cfg = dict(args.model_config.get("SAMPLING_AG_CONFIG", {}) or {})
+        ag_cfg["allow_force_argmax"] = True
+        args.model_config["SAMPLING_AG_CONFIG"] = ag_cfg
+
         # Call parent constructor with vision-specific classes
         super().__init__(
             args=args,

--- a/models/demos/qwen3_vl/tt/model_config.py
+++ b/models/demos/qwen3_vl/tt/model_config.py
@@ -105,6 +105,7 @@ class VisionModelArgs(ModelArgs):
 
     def reference_vision_model(self, depth=None):
         # Workaround until Qwen2.5-VL is fully integrated into a HF release
+        import torch
         from transformers.models.qwen3_vl.modeling_qwen3_vl import (
             Qwen3VLForConditionalGeneration as AutoModelForCausalLM,
         )
@@ -112,8 +113,12 @@ class VisionModelArgs(ModelArgs):
         print("Loading Qwen3-VL model: ", AutoModelForCausalLM)
         config = AutoModelForCausalLM.config_class.from_pretrained(self.CKPT_DIR)
         config.vision_config.depth = depth if depth is not None else config.vision_config.depth
-        model = AutoModelForCausalLM.from_pretrained(self.CKPT_DIR, config=config)
-        return model.visual
+        # transformers 5.x loads in the config dtype (bf16) by default; force float32 so the reference
+        # and its sub-modules match the float32 test inputs (4.x defaulted to float32).
+        model = AutoModelForCausalLM.from_pretrained(self.CKPT_DIR, config=config, torch_dtype=torch.float32)
+        # transformers 5.x nests the vision tower under model.model.visual (Qwen3VLModel); 4.x exposed
+        # it at the top level as model.visual.
+        return model.visual if hasattr(model, "visual") else model.model.visual
 
     def reference_vision_block(self, layer_num=0):
         return self.reference_vision_model().blocks[layer_num]

--- a/models/demos/qwen3_vl/tt/model_config.py
+++ b/models/demos/qwen3_vl/tt/model_config.py
@@ -7,7 +7,7 @@ import math
 from loguru import logger
 
 import ttnn
-from models.demos.qwen3_vl.tt.common import nearest_multiple
+from models.demos.qwen3_vl.tt.common import get_hf_visual, nearest_multiple
 from models.tt_transformers.tt.model_config import ModelArgs
 
 
@@ -116,9 +116,7 @@ class VisionModelArgs(ModelArgs):
         # transformers 5.x loads in the config dtype (bf16) by default; force float32 so the reference
         # and its sub-modules match the float32 test inputs (4.x defaulted to float32).
         model = AutoModelForCausalLM.from_pretrained(self.CKPT_DIR, config=config, torch_dtype=torch.float32)
-        # transformers 5.x nests the vision tower under model.model.visual (Qwen3VLModel); 4.x exposed
-        # it at the top level as model.visual.
-        return model.visual if hasattr(model, "visual") else model.model.visual
+        return get_hf_visual(model)
 
     def reference_vision_block(self, layer_num=0):
         return self.reference_vision_model().blocks[layer_num]

--- a/models/model_ci_tiers.md
+++ b/models/model_ci_tiers.md
@@ -60,6 +60,7 @@ The initial release of the 3-tier model CI includes models owned by the models-t
 | Qwen2.5-32B | WH LLMBox, BH QuietBox 2 |
 | Qwen2.5-Coder-32B | WH LLMBox |
 | Qwen2.5-72B-VL | WH LLMBox, BH QuietBox 2 |
+| Qwen3-VL-32B | WH LLMBox |
 | Llama90B-VL | WH LLMBox |
 | Shallow-UNet | WH N150, WH LLMBox |
 | Mistral-7B | WH N150 |

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -306,7 +306,7 @@
 - name: Qwen3-VL-32B e2e tests
   cmd: |
     uv pip install -r models/demos/qwen3_vl/requirements.txt
-    export HF_MODEL=Qwen/Qwen3-VL-32B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-VL-32B-Instruct MESH_DEVICE=T3K
+    export HF_MODEL=Qwen/Qwen3-VL-32B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-VL-32B-Instruct MESH_DEVICE=T3K PYTEST_ADDOPTS="--tb=short"
     pytest models/demos/qwen3_vl/demo/demo.py --timeout 600
   model: qwen3-vl-32b
   skus:

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -303,6 +303,19 @@
   owner_id: U07RY6B5FLJ # Gongyu Wang
   team: models
 
+- name: Qwen3-VL-32B e2e tests
+  cmd: |
+    uv pip install -r models/demos/qwen3_vl/requirements.txt
+    export HF_MODEL=Qwen/Qwen3-VL-32B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-VL-32B-Instruct MESH_DEVICE=T3K
+    pytest models/demos/qwen3_vl/demo/demo.py --timeout 600
+  model: qwen3-vl-32b
+  skus:
+    wh_llmbox_perf:
+      timeout: 10
+      tier: 2
+  owner_id: U08H31YMN4Q # Sanjay Sanjay
+  team: models
+
 # TODO Top-1/Top-5 test failing with segfaulting.
 # pytest --timeout 600 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-token-matching"
 - name: QwQ-32B e2e tests

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -594,7 +594,7 @@
 - name: Qwen3-VL-32B unit tests
   cmd: |
     uv pip install -r models/demos/qwen3_vl/requirements.txt
-    export HF_MODEL=Qwen/Qwen3-VL-32B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-VL-32B-Instruct MESH_DEVICE=T3K
+    export HF_MODEL=Qwen/Qwen3-VL-32B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-VL-32B-Instruct MESH_DEVICE=T3K PYTEST_ADDOPTS="--tb=short"
     pytest models/demos/qwen3_vl/tests/ --ignore=models/demos/qwen3_vl/tests/test_ci_dispatch.py --ignore=models/demos/qwen3_vl/tests/conftest.py
   model: qwen3-vl-32b
   skus:

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -591,6 +591,19 @@
   owner_id: U07RY6B5FLJ # Gongyu Wang
   team: models
 
+- name: Qwen3-VL-32B unit tests
+  cmd: |
+    uv pip install -r models/demos/qwen3_vl/requirements.txt
+    export HF_MODEL=Qwen/Qwen3-VL-32B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-VL-32B-Instruct MESH_DEVICE=T3K
+    pytest models/demos/qwen3_vl/tests/ --ignore=models/demos/qwen3_vl/tests/test_ci_dispatch.py --ignore=models/demos/qwen3_vl/tests/conftest.py
+  model: qwen3-vl-32b
+  skus:
+    wh_llmbox:
+      timeout: 15
+      tier: 2
+  owner_id: U08H31YMN4Q # Sanjay Sanjay
+  team: models
+
 - name: Phi-3-mini unit tests
   cmd: |
     export HF_MODEL=microsoft/Phi-3-mini-128k-instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/microsoft/Phi-3-mini-128k-instruct

--- a/tests/pipeline_reorg/release_tests.yaml
+++ b/tests/pipeline_reorg/release_tests.yaml
@@ -341,15 +341,6 @@
   team: models
   model-name: qwenimage
 
-- name: t3k_qwen3_vl_tests
-  cmd: run_t3000_qwen3_vl_tests
-  skus:
-    wh_llmbox_perf:
-      timeout: 12
-  owner_id: U08H31YMN4Q # Sanjay Sanjay
-  team: models
-  model-name: qwen3_vl
-
 # ============================================================================
 # Galaxy Wormhole tests
 # ============================================================================

--- a/tests/pipeline_reorg/t3k_demo_tests.yaml
+++ b/tests/pipeline_reorg/t3k_demo_tests.yaml
@@ -82,12 +82,3 @@
   owner_id: U09ELB03XRU # Stephen Osborne
   team: models
   model-name: mochi
-
-- name: t3k_qwen3_vl_tests
-  cmd: run_t3000_qwen3_vl_tests
-  skus:
-    wh_llmbox_perf:
-      timeout: 10
-  owner_id: U08H31YMN4Q # Sanjay Sanjay
-  team: models
-  model-name: qwen3_vl

--- a/tests/pipeline_reorg/t3k_unit_tests.yaml
+++ b/tests/pipeline_reorg/t3k_unit_tests.yaml
@@ -79,15 +79,6 @@
   team: models
   model-name: tttv2 modules
 
-- name: t3k_qwen3_vl_tests
-  cmd: run_t3000_qwen3_vl_unit_tests
-  skus:
-    wh_llmbox:
-      timeout: 15
-  owner_id: U08H31YMN4Q # Sanjay Sanjay
-  team: models
-  model-name: qwen3_vl
-
 - name: t3k_mistral-small-3.1-24b-vision_tests
   cmd: run_t3000_mistral-small-3.1-24b-vision_unit_tests
   skus:

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -80,19 +80,6 @@ run_t3000_qwenimage_tests() {
   run_t3000_dit_tests "models/tt_dit/tests/models/qwenimage/test_pipeline_qwenimage.py -k 2x4"
 }
 
-run_t3000_qwen3_vl_tests() {
-  # install qwen3_vl requirements
-  uv pip install -r models/demos/qwen3_vl/requirements.txt
-
-  # export PYTEST_ADDOPTS for concise pytest output
-  export PYTEST_ADDOPTS="--tb=short"
-
-  # Qwen3-VL-32B
-  qwen3_vl_32b=Qwen/Qwen3-VL-32B-Instruct
-  tt_cache_32b=$TT_CACHE_HOME/$qwen3_vl_32b
-  MESH_DEVICE=T3K HF_MODEL=$qwen3_vl_32b TT_CACHE_PATH=$tt_cache_32b pytest models/demos/qwen3_vl/demo/demo.py --timeout 600
-}
-
 run_t3000_wan22_tests() {
   # Record the start time
   fail=0

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -207,20 +207,6 @@ run_t3000_grok_tests() {
   fi
 }
 
-run_t3000_qwen3_vl_unit_tests() {
-  # install qwen3_vl requirements
-  uv pip install -r models/demos/qwen3_vl/requirements.txt
-
-  # export PYTEST_ADDOPTS for concise pytest output
-  export PYTEST_ADDOPTS="--tb=short"
-
-  qwen3_vl_32b=Qwen/Qwen3-VL-32B-Instruct
-  tt_cache_32b=$TT_CACHE_HOME/$qwen3_vl_32b
-
-  # run unit tests
-  MESH_DEVICE=T3K HF_MODEL=$qwen3_vl_32b TT_CACHE_PATH=$tt_cache_32b pytest models/demos/qwen3_vl/tests/ --ignore=models/demos/qwen3_vl/tests/test_ci_dispatch.py --ignore=models/demos/qwen3_vl/tests/conftest.py
-}
-
 run_t3000_deepseek_tests() {
   uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
 


### PR DESCRIPTION
## Summary
Unpins Qwen3-VL from `transformers==4.57.0` (uses the repo-wide 5.10.2), fixes the 5.x incompatibilities it surfaced, and moves its CI from the t3000 pipelines into the tier-based `models_{unit,e2e}_tests` pipelines as **tier 2**. Model: **Qwen/Qwen3-VL-32B-Instruct** (`qwen3-vl-32b`).

## 5.x migration fixes
- **Vision tower** moved `model.visual` → `model.model.visual` (`Qwen3VLModel`) — version-tolerant accessors in `tt/model_config.py`, `demo/demo.py`, `demo/combined.py`, `tt/generator_vllm.py`.
- **Reference dtype**: load the reference vision model in float32 (5.x defaults to the config bf16) so it matches the float32 test inputs.
- **Vision output**: 5.x returns `BaseModelOutputWithDeepstackFeatures`; use `pooler_output` (merged embeds) + `deepstack_features` instead of tuple-unpack / `last_hidden_state` (`test_model`, `test_wrapped_model`).

## Pipeline move (tier 2)
- Added **Qwen3-VL-32B unit** + **e2e** entries to `models_unit_tests.yaml` / `models_e2e_tests.yaml` (commands copied verbatim from the t3000 unit/demo), listed under Tier 2 in `model_ci_tiers.md`.
- Removed `t3k_qwen3_vl` entries from `t3k_unit_tests.yaml` / `t3k_demo_tests.yaml` / `release_tests.yaml` and the orphaned `run_t3000_qwen3_vl_*` shell functions. **vLLM nightly unchanged.**

## Decode-quality fix (#45166 / #48037 regression)
Bringing qwen3-vl onto 5.x surfaced a **BERTScore F1 collapse** (last-good 0.79 → 0.345) and **batch-32 greedy-decode gibberish** in the e2e demo. Root cause is shared with qwen2.5-vl (#47822 / #48037):

- With `allow_force_argmax` disabled (the non-Galaxy default), greedy decode (temp=0 → `k=1,p=0`) goes through the **heavy top-k/top-p multi-all-gather** sampling pipeline, which **corrupts at batch-32 on T3000** — the simple single-gather argmax path is correct.
- Compounded by #45166's separate sampling trace: the force-argmax all-gather's `multi_device_global_semaphore` is frozen into the captured sampling trace, so replay reuses a stale semaphore.

**Fix (mirrors qwen2.5-vl #47822, keeps sampling on-device):**
1. **Enable `allow_force_argmax`** for the qwen3-vl `Transformer` (set in `SAMPLING_AG_CONFIG` before the sampling module is built) → greedy uses the single-gather argmax path.
2. **`_tt_disable_sampling_trace = True`** → run the sampling op eagerly so the all-gather re-acquires a fresh semaphore each step (the heavy decode forward stays traced).
3. **`_tt_vllm_always_refresh_decode_trace_inputs = True`** → re-stage decode trace inputs from host each step (also fixes the #45522 repeat-batch staleness).
4. Shared `tt_transformers/tt/generator.py` honors `_tt_disable_sampling_trace` in `sample_decode_on_device` (identical to #47822; dedupes on rebase).
5. Demo keeps on-device sampling by default with a `TT_QWEN_FORCE_HOST_SAMPLING=1` A/B toggle.

This keeps decode **on-device** (no per-step logits read-back), so accuracy *and* perf are preserved.

## Validation
- `t3k_qwen3_vl_tests` unit suite **green** (all 9 tests pass).
- **e2e demo green** (on-device force-argmax): BERTScore F1 **0.788**, both `bert-score` + `text-only` pass, decode **~18.9 tok/s/user** (vs ~13.3 with the earlier host-argmax approach — ~42% faster) — [run 28233883882](https://github.com/tenstorrent/tt-metal/actions/runs/28233883882). Previously a known failure on main (4.57.0); now passes.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/unpin-qwen3vl)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/unpin-qwen3vl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/unpin-qwen3vl)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/unpin-qwen3vl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mtairum/unpin-qwen3vl)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mtairum/unpin-qwen3vl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/unpin-qwen3vl)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/unpin-qwen3vl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/unpin-qwen3vl)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/unpin-qwen3vl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/unpin-qwen3vl)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/unpin-qwen3vl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/unpin-qwen3vl)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/unpin-qwen3vl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/unpin-qwen3vl)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/unpin-qwen3vl)

