### PR TITLE
[Fix] Untilize: enable fp32_dest_acc_en for INT32 datatype

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
@@ -11,9 +11,10 @@ from tests.ttnn.utils_for_testing import assert_equal
 from tests.ttnn.unit_tests.base_functionality.test_narrow import assert_quality
 
 
-@pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat16])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat16, ttnn.int32])
 @pytest.mark.parametrize("tensor_shape", [[2, 2, 256, 512]])
 def test_untilize_single_core_interleaved_to_interleaved(device, dtype, tensor_shape):
+    torch.manual_seed(42)
     # Input memory config
     input_memory_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
 
@@ -21,12 +22,18 @@ def test_untilize_single_core_interleaved_to_interleaved(device, dtype, tensor_s
     output_memory_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
 
     # Test
-    input_torch_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
+    if dtype == ttnn.int32:
+        input_torch_tensor = torch.randint(-1000, 1000, tensor_shape, dtype=torch.int32)
+    else:
+        input_torch_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
     input_ttnn_tensor = ttnn.from_torch(input_torch_tensor, dtype=dtype, layout=ttnn.TILE_LAYOUT)
     input_ttnn_tensor = ttnn.to_device(input_ttnn_tensor, device, memory_config=input_memory_config)
     ttnn_output_tensor = ttnn.untilize(input_ttnn_tensor, memory_config=output_memory_config, use_multicore=False)
 
-    assert_quality(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor), dtype)
+    if dtype == ttnn.int32:
+        assert_equal(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor))
+    else:
+        assert_quality(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor), dtype)
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])

--- a/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
@@ -446,7 +446,7 @@ def test_untilize_single_core_sharded_to_sharded(
     assert_equal(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor))
 
 
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32])
 @pytest.mark.parametrize("tensor_shape", [[1, 1, 512, 512]])
 @pytest.mark.parametrize("input_buffer_type", [ttnn.BufferType.L1, ttnn.BufferType.DRAM])
 @pytest.mark.parametrize("output_buffer_type", [ttnn.BufferType.L1, ttnn.BufferType.DRAM])
@@ -492,7 +492,10 @@ def test_untilize_single_core_buffer_type_variations(
         output_memory_config = ttnn.MemoryConfig(output_memory_layout, output_buffer_type, height_shard_spec)
 
     # Test
-    input_torch_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
+    if dtype == ttnn.bfloat16:
+        input_torch_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
+    else:
+        input_torch_tensor = torch.randint(-(2 ** (30)), 2 ** (30) - 1, tensor_shape, dtype=torch.int32)
     input_ttnn_tensor = ttnn.from_torch(input_torch_tensor, dtype=dtype, layout=ttnn.TILE_LAYOUT)
     input_ttnn_tensor = ttnn.to_device(input_ttnn_tensor, device, memory_config=input_memory_config)
     ttnn_output_tensor = ttnn.untilize(input_ttnn_tensor, memory_config=output_memory_config, use_multicore=False)

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.cpp
@@ -43,7 +43,8 @@ ttnn::Tensor untilize(
     const std::optional<MemoryConfig>& memory_config,
     bool use_multicore,
     const std::optional<CoreRangeSet>& sub_core_grids) {
-    bool fp32_dest_acc_en = input_tensor.dtype() == DataType::UINT32 || input_tensor.dtype() == DataType::FLOAT32;
+    bool fp32_dest_acc_en = input_tensor.dtype() == DataType::INT32 || input_tensor.dtype() == DataType::UINT32 ||
+                            input_tensor.dtype() == DataType::FLOAT32;
 
     auto input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.cpp
@@ -69,7 +69,8 @@ Tensor untilize_with_unpadding(
     const std::optional<MemoryConfig>& memory_config,
     bool use_multicore,
     const std::optional<CoreRangeSet>& sub_core_grids) {
-    bool fp32_dest_acc_en = input_tensor.dtype() == DataType::UINT32 || input_tensor.dtype() == DataType::FLOAT32;
+    bool fp32_dest_acc_en = input_tensor.dtype() == DataType::INT32 || input_tensor.dtype() == DataType::UINT32 ||
+                            input_tensor.dtype() == DataType::FLOAT32;
 
     ttnn::SmallVector<uint32_t> output_end_vector;
     ttnn::Shape output_end;


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

[Fix]
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
`fp32_dest_acc_en` flag needs to be set to `true` for 32-bit datatypes to be consistent with the in untilize program factories.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

1. `untilize.cpp` and `untilize_with_unpadding.cpp` enables 32-bit dest for `FLOAT32` and `UINT32` ( I believe `INT32` should also be added for consistency) 

[`bool fp32_dest_acc_en = input_tensor.dtype() == DataType::UINT32 || input_tensor.dtype() == DataType::FLOAT32;
`](https://github.com/tenstorrent/tt-metal/blob/c4b6db19aefff433d7a47cd41e5fb3768fa21c31/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.cpp#L46)

and in 

```
if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32 || a.dtype() == DataType::FLOAT32) {
        compute_kernel_defines.emplace_back("DST_ACCUM_MODE", "1");
    }
```

`untilize` already supports `INT32` 
<img width="1088" height="884" alt="image" src="https://github.com/user-attachments/assets/8a08a815-0750-4e15-9fef-fc5e87cca9d7" />

<img width="789" height="425" alt="image" src="https://github.com/user-attachments/assets/cc160afa-493a-4b6d-84b2-40fc4e2a140d" />


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kalaivani/untilize_int)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kalaivani/untilize_int)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kalaivani/untilize_int)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kalaivani/untilize_int)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=kalaivani/untilize_int)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:kalaivani/untilize_int)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kalaivani/untilize_int)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kalaivani/untilize_int)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kalaivani/untilize_int)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kalaivani/untilize_int)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kalaivani/untilize_int)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kalaivani/untilize_int)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kalaivani/untilize_int)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kalaivani/untilize_int)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kalaivani/untilize_int)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kalaivani/untilize_int)