### PR TITLE
[Bug fix] Warm up all prefill batch sizes to prevent mid-serving trace capture (seed=0 determinism fix)

### DIFF
--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -140,7 +140,16 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         self.already_warmed_up_prefill = True
 
         sequence_lengths_to_warmup = self.model_args[0].get_warmup_prefill_supported_seq_lens()
-        warmup_batch_sizes = (1,)
+        # Warm up ALL runtime batched-prefill batch sizes (not just batch-1) so no
+        # prefill trace is compiled/captured mid-serving. A prefill trace captured
+        # AFTER the decode trace (allocation-after-capture) clobbers the decode
+        # trace's device buffers -> seeded-sampling corruption under concurrency
+        # (batched prefill x trace interaction). Pre-warming every supported batch
+        # size moves all prefill allocations before decode-trace capture.
+        if getattr(self.model_args[0], "disable_batched_prefill", False):
+            warmup_batch_sizes = (1,)
+        else:
+            warmup_batch_sizes = SUPPORTED_PREFILL_BATCH_SIZES
 
         skip_sequence_lengths = False
 


### PR DESCRIPTION
### Summary
On P150, test_non_uniform_seeding (in server_tests/test_cases/test_vllm_chat_completions.py) fails intermittently under concurrency: requests sharing seed=0 are supposed to produce identical output, but occasionally one degenerates into a repeating-token loop (HereHereHere…) so the seed=0 set is no longer unique. This can be reproduced within 3 runs.

#### Root cause
warmup_model_prefill only captured batch-1 prefill traces (warmup_batch_sizes = (1,)). At runtime, batched prefill uses batch sizes 8/16/32 (depending on how many requests arrive together), so the first time each un-warmed batch size is seen, a new prefill trace is compiled and captured mid-serving. That capture allocates device buffers after the decode trace was already captured — and allocations made after a trace capture overwrite memory the existing (decode) trace depends on, corrupting decode output. The corruption shows up as the seed=0 degeneration.

#### Tests being run during fixing
| Config                                                                                     | Result |
| --- | --- |
| batched prefill on, full tracing (trace_mode=all)                | corrupt (7/10, 11/15) |
| trace_mode=decode_only** (prefill eager, decode traced) | clean (15/15), pins it to the prefill trace, not the decode trace |
| async scheduling forced off                                                 | still corrupt, not a timing race |
| batched prefill disabled (per-user batch-1)                        | clean, only composition-invariant path |
| this fix                                                                                     | clean, zero mid-serving prefill captures |

CI runs:
TODO

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=full_batch_size_warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:full_batch_size_warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=full_batch_size_warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:full_batch_size_warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=full_batch_size_warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:full_batch_size_warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=full_batch_size_warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:full_batch_size_warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=full_batch_size_warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:full_batch_size_warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=full_batch_size_warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:full_batch_size_warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=full_batch_size_warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:full_batch_size_warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=full_batch_size_warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:full_batch_size_warmup)