### PR TITLE
[skip ci][Cleanup] Fix accessor names in kernel_spec.hpp comments

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -123,7 +123,7 @@ struct KernelSpec {
 
     // DFB bindings
     // Declares that this kernel requires a DFB resource (declared at the ProgramSpec level)
-    // The kernel constructs the accessor via DataflowBufferAccessor(dfb::<accessor_name>)
+    // The kernel constructs the accessor via DataflowBuffer(dfb::<accessor_name>)
     struct DFBBinding {
         // Endpoint role this binding plays for the DFB.
         enum class EndpointType { PRODUCER, CONSUMER };
@@ -144,7 +144,7 @@ struct KernelSpec {
 
     // Semaphore bindings
     // Declares that this kernel accesses a semaphore resource (declared at the ProgramSpec level)
-    // The kernel constructs the accessor via SemaphoreAccessor(sem::<accessor_name>)
+    // The kernel constructs the accessor via Semaphore(sem::<accessor_name>)
     struct SemaphoreBinding {
         SemaphoreSpecName semaphore_spec_name;  // identify the semaphore within the ProgramSpec
         std::string accessor_name;              // semaphore accessor name (used in the kernel source code)


### PR DESCRIPTION
### PR Category

Comment Cleanup

### Summary

Two comments in `kernel_spec.hpp` named the wrong constructor for kernel-side resource accessors:

- DFB binding: `DataflowBufferAccessor(dfb::<name>)` → `DataflowBuffer(dfb::<name>)`
- Semaphore binding: `SemaphoreAccessor(sem::<name>)` → `Semaphore(sem::<name>)`

Verified against actual kernel usage in `tests/ttnn/unit_tests/gtests/accessor/kernels/` and `tests/tt_metal/tt_metal/data_movement/`.

### Notes for reviewers

Comment-only change, no functional impact.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/cleanup-kernel-spec-comments)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/cleanup-kernel-spec-comments)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/cleanup-kernel-spec-comments)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/cleanup-kernel-spec-comments)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/cleanup-kernel-spec-comments)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/cleanup-kernel-spec-comments)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/cleanup-kernel-spec-comments)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/cleanup-kernel-spec-comments)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/cleanup-kernel-spec-comments)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/cleanup-kernel-spec-comments)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/cleanup-kernel-spec-comments)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/cleanup-kernel-spec-comments)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/cleanup-kernel-spec-comments)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/cleanup-kernel-spec-comments)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/cleanup-kernel-spec-comments)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/cleanup-kernel-spec-comments)