### PR TITLE
#48027: Preserve COL_MAJOR shard orientation across cross-layout sharded paths in transpose / permute / slice / repeat

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_permute.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_permute.py
@@ -50,27 +50,36 @@ def _tile_align(shard_shape, layout):
     return (h, w)
 
 
-def _height_shard_config(shape, device, num_cores=4, layout=ttnn.TILE_LAYOUT, buffer_type=ttnn.BufferType.L1):
+def _height_shard_config(
+    shape,
+    device,
+    num_cores=4,
+    layout=ttnn.TILE_LAYOUT,
+    buffer_type=ttnn.BufferType.L1,
+    orientation=ttnn.ShardOrientation.ROW_MAJOR,
+):
     compute_grid = device.compute_with_storage_grid_size()
     num_cores = min(num_cores, compute_grid.x * compute_grid.y)
     shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid, True)
     total_h, w = _padded_hw(shape, layout)
     shard_shape = _tile_align(((total_h + num_cores - 1) // num_cores, w), layout)
-    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, orientation)
     return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, buffer_type, shard_spec)
 
 
-def _width_shard_config(shape, device, num_cores=4, layout=ttnn.TILE_LAYOUT):
+def _width_shard_config(
+    shape, device, num_cores=4, layout=ttnn.TILE_LAYOUT, orientation=ttnn.ShardOrientation.ROW_MAJOR
+):
     compute_grid = device.compute_with_storage_grid_size()
     num_cores = min(num_cores, compute_grid.x * compute_grid.y)
     shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid, True)
     total_h, w = _padded_hw(shape, layout)
     shard_shape = _tile_align((total_h, (w + num_cores - 1) // num_cores), layout)
-    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, orientation)
     return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec)
 
 
-def _block_shard_config(shape, device, layout=ttnn.TILE_LAYOUT):
+def _block_shard_config(shape, device, layout=ttnn.TILE_LAYOUT, orientation=ttnn.ShardOrientation.ROW_MAJOR):
     compute_grid = device.compute_with_storage_grid_size()
     grid_x = min(2, compute_grid.x)
     grid_y = min(2, compute_grid.y)
@@ -79,7 +88,7 @@ def _block_shard_config(shape, device, layout=ttnn.TILE_LAYOUT):
     shard_spec = ttnn.ShardSpec(
         ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_x - 1, grid_y - 1))}),
         shard_shape,
-        ttnn.ShardOrientation.ROW_MAJOR,
+        orientation,
     )
     return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1, shard_spec)
 
@@ -136,6 +145,7 @@ def run_permute_test(
     input_mem_config=None,
     output_mem_config=None,
     dtype=ttnn.bfloat16,
+    expected_shard_orientation=None,
 ):
     torch.manual_seed(12345)
     torch_dtype = _TTNN_TO_TORCH_DTYPE[dtype]
@@ -158,6 +168,11 @@ def run_permute_test(
             ttnn.TensorMemoryLayout.BLOCK_SHARDED,
         ):
             assert actual.shard_spec is not None, "Sharded output requested but result has no shard_spec"
+            if expected_shard_orientation is not None:
+                assert actual.shard_spec.orientation == expected_shard_orientation, (
+                    f"Expected output shard orientation {expected_shard_orientation}, "
+                    f"got {actual.shard_spec.orientation}"
+                )
 
     ref = x.permute(dims)
     got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
@@ -437,14 +452,51 @@ def test_permute_universal_io_f32(shape, dims, input_layout, input_factory, outp
         pytest.param(ttnn.TensorMemoryLayout.BLOCK_SHARDED, id="B_out"),
     ],
 )
-def test_permute_sharded_input_to_sharded_nospec_wh(requested_out_layout, device):
+@pytest.mark.parametrize(
+    "input_orientation",
+    [
+        pytest.param(ttnn.ShardOrientation.ROW_MAJOR, id="row_major_in"),
+        pytest.param(ttnn.ShardOrientation.COL_MAJOR, id="col_major_in"),
+    ],
+)
+def test_permute_sharded_input_to_sharded_nospec_wh(requested_out_layout, input_orientation, device):
     shape = (1, 1, 64, 64)
     run_permute_test(
         shape,
         (0, 1, 3, 2),
         device,
-        input_mem_config=_block_shard_config(shape, device),
+        input_mem_config=_block_shard_config(shape, device, orientation=input_orientation),
         output_mem_config=ttnn.MemoryConfig(requested_out_layout, ttnn.BufferType.L1),
+        expected_shard_orientation=input_orientation,
+    )
+
+
+@pytest.mark.parametrize(
+    "input_factory, requested_out_layout",
+    [
+        pytest.param(
+            lambda d: _height_shard_config((1, 1, 128, 128), d, orientation=ttnn.ShardOrientation.COL_MAJOR),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            id="col_major_height_in_width_out_nospec",
+        ),
+        pytest.param(
+            lambda d: _width_shard_config((1, 1, 128, 128), d, orientation=ttnn.ShardOrientation.COL_MAJOR),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            id="col_major_width_in_height_out_nospec",
+        ),
+    ],
+)
+def test_permute_native_col_major_sharded_input_to_sharded_nospec_cross_layout(
+    input_factory, requested_out_layout, device
+):
+    shape = (1, 1, 128, 128)
+    run_permute_test(
+        shape,
+        (0, 1, 3, 2),
+        device,
+        input_mem_config=input_factory(device),
+        output_mem_config=ttnn.MemoryConfig(requested_out_layout, ttnn.BufferType.L1),
+        expected_shard_orientation=ttnn.ShardOrientation.COL_MAJOR,
     )
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_repeat.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_repeat.py
@@ -45,29 +45,33 @@ def _tile_align(shard_shape, layout):
     return (h, w)
 
 
-def _height_shard_config(shape, device, num_cores=4, layout=ttnn.TILE_LAYOUT):
+def _height_shard_config(
+    shape, device, num_cores=4, layout=ttnn.TILE_LAYOUT, orientation=ttnn.ShardOrientation.ROW_MAJOR
+):
     """Height-sharded MemoryConfig."""
     compute_grid = device.compute_with_storage_grid_size()
     num_cores = min(num_cores, compute_grid.x * compute_grid.y)
     shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid, True)
     total_h, w = _padded_hw(shape, layout)
     shard_shape = _tile_align(((total_h + num_cores - 1) // num_cores, w), layout)
-    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, orientation)
     return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
 
 
-def _width_shard_config(shape, device, num_cores=4, layout=ttnn.TILE_LAYOUT):
+def _width_shard_config(
+    shape, device, num_cores=4, layout=ttnn.TILE_LAYOUT, orientation=ttnn.ShardOrientation.ROW_MAJOR
+):
     """Width-sharded MemoryConfig."""
     compute_grid = device.compute_with_storage_grid_size()
     num_cores = min(num_cores, compute_grid.x * compute_grid.y)
     shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid, True)
     total_h, w = _padded_hw(shape, layout)
     shard_shape = _tile_align((total_h, (w + num_cores - 1) // num_cores), layout)
-    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, orientation)
     return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec)
 
 
-def _block_shard_config(shape, device, layout=ttnn.TILE_LAYOUT):
+def _block_shard_config(shape, device, layout=ttnn.TILE_LAYOUT, orientation=ttnn.ShardOrientation.ROW_MAJOR):
     """Block-sharded MemoryConfig (2x2 grid)."""
     compute_grid = device.compute_with_storage_grid_size()
     grid_x = min(2, compute_grid.x)
@@ -80,7 +84,7 @@ def _block_shard_config(shape, device, layout=ttnn.TILE_LAYOUT):
     shard_spec = ttnn.ShardSpec(
         ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_x - 1, grid_y - 1))}),
         shard_shape,
-        ttnn.ShardOrientation.ROW_MAJOR,
+        orientation,
     )
     return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1, shard_spec)
 
@@ -146,6 +150,7 @@ def run_repeat_test(
     output_mem_config=None,
     dtype=ttnn.bfloat16,
     pcc=0.9999,
+    expected_shard_orientation=None,
 ):
     """Run repeat and assert PCC + output memory_layout."""
     torch.manual_seed(12345)
@@ -171,6 +176,11 @@ def run_repeat_test(
             assert (
                 actual.shard_spec is not None
             ), "Sharded output requested but result has no shard_spec (silent fallback?)"
+            if expected_shard_orientation is not None:
+                assert actual.shard_spec.orientation == expected_shard_orientation, (
+                    f"Expected output shard orientation {expected_shard_orientation}, "
+                    f"got {actual.shard_spec.orientation}"
+                )
     elif input_mem_config.is_sharded():
         # Sharded input → inherit layout or fallback to interleaved (non-alignable shapes).
         assert actual.memory_layout in (
@@ -766,7 +776,7 @@ def test_repeat_default_memory_config(shape, repeat_shape, input_factory, device
     )
 
 
-# Sharded input → sharded output without shard_spec (native + composite paths).
+# Sharded input → sharded output without shard_spec; col_major_* cases cover orientation propagation.
 @pytest.mark.parametrize(
     "shape, repeat_shape, input_factory, output_layout",
     [
@@ -791,17 +801,48 @@ def test_repeat_default_memory_config(shape, repeat_shape, input_factory, device
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             id="uneven_block_in_height_out_nospec",
         ),
+        pytest.param(
+            (1, 1, 64, 64),
+            (1, 1, 1, 2),
+            lambda d: _block_shard_config((1, 1, 64, 64), d, orientation=ttnn.ShardOrientation.COL_MAJOR),
+            ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            id="col_major_block_in_block_out_nospec",
+        ),
+        pytest.param(
+            (1, 1, 64, 64),
+            (1, 1, 1, 2),
+            lambda d: _block_shard_config((1, 1, 64, 64), d, orientation=ttnn.ShardOrientation.COL_MAJOR),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            id="col_major_block_in_height_out_nospec",
+        ),
     ],
 )
 def test_repeat_sharded_in_sharded_out_nospec(shape, repeat_shape, input_factory, output_layout, device):
+    in_mc = input_factory(device)
     out_mc = ttnn.MemoryConfig(output_layout, ttnn.BufferType.L1)
+    # The output should preserve the input's shard orientation through the synthesis path.
+    expected_orientation = in_mc.shard_spec.orientation if in_mc.is_sharded() and in_mc.shard_spec else None
     run_repeat_test(
         shape,
         repeat_shape,
         device,
         input_layout=ttnn.TILE_LAYOUT,
-        input_mem_config=input_factory(device),
+        input_mem_config=in_mc,
         output_mem_config=out_mc,
+        expected_shard_orientation=expected_orientation,
+    )
+
+
+def test_repeat_native_col_major_height_sharded_to_sharded_nospec(device):
+    shape = (1, 1, 128, 128)
+    run_repeat_test(
+        shape,
+        (1, 1, 1, 2),
+        device,
+        input_layout=ttnn.TILE_LAYOUT,
+        input_mem_config=_height_shard_config(shape, device, orientation=ttnn.ShardOrientation.COL_MAJOR),
+        output_mem_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1),
+        expected_shard_orientation=ttnn.ShardOrientation.COL_MAJOR,
     )
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_slice.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_slice.py
@@ -160,7 +160,17 @@ def _explicit_width_shard_config(device, ncores, sh, sw):
 
 
 def _run_slice(
-    shape, begins, ends, step, layout, input_mem_config, output_mem_config, dtype, device, ulp_when_exact=True
+    shape,
+    begins,
+    ends,
+    step,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    dtype,
+    device,
+    ulp_when_exact=True,
+    expected_shard_orientation=None,
 ):
     """Run slice and assert output memory_layout matches request; verifies shard_spec is set when sharded."""
     torch.manual_seed(12345)
@@ -182,6 +192,11 @@ def _run_slice(
             ttnn.TensorMemoryLayout.BLOCK_SHARDED,
         ):
             assert actual.shard_spec is not None, "Sharded output requested but result has no shard_spec"
+            if expected_shard_orientation is not None:
+                assert actual.shard_spec.orientation == expected_shard_orientation, (
+                    f"Expected output shard orientation {expected_shard_orientation}, "
+                    f"got {actual.shard_spec.orientation}"
+                )
 
     ref = x[slices]
     got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
@@ -815,6 +830,43 @@ def test_slice_rm_sharded_in_sharded_no_spec_out(device):
     )
 
 
+# COL_MAJOR cases cover orientation propagation through slice's composite-reshard path.
+@pytest.mark.parametrize(
+    "requested_out_layout",
+    [
+        pytest.param(ttnn.TensorMemoryLayout.BLOCK_SHARDED, id="col_major_block_in_block_out_nospec"),
+        pytest.param(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, id="col_major_block_in_height_out_nospec"),
+    ],
+)
+def test_slice_block_sharded_input_to_sharded_nospec(requested_out_layout, device):
+    in_shape = (1, 1, 64, 64)
+    grid = device.compute_with_storage_grid_size()
+    gx, gy = min(2, grid.x), min(2, grid.y)
+    in_mc = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(gx - 1, gy - 1))}),
+            (32, 32),
+            ttnn.ShardOrientation.COL_MAJOR,
+        ),
+    )
+    out_no_spec_mc = ttnn.MemoryConfig(requested_out_layout, ttnn.BufferType.L1)
+    _run_slice(
+        in_shape,
+        (0, 0, 0, 0),
+        (1, 1, 32, 64),
+        (1, 1, 1, 1),
+        ttnn.TILE_LAYOUT,
+        in_mc,
+        out_no_spec_mc,
+        ttnn.bfloat16,
+        device,
+        ulp_when_exact=True,
+        expected_shard_orientation=ttnn.ShardOrientation.COL_MAJOR,
+    )
+
+
 def test_slice_tile_same_layout_sharded_no_spec_halving(device):
     """TILE HEIGHT-sharded → halving slice → HEIGHT no-spec out. Regression: adjust_shard_spec_to_shape
     must fall back to generate_transpose_shard_spec when the scaled shard would be sub-tile."""
@@ -832,6 +884,32 @@ def test_slice_tile_same_layout_sharded_no_spec_halving(device):
         ttnn.bfloat16,
         device,
         ulp_when_exact=True,
+    )
+
+
+def test_slice_tile_same_layout_sharded_no_spec_halving_col_major(device):
+    """Native adjust-failed fallback path: preserves COL_MAJOR input orientation."""
+    in_shape = (1, 1, 64, 64)
+    grid = device.compute_with_storage_grid_size()
+    shard_grid = ttnn.num_cores_to_corerangeset(2, grid, True)
+    in_mc = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(shard_grid, (32, 64), ttnn.ShardOrientation.COL_MAJOR),
+    )
+    out_no_spec_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1)
+    _run_slice(
+        in_shape,
+        (0, 0, 0, 0),
+        (1, 1, 32, 32),
+        (1, 1, 1, 1),
+        ttnn.TILE_LAYOUT,
+        in_mc,
+        out_no_spec_mc,
+        ttnn.bfloat16,
+        device,
+        ulp_when_exact=True,
+        expected_shard_orientation=ttnn.ShardOrientation.COL_MAJOR,
     )
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_tranpose.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_tranpose.py
@@ -31,6 +31,7 @@ def run_transpose_test(
     input_mem_config=None,
     output_mem_config=None,
     dtype=ttnn.bfloat16,
+    expected_shard_orientation=None,
 ):
     """Helper to run a single transpose test with the given configs."""
     torch.manual_seed(12345)
@@ -59,6 +60,11 @@ def run_transpose_test(
             assert (
                 actual.shard_spec is not None
             ), f"Sharded output requested but result has no shard_spec (silently fell back?)"
+            if expected_shard_orientation is not None:
+                assert actual.shard_spec.orientation == expected_shard_orientation, (
+                    f"Expected output shard orientation {expected_shard_orientation}, "
+                    f"got {actual.shard_spec.orientation}"
+                )
 
     ref = x.transpose(dim0, dim1)
     got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
@@ -96,7 +102,7 @@ def _tile_align(shard_shape, layout):
     return (h, w)
 
 
-def _block_shard_config(shape, device, layout=ttnn.TILE_LAYOUT):
+def _block_shard_config(shape, device, layout=ttnn.TILE_LAYOUT, orientation=ttnn.ShardOrientation.ROW_MAJOR):
     """Create a 2x2 block-sharded MemoryConfig; shard rounded up to tile for TILE inputs."""
     compute_grid = device.compute_with_storage_grid_size()
     grid_x = min(2, compute_grid.x)
@@ -106,30 +112,39 @@ def _block_shard_config(shape, device, layout=ttnn.TILE_LAYOUT):
     shard_spec = ttnn.ShardSpec(
         ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_x - 1, grid_y - 1))}),
         shard_shape,
-        ttnn.ShardOrientation.ROW_MAJOR,
+        orientation,
     )
     return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1, shard_spec)
 
 
-def _height_shard_config(shape, device, num_cores=4, buffer_type=ttnn.BufferType.L1, layout=ttnn.TILE_LAYOUT):
+def _height_shard_config(
+    shape,
+    device,
+    num_cores=4,
+    buffer_type=ttnn.BufferType.L1,
+    layout=ttnn.TILE_LAYOUT,
+    orientation=ttnn.ShardOrientation.ROW_MAJOR,
+):
     """Create a height-sharded MemoryConfig; shard rounded up to tile for TILE inputs."""
     compute_grid = device.compute_with_storage_grid_size()
     num_cores = min(num_cores, compute_grid.x * compute_grid.y)
     shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid, True)
     total_h, w = _padded_hw(shape, layout)
     shard_shape = _tile_align(((total_h + num_cores - 1) // num_cores, w), layout)
-    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, orientation)
     return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, buffer_type, shard_spec)
 
 
-def _width_shard_config(shape, device, num_cores=4, layout=ttnn.TILE_LAYOUT):
+def _width_shard_config(
+    shape, device, num_cores=4, layout=ttnn.TILE_LAYOUT, orientation=ttnn.ShardOrientation.ROW_MAJOR
+):
     """Create a width-sharded MemoryConfig; shard rounded up to tile for TILE inputs."""
     compute_grid = device.compute_with_storage_grid_size()
     num_cores = min(num_cores, compute_grid.x * compute_grid.y)
     shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid, True)
     total_h, w = _padded_hw(shape, layout)
     shard_shape = _tile_align((total_h, (w + num_cores - 1) // num_cores), layout)
-    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, orientation)
     return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec)
 
 
@@ -345,7 +360,7 @@ def test_transpose_dram_sharded_fallback(device):
     assert_with_ulp(ref, got, ulp_threshold=1)
 
 
-# Non-native (BLOCK) sharded input → user-requested sharded output without shard_spec.
+# Non-native (BLOCK) sharded input → sharded output without shard_spec; COL_MAJOR cases cover orientation propagation.
 @pytest.mark.parametrize(
     "requested_out_layout",
     [
@@ -354,15 +369,54 @@ def test_transpose_dram_sharded_fallback(device):
         pytest.param(ttnn.TensorMemoryLayout.BLOCK_SHARDED, id="B_out"),
     ],
 )
-def test_transpose_non_native_sharded_input_to_sharded_nospec(requested_out_layout, device):
+@pytest.mark.parametrize(
+    "input_orientation",
+    [
+        pytest.param(ttnn.ShardOrientation.ROW_MAJOR, id="row_major_in"),
+        pytest.param(ttnn.ShardOrientation.COL_MAJOR, id="col_major_in"),
+    ],
+)
+def test_transpose_non_native_sharded_input_to_sharded_nospec(requested_out_layout, input_orientation, device):
     shape = (1, 1, 64, 64)
     run_transpose_test(
         shape,
         2,
         3,
         device,
-        input_mem_config=_block_shard_config(shape, device),
+        input_mem_config=_block_shard_config(shape, device, orientation=input_orientation),
         output_mem_config=ttnn.MemoryConfig(requested_out_layout, ttnn.BufferType.L1),
+        expected_shard_orientation=input_orientation,
+    )
+
+
+# Native cross-layout sharded-nospec output: preserves input shard orientation end-to-end.
+@pytest.mark.parametrize(
+    "input_factory, requested_out_layout",
+    [
+        pytest.param(
+            lambda d: _height_shard_config((1, 1, 128, 128), d, orientation=ttnn.ShardOrientation.COL_MAJOR),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            id="col_major_height_in_width_out_nospec",
+        ),
+        pytest.param(
+            lambda d: _width_shard_config((1, 1, 128, 128), d, orientation=ttnn.ShardOrientation.COL_MAJOR),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            id="col_major_width_in_height_out_nospec",
+        ),
+    ],
+)
+def test_transpose_native_col_major_sharded_input_to_sharded_nospec_cross_layout(
+    input_factory, requested_out_layout, device
+):
+    shape = (1, 1, 128, 128)
+    run_transpose_test(
+        shape,
+        2,
+        3,
+        device,
+        input_mem_config=input_factory(device),
+        output_mem_config=ttnn.MemoryConfig(requested_out_layout, ttnn.BufferType.L1),
+        expected_shard_orientation=ttnn.ShardOrientation.COL_MAJOR,
     )
 
 

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
@@ -5,6 +5,7 @@
 #include "permute.hpp"
 
 #include "ttnn/operations/data_movement/transpose/transpose.hpp"
+#include "ttnn/operations/data_movement/transpose/device/transpose_utils.hpp"
 #include "ttnn/operations/data_movement/permute/device/permute_device_operation.hpp"
 
 #include <tt-metalium/hal.hpp>
@@ -39,10 +40,29 @@ ttnn::Tensor permute_impl(
     const bool irregular_hw = input_logical.rank() >= 2 && (input_logical[-1] % tt::constants::TILE_WIDTH != 0 ||
                                                             input_logical[-2] % tt::constants::TILE_HEIGHT != 0);
     if (is_rm_block_or_width_sharded(a) && irregular_hw) {
+        // Snapshot orientation before the L1-interleaved staging hop strips it.
+        std::optional<tt::tt_metal::ShardOrientation> input_orientation_hint;
+        if (a.shard_spec().has_value()) {
+            input_orientation_hint = a.shard_spec()->orientation;
+        }
+        auto resolved_mc = output_mem_config;
+        if (output_mem_config.has_value() && output_mem_config->is_sharded() &&
+            !output_mem_config->shard_spec().has_value()) {
+            const auto& padded_in = a.padded_shape();
+            ttnn::SmallVector<uint32_t> out_padded_vec(padded_in.rank());
+            for (size_t i = 0; i < dims.size(); ++i) {
+                out_padded_vec[i] = padded_in[dims[i]];
+            }
+            auto output_padded_shape = ttnn::Shape(std::move(out_padded_vec));
+            auto spec = ttnn::operations::data_movement::transpose::generate_transpose_shard_spec(
+                a, output_padded_shape, output_mem_config->memory_layout(), input_orientation_hint);
+            resolved_mc =
+                MemoryConfig(output_mem_config->memory_layout(), output_mem_config->buffer_type(), std::move(spec));
+        }
         const auto interleaved_l1 =
             MemoryConfig(tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::L1);
         auto x = ttnn::to_memory_config(a, interleaved_l1, std::nullopt);
-        return permute_impl(x, dims, output_mem_config, pad_value);
+        return permute_impl(x, dims, resolved_mc, pad_value);
     }
 
     auto prim_permute = [&](const ttnn::Tensor& input) -> ttnn::Tensor {

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_utils.cpp
@@ -179,7 +179,10 @@ std::optional<ShardSpec> adjust_repeat_shard_spec_to_shape(
 }
 
 std::optional<ShardSpec> generate_repeat_shard_spec(
-    const Tensor& input_tensor, const ttnn::Shape& padded_out_shape, TensorMemoryLayout memory_layout) {
+    const Tensor& input_tensor,
+    const ttnn::Shape& padded_out_shape,
+    TensorMemoryLayout memory_layout,
+    std::optional<ShardOrientation> orientation_hint) {
     auto* device = input_tensor.device();
     auto compute_grid_size = device->compute_with_storage_grid_size();
     CoreRangeSet all_cores(CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1}));
@@ -238,7 +241,14 @@ std::optional<ShardSpec> generate_repeat_shard_spec(
 
     log_debug(
         tt::LogOp, "Repeat: synthesised shard spec ({}, {}) over {} cores", shard_shape[0], shard_shape[1], num_cores);
-    return ShardSpec(all_cores, shard_shape, ShardOrientation::ROW_MAJOR);
+    // Prefer explicit hint, then input's orientation, else ROW_MAJOR.
+    ShardOrientation orientation = ShardOrientation::ROW_MAJOR;
+    if (orientation_hint.has_value()) {
+        orientation = *orientation_hint;
+    } else if (input_tensor.shard_spec().has_value()) {
+        orientation = input_tensor.shard_spec()->orientation;
+    }
+    return ShardSpec(all_cores, shard_shape, orientation);
 }
 
 }  // namespace ttnn::operations::data_movement::repeat

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_utils.hpp
@@ -35,6 +35,9 @@ std::optional<tt::tt_metal::ShardSpec> adjust_repeat_shard_spec_to_shape(
 
 // Fresh shard spec over compute grid from post-repeat shape; nullopt if it won't fit.
 std::optional<tt::tt_metal::ShardSpec> generate_repeat_shard_spec(
-    const Tensor& input_tensor, const ttnn::Shape& padded_out_shape, tt::tt_metal::TensorMemoryLayout memory_layout);
+    const Tensor& input_tensor,
+    const ttnn::Shape& padded_out_shape,
+    tt::tt_metal::TensorMemoryLayout memory_layout,
+    std::optional<tt::tt_metal::ShardOrientation> orientation_hint = std::nullopt);
 
 }  // namespace ttnn::operations::data_movement::repeat

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
@@ -218,7 +218,12 @@ ttnn::Tensor repeat(
         }
     }
 
+    // Snapshot orientation before the L1-interleaved staging hop strips it.
+    std::optional<ShardOrientation> input_orientation_hint;
     if (!native_sharded) {
+        if (input_tensor.shard_spec().has_value()) {
+            input_orientation_hint = input_tensor.shard_spec()->orientation;
+        }
         if (working_tensor.memory_config().is_sharded()) {
             // DRAM-sharded fallback via to_memory_config (sharded_to_interleaved is L1-only);
             // use working_tensor to keep rank padding from match_input_rank.
@@ -270,9 +275,8 @@ ttnn::Tensor repeat(
     if (!native_sharded && output_mem_config.is_sharded()) {
         MemoryConfig final_mc = output_mem_config;
         if (!final_mc.shard_spec().has_value()) {
-            // Synthesise shard spec from post-repeat shape.
             auto synth = operations::data_movement::repeat::generate_repeat_shard_spec(
-                working_tensor, working_tensor.padded_shape(), final_mc.memory_layout());
+                working_tensor, working_tensor.padded_shape(), final_mc.memory_layout(), input_orientation_hint);
             if (synth.has_value()) {
                 final_mc = MemoryConfig(final_mc.memory_layout(), final_mc.buffer_type(), synth);
             } else {

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -126,9 +126,10 @@ ttnn::Tensor slice(
     // output_memory_config: may be rescaled below to match the sliced output dims.
     auto output_memory_config = memory_config;
 
-    // Fill in a missing shard_spec on a sharded output: reuse source's if layouts match, else
-    // synthesize from the source shape.
-    auto resolve_mc = [&](const ttnn::Tensor& source) {
+    // Fill in a missing shard_spec on a sharded output; reuse source's if layouts match.
+    // `orientation_hint` lets composite-fallback callers forward orientation past the staging hop.
+    auto resolve_mc = [&](const ttnn::Tensor& source,
+                          std::optional<tt::tt_metal::ShardOrientation> orientation_hint = std::nullopt) {
         auto resolved_mc = output_memory_config;
         if (resolved_mc.is_sharded() && !resolved_mc.shard_spec().has_value()) {
             const auto& in_mc = source.memory_config();
@@ -138,7 +139,7 @@ ttnn::Tensor slice(
                     ttnn::MemoryConfig(resolved_mc.memory_layout(), resolved_mc.buffer_type(), in_mc.shard_spec());
             } else {
                 auto spec = operations::data_movement::transpose::generate_transpose_shard_spec(
-                    source, source.padded_shape(), resolved_mc.memory_layout());
+                    source, source.padded_shape(), resolved_mc.memory_layout(), orientation_hint);
                 resolved_mc = ttnn::MemoryConfig(resolved_mc.memory_layout(), resolved_mc.buffer_type(), spec);
             }
         }
@@ -189,6 +190,11 @@ ttnn::Tensor slice(
     const bool rm_out_bad = detail::needs_rm_composite_output(input_tensor, output_memory_config);
     const bool out_no_spec = detail::needs_sharded_output_reshard(input_tensor, output_memory_config);
     if (rm_in_bad || rm_out_bad || out_no_spec) {
+        // Snapshot orientation before the L1-interleaved staging hop strips it.
+        std::optional<tt::tt_metal::ShardOrientation> input_orientation_hint;
+        if (input_tensor.shard_spec().has_value()) {
+            input_orientation_hint = input_tensor.shard_spec()->orientation;
+        }
         const auto interleaved_l1 =
             tt::tt_metal::MemoryConfig(tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::L1);
         Tensor x = rm_in_bad ? ttnn::to_memory_config(input_tensor, interleaved_l1, std::nullopt) : input_tensor;
@@ -197,7 +203,7 @@ ttnn::Tensor slice(
         auto sliced = ttnn::slice<T>(x, begins, ends, step, interleaved_l1, std::nullopt, pad_value, sub_core_grids);
         // slice preserves layout and to_memory_config doesn't change it — no trailing to_layout needed.
         // sliced is L1-interleaved so resolve_mc falls through to generate_transpose_shard_spec.
-        const auto final_mc = resolve_mc(sliced);
+        const auto final_mc = resolve_mc(sliced, input_orientation_hint);
         if (sliced.memory_config() == final_mc) {
             return finalize_into_preallocated(sliced);
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.cpp
@@ -132,7 +132,10 @@ std::optional<ShardSpec> adjust_shard_spec_to_shape(
 // Build a sharded spec over the full compute grid (used when no input shard_spec is available
 // to scale from, e.g. interleaved input + sharded output request).
 ShardSpec generate_transpose_shard_spec(
-    const Tensor& input_tensor, const ttnn::Shape& padded_out_shape, TensorMemoryLayout memory_layout) {
+    const Tensor& input_tensor,
+    const ttnn::Shape& padded_out_shape,
+    TensorMemoryLayout memory_layout,
+    std::optional<ShardOrientation> orientation_hint) {
     auto* device = input_tensor.device();
     auto compute_grid_size = device->compute_with_storage_grid_size();
     CoreRangeSet all_cores(CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1}));
@@ -167,7 +170,14 @@ ShardSpec generate_transpose_shard_spec(
         shard_shape = {static_cast<uint32_t>(shard_height), static_cast<uint32_t>(shard_width)};
     }
     log_debug(tt::LogOp, "Transpose: generated shard spec over full compute grid ({} cores)", num_cores);
-    return ShardSpec(all_cores, shard_shape, ShardOrientation::ROW_MAJOR);
+    // Prefer explicit hint, then input's orientation, else ROW_MAJOR.
+    ShardOrientation orientation = ShardOrientation::ROW_MAJOR;
+    if (orientation_hint.has_value()) {
+        orientation = *orientation_hint;
+    } else if (input_tensor.shard_spec().has_value()) {
+        orientation = input_tensor.shard_spec()->orientation;
+    }
+    return ShardSpec(all_cores, shard_shape, orientation);
 }
 
 }  // namespace ttnn::operations::data_movement::transpose

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.hpp
@@ -17,7 +17,11 @@ bool is_native_transpose_sharding(
 std::optional<tt::tt_metal::ShardSpec> adjust_shard_spec_to_shape(
     const tt::tt_metal::ShardSpec& shard_spec, const ttnn::Shape& from_shape, const ttnn::Shape& to_shape);
 
+// Build a sharded spec over the full compute grid from the post-transform shape.
 tt::tt_metal::ShardSpec generate_transpose_shard_spec(
-    const Tensor& input_tensor, const ttnn::Shape& padded_out_shape, tt::tt_metal::TensorMemoryLayout memory_layout);
+    const Tensor& input_tensor,
+    const ttnn::Shape& padded_out_shape,
+    tt::tt_metal::TensorMemoryLayout memory_layout,
+    std::optional<tt::tt_metal::ShardOrientation> orientation_hint = std::nullopt);
 
 }  // namespace ttnn::operations::data_movement::transpose

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
@@ -21,8 +21,6 @@ namespace detail {
 using namespace tt::tt_metal::experimental;
 using namespace tt;
 using tt::tt_metal::BufferType;
-using ttnn::operations::data_movement::transpose::adjust_shard_spec_to_shape;
-using ttnn::operations::data_movement::transpose::is_native_transpose_sharding;
 
 inline Tensor transpose_(
     const Tensor& a,
@@ -71,7 +69,10 @@ inline Tensor transpose_(
                     auto output_padded_shape = input_padded_shape;
                     std::swap(output_padded_shape[2], output_padded_shape[3]);
                     auto adjusted = adjust_shard_spec_to_shape(shard_spec, input_padded_shape, output_padded_shape);
-                    if (!adjusted.has_value() ||
+                    // Layout mismatch: synthesize a fresh spec instead of reusing the input's.
+                    const bool layouts_match = !user_requested_layout || output_mem_config.value().memory_layout() ==
+                                                                             a.memory_config().memory_layout();
+                    if (!adjusted.has_value() || !layouts_match ||
                         (a.layout() == Layout::TILE && (adjusted->shape[0] % tt::constants::TILE_HEIGHT != 0 ||
                                                         adjusted->shape[1] % tt::constants::TILE_WIDTH != 0))) {
                         shard_derivation_fallback();
@@ -89,7 +90,10 @@ inline Tensor transpose_(
                 output_padded_shape[1] = a.logical_shape()[2];
                 output_padded_shape[2] = tt::round_up(a.logical_shape()[1], tt::constants::TILE_HEIGHT);
                 auto adjusted = adjust_shard_spec_to_shape(shard_spec, input_padded_shape, output_padded_shape);
-                if (!adjusted.has_value() || adjusted->shape[0] % tt::constants::TILE_HEIGHT != 0 ||
+                // Layout mismatch: synthesize a fresh spec instead of reusing the input's.
+                const bool layouts_match = !user_requested_layout || output_mem_config.value().memory_layout() ==
+                                                                         a.memory_config().memory_layout();
+                if (!adjusted.has_value() || !layouts_match || adjusted->shape[0] % tt::constants::TILE_HEIGHT != 0 ||
                     adjusted->shape[1] % tt::constants::TILE_WIDTH != 0) {
                     shard_derivation_fallback();
                 } else {
@@ -203,10 +207,29 @@ ttnn::Tensor transpose_impl(
         const bool irregular_hw = input_logical.rank() >= 2 && (input_logical[-1] % tt::constants::TILE_WIDTH != 0 ||
                                                                 input_logical[-2] % tt::constants::TILE_HEIGHT != 0);
         if (rm && in_sharded && irregular_hw) {
+            // Snapshot orientation before the L1-interleaved staging hop strips it.
+            std::optional<tt::tt_metal::ShardOrientation> input_orientation_hint;
+            if (input_tensor.shard_spec().has_value()) {
+                input_orientation_hint = input_tensor.shard_spec()->orientation;
+            }
+            auto resolved_mc = memory_config_arg;
+            if (memory_config_arg.has_value() && memory_config_arg->is_sharded() &&
+                !memory_config_arg->shard_spec().has_value()) {
+                const auto& input_padded = input_tensor.padded_shape();
+                const uint32_t n1 = input_logical.get_normalized_index(dim1);
+                const uint32_t n2 = input_logical.get_normalized_index(dim2);
+                ttnn::SmallVector<uint32_t> out_padded_vec(input_padded.cbegin(), input_padded.cend());
+                std::swap(out_padded_vec[n1], out_padded_vec[n2]);
+                auto output_padded_shape = ttnn::Shape(std::move(out_padded_vec));
+                auto spec = generate_transpose_shard_spec(
+                    input_tensor, output_padded_shape, memory_config_arg->memory_layout(), input_orientation_hint);
+                resolved_mc = tt::tt_metal::MemoryConfig(
+                    memory_config_arg->memory_layout(), memory_config_arg->buffer_type(), std::move(spec));
+            }
             const auto interleaved_l1 =
                 tt::tt_metal::MemoryConfig(tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::L1);
             Tensor x = ttnn::to_memory_config(input_tensor, interleaved_l1, std::nullopt);
-            return transpose_impl(x, dim1, dim2, memory_config_arg, pad_value);
+            return transpose_impl(x, dim1, dim2, resolved_mc, pad_value);
         }
     }
     const auto& input_shape = input_tensor.logical_shape();


### PR DESCRIPTION
### Ticket
Link to Github Issue #48027

### Problem
When a `COL_MAJOR` sharded input is fed into `ttnn::transpose`, `ttnn::permute`, `ttnn::slice`, or `ttnn::repeat` and the caller requests a **cross-layout sharded output** (different `TensorMemoryLayout`) **without** an explicit `shard_spec`, the result silently comes back as `ROW_MAJOR`. Same-layout sharded→sharded paths were unaffected.

### What this PR does
- Preserves the input's `ShardOrientation` through all four ops when the caller requests a sharded output without an explicit shard spec — on both the composite/staging-hop paths and the native device-op synthesis paths.
- Applies a single, uniform capture-and-forward pattern at the host level for paths that stage through L1 interleaved before re-sharding.
- All existing public API signatures and default behaviours are unchanged for callers that do not hit these synthesis paths.

### Tests
Wormhole B0 (N150) — universal-IO suites for the four affected ops:

| Suite | Result |
| --- | --- |
| `test_universal_input_tm_tranpose.py` | **144 passed, 2 skipped** (pre-existing bf8b skips on HC) |
| `test_universal_input_tm_permute.py` | **86 passed** |
| `test_universal_input_tm_repeat.py` | **86 passed** |
| `test_universal_input_tm_slice.py` | **54 passed** |
| **Combined** | **370 passed, 2 skipped** — no regressions |

`COL_MAJOR` orientation coverage:
- **Composite/staging-hop** (BLOCK irregular-RM / composite-reshard): `test_*_sharded_input_to_sharded_nospec` extended with `input_orientation ∈ {ROW_MAJOR, COL_MAJOR}` for transpose and permute; `col_major_block_in_*` cases for repeat and slice.
- **Native device-op synthesis** (HEIGHT/WIDTH sharded input, no staging hop): `test_transpose_native_col_major_sharded_input_to_sharded_nospec_cross_layout`, `test_permute_native_col_major_sharded_input_to_sharded_nospec_cross_layout` (new), `test_repeat_native_col_major_height_sharded_to_sharded_nospec` (new), `test_slice_tile_same_layout_sharded_no_spec_halving_col_major`.

All `run_*_test` helpers gained an `expected_shard_orientation` assertion so the contract is pinned end-to-end.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/tm_ops_bug_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/tm_ops_bug_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/tm_ops_bug_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/tm_ops_bug_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mouliraj/tm_ops_bug_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mouliraj/tm_ops_bug_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/tm_ops_bug_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/tm_ops_bug_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/tm_ops_bug_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/tm_ops_bug_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/tm_ops_bug_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/tm_ops_bug_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/tm_ops_bug_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/tm_ops_bug_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/tm_ops_bug_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/tm_ops_bug_fix)
