### PR TITLE
[skip ci] updaet teh layer notes for blaze per ND

### DIFF
--- a/infra/_title_review_smoketest.md
+++ b/infra/_title_review_smoketest.md
@@ -1,0 +1,11 @@
+# Release-notes layer map (reference)
+
+Quick reference for how `release_notes_by_layer.py` assigns a PR to a section,
+based on the paths of its changed files:
+
+- LLK — `tt_metal/tt-llk/`, `tt_metal/hw/ckernels/`
+- Metalium — other `tt_metal/`
+- TT-NN — `ttnn/`
+- Infrastructure & CI — `.github/`, `infra/`, `scripts/`
+
+A PR that touches multiple layers appears under each.


### PR DESCRIPTION
Smoke test for the new "PR Title Clarity" Copilot instruction (MINFRA-978), targeting the instruction branch as base so Copilot reads the new rule.

The change itself: adds a short reference note documenting how the release-notes layer map (`release_notes_by_layer.py`) assigns a PR to a section based on its changed-file paths. Docs only.

The title here is intentionally poor — to see whether Copilot's review suggests a clearer one (and preserves the `[skip ci]` prefix). Will be closed after we observe the review.
