### PR TITLE
Bug fix: Copying of mesh descriptor files to TTNN reports in multihost

### DIFF
--- a/ttnn/core/graph/graph_processor.cpp
+++ b/ttnn/core/graph/graph_processor.cpp
@@ -108,8 +108,8 @@ std::string get_cluster_descriptor_content() {
     return buffer.str();
 }
 
-// Get mesh coordinate mapping from generated/fabric/ directory
-// This matches the old behavior of save_mesh_descriptor() which copied these YAML files
+// Get mesh coordinate mapping from generated/fabric/ directory for the current rank.
+// Matches control_plane naming: physical_chip_mesh_coordinate_mapping_<rank+1>_of_<world_size>.yaml
 // Note: Only called during report generation (offline), not on hot path
 std::string get_mesh_coordinate_mapping_content() {
     const char* tt_metal_home = std::getenv("TT_METAL_HOME");
@@ -123,27 +123,27 @@ std::string get_mesh_coordinate_mapping_content() {
         return "";
     }
 
-    // Collect all physical_chip_mesh_coordinate_mapping*.yaml files
-    std::string combined_content;
-    for (const auto& entry : std::filesystem::directory_iterator(fabric_dir)) {
-        if (entry.is_regular_file()) {
-            std::string filename = entry.path().filename().string();
-            if (filename.find("physical_chip_mesh_coordinate_mapping") != std::string::npos &&
-                filename.find(".yaml") != std::string::npos) {
-                std::ifstream file(entry.path());
-                if (file.is_open()) {
-                    if (!combined_content.empty()) {
-                        combined_content += "\n---\n";  // YAML document separator
-                    }
-                    combined_content += "# " + filename + "\n";
-                    std::stringstream buffer;
-                    buffer << file.rdbuf();
-                    combined_content += buffer.str();
-                }
-            }
-        }
+    const auto& world_ctx = tt::tt_metal::distributed::multihost::DistributedContext::get_current_world();
+    const int rank = *world_ctx->rank();
+    const int world_size = *world_ctx->size();
+
+    std::filesystem::path mapping_file =
+        fabric_dir / ("physical_chip_mesh_coordinate_mapping_" + std::to_string(rank + 1) + "_of_" +
+                      std::to_string(world_size) + ".yaml");
+    if (world_size == 1 && !std::filesystem::exists(mapping_file)) {
+        mapping_file = fabric_dir / "physical_chip_mesh_coordinate_mapping.yaml";
     }
-    return combined_content;
+    if (!std::filesystem::exists(mapping_file)) {
+        return "";
+    }
+
+    std::ifstream file(mapping_file);
+    if (!file.is_open()) {
+        return "";
+    }
+    std::stringstream buffer;
+    buffer << file.rdbuf();
+    return buffer.str();
 }
 
 }  // namespace
@@ -773,7 +773,7 @@ nlohmann::json GraphProcessor::get_report() const {
         report["cluster_descriptor"] = cluster_desc;
     }
 
-    // Mesh coordinate mapping (from generated/fabric/*.yaml) - matches old behavior
+    // Mesh coordinate mapping (from generated/fabric/, current rank only)
     std::string mesh_mapping = get_mesh_coordinate_mapping_content();
     if (!mesh_mapping.empty()) {
         report["mesh_coordinate_mapping"] = mesh_mapping;


### PR DESCRIPTION
### PR Category
Bug fix

### Summary

This PR fixes a bug with how the `physical_chip_mesh_coordinate_mapping_x_of_y.yaml` files are copied from the `generated/fabric` directory to the TTNN `graph_capture.json` file and report directory, when reporting is enabled.

Instead of copying the individual files into the captured graph JSON and TTNN report directory, it was concatenating the files together, with a `--` separator between them in the output YAML files. That is not desirable and the YAML files from `generated/fabric` should not be changed or concatenated together.

https://github.com/tenstorrent/ttnn-visualizer/issues/1681

### Notes for reviewers

I did a manual test on `exabox` and a single host machine, and it copies the files correctly now. I have not included unit tests for this change, because of the complexity of implementing a multihost test.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=smountenay-tt/graph_processor_mesh_files_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:smountenay-tt/graph_processor_mesh_files_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=smountenay-tt/graph_processor_mesh_files_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:smountenay-tt/graph_processor_mesh_files_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=smountenay-tt/graph_processor_mesh_files_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:smountenay-tt/graph_processor_mesh_files_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=smountenay-tt/graph_processor_mesh_files_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:smountenay-tt/graph_processor_mesh_files_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=smountenay-tt/graph_processor_mesh_files_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:smountenay-tt/graph_processor_mesh_files_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=smountenay-tt/graph_processor_mesh_files_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:smountenay-tt/graph_processor_mesh_files_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=smountenay-tt/graph_processor_mesh_files_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:smountenay-tt/graph_processor_mesh_files_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=smountenay-tt/graph_processor_mesh_files_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:smountenay-tt/graph_processor_mesh_files_fix)