### PR TITLE
perf(quasar/matmul): O(1) set lookups in move_common_entries

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/utilities/matmul_utilities.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/utilities/matmul_utilities.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <set>
+#include <unordered_set>
 
 #include "tt-metalium/allocator.hpp"
 #include "tt-metalium/buffer_types.hpp"
@@ -363,15 +364,17 @@ void get_max_page_size_and_num_pages(
 }
 
 void move_common_entries(std::vector<CoreCoord>& v1, std::vector<CoreCoord>& v2, std::vector<CoreCoord>& commons) {
+    // Build a hash set from v1 for O(1) membership tests instead of O(n) std::find per item.
+    const std::unordered_set<CoreCoord> v1_set(v1.begin(), v1.end());
     for (const CoreCoord& item : v2) {
-        if (std::find(v1.begin(), v1.end(), item) != v1.end()) {
+        if (v1_set.contains(item)) {
             commons.push_back(item);
         }
     }
 
-    for (const CoreCoord& item : commons) {
-        v2.erase(std::remove(v2.begin(), v2.end(), item), v2.end());
-    }
+    const std::unordered_set<CoreCoord> commons_set(commons.begin(), commons.end());
+    v2.erase(
+        std::remove_if(v2.begin(), v2.end(), [&](const CoreCoord& c) { return commons_set.contains(c); }), v2.end());
 }
 
 void get_optimal_dram_bank_to_reader_assignment(


### PR DESCRIPTION
Issue https://github.com/tenstorrent/tt-metal/issues/48020

Replace the O(n) std::find-per-item membership test and the erase-in-loop with unordered_set lookups + a single remove_if pass. Mirrors the fix already on the non-quasar matmul_utilities. Behavior-identical.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=perf/quasar-move-common-entries-set)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:perf/quasar-move-common-entries-set)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=perf/quasar-move-common-entries-set)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:perf/quasar-move-common-entries-set)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=perf/quasar-move-common-entries-set)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:perf/quasar-move-common-entries-set)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=perf/quasar-move-common-entries-set)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:perf/quasar-move-common-entries-set)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=perf/quasar-move-common-entries-set)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:perf/quasar-move-common-entries-set)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=perf/quasar-move-common-entries-set)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:perf/quasar-move-common-entries-set)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=perf/quasar-move-common-entries-set)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:perf/quasar-move-common-entries-set)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=perf/quasar-move-common-entries-set)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:perf/quasar-move-common-entries-set)