### PR TITLE
[Metal 2.0] Port matmul MatmulMultiCore to create_program_artifacts

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_matmul_multicore.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_matmul_multicore.cpp
@@ -229,7 +229,12 @@ TEST_P(MatmulMulticoreFixture, MatmulMulticoreAccuracy) {
 INSTANTIATE_TEST_SUITE_P(
     MatmulMulticoreTests,
     MatmulMulticoreFixture,
-    ::testing::Values(MatmulMulticoreParam{2048, 2048, 2048}, MatmulMulticoreParam{2080, 2048, 64}),
+    ::testing::Values(
+        // Minimal single-tile smoke case (M=K=N=32 -> 1 output tile). Fast enough to run on
+        // the Quasar emulator's single worker core; the large shapes below are HW regressions.
+        MatmulMulticoreParam{32, 32, 32},
+        MatmulMulticoreParam{2048, 2048, 2048},
+        MatmulMulticoreParam{2080, 2048, 64}),
     [](const testing::TestParamInfo<MatmulMulticoreParam>& info) {
         return fmt::format("M{}_K{}_N{}", info.param.M, info.param.K, info.param.N);
     });

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_program_factory.cpp
@@ -10,25 +10,41 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/work_split.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 
 using namespace tt;
 using namespace tt::constants;
-using tt::tt_metal::CBDescriptor;
-using tt::tt_metal::CBFormatDescriptor;
-using tt::tt_metal::ComputeConfigDescriptor;
-using tt::tt_metal::KernelDescriptor;
-using tt::tt_metal::ProgramDescriptor;
-using tt::tt_metal::ReaderConfigDescriptor;
-using tt::tt_metal::WriterConfigDescriptor;
+using namespace tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
-ProgramDescriptor MatmulMultiCoreProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts MatmulMultiCoreProgramFactory::create_program_artifacts(
     const ttnn::prim::MatmulParams& operation_attributes,
     const ttnn::prim::MatmulInputs& tensor_args,
-    std::vector<ttnn::Tensor>& tensor_return_value,
-    const std::optional<CoreRangeSet>& /*core_range_set*/) {
+    std::vector<ttnn::Tensor>& tensor_return_value) {
+    // Metal 2.0 named resource handles for the interleaved multi-core matmul ProgramSpec.
+    // (Declared as locals — not in a file-scope anon namespace — to avoid unity-build collisions.)
+    const DFBSpecName IN0_DFB{"in0"};  // legacy CB c_0
+    const DFBSpecName IN1_DFB{"in1"};  // legacy CB c_1
+    const DFBSpecName OUT_DFB{"out"};  // legacy CB c_16
+    const TensorParamName IN0_TENSOR{"in0"};
+    const TensorParamName IN1_TENSOR{"in1"};
+    const TensorParamName OUT_TENSOR{"out"};
+    const KernelSpecName READER_KERNEL{"reader"};
+    const KernelSpecName WRITER_KERNEL{"writer"};
+    const KernelSpecName COMPUTE_KERNEL_G1{"compute_g1"};
+    const KernelSpecName COMPUTE_KERNEL_G2{"compute_g2"};
+    // Forked Metal 2.0 kernel sources (the legacy copies remain for the generic-op gtest, which
+    // still constructs a ProgramDescriptor that binds the positional-arg originals).
+    constexpr const char* READER_PATH =
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/"
+        "reader_bmm_8bank_output_tiles_partitioned_metal2.cpp";
+    constexpr const char* WRITER_PATH =
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/writer_unary_interleaved_start_id_metal2.cpp";
+    constexpr const char* COMPUTE_PATH = "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_metal2.cpp";
+
     if (!tensor_args.optional_input_tensors.empty()) {
         TT_FATAL(!tensor_args.optional_input_tensors[0].has_value(), "Bias is not supported for matmul multi core");
     }
@@ -96,70 +112,152 @@ ProgramDescriptor MatmulMultiCoreProgramFactory::create_descriptor(
     uint32_t MtKt = Mt * Kt;
     uint32_t MtNt = Mt * Nt;
 
-    ProgramDescriptor desc;
-
-    // Circular buffers
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Dataflow buffers (legacy CBs)
+    ////////////////////////////////////////////////////////////////////////////
     uint32_t num_input_tiles = 2;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_input_tiles * in0_single_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = 0,
-            .data_format = in0_data_format,
-            .page_size = in0_single_tile_size,
-        }}},
-    });
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_input_tiles * in1_single_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = 1,
-            .data_format = in1_data_format,
-            .page_size = in1_single_tile_size,
-        }}},
-    });
-    uint32_t output_cb_index = tt::CBIndex::c_16;
     uint32_t num_output_tiles = 2;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_output_tiles * output_single_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = output_cb_index,
-            .data_format = output_data_format,
-            .page_size = output_single_tile_size,
-        }}},
-    });
+    DataflowBufferSpec in0_dfb_spec{
+        .unique_id = IN0_DFB,
+        .entry_size = in0_single_tile_size,
+        .num_entries = num_input_tiles,
+        .data_format_metadata = in0_data_format,
+    };
+    DataflowBufferSpec in1_dfb_spec{
+        .unique_id = IN1_DFB,
+        .entry_size = in1_single_tile_size,
+        .num_entries = num_input_tiles,
+        .data_format_metadata = in1_data_format,
+    };
+    DataflowBufferSpec out_dfb_spec{
+        .unique_id = OUT_DFB,
+        .entry_size = output_single_tile_size,
+        .num_entries = num_output_tiles,
+        .data_format_metadata = output_data_format,
+    };
 
-    // Reader kernel
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Tensor parameters
+    ////////////////////////////////////////////////////////////////////////////
+    Group<TensorParameter> tensor_params = {
+        TensorParameter{.unique_id = IN0_TENSOR, .spec = a.tensor_spec()},
+        TensorParameter{.unique_id = IN1_TENSOR, .spec = b.tensor_spec()},
+        TensorParameter{.unique_id = OUT_TENSOR, .spec = output.tensor_spec()}};
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Reader kernel
+    ////////////////////////////////////////////////////////////////////////////
+    // last_ktile_w handles a logical K that is not a multiple of TILE_WIDTH (the reader pads the
+    // last K tile). last_ktile_h is always 0 here (no transposed-last-tile padding).
     uint32_t last_ktile_w = a.logical_shape()[-1] % TILE_WIDTH;
     uint32_t last_ktile_h = 0;
-    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)last_ktile_w, (uint32_t)last_ktile_h};
-    tt::tt_metal::TensorAccessorArgs(a).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(b).append_to(reader_compile_time_args);
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = reader_compile_time_args;
-    reader_desc.named_compile_time_args = {{"cb_in0", tt::CBIndex::c_0}, {"cb_in1", tt::CBIndex::c_1}};
-    reader_desc.config = ReaderConfigDescriptor{};
+    KernelSpec reader_spec{
+        .unique_id = READER_KERNEL,
+        .source = std::filesystem::path{READER_PATH},
+        .dfb_bindings =
+            {DFBBinding{
+                 .dfb_spec_name = IN0_DFB, .accessor_name = "cb_in0", .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{
+                 .dfb_spec_name = IN1_DFB, .accessor_name = "cb_in1", .endpoint_type = DFBEndpointType::PRODUCER}},
+        .tensor_bindings =
+            {TensorBinding{.tensor_parameter_name = IN0_TENSOR, .accessor_name = "src0"},
+             TensorBinding{.tensor_parameter_name = IN1_TENSOR, .accessor_name = "src1"}},
+        .compile_time_args = {{"in0_last_ktile_w", last_ktile_w}, {"in0_last_ktile_h", last_ktile_h}},
+        .runtime_arg_schema =
+            {.runtime_arg_names =
+                 {"Mt",
+                  "Kt",
+                  "Nt",
+                  "MtKt",
+                  "KtNt",
+                  "batch",
+                  "bcast_B",
+                  "output_tile_start_id",
+                  "num_output_tiles",
+                  "MtNt"}},
+        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+    };
 
-    // Writer kernel
-    std::vector<uint32_t> writer_compile_time_args = {};
-    tt::tt_metal::TensorAccessorArgs(output).append_to(writer_compile_time_args);
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Writer kernel
+    ////////////////////////////////////////////////////////////////////////////
+    KernelSpec writer_spec{
+        .unique_id = WRITER_KERNEL,
+        .source = std::filesystem::path{WRITER_PATH},
+        .dfb_bindings = {DFBBinding{
+            .dfb_spec_name = OUT_DFB, .accessor_name = "cb_out", .endpoint_type = DFBEndpointType::CONSUMER}},
+        .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUT_TENSOR, .accessor_name = "dst"}},
+        .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
+        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+    };
 
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = writer_compile_time_args;
-    writer_desc.named_compile_time_args = {{"cb_out", output_cb_index}};
-    writer_desc.config = WriterConfigDescriptor{};
+    Group<KernelSpec> kernels = {reader_spec, writer_spec};
 
-    // Per-core runtime args for reader and writer
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Compute kernel(s)
+    ////////////////////////////////////////////////////////////////////////////
+    const auto throttle_level = ttnn::get_throttle_level(operation_attributes.compute_kernel_config);
+    std::map<std::string, std::string> mm_kernel_defines;
+    ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
+        device->arch(), num_cores, mm_kernel_defines);
+    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
+        device->arch(), num_cores, mm_kernel_defines, throttle_level);
+
+    // One compute KernelSpec per work-split core group, differing only in the per-group output-tile
+    // count (carried as a compile-time arg — multiplicity preserved, not demoted to an RTA).
+    // bmm compute kernel: B, Mt, Nt are just 3 for loops that act as 1 large loop, so only set Nt.
+    auto make_compute_spec = [&](const KernelSpecName& unique_id, uint32_t num_output_tiles_per_core_group) {
+        ComputeHardwareConfig compute_hw{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .math_approx_mode = math_approx_mode};
+        // For a Float32 input DFB consumed under fp32_dest_acc_en, the validator requires an explicit
+        // unpack-to-dest mode entry; legacy ComputeConfig defaulted the whole vector to Default.
+        //
+        // We MUST use Default (unpack via SrcA/B), NOT UnpackToDestFp32. matmul_tiles is an FPU
+        // binary op: it reads its two operands from the SrcA/SrcB register files. UnpackToDestFp32
+        // routes the unpacker straight to the Dest register and DISABLES SrcA/B access for that DFB,
+        // so the FPU would multiply garbage -> inf/wrong results. fp32_dest_acc_en already gives the
+        // 32-bit-wide Dest accumulator the matmul needs; the inputs still go through SrcA/B (~19-bit),
+        // exactly as the legacy factory (all-Default vector) did.
+        if (fp32_dest_acc_en) {
+            if (in0_data_format == tt::DataFormat::Float32) {
+                compute_hw.unpack_to_dest_mode.insert({IN0_DFB, tt::tt_metal::UnpackToDestMode::Default});
+            }
+            if (in1_data_format == tt::DataFormat::Float32) {
+                compute_hw.unpack_to_dest_mode.insert({IN1_DFB, tt::tt_metal::UnpackToDestMode::Default});
+            }
+        }
+        return KernelSpec{
+            .unique_id = unique_id,
+            .source = std::filesystem::path{COMPUTE_PATH},
+            .compiler_options = {.defines = Table<std::string, std::string>(mm_kernel_defines)},
+            .dfb_bindings =
+                {DFBBinding{
+                     .dfb_spec_name = IN0_DFB, .accessor_name = "cb_in0", .endpoint_type = DFBEndpointType::CONSUMER},
+                 DFBBinding{
+                     .dfb_spec_name = IN1_DFB, .accessor_name = "cb_in1", .endpoint_type = DFBEndpointType::CONSUMER},
+                 DFBBinding{
+                     .dfb_spec_name = OUT_DFB, .accessor_name = "cb_out", .endpoint_type = DFBEndpointType::PRODUCER}},
+            .compile_time_args = {{"batch", 1}, {"Mt", 1}, {"Kt", Kt}, {"Nt", num_output_tiles_per_core_group}},
+            .hw_config = compute_hw,
+        };
+    };
+
+    const bool group_2_present = !core_group_2.ranges().empty();
+    kernels.push_back(make_compute_spec(COMPUTE_KERNEL_G1, num_output_tiles_per_core_group_1));
+    if (group_2_present) {
+        kernels.push_back(make_compute_spec(COMPUTE_KERNEL_G2, num_output_tiles_per_core_group_2));
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Per-core runtime args (reader + writer)
+    ////////////////////////////////////////////////////////////////////////////
+    KernelRunArgs reader_run{.kernel = READER_KERNEL};
+    KernelRunArgs writer_run{.kernel = WRITER_KERNEL};
+
     for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
@@ -171,74 +269,59 @@ ProgramDescriptor MatmulMultiCoreProgramFactory::create_descriptor(
         } else {
             TT_THROW("Core not in specified core ranges");
         }
-        reader_desc.emplace_runtime_args(
-            core,
-            {a,
-             b,
-             Mt,
-             Kt,
-             Nt,
-             MtKt,
-             KtNt,
-             B,
-             uint32_t(bcast_batch),
-             num_tiles_written,
-             num_output_tiles_per_core,
-             MtNt});
-        writer_desc.emplace_runtime_args(core, {output, num_output_tiles_per_core, num_tiles_written});
+
+        reader_run.runtime_arg_values.push_back(
+            {core,
+             {{"Mt", Mt},
+              {"Kt", Kt},
+              {"Nt", Nt},
+              {"MtKt", MtKt},
+              {"KtNt", KtNt},
+              {"batch", B},
+              {"bcast_B", uint32_t(bcast_batch)},
+              {"output_tile_start_id", num_tiles_written},
+              {"num_output_tiles", num_output_tiles_per_core},
+              {"MtNt", MtNt}}});
+        writer_run.runtime_arg_values.push_back(
+            {core, {{"num_pages", num_output_tiles_per_core}, {"start_id", num_tiles_written}}});
         num_tiles_written += num_output_tiles_per_core;
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
-
-    const auto throttle_level = ttnn::get_throttle_level(operation_attributes.compute_kernel_config);
-    std::map<std::string, std::string> mm_kernel_defines;
-    ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
-        device->arch(), num_cores, mm_kernel_defines);
-    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
-        device->arch(), num_cores, mm_kernel_defines, throttle_level);
-
-    // Compute kernel(s) — one per core group with different tile counts
-    // bmm compute kernel: B, Mt, Nt are just 3 for loops that act as 1 large loop,
-    // so only set Nt for simplicity
-    std::vector<uint32_t> compute_args_group_1 = {1, 1, Kt, num_output_tiles_per_core_group_1};
-
-    KernelDescriptor compute_desc_1;
-    compute_desc_1.kernel_source = "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm.cpp";
-    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    compute_desc_1.core_ranges = core_group_1;
-    compute_desc_1.compile_time_args = compute_args_group_1;
-    compute_desc_1.named_compile_time_args = {
-        {"cb_in0", tt::CBIndex::c_0}, {"cb_in1", tt::CBIndex::c_1}, {"cb_out", tt::CBIndex::c_16}};
-    compute_desc_1.defines = {mm_kernel_defines.begin(), mm_kernel_defines.end()};
-    compute_desc_1.config = ComputeConfigDescriptor{
-        .math_fidelity = math_fidelity,
-        .fp32_dest_acc_en = fp32_dest_acc_en,
-        .dst_full_sync_en = dst_full_sync_en,
-        .math_approx_mode = math_approx_mode};
-    desc.kernels.push_back(std::move(compute_desc_1));
-
-    if (!core_group_2.ranges().empty()) {
-        std::vector<uint32_t> compute_args_group_2 = {1, 1, Kt, num_output_tiles_per_core_group_2};
-
-        KernelDescriptor compute_desc_2;
-        compute_desc_2.kernel_source = "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm.cpp";
-        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        compute_desc_2.core_ranges = core_group_2;
-        compute_desc_2.compile_time_args = compute_args_group_2;
-        compute_desc_2.named_compile_time_args = {
-            {"cb_in0", tt::CBIndex::c_0}, {"cb_in1", tt::CBIndex::c_1}, {"cb_out", tt::CBIndex::c_16}};
-        compute_desc_2.defines = {mm_kernel_defines.begin(), mm_kernel_defines.end()};
-        compute_desc_2.config = ComputeConfigDescriptor{
-            .math_fidelity = math_fidelity,
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .dst_full_sync_en = dst_full_sync_en,
-            .math_approx_mode = math_approx_mode};
-        desc.kernels.push_back(std::move(compute_desc_2));
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Work units
+    ////////////////////////////////////////////////////////////////////////////
+    // Reader/writer span all_cores; compute is split per work-split group, so each group gets its
+    // own WorkUnitSpec (reader + writer + per-group compute). A KernelSpec may appear in multiple
+    // WorkUnitSpecs; its effective node set is the union.
+    Group<WorkUnitSpec> work_units;
+    work_units.push_back(WorkUnitSpec{
+        .name = "matmul_multi_core_g1",
+        .kernels = {READER_KERNEL, WRITER_KERNEL, COMPUTE_KERNEL_G1},
+        .target_nodes = core_group_1});
+    if (group_2_present) {
+        work_units.push_back(WorkUnitSpec{
+            .name = "matmul_multi_core_g2",
+            .kernels = {READER_KERNEL, WRITER_KERNEL, COMPUTE_KERNEL_G2},
+            .target_nodes = core_group_2});
     }
 
-    return desc;
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Assemble spec + run args
+    ////////////////////////////////////////////////////////////////////////////
+    ProgramSpec spec{
+        .name = "matmul_multi_core",
+        .kernels = kernels,
+        .dataflow_buffers = {in0_dfb_spec, in1_dfb_spec, out_dfb_spec},
+        .tensor_parameters = tensor_params,
+        .work_units = work_units,
+    };
+
+    ProgramRunArgs run_args;
+    run_args.kernel_run_args = {reader_run, writer_run};
+    run_args.tensor_args = {
+        {IN0_TENSOR, TensorArgument{a}}, {IN1_TENSOR, TensorArgument{b}}, {OUT_TENSOR, TensorArgument{output}}};
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_program_factory.hpp
@@ -5,17 +5,16 @@
 #pragma once
 
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal_v2_artifacts.hpp"
 #include "ttnn/operations/matmul/device/matmul_device_operation_types.hpp"
-#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
 struct MatmulMultiCoreProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const ttnn::prim::MatmulParams& operation_attributes,
         const ttnn::prim::MatmulInputs& tensor_args,
-        std::vector<ttnn::Tensor>& tensor_return_value,
-        const std::optional<CoreRangeSet>& core_range_set = std::nullopt);
+        std::vector<ttnn::Tensor>& tensor_return_value);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_metal2.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of bmm.cpp. The legacy compute kernel is still bound by the generic-op gtest
+// (tests/ttnn/unit_tests/gtests/test_generic_op.cpp), which builds a ProgramDescriptor with
+// positional args, so the Metal 2.0 multi-core matmul factory binds a forked copy with named args
+// and DFB handles.
+
+#include <cstdint>
+
+#include "api/compute/matmul.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "experimental/kernel_args.h"
+
+using std::uint32_t;
+
+// matmul C=A*B using dims MK*KN = MN (row major order)
+//
+void kernel_main() {
+    constexpr int onetile = 1;
+
+    uint32_t batch = get_arg(args::batch);
+    uint32_t Mt = get_arg(args::Mt);
+    uint32_t Kt = get_arg(args::Kt);
+    uint32_t Nt = get_arg(args::Nt);
+
+    constexpr auto cb_in0 = dfb::cb_in0;
+    constexpr auto cb_in1 = dfb::cb_in1;
+    constexpr auto cb_out = dfb::cb_out;
+
+    DataflowBuffer in0_cb(cb_in0);
+    DataflowBuffer in1_cb(cb_in1);
+    DataflowBuffer out_cb(cb_out);
+
+    mm_init(cb_in0, cb_in1, cb_out);
+
+    // the simplest possible version of outer product blocked matmul
+    // the reader is expected to read the A's and B's tile rows and tile columns for each output tile
+    for (uint32_t nb = 0; nb < batch; nb++) {
+        for (uint32_t mt_C = 0; mt_C < Mt; ++mt_C) {    // output tile of C
+            for (uint32_t nt_C = 0; nt_C < Nt; ++nt_C)  // output tile index of C
+            {
+                tile_regs_acquire();
+                for (uint32_t kt = 0; kt < Kt; kt++) {
+                    in0_cb.wait_front(onetile);
+                    in1_cb.wait_front(onetile);
+
+                    matmul_tiles(cb_in0, cb_in1, 0, 0, 0);
+
+                    in0_cb.pop_front(onetile);
+                    in1_cb.pop_front(onetile);
+                }
+
+                tile_regs_commit();
+
+                out_cb.reserve_back(onetile);
+
+                tile_regs_wait();
+                pack_tile(0, cb_out);
+                tile_regs_release();
+
+                out_cb.push_back(onetile);
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned_metal2.cpp
@@ -58,8 +58,8 @@ void kernel_main() {
     DataflowBuffer cb_in0(cb_id_in0);
     DataflowBuffer cb_in1(cb_id_in1);
 
-    const uint32_t in0_tile_bytes = cb_in0.get_tile_size();
-    const uint32_t in1_tile_bytes = cb_in1.get_tile_size();
+    const uint32_t in0_tile_bytes = cb_in0.get_entry_size();
+    const uint32_t in1_tile_bytes = cb_in1.get_entry_size();
 
     for (uint32_t n = 0; n < num_output_tiles; n++) {
         for (uint32_t kt = 0; kt < Kt; kt++) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned_metal2.cpp
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of reader_bmm_8bank_output_tiles_partitioned.cpp. The legacy reader is still
+// bound by the generic-op gtest (tests/ttnn/unit_tests/gtests/test_generic_op.cpp), which builds a
+// ProgramDescriptor with positional args, so the Metal 2.0 multi-core matmul factory binds a forked
+// copy with named args, DFB handles, and typed tensor bindings.
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "ttnn/operations/kernel_helper_functions/pad_tile.hpp"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    // same arg indices as in reader_binary_diff_lengths for compat
+    uint32_t Mt = get_arg(args::Mt);
+    uint32_t Kt = get_arg(args::Kt);
+    uint32_t Nt = get_arg(args::Nt);
+    uint32_t MtKt = get_arg(args::MtKt);  // if 0
+    uint32_t KtNt = get_arg(args::KtNt);
+    uint32_t batch = get_arg(args::batch);
+    uint32_t bcast_B = get_arg(args::bcast_B);  // if 1 we broadcast B to batch
+    uint32_t output_tile_start_id = get_arg(args::output_tile_start_id);
+    uint32_t num_output_tiles = get_arg(args::num_output_tiles);
+    uint32_t MtNt = get_arg(args::MtNt);
+
+    constexpr uint32_t in0_last_ktile_w = get_arg(args::in0_last_ktile_w);
+    constexpr uint32_t in0_last_ktile_h = get_arg(args::in0_last_ktile_h);
+
+    // DPRINT("Mt={} Kt={} Nt={} MtKt={} KtNt={}\n", Mt, Kt, Nt, MtKt, KtNt);
+    // DPRINT("src0={} src1={}\n", src0_addr, src1_addr);
+    // DPRINT("batch={}\n", batch);
+
+    constexpr auto cb_id_in0 = dfb::cb_in0;
+    constexpr auto cb_id_in1 = dfb::cb_in1;
+
+    constexpr uint32_t onetile = 1;
+
+    uint32_t itileA = output_tile_start_id / Nt * Kt;  // input0 row = output row * input0 width
+
+    // Keep track of end of output row and end of output batch
+    uint32_t outbatch = output_tile_start_id % MtNt;
+    uint32_t itileB_batch = output_tile_start_id % Nt;
+    uint32_t itileB = itileB_batch;  // input1 col = output col if we are bcasting
+    if (bcast_B == 0) {
+        itileB += output_tile_start_id / MtNt * KtNt;  // offset into correct batch if not bcasting
+    }
+
+    const auto s0 = TensorAccessor(ta::src0);
+    const auto s1 = TensorAccessor(ta::src1);
+
+    Noc noc;
+    DataflowBuffer cb_in0(cb_id_in0);
+    DataflowBuffer cb_in1(cb_id_in1);
+
+    const uint32_t in0_tile_bytes = cb_in0.get_tile_size();
+    const uint32_t in1_tile_bytes = cb_in1.get_tile_size();
+
+    for (uint32_t n = 0; n < num_output_tiles; n++) {
+        for (uint32_t kt = 0; kt < Kt; kt++) {
+            {  // Read A's tile at (mt, kt)
+                cb_in0.reserve_back(onetile);
+                noc.async_read(s0, cb_in0, in0_tile_bytes, {.page_id = itileA}, {.offset_bytes = 0});
+                noc.async_read_barrier();
+                if constexpr (in0_last_ktile_w > 0) {
+                    if (kt == Kt - 1) {
+                        constexpr DataFormat in0_data_format = get_dataformat(cb_id_in0);
+                        pad_last_ktile<in0_data_format, in0_last_ktile_w>(cb_in0.get_write_ptr());
+                    }
+                }
+                if constexpr (in0_last_ktile_h > 0) {
+                    if (kt == Kt - 1) {
+                        constexpr DataFormat in0_data_format = get_dataformat(cb_id_in0);
+                        pad_last_transposed_ktile<in0_data_format, in0_last_ktile_h>(cb_in0.get_write_ptr());
+                    }
+                }
+                cb_in0.push_back(onetile);
+            }
+
+            {  // Read B's tile at (kt, nt)
+                cb_in1.reserve_back(onetile);
+                noc.async_read(s1, cb_in1, in1_tile_bytes, {.page_id = itileB}, {.offset_bytes = 0});
+                noc.async_read_barrier();
+                cb_in1.push_back(onetile);
+            }
+            // DPRINT("Pushed itileA={} itileB={}\n", itileA, itileB);
+
+            itileA += 1;   // A is MK
+            itileB += Nt;  // B is KN, so to get k++ we stride by Nt
+        }  // Kt loop
+        outbatch += 1;
+        itileB_batch += 1;
+        itileB -= KtNt;  // revert B to previous state before the K loop (to avoid multiplies)
+        itileB += 1;     // Move to next B col
+
+        if (itileB_batch == Nt) {
+            itileB_batch = 0;
+            itileB -= Nt;  // Go back to first column in batch
+            if (outbatch == MtNt) {
+                if (bcast_B == 0) {
+                    itileB += KtNt;  // Move B to start of next batch
+                }
+                outbatch = 0;
+            }
+        } else {
+            itileA -= Kt;  // resets tileA to kt=0, keep the same mt
+        }
+    }  // batch loop
+}

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned_metal2.cpp
@@ -51,8 +51,8 @@ void kernel_main() {
         itileB += output_tile_start_id / MtNt * KtNt;  // offset into correct batch if not bcasting
     }
 
-    const auto s0 = TensorAccessor(ta::src0);
-    const auto s1 = TensorAccessor(ta::src1);
+    const auto s0 = TensorAccessor(tensor::src0);
+    const auto s1 = TensorAccessor(tensor::src1);
 
     Noc noc;
     DataflowBuffer cb_in0(cb_id_in0);

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/writer_unary_interleaved_start_id_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/writer_unary_interleaved_start_id_metal2.cpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of writer_unary_interleaved_start_id.cpp. The legacy writer is still bound by the
+// generic-op gtest (tests/ttnn/unit_tests/gtests/test_generic_op.cpp), which builds a
+// ProgramDescriptor with positional args, so the Metal 2.0 multi-core matmul factory binds a forked
+// copy with named args, a DFB handle, and a typed tensor binding. (The non-matmul OUT_SHARDED /
+// BACKWARDS paths are dropped — the matmul multi-core factory exercises only the interleaved,
+// forward path.)
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    const uint32_t num_pages = get_arg(args::num_pages);
+    const uint32_t start_id = get_arg(args::start_id);
+
+    constexpr auto cb_id_out = dfb::cb_out;
+
+    Noc noc;
+    DataflowBuffer cb_out(cb_id_out);
+
+    // Get page size from the DFB (works for both TILE and ROW_MAJOR layouts)
+    const uint32_t page_bytes = cb_out.get_entry_size();
+
+    // single-page ublocks (works for both TILE and ROW_MAJOR layouts)
+    constexpr uint32_t onepage = 1;
+
+    const auto s = TensorAccessor(ta::dst);
+
+    uint32_t end_id = start_id + num_pages;
+    for (uint32_t i = start_id; i < end_id; ++i) {
+        cb_out.wait_front(onepage);
+        noc.async_write(cb_out, s, page_bytes, {.offset_bytes = 0}, {.page_id = i});
+        noc.async_writes_flushed();
+        cb_out.pop_front(onepage);
+    }
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/writer_unary_interleaved_start_id_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/writer_unary_interleaved_start_id_metal2.cpp
@@ -30,7 +30,7 @@ void kernel_main() {
     // single-page ublocks (works for both TILE and ROW_MAJOR layouts)
     constexpr uint32_t onepage = 1;
 
-    const auto s = TensorAccessor(ta::dst);
+    const auto s = TensorAccessor(tensor::dst);
 
     uint32_t end_id = start_id + num_pages;
     for (uint32_t i = start_id; i < end_id; ++i) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -2124,30 +2124,9 @@ MatmulDeviceOperation::tensor_return_value_t MatmulDeviceOperation::create_outpu
     return output_tensors;
 }
 
-ttsl::hash::hash_t MatmulDeviceOperation::compute_program_hash(
-    const operation_attributes_t& attributes, const tensor_args_t& args) {
-    const auto& input_tensors = args.input_tensors;
-    const auto& input_tensor_a = input_tensors.at(0);
-    const auto& input_tensor_b = input_tensors.at(1);
-
-    auto factory = select_program_factory(attributes, args);
-
-    auto hash = tt::tt_metal::operation::hash_operation<MatmulDeviceOperation>(
-        attributes, factory.index(), input_tensor_a, input_tensor_b);
-
-    for (const auto& optional_input_tensor : args.optional_input_tensors) {
-        if (optional_input_tensor.has_value()) {
-            hash = ttsl::hash::hash_objects(hash, optional_input_tensor.value());
-        }
-    }
-
-    for (const auto& optional_output_tensor : args.optional_output_tensors) {
-        if (optional_output_tensor.has_value()) {
-            hash = ttsl::hash::hash_objects(hash, optional_output_tensor.value());
-        }
-    }
-    return hash;
-}
+// NOTE: The custom MatmulDeviceOperation::compute_program_hash was deleted by the Metal 2.0
+// MatmulMultiCoreProgramFactory port, reverting to the default reflection-based TTNN hash. See the
+// header declaration site for the rationale.
 
 tt::tt_metal::operation::OpPerformanceModelGeneral<MatmulDeviceOperation::tensor_return_value_t>
 MatmulDeviceOperation::create_op_performance_model(

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.hpp
@@ -42,8 +42,12 @@ struct MatmulDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 
-    static ttsl::hash::hash_t compute_program_hash(
-        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+    // NOTE: No custom compute_program_hash. The Metal 2.0 MatmulMultiCoreProgramFactory port reverts
+    // to the default reflection-based TTNN hash (which folds in the full input+output TensorSpecs and
+    // the program_config that selects the factory). A custom hash that omits the output TensorSpec
+    // trips UpdateTensorArgs legality failures on program-cache hits for MetalV2FactoryConcept
+    // factories; the default hash is correct-by-construction. (Sanctioned device-op edit per the
+    // Metal 2.0 port recipe.)
 
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
@@ -1199,12 +1199,10 @@ void py_module(nb::module_& mod) {
             "compute_output_specs",
             &ttnn::prim::MatmulDeviceOperation::compute_output_specs,
             nb::arg("operation_attributes"),
-            nb::arg("tensor_args"))
-        .def_static(
-            "compute_program_hash",
-            &ttnn::prim::MatmulDeviceOperation::compute_program_hash,
-            nb::arg("operation_attributes"),
             nb::arg("tensor_args"));
+    // NOTE: The "compute_program_hash" pybind hook was removed by the Metal 2.0
+    // MatmulMultiCoreProgramFactory port, which deletes the custom MatmulDeviceOperation::
+    // compute_program_hash (reverting to the default reflection-based TTNN hash).
 
     // Bind MatmulMultiCoreReuseOptimizedProgramFactory for descriptor creation
     nb::class_<ttnn::prim::MatmulMultiCoreReuseOptimizedProgramFactory>(
@@ -1227,21 +1225,10 @@ void py_module(nb::module_& mod) {
             &ttnn::prim::MatmulMultiCoreReuseOptimizedProgramFactory::default_core_range,
             nb::arg("device"));
 
-    // Bind MatmulMultiCoreProgramFactory for descriptor creation
-    nb::class_<ttnn::prim::MatmulMultiCoreProgramFactory>(mod, "MatmulMultiCoreProgramFactory")
-        .def_static(
-            "create_descriptor",
-            [](const ttnn::prim::MatmulParams& operation_attributes,
-               const ttnn::prim::MatmulInputs& tensor_args,
-               std::vector<ttnn::Tensor>& tensor_return_value,
-               const std::optional<CoreRangeSet>& core_range_set) {
-                return ttnn::prim::MatmulMultiCoreProgramFactory::create_descriptor(
-                    operation_attributes, tensor_args, tensor_return_value, core_range_set);
-            },
-            nb::arg("operation_attributes"),
-            nb::arg("tensor_args"),
-            nb::arg("tensor_return_value"),
-            nb::arg("core_range_set") = std::nullopt);
+    // NOTE: MatmulMultiCoreProgramFactory no longer exposes a "create_descriptor" pybind hook — it
+    // was ported to the Metal 2.0 create_program_artifacts path (MetalV2FactoryConcept), so the
+    // legacy ProgramDescriptor entry point (and its pybind binding) was removed. The other five
+    // factories below remain on create_descriptor.
 
     // Bind MatmulMultiCoreReuseMcast1DProgramFactory for descriptor creation
     nb::class_<ttnn::prim::MatmulMultiCoreReuseMcast1DProgramFactory>(mod, "MatmulMultiCoreReuseMcast1DProgramFactory")


### PR DESCRIPTION
Split out from #46909 (umbrella tracking thread) to keep each op migration reviewable on its own. Part of the Metal 2.0 op-migration batch.

Ports MatmulMultiCoreProgramFactory to `MetalV2FactoryConcept` (deletes custom hash + pybind hook). Adds minimal {32,32,32} smoke param. ✅ BH 349+2; ✅ craq-sim + emu.

**Draft** — see #46909 for the full tracking table and Quasar (craq-sim / emulator) validation status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vsureshTT/metal2-matmul-multicore)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vsureshTT/metal2-matmul-multicore)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vsureshTT/metal2-matmul-multicore)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vsureshTT/metal2-matmul-multicore)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vsureshTT/metal2-matmul-multicore)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vsureshTT/metal2-matmul-multicore)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vsureshTT/metal2-matmul-multicore)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vsureshTT/metal2-matmul-multicore)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vsureshTT/metal2-matmul-multicore)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vsureshTT/metal2-matmul-multicore)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vsureshTT/metal2-matmul-multicore)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vsureshTT/metal2-matmul-multicore)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vsureshTT/metal2-matmul-multicore)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vsureshTT/metal2-matmul-multicore)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vsureshTT/metal2-matmul-multicore)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vsureshTT/metal2-matmul-multicore)