### PR TITLE
[exabox] Guard against duplicate --hosts and document MPI interface validation failures

### DIFF
--- a/tools/scaleout/exabox/TROUBLESHOOTING.md
+++ b/tools/scaleout/exabox/TROUBLESHOOTING.md
@@ -8,6 +8,7 @@ Real issues encountered and their solutions.
 - [General Debugging Tips](#general-debugging-tips)
 - [Setup & Access](#setup--access)
   - [SSH Agent Forwarding for MPI](#ssh-agent-forwarding-for-mpi)
+  - [MPI Interface Validation Fails ("cannot be used for MPI communication")](#mpi-interface-validation-fails-cannot-be-used-for-mpi-communication)
   - [Tests Fail with "Permission denied" on tt-metal-cache](#tests-fail-with-permission-denied-on-tt-metal-cache)
   - [Recovery Script Fails with "could not access or execute an executable"](#recovery-script-fails-with-could-not-access-or-execute-an-executable)
 - [SLURM Issues](#slurm-issues)
@@ -199,6 +200,80 @@ When you see missing ports between the same host pair, start with physical inspe
 MPI tasks require passwordless SSH between hosts using ssh-agent forwarding.
 
 For detailed SSH setup instructions, see the [SSH Setup section in the README](./README.md#ssh-setup).
+
+---
+
+### MPI Interface Validation Fails ("cannot be used for MPI communication")
+
+**Symptom**: `run_validation.sh` (or `run_fabric_tests.sh`) rejects a network interface that is clearly up:
+
+```text
+Error: Specified MPI interface 'ens5f0np0' exists but cannot be used for MPI communication
+
+This usually means the interface is down or misconfigured.
+Check interface status with: ip link show ens5f0np0
+
+Attempting to find a working alternative interface...
+No working MPI interface found on this system.
+```
+
+But `ip link show ens5f0np0` shows `state UP` (and `ip addr` shows a valid IP).
+
+**Cause**: The error message is misleading. The interface check in `utils/mpi_if_selection.sh` does **not** test whether the link is up — it runs a real MPI probe against the **first host** in `--hosts` and checks the exit code:
+
+```bash
+timeout 3 mpirun --host "$FIRST_HOST" \
+    --mca oob_tcp_if_include "$interface" \
+    --mca btl_tcp_if_include "$interface" \
+    -np 1 hostname &>/dev/null
+```
+
+`mpirun` launches the remote process over **SSH**. If SSH to the first host fails (or just hangs), `orted` never starts, the probe times out, and the script reports "cannot be used for MPI communication." The key tell is that it **also fails to find any alternative interface** — the probe is failing universally, so it is not interface-specific.
+
+The most common trigger is **stale or missing SSH host keys**, which is very common right after nodes are **recovered / re-imaged** (their host keys change). With `BatchMode`, a changed/unknown key can't be accepted interactively, so it fails outright:
+
+```text
+ssh -o BatchMode=yes bh-glx-120-c07u02 hostname  → Host key verification failed.   (exit 255)
+mpirun --host bh-glx-120-c07u02 -np 1 hostname   → hangs, exit 124 (timeout)
+```
+
+**Diagnosis** — isolate the remote launch (use the *first* host from your `$HOSTS`, which is the one the probe targets):
+
+```bash
+FIRST_HOST="${HOSTS%%,*}"
+
+# Does plain remote mpirun work without the interface restriction?
+timeout 30 mpirun --host "$FIRST_HOST" -np 1 hostname; echo "exit=$?"
+
+# Is passwordless SSH actually working?
+timeout 10 ssh -o BatchMode=yes "$FIRST_HOST" hostname; echo "ssh_exit=$?"
+```
+
+- `Host key verification failed` / `ssh_exit=255` → stale or missing host key (see fix below)
+- `mpirun` exit `124` → the probe is hanging (almost always the SSH failure above)
+
+**Solution** — refresh the SSH host keys for all hosts in your run:
+
+```bash
+for h in bh-glx-120-c07u02 bh-glx-120-c07u08 bh-glx-120-c07u14 bh-glx-120-c07u20; do
+  ssh-keygen -R "$h"
+done
+
+ssh-keyscan -H bh-glx-120-c07u02 bh-glx-120-c07u08 bh-glx-120-c07u14 bh-glx-120-c07u20 \
+  >> ~/.ssh/known_hosts
+```
+
+Then verify SSH and the remote launch both succeed before re-running validation:
+
+```bash
+ssh -o BatchMode=yes bh-glx-120-c07u02 hostname                              # prints hostname
+timeout 30 mpirun --host bh-glx-120-c07u02 -np 1 hostname; echo "exit=$?"    # exit=0
+```
+
+**Other things to check if SSH is fine but the probe still fails**:
+
+- **Wrong `mpirun` on PATH**: `which mpirun` should ideally be the ULFM build (`/opt/openmpi-v5.0.7-ulfm/bin/mpirun`). Prepend it to PATH if a different OpenMPI is picked up.
+- **Subnet/routing mismatch**: if the hostname resolves to an address *outside* your MPI interface's subnet (e.g. host resolves to `10.32.28.1` but `ens5f0np0` is `10.32.28.33/27`), forcing OOB/BTL onto that interface can break the `orted` callback. SSH launch still works over the management net, but you may hit an OOB/BTL connectivity error mid-run. Compare `getent hosts <host>` against `ip addr show <interface>`.
 
 ---
 

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -5,6 +5,7 @@ set -eo pipefail
 # Source MPI interface validation utility
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/utils/mpi_if_selection.sh"
+source "$SCRIPT_DIR/utils/host_utils.sh"
 
 # Function to display help
 show_help() {
@@ -281,6 +282,8 @@ if [[ -z "$HOSTS" ]]; then
     show_help
     exit 1
 fi
+
+check_duplicate_hosts "$HOSTS" || exit 1
 
 if [[ "$SKIP_RESET" == true && "$SKIP_VALIDATION" == true ]]; then
     echo "Error: cannot use both --skip-reset and --skip-validation"

--- a/tools/scaleout/exabox/run_dispatch_tests.sh
+++ b/tools/scaleout/exabox/run_dispatch_tests.sh
@@ -3,6 +3,7 @@
 # Source MPI interface validation utility
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/utils/mpi_if_selection.sh"
+source "$SCRIPT_DIR/utils/host_utils.sh"
 
 # Function to display help
 show_help() {
@@ -100,6 +101,8 @@ if [[ -z "$HOSTS" ]]; then
     show_help
     exit 1
 fi
+
+check_duplicate_hosts "$HOSTS" || exit 1
 
 if [[ -z "$DOCKER_IMAGE" ]]; then
     echo "Error: --image is required"

--- a/tools/scaleout/exabox/run_fabric_tests.sh
+++ b/tools/scaleout/exabox/run_fabric_tests.sh
@@ -3,6 +3,7 @@
 # Source MPI interface validation utility
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/utils/mpi_if_selection.sh"
+source "$SCRIPT_DIR/utils/host_utils.sh"
 
 # Function to display help
 show_help() {
@@ -222,6 +223,8 @@ if [[ -z "$HOSTS" ]]; then
     show_help
     exit 1
 fi
+
+check_duplicate_hosts "$HOSTS" || exit 1
 
 if [[ -z "$DOCKER_IMAGE" ]]; then
     echo "Error: --image is required"

--- a/tools/scaleout/exabox/run_validation.sh
+++ b/tools/scaleout/exabox/run_validation.sh
@@ -3,6 +3,7 @@
 # Source MPI interface validation utility
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/utils/mpi_if_selection.sh"
+source "$SCRIPT_DIR/utils/host_utils.sh"
 
 # Function to display help
 show_help() {
@@ -207,6 +208,8 @@ if [[ -z "$HOSTS" ]]; then
     show_help
     exit 1
 fi
+
+check_duplicate_hosts "$HOSTS" || exit 1
 
 if [[ -z "$DOCKER_IMAGE" ]]; then
     echo "Error: --image is required"

--- a/tools/scaleout/exabox/utils/host_utils.sh
+++ b/tools/scaleout/exabox/utils/host_utils.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Host-list validation utilities shared by the exabox cluster scripts.
+
+# Aborts if a comma-separated --hosts list contains the same host more than once.
+# A duplicated host silently corrupts MPI rank assignment (two ranks land on the
+# same node), which later surfaces as a cryptic failure deep inside the test or
+# the topology mapper instead of a clear input error. Catch it up front.
+#
+# Usage: check_duplicate_hosts "$HOSTS" || exit 1
+check_duplicate_hosts() {
+    local host_list="$1"
+    local -a hosts
+    IFS=',' read -ra hosts <<< "$host_list"
+
+    local -A seen=()
+    local -A dupes=()
+    local h
+    for h in "${hosts[@]}"; do
+        # Tolerate empty entries from stray/trailing commas.
+        [[ -z "$h" ]] && continue
+        if [[ -n "${seen[$h]:-}" ]]; then
+            dupes["$h"]=1
+        fi
+        seen["$h"]=1
+    done
+
+    if [[ "${#dupes[@]}" -gt 0 ]]; then
+        echo "Error: --hosts contains duplicate host(s): ${!dupes[*]}" >&2
+        echo "" >&2
+        echo "Each host must appear exactly once in --hosts. Passing the same host" >&2
+        echo "twice corrupts MPI rank assignment and causes cryptic test failures." >&2
+        echo "Provided list: $host_list" >&2
+        return 1
+    fi
+    return 0
+}


### PR DESCRIPTION
## Summary
- Detect duplicate hosts in `--hosts` up front instead of letting them surface as a cryptic test/mapper failure (a duplicate puts two MPI ranks on one node).
- Document the misleading "interface cannot be used for MPI communication" error, which is usually a stale SSH host key after node recovery, not a bad interface.

## Changes
- Added `utils/host_utils.sh` (`check_duplicate_hosts()`) and wired it into `run_fabric_tests.sh`, `run_validation.sh`, and `recover.sh`.
- Added a `TROUBLESHOOTING.md` entry with the SSH host-key root cause, diagnosis commands, and `ssh-keygen -R` / `ssh-keyscan` fix.

## Test plan
- `bash -n` passes; `check_duplicate_hosts` verified for single/distinct/trailing-comma (pass) and duplicates (fail with clear message).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/validation_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/validation_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jpanasiuk/validation_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jpanasiuk/validation_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jpanasiuk/validation_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jpanasiuk/validation_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/validation_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/validation_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jpanasiuk/validation_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jpanasiuk/validation_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/validation_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/validation_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/validation_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/validation_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/validation_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/validation_fixes)