### PR TITLE
Watcher test mode doesn't always exit test

### DIFF
--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -21,6 +21,7 @@
 
 #include "hal.hpp"
 #include "impl/context/metal_context.hpp"
+#include <impl/debug/watcher_server.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include "hal_types.hpp"
 #include "llrt.hpp"
@@ -359,6 +360,19 @@ void wait_until_cores_done(
                 .count();
     }
     while (!not_done_phys_cores.empty()) {
+        // In tests, when rt_options.get_test_mode_enabled() is true, watcher
+        // will stop but will not kill the program. This section detects watcher
+        // stopping and reports a fatal error so Finish() can return and the test process can tear down.
+        if (rtoptions.get_watcher_enabled() && rtoptions.get_test_mode_enabled()) {
+            auto& watcher = *tt::tt_metal::MetalContext::instance().watcher_server();
+            if (watcher.killed_due_to_error() || !watcher.exception_message().empty()) {
+                TT_THROW(
+                    "Device {}: Aborting wait for physical cores to finish due to watcher error: {}",
+                    device_id,
+                    watcher.exception_message());
+            }
+        }
+
         if (timeout_ms > 0) {
             auto now = std::chrono::high_resolution_clock::now();
             auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count();

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -360,7 +360,7 @@ void wait_until_cores_done(
                 .count();
     }
     while (!not_done_phys_cores.empty()) {
-        // In tests, when rt_options.get_test_mode_enabled() is true, watcher
+        // In tests, when rtoptions.get_test_mode_enabled() is true, watcher
         // will stop but will not kill the program. This section detects watcher
         // stopping and reports a fatal error so Finish() can return and the test process can tear down.
         if (rtoptions.get_watcher_enabled() && rtoptions.get_test_mode_enabled()) {


### PR DESCRIPTION
### PR Category
Feature - Test related feature only


### Summary
The main reason to make this change is to enabled running regression tests back-to-back when there is the possibility of watcher errors.

With watcher enabled, but TT_METAL_WATCHER_TEST_MODE disabled, watcher kills the entire process. This is not good for simulation/emulation tests and the "device" isn't shut down due to the way watcher kills the process. Follow on tests will hang and/or the user must go manually kill the emulator process.

When TT_METAL_WATCHER_TEST_MODE is enabled, watcher doesn't kill the process and instead sets a variable to know that it caught an error, but unless a test is specifically waiting for a watcher error it can get stuck with `wait_until_cores_done` spinning forever.

This change causes `wait_until_cores_done` to throw an error if watcher is enabled, watcher test mode is enabled and a watcher error is caught. By doing this, the test fails immediately and does a proper tear-down, stopping the simulator/emulator device as well.

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kstevens/improve_watcher_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kstevens/improve_watcher_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kstevens/improve_watcher_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kstevens/improve_watcher_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kstevens/improve_watcher_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kstevens/improve_watcher_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kstevens/improve_watcher_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kstevens/improve_watcher_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kstevens/improve_watcher_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kstevens/improve_watcher_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kstevens/improve_watcher_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kstevens/improve_watcher_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kstevens/improve_watcher_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kstevens/improve_watcher_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kstevens/improve_watcher_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kstevens/improve_watcher_test)