### PR TITLE
feat: add DataType::BOOL — proper bool dtype for ttnn

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/tensor/impl/tensor_impl.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/impl/tensor_impl.hpp
@@ -101,6 +101,7 @@ auto dispatch(DataType dtype, Func&& func, Args&&... args) {
         case DataType::UINT16:
             return (std::forward<Func>(func)).template operator()<uint16_t>(std::forward<Args>(args)...);
         case DataType::UINT8:
+        case DataType::BOOL:
             return (std::forward<Func>(func)).template operator()<uint8_t>(std::forward<Args>(args)...);
         case DataType::BFLOAT8_B:
             return (std::forward<Func>(func)).template operator()<bfloat8_b>(std::forward<Args>(args)...);

--- a/tt_metal/api/tt-metalium/experimental/tensor/tensor_types.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/tensor_types.hpp
@@ -38,6 +38,7 @@ enum class DataType {
     // WARNING: narrowly supported — Blackhole only, ROW-MAJOR only for now, used exclusively
     // by the DeepSeek V3 prefill combine and dispatch ops. Check op support before opting in.
     FP8_E4M3 = 8,
+    BOOL = 10,
     INVALID = 9,
 };
 

--- a/tt_metal/api/tt-metalium/experimental/tensor/tensor_types.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/tensor_types.hpp
@@ -38,7 +38,7 @@ enum class DataType {
     // WARNING: narrowly supported — Blackhole only, ROW-MAJOR only for now, used exclusively
     // by the DeepSeek V3 prefill combine and dispatch ops. Check op support before opting in.
     FP8_E4M3 = 8,
-    BOOL = 10,
+    BOOL = 10,  // 10 (not 9) to keep INVALID = 9 stable for existing serialized/ABI data
     INVALID = 9,
 };
 

--- a/tt_metal/impl/tensor/spec/layout/page_config.cpp
+++ b/tt_metal/impl/tensor/spec/layout/page_config.cpp
@@ -21,7 +21,8 @@ size_t rm_element_size_bytes(DataType dtype) {
         case DataType::UINT32: return sizeof(uint32_t);
         case DataType::UINT16: return sizeof(uint16_t);
         case DataType::FP8_E4M3: return sizeof(float8_e4m3);
-        case DataType::UINT8: return sizeof(uint8_t);
+        case DataType::UINT8:
+        case DataType::BOOL: return sizeof(uint8_t);
         case DataType::BFLOAT8_B:
         case DataType::BFLOAT4_B:
             // To store block floats in RowMajor layout, we use a fallback and store full floats instead

--- a/tt_metal/impl/tensor/spec/tensor_spec.cpp
+++ b/tt_metal/impl/tensor/spec/tensor_spec.cpp
@@ -97,9 +97,10 @@ void validate_dtype_and_layout(DataType dtype, Layout layout) {
     auto supported_dtype = [&dtype]() {
         TT_FATAL(
             (dtype == DataType::UINT32 || dtype == DataType::INT32 || dtype == DataType::FLOAT32 ||
-             dtype == DataType::UINT8 || dtype == DataType::UINT16 || dtype == DataType::BFLOAT16 ||
-             dtype == DataType::BFLOAT8_B || dtype == DataType::BFLOAT4_B || dtype == DataType::FP8_E4M3),
-            "Only UINT32, INT32, FLOAT32, UINT16, UINT8, BFLOAT16, BFLOAT8_B, BFLOAT4_B, or FP8_E4M3 dtypes are "
+             dtype == DataType::UINT8 || dtype == DataType::BOOL || dtype == DataType::UINT16 ||
+             dtype == DataType::BFLOAT16 || dtype == DataType::BFLOAT8_B || dtype == DataType::BFLOAT4_B ||
+             dtype == DataType::FP8_E4M3),
+            "Only UINT32, INT32, FLOAT32, UINT16, UINT8, BOOL, BFLOAT16, BFLOAT8_B, BFLOAT4_B, or FP8_E4M3 dtypes are "
             "supported on device!");
     };
     auto supported_layout = [&dtype, &layout]() {
@@ -108,6 +109,7 @@ void validate_dtype_and_layout(DataType dtype, Layout layout) {
             case DataType::INT32:
             case DataType::FLOAT32:
             case DataType::UINT8:
+            case DataType::BOOL:
             case DataType::UINT16:
             case DataType::BFLOAT16: break;
             case DataType::BFLOAT8_B:

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -1191,6 +1191,7 @@ HostTensor to_dtype(const HostTensor& input_tensor, DataType dtype) {
                     return with_src_and_dst.operator()<SrcType, CMAKE_UNIQUE_NAMESPACE::bfloat8_tag>();
                 case DataType::FLOAT32: return with_src_and_dst.operator()<SrcType, float>();
                 case DataType::BFLOAT16: return with_src_and_dst.operator()<SrcType, bfloat16>();
+                case DataType::BOOL:
                 case DataType::UINT8: return with_src_and_dst.operator()<SrcType, uint8_t>();
                 case DataType::UINT16: return with_src_and_dst.operator()<SrcType, uint16_t>();
                 case DataType::UINT32: return with_src_and_dst.operator()<SrcType, uint32_t>();
@@ -1206,6 +1207,7 @@ HostTensor to_dtype(const HostTensor& input_tensor, DataType dtype) {
             case DataType::BFLOAT8_B:
             case DataType::FLOAT32: return with_src.operator()<float>();
             case DataType::BFLOAT16: return with_src.operator()<bfloat16>();
+            case DataType::BOOL:
             case DataType::UINT8: return with_src.operator()<uint8_t>();
             case DataType::UINT16: return with_src.operator()<uint16_t>();
             case DataType::UINT32: return with_src.operator()<uint32_t>();

--- a/tt_metal/impl/tensor/tensor_impl.cpp
+++ b/tt_metal/impl/tensor/tensor_impl.cpp
@@ -45,6 +45,7 @@ HostBuffer allocate_host_buffer(const TensorSpec& tensor_spec) {
         case DataType::FLOAT32: return HostBuffer(std::vector<float>(size_bytes / sizeof(float)));
         case DataType::INT32: return HostBuffer(std::vector<int32_t>(size_bytes / sizeof(int32_t)));
         case DataType::FP8_E4M3: return HostBuffer(std::vector<float8_e4m3>(size_bytes / sizeof(float8_e4m3)));
+        case DataType::BOOL:
         case DataType::UINT8: return HostBuffer(std::vector<uint8_t>(size_bytes / sizeof(uint8_t)));
         case DataType::UINT16: return HostBuffer(std::vector<uint16_t>(size_bytes / sizeof(uint16_t)));
         case DataType::BFLOAT4_B:

--- a/tt_metal/impl/tensor/tensor_types.cpp
+++ b/tt_metal/impl/tensor/tensor_types.cpp
@@ -17,6 +17,7 @@ std::ostream& operator<<(std::ostream& os, const tt::tt_metal::DataType& data_ty
         case DataType::UINT16: return os << "DataType::UINT16";
         case DataType::INT32: return os << "DataType::INT32";
         case DataType::FP8_E4M3: return os << "DataType::FP8_E4M3";
+        case DataType::BOOL: return os << "DataType::BOOL";
         case DataType::INVALID:
         default: return os << "Invalid";
     }
@@ -97,6 +98,7 @@ tt::DataFormat datatype_to_dataformat_converter(tt::tt_metal::DataType datatype)
         case tt::tt_metal::DataType::UINT16: return tt::DataFormat::UInt16;
         case tt::tt_metal::DataType::UINT8: return tt::DataFormat::UInt8;
         case tt::tt_metal::DataType::FP8_E4M3: return tt::DataFormat::Fp8_e4m3;
+        case tt::tt_metal::DataType::BOOL: return tt::DataFormat::UInt8;
         default: TT_THROW("Unsupported DataType"); return tt::DataFormat::Float16_b;  // for clang-tidy
     }
 }
@@ -136,6 +138,7 @@ auto fmt::formatter<tt::tt_metal::DataType>::format(tt::tt_metal::DataType dt, f
         case tt::tt_metal::DataType::UINT16: name = "DataType::UINT16"; break;
         case tt::tt_metal::DataType::INT32: name = "DataType::INT32"; break;
         case tt::tt_metal::DataType::FP8_E4M3: name = "DataType::FP8_E4M3"; break;
+        case tt::tt_metal::DataType::BOOL: name = "DataType::BOOL"; break;
         case tt::tt_metal::DataType::INVALID:
         default: name = "Invalid"; break;
     }

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -169,7 +169,8 @@ public:
             case tt::tt_metal::DataType::BFLOAT16: return extract_logical_data.template operator()<bfloat16>(tensor);
             case tt::tt_metal::DataType::UINT32: return extract_logical_data.template operator()<uint32_t>(tensor);
             case tt::tt_metal::DataType::FP8_E4M3: TT_THROW("FP8_E4M3 ingestion via TensorToMesh is not supported");
-            case tt::tt_metal::DataType::UINT8: return extract_logical_data.template operator()<uint8_t>(tensor);
+            case tt::tt_metal::DataType::UINT8:
+            case tt::tt_metal::DataType::BOOL: return extract_logical_data.template operator()<uint8_t>(tensor);
             case tt::tt_metal::DataType::UINT16: return extract_logical_data.template operator()<uint16_t>(tensor);
             case tt::tt_metal::DataType::INT32: return extract_logical_data.template operator()<int32_t>(tensor);
             case tt::tt_metal::DataType::INVALID: TT_THROW("Invalid data type: {}", tensor.tensor_spec().data_type());
@@ -504,7 +505,8 @@ public:
             case tt::tt_metal::DataType::UINT32: return dispatch_to_concrete.template operator()<uint32_t>(tensor);
             case tt::tt_metal::DataType::FP8_E4M3:
                 TT_THROW("FP8_E4M3 aggregation via aggregate_tensor is not supported");
-            case tt::tt_metal::DataType::UINT8: return dispatch_to_concrete.template operator()<uint8_t>(tensor);
+            case tt::tt_metal::DataType::UINT8:
+            case tt::tt_metal::DataType::BOOL: return dispatch_to_concrete.template operator()<uint8_t>(tensor);
             case tt::tt_metal::DataType::UINT16: return dispatch_to_concrete.template operator()<uint16_t>(tensor);
             case tt::tt_metal::DataType::INT32: return dispatch_to_concrete.template operator()<int32_t>(tensor);
             case tt::tt_metal::DataType::INVALID: TT_THROW("Invalid data type: {}", tensor.dtype());

--- a/ttnn/core/services/h2d_socket_service.cpp
+++ b/ttnn/core/services/h2d_socket_service.cpp
@@ -62,6 +62,7 @@ Tensor make_borrowed_host_tensor(ttsl::Span<const std::byte> bytes, const Tensor
                 ttsl::Span<int32_t>(reinterpret_cast<int32_t*>(raw), bytes.size() / sizeof(int32_t)),
                 shape,
                 MemoryPin{});
+        case DataType::BOOL:
         case DataType::UINT8:
             return Tensor::from_borrowed_data<uint8_t>(
                 ttsl::Span<uint8_t>(reinterpret_cast<uint8_t*>(raw), bytes.size() / sizeof(uint8_t)),

--- a/ttnn/core/services/socket_service_common.hpp
+++ b/ttnn/core/services/socket_service_common.hpp
@@ -27,6 +27,7 @@ inline Tensor make_zero_host_tensor(const TensorSpec& spec) {
             return Tensor::from_vector<bfloat16>(std::vector<bfloat16>(bytes / sizeof(bfloat16)), spec);
         case DataType::FLOAT32: return Tensor::from_vector<float>(std::vector<float>(bytes / sizeof(float)), spec);
         case DataType::INT32: return Tensor::from_vector<int32_t>(std::vector<int32_t>(bytes / sizeof(int32_t)), spec);
+        case DataType::BOOL:
         case DataType::UINT8: return Tensor::from_vector<uint8_t>(std::vector<uint8_t>(bytes / sizeof(uint8_t)), spec);
         case DataType::UINT16:
             return Tensor::from_vector<uint16_t>(std::vector<uint16_t>(bytes / sizeof(uint16_t)), spec);

--- a/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
@@ -71,6 +71,7 @@ tt::tt_metal::HostBuffer create_host_buffer_from_bytes(
         }
         case tt::tt_metal::DataType::FP8_E4M3:
             TT_THROW("Flatbuffer load for DataType::FP8_E4M3 is not supported during tensor deserialization.");
+        case tt::tt_metal::DataType::BOOL:
         case tt::tt_metal::DataType::UINT8: {
             ttsl::Span<uint8_t> typed_span(reinterpret_cast<uint8_t*>(data.data()), size_bytes / sizeof(uint8_t));
             return tt::tt_metal::HostBuffer(typed_span, memory_pin);

--- a/ttnn/core/tensor/flatbuffer/tensor_spec_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_spec_flatbuffer.cpp
@@ -49,6 +49,8 @@ flatbuffer::DataType to_flatbuffer(tt::tt_metal::DataType type) {
         case tt::tt_metal::DataType::UINT32: return flatbuffer::DataType::UInt32;
         case tt::tt_metal::DataType::BFLOAT8_B: return flatbuffer::DataType::BFloat8B;
         case tt::tt_metal::DataType::BFLOAT4_B: return flatbuffer::DataType::BFloat4B;
+        // BOOL shares UInt8 flatbuffer storage; the BOOL tag is not preserved across
+        // a serialize/deserialize round-trip (reads back as UINT8). Known limitation.
         case tt::tt_metal::DataType::BOOL:
         case tt::tt_metal::DataType::UINT8: return flatbuffer::DataType::UInt8;
         case tt::tt_metal::DataType::UINT16: return flatbuffer::DataType::UInt16;

--- a/ttnn/core/tensor/flatbuffer/tensor_spec_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_spec_flatbuffer.cpp
@@ -49,6 +49,7 @@ flatbuffer::DataType to_flatbuffer(tt::tt_metal::DataType type) {
         case tt::tt_metal::DataType::UINT32: return flatbuffer::DataType::UInt32;
         case tt::tt_metal::DataType::BFLOAT8_B: return flatbuffer::DataType::BFloat8B;
         case tt::tt_metal::DataType::BFLOAT4_B: return flatbuffer::DataType::BFloat4B;
+        case tt::tt_metal::DataType::BOOL:
         case tt::tt_metal::DataType::UINT8: return flatbuffer::DataType::UInt8;
         case tt::tt_metal::DataType::UINT16: return flatbuffer::DataType::UInt16;
         case tt::tt_metal::DataType::INT32: return flatbuffer::DataType::Int32;

--- a/ttnn/core/tensor/py_to_tt_tensor.cpp
+++ b/ttnn/core/tensor/py_to_tt_tensor.cpp
@@ -50,6 +50,7 @@ bool can_exec_ops_on_device(DataType type) {
         case DataType::UINT16:
             // Tilize doesn't support uint16.
         case DataType::UINT8:
+        case DataType::BOOL:
             // https://github.com/tenstorrent/tt-metal/issues/21682 (typecast doesn't support uint8)
             return false;
         default: return true;
@@ -304,7 +305,8 @@ Tensor create_tt_tensor_from_host_data(
         case DataType::BFLOAT4_B: return create_tensor_from_host_buffer.operator()<float>();
         case DataType::UINT32: return create_tensor_from_host_buffer.operator()<uint32_t>();
         case DataType::INT32: return create_tensor_from_host_buffer.operator()<int32_t>();
-        case DataType::UINT8: return create_tensor_from_host_buffer.operator()<uint8_t>();
+        case DataType::UINT8:
+        case DataType::BOOL: return create_tensor_from_host_buffer.operator()<uint8_t>();
         case DataType::UINT16: return create_tensor_from_host_buffer.operator()<uint16_t>();
         case DataType::FLOAT32: return create_tensor_from_host_buffer.operator()<float>();
         case DataType::BFLOAT16: return create_tensor_from_host_buffer.operator()<bfloat16>();
@@ -321,7 +323,7 @@ DataType compute_host_dtype(ttnn::PyDType src_dtype, const DataType& dst_dtype, 
             case ttnn::PyDType::UINT32: return DataType::UINT32;
             case ttnn::PyDType::UINT8: return DataType::UINT8;
             case ttnn::PyDType::UINT16: return DataType::UINT16;
-            case ttnn::PyDType::BOOL: return DataType::UINT8;
+            case ttnn::PyDType::BOOL: return DataType::BOOL;
             case ttnn::PyDType::UINT64:
             case ttnn::PyDType::FLOAT64:
             case ttnn::PyDType::FLOAT16:

--- a/ttnn/core/tensor/stream_service_common.hpp
+++ b/ttnn/core/tensor/stream_service_common.hpp
@@ -45,6 +45,7 @@ inline Tensor make_zero_host_tensor(const TensorSpec& spec) {
             return Tensor::from_vector<bfloat16>(std::vector<bfloat16>(bytes / sizeof(bfloat16)), spec);
         case DataType::FLOAT32: return Tensor::from_vector<float>(std::vector<float>(bytes / sizeof(float)), spec);
         case DataType::INT32: return Tensor::from_vector<int32_t>(std::vector<int32_t>(bytes / sizeof(int32_t)), spec);
+        case DataType::BOOL:
         case DataType::UINT8: return Tensor::from_vector<uint8_t>(std::vector<uint8_t>(bytes / sizeof(uint8_t)), spec);
         case DataType::UINT16:
             return Tensor::from_vector<uint16_t>(std::vector<uint16_t>(bytes / sizeof(uint16_t)), spec);

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -372,7 +372,8 @@ uint32_t Tensor::element_size() const {
         case DataType::UINT32: return sizeof(uint32_t);
         case DataType::UINT16: return sizeof(uint16_t);
         case DataType::FP8_E4M3: return sizeof(float8_e4m3);
-        case DataType::UINT8: return sizeof(uint8_t);
+        case DataType::UINT8:
+        case DataType::BOOL: return sizeof(uint8_t);
         case DataType::BFLOAT8_B:
         case DataType::BFLOAT4_B: return sizeof(std::byte);
         default: TT_THROW("Unsupported data type");

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -51,6 +51,7 @@ std::ostream& operator<<(std::ostream& os, const DataType& dtype) {
         case DataType::BFLOAT16: os << "bfloat16"; break;
         case DataType::FLOAT32: os << "float32"; break;
         case DataType::UINT8: os << "uint8"; break;
+        case DataType::BOOL: os << "bool"; break;
         case DataType::UINT16: os << "uint16"; break;
         case DataType::UINT32: os << "uint32"; break;
         case DataType::INT32: os << "int32"; break;

--- a/ttnn/core/tensor/xtensor/partition.cpp
+++ b/ttnn/core/tensor/xtensor/partition.cpp
@@ -259,7 +259,8 @@ Tensor concat(const std::vector<Tensor>& tensors, int dim) {
         case tt::tt_metal::DataType::FLOAT32: return adaptor::concat_impl<float>(tensors, reference_layout, dim);
         case tt::tt_metal::DataType::BFLOAT16: return adaptor::concat_impl<bfloat16>(tensors, reference_layout, dim);
         case tt::tt_metal::DataType::INT32: return adaptor::concat_impl<int32_t>(tensors, reference_layout, dim);
-        case tt::tt_metal::DataType::UINT8: return adaptor::concat_impl<uint8_t>(tensors, reference_layout, dim);
+        case tt::tt_metal::DataType::UINT8:
+        case tt::tt_metal::DataType::BOOL: return adaptor::concat_impl<uint8_t>(tensors, reference_layout, dim);
         case tt::tt_metal::DataType::UINT16: return adaptor::concat_impl<uint16_t>(tensors, reference_layout, dim);
         case tt::tt_metal::DataType::UINT32: return adaptor::concat_impl<uint32_t>(tensors, reference_layout, dim);
         default: TT_THROW("Unsupported data type: {}", reference_layout.get_data_type());

--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -128,13 +128,6 @@ struct PreprocessedPyTensor {
 
 PreprocessedPyTensor parse_py_tensor(nb::ndarray<nb::array_api> py_tensor, std::optional<DataType> optional_data_type) {
     auto py_tensor_dtype = py_tensor.dtype();
-    // handle bool types by changing them to uint8
-    // TODO: add proper handling for bool types as a DataType
-    if (py_tensor_dtype.code == static_cast<uint8_t>(nb::dlpack::dtype_code::Bool)) {
-        py_tensor_dtype.code = static_cast<uint8_t>(nb::dlpack::dtype_code::UInt);
-        py_tensor_dtype.bits = 8;
-        py_tensor_dtype.lanes = 1;
-    }
 
     DataType data_type = optional_data_type.value_or(get_ttnn_datatype_from_dtype(py_tensor_dtype));
 
@@ -224,7 +217,8 @@ RowMajorHostBuffer convert_to_row_major_host_buffer(const Tensor& tt_tensor, con
     auto convert_to_logical = [&tensor_spec, &dispatch_to_concrete](const HostBuffer& buffer) {
         const auto tt_dtype = tensor_spec.data_type();
         switch (tt_dtype) {
-            case DataType::UINT8: return dispatch_to_concrete.template operator()<uint8_t>(buffer);
+            case DataType::UINT8:
+            case DataType::BOOL: return dispatch_to_concrete.template operator()<uint8_t>(buffer);
             case DataType::FP8_E4M3: TT_THROW("FP8_E4M3 single-device to_torch is not supported");
             case DataType::UINT16: return dispatch_to_concrete.template operator()<uint16_t>(buffer);
             case DataType::INT32: return dispatch_to_concrete.template operator()<int32_t>(buffer);
@@ -277,7 +271,8 @@ RowMajorHostBuffer convert_to_row_major_host_buffer(
     };
 
     switch (tt_tensor.dtype()) {
-        case DataType::UINT8: return dispatch_to_concrete.template operator()<uint8_t>(tt_tensor);
+        case DataType::UINT8:
+        case DataType::BOOL: return dispatch_to_concrete.template operator()<uint8_t>(tt_tensor);
         case DataType::FP8_E4M3: return dispatch_to_concrete.template operator()<float8_e4m3>(tt_tensor);
         case DataType::UINT16: return dispatch_to_concrete.template operator()<uint16_t>(tt_tensor);
         case DataType::INT32: return dispatch_to_concrete.template operator()<int32_t>(tt_tensor);
@@ -361,7 +356,8 @@ HostBuffer convert_py_tensor_to_host_buffer(const nb::ndarray<nb::array_api>& py
             case DataType::BFLOAT16: return to_host_buffer_impl.operator()<bfloat16>(contiguous_py_tensor);
             case DataType::FLOAT32: return to_host_buffer_impl.operator()<float>(contiguous_py_tensor);
             case DataType::UINT32: return to_host_buffer_impl.operator()<uint32_t>(contiguous_py_tensor);
-            case DataType::UINT8: return to_host_buffer_impl.operator()<uint8_t>(contiguous_py_tensor);
+            case DataType::UINT8:
+            case DataType::BOOL: return to_host_buffer_impl.operator()<uint8_t>(contiguous_py_tensor);
             case DataType::UINT16: return to_host_buffer_impl.operator()<uint16_t>(contiguous_py_tensor);
             case DataType::INT32: return to_host_buffer_impl.operator()<int32_t>(contiguous_py_tensor);
             default: TT_THROW("Unsupported target DataType: {}", target_dtype);
@@ -649,14 +645,6 @@ void pytensor_module(nb::module_& mod) {
                bool enable_bfloat_opt) {
                 auto py_tensor_dtype = dlpack_tensor.dtype();
 
-                // handle bool types by changing them to uint8
-                // TODO: add proper handling for bool types as a DataType
-                if (py_tensor_dtype.code == static_cast<uint8_t>(nb::dlpack::dtype_code::Bool)) {
-                    py_tensor_dtype.code = static_cast<uint8_t>(nb::dlpack::dtype_code::UInt);
-                    py_tensor_dtype.bits = 8;
-                    py_tensor_dtype.lanes = 1;
-                }
-
                 auto src_dtype = get_PyDType_from_dtype(py_tensor_dtype);
                 auto dst_dtype = optional_data_type.value_or(get_ttnn_datatype_from_dtype(py_tensor_dtype));
 
@@ -858,6 +846,7 @@ void pytensor_module(nb::module_& mod) {
                         case DataType::UINT32: return self.to_vector<uint32_t>()[0];
                         case DataType::UINT16: return self.to_vector<uint16_t>()[0];
                         case DataType::UINT8: return self.to_vector<uint8_t>()[0];
+                        case DataType::BOOL: return self.to_vector<uint8_t>()[0];
                         case DataType::FP8_E4M3: TT_THROW("FP8_E4M3 item() is not supported");
                         case DataType::INVALID: TT_THROW("Unsupported DataType");
                     }

--- a/ttnn/cpp/ttnn-nanobind/ttnn_dtype_traits.hpp
+++ b/ttnn/cpp/ttnn-nanobind/ttnn_dtype_traits.hpp
@@ -113,6 +113,8 @@ enum class DtypeID : uint32_t {
         nbdlp::dtype{.code = static_cast<std::uint8_t>(nbdlp::dtype_code::Float), .bits = 16, .lanes = 1}),
     BFLOAT16 = nbdlp_dtype_to_int(
         nbdlp::dtype{.code = static_cast<std::uint8_t>(nbdlp::dtype_code::Bfloat), .bits = 16, .lanes = 1}),
+    BOOL = nbdlp_dtype_to_int(
+        nbdlp::dtype{.code = static_cast<std::uint8_t>(nbdlp::dtype_code::Bool), .bits = 8, .lanes = 1}),
     INVALID = 0,
 };
 
@@ -122,6 +124,11 @@ struct py_to_ {
 };
 
 // for some reason ttnn maps float16 to bfloat16
+template <>
+struct py_to_<DtypeID::BOOL> {
+    constexpr static auto ttnn_DataType = DataType::BOOL;
+};
+
 template <>
 struct py_to_<DtypeID::FLOAT16> {
     constexpr static auto ttnn_DataType = DataType::BFLOAT16;
@@ -264,6 +271,14 @@ struct ttnn_datatype_traits<DataType::INT32> {
 };
 
 template <>
+struct ttnn_datatype_traits<DataType::BOOL> {
+    using underlying_type = std::uint8_t;
+    static constexpr nbdlp::dtype value{
+        .code = static_cast<std::uint8_t>(nbdlp::dtype_code::Bool), .bits = 8, .lanes = 1};
+    static constexpr auto name = nbd::const_name("BOOL");
+};
+
+template <>
 struct ttnn_datatype_traits<DataType::FP8_E4M3> {
     using underlying_type = ::float8_e4m3;
     static constexpr nbdlp::dtype value{
@@ -283,6 +298,7 @@ constexpr nbdlp::dtype get_dtype_from_ttnn_datatype(DataType dt) noexcept {
         case DataType::UINT16: return ttnn_datatype_traits<DataType::UINT16>::value;
         case DataType::INT32: return ttnn_datatype_traits<DataType::INT32>::value;
         case DataType::FP8_E4M3: return ttnn_datatype_traits<DataType::FP8_E4M3>::value;
+        case DataType::BOOL: return ttnn_datatype_traits<DataType::BOOL>::value;
         case DataType::INVALID: [[fallthrough]];
         default: TT_THROW("get_dtype_from_ttnn_datatype: got INVALID or unhandled DataType.");
     }
@@ -305,6 +321,7 @@ constexpr DataType get_ttnn_datatype_from_dtype(nbdlp::dtype dt) noexcept {
         case DtypeID::FLOAT32: return py_to_<DtypeID::FLOAT32>::ttnn_DataType;
         case DtypeID::FLOAT16: return py_to_<DtypeID::FLOAT16>::ttnn_DataType;
         case DtypeID::BFLOAT16: return py_to_<DtypeID::BFLOAT16>::ttnn_DataType;
+        case DtypeID::BOOL: return py_to_<DtypeID::BOOL>::ttnn_DataType;
         default:
             TT_THROW("get_ttnn_datatype_from_dtype: got unexpected dlpack dtype. code: {}, bits: {}", dt.code, dt.bits);
     }
@@ -326,6 +343,7 @@ constexpr PyDType get_PyDType_from_dtype(nb::dlpack::dtype dt) {
         case DtypeID::FLOAT32: return PyDType::FLOAT32;
         case DtypeID::FLOAT16: return PyDType::FLOAT16;
         case DtypeID::BFLOAT16: return PyDType::BFLOAT16;
+        case DtypeID::BOOL: return PyDType::BOOL;
         default:
             TT_THROW("get_ttnn_datatype_from_dtype: got unexpected dlpack dtype. code: {}, bits: {}", dt.code, dt.bits);
     }

--- a/ttnn/cpp/ttnn-nanobind/ttnn_dtype_traits.hpp
+++ b/ttnn/cpp/ttnn-nanobind/ttnn_dtype_traits.hpp
@@ -123,12 +123,12 @@ struct py_to_ {
     constexpr static auto ttnn_DataType = DataType::INVALID;
 };
 
-// for some reason ttnn maps float16 to bfloat16
 template <>
 struct py_to_<DtypeID::BOOL> {
     constexpr static auto ttnn_DataType = DataType::BOOL;
 };
 
+// for some reason ttnn maps float16 to bfloat16
 template <>
 struct py_to_<DtypeID::FLOAT16> {
     constexpr static auto ttnn_DataType = DataType::BFLOAT16;

--- a/ttnn/cpp/ttnn/operations/creation/creation.cpp
+++ b/ttnn/cpp/ttnn/operations/creation/creation.cpp
@@ -185,6 +185,7 @@ Tensor full_impl(
     };
 
     switch (dtype_value) {
+        case DataType::BOOL:
         case DataType::UINT8: return concrete_full.template operator()<uint8_t>(fill_value);
         case DataType::UINT16: return concrete_full.template operator()<uint16_t>(fill_value);
         case DataType::UINT32: return concrete_full.template operator()<uint32_t>(fill_value);

--- a/ttnn/cpp/ttnn/operations/creation/creation_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/creation/creation_nanobind.cpp
@@ -505,6 +505,7 @@ Tensor from_buffer_impl(
     // bind_function releases the GIL across the C++ body; nb::cast requires it, so re-acquire GIL.
     nb::gil_scoped_acquire acquire;
     switch (dtype) {
+        case DataType::BOOL:
         case DataType::UINT8: {
             auto cpp_buffer = nb::cast<std::vector<uint8_t>>(buffer);
             return ttnn::from_buffer(std::move(cpp_buffer), shape, dtype, device, layout, memory_config);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -63,7 +63,7 @@
             a,                                                                                                \
             b,                                                                                                \
             operations::binary::BinaryOpType::OP_TYPE,                                                        \
-            (output_dtype.has_value() ? output_dtype : std::optional<const DataType>{DataType::BOOL}),        \
+            output_dtype,                                                                                     \
             memory_config,                                                                                    \
             output,                                                                                           \
             post_activations,                                                                                 \
@@ -93,7 +93,7 @@
             a,                                                                                                \
             rhs,                                                                                              \
             operations::binary::BinaryOpType::OP_TYPE,                                                        \
-            (output_dtype.has_value() ? output_dtype : std::optional<const DataType>{DataType::BOOL}),        \
+            output_dtype,                                                                                     \
             memory_config,                                                                                    \
             output,                                                                                           \
             post_activations,                                                                                 \

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -63,7 +63,7 @@
             a,                                                                                                \
             b,                                                                                                \
             operations::binary::BinaryOpType::OP_TYPE,                                                        \
-            output_dtype,                                                                                     \
+            (output_dtype.has_value() ? output_dtype : std::optional<const DataType>{DataType::BOOL}),        \
             memory_config,                                                                                    \
             output,                                                                                           \
             post_activations,                                                                                 \
@@ -93,7 +93,7 @@
             a,                                                                                                \
             rhs,                                                                                              \
             operations::binary::BinaryOpType::OP_TYPE,                                                        \
-            output_dtype,                                                                                     \
+            (output_dtype.has_value() ? output_dtype : std::optional<const DataType>{DataType::BOOL}),        \
             memory_config,                                                                                    \
             output,                                                                                           \
             post_activations,                                                                                 \

--- a/ttnn/cpp/ttnn/operations/functions.hpp
+++ b/ttnn/cpp/ttnn/operations/functions.hpp
@@ -475,6 +475,7 @@ static Tensor uniform(T low, T high, const ttnn::Shape& shape, const Layout layo
 inline Tensor random(
     const ttnn::Shape& shape, const DataType data_type = DataType::BFLOAT16, const Layout layout = Layout::ROW_MAJOR) {
     switch (data_type) {
+        case DataType::BOOL:
         case DataType::UINT8: return uniform(uint8_t(0), uint8_t(1), shape, layout);
         case DataType::UINT16: return uniform(uint16_t(0), uint16_t(1), shape, layout);
         case DataType::UINT32: return uniform(0u, 1u, shape, layout);

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -235,6 +235,7 @@ from ttnn.types import (
     bfloat4_b,
     bfloat16,
     fp8_e4m3,
+    bool,
     float32,
     MathFidelity,
     MemoryConfig,

--- a/ttnn/ttnn/types.py
+++ b/ttnn/ttnn/types.py
@@ -17,6 +17,7 @@ bfloat16 = DataType.BFLOAT16
 bfloat8_b = DataType.BFLOAT8_B
 bfloat4_b = DataType.BFLOAT4_B
 fp8_e4m3 = DataType.FP8_E4M3
+bool = DataType.BOOL
 DumpTensorMode = ttnn._ttnn.tensor.DumpTensorMode
 
 BufferType = ttnn._ttnn.tensor.BufferType


### PR DESCRIPTION
## Summary

Adds `DataType::BOOL` as a proper distinct dtype in ttnn — the foundational plumbing layer. This PR does **not** include op-level changes or tests; those follow in a separate PR.

**What this adds:**
- `DataType::BOOL = 10` enum value, distinct from `UINT8 = 5` (`INVALID` stays 9 for ABI stability)
- Hardware storage: `DataFormat::UInt8` (1 byte), same as UINT8, but a separate logical type tag
- DLPack round-trip via `{code=Bool, bits=8, lanes=1}` — same as `torch.bool`; removes the silent bool→uint8 coercion hack in `pytensor.cpp`
- Wires BOOL through all exhaustive `DataType` switches: `tensor_impl`, `tensor_spec`, `tensor_apis`, flatbuffer, distributed, creation ops, xtensor, page_config, services
- `ttnn_dtype_traits.hpp`: `DtypeID::BOOL`, `py_to_<BOOL>`, `ttnn_datatype_traits<BOOL>`
- Python: `ttnn.bool` alias in `types.py` and `__init__.py`

**Known limitation:** BOOL serializes to flatbuffer as `UInt8` and deserializes back as `UINT8` — the BOOL tag is lost across a flatbuffer round-trip. Fixing this requires a schema change and is left as follow-up.

## Testing

Testing is deferred to a follow-up PR. This PR is purely the basement implementation — making BOOL a real, distinct dtype that the rest of the stack can build on.

## Follow-up PR

- Op-level changes: comparison ops (`eq`, `gt`, `ne`, `ge`, `lt`, `le`) defaulting output dtype to BOOL
- Unit tests: round-trip, dtype identity, op output dtype, UINT8 override
- Flatbuffer schema change to preserve BOOL across serialize/deserialize

🤖 Generated with Claude Code