### PR TITLE
[LLK] Simplify llk smoke CI

### DIFF
--- a/tests/pipeline_reorg/llk_smoke_tests.yaml
+++ b/tests/pipeline_reorg/llk_smoke_tests.yaml
@@ -10,7 +10,7 @@
     cd tests/python_tests
     pytest -q --override-ini=log_cli=false -n auto -x \
       -m "$PYTEST_MARKERS" \
-      --splits 4 --group 1 --timeout=60 \
+      --splits 4 --group 1 --timeout=300 \
       --junitxml=pytest-report-wormhole-1.xml .
   skus:
     wh_n150_civ2:
@@ -26,7 +26,7 @@
     cd tests/python_tests
     pytest -q --override-ini=log_cli=false -n auto -x \
       -m "$PYTEST_MARKERS" \
-      --splits 4 --group 2 --timeout=60 \
+      --splits 4 --group 2 --timeout=300 \
       --junitxml=pytest-report-wormhole-2.xml .
   skus:
     wh_n150_civ2:
@@ -42,7 +42,7 @@
     cd tests/python_tests
     pytest -q --override-ini=log_cli=false -n auto -x \
       -m "$PYTEST_MARKERS" \
-      --splits 4 --group 3 --timeout=60 \
+      --splits 4 --group 3 --timeout=300 \
       --junitxml=pytest-report-wormhole-3.xml .
   skus:
     wh_n150_civ2:
@@ -58,7 +58,7 @@
     cd tests/python_tests
     pytest -q --override-ini=log_cli=false -n auto -x \
       -m "$PYTEST_MARKERS" \
-      --splits 4 --group 4 --timeout=60 \
+      --splits 4 --group 4 --timeout=300 \
       --junitxml=pytest-report-wormhole-4.xml .
   skus:
     wh_n150_civ2:
@@ -74,7 +74,7 @@
     cd tests/python_tests
     pytest -q --override-ini=log_cli=false -n auto -x \
       -m "$PYTEST_MARKERS" \
-      --splits 4 --group 1 --timeout=60 \
+      --splits 4 --group 1 --timeout=300 \
       --junitxml=pytest-report-blackhole-1.xml .
   skus:
     bh_p150b_civ2:
@@ -90,7 +90,7 @@
     cd tests/python_tests
     pytest -q --override-ini=log_cli=false -n auto -x \
       -m "$PYTEST_MARKERS" \
-      --splits 4 --group 2 --timeout=60 \
+      --splits 4 --group 2 --timeout=300 \
       --junitxml=pytest-report-blackhole-2.xml .
   skus:
     bh_p150b_civ2:
@@ -106,7 +106,7 @@
     cd tests/python_tests
     pytest -q --override-ini=log_cli=false -n auto -x \
       -m "$PYTEST_MARKERS" \
-      --splits 4 --group 3 --timeout=60 \
+      --splits 4 --group 3 --timeout=300 \
       --junitxml=pytest-report-blackhole-3.xml .
   skus:
     bh_p150b_civ2:
@@ -122,7 +122,7 @@
     cd tests/python_tests
     pytest -q --override-ini=log_cli=false -n auto -x \
       -m "$PYTEST_MARKERS" \
-      --splits 4 --group 4 --timeout=60 \
+      --splits 4 --group 4 --timeout=300 \
       --junitxml=pytest-report-blackhole-4.xml .
   skus:
     bh_p150b_civ2:

--- a/tests/pipeline_reorg/llk_smoke_tests.yaml
+++ b/tests/pipeline_reorg/llk_smoke_tests.yaml
@@ -8,18 +8,10 @@
   cmd: |
     set -euo pipefail
     cd tests/python_tests
-    PYTEST_COMPILE_EXTRA="-q --override-ini=log_cli=false"
-    PYTEST_RUN_EXTRA="-q --override-ini=log_cli=false"
-    pytest $PYTEST_COMPILE_EXTRA --compile-producer -n 10 \
+    pytest -q --override-ini=log_cli=false -n auto \
       -m "$PYTEST_MARKERS" \
       --splits 4 --group 1 --timeout=60 \
-      --junitxml=pytest-report-wormhole-1-compile.xml .
-    pytest $PYTEST_RUN_EXTRA --compile-consumer -x \
-      -m "$PYTEST_MARKERS" \
-      --splits 4 --group 1 \
-      --timeout=60 \
-      --junitxml=pytest-report-wormhole-1-run.xml .
-    junitparser merge pytest-report-wormhole-1-compile.xml pytest-report-wormhole-1-run.xml pytest-report-wormhole-1.xml
+      --junitxml=pytest-report-wormhole-1.xml .
   skus:
     wh_n150_civ2:
       timeout: 40
@@ -32,18 +24,10 @@
   cmd: |
     set -euo pipefail
     cd tests/python_tests
-    PYTEST_COMPILE_EXTRA="-q --override-ini=log_cli=false"
-    PYTEST_RUN_EXTRA="-q --override-ini=log_cli=false"
-    pytest $PYTEST_COMPILE_EXTRA --compile-producer -n 10 \
+    pytest -q --override-ini=log_cli=false -n auto \
       -m "$PYTEST_MARKERS" \
       --splits 4 --group 2 --timeout=60 \
-      --junitxml=pytest-report-wormhole-2-compile.xml .
-    pytest $PYTEST_RUN_EXTRA --compile-consumer -x \
-      -m "$PYTEST_MARKERS" \
-      --splits 4 --group 2 \
-      --timeout=60 \
-      --junitxml=pytest-report-wormhole-2-run.xml .
-    junitparser merge pytest-report-wormhole-2-compile.xml pytest-report-wormhole-2-run.xml pytest-report-wormhole-2.xml
+      --junitxml=pytest-report-wormhole-2.xml .
   skus:
     wh_n150_civ2:
       timeout: 40
@@ -56,18 +40,10 @@
   cmd: |
     set -euo pipefail
     cd tests/python_tests
-    PYTEST_COMPILE_EXTRA="-q --override-ini=log_cli=false"
-    PYTEST_RUN_EXTRA="-q --override-ini=log_cli=false"
-    pytest $PYTEST_COMPILE_EXTRA --compile-producer -n 10 \
+    pytest -q --override-ini=log_cli=false -n auto \
       -m "$PYTEST_MARKERS" \
       --splits 4 --group 3 --timeout=60 \
-      --junitxml=pytest-report-wormhole-3-compile.xml .
-    pytest $PYTEST_RUN_EXTRA --compile-consumer -x \
-      -m "$PYTEST_MARKERS" \
-      --splits 4 --group 3 \
-      --timeout=60 \
-      --junitxml=pytest-report-wormhole-3-run.xml .
-    junitparser merge pytest-report-wormhole-3-compile.xml pytest-report-wormhole-3-run.xml pytest-report-wormhole-3.xml
+      --junitxml=pytest-report-wormhole-3.xml .
   skus:
     wh_n150_civ2:
       timeout: 40
@@ -80,18 +56,10 @@
   cmd: |
     set -euo pipefail
     cd tests/python_tests
-    PYTEST_COMPILE_EXTRA="-q --override-ini=log_cli=false"
-    PYTEST_RUN_EXTRA="-q --override-ini=log_cli=false"
-    pytest $PYTEST_COMPILE_EXTRA --compile-producer -n 10 \
+    pytest -q --override-ini=log_cli=false -n auto \
       -m "$PYTEST_MARKERS" \
       --splits 4 --group 4 --timeout=60 \
-      --junitxml=pytest-report-wormhole-4-compile.xml .
-    pytest $PYTEST_RUN_EXTRA --compile-consumer -x \
-      -m "$PYTEST_MARKERS" \
-      --splits 4 --group 4 \
-      --timeout=60 \
-      --junitxml=pytest-report-wormhole-4-run.xml .
-    junitparser merge pytest-report-wormhole-4-compile.xml pytest-report-wormhole-4-run.xml pytest-report-wormhole-4.xml
+      --junitxml=pytest-report-wormhole-4.xml .
   skus:
     wh_n150_civ2:
       timeout: 40
@@ -104,18 +72,10 @@
   cmd: |
     set -euo pipefail
     cd tests/python_tests
-    PYTEST_COMPILE_EXTRA="-q --override-ini=log_cli=false"
-    PYTEST_RUN_EXTRA="-q --override-ini=log_cli=false"
-    pytest $PYTEST_COMPILE_EXTRA --compile-producer -n 10 \
+    pytest -q --override-ini=log_cli=false -n auto \
       -m "$PYTEST_MARKERS" \
       --splits 4 --group 1 --timeout=60 \
-      --junitxml=pytest-report-blackhole-1-compile.xml .
-    pytest $PYTEST_RUN_EXTRA --compile-consumer -x \
-      -m "$PYTEST_MARKERS" \
-      --splits 4 --group 1 \
-      --timeout=60 \
-      --junitxml=pytest-report-blackhole-1-run.xml .
-    junitparser merge pytest-report-blackhole-1-compile.xml pytest-report-blackhole-1-run.xml pytest-report-blackhole-1.xml
+      --junitxml=pytest-report-blackhole-1.xml .
   skus:
     bh_p150b_civ2:
       timeout: 40
@@ -128,18 +88,10 @@
   cmd: |
     set -euo pipefail
     cd tests/python_tests
-    PYTEST_COMPILE_EXTRA="-q --override-ini=log_cli=false"
-    PYTEST_RUN_EXTRA="-q --override-ini=log_cli=false"
-    pytest $PYTEST_COMPILE_EXTRA --compile-producer -n 10 \
+    pytest -q --override-ini=log_cli=false -n auto \
       -m "$PYTEST_MARKERS" \
       --splits 4 --group 2 --timeout=60 \
-      --junitxml=pytest-report-blackhole-2-compile.xml .
-    pytest $PYTEST_RUN_EXTRA --compile-consumer -x \
-      -m "$PYTEST_MARKERS" \
-      --splits 4 --group 2 \
-      --timeout=60 \
-      --junitxml=pytest-report-blackhole-2-run.xml .
-    junitparser merge pytest-report-blackhole-2-compile.xml pytest-report-blackhole-2-run.xml pytest-report-blackhole-2.xml
+      --junitxml=pytest-report-blackhole-2.xml .
   skus:
     bh_p150b_civ2:
       timeout: 40
@@ -152,18 +104,10 @@
   cmd: |
     set -euo pipefail
     cd tests/python_tests
-    PYTEST_COMPILE_EXTRA="-q --override-ini=log_cli=false"
-    PYTEST_RUN_EXTRA="-q --override-ini=log_cli=false"
-    pytest $PYTEST_COMPILE_EXTRA --compile-producer -n 10 \
+    pytest -q --override-ini=log_cli=false -n auto \
       -m "$PYTEST_MARKERS" \
       --splits 4 --group 3 --timeout=60 \
-      --junitxml=pytest-report-blackhole-3-compile.xml .
-    pytest $PYTEST_RUN_EXTRA --compile-consumer -x \
-      -m "$PYTEST_MARKERS" \
-      --splits 4 --group 3 \
-      --timeout=60 \
-      --junitxml=pytest-report-blackhole-3-run.xml .
-    junitparser merge pytest-report-blackhole-3-compile.xml pytest-report-blackhole-3-run.xml pytest-report-blackhole-3.xml
+      --junitxml=pytest-report-blackhole-3.xml .
   skus:
     bh_p150b_civ2:
       timeout: 40
@@ -176,18 +120,10 @@
   cmd: |
     set -euo pipefail
     cd tests/python_tests
-    PYTEST_COMPILE_EXTRA="-q --override-ini=log_cli=false"
-    PYTEST_RUN_EXTRA="-q --override-ini=log_cli=false"
-    pytest $PYTEST_COMPILE_EXTRA --compile-producer -n 10 \
+    pytest -q --override-ini=log_cli=false -n auto \
       -m "$PYTEST_MARKERS" \
       --splits 4 --group 4 --timeout=60 \
-      --junitxml=pytest-report-blackhole-4-compile.xml .
-    pytest $PYTEST_RUN_EXTRA --compile-consumer -x \
-      -m "$PYTEST_MARKERS" \
-      --splits 4 --group 4 \
-      --timeout=60 \
-      --junitxml=pytest-report-blackhole-4-run.xml .
-    junitparser merge pytest-report-blackhole-4-compile.xml pytest-report-blackhole-4-run.xml pytest-report-blackhole-4.xml
+      --junitxml=pytest-report-blackhole-4.xml .
   skus:
     bh_p150b_civ2:
       timeout: 40

--- a/tests/pipeline_reorg/llk_smoke_tests.yaml
+++ b/tests/pipeline_reorg/llk_smoke_tests.yaml
@@ -1,8 +1,7 @@
-# LLK smoke — PR-gate python_tests (no coverage, 4-way split, markers not perf and not nightly and not quasar).
+# LLK smoke — PR-gate python_tests (no coverage, markers not perf and not nightly and not quasar).
 # PYTEST_MARKERS is set by llk-smoke-impl.yaml / workflow_call inputs. ci-quiet log mode is hard-coded.
 
-- name: llk_smoke_wormhole group 1/4
-  split_group: 1
+- name: llk_smoke_wormhole
   team: llk
   coverage: false
   cmd: |
@@ -10,15 +9,14 @@
     cd tests/python_tests
     pytest -q --override-ini=log_cli=false -n auto -x \
       -m "$PYTEST_MARKERS" \
-      --splits 4 --group 1 --timeout=300 \
-      --junitxml=pytest-report-wormhole-1.xml .
+      --timeout=60 \
+      --junitxml=pytest-report-wormhole.xml .
   skus:
     wh_n150_civ2:
       timeout: 40
   owner_id: U07J3K6KS1K
 
-- name: llk_smoke_wormhole group 2/4
-  split_group: 2
+- name: llk_smoke_blackhole
   team: llk
   coverage: false
   cmd: |
@@ -26,104 +24,8 @@
     cd tests/python_tests
     pytest -q --override-ini=log_cli=false -n auto -x \
       -m "$PYTEST_MARKERS" \
-      --splits 4 --group 2 --timeout=300 \
-      --junitxml=pytest-report-wormhole-2.xml .
-  skus:
-    wh_n150_civ2:
-      timeout: 40
-  owner_id: U07J3K6KS1K
-
-- name: llk_smoke_wormhole group 3/4
-  split_group: 3
-  team: llk
-  coverage: false
-  cmd: |
-    set -euo pipefail
-    cd tests/python_tests
-    pytest -q --override-ini=log_cli=false -n auto -x \
-      -m "$PYTEST_MARKERS" \
-      --splits 4 --group 3 --timeout=300 \
-      --junitxml=pytest-report-wormhole-3.xml .
-  skus:
-    wh_n150_civ2:
-      timeout: 40
-  owner_id: U07J3K6KS1K
-
-- name: llk_smoke_wormhole group 4/4
-  split_group: 4
-  team: llk
-  coverage: false
-  cmd: |
-    set -euo pipefail
-    cd tests/python_tests
-    pytest -q --override-ini=log_cli=false -n auto -x \
-      -m "$PYTEST_MARKERS" \
-      --splits 4 --group 4 --timeout=300 \
-      --junitxml=pytest-report-wormhole-4.xml .
-  skus:
-    wh_n150_civ2:
-      timeout: 40
-  owner_id: U07J3K6KS1K
-
-- name: llk_smoke_blackhole group 1/4
-  split_group: 1
-  team: llk
-  coverage: false
-  cmd: |
-    set -euo pipefail
-    cd tests/python_tests
-    pytest -q --override-ini=log_cli=false -n auto -x \
-      -m "$PYTEST_MARKERS" \
-      --splits 4 --group 1 --timeout=300 \
-      --junitxml=pytest-report-blackhole-1.xml .
-  skus:
-    bh_p150b_civ2:
-      timeout: 40
-  owner_id: U07J3K6KS1K
-
-- name: llk_smoke_blackhole group 2/4
-  split_group: 2
-  team: llk
-  coverage: false
-  cmd: |
-    set -euo pipefail
-    cd tests/python_tests
-    pytest -q --override-ini=log_cli=false -n auto -x \
-      -m "$PYTEST_MARKERS" \
-      --splits 4 --group 2 --timeout=300 \
-      --junitxml=pytest-report-blackhole-2.xml .
-  skus:
-    bh_p150b_civ2:
-      timeout: 40
-  owner_id: U07J3K6KS1K
-
-- name: llk_smoke_blackhole group 3/4
-  split_group: 3
-  team: llk
-  coverage: false
-  cmd: |
-    set -euo pipefail
-    cd tests/python_tests
-    pytest -q --override-ini=log_cli=false -n auto -x \
-      -m "$PYTEST_MARKERS" \
-      --splits 4 --group 3 --timeout=300 \
-      --junitxml=pytest-report-blackhole-3.xml .
-  skus:
-    bh_p150b_civ2:
-      timeout: 40
-  owner_id: U07J3K6KS1K
-
-- name: llk_smoke_blackhole group 4/4
-  split_group: 4
-  team: llk
-  coverage: false
-  cmd: |
-    set -euo pipefail
-    cd tests/python_tests
-    pytest -q --override-ini=log_cli=false -n auto -x \
-      -m "$PYTEST_MARKERS" \
-      --splits 4 --group 4 --timeout=300 \
-      --junitxml=pytest-report-blackhole-4.xml .
+      --timeout=60 \
+      --junitxml=pytest-report-blackhole.xml .
   skus:
     bh_p150b_civ2:
       timeout: 40

--- a/tests/pipeline_reorg/llk_smoke_tests.yaml
+++ b/tests/pipeline_reorg/llk_smoke_tests.yaml
@@ -8,7 +8,7 @@
   cmd: |
     set -euo pipefail
     cd tests/python_tests
-    pytest -q --override-ini=log_cli=false -n auto \
+    pytest -q --override-ini=log_cli=false -n auto -x \
       -m "$PYTEST_MARKERS" \
       --splits 4 --group 1 --timeout=60 \
       --junitxml=pytest-report-wormhole-1.xml .
@@ -24,7 +24,7 @@
   cmd: |
     set -euo pipefail
     cd tests/python_tests
-    pytest -q --override-ini=log_cli=false -n auto \
+    pytest -q --override-ini=log_cli=false -n auto -x \
       -m "$PYTEST_MARKERS" \
       --splits 4 --group 2 --timeout=60 \
       --junitxml=pytest-report-wormhole-2.xml .
@@ -40,7 +40,7 @@
   cmd: |
     set -euo pipefail
     cd tests/python_tests
-    pytest -q --override-ini=log_cli=false -n auto \
+    pytest -q --override-ini=log_cli=false -n auto -x \
       -m "$PYTEST_MARKERS" \
       --splits 4 --group 3 --timeout=60 \
       --junitxml=pytest-report-wormhole-3.xml .
@@ -56,7 +56,7 @@
   cmd: |
     set -euo pipefail
     cd tests/python_tests
-    pytest -q --override-ini=log_cli=false -n auto \
+    pytest -q --override-ini=log_cli=false -n auto -x \
       -m "$PYTEST_MARKERS" \
       --splits 4 --group 4 --timeout=60 \
       --junitxml=pytest-report-wormhole-4.xml .
@@ -72,7 +72,7 @@
   cmd: |
     set -euo pipefail
     cd tests/python_tests
-    pytest -q --override-ini=log_cli=false -n auto \
+    pytest -q --override-ini=log_cli=false -n auto -x \
       -m "$PYTEST_MARKERS" \
       --splits 4 --group 1 --timeout=60 \
       --junitxml=pytest-report-blackhole-1.xml .
@@ -88,7 +88,7 @@
   cmd: |
     set -euo pipefail
     cd tests/python_tests
-    pytest -q --override-ini=log_cli=false -n auto \
+    pytest -q --override-ini=log_cli=false -n auto -x \
       -m "$PYTEST_MARKERS" \
       --splits 4 --group 2 --timeout=60 \
       --junitxml=pytest-report-blackhole-2.xml .
@@ -104,7 +104,7 @@
   cmd: |
     set -euo pipefail
     cd tests/python_tests
-    pytest -q --override-ini=log_cli=false -n auto \
+    pytest -q --override-ini=log_cli=false -n auto -x \
       -m "$PYTEST_MARKERS" \
       --splits 4 --group 3 --timeout=60 \
       --junitxml=pytest-report-blackhole-3.xml .
@@ -120,7 +120,7 @@
   cmd: |
     set -euo pipefail
     cd tests/python_tests
-    pytest -q --override-ini=log_cli=false -n auto \
+    pytest -q --override-ini=log_cli=false -n auto -x \
       -m "$PYTEST_MARKERS" \
       --splits 4 --group 4 --timeout=60 \
       --junitxml=pytest-report-blackhole-4.xml .

--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -321,9 +321,15 @@ def pytest_configure(config):
         config.getoption("--speed-of-light", default=False),
     )
 
+    worker_id = getattr(config, "workerinput", {}).get("workerid", "master")
+
+    if worker_id != "master":
+        import torch
+
+        torch.set_num_threads(1)
+
     TestConfig.setup_mode(
-        # Pass worker id here, so TestConfig can calculate Tensix tile it will run on
-        getattr(config, "workerinput", {}).get("workerid", "master"),
+        worker_id,
         config.getoption("--compile-consumer", default=False),
         config.getoption("--compile-producer", default=False),
         config.getoption("--stimuli-only"),

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -578,6 +578,25 @@ class TestConfig:
             )
             golden_generators_module.get_golden_generator = get_golden_proxied
 
+        # In DEFAULT mode with parallel workers, isolate artefacts per worker
+        if TestConfig.BUILD_MODE == BuildMode.DEFAULT and worker_id != "master":
+            TestConfig.ARTEFACTS_DIR = TestConfig.DEFAULT_ARTEFACTS_PATH / worker_id
+            TestConfig.SHARED_DIR = TestConfig.ARTEFACTS_DIR / "shared"
+            TestConfig.SHARED_OBJ_DIR = TestConfig.SHARED_DIR / "obj"
+            TestConfig.SHARED_ELF_DIR = TestConfig.SHARED_DIR / "elf"
+            TestConfig.PROFILER_SHARED_DIR = (
+                TestConfig.ARTEFACTS_DIR / "shared-profiler"
+            )
+            TestConfig.PROFILER_SHARED_OBJ_DIR = TestConfig.PROFILER_SHARED_DIR / "obj"
+            TestConfig.PROFILER_SHARED_ELF_DIR = TestConfig.PROFILER_SHARED_DIR / "elf"
+            TestConfig.COVERAGE_INFO_DIR = TestConfig.ARTEFACTS_DIR / "coverage_info"
+            TestConfig.PROFILER_META = TestConfig.ARTEFACTS_DIR / "profiler_meta"
+            TestConfig.SYNC_DIR = TestConfig.ARTEFACTS_DIR / "sync_primitives"
+            TestConfig.PERF_DATA_DIR = TestConfig.ARTEFACTS_DIR / "temp_perf_data"
+            TestConfig.DEFAULT_STIMULI_CACHE_FOLDER = (
+                TestConfig.ARTEFACTS_DIR / "temp_stimuli"
+            )
+
         # Always have a fresh build when compiling
         if TestConfig.BUILD_MODE in [BuildMode.PRODUCE, BuildMode.DEFAULT]:
             shutil.rmtree(TestConfig.ARTEFACTS_DIR.absolute(), ignore_errors=True)

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -578,25 +578,6 @@ class TestConfig:
             )
             golden_generators_module.get_golden_generator = get_golden_proxied
 
-        # In DEFAULT mode with parallel workers, isolate artefacts per worker
-        if TestConfig.BUILD_MODE == BuildMode.DEFAULT and worker_id != "master":
-            TestConfig.ARTEFACTS_DIR = TestConfig.DEFAULT_ARTEFACTS_PATH / worker_id
-            TestConfig.SHARED_DIR = TestConfig.ARTEFACTS_DIR / "shared"
-            TestConfig.SHARED_OBJ_DIR = TestConfig.SHARED_DIR / "obj"
-            TestConfig.SHARED_ELF_DIR = TestConfig.SHARED_DIR / "elf"
-            TestConfig.PROFILER_SHARED_DIR = (
-                TestConfig.ARTEFACTS_DIR / "shared-profiler"
-            )
-            TestConfig.PROFILER_SHARED_OBJ_DIR = TestConfig.PROFILER_SHARED_DIR / "obj"
-            TestConfig.PROFILER_SHARED_ELF_DIR = TestConfig.PROFILER_SHARED_DIR / "elf"
-            TestConfig.COVERAGE_INFO_DIR = TestConfig.ARTEFACTS_DIR / "coverage_info"
-            TestConfig.PROFILER_META = TestConfig.ARTEFACTS_DIR / "profiler_meta"
-            TestConfig.SYNC_DIR = TestConfig.ARTEFACTS_DIR / "sync_primitives"
-            TestConfig.PERF_DATA_DIR = TestConfig.ARTEFACTS_DIR / "temp_perf_data"
-            TestConfig.DEFAULT_STIMULI_CACHE_FOLDER = (
-                TestConfig.ARTEFACTS_DIR / "temp_stimuli"
-            )
-
         # Always have a fresh build when compiling
         if TestConfig.BUILD_MODE in [BuildMode.PRODUCE, BuildMode.DEFAULT]:
             shutil.rmtree(TestConfig.ARTEFACTS_DIR.absolute(), ignore_errors=True)

--- a/tt_metal/tt-llk/tests/python_tests/test_reduce.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_reduce.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
+# buongiorno
 import math
 
 import pytest

--- a/tt_metal/tt-llk/tests/python_tests/test_reduce.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_reduce.py
@@ -49,8 +49,29 @@ mathop_mapping = {
 }
 
 
+def _fidelities_for_format(formats):
+    """LoFi fails for Float16_b/Float32 inputs — exclude at parametrize time."""
+    if formats.input_format in [DataFormat.Float16_b, DataFormat.Float32]:
+        return [MathFidelity.HiFi2, MathFidelity.HiFi3, MathFidelity.HiFi4]
+    return [
+        MathFidelity.LoFi,
+        MathFidelity.HiFi2,
+        MathFidelity.HiFi3,
+        MathFidelity.HiFi4,
+    ]
+
+
+def _reduce_to_one_for_format(formats):
+    """Bfp8_b accumulates error easily with reduce_to_one (#45143) — exclude at parametrize time."""
+    if (
+        formats.input_format == DataFormat.Bfp8_b
+        or formats.output_format == DataFormat.Bfp8_b
+    ):
+        return [False]
+    return [False, True]
+
+
 @parametrize(
-    tile_dimensions=[[1, 32], [2, 32], [4, 32], [8, 32], [16, 32], [32, 32], [32, 16]],
     formats=input_output_formats(
         [
             DataFormat.Float32,
@@ -58,38 +79,20 @@ mathop_mapping = {
             DataFormat.Bfp8_b,
         ]
     ),
-    is_reduce_to_one=[False, True],
     reduce_dim=[ReduceDimension.Row, ReduceDimension.Column, ReduceDimension.Scalar],
     pool_type=[ReducePool.Max, ReducePool.Average, ReducePool.Sum],
-    math_fidelity=[
-        MathFidelity.LoFi,
-        MathFidelity.HiFi2,
-        MathFidelity.HiFi3,
-        MathFidelity.HiFi4,
-    ],
+    math_fidelity=_fidelities_for_format,
+    is_reduce_to_one=_reduce_to_one_for_format,
+    tile_dimensions=[[1, 32], [2, 32], [4, 32], [8, 32], [16, 32], [32, 32], [32, 16]],
 )
 def test_reduce(
     formats,
     reduce_dim,
     pool_type,
-    is_reduce_to_one,
     math_fidelity,
+    is_reduce_to_one,
     tile_dimensions,
 ):
-
-    if (formats.input_format in [DataFormat.Float16_b, DataFormat.Float32]) and (
-        math_fidelity == MathFidelity.LoFi
-    ):
-        pytest.skip("LoFi fails in these cases for reduce")
-
-    if (
-        formats.input_format == DataFormat.Bfp8_b
-        or formats.output_format == DataFormat.Bfp8_b
-    ) and is_reduce_to_one:
-        pytest.skip(
-            "Bfp8_b reduce accumulates error easily. Issue in tt-metal repo: #45143"
-        )
-
     tile_shape = construct_tile_shape(tile_dimensions)
 
     if is_reduce_to_one:
@@ -243,7 +246,6 @@ def test_reduce(
 
 
 @parametrize(
-    tile_dimensions=[[32, 32]],
     formats=[
         fmt
         for fmt in input_output_formats(
@@ -257,7 +259,6 @@ def test_reduce(
         if fmt.input_format == DataFormat.Bfp4_b
         or fmt.output_format == DataFormat.Bfp4_b
     ],
-    is_reduce_to_one=[False, True],
     reduce_dim=[ReduceDimension.Row, ReduceDimension.Column, ReduceDimension.Scalar],
     pool_type=[ReducePool.Max, ReducePool.Average, ReducePool.Sum],
     math_fidelity=[
@@ -266,13 +267,15 @@ def test_reduce(
         MathFidelity.HiFi3,
         MathFidelity.HiFi4,
     ],
+    is_reduce_to_one=[False, True],
+    tile_dimensions=[[32, 32]],
 )
 def test_reduce_bfp4_b(
     formats,
     reduce_dim,
     pool_type,
-    is_reduce_to_one,
     math_fidelity,
+    is_reduce_to_one,
     tile_dimensions,
 ):
 


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Added `torch.set_num_threads(1)` per worker to avoid CPU overload.

Removed the two phase `--compile-producer`/`--compile-consumer` split. Previously tests were collected twice once to compile in parallel, then again to run on a single worker. Now a single pytest command collects once and each worker both compiles and runs its tests in parallel.

Each architecture now runs on a single CI runner instead of four.

Skips in `test_reduce.py` were removed while investigating why it runs slower than `test_matmul.py`, and the change was kept to avoid unnecessary skip overhead.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=markoradosavljevic/fast-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:markoradosavljevic/fast-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=markoradosavljevic/fast-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:markoradosavljevic/fast-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=markoradosavljevic/fast-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:markoradosavljevic/fast-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=markoradosavljevic/fast-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:markoradosavljevic/fast-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=markoradosavljevic/fast-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:markoradosavljevic/fast-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=markoradosavljevic/fast-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:markoradosavljevic/fast-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=markoradosavljevic/fast-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:markoradosavljevic/fast-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=markoradosavljevic/fast-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:markoradosavljevic/fast-ci)