### PR TITLE
perf(ccl): return slice vector by move, not element-wise copy

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_command_stream_builders.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_command_stream_builders.cpp
@@ -52,7 +52,7 @@ std::vector<std::pair<size_t, size_t>> compute_evenly_split_sizes(size_t size, s
     for (size_t i = 0; i < num_slices; i++) {
         result.push_back(compute_slice_size_and_offset(i));
     }
-    return std::vector<std::pair<size_t, size_t>>(result.begin(), result.end());
+    return result;
 }
 
 // // Outer vector = per worker command stream, inner vector = commands


### PR DESCRIPTION
Issue https://github.com/tenstorrent/tt-metal/issues/48020

compute_evenly_split_sizes built `result` then returned `std::vector(result.begin(), result.end())`, copying every element. Return `result` directly so NRVO/move applies. Behavior-identical.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=perf/ccl-cmd-stream-return-move)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:perf/ccl-cmd-stream-return-move)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=perf/ccl-cmd-stream-return-move)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:perf/ccl-cmd-stream-return-move)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=perf/ccl-cmd-stream-return-move)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:perf/ccl-cmd-stream-return-move)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=perf/ccl-cmd-stream-return-move)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:perf/ccl-cmd-stream-return-move)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=perf/ccl-cmd-stream-return-move)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:perf/ccl-cmd-stream-return-move)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=perf/ccl-cmd-stream-return-move)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:perf/ccl-cmd-stream-return-move)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=perf/ccl-cmd-stream-return-move)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:perf/ccl-cmd-stream-return-move)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=perf/ccl-cmd-stream-return-move)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:perf/ccl-cmd-stream-return-move)