### PR TITLE
[skip ci] Add nightly cron to fabric cpu unit tests and add test scaffolding for merge gate

### DIFF
--- a/.github/scripts/utils/find-changed-files.sh
+++ b/.github/scripts/utils/find-changed-files.sh
@@ -139,7 +139,7 @@ while IFS= read -r FILE; do
             MODELS_CHANGED=true
             ANY_CODE_CHANGED=true
             ;;
-        .github/workflows/build-artifact.yaml|.github/workflows/build-docker-artifact.yaml|.github/workflows/ttsim.yaml|.github/workflows/fabric-cpu-only-tests-impl.yaml)
+        .github/workflows/build-artifact.yaml|.github/workflows/build-docker-artifact.yaml|.github/workflows/ttsim.yaml)
             BUILD_WORKFLOWS_CHANGED=true
             ANY_CODE_CHANGED=true
             ;;

--- a/.github/sku_config.yaml
+++ b/.github/sku_config.yaml
@@ -221,6 +221,10 @@ skus:
         exabox.tenstorrent.com/purpose: ci-metal
         exabox.tenstorrent.com/superpod: A29
 
+  cpu_medium:
+    runs_on:
+      - tt-ubuntu-2204-medium-stable
+
   # Synthetic CPU SKUs for ttsim simulator jobs. Tests using these SKUs run on
   # ubuntu-latest; the impl is expected to invoke .github/actions/setup-ttsim
   # gated on `startsWith(sku, 'sim_')` to download the matching libttsim_<arch>.so

--- a/.github/sku_config.yaml
+++ b/.github/sku_config.yaml
@@ -224,6 +224,9 @@ skus:
   cpu_medium:
     runs_on:
       - tt-ubuntu-2204-medium-stable
+  cpu_medium_prio:
+    runs_on:
+      - tt-ubuntu-2204-medium-prio-stable
 
   # Synthetic CPU SKUs for ttsim simulator jobs. Tests using these SKUs run on
   # ubuntu-latest; the impl is expected to invoke .github/actions/setup-ttsim

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -140,6 +140,7 @@ scaleout:
   smoke:
     wh_n300_civ2: 10
   unit:
+    cpu_medium: 90 # 6 fabric CPU-only shards × 15 min
     wh_llmbox: 60
     wh_galaxy: 25
   stress:

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -138,6 +138,8 @@ shield:
 # Former fabric + scaleout budgets merged under team scaleout (see tests/pipeline_reorg).
 scaleout:
   smoke:
+    cpu_medium: 10
+    cpu_medium_prio: 10
     wh_n300_civ2: 10
   unit:
     cpu_medium: 90 # 6 fabric CPU-only shards × 15 min

--- a/.github/workflows/fabric-cpu-only-tests-impl.yaml
+++ b/.github/workflows/fabric-cpu-only-tests-impl.yaml
@@ -8,6 +8,11 @@ on:
         type: string
         default: cpu_medium
         description: "SKU from sku_config.yaml selecting the CPU runner pool (e.g. cpu_medium)."
+      tests-yaml-path:
+        required: false
+        type: string
+        default: ./tests/pipeline_reorg/fabric_cpu_only_unit_tests.yaml
+        description: "Pipeline reorg test matrix YAML (e.g. fabric_cpu_only_smoke_merge_gate_tests.yaml for merge gate)."
       test-category:
         required: false
         type: string
@@ -29,7 +34,7 @@ jobs:
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
     env:
-      TESTS_YAML_PATH: ./tests/pipeline_reorg/fabric_cpu_only_unit_tests.yaml
+      TESTS_YAML_PATH: ${{ inputs.tests-yaml-path }}
     steps:
       - name: Checkout the repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/fabric-cpu-only-tests-impl.yaml
+++ b/.github/workflows/fabric-cpu-only-tests-impl.yaml
@@ -3,13 +3,11 @@ name: "[internal] Fabric cpu-only tests impl"
 on:
   workflow_call:
     inputs:
-      arch:
-        required: true
-        type: string
-      timeout:
+      test-category:
         required: false
-        type: number
-        default: 60
+        type: string
+        default: unit
+        description: "Time-budget workflow key passed to verify_time_budget.py (unit for fabric CPU-only tests)."
       build-artifact-name:
         required: true
         type: string
@@ -19,38 +17,54 @@ on:
       wheel-artifact-name:
         required: true
         type: string
-      runs-on:
-        required: false
-        type: string
-        default: "tt-ubuntu-2204-medium-stable"
-        description: "Runner label for fabric CPU-only unit tests"
 
 jobs:
+  load-test-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
+    env:
+      TESTS_YAML_PATH: ./tests/pipeline_reorg/fabric_cpu_only_unit_tests.yaml
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        timeout-minutes: 20
+        with:
+          sparse-checkout: |
+            .github
+            tests/pipeline_reorg
+          sparse-checkout-cone-mode: true
+      - name: Install dependencies
+        run: pip3 install PyYAML
+      - name: Verify test timeouts against budget
+        run: |
+          set -e
+          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
+          python3 .github/scripts/utils/verify_time_budget.py \
+            ${{ env.TESTS_YAML_PATH }} \
+            ./.github/time_budget.yaml \
+            "${{ inputs.test-category }}"
+      - name: Build unified test matrix based on enabled SKUs
+        id: build-matrix
+        run: |
+          python3 .github/scripts/utils/prepare_test_matrix.py \
+            ${{ env.TESTS_YAML_PATH }} \
+            "cpu_medium" \
+            ./.github/sku_config.yaml
+
   fabric-cpu-unit-tests:
-    name: ${{ inputs.arch }} fabric cpu unit tests (${{ matrix.shard.name }})
-    runs-on: ${{ inputs.runs-on }}
+    needs: load-test-matrix
+    if: ${{ needs.load-test-matrix.outputs.matrix != '[]' }}
     strategy:
       fail-fast: false
       matrix:
-        shard:
-          # Shard A (~6m20s): unit + phys-grouping + control-plane + t3k + wh-galaxy
-          - name: "unit-phys-ctrl-t3k-wh"
-            groups: "unit phys-grouping control-plane t3k wh-galaxy"
-          # BH galaxy, sharded by topology / cluster mock to keep each within the per-step timeout.
-          - name: "bh-slices"
-            groups: "bh-6u bh-single-galaxy bh-dual-galaxy bh-pod-pipeline bh-misc"
-          - name: "bh-sp4-glx"
-            groups: "bh-sp4-glx"
-          - name: "bh-subtorus"
-            groups: "bh-subtorus bh-subtorus-sc16"
-          - name: "bh-subtorus-sc20"
-            groups: "bh-subtorus-sc20"
-          - name: "bh-blitz-decode"
-            groups: "bh-blitz-decode"
+        test-group: ${{ fromJson(needs.load-test-matrix.outputs.matrix) }}
+    name: ${{ matrix.test-group.name }}
+    runs-on: ${{ matrix.test-group.runs_on }}
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
       env:
-        ARCH_NAME: ${{ inputs.arch }}
+        ARCH_NAME: ${{ matrix.test-group.arch }}
         LOGURU_LEVEL: INFO
         TT_LOGGER_LEVEL: warn
         LD_LIBRARY_PATH: /work/build/lib
@@ -77,14 +91,11 @@ jobs:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
           hang-detection-timeout: 20.0
-      - name: Run fabric cpu-only unit tests (${{ matrix.shard.name }})
-        timeout-minutes: ${{ inputs.timeout }}
+      - name: ${{ matrix.test-group.name }}
+        timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
-          # Keep commands in tests/scripts/multihost/run_fabric_cpu_only_unit_tests.sh (also runnable locally).
-          for g in ${{ matrix.shard.groups }}; do
-            ./tests/scripts/multihost/run_fabric_cpu_only_unit_tests.sh --group "$g"
-          done
-
+          mkdir -p generated/test_reports
+          ${{ matrix.test-group.cmd }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/fabric-cpu-only-tests-impl.yaml
+++ b/.github/workflows/fabric-cpu-only-tests-impl.yaml
@@ -3,6 +3,11 @@ name: "[internal] Fabric cpu-only tests impl"
 on:
   workflow_call:
     inputs:
+      runs-on-sku:
+        required: false
+        type: string
+        default: cpu_medium
+        description: "SKU from sku_config.yaml selecting the CPU runner pool (e.g. cpu_medium)."
       test-category:
         required: false
         type: string
@@ -49,7 +54,7 @@ jobs:
         run: |
           python3 .github/scripts/utils/prepare_test_matrix.py \
             ${{ env.TESTS_YAML_PATH }} \
-            "cpu_medium" \
+            "${{ inputs.runs-on-sku }}" \
             ./.github/sku_config.yaml
 
   fabric-cpu-unit-tests:

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -376,6 +376,21 @@ jobs:
       build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
 
+  # Fabric CPU-only tests removed from merge gate — https://github.com/tenstorrent/tt-metal/pull/47987
+  # Scaffolding kept for a future smoke subset (fabric_cpu_only_smoke_merge_gate_tests.yaml).
+  fabric-cpu-only-unit-tests:
+    needs: [build, resolve-docker-pull-refs, find-changes, check-harbor]
+    if: false
+    secrets: inherit
+    uses: ./.github/workflows/fabric-cpu-only-tests-impl.yaml
+    with:
+      tests-yaml-path: ./tests/pipeline_reorg/fabric_cpu_only_smoke_merge_gate_tests.yaml
+      test-category: smoke
+      runs-on-sku: ${{ github.event_name == 'merge_group' && 'cpu_medium_prio' || 'cpu_medium' }}
+      docker-image: ${{ needs.resolve-docker-pull-refs.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
+
   triage-tests:
     needs: [build, resolve-docker-pull-refs, find-changes, check-harbor]
     secrets: inherit
@@ -438,14 +453,14 @@ jobs:
         contains(join(needs.*.result, ','), 'success') ||
         contains(join(needs.*.result, ','), 'failure')
       }}
-    needs: [static-checks, docker-images, find-changes, build, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests, ttnn-merge-gate-tests, models-smoke-tests, tt-train-smoke-tests, triage-tests, fabric-unit-tests, llk-unit-tests]
+    needs: [static-checks, docker-images, find-changes, build, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests, ttnn-merge-gate-tests, models-smoke-tests, tt-train-smoke-tests, triage-tests, fabric-unit-tests, fabric-cpu-only-unit-tests, llk-unit-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Check if all jobs passed
         uses: tenstorrent/tt-metal/.github/actions/workflow-status@main
         with:
           required-jobs: "static-checks, find-changes"
-          optional-jobs: "build, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests, ttnn-merge-gate-tests, models-smoke-tests, tt-train-smoke-tests, triage-tests, fabric-unit-tests, llk-unit-tests"
+          optional-jobs: "build, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests, ttnn-merge-gate-tests, models-smoke-tests, tt-train-smoke-tests, triage-tests, fabric-unit-tests, fabric-cpu-only-unit-tests, llk-unit-tests"
         env:
           NEEDS_CONTEXT: "${{ toJSON(needs) }}"
       - if: (failure() && contains(join(needs.*.result, ','), 'failure') && github.event_name == 'merge_group')

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -378,6 +378,8 @@ jobs:
 
   # Fabric CPU-only tests removed from merge gate — https://github.com/tenstorrent/tt-metal/pull/47987
   # Scaffolding kept for a future smoke subset (fabric_cpu_only_smoke_merge_gate_tests.yaml).
+  # When re-enabling: uncomment tests in that yaml, replace `if: false` with a real trigger,
+  # and add fabric-cpu-only-unit-tests back to workflow-status needs + optional-jobs below.
   fabric-cpu-only-unit-tests:
     needs: [build, resolve-docker-pull-refs, find-changes, check-harbor]
     if: false
@@ -453,14 +455,14 @@ jobs:
         contains(join(needs.*.result, ','), 'success') ||
         contains(join(needs.*.result, ','), 'failure')
       }}
-    needs: [static-checks, docker-images, find-changes, build, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests, ttnn-merge-gate-tests, models-smoke-tests, tt-train-smoke-tests, triage-tests, fabric-unit-tests, fabric-cpu-only-unit-tests, llk-unit-tests]
+    needs: [static-checks, docker-images, find-changes, build, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests, ttnn-merge-gate-tests, models-smoke-tests, tt-train-smoke-tests, triage-tests, fabric-unit-tests, llk-unit-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Check if all jobs passed
         uses: tenstorrent/tt-metal/.github/actions/workflow-status@main
         with:
           required-jobs: "static-checks, find-changes"
-          optional-jobs: "build, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests, ttnn-merge-gate-tests, models-smoke-tests, tt-train-smoke-tests, triage-tests, fabric-unit-tests, fabric-cpu-only-unit-tests, llk-unit-tests"
+          optional-jobs: "build, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests, ttnn-merge-gate-tests, models-smoke-tests, tt-train-smoke-tests, triage-tests, fabric-unit-tests, llk-unit-tests"
         env:
           NEEDS_CONTEXT: "${{ toJSON(needs) }}"
       - if: (failure() && contains(join(needs.*.result, ','), 'failure') && github.event_name == 'merge_group')

--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -64,6 +64,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/fabric-cpu-only-tests-impl.yaml
     with:
+      runs-on-sku: cpu_medium
       docker-image: ${{ inputs.docker-image }}
       build-artifact-name: ${{ inputs.build-artifact-name }}
       wheel-artifact-name: ${{ inputs.wheel-artifact-name }}

--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -64,7 +64,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/fabric-cpu-only-tests-impl.yaml
     with:
-      arch: wormhole_b0
       docker-image: ${{ inputs.docker-image }}
       build-artifact-name: ${{ inputs.build-artifact-name }}
       wheel-artifact-name: ${{ inputs.wheel-artifact-name }}

--- a/.github/workflows/tm-fabric-tests.yaml
+++ b/.github/workflows/tm-fabric-tests.yaml
@@ -1,6 +1,9 @@
 name: "(TM-Fabric) Fabric Tests"
 
 on:
+  schedule:
+    # Once daily at 07:00 UTC — fabric CPU-only unit tests.
+    - cron: "0 7 * * *"
   workflow_dispatch:
     inputs:
       run-fabric-cpu-only-unit-tests:
@@ -82,6 +85,13 @@ on:
         type: boolean
         description: "Enable Link Time Optimization (LTO)"
 
+permissions:
+  contents: read
+  packages: write
+
+run-name: >-
+  (TM-Fabric) Fabric Tests${{ github.event_name == 'schedule' && ' [CPU-only scheduled]' || '' }}
+
 jobs:
   check-harbor:
     uses: ./.github/workflows/check-harbor.yaml
@@ -112,7 +122,7 @@ jobs:
         run: |
           matrix_items=()
 
-          # For workflow_dispatch, use inputs; for workflow_call/push, default to all true
+          # workflow_dispatch: checkbox inputs; schedule: CPU-only nightly; else: all test types.
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             run_cpu_only="${{ inputs.run-fabric-cpu-only-unit-tests }}"
             run_wh_n300="${{ inputs.run-wh-n300-fabric-tests }}"
@@ -122,6 +132,15 @@ jobs:
             bh_loudbox="${{ inputs.bh-runner-loudbox }}"
             bh_p300="${{ inputs.bh-runner-p300 }}"
             bh_quietbox_2="${{ inputs.bh-runner-quietbox-2 }}"
+          elif [[ "${{ github.event_name }}" == "schedule" ]]; then
+            run_cpu_only="true"
+            run_wh_n300="false"
+            run_wh_t3k="false"
+            run_wh_6u="false"
+            run_bh="false"
+            bh_loudbox="false"
+            bh_p300="false"
+            bh_quietbox_2="false"
           else
             # Default to true for workflow_call and push events
             run_cpu_only="true"

--- a/tests/pipeline_reorg/fabric_cpu_only_smoke_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/fabric_cpu_only_smoke_merge_gate_tests.yaml
@@ -4,7 +4,10 @@
 # Commands are kept in sync with tests/scripts/multihost/run_fabric_cpu_only_unit_tests.sh.
 # For max allowed timeout refer to .github/time_budget.yaml (scaleout -> smoke).
 #
-# Example entry disabled until merge gate re-enables fabric CPU tests (see #47987).
+# Empty until merge gate re-enables fabric CPU tests (see #47987). Uncomment the example
+# below before removing `if: false` on the merge-gate job.
+
+[]
 
 # - id: fabric-cpu-unit-smoke
 #   name: fabric cpu unit tests (unit)

--- a/tests/pipeline_reorg/fabric_cpu_only_smoke_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/fabric_cpu_only_smoke_merge_gate_tests.yaml
@@ -1,0 +1,19 @@
+# Fabric CPU-only merge-gate smoke matrix (subset of fabric_cpu_only_unit_tests.yaml).
+#
+# Each entry: name, cmd, skus, team, arch, owner_id.
+# Commands are kept in sync with tests/scripts/multihost/run_fabric_cpu_only_unit_tests.sh.
+# For max allowed timeout refer to .github/time_budget.yaml (scaleout -> smoke).
+#
+# Example entry disabled until merge gate re-enables fabric CPU tests (see #47987).
+
+# - id: fabric-cpu-unit-smoke
+#   name: fabric cpu unit tests (unit)
+#   cmd: ./tests/scripts/multihost/run_fabric_cpu_only_unit_tests.sh --group unit
+#   skus:
+#     cpu_medium:
+#       timeout: 10
+#     cpu_medium_prio:
+#       timeout: 10
+#   team: scaleout
+#   arch: wormhole_b0
+#   owner_id: U03FJB5TM5Y # Ridvan Song

--- a/tests/pipeline_reorg/fabric_cpu_only_unit_tests.yaml
+++ b/tests/pipeline_reorg/fabric_cpu_only_unit_tests.yaml
@@ -1,6 +1,6 @@
 # Fabric CPU-only unit test matrix (mock cluster / tt-run; no hardware).
 #
-# Each entry: name, cmd, skus, team, arch, owner_id.
+# Each entry: id, name, cmd, skus, team, arch, owner_id.
 # Commands are kept in sync with tests/scripts/multihost/run_fabric_cpu_only_unit_tests.sh.
 # For max allowed timeout refer to .github/time_budget.yaml (scaleout -> unit).
 

--- a/tests/pipeline_reorg/fabric_cpu_only_unit_tests.yaml
+++ b/tests/pipeline_reorg/fabric_cpu_only_unit_tests.yaml
@@ -1,0 +1,77 @@
+# Fabric CPU-only unit test matrix (mock cluster / tt-run; no hardware).
+#
+# Each entry: name, cmd, skus, team, arch, owner_id.
+# Commands are kept in sync with tests/scripts/multihost/run_fabric_cpu_only_unit_tests.sh.
+# For max allowed timeout refer to .github/time_budget.yaml (scaleout -> unit).
+
+- id: fabric-cpu-unit-phys-ctrl-t3k-wh
+  name: fabric cpu unit tests (unit-phys-ctrl-t3k-wh)
+  cmd: |
+    ./tests/scripts/multihost/run_fabric_cpu_only_unit_tests.sh --group unit
+    ./tests/scripts/multihost/run_fabric_cpu_only_unit_tests.sh --group phys-grouping
+    ./tests/scripts/multihost/run_fabric_cpu_only_unit_tests.sh --group control-plane
+    ./tests/scripts/multihost/run_fabric_cpu_only_unit_tests.sh --group t3k
+    ./tests/scripts/multihost/run_fabric_cpu_only_unit_tests.sh --group wh-galaxy
+  skus:
+    cpu_medium:
+      timeout: 15
+  team: scaleout
+  arch: wormhole_b0
+  owner_id: U03FJB5TM5Y # Ridvan Song
+
+- id: fabric-cpu-bh-slices
+  name: fabric cpu unit tests (bh-slices)
+  cmd: |
+    ./tests/scripts/multihost/run_fabric_cpu_only_unit_tests.sh --group bh-6u
+    ./tests/scripts/multihost/run_fabric_cpu_only_unit_tests.sh --group bh-single-galaxy
+    ./tests/scripts/multihost/run_fabric_cpu_only_unit_tests.sh --group bh-dual-galaxy
+    ./tests/scripts/multihost/run_fabric_cpu_only_unit_tests.sh --group bh-pod-pipeline
+    ./tests/scripts/multihost/run_fabric_cpu_only_unit_tests.sh --group bh-misc
+  skus:
+    cpu_medium:
+      timeout: 15
+  team: scaleout
+  arch: wormhole_b0
+  owner_id: U03FJB5TM5Y # Ridvan Song
+
+- id: fabric-cpu-bh-sp4-glx
+  name: fabric cpu unit tests (bh-sp4-glx)
+  cmd: ./tests/scripts/multihost/run_fabric_cpu_only_unit_tests.sh --group bh-sp4-glx
+  skus:
+    cpu_medium:
+      timeout: 15
+  team: scaleout
+  arch: wormhole_b0
+  owner_id: U03FJB5TM5Y # Ridvan Song
+
+- id: fabric-cpu-bh-subtorus
+  name: fabric cpu unit tests (bh-subtorus)
+  cmd: |
+    ./tests/scripts/multihost/run_fabric_cpu_only_unit_tests.sh --group bh-subtorus
+    ./tests/scripts/multihost/run_fabric_cpu_only_unit_tests.sh --group bh-subtorus-sc16
+  skus:
+    cpu_medium:
+      timeout: 15
+  team: scaleout
+  arch: wormhole_b0
+  owner_id: U03FJB5TM5Y # Ridvan Song
+
+- id: fabric-cpu-bh-subtorus-sc20
+  name: fabric cpu unit tests (bh-subtorus-sc20)
+  cmd: ./tests/scripts/multihost/run_fabric_cpu_only_unit_tests.sh --group bh-subtorus-sc20
+  skus:
+    cpu_medium:
+      timeout: 15
+  team: scaleout
+  arch: wormhole_b0
+  owner_id: U03FJB5TM5Y # Ridvan Song
+
+- id: fabric-cpu-bh-blitz-decode
+  name: fabric cpu unit tests (bh-blitz-decode)
+  cmd: ./tests/scripts/multihost/run_fabric_cpu_only_unit_tests.sh --group bh-blitz-decode
+  skus:
+    cpu_medium:
+      timeout: 15
+  team: scaleout
+  arch: wormhole_b0
+  owner_id: U03FJB5TM5Y # Ridvan Song

--- a/tests/scripts/multihost/run_fabric_cpu_only_unit_tests.sh
+++ b/tests/scripts/multihost/run_fabric_cpu_only_unit_tests.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Fabric CPU-only unit test driver (same commands as .github/workflows/fabric-cpu-only-tests-impl.yaml).
+# Fabric CPU-only unit test driver (keep in sync with tests/pipeline_reorg/fabric_cpu_only_*_tests.yaml).
 # Run from repository root, or from anywhere (script cds to root). Requires a built tree under ./build.
 # Requires bash (not sh/dash): bash ./tests/scripts/multihost/run_fabric_cpu_only_unit_tests.sh ...
 #


### PR DESCRIPTION
### PR Category
Infra

### Summary
Follow up to https://github.com/tenstorrent/tt-metal/pull/47987

This PR adds a cron trigger to `tm-fabric-tests.yaml` that only runs fabric cpu unit tests nightly.
The tests have also been put into pipeline reorg format: tests now live in `tests/pipeline_reorg/fabric_cpu_only_unit_tests.yaml` and `tests/pipeline_reorg/fabric_cpu_only_smoke_merge_gate_tests.yaml`

Testing: 

- [x] Manual dispatch on tm fabric tests pipeline https://github.com/tenstorrent/tt-metal/actions/runs/28136178987
- [ ] Manual dispatch on merge gate https://github.com/tenstorrent/tt-metal/actions/runs/28183150918


### Notes for reviewers
This PR does NOT enable the fabric cpu unit tests for merge gate. If the tests are stable at a later date, the scaffolding in `tests/pipeline_reorg/fabric_cpu_only_smoke_merge_gate_tests.yaml` can be used to reenable some subset of tests.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=roseli/move-fabric-cpu-tests-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:roseli/move-fabric-cpu-tests-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=roseli/move-fabric-cpu-tests-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:roseli/move-fabric-cpu-tests-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=roseli/move-fabric-cpu-tests-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:roseli/move-fabric-cpu-tests-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=roseli/move-fabric-cpu-tests-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:roseli/move-fabric-cpu-tests-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=roseli/move-fabric-cpu-tests-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:roseli/move-fabric-cpu-tests-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=roseli/move-fabric-cpu-tests-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:roseli/move-fabric-cpu-tests-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=roseli/move-fabric-cpu-tests-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:roseli/move-fabric-cpu-tests-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=roseli/move-fabric-cpu-tests-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:roseli/move-fabric-cpu-tests-2)