### PR TITLE
[Metal 2.0] Port nlp_concat_heads to create_program_artifacts

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads.cpp
@@ -8,29 +8,27 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/core_local_mem.h"
-#include "api/tensor/noc_traits.h"
+#include "api/tensor/tensor_accessor.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
     Noc noc;
 
-    // WRITER RUNTIME ARGS
-    uint32_t in0_tensor_addr = get_arg_val<uint32_t>(0);
-    uint32_t num_blocks = get_arg_val<uint32_t>(1);
-    uint32_t in0_h_dim = get_arg_val<uint32_t>(2);
-    uint32_t in0_tensor_tile_id = get_arg_val<uint32_t>(3);
+    // RUNTIME ARGS
+    uint32_t num_blocks = get_arg(args::num_blocks);
+    uint32_t in0_h_dim = get_arg(args::in0_h_dim);
+    uint32_t in0_tensor_tile_id = get_arg(args::in0_tensor_tile_id);
 
     // COMPILE TIME ARGS
-    constexpr uint32_t in0_h_tiles = get_compile_time_arg_val(0);
-    constexpr uint32_t in0_w_tiles = get_compile_time_arg_val(1);
-    constexpr uint32_t in0_c = get_compile_time_arg_val(2);
-    constexpr uint32_t in0_HtWt = get_compile_time_arg_val(3);
-    constexpr auto in0_args = TensorAccessorArgs<4>();
+    constexpr uint32_t in0_h_tiles = get_arg(args::in0_h_tiles);
+    constexpr uint32_t in0_w_tiles = get_arg(args::in0_w_tiles);
+    constexpr uint32_t in0_c = get_arg(args::in0_c);
+    constexpr uint32_t in0_HtWt = get_arg(args::in0_HtWt);
 
-    constexpr uint32_t cb_id_in0 = 0;
-    const uint32_t single_tile_size_bytes = get_tile_size(cb_id_in0);
-    const auto s0 = TensorAccessor(in0_args, in0_tensor_addr);
+    const auto s0 = TensorAccessor(ta::input);
 
-    CircularBuffer cb_in0(cb_id_in0);
+    DataflowBuffer cb_in0(dfb::in);
+    const uint32_t single_tile_size_bytes = cb_in0.get_tile_size();
 
     constexpr uint32_t block_size = 1;  // micro-block size for read/write; nothing to do with num_blocks
     uint32_t l1_write_addr;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads.cpp
@@ -25,7 +25,7 @@ void kernel_main() {
     constexpr uint32_t in0_c = get_arg(args::in0_c);
     constexpr uint32_t in0_HtWt = get_arg(args::in0_HtWt);
 
-    const auto s0 = TensorAccessor(ta::input);
+    const auto s0 = TensorAccessor(tensor::input);
 
     DataflowBuffer cb_in0(dfb::in);
     const uint32_t single_tile_size_bytes = cb_in0.get_entry_size();

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads.cpp
@@ -28,7 +28,7 @@ void kernel_main() {
     const auto s0 = TensorAccessor(ta::input);
 
     DataflowBuffer cb_in0(dfb::in);
-    const uint32_t single_tile_size_bytes = cb_in0.get_tile_size();
+    const uint32_t single_tile_size_bytes = cb_in0.get_entry_size();
 
     constexpr uint32_t block_size = 1;  // micro-block size for read/write; nothing to do with num_blocks
     uint32_t l1_write_addr;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_sharded.cpp
@@ -8,29 +8,25 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
     Noc noc;
 
-    // WRITER RUNTIME ARGS
-    uint32_t nheads = get_arg_val<uint32_t>(0);                    // This is per core per risc
-    uint32_t start_read_offset_bytes = get_arg_val<uint32_t>(1);   // offset by nheads * in0_HtWt
-    uint32_t start_write_offset_bytes = get_arg_val<uint32_t>(2);  // offset by nheads * in0_Wt
+    // RUNTIME ARGS
+    uint32_t nheads = get_arg(args::nheads);                                      // This is per core per risc
+    uint32_t start_read_offset_bytes = get_arg(args::start_read_offset_bytes);    // offset by nheads * in0_HtWt
+    uint32_t start_write_offset_bytes = get_arg(args::start_write_offset_bytes);  // offset by nheads * in0_Wt
 
     // COMPILE TIME ARGS
-    // interleaved accessor args
-    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
-    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(1);
-    constexpr uint32_t in0_h_tiles = get_compile_time_arg_val(2);
-    constexpr uint32_t head_dim_size_bytes = get_compile_time_arg_val(3);
+    constexpr uint32_t in0_h_tiles = get_arg(args::in0_h_tiles);
+    constexpr uint32_t head_dim_size_bytes = get_arg(args::head_dim_size_bytes);
     constexpr uint32_t out_row_size_bytes =
-        get_compile_time_arg_val(4);  // total nheads per core * in0_w_tiles * single_tile_size_bytes
-    constexpr uint32_t block_size = get_compile_time_arg_val(5);  // total nheads per core * in0_HtWt
+        get_arg(args::out_row_size_bytes);  // total nheads per core * in0_w_tiles * single_tile_size_bytes
+    constexpr uint32_t block_size = get_arg(args::block_size);  // total nheads per core * in0_HtWt
 
-    const uint32_t single_tile_size_bytes = get_tile_size(cb_id_in0);
-
-    CircularBuffer cb_in0(cb_id_in0);
-    CircularBuffer cb_out0(cb_id_out0);
+    DataflowBuffer cb_in0(dfb::in);
+    DataflowBuffer cb_out0(dfb::out);
 
     cb_in0.reserve_back(block_size);  // Redundant
     cb_out0.reserve_back(block_size);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/kernels/dataflow/writer_unary_interleaved_start_id_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/kernels/dataflow/writer_unary_interleaved_start_id_metal2.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of eltwise/unary/.../writer_unary_interleaved_start_id.cpp, specialized for
+// nlp_concat_heads' interleaved path (forward, non-sharded output). The legacy shared writer
+// reads a positional CTA + TensorAccessorArgs + a buffer-address RTA, which a Metal 2.0 factory
+// cannot emit; this fork uses named bindings (dfb::in / ta::output) instead. The legacy copy
+// stays in place for its ~31 co-borrowers. See METAL2_PORT_REPORT.md (cross-op kernel fork).
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/tensor_accessor.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    const uint32_t num_pages = get_arg(args::num_pages);
+    const uint32_t start_id = get_arg(args::start_id);
+
+    // Page size from the CB interface (works for both TILE and ROW_MAJOR layouts).
+    const uint32_t page_bytes = get_local_cb_interface(dfb::in).fifo_page_size;
+
+    Noc noc;
+    DataflowBuffer cb(dfb::in);
+
+    constexpr uint32_t onepage = 1;
+    const auto s = TensorAccessor(ta::output);
+
+    uint32_t end_id = start_id + num_pages;
+    for (uint32_t i = start_id; i < end_id; ++i) {
+        cb.wait_front(onepage);
+        noc.async_write(cb, s, page_bytes, {}, {.page_id = i});
+        noc.async_writes_flushed();
+        cb.pop_front(onepage);
+    }
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/kernels/dataflow/writer_unary_interleaved_start_id_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/kernels/dataflow/writer_unary_interleaved_start_id_metal2.cpp
@@ -18,11 +18,13 @@ void kernel_main() {
     const uint32_t num_pages = get_arg(args::num_pages);
     const uint32_t start_id = get_arg(args::start_id);
 
-    // Page size from the CB interface (works for both TILE and ROW_MAJOR layouts).
-    const uint32_t page_bytes = get_local_cb_interface(dfb::in).fifo_page_size;
-
     Noc noc;
     DataflowBuffer cb(dfb::in);
+
+    // Page size from the DFB (arch-portable; works for TILE and ROW_MAJOR). NOTE: do not use
+    // get_local_cb_interface(dfb::in).fifo_page_size here — that Gen1 CB-interface field reads 0
+    // on Gen2/Quasar, which makes the async_write below a 0-byte transaction (sim rejects it).
+    const uint32_t page_bytes = cb.get_entry_size();
 
     constexpr uint32_t onepage = 1;
     const auto s = TensorAccessor(ta::output);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/kernels/dataflow/writer_unary_interleaved_start_id_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/kernels/dataflow/writer_unary_interleaved_start_id_metal2.cpp
@@ -5,7 +5,7 @@
 // Metal 2.0 fork of eltwise/unary/.../writer_unary_interleaved_start_id.cpp, specialized for
 // nlp_concat_heads' interleaved path (forward, non-sharded output). The legacy shared writer
 // reads a positional CTA + TensorAccessorArgs + a buffer-address RTA, which a Metal 2.0 factory
-// cannot emit; this fork uses named bindings (dfb::in / ta::output) instead. The legacy copy
+// cannot emit; this fork uses named bindings (dfb::in / tensor::output) instead. The legacy copy
 // stays in place for its ~31 co-borrowers. See METAL2_PORT_REPORT.md (cross-op kernel fork).
 
 #include "api/dataflow/dataflow_api.h"
@@ -27,7 +27,7 @@ void kernel_main() {
     const uint32_t page_bytes = cb.get_entry_size();
 
     constexpr uint32_t onepage = 1;
-    const auto s = TensorAccessor(ta::output);
+    const auto s = TensorAccessor(tensor::output);
 
     uint32_t end_id = start_id + num_pages;
     for (uint32_t i = start_id; i < end_id; ++i) {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_program_factory.cpp
@@ -4,49 +4,62 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 #include "nlp_concat_heads_program_factory.hpp"
 #include "nlp_concat_heads_device_operation.hpp"
 #include <tt-metalium/work_split.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+
+#include <string>
+#include <vector>
 
 namespace ttnn::experimental::prim {
 
 using namespace tt::constants;
 using namespace tt;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
-ProgramDescriptor NLPConcatHeadsProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts NLPConcatHeadsProgramFactory::create_program_artifacts(
     const NlpConcatHeadsParams& /*operation_attributes*/, const Tensor& input, Tensor& output) {
+    // Metal 2.0 named resource handles (locals, for unity-build hygiene).
+    const DFBSpecName IN_DFB{"in"};
+    const DFBSpecName OUT_DFB{"out"};
+    const TensorParamName INPUT{"input"};
+    const TensorParamName OUTPUT{"output"};
+    const KernelSpecName READER_KERNEL{"reader"};
+    const KernelSpecName WRITER_KERNEL{"writer"};
+
+    constexpr const char* SHARDED_KERNEL =
+        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/kernels/dataflow/"
+        "reader_tm_tile_layout_nlp_concat_heads_sharded.cpp";
+    constexpr const char* INTERLEAVED_READER =
+        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/kernels/dataflow/"
+        "reader_tm_tile_layout_nlp_concat_heads.cpp";
+    constexpr const char* INTERLEAVED_WRITER =
+        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/kernels/dataflow/"
+        "writer_unary_interleaved_start_id_metal2.cpp";
+
     const auto& a = input;
     const auto& ashape = a.padded_shape();
 
-    tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());
+    const tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());
+    const uint32_t single_tile_size = tt::tile_size(cb_data_format);
+    const bool in_sharded = a.is_sharded();
 
-    uint32_t single_tile_size = tt::tile_size(cb_data_format);
-    tt_metal::Buffer* in0_buffer = a.buffer();
-    bool in_sharded = a.is_sharded();
-    bool out_sharded = output.is_sharded();
+    const CoreCoord compute_with_storage_grid_size = a.device()->compute_with_storage_grid_size();
 
-    CoreCoord compute_with_storage_grid_size = a.device()->compute_with_storage_grid_size();
+    uint32_t per_tensor_tiles = ashape[1] * ashape[3] / TILE_WIDTH;
+    const uint32_t in0_h_tiles = ashape[2] / TILE_HEIGHT;
+    const uint32_t in0_w_tiles = ashape[3] / TILE_WIDTH;    // head_dim
+    const uint32_t in0_c = per_tensor_tiles / in0_w_tiles;  // num_heads
+    const uint32_t in0_HtWt = in0_h_tiles * in0_w_tiles;
+    const uint32_t in0_CHtWt = in0_c * in0_HtWt;
 
-    ////////////////////////////////////////////////////////////////////////////
-    //                      TM Parameters Setup
-    ////////////////////////////////////////////////////////////////////////////
-    uint32_t per_tensor_tiles = ashape[1] * ashape[3] / TILE_WIDTH;  // 142
-
-    // Per output tensor args
-    // Output shape is: [B, 1, s, 4544]
-    uint32_t in0_h_tiles = ashape[2] / TILE_HEIGHT;
-    uint32_t in0_w_tiles = ashape[3] / TILE_WIDTH;    // head_dim
-    uint32_t in0_c = per_tensor_tiles / in0_w_tiles;  // num_heads
-    uint32_t in0_HtWt = in0_h_tiles * in0_w_tiles;
-    uint32_t in0_CHtWt = in0_c * in0_HtWt;
-
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    // Block is a unit of work; ie. num of per_tensor_tiles per core
-    uint32_t num_blocks = ashape[0] * ashape[2] / TILE_HEIGHT;
+    const uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    const uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    const uint32_t num_blocks = ashape[0] * ashape[2] / TILE_HEIGHT;
     uint32_t num_cores = 0, num_blocks_per_core_group_1 = 0, num_blocks_per_core_group_2 = 0;
     CoreRangeSet all_cores = CoreRangeSet(), core_group_1 = CoreRangeSet(), core_group_2 = CoreRangeSet();
     bool row_major = false;
@@ -67,158 +80,153 @@ ProgramDescriptor NLPConcatHeadsProgramFactory::create_descriptor(
             num_blocks_per_core_group_2) =
             tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_blocks);
     }
-    uint32_t g1_numcores = core_group_1.num_cores();
+    const uint32_t g1_numcores = core_group_1.num_cores();
 
-    ////////////////////////////////////////////////////////////////////////////
-    //                      Grayskull Device Setup
-    ////////////////////////////////////////////////////////////////////////////
-    tt_metal::Buffer* out_buffer = output.buffer();
-    TT_ASSERT(out_buffer != nullptr, "Output buffer should be allocated on device!");
+    TensorParameter input_param{.unique_id = INPUT, .spec = input.tensor_spec()};
+    TensorParameter output_param{.unique_id = OUTPUT, .spec = output.tensor_spec()};
 
-    ////////////////////////////////////////////////////////////////////////////
-    //                      Application Setup
-    ////////////////////////////////////////////////////////////////////////////
-    ProgramDescriptor desc;
-    uint32_t src0_cb_index = 0, out_cb_index = 16;
+    ProgramSpec spec;
+    spec.name = "nlp_concat_heads";
+    spec.tensor_parameters = {input_param, output_param};
 
-    KernelDescriptor reader_desc;
-    KernelDescriptor writer_desc;
+    ProgramRunArgs run_args;
+    KernelRunArgs reader_run{.kernel = READER_KERNEL};
+    KernelRunArgs writer_run{.kernel = WRITER_KERNEL};
+
     if (in_sharded) {
-        std::vector<uint32_t> compile_time_args = {
-            (std::uint32_t)src0_cb_index,
-            (std::uint32_t)out_cb_index,
-            (std::uint32_t)in0_h_tiles,
-            (std::uint32_t)in0_w_tiles * single_tile_size,
-            (std::uint32_t)num_blocks_per_core_group_1 * in0_w_tiles * single_tile_size,
-            (std::uint32_t)num_blocks_per_core_group_1 * in0_HtWt,
+        // Sharded: input (c_0) and output (c_16) are borrowed-memory CBs used purely as
+        // local address source/sink (the kernel does a self-NoC head-rearrange). Both are
+        // fake CBs -> bound reader=PRODUCER / writer=CONSUMER to satisfy the validator (the
+        // two kernels, splitting nheads across the two RISCs, run on the same nodes).
+        DataflowBufferSpec in_dfb{
+            .unique_id = IN_DFB,
+            .entry_size = single_tile_size,
+            .num_entries = per_tensor_tiles,
+            .data_format_metadata = cb_data_format,
+            .borrowed_from = INPUT,
         };
-        reader_desc.kernel_source =
-            "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/kernels/dataflow/"
-            "reader_tm_tile_layout_nlp_concat_heads_sharded.cpp";
-        reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        reader_desc.core_ranges = all_cores;
-        reader_desc.compile_time_args = compile_time_args;
-        reader_desc.config = ReaderConfigDescriptor{};
-
-        writer_desc.kernel_source =
-            "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/kernels/dataflow/"
-            "reader_tm_tile_layout_nlp_concat_heads_sharded.cpp";
-        writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        writer_desc.core_ranges = all_cores;
-        writer_desc.compile_time_args = std::move(compile_time_args);
-        writer_desc.config = WriterConfigDescriptor{};
-    } else {
-        std::vector<uint32_t> reader_compile_time_args = {
-            (std::uint32_t)in0_h_tiles,
-            (std::uint32_t)in0_w_tiles,
-            (std::uint32_t)in0_c,
-            (std::uint32_t)in0_HtWt,
+        DataflowBufferSpec out_dfb{
+            .unique_id = OUT_DFB,
+            .entry_size = single_tile_size,
+            .num_entries = per_tensor_tiles,
+            .data_format_metadata = cb_data_format,
+            .borrowed_from = OUTPUT,
         };
-        tt_metal::TensorAccessorArgs(*in0_buffer).append_to(reader_compile_time_args);
-        std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)src0_cb_index};
-        tt_metal::TensorAccessorArgs(*out_buffer).append_to(writer_compile_time_args);
 
-        reader_desc.kernel_source =
-            "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/kernels/dataflow/"
-            "reader_tm_tile_layout_nlp_concat_heads.cpp";
-        reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        reader_desc.core_ranges = all_cores;
-        reader_desc.compile_time_args = std::move(reader_compile_time_args);
-        reader_desc.config = ReaderConfigDescriptor{};
+        const KernelSpec::CompileTimeArgs cta{
+            {"in0_h_tiles", in0_h_tiles},
+            {"head_dim_size_bytes", in0_w_tiles * single_tile_size},
+            {"out_row_size_bytes", num_blocks_per_core_group_1 * in0_w_tiles * single_tile_size},
+            {"block_size", num_blocks_per_core_group_1 * in0_HtWt}};
+        const std::vector<std::string> rta_names{"nheads", "start_read_offset_bytes", "start_write_offset_bytes"};
 
-        writer_desc.kernel_source =
-            "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
-        writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        writer_desc.core_ranges = all_cores;
-        writer_desc.compile_time_args = std::move(writer_compile_time_args);
-        writer_desc.config = WriterConfigDescriptor{};
-    }
+        KernelSpec reader_spec{
+            .unique_id = READER_KERNEL,
+            .source = std::filesystem::path{SHARDED_KERNEL},
+            .dfb_bindings =
+                {DFBBinding{.dfb_spec_name = IN_DFB, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER},
+                 DFBBinding{
+                     .dfb_spec_name = OUT_DFB, .accessor_name = "out", .endpoint_type = DFBEndpointType::PRODUCER}},
+            .compile_time_args = cta,
+            .runtime_arg_schema = {.runtime_arg_names = rta_names},
+            .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        };
+        KernelSpec writer_spec{
+            .unique_id = WRITER_KERNEL,
+            .source = std::filesystem::path{SHARDED_KERNEL},
+            .dfb_bindings =
+                {DFBBinding{.dfb_spec_name = IN_DFB, .accessor_name = "in", .endpoint_type = DFBEndpointType::CONSUMER},
+                 DFBBinding{
+                     .dfb_spec_name = OUT_DFB, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
+            .compile_time_args = cta,
+            .runtime_arg_schema = {.runtime_arg_names = rta_names},
+            .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        };
 
-    // Create circular buffers
-    uint32_t cb_src0_num_tiles = per_tensor_tiles;
-    if (!in_sharded) {
-        cb_src0_num_tiles *= 2;  // double buffer
-    }
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = cb_src0_num_tiles * single_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src0_cb_index),
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
-        }}},
-        .buffer = in_sharded ? in0_buffer : nullptr,
-    });
-
-    if (out_sharded) {
-        uint32_t cb_out_num_tiles = per_tensor_tiles;
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = cb_out_num_tiles * single_tile_size,
-            .core_ranges = all_cores,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(out_cb_index),
-                .data_format = cb_data_format,
-                .page_size = single_tile_size,
-            }}},
-            .buffer = out_buffer,
-        });
-    }
-
-    const auto cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, row_major);
-    if (in_sharded) {
-        uint32_t nheads_first_risc = div_up(num_blocks_per_core_group_1, 2);
-        uint32_t nheads_second_risc = num_blocks_per_core_group_1 - nheads_first_risc;
-        // Mirror SetRuntimeArgs(program, kernel, all_cores, args) by emplacing the same
-        // per-core args on every logical core in the sharded range set.
-        for (const auto& core : corerange_to_cores(all_cores, num_cores, /*row_wise=*/true)) {
-            reader_desc.emplace_runtime_args(
-                core,
-                {
-                    (std::uint32_t)nheads_first_risc,
-                    uint32_t{0},
-                    uint32_t{0},
-                });
-            writer_desc.emplace_runtime_args(
-                core,
-                {
-                    (std::uint32_t)nheads_second_risc,
-                    (std::uint32_t)nheads_first_risc * in0_HtWt * single_tile_size,
-                    (std::uint32_t)nheads_first_risc * in0_w_tiles * single_tile_size,
-                });
+        const uint32_t nheads_first_risc = div_up(num_blocks_per_core_group_1, 2);
+        const uint32_t nheads_second_risc = num_blocks_per_core_group_1 - nheads_first_risc;
+        for (const NodeCoord& core : corerange_to_cores(all_cores, num_cores, /*row_wise=*/true)) {
+            reader_run.runtime_arg_values.push_back(
+                {core,
+                 {{"nheads", nheads_first_risc}, {"start_read_offset_bytes", 0u}, {"start_write_offset_bytes", 0u}}});
+            writer_run.runtime_arg_values.push_back(
+                {core,
+                 {{"nheads", nheads_second_risc},
+                  {"start_read_offset_bytes", nheads_first_risc * in0_HtWt * single_tile_size},
+                  {"start_write_offset_bytes", nheads_first_risc * in0_w_tiles * single_tile_size}}});
         }
 
+        spec.kernels = {reader_spec, writer_spec};
+        spec.dataflow_buffers = {in_dfb, out_dfb};
+        spec.work_units = {WorkUnitSpec{
+            .name = "nlp_concat_heads_sharded", .kernels = {READER_KERNEL, WRITER_KERNEL}, .target_nodes = all_cores}};
     } else {
+        // Interleaved: input read page-by-page via TensorAccessor into the src CB (c_0); the
+        // forked writer consumes the src CB and writes pages to the output tensor. No borrowed CB.
+        DataflowBufferSpec in_dfb{
+            .unique_id = IN_DFB,
+            .entry_size = single_tile_size,
+            .num_entries = per_tensor_tiles * 2,  // double buffer
+            .data_format_metadata = cb_data_format,
+        };
+
+        KernelSpec reader_spec{
+            .unique_id = READER_KERNEL,
+            .source = std::filesystem::path{INTERLEAVED_READER},
+            .dfb_bindings = {DFBBinding{
+                .dfb_spec_name = IN_DFB, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER}},
+            .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "input"}},
+            .compile_time_args =
+                {{"in0_h_tiles", in0_h_tiles}, {"in0_w_tiles", in0_w_tiles}, {"in0_c", in0_c}, {"in0_HtWt", in0_HtWt}},
+            .runtime_arg_schema = {.runtime_arg_names = {"num_blocks", "in0_h_dim", "in0_tensor_tile_id"}},
+            .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        };
+        KernelSpec writer_spec{
+            .unique_id = WRITER_KERNEL,
+            .source = std::filesystem::path{INTERLEAVED_WRITER},
+            .dfb_bindings = {DFBBinding{
+                .dfb_spec_name = IN_DFB, .accessor_name = "in", .endpoint_type = DFBEndpointType::CONSUMER}},
+            .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "output"}},
+            .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
+            .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        };
+
+        const auto cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, row_major);
         for (uint32_t i = 0, num_blocks_written = 0; i < cores.size(); ++i) {
-            const CoreCoord& core = cores[i];
-            uint32_t num_blocks_per_core = i < g1_numcores ? num_blocks_per_core_group_1 : num_blocks_per_core_group_2;
+            const NodeCoord& core = cores[i];
+            const uint32_t num_blocks_per_core =
+                i < g1_numcores ? num_blocks_per_core_group_1 : num_blocks_per_core_group_2;
 
-            uint32_t in0_h_dim = num_blocks_written % in0_h_tiles;
-            uint32_t in0_tensor_tile_id = (num_blocks_written / in0_h_tiles * in0_CHtWt) + (in0_h_dim * in0_w_tiles);
+            const uint32_t in0_h_dim = num_blocks_written % in0_h_tiles;
+            const uint32_t in0_tensor_tile_id =
+                (num_blocks_written / in0_h_tiles * in0_CHtWt) + (in0_h_dim * in0_w_tiles);
 
-            reader_desc.emplace_runtime_args(
-                core,
-                {
-                    in0_buffer,
-                    num_blocks_per_core,  // num_blocks
-                    in0_h_dim,            // in0_h_dim
-                    in0_tensor_tile_id,   // in0_tensor_tile_id
-                });
-
-            writer_desc.emplace_runtime_args(
-                core,
-                {
-                    out_buffer,  // out_tensor_addr
-                    num_blocks_per_core * per_tensor_tiles,
-                    num_blocks_written * per_tensor_tiles,
-                });
+            reader_run.runtime_arg_values.push_back(
+                {core,
+                 {{"num_blocks", num_blocks_per_core},
+                  {"in0_h_dim", in0_h_dim},
+                  {"in0_tensor_tile_id", in0_tensor_tile_id}}});
+            writer_run.runtime_arg_values.push_back(
+                {core,
+                 {{"num_pages", num_blocks_per_core * per_tensor_tiles},
+                  {"start_id", num_blocks_written * per_tensor_tiles}}});
             num_blocks_written += num_blocks_per_core;
         }
+
+        spec.kernels = {reader_spec, writer_spec};
+        spec.dataflow_buffers = {in_dfb};
+        spec.work_units = {WorkUnitSpec{
+            .name = "nlp_concat_heads_interleaved",
+            .kernels = {READER_KERNEL, WRITER_KERNEL},
+            .target_nodes = all_cores}};
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    run_args.kernel_run_args = {reader_run, writer_run};
+    run_args.tensor_args = {
+        {INPUT, TensorArgument{std::cref(input.mesh_tensor())}},
+        {OUTPUT, TensorArgument{std::cref(output.mesh_tensor())}}};
 
-    return desc;
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_program_factory.hpp
@@ -4,15 +4,14 @@
 
 #pragma once
 
-#include <tt-metalium/program_descriptors.hpp>
-
 #include "nlp_concat_heads_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal_v2_artifacts.hpp"
 
 namespace ttnn::experimental::prim {
 
 struct NLPConcatHeadsProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const NlpConcatHeadsParams& operation_attributes, const Tensor& input, Tensor& output);
 };
 


### PR DESCRIPTION
Split out from #46909 (umbrella tracking thread) to keep each op migration reviewable on its own. Part of the Metal 2.0 op-migration batch.

Ports nlp_concat_heads (interleaved + sharded) to `MetalV2FactoryConcept`. Includes Quasar `get_entry_size` portability + writer page-size fix. ✅ BH 217 passed; ✅ craq-sim + emu PCC 1.0.

**Draft** — see #46909 for the full tracking table and Quasar (craq-sim / emulator) validation status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vsureshTT/metal2-nlp-concat-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vsureshTT/metal2-nlp-concat-heads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vsureshTT/metal2-nlp-concat-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vsureshTT/metal2-nlp-concat-heads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vsureshTT/metal2-nlp-concat-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vsureshTT/metal2-nlp-concat-heads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vsureshTT/metal2-nlp-concat-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vsureshTT/metal2-nlp-concat-heads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vsureshTT/metal2-nlp-concat-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vsureshTT/metal2-nlp-concat-heads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vsureshTT/metal2-nlp-concat-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vsureshTT/metal2-nlp-concat-heads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vsureshTT/metal2-nlp-concat-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vsureshTT/metal2-nlp-concat-heads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vsureshTT/metal2-nlp-concat-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vsureshTT/metal2-nlp-concat-heads)