### PR TITLE
Adding init support for `cos` and `sin` in `sfpu_operations.h`

### DIFF
--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
@@ -348,6 +348,14 @@ void call_unary_sfpu_operation_init()
     {
         llk_math_eltwise_unary_sfpu_init<OPERATION>(log1p_init<APPROX_MODE, FAST_MODE, is_fp32_dest_acc_en>);
     }
+    else if constexpr (OPERATION == SfpuType::cosine)
+    {
+        llk_math_eltwise_unary_sfpu_init<OPERATION>(cosine_init<APPROX_MODE>);
+    }
+    else if constexpr (OPERATION == SfpuType::sine)
+    {
+        llk_math_eltwise_unary_sfpu_init<OPERATION>(sine_init<APPROX_MODE>);
+    }
     else if constexpr (OPERATION == SfpuType::reciprocal)
     {
         llk_math_eltwise_unary_sfpu_init<OPERATION>(recip_init<APPROX_MODE, is_fp32_dest_acc_en>);

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
@@ -324,6 +324,10 @@ void call_unary_sfpu_operation_init()
     {
         llk_math_eltwise_unary_sfpu_init<OPERATION>(init_atanh<APPROX_MODE>);
     }
+    else if constexpr (OPERATION == SfpuType::cosine)
+    {
+        llk_math_eltwise_unary_sfpu_init<OPERATION>(cosine_init<APPROX_MODE>);
+    }
     else if constexpr (OPERATION == SfpuType::exp2)
     {
         llk_math_eltwise_unary_sfpu_init<OPERATION>(exp2_init<APPROX_MODE, is_fp32_dest_acc_en>);
@@ -348,14 +352,6 @@ void call_unary_sfpu_operation_init()
     {
         llk_math_eltwise_unary_sfpu_init<OPERATION>(log1p_init<APPROX_MODE, FAST_MODE, is_fp32_dest_acc_en>);
     }
-    else if constexpr (OPERATION == SfpuType::cosine)
-    {
-        llk_math_eltwise_unary_sfpu_init<OPERATION>(cosine_init<APPROX_MODE>);
-    }
-    else if constexpr (OPERATION == SfpuType::sine)
-    {
-        llk_math_eltwise_unary_sfpu_init<OPERATION>(sine_init<APPROX_MODE>);
-    }
     else if constexpr (OPERATION == SfpuType::reciprocal)
     {
         llk_math_eltwise_unary_sfpu_init<OPERATION>(recip_init<APPROX_MODE, is_fp32_dest_acc_en>);
@@ -363,6 +359,10 @@ void call_unary_sfpu_operation_init()
     else if constexpr (OPERATION == SfpuType::rsqrt)
     {
         llk_math_eltwise_unary_sfpu_init<OPERATION>(rsqrt_init<APPROX_MODE, false /* legacy_compat */>);
+    }
+    else if constexpr (OPERATION == SfpuType::sine)
+    {
+        llk_math_eltwise_unary_sfpu_init<OPERATION>(sine_init<APPROX_MODE>);
     }
     else if constexpr (OPERATION == SfpuType::sqrt)
     {


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
We lacked support for initializing some trig SFPU ops in `tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h`.
This PR adds the missing init branches so these ops are initialized properly before running.

### Notes for reviewers
Main thing to look at: `tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jmacanovic/sfpu-cos-sin-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jmacanovic/sfpu-cos-sin-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jmacanovic/sfpu-cos-sin-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jmacanovic/sfpu-cos-sin-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jmacanovic/sfpu-cos-sin-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jmacanovic/sfpu-cos-sin-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jmacanovic/sfpu-cos-sin-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jmacanovic/sfpu-cos-sin-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jmacanovic/sfpu-cos-sin-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jmacanovic/sfpu-cos-sin-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jmacanovic/sfpu-cos-sin-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jmacanovic/sfpu-cos-sin-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jmacanovic/sfpu-cos-sin-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jmacanovic/sfpu-cos-sin-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jmacanovic/sfpu-cos-sin-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jmacanovic/sfpu-cos-sin-support)