### PR TITLE
[Cleanup] Migrate moreh dataflow kernels to Device 2.0 API

### DIFF
--- a/ttnn/cpp/ttnn/kernel/dataflow/moreh_common.hpp
+++ b/ttnn/cpp/ttnn/kernel/dataflow/moreh_common.hpp
@@ -787,12 +787,15 @@ void read_line(
                 {.offset_bytes = 0});
             noc.async_read_barrier();
             // Now copy only the valid elements to the destination CB via a local L1 unicast read.
-            UnicastEndpoint scratch_src{
-                .noc_x = static_cast<uint32_t>(my_x[0]),
-                .noc_y = static_cast<uint32_t>(my_y[0]),
-                .addr = cb_scratch.get_write_ptr(),
-            };
-            noc.async_read(scratch_src, cb, valid_elements_bytes, {.offset_bytes = 0}, {.offset_bytes = cb_offset});
+            UnicastEndpoint scratch_src{};
+            noc.async_read(
+                scratch_src,
+                cb,
+                valid_elements_bytes,
+                {.noc_x = static_cast<uint32_t>(my_x[0]),
+                 .noc_y = static_cast<uint32_t>(my_y[0]),
+                 .addr = cb_scratch.get_write_ptr()},
+                {.offset_bytes = cb_offset});
             noc.async_read_barrier();
         }
 

--- a/ttnn/cpp/ttnn/kernel/dataflow/moreh_common.hpp
+++ b/ttnn/cpp/ttnn/kernel/dataflow/moreh_common.hpp
@@ -792,8 +792,8 @@ void read_line(
                 scratch_src,
                 cb,
                 valid_elements_bytes,
-                {.noc_x = static_cast<uint32_t>(my_x[0]),
-                 .noc_y = static_cast<uint32_t>(my_y[0]),
+                {.noc_x = static_cast<uint32_t>(my_x[noc.get_noc_id()]),
+                 .noc_y = static_cast<uint32_t>(my_y[noc.get_noc_id()]),
                  .addr = cb_scratch.get_write_ptr()},
                 {.offset_bytes = cb_offset});
             noc.async_read_barrier();

--- a/ttnn/cpp/ttnn/kernel/dataflow/moreh_common.hpp
+++ b/ttnn/cpp/ttnn/kernel/dataflow/moreh_common.hpp
@@ -53,7 +53,7 @@ public:
 };
 
 template <typename T>
-FORCE_INLINE void process_data(CircularBuffer& cb, uint32_t value, int32_t num_of_elems) {
+FORCE_INLINE void process_data(CircularBuffer cb, uint32_t value, int32_t num_of_elems) {
     T* ptr = reinterpret_cast<T*>(cb.get_write_ptr());
     for (int j = 0; j < num_of_elems; j++) {
         ptr[j] = static_cast<T>(value);
@@ -61,7 +61,7 @@ FORCE_INLINE void process_data(CircularBuffer& cb, uint32_t value, int32_t num_o
 }
 
 template <>
-FORCE_INLINE void process_data<uint16_t>(CircularBuffer& cb, uint32_t value, int32_t num_of_elems) {
+FORCE_INLINE void process_data<uint16_t>(CircularBuffer cb, uint32_t value, int32_t num_of_elems) {
     uint16_t* ptr = reinterpret_cast<uint16_t*>(cb.get_write_ptr());
     for (int j = 0; j < num_of_elems; j++) {
         ptr[j] = static_cast<uint16_t>(value >> 16);
@@ -69,7 +69,7 @@ FORCE_INLINE void process_data<uint16_t>(CircularBuffer& cb, uint32_t value, int
 }
 
 template <typename T = uint16_t>
-FORCE_INLINE void generate_bcast_scaler(CircularBuffer& cb_scaler, uint32_t scaler) {
+FORCE_INLINE void generate_bcast_scaler(CircularBuffer cb_scaler, uint32_t scaler) {
     union {
         float f;
         uint32_t u;
@@ -95,7 +95,7 @@ FORCE_INLINE void generate_bcast_scaler(CircularBuffer& cb_scaler, uint32_t scal
     cb_scaler.push_back(1);
 }
 
-FORCE_INLINE void fill_cb_with_value(CircularBuffer& cb, uint32_t value, int32_t num_of_elems = 1024) {
+FORCE_INLINE void fill_cb_with_value(CircularBuffer cb, uint32_t value, int32_t num_of_elems = 1024) {
     cb.reserve_back(1);
     const DataFormat data_format = get_dataformat(cb.get_cb_id());
     switch ((uint)data_format & 0x1F) {
@@ -180,7 +180,7 @@ FORCE_INLINE void fill_subtile_mask_w(
 }
 
 template <typename T = uint16_t>
-FORCE_INLINE void generate_mask_h(CircularBuffer& cb_mask, uint32_t mask_h) {
+FORCE_INLINE void generate_mask_h(CircularBuffer cb_mask, uint32_t mask_h) {
     Scalar one = {};
     Scalar zero = {};
 
@@ -220,7 +220,7 @@ FORCE_INLINE void generate_mask_h(CircularBuffer& cb_mask, uint32_t mask_h) {
 }
 
 template <typename T = uint16_t>
-FORCE_INLINE void generate_mask_w(CircularBuffer& cb_mask, uint32_t mask_w) {
+FORCE_INLINE void generate_mask_w(CircularBuffer cb_mask, uint32_t mask_w) {
     Scalar one = {};
     Scalar zero = {};
 
@@ -260,7 +260,7 @@ FORCE_INLINE void generate_mask_w(CircularBuffer& cb_mask, uint32_t mask_w) {
 }
 
 FORCE_INLINE void generate_mask_h_w(
-    CircularBuffer& cb_mask_h_w, uint32_t mask_h, uint32_t mask_w, uint32_t single_tile_size = 2048) {
+    CircularBuffer cb_mask_h_w, uint32_t mask_h, uint32_t mask_w, uint32_t single_tile_size = 2048) {
     Scalar one = {};
     Scalar zero = {};
 
@@ -393,7 +393,7 @@ FORCE_INLINE void generate_mask_h_w(
     cb_mask_h_w.push_back(2);
 }
 
-FORCE_INLINE void generate_mask_h_w_if_needed(CircularBuffer& cb_mask_h_w, uint32_t origin_h, uint32_t origin_w) {
+FORCE_INLINE void generate_mask_h_w_if_needed(CircularBuffer cb_mask_h_w, uint32_t origin_h, uint32_t origin_w) {
     constexpr uint32_t TILE_H = 32;
     constexpr uint32_t TILE_W = 32;
 
@@ -471,7 +471,7 @@ FORCE_INLINE void mask_tile_if_need(uint32_t l1_addr, uint32_t origin_h, uint32_
 }
 
 FORCE_INLINE void generate_mask_tiles(
-    CircularBuffer& cb_mask, uint32_t mask_h, uint32_t mask_w, uint32_t single_tile_size = 2048) {
+    CircularBuffer cb_mask, uint32_t mask_h, uint32_t mask_w, uint32_t single_tile_size = 2048) {
     constexpr uint32_t num_mask_tiles = 3;
     Scalar one = {};
     Scalar zero = {};
@@ -664,7 +664,7 @@ void get_noc_offset(uint32_t h, uint32_t w, uint32_t element_size, uint32_t& noc
 // It reads values from one tile.
 template <typename AddrGen>
 void read_tile(
-    CircularBuffer& cb,
+    CircularBuffer cb,
     AddrGen addrgen,
     uint32_t noc_id,
     uint32_t size = 0,
@@ -693,7 +693,7 @@ void read_tile(
 
 template <typename AddrGen>
 void read_value(
-    CircularBuffer& cb,
+    CircularBuffer cb,
     AddrGen addrgen,
     uint32_t noc_id,
     uint32_t tilized_idx = 0,
@@ -727,8 +727,8 @@ void read_value(
  *
  * | Argument                     | Description                             | Data type        | Valid range                    | required |
  * |------------------------------|-----------------------------------------|------------------|--------------------------------|----------|
- * | cb                           | Destination CB for the read data        | CircularBuffer&  | Any valid CB                   | True     |
- * | cb_scratch                   | CB to use as scratch storage            | CircularBuffer&  | Any valid CB                   | True     |
+ * | cb                           | Destination CB for the read data        | CircularBuffer   | Any valid CB                   | True     |
+ * | cb_scratch                   | CB to use as scratch storage            | CircularBuffer   | Any valid CB                   | True     |
  * | addrgen                      | Address generator object                | AddrGen          | N/A                            | True     |
  * | num_tiles                    | Number of tiles to read                 | uint32_t         | Any uint32_t number            | True     |
  * | do_reserve                   | Whether to reserve space in the CB      | bool             | true or false                  | False    |
@@ -737,8 +737,8 @@ void read_value(
 // clang-format on
 template <typename AddrGen>
 void read_line(
-    CircularBuffer& cb,
-    CircularBuffer& cb_scratch,
+    CircularBuffer cb,
+    CircularBuffer cb_scratch,
     AddrGen addrgen,
     uint32_t num_tiles,
     bool do_reserve = true,

--- a/ttnn/cpp/ttnn/kernel/dataflow/moreh_common.hpp
+++ b/ttnn/cpp/ttnn/kernel/dataflow/moreh_common.hpp
@@ -11,6 +11,9 @@
 
 #include "tt-metalium/constants.hpp"
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
 #include "noc/noc_parameters.h"
 #include "api/numeric/bfloat16.h"
 
@@ -49,33 +52,31 @@ public:
     }
 };
 
-template <typename AddrGen>
-FORCE_INLINE void noc_async_read_tile_helper(tt::CBIndex cb, uint32_t num_tiles, uint32_t tile_idx, AddrGen addr_gen) {
-    cb_reserve_back(cb, num_tiles);
-    uint32_t addr = get_write_ptr(cb);
-    noc_async_read_page(tile_idx, addr_gen, addr);
-    noc_async_read_barrier();
-    cb_push_back(cb, num_tiles);
+template <typename T>
+FORCE_INLINE void process_data(CircularBuffer& cb, uint32_t value, int32_t num_of_elems) {
+    T* ptr = reinterpret_cast<T*>(cb.get_write_ptr());
+    for (int j = 0; j < num_of_elems; j++) {
+        ptr[j] = static_cast<T>(value);
+    }
 }
 
-template <typename AddrGen>
-FORCE_INLINE void noc_async_write_tile_helper(tt::CBIndex cb, uint32_t num_tiles, uint32_t tile_idx, AddrGen addr_gen) {
-    cb_wait_front(cb, num_tiles);
-    uint32_t l1_read_addr = get_read_ptr(cb);
-    noc_async_write_page(tile_idx, addr_gen, l1_read_addr);
-    noc_async_write_barrier();
-    cb_pop_front(cb, num_tiles);
+template <>
+FORCE_INLINE void process_data<uint16_t>(CircularBuffer& cb, uint32_t value, int32_t num_of_elems) {
+    uint16_t* ptr = reinterpret_cast<uint16_t*>(cb.get_write_ptr());
+    for (int j = 0; j < num_of_elems; j++) {
+        ptr[j] = static_cast<uint16_t>(value >> 16);
+    }
 }
 
 template <typename T = uint16_t>
-FORCE_INLINE void generate_bcast_scaler(uint32_t cb_scaler, uint32_t scaler) {
+FORCE_INLINE void generate_bcast_scaler(CircularBuffer& cb_scaler, uint32_t scaler) {
     union {
         float f;
         uint32_t u;
     } u = {};
     u.u = scaler;
-    cb_reserve_back(cb_scaler, 1);
-    auto ptr = reinterpret_cast<T*>(get_write_ptr(cb_scaler));
+    cb_scaler.reserve_back(1);
+    auto ptr = reinterpret_cast<T*>(cb_scaler.get_write_ptr());
 
     for (int j = 0; j < 1024; j++) {
         ptr[j] = T(0);
@@ -91,36 +92,20 @@ FORCE_INLINE void generate_bcast_scaler(uint32_t cb_scaler, uint32_t scaler) {
         }
     }
 
-    cb_push_back(cb_scaler, 1);
+    cb_scaler.push_back(1);
 }
 
-template <typename T>
-FORCE_INLINE void process_data(int cb_id, uint32_t value, int32_t num_of_elems) {
-    T* ptr = reinterpret_cast<T*>(get_write_ptr(cb_id));
-    for (int j = 0; j < num_of_elems; j++) {
-        ptr[j] = static_cast<T>(value);
-    }
-}
-
-template <>
-FORCE_INLINE void process_data<uint16_t>(int cb_id, uint32_t value, int32_t num_of_elems) {
-    uint16_t* ptr = reinterpret_cast<uint16_t*>(get_write_ptr(cb_id));
-    for (int j = 0; j < num_of_elems; j++) {
-        ptr[j] = static_cast<uint16_t>(value >> 16);
-    }
-}
-
-FORCE_INLINE void fill_cb_with_value(uint32_t cb_id, uint32_t value, int32_t num_of_elems = 1024) {
-    cb_reserve_back(cb_id, 1);
-    const DataFormat data_format = get_dataformat(cb_id);
+FORCE_INLINE void fill_cb_with_value(CircularBuffer& cb, uint32_t value, int32_t num_of_elems = 1024) {
+    cb.reserve_back(1);
+    const DataFormat data_format = get_dataformat(cb.get_cb_id());
     switch ((uint)data_format & 0x1F) {
         case ((uint8_t)DataFormat::Float32):
         case ((uint8_t)DataFormat::Int32):
-        case ((uint8_t)DataFormat::UInt32): process_data<uint32_t>(cb_id, value, num_of_elems); break;
+        case ((uint8_t)DataFormat::UInt32): process_data<uint32_t>(cb, value, num_of_elems); break;
         case ((uint8_t)DataFormat::Float16_b):
-        default: process_data<uint16_t>(cb_id, value, num_of_elems); break;
+        default: process_data<uint16_t>(cb, value, num_of_elems); break;
     }
-    cb_push_back(cb_id, 1);
+    cb.push_back(1);
 }
 
 FORCE_INLINE uint32_t get_tilized_idx(uint32_t h_idx, uint32_t w_idx, uint32_t tile_height, uint32_t tile_width) {
@@ -195,7 +180,7 @@ FORCE_INLINE void fill_subtile_mask_w(
 }
 
 template <typename T = uint16_t>
-FORCE_INLINE void generate_mask_h(uint32_t cb_mask, uint32_t mask_h) {
+FORCE_INLINE void generate_mask_h(CircularBuffer& cb_mask, uint32_t mask_h) {
     Scalar one = {};
     Scalar zero = {};
 
@@ -207,8 +192,8 @@ FORCE_INLINE void generate_mask_h(uint32_t cb_mask, uint32_t mask_h) {
         zero.f = 0.0f;
     }
 
-    cb_reserve_back(cb_mask, 1);
-    auto ptr = reinterpret_cast<T*>(get_write_ptr(cb_mask));
+    cb_mask.reserve_back(1);
+    auto ptr = reinterpret_cast<T*>(cb_mask.get_write_ptr());
 
     // Calculate mask heights for top and bottom subtiles
     const uint32_t mask_h_top = (mask_h >= 16) ? 16 : mask_h;        // subtiles 0, 1
@@ -231,11 +216,11 @@ FORCE_INLINE void generate_mask_h(uint32_t cb_mask, uint32_t mask_h) {
         fill_subtile_mask_h<T>(ptr, w, subtile_offsets[3], mask_h_bottom, one, zero);
     }
 
-    cb_push_back(cb_mask, 1);
+    cb_mask.push_back(1);
 }
 
 template <typename T = uint16_t>
-FORCE_INLINE void generate_mask_w(uint32_t cb_mask, uint32_t mask_w) {
+FORCE_INLINE void generate_mask_w(CircularBuffer& cb_mask, uint32_t mask_w) {
     Scalar one = {};
     Scalar zero = {};
 
@@ -247,8 +232,8 @@ FORCE_INLINE void generate_mask_w(uint32_t cb_mask, uint32_t mask_w) {
         zero.f = 0.0f;
     }
 
-    cb_reserve_back(cb_mask, 1);
-    auto ptr = reinterpret_cast<T*>(get_write_ptr(cb_mask));
+    cb_mask.reserve_back(1);
+    auto ptr = reinterpret_cast<T*>(cb_mask.get_write_ptr());
 
     // Calculate mask widths for left and right subtiles
     const uint32_t mask_w_left = (mask_w >= 16) ? 16 : mask_w;      // subtiles 0, 2
@@ -271,11 +256,11 @@ FORCE_INLINE void generate_mask_w(uint32_t cb_mask, uint32_t mask_w) {
         fill_subtile_mask_w<T>(ptr, h, subtile_offsets[3], mask_w_right, one, zero);
     }
 
-    cb_push_back(cb_mask, 1);
+    cb_mask.push_back(1);
 }
 
 FORCE_INLINE void generate_mask_h_w(
-    uint32_t cb_mask_h_w, uint32_t mask_h, uint32_t mask_w, uint32_t single_tile_size = 2048) {
+    CircularBuffer& cb_mask_h_w, uint32_t mask_h, uint32_t mask_w, uint32_t single_tile_size = 2048) {
     Scalar one = {};
     Scalar zero = {};
 
@@ -285,11 +270,11 @@ FORCE_INLINE void generate_mask_h_w(
     const auto u16_one = uint16_t(one.u >> 16);
     const auto u16_zero = uint16_t(zero.u >> 16);
 
-    cb_reserve_back(cb_mask_h_w, 2);
+    cb_mask_h_w.reserve_back(2);
 
     // mask_h
     // first tile ptr
-    auto mask_h_ptr = reinterpret_cast<uint16_t*>(get_write_ptr(cb_mask_h_w));
+    auto mask_h_ptr = reinterpret_cast<uint16_t*>(cb_mask_h_w.get_write_ptr());
     for (uint32_t w = 0; w < 16; w++) {
         // sub tile 0
         {
@@ -348,7 +333,7 @@ FORCE_INLINE void generate_mask_h_w(
 
     // mask_w
     // second tile ptr
-    auto mask_w_ptr = reinterpret_cast<uint16_t*>(get_write_ptr(cb_mask_h_w) + single_tile_size);
+    auto mask_w_ptr = reinterpret_cast<uint16_t*>(cb_mask_h_w.get_write_ptr() + single_tile_size);
     for (uint32_t h = 0; h < 16; h++) {
         // sub tile 0
         {
@@ -405,10 +390,10 @@ FORCE_INLINE void generate_mask_h_w(
         }
     }
 
-    cb_push_back(cb_mask_h_w, 2);
+    cb_mask_h_w.push_back(2);
 }
 
-FORCE_INLINE void generate_mask_h_w_if_needed(uint32_t cb_mask_h_w, uint32_t origin_h, uint32_t origin_w) {
+FORCE_INLINE void generate_mask_h_w_if_needed(CircularBuffer& cb_mask_h_w, uint32_t origin_h, uint32_t origin_w) {
     constexpr uint32_t TILE_H = 32;
     constexpr uint32_t TILE_W = 32;
 
@@ -419,7 +404,7 @@ FORCE_INLINE void generate_mask_h_w_if_needed(uint32_t cb_mask_h_w, uint32_t ori
     const uint32_t mask_w = do_mask_w ? (origin_w % TILE_W) : TILE_W;
 
     if (do_mask_h || do_mask_w) {
-        const uint32_t mask_tile_bytes = get_tile_size(cb_mask_h_w);
+        const uint32_t mask_tile_bytes = get_tile_size(cb_mask_h_w.get_cb_id());
         generate_mask_h_w(cb_mask_h_w, mask_h, mask_w, mask_tile_bytes);
     }
 }
@@ -486,7 +471,7 @@ FORCE_INLINE void mask_tile_if_need(uint32_t l1_addr, uint32_t origin_h, uint32_
 }
 
 FORCE_INLINE void generate_mask_tiles(
-    uint32_t cb_mask, uint32_t mask_h, uint32_t mask_w, uint32_t single_tile_size = 2048) {
+    CircularBuffer& cb_mask, uint32_t mask_h, uint32_t mask_w, uint32_t single_tile_size = 2048) {
     constexpr uint32_t num_mask_tiles = 3;
     Scalar one = {};
     Scalar zero = {};
@@ -497,11 +482,11 @@ FORCE_INLINE void generate_mask_tiles(
     const auto u16_one = uint16_t(one.u >> 16);
     const auto u16_zero = uint16_t(zero.u >> 16);
 
-    cb_reserve_back(cb_mask, num_mask_tiles);
+    cb_mask.reserve_back(num_mask_tiles);
 
     // mask_h
     // first tile ptr
-    auto mask_h_ptr = reinterpret_cast<uint16_t*>(get_write_ptr(cb_mask));
+    auto mask_h_ptr = reinterpret_cast<uint16_t*>(cb_mask.get_write_ptr());
     for (uint32_t w = 0; w < 16; w++) {
         // sub tile 0
         {
@@ -560,7 +545,7 @@ FORCE_INLINE void generate_mask_tiles(
 
     // mask_w
     // second tile ptr
-    auto mask_w_ptr = reinterpret_cast<uint16_t*>(get_write_ptr(cb_mask) + single_tile_size);
+    auto mask_w_ptr = reinterpret_cast<uint16_t*>(cb_mask.get_write_ptr() + single_tile_size);
     for (uint32_t h = 0; h < 16; h++) {
         // sub tile 0
         {
@@ -619,7 +604,7 @@ FORCE_INLINE void generate_mask_tiles(
 
     // mask_hw
     // third tile ptr
-    auto mask_hw_ptr = reinterpret_cast<uint16_t*>(get_write_ptr(cb_mask) + (single_tile_size * 2));
+    auto mask_hw_ptr = reinterpret_cast<uint16_t*>(cb_mask.get_write_ptr() + (single_tile_size * 2));
     for (uint32_t i = 0; i < 1024; ++i) {
         if (mask_h_ptr[i] == mask_w_ptr[i]) {
             mask_hw_ptr[i] = mask_h_ptr[i];
@@ -627,7 +612,7 @@ FORCE_INLINE void generate_mask_tiles(
             mask_hw_ptr[i] = u16_zero;
         }
     }
-    cb_push_back(cb_mask, num_mask_tiles);
+    cb_mask.push_back(num_mask_tiles);
 }
 
 uint32_t get_tilized_idx(uint32_t h, uint32_t w) {
@@ -676,75 +661,60 @@ void get_noc_offset(uint32_t h, uint32_t w, uint32_t element_size, uint32_t& noc
     noc_offset = noc_offset_align;
 }
 
-template <typename T>
-volatile tt_l1_ptr T* get_read_ptr(uint32_t cb_id) {
-    auto l1_write_addr = get_read_ptr(cb_id);
-    auto l1_ptr = reinterpret_cast<volatile tt_l1_ptr T*>(l1_write_addr);
-    return l1_ptr;
-}
-
-template <typename T>
-volatile tt_l1_ptr T* get_write_ptr(uint32_t cb_id) {
-    auto l1_write_addr = get_write_ptr(cb_id);
-    auto l1_ptr = reinterpret_cast<volatile tt_l1_ptr T*>(l1_write_addr);
-    return l1_ptr;
-}
-
 // It reads values from one tile.
-template <typename T>
+template <typename AddrGen>
 void read_tile(
-    uint32_t cb_id,
-    T addrgen,
+    CircularBuffer& cb,
+    AddrGen addrgen,
     uint32_t noc_id,
     uint32_t size = 0,
     uint32_t offset = 0,
     bool do_reserve = true,
     bool do_push_back = true) {
     constexpr uint32_t onetile = 1;
+    Noc noc;
 
     if (do_reserve) {
-        cb_reserve_back(cb_id, onetile);
+        cb.reserve_back(onetile);
     }
 
     // If the size is 0, it reads one tile.
     if (size == 0) {
-        size = get_tile_size(cb_id);
+        size = get_tile_size(cb.get_cb_id());
     }
 
-    auto l1_write_addr = get_write_ptr(cb_id);
-    auto noc_addr = addrgen.get_noc_addr(noc_id, offset);
-    noc_async_read(noc_addr, l1_write_addr, size);
-
-    noc_async_read_barrier();
+    noc.async_read(addrgen, cb, size, {.page_id = noc_id, .offset_bytes = offset}, {.offset_bytes = 0});
+    noc.async_read_barrier();
 
     if (do_push_back) {
-        cb_push_back(cb_id, onetile);
+        cb.push_back(onetile);
     }
 }
 
-template <typename T>
+template <typename AddrGen>
 void read_value(
-    uint32_t cb_id,
-    T addrgen,
+    CircularBuffer& cb,
+    AddrGen addrgen,
     uint32_t noc_id,
     uint32_t tilized_idx = 0,
     bool do_reserve = true,
     bool do_push_back = true) {
     constexpr uint32_t onetile = 1;
+    Noc noc;
 
     if (do_reserve) {
-        cb_reserve_back(cb_id, onetile);
+        cb.reserve_back(onetile);
     }
 
-    uint32_t size = get_tile_size(cb_id) / 1024;
+    const uint32_t element_size = get_tile_size(cb.get_cb_id()) / 1024;
+    const uint32_t byte_offset = tilized_idx * element_size;
 
-    auto l1_write_addr = get_write_ptr(cb_id);
-    auto noc_addr = addrgen.get_noc_addr(noc_id);
-    noc_async_read(noc_addr + tilized_idx * size, l1_write_addr + tilized_idx * size, size);
-    noc_async_read_barrier();
+    noc.async_read(
+        addrgen, cb, element_size, {.page_id = noc_id, .offset_bytes = byte_offset}, {.offset_bytes = byte_offset});
+    noc.async_read_barrier();
 
     if (do_push_back) {
-        cb_push_back(cb_id, onetile);
+        cb.push_back(onetile);
     }
 }
 
@@ -755,66 +725,81 @@ void read_value(
  *
  * Return value: None
  *
- * | Argument                     | Description                             | Data type | Valid range                    | required |
- * |------------------------------|-----------------------------------------|-----------|--------------------------------|----------|
- * | cb_id                        | Destination CB for the read data        | uint32_t  | Any valid CB ID                | True     |
- * | cb_scratch_id                | CB to use as scratch storage            | uint32_t  | Any valid CB ID                | True     |
- * | addrgen                      | Address generator object                | AddrGen   | N/A                            | True     |
- * | num_tiles                    | Number of tiles to read                 | uint32_t  | Any uint32_t number            | True     |
- * | do_reserve                   | Whether to reserve space in the CB      | bool      | true or false                  | False    |
- * | do_push_back                 | Whether to push the data back to the CB | bool      | true or false                  | False    |
+ * | Argument                     | Description                             | Data type        | Valid range                    | required |
+ * |------------------------------|-----------------------------------------|------------------|--------------------------------|----------|
+ * | cb                           | Destination CB for the read data        | CircularBuffer&  | Any valid CB                   | True     |
+ * | cb_scratch                   | CB to use as scratch storage            | CircularBuffer&  | Any valid CB                   | True     |
+ * | addrgen                      | Address generator object                | AddrGen          | N/A                            | True     |
+ * | num_tiles                    | Number of tiles to read                 | uint32_t         | Any uint32_t number            | True     |
+ * | do_reserve                   | Whether to reserve space in the CB      | bool             | true or false                  | False    |
+ * | do_push_back                 | Whether to push the data back to the CB | bool             | true or false                  | False    |
  */
 // clang-format on
-template <typename T>
+template <typename AddrGen>
 void read_line(
-    uint32_t cb_id,
-    uint32_t cb_scratch_id,
-    T addrgen,
+    CircularBuffer& cb,
+    CircularBuffer& cb_scratch,
+    AddrGen addrgen,
     uint32_t num_tiles,
     bool do_reserve = true,
     bool do_push_back = true) {
     using namespace tt::constants;
+    Noc noc;
+
     if (do_reserve) {
-        cb_reserve_back(cb_id, num_tiles);
+        cb.reserve_back(num_tiles);
     }
 
-    auto tile_bytes = get_tile_size(cb_id);
-    auto element_bytes = tile_bytes / (TILE_HEIGHT * TILE_WIDTH);
-    auto valid_elements_bytes = FACE_WIDTH * element_bytes;
+    const auto tile_bytes = get_tile_size(cb.get_cb_id());
+    const auto element_bytes = tile_bytes / (TILE_HEIGHT * TILE_WIDTH);
+    const auto valid_elements_bytes = FACE_WIDTH * element_bytes;
 
     // We want to read all valid elements, but may need to read more from DRAM,
     // because DRAM has larger read size than L1 on some architectures.
-    auto noc_read_size_bytes = std::max(valid_elements_bytes, static_cast<uint32_t>(NOC_DRAM_READ_ALIGNMENT_BYTES));
+    const auto noc_read_size_bytes =
+        std::max(valid_elements_bytes, static_cast<uint32_t>(NOC_DRAM_READ_ALIGNMENT_BYTES));
 
-    uint32_t l1_write_addr = get_write_ptr(cb_id);
+    uint32_t cb_offset = 0;
     for (uint32_t i = 0; i < num_tiles * 2; ++i) {
-        uint32_t noc_id = i / 2;
+        const uint32_t noc_id = i / 2;
         uint32_t noc_offset = 0;
         if (noc_id * 2 != i) {
             noc_offset += (FACE_HEIGHT * FACE_WIDTH) * element_bytes;
         }
-        auto src_noc_addr = addrgen.get_noc_addr(noc_id, noc_offset);
 
         if (noc_read_size_bytes == valid_elements_bytes) {
             // DRAM and L1 read sizes are aligned, so we can read directly into the destination CB.
-            noc_async_read(src_noc_addr, l1_write_addr, noc_read_size_bytes);
-            noc_async_read_barrier();
+            noc.async_read(
+                addrgen,
+                cb,
+                noc_read_size_bytes,
+                {.page_id = noc_id, .offset_bytes = noc_offset},
+                {.offset_bytes = cb_offset});
+            noc.async_read_barrier();
         } else {
             // DRAM has larger read size than L1, so there will be some padding in data read from DRAM.
             // Need to use scratch CB to read from DRAM, then copy valid parts to the destination CB.
-            auto scratch_l1_write_addr = get_write_ptr(cb_scratch_id);
-            noc_async_read(src_noc_addr, scratch_l1_write_addr, noc_read_size_bytes);
-            noc_async_read_barrier();
-            auto scratch_l1_noc_read_addr = get_noc_addr(scratch_l1_write_addr);
-            // Now copy only the valid elements to the destination CB.
-            noc_async_read(scratch_l1_noc_read_addr, l1_write_addr, valid_elements_bytes);
-            noc_async_read_barrier();
+            noc.async_read(
+                addrgen,
+                cb_scratch,
+                noc_read_size_bytes,
+                {.page_id = noc_id, .offset_bytes = noc_offset},
+                {.offset_bytes = 0});
+            noc.async_read_barrier();
+            // Now copy only the valid elements to the destination CB via a local L1 unicast read.
+            UnicastEndpoint scratch_src{
+                .noc_x = static_cast<uint32_t>(my_x[0]),
+                .noc_y = static_cast<uint32_t>(my_y[0]),
+                .addr = cb_scratch.get_write_ptr(),
+            };
+            noc.async_read(scratch_src, cb, valid_elements_bytes, {.offset_bytes = 0}, {.offset_bytes = cb_offset});
+            noc.async_read_barrier();
         }
 
-        l1_write_addr += valid_elements_bytes;
+        cb_offset += valid_elements_bytes;
     }
 
     if (do_push_back) {
-        cb_push_back(cb_id, num_tiles);
+        cb.push_back(num_tiles);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/kernels/reader_moreh_abs_pow.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/kernels/reader_moreh_abs_pow.cpp
@@ -28,15 +28,18 @@ void kernel_main() {
 
     Scalar one;
     one.f = 1.0f;
-    fill_cb_with_value(cb_id_one, one.u);
-    fill_cb_with_value(cb_id_decimal, decimal);
+    CircularBuffer cb_one(cb_id_one);
+    CircularBuffer cb_decimal(cb_id_decimal);
+    fill_cb_with_value(cb_one, one.u);
+    fill_cb_with_value(cb_decimal, decimal);
 
     constexpr uint32_t TILE_W = 32;
     const bool do_mask_w = (origin_w % TILE_W) != 0;
     const auto mask_w = do_mask_w ? (origin_w % TILE_W) : TILE_W;
 
     if (do_mask_w) {
-        generate_mask_w(cb_id_mask_w, mask_w);
+        CircularBuffer cb_mask_w(cb_id_mask_w);
+        generate_mask_w(cb_mask_w, mask_w);
     }
 
     Noc noc;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/kernels/reader_moreh_adamw.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/kernels/reader_moreh_adamw.cpp
@@ -59,19 +59,23 @@ void kernel_main() {
     const auto max_exp_avg_sq_addrg = TensorAccessor(max_exp_avg_sq_args, max_exp_avg_sq_addr);
 #endif
 
-    fill_cb_with_value(cb_scalar_args, lr);
-    fill_cb_with_value(cb_scalar_args, beta1);
-    fill_cb_with_value(cb_scalar_args, beta2);
-    fill_cb_with_value(cb_scalar_args, eps);
-    fill_cb_with_value(cb_scalar_args, weight_decay);
-    fill_cb_with_value(cb_beta1_exponent, beta1_exponent);
-    fill_cb_with_value(cb_beta2_exponent, beta2_exponent);
+    CircularBuffer cb_scalar(cb_scalar_args);
+    CircularBuffer cb_beta1_exp(cb_beta1_exponent);
+    CircularBuffer cb_beta2_exp(cb_beta2_exponent);
+    CircularBuffer cb_one(cb_id_one);
+    fill_cb_with_value(cb_scalar, lr);
+    fill_cb_with_value(cb_scalar, beta1);
+    fill_cb_with_value(cb_scalar, beta2);
+    fill_cb_with_value(cb_scalar, eps);
+    fill_cb_with_value(cb_scalar, weight_decay);
+    fill_cb_with_value(cb_beta1_exp, beta1_exponent);
+    fill_cb_with_value(cb_beta2_exp, beta2_exponent);
     union {
         float f;
         uint32_t u;
     } scaler;
     scaler.f = 1.0f;
-    fill_cb_with_value(cb_id_one, scaler.u);
+    fill_cb_with_value(cb_one, scaler.u);
 
     Noc noc;
     CircularBuffer cb_param(cb_id_param);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/kernels/reader_moreh_clip_grad_norm_step1.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/kernels/reader_moreh_clip_grad_norm_step1.cpp
@@ -29,9 +29,12 @@ void kernel_main() {
         uint32_t u;
     } scaler;
     scaler.f = 1.0f;
-    fill_cb_with_value(cb_id_decimal, decimal);
-    fill_cb_with_value(cb_id_one, scaler.u);
-    generate_mask_h_w_if_needed(cb_id_mask_h_w, origin_h, origin_w);
+    CircularBuffer cb_decimal(cb_id_decimal);
+    CircularBuffer cb_one(cb_id_one);
+    CircularBuffer cb_mask_h_w(cb_id_mask_h_w);
+    fill_cb_with_value(cb_decimal, decimal);
+    fill_cb_with_value(cb_one, scaler.u);
+    generate_mask_h_w_if_needed(cb_mask_h_w, origin_h, origin_w);
 
     constexpr uint32_t onetile = 1;
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/kernels/reader_moreh_clip_grad_norm_step2.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/kernels/reader_moreh_clip_grad_norm_step2.cpp
@@ -20,7 +20,8 @@ void kernel_main() {
     constexpr auto input_args = TensorAccessorArgs<0>();
     const auto s = TensorAccessor(input_args, input_addr);
 
-    fill_cb_with_value(cb_id_decimal, decimal);
+    CircularBuffer cb_decimal(cb_id_decimal);
+    fill_cb_with_value(cb_decimal, decimal);
 
     constexpr uint32_t onetile = 1;
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/dataflow/reader_moreh_group_norm_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/dataflow/reader_moreh_group_norm_large.cpp
@@ -53,8 +53,10 @@ void kernel_main() {
     const auto cb_id_mask_h = cb_id++;
     const auto cb_id_mask_w = cb_id++;
 
-    fill_cb_with_value(cb_id_scaler, scaler);
-    fill_cb_with_value(cb_id_eps, eps);
+    CircularBuffer cb_scaler(cb_id_scaler);
+    CircularBuffer cb_eps(cb_id_eps);
+    fill_cb_with_value(cb_scaler, scaler);
+    fill_cb_with_value(cb_eps, eps);
 
     const bool do_mask_h = (origin_h % TILE_H) != 0;
     const auto mask_h = do_mask_h ? origin_h % TILE_H : TILE_H;
@@ -63,10 +65,12 @@ void kernel_main() {
     const auto mask_w = do_mask_w ? origin_w % TILE_W : TILE_W;
 
     if (do_mask_h) {
-        generate_mask_h(cb_id_mask_h, mask_h);
+        CircularBuffer cb_mask_h(cb_id_mask_h);
+        generate_mask_h(cb_mask_h, mask_h);
     }
     if (do_mask_w) {
-        generate_mask_w(cb_id_mask_w, mask_w);
+        CircularBuffer cb_mask_w(cb_id_mask_w);
+        generate_mask_w(cb_mask_w, mask_w);
     }
 
     // input

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/dataflow/reader_moreh_group_norm_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/dataflow/reader_moreh_group_norm_small.cpp
@@ -53,8 +53,10 @@ void kernel_main() {
     const auto cb_id_mask_h = cb_id++;
     const auto cb_id_mask_w = cb_id++;
 
-    fill_cb_with_value(cb_id_scaler, scaler);
-    fill_cb_with_value(cb_id_eps, eps);
+    CircularBuffer cb_scaler(cb_id_scaler);
+    CircularBuffer cb_eps(cb_id_eps);
+    fill_cb_with_value(cb_scaler, scaler);
+    fill_cb_with_value(cb_eps, eps);
 
     const bool do_mask_h = (origin_h % TILE_H) != 0;
     const auto mask_h = do_mask_h ? origin_h % TILE_H : TILE_H;
@@ -63,10 +65,12 @@ void kernel_main() {
     const auto mask_w = do_mask_w ? origin_w % TILE_W : TILE_W;
 
     if (do_mask_h) {
-        generate_mask_h(cb_id_mask_h, mask_h);
+        CircularBuffer cb_mask_h(cb_id_mask_h);
+        generate_mask_h(cb_mask_h, mask_h);
     }
     if (do_mask_w) {
-        generate_mask_w(cb_id_mask_w, mask_w);
+        CircularBuffer cb_mask_w(cb_id_mask_w);
+        generate_mask_w(cb_mask_w, mask_w);
     }
 
     // input

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/kernels/dataflow/reader_moreh_group_norm_backward_gamma_beta_grad.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/kernels/dataflow/reader_moreh_group_norm_backward_gamma_beta_grad.cpp
@@ -65,14 +65,17 @@ void kernel_main() {
         uint32_t u;
     } one;
     one.f = 1.0f;
-    fill_cb_with_value(cb_id_one, one.u);
+    CircularBuffer cb_one(cb_id_one);
+    fill_cb_with_value(cb_one, one.u);
 
     if (do_mask_h) {
-        generate_mask_h(cb_id_mask_h, mask_h);
+        CircularBuffer cb_mask_h(cb_id_mask_h);
+        generate_mask_h(cb_mask_h, mask_h);
     }
 
     if (do_mask_w) {
-        generate_mask_w(cb_id_mask_w, mask_w);
+        CircularBuffer cb_mask_w(cb_id_mask_w);
+        generate_mask_w(cb_mask_w, mask_w);
     }
 
     // output_grad

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/kernels/dataflow/reader_moreh_group_norm_backward_input_grad_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/kernels/dataflow/reader_moreh_group_norm_backward_input_grad_large.cpp
@@ -63,16 +63,19 @@ void kernel_main() {
         uint32_t u;
     } scalar;
     scalar.f = 1.0f;
-    fill_cb_with_value(cb_id_one, scalar.u);
+    CircularBuffer cb_one(cb_id_one);
+    CircularBuffer cb_n_recip_n(cb_id_n_recip_n);
+    fill_cb_with_value(cb_one, scalar.u);
 
     const auto n = static_cast<float>((num_channels / num_groups) * origin_h * origin_w);
     scalar.f = n;
-    fill_cb_with_value(cb_id_n_recip_n, scalar.u);
+    fill_cb_with_value(cb_n_recip_n, scalar.u);
     scalar.f = 1.0f / n;
-    fill_cb_with_value(cb_id_n_recip_n, scalar.u);
+    fill_cb_with_value(cb_n_recip_n, scalar.u);
 
     if (do_mask_h || do_mask_w) {
-        generate_mask_h_w(cb_id_mask_h_w, mask_h, mask_w, get_tile_size(cb_id_mask_h_w));
+        CircularBuffer cb_mask_h_w(cb_id_mask_h_w);
+        generate_mask_h_w(cb_mask_h_w, mask_h, mask_w, get_tile_size(cb_id_mask_h_w));
     }
 
     // output_grad

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/kernels/dataflow/reader_moreh_group_norm_backward_input_grad_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/kernels/dataflow/reader_moreh_group_norm_backward_input_grad_small.cpp
@@ -63,16 +63,19 @@ void kernel_main() {
         uint32_t u;
     } scalar;
     scalar.f = 1.0f;
-    fill_cb_with_value(cb_id_one, scalar.u);
+    CircularBuffer cb_one(cb_id_one);
+    CircularBuffer cb_n_recip_n(cb_id_n_recip_n);
+    fill_cb_with_value(cb_one, scalar.u);
 
     const auto n = static_cast<float>((num_channels / num_groups) * origin_h * origin_w);
     scalar.f = n;
-    fill_cb_with_value(cb_id_n_recip_n, scalar.u);
+    fill_cb_with_value(cb_n_recip_n, scalar.u);
     scalar.f = 1.0f / n;
-    fill_cb_with_value(cb_id_n_recip_n, scalar.u);
+    fill_cb_with_value(cb_n_recip_n, scalar.u);
 
     if (do_mask_h || do_mask_w) {
-        generate_mask_h_w(cb_id_mask_h_w, mask_h, mask_w, get_tile_size(cb_id_mask_h_w));
+        CircularBuffer cb_mask_h_w(cb_id_mask_h_w);
+        generate_mask_h_w(cb_mask_h_w, mask_h, mask_w, get_tile_size(cb_id_mask_h_w));
     }
 
     // output_grad

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/reader_moreh_layer_norm_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/reader_moreh_layer_norm_large.cpp
@@ -48,15 +48,23 @@ void kernel_main() {
     const auto beta_addrg = TensorAccessor(beta_args, beta_addr);
 #endif
 
-    fill_cb_with_value(cb_id_scaler, scaler);
-    fill_cb_with_value(cb_id_eps, eps);
+    CircularBuffer cb_scaler(cb_id_scaler);
+    CircularBuffer cb_eps(cb_id_eps);
+    fill_cb_with_value(cb_scaler, scaler);
+    fill_cb_with_value(cb_eps, eps);
 
 #ifdef DO_MASK_H
-    generate_mask_h(cb_id_mask_h, mask_h);
+    {
+        CircularBuffer cb_mask_h(cb_id_mask_h);
+        generate_mask_h(cb_mask_h, mask_h);
+    }
 #endif
 
 #ifdef DO_MASK_W
-    generate_mask_w(cb_id_mask_w, mask_w);
+    {
+        CircularBuffer cb_mask_w(cb_id_mask_w);
+        generate_mask_w(cb_mask_w, mask_w);
+    }
 #endif
 
     uint32_t offs = 0;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/reader_moreh_layer_norm_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/reader_moreh_layer_norm_small.cpp
@@ -48,15 +48,23 @@ void kernel_main() {
     const auto beta_addrg = TensorAccessor(beta_args, beta_addr);
 #endif
 
-    fill_cb_with_value(cb_id_scaler, scaler);
-    fill_cb_with_value(cb_id_eps, eps);
+    CircularBuffer cb_scaler(cb_id_scaler);
+    CircularBuffer cb_eps(cb_id_eps);
+    fill_cb_with_value(cb_scaler, scaler);
+    fill_cb_with_value(cb_eps, eps);
 
 #ifdef DO_MASK_H
-    generate_mask_h(cb_id_mask_h, mask_h);
+    {
+        CircularBuffer cb_mask_h(cb_id_mask_h);
+        generate_mask_h(cb_mask_h, mask_h);
+    }
 #endif
 
 #ifdef DO_MASK_W
-    generate_mask_w(cb_id_mask_w, mask_w);
+    {
+        CircularBuffer cb_mask_w(cb_id_mask_w);
+        generate_mask_w(cb_mask_w, mask_w);
+    }
 #endif
 
     constexpr uint32_t onetile = 1;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/reader_moreh_layer_norm_backward_gamma_beta_grad.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/reader_moreh_layer_norm_backward_gamma_beta_grad.cpp
@@ -139,10 +139,12 @@ void kernel_main() {
         uint32_t u;
     } scaler;
     scaler.f = 1.0f;
-    fill_cb_with_value(cb_id_scaler, scaler.u);
+    CircularBuffer cb_scaler(cb_id_scaler);
+    fill_cb_with_value(cb_scaler, scaler.u);
 
     if (do_mask_h) {
-        generate_mask_h(cb_id_mask_h, mask_h);
+        CircularBuffer cb_mask_h(cb_id_mask_h);
+        generate_mask_h(cb_mask_h, mask_h);
     }
 
     auto mean_rstd_Ht = (mean_rstd_height + TILE_HEIGHT - 1) / TILE_HEIGHT;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/reader_moreh_layer_norm_backward_input_grad_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/reader_moreh_layer_norm_backward_input_grad_large.cpp
@@ -144,12 +144,15 @@ void kernel_main() {
         uint32_t u;
     } scaler;
     scaler.f = 1.0f;
-    fill_cb_with_value(cb_id_scaler, scaler.u);
-    fill_cb_with_value(cb_id_n_recip_n, n);
-    fill_cb_with_value(cb_id_n_recip_n, recip_n);
+    CircularBuffer cb_scaler(cb_id_scaler);
+    CircularBuffer cb_n_recip_n(cb_id_n_recip_n);
+    fill_cb_with_value(cb_scaler, scaler.u);
+    fill_cb_with_value(cb_n_recip_n, n);
+    fill_cb_with_value(cb_n_recip_n, recip_n);
 
     if (do_mask_h || do_mask_w) {
-        generate_mask_h_w(cb_id_mask_h_w, mask_h, mask_w);
+        CircularBuffer cb_mask_h_w(cb_id_mask_h_w);
+        generate_mask_h_w(cb_mask_h_w, mask_h, mask_w);
     }
 
     uint32_t offs = 0;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/reader_moreh_layer_norm_backward_input_grad_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/reader_moreh_layer_norm_backward_input_grad_small.cpp
@@ -143,12 +143,15 @@ void kernel_main() {
         uint32_t u;
     } scaler;
     scaler.f = 1.0f;
-    fill_cb_with_value(cb_id_scaler, scaler.u);
-    fill_cb_with_value(cb_id_n_recip_n, n);
-    fill_cb_with_value(cb_id_n_recip_n, recip_n);
+    CircularBuffer cb_scaler(cb_id_scaler);
+    CircularBuffer cb_n_recip_n(cb_id_n_recip_n);
+    fill_cb_with_value(cb_scaler, scaler.u);
+    fill_cb_with_value(cb_n_recip_n, n);
+    fill_cb_with_value(cb_n_recip_n, recip_n);
 
     if (do_mask_h || do_mask_w) {
-        generate_mask_h_w(cb_id_mask_h_w, mask_h, mask_w);
+        CircularBuffer cb_mask_h_w(cb_id_mask_h_w);
+        generate_mask_h_w(cb_mask_h_w, mask_h, mask_w);
     }
 
     uint32_t offs = 0;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/reader_moreh_bias_backward_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/reader_moreh_bias_backward_h.cpp
@@ -28,7 +28,8 @@ void kernel_main() {
         calculate_and_prepare_reduce_scaler<cb_id_scaler, ckernel::PoolType::SUM, ckernel::ReduceDim::REDUCE_COL>();
 
     if (do_mask_h || do_mask_w) {
-        generate_mask_h_w(cb_id_mask_h_w, mask_h, mask_w);
+        CircularBuffer cb_mask_h_w(cb_id_mask_h_w);
+        generate_mask_h_w(cb_mask_h_w, mask_h, mask_w);
     }
 
     const auto s0 = TensorAccessor(src0_args, src0_addr);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/reader_moreh_bias_backward_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/reader_moreh_bias_backward_hw.cpp
@@ -28,10 +28,12 @@ void kernel_main() {
         uint32_t u;
     } scaler;
     scaler.f = 1.0f;
-    fill_cb_with_value(cb_id_scaler, scaler.u);
+    CircularBuffer cb_scaler(cb_id_scaler);
+    fill_cb_with_value(cb_scaler, scaler.u);
 
     if (do_mask_h || do_mask_w) {
-        generate_mask_h_w(cb_id_mask_h_w, mask_h, mask_w);
+        CircularBuffer cb_mask_h_w(cb_id_mask_h_w);
+        generate_mask_h_w(cb_mask_h_w, mask_h, mask_w);
     }
 
     const auto s0 = TensorAccessor(src_args, src_addr);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/kernels/reader_moreh_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/kernels/reader_moreh_matmul.cpp
@@ -99,13 +99,15 @@ void kernel_main() {
     bool need_input_mask_w = (input_mask_w != 32);
 
     if (need_input_mask_h || need_input_mask_w) {
-        generate_mask_tiles(cb_id_in2, input_mask_h, input_mask_w);
+        CircularBuffer cb_in2(cb_id_in2);
+        generate_mask_tiles(cb_in2, input_mask_h, input_mask_w);
     }
 
     bool need_other_mask_h = (other_mask_h != 32);
     bool need_other_mask_w = (other_mask_w != 32);
     if (need_other_mask_h || need_other_mask_w) {
-        generate_mask_tiles(cb_id_in3, other_mask_h, other_mask_w);
+        CircularBuffer cb_in3(cb_id_in3);
+        generate_mask_tiles(cb_in3, other_mask_h, other_mask_w);
     }
 
     uint32_t output_tidx = output_tile_start_idx;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/reader_moreh_mean_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/reader_moreh_mean_h.cpp
@@ -39,7 +39,8 @@ void kernel_main() {
 
     constexpr uint32_t cb_id_mask_h = tt::CBIndex::c_3;
 #ifdef DO_MASK_H
-    generate_mask_h(cb_id_mask_h, mask_h);
+    CircularBuffer cb_mask_h(cb_id_mask_h);
+    generate_mask_h(cb_mask_h, mask_h);
 #endif
 
     const auto s = TensorAccessor(src_args, src_addr);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/reader_moreh_mean_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/reader_moreh_mean_nc.cpp
@@ -28,10 +28,12 @@ void kernel_main() {
         uint32_t u;
     } scaler;
     scaler.f = 0.0f;
-    fill_cb_with_value(cb_id_in1, scaler.u);
+    CircularBuffer cb_in1(cb_id_in1);
+    fill_cb_with_value(cb_in1, scaler.u);
 
     scaler.f = 1.0f / num_input_tiles;
-    fill_cb_with_value(cb_id_in2, scaler.u, 1);
+    CircularBuffer cb_in2(cb_id_in2);
+    fill_cb_with_value(cb_in2, scaler.u, 1);
 
     constexpr auto input_args = TensorAccessorArgs<0>();
     const auto s = TensorAccessor(input_args, input_addr);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/reader_moreh_mean_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/reader_moreh_mean_w.cpp
@@ -21,7 +21,8 @@ void kernel_main() {
 
     constexpr uint32_t cb_id_mask_w = tt::CBIndex::c_3;
 #ifdef DO_MASK_W
-    generate_mask_w(cb_id_mask_w, mask_w);
+    CircularBuffer cb_mask_w(cb_id_mask_w);
+    generate_mask_w(cb_mask_w, mask_w);
 #endif
 
     constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/kernels/reader_moreh_mean_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/kernels/reader_moreh_mean_backward.cpp
@@ -82,10 +82,12 @@ void kernel_main() {
         uint32_t u;
     } scaler;
     scaler.f = 0.0f;
-    fill_cb_with_value(cb_id_in1, scaler.u);
+    CircularBuffer cb_in1(cb_id_in1);
+    fill_cb_with_value(cb_in1, scaler.u);
 
     scaler.f = 1.0f / num_dim;
-    fill_cb_with_value(cb_id_in2, scaler.u, 1);
+    CircularBuffer cb_in2(cb_id_in2);
+    fill_cb_with_value(cb_in2, scaler.u, 1);
 
     const auto output_grad_addrg = TensorAccessor(output_grad_args, output_grad_addr);
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/kernels/reader_moreh_nll_loss_step1.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/kernels/reader_moreh_nll_loss_step1.cpp
@@ -54,7 +54,8 @@ void kernel_main() {
 
 #if defined(WEIGHT)
     // weight: (1, C)
-    read_line(cb_weight, cb_weight_scratch, addrg_weight, weight_num_tile);
+    CircularBuffer cb_weight_scratch_obj(cb_weight_scratch);
+    read_line(cb_weight_obj, cb_weight_scratch_obj, addrg_weight, weight_num_tile);
 
     cb_weight_obj.wait_front(weight_num_tile);
     CoreLocalMem<volatile uint16_t> weight_l1_ptr(cb_weight_obj.get_read_ptr());
@@ -63,7 +64,7 @@ void kernel_main() {
     uint32_t end_id = start_id + num_units_per_core;
     for (uint32_t i = start_id; i < end_id; ++i) {
         uint32_t target_noc_id = i;
-        read_tile(cb_target, addrg_target, target_noc_id);
+        read_tile(cb_target_obj, addrg_target, target_noc_id);
 
         cb_output_obj.reserve_back(onetile);
         cb_target_obj.wait_front(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/kernels/reader_moreh_nll_loss_step1_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/kernels/reader_moreh_nll_loss_step1_large.cpp
@@ -57,7 +57,7 @@ void kernel_main() {
     uint32_t end_id = start_id + num_units_per_core;
     for (uint32_t i = start_id; i < end_id; ++i) {
         uint32_t target_noc_id = i;
-        read_tile(cb_target, addrg_target, target_noc_id);
+        read_tile(cb_target_obj, addrg_target, target_noc_id);
 
         cb_output_obj.reserve_back(onetile);
         cb_target_obj.wait_front(onetile);
@@ -76,7 +76,7 @@ void kernel_main() {
 
                         uint32_t noc_id = target_idx / TILE_WIDTH;
                         uint32_t weight_tilized_idx = get_tilized_idx(0, target_idx);
-                        read_value(cb_weight, addrg_weight, noc_id, weight_tilized_idx);
+                        read_value(cb_weight_obj, addrg_weight, noc_id, weight_tilized_idx);
 
                         cb_weight_obj.wait_front(onetile);
                         CoreLocalMem<volatile uint16_t> weight_l1_ptr(cb_weight_obj.get_read_ptr());

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/reader_moreh_nll_loss_step2_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/reader_moreh_nll_loss_step2_2d.cpp
@@ -53,7 +53,8 @@ void kernel_main() {
 #if defined(DIVISOR)
     const auto addrg_divisor = TensorAccessor(divisor_args, divisor_addr);
 
-    read_tile(cb_divisor, addrg_divisor, 0);
+    CircularBuffer cb_divisor_obj(cb_divisor);
+    read_tile(cb_divisor_obj, addrg_divisor, 0);
 #endif
 
     uint32_t Ct = (C + TILE_HEIGHT - 1) / TILE_HEIGHT;
@@ -73,7 +74,7 @@ void kernel_main() {
         uint32_t nt = i;
 
         auto target_noc_id = nt;
-        read_tile(cb_target, addrg_target, target_noc_id);
+        read_tile(cb_target_obj, addrg_target, target_noc_id);
 
 #if defined(WEIGHT)
         cb_tmp_weight_obj.reserve_back(onetile);
@@ -94,7 +95,7 @@ void kernel_main() {
             if (target_val != ignore_index && (0 <= target_val && target_val < static_cast<int32_t>(C))) {
                 uint32_t noc_id = (nt * Ct) + (target_val / TILE_WIDTH);
                 uint32_t input_tilized_idx = get_tilized_idx(n, target_val);
-                read_value(cb_input, addrg_input, noc_id, input_tilized_idx);
+                read_value(cb_input_obj, addrg_input, noc_id, input_tilized_idx);
 
                 cb_input_obj.wait_front(onetile);
                 CoreLocalMem<volatile uint16_t> input_l1_ptr(cb_input_obj.get_read_ptr());
@@ -108,7 +109,7 @@ void kernel_main() {
 #if defined(WEIGHT)
             uint32_t noc_id = target_val / TILE_WIDTH;
             uint32_t weight_tilized_idx = get_tilized_idx(0, target_val);
-            read_value(cb_weight, addrg_weight, noc_id, weight_tilized_idx);
+            read_value(cb_weight_obj, addrg_weight, noc_id, weight_tilized_idx);
 
             cb_weight_obj.wait_front(onetile);
             CoreLocalMem<volatile uint16_t> weight_l1_ptr(cb_weight_obj.get_read_ptr());

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/reader_moreh_nll_loss_step2_3d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/reader_moreh_nll_loss_step2_3d.cpp
@@ -56,7 +56,8 @@ void kernel_main() {
 #if defined(DIVISOR)
     const auto addrg_divisor = TensorAccessor(divisor_args, divisor_addr);
 
-    read_tile(cb_divisor, addrg_divisor, 0);
+    CircularBuffer cb_divisor_obj(cb_divisor);
+    read_tile(cb_divisor_obj, addrg_divisor, 0);
 #endif
 
     uint32_t Wf = (W + FACE_WIDTH - 1) / FACE_WIDTH;
@@ -82,7 +83,7 @@ void kernel_main() {
         uint32_t target_offset;
         get_noc_offset(n, w, target_element_size, target_offset);
         read_tile(
-            cb_target,
+            cb_target_obj,
             addrg_target,
             traget_noc_id,
             NOC_MINIMUM_READ_SIZE / element_size * target_element_size,
@@ -106,7 +107,7 @@ void kernel_main() {
             if (target_val != ignore_index && (0 <= target_val && target_val < static_cast<int32_t>(C))) {
                 uint32_t noc_id = (n * Ct * Wt) + (target_val / TILE_HEIGHT) * Wt + (w / TILE_WIDTH);
                 uint32_t tilized_idx = get_tilized_idx(target_val, w + idx);
-                read_value(cb_input, addrg_input, noc_id, tilized_idx);
+                read_value(cb_input_obj, addrg_input, noc_id, tilized_idx);
 
                 cb_input_obj.wait_front(onetile);
                 CoreLocalMem<volatile uint16_t> input_l1_ptr(cb_input_obj.get_read_ptr());
@@ -118,7 +119,7 @@ void kernel_main() {
                 {
                     uint32_t noc_id = target_val / TILE_WIDTH;
                     uint32_t tilized_idx = get_tilized_idx(0, target_val);
-                    read_value(cb_weight, addrg_weight, noc_id, tilized_idx);
+                    read_value(cb_weight_obj, addrg_weight, noc_id, tilized_idx);
 
                     cb_weight_obj.wait_front(onetile);
                     CoreLocalMem<volatile uint16_t> weight_l1_ptr(cb_weight_obj.get_read_ptr());

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/reader_moreh_nll_loss_step2_4d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/reader_moreh_nll_loss_step2_4d.cpp
@@ -57,7 +57,8 @@ void kernel_main() {
 #if defined(DIVISOR)
     const auto addrg_divisor = TensorAccessor(divisor_args, divisor_addr);
 
-    read_tile(cb_divisor, addrg_divisor, 0);
+    CircularBuffer cb_divisor_obj(cb_divisor);
+    read_tile(cb_divisor_obj, addrg_divisor, 0);
 #endif
 
     CircularBuffer cb_input_obj(cb_input);
@@ -69,7 +70,8 @@ void kernel_main() {
 
     cb_weight_obj.reserve_back(weight_num_tile);
 
-    read_line(cb_weight, cb_weight_scratch, addrg_weight, weight_num_tile);
+    CircularBuffer cb_weight_scratch_obj(cb_weight_scratch);
+    read_line(cb_weight_obj, cb_weight_scratch_obj, addrg_weight, weight_num_tile);
 
     cb_weight_obj.wait_front(weight_num_tile);
     CoreLocalMem<volatile uint16_t> weight_l1_ptr(cb_weight_obj.get_read_ptr());
@@ -78,7 +80,7 @@ void kernel_main() {
     uint32_t end_id = start_id + num_tiles_per_core;
     for (uint32_t i = start_id; i < end_id; ++i) {
         uint32_t target_noc_id = i;
-        read_tile(cb_target, addrg_target, target_noc_id);
+        read_tile(cb_target_obj, addrg_target, target_noc_id);
 
         cb_target_obj.wait_front(onetile);
         CoreLocalMem<volatile int32_t> target_l1_ptr(cb_target_obj.get_read_ptr());
@@ -118,7 +120,7 @@ void kernel_main() {
 
                         uint32_t noc_id = (n * C * num_inner_tile) + target_val * num_inner_tile + inner;
                         uint32_t tilized_idx = get_tilized_idx(h, w);
-                        read_value(cb_input, addrg_input, noc_id, tilized_idx);
+                        read_value(cb_input_obj, addrg_input, noc_id, tilized_idx);
 
                         cb_input_obj.wait_front(onetile);
                         CoreLocalMem<volatile uint16_t> input_l1_ptr(cb_input_obj.get_read_ptr());

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/kernels/reader_moreh_nll_loss_backward_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/kernels/reader_moreh_nll_loss_backward_2d.cpp
@@ -52,7 +52,8 @@ void kernel_main() {
     CircularBuffer cb_weight_obj(cb_weight);
     const auto addrg_weight = TensorAccessor(weight_args, weight_addr);
 
-    read_line(cb_weight, cb_weight_scratch, addrg_weight, weight_num_tile);
+    CircularBuffer cb_weight_scratch_obj(cb_weight_scratch);
+    read_line(cb_weight_obj, cb_weight_scratch_obj, addrg_weight, weight_num_tile);
 
     cb_weight_obj.wait_front(weight_num_tile);
     CoreLocalMem<volatile uint16_t> weight_l1_ptr(cb_weight_obj.get_read_ptr());
@@ -61,10 +62,12 @@ void kernel_main() {
 #if defined(DIVISOR)
     const auto addrg_divisor = TensorAccessor(divisor_args, divisor_addr);
 
-    read_tile(cb_divisor, addrg_divisor, 0);
+    CircularBuffer cb_divisor_obj(cb_divisor);
+    read_tile(cb_divisor_obj, addrg_divisor, 0);
 #endif
 
-    read_tile(cb_output_grad, addrg_output_grad, 0);
+    CircularBuffer cb_output_grad_obj(cb_output_grad);
+    read_tile(cb_output_grad_obj, addrg_output_grad, 0);
 
     uint32_t Ct = (C + TILE_HEIGHT - 1) / TILE_HEIGHT;
 
@@ -74,7 +77,7 @@ void kernel_main() {
         uint32_t ct = i % Ct;
 
         uint32_t target_noc_id = nt;
-        read_tile(cb_target, addrg_target, target_noc_id);
+        read_tile(cb_target_obj, addrg_target, target_noc_id);
 
         cb_tmp_weight_obj.reserve_back(onetile);
         cb_target_obj.wait_front(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/kernels/reader_moreh_nll_loss_backward_3d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/kernels/reader_moreh_nll_loss_backward_3d.cpp
@@ -53,7 +53,8 @@ void kernel_main() {
     CircularBuffer cb_weight_obj(cb_weight);
     const auto addrg_weight = TensorAccessor(weight_args, weight_addr);
 
-    read_line(cb_weight, cb_weight_scratch, addrg_weight, weight_num_tile);
+    CircularBuffer cb_weight_scratch_obj(cb_weight_scratch);
+    read_line(cb_weight_obj, cb_weight_scratch_obj, addrg_weight, weight_num_tile);
 
     cb_weight_obj.wait_front(weight_num_tile);
     CoreLocalMem<volatile uint16_t> weight_l1_ptr(cb_weight_obj.get_read_ptr());
@@ -62,10 +63,12 @@ void kernel_main() {
 #if defined(DIVISOR)
     const auto addrg_divisor = TensorAccessor(divisor_args, divisor_addr);
 
-    read_tile(cb_divisor, addrg_divisor, 0);
+    CircularBuffer cb_divisor_obj(cb_divisor);
+    read_tile(cb_divisor_obj, addrg_divisor, 0);
 #endif
 
-    read_tile(cb_output_grad, addrg_output_grad, 0);
+    CircularBuffer cb_output_grad_obj(cb_output_grad);
+    read_tile(cb_output_grad_obj, addrg_output_grad, 0);
 
     uint32_t Ct = (C + TILE_HEIGHT - 1) / TILE_HEIGHT;
 
@@ -80,7 +83,7 @@ void kernel_main() {
         uint32_t Wt = num_inner_tile;
         uint32_t nt = n / TILE_HEIGHT;
         uint32_t target_noc_id = nt * Wt + wt;
-        read_tile(cb_target, addrg_target, target_noc_id);
+        read_tile(cb_target_obj, addrg_target, target_noc_id);
 
         cb_tmp_weight_obj.reserve_back(onetile);
         cb_target_obj.wait_front(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/kernels/reader_moreh_nll_loss_backward_4d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/kernels/reader_moreh_nll_loss_backward_4d.cpp
@@ -53,7 +53,8 @@ void kernel_main() {
     CircularBuffer cb_weight_obj(cb_weight);
     const auto addrg_weight = TensorAccessor(weight_args, weight_addr);
 
-    read_line(cb_weight, cb_weight_scratch, addrg_weight, weight_num_tile);
+    CircularBuffer cb_weight_scratch_obj(cb_weight_scratch);
+    read_line(cb_weight_obj, cb_weight_scratch_obj, addrg_weight, weight_num_tile);
 
     cb_weight_obj.wait_front(weight_num_tile);
     CoreLocalMem<volatile uint16_t> weight_l1_ptr(cb_weight_obj.get_read_ptr());
@@ -62,10 +63,12 @@ void kernel_main() {
 #if defined(DIVISOR)
     const auto addrg_divisor = TensorAccessor(divisor_args, divisor_addr);
 
-    read_tile(cb_divisor, addrg_divisor, 0);
+    CircularBuffer cb_divisor_obj(cb_divisor);
+    read_tile(cb_divisor_obj, addrg_divisor, 0);
 #endif
 
-    read_tile(cb_output_grad, addrg_output_grad, 0);
+    CircularBuffer cb_output_grad_obj(cb_output_grad);
+    read_tile(cb_output_grad_obj, addrg_output_grad, 0);
 
     uint32_t end_id = start_id + num_tiles_per_core;
     for (uint32_t i = start_id; i < end_id; ++i) {
@@ -75,7 +78,7 @@ void kernel_main() {
         uint32_t c = nc % C;
 
         uint32_t target_noc_id = n * num_inner_tile + inner;
-        read_tile(cb_target, addrg_target, target_noc_id);
+        read_tile(cb_target_obj, addrg_target, target_noc_id);
 
         cb_tmp_weight_obj.reserve_back(onetile);
         cb_target_obj.wait_front(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/kernels/reader_moreh_nll_loss_unreduced_backward_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/kernels/reader_moreh_nll_loss_unreduced_backward_2d.cpp
@@ -49,7 +49,8 @@ void kernel_main() {
     CircularBuffer cb_weight_obj(cb_weight);
     const auto addrg_weight = TensorAccessor(weight_args, weight_addr);
 
-    read_line(cb_weight, cb_weight_scratch, addrg_weight, Ct);
+    CircularBuffer cb_weight_scratch_obj(cb_weight_scratch);
+    read_line(cb_weight_obj, cb_weight_scratch_obj, addrg_weight, Ct);
 
     cb_weight_obj.wait_front(Ct);
     CoreLocalMem<volatile uint16_t> weight_l1_ptr(cb_weight_obj.get_read_ptr());
@@ -57,7 +58,8 @@ void kernel_main() {
 
     const auto addrg_output_grad = TensorAccessor(output_grad_args, output_grad_addr);
 
-    read_line(cb_output_grad, cb_output_grad_scratch, addrg_output_grad, Nt);
+    CircularBuffer cb_output_grad_scratch_obj(cb_output_grad_scratch);
+    read_line(cb_output_grad_obj, cb_output_grad_scratch_obj, addrg_output_grad, Nt);
 
     cb_output_grad_obj.wait_front(Nt);
 
@@ -69,7 +71,7 @@ void kernel_main() {
         uint32_t ct = i % Ct;
 
         auto target_noc_id = nt;
-        read_tile(cb_target, addrg_target, target_noc_id);
+        read_tile(cb_target_obj, addrg_target, target_noc_id);
 
         cb_input_grad_obj.reserve_back(onetile);
         cb_target_obj.wait_front(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/kernels/reader_moreh_nll_loss_unreduced_backward_3d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/kernels/reader_moreh_nll_loss_unreduced_backward_3d.cpp
@@ -48,7 +48,8 @@ void kernel_main() {
     CircularBuffer cb_weight_obj(cb_weight);
     const auto addrg_weight = TensorAccessor(weight_args, weight_addr);
 
-    read_line(cb_weight, cb_weight_scratch, addrg_weight, Ct);
+    CircularBuffer cb_weight_scratch_obj(cb_weight_scratch);
+    read_line(cb_weight_obj, cb_weight_scratch_obj, addrg_weight, Ct);
 
     cb_weight_obj.wait_front(Ct);
     CoreLocalMem<volatile uint16_t> weight_l1_ptr(cb_weight_obj.get_read_ptr());
@@ -67,10 +68,10 @@ void kernel_main() {
         uint32_t ct = nct % Ct;
 
         auto target_noc_id = nt * Wt + wt;
-        read_tile(cb_target, addrg_target, target_noc_id);
+        read_tile(cb_target_obj, addrg_target, target_noc_id);
 
         auto output_grad_noc_id = nt * Wt + wt;
-        read_tile(cb_output_grad, addrg_output_grad, output_grad_noc_id);
+        read_tile(cb_output_grad_obj, addrg_output_grad, output_grad_noc_id);
 
         cb_input_grad_obj.reserve_back(onetile);
         cb_target_obj.wait_front(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/kernels/reader_moreh_nll_loss_unreduced_backward_4d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/kernels/reader_moreh_nll_loss_unreduced_backward_4d.cpp
@@ -49,7 +49,8 @@ void kernel_main() {
     CircularBuffer cb_weight_obj(cb_weight);
     const auto addrg_weight = TensorAccessor(weight_args, weight_addr);
 
-    read_line(cb_weight, cb_weight_scratch, addrg_weight, Ct);
+    CircularBuffer cb_weight_scratch_obj(cb_weight_scratch);
+    read_line(cb_weight_obj, cb_weight_scratch_obj, addrg_weight, Ct);
 
     cb_weight_obj.wait_front(Ct);
     CoreLocalMem<volatile uint16_t> weight_l1_ptr(cb_weight_obj.get_read_ptr());
@@ -65,10 +66,10 @@ void kernel_main() {
         uint32_t c = nc % C;
 
         auto target_noc_id = n * num_inner_tile + inner;
-        read_tile(cb_target, addrg_target, target_noc_id);
+        read_tile(cb_target_obj, addrg_target, target_noc_id);
 
         auto output_grad_noc_id = n * num_inner_tile + inner;
-        read_tile(cb_output_grad, addrg_output_grad, output_grad_noc_id);
+        read_tile(cb_output_grad_obj, addrg_output_grad, output_grad_noc_id);
 
         cb_input_grad_obj.reserve_back(onetile);
         cb_target_obj.wait_front(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_h/kernels/reader_moreh_norm_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_h/kernels/reader_moreh_norm_h.cpp
@@ -27,14 +27,16 @@ void kernel_main() {
 
     Scalar one;
     one.f = 1.0f;
-    fill_cb_with_value(cb_id_one, one.u);
+    CircularBuffer cb_one(cb_id_one);
+    fill_cb_with_value(cb_one, one.u);
 
     constexpr uint32_t TILE_H = 32;
     const bool do_mask_h = (origin_h % TILE_H) != 0;
     const auto mask_h = do_mask_h ? (origin_h % TILE_H) : TILE_H;
 
     if (do_mask_h) {
-        generate_mask_h(cb_id_mask_h, mask_h);
+        CircularBuffer cb_mask_h(cb_id_mask_h);
+        generate_mask_h(cb_mask_h, mask_h);
     }
 
     Noc noc;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_nc/kernels/reader_moreh_norm_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_nc/kernels/reader_moreh_norm_nc.cpp
@@ -26,7 +26,8 @@ void kernel_main() {
 
     Scalar one;
     one.f = 1.0f;
-    fill_cb_with_value(cb_id_one, one.u);
+    CircularBuffer cb_one(cb_id_one);
+    fill_cb_with_value(cb_one, one.u);
 
     Noc noc;
     CircularBuffer cb_input(cb_id_input);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_w/kernels/reader_moreh_norm_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_w/kernels/reader_moreh_norm_w.cpp
@@ -26,14 +26,16 @@ void kernel_main() {
 
     Scalar one;
     one.f = 1.0f;
-    fill_cb_with_value(cb_id_one, one.u);
+    CircularBuffer cb_one(cb_id_one);
+    fill_cb_with_value(cb_one, one.u);
 
     constexpr uint32_t TILE_W = 32;
     const bool do_mask_w = (origin_w % TILE_W) != 0;
     const auto mask_w = do_mask_w ? (origin_w % TILE_W) : TILE_W;
 
     if (do_mask_w) {
-        generate_mask_w(cb_id_mask_w, mask_w);
+        CircularBuffer cb_mask_w(cb_id_mask_w);
+        generate_mask_w(cb_mask_w, mask_w);
     }
 
     const auto start_tile_idx = tile_offset;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/kernels/reader_moreh_norm_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/kernels/reader_moreh_norm_backward.cpp
@@ -91,7 +91,8 @@ void kernel_main() {
     // output_grad
     const auto output_grad_addrg = TensorAccessor(output_grad_args, output_grad_addr);
 
-    fill_cb_with_value(cb_id_decimal, decimal);
+    CircularBuffer cb_decimal(cb_id_decimal);
+    fill_cb_with_value(cb_decimal, decimal);
 
     Noc noc;
     CircularBuffer cb_input(cb_id_input);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/kernels/reader_moreh_sgd.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/kernels/reader_moreh_sgd.cpp
@@ -49,11 +49,12 @@ void kernel_main() {
     auto momentum_in = TensorAccessor(momentum_in_args, momentum_in_addr);
 #endif
 
-    fill_cb_with_value(cb_scalar_args, lr);
-    fill_cb_with_value(cb_scalar_args, momentum);
-    fill_cb_with_value(cb_scalar_args, dampening);
-    fill_cb_with_value(cb_scalar_args, weight_decay);
-    fill_cb_with_value(cb_scalar_args, one);
+    CircularBuffer cb_scalar_args_obj(cb_scalar_args);
+    fill_cb_with_value(cb_scalar_args_obj, lr);
+    fill_cb_with_value(cb_scalar_args_obj, momentum);
+    fill_cb_with_value(cb_scalar_args_obj, dampening);
+    fill_cb_with_value(cb_scalar_args_obj, weight_decay);
+    fill_cb_with_value(cb_scalar_args_obj, one);
 
     Noc noc;
     CircularBuffer cb_param_in_obj(cb_param_in);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_h.cpp
@@ -39,10 +39,11 @@ void kernel_main() {
         calculate_and_prepare_reduce_scaler<cb_sum_scaler, ckernel::PoolType::SUM, ckernel::ReduceDim::REDUCE_COL>();
 
     // Generate mask tile
+    CircularBuffer cb_mask_obj(cb_mask);
     if (is_fp32) {
-        generate_mask_h<uint32_t>(cb_mask, mask_h);
+        generate_mask_h<uint32_t>(cb_mask_obj, mask_h);
     } else {
-        generate_mask_h<uint16_t>(cb_mask, mask_h);
+        generate_mask_h<uint16_t>(cb_mask_obj, mask_h);
     }
 
     Noc noc;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_h_large.cpp
@@ -38,10 +38,11 @@ void kernel_main() {
         calculate_and_prepare_reduce_scaler<cb_sum_scaler, ckernel::PoolType::SUM, ckernel::ReduceDim::REDUCE_COL>();
 
     // Generate mask tile
+    CircularBuffer cb_mask_obj(cb_mask);
     if (is_fp32) {
-        generate_mask_h<uint32_t>(cb_mask, mask_h);
+        generate_mask_h<uint32_t>(cb_mask_obj, mask_h);
     } else {
-        generate_mask_h<uint16_t>(cb_mask, mask_h);
+        generate_mask_h<uint16_t>(cb_mask_obj, mask_h);
     }
 
     Noc noc;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_w.cpp
@@ -40,10 +40,11 @@ void kernel_main() {
         calculate_and_prepare_reduce_scaler<cb_sum_scaler, ckernel::PoolType::SUM, ckernel::ReduceDim::REDUCE_ROW>();
 
     // Generate mask tile
+    CircularBuffer cb_mask_obj(cb_mask);
     if (is_fp32) {
-        generate_mask_w<uint32_t>(cb_mask, mask_w);
+        generate_mask_w<uint32_t>(cb_mask_obj, mask_w);
     } else {
-        generate_mask_w<uint16_t>(cb_mask, mask_w);
+        generate_mask_w<uint16_t>(cb_mask_obj, mask_w);
     }
 
     Noc noc;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_w_large.cpp
@@ -39,10 +39,11 @@ void kernel_main() {
         calculate_and_prepare_reduce_scaler<cb_sum_scaler, ckernel::PoolType::SUM, ckernel::ReduceDim::REDUCE_ROW>();
 
     // Generate mask tile
+    CircularBuffer cb_mask_obj(cb_mask);
     if (is_fp32) {
-        generate_mask_w<uint32_t>(cb_mask, mask_w);
+        generate_mask_w<uint32_t>(cb_mask_obj, mask_w);
     } else {
-        generate_mask_w<uint16_t>(cb_mask, mask_w);
+        generate_mask_w<uint16_t>(cb_mask_obj, mask_w);
     }
 
     Noc noc;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_h.cpp
@@ -34,8 +34,10 @@ void kernel_main() {
     const auto y_in = TensorAccessor(y_args, y_addr);
     const auto dy_in = TensorAccessor(dy_args, dy_addr);
 
-    generate_bcast_scaler(cb_scaler, scaler);
-    generate_mask_h(cb_mask, mask_h);
+    CircularBuffer cb_scaler_obj(cb_scaler);
+    CircularBuffer cb_mask_obj(cb_mask);
+    generate_bcast_scaler(cb_scaler_obj, scaler);
+    generate_mask_h(cb_mask_obj, mask_h);
 
     Noc noc;
     CircularBuffer cb_y_obj(cb_y);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_h_large.cpp
@@ -34,8 +34,10 @@ void kernel_main() {
     const auto y_in = TensorAccessor(y_args, y_addr);
     const auto dy_in = TensorAccessor(dy_args, dy_addr);
 
-    generate_bcast_scaler(cb_scaler, scaler);
-    generate_mask_h(cb_mask, mask_h);
+    CircularBuffer cb_scaler_obj(cb_scaler);
+    CircularBuffer cb_mask_obj(cb_mask);
+    generate_bcast_scaler(cb_scaler_obj, scaler);
+    generate_mask_h(cb_mask_obj, mask_h);
 
     Noc noc;
     CircularBuffer cb_y_obj(cb_y);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_w.cpp
@@ -35,7 +35,8 @@ void kernel_main() {
 
     dataflow_kernel_lib::
         calculate_and_prepare_reduce_scaler<cb_scaler, ckernel::PoolType::SUM, ckernel::ReduceDim::REDUCE_ROW>();
-    generate_mask_w(cb_mask, mask_w);
+    CircularBuffer cb_mask_obj(cb_mask);
+    generate_mask_w(cb_mask_obj, mask_w);
 
     Noc noc;
     CircularBuffer cb_y_obj(cb_y);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_w_large.cpp
@@ -35,7 +35,8 @@ void kernel_main() {
 
     dataflow_kernel_lib::
         calculate_and_prepare_reduce_scaler<cb_scaler, ckernel::PoolType::SUM, ckernel::ReduceDim::REDUCE_ROW>();
-    generate_mask_w(cb_mask, mask_w);
+    CircularBuffer cb_mask_obj(cb_mask);
+    generate_mask_w(cb_mask_obj, mask_w);
 
     Noc noc;
     CircularBuffer cb_y_obj(cb_y);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/reader_moreh_int_sum_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/reader_moreh_int_sum_h.cpp
@@ -26,7 +26,8 @@ void kernel_main() {
 
 #ifdef DO_MASK_H
     constexpr uint32_t cb_id_mask_h = 1;
-    generate_mask_h<int32_t>(cb_id_mask_h, mask_h);
+    CircularBuffer cb_mask_h_obj(cb_id_mask_h);
+    generate_mask_h<int32_t>(cb_mask_h_obj, mask_h);
 #endif
 
     const auto s = TensorAccessor(src_args, src_addr);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/reader_moreh_sum_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/reader_moreh_sum_h.cpp
@@ -34,7 +34,8 @@ void kernel_main() {
 
     constexpr uint32_t cb_id_mask_h = 3;
 #ifdef DO_MASK_H
-    generate_mask_h(cb_id_mask_h, mask_h);
+    CircularBuffer cb_mask_h_obj(cb_id_mask_h);
+    generate_mask_h(cb_mask_h_obj, mask_h);
 #endif
 
     const auto s = TensorAccessor(src_args, src_addr);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/reader_moreh_int_sum_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/reader_moreh_int_sum_w.cpp
@@ -18,7 +18,8 @@ void kernel_main() {
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_mask_w = 1;
 #ifdef DO_MASK_W
-    generate_mask_w<int32_t>(cb_id_mask_w, mask_w);
+    CircularBuffer cb_mask_w_obj(cb_id_mask_w);
+    generate_mask_w<int32_t>(cb_mask_w_obj, mask_w);
 #endif
 
     constexpr uint32_t onetile = 1;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/reader_moreh_sum_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/reader_moreh_sum_w.cpp
@@ -21,7 +21,8 @@ void kernel_main() {
 
     constexpr uint32_t cb_id_mask_w = 3;
 #ifdef DO_MASK_W
-    generate_mask_w(cb_id_mask_w, mask_w);
+    CircularBuffer cb_mask_w_obj(cb_id_mask_w);
+    generate_mask_w(cb_mask_w_obj, mask_w);
 #endif
 
     constexpr uint32_t cb_id_in0 = 0;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/kernels/reader_moreh_sum_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/kernels/reader_moreh_sum_backward.cpp
@@ -78,7 +78,8 @@ void kernel_main() {
         uint32_t u;
     } scaler;
     scaler.f = 0.0f;
-    fill_cb_with_value(cb_id_in1, scaler.u);
+    CircularBuffer cb_in1_obj(cb_id_in1);
+    fill_cb_with_value(cb_in1_obj, scaler.u);
 
     const auto output_grad_addrg = TensorAccessor(output_grad_args, output_grad_addr);
 


### PR DESCRIPTION
## PR Category

Cleanup

## Summary

Issue [#45003](https://github.com/tenstorrent/tt-metal/issues/45003)

First part of moreh kernels migration to the Device 2.0 API. Rewrites the shared dataflow header `ttnn/cpp/ttnn/kernel/dataflow/moreh_common.hpp` to use `Noc`, `CircularBuffer` wrappers instead of the legacy free-function. Updates consumer kernels under `ttnn/cpp/ttnn/operations/moreh/`.

## Notes for reviewers

### moreh_common.hpp helpers migrated
- `noc_async_{read,write}_tile_helper`, templated `get_{read,write}_ptr<T>(uint32_t)` — removed as unused
- `process_data<T>`, `fill_cb_with_value`, `generate_bcast_scaler<T>`, `generate_mask_{h,w}<T>`, `generate_mask_h_w`, `generate_mask_h_w_if_needed`, `generate_mask_tiles`, `read_tile`, `read_value`, `read_line` — signatures now take `CircularBuffer` / `Noc`

### Cross-op dependency
- `operations/normalization/softmax` includes `moreh_helper_functions.hpp` on the host side and borrows moreh's kernel files (`reader_moreh_softmax_h.cpp`, `writer_moreh_softmax_h.cpp`, `moreh_softmax_h.cpp`)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/moreh-d2-migration-phase1a)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/moreh-d2-migration-phase1a)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/moreh-d2-migration-phase1a)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/moreh-d2-migration-phase1a)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/moreh-d2-migration-phase1a)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/moreh-d2-migration-phase1a)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/moreh-d2-migration-phase1a)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/moreh-d2-migration-phase1a)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/moreh-d2-migration-phase1a)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/moreh-d2-migration-phase1a)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/moreh-d2-migration-phase1a)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/moreh-d2-migration-phase1a)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/moreh-d2-migration-phase1a)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/moreh-d2-migration-phase1a)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/moreh-d2-migration-phase1a)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/moreh-d2-migration-phase1a)
