### PR TITLE
[examples] bh_dram_read: minimal DRAM read op + Blackhole bandwidth-saturation study

### DIFF
--- a/docs/superpowers/specs/2026-06-23-bh-dram-read-design.md
+++ b/docs/superpowers/specs/2026-06-23-bh-dram-read-design.md
@@ -1,0 +1,169 @@
+# bh_dram_read — Design
+
+**Date:** 2026-06-23
+**Status:** Approved (design), pending spec review
+
+## Summary
+
+`bh_dram_read` is a minimal, read-only TTNN operation intended as a clean
+skeleton for DRAM-read work (e.g. a bandwidth microbenchmark or a custom
+gather). The host API takes a single DRAM-resident input tensor and returns
+`void`. Internally it launches one device primitive whose program places **one
+worker (Tensor) core per DRAM bank**; each core reads the pages of the input
+tensor that live in its assigned bank into a circular buffer and discards them.
+There is no compute kernel and no writer kernel.
+
+The op is built on the modern descriptor-based program-factory API
+(Device 2.0 / "Metal2"): `ProgramDescriptor` + `KernelDescriptor` +
+`CBDescriptor`, with nanobind bindings, following the `examples/example`
+template.
+
+## Goals
+
+- Provide a working, minimal read-only op that compiles, binds to Python, and
+  runs on Blackhole.
+- Demonstrate the "one core per DRAM bank" placement pattern.
+- Keep the surface area small so it can be grown into a real op later.
+
+## Non-goals
+
+- No output tensor / data transform (read-only, void return).
+- No compute kernel, no writer kernel.
+- No performance tuning, multi-subchannel handling, or sharded-input support in
+  this first cut. Input is assumed DRAM **interleaved**.
+
+## Location & file layout
+
+Mirrors `ttnn/cpp/ttnn/operations/examples/example/`:
+
+```
+ttnn/cpp/ttnn/operations/examples/bh_dram_read/
+├── bh_dram_read.hpp                       # host API: void bh_dram_read(const Tensor&)
+├── bh_dram_read.cpp                       # host wrapper -> prim::bh_dram_read
+├── bh_dram_read_nanobind.hpp
+├── bh_dram_read_nanobind.cpp              # nanobind binding
+└── device/
+    ├── bh_dram_read_device_operation.hpp  # device op struct
+    ├── bh_dram_read_device_operation.cpp  # select factory / validate / specs / prim
+    ├── bh_dram_read_program_factory.cpp   # single descriptor factory
+    └── kernels/dataflow/
+        └── reader_bh_dram_read.cpp        # reader-only kernel
+```
+
+Registration: add the binding call to
+`ttnn/cpp/ttnn/operations/examples/examples_nanobind.cpp` (same place
+`bind_example_operation` is called), so it is exposed under the `examples`
+submodule. CMake source lists for the `examples` operations are updated to
+include the new `.cpp` files.
+
+## Components
+
+### 1. Host API (`bh_dram_read.hpp` / `.cpp`)
+
+```cpp
+namespace ttnn {
+void bh_dram_read(const Tensor& input_tensor);
+}
+```
+
+Implementation calls the primitive and discards its (aliased) return:
+
+```cpp
+void bh_dram_read(const Tensor& input_tensor) {
+    ttnn::prim::bh_dram_read(input_tensor);
+}
+```
+
+### 2. Device operation (`bh_dram_read_device_operation.hpp` / `.cpp`)
+
+Follows the `ExampleDeviceOperation` shape:
+
+- `operation_attributes_t` — empty for now (placeholder for future knobs).
+- `tensor_args_t` — `const Tensor& input_tensor;`
+- `spec_return_value_t = ttnn::TensorSpec;`
+- `tensor_return_value_t = Tensor;`
+- One program factory variant: `struct DramBankCore { static ProgramDescriptor
+  create_descriptor(...); };` and `program_factory_t = std::variant<DramBankCore>;`
+- `select_program_factory` returns `DramBankCore{}`.
+- `validate_on_program_cache_miss` asserts the input tensor is on device and in
+  DRAM (`input.memory_config().buffer_type() == BufferType::DRAM`) and is
+  interleaved.
+- `compute_output_specs` returns the input's spec; `create_output_tensors`
+  returns the **input tensor unchanged** (no new allocation — read-only).
+- `ttnn::prim::bh_dram_read(const Tensor&)` builds attributes + tensor_args and
+  calls `ttnn::device_operation::launch<BhDramReadDeviceOperation>(...)`.
+
+The aliased input as the "output" is what lets the host wrapper present a `void`
+API while satisfying the framework's requirement for a `tensor_return_value_t`.
+
+### 3. Program factory (`bh_dram_read_program_factory.cpp`)
+
+```
+num_banks = input.device()->num_dram_channels()
+page_size = input page size (bytes)
+total_pages = input.physical_volume() / TILE_HW   (interleaved, tiled)
+```
+
+- Select the first `num_banks` worker cores from the compute-with-storage grid
+  (row-major), core `i` ↔ bank `i`.
+- For each bank `i`, the pages that live in it (interleaved round-robin) are
+  `{ i, i+num_banks, i+2*num_banks, ... }`; count
+  `pages_in_bank_i = ceil((total_pages - i) / num_banks)` (0 if `i >= total_pages`).
+- One `CBDescriptor` (2 tiles deep) on all selected cores.
+- One reader `KernelDescriptor` (`ReaderConfigDescriptor`) on all selected
+  cores. Compile-time args: `page_size` (raw tile size, the read length) and
+  `aligned_page_size` (DRAM-aligned in-bank stride). Per-core runtime args:
+  `{ base_addr, bank_id=i, pages_in_bank_i }`.
+
+  Note: for interleaved DRAM buffers each bank stores its pages contiguously at
+  the DRAM-aligned page size, so the in-bank offset of the `s`-th page is
+  `s * aligned_page_size`, while the bytes read per page is `page_size`. The
+  exact stride is confirmed against the buffer's page layout during impl.
+- No writer, no compute kernel.
+
+### 4. Reader kernel (`reader_bh_dram_read.cpp`)
+
+```c
+// compile-time: page_size, aligned_page_size
+// runtime: base_addr, bank_id, num_pages
+for (s = 0; s < num_pages; ++s) {
+    cb_reserve_back(cb0, 1);
+    uint64_t noc_addr = get_noc_addr_from_bank_id<true>(bank_id, base_addr + s * aligned_page_size);
+    noc_async_read(noc_addr, get_write_ptr(cb0), page_size);
+    noc_async_read_barrier();
+    cb_push_back(cb0, 1);
+    cb_pop_front(cb0, 1);   // discard; reader-only
+}
+```
+
+`get_noc_addr_from_bank_id<true>(bank_id, base_addr + offset)` resolves to the
+bank's NOC base plus the in-bank byte offset; for an interleaved tiled tensor
+the `s`-th page in bank `i` sits at in-bank offset `s * aligned_page_size`.
+
+## Data flow
+
+```
+input (DRAM interleaved) ──> N worker cores (1 per bank)
+                              each core: read its bank's pages -> CB -> discard
+                            ──> void
+```
+
+## Error handling
+
+- `validate_on_program_cache_miss`: `TT_FATAL` if input is not on device, not
+  DRAM, or not interleaved.
+- If `total_pages < num_banks`, trailing cores get `num_pages = 0` and simply do
+  no reads (loop body skipped). Still placed so placement stays uniform.
+
+## Testing
+
+- C++/pytest smoke test: allocate a DRAM-interleaved tiled tensor, call
+  `ttnn.examples.bh_dram_read(t)` (exact Python path confirmed during impl),
+  assert it runs without error and the input tensor is unchanged.
+- Run on Blackhole (p150b) per the project build/test workflow.
+
+## Open questions / future work
+
+- Multi-subchannel DRAM (read from all subchannels of a bank) — deferred.
+- Sharded-input support — deferred.
+- Turning the discard loop into a timed bandwidth measurement — deferred.

--- a/docs/superpowers/specs/bh-dram-read-progress.md
+++ b/docs/superpowers/specs/bh-dram-read-progress.md
@@ -31,6 +31,7 @@ Tensor: 8192×8192 bf16 = 128 MiB, 65,536 tiles, 8 reader cores (one per bank).
 |---------|--------|----------------|-----------------|------|-------------|
 | v1 | TensorAccessor page-by-page, block of 8 + barrier per block | 17.4 | 139.3 | 188 | ~37% |
 | v2 | trid ring (8 in flight), 16 KB max NOC packets (MoE dm0 pattern) | 31.8 | 254.7 | 344 | ~67% |
+| v3 | v2 + **optimal NOC0 bank-adjacent core placement** (depth 2) | 46.3 | 370.7 | **500** | **~98%** |
 
 ### Notes
 - v1: serialized-ish; barrier per 8-page block, single NOC, page-granular reads.
@@ -44,7 +45,38 @@ Tensor: 8192×8192 bf16 = 128 MiB, 65,536 tiles, 8 reader cores (one per bank).
   187→344 GB/s = ~1.8× over v1; identical numbers before/after the over-read
   refactor (the 8192-tile case is an exact multiple of 16 KB).
 
+## Buffering-depth (NUM_TRIDS) sweep
+
+8192×8192 bf16, 8 cores. NUM_TRIDS made a kernel compile-time arg (factory reads
+`BH_DRAM_READ_NUM_TRIDS` env, default now 2). `sweep_bh_dram_read_trids.sh`.
+
+| depth | GB/s | util |
+|-------|------|------|
+| 1 (single buffer) | 186 | 36% |
+| 2 (double buffer) | 344 | 67% |
+| 3 | 344 | 67% |
+| 4 | 344 | 67% |
+| 6 | 344 | 67% |
+| 8 | 344 | 67% |
+| 12 | 344 | 67% |
+| 15 | 344 | 67% |
+
+**Conclusion:** double-buffering is sufficient — 1→2 doubles BW (latency hidden
+by 2 outstanding reads), 2→15 is byte-identical (no gain, no over-issue
+penalty). At v2's arbitrary core placement the 67% wall was **not** a buffering
+limit. Default set to 2 (same BW as 8, 4× less L1).
+
+## Optimal core placement (v3)
+
+Switched core selection from "first 8 worker cores" to
+`device->get_optimal_dram_bank_to_logical_worker_assignment(NOC::NOC_0)` —
+the worker core bank-adjacent for NOC0 reads. **344 → 500 GB/s (67% → ~98%).**
+Per-core jumps to 46.3 B/cyc, essentially the per-bank DRAM ceiling
+(512/8 GB/s ÷ 1.35 GHz ≈ 47.4 B/cyc). So the v2 bottleneck was **core
+placement / NOC distance**, not buffering or packet size. We are now within ~2%
+of peak DRAM bandwidth on a single NOC.
+
 ## Next ideas (later work)
-- Sweep `NUM_TRIDS` (8 → 16) and packet size; find the knee.
-- Use both NOCs / multiple reader cores per bank.
-- Verify arbitrary tile counts (non-multiple-of-packet tails, < num_banks tiles).
+- Dual-NOC (8 more bank-adjacent cores on NOC1, split each bank's region) —
+  likely marginal now that a single NOC already reaches ~98%.
+- Sweep packet size.

--- a/docs/superpowers/specs/bh-dram-read-progress.md
+++ b/docs/superpowers/specs/bh-dram-read-progress.md
@@ -1,0 +1,49 @@
+# bh_dram_read — progress & results log
+
+Tracking doc for the `bh_dram_read` op (DRAM read-bandwidth experiment). One
+worker core per DRAM bank; each core reads its bank's portion of a DRAM-
+interleaved tilized tensor and discards it. Read-only, void host API.
+
+Branches: `vsuresh/bh_dram_read` (spec only), `vsuresh/bh_dram_read_impl` (code).
+Device: Blackhole p150, AICLK ≈ 1350 MHz, 8 DRAM banks. Theoretical peak DRAM
+BW (tt-metal microbenchmark spec constant): **512 GB/s**.
+
+Measurement: `measure_bh_dram_read_bw.py` runs the op on a large tensor under
+`TT_METAL_DEVICE_PROFILER=1`, parses the `DRAM_READ` kernel zone from
+`generated/profiler/.logs/profile_log_device.csv`, and computes
+aggregate bytes/cycle = total_bytes / slowest-core-cycles.
+
+## Commits
+
+| commit | description |
+|--------|-------------|
+| `ca587a583cf` | docs: bh_dram_read op design spec |
+| `edc51d68467` | feat: add bh_dram_read op (one core per DRAM bank) — initial scaffold, serialized read-barrier-per-page kernel |
+
+(Updated as work lands. Newer commits appended below once made.)
+
+## Results
+
+Tensor: 8192×8192 bf16 = 128 MiB, 65,536 tiles, 8 reader cores (one per bank).
+
+| version | kernel | per-core B/cyc | aggregate B/cyc | GB/s | utilization |
+|---------|--------|----------------|-----------------|------|-------------|
+| v1 | TensorAccessor page-by-page, block of 8 + barrier per block | 17.4 | 139.3 | 188 | ~37% |
+| v2 | trid ring (8 in flight), 16 KB max NOC packets (MoE dm0 pattern) | 31.8 | 254.7 | 344 | ~67% |
+
+### Notes
+- v1: serialized-ish; barrier per 8-page block, single NOC, page-granular reads.
+- v2: copies the MoE `dm0.cpp` transaction-id pipeline — `set_state` once per
+  core (fixed bank), then `noc_async_read_one_packet_with_state_with_trid`
+  reads of `NOC_MAX_BURST_SIZE` (16 KB on BH) with `NUM_TRIDS=8` outstanding,
+  barriering a trid only when the ring is full. Goal: approach 512 GB/s.
+- v2 reads constant max-size packets and rounds the packet count up: the last
+  packet over-reads past the bank region (discarded, so harmless). The CB is
+  plain tile-paged L1 scratch sized for NUM_TRIDS packets — not packet-paged.
+  187→344 GB/s = ~1.8× over v1; identical numbers before/after the over-read
+  refactor (the 8192-tile case is an exact multiple of 16 KB).
+
+## Next ideas (later work)
+- Sweep `NUM_TRIDS` (8 → 16) and packet size; find the knee.
+- Use both NOCs / multiple reader cores per bank.
+- Verify arbitrary tile counts (non-multiple-of-packet tails, < num_banks tiles).

--- a/docs/superpowers/specs/bh-dram-read-progress.md
+++ b/docs/superpowers/specs/bh-dram-read-progress.md
@@ -18,7 +18,8 @@ aggregate bytes/cycle = total_bytes / slowest-core-cycles.
 | commit | description |
 |--------|-------------|
 | `ca587a583cf` | docs: bh_dram_read op design spec |
-| `edc51d68467` | feat: add bh_dram_read op (one core per DRAM bank) — initial scaffold, serialized read-barrier-per-page kernel |
+| `edc51d68467` | feat: add bh_dram_read op (one core per DRAM bank) — initial scaffold (v1, serialized read-barrier-per-page kernel) |
+| `670053b020f` | perf: trid pipeline + max-packet over-read (v2, 188→344 GB/s); adds measurement script + this log |
 
 (Updated as work lands. Newer commits appended below once made.)
 

--- a/measure_bh_dram_read_bw.py
+++ b/measure_bh_dram_read_bw.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Measure DRAM read bandwidth of ttnn.bh_dram_read via the on-device profiler.
+# Run with:  TT_METAL_DEVICE_PROFILER=1 python3 measure_bh_dram_read_bw.py
+#
+# Method: run the op on a large DRAM-interleaved tensor, close the device (which
+# flushes the device profiler CSV), then read the "DRAM_READ" kernel zone cycle
+# counts. Aggregate bytes/cycle = total_bytes / (slowest core's cycles), since
+# the per-bank reader cores run concurrently.
+
+import os
+import sys
+import re
+import csv
+from pathlib import Path
+
+import torch
+import ttnn
+
+BH_DRAM_BW_GB_S = 512.0  # tt-metal microbenchmark spec constant for Blackhole
+
+HEIGHT = 8192
+WIDTH = 8192
+ITERS = 3
+
+
+def find_csv():
+    base = os.environ.get("TT_METAL_PROFILER_DIR")
+    home = os.environ.get("TT_METAL_HOME", os.getcwd())
+    candidates = []
+    if base:
+        candidates.append(Path(base) / ".logs" / "profile_log_device.csv")
+    candidates.append(Path(home) / "generated" / "profiler" / ".logs" / "profile_log_device.csv")
+    for c in candidates:
+        if c.exists():
+            return c
+    return None
+
+
+def run_op():
+    torch.manual_seed(0)
+    t = torch.rand((HEIGHT, WIDTH), dtype=torch.bfloat16)
+    dev = ttnn.open_device(device_id=0)
+    try:
+        x = ttnn.from_torch(t, layout=ttnn.TILE_LAYOUT, device=dev, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        for _ in range(ITERS):
+            ttnn.bh_dram_read(x)
+        ttnn.synchronize_device(dev)
+    finally:
+        ttnn.close_device(dev)  # flushes the device profiler CSV
+
+
+def parse_csv(path):
+    # First line is a comment containing CHIP_FREQ[MHz]; second line is the header.
+    text = path.read_text().splitlines()
+    freq_mhz = None
+    for line in text[:3]:
+        m = re.search(r"CHIP_FREQ\[MHz\]:\s*([0-9.]+)", line)
+        if m:
+            freq_mhz = float(m.group(1))
+    # locate header row
+    header_idx = next(i for i, l in enumerate(text) if "zone name" in l.lower())
+    reader = csv.reader(text[header_idx:])
+    rows = list(reader)
+    header = [h.strip() for h in rows[0]]
+
+    def col(name):
+        for i, h in enumerate(header):
+            if h.lower() == name.lower():
+                return i
+        return None
+
+    ci = {k: col(k) for k in ["core_x", "core_y", "time[cycles since reset]", "zone name", "type"]}
+    # per-core list of durations of the DRAM_READ zone
+    open_ts = {}
+    durations = {}
+    for r in rows[1:]:
+        if len(r) <= max(v for v in ci.values() if v is not None):
+            continue
+        zone = r[ci["zone name"]].strip()
+        if "DRAM_READ" not in zone:
+            continue
+        core = (r[ci["core_x"]].strip(), r[ci["core_y"]].strip())
+        cyc = int(r[ci["time[cycles since reset]"]].strip())
+        typ = r[ci["type"]].strip().upper()
+        if "BEGIN" in typ or "START" in typ or typ == "ZONE_START":
+            open_ts[core] = cyc
+        elif ("END" in typ or typ == "ZONE_END") and core in open_ts:
+            durations.setdefault(core, []).append(cyc - open_ts.pop(core))
+    return freq_mhz, durations
+
+
+def main():
+    if not os.environ.get("TT_METAL_DEVICE_PROFILER"):
+        print("ERROR: set TT_METAL_DEVICE_PROFILER=1", file=sys.stderr)
+        sys.exit(2)
+
+    run_op()
+    csv_path = find_csv()
+    if not csv_path:
+        print("ERROR: profiler CSV not found", file=sys.stderr)
+        sys.exit(1)
+
+    freq_mhz, durations = parse_csv(csv_path)
+    if not durations:
+        print("ERROR: no DRAM_READ zones found in CSV", file=sys.stderr)
+        sys.exit(1)
+
+    # bytes
+    tile_bytes = 32 * 32 * 2  # bf16 tile
+    num_tiles = (HEIGHT // 32) * (WIDTH // 32)
+    total_bytes = num_tiles * tile_bytes
+
+    # per-core best (min) cycles, then the binding core is the slowest of those
+    per_core_best = {c: min(ds) for c, ds in durations.items()}
+    num_cores = len(per_core_best)
+    slowest_cycles = max(per_core_best.values())
+    per_core_bytes = total_bytes / num_cores
+
+    agg_bpc = total_bytes / slowest_cycles
+    per_core_bpc = per_core_bytes / slowest_cycles
+
+    print("\n================ bh_dram_read DRAM read bandwidth ================")
+    print(f"tensor                : {HEIGHT}x{WIDTH} bf16")
+    print(f"total bytes           : {total_bytes:,} ({total_bytes/1024/1024:.1f} MiB)")
+    print(f"num tiles             : {num_tiles:,}   (page = {tile_bytes} B)")
+    print(f"reader cores (banks)  : {num_cores}")
+    print(f"AICLK                 : {freq_mhz:.1f} MHz" if freq_mhz else "AICLK: unknown")
+    print(f"slowest core cycles   : {slowest_cycles:,}")
+    print("-----------------------------------------------------------------")
+    print(f"per-core bytes/cycle  : {per_core_bpc:.2f} B/cyc")
+    print(f"AGGREGATE bytes/cycle : {agg_bpc:.2f} B/cyc")
+    if freq_mhz:
+        gbs = agg_bpc * freq_mhz * 1e6 / 1e9
+        peak_bpc = BH_DRAM_BW_GB_S * 1e9 / (freq_mhz * 1e6)
+        print(f"AGGREGATE bandwidth   : {gbs:.1f} GB/s")
+        print(f"theoretical peak      : {BH_DRAM_BW_GB_S:.0f} GB/s  ({peak_bpc:.1f} B/cyc aggregate)")
+        print(f"UTILIZATION           : {100.0*gbs/BH_DRAM_BW_GB_S:.1f} %")
+    print("=================================================================\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/sweep_bh_dram_read_trids.sh
+++ b/sweep_bh_dram_read_trids.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Sweep the buffering depth (NUM_TRIDS = outstanding reads per core) and report
+# DRAM read bandwidth at each. Start double-buffered and work up.
+set -u
+source python_env/bin/activate
+CSV="generated/profiler/.logs/profile_log_device.csv"
+
+echo "depth | per-core B/cyc | aggregate B/cyc | GB/s | util"
+echo "------|----------------|-----------------|------|-----"
+for n in 2 3 4 6 8 12 15; do
+    rm -f "$CSV"
+    out=$(BH_DRAM_READ_NUM_TRIDS=$n TT_METAL_DEVICE_PROFILER=1 python3 measure_bh_dram_read_bw.py 2>/dev/null)
+    pc=$(echo "$out"  | sed -n 's/.*per-core bytes\/cycle  : \([0-9.]*\).*/\1/p')
+    agg=$(echo "$out" | sed -n 's/.*AGGREGATE bytes\/cycle : \([0-9.]*\).*/\1/p')
+    gbs=$(echo "$out" | sed -n 's/.*AGGREGATE bandwidth   : \([0-9.]*\).*/\1/p')
+    ut=$(echo "$out"  | sed -n 's/.*UTILIZATION           : \([0-9.]*\).*/\1/p')
+    printf "%5s | %14s | %15s | %4s | %s%%\n" "$n" "$pc" "$agg" "$gbs" "$ut"
+done

--- a/tech_reports/Saturating_DRAM_bandwidth/Saturating_DRAM_bandwidth_Blackhole.md
+++ b/tech_reports/Saturating_DRAM_bandwidth/Saturating_DRAM_bandwidth_Blackhole.md
@@ -1,0 +1,118 @@
+# Saturating DRAM bandwidth on Blackhole
+
+This document describes how to saturate DRAM read bandwidth on Tenstorrent
+Blackhole cards, reaching **~98% of the theoretical peak (500 GB/s of 512 GB/s)**
+with a simple one-reader-per-bank kernel. It is the Blackhole companion to
+[Saturating_DRAM_bandwidth.md](Saturating_DRAM_bandwidth.md), which covers the
+original Wormhole/Grayskull work; the techniques (one reader per bank,
+transaction-id double-buffering, bank-adjacent reader placement) carry over, but
+the Blackhole numbers and the relative importance of each lever differ.
+
+## Blackhole DRAM at a glance
+
+| Property | Blackhole (p150) | Wormhole b0 (ref) |
+|---|---|---|
+| DRAM banks | 8 (GDDR6) | 12 |
+| NOC subchannel endpoints per bank | 3 | 1 |
+| Theoretical peak DRAM BW | **512 GB/s** | 384 GB/s |
+| Core clock (AICLK) | ~1.35 GHz | ~1.0 GHz |
+| NOC payload width | 512 bits (64 B/word) | 256 bits (32 B/word) |
+| `NOC_MAX_BURST_SIZE` (max single packet) | **16 KB** (256 × 64 B) | 8 KB |
+
+Two consequences of the wider Blackhole NOC matter for this workload:
+
+- The **maximum single-packet read is 16 KB** (8 bf16 tiles), so each NOC
+  transaction moves twice the payload of a Wormhole packet.
+- The **per-bank ceiling** is `512 GB/s ÷ 8 banks = 64 GB/s`, i.e.
+  `64e9 ÷ 1.35e9 ≈ 47.4 bytes/cycle` per reader core. Hitting peak means each of
+  the 8 reader cores must sustain ~47 B/cyc from its bank.
+
+## The three levers
+
+A reader kernel that issues NOC reads to DRAM and discards them is limited by
+three things. On Blackhole, in increasing order of impact:
+
+### 1. Packet size — read the maximum burst
+
+Issue reads of `NOC_MAX_BURST_SIZE` (16 KB) rather than per-tile (2 KB) reads.
+Fewer, larger transactions amortize NOC issue overhead. A reader that streams
+the bank's contiguous region in 16 KB packets is the baseline; the packet count
+is rounded up so the final packet may over-read past the region end (harmless —
+every byte is discarded).
+
+### 2. Buffering depth — double-buffer with transaction ids
+
+A naive reader issues a read, waits on a barrier, then issues the next — the
+DRAM bank goes idle between the barrier and the next request. The fix (same as
+the Wormhole report) is to tag each in-flight read with a NOC **transaction id
+(trid)** and barrier on a trid only once a ring of N reads is outstanding, so
+there is always a request in flight.
+
+On Blackhole this lever saturates almost immediately. Sweeping the number of
+outstanding transactions (`NUM_TRIDS`) on a 128 MiB read:
+
+| outstanding reads | GB/s | utilization |
+|---|---|---|
+| 1 (single-buffer, barrier every read) | 186 | 36% |
+| 2 (double-buffer) | 344 | 67% |
+| 3, 4, 6, 8, 12, 15 | 344 | 67% |
+
+**Double-buffering (depth 2) captures the entire latency-hiding benefit;**
+depths 2–15 are byte-identical. Going deeper neither helps nor hurts — there is
+no over-issue penalty up to the 15-trid hardware limit (`NOC_MAX_TRANSACTION_ID
+= 0xF`), but there is also no reason to pay the extra L1. There is no need to
+triple- or quadruple-buffer.
+
+### 3. Reader core placement — the dominant lever on Blackhole
+
+This is what gets you from 67% to ~98%. The reader core for each bank must be
+placed **adjacent to that bank for the chosen NOC**, so that DRAM responses
+travel one hop and reader routes do not overlap and congest the NOC. Arbitrary
+placement (e.g. the first 8 worker cores) leaves long, overlapping routes and
+caps throughput around 67%.
+
+tt-metal exposes the optimal assignment directly:
+
+```cpp
+// One bank-adjacent worker core per DRAM bank, optimal for NOC0 reads.
+std::vector<CoreCoord> cores =
+    device->get_optimal_dram_bank_to_logical_worker_assignment(NOC::NOC_0);
+```
+
+`cores[bank_id]` is the worker core to run the reader for `bank_id` on. The
+assignment differs for `NOC::NOC_1` (the two NOCs route in opposite directions,
+so each bank's nearest core differs per NOC).
+
+## Measured results
+
+Microbenchmark: read a 8192×8192 bf16 (128 MiB) DRAM-interleaved tensor, one
+reader core per bank (8 cores), discarding the data. Timed with the on-device
+profiler (`DRAM_READ` kernel zone), `bytes ÷ slowest-core-cycles × AICLK`.
+Blackhole p150, 8 banks, 1.35 GHz, peak 512 GB/s.
+
+| stage | per-core B/cyc | aggregate B/cyc | GB/s | utilization |
+|---|---|---|---|---|
+| per-tile reads, barrier per block | 17.4 | 139 | 188 | 37% |
+| 16 KB packets + trid double-buffer, arbitrary cores | 31.8 | 255 | 344 | 67% |
+| **+ bank-adjacent optimal NOC0 placement** | **46.3** | **371** | **500** | **~98%** |
+
+At the final stage each reader sustains 46.3 B/cyc against the ~47.4 B/cyc
+per-bank ceiling — the banks themselves are the limit, and a single NOC already
+reaches ~98% of peak.
+
+## Takeaways
+
+- **Core placement dominates on Blackhole.** With bank-adjacent NOC0 placement a
+  single NOC reaches ~98% of peak; without it you are stuck near 67% no matter
+  how you tune buffering or packet size. Always use
+  `get_optimal_dram_bank_to_logical_worker_assignment`.
+- **Double-buffering is enough.** Two outstanding transactions per core fully
+  hide DRAM latency; more buffering is wasted L1.
+- **Use the 16 KB max packet.** Larger transactions amortize issue overhead.
+- **A second NOC is unnecessary for reads.** Since one NOC already reaches ~98%,
+  adding NOC1 readers can only chase the last ~2%; the per-bank DRAM rate, not
+  the NOC, is the binding constraint.
+
+A reproducible end-to-end example (the `bh_dram_read` op, build/run/measure
+steps, and the tuning sweep) is in
+[bh_dram_read_microbenchmark.md](bh_dram_read_microbenchmark.md).

--- a/tech_reports/Saturating_DRAM_bandwidth/bh_dram_read_microbenchmark.md
+++ b/tech_reports/Saturating_DRAM_bandwidth/bh_dram_read_microbenchmark.md
@@ -1,0 +1,122 @@
+# `bh_dram_read`: a Blackhole DRAM read-bandwidth microbenchmark
+
+A worked, reproducible example of saturating Blackhole DRAM read bandwidth,
+companion to
+[Saturating_DRAM_bandwidth_Blackhole.md](Saturating_DRAM_bandwidth_Blackhole.md).
+It walks through the `bh_dram_read` example op — a minimal, read-only TTNN op
+that places one worker core per DRAM bank, has each core stream its bank's
+portion of a DRAM-interleaved tensor into L1, and discards it — and shows how it
+reaches ~98% of peak.
+
+## What the op does
+
+- Host API: `ttnn.bh_dram_read(input_tensor)` (read-only, returns nothing).
+- One reader core per DRAM bank (`device->num_dram_channels()` = 8 on p150).
+- Each bank's reader is placed on the bank-adjacent worker core for NOC0 via
+  `device->get_optimal_dram_bank_to_logical_worker_assignment(NOC::NOC_0)`.
+- Each core streams its bank's contiguous region in 16 KB (`NOC_MAX_BURST_SIZE`)
+  packets, keeping `NUM_TRIDS` reads in flight (default 2 — double-buffered).
+
+Source: `ttnn/cpp/ttnn/operations/examples/bh_dram_read/`.
+
+## The reader kernel (core of the benchmark)
+
+Each core reads from a single fixed bank, so the NOC read state is set once and
+constant-size packets are streamed with a transaction-id ring:
+
+```cpp
+// reader_bh_dram_read.cpp (abridged)
+constexpr uint32_t NUM_TRIDS = get_compile_time_arg_val(0);   // buffering depth
+constexpr uint32_t PACKET    = NOC_MAX_BURST_SIZE;            // 16 KB on Blackhole
+
+const uint64_t bank_noc_base = get_noc_addr_from_bank_id<true>(bank_id, 0);
+const uint32_t num_packets   = (region_bytes + PACKET - 1) / PACKET;  // round up: over-read tail
+
+noc_async_read_one_packet_set_state(bank_noc_base, PACKET);   // size/bank fixed -> set once
+uint32_t trid_issue = 1, trid_wait = 1, in_flight = 0, offset = src_addr;
+for (uint32_t i = 0; i < num_packets; ++i) {
+    noc_async_read_set_trid(trid_issue);
+    noc_async_read_one_packet_with_state_with_trid</*skip_ptr_update=*/false, /*skip_cmdbuf_chk=*/true>(
+        bank_noc_base, offset, l1_base + (trid_issue - 1) * PACKET, trid_issue);
+    offset += PACKET;
+    ADVANCE_TRID(trid_issue);
+    if (++in_flight == NUM_TRIDS) {                           // barrier only when the ring is full
+        noc_async_read_barrier_with_trid(trid_wait);
+        ADVANCE_TRID(trid_wait);
+        --in_flight;
+    }
+}
+while (in_flight > 0) { noc_async_read_barrier_with_trid(trid_wait); ADVANCE_TRID(trid_wait); --in_flight; }
+```
+
+This pattern is adapted from the MoE `dm0.cpp` reader. Because each core owns one
+bank, `set_state` is hoisted out of the loop entirely.
+
+## Build
+
+The device profiler (Tracy) is enabled by default in `build_metal.sh`:
+
+```bash
+./build_metal.sh
+source python_env/bin/activate
+```
+
+## Run / correctness
+
+```bash
+pytest tests/ttnn/unit_tests/operations/debug/test_bh_dram_read.py -q
+```
+
+The test covers awkward tile counts (1 tile, fewer tiles than banks, prime
+counts that exercise the over-read tail, large) to confirm the op reads any
+number of tiles.
+
+## Measure bandwidth
+
+`measure_bh_dram_read_bw.py` runs the op on a large tensor under the device
+profiler, parses the `DRAM_READ` kernel zone from
+`generated/profiler/.logs/profile_log_device.csv`, and reports bytes/cycle and
+utilization (`aggregate = total_bytes ÷ slowest-core-cycles`):
+
+```bash
+TT_METAL_DEVICE_PROFILER=1 python3 measure_bh_dram_read_bw.py
+```
+
+Expected (8192×8192 bf16, p150):
+
+```
+reader cores (banks)  : 8
+per-core bytes/cycle  : 46.34 B/cyc
+AGGREGATE bandwidth   : 500.5 GB/s
+theoretical peak      : 512 GB/s
+UTILIZATION           : 97.7 %
+```
+
+## Tuning sweep (buffering depth)
+
+`NUM_TRIDS` is a kernel compile-time arg; the program factory reads the
+`BH_DRAM_READ_NUM_TRIDS` env var (1–15) to override it for sweeps:
+
+```bash
+bash sweep_bh_dram_read_trids.sh
+```
+
+| depth | GB/s | utilization |
+|---|---|---|
+| 1 | 186 | 36% |
+| 2 | 344* | 67%* |
+| 3–15 | 344* | 67%* |
+
+\* with arbitrary core placement; with bank-adjacent placement the depth-2 run
+reaches 500 GB/s / ~98%. The sweep shows buffering saturates at depth 2 — the
+default. (The 344 → 500 jump comes from placement, not buffering; see the
+companion doc.)
+
+## How the numbers were obtained
+
+- Timing: on-device profiler `DeviceZoneScopedN("DRAM_READ")` around the read
+  loop; cycles read from the profiler CSV, converted with AICLK (~1350 MHz).
+- Bytes: `physical_volume_in_tiles × tile_bytes` (the true tensor size; the
+  rounded-up over-read of the final packet is excluded from the denominator).
+- Aggregate BW: the 8 banks are read concurrently, so wall time is the slowest
+  core; `aggregate B/cyc = total_bytes ÷ slowest_core_cycles`.

--- a/tests/ttnn/unit_tests/operations/debug/test_bh_dram_read.py
+++ b/tests/ttnn/unit_tests/operations/debug/test_bh_dram_read.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_equal
+
+
+@pytest.mark.parametrize("height", [256])
+@pytest.mark.parametrize("width", [512])
+def test_bh_dram_read(device, height, width):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand((height, width), dtype=torch.bfloat16)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    # Read-only op: returns nothing, must not mutate the input.
+    result = ttnn.bh_dram_read(input_tensor)
+    assert result is None
+
+    output_tensor = ttnn.to_torch(input_tensor)
+    assert_equal(torch_input_tensor, output_tensor)

--- a/tests/ttnn/unit_tests/operations/debug/test_bh_dram_read.py
+++ b/tests/ttnn/unit_tests/operations/debug/test_bh_dram_read.py
@@ -11,8 +11,18 @@ import ttnn
 from tests.ttnn.utils_for_testing import assert_equal
 
 
-@pytest.mark.parametrize("height", [256])
-@pytest.mark.parametrize("width", [512])
+# Awkward tile counts: 1 tile, fewer tiles than DRAM banks (banks get 0 pages),
+# a prime non-multiple of the 16 KB packet (8-tile) read, and a large multiple.
+@pytest.mark.parametrize(
+    "height, width",
+    [
+        (32, 32),  # 1 tile
+        (32, 32 * 5),  # 5 tiles  (< 8 banks)
+        (32, 32 * 13),  # 13 tiles (prime, forces over-read tail)
+        (32 * 7, 32 * 11),  # 77 tiles
+        (1024, 1024),  # 1024 tiles
+    ],
+)
 def test_bh_dram_read(device, height, width):
     torch.manual_seed(0)
 

--- a/ttnn/cpp/ttnn/operations/examples/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/examples/CMakeLists.txt
@@ -17,6 +17,7 @@ file(
     GLOB_RECURSE kernels
     example/device/kernels/*
     example_multiple_return/device/kernels/*
+    bh_dram_read/device/kernels/*
 )
 
 target_sources(

--- a/ttnn/cpp/ttnn/operations/examples/bh_dram_read/bh_dram_read.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/bh_dram_read/bh_dram_read.cpp
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "bh_dram_read.hpp"
+
+namespace ttnn {
+
+void bh_dram_read(const Tensor& input_tensor) {
+    // The primitive returns the input tensor aliased unchanged (read-only op);
+    // discard it to present a void API.
+    ttnn::prim::bh_dram_read(input_tensor);
+}
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/examples/bh_dram_read/bh_dram_read.hpp
+++ b/ttnn/cpp/ttnn/operations/examples/bh_dram_read/bh_dram_read.hpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "device/bh_dram_read_device_operation.hpp"
+
+namespace ttnn {
+
+// bh_dram_read: a minimal, read-only op. Places one worker core per DRAM bank;
+// each core reads the input tensor's pages that live in its assigned bank and
+// discards them. Returns nothing.
+void bh_dram_read(const Tensor& input_tensor);
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/examples/bh_dram_read/bh_dram_read_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/bh_dram_read/bh_dram_read_nanobind.cpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "bh_dram_read_nanobind.hpp"
+
+#include <nanobind/nanobind.h>
+
+#include "ttnn-nanobind/bind_function.hpp"
+#include "ttnn/operations/examples/bh_dram_read/bh_dram_read.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::examples {
+
+void bind_bh_dram_read_operation(nb::module_& mod) {
+    ttnn::bind_function<"bh_dram_read">(
+        mod,
+        R"doc(bh_dram_read(input_tensor: ttnn.Tensor) -> None
+
+Places one worker core per DRAM bank; each core reads the input tensor's pages
+that reside in its assigned bank and discards them. Read-only; returns nothing.)doc",
+        &ttnn::bh_dram_read,
+        nb::arg("input_tensor"));
+}
+
+}  // namespace ttnn::operations::examples

--- a/ttnn/cpp/ttnn/operations/examples/bh_dram_read/bh_dram_read_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/examples/bh_dram_read/bh_dram_read_nanobind.hpp
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::examples {
+namespace nb = nanobind;
+void bind_bh_dram_read_operation(nb::module_& mod);
+}  // namespace ttnn::operations::examples

--- a/ttnn/cpp/ttnn/operations/examples/bh_dram_read/device/bh_dram_read_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/bh_dram_read/device/bh_dram_read_device_operation.cpp
@@ -18,6 +18,9 @@ void BhDramReadDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "bh_dram_read: input tensor must be on device");
     TT_FATAL(input_tensor.memory_config().is_dram(), "bh_dram_read: input tensor must be in DRAM");
     TT_FATAL(!input_tensor.memory_config().is_sharded(), "bh_dram_read: input tensor must be DRAM-interleaved");
+    TT_FATAL(
+        input_tensor.layout() == tt::tt_metal::Layout::TILE,
+        "bh_dram_read: input tensor must be tilized (reads are tile-paged)");
 }
 
 BhDramReadDeviceOperation::spec_return_value_t BhDramReadDeviceOperation::compute_output_specs(

--- a/ttnn/cpp/ttnn/operations/examples/bh_dram_read/device/bh_dram_read_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/bh_dram_read/device/bh_dram_read_device_operation.cpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "bh_dram_read_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
+
+namespace ttnn::operations::examples {
+
+BhDramReadDeviceOperation::program_factory_t BhDramReadDeviceOperation::select_program_factory(
+    const operation_attributes_t&, const tensor_args_t&) {
+    return DramBankCore{};
+}
+
+void BhDramReadDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t&, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input_tensor;
+    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "bh_dram_read: input tensor must be on device");
+    TT_FATAL(input_tensor.memory_config().is_dram(), "bh_dram_read: input tensor must be in DRAM");
+    TT_FATAL(!input_tensor.memory_config().is_sharded(), "bh_dram_read: input tensor must be DRAM-interleaved");
+}
+
+BhDramReadDeviceOperation::spec_return_value_t BhDramReadDeviceOperation::compute_output_specs(
+    const operation_attributes_t&, const tensor_args_t& tensor_args) {
+    // Read-only: the output spec mirrors the input.
+    return tensor_args.input_tensor.tensor_spec();
+}
+
+BhDramReadDeviceOperation::tensor_return_value_t BhDramReadDeviceOperation::create_output_tensors(
+    const operation_attributes_t&, const tensor_args_t& tensor_args) {
+    // Read-only: alias the input tensor as the output; no new allocation.
+    return tensor_args.input_tensor;
+}
+
+}  // namespace ttnn::operations::examples
+
+namespace ttnn::prim {
+ttnn::operations::examples::BhDramReadDeviceOperation::tensor_return_value_t bh_dram_read(const Tensor& input_tensor) {
+    using OperationType = ttnn::operations::examples::BhDramReadDeviceOperation;
+    auto operation_attributes = OperationType::operation_attributes_t{};
+    auto tensor_args = OperationType::tensor_args_t{input_tensor};
+
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
+}
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/examples/bh_dram_read/device/bh_dram_read_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/examples/bh_dram_read/device/bh_dram_read_device_operation.hpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/core.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace ttnn::operations::examples {
+
+struct BhDramReadDeviceOperation {
+    // No tunable attributes for this minimal op.
+    struct operation_attributes_t {};
+
+    struct tensor_args_t {
+        const Tensor& input_tensor;
+    };
+
+    // Read-only op: the "output" is the input tensor aliased unchanged.
+    using spec_return_value_t = ttnn::TensorSpec;
+    using tensor_return_value_t = Tensor;
+
+    // Single descriptor-based factory: one worker core per DRAM bank.
+    struct DramBankCore {
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+    };
+
+    using program_factory_t = std::variant<DramBankCore>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+};
+
+}  // namespace ttnn::operations::examples
+
+namespace ttnn::prim {
+ttnn::operations::examples::BhDramReadDeviceOperation::tensor_return_value_t bh_dram_read(const Tensor& input_tensor);
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/examples/bh_dram_read/device/bh_dram_read_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/bh_dram_read/device/bh_dram_read_program_factory.cpp
@@ -4,16 +4,32 @@
 
 #include "bh_dram_read_device_operation.hpp"
 #include <tt-metalium/work_split.hpp>
+#include <cstdlib>
 
 namespace ttnn::operations::examples {
 
 using namespace tt;
 using namespace tt::tt_metal;
 
-// Must match the kernel: NUM_TRIDS transactions of PACKET bytes are kept in
-// flight, so the L1 scratch (CB) holds NUM_TRIDS packet-sized slots.
+// NUM_TRIDS transactions of PACKET bytes are kept in flight, so the L1 scratch
+// (CB) holds NUM_TRIDS packet-sized slots. NUM_TRIDS is the buffering depth; it
+// can be overridden via the BH_DRAM_READ_NUM_TRIDS env var for tuning sweeps
+// (valid trids are 1..15 on Blackhole).
 static constexpr uint32_t PACKET_BYTES = 16384;  // NOC_MAX_BURST_SIZE on Blackhole
-static constexpr uint32_t NUM_TRIDS = 8;
+// A trid sweep showed bandwidth saturates at depth 2 (double-buffering fully
+// hides DRAM latency); 2..15 are byte-identical, only depth 1 is slower. So the
+// default is 2 -- same bandwidth as 8 at 4x less L1. See bh-dram-read-progress.md.
+static constexpr uint32_t DEFAULT_NUM_TRIDS = 2;
+
+static uint32_t get_num_trids() {
+    if (const char* e = std::getenv("BH_DRAM_READ_NUM_TRIDS")) {
+        int v = std::atoi(e);
+        if (v >= 1 && v <= 15) {
+            return static_cast<uint32_t>(v);
+        }
+    }
+    return DEFAULT_NUM_TRIDS;
+}
 
 ProgramDescriptor BhDramReadDeviceOperation::DramBankCore::create_descriptor(
     const operation_attributes_t& /*operation_attributes*/,
@@ -25,6 +41,8 @@ ProgramDescriptor BhDramReadDeviceOperation::DramBankCore::create_descriptor(
 
     tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t single_tile_size = tt::tile_size(cb_data_format);
+
+    const uint32_t num_trids = get_num_trids();  // buffering depth (outstanding reads per core)
 
     uint32_t total_pages = input_tensor.physical_volume() / constants::TILE_HW;
     // For an interleaved DRAM buffer each bank stores its pages contiguously at
@@ -40,8 +58,20 @@ ProgramDescriptor BhDramReadDeviceOperation::DramBankCore::create_descriptor(
         num_banks,
         grid.x * grid.y);
 
-    CoreRangeSet all_cores = num_cores_to_corerangeset(num_banks, grid, /*row_wise=*/true);
-    std::vector<CoreCoord> cores = corerange_to_cores(all_cores, num_banks, /*row_wise=*/true);
+    // Place each bank's reader on the worker core that is optimal for NOC0 reads
+    // from that bank (bank-adjacent placement). Indexed by bank id.
+    std::vector<CoreCoord> cores = device->get_optimal_dram_bank_to_logical_worker_assignment(NOC::NOC_0);
+    TT_FATAL(
+        cores.size() >= num_banks,
+        "bh_dram_read: optimal assignment returned {} cores < {} banks",
+        cores.size(),
+        num_banks);
+    std::vector<CoreRange> core_ranges;
+    core_ranges.reserve(num_banks);
+    for (uint32_t b = 0; b < num_banks; ++b) {
+        core_ranges.emplace_back(cores[b]);
+    }
+    CoreRangeSet all_cores(core_ranges);
 
     // ---- Build the ProgramDescriptor ----
     ProgramDescriptor desc;
@@ -52,7 +82,7 @@ ProgramDescriptor BhDramReadDeviceOperation::DramBankCore::create_descriptor(
     // the buffer directly by packet slot.
     constexpr uint32_t src0_cb_index = CBIndex::c_0;
     desc.cbs.push_back(CBDescriptor{
-        .total_size = NUM_TRIDS * PACKET_BYTES,
+        .total_size = num_trids * PACKET_BYTES,
         .core_ranges = all_cores,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = src0_cb_index,
@@ -68,6 +98,7 @@ ProgramDescriptor BhDramReadDeviceOperation::DramBankCore::create_descriptor(
         "ttnn/cpp/ttnn/operations/examples/bh_dram_read/device/kernels/dataflow/reader_bh_dram_read.cpp";
     reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = {num_trids};
     reader_desc.config = ReaderConfigDescriptor{};
 
     // Per-core runtime args: each core reads the bytes that live in its bank.

--- a/ttnn/cpp/ttnn/operations/examples/bh_dram_read/device/bh_dram_read_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/bh_dram_read/device/bh_dram_read_program_factory.cpp
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "bh_dram_read_device_operation.hpp"
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+namespace ttnn::operations::examples {
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+ProgramDescriptor BhDramReadDeviceOperation::DramBankCore::create_descriptor(
+    const operation_attributes_t& /*operation_attributes*/,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& /*tensor_return_value*/) {
+    const auto& input_tensor = tensor_args.input_tensor;
+    auto* src_buffer = input_tensor.buffer();
+    auto* device = input_tensor.device();
+
+    tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
+    uint32_t single_tile_size = tt::tile_size(cb_data_format);
+
+    uint32_t total_pages = input_tensor.physical_volume() / constants::TILE_HW;
+
+    // One worker core per DRAM bank.
+    const uint32_t num_banks = static_cast<uint32_t>(device->num_dram_channels());
+    CoreCoord grid = device->compute_with_storage_grid_size();
+    TT_FATAL(
+        num_banks <= grid.x * grid.y,
+        "bh_dram_read: {} DRAM banks exceed {} available worker cores",
+        num_banks,
+        grid.x * grid.y);
+
+    CoreRangeSet all_cores = num_cores_to_corerangeset(num_banks, grid, /*row_wise=*/true);
+    std::vector<CoreCoord> cores = corerange_to_cores(all_cores, num_banks, /*row_wise=*/true);
+
+    // ---- Build the ProgramDescriptor ----
+    ProgramDescriptor desc;
+
+    // Circular buffer: double-buffered staging for the discarded reads.
+    constexpr uint32_t src0_cb_index = CBIndex::c_0;
+    constexpr uint32_t num_input_tiles = 2;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+    });
+
+    // Reader-only kernel. The TensorAccessor maps page_id -> bank, so reading
+    // page_ids {bank_id, bank_id + num_banks, ...} keeps every read on the
+    // core's assigned bank.
+    std::vector<uint32_t> reader_compile_time_args;
+    TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/examples/bh_dram_read/device/kernels/dataflow/reader_bh_dram_read.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = reader_compile_time_args;
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    // Per-core runtime args: each core reads the pages that live in its bank.
+    for (uint32_t bank_id = 0; bank_id < num_banks; ++bank_id) {
+        // Pages in bank b (interleaved round-robin): b, b+num_banks, b+2*num_banks, ...
+        uint32_t pages_in_bank = (total_pages > bank_id) ? ((total_pages - bank_id - 1) / num_banks + 1) : 0;
+        reader_desc.runtime_args.emplace_back(
+            cores[bank_id],
+            KernelDescriptor::CoreRuntimeArgs{src_buffer->address(), pages_in_bank, bank_id, num_banks});
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::operations::examples

--- a/ttnn/cpp/ttnn/operations/examples/bh_dram_read/device/bh_dram_read_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/bh_dram_read/device/bh_dram_read_program_factory.cpp
@@ -4,12 +4,16 @@
 
 #include "bh_dram_read_device_operation.hpp"
 #include <tt-metalium/work_split.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 
 namespace ttnn::operations::examples {
 
 using namespace tt;
 using namespace tt::tt_metal;
+
+// Must match the kernel: NUM_TRIDS transactions of PACKET bytes are kept in
+// flight, so the L1 scratch (CB) holds NUM_TRIDS packet-sized slots.
+static constexpr uint32_t PACKET_BYTES = 16384;  // NOC_MAX_BURST_SIZE on Blackhole
+static constexpr uint32_t NUM_TRIDS = 8;
 
 ProgramDescriptor BhDramReadDeviceOperation::DramBankCore::create_descriptor(
     const operation_attributes_t& /*operation_attributes*/,
@@ -23,6 +27,9 @@ ProgramDescriptor BhDramReadDeviceOperation::DramBankCore::create_descriptor(
     uint32_t single_tile_size = tt::tile_size(cb_data_format);
 
     uint32_t total_pages = input_tensor.physical_volume() / constants::TILE_HW;
+    // For an interleaved DRAM buffer each bank stores its pages contiguously at
+    // the DRAM-aligned page size, so a bank's region is pages_in_bank * stride.
+    const uint32_t aligned_page_size = static_cast<uint32_t>(src_buffer->aligned_page_size());
 
     // One worker core per DRAM bank.
     const uint32_t num_banks = static_cast<uint32_t>(device->num_dram_channels());
@@ -39,11 +46,13 @@ ProgramDescriptor BhDramReadDeviceOperation::DramBankCore::create_descriptor(
     // ---- Build the ProgramDescriptor ----
     ProgramDescriptor desc;
 
-    // Circular buffer: double-buffered staging for the discarded reads.
+    // Circular buffer: plain tile-paged L1 scratch, sized to hold NUM_TRIDS
+    // max-size packets worth of over-read data. Page size is the tile (not the
+    // packet) -- a packet just spans several tile pages, and the kernel indexes
+    // the buffer directly by packet slot.
     constexpr uint32_t src0_cb_index = CBIndex::c_0;
-    constexpr uint32_t num_input_tiles = 2;
     desc.cbs.push_back(CBDescriptor{
-        .total_size = num_input_tiles * single_tile_size,
+        .total_size = NUM_TRIDS * PACKET_BYTES,
         .core_ranges = all_cores,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = src0_cb_index,
@@ -52,27 +61,22 @@ ProgramDescriptor BhDramReadDeviceOperation::DramBankCore::create_descriptor(
         }}},
     });
 
-    // Reader-only kernel. The TensorAccessor maps page_id -> bank, so reading
-    // page_ids {bank_id, bank_id + num_banks, ...} keeps every read on the
-    // core's assigned bank.
-    std::vector<uint32_t> reader_compile_time_args;
-    TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
-
+    // Reader-only kernel. Each core streams its bank's contiguous region in
+    // max-size NOC packets, addressing the bank directly via bank_id.
     KernelDescriptor reader_desc;
     reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/examples/bh_dram_read/device/kernels/dataflow/reader_bh_dram_read.cpp";
     reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = reader_compile_time_args;
     reader_desc.config = ReaderConfigDescriptor{};
 
-    // Per-core runtime args: each core reads the pages that live in its bank.
+    // Per-core runtime args: each core reads the bytes that live in its bank.
     for (uint32_t bank_id = 0; bank_id < num_banks; ++bank_id) {
         // Pages in bank b (interleaved round-robin): b, b+num_banks, b+2*num_banks, ...
         uint32_t pages_in_bank = (total_pages > bank_id) ? ((total_pages - bank_id - 1) / num_banks + 1) : 0;
+        uint32_t region_bytes = pages_in_bank * aligned_page_size;
         reader_desc.runtime_args.emplace_back(
-            cores[bank_id],
-            KernelDescriptor::CoreRuntimeArgs{src_buffer->address(), pages_in_bank, bank_id, num_banks});
+            cores[bank_id], KernelDescriptor::CoreRuntimeArgs{src_buffer->address(), region_bytes, bank_id});
     }
 
     desc.kernels.push_back(std::move(reader_desc));

--- a/ttnn/cpp/ttnn/operations/examples/bh_dram_read/device/kernels/dataflow/reader_bh_dram_read.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/bh_dram_read/device/kernels/dataflow/reader_bh_dram_read.cpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+// Reader-only kernel. One instance runs per DRAM bank. It reads the pages of
+// the input tensor that reside in this core's assigned bank into a circular
+// buffer and immediately discards them (no compute, no writer).
+void kernel_main() {
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t num_pages = get_arg_val<uint32_t>(1);
+    const uint32_t start_id = get_arg_val<uint32_t>(2);  // this core's bank id
+    const uint32_t stride = get_arg_val<uint32_t>(3);    // number of DRAM banks
+
+    constexpr auto src_args = TensorAccessorArgs<0>();
+
+    constexpr uint32_t cb_id_in0 = 0;
+    constexpr uint32_t onepage = 1;
+
+    // Page size from the CB interface (works for TILE and ROW_MAJOR layouts).
+    const uint32_t page_bytes = get_local_cb_interface(cb_id_in0).fifo_page_size;
+
+    const auto s = TensorAccessor(src_args, src_addr);
+
+    Noc noc;
+    CircularBuffer cb(cb_id_in0);
+
+    // page_ids {start_id, start_id + stride, ...} all map to this core's bank
+    // under interleaved addressing.
+    uint32_t page_id = start_id;
+    for (uint32_t i = 0; i < num_pages; ++i) {
+        cb.reserve_back(onepage);
+        noc.async_read(s, cb, page_bytes, {.page_id = page_id}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        cb.push_back(onepage);
+        // Reader-only: discard immediately so the CB never fills.
+        cb.wait_front(onepage);
+        cb.pop_front(onepage);
+        page_id += stride;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/examples/bh_dram_read/device/kernels/dataflow/reader_bh_dram_read.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/bh_dram_read/device/kernels/dataflow/reader_bh_dram_read.cpp
@@ -2,44 +2,74 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
-#include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
-#include "api/tensor/noc_traits.h"
 
-// Reader-only kernel. One instance runs per DRAM bank. It reads the pages of
-// the input tensor that reside in this core's assigned bank into a circular
-// buffer and immediately discards them (no compute, no writer).
+// Reader-only kernel. One instance runs per DRAM bank. It streams the bytes of
+// the input tensor that reside in this core's assigned bank into L1 and
+// discards them (no compute, no writer).
+//
+// Peak-bandwidth pattern (copied from the MoE dm0.cpp kernel): each core reads
+// its bank's contiguous region in maximum-size NOC packets (NOC_MAX_BURST_SIZE,
+// 16 KB on Blackhole), keeping NUM_TRIDS transactions in flight via NOC
+// transaction ids. set_state is issued once (the bank/size never change for
+// this core), then with_state reads are fired back-to-back; a per-trid barrier
+// is taken only once the trid ring is full.
+
+#define NUM_TRIDS 8  // outstanding transactions; L1 scratch = NUM_TRIDS * PACKET (matches CB depth in factory)
+#define ADVANCE_TRID(t)        \
+    do {                       \
+        (t)++;                 \
+        if ((t) > NUM_TRIDS) { \
+            (t) = 1;           \
+        }                      \
+    } while (0)
+
 void kernel_main() {
-    const uint32_t src_addr = get_arg_val<uint32_t>(0);
-    const uint32_t num_pages = get_arg_val<uint32_t>(1);
-    const uint32_t start_id = get_arg_val<uint32_t>(2);  // this core's bank id
-    const uint32_t stride = get_arg_val<uint32_t>(3);    // number of DRAM banks
-
-    constexpr auto src_args = TensorAccessorArgs<0>();
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);      // buffer base address (in-bank byte offset base)
+    const uint32_t region_bytes = get_arg_val<uint32_t>(1);  // bytes this core reads from its bank
+    const uint32_t bank_id = get_arg_val<uint32_t>(2);       // this core's DRAM bank
 
     constexpr uint32_t cb_id_in0 = 0;
-    constexpr uint32_t onepage = 1;
+    constexpr uint32_t PACKET = NOC_MAX_BURST_SIZE;  // 16 KB on Blackhole (== several tiles)
 
-    // Page size from the CB interface (works for TILE and ROW_MAJOR layouts).
-    const uint32_t page_bytes = get_local_cb_interface(cb_id_in0).fifo_page_size;
+    // L1 scratch base. The CB is sized (in the program factory) to hold
+    // NUM_TRIDS packets; slot k is reused only after its trid has been
+    // barriered, so we just index into it directly (no reserve/push/pop).
+    const uint32_t l1_base = get_write_ptr(cb_id_in0);
 
-    const auto s = TensorAccessor(src_args, src_addr);
+    const uint64_t bank_noc_base = get_noc_addr_from_bank_id<true>(bank_id, 0);
 
-    Noc noc;
-    CircularBuffer cb(cb_id_in0);
+    // Always read full max-size packets and round the count up: the final
+    // packet may over-read past region_bytes, which is fine since every byte is
+    // discarded. This keeps the hot loop a single constant-size transaction.
+    const uint32_t num_packets = (region_bytes + PACKET - 1) / PACKET;
 
-    // page_ids {start_id, start_id + stride, ...} all map to this core's bank
-    // under interleaved addressing.
-    uint32_t page_id = start_id;
-    for (uint32_t i = 0; i < num_pages; ++i) {
-        cb.reserve_back(onepage);
-        noc.async_read(s, cb, page_bytes, {.page_id = page_id}, {.offset_bytes = 0});
-        noc.async_read_barrier();
-        cb.push_back(onepage);
-        // Reader-only: discard immediately so the CB never fills.
-        cb.wait_front(onepage);
-        cb.pop_front(onepage);
-        page_id += stride;
+    {
+        // Captured by the device profiler as zone "DRAM_READ".
+        DeviceZoneScopedN("DRAM_READ");
+
+        // Stream constant max-size packets with NUM_TRIDS in flight.
+        noc_async_read_one_packet_set_state(bank_noc_base, PACKET);
+        uint32_t trid_issue = 1, trid_wait = 1, in_flight = 0;
+        uint32_t offset = src_addr;
+        for (uint32_t i = 0; i < num_packets; ++i) {
+            noc_async_read_set_trid(trid_issue);
+            noc_async_read_one_packet_with_state_with_trid</*skip_ptr_update=*/false, /*skip_cmdbuf_chk=*/true>(
+                bank_noc_base, offset, l1_base + (trid_issue - 1) * PACKET, trid_issue);
+            offset += PACKET;
+            ADVANCE_TRID(trid_issue);
+            if (++in_flight == NUM_TRIDS) {
+                noc_async_read_barrier_with_trid(trid_wait);
+                ADVANCE_TRID(trid_wait);
+                --in_flight;
+            }
+        }
+        // Drain the ring.
+        while (in_flight > 0) {
+            noc_async_read_barrier_with_trid(trid_wait);
+            ADVANCE_TRID(trid_wait);
+            --in_flight;
+        }
     }
 }

--- a/ttnn/cpp/ttnn/operations/examples/bh_dram_read/device/kernels/dataflow/reader_bh_dram_read.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/bh_dram_read/device/kernels/dataflow/reader_bh_dram_read.cpp
@@ -16,7 +16,9 @@
 // this core), then with_state reads are fired back-to-back; a per-trid barrier
 // is taken only once the trid ring is full.
 
-#define NUM_TRIDS 8  // outstanding transactions; L1 scratch = NUM_TRIDS * PACKET (matches CB depth in factory)
+// Outstanding transactions (buffering depth). Set by the program factory; the
+// L1 scratch (CB) holds NUM_TRIDS packets. Valid trids are 1..15 on Blackhole.
+constexpr uint32_t NUM_TRIDS = get_compile_time_arg_val(0);
 #define ADVANCE_TRID(t)        \
     do {                       \
         (t)++;                 \

--- a/ttnn/cpp/ttnn/operations/examples/examples_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/examples_nanobind.cpp
@@ -8,12 +8,14 @@
 
 #include "ttnn/operations/examples/example/example_nanobind.hpp"
 #include "ttnn/operations/examples/example_multiple_return/example_multiple_return_nanobind.hpp"
+#include "ttnn/operations/examples/bh_dram_read/bh_dram_read_nanobind.hpp"
 
 namespace ttnn::operations::examples {
 
 void py_module(nb::module_& mod) {
     bind_example_operation(mod);
     bind_example_multiple_return_operation(mod);
+    bind_bh_dram_read_operation(mod);
 }
 
 }  // namespace ttnn::operations::examples

--- a/ttnn/cpp/ttnn/operations/examples/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/examples/sources.cmake
@@ -2,6 +2,9 @@
 # Module owners should update this file when adding/removing/renaming source files.
 
 set(TTNN_OP_EXAMPLES_SRCS
+    bh_dram_read/bh_dram_read.cpp
+    bh_dram_read/device/bh_dram_read_device_operation.cpp
+    bh_dram_read/device/bh_dram_read_program_factory.cpp
     example/example.cpp
     example/device/example_device_operation.cpp
     example/device/multi_core_program_factory.cpp

--- a/ttnn/sources.cmake
+++ b/ttnn/sources.cmake
@@ -159,6 +159,7 @@ set(TTNN_SRC_PYBIND
     cpp/ttnn/operations/embedding_backward/embedding_backward_nanobind.cpp
     cpp/ttnn/operations/examples/example/example_nanobind.cpp
     cpp/ttnn/operations/examples/example_multiple_return/example_multiple_return_nanobind.cpp
+    cpp/ttnn/operations/examples/bh_dram_read/bh_dram_read_nanobind.cpp
     cpp/ttnn/operations/examples/examples_nanobind.cpp
     cpp/ttnn/operations/experimental/bcast_to/bcast_to_nanobind.cpp
     cpp/ttnn/operations/experimental/multi_scale_deformable_attn/multi_scale_deformable_attn_nanobind.cpp


### PR DESCRIPTION
## What

Adds `bh_dram_read`, a minimal read-only TTNN example op (under `operations/examples/`) that places one worker core per DRAM bank and has each core stream its bank's portion of a DRAM-interleaved tilized tensor into L1 and discard it. Void host API: `ttnn.bh_dram_read(input_tensor)`.

It doubles as a Blackhole DRAM read-bandwidth microbenchmark — the PR documents getting from a naive reader to **~98% of peak DRAM bandwidth (500 / 512 GB/s)** on p150.

## How (the three levers)

| stage | per-core B/cyc | GB/s | util |
|---|---|---|---|
| per-tile reads, barrier per block | 17.4 | 188 | 37% |
| 16 KB max-packet reads + trid double-buffer | 31.8 | 344 | 67% |
| **+ bank-adjacent optimal NOC0 core placement** | **46.3** | **500** | **~98%** |

- **Max NOC packet (16 KB)** reads, adapted from the MoE `dm0.cpp` reader; `set_state` hoisted since each core owns one bank.
- **Transaction-id double-buffering** — a depth sweep (1→15) shows bandwidth saturates at depth 2; deeper buffering is wasted L1. Default is 2.
- **Core placement is the dominant lever** — `device->get_optimal_dram_bank_to_logical_worker_assignment(NOC::NOC_0)` (bank-adjacent) is what takes it 67% → ~98%. Each reader then sustains ~46 B/cyc against the ~47 B/cyc per-bank ceiling.

## Contents

- Op: `ttnn/cpp/ttnn/operations/examples/bh_dram_read/` (host API, device op, descriptor program factory, trid reader kernel, nanobind binding).
- Test: `tests/ttnn/unit_tests/operations/debug/test_bh_dram_read.py` — covers arbitrary tile counts (1 tile, < banks, prime counts forcing the over-read tail, large).
- Tooling: `measure_bh_dram_read_bw.py` (device-profiler `DRAM_READ` zone → bytes/cycle + util) and `sweep_bh_dram_read_trids.sh`.
- Docs: two Blackhole tech reports in `tech_reports/Saturating_DRAM_bandwidth/` (architecture + method + results, and a reproducible walkthrough). The existing Wormhole/Grayskull report is untouched.

## Notes / open

- Draft — exploratory example op; `NUM_TRIDS` is overridable via `BH_DRAM_READ_NUM_TRIDS` for sweeps.
- Single NOC already hits ~98%, so the dual-NOC idea is noted as low-priority future work.
- Validated on Blackhole p150; not exercised on Wormhole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vsuresh/bh_dram_read_impl)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vsuresh/bh_dram_read_impl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vsuresh/bh_dram_read_impl)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vsuresh/bh_dram_read_impl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vsuresh/bh_dram_read_impl)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vsuresh/bh_dram_read_impl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vsuresh/bh_dram_read_impl)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vsuresh/bh_dram_read_impl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vsuresh/bh_dram_read_impl)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vsuresh/bh_dram_read_impl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vsuresh/bh_dram_read_impl)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vsuresh/bh_dram_read_impl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vsuresh/bh_dram_read_impl)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vsuresh/bh_dram_read_impl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vsuresh/bh_dram_read_impl)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vsuresh/bh_dram_read_impl)