### PR TITLE
[Cleanup] Migrate moreh compute kernels to Device 2.0 API

### DIFF
--- a/ttnn/cpp/ttnn/kernel/compute/moreh_common.hpp
+++ b/ttnn/cpp/ttnn/kernel/compute/moreh_common.hpp
@@ -21,116 +21,108 @@
 #include "api/compute/mask.h"
 #include "api/compute/reduce.h"
 #include "api/compute/tile_move_copy.h"
-
-// Deprecated
-ALWI void ACQ() {
-    tile_regs_acquire();
-    tile_regs_wait();
-}
-ALWI void REL() {
-    tile_regs_commit();
-    tile_regs_release();
-}
+#include "api/dataflow/circular_buffer.h"
 
 namespace ckernel {
 
-ALWI void pack_tile_with_dt(uint32_t ifrom_dst, uint32_t icb) {
+ALWI void pack_tile_with_dt(uint32_t ifrom_dst, CircularBuffer icb) {
 #if defined FP32_DEST_ACC_EN
-    pack_reconfig_data_format(icb);
+    pack_reconfig_data_format(icb.get_cb_id());
 #endif
-    pack_tile(ifrom_dst, icb);
+    pack_tile(ifrom_dst, icb.get_cb_id());
 }
 
-ALWI void copy_tile_init_with_dt(uint32_t icb, uint32_t transpose = 0) {
+ALWI void copy_tile_init_with_dt(CircularBuffer icb, uint32_t transpose = 0) {
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format_srca(icb);
+    reconfig_data_format_srca(icb.get_cb_id());
 #endif
-    copy_tile_to_dst_init_short(icb, transpose);
+    copy_tile_to_dst_init_short(icb.get_cb_id(), transpose);
 }
 
-ALWI void add_tiles_init_with_dt(uint32_t icb0 = 0, uint32_t icb1 = 1) {
+ALWI void add_tiles_init_with_dt(CircularBuffer icb0, CircularBuffer icb1) {
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0, icb1);
+    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
 #endif
-    add_tiles_init(icb0, icb1);
+    add_tiles_init(icb0.get_cb_id(), icb1.get_cb_id());
 }
 
-ALWI void add_bcast_rows_init_short_with_dt(uint32_t icb0 = 0, uint32_t icb1 = 1) {
+ALWI void add_bcast_rows_init_short_with_dt(CircularBuffer icb0, CircularBuffer icb1) {
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0, icb1);
+    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
 #endif
-    add_bcast_rows_init_short(icb0, icb1);
+    add_bcast_rows_init_short(icb0.get_cb_id(), icb1.get_cb_id());
 }
 
-ALWI void add_bcast_cols_init_short_with_dt(uint32_t icb0 = 0, uint32_t icb1 = 1) {
+ALWI void add_bcast_cols_init_short_with_dt(CircularBuffer icb0, CircularBuffer icb1) {
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0, icb1);
+    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
 #endif
-    add_bcast_cols_init_short(icb0, icb1);
+    add_bcast_cols_init_short(icb0.get_cb_id(), icb1.get_cb_id());
 }
 
-ALWI void add_bcast_scalar_init_short_with_dt(uint32_t icb0 = 0, uint32_t icb1 = 1) {
+ALWI void add_bcast_scalar_init_short_with_dt(CircularBuffer icb0, CircularBuffer icb1) {
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0, icb1);
+    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
 #endif
-    add_bcast_scalar_init_short(icb0, icb1);
+    add_bcast_scalar_init_short(icb0.get_cb_id(), icb1.get_cb_id());
 }
 
-ALWI void sub_tiles_init_with_dt(uint32_t icb0 = 0, uint32_t icb1 = 1) {
+ALWI void sub_tiles_init_with_dt(CircularBuffer icb0, CircularBuffer icb1) {
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0, icb1);
+    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
 #endif
-    sub_tiles_init(icb0, icb1);
+    sub_tiles_init(icb0.get_cb_id(), icb1.get_cb_id());
 }
 
-ALWI void sub_bcast_rows_init_short_with_dt(uint32_t icb0 = 0, uint32_t icb1 = 1) {
+ALWI void sub_bcast_rows_init_short_with_dt(CircularBuffer icb0, CircularBuffer icb1) {
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0, icb1);
+    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
 #endif
-    MATH((llk_math_eltwise_binary_init<EltwiseBinaryType::ELWSUB, BroadcastType::ROW, MathFidelity::LoFi>(icb0, icb1)));
-    UNPACK((llk_unpack_AB_init<BroadcastType::ROW>(icb0, icb1)));
+    MATH((llk_math_eltwise_binary_init<EltwiseBinaryType::ELWSUB, BroadcastType::ROW, MathFidelity::LoFi>(
+        icb0.get_cb_id(), icb1.get_cb_id())));
+    UNPACK((llk_unpack_AB_init<BroadcastType::ROW>(icb0.get_cb_id(), icb1.get_cb_id())));
 }
 
-ALWI void sub_bcast_cols_init_short_with_dt(uint32_t icb0 = 0, uint32_t icb1 = 1) {
+ALWI void sub_bcast_cols_init_short_with_dt(CircularBuffer icb0, CircularBuffer icb1) {
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0, icb1);
+    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
 #endif
-    sub_bcast_cols_init_short(icb0, icb1);
+    sub_bcast_cols_init_short(icb0.get_cb_id(), icb1.get_cb_id());
 }
 
-ALWI void sub_tiles_bcast_scalar_init_short_with_dt(uint32_t icb0 = 0, uint32_t icb1 = 1) {
+ALWI void sub_tiles_bcast_scalar_init_short_with_dt(CircularBuffer icb0, CircularBuffer icb1) {
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0, icb1);
+    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
 #endif
-    sub_tiles_bcast_scalar_init_short(icb0, icb1);
+    sub_tiles_bcast_scalar_init_short(icb0.get_cb_id(), icb1.get_cb_id());
 }
 
-ALWI void mul_tiles_init_with_dt(uint32_t icb0 = 0, uint32_t icb1 = 1) {
+ALWI void mul_tiles_init_with_dt(CircularBuffer icb0, CircularBuffer icb1) {
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0, icb1);
+    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
 #endif
-    mul_tiles_init(icb0, icb1);
+    mul_tiles_init(icb0.get_cb_id(), icb1.get_cb_id());
 }
 
-ALWI void mul_bcast_rows_init_short_with_dt(uint32_t icb0 = 0, uint32_t icb1 = 1) {
+ALWI void mul_bcast_rows_init_short_with_dt(CircularBuffer icb0, CircularBuffer icb1) {
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0, icb1);
+    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
 #endif
-    mul_bcast_rows_init_short(icb0, icb1);
+    mul_bcast_rows_init_short(icb0.get_cb_id(), icb1.get_cb_id());
 }
 
-ALWI void mul_bcast_cols_init_short_with_dt(uint32_t icb0 = 0, uint32_t icb1 = 1) {
+ALWI void mul_bcast_cols_init_short_with_dt(CircularBuffer icb0, CircularBuffer icb1) {
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0, icb1);
+    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
 #endif
-    mul_bcast_cols_init_short(icb0, icb1);
+    mul_bcast_cols_init_short(icb0.get_cb_id(), icb1.get_cb_id());
 }
 
-ALWI void mul_tiles_bcast_scalar_init_short_with_dt(uint32_t icb0 = 0, uint32_t icb1 = 1) {
+ALWI void mul_tiles_bcast_scalar_init_short_with_dt(CircularBuffer icb0, CircularBuffer icb1) {
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0, icb1);
+    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
 #endif
-    mul_tiles_bcast_scalar_init_short(icb0, icb1);
+    mul_tiles_bcast_scalar_init_short(icb0.get_cb_id(), icb1.get_cb_id());
 }
 
 class ArgFetcher {
@@ -145,9 +137,9 @@ public:
 };
 
 ALWI void mul_tiles_to_cb(
-    uint32_t icb0,
-    uint32_t icb1,
-    uint32_t ocb,
+    CircularBuffer icb0,
+    CircularBuffer icb1,
+    CircularBuffer ocb,
     uint32_t itile0 = 0,
     uint32_t itile1 = 0,
     uint32_t pop0 = 1,
@@ -155,13 +147,13 @@ ALWI void mul_tiles_to_cb(
     constexpr uint32_t onetile = 1;
     constexpr int dst0 = 0;
 
-    cb_reserve_back(ocb, onetile);
-    cb_wait_front(icb0, itile0 + 1);
-    cb_wait_front(icb1, itile1 + 1);
+    ocb.reserve_back(onetile);
+    icb0.wait_front(itile0 + 1);
+    icb1.wait_front(itile1 + 1);
 
     tile_regs_acquire();
     mul_tiles_init_with_dt(icb0, icb1);
-    mul_tiles(icb0, icb1, itile0, itile1, dst0);
+    mul_tiles(icb0.get_cb_id(), icb1.get_cb_id(), itile0, itile1, dst0);
     tile_regs_commit();
 
     tile_regs_wait();
@@ -169,19 +161,19 @@ ALWI void mul_tiles_to_cb(
     tile_regs_release();
 
     if (pop0) {
-        cb_pop_front(icb0, pop0);
+        icb0.pop_front(pop0);
     }
     if (pop1) {
-        cb_pop_front(icb1, pop1);
+        icb1.pop_front(pop1);
     }
 
-    cb_push_back(ocb, onetile);
+    ocb.push_back(onetile);
 }
 
 ALWI void mul_tiles_and_negative_to_cb(
-    uint32_t icb0,
-    uint32_t icb1,
-    uint32_t ocb,
+    CircularBuffer icb0,
+    CircularBuffer icb1,
+    CircularBuffer ocb,
     uint32_t itile0 = 0,
     uint32_t itile1 = 0,
     uint32_t pop0 = 1,
@@ -189,13 +181,13 @@ ALWI void mul_tiles_and_negative_to_cb(
     constexpr uint32_t onetile = 1;
     constexpr int dst0 = 0;
 
-    cb_reserve_back(ocb, onetile);
-    cb_wait_front(icb0, itile0 + 1);
-    cb_wait_front(icb1, itile1 + 1);
+    ocb.reserve_back(onetile);
+    icb0.wait_front(itile0 + 1);
+    icb1.wait_front(itile1 + 1);
 
     tile_regs_acquire();
     mul_tiles_init_with_dt(icb0, icb1);
-    mul_tiles(icb0, icb1, itile0, itile1, dst0);
+    mul_tiles(icb0.get_cb_id(), icb1.get_cb_id(), itile0, itile1, dst0);
 
     negative_tile_init();
     negative_tile(dst0);
@@ -206,20 +198,20 @@ ALWI void mul_tiles_and_negative_to_cb(
     tile_regs_release();
 
     if (pop0) {
-        cb_pop_front(icb0, pop0);
+        icb0.pop_front(pop0);
     }
     if (pop1) {
-        cb_pop_front(icb1, pop1);
+        icb1.pop_front(pop1);
     }
 
-    cb_push_back(ocb, onetile);
+    ocb.push_back(onetile);
 }
 
 ALWI void mul_tiles_and_mask_tile_to_cb(
-    uint32_t icb0,
-    uint32_t icb1,
-    uint32_t maskcb,
-    uint32_t ocb,
+    CircularBuffer icb0,
+    CircularBuffer icb1,
+    CircularBuffer maskcb,
+    CircularBuffer ocb,
     uint32_t itile0 = 0,
     uint32_t itile1 = 0,
     uint32_t mtile = 0,
@@ -229,18 +221,18 @@ ALWI void mul_tiles_and_mask_tile_to_cb(
     constexpr uint32_t onetile = 1;
     constexpr int dst0 = 0;
 
-    cb_reserve_back(ocb, onetile);
-    cb_wait_front(icb0, itile0 + 1);
-    cb_wait_front(icb1, itile1 + 1);
-    cb_wait_front(maskcb, mtile + 1);
+    ocb.reserve_back(onetile);
+    icb0.wait_front(itile0 + 1);
+    icb1.wait_front(itile1 + 1);
+    maskcb.wait_front(mtile + 1);
 
     tile_regs_acquire();
     mul_tiles_init_with_dt(icb0, icb1);
-    mul_tiles(icb0, icb1, itile0, itile1, dst0);
+    mul_tiles(icb0.get_cb_id(), icb1.get_cb_id(), itile0, itile1, dst0);
 
     constexpr int dst_mask = 1;
     copy_tile_init_with_dt(maskcb);
-    copy_tile(maskcb, mtile, dst_mask);
+    copy_tile(maskcb.get_cb_id(), mtile, dst_mask);
 
     mask_tile_init();
     mask_tile(dst0, dst_mask);
@@ -251,22 +243,22 @@ ALWI void mul_tiles_and_mask_tile_to_cb(
     tile_regs_release();
 
     if (pop0) {
-        cb_pop_front(icb0, pop0);
+        icb0.pop_front(pop0);
     }
     if (pop1) {
-        cb_pop_front(icb1, pop1);
+        icb1.pop_front(pop1);
     }
     if (popm) {
-        cb_pop_front(maskcb, popm);
+        maskcb.pop_front(popm);
     }
 
-    cb_push_back(ocb, onetile);
+    ocb.push_back(onetile);
 }
 
 ALWI void mul_tiles_log_to_cb(
-    uint32_t icb0,
-    uint32_t icb1,
-    uint32_t ocb,
+    CircularBuffer icb0,
+    CircularBuffer icb1,
+    CircularBuffer ocb,
     uint32_t itile0 = 0,
     uint32_t itile1 = 0,
     uint32_t pop0 = 1,
@@ -274,13 +266,13 @@ ALWI void mul_tiles_log_to_cb(
     constexpr uint32_t onetile = 1;
     constexpr int dst0 = 0;
 
-    cb_reserve_back(ocb, onetile);
-    cb_wait_front(icb0, itile0 + 1);
-    cb_wait_front(icb1, itile1 + 1);
+    ocb.reserve_back(onetile);
+    icb0.wait_front(itile0 + 1);
+    icb1.wait_front(itile1 + 1);
 
     tile_regs_acquire();
     mul_tiles_init_with_dt(icb0, icb1);
-    mul_tiles(icb0, icb1, itile0, itile1, dst0);
+    mul_tiles(icb0.get_cb_id(), icb1.get_cb_id(), itile0, itile1, dst0);
 
     log_tile_init();
     log_tile(dst0);
@@ -291,19 +283,19 @@ ALWI void mul_tiles_log_to_cb(
     tile_regs_release();
 
     if (pop0) {
-        cb_pop_front(icb0, pop0);
+        icb0.pop_front(pop0);
     }
     if (pop1) {
-        cb_pop_front(icb1, pop1);
+        icb1.pop_front(pop1);
     }
 
-    cb_push_back(ocb, onetile);
+    ocb.push_back(onetile);
 }
 
 ALWI void mul_tiles_bcast_rows_to_cb(
-    uint32_t icb0,
-    uint32_t icb1,
-    uint32_t ocb,
+    CircularBuffer icb0,
+    CircularBuffer icb1,
+    CircularBuffer ocb,
     uint32_t itile0 = 0,
     uint32_t itile1 = 0,
     uint32_t pop0 = 1,
@@ -311,17 +303,17 @@ ALWI void mul_tiles_bcast_rows_to_cb(
     constexpr uint32_t onetile = 1;
     constexpr int dst0 = 0;
 
-    cb_reserve_back(ocb, onetile);
+    ocb.reserve_back(onetile);
 
-    cb_wait_front(icb0, itile0 + 1);
-    cb_wait_front(icb1, itile1 + 1);
+    icb0.wait_front(itile0 + 1);
+    icb1.wait_front(itile1 + 1);
 
     tile_regs_acquire();
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0, icb1);
+    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
 #endif
-    mul_bcast_rows_init_short(icb0, icb1);
-    mul_tiles_bcast_rows(icb0, icb1, itile0, itile1, dst0);
+    mul_bcast_rows_init_short(icb0.get_cb_id(), icb1.get_cb_id());
+    mul_tiles_bcast_rows(icb0.get_cb_id(), icb1.get_cb_id(), itile0, itile1, dst0);
     tile_regs_commit();
 
     tile_regs_wait();
@@ -329,19 +321,19 @@ ALWI void mul_tiles_bcast_rows_to_cb(
     tile_regs_release();
 
     if (pop0) {
-        cb_pop_front(icb0, pop0);
+        icb0.pop_front(pop0);
     }
     if (pop1) {
-        cb_pop_front(icb1, pop1);
+        icb1.pop_front(pop1);
     }
 
-    cb_push_back(ocb, onetile);
+    ocb.push_back(onetile);
 }
 
 ALWI void mul_tiles_bcast_rows_log_to_cb(
-    uint32_t icb0,
-    uint32_t icb1,
-    uint32_t ocb,
+    CircularBuffer icb0,
+    CircularBuffer icb1,
+    CircularBuffer ocb,
     uint32_t itile0 = 0,
     uint32_t itile1 = 0,
     uint32_t pop0 = 1,
@@ -349,17 +341,17 @@ ALWI void mul_tiles_bcast_rows_log_to_cb(
     constexpr uint32_t onetile = 1;
     constexpr int dst0 = 0;
 
-    cb_reserve_back(ocb, onetile);
+    ocb.reserve_back(onetile);
 
-    cb_wait_front(icb0, itile0 + 1);
-    cb_wait_front(icb1, itile1 + 1);
+    icb0.wait_front(itile0 + 1);
+    icb1.wait_front(itile1 + 1);
 
     tile_regs_acquire();
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0, icb1);
+    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
 #endif
-    mul_bcast_rows_init_short(icb0, icb1);
-    mul_tiles_bcast_rows(icb0, icb1, itile0, itile1, dst0);
+    mul_bcast_rows_init_short(icb0.get_cb_id(), icb1.get_cb_id());
+    mul_tiles_bcast_rows(icb0.get_cb_id(), icb1.get_cb_id(), itile0, itile1, dst0);
 
     log_tile_init();
     log_tile(dst0);
@@ -370,19 +362,19 @@ ALWI void mul_tiles_bcast_rows_log_to_cb(
     tile_regs_release();
 
     if (pop0) {
-        cb_pop_front(icb0, pop0);
+        icb0.pop_front(pop0);
     }
     if (pop1) {
-        cb_pop_front(icb1, pop1);
+        icb1.pop_front(pop1);
     }
 
-    cb_push_back(ocb, onetile);
+    ocb.push_back(onetile);
 }
 
 ALWI void mul_tiles_bcast_cols_to_cb(
-    uint32_t icb0,
-    uint32_t icb1,
-    uint32_t ocb,
+    CircularBuffer icb0,
+    CircularBuffer icb1,
+    CircularBuffer ocb,
     uint32_t itile0 = 0,
     uint32_t itile1 = 0,
     uint32_t pop0 = 1,
@@ -390,17 +382,17 @@ ALWI void mul_tiles_bcast_cols_to_cb(
     constexpr uint32_t onetile = 1;
     constexpr int dst0 = 0;
 
-    cb_reserve_back(ocb, onetile);
+    ocb.reserve_back(onetile);
 
-    cb_wait_front(icb0, itile0 + 1);
-    cb_wait_front(icb1, itile1 + 1);
+    icb0.wait_front(itile0 + 1);
+    icb1.wait_front(itile1 + 1);
 
     tile_regs_acquire();
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0, icb1);
+    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
 #endif
-    mul_bcast_cols_init_short(icb0, icb1);
-    mul_tiles_bcast_cols(icb0, icb1, itile0, itile1, dst0);
+    mul_bcast_cols_init_short(icb0.get_cb_id(), icb1.get_cb_id());
+    mul_tiles_bcast_cols(icb0.get_cb_id(), icb1.get_cb_id(), itile0, itile1, dst0);
     tile_regs_commit();
 
     tile_regs_wait();
@@ -408,19 +400,19 @@ ALWI void mul_tiles_bcast_cols_to_cb(
     tile_regs_release();
 
     if (pop0) {
-        cb_pop_front(icb0, pop0);
+        icb0.pop_front(pop0);
     }
     if (pop1) {
-        cb_pop_front(icb1, pop1);
+        icb1.pop_front(pop1);
     }
 
-    cb_push_back(ocb, onetile);
+    ocb.push_back(onetile);
 }
 
 ALWI void mul_tiles_bcast_cols_log_to_cb(
-    uint32_t icb0,
-    uint32_t icb1,
-    uint32_t ocb,
+    CircularBuffer icb0,
+    CircularBuffer icb1,
+    CircularBuffer ocb,
     uint32_t itile0 = 0,
     uint32_t itile1 = 0,
     uint32_t pop0 = 1,
@@ -428,17 +420,17 @@ ALWI void mul_tiles_bcast_cols_log_to_cb(
     constexpr uint32_t onetile = 1;
     constexpr int dst0 = 0;
 
-    cb_reserve_back(ocb, onetile);
+    ocb.reserve_back(onetile);
 
-    cb_wait_front(icb0, itile0 + 1);
-    cb_wait_front(icb1, itile1 + 1);
+    icb0.wait_front(itile0 + 1);
+    icb1.wait_front(itile1 + 1);
 
     tile_regs_acquire();
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0, icb1);
+    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
 #endif
-    mul_bcast_cols_init_short(icb0, icb1);
-    mul_tiles_bcast_cols(icb0, icb1, itile0, itile1, dst0);
+    mul_bcast_cols_init_short(icb0.get_cb_id(), icb1.get_cb_id());
+    mul_tiles_bcast_cols(icb0.get_cb_id(), icb1.get_cb_id(), itile0, itile1, dst0);
 
     log_tile_init();
     log_tile(dst0);
@@ -449,25 +441,25 @@ ALWI void mul_tiles_bcast_cols_log_to_cb(
     tile_regs_release();
 
     if (pop0) {
-        cb_pop_front(icb0, pop0);
+        icb0.pop_front(pop0);
     }
     if (pop1) {
-        cb_pop_front(icb1, pop1);
+        icb1.pop_front(pop1);
     }
 
-    cb_push_back(ocb, onetile);
+    ocb.push_back(onetile);
 }
 
-ALWI void copy_tile_to_cb(uint32_t icb, uint32_t ocb, uint32_t itile = 0, uint32_t pop = 1) {
+ALWI void copy_tile_to_cb(CircularBuffer icb, CircularBuffer ocb, uint32_t itile = 0, uint32_t pop = 1) {
     constexpr uint32_t onetile = 1;
     constexpr int dst0 = 0;
 
-    cb_reserve_back(ocb, onetile);
-    cb_wait_front(icb, itile + 1);
+    ocb.reserve_back(onetile);
+    icb.wait_front(itile + 1);
 
     tile_regs_acquire();
     copy_tile_init_with_dt(icb);
-    copy_tile(icb, itile, dst0);
+    copy_tile(icb.get_cb_id(), itile, dst0);
     tile_regs_commit();
 
     tile_regs_wait();
@@ -475,21 +467,21 @@ ALWI void copy_tile_to_cb(uint32_t icb, uint32_t ocb, uint32_t itile = 0, uint32
     tile_regs_release();
 
     if (pop) {
-        cb_pop_front(icb, pop);
+        icb.pop_front(pop);
     }
-    cb_push_back(ocb, onetile);
+    ocb.push_back(onetile);
 }
 
-ALWI void sign_tile_to_cb(uint32_t icb, uint32_t ocb, uint32_t itile = 0, uint32_t pop = 1) {
+ALWI void sign_tile_to_cb(CircularBuffer icb, CircularBuffer ocb, uint32_t itile = 0, uint32_t pop = 1) {
     constexpr uint32_t onetile = 1;
     constexpr int dst0 = 0;
 
-    cb_reserve_back(ocb, onetile);
-    cb_wait_front(icb, itile + 1);
+    ocb.reserve_back(onetile);
+    icb.wait_front(itile + 1);
 
     tile_regs_acquire();
     copy_tile_init_with_dt(icb);
-    copy_tile(icb, itile, dst0);
+    copy_tile(icb.get_cb_id(), itile, dst0);
 
     sign_tile_init();
     sign_tile(dst0);
@@ -500,15 +492,15 @@ ALWI void sign_tile_to_cb(uint32_t icb, uint32_t ocb, uint32_t itile = 0, uint32
     tile_regs_release();
 
     if (pop) {
-        cb_pop_front(icb, pop);
+        icb.pop_front(pop);
     }
-    cb_push_back(ocb, onetile);
+    ocb.push_back(onetile);
 }
 
 ALWI void add_tiles_to_cb(
-    uint32_t icb0,
-    uint32_t icb1,
-    uint32_t ocb,
+    CircularBuffer icb0,
+    CircularBuffer icb1,
+    CircularBuffer ocb,
     uint32_t itile0 = 0,
     uint32_t itile1 = 0,
     uint32_t pop0 = 1,
@@ -516,13 +508,13 @@ ALWI void add_tiles_to_cb(
     constexpr uint32_t onetile = 1;
     constexpr int dst0 = 0;
 
-    cb_reserve_back(ocb, onetile);
-    cb_wait_front(icb0, itile0 + 1);
-    cb_wait_front(icb1, itile1 + 1);
+    ocb.reserve_back(onetile);
+    icb0.wait_front(itile0 + 1);
+    icb1.wait_front(itile1 + 1);
 
     tile_regs_acquire();
     add_tiles_init_with_dt(icb0, icb1);
-    add_tiles(icb0, icb1, itile0, itile1, dst0);
+    add_tiles(icb0.get_cb_id(), icb1.get_cb_id(), itile0, itile1, dst0);
     tile_regs_commit();
 
     tile_regs_wait();
@@ -530,19 +522,19 @@ ALWI void add_tiles_to_cb(
     tile_regs_release();
 
     if (pop0) {
-        cb_pop_front(icb0, pop0);
+        icb0.pop_front(pop0);
     }
     if (pop1) {
-        cb_pop_front(icb1, pop1);
+        icb1.pop_front(pop1);
     }
 
-    cb_push_back(ocb, onetile);
+    ocb.push_back(onetile);
 }
 
 ALWI void mask_tile_to_cb(
-    uint32_t icb,
-    uint32_t maskcb,
-    uint32_t ocb,
+    CircularBuffer icb,
+    CircularBuffer maskcb,
+    CircularBuffer ocb,
     uint32_t itile = 0,
     uint32_t mtile = 0,
     uint32_t pop = 1,
@@ -551,16 +543,16 @@ ALWI void mask_tile_to_cb(
     constexpr int dst0 = 0;
     constexpr int dst_mask = 1;
 
-    cb_reserve_back(ocb, onetile);
-    cb_wait_front(icb, itile + 1);
-    cb_wait_front(maskcb, mtile + 1);
+    ocb.reserve_back(onetile);
+    icb.wait_front(itile + 1);
+    maskcb.wait_front(mtile + 1);
 
     tile_regs_acquire();
     copy_tile_init_with_dt(icb);
-    copy_tile(icb, itile, dst0);
+    copy_tile(icb.get_cb_id(), itile, dst0);
 
     copy_tile_init_with_dt(maskcb);
-    copy_tile(maskcb, mtile, dst_mask);
+    copy_tile(maskcb.get_cb_id(), mtile, dst_mask);
 
     mask_tile_init();
     mask_tile(dst0, dst_mask);
@@ -571,19 +563,19 @@ ALWI void mask_tile_to_cb(
     tile_regs_release();
 
     if (pop) {
-        cb_pop_front(icb, pop);
+        icb.pop_front(pop);
     }
     if (popm) {
-        cb_pop_front(maskcb, popm);
+        maskcb.pop_front(popm);
     }
 
-    cb_push_back(ocb, onetile);
+    ocb.push_back(onetile);
 }
 
 ALWI void sub_tiles_bcast_cols_to_cb(
-    uint32_t icb0,
-    uint32_t icb1,
-    uint32_t ocb,
+    CircularBuffer icb0,
+    CircularBuffer icb1,
+    CircularBuffer ocb,
     uint32_t itile0 = 0,
     uint32_t itile1 = 0,
     uint32_t pop0 = 1,
@@ -591,17 +583,17 @@ ALWI void sub_tiles_bcast_cols_to_cb(
     constexpr uint32_t onetile = 1;
     constexpr int dst0 = 0;
 
-    cb_reserve_back(ocb, onetile);
+    ocb.reserve_back(onetile);
 
-    cb_wait_front(icb0, itile0 + 1);
-    cb_wait_front(icb1, itile1 + 1);
+    icb0.wait_front(itile0 + 1);
+    icb1.wait_front(itile1 + 1);
 
     tile_regs_acquire();
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0, icb1);
+    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
 #endif
-    sub_bcast_cols_init_short(icb0, icb1);
-    sub_tiles_bcast<BroadcastType::COL>(icb0, icb1, itile0, itile1, dst0);
+    sub_bcast_cols_init_short(icb0.get_cb_id(), icb1.get_cb_id());
+    sub_tiles_bcast<BroadcastType::COL>(icb0.get_cb_id(), icb1.get_cb_id(), itile0, itile1, dst0);
     tile_regs_commit();
 
     tile_regs_wait();
@@ -609,19 +601,19 @@ ALWI void sub_tiles_bcast_cols_to_cb(
     tile_regs_release();
 
     if (pop0) {
-        cb_pop_front(icb0, pop0);
+        icb0.pop_front(pop0);
     }
     if (pop1) {
-        cb_pop_front(icb1, pop1);
+        icb1.pop_front(pop1);
     }
 
-    cb_push_back(ocb, onetile);
+    ocb.push_back(onetile);
 }
 
 ALWI void sub_tiles_bcast_rows_to_cb(
-    uint32_t icb0,
-    uint32_t icb1,
-    uint32_t ocb,
+    CircularBuffer icb0,
+    CircularBuffer icb1,
+    CircularBuffer ocb,
     uint32_t itile0 = 0,
     uint32_t itile1 = 0,
     uint32_t pop0 = 1,
@@ -629,21 +621,22 @@ ALWI void sub_tiles_bcast_rows_to_cb(
     constexpr uint32_t onetile = 1;
     constexpr int dst0 = 0;
 
-    cb_reserve_back(ocb, onetile);
+    ocb.reserve_back(onetile);
 
-    cb_wait_front(icb0, itile0 + 1);
-    cb_wait_front(icb1, itile1 + 1);
+    icb0.wait_front(itile0 + 1);
+    icb1.wait_front(itile1 + 1);
 
     tile_regs_acquire();
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0, icb1);
+    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
 #endif
     // sub_bcast_rows_init_short();
     {
-        MATH((llk_math_eltwise_binary_init<EltwiseBinaryType::ELWSUB, BroadcastType::ROW, MathFidelity::LoFi>(icb0, icb1)));
-        UNPACK((llk_unpack_AB_init<BroadcastType::ROW>(icb0, icb1)));
+        MATH((llk_math_eltwise_binary_init<EltwiseBinaryType::ELWSUB, BroadcastType::ROW, MathFidelity::LoFi>(
+            icb0.get_cb_id(), icb1.get_cb_id())));
+        UNPACK((llk_unpack_AB_init<BroadcastType::ROW>(icb0.get_cb_id(), icb1.get_cb_id())));
     }
-    sub_tiles_bcast<BroadcastType::ROW>(icb0, icb1, itile0, itile1, dst0);
+    sub_tiles_bcast<BroadcastType::ROW>(icb0.get_cb_id(), icb1.get_cb_id(), itile0, itile1, dst0);
     tile_regs_commit();
 
     tile_regs_wait();
@@ -651,19 +644,19 @@ ALWI void sub_tiles_bcast_rows_to_cb(
     tile_regs_release();
 
     if (pop0) {
-        cb_pop_front(icb0, pop0);
+        icb0.pop_front(pop0);
     }
     if (pop1) {
-        cb_pop_front(icb1, pop1);
+        icb1.pop_front(pop1);
     }
 
-    cb_push_back(ocb, onetile);
+    ocb.push_back(onetile);
 }
 
 ALWI void sub_tiles_to_cb(
-    uint32_t icb0,
-    uint32_t icb1,
-    uint32_t ocb,
+    CircularBuffer icb0,
+    CircularBuffer icb1,
+    CircularBuffer ocb,
     uint32_t itile0 = 0,
     uint32_t itile1 = 0,
     uint32_t pop0 = 1,
@@ -671,13 +664,13 @@ ALWI void sub_tiles_to_cb(
     constexpr uint32_t onetile = 1;
     constexpr int dst0 = 0;
 
-    cb_reserve_back(ocb, onetile);
-    cb_wait_front(icb0, itile0 + 1);
-    cb_wait_front(icb1, itile1 + 1);
+    ocb.reserve_back(onetile);
+    icb0.wait_front(itile0 + 1);
+    icb1.wait_front(itile1 + 1);
 
     tile_regs_acquire();
     sub_tiles_init_with_dt(icb0, icb1);
-    sub_tiles(icb0, icb1, itile0, itile1, dst0);
+    sub_tiles(icb0.get_cb_id(), icb1.get_cb_id(), itile0, itile1, dst0);
     tile_regs_commit();
 
     tile_regs_wait();
@@ -685,24 +678,25 @@ ALWI void sub_tiles_to_cb(
     tile_regs_release();
 
     if (pop0) {
-        cb_pop_front(icb0, pop0);
+        icb0.pop_front(pop0);
     }
     if (pop1) {
-        cb_pop_front(icb1, pop1);
+        icb1.pop_front(pop1);
     }
 
-    cb_push_back(ocb, onetile);
+    ocb.push_back(onetile);
 }
 
-ALWI void exp_tile_to_cb(uint32_t icb, uint32_t ocb, uint32_t itile = 0, uint32_t dst = 0, uint32_t pop = 1) {
+ALWI void exp_tile_to_cb(
+    CircularBuffer icb, CircularBuffer ocb, uint32_t itile = 0, uint32_t dst = 0, uint32_t pop = 1) {
     constexpr uint32_t onetile = 1;
 
-    cb_reserve_back(ocb, onetile);
-    cb_wait_front(icb, itile + 1);
+    ocb.reserve_back(onetile);
+    icb.wait_front(itile + 1);
 
     tile_regs_acquire();
     copy_tile_init_with_dt(icb);
-    copy_tile(icb, itile, dst);
+    copy_tile(icb.get_cb_id(), itile, dst);
 
     exp_tile_init();
     exp_tile(dst);
@@ -713,20 +707,21 @@ ALWI void exp_tile_to_cb(uint32_t icb, uint32_t ocb, uint32_t itile = 0, uint32_
     tile_regs_release();
 
     if (pop) {
-        cb_pop_front(icb, pop);
+        icb.pop_front(pop);
     }
-    cb_push_back(ocb, onetile);
+    ocb.push_back(onetile);
 }
 
-ALWI void rexp_tile_to_cb(uint32_t icb, uint32_t ocb, uint32_t itile = 0, uint32_t dst = 0, uint32_t pop = 1) {
+ALWI void rexp_tile_to_cb(
+    CircularBuffer icb, CircularBuffer ocb, uint32_t itile = 0, uint32_t dst = 0, uint32_t pop = 1) {
     constexpr uint32_t onetile = 1;
 
-    cb_reserve_back(ocb, onetile);
-    cb_wait_front(icb, itile + 1);
+    ocb.reserve_back(onetile);
+    icb.wait_front(itile + 1);
 
     tile_regs_acquire();
     copy_tile_init_with_dt(icb);
-    copy_tile(icb, itile, dst);
+    copy_tile(icb.get_cb_id(), itile, dst);
 
     negative_tile_init();
     negative_tile(dst);
@@ -740,15 +735,15 @@ ALWI void rexp_tile_to_cb(uint32_t icb, uint32_t ocb, uint32_t itile = 0, uint32
     tile_regs_release();
 
     if (pop) {
-        cb_pop_front(icb, pop);
+        icb.pop_front(pop);
     }
-    cb_push_back(ocb, onetile);
+    ocb.push_back(onetile);
 }
 
 ALWI void exp_tile_and_mask_tile_to_cb(
-    uint32_t icb,
-    uint32_t maskcb,
-    uint32_t ocb,
+    CircularBuffer icb,
+    CircularBuffer maskcb,
+    CircularBuffer ocb,
     uint32_t itile = 0,
     uint32_t mtile = 0,
     uint32_t pop = 1,
@@ -757,43 +752,43 @@ ALWI void exp_tile_and_mask_tile_to_cb(
     uint32_t dst_mask = 1) {
     constexpr uint32_t onetile = 1;
 
-    cb_reserve_back(ocb, onetile);
-    cb_wait_front(icb, itile + 1);
-    cb_wait_front(maskcb, mtile + 1);
+    ocb.reserve_back(onetile);
+    icb.wait_front(itile + 1);
+    maskcb.wait_front(mtile + 1);
 
     tile_regs_acquire();
     copy_tile_init_with_dt(icb);
-    copy_tile(icb, itile, dst);
+    copy_tile(icb.get_cb_id(), itile, dst);
 
     if (pop) {
-        cb_pop_front(icb, pop);
+        icb.pop_front(pop);
     }
 
     exp_tile_init();
     exp_tile(dst);
 
     copy_tile_init_with_dt(maskcb);
-    copy_tile(maskcb, mtile, dst_mask);
+    copy_tile(maskcb.get_cb_id(), mtile, dst_mask);
 
     mask_tile_init();
     mask_tile(dst, dst_mask);
     tile_regs_commit();
 
     if (popm) {
-        cb_pop_front(maskcb, popm);
+        maskcb.pop_front(popm);
     }
 
     tile_regs_wait();
     pack_tile_with_dt(dst, ocb);
     tile_regs_release();
 
-    cb_push_back(ocb, onetile);
+    ocb.push_back(onetile);
 }
 
 ALWI void rexp_tile_and_mask_tile_to_cb(
-    uint32_t icb,
-    uint32_t maskcb,
-    uint32_t ocb,
+    CircularBuffer icb,
+    CircularBuffer maskcb,
+    CircularBuffer ocb,
     uint32_t itile = 0,
     uint32_t mtile = 0,
     uint32_t pop = 1,
@@ -802,16 +797,16 @@ ALWI void rexp_tile_and_mask_tile_to_cb(
     uint32_t dst_mask = 1) {
     constexpr uint32_t onetile = 1;
 
-    cb_reserve_back(ocb, onetile);
-    cb_wait_front(icb, itile + 1);
-    cb_wait_front(maskcb, mtile + 1);
+    ocb.reserve_back(onetile);
+    icb.wait_front(itile + 1);
+    maskcb.wait_front(mtile + 1);
 
     tile_regs_acquire();
     copy_tile_init_with_dt(icb);
-    copy_tile(icb, itile, dst);
+    copy_tile(icb.get_cb_id(), itile, dst);
 
     if (pop) {
-        cb_pop_front(icb, pop);
+        icb.pop_front(pop);
     }
 
     negative_tile_init();
@@ -821,33 +816,33 @@ ALWI void rexp_tile_and_mask_tile_to_cb(
     exp_tile(dst);
 
     copy_tile_init_with_dt(maskcb);
-    copy_tile(maskcb, mtile, dst_mask);
+    copy_tile(maskcb.get_cb_id(), mtile, dst_mask);
 
     mask_tile_init();
     mask_tile(dst, dst_mask);
     tile_regs_commit();
 
     if (popm) {
-        cb_pop_front(maskcb, popm);
+        maskcb.pop_front(popm);
     }
 
     tile_regs_wait();
     pack_tile_with_dt(dst, ocb);
     tile_regs_release();
 
-    cb_push_back(ocb, onetile);
+    ocb.push_back(onetile);
 }
 
-ALWI void recip_tile_to_cb(uint32_t icb, uint32_t ocb, uint32_t itile = 0, uint32_t pop = 1) {
+ALWI void recip_tile_to_cb(CircularBuffer icb, CircularBuffer ocb, uint32_t itile = 0, uint32_t pop = 1) {
     constexpr uint32_t onetile = 1;
     constexpr int dst0 = 0;
 
-    cb_reserve_back(ocb, onetile);
-    cb_wait_front(icb, itile + 1);
+    ocb.reserve_back(onetile);
+    icb.wait_front(itile + 1);
 
     tile_regs_acquire();
     copy_tile_init_with_dt(icb);
-    copy_tile(icb, itile, dst0);
+    copy_tile(icb.get_cb_id(), itile, dst0);
 
     recip_tile_init();
     recip_tile(dst0);
@@ -858,21 +853,21 @@ ALWI void recip_tile_to_cb(uint32_t icb, uint32_t ocb, uint32_t itile = 0, uint3
     tile_regs_release();
 
     if (pop) {
-        cb_pop_front(icb, pop);
+        icb.pop_front(pop);
     }
-    cb_push_back(ocb, onetile);
+    ocb.push_back(onetile);
 }
 
-ALWI void log_tile_to_cb(uint32_t icb, uint32_t ocb, uint32_t itile = 0, uint32_t pop = 1) {
+ALWI void log_tile_to_cb(CircularBuffer icb, CircularBuffer ocb, uint32_t itile = 0, uint32_t pop = 1) {
     constexpr uint32_t onetile = 1;
     constexpr int dst0 = 0;
 
-    cb_reserve_back(ocb, onetile);
-    cb_wait_front(icb, itile + 1);
+    ocb.reserve_back(onetile);
+    icb.wait_front(itile + 1);
 
     tile_regs_acquire();
     copy_tile_init_with_dt(icb);
-    copy_tile(icb, itile, dst0);
+    copy_tile(icb.get_cb_id(), itile, dst0);
 
     log_tile_init();
     log_tile(dst0);
@@ -883,19 +878,19 @@ ALWI void log_tile_to_cb(uint32_t icb, uint32_t ocb, uint32_t itile = 0, uint32_
     tile_regs_release();
 
     if (pop) {
-        cb_pop_front(icb, pop);
+        icb.pop_front(pop);
     }
-    cb_push_back(ocb, onetile);
+    ocb.push_back(onetile);
 }
 
 // TODO(seunghwan100): If p is 2 and decimal is 0, we can use sqrt_tile.
 ALWI void power_tile_to_cb(
-    std::uint8_t cb_x,
-    std::uint8_t cb_xpow,
-    std::uint8_t cb_logx,
-    std::uint8_t cb_decimal,
-    std::uint8_t cb_exp_lxmd,
-    std::uint8_t cb_correct_xpow,
+    CircularBuffer cb_x,
+    CircularBuffer cb_xpow,
+    CircularBuffer cb_logx,
+    CircularBuffer cb_decimal,
+    CircularBuffer cb_exp_lxmd,
+    CircularBuffer cb_correct_xpow,
     uint32_t p,
     bool p_is_negative) {
     constexpr uint32_t onetile = 1;
@@ -903,11 +898,11 @@ ALWI void power_tile_to_cb(
 
     // x^p
     tile_regs_acquire();
-    cb_wait_front(cb_x, onetile);
-    cb_reserve_back(cb_xpow, onetile);
+    cb_x.wait_front(onetile);
+    cb_xpow.reserve_back(onetile);
 
     copy_tile_init_with_dt(cb_x);
-    copy_tile(cb_x, 0, dst0);
+    copy_tile(cb_x.get_cb_id(), 0, dst0);
 
     power_iterative_tile_init();
     power_iterative_tile(dst0, p);
@@ -922,15 +917,15 @@ ALWI void power_tile_to_cb(
     pack_tile_with_dt(dst0, cb_xpow);
     tile_regs_release();
 
-    cb_push_back(cb_xpow, onetile);
+    cb_xpow.push_back(onetile);
     // We don't pop cb_x here.
 
     // log(x)
     tile_regs_acquire();
-    cb_reserve_back(cb_logx, onetile);
+    cb_logx.reserve_back(onetile);
 
     copy_tile_init_with_dt(cb_x);
-    copy_tile(cb_x, 0, dst0);
+    copy_tile(cb_x.get_cb_id(), 0, dst0);
 
     log_tile_init();
     log_tile(dst0);
@@ -940,16 +935,16 @@ ALWI void power_tile_to_cb(
     pack_tile_with_dt(dst0, cb_logx);
     tile_regs_release();
 
-    cb_pop_front(cb_x, onetile);
-    cb_push_back(cb_logx, onetile);
+    cb_x.pop_front(onetile);
+    cb_logx.push_back(onetile);
 
     // exp(log(x) * decimal)
     tile_regs_acquire();
-    cb_wait_front(cb_logx, onetile);
-    cb_reserve_back(cb_exp_lxmd, onetile);
+    cb_logx.wait_front(onetile);
+    cb_exp_lxmd.reserve_back(onetile);
 
     mul_tiles_init_with_dt(cb_logx, cb_decimal);
-    mul_tiles(cb_logx, cb_decimal, 0, 0, dst0);
+    mul_tiles(cb_logx.get_cb_id(), cb_decimal.get_cb_id(), 0, 0, dst0);
 
     exp_tile_init();
     exp_tile(dst0);
@@ -959,35 +954,35 @@ ALWI void power_tile_to_cb(
     pack_tile_with_dt(dst0, cb_exp_lxmd);
     tile_regs_release();
 
-    cb_pop_front(cb_logx, onetile);
-    cb_push_back(cb_exp_lxmd, onetile);
+    cb_logx.pop_front(onetile);
+    cb_exp_lxmd.push_back(onetile);
 
     // x^p * exp(log(x) * decimal)(==(x + decimal)^p)
     tile_regs_acquire();
-    cb_wait_front(cb_xpow, onetile);
-    cb_wait_front(cb_exp_lxmd, onetile);
-    cb_reserve_back(cb_correct_xpow, onetile);
+    cb_xpow.wait_front(onetile);
+    cb_exp_lxmd.wait_front(onetile);
+    cb_correct_xpow.reserve_back(onetile);
 
     mul_tiles_init_with_dt(cb_xpow, cb_exp_lxmd);
-    mul_tiles(cb_xpow, cb_exp_lxmd, 0, 0, dst0);
+    mul_tiles(cb_xpow.get_cb_id(), cb_exp_lxmd.get_cb_id(), 0, 0, dst0);
     tile_regs_commit();
 
     tile_regs_wait();
     pack_tile_with_dt(dst0, cb_correct_xpow);
     tile_regs_release();
 
-    cb_pop_front(cb_xpow, onetile);
-    cb_pop_front(cb_exp_lxmd, onetile);
-    cb_push_back(cb_correct_xpow, onetile);
+    cb_xpow.pop_front(onetile);
+    cb_exp_lxmd.pop_front(onetile);
+    cb_correct_xpow.push_back(onetile);
 }
 
 ALWI void power_tile_with_abs_x_to_cb(
-    std::uint8_t cb_x,
-    std::uint8_t cb_xpow,
-    std::uint8_t cb_logx,
-    std::uint8_t cb_decimal,
-    std::uint8_t cb_exp_lxmd,
-    std::uint8_t cb_correct_xpow,
+    CircularBuffer cb_x,
+    CircularBuffer cb_xpow,
+    CircularBuffer cb_logx,
+    CircularBuffer cb_decimal,
+    CircularBuffer cb_exp_lxmd,
+    CircularBuffer cb_correct_xpow,
     uint32_t p,
     bool p_is_negative) {
     constexpr uint32_t onetile = 1;
@@ -995,11 +990,11 @@ ALWI void power_tile_with_abs_x_to_cb(
 
     // x^p
     tile_regs_acquire();
-    cb_wait_front(cb_x, onetile);
-    cb_reserve_back(cb_xpow, onetile);
+    cb_x.wait_front(onetile);
+    cb_xpow.reserve_back(onetile);
 
     copy_tile_init_with_dt(cb_x);
-    copy_tile(cb_x, 0, dst0);
+    copy_tile(cb_x.get_cb_id(), 0, dst0);
 
     abs_tile_init();
     abs_tile(dst0);
@@ -1017,15 +1012,15 @@ ALWI void power_tile_with_abs_x_to_cb(
     pack_tile_with_dt(dst0, cb_xpow);
     tile_regs_release();
 
-    cb_push_back(cb_xpow, onetile);
+    cb_xpow.push_back(onetile);
     // We don't pop cb_x here.
 
     // log(x)
     tile_regs_acquire();
-    cb_reserve_back(cb_logx, onetile);
+    cb_logx.reserve_back(onetile);
 
     copy_tile_init_with_dt(cb_x);
-    copy_tile(cb_x, 0, dst0);
+    copy_tile(cb_x.get_cb_id(), 0, dst0);
 
     abs_tile_init();
     abs_tile(dst0);
@@ -1038,16 +1033,16 @@ ALWI void power_tile_with_abs_x_to_cb(
     pack_tile_with_dt(dst0, cb_logx);
     tile_regs_release();
 
-    cb_pop_front(cb_x, onetile);
-    cb_push_back(cb_logx, onetile);
+    cb_x.pop_front(onetile);
+    cb_logx.push_back(onetile);
 
     // exp(log(x) * decimal)
     tile_regs_acquire();
-    cb_wait_front(cb_logx, onetile);
-    cb_reserve_back(cb_exp_lxmd, onetile);
+    cb_logx.wait_front(onetile);
+    cb_exp_lxmd.reserve_back(onetile);
 
     mul_tiles_init_with_dt(cb_logx, cb_decimal);
-    mul_tiles(cb_logx, cb_decimal, 0, 0, dst0);
+    mul_tiles(cb_logx.get_cb_id(), cb_decimal.get_cb_id(), 0, 0, dst0);
 
     exp_tile_init();
     exp_tile(dst0);
@@ -1057,47 +1052,47 @@ ALWI void power_tile_with_abs_x_to_cb(
     pack_tile_with_dt(dst0, cb_exp_lxmd);
     tile_regs_release();
 
-    cb_pop_front(cb_logx, onetile);
-    cb_push_back(cb_exp_lxmd, onetile);
+    cb_logx.pop_front(onetile);
+    cb_exp_lxmd.push_back(onetile);
 
     // x^p * exp(log(x) * decimal)(==(x + decimal)^p)
     tile_regs_acquire();
-    cb_wait_front(cb_xpow, onetile);
-    cb_wait_front(cb_exp_lxmd, onetile);
-    cb_reserve_back(cb_correct_xpow, onetile);
+    cb_xpow.wait_front(onetile);
+    cb_exp_lxmd.wait_front(onetile);
+    cb_correct_xpow.reserve_back(onetile);
 
     mul_tiles_init_with_dt(cb_xpow, cb_exp_lxmd);
-    mul_tiles(cb_xpow, cb_exp_lxmd, 0, 0, dst0);
+    mul_tiles(cb_xpow.get_cb_id(), cb_exp_lxmd.get_cb_id(), 0, 0, dst0);
     tile_regs_commit();
 
     tile_regs_wait();
     pack_tile_with_dt(dst0, cb_correct_xpow);
     tile_regs_release();
 
-    cb_pop_front(cb_xpow, onetile);
-    cb_pop_front(cb_exp_lxmd, onetile);
-    cb_push_back(cb_correct_xpow, onetile);
+    cb_xpow.pop_front(onetile);
+    cb_exp_lxmd.pop_front(onetile);
+    cb_correct_xpow.push_back(onetile);
 }
 
 ALWI void power_and_recip_tile_to_cb(
-    std::uint8_t cb_x,
-    std::uint8_t cb_xpow,
-    std::uint8_t cb_logx,
-    std::uint8_t cb_decimal,
-    std::uint8_t cb_exp_lxmd,
-    std::uint8_t cb_recip_xpow,
+    CircularBuffer cb_x,
+    CircularBuffer cb_xpow,
+    CircularBuffer cb_logx,
+    CircularBuffer cb_decimal,
+    CircularBuffer cb_exp_lxmd,
+    CircularBuffer cb_recip_xpow,
     uint32_t p,
     bool p_is_negative) {
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
 
     // x^p
-    cb_wait_front(cb_x, onetile);
-    cb_reserve_back(cb_xpow, onetile);
+    cb_x.wait_front(onetile);
+    cb_xpow.reserve_back(onetile);
 
     tile_regs_acquire();
     copy_tile_init_with_dt(cb_x);
-    copy_tile(cb_x, 0, dst0);
+    copy_tile(cb_x.get_cb_id(), 0, dst0);
 
     power_iterative_tile_init();
     power_iterative_tile(dst0, p);
@@ -1112,15 +1107,15 @@ ALWI void power_and_recip_tile_to_cb(
     pack_tile_with_dt(dst0, cb_xpow);
     tile_regs_release();
 
-    cb_push_back(cb_xpow, onetile);
+    cb_xpow.push_back(onetile);
     // We don't pop cb_x here.
 
     // log(x)
-    cb_reserve_back(cb_logx, onetile);
+    cb_logx.reserve_back(onetile);
 
     tile_regs_acquire();
     copy_tile_init_with_dt(cb_x);
-    copy_tile(cb_x, 0, dst0);
+    copy_tile(cb_x.get_cb_id(), 0, dst0);
 
     log_tile_init();
     log_tile(dst0);
@@ -1130,16 +1125,16 @@ ALWI void power_and_recip_tile_to_cb(
     pack_tile_with_dt(dst0, cb_logx);
     tile_regs_release();
 
-    cb_pop_front(cb_x, onetile);
-    cb_push_back(cb_logx, onetile);
+    cb_x.pop_front(onetile);
+    cb_logx.push_back(onetile);
 
     // exp(log(x) * decimal)
-    cb_wait_front(cb_logx, onetile);
-    cb_reserve_back(cb_exp_lxmd, onetile);
+    cb_logx.wait_front(onetile);
+    cb_exp_lxmd.reserve_back(onetile);
 
     tile_regs_acquire();
     mul_tiles_init_with_dt(cb_logx, cb_decimal);
-    mul_tiles(cb_logx, cb_decimal, 0, 0, dst0);
+    mul_tiles(cb_logx.get_cb_id(), cb_decimal.get_cb_id(), 0, 0, dst0);
 
     exp_tile_init();
     exp_tile(dst0);
@@ -1149,17 +1144,17 @@ ALWI void power_and_recip_tile_to_cb(
     pack_tile_with_dt(dst0, cb_exp_lxmd);
     tile_regs_release();
 
-    cb_pop_front(cb_logx, onetile);
-    cb_push_back(cb_exp_lxmd, onetile);
+    cb_logx.pop_front(onetile);
+    cb_exp_lxmd.push_back(onetile);
 
     // 1 / (x^p * exp(log(x) * decimal))(==1 / (x + decimal)^p)
-    cb_wait_front(cb_xpow, onetile);
-    cb_wait_front(cb_exp_lxmd, onetile);
-    cb_reserve_back(cb_recip_xpow, onetile);
+    cb_xpow.wait_front(onetile);
+    cb_exp_lxmd.wait_front(onetile);
+    cb_recip_xpow.reserve_back(onetile);
 
     tile_regs_acquire();
     mul_tiles_init_with_dt(cb_xpow, cb_exp_lxmd);
-    mul_tiles(cb_xpow, cb_exp_lxmd, 0, 0, dst0);
+    mul_tiles(cb_xpow.get_cb_id(), cb_exp_lxmd.get_cb_id(), 0, 0, dst0);
 
     recip_tile_init();
     recip_tile(dst0);
@@ -1169,30 +1164,30 @@ ALWI void power_and_recip_tile_to_cb(
     pack_tile_with_dt(dst0, cb_recip_xpow);
     tile_regs_release();
 
-    cb_pop_front(cb_xpow, onetile);
-    cb_pop_front(cb_exp_lxmd, onetile);
-    cb_push_back(cb_recip_xpow, onetile);
+    cb_xpow.pop_front(onetile);
+    cb_exp_lxmd.pop_front(onetile);
+    cb_recip_xpow.push_back(onetile);
 }
 
-ALWI void copy_tile_to_dst(uint32_t icb, uint32_t itile = 0, uint32_t dst = 0, bool cb_wait_and_pop = true) {
+ALWI void copy_tile_to_dst(CircularBuffer icb, uint32_t itile = 0, uint32_t dst = 0, bool cb_wait_and_pop = true) {
     constexpr uint32_t onetile = 1;
     if (cb_wait_and_pop) {
-        cb_wait_front(icb, onetile);
+        icb.wait_front(onetile);
     }
-    reconfig_data_format_srca(icb);
-    copy_tile_to_dst_init_short(icb);
-    copy_tile(icb, itile, dst);
+    reconfig_data_format_srca(icb.get_cb_id());
+    copy_tile_to_dst_init_short(icb.get_cb_id());
+    copy_tile(icb.get_cb_id(), itile, dst);
     if (cb_wait_and_pop) {
-        cb_pop_front(icb, onetile);
+        icb.pop_front(onetile);
     }
 }
 
-ALWI void pack_tile_from_dst(uint32_t ocb, uint32_t dst = 0) {
+ALWI void pack_tile_from_dst(CircularBuffer ocb, uint32_t dst = 0) {
     constexpr uint32_t onetile = 1;
-    cb_reserve_back(ocb, onetile);
-    pack_reconfig_data_format(ocb);
-    pack_tile(dst, ocb);
-    cb_push_back(ocb, onetile);
+    ocb.reserve_back(onetile);
+    pack_reconfig_data_format(ocb.get_cb_id());
+    pack_tile(dst, ocb.get_cb_id());
+    ocb.push_back(onetile);
 }
 
 }  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/kernels/moreh_abs_pow_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/kernels/moreh_abs_pow_kernel.cpp
@@ -43,7 +43,11 @@ void kernel_main() {
     CircularBuffer cb_one_obj(cb_one);
     CircularBuffer cb_decimal_obj(cb_decimal);
     CircularBuffer cb_mask_w_obj(cb_mask_w);
+    CircularBuffer cb_y_obj(cb_y);
     CircularBuffer cb_xabs_obj(cb_xabs);
+    CircularBuffer cb_xpow_obj(cb_xpow);
+    CircularBuffer cb_logx_obj(cb_logx);
+    CircularBuffer cb_exp_lxmd_obj(cb_exp_lxmd);
 
     cb_one_obj.wait_front(onetile);
     cb_decimal_obj.wait_front(onetile);
@@ -61,11 +65,11 @@ void kernel_main() {
             cb_x_obj.wait_front(onetile);
             cb_xabs_obj.reserve_back(onetile);
 
-            copy_tile_init_with_dt(cb_x);
+            copy_tile_init_with_dt(cb_x_obj);
             copy_tile(cb_x, 0, dst0);
 
             if (do_mask_w && (col_idx == Wt - 1)) {
-                copy_tile_init_with_dt(cb_mask_w);
+                copy_tile_init_with_dt(cb_mask_w_obj);
                 copy_tile(cb_mask_w, 0, dst1);
 
                 mask_tile_init();
@@ -77,13 +81,14 @@ void kernel_main() {
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_xabs);
+            pack_tile_with_dt(dst0, cb_xabs_obj);
             tile_regs_release();
 
             cb_x_obj.pop_front(onetile);
             cb_xabs_obj.push_back(onetile);
 
-            power_tile_to_cb(cb_xabs, cb_xpow, cb_logx, cb_decimal, cb_exp_lxmd, cb_y, p, p_is_negative);
+            power_tile_to_cb(
+                cb_xabs_obj, cb_xpow_obj, cb_logx_obj, cb_decimal_obj, cb_exp_lxmd_obj, cb_y_obj, p, p_is_negative);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/kernels/moreh_adam.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/kernels/moreh_adam.cpp
@@ -71,6 +71,11 @@ void kernel_main() {
 #endif
     CircularBuffer cb_scalar_args_obj(cb_scalar_args);
     CircularBuffer cb_one_obj(cb_one);
+    CircularBuffer cb_param_out_obj(cb_param_out);
+    CircularBuffer cb_exp_avg_out_obj(cb_exp_avg_out);
+    CircularBuffer cb_exp_avg_sq_out_obj(cb_exp_avg_sq_out);
+    CircularBuffer tmp_cb_grad_obj(tmp_cb_grad);
+    CircularBuffer tmp_cb_exp_avg_obj(tmp_cb_exp_avg);
     CircularBuffer cb_tmp1_obj(cb_tmp1);
     CircularBuffer cb_tmp2_obj(cb_tmp2);
     CircularBuffer tmp_cb_exp_avg_sq_obj(tmp_cb_exp_avg_sq);
@@ -91,45 +96,45 @@ void kernel_main() {
         cb_max_exp_avg_sq_in_obj.wait_front(onetile);
 #endif
         // cb_tmp1 : param * weight_decay;
-        mul_tiles_to_cb(cb_param_in, cb_scalar_args, cb_tmp1, first_tile, weight_decay_tile, 0, 0);
+        mul_tiles_to_cb(cb_param_in_obj, cb_scalar_args_obj, cb_tmp1_obj, first_tile, weight_decay_tile, 0, 0);
 
         // tmp_cb_grad : cb_grad_in + cb_tmp1;
-        add_tiles_to_cb(cb_grad_in, cb_tmp1, tmp_cb_grad, first_tile, first_tile, 0, 1);
+        add_tiles_to_cb(cb_grad_in_obj, cb_tmp1_obj, tmp_cb_grad_obj, first_tile, first_tile, 0, 1);
 
         ////////////////////////////////////////////////////////////////////////
         // exp_avg = exp_avg * beta1 + grad * (1 - beta1);
         // cb_tmp1 = (1 - beta1)
-        sub_tiles_to_cb(cb_one, cb_scalar_args, cb_tmp1, first_tile, beta1_tile, 0, 0);
-        mul_tiles_to_cb(tmp_cb_grad, cb_tmp1, cb_tmp1, first_tile, first_tile, 0, 1);
+        sub_tiles_to_cb(cb_one_obj, cb_scalar_args_obj, cb_tmp1_obj, first_tile, beta1_tile, 0, 0);
+        mul_tiles_to_cb(tmp_cb_grad_obj, cb_tmp1_obj, cb_tmp1_obj, first_tile, first_tile, 0, 1);
 
         // tmp_cb_exp_avg = cb_exp_avg_in * beta1
-        mul_tiles_to_cb(cb_exp_avg_in, cb_scalar_args, tmp_cb_exp_avg, first_tile, beta1_tile, 0, 0);
+        mul_tiles_to_cb(cb_exp_avg_in_obj, cb_scalar_args_obj, tmp_cb_exp_avg_obj, first_tile, beta1_tile, 0, 0);
 
         // tmp_cb_exp_avg = tmp_cb_exp_avg + cb_tmp1
-        add_tiles_to_cb(tmp_cb_exp_avg, cb_tmp1, tmp_cb_exp_avg, first_tile, first_tile, 1, 1);
+        add_tiles_to_cb(tmp_cb_exp_avg_obj, cb_tmp1_obj, tmp_cb_exp_avg_obj, first_tile, first_tile, 1, 1);
 
         // cb_exp_avg_out
-        copy_tile_to_cb(tmp_cb_exp_avg, cb_exp_avg_out, first_tile, 0);
+        copy_tile_to_cb(tmp_cb_exp_avg_obj, cb_exp_avg_out_obj, first_tile, 0);
         //////////////////////////////////////////////////////////////////////
 
         ////////////////////////////////////////////////////////////////////////
         // exp_avg_sq = exp_avg_sq * beta2 + grad * grad * (1 - beta2);
-        sub_tiles_to_cb(cb_one, cb_scalar_args, cb_tmp1, first_tile, beta2_tile, 0, 0);
+        sub_tiles_to_cb(cb_one_obj, cb_scalar_args_obj, cb_tmp1_obj, first_tile, beta2_tile, 0, 0);
 
         // cb_tmp2 = grad * grad
-        mul_tiles_to_cb(tmp_cb_grad, tmp_cb_grad, cb_tmp2, first_tile, first_tile, 1, 0);
+        mul_tiles_to_cb(tmp_cb_grad_obj, tmp_cb_grad_obj, cb_tmp2_obj, first_tile, first_tile, 1, 0);
 
         // cb_tmp1 = cb_tmp1 * cb_tmp2
-        mul_tiles_to_cb(cb_tmp1, cb_tmp2, cb_tmp1, first_tile, first_tile, 1, 1);
+        mul_tiles_to_cb(cb_tmp1_obj, cb_tmp2_obj, cb_tmp1_obj, first_tile, first_tile, 1, 1);
 
         // tmp_cb_exp_avg_sq = cb_exp_avg_sq_in * beta2
-        mul_tiles_to_cb(cb_exp_avg_sq_in, cb_scalar_args, tmp_cb_exp_avg_sq, first_tile, beta2_tile, 0, 0);
+        mul_tiles_to_cb(cb_exp_avg_sq_in_obj, cb_scalar_args_obj, tmp_cb_exp_avg_sq_obj, first_tile, beta2_tile, 0, 0);
 
         // tmp_cb_exp_avg_sq = tmp_cb_exp_avg_sq + cb_tmp1
-        add_tiles_to_cb(tmp_cb_exp_avg_sq, cb_tmp1, tmp_cb_exp_avg_sq, first_tile, first_tile, 1, 1);
+        add_tiles_to_cb(tmp_cb_exp_avg_sq_obj, cb_tmp1_obj, tmp_cb_exp_avg_sq_obj, first_tile, first_tile, 1, 1);
 
         // cb_exp_avg_sq_out
-        copy_tile_to_cb(tmp_cb_exp_avg_sq, cb_exp_avg_sq_out, first_tile, 0);
+        copy_tile_to_cb(tmp_cb_exp_avg_sq_obj, cb_exp_avg_sq_out_obj, first_tile, 0);
         //////////////////////////////////////////////////////////////////////
 
         ////////////////////////////////////////////////////////////////////////
@@ -138,7 +143,7 @@ void kernel_main() {
         // bias_correction2 = 1 - pow(beta2, step);
         // cb_tmp1 = pow(beta2, step);
         tile_regs_acquire();
-        copy_tile_init_with_dt(cb_scalar_args);
+        copy_tile_init_with_dt(cb_scalar_args_obj);
         copy_tile(cb_scalar_args, beta2_tile, dst0);
         power_tile_init();
         power_tile(dst0, step);
@@ -146,7 +151,7 @@ void kernel_main() {
 
         tile_regs_wait();
         cb_tmp1_obj.reserve_back(onetile);
-        pack_tile_with_dt(dst0, cb_tmp1);
+        pack_tile_with_dt(dst0, cb_tmp1_obj);
         cb_tmp1_obj.push_back(onetile);
         tile_regs_release();
 
@@ -162,7 +167,7 @@ void kernel_main() {
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp1);
+        pack_tile_with_dt(dst0, cb_tmp1_obj);
         cb_tmp1_obj.pop_front(onetile);
         cb_tmp1_obj.push_back(onetile);
         tile_regs_release();
@@ -171,16 +176,16 @@ void kernel_main() {
         // tmp_cb_max_exp_avg_sq = max(cb_max_exp_avg_sq_in, tmp_cb_exp_avg_sq);
         tile_regs_acquire();
         tmp_cb_max_exp_avg_sq_obj.reserve_back(onetile);
-        copy_tile_init_with_dt(cb_max_exp_avg_sq_in);
+        copy_tile_init_with_dt(cb_max_exp_avg_sq_in_obj);
         copy_tile(cb_max_exp_avg_sq_in, first_tile, dst0);
-        copy_tile_init_with_dt(tmp_cb_exp_avg_sq);
+        copy_tile_init_with_dt(tmp_cb_exp_avg_sq_obj);
         copy_tile(tmp_cb_exp_avg_sq, first_tile, dst1);
         binary_max_tile_init();
         binary_max_tile(dst0, dst1, dst0);
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, tmp_cb_max_exp_avg_sq);
+        pack_tile_with_dt(dst0, tmp_cb_max_exp_avg_sq_obj);
         tmp_cb_max_exp_avg_sq_obj.push_back(onetile);
         tile_regs_release();
 
@@ -188,12 +193,12 @@ void kernel_main() {
         tile_regs_acquire();
         tmp_cb_max_exp_avg_sq_obj.wait_front(onetile);
         cb_max_exp_avg_sq_out_obj.reserve_back(onetile);
-        copy_tile_init_with_dt(tmp_cb_max_exp_avg_sq);
+        copy_tile_init_with_dt(tmp_cb_max_exp_avg_sq_obj);
         copy_tile(tmp_cb_max_exp_avg_sq, first_tile, dst0);
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_max_exp_avg_sq_out);
+        pack_tile_with_dt(dst0, cb_max_exp_avg_sq_out_obj);
         cb_max_exp_avg_sq_out_obj.push_back(onetile);
         tile_regs_release();
 #endif
@@ -214,7 +219,7 @@ void kernel_main() {
 #endif
         sqrt_tile_init();
         sqrt_tile(dst0);
-        pack_tile_with_dt(dst0, cb_tmp1);
+        pack_tile_with_dt(dst0, cb_tmp1_obj);
         tile_regs_commit();
 
         tile_regs_wait();
@@ -238,7 +243,7 @@ void kernel_main() {
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp1);
+        pack_tile_with_dt(dst0, cb_tmp1_obj);
         cb_tmp1_obj.pop_front(onetile);
         cb_tmp1_obj.push_back(onetile);
         tile_regs_release();
@@ -247,14 +252,14 @@ void kernel_main() {
         // cb_tmp2 = pow(beta1, step);
         tile_regs_acquire();
         cb_tmp2_obj.reserve_back(onetile);
-        copy_tile_init_with_dt(cb_scalar_args);
+        copy_tile_init_with_dt(cb_scalar_args_obj);
         copy_tile(cb_scalar_args, beta1_tile, dst0);
         power_tile_init();
         power_tile(dst0, step);
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp2);
+        pack_tile_with_dt(dst0, cb_tmp2_obj);
         cb_tmp2_obj.push_back(onetile);
         tile_regs_release();
 
@@ -271,21 +276,21 @@ void kernel_main() {
 
         tile_regs_wait();
         cb_tmp2_obj.reserve_back(onetile);
-        pack_tile_with_dt(dst0, cb_tmp2);
+        pack_tile_with_dt(dst0, cb_tmp2_obj);
         cb_tmp2_obj.push_back(onetile);
         tile_regs_release();
 
         // cb_tmp2 = lr * cb_tmp2;
-        mul_tiles_to_cb(cb_scalar_args, cb_tmp2, cb_tmp2, lr_tile, first_tile, 0, 1);
+        mul_tiles_to_cb(cb_scalar_args_obj, cb_tmp2_obj, cb_tmp2_obj, lr_tile, first_tile, 0, 1);
 
         // cb_tmp2 = cb_tmp2 * tmp_cb_exp_avg;
-        mul_tiles_to_cb(cb_tmp2, tmp_cb_exp_avg, cb_tmp2, first_tile, first_tile, 1, 1);
+        mul_tiles_to_cb(cb_tmp2_obj, tmp_cb_exp_avg_obj, cb_tmp2_obj, first_tile, first_tile, 1, 1);
 
         // cb_tmp1 = cb_tmp1 * cb_tmp2;
-        mul_tiles_to_cb(cb_tmp1, cb_tmp2, cb_tmp1, first_tile, first_tile, 1, 1);
+        mul_tiles_to_cb(cb_tmp1_obj, cb_tmp2_obj, cb_tmp1_obj, first_tile, first_tile, 1, 1);
 
         // param = param - cb_tmp1;
-        sub_tiles_to_cb(cb_param_in, cb_tmp1, cb_param_out, first_tile, first_tile, 0, 1);
+        sub_tiles_to_cb(cb_param_in_obj, cb_tmp1_obj, cb_param_out_obj, first_tile, first_tile, 0, 1);
 
         cb_param_in_obj.pop_front(onetile);
         cb_grad_in_obj.pop_front(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/kernels/moreh_adamw.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/kernels/moreh_adamw.cpp
@@ -35,14 +35,20 @@ void kernel_main() {
     constexpr auto cb_one = tt::CBIndex::c_6;
     CircularBuffer cb_one_obj(cb_one);
     constexpr auto cb_param_out = tt::CBIndex::c_16;
+    CircularBuffer cb_param_out_obj(cb_param_out);
     constexpr auto cb_exp_avg_out = tt::CBIndex::c_17;
+    CircularBuffer cb_exp_avg_out_obj(cb_exp_avg_out);
     constexpr auto cb_exp_avg_sq_out = tt::CBIndex::c_18;
+    CircularBuffer cb_exp_avg_sq_out_obj(cb_exp_avg_sq_out);
 #ifdef AMSGRAD
     constexpr auto cb_max_exp_avg_sq_out = tt::CBIndex::c_19;
+    CircularBuffer cb_max_exp_avg_sq_out_obj(cb_max_exp_avg_sq_out);
 #endif
 
     constexpr auto tmp_cb_param = tt::CBIndex::c_24;
+    CircularBuffer tmp_cb_param_obj(tmp_cb_param);
     constexpr auto tmp_cb_exp_avg = tt::CBIndex::c_25;
+    CircularBuffer tmp_cb_exp_avg_obj(tmp_cb_exp_avg);
     constexpr auto tmp_cb_exp_avg_sq = tt::CBIndex::c_26;
     CircularBuffer tmp_cb_exp_avg_sq_obj(tmp_cb_exp_avg_sq);
 #ifdef AMSGRAD
@@ -86,30 +92,32 @@ void kernel_main() {
 #endif
         // param = param - lr * weight_decay * param.
         // cb_tmp1 : weight_decay * cb_param_in
-        mul_tiles_to_cb(cb_scalar_args, cb_param_in, cb_tmp1, weight_decay_tile, first_tile, /*pop0=*/0, /*pop1=*/0);
+        mul_tiles_to_cb(
+            cb_scalar_args_obj, cb_param_in_obj, cb_tmp1_obj, weight_decay_tile, first_tile, /*pop0=*/0, /*pop1=*/0);
 
         // cb_tmp1 : lr * cb_tmp1
-        mul_tiles_to_cb(cb_scalar_args, cb_tmp1, cb_tmp1, lr_tile, first_tile, /*pop0=*/0, /*pop1=*/1);
+        mul_tiles_to_cb(cb_scalar_args_obj, cb_tmp1_obj, cb_tmp1_obj, lr_tile, first_tile, /*pop0=*/0, /*pop1=*/1);
 
         // tmp_cb_param : cb_param_in - cb_tmp1
-        sub_tiles_to_cb(cb_param_in, cb_tmp1, tmp_cb_param, first_tile, first_tile, /*pop0=*/0, /*pop1=*/1);
+        sub_tiles_to_cb(cb_param_in_obj, cb_tmp1_obj, tmp_cb_param_obj, first_tile, first_tile, /*pop0=*/0, /*pop1=*/1);
 
         ////////////////////////////////////////////////////////////////////////
         // exp_avg = exp_avg * beta1 + grad * (1 - beta1);
         // cb_tmp1 = (1 - beta1)
-        sub_tiles_to_cb(cb_one, cb_scalar_args, cb_tmp1, first_tile, beta1_tile, /*pop0=*/0, /*pop1=*/0);
+        sub_tiles_to_cb(cb_one_obj, cb_scalar_args_obj, cb_tmp1_obj, first_tile, beta1_tile, /*pop0=*/0, /*pop1=*/0);
 
         // cb_tmp1 = cb_grad_in * cb_tmp1
-        mul_tiles_to_cb(cb_grad_in, cb_tmp1, cb_tmp1, first_tile, first_tile, /*pop0=*/0, /*pop1=*/1);
+        mul_tiles_to_cb(cb_grad_in_obj, cb_tmp1_obj, cb_tmp1_obj, first_tile, first_tile, /*pop0=*/0, /*pop1=*/1);
 
         // tmp_cb_exp_avg = cb_exp_avg_in * beta1
-        mul_tiles_to_cb(cb_exp_avg_in, cb_scalar_args, tmp_cb_exp_avg, first_tile, beta1_tile, /*pop0=*/0, /*pop1=*/0);
+        mul_tiles_to_cb(
+            cb_exp_avg_in_obj, cb_scalar_args_obj, tmp_cb_exp_avg_obj, first_tile, beta1_tile, /*pop0=*/0, /*pop1=*/0);
 
         // tmp_cb_exp_avg = tmp_cb_exp_avg + cb_tmp1
-        add_tiles_to_cb(tmp_cb_exp_avg, cb_tmp1, tmp_cb_exp_avg, first_tile, first_tile);
+        add_tiles_to_cb(tmp_cb_exp_avg_obj, cb_tmp1_obj, tmp_cb_exp_avg_obj, first_tile, first_tile);
 
         // cb_exp_avg_out
-        copy_tile_to_cb(tmp_cb_exp_avg, cb_exp_avg_out, first_tile, /*pop=*/0);
+        copy_tile_to_cb(tmp_cb_exp_avg_obj, cb_exp_avg_out_obj, first_tile, /*pop=*/0);
         //////////////////////////////////////////////////////////////////////
 
         ////////////////////////////////////////////////////////////////////////
@@ -117,30 +125,36 @@ void kernel_main() {
         // cb_tmp1 = (1 - beta2)
         tile_regs_acquire();
         cb_tmp1_obj.reserve_back(onetile);
-        sub_tiles_init_with_dt(cb_one, cb_scalar_args);
+        sub_tiles_init_with_dt(cb_one_obj, cb_scalar_args_obj);
         sub_tiles(cb_one, cb_scalar_args, first_tile, beta2_tile, dst0);
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp1);
+        pack_tile_with_dt(dst0, cb_tmp1_obj);
         cb_tmp1_obj.push_back(onetile);
         tile_regs_release();
 
         // cb_tmp2 = grad * grad
-        mul_tiles_to_cb(cb_grad_in, cb_grad_in, cb_tmp2, first_tile, first_tile, /*pop0=*/0, /*pop1=*/0);
+        mul_tiles_to_cb(cb_grad_in_obj, cb_grad_in_obj, cb_tmp2_obj, first_tile, first_tile, /*pop0=*/0, /*pop1=*/0);
 
         // cb_tmp1 = cb_tmp1 * cb_tmp2
-        mul_tiles_to_cb(cb_tmp1, cb_tmp2, cb_tmp1, first_tile, first_tile);
+        mul_tiles_to_cb(cb_tmp1_obj, cb_tmp2_obj, cb_tmp1_obj, first_tile, first_tile);
 
         // tmp_cb_exp_avg_sq = cb_exp_avg_sq_in * beta2
         mul_tiles_to_cb(
-            cb_exp_avg_sq_in, cb_scalar_args, tmp_cb_exp_avg_sq, first_tile, beta2_tile, /*pop0=*/0, /*pop1=*/0);
+            cb_exp_avg_sq_in_obj,
+            cb_scalar_args_obj,
+            tmp_cb_exp_avg_sq_obj,
+            first_tile,
+            beta2_tile,
+            /*pop0=*/0,
+            /*pop1=*/0);
 
         // tmp_cb_exp_avg_sq = tmp_cb_exp_avg_sq + cb_tmp1
-        add_tiles_to_cb(tmp_cb_exp_avg_sq, cb_tmp1, tmp_cb_exp_avg_sq, first_tile, first_tile);
+        add_tiles_to_cb(tmp_cb_exp_avg_sq_obj, cb_tmp1_obj, tmp_cb_exp_avg_sq_obj, first_tile, first_tile);
 
         // cb_exp_avg_sq_out
-        copy_tile_to_cb(tmp_cb_exp_avg_sq, cb_exp_avg_sq_out, first_tile, /*pop=*/0);
+        copy_tile_to_cb(tmp_cb_exp_avg_sq_obj, cb_exp_avg_sq_out_obj, first_tile, /*pop=*/0);
         //////////////////////////////////////////////////////////////////////
 
         ////////////////////////////////////////////////////////////////////////
@@ -152,14 +166,14 @@ void kernel_main() {
         // cb_tmp1 = 1 / (1 - cb_beta2_exponent);
         tile_regs_acquire();
         cb_tmp1_obj.reserve_back(onetile);
-        sub_tiles_init_with_dt(cb_one, cb_beta2_exponent);
+        sub_tiles_init_with_dt(cb_one_obj, cb_beta2_exponent_obj);
         sub_tiles(cb_one, cb_beta2_exponent, first_tile, first_tile, dst0);
         recip_tile_init();
         recip_tile(dst0);
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp1);
+        pack_tile_with_dt(dst0, cb_tmp1_obj);
         cb_tmp1_obj.push_back(onetile);
         tile_regs_release();
 
@@ -167,21 +181,21 @@ void kernel_main() {
         // tmp_cb_max_exp_avg_sq = max(cb_max_exp_avg_sq_in, tmp_cb_exp_avg_sq);
         tile_regs_acquire();
         tmp_cb_max_exp_avg_sq_obj.reserve_back(onetile);
-        copy_tile_init_with_dt(cb_max_exp_avg_sq_in);
+        copy_tile_init_with_dt(cb_max_exp_avg_sq_in_obj);
         copy_tile(cb_max_exp_avg_sq_in, first_tile, dst0);
-        copy_tile_init_with_dt(tmp_cb_exp_avg_sq);
+        copy_tile_init_with_dt(tmp_cb_exp_avg_sq_obj);
         copy_tile(tmp_cb_exp_avg_sq, first_tile, dst1);
         binary_max_tile_init();
         binary_max_tile(dst0, dst1, dst0);
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, tmp_cb_max_exp_avg_sq);
+        pack_tile_with_dt(dst0, tmp_cb_max_exp_avg_sq_obj);
         tmp_cb_max_exp_avg_sq_obj.push_back(onetile);
         tile_regs_release();
 
         // cb_max_exp_avg_sq_out
-        copy_tile_to_cb(tmp_cb_max_exp_avg_sq, cb_max_exp_avg_sq_out, first_tile, /*pop=*/0);
+        copy_tile_to_cb(tmp_cb_max_exp_avg_sq_obj, cb_max_exp_avg_sq_out_obj, first_tile, /*pop=*/0);
 #endif
 
         // cb_tmp1 = sqrt(exp_avg_sq / cb_tmp1);
@@ -189,10 +203,10 @@ void kernel_main() {
         cb_tmp1_obj.wait_front(onetile);
         cb_tmp1_obj.reserve_back(onetile);
 #ifdef AMSGRAD
-        mul_tiles_init_with_dt(tmp_cb_max_exp_avg_sq, cb_tmp1);
+        mul_tiles_init_with_dt(tmp_cb_max_exp_avg_sq_obj, cb_tmp1_obj);
         mul_tiles(tmp_cb_max_exp_avg_sq, cb_tmp1, first_tile, first_tile, dst0);
 #else
-        mul_tiles_init_with_dt(tmp_cb_exp_avg_sq, cb_tmp1);
+        mul_tiles_init_with_dt(tmp_cb_exp_avg_sq_obj, cb_tmp1_obj);
         mul_tiles(tmp_cb_exp_avg_sq, cb_tmp1, first_tile, first_tile, dst0);
 #endif
         sqrt_tile_init();
@@ -200,7 +214,7 @@ void kernel_main() {
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp1);
+        pack_tile_with_dt(dst0, cb_tmp1_obj);
         cb_tmp1_obj.pop_front(onetile);
         cb_tmp1_obj.push_back(onetile);
 #ifdef AMSGRAD
@@ -213,14 +227,14 @@ void kernel_main() {
         tile_regs_acquire();
         cb_tmp1_obj.wait_front(onetile);
         cb_tmp1_obj.reserve_back(onetile);
-        add_tiles_init_with_dt(cb_tmp1, cb_scalar_args);
+        add_tiles_init_with_dt(cb_tmp1_obj, cb_scalar_args_obj);
         add_tiles(cb_tmp1, cb_scalar_args, first_tile, eps_tile, dst0);
         recip_tile_init();
         recip_tile(dst0);
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp1);
+        pack_tile_with_dt(dst0, cb_tmp1_obj);
         cb_tmp1_obj.pop_front(onetile);
         cb_tmp1_obj.push_back(onetile);
         tile_regs_release();
@@ -231,28 +245,28 @@ void kernel_main() {
         // cb_tmp2 = 1 / (1 - cb_beta1_exponent);
         tile_regs_acquire();
         cb_tmp2_obj.reserve_back(onetile);
-        sub_tiles_init_with_dt(cb_one, cb_beta1_exponent);
+        sub_tiles_init_with_dt(cb_one_obj, cb_beta1_exponent_obj);
         sub_tiles(cb_one, cb_beta1_exponent, first_tile, first_tile, dst0);
         recip_tile_init();
         recip_tile(dst0);
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp2);
+        pack_tile_with_dt(dst0, cb_tmp2_obj);
         cb_tmp2_obj.push_back(onetile);
         tile_regs_release();
 
         // cb_tmp2 = lr * cb_tmp2;
-        mul_tiles_to_cb(cb_scalar_args, cb_tmp2, cb_tmp2, lr_tile, first_tile, /*pop0=*/0, /*pop1=*/1);
+        mul_tiles_to_cb(cb_scalar_args_obj, cb_tmp2_obj, cb_tmp2_obj, lr_tile, first_tile, /*pop0=*/0, /*pop1=*/1);
 
         // cb_tmp2 = cb_tmp2 * tmp_cb_exp_avg;
-        mul_tiles_to_cb(cb_tmp2, tmp_cb_exp_avg, cb_tmp2, first_tile, first_tile);
+        mul_tiles_to_cb(cb_tmp2_obj, tmp_cb_exp_avg_obj, cb_tmp2_obj, first_tile, first_tile);
 
         // cb_tmp1 = cb_tmp1 * cb_tmp2;
-        mul_tiles_to_cb(cb_tmp1, cb_tmp2, cb_tmp1, first_tile, first_tile);
+        mul_tiles_to_cb(cb_tmp1_obj, cb_tmp2_obj, cb_tmp1_obj, first_tile, first_tile);
 
         // param = tmp_cb_param - cb_tmp1;
-        sub_tiles_to_cb(tmp_cb_param, cb_tmp1, cb_param_out, first_tile, first_tile);
+        sub_tiles_to_cb(tmp_cb_param_obj, cb_tmp1_obj, cb_param_out_obj, first_tile, first_tile);
 
         cb_param_in_obj.pop_front(onetile);
         cb_grad_in_obj.pop_front(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/kernels/moreh_clip_grad_norm_step1_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/kernels/moreh_clip_grad_norm_step1_kernel.cpp
@@ -33,10 +33,13 @@ void kernel_main() {
     constexpr auto cb_xabs = intermed_id + 0;
     CircularBuffer cb_xabs_obj(cb_xabs);         // |x|
     constexpr auto cb_xpow = intermed_id + 1;    // |x|^p
+    CircularBuffer cb_xpow_obj(cb_xpow);
     constexpr auto cb_xpowadd = intermed_id + 2;
     CircularBuffer cb_xpowadd_obj(cb_xpowadd);   // Add[|x|^p * exp(log(|x|) * decimal)]
     constexpr auto cb_logx = intermed_id + 3;    // log(|x|)
+    CircularBuffer cb_logx_obj(cb_logx);
     constexpr auto cb_exp_lxmd = intermed_id + 4;  // exp(log(|x|) * decimal)
+    CircularBuffer cb_exp_lxmd_obj(cb_exp_lxmd);
     constexpr auto cb_correct_xpow = intermed_id + 5;
     CircularBuffer cb_correct_xpow_obj(cb_correct_xpow);  // |x|^p * exp(log(|x|) * decimal)
 
@@ -100,7 +103,15 @@ void kernel_main() {
         tile_regs_release();
 
         // |x + decimal|^p
-        power_tile_to_cb(cb_xabs, cb_xpow, cb_logx, cb_decimal, cb_exp_lxmd, cb_correct_xpow, p, p_is_negative);
+        power_tile_to_cb(
+            cb_xabs_obj,
+            cb_xpow_obj,
+            cb_logx_obj,
+            cb_decimal_obj,
+            cb_exp_lxmd_obj,
+            cb_correct_xpow_obj,
+            p,
+            p_is_negative);
 
         if (tile_idx == 0) {
             tile_regs_acquire();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/kernels/moreh_clip_grad_norm_step2_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/kernels/moreh_clip_grad_norm_step2_kernel.cpp
@@ -20,13 +20,17 @@ void kernel_main() {
     std::uint8_t output_id{16};
     // x^p * exp(log(x) * decimal)
     const auto cb_y = output_id++;  // output(==total_norm)
+    CircularBuffer cb_y_obj(cb_y);
 
     std::uint8_t intermed_id{24};
     const auto cb_x = intermed_id++;
     CircularBuffer cb_x_obj(cb_x);           // Sum[tmp_pow_sum](==x)
     const auto cb_xpow = intermed_id++;      // x^p
+    CircularBuffer cb_xpow_obj(cb_xpow);
     const auto cb_logx = intermed_id++;      // log(x)
+    CircularBuffer cb_logx_obj(cb_logx);
     const auto cb_exp_lxmd = intermed_id++;  // exp(log(x) * decimal)
+    CircularBuffer cb_exp_lxmd_obj(cb_exp_lxmd);
 
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
@@ -74,5 +78,5 @@ void kernel_main() {
         }
     }
     // x^p
-    power_tile_to_cb(cb_x, cb_xpow, cb_logx, cb_decimal, cb_exp_lxmd, cb_y, p, p_is_negative);
+    power_tile_to_cb(cb_x_obj, cb_xpow_obj, cb_logx_obj, cb_decimal_obj, cb_exp_lxmd_obj, cb_y_obj, p, p_is_negative);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/moreh_layer_norm_large_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/moreh_layer_norm_large_kernel.cpp
@@ -99,18 +99,18 @@ void kernel_main() {
                     tile_regs_acquire();
                     cb_xsum_obj.reserve_back(onetile);
 
-                    copy_tile_init_with_dt(cb_x);
+                    copy_tile_init_with_dt(cb_x_obj);
                     copy_tile(cb_x, first_tile, dst0);  // input
 
                     if (do_mask_h && need_to_do_mask_h(w_idx, origin_Ht, origin_Wt)) {
-                        copy_tile_init_with_dt(cb_mask_h);
+                        copy_tile_init_with_dt(cb_mask_h_obj);
                         copy_tile(cb_mask_h, first_tile, dst1);  // mask_h
                         mask_tile_init();
                         mask_tile(dst0, dst1);
                     }
 
                     if (do_mask_w && ((w_idx + 1) % origin_Wt == 0)) {
-                        copy_tile_init_with_dt(cb_mask_w);
+                        copy_tile_init_with_dt(cb_mask_w_obj);
                         copy_tile(cb_mask_w, first_tile, dst1);  // mask_w
                         mask_tile_init();
                         mask_tile(dst0, dst1);
@@ -118,7 +118,7 @@ void kernel_main() {
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(dst0, cb_xsum);
+                    pack_tile_with_dt(dst0, cb_xsum_obj);
                     cb_xsum_obj.push_back(onetile);
                     tile_regs_release();
                 } else {
@@ -128,20 +128,20 @@ void kernel_main() {
                     CircularBuffer cb_tmp_obj(cb_tmp);
                     cb_tmp_obj.reserve_back(onetile);
 
-                    copy_tile_init_with_dt(cb_x);
+                    copy_tile_init_with_dt(cb_x_obj);
                     copy_tile(cb_x, j, j);  // input
 
                     const uint32_t mask_dst = j < 15 ? j + 1 : 0;
 
                     if (do_mask_h && need_to_do_mask_h(w_idx, origin_Ht, origin_Wt)) {
-                        copy_tile_init_with_dt(cb_mask_h);
+                        copy_tile_init_with_dt(cb_mask_h_obj);
                         copy_tile(cb_mask_h, first_tile, mask_dst);  // mask_h
                         mask_tile_init();
                         mask_tile(j, mask_dst);
                     }
 
                     if (do_mask_w && ((w_idx + 1) % origin_Wt == 0)) {
-                        copy_tile_init_with_dt(cb_mask_w);
+                        copy_tile_init_with_dt(cb_mask_w_obj);
                         copy_tile(cb_mask_w, first_tile, mask_dst);  // mask_w
                         mask_tile_init();
                         mask_tile(j, mask_dst);
@@ -149,7 +149,7 @@ void kernel_main() {
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(j, cb_tmp);
+                    pack_tile_with_dt(j, cb_tmp_obj);
                     cb_tmp_obj.push_back(onetile);
                     tile_regs_release();
 
@@ -158,12 +158,12 @@ void kernel_main() {
                     cb_xsum_obj.wait_front(onetile);
                     cb_xsum_obj.reserve_back(onetile);
 
-                    add_tiles_init_with_dt(cb_xsum, cb_tmp);
+                    add_tiles_init_with_dt(cb_xsum_obj, cb_tmp_obj);
                     add_tiles(cb_xsum, cb_tmp, first_tile, first_tile, dst0);
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(dst0, cb_xsum);
+                    pack_tile_with_dt(dst0, cb_xsum_obj);
 
                     cb_tmp_obj.pop_front(onetile);
                     cb_xsum_obj.pop_front(onetile);
@@ -187,12 +187,12 @@ void kernel_main() {
             tile_regs_acquire();
             cb_mean_obj.reserve_back(onetile);
 
-            copy_tile_init_with_dt(cb_ex, is_lastdim_layernorm);
+            copy_tile_init_with_dt(cb_ex_obj, is_lastdim_layernorm);
             copy_tile(cb_ex, first_tile, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_mean);
+            pack_tile_with_dt(dst0, cb_mean_obj);
 
             cb_mean_obj.push_back(onetile);
             tile_regs_release();
@@ -209,16 +209,16 @@ void kernel_main() {
             for (uint32_t j = 0; j < block_size; j++) {
                 tile_regs_acquire();
                 if (is_lastdim_layernorm) {
-                    sub_bcast_cols_init_short_with_dt(cb_x, cb_ex);
+                    sub_bcast_cols_init_short_with_dt(cb_x_obj, cb_ex_obj);
                     sub_tiles_bcast_cols(cb_x, cb_ex, j, first_tile, j);
                 } else {
-                    sub_tiles_bcast_scalar_init_short_with_dt(cb_x, cb_ex);
+                    sub_tiles_bcast_scalar_init_short_with_dt(cb_x_obj, cb_ex_obj);
                     sub_tiles_bcast_scalar(cb_x, cb_ex, j, first_tile, j);
                 }
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(j, cb_xmm);
+                pack_tile_with_dt(j, cb_xmm_obj);
                 tile_regs_release();
             }  // block_size loop
             cb_x_obj.pop_front(block_size);
@@ -233,21 +233,21 @@ void kernel_main() {
                 for (uint32_t j = 0; j < block_size; j++) {
                     tile_regs_acquire();
 
-                    copy_tile_init_with_dt(cb_xmm);
+                    copy_tile_init_with_dt(cb_xmm_obj);
                     copy_tile(cb_xmm, j, j);  // xmm
 
                     const uint32_t mask_dst = j < 15 ? j + 1 : 0;
                     const uint32_t w_idx = inner_idx + j;
 
                     if (do_mask_h && need_to_do_mask_h(w_idx, origin_Ht, origin_Wt)) {
-                        copy_tile_init_with_dt(cb_mask_h);
+                        copy_tile_init_with_dt(cb_mask_h_obj);
                         copy_tile(cb_mask_h, first_tile, mask_dst);  // mask_h
                         mask_tile_init();
                         mask_tile(j, mask_dst);
                     }
 
                     if (do_mask_w && (w_idx + 1) % origin_Wt == 0) {
-                        copy_tile_init_with_dt(cb_mask_w);
+                        copy_tile_init_with_dt(cb_mask_w_obj);
                         copy_tile(cb_mask_w, first_tile, mask_dst);  // mask_w
                         mask_tile_init();
                         mask_tile(j, mask_dst);
@@ -256,7 +256,7 @@ void kernel_main() {
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(j, cb_xmm);
+                    pack_tile_with_dt(j, cb_xmm_obj);
                     tile_regs_release();
                 }  // block_size loop
                 cb_xmm_obj.pop_front(block_size);
@@ -271,12 +271,12 @@ void kernel_main() {
             cb_xmm2_obj.reserve_back(block_size);
             for (uint32_t j = 0; j < block_size; j++) {
                 tile_regs_acquire();
-                mul_tiles_init_with_dt(cb_xmm, cb_xmm);
+                mul_tiles_init_with_dt(cb_xmm_obj, cb_xmm_obj);
                 mul_tiles(cb_xmm, cb_xmm, j, j, j);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(j, cb_xmm2);
+                pack_tile_with_dt(j, cb_xmm2_obj);
 
                 tile_regs_release();
             }  // block_size loop
@@ -293,12 +293,12 @@ void kernel_main() {
                     tile_regs_acquire();
                     cb_xmm2sum_obj.reserve_back(onetile);
 
-                    copy_tile_init_with_dt(cb_xmm2);
+                    copy_tile_init_with_dt(cb_xmm2_obj);
                     copy_tile(cb_xmm2, first_tile, dst0);
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(dst0, cb_xmm2sum);
+                    pack_tile_with_dt(dst0, cb_xmm2sum_obj);
 
                     cb_xmm2sum_obj.push_back(onetile);
                     tile_regs_release();
@@ -307,12 +307,12 @@ void kernel_main() {
                     cb_xmm2sum_obj.wait_front(onetile);
                     cb_xmm2sum_obj.reserve_back(onetile);
 
-                    add_tiles_init_with_dt(cb_xmm2sum, cb_xmm2);
+                    add_tiles_init_with_dt(cb_xmm2sum_obj, cb_xmm2_obj);
                     add_tiles(cb_xmm2sum, cb_xmm2, first_tile, j, dst0);
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(dst0, cb_xmm2sum);
+                    pack_tile_with_dt(dst0, cb_xmm2sum_obj);
 
                     cb_xmm2sum_obj.pop_front(onetile);
                     cb_xmm2sum_obj.push_back(onetile);
@@ -338,7 +338,7 @@ void kernel_main() {
         cb_var_obj.wait_front(onetile);
         cb_recip_std_obj.reserve_back(onetile);
 
-        add_tiles_init_with_dt(cb_var, cb_eps);
+        add_tiles_init_with_dt(cb_var_obj, cb_eps_obj);
         add_tiles(cb_var, cb_eps, first_tile, first_tile, dst0);
 
         rsqrt_tile_init();
@@ -346,7 +346,7 @@ void kernel_main() {
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_recip_std);
+        pack_tile_with_dt(dst0, cb_recip_std_obj);
 
         cb_var_obj.pop_front(onetile);
         cb_recip_std_obj.push_back(onetile);
@@ -358,12 +358,12 @@ void kernel_main() {
             tile_regs_acquire();
             cb_rstd_obj.reserve_back(onetile);
 
-            copy_tile_init_with_dt(cb_recip_std, is_lastdim_layernorm);
+            copy_tile_init_with_dt(cb_recip_std_obj, is_lastdim_layernorm);
             copy_tile(cb_recip_std, first_tile, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_rstd);
+            pack_tile_with_dt(dst0, cb_rstd_obj);
 
             cb_rstd_obj.push_back(onetile);
             tile_regs_release();
@@ -386,16 +386,16 @@ void kernel_main() {
             for (uint32_t j = 0; j < block_size; j++) {
                 tile_regs_acquire();
                 if (is_lastdim_layernorm) {
-                    sub_bcast_cols_init_short_with_dt(cb_x, cb_ex);
+                    sub_bcast_cols_init_short_with_dt(cb_x_obj, cb_ex_obj);
                     sub_tiles_bcast_cols(cb_x, cb_ex, j, first_tile, j);
                 } else {
-                    sub_tiles_bcast_scalar_init_short_with_dt(cb_x, cb_ex);
+                    sub_tiles_bcast_scalar_init_short_with_dt(cb_x_obj, cb_ex_obj);
                     sub_tiles_bcast_scalar(cb_x, cb_ex, j, first_tile, j);
                 }
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(j, cb_reuse);
+                pack_tile_with_dt(j, cb_reuse_obj);
                 tile_regs_release();
             }  // block_size loop
             cb_x_obj.pop_front(block_size);
@@ -412,16 +412,16 @@ void kernel_main() {
             for (uint32_t j = 0; j < block_size; j++) {
                 tile_regs_acquire();
                 if (is_lastdim_layernorm) {
-                    mul_bcast_cols_init_short_with_dt(cb_reuse, cb_recip_std);
+                    mul_bcast_cols_init_short_with_dt(cb_reuse_obj, cb_recip_std_obj);
                     mul_tiles_bcast_cols(cb_reuse, cb_recip_std, j, first_tile, j);
                 } else {
-                    mul_tiles_bcast_scalar_init_short_with_dt(cb_reuse, cb_recip_std);
+                    mul_tiles_bcast_scalar_init_short_with_dt(cb_reuse_obj, cb_recip_std_obj);
                     mul_tiles_bcast_scalar(cb_reuse, cb_recip_std, j, first_tile, j);
                 }
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(j, cb_gamma_beta_or_out);
+                pack_tile_with_dt(j, cb_gamma_beta_or_out_obj);
                 tile_regs_release();
             }  // block_size loop
             cb_reuse_obj.pop_front(block_size);
@@ -437,21 +437,21 @@ void kernel_main() {
                 for (uint32_t j = 0; j < block_size; j++) {
                     tile_regs_acquire();
                     if (is_groupnorm) {
-                        mul_tiles_bcast_scalar_init_short_with_dt(cb_gamma_beta_or_out, cb_gamma);
+                        mul_tiles_bcast_scalar_init_short_with_dt(cb_gamma_beta_or_out_obj, cb_gamma_obj);
                         mul_tiles_bcast_scalar(cb_gamma_beta_or_out, cb_gamma, j, j, j);
                     } else {
                         if (is_lastdim_layernorm) {
-                            mul_bcast_rows_init_short_with_dt(cb_gamma_beta_or_out, cb_gamma);
+                            mul_bcast_rows_init_short_with_dt(cb_gamma_beta_or_out_obj, cb_gamma_obj);
                             mul_tiles_bcast_rows(cb_gamma_beta_or_out, cb_gamma, j, j, j);
                         } else {
-                            mul_tiles_init_with_dt(cb_gamma_beta_or_out, cb_gamma);
+                            mul_tiles_init_with_dt(cb_gamma_beta_or_out_obj, cb_gamma_obj);
                             mul_tiles(cb_gamma_beta_or_out, cb_gamma, j, j, j);
                         }
                     }
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(j, cb_outg);
+                    pack_tile_with_dt(j, cb_outg_obj);
                     tile_regs_release();
                 }  // block_size loop
                 cb_gamma_beta_or_out_obj.pop_front(block_size);
@@ -467,21 +467,21 @@ void kernel_main() {
                 for (uint32_t j = 0; j < block_size; j++) {
                     tile_regs_acquire();
                     if (is_groupnorm) {
-                        add_bcast_scalar_init_short_with_dt(cb_gamma_beta, cb_beta);
+                        add_bcast_scalar_init_short_with_dt(cb_gamma_beta_obj, cb_beta_obj);
                         add_tiles_bcast_scalar(cb_gamma_beta, cb_beta, j, j, j);
                     } else {
                         if (is_lastdim_layernorm) {
-                            add_bcast_rows_init_short_with_dt(cb_gamma_beta, cb_beta);
+                            add_bcast_rows_init_short_with_dt(cb_gamma_beta_obj, cb_beta_obj);
                             add_tiles_bcast_rows(cb_gamma_beta, cb_beta, j, j, j);
                         } else {
-                            add_tiles_init_with_dt(cb_gamma_beta, cb_beta);
+                            add_tiles_init_with_dt(cb_gamma_beta_obj, cb_beta_obj);
                             add_tiles(cb_gamma_beta, cb_beta, j, j, j);
                         }
                     }
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(j, cb_out);
+                    pack_tile_with_dt(j, cb_out_obj);
                     tile_regs_release();
                 }  // block_size loop
                 cb_gamma_beta_obj.pop_front(block_size);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/moreh_layer_norm_small_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/moreh_layer_norm_small_kernel.cpp
@@ -102,11 +102,11 @@ void kernel_main() {
                     tile_regs_acquire();
                     cb_xsum_obj.reserve_back(onetile);
 
-                    copy_tile_init_with_dt(cb_x);
+                    copy_tile_init_with_dt(cb_x_obj);
                     copy_tile(cb_x, first_tile, dst0);  // input
 
                     if (do_mask_h && need_to_do_mask_h(w_idx, origin_Ht, origin_Wt)) {
-                        copy_tile_init_with_dt(cb_mask_h);
+                        copy_tile_init_with_dt(cb_mask_h_obj);
                         copy_tile(cb_mask_h, first_tile, dst1);  // mask_h
 
                         mask_tile_init();
@@ -114,7 +114,7 @@ void kernel_main() {
                     }
 
                     if (do_mask_w && ((w_idx + 1) % origin_Wt == 0)) {
-                        copy_tile_init_with_dt(cb_mask_w);
+                        copy_tile_init_with_dt(cb_mask_w_obj);
                         copy_tile(cb_mask_w, first_tile, dst1);  // mask_w
 
                         mask_tile_init();
@@ -123,7 +123,7 @@ void kernel_main() {
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(dst0, cb_xsum);
+                    pack_tile_with_dt(dst0, cb_xsum_obj);
                     cb_xsum_obj.push_back(onetile);
                     tile_regs_release();
                 } else {
@@ -133,13 +133,13 @@ void kernel_main() {
                     CircularBuffer cb_tmp_obj(cb_tmp);
                     cb_tmp_obj.reserve_back(onetile);
 
-                    copy_tile_init_with_dt(cb_x);
+                    copy_tile_init_with_dt(cb_x_obj);
                     copy_tile(cb_x, inner_idx + j, dst0);  // input
 
                     const uint32_t mask_dst = dst0 < 15 ? dst0 + 1 : 0;
 
                     if (do_mask_h && need_to_do_mask_h(w_idx, origin_Ht, origin_Wt)) {
-                        copy_tile_init_with_dt(cb_mask_h);
+                        copy_tile_init_with_dt(cb_mask_h_obj);
                         copy_tile(cb_mask_h, first_tile, mask_dst);  // mask_h
 
                         mask_tile_init();
@@ -147,7 +147,7 @@ void kernel_main() {
                     }
 
                     if (do_mask_w && ((w_idx + 1) % origin_Wt == 0)) {
-                        copy_tile_init_with_dt(cb_mask_w);
+                        copy_tile_init_with_dt(cb_mask_w_obj);
                         copy_tile(cb_mask_w, first_tile, mask_dst);  // mask_w
 
                         mask_tile_init();
@@ -156,7 +156,7 @@ void kernel_main() {
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(dst0, cb_tmp);
+                    pack_tile_with_dt(dst0, cb_tmp_obj);
                     cb_tmp_obj.push_back(onetile);
                     tile_regs_release();
 
@@ -165,12 +165,12 @@ void kernel_main() {
                     cb_xsum_obj.wait_front(onetile);
                     cb_xsum_obj.reserve_back(onetile);
 
-                    add_tiles_init_with_dt(cb_xsum, cb_tmp);
+                    add_tiles_init_with_dt(cb_xsum_obj, cb_tmp_obj);
                     add_tiles(cb_xsum, cb_tmp, first_tile, first_tile, dst0);
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(dst0, cb_xsum);
+                    pack_tile_with_dt(dst0, cb_xsum_obj);
 
                     cb_tmp_obj.pop_front(onetile);
                     cb_xsum_obj.pop_front(onetile);
@@ -194,12 +194,12 @@ void kernel_main() {
             tile_regs_acquire();
             cb_mean_obj.reserve_back(onetile);
 
-            copy_tile_init_with_dt(cb_ex, is_lastdim_layernorm);
+            copy_tile_init_with_dt(cb_ex_obj, is_lastdim_layernorm);
             copy_tile(cb_ex, first_tile, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_mean);
+            pack_tile_with_dt(dst0, cb_mean_obj);
 
             cb_mean_obj.push_back(onetile);
             tile_regs_release();
@@ -216,24 +216,24 @@ void kernel_main() {
                 const uint32_t w_idx = inner_idx + j;
                 tile_regs_acquire();
                 if (is_lastdim_layernorm) {
-                    sub_bcast_cols_init_short_with_dt(cb_x, cb_ex);
+                    sub_bcast_cols_init_short_with_dt(cb_x_obj, cb_ex_obj);
                     sub_tiles_bcast_cols(cb_x, cb_ex, w_idx, first_tile, j);
                 } else {
-                    sub_tiles_bcast_scalar_init_short_with_dt(cb_x, cb_ex);
+                    sub_tiles_bcast_scalar_init_short_with_dt(cb_x_obj, cb_ex_obj);
                     sub_tiles_bcast_scalar(cb_x, cb_ex, w_idx, first_tile, j);
                 }
                 // mask xmm
                 if (do_mask_h || do_mask_w) {
                     const uint32_t mask_dst = j < 15 ? j + 1 : 0;
                     if (do_mask_h && need_to_do_mask_h(w_idx, origin_Ht, origin_Wt)) {
-                        copy_tile_init_with_dt(cb_mask_h);
+                        copy_tile_init_with_dt(cb_mask_h_obj);
                         copy_tile(cb_mask_h, first_tile, mask_dst);  // mask_h
 
                         mask_tile_init();
                         mask_tile(j, mask_dst);
                     }
                     if (do_mask_w && (w_idx + 1) % origin_Wt == 0) {
-                        copy_tile_init_with_dt(cb_mask_w);
+                        copy_tile_init_with_dt(cb_mask_w_obj);
                         copy_tile(cb_mask_w, first_tile, mask_dst);  // mask_w
 
                         mask_tile_init();
@@ -243,7 +243,7 @@ void kernel_main() {
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(j, cb_xmm);
+                pack_tile_with_dt(j, cb_xmm_obj);
                 tile_regs_release();
             }  // block_size loop
             cb_xmm_obj.push_back(block_size);
@@ -260,12 +260,12 @@ void kernel_main() {
             tile_regs_acquire();
             cb_xmm2_obj.reserve_back(onetile);
 
-            mul_tiles_init_with_dt(cb_xmm, cb_xmm);
+            mul_tiles_init_with_dt(cb_xmm_obj, cb_xmm_obj);
             mul_tiles(cb_xmm, cb_xmm, inner_idx, inner_idx, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_xmm2);
+            pack_tile_with_dt(dst0, cb_xmm2_obj);
 
             cb_xmm2_obj.push_back(onetile);
             tile_regs_release();
@@ -274,12 +274,12 @@ void kernel_main() {
                 cb_xmm2_obj.wait_front(onetile);
                 cb_xmm2sum_obj.reserve_back(onetile);
 
-                copy_tile_init_with_dt(cb_xmm2);
+                copy_tile_init_with_dt(cb_xmm2_obj);
                 copy_tile(cb_xmm2, first_tile, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_xmm2sum);
+                pack_tile_with_dt(dst0, cb_xmm2sum_obj);
 
                 cb_xmm2_obj.pop_front(onetile);
                 cb_xmm2sum_obj.push_back(onetile);
@@ -290,12 +290,12 @@ void kernel_main() {
                 cb_xmm2_obj.wait_front(onetile);
                 cb_xmm2sum_obj.reserve_back(onetile);
 
-                add_tiles_init_with_dt(cb_xmm2sum, cb_xmm2);
+                add_tiles_init_with_dt(cb_xmm2sum_obj, cb_xmm2_obj);
                 add_tiles(cb_xmm2sum, cb_xmm2, first_tile, first_tile, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_xmm2sum);
+                pack_tile_with_dt(dst0, cb_xmm2sum_obj);
 
                 cb_xmm2sum_obj.pop_front(onetile);
                 cb_xmm2_obj.pop_front(onetile);
@@ -320,7 +320,7 @@ void kernel_main() {
         cb_recip_std_obj.reserve_back(onetile);
 
         tile_regs_acquire();
-        add_tiles_init_with_dt(cb_var, cb_eps);
+        add_tiles_init_with_dt(cb_var_obj, cb_eps_obj);
         add_tiles(cb_var, cb_eps, first_tile, first_tile, dst0);
 
         rsqrt_tile_init();
@@ -328,7 +328,7 @@ void kernel_main() {
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_recip_std);
+        pack_tile_with_dt(dst0, cb_recip_std_obj);
 
         cb_var_obj.pop_front(onetile);
         cb_recip_std_obj.push_back(onetile);
@@ -340,12 +340,12 @@ void kernel_main() {
             tile_regs_acquire();
             cb_rstd_obj.reserve_back(onetile);
 
-            copy_tile_init_with_dt(cb_recip_std, is_lastdim_layernorm);
+            copy_tile_init_with_dt(cb_recip_std_obj, is_lastdim_layernorm);
             copy_tile(cb_recip_std, first_tile, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_rstd);
+            pack_tile_with_dt(dst0, cb_rstd_obj);
 
             cb_rstd_obj.push_back(onetile);
             tile_regs_release();
@@ -363,16 +363,16 @@ void kernel_main() {
             for (uint32_t j = 0; j < block_size; j++) {
                 tile_regs_acquire();
                 if (is_lastdim_layernorm) {
-                    mul_bcast_cols_init_short_with_dt(cb_xmm, cb_recip_std);
+                    mul_bcast_cols_init_short_with_dt(cb_xmm_obj, cb_recip_std_obj);
                     mul_tiles_bcast_cols(cb_xmm, cb_recip_std, inner_idx + j, first_tile, j);
                 } else {
-                    mul_tiles_bcast_scalar_init_short_with_dt(cb_xmm, cb_recip_std);
+                    mul_tiles_bcast_scalar_init_short_with_dt(cb_xmm_obj, cb_recip_std_obj);
                     mul_tiles_bcast_scalar(cb_xmm, cb_recip_std, inner_idx + j, first_tile, j);
                 }
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(j, cb_gamma_beta_or_out);
+                pack_tile_with_dt(j, cb_gamma_beta_or_out_obj);
                 tile_regs_release();
             }  // block_size loop
             cb_gamma_beta_or_out_obj.push_back(block_size);
@@ -387,21 +387,21 @@ void kernel_main() {
                 for (uint32_t j = 0; j < block_size; j++) {
                     tile_regs_acquire();
                     if (is_groupnorm) {
-                        mul_tiles_bcast_scalar_init_short_with_dt(cb_gamma_beta_or_out, cb_gamma);
+                        mul_tiles_bcast_scalar_init_short_with_dt(cb_gamma_beta_or_out_obj, cb_gamma_obj);
                         mul_tiles_bcast_scalar(cb_gamma_beta_or_out, cb_gamma, j, j, j);
                     } else {
                         if (is_lastdim_layernorm) {
-                            mul_bcast_rows_init_short_with_dt(cb_gamma_beta_or_out, cb_gamma);
+                            mul_bcast_rows_init_short_with_dt(cb_gamma_beta_or_out_obj, cb_gamma_obj);
                             mul_tiles_bcast_rows(cb_gamma_beta_or_out, cb_gamma, j, j, j);
                         } else {
-                            mul_tiles_init_with_dt(cb_gamma_beta_or_out, cb_gamma);
+                            mul_tiles_init_with_dt(cb_gamma_beta_or_out_obj, cb_gamma_obj);
                             mul_tiles(cb_gamma_beta_or_out, cb_gamma, j, j, j);
                         }
                     }
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(j, cb_outg);
+                    pack_tile_with_dt(j, cb_outg_obj);
                     tile_regs_release();
                 }  // block_size loop
                 cb_gamma_beta_or_out_obj.pop_front(block_size);
@@ -417,21 +417,21 @@ void kernel_main() {
                 for (uint32_t j = 0; j < block_size; j++) {
                     tile_regs_acquire();
                     if (is_groupnorm) {
-                        add_bcast_scalar_init_short_with_dt(cb_gamma_beta, cb_beta);
+                        add_bcast_scalar_init_short_with_dt(cb_gamma_beta_obj, cb_beta_obj);
                         add_tiles_bcast_scalar(cb_gamma_beta, cb_beta, j, j, j);
                     } else {
                         if (is_lastdim_layernorm) {
-                            add_bcast_rows_init_short_with_dt(cb_gamma_beta, cb_beta);
+                            add_bcast_rows_init_short_with_dt(cb_gamma_beta_obj, cb_beta_obj);
                             add_tiles_bcast_rows(cb_gamma_beta, cb_beta, j, j, j);
                         } else {
-                            add_tiles_init_with_dt(cb_gamma_beta, cb_beta);
+                            add_tiles_init_with_dt(cb_gamma_beta_obj, cb_beta_obj);
                             add_tiles(cb_gamma_beta, cb_beta, j, j, j);
                         }
                     }
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(j, cb_out);
+                    pack_tile_with_dt(j, cb_out_obj);
                     tile_regs_release();
                 }  // block_size loop
                 cb_gamma_beta_obj.pop_front(block_size);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/moreh_layer_norm_backward_gamma_beta_grad_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/moreh_layer_norm_backward_gamma_beta_grad_kernel.cpp
@@ -100,11 +100,11 @@ void kernel_main() {
             cb_dy_obj.wait_front(onetile);  // comes from the reader
             cb_dycopy_obj.reserve_back(onetile);
 
-            copy_tile_init_with_dt(cb_dy);
+            copy_tile_init_with_dt(cb_dy_obj);
             copy_tile(cb_dy, 0, dst0);
 
             if (do_mask_h && ((h_idx + 1) % origin_Ht == 0)) {
-                copy_tile_init_with_dt(cb_mask_h);
+                copy_tile_init_with_dt(cb_mask_h_obj);
                 copy_tile(cb_mask_h, 0, dst1);
 
                 mask_tile_init();
@@ -112,7 +112,7 @@ void kernel_main() {
             }
 
             if (do_mask_w && ((w_idx + 1) % origin_Wt == 0)) {
-                copy_tile_init_with_dt(cb_mask_w);
+                copy_tile_init_with_dt(cb_mask_w_obj);
                 copy_tile(cb_mask_w, 0, dst1);
 
                 mask_tile_init();
@@ -121,7 +121,7 @@ void kernel_main() {
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_dycopy);
+            pack_tile_with_dt(dst0, cb_dycopy_obj);
 
             cb_dy_obj.pop_front(onetile);
             cb_dycopy_obj.push_back(onetile);
@@ -134,12 +134,12 @@ void kernel_main() {
                     tile_regs_acquire();
                     cb_dyadd_obj.reserve_back(onetile);
 
-                    copy_tile_init_with_dt(cb_dycopy);
+                    copy_tile_init_with_dt(cb_dycopy_obj);
                     copy_tile(cb_dycopy, 0, dst0);
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(dst0, cb_dyadd);
+                    pack_tile_with_dt(dst0, cb_dyadd_obj);
 
                     cb_dyadd_obj.push_back(onetile);
                     tile_regs_release();
@@ -148,12 +148,12 @@ void kernel_main() {
                     cb_dyadd_obj.wait_front(onetile);
                     cb_dyadd_obj.reserve_back(onetile);
 
-                    add_tiles_init_with_dt(cb_dyadd, cb_dycopy);
+                    add_tiles_init_with_dt(cb_dyadd_obj, cb_dycopy_obj);
                     add_tiles(cb_dyadd, cb_dycopy, 0, 0, dst0);
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(dst0, cb_dyadd);
+                    pack_tile_with_dt(dst0, cb_dyadd_obj);
 
                     cb_dyadd_obj.pop_front(onetile);
                     cb_dyadd_obj.push_back(onetile);
@@ -171,15 +171,15 @@ void kernel_main() {
                 cb_xmm_obj.reserve_back(onetile);
 
                 if (is_lastdim_layernorm) {
-                    sub_bcast_cols_init_short_with_dt(cb_x, cb_mean);
+                    sub_bcast_cols_init_short_with_dt(cb_x_obj, cb_mean_obj);
                     sub_tiles_bcast_cols(cb_x, cb_mean, 0, 0, dst0);
                 } else {
-                    sub_tiles_bcast_scalar_init_short_with_dt(cb_x, cb_mean);
+                    sub_tiles_bcast_scalar_init_short_with_dt(cb_x_obj, cb_mean_obj);
                     sub_tiles_bcast_scalar(cb_x, cb_mean, 0, 0, dst0);
                 }
 
                 if (do_mask_h && ((h_idx + 1) % origin_Ht == 0)) {
-                    copy_tile_init_with_dt(cb_mask_h);
+                    copy_tile_init_with_dt(cb_mask_h_obj);
                     copy_tile(cb_mask_h, 0, dst1);
 
                     mask_tile_init();
@@ -187,7 +187,7 @@ void kernel_main() {
                 }
 
                 if (do_mask_w && ((w_idx + 1) % origin_Wt == 0)) {
-                    copy_tile_init_with_dt(cb_mask_w);
+                    copy_tile_init_with_dt(cb_mask_w_obj);
                     copy_tile(cb_mask_w, 0, dst1);
 
                     mask_tile_init();
@@ -196,7 +196,7 @@ void kernel_main() {
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_xmm);
+                pack_tile_with_dt(dst0, cb_xmm_obj);
 
                 cb_x_obj.pop_front(onetile);
                 cb_mean_obj.pop_front(onetile);
@@ -211,16 +211,16 @@ void kernel_main() {
                 cb_y_obj.reserve_back(onetile);
 
                 if (is_lastdim_layernorm) {
-                    mul_bcast_cols_init_short_with_dt(cb_xmm, cb_rstd);
+                    mul_bcast_cols_init_short_with_dt(cb_xmm_obj, cb_rstd_obj);
                     mul_tiles_bcast_cols(cb_xmm, cb_rstd, 0, 0, dst0);
                 } else {
-                    mul_tiles_bcast_scalar_init_short_with_dt(cb_xmm, cb_rstd);
+                    mul_tiles_bcast_scalar_init_short_with_dt(cb_xmm_obj, cb_rstd_obj);
                     mul_tiles_bcast_scalar(cb_xmm, cb_rstd, 0, 0, dst0);
                 }
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_y);
+                pack_tile_with_dt(dst0, cb_y_obj);
 
                 cb_xmm_obj.pop_front(onetile);
                 cb_rstd_obj.pop_front(onetile);
@@ -232,12 +232,12 @@ void kernel_main() {
                 cb_y_obj.wait_front(onetile);
                 cb_ydy_obj.reserve_back(onetile);
 
-                mul_tiles_init_with_dt(cb_y, cb_dycopy);
+                mul_tiles_init_with_dt(cb_y_obj, cb_dycopy_obj);
                 mul_tiles(cb_y, cb_dycopy, 0, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_ydy);
+                pack_tile_with_dt(dst0, cb_ydy_obj);
 
                 cb_y_obj.pop_front(onetile);
                 cb_ydy_obj.push_back(onetile);
@@ -249,12 +249,12 @@ void kernel_main() {
                     cb_ydy_obj.wait_front(onetile);
                     cb_ydyadd_obj.reserve_back(onetile);
 
-                    copy_tile_init_with_dt(cb_ydy);
+                    copy_tile_init_with_dt(cb_ydy_obj);
                     copy_tile(cb_ydy, 0, dst0);
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(dst0, cb_ydyadd);
+                    pack_tile_with_dt(dst0, cb_ydyadd_obj);
 
                     cb_ydy_obj.pop_front(onetile);
                     cb_ydyadd_obj.push_back(onetile);
@@ -265,12 +265,12 @@ void kernel_main() {
                     cb_ydyadd_obj.wait_front(onetile);
                     cb_ydyadd_obj.reserve_back(onetile);
 
-                    add_tiles_init_with_dt(cb_ydyadd, cb_ydy);
+                    add_tiles_init_with_dt(cb_ydyadd_obj, cb_ydy_obj);
                     add_tiles(cb_ydyadd, cb_ydy, 0, 0, dst0);
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(dst0, cb_ydyadd);
+                    pack_tile_with_dt(dst0, cb_ydyadd_obj);
 
                     cb_ydy_obj.pop_front(onetile);
                     cb_ydyadd_obj.pop_front(onetile);
@@ -294,12 +294,12 @@ void kernel_main() {
                 cb_ydyadd_obj.wait_front(onetile);
                 cb_dgamma_obj.reserve_back(onetile);
 
-                copy_tile_init_with_dt(cb_ydyadd);
+                copy_tile_init_with_dt(cb_ydyadd_obj);
                 copy_tile(cb_ydyadd, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_dgamma);
+                pack_tile_with_dt(dst0, cb_dgamma_obj);
 
                 cb_ydyadd_obj.pop_front(onetile);
                 cb_dgamma_obj.push_back(onetile);
@@ -319,12 +319,12 @@ void kernel_main() {
                 cb_dyadd_obj.wait_front(onetile);
                 cb_dbeta_obj.reserve_back(onetile);
 
-                copy_tile_init_with_dt(cb_dyadd);
+                copy_tile_init_with_dt(cb_dyadd_obj);
                 copy_tile(cb_dyadd, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_dbeta);
+                pack_tile_with_dt(dst0, cb_dbeta_obj);
 
                 cb_dyadd_obj.pop_front(onetile);
                 cb_dbeta_obj.push_back(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/moreh_layer_norm_backward_input_grad_large_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/moreh_layer_norm_backward_input_grad_large_kernel.cpp
@@ -98,16 +98,16 @@ void kernel_main() {
             cb_xmm_obj.reserve_back(onetile);
 
             if (is_lastdim_layernorm) {
-                sub_bcast_cols_init_short_with_dt(cb_x, cb_mean);
+                sub_bcast_cols_init_short_with_dt(cb_x_obj, cb_mean_obj);
                 sub_tiles_bcast_cols(cb_x, cb_mean, 0, 0, dst0);
             } else {
-                sub_tiles_bcast_scalar_init_short_with_dt(cb_x, cb_mean);
+                sub_tiles_bcast_scalar_init_short_with_dt(cb_x_obj, cb_mean_obj);
                 sub_tiles_bcast_scalar(cb_x, cb_mean, 0, 0, dst0);
             }
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_xmm);
+            pack_tile_with_dt(dst0, cb_xmm_obj);
 
             cb_x_obj.pop_front(onetile);
             cb_xmm_obj.push_back(onetile);
@@ -120,15 +120,15 @@ void kernel_main() {
             cb_y_obj.reserve_back(onetile);
 
             if (is_lastdim_layernorm) {
-                mul_bcast_cols_init_short_with_dt(cb_xmm, cb_rstd);
+                mul_bcast_cols_init_short_with_dt(cb_xmm_obj, cb_rstd_obj);
                 mul_tiles_bcast_cols(cb_xmm, cb_rstd, 0, 0, dst0);
             } else {
-                mul_tiles_bcast_scalar_init_short_with_dt(cb_xmm, cb_rstd);
+                mul_tiles_bcast_scalar_init_short_with_dt(cb_xmm_obj, cb_rstd_obj);
                 mul_tiles_bcast_scalar(cb_xmm, cb_rstd, 0, 0, dst0);
             }
 
             if (do_mask_h && need_to_do_mask_h(wt, origin_Ht, origin_Wt)) {
-                copy_tile_init_with_dt(cb_mask_h_w);
+                copy_tile_init_with_dt(cb_mask_h_w_obj);
                 copy_tile(cb_mask_h_w, 0, dst1);
 
                 mask_tile_init();
@@ -136,7 +136,7 @@ void kernel_main() {
             }
 
             if (do_mask_w && ((wt + 1) % origin_Wt == 0)) {
-                copy_tile_init_with_dt(cb_mask_h_w);
+                copy_tile_init_with_dt(cb_mask_h_w_obj);
                 copy_tile(cb_mask_h_w, 1, dst1);
 
                 mask_tile_init();
@@ -145,7 +145,7 @@ void kernel_main() {
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_y);
+            pack_tile_with_dt(dst0, cb_y_obj);
 
             cb_xmm_obj.pop_front(onetile);
             cb_y_obj.push_back(onetile);
@@ -161,20 +161,20 @@ void kernel_main() {
                 cb_gamma_obj.wait_front(onetile);  // comes from the reader
 
                 if (is_groupnorm) {
-                    mul_tiles_bcast_scalar_init_short_with_dt(cb_dy, cb_gamma);
+                    mul_tiles_bcast_scalar_init_short_with_dt(cb_dy_obj, cb_gamma_obj);
                     mul_tiles_bcast_scalar(cb_dy, cb_gamma, 0, 0, dst0);
                 } else {
                     if (is_lastdim_layernorm) {
-                        mul_bcast_rows_init_short_with_dt(cb_dy, cb_gamma);
+                        mul_bcast_rows_init_short_with_dt(cb_dy_obj, cb_gamma_obj);
                         mul_tiles_bcast_rows(cb_dy, cb_gamma, 0, 0, dst0);
                     } else {
-                        mul_tiles_init_with_dt(cb_dy, cb_gamma);
+                        mul_tiles_init_with_dt(cb_dy_obj, cb_gamma_obj);
                         mul_tiles(cb_dy, cb_gamma, 0, 0, dst0);
                     }
                 }
 
                 if (do_mask_h && need_to_do_mask_h(wt, origin_Ht, origin_Wt)) {
-                    copy_tile_init_with_dt(cb_mask_h_w);
+                    copy_tile_init_with_dt(cb_mask_h_w_obj);
                     copy_tile(cb_mask_h_w, 0, dst1);
 
                     mask_tile_init();
@@ -182,7 +182,7 @@ void kernel_main() {
                 }
 
                 if (do_mask_w && ((wt + 1) % origin_Wt == 0)) {
-                    copy_tile_init_with_dt(cb_mask_h_w);
+                    copy_tile_init_with_dt(cb_mask_h_w_obj);
                     copy_tile(cb_mask_h_w, 1, dst1);
 
                     mask_tile_init();
@@ -191,7 +191,7 @@ void kernel_main() {
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_dycopy);
+                pack_tile_with_dt(dst0, cb_dycopy_obj);
 
                 cb_dy_obj.pop_front(onetile);
                 cb_gamma_obj.pop_front(onetile);
@@ -203,11 +203,11 @@ void kernel_main() {
                 tile_regs_acquire();
                 cb_dy_obj.wait_front(onetile);  // comes from the reader
 
-                copy_tile_init_with_dt(cb_dy);
+                copy_tile_init_with_dt(cb_dy_obj);
                 copy_tile(cb_dy, 0, dst0);
 
                 if (do_mask_h && need_to_do_mask_h(wt, origin_Ht, origin_Wt)) {
-                    copy_tile_init_with_dt(cb_mask_h_w);
+                    copy_tile_init_with_dt(cb_mask_h_w_obj);
                     copy_tile(cb_mask_h_w, 0, dst1);
 
                     mask_tile_init();
@@ -215,7 +215,7 @@ void kernel_main() {
                 }
 
                 if (do_mask_w && ((wt + 1) % origin_Wt == 0)) {
-                    copy_tile_init_with_dt(cb_mask_h_w);
+                    copy_tile_init_with_dt(cb_mask_h_w_obj);
                     copy_tile(cb_mask_h_w, 1, dst1);
 
                     mask_tile_init();
@@ -224,7 +224,7 @@ void kernel_main() {
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_dycopy);
+                pack_tile_with_dt(dst0, cb_dycopy_obj);
 
                 cb_dy_obj.pop_front(onetile);
                 cb_dycopy_obj.push_back(onetile);
@@ -237,12 +237,12 @@ void kernel_main() {
                 tile_regs_acquire();
                 cb_dyadd_obj.reserve_back(onetile);
 
-                copy_tile_init_with_dt(cb_dycopy);
+                copy_tile_init_with_dt(cb_dycopy_obj);
                 copy_tile(cb_dycopy, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_dyadd);
+                pack_tile_with_dt(dst0, cb_dyadd_obj);
 
                 cb_dyadd_obj.push_back(onetile);
                 tile_regs_release();
@@ -251,12 +251,12 @@ void kernel_main() {
                 cb_dyadd_obj.wait_front(onetile);
                 cb_dyadd_obj.reserve_back(onetile);
 
-                add_tiles_init_with_dt(cb_dyadd, cb_dycopy);
+                add_tiles_init_with_dt(cb_dyadd_obj, cb_dycopy_obj);
                 add_tiles(cb_dyadd, cb_dycopy, 0, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_dyadd);
+                pack_tile_with_dt(dst0, cb_dyadd_obj);
 
                 cb_dyadd_obj.pop_front(onetile);
                 cb_dyadd_obj.push_back(onetile);
@@ -272,12 +272,12 @@ void kernel_main() {
             cb_y_obj.wait_front(onetile);
             cb_ydy_obj.reserve_back(onetile);
 
-            mul_tiles_init_with_dt(cb_y, cb_dycopy);
+            mul_tiles_init_with_dt(cb_y_obj, cb_dycopy_obj);
             mul_tiles(cb_y, cb_dycopy, 0, 0, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_ydy);
+            pack_tile_with_dt(dst0, cb_ydy_obj);
 
             cb_y_obj.pop_front(onetile);
             cb_dycopy_obj.pop_front(onetile);
@@ -290,12 +290,12 @@ void kernel_main() {
                 cb_ydy_obj.wait_front(onetile);
                 cb_ydyadd_obj.reserve_back(onetile);
 
-                copy_tile_init_with_dt(cb_ydy);
+                copy_tile_init_with_dt(cb_ydy_obj);
                 copy_tile(cb_ydy, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_ydyadd);
+                pack_tile_with_dt(dst0, cb_ydyadd_obj);
 
                 cb_ydy_obj.pop_front(onetile);
                 cb_ydyadd_obj.push_back(onetile);
@@ -306,12 +306,12 @@ void kernel_main() {
                 cb_ydyadd_obj.wait_front(onetile);
                 cb_ydyadd_obj.reserve_back(onetile);
 
-                add_tiles_init_with_dt(cb_ydyadd, cb_ydy);
+                add_tiles_init_with_dt(cb_ydyadd_obj, cb_ydy_obj);
                 add_tiles(cb_ydyadd, cb_ydy, 0, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_ydyadd);
+                pack_tile_with_dt(dst0, cb_ydyadd_obj);
 
                 cb_ydy_obj.pop_front(onetile);
                 cb_ydyadd_obj.pop_front(onetile);
@@ -338,16 +338,16 @@ void kernel_main() {
         cb_recip_nrstd_obj.reserve_back(onetile);
 
         if (is_lastdim_layernorm) {
-            mul_bcast_cols_init_short_with_dt(cb_n_recip_n, cb_rstd);
+            mul_bcast_cols_init_short_with_dt(cb_n_recip_n_obj, cb_rstd_obj);
             mul_tiles_bcast_cols(cb_n_recip_n, cb_rstd, 1, 0, dst0);
         } else {
-            mul_tiles_bcast_scalar_init_short_with_dt(cb_n_recip_n, cb_rstd);
+            mul_tiles_bcast_scalar_init_short_with_dt(cb_n_recip_n_obj, cb_rstd_obj);
             mul_tiles_bcast_scalar(cb_n_recip_n, cb_rstd, 1, 0, dst0);
         }
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_recip_nrstd);
+        pack_tile_with_dt(dst0, cb_recip_nrstd_obj);
 
         cb_recip_nrstd_obj.push_back(onetile);
         tile_regs_release();
@@ -368,20 +368,20 @@ void kernel_main() {
                 cb_gamma_obj.wait_front(onetile);  // comes from the reader
 
                 if (is_groupnorm) {
-                    mul_tiles_bcast_scalar_init_short_with_dt(cb_dy, cb_gamma);
+                    mul_tiles_bcast_scalar_init_short_with_dt(cb_dy_obj, cb_gamma_obj);
                     mul_tiles_bcast_scalar(cb_dy, cb_gamma, 0, 0, dst0);
                 } else {
                     if (is_lastdim_layernorm) {
-                        mul_bcast_rows_init_short_with_dt(cb_dy, cb_gamma);
+                        mul_bcast_rows_init_short_with_dt(cb_dy_obj, cb_gamma_obj);
                         mul_tiles_bcast_rows(cb_dy, cb_gamma, 0, 0, dst0);
                     } else {
-                        mul_tiles_init_with_dt(cb_dy, cb_gamma);
+                        mul_tiles_init_with_dt(cb_dy_obj, cb_gamma_obj);
                         mul_tiles(cb_dy, cb_gamma, 0, 0, dst0);
                     }
                 }
 
                 if (do_mask_h && need_to_do_mask_h(wt, origin_Ht, origin_Wt)) {
-                    copy_tile_init_with_dt(cb_mask_h_w);
+                    copy_tile_init_with_dt(cb_mask_h_w_obj);
                     copy_tile(cb_mask_h_w, 0, dst1);
 
                     mask_tile_init();
@@ -389,7 +389,7 @@ void kernel_main() {
                 }
 
                 if (do_mask_w && ((wt + 1) % origin_Wt == 0)) {
-                    copy_tile_init_with_dt(cb_mask_h_w);
+                    copy_tile_init_with_dt(cb_mask_h_w_obj);
                     copy_tile(cb_mask_h_w, 1, dst1);
 
                     mask_tile_init();
@@ -398,7 +398,7 @@ void kernel_main() {
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_dycopy);
+                pack_tile_with_dt(dst0, cb_dycopy_obj);
 
                 cb_dy_obj.pop_front(onetile);
                 cb_gamma_obj.pop_front(onetile);
@@ -410,11 +410,11 @@ void kernel_main() {
                 tile_regs_acquire();
                 cb_dy_obj.wait_front(onetile);  // comes from the reader
 
-                copy_tile_init_with_dt(cb_dy);
+                copy_tile_init_with_dt(cb_dy_obj);
                 copy_tile(cb_dy, 0, dst0);
 
                 if (do_mask_h && need_to_do_mask_h(wt, origin_Ht, origin_Wt)) {
-                    copy_tile_init_with_dt(cb_mask_h_w);
+                    copy_tile_init_with_dt(cb_mask_h_w_obj);
                     copy_tile(cb_mask_h_w, 0, dst1);
 
                     mask_tile_init();
@@ -422,7 +422,7 @@ void kernel_main() {
                 }
 
                 if (do_mask_w && ((wt + 1) % origin_Wt == 0)) {
-                    copy_tile_init_with_dt(cb_mask_h_w);
+                    copy_tile_init_with_dt(cb_mask_h_w_obj);
                     copy_tile(cb_mask_h_w, 1, dst1);
 
                     mask_tile_init();
@@ -431,7 +431,7 @@ void kernel_main() {
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_dycopy);
+                pack_tile_with_dt(dst0, cb_dycopy_obj);
 
                 cb_dy_obj.pop_front(onetile);
                 cb_dycopy_obj.push_back(onetile);
@@ -446,12 +446,12 @@ void kernel_main() {
             cb_dycopy_obj.wait_front(onetile);
             cb_ndy_obj.reserve_back(onetile);
 
-            mul_tiles_init_with_dt(cb_n_recip_n, cb_dycopy);
+            mul_tiles_init_with_dt(cb_n_recip_n_obj, cb_dycopy_obj);
             mul_tiles(cb_n_recip_n, cb_dycopy, 0, 0, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_ndy);
+            pack_tile_with_dt(dst0, cb_ndy_obj);
 
             cb_dycopy_obj.pop_front(onetile);
             cb_ndy_obj.push_back(onetile);
@@ -466,16 +466,16 @@ void kernel_main() {
             cb_ndymdysum_obj.reserve_back(onetile);
 
             if (is_lastdim_layernorm) {
-                sub_bcast_cols_init_short_with_dt(cb_ndy, cb_dysum);
+                sub_bcast_cols_init_short_with_dt(cb_ndy_obj, cb_dysum_obj);
                 sub_tiles_bcast_cols(cb_ndy, cb_dysum, 0, 0, dst0);
             } else {
-                sub_tiles_bcast_scalar_init_short_with_dt(cb_ndy, cb_dysum);
+                sub_tiles_bcast_scalar_init_short_with_dt(cb_ndy_obj, cb_dysum_obj);
                 sub_tiles_bcast_scalar(cb_ndy, cb_dysum, 0, 0, dst0);
             }
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_ndymdysum);
+            pack_tile_with_dt(dst0, cb_ndymdysum_obj);
 
             cb_ndy_obj.pop_front(onetile);
             cb_ndymdysum_obj.push_back(onetile);
@@ -490,15 +490,15 @@ void kernel_main() {
             cb_xmm_obj.reserve_back(onetile);
 
             if (is_lastdim_layernorm) {
-                sub_bcast_cols_init_short_with_dt(cb_x, cb_mean);
+                sub_bcast_cols_init_short_with_dt(cb_x_obj, cb_mean_obj);
                 sub_tiles_bcast_cols(cb_x, cb_mean, 0, 0, dst0);
             } else {
-                sub_tiles_bcast_scalar_init_short_with_dt(cb_x, cb_mean);
+                sub_tiles_bcast_scalar_init_short_with_dt(cb_x_obj, cb_mean_obj);
                 sub_tiles_bcast_scalar(cb_x, cb_mean, 0, 0, dst0);
             }
 
             if (do_mask_h && need_to_do_mask_h(wt, origin_Ht, origin_Wt)) {
-                copy_tile_init_with_dt(cb_mask_h_w);
+                copy_tile_init_with_dt(cb_mask_h_w_obj);
                 copy_tile(cb_mask_h_w, 0, dst1);
 
                 mask_tile_init();
@@ -506,7 +506,7 @@ void kernel_main() {
             }
 
             if (do_mask_w && ((wt + 1) % origin_Wt == 0)) {
-                copy_tile_init_with_dt(cb_mask_h_w);
+                copy_tile_init_with_dt(cb_mask_h_w_obj);
                 copy_tile(cb_mask_h_w, 1, dst1);
 
                 mask_tile_init();
@@ -515,7 +515,7 @@ void kernel_main() {
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_xmm);
+            pack_tile_with_dt(dst0, cb_xmm_obj);
 
             cb_x_obj.pop_front(onetile);
             cb_xmm_obj.push_back(onetile);
@@ -528,16 +528,16 @@ void kernel_main() {
             cb_y_obj.reserve_back(onetile);
 
             if (is_lastdim_layernorm) {
-                mul_bcast_cols_init_short_with_dt(cb_xmm, cb_rstd);
+                mul_bcast_cols_init_short_with_dt(cb_xmm_obj, cb_rstd_obj);
                 mul_tiles_bcast_cols(cb_xmm, cb_rstd, 0, 0, dst0);
             } else {
-                mul_tiles_bcast_scalar_init_short_with_dt(cb_xmm, cb_rstd);
+                mul_tiles_bcast_scalar_init_short_with_dt(cb_xmm_obj, cb_rstd_obj);
                 mul_tiles_bcast_scalar(cb_xmm, cb_rstd, 0, 0, dst0);
             }
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_y);
+            pack_tile_with_dt(dst0, cb_y_obj);
 
             cb_xmm_obj.pop_front(onetile);
             cb_y_obj.push_back(onetile);
@@ -552,16 +552,16 @@ void kernel_main() {
             cb_yydysum_obj.reserve_back(onetile);
 
             if (is_lastdim_layernorm) {
-                mul_bcast_cols_init_short_with_dt(cb_y, cb_ydysum);
+                mul_bcast_cols_init_short_with_dt(cb_y_obj, cb_ydysum_obj);
                 mul_tiles_bcast_cols(cb_y, cb_ydysum, 0, 0, dst0);
             } else {
-                mul_tiles_bcast_scalar_init_short_with_dt(cb_y, cb_ydysum);
+                mul_tiles_bcast_scalar_init_short_with_dt(cb_y_obj, cb_ydysum_obj);
                 mul_tiles_bcast_scalar(cb_y, cb_ydysum, 0, 0, dst0);
             }
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_yydysum);
+            pack_tile_with_dt(dst0, cb_yydysum_obj);
 
             cb_y_obj.pop_front(onetile);
             cb_yydysum_obj.push_back(onetile);
@@ -576,12 +576,12 @@ void kernel_main() {
             cb_yydysum_obj.wait_front(onetile);
             cb_tmp4_obj.reserve_back(onetile);
 
-            sub_tiles_init_with_dt(cb_ndymdysum, cb_yydysum);
+            sub_tiles_init_with_dt(cb_ndymdysum_obj, cb_yydysum_obj);
             sub_tiles(cb_ndymdysum, cb_yydysum, 0, 0, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_tmp4);
+            pack_tile_with_dt(dst0, cb_tmp4_obj);
 
             cb_ndymdysum_obj.pop_front(onetile);
             cb_yydysum_obj.pop_front(onetile);
@@ -594,12 +594,12 @@ void kernel_main() {
             cb_tmp4_obj.wait_front(onetile);
             cb_dx_obj.reserve_back(onetile);
 
-            mul_tiles_init_with_dt(cb_tmp4, cb_recip_nrstd);
+            mul_tiles_init_with_dt(cb_tmp4_obj, cb_recip_nrstd_obj);
             mul_tiles(cb_tmp4, cb_recip_nrstd, 0, 0, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_dx);
+            pack_tile_with_dt(dst0, cb_dx_obj);
 
             cb_tmp4_obj.pop_front(onetile);
             cb_dx_obj.push_back(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/moreh_layer_norm_backward_input_grad_small_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/moreh_layer_norm_backward_input_grad_small_kernel.cpp
@@ -91,16 +91,16 @@ void kernel_main() {
         cb_recip_nrstd_obj.reserve_back(onetile);
 
         if (is_lastdim_layernorm) {
-            mul_bcast_cols_init_short_with_dt(cb_n_recip_n, cb_rstd);
+            mul_bcast_cols_init_short_with_dt(cb_n_recip_n_obj, cb_rstd_obj);
             mul_tiles_bcast_cols(cb_n_recip_n, cb_rstd, 1, 0, dst0);
         } else {
-            mul_tiles_bcast_scalar_init_short_with_dt(cb_n_recip_n, cb_rstd);
+            mul_tiles_bcast_scalar_init_short_with_dt(cb_n_recip_n_obj, cb_rstd_obj);
             mul_tiles_bcast_scalar(cb_n_recip_n, cb_rstd, 1, 0, dst0);
         }
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_recip_nrstd);
+        pack_tile_with_dt(dst0, cb_recip_nrstd_obj);
 
         cb_recip_nrstd_obj.push_back(onetile);
         tile_regs_release();
@@ -117,15 +117,15 @@ void kernel_main() {
             cb_xmm_obj.reserve_back(onetile);
 
             if (is_lastdim_layernorm) {
-                sub_bcast_cols_init_short_with_dt(cb_x, cb_mean);
+                sub_bcast_cols_init_short_with_dt(cb_x_obj, cb_mean_obj);
                 sub_tiles_bcast_cols(cb_x, cb_mean, 0, 0, dst0);
             } else {
-                sub_tiles_bcast_scalar_init_short_with_dt(cb_x, cb_mean);
+                sub_tiles_bcast_scalar_init_short_with_dt(cb_x_obj, cb_mean_obj);
                 sub_tiles_bcast_scalar(cb_x, cb_mean, 0, 0, dst0);
             }
 
             if (do_mask_h && need_to_do_mask_h(wt, origin_Ht, origin_Wt)) {
-                copy_tile_init_with_dt(cb_mask_h_w);
+                copy_tile_init_with_dt(cb_mask_h_w_obj);
                 copy_tile(cb_mask_h_w, 0, dst1);
 
                 mask_tile_init();
@@ -133,7 +133,7 @@ void kernel_main() {
             }
 
             if (do_mask_w && ((wt + 1) % origin_Wt == 0)) {
-                copy_tile_init_with_dt(cb_mask_h_w);
+                copy_tile_init_with_dt(cb_mask_h_w_obj);
                 copy_tile(cb_mask_h_w, 1, dst1);
 
                 mask_tile_init();
@@ -142,7 +142,7 @@ void kernel_main() {
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_xmm);
+            pack_tile_with_dt(dst0, cb_xmm_obj);
 
             cb_x_obj.pop_front(onetile);
             cb_xmm_obj.push_back(onetile);
@@ -154,16 +154,16 @@ void kernel_main() {
             cb_xmm_obj.wait_front(onetile);
 
             if (is_lastdim_layernorm) {
-                mul_bcast_cols_init_short_with_dt(cb_xmm, cb_rstd);
+                mul_bcast_cols_init_short_with_dt(cb_xmm_obj, cb_rstd_obj);
                 mul_tiles_bcast_cols(cb_xmm, cb_rstd, 0, 0, dst0);
             } else {
-                mul_tiles_bcast_scalar_init_short_with_dt(cb_xmm, cb_rstd);
+                mul_tiles_bcast_scalar_init_short_with_dt(cb_xmm_obj, cb_rstd_obj);
                 mul_tiles_bcast_scalar(cb_xmm, cb_rstd, 0, 0, dst0);
             }
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_y);
+            pack_tile_with_dt(dst0, cb_y_obj);
 
             cb_xmm_obj.pop_front(onetile);
             cb_y_obj.push_back(onetile);
@@ -181,20 +181,20 @@ void kernel_main() {
                 cb_gamma_obj.wait_front(onetile);  // comes from the reader
 
                 if (is_groupnorm) {
-                    mul_tiles_bcast_scalar_init_short_with_dt(cb_dy, cb_gamma);
+                    mul_tiles_bcast_scalar_init_short_with_dt(cb_dy_obj, cb_gamma_obj);
                     mul_tiles_bcast_scalar(cb_dy, cb_gamma, 0, 0, dst0);
                 } else {
                     if (is_lastdim_layernorm) {
-                        mul_bcast_rows_init_short_with_dt(cb_dy, cb_gamma);
+                        mul_bcast_rows_init_short_with_dt(cb_dy_obj, cb_gamma_obj);
                         mul_tiles_bcast_rows(cb_dy, cb_gamma, 0, 0, dst0);
                     } else {
-                        mul_tiles_init_with_dt(cb_dy, cb_gamma);
+                        mul_tiles_init_with_dt(cb_dy_obj, cb_gamma_obj);
                         mul_tiles(cb_dy, cb_gamma, 0, 0, dst0);
                     }
                 }
 
                 if (do_mask_h && need_to_do_mask_h(wt, origin_Ht, origin_Wt)) {
-                    copy_tile_init_with_dt(cb_mask_h_w);
+                    copy_tile_init_with_dt(cb_mask_h_w_obj);
                     copy_tile(cb_mask_h_w, 0, dst1);
 
                     mask_tile_init();
@@ -202,7 +202,7 @@ void kernel_main() {
                 }
 
                 if (do_mask_w && ((wt + 1) % origin_Wt == 0)) {
-                    copy_tile_init_with_dt(cb_mask_h_w);
+                    copy_tile_init_with_dt(cb_mask_h_w_obj);
                     copy_tile(cb_mask_h_w, 1, dst1);
 
                     mask_tile_init();
@@ -211,7 +211,7 @@ void kernel_main() {
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_dycopy);
+                pack_tile_with_dt(dst0, cb_dycopy_obj);
 
                 cb_dy_obj.pop_front(onetile);
                 cb_gamma_obj.pop_front(onetile);
@@ -223,11 +223,11 @@ void kernel_main() {
                 tile_regs_acquire();
                 cb_dy_obj.wait_front(onetile);  // comes from the reader
 
-                copy_tile_init_with_dt(cb_dy);
+                copy_tile_init_with_dt(cb_dy_obj);
                 copy_tile(cb_dy, 0, dst0);
 
                 if (do_mask_h && need_to_do_mask_h(wt, origin_Ht, origin_Wt)) {
-                    copy_tile_init_with_dt(cb_mask_h_w);
+                    copy_tile_init_with_dt(cb_mask_h_w_obj);
                     copy_tile(cb_mask_h_w, 0, dst1);
 
                     mask_tile_init();
@@ -235,7 +235,7 @@ void kernel_main() {
                 }
 
                 if (do_mask_w && ((wt + 1) % origin_Wt == 0)) {
-                    copy_tile_init_with_dt(cb_mask_h_w);
+                    copy_tile_init_with_dt(cb_mask_h_w_obj);
                     copy_tile(cb_mask_h_w, 1, dst1);
 
                     mask_tile_init();
@@ -244,7 +244,7 @@ void kernel_main() {
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_dycopy);
+                pack_tile_with_dt(dst0, cb_dycopy_obj);
 
                 cb_dy_obj.pop_front(onetile);
                 cb_dycopy_obj.push_back(onetile);
@@ -261,12 +261,12 @@ void kernel_main() {
                 tile_regs_acquire();
                 cb_dyadd_obj.reserve_back(onetile);
 
-                copy_tile_init_with_dt(cb_dycopy);
+                copy_tile_init_with_dt(cb_dycopy_obj);
                 copy_tile(cb_dycopy, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_dyadd);
+                pack_tile_with_dt(dst0, cb_dyadd_obj);
 
                 cb_dyadd_obj.push_back(onetile);
                 tile_regs_release();
@@ -275,12 +275,12 @@ void kernel_main() {
                 cb_dyadd_obj.wait_front(onetile);
                 cb_dyadd_obj.reserve_back(onetile);
 
-                add_tiles_init_with_dt(cb_dyadd, cb_dycopy);
+                add_tiles_init_with_dt(cb_dyadd_obj, cb_dycopy_obj);
                 add_tiles(cb_dyadd, cb_dycopy, 0, wt, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_dyadd);
+                pack_tile_with_dt(dst0, cb_dyadd_obj);
 
                 cb_dyadd_obj.pop_front(onetile);
                 cb_dyadd_obj.push_back(onetile);
@@ -305,12 +305,12 @@ void kernel_main() {
             tile_regs_acquire();
             cb_ydy_obj.reserve_back(onetile);
 
-            mul_tiles_init_with_dt(cb_y, cb_dycopy);
+            mul_tiles_init_with_dt(cb_y_obj, cb_dycopy_obj);
             mul_tiles(cb_y, cb_dycopy, wt, wt, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_ydy);
+            pack_tile_with_dt(dst0, cb_ydy_obj);
 
             cb_ydy_obj.push_back(onetile);
             tile_regs_release();
@@ -321,12 +321,12 @@ void kernel_main() {
                 cb_ydy_obj.wait_front(onetile);
                 cb_ydyadd_obj.reserve_back(onetile);
 
-                copy_tile_init_with_dt(cb_ydy);
+                copy_tile_init_with_dt(cb_ydy_obj);
                 copy_tile(cb_ydy, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_ydyadd);
+                pack_tile_with_dt(dst0, cb_ydyadd_obj);
 
                 cb_ydy_obj.pop_front(onetile);
                 cb_ydyadd_obj.push_back(onetile);
@@ -337,12 +337,12 @@ void kernel_main() {
                 cb_ydyadd_obj.wait_front(onetile);
                 cb_ydyadd_obj.reserve_back(onetile);
 
-                add_tiles_init_with_dt(cb_ydyadd, cb_ydy);
+                add_tiles_init_with_dt(cb_ydyadd_obj, cb_ydy_obj);
                 add_tiles(cb_ydyadd, cb_ydy, 0, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_ydyadd);
+                pack_tile_with_dt(dst0, cb_ydyadd_obj);
 
                 cb_ydy_obj.pop_front(onetile);
                 cb_ydyadd_obj.pop_front(onetile);
@@ -370,12 +370,12 @@ void kernel_main() {
             tile_regs_acquire();
             cb_ndy_obj.reserve_back(onetile);
 
-            mul_tiles_init_with_dt(cb_n_recip_n, cb_dycopy);
+            mul_tiles_init_with_dt(cb_n_recip_n_obj, cb_dycopy_obj);
             mul_tiles(cb_n_recip_n, cb_dycopy, 0, wt, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_ndy);
+            pack_tile_with_dt(dst0, cb_ndy_obj);
 
             cb_ndy_obj.push_back(onetile);
             tile_regs_release();
@@ -389,16 +389,16 @@ void kernel_main() {
             cb_ndymdysum_obj.reserve_back(onetile);
 
             if (is_lastdim_layernorm) {
-                sub_bcast_cols_init_short_with_dt(cb_ndy, cb_dysum);
+                sub_bcast_cols_init_short_with_dt(cb_ndy_obj, cb_dysum_obj);
                 sub_tiles_bcast_cols(cb_ndy, cb_dysum, 0, 0, dst0);
             } else {
-                sub_tiles_bcast_scalar_init_short_with_dt(cb_ndy, cb_dysum);
+                sub_tiles_bcast_scalar_init_short_with_dt(cb_ndy_obj, cb_dysum_obj);
                 sub_tiles_bcast_scalar(cb_ndy, cb_dysum, 0, 0, dst0);
             }
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_ndymdysum);
+            pack_tile_with_dt(dst0, cb_ndymdysum_obj);
 
             cb_ndy_obj.pop_front(onetile);
             cb_ndymdysum_obj.push_back(onetile);
@@ -412,16 +412,16 @@ void kernel_main() {
             cb_yydysum_obj.reserve_back(onetile);
 
             if (is_lastdim_layernorm) {
-                mul_bcast_cols_init_short_with_dt(cb_y, cb_ydysum);
+                mul_bcast_cols_init_short_with_dt(cb_y_obj, cb_ydysum_obj);
                 mul_tiles_bcast_cols(cb_y, cb_ydysum, wt, 0, dst0);
             } else {
-                mul_tiles_bcast_scalar_init_short_with_dt(cb_y, cb_ydysum);
+                mul_tiles_bcast_scalar_init_short_with_dt(cb_y_obj, cb_ydysum_obj);
                 mul_tiles_bcast_scalar(cb_y, cb_ydysum, wt, 0, dst0);
             }
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_yydysum);
+            pack_tile_with_dt(dst0, cb_yydysum_obj);
 
             cb_yydysum_obj.push_back(onetile);
             tile_regs_release();
@@ -433,12 +433,12 @@ void kernel_main() {
             cb_yydysum_obj.wait_front(onetile);
             cb_tmp1_obj.reserve_back(onetile);
 
-            sub_tiles_init_with_dt(cb_ndymdysum, cb_yydysum);
+            sub_tiles_init_with_dt(cb_ndymdysum_obj, cb_yydysum_obj);
             sub_tiles(cb_ndymdysum, cb_yydysum, 0, 0, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_tmp1);
+            pack_tile_with_dt(dst0, cb_tmp1_obj);
 
             cb_ndymdysum_obj.pop_front(onetile);
             cb_yydysum_obj.pop_front(onetile);
@@ -451,12 +451,12 @@ void kernel_main() {
             cb_tmp1_obj.wait_front(onetile);
             cb_dx_obj.reserve_back(onetile);
 
-            mul_tiles_init_with_dt(cb_tmp1, cb_recip_nrstd);
+            mul_tiles_init_with_dt(cb_tmp1_obj, cb_recip_nrstd_obj);
             mul_tiles(cb_tmp1, cb_recip_nrstd, 0, 0, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_dx);
+            pack_tile_with_dt(dst0, cb_dx_obj);
 
             cb_tmp1_obj.pop_front(onetile);
             cb_dx_obj.push_back(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_h.cpp
@@ -59,10 +59,10 @@ void kernel_main() {
             if constexpr (do_mask_h) {
                 tile_regs_acquire();
                 cb_input_obj.wait_front(onetile);
-                copy_tile_init_with_dt(cb_input);
+                copy_tile_init_with_dt(cb_input_obj);
                 copy_tile(cb_input, 0, reduce_dst_idx);
 
-                copy_tile_init_with_dt(cb_mask_h);
+                copy_tile_init_with_dt(cb_mask_h_obj);
                 copy_tile(cb_mask_h, 0, mask_dst_idx);
 
                 mask_tile_init();
@@ -71,7 +71,7 @@ void kernel_main() {
 
                 cb_masked_input_obj.reserve_back(onetile);
                 tile_regs_wait();
-                pack_tile_with_dt(reduce_dst_idx, cb_masked_input);
+                pack_tile_with_dt(reduce_dst_idx, cb_masked_input_obj);
                 tile_regs_release();
                 cb_masked_input_obj.push_back(onetile);
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_nc.cpp
@@ -46,7 +46,7 @@ void kernel_main() {
             }
 
             uint32_t cb_add = (enable_reload) ? (cb_intermed0) : (cb_in1);
-            add_tiles_init_with_dt(cb_in0, cb_add);
+            add_tiles_init_with_dt(cb_in0_obj, CircularBuffer(cb_add));
             add_tiles(cb_in0, cb_add, first_tile, first_tile, dst0);
 
             cb_in0_obj.pop_front(onetile);
@@ -57,7 +57,7 @@ void kernel_main() {
 
             cb_intermed0_obj.reserve_back(onetile);
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_intermed0);
+            pack_tile_with_dt(dst0, cb_intermed0_obj);
             tile_regs_release();
             cb_intermed0_obj.push_back(onetile);
 
@@ -67,13 +67,13 @@ void kernel_main() {
         // output * (1 / number_of_elements)
         tile_regs_acquire();
         cb_intermed0_obj.wait_front(onetile);
-        mul_tiles_bcast_scalar_init_short_with_dt(cb_intermed0, cb_scalar);
+        mul_tiles_bcast_scalar_init_short_with_dt(cb_intermed0_obj, cb_scalar_obj);
         mul_tiles_bcast<BroadcastType::SCALAR>(cb_intermed0, cb_scalar, 0, 0, 0);
         tile_regs_commit();
 
         cb_out0_obj.reserve_back(onetile);
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_out0);
+        pack_tile_with_dt(dst0, cb_out0_obj);
         tile_regs_release();
         cb_out0_obj.push_back(onetile);
         cb_intermed0_obj.pop_front(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_w.cpp
@@ -66,7 +66,7 @@ void kernel_main() {
 
                 cb_accum_dst_obj.reserve_back(onetile);
                 tile_regs_wait();
-                pack_tile_with_dt(reduce_dst_idx, cb_accum_dst);
+                pack_tile_with_dt(reduce_dst_idx, cb_accum_dst_obj);
                 tile_regs_release();
                 cb_accum_dst_obj.push_back(onetile);
             }
@@ -75,10 +75,10 @@ void kernel_main() {
                 tile_regs_acquire();
                 CircularBuffer(cb_input).wait_front(onetile);
 
-                copy_tile_init_with_dt(cb_input);
+                copy_tile_init_with_dt(CircularBuffer(cb_input));
                 copy_tile(cb_input, 0, reduce_dst_idx);
 
-                copy_tile_init_with_dt(cb_mask_w);
+                copy_tile_init_with_dt(cb_mask_w_obj);
                 copy_tile(cb_mask_w, 0, mask_dst_idx);
 
                 mask_tile_init();
@@ -87,7 +87,7 @@ void kernel_main() {
 
                 cb_masked_input_obj.reserve_back(onetile);
                 tile_regs_wait();
-                pack_tile_with_dt(reduce_dst_idx, cb_masked_input);
+                pack_tile_with_dt(reduce_dst_idx, cb_masked_input_obj);
                 tile_regs_release();
                 cb_masked_input_obj.push_back(onetile);
 
@@ -100,7 +100,7 @@ void kernel_main() {
             if (!is_w_single_tile) {
                 cb_accum_dst_obj.wait_front(onetile);
 
-                copy_tile_init_with_dt(cb_accum_dst);
+                copy_tile_init_with_dt(cb_accum_dst_obj);
                 copy_tile(cb_accum_dst, 0, reduce_dst_idx);
             }
 
@@ -113,7 +113,7 @@ void kernel_main() {
 
             cb_out_obj.reserve_back(onetile);
             tile_regs_wait();
-            pack_tile_with_dt(reduce_dst_idx, cb_out);
+            pack_tile_with_dt(reduce_dst_idx, cb_out_obj);
             tile_regs_release();
             cb_out_obj.push_back(onetile);
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/kernels/moreh_mean_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/kernels/moreh_mean_backward.cpp
@@ -21,6 +21,7 @@ void kernel_main() {
     constexpr auto cb_in1 = tt::CBIndex::c_1;
     CircularBuffer cb_in1_obj(cb_in1);  // zero tile
     constexpr auto cb_scalar = tt::CBIndex::c_2;
+    CircularBuffer cb_scalar_obj(cb_scalar);
     constexpr auto cb_out0 = tt::CBIndex::c_16;
     CircularBuffer cb_out0_obj(cb_out0);
     constexpr auto cb_intermed0 = tt::CBIndex::c_24;
@@ -34,16 +35,16 @@ void kernel_main() {
         tile_regs_acquire();
         cb_in0_obj.wait_front(onetile);
         if (ht_need_bcast && wt_need_bcast) {
-            add_bcast_scalar_init_short_with_dt(cb_in1, cb_in0);
+            add_bcast_scalar_init_short_with_dt(cb_in1_obj, cb_in0_obj);
             add_tiles_bcast_scalar(cb_in1, cb_in0, 0, 0, dst0);
         } else if (ht_need_bcast) {
-            add_bcast_rows_init_short_with_dt(cb_in1, cb_in0);
+            add_bcast_rows_init_short_with_dt(cb_in1_obj, cb_in0_obj);
             add_tiles_bcast_rows(cb_in1, cb_in0, 0, 0, dst0);
         } else if (wt_need_bcast) {
-            add_bcast_cols_init_short_with_dt(cb_in1, cb_in0);
+            add_bcast_cols_init_short_with_dt(cb_in1_obj, cb_in0_obj);
             add_tiles_bcast_cols(cb_in1, cb_in0, 0, 0, dst0);
         } else {
-            copy_tile_init_with_dt(cb_in0);
+            copy_tile_init_with_dt(cb_in0_obj);
             copy_tile(cb_in0, 0, dst0);
         }
         tile_regs_commit();
@@ -51,7 +52,7 @@ void kernel_main() {
         cb_intermed0_obj.reserve_back(onetile);
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_intermed0);
+        pack_tile_with_dt(dst0, cb_intermed0_obj);
         tile_regs_release();
 
         cb_intermed0_obj.push_back(onetile);
@@ -60,14 +61,14 @@ void kernel_main() {
         // output * (1 / number_of_elements)
         tile_regs_acquire();
         cb_intermed0_obj.wait_front(onetile);
-        mul_tiles_bcast_scalar_init_short_with_dt(cb_intermed0, cb_scalar);
+        mul_tiles_bcast_scalar_init_short_with_dt(cb_intermed0_obj, cb_scalar_obj);
         mul_tiles_bcast<BroadcastType::SCALAR>(cb_intermed0, cb_scalar, 0, 0, 0);
         tile_regs_commit();
 
         cb_out0_obj.reserve_back(onetile);
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_out0);
+        pack_tile_with_dt(dst0, cb_out0_obj);
         tile_regs_release();
 
         cb_out0_obj.push_back(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/moreh_nll_loss_step2_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/moreh_nll_loss_step2_kernel.cpp
@@ -37,7 +37,7 @@ void kernel_main() {
     cb_divisor_obj.wait_front(onetile);
 
     tile_regs_acquire();
-    copy_tile_init_with_dt(cb_divisor);
+    copy_tile_init_with_dt(cb_divisor_obj);
     copy_tile(cb_divisor, 0, dst0);
     recip_tile_init();
     recip_tile(dst0);
@@ -46,7 +46,7 @@ void kernel_main() {
     cb_divisor_obj.pop_front(onetile);
     cb_divisor_recip_obj.reserve_back(onetile);
     tile_regs_wait();
-    pack_tile_with_dt(dst0, cb_divisor_recip);
+    pack_tile_with_dt(dst0, cb_divisor_recip_obj);
     tile_regs_release();
     cb_divisor_recip_obj.push_back(onetile);
 #endif
@@ -55,7 +55,7 @@ void kernel_main() {
         cb_tmp_input_obj.wait_front(onetile);
 
         tile_regs_acquire();
-        copy_tile_init_with_dt(cb_tmp_input);
+        copy_tile_init_with_dt(cb_tmp_input_obj);
         copy_tile(cb_tmp_input, 0, dst0);
 
         negative_tile_init();
@@ -67,7 +67,7 @@ void kernel_main() {
 #if defined(WEIGHT)
         cb_tmp1_obj.reserve_back(onetile);
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp1);
+        pack_tile_with_dt(dst0, cb_tmp1_obj);
         tile_regs_release();
         cb_tmp1_obj.push_back(onetile);
 
@@ -76,7 +76,7 @@ void kernel_main() {
         cb_tmp_weight_obj.wait_front(onetile);
 
         tile_regs_acquire();
-        mul_tiles_init_with_dt(cb_tmp1, cb_tmp_weight);
+        mul_tiles_init_with_dt(cb_tmp1_obj, cb_tmp_weight_obj);
         mul_tiles(cb_tmp1, cb_tmp_weight, 0, 0, dst0);
         tile_regs_commit();
 
@@ -86,7 +86,7 @@ void kernel_main() {
 #if defined(DIVISOR)
         cb_tmp3_obj.reserve_back(onetile);
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp3);
+        pack_tile_with_dt(dst0, cb_tmp3_obj);
         tile_regs_release();
         cb_tmp3_obj.push_back(onetile);
 
@@ -103,13 +103,13 @@ void kernel_main() {
 
         cb_output_obj.reserve_back(onetile);
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_output);
+        pack_tile_with_dt(dst0, cb_output_obj);
         tile_regs_release();
         cb_output_obj.push_back(onetile);
 #else
         cb_output_obj.reserve_back(onetile);
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_output);
+        pack_tile_with_dt(dst0, cb_output_obj);
         tile_regs_release();
         cb_output_obj.push_back(onetile);
 #endif
@@ -117,7 +117,7 @@ void kernel_main() {
 #if defined(DIVISOR)
         cb_tmp1_obj.reserve_back(onetile);
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp1);
+        pack_tile_with_dt(dst0, cb_tmp1_obj);
         tile_regs_release();
         cb_tmp1_obj.push_back(onetile);
 
@@ -136,13 +136,13 @@ void kernel_main() {
 
         cb_output_obj.reserve_back(onetile);
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_output);
+        pack_tile_with_dt(dst0, cb_output_obj);
         tile_regs_release();
         cb_output_obj.push_back(onetile);
 #else
         cb_output_obj.reserve_back(onetile);
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_output);
+        pack_tile_with_dt(dst0, cb_output_obj);
         tile_regs_release();
         cb_output_obj.push_back(onetile);
 #endif

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/kernels/moreh_nll_loss_backward_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/kernels/moreh_nll_loss_backward_kernel.cpp
@@ -36,14 +36,14 @@ void kernel_main() {
     cb_tmp1_obj.reserve_back(onetile);
 
     tile_regs_acquire();
-    copy_tile_init_with_dt(cb_divisor);
+    copy_tile_init_with_dt(cb_divisor_obj);
     copy_tile(cb_divisor, 0, dst0);
     recip_tile_init();
     recip_tile(dst0);
     tile_regs_commit();
 
     tile_regs_wait();
-    pack_tile_with_dt(dst0, cb_tmp1);
+    pack_tile_with_dt(dst0, cb_tmp1_obj);
     tile_regs_release();
 
     cb_tmp1_obj.push_back(onetile);
@@ -57,14 +57,14 @@ void kernel_main() {
         cb_tmp2_obj.reserve_back(onetile);
 
         tile_regs_acquire();
-        mul_tiles_bcast_scalar_init_short_with_dt(cb_tmp_weight, cb_output_grad);
+        mul_tiles_bcast_scalar_init_short_with_dt(cb_tmp_weight_obj, cb_output_grad_obj);
         mul_tiles_bcast_scalar(cb_tmp_weight, cb_output_grad, 0, 0, dst0);
         negative_tile_init();
         negative_tile(dst0);
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp2);
+        pack_tile_with_dt(dst0, cb_tmp2_obj);
         tile_regs_release();
 
         cb_tmp2_obj.push_back(onetile);
@@ -75,12 +75,12 @@ void kernel_main() {
         cb_tmp1_obj.wait_front(onetile);
 
         tile_regs_acquire();
-        mul_tiles_bcast_scalar_init_short_with_dt(cb_tmp2, cb_tmp1);
+        mul_tiles_bcast_scalar_init_short_with_dt(cb_tmp2_obj, cb_tmp1_obj);
         mul_tiles_bcast_scalar(cb_tmp2, cb_tmp1, 0, 0, dst0);
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_input_grad);
+        pack_tile_with_dt(dst0, cb_input_grad_obj);
         tile_regs_release();
 
         cb_input_grad_obj.push_back(onetile);
@@ -92,7 +92,7 @@ void kernel_main() {
         cb_input_grad_obj.reserve_back(onetile);
 
         tile_regs_acquire();
-        mul_tiles_bcast_scalar_init_short_with_dt(cb_tmp_weight, cb_output_grad);
+        mul_tiles_bcast_scalar_init_short_with_dt(cb_tmp_weight_obj, cb_output_grad_obj);
         mul_tiles_bcast_scalar(cb_tmp_weight, cb_output_grad, 0, 0, dst0);
         negative_tile_init();
         negative_tile(dst0);
@@ -100,7 +100,7 @@ void kernel_main() {
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_input_grad);
+        pack_tile_with_dt(dst0, cb_input_grad_obj);
         tile_regs_release();
 
         cb_input_grad_obj.push_back(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_h/kernels/moreh_norm_h_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_h/kernels/moreh_norm_h_kernel.cpp
@@ -30,6 +30,7 @@ void kernel_main() {
 
     std::uint8_t output_id{tt::CBIndex::c_16};
     const auto cb_y = output_id++;  // output
+    CircularBuffer cb_y_obj(cb_y);
 
     std::uint8_t intermed_id{tt::CBIndex::c_24};
     const auto cb_tmp0 = intermed_id++;
@@ -43,13 +44,17 @@ void kernel_main() {
     const auto cb_xabs = cb_tmp0;
     CircularBuffer cb_xabs_obj(cb_xabs);   // |x|
     const auto cb_xpow = cb_tmp1;          // |x|^p
+    CircularBuffer cb_xpow_obj(cb_xpow);
     const auto cb_logx = cb_tmp2;          // log(|x|)
+    CircularBuffer cb_logx_obj(cb_logx);
     const auto cb_exp_lxmd = cb_tmp3;      // exp(log(|x|) * decimal)
+    CircularBuffer cb_exp_lxmd_obj(cb_exp_lxmd);
     const auto cb_correct_xpow = cb_tmp4;
     CircularBuffer cb_correct_xpow_obj(cb_correct_xpow);  // |x|^p * exp(log(|x|) * decimal)(==|x + decimal|^p)
     const auto cb_xpowadd = cb_tmp5;
     CircularBuffer cb_xpowadd_obj(cb_xpowadd);  // Add(|x + decimal|^p)
     const auto cb_xpowsum = cb_tmp6;       // Sum(|x + decimal|^p)
+    CircularBuffer cb_xpowsum_obj(cb_xpowsum);
 
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
@@ -76,11 +81,11 @@ void kernel_main() {
             cb_x_obj.wait_front(onetile);  // comes from the reader
             cb_xabs_obj.reserve_back(onetile);
 
-            copy_tile_init_with_dt(cb_x);
+            copy_tile_init_with_dt(cb_x_obj);
             copy_tile(cb_x, 0, dst0);
 
             if (do_mask_h && (row_idx == Ht - 1)) {
-                copy_tile_init_with_dt(cb_mask_h);
+                copy_tile_init_with_dt(cb_mask_h_obj);
                 copy_tile(cb_mask_h, 0, dst1);
 
                 mask_tile_init();
@@ -92,13 +97,21 @@ void kernel_main() {
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_xabs);
+            pack_tile_with_dt(dst0, cb_xabs_obj);
             tile_regs_release();
 
             cb_x_obj.pop_front(onetile);
             cb_xabs_obj.push_back(onetile);
 
-            power_tile_to_cb(cb_xabs, cb_xpow, cb_logx, cb_decimal, cb_exp_lxmd, cb_correct_xpow, p, p_is_negative);
+            power_tile_to_cb(
+                cb_xabs_obj,
+                cb_xpow_obj,
+                cb_logx_obj,
+                cb_decimal_obj,
+                cb_exp_lxmd_obj,
+                cb_correct_xpow_obj,
+                p,
+                p_is_negative);
 
             // Add(|x|^p)
             if (row_idx == 0) {
@@ -106,12 +119,12 @@ void kernel_main() {
                 cb_correct_xpow_obj.wait_front(onetile);
                 cb_xpowadd_obj.reserve_back(onetile);
 
-                copy_tile_init_with_dt(cb_correct_xpow);
+                copy_tile_init_with_dt(cb_correct_xpow_obj);
                 copy_tile(cb_correct_xpow, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_xpowadd);
+                pack_tile_with_dt(dst0, cb_xpowadd_obj);
                 tile_regs_release();
 
                 cb_correct_xpow_obj.pop_front(onetile);
@@ -122,12 +135,12 @@ void kernel_main() {
                 cb_xpowadd_obj.wait_front(onetile);
                 cb_xpowadd_obj.reserve_back(onetile);
 
-                add_tiles_init_with_dt(cb_correct_xpow, cb_xpowadd);
+                add_tiles_init_with_dt(cb_correct_xpow_obj, cb_xpowadd_obj);
                 add_tiles(cb_correct_xpow, cb_xpowadd, 0, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_xpowadd);
+                pack_tile_with_dt(dst0, cb_xpowadd_obj);
                 tile_regs_release();
 
                 cb_correct_xpow_obj.pop_front(onetile);
@@ -139,7 +152,15 @@ void kernel_main() {
         compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_xpowadd, cb_one, cb_xpowsum>(
             compute_kernel_lib::ReduceInputBlockShape::single());
 
-        power_tile_to_cb(cb_xpowsum, cb_tmp0, cb_tmp1, cb_recip_p_decimal, cb_tmp2, cb_y, recip_p, recip_p_is_negative);
+        power_tile_to_cb(
+            cb_xpowsum_obj,
+            cb_xabs_obj,
+            cb_xpow_obj,
+            cb_recip_p_decimal_obj,
+            cb_logx_obj,
+            cb_y_obj,
+            recip_p,
+            recip_p_is_negative);
     }
 
     cb_one_obj.pop_front(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_other/kernels/moreh_norm_other_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_other/kernels/moreh_norm_other_kernel.cpp
@@ -26,6 +26,7 @@ void kernel_main() {
 
     std::uint8_t output_id{tt::CBIndex::c_16};
     const auto cb_y = output_id++;  // output
+    CircularBuffer cb_y_obj(cb_y);
 
     std::uint8_t intermed_id{tt::CBIndex::c_24};
     const auto cb_tmp0 = intermed_id++;
@@ -38,8 +39,11 @@ void kernel_main() {
     const auto cb_xabs = cb_tmp0;
     CircularBuffer cb_xabs_obj(cb_xabs);   // |x|
     const auto cb_xpow = cb_tmp1;          // |x|^p
+    CircularBuffer cb_xpow_obj(cb_xpow);
     const auto cb_logx = cb_tmp2;          // log(|x|)
+    CircularBuffer cb_logx_obj(cb_logx);
     const auto cb_exp_lxmd = cb_tmp3;      // exp(log(|x|) * decimal)
+    CircularBuffer cb_exp_lxmd_obj(cb_exp_lxmd);
     const auto cb_correct_xpow = cb_tmp4;
     CircularBuffer cb_correct_xpow_obj(cb_correct_xpow);  // |x|^p * exp(log(|x|) * decimal)(==|x + decimal|^p)
     const auto cb_xpowadd = cb_tmp5;
@@ -62,7 +66,7 @@ void kernel_main() {
             cb_x_obj.wait_front(onetile);  // comes from the reader
             cb_xabs_obj.reserve_back(onetile);
 
-            copy_tile_init_with_dt(cb_x);
+            copy_tile_init_with_dt(cb_x_obj);
             copy_tile(cb_x, 0, dst0);
 
             abs_tile_init();
@@ -70,13 +74,21 @@ void kernel_main() {
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_xabs);
+            pack_tile_with_dt(dst0, cb_xabs_obj);
             tile_regs_release();
 
             cb_x_obj.pop_front(onetile);
             cb_xabs_obj.push_back(onetile);
 
-            power_tile_to_cb(cb_xabs, cb_xpow, cb_logx, cb_decimal, cb_exp_lxmd, cb_correct_xpow, p, p_is_negative);
+            power_tile_to_cb(
+                cb_xabs_obj,
+                cb_xpow_obj,
+                cb_logx_obj,
+                cb_decimal_obj,
+                cb_exp_lxmd_obj,
+                cb_correct_xpow_obj,
+                p,
+                p_is_negative);
 
             // Add(|x|^p)
             if (inner_idx == 0) {
@@ -84,12 +96,12 @@ void kernel_main() {
                 cb_correct_xpow_obj.wait_front(onetile);
                 cb_xpowadd_obj.reserve_back(onetile);
 
-                copy_tile_init_with_dt(cb_correct_xpow);
+                copy_tile_init_with_dt(cb_correct_xpow_obj);
                 copy_tile(cb_correct_xpow, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_xpowadd);
+                pack_tile_with_dt(dst0, cb_xpowadd_obj);
                 tile_regs_release();
 
                 cb_correct_xpow_obj.pop_front(onetile);
@@ -100,12 +112,12 @@ void kernel_main() {
                 cb_xpowadd_obj.wait_front(onetile);
                 cb_xpowadd_obj.reserve_back(onetile);
 
-                add_tiles_init_with_dt(cb_correct_xpow, cb_xpowadd);
+                add_tiles_init_with_dt(cb_correct_xpow_obj, cb_xpowadd_obj);
                 add_tiles(cb_correct_xpow, cb_xpowadd, 0, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_xpowadd);
+                pack_tile_with_dt(dst0, cb_xpowadd_obj);
                 tile_regs_release();
 
                 cb_correct_xpow_obj.pop_front(onetile);
@@ -115,7 +127,15 @@ void kernel_main() {
         }
 
         // Compute cb_y
-        power_tile_to_cb(cb_xpowadd, cb_tmp0, cb_tmp1, cb_recip_p_decimal, cb_tmp2, cb_y, recip_p, recip_p_is_negative);
+        power_tile_to_cb(
+            cb_xpowadd_obj,
+            cb_xabs_obj,
+            cb_xpow_obj,
+            cb_recip_p_decimal_obj,
+            cb_logx_obj,
+            cb_y_obj,
+            recip_p,
+            recip_p_is_negative);
     }
     cb_one_obj.pop_front(onetile);
     cb_decimal_obj.pop_front(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_w/kernels/moreh_norm_w_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_w/kernels/moreh_norm_w_kernel.cpp
@@ -30,6 +30,7 @@ void kernel_main() {
 
     std::uint8_t output_id{tt::CBIndex::c_16};
     const auto cb_y = output_id++;  // output
+    CircularBuffer cb_y_obj(cb_y);
 
     std::uint8_t intermed_id{tt::CBIndex::c_24};
     const auto cb_tmp0 = intermed_id++;
@@ -43,13 +44,17 @@ void kernel_main() {
     const auto cb_xabs = cb_tmp0;
     CircularBuffer cb_xabs_obj(cb_xabs);   // |x|
     const auto cb_xpow = cb_tmp1;          // |x|^p
+    CircularBuffer cb_xpow_obj(cb_xpow);
     const auto cb_logx = cb_tmp2;          // log(|x|)
+    CircularBuffer cb_logx_obj(cb_logx);
     const auto cb_exp_lxmd = cb_tmp3;      // exp(log(|x|) * decimal)
+    CircularBuffer cb_exp_lxmd_obj(cb_exp_lxmd);
     const auto cb_correct_xpow = cb_tmp4;
     CircularBuffer cb_correct_xpow_obj(cb_correct_xpow);  // |x|^p * exp(log(|x|) * decimal)(==|x + decimal|^p)
     const auto cb_xpowadd = cb_tmp5;
     CircularBuffer cb_xpowadd_obj(cb_xpowadd);  // Add(|x + decimal|^p)
     const auto cb_xpowsum = cb_tmp6;       // Sum(|x + decimal|^p)
+    CircularBuffer cb_xpowsum_obj(cb_xpowsum);
 
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
@@ -76,11 +81,11 @@ void kernel_main() {
             cb_x_obj.wait_front(onetile);  // comes from the reader
             cb_xabs_obj.reserve_back(onetile);
 
-            copy_tile_init_with_dt(cb_x);
+            copy_tile_init_with_dt(cb_x_obj);
             copy_tile(cb_x, 0, dst0);
 
             if (do_mask_w && (col_idx == Wt - 1)) {
-                copy_tile_init_with_dt(cb_mask_w);
+                copy_tile_init_with_dt(cb_mask_w_obj);
                 copy_tile(cb_mask_w, 0, dst1);
 
                 mask_tile_init();
@@ -92,13 +97,21 @@ void kernel_main() {
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_xabs);
+            pack_tile_with_dt(dst0, cb_xabs_obj);
             tile_regs_release();
 
             cb_x_obj.pop_front(onetile);
             cb_xabs_obj.push_back(onetile);
 
-            power_tile_to_cb(cb_xabs, cb_xpow, cb_logx, cb_decimal, cb_exp_lxmd, cb_correct_xpow, p, p_is_negative);
+            power_tile_to_cb(
+                cb_xabs_obj,
+                cb_xpow_obj,
+                cb_logx_obj,
+                cb_decimal_obj,
+                cb_exp_lxmd_obj,
+                cb_correct_xpow_obj,
+                p,
+                p_is_negative);
 
             // Add(|x|^p)
             if (col_idx == 0) {
@@ -106,12 +119,12 @@ void kernel_main() {
                 cb_correct_xpow_obj.wait_front(onetile);
                 cb_xpowadd_obj.reserve_back(onetile);
 
-                copy_tile_init_with_dt(cb_correct_xpow);
+                copy_tile_init_with_dt(cb_correct_xpow_obj);
                 copy_tile(cb_correct_xpow, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_xpowadd);
+                pack_tile_with_dt(dst0, cb_xpowadd_obj);
                 tile_regs_release();
 
                 cb_correct_xpow_obj.pop_front(onetile);
@@ -122,12 +135,12 @@ void kernel_main() {
                 cb_xpowadd_obj.wait_front(onetile);
                 cb_xpowadd_obj.reserve_back(onetile);
 
-                add_tiles_init_with_dt(cb_correct_xpow, cb_xpowadd);
+                add_tiles_init_with_dt(cb_correct_xpow_obj, cb_xpowadd_obj);
                 add_tiles(cb_correct_xpow, cb_xpowadd, 0, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_xpowadd);
+                pack_tile_with_dt(dst0, cb_xpowadd_obj);
                 tile_regs_release();
 
                 cb_correct_xpow_obj.pop_front(onetile);
@@ -139,7 +152,15 @@ void kernel_main() {
         compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_xpowadd, cb_one, cb_xpowsum>(
             compute_kernel_lib::ReduceInputBlockShape::single());
 
-        power_tile_to_cb(cb_xpowsum, cb_tmp0, cb_tmp1, cb_recip_p_decimal, cb_tmp2, cb_y, recip_p, recip_p_is_negative);
+        power_tile_to_cb(
+            cb_xpowsum_obj,
+            cb_xabs_obj,
+            cb_xpow_obj,
+            cb_recip_p_decimal_obj,
+            cb_logx_obj,
+            cb_y_obj,
+            recip_p,
+            recip_p_is_negative);
     }
 
     cb_one_obj.pop_front(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_h/kernels/moreh_norm_h_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_h/kernels/moreh_norm_h_kernel.cpp
@@ -56,11 +56,11 @@ void kernel_main() {
             cb_x_obj.wait_front(onetile);  // comes from the reader
             cb_val_obj.reserve_back(onetile);
 
-            copy_tile_init_with_dt(cb_x);
+            copy_tile_init_with_dt(cb_x_obj);
             copy_tile(cb_x, 0, dst0);
 
             if (do_mask_h && (row_idx == Ht - 1)) {
-                copy_tile_init_with_dt(cb_mask_h);
+                copy_tile_init_with_dt(cb_mask_h_obj);
                 copy_tile(cb_mask_h, 0, dst1);
 
                 mask_tile_init();
@@ -85,7 +85,7 @@ void kernel_main() {
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_val);
+            pack_tile_with_dt(dst0, cb_val_obj);
             tile_regs_release();
 
             cb_x_obj.pop_front(onetile);
@@ -97,12 +97,12 @@ void kernel_main() {
                 cb_val_obj.wait_front(onetile);
                 cb_cal_obj.reserve_back(onetile);
 
-                copy_tile_init_with_dt(cb_val);
+                copy_tile_init_with_dt(cb_val_obj);
                 copy_tile(cb_val, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_cal);
+                pack_tile_with_dt(dst0, cb_cal_obj);
                 tile_regs_release();
 
                 cb_val_obj.pop_front(onetile);
@@ -114,13 +114,13 @@ void kernel_main() {
                 cb_cal_obj.wait_front(onetile);
                 cb_cal_obj.reserve_back(onetile);
 #ifdef IS_ZERO
-                add_tiles_init_with_dt(cb_val, cb_cal);
+                add_tiles_init_with_dt(cb_val_obj, cb_cal_obj);
                 add_tiles(cb_val, cb_cal, 0, 0, dst0);
 #else
-                copy_tile_init_with_dt(cb_val);
+                copy_tile_init_with_dt(cb_val_obj);
                 copy_tile(cb_val, 0, dst0);
 
-                copy_tile_init_with_dt(cb_cal);
+                copy_tile_init_with_dt(cb_cal_obj);
                 copy_tile(cb_cal, 0, dst1);
 
                 binary_max_tile_init();
@@ -129,7 +129,7 @@ void kernel_main() {
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_cal);
+                pack_tile_with_dt(dst0, cb_cal_obj);
                 tile_regs_release();
 
                 cb_val_obj.pop_front(onetile);
@@ -146,7 +146,7 @@ void kernel_main() {
         cb_reduce_obj.wait_front(onetile);
         cb_y_obj.reserve_back(onetile);
 
-        copy_tile_init_with_dt(cb_reduce);
+        copy_tile_init_with_dt(cb_reduce_obj);
         copy_tile(cb_reduce, 0, dst0);
 #ifdef MINUS_INF
         negative_tile_init();
@@ -155,7 +155,7 @@ void kernel_main() {
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_y);
+        pack_tile_with_dt(dst0, cb_y_obj);
         tile_regs_release();
 
         cb_reduce_obj.pop_front(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_nc/kernels/moreh_norm_nc_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_nc/kernels/moreh_norm_nc_kernel.cpp
@@ -43,7 +43,7 @@ void kernel_main() {
             cb_x_obj.wait_front(onetile);  // comes from the reader
             cb_val_obj.reserve_back(onetile);
 
-            copy_tile_init_with_dt(cb_x);
+            copy_tile_init_with_dt(cb_x_obj);
             copy_tile(cb_x, 0, dst0);
 #ifdef IS_ZERO
             unary_ne_tile_init();
@@ -60,7 +60,7 @@ void kernel_main() {
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_val);
+            pack_tile_with_dt(dst0, cb_val_obj);
             tile_regs_release();
 
             cb_x_obj.pop_front(onetile);
@@ -72,12 +72,12 @@ void kernel_main() {
                 cb_val_obj.wait_front(onetile);
                 cb_cal_obj.reserve_back(onetile);
 
-                copy_tile_init_with_dt(cb_val);
+                copy_tile_init_with_dt(cb_val_obj);
                 copy_tile(cb_val, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_cal);
+                pack_tile_with_dt(dst0, cb_cal_obj);
                 tile_regs_release();
 
                 cb_val_obj.pop_front(onetile);
@@ -89,13 +89,13 @@ void kernel_main() {
                 cb_cal_obj.wait_front(onetile);
                 cb_cal_obj.reserve_back(onetile);
 #ifdef IS_ZERO
-                add_tiles_init_with_dt(cb_val, cb_cal);
+                add_tiles_init_with_dt(cb_val_obj, cb_cal_obj);
                 add_tiles(cb_val, cb_cal, 0, 0, dst0);
 #else
-                copy_tile_init_with_dt(cb_val);
+                copy_tile_init_with_dt(cb_val_obj);
                 copy_tile(cb_val, 0, dst0);
 
-                copy_tile_init_with_dt(cb_cal);
+                copy_tile_init_with_dt(cb_cal_obj);
                 copy_tile(cb_cal, 0, dst1);
 
                 binary_max_tile_init();
@@ -104,7 +104,7 @@ void kernel_main() {
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_cal);
+                pack_tile_with_dt(dst0, cb_cal_obj);
                 tile_regs_release();
 
                 cb_val_obj.pop_front(onetile);
@@ -119,7 +119,7 @@ void kernel_main() {
         cb_cal_obj.wait_front(onetile);
         cb_y_obj.reserve_back(onetile);
 
-        copy_tile_init_with_dt(cb_cal);
+        copy_tile_init_with_dt(cb_cal_obj);
         copy_tile(cb_cal, 0, dst0);
 #ifdef MINUS_INF
         negative_tile_init();
@@ -128,7 +128,7 @@ void kernel_main() {
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_y);
+        pack_tile_with_dt(dst0, cb_y_obj);
         tile_regs_release();
 
         cb_cal_obj.pop_front(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_w/kernels/moreh_norm_w_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_w/kernels/moreh_norm_w_kernel.cpp
@@ -57,11 +57,11 @@ void kernel_main() {
             cb_x_obj.wait_front(onetile);  // comes from the reader
             cb_val_obj.reserve_back(onetile);
 
-            copy_tile_init_with_dt(cb_x);
+            copy_tile_init_with_dt(cb_x_obj);
             copy_tile(cb_x, 0, dst0);
 
             if (do_mask_w && (col_idx == Wt - 1)) {
-                copy_tile_init_with_dt(cb_mask_w);
+                copy_tile_init_with_dt(cb_mask_w_obj);
                 copy_tile(cb_mask_w, 0, dst1);
                 mask_tile_init();
 #ifdef MINUS_INF
@@ -85,7 +85,7 @@ void kernel_main() {
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_val);
+            pack_tile_with_dt(dst0, cb_val_obj);
             tile_regs_release();
 
             cb_x_obj.pop_front(onetile);
@@ -97,12 +97,12 @@ void kernel_main() {
                 cb_val_obj.wait_front(onetile);
                 cb_cal_obj.reserve_back(onetile);
 
-                copy_tile_init_with_dt(cb_val);
+                copy_tile_init_with_dt(cb_val_obj);
                 copy_tile(cb_val, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_cal);
+                pack_tile_with_dt(dst0, cb_cal_obj);
                 tile_regs_release();
 
                 cb_val_obj.pop_front(onetile);
@@ -113,13 +113,13 @@ void kernel_main() {
                 cb_cal_obj.wait_front(onetile);
                 cb_cal_obj.reserve_back(onetile);
 #ifdef IS_ZERO
-                add_tiles_init_with_dt(cb_val, cb_cal);
+                add_tiles_init_with_dt(cb_val_obj, cb_cal_obj);
                 add_tiles(cb_val, cb_cal, 0, 0, dst0);
 #else
-                copy_tile_init_with_dt(cb_val);
+                copy_tile_init_with_dt(cb_val_obj);
                 copy_tile(cb_val, 0, dst0);
 
-                copy_tile_init_with_dt(cb_cal);
+                copy_tile_init_with_dt(cb_cal_obj);
                 copy_tile(cb_cal, 0, dst1);
 
                 binary_max_tile_init();
@@ -128,7 +128,7 @@ void kernel_main() {
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_cal);
+                pack_tile_with_dt(dst0, cb_cal_obj);
                 tile_regs_release();
 
                 cb_val_obj.pop_front(onetile);
@@ -145,7 +145,7 @@ void kernel_main() {
         cb_reduce_obj.wait_front(onetile);
         cb_y_obj.reserve_back(onetile);
 
-        copy_tile_init_with_dt(cb_reduce);
+        copy_tile_init_with_dt(cb_reduce_obj);
         copy_tile(cb_reduce, 0, dst0);
 #ifdef MINUS_INF
         negative_tile_init();
@@ -154,7 +154,7 @@ void kernel_main() {
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_y);
+        pack_tile_with_dt(dst0, cb_y_obj);
         tile_regs_release();
 
         cb_reduce_obj.pop_front(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/kernels/moreh_norm_backward_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/kernels/moreh_norm_backward_kernel.cpp
@@ -31,6 +31,7 @@ void kernel_main() {
 
     std::uint8_t output_id{tt::CBIndex::c_16};
     const auto cb_dx = output_id++;  // input_grad(==dx)
+    CircularBuffer cb_dx_obj(cb_dx);
 
     std::uint8_t intermed_id{tt::CBIndex::c_24};
     const auto cb_tmp0 = intermed_id++;
@@ -45,13 +46,17 @@ void kernel_main() {
     const auto cb_tmp7 = intermed_id++;
 
     const auto cb_xpow = cb_tmp0;
+    CircularBuffer cb_xpow_obj(cb_xpow);
     const auto cb_logx = cb_tmp1;
+    CircularBuffer cb_logx_obj(cb_logx);
     const auto cb_exp_lxmd = cb_tmp2;
+    CircularBuffer cb_exp_lxmd_obj(cb_exp_lxmd);
     const auto cb_correct_xpow = cb_tmp3;
     CircularBuffer cb_correct_xpow_obj(cb_correct_xpow);
     const auto cb_recip_ypow = cb_tmp6;
     CircularBuffer cb_recip_ypow_obj(cb_recip_ypow);
     const auto cb_sign = cb_tmp7;
+    CircularBuffer cb_sign_obj(cb_sign);
 
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
@@ -64,11 +69,18 @@ void kernel_main() {
         cb_y_obj.wait_front(onetile);   // comes from the reader
         cb_dy_obj.wait_front(onetile);  // comes from the reader
 
-        sign_tile_to_cb(cb_x, cb_sign, 0, /*pop=*/0);
+        sign_tile_to_cb(cb_x_obj, cb_sign_obj, 0, /*pop=*/0);
 
         // x^(p - 1)
         power_tile_with_abs_x_to_cb(
-            cb_x, cb_xpow, cb_logx, cb_decimal, cb_exp_lxmd, cb_correct_xpow, p_minus_one, p_minus_one_is_negative);
+            cb_x_obj,
+            cb_xpow_obj,
+            cb_logx_obj,
+            cb_decimal_obj,
+            cb_exp_lxmd_obj,
+            cb_correct_xpow_obj,
+            p_minus_one,
+            p_minus_one_is_negative);
 
         // x^(p - 1) * y -> cb_tmp4
         cb_correct_xpow_obj.wait_front(onetile);
@@ -76,22 +88,22 @@ void kernel_main() {
 
         tile_regs_acquire();
         if (ht_need_bcast && wt_need_bcast) {
-            mul_tiles_bcast_scalar_init_short_with_dt(cb_correct_xpow, cb_y);
+            mul_tiles_bcast_scalar_init_short_with_dt(cb_correct_xpow_obj, cb_y_obj);
             mul_tiles_bcast_scalar(cb_correct_xpow, cb_y, 0, 0, dst0);
         } else if (ht_need_bcast) {
-            mul_bcast_rows_init_short_with_dt(cb_correct_xpow, cb_y);
+            mul_bcast_rows_init_short_with_dt(cb_correct_xpow_obj, cb_y_obj);
             mul_tiles_bcast_rows(cb_correct_xpow, cb_y, 0, 0, dst0);
         } else if (wt_need_bcast) {
-            mul_bcast_cols_init_short_with_dt(cb_correct_xpow, cb_y);
+            mul_bcast_cols_init_short_with_dt(cb_correct_xpow_obj, cb_y_obj);
             mul_tiles_bcast_cols(cb_correct_xpow, cb_y, 0, 0, dst0);
         } else {
-            mul_tiles_init_with_dt(cb_correct_xpow, cb_y);
+            mul_tiles_init_with_dt(cb_correct_xpow_obj, cb_y_obj);
             mul_tiles(cb_correct_xpow, cb_y, 0, 0, dst0);
         }
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp4);
+        pack_tile_with_dt(dst0, cb_tmp4_obj);
         tile_regs_release();
 
         cb_correct_xpow_obj.pop_front(onetile);
@@ -103,29 +115,30 @@ void kernel_main() {
 
         tile_regs_acquire();
         if (ht_need_bcast && wt_need_bcast) {
-            mul_tiles_bcast_scalar_init_short_with_dt(cb_tmp4, cb_dy);
+            mul_tiles_bcast_scalar_init_short_with_dt(cb_tmp4_obj, cb_dy_obj);
             mul_tiles_bcast_scalar(cb_tmp4, cb_dy, 0, 0, dst0);
         } else if (ht_need_bcast) {
-            mul_bcast_rows_init_short_with_dt(cb_tmp4, cb_dy);
+            mul_bcast_rows_init_short_with_dt(cb_tmp4_obj, cb_dy_obj);
             mul_tiles_bcast_rows(cb_tmp4, cb_dy, 0, 0, dst0);
         } else if (wt_need_bcast) {
-            mul_bcast_cols_init_short_with_dt(cb_tmp4, cb_dy);
+            mul_bcast_cols_init_short_with_dt(cb_tmp4_obj, cb_dy_obj);
             mul_tiles_bcast_cols(cb_tmp4, cb_dy, 0, 0, dst0);
         } else {
-            mul_tiles_init_with_dt(cb_tmp4, cb_dy);
+            mul_tiles_init_with_dt(cb_tmp4_obj, cb_dy_obj);
             mul_tiles(cb_tmp4, cb_dy, 0, 0, dst0);
         }
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp5);
+        pack_tile_with_dt(dst0, cb_tmp5_obj);
         tile_regs_release();
 
         cb_tmp4_obj.pop_front(onetile);
         cb_tmp5_obj.push_back(onetile);
 
         // 1 / y^p
-        power_and_recip_tile_to_cb(cb_y, cb_tmp0, cb_tmp1, cb_decimal, cb_tmp2, cb_recip_ypow, p, p_is_negative);
+        power_and_recip_tile_to_cb(
+            cb_y_obj, cb_xpow_obj, cb_logx_obj, cb_decimal_obj, cb_exp_lxmd_obj, cb_recip_ypow_obj, p, p_is_negative);
 
         // (x^(p - 1) * y * dy) / y^p -> cb_dx
         cb_tmp5_obj.wait_front(onetile);
@@ -134,22 +147,22 @@ void kernel_main() {
 
         tile_regs_acquire();
         if (ht_need_bcast && wt_need_bcast) {
-            mul_tiles_bcast_scalar_init_short_with_dt(cb_tmp5, cb_recip_ypow);
+            mul_tiles_bcast_scalar_init_short_with_dt(cb_tmp5_obj, cb_recip_ypow_obj);
             mul_tiles_bcast_scalar(cb_tmp5, cb_recip_ypow, 0, 0, dst0);
         } else if (ht_need_bcast) {
-            mul_bcast_rows_init_short_with_dt(cb_tmp5, cb_recip_ypow);
+            mul_bcast_rows_init_short_with_dt(cb_tmp5_obj, cb_recip_ypow_obj);
             mul_tiles_bcast_rows(cb_tmp5, cb_recip_ypow, 0, 0, dst0);
         } else if (wt_need_bcast) {
-            mul_bcast_cols_init_short_with_dt(cb_tmp5, cb_recip_ypow);
+            mul_bcast_cols_init_short_with_dt(cb_tmp5_obj, cb_recip_ypow_obj);
             mul_tiles_bcast_cols(cb_tmp5, cb_recip_ypow, 0, 0, dst0);
         } else {
-            mul_tiles_init_with_dt(cb_tmp5, cb_recip_ypow);
+            mul_tiles_init_with_dt(cb_tmp5_obj, cb_recip_ypow_obj);
             mul_tiles(cb_tmp5, cb_recip_ypow, 0, 0, dst0);
         }
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp4);
+        pack_tile_with_dt(dst0, cb_tmp4_obj);
         tile_regs_release();
 
         cb_tmp5_obj.pop_front(onetile);
@@ -159,7 +172,7 @@ void kernel_main() {
         cb_dy_obj.pop_front(onetile);
 
         // multiply abs sign
-        mul_tiles_to_cb(cb_sign, cb_tmp4, cb_dx, 0, 0);
+        mul_tiles_to_cb(cb_sign_obj, cb_tmp4_obj, cb_dx_obj, 0, 0);
     }
 
     cb_decimal_obj.pop_front(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/kernels/moreh_sgd.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/kernels/moreh_sgd.cpp
@@ -7,18 +7,27 @@
 
 void kernel_main() {
     constexpr auto cb_param_in = tt::CBIndex::c_0;
+    CircularBuffer cb_param_in_obj(cb_param_in);
     constexpr auto cb_grad = tt::CBIndex::c_1;
+    CircularBuffer cb_grad_obj(cb_grad);
     constexpr auto cb_momentum_in = tt::CBIndex::c_2;
+    CircularBuffer cb_momentum_in_obj(cb_momentum_in);
 
     constexpr auto cb_param_out = tt::CBIndex::c_16;
+    CircularBuffer cb_param_out_obj(cb_param_out);
     constexpr auto cb_momentum_out = tt::CBIndex::c_17;
+    CircularBuffer cb_momentum_out_obj(cb_momentum_out);
 
     constexpr auto cb_scalar_args = tt::CBIndex::c_24;
     CircularBuffer cb_scalar_args_obj(cb_scalar_args);
     constexpr auto cb_tmp1 = tt::CBIndex::c_25;
+    CircularBuffer cb_tmp1_obj(cb_tmp1);
     constexpr auto cb_tmp2 = tt::CBIndex::c_26;
+    CircularBuffer cb_tmp2_obj(cb_tmp2);
     constexpr auto cb_tmp3 = tt::CBIndex::c_27;
+    CircularBuffer cb_tmp3_obj(cb_tmp3);
     constexpr auto cb_tmp4 = tt::CBIndex::c_28;
+    CircularBuffer cb_tmp4_obj(cb_tmp4);
 
     constexpr uint32_t lr_tile = 0;
     constexpr uint32_t momentum_tile = 1;
@@ -37,9 +46,9 @@ void kernel_main() {
         uint32_t cb_grad_tmp = cb_grad;
 #if defined(WEIGHT_DECAY)
         // grad += param * weight_decay
-        mul_tiles_to_cb(cb_param_in, cb_scalar_args, cb_tmp1, 0, weight_decay_tile, /*pop0=*/0, /*pop1=*/0);
+        mul_tiles_to_cb(cb_param_in_obj, cb_scalar_args_obj, cb_tmp1_obj, 0, weight_decay_tile, /*pop0=*/0, /*pop1=*/0);
 
-        add_tiles_to_cb(cb_grad, cb_tmp1, cb_tmp2, 0, 0, /*pop0=*/1, /*pop1=*/1);
+        add_tiles_to_cb(cb_grad_obj, cb_tmp1_obj, cb_tmp2_obj, 0, 0, /*pop0=*/1, /*pop1=*/1);
 
         cb_grad_tmp = cb_tmp2;
 #endif  // WEIGHT_DECAY
@@ -48,26 +57,46 @@ void kernel_main() {
         uint32_t cb_momentum_tmp = cb_grad_tmp;
 #if defined(MOMENTUM_INITIALIZED)
         // grad * (1 - dampening)
-        sub_tiles_to_cb(cb_scalar_args, cb_scalar_args, cb_tmp1, one_tile, dampening_tile, /*pop0=*/0, /*pop0=*/0);
+        sub_tiles_to_cb(
+            cb_scalar_args_obj, cb_scalar_args_obj, cb_tmp1_obj, one_tile, dampening_tile, /*pop0=*/0, /*pop0=*/0);
 
-        mul_tiles_to_cb(cb_grad_tmp, cb_tmp1, cb_tmp3, 0, 0, /*pop0=*/0, /*pop0=*/1);
+        {
+            CircularBuffer cb_grad_tmp_obj(cb_grad_tmp);
+            mul_tiles_to_cb(cb_grad_tmp_obj, cb_tmp1_obj, cb_tmp3_obj, 0, 0, /*pop0=*/0, /*pop0=*/1);
+        }
 
         // momentum_v * momentum
-        mul_tiles_to_cb(cb_momentum_in, cb_scalar_args, cb_tmp4, 0, momentum_tile, /*pop0=*/1, /*pop0=*/0);
+        mul_tiles_to_cb(cb_momentum_in_obj, cb_scalar_args_obj, cb_tmp4_obj, 0, momentum_tile, /*pop0=*/1, /*pop0=*/0);
 
-        add_tiles_to_cb(cb_tmp3, cb_tmp4, cb_tmp1, 0, 0, /*pop0=*/1, /*pop1=*/1);
+        add_tiles_to_cb(cb_tmp3_obj, cb_tmp4_obj, cb_tmp1_obj, 0, 0, /*pop0=*/1, /*pop1=*/1);
 
         cb_momentum_tmp = cb_tmp1;
 #endif
 
-        copy_tile_to_cb(cb_momentum_tmp, cb_momentum_out, 0, /*pop=*/0);
+        {
+            CircularBuffer cb_momentum_tmp_obj(cb_momentum_tmp);
+            copy_tile_to_cb(cb_momentum_tmp_obj, cb_momentum_out_obj, 0, /*pop=*/0);
+        }
 
 #if defined(NESTEROV)
         // grad = grad + momentum_v * momentum
         uint32_t pop_momentum = (cb_grad_tmp != cb_momentum_tmp);
-        mul_tiles_to_cb(cb_momentum_tmp, cb_scalar_args, cb_tmp3, 0, momentum_tile, /*pop0=*/pop_momentum, /*pop1=*/0);
+        {
+            CircularBuffer cb_momentum_tmp_obj(cb_momentum_tmp);
+            mul_tiles_to_cb(
+                cb_momentum_tmp_obj,
+                cb_scalar_args_obj,
+                cb_tmp3_obj,
+                0,
+                momentum_tile,
+                /*pop0=*/pop_momentum,
+                /*pop1=*/0);
+        }
 
-        add_tiles_to_cb(cb_tmp3, cb_grad_tmp, cb_tmp4, 0, 0, /*pop0=*/1, /*pop1=*/1);
+        {
+            CircularBuffer cb_grad_tmp_obj(cb_grad_tmp);
+            add_tiles_to_cb(cb_tmp3_obj, cb_grad_tmp_obj, cb_tmp4_obj, 0, 0, /*pop0=*/1, /*pop1=*/1);
+        }
 
         cb_grad_tmp = cb_tmp4;
 #else
@@ -85,8 +114,11 @@ void kernel_main() {
 #endif  // MOMENTUM
 
         // param_out = param_in - lr * grad
-        mul_tiles_to_cb(cb_scalar_args, cb_grad_tmp, cb_tmp3, lr_tile, 0, /*pop0=*/0, /*pop1=*/1);
+        {
+            CircularBuffer cb_grad_tmp_obj(cb_grad_tmp);
+            mul_tiles_to_cb(cb_scalar_args_obj, cb_grad_tmp_obj, cb_tmp3_obj, lr_tile, 0, /*pop0=*/0, /*pop1=*/1);
+        }
 
-        sub_tiles_to_cb(cb_param_in, cb_tmp3, cb_param_out, 0, 0, /*pop0=*/1, /*pop1=*/1);
+        sub_tiles_to_cb(cb_param_in_obj, cb_tmp3_obj, cb_param_out_obj, 0, 0, /*pop0=*/1, /*pop1=*/1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_c_large.cpp
@@ -11,13 +11,17 @@ void kernel_main() {
     constexpr auto cb_in0 = tt::CBIndex::c_0;
     CircularBuffer cb_in0_obj(cb_in0);
     constexpr auto cb_out0 = tt::CBIndex::c_16;
+    CircularBuffer cb_out0_obj(cb_out0);
     constexpr auto cb_exps = tt::CBIndex::c_24;
+    CircularBuffer cb_exps_obj(cb_exps);
     constexpr auto cb_recipsumexps = tt::CBIndex::c_25;
     CircularBuffer cb_recipsumexps_obj(cb_recipsumexps);
     constexpr auto cb_add = tt::CBIndex::c_26;
+    CircularBuffer cb_add_obj(cb_add);
     constexpr auto cb_max = tt::CBIndex::c_27;
     CircularBuffer cb_max_obj(cb_max);
     constexpr auto cb_tmp = tt::CBIndex::c_28;
+    CircularBuffer cb_tmp_obj(cb_tmp);
 
     constexpr uint32_t onetile = 1;
     constexpr int dst0 = 0;
@@ -32,17 +36,17 @@ void kernel_main() {
         // find max
         for (uint32_t i = 0; i < dim_size; ++i) {
             if (i == 0) {
-                copy_tile_to_cb(cb_in0, cb_max);
+                copy_tile_to_cb(cb_in0_obj, cb_max_obj);
             } else {
                 cb_in0_obj.wait_front(onetile);
                 cb_max_obj.wait_front(onetile);
 
                 tile_regs_acquire();
 
-                copy_tile_init_with_dt(cb_in0);
+                copy_tile_init_with_dt(cb_in0_obj);
                 copy_tile(cb_in0, 0, dst0);
 
-                copy_tile_init_with_dt(cb_max);
+                copy_tile_init_with_dt(cb_max_obj);
                 copy_tile(cb_max, 0, dst1);
 
                 binary_max_tile_init();
@@ -53,7 +57,7 @@ void kernel_main() {
                 cb_max_obj.reserve_back(onetile);
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_max);
+                pack_tile_with_dt(dst0, cb_max_obj);
                 tile_regs_release();
 
                 cb_max_obj.push_back(onetile);
@@ -64,28 +68,28 @@ void kernel_main() {
         // compute exp(x - max(x))
         for (uint32_t i = 0; i < dim_size; ++i) {
 #ifdef SOFTMAX
-            sub_tiles_to_cb(cb_in0, cb_max, cb_tmp, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            exp_tile_to_cb(cb_tmp, cb_exps);
+            exp_tile_to_cb(cb_tmp_obj, cb_exps_obj);
 #else
-            sub_tiles_to_cb(cb_in0, cb_max, cb_tmp, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            rexp_tile_to_cb(cb_tmp, cb_exps);
+            rexp_tile_to_cb(cb_tmp_obj, cb_exps_obj);
 #endif
 
             if (i == 0) {
-                copy_tile_to_cb(cb_exps, cb_add);
+                copy_tile_to_cb(cb_exps_obj, cb_add_obj);
             } else {
-                add_tiles_to_cb(cb_add, cb_exps, cb_add);
+                add_tiles_to_cb(cb_add_obj, cb_exps_obj, cb_add_obj);
             }
         }
 
 #ifdef LOG
         // compute log(sum)
-        log_tile_to_cb(cb_add, cb_recipsumexps);
+        log_tile_to_cb(cb_add_obj, cb_recipsumexps_obj);
 #else
         // compute 1/sum(exp(x))
-        recip_tile_to_cb(cb_add, cb_recipsumexps);
+        recip_tile_to_cb(cb_add_obj, cb_recipsumexps_obj);
 #endif
 
         // step 3, compute final result
@@ -94,30 +98,30 @@ void kernel_main() {
 #ifdef LOG
 #ifdef SOFTMAX
             // x - max - log(sum)
-            sub_tiles_to_cb(cb_in0, cb_max, cb_tmp, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            sub_tiles_to_cb(cb_tmp, cb_recipsumexps, cb_out0, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_to_cb(cb_tmp_obj, cb_recipsumexps_obj, cb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 #else
             // -x + max - log(sum)
-            sub_tiles_to_cb(cb_max, cb_in0, cb_tmp, 0, 0, /*pop0=*/0, /*pop1=*/1);
+            sub_tiles_to_cb(cb_max_obj, cb_in0_obj, cb_tmp_obj, 0, 0, /*pop0=*/0, /*pop1=*/1);
 
-            sub_tiles_to_cb(cb_tmp, cb_recipsumexps, cb_out0, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_to_cb(cb_tmp_obj, cb_recipsumexps_obj, cb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 #endif
 #else
 #ifdef SOFTMAX
             // exp(x - max) / sum
-            sub_tiles_to_cb(cb_in0, cb_max, cb_tmp, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            exp_tile_to_cb(cb_tmp, cb_exps);
+            exp_tile_to_cb(cb_tmp_obj, cb_exps_obj);
 
-            mul_tiles_to_cb(cb_exps, cb_recipsumexps, cb_out0, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            mul_tiles_to_cb(cb_exps_obj, cb_recipsumexps_obj, cb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 #else
             // rexp(x - max) / sum
-            sub_tiles_to_cb(cb_in0, cb_max, cb_tmp, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            rexp_tile_to_cb(cb_tmp, cb_exps);
+            rexp_tile_to_cb(cb_tmp_obj, cb_exps_obj);
 
-            mul_tiles_to_cb(cb_exps, cb_recipsumexps, cb_out0, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            mul_tiles_to_cb(cb_exps_obj, cb_recipsumexps_obj, cb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 #endif
 #endif
         }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h.cpp
@@ -28,6 +28,7 @@ void kernel_main() {
     constexpr auto cb_x_m_max = tt::CBIndex::c_27;
     CircularBuffer cb_x_m_max_obj(cb_x_m_max);
     constexpr auto cb_tmp = tt::CBIndex::c_28;
+    CircularBuffer cb_tmp_obj(cb_tmp);
 
     constexpr int dst0 = 0;
     constexpr int dst1 = 1;
@@ -45,7 +46,7 @@ void kernel_main() {
     for (uint32_t n = 0; n < N; ++n) {
         // find max value
         if (Ht == 1) {
-            mask_tile_to_cb(cb_in0, cb_mask, cb_tmp, 0, 0, /*pop0=*/0, /*popm=*/0);
+            mask_tile_to_cb(cb_in0_obj, cb_mask_obj, cb_tmp_obj, 0, 0, /*pop0=*/0, /*popm=*/0);
 
             compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_COL, cb_tmp, cb_max_scaler, cb_max>(
                 compute_kernel_lib::ReduceInputBlockShape::single());
@@ -59,7 +60,7 @@ void kernel_main() {
                 compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop>(
                 compute_kernel_lib::ReduceInputBlockShape::col(Ht - 1));
 
-            mask_tile_to_cb(cb_in0, cb_mask, cb_tmp, Ht - 1, 0, /*pop0=*/0, /*popm=*/0);
+            mask_tile_to_cb(cb_in0_obj, cb_mask_obj, cb_tmp_obj, Ht - 1, 0, /*pop0=*/0, /*popm=*/0);
             compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_COL, cb_tmp, cb_max_scaler, cb_max>(
                 compute_kernel_lib::ReduceInputBlockShape::single(),
                 compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
@@ -73,12 +74,12 @@ void kernel_main() {
 
         for (uint32_t h = 0; h < Ht; ++h) {
             tile_regs_acquire();
-            sub_bcast_rows_init_short_with_dt(cb_in0, cb_max);
+            sub_bcast_rows_init_short_with_dt(cb_in0_obj, cb_max_obj);
             sub_tiles_bcast<BroadcastType::ROW>(cb_in0, cb_max, h, 0, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_x_m_max);
+            pack_tile_with_dt(dst0, cb_x_m_max_obj);
             tile_regs_release();
         }
         cb_max_obj.pop_front(1);
@@ -90,7 +91,7 @@ void kernel_main() {
         cb_x_m_max_obj.wait_front(Ht);
         for (uint32_t h = 0; h < Ht; ++h) {
             tile_regs_acquire();
-            copy_tile_init_with_dt(cb_x_m_max);
+            copy_tile_init_with_dt(cb_x_m_max_obj);
             copy_tile(cb_x_m_max, h, dst0);
 
 #ifndef SOFTMAX
@@ -102,7 +103,7 @@ void kernel_main() {
             exp_tile(dst0);
 
             if (h == Ht - 1) {
-                copy_tile_init_with_dt(cb_mask);
+                copy_tile_init_with_dt(cb_mask_obj);
                 copy_tile(cb_mask, 0, dst1);
 
                 mask_tile_init();
@@ -111,7 +112,7 @@ void kernel_main() {
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_exps);
+            pack_tile_with_dt(dst0, cb_exps_obj);
             tile_regs_release();
         }
         cb_exps_obj.push_back(Ht);
@@ -162,22 +163,22 @@ void kernel_main() {
 #ifdef LOG
             // x - max - log(sum)
             tile_regs_acquire();
-            sub_bcast_rows_init_short_with_dt(cb_x_m_max, cb_recipsumexps);
+            sub_bcast_rows_init_short_with_dt(cb_x_m_max_obj, cb_recipsumexps_obj);
             sub_tiles_bcast<BroadcastType::ROW>(cb_x_m_max, cb_recipsumexps, h, 0, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_out0);
+            pack_tile_with_dt(dst0, cb_out0_obj);
             tile_regs_release();
 #else
             // exp(x - max) / psum
             tile_regs_acquire();
-            mul_bcast_rows_init_short_with_dt(cb_exps, cb_recipsumexps);
+            mul_bcast_rows_init_short_with_dt(cb_exps_obj, cb_recipsumexps_obj);
             mul_tiles_bcast_rows(cb_exps, cb_recipsumexps, h, 0, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_out0);
+            pack_tile_with_dt(dst0, cb_out0_obj);
             tile_regs_release();
 #endif
         }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h_large.cpp
@@ -10,17 +10,23 @@
 
 void kernel_main() {
     constexpr auto cb_in0 = tt::CBIndex::c_0;
+    CircularBuffer cb_in0_obj(cb_in0);
     constexpr auto cb_mask = tt::CBIndex::c_1;
+    CircularBuffer cb_mask_obj(cb_mask);
     constexpr auto cb_max_scaler = tt::CBIndex::c_2;
     constexpr auto cb_sum_scaler = tt::CBIndex::c_3;
     constexpr auto cb_out0 = tt::CBIndex::c_16;
+    CircularBuffer cb_out0_obj(cb_out0);
     constexpr auto cb_exps = tt::CBIndex::c_24;
+    CircularBuffer cb_exps_obj(cb_exps);
     constexpr auto cb_recipsumexps = tt::CBIndex::c_25;
     CircularBuffer cb_recipsumexps_obj(cb_recipsumexps);
     constexpr auto cb_add = tt::CBIndex::c_26;
+    CircularBuffer cb_add_obj(cb_add);
     constexpr auto cb_max = tt::CBIndex::c_27;
     CircularBuffer cb_max_obj(cb_max);
     constexpr auto cb_tmp = tt::CBIndex::c_28;
+    CircularBuffer cb_tmp_obj(cb_tmp);
 
     binary_op_init_common(cb_in0, cb_max_scaler, cb_out0);
 
@@ -33,7 +39,7 @@ void kernel_main() {
     for (uint32_t n = 0; n < N; ++n) {
         // find max
         if (Ht == 1) {
-            mask_tile_to_cb(cb_in0, cb_mask, cb_tmp, 0, 0, /*pop0=*/1, /*popm=*/0);
+            mask_tile_to_cb(cb_in0_obj, cb_mask_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*popm=*/0);
 
             compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_COL, cb_tmp, cb_max_scaler, cb_max>(
                 compute_kernel_lib::ReduceInputBlockShape::single());
@@ -42,7 +48,7 @@ void kernel_main() {
             compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_COL, cb_in0, cb_max_scaler, cb_max>(
                 compute_kernel_lib::ReduceInputBlockShape::col(Ht - 1));
 
-            mask_tile_to_cb(cb_in0, cb_mask, cb_tmp, 0, 0, /*pop0=*/1, /*popm=*/0);
+            mask_tile_to_cb(cb_in0_obj, cb_mask_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*popm=*/0);
 
             // Phase 2: Reduce final masked tile with accumulation
             compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_COL, cb_tmp, cb_max_scaler, cb_max>(
@@ -55,21 +61,21 @@ void kernel_main() {
             // compute exp(x - max(x))
             if (h == Ht - 1) {
 #ifdef SOFTMAX
-                sub_tiles_bcast_rows_to_cb(cb_in0, cb_max, cb_tmp, 0, 0, /*pop0=*/1, /*pop1=*/0);
+                sub_tiles_bcast_rows_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
                 exp_tile_and_mask_tile_to_cb(
-                    cb_tmp,
-                    cb_mask,
-                    cb_exps,
+                    cb_tmp_obj,
+                    cb_mask_obj,
+                    cb_exps_obj,
                     /*itile=*/0,
                     /*mtile=*/0,
                     /*pop=*/1,
                     /*popm=*/0);
 #else
                 rexp_tile_and_mask_tile_to_cb(
-                    cb_in0,
-                    cb_mask,
-                    cb_exps,
+                    cb_in0_obj,
+                    cb_mask_obj,
+                    cb_exps_obj,
                     /*itile=*/0,
                     /*mtile=*/0,
                     /*pop=*/1,
@@ -77,20 +83,20 @@ void kernel_main() {
 #endif
             } else {
 #ifdef SOFTMAX
-                sub_tiles_bcast_rows_to_cb(cb_in0, cb_max, cb_tmp, 0, 0, /*pop0=*/1, /*pop1=*/0);
+                sub_tiles_bcast_rows_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
-                exp_tile_to_cb(cb_tmp, cb_exps);
+                exp_tile_to_cb(cb_tmp_obj, cb_exps_obj);
 #else
-                sub_tiles_bcast_rows_to_cb(cb_in0, cb_max, cb_tmp, 0, 0, /*pop0=*/1, /*pop1=*/0);
+                sub_tiles_bcast_rows_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
-                rexp_tile_to_cb(cb_tmp, cb_exps);
+                rexp_tile_to_cb(cb_tmp_obj, cb_exps_obj);
 #endif
             }
 
             if (h == 0) {
-                copy_tile_to_cb(cb_exps, cb_add);
+                copy_tile_to_cb(cb_exps_obj, cb_add_obj);
             } else {
-                add_tiles_to_cb(cb_add, cb_exps, cb_add);
+                add_tiles_to_cb(cb_add_obj, cb_exps_obj, cb_add_obj);
             }
         }
 
@@ -133,9 +139,9 @@ void kernel_main() {
 #ifdef LOG
 #ifdef SOFTMAX
             // x - max - log(sum)
-            sub_tiles_bcast_rows_to_cb(cb_in0, cb_max, cb_tmp, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_bcast_rows_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            sub_tiles_bcast_rows_to_cb(cb_tmp, cb_recipsumexps, cb_out0, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_bcast_rows_to_cb(cb_tmp_obj, cb_recipsumexps_obj, cb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 #else
             // -x + max - log(sum)
             // logsoftmin not implemented
@@ -143,18 +149,18 @@ void kernel_main() {
 #else
 #ifdef SOFTMAX
             // exp(x - max) / sum
-            sub_tiles_bcast_rows_to_cb(cb_in0, cb_max, cb_tmp, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_bcast_rows_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            exp_tile_to_cb(cb_tmp, cb_exps);
+            exp_tile_to_cb(cb_tmp_obj, cb_exps_obj);
 
-            mul_tiles_bcast_rows_to_cb(cb_exps, cb_recipsumexps, cb_out0, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            mul_tiles_bcast_rows_to_cb(cb_exps_obj, cb_recipsumexps_obj, cb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 #else
             // rexp(x - max) / sum
-            sub_tiles_bcast_rows_to_cb(cb_in0, cb_max, cb_tmp, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_bcast_rows_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            rexp_tile_to_cb(cb_tmp, cb_exps);
+            rexp_tile_to_cb(cb_tmp_obj, cb_exps_obj);
 
-            mul_tiles_bcast_rows_to_cb(cb_exps, cb_recipsumexps, cb_out0, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            mul_tiles_bcast_rows_to_cb(cb_exps_obj, cb_recipsumexps_obj, cb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 #endif
 #endif
         }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w.cpp
@@ -46,7 +46,7 @@ void kernel_main() {
     for (uint32_t n = 0; n < N; ++n) {
         // find max value
         if (Wt == 1) {
-            mask_tile_to_cb(cb_in0, cb_mask, cb_tmp, 0, 0, /*pop0=*/0, /*popm=*/0);
+            mask_tile_to_cb(cb_in0_obj, cb_mask_obj, cb_tmp_obj, 0, 0, /*pop0=*/0, /*popm=*/0);
 
             compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW, cb_tmp, cb_max_scaler, cb_max>(
                 compute_kernel_lib::ReduceInputBlockShape::single());
@@ -66,7 +66,7 @@ void kernel_main() {
             // Phase 2: mask the last tile (index Wt-1, no pop) and continue reducing
             // into cb_max via Accumulate. The accumulator and output are both cb_max:
             // the helper waits+pops the previous tile, then packs+pushes the new one.
-            mask_tile_to_cb(cb_in0, cb_mask, cb_tmp, Wt - 1, 0, /*pop0=*/0, /*popm=*/0);
+            mask_tile_to_cb(cb_in0_obj, cb_mask_obj, cb_tmp_obj, Wt - 1, 0, /*pop0=*/0, /*popm=*/0);
             compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW, cb_tmp, cb_max_scaler, cb_max>(
                 compute_kernel_lib::ReduceInputBlockShape::row(1),
                 compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
@@ -80,12 +80,12 @@ void kernel_main() {
 
         for (uint32_t w = 0; w < Wt; ++w) {
             tile_regs_acquire();
-            sub_bcast_cols_init_short_with_dt(cb_in0, cb_max);
+            sub_bcast_cols_init_short_with_dt(cb_in0_obj, cb_max_obj);
             sub_tiles_bcast<BroadcastType::COL>(cb_in0, cb_max, w, 0, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_x_m_max);
+            pack_tile_with_dt(dst0, cb_x_m_max_obj);
             tile_regs_release();
         }
         cb_max_obj.pop_front(1);
@@ -97,7 +97,7 @@ void kernel_main() {
         cb_x_m_max_obj.wait_front(Wt);
         for (uint32_t w = 0; w < Wt; ++w) {
             tile_regs_acquire();
-            copy_tile_init_with_dt(cb_x_m_max);
+            copy_tile_init_with_dt(cb_x_m_max_obj);
             copy_tile(cb_x_m_max, w, dst0);
 
 #ifndef SOFTMAX
@@ -109,7 +109,7 @@ void kernel_main() {
             exp_tile(dst0);
 
             if (w == Wt - 1) {
-                copy_tile_init_with_dt(cb_mask);
+                copy_tile_init_with_dt(cb_mask_obj);
                 copy_tile(cb_mask, 0, dst1);
 
                 mask_tile_init();
@@ -118,7 +118,7 @@ void kernel_main() {
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_exps);
+            pack_tile_with_dt(dst0, cb_exps_obj);
             tile_regs_release();
         }
         cb_exps_obj.push_back(Wt);
@@ -170,22 +170,22 @@ void kernel_main() {
 #ifdef LOG
             // x - max - log(sum)
             tile_regs_acquire();
-            sub_bcast_cols_init_short_with_dt(cb_x_m_max, cb_recipsumexps);
+            sub_bcast_cols_init_short_with_dt(cb_x_m_max_obj, cb_recipsumexps_obj);
             sub_tiles_bcast<BroadcastType::COL>(cb_x_m_max, cb_recipsumexps, w, 0, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_out0);
+            pack_tile_with_dt(dst0, cb_out0_obj);
             tile_regs_release();
 #else
             // exp(x - max) / psum
             tile_regs_acquire();
-            mul_bcast_cols_init_short_with_dt(cb_exps, cb_recipsumexps);
+            mul_bcast_cols_init_short_with_dt(cb_exps_obj, cb_recipsumexps_obj);
             mul_tiles_bcast_cols(cb_exps, cb_recipsumexps, w, 0, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_out0);
+            pack_tile_with_dt(dst0, cb_out0_obj);
             tile_regs_release();
 #endif
         }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w_large.cpp
@@ -10,17 +10,23 @@
 
 void kernel_main() {
     constexpr auto cb_in0 = tt::CBIndex::c_0;
+    CircularBuffer cb_in0_obj(cb_in0);
     constexpr auto cb_mask = tt::CBIndex::c_1;
+    CircularBuffer cb_mask_obj(cb_mask);
     constexpr auto cb_max_scaler = tt::CBIndex::c_2;
     constexpr auto cb_sum_scaler = tt::CBIndex::c_3;
     constexpr auto cb_out0 = tt::CBIndex::c_16;
+    CircularBuffer cb_out0_obj(cb_out0);
     constexpr auto cb_exps = tt::CBIndex::c_24;
+    CircularBuffer cb_exps_obj(cb_exps);
     constexpr auto cb_recipsumexps = tt::CBIndex::c_25;
     CircularBuffer cb_recipsumexps_obj(cb_recipsumexps);
     constexpr auto cb_add = tt::CBIndex::c_26;
+    CircularBuffer cb_add_obj(cb_add);
     constexpr auto cb_max = tt::CBIndex::c_27;
     CircularBuffer cb_max_obj(cb_max);
     constexpr auto cb_tmp = tt::CBIndex::c_28;
+    CircularBuffer cb_tmp_obj(cb_tmp);
 
     binary_op_init_common(cb_in0, cb_max_scaler, cb_out0);
 
@@ -32,7 +38,7 @@ void kernel_main() {
     for (uint32_t n = 0; n < N; ++n) {
         // find max
         if (Wt == 1) {
-            mask_tile_to_cb(cb_in0, cb_mask, cb_tmp, 0, 0, /*pop0=*/1, /*popm=*/0);
+            mask_tile_to_cb(cb_in0_obj, cb_mask_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*popm=*/0);
 
             compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW, cb_tmp, cb_max_scaler, cb_max>(
                 compute_kernel_lib::ReduceInputBlockShape::single());
@@ -42,7 +48,7 @@ void kernel_main() {
                 compute_kernel_lib::ReduceInputBlockShape::row(Wt - 1));
 
             // Phase 2: mask the last tile and continue reducing into cb_max via Accumulate.
-            mask_tile_to_cb(cb_in0, cb_mask, cb_tmp, 0, 0, /*pop0=*/1, /*popm=*/0);
+            mask_tile_to_cb(cb_in0_obj, cb_mask_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*popm=*/0);
             compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW, cb_tmp, cb_max_scaler, cb_max>(
                 compute_kernel_lib::ReduceInputBlockShape::row(1),
                 compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
@@ -54,21 +60,21 @@ void kernel_main() {
             // compute exp(x)
             if (w == Wt - 1) {
 #ifdef SOFTMAX
-                sub_tiles_bcast_cols_to_cb(cb_in0, cb_max, cb_tmp, 0, 0, /*pop0=*/1, /*pop1=*/0);
+                sub_tiles_bcast_cols_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
                 exp_tile_and_mask_tile_to_cb(
-                    cb_tmp,
-                    cb_mask,
-                    cb_exps,
+                    cb_tmp_obj,
+                    cb_mask_obj,
+                    cb_exps_obj,
                     /*itile=*/0,
                     /*mtile=*/0,
                     /*pop=*/1,
                     /*popm=*/0);
 #else
                 rexp_tile_and_mask_tile_to_cb(
-                    cb_in0,
-                    cb_mask,
-                    cb_exps,
+                    cb_in0_obj,
+                    cb_mask_obj,
+                    cb_exps_obj,
                     /*itile=*/0,
                     /*mtile=*/0,
                     /*pop=*/1,
@@ -76,20 +82,20 @@ void kernel_main() {
 #endif
             } else {
 #ifdef SOFTMAX
-                sub_tiles_bcast_cols_to_cb(cb_in0, cb_max, cb_tmp, 0, 0, /*pop0=*/1, /*pop1=*/0);
+                sub_tiles_bcast_cols_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
-                exp_tile_to_cb(cb_tmp, cb_exps);
+                exp_tile_to_cb(cb_tmp_obj, cb_exps_obj);
 #else
-                sub_tiles_bcast_cols_to_cb(cb_in0, cb_max, cb_tmp, 0, 0, /*pop0=*/1, /*pop1=*/0);
+                sub_tiles_bcast_cols_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
-                rexp_tile_to_cb(cb_tmp, cb_exps);
+                rexp_tile_to_cb(cb_tmp_obj, cb_exps_obj);
 #endif
             }
 
             if (w == 0) {
-                copy_tile_to_cb(cb_exps, cb_add);
+                copy_tile_to_cb(cb_exps_obj, cb_add_obj);
             } else {
-                add_tiles_to_cb(cb_add, cb_exps, cb_add);
+                add_tiles_to_cb(cb_add_obj, cb_exps_obj, cb_add_obj);
             }
         }
 
@@ -132,9 +138,9 @@ void kernel_main() {
 #ifdef LOG
 #ifdef SOFTMAX
             // x - max - log(sum)
-            sub_tiles_bcast_cols_to_cb(cb_in0, cb_max, cb_tmp, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_bcast_cols_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            sub_tiles_bcast_cols_to_cb(cb_tmp, cb_recipsumexps, cb_out0, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_bcast_cols_to_cb(cb_tmp_obj, cb_recipsumexps_obj, cb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 #else
             // -x + max - log(sum)
             // logsoftmin not implemented
@@ -142,18 +148,18 @@ void kernel_main() {
 #else
 #ifdef SOFTMAX
             // exp(x - max) / sum
-            sub_tiles_bcast_cols_to_cb(cb_in0, cb_max, cb_tmp, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_bcast_cols_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            exp_tile_to_cb(cb_tmp, cb_exps);
+            exp_tile_to_cb(cb_tmp_obj, cb_exps_obj);
 
-            mul_tiles_bcast_cols_to_cb(cb_exps, cb_recipsumexps, cb_out0, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            mul_tiles_bcast_cols_to_cb(cb_exps_obj, cb_recipsumexps_obj, cb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 #else
             // rexp(x - max) / sum
-            sub_tiles_bcast_cols_to_cb(cb_in0, cb_max, cb_tmp, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_bcast_cols_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            rexp_tile_to_cb(cb_tmp, cb_exps);
+            rexp_tile_to_cb(cb_tmp_obj, cb_exps_obj);
 
-            mul_tiles_bcast_cols_to_cb(cb_exps, cb_recipsumexps, cb_out0, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            mul_tiles_bcast_cols_to_cb(cb_exps_obj, cb_recipsumexps_obj, cb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 #endif
 #endif
         }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_c_large.cpp
@@ -11,13 +11,18 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
 
     constexpr auto cb_y = tt::CBIndex::c_0;
+    CircularBuffer cb_y_obj(cb_y);
     constexpr auto cb_dy = tt::CBIndex::c_1;
+    CircularBuffer cb_dy_obj(cb_dy);
     constexpr auto cb_dx = tt::CBIndex::c_16;
+    CircularBuffer cb_dx_obj(cb_dx);
 
     constexpr auto cb_ydy = tt::CBIndex::c_24;  // y * dy
+    CircularBuffer cb_ydy_obj(cb_ydy);
     constexpr auto cb_sum = tt::CBIndex::c_25;
     CircularBuffer cb_sum_obj(cb_sum);
     constexpr auto cb_dy_m_sum = tt::CBIndex::c_26;  // dy - sum
+    CircularBuffer cb_dy_m_sum_obj(cb_dy_m_sum);
 
     uint32_t N = get_compile_time_arg_val(0);
     uint32_t dim_size = get_compile_time_arg_val(1);
@@ -29,34 +34,36 @@ void kernel_main() {
 #ifdef LOG
         for (uint32_t i = 0; i < dim_size; ++i) {
             if (i == 0) {
-                copy_tile_to_cb(cb_dy, cb_sum);
+                copy_tile_to_cb(cb_dy_obj, cb_sum_obj);
             } else {
-                add_tiles_to_cb(cb_sum, cb_dy, cb_sum);
+                add_tiles_to_cb(cb_sum_obj, cb_dy_obj, cb_sum_obj);
             }
         }
 
         for (uint32_t i = 0; i < dim_size; ++i) {
             // exp(y)
             constexpr auto cb_exp = tt::CBIndex::c_24;
-            exp_tile_to_cb(cb_y, cb_exp);
+            CircularBuffer cb_exp_obj(cb_exp);
+            exp_tile_to_cb(cb_y_obj, cb_exp_obj);
 
             // sum * exp(y)
             constexpr auto cb_inter2 = tt::CBIndex::c_26;
-            mul_tiles_to_cb(cb_sum, cb_exp, cb_inter2, 0, 0, /*pop0=*/0, /*pop1=*/1);
+            CircularBuffer cb_inter2_obj(cb_inter2);
+            mul_tiles_to_cb(cb_sum_obj, cb_exp_obj, cb_inter2_obj, 0, 0, /*pop0=*/0, /*pop1=*/1);
 
             // dy - sum * exp(y)
-            sub_tiles_to_cb(cb_dy, cb_inter2, cb_dx);
+            sub_tiles_to_cb(cb_dy_obj, cb_inter2_obj, cb_dx_obj);
         }
         cb_sum_obj.pop_front(onetile);
 #else
         // compute sum(y * dy)
         for (uint32_t i = 0; i < dim_size; ++i) {
-            mul_tiles_to_cb(cb_y, cb_dy, cb_ydy);
+            mul_tiles_to_cb(cb_y_obj, cb_dy_obj, cb_ydy_obj);
 
             if (i == 0) {
-                copy_tile_to_cb(cb_ydy, cb_sum);
+                copy_tile_to_cb(cb_ydy_obj, cb_sum_obj);
             } else {
-                add_tiles_to_cb(cb_sum, cb_ydy, cb_sum);
+                add_tiles_to_cb(cb_sum_obj, cb_ydy_obj, cb_sum_obj);
             }
         }
 
@@ -64,9 +71,9 @@ void kernel_main() {
         for (uint32_t i = 0; i < dim_size; ++i) {
             // dy - sum
             sub_tiles_to_cb(
-                cb_dy,
-                cb_sum,
-                cb_dy_m_sum,
+                cb_dy_obj,
+                cb_sum_obj,
+                cb_dy_m_sum_obj,
                 /*itile0=*/0,
                 /*itile1=*/0,
                 /*pop0=*/1,
@@ -74,10 +81,10 @@ void kernel_main() {
 
 #ifdef SOFTMAX
             // (dy - sum) * y
-            mul_tiles_to_cb(cb_dy_m_sum, cb_y, cb_dx);
+            mul_tiles_to_cb(cb_dy_m_sum_obj, cb_y_obj, cb_dx_obj);
 #else
             // -(dy - sum) * y
-            mul_tiles_and_negative_to_cb(cb_dy_m_sum, cb_y, cb_dx);
+            mul_tiles_and_negative_to_cb(cb_dy_m_sum_obj, cb_y_obj, cb_dx_obj);
 #endif
         }
         cb_sum_obj.pop_front(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_h.cpp
@@ -17,12 +17,16 @@ void kernel_main() {
     CircularBuffer cb_dy_obj(cb_dy);
     constexpr auto cb_bcast_scaler = tt::CBIndex::c_2;
     constexpr auto cb_mask = tt::CBIndex::c_3;
+    CircularBuffer cb_mask_obj(cb_mask);
     constexpr auto cb_dx = tt::CBIndex::c_16;
+    CircularBuffer cb_dx_obj(cb_dx);
 
     constexpr auto cb_ydy = tt::CBIndex::c_24;  // y * dy
+    CircularBuffer cb_ydy_obj(cb_ydy);
     constexpr auto cb_sum = tt::CBIndex::c_25;
     CircularBuffer cb_sum_obj(cb_sum);
     constexpr auto cb_inter2 = tt::CBIndex::c_26;
+    CircularBuffer cb_inter2_obj(cb_inter2);
 
     binary_op_init_common(cb_y, cb_bcast_scaler, cb_dx);
 
@@ -34,7 +38,7 @@ void kernel_main() {
         // sum(dy)
         if (Ht == 1) {
             // apply mask
-            mask_tile_to_cb(cb_dy, cb_mask, cb_inter2, /*itile=*/0, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
+            mask_tile_to_cb(cb_dy_obj, cb_mask_obj, cb_inter2_obj, /*itile=*/0, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
 
             compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_COL, cb_inter2, cb_bcast_scaler, cb_sum>(
                 compute_kernel_lib::ReduceInputBlockShape::single());
@@ -50,27 +54,31 @@ void kernel_main() {
                 compute_kernel_lib::ReduceInputBlockShape::col(Ht - 1));
 
             constexpr auto cb_inter1 = tt::CBIndex::c_25;
-            mask_tile_to_cb(cb_dy, cb_mask, cb_inter1, /*itile=*/Ht - 1, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
+            CircularBuffer cb_inter1_obj(cb_inter1);
+            mask_tile_to_cb(
+                cb_dy_obj, cb_mask_obj, cb_inter1_obj, /*itile=*/Ht - 1, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
 
             constexpr auto cb_inter2 = tt::CBIndex::c_26;
             compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_COL, cb_inter1, cb_bcast_scaler, cb_inter2>(
                 compute_kernel_lib::ReduceInputBlockShape::single());
 
-            add_tiles_to_cb(cb_inter0, cb_inter2, cb_sum);
+            CircularBuffer cb_inter0_obj(cb_inter0);
+            add_tiles_to_cb(cb_inter0_obj, cb_inter2_obj, cb_sum_obj);
         }
 
         // dy - sum * exp(y)
         constexpr auto cb_exp = tt::CBIndex::c_24;  // y * dy
+        CircularBuffer cb_exp_obj(cb_exp);
 
         for (uint32_t w = 0; w < Ht; w += onetile) {
             // exp(y)
-            exp_tile_to_cb(cb_y, cb_exp, w, /*dst=*/0, /*pop=*/0);
+            exp_tile_to_cb(cb_y_obj, cb_exp_obj, w, /*dst=*/0, /*pop=*/0);
 
             // sum * exp(y)
-            mul_tiles_bcast_rows_to_cb(cb_exp, cb_sum, cb_inter2, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            mul_tiles_bcast_rows_to_cb(cb_exp_obj, cb_sum_obj, cb_inter2_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
             // dy - sum * exp(y)
-            sub_tiles_to_cb(cb_dy, cb_inter2, cb_dx, w, 0, /*pop0=*/0, /*pop1=*/1);
+            sub_tiles_to_cb(cb_dy_obj, cb_inter2_obj, cb_dx_obj, w, 0, /*pop0=*/0, /*pop1=*/1);
         }
 
         cb_sum_obj.pop_front(onetile);
@@ -81,9 +89,9 @@ void kernel_main() {
         for (uint32_t h = 0; h < Ht; ++h) {
             if (h == Ht - 1) {
                 mul_tiles_and_mask_tile_to_cb(
-                    cb_y, cb_dy, cb_mask, cb_ydy, h, h, 0, /*pop0=*/0, /*pop1=*/0, /*popm=*/0);
+                    cb_y_obj, cb_dy_obj, cb_mask_obj, cb_ydy_obj, h, h, 0, /*pop0=*/0, /*pop1=*/0, /*popm=*/0);
             } else {
-                mul_tiles_to_cb(cb_y, cb_dy, cb_ydy, h, h, /*pop0=*/0, /*pop1=*/0);
+                mul_tiles_to_cb(cb_y_obj, cb_dy_obj, cb_ydy_obj, h, h, /*pop0=*/0, /*pop1=*/0);
             }
         }
 
@@ -99,14 +107,14 @@ void kernel_main() {
         // step 3, compute final result
         for (uint32_t h = 0; h < Ht; ++h) {
             // dy - sum
-            sub_tiles_bcast_rows_to_cb(cb_dy, cb_sum, cb_inter2, h, 0, /*pop0=*/0, /*pop1=*/0);
+            sub_tiles_bcast_rows_to_cb(cb_dy_obj, cb_sum_obj, cb_inter2_obj, h, 0, /*pop0=*/0, /*pop1=*/0);
 
 #ifdef SOFTMAX
             // (dy - sum) * y
-            mul_tiles_to_cb(cb_y, cb_inter2, cb_dx, h, 0, /*pop0=*/0, /*pop1=*/1);
+            mul_tiles_to_cb(cb_y_obj, cb_inter2_obj, cb_dx_obj, h, 0, /*pop0=*/0, /*pop1=*/1);
 #else
             // -(dy - sum) * y
-            mul_tiles_and_negative_to_cb(cb_y, cb_inter2, cb_dx, h, 0, /*pop0=*/0, /*pop1=*/1);
+            mul_tiles_and_negative_to_cb(cb_y_obj, cb_inter2_obj, cb_dx_obj, h, 0, /*pop0=*/0, /*pop1=*/1);
 #endif
         }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_h_large.cpp
@@ -12,16 +12,23 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
 
     constexpr auto cb_y = tt::CBIndex::c_0;
+    CircularBuffer cb_y_obj(cb_y);
     constexpr auto cb_dy = tt::CBIndex::c_1;
+    CircularBuffer cb_dy_obj(cb_dy);
     constexpr auto cb_bcast_scaler = tt::CBIndex::c_2;
     constexpr auto cb_mask = tt::CBIndex::c_3;
+    CircularBuffer cb_mask_obj(cb_mask);
     constexpr auto cb_dx = tt::CBIndex::c_16;
+    CircularBuffer cb_dx_obj(cb_dx);
 
     constexpr auto cb_ydy = tt::CBIndex::c_24;  // y * dy
+    CircularBuffer cb_ydy_obj(cb_ydy);
     constexpr auto cb_sum = tt::CBIndex::c_25;
     CircularBuffer cb_sum_obj(cb_sum);
     constexpr auto cb_inter2 = tt::CBIndex::c_26;
+    CircularBuffer cb_inter2_obj(cb_inter2);
     constexpr auto cb_add = tt::CBIndex::c_27;
+    CircularBuffer cb_add_obj(cb_add);
 
     binary_op_init_common(cb_y, cb_bcast_scaler, cb_dx);
 
@@ -34,18 +41,21 @@ void kernel_main() {
         for (uint32_t h = 0; h < Ht; ++h) {
             if (h == Ht - 1) {
                 if (h == 0) {
-                    mask_tile_to_cb(cb_dy, cb_mask, cb_add, /*itile=*/0, /*mtile=*/0, /*pop=*/1, /*popm=*/0);
+                    mask_tile_to_cb(
+                        cb_dy_obj, cb_mask_obj, cb_add_obj, /*itile=*/0, /*mtile=*/0, /*pop=*/1, /*popm=*/0);
                 } else {
                     constexpr auto cb_inter0 = tt::CBIndex::c_24;
-                    mask_tile_to_cb(cb_dy, cb_mask, cb_inter0, /*itile=*/0, /*mtile=*/0, /*pop=*/1, /*popm=*/0);
+                    CircularBuffer cb_inter0_obj(cb_inter0);
+                    mask_tile_to_cb(
+                        cb_dy_obj, cb_mask_obj, cb_inter0_obj, /*itile=*/0, /*mtile=*/0, /*pop=*/1, /*popm=*/0);
 
-                    add_tiles_to_cb(cb_add, cb_inter0, cb_add);
+                    add_tiles_to_cb(cb_add_obj, cb_inter0_obj, cb_add_obj);
                 }
             } else {
                 if (h == 0) {
-                    copy_tile_to_cb(cb_dy, cb_add);
+                    copy_tile_to_cb(cb_dy_obj, cb_add_obj);
                 } else {
-                    add_tiles_to_cb(cb_add, cb_dy, cb_add);
+                    add_tiles_to_cb(cb_add_obj, cb_dy_obj, cb_add_obj);
                 }
             }
         }
@@ -56,13 +66,14 @@ void kernel_main() {
         for (uint32_t h = 0; h < Ht; ++h) {
             // exp(y)
             constexpr auto cb_exp = tt::CBIndex::c_24;
-            exp_tile_to_cb(cb_y, cb_exp, 0);
+            CircularBuffer cb_exp_obj(cb_exp);
+            exp_tile_to_cb(cb_y_obj, cb_exp_obj, 0);
 
             // sum * exp(y)
-            mul_tiles_bcast_rows_to_cb(cb_exp, cb_sum, cb_inter2, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            mul_tiles_bcast_rows_to_cb(cb_exp_obj, cb_sum_obj, cb_inter2_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
             // dy - sum * exp(y)
-            sub_tiles_to_cb(cb_dy, cb_inter2, cb_dx);
+            sub_tiles_to_cb(cb_dy_obj, cb_inter2_obj, cb_dx_obj);
         }
 
         cb_sum_obj.pop_front(onetile);
@@ -72,15 +83,15 @@ void kernel_main() {
         for (uint32_t h = 0; h < Ht; ++h) {
             if (h == Ht - 1) {
                 mul_tiles_and_mask_tile_to_cb(
-                    cb_y, cb_dy, cb_mask, cb_ydy, 0, 0, 0, /*pop0=*/1, /*pop1=*/1, /*popm=*/0);
+                    cb_y_obj, cb_dy_obj, cb_mask_obj, cb_ydy_obj, 0, 0, 0, /*pop0=*/1, /*pop1=*/1, /*popm=*/0);
             } else {
-                mul_tiles_to_cb(cb_y, cb_dy, cb_ydy);
+                mul_tiles_to_cb(cb_y_obj, cb_dy_obj, cb_ydy_obj);
             }
 
             if (h == 0) {
-                copy_tile_to_cb(cb_ydy, cb_add);
+                copy_tile_to_cb(cb_ydy_obj, cb_add_obj);
             } else {
-                add_tiles_to_cb(cb_add, cb_ydy, cb_add);
+                add_tiles_to_cb(cb_add_obj, cb_ydy_obj, cb_add_obj);
             }
         }
 
@@ -91,14 +102,14 @@ void kernel_main() {
         // step 3, compute final result
         for (uint32_t h = 0; h < Ht; ++h) {
             // dy - sum
-            sub_tiles_bcast_rows_to_cb(cb_dy, cb_sum, cb_inter2, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_bcast_rows_to_cb(cb_dy_obj, cb_sum_obj, cb_inter2_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
 #ifdef SOFTMAX
             // (dy - sum) * y
-            mul_tiles_to_cb(cb_y, cb_inter2, cb_dx);
+            mul_tiles_to_cb(cb_y_obj, cb_inter2_obj, cb_dx_obj);
 #else
             // -(dy - sum) * y
-            mul_tiles_and_negative_to_cb(cb_y, cb_inter2, cb_dx);
+            mul_tiles_and_negative_to_cb(cb_y_obj, cb_inter2_obj, cb_dx_obj);
 #endif
         }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_w.cpp
@@ -17,12 +17,16 @@ void kernel_main() {
     CircularBuffer cb_dy_obj(cb_dy);
     constexpr auto cb_bcast_scaler = tt::CBIndex::c_2;
     constexpr auto cb_mask = tt::CBIndex::c_3;
+    CircularBuffer cb_mask_obj(cb_mask);
     constexpr auto cb_dx = tt::CBIndex::c_16;
+    CircularBuffer cb_dx_obj(cb_dx);
 
     constexpr auto cb_ydy = tt::CBIndex::c_24;  // y * dy
+    CircularBuffer cb_ydy_obj(cb_ydy);
     constexpr auto cb_sum = tt::CBIndex::c_25;
     CircularBuffer cb_sum_obj(cb_sum);
     constexpr auto cb_inter2 = tt::CBIndex::c_26;
+    CircularBuffer cb_inter2_obj(cb_inter2);
 
     binary_op_init_common(cb_y, cb_bcast_scaler, cb_dx);
 
@@ -34,7 +38,7 @@ void kernel_main() {
         // sum(dy)
         if (Wt == 1) {
             // apply mask
-            mask_tile_to_cb(cb_dy, cb_mask, cb_inter2, /*itile=*/0, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
+            mask_tile_to_cb(cb_dy_obj, cb_mask_obj, cb_inter2_obj, /*itile=*/0, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
 
             compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_ROW, cb_inter2, cb_bcast_scaler, cb_sum>(
                 compute_kernel_lib::ReduceInputBlockShape::single());
@@ -50,27 +54,31 @@ void kernel_main() {
                 compute_kernel_lib::ReduceInputBlockShape::row(Wt - 1));
 
             constexpr auto cb_inter1 = tt::CBIndex::c_25;
-            mask_tile_to_cb(cb_dy, cb_mask, cb_inter1, /*itile=*/Wt - 1, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
+            CircularBuffer cb_inter1_obj(cb_inter1);
+            mask_tile_to_cb(
+                cb_dy_obj, cb_mask_obj, cb_inter1_obj, /*itile=*/Wt - 1, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
 
             constexpr auto cb_inter2 = tt::CBIndex::c_26;
             compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_ROW, cb_inter1, cb_bcast_scaler, cb_inter2>(
                 compute_kernel_lib::ReduceInputBlockShape::single());
 
-            add_tiles_to_cb(cb_inter0, cb_inter2, cb_sum);
+            CircularBuffer cb_inter0_obj(cb_inter0);
+            add_tiles_to_cb(cb_inter0_obj, cb_inter2_obj, cb_sum_obj);
         }
 
         // dy - sum * exp(y)
         constexpr auto cb_exp = tt::CBIndex::c_24;  // y * dy
+        CircularBuffer cb_exp_obj(cb_exp);
 
         for (uint32_t w = 0; w < Wt; w += onetile) {
             // exp(y)
-            exp_tile_to_cb(cb_y, cb_exp, w, /*dst=*/0, /*pop=*/0);
+            exp_tile_to_cb(cb_y_obj, cb_exp_obj, w, /*dst=*/0, /*pop=*/0);
 
             // sum * exp(y)
-            mul_tiles_bcast_cols_to_cb(cb_exp, cb_sum, cb_inter2, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            mul_tiles_bcast_cols_to_cb(cb_exp_obj, cb_sum_obj, cb_inter2_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
             // dy - sum * exp(y)
-            sub_tiles_to_cb(cb_dy, cb_inter2, cb_dx, w, 0, /*pop0=*/0, /*pop1=*/1);
+            sub_tiles_to_cb(cb_dy_obj, cb_inter2_obj, cb_dx_obj, w, 0, /*pop0=*/0, /*pop1=*/1);
         }
 
         cb_sum_obj.pop_front(onetile);
@@ -81,9 +89,9 @@ void kernel_main() {
         for (uint32_t w = 0; w < Wt; ++w) {
             if (w == Wt - 1) {
                 mul_tiles_and_mask_tile_to_cb(
-                    cb_y, cb_dy, cb_mask, cb_ydy, w, w, 0, /*pop0=*/0, /*pop1=*/0, /*popm=*/0);
+                    cb_y_obj, cb_dy_obj, cb_mask_obj, cb_ydy_obj, w, w, 0, /*pop0=*/0, /*pop1=*/0, /*popm=*/0);
             } else {
-                mul_tiles_to_cb(cb_y, cb_dy, cb_ydy, w, w, /*pop0=*/0, /*pop1=*/0);
+                mul_tiles_to_cb(cb_y_obj, cb_dy_obj, cb_ydy_obj, w, w, /*pop0=*/0, /*pop1=*/0);
             }
         }
 
@@ -99,14 +107,14 @@ void kernel_main() {
         // step 3, compute final result
         for (uint32_t w = 0; w < Wt; w += onetile) {
             // dy - sum
-            sub_tiles_bcast_cols_to_cb(cb_dy, cb_sum, cb_inter2, w, 0, /*pop0=*/0, /*pop1=*/0);
+            sub_tiles_bcast_cols_to_cb(cb_dy_obj, cb_sum_obj, cb_inter2_obj, w, 0, /*pop0=*/0, /*pop1=*/0);
 
 #ifdef SOFTMAX
             // (dy - sum) * y
-            mul_tiles_to_cb(cb_y, cb_inter2, cb_dx, w, 0, /*pop0=*/0, /*pop1=*/1);
+            mul_tiles_to_cb(cb_y_obj, cb_inter2_obj, cb_dx_obj, w, 0, /*pop0=*/0, /*pop1=*/1);
 #else
             // -(dy - sum) * y
-            mul_tiles_and_negative_to_cb(cb_y, cb_inter2, cb_dx, w, 0, /*pop0=*/0, /*pop1=*/1);
+            mul_tiles_and_negative_to_cb(cb_y_obj, cb_inter2_obj, cb_dx_obj, w, 0, /*pop0=*/0, /*pop1=*/1);
 #endif
         }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_w_large.cpp
@@ -12,16 +12,23 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
 
     constexpr auto cb_y = tt::CBIndex::c_0;
+    CircularBuffer cb_y_obj(cb_y);
     constexpr auto cb_dy = tt::CBIndex::c_1;
+    CircularBuffer cb_dy_obj(cb_dy);
     constexpr auto cb_bcast_scaler = tt::CBIndex::c_2;
     constexpr auto cb_mask = tt::CBIndex::c_3;
+    CircularBuffer cb_mask_obj(cb_mask);
     constexpr auto cb_dx = tt::CBIndex::c_16;
+    CircularBuffer cb_dx_obj(cb_dx);
 
     constexpr auto cb_ydy = tt::CBIndex::c_24;  // y * dy
+    CircularBuffer cb_ydy_obj(cb_ydy);
     constexpr auto cb_sum = tt::CBIndex::c_25;
     CircularBuffer cb_sum_obj(cb_sum);
     constexpr auto cb_inter2 = tt::CBIndex::c_26;
+    CircularBuffer cb_inter2_obj(cb_inter2);
     constexpr auto cb_add = tt::CBIndex::c_27;
+    CircularBuffer cb_add_obj(cb_add);
 
     binary_op_init_common(cb_y, cb_bcast_scaler, cb_dx);
 
@@ -34,18 +41,21 @@ void kernel_main() {
         for (uint32_t w = 0; w < Wt; ++w) {
             if (w == Wt - 1) {
                 if (w == 0) {
-                    mask_tile_to_cb(cb_dy, cb_mask, cb_add, /*itile=*/0, /*mtile=*/0, /*pop=*/1, /*popm=*/0);
+                    mask_tile_to_cb(
+                        cb_dy_obj, cb_mask_obj, cb_add_obj, /*itile=*/0, /*mtile=*/0, /*pop=*/1, /*popm=*/0);
                 } else {
                     constexpr auto cb_inter0 = tt::CBIndex::c_24;
-                    mask_tile_to_cb(cb_dy, cb_mask, cb_inter0, /*itile=*/0, /*mtile=*/0, /*pop=*/1, /*popm=*/0);
+                    CircularBuffer cb_inter0_obj(cb_inter0);
+                    mask_tile_to_cb(
+                        cb_dy_obj, cb_mask_obj, cb_inter0_obj, /*itile=*/0, /*mtile=*/0, /*pop=*/1, /*popm=*/0);
 
-                    add_tiles_to_cb(cb_add, cb_inter0, cb_add);
+                    add_tiles_to_cb(cb_add_obj, cb_inter0_obj, cb_add_obj);
                 }
             } else {
                 if (w == 0) {
-                    copy_tile_to_cb(cb_dy, cb_add);
+                    copy_tile_to_cb(cb_dy_obj, cb_add_obj);
                 } else {
-                    add_tiles_to_cb(cb_add, cb_dy, cb_add);
+                    add_tiles_to_cb(cb_add_obj, cb_dy_obj, cb_add_obj);
                 }
             }
         }
@@ -56,12 +66,13 @@ void kernel_main() {
         for (uint32_t w = 0; w < Wt; w += onetile) {
             // exp(y)
             constexpr auto cb_exp = tt::CBIndex::c_24;
-            exp_tile_to_cb(cb_y, cb_exp, 0);
+            CircularBuffer cb_exp_obj(cb_exp);
+            exp_tile_to_cb(cb_y_obj, cb_exp_obj, 0);
             // sum * exp(y)
-            mul_tiles_bcast_cols_to_cb(cb_exp, cb_sum, cb_inter2, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            mul_tiles_bcast_cols_to_cb(cb_exp_obj, cb_sum_obj, cb_inter2_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
             // dy - sum * exp(y)
-            sub_tiles_to_cb(cb_dy, cb_inter2, cb_dx);
+            sub_tiles_to_cb(cb_dy_obj, cb_inter2_obj, cb_dx_obj);
         }
 
         cb_sum_obj.pop_front(onetile);
@@ -70,15 +81,15 @@ void kernel_main() {
         for (uint32_t w = 0; w < Wt; ++w) {
             if (w == Wt - 1) {
                 mul_tiles_and_mask_tile_to_cb(
-                    cb_y, cb_dy, cb_mask, cb_ydy, 0, 0, 0, /*pop0=*/1, /*pop1=*/1, /*popm=*/0);
+                    cb_y_obj, cb_dy_obj, cb_mask_obj, cb_ydy_obj, 0, 0, 0, /*pop0=*/1, /*pop1=*/1, /*popm=*/0);
             } else {
-                mul_tiles_to_cb(cb_y, cb_dy, cb_ydy);
+                mul_tiles_to_cb(cb_y_obj, cb_dy_obj, cb_ydy_obj);
             }
 
             if (w == 0) {
-                copy_tile_to_cb(cb_ydy, cb_add);
+                copy_tile_to_cb(cb_ydy_obj, cb_add_obj);
             } else {
-                add_tiles_to_cb(cb_add, cb_ydy, cb_add);
+                add_tiles_to_cb(cb_add_obj, cb_ydy_obj, cb_add_obj);
             }
         }
 
@@ -89,14 +100,14 @@ void kernel_main() {
         // step 3, compute final result
         for (uint32_t w = 0; w < Wt; w += onetile) {
             // dy - sum
-            sub_tiles_bcast_cols_to_cb(cb_dy, cb_sum, cb_inter2, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_bcast_cols_to_cb(cb_dy_obj, cb_sum_obj, cb_inter2_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
 #ifdef SOFTMAX
             // (dy - sum) * y
-            mul_tiles_to_cb(cb_y, cb_inter2, cb_dx);
+            mul_tiles_to_cb(cb_y_obj, cb_inter2_obj, cb_dx_obj);
 #else
             // -(dy - sum) * y
-            mul_tiles_and_negative_to_cb(cb_y, cb_inter2, cb_dx);
+            mul_tiles_and_negative_to_cb(cb_y_obj, cb_inter2_obj, cb_dx_obj);
 #endif
         }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/moreh_int_sum_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/moreh_int_sum_h.cpp
@@ -12,10 +12,13 @@ void kernel_main() {
     constexpr uint32_t origin_H = get_compile_time_arg_val(2);
 
     auto cb_in0 = tt::CBIndex::c_0;
+    CircularBuffer cb_in0_obj(cb_in0);
     constexpr auto cb_mask_h = tt::CBIndex::c_1;
     CircularBuffer cb_mask_h_obj(cb_mask_h);
     constexpr auto cb_out0 = tt::CBIndex::c_16;
+    CircularBuffer cb_out0_obj(cb_out0);
     constexpr auto cb_intermed0 = tt::CBIndex::c_24;
+    CircularBuffer cb_intermed0_obj(cb_intermed0);
     constexpr uint32_t TILE_H = 32;
     constexpr bool do_mask_h = (origin_H % TILE_H) != 0;
 
@@ -34,10 +37,10 @@ void kernel_main() {
         constexpr bool is_single_ht = (Ht == 1);
         if (is_single_ht) {
             tile_regs_acquire();
-            copy_tile_to_dst(cb_in0, idx0, dst0);
+            copy_tile_to_dst(cb_in0_obj, idx0, dst0);
 
             if (do_mask_h) {
-                copy_tile_to_dst(cb_mask_h, idx0, dst1, false);
+                copy_tile_to_dst(cb_mask_h_obj, idx0, dst1, false);
                 mask_tile_init();
                 mask_tile(dst0, dst1, DataFormat::Int32);
             }
@@ -47,47 +50,47 @@ void kernel_main() {
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_from_dst(cb_out0, dst0);
+            pack_tile_from_dst(cb_out0_obj, dst0);
             tile_regs_release();
         } else {
             for (uint32_t ht = 0; ht < Ht; ++ht) {
                 if (ht == 0) {
                     tile_regs_acquire();
-                    copy_tile_to_dst(cb_in0, idx0, dst0);
+                    copy_tile_to_dst(cb_in0_obj, idx0, dst0);
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_from_dst(cb_intermed0, dst0);
+                    pack_tile_from_dst(cb_intermed0_obj, dst0);
                     tile_regs_release();
                 } else {
                     tile_regs_acquire();
-                    copy_tile_to_dst(cb_in0, idx0, dst0);
+                    copy_tile_to_dst(cb_in0_obj, idx0, dst0);
 
                     if (ht == Ht - 1 && do_mask_h) {
-                        copy_tile_to_dst(cb_mask_h, idx0, dst1, false);
+                        copy_tile_to_dst(cb_mask_h_obj, idx0, dst1, false);
                         mask_tile_init();
                         mask_tile(dst0, dst1, DataFormat::Int32);
                     }
 
-                    copy_tile_to_dst(cb_intermed0, idx0, dst1);
+                    copy_tile_to_dst(cb_intermed0_obj, idx0, dst1);
                     sfpu_sum_int_init();
                     sfpu_add_int(dst0, dst1);
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_from_dst(cb_intermed0, dst0);
+                    pack_tile_from_dst(cb_intermed0_obj, dst0);
                     tile_regs_release();
                 }
             }
 
             tile_regs_acquire();
-            copy_tile_to_dst(cb_intermed0, idx0, dst0);
+            copy_tile_to_dst(cb_intermed0_obj, idx0, dst0);
             sfpu_sum_int_init();
             sfpu_sum_int_col(dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_from_dst(cb_out0, dst0);
+            pack_tile_from_dst(cb_out0_obj, dst0);
             tile_regs_release();
         }
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/moreh_int_sum_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/moreh_int_sum_nc.cpp
@@ -11,8 +11,11 @@ void kernel_main() {
     constexpr uint32_t num_input_tiles = get_compile_time_arg_val(1);
 
     constexpr auto cb_in0 = tt::CBIndex::c_0;
+    CircularBuffer cb_in0_obj(cb_in0);
     constexpr auto cb_out0 = tt::CBIndex::c_16;
+    CircularBuffer cb_out0_obj(cb_out0);
     constexpr auto cb_intermed0 = tt::CBIndex::c_24;
+    CircularBuffer cb_intermed0_obj(cb_intermed0);
     constexpr int onetile = 1;
     constexpr int idx0 = 0;
     constexpr int dst0 = 0;
@@ -24,9 +27,9 @@ void kernel_main() {
         for (uint32_t j = 0; j < num_input_tiles; ++j) {
             bool last_out = (j == num_input_tiles - 1);
             tile_regs_acquire();
-            copy_tile_to_dst(cb_in0, idx0, dst0);
+            copy_tile_to_dst(cb_in0_obj, idx0, dst0);
             if (enable_reload) {
-                copy_tile_to_dst(cb_intermed0, idx0, dst1);
+                copy_tile_to_dst(cb_intermed0_obj, idx0, dst1);
                 sfpu_sum_int_init();
                 sfpu_add_int(dst0, dst1);
             }
@@ -34,7 +37,7 @@ void kernel_main() {
 
             tile_regs_wait();
             uint32_t cb_out = (last_out) ? (cb_out0) : (cb_intermed0);
-            pack_tile_from_dst(cb_out, dst0);
+            pack_tile_from_dst(CircularBuffer(cb_out), dst0);
             tile_regs_release();
             enable_reload = true;
         }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/moreh_int_sum_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/moreh_int_sum_w.cpp
@@ -12,10 +12,13 @@ void kernel_main() {
     constexpr uint32_t origin_W = get_compile_time_arg_val(2);
 
     constexpr auto cb_in0 = tt::CBIndex::c_0;
+    CircularBuffer cb_in0_obj(cb_in0);
     constexpr auto cb_mask_w = tt::CBIndex::c_1;
     CircularBuffer cb_mask_w_obj(cb_mask_w);
     constexpr auto cb_intermed0 = tt::CBIndex::c_24;
+    CircularBuffer cb_intermed0_obj(cb_intermed0);
     constexpr auto cb_out0 = tt::CBIndex::c_16;
+    CircularBuffer cb_out0_obj(cb_out0);
     constexpr uint32_t TILE_W = 32;
     constexpr bool do_mask_w = (origin_W % TILE_W) != 0;
     constexpr int onetile = 1;
@@ -33,10 +36,10 @@ void kernel_main() {
         constexpr bool is_single_wt = (Wt == 1);
         if (is_single_wt) {
             tile_regs_acquire();
-            copy_tile_to_dst(cb_in0, idx0, dst0);
+            copy_tile_to_dst(cb_in0_obj, idx0, dst0);
 
             if (do_mask_w) {
-                copy_tile_to_dst(cb_mask_w, idx0, dst1, false);
+                copy_tile_to_dst(cb_mask_w_obj, idx0, dst1, false);
                 mask_tile_init();
                 mask_tile(dst0, dst1, DataFormat::Int32);
             }
@@ -46,46 +49,46 @@ void kernel_main() {
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_from_dst(cb_out0, dst0);
+            pack_tile_from_dst(cb_out0_obj, dst0);
             tile_regs_release();
         } else {
             for (uint32_t wt = 0; wt < Wt; ++wt) {
                 if (wt == 0) {
                     tile_regs_acquire();
-                    copy_tile_to_dst(cb_in0, idx0, dst0);
+                    copy_tile_to_dst(cb_in0_obj, idx0, dst0);
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_from_dst(cb_intermed0, dst0);
+                    pack_tile_from_dst(cb_intermed0_obj, dst0);
                     tile_regs_release();
                 } else {
                     tile_regs_acquire();
-                    copy_tile_to_dst(cb_in0, idx0, dst0);
+                    copy_tile_to_dst(cb_in0_obj, idx0, dst0);
                     if (wt == Wt - 1 && do_mask_w) {
-                        copy_tile_to_dst(cb_mask_w, idx0, dst1, false);
+                        copy_tile_to_dst(cb_mask_w_obj, idx0, dst1, false);
                         mask_tile_init();
                         mask_tile(dst0, dst1, DataFormat::Int32);
                     }
 
-                    copy_tile_to_dst(cb_intermed0, idx0, dst1);
+                    copy_tile_to_dst(cb_intermed0_obj, idx0, dst1);
                     sfpu_sum_int_init();
                     sfpu_add_int(dst0, dst1);
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_from_dst(cb_intermed0, dst0);
+                    pack_tile_from_dst(cb_intermed0_obj, dst0);
                     tile_regs_release();
                 }
             }
 
             tile_regs_acquire();
-            copy_tile_to_dst(cb_intermed0, idx0, dst0);
+            copy_tile_to_dst(cb_intermed0_obj, idx0, dst0);
             sfpu_sum_int_init();
             sfpu_sum_int_row(dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_from_dst(cb_out0, dst0);
+            pack_tile_from_dst(cb_out0_obj, dst0);
             tile_regs_release();
         }
     }


### PR DESCRIPTION
## PR Category

Cleanup

## Summary

Issue [#45003](https://github.com/tenstorrent/tt-metal/issues/45003)

Rewrites the shared compute header `ttnn/cpp/ttnn/kernel/compute/moreh_common.hpp` to use the Device 2.0 `CircularBuffer` wrapper instead of the legacy `uint32_t cb_id` API, and updates all consumer compute kernels under `ttnn/cpp/ttnn/operations/moreh/`. Companion to PR #47923 which migrated the dataflow-side header.

## Notes for reviewers

### moreh_common.hpp helpers migrated

LLK math primitives (`mul_tiles`, `add_tiles`, `pack_tile`, `copy_tile`, `tile_regs_*`, SFPU ops, `binary_op_init_common`, etc.) are unchanged, this PR leaves them on the CB index API

### Risk
- No behavioral changes intended; the rewritten helpers are line-for-line equivalent except for the API surface change
- `ACQ()` / `REL()` removed — verified zero callers across the entire repo

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/moreh-d2-migration-phase1b)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/moreh-d2-migration-phase1b)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/moreh-d2-migration-phase1b)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/moreh-d2-migration-phase1b)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/moreh-d2-migration-phase1b)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/moreh-d2-migration-phase1b)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/moreh-d2-migration-phase1b)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/moreh-d2-migration-phase1b)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/moreh-d2-migration-phase1b)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/moreh-d2-migration-phase1b)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/moreh-d2-migration-phase1b)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/moreh-d2-migration-phase1b)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/moreh-d2-migration-phase1b)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/moreh-d2-migration-phase1b)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/moreh-d2-migration-phase1b)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/moreh-d2-migration-phase1b)
