### PR TITLE
#45821: clear program cache on MeshDevice reconfiguration

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_device_reshape.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device_reshape.cpp
@@ -16,9 +16,11 @@
 #include <tt-metalium/dispatch_core_common.hpp>
 #include "gmock/gmock.h"
 #include "hostdevcommon/common_values.hpp"
+#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/mesh_config.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/program_cache.hpp>
 #include <tt-metalium/system_mesh.hpp>
 #include <tt-metalium/maybe_remote.hpp>
 #include "impl/context/metal_context.hpp"
@@ -165,6 +167,22 @@ TEST_F(MeshDevice1x8ReshapeTest, From1x8To2x4ThenBackTo1x8) {
 
     mesh_device_->reshape(MeshShape(1, 8));
     EXPECT_EQ(mesh_device_->get_device_ids(), original_order);
+}
+
+TEST_F(MeshDevice1x8ReshapeTest, ReshapeClearsProgramCache) {
+    // Reshape remaps device order, so stale cached programs must be dropped.
+
+    // Inserts a dummy entry so num_program_cache_entries() > 0 without dispatching a workload.
+    mesh_device_->get_program_cache().insert(
+        tt::tt_metal::program_cache::detail::ProgramCacheKey{1, "reconfig_regression_dummy"},
+        tt::tt_metal::program_cache::detail::CachedProgramFactory(
+            tt::tt_metal::program_cache::detail::CachedProgram<int>(tt::tt_metal::CreateProgram(), 0), 0));
+
+    EXPECT_GT(mesh_device_->num_program_cache_entries(), 0u);
+
+    mesh_device_->reshape(MeshShape(2, 4));
+
+    EXPECT_EQ(mesh_device_->num_program_cache_entries(), 0u);
 }
 
 TEST_F(MeshDevice1x8ReshapeTest, InvalidTotalDeviceCount) {

--- a/tests/tt_metal/distributed/test_mesh_sub_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_sub_device.cpp
@@ -31,6 +31,7 @@
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/program.hpp>
+#include <tt-metalium/program_cache.hpp>
 #include <tt_stl/span.hpp>
 #include <tt-metalium/sub_device_types.hpp>
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
@@ -42,6 +43,44 @@ namespace {
 
 namespace tt::tt_metal {
 using MeshSubDeviceTestSuite = GenericMeshDeviceFixture;
+
+TEST_F(MeshSubDeviceTestSuite, LoadSubDeviceManagerClearsProgramCache) {
+    // Loading a manager may remap SubDeviceId -> worker cores, so cached programs must be dropped.
+    SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
+    SubDevice sub_device_2(std::array{CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})})});
+    auto sub_device_manager = mesh_device_->create_sub_device_manager({sub_device_1, sub_device_2}, 3200);
+
+    // Inserts a dummy entry so num_program_cache_entries() > 0 without dispatching a workload.
+    mesh_device_->get_program_cache().insert(
+        ::tt::tt_metal::program_cache::detail::ProgramCacheKey{1, "reconfig_regression_dummy"},
+        ::tt::tt_metal::program_cache::detail::CachedProgramFactory(
+            ::tt::tt_metal::program_cache::detail::CachedProgram<int>(::tt::tt_metal::CreateProgram(), 0), 0));
+
+    EXPECT_GT(mesh_device_->num_program_cache_entries(), 0u);
+
+    mesh_device_->load_sub_device_manager(sub_device_manager);
+
+    EXPECT_EQ(mesh_device_->num_program_cache_entries(), 0u);
+}
+
+TEST_F(MeshSubDeviceTestSuite, ClearLoadedSubDeviceManagerClearsProgramCache) {
+    // Reverting to the default manager remaps worker cores, so cached programs must be dropped.
+    SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
+    SubDevice sub_device_2(std::array{CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})})});
+    auto sub_device_manager = mesh_device_->create_sub_device_manager({sub_device_1, sub_device_2}, 3200);
+    mesh_device_->load_sub_device_manager(sub_device_manager);
+
+    // Inserts a dummy entry so num_program_cache_entries() > 0 without dispatching a workload.
+    mesh_device_->get_program_cache().insert(
+        ::tt::tt_metal::program_cache::detail::ProgramCacheKey{1, "reconfig_regression_dummy"},
+        ::tt::tt_metal::program_cache::detail::CachedProgramFactory(
+            ::tt::tt_metal::program_cache::detail::CachedProgram<int>(::tt::tt_metal::CreateProgram(), 0), 0));
+    EXPECT_GT(mesh_device_->num_program_cache_entries(), 0u);
+
+    mesh_device_->clear_loaded_sub_device_manager();
+
+    EXPECT_EQ(mesh_device_->num_program_cache_entries(), 0u);
+}
 
 TEST_F(MeshSubDeviceTestSuite, SyncWorkloadsOnSubDevice) {
     SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -876,6 +876,7 @@ void MeshDeviceImpl::reshape(const MeshShape& new_shape) {
     }
     auto new_view = std::make_unique<MeshDeviceView>(new_shape, new_device_order, new_fabric_node_ids);
     view_ = std::move(new_view);
+    clear_program_cache();  // Reshape remaps device order
 }
 
 bool MeshDeviceImpl::close() {
@@ -1103,11 +1104,13 @@ void MeshDeviceImpl::load_sub_device_manager(SubDeviceManagerId sub_device_manag
     auto lock = lock_api();
     validate_sub_device_manager_tracker();
     sub_device_manager_tracker_->load_sub_device_manager(sub_device_manager_id);
+    clear_program_cache();  // Manager switch may remap SubDeviceId
 }
 void MeshDeviceImpl::clear_loaded_sub_device_manager() {
     auto lock = lock_api();
     validate_sub_device_manager_tracker();
     sub_device_manager_tracker_->clear_loaded_sub_device_manager();
+    clear_program_cache();  // possibility of remapping worker cores baked into cached programs.
 }
 
 CoreCoord MeshDeviceImpl::dram_grid_size() const {


### PR DESCRIPTION
### PR Category
Addressing architectural issues

## Summary
Program-cache entries bake in device-global state (resolved worker cores, mesh device order, fabric routing) that is not part of the cache key. Reconfiguring a `MeshDevice` left stale entries in the cache, so a later op with an unchanged key could hit a program compiled for the old configuration — a wrong-result hazard (follow-up to the #45821 hash-collision work).

The cache was only ever auto-cleared on `Device::close()`; `MeshDevice` reconfiguration paths never cleared it, and the same `SubDeviceId` can map to different cores across sub-device managers.

This PR makes the `MeshDevice` reconfiguration APIs clear the program cache automatically, so callers no longer have to remember a manual `clear_program_cache()`.

## Changes
- `MeshDeviceImpl::reshape()` clears the program cache after rebuilding the mesh view (device order / fabric-node mapping change).
- `MeshDeviceImpl::load_sub_device_manager()` clears the cache after a manager switch (may remap `SubDeviceId` → worker cores).
- `MeshDeviceImpl::clear_loaded_sub_device_manager()` clears the cache after reverting to the default manager.

## Notes for reviewers
- Scope is the well-defined `MeshDevice` reconfiguration APIs only. `create_sub_device_manager`/`remove_sub_device_manager` and stall-group changes do not alter active state and are intentionally left untouched.
- Single-device `Device` is unchanged: its sub-device APIs are deprecated/fatal, it has no `reshape`, and `Device::close()` already clears.
- Clearing is unconditional and these are infrequent, explicit operations, so the only cost is a recompile on the next dispatch — acceptable for the correctness guarantee.
- Out of scope (not clean reconfig APIs): service-core compute-grid shrink and CCL semaphore/buffer reallocation; ops affected by those still rely on their own keys / manual clears.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_clear_cache_logic)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_clear_cache_logic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_clear_cache_logic)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_clear_cache_logic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_clear_cache_logic)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_clear_cache_logic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_clear_cache_logic)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_clear_cache_logic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_clear_cache_logic)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_clear_cache_logic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_clear_cache_logic)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_clear_cache_logic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_clear_cache_logic)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_clear_cache_logic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_clear_cache_logic)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_clear_cache_logic)