### PR TITLE
[Feature] Add causal GQA support for ring joint SDPA

### DIFF
--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -15,6 +15,7 @@ Perf tests are included but skipped on CI.
 Model Configurations:
 - WAN: nhq == nhk == nhv, d_q == d_k == d_v == 128, bfloat16 for all tensors
 - MLA: nhk == 1, d_q == d_k == 576, d_v == 128, bfloat16 for Q, bfloat8_b for K/V
+- Minimax3 GQA: nhk == nhv < nhq, d_q == d_k == d_v == 128, bfloat16 for Q, bfloat8_b for K/V
 
 BH adaptation: uses init_device_compute_kernel_config instead of WormholeComputeKernelConfig.
 """
@@ -68,7 +69,6 @@ class ModelConfig:
     d_k: int
     d_v: int
     is_causal: bool
-    is_balanced: bool
 
     # Dtypes
     q_dtype: ttnn.DataType
@@ -80,6 +80,8 @@ class ModelConfig:
 
     # Can be hardware-dependent to keep per-core work balanced between Galaxy and Quiet Box
     seq_len: int
+
+    is_balanced: bool = False
 
 
 def generate_model_configs(mesh_config: MeshConfig) -> Dict[str, ModelConfig]:
@@ -98,12 +100,53 @@ def generate_model_configs(mesh_config: MeshConfig) -> Dict[str, ModelConfig]:
             d_k=128,
             d_v=128,
             is_causal=False,
-            is_balanced=False,
             q_dtype=ttnn.bfloat16,
             kv_dtype=ttnn.bfloat16,
             q_chunk_sizes=[224, 256, 288],
             k_chunk_sizes=[128, 256, 512],
             seq_len=9472 if mesh_config.is_galaxy else 8544,  # Tuned for each platform to match per-core work
+        )
+    )
+
+    configs.append(
+        ModelConfig(
+            name="minimax3_gqa_smoke",
+            nhq=16,
+            nhk=1,
+            nhv=1,
+            d_q=128,
+            d_k=128,
+            d_v=128,
+            is_causal=True,
+            is_balanced=True,
+            q_dtype=ttnn.bfloat16,
+            kv_dtype=ttnn.bfloat8_b,
+            # q_chunk=256 (Sq_chunk_t > 2*qktv_h) exercises the full-size cb_out streaming path on the
+            # production row-wide multicast transport — guards the streaming cb_out shrink fix.
+            q_chunk_sizes=[128, 256],
+            k_chunk_sizes=[512],
+            seq_len=1024,
+        )
+    )
+
+    configs.append(
+        ModelConfig(
+            name="minimax3_gqa_unicast_smoke",
+            nhq=16,
+            nhk=2,
+            nhv=2,
+            d_q=128,
+            d_k=128,
+            d_v=128,
+            is_causal=True,
+            is_balanced=True,
+            q_dtype=ttnn.bfloat16,
+            kv_dtype=ttnn.bfloat8_b,
+            # Grouped-unicast fallback (nhk>1) is otherwise only nominally exercised, so sweep a
+            # small q/k chunk cross-product over a longer prefix instead of a single shape.
+            q_chunk_sizes=[128, 256],
+            k_chunk_sizes=[256, 512],
+            seq_len=1024,
         )
     )
 
@@ -118,7 +161,6 @@ def generate_model_configs(mesh_config: MeshConfig) -> Dict[str, ModelConfig]:
             d_k=128,
             d_v=128,
             is_causal=False,
-            is_balanced=False,
             q_dtype=ttnn.bfloat16,
             kv_dtype=ttnn.bfloat16,
             q_chunk_sizes=[224, 256, 288],
@@ -140,7 +182,6 @@ def generate_model_configs(mesh_config: MeshConfig) -> Dict[str, ModelConfig]:
             d_k=128,
             d_v=128,
             is_causal=False,
-            is_balanced=False,
             q_dtype=ttnn.bfloat16,
             kv_dtype=ttnn.bfloat16,
             q_chunk_sizes=[224],
@@ -162,7 +203,6 @@ def generate_model_configs(mesh_config: MeshConfig) -> Dict[str, ModelConfig]:
             d_k=128,
             d_v=128,
             is_causal=False,
-            is_balanced=False,
             q_dtype=ttnn.bfloat16,
             kv_dtype=ttnn.bfloat16,
             q_chunk_sizes=[288],
@@ -185,7 +225,6 @@ def generate_model_configs(mesh_config: MeshConfig) -> Dict[str, ModelConfig]:
             d_k=128,
             d_v=128,
             is_causal=False,
-            is_balanced=False,
             q_dtype=ttnn.bfloat16,
             kv_dtype=ttnn.bfloat16,
             q_chunk_sizes=[288],
@@ -242,6 +281,45 @@ def generate_model_configs(mesh_config: MeshConfig) -> Dict[str, ModelConfig]:
 MODEL_CONFIGS = generate_model_configs(MESH_CONFIG)
 
 
+def generate_ring_joint_perf_model_configs(
+    mesh_config: MeshConfig, model_configs: Dict[str, ModelConfig]
+) -> Dict[str, ModelConfig]:
+    perf_configs = dict(model_configs)
+
+    perf_configs["minimax3_gqa_causal_perf"] = ModelConfig(
+        name="minimax3_gqa_causal_perf",
+        nhq=16,
+        nhk=1,
+        nhv=1,
+        d_q=128,
+        d_k=128,
+        d_v=128,
+        is_causal=True,
+        is_balanced=True,
+        q_dtype=ttnn.bfloat16,
+        kv_dtype=ttnn.bfloat8_b,
+        q_chunk_sizes=[128],
+        k_chunk_sizes=[512],
+        seq_len=4096,
+    )
+
+    return perf_configs
+
+
+RING_JOINT_PERF_MODEL_CONFIGS = generate_ring_joint_perf_model_configs(MESH_CONFIG, MODEL_CONFIGS)
+
+
+def model_uses_tp_replicated_shared_k(model: ModelConfig) -> bool:
+    return model.nhk == 1 and model.nhv == model.nhq
+
+
+def scaled_model_heads_for_mesh(model: ModelConfig, mesh_config: MeshConfig) -> Tuple[int, int, int]:
+    nhq = model.nhq * mesh_config.tp_size
+    nhk = model.nhk if model_uses_tp_replicated_shared_k(model) else model.nhk * mesh_config.tp_size
+    nhv = model.nhv * mesh_config.tp_size
+    return nhq, nhk, nhv
+
+
 # Accuracy threshold constants
 DEFAULT_PCC_THRESHOLD = 0.994
 DEFAULT_RMSE_THRESHOLD = 0.05
@@ -294,10 +372,12 @@ def torch_sdpa_reference(q, k, v, is_causal=False):
     Dv = v.shape[-1]
 
     def take_heads(t, h_start, h_end):
-        # MLA broadcasts a single KV head across all Q heads via expand (no copy).
-        if t.shape[1] != H:
-            return t.expand(B, h_end - h_start, -1, -1)
-        return t[:, h_start:h_end]
+        if t.shape[1] == H:
+            return t[:, h_start:h_end]
+        assert H % t.shape[1] == 0, f"Q heads must be divisible by KV heads, got H={H}, KV={t.shape[1]}"
+        heads_per_kv = H // t.shape[1]
+        kv_indices = torch.arange(h_start, h_end, device=t.device) // heads_per_kv
+        return t[:, kv_indices]
 
     if total_seq <= SEQ_CHUNK and H <= HEAD_CHUNK:
         attn_out = torch.nn.functional.scaled_dot_product_attention(
@@ -366,6 +446,13 @@ def assert_pcc_rmse(expected, actual, pcc_threshold, rmse_threshold, label):
         assert rmse < rmse_threshold, f"{label} RMSE {rmse:.6f} exceeds threshold {rmse_threshold}"
     assert pcc >= pcc_threshold, f"{label} PCC {pcc} below threshold {pcc_threshold}"
     return pcc, rmse
+
+
+def is_supported_ring_joint_head_mode(nhq, nhk, nhv):
+    is_mha = nhq == nhk == nhv
+    is_separate_v_shared_k = nhk == 1 and nhv == nhq
+    is_gqa_grouped_kv = nhk == nhv < nhq and nhk > 0 and nhq % nhk == 0
+    return is_mha or is_separate_v_shared_k or is_gqa_grouped_kv
 
 
 def device_tensors_mismatch_marker(reference_tensor, actual_tensor):
@@ -518,17 +605,15 @@ def generate_test_configs(mesh_config: MeshConfig, model_configs: Dict[str, Mode
     config_ids = []
 
     for _, model in model_configs.items():
+        nhq, nhk, nhv = scaled_model_heads_for_mesh(model, mesh_config)
         for q_chunk, k_chunk in product(model.q_chunk_sizes, model.k_chunk_sizes):
             configs.append(
                 (
                     BATCH_SIZE,
                     model.seq_len * mesh_config.sp_size,  # Global sequence length across all devices in the ring
-                    model.nhq * mesh_config.tp_size,  # Total query heads across all TP shards
-                    model.nhk
-                    * (
-                        mesh_config.tp_size if model.nhk != 1 else 1
-                    ),  # Total key heads across all TP shards (handle nhk=1 case for MLA)
-                    model.nhv * mesh_config.tp_size,  # Total value heads across all TP shards
+                    nhq,  # Total query heads across all TP shards
+                    nhk,  # Total key heads across all TP shards
+                    nhv,  # Total value heads across all TP shards
                     model.d_q,
                     model.d_k,
                     model.d_v,
@@ -696,11 +781,8 @@ def run_ring_joint_sdpa(
     # Ensure reproducible results
     torch.manual_seed(1234)
 
-    # Validate head count constraints
-    # For WAN: nhq == nhk == nhv (standard attention)
-    # For MLA: nhk == 1, nhq == nhv (multi-latent attention with single K head)
-    if nhk != 1 and nhq != nhk:
-        pytest.skip(f"Ring joint attention requires nhq == nhk or nhk == 1, got nhq={nhq}, nhk={nhk}")
+    if not is_supported_ring_joint_head_mode(nhq, nhk, nhv):
+        pytest.skip(f"Unsupported ring joint attention heads: nhq={nhq}, nhk={nhk}, nhv={nhv}")
 
     runtime = open_ring_joint_sdpa_runtime(mesh_config)
     mesh_device = runtime.mesh_device
@@ -919,9 +1001,7 @@ def run_ring_joint_sdpa_model_configs(
     torch.manual_seed(1234)
 
     b = BATCH_SIZE
-    nhq = model.nhq * mesh_config.tp_size
-    nhk = model.nhk * (mesh_config.tp_size if model.nhk != 1 else 1)
-    nhv = model.nhv * mesh_config.tp_size
+    nhq, nhk, nhv = scaled_model_heads_for_mesh(model, mesh_config)
     sq = model.seq_len * mesh_config.sp_size
     d_q, d_k, d_v = model.d_q, model.d_k, model.d_v
     q_dtype, kv_dtype = model.q_dtype, model.kv_dtype
@@ -936,8 +1016,8 @@ def run_ring_joint_sdpa_model_configs(
         f"do_check={do_check}, num_iterations={num_iterations}"
     )
 
-    if nhk != 1 and nhq != nhk:
-        pytest.skip(f"Ring joint attention requires nhq == nhk or nhk == 1, got nhq={nhq}, nhk={nhk}")
+    if not is_supported_ring_joint_head_mode(nhq, nhk, nhv):
+        pytest.skip(f"Unsupported ring joint attention heads: nhq={nhq}, nhk={nhk}, nhv={nhv}")
 
     owns_runtime = runtime is None
     if runtime is None:
@@ -1436,13 +1516,12 @@ def run_ring_joint_sdpa_chunked(
         qk_configs = list(qk_configs)
         assert qk_configs, f"No q/k configs provided for chunked model {model.name}"
 
-    # model.nhq/nhk/nhv are PER RING; scale to total head counts across all TP shards
-    # (mirrors the sweep convention; nhk=1 stays 1 for MLA's single shared K head).
-    nhq = model.nhq * mesh_config.tp_size
-    nhk = model.nhk * (mesh_config.tp_size if model.nhk != 1 else 1)
-    nhv = model.nhv * mesh_config.tp_size
+    # model.nhq/nhk/nhv are PER RING; scale to total head counts across all TP shards.
+    # Only the MLA-style shared-K path keeps nhk=1 replicated across TP.
+    nhq, nhk, nhv = scaled_model_heads_for_mesh(model, mesh_config)
     d_q, d_k, d_v = model.d_q, model.d_k, model.d_v
     q_dtype, kv_dtype = model.q_dtype, model.kv_dtype
+    # Chunked cache growth is linear in sequence order; balanced zigzag applies only to full prefill.
     is_balanced = False
 
     b = BATCH_SIZE
@@ -1743,8 +1822,7 @@ def run_ring_joint_sdpa_chunked(
                         persistent_output_buffer_kv=persistent_output_buffer_k,
                         head_dim_v=d_v,
                         logical_n=e,
-                        # kv_actual_isl requires is_balanced=False.
-                        is_balanced=False if reuse_kv_buffer else is_balanced,
+                        is_balanced=is_balanced,
                         program_config=program_config,
                         compute_kernel_config=compute_kernel_config,
                         dim=2,
@@ -1766,8 +1844,7 @@ def run_ring_joint_sdpa_chunked(
                     tt_V,
                     e,
                     is_causal=True,
-                    # kv_actual_isl requires is_balanced=False.
-                    is_balanced=False if reuse_kv_buffer else is_balanced,
+                    is_balanced=is_balanced,
                     p_buf_k=persistent_output_buffer_k,
                     p_buf_v=persistent_output_buffer_v,
                     program_config=program_config,
@@ -2780,7 +2857,6 @@ def test_ring_joint_attention_chunked_nd_sharded_indexed_kv_cache_accuracy():
         d_k=64,
         d_v=32,
         is_causal=True,
-        is_balanced=False,
         q_dtype=ttnn.bfloat16,
         kv_dtype=ttnn.bfloat16,
         q_chunk_sizes=[32],
@@ -2854,7 +2930,6 @@ def test_ring_mla_chunked_nd_sharded_indexed_kv_cache_accuracy_and_determinism()
         d_k=64,
         d_v=32,
         is_causal=True,
-        is_balanced=False,
         q_dtype=ttnn.bfloat16,
         kv_dtype=ttnn.bfloat16,
         q_chunk_sizes=[32],
@@ -2904,9 +2979,10 @@ def test_ring_mla_nd_sharded_indexed_kv_cache_accuracy():
     )
 
 
-# Generate test parameters dynamically based on detected hardware for different models (WAN, MLA, VideGen...)
-TEST_CONFIGS, TEST_CONFIG_IDS = generate_test_configs(MESH_CONFIG, MODEL_CONFIGS)
+# Generate perf test parameters dynamically based on detected hardware for different models (WAN, MLA, VideGen...)
+TEST_CONFIGS, TEST_CONFIG_IDS = generate_test_configs(MESH_CONFIG, RING_JOINT_PERF_MODEL_CONFIGS)
 TEST_CONFIG_MODELS = list(MODEL_CONFIGS.keys())
+PERF_TEST_CONFIG_MODELS = list(RING_JOINT_PERF_MODEL_CONFIGS.keys())
 
 
 def generate_ring_mla_test_configs(mesh_config: MeshConfig, model_configs: Dict[str, ModelConfig]):
@@ -3164,7 +3240,7 @@ def test_ring_mla_determinism(
 
 # === TEST 4: PERFORMANCE TABLE GENERATOR (skipped on CI) ===
 @pytest.mark.skipif(os.environ.get("CI") == "true", reason="Performance test - skip on CI")
-@pytest.mark.parametrize("model_name", TEST_CONFIG_MODELS)
+@pytest.mark.parametrize("model_name", PERF_TEST_CONFIG_MODELS)
 def test_ring_joint_attention_create_perf_table(model_name):
     """
     Sweep chunk sizes for ring joint attention SDPA and print a performance table.
@@ -3173,7 +3249,7 @@ def test_ring_joint_attention_create_perf_table(model_name):
     from tracy.process_model_log import run_device_profiler
 
     mesh_config = MESH_CONFIG
-    model_configs = MODEL_CONFIGS
+    model_configs = RING_JOINT_PERF_MODEL_CONFIGS
 
     ring_size = mesh_config.sp_size
 
@@ -3445,7 +3521,7 @@ def test_ring_joint_attention_perf_check(
 
     assert (
         len(r["CORE COUNT"]) > 0 and len(r["DEVICE KERNEL DURATION [ns]"]) > 0
-    ), "profiler returned no SDPA ops — inner test was skipped or did not produce a kernel run"
+    ), "profiler returned no SDPA ops - inner test was skipped or did not produce a kernel run"
 
     measured_core_count = int(r["CORE COUNT"][0])
     duration_ns = int(r["DEVICE KERNEL DURATION [ns]"].max())
@@ -3553,7 +3629,6 @@ CHUNKED_PREFILL_MODEL_CONFIGS = {
         d_k=576,
         d_v=128,
         is_causal=True,
-        is_balanced=True,
         q_dtype=ttnn.bfloat16,
         kv_dtype=ttnn.bfloat8_b,
         q_chunk_sizes=[32],
@@ -3571,6 +3646,27 @@ RING_MLA_CHUNKED_MODEL_CONFIGS = {
     name: replace(cfg, d_v=RING_MLA_CHUNKED_LATENT_D_V) for name, cfg in CHUNKED_PREFILL_MODEL_CONFIGS.items()
 }
 
+# Minimax3 production chunked-prefill GQA shape. The full model is 64 Q heads and 4 K/V
+# heads. With TP=4, each chip sees one KV head; keep the config per-ring so the generic
+# TP scaling produces 64Q/4KV globally on Galaxy and still exercises one-KV-head GQA locally.
+MINIMAX3_GQA_CHUNKED_MODEL_CONFIGS = {
+    "minimax3_55k": ModelConfig(
+        name="minimax3_55k",
+        nhq=16,
+        nhk=1,
+        nhv=1,
+        d_q=128,
+        d_k=128,
+        d_v=128,
+        is_causal=True,
+        q_dtype=ttnn.bfloat16,
+        kv_dtype=ttnn.bfloat8_b,
+        q_chunk_sizes=[128],
+        k_chunk_sizes=[512],
+        seq_len=CHUNKED_PREFILL_CHUNK_SIZE,  # unused by chunked path
+    ),
+}
+
 
 def _generate_chunked_configs(model_configs):
     configs = []
@@ -3584,6 +3680,9 @@ def _generate_chunked_configs(model_configs):
 
 CHUNKED_CONFIGS, CHUNKED_CONFIG_IDS = _generate_chunked_configs(CHUNKED_PREFILL_MODEL_CONFIGS)
 RING_MLA_CHUNKED_CONFIGS, RING_MLA_CHUNKED_CONFIG_IDS = _generate_chunked_configs(RING_MLA_CHUNKED_MODEL_CONFIGS)
+MINIMAX3_GQA_CHUNKED_CONFIGS, MINIMAX3_GQA_CHUNKED_CONFIG_IDS = _generate_chunked_configs(
+    MINIMAX3_GQA_CHUNKED_MODEL_CONFIGS
+)
 
 
 def _generate_chunked_test_configs(model_configs, chunked_configs, chunked_config_ids):
@@ -3611,6 +3710,14 @@ RING_MLA_CHUNKED_TEST_CONFIGS, RING_MLA_CHUNKED_TEST_CONFIG_IDS = _generate_chun
     RING_MLA_CHUNKED_CONFIGS,
     RING_MLA_CHUNKED_CONFIG_IDS,
 )
+MINIMAX3_GQA_CHUNKED_TEST_CONFIGS, MINIMAX3_GQA_CHUNKED_TEST_CONFIG_IDS = _generate_chunked_test_configs(
+    MINIMAX3_GQA_CHUNKED_MODEL_CONFIGS,
+    MINIMAX3_GQA_CHUNKED_CONFIGS,
+    MINIMAX3_GQA_CHUNKED_CONFIG_IDS,
+)
+
+MINIMAX3_GQA_CHUNKED_ACCURACY_CHUNK_SIZE = CHUNKED_PREFILL_CHUNK_SIZE
+MINIMAX3_GQA_CHUNKED_ACCURACY_TOTAL_SEQ = 3 * MINIMAX3_GQA_CHUNKED_ACCURACY_CHUNK_SIZE
 
 
 @pytest.mark.parametrize("chunk_size", [CHUNKED_PREFILL_CHUNK_SIZE], ids=[f"chunk{CHUNKED_PREFILL_CHUNK_SIZE}"])
@@ -3632,6 +3739,138 @@ def test_ring_joint_attention_sdpa_chunked_accuracy(model_name, qk_configs, chun
     )
 
 
+@pytest.mark.parametrize(
+    "nhq, nhk, nhv, supported",
+    [
+        # Supported head modes (mirror the device-op classification in ring_joint_sdpa_device_operation.cpp).
+        (16, 16, 16, True),  # MHA
+        (16, 1, 16, True),  # separate-V shared-K
+        (16, 1, 1, True),  # GQA, one local KV head (production multicast case)
+        (16, 2, 2, True),  # GQA, grouped KV (unicast-fallback case)
+        (16, 4, 4, True),  # GQA, larger group count
+        # Rejected: GQA ratio must divide evenly and K/V head counts must match.
+        (16, 3, 3, False),  # nhq % nhk != 0
+        (16, 5, 5, False),  # nhq % nhk != 0
+        (16, 2, 4, False),  # nhk != nhv
+        (16, 16, 1, False),  # NVH must equal NQH for shared-K, or NQH for GQA
+        (16, 32, 32, False),  # nhk > nhq
+    ],
+)
+def test_is_supported_ring_joint_head_mode(nhq, nhk, nhv, supported):
+    """Lock the GQA head-mode acceptance contract that the test harness uses to skip and that the
+    device op enforces via TT_FATAL (ring_joint_sdpa_device_operation.cpp head-relationship check).
+    Pure host-side check — no device required."""
+    assert is_supported_ring_joint_head_mode(nhq, nhk, nhv) == supported
+
+
+def test_ring_joint_attention_gqa_with_joint_tensors_rejected(expect_error):
+    """GQA grouped-K/V is unsupported with joint tensors; the device op must reject it (validation-only,
+    so no kernel runs). Covers ring_joint_sdpa_device_operation.cpp's GQA-with-joint TT_FATAL, which the
+    host head-mode guard does not catch."""
+    mesh_config = MESH_CONFIG
+    b, nhq, nhk, nhv, d = 1, 16, 2, 2, 128  # GQA grouped K/V (nhk == nhv < nhq)
+    sq = 512 * mesh_config.sp_size
+    joint_l = 32  # tile-aligned joint length
+
+    runtime = open_ring_joint_sdpa_runtime(mesh_config)
+    try:
+        mesh_device = runtime.mesh_device
+        sp_axis, tp_axis = runtime.sp_axis, runtime.tp_axis
+        mesh_shape = tuple(mesh_device.shape)
+        replicate = ttnn.ReplicateTensorToMesh(mesh_device)
+
+        # Mirror the run helper's sharding so the gathered-buffer shape check (input_seq * ring_size)
+        # passes and validation proceeds to the GQA-with-joint check.
+        def sharded(t, shard_heads):
+            dims = [None, None]
+            dims[sp_axis] = 2  # shard inputs on the sequence dim
+            if mesh_config.tp_size > 1 and shard_heads:
+                dims[tp_axis] = 1
+            return ttnn.from_torch(
+                t,
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=mesh_device,
+                mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=dims),
+            )
+
+        def persistent(t):
+            dims = [None, None]  # seq NOT sharded: holds the gathered full sequence
+            if mesh_config.tp_size > 1:
+                dims[tp_axis] = 1
+            return ttnn.from_torch(
+                t,
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=mesh_device,
+                mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=dims),
+            )
+
+        def replicated(t):
+            return ttnn.from_torch(
+                t, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=mesh_device, mesh_mapper=replicate
+            )
+
+        tt_q = sharded(fa_rand(b, nhq, sq, d), shard_heads=True)
+        tt_k = sharded(fa_rand(b, nhk, sq, d), shard_heads=True)
+        tt_v = sharded(fa_rand(b, nhv, sq, d), shard_heads=True)
+        # Joint tensors only need to exist with valid shapes to reach the GQA-with-joint check.
+        joint_q = replicated(fa_rand(b, nhq, joint_l, d))
+        joint_k = replicated(fa_rand(b, nhk, joint_l, d))
+        joint_v = replicated(fa_rand(b, nhv, joint_l, d))
+        p_buf_k, p_buf_v = persistent(torch.zeros(b, nhk, sq, d)), persistent(torch.zeros(b, nhv, sq, d))
+
+        program_config = ttnn.SDPAProgramConfig(
+            compute_with_storage_grid_size=runtime.sdpa_compute_grid,
+            q_chunk_size=128,
+            k_chunk_size=512,
+            exp_approx_mode=False,
+        )
+
+        # Joint tensors require non-causal (causal+joint is rejected earlier), so this is the
+        # non-causal GQA + joint case that the GQA-with-joint TT_FATAL is meant to catch.
+        with expect_error(RuntimeError, "GQA with joint tensors"):
+            ttnn.transformer.ring_joint_scaled_dot_product_attention(
+                tt_q,
+                tt_k,
+                tt_v,
+                joint_q,
+                joint_k,
+                joint_v,
+                persistent_output_buffer_k=p_buf_k,
+                persistent_output_buffer_v=p_buf_v,
+                joint_strategy="rear",
+                logical_n=sq,
+                is_causal=False,
+                is_balanced=False,
+                program_config=program_config,
+                compute_kernel_config=runtime.compute_kernel_config,
+                dim=2,
+                multi_device_global_semaphore=runtime.ccl_semaphore_handles,
+                num_links=runtime.num_links,
+                cluster_axis=runtime.sp_axis,
+                mesh_device=mesh_device,
+                topology=runtime.topology,
+                subdevice_id=runtime.worker_sub_device_id,
+                ccl_core_grid_offset=(runtime.ccl_column, 0),
+                use_column_major_ccl=True,
+            )
+    finally:
+        close_ring_joint_sdpa_runtime(runtime)
+
+
+def test_ring_joint_attention_minimax3_gqa_chunked_accuracy():
+    """Small causal GQA chunked-prefill PCC gate for Minimax3 dims without the full 55k CPU reference."""
+    run_ring_joint_sdpa_chunked(
+        MESH_CONFIG,
+        MINIMAX3_GQA_CHUNKED_MODEL_CONFIGS["minimax3_55k"],
+        chunk_size=MINIMAX3_GQA_CHUNKED_ACCURACY_CHUNK_SIZE,
+        total_seq=MINIMAX3_GQA_CHUNKED_ACCURACY_TOTAL_SEQ,
+        qk_configs=[(128, 512)],
+        persistent_buffer_mode="reuse_max",
+    )
+
+
 @pytest.mark.skipif(os.environ.get("CI") == "true", reason="Performance test - skip on CI")
 @pytest.mark.parametrize("reuse_kv_buffer", [False, True], ids=["fresh_kv", "reuse_kv"])
 @pytest.mark.parametrize("chunk_size", [CHUNKED_PREFILL_CHUNK_SIZE], ids=[f"chunk{CHUNKED_PREFILL_CHUNK_SIZE}"])
@@ -3649,6 +3888,30 @@ def test_ring_joint_attention_chunked_perf_impl(model_name, qk_configs, chunk_si
     run_ring_joint_sdpa_chunked(
         mesh_config,
         CHUNKED_PREFILL_MODEL_CONFIGS[model_name],
+        chunk_size=chunk_size,
+        qk_configs=qk_configs,
+        persistent_buffer_mode="reuse_max",
+        do_check=False,
+        reuse_kv_buffer=reuse_kv_buffer,
+    )
+
+
+@pytest.mark.skipif(os.environ.get("CI") == "true", reason="Performance test - skip on CI")
+@pytest.mark.parametrize("reuse_kv_buffer", [False, True], ids=["fresh_kv", "reuse_kv"])
+@pytest.mark.parametrize("chunk_size", [CHUNKED_PREFILL_CHUNK_SIZE], ids=[f"chunk{CHUNKED_PREFILL_CHUNK_SIZE}"])
+@pytest.mark.parametrize(
+    "model_name,qk_configs",
+    MINIMAX3_GQA_CHUNKED_TEST_CONFIGS,
+    ids=MINIMAX3_GQA_CHUNKED_TEST_CONFIG_IDS,
+)
+def test_ring_joint_attention_minimax3_gqa_chunked_perf_impl(model_name, qk_configs, chunk_size, reuse_kv_buffer):
+    """Minimax3 GQA chunked prefill without the CPU reference. This mirrors the Kimi chunked
+    perf harness but uses one KV head per TP shard."""
+    mesh_config = MESH_CONFIG
+
+    run_ring_joint_sdpa_chunked(
+        mesh_config,
+        MINIMAX3_GQA_CHUNKED_MODEL_CONFIGS[model_name],
         chunk_size=chunk_size,
         qk_configs=qk_configs,
         persistent_buffer_mode="reuse_max",
@@ -3725,6 +3988,29 @@ def test_ring_joint_attention_sdpa_chunked_determinism(model_name, qk_configs, c
         qk_configs=qk_configs,
         num_iterations=3,
     )
+
+
+@pytest.mark.parametrize("chunk_size", [CHUNKED_PREFILL_CHUNK_SIZE], ids=[f"chunk{CHUNKED_PREFILL_CHUNK_SIZE}"])
+@pytest.mark.parametrize(
+    "model_name,qk_configs",
+    MINIMAX3_GQA_CHUNKED_TEST_CONFIGS,
+    ids=MINIMAX3_GQA_CHUNKED_TEST_CONFIG_IDS,
+)
+def test_ring_joint_attention_minimax3_gqa_chunked_determinism(model_name, qk_configs, chunk_size):
+    """Run the Minimax3 final chunk three times and require bit-exact output. The final chunk is
+    the production-shaped 5k Q chunk attending to the full 55k K/V cache on Galaxy."""
+    mesh_config = MESH_CONFIG
+    n_chunks = CHUNKED_PREFILL_TOTAL_SEQ // chunk_size
+    final_chunk = n_chunks - 1
+
+    with mock.patch.dict(os.environ, {CHUNKED_PREFILL_CHUNK_ID_ENV: str(final_chunk)}):
+        run_ring_joint_sdpa_chunked(
+            mesh_config,
+            MINIMAX3_GQA_CHUNKED_MODEL_CONFIGS[model_name],
+            chunk_size=chunk_size,
+            qk_configs=qk_configs,
+            num_iterations=3,
+        )
 
 
 @pytest.mark.parametrize("chunk_size", [CHUNKED_PREFILL_CHUNK_SIZE], ids=[f"chunk{CHUNKED_PREFILL_CHUNK_SIZE}"])
@@ -3924,6 +4210,54 @@ def test_ring_joint_attention_create_chunked_perf_table(model_name, q_chunk_size
 @pytest.mark.parametrize("chunk_size", [CHUNKED_PREFILL_CHUNK_SIZE], ids=[f"chunk{CHUNKED_PREFILL_CHUNK_SIZE}"])
 @pytest.mark.parametrize(
     "model_name,q_chunk_size,k_chunk_size",
+    MINIMAX3_GQA_CHUNKED_CONFIGS,
+    ids=MINIMAX3_GQA_CHUNKED_CONFIG_IDS,
+)
+def test_ring_joint_attention_minimax3_gqa_create_chunked_perf_table(
+    model_name, q_chunk_size, k_chunk_size, chunk_size
+):
+    """Per-chunk math-util + duration table for Minimax3 GQA chunked prefill."""
+    _run_chunked_perf_table(
+        MESH_CONFIG,
+        MINIMAX3_GQA_CHUNKED_MODEL_CONFIGS[model_name],
+        model_name,
+        q_chunk_size,
+        k_chunk_size,
+        chunk_size,
+        accuracy_test_name="test_ring_joint_attention_minimax3_gqa_chunked_perf_impl",
+        subdir="ttnn_ring_joint_sdpa_minimax3_gqa_chunked_performance",
+        label="Ring Joint Minimax3 GQA Chunked-Prefill (reuse KV buffer)",
+        id_suffix="-reuse_kv",
+    )
+
+
+def compute_chunked_prefill_perf_check_utilization(
+    mesh_config, model, chunk_size, perf_chunk, duration_ns, measured_core_count
+):
+    # Chunk geometry: q_per_dev Q rows attend to the full prefix (non-causal rectangle) plus
+    # the current chunk's causal triangle. Folding the triangle into an effective K/V length
+    # (prefix + chunk_size/2) makes compute_ring_joint_utilization's non-causal FLOPs exact.
+    q_per_dev = chunk_size // mesh_config.sp_size
+    prefix_k = perf_chunk * chunk_size
+    effective_kv = prefix_k + chunk_size // 2
+
+    # Match perf-table effective_cores rounding (ignore non-multiple-of-grid-row CCL strays).
+    effective_cores = measured_core_count - measured_core_count % mesh_config.grid_rows
+    assert (
+        effective_cores > 0
+    ), f"effective_cores=0 (measured_core_count={measured_core_count}) - profiler output incomplete"
+
+    utilization = compute_ring_joint_utilization(
+        q_per_dev, effective_kv, model.d_q, model.d_v, model.nhq, duration_ns, effective_cores, is_causal=False
+    )
+    return utilization, effective_cores
+
+
+@pytest.mark.skipif(os.environ.get("CI") == "true", reason="Performance test - skip on CI")
+@pytest.mark.timeout(1200)
+@pytest.mark.parametrize("chunk_size", [CHUNKED_PREFILL_CHUNK_SIZE], ids=[f"chunk{CHUNKED_PREFILL_CHUNK_SIZE}"])
+@pytest.mark.parametrize(
+    "model_name,q_chunk_size,k_chunk_size",
     RING_MLA_CHUNKED_CONFIGS,
     ids=RING_MLA_CHUNKED_CONFIG_IDS,
 )
@@ -3960,6 +4294,20 @@ else:
         # (model_name, q_chunk_size, k_chunk_size, ring_size, expected_util)
         # 4-device ring (QuietBox, 100 SDPA cores)
         ("kimi50k", 32, 640, 4, 66.05),
+    ]
+
+
+if MESH_CONFIG.is_galaxy:
+    MINIMAX3_GQA_CHUNKED_PERF_CHECK_CONFIGS = [
+        # (model_name, q_chunk_size, k_chunk_size, ring_size, expected_util)
+        # 8-device ring (Galaxy, sp=8 tp=4): production 5k Q chunk attending to 50k K/V prefix.
+        ("minimax3_55k", 128, 512, 8, 47.64),
+    ]
+else:
+    MINIMAX3_GQA_CHUNKED_PERF_CHECK_CONFIGS = [
+        # (model_name, q_chunk_size, k_chunk_size, ring_size, expected_util)
+        # 4-device ring (QuietBox): same per-device Q rows and 16Q/1KV local GQA shape.
+        ("minimax3_55k", 128, 512, 4, 47.64),
     ]
 
 
@@ -4014,26 +4362,13 @@ def test_ring_mla_chunked_perf_check(model_name, q_chunk_size, k_chunk_size, rin
 
     assert (
         len(r["CORE COUNT"]) > 0 and len(r["DEVICE KERNEL DURATION [ns]"]) > 0
-    ), "profiler returned no SDPA ops — inner test was skipped or did not produce a kernel run"
+    ), "profiler returned no SDPA ops - inner test was skipped or did not produce a kernel run"
 
     measured_core_count = int(r["CORE COUNT"][0])
     duration_ns = int(r["DEVICE KERNEL DURATION [ns]"].max())
 
-    # Match perf-table effective_cores rounding (ignore non-multiple-of-10 strays)
-    effective_cores = measured_core_count - measured_core_count % 10
-    assert (
-        effective_cores > 0
-    ), f"effective_cores=0 (measured_core_count={measured_core_count}) — profiler output incomplete"
-
-    # Chunk geometry: q_per_dev Q rows attend to the full prefix (non-causal rectangle) plus
-    # the current chunk's causal triangle. Folding the triangle into an effective K/V length
-    # (prefix + chunk_size/2) makes compute_ring_joint_utilization's non-causal FLOPs exact.
-    q_per_dev = chunk_size // ring_size_expected
-    prefix_k = perf_chunk * chunk_size
-    effective_kv = prefix_k + chunk_size // 2
-
-    utilization = compute_ring_joint_utilization(
-        q_per_dev, effective_kv, model.d_q, model.d_v, model.nhq, duration_ns, effective_cores, is_causal=False
+    utilization, _ = compute_chunked_prefill_perf_check_utilization(
+        MESH_CONFIG, model, chunk_size, perf_chunk, duration_ns, measured_core_count
     )
 
     lower = expected_util * (1 - RING_JOINT_PERF_MARGIN)
@@ -4041,6 +4376,80 @@ def test_ring_mla_chunked_perf_check(model_name, q_chunk_size, k_chunk_size, rin
 
     logger.info(
         f"ring_mla chunked 50k+5k perf check {config_id}: "
+        f"duration={duration_ns/1e6:.3f} ms, math_util={utilization:.2f}% "
+        f"(expected {expected_util:.2f}%, band [{lower:.2f}, {upper:.2f}])"
+    )
+
+    assert lower <= utilization <= upper, (
+        f"Math utilization {utilization:.2f}% outside band [{lower:.2f}, {upper:.2f}] "
+        f"(expected {expected_util:.2f}%, margin +/- {RING_JOINT_PERF_MARGIN*100:.1f}%)"
+    )
+
+
+@pytest.mark.skipif(
+    os.environ.get("SDPA_PERF_CHECKS") != "1",
+    reason="Set SDPA_PERF_CHECKS=1 to run (CI: sdpa perf tests job)",
+)
+@pytest.mark.timeout(600)
+@pytest.mark.parametrize(
+    "model_name, q_chunk_size, k_chunk_size, ring_size_expected, expected_util",
+    MINIMAX3_GQA_CHUNKED_PERF_CHECK_CONFIGS,
+    ids=[f"{cfg[0]}-q{cfg[1]}-k{cfg[2]}-ring{cfg[3]}" for cfg in MINIMAX3_GQA_CHUNKED_PERF_CHECK_CONFIGS],
+)
+def test_ring_joint_attention_minimax3_gqa_chunked_perf_check(
+    model_name, q_chunk_size, k_chunk_size, ring_size_expected, expected_util
+):
+    """Measure Minimax3 GQA chunked-prefill math utilization for the production-style final chunk.
+
+    RING_JOINT_CHUNKED_CHUNK_ID isolates the final chunk so only its iteration is profiled; the
+    inner perf_impl uses reuse_kv mode so kv_actual_isl models the long prefix with a stable cache shape.
+    """
+    from tracy.process_model_log import run_device_profiler
+
+    if MESH_CONFIG.sp_size != ring_size_expected:
+        pytest.skip(f"Expected ring size {ring_size_expected}, current topology has ring size {MESH_CONFIG.sp_size}")
+
+    model = MINIMAX3_GQA_CHUNKED_MODEL_CONFIGS[model_name]
+    chunk_size = CHUNKED_PREFILL_CHUNK_SIZE
+    n_chunks = CHUNKED_PREFILL_TOTAL_SEQ // chunk_size
+    perf_chunk = n_chunks - 1
+
+    config_id = f"{get_test_case_id(model, q_chunk_size, k_chunk_size)}-chunk{chunk_size}-reuse_kv"
+    subdir = "ttnn_ring_joint_sdpa_minimax3_gqa_chunked_perf_check"
+    command = (
+        "pytest tests/nightly/blackhole/sdpa/"
+        f"test_ring_joint_sdpa.py::test_ring_joint_attention_minimax3_gqa_chunked_perf_impl[{config_id}]"
+    )
+
+    float_cols = ["CORE COUNT", "DEVICE KERNEL DURATION [ns]"]
+    cols = ["ATTRIBUTES"]
+
+    with mock.patch.dict(os.environ, {"CI": "false", CHUNKED_PREFILL_CHUNK_ID_ENV: str(perf_chunk)}):
+        run_device_profiler(command, subdir, device_analysis_types=["device_kernel_duration"])
+    r = post_process_ops_log(
+        subdir,
+        float_columns=float_cols,
+        columns=cols,
+        op_name="RingJointSDPADeviceOperation",
+        sum_vals=False,
+        has_signposts=False,
+    )
+
+    assert (
+        len(r["CORE COUNT"]) > 0 and len(r["DEVICE KERNEL DURATION [ns]"]) > 0
+    ), "profiler returned no SDPA ops - inner test was skipped or did not produce a kernel run"
+
+    measured_core_count = int(r["CORE COUNT"][0])
+    duration_ns = int(r["DEVICE KERNEL DURATION [ns]"].max())
+    utilization, _ = compute_chunked_prefill_perf_check_utilization(
+        MESH_CONFIG, model, chunk_size, perf_chunk, duration_ns, measured_core_count
+    )
+
+    lower = expected_util * (1 - RING_JOINT_PERF_MARGIN)
+    upper = expected_util * (1 + RING_JOINT_PERF_MARGIN)
+
+    logger.info(
+        f"Minimax3 GQA chunked final-chunk perf check {config_id}: "
         f"duration={duration_ns/1e6:.3f} ms, math_util={utilization:.2f}% "
         f"(expected {expected_util:.2f}%, band [{lower:.2f}, {upper:.2f}])"
     )

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/chain_link.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/chain_link.hpp
@@ -10,12 +10,17 @@
 #include "api/dataflow/noc_semaphore.h"
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
+#include "ttnn/operations/transformer/sdpa/device/kernels/ring_joint_chain_layout.hpp"
 
 /**
  * ChainConfig: Runtime args for store-and-forward chain configuration.
  * Mirrors the append_to_args() layout in ring_joint_sdpa_program_factory.cpp.
  */
 struct ChainConfig {
+    static constexpr uint32_t kRuntimeArgCount =
+        ttnn::operations::transformer::sdpa::ring_joint::kChainConfigRuntimeArgCount;
+    static_assert(kRuntimeArgCount == 18, "ChainConfig::read_from_args must match the shared runtime arg layout");
+
     bool participates = false;
     bool is_injector = false;
     bool is_sink = false;
@@ -35,7 +40,7 @@ struct ChainConfig {
     uint32_t mcast_num_dests = 0;
     uint32_t mcast_sender_wait = 0;
 
-    // Read 18 args in canonical order matching append_to_args()
+    // Read kRuntimeArgCount args in canonical order matching append_to_args().
     static ChainConfig read_from_args(uint32_t& argidx) {
         ChainConfig cfg;
         cfg.participates = static_cast<bool>(get_arg_val<uint32_t>(argidx++));

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -12,6 +12,9 @@
 #include "chunked_prefill_utils.hpp"
 #include "chain_link.hpp"
 #include "fused_op_receiver.hpp"
+#include "ttnn/operations/transformer/sdpa/device/kernels/ring_joint_chain_layout.hpp"
+
+namespace ring_joint = ttnn::operations::transformer::sdpa::ring_joint;
 
 template <bool has_joint_inputs, uint32_t joint_tensor_args_offset>
 constexpr uint32_t get_post_tensor_args_offset() {
@@ -162,9 +165,6 @@ void kernel_main() {
     constexpr uint32_t B = get_compile_time_arg_val(0);
     constexpr uint32_t NH = get_compile_time_arg_val(1);
     constexpr uint32_t NHK = get_compile_time_arg_val(2);
-    // K chain selection: batch chain when NHK == 1 (MLA mode), else head chain
-    // Derived from NHK to enable conditional arg layout (saves resources when unused)
-    constexpr bool k_uses_batch_chain = (NHK == 1);
     constexpr uint32_t DHt = get_compile_time_arg_val(3);
     constexpr uint32_t vDHt = get_compile_time_arg_val(4);
     constexpr uint32_t Sq_chunk_t = get_compile_time_arg_val(5);
@@ -199,6 +199,8 @@ void kernel_main() {
     constexpr uint32_t NHV = get_compile_time_arg_val(30);
     // Latent-V mode: absent V is materialized from the prefix of K tiles already in L1.
     constexpr bool v_shares_k_buffer = get_compile_time_arg_val(31) == 1;
+    constexpr bool gqa_grouped_kv = ring_joint::is_gqa_grouped_kv_head_mode(v_shares_k_buffer, NH, NHK, NHV);
+    constexpr bool k_uses_batch_chain = ring_joint::uses_shared_k_batch_chain(gqa_grouped_kv, NHK);
     // In-place latent-V (single-tile Q): the compute kernel reads V straight from K^T, so the
     // reader never materializes V. Shared with the program factory and compute kernel.
     constexpr bool kt_inplace_v = kt_inplace_v_enabled(v_shares_k_buffer, Sq_chunk_t);
@@ -241,12 +243,18 @@ void kernel_main() {
     // Head chain runtime args (always present)
     const ChainConfig head_cfg = ChainConfig::read_from_args(argidx);
 
-    // Batch chain runtime args (only present when k_uses_batch_chain / NHK == 1)
+    // Batch chain runtime args (only present for non-GQA shared-K modes).
     ChainConfig batch_cfg;  // default zero-initialized
     uint32_t max_q_per_core = 0;
     if constexpr (k_uses_batch_chain) {
         batch_cfg = ChainConfig::read_from_args(argidx);
         max_q_per_core = get_arg_val<uint32_t>(argidx++);
+    }
+    ChainConfig gqa_cfg;  // default zero-initialized
+    uint32_t gqa_max_q_per_core = 0;
+    if constexpr (gqa_grouped_kv) {
+        gqa_cfg = ChainConfig::read_from_args(argidx);
+        gqa_max_q_per_core = get_arg_val<uint32_t>(argidx++);
     }
 
     const uint32_t logical_nt = get_arg_val<uint32_t>(argidx++);
@@ -257,12 +265,27 @@ void kernel_main() {
 
     // Compile-time semaphore ids and chain flags are appended after all TensorAccessorArgs().
     // ChainLink takes semaphore IDs directly (the new Semaphore<> wrapper resolves them to L1 addrs).
-    uint32_t head_sender_semaphore_id = get_compile_time_arg_val(post_tensor_args_offset);
-    uint32_t head_receiver_semaphore_id = get_compile_time_arg_val(post_tensor_args_offset + 1);
-    uint32_t head_valid_semaphore_id = get_compile_time_arg_val(post_tensor_args_offset + 2);
-    constexpr bool head_mcast_enabled = get_compile_time_arg_val(post_tensor_args_offset + 3) == 1;
+    constexpr uint32_t chain_sender_semaphore_arg_offset = ring_joint::kChainSenderSemaphoreCompileArgOffset;
+    constexpr uint32_t chain_receiver_semaphore_arg_offset = ring_joint::kChainReceiverSemaphoreCompileArgOffset;
+    constexpr uint32_t chain_valid_semaphore_arg_offset = ring_joint::kChainValidSemaphoreCompileArgOffset;
+    constexpr uint32_t chain_mcast_enabled_arg_offset = ring_joint::kChainMcastEnabledCompileArgOffset;
+    constexpr uint32_t chain_compile_arg_count = ring_joint::kChainCompileArgCount;
 
-    // Batch chain semaphores (only present when k_uses_batch_chain / NHK == 1).
+    uint32_t head_sender_semaphore_id =
+        get_compile_time_arg_val(post_tensor_args_offset + chain_sender_semaphore_arg_offset);
+    uint32_t head_receiver_semaphore_id =
+        get_compile_time_arg_val(post_tensor_args_offset + chain_receiver_semaphore_arg_offset);
+    uint32_t head_valid_semaphore_id =
+        get_compile_time_arg_val(post_tensor_args_offset + chain_valid_semaphore_arg_offset);
+    constexpr bool head_mcast_enabled =
+        get_compile_time_arg_val(post_tensor_args_offset + chain_mcast_enabled_arg_offset) == 1;
+    constexpr uint32_t head_chain_arg_count = chain_compile_arg_count;
+    constexpr uint32_t batch_chain_arg_count = k_uses_batch_chain ? chain_compile_arg_count : 0;
+    constexpr uint32_t gqa_chain_arg_count = gqa_grouped_kv ? chain_compile_arg_count : 0;
+    constexpr uint32_t batch_chain_ct_offset = post_tensor_args_offset + head_chain_arg_count;
+    constexpr uint32_t gqa_chain_ct_offset = batch_chain_ct_offset + batch_chain_arg_count;
+
+    // Batch chain semaphores (only present for non-GQA shared-K modes).
     // Initialize to 0; will be overwritten if k_uses_batch_chain. Non-participants never use them.
     uint32_t batch_sender_semaphore_id = 0;
     uint32_t batch_receiver_semaphore_id = 0;
@@ -271,20 +294,35 @@ void kernel_main() {
     // batch_mcast_enabled: read from compile-time args if present, else false (for template instantiation)
     constexpr bool batch_mcast_enabled = []() {
         if constexpr (k_uses_batch_chain) {
-            return get_compile_time_arg_val(post_tensor_args_offset + 7) == 1;
+            return get_compile_time_arg_val(batch_chain_ct_offset + chain_mcast_enabled_arg_offset) == 1;
         }
         return false;
     }();
 
     if constexpr (k_uses_batch_chain) {
-        batch_sender_semaphore_id = get_compile_time_arg_val(post_tensor_args_offset + 4);
-        batch_receiver_semaphore_id = get_compile_time_arg_val(post_tensor_args_offset + 5);
-        batch_valid_semaphore_id = get_compile_time_arg_val(post_tensor_args_offset + 6);
+        batch_sender_semaphore_id = get_compile_time_arg_val(batch_chain_ct_offset + chain_sender_semaphore_arg_offset);
+        batch_receiver_semaphore_id =
+            get_compile_time_arg_val(batch_chain_ct_offset + chain_receiver_semaphore_arg_offset);
+        batch_valid_semaphore_id = get_compile_time_arg_val(batch_chain_ct_offset + chain_valid_semaphore_arg_offset);
     }
 
-    constexpr uint32_t head_chain_arg_count = 4;
-    constexpr uint32_t batch_chain_arg_count = k_uses_batch_chain ? 4 : 0;
-    constexpr uint32_t cb_arg_offset = post_tensor_args_offset + head_chain_arg_count + batch_chain_arg_count;
+    uint32_t gqa_sender_semaphore_id = 0;
+    uint32_t gqa_receiver_semaphore_id = 0;
+    uint32_t gqa_valid_semaphore_id = 0;
+    constexpr bool gqa_mcast_enabled = []() {
+        if constexpr (gqa_grouped_kv) {
+            return get_compile_time_arg_val(gqa_chain_ct_offset + chain_mcast_enabled_arg_offset) == 1;
+        }
+        return false;
+    }();
+    if constexpr (gqa_grouped_kv) {
+        gqa_sender_semaphore_id = get_compile_time_arg_val(gqa_chain_ct_offset + chain_sender_semaphore_arg_offset);
+        gqa_receiver_semaphore_id = get_compile_time_arg_val(gqa_chain_ct_offset + chain_receiver_semaphore_arg_offset);
+        gqa_valid_semaphore_id = get_compile_time_arg_val(gqa_chain_ct_offset + chain_valid_semaphore_arg_offset);
+    }
+
+    constexpr uint32_t cb_arg_offset =
+        post_tensor_args_offset + head_chain_arg_count + batch_chain_arg_count + gqa_chain_arg_count;
     constexpr uint32_t cb_q_in = get_compile_time_arg_val(cb_arg_offset + 0);
     constexpr uint32_t cb_k_in = get_compile_time_arg_val(cb_arg_offset + 1);
     constexpr uint32_t cb_v_in = get_compile_time_arg_val(cb_arg_offset + 2);
@@ -299,7 +337,7 @@ void kernel_main() {
 
     Noc noc;
 
-    // Head chain (head-level): matches (batch, head), used by V and optionally K
+    // Head chain (query-head level): MHA uses it for K/V; separate-V shared-K uses it for V only.
     ChainLink<head_mcast_enabled, true> head_chain(
         head_cfg.participates,
         head_cfg.is_injector,
@@ -323,7 +361,7 @@ void kernel_main() {
         head_cfg.head,
         head_cfg.next_core_q_chunks);
 
-    // Batch chain (batch-level): matches batch only, used by K when NHK == 1 (MLA mode)
+    // Batch chain (batch-level): matches batch only, used by K in non-GQA shared-K modes.
     ChainLink<batch_mcast_enabled, false> batch_chain(
         batch_cfg.participates,
         batch_cfg.is_injector,
@@ -347,12 +385,44 @@ void kernel_main() {
         0,  // chain_head unused for batch-level chain
         batch_cfg.next_core_q_chunks);
 
-    // Non-shared V uses the head chain. Latent-V reads V from K and does not need a separate V chain.
-    auto& v_chain = head_chain;
+    // GQA grouped chain (head-level where head means KV head): used by both K and V in GQA_GROUPED_KV.
+    ChainLink<gqa_mcast_enabled, true> gqa_chain(
+        gqa_cfg.participates,
+        gqa_cfg.is_injector,
+        gqa_cfg.is_sink,
+        gqa_sender_semaphore_id,
+        gqa_receiver_semaphore_id,
+        gqa_valid_semaphore_id,
+        gqa_cfg.signal_target_x<gqa_mcast_enabled>(),
+        gqa_cfg.signal_target_y<gqa_mcast_enabled>(),
+        gqa_cfg.next_physical_x,
+        gqa_cfg.next_physical_y,
+        gqa_cfg.mcast_start_x,
+        gqa_cfg.mcast_start_y,
+        gqa_cfg.mcast_end_x,
+        gqa_cfg.mcast_end_y,
+        gqa_cfg.mcast_num_dests,
+        gqa_cfg.mcast_sender_wait,
+        v_chunk_tiles,
+        v_tile_bytes,
+        gqa_cfg.batch,
+        gqa_cfg.head,
+        gqa_cfg.next_core_q_chunks);
 
-    // K uses batch chain when NHK == 1 (MLA), else head chain (compile-time IIFE selection)
+    // Non-shared V uses the head chain, except GQA where K and V share the grouped KV-head chain.
+    auto& v_chain = [&]() -> auto& {
+        if constexpr (gqa_grouped_kv) {
+            return gqa_chain;
+        } else {
+            return head_chain;
+        }
+    }();
+
+    // K uses the grouped GQA chain, the batch chain for shared-K modes, otherwise the query-head chain.
     auto& k_chain = [&]() -> auto& {
-        if constexpr (k_uses_batch_chain) {
+        if constexpr (gqa_grouped_kv) {
+            return gqa_chain;
+        } else if constexpr (k_uses_batch_chain) {
             return batch_chain;
         } else {
             return head_chain;
@@ -453,12 +523,19 @@ void kernel_main() {
             }
         }
 
-        // When K mcast is enabled, loop max_q_per_core times to stay synchronized with injector
-        // Cores with less work do padded iterations (K mcast sync only, no real work)
-        const uint32_t loop_q_count = (k_uses_batch_chain && batch_mcast_enabled) ? max_q_per_core : q_per_core;
+        // When K/V mcast is enabled, loop the per-chain max so receivers with less real Q work
+        // still participate in padded multicast handshakes without pushing compute-visible data.
+        uint32_t loop_q_count = q_per_core;
+        if constexpr (k_uses_batch_chain && batch_mcast_enabled) {
+            loop_q_count = max_q_per_core;
+        }
+        if constexpr (gqa_grouped_kv && gqa_mcast_enabled) {
+            loop_q_count = gqa_max_q_per_core;
+        }
+        uint32_t gqa_group_q_iter = 0;
 
         for (uint32_t q_iter = 0; q_iter < loop_q_count; ++q_iter) {
-            // Check if this is a real iteration (has actual work) or padded (K mcast sync only)
+            // Check if this is a real iteration or only padded chain/mcast synchronization.
             const bool is_padded_iter = (q_iter >= q_per_core);
 
             // Calculate global_q_chunk for all iterations (including padded).
@@ -470,8 +547,21 @@ void kernel_main() {
             const uint32_t nb = global_q_chunk / (NH * num_q_chunks);
             const uint32_t nq = (global_q_chunk % (NH * num_q_chunks)) / num_q_chunks;
             const uint32_t q_chunk = global_q_chunk % num_q_chunks;
+            const uint32_t nk = nq / q_heads_per_k;
             const auto q_row_start_tile = q_chunk * Sq_chunk_t;
             const bool is_joint_q = has_joint_q ? (q_chunk >= num_local_q_chunks) : false;
+            const uint32_t q_iter_local = [&]() {
+                if constexpr (gqa_grouped_kv) {
+                    return gqa_group_q_iter;
+                } else {
+                    return q_iter;
+                }
+            }();
+            if constexpr (gqa_grouped_kv) {
+                if (nb == gqa_cfg.batch && nk == gqa_cfg.head) {
+                    gqa_group_q_iter++;
+                }
+            }
 
             const bool balanced_skip_q = q_chunk < half_sequence && is_balanced && ring_index < ring_id;
 
@@ -479,7 +569,7 @@ void kernel_main() {
             // nothing (no Q, no K/V) — compute's normalize-only path on the last ring iter does
             // not read Q (normalize uses only restored sum/out).
             // Skip logic applies to all iterations (including padded) so injector and receivers
-            // make the same skip decisions, keeping K mcast sync aligned.
+            // make the same skip decisions, keeping chain/mcast sync aligned.
             if (balanced_skip_q) {
                 continue;
             }
@@ -494,9 +584,6 @@ void kernel_main() {
                     q_end_seq_tile = Lt;
                 }
             }
-
-            // Iteration counter for chain forwarding decisions
-            const uint32_t q_iter_local = q_iter;
 
             // When q_per_core == 1, Q is identical across ring iterations: compute keeps it
             // fronted in the CB, so we only need to read it once on the first active ring iteration.
@@ -525,7 +612,6 @@ void kernel_main() {
                 // Default to local/gathered KV; override below for joint KV when applicable.
                 Slice k_slice;
                 uint32_t end_seq_tile;
-                const uint32_t nk = nq / q_heads_per_k;
                 // Local KV reads the indexed cache slot; gathered KV is at slot 0 of the scratch buffer.
                 const uint32_t kv_batch = indexed_kv_cache ? kv_cache_batch_idx : nb;
                 const uint32_t gathered_kv_batch = indexed_kv_cache ? 0 : nb;
@@ -548,8 +634,15 @@ void kernel_main() {
                 }
 
                 // K: either read locally (injector or not participant) or receive from chain
+                const uint32_t k_chain_head = [&]() {
+                    if constexpr (gqa_grouped_kv) {
+                        return nk;
+                    } else {
+                        return nq;
+                    }
+                }();
                 CircularBuffer cb_k(cb_k_in);
-                if constexpr (k_uses_batch_chain && batch_mcast_enabled) {
+                if constexpr ((k_uses_batch_chain && batch_mcast_enabled) || (gqa_grouped_kv && gqa_mcast_enabled)) {
                     // Ensures that compute has completed with the previous K chunk before we overwrite the buffer with
                     // the next K chunk for mcast.
                     const uint32_t reserve_tiles = is_padded_iter ? 2 * k_chunk_tiles : k_chunk_tiles;
@@ -558,7 +651,7 @@ void kernel_main() {
                     cb_k.reserve_back(k_chunk_tiles);
                 }
                 uint32_t cb_k_start_address = cb_k.get_write_ptr();
-                if (k_chain.should_receive(nb, nq)) {
+                if (k_chain.should_receive(nb, k_chain_head)) {
                     k_chain.receive(noc);
                 } else {
                     // Injector or non-participant: read K from DRAM. Dispatch directly so
@@ -584,17 +677,26 @@ void kernel_main() {
                 }
 
                 // Forward K chunk via chain (uses K's data size explicitly)
-                if (k_chain.should_forward(nb, nq, q_iter_local)) {
+                if (k_chain.should_forward(nb, k_chain_head, q_iter_local)) {
                     k_chain.forward(noc, cb_k_start_address, k_chunk_tiles, k_tile_bytes);
                 }
 
-                // Skip Q and compute-visible pushes for padded K-mcast iterations.
+                // Skip Q and compute-visible pushes for padded mcast iterations.
                 // Note: push_back is intentionally skipped — without it, the write pointer
                 // doesn't advance, so reserve_back returns the same address each iteration.
                 // This lets the buffer act as a reusable staging area for the mcast.
                 if (is_padded_iter) {
-                    // Padded iterations participate in the chain handshake but do not generate
-                    // compute-visible K/V. In latent-V mode, only the K^T segment is transported.
+                    // Padded GQA receivers must also receive V, because the row injector multicasts
+                    // both K and V and waits for every receiver's ready signal. The data remains
+                    // staging-only because we intentionally do not push it to compute.
+                    if constexpr (gqa_grouped_kv && gqa_mcast_enabled) {
+                        const uint32_t nv = nq / q_heads_per_v;
+                        CircularBuffer cb_v(cb_v_in);
+                        cb_v.reserve_back(2 * v_cb_entry_tiles);
+                        if (v_chain.should_receive(nb, nv)) {
+                            v_chain.receive(noc);
+                        }
+                    }
                     continue;
                 }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/ring_joint_chain_layout.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/ring_joint_chain_layout.hpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+namespace ttnn::operations::transformer::sdpa::ring_joint {
+
+constexpr uint32_t kChainConfigRuntimeArgCount = 18;
+
+constexpr uint32_t kChainSenderSemaphoreCompileArgOffset = 0;
+constexpr uint32_t kChainReceiverSemaphoreCompileArgOffset = 1;
+constexpr uint32_t kChainValidSemaphoreCompileArgOffset = 2;
+constexpr uint32_t kChainSemaphoreCompileArgCount = 3;
+constexpr uint32_t kChainMcastEnabledCompileArgOffset = kChainSemaphoreCompileArgCount;
+constexpr uint32_t kChainCompileArgCount = kChainSemaphoreCompileArgCount + 1;
+
+// Tensor K/V GQA: fewer K/V heads than Q heads, one K/V head shared by each query-head group.
+// Latent-V modes are excluded because V is packed into K and uses the existing shared-K path.
+constexpr bool is_gqa_grouped_kv_head_mode(bool v_shares_k_buffer, uint32_t nqh, uint32_t nkh, uint32_t nvh) {
+    return !v_shares_k_buffer && (nkh == nvh) && (nkh > 0) && (nkh < nqh) && (nqh % nkh == 0);
+}
+
+// The batch chain is only for non-GQA shared-K cases (separate-V shared-K and latent-V MLA).
+// GQA with one local KV head still has NHK == 1, but it must use grouped KV-head transport.
+constexpr bool uses_shared_k_batch_chain(bool gqa_grouped_kv, uint32_t nkh) { return !gqa_grouped_kv && (nkh == 1); }
+
+}  // namespace ttnn::operations::transformer::sdpa::ring_joint

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
@@ -14,6 +14,7 @@
 #include "ttnn/operations/ccl/ccl_op_fusion.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"
 #include "ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_device_operation.hpp"
+#include "ttnn/operations/transformer/sdpa/device/kernels/ring_joint_chain_layout.hpp"
 #include "ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation_types.hpp"
 #include "ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.hpp"
 #include "ttnn/operations/transformer/sdpa/device/sdpa_perf_model.hpp"
@@ -26,6 +27,39 @@ namespace ttnn::prim {
 using namespace experimental::ccl;
 
 namespace {
+
+namespace ring_joint = ttnn::operations::transformer::sdpa::ring_joint;
+
+// Chunked causal prefill does not have the same valid-pair geometry as a full causal
+// Sq x Sk attention window. A new Q chunk attends to all prior K/V tokens as a full
+// rectangle, then attends to its own chunk causally as a triangle:
+//
+//   valid_pairs_global = q_chunk * prefix_k + q_chunk * (q_chunk + 1) / 2
+//
+// Ring-joint shards Q rows across the ring, while every shard still sees the same
+// global K prefix, so each device models 1 / ring_size of the global valid pairs.
+// The generic SDPA causal model uses Sq * Sk / 2, which undercounts late chunked
+// prefill chunks where most work is the prefix rectangle.
+int compute_chunked_causal_sdpa_ideal_cycles(
+    uint32_t batch_size,
+    uint32_t num_heads_q,
+    uint32_t q_global,
+    uint32_t prefix_k_global,
+    uint32_t ring_size,
+    uint32_t DH,
+    uint32_t DV,
+    tt::tt_metal::MathFidelity math_fidelity,
+    int num_cores) {
+    if (ring_size == 0 || num_cores <= 0 || q_global == 0) {
+        return 0;
+    }
+
+    const double q = static_cast<double>(q_global);
+    const double prefix_k = static_cast<double>(prefix_k_global);
+    const double valid_pairs_per_device = (q * prefix_k + (q * (q + 1.0) / 2.0)) / static_cast<double>(ring_size);
+    return operations::transformer::sdpa::compute_sdpa_ideal_cycles_for_valid_pairs(
+        batch_size, num_heads_q, valid_pairs_per_device, DH, DV, math_fidelity, num_cores);
+}
 
 void validate_ring_joint_all_gather_on_program_cache_miss(
     const ttnn::experimental::prim::RingAttentionAllGatherAsyncParams& operation_attributes,
@@ -478,12 +512,33 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
         k_shape[2],
         v_shape[2]);
 
-    TT_FATAL(
-        has_latent_v || NQH == NVH,
-        "Tensor-V mode requires Q num_heads to equal V num_heads. Got Q: {}, V: {}",
-        NQH,
-        NVH);
-    TT_FATAL(NKH == NVH || NKH == 1, "K num_heads must be equal to V num_heads or 1. Got K: {}, V: {}", NKH, NVH);
+    if (!has_latent_v) {
+        const bool tensor_mha = (NQH == NKH) && (NKH == NVH);
+        const bool tensor_separate_v_shared_k = (NKH == 1) && (NVH == NQH);
+        const bool tensor_gqa_grouped_kv =
+            ring_joint::is_gqa_grouped_kv_head_mode(/*v_shares_k_buffer=*/false, NQH, NKH, NVH);
+
+        TT_FATAL(
+            tensor_mha || tensor_separate_v_shared_k || tensor_gqa_grouped_kv,
+            "Unsupported tensor-V head relationship. Expected MHA (NQH == NKH == NVH), separate-V shared-K "
+            "(NKH == 1 && NVH == NQH), or GQA (NKH == NVH < NQH && NQH % NKH == 0). Got NQH: {}, "
+            "NKH: {}, NVH: {}",
+            NQH,
+            NKH,
+            NVH);
+        TT_FATAL(
+            !has_joint_tensors || !tensor_gqa_grouped_kv,
+            "Ring joint SDPA GQA with joint tensors is unsupported. Got NQH: {}, NKH: {}, NVH: {}",
+            NQH,
+            NKH,
+            NVH);
+    } else {
+        TT_FATAL(
+            NKH == NVH || NKH == 1,
+            "K num_heads must be equal to V num_heads or 1 in latent-V mode. Got K: {}, V: {}",
+            NKH,
+            NVH);
+    }
 
     // Validate chunk sizes if program config is provided
 
@@ -658,9 +713,21 @@ tt::tt_metal::operation::OpPerformanceModelGeneral<Tensors> RingJointSDPADeviceO
     const uint32_t NQH = q_shape[1];
     const uint32_t N_local = q_shape[2];
     const uint32_t N_global = gathered_k_shape[2];
+    const bool has_joint_tensors =
+        tensor_args.joint_q.has_value() || tensor_args.joint_k.has_value() || tensor_args.joint_v.has_value();
     const uint32_t L = tensor_args.joint_q.has_value() ? tensor_args.joint_q.value().logical_shape()[2] : 0;
     const uint32_t DH = q_shape[3];
     const uint32_t DV = tensor_args.v_head_dim(args.latent_v_head_dim);
+
+    if (args.is_causal && args.has_kv_pad_rotation() && !has_joint_tensors) {
+        const uint32_t logical_n = static_cast<uint32_t>(args.logical_n);
+        const uint32_t prefix_k = args.kv_actual_isl.value();
+        const uint32_t new_q_global = logical_n - prefix_k;
+        const uint32_t ring_size = static_cast<uint32_t>(args.ring_size);
+        int ideal_cycles = compute_chunked_causal_sdpa_ideal_cycles(
+            B, NQH, new_q_global, prefix_k, ring_size, DH, DV, fidelity, grid.x * grid.y);
+        return operation::OpPerformanceModelGeneral<Tensors>(input_tensors, output_tensors, ideal_cycles);
+    }
 
     // RingJointSDPA: local Q and joint Q attend to (gathered K + joint K)
     // Total Q dimension: N_local + L, Total K dimension: N_global + L

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -4,6 +4,7 @@
 
 #include "ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.hpp"
 #include "kernels/dataflow/chunked_prefill_utils.hpp"
+#include "ttnn/operations/transformer/sdpa/device/kernels/ring_joint_chain_layout.hpp"
 #include "ttnn/operations/transformer/sdpa/device/ring_id_sequencer.hpp"
 #include "ttnn/operations/transformer/sdpa/device/sdpa_subblock_utils.hpp"
 
@@ -34,6 +35,7 @@ using namespace tt::tt_metal;
 namespace {
 
 namespace ag_rt = ttnn::ring_attention_all_gather_async_detail;
+namespace ring_joint = ttnn::operations::transformer::sdpa::ring_joint;
 
 // Host-side summary of which ring-loop iterations do useful SDPA work. Bits are indexed by ring_iter,
 // not ring_id; kernels still advance their sync/ring-id sequence on every iter before checking the mask.
@@ -132,8 +134,12 @@ constexpr uint32_t kComputeGlobalQEndArg = 1;
 constexpr uint32_t kReaderBaseBufferArgCount = 5;
 constexpr uint32_t kReaderJointBufferArgCount = 3;
 constexpr uint32_t kReaderQWorkArgCount = 3;
-constexpr uint32_t kRingJointChainConfigArgCount = 18;
+constexpr uint32_t kRingJointChainConfigArgCount = ring_joint::kChainConfigRuntimeArgCount;
+constexpr uint32_t kRingJointChainCompileArgCount = ring_joint::kChainCompileArgCount;
+constexpr uint32_t kRingJointChainSemaphoreCompileArgCount = ring_joint::kChainSemaphoreCompileArgCount;
+constexpr uint32_t kRingJointChainMcastEnabledCompileArgOffset = ring_joint::kChainMcastEnabledCompileArgOffset;
 constexpr uint32_t kReaderBatchChainExtraArgCount = 1;
+constexpr uint32_t kReaderGQAChainExtraArgCount = 1;
 constexpr uint32_t kWriterBaseArgCount = 5;
 constexpr uint32_t kComputeRingSequencerArgCount = 6;
 
@@ -417,8 +423,12 @@ RingJointRuntimeArgLayout get_runtime_arg_layout(
     const auto& k_shape = tensor_args.gathered_k.logical_shape();
     const bool has_joint_tensors = tensor_args.joint_q.has_value();
     const uint32_t L = has_joint_tensors ? tensor_args.joint_q->logical_shape()[2] : 0;
+    const uint32_t NH = tensor_args.input_q.logical_shape()[1];
     const uint32_t NHK = k_shape[1];
-    const bool k_uses_batch_chain = (NHK == 1);
+    const uint32_t NHV = tensor_args.v_num_heads();
+    const bool v_shares_k_buffer = tensor_args.has_latent_v();
+    const bool gqa_grouped_kv = ring_joint::is_gqa_grouped_kv_head_mode(v_shares_k_buffer, NH, NHK, NHV);
+    const bool k_uses_batch_chain = ring_joint::uses_shared_k_batch_chain(gqa_grouped_kv, NHK);
 
     RingJointRuntimeArgLayout layout;
     layout.grid_size = args.program_config.has_value() ? args.program_config->compute_with_storage_grid_size
@@ -427,9 +437,10 @@ RingJointRuntimeArgLayout get_runtime_arg_layout(
     const uint32_t joint_buffer_args = (L != 0) ? kReaderJointBufferArgCount : 0;
     const uint32_t batch_chain_args =
         k_uses_batch_chain ? (kRingJointChainConfigArgCount + kReaderBatchChainExtraArgCount) : 0;
+    const uint32_t gqa_chain_args = gqa_grouped_kv ? (kRingJointChainConfigArgCount + kReaderGQAChainExtraArgCount) : 0;
     layout.reader_kv_cache_batch_idx = kReaderBaseBufferArgCount + joint_buffer_args + 2;
     layout.reader_logical_nt = kReaderBaseBufferArgCount + joint_buffer_args + kReaderQWorkArgCount +
-                               kRingJointChainConfigArgCount + batch_chain_args;
+                               kRingJointChainConfigArgCount + batch_chain_args + gqa_chain_args;
     layout.reader_active_ring_iter_mask = layout.reader_logical_nt + 1;
     layout.writer_logical_nt = kWriterBaseArgCount;
     layout.writer_active_ring_iter_mask = layout.writer_logical_nt + 1;
@@ -780,6 +791,8 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     const uint32_t kv_cache_batch_idx = args.kv_cache_batch_idx.value_or(0);
     const uint32_t L = has_joint_tensors ? joint_tensor_q->logical_shape()[2] : 0;
     const uint32_t vDH = tensor_args.v_head_dim(args.latent_v_head_dim);
+    const bool gqa_grouped_kv = ring_joint::is_gqa_grouped_kv_head_mode(v_shares_k_buffer, NH, NHK, NHV);
+    const bool k_uses_batch_chain = ring_joint::uses_shared_k_batch_chain(gqa_grouped_kv, NHK);
 
     const uint32_t q_local_padded_Nt = q_local_padded_N / tt::constants::TILE_HEIGHT;
     const uint32_t kv_local_padded_Nt = kv_local_padded_N / tt::constants::TILE_HEIGHT;
@@ -1040,12 +1053,16 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     const uint32_t out_in0_num_subblocks = Sq_chunk_t / out_out_subblock_h;
     const uint32_t out_in1_num_subblocks = vDHt / out_out_subblock_w;
 
-    // Streaming: shrink cb_out to a 2-slot ping-pong (see sdpa_subblock_utils.hpp). Only safe
-    // when Phase-2's save_to_staging branch can't fire — i.e. `is_last_k && !is_last_ring_iter
-    // && q_per_core > 1` is always false. That branch packs at offset qktv_h*vDHt and would
-    // overrun the 2*qktv_h*vDHt buffer on its 2nd Q chunk.
-    const bool streaming_shrink_safe =
-        use_streaming_compute && (args.all_gather_operation_attributes.ring_size == 1 || max_q_per_core == 1);
+    // Streaming: shrink cb_out to a 2-slot ping-pong (see sdpa_subblock_utils.hpp), unless either:
+    //  - Phase-2's save_to_staging branch can fire (packs at offset qktv_h*vDHt, overruns the
+    //    2*qktv_h*vDHt buffer on the 2nd Q chunk): gated by ring_size==1 || max_q_per_core==1.
+    //  - the full Sq_chunk_t*vDHt output doesn't fit in 2 row groups: Phase-2 reserves it in a
+    //    single reserve_back, which then blocks forever (deadlock seen at q_chunk=256 causal).
+    // Otherwise keep the full-size cb_out (the default path).
+    const bool streaming_shrink_fits = Sq_chunk_t <= 2 * writer_out_row_group_h;
+    const bool streaming_shrink_safe = use_streaming_compute &&
+                                       (args.all_gather_operation_attributes.ring_size == 1 || max_q_per_core == 1) &&
+                                       streaming_shrink_fits;
     if (streaming_shrink_safe) {
         out0_t = detail::streaming_cb_out_tiles(out_out_subblock_h, out_out_subblock_w, dst_size, Sq_chunk_t, vDHt);
         TT_FATAL(
@@ -1209,31 +1226,39 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         }
 
         void append_to_compile_args(std::vector<uint32_t>& args) const {
+            const size_t start_size = args.size();
             args.push_back(sender_id);
             args.push_back(receiver_id);
             args.push_back(valid_id);
+            TT_FATAL(
+                args.size() == start_size + kRingJointChainSemaphoreCompileArgCount,
+                "RingJoint ChainSemaphores expected to append {} compile-time args, appended {}",
+                kRingJointChainSemaphoreCompileArgCount,
+                args.size() - start_size);
         }
     };
 
-    // K chain selection: batch chain when NHK == 1 (MLA mode), else head chain
-    // Computed early to gate resource allocation
-    const bool k_uses_batch_chain = (NHK == 1);
-
-    const auto head_sems = ChainSemaphores::create(desc, core_grid_set);  // head chain (V, optionally K)
-    // Only create batch semaphores for MLA mode (NHK == 1)
+    const auto head_sems = ChainSemaphores::create(desc, core_grid_set);  // head chain (MHA or separate-V V)
     std::optional<ChainSemaphores> batch_sems;
     if (k_uses_batch_chain) {
-        batch_sems = ChainSemaphores::create(desc, core_grid_set);  // batch chain (K in MLA mode)
+        batch_sems = ChainSemaphores::create(desc, core_grid_set);  // batch chain (shared K)
+    }
+    std::optional<ChainSemaphores> gqa_sems;
+    if (gqa_grouped_kv) {
+        gqa_sems = ChainSemaphores::create(desc, core_grid_set);  // grouped K/V chain
     }
 
     // Append semaphore ids to reader compile-time args (must match reader kernel expectations)
-    // Kernel derives k_uses_batch_chain from NHK, so batch chain args are conditionally present
     const auto sem_args_offset = reader_compile_time_args.size();
     head_sems.append_to_compile_args(reader_compile_time_args);
     reader_compile_time_args.push_back(0);  // head_mcast_enabled placeholder (patched after chain construction)
     if (k_uses_batch_chain) {
         batch_sems->append_to_compile_args(reader_compile_time_args);
         reader_compile_time_args.push_back(0);  // batch_mcast_enabled placeholder (patched after chain construction)
+    }
+    if (gqa_grouped_kv) {
+        gqa_sems->append_to_compile_args(reader_compile_time_args);
+        reader_compile_time_args.push_back(0);  // gqa_mcast_enabled placeholder (patched after chain construction)
     }
 
     std::vector<uint32_t> writer_compile_time_args = {
@@ -1491,7 +1516,7 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
 
         // Chain scope: batch is always used; head distinguishes head-level vs batch-level
         uint32_t batch = 0;
-        uint32_t head = 0;  // 0 for batch-level chains (K in MLA mode)
+        uint32_t head = 0;  // 0 for batch-level shared-K chains
 
         // Linear chain topology
         CoreCoord prev_physical = CoreCoord{0, 0};
@@ -1535,8 +1560,9 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     };
 
     std::vector<CoreWork> core_work(num_cores);
-    std::vector<ChainConfig> head_chain_configs(num_cores);   // V chain (head-level), optionally K in non-MLA
-    std::vector<ChainConfig> batch_chain_configs(num_cores);  // K chain (batch-level) in MLA mode
+    std::vector<ChainConfig> head_chain_configs(num_cores);   // MHA K/V chain or separate-V V chain
+    std::vector<ChainConfig> batch_chain_configs(num_cores);  // Shared-K chain for separate-V/latent modes
+    std::vector<ChainConfig> gqa_chain_configs(num_cores);    // Grouped K/V chain for GQA_GROUPED_KV
     const uint32_t total_heads = B * NH;
     std::vector<std::vector<HeadSegmentRef>> head_segments(total_heads);
 
@@ -1623,7 +1649,8 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
                                  uint32_t batch,
                                  uint32_t head,
                                  std::vector<ChainConfig>& chain_configs,
-                                 const std::vector<CoreWork>& core_work) -> bool {
+                                 const std::vector<CoreWork>& core_work,
+                                 bool require_single_head_injector = true) -> bool {
         if (chain_segs.size() < 2) {
             return false;
         }
@@ -1632,7 +1659,7 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
             if (core_work[chain_segs[idx].first].global_q_count == 0) {
                 continue;
             }
-            if (core_work[chain_segs[idx].first].head_work.size() == 1) {
+            if (!require_single_head_injector || core_work[chain_segs[idx].first].head_work.size() == 1) {
                 injector_pos = idx;
                 break;
             }
@@ -1660,21 +1687,118 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         return true;
     };
 
-    // Build head chains (V chain): one per (batch, head) pair that spans >= 2 cores.
-    for (uint32_t head_id = 0; head_id < static_cast<uint32_t>(head_segments.size()); ++head_id) {
-        const auto& segs = head_segments[head_id];
-        if (segs.size() < 2) {
-            continue;
+    struct RowWideChainMcastSelection {
+        uint32_t row = 0;
+        uint32_t injector_idx = 0;
+        uint32_t max_q = 0;
+        uint32_t num_receivers = 0;
+        CoreCoord injector_physical = CoreCoord{0, 0};
+        CoreCoord phys_start = CoreCoord{0, 0};
+        CoreCoord phys_end = CoreCoord{0, 0};
+    };
+
+    // Pick a row-wide multicast injector among max-work cores. The recent-column FIFO spreads injectors across
+    // physical X columns for NoC diversity; correctness still requires a max-work injector so padded loops never
+    // read K/V beyond the real q-iteration span.
+    auto select_row_wide_chain_mcast =
+        [&](uint32_t row, std::deque<uint32_t>& recent_cols) -> std::optional<RowWideChainMcastSelection> {
+        if (recent_cols.size() >= grid_size.x) {
+            recent_cols.pop_front();
         }
-        std::vector<ChainSegment> chain_segs;
-        chain_segs.reserve(segs.size());
-        for (const auto& seg : segs) {
-            chain_segs.emplace_back(seg.core_idx, core_work[seg.core_idx].head_work[seg.head_work_index].q_chunk_count);
+
+        uint32_t row_max_q = 0;
+        for (uint32_t col = 0; col < grid_size.x; ++col) {
+            const uint32_t ci = row * grid_size.x + col;
+            row_max_q = std::max(row_max_q, core_work[ci].global_q_count);
         }
-        build_linear_chain(chain_segs, head_id / NH, head_id % NH, head_chain_configs, core_work);
+        if (row_max_q == 0) {
+            return std::nullopt;
+        }
+
+        uint32_t injector_idx = std::numeric_limits<uint32_t>::max();
+        for (uint32_t col = 0; col < grid_size.x; ++col) {
+            const uint32_t ci = row * grid_size.x + col;
+            if (core_work[ci].global_q_count != row_max_q) {
+                continue;
+            }
+            const uint32_t phys_x = core_work[ci].physical_core.x;
+            const bool excluded = std::find(recent_cols.begin(), recent_cols.end(), phys_x) != recent_cols.end();
+            if (!excluded) {
+                injector_idx = ci;
+                break;
+            }
+            if (injector_idx == std::numeric_limits<uint32_t>::max()) {
+                injector_idx = ci;
+            }
+        }
+
+        TT_FATAL(
+            injector_idx != std::numeric_limits<uint32_t>::max(),
+            "RingJoint row mcast failed to find a max-work injector for row {}",
+            row);
+        const CoreCoord injector_physical = core_work[injector_idx].physical_core;
+        recent_cols.push_back(injector_physical.x);
+
+        return RowWideChainMcastSelection{
+            .row = row,
+            .injector_idx = injector_idx,
+            .max_q = row_max_q,
+            .num_receivers = grid_size.x - 1,
+            .injector_physical = injector_physical,
+            .phys_start = device->worker_core_from_logical_core(CoreCoord{0, row}),
+            .phys_end = device->worker_core_from_logical_core(CoreCoord{grid_size.x - 1, row}),
+        };
+    };
+
+    auto configure_row_wide_chain_mcast = [&](const RowWideChainMcastSelection& selection,
+                                              uint32_t batch,
+                                              uint32_t head,
+                                              std::vector<ChainConfig>& chain_configs,
+                                              std::vector<uint32_t>& chain_max_q) {
+        for (uint32_t col = 0; col < grid_size.x; ++col) {
+            const uint32_t ci = selection.row * grid_size.x + col;
+            auto& cfg = chain_configs[ci];
+            cfg.participates = true;
+            cfg.batch = batch;
+            cfg.head = head;
+            cfg.prev_physical = CoreCoord{0, 0};
+            cfg.next_physical = CoreCoord{0, 0};
+            cfg.mcast_start = selection.phys_start;
+            cfg.mcast_end = selection.phys_end;
+            cfg.injector_physical = selection.injector_physical;
+            cfg.is_injector = (ci == selection.injector_idx);
+            cfg.is_sink = !cfg.is_injector;
+            if (cfg.is_injector) {
+                cfg.mcast_num_dests = selection.num_receivers;
+                cfg.mcast_sender_wait = selection.num_receivers;
+                cfg.next_core_q_chunks = selection.max_q;
+            } else {
+                cfg.mcast_num_dests = 0;
+                cfg.mcast_sender_wait = 0;
+                cfg.next_core_q_chunks = 0;
+            }
+            chain_max_q[ci] = selection.max_q;
+        }
+    };
+
+    // Build head chains for MHA and separate-V shared-K. GQA uses KV-head-grouped chains instead.
+    if (!gqa_grouped_kv) {
+        for (uint32_t head_id = 0; head_id < static_cast<uint32_t>(head_segments.size()); ++head_id) {
+            const auto& segs = head_segments[head_id];
+            if (segs.size() < 2) {
+                continue;
+            }
+            std::vector<ChainSegment> chain_segs;
+            chain_segs.reserve(segs.size());
+            for (const auto& seg : segs) {
+                chain_segs.emplace_back(
+                    seg.core_idx, core_work[seg.core_idx].head_work[seg.head_work_index].q_chunk_count);
+            }
+            build_linear_chain(chain_segs, head_id / NH, head_id % NH, head_chain_configs, core_work);
+        }
     }
 
-    // Third pass: Check multicast eligibility and configure mcast for eligible chains
+    // Check query-head chain multicast eligibility and configure mcast for eligible chains.
     uint32_t mcast_chains = 0;
     {
         struct McastCandidate {
@@ -1861,12 +1985,108 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
             static_cast<uint32_t>(candidates.size()));
     }
 
-    // Build batch chains (K chain): one per batch when NHK == 1 (MLA case).
+    uint32_t gqa_grouped_chains = 0;
+    uint32_t gqa_grouped_participant_cores = 0;
+    uint32_t gqa_local_fallback_cores = 0;
+    bool gqa_mcast_enabled = false;
+    std::string gqa_mcast_fallback_reason;
+    std::vector<uint32_t> gqa_chain_max_q(num_cores, 0);  // per-core loop-padding count
+    if (gqa_grouped_kv) {
+        const uint32_t q_heads_per_kv = NH / NHK;
+        std::vector<std::vector<ChainSegment>> kv_group_segments(B * NHK);
+
+        for (uint32_t ci = 0; ci < num_cores; ++ci) {
+            if (core_work[ci].global_q_count == 0) {
+                continue;
+            }
+
+            bool has_single_group = false;
+            bool spans_multiple_groups = false;
+            uint32_t single_group_id = 0;
+            uint32_t q_chunk_count = 0;
+            for (const auto& hw : core_work[ci].head_work) {
+                const uint32_t kv_head = hw.head / q_heads_per_kv;
+                const uint32_t group_id = hw.batch * NHK + kv_head;
+                if (!has_single_group) {
+                    has_single_group = true;
+                    single_group_id = group_id;
+                } else if (single_group_id != group_id) {
+                    spans_multiple_groups = true;
+                    break;
+                }
+                q_chunk_count += hw.q_chunk_count;
+            }
+
+            if (has_single_group && !spans_multiple_groups) {
+                kv_group_segments[single_group_id].emplace_back(ci, q_chunk_count);
+                gqa_grouped_participant_cores++;
+            } else {
+                gqa_local_fallback_cores++;
+            }
+        }
+
+        for (uint32_t group_id = 0; group_id < static_cast<uint32_t>(kv_group_segments.size()); ++group_id) {
+            const auto& chain_segs = kv_group_segments[group_id];
+            if (chain_segs.size() < 2) {
+                continue;
+            }
+            const uint32_t batch = group_id / NHK;
+            const uint32_t kv_head = group_id % NHK;
+            if (build_linear_chain(chain_segs, batch, kv_head, gqa_chain_configs, core_work, false)) {
+                gqa_grouped_chains++;
+            }
+        }
+
+        // Production Minimax3 GQA has one local K/V head per chip (B=1, NHK=NHV=1). In that case every
+        // active Q-head core consumes the same K and V chunks, so use row-wide multicast instead of
+        // the store-and-forward grouped chain. Idle cores inside an active row also participate with
+        // padded iterations so the multicast rectangle never writes into a non-participating worker.
+        if (B > 1) {
+            gqa_mcast_fallback_reason = "B > 1 (multi-batch GQA mcast not supported)";
+        } else if (NHK != 1) {
+            gqa_mcast_fallback_reason = "NHK != 1 (multi-KV-head GQA mcast not supported)";
+        } else if (num_cores < 2) {
+            gqa_mcast_fallback_reason = "num_cores < 2";
+        } else if (grid_size.x < 2) {
+            gqa_mcast_fallback_reason = "grid_size.x < 2 (singleton rows)";
+        } else {
+            std::deque<uint32_t> recent_cols;  // FIFO of <= grid.x-1 most-recent claimed phys_x
+            uint32_t gqa_mcast_rows = 0;
+
+            for (uint32_t row = 0; row < grid_size.y; ++row) {
+                const std::optional<RowWideChainMcastSelection> selection =
+                    select_row_wide_chain_mcast(row, recent_cols);
+                if (!selection.has_value()) {
+                    continue;
+                }
+                configure_row_wide_chain_mcast(*selection, 0, 0, gqa_chain_configs, gqa_chain_max_q);
+                gqa_mcast_rows++;
+
+                log_debug(
+                    tt::LogOp,
+                    "GQA K/V mcast row {}: injector core {} phys=({},{}) max_q={}, rect ({},{})-({},{})",
+                    selection->row,
+                    selection->injector_idx,
+                    selection->injector_physical.x,
+                    selection->injector_physical.y,
+                    selection->max_q,
+                    selection->phys_start.x,
+                    selection->phys_start.y,
+                    selection->phys_end.x,
+                    selection->phys_end.y);
+            }
+
+            gqa_mcast_enabled = gqa_mcast_rows > 0;
+            if (!gqa_mcast_enabled) {
+                gqa_mcast_fallback_reason = "no active rows";
+            }
+        }
+    }
+
+    // Build batch chains (K chain): one per batch for shared-K separate-V/latent cases.
     // K is shared across all heads, so all active cores in a batch form one chain.
-    // Note: device op validates NHK == NVH || NHK == 1, so NHK == 1 is the only case where
-    // K is shared across every head. Guard deliberately rejects GQA (which would need group-scoped chains).
     // Sorted by physical position for a stable unicast ordering (overwritten by mcast pass if eligible).
-    if (NHK == 1) {
+    if (k_uses_batch_chain) {
         std::map<uint32_t, std::vector<uint32_t>> batch_to_cores;
         for (uint32_t i = 0; i < num_cores; ++i) {
             if (core_work[i].global_q_count == 0) {
@@ -1897,19 +2117,14 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         }
     }
 
-    // K multicast pass: one mcast chain per logical row. Each chain's injector is
-    // the greedy max-work core in its row, picked under a FIFO-windowed physical-
-    // column exclusion (window size grid_size.x - 1): successive chains always land
-    // in a column distinct from the previous chain's. On a square grid this gives a
-    // clean diagonal; when grid_size.y > grid_size.x the window cycles columns
-    // naturally (e.g. 3x6 -> cols 0,1,2,0,1,2). Per-core loop padding lets each
-    // chain pad to its own injector's iteration count.
+    // K multicast pass: one mcast chain per logical row. Shared-K keeps the legacy all-or-nothing policy:
+    // every row must contain work, otherwise the previously built linear batch chain remains active.
     bool k_mcast_enabled = false;
     std::string k_mcast_fallback_reason;
     std::vector<uint32_t> k_chain_max_q(num_cores, 0);  // per-core loop-padding count
 
-    if (NHK != 1) {
-        // Not MLA mode - no K sharing needed
+    if (!k_uses_batch_chain) {
+        // No non-GQA shared-K batch chain to multicast.
     } else if (B > 1) {
         k_mcast_fallback_reason = "B > 1 (multi-batch not supported)";
     } else if (num_cores < 2) {
@@ -1918,98 +2133,39 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         // Each chain would be a singleton (1 core, no sinks) — mcast is degenerate.
         k_mcast_fallback_reason = "grid_size.x < 2 (singleton chains)";
     } else {
-        std::vector<uint32_t> chain_injector_idx(grid_size.y, 0);
-        std::vector<uint32_t> chain_max_q(grid_size.y, 0);
+        std::vector<RowWideChainMcastSelection> row_mcast_selections;
+        row_mcast_selections.reserve(grid_size.y);
         std::deque<uint32_t> recent_cols;  // FIFO of <= grid.x-1 most-recent claimed phys_x
 
         bool all_chains_picked = true;
         for (uint32_t row = 0; row < grid_size.y; ++row) {
-            if (recent_cols.size() >= grid_size.x) {
-                recent_cols.pop_front();
-            }
-            // Row-wide max work. The injector MUST be a core with this max, because
-            // K is read from DRAM by the injector and mcast to all row sinks. If the
-            // injector had fewer real iters than some sink, its padded iters would
-            // read K with an out-of-bounds nb derived from a wrapped global_q_chunk
-            // (in MLA mode K is broadcast across heads, but `nb = global_q_chunk /
-            // (NH*num_q_chunks)` becomes >0 once linear_index exceeds the head span)
-            // and mcast garbage K bytes to sinks that are still on real iters.
-            uint32_t row_max_q = 0;
-            for (uint32_t col = 0; col < grid_size.x; ++col) {
-                const uint32_t ci = row * grid_size.x + col;
-                row_max_q = std::max(row_max_q, core_work[ci].global_q_count);
-            }
-            if (row_max_q == 0) {
+            const std::optional<RowWideChainMcastSelection> selection = select_row_wide_chain_mcast(row, recent_cols);
+            if (!selection.has_value()) {
                 k_mcast_fallback_reason = fmt::format("row {} has no work", row);
                 all_chains_picked = false;
                 break;
             }
-            // Among max-work cores in the row, prefer one in an un-claimed column
-            // (keeps the FIFO column cycling for NoC diversity); if all max-work
-            // cores live in excluded columns, fall back to the first one — correctness
-            // (valid K from a real-iter injector) trumps column diversity.
-            uint32_t best_idx = std::numeric_limits<uint32_t>::max();
-            for (uint32_t col = 0; col < grid_size.x; ++col) {
-                const uint32_t ci = row * grid_size.x + col;
-                if (core_work[ci].global_q_count != row_max_q) {
-                    continue;
-                }
-                const uint32_t phys_x = core_work[ci].physical_core.x;
-                const bool excluded = (std::find(recent_cols.begin(), recent_cols.end(), phys_x) != recent_cols.end());
-                if (!excluded) {
-                    best_idx = ci;
-                    break;
-                }
-                if (best_idx == std::numeric_limits<uint32_t>::max()) {
-                    best_idx = ci;  // first excluded max-work core, kept as fallback
-                }
-            }
-            chain_injector_idx[row] = best_idx;
-            chain_max_q[row] = row_max_q;
-            recent_cols.push_back(core_work[best_idx].physical_core.x);
+            row_mcast_selections.push_back(*selection);
         }
 
         if (all_chains_picked) {
             k_mcast_enabled = true;
-            const uint32_t num_receivers = grid_size.x - 1;
 
-            for (uint32_t row = 0; row < grid_size.y; ++row) {
-                const uint32_t injector_idx = chain_injector_idx[row];
-                const uint32_t chain_max_q_v = chain_max_q[row];
-                const CoreCoord injector_physical = core_work[injector_idx].physical_core;
-                const CoreCoord phys_start = device->worker_core_from_logical_core(CoreCoord{0, row});
-                const CoreCoord phys_end = device->worker_core_from_logical_core(CoreCoord{grid_size.x - 1, row});
-
-                for (uint32_t col = 0; col < grid_size.x; ++col) {
-                    const uint32_t ci = row * grid_size.x + col;
-                    auto& kc = batch_chain_configs[ci];
-                    kc.participates = true;
-                    kc.mcast_start = phys_start;
-                    kc.mcast_end = phys_end;
-                    kc.injector_physical = injector_physical;
-                    kc.batch = 0;  // reset: unicast K pass may have set this to a real batch id
-                    kc.is_injector = (ci == injector_idx);
-                    kc.is_sink = !kc.is_injector;
-                    if (kc.is_injector) {
-                        kc.mcast_num_dests = num_receivers;
-                        kc.mcast_sender_wait = num_receivers;
-                        kc.next_core_q_chunks = chain_max_q_v;
-                    }
-                    k_chain_max_q[ci] = chain_max_q_v;
-                }
+            for (const auto& selection : row_mcast_selections) {
+                configure_row_wide_chain_mcast(selection, 0, 0, batch_chain_configs, k_chain_max_q);
 
                 log_debug(
                     tt::LogOp,
                     "K mcast row {}: injector core {} phys=({},{}) max_q={}, rect ({},{})-({},{})",
-                    row,
-                    injector_idx,
-                    injector_physical.x,
-                    injector_physical.y,
-                    chain_max_q_v,
-                    phys_start.x,
-                    phys_start.y,
-                    phys_end.x,
-                    phys_end.y);
+                    selection.row,
+                    selection.injector_idx,
+                    selection.injector_physical.x,
+                    selection.injector_physical.y,
+                    selection.max_q,
+                    selection.phys_start.x,
+                    selection.phys_start.y,
+                    selection.phys_end.x,
+                    selection.phys_end.y);
             }
         }
     }
@@ -2017,13 +2173,29 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     // Update mcast compile-time args
     const bool head_mcast_enabled = (mcast_chains > 0);
 
-    reader_compile_time_args[sem_args_offset + 3] = head_mcast_enabled ? 1 : 0;
-    // Batch chain args only present when k_uses_batch_chain (NHK == 1)
+    reader_compile_time_args[sem_args_offset + kRingJointChainMcastEnabledCompileArgOffset] =
+        head_mcast_enabled ? 1 : 0;
+    // Batch chain args only present when k_uses_batch_chain.
     if (k_uses_batch_chain) {
-        reader_compile_time_args[sem_args_offset + 7] = k_mcast_enabled ? 1 : 0;
+        const uint32_t batch_mcast_arg_index =
+            sem_args_offset + kRingJointChainCompileArgCount + kRingJointChainMcastEnabledCompileArgOffset;
+        reader_compile_time_args[batch_mcast_arg_index] = k_mcast_enabled ? 1 : 0;
+    }
+    if (gqa_grouped_kv) {
+        const uint32_t gqa_mcast_arg_index =
+            sem_args_offset + kRingJointChainCompileArgCount + kRingJointChainMcastEnabledCompileArgOffset;
+        reader_compile_time_args[gqa_mcast_arg_index] = gqa_mcast_enabled ? 1 : 0;
     }
 
-    if (k_uses_batch_chain) {
+    if (gqa_grouped_kv) {
+        log_debug(
+            tt::LogOp,
+            "K/V chain mode: grouped GQA {} (chains={}, participant_cores={}, local_fallback_cores={})",
+            gqa_mcast_enabled ? "mcast" : fmt::format("unicast, {}", gqa_mcast_fallback_reason),
+            gqa_grouped_chains,
+            gqa_grouped_participant_cores,
+            gqa_local_fallback_cores);
+    } else if (k_uses_batch_chain) {
         log_debug(
             tt::LogOp,
             "K chain mode: batch ({})",
@@ -2103,11 +2275,12 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         // Append chain runtime args for store-and-forward
         const auto& head_chain = head_chain_configs.at(i);
         const auto& batch_chain = batch_chain_configs.at(i);
+        const auto& gqa_chain = gqa_chain_configs.at(i);
 
         log_debug(
             tt::LogOp,
             "core logical=({},{})->phys=({},{}), q=[{},{}), head_chain={{part:{}, inj:{}, sink:{}, "
-            "b:{}, h:{}, next_cnt:{}}}",
+            "b:{}, h:{}, next_cnt:{}}}, gqa_chain={{part:{}, inj:{}, sink:{}, b:{}, kvh:{}, next_cnt:{}}}",
             core.x,
             core.y,
             core_work.at(i).physical_core.x,
@@ -2119,19 +2292,31 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
             head_chain.is_sink,
             head_chain.batch,
             head_chain.head,
-            head_chain.next_core_q_chunks);
+            head_chain.next_core_q_chunks,
+            gqa_chain.participates,
+            gqa_chain.is_injector,
+            gqa_chain.is_sink,
+            gqa_chain.batch,
+            gqa_chain.head,
+            gqa_chain.next_core_q_chunks);
 
-        // Head chain (V chain, optionally K in non-MLA): 18 args via unified layout
+        // Head chain: 18 args via unified layout. MHA uses it for K/V; separate-V shared-K uses it for V only.
         std::vector<uint32_t> head_chain_args;
         head_chain.append_to_args(head_chain_args);
         reader_args.append(head_chain_args);
 
-        // Batch chain (K chain in MLA mode): 18 args + 1 for loop padding (only when NHK == 1)
+        // Batch chain: 18 args + 1 for loop padding (only for shared-K separate-V/latent modes).
         if (k_uses_batch_chain) {
             std::vector<uint32_t> batch_chain_args;
             batch_chain.append_to_args(batch_chain_args);
             reader_args.append(batch_chain_args);
             reader_args.push_back(k_chain_max_q[i]);  // For K mcast loop padding (per-chain)
+        }
+        if (gqa_grouped_kv) {
+            std::vector<uint32_t> gqa_chain_args;
+            gqa_chain.append_to_args(gqa_chain_args);
+            reader_args.append(gqa_chain_args);
+            reader_args.push_back(gqa_chain_max_q[i]);  // For GQA K/V mcast loop padding (per row).
         }
 
         reader_args.push_checked(runtime_arg_layout.reader_logical_nt, logical_nt, "reader.logical_nt");

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_perf_model.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_perf_model.cpp
@@ -8,6 +8,35 @@
 
 namespace ttnn::operations::transformer::sdpa {
 
+namespace {
+
+constexpr double kFlopsPerFma = 2.0;  // Each FMA is 2 FLOPS
+// Wormhole and Blackhole have identical matmul throughput per cycle.
+constexpr double kTensixMulAddsPerCycleLofi = 4096.0;
+
+}  // namespace
+
+int compute_sdpa_ideal_cycles_for_valid_pairs(
+    uint32_t batch_size,
+    uint32_t num_heads_q,
+    double valid_pairs,
+    uint32_t DH,
+    uint32_t DV,
+    tt::tt_metal::MathFidelity math_fidelity,
+    int num_cores) {
+    if (valid_pairs <= 0.0 || num_cores <= 0) {
+        return 0;
+    }
+
+    const double fma_flops = kFlopsPerFma * valid_pairs * static_cast<double>(DH + DV) *
+                             static_cast<double>(num_heads_q) * static_cast<double>(batch_size);
+
+    // Ideal total cycles is ESTIMATED_FLOPS / IDEAL_THROUGHPUT.
+    return static_cast<int>(std::ceil(
+        (fma_flops / (static_cast<double>(num_cores) * kTensixMulAddsPerCycleLofi)) *
+        static_cast<double>(tt::tt_metal::operation::OpPerformanceModel::fidelity_multiplier(math_fidelity))));
+}
+
 int compute_sdpa_ideal_cycles(
     uint32_t batch_size,
     uint32_t num_heads_q,
@@ -18,27 +47,15 @@ int compute_sdpa_ideal_cycles(
     bool is_causal,
     tt::tt_metal::MathFidelity math_fidelity,
     int num_cores) {
-    constexpr int64_t FLOPS_PER_FMA = 2;  // Each FMA is 2 FLOPS
-    int64_t num_mul_adds = 0;
+    double valid_pairs = static_cast<double>(Sq) * static_cast<double>(Sk);
 
-    // Q * K matmul: [B, NQH, Sq, DH] x [B, NKV, DH, Sk] -> [B, NQH, Sq, Sk]
-    num_mul_adds += FLOPS_PER_FMA * DH * Sq * Sk * num_heads_q * batch_size;
-
-    // attention * V matmul: [B, NQH, Sq, Sk] x [B, NKV, Sk, DV] -> [B, NQH, Sq, DV]
-    num_mul_adds += FLOPS_PER_FMA * DV * Sq * Sk * num_heads_q * batch_size;
-
-    // If causal, only half of the FMAs are actually performed
+    // If causal, only half of the FMAs are actually performed.
     if (is_causal) {
-        num_mul_adds /= 2;
+        valid_pairs /= 2.0;
     }
 
-    // Wormhole and Blackhole have identical matmul throughput per cycle
-    const int tensix_mul_adds_per_cycle_lofi = 4096;
-
-    // Ideal total cycles is ESTIMATED_FLOPS / IDEAL_THROUGHPUT
-    return static_cast<int>(std::ceil(
-        (static_cast<float>(num_mul_adds) / static_cast<float>(num_cores * tensix_mul_adds_per_cycle_lofi)) *
-        static_cast<float>(tt::tt_metal::operation::OpPerformanceModel::fidelity_multiplier(math_fidelity))));
+    return compute_sdpa_ideal_cycles_for_valid_pairs(
+        batch_size, num_heads_q, valid_pairs, DH, DV, math_fidelity, num_cores);
 }
 
 }  // namespace ttnn::operations::transformer::sdpa

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_perf_model.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_perf_model.hpp
@@ -35,4 +35,15 @@ int compute_sdpa_ideal_cycles(
     tt::tt_metal::MathFidelity math_fidelity,
     int num_cores);
 
+// Compute ideal cycles from the number of valid Q/K attention pairs. This is useful for attention
+// variants whose valid-pair geometry is not a simple full or causal Sq x Sk rectangle.
+int compute_sdpa_ideal_cycles_for_valid_pairs(
+    uint32_t batch_size,
+    uint32_t num_heads_q,
+    double valid_pairs,
+    uint32_t DH,
+    uint32_t DV,
+    tt::tt_metal::MathFidelity math_fidelity,
+    int num_cores);
+
 }  // namespace ttnn::operations::transformer::sdpa


### PR DESCRIPTION
### PR Category
Feature, Performance

### Summary
Adds causal GQA support to ring joint SDPA for tensor K/V without changing the public API. Joint tensors remain out of scope for grouped-query mode.

This adds internal head-mode classification for MHA, shared-K separate-V, and grouped K/V; routes grouped K/V through row multicast for the production one-KV-head-per-chip case with grouped unicast/local fallback; and adds a Minimax3 causal chunked production-shape perf gate for `q128/k512`, Q bf16, K/V bfp8_b.

The chunked causal reuse-KV perf model now accounts for the prefix rectangle plus current-chunk causal triangle. That changes reported utilization for all reuse-KV chunked prefill users, including MLA and Kimi, while measured-duration perf gates remain unchanged.

- New Minimax3 GQA perf gate: `1.070 ms`, `47.64%` math util, expected `48.00%` band `[47.52, 48.48]`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-gqa-causal)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/ring-joint-sdpa-gqa-causal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-gqa-causal)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/ring-joint-sdpa-gqa-causal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-gqa-causal)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/ring-joint-sdpa-gqa-causal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-gqa-causal)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/ring-joint-sdpa-gqa-causal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-gqa-causal)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/ring-joint-sdpa-gqa-causal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-gqa-causal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/ring-joint-sdpa-gqa-causal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-gqa-causal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/ring-joint-sdpa-gqa-causal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-gqa-causal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/ring-joint-sdpa-gqa-causal)