### PR TITLE
[Bug fix] Respect harvested DRAM channels in Metal DRAM-view + prefetcher sender selection

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_dram_subchannel_helper.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_subchannel_helper.cpp
@@ -42,7 +42,7 @@ TEST_F(DramSubchannelHelperFixture, PicksUnreservedSubchannelPerBank) {
         // Logical/compacted channel — get_dram_core_for_channel indexes the compacted DRAM grid,
         // so on a harvested board this must match what pick_unused_dram_logical_core uses (passing
         // the raw physical channel here indexes the wrong core and the harvested grid throws).
-        const size_t channel = soc_desc.get_logical_channel_for_dram_view(static_cast<int>(bank));
+        const size_t channel = soc_desc.get_channel_for_dram_view(static_cast<int>(bank));
         uint32_t expected_free = num_subchannels;
         for (uint32_t sub = 0; sub < num_subchannels; ++sub) {
             tt::umd::CoreCoord coord = soc_desc.get_dram_core_for_channel(

--- a/tests/tt_metal/tt_metal/api/test_dram_subchannel_helper.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_subchannel_helper.cpp
@@ -39,7 +39,10 @@ TEST_F(DramSubchannelHelperFixture, PicksUnreservedSubchannelPerBank) {
             reserved.emplace(c.x, c.y);
         }
 
-        const size_t channel = soc_desc.get_channel_for_dram_view(static_cast<int>(bank));
+        // Logical/compacted channel — get_dram_core_for_channel indexes the compacted DRAM grid,
+        // so on a harvested board this must match what pick_unused_dram_logical_core uses (passing
+        // the raw physical channel here indexes the wrong core and the harvested grid throws).
+        const size_t channel = soc_desc.get_logical_channel_for_dram_view(static_cast<int>(bank));
         uint32_t expected_free = num_subchannels;
         for (uint32_t sub = 0; sub < num_subchannels; ++sub) {
             tt::umd::CoreCoord coord = soc_desc.get_dram_core_for_channel(

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1505,7 +1505,7 @@ CoreCoord MeshDeviceImpl::pick_unused_dram_logical_core(uint32_t bank_id) const 
     }
 
     const uint32_t num_subchannels = soc_desc.get_grid_size(tt::CoreType::DRAM).y;
-    const size_t channel = soc_desc.get_logical_channel_for_dram_view(static_cast<int>(bank_id));
+    const size_t channel = soc_desc.get_channel_for_dram_view(static_cast<int>(bank_id));
     for (uint32_t sub = 0; sub < num_subchannels; ++sub) {
         tt::umd::CoreCoord coord = soc_desc.get_dram_core_for_channel(
             static_cast<int>(channel), static_cast<int>(sub), tt::CoordSystem::TRANSLATED);
@@ -1531,7 +1531,7 @@ std::vector<CoreCoord> MeshDeviceImpl::dram_sender_logical_cores(uint32_t bank_i
     const CoreCoord noc1_endpoint_phys =
         soc_desc.get_preferred_worker_core_for_dram_view(static_cast<int>(bank_id), /*noc=*/static_cast<uint8_t>(1));
     const uint32_t num_subchannels = soc_desc.get_grid_size(tt::CoreType::DRAM).y;
-    const size_t channel = soc_desc.get_logical_channel_for_dram_view(static_cast<int>(bank_id));
+    const size_t channel = soc_desc.get_channel_for_dram_view(static_cast<int>(bank_id));
     for (uint32_t sub = 0; sub < num_subchannels; ++sub) {
         const tt::umd::CoreCoord coord = soc_desc.get_dram_core_for_channel(
             static_cast<int>(channel), static_cast<int>(sub), tt::CoordSystem::TRANSLATED);

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1505,7 +1505,7 @@ CoreCoord MeshDeviceImpl::pick_unused_dram_logical_core(uint32_t bank_id) const 
     }
 
     const uint32_t num_subchannels = soc_desc.get_grid_size(tt::CoreType::DRAM).y;
-    const size_t channel = soc_desc.get_channel_for_dram_view(static_cast<int>(bank_id));
+    const size_t channel = soc_desc.get_logical_channel_for_dram_view(static_cast<int>(bank_id));
     for (uint32_t sub = 0; sub < num_subchannels; ++sub) {
         tt::umd::CoreCoord coord = soc_desc.get_dram_core_for_channel(
             static_cast<int>(channel), static_cast<int>(sub), tt::CoordSystem::TRANSLATED);
@@ -1531,7 +1531,7 @@ std::vector<CoreCoord> MeshDeviceImpl::dram_sender_logical_cores(uint32_t bank_i
     const CoreCoord noc1_endpoint_phys =
         soc_desc.get_preferred_worker_core_for_dram_view(static_cast<int>(bank_id), /*noc=*/static_cast<uint8_t>(1));
     const uint32_t num_subchannels = soc_desc.get_grid_size(tt::CoreType::DRAM).y;
-    const size_t channel = soc_desc.get_channel_for_dram_view(static_cast<int>(bank_id));
+    const size_t channel = soc_desc.get_logical_channel_for_dram_view(static_cast<int>(bank_id));
     for (uint32_t sub = 0; sub < num_subchannels; ++sub) {
         const tt::umd::CoreCoord coord = soc_desc.get_dram_core_for_channel(
             static_cast<int>(channel), static_cast<int>(sub), tt::CoordSystem::TRANSLATED);

--- a/tt_metal/llrt/metal_soc_descriptor.cpp
+++ b/tt_metal/llrt/metal_soc_descriptor.cpp
@@ -92,7 +92,7 @@ size_t metal_SocDescriptor::get_address_offset(int dram_view) const {
     return this->dram_view_address_offsets.at(dram_view);
 }
 
-size_t metal_SocDescriptor::get_channel_for_dram_view(int dram_view) const {
+size_t metal_SocDescriptor::get_physical_channel_for_dram_view(int dram_view) const {
     TT_ASSERT(
         dram_view < this->dram_view_channels.size(),
         "dram_view={} must be within range of dram_view_channels.size={}",
@@ -101,8 +101,8 @@ size_t metal_SocDescriptor::get_channel_for_dram_view(int dram_view) const {
     return this->dram_view_channels.at(dram_view);
 }
 
-size_t metal_SocDescriptor::get_logical_channel_for_dram_view(int dram_view) const {
-    const size_t physical_channel = get_channel_for_dram_view(dram_view);
+size_t metal_SocDescriptor::get_channel_for_dram_view(int dram_view) const {
+    const size_t physical_channel = get_physical_channel_for_dram_view(dram_view);
     const uint32_t dram_harvesting_mask = this->harvesting_masks.dram_harvesting_mask;
     TT_ASSERT(
         (dram_harvesting_mask & (1u << physical_channel)) == 0,
@@ -156,7 +156,7 @@ CoreCoord metal_SocDescriptor::get_physical_dram_core_from_logical(const CoreCoo
 }
 
 CoreCoord metal_SocDescriptor::get_logical_dram_core_for_subchannel(int dram_view, int subchannel) const {
-    const int channel = static_cast<int>(get_logical_channel_for_dram_view(dram_view));
+    const int channel = static_cast<int>(get_channel_for_dram_view(dram_view));
     const tt::umd::CoreCoord phys_umd = get_dram_core_for_channel(channel, subchannel, tt::CoordSystem::TRANSLATED);
     const CoreCoord phys{phys_umd.x, phys_umd.y};
     TT_FATAL(

--- a/tt_metal/llrt/metal_soc_descriptor.cpp
+++ b/tt_metal/llrt/metal_soc_descriptor.cpp
@@ -10,13 +10,19 @@
 #include <umd/device/types/arch.hpp>
 
 namespace {
+// True if physical DRAM `channel` is harvested per `dram_harvesting_mask`. Single home for the
+// bit-masking convention used across the DRAM-view helpers below.
+bool is_dram_channel_harvested(uint32_t dram_harvesting_mask, size_t channel) {
+    return (dram_harvesting_mask & (1u << channel)) != 0;
+}
+
 // Number of harvested DRAM channels with index strictly below `channel`. Maps a physical DRAM
 // channel to its compacted/logical index via (physical - harvested_before): UMD presents only
 // non-harvested channels, compacted, so a physical channel with a gap must be shifted down.
 size_t harvested_before(uint32_t dram_harvesting_mask, size_t channel) {
     size_t count = 0;
     for (size_t c = 0; c < channel; ++c) {
-        if ((dram_harvesting_mask & (1u << c)) != 0) {
+        if (is_dram_channel_harvested(dram_harvesting_mask, c)) {
             ++count;
         }
     }
@@ -105,7 +111,7 @@ size_t metal_SocDescriptor::get_channel_for_dram_view(int dram_view) const {
     const size_t physical_channel = get_physical_channel_for_dram_view(dram_view);
     const uint32_t dram_harvesting_mask = this->harvesting_masks.dram_harvesting_mask;
     TT_ASSERT(
-        (dram_harvesting_mask & (1u << physical_channel)) == 0,
+        !is_dram_channel_harvested(dram_harvesting_mask, physical_channel),
         "dram_view={} refers to harvested physical DRAM channel {}",
         dram_view,
         physical_channel);
@@ -205,13 +211,10 @@ void metal_SocDescriptor::load_dram_metadata_from_device_descriptor() {
     this->dram_bank_endpoint_coords.clear();
 
     const uint32_t dram_harvesting_mask = this->harvesting_masks.dram_harvesting_mask;
-    auto is_dram_channel_harvested = [dram_harvesting_mask](size_t physical_channel) {
-        return (dram_harvesting_mask & (1u << physical_channel)) != 0;
-    };
 
     for (const auto& dram_view : device_descriptor_yaml["dram_views"]) {
         size_t channel = dram_view["channel"].as<size_t>();
-        if (is_dram_channel_harvested(channel)) {
+        if (is_dram_channel_harvested(dram_harvesting_mask, channel)) {
             continue;
         }
         const size_t logical_channel = channel - harvested_before(dram_harvesting_mask, channel);

--- a/tt_metal/llrt/metal_soc_descriptor.cpp
+++ b/tt_metal/llrt/metal_soc_descriptor.cpp
@@ -6,9 +6,23 @@
 
 #include <tt_stl/assert.hpp>
 #include <yaml-cpp/yaml.h>
-#include <string>
 
 #include <umd/device/types/arch.hpp>
+
+namespace {
+// Number of harvested DRAM channels with index strictly below `channel`. Maps a physical DRAM
+// channel to its compacted/logical index via (physical - harvested_before): UMD presents only
+// non-harvested channels, compacted, so a physical channel with a gap must be shifted down.
+size_t harvested_before(uint32_t dram_harvesting_mask, size_t channel) {
+    size_t count = 0;
+    for (size_t c = 0; c < channel; ++c) {
+        if ((dram_harvesting_mask & (1u << c)) != 0) {
+            ++count;
+        }
+    }
+    return count;
+}
+}  // namespace
 
 CoreCoord metal_SocDescriptor::get_preferred_worker_core_for_dram_view(int dram_view, uint8_t noc) const {
     TT_ASSERT(
@@ -87,6 +101,17 @@ size_t metal_SocDescriptor::get_channel_for_dram_view(int dram_view) const {
     return this->dram_view_channels.at(dram_view);
 }
 
+size_t metal_SocDescriptor::get_logical_channel_for_dram_view(int dram_view) const {
+    const size_t physical_channel = get_channel_for_dram_view(dram_view);
+    const uint32_t dram_harvesting_mask = this->harvesting_masks.dram_harvesting_mask;
+    TT_ASSERT(
+        (dram_harvesting_mask & (1u << physical_channel)) == 0,
+        "dram_view={} refers to harvested physical DRAM channel {}",
+        dram_view,
+        physical_channel);
+    return physical_channel - harvested_before(dram_harvesting_mask, physical_channel);
+}
+
 size_t metal_SocDescriptor::get_num_dram_views() const { return this->dram_view_eth_cores.size(); }
 
 int metal_SocDescriptor::get_dram_channel_from_logical_core(const CoreCoord& logical_coord) const {
@@ -131,7 +156,7 @@ CoreCoord metal_SocDescriptor::get_physical_dram_core_from_logical(const CoreCoo
 }
 
 CoreCoord metal_SocDescriptor::get_logical_dram_core_for_subchannel(int dram_view, int subchannel) const {
-    const int channel = static_cast<int>(get_channel_for_dram_view(dram_view));
+    const int channel = static_cast<int>(get_logical_channel_for_dram_view(dram_view));
     const tt::umd::CoreCoord phys_umd = get_dram_core_for_channel(channel, subchannel, tt::CoordSystem::TRANSLATED);
     const CoreCoord phys{phys_umd.x, phys_umd.y};
     TT_FATAL(
@@ -179,10 +204,18 @@ void metal_SocDescriptor::load_dram_metadata_from_device_descriptor() {
     this->dram_view_address_offsets.clear();
     this->dram_bank_endpoint_coords.clear();
 
+    const uint32_t dram_harvesting_mask = this->harvesting_masks.dram_harvesting_mask;
+    auto is_dram_channel_harvested = [dram_harvesting_mask](size_t physical_channel) {
+        return (dram_harvesting_mask & (1u << physical_channel)) != 0;
+    };
+
     for (const auto& dram_view : device_descriptor_yaml["dram_views"]) {
         size_t channel = dram_view["channel"].as<size_t>();
-        if (channel >= get_grid_size(tt::CoreType::DRAM).x) {
-            // DRAM can be harvested and we don't create unique soc desc for diff harvesting
+        if (is_dram_channel_harvested(channel)) {
+            continue;
+        }
+        const size_t logical_channel = channel - harvested_before(dram_harvesting_mask, channel);
+        if (logical_channel >= get_grid_size(tt::CoreType::DRAM).x) {
             break;
         }
         size_t address_offset = dram_view["address_offset"].as<size_t>();
@@ -197,7 +230,7 @@ void metal_SocDescriptor::load_dram_metadata_from_device_descriptor() {
                     eth_endpoint);
             }
             tt::umd::CoreCoord eth_dram_endpoint_coord =
-                get_dram_core_for_channel(channel, eth_endpoint, tt::CoordSystem::TRANSLATED);
+                get_dram_core_for_channel(logical_channel, eth_endpoint, tt::CoordSystem::TRANSLATED);
             eth_dram_cores.push_back({eth_dram_endpoint_coord.x, eth_dram_endpoint_coord.y});
             eth_endpoints.push_back(eth_endpoint);
         }
@@ -212,7 +245,7 @@ void metal_SocDescriptor::load_dram_metadata_from_device_descriptor() {
                     worker_endpoint);
             }
             tt::umd::CoreCoord worker_endpoint_coord =
-                get_dram_core_for_channel(channel, worker_endpoint, tt::CoordSystem::TRANSLATED);
+                get_dram_core_for_channel(logical_channel, worker_endpoint, tt::CoordSystem::TRANSLATED);
 
             worker_dram_cores.push_back({worker_endpoint_coord.x, worker_endpoint_coord.y});
             worker_endpoints.push_back(worker_endpoint);
@@ -227,11 +260,12 @@ void metal_SocDescriptor::load_dram_metadata_from_device_descriptor() {
         size_t preferred_subchannel = worker_endpoints[0];
         std::vector<CoreCoord> bank_endpoints;
         bank_endpoints.reserve(num_subchannels);
-        auto preferred_coord = get_dram_core_for_channel(channel, preferred_subchannel, tt::CoordSystem::TRANSLATED);
+        auto preferred_coord =
+            get_dram_core_for_channel(logical_channel, preferred_subchannel, tt::CoordSystem::TRANSLATED);
         bank_endpoints.push_back({preferred_coord.x, preferred_coord.y});
         for (size_t sub = 0; sub < num_subchannels; sub++) {
             if (sub != preferred_subchannel) {
-                auto coord = get_dram_core_for_channel(channel, sub, tt::CoordSystem::TRANSLATED);
+                auto coord = get_dram_core_for_channel(logical_channel, sub, tt::CoordSystem::TRANSLATED);
                 bank_endpoints.push_back({coord.x, coord.y});
             }
         }

--- a/tt_metal/llrt/metal_soc_descriptor.hpp
+++ b/tt_metal/llrt/metal_soc_descriptor.hpp
@@ -53,7 +53,7 @@ public:
     std::vector<CoreCoord> get_metal_dram_cores(tt::CoordSystem coord_system) const;
     CoreCoord get_logical_core_for_dram_view(int dram_view) const;
     size_t get_address_offset(int dram_view) const;
-    size_t get_logical_channel_for_dram_view(int dram_view) const;
+    size_t get_channel_for_dram_view(int dram_view) const;
     size_t get_num_dram_views() const;
 
     int get_dram_channel_from_logical_core(const CoreCoord& logical_coord) const;
@@ -76,9 +76,9 @@ public:
 
 private:
     // Physical DRAM channel (device-descriptor numbering, with harvested-channel gaps) for a dram
-    // view. Internal building block for get_logical_channel_for_dram_view, which compacts it to the
+    // view. Internal building block for get_channel_for_dram_view, which compacts it to the logical
     // index get_dram_core_for_channel expects; callers want the logical one.
-    size_t get_channel_for_dram_view(int dram_view) const;
+    size_t get_physical_channel_for_dram_view(int dram_view) const;
 
     // True if `translated_coord` is any DRAM view's NOC0 worker endpoint (the subchannel a NOC0 DRAM
     // access routes to) -- the syseng-owned endpoint excluded by get_metal_dram_cores on Blackhole.

--- a/tt_metal/llrt/metal_soc_descriptor.hpp
+++ b/tt_metal/llrt/metal_soc_descriptor.hpp
@@ -53,7 +53,7 @@ public:
     std::vector<CoreCoord> get_metal_dram_cores(tt::CoordSystem coord_system) const;
     CoreCoord get_logical_core_for_dram_view(int dram_view) const;
     size_t get_address_offset(int dram_view) const;
-    size_t get_channel_for_dram_view(int dram_view) const;
+    size_t get_logical_channel_for_dram_view(int dram_view) const;
     size_t get_num_dram_views() const;
 
     int get_dram_channel_from_logical_core(const CoreCoord& logical_coord) const;
@@ -75,6 +75,11 @@ public:
     std::map<CoreCoord, int32_t> physical_routing_to_profiler_flat_id;
 
 private:
+    // Physical DRAM channel (device-descriptor numbering, with harvested-channel gaps) for a dram
+    // view. Internal building block for get_logical_channel_for_dram_view, which compacts it to the
+    // index get_dram_core_for_channel expects; callers want the logical one.
+    size_t get_channel_for_dram_view(int dram_view) const;
+
     // True if `translated_coord` is any DRAM view's NOC0 worker endpoint (the subchannel a NOC0 DRAM
     // access routes to) -- the syseng-owned endpoint excluded by get_metal_dram_cores on Blackhole.
     // Argument must be a TRANSLATED (UMD) coord; a metal-logical {view, subchannel} coord never matches.


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
On Blackhole boards with a **mid-grid harvested DRAM channel** (e.g. p100a), Metal's DRAM-view
metadata and the programmable-DRAM-sender selection used the **physical** DRAM channel directly
where a **compacted/logical** index is required.

`SocDescriptor::get_dram_core_for_channel(chan, …)` builds `CoreCoord(chan, …, LOGICAL)`, and UMD
presents only non-harvested DRAM channels (compacted). The old code passed the physical channel and
only coped with *trailing* harvesting (`channel >= grid.x → break`). With a harvested channel in the
*middle* of the grid this indexed the wrong DRAM core, so `pick_unused_dram_logical_core` /
`dram_sender_logical_cores` could select a **syseng GDDR telemetry endpoint** as a tensor-prefetcher
sender. The prefetcher then clobbered that endpoint, corrupting ARC's aggregate `GDDR_STATUS`
training bit for the channel — so the *next* device init hung in UMD's
`wait_dram_channel_training` (300 s timeout). Symptom: the streaming tensor-prefetcher matmul test
passes once, then hangs on the next run without a hardware reset.

**Fix:** map physical DRAM channels to compacted/logical indices (physical − harvested-channels-before,
via a shared `harvested_before` helper) and skip harvested channels when loading DRAM metadata; route
all `get_dram_core_for_channel` callers and the prefetcher sender selection through the logical channel.

Relates to #45751.

### Notes for reviewers
- Focus on `get_channel_for_dram_view` and `load_dram_metadata_from_device_descriptor` in
  `metal_soc_descriptor.cpp` — the physical→logical remap. (`get_channel_for_dram_view` is the public
  accessor and returns the **logical/compacted** channel; the private `get_physical_channel_for_dram_view`
  is the raw building block.)
- **No-op when nothing is harvested** (`dram_harvesting_mask == 0` ⇒ logical == physical, skip none),
  so non-harvested boards are unaffected. Verified: caller coverage is complete —
  `get_physical_channel_for_dram_view` (physical) is now consumed only inside `get_channel_for_dram_view`.
- This touches **core DRAM-view enumeration**, not just the prefetcher — on harvested boards it changes
  which physical cores back each `dram_view`/bank for all DRAM paths (the old mapping was simply wrong
  there). A general sharded-DRAM smoke on a harvested board is worth a look.
- Validated on p100a: the streaming tensor-prefetcher matmul sweep now passes **3 runs back-to-back
  with no reset between** (9/9 each); it hung on the 2nd run before.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/fix-dram-harvested-prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/fix-dram-harvested-prefetcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/fix-dram-harvested-prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/fix-dram-harvested-prefetcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/fix-dram-harvested-prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/fix-dram-harvested-prefetcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/fix-dram-harvested-prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/fix-dram-harvested-prefetcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/fix-dram-harvested-prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/fix-dram-harvested-prefetcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/fix-dram-harvested-prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/fix-dram-harvested-prefetcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/fix-dram-harvested-prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/fix-dram-harvested-prefetcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/fix-dram-harvested-prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/fix-dram-harvested-prefetcher)
