### PR TITLE
[Bug fix] Fix runtime CI test failures in pow test and dispatch perf script

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_pow_fractional.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_pow_fractional.py
@@ -16,24 +16,15 @@ def test_pow_fractional_composite(device):
     C = 2
     H = 32
     W = 32
-    x = torch.randn((N, C, H, W)).bfloat16().float()
+    x = (torch.rand((N, C, H, W)) + 0.01).bfloat16().float()
 
-    xt = (
-        ttnn.Tensor(
-            x.reshape(-1).tolist(),
-            x.shape,
-            ttnn.bfloat16,
-            ttnn.ROW_MAJOR_LAYOUT,
-        )
-        .to(ttnn.TILE_LAYOUT)
-        .to(device)
-    )
+    xt = ttnn.from_torch(x, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
 
     y = 3 + torch.randn(1, 1, 1, 1).bfloat16().float()
     yt = y
     yt_floor = math.floor(yt)
     yt_trunc = yt - yt_floor
-    pow_trunc_log = ttnn.multiply(ttnn.log(xt, fast_and_approximate_mode=True), yt_trunc)
+    pow_trunc_log = ttnn.multiply(ttnn.log(xt), yt_trunc)
     pow_frac = ttnn.exp(pow_trunc_log)
     xtt = ttnn.mul(ttnn.pow(xt, yt_floor), pow_frac)
     assert list(xtt.padded_shape) == [N, C, H, W]

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/compare_pgm_dispatch_perf_ci.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/compare_pgm_dispatch_perf_ci.py
@@ -42,7 +42,9 @@ def add_benchmark_iterations(input):
             out[name] = benchmark
         elif benchmark["repetitions"] == 2:
             if benchmark["run_type"] == "iteration":
-                if name in out:
+                if "error_occurred" in benchmark:
+                    out.setdefault(name, benchmark)
+                elif name in out and "IterationTime" in out[name]:
                     # Use the minimum time to reduce the impact of flakes. Flakes are unlikely to improve performance,
                     # but may hurt performance due to some other process using CPU. Avoid using the median in the 2
                     # repetition case, because it reverts to the mean and is more sensitive to flakes.


### PR DESCRIPTION
## Summary

Fixes two independent runtime CI failures:

1. **`test_pow_fractional_composite`** — The test was using `torch.randn` which produces ~50% negative values. Computing `pow(negative, 2.54)` is undefined for real numbers, producing NaN in the PyTorch golden reference. This caused a PCC of ~0.64 against hardware output, failing the 0.99 threshold. The test was previously masked by `pytest -x` stopping at the earlier `test_indexed_slice` failure (fixed in #47296).

2. **`compare_pgm_dispatch_perf_ci.py`** — The script crashed with `KeyError: 'IterationTime'` when a Google Benchmark entry had `error_occurred` set (e.g. from Trace buffer OOM) and therefore lacked timing fields. The OOM trigger was separately fixed in #47766, but the script remains vulnerable to any future benchmark error.

## Changes

**`test_pow_fractional.py`**
- `torch.randn` → `torch.rand() + 0.01` to keep inputs strictly positive
- Legacy `ttnn.Tensor().to().to()` → `ttnn.from_torch()`
- Dropped `fast_and_approximate_mode=True` from `ttnn.log` (default is already `False`)

**`compare_pgm_dispatch_perf_ci.py`**
- Guard `IterationTime` access with `error_occurred` check in `add_benchmark_iterations()`
- Error entries are preserved via `setdefault` for downstream error-handling logic

## Test plan

- [x] `test_pow_fractional_composite` passes locally on Blackhole (PCC: 0.9955 composite, 0.9999 direct)
- [x] `compare_pgm_dispatch_perf_ci.py` verified with normal, error-only, and mixed benchmark inputs
- [ ] Runtime Integration Tests CI green
- [ ] Runtime Performance Tests CI green

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-runtime-ci-test-failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:msudumbrekar/fix-runtime-ci-test-failures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-runtime-ci-test-failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:msudumbrekar/fix-runtime-ci-test-failures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-unit-tests.yaml/badge.svg?branch=msudumbrekar/fix-runtime-ci-test-failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-unit-tests.yaml?query=branch:msudumbrekar/fix-runtime-ci-test-failures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-integration-tests.yaml/badge.svg?branch=msudumbrekar/fix-runtime-ci-test-failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-integration-tests.yaml?query=branch:msudumbrekar/fix-runtime-ci-test-failures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-perf-tests.yaml/badge.svg?branch=msudumbrekar/fix-runtime-ci-test-failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-perf-tests.yaml?query=branch:msudumbrekar/fix-runtime-ci-test-failures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=msudumbrekar/fix-runtime-ci-test-failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:msudumbrekar/fix-runtime-ci-test-failures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=msudumbrekar/fix-runtime-ci-test-failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:msudumbrekar/fix-runtime-ci-test-failures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=msudumbrekar/fix-runtime-ci-test-failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:msudumbrekar/fix-runtime-ci-test-failures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=msudumbrekar/fix-runtime-ci-test-failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:msudumbrekar/fix-runtime-ci-test-failures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=msudumbrekar/fix-runtime-ci-test-failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:msudumbrekar/fix-runtime-ci-test-failures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=msudumbrekar/fix-runtime-ci-test-failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:msudumbrekar/fix-runtime-ci-test-failures)