### PR TITLE
[Bug fix] Temporarily disable watcher NOC sanitization on Quasar in fast dispatch mode

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
@@ -175,6 +175,9 @@ TEST_F(MeshWatcherDelayFixture, TensixTestWatcherSanitizeInsertDelays) {
     if (this->slow_dispatch_) {
         GTEST_SKIP();
     }
+    if (tt::tt_metal::MetalContext::instance().rtoptions().watcher_noc_sanitize_disabled()) {
+        GTEST_SKIP();
+    }
 
     this->RunTestOnDevice(
         [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -107,6 +107,10 @@ void RunTestOnCore(
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     bool is_quasar = hal.get_arch() == tt::ARCH::QUASAR;
 
+    if (tt::tt_metal::MetalContext::instance().rtoptions().watcher_noc_sanitize_disabled()) {
+        GTEST_SKIP();
+    }
+
     // IDLE_ETH cores only support SD (FD not yet implemented)
     // TENSIX/ACTIVE_ETH cores: SD only used for Quasar watcher tests (TODO: Remove once FD enabled on Quasar)
     if (fixture->IsSlowDispatch() && !is_idle_eth_core && !is_quasar) {

--- a/tt_metal/impl/context/metal_env.cpp
+++ b/tt_metal/impl/context/metal_env.cpp
@@ -143,7 +143,7 @@ void MetalEnvImpl::initialize_base_objects() {
             this->rtoptions_->set_dram_backed_cq(true);
         }
         // Watcher NOC sanitization currently only works on Quasar in slow dispatch.
-        // Once it is supported on Quasar in fast dispatch, this can be removed.
+        // TODO: Remove this once NOC sanitization is supported on Quasar in fast dispatch (#45878)
         this->rtoptions_->disable_watcher_noc_sanitize();
     }
 

--- a/tt_metal/impl/context/metal_env.cpp
+++ b/tt_metal/impl/context/metal_env.cpp
@@ -135,12 +135,16 @@ void MetalEnvImpl::initialize_base_objects() {
     cluster_ = std::make_unique<Cluster>(*this->rtoptions_);
     this->verify_fw_capabilities();
 
-    if (platform_arch == tt::ARCH::QUASAR && this->rtoptions_->get_fast_dispatch() &&
-        this->cluster_->get_target_device_type() == tt::TargetDevice::Simulator) {
-        log_info(
-            tt::LogMetal,
-            "Enabling DRAM-backed command queues for Quasar simulator because host hugepages are not available");
-        this->rtoptions_->set_dram_backed_cq(true);
+    if (platform_arch == tt::ARCH::QUASAR && this->rtoptions_->get_fast_dispatch()) {
+        if (this->cluster_->get_target_device_type() == tt::TargetDevice::Simulator) {
+            log_info(
+                tt::LogMetal,
+                "Enabling DRAM-backed command queues for Quasar simulator because host hugepages are not available");
+            this->rtoptions_->set_dram_backed_cq(true);
+        }
+        // Watcher NOC sanitization currently only works on Quasar in slow dispatch.
+        // Once it is supported on Quasar in fast dispatch, this can be removed.
+        this->rtoptions_->disable_watcher_noc_sanitize();
     }
 
     // Get is_base_routing_fw_enabled from the already-constructed Cluster instead of running

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -122,6 +122,7 @@ void WatcherServer::Impl::attach_devices() {
         return;
     }
 
+    // TODO: Remove this once NOC sanitization is supported on Quasar in fast dispatch (#45878)
     if (env_.get_hal().get_arch() == tt::ARCH::QUASAR && rtoptions.get_fast_dispatch()) {
         log_warning(
             tt::LogMetal,

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -122,6 +122,12 @@ void WatcherServer::Impl::attach_devices() {
         return;
     }
 
+    if (env_.get_hal().get_arch() == tt::ARCH::QUASAR && rtoptions.get_fast_dispatch()) {
+        log_warning(
+            tt::LogMetal,
+            "Watcher NOC sanitization has been disabled as it is currently not supported on Quasar in fast dispatch.");
+    }
+
     {
         const std::lock_guard<std::mutex> lock(watch_mutex_);
         create_log_file();

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -466,7 +466,6 @@ public:
     }
     const std::set<std::string>& get_watcher_disabled_features() const { return watcher_disabled_features; }
     bool watcher_status_disabled() const { return watcher_feature_disabled(watcher_waypoint_str); }
-    bool watcher_noc_sanitize_disabled() const { return watcher_feature_disabled(watcher_noc_sanitize_str); }
     bool watcher_assert_disabled() const { return watcher_feature_disabled(watcher_assert_str); }
     bool watcher_pause_disabled() const { return watcher_feature_disabled(watcher_pause_str); }
     bool watcher_ring_buffer_disabled() const { return watcher_feature_disabled(watcher_ring_buffer_str); }
@@ -475,6 +474,8 @@ public:
     bool watcher_eth_disabled() const { return watcher_feature_disabled(watcher_eth_str); }
     bool watcher_eth_link_status_disabled() const { return watcher_feature_disabled(watcher_eth_link_status_str); }
     bool watcher_cb_sanitize_disabled() const { return watcher_feature_disabled(watcher_cb_sanitize_str); }
+    bool watcher_noc_sanitize_disabled() const { return watcher_feature_disabled(watcher_noc_sanitize_str); }
+    void disable_watcher_noc_sanitize() { watcher_disabled_features.insert(watcher_noc_sanitize_str); }
 
     bool get_lightweight_kernel_asserts() const { return lightweight_kernel_asserts; }
     void set_lightweight_kernel_asserts(bool enabled) { lightweight_kernel_asserts = enabled; }

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -474,6 +474,9 @@ public:
     bool watcher_eth_disabled() const { return watcher_feature_disabled(watcher_eth_str); }
     bool watcher_eth_link_status_disabled() const { return watcher_feature_disabled(watcher_eth_link_status_str); }
     bool watcher_cb_sanitize_disabled() const { return watcher_feature_disabled(watcher_cb_sanitize_str); }
+
+    // TODO: Remove these Watcher NOC sanitize functions once NOC sanitization is supported on Quasar in fast dispatch
+    // (#45878)
     bool watcher_noc_sanitize_disabled() const { return watcher_feature_disabled(watcher_noc_sanitize_str); }
     void disable_watcher_noc_sanitize() { watcher_disabled_features.insert(watcher_noc_sanitize_str); }
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Watcher NOC sanitization is currently not supported on Quasar in fast dispatch mode. This PR temporarily disables it in that configuration and updates affected watcher tests to skip via `GTEST_SKIP()`. Once NOC sanitization is supported on Quasar in fast dispatch, it will be re-enabled.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_disable_noc_sanitize)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sagarwal/qsr_disable_noc_sanitize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_disable_noc_sanitize)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sagarwal/qsr_disable_noc_sanitize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sagarwal/qsr_disable_noc_sanitize)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sagarwal/qsr_disable_noc_sanitize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/qsr_disable_noc_sanitize)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/qsr_disable_noc_sanitize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sagarwal/qsr_disable_noc_sanitize)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sagarwal/qsr_disable_noc_sanitize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sagarwal/qsr_disable_noc_sanitize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sagarwal/qsr_disable_noc_sanitize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sagarwal/qsr_disable_noc_sanitize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sagarwal/qsr_disable_noc_sanitize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sagarwal/qsr_disable_noc_sanitize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sagarwal/qsr_disable_noc_sanitize)