### PR TITLE
[REVIEW/DRAFT] Metal 2.0 spec-as-key as its own ProgramSpecFactoryConcept + explicit create_spec launch

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -3,13 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gmock/gmock.h>
+#include <span>
 #include <type_traits>
+#include <vector>
 
 #include "ttnn/distributed/api.hpp"
 #include "ttnn/distributed/distributed_tensor.hpp"
 #include "ttnn/mesh_device_operation_adapter.hpp"
 #include "ttnn/mesh_device_operation_utils.hpp"
 #include "ttnn/metal_v2_artifacts.hpp"
+#include "ttnn/program_spec_artifacts.hpp"
 #include "ttnn/operation_concepts.hpp"
 #include "ttnn/operations/examples/example/device/example_device_operation.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -150,6 +153,55 @@ TEST(LaunchOperationTest, MetalV2AdapterCompiles) {
     [[maybe_unused]] auto create = &Adapter::create_mesh_workload;
     [[maybe_unused]] auto apply = &Adapter::apply_descriptor;
     [[maybe_unused]] auto resolve = &Adapter::resolve_bindings;
+    SUCCEED();
+}
+
+// === Spec (ProgramSpecFactoryConcept) compile-coverage ===
+// No real op uses create_program_spec yet, so force-instantiate the ProgramSpec adapter bodies here.
+// Runtime behavior (miss->hit re-bind, owned-tensor liveness) needs a real dispatched op.
+struct ProgramSpecFactory {
+    static ttnn::device_operation::ProgramSpecArtifacts create_program_spec(
+        const OperationAttributes& /*attrs*/, const Tensor& /*tensor_args*/, Tensor& /*tensor_return_value*/) {
+        return ttnn::device_operation::ProgramSpecArtifacts{};
+    }
+};
+
+// Spec factory that also owns tensors: get_owned_tensors + the span overload of create_program_spec.
+struct ProgramSpecOwnedFactory {
+    static std::vector<tt::tt_metal::MeshTensor> get_owned_tensors(
+        const OperationAttributes& /*attrs*/, const Tensor& /*tensor_args*/, Tensor& /*tensor_return_value*/) {
+        return {};
+    }
+    static ttnn::device_operation::ProgramSpecArtifacts create_program_spec(
+        const OperationAttributes& /*attrs*/,
+        const Tensor& /*tensor_args*/,
+        Tensor& /*tensor_return_value*/,
+        std::span<const tt::tt_metal::MeshTensor> /*owned*/) {
+        return ttnn::device_operation::ProgramSpecArtifacts{};
+    }
+};
+
+static_assert(ttnn::device_operation::ProgramSpecFactoryConcept<ProgramSpecFactory>);
+static_assert(!ttnn::device_operation::MetalV2FactoryConcept<ProgramSpecFactory>);
+static_assert(!ttnn::device_operation::ProgramFactoryConcept<ProgramSpecFactory>);
+static_assert(!ttnn::device_operation::ProgramDescriptorFactoryConcept<ProgramSpecFactory>);
+static_assert(!ttnn::device_operation::ProgramSpecFactoryWithOwnedTensorsConcept<ProgramSpecFactory>);
+static_assert(ttnn::device_operation::ProgramSpecFactoryConcept<ProgramSpecOwnedFactory>);
+static_assert(ttnn::device_operation::ProgramSpecFactoryWithOwnedTensorsConcept<ProgramSpecOwnedFactory>);
+
+TEST(LaunchOperationTest, ProgramSpecAdapterCompiles) {
+    using Adapter = device_operation::MeshDeviceOperationAdapter<
+        MetalV2MinimalOp>::ProgramSpecMeshWorkloadFactoryAdapter<ProgramSpecFactory>;
+    [[maybe_unused]] auto create_spec = &Adapter::create_spec;
+    [[maybe_unused]] auto cache_hash = &Adapter::cache_hash;
+    [[maybe_unused]] auto stamp = &Adapter::stamp;
+    [[maybe_unused]] auto apply = &Adapter::apply_program_spec;
+
+    using OwnedAdapter = device_operation::MeshDeviceOperationAdapter<
+        MetalV2MinimalOp>::ProgramSpecWithOwnedTensorsMeshWorkloadFactoryAdapter<ProgramSpecOwnedFactory>;
+    [[maybe_unused]] auto owned_create_spec = &OwnedAdapter::create_spec;
+    [[maybe_unused]] auto owned_stamp = &OwnedAdapter::stamp;
+    [[maybe_unused]] auto owned_apply = &OwnedAdapter::apply_program_spec;
     SUCCEED();
 }
 

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -356,6 +356,128 @@ void create_and_cache_mesh_workload(
         });
 }
 
+// True iff every alternative of the op's program_factory_t is a ProgramSpecFactoryConcept -- i.e. this
+// op uses the spec-as-key path and is launched via launch_mesh_program_spec.
+template <typename Variant, std::size_t... Is>
+consteval bool all_alternatives_program_spec(std::index_sequence<Is...>) {
+    return (ProgramSpecFactoryConcept<std::variant_alternative_t<Is, Variant>> && ...);
+}
+template <typename mesh_device_operation_t>
+inline constexpr bool is_program_spec_mesh_op_v =
+    all_alternatives_program_spec<typename mesh_device_operation_t::program_factory_t>(
+        std::make_index_sequence<std::variant_size_v<typename mesh_device_operation_t::program_factory_t>>{});
+
+// Shared spec-as-key flow, parameterized on the spec adapter (base or owned-tensor). Build the
+// ProgramSpec once (the explicit create_spec step), key the cache on its content -- always from the spec,
+// never a cheap attribute hash -- then re-apply run args on a hit or stamp on a miss.
+template <typename Adapter, DeviceOperationWithMeshDeviceAdapter mesh_device_operation_t>
+void run_spec_flow(
+    const typename mesh_device_operation_t::operation_attributes_t& operation_attributes,
+    const typename mesh_device_operation_t::tensor_args_t& tensor_args,
+    typename mesh_device_operation_t::tensor_return_value_t& tensor_return_value,
+    ttnn::MeshDevice* mesh_device,
+    std::size_t program_factory_index) {
+    using cached_mesh_workload_t = typename Adapter::cached_mesh_workload_t;
+    auto& program_cache = mesh_device->get_program_cache();
+
+    // Target mesh coordinates, extracted once and reused for the range set and the key.
+    const auto target_coords = mesh_device_operation_utils::extract_tensor_coordinates(tensor_args, mesh_device);
+    ttnn::MeshCoordinateRangeSet tensor_coords;
+    if (mesh_device_operation_utils::all_tensors_have_uniform_storage(tensor_args)) {
+        tensor_coords.merge(ttnn::MeshCoordinateRange(mesh_device->shape()));
+    } else {
+        for (const auto& coord : target_coords) {
+            tensor_coords.merge(ttnn::MeshCoordinateRange(coord, coord));
+        }
+    }
+
+    // Build the spec once, explicitly; its ProgramSpec content is the cache key.
+    auto built = Adapter::create_spec(operation_attributes, tensor_args, tensor_return_value);
+
+    ProgramCacheKey program_key;
+    bool program_cache_hit = false;
+    if (program_cache.is_enabled()) {
+        program_key.hash = Adapter::cache_hash(built.artifacts);
+        for (const auto& coord : target_coords) {
+            program_key.hash = ttsl::hash::hash_objects(program_key.hash, coord);
+        }
+        // Keyed on the ProgramSpec content, so the canonical companion is just the op identity.
+        program_key.canonical =
+            std::string{ttsl::get_type_name<typename mesh_device_operation_t::device_operation_t>()};
+        program_cache_hit = program_cache.contains(program_key);
+        if (!program_cache_hit && !program_cache.cache_misses_allowed()) {
+            auto op_name = get_operation_name<mesh_device_operation_t>(operation_attributes);
+            TT_THROW("Device operation \"{}\": program cache miss occurred, but cache misses are forbidden", op_name);
+        }
+    }
+
+    log_operation<mesh_device_operation_t>(
+        mesh_device->id(), operation_attributes, tensor_args, program_key.hash, program_cache_hit);
+
+    if (program_cache_hit) {
+        if constexpr (HasValidateOnProgramCacheHit<mesh_device_operation_t>) {
+            mesh_device_operation_t::validate_on_program_cache_hit(operation_attributes, tensor_args);
+        } else {
+            mesh_device_operation_t::validate_on_program_cache_miss(operation_attributes, tensor_args);
+        }
+        auto& cached_program_factory = program_cache.get(program_key);
+        auto& cached_mesh_workload = cached_program_factory.cached_program.template get<cached_mesh_workload_t>();
+        Adapter::apply_program_spec(cached_mesh_workload, built);
+        enqueue_mesh_workload<mesh_device_operation_t>(
+            operation_attributes, tensor_args, tensor_return_value, mesh_device, cached_mesh_workload.workload);
+    } else {
+        mesh_device_operation_t::validate_on_program_cache_miss(operation_attributes, tensor_args);
+        auto cached_workload = Adapter::stamp(built, tensor_coords, mesh_device);
+
+        bool hook_blocks = false;
+        if (auto hook = tt::tt_metal::GraphTracker::instance().get_hook()) {
+            auto* processor_hooks = dynamic_cast<ttnn::graph::ProcessorHooks*>(hook.get());
+            if (processor_hooks) {
+                hook_blocks = processor_hooks->get_block();
+            }
+        }
+        if (program_cache.is_enabled() && !hook_blocks) {
+            program_cache.insert(program_key, CachedProgramFactory{std::move(cached_workload), program_factory_index});
+            auto& cached_program_factory = program_cache.get(program_key);
+            auto& workload = cached_program_factory.cached_program.template get<cached_mesh_workload_t>().workload;
+            enqueue_mesh_workload<mesh_device_operation_t>(
+                operation_attributes, tensor_args, tensor_return_value, mesh_device, workload);
+        } else {
+            enqueue_mesh_workload<mesh_device_operation_t>(
+                operation_attributes, tensor_args, tensor_return_value, mesh_device, cached_workload.workload);
+        }
+    }
+}
+
+// Launch path for Spec ops: route to the base spec adapter, or -- for the discouraged owned-tensor opt-in
+// -- the separate owned adapter, which exists apart precisely so it reads as "you are doing something
+// wrong" and can be deleted wholesale once no op needs it.
+template <DeviceOperationWithMeshDeviceAdapter mesh_device_operation_t>
+void launch_mesh_program_spec(
+    const typename mesh_device_operation_t::operation_attributes_t& operation_attributes,
+    const typename mesh_device_operation_t::tensor_args_t& tensor_args,
+    typename mesh_device_operation_t::tensor_return_value_t& tensor_return_value,
+    ttnn::MeshDevice* mesh_device) {
+    auto program_factory = mesh_device_operation_t::select_program_factory(operation_attributes, tensor_args);
+    auto program_factory_index = program_factory.index();
+    std::visit(
+        [&]<ProgramSpecFactoryConcept SpecFactory>(const SpecFactory&) {
+            if constexpr (ProgramSpecFactoryWithOwnedTensorsConcept<SpecFactory>) {
+                run_spec_flow<
+                    typename mesh_device_operation_t::template ProgramSpecWithOwnedTensorsMeshWorkloadFactoryAdapter<
+                        SpecFactory>,
+                    mesh_device_operation_t>(
+                    operation_attributes, tensor_args, tensor_return_value, mesh_device, program_factory_index);
+            } else {
+                run_spec_flow<
+                    typename mesh_device_operation_t::template ProgramSpecMeshWorkloadFactoryAdapter<SpecFactory>,
+                    mesh_device_operation_t>(
+                    operation_attributes, tensor_args, tensor_return_value, mesh_device, program_factory_index);
+            }
+        },
+        program_factory);
+}
+
 // Main function to launch operations on mesh devices with special handling for MeshDeviceOperationAdapter
 template <DeviceOperationWithMeshDeviceAdapter mesh_device_operation_t>
 void launch_operation_with_adapter(
@@ -368,6 +490,13 @@ void launch_operation_with_adapter(
         if (mesh_device_operation_t::skip_launch(operation_attributes, tensor_args, tensor_return_value)) {
             return;
         }
+    }
+
+    // Spec ops take the dedicated spec-as-key path (build the spec, key on it, apply/stamp).
+    if constexpr (is_program_spec_mesh_op_v<mesh_device_operation_t>) {
+        launch_mesh_program_spec<mesh_device_operation_t>(
+            operation_attributes, tensor_args, tensor_return_value, mesh_device);
+        return;
     }
 
     auto& program_cache = mesh_device->get_program_cache();

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -24,11 +24,14 @@
 #include <unordered_map>
 #include <variant>
 #include <vector>
+#include <span>
 #include <array>
 #include <tuple>
 #include "ttnn/distributed/types.hpp"
 #include "ttnn/mesh_device_operation_utils.hpp"
 #include "ttnn/metal_v2_artifacts.hpp"
+#include "ttnn/program_spec_artifacts.hpp"
+#include "ttnn/program_spec_hash.hpp"
 #include "ttnn/operation_concepts.hpp"
 #include "ttnn/operation.hpp"
 #include <tt_stl/reflection.hpp>
@@ -794,6 +797,125 @@ public:
                     fresh_tensor_args.emplace(b.tensor_parameter_name, TensorArgument{mesh_tensors[b.tensor_idx]});
                 }
                 tt::tt_metal::experimental::UpdateTensorArgs(program, fresh_tensor_args);
+            }
+        }
+    };
+
+    // -----------------------------------------------------------------------
+    // ProgramSpecMeshWorkloadFactoryAdapter (Spec)
+    //
+    // Adapts a ProgramSpecFactoryConcept factory. The launch builds the spec once (create_spec), hashes
+    // its ProgramSpec content for the cache key (always from the spec), then stamps a Program per
+    // coordinate range on a miss or re-binds tensors on a hit.
+    // -----------------------------------------------------------------------
+    template <ProgramSpecFactoryConcept SpecFactory>
+    struct ProgramSpecMeshWorkloadFactoryAdapter {
+        // No per-entry state: a Spec op's run args are rebuilt from the spec every dispatch.
+        struct shared_variables_t {};
+        using cached_mesh_workload_t = AdaptedCachedMeshWorkload<shared_variables_t>;
+
+        // The build product of one dispatch: just the artifacts (spec + run args).
+        struct BuiltSpec {
+            ProgramSpecArtifacts artifacts;
+        };
+
+        // Explicit create_spec: build the ProgramSpecArtifacts. Run args reference this dispatch's
+        // tensors, so they can be applied directly on both miss and hit.
+        static BuiltSpec create_spec(
+            const operation_attributes_t& attrs,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value) {
+            return BuiltSpec{SpecFactory::create_program_spec(attrs, tensor_args, tensor_return_value)};
+        }
+
+        // Cache key: the ProgramSpec content combined with the op type. Always from the spec.
+        static ttsl::hash::hash_t cache_hash(const ProgramSpecArtifacts& artifacts) {
+            return ttsl::hash::hash_objects(
+                ttsl::hash::type_hash<DeviceOperation>, program_spec_cache_key(artifacts.spec));
+        }
+
+        // Cache miss: build one Program per coordinate range from the spec and supply its run args.
+        static cached_mesh_workload_t stamp(
+            const BuiltSpec& built, const ttnn::MeshCoordinateRangeSet& tensor_coords, ttnn::MeshDevice* mesh_device) {
+            tt::tt_metal::distributed::MeshWorkload mesh_workload;
+            std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
+            for (const auto& range : tensor_coords.ranges()) {
+                auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, built.artifacts.spec);
+                tt::tt_metal::experimental::SetProgramRunArgs(program, built.artifacts.run_params);
+                shared_variables.emplace(range, shared_variables_t{});
+                mesh_workload.add_program(range, std::move(program));
+            }
+            return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
+        }
+
+        // Cache hit: supply this dispatch's freshly-built run args to each cached Program -- the canonical
+        // per-execution apply, not a tensor-arg patch. (create_spec already ran to produce the key, so
+        // run_params reference this dispatch's tensors.)
+        static void apply_program_spec(cached_mesh_workload_t& cached_workload, const BuiltSpec& built) {
+            for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
+                tt::tt_metal::experimental::SetProgramRunArgs(program, built.artifacts.run_params);
+            }
+        }
+    };
+
+    // -----------------------------------------------------------------------
+    // ProgramSpecWithOwnedTensorsMeshWorkloadFactoryAdapter (SpecWithOwnedTensors)
+    //
+    // Opt-in and discouraged: the factory allocates its own device tensors via get_owned_tensors that its
+    // run args reference. ttnn keeps them alive for the cache entry so they outlive the async enqueue.
+    // Everything owned-tensor-specific lives here -- the base Spec adapter has none of it. Reach for this
+    // only if an op genuinely cannot express every tensor as an io arg.
+    // -----------------------------------------------------------------------
+    template <ProgramSpecFactoryWithOwnedTensorsConcept SpecFactory>
+    struct ProgramSpecWithOwnedTensorsMeshWorkloadFactoryAdapter {
+        struct shared_variables_t {
+            // Op-owned tensors kept alive for the cache entry so they outlive the async enqueue.
+            std::shared_ptr<std::vector<tt::tt_metal::MeshTensor>> owned_tensors;
+        };
+        using cached_mesh_workload_t = AdaptedCachedMeshWorkload<shared_variables_t>;
+
+        // The build product of one dispatch: the artifacts plus the owned tensors they reference.
+        struct BuiltSpec {
+            ProgramSpecArtifacts artifacts;
+            std::shared_ptr<std::vector<tt::tt_metal::MeshTensor>> owned;
+        };
+
+        // Explicit create_spec: allocate the owned tensors, then build the artifacts referencing them.
+        static BuiltSpec create_spec(
+            const operation_attributes_t& attrs,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value) {
+            auto owned = std::make_shared<std::vector<tt::tt_metal::MeshTensor>>(
+                SpecFactory::get_owned_tensors(attrs, tensor_args, tensor_return_value));
+            auto artifacts = SpecFactory::create_program_spec(
+                attrs, tensor_args, tensor_return_value, std::span<const tt::tt_metal::MeshTensor>(*owned));
+            return BuiltSpec{std::move(artifacts), std::move(owned)};
+        }
+
+        static ttsl::hash::hash_t cache_hash(const ProgramSpecArtifacts& artifacts) {
+            return ttsl::hash::hash_objects(
+                ttsl::hash::type_hash<DeviceOperation>, program_spec_cache_key(artifacts.spec));
+        }
+
+        // Cache miss: stamp the spec per range and park the owned tensors so they stay alive.
+        static cached_mesh_workload_t stamp(
+            const BuiltSpec& built, const ttnn::MeshCoordinateRangeSet& tensor_coords, ttnn::MeshDevice* mesh_device) {
+            tt::tt_metal::distributed::MeshWorkload mesh_workload;
+            std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
+            for (const auto& range : tensor_coords.ranges()) {
+                auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, built.artifacts.spec);
+                tt::tt_metal::experimental::SetProgramRunArgs(program, built.artifacts.run_params);
+                shared_variables.emplace(range, shared_variables_t{.owned_tensors = built.owned});
+                mesh_workload.add_program(range, std::move(program));
+            }
+            return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
+        }
+
+        // Cache hit: apply this dispatch's fresh run args and re-park this dispatch's owned tensors.
+        static void apply_program_spec(cached_mesh_workload_t& cached_workload, const BuiltSpec& built) {
+            for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
+                tt::tt_metal::experimental::SetProgramRunArgs(program, built.artifacts.run_params);
+                cached_workload.shared_variables.at(coordinate_range).owned_tensors = built.owned;
             }
         }
     };

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -72,6 +72,8 @@ template <typename T>
 concept ProgramDescriptorFactoryConcept = (requires { &T::create_descriptor; } || WorkloadDescriptorConcept<T>) &&
                                           !ProgramFactoryConcept<T> && !MeshWorkloadFactoryConcept<T>;
 
+// === Temporary Solution to Unblock Quasar === op-porting concept owned elsewhere; keep as-is, to be
+// deleted once ports move to ProgramSpecFactoryConcept below.
 // Metal 2.0 op-porting stepping-stone factory concept: factories that return
 // ProgramArtifacts (a ProgramSpec + ProgramRunArgs + any op-owned tensors) from
 // create_program_artifacts. The framework adapter stamps a Program from the spec onto
@@ -90,6 +92,18 @@ concept ProgramDescriptorFactoryConcept = (requires { &T::create_descriptor; } |
 template <typename T>
 concept MetalV2FactoryConcept = requires { &T::create_program_artifacts; } && !ProgramFactoryConcept<T> &&
                                 !MeshWorkloadFactoryConcept<T> && !ProgramDescriptorFactoryConcept<T>;
+
+// === Spec === keys the program cache on the ProgramSpec content (always hashed from the spec, never a
+// cheap attribute hash). Factory returns ProgramSpecArtifacts from create_program_spec.
+template <typename T>
+concept ProgramSpecFactoryConcept =
+    requires { &T::create_program_spec; } && !ProgramFactoryConcept<T> && !MeshWorkloadFactoryConcept<T> &&
+    !ProgramDescriptorFactoryConcept<T> && !MetalV2FactoryConcept<T>;
+
+// === SpecWithOwnedTensors === a Spec factory that also allocates its own device tensors via
+// get_owned_tensors (scratch/config). Discouraged; prefer expressing every tensor as an io arg.
+template <typename T>
+concept ProgramSpecFactoryWithOwnedTensorsConcept = ProgramSpecFactoryConcept<T> && requires { &T::get_owned_tensors; };
 
 // Detect operations that put create_descriptor directly on the operation struct
 // (no program_factory_t wrapper needed for single-descriptor operations).
@@ -126,9 +140,8 @@ concept HasSelectProgramFactory = requires(
     } -> std::same_as<typename device_operation_t::program_factory_t>;
 };
 
-// Validate that all variant alternatives in a program_factory_t satisfy exactly one of
-// ProgramFactoryConcept, MeshWorkloadFactoryConcept, ProgramDescriptorFactoryConcept,
-// or MetalV2FactoryConcept.
+// Each variant alternative must satisfy exactly one factory concept. SpecWithOwnedTensors is a
+// refinement of ProgramSpecFactoryConcept, so it is not counted as a separate bucket.
 namespace detail {
 template <typename Variant, std::size_t... Is>
 consteval bool all_factories_valid(std::index_sequence<Is...>) {
@@ -136,7 +149,8 @@ consteval bool all_factories_valid(std::index_sequence<Is...>) {
         ((ProgramFactoryConcept<std::variant_alternative_t<Is, Variant>> +
           MeshWorkloadFactoryConcept<std::variant_alternative_t<Is, Variant>> +
           ProgramDescriptorFactoryConcept<std::variant_alternative_t<Is, Variant>> +
-          MetalV2FactoryConcept<std::variant_alternative_t<Is, Variant>>) == 1) &&
+          MetalV2FactoryConcept<std::variant_alternative_t<Is, Variant>> +
+          ProgramSpecFactoryConcept<std::variant_alternative_t<Is, Variant>>) == 1) &&
         ...);
 }
 }  // namespace detail

--- a/ttnn/api/ttnn/program_spec_artifacts.hpp
+++ b/ttnn/api/ttnn/program_spec_artifacts.hpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+
+namespace ttnn::device_operation {
+
+// Build product of a ProgramSpecFactoryConcept factory's create_program_spec: the immutable
+// ProgramSpec (the program-cache key) plus the ProgramRunArgs that bind it to this dispatch's tensors.
+struct ProgramSpecArtifacts {
+    tt::tt_metal::experimental::ProgramSpec spec;
+    tt::tt_metal::experimental::ProgramRunArgs run_params;
+};
+
+}  // namespace ttnn::device_operation

--- a/ttnn/api/ttnn/program_spec_hash.hpp
+++ b/ttnn/api/ttnn/program_spec_hash.hpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Content hash of a Metal 2.0 ProgramSpec, for use as a program-cache key.
+//
+// The ProgramSpec fully defines a compiled Program, so hashing it keys the cache
+// at program identity: two specs collide iff they describe the same Program. This
+// is the correct-by-construction replacement for hand-maintained per-op
+// compute_program_hash, which has to be kept in sync with the program by hand.
+//
+// ProgramSpec is reflection-hashable via ttsl::hash out of the box, so almost all
+// of it is hashed generically. The single semantic generic reflection can't express
+// is shape *relaxation*: a TensorParameter may declare dynamic_tensor_shape /
+// match_padded_shape_only, meaning the Program is invariant to (part of) the tensor
+// shape. The implementation honors that so volume-equivalent shapes (e.g. [2,3] and
+// [3,2], both one tile) share a cache entry instead of fragmenting it. Every other
+// field is folded in via reflection, so adding a field to
+// KernelSpec/DataflowBufferSpec/etc. is picked up automatically; a static_assert in
+// the .cpp guards the one place that isn't (the top-level ProgramSpec field set), so
+// a new ProgramSpec member can't silently slip out of the key.
+
+#include <cstddef>
+
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+
+namespace ttnn::device_operation {
+
+// Content hash of `spec`, suitable as a program-cache key. Combine with the op's
+// type hash at the call site so distinct ops with coincidentally-identical specs
+// don't collide.
+std::size_t program_spec_cache_key(const tt::tt_metal::experimental::ProgramSpec& spec);
+
+}  // namespace ttnn::device_operation

--- a/ttnn/core/program_spec_hash.cpp
+++ b/ttnn/core/program_spec_hash.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/program_spec_hash.hpp"
+
+#include <cstdint>
+
+#include <reflect>
+#include <tt_stl/reflection.hpp>
+
+namespace ttnn::device_operation {
+
+namespace {
+
+// TensorParameter, with shape folded in per its declared relaxations. (Everything
+// else about the parameter is identity-relevant and always hashed.)
+std::size_t hash_tensor_parameter(const tt::tt_metal::experimental::TensorParameter& p) {
+    const auto& spec = p.spec;
+    // Data type, layout and memory config (which carries the sharding configuration) are always
+    // identity-relevant, so they always go into the hash. Only the *shape* is folded in conditionally,
+    // per the parameter's declared relaxations below.
+    std::size_t hash = ttsl::hash::hash_objects_with_default_seed(
+        p.unique_id.get(), spec.data_type(), spec.layout(), spec.memory_config());
+
+    if (p.advanced_options.dynamic_tensor_shape) {
+        // Program depends only on element/page count, not on tensor shape.
+        hash = ttsl::hash::hash_objects(hash, static_cast<uint64_t>(spec.padded_shape().volume()));
+    } else if (p.advanced_options.match_padded_shape_only) {
+        // Logical shape may vary; the padded shape (and thus access pattern) is fixed.
+        hash = ttsl::hash::hash_objects(hash, spec.padded_shape());
+    } else {
+        hash = ttsl::hash::hash_objects(hash, spec.logical_shape(), spec.padded_shape());
+    }
+    return hash;
+}
+
+}  // namespace
+
+std::size_t program_spec_cache_key(const tt::tt_metal::experimental::ProgramSpec& spec) {
+    // ProgramSpec currently has 7 fields; tensor_parameters is the only one needing
+    // relaxation-aware handling, so it is hashed separately below and the other six
+    // are hashed generically. If a field is added/removed, update this function (and
+    // this count) so the new field participates in the key.
+    static_assert(reflect::size<tt::tt_metal::experimental::ProgramSpec>() == 7);
+
+    std::size_t hash = ttsl::hash::hash_objects_with_default_seed(
+        spec.name,
+        spec.kernels,
+        spec.dataflow_buffers,
+        spec.cross_node_dataflow_buffers,
+        spec.semaphores,
+        spec.work_units);
+
+    for (const auto& p : spec.tensor_parameters) {
+        hash = ttsl::hash::hash_objects(hash, hash_tensor_parameter(p));
+    }
+    return hash;
+}
+
+}  // namespace ttnn::device_operation

--- a/ttnn/sources.cmake
+++ b/ttnn/sources.cmake
@@ -13,6 +13,7 @@ set(TTNN_CORE_SRCS
     core/core.cpp
     core/device.cpp
     core/device_operation_detail.cpp
+    core/program_spec_hash.cpp
     cpp/tools/profiler/op_profiler_json.cpp
     core/distributed/api.cpp
     core/distributed/distributed_tensor.cpp


### PR DESCRIPTION
**Draft / review copy** of the spec-path rework discussed on #47473 — isolated on a fresh branch, single commit, so the diff is easy to validate. Not for merge.

## What this is
Spec-as-key gets its **own** factory concept (not a repurpose of the existing one) and a **dedicated explicit-flow launch** using the canonical run-args API.

### 5 factory concepts (commented, mutually exclusive)
- `ProgramFactoryConcept` (Legacy) — untouched
- `ProgramDescriptorFactoryConcept` (Descriptors) — untouched
- `MetalV2FactoryConcept` (**Temporary Solution to Unblock Quasar**) — **byte-identical to main**; deleted once ports migrate
- `ProgramSpecFactoryConcept` (**Spec**) — new; `create_program_spec` → `ProgramSpecArtifacts`
- `ProgramSpecFactoryWithOwnedTensorsConcept` (**SpecWithOwnedTensors**) — new; Spec + `get_owned_tensors`

### Explicit launch (`launch_mesh_program_spec`)
```
built = create_spec(...)                 // build the ProgramSpec once, explicitly
key   = hash(built.spec) (+ coords)      // always from the spec, never a cheap hash
if (cache.find(key))  SetProgramRunArgs(program, built.run_params)   // apply run args (per-execution)
else                  stamp(built.spec)                              // build the workload
```
Cache hit uses **`SetProgramRunArgs`** — the canonical per-execution apply per the metal2 migration guide — **not** the `UpdateTensorArgs` patch (which the metal header itself marks for removal). Because the spec is built every dispatch (for the key), there's no index-remapping / binding bookkeeping at all.

## Notes
- **Net-additive**: +377 / −4. The other four factory architectures and their dispatch are untouched.
- Own `ProgramSpecArtifacts` (`{ProgramSpec, ProgramRunArgs}`); spec-hash helper renamed off the `metal_v2_` prefix.
- Built with `--build-ttnn-tests` (0 errors); the new adapter bodies are force-instantiated by a compile-coverage test. **Known gap:** `launch_mesh_program_spec` is fully instantiated only when a real Spec op routes through it (the transpose port).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/metal2-spec-concept-review)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/metal2-spec-concept-review)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/metal2-spec-concept-review)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/metal2-spec-concept-review)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/metal2-spec-concept-review)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/metal2-spec-concept-review)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/metal2-spec-concept-review)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/metal2-spec-concept-review)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/metal2-spec-concept-review)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/metal2-spec-concept-review)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/metal2-spec-concept-review)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/metal2-spec-concept-review)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/metal2-spec-concept-review)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/metal2-spec-concept-review)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/metal2-spec-concept-review)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/metal2-spec-concept-review)