### PR TITLE
Bug Fix: Correct reduce scatter M non-determinism

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_scatter_batch_invariance_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_scatter_batch_invariance_bh.py
@@ -29,8 +29,13 @@ What this test does:
   the bug for the CCL team. Both outputs match the torch reference in PCC (not a correctness bug);
   the failure is purely an M-dependent reduction order.
 
-Run (4-chip Blackhole, e.g. P150x4 / P300x2):
-  pytest tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_batch_invariance_bh.py -s
+Run (any multi-chip Blackhole line/ring, e.g. P150x4 / P300x2 / 8-chip box):
+  pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_scatter_batch_invariance_bh.py -s
+
+Uses the bh_1d_mesh_device fixture, which auto-sizes to whatever Blackhole box is present
+(1/2/4/8/32 chips) and presents it as a 1D line/ring. The reduce-scatter spans all available
+chips, so the per-device hidden stays fixed (PER_DEVICE_N) while the global hidden scales with
+the device count.
 """
 
 import pytest
@@ -41,9 +46,8 @@ import random
 import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
 
-# Mirrors the Qwen3-32B / P150x4 wo reduce-scatter exactly:
-NUM_DEVICES = 8
-PER_DEVICE_N = 5120  # self.dim for Qwen3-32B; global hidden = 5120 * 4 = 20480
+# Mirrors the Qwen3-32B / P150x4 wo reduce-scatter (per-device hidden):
+PER_DEVICE_N = 5120  # self.dim for Qwen3-32B; global hidden = PER_DEVICE_N * num_devices
 DIM = 3  # scatter dim (hidden)
 M_BIG = 1024  # batched prefill: 8 users x 128 tokens packed
 M_SMALL = 128  # single-user prefill
@@ -54,19 +58,26 @@ NUM_BUFFERS_PER_CHANNEL = 2
 
 
 def _run_reduce_scatter(mesh_device, global_input, dtype, topology, sub_device_id, sub_stall_group, num_links):
-    """Reduce-scatter one global [1,1,M,PER_DEVICE_N*NUM_DEVICES] tensor across the mesh on DIM.
+    """Reduce-scatter one global [1,1,M,PER_DEVICE_N*num_devices] tensor across the mesh on DIM.
 
-    Replicates on mesh axis 0 and shards DIM across the 4 chips, so each chip holds a
-    [1,1,M,PER_DEVICE_N] partial; reduce_scatter sums the 4 partials and scatters DIM.
-    Returns the composed [1,1,M,PER_DEVICE_N] output (torch) and the torch reference.
+    Shards DIM across all chips (one chip per shard) and replicates the trivial mesh axis, so each
+    chip holds a [1,1,M,PER_DEVICE_N] partial; reduce_scatter sums the num_devices partials and
+    scatters DIM. Returns the composed [1,1,M,PER_DEVICE_N] output (torch) and the torch reference.
     """
+    num_devices = mesh_device.get_num_devices()
     grid = mesh_device.compute_with_storage_grid_size()
     ccl_crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))})
     rs_semaphores = [ttnn.create_global_semaphore(mesh_device, ccl_crs, 0) for _ in range(3)]
     barrier_semaphore = ttnn.create_global_semaphore(mesh_device, ccl_crs, 0)
     mesh_shape = tuple(mesh_device.shape)
 
-    # Per-device input is [1,1,M,PER_DEVICE_N]: replicate on axis 0, shard DIM across axis 1.
+    # bh_1d_mesh_device lays the chips out on a single axis (the other is size 1). Shard DIM across
+    # whichever axis actually holds the devices and replicate the trivial one.
+    shard_axis = 0 if mesh_shape[0] > 1 else 1
+    placements = [ttnn.PlacementReplicate(), ttnn.PlacementReplicate()]
+    placements[shard_axis] = ttnn.PlacementShard(DIM)
+
+    # Per-device input is [1,1,M,PER_DEVICE_N].
     input_mesh = ttnn.from_torch(
         global_input,
         device=mesh_device,
@@ -75,7 +86,7 @@ def _run_reduce_scatter(mesh_device, global_input, dtype, topology, sub_device_i
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
         mesh_mapper=ttnn.create_mesh_mapper(
             mesh_device,
-            ttnn.MeshMapperConfig([ttnn.PlacementReplicate(), ttnn.PlacementShard(DIM)], ttnn.MeshShape(*mesh_shape)),
+            ttnn.MeshMapperConfig(placements, ttnn.MeshShape(*mesh_shape)),
         ),
     )
 
@@ -100,20 +111,13 @@ def _run_reduce_scatter(mesh_device, global_input, dtype, topology, sub_device_i
     out.deallocate(True)
     input_mesh.deallocate(True)
 
-    chunks = torch.chunk(global_input.float(), NUM_DEVICES, DIM)
+    chunks = torch.chunk(global_input.float(), num_devices, DIM)
     ref = torch.stack(chunks).sum(0)  # [1,1,M,PER_DEVICE_N]
     return out_torch.float(), ref
 
 
 @pytest.mark.parametrize("num_links", [1, 2], ids=["1link", "2link"])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat16], ids=["bfloat8_b", "bfloat16"])
-@pytest.mark.parametrize(
-    "mesh_device",
-    [
-        pytest.param((1, 8)),
-    ],
-    indirect=True,
-)
 @pytest.mark.parametrize(
     "device_params",
     [
@@ -125,9 +129,12 @@ def _run_reduce_scatter(mesh_device, global_input, dtype, topology, sub_device_i
     ids=["fabric_1D_ring"],
     indirect=True,
 )
-def test_reduce_scatter_batch_invariance(mesh_device, dtype, num_links):
-    #    if NUM_DEVICES not in list(mesh_device.shape):
-    #        pytest.skip(f"needs a {NUM_DEVICES}-chip mesh, got shape {list(mesh_device.shape)}")
+def test_reduce_scatter_batch_invariance(bh_1d_mesh_device, dtype, num_links):
+    # bh_1d_mesh_device auto-sizes to the box (1/2/4/8/32 chips); a 1-chip mesh can't reduce-scatter.
+    mesh_device = bh_1d_mesh_device
+    num_devices = mesh_device.get_num_devices()
+    if num_devices < 2:
+        pytest.skip(f"reduce-scatter needs >=2 chips, got {num_devices}")
 
     topology = ttnn.Topology.Ring
 
@@ -146,7 +153,7 @@ def test_reduce_scatter_batch_invariance(mesh_device, dtype, num_links):
     try:
         torch.manual_seed(0)
         # ONE global tensor at M=1024; the M=128 input is its first 128 rows (bit-identical).
-        global_big = torch.rand((1, 1, M_BIG, PER_DEVICE_N * NUM_DEVICES)).bfloat16().float()
+        global_big = torch.rand((1, 1, M_BIG, PER_DEVICE_N * num_devices)).bfloat16().float()
         global_small = global_big[:, :, :M_SMALL, :].clone()
 
         out_big, ref_big = _run_reduce_scatter(

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_scatter_batch_invariance_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_scatter_batch_invariance_bh.py
@@ -23,7 +23,6 @@ Uses bh_1d_mesh_device (auto-sizes to the BH box as a 1D line/ring; RS spans all
 import pytest
 import torch
 from loguru import logger
-import random
 
 import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
@@ -128,9 +127,6 @@ def test_reduce_scatter_batch_invariance(bh_1d_mesh_device, dtype, num_links):
     sub_device_manager = mesh_device.create_sub_device_manager([worker_sub_device], 0)
     mesh_device.load_sub_device_manager(sub_device_manager)
     mesh_device.set_sub_device_stall_group(sub_stall_group)
-
-    torch.manual_seed(2005)
-    random.seed(2005)
 
     try:
         torch.manual_seed(0)

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_scatter_batch_invariance_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_scatter_batch_invariance_bh.py
@@ -3,39 +3,21 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Minimal repro: ttnn.experimental.reduce_scatter_minimal_async is BATCH-VARIANT with num_links=2.
+Regression guard: reduce_scatter_minimal_async (Ring) must be BATCH-INVARIANT (tt-metal#47238,
+tt-inference-server#4004).
 
-Context (tenstorrent/tt-metal#47238, tt-inference-server#4004):
-  On Qwen3-32B / P150x4 (BH, 1x4 mesh, Ring), the attention output (wo) projection is followed
-  by a 4-device reduce-scatter on dim=3 (models/tt_transformers/tt/ccl.py:tt_all_reduce ->
-  ttnn.experimental.reduce_scatter_minimal_async). For this mesh the model uses num_links=2
-  (tt_ccl.get_num_links(0)). Per-op activation dumps proved the wo matmul output feeding the RS
-  is BIT-IDENTICAL between a single-user prefill (M=128) and a batched prefill (M=1024, 8 users
-  packed), yet the RS OUTPUT differs by ~1 ULP. That delta compounds across the 64 decoder layers
-  and changes which token seeded categorical sampling draws -> the seed=0 determinism test fails
-  only with batched prefill.
+Feeds bit-identical input rows at M=1024 and M=128 (the small one is a slice of the big one) and
+asserts output rows [0:128] are exactly equal. They weren't: the bidirectional ring sent even
+tile-chunks forward and odd backward, accumulating partials in opposite (non-associative) order,
+and that even/odd assignment was M-dependent -> a ~1-ULP delta that compounded over Qwen3-32B's
+layers and broke seeded sampling under batched prefill. Fixed by deriving chunk parity from the
+global tile index (chunk_ring_parity<>() in the 3 ring kernels: reader/reduction/writer).
 
-  The divergence is the multi-link work split: with num_links=2 the reduction/accumulation order
-  along the scatter dim depends on the M (row) dimension, so the same input rows reduce in a
-  different order at M=128 vs M=1024. With num_links=1 the op is batch-invariant.
+All cases (bf8/bf16 x 1/2 link) should PASS with 0 differing elements; pre-fix only num_links=2
+failed. PCC vs torch stays ~0.99994 throughout -- this was reduction order, never correctness.
 
-What this test does:
-  Builds ONE global input at M=1024 and derives the M=128 input by SLICING its first 128 rows, so
-  the per-device inputs for rows [0:128] are bit-identical between the two runs. Runs
-  reduce_scatter_minimal_async on both and compares output rows [0:128]. For a batch-INVARIANT op
-  these must be exactly equal.
-
-  Expected on current main: num_links=1 PASSES (invariant), num_links=2 FAILS (batch-variant) ->
-  the bug for the CCL team. Both outputs match the torch reference in PCC (not a correctness bug);
-  the failure is purely an M-dependent reduction order.
-
-Run (any multi-chip Blackhole line/ring, e.g. P150x4 / P300x2 / 8-chip box):
-  pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_scatter_batch_invariance_bh.py -s
-
-Uses the bh_1d_mesh_device fixture, which auto-sizes to whatever Blackhole box is present
-(1/2/4/8/32 chips) and presents it as a 1D line/ring. The reduce-scatter spans all available
-chips, so the per-device hidden stays fixed (PER_DEVICE_N) while the global hidden scales with
-the device count.
+Uses bh_1d_mesh_device (auto-sizes to the BH box as a 1D line/ring; RS spans all chips):
+  pytest .../blackhole_CI/box/nightly/test_reduce_scatter_batch_invariance_bh.py -s
 """
 
 import pytest
@@ -186,10 +168,10 @@ def test_reduce_scatter_batch_invariance(bh_1d_mesh_device, dtype, num_links):
         )
 
         assert max_abs_diff == 0.0, (
-            f"reduce_scatter_minimal_async is BATCH-VARIANT (dtype={dtype}, num_links={num_links}): identical "
-            f"inputs for rows [0:128] produced outputs differing by max {max_abs_diff:.3e} between M=1024 and "
-            f"M=128 ({num_diff}/{total} elements). This ~1-ULP delta is the root cause of "
-            f"tt-inference-server#4004 (seeded-sampling non-determinism under batched prefill)."
+            f"reduce_scatter_minimal_async regressed to BATCH-VARIANT (dtype={dtype}, num_links={num_links}): "
+            f"identical rows [0:128] differ by max {max_abs_diff:.3e} between M=1024 and M=128 "
+            f"({num_diff}/{total} elements) -- ring tile-chunk parity is M-dependent again; check "
+            f"chunk_ring_parity() in the 3 ring kernels."
         )
     finally:
         mesh_device.reset_sub_device_stall_group()

--- a/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_batch_invariance_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_batch_invariance_bh.py
@@ -36,12 +36,13 @@ Run (4-chip Blackhole, e.g. P150x4 / P300x2):
 import pytest
 import torch
 from loguru import logger
+import random
 
 import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
 
 # Mirrors the Qwen3-32B / P150x4 wo reduce-scatter exactly:
-NUM_DEVICES = 4
+NUM_DEVICES = 8
 PER_DEVICE_N = 5120  # self.dim for Qwen3-32B; global hidden = 5120 * 4 = 20480
 DIM = 3  # scatter dim (hidden)
 M_BIG = 1024  # batched prefill: 8 users x 128 tokens packed
@@ -63,6 +64,7 @@ def _run_reduce_scatter(mesh_device, global_input, dtype, topology, sub_device_i
     ccl_crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))})
     rs_semaphores = [ttnn.create_global_semaphore(mesh_device, ccl_crs, 0) for _ in range(3)]
     barrier_semaphore = ttnn.create_global_semaphore(mesh_device, ccl_crs, 0)
+    mesh_shape = tuple(mesh_device.shape)
 
     # Per-device input is [1,1,M,PER_DEVICE_N]: replicate on axis 0, shard DIM across axis 1.
     input_mesh = ttnn.from_torch(
@@ -73,9 +75,7 @@ def _run_reduce_scatter(mesh_device, global_input, dtype, topology, sub_device_i
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
         mesh_mapper=ttnn.create_mesh_mapper(
             mesh_device,
-            ttnn.MeshMapperConfig(
-                [ttnn.PlacementReplicate(), ttnn.PlacementShard(DIM)], ttnn.MeshShape(1, NUM_DEVICES)
-            ),
+            ttnn.MeshMapperConfig([ttnn.PlacementReplicate(), ttnn.PlacementShard(DIM)], ttnn.MeshShape(*mesh_shape)),
         ),
     )
 
@@ -108,16 +108,28 @@ def _run_reduce_scatter(mesh_device, global_input, dtype, topology, sub_device_i
 @pytest.mark.parametrize("num_links", [1, 2], ids=["1link", "2link"])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat16], ids=["bfloat8_b", "bfloat16"])
 @pytest.mark.parametrize(
-    "device_params, topology",
+    "mesh_device",
     [
-        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1171456}, ttnn.Topology.Ring),
+        pytest.param((1, 8)),
     ],
-    indirect=["device_params"],
+    indirect=True,
 )
-def test_reduce_scatter_batch_invariance(bh_1d_mesh_device, dtype, topology, num_links):
-    mesh_device = bh_1d_mesh_device
-    if NUM_DEVICES not in list(mesh_device.shape):
-        pytest.skip(f"needs a {NUM_DEVICES}-chip mesh, got shape {list(mesh_device.shape)}")
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+            "trace_region_size": 500_000,
+        }
+    ],
+    ids=["fabric_1D_ring"],
+    indirect=True,
+)
+def test_reduce_scatter_batch_invariance(mesh_device, dtype, num_links):
+    #    if NUM_DEVICES not in list(mesh_device.shape):
+    #        pytest.skip(f"needs a {NUM_DEVICES}-chip mesh, got shape {list(mesh_device.shape)}")
+
+    topology = ttnn.Topology.Ring
 
     grid = mesh_device.compute_with_storage_grid_size()
     ccl_crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))})
@@ -128,6 +140,9 @@ def test_reduce_scatter_batch_invariance(bh_1d_mesh_device, dtype, topology, num
     mesh_device.load_sub_device_manager(sub_device_manager)
     mesh_device.set_sub_device_stall_group(sub_stall_group)
 
+    torch.manual_seed(2005)
+    random.seed(2005)
+
     try:
         torch.manual_seed(0)
         # ONE global tensor at M=1024; the M=128 input is its first 128 rows (bit-identical).
@@ -137,9 +152,13 @@ def test_reduce_scatter_batch_invariance(bh_1d_mesh_device, dtype, topology, num
         out_big, ref_big = _run_reduce_scatter(
             mesh_device, global_big, dtype, topology, sub_device_id, sub_stall_group, num_links
         )
+        print(f"{out_big.shape=} {ref_big.shape=}")
+
         out_small, ref_small = _run_reduce_scatter(
             mesh_device, global_small, dtype, topology, sub_device_id, sub_stall_group, num_links
         )
+
+        print(f"{out_small.shape=} {ref_small.shape=}")
 
         # Each individually matches the torch reference (NOT a correctness bug):
         _, pcc_big = comp_pcc(out_big, ref_big)
@@ -147,12 +166,16 @@ def test_reduce_scatter_batch_invariance(bh_1d_mesh_device, dtype, topology, num
         logger.info(f"[{dtype} {num_links}link] PCC vs torch  M=1024: {pcc_big}   M=128: {pcc_small}")
 
         big_slice = out_big[:, :, :M_SMALL, :]
-        max_abs_diff = (big_slice - out_small).abs().max().item()
+        diff = torch.abs(big_slice - out_small)
+        max_abs_diff = diff.max().item()
+        max_idx = diff.argmax()
+        val = big_slice.view(-1)[max_idx].item()
+
         num_diff = (big_slice != out_small).sum().item()
         total = out_small.numel()
         logger.warning(
             f"[{dtype} {num_links}link] BATCH-VARIANCE: max|out(M=1024)[:128] - out(M=128)| = "
-            f"{max_abs_diff:.3e}  ({num_diff}/{total} elements differ)"
+            f"{max_abs_diff:.3e} {val=} ({num_diff}/{total} elements differ)"
         )
 
         assert max_abs_diff == 0.0, (

--- a/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_batch_invariance_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_batch_invariance_bh.py
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Minimal repro: ttnn.experimental.reduce_scatter_minimal_async is BATCH-VARIANT with num_links=2.
+
+Context (tenstorrent/tt-metal#47238, tt-inference-server#4004):
+  On Qwen3-32B / P150x4 (BH, 1x4 mesh, Ring), the attention output (wo) projection is followed
+  by a 4-device reduce-scatter on dim=3 (models/tt_transformers/tt/ccl.py:tt_all_reduce ->
+  ttnn.experimental.reduce_scatter_minimal_async). For this mesh the model uses num_links=2
+  (tt_ccl.get_num_links(0)). Per-op activation dumps proved the wo matmul output feeding the RS
+  is BIT-IDENTICAL between a single-user prefill (M=128) and a batched prefill (M=1024, 8 users
+  packed), yet the RS OUTPUT differs by ~1 ULP. That delta compounds across the 64 decoder layers
+  and changes which token seeded categorical sampling draws -> the seed=0 determinism test fails
+  only with batched prefill.
+
+  The divergence is the multi-link work split: with num_links=2 the reduction/accumulation order
+  along the scatter dim depends on the M (row) dimension, so the same input rows reduce in a
+  different order at M=128 vs M=1024. With num_links=1 the op is batch-invariant.
+
+What this test does:
+  Builds ONE global input at M=1024 and derives the M=128 input by SLICING its first 128 rows, so
+  the per-device inputs for rows [0:128] are bit-identical between the two runs. Runs
+  reduce_scatter_minimal_async on both and compares output rows [0:128]. For a batch-INVARIANT op
+  these must be exactly equal.
+
+  Expected on current main: num_links=1 PASSES (invariant), num_links=2 FAILS (batch-variant) ->
+  the bug for the CCL team. Both outputs match the torch reference in PCC (not a correctness bug);
+  the failure is purely an M-dependent reduction order.
+
+Run (4-chip Blackhole, e.g. P150x4 / P300x2):
+  pytest tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_batch_invariance_bh.py -s
+"""
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+
+# Mirrors the Qwen3-32B / P150x4 wo reduce-scatter exactly:
+NUM_DEVICES = 4
+PER_DEVICE_N = 5120  # self.dim for Qwen3-32B; global hidden = 5120 * 4 = 20480
+DIM = 3  # scatter dim (hidden)
+M_BIG = 1024  # batched prefill: 8 users x 128 tokens packed
+M_SMALL = 128  # single-user prefill
+# tt_all_reduce() defaults used by the model for this path:
+CHUNKS_PER_SYNC = 10
+NUM_WORKERS_PER_LINK = 2
+NUM_BUFFERS_PER_CHANNEL = 2
+
+
+def _run_reduce_scatter(mesh_device, global_input, dtype, topology, sub_device_id, sub_stall_group, num_links):
+    """Reduce-scatter one global [1,1,M,PER_DEVICE_N*NUM_DEVICES] tensor across the mesh on DIM.
+
+    Replicates on mesh axis 0 and shards DIM across the 4 chips, so each chip holds a
+    [1,1,M,PER_DEVICE_N] partial; reduce_scatter sums the 4 partials and scatters DIM.
+    Returns the composed [1,1,M,PER_DEVICE_N] output (torch) and the torch reference.
+    """
+    grid = mesh_device.compute_with_storage_grid_size()
+    ccl_crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))})
+    rs_semaphores = [ttnn.create_global_semaphore(mesh_device, ccl_crs, 0) for _ in range(3)]
+    barrier_semaphore = ttnn.create_global_semaphore(mesh_device, ccl_crs, 0)
+
+    # Per-device input is [1,1,M,PER_DEVICE_N]: replicate on axis 0, shard DIM across axis 1.
+    input_mesh = ttnn.from_torch(
+        global_input,
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=dtype,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.create_mesh_mapper(
+            mesh_device,
+            ttnn.MeshMapperConfig(
+                [ttnn.PlacementReplicate(), ttnn.PlacementShard(DIM)], ttnn.MeshShape(1, NUM_DEVICES)
+            ),
+        ),
+    )
+
+    out = ttnn.experimental.reduce_scatter_minimal_async(
+        input_mesh,
+        persistent_output_buffers=None,
+        dim=DIM,
+        multi_device_global_semaphore=rs_semaphores,
+        barrier_semaphore=barrier_semaphore,
+        num_links=num_links,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        intermediate_memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        topology=topology,
+        chunks_per_sync=CHUNKS_PER_SYNC,
+        num_workers_per_link=NUM_WORKERS_PER_LINK,
+        num_buffers_per_channel=NUM_BUFFERS_PER_CHANNEL,
+        subdevice_id=sub_device_id,
+    )
+    ttnn.synchronize_device(mesh_device, sub_device_ids=sub_stall_group)
+
+    out_torch = ttnn.to_torch(ttnn.from_device(out), mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=DIM))
+    out.deallocate(True)
+    input_mesh.deallocate(True)
+
+    chunks = torch.chunk(global_input.float(), NUM_DEVICES, DIM)
+    ref = torch.stack(chunks).sum(0)  # [1,1,M,PER_DEVICE_N]
+    return out_torch.float(), ref
+
+
+@pytest.mark.parametrize("num_links", [1, 2], ids=["1link", "2link"])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat16], ids=["bfloat8_b", "bfloat16"])
+@pytest.mark.parametrize(
+    "device_params, topology",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1171456}, ttnn.Topology.Ring),
+    ],
+    indirect=["device_params"],
+)
+def test_reduce_scatter_batch_invariance(bh_1d_mesh_device, dtype, topology, num_links):
+    mesh_device = bh_1d_mesh_device
+    if NUM_DEVICES not in list(mesh_device.shape):
+        pytest.skip(f"needs a {NUM_DEVICES}-chip mesh, got shape {list(mesh_device.shape)}")
+
+    grid = mesh_device.compute_with_storage_grid_size()
+    ccl_crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))})
+    worker_sub_device = ttnn.SubDevice([ccl_crs])
+    sub_device_id = ttnn.SubDeviceId(0)
+    sub_stall_group = [sub_device_id]
+    sub_device_manager = mesh_device.create_sub_device_manager([worker_sub_device], 0)
+    mesh_device.load_sub_device_manager(sub_device_manager)
+    mesh_device.set_sub_device_stall_group(sub_stall_group)
+
+    try:
+        torch.manual_seed(0)
+        # ONE global tensor at M=1024; the M=128 input is its first 128 rows (bit-identical).
+        global_big = torch.rand((1, 1, M_BIG, PER_DEVICE_N * NUM_DEVICES)).bfloat16().float()
+        global_small = global_big[:, :, :M_SMALL, :].clone()
+
+        out_big, ref_big = _run_reduce_scatter(
+            mesh_device, global_big, dtype, topology, sub_device_id, sub_stall_group, num_links
+        )
+        out_small, ref_small = _run_reduce_scatter(
+            mesh_device, global_small, dtype, topology, sub_device_id, sub_stall_group, num_links
+        )
+
+        # Each individually matches the torch reference (NOT a correctness bug):
+        _, pcc_big = comp_pcc(out_big, ref_big)
+        _, pcc_small = comp_pcc(out_small, ref_small)
+        logger.info(f"[{dtype} {num_links}link] PCC vs torch  M=1024: {pcc_big}   M=128: {pcc_small}")
+
+        big_slice = out_big[:, :, :M_SMALL, :]
+        max_abs_diff = (big_slice - out_small).abs().max().item()
+        num_diff = (big_slice != out_small).sum().item()
+        total = out_small.numel()
+        logger.warning(
+            f"[{dtype} {num_links}link] BATCH-VARIANCE: max|out(M=1024)[:128] - out(M=128)| = "
+            f"{max_abs_diff:.3e}  ({num_diff}/{total} elements differ)"
+        )
+
+        assert max_abs_diff == 0.0, (
+            f"reduce_scatter_minimal_async is BATCH-VARIANT (dtype={dtype}, num_links={num_links}): identical "
+            f"inputs for rows [0:128] produced outputs differing by max {max_abs_diff:.3e} between M=1024 and "
+            f"M=128 ({num_diff}/{total} elements). This ~1-ULP delta is the root cause of "
+            f"tt-inference-server#4004 (seeded-sampling non-determinism under batched prefill)."
+        )
+    finally:
+        mesh_device.reset_sub_device_stall_group()
+        mesh_device.clear_loaded_sub_device_manager()

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_common/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_common/kernels/common.hpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+namespace reduce_scatter_common {
+
+/* Compute the ring-directional parity for a chunk of tiles such that it is independent of worker distribution or
+ * total number of chunks. This avoids some lower dim dependent non-determinism ultimately caused by floating point
+ * accumulation non-associativity.
+ *
+ */
+
+template <uint32_t tile_granularity>
+std::tuple<bool, uint32_t> chunk_ring_parity(uint32_t tiles_read, uint32_t total_tiles_to_read) {
+    const bool is_even_chunk = ((tiles_read / tile_granularity) % 2) == 0;
+    const uint32_t next_boundary = ((tiles_read / tile_granularity) + 1) * tile_granularity;
+    const uint32_t tiles_to_read = std::min(next_boundary, total_tiles_to_read) - tiles_read;
+
+    return std::tie(is_even_chunk, tiles_to_read);
+}
+}  // namespace reduce_scatter_common

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_common/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_common/kernels/common.hpp
@@ -4,6 +4,10 @@
 
 #pragma once
 
+#include <algorithm>
+#include <cstdint>
+#include <tuple>
+
 namespace reduce_scatter_common {
 
 /* Compute the ring-directional parity for a chunk of tiles such that it is independent of worker distribution or
@@ -18,6 +22,6 @@ std::tuple<bool, uint32_t> chunk_ring_parity(uint32_t tiles_read, uint32_t total
     const uint32_t next_boundary = ((tiles_read / tile_granularity) + 1) * tile_granularity;
     const uint32_t tiles_to_read = std::min(next_boundary, total_tiles_to_read) - tiles_read;
 
-    return std::tie(is_even_chunk, tiles_to_read);
+    return std::make_tuple(is_even_chunk, tiles_to_read);
 }
 }  // namespace reduce_scatter_common

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
@@ -185,15 +185,18 @@ void kernel_main() {
                  * forward handles even chunks, backward handles odd chunks (1 chunk = tile_granularity tiles)
                  * after ring_size-1 steps, we've transferred all tiles
                  */
-                bool is_even_chunk = true;
                 while (tiles_read < total_tiles_to_read) {
-                    uint32_t tiles_to_read = 0;
-                    uint32_t tiles_remaining = total_tiles_to_read - tiles_read;
-                    if (is_even_chunk) {
-                        tiles_to_read = std::min(tiles_remaining / 2, tile_granularity);
-                    } else {
-                        tiles_to_read = std::min(tiles_remaining, tile_granularity);
-                    }
+                    // Batch-invariant chunking: a tile's even/odd (forward/backward) direction must
+                    // depend only on its GLOBAL position in the output channel, never on M or on how
+                    // the channel is split across links/workers. tiles_read is that global index, so
+                    // derive parity from its tile_granularity-block and clip each chunk to the block
+                    // boundary (parity is then uniform within a chunk). The old local toggle starting
+                    // at `true` from each worker's start_tiles_read flipped a tile's direction when
+                    // num_links*num_workers_per_direction > 1, reversing the per-element ring-reduction
+                    // order at different prefill batch sizes (tt-metal#47238).
+                    bool is_even_chunk = ((tiles_read / tile_granularity) % 2) == 0;
+                    uint32_t next_boundary = ((tiles_read / tile_granularity) + 1) * tile_granularity;
+                    uint32_t tiles_to_read = std::min(next_boundary, total_tiles_to_read) - tiles_read;
 
                     if ((is_even_chunk && !even_chunks) || (!is_even_chunk && !odd_chunks) || tiles_to_read == 0) {
                         // Skip this chunk
@@ -271,8 +274,6 @@ void kernel_main() {
                             }
                         }
                     }  // if skip or process
-
-                    is_even_chunk = !is_even_chunk;
                 }  // while total_tiles_to_read
 
                 input_tile_id_start += input_channel_num_pages;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
@@ -6,6 +6,7 @@
 #include <tt-metalium/buffer_types.hpp>
 #include "ttnn/operations/ccl/ccl_host_types.hpp"
 #include "ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
+#include "cpp/ttnn/operations/experimental/ccl/reduce_scatter_common/kernels/common.hpp"
 #include <cstdint>
 #include <utility>
 
@@ -183,20 +184,13 @@ void kernel_main() {
                 /**
                  * Interleave forward and backward ring reads
                  * forward handles even chunks, backward handles odd chunks (1 chunk = tile_granularity tiles)
-                 * after ring_size-1 steps, we've transferred all tiles
+                 * after ring_size-1 steps, we've transferred all tiles.
+                 *
+                 * Chunk forward/backward parity is fixed, independent of chunk count or distribution to workers
                  */
                 while (tiles_read < total_tiles_to_read) {
-                    // Batch-invariant chunking: a tile's even/odd (forward/backward) direction must
-                    // depend only on its GLOBAL position in the output channel, never on M or on how
-                    // the channel is split across links/workers. tiles_read is that global index, so
-                    // derive parity from its tile_granularity-block and clip each chunk to the block
-                    // boundary (parity is then uniform within a chunk). The old local toggle starting
-                    // at `true` from each worker's start_tiles_read flipped a tile's direction when
-                    // num_links*num_workers_per_direction > 1, reversing the per-element ring-reduction
-                    // order at different prefill batch sizes (tt-metal#47238).
-                    bool is_even_chunk = ((tiles_read / tile_granularity) % 2) == 0;
-                    uint32_t next_boundary = ((tiles_read / tile_granularity) + 1) * tile_granularity;
-                    uint32_t tiles_to_read = std::min(next_boundary, total_tiles_to_read) - tiles_read;
+                    const auto [is_even_chunk, tiles_to_read] =
+                        reduce_scatter_common::chunk_ring_parity<tile_granularity>(tiles_read, total_tiles_to_read);
 
                     if ((is_even_chunk && !even_chunks) || (!is_even_chunk && !odd_chunks) || tiles_to_read == 0) {
                         // Skip this chunk

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
@@ -312,15 +312,18 @@ void kernel_main() {
                 uint32_t tiles_read = start_tiles_read;
                 uint32_t total_tiles_to_read = start_tiles_to_read;
 
-                bool is_even_chunk = true;
                 while (tiles_read < total_tiles_to_read) {
-                    uint32_t tiles_to_read = 0;
-                    uint32_t tiles_remaining = total_tiles_to_read - tiles_read;
-                    if (is_even_chunk) {
-                        tiles_to_read = std::min(tiles_remaining / 2, tile_granularity);
-                    } else {
-                        tiles_to_read = std::min(tiles_remaining, tile_granularity);
-                    }
+                    // Batch-invariant chunking: a tile's even/odd (forward/backward) direction must
+                    // depend only on its GLOBAL position in the output channel, never on M or on how
+                    // the channel is split across links/workers. tiles_read is that global index, so
+                    // derive parity from its tile_granularity-block and clip each chunk to the block
+                    // boundary (parity is then uniform within a chunk). The old local toggle starting
+                    // at `true` from each worker's start_tiles_read flipped a tile's direction when
+                    // num_links*num_workers_per_direction > 1, reversing the per-element ring-reduction
+                    // order at different prefill batch sizes (tt-metal#47238).
+                    bool is_even_chunk = ((tiles_read / tile_granularity) % 2) == 0;
+                    uint32_t next_boundary = ((tiles_read / tile_granularity) + 1) * tile_granularity;
+                    uint32_t tiles_to_read = std::min(next_boundary, total_tiles_to_read) - tiles_read;
 
                     if ((is_even_chunk && !even_chunks) || (!is_even_chunk && !odd_chunks) || tiles_to_read == 0) {
                         // Skip this chunk
@@ -433,8 +436,6 @@ void kernel_main() {
                             cb_pop_front(cb_out, tile_granularity);
                         }  // if remote or local
                     }  // if skip or process
-
-                    is_even_chunk = !is_even_chunk;
                 }  // while total_tiles_to_read
 
                 interm_tile_id_start += input_channel_num_pages;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
@@ -9,6 +9,7 @@
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
 #include "cpp/ttnn/operations/ccl/ccl_host_types.hpp"
 #include "cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
+#include "cpp/ttnn/operations/experimental/ccl/reduce_scatter_common/kernels/common.hpp"
 #include "tt_metal/fabric/hw/inc/tt_fabric_status.h"
 #include "tt_metal/fabric/hw/inc/linear/addrgen_api.h"
 #include "tt_metal/fabric/hw/inc/packet_header_pool.h"
@@ -313,17 +314,8 @@ void kernel_main() {
                 uint32_t total_tiles_to_read = start_tiles_to_read;
 
                 while (tiles_read < total_tiles_to_read) {
-                    // Batch-invariant chunking: a tile's even/odd (forward/backward) direction must
-                    // depend only on its GLOBAL position in the output channel, never on M or on how
-                    // the channel is split across links/workers. tiles_read is that global index, so
-                    // derive parity from its tile_granularity-block and clip each chunk to the block
-                    // boundary (parity is then uniform within a chunk). The old local toggle starting
-                    // at `true` from each worker's start_tiles_read flipped a tile's direction when
-                    // num_links*num_workers_per_direction > 1, reversing the per-element ring-reduction
-                    // order at different prefill batch sizes (tt-metal#47238).
-                    bool is_even_chunk = ((tiles_read / tile_granularity) % 2) == 0;
-                    uint32_t next_boundary = ((tiles_read / tile_granularity) + 1) * tile_granularity;
-                    uint32_t tiles_to_read = std::min(next_boundary, total_tiles_to_read) - tiles_read;
+                    const auto [is_even_chunk, tiles_to_read] =
+                        reduce_scatter_common::chunk_ring_parity<tile_granularity>(tiles_read, total_tiles_to_read);
 
                     if ((is_even_chunk && !even_chunks) || (!is_even_chunk && !odd_chunks) || tiles_to_read == 0) {
                         // Skip this chunk

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduction.cpp
@@ -63,15 +63,18 @@ void kernel_main() {
                 uint32_t tiles_read = start_tiles_read;
                 uint32_t total_tiles_to_read = start_tiles_to_read;
 
-                bool is_even_chunk = true;
                 while (tiles_read < total_tiles_to_read) {
-                    uint32_t tiles_to_read = 0;
-                    uint32_t tiles_remaining = total_tiles_to_read - tiles_read;
-                    if (is_even_chunk) {
-                        tiles_to_read = std::min(tiles_remaining / 2, tile_granularity);
-                    } else {
-                        tiles_to_read = std::min(tiles_remaining, tile_granularity);
-                    }
+                    // Batch-invariant chunking: a tile's even/odd (forward/backward) direction must
+                    // depend only on its GLOBAL position in the output channel, never on M or on how
+                    // the channel is split across links/workers. tiles_read is that global index, so
+                    // derive parity from its tile_granularity-block and clip each chunk to the block
+                    // boundary (parity is then uniform within a chunk). The old local toggle starting
+                    // at `true` from each worker's start_tiles_read flipped a tile's direction when
+                    // num_links*num_workers_per_direction > 1, reversing the per-element ring-reduction
+                    // order at different prefill batch sizes (tt-metal#47238).
+                    bool is_even_chunk = ((tiles_read / tile_granularity) % 2) == 0;
+                    uint32_t next_boundary = ((tiles_read / tile_granularity) + 1) * tile_granularity;
+                    uint32_t tiles_to_read = std::min(next_boundary, total_tiles_to_read) - tiles_read;
 
                     if ((is_even_chunk && !even_chunks) || (!is_even_chunk && !odd_chunks) || tiles_to_read == 0) {
                         // Skip this chunk
@@ -121,8 +124,6 @@ void kernel_main() {
                         tiles_read += tiles_to_read;
 
                     }  // if skip or process
-
-                    is_even_chunk = !is_even_chunk;
                 }  // while total_tiles_to_read
             }  // for slice_C
         }  // for num_iters

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduction.cpp
@@ -7,6 +7,7 @@
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "cpp/ttnn/operations/experimental/ccl/reduce_scatter_common/kernels/common.hpp"
 
 void kernel_main() {
     // Define all compile-time arguments at the beginning
@@ -64,17 +65,8 @@ void kernel_main() {
                 uint32_t total_tiles_to_read = start_tiles_to_read;
 
                 while (tiles_read < total_tiles_to_read) {
-                    // Batch-invariant chunking: a tile's even/odd (forward/backward) direction must
-                    // depend only on its GLOBAL position in the output channel, never on M or on how
-                    // the channel is split across links/workers. tiles_read is that global index, so
-                    // derive parity from its tile_granularity-block and clip each chunk to the block
-                    // boundary (parity is then uniform within a chunk). The old local toggle starting
-                    // at `true` from each worker's start_tiles_read flipped a tile's direction when
-                    // num_links*num_workers_per_direction > 1, reversing the per-element ring-reduction
-                    // order at different prefill batch sizes (tt-metal#47238).
-                    bool is_even_chunk = ((tiles_read / tile_granularity) % 2) == 0;
-                    uint32_t next_boundary = ((tiles_read / tile_granularity) + 1) * tile_granularity;
-                    uint32_t tiles_to_read = std::min(next_boundary, total_tiles_to_read) - tiles_read;
+                    const auto [is_even_chunk, tiles_to_read] =
+                        reduce_scatter_common::chunk_ring_parity<tile_granularity>(tiles_read, total_tiles_to_read);
 
                     if ((is_even_chunk && !even_chunks) || (!is_even_chunk && !odd_chunks) || tiles_to_read == 0) {
                         // Skip this chunk


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/issues/47238

### Summary
- The reduce scatter ring implementation had an unanchored assignment of tensor chunks to ring directions and therefore non-deterministic reduction ordering which might vary with number of workers or upper dimension. Due to non-associativity of floating point reductions this could lead to non-deterministic results for the same(ish) inputs.
- Here I have implemented a tweak to the algorithm to fix the directional parity based only on the chunk's index, maintaining reduction consistency.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
- Perf appears unchanged: (BH LB 1x8, default hyperparams)

**Main**
| INPUT_0 X | N  | Min (ns) | Max (ns) | Avg (ns) | Median (ns) |
|----------:|---:|---------:|---------:|---------:|------------:|
|       256 | 80 |   14,722 |   23,689 |   22,441 |      22,987 |
|      1024 | 80 |   26,574 |   38,131 |   28,942 |      28,437 |
|      2048 | 80 |   27,234 |   32,721 |   29,110 |      29,067 |

**Here**
| INPUT_0 X | N  | Min (ns) | Max (ns) | Avg (ns) | Median (ns) |
|----------:|---:|---------:|---------:|---------:|------------:|
|       256 | 80 |   14,556 |   23,619 |   22,362 |      22,943 |
|      1024 | 80 |   26,114 |   32,110 |   28,134 |      28,270 |
|      2048 | 80 |   27,616 |   37,537 |   29,839 |      29,641 |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amorrison/reduce-scatter-m-non-determinism)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amorrison/reduce-scatter-m-non-determinism) No new failures ✅
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amorrison/reduce-scatter-m-non-determinism)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amorrison/reduce-scatter-m-non-determinism)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=amorrison/reduce-scatter-m-non-determinism)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:amorrison/reduce-scatter-m-non-determinism)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amorrison/reduce-scatter-m-non-determinism)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amorrison/reduce-scatter-m-non-determinism)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amorrison/reduce-scatter-m-non-determinism)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amorrison/reduce-scatter-m-non-determinism) no new reproducible failures ✅ 
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amorrison/reduce-scatter-m-non-determinism)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amorrison/reduce-scatter-m-non-determinism)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amorrison/reduce-scatter-m-non-determinism)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amorrison/reduce-scatter-m-non-determinism)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amorrison/reduce-scatter-m-non-determinism)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amorrison/reduce-scatter-m-non-determinism)