### PR TITLE
[sparse_sdpa] Fix brisc build: wrap CB index in CircularBuffer for bcast helper

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_writer.cpp
@@ -68,7 +68,7 @@ void kernel_main() {
 
     // Col-identity (column 0 = 1.0): compute matmul-reduces the partial row-sum against it to finalize the
     // within-tile reduction in normalize_row_streaming.
-    generate_bcast_col_scalar(cb_col_identity, one_bf16_packed);
+    generate_bcast_col_scalar(CircularBuffer(cb_col_identity), one_bf16_packed);
 
     // All-(-inf) tile (row 0; compute bcast-adds it to fully-masked key tiles). Only row 0 matters for the
     // row-broadcast add: cols 0-15 -> face0 row0 (offset c), cols 16-31 -> face1 row0 (offset 256+c).


### PR DESCRIPTION
Wrap the CB index in `CircularBuffer(...)` in `sparse_sdpa_writer`, fixing the brisc JIT build broken by the Device 2.0 bcast-scalar migration (#47446) which changed `generate_bcast_col_scalar` to take a `CircularBuffer`. This kernel was the only caller missed.

bhpc run: https://github.com/tenstorrent/tt-metal/actions/runs/28097800764