### PR TITLE
emule: drop vestigial tt_emule::Device __device thread-local

### DIFF
--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -87,7 +87,6 @@ thread_local uint32_t* __rt_args = nullptr;
 thread_local uint32_t* __common_rt_args = nullptr;
 
 thread_local tt_emule::Core* __core = nullptr;
-thread_local tt_emule::Device* __device = nullptr;
 
 // Memory bridge pointers — now non-static for -rdynamic export.
 thread_local uint8_t* __emule_bridge_l1 = nullptr;
@@ -2221,7 +2220,6 @@ static void launch_cores(
                             __emule_tc_array = tc_array;
                             __processor_id = ki.processor_id;
                             __core = core;
-                            __device = nullptr;
                             __emule_core_map = core_map_ptr;
                             my_x[0] = px;
                             my_x[1] = px;


### PR DESCRIPTION
## What

Removes the vestigial `thread_local tt_emule::Device* __device` from `tt_metal/impl/emulation/emulated_program_runner.cpp`. It was pinned to `nullptr` and never dereferenced by any JIT kernel (kernels reach memory through `__core` and the C-linkage bridges); it existed only as the integrated-path counterpart to tt-emule's standalone fake-device path.

## Why

Kernel-ABI **companion** to the tt-emule change that removes the standalone path and the `tt_emule::Device` type entirely (pinned via `tt-metal-pin.txt`; tt-emule PR linked from there). With this merged, tt-emule drops the `__device` extern from `jit_kernel_stubs.hpp` and deletes `tt_emule::Device`.

## Test plan

Built with `TT_METAL_USE_EMULE=ON` against the companion tt-emule branch and ran the emule C++ regressions: WH 39/0, BH 19/0 (zero-tolerance), quasar 103/11 (matches `known-failures-quasar.txt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=arminale/drop-vestigial-emule-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:arminale/drop-vestigial-emule-device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=arminale/drop-vestigial-emule-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:arminale/drop-vestigial-emule-device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=arminale/drop-vestigial-emule-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:arminale/drop-vestigial-emule-device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=arminale/drop-vestigial-emule-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:arminale/drop-vestigial-emule-device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=arminale/drop-vestigial-emule-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:arminale/drop-vestigial-emule-device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=arminale/drop-vestigial-emule-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:arminale/drop-vestigial-emule-device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=arminale/drop-vestigial-emule-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:arminale/drop-vestigial-emule-device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=arminale/drop-vestigial-emule-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:arminale/drop-vestigial-emule-device)