### PR TITLE
[Metal 2.0] Port nlp_create_qkv_heads to create_program_artifacts

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/compute/transpose_wh_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/compute/transpose_wh_metal2.cpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of ttnn/cpp/ttnn/kernel/compute/transpose_wh.cpp.
+// The shared compute kernel is still used by sibling ops on the legacy ProgramDescriptor
+// path (nlp_create_qkv_heads_boltz / _vit, split_query_key_value_and_split_heads), so this
+// op's Metal 2.0 Interleaved factory binds a forked copy with named args + DFB handles.
+
+#include <cstdint>
+
+#include "api/compute/transpose_wh.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    constexpr auto NHtWt = get_arg(args::NHtWt);
+    transpose_wh_init(dfb::in_k, dfb::out_k);
+
+    // transpose a row-major block:
+    // - assumes the tiles come in in column major order from reader
+    // - uses reader_unary_transpose_wh
+    // - transpose_wh each tile
+    for (uint32_t n = 0; n < NHtWt; n++) {
+        cb_wait_front(dfb::in_k, 1);
+        cb_reserve_back(dfb::out_k, 1);
+
+        tile_regs_acquire();
+        transpose_wh_tile(dfb::in_k, 0, 0);
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(0, dfb::out_k);
+        tile_regs_release();
+
+        cb_push_back(dfb::out_k, 1);
+        cb_pop_front(dfb::in_k, 1);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads_metal2.cpp
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of reader_tm_tile_layout_nlp_create_qkv_heads.cpp. The legacy reader is still
+// bound by sibling ops on the ProgramDescriptor path (nlp_create_qkv_heads_segformer / _vit), so
+// this op's Metal 2.0 Interleaved factory binds a forked copy with named args, DFB handles, and
+// typed tensor bindings.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    Noc noc;
+
+    // READER RUNTIME ARGS
+    uint32_t num_blocks = get_arg(args::num_blocks);
+    uint32_t in0_tensor_tile_id = get_arg(args::in0_tensor_tile_id);
+    uint32_t in1_tensor_tile_id = get_arg(args::in1_tensor_tile_id);
+
+    // COMPILE TIME ARGS
+    // READER COMPILE TIME ARGS
+    constexpr uint32_t q_num_tiles = get_arg(args::q_num_tiles);
+    constexpr uint32_t kv_num_tiles = get_arg(args::kv_num_tiles);
+
+    constexpr auto cb_id_qv = dfb::qv;  // cb for Q, V heads
+#ifdef TRANSPOSE_K_HEADS
+    constexpr auto cb_id_k = dfb::in_k;  // cb for K heads (used by compute)
+#else
+    constexpr auto cb_id_k = dfb::qv;  // cb for K heads (directly to writer)
+#endif
+
+    constexpr uint32_t onetile = 1;
+    const auto s0 = TensorAccessor(ta::input_q);
+
+#ifdef READ_FROM_INPUT_TENSOR_KV
+    const auto s1 = TensorAccessor(ta::input_kv);
+#endif
+
+    DataflowBuffer cb_qv(cb_id_qv);
+    DataflowBuffer cb_k(cb_id_k);
+
+    // get_entry_size() is the arch-portable per-entry byte size (== single tile size here, since
+    // the factory sets the DFB entry_size to single_tile_size). DataflowBuffer::get_tile_size() is
+    // #ifndef ARCH_QUASAR-gated, so it does not exist on Gen2/Quasar; get_entry_size() does.
+    const uint32_t tile_bytes_qv = cb_qv.get_entry_size();
+    const uint32_t tile_bytes_k = cb_k.get_entry_size();
+
+    for (uint32_t block = 0; block < num_blocks; block++) {
+        // Q
+        for (uint32_t i = 0; i < q_num_tiles; i++) {
+            cb_qv.reserve_back(onetile);
+            uint32_t l1_write_addr = cb_qv.get_write_ptr();
+            noc.async_read(
+                s0, CoreLocalMem<uint32_t>(l1_write_addr), tile_bytes_qv, {.page_id = in0_tensor_tile_id}, {});
+            noc.async_read_barrier();
+            cb_qv.push_back(onetile);
+            in0_tensor_tile_id++;
+        }
+
+        // K
+        for (uint32_t i = 0; i < kv_num_tiles; i++) {
+            cb_k.reserve_back(onetile);
+            uint32_t l1_write_addr = cb_k.get_write_ptr();
+#ifdef READ_FROM_INPUT_TENSOR_KV
+            noc.async_read(
+                s1, CoreLocalMem<uint32_t>(l1_write_addr), tile_bytes_k, {.page_id = in1_tensor_tile_id}, {});
+            in1_tensor_tile_id++;
+#else
+            noc.async_read(
+                s0, CoreLocalMem<uint32_t>(l1_write_addr), tile_bytes_k, {.page_id = in0_tensor_tile_id}, {});
+            in0_tensor_tile_id++;
+#endif
+            noc.async_read_barrier();
+            cb_k.push_back(onetile);
+        }
+
+        // V
+        for (uint32_t i = 0; i < kv_num_tiles; i++) {
+            cb_qv.reserve_back(onetile);
+            uint32_t l1_write_addr = cb_qv.get_write_ptr();
+#ifdef READ_FROM_INPUT_TENSOR_KV
+            noc.async_read(
+                s1, CoreLocalMem<uint32_t>(l1_write_addr), tile_bytes_qv, {.page_id = in1_tensor_tile_id}, {});
+            in1_tensor_tile_id++;
+#else
+            noc.async_read(
+                s0, CoreLocalMem<uint32_t>(l1_write_addr), tile_bytes_qv, {.page_id = in0_tensor_tile_id}, {});
+            in0_tensor_tile_id++;
+#endif
+            noc.async_read_barrier();
+            cb_qv.push_back(onetile);
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads_metal2.cpp
@@ -36,10 +36,10 @@ void kernel_main() {
 #endif
 
     constexpr uint32_t onetile = 1;
-    const auto s0 = TensorAccessor(ta::input_q);
+    const auto s0 = TensorAccessor(tensor::input_q);
 
 #ifdef READ_FROM_INPUT_TENSOR_KV
-    const auto s1 = TensorAccessor(ta::input_kv);
+    const auto s1 = TensorAccessor(tensor::input_kv);
 #endif
 
     DataflowBuffer cb_qv(cb_id_qv);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads_sharded.cpp
@@ -8,36 +8,45 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
+#include "api/tensor/tensor_accessor.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
     Noc noc;
 
-    uint32_t head_size = get_arg_val<uint32_t>(0);
-    uint32_t num_q_heads = get_arg_val<uint32_t>(1);
-    uint32_t num_q_heads_per_core = get_arg_val<uint32_t>(2);
-    uint32_t remote_q_head_start_idx = get_arg_val<uint32_t>(3);
-    uint32_t start_q_x = get_arg_val<uint32_t>(4);
-    uint32_t start_q_y = get_arg_val<uint32_t>(5);
-    uint32_t q_base_addr = get_arg_val<uint32_t>(6);
-    uint32_t q_start_addr = get_arg_val<uint32_t>(7);
-    uint32_t q_offset = get_arg_val<uint32_t>(8);
-    constexpr uint32_t cb_id_q_out = get_compile_time_arg_val(0);
+    uint32_t head_size = get_arg(args::head_size);
+    uint32_t num_q_heads = get_arg(args::num_q_heads);
+    uint32_t num_q_heads_per_core = get_arg(args::num_q_heads_per_core);
+    uint32_t remote_q_head_start_idx = get_arg(args::remote_q_head_start_idx);
+    uint32_t start_q_x = get_arg(args::start_q_x);
+    uint32_t start_q_y = get_arg(args::start_q_y);
+    // Source-shard base addresses are recovered from the typed tensor binding(s) (Case 2 bridge):
+    // the legacy raw-uint32_t q_base_addr / kv_base_addr RTAs become host-computed *offsets* added
+    // to the accessor base on the kernel side. q_offset is the within-shard write offset (RISC1).
+    uint32_t q_start_offset = get_arg(args::q_start_offset);
+    uint32_t q_offset = get_arg(args::q_offset);
 
-    bool read_kv_heads = get_arg_val<uint32_t>(9);
+    // NoC coordinates of the input shard cores arrive as common runtime varargs, laid out
+    // [x0..x_{num_x-1}, y0..y_{num_y-1}]: get_common_vararg(x) for x-coords,
+    // get_common_vararg(num_x + y) for y-coords.
+    uint32_t num_x = get_arg(args::num_x);
 
-    uint32_t num_x = get_arg_val<uint32_t>(18);
-    tt_l1_ptr uint32_t* in0_mcast_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(19));
-    tt_l1_ptr uint32_t* in0_mcast_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(19 + num_x));
+    // Q input shard base (Case 2 bridge): get_bank_base_address() returns the per-shard local
+    // address, identical across shard cores, which is exactly the legacy q_base_addr.
+    const auto input_q = TensorAccessor(ta::input_q);
+    const uint32_t q_base_addr = input_q.get_bank_base_address();
 
-    CircularBuffer cb_q_out(cb_id_q_out);
+    DataflowBuffer cb_q_out(dfb::q_out);
     UnicastEndpoint src_ep;
+
+    bool read_kv_heads = get_arg(args::read_kv_heads);
 
     uint32_t q_x = start_q_x;
     uint32_t q_y = start_q_y;
     uint32_t remote_q_head_idx = remote_q_head_start_idx;
-    uint32_t q_src_noc_x = in0_mcast_noc_x[q_x];
-    uint32_t q_src_noc_y = in0_mcast_noc_y[q_y];
-    uint32_t q_src_addr = q_start_addr;
+    uint32_t q_src_noc_x = get_common_vararg(q_x);
+    uint32_t q_src_noc_y = get_common_vararg(num_x + q_y);
+    uint32_t q_src_addr = q_base_addr + q_start_offset;
     uint32_t q_write_addr = cb_q_out.get_write_ptr() + q_offset;
 
     for (uint32_t q = 0; q < num_q_heads; ++q) {
@@ -57,8 +66,8 @@ void kernel_main() {
             if (q_x == num_x) {
                 q_x = 0;
                 q_y++;
-                q_src_noc_x = in0_mcast_noc_x[q_x];
-                q_src_noc_y = in0_mcast_noc_y[q_y];
+                q_src_noc_x = get_common_vararg(q_x);
+                q_src_noc_y = get_common_vararg(num_x + q_y);
                 q_src_addr = q_base_addr;
             }
         }
@@ -66,24 +75,33 @@ void kernel_main() {
     }
 
     if (read_kv_heads) {
-        uint32_t num_kv_heads = get_arg_val<uint32_t>(10);
-        uint32_t num_kv_heads_per_core = get_arg_val<uint32_t>(11);
-        uint32_t remote_kv_head_start_idx = get_arg_val<uint32_t>(12);
-        uint32_t start_kv_x = get_arg_val<uint32_t>(13);
-        uint32_t start_kv_y = get_arg_val<uint32_t>(14);
-        uint32_t kv_base_addr = get_arg_val<uint32_t>(15);
-        uint32_t kv_start_addr = get_arg_val<uint32_t>(16);
-        uint32_t num_kv_tiles = get_arg_val<uint32_t>(17);
-        constexpr uint32_t cb_id_kv_out = get_compile_time_arg_val(1);
+        uint32_t num_kv_heads = get_arg(args::num_kv_heads);
+        uint32_t num_kv_heads_per_core = get_arg(args::num_kv_heads_per_core);
+        uint32_t remote_kv_head_start_idx = get_arg(args::remote_kv_head_start_idx);
+        uint32_t start_kv_x = get_arg(args::start_kv_x);
+        uint32_t start_kv_y = get_arg(args::start_kv_y);
+        // KV-source base offsets (Case 2 bridge). When a separate KV input tensor is present its
+        // base comes from its own accessor; otherwise the K/V source is the Q input shard.
+        uint32_t kv_base_offset = get_arg(args::kv_base_offset);
+        uint32_t kv_start_offset = get_arg(args::kv_start_offset);
+        uint32_t num_kv_tiles = get_arg(args::num_kv_tiles);
 
-        CircularBuffer cb_kv_out(cb_id_kv_out);
+#ifdef READ_FROM_INPUT_TENSOR_KV
+        const auto input_kv = TensorAccessor(ta::input_kv);
+        const uint32_t kv_source_base = input_kv.get_bank_base_address();
+#else
+        const uint32_t kv_source_base = q_base_addr;
+#endif
+        uint32_t kv_base_addr = kv_source_base + kv_base_offset;
+
+        DataflowBuffer cb_kv_out(dfb::kv_out);
 
         uint32_t kv_x = start_kv_x;
         uint32_t kv_y = start_kv_y;
         uint32_t remote_kv_head_idx = remote_kv_head_start_idx;
-        uint32_t kv_src_noc_x = in0_mcast_noc_x[kv_x];
-        uint32_t kv_src_noc_y = in0_mcast_noc_y[kv_y];
-        uint32_t kv_src_addr = kv_start_addr;
+        uint32_t kv_src_noc_x = get_common_vararg(kv_x);
+        uint32_t kv_src_noc_y = get_common_vararg(num_x + kv_y);
+        uint32_t kv_src_addr = kv_source_base + kv_start_offset;
         cb_kv_out.reserve_back(num_kv_tiles);
         uint32_t kv_write_addr = cb_kv_out.get_write_ptr();
 
@@ -105,8 +123,8 @@ void kernel_main() {
                     kv_x = 0;
                     kv_y++;
                 }
-                kv_src_noc_x = in0_mcast_noc_x[kv_x];
-                kv_src_noc_y = in0_mcast_noc_y[kv_y];
+                kv_src_noc_x = get_common_vararg(kv_x);
+                kv_src_noc_y = get_common_vararg(num_x + kv_y);
                 kv_src_addr = kv_base_addr;
             }
             noc.async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads_sharded.cpp
@@ -33,7 +33,7 @@ void kernel_main() {
 
     // Q input shard base (Case 2 bridge): get_bank_base_address() returns the per-shard local
     // address, identical across shard cores, which is exactly the legacy q_base_addr.
-    const auto input_q = TensorAccessor(ta::input_q);
+    const auto input_q = TensorAccessor(tensor::input_q);
     const uint32_t q_base_addr = input_q.get_bank_base_address();
 
     DataflowBuffer cb_q_out(dfb::q_out);
@@ -87,7 +87,7 @@ void kernel_main() {
         uint32_t num_kv_tiles = get_arg(args::num_kv_tiles);
 
 #ifdef READ_FROM_INPUT_TENSOR_KV
-        const auto input_kv = TensorAccessor(ta::input_kv);
+        const auto input_kv = TensorAccessor(tensor::input_kv);
         const uint32_t kv_source_base = input_kv.get_bank_base_address();
 #else
         const uint32_t kv_source_base = q_base_addr;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/dataflow/writer_tm_tile_layout_nlp_create_qkv_heads_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/dataflow/writer_tm_tile_layout_nlp_create_qkv_heads_metal2.cpp
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of writer_tm_tile_layout_nlp_create_qkv_heads.cpp. The legacy writer is still
+// bound by sibling ops on the ProgramDescriptor path (nlp_create_qkv_heads_segformer / _vit), so
+// this op's Metal 2.0 Interleaved factory binds a forked copy with named args, DFB handles, and
+// typed tensor bindings.
+
+#include <stdint.h>
+#include <array>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    Noc noc;
+
+    // WRITER RUNTIME ARGS
+    uint32_t num_blocks = get_arg(args::num_blocks);
+    uint32_t q_out_h_dim = get_arg(args::q_out_h_dim);
+    uint32_t q_out_tensor_tile_id = get_arg(args::q_out_tensor_tile_id);
+    uint32_t k_out_tensor_tile_id = get_arg(args::k_out_tensor_tile_id);
+    uint32_t v_out_tensor_tile_id = get_arg(args::v_out_tensor_tile_id);
+
+    // COMPILE TIME ARGS
+    constexpr uint32_t q_out_h_tiles = get_arg(args::q_out_h_tiles);
+    constexpr uint32_t q_out_w_tiles = get_arg(args::q_out_w_tiles);
+    constexpr uint32_t q_out_HtWt = get_arg(args::q_out_HtWt);
+    constexpr uint32_t q_out_c = get_arg(args::q_out_c);
+    constexpr uint32_t kv_out_c = get_arg(args::kv_out_c);
+    const auto sq = TensorAccessor(ta::q_output);
+    const auto sk = TensorAccessor(ta::k_output);
+    const auto sv = TensorAccessor(ta::v_output);
+
+    constexpr auto cb_id_qv = dfb::qv;  // cb for Q, V heads tiles
+#ifdef TRANSPOSE_K_HEADS
+    constexpr auto cb_id_k = dfb::out_k;  // cb for K heads (filled by compute)
+#else
+    constexpr auto cb_id_k = dfb::qv;  // cb for K heads (directly from reader)
+#endif
+
+    DataflowBuffer cb_qv(cb_id_qv);
+    DataflowBuffer cb_k(cb_id_k);
+
+    // get_entry_size() is the arch-portable per-entry byte size (== single tile size here, since
+    // the factory sets the DFB entry_size to single_tile_size). DataflowBuffer::get_tile_size() is
+    // #ifndef ARCH_QUASAR-gated, so it does not exist on Gen2/Quasar; get_entry_size() does.
+    const uint32_t tile_bytes_qv = cb_qv.get_entry_size();
+    const uint32_t tile_bytes_k = cb_k.get_entry_size();
+
+    constexpr uint32_t block_size = 1;  // micro-block size for read/write; nothing to do with num_blocks
+    // TODO: This might negatively impact perf
+    constexpr uint32_t out_num_tiles_read = block_size;  // always read and pop by micro-block size for generality
+    uint32_t l1_read_addr;
+    uint32_t q_out_tensor_current_tile_id;  // need this to update q_out_tensor_tile_id
+    uint32_t k_out_tensor_current_tile_id;  // need this to update k_out_tensor_tile_id
+    uint32_t v_out_tensor_current_tile_id;  // need this to update v_out_tensor_tile_id
+    uint32_t out_tensor_current_tile_id_along_c;
+
+    for (uint32_t block = 0; block < num_blocks; block++) {
+        // q + create q head --> outputs: [B, num_q_heads, S, head_dim]
+        out_tensor_current_tile_id_along_c = q_out_tensor_tile_id;
+        for (uint32_t c_dim = 0; c_dim < q_out_c; c_dim++) {
+            q_out_tensor_current_tile_id = out_tensor_current_tile_id_along_c;
+            for (uint32_t w_dim = 0; w_dim < q_out_w_tiles; w_dim++) {
+                cb_qv.wait_front(out_num_tiles_read);
+                l1_read_addr = cb_qv.get_read_ptr();
+                noc.async_write(
+                    CoreLocalMem<uint32_t>(l1_read_addr),
+                    sq,
+                    tile_bytes_qv,
+                    {},
+                    {.page_id = q_out_tensor_current_tile_id});
+
+                noc.async_write_barrier();
+                cb_qv.pop_front(out_num_tiles_read);
+
+                q_out_tensor_current_tile_id++;
+            }
+            out_tensor_current_tile_id_along_c += q_out_HtWt;
+        }
+
+// k + create k head --> outputs: [B, num_kv_heads, S, head_dim]
+#ifndef TRANSPOSE_K_HEADS
+        out_tensor_current_tile_id_along_c = k_out_tensor_tile_id;
+#else
+        k_out_tensor_current_tile_id = k_out_tensor_tile_id;
+#endif
+        for (uint32_t c_dim = 0; c_dim < kv_out_c; c_dim++) {
+#ifndef TRANSPOSE_K_HEADS
+            k_out_tensor_current_tile_id = out_tensor_current_tile_id_along_c;
+#endif
+            for (uint32_t w_dim = 0; w_dim < q_out_w_tiles; w_dim++) {
+                cb_k.wait_front(out_num_tiles_read);
+                l1_read_addr = cb_k.get_read_ptr();
+                noc.async_write(
+                    CoreLocalMem<uint32_t>(l1_read_addr),
+                    sk,
+                    tile_bytes_k,
+                    {},
+                    {.page_id = k_out_tensor_current_tile_id});
+
+                noc.async_write_barrier();
+                cb_k.pop_front(out_num_tiles_read);
+
+#ifndef TRANSPOSE_K_HEADS
+                k_out_tensor_current_tile_id++;
+#else
+                k_out_tensor_current_tile_id += q_out_h_tiles;
+#endif
+            }
+#ifndef TRANSPOSE_K_HEADS
+            out_tensor_current_tile_id_along_c += q_out_HtWt;
+#endif
+        }
+
+        // v + create v head --> outputs: [B, num_kv_heads, S, head_dim]
+        out_tensor_current_tile_id_along_c = v_out_tensor_tile_id;
+        for (uint32_t c_dim = 0; c_dim < kv_out_c; c_dim++) {
+            v_out_tensor_current_tile_id = out_tensor_current_tile_id_along_c;
+            for (uint32_t w_dim = 0; w_dim < q_out_w_tiles; w_dim++) {
+                cb_qv.wait_front(out_num_tiles_read);
+                l1_read_addr = cb_qv.get_read_ptr();
+                noc.async_write(
+                    CoreLocalMem<uint32_t>(l1_read_addr),
+                    sv,
+                    tile_bytes_qv,
+                    {},
+                    {.page_id = v_out_tensor_current_tile_id});
+
+                noc.async_write_barrier();
+                cb_qv.pop_front(out_num_tiles_read);
+
+                v_out_tensor_current_tile_id++;
+            }
+            out_tensor_current_tile_id_along_c += q_out_HtWt;
+        }
+
+        // Update out_tensor_tile_id for next h_dim or batch if we finish one CHtWt
+        q_out_h_dim++;
+        if (q_out_h_dim < q_out_h_tiles) {
+            q_out_tensor_tile_id += q_out_w_tiles;
+#ifndef TRANSPOSE_K_HEADS
+            k_out_tensor_tile_id += q_out_w_tiles;
+#else
+            k_out_tensor_tile_id++;
+#endif
+            v_out_tensor_tile_id += q_out_w_tiles;
+        } else {
+            // If we finish one batch, always roll over to next tile in memory
+            // This is just the current_tile_id, except for K when we transpose heads
+            // In this case, decrement k_out_tensor_current_tile_id by the stride (q_out_h_tiles) and add 1 to roll over
+            q_out_tensor_tile_id = q_out_tensor_current_tile_id;
+#ifndef TRANSPOSE_K_HEADS
+            k_out_tensor_tile_id = k_out_tensor_current_tile_id;
+#else
+            k_out_tensor_tile_id = ++k_out_tensor_current_tile_id - q_out_h_tiles;  // inc by 1 and decrement by stride
+#endif
+            v_out_tensor_tile_id = v_out_tensor_current_tile_id;
+            q_out_h_dim = 0;
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/dataflow/writer_tm_tile_layout_nlp_create_qkv_heads_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/dataflow/writer_tm_tile_layout_nlp_create_qkv_heads_metal2.cpp
@@ -32,9 +32,9 @@ void kernel_main() {
     constexpr uint32_t q_out_HtWt = get_arg(args::q_out_HtWt);
     constexpr uint32_t q_out_c = get_arg(args::q_out_c);
     constexpr uint32_t kv_out_c = get_arg(args::kv_out_c);
-    const auto sq = TensorAccessor(ta::q_output);
-    const auto sk = TensorAccessor(ta::k_output);
-    const auto sv = TensorAccessor(ta::v_output);
+    const auto sq = TensorAccessor(tensor::q_output);
+    const auto sk = TensorAccessor(tensor::k_output);
+    const auto sv = TensorAccessor(tensor::v_output);
 
     constexpr auto cb_id_qv = dfb::qv;  // cb for Q, V heads tiles
 #ifdef TRANSPOSE_K_HEADS

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.hpp
@@ -13,6 +13,8 @@
 #include "ttnn/types.hpp"  // exposes ttnn::MemoryConfig alias used in member/signature declarations
 
 #include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/device_operation.hpp"
+#include "ttnn/metal_v2_artifacts.hpp"
 
 namespace ttnn::operations::experimental::transformer {
 
@@ -35,14 +37,14 @@ struct NlpCreateHeadsDeviceOperation {
     using tensor_return_value_t = std::tuple<Tensor, Tensor, Tensor>;
 
     struct Interleaved {
-        static tt::tt_metal::ProgramDescriptor create_descriptor(
+        static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value);
     };
 
     struct Sharded {
-        static tt::tt_metal::ProgramDescriptor create_descriptor(
+        static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_program_factory.cpp
@@ -4,9 +4,10 @@
 
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/work_split.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 
 #include "nlp_create_qkv_heads_device_operation.hpp"
 
@@ -15,11 +16,37 @@ namespace ttnn::operations::experimental::transformer {
 using namespace tt::constants;
 using namespace tt;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
-ProgramDescriptor NlpCreateHeadsDeviceOperation::Interleaved::create_descriptor(
+ttnn::device_operation::ProgramArtifacts NlpCreateHeadsDeviceOperation::Interleaved::create_program_artifacts(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {
+    // Metal 2.0 named resource handles for the interleaved nlp_create_qkv_heads ProgramSpec.
+    // (Declared as locals — not in a file-scope anon namespace — to avoid unity-build collisions.)
+    const DFBSpecName QV_DFB{"qv"};        // legacy cb1: Q/V tiles (and K when not transposed)
+    const DFBSpecName IN_K_DFB{"in_k"};    // legacy cb0: K tiles into compute (transpose only)
+    const DFBSpecName OUT_K_DFB{"out_k"};  // legacy cb16: transposed K tiles out of compute (transpose only)
+    const TensorParamName INPUT_Q_TENSOR{"input_q"};
+    const TensorParamName INPUT_KV_TENSOR{"input_kv"};
+    const TensorParamName Q_OUT_TENSOR{"q_output"};
+    const TensorParamName K_OUT_TENSOR{"k_output"};
+    const TensorParamName V_OUT_TENSOR{"v_output"};
+    const KernelSpecName READER_KERNEL{"reader"};
+    const KernelSpecName WRITER_KERNEL{"writer"};
+    const KernelSpecName COMPUTE_KERNEL_G1{"compute_g1"};
+    const KernelSpecName COMPUTE_KERNEL_G2{"compute_g2"};
+    // Forked Metal 2.0 kernel sources (legacy copies stay for unmigrated sibling ops).
+    constexpr const char* READER_PATH =
+        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/dataflow/"
+        "reader_tm_tile_layout_nlp_create_qkv_heads_metal2.cpp";
+    constexpr const char* WRITER_PATH =
+        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/dataflow/"
+        "writer_tm_tile_layout_nlp_create_qkv_heads_metal2.cpp";
+    constexpr const char* COMPUTE_PATH =
+        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/compute/"
+        "transpose_wh_metal2.cpp";
+
     const Tensor& input_tensor = tensor_args.input_tensor_q;
     std::optional<const Tensor> input_tensor_kv = tensor_args.input_tensor_kv;
     const uint32_t num_q_heads = operation_attributes.num_q_heads;
@@ -39,10 +66,8 @@ ProgramDescriptor NlpCreateHeadsDeviceOperation::Interleaved::create_descriptor(
     tt_metal::Buffer* in0_buffer = input_tensor.buffer();
     TT_ASSERT(in0_buffer->size() % single_tile_size == 0);
 
-    tt_metal::Buffer* in1_buffer = nullptr;
     if (read_from_input_tensor_kv) {
-        in1_buffer = input_tensor_kv.value().buffer();
-        TT_ASSERT(in1_buffer->size() % single_tile_size == 0);
+        TT_ASSERT(input_tensor_kv.value().buffer()->size() % single_tile_size == 0);
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -74,147 +99,171 @@ ProgramDescriptor NlpCreateHeadsDeviceOperation::Interleaved::create_descriptor(
         tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_blocks);
 
     ////////////////////////////////////////////////////////////////////////////
-    //                      Grayskull Device Setup
+    //                      Output tensors
     ////////////////////////////////////////////////////////////////////////////
     tt_metal::Tensor& q = std::get<0>(output);
     tt_metal::Tensor& k = std::get<1>(output);
     tt_metal::Tensor& v = std::get<2>(output);
 
-    tt_metal::Buffer* q_buffer = q.buffer();
-    TT_ASSERT(q_buffer != nullptr, "Output q buffer should be allocated on device!");
-    tt_metal::Buffer* k_buffer = k.buffer();
-    TT_ASSERT(k_buffer != nullptr, "Output k buffer should be allocated on device!");
-    tt_metal::Buffer* v_buffer = v.buffer();
-    TT_ASSERT(v_buffer != nullptr, "Output v buffer should be allocated on device!");
+    TT_ASSERT(q.buffer() != nullptr, "Output q buffer should be allocated on device!");
+    TT_ASSERT(k.buffer() != nullptr, "Output k buffer should be allocated on device!");
+    TT_ASSERT(v.buffer() != nullptr, "Output v buffer should be allocated on device!");
 
     ////////////////////////////////////////////////////////////////////////////
-    //                      Application Setup
+    //                      Dataflow buffers (legacy CBs)
     ////////////////////////////////////////////////////////////////////////////
-    ProgramDescriptor desc;
-
-    std::vector<uint32_t> reader_compile_time_args = {
-        (std::uint32_t)q_num_tiles,
-        (std::uint32_t)kv_num_tiles,
-    };
-    tt::tt_metal::TensorAccessorArgs(in0_buffer).append_to(reader_compile_time_args);
-    // Always append placeholder/accessor for in1 to keep offsets stable
-    tt::tt_metal::TensorAccessorArgs(read_from_input_tensor_kv ? in1_buffer : nullptr)
-        .append_to(reader_compile_time_args);
-
-    // TODO: Q, K, V doesn't necessarily need to be the same output mem config
-    std::vector<uint32_t> writer_compile_time_args = {
-        (std::uint32_t)q_out_h_tiles,
-        (std::uint32_t)q_out_w_tiles,
-        (std::uint32_t)q_out_HtWt,
-        (std::uint32_t)num_q_heads,   // q_out_c
-        (std::uint32_t)num_kv_heads,  // kv_out_c
-    };
-    tt::tt_metal::TensorAccessorArgs(q_buffer).append_to(writer_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(k_buffer).append_to(writer_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(v_buffer).append_to(writer_compile_time_args);
-
-    KernelDescriptor::Defines reader_defines;
-    KernelDescriptor::Defines writer_defines;
-    if (transpose_k_heads) {
-        // For FLOAT32 input, enable fp32 dest accumulation so the JIT data-format selection
-        // resolves the unpack-dst CB to Tf32 (10-bit mantissa) instead of Float16_b (7-bit
-        // mantissa). Mirrors the per-dtype promotion in eltwise unary/binary primitives.
-        const bool fp32_dest_acc_en = input_tensor.dtype() == tt_metal::DataType::FLOAT32;
-
-        std::vector<uint32_t> compute_args_core_group_1 = {num_blocks_per_core_group_1 * kv_num_tiles};
-        KernelDescriptor compute_desc_1;
-        compute_desc_1.kernel_source = "ttnn/cpp/ttnn/kernel/compute/transpose_wh.cpp";
-        compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        compute_desc_1.core_ranges = core_group_1;
-        compute_desc_1.compile_time_args = std::move(compute_args_core_group_1);
-        compute_desc_1.config = ComputeConfigDescriptor{.fp32_dest_acc_en = fp32_dest_acc_en};
-        desc.kernels.push_back(std::move(compute_desc_1));
-
-        if (core_group_2.num_cores() > 0) {
-            std::vector<uint32_t> compute_args_core_group_2 = {num_blocks_per_core_group_2 * kv_num_tiles};
-            KernelDescriptor compute_desc_2;
-            compute_desc_2.kernel_source = "ttnn/cpp/ttnn/kernel/compute/transpose_wh.cpp";
-            compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
-            compute_desc_2.core_ranges = core_group_2;
-            compute_desc_2.compile_time_args = std::move(compute_args_core_group_2);
-            compute_desc_2.config = ComputeConfigDescriptor{.fp32_dest_acc_en = fp32_dest_acc_en};
-            desc.kernels.push_back(std::move(compute_desc_2));
-        }
-
-        reader_defines.emplace_back("TRANSPOSE_K_HEADS", "1");
-        writer_defines.emplace_back("TRANSPOSE_K_HEADS", "1");
-    }
-    if (read_from_input_tensor_kv) {
-        reader_defines.emplace_back("READ_FROM_INPUT_TENSOR_KV", "1");
-    }
-
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/dataflow/"
-        "reader_tm_tile_layout_nlp_create_qkv_heads.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.defines = std::move(reader_defines);
-    reader_desc.config = ReaderConfigDescriptor{};
-
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/dataflow/"
-        "writer_tm_tile_layout_nlp_create_qkv_heads.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.defines = std::move(writer_defines);
-    writer_desc.config = WriterConfigDescriptor{};
-
-    // Create circular buffers
+    // Create dataflow buffers
     uint32_t micro_block_size = 1;                 // Num tiles to read/wait for in reader and writer
     uint32_t cb_num_tiles = micro_block_size * 4;  // Quadruple buffer everything
 
     // TODO: Investigate perf allocating full in0_w_tiles with double buffer
     // uint32_t cb1_num_tiles = in0_w_tiles * 2; // double buffer; this runs out of space for generic shapes
-    uint32_t src1_cb_index = 1;  // cb0 is needed for compute if we want to use generic transpose_wh compute kernel
-    uint32_t cb1_num_tiles = cb_num_tiles;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = cb1_num_tiles * single_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src1_cb_index),
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
-        }}},
-    });
+    // QV DFB (legacy cb1): cb0 is needed for compute if we want to use the generic transpose_wh compute kernel.
+    DataflowBufferSpec qv_dfb_spec{
+        .unique_id = QV_DFB,
+        .entry_size = single_tile_size,
+        .num_entries = cb_num_tiles,
+        .data_format_metadata = cb_data_format,
+    };
 
     // If we transpose_k_heads:
-    // - reader will write to cb0, instead of cb1
-    // - compute will wait on cb0 and write to cb16
-    // - writer will wait on cb 16, instead of cb1
-    if (transpose_k_heads) {
-        uint32_t src0_cb_index = 0;
-        uint32_t cb0_num_tiles = cb_num_tiles;
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = cb0_num_tiles * single_tile_size,
-            .core_ranges = all_cores,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(src0_cb_index),
-                .data_format = cb_data_format,
-                .page_size = single_tile_size,
-            }}},
-        });
+    // - reader will write to cb0 (in_k), instead of cb1 (qv)
+    // - compute will wait on cb0 (in_k) and write to cb16 (out_k)
+    // - writer will wait on cb16 (out_k), instead of cb1 (qv)
+    DataflowBufferSpec in_k_dfb_spec{
+        .unique_id = IN_K_DFB,
+        .entry_size = single_tile_size,
+        .num_entries = cb_num_tiles,
+        .data_format_metadata = cb_data_format,
+    };
+    DataflowBufferSpec out_k_dfb_spec{
+        .unique_id = OUT_K_DFB,
+        .entry_size = single_tile_size,
+        .num_entries = cb_num_tiles,
+        .data_format_metadata = cb_data_format,
+    };
 
-        uint32_t out_cb_index = 16;
-        uint32_t out_cb_num_tiles = cb_num_tiles;
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = out_cb_num_tiles * single_tile_size,
-            .core_ranges = all_cores,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(out_cb_index),
-                .data_format = cb_data_format,
-                .page_size = single_tile_size,
-            }}},
-        });
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Tensor parameters
+    ////////////////////////////////////////////////////////////////////////////
+    Group<TensorParameter> tensor_params = {
+        TensorParameter{.unique_id = INPUT_Q_TENSOR, .spec = input_tensor.tensor_spec()},
+        TensorParameter{.unique_id = Q_OUT_TENSOR, .spec = q.tensor_spec()},
+        TensorParameter{.unique_id = K_OUT_TENSOR, .spec = k.tensor_spec()},
+        TensorParameter{.unique_id = V_OUT_TENSOR, .spec = v.tensor_spec()}};
+    if (read_from_input_tensor_kv) {
+        tensor_params.push_back(
+            TensorParameter{.unique_id = INPUT_KV_TENSOR, .spec = input_tensor_kv.value().tensor_spec()});
     }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Kernel specs
+    ////////////////////////////////////////////////////////////////////////////
+    // Reader/writer carry TRANSPOSE_K_HEADS (gates the in_k/out_k DFB handle aliases) and the reader
+    // additionally carries READ_FROM_INPUT_TENSOR_KV (gates the optional ta::input_kv accessor).
+    Table<std::string, std::string> reader_defines;
+    Table<std::string, std::string> writer_defines;
+    if (transpose_k_heads) {
+        reader_defines.insert({"TRANSPOSE_K_HEADS", "1"});
+        writer_defines.insert({"TRANSPOSE_K_HEADS", "1"});
+    }
+    if (read_from_input_tensor_kv) {
+        reader_defines.insert({"READ_FROM_INPUT_TENSOR_KV", "1"});
+    }
+
+    // Reader binds input_q (+ input_kv when present) and produces QV (and IN_K when transposed).
+    Group<TensorBinding> reader_tensor_bindings = {
+        TensorBinding{.tensor_parameter_name = INPUT_Q_TENSOR, .accessor_name = "input_q"}};
+    if (read_from_input_tensor_kv) {
+        reader_tensor_bindings.push_back(
+            TensorBinding{.tensor_parameter_name = INPUT_KV_TENSOR, .accessor_name = "input_kv"});
+    }
+    Group<DFBBinding> reader_dfb_bindings = {
+        DFBBinding{.dfb_spec_name = QV_DFB, .accessor_name = "qv", .endpoint_type = DFBEndpointType::PRODUCER}};
+    if (transpose_k_heads) {
+        reader_dfb_bindings.push_back(
+            DFBBinding{.dfb_spec_name = IN_K_DFB, .accessor_name = "in_k", .endpoint_type = DFBEndpointType::PRODUCER});
+    }
+
+    KernelSpec reader_spec{
+        .unique_id = READER_KERNEL,
+        .source = std::filesystem::path{READER_PATH},
+        .compiler_options = {.defines = reader_defines},
+        .dfb_bindings = reader_dfb_bindings,
+        .tensor_bindings = reader_tensor_bindings,
+        .compile_time_args = {{"q_num_tiles", q_num_tiles}, {"kv_num_tiles", kv_num_tiles}},
+        .runtime_arg_schema = {.runtime_arg_names = {"num_blocks", "in0_tensor_tile_id", "in1_tensor_tile_id"}},
+        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+    };
+
+    // Writer binds q/k/v outputs and consumes QV (and OUT_K when transposed).
+    Group<DFBBinding> writer_dfb_bindings = {
+        DFBBinding{.dfb_spec_name = QV_DFB, .accessor_name = "qv", .endpoint_type = DFBEndpointType::CONSUMER}};
+    if (transpose_k_heads) {
+        writer_dfb_bindings.push_back(DFBBinding{
+            .dfb_spec_name = OUT_K_DFB, .accessor_name = "out_k", .endpoint_type = DFBEndpointType::CONSUMER});
+    }
+
+    KernelSpec writer_spec{
+        .unique_id = WRITER_KERNEL,
+        .source = std::filesystem::path{WRITER_PATH},
+        .compiler_options = {.defines = writer_defines},
+        .dfb_bindings = writer_dfb_bindings,
+        .tensor_bindings =
+            {TensorBinding{.tensor_parameter_name = Q_OUT_TENSOR, .accessor_name = "q_output"},
+             TensorBinding{.tensor_parameter_name = K_OUT_TENSOR, .accessor_name = "k_output"},
+             TensorBinding{.tensor_parameter_name = V_OUT_TENSOR, .accessor_name = "v_output"}},
+        .compile_time_args =
+            {{"q_out_h_tiles", q_out_h_tiles},
+             {"q_out_w_tiles", q_out_w_tiles},
+             {"q_out_HtWt", q_out_HtWt},
+             {"q_out_c", num_q_heads},
+             {"kv_out_c", num_kv_heads}},
+        .runtime_arg_schema =
+            {.runtime_arg_names =
+                 {"num_blocks", "q_out_h_dim", "q_out_tensor_tile_id", "k_out_tensor_tile_id", "v_out_tensor_tile_id"}},
+        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+    };
+
+    Group<KernelSpec> kernels = {reader_spec, writer_spec};
+
+    // Compute (transpose_k_heads only): one KernelSpec per work-split core group, consuming IN_K and
+    // producing OUT_K. Per-group CTA (NHtWt) preserved as compile-time multiplicity, not demoted to
+    // an RTA. For FLOAT32 input, enable fp32 dest accumulation so the unpack-dst CB resolves to Tf32
+    // (10-bit mantissa) instead of Float16_b (7-bit mantissa); Metal 2.0 additionally requires an
+    // explicit UnpackToDestFp32 entry for the Float32 IN_K consumer DFB.
+    const bool fp32_dest_acc_en = transpose_k_heads && input_tensor.dtype() == tt_metal::DataType::FLOAT32;
+    auto make_compute_spec = [&](const KernelSpecName& unique_id, uint32_t num_blocks_per_core_group) {
+        ComputeHardwareConfig compute_hw{.fp32_dest_acc_en = fp32_dest_acc_en};
+        if (fp32_dest_acc_en) {
+            compute_hw.unpack_to_dest_mode.insert({IN_K_DFB, tt::tt_metal::UnpackToDestMode::UnpackToDestFp32});
+        }
+        return KernelSpec{
+            .unique_id = unique_id,
+            .source = std::filesystem::path{COMPUTE_PATH},
+            .dfb_bindings =
+                {DFBBinding{
+                     .dfb_spec_name = IN_K_DFB, .accessor_name = "in_k", .endpoint_type = DFBEndpointType::CONSUMER},
+                 DFBBinding{
+                     .dfb_spec_name = OUT_K_DFB, .accessor_name = "out_k", .endpoint_type = DFBEndpointType::PRODUCER}},
+            .compile_time_args = {{"NHtWt", num_blocks_per_core_group * kv_num_tiles}},
+            .hw_config = compute_hw,
+        };
+    };
+
+    const bool group_2_present = core_group_2.num_cores() > 0;
+    if (transpose_k_heads) {
+        kernels.push_back(make_compute_spec(COMPUTE_KERNEL_G1, num_blocks_per_core_group_1));
+        if (group_2_present) {
+            kernels.push_back(make_compute_spec(COMPUTE_KERNEL_G2, num_blocks_per_core_group_2));
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Per-core runtime args
+    ////////////////////////////////////////////////////////////////////////////
+    KernelRunArgs reader_run{.kernel = READER_KERNEL};
+    KernelRunArgs writer_run{.kernel = WRITER_KERNEL};
 
     for (uint32_t i = 0, num_blocks_written = 0; i < num_cores; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
@@ -236,53 +285,105 @@ ProgramDescriptor NlpCreateHeadsDeviceOperation::Interleaved::create_descriptor(
                                             ? (num_blocks_written / q_out_h_tiles * kv_out_CHtWt) + q_out_h_dim
                                             : v_out_tensor_tile_id;
 
-        KernelDescriptor::RTArgList reader_rt;
-        reader_rt.reserve(5);
-        reader_rt.push_back(in0_buffer);
-        if (in1_buffer != nullptr) {
-            reader_rt.push_back(in1_buffer);
-        } else {
-            reader_rt.push_back(uint32_t{0});
-        }
-        reader_rt.push_back(num_blocks_per_core);
-        reader_rt.push_back(num_blocks_written * in0_w_tiles);
-        reader_rt.push_back(num_blocks_written * in1_w_tiles);
-        reader_desc.emplace_runtime_args(core, reader_rt);
+        reader_run.runtime_arg_values.push_back(
+            {core,
+             {{"num_blocks", num_blocks_per_core},
+              {"in0_tensor_tile_id", num_blocks_written * in0_w_tiles},
+              {"in1_tensor_tile_id", num_blocks_written * in1_w_tiles}}});
 
-        writer_desc.emplace_runtime_args(
-            core,
-            {
-                q_buffer,              // q_tensor_addr
-                k_buffer,              // k_tensor_addr
-                v_buffer,              // v_tensor_addr
-                num_blocks_per_core,   // num_blocks
-                q_out_h_dim,           // q_out_h_dim
-                q_out_tensor_tile_id,  // q_out_tensor_tile_id
-                k_out_tensor_tile_id,  // k_out_tensor_tile_id
-                v_out_tensor_tile_id,  // v_out_tensor_tile_id
-            });
+        writer_run.runtime_arg_values.push_back(
+            {core,
+             {{"num_blocks", num_blocks_per_core},
+              {"q_out_h_dim", q_out_h_dim},
+              {"q_out_tensor_tile_id", q_out_tensor_tile_id},
+              {"k_out_tensor_tile_id", k_out_tensor_tile_id},
+              {"v_out_tensor_tile_id", v_out_tensor_tile_id}}});
 
         num_blocks_written += num_blocks_per_core;
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Work units
+    ////////////////////////////////////////////////////////////////////////////
+    // Reader/writer span all_cores; the compute kernel is split per work-split group, so when
+    // transposing each group gets its own WorkUnitSpec (reader + writer + per-group compute). A
+    // KernelSpec may appear in multiple WorkUnitSpecs; its effective node set is the union.
+    Group<WorkUnitSpec> work_units;
+    if (transpose_k_heads) {
+        work_units.push_back(WorkUnitSpec{
+            .name = "nlp_create_qkv_heads_interleaved_g1",
+            .kernels = {READER_KERNEL, WRITER_KERNEL, COMPUTE_KERNEL_G1},
+            .target_nodes = core_group_1});
+        if (group_2_present) {
+            work_units.push_back(WorkUnitSpec{
+                .name = "nlp_create_qkv_heads_interleaved_g2",
+                .kernels = {READER_KERNEL, WRITER_KERNEL, COMPUTE_KERNEL_G2},
+                .target_nodes = core_group_2});
+        }
+    } else {
+        work_units.push_back(WorkUnitSpec{
+            .name = "nlp_create_qkv_heads_interleaved",
+            .kernels = {READER_KERNEL, WRITER_KERNEL},
+            .target_nodes = all_cores});
+    }
 
-    return desc;
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Assemble spec + run args
+    ////////////////////////////////////////////////////////////////////////////
+    Group<DataflowBufferSpec> dataflow_buffers = {qv_dfb_spec};
+    if (transpose_k_heads) {
+        dataflow_buffers.push_back(in_k_dfb_spec);
+        dataflow_buffers.push_back(out_k_dfb_spec);
+    }
+
+    ProgramSpec spec{
+        .name = "nlp_create_qkv_heads_interleaved",
+        .kernels = kernels,
+        .dataflow_buffers = dataflow_buffers,
+        .tensor_parameters = tensor_params,
+        .work_units = work_units,
+    };
+
+    ProgramRunArgs run_args;
+    run_args.kernel_run_args = {reader_run, writer_run};
+    run_args.tensor_args = {
+        {INPUT_Q_TENSOR, TensorArgument{input_tensor.mesh_tensor()}},
+        {Q_OUT_TENSOR, TensorArgument{q.mesh_tensor()}},
+        {K_OUT_TENSOR, TensorArgument{k.mesh_tensor()}},
+        {V_OUT_TENSOR, TensorArgument{v.mesh_tensor()}}};
+    if (read_from_input_tensor_kv) {
+        run_args.tensor_args.insert({INPUT_KV_TENSOR, TensorArgument{input_tensor_kv.value().mesh_tensor()}});
+    }
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
-ProgramDescriptor NlpCreateHeadsDeviceOperation::Sharded::create_descriptor(
+ttnn::device_operation::ProgramArtifacts NlpCreateHeadsDeviceOperation::Sharded::create_program_artifacts(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {
+    // Metal 2.0 named resource handles for the sharded nlp_create_qkv_heads ProgramSpec.
+    // (Declared as locals — not in a file-scope anon namespace — to avoid unity-build collisions.)
+    const DFBSpecName Q_OUT_DFB{"q_out"};
+    const DFBSpecName K_OUT_DFB{"k_out"};
+    const DFBSpecName V_OUT_DFB{"v_out"};
+    const TensorParamName INPUT_Q_TENSOR{"input_q"};
+    const TensorParamName INPUT_KV_TENSOR{"input_kv"};
+    const TensorParamName Q_OUT_TENSOR{"q_output"};
+    const TensorParamName K_OUT_TENSOR{"k_output"};
+    const TensorParamName V_OUT_TENSOR{"v_output"};
+    const KernelSpecName READER_KERNEL{"reader"};
+    const KernelSpecName WRITER_KERNEL{"writer"};
+    constexpr const char* KERNEL_PATH =
+        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/dataflow/"
+        "reader_tm_tile_layout_nlp_create_qkv_heads_sharded.cpp";
+
     const auto& input_tensor = tensor_args.input_tensor_q;
     const auto& input_tensor_kv = tensor_args.input_tensor_kv;
     auto& output = tensor_return_value;
     auto head_dim = operation_attributes.head_dim;
     auto num_q_heads = operation_attributes.num_q_heads;
     auto num_kv_heads = operation_attributes.num_kv_heads;
-
-    ProgramDescriptor desc;
 
     tt_metal::IDevice* device = input_tensor.device();
 
@@ -304,84 +405,66 @@ ProgramDescriptor NlpCreateHeadsDeviceOperation::Sharded::create_descriptor(
     uint32_t per_risc1_out_q_heads = per_core_out_q_heads / 2;
     uint32_t per_core_in_q_heads = num_q_heads / input_tensor.shard_spec().value().num_cores();
 
-    uint32_t q_output_cb_index = CBIndex::c_16;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = q_num_tiles * single_tile_size,
-        .core_ranges = q_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(q_output_cb_index),
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
-        }}},
-        .buffer = std::get<0>(output).buffer(),
-    });
+    // Output DFBs borrow the q/k/v output shard buffers (legacy CBs c_16/c_17/c_18). They are
+    // write-only address sources (no real FIFO): the kernel grabs base via get_write_ptr() and
+    // does explicit NoC reads into the borrowed L1. Bound as self-loops / producer-consumer
+    // pairs purely to satisfy the validator's producer-and-consumer rule. See METAL2_PORT_REPORT.
+    DataflowBufferSpec q_out_dfb_spec{
+        .unique_id = Q_OUT_DFB,
+        .entry_size = single_tile_size,
+        .num_entries = q_num_tiles,
+        .data_format_metadata = cb_data_format,
+        .borrowed_from = Q_OUT_TENSOR,
+    };
 
     auto k_shard_spec = std::get<1>(output).shard_spec().value();
     auto k_cores = k_shard_spec.grid;
     auto k_num_tiles = k_shard_spec.shape[0] * k_shard_spec.shape[1] / TILE_HW;
 
-    uint32_t k_output_cb_index = CBIndex::c_17;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = k_num_tiles * single_tile_size,
-        .core_ranges = k_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(k_output_cb_index),
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
-        }}},
-        .buffer = std::get<1>(output).buffer(),
-    });
+    DataflowBufferSpec k_out_dfb_spec{
+        .unique_id = K_OUT_DFB,
+        .entry_size = single_tile_size,
+        .num_entries = k_num_tiles,
+        .data_format_metadata = cb_data_format,
+        .borrowed_from = K_OUT_TENSOR,
+    };
 
     auto v_shard_spec = std::get<0>(output).shard_spec().value();
     auto v_cores = q_shard_spec.grid;
     auto v_num_tiles = v_shard_spec.shape[0] * v_shard_spec.shape[1] / TILE_HW;
 
-    uint32_t v_output_cb_index = CBIndex::c_18;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = v_num_tiles * single_tile_size,
-        .core_ranges = v_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(v_output_cb_index),
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
-        }}},
-        .buffer = std::get<2>(output).buffer(),
-    });
+    DataflowBufferSpec v_out_dfb_spec{
+        .unique_id = V_OUT_DFB,
+        .entry_size = single_tile_size,
+        .num_entries = v_num_tiles,
+        .data_format_metadata = cb_data_format,
+        .borrowed_from = V_OUT_TENSOR,
+    };
 
     uint32_t per_core_out_kv_heads = num_kv_heads / k_cores.num_cores();
     uint32_t per_core_in_kv_heads =
         num_kv_heads / (read_from_input_tensor_kv ? input_tensor_kv.value().shard_spec().value().num_cores()
                                                   : input_tensor.shard_spec().value().num_cores());
 
-    uint32_t q_base_addr = input_tensor.buffer()->address();
-    uint32_t k_base_addr = 0;
-    if (read_from_input_tensor_kv) {
-        k_base_addr = input_tensor_kv.value().buffer()->address();
-    } else {
-        k_base_addr = q_base_addr + per_core_in_q_heads * head_tiles * single_tile_size;
-    }
-    uint32_t v_base_addr = k_base_addr + (per_core_in_kv_heads * head_tiles * single_tile_size);
+    // Host-computed offsets relative to the source-shard bases. The legacy kernel consumed
+    // pre-shifted raw addresses (q_base_addr / q_start_addr / k_base_addr / k_start_addr /
+    // v_base_addr / v_start_addr); under Metal 2.0 the source bases are recovered kernel-side from
+    // the typed tensor binding(s) via get_bank_base_address() (Case 2 bridge) and the host passes
+    // only the offsets, added on the kernel side. The arithmetic itself is unchanged from legacy.
+    //
+    // K/V source base: input_kv when present, otherwise the Q input shard offset by the Q-head span.
+    uint32_t kv_base_offset_reader =
+        read_from_input_tensor_kv ? 0u : (per_core_in_q_heads * head_tiles * single_tile_size);
+    // V (writer) base sits one KV-head span past the K (reader) base within the same source shard.
+    uint32_t kv_base_offset_writer = kv_base_offset_reader + (per_core_in_kv_heads * head_tiles * single_tile_size);
 
-    std::vector<uint32_t> reader_compile_time_args = {q_output_cb_index, k_output_cb_index};
-    std::vector<uint32_t> writer_compile_time_args = {q_output_cb_index, v_output_cb_index};
-
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/dataflow/"
-        "reader_tm_tile_layout_nlp_create_qkv_heads_sharded.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = q_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderConfigDescriptor{};
-
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/dataflow/"
-        "reader_tm_tile_layout_nlp_create_qkv_heads_sharded.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = q_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterConfigDescriptor{};
+    // Tensor parameters: the q/k/v output tensors back the borrowed DFBs. The Q input tensor
+    // (and KV input tensor when present) supply the source-shard bases (Case 2 bridge), recovered
+    // kernel-side via get_bank_base_address().
+    TensorParameter input_q_param{.unique_id = INPUT_Q_TENSOR, .spec = input_tensor.tensor_spec()};
+    TensorParameter q_out_param{.unique_id = Q_OUT_TENSOR, .spec = std::get<0>(output).tensor_spec()};
+    TensorParameter k_out_param{.unique_id = K_OUT_TENSOR, .spec = std::get<1>(output).tensor_spec()};
+    TensorParameter v_out_param{.unique_id = V_OUT_TENSOR, .spec = std::get<2>(output).tensor_spec()};
 
     uint32_t num_cores = std::max(q_cores.num_cores(), k_cores.num_cores());
 
@@ -390,107 +473,204 @@ ProgramDescriptor NlpCreateHeadsDeviceOperation::Sharded::create_descriptor(
 
     const auto& cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, true);
 
-    std::vector<uint32_t> noc_x_coords;
-    noc_x_coords.reserve(num_cores_x);
+    // NoC coordinates of the input shard cores. Identical for every output core, so they are
+    // broadcast as Metal 2.0 *common* runtime varargs, laid out [x0..x_{nx-1}, y0..y_{ny-1}].
+    // The kernel reads get_common_vararg(x) for x-coords, get_common_vararg(num_x + y) for y-coords.
+    std::vector<uint32_t> noc_coords;
+    noc_coords.reserve(num_cores_x + num_cores_y);
     for (uint32_t x = 0; x < num_cores_x; ++x) {
-        noc_x_coords.push_back(device->worker_core_from_logical_core({x, 0}).x);
+        noc_coords.push_back(device->worker_core_from_logical_core({x, 0}).x);
     }
-    std::vector<uint32_t> noc_y_coords;
-    noc_y_coords.reserve(num_cores_y);
     for (uint32_t y = 0; y < num_cores_y; ++y) {
-        noc_y_coords.push_back(device->worker_core_from_logical_core({0, y}).y);
+        noc_coords.push_back(device->worker_core_from_logical_core({0, y}).y);
     }
+
+    // Runtime-arg schema shared by reader and writer (same kernel source, bound twice).
+    const std::vector<std::string> rt_arg_names = {
+        "head_size",
+        "num_q_heads",
+        "num_q_heads_per_core",
+        "remote_q_head_start_idx",
+        "start_q_x",
+        "start_q_y",
+        "q_start_offset",
+        "q_offset",
+        "read_kv_heads",
+        "num_kv_heads",
+        "num_kv_heads_per_core",
+        "remote_kv_head_start_idx",
+        "start_kv_x",
+        "start_kv_y",
+        "kv_base_offset",
+        "kv_start_offset",
+        "num_kv_tiles",
+        "num_x"};
+
+    // When a separate KV input tensor is present the kernel recovers its base from a second
+    // tensor binding; gate the binding and its kernel-side accessor on READ_FROM_INPUT_TENSOR_KV.
+    auto make_tensor_bindings = [&]() {
+        Group<TensorBinding> bindings = {
+            TensorBinding{.tensor_parameter_name = INPUT_Q_TENSOR, .accessor_name = "input_q"}};
+        if (read_from_input_tensor_kv) {
+            bindings.push_back(TensorBinding{.tensor_parameter_name = INPUT_KV_TENSOR, .accessor_name = "input_kv"});
+        }
+        return bindings;
+    };
+    Table<std::string, std::string> kv_defines;
+    if (read_from_input_tensor_kv) {
+        kv_defines.insert({"READ_FROM_INPUT_TENSOR_KV", "1"});
+    }
+
+    // Reader binds q_out (shared with writer) + k_out (reader-private). Writer binds q_out +
+    // v_out (writer-private). q_out is written by both kernels on the same nodes, so it is bound
+    // reader = PRODUCER / writer = CONSUMER; the reader-private k_out and writer-private v_out are
+    // self-looped (PRODUCER + CONSUMER on the single kernel that touches them).
+    KernelSpec reader_spec{
+        .unique_id = READER_KERNEL,
+        .source = std::filesystem::path{KERNEL_PATH},
+        .compiler_options = {.defines = kv_defines},
+        .dfb_bindings =
+            {DFBBinding{
+                 .dfb_spec_name = Q_OUT_DFB, .accessor_name = "q_out", .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{
+                 .dfb_spec_name = K_OUT_DFB, .accessor_name = "kv_out", .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{
+                 .dfb_spec_name = K_OUT_DFB, .accessor_name = "kv_out", .endpoint_type = DFBEndpointType::CONSUMER}},
+        .tensor_bindings = make_tensor_bindings(),
+        .runtime_arg_schema = {.runtime_arg_names = rt_arg_names},
+        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+    };
+    reader_spec.advanced_options.num_common_runtime_varargs = noc_coords.size();
+
+    KernelSpec writer_spec{
+        .unique_id = WRITER_KERNEL,
+        .source = std::filesystem::path{KERNEL_PATH},
+        .compiler_options = {.defines = kv_defines},
+        .dfb_bindings =
+            {DFBBinding{
+                 .dfb_spec_name = Q_OUT_DFB, .accessor_name = "q_out", .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{
+                 .dfb_spec_name = V_OUT_DFB, .accessor_name = "kv_out", .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{
+                 .dfb_spec_name = V_OUT_DFB, .accessor_name = "kv_out", .endpoint_type = DFBEndpointType::CONSUMER}},
+        .tensor_bindings = make_tensor_bindings(),
+        .runtime_arg_schema = {.runtime_arg_names = rt_arg_names},
+        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+    };
+    writer_spec.advanced_options.num_common_runtime_varargs = noc_coords.size();
+
+    KernelRunArgs reader_run{.kernel = READER_KERNEL};
+    KernelRunArgs writer_run{.kernel = WRITER_KERNEL};
+    reader_run.advanced_options.common_runtime_varargs = noc_coords;
+    writer_run.advanced_options.common_runtime_varargs = noc_coords;
 
     uint32_t remote_q_head_start_idx = 0;
     uint32_t remote_kv_head_start_idx = 0;
     uint32_t q_x = 0, q_y = 0, kv_x = 0, kv_y = 0;
-    uint32_t q_start_addr = q_base_addr;
-    uint32_t k_start_addr = k_base_addr;
-    uint32_t v_start_addr = v_base_addr;
+    // Offsets (relative to the source-shard bases) tracking the legacy q_start_addr / k_start_addr /
+    // v_start_addr cursors. The kernel adds the recovered accessor base to these.
+    uint32_t q_start_offset = 0;
+    uint32_t k_start_offset = kv_base_offset_reader;
+    uint32_t v_start_offset = kv_base_offset_writer;
 
     uint32_t remote_q_read = 0;
     uint32_t remote_kv_read = 0;
-    // TODO: convert to emplace_runtime_args(Buffer*) for fast cache-hit patching once the
-    // reader/writer kernel ABI is updated to accept (base_buffer, offset) pairs and compute
-    // q_start_addr = get_arg_val(base_pos) + get_arg_val(offset_pos) in-kernel.  Today both
-    // q_base_addr and q_start_addr are baked as raw uint32_t (q_start_addr = q_base_addr +
-    // remote_q_head_start_idx * head_size), and similarly for K/V whose base addresses are
-    // themselves computed offsets into the input (or kv) buffer rather than standalone
-    // buffers, which makes a clean BufferBinding registration non-trivial.  No BufferBinding
-    // is registered for this op, so the contract-1 adapter falls back to the slow-path
-    // rebuild via apply_descriptor_runtime_args on cache hits (see
-    // mesh_device_operation_adapter.hpp apply_descriptor — Contract-1 branch with empty
-    // resolved_bindings.rt_args), which correctly refreshes the addresses, just not as fast.
     for (uint32_t i = 0; i < num_cores; ++i) {
-        const auto& core = cores[i];
+        const NodeCoord core = cores[i];
         bool read_kv_heads = i < k_cores.num_cores();
-        std::vector<uint32_t> reader_runtime_args;
-        reader_runtime_args.reserve(18 + num_cores_x + num_cores_y);
-        reader_runtime_args = {
-            head_size,
-            per_risc0_out_q_heads,
-            per_core_in_q_heads,
-            remote_q_head_start_idx,
-            q_x,
-            q_y,
-            q_base_addr,
-            q_start_addr,
-            0,
-            read_kv_heads,
-            per_core_out_kv_heads,
-            per_core_in_kv_heads,
-            remote_kv_head_start_idx,
-            kv_x,
-            kv_y,
-            k_base_addr,
-            k_start_addr,
-            k_num_tiles,
-            num_cores_x,
-        };
-        reader_runtime_args.insert(reader_runtime_args.end(), noc_x_coords.begin(), noc_x_coords.end());
-        reader_runtime_args.insert(reader_runtime_args.end(), noc_y_coords.begin(), noc_y_coords.end());
+
+        // RISC0 (reader) per-node runtime args.
+        KernelRunArgs::RuntimeArgValues reader_args{
+            {"head_size", head_size},
+            {"num_q_heads", per_risc0_out_q_heads},
+            {"num_q_heads_per_core", per_core_in_q_heads},
+            {"remote_q_head_start_idx", remote_q_head_start_idx},
+            {"start_q_x", q_x},
+            {"start_q_y", q_y},
+            {"q_start_offset", q_start_offset},
+            {"q_offset", 0u},
+            {"read_kv_heads", static_cast<uint32_t>(read_kv_heads)},
+            {"num_kv_heads", per_core_out_kv_heads},
+            {"num_kv_heads_per_core", per_core_in_kv_heads},
+            {"remote_kv_head_start_idx", remote_kv_head_start_idx},
+            {"start_kv_x", kv_x},
+            {"start_kv_y", kv_y},
+            {"kv_base_offset", kv_base_offset_reader},
+            {"kv_start_offset", k_start_offset},
+            {"num_kv_tiles", k_num_tiles},
+            {"num_x", num_cores_x}};
 
         remote_q_read += per_risc0_out_q_heads;
         q_y = (remote_q_read / per_core_in_q_heads) / num_cores_x;
         q_x = (remote_q_read / per_core_in_q_heads) % num_cores_x;
         remote_q_head_start_idx = (remote_q_head_start_idx + per_risc0_out_q_heads) % per_core_in_q_heads;
-        q_start_addr = q_base_addr + remote_q_head_start_idx * head_size;
+        q_start_offset = remote_q_head_start_idx * head_size;
 
-        reader_desc.runtime_args.emplace_back(core, reader_runtime_args);
+        reader_run.runtime_arg_values.push_back({core, reader_args});
 
-        reader_runtime_args[1] = per_risc1_out_q_heads;
-        reader_runtime_args[3] = remote_q_head_start_idx;
-        reader_runtime_args[4] = q_x;
-        reader_runtime_args[5] = q_y;
-        reader_runtime_args[7] = q_start_addr;
-        reader_runtime_args[8] = per_risc0_out_q_heads * head_size;
+        // RISC1 (writer) per-node runtime args: same layout, advanced for the second half of Q.
+        KernelRunArgs::RuntimeArgValues writer_args = reader_args;
+        writer_args["num_q_heads"] = per_risc1_out_q_heads;
+        writer_args["remote_q_head_start_idx"] = remote_q_head_start_idx;
+        writer_args["start_q_x"] = q_x;
+        writer_args["start_q_y"] = q_y;
+        writer_args["q_start_offset"] = q_start_offset;
+        writer_args["q_offset"] = per_risc0_out_q_heads * head_size;
 
         if (per_risc1_out_q_heads > 0) {
             remote_q_read += per_risc1_out_q_heads;
             q_y = (remote_q_read / per_core_in_q_heads) / num_cores_x;
             q_x = (remote_q_read / per_core_in_q_heads) % num_cores_x;
             remote_q_head_start_idx = (per_risc1_out_q_heads + remote_q_head_start_idx) % per_core_in_q_heads;
-            q_start_addr = q_base_addr + remote_q_head_start_idx * head_size;
+            q_start_offset = remote_q_head_start_idx * head_size;
         }
 
         if (read_kv_heads) {
-            reader_runtime_args[15] = v_base_addr;
-            reader_runtime_args[16] = v_start_addr;
+            writer_args["kv_base_offset"] = kv_base_offset_writer;
+            writer_args["kv_start_offset"] = v_start_offset;
             remote_kv_read += per_core_out_kv_heads;
             kv_y = (remote_kv_read / per_core_in_kv_heads) / num_cores_x;
             kv_x = (remote_kv_read / per_core_in_kv_heads) % num_cores_x;
             remote_kv_head_start_idx = (remote_kv_head_start_idx + per_core_out_kv_heads) % per_core_in_kv_heads;
-            k_start_addr = k_base_addr + remote_kv_head_start_idx * head_size;
-            v_start_addr = v_base_addr + remote_kv_head_start_idx * head_size;
+            k_start_offset = kv_base_offset_reader + remote_kv_head_start_idx * head_size;
+            v_start_offset = kv_base_offset_writer + remote_kv_head_start_idx * head_size;
         }
 
-        writer_desc.runtime_args.emplace_back(core, std::move(reader_runtime_args));
+        writer_run.runtime_arg_values.push_back({core, writer_args});
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    WorkUnitSpec wu{
+        .name = "nlp_create_qkv_heads_sharded",
+        .kernels = {READER_KERNEL, WRITER_KERNEL},
+        .target_nodes = q_cores,
+    };
 
-    return desc;
+    Group<TensorParameter> tensor_params = {input_q_param, q_out_param, k_out_param, v_out_param};
+    if (read_from_input_tensor_kv) {
+        tensor_params.push_back(
+            TensorParameter{.unique_id = INPUT_KV_TENSOR, .spec = input_tensor_kv.value().tensor_spec()});
+    }
+
+    ProgramSpec spec{
+        .name = "nlp_create_qkv_heads_sharded",
+        .kernels = {reader_spec, writer_spec},
+        .dataflow_buffers = {q_out_dfb_spec, k_out_dfb_spec, v_out_dfb_spec},
+        .tensor_parameters = tensor_params,
+        .work_units = {wu},
+    };
+
+    ProgramRunArgs run_args;
+    run_args.kernel_run_args = {reader_run, writer_run};
+    run_args.tensor_args = {
+        {INPUT_Q_TENSOR, TensorArgument{input_tensor.mesh_tensor()}},
+        {Q_OUT_TENSOR, TensorArgument{std::get<0>(output).mesh_tensor()}},
+        {K_OUT_TENSOR, TensorArgument{std::get<1>(output).mesh_tensor()}},
+        {V_OUT_TENSOR, TensorArgument{std::get<2>(output).mesh_tensor()}}};
+    if (read_from_input_tensor_kv) {
+        run_args.tensor_args.insert({INPUT_KV_TENSOR, TensorArgument{input_tensor_kv.value().mesh_tensor()}});
+    }
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::operations::experimental::transformer


### PR DESCRIPTION
Split out from #46909 (umbrella tracking thread) to keep each op migration reviewable on its own. Part of the Metal 2.0 op-migration batch.

Ports nlp_create_qkv_heads (interleaved + sharded) to `MetalV2FactoryConcept`. ✅ BH 111 passed; ✅ craq-sim + emu PCC 1.0 (incl. transpose-K).

**Draft** — see #46909 for the full tracking table and Quasar (craq-sim / emulator) validation status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vsureshTT/metal2-nlp-create-qkv-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vsureshTT/metal2-nlp-create-qkv-heads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vsureshTT/metal2-nlp-create-qkv-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vsureshTT/metal2-nlp-create-qkv-heads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vsureshTT/metal2-nlp-create-qkv-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vsureshTT/metal2-nlp-create-qkv-heads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vsureshTT/metal2-nlp-create-qkv-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vsureshTT/metal2-nlp-create-qkv-heads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vsureshTT/metal2-nlp-create-qkv-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vsureshTT/metal2-nlp-create-qkv-heads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vsureshTT/metal2-nlp-create-qkv-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vsureshTT/metal2-nlp-create-qkv-heads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vsureshTT/metal2-nlp-create-qkv-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vsureshTT/metal2-nlp-create-qkv-heads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vsureshTT/metal2-nlp-create-qkv-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vsureshTT/metal2-nlp-create-qkv-heads)