### PR TITLE
[indexer_score] per-device chunk_start from mesh coordinate (ring_joint_sdpa style)

### DIFF
--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -80,6 +80,12 @@ jobs:
               SDPA_PERF_CHECKS=1 pytest tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py::test_exp_ring_joint_attention_perf_check -svv
             timeout: 10
             test-type: fast-qb2
+          - name: indexer_score multi-device tests (QB2 only)
+            # The per-device chunk_start (SP=4 and SP=2xTP=2) mesh tests; single-chip cases in the same
+            # file run in tt-metal-l2-nightly. -k selects only the multi-device functions.
+            cmd: pytest tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py -k indexer_score_qb -svv
+            timeout: 10
+            test-type: fast-qb2
           # NOTE: All slow / loudbox / qb multi-card BH tests have been migrated
           # into tests/pipeline_reorg/blackhole_e2e_tests.yaml and are now run by
           # the blackhole-e2e-tests workflow. This file only carries the

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -17,9 +17,11 @@ Two deployments, both Galaxy chunked prefill (50K history + 5K chunk =
              heads and the -inf mask is head-independent, so -inf survives the
              cross-TP sum)
 
-SP enters only via ``chunk_start``, so this is single-chip with ``sp_rank``
-selecting the ring position. This file is deliberately narrow (GLM5/DSv32 shapes
-only); broader knob/corner/validation coverage will be migrated in separately.
+We test on single chip with an explicit ``chunk_start``, ``sp_rank`` selecting the ring
+position. The multi-device QuietBox tests at the end instead derive ``chunk_start`` per
+device from the real mesh coordinate (one hash-excluded program serving every SP rank).
+This file is deliberately narrow (GLM5/DSv32 shapes only); broader knob/corner/validation
+coverage will be migrated in separately.
 """
 
 import os
@@ -831,11 +833,6 @@ QB_CASES = [("glm5", 8), ("dsv32", 16)]
 QB_IDS = [c[0] for c in QB_CASES]
 
 
-def _require_devices(mesh_device, n):
-    if mesh_device.get_num_devices() < n:
-        pytest.skip(f"requires {n} devices, have {mesh_device.get_num_devices()}")
-
-
 def _global_inputs(heads, chunk, t, seed):
     """Global GLX tensors (bf16; deployed dtypes applied at shard time): q/w over `chunk` queries, k over
     `t` all-gathered keys. Weights are random so some gates are negative (-inf must stay distinguishable
@@ -882,8 +879,6 @@ def _shard_1d(mesh_device, heads, seed):
 def test_indexer_score_qb_per_device_chunk_start(mesh_device, case_id, heads):
     """One mesh dispatch over 4 BH devices, each deriving its own chunk_start from its coordinate.
     Validate each device's output against its own chunk_start reference."""
-    _require_devices(mesh_device, QB_SP)
-
     q_g, k_g, w_g, q_dev, k_dev, w_dev = _shard_1d(mesh_device, heads, seed=42)
 
     # chunk_start_idx OMITTED -> the op deduces base = T - sp_ring*Sq = QB_HISTORY (sp_ring = 4 devices,
@@ -900,8 +895,6 @@ def test_indexer_score_qb_per_device_chunk_start(mesh_device, case_id, heads):
 def test_indexer_score_qb_one_compile_all_chunk_starts(mesh_device, case_id, heads):
     """chunk_start is excluded from the program hash: running several different bases must add exactly
     ONE program-cache entry (the first compile), proving no per-value recompile."""
-    _require_devices(mesh_device, QB_SP)
-
     _, _, _, q_dev, k_dev, w_dev = _shard_1d(mesh_device, heads, seed=7)
 
     # Three distinct chunk-start bases (all within the causal window). Only the first should compile.
@@ -943,8 +936,6 @@ def test_indexer_score_qb_sp2_tp2(mesh_device, case_id, heads):
     cluster_axis (SP), constant across the TP axis; heads split across TP. Each TP device computes a
     partial head-sum, which the test sums back (the TP all-reduce) and validates per SP rank against
     its own full-head, own-chunk_start reference."""
-    _require_devices(mesh_device, QB2_SP * QB2_TP)
-
     q_g, k_g, w_g = _global_inputs(heads, QB2_CHUNK, QB2_T, seed=42)
 
     # q/w: seq (dim 2) sharded along the SP axis, heads (dim 1) along the TP axis. k replicated.

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -809,3 +809,168 @@ def test_indexer_score_streaming_qmcast_uneven_bands(device):
     assert max_bands > min_bands, f"need an uneven band split: U={U}, cols_used={cols_used}"
 
     _run_and_check(device, heads, dim, sq, t, chunk_start, q_chunk, k_chunk, head_group)
+
+
+# ==============================================================================================
+# Multi-device (QuietBox, 4 BH) tests: PER-DEVICE chunk_start derived from the mesh coordinate.
+# ==============================================================================================
+# Use the `mesh_device` fixture (vs `device` above); they auto-skip on a single chip (the fixture skips
+# when requested devices exceed the machine's), so they no-op on the single-chip nightly and run on a
+# QuietBox. A SINGLE mesh dispatch where each device is a different SP rank: chunk_start = chunk_start_idx
+# + r*Sq (r = linearized index along cluster_axis), one hash-excluded program for all. Two layouts:
+#   - 1D SP=4 (flat mesh): history 25600 + chunk 4*640 -> T 28160; cluster_axis unset (linear order).
+#   - 2D SP=2 x TP=2:      history 25600 + chunk 2*640 -> T 26880; cluster_axis = SP axis, heads split.
+# Functional only (exact -inf map + PCC >= 0.999 per SP rank); reuse indexer_score_ref / assert_indexer_match.
+
+QB_DIM = 128  # indexer head dim
+QB_SQ = 640  # queries per SP rank (preserved from the SP=8 deployment)
+QB_HISTORY = 25600  # 25k history, tile-aligned (800 tiles)
+
+# GLM5 (8 heads) and DSv32 (16 heads), as in the single-device deployment cases above.
+QB_CASES = [("glm5", 8), ("dsv32", 16)]
+QB_IDS = [c[0] for c in QB_CASES]
+
+
+def _require_devices(mesh_device, n):
+    if mesh_device.get_num_devices() < n:
+        pytest.skip(f"requires {n} devices, have {mesh_device.get_num_devices()}")
+
+
+def _global_inputs(heads, chunk, t, seed):
+    """Global GLX tensors (bf16; deployed dtypes applied at shard time): q/w over `chunk` queries, k over
+    `t` all-gathered keys. Weights are random so some gates are negative (-inf must stay distinguishable
+    from low-but-valid scores)."""
+    g = torch.Generator().manual_seed(seed)
+    q = torch.randn(1, heads, chunk, QB_DIM, generator=g, dtype=torch.bfloat16)
+    k = torch.randn(1, 1, t, QB_DIM, generator=g, dtype=torch.bfloat16)
+    w = torch.randn(1, heads, chunk, 1, generator=g, dtype=torch.bfloat16)
+    return q, k, w
+
+
+def _to_mesh(mesh_device, t, dtype, mapper):
+    """from_torch with the shared tiled-layout boilerplate."""
+    return ttnn.from_torch(t, device=mesh_device, layout=ttnn.TILE_LAYOUT, dtype=dtype, mesh_mapper=mapper)
+
+
+def _per_sp_ref(q_g, k_g, w_g, sp_count, history):
+    """Reference: each SP rank's full-head score (chunk_start = history + sp*Sq), concatenated along seq."""
+    refs = []
+    for sp in range(sp_count):
+        sl = slice(sp * QB_SQ, (sp + 1) * QB_SQ)
+        refs.append(indexer_score_ref(q_g[:, :, sl, :], k_g, w_g[:, :, sl, :], history + sp * QB_SQ))
+    return torch.cat(refs, dim=2)
+
+
+# ---- 1D mesh: SP=4 (flat QuietBox), cluster_axis unset (linear device order) ------------------
+QB_SP = 4  # devices (QuietBox); SP ring positions 0..3
+QB_CHUNK = QB_SP * QB_SQ  # 2560 chunk queries (2.5k), sharded SP=4 -> 640/device
+QB_T = QB_HISTORY + QB_CHUNK  # 28160 all-gathered keys (880 tiles)
+
+
+def _shard_1d(mesh_device, heads, seed):
+    """SP=4 inputs: q/w sharded along seq (each device its own 640 rows), k replicated. Deployed dtypes."""
+    q_g, k_g, w_g = _global_inputs(heads, QB_CHUNK, QB_T, seed)
+    shard = ttnn.ShardTensorToMesh(mesh_device, dim=2)
+    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard)
+    w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard)
+    k_dev = _to_mesh(mesh_device, k_g, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
+    return q_g, k_g, w_g, q_dev, k_dev, w_dev
+
+
+@pytest.mark.parametrize("mesh_device", [QB_SP], indirect=True)
+@pytest.mark.parametrize("case_id, heads", QB_CASES, ids=QB_IDS)
+def test_indexer_score_qb_per_device_chunk_start(mesh_device, case_id, heads):
+    """One mesh dispatch over 4 BH devices, each deriving its own chunk_start from its coordinate.
+    Validate each device's output against its own chunk_start reference."""
+    _require_devices(mesh_device, QB_SP)
+
+    q_g, k_g, w_g, q_dev, k_dev, w_dev = _shard_1d(mesh_device, heads, seed=42)
+
+    # chunk_start_idx OMITTED -> the op deduces base = T - sp_ring*Sq = QB_HISTORY (sp_ring = 4 devices,
+    # cluster_axis unset), then device r gets base + r*Sq. No chunk_start passed at all.
+    out = ttnn.experimental.indexer_score(q_dev, k_dev, w_dev, program_config=glx_config(heads))
+    out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=2))
+
+    ref = _per_sp_ref(q_g, k_g, w_g, QB_SP, QB_HISTORY)
+    assert_indexer_match(out_t, ref, QB_CHUNK, QB_T, check_neg=True)
+
+
+@pytest.mark.parametrize("mesh_device", [QB_SP], indirect=True)
+@pytest.mark.parametrize("case_id, heads", QB_CASES, ids=QB_IDS)
+def test_indexer_score_qb_one_compile_all_chunk_starts(mesh_device, case_id, heads):
+    """chunk_start is excluded from the program hash: running several different bases must add exactly
+    ONE program-cache entry (the first compile), proving no per-value recompile."""
+    _require_devices(mesh_device, QB_SP)
+
+    _, _, _, q_dev, k_dev, w_dev = _shard_1d(mesh_device, heads, seed=7)
+
+    # Three distinct chunk-start bases (all within the causal window). Only the first should compile.
+    bases = [QB_HISTORY, QB_HISTORY - QB_SQ, QB_HISTORY - 2 * QB_SQ]
+
+    entries_before = mesh_device.num_program_cache_entries()
+    for base in bases:
+        ttnn.experimental.indexer_score(
+            q_dev, k_dev, w_dev, chunk_start_idx=base, program_config=glx_config(heads)
+        ).deallocate()
+
+    added = mesh_device.num_program_cache_entries() - entries_before
+    assert added == 1, f"expected 1 program-cache entry across 3 distinct chunk_start bases, got {added}"
+
+
+# ---- 2D mesh: SP=2 (one axis) x TP=2 (the other, head-split) ----------------------------------
+# Exercises cluster_axis on a real 2D mesh, which a 1xN mesh can't: chunk_start must vary along the
+# SP axis only, while the two TP devices sharing an SP position get the SAME chunk_start.
+QB2_SP = 2  # sequence-parallel ranks (chunk_start varies along this axis)
+QB2_TP = 2  # tensor-parallel ranks (heads split across this axis)
+QB2_CHUNK = QB2_SP * QB_SQ  # 1280 chunk queries, sharded SP=2 -> 640/device
+QB2_T = QB_HISTORY + QB2_CHUNK  # 26880 keys (840 tiles)
+QB2_SP_AXIS = 0  # mesh rows = SP ring (passed as cluster_axis)
+QB2_TP_AXIS = 1  # mesh cols = TP head split
+
+
+def _axis_dims(sp_dim, tp_dim):
+    """A 2-tuple indexed by mesh axis: SP axis -> sp_dim, TP axis -> tp_dim. Used for both the q/w shard
+    mapper and the output composer (sharding and concat use the same dims here)."""
+    dims = [None, None]
+    dims[QB2_SP_AXIS], dims[QB2_TP_AXIS] = sp_dim, tp_dim
+    return tuple(dims)
+
+
+@pytest.mark.parametrize("mesh_device", [(QB2_SP, QB2_TP)], ids=["2x2"], indirect=True)
+@pytest.mark.parametrize("case_id, heads", QB_CASES, ids=QB_IDS)
+def test_indexer_score_qb_sp2_tp2(mesh_device, case_id, heads):
+    """One mesh dispatch over a 2x2 mesh: chunk_start derived per-device from the coordinate along
+    cluster_axis (SP), constant across the TP axis; heads split across TP. Each TP device computes a
+    partial head-sum, which the test sums back (the TP all-reduce) and validates per SP rank against
+    its own full-head, own-chunk_start reference."""
+    _require_devices(mesh_device, QB2_SP * QB2_TP)
+
+    q_g, k_g, w_g = _global_inputs(heads, QB2_CHUNK, QB2_T, seed=42)
+
+    # q/w: seq (dim 2) sharded along the SP axis, heads (dim 1) along the TP axis. k replicated.
+    mesh_shape = tuple(mesh_device.shape)
+    qw_dims = _axis_dims(sp_dim=2, tp_dim=1)
+    shard_qw = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=qw_dims)
+    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard_qw)
+    w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard_qw)
+    k_dev = _to_mesh(mesh_device, k_g, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
+
+    # chunk_start_idx OMITTED: the op deduces base = T - sp_ring*Sq, where sp_ring is the mesh extent
+    # along cluster_axis (2, the SP axis) -- NOT the total device count (4). Device (sp, tp) then gets
+    # chunk_start = base + sp*Sq -- identical for both TP devices at SP position sp.
+    out = ttnn.experimental.indexer_score(
+        q_dev,
+        k_dev,
+        w_dev,
+        cluster_axis=QB2_SP_AXIS,
+        program_config=glx_config(heads // QB2_TP),  # per-device head count
+    )
+    # Concat SP shards along seq (dim 2) and the TP head-partials along the size-1 head dim (dim 1), then
+    # SUM the partials (the TP all-reduce) -> full [1,1,1280,T] score.
+    out_t = ttnn.to_torch(
+        out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=qw_dims)
+    )
+    out_t = out_t.float().sum(dim=1, keepdim=True)
+
+    ref = _per_sp_ref(q_g, k_g, w_g, QB2_SP, QB_HISTORY)
+    assert_indexer_match(out_t, ref, QB2_CHUNK, QB2_T, check_neg=True)

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -12,10 +12,24 @@
 #include <tt-metalium/hal.hpp>
 
 #include "kernels/indexer_score_work_split.hpp"  // shared banded grid mapping (rows_for_groups / cols_for_bands)
+#include "ttnn/operations/ccl/ccl_common.hpp"    // get_linearized_index_from_physical_coord
 
 namespace ttnn::operations::experimental::indexer_score {
 
 namespace {
+// Largest per-device chunk_start across the mesh = base + max_rank*Sq, where max_rank is the largest
+// linearized index along cluster_axis (0 on a single device). Used by the worst-case window check.
+uint32_t max_chunk_start(const operation_attributes_t& attrs, const Tensor& q, uint32_t Sq) {
+    uint32_t max_rank = 0;
+    if (q.device_storage().get_coords().size() > 1) {
+        for (const auto& coord : q.device_storage().get_coords()) {
+            max_rank =
+                std::max(max_rank, ttnn::ccl::get_linearized_index_from_physical_coord(q, coord, attrs.cluster_axis));
+        }
+    }
+    return attrs.chunk_start_idx + max_rank * Sq;
+}
+
 // Miss-only checks: either hash-pinned (placement, non-indexed k batch shape) so they can't differ on a
 // hit, or caller errors the framework rules out anyway (device residency, allocation, same-device) and
 // never checked on a hit pre-PR. The slot/kv_len values that do differ on a hit live in
@@ -48,7 +62,6 @@ void validate_static(const operation_attributes_t& attrs, const tensor_args_t& t
 // The slot/kv_len values: hashed only by has_value(), so they can differ on a cache hit and feed kernel
 // addressing (page offset / read width). Cheap integer checks on shape metadata, run on miss AND hit.
 void validate_runtime_values(const operation_attributes_t& attrs, const tensor_args_t& t) {
-    const auto& q = t.q;
     const auto& k = t.k;
 
     // Indexed KV cache: k is [B,1,T,D]; cache_batch_idx picks a slot (q/weights are batch 1). An
@@ -62,13 +75,11 @@ void validate_runtime_values(const operation_attributes_t& attrs, const tensor_a
             kB);
     }
 
-    // Runtime KV length: k is a persistent buffer of (hashed) length T; kv_len <= T is the valid prefix this
-    // dispatch (value not hashed -> re-checked here). chunk_start+Sq <= kv_len keeps the causal window inside
-    // the valid keys, preserving the kernel's "stale-k tail -> -inf overwrite" invariant (no unwritten tile
-    // is ever accumulated).
+    // Runtime KV length: k is a persistent buffer of (hashed) length T; kv_len <= T is the valid prefix
+    // this dispatch (value not hashed -> re-checked here). The chunk-window-vs-kv_len bound lives in
+    // validate_chunk_start, which keeps every chunk_start check in one place.
     if (attrs.kv_len.has_value()) {
         const uint32_t T = k.logical_shape()[2];
-        const uint32_t Sq = q.logical_shape()[2];
         const uint32_t kv_len = attrs.kv_len.value();
         TT_FATAL(kv_len % tt::constants::TILE_WIDTH == 0, "indexer_score kv_len {} must be tile-aligned", kv_len);
         TT_FATAL(
@@ -76,13 +87,42 @@ void validate_runtime_values(const operation_attributes_t& attrs, const tensor_a
             "indexer_score kv_len {} must be in (0, T={}] (the allocated k length)",
             kv_len,
             T);
+    }
+}
+
+// Runs on cache miss AND hit (chunk_start is hash-excluded). All chunk_start checks in one place: base
+// alignment, and the fullest device's window against T and -- when set -- kv_len. Per-rank stride Sq is
+// tile-aligned by the shape check, so only the base needs an alignment check.
+void validate_chunk_start(const operation_attributes_t& attrs, const tensor_args_t& t) {
+    const uint32_t Sq = t.q.logical_shape()[2];
+    const uint32_t T = t.k.logical_shape()[2];
+    TT_FATAL(
+        attrs.chunk_start_idx % tt::constants::TILE_WIDTH == 0,
+        "chunk_start_idx {} must be tile-aligned",
+        attrs.chunk_start_idx);
+    const uint32_t max_cs = max_chunk_start(attrs, t.q, Sq);
+    TT_FATAL(
+        max_cs + Sq <= T,
+        "fullest-device chunk window [{}, {}+{}) exceeds T={} (base={}, per-rank stride Sq={})",
+        max_cs,
+        max_cs,
+        Sq,
+        T,
+        attrs.chunk_start_idx,
+        Sq);
+    // Causal window must also stay inside the valid prefix (kv_len <= T already checked above).
+    if (attrs.kv_len.has_value()) {
+        const uint32_t kv_len = attrs.kv_len.value();
         TT_FATAL(
-            attrs.chunk_start_idx + Sq <= kv_len,
-            "indexer_score causal window [{}, {}+{}) exceeds kv_len={} (cannot attend past the valid keys)",
-            attrs.chunk_start_idx,
-            attrs.chunk_start_idx,
+            max_cs + Sq <= kv_len,
+            "fullest-device causal window [{}, {}+{}) exceeds kv_len={} (cannot attend past the valid keys; "
+            "base={}, per-rank stride Sq={})",
+            max_cs,
+            max_cs,
             Sq,
-            kv_len);
+            kv_len,
+            attrs.chunk_start_idx,
+            Sq);
     }
 }
 }  // namespace
@@ -94,17 +134,25 @@ IndexerScoreDeviceOperation::program_factory_t IndexerScoreDeviceOperation::sele
 
 ttsl::hash::hash_t IndexerScoreDeviceOperation::compute_program_hash(
     const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-    // Default reflection hash, except the two persistent-cache optionals contribute only has_value() (whether
-    // indexed / runtime-kv_len), not their values -- those are runtime args re-applied every dispatch, so
-    // switching slot/kv_len reuses one program. Everything else stays hashed (chunk_start_idx, configs, full
-    // q/k/w specs incl. k's T/B), so do NOT drop fields beyond those two values.
+    // Hash what shapes the binary, NOT the runtime values: chunk_start_idx is EXCLUDED (per-device runtime),
+    // cache_batch_idx / kv_len contribute only has_value() -- so distinct slot / kv_len / chunk_start reuse
+    // one program. cluster_axis IS hashed (fixes each device's linearized index); tensor_args cover dtype +
+    // shape. Do NOT add chunk_start_idx or the slot/kv_len values here or they will recompile.
     return tt::tt_metal::operation::hash_operation<IndexerScoreDeviceOperation>(
-        attrs.chunk_start_idx,
         attrs.program_config,
         attrs.compute_kernel_config,
+        attrs.cluster_axis.has_value(),
+        attrs.cluster_axis.value_or(0u),
         attrs.has_indexed_kv_cache(),
         attrs.has_runtime_kv_len(),
         tensor_args);
+}
+
+void IndexerScoreDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+    // chunk_start, cache slot, and kv_len are all hash-excluded runtime values, so their checks run on hits too.
+    validate_runtime_values(attrs, tensor_args);
+    validate_chunk_start(attrs, tensor_args);
 }
 
 void IndexerScoreDeviceOperation::validate_on_program_cache_miss(
@@ -177,17 +225,7 @@ void IndexerScoreDeviceOperation::validate_on_program_cache_miss(
         Sq,
         T,
         D);
-    TT_FATAL(
-        attrs.chunk_start_idx % tt::constants::TILE_WIDTH == 0,
-        "chunk_start_idx {} must be tile-aligned",
-        attrs.chunk_start_idx);
-    TT_FATAL(
-        attrs.chunk_start_idx + Sq <= T,
-        "chunk window [{}, {}+{}) exceeds T={}",
-        attrs.chunk_start_idx,
-        attrs.chunk_start_idx,
-        Sq,
-        T);
+    validate_chunk_start(attrs, tensor_args);  // base/stride alignment + worst-device window (also runs on cache hit)
 
     // Work-unit knobs (elements, tile-aligned); see IndexerScoreProgramConfig.
     const auto& cfg = attrs.program_config;
@@ -208,13 +246,6 @@ void IndexerScoreDeviceOperation::validate_on_program_cache_miss(
     // KC need not divide Tt: the last unit is then partial. Compute still runs a full KC-wide strip
     // (pad cols matmul stale k, overwritten with full -inf) and the writer clips to the valid width.
     TT_FATAL(HB > 0 && Hi % HB == 0, "head_group_size {} must divide Hi {}", HB, Hi);
-}
-
-void IndexerScoreDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-    // Equal hash already pins everything else (placement, shapes, configs); only the slot/kv_len values can
-    // differ on a hit, so re-check just those. Static invariants stay miss-only (validate_static).
-    validate_runtime_values(attrs, tensor_args);
 }
 
 IndexerScoreDeviceOperation::spec_return_value_t IndexerScoreDeviceOperation::compute_output_specs(
@@ -306,10 +337,12 @@ IndexerScoreDeviceOperation::invoke(
     const IndexerScoreProgramConfig& program_config,
     const DeviceComputeKernelConfig& compute_kernel_config,
     std::optional<uint32_t> cache_batch_idx,
-    std::optional<uint32_t> kv_len) {
+    std::optional<uint32_t> kv_len,
+    std::optional<uint32_t> cluster_axis) {
     return {
         operation_attributes_t{
             .chunk_start_idx = chunk_start_idx,
+            .cluster_axis = cluster_axis,
             .program_config = program_config,
             .compute_kernel_config = compute_kernel_config,
             .cache_batch_idx = cache_batch_idx,
@@ -325,12 +358,33 @@ ttnn::Tensor indexer_score(
     const ttnn::Tensor& q,
     const ttnn::Tensor& k,
     const ttnn::Tensor& weights,
-    uint32_t chunk_start_idx,
+    std::optional<uint32_t> chunk_start_idx,
     const ttnn::operations::experimental::indexer_score::IndexerScoreProgramConfig& program_config,
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
     std::optional<uint32_t> cache_batch_idx,
-    std::optional<uint32_t> kv_len) {
+    std::optional<uint32_t> kv_len,
+    std::optional<uint32_t> cluster_axis) {
     using OperationType = ttnn::operations::experimental::indexer_score::IndexerScoreDeviceOperation;
+
+    // Resolve the base = rank 0's absolute chunk_start. Multichip: omit it -> deduce from the chunked-prefill
+    // invariant base = T - sp_ring*Sq, where sp_ring is the mesh extent along cluster_axis (whole mesh if
+    // unset; so a 2D SP x TP mesh uses the SP-axis length, not total devices). Single chip: caller passes it.
+    uint32_t base = 0;
+    if (chunk_start_idx.has_value()) {
+        base = *chunk_start_idx;
+    } else {
+        const uint32_t Sq = q.logical_shape()[2];
+        const uint32_t T = k.logical_shape()[2];
+        const uint32_t sp_ring = ttnn::ccl::get_topological_dimension(q, cluster_axis);
+        TT_FATAL(
+            T >= sp_ring * Sq,
+            "indexer_score: cannot deduce chunk_start_idx -- T={} < sp_ring({})*Sq({}). Pass chunk_start_idx "
+            "explicitly if K does not equal history + the SP-gathered chunk.",
+            T,
+            sp_ring,
+            Sq);
+        base = T - sp_ring * Sq;
+    }
     // Default math_fidelity follows the matmul-input dtypes (both bfp8 -> LoFi for the 2x peak, else
     // HiFi2 to keep the bf16 mantissa); a caller-supplied config overrides per field. fp32-dest acc and
     // full-sync default off -- the only modes this op's custom LLK is validated for (see validate).
@@ -345,7 +399,7 @@ ttnn::Tensor indexer_score(
         /*default_dst_full_sync_en=*/false);
     // Reuse invoke() so attribute/tensor packing lives in one place.
     auto [operation_attributes, tensor_args] =
-        OperationType::invoke(q, k, weights, chunk_start_idx, program_config, resolved, cache_batch_idx, kv_len);
+        OperationType::invoke(q, k, weights, base, program_config, resolved, cache_batch_idx, kv_len, cluster_axis);
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -366,16 +366,23 @@ ttnn::Tensor indexer_score(
     std::optional<uint32_t> cluster_axis) {
     using OperationType = ttnn::operations::experimental::indexer_score::IndexerScoreDeviceOperation;
 
-    // Resolve the base = rank 0's absolute chunk_start. Multichip: omit it -> deduce from the chunked-prefill
-    // invariant base = T - sp_ring*Sq, where sp_ring is the mesh extent along cluster_axis (whole mesh if
-    // unset; so a 2D SP x TP mesh uses the SP-axis length, not total devices). Single chip: caller passes it.
+    // base = rank 0's absolute chunk_start. Multichip: omit it -> deduce base = T - sp_ring*Sq (assumes K is
+    // history + the full SP-gathered chunk). Caveats: (1) deduced window ends exactly at T, so it's incompatible
+    // with a growing kv_len < T -- pass chunk_start_idx explicitly there; (2) single-chip default flipped to
+    // nullopt (was 0), so omitting now gives base = T - Sq, not 0.
     uint32_t base = 0;
     if (chunk_start_idx.has_value()) {
         base = *chunk_start_idx;
     } else {
         const uint32_t Sq = q.logical_shape()[2];
         const uint32_t T = k.logical_shape()[2];
-        const uint32_t sp_ring = ttnn::ccl::get_topological_dimension(q, cluster_axis);
+        // sp_ring with the per-device rank's min-relative convention (get_linearized_index returns coord-min, so
+        // sp_ring = max_rank + 1). get_topological_dimension (max+1) would over-count on a nonzero-offset sub-mesh.
+        uint32_t max_rank = 0;
+        for (const auto& coord : q.device_storage().get_coords()) {  // single device -> one coord, max_rank 0
+            max_rank = std::max(max_rank, ttnn::ccl::get_linearized_index_from_physical_coord(q, coord, cluster_axis));
+        }
+        const uint32_t sp_ring = max_rank + 1;
         TT_FATAL(
             T >= sp_ring * Sq,
             "indexer_score: cannot deduce chunk_start_idx -- T={} < sp_ring({})*Sq({}). Pass chunk_start_idx "

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
@@ -24,13 +24,13 @@ struct IndexerScoreDeviceOperation {
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
 
-    // Custom hash so the cache_batch_idx / kv_len values do NOT recompile (only their has_value() is hashed);
-    // everything else keys as usual. See the definition for details.
+    // Custom hash: the runtime values (cache_batch_idx / kv_len / chunk_start_idx) are excluded so they reuse
+    // one compiled program; cluster_axis IS hashed. See the definition for the full rationale.
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
-    // Only re-checks the runtime values (slot < B, kv_len bounds) that can change on a hit; the hash pins
-    // everything else. See validate_runtime_values.
+    // Re-checks the runtime values that can change on a hit: persistent-cache values (slot < B, kv_len bounds)
+    // and the hash-excluded chunk_start window/alignment (mirrors ring_joint_sdpa's runtime revalidation).
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
@@ -49,7 +49,8 @@ struct IndexerScoreDeviceOperation {
         const IndexerScoreProgramConfig& program_config,
         const DeviceComputeKernelConfig& compute_kernel_config,
         std::optional<uint32_t> cache_batch_idx,
-        std::optional<uint32_t> kv_len);
+        std::optional<uint32_t> kv_len,
+        std::optional<uint32_t> cluster_axis);
 };
 
 }  // namespace ttnn::operations::experimental::indexer_score
@@ -66,16 +67,22 @@ namespace ttnn::experimental {
 // kv_len: when set, only the first kv_len key positions of k are valid this dispatch (rest masked out);
 // must be tile-aligned, in (0, T], with chunk_start_idx + Sq <= kv_len. Output is still [B, 1, Sq, T] with
 // only columns [0, kv_len) written.
-// Both values are re-applied each dispatch and excluded from the program hash, so switching slot or growing
-// kv_len reuses ONE program -- no recompile.
+// chunk_start_idx is the ABSOLUTE chunk_start of rank 0 (lowest cluster_axis coord); rank r uses
+// chunk_start_idx + r*Sq, so one dispatch gives each SP rank its own chunk_start. OMIT it on multichip: the
+// base is deduced as T - sp_ring*Sq (sp_ring = mesh extent along cluster_axis, whole mesh if unset -- a 2D
+// SP x TP mesh uses the SP-axis length, not total devices). On single chip (one device = rank 0) set it to
+// history + rank*Sq to simulate any rank. cluster_axis selects the SP ring axis.
+// All of cache_batch_idx / kv_len / chunk_start are re-applied each dispatch and excluded from the program
+// hash, so switching slot, growing kv_len, or changing chunk_start reuses ONE program -- no recompile.
 ttnn::Tensor indexer_score(
     const ttnn::Tensor& q,
     const ttnn::Tensor& k,
     const ttnn::Tensor& weights,
-    uint32_t chunk_start_idx = 0,
+    std::optional<uint32_t> chunk_start_idx = std::nullopt,
     const ttnn::operations::experimental::indexer_score::IndexerScoreProgramConfig& program_config = {},
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
     std::optional<uint32_t> cache_batch_idx = std::nullopt,
-    std::optional<uint32_t> kv_len = std::nullopt);
+    std::optional<uint32_t> kv_len = std::nullopt,
+    std::optional<uint32_t> cluster_axis = std::nullopt);
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
@@ -28,7 +28,12 @@ inline uint32_t resolve_head_group(const IndexerScoreProgramConfig& cfg, uint32_
 }
 
 struct operation_attributes_t {
-    uint32_t chunk_start_idx{0};
+    // Absolute chunk_start of rank 0 (lowest cluster_axis coord; the only device on a single chip). Rank r
+    // uses chunk_start_idx + r*Sq (Sq = per-device q seq len; r = linearized index along cluster_axis), so
+    // the per-device value is derived host-side and passed to compute as a RUNTIME arg, hash-excluded --
+    // distinct values reuse one program (see compute_program_hash).
+    uint32_t chunk_start_idx{0};             // absolute chunk_start of rank 0 (elements, tile-aligned)
+    std::optional<uint32_t> cluster_axis{};  // mesh axis that is the SP ring; unset = linear device order
     IndexerScoreProgramConfig program_config{};
     // Resolved (not optional) so it is part of the reflected program-cache key; the public callable
     // fills it from the user's optional config, defaulting math_fidelity to the dtype-derived choice.

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
@@ -14,31 +14,51 @@
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-logger/tt-logger.hpp>         // log_info: per-program schedule/mcast summary
+#include <tt-metalium/mesh_workload.hpp>
 #include "hostdevcommon/kernel_structs.h"  // tt::CBIndex
 
 #include "ttnn/operations/transformer/sdpa/device/sdpa_subblock_utils.hpp"
+#include "ttnn/operations/ccl/ccl_common.hpp"    // get_linearized_index_from_physical_coord
 #include "kernels/indexer_score_cb.hpp"          // shared host/device CB-index argument layout (CbArg)
 #include "kernels/indexer_score_work_split.hpp"  // shared host/device causal work-split formula
 
 namespace ttnn::operations::experimental::indexer_score::program {
 
-// Runtime-arg slots, shared by create()/override_runtime_arguments() and matched positionally
-// by the kernels. Reader: q,k,w addrs then schedule(6) + mcast(2x8); writer: out addr then schedule(6).
+// Runtime-arg slots, shared by create_at()/override_runtime_arguments() and matched positionally by the
+// kernels. Reader: q,k,w addrs then schedule(6) + mcast(2x8) + persistent-cache(2); compute: schedule(6)
+// then kv_len_tiles[6] + chunk_start_tiles[7]; writer: out addr then schedule(6) + kv_len_tiles.
 namespace rt_arg {
 constexpr uint32_t reader_q_addr = 0;
 constexpr uint32_t reader_k_addr = 1;
 constexpr uint32_t reader_w_addr = 2;
+constexpr uint32_t compute_chunk_start_tiles = 7;  // after the 6 sched scalars + kv_len[6]; match the compute kernel
 constexpr uint32_t writer_out_addr = 0;
 // Persistent-cache args, appended after the schedule/mcast args of each kernel (excluded from the hash,
 // re-patched on a cache hit). Reader: 3 addrs + 6 schedule + 2 mcast dirs * 8 = 25, then the two below.
-constexpr uint32_t reader_num_scalars = 3 + 6;   // q/k/w addrs + schedule {row_group0..max_bands}
-constexpr uint32_t mcast_args_per_dir = 8;       // role, rect (xs,ys,xe,ye), sender (sx,sy), ndst
-constexpr uint32_t reader_num_mcast_dirs = 2;    // K column, then Q/W row
+constexpr uint32_t reader_num_scalars = 3 + 6;  // q/k/w addrs + schedule {row_group0..max_bands}
+constexpr uint32_t mcast_args_per_dir = 8;      // role, rect (xs,ys,xe,ye), sender (sx,sy), ndst
+constexpr uint32_t reader_num_mcast_dirs = 2;   // K column, then Q/W row
 constexpr uint32_t reader_k_batch_offset = reader_num_scalars + reader_num_mcast_dirs * mcast_args_per_dir;  // 25
 constexpr uint32_t reader_kv_len_tiles = reader_k_batch_offset + 1;                                          // 26
-constexpr uint32_t compute_kv_len_tiles = 6;  // after the 6 schedule scalars {row_group0..max_bands}
+constexpr uint32_t compute_kv_len_tiles = 6;     // after the 6 schedule scalars {row_group0..max_bands}
 constexpr uint32_t writer_kv_len_tiles = 1 + 6;  // out_addr + the 6 schedule scalars {row_group0..max_bands}
 }  // namespace rt_arg
+
+// Per-device chunk_start (in tiles): base + rank*Sq, /TILE_WIDTH (the per-rank stride is exactly the
+// per-device query count Sq). Shared by create_at (derives device_index from the coordinate) and
+// override (reuses the stored device_index).
+inline uint32_t chunk_start_tiles_for(const operation_attributes_t& args, uint32_t device_index, uint32_t Sq) {
+    return (args.chunk_start_idx + device_index * Sq) / tt::constants::TILE_WIDTH;
+}
+
+// This device's linearized SP-ring index; 0 on a single device (no coordinate lookup needed).
+inline uint32_t device_index_for(
+    const operation_attributes_t& args, const ttnn::MeshCoordinate& coord, const Tensor& q) {
+    if (q.device_storage().get_coords().size() <= 1) {
+        return 0;
+    }
+    return ttnn::ccl::get_linearized_index_from_physical_coord(q, coord, args.cluster_axis);
+}
 
 // Patch one runtime-arg slot on a program-cache hit, asserting the slot exists.
 inline void patch_arg(tt::tt_metal::RuntimeArgsData& args, uint32_t index, uint32_t value, const char* name) {
@@ -67,8 +87,11 @@ inline PersistentCacheArgs persistent_cache_args(const operation_attributes_t& a
 // columns (k multicast down a column). One (group, band) cell = one work unit of QC q-tile-rows x
 // up-to-KC k-tiles. Heads stream in HB-head groups; the causal masked suffix is stamped to -inf by
 // compute (zeros unsafe: gates can be negative). See indexer_score_work_split.hpp for the grid map.
-IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create(
-    const operation_attributes_t& args, const tensor_args_t& tensors, tensor_return_value_t& out) {
+IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_at(
+    const operation_attributes_t& args,
+    const ttnn::MeshCoordinate& coord,
+    const tensor_args_t& tensors,
+    tensor_return_value_t& out) {
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
     const auto& q = tensors.q;
@@ -82,10 +105,14 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create(
     const uint32_t D = q.logical_shape()[3];
     const uint32_t T = k.logical_shape()[2];
 
+    // This device's SP-ring index and chunk_start (tiles), derived from the mesh coordinate (stride = Sq).
+    // chunk_t is a compute RUNTIME arg (not compile-time), so the binary is identical across coords and steps.
+    const uint32_t device_index = device_index_for(args, coord, q);
+    const uint32_t chunk_t = chunk_start_tiles_for(args, device_index, Sq);
+
     const uint32_t Sqt = Sq / tt::constants::TILE_HEIGHT;
     const uint32_t Tt = T / tt::constants::TILE_WIDTH;
     const uint32_t Dt = D / tt::constants::TILE_WIDTH;
-    const uint32_t chunk_t = args.chunk_start_idx / tt::constants::TILE_WIDTH;
 
     // Work-unit knobs, converted from elements to tiles / heads.
     const auto& cfg = args.program_config;
@@ -252,8 +279,9 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create(
     // No up-front L1-fit guard: an oversized QC/KC/head_group config fails at CB allocation. The caller
     // owns the knob trade-off (see glx_config() in the test).
 
-    // Common args: 8 dims then the CB indices in CbArg order (kernels read both from this shared base).
-    std::vector<uint32_t> common_ct = {Hi, Sqt, Tt, Dt, chunk_t, QC, KC, HB};
+    // Common args: 7 dims then the CB indices in CbArg order (kernels read both from this shared base).
+    // chunk_t is NOT here -- it is a per-device compute runtime arg (derived from the coordinate above).
+    std::vector<uint32_t> common_ct = {Hi, Sqt, Tt, Dt, QC, KC, HB};
     common_ct.insert(common_ct.end(), cb_id.begin(), cb_id.end());
 
     std::vector<uint32_t> reader_ct = common_ct;
@@ -375,9 +403,12 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create(
             reader_rt.push_back(k_batch_page_offset);
             reader_rt.push_back(kv_len_tiles);
             tt::tt_metal::SetRuntimeArgs(program, reader_id, core, reader_rt);
-            // compute: schedule scalars then kv_len_tiles at slot [6].
+            // compute: schedule scalars[0-5], then kv_len_tiles[6] and chunk_start_tiles[7]. Both are
+            // hash-excluded runtime values -- kv_len is per-dispatch, chunk_t is per-device (from the
+            // coordinate) -- so distinct values reuse one compiled program.
             std::vector<uint32_t> compute_rt(sched.begin(), sched.end());
-            compute_rt.push_back(kv_len_tiles);
+            compute_rt.push_back(kv_len_tiles);  // slot [6]
+            compute_rt.push_back(chunk_t);       // slot [7]
             tt::tt_metal::SetRuntimeArgs(program, compute_id, core, compute_rt);
             std::vector<uint32_t> writer_rt = {out.buffer()->address()};
             writer_rt.insert(writer_rt.end(), sched.begin(), sched.end());
@@ -392,31 +423,58 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create(
             .reader_kernel = reader_id,
             .compute_kernel = compute_id,
             .writer_kernel = writer_id,
-            .worker_cores = cores}};
+            .worker_cores = cores,
+            .device_index = device_index}};
+}
+
+IndexerScoreProgramFactory::cached_mesh_workload_t IndexerScoreProgramFactory::create_mesh_workload(
+    const operation_attributes_t& args,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const tensor_args_t& tensors,
+    tensor_return_value_t& out) {
+    tt::tt_metal::distributed::MeshWorkload mesh_workload;
+    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
+    // One program per coordinate: each device derives its own chunk_start from its coordinate. A single
+    // device is a 1x1 mesh, so this loops once with index 0 (the single-chip / scalar path).
+    for (const auto& range : tensor_coords.ranges()) {
+        for (const auto& coord : range) {
+            const ttnn::MeshCoordinateRange single{coord, coord};
+            auto cached = create_at(args, coord, tensors, out);
+            shared_variables[single] = cached.shared_variables;
+            mesh_workload.add_program(single, std::move(cached.program));
+        }
+    }
+    return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
 }
 
 void IndexerScoreProgramFactory::override_runtime_arguments(
-    cached_program_t& cached,
+    cached_mesh_workload_t& cached,
     const operation_attributes_t& args,
     const tensor_args_t& tensors,
     tensor_return_value_t& out) {
-    auto& shared = cached.shared_variables;
-    auto& reader_args = tt::tt_metal::GetRuntimeArgs(cached.program, shared.reader_kernel);
-    auto& compute_args = tt::tt_metal::GetRuntimeArgs(cached.program, shared.compute_kernel);
-    auto& writer_args = tt::tt_metal::GetRuntimeArgs(cached.program, shared.writer_kernel);
-    // cache_batch_idx and kv_len are excluded from the hash, so a hit may carry new values against the same
-    // cached program -- re-apply both every dispatch (the analog of buffer-address patching).
+    // All hash-excluded runtime values re-applied on a cache hit: buffer addresses (uniform across the mesh),
+    // cache_batch_idx / kv_len (per-dispatch), and chunk_start (per-coordinate, recomputed from the stored
+    // device_index) -- so a hit patches all of them without recompiling.
+    const uint32_t Sq = tensors.q.logical_shape()[2];
     const auto [k_batch_page_offset, kv_len_tiles] = persistent_cache_args(args, tensors.k);
-    for (const auto& core : shared.worker_cores) {
-        auto& reader_rt = reader_args[core.x][core.y];
-        patch_arg(reader_rt, rt_arg::reader_q_addr, tensors.q.buffer()->address(), "reader.q_addr");
-        patch_arg(reader_rt, rt_arg::reader_k_addr, tensors.k.buffer()->address(), "reader.k_addr");
-        patch_arg(reader_rt, rt_arg::reader_w_addr, tensors.weights.buffer()->address(), "reader.w_addr");
-        patch_arg(reader_rt, rt_arg::reader_k_batch_offset, k_batch_page_offset, "reader.k_batch_offset");
-        patch_arg(reader_rt, rt_arg::reader_kv_len_tiles, kv_len_tiles, "reader.kv_len_tiles");
-        patch_arg(compute_args[core.x][core.y], rt_arg::compute_kv_len_tiles, kv_len_tiles, "compute.kv_len_tiles");
-        patch_arg(writer_args[core.x][core.y], rt_arg::writer_out_addr, out.buffer()->address(), "writer.out_addr");
-        patch_arg(writer_args[core.x][core.y], rt_arg::writer_kv_len_tiles, kv_len_tiles, "writer.kv_len_tiles");
+    for (auto& [range, shared] : cached.shared_variables) {
+        auto& program = cached.workload.get_programs().at(range);
+        auto& reader_args = tt::tt_metal::GetRuntimeArgs(program, shared.reader_kernel);
+        auto& compute_args = tt::tt_metal::GetRuntimeArgs(program, shared.compute_kernel);
+        auto& writer_args = tt::tt_metal::GetRuntimeArgs(program, shared.writer_kernel);
+        const uint32_t chunk_t = chunk_start_tiles_for(args, shared.device_index, Sq);
+        for (const auto& core : shared.worker_cores) {
+            auto& reader_rt = reader_args[core.x][core.y];
+            patch_arg(reader_rt, rt_arg::reader_q_addr, tensors.q.buffer()->address(), "reader.q_addr");
+            patch_arg(reader_rt, rt_arg::reader_k_addr, tensors.k.buffer()->address(), "reader.k_addr");
+            patch_arg(reader_rt, rt_arg::reader_w_addr, tensors.weights.buffer()->address(), "reader.w_addr");
+            patch_arg(reader_rt, rt_arg::reader_k_batch_offset, k_batch_page_offset, "reader.k_batch_offset");
+            patch_arg(reader_rt, rt_arg::reader_kv_len_tiles, kv_len_tiles, "reader.kv_len_tiles");
+            patch_arg(compute_args[core.x][core.y], rt_arg::compute_kv_len_tiles, kv_len_tiles, "compute.kv_len_tiles");
+            patch_arg(compute_args[core.x][core.y], rt_arg::compute_chunk_start_tiles, chunk_t, "compute.chunk_start");
+            patch_arg(writer_args[core.x][core.y], rt_arg::writer_out_addr, out.buffer()->address(), "writer.out_addr");
+            patch_arg(writer_args[core.x][core.y], rt_arg::writer_kv_len_tiles, kv_len_tiles, "writer.kv_len_tiles");
+        }
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.hpp
@@ -8,6 +8,7 @@
 
 #include "indexer_score_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
+#include "ttnn/distributed/types.hpp"  // MeshCoordinate(RangeSet)
 
 namespace ttnn::operations::experimental::indexer_score::program {
 
@@ -16,18 +17,37 @@ struct IndexerScoreSharedVariables {
     tt::tt_metal::KernelHandle compute_kernel;
     tt::tt_metal::KernelHandle writer_kernel;
     std::vector<CoreCoord> worker_cores;
+    // This device's linearized SP-ring index (from its mesh coordinate); chunk_start = base + idx*stride.
+    // Stored so override_runtime_arguments can recompute chunk_start for new base/stride on a cache hit.
+    uint32_t device_index = 0;
 };
 
+// Native mesh-workload factory: one program per mesh coordinate so each device derives its own
+// chunk_start from its coordinate (mirrors ring_joint_sdpa). A single device is a 1x1 mesh, so the
+// single-chip path flows through the same code with one coordinate (index 0).
 struct IndexerScoreProgramFactory {
     using shared_variables_t = IndexerScoreSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
 
-    static cached_program_t create(
-        const operation_attributes_t& args, const tensor_args_t& tensors, tensor_return_value_t& out);
+    static cached_mesh_workload_t create_mesh_workload(
+        const operation_attributes_t& args,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
+        const tensor_args_t& tensors,
+        tensor_return_value_t& out);
 
     static void override_runtime_arguments(
-        cached_program_t& cached,
+        cached_mesh_workload_t& cached,
         const operation_attributes_t& args,
+        const tensor_args_t& tensors,
+        tensor_return_value_t& out);
+
+private:
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    // Build one device's program; chunk_start is derived from `coord`.
+    static cached_program_t create_at(
+        const operation_attributes_t& args,
+        const ttnn::MeshCoordinate& coord,
         const tensor_args_t& tensors,
         tensor_return_value_t& out);
 };

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/compute_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/compute_indexer_score.cpp
@@ -285,10 +285,14 @@ inline void drain_phantom_band_q() {
 /** Stamp the causal -inf mask onto q_row's masked suffix [valid, KC) in place, so the strip still
  *  untilizes via the fast W=KC path (empty loop when the row is fully valid). */
 inline void stamp_masked_suffix(
-    const WorkUnitSpan& span, uint32_t q_row, uint32_t slot_base, uint32_t k_tiles_in_unit) {
+    const WorkUnitSpan& span,
+    uint32_t q_row,
+    uint32_t slot_base,
+    uint32_t k_tiles_in_unit,
+    uint32_t chunk_start_tiles) {
     const uint32_t k_tile0 = span.k_tile_start();
     const uint32_t diag_tile = chunk_start_tiles + span.q_tile_start() + q_row;
-    const uint32_t valid = row_valid_prefix(span.q_tile_start() + q_row, k_tile0, k_tiles_in_unit);
+    const uint32_t valid = row_valid_prefix(span.q_tile_start() + q_row, k_tile0, k_tiles_in_unit, chunk_start_tiles);
     for (uint32_t k_col = valid; k_col < k_tiles_per_unit; ++k_col) {
         stamp_mask_tile<cb_acc_strip, cb_mask>(slot_base + k_col, k_tile0 + k_col, diag_tile);
     }
@@ -307,6 +311,8 @@ void kernel_main() {
     // Valid KV length in tiles: caps each cell's valid columns (the causal mask suffix grows to cover the
     // unwritten tail). Full k_len_tiles when not set, so the dense path is unchanged. Excluded from the hash.
     const uint32_t kv_len_tiles = get_arg_val<uint32_t>(6);
+    // Per-device chunk-start offset (tiles), from the mesh coordinate; runtime so distinct values reuse one program.
+    const uint32_t chunk_start_tiles = get_arg_val<uint32_t>(7);
     if (num_groups == 0 || num_bands == 0) {
         return;
     }
@@ -370,7 +376,8 @@ void kernel_main() {
                     accumulate_row_streaming(q_row, slot_base);  // PHASE 1+2 head-streaming / KC==1 fallback
                 }
 
-                stamp_masked_suffix(span, q_row, slot_base, k_tiles_in_unit);  // causal -inf on masked suffix
+                // causal -inf on masked suffix; chunk_start_tiles is the per-device runtime offset.
+                stamp_masked_suffix(span, q_row, slot_base, k_tiles_in_unit, chunk_start_tiles);
             }
             acc.push_back(unit_strip);
 

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_common.hpp
@@ -15,16 +15,16 @@
 
 namespace iscore = ttnn::operations::experimental::indexer_score;
 
-// Common dim args 0..7 (same in every kernel).
-constexpr uint32_t num_heads = get_compile_time_arg_val(0);          // indexer heads
-constexpr uint32_t q_len_tiles = get_compile_time_arg_val(1);        // q chunk rows, in tiles
-constexpr uint32_t k_len_tiles = get_compile_time_arg_val(2);        // total k positions, in tiles
-constexpr uint32_t head_dim_tiles = get_compile_time_arg_val(3);     // head dim, in tiles
-constexpr uint32_t chunk_start_tiles = get_compile_time_arg_val(4);  // q chunk start offset, in tiles
-constexpr uint32_t q_tiles_per_unit = get_compile_time_arg_val(5);   // q-tile-rows per work unit (q_chunk knob)
-constexpr uint32_t k_tiles_per_unit = get_compile_time_arg_val(6);   // k tiles per work unit (k_chunk knob)
-constexpr uint32_t heads_per_group = get_compile_time_arg_val(7);    // heads resident at once (head_group knob)
-constexpr uint32_t num_dim_args = 8;
+// Common dim args 0..6 (same in every kernel). chunk_start is NOT here -- it is a per-device RUNTIME arg
+// (from the mesh coordinate; see the factory and compute kernel_main), so distinct values reuse one program.
+constexpr uint32_t num_heads = get_compile_time_arg_val(0);         // indexer heads
+constexpr uint32_t q_len_tiles = get_compile_time_arg_val(1);       // q chunk rows, in tiles
+constexpr uint32_t k_len_tiles = get_compile_time_arg_val(2);       // total k positions, in tiles
+constexpr uint32_t head_dim_tiles = get_compile_time_arg_val(3);    // head dim, in tiles
+constexpr uint32_t q_tiles_per_unit = get_compile_time_arg_val(4);  // q-tile-rows per work unit (q_chunk knob)
+constexpr uint32_t k_tiles_per_unit = get_compile_time_arg_val(5);  // k tiles per work unit (k_chunk knob)
+constexpr uint32_t heads_per_group = get_compile_time_arg_val(6);   // heads resident at once (head_group knob)
+constexpr uint32_t num_dim_args = 7;
 
 // CB indices, forwarded from the factory in CbArg order right after the dim args. Bare names so
 // kernels (and their template-arg uses) read like the host-side constants did.
@@ -51,8 +51,10 @@ constexpr uint32_t w_group_tiles = num_heads * q_tiles_per_unit;                
 constexpr uint32_t k_chunk_tiles = k_tiles_per_unit * head_dim_tiles;                    // [KC][Dt]
 
 // Thin wrapper binding the shared work-split formula to this kernel's CT dims: unmasked prefix
-// k-tiles of absolute q-tile-row q_row_abs in a unit (bound to this kernel's chunk_start_tiles).
-inline uint32_t row_valid_prefix(uint32_t q_row_abs, uint32_t k_tile_start, uint32_t k_tiles_in_unit) {
+// k-tiles of absolute q-tile-row q_row_abs in a unit. chunk_start_tiles is the per-device runtime
+// chunk-start offset (in tiles); the compute kernel reads it from a runtime arg.
+inline uint32_t row_valid_prefix(
+    uint32_t q_row_abs, uint32_t k_tile_start, uint32_t k_tiles_in_unit, uint32_t chunk_start_tiles) {
     return iscore::valid_prefix_tiles(q_row_abs, k_tile_start, k_tiles_in_unit, chunk_start_tiles);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
@@ -32,8 +32,11 @@ void bind_indexer_score(nb::module_& mod) {
             q: [B, Hi, Sq, D] bf16 or bfp8_b tiled (post non-interleaved RoPE)
             k: [B, 1, T, D] bf16 or bfp8_b tiled, single shared head
             weights: [B, Hi, Sq, 1] bf16 tiled, scales pre-folded
-            chunk_start_idx: global position of query row 0 (causality: key t
-                visible to query s iff t <= chunk_start_idx + s)
+            chunk_start_idx: absolute global position of rank 0's query row 0
+                (rank 0 = lowest cluster_axis coord; causality: key t visible to
+                query s iff t <= chunk_start + s). OMIT on a mesh -> deduced as
+                T - sp_ring*Sq (sp_ring = mesh extent along cluster_axis, whole
+                mesh if unset). Single device: set to history + rank*Sq per rank.
             program_config: work-unit knobs (q_chunk_size, k_chunk_size,
                 head_group_size; elements, tile-aligned). Defaults always fit
                 L1; raise head_group_size (0 = all resident) for performance.
@@ -50,6 +53,10 @@ void bind_indexer_score(nb::module_& mod) {
                 chunk_start_idx + Sq <= kv_len. Re-applied each dispatch, so a
                 serving loop growing kv_len (<= T) reuses one program -- no
                 recompile. Only output columns [0, kv_len) are written.
+            cluster_axis: mesh axis that is the SP ring. On a mesh, device r uses
+                chunk_start = chunk_start_idx + r*Sq, where r is its linearized
+                index along this axis (Sq = q seq len). None = linear device order
+                (1 on a single device, so chunk_start_idx is used as-is).
 
         Returns: score [B, 1, Sq, T] bf16 row-major; future/pad columns -inf.
         )doc",
@@ -58,11 +65,12 @@ void bind_indexer_score(nb::module_& mod) {
         nb::arg("k"),
         nb::arg("weights"),
         nb::kw_only(),
-        nb::arg("chunk_start_idx") = 0,
+        nb::arg("chunk_start_idx") = std::nullopt,
         nb::arg("program_config") = IndexerScoreProgramConfig{},
         nb::arg("compute_kernel_config") = std::nullopt,
         nb::arg("cache_batch_idx") = std::nullopt,
-        nb::arg("kv_len") = std::nullopt);
+        nb::arg("kv_len") = std::nullopt,
+        nb::arg("cluster_axis") = std::nullopt);
 }
 
 }  // namespace ttnn::operations::experimental::indexer_score::detail


### PR DESCRIPTION
## What

- Make `chunk_start` a **per-device runtime** value (was a compile-time arg): one compiled program now serves every device and every chunk step — `chunk_start` is excluded from the program hash, so no recompile per value.
- Each device derives its own `chunk_start = base + rank*Sq` from its **mesh coordinate** (`rank` = linearized index along `cluster_axis`), so a single mesh dispatch gives each SP rank the right causal window. The program factory is now a native `MeshWorkloadFactory` (ring_joint_sdpa style).
- On multichip the base is **deduced** from the shapes (`T - sp_ring*Sq`, where `sp_ring` is the mesh extent along `cluster_axis`, so a 2D SP×TP mesh uses the SP-axis length, not the device count); pass `chunk_start_idx` explicitly on a single chip. New optional `cluster_axis` arg.
- `validate_on_program_cache_hit` re-checks the worst-device causal window (mirrors ring's runtime-patched-scalar revalidation).
- Tests: single-chip + multi-device (1D SP=4, 2D SP=2×TP=2) consolidated into `test_indexer_score.py`; the multi-device cases auto-skip off a QuietBox. Added a QB2 post-commit CI leg.

## Test

- BHPC (Sanity tests nightly debug, blackhole): https://github.com/tenstorrent/tt-metal/actions/runs/28100306787
- L2 nightly (experimental only, blackhole): https://github.com/tenstorrent/tt-metal/actions/runs/28100297903

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/indexer-score-per-device-chunk-start)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/indexer-score-per-device-chunk-start)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/indexer-score-per-device-chunk-start)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/indexer-score-per-device-chunk-start)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/indexer-score-per-device-chunk-start)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skrstic/indexer-score-per-device-chunk-start)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/indexer-score-per-device-chunk-start)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/indexer-score-per-device-chunk-start)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/indexer-score-per-device-chunk-start)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/indexer-score-per-device-chunk-start)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/indexer-score-per-device-chunk-start)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/indexer-score-per-device-chunk-start)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/indexer-score-per-device-chunk-start)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/indexer-score-per-device-chunk-start)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/indexer-score-per-device-chunk-start)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/indexer-score-per-device-chunk-start)
