### PR TITLE
Bug fix: Fix LLK asserts sanity nightly run

### DIFF
--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -367,3 +367,4 @@ jobs:
       wheel-artifact-name: ${{ needs.resolve-artifacts.outputs.wheel-artifact-name }}
       run-ttsim-integration-tests: ${{ github.event_name == 'push' || inputs.run-ttsim-integration-tests }}
       run-metal-cpp-unit-tests: true
+      job-timeout: ${{ inputs.enable-llk-asserts && 40 || 35 }}

--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -381,7 +381,7 @@ jobs:
           cp /work/tt_metal/soc_descriptors/${{ matrix.soc_desc }} $TT_METAL_SIMULATOR_HOME/soc_descriptor.yaml
 
       - name: C++ tests
-        timeout-minutes: 30
+        timeout-minutes: 40
         run: |
           if [[ "${{ matrix.arch }}" == "quasar" ]]; then
             # ToDo: Re-enable this test once tt-sim supports NOC

--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -381,7 +381,7 @@ jobs:
           cp /work/tt_metal/soc_descriptors/${{ matrix.soc_desc }} $TT_METAL_SIMULATOR_HOME/soc_descriptor.yaml
 
       - name: C++ tests
-        timeout-minutes: 40
+        timeout-minutes: ${{ inputs.job-timeout }}
         run: |
           if [[ "${{ matrix.arch }}" == "quasar" ]]; then
             # ToDo: Re-enable this test once tt-sim supports NOC
@@ -471,7 +471,7 @@ jobs:
           cp /work/tt_metal/soc_descriptors/${{ matrix.soc_desc }} $TT_METAL_SIMULATOR_HOME/soc_descriptor.yaml
 
       - name: C++ tests
-        timeout-minutes: 10
+        timeout-minutes: ${{ inputs.job-timeout }}
         run: |
           ./build/test/tt_metal/unit_tests_api --gtest_filter="*StreamRegWrite*"
           ./build/test/tt_metal/unit_tests_api --gtest_filter="*InlineWrite*"

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_sampling.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_sampling.py
@@ -9,7 +9,7 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.common.utility_functions import is_blackhole
+from models.common.utility_functions import is_blackhole, skip_with_llk_assert
 from models.demos.deepseek_v3_b1.micro_ops.sampling.op import SamplingOp
 from models.demos.deepseek_v3_b1.utils import float_to_uint32
 
@@ -261,6 +261,7 @@ def _run_sampling_argmax_single_device_101_cores(device, seed: int, final_core_i
     )
 
 
+@skip_with_llk_assert("Hit LLK_ASSERT in sampling kernel. Issue: #47805")
 @pytest.mark.parametrize(
     "seed, final_core_idx",
     [

--- a/tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py
@@ -17,20 +17,21 @@ import math
 import os
 from unittest import mock
 
-import torch
-from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
-import ttnn
-from ttnn.operations.ccl import Topology
-from loguru import logger
 import pytest
+import torch
+from loguru import logger
+from ttnn.operations.ccl import Topology
 
-from tests.ttnn.unit_tests.operations.sdpa.sdpa_test_utils import fa_rand
+import ttnn
+from models.common.utility_functions import skip_with_llk_assert
 from tests.nightly.sdpa_perf_utils import (
-    post_process_ops_log,
     compute_cores_used,
-    compute_sdpa_flops,
     compute_math_utilization,
+    compute_sdpa_flops,
+    post_process_ops_log,
 )
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+from tests.ttnn.unit_tests.operations.sdpa.sdpa_test_utils import fa_rand
 
 
 def create_fabric_router_config(max_payload_size):
@@ -805,6 +806,7 @@ EXP_RING_JOINT_PERF_CHECK_CONFIGS = [
     EXP_RING_JOINT_PERF_CHECK_CONFIGS,
     ids=[f"ring{cfg[0]}-{cfg[2]}" for cfg in EXP_RING_JOINT_PERF_CHECK_CONFIGS],
 )
+@skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
 def test_exp_ring_joint_attention_perf_check(ring_size_expected, max_payload_size, payload_id, expected_util):
     """Measure exp ring joint SDPA math utilization via tracy and assert within +/- EXP_RING_JOINT_PERF_MARGIN."""
     from tracy.process_model_log import run_device_profiler

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -3068,7 +3068,7 @@ def test_ring_joint_attention_sdpa_determinism(model_names):
     RING_MLA_TEST_CONFIGS,
     ids=RING_MLA_TEST_CONFIG_IDS,
 )
-@skip_with_llk_assert("ring_mla deterministic replay is timing-sensitive with LLK asserts enabled.")
+@skip_with_llk_assert("ring_mla deterministic replay is timing-sensitive with LLK asserts enabled. Issue #47906.")
 def test_ring_mla_determinism(
     b,
     sq,

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -19,26 +19,28 @@ Model Configurations:
 BH adaptation: uses init_device_compute_kernel_config instead of WormholeComputeKernelConfig.
 """
 
-import os
 import math
-from unittest import mock
-
-import torch
+import os
 from dataclasses import dataclass, replace
 from itertools import product
-from typing import List, Dict, Sequence, Tuple
-from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
-    comp_pcc,
-)
-import ttnn
-from ttnn.operations.ccl import Topology
-from loguru import logger
+from typing import Dict, List, Sequence, Tuple
+from unittest import mock
+
 import pytest
+import torch
+from loguru import logger
+from ttnn.operations.ccl import Topology
+
+import ttnn
+from models.common.utility_functions import skip_with_llk_assert
 
 # ============================================================================
 # CONFIGURATION CONSTANTS
 # ============================================================================
 from tests.nightly.sdpa_perf_utils import MeshConfig
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
+    comp_pcc,
+)
 
 MESH_CONFIG = MeshConfig.detect()
 
@@ -247,10 +249,12 @@ NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK = 32
 
 from tests.nightly.sdpa_perf_utils import (
     ARCH_CONSTANTS,
-    post_process_ops_log,
+)
+from tests.nightly.sdpa_perf_utils import compute_math_utilization as compute_ring_joint_utilization
+from tests.nightly.sdpa_perf_utils import (
     compute_sdpa_flops,
-    compute_math_utilization as compute_ring_joint_utilization,
     create_balanced_chunk_order,
+    post_process_ops_log,
     reorder_tensor_chunks,
     reverse_reorder_tensor_chunks,
 )
@@ -3064,6 +3068,7 @@ def test_ring_joint_attention_sdpa_determinism(model_names):
     RING_MLA_TEST_CONFIGS,
     ids=RING_MLA_TEST_CONFIG_IDS,
 )
+@skip_with_llk_assert("ring_mla deterministic replay is timing-sensitive with LLK asserts enabled.")
 def test_ring_mla_determinism(
     b,
     sq,
@@ -3342,6 +3347,7 @@ else:
     RING_JOINT_PERF_CHECK_CONFIGS,
     ids=[f"{cfg[0]}-q{cfg[1]}-k{cfg[2]}-ring{cfg[3]}" for cfg in RING_JOINT_PERF_CHECK_CONFIGS],
 )
+@skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
 def test_ring_joint_attention_perf_check(
     model_name, q_chunk_size, k_chunk_size, ring_size_expected, expected_util, margin
 ):
@@ -3863,6 +3869,7 @@ else:
     RING_MLA_CHUNKED_PERF_CHECK_CONFIGS,
     ids=[f"{cfg[0]}-q{cfg[1]}-k{cfg[2]}-ring{cfg[3]}" for cfg in RING_MLA_CHUNKED_PERF_CHECK_CONFIGS],
 )
+@skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
 def test_ring_mla_chunked_perf_check(model_name, q_chunk_size, k_chunk_size, ring_size_expected, expected_util):
     """Measure ring_mla chunked-prefill math utilization for the kimi 50k+5k galaxy chunk (a 5k Q
     chunk against a 50k K/V prefix), simulated on the 4-device QuietBox, via tracy and assert

--- a/tests/ttnn/unit_tests/base_functionality/test_d2h_stream_service.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_d2h_stream_service.py
@@ -7,8 +7,7 @@ import pytest
 import torch
 
 import ttnn
-
-from models.common.utility_functions import skip_for_slow_dispatch
+from models.common.utility_functions import skip_for_slow_dispatch, skip_with_llk_assert
 
 # D2HStreamService claims FD dispatch-column service cores, which the runtime only permits when
 # BOTH conditions hold (see tt_metal/impl/internal/service/service_core_manager.cpp):
@@ -37,6 +36,7 @@ _D2H_SUPPORTED_CLUSTER_TYPES = frozenset(
 )
 pytestmark = [
     skip_for_slow_dispatch(),
+    skip_with_llk_assert("D2HStreamService fails to pin host DMA buffers. Issue: #47909"),
     pytest.mark.skipif(
         ttnn.cluster.get_cluster_type() not in _D2H_SUPPORTED_CLUSTER_TYPES,
         reason="D2HStreamService is only supported on Blackhole and UBB Galaxy clusters",


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes the LLK-asserts sanity nightly run by skipping tests that are not meaningful under `TT_METAL_LLK_ASSERTS=1` and by applying the existing configurable timeout to all C++ tt-sim test variants.

### Notes for reviewers
Please focus on whether the skipped tests are appropriate for the LLK-asserts lane. The skipped coverage is either performance/profiling oriented, already tracked as an LLK assert issue, or timing-sensitive determinism coverage that remains exercised in the normal nightly.

### Test plan
- run: https://github.com/tenstorrent/tt-metal/actions/runs/28091827566
- `python -m py_compile tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py`
- Reviewed failing LLK-asserts sanity jobs for SDPA determinism and D2H stream service failures.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/fix_sanity_nightly_debug_runs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/fix_sanity_nightly_debug_runs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/fix_sanity_nightly_debug_runs)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/fix_sanity_nightly_debug_runs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/fix_sanity_nightly_debug_runs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/fix_sanity_nightly_debug_runs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/fix_sanity_nightly_debug_runs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/fix_sanity_nightly_debug_runs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/fix_sanity_nightly_debug_runs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/fix_sanity_nightly_debug_runs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/fix_sanity_nightly_debug_runs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/fix_sanity_nightly_debug_runs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/fix_sanity_nightly_debug_runs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/fix_sanity_nightly_debug_runs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/fix_sanity_nightly_debug_runs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/fix_sanity_nightly_debug_runs)