### PR TITLE
perf(groupnorm): reserve mask stride vector and hoist index math

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_input_mask.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_input_mask.cpp
@@ -56,6 +56,7 @@ ttnn::Tensor create_group_norm_input_mask_impl(
     const int64_t num_cols_per_group = num_channel / num_groups;
 
     std::vector<int64_t> start_strides;
+    start_strides.reserve(num_cores_across_channel * num_groups_per_core);
     for (int64_t core = 0; core < num_cores_across_channel; ++core) {
         int64_t row_offset = 0;
         start_strides.push_back(0);
@@ -83,10 +84,11 @@ ttnn::Tensor create_group_norm_input_mask_impl(
     for (int64_t group = 0; group < out_num_groups; ++group) {
         int64_t start_stride = start_strides[group];
         int64_t end_stride = std::min(end_strides[group], out_mask_width);
+        const int64_t group_base = group * out_tile_height * out_mask_width;
         for (int64_t h = 0; h < out_tile_height; ++h) {
+            const int64_t row_base = group_base + (h * out_mask_width);
             for (int64_t w = start_stride; w < end_stride; ++w) {
-                int64_t idx = (group * out_tile_height * out_mask_width) + (h * out_mask_width) + w;
-                mask_vec[idx] = mask_value;
+                mask_vec[row_base + w] = mask_value;
             }
         }
     }


### PR DESCRIPTION
Issue : https://github.com/tenstorrent/tt-metal/issues/48020

Reserve start_strides up front (avoids reallocations) and lift the per-iteration index base out of the inner mask-fill loops. Micro-opt on the host-side group-norm input-mask build; behavior-identical.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=perf/groupnorm-mask-reserve-hoist)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:perf/groupnorm-mask-reserve-hoist)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=perf/groupnorm-mask-reserve-hoist)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:perf/groupnorm-mask-reserve-hoist)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=perf/groupnorm-mask-reserve-hoist)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:perf/groupnorm-mask-reserve-hoist)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=perf/groupnorm-mask-reserve-hoist)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:perf/groupnorm-mask-reserve-hoist)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=perf/groupnorm-mask-reserve-hoist)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:perf/groupnorm-mask-reserve-hoist)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=perf/groupnorm-mask-reserve-hoist)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:perf/groupnorm-mask-reserve-hoist)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=perf/groupnorm-mask-reserve-hoist)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:perf/groupnorm-mask-reserve-hoist)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=perf/groupnorm-mask-reserve-hoist)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:perf/groupnorm-mask-reserve-hoist)