### PR TITLE
[Bug fix] Fix decode_forward crash for row-sharded models (GPT-OSS) under vLLM async scheduling

### DIFF
--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1284,6 +1284,21 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 # The host position itself may lag the device by one step under
                 # async scheduling, so accept both.
                 host_pos = start_pos[i].reshape(-1).to(torch.int64)
+                # The device token/position buffers are read from a single device
+                # shard (get_device_tensors(...)[0]). That holds the full per-chunk
+                # batch only when the decode inputs are replicated across the mesh
+                # (e.g. Llama-3.1-8B, which this async-ahead keep was designed for).
+                # Models that shard the decode batch across mesh devices
+                # (users_row_sharded, e.g. GPT-OSS) expose only B/num_shards entries
+                # on shard 0, so dev_toks/dev_pos are shorter than the full host
+                # chunk. Reconstructing the full batch needs the model's mesh layout,
+                # which the shared generator doesn't have; rather than crash on the
+                # mismatched comparison, fall back to the host-provided tokens and
+                # positions for this chunk (the pre-fix behaviour).
+                if dev_pos.shape[0] != host_pos.shape[0] or dev_toks.shape[0] != tok_chunk.reshape(-1).shape[0]:
+                    new_tokens.append(tok_chunk)
+                    new_start_pos.append(start_pos[i])
+                    continue
                 use_dev = (dev_pos == host_pos) | (dev_pos == host_pos + 1)
                 prefilled = getattr(self, "_slots_prefilled_since_decode", None)
                 if prefilled:


### PR DESCRIPTION
## Ticket

Fixes [tenstorrent/tt-inference-server#4366](https://github.com/tenstorrent/tt-inference-server/issues/4366) — `[gpt-oss-120B WH Galaxy] - RuntimeError: The size of tensor a (32) must match the size of tensor b (128)`.

Observed in the tt-shield release pipeline (e.g. [this run](https://github.com/tenstorrent/tt-shield/actions/runs/28076785299/job/83282594501)).

## Bug

Under vLLM async scheduling with data-parallel batch concatenation, GPT-OSS (`GptOssForCausalLM`, a `HybridAttentionForCausalLM`) crashes the `EngineCore` during decode:

```
File ".../models/tt_transformers/tt/generator.py", line 1287, in decode_forward
    use_dev = (dev_pos == host_pos) | (dev_pos == host_pos + 1)
RuntimeError: The size of tensor a (32) must match the size of tensor b (128) at non-singleton dimension 0
```

The crash kills the engine and takes down all downstream evals/benchmarks in the pipeline. It was introduced by #47359 (commit `20252ff`, "Fix Llama-3.1-8B eval accuracy under vLLM async scheduling") — the failing line did not exist before that change, and both `stable` and `main` currently carry it unmodified.

## Root cause

#47359 added an "async-ahead device-token keep" block to `Generator.decode_forward` that, on reset / mode-switch steps, reads the device's authoritative token and position out of the decode trace input buffers:

```python
dev_toks = ttnn.to_torch(ttnn.get_device_tensors(trace_in[0])[0]).reshape(-1)[: tok_chunk.shape[0]] ...
dev_pos  = ttnn.to_torch(ttnn.get_device_tensors(trace_in[1])[0]).reshape(-1)[: tok_chunk.shape[0]] ...
host_pos = start_pos[i].reshape(-1).to(torch.int64)
use_dev  = (dev_pos == host_pos) | (dev_pos == host_pos + 1)
```

`ttnn.get_device_tensors(...)[0]` returns only the **first device shard**. This is correct for Llama-3.1-8B, whose decode inputs are **replicated** across the mesh (`ReplicateTensorToMesh`), so shard 0 holds the full per-chunk batch.

GPT-OSS shards the decode batch across the mesh. In `models/demos/gpt_oss/tt/model.py:prepare_decode_inputs_host`, when `users_row_sharded` is set:

```python
mesh_mapper = ttnn.ShardTensor2dMesh(self.mesh_device, dims=(0, None), mesh_shape=self.mesh_device.shape)
tokens         = ttnn.from_torch(tokens.squeeze(), ..., mesh_mapper=mesh_mapper)
current_pos_tt = ttnn.from_torch(current_pos,     ..., mesh_mapper=mesh_mapper)
```

`dims=(0, None)` shards dim-0 (the batch) across mesh rows, so shard 0 holds only `B / num_rows` entries. With the merged DP batch `B = 128` and `self.data_parallel == 1`:

- `dev_pos`  = first shard of the row-sharded `current_pos` → **32**
- `host_pos` = `start_pos[0].reshape(-1)` (full batch)      → **128**
- `(dev_pos == host_pos)` → `RuntimeError: size of tensor a (32) must match tensor b (128)`

i.e. the exact `32` vs `128` magnitudes in the log (32 = one row-shard of the 128-wide merged batch). The optimization simply never accounted for batch-sharded (`users_row_sharded`) layouts; GPT-OSS passed CI before #47359 because this block did not exist.

## Fix

Make the device-token-keep block resilient to layouts where a single device shard does not hold the full host chunk. When the device-derived `dev_pos` / `dev_toks` lengths don't match the host chunk, fall back to the host-provided tokens/positions for that chunk — exactly the behaviour that existed before #47359:

```python
host_pos = start_pos[i].reshape(-1).to(torch.int64)
if dev_pos.shape[0] != host_pos.shape[0] or dev_toks.shape[0] != tok_chunk.reshape(-1).shape[0]:
    new_tokens.append(tok_chunk)
    new_start_pos.append(start_pos[i])
    continue
use_dev = (dev_pos == host_pos) | (dev_pos == host_pos + 1)
```

- Removes the crash for `users_row_sharded` models (GPT-OSS).
- No regression: row-sharded models revert to their pre-#47359 decode path (which passed CI).
- The Llama-3.1-8B accuracy fix is untouched — for replicated layouts the lengths match, the guard is false, and the original logic runs.

Properly *keeping* the async-ahead device token for row-sharded models would require reconstructing the full batch from all mesh shards (model-layout-aware), which the shared generator can't do generically; that is left as a follow-up.

## Test plan

- [ ] tt-shield GPT-OSS-120B WH Galaxy release pipeline: https://github.com/tenstorrent/tt-shield/actions/runs/28162919012
- [ ] vllm nightly: https://github.com/tenstorrent/tt-metal/actions/runs/28176646742


Made with [Cursor](https://cursor.com)
