### PR TITLE
[tt_dit] Use ttnn.lerp instead of the explicit form

### DIFF
--- a/models/tt_dit/pipelines/cfg.py
+++ b/models/tt_dit/pipelines/cfg.py
@@ -63,7 +63,7 @@ class _SingleCombiner:
         split_pos = n // 2
         uncond = prediction[0:split_pos]
         cond = prediction[split_pos:]
-        combined = uncond + cfg_scale * (cond - uncond)
+        combined = ttnn.lerp(uncond, cond, cfg_scale)
 
         return (combined,)
 
@@ -89,8 +89,8 @@ class _HostCombiner:
         received_uncond = received_uncond.to(self._cond_device)
         received_cond = received_cond.to(self._uncond_device)
 
-        combined0 = uncond + cfg_scale * (received_cond - uncond)
-        combined1 = received_uncond + cfg_scale * (cond - received_uncond)
+        combined0 = ttnn.lerp(uncond, received_cond, cfg_scale)
+        combined1 = ttnn.lerp(received_uncond, cond, cfg_scale)
 
         return combined0, combined1
 
@@ -123,8 +123,8 @@ class _SocketCombiner:
         ttnn.experimental.recv_async(received_uncond, self._sockets[0].rx)
         ttnn.experimental.send_async(cond, self._sockets[1].tx)
 
-        combined0 = uncond + cfg_scale * (received_cond - uncond)
-        combined1 = received_uncond + cfg_scale * (cond - received_uncond)
+        combined0 = ttnn.lerp(uncond, received_cond, cfg_scale)
+        combined1 = ttnn.lerp(received_uncond, cond, cfg_scale)
 
         return combined0, combined1
 


### PR DESCRIPTION
### PR Category

Accuracy improvement

### Summary

This PR replaces the explicit CFG formula in the tt_dit CFG combiner by `ttnn.lerp`.

Not only is `ttnn.lerp` numerically more accurate, it also matches PyTorch bfloat16 calculation better than the explicit formula, as the two tests below show.

`test_lerp_uses_f32` shows that `ttnn.lerp` is equivalent to the explicit formula, when the inputs to the explicit formula are cast to float32 and the result is cast back to bfloat16.

Also, `test_lerp_better_match` shows that `ttnn.lerp` is a better match to CFG calculation in PyTorch using bfloat16 than the explicit formula using bfloat16.

Closes #47080.

```python
import pytest
import torch

import ttnn


@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
@pytest.mark.parametrize("cfg_scale", [2.0, 7.00])
@pytest.mark.parametrize(("m", "n"), [(512, 512)])
def test_lerp_uses_f32(*, mesh_device: ttnn.MeshDevice, cfg_scale: float, m: int, n: int) -> None:
    torch.manual_seed(0)

    # create input tensors

    torch_uncond = torch.randn([m, n])
    torch_cond = torch_uncond + 0.1 * torch.randn([m, n])

    torch_uncond_bf16 = torch_uncond.to(torch.bfloat16)
    torch_cond_bf16 = torch_cond.to(torch.bfloat16)

    tt_uncond = ttnn.from_torch(torch_uncond_bf16, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=mesh_device)
    tt_cond = ttnn.from_torch(torch_cond_bf16, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=mesh_device)

    # torch

    torch_result_via_f32 = (
        torch_uncond_bf16.float() + cfg_scale * (torch_cond_bf16.float() - torch_uncond_bf16.float())
    ).to(torch.bfloat16)

    # ttnn

    tt_result_lerp = ttnn.lerp(tt_uncond, tt_cond, cfg_scale)

    # check

    tt_result_lerp_torch = ttnn.to_torch(tt_result_lerp).float()

    assert tt_result_lerp_torch.eq(torch_result_via_f32).all()


@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
@pytest.mark.parametrize("cfg_scale", [2.0, 7.0])
@pytest.mark.parametrize(("m", "n"), [(512, 512)])
def test_lerp_better_match(*, mesh_device: ttnn.MeshDevice, cfg_scale: float, m: int, n: int) -> None:
    torch.manual_seed(0)

    # create input tensors

    torch_uncond = torch.randn([m, n])
    torch_cond = torch_uncond + 0.1 * torch.randn([m, n])

    torch_uncond_bf16 = torch_uncond.to(torch.bfloat16)
    torch_cond_bf16 = torch_cond.to(torch.bfloat16)

    tt_uncond = ttnn.from_torch(torch_uncond_bf16, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=mesh_device)
    tt_cond = ttnn.from_torch(torch_cond_bf16, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=mesh_device)

    # torch

    torch_result_via_bf16 = (torch_uncond_bf16 + cfg_scale * (torch_cond_bf16 - torch_uncond_bf16)).float()

    # ttnn

    tt_result_explicit = tt_uncond + cfg_scale * (tt_cond - tt_uncond)
    tt_result_lerp = ttnn.lerp(tt_uncond, tt_cond, cfg_scale)

    # check

    tt_result_explicit_torch = ttnn.to_torch(tt_result_explicit).float()
    tt_result_lerp_torch = ttnn.to_torch(tt_result_lerp).float()

    err_explicit = torch.nn.functional.mse_loss(tt_result_explicit_torch, torch_result_via_bf16).sqrt().item()
    err_lerp = torch.nn.functional.mse_loss(tt_result_lerp_torch, torch_result_via_bf16).sqrt().item()

    assert err_lerp < err_explicit
```

### CI Issues

- T3K failures are unrelated to tt_dit
- Galaxy has runner issues

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=friedrich/cfg-lerp)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:friedrich/cfg-lerp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=friedrich/cfg-lerp)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:friedrich/cfg-lerp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=friedrich/cfg-lerp)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:friedrich/cfg-lerp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=friedrich/cfg-lerp)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:friedrich/cfg-lerp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=friedrich/cfg-lerp)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:friedrich/cfg-lerp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=friedrich/cfg-lerp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:friedrich/cfg-lerp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=friedrich/cfg-lerp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:friedrich/cfg-lerp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=friedrich/cfg-lerp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:friedrich/cfg-lerp)