### PR TITLE
GPT-OSS: fix 120B router-weights test via realistic dummy weight scale

### DIFF
--- a/models/demos/gpt_oss/tests/unit/test_modules.py
+++ b/models/demos/gpt_oss/tests/unit/test_modules.py
@@ -164,28 +164,18 @@ def run_topk_router_component(
 
     # Extract reference TopK router from reference layer
     reference_router = reference_layer.mlp.router
-    # transformers 5.x GptOssTopKRouter.forward returns (router_logits, router_scores, router_indices);
-    # <5 returned (router_scores_dense, router_indices). Reconstruct the DENSE [num_tokens, num_experts]
-    # router_scores so the comparison below matches the pre-5.x behaviour. (The corrected router-weights
-    # comparison + the fp32 router-gate fix it surfaced are tracked separately in #47970 — kept out of this
-    # unpin PR so it stays at parity with main, which does not validate the router gate weights either.)
+    # transformers 5.x GptOssTopKRouter.forward returns (router_logits, router_scores, router_indices) with
+    # router_scores already SPARSE [num_tokens, top_k] (softmax over the top_k logits, in top-k order);
+    # <5 returned (router_scores_dense, router_indices) with router_scores DENSE [num_tokens, num_experts].
+    # GptOssMLP flattens (batch,seq,hidden) -> (num_tokens, hidden) before the router, so flatten here too
+    # (also matches the TT router, which operates on flattened tokens) and normalise both versions to a
+    # sparse [num_tokens, top_k] weight tensor aligned to router_indices.
     _router_out = reference_router(hidden_states.reshape(-1, hidden_size))
     if len(_router_out) == 3:
-        router_logits, _sparse_scores, router_indices = _router_out
-        router_scores = torch.zeros_like(router_logits).scatter_(-1, router_indices, _sparse_scores)
+        router_scores, router_indices = _router_out[1], _router_out[2]
     else:
-        router_scores, router_indices = _router_out
-    if decoder_layer.mlp.use_throughput_experts:
-        dense_router_scores = torch.concat(
-            [
-                torch.tensor(
-                    [router_scores[user, router_indices[user, i]] for i in range(router_indices.shape[1])]
-                ).reshape(1, -1)
-                for user in range(router_scores.shape[0])
-            ],
-            dim=0,
-        )
-        router_scores = dense_router_scores
+        router_scores_dense, router_indices = _router_out
+        router_scores = torch.gather(router_scores_dense, 1, router_indices)
 
     # Convert to TTNN tensors
     mesh_mapper = (
@@ -206,8 +196,17 @@ def run_topk_router_component(
     tt_router = decoder_layer.mlp.router
     tt_router_indices, tt_router_weights = tt_router(tt_hidden_states, decoder_layer.mlp.use_throughput_experts)
     mesh_composer = ttnn.ConcatMesh2dToTensor(mesh_device, dims=(0, 1), mesh_shape=tuple(mesh_device.shape))
-    tt_router_indices_torch = ttnn.to_torch(tt_router_indices, mesh_composer=mesh_composer)[:batch, :4]
-    tt_router_weights_torch = ttnn.to_torch(tt_router_weights, mesh_composer=mesh_composer)[:batch, :4]
+    top_k = router_indices.shape[1]
+    tt_router_indices_torch = ttnn.to_torch(tt_router_indices, mesh_composer=mesh_composer)[:batch, :top_k]
+    tt_router_weights_full = ttnn.to_torch(tt_router_weights, mesh_composer=mesh_composer)[:batch]
+    if decoder_layer.mlp.use_throughput_experts:
+        # throughput path returns sparse [batch, top_k] weights (top-k order)
+        tt_router_weights_torch = tt_router_weights_full[:, :top_k]
+    else:
+        # non-throughput path returns DENSE [batch, num_experts] (ttnn.scatter of the top_k weights at the
+        # selected expert ids); gather the weights at the selected indices so both sides are sparse
+        # [batch, top_k] aligned to their indices. Reading [:, :top_k] here would grab unselected experts.
+        tt_router_weights_torch = torch.gather(tt_router_weights_full, 1, tt_router_indices_torch.long())
 
     # Compare outputs
     # We will sort the indices here as the order of the indices is not guaranteed to be the same in the reference and TT implementation.
@@ -216,11 +215,13 @@ def run_topk_router_component(
     indices_passing, indices_output = compare_tensors(
         sorted_tt_indices, sorted_ref_indices, mesh_device, pcc_threshold=pcc_threshold
     )
+    # Reorder each token's weights into ascending-expert-id order so the two sides line up even when
+    # TT (bf16) and the reference (fp32) emit the same top-k experts in a different (value-sorted) order.
+    # gather along the top_k axis is the correct reorder; `weights.squeeze()[order]` indexes dim 0 and
+    # mangles the comparison for batch > 1.
     weights_passing, weights_output = compare_tensors(
-        tt_router_weights_torch.squeeze()[
-            sorted_tt_indices_order
-        ],  # we have to squeeze here because it breaks the indexing otherwise
-        router_scores.squeeze()[sorted_ref_indices_order],
+        torch.gather(tt_router_weights_torch, -1, sorted_tt_indices_order),
+        torch.gather(router_scores, -1, sorted_ref_indices_order),
         mesh_device,
         pcc_threshold=pcc_threshold,
     )
@@ -576,10 +577,17 @@ def setup_reference_layer(setup, layer_idx=0):
     # existing _attn_implementation="eager" the decoder setup uses).
     setup["config"]._experts_implementation = "eager"
     reference_layer = GptOssDecoderLayer(setup["config"], layer_idx=layer_idx)
+    # Initialize random weights at the model's real scale (config.initializer_range, 0.02 for GPT-OSS)
+    # rather than the unit-normal default. The router gate is the reason this matters: at std=1 the
+    # router logits reach ~±150 (logit_std ≈ sqrt(hidden_size) ≈ 54), a magnitude where the bf16-only
+    # ttnn.topk ties adjacent top experts and the gate softmax collapses to ~0.5/0.5 — a pure artifact
+    # of the unrealistic weight scale, not a real-model issue. At the real scale logits are ~±3, well
+    # within bf16 resolution, so the gate matches the fp32 reference. (See #47970.)
+    init_std = getattr(setup["config"], "initializer_range", 0.02)
     with torch.no_grad():
         for name, param in reference_layer.named_parameters():
             if any(proj in name for proj in ["router", "experts", "sinks"]):
-                param.data.normal_(0, 1)
+                param.data.normal_(0, init_std)
     return reference_layer
 
 


### PR DESCRIPTION
## Summary
Fixes the GPT-OSS **120B router-weights** unit-test divergence. Split out of the transformers-5.10.2 unpin (#47671, now merged); rebased onto `main`. **No kernel change** — the fix is a test-only correction.

## Root cause — a dummy-weight test artifact, not a real precision bug
`setup_reference_layer` in `tests/unit/test_modules.py` initialized the layer's router/experts/sinks at **unit-normal (`normal_(0, 1)`, std=1)**. The router logit is `hidden @ W_router`, so with std=1 weights the logit std is `≈ sqrt(hidden_size) ≈ 54` → router logits reach **~±150**.

At that magnitude the **bf16-only `ttnn.topk`** ties adjacent top logits (e.g. `109.0 == 109.0`), so the gate softmax flattens to ~**0.5/0.5** where the fp32 reference gives ~**0.95/0.05** — collapsing the gate PCC to **0.6157**. Same experts are selected (indices PCC 1.0); only the gate magnitudes diverged.

**The real model never sees these magnitudes.** GPT-OSS `config.initializer_range = 0.02`, which gives router logits ~**±3** — comfortably within bf16 resolution. The "bug" was purely an artifact of the unrealistic random-weight scale used in the test.

> The earlier revision of this PR fixed the symptom by forcing the router gate to **fp32** (`topk.py` row-max-shift + HiFi4). That has been **reverted**: fp32 in the router is undesirable, and unnecessary once the test uses realistic weights. (Thanks to review feedback for the steer.)

## Changes
- **`tests/unit/test_modules.py` — initialize dummy weights at the real scale:** `setup_reference_layer` now uses `normal_(0, config.initializer_range)` (0.02) instead of `normal_(0, 1)`. Real-scale logits (~±3) stay within bf16 resolution, so the gate matches the fp32 reference with no kernel change.
- **`tests/unit/test_modules.py` — corrected router-weights comparison (kept):** gather TT's dense non-throughput weights at the selected expert ids (instead of the first `top_k` unselected columns) and normalize the reference to the same layout. This makes the `test_decoder[decode_low_latency]` sub-check actually validate the gate (it previously false-passed by reading unselected columns). Runs in the tier-1/2 unit pipeline.

`topk.py` and `tests/fused_op_unit_tests/test_gpt_oss_router.py` are **unchanged from main** (the fp32 fix and its showcase test are removed).

## Validation
**[Run 28178109629](https://github.com/tenstorrent/tt-metal/actions/runs/28178109629)** (tier-1 120B + tier-2 20B unit, original topk + realistic weights):
- **120B [wh_llmbox] → ✅** · **120B [bh_quietbox_2] → ✅** · **120B [bh_galaxy] → ✅** — `test_decoder[decode_low_latency]` passes (was 0.6157).
- **20B [wh_llmbox] → ✅** · **20B [bh_quietbox_2] → ✅** — no regression.
- **20B [bh_p150] → ✅** (clean [rerun 28190842155](https://github.com/tenstorrent/tt-metal/actions/runs/28190842155); the original attempt infra-flaked on a GitHub codeload action-download timeout).
- wh_galaxy disregarded (chronically flaky/infra, per maintainer guidance).

The corrected comparison now passes on all healthy SKUs **with no kernel change**, confirming the divergence was a test-weight-scale artifact.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/gptoss-router-fp32-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/gptoss-router-fp32-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/gptoss-router-fp32-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/gptoss-router-fp32-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mtairum/gptoss-router-fp32-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mtairum/gptoss-router-fp32-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/gptoss-router-fp32-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/gptoss-router-fp32-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/gptoss-router-fp32-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/gptoss-router-fp32-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/gptoss-router-fp32-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/gptoss-router-fp32-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/gptoss-router-fp32-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/gptoss-router-fp32-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/gptoss-router-fp32-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/gptoss-router-fp32-gate)

