### PR TITLE
Fix INT32 type conversion in tilize with padding

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_factory_helper.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_factory_helper.cpp
@@ -27,8 +27,11 @@ uint32_t get_packed_value(const Tensor& tensor, const PadValue& pad_value) {
                     return ttnn::operations::data_movement::pack_two_uint16_into_uint32(
                         {uint16_pad_value, uint16_pad_value});
                 }
-                if (tensor.dtype() == DataType::FLOAT32 || tensor.dtype() == DataType::INT32) {
+                if (tensor.dtype() == DataType::FLOAT32) {
                     return std::bit_cast<uint32_t>(static_cast<float>(pad_value));
+                }
+                if (tensor.dtype() == DataType::INT32) {
+                    return std::bit_cast<uint32_t>(static_cast<int32_t>(pad_value));
                 }
                 TT_FATAL(
                     tensor.dtype() == DataType::UINT32, "only supporting bfloat16, float32, and uint32/int32/uint16");


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fix incorrect type conversion that caused an AssertionFailure error in tests/ttnn/unit_tests/operations/data_movement/test_tilize_with_val_padding.py.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/tilize-with-val-padding)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/tilize-with-val-padding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/tilize-with-val-padding)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/tilize-with-val-padding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mcraighead/tilize-with-val-padding)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mcraighead/tilize-with-val-padding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/tilize-with-val-padding)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/tilize-with-val-padding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/tilize-with-val-padding)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/tilize-with-val-padding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/tilize-with-val-padding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/tilize-with-val-padding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/tilize-with-val-padding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/tilize-with-val-padding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/tilize-with-val-padding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/tilize-with-val-padding)