### PR TITLE
#46878: Fix duplicate shard dims in reduce_scatter output topology

### DIFF
--- a/models/common/tests/modules/attention/test_attention_1d.py
+++ b/models/common/tests/modules/attention/test_attention_1d.py
@@ -43,7 +43,7 @@ from models.common.modules.rmsnorm.rmsnorm_1d import RMSNorm1DConfig
 from models.common.modules.tt_ccl import TT_CCL
 from models.common.tensor_utils import get_rot_transformation_mat, zeros_like_kv_cache, zeros_like_paged_cache
 from models.common.tests.utils import stable_model_seed
-from models.common.utility_functions import comp_allclose, comp_pcc, is_wormhole_b0, nearest_32
+from models.common.utility_functions import comp_allclose, comp_pcc, nearest_32
 
 # =============================================================================
 # RoPE Helper Functions (replaces TTTv1 rope imports)
@@ -1186,11 +1186,6 @@ def test_attention_1d_vs_reference(
     test_attention_1d_vs_reference_from_model_args which uses existing infrastructure
     that handles HF API differences.
     """
-    # WH B0 multi-device: reduce_scatter output topology generates duplicate shard dims
-    # causing TT_FATAL @ partition.cpp:152. Single-device (1x1) is unaffected. Refs #46878.
-    if is_wormhole_b0() and ttnn_mesh_device.get_num_devices() > 1:
-        pytest.skip("WH B0 multi-device: TT_FATAL duplicate dims in partition.cpp (refs #46878)")
-
     # Skip if mesh_shape doesn't match device
     device_shape = (ttnn_mesh_device.shape[0], ttnn_mesh_device.shape[1])
     if device_shape != mesh_shape:

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op_device_operation.cpp
@@ -124,23 +124,44 @@ std::vector<Tensor> ReduceScatterMinimalAsyncDeviceOperation::create_output_tens
 
 std::vector<tt::tt_metal::TensorTopology> ReduceScatterMinimalAsyncDeviceOperation::compute_output_topologies(
     const ReduceScatterMinimalAsyncParams& operation_attributes, const ReduceScatterMinimalAsyncInputs& tensor_args) {
-    // reduce_scatter produces (intermediate, output). The output is sharded along `dim`
-    // across `cluster_axis`; the intermediate is an internal workspace whose topology is
-    // best left matching the input so that downstream introspection is not misleading.
+    // TODO(#48421): Enforce input invariants with TT_FATAL instead of sanitising malformed topologies.
+    // Output is sharded along `dim` across `cluster_axis`; intermediate keeps the input topology.
     const auto& input_topology = tensor_args.input_tensor.tensor_topology();
     auto output_placements = input_topology.placements();
 
-    auto shard_placement =
-        tt::tt_metal::distributed::MeshMapperConfig::Shard{static_cast<int>(operation_attributes.dim)};
+    // Normalize `dim` so Shard placements are stored consistently (avoids [Shard(-1), Shard(3)]).
+    const int rank = static_cast<int>(tensor_args.input_tensor.logical_shape().rank());
+    const int dim = ((static_cast<int>(operation_attributes.dim) % rank) + rank) % rank;
+    const auto shard_placement = tt::tt_metal::distributed::MeshMapperConfig::Shard{dim};
+
+    // Replicate any other mesh axis still sharding the same tensor dim — concat_ndim requires unique dims.
+    auto clear_same_dim = [&](auto& placement) {
+        if (auto* shard = std::get_if<tt::tt_metal::distributed::MeshMapperConfig::Shard>(&placement)) {
+            if (((shard->dim % rank) + rank) % rank == dim) {
+                placement = tt::tt_metal::distributed::MeshMapperConfig::Replicate{};
+            }
+        }
+    };
 
     if (operation_attributes.cluster_axis.has_value()) {
         const auto axis = operation_attributes.cluster_axis.value();
         if (axis < output_placements.size()) {
+            for (size_t i = 0; i < output_placements.size(); ++i) {
+                if (i != axis) {
+                    clear_same_dim(output_placements[i]);
+                }
+            }
             output_placements[axis] = shard_placement;
         }
     } else {
-        for (auto& placement : output_placements) {
-            placement = shard_placement;
+        // Whole-mesh reduce_scatter: shard only real (>1) axes on `dim`; replicate size-1 axes to keep dims unique.
+        const auto& mesh_shape = input_topology.distribution_shape();
+        for (size_t i = 0; i < output_placements.size(); ++i) {
+            if (i < mesh_shape.dims() && mesh_shape[static_cast<int>(i)] > 1) {
+                output_placements[i] = shard_placement;
+            } else {
+                output_placements[i] = tt::tt_metal::distributed::MeshMapperConfig::Replicate{};
+            }
         }
     }
 


### PR DESCRIPTION
### Ticket
Closes #46878

### Problem
T3000 e2e / `wh_llmbox` has been failing for 7+ days on 56 variants of `test_attention_1d_vs_reference` (paged-prefill on Qwen2-7B / Qwen2.5 over a 1x2 mesh) with:

```
RuntimeError: TT_FATAL @ /project/ttnn/core/tensor/xtensor/partition.cpp:152:
    std::unique(sorted_dims.begin(), sorted_dims.end()) == sorted_dims.end()
info: dims must be unique
```

Single-commit bisect on `wh_llmbox` traced the regression to #44019 (`eeda2ff7e25`, "Add naive FSDP support", merged 2026-06-01). The new `compute_output_topologies` in `reduce_scatter_minimal_async_op_device_operation.cpp` writes the output `Shard` placement without normalizing the scatter `dim` and without clearing stale shards on other mesh axes. The result is an output `TensorTopology` like `[Shard(-1), Shard(3)]` or `[Shard(3), Shard(3)]`; on readback `MeshToTensor::compose` → `xtensor::concat_ndim` trips the uniqueness assert.

### Fix
Three targeted changes in `ReduceScatterMinimalAsyncDeviceOperation::compute_output_topologies`:

1. **Normalize scatter `dim` to a non-negative index.** Uses `((dim % rank) + rank) % rank` so `Shard{-1}` and `Shard{rank-1}` collapse to the same key. Prevents `[Shard(-1), Shard(3)]` style mixed-sign collisions.
2. **`cluster_axis` set → clear stale shards on other axes.** Before writing `Shard{dim}` on `cluster_axis`, walk every other axis and convert any `Shard` placement whose normalized dim equals `dim` to `Replicate`. After reduce_scatter, only `cluster_axis` should shard `dim`.
3. **`cluster_axis` unset → shard only real axes.** Previously every mesh axis was written `Shard{dim}` unconditionally; now we shard only axes with `extent > 1` and `Replicate` the trivial (size-1) ones, since sharding a size-1 axis on the same `dim` as the real axis duplicates the dim.

Together these restore the uniqueness invariant required by `concat_ndim` without reverting the FSDP feature.

Also removes the temporary `pytest.skip` and now-unused `is_wormhole_b0` import introduced by the workaround PR #47626.

cc @philei-tt for review of the topology logic.

### Verification
Latest T3K e2e run on this branch: [Run 28080474935](https://github.com/tenstorrent/tt-metal/actions/runs/28080474935) (commit `01a22731642`).
In the `models_tttv2_attention_full_set_unit_tests [wh_llmbox]` [job log](https://github.com/tenstorrent/tt-metal/actions/runs/28080474935/job/83136019579):

| Pattern | Hits |
|---|---|
| `partition.cpp:152` / `dims must be unique` (the bug this PR fixes) | **0** |

The original regressor is fully eliminated. Remaining failures in that job come from `serialization.cpp:71` failing to write `tt_cache/tttv2/attention_1d/*.tensorbin` because the HF cache mount is read-only on `wh_llmbox` — orthogonal to this fix.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/ci_failure_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/ci_failure_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/ci_failure_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/ci_failure_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mouliraj/ci_failure_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mouliraj/ci_failure_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/ci_failure_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/ci_failure_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/ci_failure_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/ci_failure_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/ci_failure_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/ci_failure_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/ci_failure_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/ci_failure_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/ci_failure_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/ci_failure_fix)
