### PR TITLE
Std algo refactor

### DIFF
--- a/tests/tt_metal/test_utils/comparison.hpp
+++ b/tests/tt_metal/test_utils/comparison.hpp
@@ -50,13 +50,14 @@ bool is_close_vectors(
         vec_a.size(),
         vec_b.size());
 
-    for (unsigned int i = 0; i < vec_a.size(); i++) {
-        if (not comparison_function(vec_a.at(i), vec_b.at(i))) {
-            if (argfail) {
-                *argfail = i;
-            }
-            return false;
+    auto it = std::mismatch(vec_a.begin(), vec_a.end(), vec_b.begin(), [&](const ValueType& a, const ValueType& b) {
+        return comparison_function(a, b);
+    });
+    if (it.first != vec_a.end()) {
+        if (argfail) {
+            *argfail = static_cast<int>(std::distance(vec_a.begin(), it.first));
         }
+        return false;
     }
     return true;
 }

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_once.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_once.cpp
@@ -71,9 +71,7 @@ inline bool lookup_devices_or_fail(
 // Generate deterministic TX pattern.
 inline std::vector<uint32_t> make_tx_pattern(size_t n_words) {
     std::vector<uint32_t> tx(n_words);
-    for (size_t i = 0; i < n_words; ++i) {
-        tx[i] = 0xA5A50000u + static_cast<uint32_t>(i);
-    }
+    std::iota(tx.begin(), tx.end(), 0xA5A50000u);
     return tx;
 }
 
@@ -83,12 +81,11 @@ inline void verify_payload_words(const std::vector<uint32_t>& rx, const std::vec
         ADD_FAILURE() << "RX size mismatch: got " << rx.size() << " words, expected " << tx.size();
         return;
     }
-    for (size_t i = 0; i < rx.size(); ++i) {
-        if (rx[i] != tx[i]) {
-            ADD_FAILURE() << "Data mismatch at word " << i << " (got 0x" << std::hex << rx[i] << ", exp 0x" << tx[i]
-                          << std::dec << ")";
-            return;
-        }
+    auto it = std::mismatch(rx.begin(), rx.end(), tx.begin());
+    if (it.first != rx.end()) {
+        const size_t i = static_cast<size_t>(it.first - rx.begin());
+        ADD_FAILURE() << "Data mismatch at word " << i << " (got 0x" << std::hex << *it.first << ", exp 0x"
+                      << *it.second << std::dec << ")";
     }
     // OK -> no failure emitted
 }

--- a/tests/tt_metal/tt_fabric/common/utils.cpp
+++ b/tests/tt_metal/tt_fabric/common/utils.cpp
@@ -539,13 +539,10 @@ void expect_mesh_graph_host_topology_matches_runtime(const ControlPlane& control
             << "rank " << mpi_rank << " mesh " << *mesh_id << " local physical mesh shape must match MGD slice";
 
         const auto& local_chip_mapping = topology_mapper.get_local_logical_mesh_chip_id_to_physical_chip_id_mapping();
-        size_t mapped_chips_on_mesh = 0;
-        for (const auto& [fabric_node_id, physical_chip_id] : local_chip_mapping) {
-            (void)physical_chip_id;
-            if (fabric_node_id.mesh_id == mesh_id) {
-                ++mapped_chips_on_mesh;
-            }
-        }
+        size_t mapped_chips_on_mesh = static_cast<size_t>(
+            std::count_if(local_chip_mapping.begin(), local_chip_mapping.end(), [&](const auto& entry) {
+                return entry.first.mesh_id == mesh_id;
+            }));
         EXPECT_EQ(mapped_chips_on_mesh, expected_local_shape.mesh_size())
             << "rank " << mpi_rank << " mesh " << *mesh_id
             << " mapped device count must match MGD per-host chip "

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/addrgen_write/multicast_runner.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/addrgen_write/multicast_runner.cpp
@@ -45,9 +45,7 @@ inline bool validate_workload_or_fail(const AddrgenTestParams& p) {
 // Generate deterministic TX pattern.
 inline std::vector<uint32_t> make_tx_pattern(size_t n_words) {
     std::vector<uint32_t> tx(n_words);
-    for (size_t i = 0; i < n_words; ++i) {
-        tx[i] = 0xA5A50000u + static_cast<uint32_t>(i);
-    }
+    std::iota(tx.begin(), tx.end(), 0xA5A50000u);
     return tx;
 }
 
@@ -57,12 +55,11 @@ inline void verify_payload_words(const std::vector<uint32_t>& rx, const std::vec
         ADD_FAILURE() << "RX size mismatch: got " << rx.size() << " words, expected " << tx.size();
         return;
     }
-    for (size_t i = 0; i < rx.size(); ++i) {
-        if (rx[i] != tx[i]) {
-            ADD_FAILURE() << "Data mismatch at word " << i << " (got 0x" << std::hex << rx[i] << ", exp 0x" << tx[i]
-                          << std::dec << ")";
-            return;
-        }
+    auto it = std::mismatch(rx.begin(), rx.end(), tx.begin());
+    if (it.first != rx.end()) {
+        const size_t i = static_cast<size_t>(it.first - rx.begin());
+        ADD_FAILURE() << "Data mismatch at word " << i << " (got 0x" << std::hex << *it.first << ", exp 0x"
+                      << *it.second << std::dec << ")";
     }
 }
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/addrgen_write/unicast_runner.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/addrgen_write/unicast_runner.cpp
@@ -78,9 +78,7 @@ inline bool lookup_devices_or_fail(
 // Generate deterministic TX pattern.
 inline std::vector<uint32_t> make_tx_pattern(size_t n_words) {
     std::vector<uint32_t> tx(n_words);
-    for (size_t i = 0; i < n_words; ++i) {
-        tx[i] = 0xA5A50000u + static_cast<uint32_t>(i);
-    }
+    std::iota(tx.begin(), tx.end(), 0xA5A50000u);
     return tx;
 }
 
@@ -90,12 +88,11 @@ inline void verify_payload_words(const std::vector<uint32_t>& rx, const std::vec
         ADD_FAILURE() << "RX size mismatch: got " << rx.size() << " words, expected " << tx.size();
         return;
     }
-    for (size_t i = 0; i < rx.size(); ++i) {
-        if (rx[i] != tx[i]) {
-            ADD_FAILURE() << "Data mismatch at word " << i << " (got 0x" << std::hex << rx[i] << ", exp 0x" << tx[i]
-                          << std::dec << ")";
-            return;
-        }
+    auto it = std::mismatch(rx.begin(), rx.end(), tx.begin());
+    if (it.first != rx.end()) {
+        const size_t i = static_cast<size_t>(it.first - rx.begin());
+        ADD_FAILURE() << "Data mismatch at word " << i << " (got 0x" << std::hex << *it.first << ", exp 0x"
+                      << *it.second << std::dec << ")";
     }
     // OK -> no failure emitted
 }

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -570,11 +570,10 @@ TEST_F(ControlPlaneFixture, TestSingleGalaxyControlPlaneInit) {
     auto physical_chip_id_0 = control_plane->get_physical_chip_id_from_fabric_node_id(fabric_node_id_0);
     const auto& chip_unique_ids = cluster.get_unique_chip_ids();
     uint64_t asic_id_0 = 0;
-    for (const auto& [chip_id, unique_id] : chip_unique_ids) {
-        if (chip_id == physical_chip_id_0) {
-            asic_id_0 = unique_id;
-            break;
-        }
+    auto it0 = std::find_if(
+        chip_unique_ids.begin(), chip_unique_ids.end(), [&](const auto& p) { return p.first == physical_chip_id_0; });
+    if (it0 != chip_unique_ids.end()) {
+        asic_id_0 = it0->second;
     }
     EXPECT_GT(asic_id_0, 0) << "ASIC ID should be greater than 0 for fabric node id 0";
     auto tray_id_0 = physical_system_descriptor->get_tray_id(tt::tt_metal::AsicID{asic_id_0});
@@ -586,11 +585,10 @@ TEST_F(ControlPlaneFixture, TestSingleGalaxyControlPlaneInit) {
     FabricNodeId fabric_node_id_1(MeshId{0}, 1);
     auto physical_chip_id_1 = control_plane->get_physical_chip_id_from_fabric_node_id(fabric_node_id_1);
     uint64_t asic_id_1 = 0;
-    for (const auto& [chip_id, unique_id] : chip_unique_ids) {
-        if (chip_id == physical_chip_id_1) {
-            asic_id_1 = unique_id;
-            break;
-        }
+    auto it1 = std::find_if(
+        chip_unique_ids.begin(), chip_unique_ids.end(), [&](const auto& p) { return p.first == physical_chip_id_1; });
+    if (it1 != chip_unique_ids.end()) {
+        asic_id_1 = it1->second;
     }
     EXPECT_GT(asic_id_1, 0) << "ASIC ID should be greater than 0 for fabric node id 1";
     auto tray_id_1 = physical_system_descriptor->get_tray_id(tt::tt_metal::AsicID{asic_id_1});
@@ -603,11 +601,11 @@ TEST_F(ControlPlaneFixture, TestSingleGalaxyControlPlaneInit) {
     FabricNodeId fabric_node_id_y_size(MeshId{0}, y_size);
     auto physical_chip_id_y_size = control_plane->get_physical_chip_id_from_fabric_node_id(fabric_node_id_y_size);
     uint64_t asic_id_y_size = 0;
-    for (const auto& [chip_id, unique_id] : chip_unique_ids) {
-        if (chip_id == physical_chip_id_y_size) {
-            asic_id_y_size = unique_id;
-            break;
-        }
+    auto it_ys = std::find_if(chip_unique_ids.begin(), chip_unique_ids.end(), [&](const auto& p) {
+        return p.first == physical_chip_id_y_size;
+    });
+    if (it_ys != chip_unique_ids.end()) {
+        asic_id_y_size = it_ys->second;
     }
     EXPECT_GT(asic_id_y_size, 0) << "ASIC ID should be greater than 0 for fabric node id " << y_size;
     auto tray_id_y_size = physical_system_descriptor->get_tray_id(tt::tt_metal::AsicID{asic_id_y_size});
@@ -1470,13 +1468,8 @@ void validate_sp5_blitz_decode_pipeline_stages(
         auto pairs =
             control_plane.get_intermesh_exit_peer_fabric_node_id_pairs_between_meshes(curr_mesh_id, next_mesh_id);
 
-        bool found = false;
-        for (const auto& [exit_node, peer_node] : pairs) {
-            if (exit_node == exit_fn && peer_node == entry_fn) {
-                found = true;
-                break;
-            }
-        }
+        bool found = std::any_of(
+            pairs.begin(), pairs.end(), [&](const auto& p) { return p.first == exit_fn && p.second == entry_fn; });
         EXPECT_TRUE(found) << "Stages [" << i << "]->[" << (i + 1) << "]: exit (M" << *curr_mesh_id << "D"
                            << exit_chip_id << ") coord " << coord_str(curr.exit_node_coord)
                            << " is not physically connected to entry (M" << *next_mesh_id << "D" << entry_chip_id

--- a/tests/tt_metal/tt_metal/api/tensor/common_tensor_test_utils.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/common_tensor_test_utils.cpp
@@ -4,6 +4,7 @@
 
 #include "common_tensor_test_utils.hpp"
 
+#include <algorithm>
 #include <cstddef>
 #include <vector>
 
@@ -39,11 +40,10 @@ void test_tensor_on_device(
     enqueue_write_tensor(cq, host_data.data(), tensor);
     enqueue_read_tensor(cq, tensor, readback_data.data());
 
-    for (size_t i = 0; i < input_buf_size; i++) {
-        EXPECT_EQ(host_data[i], readback_data[i]);
-        if (host_data[i] != readback_data[i]) {
-            break;
-        }
+    auto it = std::mismatch(host_data.begin(), host_data.end(), readback_data.begin());
+    if (it.first != host_data.end()) {
+        const size_t i = static_cast<size_t>(it.first - host_data.begin());
+        EXPECT_EQ(*it.first, *it.second) << "First mismatch at index " << i;
     }
 
     EXPECT_EQ(tensor.padded_shape(), layout.compute_padded_shape(input_shape));

--- a/tests/tt_metal/tt_metal/api/tensor/common_tensor_test_utils.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/common_tensor_test_utils.cpp
@@ -30,9 +30,9 @@ void test_tensor_on_device(
     std::vector<std::byte> readback_data(input_buf_size);
 
     constexpr int random_prime_number = 4051;
-    for (size_t i = 0; i < input_buf_size; i++) {
-        host_data[i] = static_cast<std::byte>(i % random_prime_number);
-    }
+    size_t fill_idx = 0;
+    std::generate(
+        host_data.begin(), host_data.end(), [&] { return static_cast<std::byte>(fill_idx++ % random_prime_number); });
 
     auto tensor = MeshTensor::allocate_on_device(device, TensorSpec(input_shape, layout), TensorTopology());
 

--- a/tests/tt_metal/tt_metal/api/tensor/test_tensor_nd_sharding.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_tensor_nd_sharding.cpp
@@ -39,6 +39,7 @@
 #include <chrono>
 #include <cstdint>
 #include <memory>
+#include <numeric>
 #include <tuple>
 
 #include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
@@ -1205,9 +1206,7 @@ TEST_P(NDShardingTests, LoopbackTest) {
 
     size_t volume = params.shape.volume();
     std::vector<uint16_t> data(volume);
-    for (size_t i = 0; i < volume; i++) {
-        data[i] = static_cast<uint16_t>(i);
-    }
+    std::iota(data.begin(), data.end(), uint16_t{0});
 
     auto host_tensor = HostTensor::from_vector(data, tensor_spec);
     auto& cq = mesh_device_->mesh_command_queue();
@@ -1310,9 +1309,7 @@ TEST_F(NDShardingPerfTests, TestBatchShardingPerf) {
 
     size_t volume = tensor_shape.volume();
     std::vector<uint16_t> data(volume);
-    for (size_t i = 0; i < volume; i++) {
-        data[i] = static_cast<uint16_t>(i);
-    }
+    std::iota(data.begin(), data.end(), uint16_t{0});
 
     auto measure_to_device_time_ns = [&](const TensorSpec& tensor_spec) -> double {
         auto host_tensor = HostTensor::from_vector(data, tensor_spec);

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_binary_bcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_binary_bcast.cpp
@@ -5,6 +5,7 @@
 #include <fmt/base.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cassert>
 #include <cstdint>
 #include <cstring>
@@ -311,19 +312,25 @@ bool run_sfpu_binary_bcast(const std::shared_ptr<distributed::MeshDevice>& mesh_
     const float atol = is_fp32 ? 0.0f : 1.0f / 128.0f;
     const float rtol = is_fp32 ? 1e-6f : 1.0f / 128.0f;
 
+    const auto within_tol = [&](float g, float d) { return std::fabs(g - d) <= std::max(atol, rtol * std::fabs(g)); };
+
     size_t num_mismatches = 0;
-    const size_t max_report = 8;
-    for (size_t i = 0; i < device_f.size(); ++i) {
-        const float g = golden_f[i];
-        const float d = device_f[i];
-        const float diff = std::fabs(g - d);
-        const float tol = std::max(atol, rtol * std::fabs(g));
-        if (diff > tol) {
-            if (num_mismatches < max_report) {
-                log_error(tt::LogTest, "Mismatch at flat idx {}: golden={} device={} diff={}", i, g, d, diff);
-            }
-            ++num_mismatches;
+    constexpr size_t max_report = 8;
+    auto g_it = golden_f.cbegin(), d_it = device_f.cbegin();
+    const auto g_end = golden_f.cend();
+    while (g_it != g_end) {
+        auto [m1, m2] = std::mismatch(g_it, g_end, d_it, within_tol);
+        if (m1 == g_end) {
+            break;
         }
+        if (num_mismatches < max_report) {
+            const size_t i = static_cast<size_t>(m1 - golden_f.cbegin());
+            log_error(
+                tt::LogTest, "Mismatch at flat idx {}: golden={} device={} diff={}", i, *m1, *m2, std::fabs(*m1 - *m2));
+        }
+        ++num_mismatches;
+        g_it = std::next(m1);
+        d_it = std::next(m2);
     }
     if (num_mismatches != 0) {
         log_error(tt::LogTest, "Total mismatches: {}/{}", num_mismatches, device_f.size());

--- a/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
@@ -204,16 +204,18 @@ bool check_is_close(
         }
         auto gold_bf16 = unpack_vector<bfloat16, uint32_t>(packed_golden);
         auto res_bf16 = unpack_vector<bfloat16, uint32_t>(device_res);
-        for (size_t i = 0; i < gold_bf16.size(); i++) {
-            if (!is_close(gold_bf16[i], res_bf16[i], 0.0)) {
-                log_unpacked_vectors_for_mismatch(result_label, gold_bf16, res_bf16);
-                TT_THROW(
-                    "{} mismatch at index {} golden={} device={}",
-                    result_label,
-                    i,
-                    static_cast<float>(gold_bf16[i]),
-                    static_cast<float>(res_bf16[i]));
-            }
+        auto it = std::mismatch(gold_bf16.begin(), gold_bf16.end(), res_bf16.begin(), [](bfloat16 a, bfloat16 b) {
+            return is_close(a, b, 0.0f);
+        });
+        if (it.first != gold_bf16.end()) {
+            const size_t i = static_cast<size_t>(it.first - gold_bf16.begin());
+            log_unpacked_vectors_for_mismatch(result_label, gold_bf16, res_bf16);
+            TT_THROW(
+                "{} mismatch at index {} golden={} device={}",
+                result_label,
+                i,
+                static_cast<float>(*it.first),
+                static_cast<float>(*it.second));
         }
         return true;
     }
@@ -226,17 +228,14 @@ bool check_is_close(
         if (gold_refloat.size() != res_refloat.size()) {
             TT_THROW("{} mismatch: size golden={} device={}", result_label, gold_refloat.size(), res_refloat.size());
         }
-        for (size_t i = 0; i < gold_refloat.size(); i++) {
-            if (std::fabs(gold_refloat[i] - res_refloat[i]) > atol) {
-                log_unpacked_vectors_for_mismatch(result_label, gold_refloat, res_refloat);
-                TT_THROW(
-                    "{} mismatch at index {} A={} B={} atol={}",
-                    result_label,
-                    i,
-                    gold_refloat[i],
-                    res_refloat[i],
-                    atol);
-            }
+        auto it =
+            std::mismatch(gold_refloat.begin(), gold_refloat.end(), res_refloat.begin(), [atol](float a, float b) {
+                return std::fabs(a - b) <= atol;
+            });
+        if (it.first != gold_refloat.end()) {
+            const size_t i = static_cast<size_t>(it.first - gold_refloat.begin());
+            log_unpacked_vectors_for_mismatch(result_label, gold_refloat, res_refloat);
+            TT_THROW("{} mismatch at index {} A={} B={} atol={}", result_label, i, *it.first, *it.second, atol);
         }
         return true;
     }

--- a/tests/tt_metal/tt_metal/test_sdpa_reduce_c.cpp
+++ b/tests/tt_metal/tt_metal/test_sdpa_reduce_c.cpp
@@ -62,10 +62,10 @@ static std::vector<bfloat16> golden_reduce_c(
     std::vector<bfloat16> out(rows * stats_cols, static_cast<bfloat16>(0.0f));
 
     for (uint32_t r = 0; r < rows; ++r) {
-        float row_max = -std::numeric_limits<float>::infinity();
-        for (uint32_t c = 0; c < cols; ++c) {
-            row_max = std::max(row_max, static_cast<float>(qk_im_rm[(r * cols) + c]));
-        }
+        auto row_begin = qk_im_rm.begin() + r * cols;
+        float row_max = static_cast<float>(*std::max_element(row_begin, row_begin + cols, [](bfloat16 a, bfloat16 b) {
+            return static_cast<float>(a) < static_cast<float>(b);
+        }));
         if (do_eltwise_max) {
             float working_row_max = row_max;
             row_max = std::max(row_max, static_cast<float>(prev_max_first_col[r]));

--- a/tests/ttnn/unit_tests/gtests/common_test_utils.cpp
+++ b/tests/ttnn/unit_tests/gtests/common_test_utils.cpp
@@ -4,6 +4,7 @@
 
 #include "common_test_utils.hpp"
 
+#include <algorithm>
 #include <cstddef>
 #include <cmath>
 #include <limits>
@@ -165,35 +166,30 @@ NonfiniteReport check_nonfinite_positions(const std::vector<float>& actual, cons
         return NonfiniteReport{};
     }
     NonfiniteReport report;
-    for (std::size_t i = 0; i < actual.size(); ++i) {
-        const float a = actual[i];
-        const float b = expected[i];
-        const bool a_is_nan = std::isnan(a);
-        const bool b_is_nan = std::isnan(b);
-        const bool a_is_inf = std::isinf(a);
-        const bool b_is_inf = std::isinf(b);
 
-        if (a_is_nan || b_is_nan || a_is_inf || b_is_inf) {
-            report.any_nonfinite = true;
-        }
+    report.any_nonfinite = std::any_of(actual.cbegin(), actual.cend(), [](float a) { return !std::isfinite(a); }) ||
+                           std::any_of(expected.cbegin(), expected.cend(), [](float b) { return !std::isfinite(b); });
 
-        // NaN positions must match exactly.
-        if (a_is_nan != b_is_nan) {
-            report.positions_match = false;
-            report.first_mismatch_index = i;
-            report.first_mismatch_actual = a;
-            report.first_mismatch_expected = b;
-            return report;
+    // NaN positions must match; Inf positions and signs must match.
+    const auto nonfinite_positions_match = [](float a, float b) {
+        if (std::isnan(a) != std::isnan(b)) {
+            return false;
         }
-        // Inf positions and signs must match exactly.  std::signbit picks +/- correctly
-        // for both +inf and -inf, so comparing it only when both are Inf is sufficient.
-        if (a_is_inf != b_is_inf || (a_is_inf && b_is_inf && std::signbit(a) != std::signbit(b))) {
-            report.positions_match = false;
-            report.first_mismatch_index = i;
-            report.first_mismatch_actual = a;
-            report.first_mismatch_expected = b;
-            return report;
+        if (std::isinf(a) != std::isinf(b)) {
+            return false;
         }
+        if (std::isinf(a) && std::isinf(b) && std::signbit(a) != std::signbit(b)) {
+            return false;
+        }
+        return true;
+    };
+
+    auto [it_a, it_b] = std::mismatch(actual.cbegin(), actual.cend(), expected.cbegin(), nonfinite_positions_match);
+    if (it_a != actual.cend()) {
+        report.positions_match = false;
+        report.first_mismatch_index = static_cast<size_t>(it_a - actual.cbegin());
+        report.first_mismatch_actual = *it_a;
+        report.first_mismatch_expected = *it_b;
     }
     return report;
 }

--- a/tests/ttnn/unit_tests/gtests/udm/copy/test_udm_copy.cpp
+++ b/tests/ttnn/unit_tests/gtests/udm/copy/test_udm_copy.cpp
@@ -4,7 +4,7 @@
 
 #include <gtest/gtest.h>
 
-#include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
+#include <algorithm>
 #include "tests/ttnn/unit_tests/gtests/udm/test_udm_utils.hpp"
 
 #include <tt-metalium/experimental/udm/mesh_kernel.hpp>
@@ -138,22 +138,30 @@ inline void validate(
     auto actual_data = ttnn::distributed::aggregate_tensor(actual_tensor, *composer).to_vector<bfloat16>();
 
     // Compare values
-    uint32_t volume = expected_data.size();
+    const uint32_t volume = static_cast<uint32_t>(expected_data.size());
     uint32_t mismatches = 0;
+    uint32_t printed = 0;
     const uint32_t max_print_mismatches = 10;
-
-    for (uint32_t i = 0; i < volume; ++i) {
-        if (expected_data[i] != actual_data[i]) {
-            if (mismatches < max_print_mismatches) {
-                log_error(
-                    tt::LogTest,
-                    "Mismatch at index {}: expected={}, actual={}",
-                    i,
-                    static_cast<float>(expected_data[i]),
-                    static_cast<float>(actual_data[i]));
-            }
-            mismatches++;
+    auto exp_it = expected_data.cbegin(), act_it = actual_data.cbegin();
+    const auto exp_end = expected_data.cend();
+    while (exp_it != exp_end) {
+        auto [m1, m2] = std::mismatch(exp_it, exp_end, act_it);
+        if (m1 == exp_end) {
+            break;
         }
+        if (printed < max_print_mismatches) {
+            const size_t i = static_cast<size_t>(m1 - expected_data.cbegin());
+            log_error(
+                tt::LogTest,
+                "Mismatch at index {}: expected={}, actual={}",
+                i,
+                static_cast<float>(*m1),
+                static_cast<float>(*m2));
+            ++printed;
+        }
+        ++mismatches;
+        exp_it = std::next(m1);
+        act_it = std::next(m2);
     }
 
     if (mismatches > 0) {

--- a/tt-train/tests/ops/linear_op_test.cpp
+++ b/tt-train/tests/ops/linear_op_test.cpp
@@ -6,6 +6,8 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+
 #include "autograd/auto_context.hpp"
 #include "core/compute_kernel_config.hpp"
 #include "core/tt_tensor_utils.hpp"
@@ -27,30 +29,22 @@ void compare_tensors(const ttnn::Tensor& t1, const ttnn::Tensor& t2, float eps) 
     auto t1_vec = ttml::core::to_vector(t1);
     auto t2_vec = ttml::core::to_vector(t2);
     ASSERT_EQ(t1_vec.size(), t2_vec.size());
-    bool all_equals = true;
-    for (size_t i = 0; i < t1_vec.size() && all_equals; i++) {
-        if (std::abs(t1_vec[i] - t2_vec[i]) > eps) {
-            all_equals = false;
-            EXPECT_NEAR(t1_vec[i], t2_vec[i], eps);
-        }
+    auto it = std::mismatch(
+        t1_vec.begin(), t1_vec.end(), t2_vec.begin(), [eps](float a, float b) { return std::abs(a - b) <= eps; });
+    if (it.first != t1_vec.end()) {
+        EXPECT_NEAR(*it.first, *it.second, eps);
     }
-    EXPECT_TRUE(all_equals);
+    EXPECT_TRUE(it.first == t1_vec.end());
 }
 
 bool compare_tensors_for_broken(const ttnn::Tensor& t1, const ttnn::Tensor& t2, float eps) {
     if (t1.logical_shape() != t2.logical_shape()) {
         return false;
     }
-
     auto t1_vec = ttml::core::to_vector(t1);
     auto t2_vec = ttml::core::to_vector(t2);
-    bool all_equals = true;
-    for (size_t i = 0; i < t1_vec.size() && all_equals; i++) {
-        if (std::abs(t1_vec[i] - t2_vec[i]) > eps) {
-            all_equals = false;
-        }
-    }
-    return all_equals;
+    return std::equal(
+        t1_vec.begin(), t1_vec.end(), t2_vec.begin(), [eps](float a, float b) { return std::abs(a - b) <= eps; });
 }
 
 // Disabled: non-deterministic accuracy failures — https://github.com/tenstorrent/tt-metal/issues/46121

--- a/tt-train/tests/optimizers/adamw_test.cpp
+++ b/tt-train/tests/optimizers/adamw_test.cpp
@@ -7,6 +7,9 @@
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <numeric>
+
 #include "autograd/auto_context.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "test_utils/random_data.hpp"
@@ -146,16 +149,15 @@ struct ErrorMetrics {
 
 static ErrorMetrics compute_error_metrics(
     const xt::xarray<float>& reference, const xt::xarray<float>& actual, const std::string& name) {
-    float sum_error = 0.0f;
-    float max_error = 0.0f;
     size_t count = reference.size();
 
-    for (size_t i = 0; i < count; ++i) {
-        float error = std::abs(reference(i) - actual(i));
-        sum_error += error;
-        max_error = std::max(max_error, error);
-    }
+    auto errors = std::vector<float>(count);
+    std::transform(reference.begin(), reference.end(), actual.begin(), errors.begin(), [](float r, float a) {
+        return std::abs(r - a);
+    });
 
+    float sum_error = std::accumulate(errors.begin(), errors.end(), 0.0f);
+    float max_error = *std::max_element(errors.begin(), errors.end());
     float mean_error = sum_error / static_cast<float>(count);
     return {mean_error, max_error, name};
 }

--- a/tt-train/tests/ttnn_fixed/trivial_ttnn_ops_test.cpp
+++ b/tt-train/tests/ttnn_fixed/trivial_ttnn_ops_test.cpp
@@ -6,6 +6,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <memory>
 #include <umd/device/cluster.hpp>
 #include <vector>
@@ -39,12 +40,8 @@ TEST_F(TrivialTnnFixedTest, TestMaxNegativeOne) {
     auto res = ttnn::max(tensor, /* dim */ 3, /* keepdim */ true);
     auto res_vector = ttml::core::to_vector(res);
     EXPECT_EQ(res_vector.size(), 6);
-    bool all_equal = true;
-    for (const auto& value : res_vector) {
-        if (std::fabs(value + 1.F) > 1e-2) {
-            all_equal = false;
-        }
-    }
+    bool all_equal =
+        std::all_of(res_vector.begin(), res_vector.end(), [](float v) { return std::fabs(v + 1.F) <= 1e-2F; });
     EXPECT_TRUE(all_equal);
 }
 
@@ -62,12 +59,9 @@ TEST_F(TrivialTnnFixedTest, TestMaxNegativeBatch) {
     auto res = ttnn::max(tensor, /* dim */ 3, /* keepdim */ true);
     auto res_vector = ttml::core::to_vector(res);
     EXPECT_EQ(res_vector.size(), 4);
-    bool all_equal = true;
-    for (int i = 0; i < 4 && all_equal; ++i) {
-        if (std::fabs(res_vector[i] - (-static_cast<float>(i + 1))) > 1e-2) {
-            all_equal = false;
-        }
-    }
+    bool all_equal = std::all_of(res_vector.begin(), res_vector.end(), [i = 0](float v) mutable {
+        return std::fabs(v - (-static_cast<float>(i++ + 1))) <= 1e-2F;
+    });
     EXPECT_TRUE(all_equal);
 }
 
@@ -134,10 +128,8 @@ TEST_F(TrivialTnnFixedTest, TestStableSoftmax_2) {
     auto res = ttml::ttnn_fixed::softmax(tensor, /* dim */ 3);
     auto res_vector = ttml::core::to_vector(res);
 
-    auto exp_sum = 0.0F;
-    for (auto& elem : data) {
-        exp_sum += std::exp(elem);
-    }
+    auto exp_sum =
+        std::accumulate(data.begin(), data.end(), 0.0F, [](float acc, float v) { return acc + std::exp(v); });
 
     for (int i = 0; i < res_vector.size(); ++i) {
         EXPECT_NEAR(res_vector[i], std::exp(data[i]) / exp_sum, 1e-2);

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -2779,9 +2779,18 @@ void ControlPlane::collect_and_merge_intermesh_exit_peer_fabric_node_id_pairs_fr
 
     auto merge_pair_vectors = [](std::vector<std::pair<FabricNodeId, FabricNodeId>>& into,
                                  const std::vector<std::pair<FabricNodeId, FabricNodeId>>& from) {
+        // Build a set of existing pairs so dedup is O(1) per element instead of O(n).
+        struct PairHash {
+            std::size_t operator()(const std::pair<FabricNodeId, FabricNodeId>& p) const noexcept {
+                std::size_t h1 = std::hash<FabricNodeId>{}(p.first);
+                std::size_t h2 = std::hash<FabricNodeId>{}(p.second);
+                return h1 ^ (h2 * 0x9e3779b97f4a7c15ULL + 0x6c62272e07bb0142ULL + (h1 << 6) + (h1 >> 2));
+            }
+        };
+        std::unordered_set<std::pair<FabricNodeId, FabricNodeId>, PairHash> seen(into.begin(), into.end());
         into.reserve(into.size() + from.size());
         for (const auto& p : from) {
-            if (std::find(into.begin(), into.end(), p) == into.end()) {
+            if (seen.insert(p).second) {
                 into.push_back(p);
             }
         }

--- a/tt_metal/fabric/topology_mapper.cpp
+++ b/tt_metal/fabric/topology_mapper.cpp
@@ -1307,31 +1307,37 @@ void TopologyMapper::rebuild_host_rank_structs_from_mapping(
         std::vector<MeshHostRankId> host_rank_values(host_grid_shape.mesh_size(), MeshHostRankId{0});
         std::vector<std::uint32_t> row_list(rows.begin(), rows.end());
         std::vector<std::uint32_t> col_list(cols.begin(), cols.end());
+        // row_list and col_list come from std::set so they are already sorted;
+        // use lower_bound for O(log n) index lookups instead of linear scan.
         auto row_index = [&](std::uint32_t r) {
-            return std::distance(row_list.begin(), std::find(row_list.begin(), row_list.end(), r));
+            return std::distance(row_list.begin(), std::lower_bound(row_list.begin(), row_list.end(), r));
         };
         auto col_index = [&](std::uint32_t c) {
-            return std::distance(col_list.begin(), std::find(col_list.begin(), col_list.end(), c));
+            return std::distance(col_list.begin(), std::lower_bound(col_list.begin(), col_list.end(), c));
         };
         // Compute base_rank as min over host_ranks
         std::uint32_t base_rank = std::numeric_limits<std::uint32_t>::max();
         for (const auto& [host_rank, _] : range_map) {
             base_rank = std::min(base_rank, host_rank.get());
         }
+        // Build coord→(original_host_rank, range) map to avoid O(|range_map|) inner scan.
+        std::
+            map<std::pair<std::uint32_t, std::uint32_t>, std::pair<MeshHostRankId, decltype(range_map.begin()->second)>>
+                coord_to_rank_range;
+        for (const auto& [original_host_rank, range] : range_map) {
+            std::uint32_t norm_rank = original_host_rank.get() - base_rank;
+            coord_to_rank_range[{range.start_coord()[0], range.start_coord()[1]}] = {MeshHostRankId{norm_rank}, range};
+        }
         for (std::uint32_t r : row_list) {
             for (std::uint32_t c : col_list) {
-                // find host_rank whose range starts at (r,c)
-                for (const auto& [original_host_rank, range] : range_map) {
-                    if (range.start_coord()[0] == r && range.start_coord()[1] == c) {
-                        std::size_t idx = (row_index(r) * host_grid_shape[1]) + col_index(c);
-                        std::uint32_t norm_rank = original_host_rank.get() - base_rank;
-                        MeshHostRankId host_rank_val{norm_rank};
-                        if (idx < host_rank_values.size()) {
-                            host_rank_values[idx] = host_rank_val;
-                        }
-                        mesh_host_rank_coord_ranges_.insert({{mesh_id, host_rank_val}, range});
-                        break;
+                auto it = coord_to_rank_range.find({r, c});
+                if (it != coord_to_rank_range.end()) {
+                    const auto& [host_rank_val, range] = it->second;
+                    std::size_t idx = (row_index(r) * host_grid_shape[1]) + col_index(c);
+                    if (idx < host_rank_values.size()) {
+                        host_rank_values[idx] = host_rank_val;
                     }
+                    mesh_host_rank_coord_ranges_.insert({{mesh_id, host_rank_val}, range});
                 }
             }
         }

--- a/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
+++ b/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
@@ -198,8 +198,11 @@ std::optional<DeviceAddr> FreeListOpt::allocate_at_address(DeviceAddr absolute_s
     // Find the relevant size segregated list
     size_t size_segregated_index = get_size_segregated_index(block_size_[target_block_index]);
     std::vector<size_t>& segregated_list = free_blocks_segregated_by_size_[size_segregated_index];
-    auto it = std::find(segregated_list.begin(), segregated_list.end(), target_block_index);
-    TT_ASSERT(it != segregated_list.end(), "Block not found in size segregated list");
+    auto it = std::lower_bound(
+        segregated_list.begin(), segregated_list.end(), target_block_index, [this](size_t a, size_t b) {
+            return block_address_[a] < block_address_[b];
+        });
+    TT_ASSERT(it != segregated_list.end() && *it == target_block_index, "Block not found in size segregated list");
     segregated_list.erase(it);
 
     size_t offset = start_address - block_address_[target_block_index];
@@ -543,11 +546,12 @@ void FreeListOpt::shrink_size(DeviceAddr shrink_size, bool bottom_up) {
     // Find the relevant size segregated list
     size_t size_segregated_index = get_size_segregated_index(block_size_[block_to_shrink]);
     std::vector<size_t>& segregated_list = free_blocks_segregated_by_size_[size_segregated_index];
-    for (size_t i = 0; i < segregated_list.size(); i++) {
-        if (segregated_list[i] == block_to_shrink) {
-            segregated_list.erase(segregated_list.begin() + i);
-            break;
-        }
+    auto it =
+        std::lower_bound(segregated_list.begin(), segregated_list.end(), block_to_shrink, [this](size_t a, size_t b) {
+            return block_address_[a] < block_address_[b];
+        });
+    if (it != segregated_list.end() && *it == block_to_shrink) {
+        segregated_list.erase(it);
     }
 
     // Shrink the block

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <unordered_set>
 #include <tuple>
 #include <utility>
 
@@ -1696,10 +1697,11 @@ std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBuf
 }
 
 std::vector<CoreRange> ProgramImpl::dataflow_buffers_unique_coreranges() const {
+    std::unordered_set<CoreRange> seen;
     std::vector<CoreRange> core_ranges;
     for (const auto& dfb : dataflow_buffers_) {
         for (const CoreRange& core_range : dfb->core_ranges.ranges()) {
-            if (std::find(core_ranges.begin(), core_ranges.end(), core_range) == core_ranges.end()) {
+            if (seen.insert(core_range).second) {
                 core_ranges.push_back(core_range);
             }
         }

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1198,10 +1198,11 @@ std::vector<std::shared_ptr<CircularBufferImpl>> detail::ProgramImpl::circular_b
 }
 
 std::vector<CoreRange> detail::ProgramImpl::circular_buffers_unique_coreranges() const {
+    std::unordered_set<CoreRange> seen;
     std::vector<CoreRange> core_ranges;
     for (const auto& circular_buffer : circular_buffers_) {
         for (const CoreRange& core_range : circular_buffer->core_ranges().ranges()) {
-            if (std::find(core_ranges.begin(), core_ranges.end(), core_range) == core_ranges.end()) {
+            if (seen.insert(core_range).second) {
                 core_ranges.push_back(core_range);
             }
         }

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -699,19 +699,21 @@ public:
             const std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>>& mesh_tensors) {
             std::vector<ResolvedTensorBinding> bindings;
             bindings.reserve(factory_tensor_args.size());
-            // The name is the Table key; the TensorArgument value carries only the tensor ref.
+            // Build a pointer→index map once (O(n)) to avoid O(params × tensors) std::find_if.
+            std::unordered_map<const tt::tt_metal::MeshTensor*, std::size_t> tensor_index_map;
+            tensor_index_map.reserve(mesh_tensors.size());
+            for (std::size_t idx = 0; idx < mesh_tensors.size(); ++idx) {
+                tensor_index_map.emplace(&mesh_tensors[idx].get(), idx);
+            }
             for (const auto& [tensor_parameter_name, tensor_arg] : factory_tensor_args) {
                 const auto* target = &tt::tt_metal::experimental::mesh_tensor_of(tensor_arg);
-                auto it = std::find_if(mesh_tensors.begin(), mesh_tensors.end(), [target](const auto& wrapped) {
-                    return &wrapped.get() == target;
-                });
+                auto map_it = tensor_index_map.find(target);
                 TT_FATAL(
-                    it != mesh_tensors.end(),
+                    map_it != tensor_index_map.end(),
                     "TensorArgument '{}' must reference a MeshTensor reachable from tensor_args / "
                     "tensor_return_value, or one of the factory's op_owned_tensors (got an unowned MeshTensor)",
                     tensor_parameter_name);
-                bindings.push_back(
-                    {tensor_parameter_name, static_cast<std::size_t>(std::distance(mesh_tensors.begin(), it))});
+                bindings.push_back({tensor_parameter_name, map_it->second});
             }
             return bindings;
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_nd_shard_input_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_nd_shard_input_program_factory.cpp
@@ -4,6 +4,8 @@
 
 #include "untilize_multi_core_nd_shard_input_program_factory.hpp"
 
+#include <map>
+
 #include "ttnn/common/constants.hpp"
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 #include "ttnn/operations/data_movement/untilize/device/untilize_device_operation.hpp"
@@ -212,16 +214,23 @@ ProgramDescriptor UntilizeMultiCoreNDShardInputProgramFactory::create_descriptor
     // in the writer kernel.
     const auto& mapped_cores = page_mapping.all_cores;
 
+    // Build a map from CoreCoord to its index in mapped_cores for O(log n) lookup
+    // instead of O(n) std::find inside the loop over ordered_cores_with_data.
+    std::map<CoreCoord, size_t> mapped_core_index;
+    for (size_t i = 0; i < mapped_cores.size(); ++i) {
+        mapped_core_index.emplace(mapped_cores[i], i);
+    }
+
     // Use page_mapping to count non-padding blocks per core
     // page_mapping.core_host_page_indices[core_id] contains host page indices for all device pages on that core,
     // with UncompressedBufferPageMapping::PADDING indicating padding pages
     uint32_t start_shard_id = 0;
     for (const auto& core : ordered_cores_with_data) {
-        auto core_it = std::find(mapped_cores.begin(), mapped_cores.end(), core);
+        auto core_it = mapped_core_index.find(core);
         uint32_t num_input_blocks_to_process = 0;
 
-        if (core_it != mapped_cores.end()) {
-            const size_t core_idx = std::distance(mapped_cores.begin(), core_it);
+        if (core_it != mapped_core_index.end()) {
+            const size_t core_idx = core_it->second;
             const auto& host_page_indices = page_mapping.core_host_page_indices[core_idx];
 
             // Iterate through device pages in blocks of num_tiles_per_input_block.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_recv_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_recv_utils.hpp
@@ -39,12 +39,14 @@ MeshCoordinateRangeSet get_workload_coords(
     const auto& socket_connections = mesh_socket.get_config().socket_connection_config;
 
     const auto tensor_coords_flattened = tensor_coords.coords();
+    // Build a set for O(1) membership test instead of O(n) std::find per connection.
+    const std::unordered_set<tt::tt_metal::distributed::MeshCoordinate> coord_set(
+        tensor_coords_flattened.begin(), tensor_coords_flattened.end());
     for (const auto& connection : socket_connections) {
         const auto& device_coord = socket_type == tt::tt_metal::distributed::SocketEndpoint::SENDER
                                        ? connection.sender_core.device_coord
                                        : connection.receiver_core.device_coord;
-        if (std::find(tensor_coords_flattened.begin(), tensor_coords_flattened.end(), device_coord) !=
-            tensor_coords_flattened.end()) {
+        if (coord_set.count(device_coord)) {
             workload_coords.merge(MeshCoordinateRange(device_coord, device_coord));
         }
     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -5,6 +5,7 @@
 #include "ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.hpp"
 #include "ttnn/operations/matmul/device/utilities/matmul_utilities.hpp"
 #include <algorithm>
+#include <set>
 #include <utility>
 
 #include "hostdevcommon/common_values.hpp"
@@ -2391,14 +2392,12 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
     auto all_cores_vec = corerange_to_cores(all_cores, std::nullopt, row_major);
     auto worker_cores_vec = corerange_to_cores(all_worker_cores, std::nullopt, row_major);
     auto hop_cores_vec = corerange_to_cores(hop_cores, std::nullopt, row_major);
+    // Build sets for O(log n) membership tests instead of O(n) std::find per core.
+    const std::set<CoreCoord> worker_cores_set(worker_cores_vec.begin(), worker_cores_vec.end());
+    const std::set<CoreCoord> hop_cores_set(hop_cores_vec.begin(), hop_cores_vec.end());
     for (auto core : all_cores_vec) {
-        auto all_worker_cores_iter = std::find(worker_cores_vec.begin(), worker_cores_vec.end(), core);
-        auto hop_cores_iter = std::find(hop_cores_vec.begin(), hop_cores_vec.end(), core);
-        bool core_is_in_all_worker_cores = all_worker_cores_iter != worker_cores_vec.end();
-        bool core_is_in_hop_cores = hop_cores_iter != hop_cores_vec.end();
-        if (!use_hop_cores) {
-            core_is_in_hop_cores = false;
-        }
+        bool core_is_in_all_worker_cores = worker_cores_set.count(core) > 0;
+        bool core_is_in_hop_cores = use_hop_cores && hop_cores_set.count(core) > 0;
 
         if (!core_is_in_all_worker_cores && !core_is_in_hop_cores) {  // not worker core and not hop core
             auto core_type = CORE_TYPE::IDLE_CORE;                    // idle core

--- a/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
@@ -364,15 +364,17 @@ void get_max_page_size_and_num_pages(
 }
 
 void move_common_entries(std::vector<CoreCoord>& v1, std::vector<CoreCoord>& v2, std::vector<CoreCoord>& commons) {
+    // Build a set from v1 for O(log n) membership tests.
+    const std::set<CoreCoord> v1_set(v1.begin(), v1.end());
     for (const CoreCoord& item : v2) {
-        if (std::find(v1.begin(), v1.end(), item) != v1.end()) {
+        if (v1_set.count(item)) {
             commons.push_back(item);
         }
     }
 
-    for (const CoreCoord& item : commons) {
-        v2.erase(std::remove(v2.begin(), v2.end(), item), v2.end());
-    }
+    const std::set<CoreCoord> commons_set(commons.begin(), commons.end());
+    v2.erase(
+        std::remove_if(v2.begin(), v2.end(), [&](const CoreCoord& c) { return commons_set.count(c) > 0; }), v2.end());
 }
 
 void get_optimal_dram_bank_to_reader_assignment(

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -394,7 +394,8 @@ static Tensor std_var_impl(
         ttnn::SmallVector<int64_t> perm;
         perm.reserve(rank);
         for (uint32_t i = 0; i < rank; ++i) {
-            if (std::find(dim.begin(), dim.end(), static_cast<int>(i)) == dim.end()) {
+            // dim is sorted ascending; use binary_search for O(log k) check.
+            if (!std::binary_search(dim.begin(), dim.end(), static_cast<int>(i))) {
                 perm.push_back(static_cast<int64_t>(i));
             }
         }


### PR DESCRIPTION
### PR Category
Cleanup / Performance
### Summary
Systematically replaces hand-written C++ loops across test code and
CPU-side library code with standard library algorithms. The test changes
are pure readability/robustness wins. The library changes also eliminate
genuine O(n²) or O(n-per-iteration) hot spots in dispatch and
initialization paths.
No device code, no kernel code, and no algorithmic behavior is changed.
## What
**Test code (commits 1–2, 16 files):**
- `std::mismatch` replaces hand-rolled first-difference loops (argfail
  index reporting preserved)
- `std::iota` / `std::generate` for sequential and modular fill loops
- `std::all_of` / `std::any_of` / `std::count_if` / `std::find_if`
  replace flag-accumulation and search-with-break patterns
- `std::max_element`, `std::accumulate`, `std::transform` for reduction
  loops
- `std::equal` with tolerance lambda for floating-point comparison
  baselines
**CPU library code (commit 3, 11 files):**
| File | Change | Complexity |
|------|--------|-----------|
| `program.cpp`, `dataflow_buffer.cpp` | `unordered_set<CoreRange>` dedup during CB unique-corerange collection | O(n) per insert → O(1) |
| `topology_mapper.cpp` | `lower_bound` on sorted row/col vectors + precomputed coord→rank map | O(rows×cols×\|range_map\|) → O(n log n) |
| `mesh_device_operation_adapter.hpp` | Pointer→index `unordered_map` built once before tensor binding loop | O(params × tensors) → O(params) |
| `matmul_multicore_reuse_mcast_1d_program_factory.cpp` | `std::set` for worker/hop membership, replacing two `std::find` calls per core in RT-arg loop | O(all_cores × workers) → O(n log n) |
| `control_plane.cpp` | `unordered_set` in `merge_pair_vectors` for O(1) dedup | O(n²) → O(n) |
| `matmul_utilities.cpp` | `std::set` + `remove_if` in `move_common_entries` | O(n²) → O(n log n) |
| `untilize_nd_shard_input_program_factory.cpp` | Precomputed `map<CoreCoord, size_t>` index for RT-arg dispatch loop | O(n) per core → O(log n) |
| `free_list_opt.cpp` | `lower_bound` on address-sorted segregated list at two erase sites | O(n) → O(log n) |
| `send_recv_utils.hpp` | `unordered_set<MeshCoordinate>` from tensor coords, O(1) lookup per socket connection | O(connections × coords) → O(connections) |
| `generic_reductions.cpp` | `binary_search` on already-sorted `dim` vector in permutation builder | O(rank × \|dim\|) → O(rank × log\|dim\|) |
## Why
The test loop patterns were unnecessarily verbose and easy to get wrong
(off-by-one on index reporting, missed early-exit, etc.). Using named
std algorithms makes the intent immediately clear.
For library code, several of these loops sit on paths exercised per
dispatch or per program compilation (CB config, RT-arg setup, tensor
binding). Reducing their complexity avoids repeated O(n) or O(n²) scans
that scale with the number of cores/tensors/buffers.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=std-algo-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:std-algo-refactor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=std-algo-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:std-algo-refactor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=std-algo-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:std-algo-refactor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=std-algo-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:std-algo-refactor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=std-algo-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:std-algo-refactor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=std-algo-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:std-algo-refactor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=std-algo-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:std-algo-refactor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=std-algo-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:std-algo-refactor)