### PR TITLE
[Bug fix] Batched prefill disabled for Llama 3.1 8B on P150

### DIFF
--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -627,7 +627,7 @@ class ModelArgs:
         # variance. Workaround until the prefill kernels are batch-invariant.
         # Disabled for Qwen3-32B (P150x4) and Llama-3.1-8B (P300/P150x4/P150x8).
         self.disable_batched_prefill = (self.base_model_name == "Qwen3-32B" and self.device_name == "P150x4") or (
-            self.base_model_name == "Llama-3.1-8B" and self.device_name in ("P300", "P150x4", "P150x8")
+            self.base_model_name == "Llama-3.1-8B" and self.device_name in ("P150", "P300", "P150x4", "P150x8")
         )
 
         if (


### PR DESCRIPTION
### Summary
On P150 single-chip, test_non_uniform_seeding (in server_tests/test_cases/test_vllm_chat_completions.py) fails intermittently: under concurrent load, requests sharing seed=0 are expected to produce identical output, but occasionally one degenerates into a repeating-token loop (for example: HereHereHere…), so the seed=0 set is no longer unique. This reproduces in around 30% of the runs.

Root cause
On Blackhole, the prefill matmul/attention float-reduction order depends on the batched-token count, so the same prompt prefilled in differently-sized batches (which vary with how many requests arrive together) gets slightly different results, and seeded sampling under concurrency then diverges. Forcing per-user batch-1 prefill removes the variance.

The disable list already covered the other Blackhole Llama-3.1-8B configs (P300, P150x4, P150x8) but not plain single-chip P150 — an oversight, since the same prefill kernels are in play.

### CI runs:
On dispatch run: https://github.com/tenstorrent/tt-shield/actions/runs/28165421064/job/83429797393

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llama_8b_p150_seed0_batched_prefill_switch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llama_8b_p150_seed0_batched_prefill_switch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llama_8b_p150_seed0_batched_prefill_switch)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llama_8b_p150_seed0_batched_prefill_switch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=llama_8b_p150_seed0_batched_prefill_switch)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:llama_8b_p150_seed0_batched_prefill_switch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llama_8b_p150_seed0_batched_prefill_switch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llama_8b_p150_seed0_batched_prefill_switch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llama_8b_p150_seed0_batched_prefill_switch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llama_8b_p150_seed0_batched_prefill_switch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llama_8b_p150_seed0_batched_prefill_switch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llama_8b_p150_seed0_batched_prefill_switch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llama_8b_p150_seed0_batched_prefill_switch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llama_8b_p150_seed0_batched_prefill_switch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llama_8b_p150_seed0_batched_prefill_switch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llama_8b_p150_seed0_batched_prefill_switch)