### PR TITLE
perf(dispatch): reserve per-core RTA vectors per kernel group

### DIFF
--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -755,6 +755,12 @@ BatchedTransfers assemble_runtime_args_commands(
         // Set by the user based on the kernel and core coord
         for (auto& kg : program.get_kernel_groups(index)) {
             if (kg->total_rta_size != 0) {
+                // These per-core vectors are cleared per kernel group, so reserve their final size
+                // up front (one entry per core) instead of growing one element at a time.
+                const size_t kg_num_cores = kg->core_ranges.num_cores();
+                unique_rt_args_data.reserve(kg_num_cores);
+                unique_rt_data_and_sizes.reserve(kg_num_cores);
+                unique_sub_cmds.reserve(kg_num_cores);
                 for (const CoreRange& core_range : kg->core_ranges.ranges()) {
                     for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
                         for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {


### PR DESCRIPTION
Issue : https://github.com/tenstorrent/tt-metal/issues/48020

On the program-dispatch path these per-core vectors were grown one element at a time via resize(size()+1). They're cleared per kernel group, so reserve the kg's core count up front to avoid the incremental reallocations. Behavior-identical.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=perf/dispatch-reserve-unique-rta)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:perf/dispatch-reserve-unique-rta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=perf/dispatch-reserve-unique-rta)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:perf/dispatch-reserve-unique-rta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=perf/dispatch-reserve-unique-rta)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:perf/dispatch-reserve-unique-rta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=perf/dispatch-reserve-unique-rta)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:perf/dispatch-reserve-unique-rta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=perf/dispatch-reserve-unique-rta)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:perf/dispatch-reserve-unique-rta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=perf/dispatch-reserve-unique-rta)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:perf/dispatch-reserve-unique-rta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=perf/dispatch-reserve-unique-rta)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:perf/dispatch-reserve-unique-rta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=perf/dispatch-reserve-unique-rta)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:perf/dispatch-reserve-unique-rta)