### PR TITLE
Fix int fpu datacopy MOP wrongly enabled on WH/BH in copy_tile_to_dst

### DIFF
--- a/tt_metal/hw/inc/api/compute/tile_move_copy.h
+++ b/tt_metal/hw/inc/api/compute/tile_move_copy.h
@@ -44,8 +44,14 @@ ALWI void copy_tile_to_dst_init_short(
 #endif
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
         transpose, transpose_within_16x16_face, cbid)));
+    // 4th template arg is arch-divergent (unpack_to_dest on Quasar, is_int_fpu_en on WH/BH); keep it
+    // arch-specific so WH/BH don't wrongly enable the integer-FPU datacopy MOP.
+#ifndef ARCH_QUASAR
+    MATH((llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(cbid)));
+#else
     MATH((llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE, UnpackToDestEn>(
         cbid)));
+#endif
 }
 /**
  * Perform a init for the copy tile operation. This calls the short init function and initializes packer dst offset


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Bug fix: failing sanity for wh/bh
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Unified copy_tile_to_dst_init_short passed UnpackToDestEn as template arg of llk_math_eltwise_unary_datacopy_init. That parameter is arch-divergent: on Quasar it is unpack_to_dest, but on Wormhole/Blackhole it is is_int_fpu_en. Since UnpackToDestEn is constexpr true on WH/BH, this enabled the integer-FPU datacopy MOP (TT_OP_ELWADD instead of TT_OP_MOVA2D), routing the tile copy through the FPU adder. Ultimately corrupting precision sensitive results (e.g. bf16 divide of subnormal operands).

Fix: splits the math init call per-arch so WH/BH leaves is_int_fpu_en at its false default (restoring the plain MOVA2D copy) while Quasar keeps unpack_to_dest.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skotarac/fix-copy-tile-init-int-fpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skotarac/fix-copy-tile-init-int-fpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skotarac/fix-copy-tile-init-int-fpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skotarac/fix-copy-tile-init-int-fpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skotarac/fix-copy-tile-init-int-fpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skotarac/fix-copy-tile-init-int-fpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skotarac/fix-copy-tile-init-int-fpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skotarac/fix-copy-tile-init-int-fpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skotarac/fix-copy-tile-init-int-fpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skotarac/fix-copy-tile-init-int-fpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skotarac/fix-copy-tile-init-int-fpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skotarac/fix-copy-tile-init-int-fpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skotarac/fix-copy-tile-init-int-fpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skotarac/fix-copy-tile-init-int-fpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skotarac/fix-copy-tile-init-int-fpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skotarac/fix-copy-tile-init-int-fpu)