### PR TITLE
[Tooling] Add --profile mode and machine-readable outputs to run_safe_pytest.sh

### DIFF
--- a/scripts/run_safe_pytest.sh
+++ b/scripts/run_safe_pytest.sh
@@ -12,7 +12,7 @@
 #   Skips flock, device resets, and triage (these require real hardware).
 #   No hang protection — sim runs at kHz, so wall-clock timeouts are meaningless.
 #
-# Usage: scripts/run_safe_pytest.sh [--dev] [--run-all] <test_path> [extra_pytest_args...]
+# Usage: scripts/run_safe_pytest.sh [--dev] [--run-all] [--profile] <test_path> [extra_pytest_args...]
 #
 # Options:
 #   --dev       Enables polling watcher (NoC sanitizer, waypoints, CB
@@ -20,10 +20,18 @@
 #               on hang with full triage + watcher log dump.
 #   --run-all   Run all tests instead of stopping on first failure (-x).
 #               Useful for eval scoring where you need full pass/fail counts.
+#   --profile   Run under the Tracy device profiler (python -m tracy -r). Emits
+#               a per-op CSV (generated/profiler/reports/<ts>/ops_perf_results*.csv)
+#               and prints its path as "SAFE_PYTEST: PROFILER CSV: <path>" next to
+#               the result line. Requires a Tracy-enabled build. NOTE: the tracy
+#               wrapper masks pytest's exit code, so a profiled run is reported
+#               PASS as long as profiling completed, regardless of the underlying
+#               test result. Hangs are still detected and still reset the device.
 #
 # Modes:
 #   default  - Dispatch timeout only. Lean, no debug overhead.
 #   --dev    - Debug mode with watcher, asserts, and triage (see above).
+#   --profile - Tracy device profiling with per-op CSV report (see above).
 #
 # Exit codes:
 #   0 - All tests passed
@@ -33,13 +41,20 @@
 
 set -o pipefail
 
+# SAFE_PYTEST status lines and triage/watcher dumps go to stdout (plain echo),
+# the same stream the metal runtime uses for its logging/DPRINT/JIT output;
+# pytest's own stdout/stderr pass through unchanged.
+
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DISPATCH_TIMEOUT=5
 TRIAGE_SCRIPT="${REPO_DIR}/tools/tt-triage.py"
 WATCHER_LOG="${REPO_DIR}/generated/watcher/watcher.log"
+TRIAGE_LLM_DIR="${REPO_DIR}/generated/tt-triage"
 LOCK_FILE="/tmp/tt-device.lock"
 DIRTY_FLAG="/tmp/tt-device.dirty"
 TRIAGE_LOG="/tmp/safe-pytest-triage-$$.log"
+TRIAGE_LLM="${TRIAGE_LLM_DIR}/triage.csv"
+PROFILE_REPORTS_DIR="${REPO_DIR}/generated/profiler/reports"
 
 # --- Detect simulator mode ---
 SIM_MODE=false
@@ -52,6 +67,7 @@ fi
 # --- Parse flags ---
 DEV_MODE=false
 FAIL_FAST=true
+PROFILE_MODE=false
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --dev)
@@ -62,6 +78,10 @@ while [[ $# -gt 0 ]]; do
             FAIL_FAST=false
             shift
             ;;
+        --profile)
+            PROFILE_MODE=true
+            shift
+            ;;
         *)
             break
             ;;
@@ -70,31 +90,65 @@ done
 
 # --- Argument validation ---
 if [[ $# -eq 0 ]]; then
-    echo "SAFE_PYTEST_ERROR: No test path provided" >&2
-    echo "Usage: scripts/run_safe_pytest.sh [--dev] [--run-all] <test_path> [extra_pytest_args...]" >&2
+    echo "SAFE_PYTEST_ERROR: No test path provided"
+    echo "Usage: scripts/run_safe_pytest.sh [--dev] [--run-all] [--profile] <test_path> [extra_pytest_args...]"
     exit 3
 fi
 
 TEST_PATH="$1"
 shift
 
+# --- Deferred warnings ---
+# Warnings raised during setup get buried under pytest/triage output, so the
+# user never sees them. Buffer them and flush via an EXIT trap so they surface
+# as the very last thing printed, regardless of how the script exits.
+DEFERRED_WARNINGS=()
+defer_warning() { DEFERRED_WARNINGS+=("$1"); }
+flush_deferred_warnings() {
+    if [[ ${#DEFERRED_WARNINGS[@]} -gt 0 ]]; then
+        echo ""
+        local w
+        for w in "${DEFERRED_WARNINGS[@]}"; do
+            echo "$w"
+        done
+    fi
+}
+trap flush_deferred_warnings EXIT
+
+# Newest ops_perf_results CSV before the run; set just before pytest (below).
+PROFILE_CSV_BEFORE=""
+
+# Print this run's per-op CSV path. `python -m tracy -r` writes a fresh
+# reports/<ts>/ subdir per run, so we report the newest only if it differs from
+# the pre-run snapshot — otherwise this run produced none and it's a stale leftover.
+emit_profiler_csv() {
+    [[ "$PROFILE_MODE" == true ]] || return 0
+    local csv
+    csv=$(ls -t "${PROFILE_REPORTS_DIR}"/*/ops_perf_results*.csv 2>/dev/null | head -1)
+    if [[ -n "$csv" && "$csv" != "$PROFILE_CSV_BEFORE" ]]; then
+        echo "SAFE_PYTEST: PROFILER CSV: ${csv}"
+    else
+        echo "SAFE_PYTEST: WARNING: --profile set but this run produced no ops_perf_results CSV"
+    fi
+}
+
 # --- Acquire flock (hardware only) ---
 if [[ "$SIM_MODE" == false ]]; then
     exec 9>"$LOCK_FILE"
 
-    echo "SAFE_PYTEST: Waiting for device lock..." >&2
+    echo "SAFE_PYTEST: Waiting for device lock..."
     flock 9
-    echo "SAFE_PYTEST: Device lock acquired" >&2
+    echo "SAFE_PYTEST: Device lock acquired"
 
     # --- Check if device needs reset from previous hang ---
     if [[ -f "$DIRTY_FLAG" ]]; then
-        echo "SAFE_PYTEST: Device marked dirty from previous hang, resetting..." >&2
+        echo "SAFE_PYTEST: Device marked dirty from previous hang, resetting..."
         if ! tt-smi -r; then
-            echo "SAFE_PYTEST_ERROR: Device reset (tt-smi -r) failed" >&2
+            echo "SAFE_PYTEST_ERROR: Device reset (tt-smi -r) failed"
             exit 3
         fi
         rm -f "$DIRTY_FLAG"
-        echo "SAFE_PYTEST: Device reset complete" >&2
+        echo "SAFE_PYTEST: Device reset complete"
     fi
 fi
 
@@ -102,10 +156,22 @@ fi
 cd "$REPO_DIR"
 if [[ -f python_env/bin/activate ]]; then
     if ! source python_env/bin/activate; then
-        echo "SAFE_PYTEST: WARNING: Failed to activate python_env virtual environment" >&2
+        defer_warning "SAFE_PYTEST: WARNING: Failed to activate python_env virtual environment"
     fi
 else
-    echo "SAFE_PYTEST: WARNING: python_env not found; using system Python" >&2
+    defer_warning "SAFE_PYTEST: WARNING: python_env not found; using system Python"
+fi
+
+# --- Profiling preflight ---
+# `python -m tracy` needs a Tracy-enabled build and tracy deps (e.g. websockets).
+# Probe the import it does at startup (tracy.__main__ -> tracy.serve_wasm) so a
+# missing dep fails fast here instead of as a confusing mid-run traceback.
+if [[ "$PROFILE_MODE" == true ]]; then
+    if ! python3 -c "import tracy.serve_wasm" 2>/dev/null; then
+        echo "SAFE_PYTEST_ERROR: --profile requested but 'python -m tracy' is unavailable"
+        echo "SAFE_PYTEST: Ensure a Tracy-enabled build and tracy deps (e.g. 'pip install websockets')"
+        exit 3
+    fi
 fi
 
 # --- Hang detection setup (hardware only) ---
@@ -117,10 +183,13 @@ if [[ "$SIM_MODE" == false ]]; then
     export TT_METAL_OPERATION_TIMEOUT_SECONDS="$DISPATCH_TIMEOUT"
     # Requires tt-exalens: uv pip install -r tools/triage/requirements.txt
     if ! python3 -c "import ttexalens" 2>/dev/null; then
-        echo "SAFE_PYTEST: WARNING: tt-exalens not installed — triage on hang will be unavailable." >&2
-        echo "SAFE_PYTEST: Install with: uv pip install -r tools/triage/requirements.txt" >&2
+        defer_warning "SAFE_PYTEST: WARNING: tt-exalens not installed — triage on hang will be unavailable."
+        defer_warning "SAFE_PYTEST: Install with: uv pip install -r tools/triage/requirements.txt"
     fi
-    export TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE="python3 ${TRIAGE_SCRIPT} --disable-progress > ${TRIAGE_LOG} 2>&1"
+    # --llm-output-path also writes the triage report as CSV to a persistent file,
+    # so machine-readers can consume it directly instead of scraping the log.
+    mkdir -p "${TRIAGE_LLM_DIR}"
+    export TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE="python3 ${TRIAGE_SCRIPT} --disable-progress --skip-version-check --llm-output-path=${TRIAGE_LLM} > ${TRIAGE_LOG} 2>&1"
 fi
 
 if [[ "$DEV_MODE" == true ]]; then
@@ -150,17 +219,17 @@ if [[ "$DEV_MODE" == true ]]; then
     export TT_METAL_WATCHER_DISABLE_DISPATCH=1
 
     if [[ "$SIM_MODE" == true ]]; then
-        echo "SAFE_PYTEST: [sim+dev] asserts=ebreak llk_asserts=ON watcher=polling (no hang detection on sim)" >&2
+        echo "SAFE_PYTEST: [sim+dev] asserts=ebreak llk_asserts=ON watcher=polling (no hang detection on sim)"
     else
-        echo "SAFE_PYTEST: [dev] asserts=ebreak llk_asserts=ON watcher=polling triage=ON timeout=${DISPATCH_TIMEOUT}s" >&2
+        echo "SAFE_PYTEST: [dev] asserts=ebreak llk_asserts=ON watcher=polling triage=ON timeout=${DISPATCH_TIMEOUT}s"
     fi
 elif [[ "$SIM_MODE" == true ]]; then
-    echo "SAFE_PYTEST: [sim] no hang detection" >&2
+    echo "SAFE_PYTEST: [sim] no hang detection"
 else
-    echo "SAFE_PYTEST: dispatch_timeout=${DISPATCH_TIMEOUT}s" >&2
+    echo "SAFE_PYTEST: dispatch_timeout=${DISPATCH_TIMEOUT}s"
 fi
-echo "SAFE_PYTEST: pytest ${TEST_PATH} $*" >&2
-echo "========================================" >&2
+echo "SAFE_PYTEST: pytest ${TEST_PATH} $*"
+echo "========================================"
 
 # --- Mark device dirty before running tests (hardware only) ---
 # Pessimistic: assume the device will get corrupted. If the script is killed at any
@@ -173,22 +242,39 @@ fi
 # --- Run pytest ---
 # -x: stop on first failure (avoids running tests after a hang bricks the device)
 # --run-all: skip -x to get full pass/fail counts (for eval scoring)
-PYTEST_CMD=(pytest "${TEST_PATH}")
+# --profile: wrap pytest in the Tracy profiler. `python -m tracy -r` runs pytest
+#   as a child and post-processes results into ops_perf_results*.csv on pass or
+#   fail. Its exit-code masking is handled at the result check below.
+if [[ "$PROFILE_MODE" == true ]]; then
+    PYTEST_CMD=(python -m tracy -r -m pytest "${TEST_PATH}")
+else
+    PYTEST_CMD=(pytest "${TEST_PATH}")
+fi
 if [[ "$FAIL_FAST" == true ]]; then
     PYTEST_CMD+=(-x)
 fi
 PYTEST_CMD+=("$@")
 
+# Snapshot the newest CSV now, so emit_profiler_csv can tell this run's report
+# from a pre-existing one afterward.
+if [[ "$PROFILE_MODE" == true ]]; then
+    PROFILE_CSV_BEFORE=$(ls -t "${PROFILE_REPORTS_DIR}"/*/ops_perf_results*.csv 2>/dev/null | head -1)
+fi
+
 "${PYTEST_CMD[@]}"
 EXIT_CODE=$?
 
-echo "========================================" >&2
+echo "========================================"
 
 # --- Handle result ---
-if [[ $EXIT_CODE -eq 0 ]]; then
+# The triage-log guard matters in profile mode: the tracy wrapper exits 0 even
+# when the underlying test failed OR hung, so without it a hang would be reported
+# PASS and skip the device reset. An empty triage log means no hang fired.
+if [[ $EXIT_CODE -eq 0 && ! -s "$TRIAGE_LOG" ]]; then
     rm -f "$DIRTY_FLAG"
     rm -f "$TRIAGE_LOG"
-    echo "SAFE_PYTEST_RESULT: PASS" >&2
+    emit_profiler_csv
+    echo "SAFE_PYTEST_RESULT: PASS"
     exit 0
 fi
 
@@ -199,9 +285,9 @@ if [[ $EXIT_CODE -eq 4 || $EXIT_CODE -eq 5 ]]; then
     rm -f "$DIRTY_FLAG"
     rm -f "$TRIAGE_LOG"
     if [[ $EXIT_CODE -eq 4 ]]; then
-        echo "SAFE_PYTEST_ERROR: Pytest usage error (invalid path or arguments)" >&2
+        echo "SAFE_PYTEST_ERROR: Pytest usage error (invalid path or arguments)"
     else
-        echo "SAFE_PYTEST_ERROR: No tests collected" >&2
+        echo "SAFE_PYTEST_ERROR: No tests collected"
     fi
     exit 3
 fi
@@ -221,30 +307,35 @@ fi
 # Hangs and crashes corrupt device state. Normal test failures (PCC mismatch,
 # assertion errors) and collection errors don't touch the device.
 if [[ "$IS_HANG" == true ]]; then
-    echo "SAFE_PYTEST: Resetting device..." >&2
+    echo "SAFE_PYTEST: Resetting device..."
     if tt-smi -r; then
         sleep 2
         rm -f "$DIRTY_FLAG"
-        echo "SAFE_PYTEST: Device reset complete" >&2
+        echo "SAFE_PYTEST: Device reset complete"
     else
-        echo "SAFE_PYTEST: Device reset FAILED; leaving device marked dirty" >&2
+        echo "SAFE_PYTEST: Device reset FAILED; leaving device marked dirty"
     fi
 
-    echo "SAFE_PYTEST_RESULT: HANG (exit code: $EXIT_CODE)" >&2
-    echo "" >&2
+    echo "SAFE_PYTEST_RESULT: HANG (exit code: $EXIT_CODE)"
+    echo ""
 
     # Dump full triage log
-    echo "=== TRIAGE LOG ===" >&2
-    cat "$TRIAGE_LOG" >&2
-    echo "=== END TRIAGE LOG ===" >&2
-    echo "" >&2
+    echo "=== TRIAGE LOG ==="
+    cat "$TRIAGE_LOG"
+    echo "=== END TRIAGE LOG ==="
+    echo ""
 
     # In dev mode, also dump watcher log
     if [[ "$DEV_MODE" == true && -f "$WATCHER_LOG" ]]; then
-        echo "=== WATCHER LOG (last 50 lines) ===" >&2
-        tail -50 "$WATCHER_LOG" >&2
-        echo "=== END WATCHER LOG ===" >&2
-        echo "" >&2
+        echo "=== WATCHER LOG (last 50 lines) ==="
+        tail -50 "$WATCHER_LOG"
+        echo "=== END WATCHER LOG ==="
+        echo ""
+    fi
+
+    # Emit the LLM triage path so machine-readers can find it (grep the prefix).
+    if [[ -f "$TRIAGE_LLM" ]]; then
+        echo "SAFE_PYTEST: LLM triage: ${TRIAGE_LLM}"
     fi
 
     rm -f "$TRIAGE_LOG"
@@ -253,5 +344,5 @@ fi
 
 rm -f "$DIRTY_FLAG"
 rm -f "$TRIAGE_LOG"
-echo "SAFE_PYTEST_RESULT: FAIL (exit code: $EXIT_CODE)" >&2
+echo "SAFE_PYTEST_RESULT: FAIL (exit code: $EXIT_CODE)"
 exit 1


### PR DESCRIPTION
## What

Extends `scripts/run_safe_pytest.sh` with a profiling mode and a few output/robustness improvements.

### `--profile`
- Wraps the run in the Tracy device profiler (`python -m tracy -r -m pytest …`), producing the per-op `ops_perf_results_<ts>.csv` report.
- A **preflight** imports `tracy.serve_wasm` up front and fails fast (exit 3) with a clear message if the Tracy build/deps (e.g. `websockets`) are missing, instead of a confusing mid-run traceback.
- Prints `SAFE_PYTEST: PROFILER CSV: <path>` next to the result line. The path is guarded by a **pre-run snapshot** so a stale CSV from an earlier run is never misreported as this run's output.
- Result handling honors the tracy wrapper's masked exit code (a profiled run is reported PASS as long as profiling completed), **but** still detects hangs via the triage log and resets the device.

### Other changes
- **All SAFE_PYTEST output → stdout** (was stderr), the same stream the metal runtime uses for logging/DPRINT/JIT. pytest's own stdout/stderr pass through unchanged.
- **Deferred setup warnings**: warnings (missing `python_env`, missing `tt-exalens`) are buffered and flushed on EXIT so they surface last instead of being buried under pytest/triage output.
- **Machine-readable triage on hang**: the dispatch-timeout triage command now also writes a CSV report via `--llm-output-path` (plus `--skip-version-check`), and the path is printed as `SAFE_PYTEST: LLM triage: <path>`.

## Testing

Ran on a Wormhole n150:

| Scenario | Exit | Tail |
|---|---|---|
| Baseline pass | 0 | `SAFE_PYTEST_RESULT: PASS` |
| Real test failure | 1 | `SAFE_PYTEST_RESULT: FAIL (exit code: 1)` |
| No tests collected | 3 | `SAFE_PYTEST_ERROR: No tests collected` |
| `--profile` pass | 0 | `SAFE_PYTEST: PROFILER CSV: …` + `SAFE_PYTEST_RESULT: PASS` |

Also verified: the `--profile` preflight exits 3 when Tracy deps are absent, and the stale-CSV guard reports a warning (not a stale path) when a profiled run produces no CSV.

## Notes
- In `--profile` mode a failing test is reported PASS because the tracy wrapper masks pytest's exit code — don't use `--profile` for pass/fail scoring (documented in the script header).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mstaletovic/safe-pytest-profiling)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mstaletovic/safe-pytest-profiling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mstaletovic/safe-pytest-profiling)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mstaletovic/safe-pytest-profiling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mstaletovic/safe-pytest-profiling)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mstaletovic/safe-pytest-profiling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mstaletovic/safe-pytest-profiling)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mstaletovic/safe-pytest-profiling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mstaletovic/safe-pytest-profiling)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mstaletovic/safe-pytest-profiling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mstaletovic/safe-pytest-profiling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mstaletovic/safe-pytest-profiling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mstaletovic/safe-pytest-profiling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mstaletovic/safe-pytest-profiling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mstaletovic/safe-pytest-profiling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mstaletovic/safe-pytest-profiling)