### PR TITLE
[vLLM nightly] Drop --max_num_seqs 1 for Gemma4 server entries

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -142,7 +142,7 @@ jobs:
               "runner-label": "N150",
               "arch": "arch-wormhole_b0",
               "mesh-device": "N150",
-              "additional-server-args": "--max_num_seqs 1 --async-scheduling",
+              "additional-server-args": "--async-scheduling",
               "multimodal": false,
               "owner_id": "U08TJ70UFRT"
             },
@@ -156,7 +156,7 @@ jobs:
               "arch": "arch-blackhole",
               "mesh-device": "P150x4",
               "tt-config": "{\"sample_on_device_mode\": \"decode_only\", \"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 400000000}",
-              "additional-server-args": "--max_num_seqs 1 --async-scheduling",
+              "additional-server-args": "--async-scheduling",
               "multimodal": false,
               "owner_id": "U08TJ70UFRT"
             },
@@ -170,7 +170,7 @@ jobs:
               "arch": "arch-wormhole_b0",
               "mesh-device": "T3K",
               "tt-config": "{\"sample_on_device_mode\": \"decode_only\", \"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 200000000}",
-              "additional-server-args": "--max_num_seqs 1 --async-scheduling",
+              "additional-server-args": "--async-scheduling",
               "multimodal": false,
               "owner_id": "U08TJ70UFRT"
             },
@@ -184,7 +184,7 @@ jobs:
               "arch": "arch-blackhole",
               "mesh-device": "P150x4",
               "tt-config": "{\"sample_on_device_mode\": \"decode_only\", \"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 300000000}",
-              "additional-server-args": "--max_num_seqs 1 --async-scheduling",
+              "additional-server-args": "--async-scheduling",
               "multimodal": false,
               "owner_id": "U08TJ70UFRT"
             },
@@ -537,8 +537,9 @@ jobs:
             export TT_MM_THROTTLE_PERF="${{ matrix.test-group.tt_mm_throttle_perf }}"
           fi
 
-          # Gemma4 trace-region tuning for this benchmark (random-input-len 100,
-          # single-stream max_num_seqs=1):
+          # Gemma4 trace-region tuning for this benchmark (random-input-len 100;
+          # max_num_seqs left at the vLLM default so the server can batch
+          # concurrent requests rather than serving them one at a time):
           #   * The prefill trace bucket sweep (128..4096) is the dominant trace
           #     consumer — the 4096 bucket alone is ~0.5 GB on 26B-A4B — yet a
           #     100-token prompt only ever replays the 128 bucket. Limit it so the


### PR DESCRIPTION
### PR Category
Performance

### Summary
Let the Gemma4 nightly vLLM server use vLLM's default max_num_seqs so it can batch concurrent requests instead of serving them one at a time. The single-stream cap forced requests to queue, inflating the served TTFT. Updates the four active Gemma4 matrix entries (E2B, 12B, and both 26B-A4B variants) and refreshes the now-stale single-stream comment in the trace-region tuning block.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dwadhwani/gemma4-disable-max-num-seqs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dwadhwani/gemma4-disable-max-num-seqs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dwadhwani/gemma4-disable-max-num-seqs)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dwadhwani/gemma4-disable-max-num-seqs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dwadhwani/gemma4-disable-max-num-seqs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dwadhwani/gemma4-disable-max-num-seqs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dwadhwani/gemma4-disable-max-num-seqs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dwadhwani/gemma4-disable-max-num-seqs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dwadhwani/gemma4-disable-max-num-seqs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dwadhwani/gemma4-disable-max-num-seqs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dwadhwani/gemma4-disable-max-num-seqs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dwadhwani/gemma4-disable-max-num-seqs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dwadhwani/gemma4-disable-max-num-seqs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dwadhwani/gemma4-disable-max-num-seqs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dwadhwani/gemma4-disable-max-num-seqs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dwadhwani/gemma4-disable-max-num-seqs)