### PR TITLE
[Metal 2.0] Port nlp_concat_heads_decode to create_program_artifacts

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_decode.cpp
@@ -8,30 +8,34 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
+#include "api/tensor/tensor_accessor.h"
+#include "experimental/kernel_args.h"
 
 // #include "api/debug/dprint.h"  // required in all kernels using DPRINT
 
 void kernel_main() {
     Noc noc;
 
-    uint32_t in_tile_offset_by_head = get_arg_val<uint32_t>(0);
-    uint32_t q_start_addr = get_arg_val<uint32_t>(1);
+    const uint32_t in_tile_offset_by_head = get_arg(args::in_tile_offset_by_head);
 
-    constexpr uint32_t ELEMENT_SIZE = get_compile_time_arg_val(0);
-    constexpr uint32_t SUBTILE_LINE_BYTES = get_compile_time_arg_val(1);
-    constexpr uint32_t cb_id_q_out = get_compile_time_arg_val(2);
-    constexpr uint32_t head_size = get_compile_time_arg_val(3);
-    constexpr uint32_t batch = get_compile_time_arg_val(4);
-    constexpr uint32_t head_size_num_tiles = get_compile_time_arg_val(5);
+    constexpr uint32_t ELEMENT_SIZE = get_arg(args::element_size);
+    constexpr uint32_t SUBTILE_LINE_BYTES = get_arg(args::sub_tile_line_bytes);
+    constexpr uint32_t head_size = get_arg(args::head_size);
+    constexpr uint32_t batch = get_arg(args::batch);
+    constexpr uint32_t head_size_num_tiles = get_arg(args::head_size_num_tiles);
     constexpr uint32_t PHASES_TO_READ =
-        get_compile_time_arg_val(6);  // 0 to read all phases, 1 to read only first phase, 2 to read only second phase
+        get_arg(args::phases_to_read);  // 0 to read all phases, 1 to read only first phase, 2 to read only second phase
 
-    constexpr uint32_t num_x = get_compile_time_arg_val(7);
-    constexpr uint32_t num_y = get_compile_time_arg_val(8);
-    tt_l1_ptr uint32_t* in0_mcast_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(2));
-    tt_l1_ptr uint32_t* in0_mcast_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(2 + num_x));
+    constexpr uint32_t num_x = get_arg(args::num_x);
+    constexpr uint32_t num_y = get_arg(args::num_y);
+    // NoC coordinates of the input shard cores arrive as common runtime varargs, laid out
+    // [x0..x_{num_x-1}, y0..y_{num_y-1}]: get_common_vararg(x) for x-coords, get_common_vararg(num_x + y) for y-coords.
 
-    CircularBuffer cb_q_out(cb_id_q_out);
+    // Input shard base address, recovered from the typed tensor binding (Case 2 bridge).
+    const auto input = TensorAccessor(ta::input);
+    const uint32_t q_start_addr = input.get_bank_base_address();
+
+    DataflowBuffer cb_q_out(dfb::q_out);
     UnicastEndpoint src_ep;
 
     // Q
@@ -40,8 +44,8 @@ void kernel_main() {
     uint32_t total_input_cores = num_x * num_y;
     uint32_t num_tiles_per_core = (head_size_num_tiles * batch) / total_input_cores;
 
-    uint32_t qkv_noc_x = in0_mcast_noc_x[qkv_x];
-    uint32_t qkv_noc_y = in0_mcast_noc_y[qkv_y];
+    uint32_t qkv_noc_x = get_common_vararg(qkv_x);
+    uint32_t qkv_noc_y = get_common_vararg(num_x + qkv_y);
     uint32_t qkv_read_addr = q_start_addr + in_tile_offset_by_head;
     uint32_t num_tiles_read_cur_core = 0;
     uint32_t q_write_addr = 0;
@@ -84,8 +88,8 @@ void kernel_main() {
                     qkv_x = 0;
                     qkv_y++;
                 }
-                qkv_noc_x = in0_mcast_noc_x[qkv_x];
-                qkv_noc_y = in0_mcast_noc_y[qkv_y];
+                qkv_noc_x = get_common_vararg(qkv_x);
+                qkv_noc_y = get_common_vararg(num_x + qkv_y);
                 qkv_read_addr = q_start_addr + in_tile_offset_by_head;
                 num_tiles_read_cur_core = 0;
             }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_decode.cpp
@@ -32,7 +32,7 @@ void kernel_main() {
     // [x0..x_{num_x-1}, y0..y_{num_y-1}]: get_common_vararg(x) for x-coords, get_common_vararg(num_x + y) for y-coords.
 
     // Input shard base address, recovered from the typed tensor binding (Case 2 bridge).
-    const auto input = TensorAccessor(ta::input);
+    const auto input = TensorAccessor(tensor::input);
     const uint32_t q_start_addr = input.get_bank_base_address();
 
     DataflowBuffer cb_q_out(dfb::q_out);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_decode_subcoregrid.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_decode_subcoregrid.cpp
@@ -8,30 +8,35 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
+#include "api/tensor/tensor_accessor.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
     Noc noc;
 
-    uint32_t in_tile_offset_by_head = get_arg_val<uint32_t>(0);
-    uint32_t q_start_addr = get_arg_val<uint32_t>(1);
+    const uint32_t in_tile_offset_by_head = get_arg(args::in_tile_offset_by_head);
 
-    constexpr uint32_t ELEMENT_SIZE = get_compile_time_arg_val(0);
-    constexpr uint32_t SUBTILE_LINE_BYTES = get_compile_time_arg_val(1);
-    constexpr uint32_t cb_id_q_out = get_compile_time_arg_val(2);
-    constexpr uint32_t head_size = get_compile_time_arg_val(3);
-    constexpr uint32_t batch = get_compile_time_arg_val(4);
-    constexpr uint32_t head_size_num_tiles = get_compile_time_arg_val(5);
+    constexpr uint32_t ELEMENT_SIZE = get_arg(args::element_size);
+    constexpr uint32_t SUBTILE_LINE_BYTES = get_arg(args::sub_tile_line_bytes);
+    constexpr uint32_t head_size = get_arg(args::head_size);
+    constexpr uint32_t batch = get_arg(args::batch);
+    constexpr uint32_t head_size_num_tiles = get_arg(args::head_size_num_tiles);
     constexpr uint32_t PHASES_TO_READ =
-        get_compile_time_arg_val(6);  // 0 to read all phases, 1 to read only first phase, 2 to read only second phase
+        get_arg(args::phases_to_read);  // 0 to read all phases, 1 to read only first phase, 2 to read only second phase
 
-    constexpr uint32_t in_num_cores = get_compile_time_arg_val(7);
-    constexpr uint32_t face_h = get_compile_time_arg_val(8);
-    constexpr uint32_t face_hw = get_compile_time_arg_val(9);
+    constexpr uint32_t in_num_cores = get_arg(args::in_num_cores);
+    constexpr uint32_t face_h = get_arg(args::face_h);
+    constexpr uint32_t face_hw = get_arg(args::face_hw);
 
-    tt_l1_ptr uint32_t* in0_mcast_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(2));
-    tt_l1_ptr uint32_t* in0_mcast_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(2 + in_num_cores));
+    // NoC coordinates of the input shard cores arrive as common runtime varargs, laid out
+    // [x0..x_{n-1}, y0..y_{n-1}] (n = in_num_cores): get_common_vararg(i) for x, get_common_vararg(in_num_cores + i)
+    // for y.
 
-    CircularBuffer cb_q_out(cb_id_q_out);
+    // Input shard base address, recovered from the typed tensor binding (Case 2 bridge).
+    const auto input = TensorAccessor(ta::input);
+    const uint32_t q_start_addr = input.get_bank_base_address();
+
+    DataflowBuffer cb_q_out(dfb::q_out);
     UnicastEndpoint src_ep;
 
     // Q
@@ -39,8 +44,8 @@ void kernel_main() {
     uint32_t total_input_cores = in_num_cores;
     uint32_t num_tiles_per_core = (head_size_num_tiles * batch) / total_input_cores;
 
-    uint32_t qkv_noc_x = in0_mcast_noc_x[cur_core_idx];
-    uint32_t qkv_noc_y = in0_mcast_noc_y[cur_core_idx];
+    uint32_t qkv_noc_x = get_common_vararg(cur_core_idx);
+    uint32_t qkv_noc_y = get_common_vararg(in_num_cores + cur_core_idx);
     uint32_t qkv_read_addr = q_start_addr + in_tile_offset_by_head;
     uint32_t num_tiles_read_cur_core = 0;
     uint32_t q_write_addr = 0;
@@ -76,8 +81,8 @@ void kernel_main() {
 
             if (num_tiles_read_cur_core == num_tiles_per_core) {
                 cur_core_idx++;
-                qkv_noc_x = in0_mcast_noc_x[cur_core_idx];
-                qkv_noc_y = in0_mcast_noc_y[cur_core_idx];
+                qkv_noc_x = get_common_vararg(cur_core_idx);
+                qkv_noc_y = get_common_vararg(in_num_cores + cur_core_idx);
                 qkv_read_addr = q_start_addr + in_tile_offset_by_head;
                 num_tiles_read_cur_core = 0;
             }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_decode_subcoregrid.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_decode_subcoregrid.cpp
@@ -33,7 +33,7 @@ void kernel_main() {
     // for y.
 
     // Input shard base address, recovered from the typed tensor binding (Case 2 bridge).
-    const auto input = TensorAccessor(ta::input);
+    const auto input = TensorAccessor(tensor::input);
     const uint32_t q_start_addr = input.get_bank_base_address();
 
     DataflowBuffer cb_q_out(dfb::q_out);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_program_factory.cpp
@@ -4,22 +4,37 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 #include "nlp_concat_heads_decode_program_factory.hpp"
 #include <tt-metalium/work_split.hpp>
+
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+
+#include <string>
+#include <vector>
 
 namespace ttnn::experimental::prim {
 
 using namespace tt;
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
-ProgramDescriptor NLPConcatHeadsDecodeProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts NLPConcatHeadsDecodeProgramFactory::create_program_artifacts(
     const NlpConcatHeadsDecodeParams& /*operation_attributes*/,
     const NlpConcatHeadsDecodeInputs& tensor_args,
     Tensor& output) {
+    // Metal 2.0 named resource handles for the nlp_concat_heads_decode ProgramSpec.
+    const DFBSpecName OUT_DFB{"q_out"};
+    const TensorParamName INPUT_TENSOR{"input"};
+    const TensorParamName OUTPUT_TENSOR{"output"};
+    const KernelSpecName READER_KERNEL{"reader"};
+    const KernelSpecName WRITER_KERNEL{"writer"};
+    constexpr const char* KERNEL_PATH =
+        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/kernels/dataflow/"
+        "reader_tm_tile_layout_nlp_concat_heads_decode.cpp";
+
     const auto& input_tensor = tensor_args.input;
-    ProgramDescriptor desc;
 
     const auto& input_shape = input_tensor.padded_shape();
     const uint32_t head_dim = input_shape[-1];
@@ -27,89 +42,106 @@ ProgramDescriptor NLPConcatHeadsDecodeProgramFactory::create_descriptor(
 
     tt_metal::IDevice* device = input_tensor.device();
 
-    tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    const tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    const uint32_t single_tile_size = tt::tile_size(cb_data_format);
 
-    uint32_t single_tile_size = tt::tile_size(cb_data_format);
+    const uint32_t head_tiles = head_dim / TILE_WIDTH;
+    const uint32_t head_size = head_tiles * single_tile_size;
 
-    uint32_t head_tiles = head_dim / TILE_WIDTH;
-    uint32_t head_size = head_tiles * single_tile_size;
-
-    uint32_t element_size = input_tensor.element_size();
-    uint32_t sub_tile_line_bytes = 16 * element_size;
-    auto q_shard_spec = output.shard_spec().value();
-    auto q_cores = q_shard_spec.grid;
-    auto q_num_tiles = q_shard_spec.shape[0] * q_shard_spec.shape[1] / TILE_HW;
-    auto in_shard_spec = input_tensor.shard_spec().value();
-    auto in_cores = in_shard_spec.grid;
-
-    uint32_t q_output_cb_index = CBIndex::c_16;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = q_num_tiles * single_tile_size,
-        .core_ranges = q_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(q_output_cb_index),
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
-        }}},
-        .buffer = output.buffer(),
-    });
-
-    Buffer* in_buffer = input_tensor.buffer();
+    const uint32_t element_size = input_tensor.element_size();
+    const uint32_t sub_tile_line_bytes = 16 * element_size;
+    const auto q_shard_spec = output.shard_spec().value();
+    const auto q_cores = q_shard_spec.grid;
+    const auto q_num_tiles = q_shard_spec.shape[0] * q_shard_spec.shape[1] / TILE_HW;
+    const auto in_shard_spec = input_tensor.shard_spec().value();
+    const auto in_cores = in_shard_spec.grid;
 
     // cores to read and write to output
-    uint32_t num_cores = q_cores.num_cores();  // number of cores of the output
-    auto core_grid = q_cores.bounding_box();
-    uint32_t num_cores_x = core_grid.end_coord.x + 1, num_cores_y = core_grid.end_coord.y + 1;
+    const uint32_t num_cores = q_cores.num_cores();  // number of cores of the output
+    const auto core_grid = q_cores.bounding_box();
+    const uint32_t num_cores_x = core_grid.end_coord.x + 1, num_cores_y = core_grid.end_coord.y + 1;
     const auto& cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, true);
 
     // cores for input
-    auto in_core_grid = in_cores.bounding_box();
-    uint32_t in_num_cores_x = in_core_grid.end_coord.x + 1, in_num_cores_y = in_core_grid.end_coord.y + 1;
+    const auto in_core_grid = in_cores.bounding_box();
+    const uint32_t in_num_cores_x = in_core_grid.end_coord.x + 1, in_num_cores_y = in_core_grid.end_coord.y + 1;
 
-    std::vector<uint32_t> noc_x_coords;
-    noc_x_coords.reserve(in_num_cores_x);
+    // NoC coordinates of the input shard cores. Identical for every output core, so they are
+    // passed as Metal 2.0 *common* runtime varargs (broadcast), laid out [x0..x_{nx-1}, y0..y_{ny-1}].
+    std::vector<uint32_t> noc_coords;
+    noc_coords.reserve(in_num_cores_x + in_num_cores_y);
     for (uint32_t x = 0; x < in_num_cores_x; ++x) {
-        noc_x_coords.push_back(device->worker_core_from_logical_core({x, 0}).x);
+        noc_coords.push_back(device->worker_core_from_logical_core({x, 0}).x);
     }
-    std::vector<uint32_t> noc_y_coords;
-    noc_y_coords.reserve(in_num_cores_y);
     for (uint32_t y = 0; y < in_num_cores_y; ++y) {
-        noc_y_coords.push_back(device->worker_core_from_logical_core({0, y}).y);
+        noc_coords.push_back(device->worker_core_from_logical_core({0, y}).y);
     }
 
-    // We parallelize the reader on risc0 and risc1, where each risc reads a sub-tile of the input (phase1 and phase2 of
-    // a tile respectively)
-    std::vector<uint32_t> reader_compile_time_args = {
-        (std::uint32_t)element_size,
-        (std::uint32_t)sub_tile_line_bytes,
-        q_output_cb_index,
-        head_size,
-        batch,
-        head_tiles,
-        1,  // read the first phase
-        in_num_cores_x,
-        in_num_cores_y};
+    // ----------------------------------------------------------------------------
+    // Tensor parameters. INPUT supplies the input shard base address (Case 2 bridge,
+    // recovered kernel-side via get_bank_base_address). OUTPUT backs the borrowed DFB.
+    // ----------------------------------------------------------------------------
+    TensorParameter input_param{.unique_id = INPUT_TENSOR, .spec = input_tensor.tensor_spec()};
+    TensorParameter output_param{.unique_id = OUTPUT_TENSOR, .spec = output.tensor_spec()};
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/kernels/dataflow/"
-        "reader_tm_tile_layout_nlp_concat_heads_decode.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = q_cores;
-    reader_desc.compile_time_args = reader_compile_time_args;
-    reader_desc.config = ReaderConfigDescriptor{};
+    // ----------------------------------------------------------------------------
+    // Output DFB: borrowed memory on output.buffer() (legacy CB c_16). Write-only
+    // address source (fake CB): bound reader=PRODUCER / writer=CONSUMER on the same
+    // nodes to satisfy the validator's producer-and-consumer rule. See PORT_REPORT.
+    // ----------------------------------------------------------------------------
+    DataflowBufferSpec out_dfb_spec{
+        .unique_id = OUT_DFB,
+        .entry_size = single_tile_size,
+        .num_entries = q_num_tiles,
+        .data_format_metadata = cb_data_format,
+        .borrowed_from = OUTPUT_TENSOR,
+    };
 
-    std::vector<uint32_t> writer_compile_time_args = reader_compile_time_args;
-    writer_compile_time_args[6] = 2;  // read the second phase
+    // Named CTAs shared by reader and writer (only PHASES_TO_READ differs).
+    auto make_cta = [&](uint32_t phases_to_read) {
+        return KernelSpec::CompileTimeArgs{
+            {"element_size", element_size},
+            {"sub_tile_line_bytes", sub_tile_line_bytes},
+            {"head_size", head_size},
+            {"batch", batch},
+            {"head_size_num_tiles", head_tiles},
+            {"phases_to_read", phases_to_read},
+            {"num_x", in_num_cores_x},
+            {"num_y", in_num_cores_y}};
+    };
 
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/kernels/dataflow/"
-        "reader_tm_tile_layout_nlp_concat_heads_decode.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = q_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterConfigDescriptor{};
+    KernelSpec reader_spec{
+        .unique_id = READER_KERNEL,
+        .source = std::filesystem::path{KERNEL_PATH},
+        .dfb_bindings = {DFBBinding{
+            .dfb_spec_name = OUT_DFB, .accessor_name = "q_out", .endpoint_type = DFBEndpointType::PRODUCER}},
+        .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT_TENSOR, .accessor_name = "input"}},
+        .compile_time_args = make_cta(1),  // read first phase
+        .runtime_arg_schema = {.runtime_arg_names = {"in_tile_offset_by_head"}},
+        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+    };
+    reader_spec.advanced_options.num_common_runtime_varargs = noc_coords.size();
+
+    KernelSpec writer_spec{
+        .unique_id = WRITER_KERNEL,
+        .source = std::filesystem::path{KERNEL_PATH},
+        .dfb_bindings = {DFBBinding{
+            .dfb_spec_name = OUT_DFB, .accessor_name = "q_out", .endpoint_type = DFBEndpointType::CONSUMER}},
+        .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT_TENSOR, .accessor_name = "input"}},
+        .compile_time_args = make_cta(2),  // read second phase
+        .runtime_arg_schema = {.runtime_arg_names = {"in_tile_offset_by_head"}},
+        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+    };
+    writer_spec.advanced_options.num_common_runtime_varargs = noc_coords.size();
+
+    // ----------------------------------------------------------------------------
+    // Per-node runtime args: in_tile_offset_by_head (per output core), plus the
+    // broadcast NoC-coordinate varargs.
+    // ----------------------------------------------------------------------------
+    KernelRunArgs reader_run{.kernel = READER_KERNEL};
+    KernelRunArgs writer_run{.kernel = WRITER_KERNEL};
+    reader_run.advanced_options.common_runtime_varargs = noc_coords;
+    writer_run.advanced_options.common_runtime_varargs = noc_coords;
 
     for (uint32_t i = 0; i < num_cores; ++i) {
         // Each output core i corresponds to head index i. Within the input shard, that head lives in
@@ -123,22 +155,33 @@ ProgramDescriptor NLPConcatHeadsDecodeProgramFactory::create_descriptor(
                                : (head_in_tile - 16) * sub_tile_line_bytes + 512 * element_size) +
             head_tile_idx * head_size;
 
-        const auto& core = cores[i];
-        KernelDescriptor::RTArgList rt_args;
-        rt_args.reserve(2 + in_num_cores_x + in_num_cores_y);
-        rt_args.push_back(in_tile_offset_by_batch);
-        rt_args.push_back(in_buffer);
-        rt_args.append(noc_x_coords);
-        rt_args.append(noc_y_coords);
-
-        reader_desc.emplace_runtime_args(core, rt_args);
-        writer_desc.emplace_runtime_args(core, rt_args);
+        const NodeCoord core = cores[i];
+        const KernelRunArgs::RuntimeArgValues args{{"in_tile_offset_by_head", in_tile_offset_by_batch}};
+        reader_run.runtime_arg_values.push_back({core, args});
+        writer_run.runtime_arg_values.push_back({core, args});
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    WorkUnitSpec wu{
+        .name = "nlp_concat_heads_decode",
+        .kernels = {READER_KERNEL, WRITER_KERNEL},
+        .target_nodes = q_cores,
+    };
 
-    return desc;
+    ProgramSpec spec{
+        .name = "nlp_concat_heads_decode",
+        .kernels = {reader_spec, writer_spec},
+        .dataflow_buffers = {out_dfb_spec},
+        .tensor_parameters = {input_param, output_param},
+        .work_units = {wu},
+    };
+
+    ProgramRunArgs run_args;
+    run_args.kernel_run_args = {reader_run, writer_run};
+    run_args.tensor_args = {
+        {INPUT_TENSOR, TensorArgument{std::cref(input_tensor.mesh_tensor())}},
+        {OUTPUT_TENSOR, TensorArgument{std::cref(output.mesh_tensor())}}};
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_program_factory.hpp
@@ -4,15 +4,14 @@
 
 #pragma once
 
-#include <tt-metalium/program_descriptors.hpp>
-
 #include "nlp_concat_heads_decode_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal_v2_artifacts.hpp"
 
 namespace ttnn::experimental::prim {
 
 struct NLPConcatHeadsDecodeProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const NlpConcatHeadsDecodeParams& operation_attributes,
         const NlpConcatHeadsDecodeInputs& tensor_args,
         Tensor& output);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_subcoregrids_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_subcoregrids_program_factory.cpp
@@ -4,23 +4,37 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 #include "nlp_concat_heads_decode_subcoregrids_program_factory.hpp"
 #include "nlp_concat_heads_decode_device_operation.hpp"
 #include <tt-metalium/work_split.hpp>
+
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+
+#include <string>
+#include <vector>
 
 namespace ttnn::experimental::prim {
 
 using namespace tt;
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
-ProgramDescriptor NLPConcatHeadsDecodeSubcoregridsProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts NLPConcatHeadsDecodeSubcoregridsProgramFactory::create_program_artifacts(
     const NlpConcatHeadsDecodeParams& /*operation_attributes*/,
     const NlpConcatHeadsDecodeInputs& tensor_args,
     Tensor& output) {
+    const DFBSpecName OUT_DFB{"q_out"};
+    const TensorParamName INPUT_TENSOR{"input"};
+    const TensorParamName OUTPUT_TENSOR{"output"};
+    const KernelSpecName READER_KERNEL{"reader"};
+    const KernelSpecName WRITER_KERNEL{"writer"};
+    constexpr const char* KERNEL_PATH =
+        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/kernels/dataflow/"
+        "reader_tm_tile_layout_nlp_concat_heads_decode_subcoregrid.cpp";
+
     const auto& input_tensor = tensor_args.input;
-    ProgramDescriptor desc;
 
     const auto& input_shape = input_tensor.padded_shape();
     const uint32_t head_dim = input_shape[-1];
@@ -28,18 +42,16 @@ ProgramDescriptor NLPConcatHeadsDecodeSubcoregridsProgramFactory::create_descrip
 
     tt_metal::IDevice* device = input_tensor.device();
 
-    tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
-
+    const tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
     const uint32_t single_tile_size = tt::tile_size(cb_data_format);
-    auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
-    auto tile_h = tile_shape[0];
-    auto tile_w = tile_shape[1];
-    auto tile_hw = tile_h * tile_w;
+    const auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
+    const auto tile_w = tile_shape[1];
+    const auto tile_hw = tile_shape[0] * tile_shape[1];
 
-    auto face_shape = input_tensor.tensor_spec().tile().get_face_shape();
-    auto face_h = face_shape[0];
-    auto face_w = face_shape[1];
-    auto face_hw = face_h * face_w;
+    const auto face_shape = input_tensor.tensor_spec().tile().get_face_shape();
+    const auto face_h = face_shape[0];
+    const auto face_w = face_shape[1];
+    const auto face_hw = face_h * face_w;
 
     const uint32_t head_tiles = head_dim / tile_w;
     const uint32_t head_size = head_tiles * single_tile_size;
@@ -52,20 +64,6 @@ ProgramDescriptor NLPConcatHeadsDecodeSubcoregridsProgramFactory::create_descrip
     const auto in_shard_spec = input_tensor.shard_spec().value();
     const auto in_cores = in_shard_spec.grid;
 
-    uint32_t q_output_cb_index = CBIndex::c_16;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = q_num_tiles * single_tile_size,
-        .core_ranges = q_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(q_output_cb_index),
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
-        }}},
-        .buffer = output.buffer(),
-    });
-
-    Buffer* in_buffer = input_tensor.buffer();
-
     // cores to read and write to output
     const uint32_t num_cores = q_cores.num_cores();  // number of cores of the output
     const auto& cores = corerange_to_cores(q_cores, num_cores, true);
@@ -74,49 +72,69 @@ ProgramDescriptor NLPConcatHeadsDecodeSubcoregridsProgramFactory::create_descrip
     const uint32_t in_num_cores = in_cores.num_cores();  // number of cores of the input
     const auto& in_cores_vec = corerange_to_cores(in_cores, in_num_cores, true);
 
-    std::vector<uint32_t> noc_x_coords;
-    noc_x_coords.reserve(in_num_cores);
-    std::vector<uint32_t> noc_y_coords;
-    noc_y_coords.reserve(in_num_cores);
+    // NoC coordinates of the input shard cores, broadcast as common runtime varargs,
+    // laid out [x0..x_{n-1}, y0..y_{n-1}] (n = in_num_cores).
+    std::vector<uint32_t> noc_coords;
+    noc_coords.reserve(2 * in_num_cores);
     for (uint32_t i = 0; i < in_num_cores; ++i) {
-        noc_x_coords.push_back(device->worker_core_from_logical_core(in_cores_vec[i]).x);
-        noc_y_coords.push_back(device->worker_core_from_logical_core(in_cores_vec[i]).y);
+        noc_coords.push_back(device->worker_core_from_logical_core(in_cores_vec[i]).x);
+    }
+    for (uint32_t i = 0; i < in_num_cores; ++i) {
+        noc_coords.push_back(device->worker_core_from_logical_core(in_cores_vec[i]).y);
     }
 
-    // We parallelize the reader on risc0 and risc1 as two phases, where each risc reads half-tile of the input (Phase 1
-    // reads left half-tile and Phase 2 reads right half-tile respectively)
-    std::vector<uint32_t> reader_compile_time_args = {
-        (std::uint32_t)element_size,
-        (std::uint32_t)sub_tile_line_bytes,
-        q_output_cb_index,
-        head_size,
-        batch,
-        head_tiles,
-        1,  // read the first phase
-        in_num_cores,
-        face_h,
-        face_hw};
+    TensorParameter input_param{.unique_id = INPUT_TENSOR, .spec = input_tensor.tensor_spec()};
+    TensorParameter output_param{.unique_id = OUTPUT_TENSOR, .spec = output.tensor_spec()};
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/kernels/dataflow/"
-        "reader_tm_tile_layout_nlp_concat_heads_decode_subcoregrid.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = q_cores;
-    reader_desc.compile_time_args = reader_compile_time_args;
-    reader_desc.config = ReaderConfigDescriptor{};
+    DataflowBufferSpec out_dfb_spec{
+        .unique_id = OUT_DFB,
+        .entry_size = single_tile_size,
+        .num_entries = q_num_tiles,
+        .data_format_metadata = cb_data_format,
+        .borrowed_from = OUTPUT_TENSOR,
+    };
 
-    std::vector<uint32_t> writer_compile_time_args = reader_compile_time_args;
-    writer_compile_time_args[6] = 2;  // read the second phase
+    auto make_cta = [&](uint32_t phases_to_read) {
+        return KernelSpec::CompileTimeArgs{
+            {"element_size", element_size},
+            {"sub_tile_line_bytes", sub_tile_line_bytes},
+            {"head_size", head_size},
+            {"batch", batch},
+            {"head_size_num_tiles", head_tiles},
+            {"phases_to_read", phases_to_read},
+            {"in_num_cores", in_num_cores},
+            {"face_h", static_cast<uint32_t>(face_h)},
+            {"face_hw", static_cast<uint32_t>(face_hw)}};
+    };
 
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/kernels/dataflow/"
-        "reader_tm_tile_layout_nlp_concat_heads_decode_subcoregrid.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = q_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterConfigDescriptor{};
+    KernelSpec reader_spec{
+        .unique_id = READER_KERNEL,
+        .source = std::filesystem::path{KERNEL_PATH},
+        .dfb_bindings = {DFBBinding{
+            .dfb_spec_name = OUT_DFB, .accessor_name = "q_out", .endpoint_type = DFBEndpointType::PRODUCER}},
+        .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT_TENSOR, .accessor_name = "input"}},
+        .compile_time_args = make_cta(1),
+        .runtime_arg_schema = {.runtime_arg_names = {"in_tile_offset_by_head"}},
+        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+    };
+    reader_spec.advanced_options.num_common_runtime_varargs = noc_coords.size();
+
+    KernelSpec writer_spec{
+        .unique_id = WRITER_KERNEL,
+        .source = std::filesystem::path{KERNEL_PATH},
+        .dfb_bindings = {DFBBinding{
+            .dfb_spec_name = OUT_DFB, .accessor_name = "q_out", .endpoint_type = DFBEndpointType::CONSUMER}},
+        .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT_TENSOR, .accessor_name = "input"}},
+        .compile_time_args = make_cta(2),
+        .runtime_arg_schema = {.runtime_arg_names = {"in_tile_offset_by_head"}},
+        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+    };
+    writer_spec.advanced_options.num_common_runtime_varargs = noc_coords.size();
+
+    KernelRunArgs reader_run{.kernel = READER_KERNEL};
+    KernelRunArgs writer_run{.kernel = WRITER_KERNEL};
+    reader_run.advanced_options.common_runtime_varargs = noc_coords;
+    writer_run.advanced_options.common_runtime_varargs = noc_coords;
 
     for (uint32_t i = 0; i < num_cores; ++i) {
         // in_tile_offset_by_batch is the byte offset of head row i within the input shard. Within
@@ -130,22 +148,33 @@ ProgramDescriptor NLPConcatHeadsDecodeSubcoregridsProgramFactory::create_descrip
                                                                   : (head_in_tile + face_h) * sub_tile_line_bytes) +
                                            head_tile_idx * head_size;
 
-        const auto& core = cores[i];
-        KernelDescriptor::RTArgList rt_args;
-        rt_args.reserve(2 + (2 * in_num_cores));
-        rt_args.push_back(in_tile_offset_by_batch);
-        rt_args.push_back(in_buffer);
-        rt_args.append(noc_x_coords);
-        rt_args.append(noc_y_coords);
-
-        reader_desc.emplace_runtime_args(core, rt_args);
-        writer_desc.emplace_runtime_args(core, rt_args);
+        const NodeCoord core = cores[i];
+        const KernelRunArgs::RuntimeArgValues args{{"in_tile_offset_by_head", in_tile_offset_by_batch}};
+        reader_run.runtime_arg_values.push_back({core, args});
+        writer_run.runtime_arg_values.push_back({core, args});
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    WorkUnitSpec wu{
+        .name = "nlp_concat_heads_decode_subcoregrids",
+        .kernels = {READER_KERNEL, WRITER_KERNEL},
+        .target_nodes = q_cores,
+    };
 
-    return desc;
+    ProgramSpec spec{
+        .name = "nlp_concat_heads_decode_subcoregrids",
+        .kernels = {reader_spec, writer_spec},
+        .dataflow_buffers = {out_dfb_spec},
+        .tensor_parameters = {input_param, output_param},
+        .work_units = {wu},
+    };
+
+    ProgramRunArgs run_args;
+    run_args.kernel_run_args = {reader_run, writer_run};
+    run_args.tensor_args = {
+        {INPUT_TENSOR, TensorArgument{std::cref(input_tensor.mesh_tensor())}},
+        {OUTPUT_TENSOR, TensorArgument{std::cref(output.mesh_tensor())}}};
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_subcoregrids_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_subcoregrids_program_factory.hpp
@@ -4,15 +4,14 @@
 
 #pragma once
 
-#include <tt-metalium/program_descriptors.hpp>
-
 #include "nlp_concat_heads_decode_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal_v2_artifacts.hpp"
 
 namespace ttnn::experimental::prim {
 
 struct NLPConcatHeadsDecodeSubcoregridsProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const NlpConcatHeadsDecodeParams& operation_attributes,
         const NlpConcatHeadsDecodeInputs& tensor_args,
         Tensor& output);


### PR DESCRIPTION
Split out from #46909 (umbrella tracking thread) to keep each op migration reviewable on its own. Part of the Metal 2.0 op-migration batch.

Ports nlp_concat_heads_decode (main + subcoregrids) to `MetalV2FactoryConcept`. ✅ BH 15+4 passed; craq-sim runs.

**Draft** — see #46909 for the full tracking table and Quasar (craq-sim / emulator) validation status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vsureshTT/metal2-nlp-concat-heads-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vsureshTT/metal2-nlp-concat-heads-decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vsureshTT/metal2-nlp-concat-heads-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vsureshTT/metal2-nlp-concat-heads-decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vsureshTT/metal2-nlp-concat-heads-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vsureshTT/metal2-nlp-concat-heads-decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vsureshTT/metal2-nlp-concat-heads-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vsureshTT/metal2-nlp-concat-heads-decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vsureshTT/metal2-nlp-concat-heads-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vsureshTT/metal2-nlp-concat-heads-decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vsureshTT/metal2-nlp-concat-heads-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vsureshTT/metal2-nlp-concat-heads-decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vsureshTT/metal2-nlp-concat-heads-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vsureshTT/metal2-nlp-concat-heads-decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vsureshTT/metal2-nlp-concat-heads-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vsureshTT/metal2-nlp-concat-heads-decode)