### PR TITLE
sparse_sdpa_msa: add native GQA support for MSA prefill

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -482,6 +482,7 @@ Transformer
    ttnn.transformer.scaled_dot_product_attention
    ttnn.transformer.scaled_dot_product_attention_decode
    ttnn.transformer.sparse_sdpa
+   ttnn.transformer.sparse_sdpa_msa
    ttnn.transformer.split_query_key_value_and_split_heads
    ttnn.transformer.windowed_scaled_dot_product_attention
    ttnn.experimental.indexer_score

--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -61,6 +61,7 @@ blackhole:
   # (THCON_SEC1_REG1, the fp8/LF8 SEC1 config) is still unimplemented even in latest ttsim, hit on a data-format
   # reconfig after an fp8 program. The skip stays for (2); remove once a ttsim release with both lands in CI.
   - tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py
+  - tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa_msa.py
 
   # Likely OOM killer related failures -- probably need to run these tests serially
   - tests/ttnn/unit_tests/base_functionality/test_reshape.py::test_reshape_oob

--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa.py
@@ -1,0 +1,573 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""sparse_sdpa_msa (MSA block-sparse prefill) nightly coverage, Blackhole.
+
+Causal behavior is encoded by the block ids in `indices`; the op has no token-level causal mask.
+`make_msa_inputs(causal=...)` only changes the selected blocks.
+
+This file carries the broader shape, dtype, cache, production-sampled, and determinism coverage. The smaller
+post-commit smoke lives in tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa_msa.py.
+"""
+
+import pytest
+import torch
+
+import ttnn
+
+from models.common.utility_functions import run_for_blackhole
+from tests.ttnn.unit_tests.operations.sdpa.sparse_sdpa_msa_test_utils import (
+    BLK_KV,
+    SENTINEL,
+    sparse_attention_ref_msa,
+    sparse_attention_ref_msa_sampled_tokens,
+    dense_grouped_kv_attention,
+    make_msa_inputs,
+    run_op_msa_composed,
+    run_op_msa_native,
+    pcc,
+)
+
+
+# CPU reference checks.
+
+
+@pytest.mark.parametrize("H,n_kv", [(16, 1), (32, 1)])
+@pytest.mark.parametrize("S", [8, 33])
+@pytest.mark.parametrize("nblk", [4, 8])
+def test_golden_all_blocks_selected_equals_dense(H, n_kv, S, nblk):
+    """Sparse attention with every block selected should match dense attention."""
+    d = 128
+    T = nblk * BLK_KV
+    q, k, v, indices = make_msa_inputs(H, n_kv, S, T, topk=nblk, d=d, causal=False, seed=1)
+    scale = d**-0.5
+    ref = sparse_attention_ref_msa(q, k, v, indices, scale)
+    dense = dense_grouped_kv_attention(q, k, v, scale)
+    assert pcc(ref, dense) > 0.99999, f"sparse(all)=dense mismatch, pcc={pcc(ref, dense)}"
+
+
+def test_golden_sentinel_tail_is_truncation():
+    """A sentinel (-1) tail must contribute nothing: golden with k valid blocks + sentinels == golden with
+    exactly those k blocks (no sentinel slots)."""
+    d, H, n_kv, S, nblk = 128, 16, 1, 6, 8
+    T = nblk * BLK_KV
+    scale = d**-0.5
+    gen = torch.Generator().manual_seed(3)
+    q = torch.randn(1, H, S, d, generator=gen)
+    k = torch.randn(1, n_kv, T, d, generator=gen)
+    v = torch.randn(1, n_kv, T, d, generator=gen)
+    chosen = torch.tensor([1, 3, 5], dtype=torch.int32)
+    full = torch.full((1, n_kv, S, 6), SENTINEL, dtype=torch.int32)
+    tight = torch.empty((1, n_kv, S, 3), dtype=torch.int32)
+    for s in range(S):
+        full[0, 0, s, :3] = chosen
+        tight[0, 0, s] = chosen
+    out_pad = sparse_attention_ref_msa(q, k, v, full, scale)
+    out_tight = sparse_attention_ref_msa(q, k, v, tight, scale)
+    assert pcc(out_pad, out_tight) > 0.99999
+
+
+def test_golden_all_masked_row_is_zero_not_nan():
+    """Reference-only behavior: all sentinels yield 0, but the device op requires at least one valid block."""
+    d, H, n_kv, S, nblk = 128, 16, 1, 4, 8
+    T = nblk * BLK_KV
+    gen = torch.Generator().manual_seed(4)
+    q = torch.randn(1, H, S, d, generator=gen)
+    k = torch.randn(1, n_kv, T, d, generator=gen)
+    v = torch.randn(1, n_kv, T, d, generator=gen)
+    indices = torch.full((1, n_kv, S, 4), SENTINEL, dtype=torch.int32)  # nothing selected anywhere
+    out = sparse_attention_ref_msa(q, k, v, indices, d**-0.5)
+    assert torch.isfinite(out).all(), "all-masked row produced NaN/Inf"
+    assert torch.count_nonzero(out) == 0, "all-masked row should be exactly zero"
+
+
+# Op registration smoke.
+
+
+def test_op_is_registered():
+    assert hasattr(ttnn.transformer, "sparse_sdpa_msa"), "ttnn.transformer.sparse_sdpa_msa not registered"
+
+
+pytestmark = pytest.mark.use_module_device
+
+
+# Native device tests: separate K/V, block ids in `indices`. topk=16 keeps index rows DRAM-aligned.
+
+
+@run_for_blackhole()
+@pytest.mark.parametrize("H", [16, 32])
+@pytest.mark.parametrize("S", [8, 33])
+@pytest.mark.parametrize("topk,nblk", [(16, 16), (16, 32)])
+def test_msa_native_pcc_random_selection(device, H, S, topk, nblk):
+    d = 128
+    T = nblk * BLK_KV
+    q, k, v, indices = make_msa_inputs(H, 1, S, T, topk, d, causal=False, seed=1)
+    gold = sparse_attention_ref_msa(q, k, v, indices, d**-0.5)
+    out = run_op_msa_native(q, k, v, indices, device)
+    p = pcc(out, gold)
+    assert p > 0.99, f"native random-selection PCC {p}"
+
+
+@run_for_blackhole()
+@pytest.mark.parametrize("H", [16, 32])
+@pytest.mark.parametrize("topk,nblk", [(16, 16), (16, 32)])
+def test_msa_native_pcc_causal_selection(device, H, topk, nblk):
+    """Causal block selection is encoded in `indices`; the op should match the reference."""
+    d, S = 128, 200
+    T = nblk * BLK_KV
+    q, k, v, indices = make_msa_inputs(H, 1, S, T, topk, d, causal=True, seed=2)
+    gold = sparse_attention_ref_msa(q, k, v, indices, d**-0.5)
+    out = run_op_msa_native(q, k, v, indices, device)
+    p = pcc(out, gold)
+    assert p > 0.99, f"native causal-selection PCC {p}"
+
+
+@run_for_blackhole()
+def test_msa_native_multi_token_per_core(device):
+    """Covers per-core loops with multiple query tokens per active core."""
+    d, H, S, topk, nblk = 128, 16, 300, 16, 32
+    T = nblk * BLK_KV
+    q, k, v, indices = make_msa_inputs(H, 1, S, T, topk, d, causal=False, seed=7)
+    gold = sparse_attention_ref_msa(q, k, v, indices, d**-0.5)
+    out = run_op_msa_native(q, k, v, indices, device)
+    p = pcc(out, gold)
+    assert p > 0.99, f"multi-token/core PCC {p}"
+
+
+@run_for_blackhole()
+def test_msa_native_prod_shape_sampled_accuracy(device):
+    """Accuracy check for the production-shape run used by the perf smoke."""
+    d, H, S, T, topk = 128, 16, 640, 56320, 16
+    q, k, v, indices = make_msa_inputs(H, 1, S, T, topk, d, causal=False, seed=7)
+    sample_tokens = [0, 1, 127, 128, 319, 639]
+    gold = sparse_attention_ref_msa_sampled_tokens(q, k, v, indices, d**-0.5, sample_tokens)
+    out = run_op_msa_native(q, k, v, indices, device, kv_dtype=ttnn.bfloat8_b)
+    out_sample = out[:, :, sample_tokens, :]
+    p = pcc(out_sample, gold)
+    assert p > 0.99, f"prod-shape sampled PCC {p}"
+
+
+@run_for_blackhole()
+@pytest.mark.parametrize("H,n_kv", [(32, 2), (64, 4), (64, 2)])
+def test_msa_native_gqa_pcc_random_selection(device, H, n_kv):
+    """Native GQA: each KV group serves H/n_kv query heads and owns its own block-id rows."""
+    d, S, topk, nblk = 128, 33, 16, 16
+    T = nblk * BLK_KV
+    q, k, v, indices = make_msa_inputs(H, n_kv, S, T, topk, d, causal=False, seed=17 + n_kv)
+    gold = sparse_attention_ref_msa(q, k, v, indices, d**-0.5)
+    out = run_op_msa_native(q, k, v, indices, device, kv_dtype=ttnn.bfloat8_b)
+    p = pcc(out, gold)
+    assert p > 0.99, f"native GQA random-selection PCC {p}"
+
+
+@run_for_blackhole()
+def test_msa_native_gqa_group_isolation(device):
+    """Distinct constant V per KV group catches accidentally reusing group 0 K/V or indices for every group."""
+    d, H, n_kv, S, topk, nblk = 128, 64, 4, 16, 16, 16
+    T = nblk * BLK_KV
+    q, k, _, indices = make_msa_inputs(H, n_kv, S, T, topk, d, causal=False, seed=23)
+    v = torch.empty(1, n_kv, T, d)
+    for g in range(n_kv):
+        v[:, g].fill_(float(g + 1))
+    gold = sparse_attention_ref_msa(q, k, v, indices, d**-0.5)
+    out = run_op_msa_native(q, k, v, indices, device)
+    assert torch.max(torch.abs(out.float() - gold.float())).item() < 0.1
+
+
+@run_for_blackhole()
+def test_msa_native_prod_shape_gqa_sampled_accuracy(device):
+    """Single-chip MiniMax3-style GQA shape: four KV groups, each with 16 query heads."""
+    d, H, n_kv, S, T, topk = 128, 64, 4, 640, 56320, 16
+    q, k, v, indices = make_msa_inputs(H, n_kv, S, T, topk, d, causal=False, seed=7)
+    sample_tokens = [0, 1, 127, 128, 319, 639]
+    gold = sparse_attention_ref_msa_sampled_tokens(q, k, v, indices, d**-0.5, sample_tokens)
+    out = run_op_msa_native(q, k, v, indices, device, kv_dtype=ttnn.bfloat8_b)
+    out_sample = out[:, :, sample_tokens, :]
+    p = pcc(out_sample, gold)
+    assert p > 0.99, f"prod-shape GQA sampled PCC {p}"
+
+
+@run_for_blackhole()
+def test_msa_native_pcc_sentinel_tail(device):
+    """Rows with < topk valid blocks (sentinel tail) still match the golden."""
+    d, H, S, topk, nblk = 128, 16, 12, 16, 32
+    T = nblk * BLK_KV
+    q, k, v, indices = make_msa_inputs(H, 1, S, T, topk, d, causal=False, seed=5)
+    indices[0, 0, 0, 3:] = SENTINEL  # 3 valid blocks
+    indices[0, 0, 1, 2:] = SENTINEL  # 2 valid blocks
+    gold = sparse_attention_ref_msa(q, k, v, indices, d**-0.5)
+    out = run_op_msa_native(q, k, v, indices, device)
+    p = pcc(out, gold)
+    assert p > 0.99, f"native sentinel-tail PCC {p}"
+
+
+@run_for_blackhole()
+@pytest.mark.parametrize("H", [16, 32])
+@pytest.mark.parametrize("topk,nblk", [(16, 16), (16, 32)])
+def test_msa_native_pcc_bfp8_cache(device, H, topk, nblk):
+    """K/V bfp8 cache should stay within PCC tolerance against the bf16 reference."""
+    d, S = 128, 64
+    T = nblk * BLK_KV
+    for causal in (False, True):
+        q, k, v, indices = make_msa_inputs(H, 1, S, T, topk, d, causal=causal, seed=7)
+        gold = sparse_attention_ref_msa(q, k, v, indices, d**-0.5)
+        out = run_op_msa_native(q, k, v, indices, device, kv_dtype=ttnn.bfloat8_b)
+        p = pcc(out, gold)
+        assert p > 0.99, f"native bfp8 cache PCC {p} (causal={causal})"
+
+
+# Q dtype coverage. Python tests bf16 and fp8 q; fp16 is not exposed as a host dtype here.
+
+
+@run_for_blackhole()
+@pytest.mark.parametrize("q_dtype", [ttnn.bfloat16, ttnn.fp8_e4m3])
+def test_msa_native_q_dtype(device, q_dtype):
+    """Covers bf16 and fp8 q; fp8 uses a lower PCC threshold for quantization loss."""
+    d, H, S, topk, nblk = 128, 32, 33, 16, 16
+    T = nblk * BLK_KV
+    q, k, v, indices = make_msa_inputs(H, 1, S, T, topk, d, causal=False, seed=11)
+    gold = sparse_attention_ref_msa(q, k, v, indices, d**-0.5)
+    out = run_op_msa_native(q, k, v, indices, device, kv_dtype=ttnn.bfloat8_b, q_dtype=q_dtype)
+    p = pcc(out, gold)
+    thresh = 0.99 if q_dtype == ttnn.bfloat16 else 0.985
+    assert p > thresh, f"q_dtype={q_dtype} PCC {p} (threshold {thresh})"
+
+
+@run_for_blackhole()
+def test_msa_native_output_dtype_matches_q_and_distinct_programs(device):
+    """Output dtype follows q, and q dtype is part of the program hash."""
+    d, H, S, topk, nblk = 128, 32, 16, 16, 16
+    T = nblk * BLK_KV
+    q, k, v, indices = make_msa_inputs(H, 1, S, T, topk, d, causal=False, seed=12)
+    scale = d**-0.5
+
+    def call(q_dtype):
+        mc = ttnn.DRAM_MEMORY_CONFIG
+        tt_q = ttnn.from_torch(
+            q.to(torch.float32), dtype=q_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=mc
+        )
+        tt_k = ttnn.from_torch(
+            k.to(torch.bfloat16), dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device, memory_config=mc
+        )
+        tt_v = ttnn.from_torch(
+            v.to(torch.bfloat16), dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device, memory_config=mc
+        )
+        tt_i = ttnn.from_torch(
+            indices.to(torch.int32), dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=mc
+        )
+        return ttnn.transformer.sparse_sdpa_msa(tt_q, tt_k, tt_v, tt_i, scale=scale).dtype
+
+    device.clear_program_cache()
+    assert call(ttnn.bfloat16) == ttnn.bfloat16, "bf16 q must yield bf16 output"
+    n1 = device.num_program_cache_entries()
+    assert call(ttnn.fp8_e4m3) == ttnn.fp8_e4m3, "fp8 q must yield fp8 output"
+    n2 = device.num_program_cache_entries()
+    assert n2 > n1, "bf16-q and fp8-q must build distinct programs"
+
+
+@run_for_blackhole()
+def test_msa_native_v_dim_distinct_programs_and_correct(device):
+    """Different v_dim values must build distinct programs and match the reference."""
+    d, H, S, topk, nblk = 128, 32, 16, 16, 16
+    T = nblk * BLK_KV
+    scale = d**-0.5
+    gen = torch.Generator().manual_seed(13)
+    q = torch.randn(1, H, S, d, generator=gen)
+    k = torch.randn(1, 1, T, d, generator=gen)
+    indices = torch.full((1, 1, S, topk), SENTINEL, dtype=torch.int32)
+    for s in range(S):
+        indices[0, 0, s] = torch.randperm(nblk, generator=gen)[:topk].sort().values.to(torch.int32)
+    mc = ttnn.DRAM_MEMORY_CONFIG
+
+    def call(v_dim):
+        v = torch.randn(1, 1, T, v_dim, generator=gen)
+        gold = sparse_attention_ref_msa(q, k, v, indices, scale)  # [1, H, S, v_dim]
+        tt_q = ttnn.from_torch(
+            q.to(torch.bfloat16), dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=mc
+        )
+        tt_k = ttnn.from_torch(
+            k.to(torch.bfloat16), dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device, memory_config=mc
+        )
+        tt_v = ttnn.from_torch(
+            v.to(torch.bfloat16), dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device, memory_config=mc
+        )
+        tt_i = ttnn.from_torch(
+            indices.to(torch.int32), dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=mc
+        )
+        out = ttnn.to_torch(ttnn.transformer.sparse_sdpa_msa(tt_q, tt_k, tt_v, tt_i, scale=scale))
+        return out, gold
+
+    device.clear_program_cache()
+    o1, g1 = call(128)
+    n1 = device.num_program_cache_entries()
+    assert pcc(o1, g1) > 0.99, f"v_dim=128 PCC {pcc(o1, g1)}"
+    o2, g2 = call(256)  # same q/k/indices/dtypes, only v_dim differs
+    n2 = device.num_program_cache_entries()
+    assert pcc(o2, g2) > 0.99, f"v_dim=256 PCC {pcc(o2, g2)}"
+    assert n2 > n1, "different v_dim must build distinct programs"
+
+
+# Composition baseline: map MSA onto DSA sparse_sdpa for n_kv=1.
+
+
+@run_for_blackhole()
+@pytest.mark.parametrize("H", [16, 32])
+@pytest.mark.parametrize("topk,nblk", [(4, 8), (8, 8)])
+def test_msa_composed_pcc(device, H, topk, nblk):
+    d, S = 128, 33
+    T = nblk * BLK_KV
+    q, k, v, indices = make_msa_inputs(H, 1, S, T, topk, d, causal=False, seed=1)
+    gold = sparse_attention_ref_msa(q, k, v, indices, d**-0.5)
+    out = run_op_msa_composed(q, k, v, indices, device)
+    p = pcc(out, gold)
+    assert p > 0.99, f"composed PCC {p}"
+
+
+# Tensor-feature coverage: runtime T, persistent/indexed/sharded K/V, cache-hit validation, and hash keys.
+
+_D = 128  # head dim (== v_dim here)
+
+
+def _rm(t, device, dtype):
+    return ttnn.from_torch(
+        t, dtype=dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+
+def _tile(t, device, dtype=ttnn.bfloat16, mem=ttnn.DRAM_MEMORY_CONFIG):
+    return ttnn.from_torch(t.to(torch.bfloat16), dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=mem)
+
+
+def _nd_sharded_dram_config(device, rows_per_shard, width):
+    """One DRAM shard per bank, round-robin; each [1,1,rows_per_shard,width] slot is one shard."""
+    num_banks = device.dram_grid_size().x
+    cores = [ttnn.CoreRange(ttnn.CoreCoord(b, 0), ttnn.CoreCoord(b, 0)) for b in range(num_banks)]
+    spec = ttnn.NdShardSpec(
+        shard_shape=[1, 1, rows_per_shard, width],
+        grid=ttnn.CoreRangeSet(cores),
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        shard_distribution_strategy=ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
+    )
+    return ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM, nd_shard_spec=spec)
+
+
+def _msa_indexed_inputs(H, S, T, topk, B, *, seed=0):
+    """q [1,H,S,d]; k_full/v_full [B,1,T,d] (B distinct slots); block-id indices [1,1,S,topk] (-1 tail)."""
+    gen = torch.Generator().manual_seed(seed)
+    q = torch.randn(1, H, S, _D, generator=gen)
+    k_full = torch.randn(B, 1, T, _D, generator=gen)
+    v_full = torch.randn(B, 1, T, _D, generator=gen)
+    nblk = T // BLK_KV
+    indices = torch.full((1, 1, S, topk), SENTINEL, dtype=torch.int32)
+    for s in range(S):
+        chosen = torch.randperm(nblk, generator=gen)[:topk].sort().values
+        indices[0, 0, s, : chosen.numel()] = chosen.to(torch.int32)
+    return q, k_full, v_full, indices
+
+
+def _msa_op(device, q, k_tt, v_tt, indices, **kw):
+    out = ttnn.transformer.sparse_sdpa_msa(
+        _rm(q.to(torch.bfloat16), device, ttnn.bfloat16),
+        k_tt,
+        v_tt,
+        _rm(indices.to(torch.int32), device, ttnn.uint32),
+        scale=_D**-0.5,
+        block_size=BLK_KV,
+        **kw,
+    )
+    return ttnn.to_torch(out)
+
+
+# Interleaved K/V length is a runtime shape and should not recompile.
+@run_for_blackhole()
+def test_msa_kv_len_no_recompile(device):
+    H, S, topk = 32, 8, 16
+    device.clear_program_cache()
+    for T in (
+        256,
+        512,
+        1024,
+    ):  # only K/V length differs; sentinel tail keeps topk fixed
+        q, k_full, v_full, indices = _msa_indexed_inputs(H, S, T, topk, 1, seed=T)
+        out = _msa_op(device, q, _tile(k_full, device), _tile(v_full, device), indices)
+        gold = sparse_attention_ref_msa(q, k_full, v_full, indices, _D**-0.5)
+        assert pcc(out, gold) > 0.99, f"T={T}"
+    n = device.num_program_cache_entries()
+    assert n == 1, f"changing K/V length recompiled: {n} entries (expected 1)"
+
+
+@run_for_blackhole()
+def test_msa_gqa_kv_len_no_recompile(device):
+    """GQA K/V group strides depend on runtime T and must be patched on cache hits."""
+    H, n_kv, S, topk = 64, 4, 8, 16
+    device.clear_program_cache()
+    for T in (2048, 4096):
+        q, k_full, v_full, indices = make_msa_inputs(H, n_kv, S, T, topk, _D, causal=False, seed=T)
+        out = _msa_op(device, q, _tile(k_full, device), _tile(v_full, device), indices)
+        gold = sparse_attention_ref_msa(q, k_full, v_full, indices, _D**-0.5)
+        assert pcc(out, gold) > 0.99, f"GQA T={T}"
+    n = device.num_program_cache_entries()
+    assert n == 1, f"changing GQA K/V length recompiled: {n} entries (expected 1)"
+
+
+# Oversized persistent K/V cache: queries attend only a populated prefix.
+@run_for_blackhole()
+def test_msa_oversized_persistent_kv(device):
+    H, S, T_MAX, topk = 32, 8, 1024, 16
+    device.clear_program_cache()
+    gen = torch.Generator().manual_seed(0)
+    k_full = torch.randn(1, 1, T_MAX, _D, generator=gen)
+    v_full = torch.randn(1, 1, T_MAX, _D, generator=gen)
+    k_tt, v_tt = _tile(k_full, device), _tile(v_full, device)  # persistent oversized cache
+    for valid_blocks in (2, 8):  # queries attend only the [0, valid_blocks) populated prefix
+        q = torch.randn(1, H, S, _D, generator=gen)
+        indices = torch.full((1, 1, S, topk), SENTINEL, dtype=torch.int32)
+        for s in range(S):
+            chosen = torch.randperm(valid_blocks, generator=gen)[:topk].sort().values
+            indices[0, 0, s, : chosen.numel()] = chosen.to(torch.int32)  # rest stays sentinel
+        gold = sparse_attention_ref_msa(q, k_full, v_full, indices, _D**-0.5)
+        out = _msa_op(device, q, k_tt, v_tt, indices)
+        assert pcc(out, gold) > 0.99, f"valid_blocks={valid_blocks}"
+    n = device.num_program_cache_entries()
+    assert n == 1, f"oversized reuse recompiled: {n} entries (expected 1)"
+
+
+# Indexed KV cache: cache_batch_idx selects one slot from a shared [B,1,T,d] cache.
+@run_for_blackhole()
+def test_msa_indexed_kv_cache(device):
+    H, S, T, topk, B = 32, 8, 256, 16, 3
+    device.clear_program_cache()
+    q, k_full, v_full, indices = _msa_indexed_inputs(H, S, T, topk, B)
+    k_tt, v_tt = _tile(k_full, device), _tile(v_full, device)  # [B,1,T,d] shared cache
+    for cb in range(B):
+        out = _msa_op(device, q, k_tt, v_tt, indices, cache_batch_idx=cb)
+        gold = sparse_attention_ref_msa(q, k_full[cb : cb + 1], v_full[cb : cb + 1], indices, _D**-0.5)
+        assert pcc(out, gold) > 0.99, f"cache_batch_idx={cb}"
+    n = device.num_program_cache_entries()
+    assert n == 1, f"indexing a different slot recompiled: {n} entries (expected 1)"
+
+
+@run_for_blackhole()
+def test_msa_indexed_kv_cache_first_call_nonzero_slot(device):
+    """The cache-miss build must bake the requested cache_batch_idx, not default to slot 0."""
+    H, S, T, topk, B = 32, 8, 256, 16, 3
+    device.clear_program_cache()
+    q, k_full, v_full, indices = _msa_indexed_inputs(H, S, T, topk, B, seed=31)
+    k_tt, v_tt = _tile(k_full, device), _tile(v_full, device)
+    out = _msa_op(device, q, k_tt, v_tt, indices, cache_batch_idx=1)
+    gold = sparse_attention_ref_msa(q, k_full[1:2], v_full[1:2], indices, _D**-0.5)
+    assert pcc(out, gold) > 0.99, "first indexed call with cache_batch_idx=1 read the wrong slot"
+    assert device.num_program_cache_entries() == 1
+
+
+# Indexed KV cache, ND-sharded across DRAM banks.
+@run_for_blackhole()
+def test_msa_indexed_nd_sharded_kv(device):
+    H, S, T, topk, B = 32, 8, 256, 16, 2
+    device.clear_program_cache()
+    q, k_full, v_full, indices = _msa_indexed_inputs(H, S, T, topk, B)
+    nd_cfg = _nd_sharded_dram_config(device, rows_per_shard=T, width=_D)  # each [1,1,T,d] slot is one shard
+    k_tt = _tile(k_full, device, mem=nd_cfg)
+    v_tt = _tile(v_full, device, mem=nd_cfg)
+    for cb in range(B):
+        out = _msa_op(device, q, k_tt, v_tt, indices, cache_batch_idx=cb)
+        gold = sparse_attention_ref_msa(q, k_full[cb : cb + 1], v_full[cb : cb + 1], indices, _D**-0.5)
+        assert pcc(out, gold) > 0.99, f"nd-sharded cache_batch_idx={cb}"
+
+
+# Changing T changes sharded K/V layout, so it must recompile.
+@run_for_blackhole()
+def test_msa_nd_sharded_kv_len_change(device):
+    H, S, topk = 32, 8, 16
+    device.clear_program_cache()
+    nd_cfg = _nd_sharded_dram_config(device, rows_per_shard=128, width=_D)  # fixed shard shape, independent of T
+    for T in (256, 512):
+        q, k_full, v_full, indices = _msa_indexed_inputs(H, S, T, topk, 1, seed=T)
+        out = _msa_op(device, q, _tile(k_full, device, mem=nd_cfg), _tile(v_full, device, mem=nd_cfg), indices)
+        gold = sparse_attention_ref_msa(q, k_full, v_full, indices, _D**-0.5)
+        assert pcc(out, gold) > 0.99, f"nd-sharded T={T}"
+    assert device.num_program_cache_entries() == 2, "sharded K/V must recompile per shape (2 T -> 2 entries)"
+
+
+# cache_batch_idx is hash-excluded, so out-of-range slots must be rejected on cache hits.
+@run_for_blackhole()
+def test_msa_indexed_oob_rejected_on_hit(device, expect_error):
+    H, S, T, topk, B = 32, 8, 256, 16, 2
+    device.clear_program_cache()
+    q, k_full, v_full, indices = _msa_indexed_inputs(H, S, T, topk, B)
+    k_tt, v_tt = _tile(k_full, device), _tile(v_full, device)
+    _msa_op(device, q, k_tt, v_tt, indices, cache_batch_idx=0)  # miss: builds
+    assert device.num_program_cache_entries() == 1
+    with expect_error(RuntimeError, "cache_batch_idx"):  # cache hit with out-of-range slot
+        _msa_op(device, q, k_tt, v_tt, indices, cache_batch_idx=B)
+
+
+@run_for_blackhole()
+def test_msa_bad_runtime_t_rejected_on_hit(device, expect_error):
+    """Interleaved K/V T is hash-excluded, so a cache-hit T that violates block_size must still be rejected."""
+    H, S, topk = 32, 8, 16
+    device.clear_program_cache()
+    q, k_full, v_full, indices = _msa_indexed_inputs(H, S, 256, topk, 1, seed=37)
+    _msa_op(device, q, _tile(k_full, device), _tile(v_full, device), indices)
+    assert device.num_program_cache_entries() == 1
+
+    bad_T = 320  # tile-aligned, but not divisible by BLK_KV=128
+    q_bad, k_bad, v_bad, indices_bad = _msa_indexed_inputs(H, S, bad_T, topk, 1, seed=bad_T)
+    with expect_error(RuntimeError, "block_size must divide T"):
+        _msa_op(device, q_bad, _tile(k_bad, device), _tile(v_bad, device), indices_bad)
+
+
+# Program hash covers K/V dtype.
+@run_for_blackhole()
+def test_msa_hash_distinct_kv_dtype(device):
+    H, S, T, topk = 32, 8, 256, 16
+    device.clear_program_cache()
+    q, k_full, v_full, indices = _msa_indexed_inputs(H, S, T, topk, 1)
+    gold = sparse_attention_ref_msa(q, k_full, v_full, indices, _D**-0.5)
+    for dt in (ttnn.bfloat16, ttnn.bfloat8_b):
+        out = _msa_op(device, q, _tile(k_full, device, dt), _tile(v_full, device, dt), indices)
+        assert pcc(out, gold) > 0.99, f"dtype={dt}"
+    assert device.num_program_cache_entries() == 2, "bf16 vs bfp8_b K/V must be distinct programs (2 entries)"
+
+
+# Determinism: identical inputs should produce bit-exact outputs across cached runs.
+@run_for_blackhole()
+@pytest.mark.parametrize(
+    "q_dtype,kv_dtype",
+    [(ttnn.bfloat16, ttnn.bfloat16), (ttnn.fp8_e4m3, ttnn.bfloat8_b)],
+    ids=["bf16", "fp8"],
+)
+def test_msa_native_determinism(device, q_dtype, kv_dtype):
+    d, H, S, nblk, topk, iters = 128, 32, 128, 16, 16, 10  # multi-chunk; some cores process two tokens
+    T = nblk * BLK_KV
+    q, k, v, indices = make_msa_inputs(H, 1, S, T, topk, d, causal=False, seed=11)
+    # Upload once; rerun the cached program on the same input bits.
+    mc = ttnn.DRAM_MEMORY_CONFIG
+    tt_q = ttnn.from_torch(
+        q.to(torch.float32), dtype=q_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=mc
+    )
+    tt_k = ttnn.from_torch(
+        k.to(torch.bfloat16), dtype=kv_dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=mc
+    )
+    tt_v = ttnn.from_torch(
+        v.to(torch.bfloat16), dtype=kv_dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=mc
+    )
+    tt_idx = ttnn.from_torch(
+        indices.to(torch.int32), dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=mc
+    )
+
+    def comparable(o):  # eltwise comparison uses TILE bf16
+        if o.dtype == ttnn.fp8_e4m3:
+            o = ttnn.typecast(o, ttnn.bfloat16)
+        return ttnn.to_layout(o, ttnn.TILE_LAYOUT)
+
+    ref, marker = None, None
+    for _ in range(iters):
+        cur = comparable(ttnn.transformer.sparse_sdpa_msa(tt_q, tt_k, tt_v, tt_idx, scale=d**-0.5, block_size=BLK_KV))
+        if ref is None:
+            ref = cur
+        else:
+            m = ttnn.max(ttnn.ne(ref, cur, dtype=ttnn.bfloat16))  # 0 iff bit-exact
+            marker = m if marker is None else ttnn.maximum(marker, m)
+    mismatch = float(ttnn.to_torch(ttnn.from_device(marker)).max())  # one scalar to host, once
+    assert mismatch == 0.0, "sparse_sdpa_msa output is not deterministic across repeated runs"

--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa_perf.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa_perf.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Performance smoke for the production-scale sparse_sdpa_msa shapes.
+
+Profile with:
+    python -m tracy -p -r -v -m pytest tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa_perf.py
+then read "DEVICE KERNEL DURATION [ns]" for SparseSDPAMsaOperation.
+
+Per-chip TP-shard shape: H=16, n_kv=1, S=640, T=56320 (nblk=440), topk=16, d=v_dim=128,
+block_size=128.
+Single-chip native GQA shape: H=64, n_kv=4, S=640, T=56320, topk=16, d=v_dim=128, block_size=128.
+"""
+
+import os
+
+import pytest
+
+import ttnn
+
+from models.common.utility_functions import run_for_blackhole
+from tests.ttnn.unit_tests.operations.sdpa.sparse_sdpa_msa_test_utils import make_msa_inputs, run_op_msa_native
+
+pytestmark = [
+    pytest.mark.skipif(os.getenv("CI") == "true", reason="sparse_sdpa_msa perf smoke is skipped on CI for now"),
+    pytest.mark.use_module_device,
+]
+
+
+@run_for_blackhole()
+@pytest.mark.parametrize("kv_dtype", [ttnn.bfloat8_b, ttnn.bfloat16], ids=["bfp8", "bf16"])
+def test_msa_perf_prod(device, kv_dtype):
+    d, H, S, T, topk = 128, 16, 640, 56320, 16
+    # Non-causal selection keeps topk=16 valid blocks for every query.
+    q, k, v, indices = make_msa_inputs(H, 1, S, T, topk, d, causal=False, seed=7)
+    out = run_op_msa_native(q, k, v, indices, device, kv_dtype=kv_dtype)
+    assert tuple(out.shape) == (1, H, S, d)
+
+
+@run_for_blackhole()
+@pytest.mark.parametrize("kv_dtype", [ttnn.bfloat8_b, ttnn.bfloat16], ids=["bfp8", "bf16"])
+def test_msa_perf_prod_single_chip_gqa(device, kv_dtype):
+    d, H, n_kv, S, T, topk = 128, 64, 4, 640, 56320, 16
+    q, k, v, indices = make_msa_inputs(H, n_kv, S, T, topk, d, causal=False, seed=7)
+    out = run_op_msa_native(q, k, v, indices, device, kv_dtype=kv_dtype)
+    assert tuple(out.shape) == (1, H, S, d)

--- a/tests/ttnn/unit_tests/operations/sdpa/sparse_sdpa_msa_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/sparse_sdpa_msa_test_utils.py
@@ -1,0 +1,213 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for sparse_sdpa_msa tests.
+
+The golden mirrors MiniMax-AI/MSA `sparse_attention_ref` (python/fmha_sm100/cute/test_sparse_atten.py):
+pure ``softmax(q·scale·kᵀ over selected blocks)·v`` with separate K and V. Causality is encoded by `indices`;
+the op has no token-level causal mask. RoPE and QK-norm are applied upstream.
+
+Sentinel for a masked block id is -1 (0xFFFFFFFF as uint32 bits), used as a contiguous tail.
+"""
+
+import torch
+
+import ttnn
+
+SENTINEL = -1  # masked/invalid block id; contiguous tail per (group, query) row
+BLK_KV = 128  # MSA block size in tokens (= 4 tile-rows)
+
+
+def sparse_attention_ref_msa(q, k, v, indices, scale, *, blk_kv=BLK_KV):
+    """MSA block-sparse reference: attend the selected blocks, softmax, then PV with separate V.
+    Causal behavior is encoded by block selection in `indices`; there is no token-level causal mask.
+
+        q       [B, H, S, d]            (post-rope, post-qk-norm — done upstream)
+        k, v    [B, n_kv, T, d]         (separate tensors; T % blk_kv == 0)
+        indices [B, n_kv, S, topk]      block-ids per (group, query); SENTINEL (-1) = masked, contiguous tail
+        -> out  [B, H, S, v_dim]        (v_dim = v.shape[-1])
+
+    Query heads sharing a KV head also share that KV head's block selection. All-masked rows return 0.
+    """
+    B, H, S, d = q.shape
+    n_kv, T = k.shape[1], k.shape[2]
+    topk = indices.shape[-1]
+    G = H // n_kv
+    nblk = T // blk_kv
+    assert T % blk_kv == 0 and H % n_kv == 0
+
+    qf, kf, vf = q.float(), k.float(), v.float()
+    v_dim = vf.shape[-1]
+
+    # block_mask[b, g, s, blk] — set True only for valid (non-sentinel) selected blocks (flat index_put so a
+    # sentinel clamped to block 0 can never overwrite a genuinely-selected block 0).
+    block_mask = torch.zeros(B, n_kv, S, nblk, dtype=torch.bool)
+    valid = indices >= 0
+    idx_safe = torch.where(valid, indices, torch.zeros_like(indices)).long()
+    flat_mask = block_mask.view(-1, nblk)
+    flat_valid = valid.reshape(-1, topk)
+    flat_idx = idx_safe.reshape(-1, topk)
+    row = torch.arange(flat_mask.shape[0]).unsqueeze(1)
+    flat_mask[row.expand_as(flat_idx)[flat_valid], flat_idx[flat_valid]] = True
+
+    token_mask = block_mask.repeat_interleave(blk_kv, dim=3)  # [B,n_kv,S,T]
+    token_mask = token_mask.repeat_interleave(G, dim=1)  # [B,H,S,T]
+    kf = kf.repeat_interleave(G, dim=1)  # [B,H,T,d]
+    vf = vf.repeat_interleave(G, dim=1)  # [B,H,T,d]
+
+    scores = torch.einsum("bhsd,bhtd->bhst", qf * scale, kf)  # [B,H,S,T]
+    scores = scores.masked_fill(~token_mask, float("-inf"))
+
+    row_has_value = token_mask.any(dim=-1, keepdim=True)
+    scores = torch.where(row_has_value, scores, torch.zeros_like(scores))
+    attn = torch.where(row_has_value, scores.softmax(dim=-1, dtype=torch.float32), torch.zeros_like(scores))
+    return torch.einsum("bhst,bhtd->bhsd", attn, vf[..., :v_dim])  # [B,H,S,v_dim]
+
+
+def sparse_attention_ref_msa_sampled_tokens(q, k, v, indices, scale, sample_tokens, *, blk_kv=BLK_KV):
+    """Memory-light MSA reference for selected query tokens."""
+    B, H, _, d = q.shape
+    n_kv, v_dim = k.shape[1], v.shape[-1]
+    assert B == 1 and H % n_kv == 0
+    G = H // n_kv
+
+    qf, kf, vf = q.float(), k.float(), v.float()
+    outs = []
+    for s in sample_tokens:
+        out = torch.zeros(H, v_dim, dtype=torch.float32)
+        for g in range(n_kv):
+            row = indices[0, g, s]
+            valid_blocks = row[row >= 0].long()
+            if valid_blocks.numel() == 0:
+                continue
+            h0, h1 = g * G, (g + 1) * G
+            k_sel = torch.cat([kf[0, g, int(blk) * blk_kv : (int(blk) + 1) * blk_kv] for blk in valid_blocks], dim=0)
+            v_sel = torch.cat([vf[0, g, int(blk) * blk_kv : (int(blk) + 1) * blk_kv] for blk in valid_blocks], dim=0)
+            scores = torch.matmul(qf[0, h0:h1, s] * scale, k_sel.transpose(0, 1))
+            attn = scores.softmax(dim=-1, dtype=torch.float32)
+            out[h0:h1] = torch.matmul(attn, v_sel)
+        outs.append(out)
+    return torch.stack(outs, dim=1).unsqueeze(0)  # [1,H,len(sample_tokens),v_dim]
+
+
+def dense_grouped_kv_attention(q, k, v, scale, *, causal=False, chunk_start_idx=0):
+    """Dense grouped-KV reference used when all blocks are selected."""
+    B, H, S, d = q.shape
+    n_kv, T = k.shape[1], k.shape[2]
+    G = H // n_kv
+    qf = q.float()
+    kf = k.float().repeat_interleave(G, dim=1)
+    vf = v.float().repeat_interleave(G, dim=1)
+    scores = torch.einsum("bhsd,bhtd->bhst", qf * scale, kf)
+    if causal:
+        q_pos = torch.arange(S) + chunk_start_idx
+        kv_pos = torch.arange(T)
+        scores = scores.masked_fill(kv_pos.view(1, 1, 1, T) > q_pos.view(1, 1, S, 1), float("-inf"))
+    attn = scores.softmax(dim=-1, dtype=torch.float32)
+    return torch.einsum("bhst,bhtd->bhsd", attn, vf)
+
+
+def make_msa_inputs(H, n_kv, S, T, topk, d, *, blk_kv=BLK_KV, causal=False, force_local=True, seed=0):
+    """Build q, k, v, and sorted block-id indices with a sentinel tail."""
+    gen = torch.Generator().manual_seed(seed)
+    q = torch.randn(1, H, S, d, generator=gen)
+    k = torch.randn(1, n_kv, T, d, generator=gen)
+    v = torch.randn(1, n_kv, T, d, generator=gen)
+    nblk = T // blk_kv
+    assert topk <= nblk
+    indices = torch.full((1, n_kv, S, topk), SENTINEL, dtype=torch.int32)
+    for g in range(n_kv):
+        for s in range(S):
+            if causal:
+                local = s // blk_kv  # block containing the query (chunk-local)
+                visible = min(local + 1, nblk)
+                if visible <= topk:
+                    chosen = torch.arange(visible)
+                else:
+                    pool = torch.randperm(visible, generator=gen)[:topk]
+                    if force_local and local not in pool.tolist():
+                        pool[-1] = local
+                    chosen = pool.sort().values
+            else:
+                chosen = torch.randperm(nblk, generator=gen)[:topk].sort().values
+            indices[0, g, s, : chosen.numel()] = chosen.to(torch.int32)
+    return q, k, v, indices
+
+
+def pcc(out, golden_t):
+    return torch.corrcoef(torch.stack([out.flatten().float(), golden_t.flatten().float()]))[0, 1].item()
+
+
+# Composition baseline: map separate K/V block selection onto DSA sparse_sdpa for n_kv=1.
+def run_op_msa_composed(q, k, v, indices, device, *, k_chunk_size=128):
+    assert k.shape[1] == 1 and v.shape[1] == 1, "composition baseline is n_kv==1 only"
+    _, H, S, d = q.shape
+    T = k.shape[2]
+    v_dim = v.shape[-1]
+    topk = indices.shape[-1]
+    B = BLK_KV
+    kv_packed = torch.cat([v[0, 0], k[0, 0]], dim=-1).unsqueeze(0).unsqueeze(0)  # [1,1,T,v_dim+d], V first
+    qz = torch.cat([torch.zeros(1, H, S, v_dim), q[0:1]], dim=-1)  # [1,H,S,v_dim+d]
+    Hp = ((H + 31) // 32) * 32
+    if Hp != H:
+        qz = torch.cat([qz, torch.zeros(1, Hp - H, S, v_dim + d)], dim=1)  # dummy heads
+    exp = torch.full((1, 1, S, topk * B), 0xFFFFFFFF, dtype=torch.int64)  # token-ids; sentinel = 0xFFFFFFFF
+    for s in range(S):
+        row = []
+        for j in range(topk):
+            blk = int(indices[0, 0, s, j])
+            if blk < 0:
+                continue
+            for r in range(B):
+                row.append(blk * B + r)  # all B tokens of the selected block
+        if row:
+            exp[0, 0, s, : len(row)] = torch.tensor(row, dtype=torch.int64)
+    scale = d**-0.5
+
+    def dev(t, dt):
+        return ttnn.from_torch(
+            t, dtype=dt, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )
+
+    tt_out = ttnn.transformer.sparse_sdpa(
+        dev(qz.to(torch.bfloat16), ttnn.bfloat16),
+        dev(kv_packed.to(torch.bfloat16), ttnn.bfloat16),
+        dev(exp.to(torch.int32), ttnn.uint32),
+        v_dim,
+        scale=scale,
+        k_chunk_size=k_chunk_size,
+    )
+    return ttnn.to_torch(tt_out)[:, :H]  # drop dummy heads
+
+
+def run_op_msa_native(q, k, v, indices, device, *, block_size=BLK_KV, kv_dtype=ttnn.bfloat16, q_dtype=ttnn.bfloat16):
+    """Run the native op. K/V are pre-tiled; q/indices/output stay row-major."""
+    _, H, _, d = q.shape
+    scale = d**-0.5
+
+    def dev_rm(t, dt):  # row-major: q, indices, output (ttnn quantizes float->fp8 when dt is fp8_e4m3)
+        return ttnn.from_torch(
+            t, dtype=dt, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )
+
+    def dev_tile(t, dt):  # pre-tiled K/V cache (block-aligned; bf16 or bfp8_b)
+        return ttnn.from_torch(
+            t.to(torch.bfloat16),
+            dtype=dt,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+    tt_out = ttnn.transformer.sparse_sdpa_msa(
+        dev_rm(q.to(torch.float32), q_dtype),  # float32 host (ttnn requires fp32 source when target is fp8)
+        dev_tile(k, kv_dtype),
+        dev_tile(v, kv_dtype),
+        dev_rm(indices.to(torch.int32), ttnn.uint32),  # -1 sentinel -> 0xFFFFFFFF bit pattern
+        scale=scale,
+        block_size=block_size,
+    )
+    # Output dtype matches q. fp8 can't be to_torch'd directly, so typecast fp8 -> bf16 on device first.
+    if tt_out.dtype == ttnn.fp8_e4m3:
+        tt_out = ttnn.typecast(tt_out, ttnn.bfloat16)
+    return ttnn.to_torch(tt_out)[:, :H]

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa_msa.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa_msa.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""sparse_sdpa_msa (MSA block-sparse prefill) basic post-commit smoke.
+
+This file keeps fast Blackhole coverage for the core contract: CPU reference sanity, registration, native
+n_kv=1 execution, native GQA execution, sentinel masking, q dtype, and GQA runtime-T cache hits. Broader
+shape/cache/determinism coverage lives in:
+tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa.py
+"""
+
+import pytest
+import torch
+
+import ttnn
+
+from models.common.utility_functions import run_for_blackhole
+from tests.ttnn.unit_tests.operations.sdpa.sparse_sdpa_msa_test_utils import (
+    BLK_KV,
+    SENTINEL,
+    dense_grouped_kv_attention,
+    make_msa_inputs,
+    pcc,
+    run_op_msa_native,
+    sparse_attention_ref_msa,
+)
+
+_D = 128
+REFERENCE_PCC = 0.99999  # torch reference vs equivalent torch reference
+DEVICE_PCC = 0.99  # TTNN device output vs torch reference
+FP8_Q_DEVICE_PCC = 0.985
+
+
+# CPU reference checks.
+
+
+@pytest.mark.parametrize("H,n_kv", [(16, 1), (64, 4)], ids=["mha", "gqa"])
+def test_golden_all_blocks_selected_equals_dense(H, n_kv):
+    d, S, nblk = _D, 8, 4
+    T = nblk * BLK_KV
+    q, k, v, indices = make_msa_inputs(H, n_kv, S, T, topk=nblk, d=d, causal=False, seed=1)
+    scale = d**-0.5
+    ref = sparse_attention_ref_msa(q, k, v, indices, scale)
+    dense = dense_grouped_kv_attention(q, k, v, scale)
+    assert pcc(ref, dense) > REFERENCE_PCC, f"sparse(all)=dense mismatch, pcc={pcc(ref, dense)}"
+
+
+def test_golden_sentinel_tail_is_truncation():
+    d, H, n_kv, S, nblk = _D, 16, 1, 6, 8
+    T = nblk * BLK_KV
+    scale = d**-0.5
+    gen = torch.Generator().manual_seed(3)
+    q = torch.randn(1, H, S, d, generator=gen)
+    k = torch.randn(1, n_kv, T, d, generator=gen)
+    v = torch.randn(1, n_kv, T, d, generator=gen)
+    chosen = torch.tensor([1, 3, 5], dtype=torch.int32)
+    full = torch.full((1, n_kv, S, 6), SENTINEL, dtype=torch.int32)
+    tight = torch.empty((1, n_kv, S, 3), dtype=torch.int32)
+    for s in range(S):
+        full[0, 0, s, :3] = chosen
+        tight[0, 0, s] = chosen
+    out_pad = sparse_attention_ref_msa(q, k, v, full, scale)
+    out_tight = sparse_attention_ref_msa(q, k, v, tight, scale)
+    assert pcc(out_pad, out_tight) > REFERENCE_PCC
+
+
+def test_op_is_registered():
+    assert hasattr(ttnn.transformer, "sparse_sdpa_msa"), "ttnn.transformer.sparse_sdpa_msa not registered"
+
+
+pytestmark = pytest.mark.use_module_device
+
+
+@run_for_blackhole()
+def test_msa_native_pcc_random_selection(device):
+    d, H, S, topk, nblk = _D, 16, 8, 16, 16
+    T = nblk * BLK_KV
+    q, k, v, indices = make_msa_inputs(H, 1, S, T, topk, d, causal=False, seed=1)
+    gold = sparse_attention_ref_msa(q, k, v, indices, d**-0.5)
+    out = run_op_msa_native(q, k, v, indices, device)
+    assert pcc(out, gold) > DEVICE_PCC
+
+
+@run_for_blackhole()
+def test_msa_native_gqa_pcc_random_selection(device):
+    d, H, n_kv, S, topk, nblk = _D, 64, 4, 33, 16, 16
+    T = nblk * BLK_KV
+    q, k, v, indices = make_msa_inputs(H, n_kv, S, T, topk, d, causal=False, seed=21)
+    gold = sparse_attention_ref_msa(q, k, v, indices, d**-0.5)
+    out = run_op_msa_native(q, k, v, indices, device, kv_dtype=ttnn.bfloat8_b)
+    assert pcc(out, gold) > DEVICE_PCC
+
+
+@run_for_blackhole()
+def test_msa_native_gqa_group_isolation(device):
+    d, H, n_kv, S, topk, nblk = _D, 64, 4, 16, 16, 16
+    T = nblk * BLK_KV
+    q, k, _, indices = make_msa_inputs(H, n_kv, S, T, topk, d, causal=False, seed=23)
+    v = torch.empty(1, n_kv, T, d)
+    for g in range(n_kv):
+        v[:, g].fill_(float(g + 1))
+    gold = sparse_attention_ref_msa(q, k, v, indices, d**-0.5)
+    out = run_op_msa_native(q, k, v, indices, device)
+    assert torch.max(torch.abs(out.float() - gold.float())).item() < 0.1
+
+
+@run_for_blackhole()
+def test_msa_native_pcc_sentinel_tail(device):
+    d, H, S, topk, nblk = _D, 16, 12, 16, 32
+    T = nblk * BLK_KV
+    q, k, v, indices = make_msa_inputs(H, 1, S, T, topk, d, causal=False, seed=5)
+    indices[0, 0, 0, 3:] = SENTINEL
+    indices[0, 0, 1, 2:] = SENTINEL
+    gold = sparse_attention_ref_msa(q, k, v, indices, d**-0.5)
+    out = run_op_msa_native(q, k, v, indices, device)
+    assert pcc(out, gold) > DEVICE_PCC
+
+
+@run_for_blackhole()
+@pytest.mark.parametrize("q_dtype", [ttnn.bfloat16, ttnn.fp8_e4m3], ids=["q_bf16", "q_fp8"])
+def test_msa_native_q_dtype(device, q_dtype):
+    d, H, S, topk, nblk = _D, 32, 33, 16, 16
+    T = nblk * BLK_KV
+    q, k, v, indices = make_msa_inputs(H, 1, S, T, topk, d, causal=False, seed=11)
+    gold = sparse_attention_ref_msa(q, k, v, indices, d**-0.5)
+    out = run_op_msa_native(q, k, v, indices, device, kv_dtype=ttnn.bfloat8_b, q_dtype=q_dtype)
+    thresh = DEVICE_PCC if q_dtype == ttnn.bfloat16 else FP8_Q_DEVICE_PCC
+    assert pcc(out, gold) > thresh
+
+
+def _rm(t, device, dtype):
+    return ttnn.from_torch(
+        t, dtype=dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+
+def _tile(t, device, dtype=ttnn.bfloat16):
+    return ttnn.from_torch(
+        t.to(torch.bfloat16),
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+def _msa_op(device, q, k_tt, v_tt, indices):
+    out = ttnn.transformer.sparse_sdpa_msa(
+        _rm(q.to(torch.bfloat16), device, ttnn.bfloat16),
+        k_tt,
+        v_tt,
+        _rm(indices.to(torch.int32), device, ttnn.uint32),
+        scale=_D**-0.5,
+        block_size=BLK_KV,
+    )
+    return ttnn.to_torch(out)
+
+
+@run_for_blackhole()
+def test_msa_gqa_kv_len_no_recompile(device):
+    H, n_kv, S, topk = 64, 4, 8, 16
+    device.clear_program_cache()
+    for T in (2048, 4096):
+        q, k_full, v_full, indices = make_msa_inputs(H, n_kv, S, T, topk, _D, causal=False, seed=T)
+        out = _msa_op(device, q, _tile(k_full, device), _tile(v_full, device), indices)
+        gold = sparse_attention_ref_msa(q, k_full, v_full, indices, _D**-0.5)
+        assert pcc(out, gold) > DEVICE_PCC, f"GQA T={T}"
+    n = device.num_program_cache_entries()
+    assert n == 1, f"changing GQA K/V length recompiled: {n} entries (expected 1)"
+
+
+@run_for_blackhole()
+def test_msa_bad_n_kv_rejected_on_hit(device, expect_error):
+    H, S, T, topk = 32, 8, 2048, 16
+    device.clear_program_cache()
+    q, k_full, v_full, indices = make_msa_inputs(H, 1, S, T, topk, _D, causal=False, seed=41)
+    _msa_op(device, q, _tile(k_full, device), _tile(v_full, device), indices)
+    assert device.num_program_cache_entries() == 1
+
+    q_bad, k_bad, v_bad, _ = make_msa_inputs(H, 2, S, T, topk, _D, causal=False, seed=42)
+    with expect_error(RuntimeError, "indices must be"):
+        _msa_op(device, q_bad, _tile(k_bad, device), _tile(v_bad, device), indices)

--- a/ttnn/cpp/ttnn/operations/transformer/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/transformer/CMakeLists.txt
@@ -31,6 +31,7 @@ target_sources(
             concatenate_heads/concatenate_heads.hpp
             sdpa/sdpa.hpp
             sdpa/sparse_sdpa.hpp
+            sdpa/sparse_sdpa_msa.hpp
             sdpa_decode/sdpa_decode.hpp
             sdpa_windowed/sdpa_windowed.hpp
             split_query_key_value_and_split_heads/split_query_key_value_and_split_heads.hpp

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_compute.cpp
@@ -94,7 +94,7 @@ void kernel_main() {
     const uint32_t tok_count = get_arg_val<uint32_t>(1);
 
     compute_kernel_hw_startup(cb_q_rm, cb_q_in);
-    mm_init(cb_q_in, cb_k_in, cb_out_im);  // one-time full matmul init; the no_mop matmuls reinit off this
+    matmul_init(cb_q_in, cb_k_in);  // one-time matmul init; the no_mop matmuls reinit off this
 
     scale_cb.wait_front(1);  // persistent reduce scaler; the streaming reduce assumes it is ready
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_msa_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_msa_compute.cpp
@@ -1,0 +1,268 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// sparse_sdpa_msa compute: online softmax over selected pre-tiled K/V blocks. Each token tilizes Q, streams
+// selected blocks through QK and PV, combines running max/sum/output, then normalizes the final output.
+
+#include <cstdint>
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/tile_move_copy.h"
+// compute_streaming.hpp needs declarations from compute_common.hpp (LightweightMaskContext, reduce helpers,
+// DEST_AUTO_LIMIT); include it first. Only compute_streaming primitives are used.
+#include "compute_common.hpp"
+#include "compute_streaming.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp"
+#include "api/dataflow/circular_buffer.h"  // CircularBuffer: COMPILE_FOR_TRISC-aware CB lifecycle
+#include <tt-metalium/constants.hpp>       // tt::constants::TILE_HEIGHT
+
+// Make in-place packer writes to a held CB visible to the next unpacker read.
+ALWI void pack_to_unpack_sync() {
+    PACK((t6_semaphore_post<p_stall::STALL_PACK>(semaphore::PACK_DONE)));
+    UNPACK((t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE)));
+    UNPACK((t6_semaphore_get<>(semaphore::PACK_DONE)));
+}
+
+ALWI void swap_cb(CircularBuffer& a, CircularBuffer& b) {
+    const CircularBuffer t = a;
+    a = b;
+    b = t;
+}
+
+void kernel_main() {
+    constexpr uint32_t H = get_compile_time_arg_val(0);
+    constexpr uint32_t DHt = get_compile_time_arg_val(1);
+    constexpr uint32_t vDHt = get_compile_time_arg_val(2);
+    constexpr uint32_t Skt = get_compile_time_arg_val(3);
+    constexpr uint32_t scale_fp32 = get_compile_time_arg_val(4);
+
+    // CB ids match the factory's compute compile-arg block.
+    constexpr uint32_t cb_q_rm = get_compile_time_arg_val(5);
+    constexpr uint32_t cb_q_in = get_compile_time_arg_val(6);
+    constexpr uint32_t cb_k_in = get_compile_time_arg_val(7);  // K tiled [Skt, DHt] (reader-filled, pre-tiled)
+    constexpr uint32_t cb_v_in = get_compile_time_arg_val(8);  // V tiled [Skt, vDHt] (reader-filled, pre-tiled)
+    constexpr uint32_t cb_scale = get_compile_time_arg_val(9);
+    constexpr uint32_t cb_qk_im = get_compile_time_arg_val(10);
+    constexpr uint32_t cb_max_a = get_compile_time_arg_val(11);
+    constexpr uint32_t cb_max_b = get_compile_time_arg_val(12);
+    constexpr uint32_t cb_sum_a = get_compile_time_arg_val(13);
+    constexpr uint32_t cb_sum_b = get_compile_time_arg_val(14);
+    constexpr uint32_t cb_out_a = get_compile_time_arg_val(15);
+    constexpr uint32_t cb_out_b = get_compile_time_arg_val(16);
+    constexpr uint32_t cb_corr = get_compile_time_arg_val(17);
+    constexpr uint32_t cb_out_im = get_compile_time_arg_val(18);
+    constexpr uint32_t cb_out_rm = get_compile_time_arg_val(19);
+    constexpr uint32_t cb_ctrl = get_compile_time_arg_val(20);
+    constexpr uint32_t cb_col_identity = get_compile_time_arg_val(21);
+    constexpr uint32_t cb_recip_scratch = get_compile_time_arg_val(22);
+
+    constexpr uint32_t qsb = get_compile_time_arg_val(23);    // query tile-rows per DST group (<= dst_size)
+    constexpr uint32_t Sqt = H / tt::constants::TILE_HEIGHT;  // total query tile-rows (32 heads each)
+    constexpr uint32_t q_groups = Sqt / qsb;                  // DST-bound work runs in this many query-row passes
+    constexpr uint32_t KT_stride = Skt;                       // cb_qk_im physical row width
+    constexpr uint32_t dst_size = compute_kernel_lib::DEST_AUTO_LIMIT;
+    // sub_exp uses the full key width when it fits in DEST, otherwise one key-tile column at a time.
+    constexpr uint32_t exp_sbw = (qsb * Skt <= dst_size) ? Skt : 1;
+
+    // CB wrappers for the fixed (non-ping-pong) buffers' lifecycle verbs.
+    CircularBuffer q_in_cb(cb_q_in), k_in_cb(cb_k_in), v_in_cb(cb_v_in), qk_cb(cb_qk_im), scale_cb(cb_scale),
+        ctrl_cb(cb_ctrl);
+    CircularBuffer corr_cb(cb_corr);
+
+    const uint32_t tok_count = get_arg_val<uint32_t>(1);
+
+    compute_kernel_hw_startup(cb_q_rm, cb_q_in);
+    matmul_init(cb_q_in, cb_k_in);  // one-time matmul init; the no_mop matmuls reinit off this
+
+    scale_cb.wait_front(1);  // persistent reduce scaler; the streaming reduce assumes it is ready
+
+    for (uint32_t tok = 0; tok < tok_count; ++tok) {
+        // tilize Q rows -> [Sqt, DHt]
+        compute_kernel_lib::tilize<DHt, cb_q_rm, cb_q_in>(/*num_blocks=*/Sqt, /*total_input_pages=*/H);
+        // fp8 Q tilize leaves the packer in bfp8 format; restore bf16 before QK writes scores.
+        pack_reconfig_data_format(cb_qk_im);
+
+        // Per-token control from the reader: active full-block count.
+        ctrl_cb.wait_front(1);
+        const uint32_t num_active_chunks = ckernel::read_tile_value(cb_ctrl, /*tile=*/0, /*element_offset=*/0);
+        ctrl_cb.pop_front(1);
+
+        // Flash running state, ping-pong. Reset every token; all buffers start empty.
+        CircularBuffer max_prev(cb_max_a), max_cur(cb_max_b);
+        CircularBuffer sum_prev(cb_sum_a), sum_cur(cb_sum_b);
+        CircularBuffer out_prev(cb_out_a), out_cur(cb_out_b);
+
+        for (uint32_t chunk = 0; chunk < num_active_chunks; ++chunk) {
+            // K/V are already tiled. Set source formats for QK; scores remain bf16.
+            reconfig_data_format(cb_k_in, cb_q_in);
+
+            const bool is_first = (chunk == 0);
+            const bool is_last = (chunk == num_active_chunks - 1);
+
+            // cb_qk_im / sum_cur / out_cur span all Sqt rows; the qg loop fills them band-by-band (sub_exp & PV
+            // pack at absolute row offsets; reduce/corr reserve+push per band).
+            qk_cb.reserve_back(Sqt * KT_stride);
+            sum_cur.reserve_back(Sqt);
+            out_cur.reserve_back(Sqt * vDHt);
+            k_in_cb.wait_front(Skt * DHt);   // K: shared by every query group (QK)
+            v_in_cb.wait_front(Skt * vDHt);  // V: shared by every query group (PV)
+            q_in_cb.wait_front(Sqt * DHt);
+
+            // DST holds qsb query tile-rows; process Sqt rows in q_groups passes (one pass when qsb==Sqt).
+            for (uint32_t qg = 0; qg < q_groups; ++qg) {
+                const uint32_t row_base = qg * qsb;  // first query tile-row of this group
+
+                // Set exp to the softmax scale; salad's correction below re-inits it to unit scale.
+                exp_packthread_tile_init<true, scale_fp32, InputClamping::None>();
+
+                // Phase 1: Q@K^T -> scores and running row max.
+                {
+                    // Use pack width 1 because Q tilize changes packer addrmods; wider packs need extra reinit.
+                    mm_no_mop_init_short(cb_q_in, cb_k_in, /*transpose=*/true, 1, qsb, DHt);
+                    configure_row_pack_width(cb_qk_im, 1);
+                    for (uint32_t kt = 0; kt < Skt; ++kt) {
+                        blocked_matmul_and_pack<true, /*in1_stride=*/1, /*out_num_cols=*/KT_stride>(
+                            cb_q_in,
+                            cb_k_in,
+                            cb_qk_im,
+                            /*in0_index_start=*/row_base * DHt,
+                            /*in1_index_start=*/kt * DHt,
+                            /*row_subblock_idx=*/qg,
+                            /*out_col_offset=*/kt,
+                            /*subblock_w=*/1,
+                            /*subblock_h=*/qsb,
+                            /*inner_dim=*/DHt,
+                            /*matmul_stride=*/DHt,
+                            /*trigger_reduce=*/false,
+                            /*skip_pack_configure=*/true);
+                    }
+                    // Publish the band to UNPACK while holding wr_ptr for in-place sub_exp.
+                    cb_push_back_hold_wr_ptr(cb_qk_im, qsb * KT_stride);
+                }
+
+                {
+                    // Reduce/sub_exp read scores and bf16 scalers.
+                    reconfig_data_format(cb_qk_im, cb_scale);
+                    // running row-max (MAX-only; eltwise-max against prev on chunk>0)
+                    max_cur.reserve_back(qsb);
+                    configure_single_tile_pack(max_cur.get_cb_id());
+                    reduce_c_row_group<cb_qk_im, cb_scale, KT_stride>(
+                        max_cur.get_cb_id(),
+                        max_prev.get_cb_id(),
+                        /*row_group_index=*/qg,
+                        /*do_eltwise_max=*/!is_first,
+                        qsb,
+                        Skt);
+                    max_cur.push_back(qsb);
+
+                    // sub_exp in place: cb_qk_im = exp((cb_qk_im - max)*scale); partial row-sum -> sum_cur (L1-acc).
+                    // Walk key-tile columns in DEST-sized steps.
+                    for (uint32_t kc = 0; kc < Skt; kc += exp_sbw) {
+                        sub_exp_block_bcast_cols<false, scale_fp32>(
+                            cb_qk_im,
+                            max_cur.get_cb_id(),
+                            sum_cur.get_cb_id(),
+                            /*cols_in_row=*/KT_stride,
+                            /*q_subblock=*/qg,
+                            /*global_col_base=*/kc,
+                            /*sbh=*/qsb,
+                            /*sbw=*/exp_sbw);
+                    }
+                    pack_to_unpack_sync();  // sub_exp writes must be visible to V-matmul
+                }
+
+                // Phase 2: probs@V -> current output band.
+                {
+                    qk_cb.wait_front((qg + 1) * qsb * KT_stride);
+                    // PV reads V as srcA and probabilities as srcB.
+                    reconfig_data_format(cb_v_in, cb_qk_im);
+                    mm_no_mop_init_short(cb_qk_im, cb_v_in, /*transpose=*/false, 1, qsb, Skt);
+                    configure_row_pack_width(out_cur.get_cb_id(), 1);
+                    for (uint32_t vd = 0; vd < vDHt; ++vd) {
+                        blocked_matmul_and_pack<false, /*in1_stride=*/vDHt, /*out_num_cols=*/vDHt>(
+                            cb_qk_im,
+                            cb_v_in,
+                            out_cur.get_cb_id(),
+                            /*in0_index_start=*/row_base * Skt,
+                            /*in1_index_start=*/vd,
+                            /*row_subblock_idx=*/qg,
+                            /*out_col_offset=*/vd,
+                            /*subblock_w=*/1,
+                            /*subblock_h=*/qsb,
+                            /*inner_dim=*/Skt,
+                            /*matmul_stride=*/KT_stride,
+                            /*trigger_reduce=*/false,
+                            /*skip_pack_configure=*/true);
+                    }
+                    pack_to_unpack_sync();                // publish held out_cur packs before flash combine
+                    reconfig_data_format_srca(cb_qk_im);  // PV left srcA in cb_v_in's format; restore bf16
+                }
+
+                // ===== SALAD flash combine (skip on the first chunk) =====
+                if (!is_first) {
+                    // correction = exp((prev_max - cur_max) * scale)
+                    exp_packthread_tile_init<EXP_APPROX_MODE>();
+                    corr_cb.reserve_back(qsb);
+                    sub_exp_first_col_blocks<false, scale_fp32>(
+                        max_prev.get_cb_id(), max_cur.get_cb_id(), cb_corr, /*q_subblock=*/qg, qsb);
+                    corr_cb.push_back(qsb);
+                    // Restore default packer geometry before the fused flash correction.
+                    PACK((
+                        llk_pack_init<ckernel::PackMode::Default, false, false, false>(out_cur.get_cb_id(), dst_size)));
+                    pack_reconfig_l1_acc(1);
+                    // out_prev and corr are consumed per group; sum_prev is indexed by group.
+                    salad_correct_fused<qsb, vDHt, dst_size>(
+                        out_prev.get_cb_id(),
+                        sum_prev.get_cb_id(),
+                        cb_corr,
+                        out_cur.get_cb_id(),
+                        sum_cur.get_cb_id(),
+                        /*ob_q_subblock=*/0,
+                        /*sum_q_subblock=*/qg,
+                        /*write_q_subblock=*/qg);
+                    pack_reconfig_l1_acc(0);
+                    corr_cb.pop_front(qsb);
+                    out_prev.pop_front(qsb * vDHt);  // this band's prev.out consumed into cur
+                }
+            }  // query groups
+
+            // prev max/sum consumed into cur (out_prev popped per band above).
+            if (!is_first) {
+                max_prev.pop_front(Sqt);
+                sum_prev.pop_front(Sqt);
+            }
+
+            // Publish cur.sum / cur.out (running state for the next chunk, or the final result).
+            sum_cur.push_back(Sqt);
+            out_cur.push_back(Sqt * vDHt);
+
+            if (is_last) {
+                // Finalize: reciprocal row sum, then out *= 1/sum.
+                normalize_row_streaming<
+                    /*profiling_enabled=*/false,
+                    vDHt,
+                    dst_size,
+                    cb_col_identity,
+                    cb_recip_scratch,
+                    cb_out_im,
+                    scale_fp32>(sum_cur.get_cb_id(), out_cur.get_cb_id(), Sqt);
+                max_cur.pop_front(Sqt);  // running max no longer needed
+            }
+
+            // Release the held cb_qk_im rows + this chunk's K (QK) and V (PV).
+            qk_cb.pop_front(Sqt * KT_stride);
+            k_in_cb.pop_front(Skt * DHt);
+            v_in_cb.pop_front(Skt * vDHt);
+
+            swap_cb(max_prev, max_cur);  // prev <-> cur for the next chunk
+            swap_cb(sum_prev, sum_cur);
+            swap_cb(out_prev, out_cur);
+        }
+
+        q_in_cb.pop_front(Sqt * DHt);  // Q reused across all chunks; drop it so >1 token/core stays clean
+
+        // cb_out_im was written by normalize_row_streaming; untilize -> row-major out for the writer.
+        compute_kernel_lib::untilize<vDHt, cb_out_im, cb_out_rm>(/*num_blocks=*/Sqt);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_msa_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_msa_gather.hpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Per-NoC trid ring for split block-tile gathers. Reader and writer each issue one half of a block's K/V tile
+// reads, capped at K_TRID_RING outstanding transactions per NoC.
+// Include after api/dataflow/dataflow_api.h and experimental_device_api.hpp (the reader/writer already do).
+#pragma once
+
+#include <stdint.h>
+
+namespace sparse_sdpa_msa {
+
+// Per-NoC trid-ring depth. 0 = off (plain burst). Keep <= 16.
+constexpr uint32_t K_TRID_RING = 8;
+// Avoid compile-time division by zero when K_TRID_RING is 0.
+constexpr uint32_t TRID_MOD = (K_TRID_RING == 0) ? 1u : K_TRID_RING;
+
+// One ring per block gather. K and V reads share the ring so their traffic overlaps.
+struct TridRing {
+    Noc& noc;
+    uint32_t issued = 0;
+
+    template <typename Accessor>
+    FORCE_INLINE void read(
+        const Accessor& t, experimental::CB& cb, uint32_t tile_bytes, uint32_t page_id, uint32_t offset_bytes) {
+        if constexpr (K_TRID_RING == 0) {
+            noc.async_read(t, cb, tile_bytes, {.page_id = page_id}, {.offset_bytes = offset_bytes});
+        } else {
+            const uint32_t trid = (issued % TRID_MOD) + 1;
+            if (issued >= K_TRID_RING) {
+                experimental::async_read_barrier_with_trid(noc, trid);  // free this slot before reuse
+            }
+            experimental::set_read_trid(noc, trid);
+            noc.async_read(t, cb, tile_bytes, {.page_id = page_id}, {.offset_bytes = offset_bytes});
+            ++issued;
+        }
+    }
+
+    FORCE_INLINE void drain() {
+        if constexpr (K_TRID_RING == 0) {
+            noc.async_read_barrier();
+        } else {
+            const uint32_t to_drain = (issued < K_TRID_RING) ? issued : K_TRID_RING;
+            for (uint32_t d = 0; d < to_drain; ++d) {
+                experimental::async_read_barrier_with_trid(noc, ((issued - to_drain + d) % TRID_MOD) + 1);
+            }
+            experimental::set_read_trid(noc, 0);  // restore untagged
+            issued = 0;
+        }
+    }
+};
+
+}  // namespace sparse_sdpa_msa

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_msa_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_msa_reader.cpp
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// sparse_sdpa_msa reader: for each query token, read Q rows and selected pre-tiled K/V blocks. Reader and writer
+// split each block gather into upper/lower tile halves. Masking is represented only by sentinel block ids.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
+#include "sparse_sdpa_msa_gather.hpp"  // per-NoC trid-ring (K_TRID_RING knob)
+
+constexpr uint32_t sentinel = 0xFFFFFFFFu;
+
+void kernel_main() {
+    constexpr uint32_t H_logical = get_compile_time_arg_val(0);
+    constexpr uint32_t H = get_compile_time_arg_val(1);
+    constexpr uint32_t S = get_compile_time_arg_val(2);
+    constexpr uint32_t topk = get_compile_time_arg_val(3);
+    constexpr uint32_t n_kv = get_compile_time_arg_val(4);
+    constexpr uint32_t q_row_bytes = get_compile_time_arg_val(5);
+    constexpr uint32_t idx_row_bytes = get_compile_time_arg_val(6);
+    constexpr uint32_t k_tiles_per_block = get_compile_time_arg_val(7);
+    constexpr uint32_t v_tiles_per_block = get_compile_time_arg_val(8);
+    constexpr uint32_t k_half = get_compile_time_arg_val(9);  // writer gathers [0, half)
+    constexpr uint32_t v_half = get_compile_time_arg_val(10);
+
+    // CB ids match the factory's reader compile-arg block.
+    constexpr uint32_t cb_q_rm = get_compile_time_arg_val(11);
+    constexpr uint32_t cb_k_in = get_compile_time_arg_val(12);
+    constexpr uint32_t cb_v_in = get_compile_time_arg_val(13);
+    constexpr uint32_t cb_idx = get_compile_time_arg_val(14);
+    constexpr uint32_t cb_ctrl = get_compile_time_arg_val(15);
+    constexpr uint32_t cb_kreq = get_compile_time_arg_val(16);
+    constexpr uint32_t cb_kack = get_compile_time_arg_val(17);
+
+    constexpr uint32_t k_tile_bytes = get_compile_time_arg_val(18);  // K is tiled: per-tile read size
+    constexpr uint32_t v_tile_bytes = get_compile_time_arg_val(19);  // V is tiled: per-tile read size
+
+    // K/V use RuntimeTensorShape so T can vary without recompilation.
+    constexpr auto q_args = TensorAccessorArgs<20, 0>();
+    constexpr auto k_args =
+        TensorAccessorArgs<q_args.next_compile_time_args_offset(), q_args.next_common_runtime_args_offset()>();
+    constexpr auto v_args =
+        TensorAccessorArgs<k_args.next_compile_time_args_offset(), k_args.next_common_runtime_args_offset()>();
+    constexpr auto idx_args =
+        TensorAccessorArgs<v_args.next_compile_time_args_offset(), v_args.next_common_runtime_args_offset()>();
+
+    const uint32_t q_addr = get_arg_val<uint32_t>(0);
+    const uint32_t k_addr = get_arg_val<uint32_t>(1);
+    const uint32_t v_addr = get_arg_val<uint32_t>(2);
+    const uint32_t idx_addr = get_arg_val<uint32_t>(3);
+    const uint32_t work_start = get_arg_val<uint32_t>(4);
+    const uint32_t work_count = get_arg_val<uint32_t>(5);
+    // Indexed-cache slot offsets; zero when cache_batch_idx is unset.
+    const uint32_t k_batch_tile_offset = get_arg_val<uint32_t>(6);
+    const uint32_t v_batch_tile_offset = get_arg_val<uint32_t>(7);
+    uint32_t k_group_tile_stride = 0;
+    uint32_t v_group_tile_stride = 0;
+    if constexpr (n_kv > 1) {
+        k_group_tile_stride = get_arg_val<uint32_t>(8);
+        v_group_tile_stride = get_arg_val<uint32_t>(9);
+    }
+
+    Noc noc;
+    experimental::CB q_cb(cb_q_rm), k_cb(cb_k_in), v_cb(cb_v_in), idx_cb(cb_idx), ctrl_cb(cb_ctrl);
+    experimental::CB kreq_cb(cb_kreq), kack_cb(cb_kack);
+    const auto q = TensorAccessor(q_args, q_addr);
+    const auto k = TensorAccessor(k_args, k_addr);
+    const auto v = TensorAccessor(v_args, v_addr);
+    const auto idx = TensorAccessor(idx_args, idx_addr);
+
+    // Reader-internal scratch for one token's block-id row (reserved once, reused).
+    idx_cb.reserve_back(1);
+    const uint32_t idx_l1 = idx_cb.get_write_ptr();
+    volatile tt_l1_ptr uint32_t* idx_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(idx_l1);
+
+    uint32_t tok = work_start;
+    uint32_t kv_group = 0;
+    if constexpr (n_kv > 1) {
+        kv_group = work_start / S;
+        tok = work_start - kv_group * S;
+    }
+    for (uint32_t work = 0; work < work_count; ++work) {
+        // Q: logical head rows plus zero-filled padded heads so compute always sees full 32-head tiles.
+        q_cb.reserve_back(H);
+        for (uint32_t h = 0; h < H_logical; ++h) {
+            uint32_t q_head = h;
+            if constexpr (n_kv > 1) {
+                q_head += kv_group * H_logical;
+            }
+            noc.async_read(q, q_cb, q_row_bytes, {.page_id = q_head * S + tok}, {.offset_bytes = h * q_row_bytes});
+        }
+        noc.async_read_barrier();
+        if constexpr (H_logical < H) {
+            noc.async_write_zeros(q_cb, (H - H_logical) * q_row_bytes, {.offset_bytes = H_logical * q_row_bytes});
+            noc.write_zeros_l1_barrier();
+        }
+        q_cb.push_back(H);
+
+        // Block-id row for this token.
+        uint32_t idx_page = tok;
+        if constexpr (n_kv > 1) {
+            idx_page += kv_group * S;
+        }
+        noc.async_read(idx, idx_cb, idx_row_bytes, {.page_id = idx_page}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+
+        // Binary search the first sentinel; valid blocks are a contiguous prefix.
+        uint32_t nv_blocks = topk;
+        {
+            uint32_t lo = 0, hi = topk;
+            while (lo < hi) {
+                const uint32_t mid = (lo + hi) >> 1;
+                if (idx_ptr[mid] == sentinel) {
+                    hi = mid;
+                } else {
+                    lo = mid + 1;
+                }
+            }
+            nv_blocks = lo == 0 ? 1 : lo;  // ASSERT below traps all-sentinel rows.
+        }
+        const uint32_t n_active = nv_blocks;  // each active chunk is one full block
+
+        // Compute sees full selected blocks; no token-level boundary mask is applied.
+        ctrl_cb.reserve_back(1);
+        {
+            volatile tt_l1_ptr uint32_t* cp = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(ctrl_cb.get_write_ptr());
+            cp[0] = n_active;
+        }
+        ctrl_cb.push_back(1);
+
+        for (uint32_t chunk = 0; chunk < n_active; ++chunk) {
+            const uint32_t block_id = idx_ptr[chunk];
+            // Producer contract requires at least one valid block and no sentinels in the active prefix.
+            ASSERT(block_id != sentinel);
+
+            // Reader reserves the whole block; writer fills the lower half, reader fills the upper half.
+            uint32_t k_tile0 = k_batch_tile_offset + block_id * k_tiles_per_block;
+            uint32_t v_tile0 = v_batch_tile_offset + block_id * v_tiles_per_block;
+            if constexpr (n_kv > 1) {
+                k_tile0 += kv_group * k_group_tile_stride;
+                v_tile0 += kv_group * v_group_tile_stride;
+            }
+            k_cb.reserve_back(k_tiles_per_block);
+            v_cb.reserve_back(v_tiles_per_block);
+
+            kreq_cb.reserve_back(1);
+            {
+                volatile tt_l1_ptr uint32_t* rq =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(kreq_cb.get_write_ptr());
+                rq[0] = block_id;
+                rq[1] = (chunk == n_active - 1);  // writer ends its gather phase for the token on the last block
+            }
+            kreq_cb.push_back(1);
+
+            sparse_sdpa_msa::TridRing ring{noc};  // K/V upper halves share one ring.
+            for (uint32_t i = k_half; i < k_tiles_per_block; ++i) {
+                ring.read(k, k_cb, k_tile_bytes, k_tile0 + i, i * k_tile_bytes);
+            }
+            for (uint32_t i = v_half; i < v_tiles_per_block; ++i) {
+                ring.read(v, v_cb, v_tile_bytes, v_tile0 + i, i * v_tile_bytes);
+            }
+            ring.drain();           // this NoC's upper halves landed
+            kack_cb.wait_front(1);  // writer's lower halves landed in the same L1
+            kack_cb.pop_front(1);
+            k_cb.push_back(k_tiles_per_block);
+            v_cb.push_back(v_tiles_per_block);
+        }
+
+        ++tok;
+        if constexpr (n_kv > 1) {
+            if (tok == S) {
+                tok = 0;
+                ++kv_group;
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_msa_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_msa_writer.cpp
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// sparse_sdpa_msa writer: co-gather lower K/V tile halves, write row-major output, and build persistent compute
+// tiles used by softmax normalization.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
+#include "ttnn/cpp/ttnn/kernel/dataflow/generate_bcast_scalar.hpp"  // generate_bcast_col_scalar
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
+#include "sparse_sdpa_msa_gather.hpp"  // per-NoC trid-ring (K_TRID_RING knob)
+
+constexpr uint32_t one_bf16_packed = 0x3F803F80u;  // bf16(1.0) double-packed; generate_bcast_col_scalar uses >>16
+
+void kernel_main() {
+    constexpr uint32_t H_logical = get_compile_time_arg_val(0);
+    constexpr uint32_t S = get_compile_time_arg_val(1);
+    constexpr uint32_t n_kv = get_compile_time_arg_val(2);
+    constexpr uint32_t row_bytes = get_compile_time_arg_val(3);
+    constexpr uint32_t block_tiles = get_compile_time_arg_val(4);
+    constexpr uint32_t k_tiles_per_block = get_compile_time_arg_val(5);
+    constexpr uint32_t v_tiles_per_block = get_compile_time_arg_val(6);
+    constexpr uint32_t k_half = get_compile_time_arg_val(7);
+    constexpr uint32_t v_half = get_compile_time_arg_val(8);
+
+    // CB ids match the factory's writer compile-arg block.
+    constexpr uint32_t cb_out_rm = get_compile_time_arg_val(9);
+    constexpr uint32_t cb_scale = get_compile_time_arg_val(10);
+    constexpr uint32_t cb_col_identity = get_compile_time_arg_val(11);
+    // Writer fills the lower half of each block's K/V tiles into reader-reserved CBs.
+    constexpr uint32_t cb_k_in = get_compile_time_arg_val(12);
+    constexpr uint32_t cb_v_in = get_compile_time_arg_val(13);
+    constexpr uint32_t cb_kreq = get_compile_time_arg_val(14);
+    constexpr uint32_t cb_kack = get_compile_time_arg_val(15);
+    constexpr uint32_t k_tile_bytes = get_compile_time_arg_val(16);
+    constexpr uint32_t v_tile_bytes = get_compile_time_arg_val(17);
+    constexpr auto out_args = TensorAccessorArgs<18, 0>();
+    // K/V use RuntimeTensorShape so T can vary without recompilation.
+    constexpr auto k_args =
+        TensorAccessorArgs<out_args.next_compile_time_args_offset(), out_args.next_common_runtime_args_offset()>();
+    constexpr auto v_args =
+        TensorAccessorArgs<k_args.next_compile_time_args_offset(), k_args.next_common_runtime_args_offset()>();
+
+    const uint32_t out_addr = get_arg_val<uint32_t>(0);
+    const uint32_t work_start = get_arg_val<uint32_t>(1);
+    const uint32_t work_count = get_arg_val<uint32_t>(2);
+    const uint32_t k_addr = get_arg_val<uint32_t>(3);
+    const uint32_t v_addr = get_arg_val<uint32_t>(4);
+    const uint32_t k_batch_tile_offset = get_arg_val<uint32_t>(5);  // cache_batch_idx slot offset (0 if not indexed)
+    const uint32_t v_batch_tile_offset = get_arg_val<uint32_t>(6);
+    uint32_t k_group_tile_stride = 0;
+    uint32_t v_group_tile_stride = 0;
+    if constexpr (n_kv > 1) {
+        k_group_tile_stride = get_arg_val<uint32_t>(7);
+        v_group_tile_stride = get_arg_val<uint32_t>(8);
+    }
+
+    Noc noc;
+    experimental::CB out_cb(cb_out_rm), k_cb(cb_k_in), v_cb(cb_v_in), kreq_cb(cb_kreq), kack_cb(cb_kack);
+    const auto out = TensorAccessor(out_args, out_addr);
+    const auto k = TensorAccessor(k_args, k_addr);
+    const auto v = TensorAccessor(v_args, v_addr);
+
+    // Reduce identity scaler; softmax scale is applied in compute.
+    dataflow_kernel_lib::calculate_and_prepare_reduce_scaler<
+        cb_scale,
+        ckernel::PoolType::MAX,
+        ckernel::ReduceDim::REDUCE_ROW,
+        /*reduce_factor=*/1,
+        /*compute_uses_reduce_tile=*/true>();
+
+    // Col-identity for final row-sum reduction.
+    generate_bcast_col_scalar(experimental::CB(cb_col_identity), one_bf16_packed);
+
+    uint32_t tok = work_start;
+    uint32_t kv_group = 0;
+    if constexpr (n_kv > 1) {
+        kv_group = work_start / S;
+        tok = work_start - kv_group * S;
+    }
+    for (uint32_t work = 0; work < work_count; ++work) {
+        // Co-gather lower K/V tile halves for each selected block, then ack the reader.
+        bool last = false;
+        while (!last) {
+            kreq_cb.wait_front(1);
+            uint32_t block_id;
+            {
+                volatile tt_l1_ptr uint32_t* rq =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(kreq_cb.get_read_ptr());
+                block_id = rq[0];
+                last = rq[1] != 0;
+            }
+            kreq_cb.pop_front(1);
+            uint32_t k_tile0 = k_batch_tile_offset + block_id * k_tiles_per_block;
+            uint32_t v_tile0 = v_batch_tile_offset + block_id * v_tiles_per_block;
+            if constexpr (n_kv > 1) {
+                k_tile0 += kv_group * k_group_tile_stride;
+                v_tile0 += kv_group * v_group_tile_stride;
+            }
+            sparse_sdpa_msa::TridRing ring{noc};  // K/V lower halves share one ring.
+            for (uint32_t i = 0; i < k_half; ++i) {
+                ring.read(k, k_cb, k_tile_bytes, k_tile0 + i, i * k_tile_bytes);
+            }
+            for (uint32_t i = 0; i < v_half; ++i) {
+                ring.read(v, v_cb, v_tile_bytes, v_tile0 + i, i * v_tile_bytes);
+            }
+            ring.drain();
+            kack_cb.reserve_back(1);
+            kack_cb.push_back(1);
+        }
+
+        out_cb.wait_front(block_tiles);  // one untilized [H, v_dim] block
+        for (uint32_t h = 0; h < H_logical; ++h) {
+            // Row h at CB byte offset h*row_bytes maps to output head h within this KV group.
+            uint32_t out_head = h;
+            if constexpr (n_kv > 1) {
+                out_head += kv_group * H_logical;
+            }
+            noc.async_write(out_cb, out, row_bytes, {.offset_bytes = h * row_bytes}, {.page_id = out_head * S + tok});
+        }
+        noc.async_write_barrier();
+        out_cb.pop_front(block_tiles);
+
+        ++tok;
+        if constexpr (n_kv > 1) {
+            if (tok == S) {
+                tok = 0;
+                ++kv_group;
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.cpp
@@ -1,0 +1,299 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operation.hpp"
+#include "ttnn/device.hpp"
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/hal.hpp>
+#include <bit>
+
+namespace ttnn::prim {
+
+namespace {
+// Re-check invariants excluded from the program hash. Interleaved K/V shape fields (T, batch slots, and n_kv)
+// and cache_batch_idx may vary on a cache hit; tensor layout, padding, memory placement, and device must still
+// match kernel assumptions.
+void validate_non_hashed(const SparseSDPAMsaParams& attrs, const SparseSDPAMsaInputs& t) {
+    const auto& q = t.q;
+    const auto& k = t.k;
+    const auto& v = t.v;
+    const auto& idx = t.indices;
+    TT_FATAL(
+        q.device() == k.device() && q.device() == v.device() && q.device() == idx.device(),
+        "sparse_sdpa_msa: all inputs must be on the same device");
+    // q and indices: ROW_MAJOR, DRAM, interleaved, unpadded.
+    for (const Tensor* tp : {&q, &idx}) {
+        TT_FATAL(tp->layout() == Layout::ROW_MAJOR, "sparse_sdpa_msa q/indices must be ROW_MAJOR");
+        TT_FATAL(tp->memory_config().buffer_type() == BufferType::DRAM, "sparse_sdpa_msa q/indices must be in DRAM");
+        TT_FATAL(!tp->memory_config().is_sharded(), "sparse_sdpa_msa q/indices must be interleaved");
+        TT_FATAL(tp->padded_shape() == tp->logical_shape(), "sparse_sdpa_msa q/indices must not be padded");
+    }
+    // K/V are pre-tiled DRAM caches. They may be interleaved or ND-sharded.
+    for (const Tensor* tp : {&k, &v}) {
+        TT_FATAL(tp->layout() == Layout::TILE, "sparse_sdpa_msa k/v must be TILE (pre-tiled cache)");
+        TT_FATAL(tp->memory_config().buffer_type() == BufferType::DRAM, "sparse_sdpa_msa k/v must be in DRAM");
+        TT_FATAL(tp->padded_shape() == tp->logical_shape(), "sparse_sdpa_msa k/v must not be padded");
+    }
+    const auto qs = q.logical_shape();
+    const auto is = idx.logical_shape();
+    TT_FATAL(qs.rank() == 4 && qs[0] == 1, "q must be [1,H,S,d]");
+    const uint32_t H = qs[1];
+    const uint32_t S = qs[2];
+    const uint32_t d = q.logical_shape()[3];
+    const auto ks = k.logical_shape();
+    const auto vs = v.logical_shape();
+    TT_FATAL(ks.rank() == 4 && ks[3] == d, "k must be [B,n_kv,T,d] with d matching q ({})", d);
+    TT_FATAL(
+        vs.rank() == 4 && vs[0] == ks[0] && vs[1] == ks[1] && vs[2] == ks[2],
+        "v must be [B,n_kv,T,v_dim] matching k's B/n_kv/T");
+    // v_dim is compiled into all kernels and included in the program hash.
+    TT_FATAL(
+        vs[3] > 0 && vs[3] % tt::constants::TILE_WIDTH == 0,
+        "v_dim (v last dim) must be a positive multiple of {} (got {})",
+        tt::constants::TILE_WIDTH,
+        vs[3]);
+    TT_FATAL(ks[1] > 0, "n_kv must be > 0");
+    TT_FATAL(ks[2] > 0, "k/v T (cache length) must be > 0");
+    const uint32_t n_kv = ks[1];
+    TT_FATAL(H % n_kv == 0, "sparse_sdpa_msa: H ({}) must be divisible by n_kv ({})", H, n_kv);
+    const uint32_t heads_per_kv = H / n_kv;
+    constexpr uint32_t tile_h = tt::constants::TILE_HEIGHT;
+    // Each KV group computes full 32-head tile rows. 16 heads/group is padded internally for the production
+    // TP-shard and single-chip GQA cases; larger per-group head counts must already be full tiles.
+    TT_FATAL(
+        heads_per_kv == 16 || (heads_per_kv % tile_h == 0 && heads_per_kv >= tile_h),
+        "sparse_sdpa_msa: H / n_kv must be 16 or a multiple of {} (got H {}, n_kv {}, H/n_kv {})",
+        tile_h,
+        H,
+        n_kv,
+        heads_per_kv);
+    TT_FATAL(is.rank() == 4 && is[0] == 1 && is[1] == n_kv && is[2] == S, "indices must be [1,n_kv,S,TOPK]");
+    TT_FATAL(S > 0 && is[3] > 0, "S/TOPK must be > 0");
+    TT_FATAL(
+        attrs.block_size > 0 && ks[2] % attrs.block_size == 0,
+        "block_size must divide T (got block_size {}, T {})",
+        attrs.block_size,
+        ks[2]);
+    const uint32_t B = ks[0];
+    if (attrs.cache_batch_idx.has_value()) {
+        TT_FATAL(
+            attrs.cache_batch_idx.value() < B,
+            "cache_batch_idx ({}) must be < kv batch slots ({})",
+            attrs.cache_batch_idx.value(),
+            B);
+    } else {
+        TT_FATAL(B == 1, "k/v batch must be 1 unless cache_batch_idx is set (got {})", B);
+    }
+}
+}  // namespace
+
+void SparseSDPAMsaOperation::validate_on_program_cache_hit(
+    const SparseSDPAMsaParams& attrs, const SparseSDPAMsaInputs& t) {
+    validate_non_hashed(attrs, t);
+}
+
+void SparseSDPAMsaOperation::validate_on_program_cache_miss(
+    const SparseSDPAMsaParams& attrs, const SparseSDPAMsaInputs& t) {
+    const auto& q = t.q;
+    const auto& k = t.k;
+    const auto& v = t.v;
+    const auto& idx = t.indices;
+
+    TT_FATAL(tt::tt_metal::hal::get_arch() == tt::ARCH::BLACKHOLE, "sparse_sdpa_msa is Blackhole-only");
+
+    // q is bf16 or fp8_e4m3. K/V are tiled bf16 or bfp8_b. Indices are uint32 block ids.
+    const bool q_is_fp8 = (q.dtype() == DataType::FP8_E4M3);
+    TT_FATAL(q.dtype() == DataType::BFLOAT16 || q_is_fp8, "sparse_sdpa_msa: q must be bf16 or fp8_e4m3");
+    TT_FATAL(
+        k.dtype() == DataType::BFLOAT16 || k.dtype() == DataType::BFLOAT8_B,
+        "sparse_sdpa_msa: k must be bf16 or bfp8_b");
+    TT_FATAL(
+        v.dtype() == DataType::BFLOAT16 || v.dtype() == DataType::BFLOAT8_B,
+        "sparse_sdpa_msa: v must be bf16 or bfp8_b");
+    TT_FATAL(idx.dtype() == DataType::UINT32, "indices must be uint32");
+    // fp8 Q tilize requires a 32-bit DEST accumulator.
+    TT_FATAL(
+        !q_is_fp8 || get_fp32_dest_acc_en(attrs.compute_kernel_config),
+        "fp8 q requires fp32_dest_acc_en=true (32-bit DEST for the fp8 tilize)");
+
+    validate_non_hashed(attrs, t);
+
+    const auto qs = q.logical_shape();
+    const auto is = idx.logical_shape();
+    const uint32_t d = qs[3];
+    const uint32_t v_dim = v.logical_shape()[3];
+    const uint32_t TOPK = is[3];
+
+    constexpr uint32_t tile_w = tt::constants::TILE_WIDTH;
+    TT_FATAL(d % tile_w == 0, "d (q/k last dim) must be a multiple of {} (got {})", tile_w, d);
+    // v_dim positivity and tile_w alignment are checked on hits and misses.
+
+    // block_size: one chunk == one block of block_size contiguous token rows; must tile the key axis and divide T.
+    TT_FATAL(
+        attrs.block_size >= tile_w && attrs.block_size % tile_w == 0,
+        "block_size must be a multiple of {} (got {})",
+        tile_w,
+        attrs.block_size);
+    TT_FATAL(attrs.scale > 0.0f, "scale must be > 0");
+
+    // Row-byte alignment for the ROW-MAJOR DMAs (q rows, index rows, output rows). K/V are TILE tensors (the
+    // reader reads whole tiles, which are inherently aligned), so no row-byte check applies to them.
+    const uint32_t dram_align = tt::tt_metal::hal::get_dram_alignment();
+    TT_FATAL((d * q.element_size()) % dram_align == 0, "q row bytes must be {}B aligned", dram_align);
+    TT_FATAL((TOPK * idx.element_size()) % dram_align == 0, "indices row bytes must be {}B aligned", dram_align);
+    TT_FATAL((v_dim * q.element_size()) % dram_align == 0, "output row bytes must be {}B aligned", dram_align);
+}
+
+SparseSDPAMsaOperation::spec_return_value_t SparseSDPAMsaOperation::compute_output_specs(
+    const SparseSDPAMsaParams& /*attrs*/, const SparseSDPAMsaInputs& t) {
+    auto shape = t.q.logical_shape();   // [1, H, S, d]
+    shape[3] = t.v.logical_shape()[3];  // [1, H, S, v_dim]
+    // Output is DRAM-interleaved ROW_MAJOR, with dtype matching q.
+    const tt::tt_metal::MemoryConfig out_mem{
+        tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM};
+    return TensorSpec(
+        shape, tt::tt_metal::TensorLayout(t.q.dtype(), tt::tt_metal::PageConfig(Layout::ROW_MAJOR), out_mem));
+}
+
+SparseSDPAMsaOperation::tensor_return_value_t SparseSDPAMsaOperation::create_output_tensors(
+    const SparseSDPAMsaParams& attrs, const SparseSDPAMsaInputs& t) {
+    return create_device_tensor(compute_output_specs(attrs, t), t.q.device());
+}
+
+ttsl::hash::hash_t SparseSDPAMsaOperation::compute_program_hash(
+    const SparseSDPAMsaParams& attrs, const SparseSDPAMsaInputs& t) {
+    // Hash compile-time choices. Interleaved K/V T and cache_batch_idx are patched at dispatch.
+    // Sharded K/V shapes stay hashed because accessor strides depend on them.
+    return tt::tt_metal::operation::hash_operation<SparseSDPAMsaOperation>(
+        std::bit_cast<uint32_t>(attrs.scale),
+        attrs.block_size,
+        attrs.compute_kernel_config,
+        t.q.logical_shape(),
+        t.q.dtype(),
+        t.k.dtype(),
+        t.k.memory_config(),
+        t.k.memory_config().is_sharded() ? t.k.logical_shape() : tt::tt_metal::Shape{},
+        t.v.dtype(),
+        t.v.memory_config(),
+        t.v.memory_config().is_sharded() ? t.v.logical_shape() : tt::tt_metal::Shape{},
+        t.v.logical_shape()[3],
+        attrs.has_indexed_kv_cache(),
+        t.indices.logical_shape(),
+        t.indices.dtype());
+}
+
+std::vector<tt::tt_metal::DynamicRuntimeArg> SparseSDPAMsaOperation::get_dynamic_runtime_args(
+    const SparseSDPAMsaParams& attrs,
+    const SparseSDPAMsaInputs& t,
+    Tensor& /*output*/,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    const uint32_t n_kv = t.k.logical_shape()[1];
+    // n_kv==1 non-indexed programs use zero K/V tile offsets and do not need per-group strides.
+    if (!attrs.has_indexed_kv_cache() && n_kv == 1) {
+        return {};
+    }
+    // Indexed programs patch per-slot tile offsets on every dispatch. GQA programs also patch per-KV-group strides
+    // because interleaved K/V T is intentionally excluded from the program hash.
+    constexpr uint32_t tw = tt::constants::TILE_WIDTH;
+    constexpr uint32_t th = tt::constants::TILE_HEIGHT;
+    const uint32_t T = t.k.logical_shape()[2];
+    const uint32_t d = t.q.logical_shape()[3];
+    const uint32_t v_dim = t.v.logical_shape()[3];
+    const uint32_t s = attrs.cache_batch_idx.value_or(0);
+    const uint32_t tiles_per_row = T / th;
+    const uint32_t k_group_tile_stride = tiles_per_row * (d / tw);
+    const uint32_t v_group_tile_stride = tiles_per_row * (v_dim / tw);
+    const uint32_t k_batch_tile_offset = s * n_kv * k_group_tile_stride;
+    const uint32_t v_batch_tile_offset = s * n_kv * v_group_tile_stride;
+    const tt::tt_metal::CoreCoord grid = t.q.device()->compute_with_storage_grid_size();
+    const uint32_t num_cores = grid.x * grid.y;
+    std::vector<tt::tt_metal::DynamicRuntimeArg> args;
+    // Reader and writer both gather K/V halves, so patch both kernels.
+    args.reserve((attrs.has_indexed_kv_cache() ? 4 : 0) * num_cores + (n_kv > 1 ? 4 : 0) * num_cores);
+    for (uint32_t i = 0; i < num_cores; ++i) {
+        const tt::tt_metal::CoreCoord core = {i % grid.x, i / grid.x};
+        if (attrs.has_indexed_kv_cache()) {
+            args.push_back(
+                {sparse_sdpa_msa_rt::kReaderKernelIdx,
+                 core,
+                 sparse_sdpa_msa_rt::kReaderKBatchOffsetArg,
+                 k_batch_tile_offset,
+                 /*is_common=*/false});
+            args.push_back(
+                {sparse_sdpa_msa_rt::kReaderKernelIdx,
+                 core,
+                 sparse_sdpa_msa_rt::kReaderVBatchOffsetArg,
+                 v_batch_tile_offset,
+                 /*is_common=*/false});
+            args.push_back(
+                {sparse_sdpa_msa_rt::kWriterKernelIdx,
+                 core,
+                 sparse_sdpa_msa_rt::kWriterKBatchOffsetArg,
+                 k_batch_tile_offset,
+                 /*is_common=*/false});
+            args.push_back(
+                {sparse_sdpa_msa_rt::kWriterKernelIdx,
+                 core,
+                 sparse_sdpa_msa_rt::kWriterVBatchOffsetArg,
+                 v_batch_tile_offset,
+                 /*is_common=*/false});
+        }
+        if (n_kv > 1) {
+            args.push_back(
+                {sparse_sdpa_msa_rt::kReaderKernelIdx,
+                 core,
+                 sparse_sdpa_msa_rt::kReaderKGroupStrideArg,
+                 k_group_tile_stride,
+                 /*is_common=*/false});
+            args.push_back(
+                {sparse_sdpa_msa_rt::kReaderKernelIdx,
+                 core,
+                 sparse_sdpa_msa_rt::kReaderVGroupStrideArg,
+                 v_group_tile_stride,
+                 /*is_common=*/false});
+            args.push_back(
+                {sparse_sdpa_msa_rt::kWriterKernelIdx,
+                 core,
+                 sparse_sdpa_msa_rt::kWriterKGroupStrideArg,
+                 k_group_tile_stride,
+                 /*is_common=*/false});
+            args.push_back(
+                {sparse_sdpa_msa_rt::kWriterKernelIdx,
+                 core,
+                 sparse_sdpa_msa_rt::kWriterVGroupStrideArg,
+                 v_group_tile_stride,
+                 /*is_common=*/false});
+        }
+    }
+    return args;
+}
+
+Tensor sparse_sdpa_msa(
+    const Tensor& q,
+    const Tensor& k,
+    const Tensor& v,
+    const Tensor& indices,
+    float scale,
+    uint32_t block_size,
+    ttnn::DeviceComputeKernelConfig compute_kernel_config,
+    std::optional<uint32_t> cache_batch_idx) {
+    using OperationType = ttnn::prim::SparseSDPAMsaOperation;
+    return ttnn::device_operation::launch<OperationType>(
+        OperationType::operation_attributes_t{
+            .scale = scale,
+            .block_size = block_size,
+            .compute_kernel_config = compute_kernel_config,
+            .cache_batch_idx = cache_batch_idx,
+        },
+        OperationType::tensor_args_t{
+            .q = q,
+            .k = k,
+            .v = v,
+            .indices = indices,
+        });
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.hpp
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation_types.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include <optional>
+#include <variant>
+#include <vector>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/experimental/program_descriptor_patching.hpp>
+#include "ttnn/distributed/types.hpp"
+
+namespace ttnn::prim {
+
+// Runtime-arg slots patched on cache hits for indexed K/V caches and runtime K/V group strides.
+// Keep these in sync with create_descriptor().
+namespace sparse_sdpa_msa_rt {
+inline constexpr uint32_t kReaderKernelIdx = 0;
+inline constexpr uint32_t kWriterKernelIdx = 1;
+// reader args: {q, k, v, idx, work_start, work_count, k_batch_tile_offset, v_batch_tile_offset,
+//               k_group_tile_stride, v_group_tile_stride}
+inline constexpr uint32_t kReaderKBatchOffsetArg = 6;
+inline constexpr uint32_t kReaderVBatchOffsetArg = 7;
+inline constexpr uint32_t kReaderKGroupStrideArg = 8;
+inline constexpr uint32_t kReaderVGroupStrideArg = 9;
+// writer args: {out, work_start, work_count, k, v, k_batch_tile_offset, v_batch_tile_offset,
+//               k_group_tile_stride, v_group_tile_stride}
+inline constexpr uint32_t kWriterKBatchOffsetArg = 5;
+inline constexpr uint32_t kWriterVBatchOffsetArg = 6;
+inline constexpr uint32_t kWriterKGroupStrideArg = 7;
+inline constexpr uint32_t kWriterVGroupStrideArg = 8;
+}  // namespace sparse_sdpa_msa_rt
+
+struct SparseSDPAMsaOperation {
+    using operation_attributes_t = SparseSDPAMsaParams;
+    using tensor_args_t = SparseSDPAMsaInputs;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
+
+    struct SparseSDPAMsaProgramFactory {
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
+            const operation_attributes_t& attrs, const tensor_args_t& t, tensor_return_value_t& output);
+    };
+
+    using program_factory_t = std::variant<SparseSDPAMsaProgramFactory>;
+
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    // Re-checks invariants excluded from the program hash, such as interleaved K/V length and cache_batch_idx.
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+
+    // Patches per-slot K/V tile offsets and runtime K/V group strides on cache hits.
+    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+        const operation_attributes_t& attrs,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& output,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
+};
+
+Tensor sparse_sdpa_msa(
+    const Tensor& q,
+    const Tensor& k,
+    const Tensor& v,
+    const Tensor& indices,
+    float scale,
+    uint32_t block_size,
+    ttnn::DeviceComputeKernelConfig compute_kernel_config,
+    std::optional<uint32_t> cache_batch_idx = std::nullopt);
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation_types.hpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include <optional>
+
+namespace ttnn::prim {
+
+// Primitive for MSA block-sparse prefill. K/V are separate tiled caches; masking comes only from block ids in
+// `indices` plus -1 sentinels. For GQA, each KV group owns H/n_kv query heads.
+struct SparseSDPAMsaParams {
+    float scale = 1.0f;         // compile-time; included in the program hash
+    uint32_t block_size = 128;  // tokens per selected KV block
+    DeviceComputeKernelConfig compute_kernel_config;
+    // Selects one [B,n_kv,T,*] cache slot. The value is patched as runtime K/V tile offsets and is not hashed.
+    std::optional<uint32_t> cache_batch_idx = std::nullopt;
+    bool has_indexed_kv_cache() const { return cache_batch_idx.has_value(); }
+};
+
+struct SparseSDPAMsaInputs {
+    Tensor q;        // [1,H,S,d] bf16|fp8_e4m3 ROW_MAJOR
+    Tensor k;        // [B,n_kv,T,d] TILE bf16|bfp8_b
+    Tensor v;        // [B,n_kv,T,v_dim] TILE bf16|bfp8_b
+    Tensor indices;  // [1,n_kv,S,TOPK] uint32 block ids; 0xFFFFFFFF is the sentinel
+};
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_program_factory.cpp
@@ -1,0 +1,290 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.hpp"
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/circular_buffer_constants.h>  // NUM_CIRCULAR_BUFFERS
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <bit>
+#include <map>
+#include <string>
+
+namespace ttnn::prim {
+
+tt::tt_metal::ProgramDescriptor SparseSDPAMsaOperation::SparseSDPAMsaProgramFactory::create_descriptor(
+    const SparseSDPAMsaParams& attrs, const SparseSDPAMsaInputs& t, Tensor& output) {
+    // Fixed CB ids shared with the kernels. Function scope avoids unity-build collisions with sparse_sdpa.
+    // K/V are separate pre-tiled caches. Reader and writer co-gather each block into shared K/V CBs.
+    enum SparseCB : uint32_t {
+        cb_q_rm = 0,  // Q rows (row-major, reader -> compute tilize)
+        cb_q_in,      // Q tiled [Sqt, DHt]
+        cb_k_in,      // K tiled [Skt, DHt] (reader-filled from the tiled cache; QK within-tile transpose)
+        cb_v_in,      // V tiled [Skt, vDHt] (reader-filled; separate tensor)
+        cb_scale,     // reduce identity scaler (1 tile)
+        cb_qk_im,     // scores [Sqt, Skt]
+        cb_max_a,     // running max ping-pong [Sqt, 1]
+        cb_max_b,
+        cb_sum_a,  // running sum ping-pong [Sqt, 1]
+        cb_sum_b,
+        cb_out_a,  // running out ping-pong [Sqt, vDHt] (single-buffered for L1 accumulation)
+        cb_out_b,
+        cb_corr,           // exp(prev_max - cur_max) correction [Sqt, 1]
+        cb_out_im,         // fixed pre-untilize copy of the final out [Sqt, vDHt]
+        cb_out_rm,         // untilized row-major out (compute -> writer)
+        cb_idx,            // reader-internal: one token's block-id row (uint32)
+        cb_ctrl,           // reader -> compute: active block count per token
+        cb_col_identity,   // ones-in-col0 (writer-built): finalizes the partial row-sum via matmul_reduce
+        cb_recip_scratch,  // 1-tile reciprocal scratch for normalize_row_streaming
+        cb_kreq,           // reader->writer dual-NoC handoff {block_id, is_last} (writer co-gathers the lower half)
+        cb_kack,           // writer->reader ack that its half of the block landed in cb_k_in/cb_v_in
+        cb_count
+    };
+
+    tt::tt_metal::ProgramDescriptor desc;
+
+    const uint32_t H_total = t.q.logical_shape()[1];  // total query heads
+    const uint32_t n_kv = t.k.logical_shape()[1];     // KV groups
+    const uint32_t H_logical = H_total / n_kv;        // query heads per KV group
+    const uint32_t H =
+        ((H_logical + tt::constants::TILE_HEIGHT - 1) / tt::constants::TILE_HEIGHT) * tt::constants::TILE_HEIGHT;
+    const uint32_t S = t.q.logical_shape()[2];
+    const uint32_t topk = t.indices.logical_shape()[3];  // max selected blocks per (group, query)
+    const uint32_t d = t.q.logical_shape()[3];           // head dim (e.g. 128)
+    const uint32_t v_dim = t.v.logical_shape()[3];       // V width (output width)
+    const uint32_t block_size = attrs.block_size;        // tokens per block == k_chunk (one block per chunk)
+
+    const uint32_t DHt = d / tt::constants::TILE_WIDTH;
+    const uint32_t vDHt = v_dim / tt::constants::TILE_WIDTH;
+    const uint32_t k_chunk = block_size;                       // a chunk is exactly one block
+    const uint32_t Skt = k_chunk / tt::constants::TILE_WIDTH;  // tiles per chunk along keys (block_size/32)
+    const uint32_t Sqt = H / tt::constants::TILE_HEIGHT;       // query tile-rows (32 heads each)
+    const uint32_t k_tiles_per_block = Skt * DHt;
+    const uint32_t v_tiles_per_block = Skt * vDHt;
+    const uint32_t k_half = k_tiles_per_block >> 1;
+    const uint32_t v_half = v_tiles_per_block >> 1;
+    const uint32_t scale_packed = std::bit_cast<uint32_t>(attrs.scale);
+
+    // Q is row-major; K/V are tiled and addressed per tile.
+    const uint32_t q_elem_bytes = t.q.element_size();          // 2 (bf16)
+    const uint32_t idx_elem_bytes = t.indices.element_size();  // 4
+    const uint32_t out_elem_bytes = output.element_size();     // 2
+    const uint32_t q_row_bytes = d * q_elem_bytes;
+    const uint32_t idx_row_bytes = topk * idx_elem_bytes;
+    constexpr tt::DataFormat bf = tt::DataFormat::Float16_b;
+    constexpr uint32_t tile_bytes = tt::tile_size(bf);  // 2048 (intermediate/Q/out tiles are bf16)
+    // K/V cache formats drive CB format and tile size.
+    const tt::DataFormat k_df = tt::tt_metal::datatype_to_dataformat_converter(t.k.dtype());
+    const tt::DataFormat v_df = tt::tt_metal::datatype_to_dataformat_converter(t.v.dtype());
+    const uint32_t k_tile_bytes = tt::tile_size(k_df);
+    const uint32_t v_tile_bytes = tt::tile_size(v_df);
+    // Q is read row-major and tiled on chip. fp8 Q uses bfp8_b for cb_q_in and requires fp32 DEST.
+    const tt::DataFormat q_rm_df = tt::tt_metal::datatype_to_dataformat_converter(t.q.dtype());
+    const bool q_is_fp8 = (t.q.dtype() == DataType::FP8_E4M3);
+    const tt::DataFormat q_in_df = q_is_fp8 ? tt::DataFormat::Bfp8_b : q_rm_df;
+    const uint32_t q_in_tile_bytes = tt::tile_size(q_in_df);
+    // Output dtype matches Q.
+    const tt::DataFormat out_df = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    const uint32_t out_tile_bytes = tt::tile_size(out_df);
+
+    auto* device = t.q.device();
+    tt::tt_metal::CoreCoord grid = device->compute_with_storage_grid_size();
+    auto core_grid = tt::tt_metal::CoreRangeSet(tt::tt_metal::CoreRange({0, 0}, {grid.x - 1, grid.y - 1}));
+    const uint32_t num_cores = grid.x * grid.y;
+    const uint32_t total_work = S * n_kv;
+    const uint32_t base_work = total_work / num_cores;
+    const uint32_t extra = total_work % num_cores;
+
+    // ---- CBs (fixed order = SparseCB enum) ----
+    const auto cb = [&](uint32_t page_size, uint32_t num_pages, tt::DataFormat df) {
+        const uint32_t idx = desc.cbs.size();
+        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+            .total_size = page_size * num_pages,
+            .core_ranges = core_grid,
+            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(idx), .data_format = df, .page_size = page_size}}},
+        });
+    };
+    cb(q_row_bytes, H, q_rm_df);              // cb_q_rm : H row-sticks (native Q dtype: bf16/fp8)
+    cb(q_in_tile_bytes, Sqt * DHt, q_in_df);  // cb_q_in : [Sqt,DHt] (bfp8 when Q is fp8, else Q's float format)
+    // Single-buffered: reader reserves one block and writer fills its half into the same L1 region.
+    cb(k_tile_bytes, Skt * DHt, k_df);       // cb_k_in : [Skt,DHt] tiled cache (reader-filled, no tilize)
+    cb(v_tile_bytes, Skt * vDHt, v_df);      // cb_v_in : [Skt,vDHt] tiled cache (reader-filled, no tilize)
+    cb(tile_bytes, 1, bf);                   // cb_scale
+    cb(tile_bytes, Sqt * Skt, bf);           // cb_qk_im : [Sqt,Skt]
+    cb(tile_bytes, Sqt, bf);                 // cb_max_a
+    cb(tile_bytes, Sqt, bf);                 // cb_max_b
+    cb(tile_bytes, Sqt, bf);                 // cb_sum_a
+    cb(tile_bytes, Sqt, bf);                 // cb_sum_b
+    cb(tile_bytes, Sqt * vDHt, bf);          // cb_out_a
+    cb(tile_bytes, Sqt * vDHt, bf);          // cb_out_b
+    cb(tile_bytes, Sqt, bf);                 // cb_corr
+    cb(tile_bytes, Sqt * vDHt, bf);          // cb_out_im (bf16 accumulator, full precision)
+    cb(out_tile_bytes, Sqt * vDHt, out_df);  // cb_out_rm : untilized output in Q's dtype
+    cb(topk * idx_elem_bytes, 1, bf);        // cb_idx : one block-id row
+    cb(16, 2, bf);                           // cb_ctrl : active block count (double-buffered)
+    cb(tile_bytes, 1, bf);                   // cb_col_identity
+    cb(tile_bytes, 1, bf);                   // cb_recip_scratch
+    cb(16, 2, bf);                           // cb_kreq : {block_id, is_last} reader->writer (double-buffered)
+    cb(16, 2, bf);                           // cb_kack : writer->reader ack (double-buffered)
+
+    // ---- compile-time args ----
+    // Reader args: scalars, derived geometry, CB ids, element sizes, then q/k/v/indices accessors.
+    // K/V use RuntimeTensorShape.
+    std::vector<uint32_t> reader_ct = {
+        H_logical, H, S, topk, n_kv, q_row_bytes, idx_row_bytes, k_tiles_per_block, v_tiles_per_block, k_half, v_half};
+    for (uint32_t id : {cb_q_rm, cb_k_in, cb_v_in, cb_idx, cb_ctrl, cb_kreq, cb_kack}) {
+        reader_ct.push_back(id);
+    }
+    reader_ct.push_back(k_tile_bytes);  // K is tiled: per-tile read size
+    reader_ct.push_back(v_tile_bytes);  // V is tiled: per-tile read size
+    std::vector<uint32_t> reader_crt;
+    tt::tt_metal::TensorAccessorArgs(t.q.buffer()).append_to(reader_ct, reader_crt);
+    tt::tt_metal::TensorAccessorArgs(t.k.buffer(), tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(reader_ct, reader_crt);
+    tt::tt_metal::TensorAccessorArgs(t.v.buffer(), tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(reader_ct, reader_crt);
+    tt::tt_metal::TensorAccessorArgs(t.indices.buffer()).append_to(reader_ct, reader_crt);
+
+    // Writer builds persistent compute tiles, co-gathers K/V halves, and drains row-major output.
+    const uint32_t row_bytes = vDHt * tt::constants::TILE_WIDTH * out_elem_bytes;
+    const uint32_t block_tiles = Sqt * vDHt;
+    std::vector<uint32_t> writer_ct = {
+        H_logical,
+        S,
+        n_kv,
+        row_bytes,
+        block_tiles,
+        k_tiles_per_block,
+        v_tiles_per_block,
+        k_half,
+        v_half,
+        cb_out_rm,
+        cb_scale,
+        cb_col_identity};
+    for (uint32_t id : {cb_k_in, cb_v_in, cb_kreq, cb_kack}) {
+        writer_ct.push_back(id);
+    }
+    writer_ct.push_back(k_tile_bytes);
+    writer_ct.push_back(v_tile_bytes);
+    std::vector<uint32_t> writer_crt;
+    tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(writer_ct, writer_crt);
+    tt::tt_metal::TensorAccessorArgs(t.k.buffer(), tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(writer_ct, writer_crt);
+    tt::tt_metal::TensorAccessorArgs(t.v.buffer(), tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(writer_ct, writer_crt);
+
+    std::vector<uint32_t> compute_ct = {
+        H,        DHt,      vDHt,      Skt,       scale_packed, cb_q_rm,         cb_q_in,         cb_k_in,
+        cb_v_in,  cb_scale, cb_qk_im,  cb_max_a,  cb_max_b,     cb_sum_a,        cb_sum_b,        cb_out_a,
+        cb_out_b, cb_corr,  cb_out_im, cb_out_rm, cb_ctrl,      cb_col_identity, cb_recip_scratch};
+
+    // ---- kernels ----
+    const std::string kdir = "ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/";
+    tt::tt_metal::KernelDescriptor reader_desc;
+    reader_desc.kernel_source = kdir + "dataflow/sparse_sdpa_msa_reader.cpp";
+    reader_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = core_grid;
+    reader_desc.compile_time_args = reader_ct;
+    reader_desc.common_runtime_args = reader_crt;
+    reader_desc.config = tt::tt_metal::ReaderConfigDescriptor{};
+
+    tt::tt_metal::KernelDescriptor writer_desc;
+    writer_desc.kernel_source = kdir + "dataflow/sparse_sdpa_msa_writer.cpp";
+    writer_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = core_grid;
+    writer_desc.compile_time_args = writer_ct;
+    writer_desc.common_runtime_args = writer_crt;
+    writer_desc.config = tt::tt_metal::WriterConfigDescriptor{};
+
+    auto [math_fidelity, math_approx, fp32_acc, packer_l1_acc, dst_full_sync] =
+        get_compute_kernel_config_args(tt::tt_metal::hal::get_arch(), attrs.compute_kernel_config);
+    (void)packer_l1_acc;
+
+    // Query sub-blocking: qsb tile rows must fit in DEST.
+    const uint32_t dst_size = fp32_acc ? 4u : 8u;
+    uint32_t qsb = 1;
+    for (uint32_t dd = std::min(Sqt, dst_size); dd >= 1; --dd) {
+        if (Sqt % dd == 0) {
+            qsb = dd;
+            break;
+        }
+    }
+    compute_ct.push_back(qsb);
+
+    tt::tt_metal::KernelDescriptor compute_desc;
+    compute_desc.kernel_source = kdir + "compute/sparse_sdpa_msa_compute.cpp";
+    compute_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = core_grid;
+    compute_desc.compile_time_args = compute_ct;
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    // fp8 Q must unpack into 32-bit DEST before tilize packs to bfp8.
+    if (q_is_fp8) {
+        unpack_to_dest_mode[cb_q_rm] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+    }
+    compute_desc.config = tt::tt_metal::ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_acc,
+        .dst_full_sync_en = dst_full_sync,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+        .math_approx_mode = math_approx};
+    std::map<std::string, std::string> cdefs{
+        {"EXP_APPROX_MODE", std::to_string(static_cast<int>(math_approx))},
+    };
+    compute_desc.defines = tt::tt_metal::KernelDescriptor::Defines(cdefs.begin(), cdefs.end());
+
+    auto* q_buf = t.q.buffer();
+    auto* k_buf = t.k.buffer();
+    auto* v_buf = t.v.buffer();
+    auto* idx_buf = t.indices.buffer();
+    auto* out_buf = output.buffer();
+    const uint32_t cache_batch_idx = attrs.cache_batch_idx.value_or(0);
+    const uint32_t T = t.k.logical_shape()[2];
+    const uint32_t tiles_per_row = T / tt::constants::TILE_HEIGHT;
+    const uint32_t k_group_tile_stride = tiles_per_row * DHt;
+    const uint32_t v_group_tile_stride = tiles_per_row * vDHt;
+    const uint32_t k_batch_tile_offset = cache_batch_idx * n_kv * k_group_tile_stride;
+    const uint32_t v_batch_tile_offset = cache_batch_idx * n_kv * v_group_tile_stride;
+    for (uint32_t i = 0; i < num_cores; ++i) {
+        tt::tt_metal::CoreCoord core = {i % grid.x, i / grid.x};
+        uint32_t work_start = i * base_work + std::min(i, extra);
+        uint32_t work_count = base_work + (i < extra ? 1u : 0u);
+        // Cache slot offsets are patched on hits because cache_batch_idx is not hashed.
+        reader_desc.emplace_runtime_args(
+            core,
+            {q_buf,
+             k_buf,
+             v_buf,
+             idx_buf,
+             work_start,
+             work_count,
+             k_batch_tile_offset,
+             v_batch_tile_offset,
+             k_group_tile_stride,
+             v_group_tile_stride});
+        // Writer args 5/6 are the K/V cache-slot offsets patched on cache hits.
+        writer_desc.emplace_runtime_args(
+            core,
+            {out_buf,
+             work_start,
+             work_count,
+             k_buf,
+             v_buf,
+             k_batch_tile_offset,
+             v_batch_tile_offset,
+             k_group_tile_stride,
+             v_group_tile_stride});
+        compute_desc.emplace_runtime_args(core, {work_start, work_count});
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
+    return desc;
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -16,6 +16,7 @@
 
 #include "sdpa.hpp"
 #include "sparse_sdpa.hpp"
+#include "sparse_sdpa_msa.hpp"
 #include "ttnn-nanobind/bind_function.hpp"
 #include "ttnn/operations/ccl/ccl_host_types.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"
@@ -354,6 +355,46 @@ void bind_sdpa(nb::module_& mod) {
         nb::kw_only(),
         nb::arg("scale") = nb::none(),
         nb::arg("k_chunk_size") = 128,
+        nb::arg("compute_kernel_config") = nb::none(),
+        nb::arg("cache_batch_idx") = nb::none());
+
+    ttnn::bind_function<"sparse_sdpa_msa", "ttnn.transformer.">(
+        mod,
+        R"doc(
+        MSA block-sparse prefill (MiniMax Sparse Attention), Blackhole single-chip.
+        Attends the block_size-token K/V blocks named in `indices`; -1 (0xFFFFFFFF) sentinels mask a contiguous
+        tail. The op has no causal flag; causal behavior must be encoded by the selected blocks. RoPE and
+        QK-norm are applied upstream.
+
+        Args:
+            q (ttnn.Tensor):       [1, H, S, d] bf16 | fp8_e4m3 ROW_MAJOR.
+                                   H must be divisible by n_kv; H/n_kv may be 16 or a multiple of 32.
+            k (ttnn.Tensor):       [B, n_kv, T, d] TILE bf16|bfloat8_b (B>1 only when indexed)
+            v (ttnn.Tensor):       [B, n_kv, T, v_dim] TILE bf16|bfloat8_b
+            indices (ttnn.Tensor): [1, n_kv, S, TOPK] uint32 block-ids (-1 = sentinel, contiguous tail).
+                                   Each row must contain a valid block, and valid block ids must be < T / block_size.
+
+        Keyword args:
+            scale (float, optional): defaults to d to the power of -0.5.
+            block_size (int): KV block size in tokens; defaults to 128. Must be a multiple of 32 and divide T.
+            compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional). fp8 q requires fp32_dest_acc_en.
+            cache_batch_idx (int, optional): select the batch slot of a shared [B, n_kv, T, feature_dim] K/V cache.
+                It is a dynamic runtime arg, so changing it (or T) does not recompile the kernels.
+
+        Returns:
+            ttnn.Tensor: [1, H, S, v_dim] ROW-MAJOR, dtype = q.
+
+        Additional preconditions: d and v_dim must be multiples of 32; TOPK times 4 and output row bytes must meet
+        device DRAM alignment.
+        )doc",
+        &ttnn::transformer::sparse_sdpa_msa,
+        nb::arg("q").noconvert(),
+        nb::arg("k").noconvert(),
+        nb::arg("v").noconvert(),
+        nb::arg("indices").noconvert(),
+        nb::kw_only(),
+        nb::arg("scale") = nb::none(),
+        nb::arg("block_size") = 128,
         nb::arg("compute_kernel_config") = nb::none(),
         nb::arg("cache_batch_idx") = nb::none());
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa_msa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa_msa.cpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/transformer/sdpa/sparse_sdpa_msa.hpp"
+#include "ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.hpp"
+#include <tt-metalium/hal.hpp>
+#include <cmath>
+
+namespace ttnn::transformer {
+
+ttnn::Tensor sparse_sdpa_msa(
+    const ttnn::Tensor& q,
+    const ttnn::Tensor& k,
+    const ttnn::Tensor& v,
+    const ttnn::Tensor& indices,
+    std::optional<float> scale,
+    uint32_t block_size,
+    std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config,
+    std::optional<uint32_t> cache_batch_idx) {
+    const uint32_t d = q.logical_shape()[3];  // head dim, from the tensor
+    const float resolved_scale = scale.value_or(1.0f / std::sqrt(static_cast<float>(d)));
+
+    // fp8 Q needs 32-bit DEST for tilize; bf16 Q uses the default DEST width.
+    const bool q_is_fp8 = (q.dtype() == ttnn::DataType::FP8_E4M3);
+    auto kernel_config = init_device_compute_kernel_config(
+        tt::tt_metal::hal::get_arch(),
+        compute_kernel_config,
+        /*default_fidelity=*/MathFidelity::HiFi2,
+        /*default_approx_mode=*/true,
+        /*default_fp32_acc=*/q_is_fp8,
+        /*default_l1_acc=*/false);
+
+    return ttnn::prim::sparse_sdpa_msa(q, k, v, indices, resolved_scale, block_size, kernel_config, cache_batch_idx);
+}
+
+}  // namespace ttnn::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa_msa.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa_msa.hpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include <optional>
+
+namespace ttnn::transformer {
+
+// MSA block-sparse prefill (MiniMax Sparse Attention), Blackhole single-chip. Attends the block_size-token KV
+// blocks named in `indices`; -1 sentinels mask the tail. K and V are separate tensors, and RoPE/QK-norm must be
+// applied upstream.
+//   q       [1, H, S, d]         bf16 | fp8_e4m3   ROW_MAJOR  (d = head dim, e.g. 128)
+//   k       [B, n_kv, T, d]      bf16 | bfp8_b     TILE  (pre-tiled, block-aligned; may be ND-sharded)
+//   v       [B, n_kv, T, v_dim]  bf16 | bfp8_b     TILE  (separate tensor; v_dim = the output width, taken from v)
+//   indices [1, n_kv, S, TOPK]   uint32 BLOCK-ids  ROW_MAJOR  (-1 = 0xFFFFFFFF = sentinel; a contiguous tail)
+// Returns [1, H, S, v_dim] ROW_MAJOR with dtype matching q. `scale` defaults to d**-0.5; `block_size`
+// defaults to 128. H must be divisible by n_kv; H/n_kv may be 16 (internally padded to one head tile) or a
+// multiple of 32.
+//
+// Preconditions: d, v_dim, and block_size are multiples of 32; block_size divides T; TOPK*4 and output row
+// bytes meet DRAM alignment; each index row has at least one valid block; all valid block ids are < T/block_size.
+ttnn::Tensor sparse_sdpa_msa(
+    const ttnn::Tensor& q,
+    const ttnn::Tensor& k,
+    const ttnn::Tensor& v,
+    const ttnn::Tensor& indices,
+    std::optional<float> scale = std::nullopt,
+    uint32_t block_size = 128,
+    std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+    std::optional<uint32_t> cache_batch_idx = std::nullopt);
+
+}  // namespace ttnn::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/transformer/sources.cmake
@@ -20,6 +20,9 @@ set(TTNN_OP_TRANSFORMER_SRCS
     sdpa/device/sparse_sdpa_device_operation.cpp
     sdpa/device/sparse_sdpa_program_factory.cpp
     sdpa/sparse_sdpa.cpp
+    sdpa/device/sparse_sdpa_msa_device_operation.cpp
+    sdpa/device/sparse_sdpa_msa_program_factory.cpp
+    sdpa/sparse_sdpa_msa.cpp
     sdpa_decode/device/sdpa_decode_device_operation.cpp
     sdpa_decode/device/sdpa_decode_program_factory.cpp
     sdpa_decode/sdpa_decode.cpp


### PR DESCRIPTION
## Summary
- Add native sparse_sdpa_msa support for MSA block-sparse prefill with separate tiled K/V caches.
- Add GQA/runtime-cache support and cache-hit validation for hash-excluded K/V shape fields.
- Align MSA compute kernel synchronization spelling with refined sparse_sdpa.

## Testing
- ninja -C build_Release ttnn/_ttnn.so
- TT_METAL_FORCE_JIT_COMPILE=1 scripts/run_safe_pytest.sh tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa_msa.py (12 passed, 0/41 JIT cache hits)
- TT_METAL_FORCE_JIT_COMPILE=1 scripts/run_safe_pytest.sh tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa.py (54 passed, 0/128 JIT cache hits)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/sparse_sdpa_msa)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/sparse_sdpa_msa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/sparse_sdpa_msa)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/sparse_sdpa_msa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/sparse_sdpa_msa)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/sparse_sdpa_msa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/sparse_sdpa_msa)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/sparse_sdpa_msa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/sparse_sdpa_msa)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/sparse_sdpa_msa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/sparse_sdpa_msa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/sparse_sdpa_msa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/sparse_sdpa_msa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/sparse_sdpa_msa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/sparse_sdpa_msa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/sparse_sdpa_msa)