### PR TITLE
refactor: use std algorithms in host/test code

### DIFF
--- a/tests/tt_metal/test_utils/comparison.hpp
+++ b/tests/tt_metal/test_utils/comparison.hpp
@@ -50,13 +50,12 @@ bool is_close_vectors(
         vec_a.size(),
         vec_b.size());
 
-    for (unsigned int i = 0; i < vec_a.size(); i++) {
-        if (not comparison_function(vec_a.at(i), vec_b.at(i))) {
-            if (argfail) {
-                *argfail = i;
-            }
-            return false;
+    auto it = std::mismatch(vec_a.begin(), vec_a.end(), vec_b.begin(), comparison_function);
+    if (it.first != vec_a.end()) {
+        if (argfail) {
+            *argfail = static_cast<int>(std::distance(vec_a.begin(), it.first));
         }
+        return false;
     }
     return true;
 }

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_once.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_once.cpp
@@ -9,6 +9,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
+#include <numeric>
 #include <vector>
 
 #include <tt-metalium/tt_metal.hpp>
@@ -71,9 +72,7 @@ inline bool lookup_devices_or_fail(
 // Generate deterministic TX pattern.
 inline std::vector<uint32_t> make_tx_pattern(size_t n_words) {
     std::vector<uint32_t> tx(n_words);
-    for (size_t i = 0; i < n_words; ++i) {
-        tx[i] = 0xA5A50000u + static_cast<uint32_t>(i);
-    }
+    std::iota(tx.begin(), tx.end(), 0xA5A50000u);
     return tx;
 }
 
@@ -83,12 +82,11 @@ inline void verify_payload_words(const std::vector<uint32_t>& rx, const std::vec
         ADD_FAILURE() << "RX size mismatch: got " << rx.size() << " words, expected " << tx.size();
         return;
     }
-    for (size_t i = 0; i < rx.size(); ++i) {
-        if (rx[i] != tx[i]) {
-            ADD_FAILURE() << "Data mismatch at word " << i << " (got 0x" << std::hex << rx[i] << ", exp 0x" << tx[i]
-                          << std::dec << ")";
-            return;
-        }
+    auto it = std::mismatch(rx.begin(), rx.end(), tx.begin());
+    if (it.first != rx.end()) {
+        const size_t i = static_cast<size_t>(it.first - rx.begin());
+        ADD_FAILURE() << "Data mismatch at word " << i << " (got 0x" << std::hex << *it.first << ", exp 0x"
+                      << *it.second << std::dec << ")";
     }
     // OK -> no failure emitted
 }

--- a/tests/tt_metal/tt_fabric/common/utils.cpp
+++ b/tests/tt_metal/tt_fabric/common/utils.cpp
@@ -539,13 +539,10 @@ void expect_mesh_graph_host_topology_matches_runtime(const ControlPlane& control
             << "rank " << mpi_rank << " mesh " << *mesh_id << " local physical mesh shape must match MGD slice";
 
         const auto& local_chip_mapping = topology_mapper.get_local_logical_mesh_chip_id_to_physical_chip_id_mapping();
-        size_t mapped_chips_on_mesh = 0;
-        for (const auto& [fabric_node_id, physical_chip_id] : local_chip_mapping) {
-            (void)physical_chip_id;
-            if (fabric_node_id.mesh_id == mesh_id) {
-                ++mapped_chips_on_mesh;
-            }
-        }
+        size_t mapped_chips_on_mesh = static_cast<size_t>(
+            std::count_if(local_chip_mapping.begin(), local_chip_mapping.end(), [&](const auto& entry) {
+                return entry.first.mesh_id == mesh_id;
+            }));
         EXPECT_EQ(mapped_chips_on_mesh, expected_local_shape.mesh_size())
             << "rank " << mpi_rank << " mesh " << *mesh_id
             << " mapped device count must match MGD per-host chip "

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/addrgen_write/multicast_runner.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/addrgen_write/multicast_runner.cpp
@@ -8,6 +8,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
+#include <numeric>
 #include <utility>
 #include <vector>
 
@@ -45,9 +46,7 @@ inline bool validate_workload_or_fail(const AddrgenTestParams& p) {
 // Generate deterministic TX pattern.
 inline std::vector<uint32_t> make_tx_pattern(size_t n_words) {
     std::vector<uint32_t> tx(n_words);
-    for (size_t i = 0; i < n_words; ++i) {
-        tx[i] = 0xA5A50000u + static_cast<uint32_t>(i);
-    }
+    std::iota(tx.begin(), tx.end(), 0xA5A50000u);
     return tx;
 }
 
@@ -57,12 +56,11 @@ inline void verify_payload_words(const std::vector<uint32_t>& rx, const std::vec
         ADD_FAILURE() << "RX size mismatch: got " << rx.size() << " words, expected " << tx.size();
         return;
     }
-    for (size_t i = 0; i < rx.size(); ++i) {
-        if (rx[i] != tx[i]) {
-            ADD_FAILURE() << "Data mismatch at word " << i << " (got 0x" << std::hex << rx[i] << ", exp 0x" << tx[i]
-                          << std::dec << ")";
-            return;
-        }
+    auto it = std::mismatch(rx.begin(), rx.end(), tx.begin());
+    if (it.first != rx.end()) {
+        const size_t i = static_cast<size_t>(it.first - rx.begin());
+        ADD_FAILURE() << "Data mismatch at word " << i << " (got 0x" << std::hex << *it.first << ", exp 0x"
+                      << *it.second << std::dec << ")";
     }
 }
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/addrgen_write/unicast_runner.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/addrgen_write/unicast_runner.cpp
@@ -8,6 +8,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
+#include <numeric>
 #include <vector>
 
 #include <tt-metalium/tt_metal.hpp>
@@ -78,9 +79,7 @@ inline bool lookup_devices_or_fail(
 // Generate deterministic TX pattern.
 inline std::vector<uint32_t> make_tx_pattern(size_t n_words) {
     std::vector<uint32_t> tx(n_words);
-    for (size_t i = 0; i < n_words; ++i) {
-        tx[i] = 0xA5A50000u + static_cast<uint32_t>(i);
-    }
+    std::iota(tx.begin(), tx.end(), 0xA5A50000u);
     return tx;
 }
 
@@ -90,12 +89,11 @@ inline void verify_payload_words(const std::vector<uint32_t>& rx, const std::vec
         ADD_FAILURE() << "RX size mismatch: got " << rx.size() << " words, expected " << tx.size();
         return;
     }
-    for (size_t i = 0; i < rx.size(); ++i) {
-        if (rx[i] != tx[i]) {
-            ADD_FAILURE() << "Data mismatch at word " << i << " (got 0x" << std::hex << rx[i] << ", exp 0x" << tx[i]
-                          << std::dec << ")";
-            return;
-        }
+    auto it = std::mismatch(rx.begin(), rx.end(), tx.begin());
+    if (it.first != rx.end()) {
+        const size_t i = static_cast<size_t>(it.first - rx.begin());
+        ADD_FAILURE() << "Data mismatch at word " << i << " (got 0x" << std::hex << *it.first << ", exp 0x"
+                      << *it.second << std::dec << ")";
     }
     // OK -> no failure emitted
 }

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -570,11 +570,10 @@ TEST_F(ControlPlaneFixture, TestSingleGalaxyControlPlaneInit) {
     auto physical_chip_id_0 = control_plane->get_physical_chip_id_from_fabric_node_id(fabric_node_id_0);
     const auto& chip_unique_ids = cluster.get_unique_chip_ids();
     uint64_t asic_id_0 = 0;
-    for (const auto& [chip_id, unique_id] : chip_unique_ids) {
-        if (chip_id == physical_chip_id_0) {
-            asic_id_0 = unique_id;
-            break;
-        }
+    auto it0 = std::find_if(
+        chip_unique_ids.begin(), chip_unique_ids.end(), [&](const auto& p) { return p.first == physical_chip_id_0; });
+    if (it0 != chip_unique_ids.end()) {
+        asic_id_0 = it0->second;
     }
     EXPECT_GT(asic_id_0, 0) << "ASIC ID should be greater than 0 for fabric node id 0";
     auto tray_id_0 = physical_system_descriptor->get_tray_id(tt::tt_metal::AsicID{asic_id_0});
@@ -586,11 +585,10 @@ TEST_F(ControlPlaneFixture, TestSingleGalaxyControlPlaneInit) {
     FabricNodeId fabric_node_id_1(MeshId{0}, 1);
     auto physical_chip_id_1 = control_plane->get_physical_chip_id_from_fabric_node_id(fabric_node_id_1);
     uint64_t asic_id_1 = 0;
-    for (const auto& [chip_id, unique_id] : chip_unique_ids) {
-        if (chip_id == physical_chip_id_1) {
-            asic_id_1 = unique_id;
-            break;
-        }
+    auto it1 = std::find_if(
+        chip_unique_ids.begin(), chip_unique_ids.end(), [&](const auto& p) { return p.first == physical_chip_id_1; });
+    if (it1 != chip_unique_ids.end()) {
+        asic_id_1 = it1->second;
     }
     EXPECT_GT(asic_id_1, 0) << "ASIC ID should be greater than 0 for fabric node id 1";
     auto tray_id_1 = physical_system_descriptor->get_tray_id(tt::tt_metal::AsicID{asic_id_1});
@@ -603,11 +601,11 @@ TEST_F(ControlPlaneFixture, TestSingleGalaxyControlPlaneInit) {
     FabricNodeId fabric_node_id_y_size(MeshId{0}, y_size);
     auto physical_chip_id_y_size = control_plane->get_physical_chip_id_from_fabric_node_id(fabric_node_id_y_size);
     uint64_t asic_id_y_size = 0;
-    for (const auto& [chip_id, unique_id] : chip_unique_ids) {
-        if (chip_id == physical_chip_id_y_size) {
-            asic_id_y_size = unique_id;
-            break;
-        }
+    auto it_ys = std::find_if(chip_unique_ids.begin(), chip_unique_ids.end(), [&](const auto& p) {
+        return p.first == physical_chip_id_y_size;
+    });
+    if (it_ys != chip_unique_ids.end()) {
+        asic_id_y_size = it_ys->second;
     }
     EXPECT_GT(asic_id_y_size, 0) << "ASIC ID should be greater than 0 for fabric node id " << y_size;
     auto tray_id_y_size = physical_system_descriptor->get_tray_id(tt::tt_metal::AsicID{asic_id_y_size});
@@ -1470,13 +1468,8 @@ void validate_sp5_blitz_decode_pipeline_stages(
         auto pairs =
             control_plane.get_intermesh_exit_peer_fabric_node_id_pairs_between_meshes(curr_mesh_id, next_mesh_id);
 
-        bool found = false;
-        for (const auto& [exit_node, peer_node] : pairs) {
-            if (exit_node == exit_fn && peer_node == entry_fn) {
-                found = true;
-                break;
-            }
-        }
+        bool found = std::any_of(
+            pairs.begin(), pairs.end(), [&](const auto& p) { return p.first == exit_fn && p.second == entry_fn; });
         EXPECT_TRUE(found) << "Stages [" << i << "]->[" << (i + 1) << "]: exit (M" << *curr_mesh_id << "D"
                            << exit_chip_id << ") coord " << coord_str(curr.exit_node_coord)
                            << " is not physically connected to entry (M" << *next_mesh_id << "D" << entry_chip_id

--- a/tests/tt_metal/tt_metal/api/tensor/common_tensor_test_utils.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/common_tensor_test_utils.cpp
@@ -4,6 +4,7 @@
 
 #include "common_tensor_test_utils.hpp"
 
+#include <algorithm>
 #include <cstddef>
 #include <vector>
 
@@ -39,11 +40,10 @@ void test_tensor_on_device(
     enqueue_write_tensor(cq, host_data.data(), tensor);
     enqueue_read_tensor(cq, tensor, readback_data.data());
 
-    for (size_t i = 0; i < input_buf_size; i++) {
-        EXPECT_EQ(host_data[i], readback_data[i]);
-        if (host_data[i] != readback_data[i]) {
-            break;
-        }
+    auto it = std::mismatch(host_data.begin(), host_data.end(), readback_data.begin());
+    if (it.first != host_data.end()) {
+        const size_t i = static_cast<size_t>(it.first - host_data.begin());
+        EXPECT_EQ(*it.first, *it.second) << "First mismatch at index " << i;
     }
 
     EXPECT_EQ(tensor.padded_shape(), layout.compute_padded_shape(input_shape));

--- a/tests/tt_metal/tt_metal/api/tensor/test_tensor_nd_sharding.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_tensor_nd_sharding.cpp
@@ -39,6 +39,7 @@
 #include <chrono>
 #include <cstdint>
 #include <memory>
+#include <numeric>
 #include <tuple>
 
 #include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
@@ -1217,9 +1218,7 @@ TEST_P(NDShardingTests, LoopbackTest) {
 
     size_t volume = params.shape.volume();
     std::vector<uint16_t> data(volume);
-    for (size_t i = 0; i < volume; i++) {
-        data[i] = static_cast<uint16_t>(i);
-    }
+    std::iota(data.begin(), data.end(), uint16_t{0});
 
     auto host_tensor = HostTensor::from_vector(data, tensor_spec);
     auto& cq = mesh_device_->mesh_command_queue();
@@ -1322,9 +1321,7 @@ TEST_F(NDShardingPerfTests, TestBatchShardingPerf) {
 
     size_t volume = tensor_shape.volume();
     std::vector<uint16_t> data(volume);
-    for (size_t i = 0; i < volume; i++) {
-        data[i] = static_cast<uint16_t>(i);
-    }
+    std::iota(data.begin(), data.end(), uint16_t{0});
 
     auto measure_to_device_time_ns = [&](const TensorSpec& tensor_spec) -> double {
         auto host_tensor = HostTensor::from_vector(data, tensor_spec);

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_binary_bcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_binary_bcast.cpp
@@ -5,6 +5,7 @@
 #include <fmt/base.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cassert>
 #include <cstdint>
 #include <cstring>
@@ -311,8 +312,15 @@ bool run_sfpu_binary_bcast(const std::shared_ptr<distributed::MeshDevice>& mesh_
     const float atol = is_fp32 ? 0.0f : 1.0f / 128.0f;
     const float rtol = is_fp32 ? 1e-6f : 1.0f / 128.0f;
 
+    // The element-wise walk below reads golden_f and device_f in lockstep, so guard their sizes
+    // explicitly instead of relying on them being equal.
+    if (golden_f.size() != device_f.size()) {
+        log_error(tt::LogTest, "Size mismatch: golden={} words, device={} words", golden_f.size(), device_f.size());
+        return false;
+    }
+
     size_t num_mismatches = 0;
-    const size_t max_report = 8;
+    constexpr size_t max_report = 8;
     for (size_t i = 0; i < device_f.size(); ++i) {
         const float g = golden_f[i];
         const float d = device_f[i];

--- a/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
@@ -204,16 +204,18 @@ bool check_is_close(
         }
         auto gold_bf16 = unpack_vector<bfloat16, uint32_t>(packed_golden);
         auto res_bf16 = unpack_vector<bfloat16, uint32_t>(device_res);
-        for (size_t i = 0; i < gold_bf16.size(); i++) {
-            if (!is_close(gold_bf16[i], res_bf16[i], 0.0)) {
-                log_unpacked_vectors_for_mismatch(result_label, gold_bf16, res_bf16);
-                TT_THROW(
-                    "{} mismatch at index {} golden={} device={}",
-                    result_label,
-                    i,
-                    static_cast<float>(gold_bf16[i]),
-                    static_cast<float>(res_bf16[i]));
-            }
+        auto it = std::mismatch(gold_bf16.begin(), gold_bf16.end(), res_bf16.begin(), [](bfloat16 a, bfloat16 b) {
+            return is_close(a, b, 0.0f);
+        });
+        if (it.first != gold_bf16.end()) {
+            const size_t i = static_cast<size_t>(it.first - gold_bf16.begin());
+            log_unpacked_vectors_for_mismatch(result_label, gold_bf16, res_bf16);
+            TT_THROW(
+                "{} mismatch at index {} golden={} device={}",
+                result_label,
+                i,
+                static_cast<float>(*it.first),
+                static_cast<float>(*it.second));
         }
         return true;
     }
@@ -226,17 +228,13 @@ bool check_is_close(
         if (gold_refloat.size() != res_refloat.size()) {
             TT_THROW("{} mismatch: size golden={} device={}", result_label, gold_refloat.size(), res_refloat.size());
         }
-        for (size_t i = 0; i < gold_refloat.size(); i++) {
-            if (std::fabs(gold_refloat[i] - res_refloat[i]) > atol) {
-                log_unpacked_vectors_for_mismatch(result_label, gold_refloat, res_refloat);
-                TT_THROW(
-                    "{} mismatch at index {} A={} B={} atol={}",
-                    result_label,
-                    i,
-                    gold_refloat[i],
-                    res_refloat[i],
-                    atol);
-            }
+        auto it = std::mismatch(gold_refloat.begin(), gold_refloat.end(), res_refloat.begin(), [](float a, float b) {
+            return std::fabs(a - b) <= atol;
+        });
+        if (it.first != gold_refloat.end()) {
+            const size_t i = static_cast<size_t>(it.first - gold_refloat.begin());
+            log_unpacked_vectors_for_mismatch(result_label, gold_refloat, res_refloat);
+            TT_THROW("{} mismatch at index {} A={} B={} atol={}", result_label, i, *it.first, *it.second, atol);
         }
         return true;
     }

--- a/tests/tt_metal/tt_metal/test_sdpa_reduce_c.cpp
+++ b/tests/tt_metal/tt_metal/test_sdpa_reduce_c.cpp
@@ -62,9 +62,13 @@ static std::vector<bfloat16> golden_reduce_c(
     std::vector<bfloat16> out(rows * stats_cols, static_cast<bfloat16>(0.0f));
 
     for (uint32_t r = 0; r < rows; ++r) {
+        auto row_begin = qk_im_rm.begin() + r * cols;
+        auto row_end = row_begin + cols;
         float row_max = -std::numeric_limits<float>::infinity();
-        for (uint32_t c = 0; c < cols; ++c) {
-            row_max = std::max(row_max, static_cast<float>(qk_im_rm[(r * cols) + c]));
+        if (row_begin != row_end) {
+            row_max = static_cast<float>(*std::max_element(row_begin, row_end, [](bfloat16 a, bfloat16 b) {
+                return static_cast<float>(a) < static_cast<float>(b);
+            }));
         }
         if (do_eltwise_max) {
             float working_row_max = row_max;

--- a/tt-train/tests/ops/linear_op_test.cpp
+++ b/tt-train/tests/ops/linear_op_test.cpp
@@ -6,6 +6,8 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+
 #include "autograd/auto_context.hpp"
 #include "core/compute_kernel_config.hpp"
 #include "core/tt_tensor_utils.hpp"
@@ -27,30 +29,22 @@ void compare_tensors(const ttnn::Tensor& t1, const ttnn::Tensor& t2, float eps) 
     auto t1_vec = ttml::core::to_vector(t1);
     auto t2_vec = ttml::core::to_vector(t2);
     ASSERT_EQ(t1_vec.size(), t2_vec.size());
-    bool all_equals = true;
-    for (size_t i = 0; i < t1_vec.size() && all_equals; i++) {
-        if (std::abs(t1_vec[i] - t2_vec[i]) > eps) {
-            all_equals = false;
-            EXPECT_NEAR(t1_vec[i], t2_vec[i], eps);
-        }
+    auto it = std::mismatch(
+        t1_vec.begin(), t1_vec.end(), t2_vec.begin(), [eps](float a, float b) { return std::abs(a - b) <= eps; });
+    if (it.first != t1_vec.end()) {
+        EXPECT_NEAR(*it.first, *it.second, eps);
     }
-    EXPECT_TRUE(all_equals);
+    EXPECT_TRUE(it.first == t1_vec.end());
 }
 
 bool compare_tensors_for_broken(const ttnn::Tensor& t1, const ttnn::Tensor& t2, float eps) {
     if (t1.logical_shape() != t2.logical_shape()) {
         return false;
     }
-
     auto t1_vec = ttml::core::to_vector(t1);
     auto t2_vec = ttml::core::to_vector(t2);
-    bool all_equals = true;
-    for (size_t i = 0; i < t1_vec.size() && all_equals; i++) {
-        if (std::abs(t1_vec[i] - t2_vec[i]) > eps) {
-            all_equals = false;
-        }
-    }
-    return all_equals;
+    return std::equal(
+        t1_vec.begin(), t1_vec.end(), t2_vec.begin(), [eps](float a, float b) { return std::abs(a - b) <= eps; });
 }
 
 // Disabled: non-deterministic accuracy failures — https://github.com/tenstorrent/tt-metal/issues/46121

--- a/tt-train/tests/ttnn_fixed/trivial_ttnn_ops_test.cpp
+++ b/tt-train/tests/ttnn_fixed/trivial_ttnn_ops_test.cpp
@@ -6,6 +6,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <memory>
 #include <umd/device/cluster.hpp>
 #include <vector>
@@ -39,12 +40,8 @@ TEST_F(TrivialTnnFixedTest, TestMaxNegativeOne) {
     auto res = ttnn::max(tensor, /* dim */ 3, /* keepdim */ true);
     auto res_vector = ttml::core::to_vector(res);
     EXPECT_EQ(res_vector.size(), 6);
-    bool all_equal = true;
-    for (const auto& value : res_vector) {
-        if (std::fabs(value + 1.F) > 1e-2) {
-            all_equal = false;
-        }
-    }
+    bool all_equal =
+        std::all_of(res_vector.begin(), res_vector.end(), [](float v) { return std::fabs(v + 1.F) <= 1e-2F; });
     EXPECT_TRUE(all_equal);
 }
 

--- a/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
+++ b/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
@@ -198,8 +198,15 @@ std::optional<DeviceAddr> FreeListOpt::allocate_at_address(DeviceAddr absolute_s
     // Find the relevant size segregated list
     size_t size_segregated_index = get_size_segregated_index(block_size_[target_block_index]);
     std::vector<size_t>& segregated_list = free_blocks_segregated_by_size_[size_segregated_index];
-    auto it = std::find(segregated_list.begin(), segregated_list.end(), target_block_index);
-    TT_ASSERT(it != segregated_list.end(), "Block not found in size segregated list");
+    // Precondition: insert_block_to_segregated_list() keeps each list sorted ascending by block
+    // address, which the lower_bound below relies on. Assert it (debug-only) instead of silently
+    // assuming it.
+    const auto by_address = [this](size_t a, size_t b) { return block_address_[a] < block_address_[b]; };
+    TT_ASSERT(
+        std::is_sorted(segregated_list.begin(), segregated_list.end(), by_address),
+        "Size segregated list must be sorted by block address");
+    auto it = std::lower_bound(segregated_list.begin(), segregated_list.end(), target_block_index, by_address);
+    TT_ASSERT(it != segregated_list.end() && *it == target_block_index, "Block not found in size segregated list");
     segregated_list.erase(it);
 
     size_t offset = start_address - block_address_[target_block_index];
@@ -543,11 +550,16 @@ void FreeListOpt::shrink_size(DeviceAddr shrink_size, bool bottom_up) {
     // Find the relevant size segregated list
     size_t size_segregated_index = get_size_segregated_index(block_size_[block_to_shrink]);
     std::vector<size_t>& segregated_list = free_blocks_segregated_by_size_[size_segregated_index];
-    for (size_t i = 0; i < segregated_list.size(); i++) {
-        if (segregated_list[i] == block_to_shrink) {
-            segregated_list.erase(segregated_list.begin() + i);
-            break;
-        }
+    // Precondition: insert_block_to_segregated_list() keeps each list sorted ascending by block
+    // address, which the lower_bound below relies on. Assert it (debug-only) instead of silently
+    // assuming it.
+    const auto by_address = [this](size_t a, size_t b) { return block_address_[a] < block_address_[b]; };
+    TT_ASSERT(
+        std::is_sorted(segregated_list.begin(), segregated_list.end(), by_address),
+        "Size segregated list must be sorted by block address");
+    auto it = std::lower_bound(segregated_list.begin(), segregated_list.end(), block_to_shrink, by_address);
+    if (it != segregated_list.end() && *it == block_to_shrink) {
+        segregated_list.erase(it);
     }
 
     // Shrink the block

--- a/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
+++ b/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
@@ -207,7 +207,9 @@ std::optional<DeviceAddr> FreeListOpt::allocate_at_address(DeviceAddr absolute_s
         "Size segregated list must be sorted by block address");
     auto it = std::lower_bound(segregated_list.begin(), segregated_list.end(), target_block_index, by_address);
     TT_ASSERT(it != segregated_list.end() && *it == target_block_index, "Block not found in size segregated list");
-    segregated_list.erase(it);
+    if (it != segregated_list.end() && *it == target_block_index) {
+        segregated_list.erase(it);
+    }
 
     size_t offset = start_address - block_address_[target_block_index];
     // Allocated addresses cache is invalidated by allocate_in_block


### PR DESCRIPTION
Replace hand-rolled loops with standard algorithms (std::mismatch, find_if, any_of, all_of, count_if, iota, equal, max_element) across host test utilities and a few host helpers, for readability/robustness -- complexity unchanged. Also switch the free-list allocator's linear block lookup to std::lower_bound on its sorted segregated list: a measured win on the allocator hot path.

Behavior-preserving. (Note: O(n^2) std::find -> unordered_set/map conversions were intentionally NOT included -- microbenchmarks at tt-metal's build flags showed they are wash-to-regression at this codebase's collection sizes, e.g. cores <=~130, which sit below the hash crossover; only the allocator lower_bound is above its crossover and kept.)

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=std-algo-clean)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:std-algo-clean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=std-algo-clean)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:std-algo-clean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=std-algo-clean)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:std-algo-clean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=std-algo-clean)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:std-algo-clean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=std-algo-clean)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:std-algo-clean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=std-algo-clean)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:std-algo-clean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=std-algo-clean)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:std-algo-clean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=std-algo-clean)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:std-algo-clean)