### PR TITLE
fix(bundle-python): bundle CPython into _python/ subdir, fix pyvenv.cfg home

### DIFF
--- a/scripts/bundle_python_into_venv.sh
+++ b/scripts/bundle_python_into_venv.sh
@@ -125,12 +125,23 @@ if [[ ! -d "$CPYTHON_DIR/lib" ]]; then
     exit 1
 fi
 
-# Remove Python symlinks in venv/bin/ (they point to the external managed install)
-echo "  Removing external Python symlinks from $VENV_DIR/bin/..."
+# Copy CPython into a temporary location first. This is necessary because on a
+# --force re-run against an already-bundled venv, bin/python is a relative symlink
+# (../_python/bin/python) that readlink -f resolves to $VENV_DIR/_python/bin/python,
+# making CPYTHON_DIR == BUNDLED_PYTHON_DIR. Copying to a temp dir before removing
+# anything means the source is always intact when the copy runs.
+echo "  Copying Python interpreter into $BUNDLED_PYTHON_DIR/..."
+TMP_DIR="${BUNDLED_PYTHON_DIR}.tmp"
+rm -rf "$TMP_DIR"
+mkdir -p "$TMP_DIR"
+cp -r "$CPYTHON_DIR"/* "$TMP_DIR/"
+
+# Remove Python symlinks in venv/bin/ (they point to either the external managed
+# install or, on re-bundle, into the _python/ dir that is about to be replaced).
+echo "  Removing Python symlinks from $VENV_DIR/bin/..."
 rm -f "$VENV_DIR/bin/python"*
 
-# Copy CPython into a _python/ subdirectory within the venv.
-#
+# Atomically replace _python/ with the new copy.
 # We deliberately do NOT copy into the venv root. If we did, base_prefix would
 # equal prefix ($VENV_DIR), which causes Python, uv, and pip to conclude that
 # this is NOT a virtual environment — the same symptom as the bug we are fixing.
@@ -138,10 +149,8 @@ rm -f "$VENV_DIR/bin/python"*
 #   base_prefix = $VENV_DIR/_python   (derived from pyvenv.cfg.home)
 #   prefix      = $VENV_DIR
 #   base_prefix != prefix  =>  venv is correctly recognised.
-echo "  Copying Python interpreter into $BUNDLED_PYTHON_DIR/..."
-[[ "$FORCE_BUNDLE" == "--force" ]] && rm -rf "$BUNDLED_PYTHON_DIR"
-mkdir -p "$BUNDLED_PYTHON_DIR"
-cp -r "$CPYTHON_DIR"/* "$BUNDLED_PYTHON_DIR/"
+rm -rf "$BUNDLED_PYTHON_DIR"
+mv "$TMP_DIR" "$BUNDLED_PYTHON_DIR"
 
 # Create relative symlinks in venv/bin/ that point to the bundled interpreter.
 # Relative symlinks remain valid when the venv is mounted at any NFS path —

--- a/scripts/bundle_python_into_venv.sh
+++ b/scripts/bundle_python_into_venv.sh
@@ -21,17 +21,22 @@ usage() {
     cat <<EOF
     Bundle Python interpreter into a virtual environment.
 
-    This script deep-copies the Python interpreter into the venv, making it
-    fully self-contained and portable. This is necessary for multi-host SLURM
-    environments where the venv may be shared over NFS and each host needs
-    access to the Python interpreter without relying on symlinks to a Docker
-    container's local filesystem.
+    This script deep-copies the Python interpreter into the venv's _python/
+    subdirectory, making it fully self-contained and portable. This is necessary
+    for multi-host SLURM environments where the venv may be shared over NFS and
+    each host needs access to the Python interpreter without relying on symlinks
+    to a per-host managed Python installation.
+
+    Python binaries in bin/ are replaced with relative symlinks into _python/bin/,
+    and pyvenv.cfg.home is rewritten to match. Using a subdirectory (not the venv
+    root) ensures base_prefix (_python/) != prefix (venv root), which is required
+    for uv, pip, and Python's own site.py to recognise this as a virtual environment.
 
     Usage: $0 <venv_dir> [--force]
 
     Arguments:
       venv_dir    Path to the virtual environment directory
-      --force     Bundle even if Python is not symlinked (optional)
+      --force     Re-bundle even if _python/ already exists (optional)
 
     The script uses uv's Python installation structure:
       <UV_PYTHON_INSTALL_DIR>/cpython-<version>-<platform>/bin/python
@@ -60,22 +65,15 @@ if [[ ! -d "$VENV_DIR" ]]; then
     exit 1
 fi
 
-# Check if Python interpreter needs to be bundled by checking if any python executables are symlinks
+BUNDLED_PYTHON_DIR="$VENV_DIR/_python"
+
+# Bundling is needed if the _python/ subdirectory does not yet exist.
 needs_bundling() {
-    local venv_dir="$1"
-    (
-        shopt -s nullglob
-        for py_exec in "$venv_dir/bin/python" "$venv_dir/bin/python3" "$venv_dir/bin/python3".*; do
-            if [[ -e "$py_exec" && -L "$py_exec" ]]; then
-                return 0  # true - needs bundling
-            fi
-        done
-        return 1  # false - already bundled
-    )
+    [[ ! -d "$BUNDLED_PYTHON_DIR" ]]
 }
 
-if [[ "$FORCE_BUNDLE" != "--force" ]] && ! needs_bundling "$VENV_DIR"; then
-    echo "INFO: Python interpreter is already bundled in $VENV_DIR, skipping"
+if [[ "$FORCE_BUNDLE" != "--force" ]] && ! needs_bundling; then
+    echo "INFO: Python interpreter already bundled at $BUNDLED_PYTHON_DIR, skipping"
     exit 0
 fi
 
@@ -127,12 +125,59 @@ if [[ ! -d "$CPYTHON_DIR/lib" ]]; then
     exit 1
 fi
 
-# Remove python symlinks in venv (they will be replaced with bundled interpreter)
-echo "  Removing venv python symlinks..."
+# Remove Python symlinks in venv/bin/ (they point to the external managed install)
+echo "  Removing external Python symlinks from $VENV_DIR/bin/..."
 rm -f "$VENV_DIR/bin/python"*
 
-# Copy the cpython directory contents into the venv
-echo "  Copying Python interpreter files into venv..."
-cp -r "$CPYTHON_DIR"/* "$VENV_DIR/"
+# Copy CPython into a _python/ subdirectory within the venv.
+#
+# We deliberately do NOT copy into the venv root. If we did, base_prefix would
+# equal prefix ($VENV_DIR), which causes Python, uv, and pip to conclude that
+# this is NOT a virtual environment — the same symptom as the bug we are fixing.
+# Bundling into _python/ keeps:
+#   base_prefix = $VENV_DIR/_python   (derived from pyvenv.cfg.home)
+#   prefix      = $VENV_DIR
+#   base_prefix != prefix  =>  venv is correctly recognised.
+echo "  Copying Python interpreter into $BUNDLED_PYTHON_DIR/..."
+[[ "$FORCE_BUNDLE" == "--force" ]] && rm -rf "$BUNDLED_PYTHON_DIR"
+mkdir -p "$BUNDLED_PYTHON_DIR"
+cp -r "$CPYTHON_DIR"/* "$BUNDLED_PYTHON_DIR/"
+
+# Create relative symlinks in venv/bin/ that point to the bundled interpreter.
+# Relative symlinks remain valid when the venv is mounted at any NFS path —
+# the link resolves within the venv regardless of the absolute mount point.
+echo "  Creating relative symlinks to bundled interpreter..."
+for py_exec in python python3; do
+    [[ -f "$BUNDLED_PYTHON_DIR/bin/$py_exec" ]] && \
+        ln -sf "../_python/bin/$py_exec" "$VENV_DIR/bin/$py_exec"
+done
+for versioned_py in "$BUNDLED_PYTHON_DIR/bin/python3".[0-9]*; do
+    [[ -f "$versioned_py" ]] || continue
+    py_name=$(basename "$versioned_py")
+    ln -sf "../_python/bin/$py_name" "$VENV_DIR/bin/$py_name"
+done
+
+# Rewrite pyvenv.cfg.home to point at the bundled interpreter location.
+#
+# Before bundling: home = /usr/local/share/uv/cpython-3.12.X.../bin
+#   (the external managed install; no longer accessible after Docker build or on
+#    SLURM worker nodes that lack the uv managed Python installation)
+#
+# After bundling:  home = <venv>/_python/bin
+#   (bundled inside the venv; always accessible, relative to the venv root)
+#
+# uv runs Interpreter::query against venv/bin/python to validate the environment.
+# If home points to a path Python cannot locate its stdlib from, the query fails
+# and uv reports "No virtual environment found" even though VIRTUAL_ENV is set.
+PYVENV_CFG="$VENV_DIR/pyvenv.cfg"
+if [[ -f "$PYVENV_CFG" ]]; then
+    awk -v home="$BUNDLED_PYTHON_DIR/bin" '
+        /^home = /  { print "home = " home; next }
+        { print }
+    ' "$PYVENV_CFG" > "$PYVENV_CFG.tmp" && mv "$PYVENV_CFG.tmp" "$PYVENV_CFG"
+    echo "  Updated pyvenv.cfg: home = $BUNDLED_PYTHON_DIR/bin"
+else
+    echo "WARNING: $PYVENV_CFG not found — venv may not be recognised correctly" >&2
+fi
 
 echo "  Python interpreter bundled successfully"


### PR DESCRIPTION
## Problem

`uv pip install` in the `release-models` container fails with:

```
error: No virtual environment found
```

`bundle_python_into_venv.sh` deep-copies the CPython interpreter into the venv but leaves `pyvenv.cfg.home` pointing at the original uv-managed Python path (e.g. `/usr/local/share/uv/cpython-3.12.X.../bin`). That path only exists during the build stage — it is not present in the final image layer. When uv runs `Interpreter::query` against `$VIRTUAL_ENV/bin/python`, Python reads the stale `home`, cannot find its stdlib, and the query fails.

## Fix

Bundle CPython into a `_python/` subdirectory inside the venv, replace the external symlinks with relative intra-venv symlinks, and update `pyvenv.cfg.home` to match.

**Why a subdirectory and not the venv root:** if `home` pointed at `$VENV_DIR/bin`, Python would compute `base_prefix = $VENV_DIR` (parent of `home`), making `base_prefix == prefix`. Python, uv, and pip all use `base_prefix != prefix` to determine whether they are inside a virtual environment — the result would be the same failure via a different code path.

With `home = $VENV_DIR/_python/bin`:
- `base_prefix = $VENV_DIR/_python` ≠ `prefix = $VENV_DIR` → venv is correctly recognised ✓
- No dependency on the build-time managed Python path ✓
- Symlinks in `bin/` are relative (`../_python/bin/python*`) → portable across NFS mount paths ✓

## Changes

`scripts/bundle_python_into_venv.sh`:
- Copy CPython into `$VENV_DIR/_python/` instead of the venv root
- Replace `bin/python{,3,3.X}` external symlinks with relative symlinks into `_python/bin/`
- Rewrite `pyvenv.cfg.home` via `awk` after the copy
- `needs_bundling()` now checks for `_python/` existence (the symlink check would give false positives since `bin/python*` are still symlinks after the fix)

- [x] release docker smoke tests https://github.com/tenstorrent/tt-metal/actions/runs/28142631726
- [x] multihost physical https://github.com/tenstorrent/tt-metal/actions/runs/28147615371

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/bundle-python-venv-detection)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/bundle-python-venv-detection)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/bundle-python-venv-detection)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/bundle-python-venv-detection)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/bundle-python-venv-detection)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/bundle-python-venv-detection)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/bundle-python-venv-detection)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/bundle-python-venv-detection)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/bundle-python-venv-detection)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/bundle-python-venv-detection)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/bundle-python-venv-detection)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/bundle-python-venv-detection)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/bundle-python-venv-detection)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/bundle-python-venv-detection)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/bundle-python-venv-detection)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/bundle-python-venv-detection)