### PR TITLE
perf: replace O(n) std::find-in-loop with O(1)/O(log n) lookups

### DIFF
--- a/tt_metal/distributed/experimental/blitz_decode_pipeline.cpp
+++ b/tt_metal/distributed/experimental/blitz_decode_pipeline.cpp
@@ -322,6 +322,9 @@ ResolvedBlitzDecodePipelineAllocation build_pipeline_allocation_from_topology(bo
     std::optional<tt::tt_fabric::FabricNodeId> stage_0_entry_fn;
     std::optional<tt::tt_fabric::FabricNodeId> loopback_exit_fn;
     bool found_non_z_pair = false;
+    // Build a set for O(1) membership tests instead of O(n) std::find per peer.
+    const std::unordered_set<tt::tt_fabric::FabricNodeId> unclaimed_set(
+        unclaimed_mesh_0_nodes.begin(), unclaimed_mesh_0_nodes.end());
     for (std::size_t a = 0; a < unclaimed_mesh_0_nodes.size() && !found_non_z_pair; a++) {
         auto fn_a = unclaimed_mesh_0_nodes[a];
         for (const auto& [chan_id, direction] : control_plane.get_active_fabric_eth_channels(fn_a)) {
@@ -330,9 +333,7 @@ ResolvedBlitzDecodePipelineAllocation build_pipeline_allocation_from_topology(bo
             if (peer_fn.mesh_id != mesh_ids[0]) {
                 continue;
             }
-            bool peer_unclaimed = !used_nodes.contains(peer_fn) &&
-                                  std::find(unclaimed_mesh_0_nodes.begin(), unclaimed_mesh_0_nodes.end(), peer_fn) !=
-                                      unclaimed_mesh_0_nodes.end();
+            bool peer_unclaimed = !used_nodes.contains(peer_fn) && unclaimed_set.contains(peer_fn);
             if (!peer_unclaimed) {
                 continue;
             }

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -22,6 +22,7 @@
 #include <set>
 #include <string>
 #include <tuple>
+#include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -2582,11 +2583,13 @@ void ControlPlane::collect_and_merge_router_port_directions_from_all_hosts() {
                         if (!local_direction_map.contains(direction)) {
                             local_direction_map[direction] = channels;
                         } else {
-                            // Merge channels, avoiding duplicates
+                            // Merge channels, avoiding duplicates. Track membership in a set for
+                            // O(1) lookups instead of O(n) std::find per candidate channel.
                             auto& local_channels = local_direction_map[direction];
+                            using chan_t = std::decay_t<decltype(local_channels)>::value_type;
+                            std::unordered_set<chan_t> seen_channels(local_channels.begin(), local_channels.end());
                             for (const auto& channel : channels) {
-                                if (std::find(local_channels.begin(), local_channels.end(), channel) ==
-                                    local_channels.end()) {
+                                if (seen_channels.insert(channel).second) {
                                     local_channels.push_back(channel);
                                 }
                             }

--- a/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
+++ b/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
@@ -4,6 +4,8 @@
 
 #include "dispatch_kernel_initializer.hpp"
 
+#include <unordered_map>
+
 #include <tt_stl/assert.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <llrt/tt_cluster.hpp>
@@ -190,25 +192,31 @@ void DispatchKernelInitializer::init_device_command_queues() {
         return;
     }
 
+    // Map device id -> IDevice* once for O(1) lookup instead of O(n) std::find_if per tunnel stage.
+    // Captured by reference into the async tasks below, which are all joined before this returns.
+    std::unordered_map<ChipId, Device*> device_by_id;
+    device_by_id.reserve(devices_.size());
+    for (auto* dev : devices_) {
+        device_by_id.emplace(dev->id(), dev);
+    }
+
     std::vector<std::shared_future<void>> events;
     for (auto* dev : devices_) {
         if (cluster_.get_associated_mmio_device(dev->id()) != dev->id()) {
             continue;
         }
         ChipId mmio_device_id = dev->id();
-        events.emplace_back(detail::async([this, dev, mmio_device_id]() {
+        events.emplace_back(detail::async([this, dev, mmio_device_id, &device_by_id]() {
             auto tunnels_from_mmio = cluster_.get_tunnels_from_mmio_device(mmio_device_id);
             dev->init_command_queue_device_with_topology(dispatch_topology_.get());
             log_debug(tt::LogMetal, "Command Queue initialized on Device {}", dev->id());
             for (const auto& tunnel : tunnels_from_mmio) {
                 for (uint32_t ts = tunnel.size() - 1; ts > 0; ts--) {
                     uint32_t mmio_controlled_device_id = tunnel[ts];
-                    auto it = std::find_if(devices_.begin(), devices_.end(), [&](IDevice* d) {
-                        return d->id() == mmio_controlled_device_id;
-                    });
-                    if (it != devices_.end()) {
-                        (*it)->init_command_queue_device_with_topology(dispatch_topology_.get());
-                        log_debug(tt::LogMetal, "Command Queue initialized on Device {}", (*it)->id());
+                    auto it = device_by_id.find(static_cast<ChipId>(mmio_controlled_device_id));
+                    if (it != device_by_id.end()) {
+                        it->second->init_command_queue_device_with_topology(dispatch_topology_.get());
+                        log_debug(tt::LogMetal, "Command Queue initialized on Device {}", it->second->id());
                     }
                 }
             }

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -27,6 +27,7 @@
 
 #include <mutex>
 #include <unordered_map>
+#include <unordered_set>
 
 #include <tt_stl/assert.hpp>
 #include "dispatch/kernels/cq_commands.hpp"
@@ -498,10 +499,12 @@ bool doAllDispatchCoresComeAfterNonDispatchCores(
         virtual_dispatch_cores.push_back(virtual_dispatch_core);
     }
 
+    // Build a set for O(1) membership tests instead of O(n) std::find per core.
+    const std::unordered_set<CoreCoord> virtual_dispatch_cores_set(
+        virtual_dispatch_cores.begin(), virtual_dispatch_cores.end());
     bool has_dispatch_core_been_found = false;
     for (const CoreCoord& core : virtual_cores) {
-        if (std::find(virtual_dispatch_cores.begin(), virtual_dispatch_cores.end(), core) !=
-            virtual_dispatch_cores.end()) {
+        if (virtual_dispatch_cores_set.contains(core)) {
             has_dispatch_core_been_found = true;
         } else if (has_dispatch_core_been_found) {
             return false;

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -28,6 +28,7 @@
 #include <thread>
 #include <tuple>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -777,8 +778,10 @@ bool areAllCoresDispatchCores(IDevice* device, const std::vector<CoreCoord>& vir
         dispatch_cores.push_back(virtual_dispatch_core);
     }
 
+    // Build a set for O(1) membership tests instead of O(n) std::find per core.
+    const std::unordered_set<CoreCoord> dispatch_cores_set(dispatch_cores.begin(), dispatch_cores.end());
     for (const CoreCoord& core : virtual_cores) {
-        if (std::find(dispatch_cores.begin(), dispatch_cores.end(), core) == dispatch_cores.end()) {
+        if (!dispatch_cores_set.contains(core)) {
             return false;
         }
     }

--- a/tt_metal/impl/program/program_descriptor_patching.cpp
+++ b/tt_metal/impl/program/program_descriptor_patching.cpp
@@ -31,6 +31,7 @@
 #include <cstdint>
 #include <span>
 #include <string_view>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -78,16 +79,25 @@ ResolvedBindings resolve_bindings(
         }
     }
 
-    // Map each Buffer* to its index in tensor_buffers.  Every binding Buffer* must be
-    // present; TT_FATAL fires if a factory used a non-tensor buffer in emplace_runtime_args.
+    // Map each Buffer* to its index in tensor_buffers for O(1) lookup instead of O(n) std::find
+    // per binding. emplace keeps the FIRST index for a given Buffer*, matching std::find's semantics
+    // (relevant only for the allowed input/output alias case; ambiguous duplicates already bailed above).
+    std::unordered_map<Buffer*, uint32_t> buffer_to_index;
+    buffer_to_index.reserve(tensor_buffers.size());
+    for (uint32_t i = 0; i < static_cast<uint32_t>(tensor_buffers.size()); ++i) {
+        buffer_to_index.emplace(tensor_buffers[i], i);
+    }
+
+    // Every binding Buffer* must be present; TT_FATAL fires if a factory used a non-tensor buffer
+    // in emplace_runtime_args.
     auto find_idx = [&](Buffer* buf, std::string_view context) -> uint32_t {
-        auto it = std::find(tensor_buffers.begin(), tensor_buffers.end(), buf);
+        auto it = buffer_to_index.find(buf);
         TT_FATAL(
-            it != tensor_buffers.end(),
+            it != buffer_to_index.end(),
             "Buffer* in {} not found in tensor_args/tensor_return_value enumeration. "
             "All buffer bindings must come directly from input/output tensors.",
             context);
-        return static_cast<uint32_t>(it - tensor_buffers.begin());
+        return it->second;
     };
 
     for (uint32_t k = 0; k < static_cast<uint32_t>(desc.kernels.size()); ++k) {
@@ -166,10 +176,9 @@ ResolvedBindings resolve_bindings(
                 cb_buffer = cb_desc.tensor->mesh_buffer().get_reference_buffer();
             }
             if (cb_buffer) {
-                auto it = std::find(tensor_buffers.begin(), tensor_buffers.end(), cb_buffer);
-                if (it != tensor_buffers.end()) {
-                    result.cbs.push_back(
-                        {program_cbs[ci]->id(), static_cast<uint32_t>(it - tensor_buffers.begin()), cb_desc.address_offset});
+                auto it = buffer_to_index.find(cb_buffer);
+                if (it != buffer_to_index.end()) {
+                    result.cbs.push_back({program_cbs[ci]->id(), it->second, cb_desc.address_offset});
                 }
                 // else: stable, non-tensor buffer; pegged at create time, no patching needed.
             }

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_input_and_output_nd_shard_type_and_shard_spec_identical_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_input_and_output_nd_shard_type_and_shard_spec_identical_program_factory.cpp
@@ -4,6 +4,8 @@
 
 #include "untilize_multi_core_input_and_output_nd_shard_type_and_shard_spec_identical_program_factory.hpp"
 
+#include <unordered_map>
+
 #include "ttnn/common/constants.hpp"
 
 #include <tt-metalium/buffer_distribution_spec.hpp>
@@ -141,12 +143,18 @@ ProgramDescriptor UntilizeMultiCoreInputAndOutputNDShardTypeAndShardSpecIdentica
     auto cores = corerange_to_cores(grid, std::nullopt, orientation == ShardOrientation::ROW_MAJOR);
     auto page_mapping = distribution_spec.compute_page_mapping();
     const auto& mapped_cores = page_mapping.all_cores;
+    // Map each core to its index in mapped_cores for O(1) lookup instead of O(n) std::find per core.
+    std::unordered_map<CoreCoord, size_t> mapped_core_index;
+    mapped_core_index.reserve(mapped_cores.size());
+    for (size_t i = 0; i < mapped_cores.size(); ++i) {
+        mapped_core_index.emplace(mapped_cores[i], i);
+    }
     for (const auto& core : cores) {
-        auto core_it = std::find(mapped_cores.begin(), mapped_cores.end(), core);
+        auto core_it = mapped_core_index.find(core);
         uint32_t num_blocks_to_process = 0;
         uint32_t num_tiles_to_process = 0;
-        if (core_it != mapped_cores.end()) {
-            const size_t core_idx = std::distance(mapped_cores.begin(), core_it);
+        if (core_it != mapped_core_index.end()) {
+            const size_t core_idx = core_it->second;
             const size_t num_shards_on_core = distribution_spec.num_shards_per_core(core_idx);
             num_blocks_to_process = num_blocks_per_shard * num_shards_on_core;
             num_tiles_to_process = num_tiles_per_block * num_blocks_to_process;

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <unordered_map>
+
 #include "ttnn/operation.hpp"
 #include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/math.hpp"
@@ -234,6 +236,12 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreNDShardedProgramFa
     // Logic for ND sharding makes as few assumptions about page locations as possible. Padded pages will be handled
     // in the writer kernel.
     const auto& mapped_cores = page_mapping.all_cores;
+    // Map each core to its index in mapped_cores for O(1) lookup instead of O(n) std::find per core.
+    std::unordered_map<CoreCoord, size_t> mapped_core_index;
+    mapped_core_index.reserve(mapped_cores.size());
+    for (size_t i = 0; i < mapped_cores.size(); ++i) {
+        mapped_core_index.emplace(mapped_cores[i], i);
+    }
 
     // Use page_mapping to count non-padding blocks per core
     // page_mapping.core_host_page_indices[core_id] contains host page indices for all device pages on that core,
@@ -245,11 +253,11 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreNDShardedProgramFa
         compute_desc.runtime_args.reserve(ordered_cores_with_data.size());
     }
     for (auto core : ordered_cores_with_data) {
-        auto core_it = std::find(mapped_cores.begin(), mapped_cores.end(), core);
+        auto core_it = mapped_core_index.find(core);
         uint32_t num_input_blocks_to_process = 0;
 
-        if (core_it != mapped_cores.end()) {
-            const size_t core_idx = std::distance(mapped_cores.begin(), core_it);
+        if (core_it != mapped_core_index.end()) {
+            const size_t core_idx = core_it->second;
             const auto& host_page_indices = page_mapping.core_host_page_indices[core_idx];
 
             // Iterate through device pages in blocks of num_tiles_per_input_block.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/deepseek_moe_reduce_scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/deepseek_moe_reduce_scatter_program_factory.cpp
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <optional>
+#include <unordered_set>
 #include <vector>
 
 #include <tt-metalium/experimental/fabric/fabric.hpp>
@@ -38,10 +39,12 @@ CoreCoord choose_additional_core(
         CoreCoord(0, 5),
     };
 
+    // Build a set for O(1) membership tests instead of O(n) std::find per candidate core.
+    const std::unordered_set<CoreCoord> selected_set(cores_already_selected.begin(), cores_already_selected.end());
+
     // try optimal core first
     CoreCoord optimal_supplemental_core = optimal_supplemental_core_per_link.at(clamped_num_links - 1);
-    if (std::find(cores_already_selected.begin(), cores_already_selected.end(), optimal_supplemental_core) ==
-        cores_already_selected.end()) {
+    if (!selected_set.contains(optimal_supplemental_core)) {
         return optimal_supplemental_core;
     }
 
@@ -54,8 +57,7 @@ CoreCoord choose_additional_core(
         for (size_t y = start.y; y <= end.y; y++) {
             for (size_t x = start.x; x <= end.x; x++) {
                 CoreCoord core = CoreCoord(x, y);
-                if (std::find(cores_already_selected.begin(), cores_already_selected.end(), core) ==
-                    cores_already_selected.end()) {
+                if (!selected_set.contains(core)) {
                     return core;
                 }
             }

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
@@ -7,6 +7,7 @@
 #include "ttnn/operations/matmul/device/config/matmul_program_config.hpp"
 
 #include <algorithm>
+#include <unordered_set>
 #include <utility>
 
 #include "hostdevcommon/common_values.hpp"
@@ -653,12 +654,15 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
     }
 
     // in0 sender runtime args (mcast senders)
+    // Build a set for O(1) membership tests instead of O(n) std::find per core.
+    const std::unordered_set<CoreCoord> storage_worker_common_set(
+        storage_worker_common.begin(), storage_worker_common.end());
     uint32_t sender_id = 0;
     for (auto core : mcast_senders_coords) {
         std::vector<uint32_t> mm_in0_sender_args;
 
         uint32_t worker_core_type;
-        if (find(storage_worker_common.begin(), storage_worker_common.end(), core) != storage_worker_common.end()) {
+        if (storage_worker_common_set.contains(core)) {
             worker_core_type = 2;
         } else {
             worker_core_type = 1;
@@ -694,10 +698,11 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
     }
 
     // in0 sender runtime args (idle cores in rect grid)
+    // Build sets for O(1) membership tests instead of O(n) std::find per core.
+    const std::unordered_set<CoreCoord> mcast_senders_set(mcast_senders_coords.begin(), mcast_senders_coords.end());
+    const std::unordered_set<CoreCoord> mcast_receiver_set(mcast_receiver_coords.begin(), mcast_receiver_coords.end());
     for (auto core : all_cores_in_rect_grid_vec) {
-        if (std::find(mcast_senders_coords.begin(), mcast_senders_coords.end(), core) == mcast_senders_coords.end() and
-            std::find(mcast_receiver_coords.begin(), mcast_receiver_coords.end(), core) ==
-                mcast_receiver_coords.end()) {
+        if (!mcast_senders_set.contains(core) and !mcast_receiver_set.contains(core)) {
             std::vector<uint32_t> mm_in0_idle_args;
             uint32_t worker_core_type = 0;
             mm_in0_idle_args.push_back((std::uint32_t)worker_core_type);
@@ -733,10 +738,14 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
     uint32_t expected_max_total_width = num_cores_written_back * per_core_N_storage;
     uint32_t total_tensor_width_written_back = 0;
 
-    // For all cores in the rect grid, set compute and in1 rt args for non-worker cores
+    // For all cores in the rect grid, set compute and in1 rt args for non-worker cores.
+    // Build a set of worker ranges for O(1) membership tests instead of O(n) std::find per core.
+    // NOTE: preserves the original semantics -- membership is by exact single-core range, via the
+    // implicit CoreCoord->CoreRange conversion that the std::find used here.
+    const std::unordered_set<CoreRange> all_worker_ranges_set(
+        all_worker_cores.ranges().begin(), all_worker_cores.ranges().end());
     for (auto core : all_cores_in_rect_grid_vec) {
-        if (std::find(all_worker_cores.ranges().begin(), all_worker_cores.ranges().end(), core) ==
-            all_worker_cores.ranges().end()) {  // not worker
+        if (!all_worker_ranges_set.contains(CoreRange(core, core))) {  // not worker
             bool is_worker_core = false;
             std::vector<uint32_t> mm_in1_sender_writer_args;
             mm_in1_sender_writer_args.push_back((std::uint32_t)is_worker_core);


### PR DESCRIPTION
Issue : https://github.com/tenstorrent/tt-metal/issues/48020

Hoist repeated linear scans out of per-core / per-binding loops into sets/maps built once, in host-side program factories and runtime setup:

- untilize ND-sharded program factories (with_unpadding, input_and_output): per-core std::find over mapped_cores -> unordered_map<CoreCoord,size_t>.
- matmul mcast DRAM-sharded factory: per-core std::find over sender/receiver/ storage/worker-range vectors -> unordered_set (worker-range membership keeps the original exact single-core-range semantics via unordered_set<CoreRange>).
- profiler dispatch-core checks: per-core std::find over dispatch cores -> set.
- program_descriptor_patching: per-binding std::find over tensor_buffers ->
  unordered_map<Buffer*,uint32_t> (first-index wins, matching std::find).
- deepseek_moe_reduce_scatter: per-grid-core std::find over selected cores -> set.
- dispatch_kernel_initializer: per-tunnel-stage std::find_if over devices ->
  unordered_map<ChipId,IDevice*>.
- control_plane channel merge / blitz_decode_pipeline peer check: dedup/membership std::find -> set.

Behavior-preserving; no device-kernel code touched.

### PR Category

Host Performance (overall effect minor)

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=perf/on2-hotpath-lookups)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:perf/on2-hotpath-lookups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=perf/on2-hotpath-lookups)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:perf/on2-hotpath-lookups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=perf/on2-hotpath-lookups)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:perf/on2-hotpath-lookups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=perf/on2-hotpath-lookups)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:perf/on2-hotpath-lookups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=perf/on2-hotpath-lookups)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:perf/on2-hotpath-lookups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=perf/on2-hotpath-lookups)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:perf/on2-hotpath-lookups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=perf/on2-hotpath-lookups)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:perf/on2-hotpath-lookups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=perf/on2-hotpath-lookups)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:perf/on2-hotpath-lookups)