### PR TITLE
64-bit Indices in BFP8 Host Unpack and Tiled Slice Start-Offset

### DIFF
--- a/tt_metal/impl/data_format/bfloat8.cpp
+++ b/tt_metal/impl/data_format/bfloat8.cpp
@@ -92,11 +92,13 @@ std::vector<float> unpack_bfp8_tiles_into_float_vec(
     }
 
     int num_elements_in_dword = 4;
-    uint32_t size_bytes = bfp8_tiles.size() * num_elements_in_dword;  // each uint32_t contains 4 BFP8 values
+    // 64-bit: counts/indices below overflow uint32 for tensors > 4 GB.
+    uint64_t size_bytes =
+        static_cast<uint64_t>(bfp8_tiles.size()) * num_elements_in_dword;  // each uint32_t contains 4 BFP8 values
     uint32_t single_bfp8_tile_size =
         tile.has_value() ? tile->get_tile_size(tt::DataFormat::Bfp8_b) : tile_size(tt::DataFormat::Bfp8_b);
     TT_ASSERT(size_bytes % single_bfp8_tile_size == 0);
-    uint32_t num_tiles = size_bytes / single_bfp8_tile_size;
+    uint64_t num_tiles = size_bytes / single_bfp8_tile_size;
 
     int data_index;
     int subtile_r;
@@ -113,10 +115,10 @@ std::vector<float> unpack_bfp8_tiles_into_float_vec(
     uint32_t exp_word, sub_word_index;
 
     uint32_t num_float_in_tile = subtiles_in_tile_row * subtiles_in_tile_col * subtile_rows * subtile_cols;
-    uint32_t fp32_element_index = 0;
+    uint64_t fp32_element_index = 0;
     std::vector<float> float_vec;
     float_vec.resize(num_tiles * num_float_in_tile);
-    for (int tile_index = 0; tile_index < num_tiles; ++tile_index) {
+    for (uint64_t tile_index = 0; tile_index < num_tiles; ++tile_index) {
         for (int tr = 0; tr < subtiles_in_tile_row; ++tr) {
             for (int tc = 0; tc < subtiles_in_tile_col; ++tc) {
                 for (int i = 0; i < subtile_rows; ++i) {
@@ -126,15 +128,15 @@ std::vector<float> unpack_bfp8_tiles_into_float_vec(
                         data_index =
                             (tr * (subtiles_in_tile_col * face_HW / 4) + tc * (face_HW / 4) + i * (face_W / 4) +
                              j / 4);  // Each uint32_t contains 4 BFP8 values. Divide data index by 4.
-                        int tile_and_data_index = data_index + (num_bfp8_in_tile * tile_index);
+                        int64_t tile_and_data_index = data_index + (num_bfp8_in_tile * tile_index);
 
-                        int exponent_index = (data_index >> 4) + (num_bfp8_in_tile * tile_index);
+                        int64_t exponent_index = (data_index >> 4) + (num_bfp8_in_tile * tile_index);
 
                         // Extract the uint32_t value that stores the shared exponent for this set
                         // of data. Each 32 bit word is shared amongst 64 datums
                         exp_word = bfp8_tiles[exponent_index];
 
-                        int num_exponent_words_skip = tile_index * num_exp_words;
+                        int64_t num_exponent_words_skip = tile_index * num_exp_words;
                         sub_word_index = ((tile_and_data_index - num_exponent_words_skip) >> 2) &
                                          exp_bit_mask;  // Extract the byte in which the shared exponent is stored. Each
                                                         // byte is shared amongst 16 datums.
@@ -203,7 +205,7 @@ std::vector<float> unpack_bfp8_tiles_into_float_vec(
                         // Zero out lanes where mask_denormal is true
                         man = simde_mm256_blendv_epi8(man, simde_mm256_setzero_si256(), mask_denormal);
 
-                        uint32_t float_data_index;
+                        uint64_t float_data_index;
                         if (row_major_output) {
                             float_data_index = subtile_c + (tile_W * subtile_r) + (tile_index * num_float_in_tile);
                         } else {

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
@@ -27,9 +27,10 @@ inline __attribute__((always_inline)) uint32_t get_upper_dims_compressed(const t
 inline __attribute__((always_inline)) uint32_t
 get_upper_start_offset(const ttnn::Shape& shape, Layout layout, const ttnn::Shape& slice_start) {
     // offset for every dim except last 2
-    uint32_t start_offset = 0;
+    // 64-bit: shape.volume() (element count) overflows uint32 for tensors > 4 GB.
+    uint64_t start_offset = 0;
 
-    uint32_t num_pages = shape.volume();
+    uint64_t num_pages = shape.volume();
     if (layout == Layout::TILE) {
         num_pages /= tt::constants::TILE_HW;
     } else {
@@ -38,13 +39,13 @@ get_upper_start_offset(const ttnn::Shape& shape, Layout layout, const ttnn::Shap
     }
 
     for (uint32_t dim_outer = 0; dim_outer < shape.rank() - 2; dim_outer++) {
-        uint32_t compressed_dims = 1;
+        uint64_t compressed_dims = 1;
         for (uint32_t dim_inner = 0; dim_inner <= dim_outer; dim_inner++) {
             compressed_dims *= shape[dim_inner];
         }
         start_offset += (num_pages / compressed_dims) * slice_start[dim_outer];
     }
-    return start_offset;
+    return static_cast<uint32_t>(start_offset);  // page index, fits uint32
 }
 
 inline __attribute__((always_inline)) uint32_t


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Both the host `bfloat8` tile unpack and the tiled slice start-offset truncated element/byte/page counts to 32 bits, corrupting the host readback of any tensor whose per-device element volume exceeds 2^32 (~4.29e9 elements / >4 GB).

### Notes for reviewers
Surfaced by a 32-user disaggregated-prefill KV cache (per-device bf8 tensor ~8.4 GB): to_torch / per-slot ttnn.slice readback returned zeros/garbage for high slots, while an identical 17-user cache (<2^32 elements) read back correctly.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=asaigal/bf8-slice-readback-uint64)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:asaigal/bf8-slice-readback-uint64)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=asaigal/bf8-slice-readback-uint64)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:asaigal/bf8-slice-readback-uint64)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=asaigal/bf8-slice-readback-uint64)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:asaigal/bf8-slice-readback-uint64)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=asaigal/bf8-slice-readback-uint64)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:asaigal/bf8-slice-readback-uint64)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=asaigal/bf8-slice-readback-uint64)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:asaigal/bf8-slice-readback-uint64)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=asaigal/bf8-slice-readback-uint64)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:asaigal/bf8-slice-readback-uint64)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=asaigal/bf8-slice-readback-uint64)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:asaigal/bf8-slice-readback-uint64)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=asaigal/bf8-slice-readback-uint64)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:asaigal/bf8-slice-readback-uint64)