### PR TITLE
[Cleanup] Split `to_layout` into `to_row_major_layout` and `to_tile_layout`

### DIFF
--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -77,6 +77,7 @@ set(UNIT_TESTS_API_TENSOR_SOURCES
     tensor/common_tensor_test_utils.cpp
     tensor/test_tensor_sharding.cpp
     tensor/test_host_tensor.cpp
+    tensor/test_host_tensor_to_layout.cpp
     tensor/test_mesh_tensor.cpp
     tensor/test_tensor_types.cpp
     tensor/test_tensor_layout.cpp

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_layout.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_layout.cpp
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for the host-only layout conversion tt::tt_metal::to_layout(const HostTensor&, Layout).
+//
+// Group 1 (no sharding): a matrix of {conversion direction} x {dtype}. For each cell, to_layout's
+// output is compared against an INDEPENDENTLY constructed reference tensor built directly in the
+// target layout via HostTensor::from_vector (which reaches the tiling code through a different path,
+// encode_tensor_data). Matching that reference byte-for-byte verifies the conversion produced exactly
+// what a freshly constructed tensor would hold.
+//
+// Plus dedicated tests for the special dtypes whose to_layout behavior is not a generic conversion:
+// BFLOAT8_B / BFLOAT4_B are no-ops, and FP8_E4M3 is ROW_MAJOR-only (throws when asked to tilize).
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include <tt-metalium/experimental/tensor/host_tensor.hpp>
+#include <tt-metalium/experimental/tensor/tensor_apis.hpp>
+#include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
+#include <tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp>
+#include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
+#include <tt-metalium/host_buffer.hpp>
+#include <tt-metalium/shape.hpp>
+
+namespace tt::tt_metal {
+namespace {
+
+// Builds an interleaved spec with a chosen layout. The output memory config of to_layout is
+// interleaved (it rebuilds the spec with MemoryConfig{}), so the reference tensor uses interleaved too.
+TensorSpec make_spec(const Shape& shape, DataType dtype, Layout layout) {
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    return TensorSpec(shape, TensorLayout(dtype, PageConfig(layout), memory_config));
+}
+
+// A deterministic ramp that is in-range for every dtype under test (incl. UINT8).
+template <typename T>
+std::vector<T> make_ramp(size_t count) {
+    std::vector<T> data(count);
+    for (size_t i = 0; i < count; ++i) {
+        data[i] = static_cast<T>(static_cast<float>(i % 251));
+    }
+    return data;
+}
+
+// Content-equivalence check that works for every dtype (including FP8_E4M3, which has no typed
+// reader): pull the host shard out of each tensor and compare the raw bytes directly. The tensors
+// here are single-device, so each has exactly one shard.
+void expect_equal_shard_data(const HostTensor& actual, const HostTensor& expected) {
+    const HostBuffer actual_buffer = host_buffer::get_host_buffer(actual);
+    const HostBuffer expected_buffer = host_buffer::get_host_buffer(expected);
+    const auto actual_bytes = actual_buffer.view_bytes();
+    const auto expected_bytes = expected_buffer.view_bytes();
+    ASSERT_EQ(actual_bytes.size(), expected_bytes.size());
+    EXPECT_TRUE(std::equal(actual_bytes.begin(), actual_bytes.end(), expected_bytes.begin()));
+}
+
+std::string dtype_to_str(DataType dtype) {
+    switch (dtype) {
+        case DataType::FLOAT32: return "FLOAT32";
+        case DataType::BFLOAT16: return "BFLOAT16";
+        case DataType::INT32: return "INT32";
+        case DataType::UINT32: return "UINT32";
+        case DataType::UINT16: return "UINT16";
+        case DataType::UINT8: return "UINT8";
+        default: return "UNKNOWN";
+    }
+}
+
+using ToLayoutParam = std::tuple<std::pair<Layout, Layout>, DataType>;
+
+std::string to_layout_param_name(const ::testing::TestParamInfo<ToLayoutParam>& info) {
+    const auto direction = std::get<0>(info.param);
+    const auto dtype = std::get<1>(info.param);
+    const std::string dir = (direction.first == Layout::ROW_MAJOR) ? "RmToTile" : "TileToRm";
+    return dir + "_" + dtype_to_str(dtype);
+}
+
+class HostTensorToLayoutMatrix : public ::testing::TestWithParam<ToLayoutParam> {};
+
+TEST_P(HostTensorToLayoutMatrix, MatchesFreshConstruction) {
+    const auto direction = std::get<0>(GetParam());
+    const auto dtype = std::get<1>(GetParam());
+    const auto src = direction.first;
+    const auto tgt = direction.second;
+
+    // to_layout(src -> tgt) must produce the same physical contents as a tensor freshly constructed
+    // directly in the target layout from the same logical data.
+    auto check_matches_fresh_construction = [&]<typename T>() {
+        const Shape shape{64, 64};  // 2x2 tiles; logical == physical (no padding edge cases)
+        const auto data = make_ramp<T>(shape.volume());
+
+        const auto source = HostTensor::from_vector<T>(data, make_spec(shape, dtype, src));
+        const auto result = to_layout(source, tgt);
+        const auto expected = HostTensor::from_vector<T>(data, make_spec(shape, dtype, tgt));
+
+        EXPECT_EQ(result.layout(), tgt);
+        EXPECT_EQ(result.logical_shape(), shape);
+        EXPECT_EQ(result.padded_shape(), expected.padded_shape());
+        EXPECT_EQ(result.dtype(), dtype);
+
+        expect_equal_shard_data(result, expected);
+    };
+
+    switch (dtype) {
+        case DataType::FLOAT32: check_matches_fresh_construction.operator()<float>(); break;
+        case DataType::BFLOAT16: check_matches_fresh_construction.operator()<bfloat16>(); break;
+        case DataType::INT32: check_matches_fresh_construction.operator()<int32_t>(); break;
+        case DataType::UINT32: check_matches_fresh_construction.operator()<uint32_t>(); break;
+        case DataType::UINT16: check_matches_fresh_construction.operator()<uint16_t>(); break;
+        case DataType::UINT8: check_matches_fresh_construction.operator()<uint8_t>(); break;
+        default: FAIL() << "Unhandled dtype in matrix: " << dtype_to_str(dtype);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    HostTensorToLayout,
+    HostTensorToLayoutMatrix,
+    ::testing::Combine(
+        ::testing::Values(std::pair{Layout::ROW_MAJOR, Layout::TILE}, std::pair{Layout::TILE, Layout::ROW_MAJOR}),
+        // Block-float formats (BFLOAT8_B / BFLOAT4_B) and FP8_E4M3 are intentionally excluded from
+        // this matrix: their to_layout is a no-op / throws rather than a real conversion. They are
+        // covered by the dedicated special-dtype tests below.
+        ::testing::Values(
+            DataType::FLOAT32,
+            DataType::BFLOAT16,
+            DataType::INT32,
+            DataType::UINT32,
+            DataType::UINT16,
+            DataType::UINT8)),
+    to_layout_param_name);
+
+// ----------------------------------------------------------------------------------------------------
+// Unsupported conversions.
+// ----------------------------------------------------------------------------------------------------
+
+// G2: converting a block-float tensor (BFLOAT8_B / BFLOAT4_B) from TILE to ROW_MAJOR.
+//
+// This SHOULD be a hard error. Block-float formats are only meaningful in TILE layout, so a request to
+// row-major-ize them is nonsensical and ought to be rejected. Today it is not: to_row_major_layout (in
+// tensor_apis.cpp) deliberately short-circuits these dtypes and returns the input tensor unchanged,
+// emitting only a log warning -- see the #43763 TODO at that call site. The tests below pin down that
+// current no-op behavior: the call simply does not throw. When #43763 flips the no-op into a hard
+// failure, replace the EXPECT_NO_THROW assertions here with EXPECT_ANY_THROW.
+TEST(HostTensorToLayout, Bfloat8BToRowMajorDoesNotThrow) {
+    const Shape shape{32, 32};
+    const auto data = make_ramp<float>(shape.volume());
+    const auto source = HostTensor::from_vector<float>(data, make_spec(shape, DataType::BFLOAT8_B, Layout::TILE));
+
+    EXPECT_NO_THROW(std::ignore = to_layout(source, Layout::ROW_MAJOR));
+}
+
+TEST(HostTensorToLayout, Bfloat4BToRowMajorDoesNotThrow) {
+    const Shape shape{32, 32};
+    const auto data = make_ramp<float>(shape.volume());
+    const auto source = HostTensor::from_vector<float>(data, make_spec(shape, DataType::BFLOAT4_B, Layout::TILE));
+
+    EXPECT_NO_THROW(std::ignore = to_layout(source, Layout::ROW_MAJOR));
+}
+
+// G3: dtypes that cannot be converted to TILE. FP8_E4M3 is constrained to ROW_MAJOR, so tilizing it
+// is a caller error. (Block-float formats are TILE-native, so they have no "cannot tilize" case.)
+TEST(HostTensorToLayout, Fp8E4m3CannotConvertToTile) {
+    const Shape shape{32, 32};
+    const auto data = make_ramp<float>(shape.volume());
+    const auto source = HostTensor::from_vector<float>(data, make_spec(shape, DataType::FP8_E4M3, Layout::ROW_MAJOR));
+
+    EXPECT_ANY_THROW(std::ignore = to_layout(source, Layout::TILE));
+}
+
+}  // namespace
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_layout.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_layout.cpp
@@ -16,6 +16,7 @@
 #include <gmock/gmock.h>
 
 #include <algorithm>
+#include <array>
 #include <cstdint>
 #include <string>
 #include <tuple>
@@ -29,6 +30,7 @@
 #include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
 #include <tt-metalium/host_buffer.hpp>
 #include <tt-metalium/shape.hpp>
+#include <tt-metalium/tile.hpp>
 
 namespace tt::tt_metal {
 namespace {
@@ -38,6 +40,14 @@ namespace {
 TensorSpec make_spec(const Shape& shape, DataType dtype, Layout layout) {
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     return TensorSpec(shape, TensorLayout(dtype, PageConfig(layout), memory_config));
+}
+
+// A TILE-layout spec carrying an explicit (possibly non-32x32) tile. Used to build the reference
+// tensor for the custom-tile tests below; from_vector reaches the same tiling code through
+// encode_tensor_data, which honors the spec's tile.
+TensorSpec make_tile_spec(const Shape& shape, DataType dtype, const Tile& tile) {
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    return TensorSpec(shape, TensorLayout(dtype, PageConfig(Layout::TILE, tile), memory_config));
 }
 
 // A deterministic ramp that is in-range for every dtype under test (incl. UINT8).
@@ -136,6 +146,80 @@ INSTANTIATE_TEST_SUITE_P(
             DataType::UINT16,
             DataType::UINT8)),
     to_layout_param_name);
+
+// ----------------------------------------------------------------------------------------------------
+// Custom tile sizes.
+// ----------------------------------------------------------------------------------------------------
+
+// to_tile_layout(tensor, tile) takes the tile explicitly (unlike to_layout(tensor, Layout::TILE),
+// which always uses the spec's tile), so it must honor non-32x32 tiles. For each {tile, dtype} we
+// row-major -> tile with the custom tile, then compare against a tensor freshly constructed directly
+// in TILE layout with the same custom tile -- the two must hold identical physical bytes.
+
+using CustomTileParam = std::tuple<std::array<uint32_t, 2>, DataType>;
+
+std::string custom_tile_param_name(const ::testing::TestParamInfo<CustomTileParam>& info) {
+    const auto tile_shape = std::get<0>(info.param);
+    const auto dtype = std::get<1>(info.param);
+    return "Tile" + std::to_string(tile_shape[0]) + "x" + std::to_string(tile_shape[1]) + "_" + dtype_to_str(dtype);
+}
+
+class HostTensorToTileLayoutCustomTile : public ::testing::TestWithParam<CustomTileParam> {};
+
+TEST_P(HostTensorToTileLayoutCustomTile, MatchesFreshConstruction) {
+    const auto tile_shape = std::get<0>(GetParam());
+    const auto dtype = std::get<1>(GetParam());
+    const Tile tile{tile_shape};
+
+    auto check_matches_fresh_construction = [&]<typename T>() {
+        // 64x64 is a multiple of every tile height/width under test, so logical == physical (no padding).
+        const Shape shape{64, 64};
+        const auto data = make_ramp<T>(shape.volume());
+
+        const auto source = HostTensor::from_vector<T>(data, make_spec(shape, dtype, Layout::ROW_MAJOR));
+        const auto result = to_tile_layout(source, tile);
+        const auto expected = HostTensor::from_vector<T>(data, make_tile_spec(shape, dtype, tile));
+
+        EXPECT_EQ(result.layout(), Layout::TILE);
+        EXPECT_EQ(result.logical_shape(), shape);
+        EXPECT_EQ(result.tensor_spec().tile(), tile);
+        EXPECT_EQ(result.padded_shape(), expected.padded_shape());
+        EXPECT_EQ(result.dtype(), dtype);
+
+        expect_equal_shard_data(result, expected);
+    };
+
+    switch (dtype) {
+        case DataType::FLOAT32: check_matches_fresh_construction.operator()<float>(); break;
+        case DataType::BFLOAT16: check_matches_fresh_construction.operator()<bfloat16>(); break;
+        case DataType::UINT32: check_matches_fresh_construction.operator()<uint32_t>(); break;
+        default: FAIL() << "Unhandled dtype in custom-tile matrix: " << dtype_to_str(dtype);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    HostTensorToLayout,
+    HostTensorToTileLayoutCustomTile,
+    ::testing::Combine(
+        // Valid non-default tile shapes (see TILE_FACE_HW_CHOICES in tile.cpp). 32x32 is the default
+        // and is already exercised by the dtype matrix above, so it is omitted here.
+        ::testing::Values(
+            std::array<uint32_t, 2>{16, 16},
+            std::array<uint32_t, 2>{16, 32},
+            std::array<uint32_t, 2>{32, 16},
+            std::array<uint32_t, 2>{8, 32},
+            std::array<uint32_t, 2>{1, 32}),
+        ::testing::Values(DataType::FLOAT32, DataType::BFLOAT16, DataType::UINT32)),
+    custom_tile_param_name);
+
+// A shape whose physical height/width is not a multiple of the custom tile dimensions must be rejected.
+TEST(HostTensorToLayout, CustomTileShapeMismatchThrows) {
+    const Shape shape{16, 48};  // width 48 is not a multiple of the tile width (32)
+    const auto data = make_ramp<float>(shape.volume());
+    const auto source = HostTensor::from_vector<float>(data, make_spec(shape, DataType::FLOAT32, Layout::ROW_MAJOR));
+
+    EXPECT_ANY_THROW(std::ignore = to_tile_layout(source, Tile{{16, 32}}));
+}
 
 // ----------------------------------------------------------------------------------------------------
 // Unsupported conversions.

--- a/tt_metal/api/tt-metalium/experimental/tensor/tensor_apis.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/tensor_apis.hpp
@@ -123,6 +123,8 @@ std::vector<distributed::MeshCoordinate> enqueue_write_tensor(
 // ======================================================================================
 
 HostTensor to_layout(const HostTensor& tensor, Layout target_layout);
+HostTensor to_tile_layout(const HostTensor& tensor, const Tile& tile);
+HostTensor to_row_major_layout(const HostTensor& tensor);
 
 // ======================================================================================
 //                                  .pad() and .unpad()

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -523,95 +523,111 @@ namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
 
 template <typename T>
-HostTensor to_layout_impl(const HostTensor& tensor, Layout target_layout) {
-    if (tensor.layout() == target_layout) {
+HostTensor to_row_major_layout_impl(const HostTensor& tensor) {
+    if (tensor.layout() == Layout::ROW_MAJOR) {
         return tensor;
     }
 
-    auto source_layout = tensor.layout();
-    auto tile = tt::tt_metal::Tile();
-    if (tensor.layout() == Layout::TILE) {
-        tile = tensor.tensor_spec().tile();
-    }
+    TT_FATAL(tensor.layout() == Layout::TILE, "Converting from {} to Row Major is unsupported.", tensor.layout());
+    // Construct the new tensor spec first to verify that this is a supported Tensor configuration
+    TensorSpec new_tensor_spec(
+        tensor.logical_shape(),
+        TensorLayout::fromPaddedShape(
+            tensor.dtype(),
+            PageConfig(Layout::ROW_MAJOR),
+            MemoryConfig{},
+            tensor.logical_shape(),
+            tensor.padded_shape()));
+
+    auto tile = tensor.tensor_spec().tile();
     auto physical_shape = tensor.tensor_spec().physical_shape();
-    auto convert =
-        [tile, &physical_shape, source_layout, target_layout](const HostBuffer& input_host_buffer) -> std::vector<T> {
-        const auto input_data = input_host_buffer.view_as<T>();
-        switch (source_layout) {
-            case Layout::ROW_MAJOR:
-                TT_FATAL(target_layout == Layout::TILE, "Unsupported layout conversion");
-                return tensor_impl::to_tile_major_layout(physical_shape, tile, input_data);
-            case Layout::TILE:
-                TT_FATAL(target_layout == Layout::ROW_MAJOR, "Unsupported layout conversion");
-                return tensor_impl::to_row_major_layout(physical_shape, tile, input_data);
-            case Layout::INVALID: TT_THROW("Invalid layout");
-        }
-        TT_THROW("Unreachable");
-    };
 
     auto transformed_buffer = tensor.buffer().transform(
-        [&](const HostBuffer& buffer) { return HostBuffer(convert(buffer)); },
+        [&](const HostBuffer& buffer) {
+            auto input_data = buffer.view_as<T>();
+            auto rm_data = tensor_impl::to_row_major_layout(physical_shape, tile, input_data);
+            return HostBuffer(std::move(rm_data));
+        },
         DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
-    return HostTensor::from_buffer(
-        std::move(transformed_buffer),
-        TensorSpec(
-            tensor.logical_shape(),
-            TensorLayout::fromPaddedShape(
-                tensor.dtype(),
-                PageConfig(target_layout, tile),
-                MemoryConfig{},
-                tensor.logical_shape(),
-                tensor.padded_shape())),
-        tensor.tensor_topology());
+
+    return HostTensor::from_buffer(std::move(transformed_buffer), new_tensor_spec, tensor.tensor_topology());
 }
 
 template <typename T>
-HostTensor to_layout_bfloat_impl(const HostTensor& tensor, Layout target_layout) {
-    static_assert(
-        std::is_same_v<T, tensor_impl::bfloat8_b> || std::is_same_v<T, tensor_impl::bfloat4_b>, "Invalid type T");
-    // TODO(#43763):
-    // Flipping this assert to TT_FATAL triggers multiple failures in **sanity** test suite.
-    // This silent fail has a high impact area and should be studied and addressed asap.
-    //
-    // Original comment:
-    // TODO: Flip to assert when we remove use cases in python and c++
-    if (tensor.layout() != target_layout or tensor.layout() != Layout::TILE) {
-        log_warning(
-            tt::LogAlways,
-            "Tensor layout must be Layout::TILE for bfloat8_b or bfloat4_b! Conversion from {} to {} was not executed!",
-            tensor.layout(),
-            target_layout);
-    }
-    return tensor;
-}
-
-template <>
-HostTensor to_layout_impl<tensor_impl::bfloat8_b>(const HostTensor& tensor, Layout target_layout) {
-    return to_layout_bfloat_impl<tensor_impl::bfloat8_b>(tensor, target_layout);
-}
-
-template <>
-HostTensor to_layout_impl<tensor_impl::bfloat4_b>(const HostTensor& tensor, Layout target_layout) {
-    return to_layout_bfloat_impl<tensor_impl::bfloat4_b>(tensor, target_layout);
-}
-
-template <>
-HostTensor to_layout_impl<float8_e4m3>(const HostTensor& tensor, Layout target_layout) {
-    // FP8_E4M3 is constrained to ROW_MAJOR layout in tensor_spec.cpp, so the source tensor
-    // is already ROW_MAJOR by construction. The only legal call is therefore ROW_MAJOR ->
-    // ROW_MAJOR (a no-op); any other target layout is a caller error.
-    if (target_layout == Layout::ROW_MAJOR) {
+HostTensor to_tile_layout_impl(const HostTensor& tensor, Tile tile) {
+    if (tensor.layout() == Layout::TILE) {
         return tensor;
     }
-    TT_THROW("to_layout: FP8_E4M3 only supports ROW_MAJOR layout (got target {})", target_layout);
+
+    if constexpr (std::is_same_v<T, float8_e4m3>) {
+        // FP8_E4M3 is constrained to ROW_MAJOR, so tilizing it is a caller error.
+        TT_THROW("to_layout: FP8_E4M3 only supports ROW_MAJOR layout (got target {})", Layout::TILE);
+    } else {
+        TT_FATAL(tensor.layout() == Layout::ROW_MAJOR, "Converting from {} to Tile is unsupported.", tensor.layout());
+
+        // Construct the new tensor spec first to verify that this is a supported Tensor configuration
+        TensorSpec new_tensor_spec(
+            tensor.logical_shape(),
+            TensorLayout::fromPaddedShape(
+                tensor.dtype(),
+                PageConfig(Layout::TILE, tile),
+                MemoryConfig{},
+                tensor.logical_shape(),
+                tensor.padded_shape()));
+
+        auto physical_shape = tensor.tensor_spec().physical_shape();
+
+        auto transformed_buffer = tensor.buffer().transform(
+            [&](const HostBuffer& buffer) {
+                auto input_data = buffer.view_as<T>();
+                auto tilized_data = tensor_impl::to_tile_major_layout(physical_shape, tile, input_data);
+                return HostBuffer(std::move(tilized_data));
+            },
+            DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
+
+        return HostTensor::from_buffer(std::move(transformed_buffer), new_tensor_spec, tensor.tensor_topology());
+    }
 }
 
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
+HostTensor to_row_major_layout(const HostTensor& tensor) {
+    return tensor_impl::dispatch(tensor.dtype(), [&]<typename T>() {
+        if constexpr (std::is_same_v<T, tensor_impl::bfloat4_b> || std::is_same_v<T, tensor_impl::bfloat8_b>) {
+            // TODO(#43763):
+            // Flipping this assert to TT_FATAL triggers multiple failures in **sanity** test suite.
+            // This silent fail has a high impact area and should be studied and addressed asap.
+            //
+            // Original comment:
+            // TODO: Flip to assert when we remove use cases in python and c++
+            return tensor;
+        } else if constexpr (std::is_same_v<T, float8_e4m3>) {
+            // FP8_E4M3 is constrained to ROW_MAJOR at construction, so it is already row-major.
+            return tensor;
+        } else {
+            return CMAKE_UNIQUE_NAMESPACE::to_row_major_layout_impl<T>(tensor);
+        }
+    });
+}
+
+HostTensor to_tile_layout(const HostTensor& tensor, const Tile& tile) {
+    return tensor_impl::dispatch(tensor.dtype(), [&]<typename T>() {
+        if constexpr (std::is_same_v<T, tensor_impl::bfloat4_b> || std::is_same_v<T, tensor_impl::bfloat8_b>) {
+            // Block-float formats are natively TILE — no conversion needed.
+            return tensor;
+        } else {
+            return CMAKE_UNIQUE_NAMESPACE::to_tile_layout_impl<T>(tensor, tile);
+        }
+    });
+}
+
 HostTensor to_layout(const HostTensor& tensor, Layout target_layout) {
-    return tensor_impl::dispatch(
-        tensor.dtype(), [&]<typename T>() { return CMAKE_UNIQUE_NAMESPACE::to_layout_impl<T>(tensor, target_layout); });
+    switch (target_layout) {
+        case Layout::ROW_MAJOR: return to_row_major_layout(tensor);
+        case Layout::TILE: return to_tile_layout(tensor, tensor.tensor_spec().tile());
+        default: TT_THROW("Target layout {} is not supported", target_layout);
+    }
 }
 
 // ======================================================================================

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -594,15 +594,16 @@ HostTensor to_tile_layout_impl(const HostTensor& tensor, Tile tile) {
 
 HostTensor to_row_major_layout(const HostTensor& tensor) {
     return tensor_impl::dispatch(tensor.dtype(), [&]<typename T>() {
-        if constexpr (std::is_same_v<T, tensor_impl::bfloat4_b> || std::is_same_v<T, tensor_impl::bfloat8_b>) {
-            // TODO(#43763):
+        if constexpr (
+            std::is_same_v<T, tensor_impl::bfloat4_b> || std::is_same_v<T, tensor_impl::bfloat8_b> ||
+            std::is_same_v<T, float8_e4m3>) {
+            // bfloat4_b / bfloat8_b: TODO(#43763):
             // Flipping this assert to TT_FATAL triggers multiple failures in **sanity** test suite.
             // This silent fail has a high impact area and should be studied and addressed asap.
             //
             // Original comment:
             // TODO: Flip to assert when we remove use cases in python and c++
-            return tensor;
-        } else if constexpr (std::is_same_v<T, float8_e4m3>) {
+            //
             // FP8_E4M3 is constrained to ROW_MAJOR at construction, so it is already row-major.
             return tensor;
         } else {


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

`HostTensor` represents a multi-dimensional host-side array with layout
metadata — either row-major or tile. Tile layout requires more than just
`Layout::TILE` to fully describe the tensor; specifically, the `Tile`
*shape* must also be known.

The existing `to_layout(Layout::TILE)` has a design gap: there is nowhere
in its signature to pass the `Tile` shape, so it gets smuggled in at
tensor creation time as hidden state. See #18536 and #38947.

This PR splits `to_layout` into two explicit functions:
- `to_row_major_layout()` — no extra parameters needed
- `to_tile_layout(Tile)` — tile shape passed directly at the call site

### Notes for reviewers

`to_layout` is preserved (the ttnn side still uses it) and routes to the
two new functions. When called with `Layout::TILE`, it falls back to the
old tile-recovery path — that will be cleaned up in a follow-up PR.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/split-to-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/split-to-layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/split-to-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/split-to-layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/split-to-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/split-to-layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/split-to-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/split-to-layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/split-to-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/split-to-layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/split-to-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/split-to-layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/split-to-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/split-to-layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/split-to-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/split-to-layout)