### PR TITLE
[Models CI][Tier 3] Falcon-40B tests: fix transformers 5.x silent weight-load failure (PCC/NaN) — #47924

### DIFF
--- a/models/demos/t3000/falcon40b/reference/hf_modeling_falcon.py
+++ b/models/demos/t3000/falcon40b/reference/hf_modeling_falcon.py
@@ -941,7 +941,9 @@ class FalconModel(FalconPreTrainedModel):
 # transformers 5.x: PreTrainedModel no longer inherits GenerationMixin, so models
 # that call .generate() must inherit it explicitly (harmless/redundant on <5.x).
 class FalconForCausalLM(FalconPreTrainedModel, GenerationMixin):
-    _tied_weights_keys = ["lm_head.weight"]
+    # transformers 5.x requires the dict form ({tied_key: source_key}); the legacy list form
+    # raises `'list' object has no attribute 'keys'` during post_init/tie_weights (#47924).
+    _tied_weights_keys = {"lm_head.weight": "transformer.word_embeddings.weight"}
 
     def __init__(self, config: FalconConfig):
         super().__init__(config)

--- a/models/demos/t3000/falcon40b/tests/test_falcon_attention.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_attention.py
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 from pathlib import Path
 
 import pytest
@@ -11,7 +10,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import nearest_32
-from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import FalconForCausalLM
+from models.demos.t3000.falcon40b.tests.test_utils import load_falcon_reference_model
 from models.demos.t3000.falcon40b.tt.falcon_attention import TtFalconAttention
 from models.demos.t3000.falcon40b.tt.falcon_ccl import TT_CCL
 from models.demos.t3000.falcon40b.tt.model_config import get_model_config
@@ -52,15 +51,7 @@ def run_test_FalconAttention_inference(
     model_config,
     tt_cache_path,
 ):
-    hugging_face_reference_model = FalconForCausalLM.from_pretrained(
-        model_version, local_files_only=os.getenv("CI") == "true", low_cpu_mem_usage=True, num_hidden_layers=1
-    )
-    # transformers v5 loads from_pretrained in the checkpoint dtype (bf16 for Falcon-40B);
-    # force float32 so the CPU reference matches the float32 test inputs (avoids
-    # "mixed dtype (CPU)" LayerNorm errors). Restores the pre-v5 default; mirrors the
-    # .to(torch.float32) fix applied to the falcon7b tests in #47218.
-    hugging_face_reference_model = hugging_face_reference_model.to(torch.float32)
-    hugging_face_reference_model.eval()
+    hugging_face_reference_model = load_falcon_reference_model(model_version, num_hidden_layers=1)
     configuration = hugging_face_reference_model.config
     state_dict = hugging_face_reference_model.state_dict()
     use_cache = True

--- a/models/demos/t3000/falcon40b/tests/test_falcon_attention.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_attention.py
@@ -55,6 +55,11 @@ def run_test_FalconAttention_inference(
     hugging_face_reference_model = FalconForCausalLM.from_pretrained(
         model_version, local_files_only=os.getenv("CI") == "true", low_cpu_mem_usage=True, num_hidden_layers=1
     )
+    # transformers v5 loads from_pretrained in the checkpoint dtype (bf16 for Falcon-40B);
+    # force float32 so the CPU reference matches the float32 test inputs (avoids
+    # "mixed dtype (CPU)" LayerNorm errors). Restores the pre-v5 default; mirrors the
+    # .to(torch.float32) fix applied to the falcon7b tests in #47218.
+    hugging_face_reference_model = hugging_face_reference_model.to(torch.float32)
     hugging_face_reference_model.eval()
     configuration = hugging_face_reference_model.config
     state_dict = hugging_face_reference_model.state_dict()

--- a/models/demos/t3000/falcon40b/tests/test_falcon_causallm.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_causallm.py
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 from pathlib import Path
 
 import pytest
@@ -10,7 +9,7 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import FalconForCausalLM
+from models.demos.t3000.falcon40b.tests.test_utils import load_falcon_reference_model
 from models.demos.t3000.falcon40b.tt.falcon_causallm import TtFalconCausalLM
 from models.demos.t3000.falcon40b.tt.model_config import get_model_config
 from models.tt_transformers.tt.common import get_hf_tt_cache_path
@@ -52,16 +51,7 @@ def run_test_FalconCausalLM_inference(
     model_config,
     tt_cache_path,
 ):
-    hugging_face_reference_model = FalconForCausalLM.from_pretrained(
-        model_version, local_files_only=os.getenv("CI") == "true", low_cpu_mem_usage=True, num_hidden_layers=num_layers
-    )
-
-    # transformers v5 loads from_pretrained in the checkpoint dtype (bf16 for Falcon-40B);
-    # force float32 so the CPU reference matches the float32 test inputs (avoids
-    # "mixed dtype (CPU)" LayerNorm errors). Restores the pre-v5 default; mirrors the
-    # .to(torch.float32) fix applied to the falcon7b tests in #47218.
-    hugging_face_reference_model = hugging_face_reference_model.to(torch.float32)
-    hugging_face_reference_model.eval()
+    hugging_face_reference_model = load_falcon_reference_model(model_version, num_hidden_layers=num_layers)
     configuration = hugging_face_reference_model.config
     state_dict = hugging_face_reference_model.state_dict()
 

--- a/models/demos/t3000/falcon40b/tests/test_falcon_causallm.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_causallm.py
@@ -56,6 +56,11 @@ def run_test_FalconCausalLM_inference(
         model_version, local_files_only=os.getenv("CI") == "true", low_cpu_mem_usage=True, num_hidden_layers=num_layers
     )
 
+    # transformers v5 loads from_pretrained in the checkpoint dtype (bf16 for Falcon-40B);
+    # force float32 so the CPU reference matches the float32 test inputs (avoids
+    # "mixed dtype (CPU)" LayerNorm errors). Restores the pre-v5 default; mirrors the
+    # .to(torch.float32) fix applied to the falcon7b tests in #47218.
+    hugging_face_reference_model = hugging_face_reference_model.to(torch.float32)
     hugging_face_reference_model.eval()
     configuration = hugging_face_reference_model.config
     state_dict = hugging_face_reference_model.state_dict()

--- a/models/demos/t3000/falcon40b/tests/test_falcon_decoder.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_decoder.py
@@ -271,34 +271,6 @@ def run_test_FalconDecoder_inference(
         ).flatten(0, 1),
     )
 
-    # === FALCON-DIAG (transformers 5.x NaN investigation, #47924) — temporary, remove after diagnosis ===
-    def _falcon_diag(name, t):
-        t = t.detach().float()
-        nan = int(torch.isnan(t).sum())
-        tot = int(t.numel())
-        finite = t[torch.isfinite(t)]
-        logger.info(
-            f"FALCON-DIAG {name}: shape={tuple(t.shape)} nan={nan}/{tot} all_nan={nan == tot} "
-            f"finite_min={finite.min().item() if finite.numel() else 'NA'} "
-            f"finite_max={finite.max().item() if finite.numel() else 'NA'}"
-        )
-
-    logger.info(
-        "FALCON-DIAG config: "
-        f"new_decoder_architecture={getattr(configuration, 'new_decoder_architecture', None)} "
-        f"parallel_attn={getattr(configuration, 'parallel_attn', None)} "
-        f"multi_query={getattr(configuration, 'multi_query', None)} "
-        f"num_kv_heads={getattr(configuration, 'num_kv_heads', None)} "
-        f"num_attention_heads={getattr(configuration, 'num_attention_heads', None)} "
-        f"hidden_size={getattr(configuration, 'hidden_size', None)} "
-        f"rope_theta={getattr(configuration, 'rope_theta', None)} "
-        f"bias={getattr(configuration, 'bias', None)} "
-        f"attn_impl={getattr(configuration, '_attn_implementation', None)}"
-    )
-    _falcon_diag("pytorch_out(ref)", pytorch_out)
-    _falcon_diag("tt_out_tensor", tt_out_tensor)
-    # === end FALCON-DIAG ===
-
     # check outputs ----------------------------------------------------------------------
     does_pass, output_pcc = comp_pcc(pytorch_out, tt_out_tensor, out_pcc)
     logger.info(f"Output: {output_pcc}")

--- a/models/demos/t3000/falcon40b/tests/test_falcon_decoder.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_decoder.py
@@ -10,7 +10,7 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import FalconForCausalLM
+from models.demos.t3000.falcon40b.tests.test_utils import load_falcon_reference_model
 from models.demos.t3000.falcon40b.tt.falcon_ccl import TT_CCL
 from models.demos.t3000.falcon40b.tt.falcon_decoder import TtFalconDecoderLayer
 from models.demos.t3000.falcon40b.tt.model_config import get_model_config
@@ -53,18 +53,7 @@ def run_test_FalconDecoder_inference(
     model_config,
     tt_cache_path,
 ):
-    hugging_face_reference_model = FalconForCausalLM.from_pretrained(
-        model_version,
-        local_files_only=os.getenv("CI") == "true",
-        low_cpu_mem_usage=True,
-        num_hidden_layers=layer_num + 1,
-    )
-    # transformers v5 defaults from_pretrained to dtype="auto", loading weights in the
-    # checkpoint dtype (bfloat16 for Falcon-40B). The CPU reference (incl. LayerNorm) is
-    # compared against float32 test inputs, so force float32 to match — restoring the
-    # pre-v5 default and avoiding "mixed dtype (CPU): expect parameter ... Float" errors.
-    hugging_face_reference_model = hugging_face_reference_model.to(torch.float32)
-    hugging_face_reference_model.eval()
+    hugging_face_reference_model = load_falcon_reference_model(model_version, num_hidden_layers=layer_num + 1)
     configuration = hugging_face_reference_model.config
     state_dict = hugging_face_reference_model.state_dict()
 
@@ -387,7 +376,17 @@ def run_test_FalconDecoder_inference(
     ids=["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED", "BFLOAT8_B-DRAM", "BFLOAT16-DRAM"],
 )
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
-@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
+@pytest.mark.parametrize(
+    "mesh_device",
+    # Falcon-40B requires 8 chips. On a >8-chip machine (e.g. WH LLMBox with 16),
+    # force a (1, 8) submesh via `export MESH_DEVICE=T3K`. Defaults to (1, 8).
+    [
+        {
+            "T3K": (1, 8),
+        }.get(os.environ.get("MESH_DEVICE"), (1, 8))
+    ],
+    indirect=True,
+)
 def test_FalconDecoder_inference(
     num_devices,
     model_version,

--- a/models/demos/t3000/falcon40b/tests/test_falcon_decoder.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_decoder.py
@@ -282,6 +282,34 @@ def run_test_FalconDecoder_inference(
         ).flatten(0, 1),
     )
 
+    # === FALCON-DIAG (transformers 5.x NaN investigation, #47924) — temporary, remove after diagnosis ===
+    def _falcon_diag(name, t):
+        t = t.detach().float()
+        nan = int(torch.isnan(t).sum())
+        tot = int(t.numel())
+        finite = t[torch.isfinite(t)]
+        logger.info(
+            f"FALCON-DIAG {name}: shape={tuple(t.shape)} nan={nan}/{tot} all_nan={nan == tot} "
+            f"finite_min={finite.min().item() if finite.numel() else 'NA'} "
+            f"finite_max={finite.max().item() if finite.numel() else 'NA'}"
+        )
+
+    logger.info(
+        "FALCON-DIAG config: "
+        f"new_decoder_architecture={getattr(configuration, 'new_decoder_architecture', None)} "
+        f"parallel_attn={getattr(configuration, 'parallel_attn', None)} "
+        f"multi_query={getattr(configuration, 'multi_query', None)} "
+        f"num_kv_heads={getattr(configuration, 'num_kv_heads', None)} "
+        f"num_attention_heads={getattr(configuration, 'num_attention_heads', None)} "
+        f"hidden_size={getattr(configuration, 'hidden_size', None)} "
+        f"rope_theta={getattr(configuration, 'rope_theta', None)} "
+        f"bias={getattr(configuration, 'bias', None)} "
+        f"attn_impl={getattr(configuration, '_attn_implementation', None)}"
+    )
+    _falcon_diag("pytorch_out(ref)", pytorch_out)
+    _falcon_diag("tt_out_tensor", tt_out_tensor)
+    # === end FALCON-DIAG ===
+
     # check outputs ----------------------------------------------------------------------
     does_pass, output_pcc = comp_pcc(pytorch_out, tt_out_tensor, out_pcc)
     logger.info(f"Output: {output_pcc}")

--- a/models/demos/t3000/falcon40b/tests/test_falcon_decoder.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_decoder.py
@@ -59,6 +59,11 @@ def run_test_FalconDecoder_inference(
         low_cpu_mem_usage=True,
         num_hidden_layers=layer_num + 1,
     )
+    # transformers v5 defaults from_pretrained to dtype="auto", loading weights in the
+    # checkpoint dtype (bfloat16 for Falcon-40B). The CPU reference (incl. LayerNorm) is
+    # compared against float32 test inputs, so force float32 to match — restoring the
+    # pre-v5 default and avoiding "mixed dtype (CPU): expect parameter ... Float" errors.
+    hugging_face_reference_model = hugging_face_reference_model.to(torch.float32)
     hugging_face_reference_model.eval()
     configuration = hugging_face_reference_model.config
     state_dict = hugging_face_reference_model.state_dict()

--- a/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
@@ -43,6 +43,11 @@ def run_test_FalconCausalLM_end_to_end(
     hugging_face_reference_model = FalconForCausalLM.from_pretrained(
         model_version, local_files_only=os.getenv("CI") == "true", low_cpu_mem_usage=True, num_hidden_layers=num_layers
     )
+    # transformers v5 loads from_pretrained in the checkpoint dtype (bf16 for Falcon-40B);
+    # force float32 so the CPU reference matches the float32 test inputs (avoids
+    # "mixed dtype (CPU)" LayerNorm errors). Restores the pre-v5 default; mirrors the
+    # .to(torch.float32) fix applied to the falcon7b tests in #47218.
+    hugging_face_reference_model = hugging_face_reference_model.to(torch.float32)
     hugging_face_reference_model.eval()
     configuration = hugging_face_reference_model.config
     state_dict = hugging_face_reference_model.state_dict()

--- a/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 from pathlib import Path
 
 import pytest
@@ -11,7 +10,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import profiler
-from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import FalconForCausalLM
+from models.demos.t3000.falcon40b.tests.test_utils import load_falcon_reference_model
 from models.demos.t3000.falcon40b.tt.falcon_causallm import TtFalconCausalLM
 from models.demos.t3000.falcon40b.tt.falcon_common import PytorchFalconCausalLM
 from models.demos.t3000.falcon40b.tt.model_config import get_model_config
@@ -40,15 +39,7 @@ def run_test_FalconCausalLM_end_to_end(
     profiler.clear()
 
     profiler.start("hugging_face_model_setup")
-    hugging_face_reference_model = FalconForCausalLM.from_pretrained(
-        model_version, local_files_only=os.getenv("CI") == "true", low_cpu_mem_usage=True, num_hidden_layers=num_layers
-    )
-    # transformers v5 loads from_pretrained in the checkpoint dtype (bf16 for Falcon-40B);
-    # force float32 so the CPU reference matches the float32 test inputs (avoids
-    # "mixed dtype (CPU)" LayerNorm errors). Restores the pre-v5 default; mirrors the
-    # .to(torch.float32) fix applied to the falcon7b tests in #47218.
-    hugging_face_reference_model = hugging_face_reference_model.to(torch.float32)
-    hugging_face_reference_model.eval()
+    hugging_face_reference_model = load_falcon_reference_model(model_version, num_hidden_layers=num_layers)
     configuration = hugging_face_reference_model.config
     state_dict = hugging_face_reference_model.state_dict()
     pytorch_FalconCausalLM = PytorchFalconCausalLM(hugging_face_reference_model, num_layers)

--- a/models/demos/t3000/falcon40b/tests/test_falcon_mlp.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_mlp.py
@@ -45,6 +45,11 @@ def run_test_FalconMLP_inference(
     hugging_face_reference_model = FalconForCausalLM.from_pretrained(
         model_version, local_files_only=os.getenv("CI") == "true", low_cpu_mem_usage=True, num_hidden_layers=1
     )
+    # transformers v5 loads from_pretrained in the checkpoint dtype (bf16 for Falcon-40B);
+    # force float32 so the CPU reference matches the float32 test inputs (avoids
+    # "mixed dtype (CPU)" LayerNorm errors). Restores the pre-v5 default; mirrors the
+    # .to(torch.float32) fix applied to the falcon7b tests in #47218.
+    hugging_face_reference_model = hugging_face_reference_model.to(torch.float32)
     hugging_face_reference_model.eval()
     configuration = hugging_face_reference_model.config
     state_dict = hugging_face_reference_model.state_dict()

--- a/models/demos/t3000/falcon40b/tests/test_falcon_mlp.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_mlp.py
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 from pathlib import Path
 
 import pytest
@@ -10,7 +9,7 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import FalconForCausalLM
+from models.demos.t3000.falcon40b.tests.test_utils import load_falcon_reference_model
 from models.demos.t3000.falcon40b.tt.falcon_ccl import TT_CCL
 from models.demos.t3000.falcon40b.tt.falcon_mlp import TtFalconMLP
 from models.demos.t3000.falcon40b.tt.model_config import get_model_config
@@ -42,15 +41,7 @@ def run_test_FalconMLP_inference(
     model_config,
     tt_cache_path,
 ):
-    hugging_face_reference_model = FalconForCausalLM.from_pretrained(
-        model_version, local_files_only=os.getenv("CI") == "true", low_cpu_mem_usage=True, num_hidden_layers=1
-    )
-    # transformers v5 loads from_pretrained in the checkpoint dtype (bf16 for Falcon-40B);
-    # force float32 so the CPU reference matches the float32 test inputs (avoids
-    # "mixed dtype (CPU)" LayerNorm errors). Restores the pre-v5 default; mirrors the
-    # .to(torch.float32) fix applied to the falcon7b tests in #47218.
-    hugging_face_reference_model = hugging_face_reference_model.to(torch.float32)
-    hugging_face_reference_model.eval()
+    hugging_face_reference_model = load_falcon_reference_model(model_version, num_hidden_layers=1)
     configuration = hugging_face_reference_model.config
     state_dict = hugging_face_reference_model.state_dict()
 

--- a/models/demos/t3000/falcon40b/tests/test_falcon_model.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_model.py
@@ -7,7 +7,7 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import FalconForCausalLM
+from models.demos.t3000.falcon40b.tests.test_utils import load_falcon_reference_model
 from models.demos.t3000.falcon40b.tt.falcon_model import TtFalconModel
 from models.demos.t3000.falcon40b.tt.model_config import get_model_config
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
@@ -49,15 +49,7 @@ def run_test_FalconModel_inference(
 ):
     model_name = model_location_generator(model_version, model_subdir="Falcon")
 
-    hugging_face_reference_model = FalconForCausalLM.from_pretrained(
-        model_name, low_cpu_mem_usage=True, num_hidden_layers=num_layers
-    )
-    # transformers v5 loads from_pretrained in the checkpoint dtype (bf16 for Falcon-40B);
-    # force float32 so the CPU reference matches the float32 test inputs (avoids
-    # "mixed dtype (CPU)" LayerNorm errors). Restores the pre-v5 default; mirrors the
-    # .to(torch.float32) fix applied to the falcon7b tests in #47218.
-    hugging_face_reference_model = hugging_face_reference_model.to(torch.float32)
-    hugging_face_reference_model.eval()
+    hugging_face_reference_model = load_falcon_reference_model(model_name, num_hidden_layers=num_layers)
     configuration = hugging_face_reference_model.config
     state_dict = hugging_face_reference_model.state_dict()
 

--- a/models/demos/t3000/falcon40b/tests/test_falcon_model.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_model.py
@@ -52,6 +52,11 @@ def run_test_FalconModel_inference(
     hugging_face_reference_model = FalconForCausalLM.from_pretrained(
         model_name, low_cpu_mem_usage=True, num_hidden_layers=num_layers
     )
+    # transformers v5 loads from_pretrained in the checkpoint dtype (bf16 for Falcon-40B);
+    # force float32 so the CPU reference matches the float32 test inputs (avoids
+    # "mixed dtype (CPU)" LayerNorm errors). Restores the pre-v5 default; mirrors the
+    # .to(torch.float32) fix applied to the falcon7b tests in #47218.
+    hugging_face_reference_model = hugging_face_reference_model.to(torch.float32)
     hugging_face_reference_model.eval()
     configuration = hugging_face_reference_model.config
     state_dict = hugging_face_reference_model.state_dict()

--- a/models/demos/t3000/falcon40b/tests/test_falcon_prefill_determinism.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_prefill_determinism.py
@@ -33,6 +33,11 @@ def run_test_falcon_prefill_end_to_end_determinism(
         hugging_face_reference_model = FalconForCausalLM.from_pretrained(
             model_name, low_cpu_mem_usage=True, num_hidden_layers=num_layers
         )
+        # transformers v5 loads from_pretrained in the checkpoint dtype (bf16 for Falcon-40B);
+        # force float32 so the CPU reference matches the float32 test inputs (avoids
+        # "mixed dtype (CPU)" LayerNorm errors). Restores the pre-v5 default; mirrors the
+        # .to(torch.float32) fix applied to the falcon7b tests in #47218.
+        hugging_face_reference_model = hugging_face_reference_model.to(torch.float32)
         hugging_face_reference_model.eval()
         configuration = hugging_face_reference_model.config
         state_dict = hugging_face_reference_model.state_dict()

--- a/models/demos/t3000/falcon40b/tests/test_falcon_prefill_determinism.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_prefill_determinism.py
@@ -7,7 +7,8 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import FalconConfig, FalconForCausalLM
+from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import FalconConfig
+from models.demos.t3000.falcon40b.tests.test_utils import load_falcon_reference_model
 from models.demos.t3000.falcon40b.tt.falcon_causallm import TtFalconCausalLM
 from models.demos.t3000.falcon40b.tt.model_config import get_model_config, model_config_entries
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
@@ -30,15 +31,7 @@ def run_test_falcon_prefill_end_to_end_determinism(
     if generate_weights:
         logger.info("Loading PyTorch Falcon model...")
         model_name = model_location_generator(model_version, model_subdir="Falcon")
-        hugging_face_reference_model = FalconForCausalLM.from_pretrained(
-            model_name, low_cpu_mem_usage=True, num_hidden_layers=num_layers
-        )
-        # transformers v5 loads from_pretrained in the checkpoint dtype (bf16 for Falcon-40B);
-        # force float32 so the CPU reference matches the float32 test inputs (avoids
-        # "mixed dtype (CPU)" LayerNorm errors). Restores the pre-v5 default; mirrors the
-        # .to(torch.float32) fix applied to the falcon7b tests in #47218.
-        hugging_face_reference_model = hugging_face_reference_model.to(torch.float32)
-        hugging_face_reference_model.eval()
+        hugging_face_reference_model = load_falcon_reference_model(model_name, num_hidden_layers=num_layers)
         configuration = hugging_face_reference_model.config
         state_dict = hugging_face_reference_model.state_dict()
         logger.info("Done loading PyTorch Falcon model")

--- a/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
+++ b/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
@@ -45,6 +45,11 @@ def run_test_FalconCausalLM_end_to_end(
     hugging_face_reference_model = FalconForCausalLM.from_pretrained(
         model_version, local_files_only=is_ci_env, low_cpu_mem_usage=True, num_hidden_layers=num_layers
     )
+    # transformers v5 loads from_pretrained in the checkpoint dtype (bf16 for Falcon-40B);
+    # force float32 so the CPU reference matches the float32 test inputs (avoids
+    # "mixed dtype (CPU)" LayerNorm errors). Restores the pre-v5 default; mirrors the
+    # .to(torch.float32) fix applied to the falcon7b tests in #47218.
+    hugging_face_reference_model = hugging_face_reference_model.to(torch.float32)
     hugging_face_reference_model.eval()
     configuration = hugging_face_reference_model.config
     state_dict = hugging_face_reference_model.state_dict()

--- a/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
+++ b/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
@@ -10,7 +10,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import profiler
-from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import FalconForCausalLM
+from models.demos.t3000.falcon40b.tests.test_utils import load_falcon_reference_model
 from models.demos.t3000.falcon40b.tt.falcon_causallm import TtFalconCausalLM
 from models.demos.t3000.falcon40b.tt.model_config import get_model_config
 from models.perf.perf_utils import prep_perf_report
@@ -42,15 +42,7 @@ def run_test_FalconCausalLM_end_to_end(
     profiler.clear()
 
     profiler.start("hugging_face_model_setup")
-    hugging_face_reference_model = FalconForCausalLM.from_pretrained(
-        model_version, local_files_only=is_ci_env, low_cpu_mem_usage=True, num_hidden_layers=num_layers
-    )
-    # transformers v5 loads from_pretrained in the checkpoint dtype (bf16 for Falcon-40B);
-    # force float32 so the CPU reference matches the float32 test inputs (avoids
-    # "mixed dtype (CPU)" LayerNorm errors). Restores the pre-v5 default; mirrors the
-    # .to(torch.float32) fix applied to the falcon7b tests in #47218.
-    hugging_face_reference_model = hugging_face_reference_model.to(torch.float32)
-    hugging_face_reference_model.eval()
+    hugging_face_reference_model = load_falcon_reference_model(model_version, num_hidden_layers=num_layers)
     configuration = hugging_face_reference_model.config
     state_dict = hugging_face_reference_model.state_dict()
     profiler.end("hugging_face_model_setup")

--- a/models/demos/t3000/falcon40b/tests/test_utils.py
+++ b/models/demos/t3000/falcon40b/tests/test_utils.py
@@ -93,6 +93,7 @@ def _native_falcon_state_dict(model_version, num_hidden_layers):
     return state_dict
 
 
+@lru_cache(maxsize=1)
 def load_falcon_reference_model(model_version, num_hidden_layers=None):
     """Load the vendored Falcon CPU reference with weights correctly populated, as float32.
 
@@ -104,6 +105,10 @@ def load_falcon_reference_model(model_version, num_hidden_layers=None):
     ``tie_weights`` restores ``lm_head`` if the checkpoint ties it to the input embeddings; it is
     a no-op for the (untied) falcon-40b checkpoint. The final ``.to(torch.float32)`` matches the
     float32 test inputs (avoids "mixed dtype (CPU)" LayerNorm errors).
+
+    Cached (the reference is used read-only): constructing the model re-initialises the large
+    embedding/lm_head tensors, so rebuilding it for every parametrization made the decoder sweep
+    exceed its step timeout. Building once and reusing it keeps the sweep within budget.
     """
     ci = os.getenv("CI") == "true"
     config_kwargs = {"local_files_only": ci}

--- a/models/demos/t3000/falcon40b/tests/test_utils.py
+++ b/models/demos/t3000/falcon40b/tests/test_utils.py
@@ -3,66 +3,123 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import gc
+import json
 import os
+import re
 from functools import lru_cache
 
 import torch
+from safetensors import safe_open
+from transformers.utils import cached_file
 
+from models.demos.t3000.falcon40b.reference.hf_configuration_falcon import FalconConfig
 from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import FalconForCausalLM
 
 
 @lru_cache(maxsize=1)
-def _correct_falcon_state_dict(model_version, num_hidden_layers):
-    """Load the upstream ``transformers.FalconForCausalLM`` ONCE and cache its correctly-populated
-    ``state_dict`` (cloned to standalone CPU tensors so the upstream model object can be freed).
+def _native_falcon_state_dict(model_version, num_hidden_layers):
+    """Read the pretrained Falcon weights straight from the checkpoint shards, in their native
+    layout, keeping only the tensors for the requested number of layers.
 
-    The original #47924 fix loaded the upstream model on *every* call, alongside the vendored
-    model. Over the parametrized decoder sweep (~10 params) that allocated/freed two full Falcon
-    models per param; host RAM accumulated and the silent weight-load failure *re-triggered* on
-    later params, making the reference go all-NaN (validation run 28180413545: param 1 finite /
-    PCC 0.996, params 2+ ``all_nan=True``). Caching materializes the upstream weights exactly once.
+    Why not ``from_pretrained`` (see issue #47924):
+      * Loading the checkpoint through the *vendored* ``hf_modeling_falcon.FalconForCausalLM``
+        silently leaves every parameter at its init value under transformers 5.x —
+        ``from_pretrained`` reports ``missing_keys=0`` but copies nothing.
+      * Loading through the *upstream* ``transformers.FalconForCausalLM`` does populate the
+        weights, but it applies a rotary-layout transform to the Q/K rows of the fused
+        ``query_key_value`` weight (the V rows are left untouched) to match upstream's rotary.
+        Copying that ``state_dict`` into the vendored reference — whose ``rotate_half`` expects
+        the *native* checkpoint layout — produces a correct output and V-cache but a wrong
+        K-cache (K-cache PCC collapses while V-cache stays ~1.0).
+
+    Reading the raw checkpoint tensors avoids both problems and reproduces the
+    pre-transformers-5.x (native) behavior the TT model is validated against. Only the tensors
+    for ``num_hidden_layers`` layers are read, so the single-layer decoder test stays cheap.
     """
-    from transformers import FalconForCausalLM as UpstreamFalconForCausalLM
+    ci = os.getenv("CI") == "true"
 
-    kwargs = dict(local_files_only=os.getenv("CI") == "true", low_cpu_mem_usage=True)
-    if num_hidden_layers is not None:
-        kwargs["num_hidden_layers"] = num_hidden_layers
+    def want(key):
+        m = re.match(r"transformer\.h\.(\d+)\.", key)
+        if m:
+            return num_hidden_layers is None or int(m.group(1)) < num_hidden_layers
+        return True
 
-    upstream_model = UpstreamFalconForCausalLM.from_pretrained(model_version, **kwargs)
-    state_dict = {k: v.detach().clone() for k, v in upstream_model.state_dict().items()}
-    del upstream_model
-    gc.collect()
+    state_dict = {}
+
+    def _resolve(filename):
+        try:
+            return cached_file(model_version, filename, local_files_only=ci)
+        except Exception:
+            return None
+
+    def _add_safetensors(path, keys):
+        with safe_open(path, framework="pt") as f:
+            available = set(f.keys())
+            for k in available if keys is None else keys:
+                if k in available and want(k):
+                    state_dict[k] = f.get_tensor(k)
+
+    # Prefer safetensors (sharded, then single); fall back to pickled .bin.
+    index_path = _resolve("model.safetensors.index.json")
+    if index_path is not None:
+        weight_map = json.load(open(index_path))["weight_map"]
+        shard_to_keys = {}
+        for k in weight_map:
+            if want(k):
+                shard_to_keys.setdefault(weight_map[k], []).append(k)
+        for shard, keys in shard_to_keys.items():
+            _add_safetensors(cached_file(model_version, shard, local_files_only=ci), keys)
+        return state_dict
+
+    single = _resolve("model.safetensors")
+    if single is not None:
+        _add_safetensors(single, None)
+        return state_dict
+
+    bin_index = _resolve("pytorch_model.bin.index.json")
+    if bin_index is not None:
+        weight_map = json.load(open(bin_index))["weight_map"]
+        for shard in {weight_map[k] for k in weight_map if want(k)}:
+            shard_sd = torch.load(
+                cached_file(model_version, shard, local_files_only=ci), map_location="cpu", weights_only=True
+            )
+            state_dict.update({k: v for k, v in shard_sd.items() if want(k)})
+        return state_dict
+
+    bin_sd = torch.load(
+        cached_file(model_version, "pytorch_model.bin", local_files_only=ci), map_location="cpu", weights_only=True
+    )
+    state_dict.update({k: v for k, v in bin_sd.items() if want(k)})
     return state_dict
 
 
 def load_falcon_reference_model(model_version, num_hidden_layers=None):
     """Load the vendored Falcon CPU reference with weights correctly populated, as float32.
 
-    transformers 5.x silently fails to load the pretrained weights into the vendored
-    ``hf_modeling_falcon`` model: layer params are left at their init values (LayerNorm = 1.0,
-    Linear = random) while ``from_pretrained`` reports ``missing_keys=0`` (no error), which makes
-    the reference — and the TT model, which is built from the same ``state_dict`` — produce
-    NaN / ~0-PCC output. See issue #47924. The upstream ``transformers.FalconForCausalLM`` loads
-    the *identical* checkpoint and key names correctly, so we copy its ``state_dict`` (loaded once
-    and cached, see ``_correct_falcon_state_dict``) into the vendored model. The copy happens in
-    the checkpoint dtype (bf16) before the float32 upcast, so peak host memory is bounded.
+    Weights are read straight from the checkpoint in their native layout (see
+    ``_native_falcon_state_dict`` and #47924) and copied into a freshly constructed vendored
+    model via ``load_state_dict``, since transformers 5.x ``from_pretrained`` silently fails to
+    populate the vendored model and the upstream model rewrites the Q/K rotary layout.
 
-    The final ``.to(torch.float32)`` matches the float32 test inputs (avoids "mixed dtype (CPU)"
-    LayerNorm errors) and mirrors the dtype fix from #47218 / #47929.
+    ``tie_weights`` restores ``lm_head`` if the checkpoint ties it to the input embeddings; it is
+    a no-op for the (untied) falcon-40b checkpoint. The final ``.to(torch.float32)`` matches the
+    float32 test inputs (avoids "mixed dtype (CPU)" LayerNorm errors).
     """
-    kwargs = dict(local_files_only=os.getenv("CI") == "true", low_cpu_mem_usage=True)
+    ci = os.getenv("CI") == "true"
+    config_kwargs = {"local_files_only": ci}
     if num_hidden_layers is not None:
-        kwargs["num_hidden_layers"] = num_hidden_layers
+        config_kwargs["num_hidden_layers"] = num_hidden_layers
+    config = FalconConfig.from_pretrained(model_version, **config_kwargs)
 
-    hugging_face_reference_model = FalconForCausalLM.from_pretrained(model_version, **kwargs)
-
-    # Repair the silently-unloaded weights (#47924) from the cached upstream state_dict.
-    hugging_face_reference_model.load_state_dict(_correct_falcon_state_dict(model_version, num_hidden_layers))
+    hugging_face_reference_model = FalconForCausalLM(config)
+    # strict=False: lm_head may be absent from the checkpoint when tied to the input embeddings.
+    hugging_face_reference_model.load_state_dict(
+        _native_falcon_state_dict(model_version, num_hidden_layers), strict=False
+    )
+    hugging_face_reference_model.tie_weights()
 
     hugging_face_reference_model = hugging_face_reference_model.to(torch.float32)
     hugging_face_reference_model.eval()
-
-    # Free the per-param vendored model churn so host RAM stays flat across the param sweep.
     gc.collect()
     return hugging_face_reference_model
 

--- a/models/demos/t3000/falcon40b/tests/test_utils.py
+++ b/models/demos/t3000/falcon40b/tests/test_utils.py
@@ -9,16 +9,42 @@ import torch
 from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import FalconForCausalLM
 
 
-def load_hf_model(model_version):
-    hugging_face_reference_model = FalconForCausalLM.from_pretrained(
-        model_version, local_files_only=os.getenv("CI") == "true", low_cpu_mem_usage=True
-    )
-    # transformers v5 loads from_pretrained in the checkpoint dtype (bf16 for Falcon-40B);
-    # force float32 so the CPU reference matches the float32 test inputs (avoids
-    # "mixed dtype (CPU)" LayerNorm errors). Restores the pre-v5 default; mirrors the
-    # .to(torch.float32) fix applied to the falcon7b tests in #47218.
+def load_falcon_reference_model(model_version, num_hidden_layers=None):
+    """Load the vendored Falcon CPU reference with weights correctly populated, as float32.
+
+    transformers 5.x silently fails to load the pretrained weights into the vendored
+    ``hf_modeling_falcon`` model: layer params are left at their init values (LayerNorm = 1.0,
+    Linear = random) while ``from_pretrained`` reports ``missing_keys=0`` (no error), which makes
+    the reference — and the TT model, which is built from the same ``state_dict`` — produce
+    NaN / ~0-PCC output. See issue #47924. The upstream ``transformers.FalconForCausalLM`` loads
+    the *identical* checkpoint and key names correctly, so we copy its ``state_dict`` into the
+    vendored model. The copy happens in the checkpoint dtype (bf16) and the upstream model is
+    freed before the float32 upcast, so peak host memory is unchanged.
+
+    The final ``.to(torch.float32)`` matches the float32 test inputs (avoids "mixed dtype (CPU)"
+    LayerNorm errors) and mirrors the dtype fix from #47218 / #47929.
+    """
+    from transformers import FalconForCausalLM as UpstreamFalconForCausalLM
+
+    kwargs = dict(local_files_only=os.getenv("CI") == "true", low_cpu_mem_usage=True)
+    if num_hidden_layers is not None:
+        kwargs["num_hidden_layers"] = num_hidden_layers
+
+    hugging_face_reference_model = FalconForCausalLM.from_pretrained(model_version, **kwargs)
+
+    # Repair the silently-unloaded weights (#47924) by copying them from the upstream Falcon
+    # class, which loads the same checkpoint correctly under transformers 5.x.
+    upstream_model = UpstreamFalconForCausalLM.from_pretrained(model_version, **kwargs)
+    hugging_face_reference_model.load_state_dict(upstream_model.state_dict())
+    del upstream_model
+
     hugging_face_reference_model = hugging_face_reference_model.to(torch.float32)
     hugging_face_reference_model.eval()
+    return hugging_face_reference_model
+
+
+def load_hf_model(model_version):
+    hugging_face_reference_model = load_falcon_reference_model(model_version)
     state_dict = hugging_face_reference_model.state_dict()
 
     return hugging_face_reference_model, state_dict

--- a/models/demos/t3000/falcon40b/tests/test_utils.py
+++ b/models/demos/t3000/falcon40b/tests/test_utils.py
@@ -2,11 +2,37 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import gc
 import os
+from functools import lru_cache
 
 import torch
 
 from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import FalconForCausalLM
+
+
+@lru_cache(maxsize=1)
+def _correct_falcon_state_dict(model_version, num_hidden_layers):
+    """Load the upstream ``transformers.FalconForCausalLM`` ONCE and cache its correctly-populated
+    ``state_dict`` (cloned to standalone CPU tensors so the upstream model object can be freed).
+
+    The original #47924 fix loaded the upstream model on *every* call, alongside the vendored
+    model. Over the parametrized decoder sweep (~10 params) that allocated/freed two full Falcon
+    models per param; host RAM accumulated and the silent weight-load failure *re-triggered* on
+    later params, making the reference go all-NaN (validation run 28180413545: param 1 finite /
+    PCC 0.996, params 2+ ``all_nan=True``). Caching materializes the upstream weights exactly once.
+    """
+    from transformers import FalconForCausalLM as UpstreamFalconForCausalLM
+
+    kwargs = dict(local_files_only=os.getenv("CI") == "true", low_cpu_mem_usage=True)
+    if num_hidden_layers is not None:
+        kwargs["num_hidden_layers"] = num_hidden_layers
+
+    upstream_model = UpstreamFalconForCausalLM.from_pretrained(model_version, **kwargs)
+    state_dict = {k: v.detach().clone() for k, v in upstream_model.state_dict().items()}
+    del upstream_model
+    gc.collect()
+    return state_dict
 
 
 def load_falcon_reference_model(model_version, num_hidden_layers=None):
@@ -17,29 +43,27 @@ def load_falcon_reference_model(model_version, num_hidden_layers=None):
     Linear = random) while ``from_pretrained`` reports ``missing_keys=0`` (no error), which makes
     the reference — and the TT model, which is built from the same ``state_dict`` — produce
     NaN / ~0-PCC output. See issue #47924. The upstream ``transformers.FalconForCausalLM`` loads
-    the *identical* checkpoint and key names correctly, so we copy its ``state_dict`` into the
-    vendored model. The copy happens in the checkpoint dtype (bf16) and the upstream model is
-    freed before the float32 upcast, so peak host memory is unchanged.
+    the *identical* checkpoint and key names correctly, so we copy its ``state_dict`` (loaded once
+    and cached, see ``_correct_falcon_state_dict``) into the vendored model. The copy happens in
+    the checkpoint dtype (bf16) before the float32 upcast, so peak host memory is bounded.
 
     The final ``.to(torch.float32)`` matches the float32 test inputs (avoids "mixed dtype (CPU)"
     LayerNorm errors) and mirrors the dtype fix from #47218 / #47929.
     """
-    from transformers import FalconForCausalLM as UpstreamFalconForCausalLM
-
     kwargs = dict(local_files_only=os.getenv("CI") == "true", low_cpu_mem_usage=True)
     if num_hidden_layers is not None:
         kwargs["num_hidden_layers"] = num_hidden_layers
 
     hugging_face_reference_model = FalconForCausalLM.from_pretrained(model_version, **kwargs)
 
-    # Repair the silently-unloaded weights (#47924) by copying them from the upstream Falcon
-    # class, which loads the same checkpoint correctly under transformers 5.x.
-    upstream_model = UpstreamFalconForCausalLM.from_pretrained(model_version, **kwargs)
-    hugging_face_reference_model.load_state_dict(upstream_model.state_dict())
-    del upstream_model
+    # Repair the silently-unloaded weights (#47924) from the cached upstream state_dict.
+    hugging_face_reference_model.load_state_dict(_correct_falcon_state_dict(model_version, num_hidden_layers))
 
     hugging_face_reference_model = hugging_face_reference_model.to(torch.float32)
     hugging_face_reference_model.eval()
+
+    # Free the per-param vendored model churn so host RAM stays flat across the param sweep.
+    gc.collect()
     return hugging_face_reference_model
 
 

--- a/models/demos/t3000/falcon40b/tests/test_utils.py
+++ b/models/demos/t3000/falcon40b/tests/test_utils.py
@@ -4,6 +4,8 @@
 
 import os
 
+import torch
+
 from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import FalconForCausalLM
 
 
@@ -11,6 +13,11 @@ def load_hf_model(model_version):
     hugging_face_reference_model = FalconForCausalLM.from_pretrained(
         model_version, local_files_only=os.getenv("CI") == "true", low_cpu_mem_usage=True
     )
+    # transformers v5 loads from_pretrained in the checkpoint dtype (bf16 for Falcon-40B);
+    # force float32 so the CPU reference matches the float32 test inputs (avoids
+    # "mixed dtype (CPU)" LayerNorm errors). Restores the pre-v5 default; mirrors the
+    # .to(torch.float32) fix applied to the falcon7b tests in #47218.
+    hugging_face_reference_model = hugging_face_reference_model.to(torch.float32)
     hugging_face_reference_model.eval()
     state_dict = hugging_face_reference_model.state_dict()
 

--- a/models/demos/t3000/falcon40b/tests/unit_tests/layernorm/test_falcon_layernorm.py
+++ b/models/demos/t3000/falcon40b/tests/unit_tests/layernorm/test_falcon_layernorm.py
@@ -8,7 +8,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import torch2tt_tensor, tt2torch_tensor
-from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import FalconForCausalLM
+from models.demos.t3000.falcon40b.tests.test_utils import load_falcon_reference_model
 from models.demos.t3000.falcon40b.tt.model_config import get_model_config
 from models.demos.t3000.falcon40b.tt.model_utils import convert_to_layout
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
@@ -148,15 +148,7 @@ def run_test_FalconLayernorm_inference(pcc, device, model_location_generator, ge
 
     model_name = model_location_generator(model_version, model_subdir="Falcon")
 
-    hugging_face_reference_model = FalconForCausalLM.from_pretrained(
-        model_name, low_cpu_mem_usage=True, num_hidden_layers=1
-    )
-    # transformers v5 loads from_pretrained in the checkpoint dtype (bf16 for Falcon-40B);
-    # force float32 so the CPU reference matches the float32 test inputs (avoids
-    # "mixed dtype (CPU)" LayerNorm errors). Restores the pre-v5 default; mirrors the
-    # .to(torch.float32) fix applied to the falcon7b tests in #47218.
-    hugging_face_reference_model = hugging_face_reference_model.to(torch.float32)
-    hugging_face_reference_model.eval()
+    hugging_face_reference_model = load_falcon_reference_model(model_name, num_hidden_layers=1)
     config = hugging_face_reference_model.config
     gamma = hugging_face_reference_model.transformer.h[0].ln_attn.weight
     beta = hugging_face_reference_model.transformer.h[0].ln_attn.bias

--- a/models/demos/t3000/falcon40b/tests/unit_tests/layernorm/test_falcon_layernorm.py
+++ b/models/demos/t3000/falcon40b/tests/unit_tests/layernorm/test_falcon_layernorm.py
@@ -151,6 +151,11 @@ def run_test_FalconLayernorm_inference(pcc, device, model_location_generator, ge
     hugging_face_reference_model = FalconForCausalLM.from_pretrained(
         model_name, low_cpu_mem_usage=True, num_hidden_layers=1
     )
+    # transformers v5 loads from_pretrained in the checkpoint dtype (bf16 for Falcon-40B);
+    # force float32 so the CPU reference matches the float32 test inputs (avoids
+    # "mixed dtype (CPU)" LayerNorm errors). Restores the pre-v5 default; mirrors the
+    # .to(torch.float32) fix applied to the falcon7b tests in #47218.
+    hugging_face_reference_model = hugging_face_reference_model.to(torch.float32)
     hugging_face_reference_model.eval()
     config = hugging_face_reference_model.config
     gamma = hugging_face_reference_model.transformer.h[0].ln_attn.weight

--- a/models/demos/t3000/falcon40b/tests/unit_tests/layernorm/test_fused_falcon_layernorm.py
+++ b/models/demos/t3000/falcon40b/tests/unit_tests/layernorm/test_fused_falcon_layernorm.py
@@ -8,7 +8,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import torch2tt_tensor, tt2torch_tensor
-from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import FalconForCausalLM
+from models.demos.t3000.falcon40b.tests.test_utils import load_falcon_reference_model
 from models.demos.t3000.falcon40b.tt.model_config import get_model_config
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
 
@@ -230,15 +230,7 @@ def run_test_FalconLayernorm_inference(pcc, device, model_location_generator, ge
 
     model_name = model_location_generator(model_version, model_subdir="Falcon")
 
-    hugging_face_reference_model = FalconForCausalLM.from_pretrained(
-        model_name, low_cpu_mem_usage=True, num_hidden_layers=1
-    )
-    # transformers v5 loads from_pretrained in the checkpoint dtype (bf16 for Falcon-40B);
-    # force float32 so the CPU reference matches the float32 test inputs (avoids
-    # "mixed dtype (CPU)" LayerNorm errors). Restores the pre-v5 default; mirrors the
-    # .to(torch.float32) fix applied to the falcon7b tests in #47218.
-    hugging_face_reference_model = hugging_face_reference_model.to(torch.float32)
-    hugging_face_reference_model.eval()
+    hugging_face_reference_model = load_falcon_reference_model(model_name, num_hidden_layers=1)
     config = hugging_face_reference_model.config
     gamma1 = hugging_face_reference_model.transformer.h[0].ln_attn.weight
     beta1 = hugging_face_reference_model.transformer.h[0].ln_attn.bias

--- a/models/demos/t3000/falcon40b/tests/unit_tests/layernorm/test_fused_falcon_layernorm.py
+++ b/models/demos/t3000/falcon40b/tests/unit_tests/layernorm/test_fused_falcon_layernorm.py
@@ -233,6 +233,11 @@ def run_test_FalconLayernorm_inference(pcc, device, model_location_generator, ge
     hugging_face_reference_model = FalconForCausalLM.from_pretrained(
         model_name, low_cpu_mem_usage=True, num_hidden_layers=1
     )
+    # transformers v5 loads from_pretrained in the checkpoint dtype (bf16 for Falcon-40B);
+    # force float32 so the CPU reference matches the float32 test inputs (avoids
+    # "mixed dtype (CPU)" LayerNorm errors). Restores the pre-v5 default; mirrors the
+    # .to(torch.float32) fix applied to the falcon7b tests in #47218.
+    hugging_face_reference_model = hugging_face_reference_model.to(torch.float32)
     hugging_face_reference_model.eval()
     config = hugging_face_reference_model.config
     gamma1 = hugging_face_reference_model.transformer.h[0].ln_attn.weight


### PR DESCRIPTION
## Summary

Fixes the Falcon-40B unit test (`test_falcon_decoder.py`, Tier 3 `wh_llmbox_perf`) which regressed under the transformers 4.53 → 5.10.2 bump (#47218). Tracked in #47924.

The CPU reference path had three coupled problems, all surfaced by transformers 5.x:

1. **Silent weight-load failure.** The vendored `reference/hf_modeling_falcon.py` declared `_tied_weights_keys` in the legacy **list** form (`["lm_head.weight"]`). transformers 5.x requires the **dict** form `{tied_key: source_key}`; the list raises `'list' object has no attribute 'keys'` in `post_init`/`tie_weights`, which on 5.10.2 manifests as `from_pretrained` reporting `missing_keys=0` while copying **no** values (every parameter left at init → NaN / ~0 PCC).

2. **K-cache regression from the upstream-weights workaround.** Populating the reference by copying the *upstream* `transformers.FalconForCausalLM` state_dict works for output and the V-cache, but upstream applies a **rotary-layout transform to the Q/K rows** of the fused `query_key_value` weight (V rows untouched). Copied into the vendored reference — whose `rotate_half` expects the **native** checkpoint layout — this collapses the K-cache PCC (0.9999 → 0.16–0.90; K ATOL 0.198 → 11.69) while output stays ~0.996 (Q·K is preserved). 

3. **Step timeout.** Reading the native checkpoint and constructing the (re-initialised) reference on every parametrization pushed the decoder sweep from ~3 min to the 5-min step timeout.

## Changes

- `reference/hf_modeling_falcon.py`: `_tied_weights_keys` → dict form (transformers 5.x).
- `tests/test_utils.py`: `load_falcon_reference_model` now reads the **raw checkpoint tensors** (native layout) via safetensors + `load_state_dict` into a freshly constructed model — reproducing pre-transformers-5.x behavior the TT model is validated against. Only the requested layers are read (single-layer decoder stays cheap), the read is cached, `tie_weights` restores a tied `lm_head` (no-op for the untied falcon-40b checkpoint), and the read-only reference model is cached so the sweep is built once. `.to(torch.float32)` matches the float32 test inputs.
- All falcon40b test loaders route through `load_falcon_reference_model`; temporary diagnostic instrumentation removed.

## Validation

- Root cause reproduced and the fix validated **locally** on transformers 5.4 with synthetic sharded + tied/untied checkpoints (native Q/K `max|diff|=0`, silent-load reproduced).
- **T3000 CI green:** [run 28233530640](https://github.com/tenstorrent/tt-metal/actions/runs/28233530640) — `8 passed, 8 skipped in 216.62s`; Output ~0.998, K-cache 0.9999, K-cache new-token 0.9998, V-cache 0.9999 across all params (matches the last pre-bump green run).

Resolves #47924.