### PR TITLE
[Metal 2.0] Migration guides + porting recipes

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/metal2_migration_guide.md
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/metal2_migration_guide.md
@@ -1,0 +1,1226 @@
+# Metal 2.0 Migration Guide (WH/BH)
+
+This guide helps developers migrate from the legacy `ProgramDescriptor` / `host_api.hpp` APIs to the new  Metal 2.0 host APIs in `tt_metal/api/tt-metalium/experimental/metal2_host_api/`.
+
+The focus of this guide is **Wormhole** and **Blackhole** (Gen1 architectures).
+
+Things to remember:
+ - The Metal 2.0 APIs are experimental and subject to changes.
+ - Metal 2.0 is a work in progress; not all legacy API features fully implemented.
+ - Not all planned improvements are available yet.
+
+> **Prerequisite**: Before attempting Metal 2.0 migration, complete the [Device 2.0 Data Movement migration](../../kernel_apis/data_movement/device_api_migration_guide.md). All kernel code migration examples in this guide assume Device 2.0 migration is already done.
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Concept Map](#concept-map)
+3. [Header Files](#header-files)
+4. [Host API Migration](#host-api-migration)
+   - [ProgramSpec](#programspec)
+   - [KernelSpec](#kernelspec)
+   - [DataflowBufferSpec](#dataflowbufferspec)
+   - [SemaphoreSpec](#semaphorespec)
+   - [TensorParameter](#tensorparameter)
+   - [WorkUnitSpec](#workunitspec)
+   - [ProgramRunArgs](#programrunargs)
+5. [Device-Side Migration](#device-side-migration)
+   - [Circular Buffers → Dataflow Buffers](#circular-buffers--dataflow-buffers)
+   - [TensorAccessor](#tensoraccessor)
+   - [Kernel Argument Retrieval Syntax](#kernel-argument-retrieval-syntax)
+6. [Design Principles](#design-principles)
+   - [Principle 1: Immutable spec, mutable run-args](#principle-1-immutable-spec-mutable-run-args)
+   - [Principle 2: First-class named resource bindings](#principle-2-first-class-named-resource-bindings)
+   - [Principle 3: Named arguments throughout](#principle-3-named-arguments-throughout)
+7. [TTNN Framework Integration](#ttnn-framework-integration)
+8. [Complete Migration Examples](#complete-migration-examples)
+9. [Troubleshooting](#troubleshooting)
+   - [Cryptic error → likely cause](#cryptic-error--likely-cause)
+
+---
+
+## Overview
+
+Metal 2.0 introduces a new family of host APIs for Program specification. Metal 2.0 is designed to:
+ - Enable **Quasar** (which the legacy APIs do not — and will not — support)
+ - Address longstanding user pain points in the legacy APIs
+
+Key Metal 2.0 changes, at a glance:
+ - *Immutable and mutable descriptors*. Like `ProgramDescriptor`, Metal 2.0 is a descriptor-based API. But, it separates the mutable properties of a Program (`ProgramSpec`) from those properties that are updated for each execution (`ProgramRunArgs`).
+ - *Dataflow Buffers (DFBs)* replace Circular Buffers (CBs). Both host and device-side syntax is improved.
+ - *Kernel arguments* specification (host side) and retrieval (device side) are signficantly improved. (_Note_: Only the first of several improvements is currently available in Metal 2.0; expect further changes to this part of the API.)
+ - *Resource placement* (i.e. `core_ranges`) is inferred where possible to make the API more AI-friendly and more intuitive with Quasar's multi-threaded kernels. The mapping of kernels to worker nodes in the device is communicated via a new top-level concept (`WorkUnitSpec`).
+- *Quasar-specific features* like kernel threading.
+
+Some benefits of Metal 2.0:
+
+- **Named resource bindings**. Metal 2.0 natively supports binding resources (DFBs, semaphores, tensors, etc) to kernels. The corresponding handles are cleanly passed to the device code with user-defined accessor names.
+- **Named arguments**. Compile-time, runtime, and common runtime arguments are addressed by name on both the host and device sides. Positional CTAs are gone from the API entirely; positional RTAs/CRTAs survive only as **varargs**, intended for the rare kernels that read a dynamic-count argument tail in a loop (e.g. shape of an N-D tensor where N is a CTA). For everything else, prefer names.
+
+> **Stated goal: eliminate raw pointer arguments.** With DFBs, semaphores, and tensors all bindable as named resources, runtime args carrying a buffer or tensor address should now be the exception rather than the rule. If you're about to put `tensor.buffer()->address()` in a runtime arg, you're probably doing it wrong — bind the tensor as a `TensorParameter` instead.
+
+> **Argument naming.** Metal 2.0 is designed around named arguments. Compile-time arguments must be named — positional CTAs are no longer part of the API. Runtime and common runtime arguments may be named (the typical case) or positional (varargs, intended for kernels with a genuinely dynamic argument count consumed in a loop — e.g., an N-dimensional shape where N is a CTA). When porting from a legacy kernel, individually-known RTAs translate naturally to named RTAs; reach for varargs only when the kernel actually loops over the arguments.
+
+Many additional improvements are planned, but are not yet available in the experimental APIs.
+
+---
+
+## Concept Map
+
+| ProgramDescriptor (legacy) | Metal 2.0 |
+|---|---|
+| `ProgramDescriptor` | `ProgramSpec` (immutable description) + `ProgramRunArgs` (per-execution values) |
+| `KernelDescriptor` | `KernelSpec` |
+| `KernelDescriptor::core_ranges` | derived from `WorkUnitSpec::target_nodes` |
+| `KernelDescriptor::compile_time_args` (positional)<br>`KernelDescriptor::named_compile_time_args` (named — partial legacy support) | `KernelSpec::compile_time_args` (named *only*) |
+| `KernelDescriptor::runtime_args` / `common_runtime_args` | **Schema** (names): declared on `KernelSpec::runtime_arg_schema`<br>**Values**: supplied per execution on `ProgramRunArgs::KernelRunArgs` |
+| `CBDescriptor` | `DataflowBufferSpec` (placement derived from kernel bindings) |
+| `SemaphoreDescriptor` | `SemaphoreSpec` |
+| `TensorAccessorArgs<...>` <br> (plumbing + buffer-address RTA) | `TensorAccessor(ta::name)` in the kernel code; <br>`TensorParameter` on `ProgramSpec` (parallel to DFB / Semaphore) |
+| *(no analogue)* | `WorkUnitSpec` — declares groups of kernels that operate together on a worker node, and on which nodes they run |
+| `CoreCoord` / `CoreRange` / `CoreRangeSet`  | `NodeCoord` / `NodeRange` / `NodeRangeSet` |
+
+> **Terminology Note**: Metal 2.0 renames "core" to "node" to disambiguate a previously overloaded term. The legacy "core" was used for both individual RISC-V cores within a node *and* for the larger hardware unit at a given (x,y) NoC address. In Metal 2.0, "node" means the latter.
+
+---
+
+## Header Files
+
+```cpp
+#include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+```
+
+Sub-headers are pulled in transitively:
+ - `kernel_spec.hpp`
+ - `dataflow_buffer_spec.hpp`
+ - `semaphore_spec.hpp`
+ - `tensor_parameter.hpp`
+
+**These header files are self-documenting, with extensive comments.** Please read them!
+
+All Metal 2.0 host API symbols currently live in the `tt::tt_metal::experimental` namespace.
+
+> **Note:** The Program-creation entry points in `metal2_host_api/program.hpp` are *temporary*. Migration to the final form will take place when the APIs leave `experimental` to join the main API directory. User code updates will be trivial.
+
+---
+
+## Host API Migration
+
+> **Type system heads-up (before the per-spec sections below).** Two API-wide conventions to keep in mind as you read the examples:
+>
+> - **Spec names are `ttsl::StrongType`-wrapped, not bare strings.** Each spec category has its own name type — `KernelSpecName`, `DFBSpecName`, `SemaphoreSpecName`, `TensorParamName` (all wrapping `std::string`). Strong types forbid implicit conversion from `std::string` or `const char*`, so `.unique_id = "reader"` does not compile; the literal must be explicitly wrapped: `.unique_id = KernelSpecName{"reader"}`. The doc examples use a typed-constants pattern — declare each name once as a typed `const`, then reference the constant at each use site:
+>     ```cpp
+>     const KernelSpecName  READER{"reader"};
+>     const DFBSpecName     MY_DFB{"my_dfb"};
+>     const SemaphoreSpecName DONE{"done"};
+>     const TensorParamName INPUT{"input"};
+>     ```
+>   (`ProgramSpec::name` and `WorkUnitSpec::name` are *not* strong-typed — they're plain `std::string` debug/messaging labels with no uniqueness invariant. Don't wrap those.)
+>
+> - **Collection types: `Group<T>` and `Table<K, V>`.** Metal 2.0's API uses two utility types to disambiguate intent:
+>   - **`Group<T>`** — an unordered collection of `T` ("a bunch of these," order not semantic). Currently a thin alias for `std::vector<T>`; you can construct with brace-init `{a, b, c}` exactly like a vector.
+>   - **`Table<K, V>`** — a key-value map with the syntax of `std::unordered_map` and hash-friendly storage. Brace-init with `{{key, value}, {key, value}, ...}` works as expected.
+>
+>   These appear pervasively in the spec headers (`ProgramSpec::kernels` is `Group<KernelSpec>`, `ProgramRunArgs::tensor_args` is `Table<TensorParamName, TensorArgument>`, etc.). For initializer-list construction you rarely need to type them; for explicit-type sites (e.g., a conditional ternary that needs a common type), use the `Group<T>` / `Table<K, V>` name directly rather than `std::vector` / `std::unordered_map`.
+
+### ProgramSpec
+
+`ProgramSpec` is the top-level descriptor, replacing `ProgramDescriptor`. It describes the immutable properties of a Program, analogous to a function's signature and body.
+
+A `Program` is built once from its `ProgramSpec`, then executed many times by supplying fresh `ProgramRunArgs` per execution.
+
+**Legacy:**
+
+```cpp
+ProgramDescriptor desc = {
+    .kernels = {kernel_desc_1, kernel_desc_2},
+    .semaphores = {sem_desc},
+    .cbs = {cb_desc_1, cb_desc_2},
+};
+Program program = Program(desc);
+```
+
+**Metal 2.0:**
+
+```cpp
+ProgramSpec spec{
+    .name = "my_program",
+    .kernels = {kernel_1, kernel_2},
+    .dataflow_buffers = {dfb_1, dfb_2},
+    .semaphores = {sem_1},
+    .work_units = {main_work_unit},
+};
+Program program = MakeProgramFromSpec(*mesh_device, spec);  // temporary free function
+//Program program = Program(spec);            // stable API form
+```
+
+Two structural additions vs. `ProgramDescriptor`:
+
+- `name` — a human-readable label for debug and messaging (plain `std::string`; no uniqueness invariant).
+- `work_units` — the new top-level concept that declares where kernels run. (See [WorkUnitSpec](#workunitspec).)
+
+---
+
+### KernelSpec
+
+`KernelSpec` replaces `KernelDescriptor`. Notes:
+
+1. **Placement.** The kernel's effective node set is derived from the `WorkUnitSpec`(s) that include it.
+2. **Runtime arguments.** The `KernelSpec` declares a runtime arguments _schema_; runtime-arg _values_ are supplied per execution through `ProgramRunArgs` or `ProgramRunArgsView`.
+3. **Resource bindings.** New syntax to bind DFB endpoints, semaphores, and tensors to the kernel, and retrieve them by name in device code. (See [TensorParameter](#tensorparameter) for the tensor case.)
+4. **Multiple `KernelSpec`s per source.** A single kernel source file may be represented by multiple `KernelSpec`s if structural specialization is needed (different CTA bindings, different DFB or semaphore bindings, etc.). Each `KernelSpec` is compiled and placed independently.
+
+
+**Legacy** (`KernelDescriptor`):
+
+```cpp
+KernelDescriptor reader = {
+    .kernel_source = "kernels/reader.cpp",
+    .core_ranges = CoreRangeSet{CoreRange{{0,0}, {0,0}}},
+    .compile_time_args = {src_cb_idx, dst_cb_idx, page_size},
+    .runtime_args = {{{0,0}, {start_page, num_pages}}},
+    .config = DataMovementConfigDescriptor{
+        .processor = DataMovementProcessor::RISCV_0,
+        .noc = NOC::RISCV_0_default,
+    },
+};
+```
+
+**Metal 2.0** (`KernelSpec`):
+
+```cpp
+// ----- KernelSpec: kernel declaration -----
+const KernelSpecName READER{"reader"};
+
+KernelSpec reader{
+    .unique_id = READER,
+    .source = "kernels/reader.cpp",
+    // (Placement is declared on WorkUnitSpec, below.)
+    .compile_time_args = {
+        {"src_cb_idx", src_cb_idx},
+        {"dst_cb_idx", dst_cb_idx},
+        {"page_size", page_size},
+    },
+    .runtime_arg_schema = {
+        // Schema only — argument values are set per execution, on ProgramRunArgs.
+        .runtime_arg_names = {"start_page", "num_pages"},
+    },
+    .hw_config = DataMovementHardwareConfig{
+        // RoleHint is the primary intent knob — READER/WRITER auto-infers the
+        // Gen1 processor/NOC pair (and the Gen2 default config). UNSPECIFIED
+        // requires you to provide gen1_config explicitly (power-user override).
+        .role = DataMovementRoleHint::READER,
+    },
+};
+
+// ----- WorkUnitSpec: kernel placement and worker assignments -----
+WorkUnitSpec main_work_unit{
+    .name = "main",
+    .kernels = {READER},
+    .target_nodes = NodeCoord{0, 0},
+};
+
+// ----- ProgramSpec: assemble into the program description -----
+ProgramSpec spec{
+    .name = "my_program",
+    .kernels = {reader},
+    .work_units = {main_work_unit},
+};
+Program program = MakeProgramFromSpec(*mesh_device, spec);
+
+// ----- ProgramRunArgs: argument values, set per execution -----
+ProgramRunArgs params;
+params.kernel_run_args = {{
+    .kernel = READER,
+    .runtime_arg_values = {{NodeCoord{0, 0},
+        {{"start_page", start_page}, {"num_pages", num_pages}}}},
+}};
+SetProgramRunArgs(program, params);
+```
+
+
+---
+
+### DataflowBufferSpec
+
+`DataflowBufferSpec` replaces `CBDescriptor`. Some host-side changes:
+
+1. **Kernel bindings.** A DFB's producer and consumer kernels each declares a `DFBBinding` on its `KernelSpec`, naming the DFB endpoint and a local accessor name. The kernel code references the DFB through that local accessor name (e.g. `dfb::my_dfb`); the magic-number CB index is gone.
+2. **Placement is derived.** A DFB lives wherever its bound producer / consumer kernels run; you do not pass `core_ranges`.
+3. **Multi-threaded DFB access patterns.** These are pertinent to multi-threaded kernels on Quasar.
+
+**Legacy** (`CBDescriptor`):
+
+```cpp
+constexpr uint32_t cb_idx = 0;
+
+CBDescriptor cb_desc = {
+    .total_size = num_pages * page_size,
+    .core_ranges = CoreRangeSet{CoreRange{{0,0}, {0,0}}},
+    .format_descriptors = {{
+        .buffer_index = cb_idx,
+        .data_format = tt::DataFormat::Float16_b,
+        .page_size = page_size,
+    }},
+};
+// Producer and consumer kernels reference the CB by `cb_idx` (= 0) in their CTAs.
+```
+
+**Metal 2.0** (`DataflowBufferSpec`):
+
+```cpp
+const DFBSpecName MY_DFB{"my_dfb"};
+
+DataflowBufferSpec dfb{
+    .unique_id = MY_DFB,
+    .entry_size = page_size,
+    .num_entries = num_pages,
+    .data_format_metadata = tt::DataFormat::Float16_b,
+    // No node_ranges — placement is derived from kernel bindings
+};
+
+// Bound on each kernel that uses the DFB:
+KernelSpec producer{ /* ... */
+    .dfb_bindings = {{
+        .dfb_spec_name = MY_DFB,
+        .accessor_name = "out_dfb",
+        .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER
+    }},
+};
+KernelSpec consumer{ /* ... */
+    .dfb_bindings = {{
+        .dfb_spec_name = MY_DFB,
+        .accessor_name = "in_dfb",  // independent of the producer's name
+        .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER
+    }},
+};
+```
+
+**Spec-validator: every DFB needs ≥1 PRODUCER and ≥1 CONSUMER binding.** The host validator rejects programs where a DFB has only producers or only consumers across the kernels that bind it. When kernels have asymmetric conditional usage of the same DFB (e.g., a reader unconditionally produces a tile but a compute kernel only conditionally needs it), satisfy the constraint by declaring the conditional-side `DFBBinding` unconditionally on the host. Do not modify the kernel's `wait_front` / `pop_front` patterns to "balance" the topology: per-execution DFB state is reinitialized at each program enqueue, so a tile produced and never consumed is harmless.
+
+**Spec-validator: `unpack_to_dest_mode` required for Float32 DFB consumers on `fp32_dest_acc_en` compute kernels.** When a compute `KernelSpec` sets `ComputeHardwareConfig::fp32_dest_acc_en = true`, every Float32-formatted DFB it consumes must appear in `ComputeHardwareConfig::unpack_to_dest_mode` (a `Table<DFBSpecName, UnpackToDestMode>`) with an explicit entry. Legacy `ComputeConfig` defaulted silently; Metal 2.0's validator requires the choice to be made explicit. Use `{DFB_UNIQUE_ID, UnpackToDestMode::Default}` to preserve legacy semantics; pick a non-default mode only when the kernel needs it. Symptom of forgetting: the validator complains at program-spec build time with a message pointing at the FP32 DFB.
+
+**Borrowed-memory DFBs.** A DFB can be built on top of an existing `Buffer`'s memory rather than allocating its own L1 storage — the Metal 2.0 form of the legacy "dynamic circular buffer." Set `DataflowBufferSpec::borrowed_from` to the name of a `TensorParameter` whose buffer backs the DFB; the DFB's L1 address resolves at runtime from the corresponding `TensorArgument` in `ProgramRunArgs::tensor_args`.
+
+**Aliased DFBs.** Two or more DFBs can share backing L1 memory via `DataflowBufferSpec::advanced_options.alias_with` (the field lives on `DFBAdvancedOptions`). The aliased DFBs are logically distinct (each has its own `unique_id` and bindings) but physically occupy the same L1 region. Useful when two same-shape DFBs are produced and consumed in non-overlapping phases of the kernel — the L1 footprint collapses. All aliased DFBs must have the same total size (`num_entries * entry_size`), must be bound to the same kernels, and must mutually declare each other in `alias_with`. Aliased DFBs offer no guarantee against data clobbering between the logical buffers; correctness is the kernel author's responsibility.
+
+Remote DFBs spanning nodes are described in `dataflow_buffer_spec.hpp` but are not yet supported.
+
+> **`tile_format_metadata` (the legacy `format_descriptors[i].tile` field).** `DataflowBufferSpec` carries a second optional metadata field, `std::optional<tt::tt_metal::Tile> tile_format_metadata`, that mirrors the legacy `CBFormatDescriptor::tile`. It is load-bearing for non-default tile geometry — tiny tiles, non-32x32, transposed-face, narrow-tile configurations (introduced for matmul tiny tiles in PR #12908). The value threads through the JIT path into per-CB `constexpr uint8_t unpack_tile_r_dim[]` / `unpack_tile_c_dim[]` / `unpack_num_faces[]` (and pack-side equivalents) inside the compute kernel's generated `chlkc_descriptors.h`, where LLK unpacker / packer init reads it.
+>
+> For DFBs holding **standard 32x32 tiles**, the JIT fallback when this field is `nullopt` yields the same generated arrays as setting `Tile()` — so leaving the field unset is observably identical to setting it. Most CBs in most ops are standard 32x32, which is why the field can look vestigial at a glance.
+>
+> **Operational rule for porters:** copy this field from the legacy CB's `format_descriptors[i].tile`. That preserves correctness for any non-default-tile use case and is harmless when the legacy field was `nullopt` or default.
+
+---
+
+### SemaphoreSpec
+
+`SemaphoreSpec` replaces `SemaphoreDescriptor`. Some notes:
+
+1. **Kernel resource binding**: Semaphores are bound by the `KernelSpec`. The kernel code accesses the semaphore by name through the binding's `accessor_name`.
+2. **Initial value**: Semaphores are default-initialized to zero. Semaphores with non-zero initial values are not support in Quasar; they are temporarily available for WH/BH, but support will be deprecated once remote DFB support is available.
+
+**Legacy** (`SemaphoreDescriptor`):
+
+```cpp
+SemaphoreDescriptor sem_desc{
+    .id = 0,
+    .core_type = CoreType::WORKER,
+    .core_ranges = CoreRangeSet{CoreRange{{0,0}, {3,3}}},
+    .initial_value = 0,
+};
+// Kernels access the semaphore via an ID, typically passed as a runtime argument.
+```
+
+**Metal 2.0** (`SemaphoreSpec`):
+
+```cpp
+const SemaphoreSpecName DONE{"done"};
+
+SemaphoreSpec done_sem{
+    .unique_id = DONE,
+    .target_nodes = NodeRange{{0,0}, {3,3}}, // explicit placement
+};
+
+// Bound on each kernel that uses the semaphore:
+KernelSpec writer{ /* ... */
+    .semaphore_bindings = {{
+        .semaphore_spec_name = DONE,
+        .accessor_name = "kernel_done",  // kernel code accesses as `sem::kernel_done`
+    }},
+};
+```
+
+---
+
+### TensorParameter
+
+`TensorParameter` declares a tensor as a Program-scope resource. Kernels access it via `KernelSpec::TensorBinding`; the runtime `MeshTensor` is supplied per execution via `ProgramRunArgs::TensorArgument`. The kernel-author API collapses to a single line: `TensorAccessor(ta::name)`.
+
+Three pieces, paralleling the DFB / Semaphore pattern with one deliberate asymmetry: tensors are *user-managed* resources (you own the lifetime), so the program-scope type is named `TensorParameter` (distinguished from the "Spec" pattern used elsewhere in the API) — echoing the "ProgramSpec is a function signature; ProgramRunArgs is the call args" framing.
+
+One thing to be aware of: `TensorSpec` is a property of a `MeshTensor`. This pre-exists Metal 2.0; it is not part of the "Spec" object pattern in the rest of the Metal 2.0 APIs.
+
+**Spec-validator: every TensorParameter needs ≥1 TensorBinding across the program's kernels.** Symmetric sibling of the DFB producer/consumer rule. A `TensorParameter` declared on `ProgramSpec` but never bound by any kernel is rejected by the validator. If you find yourself with an unbound `TensorParameter`, either drop the declaration (the tensor isn't actually needed by the program) or add the missing `TensorBinding` on the kernel that uses it.
+
+> **⚠ Pre-migration check.** Before migrating an op, grep its kernel sources for `ArgConfig::Runtime`. If any kernel uses **`ArgConfig::RuntimeTensorShape`** (or the closely related `RuntimeShardShape` / `RuntimeBankCoords`), Metal 2.0 supports the capability via `TensorParameter::advanced_options.dynamic_tensor_shape = true` (full relaxation: `logical_shape` and `padded_shape` may both vary at enqueue) or `match_padded_shape_only = true` (weaker: `logical_shape` may vary, `padded_shape` must match). Both opt-ins are documented **UNSAFE** in the framework header — most kernels won't function correctly if the bound tensor's spec deviates from the declared spec — and adopting them has structural implications for the factory's interaction with the framework's per-dispatch caching path. Treat their use as a deliberate design choice, not a drop-in fix. The remaining flavors — `RuntimeRank`, `RuntimeNumBanks` — do not have a clean translation today; they have ~zero user sites outside tests, so this rarely matters in practice. **Family heads-up — `eltwise`:** ops in this family (binary / unary / ternary) very likely trip this check. Their dataflow kernels are written shape-agnostically (they iterate tile-by-tile and bake in no specific dimensions), and the legacy factories typically declare `RuntimeTensorShape` on the I/O tensors — so the faithful port very likely sets `dynamic_tensor_shape = true` on those `TensorParameter`s. This is *mirroring* a relaxation the legacy op already had, not speculatively adding a new one; still confirm with the grep above rather than assuming.
+
+#### Legacy
+
+```cpp
+// host: append TensorAccessor args to the kernel's positional CTA list,
+// pass the buffer base address as a runtime arg.
+std::vector<uint32_t> reader_cta = {input_page_size, /* other CTAs */};
+tt::tt_metal::TensorAccessorArgs(input.buffer()).append_to(reader_cta);
+
+auto reader_kid = CreateKernel(program, "reader.cpp", core,
+    ReaderDataMovementConfig(reader_cta));
+SetRuntimeArgs(program, reader_kid, core,
+    {input.buffer()->address(), /* other RTAs */});
+```
+
+```cpp
+// kernel: read the buffer address from the RTA list, manually thread
+// CTA offsets to construct TensorAccessorArgs, then build the accessor.
+constexpr uint32_t input_page_size = get_compile_time_arg_val(0);
+// ...other compile-time args...
+constexpr auto input_args = TensorAccessorArgs<N>();   // N = number of preceding CTAs
+uint32_t input_addr = get_arg_val<uint32_t>(0);
+auto input = TensorAccessor(input_args, input_addr);
+```
+
+#### Metal 2.0
+
+```cpp
+const TensorParamName INPUT{"input"};
+
+// In ProgramSpec — declare the tensor as a Program-scope parameter.
+// Use the tensor's own TensorSpec; the binding's spec must equal the runtime tensor's spec.
+ProgramSpec spec;
+spec.tensor_parameters = {
+    {.unique_id = INPUT, .spec = input_tensor.tensor_spec()},
+};
+
+// In KernelSpec — bind the parameter, naming the kernel-side accessor.
+KernelSpec reader{ /* ... */
+    .tensor_bindings = {{
+        .tensor_parameter_name = INPUT,
+        .accessor_name = "input",   // kernel accesses as `ta::input`
+    }},
+};
+spec.kernels = {reader};
+
+Program program = MakeProgramFromSpec(*mesh_device, spec);
+
+// In ProgramRunArgs — supply the actual MeshTensor per execution.
+ProgramRunArgs params;
+params.tensor_args = {
+    {INPUT, TensorArgument{input_tensor}},
+};
+SetProgramRunArgs(program, params);
+```
+
+```cpp
+// kernel: one line. No CTA-offset bookkeeping, no buffer-address RTA.
+auto input = TensorAccessor(ta::input);
+```
+
+The buffer-address RTA is gone — the binding mechanism auto-injects the per-enqueue base address. The `TensorAccessorArgs<N>()` line is gone too — the layout metadata is packed by the host at program creation.
+
+#### Migration recipe
+
+For each op:
+
+1. **Pre-flight.** Grep the op's kernel sources for `ArgConfig::Runtime`. If `RuntimeTensorShape` (or `RuntimeShardShape` / `RuntimeBankCoords`) appears anywhere, the migration is possible but the `TensorParameter`s for the affected tensors need `advanced_options.dynamic_tensor_shape = true` (or the weaker `match_padded_shape_only = true`) — see callout above for the safety and structural caveats before adopting either.
+2. **Find each `TensorAccessor`.** In each kernel, locate every `TensorAccessor(args, addr)` construction. For each, trace `addr` back through the host code to the originating `Tensor`.
+3. **Declare `TensorParameter`s.** Add one entry per tensor to `ProgramSpec::tensor_parameters`, using `tensor.tensor_spec()`. Pick a stable `unique_id`; declare it as a typed constant (`const TensorParamName INPUT{"input"};`) and reuse the constant at each use site.
+4. **Add `TensorBinding`s.** On each `KernelSpec` whose kernel accesses the tensor, add an entry to `tensor_bindings` referencing the parameter by name. The `accessor_name` is the kernel-side identifier — it will appear as `ta::<accessor_name>`.
+5. **Update kernel code.**
+   - Replace `TensorAccessor(args, addr)` with `TensorAccessor(ta::<accessor_name>)`.
+   - Drop the `TensorAccessorArgs<offset>()` line and any manual `next_compile_time_args_offset()` chaining.
+   - Drop the `get_arg_val<uint32_t>(N)` line that retrieved the buffer address — those bytes are no longer in your RTA list, so re-index any RTAs that came after.
+6. **Wire `tensor_args`.** Add one `TensorArgument` per `TensorParameter` to `ProgramRunArgs::tensor_args`, passing the actual `MeshTensor`.
+
+#### Validation
+
+At enqueue, the runtime `MeshTensor`'s `TensorSpec` must equal the binding's declared spec. Mismatches error loudly with a message naming the binding. The binding declaration is the single source of truth for layout — if the supplied tensor doesn't match, the bug is at the call site (typically: a layout transformation that should have been wired into the program but was applied externally to the tensor).
+
+#### Multi-kernel-same-tensor
+
+The common case (matmul reader + compute reading the same input; reshard reader/writer pipelines) is the cleanest fit for the binding model. Each kernel declares its own `TensorBinding` to the same `TensorParameter` with its own kernel-local `accessor_name`; the underlying tensor identity stays singular at the program level. This is structurally different from the legacy pattern, where the same tensor's address would be passed as a separate RTA on every kernel — and divergence between those was a real (silent) failure mode.
+
+#### What's not covered yet
+
+- **Manual `DistributionSpec` reuse** (the "advanced reuse-bank-coords-across-accessors" path from the [TensorAccessor guide](../../../../tech_reports/tensor_accessor/tensor_accessor.md)). Not commonly used in production ops.
+- **Tensor bindings on compute kernels** are out of scope. `TensorAccessor` was never supported for compute kernels (TRISC builds don't compile its NoC-using includes), so migration should not encounter any.
+
+---
+
+### WorkUnitSpec
+
+`WorkUnitSpec` is a new top-level concept in Metal 2.0. It declares groups of kernels that operate together on a worker node, and on which nodes they run.
+
+**Single work unit on one node:**
+
+```cpp
+WorkUnitSpec wu{
+    .name = "main",
+    .kernels = {READER, WRITER},
+    .target_nodes = NodeCoord{0, 0},
+};
+```
+
+**One work unit spanning a range of nodes:**
+
+```cpp
+WorkUnitSpec wu{
+    .name = "main",
+    .kernels = {READER, COMPUTE, WRITER},
+    .target_nodes = NodeRange{{0, 0}, {3, 3}},  // 4×4 grid
+};
+```
+
+**A kernel belonging to multiple work units** (e.g. for a kernel that runs on both an inner block and a halo region, with different DFB partners in each):
+
+```cpp
+WorkUnitSpec wu_inner{
+    .name = "inner",
+    .kernels = {COMPUTE, INNER_READER},
+    .target_nodes = inner_node_range_set
+};
+WorkUnitSpec wu_halo{
+    .name = "halo",
+    .kernels = {COMPUTE, HALO_READER},
+    .target_nodes = halo_node_range_set
+};
+// COMPUTE's effective node set is the union of inner + halo.
+```
+
+---
+
+### ProgramRunArgs
+
+`ProgramRunArgs` describes the mutable properties of the Program. These parameters are specified anew with each Program enqueue:
+ - Kernel runtime arguments
+ - Kernel common runtime arguments
+ - Tensor arguments (`tensor_args`) — one `MeshTensor` per declared `TensorParameter`. See [TensorParameter](#tensorparameter). Borrowed-memory DFBs draw their backing L1 address from the corresponding `tensor_args` entry automatically; they don't require a separate `dfb_run_overrides` entry.
+
+All kernel arguments are named arguments in Metal 2.0. For kernels that accept a variable number of arguments, the API additionally provides an  "varargs" mechanism.
+
+**Legacy** (values on the descriptor):
+
+```cpp
+KernelDescriptor reader = {
+    // ...
+    .runtime_args = {{{0, 0}, {start_page, num_tiles}}},
+    .common_runtime_args = {bank_id},
+};
+```
+
+**Metal 2.0** (schema on the spec, values on the run params):
+
+```cpp
+// Schema declared on the kernel:
+KernelSpec reader{
+    .unique_id = READER,
+    // ...
+    .runtime_arg_schema = {
+        .runtime_arg_names = {"start_page", "num_tiles"},
+        .common_runtime_arg_names = {"bank_id"},
+    },
+};
+
+// Values supplied per execution:
+ProgramRunArgs params;
+params.kernel_run_args = {{
+    .kernel = READER,
+    .runtime_arg_values = {{NodeCoord{0, 0},
+        {{"start_page", start_page}, {"num_tiles", num_tiles}}}},
+    .common_runtime_arg_values = {{"bank_id", bank_id}},
+}};
+SetProgramRunArgs(program, params); // temporary free function
+```
+
+Vararg form — for kernels with a genuinely dynamic argument tail (loop-retrieved on the device side). The canonical fit is a CTA-bound count plus a per-element payload, e.g. an N-dimensional shape. Vararg counts live on `KernelAdvancedOptions` (schema side); vararg values live on `AdvancedKernelRunArgs` (per-execution side, nested under each `KernelRunArgs` entry's `.advanced_options`):
+
+```cpp
+// Schema (on KernelSpec::advanced_options, which is KernelAdvancedOptions):
+.compile_time_args = {{"rank", rank}},
+.advanced_options = {
+    .num_runtime_varargs = rank,  // shape: one entry per dimension
+},
+
+// Values (on the matching KernelRunArgs entry's .advanced_options, which is AdvancedKernelRunArgs):
+//   .runtime_varargs is Table<NodeCoord, std::vector<uint32_t>>
+params.kernel_run_args = {{
+    .kernel = MY_KERNEL,
+    .advanced_options = {
+        .runtime_varargs = {{NodeCoord{0, 0}, shape_dims}},  // shape_dims.size() == rank
+    },
+}};
+```
+
+Named and vararg forms can coexist on the same kernel. Vararg indices are stable across schema changes — promoting a named RTA to a CRTA, or adding/removing named args, does not shift vararg indices. Common runtime varargs (`num_common_runtime_varargs`, retrieved on the device via `get_common_vararg(i)`) work analogously, broadcast across all nodes.
+
+> The vararg form is intended for kernels whose device-side code retrieves arguments in a loop — i.e., `get_vararg(i)` with `i` a runtime variable. When the kernel reads each argument by a constant index (`get_vararg(0)`, `get_vararg(1)`, …), the named form reads more clearly on both sides.
+
+---
+
+## Device-Side Migration
+
+### Circular Buffers → Dataflow Buffers
+
+Metal 2.0 replaces Circular Buffers (CBs) with Dataflow Buffers (DFBs). Notes:
+
+1. **Construction from local accessor name**. You construct your DFB from its local accessor, not a magic-number `cb_id`. The accessor is auto-generated from the host-side DFB binding and lives in the `dfb::` namespace inside `kernel_bindings_generated.h`.
+2. **`experimental::CircularBuffer` compatible APIs**. The kernel-side DFB APIs are drop-in-compatible with the Device 2.0 `experimental::CircularBuffer` wrapper methods and semantics on Gen1. Gen2 permits more advanced capabilities.
+3. **Direct use in LLK compute APIs (WH/BH)**. The `dfb::my_dfb` accessor constants implicitly convert to `uint32_t`, so on WH/BH you can pass them directly to LLK compute APIs (`reduce_init`, `pack_tile`, `cb_wait_front`, etc.) that take a raw CB id — no `.id` extraction or temporary `DataflowBuffer` needed. The Quasar LLK signatures are intended to take DFB handles natively; that refresh is in progress.
+
+**Legacy (Device 2.0 `experimental::CircularBuffer`):**
+
+```cpp
+constexpr uint32_t cb_id = 0;
+experimental::CircularBuffer cb(cb_id);
+
+cb.reserve_back(num_pages);
+uint32_t write_ptr = cb.get_write_ptr();
+// ... write data ...
+cb.push_back(num_pages);
+```
+
+**Metal 2.0 (`experimental::DataflowBuffer`):**
+
+```cpp
+// Host-side DFB binding declared accessor_name = "my_dfb".
+// Auto-generated from that: constexpr DFBAccessor dfb::my_dfb;
+experimental::DataflowBuffer dfb(dfb::my_dfb);
+
+dfb.reserve_back(num_entries);
+uint32_t write_ptr = dfb.get_write_ptr();
+// ... write data ...
+dfb.push_back(num_entries);
+```
+
+
+> **Implicit sync (Quasar)**: On Gen2, you can elide the explicit `reserve_back` / `push_back` (or `wait_front` / `pop_front`) pattern entirely. Pass the DFB directly to `experimental::Noc::async_read` or `async_write`, and the runtime hardware handles the FIFO sync via ISR. This is the default behavior; you can disable it per-DFB endpoint by listing the DFB's `unique_id` in `Gen2Config::disable_implicit_sync_for` (on the kernel's `DataMovementHardwareConfig::gen2_config`): e.g. `gen2_config = Gen2Config{.disable_implicit_sync_for = {"my_dfb"}}` (rarely needed). On Gen1, the option is a no-op — the explicit FIFO pattern shown above remains the way.
+
+---
+
+### TensorAccessor
+
+Construction collapses to one line. `TensorAccessor` takes the codegen-emitted token directly; everything else is unchanged from today (`get_noc_addr`, `get_bank_and_offset`, `dspec()`, `noc_async_read_page`, etc.).
+
+The token lives in the `ta::` namespace inside `kernel_bindings_generated.h` (auto-generated from the host-side `TensorBinding`), parallel to the `dfb::` and `sem::` namespaces.
+
+**Legacy:**
+
+```cpp
+constexpr uint32_t input_page_size = get_compile_time_arg_val(0);
+// ...other compile-time args...
+constexpr auto input_args = TensorAccessorArgs<N>();    // N = preceding CTA count
+constexpr auto index_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
+uint32_t input_addr = get_arg_val<uint32_t>(0);
+uint32_t index_addr = get_arg_val<uint32_t>(1);
+
+auto input = TensorAccessor(input_args, input_addr);
+auto index = TensorAccessor(index_args, index_addr);
+```
+
+**Metal 2.0:**
+
+```cpp
+auto input = TensorAccessor(ta::input);
+auto index = TensorAccessor(ta::index);
+```
+
+The `TensorAccessorArgs<N>()` lines, the manual `next_compile_time_args_offset()` chaining for multi-tensor stacking, and the buffer-address RTAs are all gone. Layout metadata is packed by the host into the kernel's compile-time args at program creation, not retrieved by the kernel; the per-enqueue base address rides on a host-managed slot in the kernel's CRTA buffer that the kernel never sees directly.
+
+See [TensorParameter](#tensorparameter) for the host-side declaration that produces the `ta::` namespace.
+
+---
+
+### Kernel Argument Retrieval Syntax
+
+The Metal 2.0 host API declares kernel arguments by name; the kernel-side API retrieves them by name. This replaces the legacy positional `get_arg_val<uint32_t>(N)` style.
+
+**The only `#include` a porter adds to a kernel is `experimental/kernel_args.h`** — that pulls in the accessor templates (`get_arg`, `args::`, `dfb::`, `sem::`, `ta::`). The generated headers `kernel_bindings_generated.h` (which carries `dfb::` / `sem::` / `ta::` declarations from the host bindings) and `kernel_args_generated.h` (which carries `args::` declarations from `compile_time_args` + `runtime_arg_schema`) are auto-included by the build system via `<kernel_includes.hpp>` before the kernel source. **Do not** `#include` either generated header from your kernel.
+
+**Example 1 — Named arguments only.**
+
+Suppose the host declared the following on `KernelSpec`:
+
+```cpp
+.compile_time_args = {{"bank_id", 0}, {"entry_size", 1024}},
+.runtime_arg_schema = {
+    .runtime_arg_names = {"start_page"},
+    .common_runtime_arg_names = {"num_entries"},
+},
+```
+
+**Legacy (positional):**
+
+```cpp
+void kernel_main() {
+    constexpr uint32_t bank_id    = get_compile_time_arg_val(0);
+    constexpr uint32_t entry_size = get_compile_time_arg_val(1);
+    uint32_t start_page    = get_arg_val<uint32_t>(0);    // RTA index 0
+    uint32_t num_entries = get_common_arg_val<uint32_t>(0);  // CRTA index 0
+    // ...
+}
+```
+
+**Metal 2.0 (named):**
+
+```cpp
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    constexpr auto bank_id    = get_arg(args::bank_id);     // CTA — compile-time constant
+    constexpr auto entry_size = get_arg(args::entry_size);  // CTA
+    auto start_page             = get_arg(args::start_page);    // RTA
+    const auto num_entries    = get_arg(args::num_entries); // CRTA
+    // ...
+}
+```
+
+CTAs, RTAs, and CRTAs are accessed through the same `get_arg(args::name)` mechanism in device code. The dispatch type (compile-time, runtime, common runtime) is a host-only concept — the kernel author no longer needs to know or care which kind of argument they're reading. The C++ type-deduction context (`constexpr auto`, `auto`, `const auto`) is the only place the distinction surfaces.
+
+**Example 2 — Named arguments plus varargs (the niche case).**
+
+Some kernels read a dynamic-count argument tail in a loop — e.g. an N-dimensional tensor's shape, where N is itself a CTA. That's the case varargs are designed for:
+
+```cpp
+.compile_time_args = {{"rank", rank}},
+.runtime_arg_schema = {
+    .runtime_arg_names = {"start_page"},
+    .common_runtime_arg_names = {"num_entries"},
+    .num_runtime_varargs = rank,  // shape: one entry per dimension
+},
+```
+
+```cpp
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    constexpr auto rank      = get_arg(args::rank);          // CTA
+    auto start_page          = get_arg(args::start_page);    // RTA
+    const auto num_entries   = get_arg(args::num_entries);   // CRTA
+
+    // Vararg RTAs read in a loop — count is bound to `rank`:
+    uint32_t shape[rank];
+    for (uint32_t i = 0; i < rank; ++i) {
+        shape[i] = get_vararg(i);
+    }
+    // ...
+}
+```
+
+Common runtime varargs are analogous: declare with `num_common_runtime_varargs`, retrieve on the device with `get_common_vararg(i)`. Same loop-retrieval criterion applies.
+
+> When porting a legacy kernel with positional RTAs, the natural Metal 2.0 form is named RTAs — one per legacy positional argument. A translation into vararg slots compiles and runs (and may be useful as an interim step on a large kernel), but the named form is the recommended endpoint for new code. The distinguishing criterion is whether the kernel's device-side `get_vararg(i)` calls use `i` as a runtime variable (varargs are appropriate) or constants (named RTAs are clearer).
+
+Vararg indices are stable across schema changes: promoting a named RTA to a CRTA, or adding or removing named arguments, does not shift vararg indices. (This stability lets you migrate incrementally — rename arguments to named form one at a time without disturbing the remaining varargs.)
+
+> **Note**: This argument-retrieval syntax will evolve again to support custom argument types beyond `uint32_t` (including std::array and user-defined POD types). The named-accessor mechanism (`get_arg(args::name)`) will be preserved; the underlying types will become user-extensible. Migrators should plan to revisit kernel arguments after these changes.
+
+---
+
+## Design Principles
+
+The sections above describe the Metal 2.0 API surface piece by piece. This section steps back and presents the design intent that ties those pieces together. Reading these principles helps you recognize when a port is *faithful* (preserves intent and reaps the ergonomic improvement Metal 2.0 promises) versus when it merely *translates syntax* (carrying forward workarounds that should evaporate).
+
+### Principle 1: Immutable spec, mutable run-args
+
+Metal 2.0 splits a Program's description into two parts:
+
+- **`ProgramSpec`** — the immutable description (the "function signature and body"). Captures kernel sources, resource declarations, work-unit assignments, and argument *schemas*.
+- **`ProgramRunArgs`** — the per-execution mutable values (the "call arguments"). Carries runtime argument values, tensor identities, and any other field that may legitimately differ between executions.
+
+This split is the **only** structural divergence from legacy `ProgramDescriptor`. Every other Metal 2.0 type maps roughly 1:1 with its `ProgramDescriptor` counterpart — `KernelSpec` ↔ `KernelDescriptor`, `DataflowBufferSpec` ↔ `CBDescriptor`, `SemaphoreSpec` ↔ `SemaphoreDescriptor`, and so on.
+
+The separation enables two performance optimizations the legacy API couldn't express:
+
+1. **Caching**: a `Program` built once from a `ProgramSpec` can be executed many times with fresh `ProgramRunArgs` — the compile/build cost is paid once.
+2. **Partial updates**: for ops whose mutable surface is small (typically just the tensor identities), the framework can apply a partial update on cache hit instead of re-issuing the full `ProgramRunArgs`.
+
+For the op author, the practical implication is that **the schema and the values are conceptually paired** even though they live in different structures. When you add a named RTA to a `KernelSpec`'s schema, you simultaneously add its per-node value to `ProgramRunArgs::kernel_run_args`. When you declare a `TensorParameter`, you simultaneously add its `TensorArgument`. The spec/run-args separation is most visible to the framework and tooling; during construction, the two are built together.
+
+### Principle 2: First-class named resource bindings
+
+This is the largest design shift in Metal 2.0 — and the principle responsible for the bulk of the stylistic improvement Metal 2.0 offers.
+
+**Resources (tensors, DFBs, semaphores) bind by name.** Each resource is declared once on the `ProgramSpec` (as a `TensorParameter`, `DataflowBufferSpec`, or `SemaphoreSpec`), then bound to each kernel that uses it via a `TensorBinding` / `DFBBinding` / `SemaphoreBinding` on the `KernelSpec`. The kernel accesses the resource through an auto-generated handle (`ta::name`, `dfb::name`, `sem::name`) without needing to know its underlying ID, address, or layout.
+
+Legacy `ProgramDescriptor` had no equivalent abstraction. Resources were referenced indirectly:
+
+- **Tensors** via their buffer's base address, packed into a runtime argument; layout metadata via `TensorAccessorArgs` plumbing appended to the kernel's compile-time arg list.
+- **Circular buffers** via a magic-number CB index assigned to `CBDescriptor::format_descriptors[].buffer_index`; producer and consumer kernels referenced that index via a positional or named CTA.
+- **Semaphores** via their integer ID, typically passed as a runtime argument.
+
+The named-binding design produces a series of consequent changes — patterns that are *non-translations* during port. They appear in legacy code; they should **not** appear in a faithful Metal 2.0 port.
+
+**Tensor accessor.**
+
+```cpp
+// Legacy: address as RTA, layout metadata via TensorAccessorArgs<N>() chains.
+constexpr auto args = TensorAccessorArgs<N>();
+uint32_t addr = get_arg_val<uint32_t>(0);
+auto a = TensorAccessor(args, addr);
+
+// Metal 2.0: one line.
+auto a = TensorAccessor(ta::input);
+```
+
+Neither `tensor.buffer()->address()` (host side) nor `TensorAccessorArgs<N>()` (device side) survives a faithful port.
+
+**Dataflow buffer.**
+
+```cpp
+// Legacy: magic-number CB index passed via CTA, used to construct CB wrapper.
+constexpr uint32_t cb_id = 0;
+experimental::CircularBuffer cb(cb_id);
+
+// Metal 2.0: named handle from the binding.
+experimental::DataflowBuffer cb(dfb::my_dfb);
+```
+
+The magic-number CB index doesn't appear on the host or in the kernel.
+
+**Semaphore.**
+
+```cpp
+// Legacy: ID forwarded as RTA, kernel constructs the access from the ID.
+uint32_t sem_id = get_arg_val<uint32_t>(2);
+
+// Metal 2.0: named handle from the binding; access via sem::done.
+```
+
+The semaphore-ID RTA is gone.
+
+**Multi-kernel access to the same resource.** The named-binding design makes resource identity singular at the program level. Legacy: each kernel reads the same tensor's address as an independent RTA; divergence between those RTAs was a silent failure mode. Metal 2.0: one `TensorParameter`, multiple `TensorBinding`s — each with its own per-kernel `accessor_name`. The accessor names are local aliases; the binding declarations are the single source of truth.
+
+**Optional resources.** A binding may be declared conditionally on the host (omitted from `KernelSpec::dfb_bindings` / `tensor_bindings` when the path isn't taken). On the kernel side, the gate has to happen at the **preprocessor** level: Metal 2.0's `dfb::<name>` namespace is generated from the actual host bindings — `dfb::cb_scaled` exists only when the host actually binds it — and `if constexpr` in non-template `kernel_main` still performs name lookup on the discarded branch, so `if constexpr (false) { … dfb::cb_scaled … }` fails to compile at parse time. The host emits a matching `#define` via `KernelSpec::compiler_options.defines`; the kernel `#ifdef`-gates both the binding's `constexpr` alias and every expression referencing it.
+
+```cpp
+// Host side:
+KernelSpec compute{
+    .compile_time_args = { /* ... */ },
+    .compiler_options = {.defines = do_scale
+        ? Table<std::string, std::string>{{"DO_SCALE", "1"}}
+        : Table<std::string, std::string>{}},
+    .dfb_bindings = do_scale
+        ? Group<DFBBinding>{INPUT, OUTPUT, SCALED}
+        : Group<DFBBinding>{INPUT, OUTPUT},
+};
+
+// Kernel side:
+#ifdef DO_SCALE
+constexpr uint32_t cb_scaled_id = dfb::cb_scaled;
+#endif
+
+#ifdef DO_SCALE
+experimental::DataflowBuffer cb_scaled(dfb::cb_scaled);
+cb_scaled.wait_front(...);
+// ... all uses of cb_scaled
+#endif
+```
+
+The full discussion (file-scope ternaries, preprocessor-stage parsing) is in [Pattern: Conditional / optional DFB bindings](metal2_port_patterns.md#pattern-conditional--optional-dfb-bindings). The "always bind and gate only the uses" alternative — wrapper declared unconditionally — is wrong on two counts: it pays L1 unnecessarily for an unused buffer, *and* `if constexpr` doesn't gate name lookup in a non-template kernel even if you reached for it.
+
+---
+
+When a port carries any of these patterns forward verbatim — buffer-address RTAs, magic CB indices, semaphore-ID RTAs, always-bound optional DFBs — it has translated syntax without internalizing the design shift. The code compiles, may even run correctly, but it defeats the ergonomics improvement Metal 2.0 is built to deliver. The [Concept Map](#concept-map) early in this guide pairs the syntax-level translations; the named-binding principle is what explains *why* certain legacy idioms shouldn't reappear at all.
+
+### Principle 3: Named arguments throughout
+
+Argument naming extends the named-binding ethos to scalar values:
+
+- **Compile-time arguments are named only.** Positional CTAs are gone from the Metal 2.0 API.
+- **Runtime arguments are typically named.** A `varargs` mechanism exists as a niche escape hatch.
+- **Common runtime arguments are typically named.** Same `varargs` mechanism applies.
+
+The `args::` namespace generated from a `KernelSpec`'s schema gives the kernel one uniform retrieval API: `get_arg(args::name)`. The CTA/RTA/CRTA distinction is a host-only concern; the kernel author doesn't need to know which dispatch slot a given argument lives in.
+
+Legacy `ProgramDescriptor` offered a hybrid model: `KernelDescriptor::compile_time_args` (positional, vector of `uint32_t`) and `KernelDescriptor::named_compile_time_args` (named, vector of `{name, value}` pairs). Many recent ops — matmul among them — use the named half. For ports of those ops:
+
+- Named CTAs in legacy → named CTAs in Metal 2.0. 1:1 mechanical.
+- Positional CTAs in legacy → named CTAs in Metal 2.0. Explicit naming required during port; pick names that reflect what the kernel actually does with the value.
+
+> **Use varargs only when the kernel reads its arguments in a loop.** Varargs are designed for kernels whose device-side code retrieves arguments via `get_vararg(i)` where `i` is a runtime variable — the canonical case is an N-dimensional shape gated on a CTA-known `rank`. When each argument is referenced by a constant index (`get_vararg(0)`, `get_vararg(1)`, ...), the named form is clearer on both sides. A port from positional RTAs to varargs may compile and run, but it preserves the legacy positional vocabulary instead of upgrading to Metal 2.0's named one. See the [patterns catalog](metal2_port_patterns.md) caution on varargs.
+
+---
+
+## TTNN Framework Integration
+
+TTNN ops integrate with the Metal 2.0 host API through the `ttnn::device_operation` framework. The framework provides three factory *concepts*; an op's program factory satisfies whichever concept matches its construction model:
+
+- **`ProgramFactoryConcept`** — the oldest concept; legacy `host_api.hpp` builder-style factories. Returns a `CachedProgram<shared_variables_t>` from `create()`; updates per-execution state via `override_runtime_arguments()`.
+- **`ProgramDescriptorFactoryConcept`** — the intermediate concept; legacy `ProgramDescriptor`-based factories. Returns a `tt::tt_metal::ProgramDescriptor` from `create_descriptor()`.
+- **`MetalV2FactoryConcept`** — the Metal 2.0 concept. Returns a `ttnn::device_operation::ProgramArtifacts` (the `ProgramSpec`, its `ProgramRunArgs`, and any op-owned tensors) from `create_program_artifacts()`. **This is the concept ops port to.**
+
+> The porter-facing detail for this concept — the feasibility gate, the device-op-class edits a port forces, and the cache lifecycle in operational terms — lives in [`port_op_to_metal2_ttnn_factory.md`](port_op_to_metal2_ttnn_factory.md). This section is the conceptual overview.
+
+### Factory skeleton
+
+A Metal 2.0 program factory has the following shape:
+
+```cpp
+// In your factory header:
+struct MyProgramFactory {
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
+        const operation_attributes_t& attributes,
+        const tensor_args_t&           tensor_args,
+        tensor_return_value_t&         tensor_return_value);
+};
+
+// In your factory implementation:
+ttnn::device_operation::ProgramArtifacts MyProgramFactory::create_program_artifacts(
+    const operation_attributes_t& attributes,
+    const tensor_args_t&           tensor_args,
+    tensor_return_value_t&         tensor_return_value) {
+
+    // ... build the spec and run args ...
+
+    tt::tt_metal::experimental::ProgramSpec spec{
+        .name = "my_program",
+        // ...
+    };
+    tt::tt_metal::experimental::ProgramRunArgs run_params;
+    // ... populate run_params ...
+
+    return ttnn::device_operation::ProgramArtifacts{
+        .spec       = std::move(spec),
+        .run_params = std::move(run_params),
+        // .op_owned_tensors = {},  // default-empty; populate only when the factory
+        //                          // allocates its own scratch / workspace tensors,
+        //                          // whose lifetime then tracks the cached entry.
+    };
+}
+```
+
+`ProgramArtifacts` has three fields — `spec`, `run_params`, and `op_owned_tensors` (default-empty). Most ports leave `op_owned_tensors` defaulted; a factory that allocates its own scratch / workspace `MeshTensor`s returns them there, and the framework keeps them alive at a stable address for the cached `Program`'s lifetime. (Op-owned `GlobalSemaphore`s are not supported — the artifact carries only `MeshTensor`s.)
+
+> **Tensor types in a ProgramFactory.** A factory sits between two tensor-type universes; you'll see three names but only two real types:
+> - **`ttnn::Tensor`** — TTNN's PyTorch-like tensor wrapper. Can in general represent either a host-resident or device-resident tensor, but **is always device-resident in a ProgramFactory.** This is what `tensor_args` and `tensor_return_value` carry into `create_program_artifacts`.
+> - **`tt::tt_metal::MeshTensor`** — Metalium's native device-tensor type. RAII handle with unique ownership over a (mesh) device allocation. Metal 2.0's `TensorArgument` (the entries you populate in `ProgramRunArgs::tensor_args`) takes a `const MeshTensor&` — this is the type the rest of the Metal 2.0 API speaks.
+> - **`tt::tt_metal::Tensor`** — a deprecated alias for `ttnn::Tensor`, not a third type. The class is declared in the `tt::tt_metal` namespace despite its header living under `ttnn/` — a refactoring artifact. If you encounter `tt_metal::Tensor` in legacy code, mentally substitute `ttnn::Tensor`.
+>
+> **Extract `MeshTensor` from each input at the top of the factory.** `ttnn::Tensor::mesh_tensor()` returns `const MeshTensor&` (the rvalue overload is `= delete`'d to prevent dangling references on temporaries). Recommended style — extract once at factory entry, work with `MeshTensor` references throughout:
+>
+> ```cpp
+> ttnn::device_operation::ProgramArtifacts MyProgramFactory::create_program_artifacts(
+>     const operation_attributes_t& attributes,
+>     const tensor_args_t&           tensor_args,
+>     tensor_return_value_t&         tensor_return_value) {
+>
+>     const auto& input  = tensor_args.input.mesh_tensor();
+>     const auto& output = tensor_return_value.mesh_tensor();
+>     // Use `input` / `output` (MeshTensor&) for the rest of the factory body —
+>     // pass to helpers, build TensorParameter specs, populate TensorArguments.
+> }
+> ```
+>
+> Pass `MeshTensor` directly to helper functions as `const MeshTensor&`; do **not** wrap in `std::cref` / `std::reference_wrapper<const MeshTensor>`. Reaching back to `.mesh_tensor()` at each call site compiles and runs correctly but is not the recommended style — extract once and pass the reference.
+
+A Metal 2.0 factory **does not** construct the `Program` itself, nor does it call `SetProgramRunArgs` directly. Those are the framework adapter's responsibilities.
+
+### Cache-miss vs cache-hit lifecycle
+
+The framework manages two distinct execution paths:
+
+- **Cache miss** (first execution, or a new op-args key): the framework calls `create_program_artifacts`, then internally calls `MakeProgramFromSpec(*device, spec)` to build the `Program`, then `SetProgramRunArgs(program, run_params)` to apply the per-execution values, resolving each `TensorArgument` against the op's io tensors and any `op_owned_tensors`. The full spec is realized once; op-owned tensors are parked in the cache entry at a stable address.
+- **Cache hit** (subsequent executions with a still-valid cached `Program`): the framework **does not re-run the factory**. It refreshes the tensor bindings — the io tensors plus the parked op-owned ones — via `UpdateTensorArgs`, and skips the build. Only the tensor bindings are refreshed; other run-arg values keep the values they were given at cache-miss.
+
+The cache key is the op itself — its type, attributes, and tensor args (the framework's automatic hash), combined with the target mesh coordinates; a custom `compute_program_hash`, if present, replaces that default. A factory satisfying `MetalV2FactoryConcept` is routed through `MetalV2MeshWorkloadFactoryAdapter`, which handles both paths.
+
+### TTNN's immutability convention
+
+A practical consequence of TTNN's caching: **most parameters that *could* vary between calls are treated as if they were immutable, and the cache is invalidated when they change**. The actually-mutable surface across calls is small — typically just the tensor identities (`tensor_args` in `ProgramRunArgs`).
+
+An op author specifying a Metal 2.0 factory does not directly experience the spec/run-args separation as a per-call distinction. The two are constructed together in `create_program_artifacts`; the framework's cache machinery converts that single construction call into either a full realization (cache miss) or a tensor-binding refresh (cache hit). Designing your factory to construct paired resources and values together — `TensorParameter` and its `TensorArgument`, RTA schema and its values — reflects the actual authoring flow.
+
+---
+
+## Complete Migration Examples
+
+### Example 1: Single-Core Reader / Writer with One DFB
+
+Reader kernel reads pages from an input tensor into a DFB; writer kernel pulls from the DFB and writes pages to an output tensor.
+
+**Legacy (`ProgramDescriptor`):**
+
+```cpp
+constexpr uint32_t cb_idx     = 0;
+constexpr uint32_t page_size  = 1024;
+constexpr uint32_t num_pages  = 8;
+const CoreCoord core{0, 0};
+
+CBDescriptor cb_desc = {
+    .total_size = num_pages * page_size,
+    .core_ranges = CoreRangeSet{CoreRange{core}},
+    .format_descriptors = {{
+        .buffer_index = cb_idx,
+        .data_format = tt::DataFormat::Float16_b,
+        .page_size = page_size,
+    }},
+};
+
+// Reader: TensorAccessor args appended to the positional CTA list; buffer
+// address passed as an RTA.
+std::vector<uint32_t> reader_cta = {cb_idx, page_size};
+tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(reader_cta);
+
+KernelDescriptor reader = {
+    .kernel_source = "kernels/reader.cpp",
+    .core_ranges = CoreRangeSet{CoreRange{core}},
+    .compile_time_args = reader_cta,
+    .runtime_args = {{core, {input_tensor.buffer()->address(), num_pages}}},
+    .config = ReaderConfigDescriptor{},
+};
+
+// Writer: same shape on the output side.
+std::vector<uint32_t> writer_cta = {cb_idx, page_size};
+tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(writer_cta);
+
+KernelDescriptor writer = {
+    .kernel_source = "kernels/writer.cpp",
+    .core_ranges = CoreRangeSet{CoreRange{core}},
+    .compile_time_args = writer_cta,
+    .runtime_args = {{core, {output_tensor.buffer()->address(), num_pages}}},
+    .config = WriterConfigDescriptor{},
+};
+
+ProgramDescriptor program_desc = {
+    .kernels = {reader, writer},
+    .cbs = {cb_desc},
+};
+```
+
+**Metal 2.0:**
+
+```cpp
+const KernelSpecName  READER{"reader"};
+const KernelSpecName  WRITER{"writer"};
+const DFBSpecName     DFB{"loopback_dfb"};
+const TensorParamName INPUT{"input"};
+const TensorParamName OUTPUT{"output"};
+
+constexpr uint32_t page_size = 1024;
+constexpr uint32_t num_pages = 8;
+const NodeCoord node{0, 0};
+
+KernelSpec reader{
+    .unique_id = READER,
+    .source = "kernels/reader.cpp",
+    .compile_time_args = {{"page_size", page_size}},
+    .runtime_arg_schema = {.runtime_arg_names = {"num_pages"}},
+    .dfb_bindings = {{
+        .dfb_spec_name = DFB,
+        .accessor_name = "out_dfb",
+        .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER
+    }},
+    .tensor_bindings = {{
+        .tensor_parameter_name = INPUT,
+        .accessor_name = "input",   // kernel accesses as `ta::input`
+    }},
+    .hw_config = DataMovementHardwareConfig{
+        .role = DataMovementRoleHint::READER,
+    },
+};
+
+KernelSpec writer{
+    .unique_id = WRITER,
+    .source = "kernels/writer.cpp",
+    .compile_time_args = {{"page_size", page_size}},
+    .runtime_arg_schema = {.runtime_arg_names = {"num_pages"}},
+    .dfb_bindings = {{
+        .dfb_spec_name = DFB,
+        .accessor_name = "in_dfb",
+        .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER
+    }},
+    .tensor_bindings = {{
+        .tensor_parameter_name = OUTPUT,
+        .accessor_name = "output",  // kernel accesses as `ta::output`
+    }},
+    .hw_config = DataMovementHardwareConfig{
+        .role = DataMovementRoleHint::WRITER,
+    },
+};
+
+DataflowBufferSpec dfb{
+    .unique_id = DFB,
+    .entry_size = page_size,
+    .num_entries = num_pages,
+    .data_format_metadata = tt::DataFormat::Float16_b,
+};
+
+ProgramSpec spec{
+    .name = "loopback",
+    .kernels = {reader, writer},
+    .dataflow_buffers = {dfb},
+    .tensor_parameters = {
+        {.unique_id = INPUT,  .spec = input_tensor.tensor_spec()},
+        {.unique_id = OUTPUT, .spec = output_tensor.tensor_spec()},
+    },
+    .work_units = {{
+        .name = "main",
+        .kernels = {READER, WRITER},
+        .target_nodes = node,
+    }},
+};
+Program program = MakeProgramFromSpec(*mesh_device, spec);
+
+ProgramRunArgs params;
+params.kernel_run_args = {
+    {.kernel = READER,
+     .runtime_arg_values = {{node, {{"num_pages", num_pages}}}}},
+    {.kernel = WRITER,
+     .runtime_arg_values = {{node, {{"num_pages", num_pages}}}}},
+};
+params.tensor_args = {
+    {INPUT,  TensorArgument{input_tensor}},
+    {OUTPUT, TensorArgument{output_tensor}},
+};
+SetProgramRunArgs(program, params);
+```
+
+`ProgramDescriptor` collapses all of placement, schema, and values into one nested struct, while Metal 2.0 keeps each concern visible as its own field. This example demonstrated named CTAs, DFB binding-by-name, derived DFB placement, TensorAccessor binding (replacing the manual `TensorAccessorArgs` plumbing chain on the host and the `TensorAccessorArgs<N>()` offset bookkeeping in the kernel), and mutable / immutable separation.
+
+### Example 2: Multi-Core with Cross-Core Synchronization
+
+Same reader/writer kernels as Example 1, but now running on a 2×2 grid with a semaphore-based handshake. Each node reads (and writes) its own slice of the tensor. Only the deltas are shown — fields that are unchanged from Example 1 are elided with `// (unchanged)`.
+
+**Legacy (`ProgramDescriptor`):**
+
+```cpp
+const CoreRangeSet cores = CoreRangeSet{CoreRange{{0, 0}, {1, 1}}};
+const uint32_t pages_per_core = num_pages / 4;  // 8 / 4 = 2 pages per core
+
+SemaphoreDescriptor done_sem{
+    .id = 0,
+    .core_type = CoreType::WORKER,
+    .core_ranges = cores,
+    .initial_value = 0,
+};
+
+KernelDescriptor reader = {
+    // (unchanged — same TensorAccessor CTAs, kernel source, etc.)
+    .core_ranges = cores,
+    // Per-core runtime args. Same buffer base address on every core; each
+    // core reads a different slice via start_page. Semaphore ID rides as an RTA.
+    .runtime_args = {
+        {{0,0}, {input_tensor.buffer()->address(), 0u,                  pages_per_core, /*sem_id=*/0}},
+        {{1,0}, {input_tensor.buffer()->address(), 1u*pages_per_core,   pages_per_core, 0}},
+        {{0,1}, {input_tensor.buffer()->address(), 2u*pages_per_core,   pages_per_core, 0}},
+        {{1,1}, {input_tensor.buffer()->address(), 3u*pages_per_core,   pages_per_core, 0}},
+    },
+    // ...
+};
+
+ProgramDescriptor program_desc = {
+    .kernels = {reader, writer},
+    .semaphores = {done_sem},
+    .cbs = {cb_desc},
+};
+```
+
+**Metal 2.0:**
+
+```cpp
+const SemaphoreSpecName DONE{"done"};
+const NodeRange cores{{0, 0}, {1, 1}};
+const uint32_t pages_per_node = num_pages / 4;  // 8 / 4 = 2 pages per node
+
+SemaphoreSpec done_sem{
+    .unique_id = DONE,
+    .target_nodes = cores,
+};
+
+KernelSpec reader{
+    // (unchanged — same TensorBinding to INPUT, DFB binding, source, etc.)
+    // No core_ranges — placement comes from WorkUnitSpec, below.
+    // No semaphore in the args — bind it instead:
+    .semaphore_bindings = {{
+        .semaphore_spec_name = DONE,
+        .accessor_name = "done",  // kernel accesses as `sem::done`
+    }},
+    // RTA schema gains start_page so each node knows which slice it owns.
+    // The buffer address is gone — the TensorBinding auto-injects it.
+    .runtime_arg_schema = {.runtime_arg_names = {"start_page", "num_pages"}},
+    // ...
+};
+
+ProgramSpec spec{
+    .name = "loopback_2x2",
+    .kernels = {reader, writer},
+    .dataflow_buffers = {dfb},
+    .semaphores = {done_sem},
+    .tensor_parameters = {
+        {.unique_id = INPUT,  .spec = input_tensor.tensor_spec()},
+        {.unique_id = OUTPUT, .spec = output_tensor.tensor_spec()},
+    },
+    .work_units = {{
+        .name = "main",
+        .kernels = {READER, WRITER},
+        .target_nodes = cores,  // 2×2 grid
+    }},
+};
+Program program = MakeProgramFromSpec(*mesh_device, spec);
+
+ProgramRunArgs params;
+// One runtime_arg_values entry per node where the kernel runs.
+// Tensor identity is singular: one TensorParameter for the input tensor,
+// regardless of how many nodes access it. Per-node access varies via slice
+// indices, not addresses.
+params.kernel_run_args = {{
+    .kernel = READER,
+    .runtime_arg_values = {
+        {{0,0}, {{"start_page", 0u},                  {"num_pages", pages_per_node}}},
+        {{1,0}, {{"start_page", 1u*pages_per_node},   {"num_pages", pages_per_node}}},
+        {{0,1}, {{"start_page", 2u*pages_per_node},   {"num_pages", pages_per_node}}},
+        {{1,1}, {{"start_page", 3u*pages_per_node},   {"num_pages", pages_per_node}}},
+    },
+}, /* writer entry similarly */ };
+params.tensor_args = {
+    {INPUT,  TensorArgument{input_tensor}},
+    {OUTPUT, TensorArgument{output_tensor}},
+};
+SetProgramRunArgs(program, params);
+```
+
+Key differences vs. the legacy pattern:
+
+- Multi-core placement moves from `core_ranges` on each kernel to a single `target_nodes` on the `WorkUnitSpec`.
+- The semaphore is bound at the kernel spec; the semaphore ID no longer travels as a runtime argument. Kernel code accesses it as `sem::done`.
+- **Tensor identity is singular** — one `TensorParameter` per tensor, regardless of how many nodes access it. The legacy column repeats `input_tensor.buffer()->address()` on every node; Metal 2.0 makes that singular by construction. Per-node access varies through `start_page` / `num_pages` slice RTAs only.
+- Per-node runtime args are still per-node, but addressed by `NodeCoord` and named.
+
+---
+
+## Troubleshooting
+
+Common pitfalls when migrating from `ProgramDescriptor`:
+
+- **Don't pass tensor addresses as runtime arguments.** Metal 2.0's `TensorBinding` auto-injects per-enqueue base addresses; that's the supported path. If your migration ports `tensor.buffer()->address()` over verbatim as an RTA, revisit — you want a `TensorBinding`.
+- **Every kernel must belong to a `WorkUnitSpec`.** A kernel listed in `ProgramSpec::kernels` but not referenced by any `WorkUnitSpec::kernels` has no place to run. This will trigger an error.
+- **DFB placement is derived, not specified.** Don't pass a node range to `DataflowBufferSpec` — the DFB lives wherever its bound producer / consumer kernels run. `DataflowBufferSpec` has no `target_nodes` field by design.
+- **Local DFB invariant.** A local DFB's producer and consumer kernels must share *identical* `WorkUnitSpec` membership.
+- **Compile-time arguments are named only.** Positional CTAs are not part of the Metal 2.0 API; use named CTAs throughout.
+- **Runtime varargs are intended for dynamic-count tails.** `num_runtime_varargs` (and `num_common_runtime_varargs`) is the right fit for kernels that consume a variable number of arguments in a loop — e.g., an N-dimensional shape gated on a CTA-known `rank`. For kernels with a fixed set of individually-known arguments, named RTAs are the recommended form, even when porting from a positional legacy interface.
+- **`ProgramRunArgs` requires that every named RTA must be set on every node.** Missing an entry for a node where the kernel runs causes `SetProgramRunArgs` to error. The same applies to varargs. (Note: There is also a power-user `ProgramRunArgsView` API that provides a stateful view into the dispatch buffers; it is not yet supported.)
+
+### Cryptic error → likely cause
+
+When a build error or spec-validator failure doesn't make the fix obvious, search this table for the message text before debugging from scratch. Entries here are cases where the symptom and the fix sit far apart — most other errors are best diagnosed by reading the message directly.
+
+| Symptom (substring to grep for in your output) | Likely cause | Fix |
+|---|---|---|
+| Linker: `undefined reference to 'dfb::...'` (e.g. `dfb::cb_scaled`) inside a kernel TU | Kernel `#include`s the wrong generated header. `dfb::*` lives in `kernel_bindings_generated.h`; `args::*` lives in `kernel_args_generated.h`. | Remove any explicit include of either generated header. The only include a ported kernel adds is `experimental/kernel_args.h` — the framework injects both. |
+| Spec-validator: DataflowBuffer with 0 producers / 0 consumers | Host-side topology mismatch — the DFB was declared but only one end of its pipeline binds it. The other end is bound to a different DFB, missing entirely, or doesn't appear in any kernel's `kernel_bindings`. | Fix on the host: add the missing binding. **Do not** modify the kernel's `wait_front` / `pop_front` calls to mask the imbalance — per-execution DFB state is reinitialized, so a tile produced and never consumed is harmless. |
+| Spec-validator: TensorParameter with 0 TensorBindings | TensorParameter declared but no kernel binds it. | Bind the tensor on the kernel(s) that use it, or remove the parameter. |
+| Spec-validator: `unpack_to_dest_mode` required (or LLK-side dest-accumulator dtype assert) | Compute kernel sets `fp32_dest_acc_en = true` and consumes a `DataType::Float32` DFB, but no `UnpackToDestMode` was set for that DFB on the compute kernel's `ComputeHardwareConfig`. | On the compute kernel's `hw_config` (a `ComputeHardwareConfig`), add an entry to the `unpack_to_dest_mode` table keyed by the DFB's `DFBSpecName`: `unpack_to_dest_mode = {{DFB_NAME, UnpackToDestMode::UnpackToDestFp32}}`. |
+| Spec-validator: aliased-DFB rule failure (size / strict-clique / borrowed-memory consistency) | The DFBs declared via `advanced_options.alias_with` violate one of the three legality rules. | The error names which rule fails. Most common case: a DFB was added on one member's alias list but missed on the other(s) — `advanced_options.alias_with` must form a strict clique (every member names every other member). |
+| `UpdateTensorArgs` `TensorSpec` legality check fires — typically on a fast-path program-cache hit | The op defines a custom `compute_program_hash` that doesn't fold `TensorSpec` into the hash key. The program cache reports a hit, but the cached `ProgramSpec` was built for a different `TensorSpec`. Metal 2.0's `UpdateTensorArgs` legality check (intentionally kept on) catches the resulting mismatch. | **Do not** attempt to update the custom hash to include `TensorSpec`. Revert the op to use the default TTNN hash (reflection-based, naturally folds in `TensorSpec`). Note the revert in `METAL2_PORT_REPORT.md` under "Open items" so the op author can decide whether to reintroduce a corrected custom hash later. The unnecessary cache misses incurred by reverting are the right trade-off vs. silently-incorrect cache hits. |

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/metal2_migration_guide_quasar.md
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/metal2_migration_guide_quasar.md
@@ -1,0 +1,821 @@
+# Metal 2.0 Migration Guide — From the Temporary Quasar APIs
+
+> ⚠️ **STALE — DO NOT READ.** This guide has not been updated for the Metal 2.0 API cleanups landed in PRs #45290 (structural), #45598 (naming), #45160 (disable_implicit_sync relocation), and several others. Field names, type names, namespace paths, and feature locations referenced below are out of date. A full rewrite is pending. If you need Quasar migration guidance in the meantime, ask Audrey directly.
+
+This guide is for Quasar developers migrating from the temporary placeholder APIs in `tt_metal/api/tt-metalium/experimental/host_api.hpp` and `tt_metal/api/tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp` to the new Metal 2.0 host APIs in `tt_metal/api/tt-metalium/experimental/metal2_host_api/`. (For WH/BH migration to Metal 2.0, look [here instead](metal2_migration_guide.md).)
+
+> **Audience**: Internal-only. The temporary Quasar APIs were always meant to be short-lived.
+
+> **Note**: The Metal 2.0 APIs are experimental and subject to change.
+
+The temporary Quasar APIs (`experimental::quasar::CreateKernel`, `experimental::dfb::CreateDataflowBuffer`) will soon be moved out of the public API surface — they will remain accessible to tests, but customer-facing code (i.e. IP customer deliverables) should use the Metal 2.0 APIs covered in this guide. Metal 2.0 has feature parity with the temporary Quasar APIs.
+
+> **Prerequisites**: Before moving to Metal 2.0, ensure your device DM code is Device 2.0 compliant [Device 2.0 Data Movement migration](../../kernel_apis/data_movement/device_api_migration_guide.md).
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Concept Map](#concept-map)
+3. [Header Files](#header-files)
+4. [Host API Migration](#host-api-migration)
+   - [ProgramSpec](#programspec)
+   - [KernelSpec](#kernelspec)
+   - [DataflowBufferSpec](#dataflowbufferspec)
+   - [SemaphoreSpec](#semaphorespec)
+   - [TensorParameter](#tensorparameter)
+   - [WorkUnitSpec](#workunitspec)
+   - [ProgramRunParams](#programrunparams)
+5. [Device-Side Migration](#device-side-migration)
+   - [Circular Buffers → Dataflow Buffers](#circular-buffers--dataflow-buffers)
+   - [TensorAccessor](#tensoraccessor)
+   - [Kernel Argument Retrieval Syntax](#kernel-argument-retrieval-syntax)
+6. [Complete Migration Example](#complete-migration-example)
+7. [Troubleshooting](#troubleshooting)
+
+---
+
+## Overview
+
+The temporary Quasar host APIs were meant as a placeholder to unblock early Quasar bring-up. The Metal 2.0 host APIs are the user-facing replacement.
+
+The temporary Quasar APIs are imperative builders based on the legacy `host_api.hpp`:
+ - (custom) `experimental::quasar::CreateKernel`
+ - (custom) `experimental::dfb::CreateDataflowBuffer`
+ - standard `host_api.hpp` calls
+     - `CreateProgram`
+     - `CreateSemaphore`
+     - `SetRuntimeArgs`, ...)
+
+Metal 2.0 is a descriptor-based API: you populate a `ProgramSpec` data structure describing the entire program, then call `MakeProgramFromSpec(spec)` to build it.
+
+Two style shifts to watch for during migration:
+
+> **Stated goal: eliminate raw pointer arguments.** With DFBs, semaphores, and tensors all bindable as named resources, runtime args carrying a buffer or tensor address should now be the exception rather than the rule. If you're about to put `tensor.buffer()->address()` in a runtime arg, you're probably doing it wrong — bind the tensor as a `TensorParameter` instead.
+
+> **Argument naming.** Metal 2.0 is designed around named arguments. Compile-time arguments must be named — positional CTAs are no longer part of the API. Runtime and common runtime arguments may be named (the typical case) or positional (varargs, intended for kernels with a genuinely dynamic argument count consumed in a loop — e.g., an N-dimensional shape where N is a CTA). When porting from a legacy kernel, individually-known RTAs translate naturally to named RTAs; reach for varargs only when the kernel actually loops over the arguments.
+
+---
+
+## Concept Map
+
+| ProgramDescriptor (legacy) | Metal 2.0 |
+|---|---|
+| `ProgramDescriptor` | `ProgramSpec` (immutable description) + `ProgramRunParams` (per-execution values) |
+| `KernelDescriptor` | `KernelSpec` |
+| `KernelDescriptor::core_ranges` | derived from `WorkUnitSpec::target_nodes` |
+| `KernelDescriptor::compile_time_args` (positional) | `KernelSpec::compile_time_arg_bindings` (named *only*) |
+| `KernelDescriptor::runtime_args` / `common_runtime_args` | **Schema** (names): declared on `KernelSpec::runtime_arguments_schema`<br>**Values**: supplied per execution on `ProgramRunParams::KernelRunParams` |
+| `CBDescriptor` | `DataflowBufferSpec` (placement derived from kernel bindings) |
+| `SemaphoreDescriptor` | `SemaphoreSpec` |
+| `TensorAccessorArgs<...>` <br> (plumbing + buffer-address RTA) | `TensorAccessor(ta::name)` in the kernel code; <br>`TensorParameter` on `ProgramSpec` (parallel to DFB / Semaphore) |
+| *(no analogue)* | `WorkUnitSpec` — declares groups of kernels that operate together on a worker node, and on which nodes they run |
+| `CoreCoord` / `CoreRange` / `CoreRangeSet`  | `NodeCoord` / `NodeRange` / `NodeRangeSet` |
+
+> **Terminology Note**: Metal 2.0 renames "core" to "node" to disambiguate a previously overloaded term. The legacy "core" was used for both individual RISC-V cores within a node *and* for the larger hardware unit at a given (x,y) NoC address. In Metal 2.0, "node" means the latter.
+
+---
+
+## Header Files
+
+```cpp
+#include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_params.hpp>
+```
+
+Sub-headers are pulled in transitively:
+ - `kernel_spec.hpp`
+ - `dataflow_buffer_spec.hpp`
+ - `semaphore_spec.hpp`
+ - `tensor_parameter.hpp`
+
+**These header files are self-documenting, with extensive comments.** Please read them!
+
+All Metal 2.0 host API symbols currently live in the `tt::tt_metal::experimental::metal2_host_api` namespace.
+
+> **Note:** The Program-creation entry points in `metal2_host_api/program.hpp` are *temporary*. Migration to the final form will take place when the APIs leave `experimental` to join the main API directory. User code updates will be trivial.
+
+
+---
+
+## Host API Migration
+
+### ProgramSpec
+See `program_spec.hpp`.
+
+**Legacy:**
+
+```cpp
+Program program = CreateProgram();
+
+KernelHandle reader_h = experimental::quasar::CreateKernel(
+    program, "kernels/reader.cpp", core_spec, dm_config);
+KernelHandle writer_h = experimental::quasar::CreateKernel(
+    program, "kernels/writer.cpp", core_spec, dm_config);
+
+uint32_t dfb_id = experimental::dfb::CreateDataflowBuffer(program, core_spec, dfb_config);
+experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
+    program, dfb_id, reader_h, writer_h);
+
+CreateSemaphore(program, core_spec, /*initial_value=*/0);
+
+SetRuntimeArgs(program, reader_h, core, {start_page, num_pages});
+SetRuntimeArgs(program, writer_h, core, {start_page, num_pages});
+
+EnqueueProgram(cq, program, /*blocking=*/false);
+```
+
+**Metal 2.0:**
+
+```cpp
+ProgramSpec spec{
+    .program_id = "my_program",
+    .kernels = {reader, writer},
+    .dataflow_buffers = {dfb},
+    .semaphores = {sem},
+    .work_units = {main_work_unit},
+};
+Program program = MakeProgramFromSpec(spec);  // (temporary free function)
+
+ProgramRunParams params;
+params.kernel_run_params = { /* per-execution argument values */ };
+SetProgramRunParameters(program, params);  // (temporary free function)
+
+EnqueueProgram(cq, program, /*blocking=*/false);
+```
+
+---
+
+### KernelSpec
+See `kernel_spec.hpp`.
+
+The Quasar `experimental::quasar::CreateKernel` family is replaced by populating `KernelSpec`, and adding it to `ProgramSpec::kernels`. This is the difference between a builder API and a descriptor API. You don't add kernels to the Program imperatively; they are declared as data and consumed at the end at Program creation.
+
+**Legacy:**
+
+```cpp
+Program program;
+
+QuasarDataMovementConfig dm_config{
+    .num_threads_per_cluster = 8,
+    .compile_args = {src_cb_idx, dst_cb_idx, page_size},
+};
+KernelHandle reader_handle = experimental::quasar::CreateKernel(
+    program,
+    "kernels/reader.cpp",
+    CoreCoord{0, 0},
+    dm_config);
+
+SetRuntimeArgs(program, reader_handle, CoreCoord{0, 0}, {start_page, num_pages});
+```
+
+**Metal 2.0:**
+
+```cpp
+// ----- KernelSpec: kernel declaration -----
+constexpr const char* READER = "reader";
+
+KernelSpec reader{
+    .unique_id = READER,
+    .source = KernelSpec::SourceFilePath{"kernels/reader.cpp"},
+    .num_threads = 6,  // Metal 2.0 reserves DM0/DM1; max user threads = 6.
+    // (Placement is declared on WorkUnitSpec, below.)
+    .compile_time_arg_bindings = {
+        {"src_cb_idx", src_cb_idx},
+        {"dst_cb_idx", dst_cb_idx},
+        {"page_size", page_size},
+    },
+    .runtime_arguments_schema = {
+        // Schema only — argument values are set per execution, on ProgramRunParams.
+        .named_runtime_args = {"start_page", "num_pages"},
+    },
+    .config_spec = DataMovementConfiguration{
+        .gen2_data_movement_config = DataMovementConfiguration::Gen2DataMovementConfig{},
+    },
+};
+
+// ----- WorkUnitSpec: where the kernel runs -----
+WorkUnitSpec main_work_unit{
+    .unique_id = "main",
+    .kernels = {READER},
+    .target_nodes = NodeCoord{0, 0},
+};
+
+// ----- ProgramSpec: assemble into the program description -----
+ProgramSpec spec{
+    .program_id = "my_program",
+    .kernels = {reader},
+    .work_units = {main_work_unit},
+};
+Program program = MakeProgramFromSpec(spec);  // temporary free function
+
+// ----- ProgramRunParams: argument values, set per execution -----
+ProgramRunParams params;
+params.kernel_run_params = {{
+    .kernel_spec_name = READER,
+    .named_runtime_args = {{NodeCoord{0, 0},
+        {{"start_page", start_page}, {"num_pages", num_pages}}}},
+}};
+SetProgramRunParameters(program, params);  // temporary free function
+```
+
+Reuse a single `constexpr const char*` for `unique_id` everywhere the kernel is referenced (`WorkUnitSpec`, `ProgramRunParams`, DFB and semaphore bindings) — this catches typos at compile time.
+
+> **New DM thread cap**: `QuasarDataMovementConfig::num_threads_per_cluster` allowed up to 8 DM threads. Metal 2.0 reserves DM0 and DM1 for runtime use, so `KernelSpec::num_threads` is capped at 6 for DM kernels. Specifying 7 or 8 will fail validation.
+
+---
+
+### DataflowBufferSpec
+See `dataflow_buffer_spec.hpp`.
+
+`DataflowBufferSpec` replaces the two-step Quasar pattern — `experimental::dfb::CreateDataflowBuffer` followed by `BindDataflowBufferToProducerConsumerKernels`.
+
+Changes:
+
+1. **Placement is derived, not specified.** The DFB lives wherever its bound producer / consumer kernels run; you don't pass a `core_spec` to the DFB. The runtime now infers everything that the legacy bind-after-create call had to be told (which RISCs, how many threads, etc.). Local DFB producer and consumer kernels must have identical `WorkUnitSpec` membership.
+2. **Endpoints are bound at the kernel spec.** Each producer / consumer kernel declares a `DFBBinding` on its `KernelSpec`, naming the DFB and a local accessor name. The kernel code references the DFB through that local accessor name (e.g. `dfb::my_dfb`).
+
+**Legacy:**
+
+```cpp
+experimental::dfb::DataflowBufferConfig dfb_config{
+    .entry_size = page_size,
+    .num_entries = num_pages,
+    .producer_risc_mask = 0x01,  // DM0
+    .consumer_risc_mask = 0x02,  // DM1
+    .pap = experimental::dfb::AccessPattern::STRIDED,
+    .cap = experimental::dfb::AccessPattern::STRIDED,
+    .data_format = tt::DataFormat::Float16_b,
+};
+uint32_t dfb_id = experimental::dfb::CreateDataflowBuffer(program, core_spec, dfb_config);
+experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
+    program, dfb_id, producer_handle, consumer_handle);
+```
+
+**Metal 2.0:**
+
+```cpp
+constexpr const char* MY_DFB = "my_dfb";
+
+DataflowBufferSpec dfb{
+    .unique_id = MY_DFB,
+    .entry_size = page_size,
+    .num_entries = num_pages,
+    .data_format_metadata = tt::DataFormat::Float16_b,
+    // No core_spec, no producer/consumer RISC masks — derived from kernel bindings.
+};
+
+// Bound on each kernel that uses the DFB:
+KernelSpec producer{ /* ... */
+    .dfb_bindings = {{
+        .dfb_spec_name = MY_DFB,
+        .local_accessor_name = "out_dfb",
+        .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER,
+        .access_pattern = DFBAccessPattern::STRIDED,
+    }},
+};
+KernelSpec consumer{ /* ... */
+    .dfb_bindings = {{
+        .dfb_spec_name = MY_DFB,
+        .local_accessor_name = "in_dfb",  // independent of the producer's name
+        .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER,
+        .access_pattern = DFBAccessPattern::STRIDED,
+    }},
+};
+```
+
+Each `local_accessor_name` is independent per binding; the producer and consumer can name the same DFB differently in their respective kernel sources. The producer/consumer RISC masks that the legacy `DataflowBufferConfig` carried are no longer needed: the runtime determines RISC assignment from the kernel bindings.
+
+**Borrowed-memory DFBs.** A DFB can be built on top of an existing `Buffer`'s memory rather than allocating its own L1 storage — the Metal 2.0 form of the legacy "dynamic circular buffer." Set `DataflowBufferSpec::borrowed_from` to the name of a `TensorParameter` whose buffer backs the DFB; the DFB's L1 address resolves at runtime from the corresponding `TensorArg` in `ProgramRunParams::tensor_args`.
+
+**Aliased DFBs.** Two or more DFBs can share backing L1 memory via `DataflowBufferSpec::alias_with`. The aliased DFBs are logically distinct (each has its own `unique_id` and bindings) but physically occupy the same L1 region — useful when same-shape DFBs are produced and consumed in non-overlapping phases. All aliased DFBs must have the same total size (`num_entries * entry_size`), must be bound to the same kernels, and must mutually declare each other in `alias_with`. Aliased DFBs offer no guarantee against data clobbering; correctness is the kernel author's responsibility.
+
+Remote DFBs are exposed in `dataflow_buffer_spec.hpp` but aren't supported yet.
+
+---
+
+### SemaphoreSpec
+
+`SemaphoreSpec` replaces `CreateSemaphore`. Changes:
+
+1. **Descriptor API**, no longer minted by an imperative `CreateSemaphore` call into a Program object.
+2. **Semaphore IDs no longer travel as runtime arguments.** Each kernel that uses a semaphore declares a `SemaphoreBinding` naming it and giving it a local accessor name; kernel code accesses it as `sem::accessor_name`.
+
+Unlike DFBs, semaphore placement is *not* derived: a semaphore is a remote resource accessible from any kernel, so its node set is specified directly via `target_nodes`.
+
+**Legacy:**
+
+```cpp
+uint32_t sem_id = CreateSemaphore(program, core_spec, /*initial_value=*/0);
+
+// Pass the ID to kernels that need it, as a runtime arg:
+SetRuntimeArgs(program, reader_h, core, {/* ... */, sem_id});
+```
+
+**Metal 2.0:**
+
+```cpp
+constexpr const char* DONE = "done";
+
+SemaphoreSpec done_sem{
+    .unique_id = DONE,
+    .target_nodes = NodeRange{{0,0}, {3,3}},
+};
+
+// Bound on each kernel that uses the semaphore:
+KernelSpec writer{ /* ... */
+    .semaphore_bindings = {{
+        .semaphore_spec_name = DONE,
+        .accessor_name = "done",  // kernel code accesses as `sem::done`
+    }},
+};
+```
+
+Notes:
+
+- `SemaphoreSpec::SemaphoreMemoryType::Register` is a placeholder for a Gen2 hardware feature (register-backed semaphores); it is not yet supported. Only `L1` works today. If we ever decide to support `Register`, we'll hopefully automate the L1 / Register selection on Quasar.
+- Setting `initial_value` to a non-zero value is not supported on Gen2 (for compatibility with Register-based semaphores). We hope to deprecate non-zero initial values on Gen 1 as well, with the help of remote DFB.
+
+---
+
+### TensorParameter
+
+`TensorParameter` declares a tensor as a Program-scope resource. Kernels access it via `KernelSpec::TensorBinding`; the runtime `MeshTensor` is supplied per execution via `ProgramRunParams::TensorArg`. The kernel-author API collapses to a single line: `TensorAccessor(ta::name)`.
+
+Three pieces, paralleling the DFB / Semaphore pattern with one deliberate asymmetry: tensors are *user-managed* resources (you own the lifetime), so the program-scope type is named `TensorParameter` rather than `TensorSpec`.
+
+> **⚠ Pre-migration check.** If your kernel sources contain `ArgConfig::RuntimeTensorShape`, this op cannot migrate to Metal 2.0 yet — Metal 2.0 has no positional-CTA mechanism, so the legacy plumbing has no equivalent. (`RuntimeTensorShape` is a production-op feature; you almost certainly won't encounter it in Quasar tests.)
+
+#### Legacy
+
+```cpp
+// host: append TensorAccessor args to the kernel's positional CTA list,
+// pass the buffer base address as a runtime arg.
+std::vector<uint32_t> reader_cta = {page_size};
+tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(reader_cta);
+
+experimental::quasar::QuasarDataMovementConfig reader_config{
+    .num_threads_per_cluster = 3,
+    .compile_args = reader_cta,
+};
+KernelHandle reader_h = experimental::quasar::CreateKernel(
+    program, "kernels/reader.cpp", cluster, reader_config);
+SetRuntimeArgs(program, reader_h, cluster, {input_tensor.buffer()->address(), num_pages});
+```
+
+```cpp
+// kernel: read the buffer address from the RTA list, manually thread
+// CTA offsets to construct TensorAccessorArgs, then build the accessor.
+constexpr uint32_t page_size = get_compile_time_arg_val(0);
+constexpr auto input_args = TensorAccessorArgs<1>();   // 1 = number of preceding CTAs
+uint32_t input_addr = get_arg_val<uint32_t>(0);
+auto input = TensorAccessor(input_args, input_addr);
+```
+
+#### Metal 2.0
+
+```cpp
+constexpr const char* INPUT = "input";
+
+// In ProgramSpec — declare the tensor as a Program-scope parameter.
+ProgramSpec spec;
+spec.tensor_parameters = {
+    {.unique_id = INPUT, .spec = input_tensor.tensor_spec()},
+};
+
+// In KernelSpec — bind the parameter, naming the kernel-side accessor.
+KernelSpec reader{ /* ... */
+    .tensor_bindings = {{
+        .tensor_parameter_name = INPUT,
+        .accessor_name = "input",   // kernel accesses as `ta::input`
+    }},
+};
+spec.kernels = {reader};
+
+Program program = MakeProgramFromSpec(*mesh_device, spec);
+
+// In ProgramRunParams — supply the actual MeshTensor per execution.
+ProgramRunParams params;
+params.tensor_args = {
+    {.tensor_parameter_name = INPUT, .tensor = input_tensor},
+};
+SetProgramRunParameters(program, params);
+```
+
+```cpp
+// kernel: one line. No CTA-offset bookkeeping, no buffer-address RTA.
+auto input = TensorAccessor(ta::input);
+```
+
+The buffer-address RTA is gone — the binding mechanism auto-injects the per-enqueue base address. The `TensorAccessorArgs<N>()` line is gone too — the layout metadata is packed by the host at program creation.
+
+#### Migration recipe
+
+For each test:
+
+1. **Find each `TensorAccessor`.** In each kernel, locate every `TensorAccessor(args, addr)` construction. For each, trace `addr` back through the host code to the originating `Tensor`.
+2. **Declare `TensorParameter`s.** Add one entry per tensor to `ProgramSpec::tensor_parameters`, using `tensor.tensor_spec()`. Pick a stable `unique_id` constant.
+3. **Add `TensorBinding`s.** On each `KernelSpec` whose kernel accesses the tensor, add an entry to `tensor_bindings`. The `accessor_name` will appear as `ta::<accessor_name>` in the kernel.
+4. **Update kernel code.**
+   - Replace `TensorAccessor(args, addr)` with `TensorAccessor(ta::<accessor_name>)`.
+   - Drop the `TensorAccessorArgs<offset>()` line.
+   - Drop the `get_arg_val<uint32_t>(N)` line that retrieved the buffer address — re-index any RTAs that came after.
+5. **Wire `tensor_args`.** Add one `TensorArg` per `TensorParameter` to `ProgramRunParams::tensor_args`, passing the actual `MeshTensor`.
+
+#### Validation
+
+At enqueue, the runtime `MeshTensor`'s `TensorSpec` must equal the binding's declared spec. Mismatches error loudly with a message naming the binding.
+
+---
+
+### WorkUnitSpec
+
+`WorkUnitSpec` is a new top-level concept that replaces the `core_spec` argument from `experimental::quasar::CreateKernel` (and from `experimental::dfb::CreateDataflowBuffer`). It declares groups of kernels that operate together on a worker node, and on which nodes they run.
+
+**Single work unit on one node:**
+
+```cpp
+WorkUnitSpec wu{
+    .unique_id = "main",
+    .kernels = {READER, WRITER},
+    .target_nodes = NodeCoord{0, 0},
+};
+```
+
+**One work unit spanning a range of nodes:**
+
+```cpp
+WorkUnitSpec wu{
+    .unique_id = "main",
+    .kernels = {READER, COMPUTE, WRITER},
+    .target_nodes = NodeRange{{0, 0}, {3, 3}},  // 4×4 grid
+};
+```
+
+**A kernel belonging to multiple work units** — for example, a compute kernel that runs on both an inner block (paired with one reader/writer) and a halo region (paired with a different reader/writer):
+
+```cpp
+WorkUnitSpec wu_inner{
+    .unique_id = "inner",
+    .kernels = {COMPUTE, INNER_READER},
+    .target_nodes = NodeRange{{1, 1}, {2, 2}},
+};
+WorkUnitSpec wu_halo{
+    .unique_id = "halo",
+    .kernels = {COMPUTE, HALO_READER},
+    .target_nodes = halo_node_range_set,
+};
+// COMPUTE's effective node set is the union: inner ∪ halo.
+```
+
+---
+
+### ProgramRunParams
+
+`ProgramRunParams` replaces `SetRuntimeArgs(program, kernel_handle, core, args)` and related APIs. The kernel declares its runtime-arg *schema*; values are supplied per execution via `ProgramRunParams`. Tensor arguments — one `MeshTensor` per declared `TensorParameter` — also live on `ProgramRunParams::tensor_args` (see [TensorParameter](#tensorparameter)).
+
+**Legacy:**
+
+```cpp
+// All arguments are positional
+SetRuntimeArgs(program, reader_h, core, {start_page, num_pages, sem_id});
+SetCommonRuntimeArgs(program, reader_h, {bank_id});
+```
+
+**Metal 2.0:**
+
+```cpp
+// Schema declared on the kernel (with named arguments!):
+KernelSpec reader{
+    .unique_id = READER,
+    // ...
+    .runtime_arguments_schema = {
+        .named_runtime_args = {"start_page", "num_pages"},
+        .named_common_runtime_args = {"bank_id"},
+    },
+    // (sem_id no longer travels as a runtime arg — bind the semaphore instead.)
+};
+
+// Values supplied per execution:
+ProgramRunParams params;
+params.kernel_run_params = {{
+    .kernel_spec_name = READER,
+    .named_runtime_args = {{NodeCoord{0, 0},
+        {{"start_page", start_page}, {"num_pages", num_pages}}}},
+    .named_common_runtime_args = {{"bank_id", bank_id}},
+}};
+SetProgramRunParameters(program, params);  // temporary free function
+```
+
+Some kernels can't get away with just named arguments — they're written to consume a dynamic-count argument tail (e.g. variable tensor rank), retrieved in a loop on the device. For those, varargs:
+
+```cpp
+// Schema:
+.compile_time_arg_bindings = {{"rank", rank}},
+.runtime_arguments_schema = {
+    .num_runtime_varargs = rank,  // shape: one entry per dimension
+},
+
+// Values:
+.runtime_varargs = {{NodeCoord{0, 0}, shape_dims}},  // shape_dims.size() == rank
+```
+
+Named and vararg forms can coexist on the same kernel. Vararg indices are stable across schema changes. Common runtime varargs (`num_common_runtime_varargs`, retrieved on the device via `get_common_vararg(i)`) work analogously, broadcast across all nodes.
+
+> The vararg form is intended for kernels whose device-side code retrieves arguments in a loop — i.e., `get_vararg(i)` with `i` a runtime variable. When the kernel reads each argument by a constant index (`get_vararg(0)`, `get_vararg(1)`, …), the named form reads more clearly on both sides.
+
+`ProgramRunParams` must be specified for every kernel that has runtime arguments, on every node where the kernel runs. Kernel handles are gone — kernels are referenced by `unique_id` string (`kernel_spec_name`).
+
+There's a "power user, efficient inner loop" version of the runtime args update API: `ProgramRunParamsView`. It's not implemented yet.
+
+---
+
+## Device-Side Migration
+
+### TensorAccessor
+
+Construction collapses to one line. `TensorAccessor` takes the codegen-emitted token directly; everything else is unchanged from today (`get_noc_addr`, `get_bank_and_offset`, `dspec()`, `noc_async_read_page`, etc.).
+
+The token lives in the `ta::` namespace inside `kernel_bindings_generated.h` (auto-generated from the host-side `TensorBinding`), parallel to the `dfb::` and `sem::` namespaces.
+
+**Legacy:**
+
+```cpp
+constexpr uint32_t page_size = get_compile_time_arg_val(0);
+constexpr auto input_args = TensorAccessorArgs<1>();
+uint32_t input_addr = get_arg_val<uint32_t>(0);
+auto input = TensorAccessor(input_args, input_addr);
+```
+
+**Metal 2.0:**
+
+```cpp
+auto input = TensorAccessor(ta::input);
+```
+
+The `TensorAccessorArgs<N>()` line, the manual `next_compile_time_args_offset()` chaining for multi-tensor stacking, and the buffer-address RTA are all gone. Layout metadata is packed by the host into the kernel's compile-time args at program creation; the per-enqueue base address rides on a host-managed CRTA slot the kernel never sees directly.
+
+See [TensorParameter](#tensorparameter) for the host-side declaration that produces the `ta::` namespace.
+
+---
+
+### Kernel Argument Retrieval Syntax
+
+The Metal 2.0 host API declares kernel arguments by name; the kernel-side API retrieves them by name. This replaces the legacy positional `get_arg_val<uint32_t>(N)` style.
+
+**The only `#include` a porter adds to a kernel is `experimental/kernel_args.h`** — that pulls in the accessor templates (`get_arg`, `args::`, `dfb::`, `sem::`, `ta::`). The generated headers `kernel_bindings_generated.h` (which carries `dfb::` / `sem::` / `ta::` declarations from the host bindings) and `kernel_args_generated.h` (which carries `args::` declarations from `compile_time_arg_bindings` + `runtime_arguments_schema`) are auto-included by the build system via `<kernel_includes.hpp>` before the kernel source. **Do not** `#include` either generated header from your kernel.
+
+**Example 1 — Named arguments only.**
+
+Suppose the host declared the following on `KernelSpec`:
+
+```cpp
+.compile_time_arg_bindings = {{"bank_id", 0}, {"entry_size", 1024}},
+.runtime_arguments_schema = {
+    .named_runtime_args = {"start_page"},
+    .named_common_runtime_args = {"num_entries"},
+},
+```
+
+**Legacy (positional):**
+
+```cpp
+void kernel_main() {
+    constexpr uint32_t bank_id    = get_compile_time_arg_val(0);
+    constexpr uint32_t entry_size = get_compile_time_arg_val(1);
+    uint32_t start_page    = get_arg_val<uint32_t>(0);    // RTA index 0
+    uint32_t num_entries = get_common_arg_val<uint32_t>(0);  // CRTA index 0
+    // ...
+}
+```
+
+**Metal 2.0 (named):**
+
+```cpp
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    constexpr auto bank_id    = get_arg(args::bank_id);     // CTA — compile-time constant
+    constexpr auto entry_size = get_arg(args::entry_size);  // CTA
+    auto start_page             = get_arg(args::start_page);    // RTA
+    const auto num_entries    = get_arg(args::num_entries); // CRTA
+    // ...
+}
+```
+
+CTAs, RTAs, and CRTAs are accessed through the same `get_arg(args::name)` mechanism in device code. The dispatch type (compile-time, runtime, common runtime) is a host-only concept — the kernel author no longer needs to know or care which kind of argument they're reading. The C++ type-deduction context (`constexpr auto`, `auto`, `const auto`) is the only place the distinction surfaces.
+
+**Example 2 — Named arguments plus varargs (the niche case).**
+
+Some kernels read a dynamic-count argument tail in a loop — e.g. an N-dimensional tensor's shape, where N is itself a CTA. That's the case varargs are designed for:
+
+```cpp
+.compile_time_arg_bindings = {{"rank", rank}},
+.runtime_arguments_schema = {
+    .named_runtime_args = {"start_page"},
+    .named_common_runtime_args = {"num_entries"},
+    .num_runtime_varargs = rank,  // shape: one entry per dimension
+},
+```
+
+```cpp
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    constexpr auto rank      = get_arg(args::rank);          // CTA
+    auto start_page          = get_arg(args::start_page);    // RTA
+    const auto num_entries   = get_arg(args::num_entries);   // CRTA
+
+    // Vararg RTAs read in a loop — count is bound to `rank`:
+    uint32_t shape[rank];
+    for (uint32_t i = 0; i < rank; ++i) {
+        shape[i] = get_vararg(i);
+    }
+    // ...
+}
+```
+
+Common runtime varargs are analogous: declare with `num_common_runtime_varargs`, retrieve on the device with `get_common_vararg(i)`. Same loop-retrieval criterion applies.
+
+> When porting a legacy kernel with positional RTAs, the natural Metal 2.0 form is named RTAs — one per legacy positional argument. A translation into vararg slots compiles and runs (and may be useful as an interim step on a large kernel), but the named form is the recommended endpoint for new code. The distinguishing criterion is whether the kernel's device-side `get_vararg(i)` calls use `i` as a runtime variable (varargs are appropriate) or constants (named RTAs are clearer).
+
+Vararg indices are stable across schema changes: promoting a named RTA to a CRTA, or adding or removing named arguments, does not shift vararg indices. (This stability lets you migrate incrementally — rename arguments to named form one at a time without disturbing the remaining varargs.)
+
+> **Note**: This argument-retrieval syntax will evolve again to support custom argument types beyond `uint32_t` (including user-defined POD types). The named-accessor mechanism (`get_arg(args::name)`) will be preserved; the underlying types will become user-extensible.
+
+---
+
+## Complete Migration Example
+
+Reader kernel reads pages from an input tensor into a DFB; writer kernel pulls from the DFB and writes pages to an output tensor. Multi-threaded kernels (3 producer threads, 3 consumer threads — at Metal 2.0's 6-DM-thread cap) on a single Quasar cluster, no semaphores. End-to-end host code.
+
+**Legacy:**
+
+```cpp
+constexpr uint32_t page_size = 1024;
+constexpr uint32_t num_pages = 8;
+const CoreCoord cluster{0, 0};
+
+Program program = CreateProgram();
+
+// Reader kernel — 3 threads. Append TensorAccessor args to the CTA list.
+std::vector<uint32_t> reader_cta = {page_size};
+tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(reader_cta);
+
+experimental::quasar::QuasarDataMovementConfig reader_config{
+    .num_threads_per_cluster = 3,
+    .compile_args = reader_cta,
+};
+KernelHandle reader_h = experimental::quasar::CreateKernel(
+    program, "kernels/reader.cpp", cluster, reader_config);
+
+// Writer kernel — 3 threads. Same shape on the output side.
+std::vector<uint32_t> writer_cta = {page_size};
+tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(writer_cta);
+
+experimental::quasar::QuasarDataMovementConfig writer_config{
+    .num_threads_per_cluster = 3,
+    .compile_args = writer_cta,
+};
+KernelHandle writer_h = experimental::quasar::CreateKernel(
+    program, "kernels/writer.cpp", cluster, writer_config);
+
+// DFB — multi-threaded producer (DM0-DM2) and consumer (DM3-DM5)
+experimental::dfb::DataflowBufferConfig dfb_config{
+    .entry_size = page_size,
+    .num_entries = num_pages,
+    .producer_risc_mask = 0x07,  // DM0 | DM1 | DM2
+    .num_producers = 3,
+    .pap = experimental::dfb::AccessPattern::STRIDED,
+    .consumer_risc_mask = 0x38,  // DM3 | DM4 | DM5
+    .num_consumers = 3,
+    .cap = experimental::dfb::AccessPattern::STRIDED,
+    .data_format = tt::DataFormat::Float16_b,
+};
+uint32_t dfb_id = experimental::dfb::CreateDataflowBuffer(program, cluster, dfb_config);
+experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
+    program, dfb_id, reader_h, writer_h);
+
+// Runtime args — buffer addresses ride as RTAs.
+SetRuntimeArgs(program, reader_h, cluster, {input_tensor.buffer()->address(), num_pages});
+SetRuntimeArgs(program, writer_h, cluster, {output_tensor.buffer()->address(), num_pages});
+
+EnqueueProgram(cq, program, /*blocking=*/false);
+```
+
+**Metal 2.0:**
+
+```cpp
+constexpr const char* READER = "reader";
+constexpr const char* WRITER = "writer";
+constexpr const char* DFB    = "loopback_dfb";
+constexpr const char* INPUT  = "input";
+constexpr const char* OUTPUT = "output";
+
+constexpr uint32_t page_size = 1024;
+constexpr uint32_t num_pages = 8;
+const NodeCoord node{0, 0};
+
+KernelSpec reader{
+    .unique_id = READER,
+    .source = KernelSpec::SourceFilePath{"kernels/reader.cpp"},
+    .num_threads = 3,  // 3 producer threads
+    .compile_time_arg_bindings = {{"page_size", page_size}},
+    .runtime_arguments_schema = {.named_runtime_args = {"num_pages"}},
+    .dfb_bindings = {{
+        .dfb_spec_name = DFB,
+        .local_accessor_name = "out_dfb",
+        .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER,
+        .access_pattern = DFBAccessPattern::STRIDED,
+    }},
+    .tensor_bindings = {{
+        .tensor_parameter_name = INPUT,
+        .accessor_name = "input",   // kernel accesses as `ta::input`
+    }},
+    .config_spec = DataMovementConfiguration{
+        .gen2_data_movement_config = DataMovementConfiguration::Gen2DataMovementConfig{},
+    },
+};
+
+KernelSpec writer{
+    .unique_id = WRITER,
+    .source = KernelSpec::SourceFilePath{"kernels/writer.cpp"},
+    .num_threads = 3,  // 3 consumer threads
+    .compile_time_arg_bindings = {{"page_size", page_size}},
+    .runtime_arguments_schema = {.named_runtime_args = {"num_pages"}},
+    .dfb_bindings = {{
+        .dfb_spec_name = DFB,
+        .local_accessor_name = "in_dfb",
+        .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER,
+        .access_pattern = DFBAccessPattern::STRIDED,
+    }},
+    .tensor_bindings = {{
+        .tensor_parameter_name = OUTPUT,
+        .accessor_name = "output",  // kernel accesses as `ta::output`
+    }},
+    .config_spec = DataMovementConfiguration{
+        .gen2_data_movement_config = DataMovementConfiguration::Gen2DataMovementConfig{},
+    },
+};
+
+DataflowBufferSpec dfb{
+    .unique_id = DFB,
+    .entry_size = page_size,
+    .num_entries = num_pages,
+    .data_format_metadata = tt::DataFormat::Float16_b,
+};
+
+ProgramSpec spec{
+    .program_id = "loopback",
+    .kernels = {reader, writer},
+    .dataflow_buffers = {dfb},
+    .tensor_parameters = {
+        {.unique_id = INPUT,  .spec = input_tensor.tensor_spec()},
+        {.unique_id = OUTPUT, .spec = output_tensor.tensor_spec()},
+    },
+    .work_units = {{
+        .unique_id = "main",
+        .kernels = {READER, WRITER},
+        .target_nodes = node,
+    }},
+};
+Program program = MakeProgramFromSpec(*mesh_device, spec);
+
+ProgramRunParams params;
+params.kernel_run_params = {
+    {.kernel_spec_name = READER,
+     .named_runtime_args = {{node, {{"num_pages", num_pages}}}}},
+    {.kernel_spec_name = WRITER,
+     .named_runtime_args = {{node, {{"num_pages", num_pages}}}}},
+};
+params.tensor_args = {
+    {.tensor_parameter_name = INPUT,  .tensor = input_tensor},
+    {.tensor_parameter_name = OUTPUT, .tensor = output_tensor},
+};
+SetProgramRunParameters(program, params);
+
+EnqueueProgram(cq, program, /*blocking=*/false);
+```
+
+The Metal 2.0 form is more verbose, but carries additional structure. DFB endpoint information, in particular, was scattered across `DataflowBufferConfig` (RISC masks, access patterns) and the subsequent `BindDataflowBufferToProducerConsumerKernels` call (kernel handles); in Metal 2.0 it lives entirely on each `KernelSpec::dfb_bindings`. Tensor identity moves out of runtime args entirely — `TensorParameter` declarations live alongside DFBs at the program level, and the kernel-side `TensorAccessorArgs<N>()` offset bookkeeping disappears.
+
+---
+
+## Troubleshooting
+
+Common pitfalls when migrating from the temporary Quasar APIs:
+
+- **Don't pass tensor addresses as runtime arguments.** Metal 2.0's `TensorBinding` auto-injects per-enqueue base addresses; that's the supported path. If your migration ports `tensor.buffer()->address()` over verbatim as an RTA, revisit — you want a `TensorBinding`.
+- **Runtime varargs are intended for dynamic-count tails.** `num_runtime_varargs` is the right fit for kernels that consume a variable number of arguments in a loop — e.g., an N-dimensional shape gated on a CTA-known `rank`. For kernels with a fixed set of individually-known arguments, named RTAs are the recommended form, even when porting from a positional legacy interface.
+
+---
+
+## Kernel globals
+
+Metal 2.0 has no equivalent of the temporary Quasar API's `QuasarDataMovementConfig::is_legacy_kernel` flag.
+
+On WH/BH, each DM core has its own private memory and gets its own copy of the kernel binary, so `.data` / `.bss` are effectively per-core for free. On Quasar, the 8 DM cores in a cluster share L1, and the natural model is one shared binary with multiple threads — globals live in one place and are *shared* across all DM threads. Setting `is_legacy_kernel = true` recovered WH/BH semantics by duplicating the kernel binary per DM core, at the cost of L1 footprint.
+
+Metal 2.0 always uses the shared-binary model. If you depended on `is_legacy_kernel = true`, the kernel must be rewritten — use `thread_local` for variables that genuinely need per-thread state.
+
+The flag's implicit premise was that you would want to thread an existing WH/BH kernel as a first porting step. That premise is no longer correct: the recommended quick-port path from WH/BH to Quasar is to keep kernels **single-threaded**. (A Quasar Neo Cluster is not four BH workers in a trenchcoat; and Metal 2.0's 6-DM-thread cap precludes the brute-thread approach in any case.) Single-threaded kernels are unaffected by this behavior change.

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/metal2_port_patterns.md
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/metal2_port_patterns.md
@@ -1,0 +1,502 @@
+# Metal 2.0 Op Port — Patterns & Anti-Patterns Catalog
+
+This catalog accumulates patterns and anti-patterns observed during Metal 2.0 op ports. It is referenced from the [feasibility audit](port_op_to_metal2_audit.md) for yellow-tier override guidance, from the [port recipe's planning step](port_op_to_metal2_recipe.md#plan-the-spec) for structural-decision reference, and from the recipe's verification step for the anti-pattern self-audit checklist.
+
+Each entry is self-contained. New entries land here as they're discovered during ports.
+
+## Conventions
+
+Entry shape — load-bearing fields, in order:
+- **Category**: `Pattern` (an affordance to reach for) | `Anti-pattern` (a shape to avoid) | `Caution` (a judgment call with consequences). Sanctioned-exception entries carry a parenthetical category suffix (e.g. `Pattern (sanctioned kernel-side exception)`) flagging that the entry documents a deliberate carve-out from a stricter rule elsewhere in the recipe.
+- **Recognition signal**: what to look for in legacy code (or proposed port code).
+- **Decision** (Pattern / Caution) or **Why wrong** (Anti-pattern): the prescribed move and its rationale.
+
+Optional fields, used when the entry's substance requires them:
+- **Why this is hard** (before Decision): explanatory rationale when the recognition→decision step has non-obvious reasoning the porter benefits from understanding before reading the prescription. May also appear as **Why this is a sanctioned X exception** for sanctioned-exception entries.
+- **Correct port**: code or prose showing the right pattern. Most Pattern entries include this; omit when the Decision is fully prescriptive on its own.
+- **Constraint**: scoping fence on where the entry's authority ends. Beyond that boundary, capitulate per the recipe's [§When the discipline doesn't fit](port_op_to_metal2_recipe.md#when-the-discipline-doesnt-fit).
+- **Sanctioned exception note**: for sanctioned-exception entries, explicit acknowledgement that the prescription deviates from a stricter rule (typically the [kernel-side whitelist](port_op_to_metal2_recipe.md#kernel-side-whitelist) or [host-side scope discipline](port_op_to_metal2_recipe.md#host-side-stay-in-the-lane)), with the why-this-is-legitimate reasoning. Paired with the Category suffix.
+- **Prerequisite**: Metal 2.0 framework commit / PR / version below which the pattern doesn't apply.
+- **See also**: cross-references.
+
+## Entries
+
+### Patterns
+
+- [Self-loop DFB binding (producer == consumer)](#pattern-self-loop-dfb-binding)
+- [Fake CB → self-loop DFB (interim workaround)](#pattern-fake-cb--self-loop-dfb-interim-workaround)
+- [Conditional / optional DFB bindings](#pattern-conditional--optional-dfb-bindings)
+- [Aliased DFBs (legacy aliased CBs)](#pattern-aliased-dfbs-legacy-aliased-cbs)
+- [Same-FIFO aliasing (one DFB, multiple kernel-side names)](#pattern-same-fifo-aliasing-one-dfb-multiple-kernel-side-names)
+- [Pass DFB handles directly to LLKs and kernel-lib helpers](#pattern-pass-dfb-handles-directly-to-llks-and-kernel-lib-helpers)
+- [Multi-variant factories](#pattern-multi-variant-factories)
+- [Unity-build hygiene for anonymous-namespace symbols](#pattern-unity-build-hygiene-for-anonymous-namespace-symbols)
+- [Host-computed base-pointer offset → CTA offset + kernel-side addition](#pattern-host-computed-base-pointer-offset--cta-offset--kernel-side-addition)
+- [Removing pybound legacy factory entry points](#pattern-removing-pybound-legacy-factory-entry-points)
+
+### Anti-patterns
+
+- [Demoting per-group CTA to RTA](#anti-pattern-demoting-per-group-cta-to-rta)
+- [`.id` extraction or temp DFB wrappers at LLK call sites](#anti-pattern-id-extraction-or-temp-dfb-wrappers-at-llk-call-sites)
+
+### Cautions
+
+- [Avoid varargs unless absolutely necessary](#caution-avoid-varargs-unless-absolutely-necessary)
+- [Modifying a shared dataflow kernel](#caution-modifying-a-shared-dataflow-kernel)
+
+---
+
+## Pattern: Self-loop DFB binding
+
+**Category**: Pattern
+
+**Recognition signal**: A compute kernel that both produces and consumes the same buffer. Common in accumulator patterns where the kernel writes a partial result, reads it back, and updates it across iterations.
+
+**Decision**: Declare two `DFBBinding`s on the same `KernelSpec` for the same DFB — one with `endpoint_type = PRODUCER`, one with `endpoint_type = CONSUMER`. The two bindings may share a single `accessor_name` (yielding one device-side `dfb::name` handle), or use two distinct names (yielding two device-side handles aliasing the same DFB).
+
+**Correct port**:
+
+```cpp
+// Shared-name form (most natural for self-loop):
+BindDFB(compute, ACC_DFB, "acc", DFBEndpointType::PRODUCER);
+BindDFB(compute, ACC_DFB, "acc", DFBEndpointType::CONSUMER);
+
+// Kernel side:
+experimental::DataflowBuffer cb_acc(dfb::acc);  // one wrapper drives both directions
+```
+
+The two-distinct-names form (`acc_w` for PRODUCER, `acc_r` for CONSUMER, yielding `dfb::acc_w` and `dfb::acc_r` aliasing the same DFB) also works.
+
+**Prerequisite** (shared-name form only): per-kernel accessor-name dedup relaxation, commit `332413412af` on `akertesz/misc-op-port-fixes`. The two-distinct-names form has always worked.
+
+**See also**: [Anti-pattern: Demoting per-group CTA to RTA](#anti-pattern-demoting-per-group-cta-to-rta) (separate pattern, but the same "host-side variation in `KernelSpec`" mental model).
+
+---
+
+## Pattern: Fake CB → self-loop DFB (interim workaround)
+
+**Category**: Pattern (interim workaround)
+
+**Recognition signal**: A **fake CB** — a CircularBuffer the kernel uses purely as an *address source* (a base-pointer grab via `get_read_ptr` / `get_pointer_to_cb_data`, then a direct memory read), with **no real producer–consumer pair**: nothing produces into it as a FIFO, nothing waits on it. The legacy idiom borrows a CB onto a resident tensor's buffer because, pre–Metal 2.0, that was the only way to hand a kernel a base pointer to resident memory. The audit flags these as **FYI-P** (it does not gate — this workaround keeps the port unblocked). The port-time problem: a Metal 2.0 DFB requires **≥1 PRODUCER and ≥1 CONSUMER** binding, but a fake CB is *one-ended* — there is no honest producer (or consumer) to declare, so the spec validator rejects it.
+
+**Decision**: Bind the fake CB as a **self-loop DFB** — declare *both* a PRODUCER and a CONSUMER binding, both on the **same kernel** (the one that reads it). This borrows the [Self-loop DFB binding](#pattern-self-loop-dfb-binding) mechanism purely to satisfy the validator's producer-and-consumer rule. It is a deliberate white lie: nothing is actually produced or consumed as a FIFO, but the binding is well-formed and the kernel reads the memory by base pointer exactly as before. (Contrast the self-loop pattern proper, where the producer *and* consumer are **real** — an accumulator. Here neither is.)
+
+**Correct port**:
+
+```cpp
+// Fake CB the compute kernel reads only as an address source.
+// Self-loop it on the single reading kernel so the validator is satisfied:
+KernelSpec compute{
+    // ...
+    .dfb_bindings = {
+        DFBBinding{.dfb_spec_name = RECIP, .accessor_name = "recip", .endpoint_type = DFBEndpointType::PRODUCER},
+        DFBBinding{.dfb_spec_name = RECIP, .accessor_name = "recip", .endpoint_type = DFBEndpointType::CONSUMER},
+    },
+};
+
+// Kernel side — unchanged from legacy; still a base-pointer read, no FIFO ops:
+experimental::DataflowBuffer dfb_recip(dfb::recip);
+// ... read via base pointer as before ...
+```
+
+(Shared `accessor_name` for both endpoints relies on the per-kernel accessor-name dedup relaxation noted under [Self-loop DFB binding](#pattern-self-loop-dfb-binding); the two-distinct-names form also works.)
+
+**Document the hack prominently in the port report.** This is an *interim* workaround, not the intended end state. Record each fake-CB self-loop binding in the report's [Open items for downstream](port_op_to_metal2_recipe.md#capture-the-port-report), stating plainly that the self-loop is a validator-satisfying device and **not** a real FIFO — so the eventual migration can find and replace every one.
+
+**Long-term direction** (why this is interim). Fake CBs split into two kinds, each with its own real fix coming:
+- **Scratchpad-shaped** — the kernel *reads and writes* the borrowed memory as scratch → the forthcoming **Metal 2.0 kernel scratchpad resource**.
+- **Tensor-local-view** — the kernel only *reads* a resident tensor's L1 by base pointer → a forthcoming **"local" `TensorAccessor`** variant. (An earlier attempt to repurpose Device 2.0's `CoreLocalMem` for this was rejected on review as too gross; the replacement is being redesigned.)
+
+Until those land, the self-loop binding is the sanctioned way to keep a fake-CB op portable.
+
+**See also**: [Self-loop DFB binding](#pattern-self-loop-dfb-binding) (the legitimate accumulator case whose mechanism this borrows — there the producer/consumer are real).
+
+---
+
+## Pattern: Conditional / optional DFB bindings
+
+**Category**: Pattern
+
+**Recognition signal**: A resource — a DFB, a tensor (`TensorAccessor`), or a semaphore — is used by a kernel only on some code paths, with the configuration known at host time (e.g. a `cb_scaled` DFB used only when `do_scale = true`, a `cb_fusion` used only when `FUSE_PRE_ADD`, or an optional `batch_offset` tensor read only when a feature flag is set). The compile-time tell, in a build where the feature is *off*, is a name-resolution failure on the generated token: `'cb_scaled' is not a member of 'dfb'`, `'batch_offset' is not a member of 'ta'`, or the `sem::` equivalent.
+
+**Why this is hard.** Metal 2.0's `dfb::<name>` namespace is generated from the actual host bindings: if the host omits SCALED from `dfb_bindings`, `dfb::cb_scaled` is not declared in `kernel_bindings_generated.h`. C++ `if constexpr` in a non-template function (which `kernel_main()` is) still performs name lookup on the discarded branch — so `if constexpr (false) { ... dfb::cb_scaled ... }` fails to compile at parse time even though the branch is dead at codegen. The same constraint hits kernels that reference the conditional DFB name from file-scope contexts like ternaries: both operands resolve at parse time regardless of which branch the constant condition selects. The fix is to gate the kernel-side references at the **preprocessor** level, before C++ parsing sees them.
+
+This applies verbatim to `ta::<name>` (optional tensors) and `sem::<name>` — all three namespaces are emitted by genfiles **per-binding**, so a resource no kernel binds on the off-path produces no token at all. Optional **tensors** are the case where the `#ifdef` gate is not merely preferred but **mandatory**: an absent tensor often has nothing to bind even in principle (the argument may simply not be passed), so there is no always-bind fallback to reach for.
+
+**Decision.** Conditionally bind the DFB on the host. Emit a matching preprocessor define via `KernelSpec::defines` when the binding is present. On the kernel side, `#ifdef`-gate the constexpr alias of the DFB name and all expressions that reference it.
+
+```cpp
+// Host:
+const bool fuse_pre_add = ...;
+KernelSpec compute{
+    .compile_time_args = { /* ... */ },
+    .compiler_options = {.defines = fuse_pre_add
+        ? Table<std::string, std::string>{{"FUSE_PRE_ADD", "1"}}
+        : Table<std::string, std::string>{}},
+    .dfb_bindings = fuse_pre_add
+        ? Group<DFBBinding>{INPUT, OUTPUT, FUSION}
+        : Group<DFBBinding>{INPUT, OUTPUT},
+};
+
+// Kernel:
+#ifdef FUSE_PRE_ADD
+constexpr uint32_t cb_fusion = dfb::cb_fusion;
+#endif
+
+// File-scope expression referencing the conditional name:
+#ifdef FUSE_PRE_ADD
+constexpr uint32_t cb_x = (do_gamma | do_beta) ? cb_fusion : cb_out;
+#else
+constexpr uint32_t cb_x = cb_out;
+#endif
+```
+
+The `#ifdef` runs at the preprocessor stage, before the C++ compiler sees the code — so `dfb::cb_fusion` never enters name lookup in the unfused build, and the conditionally-bound DFB is honored end-to-end. This avoids the L1 cost of binding the DFB unconditionally (which can be significant for L1-tight ops — layernorm's `cb_fusion` is ~16 tiles, for example) and works regardless of whether the kernel references the DFB name from file-scope expressions or only inside function bodies.
+
+**Promote a CTA gate to a define.** A subtle case: the legacy kernel may gate the conditional DFB's *use* through a **CTA** (`if constexpr (do_gamma) { … cb_gamma … }`) rather than an `#ifdef`. The `if constexpr` still name-looks-up `dfb::cb_gamma` in the discarded branch, so the port must **promote** that gate to the preprocessor — convert the `if constexpr` to `#ifdef FUSE_GAMMA`, and emit the matching define from the host. Watch the emission target: the legacy factory often sent the define to only *some* kernels (e.g. the reader), but the promoted `#ifdef` must be fed to **every** kernel that references the conditionally-bound DFB. The define and the binding share one condition.
+
+**Don't bind unconditionally** as an alternative. You might be tempted to unconditionally bind a DFB so its token always exists. This is a bad solution: it wastes L1 SRAM, a scarce resource that is in short supply on these devices. And beyond the L1 cost, it fails to compile anyway when the kernel needs to reference the conditionally-used name from a file-scope ternary or similar parse-time-resolves-both-branches context. For optional **tensors** it is not even an option — there may be nothing to bind (see *Why this is hard* above).
+
+**Future direction — `#ifdef` is a temporary scaffold.** Metal 2.0 work to NTTP-ify all CTAs will let the entire kernel body be template-instantiated on the CTA values, at which point `if constexpr` discarded branches truly skip non-dependent name lookup, and the `#ifdef` scaffolding is retired in favor of `if constexpr (do_scale) { use dfb::name; }`. That work is in flight and will soon supersede this pattern. Until NTTP CTAs land, `#ifdef`-gated conditional bindings are the recommended pattern for Metal 2.0 today.
+
+---
+
+## Pattern: Aliased DFBs (legacy aliased CBs)
+
+**Category**: Pattern
+
+**Recognition signal**: Legacy code that places two or more `buffer_index` values on the *same* `CBDescriptor` — multi-element `format_descriptors`, multi-key `data_format_spec` map in the imperative form, or repeated `set_page_size` calls with different `buffer_index` arguments on the same `CircularBufferConfig`. The legacy intent is two logically distinct buffers sharing one L1 region. The audit's [Aliased Circular Buffers entry](port_op_to_metal2_audit.md#aliased-circular-buffers-cbs-sharing-backing-memory--landed) catches this in the legacy inventory.
+
+**Decision**: Declare one `DataflowBufferSpec` per legacy `buffer_index`. Aliasing is an **advanced/ninja feature** — the `alias_with` field lives on `DFBAdvancedOptions` (see [`advanced_options.hpp`](../../../../../../../tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp)), reached via `DataflowBufferSpec::advanced_options.alias_with`. Set each spec's `advanced_options.alias_with` to mutually reference the others — the alias group must be a *strict clique* (every member names every other member). All members of the alias group share these legality constraints:
+- Same `num_entries * entry_size` (total backing size identical).
+- Bound to the same set of kernels.
+- Borrowed-memory consistency (either all `borrowed_from` matching `TensorParameter`s, or none borrowed).
+
+The validator enforces these as the three legality rules; missing any of them surfaces with a message in the [migration guide's troubleshooting table](metal2_migration_guide.md#cryptic-error--likely-cause). The `DFBAdvancedOptions` header comments are the authoritative source for the field's contract — including the explicit "no clobbering guarantees" note: aliased DFBs share backing memory, and correctness of *which* logical buffer's data is live at any moment is the kernel author's responsibility.
+
+**Correct port**:
+
+```cpp
+// Two indices that legacy shared via a single CBDescriptor become two
+// DFBs with mutual alias_with entries (advanced_options-nested):
+DataflowBufferSpec INTERM0{ .unique_id = INTERM0_ID, .num_entries = N, .entry_size = S,
+                            .advanced_options = {.alias_with = {OUTPUT_ID}} };
+DataflowBufferSpec OUTPUT{  .unique_id = OUTPUT_ID,  .num_entries = N, .entry_size = S,
+                            .advanced_options = {.alias_with = {INTERM0_ID}} };
+```
+
+For larger alias groups (three or more), every member names every other member in its `advanced_options.alias_with` — partial mentions are rejected by the validator.
+
+**Don't split** the aliased CB into independent, non-aliased DFBs. That changes the L1 footprint and breaks any kernel assumption that the indices shared an address.
+
+**See also**: [migration guide — DataflowBufferSpec: Aliased DFBs](metal2_migration_guide.md#dataflowbufferspec); [audit — Aliased Circular Buffers entry](port_op_to_metal2_audit.md#aliased-circular-buffers-cbs-sharing-backing-memory--landed); [Same-FIFO aliasing](#pattern-same-fifo-aliasing-one-dfb-multiple-kernel-side-names) (the *other* kind of "aliasing" — don't confuse them).
+
+---
+
+## Pattern: Same-FIFO aliasing (one DFB, multiple kernel-side names)
+
+**Category**: Pattern
+
+**Recognition signal**: A kernel refers to **one** circular buffer through **multiple names**, via legacy `uint32_t` CB-index aliasing — `constexpr uint32_t cb_x = cb_in;`, or a ternary that resolves one name to a CB index (`constexpr uint32_t cb_x = fuse ? cb_fusion : cb_out;`). Both names are then used for the *same* FIFO: a `push`/`reserve_back` via one name is seen by a `wait_front`/`pop_front` via the other, because they are literally the same buffer with the same read/write pointers.
+
+**This is not [Aliased DFBs](#pattern-aliased-dfbs-legacy-aliased-cbs).** The two are easy to conflate and the distinction is correctness-critical:
+
+| | Aliased DFBs (`alias_with`) | Same-FIFO aliasing (this entry) |
+|---|---|---|
+| Buffers | Two+ **distinct** DFBs | **One** DFB |
+| FIFO pointers | **Independent** per DFB | **Shared** — one FIFO |
+| What's shared | The physical L1 region | The buffer's identity |
+| Legacy form | Two CB *indices* configured at the same L1 address | Two `uint32_t` *variables* holding the same CB index |
+
+Modeling same-FIFO aliasing with `alias_with` is a **bug**: you would get two independent FIFOs at one address, and the producer/consumer pointer coherence the kernel relies on (produce via one name, consume via the other) is lost silently.
+
+**Decision**: Keep **one** `DataflowBufferSpec` and **one** `DFBBinding`. Express the second name as a **kernel-side handle alias** — a `constexpr` alias of the generated token:
+
+```cpp
+// Legacy: cb_x and cb_in are the same CB index.
+constexpr uint32_t cb_x = cb_in;
+// ... uses both cb_x and cb_in for the same FIFO ...
+
+// Metal 2.0: one binding (dfb::cb_in); alias the handle, construct ONE object.
+constexpr auto cb_x = dfb::cb_in;     // cb_x and dfb::cb_in are the same handle
+DataflowBuffer dfb_in(dfb::cb_in);    // a SINGLE object for the FIFO
+```
+
+**Don't**:
+- **Don't add a second `DFBBinding`** to the same DFB under a different `accessor_name` to manufacture a `dfb::cb_x` token. A kernel binds a given DFB under exactly one accessor name (the [self-loop pair](#pattern-self-loop-dfb-binding) — one name, PRODUCER+CONSUMER — is the only "twice" form), and the spec validator rejects a second name for the same DFB.
+- **Don't construct two `DataflowBuffer` objects from the same `DFBAccessor`** (`DataflowBuffer a(dfb::cb_in); DataflowBuffer b(dfb::cb_in);`). It compiles and runs, but two objects aliasing one FIFO break the object↔DFB identity that device-side debug tooling depends on. Alias the *handle*, keep *one* object.
+
+**Path-dependent variant.** When the aliased name resolves to *different* DFBs on different compile-time paths (`cb_x` is `dfb::cb_fusion` when fused, `dfb::cb_out` otherwise), gate the handle alias under the matching `#ifdef` so each path names only DFBs bound on it — the [Conditional / optional DFB bindings](#pattern-conditional--optional-dfb-bindings) pattern applied to the *name→DFB mapping*:
+
+```cpp
+#ifdef FUSE
+constexpr auto cb_x = dfb::cb_fusion;
+#else
+constexpr auto cb_x = dfb::cb_out;
+#endif
+```
+
+**See also**: [Aliased DFBs](#pattern-aliased-dfbs-legacy-aliased-cbs) (the distinct-buffers / shared-memory kind); [Conditional / optional DFB bindings](#pattern-conditional--optional-dfb-bindings); [Self-loop DFB binding](#pattern-self-loop-dfb-binding).
+
+---
+
+## Pattern: Pass DFB handles directly to LLKs and kernel-lib helpers
+
+**Category**: Pattern
+
+**Recognition signal**: A kernel uses LLK compute APIs (`reduce_init`, `pack_tile`, `matmul_init`, `cb_wait_front`, etc.) or kernel-library helpers (`compute_kernel_lib::reduce<>`, `dataflow_kernel_lib::prepare_reduce_scaler<>`, etc.) that take `uint32_t` CB ids as parameters.
+
+**Decision**: Pass `dfb::name` directly. The implicit conversion `DFBAccessor::operator uint32_t()` lets named DFB handles flow into any function expecting a `uint32_t` CB id, without manual extraction or wrapping.
+
+**Correct port**:
+
+```cpp
+// LLK calls:
+reduce_init<PoolType::SUM, ReduceDim::REDUCE_ROW>(dfb::input, dfb::scaler, dfb::output);
+cb_wait_front(dfb::input, 1);
+pack_tile(0, dfb::output);
+
+// Kernel-lib calls:
+compute_kernel_lib::reduce<...>(dfb::in0, dfb::scaler, dfb::out, /* block shape */, ...);
+dataflow_kernel_lib::prepare_reduce_scaler<dfb::scaler, REDUCE_OP, REDUCE_DIM>(scaler_f);
+```
+
+No `.id` extraction, no temporary `DataflowBuffer` constructed just to retrieve its underlying id, no wrapper structs.
+
+**Template-parameter position works too.** The example `dataflow_kernel_lib::prepare_reduce_scaler<dfb::scaler, REDUCE_OP, REDUCE_DIM>(scaler_f)` above uses `dfb::scaler` as a non-type template parameter. The `DFBAccessor::operator uint32_t()` conversion is `constexpr`, so `dfb::name` is a valid integral constant expression wherever the legacy signature took a `uint32_t` non-type template parameter — call-argument and template-argument positions are both fine.
+
+**Today vs. tomorrow**: Today's LLKs and kernel-lib helpers on WH/BH accept `uint32_t` — the implicit conversion is the right bridge for porting-scope work. Kernel-lib and LLK Quasar correctness is upstream of any WH/BH port; do not preemptively wrap or refactor.
+
+**Prerequisite**: implicit conversion on `DFBAccessor::operator uint32_t()`, commit `3fbb1016d08` on `akertesz/dfb-accessor-implicit-conv`, PR #44646.
+
+**See also**: [Anti-pattern: `.id` extraction or temp DFB wrappers](#anti-pattern-id-extraction-or-temp-dfb-wrappers-at-llk-call-sites).
+
+---
+
+## Pattern: Multi-variant factories
+
+**Category**: Pattern
+
+**Recognition signal**: One program factory builds multiple `ProgramSpec`s depending on a variant attribute — e.g. Welford reduction's `reduce_dim` selecting among W/H/HW variants, each with its own kernels, its own DFB set, and its own RTA schema.
+
+**Decision**: Branch on the variant inside `create_program_artifacts`. No class hierarchy is needed; the variant is a configuration, not a factory subclass. Per-variant DFB unique ids and KernelSpec sources are local to each branch.
+
+**Correct port**:
+
+```cpp
+ttnn::device_operation::ProgramArtifacts MyFactory::create_program_artifacts(
+    const operation_attributes_t& attrs,
+    const tensor_args_t&           inputs,
+    tensor_return_value_t&         output) {
+    switch (attrs.variant) {
+        case Variant::W:   return build_w_artifacts(attrs, inputs, output);
+        case Variant::H:   return build_h_artifacts(attrs, inputs, output);
+        case Variant::HW:  return build_hw_artifacts(attrs, inputs, output);
+    }
+}
+```
+
+Each variant's helper builds its own `ProgramSpec` and `ProgramRunArgs`. Where variants share kernels, the same kernel source is reused (with different `KernelSpec`s, possibly different CTA bindings).
+
+---
+
+## Pattern: Unity-build hygiene for anonymous-namespace symbols
+
+**Category**: Pattern
+
+**Recognition signal**: Multiple program-factory `.cpp` files in the same CMake target each defining anonymous-namespace symbols (`MakeDFB`, `BindDFB`, `READER_KERNEL`, work-distribution structs, etc.) with the same name. Unity-build concatenates the `.cpp`s into one translation unit; C++ rules merge all `namespace { ... }` blocks into one scope, producing duplicate-symbol errors.
+
+**Decision**: Hoist truly-identical declarations (helper functions, shared DFB ids) into a shared header with `inline` (functions) or `inline constexpr` (constants) linkage. For per-factory constants and structs with the same role but different content, prefix with the factory name (`W_READER_KERNEL`, `H_READER_KERNEL`, `WWorkDistribution`, `HWorkDistribution`). Function overloads distinguished by first-parameter type coexist as overloads in the merged anon namespace.
+
+**Correct port**:
+
+```cpp
+// In a shared header (e.g., reduce_metal2_factory_helpers.hpp):
+namespace {
+inline const DFBSpecName INPUT_DFB{"input"};
+inline const DFBSpecName OUTPUT_DFB{"output"};
+inline DataflowBufferSpec MakeDFB(/* ... */) { /* ... */ }
+inline void BindDFB(KernelSpec& k, /* ... */) { /* ... */ }
+}
+
+// In per-factory .cpp files:
+namespace {
+const KernelSpecName W_READER_KERNEL{"reader_w"};
+const KernelSpecName H_READER_KERNEL{"reader_h"};
+struct WWorkDistribution { /* ... */ };
+struct HWorkDistribution { /* ... */ };
+}
+```
+
+This isn't a Metal 2.0-specific issue, but it surfaces during op porting because most ops have multiple factories per device-operation, and Metal 2.0's named-binding pattern tempts authors to introduce more named constants.
+
+---
+
+## Anti-pattern: Demoting per-group CTA to RTA
+
+**Category**: Anti-pattern
+
+**Recognition signal**: A legacy factory uses `split_work_to_cores` and creates two `KernelDescriptor`s for the compute kernel (one per core group) with different per-group CTA values (e.g. one with `Ht=X1`, one with `Ht=X2`). The Metal 2.0 port has *one* `KernelSpec` for the compute kernel, and the dimension that varied per group has been moved into `KernelSpec::runtime_arg_schema.runtime_arg_names` instead of `compile_time_args`.
+
+**Why wrong**: The premise — "Metal 2.0 supports only one `KernelSpec` per kernel source" — is false. Metal 2.0 supports multiple `KernelSpec`s referencing the same source with different CTA bindings, each placed in its own `WorkUnitSpec`, sharing upstream/downstream DFBs as multi-bindings. The "two `KernelDescriptor`s per work split" idiom translates 1:1 to "two `KernelSpec`s of the same source, in two `WorkUnitSpec`s, both binding the same input/output DFBs."
+
+The demotion sacrifices compile-time loop unrolling on the demoted dimension — a real, measurable kernel-perf regression — and is unnecessary.
+
+**Correct port**:
+
+```cpp
+// Two compute KernelSpecs of the same source, differing only on the per-group CTA:
+const KernelSpecName COMPUTE_G1{"compute_g1"};
+const KernelSpecName COMPUTE_G2{"compute_g2"};
+auto make_compute = [&](KernelSpecName unique_id, uint32_t Ht) {
+    return KernelSpec{
+        .unique_id = std::move(unique_id),
+        .source = "reduce.cpp",
+        .compile_time_args = {{"Ht", Ht}, {"Wt", Wt}, {"NC", NC}},
+        .dfb_bindings = { /* INPUT consumer, OUTPUT producer */ },
+        // ...
+    };
+};
+Group<KernelSpec> kernels = {reader, writer,
+    make_compute(COMPUTE_G1, num_rows_per_core_group_1)};
+if (group_2_present) {
+    kernels.push_back(make_compute(COMPUTE_G2, num_rows_per_core_group_2));
+}
+
+// Two WorkUnitSpecs, one per core group:
+WorkUnitSpec wu_g1{.name = "wu_g1", .kernels = {READER, WRITER, COMPUTE_G1},
+                   .target_nodes = core_group_1};
+WorkUnitSpec wu_g2{.name = "wu_g2", .kernels = {READER, WRITER, COMPUTE_G2},
+                   .target_nodes = core_group_2};
+```
+
+The framework validates that the two compute `KernelSpec`s have non-overlapping WU coverage and that their CONSUMER bindings of INPUT (and PRODUCER bindings of OUTPUT) match — the local hardware invariant that exactly one reader, one writer, and one compute run together at each node is preserved. (See [`dataflow_buffer_spec.hpp`](../../../../../../../tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp) for the full canonical statement of the DFB endpoint invariant — including the third condition, "same kernel kind," that's implicit in this all-compute example.)
+
+---
+
+## Pattern: Host-computed base-pointer offset → CTA offset + kernel-side addition
+
+**Category**: Pattern (sanctioned kernel-side exception)
+
+**Recognition signal**: The legacy host code computes an offset from the op's attributes / shapes / strides, *adds it to a tensor's base pointer*, and threads the result through a runtime argument. The kernel reads the pre-shifted address and uses it directly. The hallmark expression on the host side is `tensor.buffer()->address() + compute_offset(attrs)` (or similar arithmetic). The audit's [TensorAccessor handling](port_op_to_metal2_audit.md#tensoraccessor-handling) subject flags this binding (a buffer-address-through-RTA bypass) — but it's the variant that *can't* be cleanly resolved by replacing the address-RTA with a `TensorBinding` alone, because the offset arithmetic lives on the host side of the legacy boundary.
+
+In the wild: `ttnn/cpp/ttnn/operations/data_movement/slice/` (slice computes a per-region offset on the host, then composes it with the input buffer's base address before handing the result to the kernel).
+
+**Why a straight `TensorBinding` fix doesn't work**: Metal 2.0's `TensorArgument` carries a tensor identity, not a pre-offset memory address — there is no way to attach an offset to a `TensorArgument` and have the kernel receive `base + offset` automatically. Passing the offset-shifted address as a raw RTA preserves the legacy *RTA-smuggling* shape that the audit's TensorAccessor-handling subject was built to eliminate — same bug under a different name. The sanctioned resolution moves the addition across the host/kernel boundary.
+
+**Decision**: Three-part rewrite:
+
+1. **Keep the host-side offset arithmetic on the host.** Whatever computation derives the offset value from attributes / shapes / strides stays exactly where it was. Only its *target* changes — it no longer pre-shifts a pointer.
+2. **Pass the original tensor as a `TensorParameter` / `TensorBinding`** — the standard binding-mechanism translation. The kernel constructs `TensorAccessor(ta::<name>)` and obtains the base address from it.
+3. **Pass the computed offset as a named compile-time argument** on the `KernelSpec`. Add the offset on the kernel side, in a single line after retrieving the base address from the accessor.
+
+**Synthetic example**.
+
+```cpp
+// Legacy host (smuggling shape):
+uint32_t addr = input.buffer()->address() + compute_offset(attrs);
+KernelDescriptor reader = {
+    .kernel_source = "reader.cpp",
+    .runtime_args  = {{{0,0}, {addr, /* other RTAs */}}},
+};
+
+// Legacy kernel (consumes the pre-shifted address):
+uint32_t base = get_arg_val<uint32_t>(0);
+// ... use `base` directly as the read address ...
+```
+
+```cpp
+// Metal 2.0 host:
+const uint32_t offset = compute_offset(attrs);  // unchanged host-side arithmetic
+KernelSpec reader{
+    .unique_id = READER,
+    .source = "reader.cpp",
+    .compile_time_args = {{"offset", offset}, /* other CTAs */},
+    .tensor_bindings = {{
+        .tensor_parameter_name = INPUT,
+        .accessor_name = "in",
+    }},
+    // ...
+};
+
+// Metal 2.0 kernel (one-line addition — the sanctioned exception):
+auto in = TensorAccessor(ta::in);
+constexpr auto offset = get_arg(args::offset);
+uint32_t base = in.get_bank_base_address(bank_id) + offset;
+// ... use `base` as the read address ...
+```
+
+**Sanctioned exception note**: This pattern *explicitly* requires a kernel-side change that is not on the [recipe's kernel-side whitelist](port_op_to_metal2_recipe.md#kernel-side-whitelist) — the `+ offset` addition after the accessor's base-address retrieval. That's deliberate. This is the documented, sanctioned exception; applying it does not constitute off-whitelist improvising. The kernel-side discipline's spirit (mechanical translation, no creative work, no functional change) is preserved: the kernel's *behavior* is identical before and after, since `base + offset` on the kernel simply relocates one host-side line into the kernel — the arithmetic is unchanged, the read pattern is unchanged, only the boundary moves.
+
+**Constraint**: The offset must be expressible as a compile-time argument — i.e., a factory-construction-time value derivable from attributes / shapes. The sanctioned path is **CTA-only**. If your offset would need to be per-dispatch-varying (RTA), this pattern doesn't apply; capitulate per the recipe's [§When the discipline doesn't fit](port_op_to_metal2_recipe.md#when-the-discipline-doesnt-fit).
+
+---
+
+## Pattern: Removing pybound legacy factory entry points
+
+**Category**: Pattern (sanctioned host-side exception)
+
+**Recognition signal**: A pybind file inside the op directory (typically `*_pybind.cpp` / `*_pybind.hpp`, or a `bindings/` subdirectory under the op) exposes a legacy host-API function that ceases to exist post-port. The canonical case is `create_program_descriptor` — once the op moves to a `MetalV2FactoryConcept` factory, that function is gone, and the pybind line that exposed it references a non-existent symbol. The rule generalizes: *any* pybind exposure of a legacy factory entry point that the port deletes falls under this entry.
+
+**Why this is a sanctioned host-side exception**: The [host-side scope discipline](port_op_to_metal2_recipe.md#host-side-stay-in-the-lane) keeps op-level host code outside the program factory body off-limits during the port. A pybind file is op-level host code outside the program factory body, so the blanket rule would forbid touching it — but a pybind line that references a vanished symbol is structurally untenable: leaving it as-is means the post-port code doesn't compile (or links against nothing). Deletion is mandatory; the rule's blanket prohibition is lifted *narrowly* for this case.
+
+**Decision**:
+
+1. **Delete** the pybind line(s) that expose the vanished function. Do not attempt to "update" the binding to point at the new factory's entry point (e.g., `create_program_artifacts`) — the two functions have different signatures and use patterns, and the Python-side callers (if any) need to be addressed separately, not silently retargeted. Make the smallest change that restores compilation: just remove the line(s).
+2. **Record the deletion prominently in the port report** under [Handoff points](port_op_to_metal2_recipe.md#handoff-points). Include: the pybind file path, the function name(s) deleted, and a one-line description of what the function was for (if you can tell from the surrounding code). This is a *user-visible API surface change* — downstream Python consumers (tests, notebooks, internal tooling) that called into the legacy entry point need to be findable by the people who maintain them. The prominent report entry is how they get found.
+
+**Constraint**: This exception applies *only* to pybind exposures of factory entry points that the Metal 2.0 port causes to disappear. Other op-level pybind lines — the user-facing op binding itself, attribute conversions, return-value handling — remain off-limits per the host-side scope discipline. If you're uncertain whether a given pybind line falls inside or outside the exception, the safe move is to leave it and write a finding in the report.
+
+---
+
+## Anti-pattern: `.id` extraction or temp DFB wrappers at LLK call sites
+
+**Category**: Anti-pattern
+
+**Recognition signal**: At a kernel call site for an LLK (`reduce_init`, `pack_tile`, etc.) or kernel-lib helper, the code does any of:
+
+- `.id`-extraction: `reduce_init(dfb::input.id, ...)`.
+- Temporary wrapper: `experimental::DataflowBuffer in_dfb(dfb::input); reduce_init(in_dfb.get_id(), ...)`.
+- Typed-shim struct: a wrapper template (`BufferRef<T>` or similar) that holds a CB id and exposes `operator uint32_t`.
+
+**Why wrong**: Each of these reinvents an implicit conversion that `DFBAccessor` already provides. The `.id` form encodes the LLK's CB-id vocabulary into kernel code that should be DFB-centric; temporary wrappers add construction cost for no benefit; typed shims reproduce the implicit conversion locally and clutter the call site.
+
+**Correct port**: See [Pattern: Pass DFB handles directly to LLKs and kernel-lib helpers](#pattern-pass-dfb-handles-directly-to-llks-and-kernel-lib-helpers).
+
+**Prerequisite**: `DFBAccessor::operator uint32_t()` exists, commit `3fbb1016d08` on `akertesz/dfb-accessor-implicit-conv`, PR #44646. On older Metal 2.0 snapshots without this conversion, the `.id` workaround was the right answer.
+
+---
+
+## Caution: Avoid varargs unless absolutely necessary
+
+**Category**: Caution
+
+**Recognition signal**: A `KernelSpec` declares `advanced_options.num_runtime_varargs > 0` (or `advanced_options.num_common_runtime_varargs > 0`), or a kernel uses `get_vararg(i)` / `get_common_vararg(i)`. The vararg fields live on `KernelAdvancedOptions` (see [`advanced_options.hpp`](../../../../../../../tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp)) — they're an explicit advanced/temporary mechanism slated for deprecation in favor of `std::array` typed arguments.
+
+**Decision**: Varargs are designed for kernels whose device-side code retrieves arguments via `get_vararg(i)` with `i` a runtime variable — the canonical case is an N-dimensional shape gated on a CTA-known `rank`. When each argument is referenced by a constant index (`get_vararg(0)`, `get_vararg(1)`, ...), the named form is clearer on both sides.
+
+**Why caution rather than anti-pattern**: A port from positional legacy RTAs to varargs compiles and runs. It can be a reasonable interim step on a large kernel. But it preserves the legacy positional vocabulary instead of upgrading to Metal 2.0's named one; the named form is the recommended endpoint for new code.
+
+**The named/vararg test**: look at the device-side retrieval. If every `get_vararg(i)` uses a constant `i`, you wanted named arguments — give them names. If `i` is a runtime variable iterating over a count, varargs are the right fit.
+
+---
+
+## Caution: Modifying a shared dataflow kernel
+
+**Category**: Caution
+
+**Recognition signal**: A port modifies a kernel source that lives outside the op's own directory — typically a reader / writer in `ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/` or similar. Common shared kernels include `reader_unary_interleaved_start_id.cpp`, `writer_unary_interleaved_start_id.cpp`, `reader_unary_reduce_universal_start_id.cpp`, and `writer_unary_sharded.cpp` (under `data_movement/sharded/device/kernels/dataflow/`).
+
+**Decision**: Pick one of two paths, based on whether all consumers of the kernel can co-migrate to Metal 2.0 in the same PR (or a bundled set of PRs):
+
+1. **In-place modification** — when every consumer op of the kernel is being ported to Metal 2.0 in the same PR or bundled set. Modify the kernel source and update each consumer's factory consistently. Before editing, grep for all consumers (`grep -rl <kernel-filename> ttnn/cpp/ttnn/operations/`) and verify each one is in the bundled set.
+
+2. **Fork with `_metal2` suffix** — the typical answer during the bulk-port window, when consumers cannot all co-migrate. Copy the kernel into a `_metal2`-suffixed file alongside the original (e.g., `writer_unary_interleaved_start_id_metal2.cpp` next to the legacy `writer_unary_interleaved_start_id.cpp`). Modify the copy for Metal 2.0 — named bindings, `dfb::name`, `ta::name`, named RTAs. Reference the new file from the ported factory's `KernelSpec::source`. The legacy copy stays in place for unmigrated consumers.
+
+   **Sunset:** delete the legacy copy when the last unmigrated consumer ports. The `_metal2` suffix is a load-bearing signal during this window — anyone touching the legacy copy should see the suffix and consider whether the change also belongs on the fork.
+
+   **Drift discipline:** until sunset, bug fixes to the legacy copy should be evaluated for the `_metal2` copy. The fork is intentionally short-lived; keeping the two in sync is the cost of unblocking the bulk-port wave without coordinating dozens of consumer PRs.
+
+A kernel-source change that compiles cleanly for the porting op but breaks a sibling op's CTA layout is one of the failure modes that escapes the recipe's anti-pattern self-audit — it's *not* in the ported op's own files. The legacy-inventory step explicitly notes any cross-op kernel sources, and the port report records the touch under "Open items for downstream" with the chosen path (in-place co-migration list, or fork) so the next sibling-op porter sees the coordination signal.
+
+**Excluded from "cross-op"**: kernel-lib (`ttnn/cpp/ttnn/kernel_lib/`) and standard framework APIs (`tt_metal/hw/inc/api/...`) — these are out of porter scope by the [recipe's scope boundary](port_op_to_metal2_recipe.md#read-this-first) and the porter does not modify them. Cross-op kernels are sources living in *another op's* kernel directory.

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/metal2_workspace_setup.md
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/metal2_workspace_setup.md
@@ -1,0 +1,126 @@
+# Metal 2.0 — Workspace Setup for Porting
+
+Use this when you have **no existing tt-metal checkout**. If you've been given an existing clone or worktree path, skip to **Run tests**.
+
+This doc is referenced by the [port recipe](port_op_to_metal2_recipe.md) under "Before you begin." Scope: bootstrap only — clone, environment, build, test invocation patterns. The port itself lives in the recipe.
+
+## Clone
+
+```bash
+git clone git@github.com:tenstorrent/tt-metal.git --recurse-submodules
+cd tt-metal
+```
+
+If SSH isn't configured, fall back to HTTPS:
+
+```bash
+git clone https://github.com/tenstorrent/tt-metal.git --recurse-submodules
+```
+
+## Python environment
+
+```bash
+export PYTHONPATH=$(pwd)
+./create_venv.sh
+source python_env/bin/activate
+```
+
+`PYTHONPATH` must point to your actual clone. Use `$(pwd)` from inside the clone — do not hardcode a path copied from someone else's environment.
+
+## Build
+
+```bash
+./build_metal.sh --build-tests
+```
+
+Use `--build-tests` (Metal **and** TTNN tests). Do **not** use `--build-metal-tests` alone — that flag omits the TTNN gtests an op porter needs.
+
+Cold build on a warm farm node: ~7 minutes for Metal tests alone; expect a few minutes more for the full `--build-tests`. Subsequent incremental builds are fast.
+
+For iterative rebuilds during a port, target binaries directly:
+
+```bash
+cmake --build build_Release --target ttnncpp unit_tests_ttnn -j 8
+```
+
+## Run tests
+
+**Metal 2.0 unit tests** (sanity-check the build):
+
+```bash
+./build/test/tt_metal/unit_tests_api --gtest_filter="*ProgramSpec*"
+```
+
+**Op-specific gtests** live under `./build/test/ttnn/`. The umbrella binary is `unit_tests_ttnn`; specialized variants (`unit_tests_ttnn_tensor`, `unit_tests_ttnn_ccl`, etc.) exist alongside it.
+
+```bash
+# List what's there
+ls ./build/test/ttnn/
+
+# Discover the test names without running anything (safe without HW)
+./build/test/ttnn/unit_tests_ttnn --gtest_list_tests | head
+
+# Run tests filtered to your op (requires HW)
+./build/test/ttnn/unit_tests_ttnn --gtest_filter="*<YourOp>*"
+```
+
+Tests that exercise the device require attached hardware. On a farm node with a reservation, this is satisfied.
+
+## Run tests for the op you ported
+
+Tests for an op `<op>` live in two predictable places:
+
+- **C++ gtests:** `tests/ttnn/unit_tests/gtests/test_<op>.cpp` (linked into the umbrella binary `./build/test/ttnn/unit_tests_ttnn`). UDM/specialized variants live in subdirs like `gtests/udm/<op>/` and link into sibling binaries (`unit_tests_ttnn_udm`, `unit_tests_ttnn_tensor`, `unit_tests_ttnn_ccl`, ...).
+- **Python pytests:** `tests/ttnn/unit_tests/operations/<op-family-slug>/` (plus nightly variants under `tests/ttnn/nightly/unit_tests/operations/<op-family-slug>/`).
+
+⚠ The pytest directory uses the **op-family slug**, not always the literal op name (e.g., reduction's tests live at `tests/ttnn/unit_tests/operations/reduce/`, not `reduction/`). The recipe asks the invoker to supply this path — confirm with `find` if unsure.
+
+### Find the tests for `<op>`
+
+```bash
+# C++ sources
+find tests/ttnn -path '*<op>*' -name '*.cpp'
+
+# Python sources
+find tests/ttnn -path '*operations/<op>*' -name 'test_*.py'
+
+# Which gtest binary owns the C++ tests (discovery only, no HW needed)
+for b in ./build/test/ttnn/unit_tests_ttnn*; do
+  echo "== $b =="; "$b" --gtest_list_tests 2>/dev/null | grep -i '<op>'
+done
+
+# Verify pytest collection without running
+pytest tests/ttnn/unit_tests/operations/<op>/ --collect-only -q
+```
+
+### Run them (requires HW)
+
+```bash
+./build/test/ttnn/unit_tests_ttnn --gtest_filter='*<Op>*'      # fast, ~op-scoped
+pytest tests/ttnn/unit_tests/operations/<op>/ -x               # broader coverage
+```
+
+**Recommended order:** run the gtest filter first — it's faster and exercises the C++ op directly, so it fails fast on a broken port. Run pytests after gtests are green to cover the Python-API surface, dtype/layout sweeps, and program-cache behavior. Nightly pytests are heavy; skip unless you suspect a regression they'd catch.
+
+### Worked example: `reduction`
+
+```bash
+# C++: test_reduction.cpp -> unit_tests_ttnn (tests: SumTensor*, MinMaxTensor* fixtures)
+./build/test/ttnn/unit_tests_ttnn --gtest_list_tests | grep -iE '(sum|minmax)tensor'
+./build/test/ttnn/unit_tests_ttnn --gtest_filter='SumTensor*:MinMaxTensor*'
+
+# UDM reduction lives in a sibling binary
+./build/test/ttnn/unit_tests_ttnn_udm --gtest_filter='*Reduction*'
+
+# Python
+pytest tests/ttnn/unit_tests/operations/reduce/ -x
+```
+
+Note: the pytest directory is `reduce/`, not `reduction/` — directory names are op-family slugs and not always the obvious noun. Use the `find` command above to confirm.
+
+## Friction surfaced during validation
+
+1. **`--build-metal-tests` is insufficient** for op porting — it omits TTNN gtests entirely. Always use `--build-tests` (or pass both `--build-metal-tests` and `--build-ttnn-tests` together).
+2. **`PYTHONPATH`** must point to your actual clone path. Copying a hardcoded `/proj_sw/user_dev/$USER/tt-metal` from someone else's instructions will silently set the wrong path if you cloned elsewhere.
+3. **`build/`** is a symlink (e.g., to `build_Release/`). Either path works in invocations.
+4. **`reduce/` vs `reduction/`** — pytest directories use op-family slugs. Always verify with `find`.

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/port_op_to_metal2_audit.md
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/port_op_to_metal2_audit.md
@@ -1,0 +1,805 @@
+# Porting an Op to Metal 2.0 — Feasibility Audit
+
+> This is the first of two documents covering the Metal 2.0 op port workflow. **This document covers the feasibility audit only — the gate that decides whether a given op can be ported today.** The port recipe (inventory, planning, construction, verification) lives in [`port_op_to_metal2_recipe.md`](port_op_to_metal2_recipe.md) and is loaded only after the audit clears with explicit user go-ahead.
+>
+> If you encounter a feature in the framework headers whose Appendix A status looks stale — most commonly, an `UNSUPPORTED` entry whose API has clearly landed — see [§Maintenance: keeping Appendix A current](#maintenance-keeping-appendix-a-current) for the override procedure.
+
+## Read this first
+
+**Why this audit exists.** Past attempts to port ops that weren't ready have produced wasted human and agent time, broken code, and PRs that had to be rolled back. This audit is the safeguard: it determines whether a given op *can* be ported today, before any port work begins. When the audit's actual finding is "no, not yet," a clearly grounded refusal — with file references and reasons — is a complete, valid deliverable. Producing such a refusal is not a half-finished port; it *is* the work. Equally, when the actual finding is GREEN, that's the deliverable. Your job is to follow the evidence; no thumb on the scale either way.
+
+**Audience**: AI agents asked to determine whether a TTNN op can be ported from the **`ProgramDescriptor` API** to the Metal 2.0 host API. Humans looking for a conceptual map of API differences should read [`metal2_migration_guide.md`](metal2_migration_guide.md) instead.
+
+**If you're new to this stack — quick orientation:**
+
+- **Tenstorrent accelerators** come in two architectural generations. **Gen1** is the shipping silicon today: `WH` = Wormhole, `BH` = Blackhole. **Gen2** is in development: `Quasar` (and siblings). This audit covers Gen1 ops; Metal 2.0 is designed to serve both architectures.
+- **TTNN** is the high-level neural-network library for Tenstorrent accelerators. Ops live in `ttnn/cpp/ttnn/operations/<family>/<op>/`. A typical op has a device-operation class on the host side and one or more program factories that build what runs on the accelerator.
+- **Metal 2.0** is the new **host API** — what the program factory uses to declare kernels, buffers, semaphores, and bindings. It also introduces **DFB** (Dataflow Buffer) at the spec layer, replacing the legacy **CB** (CircularBuffer); the two are essentially synonyms on Gen1, but DFB's semantics diverge meaningfully on Gen2.
+- **Device 2.0** is a *separate, earlier* overhaul of the **kernel-side** data-movement APIs (safer, more object-oriented wrappers — `experimental::Noc`, kernel-side `CircularBuffer` wrappers, etc.). The [Prerequisites step](#prerequisites) gates on Device 2.0 migration — for the op's own kernels *and* any donor kernels it calls — as a hard prerequisite to Metal 2.0, but Device 2.0 is *not* part of Metal 2.0 itself.
+- **`ProgramDescriptor` API** is a TTNN-side framework that ops must migrate to before a Metal 2.0 port becomes possible. The [Prerequisites step](#prerequisites) gates on it.
+- **Common acronyms you'll see throughout:** `CB` = CircularBuffer; `DFB` = DataflowBuffer (see above); `RTA` = runtime args; `CTA` = compile-time args; `CRTA` = common runtime args (values broadcast to all nodes); `TA` = TensorAccessor; `LLK` = Low-Level Kernel (the framework-provided kernel-side primitives); `NoC` = Network-on-Chip (the on-die fabric).
+
+For the conceptual map of how Metal 2.0 abstractions fit together — `ProgramSpec`, `KernelSpec`, `TensorParameter` / `TensorBinding`, `DataflowBufferSpec`, the spec/run-args split — see [`metal2_migration_guide.md`](metal2_migration_guide.md).
+
+**Scope**: This guide is for **TTNN ops that target Gen1 architectures** (Wormhole / WH, Blackhole / BH), to assess Metal 2.0 portability and gather findings about what the port will require.
+
+The audit produces useful findings for ops in two states:
+
+- **Already on the `ProgramDescriptor` API.** The audit decides whether the Metal 2.0 port can proceed. GREEN → port can begin (after explicit user go-ahead).
+- **Still on legacy `host_api.hpp` (imperative builder).** The audit RED's the ProgramDescriptor prerequisite and continues — the remaining subjects still surface findings that inform what the eventual Metal 2.0 port will need, once the `ProgramDescriptor` migration (a substantial, separate workstream) lands. This is data-gathering for downstream planning, not a port attempt.
+
+In either case, the audit's deliverable is the report. Porting itself happens via the [port recipe](port_op_to_metal2_recipe.md), which is loaded only after the audit clears (GREEN) with explicit user go-ahead.
+
+This guide is **not** for the following adjacent tasks. If your task is one of these, stop and surface the mismatch to the user — do not use this guide:
+
+- **Porting from Gen1 to Quasar** (different target architecture, different threading model). Out of scope entirely.
+- **Porting legacy Quasar tests** (those built against the temporary `experimental::quasar::CreateKernel` / `experimental::dfb::CreateDataflowBuffer` APIs) to Metal 2.0. A separate guide will cover that case; it is not this guide.
+
+If you are unsure whether your task fits the in-scope description, ask the user before proceeding.
+
+**Operating principle**: Your job is to identify gaps, not to invent solutions for unimplemented features.
+
+Some features the legacy API supports are not yet available in Metal 2.0. When you encounter such a feature, the correct response is to **refuse the port and report the gap to the user.** Refusing is not a failure mode — it is the correct outcome when a gate fails.
+When in doubt about feature support, **ask the user.** Do not infer support from API surface — the absence of a compile error does not mean the construct is supported.
+
+**What happens to your report.** Each audit report becomes a direct input to a downstream effort — not just an entry in a tracking spreadsheet:
+
+- A **RED** report feeds the **prereq-migration efforts**. The `ProgramDescriptor` migration team and the Device 2.0 migration team consume RED audits to scope and sequence the work that unblocks the Metal 2.0 port. A RED isn't a dead end — it's evidence routed to the team that resolves the gap.
+- A **GREEN** report feeds the **Metal 2.0 port recipe** at [`port_op_to_metal2_recipe.md`](port_op_to_metal2_recipe.md). The porter loads the audit as context when performing the port itself.
+- A **YELLOW** report is **genuinely ambiguous** and is evaluated case-by-case with the user to decide which downstream path the op takes.
+
+Your tier assignment, your subset suggestions, and the specificity of your finding details all carry weight in these downstream uses. Too-conservative RED misroutes work to a prereq team that doesn't need it; too-lenient GREEN sends a port attempt into a fail. The single strongest thing you can do is **be specific**: name files and lines; quote the construct you saw; describe what triggered the rule. Vague findings are the hardest to use downstream.
+
+**About this recipe.** This recipe is the product of iteration — earlier auditors' observations have already shaped it, and yours can too. If during your audit a step feels unclear, a rule contradicts itself, the recipe doesn't anticipate a case you're hitting, or guidance conflicts with what you observe in the code, **write it down in the audit report's "Recipe notes" section** rather than silently picking an interpretation. Treat the recipe as your guide, not your shackle. The recipe maintainer reads every report; the friction you log makes the next auditor's job easier.
+
+## Workflow at a glance
+
+Porting an op is a workflow split across two documents:
+
+1. **Feasibility audit.** *(This document.)* Assess this op's Metal 2.0 portability and capture findings — including what work will be required if the port can't proceed yet. Output: write `METAL2_PREPORT_AUDIT.md` to the op directory, then STOP.
+2. **Port recipe** — legacy inventory, spec planning, construction, and verification. Lives in [`port_op_to_metal2_recipe.md`](port_op_to_metal2_recipe.md). Loaded only after the audit clears with explicit user go-ahead.
+
+This audit document covers the feasibility audit only. **Your job in this document is to decide whether the port is feasible — not to perform it.** Producing the audit report and stopping is the complete deliverable. The recipe document is loaded as a separate step, after the user has reviewed your audit and explicitly asked you to proceed.
+
+You do not skip the audit. You do not pre-load the recipe document. The audit is its own unit of work.
+
+---
+
+## Feasibility audit
+
+For the op in scope, work through the audit in seven subjects, in order: **[Prerequisites](#prerequisites)** (ProgramDescriptor + Device 2.0), **[Feature compatibility](#feature-compatibility)**, **[TensorAccessor handling](#tensoraccessor-handling)**, **[Out-of-directory coupling](#out-of-directory-coupling)**, **[Custom program hash](#custom-program-hash)**, **[Other signals](#other-signals)**, and **[TTNN factory concept analysis](#ttnn-factory-concept-analysis)** (run last, since it draws on the others' findings). Each subject's checks have three possible outcomes:
+
+- **Green** — proceed past this check.
+- **Yellow** — requires user judgment (ambiguous signal, or a supported-but-trade-off construct). Ask the user; respect the answer.
+- **Red** — record the reason in the audit report and continue the audit. A RED outcome means the port is blocked on this finding; it does not mean stop auditing. Always complete the remaining checks and steps so the report captures everything the port will eventually need to clear, not just the first blocker.
+
+**Scope of the audit.**
+
+- **Follow kernel references, not directory boundaries.** Audit every kernel referenced by any `KernelDescriptor::kernel_source` in the op's program factories — cross-op kernels living in adjacent directories (e.g. `eltwise/`, `data_movement/`, `kernels/dataflow/`) are in scope when the op uses them.
+- **Unreferenced kernel files in the op's directory are out of scope.** If the op's directory contains kernel files that no factory references (dead code, tests, work-in-progress), do not audit their contents. If their presence could confuse a reader of the report, mention them in the identifying section as unreferenced; otherwise ignore them.
+- **Multiple device-operations in one op directory.** If the directory contains more than one `DeviceOperation` type sharing factories or kernels (e.g. `ReduceDeviceOperation` plus `WelfordReduceDeviceOperation`), audit them together and produce a single combined report. If the device-operations are independent, audit each separately. Ask the user if unsure whether to bundle. **When bundling, retain per-DeviceOperation attribution where findings differ** — name which DeviceOperation (or which of its factories) a given finding applies to, so a downstream consumer (per-op spreadsheet, ticket tracker, port planner) can extract per-DeviceOperation status from the bundled report when their accounting needs it. Bundling reflects the porting unit (shared code → shared port); downstream tools may legitimately operate at the DeviceOperation level (e.g. Tracy profiling, per-op leadership reporting).
+- **Routine runtime-arg setup is not a general audit signal — [TensorAccessor handling](#tensoraccessor-handling) handles the one specific case.** Most RTAs translate directly to `KernelSpec::runtime_arg_schema` and `ProgramRunArgs`; treat them as routine port work, not gates. The historical `tensor.buffer()->address()`-as-RTA pattern is the one exception: pre–Metal 2.0 it was style-yuck-but-correct, but under TTNN's recent fast-path-cache binding-injection changes it is now a per-binding correctness hazard. The TensorAccessor-handling subject catches and reports buffer-address RTAs specifically (as Case 2 bindings); routine runtime-arg setup outside that pattern remains non-signal.
+
+**Finding roles and routing.** Every audit finding carries one of four roles, and the role decides which output document it lands in (see [Output: the two documents](#output-the-two-documents)). This table is the audit's backbone — the per-check sections below *produce* these findings; they are not a separate set of rules.
+
+| Finding | Role | Routing |
+|---|---|---|
+| Op on ProgramDescriptor API | **GATE** | brief: cleared/blocked · team: detail → ProgramDescriptor team |
+| Device 2.0 compliance (own + donor kernels) | **GATE** | brief: cleared/blocked · team: exact violations → Device 2.0 team |
+| UNSUPPORTED feature in use (incl. CTA varargs) | **GATE** | brief: cleared/blocked · team: detail → wait-for-feature |
+| TTNN factory analysis — op-owned tensors · genuine MeshWorkload need | **FYI-U** | team only |
+| TTNN factory analysis — pybind `create_descriptor` · other risky pybind · custom override-RTA | **FYI-P** | brief (Watch-for) + team |
+| Per-binding TensorAccessor handling — Case 1 (`TensorAccessor`) / Case 2 (raw pointer → bridge) | **PORT WORK** | brief (Construct) + team |
+| Delete custom `compute_program_hash` (→ default) | **PORT WORK** | brief (Construct) + team |
+| Notable constructs — aliased CB / borrowed-mem DFB / dynamic TA (confusing); non-zero sem init (deprecated-but-fine) | **FYI-P** | brief (Watch-for) + team |
+| Fake CB (address-only; no producer + consumer) — port applies the workaround | **FYI-P** | brief (Watch-for) + team |
+| Cross-op / shared-kernel flags | **FYI-P** | brief (Watch-for) + team |
+| RTA varargs | **FYI-P** | brief (Watch-for) + team |
+| Out-of-directory coupling & donor shape analysis | **FYI-U** | team only |
+| Tensor-parameter relaxation candidates (fallible) | **FYI-U** | team only |
+| Incidental code anomalies — dead RTAs, dead-but-hashed attributes, suspicious constants | **FYI-U** | team only |
+
+**The four roles:**
+- **GATE** — blocks the port (an unmet prereq or an UNSUPPORTED feature). On PASS, the porter brief carries a one-line "cleared"; on FAIL, *no brief is issued* (there is no port) and the detail routes to the owning team. Always complete every check even after a GATE fails — the report captures everything the port will eventually need.
+- **PORT WORK** — the porter must *act* on it during the port.
+- **FYI-P** — informational, surfaced *to the porter* (and recorded for the team).
+- **FYI-U** — informational, *team-only* (feeds other workstreams; never reaches the porter).
+
+Findings flow to the two output documents by role: the **porter brief** carries GATE-cleared lines + all PORT WORK + all FYI-P; the **team findings** doc carries everything. See [Output: the two documents](#output-the-two-documents).
+
+### Prerequisites
+
+Metal 2.0 migration sits at the end of a chain of prior modernizations. This subject confirms the two hard prerequisites — the **`ProgramDescriptor` API** and **Device 2.0 data-movement migration** — and **both GATE the port**:
+
+- **Check 1 — `ProgramDescriptor` API** is the standalone hard prereq. If unmet, it is its own PR — substantial, separate work with TTNN-infrastructure implications that does *not* bundle with the Metal 2.0 port. Record the gap and continue the audit; do not attempt the migration here.
+- **Check 2 — Device 2.0 migration** (the op's own kernels *and* any donor kernels it calls) is also a hard prereq: the Metal 2.0 binding tokens attach to Device 2.0 wrapper objects, so a kernel still on Device 1.0 idioms cannot take the whitelisted swaps.
+
+**Complete both checks regardless of individual outcomes, then continue through the remaining subjects.** The audit's job is to gather a complete picture of what porting this op will require, including features the op uses that may be blocked on prereq work, characteristics that shape the port's scope, downstream dependencies on donor migrations, and per-binding correctness hazards. Do not exit early on a RED prereq — surface all findings to the report.
+
+**Check 1 (GATE): Op is on the `ProgramDescriptor` API.**
+
+Confirm the op's program-factory code populates a `ProgramDescriptor` and uses `KernelDescriptor`, `CBDescriptor`, `SemaphoreDescriptor`, etc. — *not* the older imperative-builder style from `host_api.hpp` (`CreateProgram` / `CreateKernel` / `CreateCircularBuffer` / `SetRuntimeArgs` / etc.).
+
+- **Green**: op uses the `ProgramDescriptor` API.
+- **Red (GATE)**: op uses the imperative `host_api.hpp` builder API (not `ProgramDescriptor`). Record the prereq gap — `ProgramDescriptor` migration is a **prerequisite to Metal 2.0 porting**, a substantial standalone body of work with TTNN-infrastructure implications, addressed in its own PR. **Do not attempt the migration as part of this audit, do not bundle it with anything, do not propose a partial conversion.** Continue with Check 2 and the remaining subjects — the feature-compatibility, TensorAccessor, call-surface, and other scans still produce useful findings (some features may need attention regardless of which API the op is currently on; others will only become relevant after the prereq lands).
+
+**Check 2 (GATE): Device 2.0 Data Movement migration — every kernel the op uses.**
+
+Confirm **every kernel this op exercises** is Device 2.0 compliant — **regardless of where the kernel file lives**. The op's own kernels, shared kernel-library code, in-family shared kernels, and borrowed/donor kernels from other families all count equally; location does not change the gate. What matters is whether the op's program factory instantiates or calls into the kernel. (An op may own *no* kernels of its own and file-path-instantiate all of them from a shared pool — those instantiated kernels are still fully subject to this gate; treat them as the op's effective kernels here.) See the [Device 2.0 Data Movement migration guide](../../kernel_apis/data_movement/device_api_migration_guide.md) for what compliance entails. The *coupling* that borrowing induces is inventoried under [Out-of-directory coupling](#out-of-directory-coupling); the *gating* judgment lives here.
+
+- **Green**: every kernel the op uses — wherever it lives — is Device 2.0 compliant.
+- **Yellow — substantively compliant with isolated legacy holdovers** (structurally portable; the holdover is Device 2.0 cleanup, *not* port scope). Kernel uses `experimental::Noc`, `experimental::CircularBuffer`, etc. for the bulk of operations and has a small number of isolated legacy holdovers from the **CB-index-keyed free-function family**: free functions taking a `uint32_t` CB index where the corresponding Device-2.0 wrapper object is already in scope at the call site. A free function is a holdover **only if a Device-2.0 wrapper-method replacement exists for it** — e.g. `get_read_ptr(cb_id)` → `cb_obj.get_read_ptr()`, `get_write_ptr(cb_id)` → `cb_obj.get_write_ptr()`. The shape (single CB-index argument, wrapper already in scope) is the cue, but it is **not** sufficient on its own: some CB-index free functions are *sanctioned* in Device 2.0 — its own migrated code uses them and they have no member form — and those are **not** holdovers. **If Device 2.0 allows the free function, so do we.** Currently sanctioned (do **not** flag): `get_tile_size(cb_id)` and `get_local_cb_interface(cb_id)`, both of which the [Device 2.0 migration guide](../../kernel_apis/data_movement/device_api_migration_guide.md) keeps as free functions in its migrated examples. *Breadcrumb:* `DFBAccessor` member-form replacements for these are planned, so the holdover-vs-sanctioned boundary will move — when unsure whether a free function has a member form, check the current Device 2.0 surface rather than assuming the shape alone makes it a holdover.
+
+  Each holdover is a 1-line mechanical replacement (e.g. `get_read_ptr(cb_id)` → `cb_obj.get_read_ptr()`). The op is otherwise structurally Device 2.0 — the wrapper objects are in scope, so the Metal 2.0 binding tokens attach — so the op is *feasible*, and the audit **still issues the porter brief** (no point forcing a re-audit after a trivial cleanup). **But the port cannot start until the holdover is fixed, and the fix is not part of the port:** a Device 2.0 change is out of port scope even when it's one line (the [kernel-side whitelist](port_op_to_metal2_recipe.md#kernel-side-whitelist) lets the port touch no Device 2.0 idioms — the port never scoops up stray holdovers). So: report each holdover with `file:line`, route it to the Device 2.0 effort to be cleaned **first** on that track, and have the brief flag it **prominently as a blocker the porter must clear before porting** (see [Output: the two documents](#output-the-two-documents)). The yellow tier applies when the holdovers are isolated within a kernel that otherwise consistently uses the wrappers; absolute count is a heuristic, not a rule.
+- **Red (GATE)**: any kernel the op uses — own, shared-library, in-family shared, or cross-family donor — broadly uses legacy Device 1.0 idioms (raw `noc_async_read`, manual CB index management, `InterleavedAddrGen` / `ShardedAddrGen` / `InterleavedAddrGenFast` / `InterleavedPow2AddrGen*`, raw sem addresses, etc.). **The port is blocked** until that kernel's Device 2.0 migration lands; route the exact violations to the team that owns Device 2.0 migration, naming the kernel file (and, for a borrowed/donor kernel, its owning family) so the dependency is schedulable.
+
+**Why Device 2.0 gates the port.** Device 2.0 cleanup is *not* on the [kernel-side whitelist](port_op_to_metal2_recipe.md#kernel-side-whitelist) of sanctioned port-time changes, and — more fundamentally — the Metal 2.0 binding tokens (`dfb::name`, `sem::name`, `ta::name`) attach to the Device 2.0 wrapper objects. A kernel still on Device 1.0 idioms has nothing for those tokens to bind to, so it cannot take the whitelisted Metal 2.0 swaps. Device 2.0 is therefore a hard structural prerequisite, on par with the `ProgramDescriptor` migration. (The isolated-holdover YELLOW above is the one carve-out, and only because the wrappers are *already in scope* there — the kernel is structurally Device 2.0 and the tokens attach.)
+
+### Feature compatibility
+
+Some legacy-API features are not yet supported in Metal 2.0. If the op uses one, it cannot be ported until support lands — those are **GATE** findings. Most legacy features, though, already have a Metal 2.0 home; a few of those translate via a non-obvious construct or carry a caveat, and those surface to the porter as heads-ups (**FYI-P**).
+
+**Run this scan regardless of the [Prerequisites](#prerequisites) outcome.** Each Appendix A entry's recognition signals work against both ProgramDescriptor-form and imperative-`host_api.hpp`-form code — see the per-entry recognition bullets. Even when the ProgramDescriptor prereq RED's the op, the feature scan still surfaces which features it uses; that's the data point the human reader needs to plan downstream work.
+
+For each entry in [Appendix A: Metal 2.0 feature compatibility](#appendix-a-metal-20-feature-compatibility), scan the op (host code, kernel code, factory functions, descriptors) using the recognition signals listed for that feature. Each entry declares its tier in the header — `UNSUPPORTED` (no Metal 2.0 support yet) or `LANDED` (supported today; the Status field names the replacement construct).
+
+- **Green**: no entry's recognition signals fire, or only `LANDED` entries fire whose translation is routine.
+- **Red (GATE)**: an `UNSUPPORTED` entry's signals match definitively. Report the feature name, the `file:line` where it appears, and the recognition signal that fired. The port is blocked on this finding; continue scanning the remaining Appendix A entries and the rest of the audit — complete the full audit even after a RED match.
+- **Yellow**: an `UNSUPPORTED` entry's signals match *ambiguously* (you cannot be sure whether the feature is in use). Ask the user; on confirmation it becomes a GATE, otherwise green.
+
+**Notable `LANDED` features (FYI-P heads-up).** A handful of supported features are worth flagging to the porter even though they don't gate — they translate via a non-obvious construct or carry a caveat. When one fires, surface it as a heads-up with its `file:line` and the construct the port will use:
+
+- **Aliased CBs** → `DataflowBufferSpec::advanced_options.alias_with` (a ninja feature; see the entry for the legality constraints).
+- **Borrowed-memory DFB** (dynamic CB on borrowed `Buffer` memory) → `DataflowBufferSpec::borrowed_from`.
+- **Dynamic `TensorAccessor`** (`ArgConfig::Runtime*`) → the **UNSAFE** `TensorParameterAdvancedOptions` relaxation opt-ins; adopting them has per-dispatch-caching implications, so flag for the user's awareness.
+- **Non-zero semaphore initial value** → `SemaphoreSpec::advanced_options.initial_value`, which is `[[deprecated]]` and unsupported on Gen2. Deprecated-but-fine on Gen1; note it so nobody mistakes it for a blocker.
+
+If the op uses something *not listed* in Appendix A and you are uncertain of its support status, treat as yellow and ask. Do not assume support from API surface.
+
+### TensorAccessor handling
+
+Every tensor a kernel reads must reach Metal 2.0 through the typed binding channel (`TensorParameter` / `TensorBinding`). This subject inventories, **per binding**, how the legacy op accesses each tensor and classifies the port work into one of two cases. Both cases are **PORT WORK** — the porter acts on them during the port; neither gates. (This subject merges what earlier versions of the audit split across a "TensorAccessor usage" check and a separate "TensorAccessor bypass" check: they detect the same population — tensors not cleanly on `TensorAccessor` — so they are one subject now.)
+
+**Why this matters.** The legacy hazard is a tensor base address that reaches the kernel through an RTA/CRTA. Under TTNN's fast-path-cache binding-injection model, the framework patches the typed-binding channel on cache hit but leaves RTAs untouched — so a buffer address routed through an RTA stays at whatever value the cache-populating call wrote, and on later cache hits with new tensor storage of the same shape the kernel reads the *original* buffer. No assertion fires; just wrong numerics, only on cache hits with non-identical storage. Pre–Metal 2.0 this was a style concern (*"yuck, raw pointers"*); the fast-path change made it silently wrong. The port replaces that RTA-smuggled address with a typed `TensorParameter` binding (which *does* refresh) — regardless of what the kernel then does with the base pointer (the two cases below), and including kernels that use no `TensorAccessor` at all (older addr-gen idioms, hand-rolled NoC walks).
+
+This resolves **at port time** — it waits for no framework feature, with one exception: a raw-pointer (Case 2) binding inside a **compute** kernel, which is blocked pending the compute-kernel `TensorBinding` fix (see the compute-kernel callout under *The two cases*).
+
+**Scope.** Audit only kernels that actually touch tensor memory. **Compute kernels that only consume from / produce to circular buffers are out of scope** — they read CB pointers, not tensor memory; the tensor read happens upstream in a dataflow kernel.
+
+**Causal-link gate (run this first, per binding).** Before classifying any binding, check whether the kernel's access is a **borrowed-memory DFB read**: it reads tensor data through `cb_*.wait_front` / `cb_*.get_read_ptr` from a CB that is itself a borrowed-memory CB (see the [Dynamic CircularBuffer entry](#dynamic-circularbuffer-cb-built-on-borrowed-buffer-memory--landed) under Feature compatibility). There the lack of `TensorAccessor` is *intended* — the borrowed-memory DFB **is** the tensor access — and the port handles it via `DataflowBufferSpec::borrowed_from`. Mark such a binding **clean**; do not force it into Case 1 or Case 2. Mis-classifying it as "convert to TensorAccessor" would be a regression.
+
+**But "clean" requires a real producer *and* consumer.** A borrowed-memory CB is only a genuine DFB if something produces into it and something consumes it — a sharded reader's fake-push satisfying a waiting compute consumer is the canonical legit case. **Litmus: does the CB have a producer *and* a consumer?** (The same core may be both.) If nothing produces into the CB and it is merely read by base pointer — no FIFO anyone waits on — it is a **fake CB**, *not* a clean borrowed-memory DFB. A fake CB cannot be expressed as a Metal 2.0 DFB (the spec validator requires ≥1 producer and ≥1 consumer), so the port resolves it with the sanctioned **fake-CB workaround** (see the porting recipe). This does **not** gate — the workaround keeps the port unblocked — but **report it as a heads-up (FYI-P)** at the **(CB, endpoint)** edge (the same CB can be a real LLK operand on one binding and address-only on another). The recip-LUT shape (resident input, read by raw pointer, no producer) is the trap this catches. If a kernel involves sharded code paths or reads from a CB rather than via `TensorAccessor`, scan the Dynamic CircularBuffer rule for the same code path before finalizing.
+
+**The two cases.** For each `TensorParameter` the op declares (or would declare in the port), classify by **what the kernel does with the tensor's base pointer**. In *both* cases the legacy host smuggles `buffer()->address()` in through an RTA/CRTA — the distinction is purely what the kernel does with that raw pointer on the device side, not whether one exists. A mechanical observation, not a judgment call:
+
+- **clean** — a borrowed-memory DFB read (the causal-link gate above). The DFB *is* the tensor access; the port handles it via `DataflowBufferSpec::borrowed_from`. Neither Case 1 nor Case 2 — no work item here.
+- **Case 1 — via `TensorAccessor`** (the common case). The kernel feeds that base address into a `TensorAccessor` constructor (`TensorAccessor(args, addr)`) and does all its memory access *through* the accessor (`accessor.get_noc_addr(page)` and friends). **Port work:** express the binding as a `TensorParameter` / `TensorBinding`; the kernel builds `TensorAccessor(ta::name)` instead, and the legacy address-via-RTA plus its `TensorAccessorArgs` plumbing both disappear. Mechanical, low-risk.
+- **Case 2 — raw pointer.** The kernel uses that base address *directly* — explicit address arithmetic and hand-rolled NoC calls, never constructing a `TensorAccessor` from it. **Port work:** express the binding as a `TensorParameter` / `TensorBinding` too (the address never stays on an RTA), but the kernel pulls the base via the sanctioned `TensorAccessor::get_bank_base_address` bridge and **keeps its existing raw arithmetic unchanged**. We do **not** rewrite raw access into `TensorAccessor` iteration — that conversion is deliberately out of scope (too high-risk for a port). A buffer-address RTA is *not* an acceptable substitute for the bridge.
+
+  > ⚠ **Case 2 in a *compute* kernel is currently blocked.** `get_bank_base_address` lives on `TensorAccessor`, which a compute (TRISC) kernel cannot bind today — so a compute kernel needing a raw base address has no bridge. Such a binding **gates the port**: report it and stop, routing it to the compute-kernel `TensorBinding` fix. Do *not* fall back to smuggling the address through a CRTA/RTA — even from an op-owned tensor, where it would be strictly correct, that path is closed (see [recipe rule 5](port_op_to_metal2_recipe.md#kernel-side-whitelist)).
+
+**Detection — host side.** Any site where `buffer->address()` (or `->address()` / `(*buffer).address()` / `tensor.buffer()->address()`) flows into a runtime-args context. Common shapes:
+
+- **Descriptor form** (the in-scope case for `ProgramDescriptor`-API ops): `KernelDescriptor::runtime_args` or `runtime_common_args` initializers containing the address expression directly. E.g. `kd.runtime_args = {{core_coord, {input_buffer->address(), num_pages}}};`.
+- **Imperative form** (only in ProgramDescriptor-prereq RED ops, but record matches since the eventual port still needs them): `SetRuntimeArgs` / `SetCommonRuntimeArgs` argument lists containing the address expression.
+- **Helper-function form**: a function takes a `Buffer*` / `Buffer&` and injects its address into an arg vector (`args.push_back(...)`, in-place vector init, named accumulator). Read the helper body — it often hides the bypass.
+- **`Buffer*`-binding form** (descriptor API): the factory pushes a `Buffer*` (the pointer object itself, *not* `->address()`) into `KernelDescriptor::RTArgList` / `emplace_runtime_args`. The framework auto-registers these as `BufferBinding`s and **patches them on cache hits**, so this shape is *correct-on-cache-hit today* — it is **not** the silent-wrong hazard. (It's the framework's interim hack for plugging the stale-pointer hole in `ProgramDescriptor` ports; the Metal 2.0 typed binding supersedes it.) **Still enumerate it** — the kernel consumes a raw `uint32_t` base, so it is **Case 2** (raw pointer → bind as `TensorParameter`, bridge via `get_bank_base_address`) — but record it as routine port work, not a correctness hazard (the framework patches it on cache hits today). Enumerating *all* pointer arguments is the point; just don't over-state the urgency of this one.
+- **CTA-baked-address form**: the factory bakes `buffer->address()` into a **compile-time** arg (not an RTA) that a kernel consumes as a `TensorAccessor` base address (often via an NTTP). Like the `Buffer*` form, this is **not** the silent-wrong hazard — a compile-time arg forces a recompile per address, so a stale base can't survive a cache hit — but it **is** a pointer argument to enumerate: classify it **Case 1** (via `TensorAccessor` — express it as a `TensorParameter`, and the CTA-baked address + kernel-side NTTP base both disappear). Detect it by a `buffer->address()` / `.address()` expression flowing into the factory's *compile-time*-args list rather than its runtime-args list.
+
+For each `TensorParameter`, cross-check: does the same buffer also appear in an RTA address argument? If yes, that buffer is consumed as a raw pointer → **Case 2** (bind as `TensorParameter`, bridge via `get_bank_base_address`).
+
+**Detection — kernel side.**
+
+- `get_noc_addr_from_bank_id<bank_type>(bank_id, addr)` where `addr` traces back to a `get_arg_val`. The textbook anti-pattern.
+- `get_noc_addr(x, y, addr)` where `addr` traces back to RTAs.
+- `noc.async_read(addr, ...)` / `noc_async_read(addr, ...)` where `addr` was computed from an RTA-sourced base + offset arithmetic.
+- Variable names that telegraph buffer-address purpose — `src_addr`, `dst_addr`, `remote_addr`, `base_addr`, `input_addr` — when their value comes from `get_arg_val`.
+
+**False-positive guards — do NOT flag.**
+
+- `get_arg_val<uint32_t>` for shape / count / index / control values. Those uint32s aren't addresses.
+- `accessor.get_noc_addr(page_id)` outputs — that's the `TensorAccessor` path (Case 1), not a raw-pointer Case 2; don't flag it.
+- Host-side `set_globally_allocated_address(buffer)` — the borrowed-memory pattern, covered by the Dynamic CircularBuffer feature entry (clean via the causal-link gate).
+- Kernel reading from a borrowed-memory CB via `cb.get_read_ptr()` — clean; the causal-link gate applies.
+
+**Granularity — per binding, not per op.** An op may have multiple tensor bindings, some clean and some needing work. Report per binding — a single Case-1 or Case-2 binding fires this subject even when the op's primary I/O is via `TensorAccessor`. **Classification can also vary per factory within one bundled op** — the *same* `TensorParameter` may be clean (borrowed-memory DFB) in one factory and Case 1 in another (e.g. a sharded vs. an interleaved factory). When that happens, record the per-factory split via the report's Per-DeviceOperation attribution rather than forcing one flat verdict for the binding.
+
+**Op-level roll-up:** `✓ clean` (every binding clean) / `⚠ port work` (one or more Case-1 / Case-2 bindings), with the per-binding inventory in the report.
+
+### Out-of-directory coupling
+
+Run this subject regardless of the other subjects' outcomes. **The findings here are informational (FYI).** The one place donor coupling *gates* the port — a donor kernel still on pre-Device-2.0 idioms — is judged in [Prerequisites § Check 2](#prerequisites); this subject inventories the coupling in full so that gate is well-scoped and any future multi-op coordination is visible. This is the most substantial subject in the audit; budget time accordingly. It covers **two distinct escape types**: *function-call escape* (the kernel `#include`s and calls another op's helper function) and *file-path kernel instantiation* (the program factory `CreateKernel`s a kernel `.cpp` owned by another op). The bulk of the machinery addresses function-call escape; file-path escape is surfaced separately at the end as a coupling signal.
+
+**Why this check exists.** Op kernels frequently `#include` headers outside their own directory. When a Metal 2.0 port crosses one of these boundaries, the kernel's named tokens (`dfb::name`, `sem::name`, `ta::name`) need to translate into whatever shape the donor's signature expects. Some shapes cross cleanly; others require donor-side conversion work, most commonly because **the donor itself isn't on Device 2.0 yet**.
+
+The Device 2.0 → Metal 2.0 sequencing rule applies: ops must complete Device 2.0 migration before Metal 2.0 can proceed. A donor consumed by this op that is still on pre-Device-2.0 idioms (`InterleavedAddrGen`, `ShardedAddrGen`, raw sem addresses, `CircularBuffer&`) blocks this op's Metal 2.0 port until the donor migrates — that **GATE judgment is recorded in [Prerequisites § Check 2](#prerequisites)**; here, inventory the donor shape so the gate is specific and schedulable.
+
+**Inventory phase.** For each kernel file in the op, list every `#include` whose resolved path lies outside the op's own directory. Identify the donor class:
+
+1. **`tt_metal/*`** — LLK / HAL / firmware. No concern.
+2. **`ttnn/cpp/ttnn/kernel_lib/`** — official shared kernel library; lib team handles internally.
+3. **`ttnn/cpp/ttnn/kernel/`** (singular) — a second shared-kernel pool. Treat as shared-lib class.
+4. **`ttnn/cpp/ttnn/operations/kernel_helper_functions/`** — small shared utility pool.
+5. **In-family shared** — kernels within the same op family. In-family escapes don't *gate* the Metal 2.0 port; you port the family together. (This concerns the Metal 2.0 *syntax* rewrite, not Device 2.0 — in-family kernels remain fully subject to the [Device 2.0 gate](#prerequisites), which is location-independent.)
+6. **Cross-family donor** — kernels in another op family's directory.
+
+**Per-call shape analysis.** For each donor file consumed by the op, identify which public functions the op's kernels actually call, and classify each by the shape of the resource handles in its signature.
+
+| Shape | Status | Notes |
+|---|---|---|
+| `Semaphore` / `Semaphore&` / `const Semaphore&` | ✓ excellent | Device 2.0 native. |
+| `uint32_t sem_id` | ⚠ suboptimal | `sem::name`'s constexpr cast to `uint32_t (sem_id)` handles once landed. Workable today. |
+| `uint32_t sem_addr` (L1) or `uint64_t` NOC-encoded sem | ✗ not OK | No clean Metal-2.0 → donor bridge today. A backdoor could be added. |
+| `TensorAccessor<DSpec>` / ref (Shape 1) | ✓ excellent | Porter constructs `TensorAccessor(ta::name)` and passes. |
+| `TensorAccessorArgs<N>` (Shape 2) | ✗ not OK | Porter can pass `ta::name.args`. Workable, but suboptimal. |
+| Tensor CTA offset as NTTP (Shape 3) | ✗ not OK | No workaround today; would require a one-line `ta::name::cta_offset` add to `TensorAccessorBindingToken`. |
+| Old-style addr-gen — `InterleavedAddrGen`, `ShardedAddrGen`, `InterleavedAddrGenFast`, `InterleavedPow2AddrGen*` (Shape 4) | ⭐ ✗ very not OK | Donor is pre-Device-2.0 — the donor-side Device 2.0 **GATE** (recorded in [Prerequisites § Check 2](#prerequisites); the op's *own* kernels are gated there too). Inventory the donor file + kernel here so the gate is specific. |
+| `uint32_t cb_id` | ✓ OK | `dfb::name`'s constexpr cast handles runtime AND template-parameter position. |
+| `CircularBuffer` / `CircularBuffer&` / `const CircularBuffer&` | ⭐ ⚠ flag | Op-by-op porting + DFB-replaces-CB on the consumer side leaves no clean per-op story today. Flag for cross-team discussion. |
+
+One donor file can have multiple functions with different shapes — classify per function.
+
+**Report format.** Three-part structure:
+
+1. **Op-level roll-up** — one-line headline status (`✓ clean` / `⚠ workable` / `⭐ blocked`), plus a tight bullet inventory of the kinds of issues found across all donors.
+2. **Summary table** — one row per (op kernel, donor file) pair across all buckets.
+3. **Per-call detail** — per-function breakdown for donors with ⚠ / ✗ / ⭐ entries. Omitted entirely if all rolls are ✓.
+
+Status roll-up uses ✓ / ⚠ / ✗ / ⭐. The star is reserved for entries that create scheduling blockers — Shape 4 (donor pre-Device-2.0, the donor-side Device 2.0 gate per [Prerequisites § Check 2](#prerequisites)) and `CircularBuffer&` (op-by-op friction). Other ✗/⚠ items are workable today or need donor work, but don't sequence-block.
+
+**Borrowed kernel files (file-path kernel instantiation).** Separate from the function-call escapes inventoried above: list every kernel `.cpp` file the op's program factory instantiates whose source it does **not** own — anything from a shared pool, in-family or cross-family. (Some ops own *none* of their kernels and instantiate every one from a shared pool — list them all.) For each, record:
+
+- The kernel file's path.
+- The owning op family (or shared pool).
+- Whether the file is also instantiated by other ops (broadly-shared) or is a one-off borrow — and, where cheap to determine, *which* other ops.
+
+This signal **does not gate the port**, but it induces a **port-the-family-together coupling that must be reported**. A shared kernel's Metal 2.0 rewrite (CB→DFB, named-token bindings, etc.) is a *single* rewrite: every op that instantiates that kernel must adopt it in the same change, or the co-borrowers break the instant one op migrates in isolation. So the set of ops sharing a kernel forms a Metal 2.0 **port-together set** — report that set (or as much of it as is cheap to find) so planners can sequence the shared rewrite as one unit. Surface this even when the function-call escape roll-up is `✓ clean` — file-path coupling is independent. (This is distinct from the [Device 2.0 gate](#prerequisites), which applies to every one of these kernels regardless of coupling.)
+
+### Custom program hash
+
+**Recognition.** The op's device-operation type defines a `compute_program_hash` member or override, replacing the default reflection-based hash. Record the location (`file:line`).
+
+**Finding role: PORT WORK — delete it.** If the op has a custom `compute_program_hash`, the port **deletes it and reverts to the default TTNN hash.** This is a *sanctioned exception* to the rule that the device-operation class is off-limits during the port — parallel to the [pybind-deletion exception](port_op_to_metal2_recipe.md#host-side-stay-in-the-lane). The justification is structural:
+
+- **No Metal 2.0 factory concept reads the custom hash.** It has no role in the ported caching path.
+- **PD-ported custom hashes are frequently incorrect now.** Many were written against an earlier framework and silently omit `TensorSpec` from the key — which trips `UpdateTensorArgs` legality failures on fast-path cache hits (a cache hit on a `ProgramSpec` built for different inputs).
+- **The default is correct-by-construction.** The default hash keys on the op args that determine the program — its type, attributes, and tensor args (including each tensor's `TensorSpec`) — so a cache hit only happens for a genuinely equivalent invocation.
+
+So this is neither "patch the custom hash" nor "wait and see if it bites at verification" — it is a deletion the porter performs as part of the port, recorded prominently in the port report (a device-op-class change). Do **not** try to repair a custom hash to include `TensorSpec`; that path leads to subtle bugs.
+
+**Before deleting — mine it for relaxation candidates (FYI-U, team-only, FALLIBLE).** A custom hash sometimes encodes which tensor properties the op *actually* depends on — a clue to where a `TensorParameter` relaxation (`dynamic_tensor_shape` / `match_padded_shape_only`) might be safe. Before the hash disappears, read it and record any such candidates for the team's relaxation roadmap. **This is fallible**: many custom hashes are themselves wrong, so a candidate mined from one is a *candidate to verify*, not a conclusion. The default remains strict (per the [TTNN integration doc](port_op_to_metal2_ttnn_factory.md)); a relaxation is applied only on explicit user OK. These candidates never reach the porter brief — they feed the team record only.
+
+### Other signals
+
+A residual subject for signals that don't belong to any of the other subjects. Today it holds one check.
+
+**RTA varargs (FYI-P).** Recognition: a kernel reads `num_runtime_varargs > 0` from its `KernelDescriptor`, OR pulls arguments in a counted loop (`for (int i = 0; i < N; ++i) { get_arg_val<uint32_t>(i); ... }`) where `N` is itself runtime-known. Typical in ops with a runtime-variable input count.
+
+Metal 2.0 **supports** RTA varargs via the kernel-side vararg mechanism, so this does not gate — it is a porter heads-up. Report the kernel and the recognition site (`file:line`), and note that the port will choose between named RTAs (the recommended endpoint — one named RTA per legacy positional argument) and Metal 2.0's RTA vararg mechanism (only when the kernel genuinely loop-retrieves with a runtime-varying index, per the recipe's [kernel-side whitelist rule 4](port_op_to_metal2_recipe.md#kernel-side-whitelist)).
+
+**Not to be confused with CTA varargs**, which **do** gate the port (caught by the [CTA varargs Appendix A entry](#variable-count-compile-time-arguments-cta-varargs--unsupported)): kernels that loop over `get_compile_time_arg_val(i)` with a runtime-varying `i`, or ops whose `tensor_args_t` carries a variable-count container like `std::vector<Tensor>`.
+
+**Incidental code anomalies (FYI-U).** While reading the op you will sometimes notice latent issues that are neither audit findings nor the porter's to fix — a dead/unused RTA, an attribute the factory forces or ignores yet still feeds to `compute_program_hash`, a suspicious hardcoded constant. Record these in the report's **Misc anomalies** section: team-only, non-gating, *not* porter-actionable (they route to the op owner, never into the port diff). Don't go hunting for them — just note what you happen to see while auditing.
+
+### TTNN factory concept analysis
+
+**This subject is analysis, not a decision.** Ops port to a single Metal 2.0 factory concept (`MetalV2FactoryConcept`); this subject does **not** re-decide that and does **not** itself gate. Your job is to answer six questions about the op's TTNN-side shape and record each with `file:line` evidence; the downstream port (see [`port_op_to_metal2_ttnn_factory.md`](port_op_to_metal2_ttnn_factory.md)) consumes them to confirm the op fits that concept and to surface any residual blocker (genuine multi-program, op-owned `GlobalSemaphore`s). Run this subject **last**, after the other subjects have produced their findings — op-owned-tensor recognition draws on the [TensorAccessor-handling](#tensoraccessor-handling) per-binding inventory.
+
+**Scope reminder.** Throughout, *"does this op …"* means *"do **any** of this op's ProgramFactories …"* — inspect every ProgramFactory the op defines; a yes on any one is a yes for the op, and you attribute the finding to the factory (and DeviceOperation, when bundled) where it appears.
+
+Answer each question Yes/No with the evidence that decided it:
+
+1. **Op-owned tensors?** Does any ProgramFactory allocate and manage device tensors of its own — intermediate / scratch tensors beyond the op's declared input and output tensors? *Recognition:* a factory (or the device-operation's tensor plumbing) that creates a device tensor it owns — e.g. `create_device_tensor` / `allocate_tensor_on_device` in the factory or device-op `.cpp`, or an intermediate `Tensor` constructed and threaded into the program that is not in `tensor_args` / `tensor_return_value`. Record each owned-tensor site.
+
+2. **MeshWorkload concept needed?** Does any ProgramFactory *genuinely* require multi-program / MeshWorkload structure (true cross-program or cross-device coordination)? *Recognition:* the factory provides `create_mesh_workload` / `create_workload_descriptor`, or the device-operation carries `cached_mesh_workload_t`. **False-positive trap — read this before answering Yes.** A *legacy* op may sit on the MeshWorkload path only because the old framework couldn't carry op-owned tensors on the single-program path — a plumbing artifact, **not** a genuine MeshWorkload need. `MetalV2FactoryConcept` now carries op-owned tensors natively (`op_owned_tensors`), so such an op is morally single-program and **ports cleanly** — it is not blocked. Distinguish "needs MeshWorkload because the op is genuinely multi-program / cross-device-coordinated" (→ **Yes**) from "appears on the MeshWorkload path only because it has op-owned tensors" (→ **No**, and say so explicitly, naming Q1 as the cause). When you can't tell, mark it a question for the user rather than guessing Yes.
+
+3. **Pybind `create_descriptor`?** Does the op pybind the *innards of a ProgramFactory*? **Carve-out first:** every op pybinds the op *itself* — the user-facing function (`bind_function<"op_name">` / `mod.def("op_name", …)`), its program-config classes, its enums. **That normal surface is expected and is *not* a finding.** What this question targets is the surprise: a binding of the **ProgramFactory class** that reaches into `create_descriptor`. *Recognition:* an `nb::class_<…ProgramFactory>(…).def_static("create_descriptor", …)` (or `.def`) in the op's `*_nanobind.cpp`. The port deletes this (a sanctioned device-op-class edit — see `port_op_to_metal2_ttnn_factory.md`); record the binding site. *(Canonical example: layernorm's `bind_normalization_layernorm_program_factory` binds `create_descriptor` on both factory classes — note the extra `core_range_set` parameter that exists **only** to drive the pybind hook, the tell that this is factory-innards, not the normal op surface.)*
+
+4. **Other migration-risky pybind?** Does the op pybind anything *else* from the **ProgramFactory or DeviceOperation internals** that would interfere with the Metal 2.0 migration? *(Deliberately broad — and the Q3 carve-out applies again: the normal op-function / program-config / enum bindings don't count.)* The discriminator is *what the `nb::class_<>` wraps*: a `DeviceOperation` or factory/param class is the surprise. Look for the device-op's methods exposed to Python (`compute_program_hash`, `create_output_tensors`, `compute_output_specs`, `select_program_factory`), pybound attribute / input structs, a factory parameter that exists only to drive a pybind hook, or any introspection entry point returning `ProgramDescriptor`. When something looks like it could complicate the port, surface it with its site rather than deciding it's harmless. *(Canonical example: layernorm's `bind_normalization_layernorm_device_operation` and `..._params_and_inputs`.)*
+
+5. **Custom hash?** Does the op declare a custom `compute_program_hash`? Yes/No + `file:line`. *This is a presence check only* — the treatment (the port deletes it, reverting to the default) lives in the [Custom program hash](#custom-program-hash) subject; cross-reference it rather than re-deriving.
+
+6. **Custom override-runtime-args?** Does any ProgramFactory define a custom `override_runtime_arguments` (the cached-program override hook)? Yes/No + `file:line`. *Recognition:* a `static void <Factory>::override_runtime_arguments(...)` declaration / definition.
+
+**Finding roles.** None of these gate. Q1 and Q2 are **FYI-U** (team-only — they inform the port's TTNN ProgramFactory wiring). Q3, Q4, and Q6 are also **FYI-P** porter heads-ups, because each presages a device-op-class edit; Q5 (custom hash) is already carried as PORT WORK by the [Custom program hash](#custom-program-hash) subject, so here it's a presence cross-reference. Record all six in the team doc; surface Q3/Q4/Q6 in the porter brief.
+
+**Output.** Record the six answers in `METAL2_PREPORT_AUDIT.md`: the Yes/No summary fills the *TTNN Readiness* rows of the [Status summary](#output-the-two-documents), the full evidence lands under **TTNN factory analysis** in the Team-only section, and the porter-relevant items (Q3, Q4, Q6) are mirrored into **Heads-ups** (and thus the brief).
+
+### Output: the two documents
+
+The audit emits up to **two** files, by audience. Write them to the **op's root directory** — one level above `device/`, alongside the op's host-facing `.cpp` / `.hpp` files (e.g. `ttnn/cpp/ttnn/operations/<family>/<op>/`), **not** inside the `device/` subdir even though the program-factory `.cpp` files live there. They sit next to `METAL2_PORT_PLAN.md` and `METAL2_PORT_REPORT.md` (written later by the port recipe), so all generated docs for the port land in one spot.
+
+- **`METAL2_PREPORT_AUDIT.md`** — **team-facing, always emitted.** The complete record, and the source the cross-team readiness spreadsheet is filled from. Every finding lands here, regardless of role.
+- **`METAL2_PORT_BRIEF.md`** — **porter-facing, emitted when the audit clears every gate** — either fully GREEN, **or** YELLOW *only* on isolated Device-2.0 holdovers. (In the holdover case the op is feasible, so the brief issues — no point forcing a re-audit after a trivial cleanup — but it flags the holdovers **prominently as a blocker the porter must clear first**, on the Device 2.0 track, before porting.) The porter's actionable input, ordered by the porter's *workflow*: plan, then construct, then watch-for. On any **RED** there is no brief — there is no port yet.
+
+Findings route to these documents by role (per the [finding-roles routing table](#feasibility-audit) at the top of the audit): the **brief** carries GATE-cleared one-liners + all PORT WORK + all FYI-P; the **team doc** carries everything, including FYI-U.
+
+**Cross-references inside the generated files name the doc plainly** (e.g. `port_op_to_metal2_ttnn_factory.md`) rather than using a markdown link. These files live in the *op directory*, where a doc-relative link (`](port_op_to_metal2_ttnn_factory.md)`) doesn't resolve, and op directories sit at varying depths — so a hardcoded relative path is fragile. The porter has the repo open; a plain doc name is enough.
+
+**In chat, surface only the Result line plus the file path(s)** so the user can open the files when ready. Do not paste a full report inline — an audit of any non-trivial op runs to dozens or hundreds of lines, and chat-scrollback isn't the right home for it. Markdown formatting in the files is required, not optional: the headers, tables, and inline-`code` spans are what make a sizeable report skim-friendly.
+
+**Reassuring framing for the human reader.** A RED gates *this specific port attempt* but is **not** a permanent blocker — most REDs mean "Metal 2.0 hasn't implemented this yet," and the port becomes possible once the feature lands; a few (today: just `address_offset`) need a runtime-team consultation about a redesigned API. Surface the future path explicitly for every RED, so a colleague reads the path forward, not just the gate. In particular, a **ProgramDescriptor-prerequisite RED is the expected outcome** for any op still on the legacy imperative API — not an alarm — and the port unblocks once that op's `ProgramDescriptor` migration lands.
+
+**Code-path scope.** Blockers are often confined to specific code paths (e.g. a single factory's `if (use_width_sharding)` branch). When so, identify clean vs. blocked paths explicitly and offer a scoped-subset port — "interleaved-only paths, omitting the sharded path." A partial port that delivers value now may beat waiting for the full gate to clear; reflect it in the Result (`RED at op level; subset <X> is clear`).
+
+#### `METAL2_PREPORT_AUDIT.md` — team-facing (always emitted)
+
+Opens with a **status summary that mirrors the cross-team readiness spreadsheet 1:1** — one field per spreadsheet column, grouped Prereqs / Feature Support / TTNN Readiness — so a parsing reader does straight field→column copies. The detail sections follow. (Extend any cell, row, or paragraph with multi-line context where it improves clarity.)
+
+````markdown
+# Metal 2.0 Audit Findings — `<op path>`
+
+<Identifying section: device operations sharing the directory, factory file list, anything needed to disambiguate. For multi-device-op directories, nest — outer bullets for device-operations, inner for their program factories. Example shape:
+
+- **`ReduceDeviceOperation`**
+  - `ReduceSingleCoreHwProgramFactory` (`reduce_op_single_core_hw_program_factory.cpp`)
+  - `ReduceMultiCoreHProgramFactory` (`reduce_op_multi_core_h_program_factory.cpp`)
+- **`WelfordReduceDeviceOperation`**
+  - `WelfordReduceProgramFactory` (`welford_reduce_program_factory.cpp`)
+>
+
+**Scope:** TTNN op, Gen1 (WH/BH) target — within scope of `port_op_to_metal2_audit.md`.
+
+## Status summary
+
+| Field | Value |
+|---|---|
+| **Op directory** | `<path>` |
+| **Overall** | GREEN / YELLOW / RED |
+| **DOps / Factories** | `<DeviceOperation>` → `<factory list>` |
+| *Prereqs* — ProgramDescriptor | Yes / No |
+| *Prereqs* — Device 2.0 (every kernel used) | Yes / Yes-with-holdovers (YELLOW — fix on D2.0 track first) / No |
+| *Prereqs* — Cross-op escapes | Ok / issue |
+| *Feature Support* — overall | GREEN / RED |
+| *Feature Support* — Variadic-CTA | Ok / Unsupported |
+| *TTNN Readiness* — Op-owned tensors | No / Yes: `<factory + site>` |
+| *TTNN Readiness* — MeshWorkload needed | No / No (op-owned tensors — carried natively, single-program) / Yes (genuine): `<reason>` |
+| *TTNN Readiness* — Pybind `create_descriptor` | No / Yes: `<nanobind site>` |
+| *TTNN Readiness* — Other risky pybind | None / `<description + site>` |
+| *TTNN Readiness* — Custom hash | No / Yes → delete (see Custom program hash) |
+| *TTNN Readiness* — Custom override-RTA | No / Yes: `<factory + site>` |
+| *TTNN Readiness* — Fake CBs (address-only) | None / present: `<(CB, endpoint) sites>` (workaround) |
+
+**Fake CBs** = CBs used purely as an address source. **Litmus: does the CB have a producer *and* a consumer?** (Same core may be both.) No producer–consumer pair → fake: a Metal 2.0 DFB needs ≥1 of each, so a fake CB can't be expressed as a DFB — the port resolves it with the sanctioned fake-CB workaround (see the porting recipe), so it's an **FYI-P heads-up, not a gate**. Granularity is the **(CB, endpoint) edge** — the same CB can be a real LLK operand on one binding and address-only on another; record each address-only edge.
+
+## Result
+
+**GREEN → brief issued** · **RED → blocked on `<gate>`**, routed to the `<ProgramDescriptor / Device 2.0 / wait-for-feature>` team · **YELLOW → open questions (see below)**. State the primary blocker(s) in plain language; if localized, name a clean subset (`RED at op level; subset <X> is clear`).
+
+## Gate detail
+
+- **ProgramDescriptor:** <GREEN — or — RED with the imperative-API calls that disqualify, plus the "separate ongoing effort; expected outcome for legacy ops; unblocks when the migration lands" framing.>
+- **Device 2.0 (every kernel used):** <GREEN — or — YELLOW (isolated CB-index holdovers; routed to the Device 2.0 effort, *not* folded into the port; table below) — or — RED with exact violations @ `file:line`, routed to the Device 2.0 team. Name the kernel file and, for a borrowed/donor kernel, its owning family.>
+
+  | File | Line | Call | Wrapper in scope |
+  |---|---|---|---|
+  | `<path>` | `<n>` | `<call>` | `<wrapper>` |
+
+- **Feature compatibility:** every Appendix A entry, in order. Per-row status: `N/A` when the feature category is absent — *including an UNSUPPORTED feature the op doesn't use* (not a vacuous GREEN); `GREEN` only for a LANDED feature actually in use and clean; `RED` for an UNSUPPORTED feature in use. UNSUPPORTED hits (incl. CTA varargs) get an H4 detail block with signal, `file:line` sites, and expected resolution. For `address_offset`, surface the runtime-team-consultation message verbatim per the entry's Action field.
+
+  | Feature | Status | Notes |
+  |---|---|---|
+  | GlobalCircularBuffer | GREEN / RED / N/A | |
+  | Dynamic CircularBuffer (borrowed memory) | GREEN / N/A | port uses `borrowed_from` |
+  | CBDescriptor `address_offset` (non-zero) | GREEN / RED / N/A | |
+  | Aliased Circular Buffers | GREEN / N/A | port uses `advanced_options.alias_with` |
+  | GlobalSemaphore | GREEN / RED / N/A | |
+  | Non-zero semaphore initial value | GREEN / N/A | `[[deprecated]]`, Gen2-unsupported — heads-up |
+  | Dynamic TensorAccessor (`ArgConfig::Runtime*`) | GREEN / N/A | UNSAFE relaxation opt-in — heads-up |
+  | `UpdateCircularBuffer*` | GREEN / RED / N/A | |
+  | Variable-count compile-time arguments (CTA varargs) | GREEN / RED / N/A | |
+
+## Port-work summary  *(mirrors the brief)*
+
+- **Tensor bindings** (per binding): `<name>` Case 1 (`TensorAccessor`) / Case 2 (raw pointer → bridge; **blocked in a compute kernel**) / clean (borrowed-DFB).
+- **Custom hash:** delete custom `compute_program_hash` → default (sanctioned exception) | none.
+
+## Heads-ups  *(mirrors the brief)*
+
+- **Notable LANDED constructs:** aliased CB / borrowed-mem DFB / dynamic TA / non-zero sem init — with `file:line` and the construct the port uses.
+- **Fake CBs (address-only):** each CB used purely as an address source — no producer + consumer pair — at the `(CB, endpoint)` edge with `file:line`. The port resolves it with the fake-CB workaround (see the porting recipe); it does **not** gate.
+- **Cross-op / shared kernels:** borrowed kernel files + shared-kernel coupling.
+- **RTA varargs:** kernel + recognition site.
+- **TTNN factory analysis (porter-relevant):** pybind `create_descriptor` to delete · other migration-risky pybind · custom `override_runtime_arguments` — each with `file:line`.
+
+## Team-only
+
+- **Out-of-directory coupling & donor shape:** the full by-shape inventory (op-level roll-up, summary table, per-call detail, borrowed kernel files).
+- **Relaxation candidates** (mined from the custom hash before deletion): **FALLIBLE — candidates to verify**, default strict.
+- **TTNN factory analysis:** the six-question answers — op-owned tensors, MeshWorkload need (genuine vs. op-owned-tensor artifact), pybind `create_descriptor`, other risky pybind, custom hash, custom `override_runtime_arguments` — with `file:line` evidence. Informs the port's TTNN ProgramFactory wiring; does not gate.
+
+## Misc anomalies  *(omit if none; team-only, non-gating)*
+
+<Latent code issues noticed while auditing that are neither audit gates nor porter work — dead/unused RTAs, attributes forced or ignored in the factory yet still fed to `compute_program_hash`, suspicious hardcoded constants, and the like. One bullet each with `file:line`. These route to the op owner; the port does not act on them.>
+
+## Per-DeviceOperation attribution  *(when bundled)*
+
+<One status-summary row per DeviceOperation when the directory bundles more than one and findings differ.>
+
+## Questions for the user  *(omit if none)*
+
+1. **<short title>:** <question, with the `file:line` context that prompted it>
+
+## Recipe notes  *(omit if none)*
+
+<Friction with *this audit recipe itself*, not findings about the op — a step that was unclear or contradictory, a recognition rule that false-fired (name the guard that should cover it), a case the recipe didn't anticipate, a tier boundary that forced an unacknowledged judgment call. Be concrete: cite the section, quote the line. The recipe maintainer reads these.>
+````
+
+#### `METAL2_PORT_BRIEF.md` — porter-facing (emitted on all-GREEN, or YELLOW on Device-2.0 holdovers only)
+
+Ordered by the porter's workflow: plan → construct → watch-for. Issued when every gate is cleared — fully GREEN, or YELLOW only on isolated Device 2.0 holdovers (in which case the **Blocked-until** block below is mandatory). Never on RED.
+
+````markdown
+# Metal 2.0 Port Brief — `<op path>`
+
+> Audit cleared all gates. This is your actionable input; the full record is in `METAL2_PREPORT_AUDIT.md`.
+
+**Gates cleared:** ProgramDescriptor ✓ · Device 2.0 ✓ *(or ▲ if holdovers — see Blocked-until)* · Features ✓
+
+<Include this block prominently **only** when the Device 2.0 gate cleared as YELLOW (isolated holdovers); omit it on a fully clean port:>
+> ⚠ **BLOCKED until Device 2.0 cleanup.** This port **cannot begin** until these isolated Device 2.0 holdovers are fixed — *separately, on the Device 2.0 track; never in the port diff*: `<kernel:file:line — call → member-form>`, … Once they're clean, proceed with this brief as-is — **no re-audit needed.**
+
+## TTNN factory analysis
+
+These facts feed the port's TTNN ProgramFactory wiring (→ `port_op_to_metal2_ttnn_factory.md`); the op ports to `MetalV2FactoryConcept`. Carry them forward:
+
+- **Op-owned tensors:** <none | `<factory + site>`>
+- **MeshWorkload:** <not needed | genuine multi-program need | op-owned tensors only (carried natively — not a real need)>
+- **Pybind `create_descriptor`:** <none | delete at `<nanobind site>`>
+- **Other risky pybind:** <none | `<description + site>`>
+- **Custom `override_runtime_arguments`:** <none | `<factory + site>`>
+
+## Construct — to do
+
+**Tensor bindings** (per binding):
+
+- `<name>` — **Case 1** (via `TensorAccessor`) → express as `TensorParameter` / `TensorBinding`; kernel uses `TensorAccessor(ta::name)`.
+- `<name>` — **Case 2** (raw pointer) → bind the tensor, pull the base via `get_bank_base_address`, raw walk unchanged. *(Compute kernel → blocked: fail the port pending the compute-kernel `TensorBinding` fix.)*
+
+**Custom hash:** <delete custom `compute_program_hash` → default (sanctioned exception) | none>
+
+## Watch for
+
+- **Notable constructs:** <aliased CB @ loc → [pattern] · borrowed-mem DFB → [recipe] · dynamic TA → [pointer] · non-zero sem init → deprecated, expected | none>
+- **Cross-op / shared kernels:** <path → caution per [pattern] | none>
+- **RTA varargs:** <kernel → prefer named RTAs | none>
+````
+
+#### N/A vs. GREEN
+
+Per row, the status is one of three:
+
+- **`N/A`** — the feature's precondition is absent from the op (the op uses no semaphores, so `Non-zero semaphore initial value` cannot fire; the op has no variable-count CTAs, so the CTA-varargs entry cannot fire; etc.). **An UNSUPPORTED feature the op simply doesn't use is `N/A`, *not* `GREEN`** — the gate didn't fire because the feature is *absent*, so there is nothing to "pass." This is the common mismark: don't GREEN an absent gate-feature.
+- **`GREEN`** — a **LANDED** feature *is* present and clean (e.g. a borrowed-memory DFB in use, translated via `borrowed_from`).
+- **`RED`** — an UNSUPPORTED feature is present.
+
+In short: reserve `GREEN` for a feature actually *in use* and supported; an absent feature is `N/A`, whatever its tier. (The *subject's* overall roll-up may still read "GREEN — no gate fired"; that's the subject verdict, distinct from these per-row labels.)
+
+For UNSUPPORTED feature-detail blocks, the **Expected resolution** is usually a short paraphrase of the entry's Status field — e.g. "not yet supported in Metal 2.0; port will be possible once GlobalCircularBuffer support lands on `KernelSpec` / `DataflowBufferSpec`." For the `address_offset` entry specifically, surface the runtime-team-consultation message verbatim per the entry's Action field.
+
+#### RED short-circuit: the ProgramDescriptor prerequisite fires
+
+When the ProgramDescriptor gate fails, the later subjects become moot — there is no point doing a full audit of an op that cannot be ported in this state. **Do not stop with a one-line report.** Instead, fill in the remaining subjects on a best-effort basis (the user benefits from knowing what they'll face *after* the migration clears) and mark each subsequent finding `(observed-but-moot until the ProgramDescriptor prereq clears)`. Don't block the report on completing them; if a subject is impractical to evaluate without the translation, mark it `(deferred — re-evaluate after the prereq clears)` and move on. The Result and Gate detail still emphasize the prerequisite as the primary blocker; the moot-with-caveat findings are forward-looking context.
+
+Save the file(s) and surface the path(s) with the Result line. **Stop here.** The audit file(s) are the complete deliverable of this document.
+
+### After the audit: what happens next
+
+- **On RED**: this op cannot be ported in its current state. Surface the `METAL2_PREPORT_AUDIT.md` path and Result; stop. No brief is written, and the recipe is not loaded.
+- **On YELLOW**: surface the path, the Result, and the open questions. Wait for the user's decisions. On resolution, update the team doc in place and confirm GREEN before any handoff.
+- **On GREEN + explicit user go-ahead**: both files are written (the team doc and the brief). Load [`port_op_to_metal2_recipe.md`](port_op_to_metal2_recipe.md) to perform the port, passing the audit files as context — the recipe needs the cleared gates and decisions, *including the TTNN factory analysis*. Do not load the recipe on your own initiative; the user must explicitly approve.
+- **On GREEN with isolated Device 2.0 holdovers**: both files are written — the brief carries the **Blocked-until** notice. Surface the brief, the team doc, and the holdover list. The path forward: the holdovers are fixed **first**, on the Device 2.0 track (*not* as part of the port), after which the porter proceeds with the already-issued brief — **no re-audit**. The recipe loads once the holdovers are clean and the user gives go-ahead.
+
+---
+
+## Appendix A: Metal 2.0 feature compatibility
+
+This appendix lists legacy-API features relevant to the port. Each entry falls into one of two tiers, declared in the entry's header:
+
+- **UNSUPPORTED** — Metal 2.0 does not currently support this feature. Action: refuse the port and report (a GATE / RED). Each entry's **Status** field describes the future path: most entries will be supported as-is when implemented; a few will only be addressable via a redesigned, semantically different construct (and may require a runtime-team consultation before re-attempting). Always check the Status field before telling the user "wait and revisit."
+- **LANDED** — Metal 2.0 supports the feature today; no port gate. The entry's **Status** field names the Metal 2.0 construct that replaces the legacy form. A handful of LANDED features translate via a non-obvious construct or carry a caveat (aliased CBs, borrowed-memory DFB, dynamic `TensorAccessor`, non-zero semaphore initial value) — surface those as porter heads-ups (**FYI-P**) per the [Feature compatibility](#feature-compatibility) subject; they still do not gate.
+
+### Maintenance: keeping Appendix A current
+
+Appendix A is actively maintained as Metal 2.0's feature surface evolves. When framework changes touch a feature listed here, the doc maintainer updates the relevant entry — typically changing the tier (e.g., from `UNSUPPORTED` to `LANDED`) and rewriting the Status / Action paragraphs to reference the new construct.
+
+**Staleness override for porting AIs.** If during the audit you observe a feature in the codebase whose Appendix A entry is marked `UNSUPPORTED` but the framework headers clearly show the API has landed (e.g., the spec/field/method the legacy construct would need to translate to is *visibly present* in `tt_metal/api/tt-metalium/experimental/metal2_host_api/`), this likely means the audit doc is stale. Do not refuse the port reflexively. Instead:
+
+1. Report the row as **YELLOW (staleness override)** rather than RED.
+2. In the report's Questions for the user section, flag the apparent discrepancy: cite the Appendix A row, name the framework header / commit that contradicts it, and ask the user to confirm whether the feature is now supported.
+3. Respect the user's answer; if they confirm support, proceed with the port using the new construct. The doc maintainer will update Appendix A separately.
+
+This override mechanism is a safety net for the brief windows between a framework merge and the audit-doc update. Do not invent it for entries that are clearly still unsupported (no API surface present); only for cases where the codebase contradicts the doc.
+
+When scanning during the [Feature compatibility](#feature-compatibility) subject, match each feature's recognition signals against the op's source. If any signal matches, take the action declared in the entry.
+
+> **For maintainers adding new entries — skim if you're applying the recipe, not editing it.** Features whose underlying *functionality* Metal 2.0 will *never* support are handled differently: they are either reclassified as a prereq fix (the legacy use is replaced before porting) or get a dedicated fix-up recipe in the port recipe. They do *not* live here, because the action for them is not "wait" or "ask" — it is "transform." (Features whose *current API form* will not be supported but whose *underlying functionality* will be — via a different construct — do belong here as UNSUPPORTED entries; the entry's Status field calls out the redesign requirement.) If you are about to add an entry and the underlying functionality has no planned support, route it to the prereq-fix path or to a port-recipe fix-up entry instead — not here.
+
+Each entry follows this uniform format:
+- **Status** — support state and tier framing.
+- **Recognition — definitely this feature** — signals that, if matched, mean the feature is in use. Trigger the entry's action.
+- **Recognition — false-positive guard** — superficially similar constructs that are *not* this feature. Do not trigger the action on these.
+- **Action** — what to do when the rule fires (refuse, or — for LANDED features — note the construct / heads-up).
+- **Examples in the wild** — real op locations using this feature, for ground-truthing your match.
+
+If your op uses something not listed here and you are unsure of its support status, treat as yellow and ask the user. Do not assume support from API surface alone.
+
+### GlobalCircularBuffer — UNSUPPORTED
+
+**Status**: Not yet supported in Metal 2.0. No equivalent of `experimental::GlobalCircularBuffer` on `KernelSpec` or `DataflowBufferSpec`.
+
+**Recognition — definitely this feature** (refuse and report):
+
+- Any reference to the type `tt::tt_metal::experimental::GlobalCircularBuffer` (qualified or via a `using` alias).
+- Calls to `experimental::CreateGlobalCircularBuffer(...)`.
+- `#include <tt-metalium/global_circular_buffer.hpp>` paired with any of the other signals (header presence alone is suggestive but not definitive).
+- **Descriptor-API attachment**: a `CBDescriptor` literal or struct with its `.global_circular_buffer` field set to a non-null pointer. The type token does not appear at the assignment site — look for the **field name** `global_circular_buffer` on a `CBDescriptor`. This is the arcane signal; an AI scanning a `CBDescriptor` setup can easily miss it.
+- **Imperative-API attachment**: the `UpdateDynamicCircularBufferAddress(program, cb_handle, const GlobalCircularBuffer&)` overload (the three-arg form taking a `GlobalCircularBuffer`). The two-arg form taking a `Buffer&` is unrelated.
+- Op factory function signatures with parameter type `std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>&` (commonly named `global_cb`).
+
+**Recognition — false-positive guard**:
+
+Plain `CircularBuffer`, `CBHandle`, `CBDescriptor`, or `CBFormatDescriptor` *without* the GCB attachment field set are the regular path → supported in Metal 2.0 as `DataflowBufferSpec`. Do not refuse these. The disambiguator is either the literal token `Global` in the type name **or** the `global_circular_buffer` field on a `CBDescriptor` being non-null.
+
+**Action**: STOP. Report to the user that this op uses `GlobalCircularBuffer`, which is not yet supported in Metal 2.0. Do not invent a workaround.
+
+**Examples in the wild** (for ground-truthing your match):
+- `ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp`
+- `ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_device_operation.cpp`
+- `ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/`
+
+### Dynamic CircularBuffer (CB built on borrowed Buffer memory) — LANDED
+
+**Status**: Supported in Metal 2.0. The legacy "dynamic circular buffer" pattern — `CBDescriptor::buffer = <some_buffer>` placing a CB on top of an existing `Buffer`'s memory — translates to Metal 2.0 as a **borrowed-memory DFB** via `DataflowBufferSpec::borrowed_from`. See `tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp:95` for the spec field.
+
+**Recognition — definitely this feature** (no port gate; use borrowed-memory DFB):
+
+- **Descriptor-API** (the in-scope path): a `CBDescriptor` literal or struct assignment with its `.buffer` field set to a non-null `Buffer*` (any expression that is not statically `nullptr`). The type token does not appear at the assignment site — look for the **field name** `buffer` on a `CBDescriptor`. The companion field `.address_offset` is meaningful only when `.buffer` is set; it is not an independent signal.
+- **Imperative-API** (an op on the imperative `host_api.hpp` builder API also trips the ProgramDescriptor prerequisite RED; these signals additionally catch usage that leaks in via shared utility code — e.g. `cb_utils.hpp` — that the op calls):
+  - `CircularBufferConfig::set_globally_allocated_address(buffer)`
+  - `CircularBufferConfig::set_globally_allocated_address_and_total_size(buffer, total_size)`
+  - The three-argument constructor `CircularBufferConfig(total_size, data_format_spec, buffer)`
+
+**Recognition — false-positive guard**:
+
+- A `CBDescriptor` with `.buffer = nullptr` (or with `.buffer` simply not set) is a regular CB → standard `DataflowBufferSpec` (no `borrowed_from`). Do not require the borrowed-memory path for these.
+- The `.global_circular_buffer` field on `CBDescriptor` is a *different* feature, covered by the GlobalCircularBuffer rule above. Do not conflate the two — `.buffer` and `.global_circular_buffer` are independent fields on `CBDescriptor` with different meanings.
+- A `CircularBufferConfig` constructed via the one-argument form `CircularBufferConfig(total_size)` followed by `set_page_size(...)` calls (no `set_globally_allocated_address`, no three-arg constructor) is a regular static CB → standard `DataflowBufferSpec`.
+
+**Action**: Proceed with the port. On the Metal 2.0 side, declare the affected `DataflowBufferSpec` with `borrowed_from = <tensor_parameter_name>` naming the `TensorParameter` whose buffer backs the DFB. The DFB's handle (`dfb::name`) resolves to the borrowed L1 address at runtime; the kernel-side code that previously read from the borrowed-memory CB continues to work via the DFB wrapper.
+
+**Examples in the wild** (op locations whose port exercises this construct):
+- Descriptor-API form (`CBDescriptor::buffer` set):
+  - `ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core.cpp`
+  - `ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_*_program_factory.cpp` (sharded, mcast, no_mcast)
+  - `ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_*_program_factory.cpp`
+- Imperative-API form (`set_globally_allocated_address`, often via shared utilities):
+  - `ttnn/cpp/ttnn/operations/cb_utils.hpp` (utility; called from many ops)
+  - `ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_program_factory.cpp`
+  - `ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.cpp`
+
+### CBDescriptor `address_offset` set to non-zero — UNSUPPORTED (current form not planned)
+
+**Status**: Not supported in Metal 2.0, and **not slated for support in its current form**. The `address_offset` field on `CBDescriptor` is a recently introduced interim mechanism for placing a CB at a non-zero offset within a `Buffer` (or at an absolute address, when used without a `buffer`). Metal 2.0 will not carry this construct forward as-is. The functional capability the field provides will be available in a **semantically different way** in Metal 2.0; a direct translation is not possible. The user must consult the runtime team about their actual use case before this op can be ported.
+
+This rule will most often fire together with the Dynamic CircularBuffer rule above (offset is most often used with a Buffer-backed CB), but it is checked separately because:
+- It is severable: a CB can use a non-zero `address_offset` without a Buffer-backed CB (placing the CB at an absolute L1 address — the "manually placed CB" mode documented in `ttnn/api/ttnn/tensor/tensor_utils.hpp`).
+- It carries a stronger signal than dynamic CB alone — the form is being phased out, not just "not yet implemented."
+
+**Recognition — definitely this feature** (refuse and report; flag prominently):
+
+- A `CBDescriptor` literal or struct assignment with `.address_offset` set to a non-zero literal or any expression that is not statically `0`.
+- `CircularBufferConfig::set_address_offset(non_zero)` (imperative API; an op using it directly also trips the ProgramDescriptor prerequisite, but record matches here too — including any leaking in via shared utility code).
+- `UpdateDynamicCircularBufferAddress(program, cb_handle, buffer, offset)` — the four-argument overload — when `offset` is non-zero.
+- Calls to helpers like `cb_descriptor_from_sharded_tensor(cb_index, tensor, address_offset, ...)` in `ttnn/api/ttnn/tensor/tensor_utils.hpp` where the third argument (`address_offset`) is passed a non-zero value.
+
+**Recognition — false-positive guard**:
+
+- `.address_offset = 0` or `.address_offset` not set (default zero) is fine for *this* rule → green. (The Dynamic CircularBuffer rule may still fire if `.buffer` is set; check independently.)
+- `UpdateDynamicCircularBufferAddress(program, cb_handle, buffer)` — three-argument form with no offset → not this rule.
+- Kernel-side `bank_address_offset` parameters on calls like `get_noc_addr_from_bank_id<...>(bank_id, bank_address_offset)` are an unrelated kernel-side feature → not this rule.
+
+**Action**: STOP. **Flag prominently in the audit report** — do not bury this among other RED entries. Use stronger emphasis than for routine UNSUPPORTED items, and surface the following message to the user **verbatim**:
+
+> The `address_offset` field is a recently introduced interim mechanism that will not survive into Metal 2.0 in its current form. The underlying capability you need will be available, but only via a different API that is not a direct translation. Please reach out to the runtime team to discuss your use case before proceeding with this port.
+
+Recommended report shape when this rule fires:
+
+```
+*** CRITICAL: CBDescriptor address_offset feature in use ***
+File: <file:line>
+[verbatim message above]
+```
+
+Do not invent a workaround. Do not propose an alternative implementation. Do not attempt a partial port. The correct path is a runtime-team consultation, then revisit.
+
+**Examples in the wild** (for ground-truthing your match):
+
+`address_offset` was introduced recently and has limited adoption in checked-in code today. Likely paths to a non-zero usage:
+- Direct `CBDescriptor` literal with `.address_offset = <non-zero>`.
+- Helper `cb_descriptor_from_sharded_tensor(cb_index, tensor, address_offset, ...)` in `ttnn/api/ttnn/tensor/tensor_utils.hpp` — inspect callers for non-zero third arguments.
+- Python op authors using the nanobind-exposed `address_offset` parameter on `CBDescriptor` (`ttnn/cpp/ttnn-nanobind/program_descriptors.cpp`).
+
+If you find no concrete non-zero usage in the op being ported, this rule is green — that is the expected outcome for most ops today.
+
+### Aliased Circular Buffers (CBs sharing backing memory) — LANDED
+
+**Status**: Supported in Metal 2.0. The legacy aliased-CB pattern — a single `CBDescriptor` whose `format_descriptors` contains multiple `CBFormatDescriptor` elements (each at a distinct `buffer_index`, sharing backing memory) — translates to Metal 2.0 as **aliased DFBs** via `DataflowBufferSpec::advanced_options.alias_with`. Note: aliasing is an **advanced/ninja feature** — the field lives on `DFBAdvancedOptions` (see [`advanced_options.hpp`](../../../../../../../tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp)), with a CAUTION header documenting that aliased DFBs offer no clobbering guarantees. See the migration guide's "Aliased DFBs" note in the [DataflowBufferSpec section](metal2_migration_guide.md#dataflowbufferspec) for the porting shape.
+
+The term "aliased CB" is descriptive — it does not appear in the legacy API surface. The legacy expression of this feature lives in the array-shape of certain `CircularBufferConfig` fields (sized `NUM_CIRCULAR_BUFFERS`, almost always populated with one entry) and in the `SmallVector<CBFormatDescriptor, 1>` shape of `CBDescriptor::format_descriptors`. The signal is the cardinality of those collections, not any named field.
+
+**Recognition — definitely this feature** (no port gate; use aliased DFBs):
+
+- **Descriptor API** (the in-scope path): a `CBDescriptor` whose `format_descriptors` initializer contains **more than one** `CBFormatDescriptor` element. Concretely:
+  - Single-element (normal): `format_descriptors = {{CBFormatDescriptor{...}}}` → standard `DataflowBufferSpec`.
+  - Multi-element (aliased): `format_descriptors = {{CBFormatDescriptor{...}, CBFormatDescriptor{...}}}` (or three+) → one `DataflowBufferSpec` per buffer index, mutually declared via `advanced_options.alias_with`.
+  - The differing element is typically `buffer_index` — two distinct indices sharing the same backing storage.
+- **Imperative API** (an op on the imperative `host_api.hpp` builder API also trips the ProgramDescriptor prerequisite RED; these signals additionally catch usage that leaks in via shared utility code):
+  - `CircularBufferConfig(total_size, data_format_spec)` where `data_format_spec` is a `std::map<uint8_t, tt::DataFormat>` with **more than one** key (e.g. `{{idx1, fmt1}, {idx2, fmt2}}`).
+  - Two or more `.set_page_size(buffer_index, ...)` calls **with different `buffer_index` values** chained on the same `CircularBufferConfig` instance.
+  - Companion signal: `.set_tile_dims(buffer_index, ...)` chained with multiple distinct `buffer_index` values on the same config.
+
+**Recognition — false-positive guard**:
+
+- A file that creates *many* CBs, each with a single buffer index, is **not** aliased — aliased means a *single* config has multiple indices. Confirm the multiple `set_page_size` calls are on the *same* `CircularBufferConfig` instance, not on different ones.
+- Single-element initializers (`{{CBFormatDescriptor{...}}}` for the descriptor form, single-key `{{idx, fmt}}` map for the imperative form) are the dominant pattern by a wide margin → standard DFB for this rule.
+- The `CBDescriptor::remote_format_descriptors` field is a *different* concept (relates to remote DFBs, a separate planned feature) and is not covered by this rule. Multi-element values there have a different meaning; do not conflate.
+
+**Action**: Proceed with the port. Declare one `DataflowBufferSpec` per buffer index, each with `advanced_options.alias_with` mutually naming the other(s). All aliased DFBs must have the same `num_entries * entry_size` and must be bound to the same kernels. The `DFBAdvancedOptions` header comments capture the legality constraints; the migration guide section linked above shows the porting shape. **Do not** "split" the aliased CB into independent DFBs — that changes the L1 footprint and breaks the kernel's assumption that the indices share an address.
+
+**Examples in the wild** (op locations whose port exercises this construct):
+- Descriptor-API form: currently not exercised by any checked-in ttnn op (every `format_descriptors` initializer in current op factories is single-element).
+- Imperative-API form (these ops trip the ProgramDescriptor prerequisite RED in addition to this entry — record both):
+  - `ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp` (around line 840 — output + interim sharing memory; has the comment "share buffer")
+  - `ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp`
+  - `ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_program_factory.cpp`
+  - `ttnn/cpp/ttnn/operations/matmul/device/sparse/factory/sparse_matmul_multicore_reuse_mcast_1d_optimized.cpp`
+  - `ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.cpp` (multiple sites — cos/sin interim/sync pairs)
+  - `ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_multi_core_program_factory.cpp`
+  - `ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_1d_mm_fusion.cpp`
+
+### GlobalSemaphore — UNSUPPORTED
+
+**Status**: Not yet supported in Metal 2.0. The Metal 2.0 source confirms this with a TODO at `tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp` (search for `TODO -- GlobalSemaphore bindings`).
+
+**Recognition — definitely this feature** (refuse and report):
+
+- Any reference to the type `tt::tt_metal::GlobalSemaphore` (qualified or via a `using` alias). Note: the type lives in plain `tt::tt_metal::`, not `experimental::`.
+- Calls to `experimental::CreateGlobalSemaphore(...)`. Note: the factory *is* in `experimental::` even though the type is not.
+- `#include <tt-metalium/global_semaphore.hpp>`.
+- Op factory function signatures with parameter type `const GlobalSemaphore&` or `std::optional<GlobalSemaphore>` (commonly named `semaphore`, `global_semaphore`, `multi_device_global_semaphore`).
+
+**Recognition — false-positive guard**:
+
+Plain `Semaphore` / `CreateSemaphore(program, core_spec, initial_value)` is the regular semaphore path → supported in Metal 2.0 as `SemaphoreSpec`. Do not refuse these. The disambiguator is the literal token `Global` in the type name; if it is not there, this rule does not apply.
+
+**Action**: STOP. Report to the user that this op uses `GlobalSemaphore`, which is not yet supported in Metal 2.0. Do not invent a workaround.
+
+**Examples in the wild** (for ground-truthing your match):
+- Most CCL ops under `ttnn/cpp/ttnn/operations/experimental/ccl/`, e.g. `llama_reduce_scatter/device/llama_reduce_scatter_device_operation.cpp`, `all_gather_concat_heads_fused/device/`, `llama_all_gather_matmul_async/device/`.
+
+### Non-zero semaphore initial value — LANDED (deprecated; FYI-P heads-up)
+
+**Status**: Supported by Metal 2.0 on Gen1 today, but **explicitly deprecated**. The legacy path lets you create a semaphore with a non-zero initial value via `CreateSemaphore(program, core_spec, initial_value)` (where `initial_value != 0`) or by setting `SemaphoreDescriptor::initial_value` to a non-zero value. The Metal 2.0 destination is `SemaphoreSpec::advanced_options.initial_value` (on `SemaphoreAdvancedOptions`) — which carries a `[[deprecated]]` attribute. The translation works on Gen1, but the field is **unsupported on Gen2** and will be removed when the planned **Remote DFB** feature lands and supplants the use case. Use of non-zero initial values today is therefore a porter heads-up (**FYI-P**), not a gate: it is supported on Gen1 so the port proceeds; the porter just needs to know the field is deprecated and Gen2-unsupported.
+
+**Recognition — definitely this feature** (LANDED — surface as a heads-up):
+
+- `CreateSemaphore(program, core_spec, initial_value)` calls where `initial_value` is:
+  - A non-zero integer literal (`1`, `2`, etc.).
+  - A constant or symbol whose value is **not self-evidently zero** (e.g. `INVALID`, `INVALID_SEM`, project-specific sentinel constants). When in doubt, treat it as in use and flag the heads-up — do not assume the symbol is zero. If you can resolve the constant's definition and it is in fact zero, no flag.
+- `SemaphoreDescriptor` literals or struct assignments where `.initial_value` is set to a non-zero literal or a not-evidently-zero symbol.
+
+**Recognition — false-positive guard**:
+
+- `CreateSemaphore(program, core_spec, 0)` — explicit zero literal → green, no action.
+- `SemaphoreDescriptor{ ..., .initial_value = 0 }` — explicit zero literal → green.
+- `GlobalSemaphore` is a separate type, covered by its own rule above. Do not match this rule against `GlobalSemaphore` constructions or `experimental::CreateGlobalSemaphore(...)` calls.
+
+**Action**: Surface as a **heads-up (FYI-P)** in the audit. Include in the report:
+- The semaphore creation site (`file:line`).
+- The initial-value expression as written.
+- A note that the construct is supported on Gen1 today but deprecated and Gen2-unsupported.
+
+**This does not gate the port.** The translation is direct — set `SemaphoreSpec::advanced_options.initial_value` to the same value used in the legacy code (acknowledging the `[[deprecated]]` warning and the Gen2 unsupported status). The port's mechanical work is unaffected.
+
+**Examples in the wild** (for ground-truthing your match):
+- `ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_program_factory.cpp` (`INVALID` sentinel)
+- `ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_program_factory.cpp` (`INVALID` sentinel)
+- `ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp` (literal `1`)
+- `ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/moe_gpt_program_factory.cpp` (`INVALID` / `INVALID_SEM` sentinels)
+
+### Dynamic TensorAccessor (`ArgConfig::Runtime*` flavors: RuntimeTensorShape, RuntimeRank, RuntimeNumBanks, RuntimeShardShape, RuntimeBankCoords) — LANDED (UNSAFE opt-in; FYI-P heads-up)
+
+**Status**: Supported by Metal 2.0 today via two opt-ins on `TensorParameter::advanced_options` — but their use carries caveats that make this a porter heads-up (**FYI-P**) rather than a silent green.
+
+- `TensorParameterAdvancedOptions::dynamic_tensor_shape = true` — full relaxation. The bound `MeshTensor`'s `logical_shape` *and* `padded_shape` may differ from the `TensorParameter`'s declared spec. For interleaved tensors the `TensorAccessor` configuration is unchanged; for sharded tensors the accessor reflects the argument's actual shape (shape becomes an implicit runtime argument). This is the translation path for the legacy `ArgConfig::RuntimeTensorShape` (and the closely related `RuntimeShardShape` / `RuntimeBankCoords` flavors).
+- `TensorParameterAdvancedOptions::match_padded_shape_only = true` — weaker relaxation. The bound tensor's `logical_shape` may vary, but its `padded_shape` must match the declared spec exactly. `TensorAccessor` configuration is completely unchanged.
+
+Both options are documented **UNSAFE** in the framework header: most kernels will not function correctly if the tensor argument's spec deviates from the declared spec. Adopting them also has structural implications for how the op's factory interacts with the framework's per-dispatch caching path — implications that warrant discussion before a port commits to either opt-in.
+
+The remaining `ArgConfig::Runtime*` flavors — `RuntimeRank`, `RuntimeNumBanks` — do not have a clean translation via these options. Both have ~zero user sites outside tests, so in practice this rarely matters; flag them in the audit for the user's awareness if they appear.
+
+**Recognition — definitely this feature** (LANDED — surface as a heads-up):
+
+- Any reference to one of the following enumerators in op host code:
+  - `tensor_accessor::ArgConfig::RuntimeTensorShape`
+  - `tensor_accessor::ArgConfig::RuntimeRank`
+  - `tensor_accessor::ArgConfig::RuntimeNumBanks`
+  - `tensor_accessor::ArgConfig::RuntimeShardShape`
+  - `tensor_accessor::ArgConfig::RuntimeBankCoords`
+- A canonical grep target that catches all five: `ArgConfig::Runtime`. If this token appears in op host code (not in `tt_metal/impl/buffers/tensor_accessor_args.cpp`, which is the implementation file), the rule fires.
+- Calls of the form `TensorAccessorArgs(buffer, tensor_accessor::ArgConfig::Runtime*)` — i.e. the two-argument form of `TensorAccessorArgs` whose second argument is one of the `Runtime*` flavors. The most common appearance is `.append_to(...)` or `.get_common_runtime_args()` immediately after.
+
+In practice, `RuntimeTensorShape` is the dominant flavor; the other four have ~zero user sites outside tests. A grep for `ArgConfig::Runtime` will surface all of them in one pass.
+
+**Recognition — false-positive guard**:
+
+The single-argument form `TensorAccessorArgs(buffer)` (with no second arg, or with a non-`Runtime*` `ArgConfig` value) is the standard path → supported in Metal 2.0 via `TensorParameter` + `TensorBinding`. Do not refuse these. The disambiguator is the literal token `Runtime` on an `ArgConfig::` qualifier.
+
+**Action**: Surface as a **heads-up (FYI-P)** in the audit. Include in the report:
+- Each site of `ArgConfig::Runtime*` use (`file:line`) and the flavor in use.
+- A note that Metal 2.0 supports the runtime-shape capability via `TensorParameterAdvancedOptions::dynamic_tensor_shape` (or the weaker `match_padded_shape_only`), but the options are marked **UNSAFE** in the framework header and adopting them has structural implications for the factory's interaction with per-dispatch caching. The default remains **strict**; applying a relaxation is an explicit user-OK decision (see the [TTNN integration doc](port_op_to_metal2_ttnn_factory.md)), not an automatic port step.
+- If any of the niche flavors (`RuntimeRank`, `RuntimeNumBanks`) appear, surface them separately: those do not have a clean advanced-options translation today.
+
+**This does not gate the port.** When a relaxation is applied, the translation is: set `TensorParameter::advanced_options.dynamic_tensor_shape = true` (full relaxation) or `match_padded_shape_only = true` (padded-shape-only relaxation) on the affected `TensorParameter`(s). The recognition-signal sites — the `ArgConfig::Runtime*` tokens in the legacy code — are the porter's anchor for which `TensorParameter`s need the opt-in.
+
+**Examples in the wild** (for ground-truthing your match):
+- `ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp`
+- `ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp`
+- `ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp`
+- `ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp`
+- `ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp`
+
+### Per-execution CircularBuffer size updates (UpdateCircularBufferTotalSize, UpdateCircularBufferPageSize, UpdateDynamicCircularBufferAddressAndTotalSize) — UNSUPPORTED
+
+**Status**: Not yet supported in Metal 2.0. The legacy free functions `UpdateCircularBufferTotalSize(program, cb_handle, total_size)` and `UpdateCircularBufferPageSize(program, cb_handle, buffer_index, page_size)` mutate a CB's total size or per-buffer-index page size between Program executions. The combo function `UpdateDynamicCircularBufferAddressAndTotalSize(program, cb_handle, buffer, total_size)` folds the per-execution total-size mutation onto a dynamic-CB address rebind — the address-rebind part is supported (borrowed-memory DFBs), but the bundled total-size mutation is the same UNSUPPORTED capability. Metal 2.0 does not yet expose an equivalent — `ProgramRunArgs` reserves placeholder fields for per-execution DFB size / entry size, but they are explicitly "not yet supported."
+
+**Recognition — definitely this feature** (refuse and report):
+
+- Calls to `UpdateCircularBufferTotalSize(program, cb_handle, total_size)`.
+- Calls to `UpdateCircularBufferPageSize(program, cb_handle, buffer_index, page_size)`.
+- Calls to `UpdateDynamicCircularBufferAddressAndTotalSize(program, cb_handle, buffer, total_size)` — the 4-arg "Address And Total Size" combo form. The address-rebind half maps to borrowed-memory DFB (LANDED); the total-size half is the UNSUPPORTED feature this rule catches. Distinguished from `UpdateDynamicCircularBufferAddress` (3-arg, address only — supported) by the `AndTotalSize` suffix in the function name.
+- A canonical grep target that catches all three: `UpdateCircularBuffer`. (See guard below for one false positive.)
+- Typical call site: cached-program override hooks (e.g. `override_runtime_arguments` and similar callbacks), where CB sizing is re-tuned per shape between executions of the same Program.
+
+**Recognition — false-positive guard**:
+
+`UpdateDynamicCircularBufferAddress` (the **3-arg** form — `(program, cb_handle, buffer)` or `(program, cb_handle, global_cb)`) is a different function with different semantics — do not refuse based on the `UpdateCircularBuffer` substring matching it. The 4-arg form **with an `address_offset` argument** (`UpdateDynamicCircularBufferAddress(program, cb_handle, buffer, offset)`) is covered by the `address_offset` rule above. The 4-arg form with `AndTotalSize` in the name is **caught by this rule**, not exempted.
+
+**Action**: STOP. Report to the user that this op uses one or more of `UpdateCircularBufferTotalSize` / `UpdateCircularBufferPageSize` / `UpdateDynamicCircularBufferAddressAndTotalSize`, which Metal 2.0 does not yet support. Do not invent a workaround. In particular, do not "fix" this by recreating the Program from scratch on every execution — that defeats the cached-program model the call site is part of and is not what the user wants.
+
+**Examples in the wild** (for ground-truthing your match):
+- `ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp`
+- `ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_program_factory.cpp` (the `AndTotalSize` 4-arg form)
+- `ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_program_factory.cpp`
+- `ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_program_factory.cpp`
+- `ttnn/cpp/ttnn/operations/generic/device/generic_op_program_factory.cpp`
+
+---
+
+### Variable-count compile-time arguments (CTA varargs) — UNSUPPORTED
+
+**Status**: Not yet supported in Metal 2.0. Ops whose structure requires a *variable number of compile-time arguments* — for example, ops that accept a list of input tensors of runtime-varying count, or kernels that iterate over a runtime-varying number of CTAs — cannot be ported today. Metal 2.0's `compile_time_args` schema requires fixed-shape declaration at factory-construction time; there is no kernel-side equivalent of the legacy positional-CTA loop yet. A CTA-vararg feature is on the host API roadmap.
+
+**Recognition — definitely this feature** (refuse and report):
+
+- **Op-level signal.** The op accepts a *variable number of input tensors* — e.g., the device-operation class's `tensor_args_t` carries a `std::vector<Tensor>` (or equivalent variable-count container) rather than a fixed-count tuple of named tensors. The variadic input signature is the strongest cue: if the op author needed a variable-count input list, the legacy kernel almost certainly threads per-input metadata through CTA varargs.
+- **Kernel-level signal.** The kernel reads compile-time args using a *runtime-varying index* — e.g., `get_compile_time_arg_val(i)` inside a loop where `i` depends on a count value, or a kernel template instantiated over a variable count derived from a CTA.
+
+Either signal fires the rule.
+
+**Recognition — false-positive guard**:
+
+- *RTA varargs* (`get_vararg(i)` for runtime args) ARE supported in Metal 2.0 via the kernel-side vararg mechanism — see the porter recipe's [kernel-side whitelist rule 4](port_op_to_metal2_recipe.md#kernel-side-whitelist) and the [patterns catalog's Caution on varargs](metal2_port_patterns.md#caution-avoid-varargs-unless-absolutely-necessary). The rule fires only on *compile-time* varargs.
+- A fixed-count list of input tensors known at port time (e.g., always exactly 4 inputs) is not variadic — that's a multi-input op with a known shape. Port it as multiple named `TensorParameter`s and `TensorBinding`s.
+
+**Action**: STOP. Report to the user that this op's structure requires a CTA-vararg feature Metal 2.0 does not yet support. Do not attempt to capitulate by demoting CTAs to RTAs (that's the [Demoting per-group CTA to RTA anti-pattern](metal2_port_patterns.md#anti-pattern-demoting-per-group-cta-to-rta)) or by hand-unrolling the variable-count loop in the kernel.
+
+**Examples in the wild** (for ground-truthing your match):
+- `ttnn/cpp/ttnn/operations/data_movement/concat/` — accepts a runtime-varying list of input tensors.
+
+---
+
+## After you submit
+
+A grounded RED audit is not a failed port; it is the audit working as designed. The same goes for a YELLOW where you raised the question rather than guess. The deliverable here is clarity — what porting this op would actually require, surfaced clearly enough that a colleague can act on it. Your job in this document was to decide whether the port is feasible, not to perform it; once the report is on its way, that work is complete.

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/port_op_to_metal2_recipe.md
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/port_op_to_metal2_recipe.md
@@ -1,0 +1,778 @@
+# Porting an Op to Metal 2.0 — Port Recipe
+
+> This is the second of two documents covering the Metal 2.0 op port workflow. **This document covers the port itself — legacy inventory, spec planning, construction, and verification.** The feasibility audit (the gate that precedes the port) lives in [`port_op_to_metal2_audit.md`](port_op_to_metal2_audit.md) and is a hard prerequisite to anything in this document.
+
+## Read this first
+
+**Audience**: AI agents asked to perform the actual Metal 2.0 port of a TTNN op, *after* the feasibility audit has cleared with GREEN status and the user has explicitly approved proceeding.
+
+**If you're new to this stack — quick orientation:**
+
+- **Tenstorrent accelerators** come in two architectural generations. **Gen1** is the shipping silicon today: `WH` = Wormhole, `BH` = Blackhole. **Gen2** is in development: `Quasar` (and siblings). The ops you'll port target Gen1, but Metal 2.0 is designed to serve both — the same API targets both architectures.
+- **TTNN** is the high-level neural-network library for Tenstorrent accelerators. Ops live in `ttnn/cpp/ttnn/operations/<family>/<op>/`. A typical op has a device-operation class on the host side and one or more program factories that build what runs on the accelerator.
+- **Metal 2.0** is the new **host API** — what the program factory uses to declare kernels, buffers, semaphores, and bindings. It also introduces **DFB** (Dataflow Buffer) at the spec layer, replacing the legacy **CB** (CircularBuffer); the two are essentially synonyms on Gen1, but DFB's semantics diverge meaningfully on Gen2.
+- **Device 2.0** is a *separate, earlier* overhaul of the **kernel-side** data-movement APIs (safer, more object-oriented wrappers — `experimental::Noc`, kernel-side `CircularBuffer` wrappers, etc.). It's a **bundled prereq** to Metal 2.0 — the audit checks that ops are already on it — not part of Metal 2.0 itself.
+- **Common acronyms you'll see throughout:** `CB` = CircularBuffer; `DFB` = DataflowBuffer (see above); `RTA` = runtime args; `CTA` = compile-time args; `CRTA` = common runtime args (values broadcast to all nodes); `TA` = TensorAccessor; `LLK` = Low-Level Kernel (the framework-provided kernel-side primitives); `NoC` = Network-on-Chip (the on-die fabric).
+
+For the conceptual map of how Metal 2.0 abstractions fit together — `ProgramSpec`, `KernelSpec`, `TensorParameter` / `TensorBinding`, `DataflowBufferSpec`, the spec/run-args split — see [`metal2_migration_guide.md`](metal2_migration_guide.md). The recipe below assumes you've at least skimmed it.
+
+**Precondition — non-negotiable**: You may only invoke this document if:
+
+1. The audit in [`port_op_to_metal2_audit.md`](port_op_to_metal2_audit.md) was performed for this op and produced an **overall GREEN** result (or a YELLOW with all questions resolved by the user in favor of proceeding).
+2. The user has **explicitly asked you to proceed** with the port. A green audit alone is not sufficient — the user must have read the audit and given an unambiguous go-ahead.
+
+If either condition is unmet, stop. Return to the audit document. Do not improvise.
+
+**Why this migration matters.** Metal 2.0 is a substantial overhaul of the host API for programming Tenstorrent hardware — hold this motivation in mind, because it shapes the judgment calls the recipe itself can't fully specify, and it's why the work is worth doing. The legacy host API hurt the project for years in concrete, structural ways. Positional `uint32_t` kernel arguments hide the meaning of every slot; the compiler can't catch a mismatch. Magic CB indices propagate through CTA lists with no compiler-checked connection back to the CB they reference. Raw pointers flow through the host interface straight into device kernels with no safeties, surfacing as hard-to-debug device hangs when they go wrong. And because the legacy API doesn't tell the framework which kernel uses which CB or in what role, the framework can't catch your mistakes at spec-construction time — they surface at runtime as hangs or wrong numerics. Every legacy idiom you'll replace in this port — magic CB indices, positional CTAs, buffer-address RTAs, host-side `TensorAccessorArgs` plumbing — is an instance of one of those problems. **Metal 2.0's typed binding model is the fix:** bindings the compiler checks, a host that knows the device topology (so the spec validator catches mistakes before launch), and a binding mechanism that carries the meaning the legacy `uint32_t` channel couldn't.
+
+**Your port is one link in a chain.** Metal 2.0 is pulling adjacent migrations through with it under a Gen2-customer-driven schedule: Device 2.0 and TensorAccessor adoption are bundled prereqs the audit gates on, and TTNN's ProgramDescriptor migration — a parallel TTNN-side effort, coupled to Metal 2.0 by design — is racing to finish under the same pressure. The API you're learning here is the same API that will target Gen2 (Quasar) hardware; there aren't two APIs to learn. Landing your port unblocks the next op, which unblocks its consumers, which unblock framework features the runtime team has planned. The cumulative effect, once the push lands, is a meaningfully cleaner way to specify what runs on a Tenstorrent accelerator.
+
+**Operating posture.** Two principles govern every judgment call in the port. Both cut against the natural pull to be maximally helpful by solving everything in front of you — so they're stated plainly here, with the full reasoning in the sections named:
+
+- **When Metal 2.0 doesn't fit, stop and report — this is a successful outcome, not a failed one.** The audit cleared the features and prereqs known at audit time, but during the port you may discover something it missed: a feature gate that didn't fire, a kernel pattern that doesn't translate cleanly, an interaction nobody anticipated (including an API that behaves as though it has a bug — report it, don't paper over it). The correct response is to surface it, not improvise around it. In particular, if you find yourself constructing a clever workaround — packing data into varargs to simulate a missing field, threading a buffer address through an RTA because the binding mechanism doesn't fit, hand-rolling a synchronization primitive — **stop.** Whatever you're about to write is almost certainly wrong. A grounded stop is a complete, valued deliverable, on the same success tier as a finished port — see [§When the discipline doesn't fit](#when-the-discipline-doesnt-fit).
+- **When you notice an unrelated improvement, leave it and route it to the report.** Refactors, bug fixes, stale comments, a too-tight validation you can see how to loosen — real as they may be, they don't belong in this diff. They aren't suppressed; they're delivered to the people with the context to act on them, via `METAL2_PORT_REPORT.md`. The full rationale — and why bundling them is actively harmful, not merely unnecessary — is in [§Scope discipline](#scope-discipline); read it before you touch a file.
+
+**The "why" as a judgment heuristic.** When the recipe doesn't quite fit and you're tempted to improvise, the test is whether what you're about to do preserves typed bindings, the host-aware binding model, and the spec/run-args separation that the verification step audits. If yes, you're probably on a supported path. If no — varargs-packing, address-through-RTA, hand-rolled sync — you're recreating the legacy problems Metal 2.0 was built to fix. Stop and ask.
+
+**Working practices for the bulk-port effort.** This is one of many ports happening in parallel against actively-evolving docs. Read the following before you start; they shape how you should approach the work.
+
+- **Your friction signals are a real deliverable.** The team needs them from each port to improve the recipe / patterns catalog / migration guide; a port that captures a real blocker and stops is more valuable than one that powers through with workarounds. The `METAL2_PORT_REPORT.md` you produce is part of why you are doing this work, not an afterthought.
+- **Capture friction as you go, not at the end.** Open `METAL2_PORT_REPORT.md` at the start of the port. When something surprises you — a missing doc, an unexpected error, a near-miss — write a one-line note immediately, even rough. A friction note added in the moment is worth more than a polished paragraph reconstructed two hours later. Polish at the end; capture in the moment.
+- **Time budget on stuck points.** If you spend more than ~30 minutes on a single stuck point with no traction, **stop**. Capture what you tried, what failed, and your current hypothesis in `METAL2_PORT_REPORT.md` under "Friction" or "Open items," then move on or surface the question to the invoker. Burning the day powering through a stuck point is not the assignment.
+- **Do not 'fix' the legacy kernel.** If the legacy kernel does something you don't understand or that seems wrong, the legacy kernel is the source of truth for what the op does. Surface kernel-level questions as questions in the report; do not modify the kernel's logic to match what you think Metal 2.0 wants. (Mechanical edits to make the kernel build against Metal 2.0 APIs — named handles, generated headers, etc. — are a different category and are expected.)
+
+**Scope boundary — read carefully.** The porter's writeable surface is the **op's own directory** (the device-op factory, its kernels, its tests, the three `METAL2_*.md` artifacts). Files outside that directory — shared kernel-lib headers under `ttnn/cpp/ttnn/kernel_lib/`, LLKs under `tt_metal/`, framework primitives — are out of scope. The port respects this boundary; it does not propose changes to those files.
+
+**The atomic unit of a port is one ProgramFactory — not the whole device-operation.** A device-op may hold several factories in its `program_factory_t` variant (e.g. an interleaved factory and a sharded factory). You port **one factory together with the kernel entry points it binds**, as a unit; you do *not* have to convert the whole op at once. A `program_factory_t` variant is valid with its factories on *different* concepts — one on Metal 2.0's `MetalV2FactoryConcept`, the others still on the legacy `ProgramDescriptorFactoryConcept` — and the framework dispatches per-factory at runtime, so a half-ported op builds and runs correctly. For a large multi-factory op this is the lever that keeps the port tractable: port one factory now, the rest later. **When handed a multi-factory op, default to porting the factories one at a time, autonomously — don't raise a "which factory?" question.** Each factory is a complete sub-port: a finished factory with its other factories cleanly reported as remaining work is a valid, shippable deliverable, not a partial failure. Port one factory fully (its own `METAL2_PORT_PLAN.md` / `METAL2_PORT_REPORT.md` entries), then continue to the next only if it's clearly tractable in the same pass; stopping after one with the rest enumerated for the next pass is the expected shape for a large op. The variant's other factories stay on their legacy concept meanwhile, and the op keeps building and running.
+
+*Within* that unit the conversion **is** atomic: a factory that speaks Metal 2.0 bindings can only launch kernels whose entry points read those bindings, so the factory and every kernel-source entry point it can select (including runtime-selected sources) flip together — there is no half-Metal-2.0 factory. **Shared kernels between the op's own factories** are therefore the thing to watch, and not all "sharing" is alike:
+- **Shared top-level entry point** (two of the op's factories bind the *same* kernel `.cpp`'s `kernel_main`): that source gets Metal-2.0-ified for whichever factory you port, which breaks the other factory's use of it. Treat it like a shared kernel — port both factories together, or fork the source (see [Caution: Modifying a shared dataflow kernel](metal2_port_patterns.md#caution-modifying-a-shared-dataflow-kernel)).
+- **Shared routines / cross-calls** (kernels calling common helpers or kernel-lib functions): bridged by the boundary features (`dfb::name`→`uint32_t`, etc. — see *Crossing the boundary* below). Not a coupling; leave the helpers alone.
+
+**Crossing the boundary in kernel code.** Some kernel call sites in the ported kernels invoke functions whose source lives outside the op directory — kernel-lib helpers (`dataflow_kernel_lib::*`, `compute_kernel_lib::*`), LLKs (`reduce_init`, `pack_tile`, `cb_wait_front`, etc.). These callees take `uint32_t` CB ids today.
+
+- **`dfb::name` crosses freely.** Pass `dfb::name` directly at the call site. The `DFBAccessor::operator uint32_t()` implicit conversion bridges the named handle to the legacy `uint32_t` signature without `.id` extraction, temporary wrappers, or typed shims. See [Pattern: Pass DFB handles directly to LLKs and kernel-lib helpers](metal2_port_patterns.md#pattern-pass-dfb-handles-directly-to-llks-and-kernel-lib-helpers).
+- **`sem::name` and `ta::name` do NOT cross — assumption.** Unlike `dfb::name`, the semaphore and tensor-accessor handles have no implicit conversion to `uint32_t` today. **The recipe assumes that no out-of-op call site requires passing one** — semaphores and tensor accessors are consumed inside the op's own kernels. If you encounter a call site whose callee lives outside the op directory and that requires a operand that is structurally unavailable to the Metal 2.0-converted code, this is an **assumption violation**. These are supposed to have been already prepared for Metal 2.0 migration. Do not write the call. Do not preemptively wrap, refactor, or extract — the fix is upstream of the porter's scope. Stop and record the site in [`METAL2_PORT_REPORT.md` — Handoff points](#capture-the-port-report) so the kernel-lib / API owners can address it.
+
+**Two exceptions to the boundary rule** — these are not "out-of-op" call graphs:
+
+- **Cross-op kernel files** — some ops share dataflow kernels that live in another op's directory (e.g., `eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp` reused by many ops). The legacy inventory step flags these; modifying them is porter-touchable with caution per [Caution: Modifying a shared dataflow kernel](metal2_port_patterns.md#caution-modifying-a-shared-dataflow-kernel). These are *peer ops*, not framework callees. Document the changes you found necessary in the `METAL2_PORT_REPORT.md`.
+- **Framework primitives the porter uses directly** — `noc.async_read(...)`, `dfb.wait_front(...)` on a `DataflowBuffer` the porter constructs locally from `dfb::name`, the `TensorAccessor(ta::name)` constructor, etc. These are *consumed by* the porter's kernel code (named handles flow in via the documented constructors); they are not handoffs to out-of-op code.
+
+**Generated docs in the op directory.** This recipe directs you to write three files into the op's directory, alongside the program factory `.cpp` files:
+
+- `METAL2_PREPORT_AUDIT.md` — the audit report. (Written by the [audit doc](port_op_to_metal2_audit.md), not this one; included here so you know it's expected to be present as input.)
+- `METAL2_PORT_PLAN.md` — the port plan (this recipe's load-bearing artifact). Externalizes structural decisions before mechanical translation begins. Read by you during construction and verification, by human reviewers during PR review, and by future debuggers. See [Appendix A](#appendix-a--metal2_port_planmd-template) for the template.
+- `METAL2_PORT_REPORT.md` — the post-port report. Records handoff points, successes, friction, and open items observed during the port. Written at the end of the port; feeds doc evolution and informs the kernel-lib / API teams. See [Capture the port report](#capture-the-port-report) for the structure.
+
+All three are committed alongside the port.
+
+**Workflow at a glance**:
+
+1. [**Legacy inventory**](#legacy-inventory) — Consume the audit; record the legacy structure to `METAL2_PORT_PLAN.md`.
+2. [**Plan the spec**](#plan-the-spec) — Apply host-side specialization principles; identify legacy plumbing that should evaporate. Externalize all structural decisions to the plan.
+3. [**Construct paired spec + run-args**](#construct-paired-spec--run-args) — Construct the spec and run-args, paired by resource. Mechanical translation per the plan.
+4. [**Verification**](#verification) — Build, run tests, run anti-pattern self-audit against the [patterns catalog](metal2_port_patterns.md).
+5. [**Capture the port report**](#capture-the-port-report) — Write `METAL2_PORT_REPORT.md` recording handoff points, successes, friction, and open items for downstream.
+
+**Reference material** the recipe relies on, loaded on demand:
+
+- [Migration guide — Design Principles](metal2_migration_guide.md#design-principles): why certain legacy plumbing should evaporate during port.
+- [TTNN integration doc](port_op_to_metal2_ttnn_factory.md): the factory concept, the `create_program_artifacts` entry point, the cache lifecycle, and the device-op-class edits the port forces.
+- [Patterns catalog](metal2_port_patterns.md): recognition signals + decisions for structural patterns and anti-patterns.
+
+---
+
+## Before you begin
+
+### Inputs the invoker should have supplied
+
+Before starting, confirm you have the following. If any is missing or unclear, ask the invoker before proceeding — the invoker can answer in seconds; you will burn substantial time guessing.
+
+- **Legacy op source path** — the directory containing the op's legacy program-factory `.cpp`/`.hpp` files and kernel sources.
+- **Tests directory** — the path under `tests/ttnn/unit_tests/operations/<op-family-slug>/` where the op's pytests live. Note that the directory uses the **op-family slug**, not always the literal op name (e.g., reduction's tests live at `tests/ttnn/unit_tests/operations/reduce/`, not `reduction/`). If the invoker didn't supply this, discover it with `find tests/ttnn -path '*operations*' -name 'test_*.py' | grep -i <op>`.
+- **`METAL2_PREPORT_AUDIT.md`** — present in the op directory with overall GREEN status (precondition above). The audit includes a **TTNN ProgramFactory** section recording the Metal 2.0 factory concept the port targets; that decision is inherited, not re-derived. See the [TTNN integration doc](port_op_to_metal2_ttnn_factory.md) for the concept and the device-op-class edits the port forces.
+- **(Optional) Reference port** — a recently-completed similar op the invoker recommends studying for shape. The invoker may not always have one; absence is not a blocker. The first worked end-to-end `create_program_artifacts` port is **accumulation** (cumsum/cumprod) on branch `akertesz/porting-experiment-accumulation-jun10` — a small single-program op exercising tensor bindings, a self-loop DFB, work-split multiplicity, and the custom-hash deletion. A good shape reference when no closer op exists. It lives on that sibling branch, **not** your port branch — read it with `git show akertesz/porting-experiment-accumulation-jun10:<path>` rather than expecting it in your working tree.
+
+### Workspace bootstrap
+
+If you have no existing tt-metal checkout, follow [`metal2_workspace_setup.md`](metal2_workspace_setup.md) for the clone / Python-env / build sequence. Key facts captured there that often trip up porters:
+
+- The right build flag for op work is `./build_metal.sh --build-tests`. `--build-metal-tests` alone is **insufficient** — it omits TTNN gtests entirely.
+- `PYTHONPATH` must be `$(pwd)` from inside your clone, not a path copied from someone else's instructions.
+- Iterative rebuilds during the port: `cmake --build build_Release --target ttnncpp unit_tests_ttnn -j 8`.
+
+### Use a subagent for builds and tests
+
+Builds and test runs produce large output that will pollute your working context — `./build_metal.sh` writes thousands of lines, gtest output on a full op test directory is even worse. **Delegate every build and every test run to a subagent.** The subagent runs the command, captures all output to a log file, and returns only a tight summary (exit code + extracted errors + log path). You do the reasoning; the subagent absorbs the noise.
+
+**Subagent prompt template:**
+
+````
+You are a build/test helper for a Metal 2.0 op porter. Run the command below, capture all output to <log_path>, and return ONLY a tight summary.
+
+Command: <command>
+Working directory: <cwd>
+Log path: <log_path>
+
+Return format:
+- Exit code: <code>
+- Status: SUCCESS / FAILURE / TIMEOUT
+- Key errors (if FAILURE): up to 10 lines of compiler or test errors, no boilerplate stack frames unless they show the cause.
+- Log path for deep dive: <log_path>
+
+Do NOT try to fix anything. Do NOT run other commands. Do NOT read unrelated files. Do NOT make recommendations about next steps.
+
+If the build or test hangs (>15 min with no log progress), kill it, return TIMEOUT, and report the last 20 lines logged.
+````
+
+**When to use:** every build, every gtest run, every pytest run. If you are iterating on a single failing test and have already seen the error once, reading the log file directly is fine — but the first invocation of any build or test command should always go through the helper to get a clean error extract.
+
+**Don't use the helper to make decisions.** The helper runs and reports. You read the report and decide what to do next. If you need to investigate a specific error in detail, read the log file the helper points you at.
+
+---
+
+## Legacy inventory
+
+*This is an observation step. No decisions yet.*
+
+**Inputs**:
+- The audit report (`METAL2_PREPORT_AUDIT.md` in the op directory). The audit's "kernels referenced" and "factory shape" sections are the starting point for the inventory.
+- The op's program-factory `.cpp` / `.hpp` files.
+- The kernel sources referenced by the factories.
+
+**Output**: write the **Legacy Inventory** section of `METAL2_PORT_PLAN.md` to the op's directory. Record:
+
+- **Legacy factory shape**: which `ttnn::device_operation` concept the legacy factory currently satisfies (`ProgramFactoryConcept` / `ProgramDescriptorFactoryConcept` / `MeshWorkloadFactoryConcept`). For each variant (if the device-operation is multi-variant), record separately. *(The Metal 2.0 factory concept the port lands on was chosen during the audit — see the audit report's TTNN ProgramFactory section. The recipe inherits that decision; carry it forward to the [TTNN ProgramFactory port-plan section](#ttnn-programfactory) below.)*
+- **Custom `compute_program_hash`**: does the device-operation define a custom `compute_program_hash` (overriding the default reflection-based hash)? If yes, record file:line — **the port deletes it**, reverting to the default hash. This is one of the two sanctioned device-op-class edits the port forces; the rationale and procedure live in the [TTNN integration doc — Delete a custom `compute_program_hash`](port_op_to_metal2_ttnn_factory.md#1-delete-a-custom-compute_program_hash). Record the deletion in the port report.
+- **Kernels**: every `KernelDescriptor` (one row per descriptor):
+  - `kernel_source` (file path; flag any path outside the op's own directory — cross-op kernels are a Caution case).
+  - `core_ranges` (verbatim).
+  - `compile_time_args` (positional values) — read these from the **host factory's emission order**, which is authoritative for slot positions; a kernel-side reconstruction (counting `get_compile_time_arg_val(N)` reads) is easy to misalign, especially in a delegated inventory.
+  - `named_compile_time_args` (name → value pairs).
+  - `runtime_args` and `common_runtime_args` (names if known, dimensions, and shapes).
+  - `defines` (key → value pairs).
+  - `config` (the descriptor type: `ReaderConfigDescriptor` / `WriterConfigDescriptor` / `ComputeConfigDescriptor` and its content).
+- **CBs**: every `CBDescriptor` (one row per descriptor):
+  - `total_size`, `core_ranges`, format descriptors (`buffer_index`, `data_format`, `page_size`, `tile` if set).
+- **Semaphores**: every `SemaphoreDescriptor`:
+  - `id`, `core_type`, `core_ranges`, `initial_value`.
+- **Tensor accessors**: every `TensorAccessor` use site (host and device):
+  - Originating `Tensor` (input / output / which input/output).
+  - Where its address surfaces in the host RTA list.
+- **Work split**: which `split_work_to_cores` call (or similar) drives the per-core counts. Record `(num_cores, all_cores, core_group_1, core_group_2, count_per_group_1, count_per_group_2)`.
+- **Cross-op kernels**: explicitly list any kernel source path outside the op's directory; flag for [Caution: Modifying a shared dataflow kernel](metal2_port_patterns.md#caution-modifying-a-shared-dataflow-kernel).
+- **Factory variants**: if the device-operation has multiple variants (e.g., reduce W vs H vs HW; Welford W/H/HW), record each variant's complete inventory.
+- **Runtime kernel-source selection**: if the factory chooses its kernel *source file* at runtime (a switch over kernel paths, rather than one fixed source per `KernelDescriptor`), record every source it can select. Because the spec's bindings must match the selected source, the factory and **all** of its selectable sources convert together — there is no "port the common path only" sub-target that builds. This (not the whole device-op — see [the atomic-unit note](#read-this-first)) is the true size of the port: one factory + every kernel entry point it can bind. Selection often runs on **several independent axes at once** — broadcast type × compute flavor (`is_sfpu` / `is_where`) × layout (tile / row-major) — and they *multiply*: a single "no-broadcast" path can still fan out to multiple compute kernels (e.g. fp32 `add` routes to the *SFPU* kernel, not the FPU one). Enumerate entry points across **all** axes, not just the obvious one. Size the effort against that, and if a single factory's unit is still too large to port faithfully in one pass, that is a legitimate [grounded stop](#when-the-discipline-doesnt-fit) — surface it. Map each DFB's producer/consumer roles **per selected source path**, not once for the op: a DFB's producer can *move between kernels* across paths — e.g. an input DFB filled by the *reader* on a tile path but by *compute* (via `tilize`) on a row-major path — so one fixed role assignment will mis-bind the other path.
+
+**Stop signals**:
+- An unreferenced kernel file in the op's directory: not a stop, but note in the inventory's "Flags" subsection (so the report makes clear what was *not* audited).
+- A descriptor type not in the audit's scan: stop and report. The audit's Appendix A is the authoritative scope — anything the legacy factory uses that doesn't map onto an entry there is a signal the audit was incomplete.
+
+---
+
+## Plan the spec
+
+*This is the load-bearing planning step. Externalize all structural decisions before writing code.*
+
+**Inputs**:
+- The Legacy Inventory written in the previous step.
+- **The audit report's TTNN ProgramFactory section** — the Metal 2.0 factory concept your port targets was confirmed during the audit. Plan against it; do not re-derive it.
+- The [migration guide — Design Principles](metal2_migration_guide.md#design-principles), especially Principle 2 (named bindings) which drives the "Dropped Plumbing" section below.
+- The [TTNN integration doc](port_op_to_metal2_ttnn_factory.md#the-metal-20-factory-concept) for the factory concept the ported op will satisfy and the entry point that returns the spec.
+- The [patterns catalog](metal2_port_patterns.md).
+- Any yellow-tier items from the audit (apply per the catalog's override guidance for each).
+
+**Output**: extend `METAL2_PORT_PLAN.md` with the following sections (see [Appendix A](#appendix-a--metal2_port_planmd-template) for the template). Each section may say "none" with a one-line justification when no items apply.
+
+### TTNN ProgramFactory
+
+Carry forward the audit's factory decision. This section is brief — the audit confirmed the concept and the recipe inherits the result; the recipe is *not* the place to re-derive the choice.
+
+- **Concept (inherited from audit)**: copy the concept name from the audit report's TTNN ProgramFactory section (`MetalV2FactoryConcept` for every portable op today).
+- **Custom `compute_program_hash`**: note whether the audit flagged one for deletion (carried from the Legacy Inventory).
+- **Implementation notes** (optional): anything specific to how this op will realize the concept that's worth surfacing before construction. Most ports don't need this.
+
+If you find yourself disagreeing with the audit's choice, **stop and surface the disagreement to the invoker** — do not unilaterally override. The audit is the source of truth for the chosen concept; an in-port revision is a signal the audit was incomplete and the invoker needs to know. See the [TTNN integration doc](port_op_to_metal2_ttnn_factory.md) for the concept and the device-op-class edits the port forces.
+
+### Planned Spec Shape
+
+The Metal 2.0 spec shape. Default: 1:1 with legacy.
+
+- **KernelSpecs**: one per legacy `KernelDescriptor` (default). When the legacy factory has multiple `KernelDescriptor`s of the same source for work-split, **preserve the multiplicity**: one `KernelSpec` per legacy `KernelDescriptor`, with the per-group CTAs reproduced. See [Anti-pattern: Demoting per-group CTA to RTA](metal2_port_patterns.md#anti-pattern-demoting-per-group-cta-to-rta) for why this is non-negotiable.
+- **DataflowBufferSpecs**: one per legacy `CBDescriptor`, with one extra spec per additional `buffer_index` for aliased CBs (legacy multi-element `format_descriptors`). For aliased cases, each member of the alias group declares the other(s) via `advanced_options.alias_with` — see [Pattern: Aliased DFBs](metal2_port_patterns.md#pattern-aliased-dfbs-legacy-aliased-cbs) for the legality constraints. For borrowed-memory cases (legacy `CBDescriptor::buffer` set), plan the DFB with `borrowed_from = <tensor_parameter_name>` naming the `TensorParameter` whose buffer backs the DFB.
+- **SemaphoreSpecs**: one per legacy `SemaphoreDescriptor`.
+- **TensorParameters**: one per distinct legacy `TensorAccessor` originating tensor. Note that multiple kernel-side accesses to the same tensor collapse to one `TensorParameter` with multiple `TensorBinding`s.
+- **WorkUnitSpecs**: one per distinct (set of kernels, target nodes) pairing. Most ops have one or two.
+- **Op-owned tensors** (rare — most ops have none): one per legacy intermediate / scratch / workspace device tensor the factory allocated beyond the op's declared io (the audit's [TTNN factory Q1](port_op_to_metal2_audit.md#ttnn-factory-concept-analysis) names them). They are carried in the artifact's `op_owned_tensors`, allocated by the factory and bound like io tensors — see the op-owned step under [§Construct paired spec + run-args](#construct-paired-spec--run-args).
+
+### Preserved Multiplicity
+
+For each work-split case, explicitly list the multi-`KernelSpec` mapping:
+
+```
+Legacy KernelDescriptors [list] of source <path>
+  → KernelSpecs [list] of same source
+  → in WorkUnitSpecs [list]
+  → sharing upstream/downstream DFBs as multi-bindings: [list]
+```
+
+If the legacy code has no multi-`KernelDescriptor` work split, this section reads "none — no work-split multiplicity in legacy."
+
+### Dropped Plumbing
+
+For each legacy RTA or CTA that should *not* survive the port, list it with the replacement primitive:
+
+- **Buffer-address RTAs** (`tensor.buffer()` / `tensor.buffer()->address()` in legacy RTA values; `get_arg_val<uint32_t>(N)` in kernel passed to `TensorAccessor`): replaced by `TensorBinding`. List each kernel's affected RTA slot.
+  - *Case 2 (raw pointer) bindings.* If the audit classified a binding as **Case 2** (the kernel uses a raw base pointer), it still flows through the typed channel as a `TensorBinding`; the base pointer is pulled kernel-side via the sanctioned `get_bank_base_address` bridge (see [kernel-side whitelist rule 5](#kernel-side-whitelist) for the mechanics). List each affected binding here. **A Case 2 binding in a *compute* kernel is blocked** — no bridge exists there yet (rule 5) — so the port fails pending the compute-kernel `TensorBinding` fix. (Case 1 bindings — via `TensorAccessor`, the common case — need no special note.)
+- **Magic CB indices in CTAs**: replaced by `DFBBinding`. List each kernel's affected CTA slot.
+- **`TensorAccessorArgs` plumbing**: replaced by the binding mechanism end-to-end. List each `TensorAccessorArgs(buffer).append_to(cta)` site and its kernel-side `TensorAccessorArgs<N>()` / `next_compile_time_args_offset()` chain.
+- **Semaphore-ID RTAs**: replaced by `SemaphoreBinding`. List each kernel's affected RTA slot.
+- **Positional CTAs**: replaced by named CTAs. List each kernel's positional CTA list with the names you'll assign.
+
+This section's enumeration is the gate against builder-pattern carry-over. If a legacy RTA / CTA is not listed here, it will be translated by reflex during construction — which is exactly the failure mode this gate exists to prevent. See [migration guide — Principle 2](metal2_migration_guide.md#principle-2-first-class-named-resource-bindings) for the rationale.
+
+### Applied Patterns
+
+For each non-trivial pattern from the [catalog](metal2_port_patterns.md) invoked by this port, name the pattern and the context:
+
+- "[Self-loop DFB binding](metal2_port_patterns.md#pattern-self-loop-dfb-binding): ACC_DFB on compute KernelSpec (both PRODUCER and CONSUMER)."
+- "[Conditional optional binding](metal2_port_patterns.md#pattern-conditional--optional-dfb-bindings): SCALED_DFB on compute KernelSpec, gated by `do_scale` CTA."
+- "[Multi-variant factory](metal2_port_patterns.md#pattern-multi-variant-factories): `reduce_dim` variant selection inside `create_program_artifacts`."
+
+### Deferred / Flagged
+
+Any items the audit flagged as YELLOW that affect this port, plus any new findings the planning step uncovered:
+
+- Yellow audit items, with the relevant [catalog](metal2_port_patterns.md) override guidance entry referenced.
+- New findings: anything the audit missed that surfaced during structural planning.
+
+**Stop signal**: if planning uncovers a structural issue the audit didn't catch — e.g., a kernel that genuinely cannot be expressed without one of the legacy workarounds, or a feature gate that the audit's Appendix A doesn't cover — **stop and report**. Don't paper it over by demoting CTAs, packing varargs, or hand-rolling primitives. The audit's gate set improves with what later steps discover.
+
+---
+
+## Scope discipline
+
+*Read this before you touch a file. This section governs every edit in the port — host-side and device-side.*
+
+### The principle
+
+**The premise.** A Metal 2.0 port is a *targeted, scope-tight* transformation: the program factory is restructured to the new host API, and that restructuring projects mechanically into the kernel. Nothing else changes. The expected post-port behavior of the op — its numerics, its performance, every observable side effect — is *identical* to the pre-port behavior. If your diff looks like anything other than the Metal 2.0 transformation, something has gone off-script.
+
+**Two deliverables.** You're producing two things, not one: the diff and the port report. Both are load-bearing. The diff is what ships; the report is what feeds back into the framework's understanding of where its assumptions break, which ops were tricky and why, which patterns surfaced that we hadn't anticipated. A clean diff with a thorough report has the same success-tier as a clean diff with a sparse report — possibly higher, depending on what the report contains. Don't treat the report as a write-up of what you already did; treat it as a deliverable in its own right.
+
+**Improvements are not suppressed — they are routed.** This recipe will at points ask you to leave things alone that you can see how to improve. Refactors, bug fixes, perf optimizations, stale comments, suboptimal type checks, missing validations, hardcoded constants that should be parameters — leave them all. *Write each one up in the report.* Those observations don't disappear into the void; the report is a real channel, read by people with the context to act on findings. The improvement isn't being deleted, it's being delivered to the right hands at the right time.
+
+**Why this is actively harmful, not just unnecessary.** The instinct here — *I see a problem, I can fix it cheaply, it's the right thing to do* — is a good instinct in most software work. In this work it's wrong, and not by a small margin. Four reasons, compounding:
+
+1. **The diff loses attribution.** A port PR that bundles improvements becomes ambiguous in future bisection. When a regression appears six weeks from now and `git bisect` lands on this commit, the question "did the port cause it, or did the bundled change?" is expensive to answer — and the trust damage compounds. A scope-tight diff says "if a regression appears here, it's a Metal 2.0 issue"; a bundled diff says "good luck."
+
+2. **The improvement is denied proper review.** Reviewers looking at a Metal 2.0 port PR have their attention budgeted on the *port*: spec construction, binding shape, kernel projection. They are not budgeted to evaluate a bug-fix patch sitting alongside. The improvement gets less scrutiny than it would get in its own PR — exactly the opposite of what an improvement deserves.
+
+3. **You are not in a position to evaluate the improvement.** The porter sees a local pattern and reasons from local evidence. But ops carry context the porter doesn't have: silicon-generation constraints, calling-convention assumptions, historical bug-fix scars, downstream caller expectations. A change that looks self-evidently correct from inside the file may be wrong from outside it. Example: a porter tightening a `TT_FATAL` on a tensor dtype check to "also accept INT32" may not realize that INT32 support is Quasar-only and this op doesn't target Quasar yet — a "correct-looking" change that is, in context, a bug. *The porter's confidence here is structurally lower than it feels.*
+
+4. **Codebase policy.** PRs that do multiple things at once are explicitly contrary to the codebase's review norms, regardless of how good the bundled changes are individually.
+
+If at any point during the port you find yourself reaching past the rules below, treat that as a signal — *the port has met its limit, not the porter has met theirs.* The [§When the discipline doesn't fit](#when-the-discipline-doesnt-fit) off-ramp at the bottom of this section is the proper resolution; it is on the same success tier as a completed port.
+
+### Host-side: stay in the lane
+
+The host-side discipline divides cleanly along a line between *the program factory body* and *everything around it*:
+
+- **The program factory body is the port.** The `create_program_artifacts` function (and any helpers it calls) is where Metal 2.0's host API is constructed — this code will be heavily rewritten by the port, and that's the work. Stay inside the Metal 2.0 transformation patterns documented in [§Construct paired spec + run-args](#construct-paired-spec--run-args) and [migration guide](metal2_migration_guide.md). Don't refactor adjacent code in the factory while you're there. Don't tighten or loosen a `TT_FATAL` that lives inside the factory. Don't reorder, rename, or "clean up" variables beyond the API renames documented (e.g., `cb_*` → `dfb_*`). The legacy CB API (`CBDescriptor`, `.cbs`, etc.) is replaced by `DataflowBufferSpec` and its companions — no CB references should survive in the post-port factory code (see also Kernel-side whitelist rule 1 for the symmetric kernel-side statement).
+
+- **The op-level host code outside the factory is off-limits.** The device-operation class itself (`validate`, `invoke`, `compute_output_specs`, attribute parsing, the `OpInputs` / `OpParams` definitions, runtime-arg validation, tensor-dtype checks, etc.) is *not* part of the Metal 2.0 port. Do not edit it. Even if the change seems trivial, even if it seems correct, even if you can see exactly what it should say. If you encounter something here that wants changing — a too-tight validation, a stale comment, a `TT_FATAL` whose message is wrong, a missing check — write it up in the port report under findings. Do not change the file.
+
+There are exactly two *documented* exceptions to the off-limits rule — both device-op-class deletions the port forces, both recorded prominently in the port report. The full rationale and procedure for each live in the [TTNN integration doc — Device-operation-class edits the port forces](port_op_to_metal2_ttnn_factory.md#device-operation-class-edits-the-port-forces); in brief:
+
+1. **A custom `compute_program_hash`** — delete it, reverting to the default TTNN hash (when the audit flagged one). Don't patch it to add `TensorSpec`; delete it.
+2. **Pybind lines for a legacy factory entry point the port makes vanish** (`create_program_descriptor` is the canonical case) — deletion is mandatory to keep the build green, and it's a user-visible surface change worth a Handoff-points entry.
+
+Neither extends to any other device-op-class edit. Everything else here stays exactly as it is, routed to the report.
+
+Concrete example of what *not* to do, drawn from a prior porting attempt:
+
+```cpp
+// In the op's device-operation class (NOT the program factory):
+
+// Before the port:
+TT_FATAL(k.dtype() == DataType::UINT32, "Only UINT32 dtypes are supported for k!");
+
+// Tempting "improvement" during the port:
+TT_FATAL(k.dtype() == DataType::UINT32 || k.dtype() == DataType::INT32,
+         "Only UINT32 & INT32 dtypes are supported for k!");
+```
+
+This change is wrong in context: INT32 support is Quasar-only, and this op doesn't target Quasar yet. But more importantly, *whether or not it's correct in context isn't the porter's question to answer.* The change is unrelated to the Metal 2.0 port. It belongs in a separate PR with its own review. Bundled into the port, it muddies attribution and crowds out the actual deliverable. The right action: leave the `TT_FATAL` exactly as it is, and write a finding in the port report ("`k.dtype()` is restricted to UINT32; INT32 also seems plausible — flagging for owner review").
+
+### Kernel-side whitelist
+
+The following are the *only* changes you should be making to kernel code during a Metal 2.0 port. The single `#include` a porter adds to a kernel is `experimental/kernel_args.h` (which pulls in `get_arg`, `args::`, `dfb::`, `sem::`, `ta::`); the generated headers are auto-included by the build system — do not `#include` them yourself.
+
+**1. CircularBuffer → DataflowBuffer.** The object type swap, methods unchanged. Variable name updates limited to following the API rename (`cb_*` → `dfb_*`) — to keep the kernel readable. Don't rename for any other reason.
+
+> A few `CircularBuffer` methods have no `DataflowBuffer` twin — the pointer-selection wrappers (`AddrSelector`, `CircularBufferView`, `use<AddrSelector::READ_PTR>(cb)`). These don't port across as methods; instead the wrapper *drops*, because a bare `DataflowBuffer` used as a NoC source/destination is already pointer-sourced (e.g. `noc.async_write(use<…READ_PTR>(cb_out), …)` becomes `noc.async_write(dfb_out, …)`). When a CB-only method has no DFB equivalent, expect the DFB to make the wrapper unnecessary rather than porting it.
+
+This transition is **total**. Post-port, *no* `CircularBuffer` references survive — neither on the kernel side (the rule above) nor on the host side (where `CBDescriptor`, `.cbs`, and any other legacy CB-API references are replaced by `DataflowBufferSpec` and friends per [§Construct paired spec + run-args](#construct-paired-spec--run-args)). Sweep both sides: stale comments referencing CB, unused `#include`s, helper functions named `MakeCB*`, dead-code paths still building `CBDescriptor` — all gone. A grep for `CircularBuffer` and `CBDescriptor` across the op directory at the end of the port should return zero hits in code (only legacy-comparison artifacts in the port report, if any).
+
+```cpp
+// Legacy:
+CircularBuffer cb_in(cb_in_idx);
+cb_in.wait_front(1);
+cb_in.pop_front(1);
+
+// Metal 2.0:
+DataflowBuffer dfb_in(dfb::in);
+dfb_in.wait_front(1);
+dfb_in.pop_front(1);
+```
+
+**2. CB id → DFBAccessor at LLK / kernel-lib call sites.** Magic-number CB indices (some older kernels hardcoded these) and `uint32_t cb_*_idx` CTA reads are replaced by the `dfb::<name>` handle. The accessor's implicit conversion to `uint32_t` lets it flow into LLK primitives (`reduce_init`, `pack_tile`, `matmul_init`, etc.) and kernel-library helpers expecting a CB id, without extraction or wrapping.
+
+> A CB index carried by a *named* CTA (`get_named_compile_time_arg_val("cb_in")`) converts the same way — to `dfb::cb_in`, **not** to `get_arg(args::cb_in)`. Whether the legacy CB index arrived positionally or by name, it becomes a DFB binding, never a named argument (rule 4). Named args are for non-CB scalars.
+
+```cpp
+// Legacy:
+constexpr uint32_t cb_in_idx  = get_compile_time_arg_val(0);
+constexpr uint32_t cb_out_idx = get_compile_time_arg_val(1);
+reduce_init<...>(cb_in_idx, cb_scale_idx, cb_out_idx);
+pack_tile(0, cb_out_idx);
+
+// Metal 2.0:
+reduce_init<...>(dfb::in, dfb::scale, dfb::out);
+pack_tile(0, dfb::out);
+```
+
+**3. Resource construction from named tokens.** Every kernel-side resource is constructed from its named binding token:
+
+```cpp
+DataflowBuffer  dfb_in(dfb::in);
+TensorAccessor  input(ta::input);
+Semaphore       done(sem::done);
+```
+
+For `TensorAccessor` specifically, this *replaces* the legacy multi-step construction dance. The host-side binding mechanism now packs the layout metadata into the kernel's compile-time args at program creation and auto-injects the per-enqueue base address — work the kernel used to do explicitly via `TensorAccessorArgs<N>()` (with manual offset chaining) and a buffer-address RTA read. The kernel-side rewrite collapses to the one-line construction:
+
+```cpp
+// Legacy:
+constexpr auto input_args = TensorAccessorArgs<N>();    // N = preceding CTA count
+constexpr auto index_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
+uint32_t input_addr = get_arg_val<uint32_t>(0);
+uint32_t index_addr = get_arg_val<uint32_t>(1);
+auto input = TensorAccessor(input_args, input_addr);
+auto index = TensorAccessor(index_args, index_addr);
+
+// Metal 2.0:
+auto input = TensorAccessor(ta::input);
+auto index = TensorAccessor(ta::index);
+```
+
+If positional RTAs survive after the buffer-address RTA goes away (uncommon — most ports also convert all RTAs to named per rule 4), re-index them.
+
+> *Boundary note:* `dfb::name` implicitly converts to `uint32_t`; `sem::name` and `ta::name` do not. The recipe assumes no out-of-op call site requires passing a `sem::` or `ta::` handle — see [§Read this first](#read-this-first). If you encounter one, that's an assumption violation; stop and document per the off-ramp below.
+
+**4. Named arguments throughout.** Compile-time, runtime, and common runtime arguments all become named via `get_arg(args::<name>)`. The CTA / RTA / CRTA distinction is a host-only concern; the kernel uses one uniform retrieval syntax. Pick names that match the variables they were going to be assigned to.
+
+```cpp
+// Legacy:
+constexpr uint32_t page_size = get_compile_time_arg_val(0);
+constexpr uint32_t num_pages = get_compile_time_arg_val(1);
+uint32_t start_page          = get_arg_val<uint32_t>(0);
+uint32_t bank_id             = get_common_arg_val<uint32_t>(0);
+
+// Metal 2.0:
+constexpr auto page_size = get_arg(args::page_size);  // CTA
+constexpr auto num_pages = get_arg(args::num_pages);  // CTA
+auto start_page          = get_arg(args::start_page); // RTA
+const auto bank_id       = get_arg(args::bank_id);    // CRTA
+```
+
+Varargs (`get_vararg(i)`) only when a subset of arguments is *genuinely dynamic in kernel code* — i.e. retrieved in a loop where `i` is a runtime variable (the canonical case: an N-dimensional shape gated on a CTA-bound `rank`). When each argument is referenced by a constant index, the named form is clearer on both sides. **Report any retained varargs use in the port report.**
+
+**5. No raw pointers in arguments.** Raw pointers — typically buffer base addresses — must not be passed as compile-time, runtime, common runtime, or vararg arguments. The binding mechanism handles base addresses for tensors automatically; if a kernel *genuinely* needs a raw pointer (a **Case 2** binding — the legacy kernel used a raw base address with explicit arithmetic), get it from a `TensorAccessor` (zero overhead):
+
+```cpp
+// Legacy:
+uint32_t input_addr = get_arg_val<uint32_t>(0);
+// ... explicit address arithmetic on input_addr ...
+
+// Metal 2.0:
+auto input = TensorAccessor(ta::input);
+uint32_t input_addr = input.get_bank_base_address(bank_id);  // when truly needed
+```
+
+Most ports don't reach for the raw pointer at all — `TensorAccessor`'s normal page-access methods are the standard path (**Case 1** bindings, the common case; they never touch the bridge). `get_bank_base_address` is the escape hatch for **Case 2** bindings — a kernel that used a raw base address with explicit arithmetic. The binding still flows through the typed channel; only the base pointer is extracted here, and the raw arithmetic is left unchanged (no conversion to `TensorAccessor` iteration).
+
+> *Compute kernels — Case 2 is blocked, not an escape valve.* The `get_bank_base_address` bridge lives on `TensorAccessor`, and **a compute kernel cannot bind a `TensorAccessor` today** — the accessor's codegen pulls in the NOC dataflow API, absent from a compute (TRISC) build. So a compute kernel that genuinely needs a raw L1 base address has no bridge, and **the port is blocked**: stop and report it, routing the binding to the compute-kernel `TensorBinding` fix. Do **not** smuggle the address through a CRTA/RTA — even from an **op-owned** tensor, where the address is stable and it would be *strictly* correct, this is a path we deliberately do not take (it normalizes the very pattern Metal 2.0 exists to remove). The one legitimate alternative: if the kernel's access fits a **borrowed-memory DFB** — it reads the data through a `dfb::name` (`get_read_ptr()`), not raw arithmetic — use that. A borrowed DFB is a real framework-managed binding (its backing address refreshes on every cache hit), not a smuggle, and it sidesteps the block. If neither an accessor nor a borrowed DFB fits, the port stops here.
+
+> *Sanctioned exception — host-computed offset.* When the legacy host pre-composed a base pointer with a host-side-computed offset (`tensor.buffer()->address() + compute_offset(attrs)`) and passed the result through an RTA, the standard `TensorBinding` fix isn't enough on its own — the offset arithmetic has to cross the host/kernel boundary. Apply [Pattern: Host-computed base-pointer offset](metal2_port_patterns.md#pattern-host-computed-base-pointer-offset--cta-offset--kernel-side-addition): pass the tensor as a binding, pass the offset as a *named CTA*, and add the single `+ offset` line on the kernel side after the accessor's base-address retrieval. This is the only documented kernel-side modification beyond the whitelist above.
+
+**6. Conditionally bound resources (DFB, tensor, semaphore).** A binding declared conditionally on the host (omitted from the kernel's bindings when a path isn't taken) requires kernel-side coordination:
+
+- The condition that selects the binding moves from a CTA to a kernel-side `#define` (emitted by the host via `KernelSpec::compiler_options.defines`).
+- `#ifdef`-gate the `constexpr` alias of the binding token at file scope.
+- `#ifdef`-gate any expression — including file-scope ternaries — that references the alias.
+
+```cpp
+// Legacy:
+constexpr uint32_t cb_fusion_idx = get_compile_time_arg_val(2);
+constexpr bool fuse_pre_add      = get_compile_time_arg_val(3);
+constexpr uint32_t cb_x = fuse_pre_add ? cb_fusion_idx : cb_out_idx;
+
+// Metal 2.0:
+#ifdef FUSE_PRE_ADD
+constexpr uint32_t cb_fusion = dfb::fusion;
+#endif
+#ifdef FUSE_PRE_ADD
+constexpr uint32_t cb_x = cb_fusion;
+#else
+constexpr uint32_t cb_x = cb_out;
+#endif
+```
+
+The `#ifdef` runs at the preprocessor stage, before the C++ compiler sees the code — so `dfb::fusion` never enters name lookup in the unfused build, and the conditionally-bound resource is honored end-to-end. See [patterns catalog — Conditional / optional DFB bindings](metal2_port_patterns.md#pattern-conditional--optional-dfb-bindings) for the deeper rationale.
+
+**7. Comments — preserve.** The kernel's self-documentation is load-bearing. Slight tweaks to align an existing comment with the line you're forced to change are fine; **deletion is not.** When in doubt, err on the side of preserving information. **A previous porter deleted huge blocks of highly relevant comments while adding `#ifdef`s** — do not repeat that.
+
+The temptation is strongest when adding `#ifdef` blocks — the new structure may feel like it "obviates" an old explanatory comment that sat above the conditional. It doesn't. The explanation of *why* the conditional exists is still valuable; the change in HOW it's gated doesn't retire the WHY. Keep the comments.
+
+**8. No edits to kernel code outside the op's directory.** Shared kernels (under `ttnn/cpp/ttnn/kernel_lib/`, framework primitive locations, or anywhere outside this op's own top-level directory) are vetted for Metal 2.0 compatibility *before* op porting begins. If you find you need to edit one to complete the port, that's a signal the vetting missed something — and the most valuable thing you can do is surface that fact, not bundle the fix. Document in the port report:
+
+- The shared kernel file (path).
+- The function or construct that needed change.
+- What Metal 2.0–side change would have been needed (named-arg conversion, `dfb::` handle plumbed through a uint32_t parameter, etc.).
+
+The fix belongs in a separate PR, owned by the team responsible for the shared kernel. **Do not bundle external-kernel changes into the port PR.** If the implicit conversion `DFBAccessor → uint32_t` is enough to make a call site work without modifying the callee, that's fine — pass the handle and move on. But if you'd need to edit the callee, stop.
+
+For shared kernels that live *inside* `ttnn/cpp/ttnn/operations` but are used by multiple ops (a kernel that several siblings rely on), see [patterns catalog — Modifying a shared dataflow kernel](metal2_port_patterns.md#caution-modifying-a-shared-dataflow-kernel) for the fork-vs-in-place decision.
+
+### When the discipline doesn't fit
+
+If you reach a point where the changes the port would require fall outside the host-side scope or the kernel-side whitelist above, **stop.** Don't improvise. Don't introduce a "clever" workaround. Don't expand the rules by one "just this once." Capitulate gracefully.
+
+**This is not a failed port — it is a *successful capitulation*.** Same success tier as a clean port. The framework's calibration depends on knowing where its assumptions break, and a grounded capitulation gives the maintainers a clear picture of what to refine before the next porting wave. A creative workaround buried in a diff gives them noise; a clean writeup gives them signal.
+
+Record in the port report's *Successful failure* section:
+
+- The op (path, factory).
+- The file and the specific lines / constructs that needed to change.
+- A short explanation of *why* mechanical conversion failed — what the code was doing that didn't fit a binding-token replacement, a comment-preserving `#ifdef`, the host-side-scope boundary, or whichever rule was the sticking point.
+- (If you can sketch it) what the off-rules change would have been, accurate enough that a maintainer can evaluate the gap.
+
+**The stop-signal we see most often:** *if you find yourself reaching past the op's own directory to make kernel changes, that's the signal.* The op shouldn't have made it to porting if its kernel needs out-of-dir changes — flag this prominently in the report. Other signals will surface as porting experience accumulates; this list will grow.
+
+---
+
+## Construct paired spec + run-args
+
+*Mechanical translation from the plan. Build each resource's spec entry and its run-args entry together. Every edit in this step — host-side and kernel-side — is governed by the [§Scope discipline](#scope-discipline) section above.*
+
+**Operating principle**: prefer designated initializers. Metal 2.0 was designed to support them and the spec reads as data, not as procedure. This holds for resource bindings specifically: write `DFBBinding`s in the full designated-initializer form —
+
+```cpp
+DFBBinding{
+    .dfb_spec_name = INPUT,
+    .accessor_name = "in0",
+    .endpoint_type = DFBEndpointType::CONSUMER,
+}
+```
+
+— **not** the `ProducerOf(...)` / `ConsumerOf(...)` / `StridedConsumerOf(...)` / `AllConsumerOf(...)` convenience factories. Those factories exist to trim boilerplate in unit tests, but inside a block of designated-initializer specs a call expression reads as an outlier, and it hides the `endpoint_type` and `access_pattern` that the full form states inline. Keep the spec uniform and the roles explicit.
+
+**`Table`s are maps, not vectors.** Several spec fields that look list-like — `compile_time_args`, `runtime_arg_values` / `common_runtime_arg_values`, `unpack_to_dest_mode`, `defines`, `tensor_args` — are `Table` (a hash-friendly map type), *not* `std::vector`. `Table` has **no `push_back` and no iterator-pair constructor**; building one the way you'd build a vector won't compile. Use brace-init `{{key, value}, …}`, `insert` / `emplace`, `operator[]`, or the single-argument range constructor `Table(existing_map)` (e.g. to convert a legacy `std::map` of defines). When a `Table` must be built conditionally, declare it and `insert`/`emplace` into it — don't reach for `push_back`.
+
+For each resource type, construct the spec entry and its run-args entry as a pair. The order emerges naturally from the op's existing structure (reader / writer / compute order, tensor → DFB → semaphore precedence); the recipe does not prescribe a fixed sequence.
+
+- **`KernelSpec` ↔ `KernelRunArgs`.** For each planned `KernelSpec`, build the schema (`compile_time_args`, `runtime_arg_schema`, `dfb_bindings`, `tensor_bindings`, `semaphore_bindings`, `hw_config`); alongside, build the corresponding `KernelRunArgs` entry (per-node `runtime_arg_values` and `common_runtime_arg_values`). If the kernel has no RTAs, the run-args entry may be omitted entirely.
+- **`DataflowBufferSpec`.** Build with `entry_size`, `num_entries`, `data_format_metadata`, and `tile_format_metadata` **copied from the legacy CB's `format_descriptors[i].tile`** when that field was set (see [migration guide for the rationale](metal2_migration_guide.md#dataflowbufferspec)). No placement field — placement is derived from the kernel bindings. **`entry_size` and `num_entries` are set once at spec construction** — compute them from anything the spec construction has access to (input tensor shapes / shard specs, fields on `operation_attributes`). The `dfb_run_overrides` size-override fields exist in the API but are not supported today; do not use them. (Ops that historically mutated CB sizes between executions are caught at audit time by the [Per-execution CircularBuffer size updates](port_op_to_metal2_audit.md#per-execution-circularbuffer-size-updates-updatecircularbuffertotalsize-updatecircularbufferpagesize-updatedynamiccircularbufferaddressandtotalsize--unsupported) UNSUPPORTED entry.) For borrowed-memory DFBs, set `borrowed_from = <tensor_parameter_name>` naming the `TensorParameter` whose buffer backs the DFB; the backing L1 address resolves at runtime from the corresponding `TensorArgument`, so no `dfb_run_overrides` entry is needed for the backing memory. For aliased DFBs (legacy aliased CBs), set each spec's `advanced_options.alias_with` to mutually name the other members of the alias group — see [Pattern: Aliased DFBs](metal2_port_patterns.md#pattern-aliased-dfbs-legacy-aliased-cbs). For a **fake CB** — a CB the kernel uses purely as an address source, with no real producer/consumer (the audit flags these FYI) — build a normal `DataflowBufferSpec` and bind it as a **self-loop** (PRODUCER + CONSUMER on the reading kernel) to satisfy the validator, then document the hack prominently in the report; see [Pattern: Fake CB → self-loop DFB](metal2_port_patterns.md#pattern-fake-cb--self-loop-dfb-interim-workaround).
+- **`SemaphoreSpec`.** Build with `target_nodes`. (Semaphores have no per-execution counterpart on `ProgramRunArgs`.)
+- **`TensorParameter` ↔ `TensorArgument`.** Declare each tensor as a `TensorParameter` (using `<tensor>.tensor_spec()`); alongside, add the corresponding `TensorArgument` to `ProgramRunArgs::tensor_args`. Here `<tensor>` is the device-resident `ttnn::Tensor` arriving via `tensor_args` / `tensor_return_value`; the `TensorArgument` must reference that same tensor (the framework matches it back by `MeshTensor` identity, so a copy fails) — see the [TTNN integration doc — Extracting the tensor](port_op_to_metal2_ttnn_factory.md#extracting-the-tensor). Build the `TensorArgument` by passing the `MeshTensor` **directly** (`{INPUT, input}`); do **not** wrap it in `std::cref` / `std::reference_wrapper<const MeshTensor>`. `TensorArgument` is a `reference_wrapper`-backed variant and the implicit conversion binds the reference for you — the explicit `std::cref` adds noise without changing behavior.
+- **Op-owned tensors (scratch / workspace) — allocate, place, then bind.** Only when the legacy factory allocated its own intermediate device tensors beyond the op's io (audit Q1); most ports skip this. Three moves:
+    1. **Allocate a `MeshTensor` directly** (not via `ttnn::Tensor` / `create_device_tensor`): `tt::tt_metal::MeshTensor::allocate_on_device(*mesh_device, scratch_spec, tt::tt_metal::TensorTopology::create_fully_replicated_tensor_topology(mesh_device->shape()))`. Source `mesh_device` from any io tensor — `tensor_args.<input>.device()` returns the `MeshDevice*` the framework stamps the workload onto. The topology is **always fully-replicated**: a `MetalV2FactoryConcept` op is single-program, so identical workspace lands on every mesh coordinate — there is no other case to consider. `scratch_spec` is the `TensorSpec` the legacy intermediate used (shape / dtype / layout / memory config).
+    2. **Move it into `ProgramArtifacts::op_owned_tensors`.** The framework parks it in the cache entry at a **stable address** for the cached `Program`'s life — allocated once on a cache miss, re-patched (never re-allocated) on a hit.
+    3. **Bind it exactly like an io tensor** — a `TensorParameter` from its `.tensor_spec()` plus a matching `TensorArgument`; the kernel reads it through its `TensorAccessor` as usual.
+
+  **Identity footgun.** The framework resolves each `TensorArgument` to its tensor **by pointer identity** against the `op_owned_tensors` elements — a mismatch is a runtime `TT_FATAL` ("unowned MeshTensor"). So **populate `op_owned_tensors` first, then build the `TensorArgument`s against the vector's elements**, never against a pre-move local. If you place more than one, `reserve()` the vector up front so a later `push_back` can't reallocate and invalidate references you already took; vector moves preserve element addresses, so handing it to the artifact and returning by value are both safe.
+
+  **Untested at runtime** — no production op exercises this path yet (compile-coverage only). The first op-owned port is its shakedown: surface any friction (allocation ergonomics, binding identity, the topology choice) rather than trusting it blindly.
+- **`WorkUnitSpec`.** Build with `kernels` (by `unique_id`) and `target_nodes`. No per-execution counterpart.
+
+After all resources are built, assemble the `ProgramSpec` (collecting `kernels`, `dataflow_buffers`, `semaphores`, `tensor_parameters`, `work_units`) and the `ProgramRunArgs` (collecting `kernel_run_args`, `tensor_args`). Return them wrapped as `ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)}` from the factory's `create_program_artifacts` method — see the [TTNN integration doc](port_op_to_metal2_ttnn_factory.md#the-metal-20-factory-concept) for the method signature and the cache lifecycle the framework wraps around it. When the op has op-owned tensors, also `std::move` them into the artifact's `op_owned_tensors` field (allocated and bound during construction, per the op-owned step above); omit the field otherwise — it defaults empty.
+
+**Hardware-config shortcuts.** Two helpers worth knowing for the `hw_config` field on `KernelSpec`:
+
+- *DM kernels*: prefer `DataMovementRoleHint::READER` or `DataMovementRoleHint::WRITER` over manual `gen1_config` setup. (`DataMovementRoleHint` is the namespace-level alias of `DataMovementHardwareConfig::RoleHint`; prefer it over the scoped form.) The RoleHint auto-infers the Gen1 processor/NOC pair (and the Gen2 default config), so the construction is one line: `.hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER}`. `UNSPECIFIED` permits a power-user override via explicit `gen1_config`.
+- *Compute kernels*: if the ported op carries a TTNN `ComputeKernelConfig`, use the converter helper `to_compute_hardware_config(const ComputeKernelConfig&)` (declared in `ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.hpp`) to translate it to `ComputeHardwareConfig` rather than rebuilding field-by-field. The helper maps `math_fidelity`, `math_approx_mode`, `fp32_dest_acc_en`, `dst_full_sync_en` 1:1. **`unpack_to_dest_mode` is not part of the helper** — the factory must configure it separately when needed (e.g., for FP32 DFB consumers under `fp32_dest_acc_en`). Each `unpack_to_dest_mode` entry is keyed by a DFB the kernel binds, so a *conditionally*-bound DFB's entry must be gated on the **same condition as its binding**: the spec validator rejects an `unpack_to_dest_mode` key naming a DFB the kernel doesn't bind. (A legacy CB-id-indexed array could carry the entry unconditionally; Metal 2.0 cannot.)
+
+**Stop signals**: any urge to —
+
+- Demote a CTA to a runtime arg to make a single `KernelSpec` work where the legacy had multiple. ([Anti-pattern](metal2_port_patterns.md#anti-pattern-demoting-per-group-cta-to-rta).)
+- Bind a conditionally-used DFB *unconditionally* on the host to dodge the `if constexpr` name-lookup problem. That wastes L1 and breaks the moment the kernel references the name from a file-scope ternary or similar context. The right shape is conditional host binding + matching `KernelSpec::defines` + kernel-side `#ifdef`-gated alias and uses — see [Pattern: Conditional / optional DFB bindings](metal2_port_patterns.md#pattern-conditional--optional-dfb-bindings).
+- Extract `.id` from a `dfb::name`, or construct a temporary `DataflowBuffer` to retrieve its underlying id. ([Anti-pattern](metal2_port_patterns.md#anti-pattern-id-extraction-or-temp-dfb-wrappers-at-llk-call-sites).)
+- Pack data into varargs that should be named arguments. ([Caution](metal2_port_patterns.md#caution-avoid-varargs-unless-absolutely-necessary).)
+- Thread a buffer address through an RTA because the binding mechanism doesn't fit. *(A **compute** kernel needing a raw L1 base address cannot bind a `TensorAccessor`, so it has no bridge — that does **not** make an RTA acceptable; the port is **blocked** there pending the compute-kernel `TensorBinding` fix, per [kernel-side whitelist rule 5](#kernel-side-whitelist).)*
+- Hand-roll a synchronization primitive.
+- Modify a kernel's `wait_front` / `pop_front` calls to "balance" a DFB's producer / consumer topology. The host-side spec validator's "every DFB needs ≥1 PRODUCER and ≥1 CONSUMER" check is satisfied by adjusting the *binding* declaration on the host (declare the conditional-side endpoint unconditionally), not by adding consumes/produces inside the kernel. Per-execution DFB state is reinitialized, so a tile produced and never consumed is harmless across enqueues.
+
+If any of these appear in your draft, **stop and report**. The likely cause is a structural decision during planning that should be revisited.
+
+**Exception — Case 2 (raw pointer) bindings.** If the audit classified a `TensorParameter` as **Case 2** (the kernel uses a raw base pointer), the binding still flows through the typed channel; only the *base pointer* is extracted kernel-side via the sanctioned `get_bank_base_address` bridge (see [kernel-side whitelist rule 5](#kernel-side-whitelist)), never threaded through an RTA. This is the **one** carve-out from the "buffer address through an RTA" stop signal above, and it is **data-movement only**: a **compute** kernel cannot bind a `TensorAccessor`, so a Case 2 binding there has no bridge and **blocks the port** (rule 5) rather than falling back to an RTA.
+
+---
+
+## Verification
+
+*Build, test, anti-pattern self-audit.*
+
+### Build
+
+Build the ported op's TTNN target and its test binary via the [build/test helper subagent](#use-a-subagent-for-builds-and-tests):
+
+```bash
+cmake --build build_Release --target ttnncpp unit_tests_ttnn -j 8
+```
+
+(If the op's tests live in a sibling binary — `unit_tests_ttnn_udm`, `unit_tests_ttnn_tensor`, `unit_tests_ttnn_ccl`, etc. — substitute or add it to the target list.)
+
+The helper returns SUCCESS / FAILURE + key errors. On FAILURE, common causes:
+
+- `AllFactoriesValid` `static_assert` fires → a factory satisfies two concepts (likely a stale `cached_program_t` declaration alongside the new `create_program_artifacts`). Audit for missed deletions in the header.
+- Unresolved symbol for `override_runtime_arguments` → some code path still calls it. Should only happen for the framework adapter, which doesn't for `MetalV2FactoryConcept` factories. Re-audit.
+- Error referencing `metal_v2_artifacts.hpp` (or other framework header) not found → the framework dependency is not on this branch. Stop and report; the framework PR was a precondition for the audit (which should have failed pre-port).
+- `kernel_args_generated.h` mentions a name that doesn't exist → host added a named CTA / RTA without the kernel referencing it (or vice versa). Reconcile.
+- Linker error `undefined reference to 'dfb::...'` inside a kernel TU → the kernel `#include`s the wrong generated header. `dfb::*` lives in `kernel_bindings_generated.h`, `args::*` in `kernel_args_generated.h`. The only `#include` a ported kernel should add is `experimental/kernel_args.h`; the framework injects both generated headers automatically.
+
+### Run tests
+
+Run the op's correctness tests via the helper. Use the **tests directory the invoker supplied** in [Before you begin](#before-you-begin). Two layers:
+
+```bash
+# C++ gtests — fast, fails fast on a broken port
+./build/test/ttnn/unit_tests_ttnn --gtest_filter='*<Op>*'
+
+# Python pytests — broader coverage (dtype/layout sweeps, program-cache behavior)
+pytest <invoker-supplied-tests-dir> -x -v
+```
+
+Recommended order: gtests first (faster, exercises the C++ op directly), then pytests once gtests are green. If the op has a UDM/specialized variant, its gtests live in a sibling binary (`unit_tests_ttnn_udm`, etc.) — the recipe's worked example in [`metal2_workspace_setup.md`](metal2_workspace_setup.md) shows the pattern.
+
+> **A selected-but-unconverted kernel path can crash the whole pytest *session*, not just fail it.** While converting kernels path-by-path, a test that selects a not-yet-converted kernel hits that kernel's positional `get_compile_time_arg_val(0)` (the host now emits only named args), which `static_assert`s at JIT; the resulting `TT_FATAL` can segfault the Python process during traceback rendering (exit 139) and take down the entire pytest run rather than reporting a clean failure. Exclude not-yet-converted paths with `-k` until you convert them. This is a known tooling issue — not a port error, and not a card hang (no `0xdeadc0de`).
+
+All tests passing pre-conversion should continue to pass post-conversion. If a previously-passing test now fails, **stop and report** — likely cause is a structural error in the spec that compiled but failed at `MakeProgramFromSpec` validation, or an incorrect tensor-arg / runtime-arg layout.
+
+If compilation passes but the test fails with a `TT_FATAL` from `program_spec.cpp` or `program_run_args.cpp`, the [patterns catalog](metal2_port_patterns.md) has entries for the most common failure modes (DFB binding multiplicity mismatches, missing kernel run-args entries, etc.). Cross-reference the error message against the catalog.
+
+For symptom-organized lookup (errors whose fix isn't obvious from the message text), see the [migration guide's troubleshooting table](metal2_migration_guide.md#cryptic-error--likely-cause).
+
+**Custom `compute_program_hash` failure mode.** The port should already have deleted any custom `compute_program_hash` (reverting to the default) per the [TTNN integration doc](port_op_to_metal2_ttnn_factory.md#1-delete-a-custom-compute_program_hash) — it's proactive port work, not a wait-and-see. The signature of one that survived: `UpdateTensorArgs` `TensorSpec` legality failures on the *second and later* test invocations (program cache hot), not the first. If you see that, find the surviving custom hash and delete it; do not patch it to include `TensorSpec`. Confirm the deletion is recorded in `METAL2_PORT_REPORT.md`.
+
+### Anti-pattern self-audit
+
+Scan the ported code against this checklist. Each item is a Metal 2.0 design-intent failure to look for; the [patterns catalog](metal2_port_patterns.md) has the full discussion of each.
+
+- [ ] **No `tensor.buffer()->address()` survived.** Search the factory `.cpp` for this string; if present, the corresponding tensor needs a `TensorBinding` instead.
+- [ ] **No magic-number CB indices in CTAs.** Search `compile_time_args` for values that are CB indices (typically small integers or `CBIndex::c_*`); if found, the value should come from a `DFBBinding` instead.
+- [ ] **No `TensorAccessorArgs<N>()` survived in any ported kernel.** Search for this; if present, the kernel needs `TensorAccessor(ta::name)` instead.
+- [ ] **Conditional DFB bindings follow [Pattern: Conditional / optional DFB bindings](metal2_port_patterns.md#pattern-conditional--optional-dfb-bindings).** For each conditionally-used DFB: the host conditionally binds it; `KernelSpec::defines` carries the matching preprocessor flag; the kernel `#ifdef`-gates both the constexpr alias of the DFB name and every expression referencing it. No unconditional bindings introduced as a workaround.
+- [ ] **No `.id` extraction at LLK call sites.** Search for `.id` on `dfb::` handles; if present, pass `dfb::name` directly.
+- [ ] **No CTA→RTA demotion in compute kernels.** If a per-group dimension was moved from CTA to RTA in the port, the structural decision is wrong; revisit planning.
+- [ ] **All CTAs are named.** Search the factory for positional `compile_time_args = {...}`; should be `compile_time_args = {{name, value}, ...}` only.
+- [ ] **No new varargs unless the kernel reads them in a loop.** Check `num_runtime_varargs` use; if the kernel reads `get_vararg(0)`, `get_vararg(1)`, ..., the named form is the right answer.
+
+If any checklist item fails, return to planning / construction to fix. Do not paper over with kernel-side modifications.
+
+---
+
+## Capture the port report
+
+**Open `METAL2_PORT_REPORT.md` at the start of the port and update as you go** — do not write it retrospectively. Add a one-line note the moment something surprises you, even rough. Polish entries at the end; capture in the moment. A friction note written when it happened is worth more than a paragraph reconstructed two hours later.
+
+The final report is committed when the port reaches its stopping point — whether that's "all factories ported and tests pass" or "stuck on issue X and cannot proceed" — alongside `METAL2_PREPORT_AUDIT.md` and `METAL2_PORT_PLAN.md` in the op directory. The report captures what happened during the port: things that need handoff to other teams, things the docs got right, things the docs missed, and things the next porter or doc maintainer should know.
+
+The report is read by the kernel-lib / API owners (for handoff points), by the doc maintainers (for friction-driven evolution of the audit / recipe / catalog / migration guide), and by future porters of related ops.
+
+Structure the report with the following sections. Each section may be empty (write "none" with a one-line note); do not omit sections.
+
+### TTNN ProgramFactory
+
+Confirms the realized factory shape against the audit's decision, and records the device-op-class edits the port forced. Filled out per the [TTNN integration doc — Port report deliverable](port_op_to_metal2_ttnn_factory.md#port-report-deliverable-porter-facing): concept realized, custom-hash deletion (file:line or none), pybind entry points removed (or none), and open items (relaxation candidates, capabilities not yet on main the op would benefit from, friction with the concept fit).
+
+If the port stayed on the default concept with no device-op edits, this section is short — that's the success case.
+
+### Handoff points
+
+Escalations to teams outside the porter's scope. Each entry is something the porter cannot fix from within the op directory and that should not be papered over.
+
+Includes (not exhaustive):
+
+- **Boundary-rule assumption violations.** A call site outside the op directory that required `sem::name` or `ta::name` (per the [scope boundary](#read-this-first)). Cite the file:line, the callee, and the named handle that the call site demands. Tagged "API: requires implicit conversion / refactor."
+- **Kernel-lib gaps.** Cases where a shared kernel-lib helper or LLK is incompatible with Metal 2.0 binding semantics in a way the porter cannot work around. Cite the helper, the call site, the specific incompatibility.
+- **Framework gaps.** Audit-time entries that were YELLOW or UNSUPPORTED and that bit during the port. Cite the audit entry, what the port needed, and the workaround (if any) you adopted.
+- **Removed pybind surface.** Any pybind line(s) deleted because the port made a legacy factory entry point (e.g., `create_program_descriptor`) vanish. Cite the pybind file path, the function name(s) removed, and a one-line description of what the function was for. Tagged "API surface: removed entry point." This is a *user-visible* surface change — downstream Python consumers (tests, notebooks, internal tooling) need to find this entry to update their callers. See [Pattern: Removing pybound legacy factory entry points](metal2_port_patterns.md#pattern-removing-pybound-legacy-factory-entry-points).
+
+Each handoff entry should be writable as a standalone ticket. The porter is the original reporter; the listed team is the owner.
+
+### Successes
+
+Places where the docs steered the port right. Especially valuable when the porter almost did something the catalog warned against and the warning fired correctly — these are the entries that justify keeping a doc section in its current form.
+
+Cite the doc section by name and link; cite the file:line in the ported code where the warning applied. Brief — one short paragraph per entry.
+
+### Friction
+
+What bit during the port and how the docs helped or didn't. Two subcategories:
+
+- **Gaps** — where the docs didn't have an answer, or had a stale answer. Most actionable kind of entry — directly translates to a doc improvement.
+- **Confusion** — where the docs were ambiguous, hard to follow, or led to a near-miss before the right path became clear.
+
+Cite the doc section, the file:line in the port, and what the right answer turned out to be.
+
+### Open items for downstream
+
+Anything the porter discovered that is in scope for *some* future work but not the current port. The next porter or doc maintainer reads this section to know what to pick up. Includes:
+
+- **Fake-CB self-loop bindings (interim hack — flag prominently).** Each fake CB you bound as a self-loop DFB ([Pattern: Fake CB → self-loop DFB](metal2_port_patterns.md#pattern-fake-cb--self-loop-dfb-interim-workaround)): list it with `file:line`, the `(CB, endpoint)` it stands in for, and which kind it is — **scratchpad** (read/write) or **tensor-local-view** (read-only). State plainly that the self-loop is a validator-satisfying device, not a real FIFO. This is the load-bearing record the eventual scratchpad / local-`TensorAccessor` migration uses to find and replace every one — so do not bury it.
+- **Cross-op kernel touches.** Any kernel source the port modified or forked that lives outside the op directory (per the [scope boundary](#read-this-first) and the [shared-dataflow-kernel Caution](metal2_port_patterns.md#caution-modifying-a-shared-dataflow-kernel)). Excludes `ttnn/cpp/ttnn/kernel_lib/` and standard framework APIs, which are scope boundaries the porter does not cross. For each cross-op kernel, record: (a) the kernel path; (b) the path taken — **in-place modification** (with the bundled-set consumer list) or **fork** (with the `_metal2`-suffixed new file's path); (c) the remaining unmigrated consumer op directories. This list is the coordination signal for the next sibling-op port and, for forks, the sunset checklist for when the legacy copy can be deleted.
+- Per-op carry-over (sibling ops the porter noticed would benefit from the same pattern).
+- Doc-evolution suggestions that don't fit cleanly into a Gap entry (broader restructure, new pattern entry candidate).
+- Test coverage notes the verification step surfaced but didn't act on.
+
+---
+
+**Substance over comprehensiveness** — 5–15 well-targeted entries across the four sections beats 30 shallow ones. Be specific: cite file paths, line numbers, doc sections.
+
+Commit `METAL2_PORT_REPORT.md` alongside the port code, audit report, and port plan. All four artifacts (port code + the three `METAL2_*.md` files) form the port's PR.
+
+---
+
+## Appendix A — `METAL2_PORT_PLAN.md` template
+
+Copy this template to the op's directory at the start of the port:
+
+````markdown
+# Port Plan — <op name>
+
+Port plan for `<op>`, ported from `<legacy api>` to Metal 2.0.
+Written during the inventory and planning steps; committed alongside the port for review.
+
+## Legacy Inventory
+
+*Filled in during the inventory step.*
+
+### Legacy factory shape
+- Concept: <ProgramFactoryConcept | ProgramDescriptorFactoryConcept | MeshWorkloadFactoryConcept>
+- Variants: <list, or "single">
+- Custom `compute_program_hash`: <deleted → default (sanctioned exception), was at file:line | none — already default reflection-based hash>
+
+*(The Metal 2.0 factory concept the port targets was chosen during the audit — see the audit report's TTNN ProgramFactory section. Carried forward in the [TTNN ProgramFactory](#ttnn-programfactory) section below.)*
+
+> **Multi-variant ops** (e.g., Welford W/H/HW; Reduce W/H/HW): repeat the Kernels / CBs / Semaphores / Tensor accessors / Work split sub-sections **per variant**. Nest the per-variant blocks under a `### Variant: <name>` heading and downshift the per-resource headings to `####`. Cross-op kernels and Flags stay top-level — they typically apply across variants. The single-variant skeleton below is the inner shape of each variant block.
+
+### Kernels
+| unique_id | source | core_ranges | CTAs (positional) | CTAs (named) | RTAs | CRTAs | defines | config |
+|---|---|---|---|---|---|---|---|---|
+| reader | ... | ... | ... | ... | ... | ... | ... | ... |
+| writer | ... | ... | ... | ... | ... | ... | ... | ... |
+| compute | ... | ... | ... | ... | ... | ... | ... | ... |
+
+### CBs
+| index | total_size | core_ranges | data_format | page_size | tile (if set) |
+|---|---|---|---|---|---|
+| 0 | ... | ... | ... | ... | ... |
+
+### Semaphores
+| id | core_type | core_ranges | initial_value |
+|---|---|---|---|
+| 0 | ... | ... | ... |
+
+(or "none")
+
+### Tensor accessors
+| host site (file:line) | originating Tensor | RTA slot (host) | CTA offset (kernel) |
+|---|---|---|---|
+| ... |
+
+### Work split
+- Driver: `split_work_to_cores(<args>)`
+- num_cores: ...
+- core_group_1: ..., count_per_core: ...
+- core_group_2: ..., count_per_core: ...
+
+(or "n/a — single core")
+
+### Cross-op kernels
+List any kernel `source` path outside the op's directory. Each one is a Caution case (see [catalog](metal2_port_patterns.md#caution-modifying-a-shared-dataflow-kernel)) and is also reported in `METAL2_PORT_REPORT.md` under "Open items for downstream."
+
+(or "none")
+
+### Flags
+Anything the inventory step noticed but didn't classify — unreferenced kernel files, unusual descriptors, etc.
+
+(or "none")
+
+## TTNN ProgramFactory
+
+*Filled in during the planning step. The concept itself was chosen in the audit; this section carries it forward.*
+
+- **Concept (inherited from audit)**: <MetalV2FactoryConcept>
+- **Custom `compute_program_hash`**: <delete (was at file:line) | none>
+- **Implementation notes** (optional): <anything specific to how this op will realize the concept that's worth surfacing before construction>
+
+(If you find yourself disagreeing with the audit's choice, stop and surface to the invoker — do not override.)
+
+## Planned Spec Shape
+
+*Filled in during the planning step.*
+
+> **Multi-variant ops**: repeat this section per variant, nested under `### Variant: <name>` headings.
+
+- KernelSpecs: ...
+- DataflowBufferSpecs: ...
+- SemaphoreSpecs: ...
+- TensorParameters: ...
+- WorkUnitSpecs: ...
+
+## Preserved Multiplicity
+
+> **Multi-variant ops**: repeat per variant if work-split multiplicity differs across variants; a single shared row suffices if the pattern is identical across variants.
+
+| legacy KernelDescriptors | same-source KernelSpecs | WorkUnitSpecs | shared DFBs (multi-binding) |
+|---|---|---|---|
+| ... |
+
+(or "none — no work-split multiplicity in legacy")
+
+## Dropped Plumbing
+
+For each legacy RTA / CTA that disappears in the port:
+
+| legacy location (file:line) | legacy form | Metal 2.0 replacement |
+|---|---|---|
+| reader.cpp RTA slot 0 | `tensor.buffer()->address()` | `TensorBinding(input)` |
+| reader.cpp CTA slot 0 | `cb_idx = 0` | `DFBBinding(input, "in0", CONSUMER)` |
+| ... |
+
+## Applied Patterns
+
+List any patterns from the catalog invoked by this port:
+
+- ... ([catalog entry link])
+- ...
+
+(or "none")
+
+## Deferred / Flagged
+
+- Yellow items from audit: ... ([catalog override guidance link])
+- New findings during planning: ...
+
+(or "none")
+````
+
+---
+
+## Appendix B — Cross-references
+
+- [Feasibility audit](port_op_to_metal2_audit.md)
+- [Migration guide (concept map, design principles, TTNN integration)](metal2_migration_guide.md)
+- [Patterns catalog](metal2_port_patterns.md)

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/port_op_to_metal2_ttnn_factory.md
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/port_op_to_metal2_ttnn_factory.md
@@ -1,0 +1,184 @@
+# Porting an Op to Metal 2.0 — TTNN Integration
+
+> The TTNN device-operation glue a Metal 2.0 port needs: which factory concept the op lands on, the factory entry point that returns the spec, and the two device-op-class edits the port forces (custom-hash deletion, pybind cleanup). Lives in its own document because the TTNN factory layer churns on a different cadence than the Metal 2.0 host API — the [port recipe](port_op_to_metal2_recipe.md) covers building the `ProgramSpec` + `ProgramRunArgs` (stable); this doc covers wiring that into TTNN's framework (in flux).
+
+## Read this first
+
+**Primary audience**: AI agents performing the [audit](port_op_to_metal2_audit.md) on a TTNN op. The audit's final step is to confirm the op fits the Metal 2.0 factory concept and record the choice in the audit report.
+
+**Secondary audience**: AI agents performing the [port](port_op_to_metal2_recipe.md). The port inherits the audit's decision and implements the factory entry point against it. The "Port plan" and "Port report" deliverable sections at the bottom of this document carry the decision forward through the port artifacts.
+
+**The division of labor with the recipe.** The recipe owns the *contents* of the artifact — how you build a `ProgramSpec` (kernels, DFBs, semaphores, tensor parameters, work units) and its paired `ProgramRunArgs`. This document owns the *wrapper* — the factory method that returns those two objects to the framework, how the framework caches and dispatches it, and the handful of device-operation-class edits the port forces. When the recipe says "return the artifact," the shape of that return lives here.
+
+---
+
+## The Metal 2.0 factory concept
+
+A Metal 2.0 op factory satisfies **`MetalV2FactoryConcept`**: it implements a single method, `create_program_artifacts`, that returns a `ProgramArtifacts` (a `ProgramSpec`, its `ProgramRunArgs`, and any op-owned tensors the factory allocates). The framework adapter stamps a `Program` from the spec onto each mesh coordinate range on cache miss, and refreshes tensor bindings on cache hit.
+
+This is the Metal 2.0 factory concept ops port to today. It supports:
+
+- **Single-program** — the factory produces one `ProgramSpec`, stamped identically across the mesh.
+- **Op-owned device tensors (optional)** — the factory *may* allocate its own scratch / workspace `MeshTensor`s and return them in `op_owned_tensors`; the framework parks them in the cache entry at a stable address for the cached `Program`'s lifetime. It may **not** allocate its own `GlobalSemaphore`s (the artifact carries only `MeshTensor`s). Every tensor a `TensorArgument` references must be reachable from `tensor_args` / `tensor_return_value` *or* be one of the `op_owned_tensors`.
+- **Strict tensor-arg matching** — every `TensorParameter` enforces an exact `TensorSpec` match when the framework binds a tensor to it.
+
+```cpp
+struct MyProgramFactory {
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
+        const operation_attributes_t& attributes,
+        const tensor_args_t&          tensor_args,
+        tensor_return_value_t&        tensor_return_value);
+};
+```
+
+`ProgramArtifacts` has three fields — `spec`, `run_params`, and `op_owned_tensors` (default-empty):
+
+```cpp
+ttnn::device_operation::ProgramArtifacts MyProgramFactory::create_program_artifacts(
+    const operation_attributes_t& attributes,
+    const tensor_args_t&          tensor_args,
+    tensor_return_value_t&        tensor_return_value) {
+
+    // ... build the spec and run-args (see the recipe's Construct step) ...
+    tt::tt_metal::experimental::ProgramSpec    spec{ /* ... */ };
+    tt::tt_metal::experimental::ProgramRunArgs run_args{ /* ... */ };
+
+    return ttnn::device_operation::ProgramArtifacts{
+        .spec       = std::move(spec),
+        .run_params = std::move(run_args),
+        // .op_owned_tensors = std::move(scratch),  // only if the factory allocates its own tensors
+    };
+}
+```
+
+### How the framework caches and dispatches it
+
+The op author writes only `create_program_artifacts`. The framework adapter does the rest:
+
+- **Cache miss**: the adapter calls `create_program_artifacts`, builds one `Program` per mesh coordinate range from the spec, applies the initial `ProgramRunArgs`, and resolves each `TensorArgument` against the tensors enumerated from `tensor_args` / `tensor_return_value` followed by the factory's `op_owned_tensors` (matched by `MeshTensor` identity within the call). The op-owned tensors are parked in the cache entry so their allocation outlives the miss and stays at a stable address across dispatches.
+- **Cache hit**: the adapter enumerates fresh tensors (io tensors plus the parked op-owned ones) and patches their `TensorArgument`s into the cached `Program` in place — **only the tensor arguments are refreshed**, nothing else in the run-args — no `Program` rebuild, no factory re-run.
+
+The cache key is the op itself — its type, attributes, and tensor args (the framework's automatic hash), combined with the target mesh coordinates; a custom `compute_program_hash`, if present, replaces that default. Two dispatches with matching op-args share a cache entry, and only the tensor bindings are refreshed between them. The porter doesn't write any of this — it falls out of returning a correct `ProgramArtifacts`.
+
+### Extracting the tensor
+
+The factory receives device-resident `ttnn::Tensor`s through `tensor_args` and `tensor_return_value`. Declare each `TensorParameter` from the tensor's `tensor_spec()`, and reference the same tensor from the paired `TensorArgument` in `ProgramRunArgs::tensor_args`. The adapter matches a `TensorArgument` back to its input by `MeshTensor` identity — so a `TensorArgument` must reference a tensor reachable from the factory's parameters (an io tensor, or one of the `op_owned_tensors`), never a copy. (Constructing or copying a tensor and referencing the copy fails at runtime.)
+
+---
+
+## Feasibility gate
+
+The audit's job here is one question: **does the op fit the single concept above?**
+
+- **Single-program** (the common case — op-owned tensors are fine) → `MetalV2FactoryConcept`. Proceed.
+- **Anything else** → the port is **blocked on framework work**, not porter-resolvable. Record RED and stop.
+
+The "anything else" cases — and the reason they're blocked:
+
+- **Op-owned `GlobalSemaphore`s.** The factory allocates its own `GlobalSemaphore`s in its body. Op-owned *tensors* are supported (the artifact carries them; see above), but the artifact has no slot for op-owned semaphores yet. An op needing only op-owned *tensors* is **not** blocked — it ports cleanly.
+- **Multi-program / per-coord variation.** The op's programs genuinely differ across mesh coordinates (CCL-style). The single-program adapter stamps one spec everywhere.
+
+Op-owned *tensors* are supported on this concept; the remaining gaps — op-owned `GlobalSemaphore`s and genuine multi-program workloads — are not porter-resolvable and are tracked separately. If you hit one, the op is parked until that framework work lands — record it in the audit so it feeds prioritization.
+
+> **Heads-up — a legacy `MeshWorkload` is not automatically a multi-program op.** Some legacy ops construct a `MeshWorkload` only because the legacy framework couldn't carry op-owned tensors on the single-program path. If every per-coord program is structurally identical (same kernels, same DFB shape, same bindings — only the tensor data differs) and the only thing pushing it multi-program was a resource workaround, the op is *morally* single-program and **ports cleanly** — carry its workspace tensors in `op_owned_tensors` on the single-program concept and drop the `MeshWorkload`. Record it as a resource-workaround unwind rather than genuine per-coord variation.
+
+### Tensor-arg matching — keep strict
+
+Every `TensorParameter` enforces an exact `TensorSpec` match by default. **Don't deviate during a port.** The relaxation infrastructure exists (`TensorParameter::advanced_options`, holding `dynamic_tensor_shape` / `match_padded_shape_only`), and the per-dispatch legality check respects it, but relaxations are a deliberate correctness-sensitive opt-in: the kernel must *actually* tolerate the relaxation, and declaring one the kernel doesn't tolerate is a silent wrong-answer bug. The bias of mistakes favors strict — forgetting to relax is merely slower (narrower cache equivalence, still correct); relaxing incorrectly is wrong output. A port is not the context to make that call. If you notice a kernel that *would* tolerate a relaxation (e.g. padding-only dimension differences), capture it in the port report under "Open items for downstream" — don't bake it into the port.
+
+**The exception is a *known-required* relaxation the docs already call out.** Where a kernel is known to need one, it is flagged for you — the [pre-migration `ArgConfig::Runtime*` check](metal2_migration_guide.md#tensorparameter) and its op-family heads-ups (e.g. `eltwise` → `dynamic_tensor_shape = true`). Those are faithful mirrors of a relaxation the legacy op *already* declared, not a judgment call you're making. So the rule is two-sided: don't *self-decide* a relaxation, but *do* apply the ones the docs flag as required — follow the hint rather than DIY-ing it (or, conversely, ignoring it).
+
+---
+
+## Device-operation-class edits the port forces
+
+The port's writeable surface is the program factory body — the device-operation class (`validate`, `invoke`, `compute_output_specs`, attribute parsing) is otherwise off-limits (see the recipe's [Scope discipline](port_op_to_metal2_recipe.md#scope-discipline)). There are **three** sanctioned exceptions, each forced by the port, each recorded prominently in the port report.
+
+### 1. Delete a custom `compute_program_hash`
+
+If the device-operation defines a custom `compute_program_hash` (overriding the default reflection-based hash), **the port deletes it**, reverting to the default. This is sanctioned — not a freelance device-op edit — because:
+
+- No Metal 2.0 factory concept reads a custom hash; the framework's automatic hash of the op (type + attributes + tensor args) is the cache key.
+- ProgramDescriptor-ported custom hashes are frequently incorrect now: they silently omit `TensorSpec`, which trips `UpdateTensorArgs` legality failures on the *second and later* dispatches (program cache hot), not the first.
+- The default is correct-by-construction.
+
+Delete it as part of the port. Do **not** patch it to add `TensorSpec` (that path leads to subtle bugs), and do **not** defer it to "see if it bites at verification" — it's proactive port work. Record the deletion (file:line of what was removed) in the port report. If a custom hash is ever missed, its signature is `UpdateTensorArgs` `TensorSpec` legality failures on the second-and-later test invocations; the fix is the same — find and delete it.
+
+### 2. Remove pybound legacy factory entry points
+
+When the port causes a legacy factory entry point to vanish (`create_program_descriptor` is the canonical case), any pybind line referencing it must be deleted — leaving it would break the post-port build. This is a *user-visible* API surface change: downstream Python consumers (tests, notebooks, internal tooling) may reference the removed entry point. The exception is narrow — it applies *only* to the disappearing factory entry point, not to other pybind lines on the same op. See [Pattern: Removing pybound legacy factory entry points](metal2_port_patterns.md#pattern-removing-pybound-legacy-factory-entry-points) for the procedure, and record the removal in the port report under Handoff points (cite the pybind file, the function name, and what it was for).
+
+### 3. Drop a factory parameter that exists only for a pybind hook
+
+Some legacy factories carry a non-standard parameter that production code never sets — it exists only so a pybind test/introspection hook can drive the factory (layernorm's `create_descriptor` took an extra `const std::optional<CoreRangeSet>& core_range_set` used only by its pybind hook). The fixed `create_program_artifacts` signature (`attributes`, `tensor_args`, `tensor_return_value`) cannot carry it. Drop the parameter, inline its production default in the factory body, and delete the pybind hook that passed it (same procedure and report-handling as exception 2). This is mechanically the pybind-removal case with an extra parameter to unwind; flag it the same way. Don't try to preserve the hook — its `ProgramDescriptor` return is exactly what the port eliminates.
+
+---
+
+## Audit report deliverable
+
+The auditor adds the following to `METAL2_PREPORT_AUDIT.md`. The decision is recorded here; the port inherits it.
+
+```markdown
+## TTNN ProgramFactory
+
+### Concept
+MetalV2FactoryConcept — or — BLOCKED (op-owned GlobalSemaphores / genuine multi-program; see below)
+
+### Fit
+- Single vs multi-program: [single — one ProgramSpec stamped across the mesh / multi — BLOCKED]
+- Op-owned device resources: [none / op-owned tensors (supported) / op-owned GlobalSemaphores — BLOCKED, list them]
+- Tensor-arg matching: strict [default; deviation requires a paragraph and is not a port-time call]
+- Legacy-to-Metal-2.0 shape: [1:1 with legacy — or — legacy MeshWorkload was a resource workaround, see heads-up]
+
+### Custom compute_program_hash
+[present at file:line → port deletes it / none — already default reflection-based hash]
+
+### Stop signals
+[If BLOCKED: which framework capability is missing (op-owned GlobalSemaphores / genuine multi-program), and confirm the overall audit result is RED. Otherwise: "None."]
+```
+
+## Port plan deliverable (porter-facing)
+
+The porter inherits the audit's decision; the port plan's TTNN section is a brief carry-forward, not a re-derivation:
+
+```markdown
+## TTNN ProgramFactory
+- Concept (inherited from audit): MetalV2FactoryConcept
+- Custom compute_program_hash: [delete (was at file:line) / none]
+- Implementation notes: [optional — anything specific about how this op realizes the concept; most ports won't need this]
+```
+
+If you find yourself disagreeing with the audit's decision, **stop and surface it** — don't unilaterally override. An in-port revision is a signal the audit was incomplete, and the invoker needs to know.
+
+## Port report deliverable (porter-facing)
+
+The porter adds the following to `METAL2_PORT_REPORT.md` at the end of the port. The audit decided; the report confirms what was realized and surfaces friction.
+
+```markdown
+## TTNN ProgramFactory
+
+### Concept realized
+[Confirm MetalV2FactoryConcept, or — if something changed — explain why and confirm it was surfaced with the invoker before re-deciding.]
+
+### Device-op-class edits
+- Custom compute_program_hash deleted: [file:line, or "none"]
+- Pybind entry points removed: [file + function, or "none"]
+
+### Open items
+[Anything noticed about the factory layer during the port:
+- Relaxation candidates (kernels that would tolerate relaxed tensor matching — not applied during port).
+- Reasons the op would benefit from a capability not yet on this concept (op-owned GlobalSemaphores, multi-program, caching-strategy control).
+- Friction with the concept fit or the entry-point wiring.]
+```
+
+If the port stayed on the default concept with no device-op edits, these sections are short — that's the success case.
+
+---
+
+## Cross-references
+
+- [Audit doc](port_op_to_metal2_audit.md) — the feasibility audit that invokes this document as its final step.
+- [Port recipe](port_op_to_metal2_recipe.md) — builds the `ProgramSpec` + `ProgramRunArgs` this document's factory entry point returns.
+- [Migration guide — Design Principles](metal2_migration_guide.md#design-principles) — the named-binding model the spec is built on.
+- [`ttnn/api/ttnn/operation_concepts.hpp`](https://github.com/tenstorrent/tt-metal/blob/main/ttnn/api/ttnn/operation_concepts.hpp) — `MetalV2FactoryConcept` definition in code.
+- [`ttnn/api/ttnn/metal_v2_artifacts.hpp`](https://github.com/tenstorrent/tt-metal/blob/main/ttnn/api/ttnn/metal_v2_artifacts.hpp) — `ProgramArtifacts` field layout.

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/user_orientation.md
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/user_orientation.md
@@ -1,0 +1,36 @@
+# Orientation
+
+> This is a human-facing document. Please read this before attempting any Metal 2.0 ports!
+
+
+A Metal 2.0 port is done in two steps:
+ 1. Audit (evaluable the op's readiness for porting)
+ 2. Actually port the op
+
+The porting recipes are available on the branch `akertesz/metal2-documentation`. The recipes are designed to be AI-facing, not human-friendly.
+
+Please familiarize yourself with Metal 2.0 by reading the introducion to `metal2_migration_guide.md`, and by browsing the (self-documenting) header files in `/tt_metal/api/tt-metalium/experimental/metal2-host-apis/`.
+
+
+## Audit step
+The audit step can be done by either Claude Sonnet (max effort) or Opus. The audit produces two outputs:
+ - **METAL2_PORT_AUDIT.md** provides the result of the audit.
+ - **METAL2_PORT_BRIEF.md** provides information required by the subsequent porting step. It's only produced if the audit was successful.
+
+
+## Porting step
+The porting step requires a capable AI model with **full context availability**. To ensure a good result, it is *essential* that you do the following:
+ - Use **Claude Opus 1M** (with extra-high or max effort)
+ - Launch the port as your **primary session**. You cannot use a subagent for the main port, because subagents cannot delegate builds to subagents.
+ - Launch the port in a **fresh instance**. Do not reuse the same session that you used for the audit, or that you used for a previous port. You need to have the full context window available to ensure peek AI performance.
+ - Ask the AI agent to **launch all builds and tests using subagents**. The build and test output are very context intensive.
+ - If the AI agent reports that it can only port a subset of ProgramFactories for the op within its context budget, respect this and launch the remaining ones from another fresh instance.
+
+Experiments have demonstrated that porting quality falls off significantly if you don't follow these guidelines. Please be very conscious of context window size for Metal 2.0 ports.
+
+
+# Prompts
+
+Please use the prompts below to launch the recipes.
+
+## TODO


### PR DESCRIPTION
Split out from #46909 (umbrella tracking thread) to keep each op migration reviewable on its own. Part of the Metal 2.0 op-migration batch.

Adds the 8 Metal 2.0 migration-guide / porting-recipe docs under `docs/.../metal_2.0/` (from #43321).

**Draft** — see #46909 for the full tracking table and Quasar (craq-sim / emulator) validation status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vsureshTT/metal2-docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vsureshTT/metal2-docs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vsureshTT/metal2-docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vsureshTT/metal2-docs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vsureshTT/metal2-docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vsureshTT/metal2-docs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vsureshTT/metal2-docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vsureshTT/metal2-docs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vsureshTT/metal2-docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vsureshTT/metal2-docs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vsureshTT/metal2-docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vsureshTT/metal2-docs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vsureshTT/metal2-docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vsureshTT/metal2-docs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vsureshTT/metal2-docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vsureshTT/metal2-docs)