### PR TITLE
[cleanup] quasar: porting unary broadcast to tensorshape

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -13,16 +13,6 @@
  * LLK ELTWISE UNARY DATACOPY
  *************************************************************************/
 
-inline TileShape llk_math_eltwise_unary_broadcast_tile_shape(const std::uint32_t operand) {
-    const std::uint32_t operand_id = get_operand_id(operand);
-    return TileShape{
-        .num_faces = get_operand_num_faces(operand_id),
-        .face_r_dim = get_operand_face_r_dim(operand_id),
-        .face_c_dim = static_cast<std::uint32_t>(ckernel::trisc::FACE_C_DIM),
-        .narrow_tile = get_operand_narrow_tile(operand_id) != 0,
-    };
-}
-
 /**
  * @brief Initialize eltwise unary datacopy operations
  *
@@ -61,8 +51,9 @@ inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand) {
         }
     } else {
         static_assert(type == DataCopyType::B2D);
-        const TileShape tile_shape = llk_math_eltwise_unary_broadcast_tile_shape(operand);
-        _llk_math_eltwise_unary_broadcast_init_<src_b_bcast_type, false /*unpack_to_dest*/, EN_32BIT_DEST>(tile_shape);
+        const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand);
+        _llk_math_eltwise_unary_broadcast_init_<src_b_bcast_type, false /*unpack_to_dest*/, EN_32BIT_DEST>(
+            tensor_shape);
     }
 }
 
@@ -91,8 +82,8 @@ inline void llk_math_eltwise_unary_datacopy(const std::uint32_t dst_index, const
 
     if constexpr (src_b_bcast_type != BroadcastType::NONE && !unpack_to_dest) {
         static_assert(type == DataCopyType::B2D, "Unary broadcast math path requires DataCopyType::B2D");
-        const TileShape tile_shape = llk_math_eltwise_unary_broadcast_tile_shape(operand);
-        _llk_math_eltwise_unary_broadcast_<src_b_bcast_type, false, EN_32BIT_DEST>(dst_index, tile_shape);
+        const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand);
+        _llk_math_eltwise_unary_broadcast_<src_b_bcast_type, false, EN_32BIT_DEST>(dst_index, tensor_shape);
     } else {
         // 32-bit unpack-to-dest: math is a sync-only forwarder (unpacker wrrites DEST), no MOP to run.
         if (!(unpack_to_dest && llk_math_is_unpack_to_dest_32b(operand_id))) {

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unary_broadcast_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unary_broadcast_quasar.py
@@ -30,6 +30,8 @@ from helpers.test_variant_parameters import (
     IMPLIED_MATH_FORMAT,
     NUM_BLOCKS,
     NUM_FACES,
+    NUM_FACES_C_DIM,
+    NUM_FACES_R_DIM,
     NUM_TILES_IN_BLOCK,
     TEST_FACE_DIMS,
     TILE_COUNT,
@@ -156,6 +158,8 @@ def test_unary_broadcast_quasar(
                 output_num_blocks=output_num_blocks,
             ),
             TEST_FACE_DIMS(face_r_dim=face_r_dim, face_c_dim=FACE_C_DIM),
+            NUM_FACES_R_DIM(num_faces_r_dim),
+            NUM_FACES_C_DIM(num_faces_c_dim),
         ],
         variant_stimuli=StimuliConfig(
             src_A,

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
@@ -8,6 +8,7 @@
 #include "ckernel.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
+#include "quasar_test_common.h"
 #include "sfpu_stub.h"
 
 // Globals
@@ -43,20 +44,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
         set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
     }
 
-    buffer_descriptor_u bd_val = {0};
-    bd_val.f.l1_addr_16B       = L1_ADDRESS(params.buffer_B[0]);
-    bd_val.f.format            = static_cast<std::uint8_t>(formats.unpack_A_src);
-    bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
-    bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
-    bd_val.f.z_dim             = params.num_faces;
+    const auto tensor_shape = tensor_shape_from_params(params);
 
-    td_val_A.buf_desc        = bd_val;
-    td_val_A.buf_desc_id     = buf_desc_id_a;
-    td_val_A.reg_data_format = static_cast<std::uint8_t>(formats.unpack_A_dst);
-
-    td_val_B.buf_desc        = bd_val;
-    td_val_B.buf_desc_id     = buf_desc_id_b;
-    td_val_B.reg_data_format = static_cast<std::uint8_t>(formats.unpack_A_dst);
+    td_val_A = ckernel::trisc::construct_tdma_desc(tensor_shape, L1_ADDRESS(params.buffer_B[0]), formats.unpack_A_src, buf_desc_id_a, formats.unpack_A_dst);
+    td_val_B = ckernel::trisc::construct_tdma_desc(tensor_shape, L1_ADDRESS(params.buffer_B[0]), formats.unpack_A_src, buf_desc_id_b, formats.unpack_A_dst);
 
     _configure_buf_desc_table_(td_val_A.buf_desc_id, td_val_A.buf_desc);
     _configure_buf_desc_table_(td_val_B.buf_desc_id, td_val_B.buf_desc);
@@ -127,10 +118,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
 
-        TileShape tile_shape = {
-            .num_faces = params.num_faces, .face_r_dim = params.TEST_FACE_R_DIM, .face_c_dim = params.TEST_FACE_C_DIM, .narrow_tile = false};
+        const auto tensor_shape = tensor_shape_from_params(params);
 
-        _llk_math_eltwise_unary_broadcast_init_<BROADCAST_TYPE, unpack_to_dest, is_fp32_dest_acc_en>(tile_shape);
+        _llk_math_eltwise_unary_broadcast_init_<BROADCAST_TYPE, unpack_to_dest, is_fp32_dest_acc_en>(tensor_shape);
 
         const std::uint32_t tiles_in_block = params.OUTPUT_NUM_TILES_IN_BLOCK;
         const std::uint32_t num_blocks     = static_cast<std::uint32_t>(params.INPUT_NUM_BLOCKS);
@@ -139,7 +129,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             for (std::uint32_t tile = 0; tile < tiles_in_block; tile++)
             {
-                _llk_math_eltwise_unary_broadcast_<BROADCAST_TYPE, unpack_to_dest, is_fp32_dest_acc_en>(tile, tile_shape);
+                _llk_math_eltwise_unary_broadcast_<BROADCAST_TYPE, unpack_to_dest, is_fp32_dest_acc_en>(tile, tensor_shape);
             }
             _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
         }
@@ -171,22 +161,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
         set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
     }
 
-    buffer_descriptor_u bd_val = {0};
-    bd_val.f.l1_addr_16B       = L1_ADDRESS(params.buffer_Res[0]);
-    bd_val.f.format            = static_cast<std::uint8_t>(formats.pack_dst);
-    bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
-    bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
-    bd_val.f.z_dim             = params.num_faces;
+    const auto tensor_shape = tensor_shape_from_params(params);
 
-    tdma_descriptor_t tdma_desc;
-
-    tdma_desc.buf_desc        = bd_val;
-    tdma_desc.buf_desc_id     = buf_desc_id;
-    tdma_desc.reg_data_format = static_cast<std::uint8_t>(formats.pack_src);
+    tdma_descriptor_t tdma_desc =
+        ckernel::trisc::construct_tdma_desc(tensor_shape, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst, buf_desc_id, formats.pack_src);
 
     _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
     _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc);
-    _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, 1);
+    _llk_pack_init_(buf_desc_id, tensor_shape, 1);
 
     const std::uint32_t output_num_blocks     = static_cast<std::uint32_t>(params.OUTPUT_NUM_BLOCKS);
     const std::uint32_t output_tiles_in_block = params.OUTPUT_NUM_TILES_IN_BLOCK;
@@ -196,7 +178,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         for (std::uint32_t tile = 0; tile < output_tiles_in_block; tile++)
         {
             const std::uint32_t res_tile_idx = (block * output_tiles_in_block) + tile;
-            _llk_pack_(tile, res_tile_idx, ckernel::DEFAULT_TENSOR_SHAPE);
+            _llk_pack_(tile, res_tile_idx, tensor_shape);
         }
         _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
     }

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_defs.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_defs.h
@@ -32,20 +32,6 @@ enum register_space_e
     ADDR_COUNTERS = 0x2
 };
 
-// This struct contains all the information needed to specify a tile
-//  shape, for a default 32x32 tile these are the values:
-//  num_faces = 4;
-//  face_r_dim = 16;
-//  face_c_dim = 16;
-//  narrow_tile = 0;
-struct TileShape
-{
-    std::uint32_t num_faces;
-    std::uint32_t face_r_dim;
-    std::uint32_t face_c_dim;
-    bool narrow_tile;
-};
-
 // TODO: AM; rename enum values, issue #1275
 enum ThreadId
 {

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_unary_broadcast.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_unary_broadcast.h
@@ -185,6 +185,7 @@ template <BroadcastType BROADCAST_TYPE, bool unpack_to_dest = false, bool is_fp3
 inline void _llk_math_eltwise_unary_broadcast_init_(const TensorShape& tensor_shape)
 {
     static_assert(!(unpack_to_dest && is_fp32_dest_acc_en), "Unary broadcast: unpack_to_dest with Float32 dest accumulation is not supported yet");
+    LLK_ASSERT(tensor_shape.total_num_faces() == 4, "Unary broadcast currently only supports 32x32 tiles");
     _llk_math_eltwise_unary_broadcast_addrmod_<BROADCAST_TYPE, unpack_to_dest>(tensor_shape);
     if constexpr (!unpack_to_dest)
     {

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_unary_broadcast.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_unary_broadcast.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 
 #include "llk_math_common.h"
+#include "tensor_shape.h"
 using namespace ckernel;
 using namespace ckernel::trisc;
 using namespace ckernel::math;
@@ -21,10 +22,10 @@ using namespace ckernel::math;
  *
  * @tparam BROADCAST_TYPE: Scalar, row, or column broadcast (must not be NONE), values = <COL/ROW/SCALAR>
  * @tparam unpack_to_dest: When true, UNP_A wrote to dest; ADDR_MOD_3 used for dest<->srcB moves
- * @param tile_shape: Face geometry (face_r_dim, num_faces) for row-broadcast addrmods
+ * @param tensor_shape: Face geometry (face_r_dim, num_faces) for row-broadcast addrmods
  */
 template <BroadcastType BROADCAST_TYPE, bool unpack_to_dest = false>
-inline void _llk_math_eltwise_unary_broadcast_addrmod_(const TileShape& tile_shape)
+inline void _llk_math_eltwise_unary_broadcast_addrmod_(const TensorShape& tensor_shape)
 {
     static_assert(BROADCAST_TYPE != BroadcastType::NONE, "Broadcast type cannot be NONE");
 
@@ -37,7 +38,7 @@ inline void _llk_math_eltwise_unary_broadcast_addrmod_(const TileShape& tile_sha
     if constexpr (BROADCAST_TYPE == BroadcastType::ROW)
     {
         addr_mod_t {
-            .srcb = {.incr = static_cast<std::uint8_t>(tile_shape.face_r_dim)},
+            .srcb = {.incr = static_cast<std::uint8_t>(tensor_shape.face_r_dim)},
             .dest = {.incr = row_step},
         }
             .set(ADDR_MOD_2);
@@ -48,8 +49,8 @@ inline void _llk_math_eltwise_unary_broadcast_addrmod_(const TileShape& tile_sha
         if constexpr (BROADCAST_TYPE == BroadcastType::ROW)
         {
             addr_mod_t {
-                .srcb = {.incr = static_cast<std::uint8_t>(tile_shape.face_r_dim)},
-                .dest = {.incr = static_cast<std::uint16_t>(tile_shape.face_r_dim)},
+                .srcb = {.incr = static_cast<std::uint8_t>(tensor_shape.face_r_dim)},
+                .dest = {.incr = static_cast<std::uint16_t>(tensor_shape.face_r_dim)},
             }
                 .set(ADDR_MOD_3);
         }
@@ -71,10 +72,10 @@ inline void _llk_math_eltwise_unary_broadcast_addrmod_(const TileShape& tile_sha
  * @tparam unpack_to_dest: When true, unpack filled dest; MOVB2D reads srcB only, so @ref _llk_math_eltwise_unary_broadcast_ runs MOVD2B (dest->srcB) first,
  *         then programs this MOVB2D MOP. ROW uses the fixed replay below; COL/SCALAR use the same outer/inner template as the non-unpack_to_dest path with
  *         ADDR_MOD_3 from addrmod.
- * @param tile_shape: Tile shape for loop counts and row dimensions
+ * @param tensor_shape: Tile shape for loop counts and row dimensions
  */
 template <BroadcastType BROADCAST_TYPE, bool unpack_to_dest = false>
-inline void _llk_math_eltwise_unary_broadcast_mop_config_(const TileShape& tile_shape)
+inline void _llk_math_eltwise_unary_broadcast_mop_config_(const TensorShape& tensor_shape)
 {
     static_assert(BROADCAST_TYPE != BroadcastType::NONE, "Broadcast type cannot be NONE");
 
@@ -102,8 +103,9 @@ inline void _llk_math_eltwise_unary_broadcast_mop_config_(const TileShape& tile_
     }
     else
     {
-        const std::uint32_t num_rows = (BROADCAST_TYPE == BroadcastType::SCALAR) ? tile_shape.num_faces * tile_shape.face_r_dim : tile_shape.face_r_dim;
-        const std::uint32_t outer    = (BROADCAST_TYPE == BroadcastType::SCALAR) ? 1U : static_cast<std::uint32_t>(tile_shape.num_faces);
+        const std::uint32_t num_rows =
+            (BROADCAST_TYPE == BroadcastType::SCALAR) ? tensor_shape.total_num_faces() * tensor_shape.face_r_dim : tensor_shape.face_r_dim;
+        const std::uint32_t outer    = (BROADCAST_TYPE == BroadcastType::SCALAR) ? 1U : static_cast<std::uint32_t>(tensor_shape.total_num_faces());
         const std::uint32_t inner    = num_rows >> rows_log2(ELTWISE_MATH_ROWS);
 
         const std::uint32_t dst_lo     = (BROADCAST_TYPE != BroadcastType::COL) ? 1U : 0U;
@@ -135,10 +137,10 @@ inline void _llk_math_eltwise_unary_broadcast_mop_config_(const TileShape& tile_
  * @brief MOP for MOVD2B when unpack wrote to dest (move dest rows back to srcB for MOVB2D).
  *
  * @tparam BROADCAST_TYPE: Scalar, row, or column broadcast, values = <COL/ROW/SCALAR>
- * @param tile_shape: Used for row/col loop counts outside ROW special case
+ * @param tensor_shape: Used for row/col loop counts outside ROW special case
  */
 template <BroadcastType BROADCAST_TYPE>
-inline void _llk_math_eltwise_unary_broadcast_d2b_mop_config_(const TileShape& tile_shape)
+inline void _llk_math_eltwise_unary_broadcast_d2b_mop_config_(const TensorShape& tensor_shape)
 {
     if constexpr (BROADCAST_TYPE == BroadcastType::ROW)
     {
@@ -154,8 +156,9 @@ inline void _llk_math_eltwise_unary_broadcast_d2b_mop_config_(const TileShape& t
     else
     {
         // SCALAR: all faces × rows. COL: column broadcast touches two faces in dest (mirrors unpack UNPACR_DEST_FACE 0 and 2), so row count is 2× face_r_dim.
-        const std::uint32_t rows_sel  = (BROADCAST_TYPE == BroadcastType::SCALAR) ? tile_shape.num_faces * tile_shape.face_r_dim : tile_shape.face_r_dim * 2;
-        const std::uint32_t inner_d2b = (BROADCAST_TYPE == BroadcastType::SCALAR) ? 1U : (rows_sel >> rows_log2(ELTWISE_MATH_ROWS));
+        const std::uint32_t rows_sel =
+            (BROADCAST_TYPE == BroadcastType::SCALAR) ? tensor_shape.total_num_faces() * tensor_shape.face_r_dim : tensor_shape.face_r_dim * 2;
+        const std::uint32_t inner_d2b = (BROADCAST_TYPE == BroadcastType::SCALAR) ? 1U : rows_sel >> rows_log2(ELTWISE_MATH_ROWS);
 
         const auto f = [](std::uint8_t am, std::uint32_t d32) { return TT_OP_MOVD2B(d32, 0, am, p_mov_src_to_dest::MOV_8_ROWS, 0, 0); };
 
@@ -174,18 +177,18 @@ inline void _llk_math_eltwise_unary_broadcast_d2b_mop_config_(const TileShape& t
  * @tparam BROADCAST_TYPE: Scalar, row, or column broadcast, values = <COL/ROW/SCALAR>
  * @tparam unpack_to_dest: UNP path wrote to dest; MOVB2D MOP deferred to per-tile call
  * @tparam is_fp32_dest_acc_en: Same name/position as unpack init for uniform call sites. Must be false when unpack_to_dest is true (static_assert below)
- * @param tile_shape: Passed to addrmod / MOP setup
+ * @param tensor_shape: Passed to addrmod / MOP setup
  * @note On the unpack thread, pair with @ref _llk_unpack_unary_broadcast_operands_init_ (T0) with matching BROADCAST_TYPE/unpack_to_dest.
  * @note @ref _llk_math_eltwise_unary_broadcast_ runs the configured op with matching template args.
  */
 template <BroadcastType BROADCAST_TYPE, bool unpack_to_dest = false, bool is_fp32_dest_acc_en = false>
-inline void _llk_math_eltwise_unary_broadcast_init_(const TileShape& tile_shape)
+inline void _llk_math_eltwise_unary_broadcast_init_(const TensorShape& tensor_shape)
 {
     static_assert(!(unpack_to_dest && is_fp32_dest_acc_en), "Unary broadcast: unpack_to_dest with Float32 dest accumulation is not supported yet");
-    _llk_math_eltwise_unary_broadcast_addrmod_<BROADCAST_TYPE, unpack_to_dest>(tile_shape);
+    _llk_math_eltwise_unary_broadcast_addrmod_<BROADCAST_TYPE, unpack_to_dest>(tensor_shape);
     if constexpr (!unpack_to_dest)
     {
-        _llk_math_eltwise_unary_broadcast_mop_config_<BROADCAST_TYPE, false>(tile_shape);
+        _llk_math_eltwise_unary_broadcast_mop_config_<BROADCAST_TYPE, false>(tensor_shape);
     }
     _reset_counters_<p_setrwc::SET_ABD_F>();
 }
@@ -197,20 +200,21 @@ inline void _llk_math_eltwise_unary_broadcast_init_(const TileShape& tile_shape)
  * @tparam unpack_to_dest: When true, runs D2B then MOVB2D replay for unpack-to-dest workaround
  * @tparam is_fp32_dest_acc_en: Same template args as init; combination unpack_to_dest + true is rejected in init
  * @param tile_idx: Destination tile index within current dest bank (SyncHalf)
- * @param tile_shape: Used when unpack_to_dest (D2B / MOVB2D MOP); otherwise ignored
+ * @param tensor_shape: Used when unpack_to_dest (D2B / MOVB2D MOP); otherwise ignored
  * @note Call @ref _llk_math_eltwise_unary_broadcast_init_ with matching template args before this function.
  */
 template <BroadcastType BROADCAST_TYPE, bool unpack_to_dest = false, bool is_fp32_dest_acc_en = false>
-inline void _llk_math_eltwise_unary_broadcast_(const std::uint32_t tile_idx, [[maybe_unused]] const TileShape& tile_shape)
+inline void _llk_math_eltwise_unary_broadcast_(const std::uint32_t tile_idx, [[maybe_unused]] const TensorShape& tensor_shape)
 {
     _set_dst_write_addr_<DstTileShape::Tile32x32>(tile_idx);
+    //_set_dst_write_addr_by_rows_(find_max(FACE_R_DIM, tensor_shape.face_r_dim * tensor_shape.total_num_faces()), tile_idx);
 
     if constexpr (unpack_to_dest)
     {
-        _llk_math_eltwise_unary_broadcast_d2b_mop_config_<BROADCAST_TYPE>(tile_shape);
+        _llk_math_eltwise_unary_broadcast_d2b_mop_config_<BROADCAST_TYPE>(tensor_shape);
         ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
         _reset_counters_<p_setrwc::SET_ABD_F>();
-        _llk_math_eltwise_unary_broadcast_mop_config_<BROADCAST_TYPE, true>(tile_shape);
+        _llk_math_eltwise_unary_broadcast_mop_config_<BROADCAST_TYPE, true>(tensor_shape);
     }
 
     TTI_STALLWAIT(p_stall::STALL_MATH, 0, p_stall::WAIT_SFPU, p_stall::SRCB_VLD); // TEN-4367 - SrcB sync workaround

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_unary_broadcast.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_unary_broadcast.h
@@ -207,7 +207,6 @@ template <BroadcastType BROADCAST_TYPE, bool unpack_to_dest = false, bool is_fp3
 inline void _llk_math_eltwise_unary_broadcast_(const std::uint32_t tile_idx, [[maybe_unused]] const TensorShape& tensor_shape)
 {
     _set_dst_write_addr_<DstTileShape::Tile32x32>(tile_idx);
-    //_set_dst_write_addr_by_rows_(find_max(FACE_R_DIM, tensor_shape.face_r_dim * tensor_shape.total_num_faces()), tile_idx);
 
     if constexpr (unpack_to_dest)
     {


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
closes https://github.com/tenstorrent/tt-llk/issues/1518

replaces TileShape with TensorShape in unary broadcast, removes TileShape

### Notes for reviewers
TensorShape is added into function signatures, but tiny-tile compatibility is not added. Tiny-tile support seems to require a significant refactor of the quasar unary broadcast kernel, and (I believe) unary broadcast is lower on the priority list for quasar tiny-tile support (compared to kernels such as matmul, reduce)  
In addition, the goal of the issue seemed to be to deprecate TileShape param and replace with TensorShape.

@ndivnicTT @ncvetkovicTT @rtawfik01 please let me know if I am misaligned on the above, I can work on adding tiny-tile support to this kernel if that is the case.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jihoonyou/tileshape-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jihoonyou/tileshape-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jihoonyou/tileshape-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jihoonyou/tileshape-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jihoonyou/tileshape-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jihoonyou/tileshape-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jihoonyou/tileshape-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jihoonyou/tileshape-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jihoonyou/tileshape-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jihoonyou/tileshape-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jihoonyou/tileshape-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jihoonyou/tileshape-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jihoonyou/tileshape-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jihoonyou/tileshape-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jihoonyou/tileshape-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jihoonyou/tileshape-cleanup)