### PR TITLE
Update Mochi encoder test perf threshold for BH QB2

### DIFF
--- a/models/tt_dit/tests/models/mochi/test_performance_mochi.py
+++ b/models/tt_dit/tests/models/mochi/test_performance_mochi.py
@@ -241,7 +241,7 @@ def test_mochi_pipeline_performance(
         assert is_blackhole(), "2x2 is only supported for blackhole"
         # Tighten these once we have a stable BH QuietBox baseline in CI.
         expected_metrics = {
-            "encoder": 8.0,
+            "encoder": 12.5,
             "denoising": 2600,
             "vae": 90,
             "total": 2700,


### PR DESCRIPTION
### Summary

Addresses issue [47026](https://github.com/tenstorrent/tt-metal/issues/47026). The Mochi encoder perf threshold has been increased from 8.0s -> 12.5s on BH QB2.
