### PR TITLE
[diag] Minimal UMD device bring-up probe + isolation tooling (issue #47866 repro)

### DIFF
--- a/tools/scaleout/CMakeLists.txt
+++ b/tools/scaleout/CMakeLists.txt
@@ -178,6 +178,18 @@ target_link_libraries(
         cxxopts::cxxopts
 )
 
+# Minimal UMD-level device bring-up probe (issue #47866 repro). Pure UMD: just Cluster + start_device.
+add_executable(umd_start_device_probe src/umd_start_device_probe.cpp)
+
+set_target_properties(
+    umd_start_device_probe
+    PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY
+            ${Metalium_BINARY_DIR}/tools/scaleout
+)
+
+target_link_libraries(umd_start_device_probe PRIVATE umd::tt-umd)
+
 # Generate MGD library
 add_library(generate_mgd_lib OBJECT generate_mgd/generate_mgd.cpp)
 

--- a/tools/scaleout/c04u14_chip26_start_device_hang.md
+++ b/tools/scaleout/c04u14_chip26_start_device_hang.md
@@ -1,0 +1,119 @@
+# Device bring-up hang on `bh-glx-120-c04u14` — logical chip 26 stuck in `Cluster::start_device()`
+
+**Status:** Root-caused to a single ASIC. Reproduces in isolation on one host → hardware/firmware fault, not a fabric/MGD/test problem.
+
+**Date:** 2026-06-23
+**Cluster:** SC36 / 120c Blackhole galaxy (revAB, Aisle C), hosts `bh-glx-120-c0*`
+**Failing host:** `bh-glx-120-c04u14` (MPI rank 6 in the 12-host run)
+**Failing device:** **logical/UMD chip id 26** (PCIe enumeration id **18**; tt-smi "UMD Chip ID" 26 → PCI BDF `0000:c3:…` — confirm against the tt-smi snapshot)
+
+---
+
+## TL;DR
+
+`bh-glx-120-c04u14` has one ASIC (**logical chip 26**) whose ARC/firmware does **not complete device bring-up**. The chip is PCIe-enumerable (tt-smi lists all 32 chips) and topology discovery sees it, but UMD `Cluster::start_device()` **hangs indefinitely** on `get_chip(26)->start_device(...)`. There is no timeout on that path, so:
+
+- **Single host:** the process hangs after `[PSD-DEBUG] start_device: bringing up chip 26` (chips 0–25 came up in ~1 ms each).
+- **Multi-host (12 hosts):** rank 6 (`c04u14`) hangs in `start_device` **before** reaching Physical System Descriptor (PSD) discovery; the other 11 ranks finish device init, reach the PSD discovery entry `barrier()`, and **block forever** waiting for rank 6 → the launcher eventually kills the whole job.
+
+Mock-cluster-descriptor runs pass because they never open real silicon (no `start_device`).
+
+---
+
+## Symptom (production, multi-host)
+
+Running PSD discovery across the 12 SC36 hosts:
+
+```
+TT_METAL_SLOW_DISPATCH_MODE=1 tt-run --tcp-interface ens5f0np0 --hosts $HOSTS \
+  --mesh-graph-descriptor models/demos/deepseek_v3_b1/scaleout_configs/blitz_decode_single_pod_mesh_graph_descriptor.textproto true
+```
+
+hangs and is killed. With the `[PSD-DEBUG]` instrumentation, **11 of 12 ranks** log:
+
+```
+[PSD-DEBUG] rank N host '…': entering PSD discovery, waiting on entry barrier (all 12 ranks must reach it) ...
+```
+
+The only rank that never reaches it is **rank 6 = `bh-glx-120-c04u14`**. Its UMD log shows it ~1 s behind every peer and ending at:
+
+```
+UMD | Starting devices in cluster (cluster.cpp:1236)
+```
+
+with **no** `Starting devices in cluster completed.` — i.e. stuck inside the per-chip `start_device` loop, before PSD discovery even begins.
+
+## Isolation + pinpoint (single host) — the smoking gun
+
+`tools/scaleout/isolate_host_device_init.sh` run on `c04u14` (single rank, `single_bh_galaxy` MGD):
+
+1. **tt-smi:** all 32 chips (UMD Chip ID 0–31) enumerate and are listed as resettable. No PCIe/enumeration error. → the chip is *visible*, the fault is in *bring-up*.
+2. **Device bring-up** (`Cluster::start_device`, per-chip `[PSD-DEBUG]` logging):
+
+```
+[PSD-DEBUG] start_device: bringing up chip 0  ... chip 0 brought up OK
+...                                            (chips 0–25 each OK, ~1 ms apart)
+[PSD-DEBUG] start_device: bringing up chip 25 ... chip 25 brought up OK
+[PSD-DEBUG] start_device: bringing up chip 26   ←  LAST LINE. No "chip 26 brought up OK". Hang.
+```
+
+Chips 0–25 complete in ~13 ms total; **chip 26 never returns** from `get_chip(26)->start_device(...)`. This reproduces standalone on `c04u14`, confirming it is a property of that ASIC, not of the multi-host run.
+
+## Chip identification
+
+From `Opening local chip ids/PCIe ids: {0..31}/[0..15,24,25,26,27,28,29,30,31,16,17,18,19,20,21,22,23]`:
+
+| logical chip | 24 | 25 | **26** | 27 |
+|---|---|---|---|---|
+| PCIe id | 16 | 17 | **18** | 19 |
+
+So **logical chip 26 → PCIe id 18**. Cross-reference tt-smi (UMD Chip ID 26 → PCI BDF `0000:c3:…`) in the saved snapshot for the physical board/tray slot.
+
+---
+
+## Root cause
+
+`get_chip(26)->start_device()` performs the ASIC's ARC/firmware bring-up (deassert resets, ARC handshake, power-state setup). Logical chip 26 on `c04u14` accepts PCIe enumeration but its ARC does not complete this handshake, so the call blocks with no timeout.
+
+This is **not**:
+- a fabric / MGD / ethernet-link issue (the hang is before any fabric/ethernet code),
+- a cross-host issue (each host opens only its own local chips; `remote chip ids {}`),
+- a test/CI logic problem (mock passes precisely because it never starts silicon).
+
+It **is** a per-ASIC bring-up fault on one chip of one host. The earlier `Waiting for AICLK value to settle … possible overheating … AICLK clamped` warnings on several chips suggest marginal power/clock bring-up on this system generally; chip 26 is the one that crosses from "slow" into "stuck."
+
+## Why the whole 12-host job dies
+
+`run_physical_system_discovery()` opens with `distributed_context->barrier()`. The UMD cluster (and `start_device`) runs during `MetalContext`/cluster construction **before** that barrier. So rank 6 never arrives at the barrier; ranks 0–5 and 7–11 block in it indefinitely. The collective has no timeout, so the run only ends when the MPI launcher / tt-run watchdog tears it down.
+
+---
+
+## Remediation
+
+1. **Reset and retry** on `c04u14`:
+   - `tt-smi -r <board>` (board-level) or galaxy reset (`tt-smi -glx_reset`), then re-run `isolate_host_device_init.sh`.
+   - If chip 26 then brings up `OK`, the fault was a recoverable wedged ARC state.
+2. **If it persists after reset:** hardware/firmware fault on that ASIC — flag the board (board number `00000471…`, BDF `0000:c3:…`) for service; check chip 26 temperature/power rails and firmware (`19.11.0`, newer than the tested `19.5.0`).
+3. **Workaround to keep testing meanwhile:** exclude `c04u14` from `$HOSTS` (use a different 12-host set) — the rest pass discovery.
+
+## How to reproduce / verify
+
+```bash
+ssh bh-glx-120-c04u14
+source /data/rsong/tt-blaze-5/env.sh
+bash tools/scaleout/isolate_host_device_init.sh ens5f0np0
+# Expect: hang after "[PSD-DEBUG] start_device: bringing up chip 26"
+# Healthy host (e.g. c01u02) completes all 32 chips with "brought up OK".
+```
+
+> Caveat: if a future run of the script completes all 32 chips (paste was merely truncated / the ARC self-recovered), then `c04u14` is currently healthy in isolation and the production hang was transient — rerun a few times to confirm chip 26 reproducibly hangs before condemning the board.
+
+---
+
+## Appendix — diagnostic instrumentation added (temporary, tag `[PSD-DEBUG]`)
+
+- `tt_metal/third_party/umd/device/cluster.cpp` — `Cluster::start_device()`: per-chip "bringing up chip N" / "chip N brought up OK" logging (pinpoints the stuck chip).
+- `tt_metal/fabric/physical_system_discovery.cpp` — `run_physical_system_discovery` / `exchange_metadata` / `resolve_hostname_uniqueness`: per-stage + per-peer logging (pinpoints the stuck rank/host in the multi-host gather).
+- `tools/scaleout/isolate_host_device_init.sh` — single-host tt-smi + device-bring-up reproduction.
+
+All `[PSD-DEBUG]` logging is temporary and should be removed once the hardware issue is resolved.

--- a/tools/scaleout/isolate_host_device_init.sh
+++ b/tools/scaleout/isolate_host_device_init.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Single-host isolation + pinpoint for the PSD-discovery device bring-up hang.
+#
+# Background: in a multi-host run, one host (e.g. bh-glx-120-c04u14 / rank 6) hangs in UMD
+# Cluster::start_device ("Starting devices in cluster", cluster.cpp) BEFORE PSD discovery, so
+# every other rank blocks at the discovery entry barrier and the job is killed. This script
+# reproduces that bring-up on a SINGLE host and names the exact chip that hangs.
+#
+# Usage (run ON the suspect host, with env.sh sourced so tt-run / tt-smi / TT_METAL_HOME are set):
+#     source /data/rsong/tt-blaze-5/env.sh
+#     bash tools/scaleout/isolate_host_device_init.sh [tcp_interface]
+#
+# Requires the build with the [PSD-DEBUG] per-chip start_device logging (UMD cluster.cpp).
+
+set +e
+HOST=$(hostname)
+IFACE="${1:-ens5f0np0}"
+TS=$(date +%H%M%S)
+SMI_LOG="/tmp/isolate_${HOST}_ttsmi_${TS}.log"
+INIT_LOG="/tmp/isolate_${HOST}_devinit_${TS}.log"
+MGD="tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_mesh_graph_descriptor.textproto"
+
+echo "================ single-host isolation on ${HOST} (iface=${IFACE}) ================"
+
+echo
+echo "----- [1] tt-smi health snapshot (per-chip: temp / AICLK / ARC / link / fw) -----"
+echo "    A chip whose ARC is wedged will show up here as unreadable / error, or tt-smi itself will stall."
+timeout 120 tt-smi -ls 2>&1 | tail -40   # non-interactive board list (no TUI)
+timeout 120 tt-smi -s --snapshot_no_tty -f "${SMI_LOG}" >/dev/null 2>&1
+echo "    (snapshot -> ${SMI_LOG}; rc=$? -- non-zero/timeout here itself implicates a wedged chip)"
+
+echo
+echo "----- [2] single-host device bring-up (reproduces Cluster::start_device) -----"
+echo "    Watch the [PSD-DEBUG] 'bringing up chip N' lines: the LAST one with no matching"
+echo "    'chip N brought up OK' is the chip whose start_device() hung."
+echo "    (map logical chip N -> PCIe id via the 'Opening local chip ids/PCIe ids' line.)"
+: "${TT_METAL_HOME:?source env.sh first}"
+cd "${TT_METAL_HOME}" || exit 2
+
+TT_METAL_LOGGER_TYPES=UMD,Fabric TT_METAL_LOGGER_LEVEL=debug TT_METAL_SLOW_DISPATCH_MODE=1 \
+    timeout 240 tt-run \
+      --tcp-interface "${IFACE}" \
+      --hosts "${HOST}" \
+      --force-rediscovery \
+      --mesh-graph-descriptor "${MGD}" \
+      true 2>&1 | tee "${INIT_LOG}" \
+    | grep -aE "PSD-DEBUG|Starting devices in cluster|brought up|Opening local chip|AICLK|[Ee]rror|Completed topology|Cluster constructor"
+rc=${PIPESTATUS[0]}
+
+echo
+echo "================ RESULT ================"
+if [ "${rc}" = "124" ]; then
+    echo "TIMED OUT (240s) -> device bring-up hung on ${HOST}. Stuck chip = last '[PSD-DEBUG] bringing up chip N' below:"
+    grep -aE "\[PSD-DEBUG\] start_device: (bringing up|.* brought up OK)" "${INIT_LOG}" | tail -4
+else
+    echo "completed rc=${rc} (no hang on ${HOST} this run)."
+fi
+echo "Full device-init log: ${INIT_LOG}"
+echo "tt-smi snapshot:      ${SMI_LOG}"

--- a/tools/scaleout/src/umd_start_device_probe.cpp
+++ b/tools/scaleout/src/umd_start_device_probe.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Minimal UMD-level reproduction for the device bring-up hang (issue #47866).
+//
+// Opens all local chips on THIS host and brings them up via tt::umd::Cluster::start_device().
+// No MPI, no mesh-graph-descriptor, no tt-run, no tt-metal MetalContext — just the pure UMD
+// device bring-up path that hangs in the multi-host run.
+//
+// On a healthy host this prints "all chips brought up OK" and exits 0. On a host with a wedged
+// ASIC it hangs inside start_device; with the temporary [PSD-DEBUG] per-chip logging in UMD
+// (device/cluster.cpp + device/chip/local_chip.cpp) the last "bringing up chip N" / "step k/4"
+// line names the exact chip and sub-step that hung.
+//
+// Build:  cmake --build build --target umd_start_device_probe
+// Run:    TT_METAL_LOGGER_TYPES=UMD TT_METAL_LOGGER_LEVEL=debug ./build/tools/scaleout/umd_start_device_probe
+
+#include <cstdio>
+
+#include <umd/device/cluster.hpp>
+
+int main() {
+    using namespace tt::umd;
+
+    std::printf("[umd_start_device_probe] constructing Cluster (enumerating local chips) ...\n");
+    std::fflush(stdout);
+    Cluster cluster;
+
+    std::printf("[umd_start_device_probe] start_device({.init_device = true}) — bringing up all local chips ...\n");
+    std::fflush(stdout);
+    cluster.start_device({.init_device = true});
+
+    std::printf("[umd_start_device_probe] all chips brought up OK; closing.\n");
+    std::fflush(stdout);
+    cluster.close_device();
+    return 0;
+}


### PR DESCRIPTION
## What

Minimal UMD-level reproduction + isolation tooling for the SC36 multi-host PSD-discovery hang (**#47866**), where one host wedges in UMD `Cluster::start_device` and blocks the whole 12-host job at the discovery entry barrier. Root-caused to **`bh-glx-120-c04u14`, logical chip 26**.

- **`tools/scaleout/src/umd_start_device_probe.cpp`** — a tiny pure-UMD probe (`Cluster` + `start_device`, all local chips; no MPI / no mesh-graph-descriptor / no tt-run / no MetalContext). This is the smallest thing that exercises the exact bring-up path that hangs.
- `tools/scaleout/isolate_host_device_init.sh` — single-host `tt-smi` + bring-up wrapper.
- `tools/scaleout/c04u14_chip26_start_device_hang.md` — root-cause write-up.

## Reproduction — small UMD test

```bash
source /data/rsong/tt-blaze-5/env.sh
cmake -B build -DTT_METAL_BUILD_TESTS=ON
cmake --build build --target umd_start_device_probe -j"$(nproc)"

# Run ON the suspect host (single host, no MPI/MGD/tt-run):
TT_METAL_LOGGER_TYPES=UMD TT_METAL_LOGGER_LEVEL=debug \
  ./build/tools/scaleout/umd_start_device_probe
```

**Expected:**
- **Healthy host** → `constructing Cluster …` → `start_device(...) — bringing up all local chips …` → `all chips brought up OK; closing.` exit 0.
- **Bad host (`c04u14`)** → constructs the cluster fine, then **hangs in `start_device`** with no `all chips brought up OK`.

To name the exact chip/sub-step, build with the temporary `[PSD-DEBUG]` per-chip logging in UMD (`device/cluster.cpp` start_device loop + `device/chip/local_chip.cpp` per-step) — then the last `[PSD-DEBUG] start_device: bringing up chip N` / `start_device step k/4` line is the culprit (chip 26 on c04u14). That logging lives in the `umd` submodule and is intentionally **not** in this PR (temporary diagnostics; documented in the write-up).

## Notes
- The probe links only `umd::tt-umd`; it does not pull in tt-metal/MetalContext, so it isolates the fault to the UMD device-bring-up layer.
- See tenstorrent/tt-umd#2907 for the full root cause, the multi-host symptom, and remediation (board/galaxy reset; service the ASIC if it persists).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rsong/umd-start-device-probe)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rsong/umd-start-device-probe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rsong/umd-start-device-probe)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rsong/umd-start-device-probe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rsong/umd-start-device-probe)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rsong/umd-start-device-probe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rsong/umd-start-device-probe)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rsong/umd-start-device-probe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rsong/umd-start-device-probe)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rsong/umd-start-device-probe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rsong/umd-start-device-probe)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rsong/umd-start-device-probe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rsong/umd-start-device-probe)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rsong/umd-start-device-probe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rsong/umd-start-device-probe)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rsong/umd-start-device-probe)