### PR TITLE
[QSR] Add support for Quasar device read/write to host over PCIe

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/device_pcie_loopback/kernels/device_pcie_loopback.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/device_pcie_loopback/kernels/device_pcie_loopback.cpp
@@ -19,28 +19,13 @@ void kernel_main() {
     constexpr uint32_t l1_staging_addr = get_arg(args::l1_staging_addr);
     constexpr uint32_t transfer_size_bytes = get_arg(args::transfer_size_bytes);
 
-    DPRINT("Device PCIe Loopback Start\n");
     const uint64_t pcie_noc_xy = uint64_t(NOC_XY_PCIE_ENCODING(PCIE_NOC_X, PCIE_NOC_Y));
 
     const uint64_t host_src_noc_addr = pcie_noc_xy | host_src_pcie_addr;
-    DPRINT(
-        "Device PCIe Loopback NOC read from 0x{:x} to 0x{:x} size {}\n",
-        host_src_noc_addr,
-        l1_staging_addr,
-        transfer_size_bytes);
     noc_async_read(host_src_noc_addr, l1_staging_addr, transfer_size_bytes);
-    DPRINT("Device PCIe Loopback NOC read barrier\n");
     noc_async_read_barrier();
-    DPRINT("Device PCIe Loopback NOC read barrier done\n");
 
     const uint64_t host_dst_noc_addr = pcie_noc_xy | host_dst_pcie_addr;
-    DPRINT(
-        "Device PCIe Loopback NOC write from 0x{:x} to 0x{:x} size {}\n",
-        l1_staging_addr,
-        host_dst_noc_addr,
-        transfer_size_bytes);
     noc_async_write(l1_staging_addr, host_dst_noc_addr, transfer_size_bytes);
-    DPRINT("Device PCIe Loopback NOC write barrier\n");
     noc_async_write_barrier();
-    DPRINT("Device PCIe Loopback NOC write barrier done\n");
 }

--- a/tests/tt_metal/tt_metal/data_movement/device_pcie_loopback/kernels/device_pcie_loopback.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/device_pcie_loopback/kernels/device_pcie_loopback.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Minimal device PCIe loopback kernel, modeled on cq_prefetch.cpp read_from_pcie() and
+// cq_dispatch.cpp host writes:
+//   1. noc_async_read from host (PCIe NOC address) into L1 staging
+//   2. noc_async_write from L1 staging back to a second host (PCIe NOC) address
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "experimental/kernel_args.h"
+#include "noc/noc_parameters.h"
+
+void kernel_main() {
+    constexpr uint32_t host_src_pcie_addr = get_arg(args::host_src_pcie_addr);
+    constexpr uint32_t host_dst_pcie_addr = get_arg(args::host_dst_pcie_addr);
+    constexpr uint32_t l1_staging_addr = get_arg(args::l1_staging_addr);
+    constexpr uint32_t transfer_size_bytes = get_arg(args::transfer_size_bytes);
+
+    DPRINT("Device PCIe Loopback Start\n");
+    const uint64_t pcie_noc_xy = uint64_t(NOC_XY_PCIE_ENCODING(PCIE_NOC_X, PCIE_NOC_Y));
+
+    const uint64_t host_src_noc_addr = pcie_noc_xy | host_src_pcie_addr;
+    DPRINT(
+        "Device PCIe Loopback NOC read from 0x{:x} to 0x{:x} size {}\n",
+        host_src_noc_addr,
+        l1_staging_addr,
+        transfer_size_bytes);
+    noc_async_read(host_src_noc_addr, l1_staging_addr, transfer_size_bytes);
+    DPRINT("Device PCIe Loopback NOC read barrier\n");
+    noc_async_read_barrier();
+    DPRINT("Device PCIe Loopback NOC read barrier done\n");
+
+    const uint64_t host_dst_noc_addr = pcie_noc_xy | host_dst_pcie_addr;
+    DPRINT(
+        "Device PCIe Loopback NOC write from 0x{:x} to 0x{:x} size {}\n",
+        l1_staging_addr,
+        host_dst_noc_addr,
+        transfer_size_bytes);
+    noc_async_write(l1_staging_addr, host_dst_noc_addr, transfer_size_bytes);
+    DPRINT("Device PCIe Loopback NOC write barrier\n");
+    noc_async_write_barrier();
+    DPRINT("Device PCIe Loopback NOC write barrier done\n");
+}

--- a/tests/tt_metal/tt_metal/data_movement/device_pcie_loopback/test_device_pcie_loopback.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/device_pcie_loopback/test_device_pcie_loopback.cpp
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Exercises device reads/writes to host memory through the PCIe NOC path (host hugepage /
+// sysmem), using the same noc_async_read / noc_async_write pattern as cq_prefetch.cpp and
+// test_kernels/.../pcie_write_16b.cpp. Intended as a fast alternative to SD prefetch
+// TestTerminate when validating Quasar VCS simulator host DMA.
+
+#include "device_fixture.hpp"
+
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include <tt-metalium/tt_metal.hpp>
+
+#include "dispatch/memcpy.hpp"
+#include <impl/debug/dprint_server.hpp>
+#include <impl/debug/watcher_server.hpp>
+#include "impl/context/metal_context.hpp"
+#include "llrt.hpp"
+#include "llrt/tt_cluster.hpp"
+
+#include <chrono>
+#include <thread>
+
+#ifndef OVERRIDE_KERNEL_PREFIX
+#define OVERRIDE_KERNEL_PREFIX ""
+#endif
+
+namespace tt::tt_metal {
+
+namespace {
+
+// Offsets within channel-0 host hugepage / sysmem. Keep clear of dispatch CQ headroom.
+constexpr uint32_t kHostSrcOffset = 0x10000;
+constexpr uint32_t kHostDstOffset = 0x11000;
+constexpr uint32_t kTransferSizeBytes = 128;
+
+void fill_pattern(std::vector<uint32_t>& data) {
+    for (uint32_t i = 0; i < data.size(); ++i) {
+        data[i] = 0xA5A50000u | (i & 0xFFFFu);
+    }
+}
+
+// MeshDevice close destroys MetalContext, which stops watcher/dprint server threads.
+// On Quasar sim, watcher dumps can take tens of seconds and contend with DPRINT reads.
+// Wait for watcher to finish a couple of dump cycles first (MeshWatcherFixture pattern),
+// then drain DPRINT before teardown.
+void sync_debug_servers_before_teardown() {
+    auto& ctx = MetalContext::instance();
+    if (ctx.rtoptions().get_watcher_enabled() && ctx.watcher_server()) {
+        const int dumps_at_end = ctx.watcher_server()->dump_count();
+        while (ctx.watcher_server()->dump_count() < dumps_at_end + 2) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+    }
+    if (ctx.rtoptions().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint) && ctx.dprint_server()) {
+        ctx.dprint_server()->await();
+    }
+}
+
+}  // namespace
+
+TEST_F(QuasarMeshDeviceSingleCardFixture, HostHugepagePcieLoopback) {
+    auto mesh_device = devices_.at(0);
+    IDevice* device = mesh_device->get_devices()[0];
+    TT_FATAL(device->is_mmio_capable(), "Host hugepage test requires an MMIO-capable device");
+
+    auto& cluster = MetalContext::instance().get_cluster();
+    const ChipId mmio_device_id = cluster.get_associated_mmio_device(device->id());
+    const uint16_t channel = cluster.get_assigned_channel_for_device(device->id());
+
+    void* host_hugepage_base = cluster.host_dma_address(0, mmio_device_id, channel);
+    ASSERT_NE(host_hugepage_base, nullptr) << "Host hugepage is not mapped for this device";
+
+    const uint32_t channel_size = cluster.get_host_channel_size(mmio_device_id, channel);
+    ASSERT_GE(channel_size, kHostDstOffset + kTransferSizeBytes) << "Host channel too small for test buffers";
+
+    // Device-side PCIe byte offsets mirror host hugepage offsets (see SimulationSysmemManager mapping).
+    const uint64_t pcie_base = cluster.get_pcie_base_addr_from_device(device->id());
+    const uint32_t host_src_pcie_addr = static_cast<uint32_t>(pcie_base + kHostSrcOffset);
+    const uint32_t host_dst_pcie_addr = static_cast<uint32_t>(pcie_base + kHostDstOffset);
+
+    const experimental::NodeCoord node{0, 0};
+    const uint32_t l1_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+    const uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
+    const uint32_t l1_staging_addr = l1_base + l1_alignment * 8;
+
+    // Step 1: Host writes known pattern to src region in hugepage.
+    std::vector<uint32_t> expected(kTransferSizeBytes / sizeof(uint32_t));
+    fill_pattern(expected);
+    auto* host_src_ptr = reinterpret_cast<uint8_t*>(host_hugepage_base) + kHostSrcOffset;
+    std::memcpy(host_src_ptr, expected.data(), kTransferSizeBytes);
+
+    // Poison dst so we can tell the kernel actually wrote it.
+    std::vector<uint32_t> poison(expected.size(), 0xDEADBEEFu);
+    auto* host_dst_ptr = reinterpret_cast<uint8_t*>(host_hugepage_base) + kHostDstOffset;
+    std::memcpy(host_dst_ptr, poison.data(), kTransferSizeBytes);
+    tt_driver_atomics::sfence();
+
+    // Step 2-4: Kernel reads host src -> L1, then L1 -> host dst (via compile-time args).
+    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    distributed::MeshWorkload workload;
+    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+
+    const experimental::KernelSpecName DM_KERNEL{"device_pcie_loopback"};
+
+    experimental::KernelSpec dm_kernel_spec{
+        .unique_id = DM_KERNEL,
+        .source = OVERRIDE_KERNEL_PREFIX
+        "tests/tt_metal/tt_metal/data_movement/device_pcie_loopback/kernels/device_pcie_loopback.cpp",
+        .num_threads = 1,
+        .compile_time_args =
+            {{"host_src_pcie_addr", host_src_pcie_addr},
+             {"host_dst_pcie_addr", host_dst_pcie_addr},
+             {"l1_staging_addr", l1_staging_addr},
+             {"transfer_size_bytes", kTransferSizeBytes}},
+        .hw_config =
+            experimental::DataMovementHardwareConfig{
+                .gen2_config = experimental::DataMovementHardwareConfig::Gen2Config{}},
+    };
+
+    experimental::WorkUnitSpec main_wu{
+        .name = "main",
+        .kernels = {DM_KERNEL},
+        .target_nodes = node,
+    };
+
+    experimental::ProgramSpec spec{
+        .name = "device_pcie_loopback",
+        .kernels = {dm_kernel_spec},
+        .work_units = {main_wu},
+    };
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(cq, workload, true);
+
+    // Step 5: Host verifies dst hugepage region matches src.
+    std::vector<uint32_t> host_dst_readback(expected.size());
+    std::memcpy(host_dst_readback.data(), host_dst_ptr, kTransferSizeBytes);
+    EXPECT_EQ(host_dst_readback, expected) << "Host dst hugepage mismatch after device PCIe write";
+
+    // Step 6: Host verifies L1 staging matches src.
+    std::vector<uint32_t> l1_readback;
+    std::cout << "Reading back from L1 staging address: " << std::hex << l1_staging_addr << std::dec << std::endl;
+    detail::ReadFromDeviceL1(device, node, l1_staging_addr, kTransferSizeBytes, l1_readback);
+    EXPECT_EQ(l1_readback, expected) << "L1 staging mismatch after device PCIe read";
+
+    sync_debug_servers_before_teardown();
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/device_pcie_loopback/test_device_pcie_loopback.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/device_pcie_loopback/test_device_pcie_loopback.cpp
@@ -145,7 +145,6 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, HostHugepagePcieLoopback) {
 
     // Step 6: Host verifies L1 staging matches src.
     std::vector<uint32_t> l1_readback;
-    std::cout << "Reading back from L1 staging address: " << std::hex << l1_staging_addr << std::dec << std::endl;
     detail::ReadFromDeviceL1(device, node, l1_staging_addr, kTransferSizeBytes, l1_readback);
     EXPECT_EQ(l1_readback, expected) << "L1 staging mismatch after device PCIe read";
 

--- a/tests/tt_metal/tt_metal/data_movement/sources.cmake
+++ b/tests/tt_metal/tt_metal/data_movement/sources.cmake
@@ -25,6 +25,7 @@ set(UNIT_TESTS_DATA_MOVEMENT_SRC
     direct_write/test_direct_write.cpp
     pcie_read_bw/test_pcie_read_bw.cpp
     pcie_write_bw/test_pcie_write_bw.cpp
+    device_pcie_loopback/test_device_pcie_loopback.cpp
     atomics/test_atomic_semaphore_bandwidth.cpp
     multicast_atomics/test_multicast_atomic_semaphore.cpp
     noc_api_latency/test_noc_api_latency.cpp

--- a/tt_metal/impl/context/metal_env.cpp
+++ b/tt_metal/impl/context/metal_env.cpp
@@ -135,13 +135,13 @@ void MetalEnvImpl::initialize_base_objects() {
     cluster_ = std::make_unique<Cluster>(*this->rtoptions_);
     this->verify_fw_capabilities();
 
-    if (platform_arch == tt::ARCH::QUASAR && this->rtoptions_->get_fast_dispatch() &&
-        this->cluster_->get_target_device_type() == tt::TargetDevice::Simulator) {
-        log_info(
-            tt::LogMetal,
-            "Enabling DRAM-backed command queues for Quasar simulator because host hugepages are not available");
-        this->rtoptions_->set_dram_backed_cq(true);
-    }
+    //    if (platform_arch == tt::ARCH::QUASAR && this->rtoptions_->get_fast_dispatch() &&
+    //        this->cluster_->get_target_device_type() == tt::TargetDevice::Simulator) {
+    //        log_info(
+    //            tt::LogMetal,
+    //            "Enabling DRAM-backed command queues for Quasar simulator because host hugepages are not available");
+    //        this->rtoptions_->set_dram_backed_cq(true);
+    //    }
 
     // Get is_base_routing_fw_enabled from the already-constructed Cluster instead of running
     // a throwaway TopologyDiscovery via get_cluster_type_from_cluster_desc().

--- a/tt_metal/impl/context/metal_env.cpp
+++ b/tt_metal/impl/context/metal_env.cpp
@@ -135,13 +135,13 @@ void MetalEnvImpl::initialize_base_objects() {
     cluster_ = std::make_unique<Cluster>(*this->rtoptions_);
     this->verify_fw_capabilities();
 
-    //    if (platform_arch == tt::ARCH::QUASAR && this->rtoptions_->get_fast_dispatch() &&
-    //        this->cluster_->get_target_device_type() == tt::TargetDevice::Simulator) {
-    //        log_info(
-    //            tt::LogMetal,
-    //            "Enabling DRAM-backed command queues for Quasar simulator because host hugepages are not available");
-    //        this->rtoptions_->set_dram_backed_cq(true);
-    //    }
+    if (platform_arch == tt::ARCH::QUASAR && this->rtoptions_->get_fast_dispatch() &&
+        this->cluster_->get_target_device_type() == tt::TargetDevice::Simulator) {
+        log_info(
+            tt::LogMetal,
+            "Enabling DRAM-backed command queues for Quasar simulator because host hugepages are not available");
+        this->rtoptions_->set_dram_backed_cq(true);
+    }
 
     // Get is_base_routing_fw_enabled from the already-constructed Cluster instead of running
     // a throwaway TopologyDiscovery via get_cluster_type_from_cluster_desc().

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -257,7 +257,11 @@ inline void fprintClientName(FILE* f, uint32_t client_id) {
 }
 
 // DPRINT queries can take tens of seconds per poll on RTL sim.
-inline int debug_server_timeout_sec(const llrt::RunTimeOptions& rtoptions) {
+inline int debug_server_wait_timeout_sec(const llrt::RunTimeOptions& rtoptions) {
+    return rtoptions.get_simulator_enabled() ? 30 : 5;
+}
+
+inline int debug_server_finish_timeout_sec(const llrt::RunTimeOptions& rtoptions) {
     return rtoptions.get_simulator_enabled() ? 30 : 2;
 }
 

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -255,4 +255,10 @@ inline void fprintClientName(FILE* f, uint32_t client_id) {
         fprintf(f, "NEO_%u", client_id - overlay::NEO_0);
     }
 }
+
+// DPRINT queries can take tens of seconds per poll on RTL sim.
+inline int debug_server_timeout_sec(const llrt::RunTimeOptions& rtoptions) {
+    return rtoptions.get_simulator_enabled() ? 30 : 2;
+}
+
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -941,8 +941,9 @@ DPrintServer::Impl::~Impl() {
 
     // Wait for the thread to end, with a timeout
     auto future = std::async(std::launch::async, &std::thread::join, print_server_thread_);
-    if (future.wait_for(std::chrono::seconds(2)) == std::future_status::timeout) {
-        log_fatal(tt::LogMetal, "Timed out waiting on debug print thread to terminate.");
+    const int join_timeout_sec = debug_server_timeout_sec(env_.get_rtoptions());
+    if (future.wait_for(std::chrono::seconds(join_timeout_sec)) == std::future_status::timeout) {
+        log_fatal(tt::LogMetal, "Timed out waiting on debug print thread to terminate ({}s).", join_timeout_sec);
     }
     delete print_server_thread_;
     print_server_thread_ = nullptr;
@@ -986,8 +987,9 @@ void DPrintServer::Impl::await() {
         } while (num_riscs_waiting > 0 || new_data_last_iter_ || wait_loop_iterations_ < 2);
     };
     auto future = std::async(std::launch::async, poll_until_no_new_data);
-    if (future.wait_for(std::chrono::seconds(5)) == std::future_status::timeout) {
-        TT_THROW("Timed out waiting on debug print server to read data.");
+    const int await_timeout_sec = debug_server_timeout_sec(env_.get_rtoptions());
+    if (future.wait_for(std::chrono::seconds(await_timeout_sec)) == std::future_status::timeout) {
+        TT_THROW("Timed out waiting on debug print server to read data ({}s).", await_timeout_sec);
     }
 }  // await
 

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -941,7 +941,7 @@ DPrintServer::Impl::~Impl() {
 
     // Wait for the thread to end, with a timeout
     auto future = std::async(std::launch::async, &std::thread::join, print_server_thread_);
-    const int join_timeout_sec = debug_server_timeout_sec(env_.get_rtoptions());
+    const int join_timeout_sec = debug_server_finish_timeout_sec(env_.get_rtoptions());
     if (future.wait_for(std::chrono::seconds(join_timeout_sec)) == std::future_status::timeout) {
         log_fatal(tt::LogMetal, "Timed out waiting on debug print thread to terminate ({}s).", join_timeout_sec);
     }
@@ -987,7 +987,7 @@ void DPrintServer::Impl::await() {
         } while (num_riscs_waiting > 0 || new_data_last_iter_ || wait_loop_iterations_ < 2);
     };
     auto future = std::async(std::launch::async, poll_until_no_new_data);
-    const int await_timeout_sec = debug_server_timeout_sec(env_.get_rtoptions());
+    const int await_timeout_sec = debug_server_wait_timeout_sec(env_.get_rtoptions());
     if (future.wait_for(std::chrono::seconds(await_timeout_sec)) == std::future_status::timeout) {
         TT_THROW("Timed out waiting on debug print server to read data ({}s).", await_timeout_sec);
     }

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp
@@ -535,6 +535,7 @@ void Hal::initialize_qa(std::uint32_t profiler_dram_bank_size_per_risc_bytes, bo
     // Values found in PCIe tile spec
     this->pcie_addr_lower_bound_ = 0x0000'0000'0000'0000ULL;
     this->pcie_addr_upper_bound_ = 0x1FFF'FFFF'FFFF'FFFFULL;
+    this->supports_64_bit_pcie_addressing_ = true;
 
     this->noc_x_id_translate_table_ = {};
 

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp
@@ -532,6 +532,10 @@ void Hal::initialize_qa(std::uint32_t profiler_dram_bank_size_per_risc_bytes, bo
     this->nan_ = NAN_QA;
     this->inf_ = INF_QA;
 
+    // Values found in PCIe tile spec
+    this->pcie_addr_lower_bound_ = 0x0000'0000'0000'0000ULL;
+    this->pcie_addr_upper_bound_ = 0x1FFF'FFFF'FFFF'FFFFULL;
+
     this->noc_x_id_translate_table_ = {};
 
     this->noc_y_id_translate_table_ = {};


### PR DESCRIPTION
### PR Category
Feature #47849 

### Summary
Added support for Quasar device read/write to host over PCIe. Requires matching update to simulator/emulator & soc_descriptor.yaml files.

Changes consist of 3 parts:
1. Set `pcie_addr_lower_bound_` & `pcie_addr_upper_bound_` in `qa_hal.cpp`
2. Add new PCIe loopback test to test this path.
3. Add longer timeouts to DPRINT when running on RTL simulator.

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kstevens/issue_47849)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kstevens/issue_47849)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kstevens/issue_47849)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kstevens/issue_47849)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kstevens/issue_47849)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kstevens/issue_47849)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kstevens/issue_47849)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kstevens/issue_47849)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kstevens/issue_47849)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kstevens/issue_47849)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kstevens/issue_47849)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kstevens/issue_47849)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kstevens/issue_47849)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kstevens/issue_47849)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kstevens/issue_47849)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kstevens/issue_47849)