### PR TITLE
[skip ci] Disable UDM fabric read tests (Fabric2D*Fixture) due to BRISC assert in test_udm_read_sender.cpp

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -2298,6 +2298,10 @@ void UDMFabricUnicastCommon(
     std::optional<RoutingDirection> override_initial_direction,
     std::optional<std::vector<std::pair<CoreCoord, CoreCoord>>> worker_coords_list,
     bool dual_risc) {
+    // Temporarily disabled: test_udm_read_sender.cpp trips a BRISC assert, refs #47073
+    if (noc_packet_type == NocPacketType::NOC_UNICAST_READ) {
+        GTEST_SKIP() << "UDM read tests disabled due to BRISC assert in test_udm_read_sender.cpp, refs #47073";
+    }
     // Build list of worker coordinate pairs - default to single pair (0,0) -> (1,0)
     std::vector<std::pair<CoreCoord, CoreCoord>> worker_pairs;
     if (worker_coords_list.has_value()) {


### PR DESCRIPTION
The `Fabric2D*Fixture.*` tests that exercise `NOC_UNICAST_READ` via `UDMFabricUnicastCommon` have been failing for 7+ days on T3000 fast tests. The BRISC trips an assert at line 714 in `tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_read_sender.cpp`, causing the entire `fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"` run to abort with exit code 134.

This PR adds a `GTEST_SKIP()` guard inside `UDMFabricUnicastCommon` scoped to `NOC_UNICAST_READ` only, so all other packet types (write, atomic-inc, etc.) continue to run unaffected.

refs #47073

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47073)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lifecycle/disable-issue-47073)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47073)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lifecycle/disable-issue-47073)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=lifecycle/disable-issue-47073)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:lifecycle/disable-issue-47073)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lifecycle/disable-issue-47073)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lifecycle/disable-issue-47073)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47073)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lifecycle/disable-issue-47073)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lifecycle/disable-issue-47073)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lifecycle/disable-issue-47073)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lifecycle/disable-issue-47073)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lifecycle/disable-issue-47073)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lifecycle/disable-issue-47073)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lifecycle/disable-issue-47073)