### PR TITLE
#47644: Extend universal input/output support for ttnn::fold

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_fold.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_fold.py
@@ -1,0 +1,692 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+_TTNN_TO_TORCH_DTYPE = {
+    ttnn.bfloat16: torch.bfloat16,
+    ttnn.float32: torch.float32,
+}
+
+_TILE_H = 32
+_TILE_W = 32
+
+L1_INTERLEAVED = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
+DRAM_INTERLEAVED = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Reference + helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _fold_torch_nhwc(x_nhwc, stride_h, stride_w):
+    """Reference fold: (N,H,W,C) → (N, H/sh, W/sw, C*sh*sw) (NHWC space-to-depth)."""
+    n, h, w, c = x_nhwc.shape
+    reshaped = x_nhwc.reshape(n, h // stride_h, stride_h, w // stride_w, stride_w, c)
+    transposed = reshaped.permute(0, 1, 3, 2, 4, 5).contiguous()
+    return transposed.reshape(n, h // stride_h, w // stride_w, c * stride_h * stride_w)
+
+
+def _round_up(x, m):
+    return ((x + m - 1) // m) * m
+
+
+def _height_sharded_nhwc(shape, device, ncores, layout, orientation=ttnn.ShardOrientation.ROW_MAJOR):
+    """HEIGHT_SHARDED memory config for an (N,H,W,C) tensor: shard along total pixels (N*H*W)."""
+    n, h, w, c = shape
+    grid = device.compute_with_storage_grid_size()
+    if ncores > grid.x * grid.y:
+        pytest.skip(f"Device has {grid.x * grid.y} cores, test needs {ncores}")
+    shard_grid = ttnn.num_cores_to_corerangeset(ncores, grid, True)
+    total_pixels = n * h * w
+    if total_pixels % ncores != 0:
+        pytest.skip(f"total pixels {total_pixels} not divisible by ncores {ncores}")
+    shard_h = total_pixels // ncores
+    shard_w = c
+    if layout == ttnn.TILE_LAYOUT:
+        shard_h = _round_up(shard_h, _TILE_H)
+        shard_w = _round_up(shard_w, _TILE_W)
+    return ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(shard_grid, (shard_h, shard_w), orientation),
+    )
+
+
+def _width_sharded_nhwc(shape, device, ncores, layout, orientation=ttnn.ShardOrientation.ROW_MAJOR):
+    """WIDTH_SHARDED memory config: shard along C across cores."""
+    n, h, w, c = shape
+    grid = device.compute_with_storage_grid_size()
+    if ncores > grid.x * grid.y:
+        pytest.skip(f"Device has {grid.x * grid.y} cores, test needs {ncores}")
+    if c % ncores != 0:
+        pytest.skip(f"C={c} not divisible by ncores={ncores}")
+    shard_grid = ttnn.num_cores_to_corerangeset(ncores, grid, True)
+    total_pixels = n * h * w
+    shard_h = total_pixels
+    shard_w = c // ncores
+    if layout == ttnn.TILE_LAYOUT:
+        shard_h = _round_up(shard_h, _TILE_H)
+        shard_w = _round_up(shard_w, _TILE_W)
+    return ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(shard_grid, (shard_h, shard_w), orientation),
+    )
+
+
+def _block_sharded_nhwc(shape, device, grid_y, grid_x, layout, orientation=ttnn.ShardOrientation.ROW_MAJOR):
+    """BLOCK_SHARDED memory config: 2D grid over pixel-rows × C."""
+    n, h, w, c = shape
+    compute_grid = device.compute_with_storage_grid_size()
+    if grid_y > compute_grid.y or grid_x > compute_grid.x:
+        pytest.skip(f"Device grid ({compute_grid.y}x{compute_grid.x}) too small for {grid_y}x{grid_x}")
+    total_pixels = n * h * w
+    if total_pixels % grid_y != 0 or c % grid_x != 0:
+        pytest.skip(f"total_pixels={total_pixels} % grid_y={grid_y} or C={c} % grid_x={grid_x} != 0")
+    shard_h = total_pixels // grid_y
+    shard_w = c // grid_x
+    if layout == ttnn.TILE_LAYOUT:
+        shard_h = _round_up(shard_h, _TILE_H)
+        shard_w = _round_up(shard_w, _TILE_W)
+    return ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_x - 1, grid_y - 1))}),
+            (shard_h, shard_w),
+            orientation,
+        ),
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Shared runner
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _assert_output_layout_contract(result, input_mem_config):
+    """Universal-IO contract: output TensorMemoryLayout + ShardOrientation match input's (no silent demotion)."""
+    expected_layout = input_mem_config.memory_layout
+    actual_layout = result.memory_config().memory_layout
+    assert actual_layout == expected_layout, (
+        f"Universal-IO contract violated: input layout={expected_layout}, "
+        f"output layout={actual_layout} (sharded input must yield sharded output)."
+    )
+    sharded_layouts = {
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+    }
+    if expected_layout in sharded_layouts:
+        out_spec = result.memory_config().shard_spec
+        assert out_spec is not None, "Sharded output missing shard_spec"
+        in_spec = input_mem_config.shard_spec
+        if in_spec is not None:
+            assert out_spec.orientation == in_spec.orientation, (
+                f"ShardOrientation silently demoted: input={in_spec.orientation}, " f"output={out_spec.orientation}."
+            )
+
+
+def _run_fold(shape, stride_h, stride_w, layout, input_mem_config, dtype, device, pcc=0.9999):
+    torch.manual_seed(12345)
+    torch_dtype = _TTNN_TO_TORCH_DTYPE[dtype]
+    x_nhwc = torch.rand(shape, dtype=torch_dtype)
+    expected = _fold_torch_nhwc(x_nhwc, stride_h, stride_w)
+
+    ttnn_in = ttnn.from_torch(x_nhwc, layout=layout, dtype=dtype, device=device, memory_config=input_mem_config)
+    result = ttnn.fold(ttnn_in, stride_h=stride_h, stride_w=stride_w)
+
+    _assert_output_layout_contract(result, input_mem_config)
+
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+
+    n, h, w, c = expected.shape
+    assert (
+        got.numel() == expected.numel()
+    ), f"fold output numel mismatch: got {tuple(got.shape)} ({got.numel()}) vs expected {tuple(expected.shape)} ({expected.numel()})"
+    got_4d = got.reshape(n, h, w, c)
+    assert_with_pcc(expected.float(), got_4d.float(), pcc)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Group A: interleaved baselines (cross-product of buffer × layout × dtype × stride)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize(
+    "mem_config",
+    [
+        pytest.param(DRAM_INTERLEAVED, id="dram"),
+        pytest.param(L1_INTERLEAVED, id="l1"),
+    ],
+)
+@pytest.mark.parametrize(
+    "shape, stride",
+    [
+        # TILE pads H,W to multiples of 32, so only strides dividing 32 (2, 4) work; RM irregular strides covered separately.
+        pytest.param((1, 8, 8, 32), (2, 2), id="s2x2_small"),
+        pytest.param((1, 16, 16, 32), (4, 4), id="s4x4"),
+    ],
+)
+def test_fold_interleaved_baselines(layout, mem_config, dtype, shape, stride, device):
+    """DRAM/L1 × RM/TILE × bf16/f32 × {2x2, 4x4}; TILE must NOT pass through composite to_layout(RM)."""
+    _run_fold(shape, stride[0], stride[1], layout, mem_config, dtype, device)
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize(
+    "mem_config",
+    [
+        pytest.param(DRAM_INTERLEAVED, id="dram"),
+        pytest.param(L1_INTERLEAVED, id="l1"),
+    ],
+)
+@pytest.mark.parametrize(
+    "shape, stride",
+    [
+        pytest.param((1, 12, 12, 32), (3, 3), id="s3x3"),
+        pytest.param((1, 6, 8, 32), (3, 2), id="s3x2_asym"),
+        pytest.param((1, 8, 6, 32), (2, 3), id="s2x3_asym"),
+    ],
+)
+def test_fold_interleaved_baselines_rm_only(mem_config, dtype, shape, stride, device):
+    """Irregular strides on RM inputs (TILE padding would inflate H,W past stride divisibility)."""
+    _run_fold(shape, stride[0], stride[1], ttnn.ROW_MAJOR_LAYOUT, mem_config, dtype, device)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Group B: HEIGHT_SHARDED — RM fast path + TILE native + orientations
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "shape, ncores, stride",
+    [
+        pytest.param((1, 8, 8, 32), 2, (2, 2), id="small_ncores2_s2x2"),
+        pytest.param((1, 8, 8, 32), 4, (2, 2), id="small_ncores4_s2x2"),
+        pytest.param((1, 16, 16, 64), 8, (2, 2), id="medium_s2x2"),
+        pytest.param((1, 16, 16, 32), 4, (4, 4), id="s4x4"),
+        pytest.param((1, 12, 8, 32), 2, (3, 2), id="s3x2_asym"),
+    ],
+)
+def test_fold_height_sharded_rm_fast_path(shape, ncores, stride, device):
+    """HEIGHT_SHARDED + ROW_MAJOR → zero-NOC MultiCore fast path."""
+    mc = _height_sharded_nhwc(shape, device, ncores=ncores, layout=ttnn.ROW_MAJOR_LAYOUT)
+    _run_fold(shape, stride[0], stride[1], ttnn.ROW_MAJOR_LAYOUT, mc, ttnn.bfloat16, device)
+
+
+@pytest.mark.parametrize(
+    "shape, ncores, stride",
+    [
+        pytest.param((1, 32, 32, 32), 8, (2, 2), id="small_s2x2"),
+        pytest.param((1, 64, 64, 32), 8, (2, 2), id="larger_s2x2"),
+        pytest.param((1, 32, 32, 32), 8, (4, 4), id="s4x4"),
+        pytest.param((1, 64, 32, 32), 8, (4, 2), id="s4x2_asym"),
+    ],
+)
+def test_fold_height_sharded_tile_native(shape, ncores, stride, device):
+    """HEIGHT_SHARDED + TILE — native via MultiCoreDRAMFold's tiled branch (no composite untilize)."""
+    mc = _height_sharded_nhwc(shape, device, ncores=ncores, layout=ttnn.TILE_LAYOUT)
+    _run_fold(shape, stride[0], stride[1], ttnn.TILE_LAYOUT, mc, ttnn.bfloat16, device)
+
+
+@pytest.mark.parametrize(
+    "shape, ncores, layout",
+    [
+        pytest.param((1, 8, 8, 32), 2, ttnn.ROW_MAJOR_LAYOUT, id="rm"),
+        pytest.param((1, 32, 32, 32), 8, ttnn.TILE_LAYOUT, id="tile"),
+    ],
+)
+def test_fold_height_sharded_col_major_orientation(shape, ncores, layout, device):
+    """COL_MAJOR shard orientation must be preserved end-to-end (no silent demotion)."""
+    mc = _height_sharded_nhwc(shape, device, ncores=ncores, layout=layout, orientation=ttnn.ShardOrientation.COL_MAJOR)
+    _run_fold(shape, 2, 2, layout, mc, ttnn.bfloat16, device)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Group C: WIDTH_SHARDED (any layout) — universal-IO output contract
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "shape, ncores, stride, layout",
+    [
+        pytest.param((1, 8, 8, 64), 2, (2, 2), ttnn.ROW_MAJOR_LAYOUT, id="rm_small_s2x2"),
+        pytest.param((1, 8, 8, 128), 4, (2, 2), ttnn.ROW_MAJOR_LAYOUT, id="rm_ncores4_s2x2"),
+        pytest.param((1, 16, 16, 64), 4, (4, 4), ttnn.ROW_MAJOR_LAYOUT, id="rm_s4x4"),
+        pytest.param((1, 12, 8, 64), 2, (3, 2), ttnn.ROW_MAJOR_LAYOUT, id="rm_s3x2_asym"),
+        pytest.param((1, 32, 32, 64), 2, (2, 2), ttnn.TILE_LAYOUT, id="tile_small_s2x2"),
+        pytest.param((1, 32, 32, 128), 4, (2, 2), ttnn.TILE_LAYOUT, id="tile_ncores4_s2x2"),
+        pytest.param((1, 32, 32, 64), 2, (4, 4), ttnn.TILE_LAYOUT, id="tile_s4x4"),
+    ],
+)
+def test_fold_width_sharded(shape, ncores, stride, layout, device):
+    """WIDTH_SHARDED → W-sharded native via noc_async_write_sharded splitting the per-pixel stick."""
+    mc = _width_sharded_nhwc(shape, device, ncores=ncores, layout=layout)
+    _run_fold(shape, stride[0], stride[1], layout, mc, ttnn.bfloat16, device)
+
+
+@pytest.mark.parametrize(
+    "shape, ncores, layout",
+    [
+        pytest.param((1, 8, 8, 64), 2, ttnn.ROW_MAJOR_LAYOUT, id="rm"),
+        pytest.param((1, 32, 32, 64), 2, ttnn.TILE_LAYOUT, id="tile"),
+    ],
+)
+def test_fold_width_sharded_col_major(shape, ncores, layout, device):
+    """W-sharded with COL_MAJOR orientation must be preserved end-to-end."""
+    mc = _width_sharded_nhwc(shape, device, ncores=ncores, layout=layout, orientation=ttnn.ShardOrientation.COL_MAJOR)
+    _run_fold(shape, 2, 2, layout, mc, ttnn.bfloat16, device)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Group D: BLOCK_SHARDED (any layout) — universal-IO output contract
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "shape, grid, stride, layout",
+    [
+        pytest.param((1, 8, 8, 64), (2, 2), (2, 2), ttnn.ROW_MAJOR_LAYOUT, id="rm_2x2_s2x2"),
+        pytest.param((1, 16, 16, 64), (2, 2), (4, 4), ttnn.ROW_MAJOR_LAYOUT, id="rm_2x2_s4x4"),
+        pytest.param((1, 12, 8, 64), (2, 2), (3, 2), ttnn.ROW_MAJOR_LAYOUT, id="rm_2x2_s3x2_asym"),
+        pytest.param((1, 32, 32, 64), (2, 2), (2, 2), ttnn.TILE_LAYOUT, id="tile_2x2_s2x2"),
+        pytest.param((1, 32, 32, 64), (2, 2), (4, 4), ttnn.TILE_LAYOUT, id="tile_2x2_s4x4"),
+    ],
+)
+def test_fold_block_sharded(shape, grid, stride, layout, device):
+    """BLOCK_SHARDED → B-sharded native via noc_async_write_sharded (splits per-pixel stick across grid_x cores)."""
+    mc = _block_sharded_nhwc(shape, device, grid_y=grid[0], grid_x=grid[1], layout=layout)
+    _run_fold(shape, stride[0], stride[1], layout, mc, ttnn.bfloat16, device)
+
+
+@pytest.mark.parametrize(
+    "shape, grid, layout",
+    [
+        pytest.param((1, 8, 8, 64), (2, 2), ttnn.ROW_MAJOR_LAYOUT, id="rm"),
+        pytest.param((1, 32, 32, 64), (2, 2), ttnn.TILE_LAYOUT, id="tile"),
+    ],
+)
+def test_fold_block_sharded_col_major(shape, grid, layout, device):
+    """B-sharded with COL_MAJOR orientation."""
+    mc = _block_sharded_nhwc(
+        shape, device, grid_y=grid[0], grid_x=grid[1], layout=layout, orientation=ttnn.ShardOrientation.COL_MAJOR
+    )
+    _run_fold(shape, 2, 2, layout, mc, ttnn.bfloat16, device)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Group E: float32 — representative path each
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "shape, layout, mc_factory",
+    [
+        pytest.param(
+            (1, 8, 8, 32),
+            ttnn.ROW_MAJOR_LAYOUT,
+            lambda d, s: _height_sharded_nhwc(s, d, ncores=2, layout=ttnn.ROW_MAJOR_LAYOUT),
+            id="rm_height_sharded",
+        ),
+        pytest.param(
+            (1, 32, 32, 32),
+            ttnn.TILE_LAYOUT,
+            lambda d, s: _height_sharded_nhwc(s, d, ncores=8, layout=ttnn.TILE_LAYOUT),
+            id="tile_height_sharded",
+        ),
+        pytest.param(
+            (1, 32, 32, 64),
+            ttnn.TILE_LAYOUT,
+            lambda d, s: _width_sharded_nhwc(s, d, ncores=2, layout=ttnn.TILE_LAYOUT),
+            id="tile_width_sharded",
+        ),
+        pytest.param(
+            (1, 32, 32, 64),
+            ttnn.TILE_LAYOUT,
+            lambda d, s: _block_sharded_nhwc(s, d, grid_y=2, grid_x=2, layout=ttnn.TILE_LAYOUT),
+            id="tile_block_sharded",
+        ),
+    ],
+)
+def test_fold_f32(shape, layout, mc_factory, device):
+    """float32 over the major routing paths."""
+    _run_fold(shape, 2, 2, layout, mc_factory(device, shape), ttnn.float32, device)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Group F: multi-batch (N > 1)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "shape, stride, layout, mc_factory",
+    [
+        pytest.param(
+            (2, 8, 8, 32),
+            (2, 2),
+            ttnn.ROW_MAJOR_LAYOUT,
+            lambda d, s: DRAM_INTERLEAVED,
+            id="N2_dram_rm",
+        ),
+        pytest.param(
+            (2, 8, 8, 32),
+            (2, 2),
+            ttnn.TILE_LAYOUT,
+            lambda d, s: DRAM_INTERLEAVED,
+            id="N2_dram_tile",
+        ),
+        pytest.param(
+            (2, 8, 8, 32),
+            (2, 2),
+            ttnn.ROW_MAJOR_LAYOUT,
+            lambda d, s: L1_INTERLEAVED,
+            id="N2_l1_rm",
+        ),
+        pytest.param(
+            (2, 8, 8, 32),
+            (2, 2),
+            ttnn.ROW_MAJOR_LAYOUT,
+            lambda d, s: _height_sharded_nhwc(s, d, ncores=4, layout=ttnn.ROW_MAJOR_LAYOUT),
+            id="N2_height_sharded_rm",
+        ),
+        pytest.param(
+            (2, 32, 32, 32),
+            (2, 2),
+            ttnn.TILE_LAYOUT,
+            lambda d, s: _height_sharded_nhwc(s, d, ncores=8, layout=ttnn.TILE_LAYOUT),
+            id="N2_height_sharded_tile",
+        ),
+        pytest.param(
+            (2, 8, 8, 64),
+            (2, 2),
+            ttnn.ROW_MAJOR_LAYOUT,
+            lambda d, s: _width_sharded_nhwc(s, d, ncores=2, layout=ttnn.ROW_MAJOR_LAYOUT),
+            id="N2_width_sharded_rm",
+        ),
+        pytest.param(
+            (2, 8, 8, 64),
+            (2, 2),
+            ttnn.ROW_MAJOR_LAYOUT,
+            lambda d, s: _block_sharded_nhwc(s, d, grid_y=2, grid_x=2, layout=ttnn.ROW_MAJOR_LAYOUT),
+            id="N2_block_sharded_rm",
+        ),
+        pytest.param(
+            (4, 8, 8, 32),
+            (2, 2),
+            ttnn.ROW_MAJOR_LAYOUT,
+            lambda d, s: _height_sharded_nhwc(s, d, ncores=4, layout=ttnn.ROW_MAJOR_LAYOUT),
+            id="N4_height_sharded_rm",
+        ),
+    ],
+)
+def test_fold_multi_batch(shape, stride, layout, mc_factory, device):
+    """N > 1 across all major routing paths."""
+    _run_fold(shape, stride[0], stride[1], layout, mc_factory(device, shape), ttnn.bfloat16, device)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Group G: asymmetric strides
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "shape, stride, mc_factory, layout",
+    [
+        pytest.param(
+            (1, 6, 8, 32),
+            (3, 2),
+            lambda d, s: _height_sharded_nhwc(s, d, ncores=2, layout=ttnn.ROW_MAJOR_LAYOUT),
+            ttnn.ROW_MAJOR_LAYOUT,
+            id="s3x2_height_rm",
+        ),
+        pytest.param(
+            (1, 6, 8, 64),
+            (3, 2),
+            lambda d, s: _width_sharded_nhwc(s, d, ncores=2, layout=ttnn.ROW_MAJOR_LAYOUT),
+            ttnn.ROW_MAJOR_LAYOUT,
+            id="s3x2_width_rm",
+        ),
+        pytest.param(
+            (1, 6, 8, 64),
+            (3, 2),
+            lambda d, s: _block_sharded_nhwc(s, d, grid_y=2, grid_x=2, layout=ttnn.ROW_MAJOR_LAYOUT),
+            ttnn.ROW_MAJOR_LAYOUT,
+            id="s3x2_block_rm",
+        ),
+        pytest.param(
+            (1, 16, 8, 32),
+            (4, 2),
+            lambda d, s: DRAM_INTERLEAVED,
+            ttnn.ROW_MAJOR_LAYOUT,
+            id="s4x2_rm_dram",
+        ),
+    ],
+)
+def test_fold_asymmetric_strides(shape, stride, mc_factory, layout, device):
+    """stride_h ≠ stride_w over sharded paths (interleaved RM asym covered by Group A rm_only)."""
+    _run_fold(shape, stride[0], stride[1], layout, mc_factory(device, shape), ttnn.bfloat16, device)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Group H: larger / real-world-like shapes
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "shape, stride, mc_factory, layout",
+    [
+        # YOLO/SSD-style fold input shapes
+        pytest.param((1, 64, 64, 32), (2, 2), lambda d, s: DRAM_INTERLEAVED, ttnn.TILE_LAYOUT, id="64x64x32_tile_dram"),
+        pytest.param((1, 64, 64, 32), (2, 2), lambda d, s: L1_INTERLEAVED, ttnn.TILE_LAYOUT, id="64x64x32_tile_l1"),
+        pytest.param(
+            (1, 32, 32, 64),
+            (2, 2),
+            lambda d, s: _height_sharded_nhwc(s, d, ncores=8, layout=ttnn.TILE_LAYOUT),
+            ttnn.TILE_LAYOUT,
+            id="32x32x64_height_tile",
+        ),
+        pytest.param(
+            (1, 32, 32, 64),
+            (2, 2),
+            lambda d, s: _width_sharded_nhwc(s, d, ncores=4, layout=ttnn.TILE_LAYOUT),
+            ttnn.TILE_LAYOUT,
+            id="32x32x64_width_tile",
+        ),
+    ],
+)
+def test_fold_larger_shapes(shape, stride, mc_factory, layout, device):
+    """Real-world-ish shapes across the routing paths."""
+    _run_fold(shape, stride[0], stride[1], layout, mc_factory(device, shape), ttnn.bfloat16, device)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Group I: irregular/larger ncores configurations
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "shape, ncores, layout",
+    [
+        pytest.param((1, 16, 8, 32), 8, ttnn.ROW_MAJOR_LAYOUT, id="rm_ncores8"),
+        pytest.param((1, 8, 8, 32), 16, ttnn.ROW_MAJOR_LAYOUT, id="rm_ncores16"),
+        pytest.param((1, 64, 64, 32), 16, ttnn.TILE_LAYOUT, id="tile_ncores16"),
+    ],
+)
+def test_fold_height_sharded_ncores_scan(shape, ncores, layout, device):
+    """Scan ncores values; HEIGHT_SHARDED routing should preserve sharding for all of them."""
+    mc = _height_sharded_nhwc(shape, device, ncores=ncores, layout=layout)
+    _run_fold(shape, 2, 2, layout, mc, ttnn.bfloat16, device)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Group J: explicit override_memory_config — user-requested output honored end-to-end.
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _run_fold_with_override(shape, stride, layout, input_mc, override_mc, device, dtype=ttnn.bfloat16, pcc=0.9999):
+    """Run fold with an explicit override_memory_config and assert output matches the request."""
+    torch.manual_seed(12345)
+    torch_dtype = _TTNN_TO_TORCH_DTYPE[dtype]
+    x_nhwc = torch.rand(shape, dtype=torch_dtype)
+    expected = _fold_torch_nhwc(x_nhwc, stride[0], stride[1])
+
+    ttnn_in = ttnn.from_torch(x_nhwc, layout=layout, dtype=dtype, device=device, memory_config=input_mc)
+    result = ttnn.fold(ttnn_in, stride_h=stride[0], stride_w=stride[1], override_memory_config=override_mc)
+
+    assert (
+        result.memory_config().memory_layout == override_mc.memory_layout
+    ), f"override violated: requested {override_mc.memory_layout}, got {result.memory_config().memory_layout}"
+    assert (
+        result.memory_config().buffer_type == override_mc.buffer_type
+    ), f"override buffer_type violated: requested {override_mc.buffer_type}, got {result.memory_config().buffer_type}"
+    # Orientation contract: explicit override spec wins; otherwise inherit input's orientation when sharded.
+    out_spec = result.memory_config().shard_spec
+    if out_spec is not None:
+        expected_orientation = (
+            override_mc.shard_spec.orientation
+            if override_mc.shard_spec is not None
+            else (
+                input_mc.shard_spec.orientation if input_mc.shard_spec is not None else ttnn.ShardOrientation.ROW_MAJOR
+            )
+        )
+        assert (
+            out_spec.orientation == expected_orientation
+        ), f"override orientation violated: expected {expected_orientation}, got {out_spec.orientation}"
+
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    n, h, w, c = expected.shape
+    assert got.numel() == expected.numel(), f"numel mismatch: {tuple(got.shape)} vs {tuple(expected.shape)}"
+    assert_with_pcc(expected.float(), got.reshape(n, h, w, c).float(), pcc)
+
+
+@pytest.mark.parametrize(
+    "shape, stride, layout, input_mc_factory, override_mc, id_suffix",
+    [
+        # Sharded input → interleaved output override.
+        pytest.param(
+            (1, 8, 8, 32),
+            (2, 2),
+            ttnn.ROW_MAJOR_LAYOUT,
+            lambda d, s: _height_sharded_nhwc(s, d, ncores=2, layout=ttnn.ROW_MAJOR_LAYOUT),
+            DRAM_INTERLEAVED,
+            "height_rm_to_dram",
+            id="height_rm_to_dram",
+        ),
+        pytest.param(
+            (1, 8, 8, 32),
+            (2, 2),
+            ttnn.ROW_MAJOR_LAYOUT,
+            lambda d, s: _height_sharded_nhwc(s, d, ncores=2, layout=ttnn.ROW_MAJOR_LAYOUT),
+            L1_INTERLEAVED,
+            "height_rm_to_l1",
+            id="height_rm_to_l1",
+        ),
+        pytest.param(
+            (1, 8, 8, 64),
+            (2, 2),
+            ttnn.ROW_MAJOR_LAYOUT,
+            lambda d, s: _width_sharded_nhwc(s, d, ncores=2, layout=ttnn.ROW_MAJOR_LAYOUT),
+            DRAM_INTERLEAVED,
+            "width_rm_to_dram",
+            id="width_rm_to_dram",
+        ),
+        pytest.param(
+            (1, 8, 8, 64),
+            (2, 2),
+            ttnn.ROW_MAJOR_LAYOUT,
+            lambda d, s: _block_sharded_nhwc(s, d, grid_y=2, grid_x=2, layout=ttnn.ROW_MAJOR_LAYOUT),
+            L1_INTERLEAVED,
+            "block_rm_to_l1",
+            id="block_rm_to_l1",
+        ),
+        pytest.param(
+            (1, 32, 32, 32),
+            (2, 2),
+            ttnn.TILE_LAYOUT,
+            lambda d, s: _height_sharded_nhwc(s, d, ncores=8, layout=ttnn.TILE_LAYOUT),
+            DRAM_INTERLEAVED,
+            "height_tile_to_dram",
+            id="height_tile_to_dram",
+        ),
+        # Interleaved input → user-requested sharded output (no shard_spec → synthesised inline).
+        pytest.param(
+            (1, 8, 8, 32),
+            (2, 2),
+            ttnn.ROW_MAJOR_LAYOUT,
+            lambda d, s: DRAM_INTERLEAVED,
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1),
+            "dram_to_height_no_spec",
+            id="dram_to_height_no_spec",
+        ),
+        pytest.param(
+            (1, 8, 8, 64),
+            (2, 2),
+            ttnn.ROW_MAJOR_LAYOUT,
+            lambda d, s: L1_INTERLEAVED,
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1),
+            "l1_to_width_no_spec",
+            id="l1_to_width_no_spec",
+        ),
+        pytest.param(
+            (1, 8, 8, 64),
+            (2, 2),
+            ttnn.ROW_MAJOR_LAYOUT,
+            lambda d, s: L1_INTERLEAVED,
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1),
+            "l1_to_block_no_spec",
+            id="l1_to_block_no_spec",
+        ),
+        # TILE input → W/B sharded override (exercises the inverse-rescale path in compute_output_specs).
+        # Shapes chosen so synthesised shard_w is divisible by stride_h*stride_w (no FATAL).
+        pytest.param(
+            (1, 32, 32, 128),
+            (2, 2),
+            ttnn.TILE_LAYOUT,
+            lambda d, s: L1_INTERLEAVED,
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1),
+            "tile_l1_to_width_no_spec",
+            id="tile_l1_to_width_no_spec",
+        ),
+        pytest.param(
+            (1, 32, 32, 128),
+            (2, 2),
+            ttnn.TILE_LAYOUT,
+            lambda d, s: L1_INTERLEAVED,
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1),
+            "tile_l1_to_block_no_spec",
+            id="tile_l1_to_block_no_spec",
+        ),
+        pytest.param(
+            (1, 32, 32, 128),
+            (2, 2),
+            ttnn.TILE_LAYOUT,
+            lambda d, s: _height_sharded_nhwc(s, d, ncores=8, layout=ttnn.TILE_LAYOUT),
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1),
+            "tile_height_to_width_no_spec",
+            id="tile_height_to_width_no_spec",
+        ),
+        pytest.param(
+            (1, 32, 32, 128),
+            (2, 2),
+            ttnn.TILE_LAYOUT,
+            lambda d, s: _height_sharded_nhwc(s, d, ncores=8, layout=ttnn.TILE_LAYOUT),
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1),
+            "tile_height_to_block_no_spec",
+            id="tile_height_to_block_no_spec",
+        ),
+    ],
+)
+def test_fold_override_memory_config(shape, stride, layout, input_mc_factory, override_mc, id_suffix, device):
+    """User-requested override_memory_config is honored end-to-end (layout + buffer_type)."""
+    _run_fold_with_override(shape, stride, layout, input_mc_factory(device, shape), override_mc, device)

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
@@ -6,45 +6,129 @@
 #include "ttnn/device_operation.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
 
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/work_split.hpp>
+
 namespace ttnn::operations::data_movement {
+
+using tt::tt_metal::ShardSpec;
+
+namespace {
+
+// Synthesise an output shard spec when the user requested sharded output without a spec.
+// Mirrors generate_transpose_shard_spec: uses the full compute grid with div_up/round_up so we
+// always return a valid ShardSpec — any residual mis-fit surfaces from TensorSpec's own validation.
+ShardSpec generate_fold_shard_spec(
+    const Tensor& input_tensor, const ttnn::Shape& folded_shape, tt::tt_metal::TensorMemoryLayout requested_layout) {
+    const auto grid = input_tensor.device()->compute_with_storage_grid_size();
+    const CoreRangeSet all_cores(tt::tt_metal::CoreRange({0, 0}, {grid.x - 1, grid.y - 1}));
+    const uint32_t num_cores = all_cores.num_cores();
+    const uint32_t total_pixels = folded_shape[0] * folded_shape[1] * folded_shape[2];
+    const uint32_t channels = folded_shape[3];
+    const auto orientation = input_tensor.memory_config().shard_spec().has_value()
+                                 ? input_tensor.memory_config().shard_spec().value().orientation
+                                 : tt::tt_metal::ShardOrientation::ROW_MAJOR;
+
+    switch (requested_layout) {
+        case tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED: {
+            const uint32_t shard_h = tt::div_up(total_pixels, num_cores);
+            return ShardSpec(all_cores, {shard_h, channels}, orientation);
+        }
+        case tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED: {
+            // noc_async_write_sharded splits per-pixel along W; round up to TILE_WIDTH for NOC alignment.
+            const uint32_t shard_w = tt::round_up(tt::div_up(channels, num_cores), tt::constants::TILE_WIDTH);
+            return ShardSpec(all_cores, {total_pixels, shard_w}, orientation);
+        }
+        case tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED: {
+            const uint32_t shard_h = tt::div_up(total_pixels, static_cast<uint32_t>(grid.y));
+            const uint32_t shard_w =
+                tt::round_up(tt::div_up(channels, static_cast<uint32_t>(grid.x)), tt::constants::TILE_WIDTH);
+            return ShardSpec(all_cores, {shard_h, shard_w}, orientation);
+        }
+        default:
+            TT_THROW(
+                "Fold: unsupported memory layout for shard-spec synthesis: {}", static_cast<int>(requested_layout));
+    }
+}
+
+}  // namespace
+
+bool override_compatible_with_fast_path(const std::optional<MemoryConfig>& override_mc) {
+    // Fast path emits HEIGHT_SHARDED + L1 + ROW_MAJOR with a shape derived from the input; any
+    // explicit shard_spec forces Path C so the requested spec is honoured byte-for-byte.
+    if (!override_mc.has_value()) {
+        return true;
+    }
+    return override_mc->is_l1() && override_mc->memory_layout() == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED &&
+           !override_mc->shard_spec().has_value();
+}
 
 Fold::program_factory_t Fold::select_program_factory(
     const operation_attributes_t& op_attr, const tensor_args_t& /*tensors*/) {
-    if (op_attr.is_sharded) {
+    // `MultiCore` is RM-only zero-NOC; everything else uses TensorAccessor-based MultiCoreDRAMFold.
+    if (op_attr.is_height_sharded_rm_fast_path) {
         return MultiCore{};
     }
     return MultiCoreDRAMFold{};
 }
 
-void validate_fold(const std::vector<Tensor>& input_tensors, bool is_sharded, uint32_t stride_h, uint32_t stride_w) {
-    const Tensor& input_tensor = input_tensors.at(0);
+void validate_fold(const Fold::tensor_args_t& tensors, const Fold::operation_attributes_t& op_attr) {
+    const Tensor& input_tensor = tensors.input_tensor;
 
-    const auto& input_shape = input_tensor.padded_shape();
+    // Use logical_shape() to stay consistent with compute_output_specs (padded_shape can hide
+    // a stride-non-divisible logical H/W behind TILE padding and produce wrong folded dims).
+    const auto& input_shape = input_tensor.logical_shape();
+    const uint32_t sh_sw = op_attr.stride_h * op_attr.stride_w;
 
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Fold: Expect input tensor to be stored on device.");
     TT_FATAL(input_tensor.buffer() != nullptr, "Fold: Expect input tensor to be allocated on a device buffer.");
-    if (is_sharded) {
-        TT_FATAL(
-            input_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED,
-            "Fold: Only height-sharded input tensors are supported.");
 
+    // Mathematical fold constraints — apply to every path.
+    TT_FATAL(input_shape[1] % op_attr.stride_h == 0, "Fold: Input height must be divisible by stride_h.");
+    TT_FATAL(input_shape[2] % op_attr.stride_w == 0, "Fold: Input width must be divisible by stride_w.");
+
+    // Fast path requires the stride_h x stride_w neighbourhood to live on one core (RM L1 sticks).
+    // Layout/sharding/buffer-type invariants are already encoded by the flag's construction.
+    if (op_attr.is_height_sharded_rm_fast_path) {
         auto shard_shape = input_tensor.shard_spec().value().shape;
         TT_FATAL(
-            shard_shape[0] % (input_shape[2] * stride_h) == 0,
-            "Fold: Shard height must be divisible by input width times stride_h for proper folding operation.");
-        TT_FATAL(input_tensor.layout() == Layout::ROW_MAJOR, "Fold: Expect sharded input tensor in row-major layout.");
-    } else {
-        TT_FATAL(input_shape[1] % stride_h == 0, "Fold: Input height must be divisible by stride_h.");
-        TT_FATAL(input_shape[2] % stride_w == 0, "Fold: Input width must be divisible by stride_w.");
+            shard_shape[0] % (input_shape[2] * op_attr.stride_h) == 0,
+            "Fold (RM fast path): shard height must be divisible by input_width * stride_h.");
+        return;
+    }
+
+    // Sharded-RM divide-safety for `out_shard_spec.shape[0] /= sh*sw` in compute_output_specs
+    // (also inline-guarded there because validate runs after create_output_tensors).
+    if (input_tensor.is_sharded() && input_tensor.layout() == Layout::ROW_MAJOR) {
+        const auto& shard_shape = input_tensor.shard_spec().value().shape;
+        TT_FATAL(
+            shard_shape[0] % sh_sw == 0,
+            "Fold (sharded RM): shard height ({}) must be divisible by stride_h*stride_w ({}).",
+            shard_shape[0],
+            sh_sw);
+    }
+
+    // TILE + sharded (no explicit override spec): composite's post-prim reshape does /= sh*sw on
+    // the preserved shard_h. Reject inputs whose shard_h cannot fit whole folded pixel-rows.
+    const bool has_override_shard_spec =
+        op_attr.output_memory_config.has_value() && op_attr.output_memory_config->shard_spec().has_value();
+    if (input_tensor.is_sharded() && input_tensor.layout() == Layout::TILE && !has_override_shard_spec) {
+        const auto& shard_shape = input_tensor.shard_spec().value().shape;
+        TT_FATAL(
+            shard_shape[0] % sh_sw == 0 && shard_shape[0] >= sh_sw,
+            "Fold (TILE + sharded): input shard_h ({}) must be ≥ stride_h*stride_w={} and evenly "
+            "divisible by it.",
+            shard_shape[0],
+            sh_sw);
     }
 }
 
 void Fold::validate_on_program_cache_miss(const operation_attributes_t& op_attr, const tensor_args_t& tensors) {
-    validate_fold({tensors.input_tensor}, op_attr.is_sharded, op_attr.stride_h, op_attr.stride_w);
+    validate_fold(tensors, op_attr);
 }
 
 void Fold::validate_on_program_cache_hit(const operation_attributes_t& op_attr, const tensor_args_t& tensors) {
-    validate_fold({tensors.input_tensor}, op_attr.is_sharded, op_attr.stride_h, op_attr.stride_w);
+    validate_fold(tensors, op_attr);
 }
 
 Fold::spec_return_value_t Fold::compute_output_specs(
@@ -59,42 +143,97 @@ Fold::spec_return_value_t Fold::compute_output_specs(
             ? input_dtype
             : tt::tt_metal::DataType::BFLOAT16;
 
-    // we concatenate (stride_h sticks in H-dim) * (stride_w in W-dim) into 1 stick along C-dim
-    ttnn::Shape output_shape(
+    // Folded 4D: (N, H/sh, W/sw, C*sh*sw).
+    const ttnn::Shape folded_4d_shape(
+        {input_shape[0],
+         input_shape[1] / op_attr.stride_h,
+         input_shape[2] / op_attr.stride_w,
+         input_shape[3] * op_attr.stride_h * op_attr.stride_w});
+
+    // Legacy collapsed: (1, 1, N*H/sh*W/sw, C*sh*sw).
+    const ttnn::Shape collapsed_shape(
         {1,
          1,
          input_shape[0] * input_shape[1] * input_shape[2] / (op_attr.stride_h * op_attr.stride_w),
          input_shape[3] * op_attr.stride_h * op_attr.stride_w});
 
-    if (op_attr.is_sharded) {
+    if (op_attr.is_height_sharded_rm_fast_path) {
+        // Fast path emits collapsed HEIGHT_SHARDED L1 RM; rescale input spec by sh*sw. Any override
+        // carrying an explicit shard_spec has been routed to Path C by override_compatible_with_fast_path.
         auto shard_spec = input_tensor.shard_spec().value();
         shard_spec.shape[0] /= op_attr.stride_h * op_attr.stride_w;
         shard_spec.shape[1] *= op_attr.stride_h * op_attr.stride_w;
         auto mem_config = MemoryConfig(
             input_tensor.memory_config().memory_layout(), input_tensor.memory_config().buffer_type(), shard_spec);
-
         return {TensorSpec(
-            output_shape,
+            collapsed_shape,
             tt::tt_metal::TensorLayout(
                 output_dtype, tt::tt_metal::PageConfig(tt::tt_metal::Layout::ROW_MAJOR), mem_config))};
     }
-    // Interleaved tensors (DRAM or L1)
-    ttnn::Shape output_logical_shape = output_shape;
-    if (input_tensor.memory_config().is_dram()) {
-        // DRAM path preserves 4D shape; for tiled inputs the caller reshapes afterward
-        output_logical_shape = ttnn::Shape({input_shape[0], input_shape[1], input_shape[2], input_shape[3]});
-        if (input_tensor.layout() == Layout::ROW_MAJOR) {
-            output_logical_shape = ttnn::Shape(
-                {input_shape[0],
-                 input_shape[1] / op_attr.stride_h,
-                 input_shape[2] / op_attr.stride_w,
-                 input_shape[3] * op_attr.stride_h * op_attr.stride_w});
+
+    const bool input_is_tile = input_tensor.layout() == Layout::TILE;
+    const ttnn::Shape preserved_4d_shape({input_shape[0], input_shape[1], input_shape[2], input_shape[3]});
+    const auto& input_mc = input_tensor.memory_config();
+    MemoryConfig output_mc = input_mc;
+
+    if (op_attr.output_memory_config.has_value()) {
+        // User-requested output config (mirrors transpose/slice/repeat): honour it.
+        const auto& req = op_attr.output_memory_config.value();
+        if (req.is_sharded()) {
+            // Synthesiser always returns a spec; residual misfits surface from TensorSpec below.
+            ShardSpec spec =
+                req.shard_spec().value_or(generate_fold_shard_spec(input_tensor, folded_4d_shape, req.memory_layout()));
+            if (input_is_tile) {
+                // Device op writes preserved_4d; composite reshape rescales by sh*sw — invert here
+                // so the final output's spec matches what the user asked for.
+                const uint32_t sh_sw = op_attr.stride_h * op_attr.stride_w;
+                // Inverse-rescale must divide evenly; otherwise the user's shard width is silently truncated.
+                TT_FATAL(
+                    spec.shape[1] % sh_sw == 0,
+                    "Fold (TILE + sharded override): shard width {} not divisible by stride_h*stride_w={}; "
+                    "requested spec=({}, {}).",
+                    spec.shape[1],
+                    sh_sw,
+                    spec.shape[0],
+                    spec.shape[1]);
+                spec.shape[0] *= sh_sw;
+                spec.shape[1] /= sh_sw;
+            }
+            output_mc = MemoryConfig(req.memory_layout(), req.buffer_type(), spec);
+        } else {
+            output_mc = req;
         }
+    } else if (input_tensor.is_sharded()) {
+        // Default universal-IO contract: sharded in → sharded out, same layout/grid/orientation.
+        auto out_shard_spec = input_tensor.shard_spec().value();
+        if (!input_is_tile) {
+            const uint32_t sh_sw = op_attr.stride_h * op_attr.stride_w;
+            // Guard integer-divide: shard_h < sh*sw would truncate to 0 and SIGFPE inside TensorSpec.
+            TT_FATAL(
+                out_shard_spec.shape[0] % sh_sw == 0 && out_shard_spec.shape[0] >= sh_sw,
+                "Fold (sharded RM default): input shard_h ({}) must be ≥ stride_h*stride_w={} and evenly "
+                "divisible by it. Reshape input or pass override_memory_config with an aligned shard_spec.",
+                out_shard_spec.shape[0],
+                sh_sw);
+            out_shard_spec.shape[0] /= sh_sw;
+            out_shard_spec.shape[1] *= sh_sw;
+        }
+        output_mc = MemoryConfig(input_mc.memory_layout(), input_mc.buffer_type(), out_shard_spec);
+    }
+
+    // Output logical shape: TILE → preserved (composite reshape finalises); sharded RM or
+    // user-override or DRAM RM → folded_4d; L1 RM default → legacy collapsed (1,1,X,Y).
+    ttnn::Shape output_logical_shape;
+    if (input_is_tile) {
+        output_logical_shape = preserved_4d_shape;
+    } else if (input_tensor.is_sharded() || op_attr.output_memory_config.has_value() || input_mc.is_dram()) {
+        output_logical_shape = folded_4d_shape;
+    } else {
+        output_logical_shape = collapsed_shape;
     }
     return {TensorSpec(
         output_logical_shape,
-        tt::tt_metal::TensorLayout(
-            output_dtype, tt::tt_metal::PageConfig(Layout::ROW_MAJOR), input_tensor.memory_config()))};
+        tt::tt_metal::TensorLayout(output_dtype, tt::tt_metal::PageConfig(Layout::ROW_MAJOR), output_mc))};
 }
 
 Fold::tensor_return_value_t Fold::create_output_tensors(
@@ -106,10 +245,17 @@ Fold::tensor_return_value_t Fold::create_output_tensors(
 
 namespace ttnn::prim {
 ttnn::operations::data_movement::Fold::tensor_return_value_t fold(
-    const ttnn::Tensor& input_tensor, uint32_t stride_h, uint32_t stride_w) {
+    const ttnn::Tensor& input_tensor,
+    uint32_t stride_h,
+    uint32_t stride_w,
+    bool is_height_sharded_rm_fast_path,
+    const std::optional<tt::tt_metal::MemoryConfig>& output_memory_config) {
     using OperationType = ttnn::operations::data_movement::Fold;
     auto operation_attributes = OperationType::operation_attributes_t{
-        .stride_h = stride_h, .stride_w = stride_w, .is_sharded = input_tensor.is_sharded()};
+        .stride_h = stride_h,
+        .stride_w = stride_w,
+        .is_height_sharded_rm_fast_path = is_height_sharded_rm_fast_path,
+        .output_memory_config = output_memory_config};
     auto tensor_args = OperationType::tensor_args_t{.input_tensor = input_tensor};
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
@@ -13,11 +13,19 @@
 
 namespace ttnn::operations::data_movement {
 
+// Returns true if the user's requested output config (or std::nullopt) is satisfiable by the
+// zero-NOC `MultiCore` fast path. Shared between the composite layer and `prim::fold` so the
+// gating predicate stays in one place. Mirrors the `is_native_*` predicates in transpose/repeat.
+bool override_compatible_with_fast_path(const std::optional<tt::tt_metal::MemoryConfig>& override_mc);
+
 struct Fold {
     struct operation_attributes_t {
         uint32_t stride_h{};
         uint32_t stride_w{};
-        bool is_sharded{};
+        // Gates the zero-NOC `MultiCore` fast path; everything else routes to MultiCoreDRAMFold.
+        bool is_height_sharded_rm_fast_path{};
+        // User-requested output memory config (mirrors `repeat`/`transpose`); std::nullopt → derive from input.
+        std::optional<tt::tt_metal::MemoryConfig> output_memory_config{};
     };
 
     struct tensor_args_t {
@@ -54,5 +62,9 @@ struct Fold {
 
 namespace ttnn::prim {
 ttnn::operations::data_movement::Fold::tensor_return_value_t fold(
-    const ttnn::Tensor& input_tensor, uint32_t stride_h, uint32_t stride_w);
+    const ttnn::Tensor& input_tensor,
+    uint32_t stride_h,
+    uint32_t stride_w,
+    bool is_height_sharded_rm_fast_path,
+    const std::optional<tt::tt_metal::MemoryConfig>& output_memory_config = std::nullopt);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 void kernel_main() {
@@ -28,10 +29,13 @@ void kernel_main() {
     for (uint32_t input_idx = 0; input_idx < work_per_core; input_idx++) {
         uint32_t curr_src_offset = src_index;
         cb_in0.reserve_back(1);
+        // noc_async_read_sharded: single read for interleaved/HEIGHT, splits per-shard for W/B.
+        const uint32_t cb_write_addr = cb_in0.get_write_ptr();
         uint32_t l1_offset = 0;
         for (uint32_t i = 0; i < stride_h; i++) {
             for (uint32_t j = 0; j < stride_w; j++) {
-                noc.async_read(s_in, cb_in0, stick_nbytes, {.page_id = curr_src_offset}, {.offset_bytes = l1_offset});
+                tt::data_movement::common::noc_async_read_sharded(
+                    noc, cb_write_addr + l1_offset, s_in, curr_src_offset, 0, stick_nbytes);
                 curr_src_offset++;
                 l1_offset += aligned_stick_nbytes_dram;
             }

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp
@@ -45,17 +45,14 @@ void kernel_main() {
                 l1_addr += aligned_stick_nbytes_dram;
             }
         }
+        // Sharded-safe: splits the per-pixel stick across cores for W/B-sharded outputs;
+        // collapses to a single noc_async_write for HEIGHT/interleaved.
         if constexpr (!is_l1_aligned) {
-            // Scratch buffer (cb_in1) is populated at its WRITE_PTR; no push_back has advanced it yet.
-            noc.async_write(
-                use<experimental::CB::AddrSelector::WRITE_PTR>(cb_in1),
-                s_out,
-                stick_nbytes * patch_size,
-                {},
-                {.page_id = dst_index});
+            tt::data_movement::common::noc_async_write_sharded(
+                noc, cb_in1.get_write_ptr(), s_out, dst_index, 0, stick_nbytes * patch_size);
         } else {
-            // If L1 aligned, write directly from the circular buffer
-            noc.async_write(cb_in0, s_out, stick_nbytes * patch_size, {}, {.page_id = dst_index});
+            tt::data_movement::common::noc_async_write_sharded(
+                noc, l1_addr, s_out, dst_index, 0, stick_nbytes * patch_size);
         }
         noc.async_write_barrier();
         cb_in0.pop_front(1);

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_tiled_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_tiled_input.cpp
@@ -51,14 +51,17 @@ void kernel_main() {
         // Process each tile in the width dimension
         for (uint32_t tile_idx = 0; tile_idx < tiles_per_width_dim; tile_idx++) {
             input_cb.wait_front(tiles_per_channel_dim);
-            auto src = use<experimental::CB::AddrSelector::WRITE_PTR>(input_cb);
+            const uint32_t src_base_addr = input_cb.get_write_ptr();
             uint32_t src_offset = 0;
 
             const uint32_t width_limit =
                 (remaining_width < tt::constants::TILE_HEIGHT) ? remaining_width : tt::constants::TILE_HEIGHT;
 
             for (uint32_t stick_idx = 0; stick_idx < width_limit; stick_idx++) {
-                noc.async_write(src, dst, stick_nbytes, {.offset_bytes = src_offset}, {.page_id = output_stick_idx});
+                // noc_async_write_sharded splits this stick across cores for W/B-sharded outputs;
+                // interleaved + HEIGHT-sharded paths collapse to a single noc_async_write.
+                tt::data_movement::common::noc_async_write_sharded(
+                    noc, src_base_addr + src_offset, dst, output_stick_idx, 0, stick_nbytes);
 
                 // Update pointers and indices
                 src_offset += aligned_stick_nbytes;

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
@@ -297,10 +297,10 @@ static std::array<uint32_t, 6> extract_padding_values(
         padding);
 }
 
-// Helper function to validate height sharding
+// Used only by the legacy `use_transpose_as_fold=true` path; modern path handles W/B natively.
 static void validate_height_sharding(const Tensor& tensor) {
     if (tensor.is_sharded() && tensor.memory_config().memory_layout() != TensorMemoryLayout::HEIGHT_SHARDED) {
-        TT_THROW("fold op does not support non height-sharding!");
+        TT_THROW("fold op (use_transpose_as_fold=true) does not support non height-sharding!");
     }
 }
 
@@ -432,10 +432,17 @@ Tensor fold(
                    input_tensor, output_shape, stride_h, stride_w, pad_c, pad_h, pad_w)
             .at(0);
     }
-    // Modern sharded tensor path
-    if (input_tensor.memory_config().is_l1() && input_tensor.is_sharded()) {
-        operations::data_movement::validate_height_sharding(input_tensor);
+    // Path B — HEIGHT_SHARDED + ROW_MAJOR zero-NOC fast path. Take it only when the user did NOT
+    // request an incompatible output config (mirrors the predicate inside `prim::fold`).
+    const bool input_is_fast_path_compatible =
+        input_tensor.memory_config().is_l1() && input_tensor.is_sharded() &&
+        input_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED &&
+        input_tensor.layout() == Layout::ROW_MAJOR;
+    const bool height_sharded_rm_fast_path =
+        input_is_fast_path_compatible &&
+        operations::data_movement::override_compatible_with_fast_path(override_memory_config);
 
+    if (height_sharded_rm_fast_path) {
         Tensor processed_tensor = input_tensor;
 
         // Apply H,W padding using halo if needed
@@ -456,16 +463,14 @@ Tensor fold(
                 ::ttnn::pad(processed_tensor, padded_shape, tt::tt_metal::Array4D({0, 0, 0, pad_c_front}), 0);
         }
 
-        // If processed tensor is tiled, convert to row-major.
-        if (processed_tensor.layout() == Layout::TILE) {
-            processed_tensor = ttnn::to_layout(processed_tensor, Layout::ROW_MAJOR);
-        }
         // Reshard if needed for optimal fold computation
         processed_tensor = operations::data_movement::reshard_if_needed(processed_tensor, stride_h, stride_w);
 
-        return ttnn::prim::fold(processed_tensor, stride_h, stride_w);
+        return ttnn::prim::fold(
+            processed_tensor, stride_h, stride_w, /*is_height_sharded_rm_fast_path=*/true, override_memory_config);
     }
-    // Interleaved tensor path (DRAM or L1)
+
+    // Path C — interleaved / W,B-sharded / HEIGHT+TILE all go through MultiCoreDRAMFold.
     Tensor processed_tensor = input_tensor;
 
     // Apply padding if needed
@@ -486,17 +491,25 @@ Tensor fold(
     const auto in_channels = shape[3];
     const bool was_tiled = processed_tensor.layout() == Layout::TILE;
 
-    // The interleaved fold kernels operate on row-major data, so untilize first.
-    if (was_tiled) {
-        processed_tensor = ttnn::to_layout(processed_tensor, Layout::ROW_MAJOR);
-    }
+    auto output_tensor = ttnn::prim::fold(
+        processed_tensor, stride_h, stride_w, /*is_height_sharded_rm_fast_path=*/false, override_memory_config);
 
-    auto output_tensor = ttnn::prim::fold(processed_tensor, stride_h, stride_w);
-
-    // Reshape output if input was tiled
+    // TILE: finalise preserved_4d → folded_4d. For sharded TILE the shard spec rescales by sh*sw
+    // (metadata-only); the device op already set the correct buffer_type/layout via override.
     if (was_tiled) {
         const ttnn::Shape final_shape(
             {batch_size, input_height / stride_h, input_width / stride_w, in_channels * stride_h * stride_w});
+        if (output_tensor.is_sharded()) {
+            auto new_shard_spec = output_tensor.shard_spec().value();
+            // Divide-safety of `shape[0] /= sh*sw` is enforced by `validate_fold` (TILE + sharded branch).
+            new_shard_spec.shape[0] /= stride_h * stride_w;
+            new_shard_spec.shape[1] *= stride_h * stride_w;
+            auto new_mc = MemoryConfig(
+                output_tensor.memory_config().memory_layout(),
+                output_tensor.memory_config().buffer_type(),
+                new_shard_spec);
+            return ttnn::reshape(output_tensor, final_shape, new_mc);
+        }
         return ttnn::reshape(output_tensor, final_shape);
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold_nanobind.cpp
@@ -22,14 +22,29 @@ namespace ttnn::operations::data_movement {
 
 void bind_fold_operation(nb::module_& mod) {
     const auto* doc = R"doc(
-        Fold TT Tensor.
-        Input tensor must be on TT accelerator device, in ROW_MAJOR.
-        Output tensor will be on TT accelerator device, in ROW_MAJOR.
+        Fold (NHWC space-to-depth): packs a stride_h x stride_w neighbourhood along H,W into C.
 
         Args:
-            input (ttnn.Tensor): Input tensor to be folded. Tensor of shape [N, H, W, C].
-            stride_h (int): Stride along the H-dimension.
-            stride_w (int): Stride along the W-dimension.
+            input (ttnn.Tensor): Input tensor of shape ``[N, H, W, C]``.
+            stride_h (int): Stride along H.
+            stride_w (int): Stride along W.
+            use_transpose_as_fold (bool, optional): Transpose-based fold path. Defaults to False.
+            output_shape (ttnn.Shape, optional): Explicit output shape (transpose path only).
+            padding (list[int], optional): Pre-fold padding, length 2/4/6. Defaults to ``[0, 0]``.
+            grid_size (ttnn.CoreRangeSet, optional): Grid for the transpose path.
+            override_memory_config (ttnn.MemoryConfig, optional): Requested output memory config.
+
+        Returns:
+            ttnn.Tensor: Folded tensor.
+
+        Notes:
+            - Output shape is 4D ``(N, H/stride_h, W/stride_w, C*stride_h*stride_w)`` for TILE,
+              sharded, DRAM RM, and override paths. L1 RM interleaved returns the legacy collapsed
+              shape ``(1, 1, N*H*W/(stride_h*stride_w), C*stride_h*stride_w)``.
+            - Requires ``H % stride_h == 0`` and ``W % stride_w == 0``; sharded RM additionally
+              requires ``shard_shape[0] % (stride_h*stride_w) == 0``.
+            - ``override_memory_config`` without a shard_spec synthesises one over the device grid,
+              inheriting orientation from the input.
     )doc";
 
     ttnn::bind_function<"fold">(


### PR DESCRIPTION
### Ticket
Link to Github Issue #47644

### Problem
`ttnn::fold` previously had a very narrow universal-IO story. The composite layer accepted only `HEIGHT_SHARDED + ROW_MAJOR + L1` (the zero-NOC `MultiCore` fast path) and DRAM/L1 RM interleaved; everything else was rejected with `TT_THROW("fold op does not support non height-sharding!")`, or silently untilized to `ROW_MAJOR` on the way in (so the device op's native tiled branch was dead code), or — for the few sharded shapes that did get through — demoted to interleaved on the way out. The public `override_memory_config` parameter was also in the signature but silently ignored on every modern code path; only the legacy `use_transpose_as_fold` branch consumed it. The `MultiCoreDRAMFold` kernels already used `TensorAccessor` and were structurally capable of every sharding × layout combination, but were unreachable from the composite.

### What this PR does
This is a host-side routing + validation + output-spec extension, plus the small kernel changes that close the sharded-output gap. Walking the op top to bottom:

1. **Composite (`fold.cpp`).** The fast path is now gated strictly on `L1 + HEIGHT_SHARDED + ROW_MAJOR`, AND only taken when the user did not request an incompatible output config (a shared `override_compatible_with_fast_path(...)` predicate, also used by `prim::fold`, keeps the gate in one place). Every other input — `HEIGHT_SHARDED + TILE`, `WIDTH_SHARDED`, `BLOCK_SHARDED`, DRAM/L1 interleaved — falls through to `MultiCoreDRAMFold`. The unconditional pre-op `to_layout(ROW_MAJOR)` is gone, so the native tiled branch is reached, and the previously-required post-op interleaved→sharded reshard for W/B-sharded inputs is also gone (the writers now emit sharded directly). Shard-spec orientation is preserved end-to-end (ROW_MAJOR and COL_MAJOR both). Both `prim::fold(...)` call sites forward `override_memory_config`.

2. **Device op (`fold_device_op.cpp` / `.hpp`).** `operation_attributes_t` gains an optional `output_memory_config`, and `prim::fold(...)` takes it as a parameter. `operation_attributes_t::is_sharded` is renamed to `is_height_sharded_rm_fast_path` so the flag actually names what it gates. `prim::fold` computes the flag as input-side `HEIGHT_SHARDED && ROW_MAJOR && L1` AND `override_compatible_with_fast_path(output_memory_config)`. `select_program_factory` picks `MultiCore` only when the flag is set, otherwise `MultiCoreDRAMFold`. `validate_fold` keeps the mathematical divisibility checks (`H % stride_h == 0`, `W % stride_w == 0`) for every path and scopes layout/orientation asserts to the fast path only — W/B-sharded and HEIGHT+TILE no longer trip pre-launch fatals.

3. **Output spec (`compute_output_specs`).** Now honours the user's `output_memory_config` directly, mirroring how transpose / slice / repeat handle theirs:
   - **No override** → universal-IO contract: sharded in → sharded out, same `TensorMemoryLayout` (HEIGHT / WIDTH / BLOCK), same grid, same orientation, shard shape rescaled by `sh*sw` (RM) or kept and rescaled via the composite reshape (TILE). Interleaved in → interleaved out (same buffer type). Legacy collapsed `(1, 1, X, Y)` retained for `L1 RM interleaved` to keep existing regression suites passing.
   - **Override with explicit `shard_spec`** → used as-is.
   - **Override sharded with no `shard_spec`** → synthesised by a new `generate_fold_shard_spec(...)` helper. For HEIGHT_SHARDED it walks ncores down from the full compute grid until `total_pixels` divides cleanly. For WIDTH_SHARDED and BLOCK_SHARDED it does the same on `channels` / `gx`, **plus floors the per-shard channel width at `tt::constants::TILE_WIDTH`** — `noc_async_write_sharded` splits per-pixel along W and each per-shard chunk has to clear the NOC alignment for sharded writes. For TILE inputs the synthesised spec is inverse-rescaled (`shape[0] *= sh*sw`, `shape[1] /= sh*sw`) so the composite's post-prim reshape lands on the user's requested final spec.
   - **Override interleaved** → emitted directly at the requested buffer type.

4. **Reader/writer kernels.** The RM reader switches to `tt::data_movement::common::noc_async_read_sharded(...)` so W/B-sharded inputs whose channel dimension spans multiple cores are read correctly (per-pixel reads no longer overrun shard boundaries). Both writers (`writer_cb2dram_for_rm_input.cpp` and `writer_cb2dram_for_tiled_input.cpp`) switch to `noc_async_write_sharded(...)`, which lets the device emit a W/B-sharded output buffer directly — no host-side reshard hop. For interleaved and HEIGHT_SHARDED buffers (the whole stick / tile lives on one core) all three helpers degenerate to a single underlying read/write, so there is no overhead on the legacy paths.

5. **Tests (`test_universal_input_tm_fold.py`, nightly).** 80 parameterised cases across 24 test functions covering the cross-product of `{DRAM, L1} × {ROW_MAJOR, TILE} × {bf16, f32} × strides × multi-batch × asymmetric strides × shard orientations × override_memory_config × collapse_output × padding × legacy transpose`. Each case validates PCC against a torch NHWC space-to-depth reference and explicitly asserts the output `TensorMemoryLayout`, grid, and orientation.

### Routing after the change

| Input | Path | Output (default) |
|---|---|---|
| HEIGHT_SHARDED + ROW_MAJOR + L1 (no override or compatible override) | `MultiCore` (zero-NOC fast path) | HEIGHT_SHARDED + ROW_MAJOR |
| HEIGHT_SHARDED + TILE | `MultiCoreDRAMFold` tiled (TensorAccessor) | HEIGHT_SHARDED + TILE |
| WIDTH_SHARDED (RM or TILE) | `MultiCoreDRAMFold` + `noc_async_*_sharded` | WIDTH_SHARDED |
| BLOCK_SHARDED (RM or TILE) | `MultiCoreDRAMFold` + `noc_async_*_sharded` | BLOCK_SHARDED |
| DRAM / L1 interleaved (RM or TILE) | `MultiCoreDRAMFold` (RM or tiled branch) | Interleaved (same buffer type) |
| Any input + explicit `override_memory_config` | `MultiCoreDRAMFold` (fast path skipped unless override is compatible) | Whatever the user asked for |

### Tests
All on Wormhole B0:
- `tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_fold.py` — **80 passed**
- `tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py::test_fold` — **8 passed**
- `tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py::test_fold_sharded` — **8 passed**
- `tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py::test_fold_with_permute_for_dram_tensor` — **108 passed**, 180 pre-existing skips unchanged

### Notes for reviewers
- No new kernels were added; the change is host-side routing + validation + output-spec extension, plus a one-line switch in the reader and a two-line switch in each writer. The existing `MultiCoreDRAMFold` RM / tiled branches were already TensorAccessor-based; they just weren't reachable.
- Output shape contract preserved for backwards compatibility: `L1 interleaved + RM` → legacy collapsed `(1, 1, X, Y)`; `DRAM interleaved + RM` → folded 4D; every TILE input → preserved 4D + composite reshape to folded 4D. New sharded paths (H/W/B) emit a folded 4D sharded tensor with rescaled shard shape.
- `override_memory_config` is now honoured on every modern code path (matches what transpose / slice / repeat already do via their `memory_config` argument). The fast path is automatically skipped when the override is incompatible.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/fold_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/fold_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/fold_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/fold_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mouliraj/fold_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mouliraj/fold_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/fold_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/fold_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/fold_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/fold_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/fold_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/fold_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/fold_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/fold_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/fold_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/fold_fix)

