### PR TITLE
Add sparse MLA (DSA) support into the existing deepseek_v3_d_p stack

### DIFF
--- a/models/demos/deepseek_v3_d_p/reference/cpu_deepseek_v32/README.md
+++ b/models/demos/deepseek_v3_d_p/reference/cpu_deepseek_v32/README.md
@@ -1,0 +1,309 @@
+# DeepSeek-V3.2 attention (Indexer + MLA) — CPU reference
+
+CPU-runnable reimplementation of the DeepSeek-V3.2-Exp attention stack: the **MLA**
+(Multi-Head Latent Attention) layer and the **Indexer** (the "lightning indexer" sparse
+attention selector) that MLA nests. Mirrors the GPU reference in
+`DeepSeek-V3.2-Exp/inference/` (`model.py`, `kernel.py`); the tilelang CUDA kernels and
+tensor-parallel `Linear` variants are replaced with pure PyTorch so the layers run and can
+be inspected on CPU. The MLA spec followed is `DeepSeek-V3.2-Exp/MLA_LAYER.md`.
+
+The Indexer scores every cached key per query and returns the indices of the top-K most
+relevant tokens; MLA turns those into an additive `{0, -inf}` mask and runs attention over
+the latent KV cache.
+
+## Files
+
+| File | Contents |
+|------|----------|
+| `model.py` | Architecture only: `ModelArgs`, building blocks (`Linear`, `LayerNorm`, `RMSNorm`), and the `IndexerCPU` / `MLACPU` modules |
+| `weights.py` | Weight init (`initialize_weights`) + pretrained HF loading/dequant (`load_attention_state_dict`, `_HF_TO_MLA`, `_dequant_fp8`) |
+| `utils.py` | CPU kernel equivalents (`act_quant_cpu`, `fp8_index_cpu`, `rotate_activation_cpu`) + RoPE helpers (`precompute_freqs_cis`, `apply_rotary_emb`) |
+| `test_model.py` | Forward/equivalence/determinism harness (`test_indexer_layer`, `test_mla_layer`, `test_*_pretrained_layer0`, `test_mla_pretrained_determinism`) |
+
+## How to run
+
+```bash
+cd models/demos/deepseek_v3_d_p/reference/cpu_deepseek_v32
+python test_model.py            # or: pytest test_model.py -m slow
+```
+
+This builds an `IndexerCPU` and an `MLACPU` with random weights (`seed=42`,
+`batch_size=2`, `seq_len=8`) and:
+- **Indexer** — runs one forward pass and asserts output shapes.
+- **MLA** — runs a one-shot **prefill** of `P` tokens, then on a fresh identically-seeded
+  module runs **prefill(P-1) + decode(1)**, and asserts the decoded last position matches
+  the one-shot prefill (the cache-correctness invariant).
+
+Outputs are saved to `test_outputs/` (`topk_indices.pt`, `index_scores.pt`, `k_cache.pt`,
+`mla_prefill_out.pt`, `mla_decode_out.pt`, `mla_metadata.json`).
+
+## Loading pretrained weights
+
+Random init is the default. `initialize_weights` is the single entry point — pass a
+`layer` to load real DeepSeek-V3.2-Exp weights, and it resolves the right shard(s) from the
+HF index and loads them, downloading any missing shard in full **just-in-time** (cached; it
+logs a warning first since shards are multi-GB):
+
+```python
+from model import MLACPU, ModelArgs
+from weights import initialize_weights
+
+mla = MLACPU(ModelArgs())
+initialize_weights(mla)            # random init (default)
+initialize_weights(mla, layer=0)   # pretrained layer 0; downloads the shard if missing
+```
+
+For layer 0 that shard is `model-00001-of-000163.safetensors` (~5.2 GB). Other modes:
+`local_files_only=True` (cache only, raises if absent — used by tests to skip) and
+`checkpoint_path=<shard>` (load from a local path you already have). The repo is public/MIT
+— no gating — but `huggingface_hub` and ~5 GB of free disk are required. The lower-level
+`load_pretrained_hf` / `load_pretrained` / `resolve_layer_shards` remain available.
+
+Mechanics (`weights.load_attention_state_dict`):
+- HF transformers-style names are mapped to our module names via `_HF_TO_MLA` (mirrors
+  `inference/convert.py`): `q_a_proj→wq_a`, `q_b_proj→wq_b`, `kv_a_proj_with_mqa→wkv_a`,
+  `kv_b_proj→wkv_b`, `o_proj→wo`, the layernorms→`q_norm`/`kv_norm`, and
+  `indexer.{wq_b,wk,k_norm,weights_proj}` straight through.
+- fp8 (`float8_e4m3fn`) weights are dequantized to bf16 with their companion
+  `weight_scale_inv` blockwise (128×128) scales (`weights._dequant_fp8`, matching
+  `model.py:weight_dequant`). Norms and the indexer's `weights_proj` are cast to fp32 to
+  match the module dtypes.
+- For an `MLACPU` module, `initialize_weights` loads MLA **and** its nested indexer in one
+  `load_state_dict(strict=False)`; for a standalone `IndexerCPU` it strips the `indexer.`
+  prefix. `test_mla_pretrained_layer0` exercises this and is skipped if the shard isn't
+  cached.
+
+## Config (DeepSeek-V3.2 671B / `config_671B_v3.2.json`)
+
+```python
+# shared
+dim              = 7168     # model dimension
+q_lora_rank      = 1536     # query LoRA rank (shared by MLA and the indexer)
+qk_rope_head_dim = 64       # rotary dim (rope/2 = 32 complex pairs)
+scale_fmt        = "ue8m0"  # power-of-two quantization scales
+max_batch_size   = 8
+max_seq_len      = 16384    # > original_seq_len (4096) -> YaRN mscale applies
+# MLA
+n_heads          = 128      # attention heads
+kv_lora_rank     = 512      # KV latent rank (c)
+qk_nope_head_dim = 128      # non-positional Q/K per-head dim
+qk_head_dim      = 192      # nope + rope
+v_head_dim       = 128      # value per-head dim
+# Indexer
+index_n_heads    = 64       # index heads (half of MLA's; K is single-head)
+index_head_dim   = 128      # dim per index head
+index_topk       = 2048     # tokens selected per query
+```
+
+All projections are **bias-free** (`Linear(bias=False)`).
+
+---
+
+# MLA
+
+MLA compresses K/V into a small **latent** that is cached (`kv_cache` 512 + `pe_cache` 64
+per token, ~71× smaller than a classic MHA cache). Two runtime paths share one front-end,
+selected purely by chunk length (a causal `mask` is built only when `seqlen > 1`):
+
+- **Prefill / MHA** (`mask is not None`, `seqlen > 1`): K and V are materialized per head
+  via `wkv_b`, standard scaled-dot-product attention.
+- **Decode / MQA** (`mask is None`, `seqlen == 1`): `wkv_b` is **absorbed** into the query
+  and the output, so attention runs directly against the latent cache — no per-head K/V.
+
+The two are algebraically equal on overlapping positions.
+`softmax_scale = qk_head_dim**-0.5 = 192**-0.5`, multiplied by `mscale²` (YaRN) since
+`max_seq_len > original_seq_len`, with `mscale = 0.1 * mscale_arg * log(rope_factor) + 1`.
+
+### Learnable parameters (one MLA layer)
+
+| Module | Type | Weight shape (in → out) |
+|---|---|---|
+| `wq_a` | Linear | 7168 → 1536 |
+| `q_norm` | RMSNorm | (1536,) |
+| `wq_b` | Linear | 1536 → 24576 (= 128 × 192) |
+| `wkv_a` | Linear | 7168 → 576 (= 512 + 64) |
+| `kv_norm` | RMSNorm | (512,) |
+| `wkv_b` | Linear | 512 → 32768 (= 128 × 256) |
+| `wo` | Linear | 16384 → 7168 |
+| `indexer` | IndexerCPU | (nested — see below) |
+
+The `256` columns of `wkv_b` per head split as `[qk_nope_head_dim=128 | v_head_dim=128]`;
+ordering matters for the decode absorption slices `[:, :128]` and `[:, -128:]`.
+
+### Buffers (latent KV cache, not checkpoint weights)
+
+| Buffer | Shape | Holds |
+|---|---|---|
+| `kv_cache` | `[max_batch, max_seq, 512]` bf16 | latent `kv` (post `kv_norm`), no rope |
+| `pe_cache` | `[max_batch, max_seq, 64]` bf16 | `k_pe` — shared rope key (1 head) |
+
+### Forward pass
+
+Inputs: `x [B,S,7168]`, `start_pos`, `freqs_cis [S,32]` (YaRN table sliced at absolute
+positions), `mask [S,S]` (prefill) or `None` (decode). Output: `out [B,S,7168]`.
+
+**Shared front-end (both paths)**
+1. `qr = q_norm(wq_a(x))` → `[B,S,1536]` (also fed to the indexer).
+2. `q = wq_b(qr).view(B,S,128,192)`; split `[q_nope=128, q_pe=64]`; **interleaved** RoPE on `q_pe`.
+3. `kv, k_pe = split(wkv_a(x), [512, 64])`; `kv = kv_norm(kv)`; **interleaved** RoPE on `k_pe.unsqueeze(2)`.
+4. **fp8 KV-cache simulation**: `act_quant_cpu(kv)` then dequant, so the stored latent is exactly what the device would store (applied on every write path).
+5. Write `kv → kv_cache[:, start:end]`, `k_pe → pe_cache[:, start:end]`.
+
+**Prefill / MHA** (`mask is not None`)
+```
+q   = cat([q_nope, q_pe], -1)                     # [B, S, H, 192]
+kvb = wkv_b(kv).view(B, S, H, 256)
+k_nope, v = split(kvb, [128, 128])
+k   = cat([k_nope, k_pe.expand(H)], -1)           # [B, S, H, 192]
+scores = einsum('bshd,bthd->bsht', q, k) * softmax_scale
+topk_indices = indexer(x, qr, start_pos, freqs_cis, mask)
+index_mask = (-inf scattered to 0 at topk_indices) + causal_mask
+scores += index_mask.unsqueeze(2);  scores = softmax(scores)
+x = einsum('bsht,bthd->bshd', scores, v)          # [B, S, H, v]
+out = wo(x.flatten(2))
+```
+
+**Decode / MQA** (`mask is None`, weight absorption)
+```
+wkv_b = wkv_b.weight.view(H, 256, c=512)
+q_nope = einsum('bshd,hdc->bshc', q_nope, wkv_b[:, :128])          # absorb into query
+scores = ( einsum('bshc,btc->bsht', q_nope, kv_cache)
+         + einsum('bshr,btr->bsht', q_pe,   pe_cache) ) * softmax_scale
+topk_indices = indexer(...);  index_mask = -inf scattered to 0 at topk_indices
+scores += index_mask.unsqueeze(2);  scores = softmax(scores)
+x = einsum('bsht,btc->bshc', scores, kv_cache)                    # [B, S, H, c]
+x = einsum('bshc,hdc->bshd', x, wkv_b[:, -128:])                  # absorb value half -> v
+out = wo(x.flatten(2))
+```
+
+### Key design choices / gotchas
+
+1. **Two code paths must agree.** Prefill (materialized K/V) and decode (absorbed `wkv_b`)
+   are algebraically equal by the `wkv_b` absorption identity, *provided they read the same
+   latent cache*. The harness asserts this (the **cache-correctness invariant**,
+   `MLA_LAYER.md` §B.6): prefill `P` tokens vs prefill `P-1` + decode 1 must produce the
+   same output for position `P-1`. On CPU this matches within ~1 bf16 ULP.
+2. **Small `seq_len` in the harness.** With `seq_len = 8 ≤ index_topk = 2048`, the indexer
+   selects *all* positions, so the additive index mask is all-zero — the equivalence test
+   isolates the attention math from the (discrete) top-k selection, which would otherwise be
+   sensitive to tiny score perturbations.
+3. **`k_pe` is shared across heads** (MQA-style key rope): `[B,S,1,64]` expanded to all 128
+   heads; only `q_pe` is per-head.
+4. **Latent caching** is the MLA memory win: `kv_cache` stores the post-`kv_norm` latent
+   (512, no rope), `pe_cache` the shared rope key (64) — not per-head K/V.
+5. **Softmax in fp32** then cast back, for numerical stability.
+
+---
+
+# Indexer
+
+The Indexer is a sparse-attention selector. For each query position it scores every cached
+key, sums the score across all 64 index heads, and returns the top-K token indices. Its
+only output is `topk_indices`; MLA turns those into the additive index mask. The scoring
+path runs in FP8 on device for memory/bandwidth efficiency. `softmax_scale = index_head_dim**-0.5 = 128**-0.5`.
+
+Note `index_n_heads = 64` is **half** of MLA's `n_heads = 128`, and the indexer's **K is
+single-head** (one shared 128-d key dotted against all 64 query heads).
+
+### Learnable parameters
+
+| Parameter | Shape | Dtype | Description |
+|-----------|-------|-------|-------------|
+| `wq_b.weight` | `[index_n_heads*index_head_dim, q_lora_rank]` = `[8192, 1536]` | bf16 | Query projection (consumes MLA's `qr`) |
+| `wk.weight` | `[index_head_dim, dim]` = `[128, 7168]` | bf16 | Single-head key projection |
+| `k_norm.weight` / `.bias` | `[128]` | fp32 | LayerNorm γ / β (full LayerNorm, not RMSNorm) |
+| `weights_proj.weight` | `[index_n_heads, dim]` = `[64, 7168]` | fp32 | Per-head importance weights |
+
+### Buffers (cache)
+
+| Buffer | Shape | Holds |
+|--------|-------|-------|
+| `k_cache` | `[max_batch, max_seq, 128]` bf16 (device: `float8_e4m3fn`) | quantized keys |
+| `k_scale_cache` | `[max_batch, max_seq, 1]` fp32 | per-block dequant scale |
+
+On CPU the key cache is stored bf16 (matmul-friendly) but values are rounded onto the FP8
+E4M3 grid during quantization so the quantization error is simulated.
+
+### Forward pass
+
+Inputs: `x [B,L,7168]`, `qr [B,L,1536]` (MLA's `q_norm` output), `start_pos`,
+`freqs_cis`, `mask [L, end_pos]` or `None`.
+
+1. **Query / RoPE** — `q = wq_b(qr).view(B,L,64,128)`; split `[q_pe=64, q_nope=64]`;
+   **non-interleaved** RoPE on `q_pe`; `cat([q_pe, q_nope])` (**rope first**).
+2. **Key / RoPE** — `k = k_norm(wk(x))` → `[B,L,128]`; split `k_pe`/`k_nope`;
+   non-interleaved RoPE on `k_pe`; `cat([k_pe, k_nope])`.
+3. **Hadamard** — `rotate_activation_cpu` (orthogonal Walsh–Hadamard, scale `128**-0.5`) on
+   `q` and `k`. Orthogonal, so it does not change `q·k`; it only spreads outliers for fp8.
+4. **Quantization** — `act_quant_cpu` block-quantizes (`block_size=128`); `ue8m0` rounds
+   scales to a power of two.
+5. **Cache update** — write `k_fp8` / `k_scale` into `k_cache` / `k_scale_cache`.
+6. **Weights** — `weights = weights_proj(x.float()) * index_n_heads**-0.5 * q_scale * softmax_scale`.
+7. **Index score** — `fp8_index`: `relu(q @ kᵀ) * weights`, **summed over heads** → `[B,L,C]`, `* k_scale`.
+8. **Mask (optional)** — `index_score += mask`.
+9. **Top-K** — `topk_indices = index_score.topk(min(index_topk, end_pos), dim=-1)[1]`.
+
+Output: `topk_indices [B,L,min(index_topk,end_pos)]` (the CPU harness also returns
+`index_score [B,L,end_pos]` for inspection).
+
+```mermaid
+flowchart TD
+    QR["qr [B,L,1536]"] --> WQB["Linear wq_b [8192,1536]"]
+    WQB --> QVIEW["reshape [B,L,64,128]"]
+    QVIEW --> QSPLIT["split pe/nope"]
+    QSPLIT -->|"q_pe"| QROPE["RoPE (non-interleaved)"]
+    QSPLIT -->|"q_nope"| QCONCAT["concat [q_pe, q_nope]"]
+    QROPE --> QCONCAT
+    QCONCAT --> QHAD["Hadamard"] --> QQUANT["act_quant (bs=128)"]
+    QQUANT -->|"q_fp8, q_scale"| FP8
+
+    X["x [B,L,7168]"] --> WK["Linear wk [128,7168]"]
+    WK --> KNORM["LayerNorm k_norm"] --> KSPLIT["split pe/nope"]
+    KSPLIT -->|"k_pe"| KROPE["RoPE (non-interleaved)"]
+    KSPLIT -->|"k_nope"| KCONCAT["concat [k_pe, k_nope]"]
+    KROPE --> KCONCAT
+    KCONCAT --> KHAD["Hadamard"] --> KQUANT["act_quant (bs=128)"]
+    KQUANT --> KCACHE["k_cache / k_scale_cache"]
+    KCACHE -->|"k_fp8, k_scale"| FP8
+
+    X --> WPROJ["Linear weights_proj (fp32) [64,7168]"]
+    WPROJ --> WSCALE["* 1/√64 * q_scale * softmax_scale"]
+    QQUANT --> WSCALE
+    WSCALE -->|"weights"| FP8
+
+    FP8["fp8_index: relu(q@kᵀ)*w → Σheads → *k_scale"]
+    FP8 -->|"index_score [B,L,C]"| ADDMASK["+ mask (optional)"]
+    ADDMASK --> TOPK["topk(min(2048,C))"] --> OUTPUT["topk_indices"]
+```
+
+### Indexer-specific notes
+
+- **Per-head scoring summed across heads**: a token's score is the sum over all 64 index
+  heads of its ReLU'd, weighted query·key score.
+- **Single-head K** shared across the 64 query heads; **`weights_proj` is fp32**.
+- **Rope/nope order is `[pe, nope]`** (rope first) — opposite of MLA's `[nope, pe]`.
+
+---
+
+## CPU vs. GPU reference (deviations)
+
+| Aspect | GPU reference | CPU port |
+|--------|---------------|----------|
+| `ColumnParallelLinear` / `RowParallelLinear` | sharded; `wo` does `all_reduce` | plain `Linear`; at `world_size=1` the all-reduce is a no-op |
+| Index / attention / GEMM kernels | tilelang JIT (`fp8_index`, `act_quant`) | `torch.einsum` / `torch` ops |
+| Quantized dtype | `float8_e4m3fn` | bf16 storage, values rounded onto the E4M3 grid |
+| `ue8m0` scales | `fast_round_scale` (pow-2) | `2**ceil(log2(amax * fp8_max_inv))` |
+| MLA KV cache | `float8_e4m3fn` on device | bf16, but `act_quant_cpu` quant→dequant *simulates* fp8 precision — applied identically on both write paths |
+| `weight_dequant` (fp8 → bf16) | run on device | done at load time in `weights._dequant_fp8` (random init skips it) |
+| Hadamard | `fast_hadamard_transform` package | recursive Walsh–Hadamard (Sylvester order) |
+| RoPE | `apply_rotary_emb` | same helper; **MLA interleaved**, **Indexer non-interleaved**; `freqs_cis` is YaRN-scaled and tracks **absolute** position |
+| Distributed `dist.broadcast` topk check | present | omitted (single process) |
+
+These keep the math equivalent; the only intentional numerical differences are the absence
+of true fp8 storage and any tilelang-specific accumulation order.
+
+## Next steps
+
+Pretrained-weight loading is implemented (see "Loading pretrained weights"). A natural
+follow-up is a numerical cross-check of the CPU layer-0 output against the GPU reference
+(`inference/model.py`) on identical inputs/weights.

--- a/models/demos/deepseek_v3_d_p/reference/cpu_deepseek_v32/__init__.py
+++ b/models/demos/deepseek_v3_d_p/reference/cpu_deepseek_v32/__init__.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DeepSeek-V3.2 / GLM-5.1 sparse-MLA CPU reference — public API.
+
+The only supported entry points are re-exported here. Internals (``ModelArgs``, ``MLACPU``,
+``IndexerCPU``, weight loaders, RoPE helpers) are implementation detail — import from this package,
+not its submodules. See ``API_SPEC.md``.
+"""
+
+from models.demos.deepseek_v3_d_p.reference.cpu_deepseek_v32.reference import (
+    CANONICAL_WEIGHT_NAMES,
+    SparseMLAConfig,
+    SparseMLAReference,
+    Weights,
+    pretrained_mla_weights,
+    random_mla_weights,
+)
+
+__all__ = [
+    "SparseMLAReference",
+    "SparseMLAConfig",
+    "Weights",
+    "random_mla_weights",
+    "pretrained_mla_weights",
+    "CANONICAL_WEIGHT_NAMES",
+]

--- a/models/demos/deepseek_v3_d_p/reference/cpu_deepseek_v32/conftest.py
+++ b/models/demos/deepseek_v3_d_p/reference/cpu_deepseek_v32/conftest.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Ensure the repo root is on ``sys.path`` so the absolute
+``models.demos.deepseek_v3_d_p.reference.cpu_deepseek_v32.*`` imports resolve under any pytest
+invocation (plain ``pytest`` does not add the CWD, unlike ``python -m pytest``).
+"""
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))

--- a/models/demos/deepseek_v3_d_p/reference/cpu_deepseek_v32/model.py
+++ b/models/demos/deepseek_v3_d_p/reference/cpu_deepseek_v32/model.py
@@ -1,0 +1,479 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+CPU-compatible reference for the DeepSeek V3.2 attention stack.
+
+Mirrors the GPU reference (``DeepSeek-V3.2-Exp/inference/model.py``) but replaces
+the tilelang CUDA kernels and the tensor-parallel ``Linear`` variants with plain
+PyTorch so the layers run and can be inspected on CPU.
+
+Contains:
+  * ``ModelArgs``  — unified config (671B v3.2) for both layers.
+  * Building blocks — ``Linear``, ``LayerNorm``, ``RMSNorm``.
+  * ``IndexerCPU``  — the "lightning indexer" sparse-attention selector; its only
+    output is ``topk_indices``.
+  * ``MLACPU``      — Multi-Head Latent Attention; consumes the indexer's
+    ``topk_indices`` and runs both the prefill (MHA) and decode (MQA-absorbed)
+    paths.
+
+This module is architecture only. CPU kernel equivalents and RoPE helpers live
+in ``utils.py``; weight init + pretrained HF loading live in ``weights.py``; the
+test harness in ``test_model.py``.
+"""
+
+import math
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from loguru import logger
+
+from models.demos.deepseek_v3_d_p.reference.cpu_deepseek_v32.utils import (
+    act_quant_cpu,
+    apply_rotary_emb,
+    fp8_index_cpu,
+    rotate_activation_cpu,
+)
+
+# block size for the fp8 quantization simulation (matches reference kernel.py)
+BLOCK_SIZE = 128
+
+
+@dataclass
+class ModelArgs:
+    """
+    Unified model arguments for the Indexer + MLA, from config_671B_v3.2.json.
+
+    Carries every field both layers read, so a single instance can be shared
+    between ``MLACPU`` and its nested ``IndexerCPU``.
+    """
+
+    max_batch_size: int = 8
+    max_seq_len: int = 4096 * 4  # 16384
+    dim: int = 7168
+    # MLA
+    n_heads: int = 128
+    q_lora_rank: int = 1536
+    kv_lora_rank: int = 512
+    qk_nope_head_dim: int = 128
+    qk_rope_head_dim: int = 64
+    v_head_dim: int = 128
+    # YaRN / RoPE
+    original_seq_len: int = 4096
+    rope_theta: float = 10000.0
+    rope_factor: float = 40
+    beta_fast: int = 32
+    beta_slow: int = 1
+    mscale: float = 1.0
+    # Quantization scale format ("ue8m0" -> power-of-two scales).
+    scale_fmt: Optional[str] = "ue8m0"
+    # Indexer
+    index_n_heads: int = 64
+    index_head_dim: int = 128
+    index_topk: int = 2048
+    # Indexer RoPE convention: DeepSeek-V3.2 = non-interleaved (rotate_half);
+    # GLM-5.1 = interleaved. (MLA RoPE is always interleaved.)
+    index_rope_interleave: bool = False
+
+    @property
+    def qk_head_dim(self) -> int:
+        return self.qk_nope_head_dim + self.qk_rope_head_dim
+
+
+# ===== Building blocks =====
+
+
+class Linear(nn.Module):
+    """
+    Simple linear layer matching reference implementation.
+
+    Note: Weights are allocated as empty tensors and must be initialized
+    via initialize_weights() before use. The reference constructs all of its
+    projections bias-free (bias=False), so bias defaults to off here.
+    """
+
+    def __init__(self, in_features: int, out_features: int, bias: bool = False, dtype=torch.bfloat16):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        # Allocate empty tensors (matches reference implementation)
+        self.weight = nn.Parameter(torch.empty(out_features, in_features, dtype=dtype))
+        if bias:
+            self.bias = nn.Parameter(torch.empty(out_features, dtype=dtype))
+        else:
+            self.register_parameter("bias", None)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return F.linear(x, self.weight, self.bias)
+
+
+class LayerNorm(nn.Module):
+    """
+    LayerNorm matching reference implementation (model.py:LayerNorm).
+
+    Note: γ (weight) is initialized to 1 and β (bias) to 0. Computation is done
+    in float32 and cast back to the input dtype, with eps=1e-6 to match the
+    reference. Used by the Indexer's ``k_norm``.
+    """
+
+    def __init__(self, normalized_shape: int):
+        super().__init__()
+        # Initialize γ to 1, β to 0 (standard LayerNorm initialization), float32
+        self.weight = nn.Parameter(torch.ones(normalized_shape, dtype=torch.float32))
+        self.bias = nn.Parameter(torch.zeros(normalized_shape, dtype=torch.float32))
+        self.eps = 1e-6
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return F.layer_norm(x.float(), (self.weight.shape[0],), self.weight, self.bias, self.eps).type_as(x)
+
+
+class RMSNorm(nn.Module):
+    """
+    Root Mean Square LayerNorm matching the reference (model.py:RMSNorm).
+
+    Computation is in float32 with eps=1e-6; ``weight`` (γ) initialized to ones.
+    Unlike the Indexer's ``k_norm`` (a full LayerNorm with bias), MLA uses
+    RMSNorm for ``q_norm`` and ``kv_norm``.
+    """
+
+    def __init__(self, dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.dim = dim
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        dtype = x.dtype
+        x = x.float()
+        var = x.pow(2).mean(-1, keepdim=True)
+        x = x * torch.rsqrt(var + self.eps)
+        return (self.weight * x).to(dtype)
+
+
+# ===== Indexer =====
+
+
+class IndexerCPU(nn.Module):
+    """
+    CPU-compatible version of the Indexer layer (the "lightning indexer").
+
+    Modified from the reference to use CPU-compatible operations. Its only output
+    is ``topk_indices`` — the set of past positions each query is allowed to
+    attend to.
+    """
+
+    def __init__(self, args: ModelArgs, use_fp8_path: bool = True):
+        super().__init__()
+        self.dim = args.dim
+        self.n_heads = args.index_n_heads
+        self.head_dim = args.index_head_dim
+        self.rope_head_dim = args.qk_rope_head_dim
+        self.index_topk = args.index_topk
+        self.rope_interleave = args.index_rope_interleave  # GLM: True; DS: False
+        self.q_lora_rank = args.q_lora_rank
+        self.scale_fmt = args.scale_fmt
+        # When False, skip the orthogonal Hadamard transform and the fp8
+        # quant/dequant and score directly in bf16/fp32:
+        # both are precision-only (Hadamard is orthogonal, so it does not change
+        # q·k), so this is the functional path the ttnn port matches.
+        self.use_fp8_path = use_fp8_path
+
+        # Projections (bias-free, matching the reference indexer)
+        self.wq_b = Linear(self.q_lora_rank, self.n_heads * self.head_dim)
+        self.wk = Linear(self.dim, self.head_dim)
+        self.k_norm = LayerNorm(self.head_dim)
+        self.weights_proj = Linear(self.dim, self.n_heads, dtype=torch.float32)
+        self.softmax_scale = self.head_dim**-0.5
+
+        # Buffers (using bfloat16 instead of FP8 for CPU compatibility)
+        self.register_buffer(
+            "k_cache",
+            torch.zeros(args.max_batch_size, args.max_seq_len, self.head_dim, dtype=torch.bfloat16),
+            persistent=False,
+        )
+        self.register_buffer(
+            "k_scale_cache",
+            torch.zeros(args.max_batch_size, args.max_seq_len, self.head_dim // 128, dtype=torch.float32),
+            persistent=False,
+        )
+
+        logger.info(f"Initialized IndexerCPU with {self.n_heads} heads, head_dim={self.head_dim}")
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        qr: torch.Tensor,
+        start_pos: int,
+        freqs_cis: torch.Tensor,
+        mask: Optional[torch.Tensor],
+    ):
+        """
+        Forward pass of Indexer layer.
+
+        Args:
+            x: Input features [B, L, dim]
+            qr: Query representation [B, L, q_lora_rank]
+            start_pos: Starting position in cache
+            freqs_cis: Rotary embedding frequencies
+            mask: Optional attention mask
+
+        Returns:
+            (topk_indices, index_score)
+        """
+        bsz, seqlen, _ = x.size()
+        end_pos = start_pos + seqlen
+
+        logger.info(f"Indexer forward: bsz={bsz}, seqlen={seqlen}, start_pos={start_pos}")
+
+        # Query projection
+        q = self.wq_b(qr)  # [B, L, n_heads * head_dim]
+        q = q.view(bsz, seqlen, self.n_heads, self.head_dim)  # [B, L, H, D]
+
+        # Split RoPE and non-RoPE parts
+        q_pe, q_nope = torch.split(q, [self.rope_head_dim, self.head_dim - self.rope_head_dim], dim=-1)
+
+        # Apply RoPE (DS: non-interleaved / GLM: interleaved — ModelArgs.index_rope_interleave)
+        q_pe = apply_rotary_emb(q_pe, freqs_cis, interleaved=self.rope_interleave)
+
+        # Concatenate back
+        q = torch.cat([q_pe, q_nope], dim=-1)  # [B, L, H, D]
+
+        # Key projection
+        k = self.wk(x)  # [B, L, D]
+        k = self.k_norm(k)  # [B, L, D]
+
+        # Split and apply RoPE to key
+        k_pe, k_nope = torch.split(k, [self.rope_head_dim, self.head_dim - self.rope_head_dim], dim=-1)
+        k_pe = apply_rotary_emb(k_pe.unsqueeze(2), freqs_cis, interleaved=self.rope_interleave).squeeze(2)
+        k = torch.cat([k_pe, k_nope], dim=-1)  # [B, L, D]
+
+        if self.use_fp8_path:
+            # Hadamard transform
+            q = rotate_activation_cpu(q)
+            k = rotate_activation_cpu(k)
+
+            # FP8 quantization (CPU version using bfloat16)
+            q_fp8, q_scale = act_quant_cpu(q, block_size=BLOCK_SIZE, scale_fmt=self.scale_fmt)
+            k_fp8, k_scale = act_quant_cpu(k, block_size=BLOCK_SIZE, scale_fmt=self.scale_fmt)
+
+            # Update cache
+            self.k_cache[:bsz, start_pos:end_pos] = k_fp8
+            self.k_scale_cache[:bsz, start_pos:end_pos] = k_scale
+
+            # Compute weights
+            weights = self.weights_proj(x.float())  # [B, L, H]
+            weights = weights * (self.n_heads**-0.5)  # Scale by 1/sqrt(n_heads)
+            weights = weights.unsqueeze(-1)  # [B, L, H, 1]
+            weights = weights * q_scale * self.softmax_scale  # [B, L, H, 1]
+
+            # Compute index scores using FP8 index operation
+            index_score = fp8_index_cpu(
+                q_fp8,  # [B, L, H, D]
+                weights.squeeze(-1),  # [B, L, H]
+                self.k_cache[:bsz, :end_pos],  # [B, C, D]
+                self.k_scale_cache[:bsz, :end_pos].squeeze(-1),  # [B, C]
+            )
+        else:
+            # Clean functional path (no Hadamard, no fp8): the dequant scales are
+            # identity, so fold only weights_proj * Hi**-0.5 * softmax_scale into
+            # the per-head weights and pass unit key scales.
+            self.k_cache[:bsz, start_pos:end_pos] = k
+            weights = self.weights_proj(x.float()) * (self.n_heads**-0.5) * self.softmax_scale  # [B, L, H]
+            index_score = fp8_index_cpu(
+                q,  # [B, L, H, D]
+                weights,  # [B, L, H]
+                self.k_cache[:bsz, :end_pos],  # [B, C, D]
+                torch.ones(bsz, end_pos, dtype=torch.float32),  # unit key scales
+            )
+
+        # index_score is summed over heads: [B, L, C] where C == end_pos
+        assert index_score.shape == (
+            bsz,
+            seqlen,
+            end_pos,
+        ), f"Expected index_score shape {(bsz, seqlen, end_pos)}, got {tuple(index_score.shape)}"
+
+        # Apply mask if provided ([seqlen, end_pos] broadcasts over batch)
+        if mask is not None:
+            index_score = index_score + mask
+
+        # Top-K selection
+        topk_k = min(self.index_topk, end_pos)
+        topk_indices = index_score.topk(topk_k, dim=-1)[1]  # [B, L, topk]
+
+        assert topk_indices.shape == (
+            bsz,
+            seqlen,
+            topk_k,
+        ), f"Expected topk_indices shape {(bsz, seqlen, topk_k)}, got {tuple(topk_indices.shape)}"
+
+        return topk_indices, index_score
+
+
+# ===== MLA =====
+
+
+class MLACPU(nn.Module):
+    """
+    CPU-compatible version of the MLA (Multi-Head Latent Attention) layer.
+
+    Replaces ColumnParallelLinear / RowParallelLinear with plain Linear
+    (world_size == 1, so the all-reduce in ``wo`` is a no-op), drops weight
+    dequant (random bf16 weights), and keeps the KV-cache fp8 quant/dequant as a
+    precision *simulation* applied identically on every write path.
+    """
+
+    def __init__(self, args: ModelArgs, simulate_fp8: bool = True):
+        super().__init__()
+        self.dim = args.dim
+        self.n_heads = args.n_heads
+        self.q_lora_rank = args.q_lora_rank
+        self.kv_lora_rank = args.kv_lora_rank
+        self.qk_nope_head_dim = args.qk_nope_head_dim
+        self.qk_rope_head_dim = args.qk_rope_head_dim
+        self.qk_head_dim = args.qk_nope_head_dim + args.qk_rope_head_dim
+        self.v_head_dim = args.v_head_dim
+        self.scale_fmt = args.scale_fmt
+        # When False, the latent KV cache stores the plain bf16 latent (no fp8
+        # precision simulation). Kept True by default to mirror the device's fp8
+        # KV cache; disabled by the ttnn port, which stores bf16, so the two match.
+        self.simulate_fp8 = simulate_fp8
+
+        # Projections (Column/Row-parallel collapse to plain Linear at world_size=1).
+        self.wq_a = Linear(self.dim, self.q_lora_rank)
+        self.q_norm = RMSNorm(self.q_lora_rank)
+        self.wq_b = Linear(self.q_lora_rank, self.n_heads * self.qk_head_dim)
+        self.wkv_a = Linear(self.dim, self.kv_lora_rank + self.qk_rope_head_dim)
+        self.kv_norm = RMSNorm(self.kv_lora_rank)
+        self.wkv_b = Linear(self.kv_lora_rank, self.n_heads * (self.qk_nope_head_dim + self.v_head_dim))
+        self.wo = Linear(self.n_heads * self.v_head_dim, self.dim)
+
+        # softmax scale with YaRN mscale correction (max_seq_len > original_seq_len).
+        self.softmax_scale = self.qk_head_dim**-0.5
+        if args.max_seq_len > args.original_seq_len:
+            mscale = 0.1 * args.mscale * math.log(args.rope_factor) + 1.0
+            self.softmax_scale = self.softmax_scale * mscale * mscale
+
+        # Nested sparse-attention selector (shares the same args instance).
+        self.indexer = IndexerCPU(args)
+
+        # Latent KV cache (the MLA memory win): stores latent kv (512) + k_pe (64).
+        self.register_buffer(
+            "kv_cache",
+            torch.zeros(args.max_batch_size, args.max_seq_len, self.kv_lora_rank, dtype=torch.bfloat16),
+            persistent=False,
+        )
+        self.register_buffer(
+            "pe_cache",
+            torch.zeros(args.max_batch_size, args.max_seq_len, self.qk_rope_head_dim, dtype=torch.bfloat16),
+            persistent=False,
+        )
+
+        logger.info(f"Initialized MLACPU with {self.n_heads} heads, qk_head_dim={self.qk_head_dim}")
+
+    def _simulate_fp8_kv(self, kv: torch.Tensor) -> torch.Tensor:
+        """
+        Simulate the deployed fp8 KV-cache precision: quantize then dequantize so
+        the value stored is what the device would store. Applied on the write
+        path in BOTH branches, so decode reads exactly what prefill wrote
+        (cache-correctness invariant). See model.py:570-571.
+        """
+        kv_fp8, kv_scale = act_quant_cpu(kv.contiguous(), block_size=BLOCK_SIZE, scale_fmt=self.scale_fmt)
+        kv_deq = (kv_fp8.view(-1, BLOCK_SIZE).float() * kv_scale.view(-1, 1)).to(kv.dtype).view_as(kv)
+        return kv_deq
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        start_pos: int,
+        freqs_cis: torch.Tensor,
+        mask: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        """
+        Args:
+            x: input features [B, S, dim]
+            start_pos: write offset into the cache
+            freqs_cis: rotary frequencies for absolute positions [S, rope/2]
+            mask: causal mask [S, S] for prefill, or None for decode
+
+        Returns:
+            out: [B, S, dim]
+        """
+        bsz, seqlen, _ = x.size()
+        end_pos = start_pos + seqlen
+        logger.info(
+            f"MLA forward: bsz={bsz}, seqlen={seqlen}, start_pos={start_pos}, mask={'set' if mask is not None else 'None'}"
+        )
+
+        # ----- Shared front-end -----
+        qr = self.q_norm(self.wq_a(x))  # [B, S, q_lora_rank]
+        q = self.wq_b(qr)  # [B, S, H * qk_head_dim]
+        q = q.view(bsz, seqlen, self.n_heads, self.qk_head_dim)
+        q_nope, q_pe = torch.split(q, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
+        # MLA RoPE is interleaved (the indexer's is not).
+        q_pe = apply_rotary_emb(q_pe, freqs_cis, interleaved=True)
+
+        kv = self.wkv_a(x)  # [B, S, kv_lora_rank + rope]
+        kv, k_pe = torch.split(kv, [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
+        kv = self.kv_norm(kv)  # latent kv [B, S, 512]
+        k_pe = apply_rotary_emb(k_pe.unsqueeze(2), freqs_cis, interleaved=True)  # [B, S, 1, 64]
+
+        # fp8 KV-cache precision simulation (consistent on every write path).
+        if self.simulate_fp8:
+            kv = self._simulate_fp8_kv(kv)
+
+        # Write current chunk into the latent caches.
+        self.kv_cache[:bsz, start_pos:end_pos] = kv
+        self.pe_cache[:bsz, start_pos:end_pos] = k_pe.squeeze(2)
+
+        if mask is not None and start_pos == 0:
+            # ----- Prefill / MHA: materialize per-head K and V via wkv_b -----
+            # Chunked prefill (start_pos > 0, mask [S, end_pos]) takes the decode/MQA
+            # branch below: K/V come from the caches, mask keeps chunk causality.
+            q = torch.cat([q_nope, q_pe], dim=-1)  # [B, S, H, qk_head_dim]
+            kv_b = self.wkv_b(kv)  # [B, S, H * (nope + v)]
+            kv_b = kv_b.view(bsz, seqlen, self.n_heads, self.qk_nope_head_dim + self.v_head_dim)
+            k_nope, v = torch.split(kv_b, [self.qk_nope_head_dim, self.v_head_dim], dim=-1)
+            k = torch.cat([k_nope, k_pe.expand(-1, -1, self.n_heads, -1)], dim=-1)  # [B, S, H, qk_head_dim]
+            scores = torch.einsum("bshd,bthd->bsht", q, k) * self.softmax_scale  # [B, S, H, T]
+
+            # Indexer -> additive {0, -inf} mask, combined with the causal mask.
+            topk_indices = self.indexer(x, qr, start_pos, freqs_cis, mask)[0]
+            index_mask = torch.full((bsz, seqlen, seqlen), float("-inf"), device=x.device).scatter_(-1, topk_indices, 0)
+            index_mask = index_mask + mask
+            scores = scores + index_mask.unsqueeze(2)
+
+            scores = scores.softmax(dim=-1, dtype=torch.float32).type_as(x)
+            x_attn = torch.einsum("bsht,bthd->bshd", scores, v)  # [B, S, H, v]
+        else:
+            # ----- Decode / MQA: absorb wkv_b into Q and output -----
+            wkv_b = self.wkv_b.weight.view(self.n_heads, -1, self.kv_lora_rank)  # [H, 256, c]
+            # Absorb the nope half of wkv_b into the query (-> width c).
+            q_nope_abs = torch.einsum("bshd,hdc->bshc", q_nope, wkv_b[:, : self.qk_nope_head_dim])  # [B, S, H, c]
+            scores = (
+                torch.einsum("bshc,btc->bsht", q_nope_abs, self.kv_cache[:bsz, :end_pos])
+                + torch.einsum("bshr,btr->bsht", q_pe, self.pe_cache[:bsz, :end_pos])
+            ) * self.softmax_scale  # [B, S, H, T]
+
+            topk_indices = self.indexer(x, qr, start_pos, freqs_cis, mask)[0]
+            index_mask = torch.full((bsz, seqlen, end_pos), float("-inf"), device=x.device).scatter_(
+                -1, topk_indices, 0
+            )
+            # Chunked prefill ([S>1, end_pos] mask): rows with fewer causal keys than
+            # topk still get future indices scattered to 0 — re-impose causality like
+            # the prefill branch above (mask shape [S, end_pos], rows offset start_pos).
+            if mask is not None:
+                index_mask = index_mask + mask
+            scores = scores + index_mask.unsqueeze(2)
+
+            scores = scores.softmax(dim=-1, dtype=torch.float32).type_as(x)
+            x_attn = torch.einsum("bsht,btc->bshc", scores, self.kv_cache[:bsz, :end_pos])  # [B, S, H, c]
+            # Absorb the value half of wkv_b at the very end (-> width v).
+            x_attn = torch.einsum("bshc,hdc->bshd", x_attn, wkv_b[:, -self.v_head_dim :])  # [B, S, H, v]
+
+        out = self.wo(x_attn.flatten(2))  # [B, S, dim]
+        logger.info(f"MLA output shape: {tuple(out.shape)}")
+        return out

--- a/models/demos/deepseek_v3_d_p/reference/cpu_deepseek_v32/reference.py
+++ b/models/demos/deepseek_v3_d_p/reference/cpu_deepseek_v32/reference.py
@@ -1,0 +1,236 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Public API for the DeepSeek-V3.2 / GLM-5.1 sparse-MLA CPU reference.
+
+Shaped after the device model ``ttMLA``: construct with ``(config, weights)`` plus ``seq_len``, then
+``forward(hidden_states)``. The HF-attribute config is the only configuration input; the upstream
+``ModelArgs`` is derived from it internally and never leaves the package. A single canonical weights
+dict (HF/checkpoint naming — the same one ``ttMLA`` consumes) initializes both backends; this module
+remaps it to the upstream CPU parameter names on load.
+
+See ``API_SPEC.md`` in this directory for the full design.
+"""
+
+from __future__ import annotations
+
+from os import PathLike
+from typing import Protocol, runtime_checkable
+
+import torch
+
+from models.demos.deepseek_v3_d_p.reference.cpu_deepseek_v32.model import MLACPU, ModelArgs
+from models.demos.deepseek_v3_d_p.reference.cpu_deepseek_v32.utils import precompute_freqs_cis
+from models.demos.deepseek_v3_d_p.reference.cpu_deepseek_v32.weights import (
+    CANONICAL_TO_CPU,
+    DEFAULT_REPO,
+    load_attention_state_dict,
+    resolve_layer_shards,
+)
+
+# Canonical weights: keyed by HF/checkpoint names — the exact dict ttMLA consumes.
+Weights = dict[str, torch.Tensor]
+
+
+@runtime_checkable
+class SparseMLAConfig(Protocol):
+    """The HF-attribute config contract this package reads (deepseek_v32_hf_config / glm_hf_config)."""
+
+    hidden_size: int
+    num_attention_heads: int
+    q_lora_rank: int
+    kv_lora_rank: int
+    qk_nope_head_dim: int
+    qk_rope_head_dim: int
+    v_head_dim: int
+    rope_theta: float
+    rope_scaling: dict  # factor, mscale, beta_fast, beta_slow, original_max_position_embeddings
+    index_n_heads: int
+    index_head_dim: int
+    index_topk: int
+    index_rope_interleave: bool
+
+
+# Canonical (HF/checkpoint) <-> CPU-port name maps. The correspondence is owned by weights.py
+# (CANONICAL_TO_CPU); here we just take it and its inverse so device weights and the CPU truth agree.
+_CANONICAL_TO_CPU = CANONICAL_TO_CPU
+_CPU_TO_CANONICAL: dict[str, str] = {cpu: canon for canon, cpu in _CANONICAL_TO_CPU.items()}
+
+# Canonical key set, for callers that want to validate against the ttnn contract.
+CANONICAL_WEIGHT_NAMES: tuple[str, ...] = tuple(_CANONICAL_TO_CPU)
+
+
+def _model_args_from_hf(config: SparseMLAConfig, seq_len: int) -> ModelArgs:
+    """Derive the upstream ModelArgs from the HF config (the single source of dims).
+
+    YaRN is gated inside MLACPU by ``max_seq_len > original_seq_len``; we drive that gate from
+    ``rope_scaling.factor`` (not from ``config.max_seq_len``, which tests mutate to the device rope-table
+    length). ``seq_len`` sizes the RoPE table + the internal KV/PE cache. Fields the config doesn't
+    carry (``scale_fmt``) keep the ModelArgs defaults.
+    """
+    rs = config.rope_scaling
+    original = int(rs["original_max_position_embeddings"])
+    factor = float(rs["factor"])
+    if factor > 1.0:  # YaRN active (V3.2): gate must be True
+        original_seq_len = original
+        max_seq_len = max(int(seq_len), original + 1)
+    else:  # no YaRN (GLM): gate must be False (max == original)
+        original_seq_len = max_seq_len = max(int(seq_len), original)
+    return ModelArgs(
+        max_batch_size=1,
+        max_seq_len=max_seq_len,
+        original_seq_len=original_seq_len,
+        dim=config.hidden_size,
+        n_heads=config.num_attention_heads,
+        q_lora_rank=config.q_lora_rank,
+        kv_lora_rank=config.kv_lora_rank,
+        qk_nope_head_dim=config.qk_nope_head_dim,
+        qk_rope_head_dim=config.qk_rope_head_dim,
+        v_head_dim=config.v_head_dim,
+        rope_theta=float(config.rope_theta),
+        rope_factor=factor,
+        beta_fast=int(rs["beta_fast"]),
+        beta_slow=int(rs["beta_slow"]),
+        mscale=float(rs["mscale"]),
+        index_n_heads=config.index_n_heads,
+        index_head_dim=config.index_head_dim,
+        index_topk=config.index_topk,
+        index_rope_interleave=config.index_rope_interleave,
+    )
+
+
+def random_mla_weights(config: SparseMLAConfig, *, seed: int = 42) -> Weights:
+    """Config-driven random MLA + indexer weights in canonical naming (no model, no caches).
+
+    Dtypes match the upstream modules: bf16 Linear weights, fp32 norms (γ) / k_norm bias (β) /
+    ``weights_proj``. Cheap enough for the perf path (50k seq) since nothing is allocated but the
+    weights themselves.
+    """
+    g = torch.Generator().manual_seed(seed)
+    std = float(getattr(config, "initializer_range", 0.02))
+    h = config.hidden_size
+    n_heads = config.num_attention_heads
+    qk_head_dim = config.qk_nope_head_dim + config.qk_rope_head_dim
+    idx_heads = config.index_n_heads
+    idx_dim = config.index_head_dim
+
+    def lin(out_f: int, in_f: int) -> torch.Tensor:
+        return (torch.randn(out_f, in_f, generator=g) * std).to(torch.bfloat16)
+
+    return {
+        "q_a_proj.weight": lin(config.q_lora_rank, h),
+        "q_a_layernorm.weight": torch.ones(config.q_lora_rank, dtype=torch.float32),
+        "q_b_proj.weight": lin(n_heads * qk_head_dim, config.q_lora_rank),
+        "kv_a_proj_with_mqa.weight": lin(config.kv_lora_rank + config.qk_rope_head_dim, h),
+        "kv_a_layernorm.weight": torch.ones(config.kv_lora_rank, dtype=torch.float32),
+        "kv_b_proj.weight": lin(n_heads * (config.qk_nope_head_dim + config.v_head_dim), config.kv_lora_rank),
+        "o_proj.weight": lin(h, n_heads * config.v_head_dim),
+        "indexer.wq_b.weight": lin(idx_heads * idx_dim, config.q_lora_rank),
+        "indexer.wk.weight": lin(idx_dim, h),
+        "indexer.k_norm.weight": torch.ones(idx_dim, dtype=torch.float32),
+        "indexer.k_norm_bias.weight": torch.zeros(idx_dim, dtype=torch.float32),
+        "indexer.weights_proj.weight": (torch.randn(idx_heads, h, generator=g) * std).to(torch.float32),
+    }
+
+
+def pretrained_mla_weights(
+    config: SparseMLAConfig,
+    *,
+    layer: int,
+    repo: str = DEFAULT_REPO,
+    checkpoint_path: str | PathLike[str] | list[str] | None = None,
+) -> Weights:
+    """Load layer-``layer`` pretrained MLA + indexer weights as the canonical dict (fp8 dequantized).
+
+    ``checkpoint_path`` (a local shard path or list) takes precedence over HF resolution from ``repo``.
+    ``config`` is accepted for symmetry / future validation; shapes come from the checkpoint.
+    """
+    shards = checkpoint_path if checkpoint_path is not None else resolve_layer_shards(layer, repo)
+    cpu_sd = load_attention_state_dict(shards, layer)  # upstream CPU names, dequantized
+    return {_CPU_TO_CANONICAL[cpu]: t for cpu, t in cpu_sd.items()}
+
+
+class SparseMLAReference:
+    """CPU truth for one DeepSeek-V3.2 / GLM-5.1 sparse-MLA layer. Built like ttMLA: ``(config, weights)``."""
+
+    def __init__(
+        self,
+        config: SparseMLAConfig,
+        weights: Weights,
+        *,
+        seq_len: int,
+        simulate_fp8: bool = False,
+    ) -> None:
+        self._seq_len = int(seq_len)
+        self._args = _model_args_from_hf(config, seq_len)
+        # simulate_fp8=False (default) is the bf16 functional-parity path the ttnn port matches.
+        self._mla = MLACPU(self._args, simulate_fp8=simulate_fp8).eval()
+        self._mla.indexer.use_fp8_path = simulate_fp8
+
+        missing_canon = [c for c in _CANONICAL_TO_CPU if c not in weights]
+        if missing_canon:
+            raise KeyError(f"weights missing canonical keys: {missing_canon}")
+        cpu_weights = {_CANONICAL_TO_CPU[c]: t for c, t in weights.items() if c in _CANONICAL_TO_CPU}
+        self._mla.load_state_dict(cpu_weights, strict=True)
+
+        self._freqs = precompute_freqs_cis(self._args)
+        self._filled = 0  # highest end position written into the caches (across chunked calls)
+        self._last_topk: torch.Tensor | None = None
+        self._last_logits: torch.Tensor | None = None
+        # Capture the indexer's (topk, logits) from inside the single forward pass — no second run.
+        self._mla.indexer.register_forward_hook(self._capture_indexer)
+
+    def _capture_indexer(self, module, inputs, output) -> None:  # noqa: ANN001 (torch hook signature)
+        topk, logits = output
+        self._last_topk, self._last_logits = topk, logits
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        actual_start: int = 0,
+        actual_end: int | None = None,
+    ) -> torch.Tensor:
+        """Single forward pass; returns the MLA output [B, S, dim].
+
+        Mirrors ``ttMLA.forward``: ``actual_start``/``actual_end`` are the cache write offsets. RoPE and
+        the causal mask are built internally. The indexer runs inside this pass — its logits/topk and the
+        KV/index caches are exposed via the properties below. Chunked prefill = call this in a loop with
+        increasing ``actual_start`` (the same pattern as the device chunked test).
+        """
+        x = hidden_states.to(torch.bfloat16)
+        seqlen = x.shape[-2]
+        end = int(actual_end) if actual_end is not None else actual_start + seqlen
+        assert end <= self._seq_len, f"end {end} exceeds seq_len {self._seq_len}"
+        freqs = self._freqs[actual_start:end]
+        # Causal mask [seqlen, end]; triu offset by actual_start keeps chunk causality (== single-shot at 0).
+        mask = torch.full((seqlen, end), float("-inf")).triu_(actual_start + 1)
+        with torch.no_grad():
+            out = self._mla.forward(x, actual_start, freqs, mask)
+        self._filled = max(self._filled, end)
+        return out
+
+    @property
+    def indexer_logits(self) -> torch.Tensor:
+        """Indexer index-scores from the last forward [1, S, end] (causal region matches the reference)."""
+        assert self._last_logits is not None, "call forward() first"
+        return self._last_logits
+
+    @property
+    def indexer_topk(self) -> torch.Tensor:
+        """Indexer top-k selected indices from the last forward [1, S, k]."""
+        assert self._last_topk is not None, "call forward() first"
+        return self._last_topk
+
+    @property
+    def kvpe_cache(self) -> torch.Tensor:
+        """Latent-kv ++ k_pe in device layout [1, 1, S, kv_lora_rank + qk_rope_head_dim]."""
+        kv = self._mla.kv_cache[:1, : self._filled]
+        pe = self._mla.pe_cache[:1, : self._filled]
+        return torch.cat([kv, pe], dim=-1).unsqueeze(1)
+
+    @property
+    def index_cache(self) -> torch.Tensor:
+        """Indexer key cache [1, S, index_head_dim]."""
+        return self._mla.indexer.k_cache[:1, : self._filled]

--- a/models/demos/deepseek_v3_d_p/reference/cpu_deepseek_v32/sparse_sdpa_prefill.py
+++ b/models/demos/deepseek_v3_d_p/reference/cpu_deepseek_v32/sparse_sdpa_prefill.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Reference implementation (torch golden) of the DSA sparse-MLA prefill op.
+
+Mirrors the interface of ``models/demos/deepseek_v32/tt/ops.py::sparse_mla``
+(branch ``mvasilijevic/dsa_functional``) so it can be a drop-in golden / the
+on-device op can be a drop-in replacement. Single op, single output tensor.
+
+Difference from the host fallback in ``ops.py``: masking is **fully baked into
+the indices** (FlashMLA sparse contract — "indices already encode it"). Any
+slot that must not be attended carries the sentinel ``MASKED_INDEX``:
+
+    index == 0xFFFFFFFF  ->  this slot scores -inf  (contributes 0 to softmax)
+
+So there is **no position/causal math in the op** — ``start_pos`` is accepted
+only for signature parity with ``sparse_mla`` and is ignored. The upstream
+indexer is responsible for emitting the sentinel for causal/pad slots.
+
+Absorbed MQA over the top-k selected latents (one latent KV head, shared across
+all query heads):
+
+    q       [1, H, S, 576]   absorbed queries (q_nope·wkv_b ++ q_pe)
+    kvpe    [T, 576]         full latent prefix (512 latent ++ 64 rope), one head
+    indices [1, 1, S, k]     uint32 global key positions; 0xFFFFFFFF = masked
+    scale   scalar           softmax scale (with YaRN mscale)
+    ->      [1, H, S, 512]   bf16-equivalent; latent-512 space (wkv_b value
+                             absorption 512->128 happens AFTER this op)
+
+Latent KV layout: ``kvpe[..., :512]`` is the latent kv (== V); ``kvpe[..., 512:]``
+is k_pe (rope). K used for scoring is the full 576; V used for output is the
+first 512 (a view).
+
+Two equivalent forms:
+* ``sparse_mla``        — the op (gather k selected slots). Validate the kernel
+                          against this.
+* ``sparse_mla_masked`` — dense-mask golden (equivalence oracle only).
+"""
+
+import torch
+
+MASKED_INDEX = 0xFFFFFFFF  # sentinel: slot is masked out (scores -inf)
+
+LATENT_DIM = 512  # kv_lora_rank — V is kvpe[..., :LATENT_DIM]
+ROPE_DIM = 64  # qk_rope_head_dim
+KV_DIM = LATENT_DIM + ROPE_DIM  # 576 — full K width
+
+
+def _prep(q, kvpe, indices):
+    """Normalize the sparse_mla-shaped inputs to [B,H,S,Dk] / [B,T,Dk] / [B,S,k]."""
+    B, H, S, Dk = q.shape
+    k = indices.shape[-1]
+    idx = indices.reshape(B, S, k)  # tolerate [1,1,S,k] / [B,1,S,k] / [B,S,k]
+    if kvpe.dim() == 2:  # [T, 576] shared across batch (the sparse_mla convention)
+        kv = kvpe.unsqueeze(0).expand(B, kvpe.shape[0], Dk)
+    else:  # [B, T, 576]
+        kv = kvpe
+    return B, H, S, Dk, k, idx, kv
+
+
+def sparse_mla(
+    q: torch.Tensor,  # [1, H, S, 576] absorbed queries (nope·wkv_b ++ rope)
+    kvpe: torch.Tensor,  # [T, 576] full latent prefix (K=full 576, V=[:512])
+    indices: torch.Tensor,  # [1, 1, S, k] uint32 global key positions; 0xFFFFFFFF = masked
+    scale: float,
+    start_pos: int = 0,  # accepted for parity with ops.py::sparse_mla; IGNORED (indices encode causality)
+) -> torch.Tensor:  # [1, H, S, 512]
+    """
+    Absorbed MQA over the top-k selected latents only. Masking is baked into
+    ``indices`` via ``MASKED_INDEX``; no causal/position math here.
+
+    For each (query row s) gather the k latents named by ``indices[..., s, :]``
+    (one set, shared across all heads), score against every head's query over
+    the full 576 width, set ``-inf`` on sentinel slots, softmax over the k axis,
+    and weighted-sum the gathered V views (first 512).
+    """
+    del start_pos  # causality is encoded in `indices` (sentinel), not positions
+    B, H, S, Dk, k, idx, kv = _prep(q, kvpe, indices)
+    T = kv.shape[1]
+
+    masked = idx == MASKED_INDEX  # [B,S,k]
+    # Clamp sentinels in-bounds so the gather is legal; the gathered data is
+    # discarded by the -inf score, so the value is moot.
+    idx_safe = torch.where(masked, torch.zeros_like(idx), idx).to(torch.int64)
+
+    # gather selected KV (shared across heads): [B,T,Dk] -> [B,S,k,Dk]
+    idx_g = idx_safe.view(B, S, k, 1).expand(B, S, k, Dk)
+    sel = torch.gather(kv.unsqueeze(1).expand(B, S, T, Dk), 2, idx_g)  # [B,S,k,Dk]
+
+    # scores over the full 576 width: <q[b,h,s,:], sel[b,s,j,:]>
+    scores = torch.einsum("bhsd,bsjd->bhsj", q, sel) * scale  # [B,H,S,k]
+    scores = scores.masked_fill(masked.view(B, 1, S, k), float("-inf"))
+
+    probs = scores.softmax(dim=-1, dtype=torch.float32).to(q.dtype)  # [B,H,S,k]
+    out = torch.einsum("bhsj,bsjd->bhsd", probs, sel[..., :LATENT_DIM])  # [B,H,S,512]
+    return out
+
+
+def sparse_mla_masked(
+    q: torch.Tensor,  # [1, H, S, 576]
+    kvpe: torch.Tensor,  # [T, 576]
+    indices: torch.Tensor,  # [1, 1, S, k]; 0xFFFFFFFF = masked
+    scale: float,
+    start_pos: int = 0,
+) -> torch.Tensor:  # [1, H, S, 512]
+    """Dense-mask golden (equivalence oracle). Softmax over the full T axis."""
+    del start_pos
+    B, H, S, Dk, k, idx, kv = _prep(q, kvpe, indices)
+    T = kv.shape[1]
+
+    masked = idx == MASKED_INDEX
+    # Route sentinels to a throwaway column T (sliced off) so they never enable
+    # a real position; valid entries keep their index.
+    idx_safe = torch.where(masked, torch.full_like(idx, T), idx).to(torch.int64)
+
+    scores = torch.einsum("bhsd,btd->bhst", q, kv) * scale  # [B,H,S,T]
+    index_mask = torch.full((B, S, T + 1), float("-inf"), device=q.device)
+    index_mask.scatter_(-1, idx_safe, 0.0)
+    index_mask = index_mask[..., :T]  # drop throwaway col
+
+    scores = scores + index_mask.unsqueeze(1)  # [B,1,S,T] over heads
+    probs = scores.softmax(dim=-1, dtype=torch.float32).to(q.dtype)
+    out = torch.einsum("bhst,btd->bhsd", probs, kv[..., :LATENT_DIM])  # [B,H,S,512]
+    return out
+
+
+def _selfcheck() -> None:
+    """Prove the op == dense-mask golden on sentinel-padded, sparse_mla-shaped inputs."""
+    torch.manual_seed(0)
+    H, S = 8, 16
+    T = S  # full prefill
+    k = 8  # selected slots per row (< T => non-trivial)
+    scale = KV_DIM**-0.5
+
+    q = torch.randn(1, H, S, KV_DIM)
+    kvpe = torch.randn(T, KV_DIM)  # [T,576] — sparse_mla convention
+
+    # sentinel-padded indices [1,1,S,k]: random unique valid prefix per row, rest masked.
+    indices = torch.full((1, 1, S, k), MASKED_INDEX, dtype=torch.int64)
+    for s in range(S):
+        n = int(torch.randint(1, k + 1, (1,)))
+        indices[0, 0, s, :n] = torch.randperm(T)[:n]
+
+    a = sparse_mla(q, kvpe, indices, scale)
+    b = sparse_mla_masked(q, kvpe, indices, scale)
+    assert a.shape == (1, H, S, LATENT_DIM), a.shape
+    torch.testing.assert_close(a, b, rtol=1e-3, atol=1e-3)
+    print(f"OK: sparse_mla == dense-mask golden; out {tuple(a.shape)} (K=576, V=512, sentinel-masked)")
+
+
+if __name__ == "__main__":
+    _selfcheck()

--- a/models/demos/deepseek_v3_d_p/reference/cpu_deepseek_v32/test_model.py
+++ b/models/demos/deepseek_v3_d_p/reference/cpu_deepseek_v32/test_model.py
@@ -1,0 +1,336 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+CPU test harness for the DeepSeek V3.2 reference layers (Indexer + MLA).
+
+  * ``test_indexer_layer`` — random indexer, one forward pass; asserts shapes.
+  * ``test_mla_layer``     — random MLA, one-shot prefill vs. prefill(P-1)+decode(1);
+    asserts the decoded position matches the prefill (cache-correctness invariant).
+  * ``test_*_pretrained_layer0`` — load real layer-0 weights (skipped if the shard
+    isn't cached) and run one forward.
+
+Models and inputs are built once via module-scoped fixtures and reused: random
+(`mla`, `indexer`) and pretrained layer-0 (`mla_pretrained`, `indexer_pretrained`)
+instances, plus shared inputs (`x`, `qr`, `freqs_cis`). ``x`` is parametrizable
+(one shape for now). Reuse is safe because each MLA forward fully rewrites the
+causal cache range it reads, so tests are order-independent.
+
+All non-pretrained tests are pytest-discoverable and also run from ``main()``
+(which calls the creation helpers directly instead of using fixtures).
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# Allow `python test_model.py` from this directory: ensure the repo root is on
+# sys.path so the absolute `models.demos.deepseek_v3_d_p.reference.cpu_deepseek_v32.*` imports
+# below resolve. Under `python -m pytest` from the repo root this is a no-op.
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+import pytest
+import torch
+from loguru import logger
+
+from models.demos.deepseek_v3_d_p.reference.cpu_deepseek_v32.model import MLACPU, IndexerCPU, ModelArgs
+from models.demos.deepseek_v3_d_p.reference.cpu_deepseek_v32.utils import precompute_freqs_cis
+from models.demos.deepseek_v3_d_p.reference.cpu_deepseek_v32.weights import initialize_weights
+
+SEED = 42
+BATCH_SIZE = 2
+# Small seq_len -> index_topk collapses to min(2048, T) = T (all positions
+# selected), so the index mask is all-zero and the MLA equivalence test isolates
+# the attention math from the discrete top-k selection.
+SEQ_LEN = 8
+PRETRAINED_LAYER = 0
+N_DETERMINISM_RUNS = 5
+PCC = 0.9999
+# Prefill (MHA) and decode (MQA-absorbed) are algebraically identical (fp32 agrees
+# to ~1e-6); in bf16 they match to PCC ~0.9999, so assert a safe 0.999 floor —
+# far above a broken path, well below the bf16 noise floor.
+EQUIV_PCC = 0.999
+# Saved tensors / metadata land under ~/.cache, outside the repo, so the artifacts need no
+# .gitignore. Override with DEEPSEEK_V32_TEST_OUTPUT_DIR.
+_DEFAULT_OUTPUT_DIR = Path.home() / ".cache" / "deepseek_v32" / "test_outputs"
+OUTPUT_DIR = Path(os.environ.get("DEEPSEEK_V32_TEST_OUTPUT_DIR", _DEFAULT_OUTPUT_DIR))
+
+
+# ===== Creation helpers (encapsulation) =====
+
+
+def make_args() -> ModelArgs:
+    return ModelArgs()
+
+
+def make_input(args: ModelArgs, batch_size: int = BATCH_SIZE, seq_len: int = SEQ_LEN, seed: int = SEED + 1):
+    """Random input features ``[B, S, dim]`` (seeded for reproducibility)."""
+    torch.manual_seed(seed)
+    return torch.randn(batch_size, seq_len, args.dim, dtype=torch.bfloat16)
+
+
+def make_qr(args: ModelArgs, batch_size: int = BATCH_SIZE, seq_len: int = SEQ_LEN, seed: int = SEED + 2):
+    """Random query latent ``[B, S, q_lora_rank]`` (the indexer's `qr` input)."""
+    torch.manual_seed(seed)
+    return torch.randn(batch_size, seq_len, args.q_lora_rank, dtype=torch.bfloat16)
+
+
+def build_mla(args: ModelArgs, seed: int = SEED) -> MLACPU:
+    """An ``MLACPU`` with random (seeded) weights, including the nested indexer."""
+    torch.manual_seed(seed)
+    mla = MLACPU(args)
+    initialize_weights(mla)
+    return mla
+
+
+def build_indexer(args: ModelArgs, seed: int = SEED) -> IndexerCPU:
+    """A standalone ``IndexerCPU`` with random (seeded) weights."""
+    torch.manual_seed(seed)
+    indexer = IndexerCPU(args)
+    initialize_weights(indexer)
+    return indexer
+
+
+def _load_layer0_or_skip(module):
+    """Load cached layer-0 pretrained weights into ``module``, or skip the test."""
+    from huggingface_hub.utils import LocalEntryNotFoundError
+
+    try:
+        initialize_weights(module, layer=PRETRAINED_LAYER, local_files_only=True)
+    except LocalEntryNotFoundError:
+        pytest.skip("layer-0 shard not cached; run a pretrained load once to populate it (downloads ~5 GB)")
+    return module
+
+
+# ===== Shared fixtures (built once per module, reused across tests) =====
+
+
+@pytest.fixture(scope="module")
+def args() -> ModelArgs:
+    return make_args()
+
+
+@pytest.fixture(scope="module")
+def freqs_cis(args) -> torch.Tensor:
+    return precompute_freqs_cis(args)
+
+
+# (batch, seq) shapes to test. seq stays <= index_topk (2048) so the index mask
+# is all-zero and the MLA equivalence test isolates the attention math.
+X_SHAPES = [(BATCH_SIZE, SEQ_LEN), (1, 100)]
+
+
+@pytest.fixture(scope="module", params=X_SHAPES, ids=lambda p: f"b{p[0]}_s{p[1]}")
+def x(args, request) -> torch.Tensor:
+    """Input features. Parametrizable: add (batch, seq) tuples to `X_SHAPES`."""
+    batch_size, seq_len = request.param
+    return make_input(args, batch_size, seq_len)
+
+
+@pytest.fixture(scope="module")
+def qr(args, x) -> torch.Tensor:
+    """Query latent matching ``x``'s shape (the indexer's `qr` input)."""
+    batch_size, seq_len, _ = x.shape
+    return make_qr(args, batch_size, seq_len)
+
+
+@pytest.fixture(scope="module")
+def mla(args) -> MLACPU:
+    return build_mla(args)
+
+
+@pytest.fixture(scope="module")
+def indexer(args) -> IndexerCPU:
+    return build_indexer(args)
+
+
+@pytest.fixture(scope="module")
+def mla_pretrained(args) -> MLACPU:
+    return _load_layer0_or_skip(MLACPU(args))
+
+
+@pytest.fixture(scope="module")
+def indexer_pretrained(args) -> IndexerCPU:
+    return _load_layer0_or_skip(IndexerCPU(args))
+
+
+# ===== Indexer tests =====
+
+
+def _check_indexer_forward(indexer: IndexerCPU, x: torch.Tensor, qr: torch.Tensor, freqs_cis: torch.Tensor):
+    """Run one indexer forward and assert output shapes / finiteness."""
+    bsz, seqlen, _ = x.size()
+    topk_indices, index_scores = indexer.forward(x, qr, start_pos=0, freqs_cis=freqs_cis[:seqlen], mask=None)
+    topk_k = min(indexer.index_topk, seqlen)
+    assert index_scores.shape == (bsz, seqlen, seqlen)
+    assert topk_indices.shape == (bsz, seqlen, topk_k)
+    assert torch.isfinite(index_scores).all()
+    return topk_indices, index_scores
+
+
+@pytest.mark.slow
+def test_indexer_layer(indexer, x, qr, freqs_cis):
+    """Random indexer: one forward pass, check output shapes."""
+    logger.info("DeepSeek V3.2 Indexer CPU Test (random)")
+    topk_indices, index_scores = _check_indexer_forward(indexer, x, qr, freqs_cis)
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    torch.save(topk_indices, OUTPUT_DIR / "topk_indices.pt")
+    torch.save(index_scores, OUTPUT_DIR / "index_scores.pt")
+    logger.info("✓ Indexer test completed successfully")
+
+
+@pytest.mark.slow
+def test_indexer_pretrained_layer0(indexer_pretrained, x, qr, freqs_cis):
+    """Pretrained layer-0 indexer: one forward pass, check output shapes."""
+    logger.info("DeepSeek V3.2 Indexer CPU Test (pretrained layer 0)")
+    _check_indexer_forward(indexer_pretrained, x, qr, freqs_cis)
+    logger.info("✓ Pretrained layer-0 indexer forward OK")
+
+
+# ===== MLA tests =====
+
+
+def _run_prefill(mla: MLACPU, x: torch.Tensor, freqs_cis_full: torch.Tensor) -> torch.Tensor:
+    """One-shot prefill over the whole chunk (mask is not None -> MHA path)."""
+    _, seqlen, _ = x.size()
+    mask = torch.full((seqlen, seqlen), float("-inf")).triu_(1)
+    return mla.forward(x, start_pos=0, freqs_cis=freqs_cis_full[0:seqlen], mask=mask)
+
+
+def _run_prefill_then_decode(mla: MLACPU, x: torch.Tensor, freqs_cis_full: torch.Tensor) -> torch.Tensor:
+    """
+    Prefill the first P-1 tokens, then decode token P-1 (mask is None -> MQA
+    path). Returns the decoded output for the single last position [B, 1, dim].
+    """
+    _, seqlen, _ = x.size()
+    p = seqlen - 1
+    if p > 0:
+        mask = torch.full((p, p), float("-inf")).triu_(1)
+        _ = mla.forward(x[:, :p], start_pos=0, freqs_cis=freqs_cis_full[0:p], mask=mask)
+    return mla.forward(x[:, p : p + 1], start_pos=p, freqs_cis=freqs_cis_full[p : p + 1], mask=None)
+
+
+@pytest.mark.slow
+def test_mla_layer(mla, x, freqs_cis):
+    """
+    Random MLA prefill vs. prefill+decode on the same module, asserting the
+    cache-correctness invariant: prefilling P tokens then
+    decoding token P gives the same output for position P as prefilling P+1 at
+    once. Same weights (one module) + fresh causal cache writes each run.
+
+    Compared via PCC: the paths are algebraically identical, so the residual is
+    pure bf16 rounding (raw max-abs would surface a misleadingly large worst
+    element; PCC reflects that the vectors are effectively the same).
+    """
+    from tests.ttnn.utils_for_testing import assert_with_pcc
+
+    logger.info("DeepSeek V3.2 MLA CPU Test (random)")
+    prefill_out = _run_prefill(mla, x, freqs_cis)
+    decode_out = _run_prefill_then_decode(mla, x, freqs_cis)
+
+    p = x.size(1) - 1
+    ref_last = prefill_out[:, p : p + 1].float()
+    dec_last = decode_out.float()
+    assert torch.isfinite(prefill_out).all() and torch.isfinite(decode_out).all()
+
+    _, pcc_msg = assert_with_pcc(ref_last, dec_last, pcc=EQUIV_PCC)
+    max_abs = (ref_last - dec_last).abs().max().item()
+    logger.info(f"Prefill-vs-decode equivalence (position P-1): {pcc_msg}; max|Δ|={max_abs:.6f}")
+    logger.info("✓ Paths agree (PCC)")
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    torch.save(prefill_out, OUTPUT_DIR / "mla_prefill_out.pt")
+    torch.save(decode_out, OUTPUT_DIR / "mla_decode_out.pt")
+    metadata = {
+        "batch_size": x.size(0),
+        "seq_len": x.size(1),
+        "seed": SEED,
+        "prefill_out_shape": list(prefill_out.shape),
+        "decode_out_shape": list(decode_out.shape),
+        "equiv_pcc_threshold": EQUIV_PCC,
+        "max_abs_diff": max_abs,
+    }
+    with open(OUTPUT_DIR / "mla_metadata.json", "w") as f:
+        json.dump(metadata, f, indent=2)
+    logger.info("✓ MLA test completed successfully")
+
+
+@pytest.mark.slow
+def test_mla_pretrained_layer0(mla_pretrained, x, freqs_cis):
+    """Pretrained layer-0 MLA: one prefill forward, check shape / finiteness."""
+    logger.info("DeepSeek V3.2 MLA CPU Test (pretrained layer 0)")
+    bsz, seqlen, _ = x.size()
+    mask = torch.full((seqlen, seqlen), float("-inf")).triu_(1)
+    with torch.no_grad():
+        out = mla_pretrained.forward(x, start_pos=0, freqs_cis=freqs_cis[:seqlen], mask=mask)
+    assert out.shape == (bsz, seqlen, mla_pretrained.dim)
+    assert torch.isfinite(out).all()
+    logger.info("✓ Pretrained layer-0 MLA forward OK")
+
+
+@pytest.mark.slow
+def test_mla_pretrained_determinism(mla_pretrained, x, freqs_cis, n_runs: int = N_DETERMINISM_RUNS):
+    """
+    Pretrained MLA forward must be deterministic and idempotent: the same input
+    run ``n_runs`` times yields the same output, and the MLA + indexer caches are
+    unchanged after each run. Compared against the first run via PCC.
+    """
+    from tests.ttnn.utils_for_testing import assert_with_pcc
+
+    logger.info(f"DeepSeek V3.2 MLA determinism test ({n_runs} runs, pcc={PCC})")
+    bsz, seqlen, _ = x.size()
+    mask = torch.full((seqlen, seqlen), float("-inf")).triu_(1)
+
+    def run_forward():
+        with torch.no_grad():
+            return mla_pretrained.forward(x, start_pos=0, freqs_cis=freqs_cis[:seqlen], mask=mask)
+
+    def snapshot_caches():
+        # Only the written slice [:bsz, :end_pos] is meaningful; the rest stays zero.
+        m = mla_pretrained
+        return {
+            "kv_cache": m.kv_cache[:bsz, :seqlen].clone(),
+            "pe_cache": m.pe_cache[:bsz, :seqlen].clone(),
+            "indexer.k_cache": m.indexer.k_cache[:bsz, :seqlen].clone(),
+            "indexer.k_scale_cache": m.indexer.k_scale_cache[:bsz, :seqlen].clone(),
+        }
+
+    out_ref = run_forward()
+    caches_ref = snapshot_caches()
+
+    for i in range(1, n_runs):
+        out = run_forward()
+        assert_with_pcc(out_ref.float(), out.float(), pcc=PCC)
+        caches = snapshot_caches()
+        for name, ref in caches_ref.items():
+            assert_with_pcc(ref.float(), caches[name].float(), pcc=PCC)
+        logger.info(f"  run {i + 1}/{n_runs}: output + caches match")
+
+    logger.info(f"✓ MLA forward deterministic across {n_runs} runs (output + caches unchanged)")
+
+
+def main():
+    """Run the random-weight tests outside pytest, building model/data once."""
+    logger.info(f"Random seed set to {SEED}")
+    try:
+        args = make_args()
+        freqs_cis = precompute_freqs_cis(args)
+        x = make_input(args)
+        qr = make_qr(args)
+
+        test_indexer_layer(build_indexer(args), x, qr, freqs_cis)
+        test_mla_layer(build_mla(args), x, freqs_cis)
+        logger.info("✓ All tests completed successfully")
+    except Exception as e:
+        logger.error(f"❌ Error during test: {e}")
+        import traceback
+
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/demos/deepseek_v3_d_p/reference/cpu_deepseek_v32/utils.py
+++ b/models/demos/deepseek_v3_d_p/reference/cpu_deepseek_v32/utils.py
@@ -1,0 +1,301 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+CPU-compatible utilities for the DeepSeek V3.2 reference (Indexer + MLA).
+
+Contains:
+  * CPU equivalents of the tilelang CUDA kernels: ``act_quant_cpu``,
+    ``fp8_index_cpu``, ``rotate_activation_cpu`` (Walsh-Hadamard transform).
+  * Rotary-positional-embedding helpers shared by both layers:
+    ``precompute_freqs_cis`` (YaRN-scaled) and ``apply_rotary_emb`` (interleaved
+    for MLA, non-interleaved for the Indexer).
+
+These are pure-PyTorch and free of any model-class imports, so ``model.py`` can
+import them without a circular dependency.
+"""
+
+import math
+from typing import Tuple
+
+import torch
+import torch.nn.functional as F
+
+# ===== Kernel equivalents (mock tilelang kernels) =====
+
+
+def act_quant_cpu(x: torch.Tensor, block_size: int = 128, scale_fmt: str = None) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    CPU-compatible version of act_quant (FP8 quantization).
+
+    Mirrors the reference tilelang kernel (kernel.py:act_quant_kernel):
+    1. Computing block-wise absolute maximum (clamped to 1e-4)
+    2. Computing the per-block scale. When ``scale_fmt`` is set (e.g. "ue8m0"),
+       the scale is rounded up to a power of two, matching ``fast_round_scale``.
+    3. Quantizing ``x / scale`` onto the FP8 E4M3 grid (rounding through
+       float8_e4m3fn so the FP8 quantization error is simulated), stored as
+       bfloat16 for CPU-friendly downstream matmuls.
+
+    Args:
+        x: Input tensor [*, N] where N % block_size == 0
+        block_size: Block size for quantization (default: 128)
+        scale_fmt: Scale format. When not None, scales are rounded to a power
+            of two (ue8m0-style), matching the reference round_scale path.
+
+    Returns:
+        Tuple of (quantized_tensor, scale_factors)
+        - quantized_tensor: bfloat16 (simulating FP8 E4M3)
+        - scale_factors: float32
+    """
+    assert x.is_contiguous(), "Input tensor must be contiguous"
+    assert (
+        x.size(-1) % block_size == 0
+    ), f"Last dimension size must be divisible by block_size (block_size={block_size})"
+
+    # FP8 E4M3 range
+    fp8_min = -448.0
+    fp8_max = 448.0
+    fp8_max_inv = 1.0 / fp8_max
+
+    N = x.size(-1)
+    original_shape = x.shape
+
+    # Reshape to [*, num_blocks, block_size]
+    x_reshaped = x.to(torch.float32).view(-1, N // block_size, block_size)
+
+    # Compute absolute maximum per block
+    amax = x_reshaped.abs().max(dim=-1, keepdim=True)[0]  # [*, num_blocks, 1]
+    amax = torch.clamp(amax, min=1e-4)  # Avoid division by zero
+
+    # Compute scale factors
+    if scale_fmt is not None:
+        # ue8m0: round the scale up to the nearest power of two.
+        # Equivalent to fast_round_scale = fast_pow2(fast_log2_ceil(amax * fp8_max_inv)).
+        scale = torch.pow(2.0, torch.ceil(torch.log2(amax * fp8_max_inv)))  # [*, num_blocks, 1]
+    else:
+        scale = amax * fp8_max_inv  # [*, num_blocks, 1]
+
+    # Quantize: divide by scale, clamp to FP8 range, and round onto the FP8
+    # E4M3 grid so the quantization error is simulated (matches the on-device
+    # float8_e4m3fn cache). Stored as bfloat16 for CPU-friendly matmuls.
+    x_quantized = torch.clamp(x_reshaped / scale, fp8_min, fp8_max)
+    x_quantized = x_quantized.to(torch.float8_e4m3fn).to(torch.bfloat16)
+
+    # Reshape back to original shape
+    x_quantized = x_quantized.view(original_shape)
+    scale = scale.squeeze(-1).view(*original_shape[:-1], N // block_size).to(torch.float32)
+
+    return x_quantized, scale
+
+
+def fp8_index_cpu(
+    q: torch.Tensor,
+    q_s: torch.Tensor,
+    k: torch.Tensor,
+    k_s: torch.Tensor,
+) -> torch.Tensor:
+    """
+    CPU-compatible version of fp8_index kernel.
+
+    Computes index scores: Q @ K^T with FP8 scaling and ReLU.
+
+    The CUDA kernel does:
+    1. Q @ K^T (FP8 matmul)
+    2. ReLU(logits) * q_scale (per-head weights)
+    3. Sum over heads
+    4. Multiply by k_scale
+
+    Args:
+        q: Query tensor [B, L, H, D] in bfloat16 (simulating FP8)
+        q_s: Query scale/weights [B, L, H] in float32 (combined q_scale * weights)
+        k: Key cache [B, C, D] in bfloat16 (simulating FP8)
+        k_s: Key scales [B, C] in float32
+
+    Returns:
+        index_score: [B, L, C] in float32 (summed over heads)
+    """
+    # Q @ K^T per head: [B, L, H, D] x [B, C, D] -> [B, L, H, C]
+    index_score = torch.einsum("blhd,bcd->blhc", q.float(), k.float())
+
+    # Apply ReLU, then per-head weights (q_scale)
+    index_score = F.relu(index_score)
+    index_score = index_score * q_s.unsqueeze(-1)  # [B, L, H, C] * [B, L, H, 1]
+
+    # Sum over heads: [B, L, H, C] -> [B, L, C] (matches reduce_sum in the kernel)
+    index_score = index_score.sum(dim=2)  # [B, L, C]
+
+    # Apply k_scale after the head sum: [B, L, C] * [B, 1, C]
+    index_score = index_score * k_s.unsqueeze(1)  # [B, L, C]
+
+    return index_score
+
+
+def rotate_activation_cpu(x: torch.Tensor, scale: float = None) -> torch.Tensor:
+    """
+    CPU-compatible Hadamard transform (Walsh-Hadamard transform).
+
+    Applies fast Walsh-Hadamard transform recursively.
+
+    Args:
+        x: Input tensor [..., D] where D must be a power of 2
+        scale: Scaling factor (default: D ** -0.5)
+
+    Returns:
+        Transformed tensor with same shape as input
+    """
+    assert x.dtype == torch.bfloat16, "Input must be bfloat16"
+
+    hidden_size = x.size(-1)
+
+    # Check if hidden_size is power of 2
+    if (hidden_size & (hidden_size - 1)) != 0:
+        raise ValueError(f"Hidden size {hidden_size} must be a power of 2 for Hadamard transform")
+
+    if scale is None:
+        scale = hidden_size**-0.5
+
+    # Convert to float32 for computation
+    x_f32 = x.to(torch.float32)
+
+    # Flatten all dimensions except last
+    original_shape = x_f32.shape
+    x_flat = x_f32.reshape(-1, hidden_size)  # [N, D]
+
+    # Apply Hadamard transform
+    x_transformed = _hadamard_transform_recursive(x_flat)
+
+    # Scale
+    x_transformed = x_transformed * scale
+
+    # Reshape back and convert to bfloat16
+    x_transformed = x_transformed.reshape(original_shape).to(torch.bfloat16)
+
+    return x_transformed
+
+
+def _hadamard_transform_recursive(x: torch.Tensor) -> torch.Tensor:
+    """
+    Recursive implementation of Fast Walsh-Hadamard Transform.
+
+    Args:
+        x: Input tensor [N, D] where D is a power of 2
+
+    Returns:
+        Transformed tensor [N, D]
+    """
+    N, D = x.shape
+
+    if D == 1:
+        return x
+
+    # Split into two halves
+    half = D // 2
+    x_left = x[:, :half]
+    x_right = x[:, half:]
+
+    # Recursively apply to each half
+    y_left = _hadamard_transform_recursive(x_left)
+    y_right = _hadamard_transform_recursive(x_right)
+
+    # Combine: Hadamard matrix [[1, 1], [1, -1]]
+    result = torch.cat(
+        [
+            y_left + y_right,  # Top half
+            y_left - y_right,  # Bottom half
+        ],
+        dim=1,
+    )
+
+    return result
+
+
+# ===== Rotary positional embeddings (shared by Indexer + MLA) =====
+
+
+def precompute_freqs_cis(args, apply_yarn: bool = None) -> torch.Tensor:
+    """
+    Precomputes frequency-based complex exponential values for rotary positional embeddings.
+
+    Args:
+        args: Model arguments containing positional embedding parameters
+            (``qk_rope_head_dim``, ``max_seq_len``, ``beta_fast``, ``beta_slow``,
+            ``rope_theta``, ``rope_factor``, ``original_seq_len``).
+        apply_yarn: whether to apply the YaRN frequency rescaling. ``None`` (default) keeps the
+            official gate (``max_seq_len > original_seq_len``); pass ``True``/``False`` to force it.
+            The YaRN ramp itself depends only on ``original_seq_len``/``rope_factor`` — NOT
+            ``max_seq_len`` — so forcing it lets the table length (``max_seq_len``) be sized to the
+            sequence independently of whether long-context scaling is active.
+
+    Returns:
+        torch.Tensor: Precomputed complex exponential values [seq_len, rope_head_dim//2]
+    """
+    dim = args.qk_rope_head_dim
+    seqlen = args.max_seq_len
+    beta_fast = args.beta_fast
+    beta_slow = args.beta_slow
+    base = args.rope_theta
+    factor = args.rope_factor
+
+    def find_correction_dim(num_rotations, dim, base, max_seq_len):
+        """Computes the correction dimension for rotary positional embedding."""
+        return dim * math.log(max_seq_len / (num_rotations * 2 * math.pi)) / (2 * math.log(base))
+
+    def find_correction_range(low_rot, high_rot, dim, base, max_seq_len):
+        """Computes the range of correction dimensions."""
+        low = math.floor(find_correction_dim(low_rot, dim, base, max_seq_len))
+        high = math.ceil(find_correction_dim(high_rot, dim, base, max_seq_len))
+        return max(low, 0), min(high, dim - 1)
+
+    def linear_ramp_factor(min_val, max_val, dim):
+        """Computes a linear ramp function for smoothing."""
+        if min_val == max_val:
+            max_val += 0.001
+        linear_func = (torch.arange(dim, dtype=torch.float32) - min_val) / (max_val - min_val)
+        ramp_func = torch.clamp(linear_func, 0, 1)
+        return ramp_func
+
+    # Compute base frequencies
+    freqs = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+
+    # Apply correction for extended sequence lengths (YaRN). The gate is on max_seq_len by default
+    # (official behaviour); callers that size the table to a short sequence but still want the model's
+    # long-context scaling pass apply_yarn=True.
+    do_yarn = (seqlen > args.original_seq_len) if apply_yarn is None else apply_yarn
+    if do_yarn:
+        low, high = find_correction_range(beta_fast, beta_slow, dim, base, args.original_seq_len)
+        smooth = 1 - linear_ramp_factor(low, high, dim // 2)
+        freqs = freqs / factor * (1 - smooth) + freqs * smooth
+
+    # Create position indices and compute outer product
+    t = torch.arange(seqlen)
+    freqs = torch.outer(t, freqs)  # [seq_len, rope_head_dim//2]
+
+    # Convert to complex exponentials
+    freqs_cis = torch.polar(torch.ones_like(freqs), freqs)
+
+    return freqs_cis
+
+
+def apply_rotary_emb(x: torch.Tensor, freqs_cis: torch.Tensor, interleaved: bool = True) -> torch.Tensor:
+    """
+    Applies rotary positional embeddings.
+
+    Args:
+        x: Input tensor
+        freqs_cis: Precomputed complex exponential values
+        interleaved: Whether to use interleaved format (MLA uses True, the
+            Indexer uses False)
+
+    Returns:
+        Tensor with rotary embeddings applied
+    """
+    dtype = x.dtype
+    shape = x.shape
+    if not interleaved:
+        x = x.view(*shape[:-1], 2, -1).transpose(-1, -2).contiguous()
+    x = torch.view_as_complex(x.float().view(*shape[:-1], -1, 2))
+    freqs_cis = freqs_cis.view(1, x.size(1), 1, x.size(-1))
+    y = torch.view_as_real(x * freqs_cis).flatten(3)
+    if not interleaved:
+        y = torch.cat([y[..., 0::2], y[..., 1::2]], dim=-1)
+    return y.to(dtype)

--- a/models/demos/deepseek_v3_d_p/reference/cpu_deepseek_v32/weights.py
+++ b/models/demos/deepseek_v3_d_p/reference/cpu_deepseek_v32/weights.py
@@ -1,0 +1,212 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Weight initialization and loading for the CPU reference layers (``IndexerCPU`` /
+``MLACPU`` in ``model.py``).
+
+Two entry points, both via the free function ``initialize_weights(module, ...)``:
+  * random init (default) — normal(0, 0.02) on every ``Linear``; norms keep ones.
+  * pretrained load — read a layer's attention tensors from DeepSeek-V3.2-Exp
+    safetensors shard file(s), map HF (transformers-style) names to our module
+    names (mirrors ``inference/convert.py``), and dequantize fp8 → bf16.
+
+Pretrained shards are fetched just-in-time (and cached) by ``load_pretrained_hf`` /
+``resolve_layer_shards``. This module depends on ``model.py`` (for the module/layer
+types); ``model.py`` does not import it, so there is no circular import.
+"""
+
+import torch
+import torch.nn as nn
+from loguru import logger
+
+from models.demos.deepseek_v3_d_p.reference.cpu_deepseek_v32.model import BLOCK_SIZE, IndexerCPU, Linear
+
+DEFAULT_REPO = "deepseek-ai/DeepSeek-V3.2-Exp"
+_INDEX_FILE = "model.safetensors.index.json"
+
+# Single source of truth for MLA/indexer weight naming across the conventions in play:
+#   * canonical / device  — what ttMLA + SparseMLAReference consume. Equals the HF-checkpoint name for
+#     every tensor EXCEPT the indexer LayerNorm bias, which the device keeps as a separate
+#     ``indexer.k_norm_bias.weight`` tensor (γ and β split), where the checkpoint/CPU store it as the
+#     LayerNorm's native ``indexer.k_norm.bias``.
+#   * CPU port            — MLACPU/IndexerCPU module parameter names (``wq_a``, ``q_norm``, ...).
+# CANONICAL_TO_CPU is the authority; the HF-checkpoint reader map (_HF_TO_MLA) is derived from it.
+CANONICAL_TO_CPU = {
+    "q_a_proj.weight": "wq_a.weight",
+    "q_a_layernorm.weight": "q_norm.weight",
+    "q_b_proj.weight": "wq_b.weight",
+    "kv_a_proj_with_mqa.weight": "wkv_a.weight",
+    "kv_a_layernorm.weight": "kv_norm.weight",
+    "kv_b_proj.weight": "wkv_b.weight",
+    "o_proj.weight": "wo.weight",
+    "indexer.wq_b.weight": "indexer.wq_b.weight",
+    "indexer.wk.weight": "indexer.wk.weight",
+    "indexer.k_norm.weight": "indexer.k_norm.weight",
+    "indexer.k_norm_bias.weight": "indexer.k_norm.bias",
+    "indexer.weights_proj.weight": "indexer.weights_proj.weight",
+}
+
+# HF (transformers-style) submodule name -> CPU param prefix, derived from CANONICAL_TO_CPU (mirrors
+# inference/convert.py). The HF-checkpoint key equals the canonical key for every tensor except the
+# indexer LayerNorm bias, which rides under the ``indexer.k_norm`` submodule (so it's excluded here —
+# its prefix already comes from the ``indexer.k_norm.weight`` row). fp8 weights carry a companion
+# ``*.weight_scale_inv``.
+_HF_TO_MLA = {
+    canon[: -len(".weight")]: cpu[: -len(".weight")]
+    for canon, cpu in CANONICAL_TO_CPU.items()
+    if canon != "indexer.k_norm_bias.weight"
+}
+
+
+def _dequant_fp8(weight: torch.Tensor, scale_inv: torch.Tensor, block: int = BLOCK_SIZE) -> torch.Tensor:
+    """
+    Reconstruct a bf16 weight from a blockwise fp8 (e4m3) checkpoint tensor and
+    its per-(block x block) scale, matching model.py:weight_dequant. ``scale_inv``
+    has shape ``[ceil(O/block), ceil(I/block)]``.
+    """
+    w = weight.float()
+    s = scale_inv.repeat_interleave(block, 0)[: w.shape[0]].repeat_interleave(block, 1)[:, : w.shape[1]]
+    return (w * s).to(torch.bfloat16)
+
+
+def load_attention_state_dict(shard_paths, layer: int) -> dict:
+    """
+    Read one transformer layer's attention (MLA + indexer) tensors from the given
+    DeepSeek-V3.2-Exp safetensors shard file(s) and return a state dict keyed to
+    ``MLACPU``'s parameter names (indexer params keep the ``indexer.`` prefix).
+
+    fp8 weights are dequantized to bf16; norms and the indexer's ``weights_proj``
+    are cast to fp32 to match the module dtypes. Shard paths come from
+    ``resolve_layer_shards`` (which downloads on demand).
+    """
+    from safetensors import safe_open
+
+    if isinstance(shard_paths, str):
+        shard_paths = [shard_paths]
+    prefix = f"model.layers.{layer}.self_attn."
+    state = {}
+    for path in shard_paths:
+        with safe_open(path, framework="pt", device="cpu") as f:
+            for k in (k for k in f.keys() if k.startswith(prefix)):
+                if k.endswith(".weight_scale_inv"):
+                    continue
+                sub, field = k[len(prefix) :].rsplit(".", 1)  # ("q_a_proj","weight") / ("indexer.wk","weight")
+                if sub not in _HF_TO_MLA:
+                    continue
+                t = f.get_tensor(k)
+                if t.dtype == torch.float8_e4m3fn:
+                    t = _dequant_fp8(t, f.get_tensor(k.replace(".weight", ".weight_scale_inv")))
+                key = f"{_HF_TO_MLA[sub]}.{field}"
+                # Match module dtypes: norms + weights_proj fp32, linear weights bf16.
+                t = t.float() if ("norm" in key or "weights_proj" in key) else t.to(torch.bfloat16)
+                state[key] = t
+    if not state:
+        raise ValueError(f"No layer-{layer} attention tensors found in {shard_paths}.")
+    return state
+
+
+def _check_pretrained_load(missing, unexpected, what: str):
+    """Validate a strict=False load_state_dict result for a pretrained load."""
+    if missing:
+        raise RuntimeError(f"{what}: parameters missing from checkpoint: {missing}")
+    if unexpected:
+        logger.warning(f"{what}: ignoring unexpected checkpoint keys: {unexpected}")
+
+
+def init_random(module: nn.Module):
+    """
+    Random-init every ``Linear`` in ``module`` (normal 0, 0.02); norms keep their
+    default (ones) value. Works for both ``IndexerCPU`` and ``MLACPU`` (whose walk
+    also covers the nested indexer, in registration order).
+    """
+    name = type(module).__name__
+    logger.info(f"Initializing {name} weights randomly for testing")
+    for _, m in module.named_modules():
+        if isinstance(m, Linear):
+            nn.init.normal_(m.weight, mean=0.0, std=0.02)
+            if m.bias is not None:
+                nn.init.normal_(m.bias, mean=0.0, std=0.02)
+    logger.info(f"✓ {name} random weight initialization complete")
+
+
+def load_pretrained(module: nn.Module, shard_paths, layer: int = 0):
+    """
+    Load pretrained weights for ``layer`` into ``module`` from DeepSeek-V3.2-Exp
+    safetensors shard file(s). ``MLACPU`` gets MLA + nested indexer; a standalone
+    ``IndexerCPU`` gets just the indexer tensors (``indexer.`` prefix stripped).
+    """
+    name = type(module).__name__
+    logger.info(f"Loading pretrained {name} weights (layer {layer}) from {shard_paths}")
+    sd = load_attention_state_dict(shard_paths, layer)
+    if isinstance(module, IndexerCPU):
+        sd = {k[len("indexer.") :]: v for k, v in sd.items() if k.startswith("indexer.")}
+    missing, unexpected = module.load_state_dict(sd, strict=False)
+    _check_pretrained_load(missing, unexpected, f"{name} layer {layer}")
+    logger.info(f"✓ Loaded pretrained {name} weights")
+
+
+def initialize_weights(
+    module: nn.Module,
+    layer: int = None,
+    checkpoint_path=None,
+    repo: str = DEFAULT_REPO,
+    token: str = None,
+    local_files_only: bool = False,
+):
+    """
+    The single weight-init entry point. Modes:
+
+    * **random** (default) — neither ``layer`` nor ``checkpoint_path`` given.
+    * **pretrained from HF** — ``layer`` given: resolve + (JIT) download that layer's
+      shard(s) and load them. ``local_files_only=True`` uses the cache only and raises
+      ``LocalEntryNotFoundError`` if a shard is absent (so callers can skip).
+    * **pretrained from a local shard** — ``checkpoint_path`` (a shard path or list)
+      for ``layer`` (default 0); takes precedence over HF resolution.
+    """
+    if checkpoint_path is not None:
+        load_pretrained(module, checkpoint_path, layer or 0)
+    elif layer is not None:
+        load_pretrained_hf(module, layer, repo, token, local_files_only)
+    else:
+        init_random(module)
+
+
+def resolve_layer_shards(layer: int = 0, repo: str = DEFAULT_REPO, token: str = None, local_files_only: bool = False):
+    """
+    Return local path(s) to the safetensors shard(s) that hold ``layer``'s attention
+    (MLA + indexer) weights. Missing files are downloaded just-in-time, in full, via
+    ``hf_hub_download`` (cached, atomic) — a warning is emitted first since the shards
+    are multi-GB. With ``local_files_only=True`` only cached files are used and
+    ``LocalEntryNotFoundError`` is raised if a shard is absent.
+    """
+    import json
+
+    from huggingface_hub import hf_hub_download, try_to_load_from_cache
+
+    index = hf_hub_download(repo, _INDEX_FILE, token=token, local_files_only=local_files_only)
+    weight_map = json.load(open(index))["weight_map"]
+    prefix = f"model.layers.{layer}.self_attn."
+    shards = sorted({weight_map[k] for k in weight_map if k.startswith(prefix)})
+    if not shards:
+        raise ValueError(f"No attention tensors for layer {layer} in {repo} index.")
+
+    if not local_files_only:
+        missing = [s for s in shards if not isinstance(try_to_load_from_cache(repo, s), str)]
+        if missing:
+            logger.warning(
+                f"Downloading {len(missing)} shard(s) for layer {layer} from {repo} "
+                f"({', '.join(missing)}); this can take a while — the shards are multi-GB."
+            )
+    return [hf_hub_download(repo, s, token=token, local_files_only=local_files_only) for s in shards]
+
+
+def load_pretrained_hf(
+    module: nn.Module, layer: int = 0, repo: str = DEFAULT_REPO, token: str = None, local_files_only: bool = False
+):
+    """
+    Resolve (downloading if needed) and load ``layer``'s pretrained weights from the
+    DeepSeek-V3.2-Exp HF repo into ``module``. Convenience wrapper over
+    ``resolve_layer_shards`` + ``load_pretrained``.
+    """
+    load_pretrained(module, resolve_layer_shards(layer, repo, token, local_files_only), layer)

--- a/models/demos/deepseek_v3_d_p/reference/deepseek_v3_2_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/deepseek_v3_2_config.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+DeepSeek-V3.2-Exp model configuration.
+
+Single source of truth for the V3.2 HF-attribute config the unified ttMLA reads. Built directly
+rather than via AutoConfig: V3.2's `model_type` is `deepseek_v32` (architecture
+`DeepseekV32ForCausalLM`) and needs trust_remote_code, which we avoid here — and, unlike a borrowed
+DeepSeek-V3 / R1 config, this one actually carries the DSA fields so the sparse resolver detects it.
+
+V3.2 shares every MLA dimension and the YaRN RoPE with DeepSeek-V3 / R1, and adds the lightning
+indexer (index_n_heads / index_head_dim / index_topk; non-interleaved indexer RoPE). Values are from
+the HF config.json: https://huggingface.co/deepseek-ai/DeepSeek-V3.2-Exp/blob/main/config.json
+"""
+
+import types
+
+
+class DeepseekV32Config:
+    """DeepSeek-V3.2-Exp model dimensions (from HF config.json)."""
+
+    # Core dimensions
+    EMB_SIZE = 7168  # hidden_size
+    INTERMEDIATE_SIZE = 18432  # dense FFN hidden dimension
+    MOE_INTERMEDIATE_SIZE = 2048  # MoE FFN hidden dimension
+
+    # MoE configuration
+    NUM_ROUTED_EXPERTS = 256
+    NUM_EXPERTS_PER_TOKEN = 8
+    NUM_SHARED_EXPERTS = 1
+
+    # Model architecture
+    NUM_LAYERS = 61
+    NUM_DENSE_LAYERS = 3  # first_k_dense_replace
+    VOCAB_SIZE = 129280
+    MAX_POSITION_EMBEDDINGS = 163840
+
+    # MLA dimensions (identical to DeepSeek-V3 / R1)
+    NUM_ATTENTION_HEADS = 128
+    Q_LORA_RANK = 1536
+    KV_LORA_RANK = 512
+    QK_NOPE_HEAD_DIM = 128
+    QK_ROPE_HEAD_DIM = 64
+    V_HEAD_DIM = 128
+
+    # Indexer / sparse attention (DSA)
+    INDEX_TOPK = 2048
+    INDEX_HEAD_DIM = 128
+    INDEX_N_HEADS = 64
+    INDEX_ROPE_INTERLEAVE = False  # DeepSeek indexer RoPE is non-interleaved (rotate_half)
+
+    # RoPE / YaRN (factor > 1 → YaRN active, same as DeepSeek-V3 / R1)
+    RMS_NORM_EPS = 1e-6
+    ROUTE_SCALE = 2.5
+    ROPE_THETA = 10000.0
+    ROPE_FACTOR = 40
+    ORIGINAL_SEQ_LEN = 4096  # rope_scaling.original_max_position_embeddings
+    BETA_FAST = 32
+    BETA_SLOW = 1
+    MSCALE = 1.0
+    MSCALE_ALL_DIM = 1.0
+
+    # Other
+    INITIALIZER_RANGE = 0.02
+
+
+def deepseek_v32_hf_config(max_seq: int = 16384):
+    """HF-attribute-style config the unified ttMLA reads (DeepSeek-V3.2 dims + YaRN + DSA indexer).
+
+    Mirrors `glm_hf_config()`. YaRN is active (`rope_factor=40 > 1`): the device runs YaRN with
+    `original_max_position_embeddings=4096`, identical to DeepSeek-V3 / R1. The four `index_*` attrs
+    configure the DSA lightning indexer (non-interleaved RoPE, vs GLM's interleaved). `has_indexer=True`
+    marks the layer sparse so the cache/loading resolver (`resolve_has_indexer`) detects it without
+    relying on host weights or a built cache. The sparse-MLA CPU reference derives its `ModelArgs` from
+    this same config (reference.cpu_deepseek_v32), so the device and the truth share one source of dims.
+    """
+    return types.SimpleNamespace(
+        hidden_size=DeepseekV32Config.EMB_SIZE,
+        num_attention_heads=DeepseekV32Config.NUM_ATTENTION_HEADS,
+        num_key_value_heads=DeepseekV32Config.NUM_ATTENTION_HEADS,
+        kv_lora_rank=DeepseekV32Config.KV_LORA_RANK,
+        q_lora_rank=DeepseekV32Config.Q_LORA_RANK,
+        qk_nope_head_dim=DeepseekV32Config.QK_NOPE_HEAD_DIM,
+        qk_rope_head_dim=DeepseekV32Config.QK_ROPE_HEAD_DIM,
+        v_head_dim=DeepseekV32Config.V_HEAD_DIM,
+        rms_norm_eps=DeepseekV32Config.RMS_NORM_EPS,
+        max_seq_len=max_seq,
+        rope_theta=float(DeepseekV32Config.ROPE_THETA),
+        attention_bias=False,
+        initializer_range=DeepseekV32Config.INITIALIZER_RANGE,
+        rope_scaling={
+            "factor": DeepseekV32Config.ROPE_FACTOR,
+            "mscale": DeepseekV32Config.MSCALE,
+            "mscale_all_dim": DeepseekV32Config.MSCALE_ALL_DIM,
+            "beta_fast": DeepseekV32Config.BETA_FAST,
+            "beta_slow": DeepseekV32Config.BETA_SLOW,
+            "original_max_position_embeddings": DeepseekV32Config.ORIGINAL_SEQ_LEN,
+        },
+        index_n_heads=DeepseekV32Config.INDEX_N_HEADS,
+        index_head_dim=DeepseekV32Config.INDEX_HEAD_DIM,
+        index_topk=DeepseekV32Config.INDEX_TOPK,
+        index_rope_interleave=DeepseekV32Config.INDEX_ROPE_INTERLEAVE,
+        has_indexer=True,
+    )

--- a/models/demos/deepseek_v3_d_p/reference/glm_5_1_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/glm_5_1_config.py
@@ -9,6 +9,8 @@ Single source of truth for model dimension constants.
 Values from HuggingFace config.json for GLM-5.1.
 """
 
+import types
+
 
 class GLM51Config:
     """GLM 5.1 model dimensions."""
@@ -49,3 +51,40 @@ class GLM51Config:
     RMS_NORM_EPS = 1e-5
     ROUTE_SCALE = 2.5
     ROPE_THETA = 1000000
+
+
+def glm_hf_config(max_seq: int = 8192):
+    """HF-attribute-style config the unified ttMLA reads (GLM dims, no YaRN).
+
+    Built directly rather than via AutoConfig: GLM's model_type (`glm_moe_dsa`) is not
+    registered with transformers, so AutoConfig cannot load it. `rope_scaling.factor=1.0`
+    disables both the YaRN frequency scaling and the mscale² softmax correction → plain
+    RoPE at θ=1e6 with scale = qk_head_dim**-0.5. The four `index_*` attrs configure the
+    DSA indexer (GLM's indexer RoPE is interleaved; DeepSeek's is not).
+    """
+    return types.SimpleNamespace(
+        hidden_size=GLM51Config.EMB_SIZE,
+        num_attention_heads=GLM51Config.NUM_ATTENTION_HEADS,
+        num_key_value_heads=GLM51Config.NUM_ATTENTION_HEADS,
+        kv_lora_rank=GLM51Config.KV_LORA_RANK,
+        q_lora_rank=GLM51Config.Q_LORA_RANK,
+        qk_nope_head_dim=GLM51Config.QK_NOPE_HEAD_DIM,
+        qk_rope_head_dim=GLM51Config.QK_ROPE_HEAD_DIM,
+        v_head_dim=GLM51Config.V_HEAD_DIM,
+        rms_norm_eps=GLM51Config.RMS_NORM_EPS,
+        max_seq_len=max_seq,
+        rope_theta=float(GLM51Config.ROPE_THETA),
+        attention_bias=False,
+        rope_scaling={
+            "factor": 1.0,
+            "mscale": 1.0,
+            "mscale_all_dim": 0.0,
+            "beta_fast": 32,
+            "beta_slow": 1,
+            "original_max_position_embeddings": max_seq,
+        },
+        index_n_heads=GLM51Config.INDEX_N_HEADS,
+        index_head_dim=GLM51Config.INDEX_HEAD_DIM,
+        index_topk=GLM51Config.INDEX_TOPK,
+        index_rope_interleave=True,
+    )

--- a/models/demos/deepseek_v3_d_p/tests/conftest.py
+++ b/models/demos/deepseek_v3_d_p/tests/conftest.py
@@ -422,6 +422,12 @@ def _resolve_hf_config(model_path_str: str):
 @lru_cache(maxsize=None)
 def _resolve_config_only(variant_name: str):
     v = TEST_VARIANTS[variant_name]
+    # Hand-built config takes precedence: some models (e.g. GLM-5.1 `glm_moe_dsa`, DeepSeek-V3.2
+    # `deepseek_v32`) are not registered with transformers, so AutoConfig cannot load them. The builder
+    # returns a ready HF-attribute config. (Result is lru_cached like the AutoConfig path; tests that
+    # mutate config.max_seq_len already rely on this shared/cached object.)
+    if v.config_builder is not None:
+        return v.config_builder()
     # Check environment variable first
     env_path = os.getenv(v.env_var)
     if env_path:

--- a/models/demos/deepseek_v3_d_p/tests/model_variants.py
+++ b/models/demos/deepseek_v3_d_p/tests/model_variants.py
@@ -15,12 +15,14 @@ to `TEST_VARIANTS`.
 """
 
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3Attention as DSv3RefAttention
 from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3Model as DSv3RefModel
 from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3MoE as DSv3RefMoE
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_2_config import deepseek_v32_hf_config
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
+from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config, glm_hf_config
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6.modeling_deepseek import DeepseekV3Attention as KimiRefAttention
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6.modeling_deepseek import DeepseekV3Model as KimiRefModel
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6.modeling_deepseek import DeepseekV3MoE as KimiRefMoE
@@ -52,6 +54,7 @@ class TestVariant:
         supports_pretrained: bool = True,
         prefill_trace_default: Optional[str] = None,
         prefill_trace_layout: str = "single_file",
+        config_builder: Optional[Callable[[], object]] = None,
     ) -> None:
         self.name = name
         self.env_var = env_var
@@ -76,6 +79,13 @@ class TestVariant:
         # or "chunked_group_a_v1" (Kimi — each tensor a directory of row-sharded rows_<s>_<e>.safetensors,
         # hidden_states/ -> decoder_io/). The chunked trace readers in the tests dispatch on this.
         self.prefill_trace_layout = prefill_trace_layout
+        # --- DSA (Deepseek Sparse Attention) capabilities -------------------------------------------
+        # Per-variant behaviour branches on these fields (data-driven), not on `name`.
+        # config_builder: returns a ready HF-attribute config when AutoConfig cannot load the model
+        # (GLM's model_type `glm_moe_dsa` is unregistered). When set, it overrides the disk/HF
+        # resolution path in conftest, and is also the single source the sparse-MLA CPU reference
+        # derives its ModelArgs from (see reference.cpu_deepseek_v32). None = resolve via AutoConfig.
+        self.config_builder = config_builder
 
 
 DSV3 = TestVariant(
@@ -120,4 +130,58 @@ KIMI_V2_6 = TestVariant(
     prefill_trace_layout="chunked_group_a_v1",
 )
 
-TEST_VARIANTS = {v.name: v for v in [DSV3, KIMI_V2_6]}
+DSV32 = TestVariant(
+    name="deepseek_v32",
+    env_var="DEEPSEEK_V32_HF_MODEL",
+    # V3.2-Exp config is hand-built (deepseek_v32_hf_config), like GLM: model_type `deepseek_v32` needs
+    # trust_remote_code via AutoConfig, and — unlike a borrowed R1 config — the hand-built one carries
+    # the DSA index_* fields so the sparse resolver (TtIndexer.matches_config) detects it. MLA dims +
+    # YaRN match R1; the indexer is non-interleaved. hf_repo_id is the real V3.2-Exp repo (used only by
+    # the pretrained path below + as the DEEPSEEK_V32_HF_MODEL override target).
+    hf_repo_id="deepseek-ai/DeepSeek-V3.2-Exp",
+    # model_config: a dims class read only by the full-transformer / prefill tests (NUM_DENSE_LAYERS,
+    # NUM_ROUTED_EXPERTS). Kept as DeepSeekV3Config because V3.2 shares R1's MoE dims (256 experts, 3
+    # dense layers). Swap for a V3.2 dims class if/when a V3.2 full-transformer path is wired.
+    model_config=DeepSeekV3Config,
+    # config the device runs on: the hand-built V3.2 HF-attribute config (DSA index_* + YaRN). This is
+    # what config_only resolves to for V3.2 (conftest short-circuits to config_builder).
+    config_builder=deepseek_v32_hf_config,
+    # The MLA truth is MLACPU (the "mlacpu" sparse reference) with random/CPU weights, so the sparse
+    # tests never load pretrained HF weights — the pretrained path is disabled.
+    supports_pretrained=False,
+    # --- Pretrained-weight resolution (DISABLED) -------------------------------------------------
+    # These locate an on-disk HF checkout (config.json + safetensors index + shards) for the pretrained
+    # path; order is env_var -> default_local_path -> shared_path -> download hf_repo_id.
+    # num_layers_to_download bounds the HF download to the first N layers' shards (+embeddings+norm), so
+    # the full ~600GB model isn't pulled. All unused while supports_pretrained=False. To enable a V3.2
+    # pretrained / full-model path: set supports_pretrained=True, point these at a real DeepSeek-V3.2-Exp
+    # checkout (NOT an R1 one — V3.2 ships the indexer weights R1 lacks), and add a test that requests
+    # the pretrained_transformer_weights / state_dict / model_path fixtures.
+    # default_local_path=Path("/path/to/DeepSeek-V3.2-Exp"),
+    # shared_path=Path("/proj_sw/user_dev/deepseek-ai/DeepSeek-V3.2-Exp"),
+    # num_layers_to_download=24,
+    # Block / full-model parity is out of P0 scope; the MLA truth comes from MLACPU, not HF attn.
+    reference_model_cls=None,
+    reference_attention_cls=None,
+    reference_moe_cls=None,
+    mla_ref_cache_env="DEEPSEEK_V32_MLA_REF_CACHE",
+    mla_pcc_threshold=0.996,
+)
+
+GLM51 = TestVariant(
+    name="glm_5_1",
+    env_var="GLM51_HF_MODEL",
+    hf_repo_id="zai-org/GLM-5.1",
+    model_config=GLM51Config,
+    # No HF pretrained_transformer_weights path: GLM ships per-layer shards and its MLA dims
+    # (nope=192, v=256) differ from the dequant fixture's assumptions. Config is hand-built.
+    supports_pretrained=False,
+    reference_model_cls=None,
+    reference_attention_cls=None,
+    reference_moe_cls=None,
+    mla_ref_cache_env="GLM51_MLA_REF_CACHE",
+    mla_pcc_threshold=0.995,
+    config_builder=glm_hf_config,
+)
+
+TEST_VARIANTS = {v.name: v for v in [DSV3, KIMI_V2_6, DSV32, GLM51]}

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/conftest.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/conftest.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Sparse-MLA (DSA) suite conftest. Registering the plugin HERE — instead of in the shared tests/
+# conftest — scopes its perf/trace markers and the --ds-* MLA/indexer knobs to this subtree: they are
+# only registered when the sparse tests are collected, so dense runs (e.g. tests/test_mla.py) never see
+# them. Fixtures from the parent tests/ conftest (variant, config_only, mesh_device) still apply here.
+pytest_plugins = ["models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_plugin"]

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/sparse_mla_mesh.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/sparse_mla_mesh.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Hardware-adaptive mesh parametrization for the DeepSeek V3.2 device tests.
+
+The tests are written for a `mesh_device` whose shape is ``(sp_size, tp_size)``
+(``sp_axis, tp_axis = 0, 1``). Which shapes are valid depends on the box the
+suite runs on, so instead of hard-coding ``[(1, 4), (2, 2)]`` every test pulls
+its parametrization from here:
+
+    QuietBox  (4 chips):  single chip, TP=4,        SP=2 × TP=2
+    LoudBox   (8 chips):  SP=8,        SP=4 × TP=2,  SP=2 × TP=4
+    Galaxy   (32 chips):  SP=8 × TP=4   (production layout)
+
+Detection mirrors ``tests/nightly/sdpa_perf_utils.MeshConfig.detect()``: it
+counts ``/dev/tenstorrent/*`` device nodes WITHOUT opening them, so it is safe to
+call at pytest-collection time (no device locks, no subprocess interference).
+
+We key the shape sets on the EXACT device count rather than emitting every shape
+that "fits". A multi-chip shape smaller than the physical box opens a sub-mesh,
+which the runtime does not reliably support (see the warning in the top-level
+``mesh_device`` fixture), and exact-match also makes each box exercise all of its
+silicon instead of an arbitrary corner of it.
+"""
+
+import glob
+import os
+
+import pytest
+
+
+def detect_num_devices() -> int:
+    """Number of TT devices, counted from /dev/tenstorrent/* without opening them.
+
+    Device nodes are numeric (/dev/tenstorrent/0, .../1, ...); filtering to those
+    avoids miscounting sibling entries such as the ``by-id/`` directory.
+    """
+    return len([p for p in glob.glob("/dev/tenstorrent/*") if os.path.basename(p).isdigit()])
+
+
+# (sp_size, tp_size) shapes per box, keyed by exact physical device count.
+# In production (Galaxy) the layout is TP=4, SP=8.
+MESH_SHAPES_BY_DEVICE_COUNT = {
+    1: [(1, 1)],  # single chip
+    4: [(1, 1), (1, 4), (2, 2)],  # QuietBox: single, TP=4, SP2×TP2
+    8: [(8, 1), (4, 2), (2, 4)],  # LoudBox: SP=8, SP4×TP2, SP2×TP4
+    32: [(8, 4)],  # Galaxy (prod): SP=8, TP=4
+}
+
+# The kvpe cache is ND-sharded in 32-token DRAM-bank chunks
+# (kv_cache_utils.NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK). With fewer than two chunks per
+# SP shard the cache collapses to a layout the update_cache op rejects, so a
+# per-chip sequence below this is degenerate (e.g. seq256 over SP=8 → 32 tok/chip).
+KVPE_MIN_TOKENS_PER_CHIP = 64
+
+
+def skip_if_seq_too_small_for_sp(seq_len: int, mesh_device) -> None:
+    """Skip when SP-sharding `seq_len` leaves too few tokens/chip for the kvpe cache."""
+    sp = list(mesh_device.shape)[0]
+    local = seq_len // sp
+    if local < KVPE_MIN_TOKENS_PER_CHIP:
+        pytest.skip(
+            f"seq_len {seq_len} over SP={sp} → {local} tokens/chip "
+            f"(< {KVPE_MIN_TOKENS_PER_CHIP}); kvpe ND-shard cache needs ≥2 DRAM-bank chunks per shard"
+        )
+
+
+def _shape_id(shape) -> str:
+    """Stable pytest id for a (sp, tp) shape, e.g. (2, 4) -> 'sp2xtp4'."""
+    sp, tp = shape
+    return f"sp{sp}xtp{tp}"
+
+
+def supported_mesh_shapes(num_devices: int = None):
+    """(shapes, ids) — SP×TP shape set for the detected box.
+
+    Unknown box: a single pure-TP plane spanning every chip, so the suite still runs (and is
+    clearly labelled) on non-standard machines.
+    """
+    if num_devices is None:
+        num_devices = detect_num_devices()
+    shapes = MESH_SHAPES_BY_DEVICE_COUNT.get(num_devices) or [(1, max(num_devices, 1))]
+    return shapes, [_shape_id(s) for s in shapes]
+
+
+def parametrize_mesh_device():
+    """`@parametrize_mesh_device()` — indirect `mesh_device` over the box's SP×TP shapes.
+
+    Drop-in for ``@pytest.mark.parametrize("mesh_device", [...], indirect=True)``;
+    the shape set is chosen from the hardware at collection time.
+    """
+    shapes, ids = supported_mesh_shapes()
+    return pytest.mark.parametrize("mesh_device", shapes, ids=ids, indirect=True)

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/sparse_mla_plugin.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/sparse_mla_plugin.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Pytest plugin for the sparse-MLA (DSA) tests — DeepSeek V3.2 & GLM-5.1.
+
+This is a real plugin module (NOT a conftest), registered via ``pytest_plugins`` in this package's
+conftest (``tests/sparse_mla/conftest.py``). Living under the sparse_mla/ subtree scopes its options
+and markers: they register only when these sparse tests are collected, so dense runs (tests/test_mla.py)
+never see them. Because it is referenced by its dotted name and never auto-loaded as a conftest, pytest
+registers it exactly once.
+
+It carries what the sparse suites must share: the ``perf`` / ``trace`` markers (for the out-of-band
+suites that run separately from the fast correctness matrix) and the ``--ds-*`` MLA/indexer knobs with
+their ``ds_*`` fixtures.
+"""
+
+import re
+
+import pytest
+
+
+def is_marker_explicitly_selected(config, marker: str) -> bool:
+    markexpr = getattr(config.option, "markexpr", "") or ""
+    token = re.escape(marker)
+    selected = re.search(rf"(^|[\s()]){token}($|[\s()])", markexpr)
+    negated = re.search(rf"(^|[\s()])not\s+{token}($|[\s()])", markexpr)
+    return bool(selected and not negated)
+
+
+def pytest_configure(config):
+    """Register the markers for tests that run SEPARATELY from the default correctness matrix.
+
+    The sparse-MLA correctness suite (test_sparse_mla.py) is small/fast enough (~2 min) to run
+    wholesale, so it carries no tier/intent markers. Only the out-of-band suites are marked, so CI can
+    exclude them with e.g. -m "not perf and not trace".
+    """
+    for line in (
+        "perf: per-op device-kernel timing (run under tracy, separate from correctness)",
+        "trace: official trace-bundle parity tests (run separately from the correctness matrix)",
+    ):
+        config.addinivalue_line("markers", line)
+
+
+def pytest_addoption(parser):
+    """DSA (V3.2 / GLM) MLA/indexer test knobs: weights source + input data."""
+    g = parser.getgroup("deepseek_dsa")
+    g.addoption(
+        "--ds-layer",
+        type=int,
+        default=None,
+        help="Pretrained transformer layer to load into MLA/indexer (default: random weights).",
+    )
+    g.addoption(
+        "--ds-checkpoint",
+        default=None,
+        help="Local safetensors shard path(s), comma-separated; overrides HF resolution for --ds-layer.",
+    )
+    g.addoption(
+        "--ds-repo",
+        default=None,
+        help="HF repo for pretrained weights (default: deepseek-ai/DeepSeek-V3.2-Exp).",
+    )
+    g.addoption(
+        "--ds-input",
+        default=None,
+        help="Path to a .pt file with the MLA/indexer input hidden states [..., seq, hidden]; "
+        "default is deterministic randn(seed).",
+    )
+    g.addoption(
+        "--ds-kpe-layout",
+        choices=["interleaved", "vllm"],
+        default="interleaved",
+        help="k_pe RoPE layout for the KV-cache reference comparison (test_sparse_mla_vs_trace.py). "
+        "'interleaved' (default): our/official layout — assert latent PCC + frame-invariant k_pe L2. "
+        "'vllm': reindex our k_pe to vLLM's half-split layout and assert element-wise PCC (cross-stack).",
+    )
+
+
+@pytest.fixture
+def ds_layer(request):
+    return request.config.getoption("--ds-layer")
+
+
+@pytest.fixture
+def ds_checkpoint(request):
+    val = request.config.getoption("--ds-checkpoint")
+    if not val:
+        return None
+    paths = [p for p in val.split(",") if p]
+    return paths[0] if len(paths) == 1 else paths
+
+
+@pytest.fixture
+def ds_repo(request):
+    return request.config.getoption("--ds-repo")
+
+
+@pytest.fixture
+def ds_input(request):
+    return request.config.getoption("--ds-input")
+
+
+@pytest.fixture
+def ds_kpe_layout(request):
+    return request.config.getoption("--ds-kpe-layout")

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/sparse_mla_reference.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/sparse_mla_reference.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Test-side glue around the sparse-MLA CPU reference package (`reference.cpu_deepseek_v32`).
+
+The package owns the model + weights API (see its `API_SPEC.md`): a single canonical weights dict
+(HF naming) constructs both `ttMLA` and `SparseMLAReference`, so device and truth are bit-identical
+and PCC is meaningful. This module only adds what's specific to the test harness: deterministic input
+generation, the per-variant disk cache for reference outputs, and a small weight-source helper.
+"""
+
+import os
+from pathlib import Path
+
+import torch
+from loguru import logger
+
+from models.demos.deepseek_v3_d_p.reference.cpu_deepseek_v32 import (
+    CANONICAL_WEIGHT_NAMES,
+    SparseMLAReference,
+    Weights,
+    pretrained_mla_weights,
+    random_mla_weights,
+)
+from models.demos.deepseek_v3_d_p.tt.mla.indexer import INDEXER_WEIGHT_NAMES
+
+# Boundary check: the package's canonical indexer weight names must match the ttnn contract
+# (TtIndexer.WEIGHT_NAMES), so a device-side rename surfaces here instead of drifting silently.
+_CONTRACT_INDEXER_KEYS = frozenset(f"{n}.weight" for n in INDEXER_WEIGHT_NAMES)
+_EMITTED_INDEXER_KEYS = frozenset(k for k in CANONICAL_WEIGHT_NAMES if k.startswith("indexer."))
+assert _EMITTED_INDEXER_KEYS == _CONTRACT_INDEXER_KEYS, (
+    f"canonical indexer keys drifted from TtIndexer.WEIGHT_NAMES: "
+    f"{sorted(_EMITTED_INDEXER_KEYS)} != {sorted(_CONTRACT_INDEXER_KEYS)}"
+)
+
+
+def cpu_ref_cache_dir(variant) -> Path:
+    """Disk cache dir for this variant's CPU reference outputs (env override, else /tmp)."""
+    env = variant.mla_ref_cache_env or "DEEPSEEK_V3_MLA_REF_CACHE"
+    return Path(os.environ.get(env, f"/tmp/{variant.name}_mla_ref_cache"))
+
+
+def build_weights(variant, config, *, seed=42, layer=None, checkpoint_path=None, repo=None) -> tuple[Weights, str]:
+    """Canonical weights + a source tag (so random/pretrained ref caches never collide).
+
+    Random by default; pretrained layer `layer` from a local `checkpoint_path` or HF `repo` (defaulting
+    to the variant's own `hf_repo_id` — the test owns the repo, per the package API_SPEC). The same dict
+    feeds both the device (`ttMLA`) and the CPU truth (`SparseMLAReference`).
+    """
+    if checkpoint_path is not None:
+        return pretrained_mla_weights(config, layer=layer or 0, checkpoint_path=checkpoint_path), f"ckptL{layer or 0}"
+    if layer is not None:
+        return pretrained_mla_weights(config, layer=layer, repo=repo or variant.hf_repo_id), f"layer{layer}"
+    return random_mla_weights(config, seed=seed), f"random_seed{seed}"
+
+
+def make_hidden(seq_len, hidden_size, seed=42, input_path=None):
+    """MLA/indexer input [1, seq, hidden] bf16: from `input_path` (.pt, sliced/checked) or randn(seed)."""
+    if input_path:
+        t = torch.load(input_path, weights_only=True)
+        t = t["hidden_states"] if isinstance(t, dict) else t
+        t = t.reshape(-1, t.shape[-1])  # [.., hidden] -> [tokens, hidden]
+        assert (
+            t.shape[0] >= seq_len and t.shape[-1] == hidden_size
+        ), f"input {tuple(t.shape)} can't supply [{seq_len}, {hidden_size}]"
+        return t[:seq_len].reshape(1, seq_len, hidden_size).to(torch.bfloat16)
+    torch.manual_seed(seed)
+    return torch.randn(1, seq_len, hidden_size, dtype=torch.bfloat16)
+
+
+def run_cpu_reference(config, weights, hidden_states, seq_len, cache_dir, cache_tag):
+    """Single-shot sparse-MLA CPU truth (indexer active). Disk-cached (output + KVPE) under `cache_dir`.
+
+    Returns (ref_output [1, seq, dim], ref_kvpe [1, 1, seq, kv_lora_rank + rope]).
+    """
+    cache_path = Path(cache_dir) / f"{cache_tag}_seq{seq_len}.pt"
+    if cache_path.exists():
+        logger.info(f"Loading cached CPU reference from {cache_path}")
+        cached = torch.load(cache_path, weights_only=True)
+        return cached["ref_output"], cached["ref_kvpe"]
+
+    ref = SparseMLAReference(config, weights, seq_len=seq_len)
+    ref_output = ref.forward(hidden_states)
+    ref_kvpe = ref.kvpe_cache  # device layout [1, 1, seq, kv_lora_rank + rope]
+
+    Path(cache_dir).mkdir(parents=True, exist_ok=True)
+    torch.save({"ref_output": ref_output, "ref_kvpe": ref_kvpe}, cache_path)
+    logger.info(f"Saved CPU reference to {cache_path}")
+    return ref_output, ref_kvpe
+
+
+def run_cpu_reference_chunked(config, weights, hidden_states, seq_len, chunk, cache_dir, cache_tag):
+    """Chunk-loop sparse-MLA CPU truth (decode branch via actual_start). Disk-cached.
+
+    Returns (ref_output [1, seq, dim], ref_kvpe [1, seq, kv_lora_rank + rope]).
+    """
+    cache_path = Path(cache_dir) / f"chunked_{cache_tag}_seq{seq_len}_c{chunk}.pt"
+    if cache_path.exists():
+        logger.info(f"Loading cached chunked CPU reference from {cache_path}")
+        cached = torch.load(cache_path, weights_only=True)
+        return cached["ref_output"], cached["ref_kvpe"]
+
+    ref = SparseMLAReference(config, weights, seq_len=seq_len)
+    outs = [ref.forward(hidden_states[:, s : s + chunk], actual_start=s) for s in range(0, seq_len, chunk)]
+    ref_output = torch.cat(outs, dim=1)
+    ref_kvpe = ref.kvpe_cache.squeeze(1)  # [1, seq, kv_lora_rank + rope] (chunked KVPE comparison layout)
+
+    Path(cache_dir).mkdir(parents=True, exist_ok=True)
+    torch.save({"ref_output": ref_output, "ref_kvpe": ref_kvpe}, cache_path)
+    logger.info(f"Saved chunked CPU reference to {cache_path}")
+    return ref_output, ref_kvpe

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
@@ -1,0 +1,432 @@
+# SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sparse MLA / DSA tests for DeepSeek V3.2-family variants.
+
+Dense MLA coverage lives in test_mla.py. This file keeps the sparse reference
+path separate while reusing the same TT execution helper and the production mesh
+/ fabric axes from the dense MLA tests.
+"""
+
+import os
+
+import pytest
+import torch
+from loguru import logger
+from ttnn.device import is_blackhole
+
+import ttnn
+from models.common.utility_functions import comp_pcc
+from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_mesh import KVPE_MIN_TOKENS_PER_CHIP, detect_num_devices
+from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_reference import (
+    build_weights,
+    cpu_ref_cache_dir,
+    make_hidden,
+    run_cpu_reference,
+    run_cpu_reference_chunked,
+)
+from models.demos.deepseek_v3_d_p.tests.test_mla import run_mla_inference
+from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
+from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
+from models.demos.deepseek_v3_d_p.tt.mla.utils import blockcyclic_positions
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config, get_max_payload_size
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
+from models.demos.deepseek_v3_d_p.utils.test_utils import WH_WORKER_L1_SIZE
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+SPARSE_OUTPUT_PCC = 0.98
+SPARSE_KVPE_PCC = 0.99
+SPARSE_VARIANTS = ["deepseek_v32", "glm_5_1"]
+
+# ---------------------------------------------------------------------------
+# TEST MATRIX — single source of truth (see _sparse_cases for how it expands)
+# ---------------------------------------------------------------------------
+# Box-adaptive candidate meshes (sp, tp), keyed by physical device count. Each box lists ONLY shapes
+# that fit it, so off-box shapes are never generated (no "needs N devices" skips). Shapes must be
+# TP>=2 (the dense 128-head epilogue overflows L1 at TP=1). Coverage rationale:
+#   QuietBox (4):  (2,2) TP=2 for GLM + DeepSeek; (1,4) gives DeepSeek a TP=4 point (GLM caps at TP=2).
+#   LoudBox  (8):  (2,4) TP=4 and (4,2) TP=2 (the full-box GLM shape).
+#   Galaxy   (32): (8,4) production TP=4 + (8,2) TP=2 plane so GLM is exercised.
+# Mesh shape is NOT correctness-invariant, so accuracy sweeps the whole box set; determinism and
+# chunked pin to each variant's anchor (highest supported TP) — see _sparse_cases(anchor_only=True).
+SPARSE_MESH_BY_DEVICES = {
+    4: [(2, 2), (1, 4)],
+    8: [(2, 4), (4, 2)],
+    32: [(8, 4), (8, 2)],
+}
+
+# seq_len is a sparsity-regime axis (not a code path): accuracy keeps one inert-top-k point (256,
+# where sparse == dense) and one real-pruning point (5120). determinism/chunked use the single
+# prod-closest length (5120). 2048 dropped (also inert, redundant with 256).
+SPARSE_SEQS_ACCURACY = [256, 5120]
+SPARSE_SEQS_ANCHOR = [5120]
+
+
+def _sparse_meshes():
+    """Current box's candidate (sp, tp) meshes; best-effort single TP plane on non-standard boxes."""
+    n = detect_num_devices()
+    return SPARSE_MESH_BY_DEVICES.get(n, [(1, max(n, 1))])
+
+
+# GLM exception (expected to be temporary): sparse_sdpa needs per-chip n_heads/tp >= 32, and GLM has
+# only 64 q-heads, so it caps at TP=2. DeepSeek (128 heads) has no such limit. Handled locally here
+# rather than as a TestVariant field, so this soon-to-be-lifted limitation doesn't leak into the
+# generic variant metadata (and the other models).
+_GLM_MAX_TP = 2
+
+
+def _mesh_ok_for_variant(variant_name, mesh):
+    return not (variant_name == "glm_5_1" and mesh[1] > _GLM_MAX_TP)
+
+
+def _seq_ok_for_mesh(seq_len, mesh):
+    # kvpe ND-shard cache needs >= KVPE_MIN_TOKENS_PER_CHIP tokens per SP shard.
+    return seq_len // mesh[0] >= KVPE_MIN_TOKENS_PER_CHIP
+
+
+def _anchor_mesh(variant_name, meshes):
+    """Production-closest mesh for a variant: the highest TP it supports among the box's meshes."""
+    return max((m for m in meshes if _mesh_ok_for_variant(variant_name, m)), key=lambda m: m[1])
+
+
+def _sparse_cases(seqs, anchor_only):
+    """Generate (variant, mesh, seq_len) params for the CURRENT box — only valid combos, so the
+    collected matrix equals the run matrix (validity is enforced here, not via runtime skips)."""
+    meshes = _sparse_meshes()
+    cases = []
+    for variant_name in SPARSE_VARIANTS:
+        usable = [m for m in meshes if _mesh_ok_for_variant(variant_name, m)]
+        chosen = [_anchor_mesh(variant_name, meshes)] if (anchor_only and usable) else usable
+        for mesh in chosen:
+            for seq_len in seqs:
+                if not _seq_ok_for_mesh(seq_len, mesh):
+                    continue
+                cases.append(
+                    pytest.param(variant_name, mesh, seq_len, id=f"{variant_name}-{mesh[0]}x{mesh[1]}-seq{seq_len}")
+                )
+    return cases
+
+
+SPARSE_ACCURACY_CASES = _sparse_cases(SPARSE_SEQS_ACCURACY, anchor_only=False)
+SPARSE_ANCHOR_CASES = _sparse_cases(SPARSE_SEQS_ANCHOR, anchor_only=True)
+
+# All three fabric transports, keyed by name. Fabric is NOT swept: correctness is ~invariant to the
+# transport, so the suite pins one fabric (PREFERRED below) and lets a dedicated fabric test cover
+# multi-transport bring-up. The ids/dicts are kept so DS_SPARSE_FABRIC can select any of them.
+_SPARSE_FABRICS = {
+    "line": {
+        "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+        "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
+    },
+    "ring": {
+        "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+        "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
+    },
+    "fabric2d": {
+        "fabric_config": ttnn.FabricConfig.FABRIC_2D,
+        "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
+        "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
+        "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
+    },
+}
+# Auto-pin the fabric: priority fabric2d > ring > line (fabric2d is the Galaxy/production bring-up).
+# Override with DS_SPARSE_FABRIC=line|ring|fabric2d. TODO: replace the priority default with a real
+# per-box capability probe; for now it defaults to the top-priority (production) transport.
+_SPARSE_FABRIC_PRIORITY = ["fabric2d", "ring", "line"]
+
+
+def _preferred_fabric_name() -> str:
+    env = os.environ.get("DS_SPARSE_FABRIC")
+    if env:
+        assert env in _SPARSE_FABRICS, f"DS_SPARSE_FABRIC={env!r} must be one of {sorted(_SPARSE_FABRICS)}"
+        return env
+    return _SPARSE_FABRIC_PRIORITY[0]
+
+
+PREFERRED_FABRIC = _preferred_fabric_name()
+SPARSE_DEVICE_PARAMS = [_SPARSE_FABRICS[PREFERRED_FABRIC]]
+SPARSE_DEVICE_IDS = [PREFERRED_FABRIC]
+
+
+def _topology_from_device_params(device_params):
+    return (
+        ttnn.Topology.Ring
+        if device_params.get("fabric_config") == ttnn.FabricConfig.FABRIC_1D_RING
+        else ttnn.Topology.Linear
+    )
+
+
+def run_sparse_mla_accuracy_case(
+    variant, config, mesh_device, seq_len, topology, ds_layer=None, ds_checkpoint=None, ds_repo=None
+):
+    """Sparse-MLA accuracy: device output + KVPE cache vs MLACPU sparse reference."""
+    # Validity (tp<=cap, seq/sp>=min tokens, off-box shapes) is enforced by _sparse_cases at
+    # collection time, so there are no runtime skips here: collected == run.
+    logger.info(
+        f"[{variant.name}] sparse MLA accuracy start: seq_len={seq_len} "
+        f"mesh={tuple(mesh_device.shape)} topology={topology}"
+    )
+    logger.debug(f"[{variant.name}] sparse MLA accuracy: building TT/CPU weights")
+    weights, src_tag = build_weights(variant, config, layer=ds_layer, checkpoint_path=ds_checkpoint, repo=ds_repo)
+    config.max_seq_len = seq_len
+    logger.debug(f"[{variant.name}] sparse MLA accuracy: reference source tag={src_tag}")
+
+    mesh_shape = list(mesh_device.shape)
+    sp_axis, tp_axis = 0, 1
+    logger.debug(f"[{variant.name}] sparse MLA accuracy: initializing KVPE cache mesh_shape={mesh_shape}")
+    tt_kvpe_cache = init_kvpe_cache(
+        kvpe_cache_head_dim=config.kv_lora_rank + config.qk_rope_head_dim,
+        mesh_device=mesh_device,
+        seq_len=seq_len,
+        mesh_shape=mesh_shape,
+        sp_axis=sp_axis,
+        num_kvpe_cache_layers=1,
+    )
+
+    logger.info(f"[{variant.name}] sparse MLA accuracy: running TT inference")
+    tt_output, hidden_states, _, shard_dims = run_mla_inference(
+        config=config,
+        weights=weights,
+        mesh_device=mesh_device,
+        seq_len=seq_len,
+        mesh_shape=mesh_shape,
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        is_balanced=False,
+        topology=topology,
+        tt_kvpe_cache=tt_kvpe_cache,
+    )
+
+    cache_dir = cpu_ref_cache_dir(variant)
+    logger.info(f"[{variant.name}] sparse MLA accuracy: running CPU reference")
+    ref_output, ref_kvpe = run_cpu_reference(
+        config, weights, hidden_states, seq_len, cache_dir, cache_tag=f"{src_tag}_funcidx"
+    )
+
+    logger.debug(f"[{variant.name}] sparse MLA accuracy: collecting TT output shard_dims={shard_dims}")
+    tt_output_cpu = ttnn.to_torch(
+        tt_output,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=shard_dims, mesh_shape=mesh_device.shape),
+    ).to(torch.bfloat16)
+    if seq_len > 2048:
+        for name, sl in [("rows<2048", slice(0, 2048)), ("rows>=2048", slice(2048, seq_len))]:
+            _, m = comp_pcc(ref_output[:, sl], tt_output_cpu[0, :, sl], 0)
+            logger.info(f"[{variant.name}] band {name}: {m}")
+    _, pcc_message = assert_with_pcc(ref_output.unsqueeze(0), tt_output_cpu, SPARSE_OUTPUT_PCC)
+    logger.info(f"[{variant.name}] Output PCC: {pcc_message}")
+
+    logger.debug(f"[{variant.name}] sparse MLA accuracy: collecting KVPE cache")
+    tt_kvpe = ttnn.to_torch(
+        tt_kvpe_cache,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape),
+    ).to(torch.bfloat16)[:1, :1]
+    kv = config.kv_lora_rank
+    _, kv_pcc = assert_with_pcc(ref_kvpe[..., :kv], tt_kvpe[..., :kv], SPARSE_KVPE_PCC)
+    _, pe_pcc = assert_with_pcc(ref_kvpe[..., kv:], tt_kvpe[..., kv:], SPARSE_KVPE_PCC)
+    logger.info(f"[{variant.name}] KVPE cache PCC: kv={kv_pcc} pe={pe_pcc}")
+    ttnn.synchronize_device(mesh_device)
+    logger.info(f"[{variant.name}] sparse MLA accuracy complete")
+
+
+def run_sparse_mla_determinism_case(
+    variant, config, mesh_device, seq_len, n_runs, topology, ds_layer, ds_checkpoint, ds_repo
+):
+    """Run the same sparse MLA case repeatedly and compare outputs."""
+    # Mesh is the per-variant anchor and seq fits SP — guaranteed by _sparse_cases (no runtime skips).
+    logger.info(
+        f"[{variant.name}] sparse MLA determinism start: seq_len={seq_len} "
+        f"mesh={tuple(mesh_device.shape)} topology={topology} n_runs={n_runs}"
+    )
+    logger.debug(f"[{variant.name}] sparse MLA determinism: building TT weights")
+    weights, _ = build_weights(variant, config, layer=ds_layer, checkpoint_path=ds_checkpoint, repo=ds_repo)
+    config.max_seq_len = seq_len
+    mesh_shape = list(mesh_device.shape)
+    sp_axis, tp_axis = 0, 1
+
+    baseline = None
+    for run_idx in range(n_runs):
+        logger.info(f"[{variant.name}] sparse MLA determinism run {run_idx + 1}/{n_runs}: running TT inference")
+        logger.debug(f"[{variant.name}] sparse MLA determinism run {run_idx + 1}: initializing KVPE cache")
+        tt_kvpe_cache = init_kvpe_cache(
+            kvpe_cache_head_dim=config.kv_lora_rank + config.qk_rope_head_dim,
+            mesh_device=mesh_device,
+            seq_len=seq_len,
+            mesh_shape=mesh_shape,
+            sp_axis=sp_axis,
+            num_kvpe_cache_layers=1,
+        )
+        tt_output, _, _, shard_dims = run_mla_inference(
+            config=config,
+            weights=dict(weights),
+            mesh_device=mesh_device,
+            seq_len=seq_len,
+            mesh_shape=mesh_shape,
+            sp_axis=sp_axis,
+            tp_axis=tp_axis,
+            is_balanced=False,
+            topology=topology,
+            tt_kvpe_cache=tt_kvpe_cache,
+        )
+        logger.debug(f"[{variant.name}] sparse MLA determinism run {run_idx + 1}: collecting TT output")
+        current = ttnn.to_torch(
+            tt_output,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=shard_dims, mesh_shape=mesh_device.shape),
+        ).to(torch.bfloat16)
+        ttnn.synchronize_device(mesh_device)
+
+        if baseline is None:
+            baseline = current
+            logger.debug(f"[{variant.name}] sparse MLA determinism run {run_idx + 1}: stored baseline")
+            continue
+
+        logger.debug(f"[{variant.name}] sparse MLA determinism run {run_idx + 1}: comparing with baseline")
+        exact = torch.equal(baseline, current)
+        _, msg = assert_with_pcc(baseline.float(), current.float(), 0.9999)
+        logger.info(f"[{variant.name}] determinism run0 vs run{run_idx}: exact={exact} pcc={msg}")
+    logger.info(f"[{variant.name}] sparse MLA determinism complete")
+
+
+def run_sparse_mla_chunked_case(
+    variant, config, mesh_device, seq_len, chunk, ds_layer, ds_checkpoint, ds_repo, ds_input
+):
+    """Sparse chunked prefill: compare chunked ttMLA against MLACPU sparse chunked truth."""
+    # Anchor mesh (TP>=2) and seq/SP validity are guaranteed by _sparse_cases (no runtime skips).
+    #
+    # CACHE-QUANTIZATION NOTE: the CPU reference keeps KVPE in bf16 (SparseMLAReference defaults to
+    # simulate_fp8=False — see reference.cpu_deepseek_v32), matching the bf16 single-shot device
+    # cache. But the chunked DEVICE path reads the prefix back from the bf8 KVPE cache and upcasts it in
+    # _gather_kvpe_prefix, so this comparison crosses a bf8 cache round-trip the reference does not model.
+    # That quantization noise eats into the SPARSE_OUTPUT_PCC headroom here (vs single-shot). If chunked
+    # PCC ever drifts toward the threshold, add a simulate_fp8=True reference variant to separate expected
+    # cache-quantization noise from a true logic regression.
+    seed = 42
+    logger.info(
+        f"[{variant.name}] sparse MLA chunked start: seq_len={seq_len} chunk={chunk} "
+        f"mesh={tuple(mesh_device.shape)} ds_input={bool(ds_input)}"
+    )
+    logger.debug(f"[{variant.name}] sparse MLA chunked: building TT/CPU weights")
+    weights, src_tag = build_weights(
+        variant, config, seed=seed, layer=ds_layer, checkpoint_path=ds_checkpoint, repo=ds_repo
+    )
+    config.max_seq_len = seq_len
+
+    mesh_shape = list(mesh_device.shape)
+    sp_axis, tp_axis = 0, 1
+    logger.debug(f"[{variant.name}] sparse MLA chunked: initializing KVPE cache mesh_shape={mesh_shape}")
+    tt_kvpe_cache = init_kvpe_cache(
+        kvpe_cache_head_dim=config.kv_lora_rank + config.qk_rope_head_dim,
+        mesh_device=mesh_device,
+        seq_len=seq_len,
+        mesh_shape=mesh_shape,
+        sp_axis=sp_axis,
+        num_kvpe_cache_layers=1,
+    )
+
+    logger.debug(f"[{variant.name}] sparse MLA chunked: constructing TT module and indexed RoPE tensors")
+    mla_tt = ttMLA(
+        config,
+        weights,
+        mesh_device,
+        layer_idx=0,
+        seq_len=seq_len,
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        is_chunked=True,
+        layer_num=1,
+    )
+    rope = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=False)
+    rope_tensors = rope.get_rope_tensors_indexed(seq_len, chunk)
+
+    hidden = make_hidden(seq_len, config.hidden_size, seed, ds_input)
+    if ds_input:
+        src_tag = f"{src_tag}_in{abs(hash(ds_input)) % 10**8}"
+    shard_dims = [None, None]
+    shard_dims[tp_axis], shard_dims[sp_axis] = -1, -2
+
+    outs = []
+    num_chunks = (seq_len + chunk - 1) // chunk
+    for chunk_idx, s in enumerate(range(0, seq_len, chunk)):
+        logger.info(f"[{variant.name}] sparse MLA chunked TT chunk {chunk_idx + 1}/{num_chunks}: actual_start={s}")
+        tt_x = ttnn.from_torch(
+            hidden[:, s : s + chunk].unsqueeze(0),
+            device=mesh_device,
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            layout=ttnn.TILE_LAYOUT,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims),
+        )
+        out = mla_tt.forward(tt_x, rope_tensors, tt_kvpe_cache, actual_start=s)
+        outs.append(
+            ttnn.to_torch(
+                out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=shard_dims, mesh_shape=mesh_device.shape)
+            ).to(torch.bfloat16)
+        )
+    tt_output = torch.cat(outs, dim=2)
+
+    cache_dir = cpu_ref_cache_dir(variant)
+    logger.info(f"[{variant.name}] sparse MLA chunked: running CPU reference")
+    ref_output, ref_kvpe = run_cpu_reference_chunked(
+        config, weights, hidden, seq_len, chunk, cache_dir, cache_tag=f"{src_tag}_funcidx"
+    )
+
+    for s in range(0, seq_len, chunk):
+        _, m = comp_pcc(ref_output[:, s : s + chunk], tt_output[0, :, s : s + chunk], 0)
+        logger.info(f"[{variant.name}] chunk@{s}: {m}")
+
+    sp = mesh_device.shape[0]
+    logger.debug(f"[{variant.name}] sparse MLA chunked: collecting KVPE cache")
+    cache_sr = ttnn.to_torch(
+        tt_kvpe_cache, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape)
+    ).to(torch.bfloat16)[:, :1]
+    p = blockcyclic_positions(sp, chunk, cache_sr.shape[2])
+    nat = torch.empty(cache_sr.shape[2], cache_sr.shape[-1], dtype=torch.bfloat16)
+    nat[p] = cache_sr[0, 0]
+    _, m = comp_pcc(ref_kvpe, nat[:seq_len].unsqueeze(0), 0)
+    logger.info(f"[{variant.name}] kvpe prefix: {m}")
+
+    _, pcc_message = assert_with_pcc(ref_output.unsqueeze(0), tt_output, SPARSE_OUTPUT_PCC)
+    logger.info(f"[{variant.name}] Chunked output PCC: {pcc_message}")
+    ttnn.synchronize_device(mesh_device)
+    logger.info(f"[{variant.name}] sparse MLA chunked complete")
+
+
+# One combined parametrization (variant, mesh_device, seq_len) instead of three independent axes: the
+# cases are generated by _sparse_cases for the current box, so the collected matrix IS the run matrix.
+@pytest.mark.parametrize("variant, mesh_device, seq_len", SPARSE_ACCURACY_CASES, indirect=["variant", "mesh_device"])
+@pytest.mark.parametrize("device_params", SPARSE_DEVICE_PARAMS, ids=SPARSE_DEVICE_IDS, indirect=True)
+@pytest.mark.skipif(not is_blackhole(), reason="DSA ops (indexer / sparse SDPA) are Blackhole-only")
+@pytest.mark.timeout(0)
+def test_sparse_mla_accuracy(
+    mesh_device, seq_len, device_params, variant, config_only, ds_layer, ds_checkpoint, ds_repo
+):
+    topology = _topology_from_device_params(device_params)
+    run_sparse_mla_accuracy_case(variant, config_only, mesh_device, seq_len, topology, ds_layer, ds_checkpoint, ds_repo)
+
+
+# Anchor cases (per-variant prod-closest mesh, seq=4096); collected == run.
+@pytest.mark.parametrize("variant, mesh_device, seq_len", SPARSE_ANCHOR_CASES, indirect=["variant", "mesh_device"])
+@pytest.mark.parametrize("device_params", SPARSE_DEVICE_PARAMS, ids=SPARSE_DEVICE_IDS, indirect=True)
+@pytest.mark.parametrize("n_runs", [3], ids=["x3"])
+@pytest.mark.skipif(not is_blackhole(), reason="DSA ops (indexer / sparse SDPA) are Blackhole-only")
+@pytest.mark.timeout(0)
+def test_sparse_mla_determinism(
+    mesh_device, seq_len, n_runs, device_params, variant, config_only, ds_layer, ds_checkpoint, ds_repo
+):
+    topology = _topology_from_device_params(device_params)
+    run_sparse_mla_determinism_case(
+        variant, config_only, mesh_device, seq_len, n_runs, topology, ds_layer, ds_checkpoint, ds_repo
+    )
+
+
+# Anchor cases (seq=5120) crossed with the single prefill chunk size; collected == run.
+@pytest.mark.parametrize("variant, mesh_device, seq_len", SPARSE_ANCHOR_CASES, indirect=["variant", "mesh_device"])
+@pytest.mark.parametrize("device_params", SPARSE_DEVICE_PARAMS, ids=SPARSE_DEVICE_IDS, indirect=True)
+@pytest.mark.parametrize("chunk", [1024], ids=["c1k"])
+@pytest.mark.skipif(not is_blackhole(), reason="DSA ops (indexer / sparse SDPA) are Blackhole-only")
+@pytest.mark.timeout(0)
+def test_sparse_mla_chunked(
+    mesh_device, seq_len, chunk, device_params, variant, config_only, ds_layer, ds_checkpoint, ds_repo, ds_input
+):
+    run_sparse_mla_chunked_case(
+        variant, config_only, mesh_device, seq_len, chunk, ds_layer, ds_checkpoint, ds_repo, ds_input
+    )

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_cache.py
@@ -1,0 +1,212 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DSA (sparse MLA) cache/loading tests — the contract added by the sparse_mla_cache_loading plan.
+
+Dense MLA cache coverage lives in cache/test_mla_cache.py. This suite verifies the sparse-specific
+behavior: sparse capability is resolved explicitly (config / host weights / cache), the offline
+cache build emits the indexer tensorbins, cache-only construction stays sparse (binds TtIndexer,
+never dense), completeness covers the indexer files, and a sparse cache-only construct with no cache
+warns and stays sparse (mirrors dense's lenient placeholder load) instead of silently going dense.
+
+The `matches_config` test is host-only (no device); the build→cache-only→PCC test runs on a TP>=2
+mesh so the sparse epilogue / GLM (TP≤2) fit. Validity gating (so collected==run) is the same as
+test_sparse_mla.py — here we just fix one (4,2) mesh that both variants support.
+"""
+
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+from loguru import logger
+from ttnn.device import is_blackhole
+
+import ttnn
+from models.demos.deepseek_v3_d_p.reference.cpu_deepseek_v32 import random_mla_weights
+from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
+from models.demos.deepseek_v3_d_p.tt.mla.indexer import TtIndexer, resolve_has_indexer
+from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
+from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker, report_and_clear
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
+from models.demos.deepseek_v3_d_p.utils.test_utils import WH_WORKER_L1_SIZE
+from tests.ttnn.utils_for_testing import comp_pcc
+
+CACHE_DIR = Path("/tmp/DS_PREFILL_sparse_mla")
+SEQ_LEN = 256
+SP_AXIS, TP_AXIS = 0, 1
+
+
+# --------------------------------------------------------------------------------------------------
+# Host-only: the config-detection path, isolated from the host/cache fallbacks. A regression where a
+# variant's runtime config stops carrying the DSA fields would be masked by the PCC test below (it can
+# resolve sparse via the cache), so assert matches_config / resolve_has_indexer directly.
+# --------------------------------------------------------------------------------------------------
+@pytest.mark.parametrize("variant", ["deepseek_v32", "glm_5_1"], indirect=True, ids=["deepseek_v32", "glm_5_1"])
+def test_matches_config_detects_dsa(variant, config_only):
+    assert TtIndexer.matches_config(config_only), f"{variant.name}: runtime config should carry DSA index_* fields"
+    # No host weights, no cache, no explicit override -> still resolves sparse purely from the config.
+    assert resolve_has_indexer(config_only) is True
+
+
+def test_matches_config_rejects_dense():
+    """A dense DeepSeek-V3 / R1-style config (no index_* fields) must not look sparse."""
+    dense = SimpleNamespace(q_lora_rank=1536, hidden_size=7168)
+    assert TtIndexer.matches_config(dense) is False
+    assert resolve_has_indexer(dense) is False
+    # ...unless a caller explicitly forces it (escape hatch).
+    assert resolve_has_indexer(dense, explicit=True) is True
+
+
+# --------------------------------------------------------------------------------------------------
+# Device: build -> cache-only load stays sparse and reproduces the from-weights output.
+# --------------------------------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def cleanup_cache():
+    if CACHE_DIR.exists():
+        shutil.rmtree(CACHE_DIR)
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    yield
+    report_and_clear()
+
+
+def _forward(mla, mesh_device, rope_tensors, kvpe_cache, hidden):
+    """Single-shot sparse MLA forward, mirroring run_mla_inference's SP×TP input sharding."""
+    shard_dims = [None, None]
+    shard_dims[TP_AXIS], shard_dims[SP_AXIS] = -1, -2
+    tt_hidden = ttnn.from_torch(
+        hidden.unsqueeze(0),  # [1, batch, seq, hidden]
+        device=mesh_device,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims),
+    )
+    out = mla.forward(hidden_states=tt_hidden, rope_tensors=rope_tensors, kvpe_cache=kvpe_cache)
+    return ttnn.to_torch(
+        out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=shard_dims, mesh_shape=mesh_device.shape)
+    ).to(torch.bfloat16)
+
+
+def _new_kvpe(config, mesh_device, mesh_shape):
+    return init_kvpe_cache(
+        kvpe_cache_head_dim=config.kv_lora_rank + config.qk_rope_head_dim,
+        mesh_device=mesh_device,
+        seq_len=SEQ_LEN,
+        mesh_shape=mesh_shape,
+        sp_axis=SP_AXIS,
+        num_kvpe_cache_layers=1,
+    )
+
+
+def _build_mla(config, state_dict, mesh_device, weight_cache_path):
+    return ttMLA(
+        config,
+        state_dict,
+        mesh_device,
+        layer_idx=0,
+        seq_len=SEQ_LEN,
+        sp_axis=SP_AXIS,
+        tp_axis=TP_AXIS,
+        weight_cache_path=weight_cache_path,
+    )
+
+
+@pytest.mark.parametrize(
+    "mesh_device, device_params",
+    [
+        pytest.param(
+            (4, 2),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
+            },
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="linear"),
+            id="linear-4x2",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize("variant", ["deepseek_v32", "glm_5_1"], indirect=True, ids=["deepseek_v32", "glm_5_1"])
+@pytest.mark.skipif(not is_blackhole(), reason="DSA ops (indexer / sparse SDPA) are Blackhole-only")
+@pytest.mark.timeout(0)
+def test_sparse_mla_cache_only_stays_sparse(mesh_device, device_params, variant, config_only):
+    """from-weights -> offline cache build -> cache-only construct: stays sparse, reproduces output,
+    and the indexer cache is part of completeness. Also covers the completeness + failure-mode cases."""
+    config = config_only
+    config.max_seq_len = SEQ_LEN
+    weights = random_mla_weights(config)  # device-vs-device round-trip: config-shaped weights suffice
+    mesh_shape = list(mesh_device.shape)
+
+    rope_tensors = RotarySetup(config, mesh_device, sp_axis=SP_AXIS, is_balanced=False).get_rope_tensors(SEQ_LEN)
+    torch.manual_seed(42)
+    hidden = torch.randn(1, SEQ_LEN, config.hidden_size, dtype=torch.bfloat16)
+
+    # === from weights (no cache) ===
+    mla_w = _build_mla(config, weights, mesh_device, weight_cache_path=None)
+    assert mla_w._has_indexer, f"{variant.name}: from-weights construction must be sparse"
+    out_weights = _forward(mla_w, mesh_device, rope_tensors, _new_kvpe(config, mesh_device, mesh_shape), hidden)
+
+    # === offline cache build: dense + indexer tensorbins ===
+    init_checker(CACHE_DIR)
+    assert not ttMLA.check_cache_complete(CACHE_DIR, "layer_0.mla", has_indexer=True), "cache empty before build"
+    ttMLA.build_ttnn_cache(weights, CACHE_DIR, mesh_device, config, 0, SEQ_LEN, SP_AXIS, TP_AXIS)
+    init_checker(CACHE_DIR)
+    assert ttMLA.check_cache_complete(CACHE_DIR, "layer_0.mla", has_indexer=True), "dense+indexer cache complete"
+
+    # === cache-only construct: empty state dict, must stay sparse and bind TtIndexer ===
+    mla_c = _build_mla(config, {}, mesh_device, weight_cache_path=CACHE_DIR)
+    assert mla_c._has_indexer, f"{variant.name}: cache-only construction must stay sparse, not fall back to dense"
+    assert type(mla_c._indexer).__name__ == "TtIndexer", "cache-only must bind TtIndexer, not NullIndexer"
+    out_cache = _forward(mla_c, mesh_device, rope_tensors, _new_kvpe(config, mesh_device, mesh_shape), hidden)
+
+    passed, pcc = comp_pcc(out_weights, out_cache, 0.999)
+    logger.info(f"[{variant.name}] sparse cache-only vs from-weights PCC: {pcc}")
+    assert passed, f"{variant.name}: cache-only output diverged from from-weights: PCC={pcc}"
+
+    # === completeness: a missing indexer tensorbin fails the sparse check (but not the dense check) ===
+    one = next(CACHE_DIR.glob("layer_0.mla.indexer_*.tensorbin"))
+    one.unlink()
+    init_checker(CACHE_DIR)
+    assert ttMLA.check_cache_complete(CACHE_DIR, "layer_0.mla", has_indexer=False), "dense-only check still complete"
+    assert not ttMLA.check_cache_complete(
+        CACHE_DIR, "layer_0.mla", has_indexer=True
+    ), "missing indexer tensorbin must fail the sparse completeness check"
+    ttnn.synchronize_device(mesh_device)
+
+
+@pytest.mark.parametrize(
+    "mesh_device, device_params",
+    [
+        pytest.param(
+            (4, 2),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
+            },
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="linear"),
+            id="linear-4x2",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize("variant", ["deepseek_v32"], indirect=True, ids=["deepseek_v32"])
+@pytest.mark.skipif(not is_blackhole(), reason="DSA ops (indexer / sparse SDPA) are Blackhole-only")
+@pytest.mark.timeout(0)
+def test_sparse_cache_only_without_cache_warns_stays_sparse(mesh_device, device_params, variant, config_only):
+    """Sparse cache-only construction with no indexer cache must WARN (not raise — mirrors dense's
+    lenient placeholder load) and stay sparse, never silently fall back to dense."""
+    config = config_only
+    config.max_seq_len = SEQ_LEN
+    warnings = []
+    sink = logger.add(lambda m: warnings.append(str(m)), level="WARNING")
+    try:
+        mla = _build_mla(config, {}, mesh_device, weight_cache_path=CACHE_DIR)  # empty (cleaned) dir
+    finally:
+        logger.remove(sink)
+    assert mla._has_indexer, "must stay sparse (resolved from config), not fall back to dense"
+    assert type(mla._indexer).__name__ == "TtIndexer", "must bind TtIndexer, never NullIndexer"
+    assert any(
+        "indexer has neither host weights nor a complete cache" in m for m in warnings
+    ), f"expected a loud warning about the missing indexer weights/cache; got: {warnings}"

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
@@ -1,0 +1,326 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tracy perf harness for the DeepSeek V3.2 MLA (DSA) chunked-prefill layer.
+
+Production scenario (defaults): process one **5k-token chunk** with **50k tokens already cached**,
+on the Galaxy **SP=8 × TP=4** mesh.
+
+The test can also run on smaller Blackhole boxes by profiling a per-chip Galaxy slice:
+  * Galaxy   (32 chips): SP=8 × TP=4, chunk=5120, heads=128
+  * LoudBox  (8 chips):  SP=2 × TP=4, chunk=1280, heads=128
+  * QuietBox (4 chips):  SP=1 × TP=4, chunk=640,  heads=128
+
+That keeps the per-chip COMPUTE shapes equal to Galaxy: local query rows/chip (640), MLA heads/chip
+(32), indexer heads/chip (16). The indexer K-cache is replicated full-depth (50k) on every chip and the
+sparse SDPA is top-k-gated, so kernel timing is a faithful Galaxy proxy. CAVEAT: the KVPE cache is
+SP-sharded, so its per-chip depth is 50k/SP (50k on QuietBox, 25k on LoudBox, 6.25k on Galaxy) — per-chip
+KVPE footprint and any op that scales with KVPE depth are heavier on smaller boxes.
+No reference values: this just runs the real device forward and reports per-op device-kernel time.
+Multi-chip rows are device-collapsed (compute=max, collectives=avg across chips) via merge_device_rows
+so the reported time is per-step critical path, not the ~8× over-count of summing parallel device rows.
+
+Two-test pattern (mirrors tests/nightly/blackhole/sdpa):
+  * test_mla_chunked_perf_impl  — the work to profile. Builds the v32 ttMLA, populates the index/KV
+    caches directly to stand in for the cached prefix (no warm-up forwards), then wraps a SINGLE
+    `chunk`-token forward in signpost("start"/"stop"). Run this under tracy.
+  * test_mla_chunked_perf       — the driver. Spawns the impl under tracy via run_device_profiler,
+    reads the device ops log for the signposted region, prints a per-op table, and writes a CSV.
+
+Run (Blackhole Galaxy/LoudBox/QuietBox):
+    pytest -m perf models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py::test_mla_chunked_perf -s
+
+Knobs (env): DS_PERF_CACHE (default 51200), DS_PERF_CHUNK (default 5120), DS_PERF_CSV.
+DS_PERF_CHUNK is the Galaxy-global target chunk; smaller boxes scale the measured chunk by SP/8.
+
+NOTE: caches are POPULATED directly (random index keys; KVPE left at init) rather than warmed with
+real chunks — only op shapes/timing matter here, not values. The indexer rope now scales from the HF
+config (mla.py), so `config.max_seq_len = total` is enough for a 50k+ context (no manual rope bump).
+"""
+
+import copy
+import os
+from dataclasses import dataclass
+from unittest import mock
+
+import pandas as pd
+import pytest
+import torch
+from loguru import logger
+from ttnn.device import is_blackhole
+
+import ttnn
+from models.demos.deepseek_v3_d_p.reference.cpu_deepseek_v32 import random_mla_weights
+from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_mesh import detect_num_devices
+from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_plugin import is_marker_explicitly_selected
+from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_reference import make_hidden
+from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
+from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
+from models.demos.deepseek_v3_d_p.utils.test_utils import WH_WORKER_L1_SIZE
+
+CACHE_TOKENS = int(os.environ.get("DS_PERF_CACHE", 51200))  # 50 * 1024 already cached
+CHUNK_TOKENS = int(os.environ.get("DS_PERF_CHUNK", 5120))  # 5 * 1024 processed this step
+SUBDIR = "deepseek_v32_sparse_mla_perf"
+CSV_OUT = os.environ.get("DS_PERF_CSV", "deepseek_v32_sparse_mla_perf.csv")
+
+pytestmark = pytest.mark.perf
+
+GALAXY_SP = 8
+GALAXY_TP = 4
+GALAXY_NUM_HEADS = 128
+GALAXY_INDEX_HEADS = 64
+INDEX_HEAD_DIM = 128
+
+
+@dataclass(frozen=True)
+class PerfWorkload:
+    system_name: str
+    num_devices: int
+    mesh_shape: tuple[int, int]
+    cache_tokens: int
+    chunk_tokens: int
+    num_attention_heads: int
+    index_n_heads: int
+
+    @property
+    def sp(self) -> int:
+        return self.mesh_shape[0]
+
+    @property
+    def tp(self) -> int:
+        return self.mesh_shape[1]
+
+    @property
+    def id(self) -> str:
+        return f"{self.system_name.lower()}_sp{self.sp}xtp{self.tp}"
+
+
+_SYSTEM_BY_DEVICE_COUNT = {
+    4: ("QuietBox", (1, 4)),
+    8: ("LoudBox", (2, 4)),
+    32: ("Galaxy", (8, 4)),
+}
+
+
+def _exact_div(numerator: int, denominator: int, label: str) -> int:
+    if numerator % denominator != 0:
+        raise ValueError(f"{label}={numerator} must be divisible by {denominator}")
+    return numerator // denominator
+
+
+def _detect_perf_workload() -> tuple[PerfWorkload, str | None]:
+    num_devices = detect_num_devices()
+    system = _SYSTEM_BY_DEVICE_COUNT.get(num_devices)
+    if system is None:
+        placeholder = PerfWorkload("unsupported", num_devices, (1, 1), CACHE_TOKENS, CHUNK_TOKENS, 32, 16)
+        return placeholder, (
+            "DeepSeek V3.2 sparse MLA perf supports Blackhole QuietBox/LoudBox/Galaxy only "
+            f"(detected {num_devices} chips)"
+        )
+
+    system_name, mesh_shape = system
+    sp, tp = mesh_shape
+    local_chunk = _exact_div(CHUNK_TOKENS, GALAXY_SP, "DS_PERF_CHUNK")
+    local_heads = _exact_div(GALAXY_NUM_HEADS, GALAXY_TP, "GALAXY_NUM_HEADS")
+    local_index_heads = _exact_div(GALAXY_INDEX_HEADS, GALAXY_TP, "GALAXY_INDEX_HEADS")
+    workload = PerfWorkload(
+        system_name=system_name,
+        num_devices=num_devices,
+        mesh_shape=mesh_shape,
+        cache_tokens=CACHE_TOKENS,
+        chunk_tokens=local_chunk * sp,
+        num_attention_heads=local_heads * tp,
+        index_n_heads=local_index_heads * tp,
+    )
+    return workload, None
+
+
+PERF_WORKLOAD, PERF_SKIP_REASON = _detect_perf_workload()
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _require_perf(request):
+    if is_marker_explicitly_selected(request.config, "perf"):
+        return
+    pytest.skip("sparse MLA perf tests require explicit marker selection: pytest -m perf")
+
+
+# ============================================================================
+# Inner: the work to profile (run under tracy by the driver below)
+# ============================================================================
+@pytest.mark.parametrize("mesh_device", [PERF_WORKLOAD.mesh_shape], ids=[PERF_WORKLOAD.id], indirect=True)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
+        }
+    ],
+    ids=["line"],
+    indirect=True,
+)
+@pytest.mark.parametrize("variant", ["deepseek_v32"], indirect=True, ids=["deepseek_v32"])
+@pytest.mark.skipif(os.environ.get("CI") == "true", reason="Performance test — skip on CI")
+@pytest.mark.timeout(0)
+def test_mla_chunked_perf_impl(mesh_device, device_params, variant, config_only):
+    from tracy import signpost
+
+    if PERF_SKIP_REASON:
+        pytest.skip(PERF_SKIP_REASON)
+
+    cache, chunk = PERF_WORKLOAD.cache_tokens, PERF_WORKLOAD.chunk_tokens
+    total = cache + chunk
+    sp_axis, tp_axis = 0, 1
+    sp, tp = mesh_device.shape
+    assert (sp, tp) == PERF_WORKLOAD.mesh_shape, f"expected mesh {PERF_WORKLOAD.mesh_shape}, got {(sp, tp)}"
+    assert cache % chunk == 0, f"cache {cache} must be a whole number of {chunk}-token chunks"
+    assert total % sp == 0 and (total // sp) % 32 == 0, f"total {total} must be tile-aligned per SP={sp} chip"
+    assert (
+        PERF_WORKLOAD.num_attention_heads // tp == GALAXY_NUM_HEADS // GALAXY_TP
+    ), "local MLA heads/chip must match Galaxy"
+
+    config = copy.deepcopy(config_only)
+    config.max_seq_len = total  # rope-table / buffer length (same hack as the correctness tests)
+    config.num_attention_heads = PERF_WORKLOAD.num_attention_heads
+    if hasattr(config, "num_key_value_heads"):
+        config.num_key_value_heads = PERF_WORKLOAD.num_attention_heads
+    config.index_n_heads = PERF_WORKLOAD.index_n_heads
+    config.index_head_dim = getattr(config, "index_head_dim", INDEX_HEAD_DIM)
+    config.index_topk = getattr(config, "index_topk", 2048)
+    config.index_rope_interleave = getattr(config, "index_rope_interleave", False)
+    weights = random_mla_weights(config)
+
+    # Indexer rope now scales from config.max_seq_len (set above) — no manual bump needed.
+    mla = ttMLA(
+        config,
+        dict(weights),
+        mesh_device,
+        layer_idx=0,
+        seq_len=total,
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        is_chunked=True,
+        layer_num=1,
+    )
+
+    rope = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=False).get_rope_tensors_indexed(total, chunk)
+    kvpe_cache = init_kvpe_cache(
+        kvpe_cache_head_dim=config.kv_lora_rank + config.qk_rope_head_dim,
+        mesh_device=mesh_device,
+        seq_len=total,
+        mesh_shape=list(mesh_device.shape),
+        sp_axis=sp_axis,
+        num_kvpe_cache_layers=1,
+    )
+
+    # Represent `cache` already-processed tokens by POPULATING the caches directly (no warm-up
+    # forwards). The indexer K-cache (replicated, natural order, grown by concat) is filled with random
+    # keys so the measured chunk scores against a full `cache`-length prefix. The KVPE block-cyclic
+    # cache is left at its init: the measured chunk writes its own slab and the gather reads the full
+    # prefix, and cache values don't change op shapes/timing.
+    mla._indexer._index_kbuf = ttnn.from_torch(
+        torch.randn(1, 1, cache, mla._indexer.index_args.index_head_dim, dtype=torch.bfloat16),
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+    hidden = make_hidden(chunk, config.hidden_size, seed=42)  # only the measured chunk
+    shard_dims = [None, None]
+    shard_dims[tp_axis], shard_dims[sp_axis] = -1, -2
+    tt_x = ttnn.from_torch(
+        hidden[:, :chunk].unsqueeze(0),
+        device=mesh_device,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims),
+    )
+
+    logger.info(
+        f"profiling {PERF_WORKLOAD.system_name} proxy: one {chunk}-token chunk @ {cache}-token cache "
+        f"(end_pos={total}) on SP={sp}×TP={tp}; local chunk={chunk // sp}, "
+        f"local MLA heads={config.num_attention_heads // tp}, local indexer heads={config.index_n_heads // tp}"
+    )
+    signpost("start")
+    out = mla.forward(tt_x, rope, kvpe_cache, actual_start=cache)
+    ttnn.deallocate(out)
+    ttnn.synchronize_device(mesh_device)
+    signpost("stop")
+
+
+# ============================================================================
+# Outer: drive the impl under tracy, post-process, print + write CSV
+# ============================================================================
+@pytest.mark.skipif(os.environ.get("CI") == "true", reason="perf test — run locally with tracy")
+@pytest.mark.timeout(0)
+def test_mla_chunked_perf():
+    from tracy.process_model_log import run_device_profiler
+
+    if PERF_SKIP_REASON:
+        pytest.skip(PERF_SKIP_REASON)
+
+    # merge_device_rows: the deepseek_v3_d_p / tt_transformers convention for collapsing the device
+    # dimension of a multi-chip Tracy ops log (see models/demos/deepseek_v3_d_p/utils/perf_utils.py).
+    from models.tt_transformers.tests.test_utils import merge_device_rows
+    from tests.nightly.sdpa_perf_utils import post_process_ops_log
+
+    # The impl is skipif(CI=="true"); CI=false in the subprocess lets it run there (mirrors the
+    # tests/nightly/blackhole/sdpa perf pattern). The driver itself opens no device, so when the gate is
+    # run by node-id only the tracy subprocess opens the board — no parent CHIP_IN_USE lock contention.
+    command = (
+        "pytest -m perf models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py"
+        "::test_mla_chunked_perf_impl"
+    )
+    with mock.patch.dict(os.environ, {"CI": "false"}):
+        run_device_profiler(command, SUBDIR, device_analysis_types=["device_kernel_duration"])
+
+    dur_col = "DEVICE KERNEL DURATION [ns]"
+    # Rows between signpost("start") and signpost("stop") = the measured chunk's device ops, with ONE
+    # ROW PER (op call × mesh chip). On the selected SP×TP mesh every op runs across chips in parallel,
+    # so the raw rows must NOT be summed — that over-counts wall-clock by ~num_devices. Collapse
+    # the device dimension to one row per logical op call with the standard merge_device_rows rule:
+    #   * compute ops -> MAX duration across chips (the slowest chip gates the step = critical path)
+    #   * collectives -> AVG duration across chips (all chips run the same collective together)
+    df = post_process_ops_log(SUBDIR, has_signposts=True)
+    df[dur_col] = pd.to_numeric(df[dur_col], errors="coerce")
+    df = merge_device_rows(df)  # filters to tt_dnn_device rows internally
+    assert len(df), "no device ops in the signposted region — was the impl skipped (wrong device count)?"
+
+    total_ns = df[dur_col].sum()
+    by_op = (
+        df.groupby("OP CODE")[dur_col]
+        .agg(count="count", total_ns="sum", avg_ns="mean")
+        .sort_values("total_ns", ascending=False)
+    )
+    by_op["pct"] = 100.0 * by_op["total_ns"] / total_ns
+
+    # Manual formatting (pandas to_string can truncate long tables) — print every op.
+    header = f"{'OP CODE':<44}{'count':>7}{'total_ms':>12}{'avg_us':>12}{'pct':>8}"
+    rows = [
+        f"{op:<44}{int(r['count']):>7}{r['total_ns']/1e6:>12.3f}{r['avg_ns']/1e3:>12.1f}{r['pct']:>7.1f}%"
+        for op, r in by_op.iterrows()
+    ]
+    table = "\n".join(
+        [
+            f"DeepSeek V3.2 MLA chunked perf — {PERF_WORKLOAD.system_name} proxy "
+            f"{PERF_WORKLOAD.chunk_tokens}-tok chunk @ {PERF_WORKLOAD.cache_tokens}-tok cache, "
+            f"SP={PERF_WORKLOAD.sp}×TP={PERF_WORKLOAD.tp}",
+            f"Galaxy target: {CHUNK_TOKENS}-tok chunk @ {CACHE_TOKENS}-tok cache, SP=8×TP=4; "
+            f"local chunk={CHUNK_TOKENS // GALAXY_SP}, local MLA heads={GALAXY_NUM_HEADS // GALAXY_TP}",
+            f"critical-path device-kernel time over the chunk (device-collapsed: compute=max, "
+            f"collectives=avg across chips): {total_ns/1e6:.3f} ms across {int(by_op['count'].sum())} op calls",
+            header,
+            "-" * len(header),
+            *rows,
+        ]
+    )
+    logger.info("\n" + table)
+    print("\n" + table)  # ensure full table reaches stdout even if logging is filtered
+
+    by_op.reset_index().to_csv(CSV_OUT, index=False)
+    logger.info(f"per-op CSV written to {os.path.abspath(CSV_OUT)}")

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_vs_trace.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_vs_trace.py
@@ -1,0 +1,533 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+DeepSeek V3.2 MLA/indexer/KV-cache vs the OFFICIAL reference values.
+
+Unlike test_mla.py (whose truth is the in-repo MLACPU model), the truth here is
+the recorded output of the official DeepSeek-V3.2 CUDA stack, captured from a
+vLLM run (a single 5120-token prefill) and stored as safetensors streams.
+Reference layers available: 0, 30, 60.
+
+Streams (per layer L), loaded by load_stream:
+  module_io/mla_input_layer_L     [5120, 7168] bf16   (== indexer_input)
+  module_io/mla_output_layer_L    [5120, 7168] bf16
+  dsa/indexer_logits_layer_L      [5120, 5120] fp32   (pre-causal-mask index_score)
+  dsa/dsa_topk_indices_layer_L    [5120, 2048] int32  (-1 = unfilled / causal pad)
+  kv_cache/layer_L                [5120, 576]  bf16   (latent kv 512 ++ k_pe 64)
+
+The reference dir defaults to the sibling bit_sculpt checkout; override with
+$DEEPSEEK_V32_REF_DIR. Pretrained layer weights are pulled from HF on demand
+(cached) by pretrained_mla_weights(layer=L) — multi-GB shards, downloaded once.
+
+FUNCTIONAL-PARITY caveat: the reference ran the real FP8 (ue8m0)
++ Hadamard indexer path and an fp8 KV cache; our port runs the bf16 functional
+path (use_fp8_path=False, simulate_fp8=False). Hadamard is orthogonal (q·k
+unchanged) but fp8 adds quantization noise, so PCC is high-but-not-exact BY
+DESIGN. Thresholds below absorb that gap; the tests log actual numbers.
+
+KNOWN k_pe ROPE-FRAME ARTIFACT: the KV-cache k_pe slice (last 64) compares poorly
+element-wise (~0.43 PCC) because the reference stores it in a different RoPE
+frame (rotate_half vs our interleaved). This is harmless — RoPE preserves the
+per-row L2 norm (matches to ~0.4%) and q·k is frame-invariant, so the MLA output
+matches at ~0.9998. The KV tests therefore assert the latent slice + a
+frame-invariant L2 check on k_pe, and log the raw k_pe PCC as a diagnostic only.
+For cross-stack interop (a vLLM-written cache consumed by our kernel, or vice versa)
+the layout DOES matter: pass --ds-kpe-layout vllm to reindex our k_pe to vLLM's
+half-split layout (interleaved_to_halfsplit_perm in tt/mla/rope.py) and assert a hard
+element-wise k_pe PCC (~0.99997) instead of the frame-invariant L2.
+
+Runtime (Blackhole 1x4, layer shard already downloaded — measured layer 0):
+  host_*  (CPU only)            ~25 s for all 3 (shared module fixture: weight load +
+                                one 5120 forward; the 3 asserts are ~0 s each)
+  device indexer                ~45 s  (10 s mesh setup + 30 s device stems/score/topk)
+  device kv                     ~65 s  (forward + sparse_mla host fallback, ~24 GB RAM)
+  device mla                    ~50 s  (forward + sparse_mla host fallback, ~24 GB RAM)
+First run adds one-time JIT kernel compile (~1-2 min) and, if uncached, a multi-GB
+HF shard download. All are correctness gates → marked `gate`; @timeout(0).
+
+────────────────────────────────────────────────────────────────────────────────
+GLM-5.1 (model id `glm_5_1`) — same harness, different model
+────────────────────────────────────────────────────────────────────────────────
+GLM-5.1 (`zai-org/GLM-5.1`, HF `glm_moe_dsa`) is a DeepSeek-V3.2-family model (MLA +
+DSA indexer + sparse attn); its vLLM trace mirrors the V3.2 layout, so every test
+body below is shared. The host/device tests are parametrized over `model` ∈
+{deepseek_v32, glm_5_1} (filter with `-k glm_5_1` / `-k deepseek_v32`). GLM differs
+only in: hidden 6144 (vs 7168); 64 q-heads (vs 128) → sparse_sdpa needs per-chip
+H = 64/tp ≥ 32, so **tp ≤ 2** (tp>2 meshes are skipped for GLM); indexer RoPE is
+INTERLEAVED (DS's is not); and NO YaRN (scale = qk_head_dim**-0.5). The config is
+hand-built (transformers can't load glm_moe_dsa) and weights load from
+zai-org/GLM-5.1 via the identical HF→MLACPU map. Trace dir: $GLM51_REF_DIR (default
+<repo>/bit_sculpt/results/glm-51); layers 0/30/60/77. The GLM-only CPU-only block at
+the bottom validates the trace bundle (no weights/device).
+"""
+
+import glob
+import os
+from pathlib import Path
+
+import pytest
+import torch
+from loguru import logger
+from ttnn.device import is_blackhole
+
+import ttnn
+from models.common.utility_functions import comp_pcc
+from models.demos.deepseek_v3_d_p.reference.cpu_deepseek_v32 import SparseMLAReference, pretrained_mla_weights
+from models.demos.deepseek_v3_d_p.reference.cpu_deepseek_v32.weights import DEFAULT_REPO
+from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config, glm_hf_config  # GLM dims + HF config
+from models.demos.deepseek_v3_d_p.tests.conftest import _resolve_config_only  # == the config_only fixture
+from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_mesh import (
+    parametrize_mesh_device,
+    skip_if_seq_too_small_for_sp,
+)
+from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_plugin import is_marker_explicitly_selected
+from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
+from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup, interleaved_to_halfsplit_perm
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
+from models.demos.deepseek_v3_d_p.utils.test_utils import WH_WORKER_L1_SIZE
+
+# Bespoke suite: validated against recorded vLLM trace bundles (indexer logits/topk, sparse output,
+# k_pe frame), so it stays here rather than on the v3.1 TestVariant infra. `trace` marks it as a
+# trace-bundle parity test (run separately from the CI correctness matrix).
+pytestmark = pytest.mark.trace
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _require_trace_marker(request):
+    if not is_marker_explicitly_selected(request.config, "trace"):
+        pytest.skip("sparse MLA trace tests require explicit marker selection: pytest -m trace")
+
+
+SEQ_LEN = 5120  # the reference prefill length (fixed by the capture)
+REF_LAYERS = [0, 30, 60]
+
+# Thresholds — functional-parity (fp8 ref vs bf16 port). Observed layer 0:
+# logits 0.96, topk mean 0.985 (min row 0.91), latent 0.998, output 0.9998.
+LOGITS_PCC = 0.95
+TOPK_OVERLAP_MEAN = 0.95
+TOPK_OVERLAP_ROW_MIN = 0.85
+KV_LATENT_PCC = 0.99
+KV_PE_L2_RELERR_MAX = 0.05  # frame-invariant: per-row ||k_pe|| must match
+KV_PE_VLLM_PCC = 0.999  # element-wise, once our k_pe is reindexed to vLLM's half-split layout
+OUTPUT_PCC = 0.98
+
+
+# ----------------------------------------------------------------------------
+# GLM-5.1 specifics. The DeepSeek-V3.2 code below is unchanged; GLM reuses every
+# test body and differs only here: its config/weights builders, its layer set, and
+# the tp ≤ 2 mesh cap. (model, layer) cases drive the shared host/device tests.
+# ----------------------------------------------------------------------------
+GLM_REF_LAYERS = [0, 30, 60, 77]  # indexer_logits captured for these (topk/kv exist for all 78)
+GLM_REPO = os.environ.get("GLM51_REPO", "zai-org/GLM-5.1")  # bf16 master; "-FP8" also works (loader dequants)
+# (model, layer) cases — DS and GLM share every host/device body.
+_CASES = [("deepseek_v32", l) for l in REF_LAYERS] + [("glm_5_1", l) for l in GLM_REF_LAYERS]
+_CASE_IDS = [f"{m}-L{l}" for m, l in _CASES]
+
+
+# GLM HF-attribute config (transformers can't load glm_moe_dsa). Module-local alias.
+_glm_hf_config = glm_hf_config
+
+
+def _weights_for(model: str, config, layer: int):
+    """Pretrained canonical weights for (model, layer) — the one dict feeding both ttMLA and the CPU
+    reference (GLM has its own repo; DS uses the V3.2 repo). fp8 is dequantized on load."""
+    return pretrained_mla_weights(config, layer=layer, repo=GLM_REPO if model == "glm_5_1" else DEFAULT_REPO)
+
+
+# ----------------------------------------------------------------------------
+# Reference loading
+# ----------------------------------------------------------------------------
+def _ref_dir(model: str) -> Path:
+    """Trace bundle dir for `model`: $GLM51_REF_DIR / $DEEPSEEK_V32_REF_DIR, else the in-tree
+    bit_sculpt checkout at the repo root. This file lives at tests/sparse_mla/, so the repo root
+    (<...>/tt-metal, which holds bit_sculpt/) is parents[5]."""
+    sub = "glm-51" if model == "glm_5_1" else "deepseek-v32"
+    env = os.environ.get("GLM51_REF_DIR" if model == "glm_5_1" else "DEEPSEEK_V32_REF_DIR")
+    return Path(env) if env else Path(__file__).resolve().parents[5] / "bit_sculpt" / "results" / sub
+
+
+def load_stream(stream_dir: Path) -> torch.Tensor:
+    """One (stream, layer) → full tensor; single-file or chunked rows_*.safetensors."""
+    from safetensors.torch import load_file
+
+    files = sorted(glob.glob(f"{stream_dir}/rows_*.safetensors"))
+    parts = []
+    for f in files:
+        d = load_file(f)
+        (key,) = d.keys()
+        parts.append(d[key])
+    return torch.cat(parts, dim=0)
+
+
+def load_reference(model: str, layer: int) -> dict:
+    """Load every reference stream for (`model`, `layer`), or skip if the data is absent."""
+    root = _ref_dir(model)
+    need = {
+        "mla_in": root / "module_io" / f"mla_input_layer_{layer}",
+        "mla_out": root / "module_io" / f"mla_output_layer_{layer}",
+        "logits": root / "dsa" / f"indexer_logits_layer_{layer}",
+        "topk": root / "dsa" / f"dsa_topk_indices_layer_{layer}",
+        "kv": root / "kv_cache" / f"layer_{layer}",
+    }
+    if model == "glm_5_1":
+        need["idx_in"] = root / "module_io" / f"indexer_input_layer_{layer}"  # for the trace-internal checks
+    missing = [str(p) for p in need.values() if not glob.glob(f"{p}/rows_*.safetensors")]
+    if missing:
+        env = "GLM51_REF_DIR" if model == "glm_5_1" else "DEEPSEEK_V32_REF_DIR"
+        pytest.skip(f"{model} reference streams not found (set ${env}): missing {missing}")
+    return {k: load_stream(v) for k, v in need.items()}
+
+
+def _topk_overlap(ref_topk: torch.Tensor, got_topk: torch.Tensor, rows) -> dict:
+    """Per-row Jaccard-style overlap |ref ∩ got| / |ref| over the causal valid set."""
+    out = {}
+    for r in rows:
+        n = min(r + 1, ref_topk.shape[1])
+        want = set(ref_topk[r][ref_topk[r] >= 0].tolist())
+        got = got_topk[r]
+        got = set(got[(got >= 0) & (got < SEQ_LEN) & (got <= r)].tolist())
+        out[r] = len(want & got) / max(1, len(want))
+    return out
+
+
+# ----------------------------------------------------------------------------
+# Host ceiling: MLACPU (the in-repo golden) vs the official reference.
+# Establishes the achievable PCC — any device gap above this is a port issue,
+# not a model-formulation gap. CPU only, no device needed.
+# ----------------------------------------------------------------------------
+@pytest.fixture(scope="module")
+def _host(request):
+    """Run MLACPU once per (model, layer): returns (logits, topk, kvpe, output) + reference.
+    NOTE: the full forward at seq5120 is slow on CPU (minutes) — prefer the device tests."""
+    model, layer = request.param
+    ref = load_reference(model, layer)
+    config = _config_for(model)
+    sref = SparseMLAReference(config, _weights_for(model, config, layer), seq_len=SEQ_LEN)
+    x = ref["mla_in"].unsqueeze(0)  # [1, S, hidden]
+    out = sref.forward(x)[0]  # single pass: also fills caches + indexer logits/topk
+    return dict(
+        ref=ref,
+        logits=sref.indexer_logits[0],  # [S, S]
+        topk=sref.indexer_topk[0],  # [S, k]
+        kvpe=sref.kvpe_cache[0, 0],  # [S, 576]
+        out=out,
+    )
+
+
+@pytest.mark.parametrize("_host", _CASES, ids=_CASE_IDS, indirect=True)
+def test_indexer_host_vs_reference(_host):
+    """Host indexer logits + top-k vs the official capture. ~1-2 min."""
+    ref, logits = _host["ref"], _host["logits"]
+    tril = torch.tril(torch.ones(SEQ_LEN, SEQ_LEN, dtype=torch.bool))
+    _, pcc = comp_pcc(ref["logits"][tril].float(), logits[tril].float(), 0)
+    logger.info(f"[host] indexer logits PCC (causal region): {pcc}")
+    rows = [0, 1, 100, 1000, 2047, 2048, 2049, 3000, 4096, SEQ_LEN - 1]
+    ov = _topk_overlap(ref["topk"], _host["topk"], rows)
+    mean = sum(ov.values()) / len(ov)
+    logger.info(f"[host] topk overlap mean={mean:.4f} per-row={ {r: round(v,4) for r,v in ov.items()} }")
+    assert pcc >= LOGITS_PCC, f"indexer logits PCC {pcc} < {LOGITS_PCC}"
+    assert mean >= TOPK_OVERLAP_MEAN, f"topk overlap mean {mean} < {TOPK_OVERLAP_MEAN}"
+    assert min(ov.values()) >= TOPK_OVERLAP_ROW_MIN, f"topk overlap row min {min(ov.values())} < {TOPK_OVERLAP_ROW_MIN}"
+
+
+@pytest.mark.parametrize("_host", _CASES, ids=_CASE_IDS, indirect=True)
+def test_kv_cache_host_vs_reference(_host, ds_kpe_layout):
+    """Host KV cache vs the official capture: latent PCC + k_pe (--ds-kpe-layout). ~1-2 min."""
+    ref_kv, kvpe = _host["ref"]["kv"], _host["kvpe"]
+    _assert_kv(ref_kv, kvpe, tag="host", kpe_layout=ds_kpe_layout)
+
+
+@pytest.mark.parametrize("_host", _CASES, ids=_CASE_IDS, indirect=True)
+def test_mla_output_host_vs_reference(_host):
+    """Host MLA output vs the official capture. ~1-2 min."""
+    _, pcc = comp_pcc(_host["ref"]["mla_out"].float(), _host["out"].float(), 0)
+    logger.info(f"[host] MLA output PCC: {pcc}")
+    assert pcc >= OUTPUT_PCC, f"MLA output PCC {pcc} < {OUTPUT_PCC}"
+
+
+def _assert_kv(ref_kv: torch.Tensor, kvpe: torch.Tensor, tag: str, kpe_layout: str = "interleaved"):
+    """Shared KV-cache assertion. Always asserts the latent-512 PCC. For the k_pe
+    rope half (last 64) the check depends on kpe_layout (--ds-kpe-layout):
+
+      "interleaved" (default): our/official layout differs from vLLM's only by a
+        RoPE-frame permutation, so a raw element-wise PCC is meaningless. Assert a
+        frame-INVARIANT per-row L2 match; log raw k_pe PCC as a diagnostic.
+      "vllm": reindex our k_pe to vLLM's half-split layout via
+        interleaved_to_halfsplit_perm() (see rope.py) and assert element-wise PCC —
+        the hard check for cross-stack KV-cache interop."""
+    kv = 512
+    _, lat = comp_pcc(ref_kv[:, :kv].float(), kvpe[:, :kv].float(), 0)
+    assert lat >= KV_LATENT_PCC, f"KV latent PCC {lat} < {KV_LATENT_PCC}"
+    pe_ref, pe_got = ref_kv[:, kv:].float(), kvpe[:, kv:].float()
+    if kpe_layout == "vllm":
+        pe_got = pe_got[:, interleaved_to_halfsplit_perm(pe_got.shape[1])]
+        _, pe_pcc = comp_pcc(pe_ref, pe_got, 0)
+        logger.info(f"[{tag}] KV latent PCC={lat}  k_pe PCC (vLLM half-split layout)={pe_pcc}")
+        assert pe_pcc >= KV_PE_VLLM_PCC, f"k_pe (vLLM-layout) PCC {pe_pcc} < {KV_PE_VLLM_PCC}"
+    else:
+        _, pe_pcc = comp_pcc(pe_ref, pe_got, 0)
+        pe_l2_relerr = ((pe_got.norm(dim=1) - pe_ref.norm(dim=1)).abs() / (pe_ref.norm(dim=1) + 1e-3)).mean().item()
+        logger.info(f"[{tag}] KV latent PCC={lat}  k_pe PCC={pe_pcc} (frame diag)  k_pe L2 rel-err={pe_l2_relerr:.4f}")
+        assert pe_l2_relerr <= KV_PE_L2_RELERR_MAX, f"k_pe L2 rel-err {pe_l2_relerr} > {KV_PE_L2_RELERR_MAX}"
+
+
+# ----------------------------------------------------------------------------
+# Device: the TT implementation vs the official reference (Blackhole 1x4).
+# ----------------------------------------------------------------------------
+_DEVICE_PARAMS = [
+    {
+        "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+        "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
+    }
+]
+
+
+def _config_for(model: str):
+    """ttMLA HF-style config (carries the DSA index_* fields). Both are hand-built — transformers can't
+    load glm_moe_dsa / deepseek_v32. DS uses the V3.2 config (NOT the dense R1 one): the indexer needs the
+    real index_* fields, not the getattr defaults the dense config would silently fall back to."""
+    return _glm_hf_config() if model == "glm_5_1" else _resolve_config_only("deepseek_v32")
+
+
+def _skip_unsupported(model: str, mesh_device) -> None:
+    """Shared device guards: too-few-tokens-per-SP-chip (both); and GLM's tp ≤ 2 (64 q-heads,
+    sparse_sdpa needs per-chip H = 64/tp ≥ 32 → tp>2 meshes are skipped for GLM)."""
+    skip_if_seq_too_small_for_sp(SEQ_LEN, mesh_device)
+    if model == "glm_5_1" and mesh_device.shape[1] > 2:
+        pytest.skip(f"GLM sparse_sdpa needs per-chip H=64/tp≥32 → tp≤2 (mesh tp={mesh_device.shape[1]})")
+
+
+def _make_mla(model, config, layer, mesh_device, is_chunked=False):
+    config.max_seq_len = SEQ_LEN  # rope-table length (same hack as v3 run_model / test_mla)
+    weights = _weights_for(model, config, layer)  # canonical dict — same tensors the CPU truth uses
+    return ttMLA(
+        config, weights, mesh_device, layer_idx=0, seq_len=SEQ_LEN, sp_axis=0, tp_axis=1, is_chunked=is_chunked
+    )
+
+
+def _shard_idx_input(t, mesh_device):
+    """Indexer input [1,1,S,hidden]: SP-shard the sequence (dim -2, mesh axis 0) and TP-shard hidden
+    (dim -1, axis 1) — the same SP×TP layout the MLA forward uses. At SP=1 the SP shard is a no-op;
+    at SP>1 each chip holds S/sp tokens, so _indexer.forward's SP all-gather rebuilds the global seq."""
+    return ttnn.from_torch(
+        t,
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=(-2, -1)),
+    )
+
+
+@parametrize_mesh_device()
+@pytest.mark.parametrize("device_params", _DEVICE_PARAMS, ids=["line"], indirect=True)
+@pytest.mark.parametrize("model, layer", _CASES, ids=_CASE_IDS)
+@pytest.mark.timeout(0)
+def test_indexer_device_vs_reference(mesh_device, model, layer, device_params, monkeypatch):
+    """Device indexer (stems + indexer_score + top-k) vs the official capture. ~2-3 min."""
+    _skip_unsupported(model, mesh_device)
+    ref = load_reference(model, layer)
+    mla = _make_mla(model, _config_for(model), layer, mesh_device)
+    x = ref["mla_in"].reshape(1, 1, SEQ_LEN, -1)  # [1,1,S,hidden]
+
+    captured = {}
+    # Capture the FULL head-summed logits that feed top-k. Under TP head-sharding the head-sum is split
+    # across tp: indexer_score returns this chip's PARTIAL (H_idx/tp heads) and _indexer.forward all-reduces
+    # the partials before top-k. So capture top-k's input by patching the ttnn op the indexer calls.
+    orig_topk = ttnn.experimental.topk_large_indices
+
+    def _capture_topk(logits, k):
+        captured["logits"] = logits
+        return orig_topk(logits, k=k)
+
+    monkeypatch.setattr(ttnn.experimental, "topk_large_indices", _capture_topk)
+    # _indexer.forward takes the per-chip (SP-local) sequence; it all-gathers back to the global glob.
+    xs = _shard_idx_input(x, mesh_device)
+    sl = SEQ_LEN // mesh_device.shape[0]
+    qr = mla._q_a_latent(xs, sl, mla._get_act_mem_config("q_b_proj", sl))
+    idx = mla._indexer.forward(xs, qr, sl)
+
+    # The indexer is now query-SP-sharded: top-k input is [1,1,S/sp,end_pos] (TP-replicated) and idx is
+    # [1,1,S/sp,k]. Reassemble the full S by concatenating the SP shards (tp=0 column) along the query dim.
+    sp_, tp_ = list(mesh_device.shape)
+    _sp_gather = lambda t: torch.cat([ttnn.to_torch(ttnn.get_device_tensors(t)[r * tp_]) for r in range(sp_)], dim=2)
+    logits = _sp_gather(captured["logits"]).float()[0, 0]  # [S, S]; future cols -inf
+    got_topk = _sp_gather(idx).long()[0, 0]  # [S, k]
+    # PCC only over the causal region (device masks future to -inf; ref is pre-mask).
+    tril = torch.tril(torch.ones(SEQ_LEN, SEQ_LEN, dtype=torch.bool))
+    _, pcc = comp_pcc(ref["logits"][tril].float(), logits[tril], 0)
+    logger.info(f"[device {model} L{layer}] indexer logits PCC (causal region): {pcc}")
+    rows = [0, 1, 100, 1000, 2047, 2048, 2049, 3000, 4096, SEQ_LEN - 1]
+    ov = _topk_overlap(ref["topk"], got_topk, rows)
+    mean = sum(ov.values()) / len(ov)
+    logger.info(
+        f"[device {model} L{layer}] topk overlap mean={mean:.4f} per-row={ {r: round(v,4) for r,v in ov.items()} }"
+    )
+    ttnn.synchronize_device(mesh_device)
+    assert pcc >= LOGITS_PCC, f"indexer logits PCC {pcc} < {LOGITS_PCC}"
+    assert mean >= TOPK_OVERLAP_MEAN, f"topk overlap mean {mean} < {TOPK_OVERLAP_MEAN}"
+    assert min(ov.values()) >= TOPK_OVERLAP_ROW_MIN, f"topk overlap row min {min(ov.values())} < {TOPK_OVERLAP_ROW_MIN}"
+
+
+def _run_device_forward(model, config, layer, mesh_device):
+    """Single-shot ttMLA forward over the reference input; returns (ref, output[1,S,hidden], kvpe[S,576])."""
+    ref = load_reference(model, layer)
+    mla = _make_mla(model, config, layer, mesh_device)
+    sp_axis, tp_axis = 0, 1
+    kvpe_cache = init_kvpe_cache(
+        kvpe_cache_head_dim=config.kv_lora_rank + config.qk_rope_head_dim,
+        mesh_device=mesh_device,
+        seq_len=SEQ_LEN,
+        mesh_shape=list(mesh_device.shape),
+        sp_axis=sp_axis,
+        num_kvpe_cache_layers=1,
+    )
+    rope_tensors = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=False).get_rope_tensors(SEQ_LEN)
+
+    shard_dims = [None, None]
+    shard_dims[tp_axis], shard_dims[sp_axis] = -1, -2
+    tt_x = ttnn.from_torch(
+        ref["mla_in"].reshape(1, 1, SEQ_LEN, -1),
+        device=mesh_device,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims),
+    )
+    out = mla.forward(tt_x, rope_tensors, kvpe_cache)
+    out_t = ttnn.to_torch(
+        out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=shard_dims, mesh_shape=mesh_device.shape)
+    ).to(torch.bfloat16)[
+        0
+    ]  # [1, S, hidden]
+    # KVPE: replicated across TP — concat TP replicas on the unused dim 1, keep first.
+    kvpe_t = ttnn.to_torch(
+        kvpe_cache, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape)
+    ).to(torch.bfloat16)[
+        0, 0, :SEQ_LEN
+    ]  # [S, 576]
+    return ref, out_t, kvpe_t
+
+
+@parametrize_mesh_device()
+@pytest.mark.parametrize("device_params", _DEVICE_PARAMS, ids=["line"], indirect=True)
+@pytest.mark.parametrize("model, layer", _CASES, ids=_CASE_IDS)
+@pytest.mark.timeout(0)
+def test_kv_cache_device_vs_reference(mesh_device, model, layer, device_params, ds_kpe_layout):
+    """Device KV cache vs the official capture: latent PCC + k_pe (--ds-kpe-layout). ~4-7 min."""
+    _skip_unsupported(model, mesh_device)
+    ref, _, kvpe = _run_device_forward(model, _config_for(model), layer, mesh_device)
+    _assert_kv(ref["kv"], kvpe, tag=f"device {model} L{layer}", kpe_layout=ds_kpe_layout)
+    ttnn.synchronize_device(mesh_device)
+
+
+@parametrize_mesh_device()
+@pytest.mark.parametrize("device_params", _DEVICE_PARAMS, ids=["line"], indirect=True)
+@pytest.mark.parametrize("model, layer", _CASES, ids=_CASE_IDS)
+@pytest.mark.timeout(0)
+def test_mla_output_device_vs_reference(mesh_device, model, layer, device_params):
+    """Device MLA output vs the official capture. ~4-7 min (sparse_mla host fallback)."""
+    _skip_unsupported(model, mesh_device)
+    ref, out, _ = _run_device_forward(model, _config_for(model), layer, mesh_device)
+    tt = out.unsqueeze(0)  # [1,1,S,hidden] -> compare as [1,S,hidden]
+    ref_out = ref["mla_out"].reshape(1, SEQ_LEN, -1)
+    for nm, sl in [("rows<2048", slice(0, 2048)), ("rows>=2048", slice(2048, SEQ_LEN))]:
+        _, m = comp_pcc(ref_out[:, sl].float(), out[:, sl].float(), 0)
+        logger.info(f"[device {model} L{layer}] band {nm}: {m}")
+    _, pcc = comp_pcc(ref_out.float(), out.float(), 0)
+    logger.info(f"[device {model} L{layer}] MLA output PCC: {pcc}")
+    ttnn.synchronize_device(mesh_device)
+    assert pcc >= OUTPUT_PCC, f"MLA output PCC {pcc} < {OUTPUT_PCC}"
+
+
+# ════════════════════════════════════════════════════════════════════════════════
+# GLM-5.1 trace-internal consistency (no weights, no device).
+# Validates that the captured GLM bundle is well-formed and self-consistent (and that
+# the loader is correct), independent of any model. GLM-only: the shape asserts use
+# GLM dims. Filter: -k "glm_5_1 and not host and not device".
+# ════════════════════════════════════════════════════════════════════════════════
+_GLM_D = GLM51Config.EMB_SIZE  # 6144
+_GLM_KV_LORA = GLM51Config.KV_LORA_RANK  # 512  (latent kv; also the V width)
+_GLM_ROPE = GLM51Config.QK_ROPE_HEAD_DIM  # 64   (k_pe)
+_GLM_KVPE = _GLM_KV_LORA + _GLM_ROPE  # 576
+_GLM_INDEX_TOPK = GLM51Config.INDEX_TOPK  # 2048
+# Boundary-probing rows around the index_topk=2048 cutover.
+_PROBE_ROWS = [0, 1, 100, 1000, 2047, 2048, 2049, 3000, 4096, SEQ_LEN - 1]
+_SELFTEST_OVERLAP_MIN = 0.99  # the GPU's own logits must reproduce its own top-k
+
+
+@pytest.fixture(scope="module")
+def trace(request):
+    """One GLM layer's full reference bundle, loaded once per parametrized layer."""
+    return load_reference("glm_5_1", request.param)
+
+
+@pytest.mark.parametrize("trace", GLM_REF_LAYERS, ids=[f"glm_5_1-L{l}" for l in GLM_REF_LAYERS], indirect=True)
+def test_trace_shapes_and_dtypes(trace):
+    """Every stream has the GLM-config shape/dtype and contains no NaN/Inf."""
+    assert trace["mla_in"].shape == (SEQ_LEN, _GLM_D), trace["mla_in"].shape
+    assert trace["mla_out"].shape == (SEQ_LEN, _GLM_D), trace["mla_out"].shape
+    assert trace["idx_in"].shape == (SEQ_LEN, _GLM_D), trace["idx_in"].shape
+    assert trace["logits"].shape == (SEQ_LEN, SEQ_LEN), trace["logits"].shape
+    assert trace["logits"].dtype == torch.float32, trace["logits"].dtype
+    assert trace["topk"].shape == (SEQ_LEN, _GLM_INDEX_TOPK), trace["topk"].shape
+    assert trace["topk"].dtype == torch.int32, trace["topk"].dtype
+    assert trace["kv"].shape == (SEQ_LEN, _GLM_KVPE), trace["kv"].shape
+    for k in ("mla_in", "mla_out", "idx_in", "kv"):
+        assert torch.isfinite(trace[k].float()).all(), f"{k} has non-finite values"
+    assert torch.isfinite(trace["logits"]).all(), "logits has non-finite values"
+
+
+@pytest.mark.parametrize("trace", GLM_REF_LAYERS, ids=[f"glm_5_1-L{l}" for l in GLM_REF_LAYERS], indirect=True)
+def test_indexer_input_equals_mla_input(trace):
+    """The same post-input_layernorm hidden feeds both MLA and the indexer."""
+    assert torch.equal(trace["idx_in"], trace["mla_in"])
+
+
+@pytest.mark.parametrize("trace", GLM_REF_LAYERS, ids=[f"glm_5_1-L{l}" for l in GLM_REF_LAYERS], indirect=True)
+def test_topk_causal_and_sentinel(trace):
+    """dsa_topk_indices is already causal; -1 pads rows with < index_topk valid keys.
+    For row r: exactly min(r+1, k) distinct non-neg indices, all in [0, r]; and for
+    r < k the selected set is the entire causal prefix {0..r} (nothing to choose)."""
+    tk = trace["topk"]
+    for r in _PROBE_ROWS:
+        nonneg = tk[r][tk[r] >= 0]
+        assert nonneg.numel() == min(r + 1, _GLM_INDEX_TOPK), (r, nonneg.numel())
+        assert int(nonneg.max()) <= r and int(nonneg.min()) >= 0, (r, int(nonneg.max()))
+        assert nonneg.unique().numel() == nonneg.numel(), f"row {r} has duplicate indices"
+        if r + 1 <= _GLM_INDEX_TOPK:
+            assert set(nonneg.tolist()) == set(range(r + 1)), f"row {r} not the full causal prefix"
+    rows = torch.arange(SEQ_LEN, dtype=tk.dtype).unsqueeze(1)
+    valid = tk >= 0
+    assert bool((tk[valid] < SEQ_LEN).all()), "a selected index is >= SEQ_LEN"
+    assert bool(((tk <= rows) | ~valid).all()), "a selected index is in the future (> its row)"
+
+
+@pytest.mark.parametrize("trace", GLM_REF_LAYERS, ids=[f"glm_5_1-L{l}" for l in GLM_REF_LAYERS], indirect=True)
+def test_logits_reproduce_topk(trace):
+    """Headline self-consistency: argtop_k(logits[t, :t+1]) == dsa_topk_indices[t].
+    Proves the captured logits and top-k are a matched pair (and the loader is
+    correct) — independent of any model weights. Set-overlap absorbs fp32 ties."""
+    lg, tk = trace["logits"], trace["topk"]
+    ov = {}
+    for r in _PROBE_ROWS:
+        k = min(r + 1, _GLM_INDEX_TOPK)
+        got = set(torch.topk(lg[r, : r + 1].float(), k).indices.tolist())
+        want = set(tk[r][tk[r] >= 0].tolist())
+        ov[r] = len(want & got) / max(1, len(want))
+    mean = sum(ov.values()) / len(ov)
+    logger.info(
+        f"[glm_5_1 trace] logits→topk self-overlap mean={mean:.5f} per-row={ {r: round(v, 4) for r, v in ov.items()} }"
+    )
+    assert min(ov.values()) >= _SELFTEST_OVERLAP_MIN, f"logits do not reproduce topk: {ov}"
+
+
+@pytest.mark.parametrize("trace", GLM_REF_LAYERS, ids=[f"glm_5_1-L{l}" for l in GLM_REF_LAYERS], indirect=True)
+def test_kv_split_sanity(trace):
+    """kv_cache is [latent kv_lora=512 ‖ k_pe=64]; both halves finite. Logs the
+    per-half magnitude (latent is small/compressed; k_pe carries the rope key)."""
+    kv = trace["kv"]
+    latent, kpe = kv[:, :_GLM_KV_LORA].float(), kv[:, _GLM_KV_LORA:].float()
+    assert kpe.shape[1] == _GLM_ROPE, kpe.shape
+    assert torch.isfinite(latent).all() and torch.isfinite(kpe).all()
+    logger.info(f"[glm_5_1 trace] kv latent |mean|={latent.abs().mean():.4f}  k_pe |mean|={kpe.abs().mean():.4f}")

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -1,0 +1,501 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DeepSeek-V3.2 / GLM DSA lightning indexer (top-k key selection for sparse MLA).
+
+A self-contained component owned by ttMLA. It owns the indexer-only state (weights, device
+index-key cache, RoPE tables, arch constants) and runs the on-device stems / RoPE / collectives
+/ logits / top-k. The shared q_a latent (qr) is passed into forward() by ttMLA; everything else it
+reuses from the MLA layer — the SP×TP mesh + axes, compute-kernel configs, softmax scale,
+weight-cache location and the CCL handles — is injected through the constructor; the indexer holds
+no reference back to ttMLA (and no MLA weights) and runs its own TP/SP collectives. Inert for dense
+v3.1 (no indexer weights → ttMLA never builds it).
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3_d_p.tt.mla.rope import get_cos_sin_matrix, get_rot_transformation_mat
+
+# DSA indexer weight names are owned by TtIndexer.WEIGHT_NAMES (single source of truth). A
+# module-level INDEXER_WEIGHT_NAMES alias is defined at the bottom of this file for back-compat.
+
+
+class TtIndexer:
+    """DSA lightning indexer for one MLA layer. Self-contained: owns the indexer weights, the
+    grown-by-concat device index-key cache and the indexer RoPE tables, and runs its own TP/SP
+    collectives. All MLA-layer dependencies it reuses are injected at construction (no ttMLA ref)."""
+
+    # --- DSA ownership: weight names, config-field detection, host/cache API. ttMLA routes all
+    # indexer weight-name / config-field / cache-file / placeholder decisions through these so the
+    # DSA facts live here, not in ttMLA. Mirrors dense ttMLA's check/build/convert cache pattern.
+    WEIGHT_NAMES = (
+        "indexer.wq_b",
+        "indexer.wk",
+        "indexer.k_norm",
+        "indexer.k_norm_bias",
+        "indexer.weights_proj",
+    )
+    # Config fields that mark a runtime config as DSA-sparse (index_rope_interleave is optional and
+    # defaults to False; the three below are the discriminator vs a dense DeepSeek-V3 / R1 config).
+    REQUIRED_CONFIG_FIELDS = ("index_topk", "index_n_heads", "index_head_dim")
+
+    @classmethod
+    def matches_config(cls, config) -> bool:
+        """True iff the runtime config carries the DSA indexer fields (dense R1/V3 lacks them)."""
+        return all(getattr(config, name, None) is not None for name in cls.REQUIRED_CONFIG_FIELDS)
+
+    @classmethod
+    def has_host_weights(cls, state_dict) -> bool:
+        """True iff a live state dict carries all indexer host tensors (from-weights callers)."""
+        return bool(state_dict) and all(f"{n}.weight" in state_dict for n in cls.WEIGHT_NAMES)
+
+    @classmethod
+    def extract_host_weights(cls, state_dict) -> dict:
+        """Non-mutating pull of the indexer host tensors out of a state dict (keyed by WEIGHT_NAMES)."""
+        return {n: state_dict[f"{n}.weight"] for n in cls.WEIGHT_NAMES if f"{n}.weight" in state_dict}
+
+    @staticmethod
+    def _cache_short_name(weight_name: str) -> str:
+        return weight_name.split(".")[-1]  # "indexer.wq_b" -> "wq_b"
+
+    @classmethod
+    def check_cache_complete(cls, cache_path, cache_name_prefix: str) -> bool:
+        """True iff every indexer tensorbin exists under cache_name_prefix (e.g. 'layer_0.mla').
+        Uses a direct ``Path.glob`` (no `init_checker`/global-state dependency) because this also runs
+        at ttMLA construction time — the resolver / __init__ gate — where the global fast-cache checker
+        is not necessarily initialized. It's a one-off per-layer check (5 files), so the batch
+        fast-checker optimization isn't needed here. Indexer files are `{prefix}.indexer_{short}` — a
+        disjoint prefix space from the dense MLA names, so dense and indexer checks never alias."""
+        if cache_path is None:
+            return False
+        cache_path = Path(cache_path)
+        for name in cls.WEIGHT_NAMES:
+            short = cls._cache_short_name(name)
+            if not any(cache_path.glob(f"{cache_name_prefix}.indexer_{short}*.tensorbin")):
+                logger.debug(f"TTNN indexer cache missing: {cache_name_prefix}.indexer_{short}")
+                return False
+        return True
+
+    @classmethod
+    def build_ttnn_cache(
+        cls, idx_host, cache_path, mesh_device, config, layer_idx, sp_axis: int = 0, tp_axis: int = 1
+    ) -> None:
+        """Write the indexer tensorbins to disk (device=None, no device copy)."""
+        cls._convert_and_cache_weights(
+            idx_host, mesh_device, config, layer_idx, sp_axis, tp_axis, cache_path=cache_path, device=None
+        )
+
+    @classmethod
+    def _convert_and_cache_weights(
+        cls, idx_host, mesh_device, config, layer_idx, sp_axis: int = 0, tp_axis: int = 1, cache_path=None, device=None
+    ):
+        """Indexer weights → device (or cache). Mirrors dense MLA's converter:
+        - host tensors present: transpose/shard/replicate and (optionally) write the cache;
+        - `idx_host` falsy + `device=mesh_device`: build `torch.empty()` placeholders in the host
+          (pre-transpose) shapes and rely on existing tensorbins (`as_tensor` ignores the placeholder
+          on a cache hit);
+        - `device=None`: build the cache only, return None.
+        Returns the device-tensor dict keyed by short name (wq_b/wk/weights_proj/k_norm/k_norm_bias),
+        or None when device is None. Cache filenames stay byte-compatible with the previously
+        opportunistic `layer_{i}.mla.indexer_*` files (same dtype/layout/mapper)."""
+        index_n_heads = getattr(config, "index_n_heads", 64)
+        index_head_dim = getattr(config, "index_head_dim", 128)
+        q_lora_rank = config.q_lora_rank
+        hidden_size = config.hidden_size
+
+        def _cache_name(short):
+            return str(cache_path / f"layer_{layer_idx}.mla.indexer_{short}") if cache_path else None
+
+        # A device load with no host weights must be backed by a complete tensorbin set, else
+        # `as_tensor` converts the empty placeholders into garbage indexer weights. Mirror dense MLA's
+        # lenient placeholder load (don't block construction) — but, unlike dense which is silent, WARN
+        # loudly so the misuse is visible. The layer still stays sparse (binds TtIndexer); it does not
+        # fall back to dense. (Build mode, device=None, is gated upstream by ttMLA.build_ttnn_cache.)
+        if not idx_host and device is not None and not cls.check_cache_complete(cache_path, f"layer_{layer_idx}.mla"):
+            logger.warning(
+                f"Sparse MLA layer {layer_idx}: indexer has neither host weights nor a complete cache at "
+                f"{cache_path!r}; loading from empty placeholders — indexer output will be garbage. "
+                f"Build the indexer cache or pass the indexer weights."
+            )
+
+        if idx_host:
+            wq_b = idx_host["indexer.wq_b"]
+            wk = idx_host["indexer.wk"]
+            wproj = idx_host["indexer.weights_proj"]
+            knorm = idx_host["indexer.k_norm"]
+            knorm_b = idx_host["indexer.k_norm_bias"]
+        else:  # cache-only: placeholders in host (pre-transpose) shapes; as_tensor ignores them on a hit
+            wq_b = torch.empty(index_n_heads * index_head_dim, q_lora_rank)
+            wk = torch.empty(index_head_dim, hidden_size)
+            wproj = torch.empty(index_n_heads, hidden_size)
+            knorm = torch.empty(index_head_dim)
+            knorm_b = torch.empty(index_head_dim)
+
+        mem = ttnn.DRAM_MEMORY_CONFIG if device else None
+
+        def repl(t, short):  # k_norm runs on the reduced 128-wide key, so it is replicated across TP
+            return ttnn.as_tensor(
+                t.contiguous().to(torch.bfloat16),
+                device=device,
+                layout=ttnn.TILE_LAYOUT,
+                dtype=ttnn.bfloat16,
+                memory_config=mem,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+                cache_file_name=_cache_name(short),
+            )
+
+        def shard(t, axis, short):  # host [out, in] -> device [in, out], dim `axis` sharded across tp
+            dims = [None, None]
+            dims[tp_axis] = axis
+            return ttnn.as_tensor(
+                t.T.contiguous().to(torch.bfloat16),
+                device=device,
+                layout=ttnn.TILE_LAYOUT,
+                dtype=ttnn.bfloat16,
+                memory_config=mem,
+                mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=dims),
+                cache_file_name=_cache_name(short),
+            )
+
+        # wq_b is column-parallel: shard its H_idx*D_idx OUTPUT across tp (each chip builds H_idx/tp
+        # heads; qr is replicated → no reduce). wk / weights_proj contract over hidden (TP-sharded), so
+        # they upload transposed and sharded on that contraction axis → partials reduced by _tp_rs_ag.
+        result = {
+            "wq_b": shard(wq_b, 1, "wq_b"),  # [q_lora_rank, H_idx*D_idx] col-sharded on out
+            "wk": shard(wk, 0, "wk"),  # [dim, D_idx] sharded on dim
+            "weights_proj": shard(wproj, 0, "weights_proj"),  # [dim, H_idx] sharded on dim
+            "k_norm": repl(knorm, "k_norm"),  # [D_idx]
+            "k_norm_bias": repl(knorm_b, "k_norm_bias"),  # [D_idx]
+        }
+        if device is None:
+            for v in result.values():
+                del v
+            return None
+        return result
+
+    def __init__(
+        self,
+        idx_host,
+        *,
+        config,
+        mesh_device,
+        sp_axis: int,
+        tp_axis: int,
+        default_compute_kernel_config,
+        hifi4_fp32_compute_kernel_config,
+        weight_cache_path,
+        layer_idx: int,
+        tt_ccl,
+        ccl_num_links: int,
+        ccl_topology,
+    ):
+        """Architecture constants are read from the HF config (DS defaults below; GLM sets
+        index_rope_interleave / index_n_heads etc.). θ / YaRN / rope table length come from the
+        same config — single source of truth. Device index-key cache is grown by concat per chunk.
+
+        Injected from ttMLA (the indexer keeps no back-reference): the SP×TP mesh + axes,
+        compute-kernel configs, weight-cache location, and the CCL handles used by the inlined
+        collectives (_tp_rs_ag / _sp_all_gather). The indexer derives its own softmax scale
+        (index_head_dim**-0.5) — it does NOT reuse MLA's qk_head_dim*mscale scale. The q_a latent
+        (qr) is passed into forward(), not held here — so the indexer holds no MLA weights."""
+        self.config = config
+        self.mesh_device = mesh_device
+        self.sp_axis = sp_axis
+        self.tp_axis = tp_axis
+        mesh_shape = list(mesh_device.shape)
+        self.sp_factor = mesh_shape[sp_axis]
+        self.tp_factor = mesh_shape[tp_axis]
+        self.default_compute_kernel_config = default_compute_kernel_config
+        self.hifi4_fp32_compute_kernel_config = hifi4_fp32_compute_kernel_config
+        self.weight_cache_path = weight_cache_path
+        self.layer_idx = layer_idx
+        self.tt_ccl = tt_ccl
+        self.ccl_num_links = ccl_num_links
+        self.ccl_topology = ccl_topology
+        self.index_args = SimpleNamespace(
+            index_n_heads=getattr(config, "index_n_heads", 64),
+            index_head_dim=getattr(config, "index_head_dim", 128),
+            index_topk=getattr(config, "index_topk", 2048),
+            index_rope_interleave=getattr(config, "index_rope_interleave", False),
+        )
+        self._index_kbuf = None
+        self._upload_weights(idx_host)
+        self._build_rope_tables()
+
+    # Inlined TP/SP collectives — the indexer owns its own copy so it depends on tt_ccl, not on ttMLA
+    # (the dense MLA forward keeps its own equivalents; both go through the same tt_ccl handles).
+    def _tp_rs_ag(self, t, rs_only=False):
+        """All-reduce over TP = reduce-scatter (dim 3) then all-gather; rs_only stops after the RS."""
+        if self.tp_factor == 1:
+            return t
+        t = ttnn.experimental.reduce_scatter_minimal_async(
+            t,
+            persistent_output_buffers=None,
+            dim=3,
+            multi_device_global_semaphore=self.tt_ccl.get_and_cycle_rs_semaphore_handles(cluster_axis=self.tp_axis),
+            barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.tp_axis),
+            num_links=self.ccl_num_links,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            topology=self.ccl_topology,
+            cluster_axis=self.tp_axis,
+        )
+        if rs_only:
+            return t
+        return ttnn.experimental.all_gather_async(
+            t,
+            dim=3,
+            multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis=self.tp_axis),
+            barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.tp_axis),
+            num_links=self.ccl_num_links,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            topology=self.ccl_topology,
+            cluster_axis=self.tp_axis,
+        )
+
+    def _sp_all_gather(self, t, dim):
+        """All-gather across the SP axis (sequence) → full-S replicated on SP. sp=1: no-op."""
+        if self.sp_factor == 1:
+            return t
+        return ttnn.experimental.all_gather_async(
+            t,
+            dim=dim,
+            multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis=self.sp_axis),
+            barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.sp_axis),
+            num_links=self.ccl_num_links,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            topology=self.ccl_topology,
+            cluster_axis=self.sp_axis,
+        )
+
+    def _build_rope_tables(self):
+        """Precompute device cos/sin for the indexer RoPE via the shared builder
+        (``get_cos_sin_matrix``). ``index_rope_interleave`` picks the layout + matching device op:
+        DS (False) -> rotate_half (halves [c0,c1,..,c0,c1,..], no trans_mat) -> rotary_embedding_hf;
+        GLM (True) -> interleaved (duplicated pairs [c0,c0,c1,c1,..] + trans_mat) ->
+        rotary_embedding_llama (matches the MLA's own rope). Tables are pure rotations (no mscale
+        baked in, matching the reference indexer). Op selection stays in ``_device_rope_pe``.
+
+        Frequencies come from the HF ``self.config`` — the single source of truth and identical to the
+        MLA's own rope (same θ / YaRN); the builder always applies YaRN, which is a no-op at
+        ``rope_factor==1`` (GLM). Tables are full-length; ``_device_rope_pe`` slices per chunk."""
+        interleave = self.index_args.index_rope_interleave
+        cos, sin = get_cos_sin_matrix(self.config, interleave=interleave)  # pure rotation tables (no mscale)
+        repl = lambda t: ttnn.from_torch(
+            t.to(torch.bfloat16),
+            device=self.mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=ttnn.bfloat16,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        )
+        self._idx_cos, self._idx_sin = repl(cos), repl(sin)
+        self._idx_trans = repl(get_rot_transformation_mat()) if interleave else None
+
+    def _upload_weights(self, idx_host):
+        """Indexer weights → device via the shared converter. `idx_host` may be a full host dict
+        (from-weights) or falsy (cache-only: the converter builds placeholders and reads the
+        `layer_{idx}.mla.indexer_*` tensorbins). The converter also writes the cache opportunistically
+        on a from-weights load, exactly as before."""
+        w = self._convert_and_cache_weights(
+            idx_host,
+            self.mesh_device,
+            self.config,
+            self.layer_idx,
+            self.sp_axis,
+            self.tp_axis,
+            cache_path=self.weight_cache_path,
+            device=self.mesh_device,
+        )
+        self._idx_wq_b = w["wq_b"]
+        self._idx_wk = w["wk"]
+        self._idx_wproj = w["weights_proj"]
+        self._idx_knorm_w = w["k_norm"]
+        self._idx_knorm_b = w["k_norm_bias"]
+
+    def _device_rope_pe(self, x: ttnn.Tensor, glob: int, start_pos: int, sp_shard: bool = False) -> ttnn.Tensor:
+        """On-device RoPE on the rope half (first 64) of the last dim.
+        x [1, n_heads, S, D_idx]; cos/sin sliced to this chunk's global positions [start_pos,
+        start_pos+glob). With sp_shard the cos/sin are mesh-partitioned across SP so each chip
+        ropes its own contiguous query block (positions start_pos + sp_rank*S_local) — used for the
+        SP-sharded indexer queries (the K cache stays full/gathered, so it ropes unsharded)."""
+        h, n = x.shape[1], x.shape[2]
+        pe = ttnn.slice(x, [0, 0, 0, 0], [1, h, n, 64])
+        nope = ttnn.slice(x, [0, 0, 0, 64], [1, h, n, self.index_args.index_head_dim])
+        cos = ttnn.slice(self._idx_cos, [0, 0, start_pos, 0], [1, 1, start_pos + glob, 64])
+        sin = ttnn.slice(self._idx_sin, [0, 0, start_pos, 0], [1, 1, start_pos + glob, 64])
+        if sp_shard and self.sp_factor > 1:  # each SP chip keeps its block's cos/sin (natural-order shard)
+            cos = ttnn.mesh_partition(cos, dim=2, cluster_axis=self.sp_axis)
+            sin = ttnn.mesh_partition(sin, dim=2, cluster_axis=self.sp_axis)
+        if self._idx_trans is not None:  # GLM: interleaved RoPE (Meta-style + trans_mat)
+            pe = ttnn.experimental.rotary_embedding_llama(pe, cos, sin, self._idx_trans, is_decode_mode=False)
+        else:  # DS: non-interleaved (rotate_half)
+            pe = ttnn.experimental.rotary_embedding_hf(
+                pe, cos, sin, is_decode_mode=False, compute_kernel_config=self.hifi4_fp32_compute_kernel_config
+            )
+        return ttnn.concat([pe, nope], dim=-1)
+
+    def write_k(self, hidden_states: ttnn.Tensor, seq_len: int, start_pos: int):
+        """Device K stem (wk + TP all-reduce + k_norm + SP all-gather + device rope),
+        appended to the device index-key cache. forward() calls this on every chunk so the key-cache
+        stays complete — else later chunks score against missing keys for the early prefix. (Dense v3.1
+        binds a NullIndexer instead, so write_k never runs there.)"""
+        k = ttnn.linear(
+            hidden_states,
+            self._idx_wk,
+            compute_kernel_config=self.default_compute_kernel_config,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )  # per-chip partial [1, 1, S/sp, D_idx]
+        k = self._tp_rs_ag(k)  # all-reduce over TP
+        k = ttnn.layer_norm(
+            k,
+            weight=self._idx_knorm_w,
+            bias=self._idx_knorm_b,
+            epsilon=1e-6,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            compute_kernel_config=self.default_compute_kernel_config,
+        )
+        glob = seq_len * self.sp_factor
+        k = self._sp_all_gather(k, dim=2)  # [1, 1, glob, D_idx] full, replicated, natural order
+        k = self._device_rope_pe(k, glob, start_pos)  # on-device non-interleaved rope
+        # Grow the replicated device cache by concat (natural order; no block-cyclic).
+        # FOLLOW-UP (scoped redesign, not a drop-in): concat reallocates the whole key-cache each chunk
+        # (O(n^2) copies over a long prefill). Reusing the MLA block-cyclic KVPE cache machinery
+        # (update_padded_kv_cache + a gather/un-rotate read like _gather_kvpe_prefix) would avoid that,
+        # but it changes the indexer key-cache layout (replicated-natural -> block-cyclic-SP) and the
+        # scoring read path, so it is tracked as its own task rather than done here.
+        # The rest of this MLA code manually deallocates intermediate device tensors, so free the device
+        # buffers we drop here too rather than relying on Python ref-loss (which would accumulate device
+        # allocations over a long chunked prefill or across repeated requests).
+        if start_pos == 0 or self._index_kbuf is None:
+            if self._index_kbuf is not None:  # start_pos==0 reset: drop the prior request's full cache
+                ttnn.deallocate(self._index_kbuf)
+            self._index_kbuf = k
+        else:
+            old = self._index_kbuf
+            self._index_kbuf = ttnn.concat([old, k], dim=2)  # concat copies into a fresh buffer...
+            ttnn.deallocate(old)  # ...so the old cache and this chunk's keys are both free to drop
+            ttnn.deallocate(k)
+
+    def forward(self, hidden_states: ttnn.Tensor, qr: ttnn.Tensor, seq_len: int, start_pos: int = 0) -> ttnn.Tensor:
+        """Indexer forward → top-k key indices [1, 1, S/sp, k] over the device index-key cache, SP-sharded
+        on the query axis (each chip scores its own S/sp rows; no Q/W all-gather). Fully on-device:
+        stems, RoPE, cache, logits, topk — no host. K stays full/replicated (every query scores all keys).
+
+        ``qr`` is the shared q_a latent (q_a_proj + TP all-reduce + q_a_layernorm) — ttMLA computes it once
+        and passes it in; the indexer applies wq_b to it (no q_a stem of its own). ``qr`` is NOT deallocated
+        here — ttMLA's _q_stem consumes it afterwards. ``hidden_states`` is still needed for the K stem
+        (write_k) and the per-head weights (weights_proj). (write_k is called internally here; ttMLA.forward
+        only ever calls self._indexer.forward — it never calls write_k directly.)"""
+        a = self.index_args
+        glob = seq_len * self.sp_factor  # global query/key count this chunk
+        end_pos = start_pos + glob
+        self.write_k(hidden_states, seq_len, start_pos)
+
+        # Q stem: the shared q_a latent (qr) -> indexer wq_b.
+        q = ttnn.linear(
+            qr,
+            self._idx_wq_b,
+            compute_kernel_config=self.default_compute_kernel_config,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )  # [1, 1, S/sp, (H_idx/tp)*D_idx] — queries stay SP-sharded (no all-gather; each chip scores its own rows)
+        heads_local = a.index_n_heads // self.tp_factor  # this chip's indexer heads (col-parallel wq_b)
+        q, _, _ = ttnn.experimental.nlp_create_qkv_heads(
+            q, num_heads=heads_local, num_kv_heads=0, transpose_k_heads=False, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )  # [1, H_idx/tp, S/sp, D_idx]
+        q_dev = self._device_rope_pe(q, glob, start_pos, sp_shard=True)  # per-chip query positions
+
+        # weights_proj: device stem -> reduce-scatter the H_idx heads across tp (each chip keeps the
+        # reduced H_idx/tp slice matching its wq_b heads) -> SP gather -> scale -> [1, 1, glob, H_idx/tp].
+        wts = ttnn.linear(
+            hidden_states,
+            self._idx_wproj,
+            compute_kernel_config=self.default_compute_kernel_config,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        wts = self._tp_rs_ag(wts, rs_only=True)  # reduce-scatter on the head dim -> this chip's heads
+        # Indexer softmax scale = index_head_dim**-0.5 (NO mscale), matching the reference IndexerCPU
+        # (model.py: softmax_scale = head_dim**-0.5). Distinct from MLA's qk_head_dim*mscale**2 scale —
+        # though as a uniform positive multiplier it cannot change the top-k selection regardless.
+        wts = ttnn.multiply(wts, a.index_n_heads**-0.5 * a.index_head_dim**-0.5)  # SP-sharded [1,1,S/sp,H_idx/tp]
+
+        # Causality is fused inside indexer_score (future columns -> -inf from chunk_start_idx),
+        # so no triu mask add here. Each chip scores only its H_idx/tp heads -> a PARTIAL logit
+        # (the head-sum is separable; the -inf mask is head-independent so it survives the sum).
+        # HB=0 keeps all H_idx/tp heads resident (fits L1 for tp>=2, i.e. <=32 heads/chip); tp=1 has
+        # all 64 heads on one chip and must head-stream (HB=16).
+        hb = 0 if self.tp_factor > 1 else 16
+        # Indexer kernel knobs: QC=2 (q_chunk=64), KC=8 (k_chunk=256) capped to Skv/32 (the op requires
+        # KC <= Skv/32; inert at the model's DSA K). HB=0 keeps all heads resident; HB=16 streams (tp=1).
+        cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=min(256, end_pos), head_group_size=hb)
+        # SP-sharded queries: each chip scores only its S/sp rows vs the full key cache, with a per-device
+        # causal offset so the mask is correct without computing the full glob logits on every chip. The op
+        # derives that offset itself from the mesh coordinate: with cluster_axis=sp_axis, chip r uses
+        # chunk_start = chunk_start_idx + r*Sq, and Sq = S/sp = seq_len here, so chunk_start = start_pos +
+        # sp_rank*seq_len. topk below then stays SP-sharded ([1,1,S/sp,k]) — fed straight to sparse_mla.
+        # indexer_score wants per-head weights [1, H_idx/tp, S/sp, 1]; wts is [1, 1, S/sp, H_idx/tp].
+        weights = ttnn.permute(wts, (0, 3, 2, 1))
+        logits = ttnn.experimental.indexer_score_dsa(
+            q_dev,
+            self._index_kbuf,
+            weights,
+            chunk_start_idx=start_pos,
+            program_config=cfg,
+            cluster_axis=self.sp_axis,
+        )
+        # All-reduce(SUM) the partial logits over tp -> full head-summed logit before top-k. The op emits
+        # ROW_MAJOR; _tp_rs_ag (reduce_scatter+all_gather) runs in TILE, so round-trip the layout.
+        if self.tp_factor > 1:
+            # The op emits ROW_MAJOR; round-trip to TILE for the all-reduce. Passing RM straight to the
+            # CCL is correct but ~10 ms slower — ttnn's RM reduce_scatter/all_gather tilize-with-padding
+            # internally and add RM concats, costing more than this explicit ~6 ms tilize/untilize.
+            logits = ttnn.to_layout(logits, ttnn.TILE_LAYOUT)
+            logits = self._tp_rs_ag(logits)  # RS+AG over tp_axis == all-reduce SUM (reduce accumulates fp32)
+            logits = ttnn.to_layout(logits, ttnn.ROW_MAJOR_LAYOUT)
+        # Top-k key indices [1,1,S/sp,k] (ROW_MAJOR uint32). Future/pad -inf columns surface as the
+        # 0xFFFFFFFF sentinel that sparse_mla drops. topk_large_indices: 16 <= k <= 2048, multiple of 16.
+        # index_topk is a multiple of 16, so k is too iff end_pos is — assert it at the caller contract
+        # (current chunk sizing guarantees tile alignment) rather than failing deep inside the op.
+        assert end_pos % 16 == 0, f"indexer top-k requires a tile-aligned key count; got end_pos={end_pos}"
+        return ttnn.experimental.topk_large_indices(logits, k=min(self.index_args.index_topk, end_pos))
+
+
+class NullIndexer:
+    """Dense v3.1 stand-in for TtIndexer: forward() is a no-op returning None (no top-k, no K-cache
+    write). Lets ttMLA bind self._indexer once at construction and call it unconditionally in forward.
+    Mirrors TtIndexer.forward's contract — keep the two in sync if that signature/return changes."""
+
+    def forward(self, *args, **kwargs):
+        return None
+
+
+# Back-compat alias; TtIndexer.WEIGHT_NAMES is the single source of truth.
+INDEXER_WEIGHT_NAMES = TtIndexer.WEIGHT_NAMES
+
+
+def resolve_has_indexer(config, state_dict=None, explicit=None, weight_cache_path=None, cache_name_prefix=None) -> bool:
+    """Single source of truth for "is this a sparse DSA layer?", used by every ttMLA cache/check/
+    build/load path so they cannot disagree. Resolution order:
+      1. explicit override when not None,
+      2. config.has_indexer when present (absence = unknown, NOT False),
+      3. TtIndexer.matches_config(config) — runtime config carries DSA index_* fields,
+      4. TtIndexer.has_host_weights(state_dict) — live from-weights callers,
+      5. TtIndexer.check_cache_complete(...) — cache-only callers with a complete indexer cache,
+      6. otherwise dense.
+    Never resolve sparse detection through getattr(config, "has_indexer", False): a default-False
+    flag silently disables sparse for cache-only construction (the bug this whole path fixes)."""
+    if explicit is not None:
+        return explicit
+    flag = getattr(config, "has_indexer", None)
+    if flag is not None:
+        return bool(flag)
+    if TtIndexer.matches_config(config):
+        return True
+    if TtIndexer.has_host_weights(state_dict):
+        return True
+    if weight_cache_path is not None and cache_name_prefix is not None:
+        return TtIndexer.check_cache_complete(weight_cache_path, cache_name_prefix)
+    return False

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -12,7 +12,9 @@ from transformers.configuration_utils import PretrainedConfig
 
 import ttnn
 from models.common.utility_functions import is_blackhole
+from models.demos.deepseek_v3_d_p.tt.mla.indexer import NullIndexer, TtIndexer, resolve_has_indexer
 from models.demos.deepseek_v3_d_p.tt.mla.mla_config import MLA_MATMUL_CONFIG, MLA_SDPA_CONFIG
+from models.demos.deepseek_v3_d_p.tt.mla.utils import blockcyclic_to_natural
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import get_tt_ccl
 
 
@@ -29,14 +31,21 @@ class ttMLA:
     ]
 
     @staticmethod
-    def check_cache_complete(cache_path: Path, cache_name_prefix: str) -> bool:
-        """Check if all 8 MLA weight cache files exist."""
+    def check_cache_complete(cache_path: Path, cache_name_prefix: str, has_indexer: bool = False) -> bool:
+        """Check that the dense MLA weight cache files exist, plus the indexer tensorbins when sparse.
+
+        Dense by default (preserves existing callers). When ``has_indexer=True`` the indexer cache
+        (``{prefix}.indexer_*``) must also be complete — a disjoint prefix space from the dense MLA
+        names, so the dense loop here never matches indexer files and vice versa
+        (see ``TtIndexer.check_cache_complete``)."""
         from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import pattern_exists
 
         for name in ttMLA.MLA_WEIGHT_NAMES:
             if not pattern_exists(f"{cache_name_prefix}.{name}*.tensorbin", "MLA"):
                 logger.debug(f"TTNN cache missing: {cache_name_prefix}.{name}")
                 return False
+        if has_indexer and not TtIndexer.check_cache_complete(cache_path, cache_name_prefix):
+            return False
         return True
 
     @staticmethod
@@ -210,15 +219,29 @@ class ttMLA:
         sp_axis: int = 0,
         tp_axis: int = 1,
         kv_only: bool = False,
+        has_indexer: bool | None = None,
     ):
-        """Build TTNN cache for MLA weights using device=None (no device copy)."""
+        """Build TTNN cache for MLA weights using device=None (no device copy). For DSA-sparse
+        variants also writes the indexer tensorbins. Fails fast if sparse mode is resolved but the
+        host indexer weights are missing — never silently builds a dense-only cache for a sparse layer."""
         ttMLA._convert_and_cache_weights(
             state_dict, mesh_device, config, layer_idx, sp_axis, tp_axis, cache_path, device=None, kv_only=kv_only
         )
+        resolved_has_indexer = resolve_has_indexer(config, state_dict=state_dict, explicit=has_indexer)
+        if resolved_has_indexer:
+            if not TtIndexer.has_host_weights(state_dict):
+                raise ValueError(
+                    f"Sparse MLA cache build for layer {layer_idx} resolved has_indexer=True but the "
+                    f"state dict is missing indexer weights {TtIndexer.WEIGHT_NAMES}. Provide them or "
+                    f"pass has_indexer=False."
+                )
+            TtIndexer.build_ttnn_cache(
+                TtIndexer.extract_host_weights(state_dict), cache_path, mesh_device, config, layer_idx, sp_axis, tp_axis
+            )
 
     def __init__(
         self,
-        config: PretrainedConfig,
+        config: PretrainedConfig,  # TODO: figure out how to use this for GLM and DSv32
         state_dict: dict[str, torch.Tensor],
         mesh_device: ttnn.MeshDevice,
         layer_idx: int = 0,
@@ -232,7 +255,14 @@ class ttMLA:
         slot_num: int = 1,
         layer_num: int = 61,
         kv_only: bool = False,
+        has_indexer: bool | None = None,
     ):
+        # DSA indexer weights (v3.2 / GLM): extract NON-mutating, so the caller's state_dict survives
+        # repeated construction / cache build+load (the old pop() emptied it on the first pass). Dense
+        # v3.1 has none. Sparse capability is resolved below via resolve_has_indexer (config DSA fields /
+        # host weights / complete cache) — never from the mere presence of these keys — so cache-only
+        # construction stays sparse instead of silently going dense.
+        idx_host = TtIndexer.extract_host_weights(state_dict)
         self.config = config
         self.mesh_device = mesh_device
         self.layer_idx = layer_idx
@@ -374,6 +404,53 @@ class ttMLA:
             self.wkv_b2_weight = weights["wkv_b2"]
             self.o_proj_weight = weights["o_proj"]
         logger.info(f"Loaded {len(weights)} weights in MLA layer {layer_idx} (kv_only={kv_only})")
+
+        # DSA indexer (v3.2 / GLM): resolve sparse mode EXPLICITLY — config DSA fields, then live host
+        # weights, then a complete indexer cache — never from bool(idx_host), which silently went dense
+        # for cache-only construction. The TtIndexer owns the indexer stems / RoPE tables / device
+        # key-cache and reuses this MLA's q_a stem + collectives. Inert for dense v3.1.
+        self._has_indexer = resolve_has_indexer(
+            config,
+            state_dict=state_dict,
+            explicit=has_indexer,
+            weight_cache_path=self.weight_cache_path,
+            cache_name_prefix=f"layer_{layer_idx}.mla",
+        )
+        if self._has_indexer:
+            # The indexer assumes natural-order SP sharding (contiguous per-chip query blocks: its
+            # device RoPE and the indexer_score per-device causal offset both index positions as
+            # start_pos + sp_rank*S_local). The balanced chunk reorder breaks that, so guard it.
+            assert not self.is_balanced, "DSA indexer requires is_balanced=False (natural-order SP sharding)"
+            # kv_only (last-layer KV-only fast path) skips Q/SDPA AND the indexer K-cache write, so a
+            # sparse decode would read an unpopulated indexer cache. Not implemented — fail at construction.
+            assert not self.kv_only, "DSA sparse path does not support kv_only (skips the indexer K-cache write)"
+            # TtIndexer warns (does not raise) if given neither host weights nor a complete cache —
+            # mirroring dense MLA's lenient placeholder load, but loudly. The layer still stays sparse
+            # (binds TtIndexer), so it never silently falls back to dense.
+            self._indexer = TtIndexer(
+                idx_host if idx_host else None,  # None → TtIndexer loads cache-only placeholders
+                config=config,
+                mesh_device=self.mesh_device,
+                sp_axis=self.sp_axis,
+                tp_axis=self.tp_axis,
+                default_compute_kernel_config=self.default_compute_kernel_config,
+                hifi4_fp32_compute_kernel_config=self.hifi4_fp32_compute_kernel_config,
+                weight_cache_path=self.weight_cache_path,
+                layer_idx=self.layer_idx,
+                tt_ccl=self.tt_ccl,
+                ccl_num_links=self.ccl_num_links,
+                ccl_topology=self.ccl_topology,
+            )
+        else:
+            self._indexer = NullIndexer()  # dense v3.1: forward calls .forward() -> None (dense path)
+
+        # Bind the attention core once, by config — sparsity (self._has_indexer) × chunking
+        # (self.is_chunked) — exactly as self._apply_rope is bound above. forward() then calls
+        # self._attention(...) with no mode ladder: the decision is made here, not per call.
+        if self._has_indexer:
+            self._attention = self._sparse_chunked_attn if self.is_chunked else self._sparse_single_attn
+        else:
+            self._attention = self._dense_chunked_attn if self.is_chunked else self._dense_single_attn
 
     @staticmethod
     def kv_cache_to_host(kvpe_cache: ttnn.Tensor, mesh_device: ttnn.MeshDevice, sp_axis: int = 0):
@@ -636,49 +713,14 @@ class ttMLA:
         )
         return attn_out
 
-    # Expects ativation in form of:
-    # [1, batch_size == 1, seq_len // sp_factor, hidden_size // tp_factor]
-    def forward(
-        self,
-        hidden_states: ttnn.Tensor,
-        rope_tensors: dict,
-        kvpe_cache: ttnn.Tensor,
-        cache_layer_idx: int = 0,
-        actual_start: Optional[int] = None,
-        cache_user_id: int = 0,
-        return_kv_intermediates: bool = False,
+    def _q_a_latent(
+        self, hidden_states: ttnn.Tensor, seq_len_local: int, norm_memory_config: ttnn.MemoryConfig
     ) -> ttnn.Tensor:
-        if self.kv_only:
-            return self._forward_kv_only(
-                hidden_states,
-                rope_tensors,
-                kvpe_cache,
-                cache_layer_idx,
-                kv_actual_isl=actual_start,
-                cache_user_id=cache_user_id,
-            )
-
-        signpost(header="MLA_START")
-        num_heads_local = self.num_heads // self.tp_factor
-        seq_len_local = hidden_states.shape[2]
-
-        # Chunked-prefill mode is fixed at construction: self.is_chunked drives buffer allocation in
-        # __init__ and the rope variant, and forward honors that flag — it does not infer the mode from
-        # the arguments. actual_start is the chunk parameter, supplied iff chunked: the absolute KV
-        # position of this chunk's first real token (cumulative valid count before it; 0 for the first
-        # chunk) — the cache write + rotation offset (the internal kv_actual_isl). The single-shot and
-        # chunked paths share the Q/KV projection + rope prologue and the nlp_concat_heads + o_proj
-        # epilogue; they differ only in cache write, attention op, and where wkv_b2 is applied. See
-        # _chunked_attn for the unified chunked impl.
-        kv_actual_isl = actual_start
-        assert (actual_start is not None) == self.is_chunked, (
-            f"actual_start ({'set' if actual_start is not None else 'None'}) does not match construction "
-            f"(self.is_chunked={self.is_chunked}); pass actual_start iff built with is_chunked=True"
-        )
-
-        # q_projection
+        """q_a projection + TP all-reduce + q_a_layernorm → the q_a latent (qr). Computed once per
+        layer and shared: _q_stem consumes it for q_b_proj, and (when present) TtIndexer.forward reads
+        it for the indexer queries — so the sparse path no longer recomputes the q_a stem."""
         # NOTE: input is ideally L1 for chunked, but hidden states memory config is set outside the module
-        tt_q = ttnn.linear(
+        qr = ttnn.linear(
             hidden_states,
             self.q_a_proj_weight,
             compute_kernel_config=self.default_compute_kernel_config,
@@ -687,8 +729,8 @@ class ttMLA:
 
         # All reduce (skip for single-device TP)
         if self.tp_factor > 1:
-            tt_q = ttnn.experimental.reduce_scatter_minimal_async(
-                tt_q,
+            qr = ttnn.experimental.reduce_scatter_minimal_async(
+                qr,
                 persistent_output_buffers=None,
                 dim=3,
                 multi_device_global_semaphore=self.tt_ccl.get_and_cycle_rs_semaphore_handles(cluster_axis=self.tp_axis),
@@ -698,8 +740,8 @@ class ttMLA:
                 topology=self.ccl_topology,
                 cluster_axis=self.tp_axis,
             )
-            tt_q = ttnn.experimental.all_gather_async(
-                tt_q,
+            qr = ttnn.experimental.all_gather_async(
+                qr,
                 dim=3,
                 multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis=self.tp_axis),
                 barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.tp_axis),
@@ -709,20 +751,31 @@ class ttMLA:
                 cluster_axis=self.tp_axis,
             )
 
-        # rmsnorm
-        tt_q = ttnn.rms_norm(
-            tt_q,
+        return ttnn.rms_norm(
+            qr,
             weight=self.q_a_layernorm_weight,
             epsilon=self.config.rms_norm_eps,
-            memory_config=self._get_act_mem_config("q_b_proj", seq_len_local),
+            memory_config=norm_memory_config,
             compute_kernel_config=self.default_compute_kernel_config,
         )
+
+    def _q_stem(
+        self,
+        qr: ttnn.Tensor,
+        rope_tensors: dict,
+        kv_actual_isl: Optional[int],
+        seq_len_local: int,
+    ) -> ttnn.Tensor:
+        """Absorbed-Q stem from the q_a latent: q_b_proj → heads → split → wkv_b1(nope) → RoPE(rope)
+        → concat. Consumes qr (the indexer, if any, has already read it by this point)."""
+        num_heads_local = self.num_heads // self.tp_factor
         tt_q = ttnn.linear(
-            tt_q,
+            qr,
             self.q_b_proj_weight,
             compute_kernel_config=self.default_compute_kernel_config,
             **self._get_mm_kwargs("q_b_proj", seq_len_local),
         )
+        ttnn.deallocate(qr)
 
         # convert to
         # [batch (1), num_heads_local, seq_len_local, qk_head_dim]
@@ -754,8 +807,22 @@ class ttMLA:
         tt_q = ttnn.concat([tt_q_nope, tt_q_rope], dim=-1)
         ttnn.deallocate(tt_q_nope)
         ttnn.deallocate(tt_q_rope)
+        return tt_q
 
-        # kv
+    def _kv_stem(
+        self,
+        hidden_states: ttnn.Tensor,
+        rope_tensors: dict,
+        kv_actual_isl: Optional[int],
+        seq_len_local: int,
+        return_kv_intermediates: bool,
+        keep_kvpe_bf16: bool,
+    ) -> tuple[ttnn.Tensor | None, ttnn.Tensor, ttnn.Tensor, dict | None]:
+        """Shared KV stem.
+
+        Returns bf16 kvpe only for sparse single-shot, where sparse attention consumes the
+        full latent prefix in bf16. All modes receive the bf8 kvpe written to the cache.
+        """
         # NOTE: input is ideally L1 for chunked, but hidden states memory config is set outside the module
         tt_kv = ttnn.linear(
             hidden_states,
@@ -808,69 +875,33 @@ class ttMLA:
         # TODO: concat rope and nope, workaround remove with ttnn.narrow or fusion
         tt_kvpe = ttnn.concat([tt_kv_nope, tt_kv_rope], dim=-1)
         ttnn.deallocate(tt_kv_rope)
-        tt_kvpe = ttnn.typecast(tt_kvpe, dtype=ttnn.bfloat8_b)
+        tt_kvpe_b8 = ttnn.typecast(tt_kvpe, dtype=ttnn.bfloat8_b)
 
         if return_kv_intermediates:
-            # post-transform concat ([.., 576], bf8) — what actually gets written to the cache.
-            kv_intermediates["tt_kvpe"] = ttnn.clone(tt_kvpe)
+            # post-transform concat ([.., 576], bf8) -- what actually gets written to the cache.
+            kv_intermediates["tt_kvpe"] = ttnn.clone(tt_kvpe_b8)
 
-        if not self.is_chunked:
-            # === single-shot prefill: fill the whole local slot, run on-device ring SDPA with a
-            # materialized V (wkv_b2 applied before attention). Unchanged from the original path. ===
-            ttnn.kv_cache.fill_cache_for_user_(kvpe_cache, tt_kvpe, cache_layer_idx)
+        if not keep_kvpe_bf16:
+            ttnn.deallocate(tt_kvpe)
+            tt_kvpe = None
 
-            tt_v_embedding = ttnn.linear(
-                tt_kv_nope,
-                self.wkv_b2_weight,
-                compute_kernel_config=self.default_compute_kernel_config,
-                **self._get_mm_kwargs("wkv_b2", seq_len_local),
-            )
+        return tt_kvpe, tt_kvpe_b8, tt_kv_nope, kv_intermediates
 
-            attn_out, _, _ = ttnn.transformer.ring_joint_scaled_dot_product_attention(
-                tt_q,
-                tt_kvpe,
-                tt_v_embedding,
-                self.joint_q,
-                self.joint_kv,
-                self.joint_v,
-                persistent_output_buffer_k=self.persistent_k_output_buffer,
-                persistent_output_buffer_v=self.persistent_v_output_buffer,
-                joint_strategy="rear",
-                logical_n=seq_len_local * self.sp_factor,
-                program_config=self._get_sdpa_program_config(seq_len_local),
-                compute_kernel_config=self.default_compute_kernel_config,
-                dim=2,
-                multi_device_global_semaphore=self.tt_ccl.ring_attention_ccl_semaphore_handles,
-                num_links=self.ccl_num_links,
-                cluster_axis=self.sp_axis,
-                mesh_device=self.mesh_device,
-                topology=self.ccl_topology,
-                ccl_core_grid_offset=self.tt_ccl.ring_attention_ccl_core_grid_offset,
-                use_column_major_ccl=True,
-                is_causal=True,
-                scale=self.scale,
-                is_balanced=self.is_balanced,
-            )
-        else:
-            # === chunked prefill: write this chunk into the cache at its per-chip offset, then run
-            # ring_mla over the populated prefix with V materialized in-op from the latent KV. wkv_b2
-            # is applied to the compact attention output afterwards (see _chunked_attn). ===
-            # Cache batch dim is user-major: each user reserves self.layer_num contiguous slots, so the
-            # flat slot is cache_user_id * layer_num + cache_layer_idx. Computed here (chunked-only) so
-            # the non-chunked path never multiplies by layer_num (None unless built for chunked prefill).
-            assert cache_user_id < self.slot_num, f"cache_user_id {cache_user_id} >= slot_num {self.slot_num}"
-            cache_batch_idx = cache_user_id * self.layer_num + cache_layer_idx
-            attn_out = self._chunked_attn(
-                tt_q=tt_q,
-                tt_kvpe=tt_kvpe,
-                kvpe_cache=kvpe_cache,
-                kv_actual_isl=kv_actual_isl,
-                cache_batch_idx=cache_batch_idx,
-                cache_layer_idx=cache_layer_idx,
-                cache_user_id=cache_user_id,
-                seq_len_local=seq_len_local,
-            )
+    def _apply_wkv_b2(self, t: ttnn.Tensor, seq_len_local: int) -> ttnn.Tensor:
+        return ttnn.linear(
+            t,
+            self.wkv_b2_weight,
+            compute_kernel_config=self.default_compute_kernel_config,
+            **self._get_mm_kwargs("wkv_b2", seq_len_local),
+        )
 
+    def _write_kvpe(self, kvpe_cache: ttnn.Tensor, tt_kvpe_b8: ttnn.Tensor, cache_layer_idx: int) -> None:
+        """Single-shot cache fill: write this layer's whole kvpe slot (bf8). Chunked modes write
+        through _chunked_attn / update_padded_kv_cache instead."""
+        ttnn.kv_cache.fill_cache_for_user_(kvpe_cache, tt_kvpe_b8, cache_layer_idx)
+
+    def _o_proj_epilogue(self, attn_out: ttnn.Tensor, seq_len_local: int) -> ttnn.Tensor:
+        """Shared nlp_concat_heads -> o_proj -> TP reduce-scatter epilogue."""
         v_out = ttnn.experimental.nlp_concat_heads(attn_out, memory_config=ttnn.DRAM_MEMORY_CONFIG)
         v_out = ttnn.linear(
             v_out,
@@ -879,7 +910,7 @@ class ttMLA:
             **self._get_mm_kwargs("o_proj", seq_len_local),
         )
         if self.tp_factor > 1:
-            out = ttnn.experimental.reduce_scatter_minimal_async(
+            return ttnn.experimental.reduce_scatter_minimal_async(
                 v_out,
                 dim=3,
                 multi_device_global_semaphore=self.tt_ccl.get_and_cycle_rs_semaphore_handles(cluster_axis=self.tp_axis),
@@ -889,12 +920,206 @@ class ttMLA:
                 topology=self.ccl_topology,
                 cluster_axis=self.tp_axis,
             )
-        else:
-            out = v_out
+        return v_out
+
+    # Expects activation in form of:
+    # [1, batch_size == 1, seq_len // sp_factor, hidden_size // tp_factor]
+    def forward(
+        self,
+        hidden_states: ttnn.Tensor,
+        rope_tensors: dict,
+        kvpe_cache: ttnn.Tensor,
+        cache_layer_idx: int = 0,
+        actual_start: Optional[int] = None,
+        cache_user_id: int = 0,
+        return_kv_intermediates: bool = False,
+    ) -> "ttnn.Tensor | tuple[ttnn.Tensor, Optional[dict]]":
+        if self.kv_only:
+            return self._forward_kv_only(
+                hidden_states,
+                rope_tensors,
+                kvpe_cache,
+                cache_layer_idx,
+                kv_actual_isl=actual_start,
+                cache_user_id=cache_user_id,
+            )
+
+        # Chunked-prefill mode is fixed at construction: self.is_chunked drives buffer allocation in
+        # __init__ and the rope variant, and forward honors that flag -- it does not infer the mode from
+        # the arguments. actual_start is the chunk parameter, supplied iff chunked.
+        assert (actual_start is not None) == self.is_chunked, (
+            f"actual_start ({'set' if actual_start is not None else 'None'}) does not match construction "
+            f"(self.is_chunked={self.is_chunked}); pass actual_start iff built with is_chunked=True"
+        )
+
+        seq_len_local = hidden_states.shape[2]
+        kv_actual_isl = actual_start
+        is_chunked = self.is_chunked
+
+        signpost(header="MLA_START")
+
+        # q-norm output uses the tuned activation memory_config in every mode (dense and sparse);
+        # the next op (q_b_proj) is the same matmul regardless of attention path.
+        q_norm_mem_config = self._get_act_mem_config("q_b_proj", seq_len_local)
+        # Compute the q_a latent once and share it: the DSA indexer reads it for its queries, then
+        # _q_stem consumes it for q_b_proj — so the sparse path does not recompute the q_a stem.
+        qr = self._q_a_latent(hidden_states, seq_len_local, q_norm_mem_config)
+
+        # DSA dispatch (v3.2 / GLM): the op graph is fixed by CONFIG — self._indexer and self._attention
+        # are bound once at construction (sparsity × chunking), never by the runtime sequence length — so
+        # a single recorded op trace replays identically for any input. (At seq_len <= index_topk the
+        # indexer top-k simply selects all available causal keys, so sparse is numerically equal to dense
+        # there.) The indexer's forward also writes its K-cache (a no-op on the dense null-indexer), so no
+        # separate warm-up write is needed.
+        indices = self._indexer.forward(hidden_states, qr, seq_len_local, start_pos=kv_actual_isl or 0)
+
+        tt_q = self._q_stem(qr, rope_tensors, kv_actual_isl, seq_len_local)
+        keep_kvpe_bf16 = self._has_indexer and not is_chunked
+        tt_kvpe, tt_kvpe_b8, tt_kv_nope, kv_intermediates = self._kv_stem(
+            hidden_states,
+            rope_tensors,
+            kv_actual_isl,
+            seq_len_local,
+            return_kv_intermediates,
+            keep_kvpe_bf16,
+        )
+
+        attn_out = self._attention(
+            tt_q=tt_q,
+            tt_kvpe=tt_kvpe,
+            tt_kvpe_b8=tt_kvpe_b8,
+            tt_kv_nope=tt_kv_nope,
+            indices=indices,
+            kvpe_cache=kvpe_cache,
+            cache_layer_idx=cache_layer_idx,
+            cache_user_id=cache_user_id,
+            seq_len_local=seq_len_local,
+            kv_actual_isl=kv_actual_isl,
+        )
+
+        out = self._o_proj_epilogue(attn_out, seq_len_local)
         signpost(header="MLA_END")
         if return_kv_intermediates:
             return out, kv_intermediates
         return out
+
+    # Attention core variants, one bound to self._attention at construction (sparsity × chunking).
+    # All four share the forward() call signature and ignore the kwargs they don't need (**_), so the
+    # bound name can be invoked uniformly. Bodies are the former mode-ladder branches, unchanged.
+
+    def _dense_single_attn(self, *, tt_q, tt_kvpe_b8, tt_kv_nope, kvpe_cache, cache_layer_idx, seq_len_local, **_):
+        # Single-shot prefill: materialize V before causal ring SDPA.
+        self._write_kvpe(kvpe_cache, tt_kvpe_b8, cache_layer_idx)
+        tt_v_embedding = self._apply_wkv_b2(tt_kv_nope, seq_len_local)
+        attn_out, _, _ = ttnn.transformer.ring_joint_scaled_dot_product_attention(
+            tt_q,
+            tt_kvpe_b8,
+            tt_v_embedding,
+            self.joint_q,
+            self.joint_kv,
+            self.joint_v,
+            persistent_output_buffer_k=self.persistent_k_output_buffer,
+            persistent_output_buffer_v=self.persistent_v_output_buffer,
+            joint_strategy="rear",
+            logical_n=seq_len_local * self.sp_factor,
+            program_config=self._get_sdpa_program_config(seq_len_local),
+            compute_kernel_config=self.default_compute_kernel_config,
+            dim=2,
+            multi_device_global_semaphore=self.tt_ccl.ring_attention_ccl_semaphore_handles,
+            num_links=self.ccl_num_links,
+            cluster_axis=self.sp_axis,
+            mesh_device=self.mesh_device,
+            topology=self.ccl_topology,
+            ccl_core_grid_offset=self.tt_ccl.ring_attention_ccl_core_grid_offset,
+            use_column_major_ccl=True,
+            is_causal=True,
+            scale=self.scale,
+            is_balanced=self.is_balanced,
+        )
+        return attn_out
+
+    def _dense_chunked_attn(
+        self,
+        *,
+        tt_q,
+        tt_kvpe_b8,
+        kvpe_cache,
+        kv_actual_isl,
+        cache_layer_idx,
+        cache_user_id,
+        seq_len_local,
+        **_,
+    ):
+        # Cache batch dim is user-major: each user reserves self.layer_num contiguous slots, so the
+        # flat slot is cache_user_id * layer_num + cache_layer_idx.
+        assert cache_user_id < self.slot_num, f"cache_user_id {cache_user_id} >= slot_num {self.slot_num}"
+        cache_batch_idx = cache_user_id * self.layer_num + cache_layer_idx
+        return self._chunked_attn(
+            tt_q=tt_q,
+            tt_kvpe=tt_kvpe_b8,
+            kvpe_cache=kvpe_cache,
+            kv_actual_isl=kv_actual_isl,
+            cache_batch_idx=cache_batch_idx,
+            cache_layer_idx=cache_layer_idx,
+            cache_user_id=cache_user_id,
+            seq_len_local=seq_len_local,
+        )
+
+    def _sparse_single_attn(
+        self, *, tt_q, tt_kvpe, tt_kvpe_b8, indices, kvpe_cache, cache_layer_idx, seq_len_local, **_
+    ):
+        assert indices is not None, "sparse MLA forward requires indexer top-k indices"
+        # Single-shot: the live kvpe IS the whole sequence (natural order, contiguous SP shard).
+        assert tt_kvpe is not None
+        self._write_kvpe(kvpe_cache, tt_kvpe_b8, cache_layer_idx)
+        gathered = self._sp_all_gather(tt_kvpe, dim=2)  # [1,1,T,576] bf16 TILE, replicated, natural
+        kvpe_dev = ttnn.to_layout(gathered, ttnn.ROW_MAJOR_LAYOUT)
+        if self.sp_factor > 1:
+            ttnn.deallocate(gathered)
+        ttnn.deallocate(tt_kvpe_b8)
+        ttnn.deallocate(tt_kvpe)
+
+        # Sparse attention runs over latent V; project to v_head_dim afterwards.
+        attn_out = self._sparse_mla(tt_q, kvpe_dev, indices)
+        ttnn.deallocate(kvpe_dev)
+        ttnn.deallocate(tt_q)
+        return self._apply_wkv_b2(attn_out, seq_len_local)
+
+    def _sparse_chunked_attn(
+        self,
+        *,
+        tt_q,
+        tt_kvpe_b8,
+        indices,
+        kvpe_cache,
+        kv_actual_isl,
+        cache_layer_idx,
+        cache_user_id,
+        seq_len_local,
+        **_,
+    ):
+        assert indices is not None, "sparse MLA forward requires indexer top-k indices"
+        start_pos = kv_actual_isl or 0
+        end_pos = start_pos + seq_len_local * self.sp_factor
+
+        # Chunked: the prefix lives in the BLOCK-CYCLIC cache; gather + un-rotate on device.
+        ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
+            kvpe_cache,
+            tt_kvpe_b8,
+            slot_idx=cache_user_id,
+            layer_idx=cache_layer_idx,
+            num_layers=self.layer_num,
+            kv_actual_global=kv_actual_isl,
+            cluster_axis=self.sp_axis,
+        )
+        kvpe_dev = self._gather_kvpe_prefix(kvpe_cache, seq_len_local, end_pos, cache_user_id, cache_layer_idx)
+        ttnn.deallocate(tt_kvpe_b8)
+
+        # Sparse attention runs over latent V; project to v_head_dim afterwards.
+        attn_out = self._sparse_mla(tt_q, kvpe_dev, indices)
+        ttnn.deallocate(kvpe_dev)
+        ttnn.deallocate(tt_q)
+        return self._apply_wkv_b2(attn_out, seq_len_local)
 
     def _forward_kv_only(
         self,
@@ -905,9 +1130,9 @@ class ttMLA:
         kv_actual_isl: int,
         cache_user_id: int,
     ) -> None:
-        """Last-layer fast path: fill the KV cache (which migration consumes) and fire the
-        migration callback, then stop. Skips Q / SDPA / output projection entirely; the
-        block also skips FFN/MoE/norm/LM head, so no first-token output is produced.
+        """Last-layer fast path: fill the KV cache (which migration consumes), then stop. Skips
+        Q / SDPA / output projection entirely; the block also skips FFN/MoE/norm/LM head, so no
+        first-token output is produced.
         """
         signpost(header="MLA_START")
         seq_len_local = hidden_states.shape[2]
@@ -972,3 +1197,77 @@ class ttMLA:
 
         signpost(header="MLA_END")
         return None
+
+    # ----------------------------------------------------------------------------------------
+    # DSA indexer + sparse attention (v3.2 / GLM). Inert unless _has_indexer (dense v3.1 path
+    # never reaches these). The full forward above shares the dense/sparse Q/KV stem and epilogue;
+    # only sparse-specific gather/attention helpers live below.
+    # ----------------------------------------------------------------------------------------
+
+    def _sp_all_gather(self, t, dim):
+        """All-gather across the SP axis (sequence) → full-S replicated on SP. sp=1: no-op."""
+        if self.sp_factor == 1:
+            return t
+        return ttnn.experimental.all_gather_async(
+            t,
+            dim=dim,
+            multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis=self.sp_axis),
+            barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.sp_axis),
+            num_links=self.ccl_num_links,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            topology=self.ccl_topology,
+            cluster_axis=self.sp_axis,
+        )
+
+    def _sparse_mla(self, q: ttnn.Tensor, kvpe: ttnn.Tensor, indices: ttnn.Tensor) -> ttnn.Tensor:
+        """Absorbed MQA over the top-k selected latents (FlashMLA sparse contract: no causal mask —
+        ``indices`` already encode it via the 0xFFFFFFFF sentinel). Invoked SPMD on the SP×TP mesh:
+        each chip runs the single-chip ``ttnn.transformer.sparse_sdpa`` over its own q shard, so q's
+        distribution is preserved — q SP-sharded on seq (dim2), TP-sharded on heads (dim1), out the same.
+
+        q: [1, H/tp, S/sp, 576] absorbed (TILE bf16); kvpe: [1, 1, T, 576] full latent prefix, ROW_MAJOR
+        replicated (K = full 576, V = leading kv_lora_rank). indices: [1, 1, S_global, k] uint32 replicated,
+        re-sharded onto SP (dim2) to match q when sp > 1 (or already SP-sharded → pass through)."""
+        assert self.sp_axis == 0 and self.tp_axis == 1, "sparse_mla assumes sp_axis=0 (outer), tp_axis=1"
+        sp = list(q.device().shape)[self.sp_axis]
+        q_rm = ttnn.to_layout(q, ttnn.ROW_MAJOR_LAYOUT)  # the op is ROW_MAJOR-only; q comes in TILE
+        idx = indices
+        if sp > 1 and indices.shape[2] == q.shape[2] * sp:
+            # Replicated full-glob indices → reshard rows onto the SP axis (inverse of all_gather), matching
+            # q's per-chip seq shard. Already-SP-sharded indices ([1,1,S/sp,k]) match q and pass through.
+            idx = ttnn.mesh_partition(indices, dim=2, cluster_axis=self.sp_axis)
+        # k_chunk_size must be a multiple of 32 that divides TOPK (prod TOPK=2048 → 128).
+        k_chunk = next((c for c in (128, 64, 32) if idx.shape[-1] % c == 0), 32)
+        out = ttnn.transformer.sparse_sdpa(
+            q_rm, kvpe, idx, v_dim=self.kv_lora_rank, scale=self.scale, k_chunk_size=k_chunk
+        )
+        ttnn.deallocate(q_rm)
+        if idx is not indices:
+            ttnn.deallocate(idx)
+        ret = ttnn.to_layout(out, ttnn.TILE_LAYOUT)  # back to TILE for the downstream wkv_b2 linear
+        ttnn.deallocate(out)
+        return ret
+
+    def _gather_kvpe_prefix(self, kvpe_cache, seq_len_local, end_pos, cache_user_id, cache_layer_idx):
+        """On-device read-back of the chunked KVPE prefix for sparse attention. The cache is
+        bf8 / TILE / ND-sharded / block-cyclic across SP; the sparse op wants the full prefix
+        bf16 / ROW_MAJOR / replicated / natural order. Pipeline (all on device — replaces the
+        former host ConcatMesh2dToTensor + blockcyclic_positions read): ND→interleaved, SP
+        all-gather to full-T (no-op at sp==1), select this user/layer slot, bf8→bf16, TILE→RM,
+        un-rotate block-cyclic→natural, trim to end_pos. Returns [1, 1, end_pos, 576] bf16 RM."""
+        cache_i = ttnn.to_memory_config(kvpe_cache, ttnn.DRAM_MEMORY_CONFIG)  # ND_SHARDED → INTERLEAVED
+        full = self._sp_all_gather(cache_i, dim=2)  # → [B, 1, seq_len_cache, 576] replicated, block-cyclic
+        if self.sp_factor > 1:
+            ttnn.deallocate(cache_i)
+        if full.shape[0] > 1:  # user-major slot select (no-op for the single-slot cache)
+            slot = cache_user_id * self.layer_num + cache_layer_idx
+            sel = ttnn.slice(full, [slot, 0, 0, 0], [slot + 1, 1, full.shape[2], full.shape[3]])
+            ttnn.deallocate(full)
+            full = sel
+        full16 = ttnn.typecast(full, ttnn.bfloat16)
+        ttnn.deallocate(full)
+        full_rm = ttnn.to_layout(full16, ttnn.ROW_MAJOR_LAYOUT)
+        ttnn.deallocate(full16)
+        out = blockcyclic_to_natural(full_rm, self.sp_factor, seq_len_local, end_pos)
+        ttnn.deallocate(full_rm)
+        return out

--- a/models/demos/deepseek_v3_d_p/tt/mla/rope.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/rope.py
@@ -22,11 +22,22 @@ def get_rot_transformation_mat():
     return rot_emb_matrix
 
 
-def get_cos_sin_matrix(hf_config):
+def get_cos_sin_matrix(hf_config, interleave: bool = True):
     """Get cos and sin matrices for rotary positional embeddings.
 
     HuggingFace returns cos/sin in [max_seq_len, dim] with dim = [t1,..,td//2, t1,..,td//2].
-    We convert to Meta-style [t1,t1,..,td//2,td//2] format and return [1, 1, max_seq_len, dim].
+    Returns cos, sin as [1, 1, max_seq_len, dim].
+
+    interleave (which physical columns form a rotated pair):
+        True  -> Meta-style duplicated pairs [t1,t1,..,td//2,td//2]; pairs (0,1),(2,3),..
+                 consumed by ``rotary_embedding_llama`` + ``get_rot_transformation_mat``
+                 (MLA q_pe/k_pe, and the GLM indexer).
+        False -> rotate_half / half-split [t1,..,td//2, t1,..,td//2]; pairs (i, i+dim/2)
+                 consumed by ``rotary_embedding_hf`` (no trans_mat) — the DeepSeek indexer.
+
+    Tables are always pure rotations (unit modulus): ``_mscale = m(mscale)/m(mscale_all_dim)``
+    is forced to 1. The YaRN mscale amplitude is applied elsewhere (the attention softmax
+    scale); for every shipped config the baked factor is 1, so this is exact.
     """
     args = {
         "dim": hf_config.qk_rope_head_dim,
@@ -40,23 +51,59 @@ def get_cos_sin_matrix(hf_config):
         "mscale": hf_config.rope_scaling["mscale"],
         "mscale_all_dim": hf_config.rope_scaling["mscale_all_dim"],
     }
+    # Force _mscale = m(mscale)/m(mscale_all_dim) = 1 → pure rotations (no amplitude in
+    # cos/sin). The mscale amplitude is applied in the attention softmax scale instead.
+    args["mscale_all_dim"] = args["mscale"]
 
     reference_rope = DeepseekV3YarnRotaryEmbedding(**args)
 
     cos = reference_rope.cos_cached
     sin = reference_rope.sin_cached
 
-    # Undo the HF permute to Meta-style
+    # HF stores [t1,..,td//2, t1,..,td//2]; take one half, then lay out per `interleave`.
     cos = cos[:, : cos.shape[1] // 2]
-    cos = torch.stack((cos, cos), dim=-1).flatten(-2)
-
     sin = sin[:, : sin.shape[1] // 2]
-    sin = torch.stack((sin, sin), dim=-1).flatten(-2)
+    if interleave:
+        cos = torch.stack((cos, cos), dim=-1).flatten(-2)  # [t1,t1,t2,t2,..]
+        sin = torch.stack((sin, sin), dim=-1).flatten(-2)
+    else:
+        cos = torch.cat((cos, cos), dim=-1)  # [t1,..,td//2, t1,..,td//2]
+        sin = torch.cat((sin, sin), dim=-1)
 
     cos = cos.unsqueeze(0).unsqueeze(0)  # [1, 1, max_seq_len, dim]
     sin = sin.unsqueeze(0).unsqueeze(0)  # [1, 1, max_seq_len, dim]
 
     return cos, sin
+
+
+def interleaved_to_halfsplit_perm(rope_dim: int = 64) -> torch.Tensor:
+    """Dim permutation that maps this MLA's RoPE layout to vLLM's (and back — it is
+    its own structural counterpart applied to the other side).
+
+    RoPE CONVENTION NOTE (verified vs DeepSeek-V3.2-Exp reference, layers 0/30/60).
+    This MLA carries q_pe and stores k_pe in the **interleaved** layout of the
+    official ``inference/model.py`` (``apply_rotary_emb(interleaved=True)``: the
+    2-D rotated pairs are dims (0,1),(2,3),...). vLLM's ``DeepseekV32`` uses the HF
+    **rotate_half / half-split** layout (pairs (i, i+rope_dim/2)) with projection
+    weights pre-permuted to suit. The two are exactly one fixed dim permutation
+    apart, so:
+      * q·k — and therefore the entire MLA output — is IDENTICAL in both layouts
+        (the dot product sums over the rope dims, which the permutation only
+        reorders). Measured: output PCC unchanged at 0.99983 either way.
+      * the stored k_pe *values* differ element-wise: a direct comparison of our
+        k_pe against a vLLM-written cache reads ~0.43 PCC, while the SAME tensor
+        reindexed by this permutation matches at 0.99997.
+
+    So within our self-consistent stack the layout is irrelevant. It matters ONLY
+    when interoperating with a vLLM-written KV cache (e.g. cross-stack disaggregated
+    prefill/decode, or validating against vLLM's recorded k_pe): reindex the rope
+    half of the cache row with ``kpe[..., interleaved_to_halfsplit_perm()]`` to put
+    it in vLLM's layout (or the reverse to ingest a vLLM cache).
+
+    Returns the index tensor p such that ``interleaved_kpe[..., p] == halfsplit_kpe``:
+    p = [0, 2, 4, ..., 1, 3, 5, ...] (even dims = cos halves, then odd dims = sin).
+    """
+    return torch.cat([torch.arange(0, rope_dim, 2), torch.arange(1, rope_dim, 2)])
 
 
 class RotarySetup:
@@ -80,8 +127,11 @@ class RotarySetup:
 
         If is_balanced, cos/sin are reordered according to balanced chunk order
         before sharding so each SP device gets rope values matching its chunk positions.
+
+        Always Meta-style interleaved cos/sin + a trans_matrix (rotary_embedding_llama) — the
+        MLA's own RoPE layout.
         """
-        cos_matrix_torch, sin_matrix_torch = get_cos_sin_matrix(self.hf_config)
+        cos_matrix_torch, sin_matrix_torch = get_cos_sin_matrix(self.hf_config, interleave=True)
 
         assert (
             seq_len <= self.hf_config.max_seq_len

--- a/models/demos/deepseek_v3_d_p/tt/mla/utils.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/utils.py
@@ -3,6 +3,8 @@
 
 import torch
 
+import ttnn
+
 
 def create_balanced_chunk_order(sp_factor: int) -> list[int]:
     """Create balanced chunk order for sequence reordering.
@@ -141,6 +143,39 @@ def blockcyclic_cache_host(
     valid = p < prior_len
     out[valid] = kv_natural[p[valid]]
     return out.reshape(1, 1, seq_len_cache, kvpe_dim)
+
+
+def blockcyclic_to_natural(t, sp: int, seq_len_local: int, end_pos: int):
+    """Reorder a gathered full-cache tensor from the cache's block-cyclic SP layout into natural
+    token order, on device — the inverse of blockcyclic_positions. t is [1, 1, seq_len_cache, 576]
+    ROW_MAJOR (block-cyclic); returns [1, 1, end_pos, 576] natural order. Identity order at sp==1."""
+    seq_len_cache, d = t.shape[2], t.shape[3]
+    chunk_local = seq_len_local  # = chunk_size_global / sp
+    slabs = seq_len_cache // (sp * chunk_local)  # chunks written into the cache
+    if sp == 1:
+        return ttnn.slice(t, (0, 0, 0, 0), (1, 1, end_pos, d))  # identity order
+    # Reorder block-cyclic [chip, slab, off] → natural [slab, chip, off]. A reshape+permute leaves
+    # the result physically NON-contiguous (a strided view): to_torch honours the strides, but the
+    # sparse_sdpa reader consumes raw physical order and silently reads garbage. Concatenating
+    # contiguous per-(slab,chip) slabs materialises a fresh contiguous tensor instead.
+    seq_local_cache = slabs * chunk_local  # rows held by one chip
+    blocks = [
+        ttnn.slice(
+            t,
+            (0, 0, c * seq_local_cache + s * chunk_local, 0),
+            (1, 1, c * seq_local_cache + (s + 1) * chunk_local, d),
+        )
+        for s in range(slabs)
+        for c in range(sp)
+    ]
+    flat = ttnn.concat(blocks, dim=2)
+    for b in blocks:
+        ttnn.deallocate(b)
+    if end_pos == seq_len_cache:
+        return flat
+    out = ttnn.slice(flat, (0, 0, 0, 0), (1, 1, end_pos, d))
+    ttnn.deallocate(flat)  # the slice is a fresh tensor; free the full concat
+    return out
 
 
 def global_to_local_token_id(

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -199,6 +199,30 @@
   owner_id: U08E1JCMAJF # Marko Bezulj
   team: models
 
+- id: bh-lb-deepseek-dsa
+  name: bh_lb_DeepSeek_DSA
+  model-name: deepseek_prefill
+  cmd: |
+    exit_code=0
+    export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528
+    export DEEPSEEK_V32_MLA_REF_CACHE=/tmp/deepseek_v32_mla_ref_cache GLM51_MLA_REF_CACHE=/tmp/glm_5_1_mla_ref_cache
+    # `line` is the verified-portable fabric on the LoudBox (ring/fabric2d fail to train on a partial-Galaxy
+    # box). The suite auto-pins one fabric (priority default fabric2d), so DS_SPARSE_FABRIC=line forces the
+    # collected fabric id back to `line` — which the -k filter below then selects.
+    export DS_SPARSE_FABRIC=line
+    # Sparse MLA (V3.2 + GLM-5.1) vs MLACPU. Random weights + on-the-fly CPU truth -> no staged weights.
+    # GLM (tp<=2) gets its primary coverage on the 4x2 full-box mesh; DeepSeek-V3.2 covers the asymmetric
+    # 2x4 mesh (its 8x4 coverage is on Galaxy). The sparse suite carries no tier markers (the determinism
+    # test is pinned to each variant's anchor mesh, not selected here), so there is no -m gate.
+    pytest models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py -k "glm_5_1 and 4x2 and line" -vvv --tb=short || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py -k "deepseek_v32 and 2x4 and line" -vvv --tb=short || exit_code=$?
+    exit $exit_code
+  skus:
+    bh_loudbox:
+      timeout: 7
+  owner_id: U07N3CUUN05  # Iva Potkonjak
+  team: models
+
 - id: bh-lb-deepseek-prefill-op-tests
   name: bh_lb_DeepSeek_PREFILL_OP_TESTS
   model-name: deepseek_prefill
@@ -208,7 +232,7 @@
     exit $exit_code
   skus:
     bh_loudbox:
-      timeout: 30
+      timeout: 27
   owner_id: U094PKWHNJ0 # Petar Milojevic
   team: models
 
@@ -224,7 +248,7 @@
     exit $exit_code
   skus:
     bh_loudbox:
-      timeout: 39
+      timeout: 35
   owner_id: U09LK84G4TF # Nikola Milicevic
   team: models
 

--- a/tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml
@@ -105,6 +105,27 @@
   owner_id: U08RL15T4N8
   team: models
 
+- name: "(Galaxy) DeepSeek Prefill - DSA MLA (V3.2)"
+  cmd: |
+    export MESH_DEVICE=TG DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528
+    export DEEPSEEK_V32_MLA_REF_CACHE=/tmp/deepseek_v32_mla_ref_cache
+    # `line` is the verified-portable fabric (ring/fabric2d for the sparse path pending Galaxy validation).
+    # The suite auto-pins one fabric (priority default fabric2d), so DS_SPARSE_FABRIC=line forces the
+    # collected fabric id back to `line` — which the -k filter below then selects.
+    export DS_SPARSE_FABRIC=line
+    # Sparse MLA (indexer + sparse SDPA) vs the MLACPU reference. Random weights + on-the-fly CPU truth
+    # -> no staged V3.2 weights needed; R1 supplies the (shared-dim) config. GLM is tp<=2, so it skips on
+    # the 8x4 (tp=4) Galaxy mesh and is covered on the LoudBox instead. The sparse suite carries no tier
+    # markers, so there is no -m gate. 8x4 is the full Galaxy mesh.
+    pytest models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py -k "deepseek_v32 and 8x4 and line" -vvv --tb=short
+  test_type: dsa_mla
+  test_group: module
+  skus:
+    bh_galaxy:
+      timeout: 10
+  owner_id: U07N3CUUN05  # Iva Potkonjak
+  team: models
+
 - name: "(Galaxy) DeepSeek Prefill - Kimi MoE"
   cmd: |
     export MESH_DEVICE=TG


### PR DESCRIPTION
Adds DeepSeek V3.2 / GLM-5.1 sparse MLA (DSA: lightning indexer + sparse SDPA) support into the existing `deepseek_v3_d_p` stack, on top of the dense MLA path.

## Summary

- Adds the DSA path to `ttMLA` in `models/demos/deepseek_v3_d_p/tt/mla` (indexer detection, sparse KV/PE cache, sparse SDPA), shared with the dense flow; `rope`/`utils` helpers extended for the sparse layout. Dense V3.1 behavior is unchanged — the sparse path is gated to the V3.2/GLM variants.
- Adds a reusable `TtIndexer` (`tt/mla/indexer.py`) for DSA index selection and sparse-attention dispatch.
- Adds the `cpu_deepseek_v32` CPU reference package (MLACPU / sparse truth) with a small public API, so device-vs-truth PCC is meaningful from one shared weights dict.
- Registers `deepseek_v32` and `glm_5_1` as variant-driven test targets and wires a sparse-MLA suite into the Blackhole e2e and Galaxy DeepSeek-prefill CI pipelines.
- Keeps the out-of-band trace and perf suites opt-in via pytest markers (`-m trace` / `-m perf`).

## Changes

All under `models/demos/deepseek_v3_d_p/`.

| Area | Change |
|---|---|
| `tt/mla/indexer.py` *(new)* | `TtIndexer` — lightning-indexer scoring + SP-sharded top-k key selection |
| `tt/mla/mla.py` | `ttMLA` gains the DSA path (sparse KV/PE cache, sparse SDPA), sharing the dense flow |
| `tt/mla/{rope,utils}.py` | RoPE / helper extensions for the sparse (indexed) layout |
| `reference/cpu_deepseek_v32/` *(new)* | CPU sparse-MLA reference; public API: `SparseMLAReference`, `random/pretrained_mla_weights` |
| `reference/{deepseek_v3_2,glm_5_1}_config.py` *(new)* | Hand-built HF configs (not `AutoConfig`-loadable) |
| `tests/sparse_mla/` *(new)* | Correctness, cache, trace (`-m trace`), perf (`-m perf`) suites + shared helpers/plugin |
| `tests/model_variants.py`, `tests/conftest.py` | Register `deepseek_v32` / `glm_5_1` variants |
| `tests/pipeline_reorg/*.yaml` | Wire the sparse suite into the Galaxy + Blackhole CI pipelines |

## How to run

```bash
pytest models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py   # Blackhole, ~2 min
```

Opt-in suites: `-m trace` (trace-bundle parity) · `-m perf` (tracy timing).

---

## CI time-budget sizing

The `models` per-SKU budget in `.github/time_budget.yaml` is fixed, and `bh_loudbox` was already fully consumed, so the new entries are sized to measured runtime (not padded). Room was reclaimed from two over-allocated, low-variance neighbours rather than raising the budget:

| `bh_loudbox` entry | was → now | actual |
|---|---|---|
| `bh_lb_DeepSeek_DSA` | N/A → **7** | ~5.6 min |
| `bh_lb_DeepSeek_PREFILL_PERF` | 39 → **35** | 27.8–31.5 min (13 runs) |
| `bh_lb_DeepSeek_PREFILL_OP_TESTS` | 30 → **27** | 22.2–23.2 min (13 runs) |
| `bh_galaxy · dsa_mla` | N/A → **10** | ~3.4 min |

`bh_loudbox` now sits exactly at budget (93+7+35+27 = 162); `bh_galaxy` at 405/410.

---
## Test plan

Re-run on the current branch head (post-review). **Every sparse/DSA job this PR adds passes; all red jobs are unrelated infra**, verified branch-vs-`main` at the log/root-cause level.

| Pipeline | Run | DSA job this PR adds | Status |
|---|---|---|---|
| `galaxy-deepseek-prefill-tests` | [28452007651](https://github.com/tenstorrent/tt-metal/actions/runs/28452007651) ✅ pass | `(Galaxy) DeepSeek Prefill - DSA MLA (V3.2)` ✅ | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=mvasilijevic/dsa_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:mvasilijevic/dsa_pr) |
| `blackhole-e2e-tests` | [28452009515](https://github.com/tenstorrent/tt-metal/actions/runs/28452009515) | `bh_lb_DeepSeek_DSA` ✅ | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=mvasilijevic/dsa_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:mvasilijevic/dsa_pr) |
| `demo-sp-release` | [28452011758](https://github.com/tenstorrent/tt-metal/actions/runs/28452011758) | *(runs no DSA job)* | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=mvasilijevic/dsa_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:mvasilijevic/dsa_pr) |

**No failing job is caused by this PR** — each red job is unrelated infrastructure, confirmed by comparing branch and `main` failure logs (not just job names):

- **`blackhole-e2e-tests`** — DSA job (`bh_lb_DeepSeek_DSA`) green; the 3 reds all pass on latest `main`: `fabric sanity` (died at runner "Set up job"), `panoptic-deeplab` (different model), `PREFILL_OP_TESTS` (passed 3/4 boxes, **cleared on re-run** → flake).
- **`demo-sp-release`** — no DSA job; **baseline-red on `main`** (all 3 recent runs fail). **10/12 branch failures are the same jobs red on `main`** (Galaxy tray reset via `IPMI`, SP1 board hang, torch.hub download); the other 2 flake on `main` too. All infra — no code/PCC failure.

Local Blackhole validation (current build): full `models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py` — **10/10 pass**, PCC 0.996–0.999, determinism bit-exact.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mvasilijevic/dsa_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mvasilijevic/dsa_pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mvasilijevic/dsa_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mvasilijevic/dsa_pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mvasilijevic/dsa_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mvasilijevic/dsa_pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mvasilijevic/dsa_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mvasilijevic/dsa_pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mvasilijevic/dsa_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mvasilijevic/dsa_pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mvasilijevic/dsa_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mvasilijevic/dsa_pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mvasilijevic/dsa_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mvasilijevic/dsa_pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mvasilijevic/dsa_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mvasilijevic/dsa_pr)

