### PR TITLE
Decouple common MLP1D from tt_transformers

### DIFF
--- a/models/common/modules/mlp/mlp_1d.py
+++ b/models/common/modules/mlp/mlp_1d.py
@@ -33,8 +33,8 @@ from models.common.modules.tt_ccl import (
     get_tt_ccl,
 )
 from models.common.tensor_utils import TILE_SIZE, get_padded_hidden_dim, pad_dim_to_size
+from models.common.transformer_types import Mode, OpGroup, TensorGroup
 from models.common.utility_functions import is_blackhole
-from models.tt_transformers.tt.common import Mode
 
 # =============================================================================
 # Top-level config dataclass
@@ -364,8 +364,7 @@ class MLP1D(LightweightModule):
 
     def forward(self, x: ttnn.Tensor | LazyWeight, mode: str | Mode) -> ttnn.Tensor:
         """Dispatch to the appropriate forward method based on mode."""
-        if isinstance(mode, Mode):
-            mode = mode.value
+        mode = mode.value if isinstance(mode, Mode) else mode
         if mode == "decode":
             return self.decode_forward(x)
         else:
@@ -470,8 +469,6 @@ class MLP1D(LightweightModule):
             raise ValueError("MLP1D cannot be used for Galaxy devices.")
 
         import torch
-
-        from models.tt_transformers.tt.model_config import OpGroup, TensorGroup
 
         # Get model_config for overrides - use passed model_config if provided
         if model_config is None:
@@ -662,7 +659,7 @@ def _find_prefill_grid(row_tiles: int, col_tiles: int, max_rows: int = 8, max_co
 
 def _get_out_subblock_w(per_core_n: int, out_subblock_h: int = 1) -> int:
     """Get output subblock width that divides per_core_n and satisfies constraints."""
-    # [ALIGNED] Exactly matching models/tt_transformers/tt/common.py:get_out_subblock_w
+    # Matches the legacy TTTv1 output subblock selection.
     out_subblock_w = 4  # TODO: Check with LLK team if this is the true bound, might be 8 now
     while out_subblock_w > 1:
         if out_subblock_w * out_subblock_h <= 4 and per_core_n % out_subblock_w == 0:

--- a/models/common/tests/modules/mlp/test_mlp_1d.py
+++ b/models/common/tests/modules/mlp/test_mlp_1d.py
@@ -32,8 +32,8 @@ from models.common.auto_compose import to_torch_auto_compose
 from models.common.modules.lazy_weight import LazyWeight
 from models.common.modules.mlp.mlp_1d import MLP1D, MLP1DConfig, _matmul_config
 from models.common.tensor_utils import TILE_SIZE
+from models.common.transformer_types import Mode
 from models.common.utility_functions import comp_allclose, comp_pcc
-from models.tt_transformers.tt.common import Mode
 
 
 def get_mlp_weights_from_ref_model(reference_mlp) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -229,6 +229,20 @@ def test_mlp_1d_config_power_user_overrides():
     assert config.decode_mlp2_input_memcfg is mock_mem_config
     assert config.decode_residual_memcfg is mock_mem_config
     assert config.activation_dtype == ttnn.bfloat16
+
+
+def test_mlp_1d_forward_accepts_common_mode():
+    """Common Mode values and legacy strings should route through the dispatcher."""
+    from models.common.modules.mlp.mlp_1d import MLP1D
+
+    model = object.__new__(MLP1D)
+    model.decode_forward = lambda x: ("decode", x)
+    model.prefill_forward = lambda x: ("prefill", x)
+
+    assert model.forward("input", Mode.DECODE) == ("decode", "input")
+    assert model.forward("input", Mode.PREFILL) == ("prefill", "input")
+    assert model.forward("input", "decode") == ("decode", "input")
+    assert model.forward("input", "prefill") == ("prefill", "input")
 
 
 # Pulled from deduped perf sweep of existing model tests in CI

--- a/models/common/transformer_types.py
+++ b/models/common/transformer_types.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from enum import Enum
+
+
+class Mode(Enum):
+    DECODE = "decode"
+    PREFILL = "prefill"
+
+
+class TensorGroup(Enum):
+    FF1_FF3 = "ff1_3"
+    FF2 = "ff2"
+    WQKV = "wqkv"
+    WO = "wo"
+    KV_CACHE = "kv_cache"
+    ACTIVATION = "activation"
+
+
+class PrecisionSetting(Enum):
+    BFP4 = "bfp4"
+    BFP8 = "bfp8"
+    BF16 = "bf16"
+
+
+class OpGroup(Enum):
+    """
+    LI_* are linear operator groups
+    SDPA_* are scaled_dot_product_attention operator groups
+    """
+
+    LI_FF1_FF3 = "li_ff1_3"
+    LI_FF2 = "li_ff2"
+    LI_QKV_DECODE = "li_qkv_decode"
+    LI_O_DECODE = "li_o_decode"
+    SDPA_DECODE = "sdpa_decode"
+    LI_QKV_PREFILL = "li_qkv_prefill"
+    LI_O_PREFILL = "li_o_prefill"
+    SDPA_PREFILL = "sdpa_prefill"
+    ACCURACY = "accuracy"
+
+
+class MathFidelitySetting(Enum):
+    LOFI = "lofi"
+    HIFI2 = "hifi2"
+    HIFI2_NA = "hifi2na"
+    HIFI2_FP16 = "hifi2fp16"
+    HIFI2_NOL1ACC = "hifi2nol1acc"
+    HIFI4 = "hifi4"
+    HIFI4_FP32 = "hifi4fp32"

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -16,6 +16,7 @@ from pydantic import AliasChoices, BaseModel, Field
 
 import ttnn
 from models.common.tensor_utils import get_rot_transformation_mat as get_rot_transformation_mat_v2
+from models.common.transformer_types import Mode  # noqa: F401
 
 
 class URL(BaseModel):
@@ -46,11 +47,6 @@ InterleavedTextMedia = Union[
     ImageMedia,
     List[Union[str, ImageMedia]],
 ]
-
-
-class Mode(Enum):
-    DECODE = "decode"
-    PREFILL = "prefill"
 
 
 class HostEmbedding(torch.nn.Module):

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -15,6 +15,7 @@ import torch
 from loguru import logger
 
 import ttnn
+from models.common.transformer_types import MathFidelitySetting, OpGroup, PrecisionSetting, TensorGroup
 from models.common.utility_functions import hf_cache_to_legacy, is_blackhole, is_wormhole_b0, nearest_32
 from models.tt_transformers.tt.common import (
     Mode,
@@ -64,38 +65,6 @@ _REPO_ROOT = Path(
 )
 
 
-class TensorGroup(Enum):
-    FF1_FF3 = "ff1_3"
-    FF2 = "ff2"
-    WQKV = "wqkv"
-    WO = "wo"
-    KV_CACHE = "kv_cache"
-    ACTIVATION = "activation"
-
-
-class PrecisionSetting(Enum):
-    BFP4 = "bfp4"
-    BFP8 = "bfp8"
-    BF16 = "bf16"
-
-
-class OpGroup(Enum):
-    """
-    LI_* are linear operator groups
-    SDPA_* are scaled_dot_product_attention operator groups
-    """
-
-    LI_FF1_FF3 = "li_ff1_3"
-    LI_FF2 = "li_ff2"
-    LI_QKV_DECODE = "li_qkv_decode"
-    LI_O_DECODE = "li_o_decode"
-    SDPA_DECODE = "sdpa_decode"
-    LI_QKV_PREFILL = "li_qkv_prefill"
-    LI_O_PREFILL = "li_o_prefill"
-    SDPA_PREFILL = "sdpa_prefill"
-    ACCURACY = "accuracy"  # This is a special group for accuracy mode, not an actual operator group
-
-
 def compute_padded_vocab_size(vocab_size: int, num_devices: int) -> int:
     """Pad total vocab so each device shard is tile-aligned."""
     if num_devices < 1:
@@ -113,16 +82,6 @@ def should_pad_sampling_logits_to_power_of_2(
 
     per_device_vocab = padded_vocab_size // sampling_splits
     return per_device_vocab > 0 and (per_device_vocab & (per_device_vocab - 1)) != 0
-
-
-class MathFidelitySetting(Enum):
-    LOFI = "lofi"
-    HIFI2 = "hifi2"
-    HIFI2_NA = "hifi2na"  # na specified `packer_l1_acc=False` and `fp32_dest_acc_en=False` in compute kernel config
-    HIFI2_FP16 = "hifi2fp16"  # fp16 specified `fp32_dest_acc_en=False` in compute kernel config
-    HIFI2_NOL1ACC = "hifi2nol1acc"  # fp32_dest_acc_en=True but packer_l1_acc=False (issue #36378)
-    HIFI4 = "hifi4"
-    HIFI4_FP32 = "hifi4fp32"
 
 
 class ModelOptimizations:


### PR DESCRIPTION
[![Galaxy TTTv2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-unit-tests.yaml/badge.svg?branch=yieldthought%2Fcommon-mlp-1d-decouple)](https://github.com/tenstorrent/tt-metal/actions/runs/28200800297)
[![PR Gate](https://github.com/tenstorrent/tt-metal/actions/workflows/pr-gate.yaml/badge.svg?branch=yieldthought%2Fcommon-mlp-1d-decouple)](https://github.com/tenstorrent/tt-metal/actions/runs/28085530883)
[![Static checks](https://github.com/tenstorrent/tt-metal/actions/workflows/all-static-checks.yaml/badge.svg?branch=yieldthought%2Fcommon-mlp-1d-decouple)](https://github.com/tenstorrent/tt-metal/actions/runs/28085530820)

## Summary
- Move transformer mode/optimization enums into `models.common.transformer_types`.
- Have `models.tt_transformers` import and re-export those common enum types for existing callers.
- Update `models.common.modules.mlp.mlp_1d` to use the common enum types, with no MLP1D behavior changes.

## Testing
- `pre-commit run --files models/common/tests/modules/mlp/test_mlp_1d.py`
- `python -m py_compile models/common/tests/modules/mlp/test_mlp_1d.py`
- `git diff --check`
- `coreview 47837` - no issues found.

Local focused pytest is blocked in this workstation shell because `pytest` is not installed. Focused and model-level pytest runs were dispatched in CI instead.

## CI Runs
- [Galaxy TTTv2 tests #28200800297](https://github.com/tenstorrent/tt-metal/actions/runs/28200800297) - running on `2e81c41d2b305340c1afcaa92884d4310781ab8d`.
  - `(Galaxy) unit tests`, `model=tttv2`; runs `Galaxy tttv2 tests [wh_galaxy_perf]`, covering TTTv2 RMSNorm2D, MLP2D, and auto-compose module tests.
  - Selected because the latest main baseline [#28159739418](https://github.com/tenstorrent/tt-metal/actions/runs/28159739418) passed the same `Galaxy tttv2 tests [wh_galaxy_perf]` job.
- [tt_transformers MLP model test #28086387554](https://github.com/tenstorrent/tt-metal/actions/runs/28086387554) - passed on `2e81c41d2b305340c1afcaa92884d4310781ab8d` (`4 passed`).
  - `MESH_DEVICE=N150 HF_HUB_OFFLINE=1 HF_HOME=/mnt/MLPerf/huggingface HF_MODEL=meta-llama/Llama-3.1-8B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.1-8B-Instruct pytest --timeout 600 --tb=short models/tt_transformers/tests/test_mlp.py`
- [MLP1D common enum focused tests #28085536558](https://github.com/tenstorrent/tt-metal/actions/runs/28085536558) - passed on `2e81c41d2b305340c1afcaa92884d4310781ab8d` (`4 passed, 681 deselected`).
  - `pytest models/common/tests/modules/mlp/test_mlp_1d.py -k "config_creation or config_defaults or config_power_user_overrides or forward_accepts_common_mode" -vv`
- [PR Gate #28085530883](https://github.com/tenstorrent/tt-metal/actions/runs/28085530883) - passed on `2e81c41d2b305340c1afcaa92884d4310781ab8d`.
- [Static checks #28085530820](https://github.com/tenstorrent/tt-metal/actions/runs/28085530820) - passed on `2e81c41d2b305340c1afcaa92884d4310781ab8d`.

Note: the earlier T3K TTTv2 modules run is not listed as a PR signal because the same MLP1D tensor-cache failure reproduces on main.
