### PR TITLE
[skip ci] Route regression triage Slack to full CI channel

### DIFF
--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -17,7 +17,7 @@ on:
         type: boolean
         default: false
       slack-channel-id:
-        description: "Slack channel ID for notifications. Leave empty to use repo secret SLACK_METAL_INFRA_CHANNEL_ID."
+        description: "Slack channel ID for notifications. Leave empty to use repo secret FULL_CI_TRIAGE_CHANNEL."
         required: false
       failures-to-elevate:
         description: 'TEST MODE. When set to N>0, discards real regressions and replaces them with N currently-stayed-failing JOBS (not pipelines). Produces exactly N top-level Slack messages, suppresses the "X other pipelines are failing" footer. Empty/0 = normal production behavior.'
@@ -309,7 +309,7 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/slack-report-analyze-workflow-data
         with:
-          channel_id: ${{ github.event.inputs.slack-channel-id || secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
+          channel_id: ${{ github.event.inputs.slack-channel-id || secrets.FULL_CI_TRIAGE_CHANNEL }}
           regressed_workflows_path: ${{ github.workspace }}/regression-notification-inputs/regressed-workflows.json
           alert_all_message_path: ${{ github.workspace }}/regression-notification-inputs/alert-all-message.txt
         env:
@@ -354,7 +354,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           slack_ts: ${{ needs.handle-failures.outputs.slack_ts }}
           slack_ts_map: ${{ needs.handle-failures.outputs.slack_ts_map }}
-          slack_channel_id: ${{ github.event.inputs.slack-channel-id || secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
+          slack_channel_id: ${{ github.event.inputs.slack-channel-id || secrets.FULL_CI_TRIAGE_CHANNEL }}
           slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           send-slack-message: true
           max_dispatches: ${{ github.event.inputs.max-regression-analysis-dispatches || '' }}

--- a/.github/workflows/grouping-ci-failures.yaml
+++ b/.github/workflows/grouping-ci-failures.yaml
@@ -61,7 +61,7 @@ jobs:
           # slack_token: Slack Bot Token for fetching messages
           slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
           # channel_id: Slack channel ID to fetch messages from
-          channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
+          channel_id: ${{ secrets.FULL_CI_TRIAGE_CHANNEL }}
           update_mode: ${{ inputs.update_mode || 'update' }}
           start_date: ${{ inputs.start_date || steps['calc-date'].outputs.start_date }}
           end_date: ${{ inputs.end_date || '' }}

--- a/.github/workflows/regression-analysis.yml
+++ b/.github/workflows/regression-analysis.yml
@@ -60,4 +60,4 @@ jobs:
           cutoff-commit: ${{ inputs.cutoff_commit }}
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          SLACK_CHANNEL_ID: ${{ inputs.slack_channel_id != '' && inputs.slack_channel_id || secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
+          SLACK_CHANNEL_ID: ${{ inputs.slack_channel_id != '' && inputs.slack_channel_id || secrets.FULL_CI_TRIAGE_CHANNEL }}


### PR DESCRIPTION
## Summary
- Routes aggregate workflow Slack notifications to `FULL_CI_TRIAGE_CHANNEL` by default while preserving the existing threading and job ownership flow.
- Routes standalone regression-analysis Slack output to `FULL_CI_TRIAGE_CHANNEL` when no explicit channel is provided.
- Routes the CI failure grouping workflow to ingest messages from `FULL_CI_TRIAGE_CHANNEL`, matching the new regression-analysis notification home.

## Rationale
This PR is a prelude to switching CI triage toward the automatic ticketing system. To lower notification spam, the main `#metal-infra-pipeline-status` channel will be reserved for notifications about tickets created for jobs that repeatedly fail with the exact same error.

The new home for regression-analysis notifications is `#full-ci-triage`. Developers can opt into that channel if they still want to follow the regression-analysis stream, but it is no longer intended to be the highest-priority triage surface. The ticketing system will link to regression-analysis reports when available and include links back to the Slack notifications as well.

Going forward, the focus should be on addressing tickets for consistently failing CI issues, rather than immediately reacting to each regression-analysis ping. The current ping-driven workflow has not been especially effective because of notification fatigue.

The automatic ticketing system creates disabling PRs after a week of a job failing in the exact same way, closes tickets when they are no longer relevant, consistently refreshes job links in tickets, and pings developers from the ticket context. That should make tickets a more effective way to get CI triaged in a timely manner.

Developers who still want the old regression-analysis notification stream can join `#full-ci-triage`.

The auto-ticketing system is an n8n workflow and is outside the scope of this PR.

## Test plan
- Parsed `.github/workflows/aggregate-workflow-data.yaml`, `.github/workflows/regression-analysis.yml`, and `.github/workflows/grouping-ci-failures.yaml` with Ruby YAML parser.
- Checked Cursor diagnostics for the edited workflow files.
- Reviewed the scoped git diff to confirm only Slack channel routing changed.