### PR TITLE
[bug fix]: restrict D2H host-IO sweeps tests to Blackhole Galaxy

### DIFF
--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io.py
@@ -55,6 +55,10 @@ def test_host_io_loopback(mesh_device, tensor_size_bytes, fifo_size, num_iterati
     if not is_slow_dispatch():
         pytest.skip("Skipping test in fast dispatch mode")
 
+    # Only run on Blackhole Galaxy; hangs on smaller Blackhole boards (P150/P300). See #47166.
+    if ttnn.cluster.get_cluster_type() != ttnn.cluster.ClusterType.BLACKHOLE_GALAXY:
+        pytest.skip("HostIO loopback is only supported on Blackhole Galaxy (#47166)")
+
     # TODO(#43079): Blackhole DEVICE_PULL host IO loopback hangs under viommu.
     if is_blackhole() and h2d_mode == ttnn.H2DMode.DEVICE_PULL:
         pytest.skip(

--- a/tests/ttnn/unit_tests/base_functionality/test_d2h_stream_service.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_d2h_stream_service.py
@@ -10,36 +10,14 @@ import ttnn
 
 from models.common.utility_functions import skip_for_slow_dispatch
 
-# D2HStreamService claims FD dispatch-column service cores, which the runtime only permits when
-# BOTH conditions hold (see tt_metal/impl/internal/service/service_core_manager.cpp):
-#   1. Fast Dispatch is active (get_claimable_cores / claim TT_FATAL otherwise), and
-#   2. the cluster is a Blackhole board or a UBB Galaxy (claim TT_FATAL otherwise).
-#
-# This is an allowlist of real clusters that satisfy condition 2. Simulator cluster types
-# (SIMULATOR_*) are deliberately excluded: the simulator has no Fast Dispatch, so it can never
-# satisfy condition 1 and would hit the "requires Fast Dispatch" TT_FATAL even on Blackhole arch.
-# Slow Dispatch on real hardware is handled separately by skip_for_slow_dispatch() below.
-# Anything not listed here (simulators, non-Galaxy Wormhole, future cluster types) skips cleanly.
-_D2H_SUPPORTED_CLUSTER_TYPES = frozenset(
-    {
-        # Blackhole single/multi-card
-        ttnn.cluster.ClusterType.P100,
-        ttnn.cluster.ClusterType.P150,
-        ttnn.cluster.ClusterType.P150_X2,
-        ttnn.cluster.ClusterType.P150_X4,
-        ttnn.cluster.ClusterType.P150_X8,
-        ttnn.cluster.ClusterType.P300,
-        ttnn.cluster.ClusterType.P300_X2,
-        # UBB Galaxy (Wormhole and Blackhole)
-        ttnn.cluster.ClusterType.GALAXY,
-        ttnn.cluster.ClusterType.BLACKHOLE_GALAXY,
-    }
-)
+# Only run on Blackhole Galaxy; smaller Blackhole boards (P150/P300) fail to pin host pages for
+# the DMA buffer. See #47750.
+_D2H_SUPPORTED_CLUSTER_TYPES = frozenset({ttnn.cluster.ClusterType.BLACKHOLE_GALAXY})
 pytestmark = [
     skip_for_slow_dispatch(),
     pytest.mark.skipif(
         ttnn.cluster.get_cluster_type() not in _D2H_SUPPORTED_CLUSTER_TYPES,
-        reason="D2HStreamService is only supported on Blackhole and UBB Galaxy clusters",
+        reason="D2HStreamService sweeps are only run on Blackhole Galaxy clusters (#47750)",
     ),
 ]
 


### PR DESCRIPTION
These D2H host-IO tests are only applicable on Blackhole Galaxy; on the smaller Blackhole boards (P150/P300) the host-pinned PCIe/DMA path fails, so they should not run there.

- test_d2h_stream_service (#47750): narrow _D2H_SUPPORTED_CLUSTER_TYPES to BLACKHOLE_GALAXY only. On P150b the D2H host-IO path fails to pin host pages for the DMA buffer ("Failed to pin pages for DMA buffer").

- test_host_io_loopback (#47166): replace the DEVICE_PULL-specific skip with a BLACKHOLE_GALAXY-only gate. On smaller Blackhole boards (P300 with viommu) the host-pinned PCIe transfer hangs in the data-transfer loop, exhausting the CI step timeout.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bzhang/disable-d2h-tests-non-bh-galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bzhang/disable-d2h-tests-non-bh-galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bzhang/disable-d2h-tests-non-bh-galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bzhang/disable-d2h-tests-non-bh-galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bzhang/disable-d2h-tests-non-bh-galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bzhang/disable-d2h-tests-non-bh-galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bzhang/disable-d2h-tests-non-bh-galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bzhang/disable-d2h-tests-non-bh-galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bzhang/disable-d2h-tests-non-bh-galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bzhang/disable-d2h-tests-non-bh-galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bzhang/disable-d2h-tests-non-bh-galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bzhang/disable-d2h-tests-non-bh-galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bzhang/disable-d2h-tests-non-bh-galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bzhang/disable-d2h-tests-non-bh-galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bzhang/disable-d2h-tests-non-bh-galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bzhang/disable-d2h-tests-non-bh-galaxy)