### PR TITLE
[skip ci] Temporarily skip Mochi BH QuietBox 2x2 pipeline performance test

### DIFF
--- a/models/tt_dit/tests/models/mochi/test_performance_mochi.py
+++ b/models/tt_dit/tests/models/mochi/test_performance_mochi.py
@@ -239,6 +239,7 @@ def test_mochi_pipeline_performance(
         }
     elif tuple(mesh_device.shape) == (2, 2) and vae_mesh_shape == (1, 4):
         assert is_blackhole(), "2x2 is only supported for blackhole"
+        pytest.skip("Skipping BH QuietBox 2x2 perf test: encoder latency consistently exceeds threshold, refs #47026")
         # Tighten these once we have a stable BH QuietBox baseline in CI.
         expected_metrics = {
             "encoder": 8.0,


### PR DESCRIPTION
The test `test_mochi_pipeline_performance[blackhole-device_params0-dit_2x2sp0tp1_vae_1x4sp0tp1_BH_QB-genmo/mochi-1-preview-848-480-3.5-50-168]` has been failing for 7+ days on the Blackhole QuietBox 2 (`bh_quietbox_2`) CI runner. The encoder step consistently exceeds its expected threshold of 8.0s (actual ~11.8–12.0s). This PR adds a narrowly-scoped `pytest.skip()` inside the `(2,2)` mesh-shape branch so only the BH QB parametrization is skipped; all other parametrizations are unaffected. refs #47026

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47026)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lifecycle/disable-issue-47026)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47026)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lifecycle/disable-issue-47026)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=lifecycle/disable-issue-47026)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:lifecycle/disable-issue-47026)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lifecycle/disable-issue-47026)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lifecycle/disable-issue-47026)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47026)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lifecycle/disable-issue-47026)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lifecycle/disable-issue-47026)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lifecycle/disable-issue-47026)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lifecycle/disable-issue-47026)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lifecycle/disable-issue-47026)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lifecycle/disable-issue-47026)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lifecycle/disable-issue-47026)