### PR TITLE
[skip ci] Disable Galaxy DiT Flux.1 perf test (bricks runners with TLB-window leak)

### DIFF
--- a/tests/pipeline_reorg/galaxy_perf_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_perf_tests.yaml
@@ -24,17 +24,25 @@
   save-perf-data: true
   model-type: SD3.5
 
-- name: Galaxy DiT Flux.1 model perf tests
-  cmd: HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub pytest models/tt_dit/tests/models/flux1/test_performance_flux1.py -k "wh_4x8sp0tp1" --timeout=500
-  model: flux1-dev
-  skus:
-    wh_galaxy_perf:
-      timeout: 15
-  owner_id: U08TED0JM9D # Samuel Adesoye
-  team: models
-  arch: wormhole_b0
-  save-perf-data: true
-  model-type: Flux.1-Dev
+# TEMPORARILY DISABLED - see https://github.com/tenstorrent/tt-metal/issues/47355
+# The 4x8 Flux.1 pipeline perf test (test_flux1_pipeline_performance_determinism, which runs
+# the full pipeline 3x in a loop) hangs the device mid-pipeline in an uninterruptible driver
+# call (pytest --timeout does not fire). The hung process is SIGKILLed by the CI action timeout,
+# leaking TLB windows that `tt-smi reset` reports as successfully reset but does not actually
+# reclaim. This bricks the runner so that all subsequent jobs fail with "Failed to allocate TLB
+# window (tt_tlb_alloc -12)". Same mechanism as the previously-disabled Qwen-Image perf test.
+# Re-enable once the hang is fixed / the runner reset reliably reclaims TLB windows.
+# - name: Galaxy DiT Flux.1 model perf tests
+#   cmd: HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub pytest models/tt_dit/tests/models/flux1/test_performance_flux1.py -k "wh_4x8sp0tp1" --timeout=500
+#   model: flux1-dev
+#   skus:
+#     wh_galaxy_perf:
+#       timeout: 15
+#   owner_id: U08TED0JM9D # Samuel Adesoye
+#   team: models
+#   arch: wormhole_b0
+#   save-perf-data: true
+#   model-type: Flux.1-Dev
 
 - name: Galaxy DiT Motif model perf tests
   cmd: HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub pytest models/tt_dit/tests/models/motif/test_performance_motif.py -k "4x8cfg1sp0tp1" --timeout=1000


### PR DESCRIPTION
## What

Comments out the **`Galaxy DiT Flux.1 model perf tests`** entry (`-k "wh_4x8sp0tp1"`) in `tests/pipeline_reorg/galaxy_perf_tests.yaml`, with an inline note pointing to #47355. Mirrors #47363 (Qwen-Image).

## Why

This test (`models/tt_dit/tests/models/flux1/test_performance_flux1.py -k "wh_4x8sp0tp1"`) hangs the device mid-pipeline in an **uninterruptible driver call** — `pytest --timeout=500` never fires, and only the CI job timeout kills it (via SIGKILL). The killed process **leaks TLB windows**; the per-job `tt-smi reset` then reports *"reset was successful"* but does **not** reclaim them, so every subsequent job on that runner fails with:

```
RuntimeError: Failed to allocate TLB window ... tt_tlb_alloc failed with error code -12
```

This is the **same mechanism** as the previously-disabled Qwen-Image perf test (#47363) — runners stayed broken after that removal because Flux.1 is a new offender.

Directly verified hang ([run 28093838373, job 83181899894](https://github.com/tenstorrent/tt-metal/actions/runs/28093838373/job/83181899894), runner `OM1-01A03-STGWH01`, 2026-06-24): the `performance` variants PASSED, then `test_flux1_pipeline_performance_determinism` (which runs the full pipeline 3× in a loop) went silent at `denoising...` 11:45:35 → `##[error]The action has timed out` at 11:46:59, with no pytest-timeout traceback.

The Flux.1 CI bring-up (#46895) merged 2026-06-22, after the Qwen-Image removal — lining up with "still bricking runners after #47363". Full analysis in #47355.

## Scope

- Disables only the 4x8 Galaxy Flux.1 variant in the perf pipeline. Other DiT 4x8 perf tests (SD3.5, Motif, Wan2.2, Mochi, DeepSeek-decode) are left active but flagged as secondary suspects in #47355 — the underlying hang likely lives in the shared `tt_dit` 4x8 pipeline path.
- Temporary — revert once the hang is fixed and/or the runner reset reliably reclaims TLB windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/disable-galaxy-flux1-perf-tlb-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/disable-galaxy-flux1-perf-tlb-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/disable-galaxy-flux1-perf-tlb-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/disable-galaxy-flux1-perf-tlb-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mtairum/disable-galaxy-flux1-perf-tlb-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mtairum/disable-galaxy-flux1-perf-tlb-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/disable-galaxy-flux1-perf-tlb-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/disable-galaxy-flux1-perf-tlb-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/disable-galaxy-flux1-perf-tlb-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/disable-galaxy-flux1-perf-tlb-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/disable-galaxy-flux1-perf-tlb-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/disable-galaxy-flux1-perf-tlb-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/disable-galaxy-flux1-perf-tlb-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/disable-galaxy-flux1-perf-tlb-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/disable-galaxy-flux1-perf-tlb-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/disable-galaxy-flux1-perf-tlb-hang)