### PR TITLE
perf(buffer): return ShardSpecBuffer::grid() by const reference

### DIFF
--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -103,7 +103,7 @@ struct ShardSpecBuffer {
         const std::array<uint32_t, 2>& page_shape,
         const std::array<uint32_t, 2>& tensor2d_shape_in_pages) :
         tensor_shard_spec(shard_spec), page_shape(page_shape), tensor2d_shape_in_pages(tensor2d_shape_in_pages) {}
-    CoreRangeSet grid() const { return tensor_shard_spec.grid; }
+    const CoreRangeSet& grid() const { return tensor_shard_spec.grid; }
     std::array<uint32_t, 2> shape() const { return tensor_shard_spec.shape; }
     ShardOrientation orientation() const { return tensor_shard_spec.orientation; }
     void set_shard_spec(const ShardSpec& shard_spec) { tensor_shard_spec = shard_spec; };


### PR DESCRIPTION
Issue : https://github.com/tenstorrent/tt-metal/issues/48020

grid() returned a CoreRangeSet (a vector<CoreRange>) by value, copying on every call. Return const& to the member instead. Behavior-identical for read-only callers; value callers still copy via auto.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=perf/buffer-grid-const-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:perf/buffer-grid-const-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=perf/buffer-grid-const-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:perf/buffer-grid-const-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=perf/buffer-grid-const-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:perf/buffer-grid-const-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=perf/buffer-grid-const-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:perf/buffer-grid-const-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=perf/buffer-grid-const-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:perf/buffer-grid-const-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=perf/buffer-grid-const-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:perf/buffer-grid-const-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=perf/buffer-grid-const-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:perf/buffer-grid-const-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=perf/buffer-grid-const-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:perf/buffer-grid-const-ref)