### PR TITLE
[skip ci] Disable Fabric2DUDMModeFixture.TestUDMFabricReadEast due to watcher assert

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -714,6 +714,7 @@ TEST_F(Fabric2DUDMModeFixture, TestUDMFabricUnicastAtomicIncWest) {
     UDMFabricUnicastCommon(this, NocPacketType::NOC_UNICAST_ATOMIC_INC, std::make_tuple(RoutingDirection::W, 1));
 }
 TEST_F(Fabric2DUDMModeFixture, TestUDMFabricReadEast) {
+    GTEST_SKIP() << "Temporarily disabled due to watcher assert in test_udm_read_sender.cpp, refs #47076";
     UDMFabricUnicastCommon(this, NocPacketType::NOC_UNICAST_READ, std::make_tuple(RoutingDirection::E, 1));
 }
 TEST_F(Fabric2DUDMModeFixture, TestUDMFabricReadWest) {


### PR DESCRIPTION
Temporarily disables `Fabric2DUDMModeFixture.TestUDMFabricReadEast` which has been failing for 7+ days on T3000 fast tests with a watcher-detected assert in `test_udm_read_sender.cpp` (BRISC tripped assert on line 714), causing the process to abort.

refs #47076

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47076)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lifecycle/disable-issue-47076)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47076)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lifecycle/disable-issue-47076)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=lifecycle/disable-issue-47076)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:lifecycle/disable-issue-47076)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lifecycle/disable-issue-47076)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lifecycle/disable-issue-47076)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47076)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lifecycle/disable-issue-47076)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lifecycle/disable-issue-47076)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lifecycle/disable-issue-47076)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lifecycle/disable-issue-47076)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lifecycle/disable-issue-47076)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lifecycle/disable-issue-47076)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lifecycle/disable-issue-47076)