### PR TITLE
conv1d: enable DRAM slicing by default, fix 4D weights & depthwise CB deadlock

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/test_conv1d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv1d.py
@@ -959,7 +959,7 @@ def run_conv1d_route(
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 1 << 15}], indirect=True)
 def test_conv1d_default_route_long_seq(device):
-    """Fix #1: a long-sequence conv1d in DRAM with no slice_config must auto-route through
+    """Fix 1: a long-sequence conv1d in DRAM with no slice_config must auto-route through
     DRAM width slicing instead of forcing L1_FULL. Same shape as the L1_FULL OOM baseline
     (test_conv1d_no_slicing_oom); without the fix this OOMs ("circular buffers grow beyond
     max L1"), with it the input is width-sliced through DRAM and matches golden."""
@@ -968,7 +968,7 @@ def test_conv1d_default_route_long_seq(device):
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 1 << 15}], indirect=True)
 def test_conv1d_default_route_auto_shard(device):
-    """Fix #1: auto-shard (shard_layout=None) with no slice_config must keep working - the
+    """Fix 1: auto-shard (shard_layout=None) with no slice_config must keep working - the
     DRAM routing path auto-determines a shard layout when none is given. Without the fix
     this OOMs in L1_FULL."""
     run_conv1d_route(device, **_SLICE_OOM_SHAPE, shard_layout=None)
@@ -976,7 +976,7 @@ def test_conv1d_default_route_auto_shard(device):
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 1 << 15}], indirect=True)
 def test_conv1d_default_route_l1_input_stays_l1(device):
-    """Fix #1 guard: an input already in L1 with no slice_config must stay in L1 (L1_FULL),
+    """Fix 1 guard: an input already in L1 with no slice_config must stay in L1 (L1_FULL),
     not get pushed through the DRAM slicing path. Small enough to fit L1; passes with and
     without the fix - it guards against the new default wrongly re-routing L1 inputs."""
     run_conv1d_route(
@@ -994,7 +994,7 @@ def test_conv1d_default_route_l1_input_stays_l1(device):
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 1 << 15}], indirect=True)
 def test_conv1d_depthwise_dram_slice_auto_shard(device):
-    """Fix #2 (4D weight reshape): depthwise (groups == C) conv1d through the DRAM-slicing
+    """Fix 2 (4D weight reshape): depthwise (groups == C) conv1d through the DRAM-slicing
     auto-shard path (explicit DRAM width slice + shard_layout=None). That path reads the
     kernel width as weight.logical_shape()[3] before weights are prepared; without the
     up-front 3D->4D reshape this raises "ShapeBase[] index out of range. 3 not in [-4, 3)".
@@ -1017,7 +1017,7 @@ def test_conv1d_depthwise_dram_slice_auto_shard(device):
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 def test_conv1d_depthwise_subblock_deadlock(device):
-    """Fix #3 (depthwise CB deadlock): a depthwise (groups == C) conv1d whose act_block_h is
+    """Fix 3 (depthwise CB deadlock): a depthwise (groups == C) conv1d whose act_block_h is
     forced large enough that out_subblock_h_ntiles > 1. The depthwise compute kernel tilized
     only in0_num_subblocks tile-rows while mul_and_accumulate_block consumed the full block;
     they mismatch when out_subblock_h_ntiles > 1, so tilize under-produces and the activation
@@ -1042,7 +1042,7 @@ def test_conv1d_depthwise_subblock_deadlock(device):
 @pytest.mark.slow
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 def test_conv1d_depthwise_default_route_long_seq(device):
-    """Regression for #46395 (fixes #1, #2, #3 end-to-end): the real vocoder STAGE_C upsample
+    """Regression for #46395 (fixes 1, 2, 3 end-to-end): the real vocoder STAGE_C upsample
     tail - depthwise groups==C at ~29k sequence length - previously OOMed/deadlocked through
     the stock conv1d path. Ported from the experimental conv1d_depthwise repro to exercise
     only the stock conv1d path. Without the fix this OOMs in L1_FULL (~4.5 MB CB vs 1.5 MB

--- a/tests/ttnn/unit_tests/operations/conv/test_conv1d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv1d.py
@@ -769,17 +769,15 @@ _SLICE_CHANNEL_BOUND_SHAPE = dict(
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 1 << 15}], indirect=True)
-def test_conv1d_no_slicing_oom(device):
-    """Baseline: the large conv1d should run out of L1 when forced into the L1_FULL path."""
-    with pytest.raises(RuntimeError) as excinfo:
+def test_conv1d_no_slicing_oom(device, expect_error):
+    """Baseline: the large conv1d should run out of L1 when forced into the L1_FULL path.
+    The match string asserts the failure is an L1 capacity error, not something unrelated."""
+    with expect_error(RuntimeError, "circular buffer|beyond max L1|Out of Memory|allocat"):
         run_conv1d_slice(
             device,
             **_SLICE_OOM_SHAPE,
             slice_config=ttnn.Conv2dL1FullSliceConfig,
         )
-    # Sanity-check the failure is an allocation/L1 capacity error and not something unrelated.
-    msg = str(excinfo.value).lower()
-    assert any(k in msg for k in ("memory", "allocat", "l1", "circular buffer", "out of")), excinfo.value
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 1 << 15}], indirect=True)
@@ -810,13 +808,13 @@ def test_conv1d_auto_dram_width_slicing(device):
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 1 << 15}], indirect=True)
-def test_conv1d_channel_bound_slicing_insufficient(device):
+def test_conv1d_channel_bound_slicing_insufficient(device, expect_error):
     """Width slicing cannot relieve a channel-bound OOM (the weight block is width-independent).
 
     Documents the boundary of conv1d DRAM slicing: when L1 pressure comes from the channel
     dimension rather than the sequence length, even maximal width slicing fails to find a fit.
     """
-    with pytest.raises(RuntimeError, match="could not find valid slice configuration"):
+    with expect_error(RuntimeError, "could not find valid slice configuration"):
         run_conv1d_slice(
             device,
             **_SLICE_CHANNEL_BOUND_SHAPE,
@@ -828,9 +826,9 @@ def test_conv1d_channel_bound_slicing_insufficient(device):
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 1 << 15}], indirect=True)
-def test_conv1d_dram_height_slicing_rejected(device):
+def test_conv1d_dram_height_slicing_rejected(device, expect_error):
     """DRAM_HEIGHT slicing is degenerate for conv1d (height==1) and must be rejected."""
-    with pytest.raises(RuntimeError, match="DRAM_HEIGHT"):
+    with expect_error(RuntimeError, "DRAM_HEIGHT"):
         run_conv1d_slice(
             device,
             batch_size=1,
@@ -845,3 +843,225 @@ def test_conv1d_dram_height_slicing_rejected(device):
                 num_slices=4,
             ),
         )
+
+
+# ---------------------------------------------------------------------------
+# Default-routing regressions (no slice_config)
+#
+# Three fixes let stock ttnn.conv1d (including depthwise groups==C) handle the
+# long-sequence / narrow-channel shapes that previously OOMed or hung when called
+# with no slice_config:
+#   1. DRAM slicing by default. A missing slice_config now forwards nullopt so conv2d
+#      auto-routes by input location - inputs already in L1 stay in L1, while DRAM/host
+#      inputs are width-sliced through DRAM (height is always 1, so the auto slice type
+#      is always DRAM_WIDTH) - instead of forcing L1_FULL and OOMing on long sequences.
+#      The DRAM path auto-determines a shard layout when shard_layout is unset, so
+#      auto_shard / shard_layout=None callers keep working.
+#   2. 4D weight reshape. The 3D conv1d weight [out, in/groups, K] is reinterpreted as
+#      4D [.., 1, K] up front, because the DRAM auto-shard path reads the kernel width
+#      (weight.logical_shape()[3]) before weights are prepared.
+#   3. Depthwise CB deadlock. The depthwise compute kernel now tilizes the full
+#      activation block height; tilizing only in0_num_subblocks tile-rows under-produced
+#      (and deadlocked the activation CB) whenever out_subblock_h_ntiles > 1, which
+#      happens at long depthwise sequence lengths.
+# ---------------------------------------------------------------------------
+
+
+def run_conv1d_route(
+    device,
+    batch_size,
+    in_channels,
+    out_channels,
+    input_length,
+    kernel_size,
+    stride,
+    padding,
+    groups=1,
+    shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+    slice_config=None,
+    act_block_h=None,
+    input_in_dram=True,
+    weights_dtype=ttnn.bfloat16,
+    activations_dtype=ttnn.bfloat16,
+    output_dtype=ttnn.bfloat16,
+    math_fidelity=ttnn.MathFidelity.HiFi4,
+    fp32_accum=False,
+    packer_l1_acc=False,
+    pcc=0.99,
+):
+    """Run ttnn.conv1d and check it against the torch golden.
+
+    slice_config=None exercises the default routing path (a DRAM/host input must auto-route
+    through DRAM width slicing rather than forcing L1_FULL). shard_layout=None selects
+    auto-shard. input_in_dram places the input in DRAM; set False to keep it in L1.
+    act_block_h sets act_block_h_override (used to force out_subblock_h_ntiles > 1).
+    """
+    torch.manual_seed(0)
+    torch_input_ncl = torch.randn(batch_size, in_channels, input_length, dtype=torch.bfloat16).float()
+    torch_weight = torch.randn(out_channels, in_channels // groups, kernel_size, dtype=torch.bfloat16).float()
+
+    golden = torch.nn.functional.conv1d(
+        torch_input_ncl,
+        torch_weight,
+        bias=None,
+        stride=stride,
+        padding=padding,
+        groups=groups,
+    )
+
+    input_tt = ttnn.from_torch(
+        torch_input_ncl.permute(0, 2, 1),  # NLC for conv1d
+        dtype=activations_dtype,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG if input_in_dram else ttnn.L1_MEMORY_CONFIG,
+    )
+    weight_tt = ttnn.from_torch(torch_weight, dtype=weights_dtype, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    conv_config = ttnn.Conv1dConfig(
+        weights_dtype=weights_dtype,
+        shard_layout=shard_layout,  # None == auto-shard
+        deallocate_activation=False,
+    )
+    if act_block_h is not None:
+        conv_config.act_block_h_override = act_block_h
+    compute_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=math_fidelity,
+        fp32_dest_acc_en=fp32_accum,
+        packer_l1_acc=packer_l1_acc,
+    )
+
+    tt_out, out_length = ttnn.conv1d(
+        input_tensor=input_tt,
+        weight_tensor=weight_tt,
+        device=device,
+        in_channels=in_channels,
+        out_channels=out_channels,
+        batch_size=batch_size,
+        input_length=input_length,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        groups=groups,
+        conv_config=conv_config,
+        compute_config=compute_config,
+        slice_config=slice_config,
+        dtype=output_dtype,
+        return_output_dim=True,
+    )
+
+    out = ttnn.to_torch(tt_out).reshape(batch_size, out_length, out_channels).permute(0, 2, 1)
+    passing, pcc_msg = check_with_pcc_without_tensor_printout(out, golden, pcc=pcc)
+    assert passing, pcc_msg
+    return out
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 1 << 15}], indirect=True)
+def test_conv1d_default_route_long_seq(device):
+    """Fix #1: a long-sequence conv1d in DRAM with no slice_config must auto-route through
+    DRAM width slicing instead of forcing L1_FULL. Same shape as the L1_FULL OOM baseline
+    (test_conv1d_no_slicing_oom); without the fix this OOMs ("circular buffers grow beyond
+    max L1"), with it the input is width-sliced through DRAM and matches golden."""
+    run_conv1d_route(device, **_SLICE_OOM_SHAPE)
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 1 << 15}], indirect=True)
+def test_conv1d_default_route_auto_shard(device):
+    """Fix #1: auto-shard (shard_layout=None) with no slice_config must keep working - the
+    DRAM routing path auto-determines a shard layout when none is given. Without the fix
+    this OOMs in L1_FULL."""
+    run_conv1d_route(device, **_SLICE_OOM_SHAPE, shard_layout=None)
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 1 << 15}], indirect=True)
+def test_conv1d_default_route_l1_input_stays_l1(device):
+    """Fix #1 guard: an input already in L1 with no slice_config must stay in L1 (L1_FULL),
+    not get pushed through the DRAM slicing path. Small enough to fit L1; passes with and
+    without the fix - it guards against the new default wrongly re-routing L1 inputs."""
+    run_conv1d_route(
+        device,
+        batch_size=1,
+        in_channels=64,
+        out_channels=64,
+        input_length=1024,
+        kernel_size=3,
+        stride=1,
+        padding=1,
+        input_in_dram=False,
+    )
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 1 << 15}], indirect=True)
+def test_conv1d_depthwise_dram_slice_auto_shard(device):
+    """Fix #2 (4D weight reshape): depthwise (groups == C) conv1d through the DRAM-slicing
+    auto-shard path (explicit DRAM width slice + shard_layout=None). That path reads the
+    kernel width as weight.logical_shape()[3] before weights are prepared; without the
+    up-front 3D->4D reshape this raises "ShapeBase[] index out of range. 3 not in [-4, 3)".
+    An explicit shard_layout (non-auto) does NOT hit this, so auto-shard is required."""
+    C = 256
+    run_conv1d_route(
+        device,
+        batch_size=1,
+        in_channels=C,
+        out_channels=C,
+        input_length=2921,
+        kernel_size=12,
+        stride=1,
+        padding=0,
+        groups=C,
+        shard_layout=None,  # auto-shard: triggers the logical_shape()[3] read
+        slice_config=ttnn.Conv2dSliceConfig(slice_type=ttnn.Conv2dDRAMSliceWidth, num_slices=8),
+    )
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+def test_conv1d_depthwise_subblock_deadlock(device):
+    """Fix #3 (depthwise CB deadlock): a depthwise (groups == C) conv1d whose act_block_h is
+    forced large enough that out_subblock_h_ntiles > 1. The depthwise compute kernel tilized
+    only in0_num_subblocks tile-rows while mul_and_accumulate_block consumed the full block;
+    they mismatch when out_subblock_h_ntiles > 1, so tilize under-produces and the activation
+    CB deadlocks (the op hangs). With the full-block-height tilize this completes and matches
+    golden. Fits L1 (no slicing) so the deadlock is the only failure mode under test."""
+    C = 64
+    run_conv1d_route(
+        device,
+        batch_size=1,
+        in_channels=C,
+        out_channels=C,
+        input_length=2048,
+        kernel_size=12,
+        stride=1,
+        padding=0,
+        groups=C,
+        act_block_h=256,  # 8 tile-rows -> out_subblock_h_ntiles > 1
+        input_in_dram=False,
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+def test_conv1d_depthwise_default_route_long_seq(device):
+    """Regression for #46395 (fixes #1, #2, #3 end-to-end): the real vocoder STAGE_C upsample
+    tail - depthwise groups==C at ~29k sequence length - previously OOMed/deadlocked through
+    the stock conv1d path. Ported from the experimental conv1d_depthwise repro to exercise
+    only the stock conv1d path. Without the fix this OOMs in L1_FULL (~4.5 MB CB vs 1.5 MB
+    L1). l1_small_size matches the vocoder's setting."""
+    C = 64
+    run_conv1d_route(
+        device,
+        batch_size=1,
+        in_channels=C,
+        out_channels=C,
+        input_length=28841,
+        kernel_size=12,
+        stride=1,
+        padding=0,
+        groups=C,
+        weights_dtype=ttnn.float32,
+        activations_dtype=ttnn.float32,
+        output_dtype=ttnn.float32,
+        fp32_accum=True,
+        packer_l1_acc=True,
+        pcc=0.999,
+    )

--- a/ttnn/cpp/ttnn/operations/conv/conv1d/conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv1d/conv1d.cpp
@@ -41,6 +41,20 @@ Conv1dResult conv1d(
             ? ttnn::reshape(input_tensor, Shape({batch_size, 1, input_length, in_channels}))
             : input_tensor;
 
+    // Reinterpret the 3D conv1d weight [out_channels, in_channels/groups, kernel_size] as 4D
+    // [.., 1, kernel_size], matching the [N, 1, input_length, C] input reshape and the {1, kernel_size}
+    // kernel. conv2d's weight prep does this for the L1 path, but the DRAM slicing auto-shard path reads
+    // weight.logical_shape()[3] (the kernel width) before weights are prepared, so it must be 4D up front.
+    const ttnn::Tensor& weight_tensor_4d = (weight_tensor.logical_shape().rank() == 3)
+                                               ? ttnn::reshape(
+                                                     weight_tensor,
+                                                     Shape(
+                                                         {weight_tensor.logical_shape()[0],
+                                                          weight_tensor.logical_shape()[1],
+                                                          1,
+                                                          weight_tensor.logical_shape()[2]}))
+                                               : weight_tensor;
+
     // padding for conv2d based on conv1d padding
     std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> conv2d_padding;
     if (std::holds_alternative<uint32_t>(padding)) {
@@ -58,22 +72,25 @@ Conv1dResult conv1d(
 
     // Conv1d reshapes the input to [N, 1, input_length, C], so the height dimension is always 1.
     // DRAM slicing is therefore only meaningful along the width dimension (DRAM_WIDTH, i.e. input_length);
-    // DRAM_HEIGHT would produce a single degenerate slice and silently collapse back to L1.
-    // When no slice config is provided, preserve the historical conv1d behaviour of forcing L1_FULL.
-    // Forwarding nullopt instead would route by input location (conv2d's default), sending DRAM/host
-    // inputs through the DRAM slicing path - which breaks existing auto_shard / shard_layout=None
-    // callers (the slicing path requires a shard layout). So conv1d opts in to DRAM slicing explicitly.
-    const ttnn::prim::Conv2dSliceConfig effective_slice_config = slice_config.value_or(
-        ttnn::prim::Conv2dSliceConfig{.slice_type = ttnn::prim::Conv2dSliceConfig::SliceType::L1_FULL});
-    TT_FATAL(
-        effective_slice_config.slice_type != ttnn::prim::Conv2dSliceConfig::SliceType::DRAM_HEIGHT,
-        "Conv1D does not support DRAM_HEIGHT slicing because the convolution height is always 1. "
-        "Use DRAM_WIDTH slicing (slices along input_length) or L1_FULL.");
+    // DRAM_HEIGHT would produce a single degenerate slice. Reject it only when requested explicitly.
+    if (slice_config.has_value()) {
+        TT_FATAL(
+            slice_config->slice_type != ttnn::prim::Conv2dSliceConfig::SliceType::DRAM_HEIGHT,
+            "Conv1D does not support DRAM_HEIGHT slicing because the convolution height is always 1. "
+            "Use DRAM_WIDTH slicing (slices along input_length) or L1_FULL.");
+    }
+    // When no slice config is provided, forward nullopt so conv2d auto-routes by input location:
+    // inputs already in L1 stay in L1, while DRAM/host inputs are width-sliced through DRAM (height is
+    // always 1, so the auto-selected slice type is always DRAM_WIDTH). This lets long sequences that
+    // would otherwise overflow L1 stream through DRAM by default instead of forcing L1_FULL. The DRAM
+    // slicing path auto-determines a shard layout when conv_config.shard_layout is unset, so
+    // shard_layout=None / auto_shard callers continue to work.
+    const std::optional<const ttnn::prim::Conv2dSliceConfig>& effective_slice_config = slice_config;
 
     auto [output_tensor, output_dimensions, weights_and_bias] =
         std::get<static_cast<int>(ConvResultType::OUTPUT_DIM_WEIGHTS_AND_BIAS)>(ttnn::conv2d(
             input_tensor_4d,
-            weight_tensor,
+            weight_tensor_4d,
             device,
             in_channels,
             out_channels,

--- a/ttnn/cpp/ttnn/operations/conv/conv1d/conv1d_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv1d/conv1d_nanobind.cpp
@@ -47,7 +47,7 @@ void bind_conv1d(nb::module_& mod) {
             conv_config (ttnn.Conv2dConfig, optional): Configuration for convolution. Default: None
             compute_config (ttnn.DeviceComputeKernelConfig, optional): Configuration for compute kernel. Default: None
             memory_config (ttnn.MemoryConfig, optional): Output Tensor's Memory Configuration. Default: None
-            slice_config (ttnn.Conv2dSliceConfig, optional): Configuration for slicing the input & output tensors in DRAM along the input_length (width) dimension. Use slice_type=Conv2dDRAMSliceWidth with num_slices=0 to auto-determine the number of slices, or num_slices=N to slice manually. DRAM_HEIGHT slicing is not supported because the conv1d height is always 1. If None, the op runs fully in L1 (L1_FULL). Default: None
+            slice_config (ttnn.Conv2dSliceConfig, optional): Configuration for slicing the input & output tensors in DRAM along the input_length (width) dimension. Use slice_type=Conv2dDRAMSliceWidth with num_slices=0 to auto-determine the number of slices, or num_slices=N to slice manually. DRAM_HEIGHT slicing is not supported because the conv1d height is always 1. If None, slicing is auto-routed by input location: inputs already in L1 run fully in L1, while DRAM/host inputs are auto width-sliced through DRAM. Default: None
             return_output_dim (bool, optional): If true, the op also returns the length of the output tensor. Default: False
             return_weights_and_bias (bool, optional): If true, the op also returns the preprocessed weight and bias on device. Default: False
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp
@@ -138,7 +138,11 @@ void kernel_main() {
 
     for (uint32_t in0_block_h_i = 0; in0_block_h_i < in0_num_blocks_h; ++in0_block_h_i) {
         for (uint32_t in0_block_w_i = 0; in0_block_w_i < in0_num_blocks_w; ++in0_block_w_i) {
-            compute_kernel_lib::tilize<in0_block_w, in0_cb_id, tilized_in0_cb_id>(in0_num_subblocks);
+            // Tilize the full activation block height. The number of tile-rows is
+            // in0_block_num_tiles / in0_block_w (== act_block_h_ntiles); this must match the tile
+            // count mul_and_accumulate_block(_coalesced) consumes below. Using in0_num_subblocks
+            // here under-produces by out_subblock_h_ntiles when it is > 1, deadlocking the CB.
+            compute_kernel_lib::tilize<in0_block_w, in0_cb_id, tilized_in0_cb_id>(in0_block_num_tiles / in0_block_w);
             reconfig_data_format_srca(tilized_in0_cb_id);
             if constexpr (coalesce_kw_reads) {
                 mul_and_accumulate_coalesced_block<in0_block_w, kernel_width, in0_block_num_tiles>(


### PR DESCRIPTION
## What

Three fixes that let stock `ttnn.conv1d` (including depthwise `groups=C`) handle the long-sequence / narrow-channel shapes that previously **OOMed or hung**, plus device-validated regression tests for each.

### Fixes (`conv1d.cpp`, `conv1d_nanobind.cpp`, conv2d depthwise kernel)
1. **DRAM slicing by default.** A missing `slice_config` no longer forces `L1_FULL`; it forwards `nullopt` so conv2d auto-routes by input location — L1 inputs stay in L1, DRAM/host inputs are width-sliced through DRAM (height is always 1, so the auto slice type is always `DRAM_WIDTH`). The DRAM path auto-determines a shard layout when `shard_layout` is unset, so `auto_shard` / `shard_layout=None` callers still work. `DRAM_HEIGHT` is rejected only when requested explicitly.
2. **4D weight reshape.** The DRAM auto-shard path reads `weight.logical_shape()[3]` before weights are prepared; the 3D conv1d weight `[out, in/groups, K]` is reinterpreted as 4D `[.., 1, K]` up front.
3. **Depthwise CB deadlock.** The depthwise compute kernel tilized `in0_num_subblocks` tile-rows but the MAC consumed the full block; they mismatch when `out_subblock_h_ntiles > 1`, deadlocking the activation CB. Tilize the full block height instead.

### Tests (`test_conv1d.py`)
Each regression was confirmed to **fail on the unfixed code** (OOM / `ShapeBase index out of range` / hang) and pass with the fix:
- `test_conv1d_default_route_long_seq`, `_auto_shard` — fix 1 (OOM without it)
- `test_conv1d_default_route_l1_input_stays_l1` — guard that L1 inputs aren't re-routed
- `test_conv1d_depthwise_dram_slice_auto_shard` — fix 2 (4D weight)
- `test_conv1d_depthwise_subblock_deadlock` — fix 3 (deadlock)
- `test_conv1d_depthwise_default_route_long_seq` (slow) — real ~29k vocoder tail, all three end-to-end

Also migrated this file's three pre-existing `pytest.raises` calls to the `expect_error` fixture (required by the `prefer-expect-error` hook once the file is touched).

## Test plan
All new + migrated tests pass on Wormhole via `scripts/run_safe_pytest.sh`. Negative-control (reverting the C++ fix) confirms each test catches its regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mstaletovic/conv1d-op-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mstaletovic/conv1d-op-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mstaletovic/conv1d-op-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mstaletovic/conv1d-op-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mstaletovic/conv1d-op-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mstaletovic/conv1d-op-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mstaletovic/conv1d-op-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mstaletovic/conv1d-op-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mstaletovic/conv1d-op-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mstaletovic/conv1d-op-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mstaletovic/conv1d-op-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mstaletovic/conv1d-op-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mstaletovic/conv1d-op-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mstaletovic/conv1d-op-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mstaletovic/conv1d-op-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mstaletovic/conv1d-op-fix)
### Manually dispatched runs (specific run IDs)

| Pipeline | Coverage | Run |
| --- | --- | --- |
| Sanity tests | ttnn unit tests incl. `test_conv1d.py` (WH) | https://github.com/tenstorrent/tt-metal/actions/runs/28098480287 |
| Blackhole post-commit | ttnn unit tests incl. `test_conv1d.py` (BH) | https://github.com/tenstorrent/tt-metal/actions/runs/28098481996 |
| L2 nightly (`conv`) | full conv unit/regression suite, WH + BH | https://github.com/tenstorrent/tt-metal/actions/runs/28104986264 |
| Device perf (single-card) | squeezebert device-perf (conv1d caller) | https://github.com/tenstorrent/tt-metal/actions/runs/28098483740 |
| Model perf (single-card) | model perf regressions | https://github.com/tenstorrent/tt-metal/actions/runs/28098485529 |
| T3K Models E2E (`mamba-2.8b`) | mamba conv1d caller (T3000) | https://github.com/tenstorrent/tt-metal/actions/runs/28100048075 |

Note: the Model-perf failure is an unrelated `bert11_Large` timing regression (BERT-large uses no conv) on a tight tolerance, not caused by this change.

