### PR TITLE
[tt-emule] Fix sharded layernorm JIT compile under x86 clang

### DIFF
--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -585,6 +585,21 @@ static void apply_x86_rewrites(std::string& src) {
         R"(reinterpret_cast<\s*(?:std::)?uint32_t\s*>\s*\(\s*((?:[^()]|\([^()]*\))*?)\s*\))");
     src = std::regex_replace(
         src, ptr_to_l1_addr_re, "static_cast<uint32_t>(reinterpret_cast<uintptr_t>($1))");
+
+    // tt-metal's sharded-layernorm dataflow util declares
+    // `using RemoteNocCoords = RemoteNocCoord[N];`. The two-stage reduce path
+    // instantiates it with N==0 for a core that has no second-stage workers,
+    // forming a zero-length array RemoteNocCoord[0]. Silicon's kernel compiler
+    // accepts that as a GNU extension; stock x86 clang rejects it as a
+    // substitution failure ("zero-length arrays are not permitted in C++"),
+    // even though the array is dead (the N==0 loop never runs and it is never
+    // indexed). The instantiation is unavoidable because kernel_main() is not a
+    // template, so the `if constexpr (use_two_stage_reduce)` dead branch is
+    // still type-checked. Rewrite the array bound so N==0 yields a 1-element
+    // dummy; behavior is identical on both arches (the element is never touched).
+    static const std::regex zero_len_noc_coords_re(
+        R"((using\s+RemoteNocCoords\s*=\s*RemoteNocCoord\s*\[)\s*N\s*(\]))");
+    src = std::regex_replace(src, zero_len_noc_coords_re, "$1(N) == 0 ? 1 : (N)$2");
 }
 
 // Patch `src_path` into `out_path`, then recurse into the quoted project headers


### PR DESCRIPTION
## Summary
The sharded layernorm dataflow kernel
`reader_mcast_receiver_unary_sharded_ln.cpp` fails to JIT-compile under emule. The two-stage
reduce util instantiates `RemoteNocCoords<0>` (a zero-length array) on
single-stage configs, but stock x86 clang-20 rejects that as a hard error, while
silicon's compiler accepts it as a GNU extension. There is no `-W` flag that suppresses it, so
all sharded layer_norm fails here and thus is blocked on emule.
Emule side PR for sharded fused norm ops bringup: https://github.com/tenstorrent/tt-emule/pull/211

## What's changed
`apply_x86_rewrites` (the emule JIT source patcher) gains one regex that rewrites
the array bound `RemoteNocCoord[N]` to `RemoteNocCoord[(N) == 0 ? 1 : (N)]`, so
N=0 yields a dead 1-element array. Behavior is identical (the element is never
indexed).

## Verification
Without the fix: 56 JIT-compile failures in `test_layer_norm_sharded.py`. With
it: 162/0. emule regression clean on all three arches (WH 39/0, BH 19/0,
Quasar 103/11 allowlist).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=brapanan/emule-sharded-fused-norm-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:brapanan/emule-sharded-fused-norm-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=brapanan/emule-sharded-fused-norm-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:brapanan/emule-sharded-fused-norm-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=brapanan/emule-sharded-fused-norm-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:brapanan/emule-sharded-fused-norm-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=brapanan/emule-sharded-fused-norm-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:brapanan/emule-sharded-fused-norm-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=brapanan/emule-sharded-fused-norm-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:brapanan/emule-sharded-fused-norm-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=brapanan/emule-sharded-fused-norm-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:brapanan/emule-sharded-fused-norm-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=brapanan/emule-sharded-fused-norm-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:brapanan/emule-sharded-fused-norm-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=brapanan/emule-sharded-fused-norm-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:brapanan/emule-sharded-fused-norm-fix)