### PR TITLE
[Metal 2.0] Port topk single-core to create_program_artifacts

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
@@ -10,6 +10,7 @@
 #include "api/compute/reconfig_data_format.h"
 #include "api/compute/pack.h"
 #include "api/dataflow/circular_buffer.h"
+#include "experimental/kernel_args.h"
 
 /**
  * Transpose tiles from width-height to height-width format and pack to destination buffer
@@ -21,8 +22,8 @@
  */
 FORCE_INLINE void transpose_and_pack(
     const uint32_t input_cb_index, const uint32_t dest_cb_index, const uint32_t total_tiles) {
-    CircularBuffer input_cb(input_cb_index);
-    CircularBuffer dest_cb(dest_cb_index);
+    DataflowBuffer input_cb(input_cb_index);
+    DataflowBuffer dest_cb(dest_cb_index);
 
     // Configure data formats for transpose operation.
     // Pack using the DESTINATION CB format: input_cb may be bf16 (higher-precision
@@ -97,7 +98,7 @@ FORCE_INLINE void read_cb_and_transpose(const uint32_t cb, const uint32_t base_o
  * @param count   Number of tiles to wait for and then remove from the front of the buffer
  */
 FORCE_INLINE void cb_wait_pop_front(const uint32_t cb, const uint32_t count) {
-    CircularBuffer cb_obj(cb);
+    DataflowBuffer cb_obj(cb);
     cb_obj.wait_front(count);
     cb_obj.pop_front(count);
 }
@@ -110,40 +111,41 @@ FORCE_INLINE void cb_wait_pop_front(const uint32_t cb, const uint32_t count) {
  * @param count   Number of tile slots to reserve at the back and then mark as available
  */
 FORCE_INLINE void cb_reserve_push_back(const uint32_t cb, const uint32_t count) {
-    CircularBuffer cb_obj(cb);
+    DataflowBuffer cb_obj(cb);
     cb_obj.reserve_back(count);
     cb_obj.push_back(count);
 }
 
 void kernel_main() {
     // Runtime arguments
-    const uint32_t work_per_core = get_arg_val<uint32_t>(0);
+    const uint32_t work_per_core = get_arg(args::work_per_core);
 
-    // Compile time args
-    constexpr uint32_t input_val_cb_index = get_compile_time_arg_val(0);        // Input values circular buffer
-    constexpr uint32_t input_ind_cb_index = get_compile_time_arg_val(1);        // Input indices circular buffer
-    constexpr uint32_t transposed_val_cb_index = get_compile_time_arg_val(2);   // Transposed values buffer
-    constexpr uint32_t transposed_ind_cb_index = get_compile_time_arg_val(3);   // Transposed indices buffer
-    constexpr uint32_t result_prep_val_cb_index = get_compile_time_arg_val(4);  // Result preparation values buffer
-    constexpr uint32_t result_prep_ind_cb_index = get_compile_time_arg_val(5);  // Result preparation indices buffer
-    constexpr uint32_t output_val_cb_index = get_compile_time_arg_val(6);       // Final output values buffer
-    constexpr uint32_t output_ind_cb_index = get_compile_time_arg_val(7);       // Final output indices buffer
-    constexpr uint32_t Ht = get_compile_time_arg_val(8);                        // Height in tiles
-    constexpr uint32_t Wt = get_compile_time_arg_val(9);                        // Width in tiles
-    constexpr uint32_t output_tiles = get_compile_time_arg_val(10);             // Number of output tiles (ceil(K/32))
-    constexpr uint32_t largest = get_compile_time_arg_val(11);                  // 1 for largest K, 0 for smallest K
+    // Compile time args. CB indices arrive as named DFB handles (constexpr-usable via the
+    // DFBAccessor->uint32_t conversion), preserving the runtime-dynamic CB-selection logic below.
+    constexpr uint32_t input_val_cb_index = (uint32_t)dfb::cb_in0;                 // Input values circular buffer
+    constexpr uint32_t input_ind_cb_index = (uint32_t)dfb::cb_index;               // Input indices circular buffer
+    constexpr uint32_t transposed_val_cb_index = (uint32_t)dfb::transposed_val;    // Transposed values buffer
+    constexpr uint32_t transposed_ind_cb_index = (uint32_t)dfb::transposed_ind;    // Transposed indices buffer
+    constexpr uint32_t result_prep_val_cb_index = (uint32_t)dfb::result_prep_val;  // Result preparation values buffer
+    constexpr uint32_t result_prep_ind_cb_index = (uint32_t)dfb::result_prep_ind;  // Result preparation indices buffer
+    constexpr uint32_t output_val_cb_index = (uint32_t)dfb::output_val;            // Final output values buffer
+    constexpr uint32_t output_ind_cb_index = (uint32_t)dfb::output_ind;            // Final output indices buffer
+    constexpr uint32_t Ht = get_arg(args::Ht);                                     // Height in tiles
+    constexpr uint32_t Wt = get_arg(args::Wt);                                     // Width in tiles
+    constexpr uint32_t output_tiles = get_arg(args::Ktiles);  // Number of output tiles (ceil(K/32))
+    constexpr uint32_t largest = get_arg(args::largest);      // 1 for largest K, 0 for smallest K
 
     // Initialize kernel components
     ckernel::topk_tile_init();
     transpose_wh_init(input_val_cb_index, output_val_cb_index);
     transpose_wh_init(input_ind_cb_index, output_ind_cb_index);
 
-    CircularBuffer input_val_cb(input_val_cb_index);
-    CircularBuffer input_ind_cb(input_ind_cb_index);
-    CircularBuffer transposed_val_cb(transposed_val_cb_index);
-    CircularBuffer transposed_ind_cb(transposed_ind_cb_index);
-    CircularBuffer result_prep_val_cb(result_prep_val_cb_index);
-    CircularBuffer result_prep_ind_cb(result_prep_ind_cb_index);
+    DataflowBuffer input_val_cb(input_val_cb_index);
+    DataflowBuffer input_ind_cb(input_ind_cb_index);
+    DataflowBuffer transposed_val_cb(transposed_val_cb_index);
+    DataflowBuffer transposed_ind_cb(transposed_ind_cb_index);
+    DataflowBuffer result_prep_val_cb(result_prep_val_cb_index);
+    DataflowBuffer result_prep_ind_cb(result_prep_ind_cb_index);
 
     constexpr uint32_t DST_VAL = 0;
     constexpr uint32_t DST_IND = 2;
@@ -303,8 +305,8 @@ void kernel_main() {
 
                 // Prepare data for merge operation
                 // Wait for required tiles to be available
-                CircularBuffer cb0_obj(cb0);
-                CircularBuffer cb1_obj(cb1);
+                DataflowBuffer cb0_obj(cb0);
+                DataflowBuffer cb1_obj(cb1);
                 cb0_obj.wait_front(in_cb_offset);  // Wait for existing sorted data
                 cb1_obj.wait_front(in_cb_offset);
                 if (transposed_offset == 0) {

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_tensor.cpp
@@ -8,40 +8,36 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "api/tensor/tensor_accessor.h"
+#include "experimental/kernel_args.h"
 
 #include <cstdint>
 
 void kernel_main() {
     // Runtime arguments
-    const uint32_t src_addr = get_arg_val<uint32_t>(0);
-    const uint32_t id = get_arg_val<uint32_t>(1);
-    const uint32_t work_per_core = get_arg_val<uint32_t>(2);
+    const uint32_t id = get_arg(args::id);
+    const uint32_t work_per_core = get_arg(args::work_per_core);
 
     // Compile time arguments
-    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
-    constexpr uint32_t cb_intermed_index = get_compile_time_arg_val(1);
-    constexpr uint32_t Ht = get_compile_time_arg_val(2);
-    constexpr uint32_t Wt = get_compile_time_arg_val(3);
-    constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(4);
-    constexpr bool uint16_output = get_compile_time_arg_val(5) == 1;
-    constexpr auto inout_tensor_args = TensorAccessorArgs<6>();
+    constexpr uint32_t Ht = get_arg(args::Ht);
+    constexpr uint32_t Wt = get_arg(args::Wt);
+    constexpr uint32_t total_number_of_cores = get_arg(args::total_number_of_cores);
+    constexpr bool uint16_output = get_arg(args::uint16_output) == 1;
 
 #if not GENERATE_INDICES
     // Precomputed indices tensor accessor
-    constexpr auto indices_args = TensorAccessorArgs<inout_tensor_args.next_compile_time_args_offset()>();
-    const uint32_t src_indices_addr = get_arg_val<uint32_t>(3);
-    const auto indices_accessor = TensorAccessor(indices_args, src_indices_addr);
+    const auto indices_accessor = TensorAccessor(ta::indices);
 #endif  // not GENERATE_INDICES
 
     // Constants
     constexpr uint32_t onetile = 1;
 
     // Tensor accessor
-    const auto inout_tensor_accessor = TensorAccessor(inout_tensor_args, src_addr);
+    const auto inout_tensor_accessor = TensorAccessor(ta::input);
 
     Noc noc;
-    CircularBuffer cb_in0(cb_id_in0);
-    CircularBuffer cb_index(cb_intermed_index);
+    DataflowBuffer cb_in0(dfb::cb_in0);
+    DataflowBuffer cb_index(dfb::cb_index);
     const uint32_t tile_bytes_in0 = cb_in0.get_tile_size();
 #if not GENERATE_INDICES
     const uint32_t tile_bytes_index = cb_index.get_tile_size();
@@ -59,9 +55,9 @@ void kernel_main() {
             cb_in0.push_back(onetile);
 #if GENERATE_INDICES
             if (uint16_output) {
-                generate_index_tile<uint16_t>(cb_intermed_index, w);
+                generate_index_tile<uint16_t>(dfb::cb_index, w);
             } else {
-                generate_index_tile<uint32_t>(cb_intermed_index, w);
+                generate_index_tile<uint32_t>(dfb::cb_index, w);
             }
 #else
             // Read precomputed indices to circular buffer

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_tensor.cpp
@@ -38,9 +38,9 @@ void kernel_main() {
     Noc noc;
     DataflowBuffer cb_in0(dfb::cb_in0);
     DataflowBuffer cb_index(dfb::cb_index);
-    const uint32_t tile_bytes_in0 = cb_in0.get_tile_size();
+    const uint32_t tile_bytes_in0 = cb_in0.get_entry_size();
 #if not GENERATE_INDICES
-    const uint32_t tile_bytes_index = cb_index.get_tile_size();
+    const uint32_t tile_bytes_index = cb_index.get_entry_size();
 #endif
 
     // Read data and generate indices

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_binary_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_binary_interleaved.cpp
@@ -6,33 +6,29 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "api/tensor/tensor_accessor.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
     // Runtime args
-    const uint32_t dst_addr0 = get_arg_val<uint32_t>(0);
-    const uint32_t dst_addr1 = get_arg_val<uint32_t>(1);
-    const uint32_t id = get_arg_val<uint32_t>(2);
-    const uint32_t work_per_core = get_arg_val<uint32_t>(3);
+    const uint32_t id = get_arg(args::id);
+    const uint32_t work_per_core = get_arg(args::work_per_core);
 
     // Compile time args
-    constexpr uint32_t values_cb_index = get_compile_time_arg_val(0);
-    constexpr uint32_t output_ind_cb_index = get_compile_time_arg_val(1);
-    constexpr uint32_t Ht = get_compile_time_arg_val(2);
-    constexpr uint32_t Kt = get_compile_time_arg_val(3);
-    constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(4);
-    constexpr auto values_tensor_args = TensorAccessorArgs<5>();
-    constexpr auto indices_tensor_args = TensorAccessorArgs<values_tensor_args.next_compile_time_args_offset()>();
+    constexpr uint32_t Ht = get_arg(args::Ht);
+    constexpr uint32_t Kt = get_arg(args::Kt);
+    constexpr uint32_t total_number_of_cores = get_arg(args::total_number_of_cores);
 
     // Constants
     constexpr uint32_t onetile = 1;
 
     // Tensor config
-    const auto values_tensor_accessor = TensorAccessor(values_tensor_args, dst_addr0);
-    const auto indices_tensor_accessor = TensorAccessor(indices_tensor_args, dst_addr1);
+    const auto values_tensor_accessor = TensorAccessor(ta::value);
+    const auto indices_tensor_accessor = TensorAccessor(ta::index);
 
     Noc noc;
-    CircularBuffer values_cb(values_cb_index);
-    CircularBuffer indices_cb(output_ind_cb_index);
+    DataflowBuffer values_cb(dfb::output_val);
+    DataflowBuffer indices_cb(dfb::output_ind);
     const uint32_t tile_bytes_val = values_cb.get_tile_size();
     const uint32_t tile_bytes_idx = indices_cb.get_tile_size();
 

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_binary_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_binary_interleaved.cpp
@@ -29,8 +29,8 @@ void kernel_main() {
     Noc noc;
     DataflowBuffer values_cb(dfb::output_val);
     DataflowBuffer indices_cb(dfb::output_ind);
-    const uint32_t tile_bytes_val = values_cb.get_tile_size();
-    const uint32_t tile_bytes_idx = indices_cb.get_tile_size();
+    const uint32_t tile_bytes_val = values_cb.get_entry_size();
+    const uint32_t tile_bytes_idx = indices_cb.get_entry_size();
 
     // Get Kt rows of values and then Kt rows of indices from compute kernel
     for (uint32_t core_loop = 0; core_loop < work_per_core; core_loop++) {

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.hpp
@@ -8,6 +8,8 @@
 
 #include "ttnn/operations/reduction/topk/device/topk_device_operation_types.hpp"
 
+#include "ttnn/device_operation.hpp"
+#include "ttnn/metal_v2_artifacts.hpp"
 #include <tt-metalium/program_descriptors.hpp>
 
 #include <optional>
@@ -22,7 +24,7 @@ struct TopKDeviceOperation {
     using tensor_return_value_t = std::tuple<Tensor, Tensor>;
 
     struct TopKSingleCoreProgramFactory {
-        static tt::tt_metal::ProgramDescriptor create_descriptor(
+        static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value);

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_single_core_program_factory.cpp
@@ -5,32 +5,58 @@
 #include "ttnn/operations/reduction/topk/device/topk_device_operation.hpp"
 
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 #include "tt-metalium/work_split.hpp"
 
-#include <map>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+
+#include <limits>
 #include <string>
+#include <vector>
 
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
-tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKSingleCoreProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts TopKDeviceOperation::TopKSingleCoreProgramFactory::create_program_artifacts(
     const TopkParams& operation_attributes,
     const TopkInputs& tensor_args,
     std::tuple<Tensor, Tensor>& tensor_return_value) {
+    // Metal 2.0 named resource handles (locals to avoid unity-build name collisions).
+    const DFBSpecName CB_IN0{"cb_in0"};
+    const DFBSpecName CB_INDEX{"cb_index"};
+    const DFBSpecName TRANSPOSED_VAL{"transposed_val"};
+    const DFBSpecName TRANSPOSED_IND{"transposed_ind"};
+    const DFBSpecName RESULT_PREP_VAL{"result_prep_val"};
+    const DFBSpecName RESULT_PREP_IND{"result_prep_ind"};
+    const DFBSpecName OUTPUT_VAL{"output_val"};
+    const DFBSpecName OUTPUT_IND{"output_ind"};
+
+    const TensorParamName INPUT_TENSOR{"input"};
+    const TensorParamName VALUE_TENSOR{"value"};
+    const TensorParamName INDEX_TENSOR{"index"};
+
+    const KernelSpecName READER_KERNEL{"reader"};
+    const KernelSpecName WRITER_KERNEL{"writer"};
+    const KernelSpecName COMPUTE_KERNEL{"compute"};
+
+    constexpr const char* READER_PATH =
+        "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_tensor.cpp";
+    constexpr const char* WRITER_PATH =
+        "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_binary_interleaved.cpp";
+    constexpr const char* COMPUTE_PATH = "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp";
+
     const auto& args = operation_attributes;
     auto& output_tensors = tensor_return_value;
     // Tensor references
-    const auto& input_tensor = tensor_args.input.mesh_tensor();
-    const auto& value_tensor = std::get<0>(output_tensors).mesh_tensor();
-    const auto& index_tensor = std::get<1>(output_tensors).mesh_tensor();
+    const auto& input_tensor = tensor_args.input;
+    const auto& value_tensor = std::get<0>(output_tensors);
+    const auto& index_tensor = std::get<1>(output_tensors);
 
     // Determine index output format based on dimension size constraints
     const ttnn::Shape input_shape = input_tensor.padded_shape();
     const bool uint16_output = (input_shape[args.dim] < std::numeric_limits<uint16_t>::max());
-
-    ProgramDescriptor desc;
 
     // Data format conversions for circular buffer configurations
     const tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
@@ -90,205 +116,227 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKSingleCoreProgramFactor
     const uint32_t result_prep_cb_tile_count = 2 * Ktiles;  // Intermediate TopK results (double-buffered)
     const uint32_t output_cb_tile_count = Ktiles;           // Final output buffer
 
-    // Circular Buffer Creations:
-    constexpr uint32_t input_cb_index = tt::CBIndex::c_0;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = input_cb_tile_count * input_tile_size,
-        .core_ranges = core_range,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(input_cb_index),
-            .data_format = input_cb_data_format,
-            .page_size = input_tile_size,
-        }}},
-    });
-
-    constexpr uint32_t index_cb_index = tt::CBIndex::c_1;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = input_cb_tile_count * index_tile_size,
-        .core_ranges = core_range,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(index_cb_index),
-            .data_format = output_ind_cb_data_format,
-            .page_size = index_tile_size,
-        }}},
-    });
-
-    // Uses bf16 when input is bfp8/bfp4 so that the insertion sort operates at higher
-    // precision and avoids shared-exponent corruption of tiles adjacent to inf values.
-    constexpr uint32_t transposed_val_cb_index = tt::CBIndex::c_2;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = transposed_cb_tile_count * compute_tile_size,
-        .core_ranges = core_range,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(transposed_val_cb_index),
-            .data_format = compute_cb_data_format,
-            .page_size = compute_tile_size,
-        }}},
-    });
-
-    constexpr uint32_t transposed_ind_cb_index = tt::CBIndex::c_3;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = transposed_cb_tile_count * index_tile_size,
-        .core_ranges = core_range,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(transposed_ind_cb_index),
-            .data_format = output_ind_cb_data_format,
-            .page_size = index_tile_size,
-        }}},
-    });
-
-    // Uses bf16 when input is bfp8/bfp4 (same rationale as transposed_val_cb_index).
-    constexpr uint32_t result_prep_val_cb_index = tt::CBIndex::c_4;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = result_prep_cb_tile_count * compute_tile_size,
-        .core_ranges = core_range,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(result_prep_val_cb_index),
-            .data_format = compute_cb_data_format,
-            .page_size = compute_tile_size,
-        }}},
-    });
-
-    constexpr uint32_t result_prep_ind_cb_index = tt::CBIndex::c_5;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = result_prep_cb_tile_count * index_tile_size,
-        .core_ranges = core_range,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(result_prep_ind_cb_index),
-            .data_format = output_ind_cb_data_format,
-            .page_size = index_tile_size,
-        }}},
-    });
-
-    constexpr uint32_t output_val_cb_index = tt::CBIndex::c_6;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = output_cb_tile_count * value_tile_size,
-        .core_ranges = core_range,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(output_val_cb_index),
-            .data_format = output_val_cb_data_format,
-            .page_size = value_tile_size,
-        }}},
-    });
-
-    constexpr uint32_t output_ind_cb_index = tt::CBIndex::c_7;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = output_cb_tile_count * index_tile_size,
-        .core_ranges = core_range,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(output_ind_cb_index),
-            .data_format = output_ind_cb_data_format,
-            .page_size = index_tile_size,
-        }}},
-    });
-
-    // Kernel Creations:
-    std::vector<uint32_t> reader_compile_time_args = {
-        input_cb_index,                       // Input values
-        index_cb_index,                       // Generated indices
-        Ht,                                   // Height in tiles
-        Wt,                                   // Width in tiles
-        total_number_of_cores,                // Total number of cores
-        static_cast<uint32_t>(uint16_output)  // Index format flag
+    // ----------------------------------------------------------------------------
+    // DataflowBufferSpecs (legacy CBs c_0..c_7, all normal/non-borrowed). The bf16
+    // staging buffers (c_2..c_5) preserve sort precision for bfp8/bfp4 inputs.
+    // ----------------------------------------------------------------------------
+    DataflowBufferSpec cb_in0_spec{
+        .unique_id = CB_IN0,
+        .entry_size = input_tile_size,
+        .num_entries = input_cb_tile_count,
+        .data_format_metadata = input_cb_data_format,
     };
-    tt::tt_metal::TensorAccessorArgs(input_tensor).append_to(reader_compile_time_args);
-    if (tensor_args.indices.has_value()) {
-        tt::tt_metal::TensorAccessorArgs(tensor_args.indices->mesh_tensor()).append_to(reader_compile_time_args);
-    }
-    const std::map<std::string, std::string> reader_defines_map = {
-        {"GENERATE_INDICES", "1"},  // tensor_args.indices.has_value() ? "0" : "1" - GH issue: #36329
+    DataflowBufferSpec cb_index_spec{
+        .unique_id = CB_INDEX,
+        .entry_size = index_tile_size,
+        .num_entries = input_cb_tile_count,
+        .data_format_metadata = output_ind_cb_data_format,
     };
-    KernelDescriptor::Defines reader_defines(reader_defines_map.begin(), reader_defines_map.end());
-
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_tensor.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = core_range;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.defines = std::move(reader_defines);
-    reader_desc.config = ReaderConfigDescriptor{};
-
-    std::vector<uint32_t> writer_compile_time_args = {
-        output_val_cb_index,   // CB6: Output values
-        output_ind_cb_index,   // CB7: Output indices
-        Ht,                    // Height in tiles
-        Ktiles,                // K value in tiles
-        total_number_of_cores  // Total number of cores
+    DataflowBufferSpec transposed_val_spec{
+        .unique_id = TRANSPOSED_VAL,
+        .entry_size = compute_tile_size,
+        .num_entries = transposed_cb_tile_count,
+        .data_format_metadata = compute_cb_data_format,
     };
-    tt::tt_metal::TensorAccessorArgs(value_tensor).append_to(writer_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(index_tensor).append_to(writer_compile_time_args);
-
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_binary_interleaved.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = core_range;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterConfigDescriptor{};
-
-    const std::vector<uint32_t> compute_args = {
-        input_cb_index,                            // Input values
-        index_cb_index,                            // Input indices
-        transposed_val_cb_index,                   // Transposed values
-        transposed_ind_cb_index,                   // Transposed indices
-        result_prep_val_cb_index,                  // Result prep values
-        result_prep_ind_cb_index,                  // Result prep indices
-        output_val_cb_index,                       // Output values
-        output_ind_cb_index,                       // Output indices
-        Ht,                                        // Height in tiles
-        Wt,                                        // Width in tiles
-        Ktiles,                                    // K value in tiles
-        static_cast<std::uint32_t>(args.largest),  // Sort order: largest (true) or smallest (false)
+    DataflowBufferSpec transposed_ind_spec{
+        .unique_id = TRANSPOSED_IND,
+        .entry_size = index_tile_size,
+        .num_entries = transposed_cb_tile_count,
+        .data_format_metadata = output_ind_cb_data_format,
+    };
+    DataflowBufferSpec result_prep_val_spec{
+        .unique_id = RESULT_PREP_VAL,
+        .entry_size = compute_tile_size,
+        .num_entries = result_prep_cb_tile_count,
+        .data_format_metadata = compute_cb_data_format,
+    };
+    DataflowBufferSpec result_prep_ind_spec{
+        .unique_id = RESULT_PREP_IND,
+        .entry_size = index_tile_size,
+        .num_entries = result_prep_cb_tile_count,
+        .data_format_metadata = output_ind_cb_data_format,
+    };
+    DataflowBufferSpec output_val_spec{
+        .unique_id = OUTPUT_VAL,
+        .entry_size = value_tile_size,
+        .num_entries = output_cb_tile_count,
+        .data_format_metadata = output_val_cb_data_format,
+    };
+    DataflowBufferSpec output_ind_spec{
+        .unique_id = OUTPUT_IND,
+        .entry_size = index_tile_size,
+        .num_entries = output_cb_tile_count,
+        .data_format_metadata = output_ind_cb_data_format,
     };
 
-    KernelDescriptor compute_desc;
-    compute_desc.kernel_source = "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp";
-    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    compute_desc.core_ranges = core_range;
-    compute_desc.compile_time_args = compute_args;
-    compute_desc.config = ComputeConfigDescriptor{
-        .fp32_dest_acc_en = !uint16_output,
-        .dst_full_sync_en = false,
+    // ----------------------------------------------------------------------------
+    // Tensor parameters. The optional precomputed-indices tensor is only bound on
+    // the dead `#if not GENERATE_INDICES` reader path (GENERATE_INDICES is hardcoded
+    // "1"); on the always-on path no indices TensorParameter is bound.
+    // ----------------------------------------------------------------------------
+    TensorParameter input_param{.unique_id = INPUT_TENSOR, .spec = input_tensor.tensor_spec()};
+    TensorParameter value_param{.unique_id = VALUE_TENSOR, .spec = value_tensor.tensor_spec()};
+    TensorParameter index_param{.unique_id = INDEX_TENSOR, .spec = index_tensor.tensor_spec()};
+
+    // ----------------------------------------------------------------------------
+    // Reader: streams input tiles into cb_in0 (c_0) and generates index tiles into
+    // cb_index (c_1, via generate_index_tile). GENERATE_INDICES is hardcoded "1"
+    // (GH issue #36329), keeping the indices-tensor read path dead.
+    // ----------------------------------------------------------------------------
+    KernelSpec reader_spec{
+        .unique_id = READER_KERNEL,
+        .source = std::filesystem::path{READER_PATH},
+        .compiler_options = {.defines = {{"GENERATE_INDICES", "1"}}},
+        .dfb_bindings =
+            {DFBBinding{.dfb_spec_name = CB_IN0, .accessor_name = "cb_in0", .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{
+                 .dfb_spec_name = CB_INDEX, .accessor_name = "cb_index", .endpoint_type = DFBEndpointType::PRODUCER}},
+        .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT_TENSOR, .accessor_name = "input"}},
+        .compile_time_args =
+            {{"Ht", Ht},
+             {"Wt", Wt},
+             {"total_number_of_cores", total_number_of_cores},
+             {"uint16_output", static_cast<uint32_t>(uint16_output)}},
+        .runtime_arg_schema = {.runtime_arg_names = {"id", "work_per_core"}},
+        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
     };
+
+    // ----------------------------------------------------------------------------
+    // Writer: consumes output_val (c_6) and output_ind (c_7), writes the value and
+    // index output tensors page-by-page (Case 1 TensorAccessor).
+    // ----------------------------------------------------------------------------
+    KernelSpec writer_spec{
+        .unique_id = WRITER_KERNEL,
+        .source = std::filesystem::path{WRITER_PATH},
+        .dfb_bindings =
+            {DFBBinding{
+                 .dfb_spec_name = OUTPUT_VAL,
+                 .accessor_name = "output_val",
+                 .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{
+                 .dfb_spec_name = OUTPUT_IND,
+                 .accessor_name = "output_ind",
+                 .endpoint_type = DFBEndpointType::CONSUMER}},
+        .tensor_bindings =
+            {TensorBinding{.tensor_parameter_name = VALUE_TENSOR, .accessor_name = "value"},
+             TensorBinding{.tensor_parameter_name = INDEX_TENSOR, .accessor_name = "index"}},
+        .compile_time_args = {{"Ht", Ht}, {"Kt", Ktiles}, {"total_number_of_cores", total_number_of_cores}},
+        .runtime_arg_schema = {.runtime_arg_names = {"id", "work_per_core"}},
+        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+    };
+
+    // ----------------------------------------------------------------------------
+    // Compute: consumes c_0/c_1, runs the insertion sort over the c_2..c_5 staging
+    // self-loops (PRODUCER+CONSUMER on this same compute kernel), produces c_6/c_7.
+    // The kernel performs runtime-dynamic CB selection over the staging buffers.
+    // ----------------------------------------------------------------------------
+    KernelSpec compute_spec{
+        .unique_id = COMPUTE_KERNEL,
+        .source = std::filesystem::path{COMPUTE_PATH},
+        .dfb_bindings =
+            {DFBBinding{.dfb_spec_name = CB_IN0, .accessor_name = "cb_in0", .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{
+                 .dfb_spec_name = CB_INDEX, .accessor_name = "cb_index", .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{
+                 .dfb_spec_name = TRANSPOSED_VAL,
+                 .accessor_name = "transposed_val",
+                 .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{
+                 .dfb_spec_name = TRANSPOSED_VAL,
+                 .accessor_name = "transposed_val",
+                 .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{
+                 .dfb_spec_name = TRANSPOSED_IND,
+                 .accessor_name = "transposed_ind",
+                 .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{
+                 .dfb_spec_name = TRANSPOSED_IND,
+                 .accessor_name = "transposed_ind",
+                 .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{
+                 .dfb_spec_name = RESULT_PREP_VAL,
+                 .accessor_name = "result_prep_val",
+                 .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{
+                 .dfb_spec_name = RESULT_PREP_VAL,
+                 .accessor_name = "result_prep_val",
+                 .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{
+                 .dfb_spec_name = RESULT_PREP_IND,
+                 .accessor_name = "result_prep_ind",
+                 .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{
+                 .dfb_spec_name = RESULT_PREP_IND,
+                 .accessor_name = "result_prep_ind",
+                 .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{
+                 .dfb_spec_name = OUTPUT_VAL,
+                 .accessor_name = "output_val",
+                 .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{
+                 .dfb_spec_name = OUTPUT_IND,
+                 .accessor_name = "output_ind",
+                 .endpoint_type = DFBEndpointType::PRODUCER}},
+        .compile_time_args =
+            {{"Ht", Ht}, {"Wt", Wt}, {"Ktiles", Ktiles}, {"largest", static_cast<uint32_t>(args.largest)}},
+        .runtime_arg_schema = {.runtime_arg_names = {"work_per_core"}},
+        .hw_config =
+            ComputeHardwareConfig{
+                .fp32_dest_acc_en = !uint16_output,
+                .dst_full_sync_en = false,
+            },
+    };
+
+    // ----------------------------------------------------------------------------
+    // Per-core runtime args: id (core offset) and work_per_core (tiles for this core).
+    // ----------------------------------------------------------------------------
+    KernelRunArgs reader_run{.kernel = READER_KERNEL};
+    KernelRunArgs writer_run{.kernel = WRITER_KERNEL};
+    KernelRunArgs compute_run{.kernel = COMPUTE_KERNEL};
 
     uint32_t id = 0;  // Offset for the next core in the group
     for (const auto& [group, work_per_core] : work_groups) {
         for (const auto& range : group.ranges()) {
             for (const auto& core : range) {
-                reader_desc.emplace_runtime_args(
-                    core,
-                    {
-                        input_tensor,
-                        id,
-                        work_per_core,
-                        tensor_args.indices.has_value()
-                            ? static_cast<uint32_t>(tensor_args.indices->mesh_tensor().address())
-                            : 0u,  // Optional indices tensor
-                    });
-                writer_desc.emplace_runtime_args(
-                    core,
-                    {
-                        value_tensor,
-                        index_tensor,
-                        id,
-                        work_per_core,
-                    });
-                compute_desc.runtime_args.emplace_back(
-                    core,
-                    KernelDescriptor::CoreRuntimeArgs{
-                        work_per_core,
-                    });
+                const NodeCoord node = core;
+                reader_run.runtime_arg_values.push_back({node, {{"id", id}, {"work_per_core", work_per_core}}});
+                writer_run.runtime_arg_values.push_back({node, {{"id", id}, {"work_per_core", work_per_core}}});
+                compute_run.runtime_arg_values.push_back({node, {{"work_per_core", work_per_core}}});
                 id++;
             }
         }
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
-    desc.kernels.push_back(std::move(compute_desc));
+    WorkUnitSpec wu{
+        .name = "topk_single_core",
+        .kernels = {READER_KERNEL, WRITER_KERNEL, COMPUTE_KERNEL},
+        .target_nodes = core_range,
+    };
 
-    return desc;
+    ProgramSpec spec{
+        .name = "topk_single_core",
+        .kernels = {reader_spec, writer_spec, compute_spec},
+        .dataflow_buffers =
+            {cb_in0_spec,
+             cb_index_spec,
+             transposed_val_spec,
+             transposed_ind_spec,
+             result_prep_val_spec,
+             result_prep_ind_spec,
+             output_val_spec,
+             output_ind_spec},
+        .tensor_parameters = {input_param, value_param, index_param},
+        .work_units = {wu},
+    };
+
+    ProgramRunArgs run_args;
+    run_args.kernel_run_args = {reader_run, writer_run, compute_run};
+    run_args.tensor_args = {
+        {INPUT_TENSOR, TensorArgument{std::cref(input_tensor.mesh_tensor())}},
+        {VALUE_TENSOR, TensorArgument{std::cref(value_tensor.mesh_tensor())}},
+        {INDEX_TENSOR, TensorArgument{std::cref(index_tensor.mesh_tensor())}}};
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::prim


### PR DESCRIPTION
Split out from #46909 (umbrella tracking thread) to keep each op migration reviewable on its own. Part of the Metal 2.0 op-migration batch.

Ports topk single-core factory to `MetalV2FactoryConcept` + Quasar `get_entry_size`. ✅ BH 117 passed; Quasar blocked on UInt16 allow-list (tracked).

**Draft** — see #46909 for the full tracking table and Quasar (craq-sim / emulator) validation status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vsureshTT/metal2-topk)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vsureshTT/metal2-topk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vsureshTT/metal2-topk)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vsureshTT/metal2-topk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vsureshTT/metal2-topk)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vsureshTT/metal2-topk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vsureshTT/metal2-topk)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vsureshTT/metal2-topk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vsureshTT/metal2-topk)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vsureshTT/metal2-topk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vsureshTT/metal2-topk)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vsureshTT/metal2-topk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vsureshTT/metal2-topk)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vsureshTT/metal2-topk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vsureshTT/metal2-topk)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vsureshTT/metal2-topk)