### PR TITLE
[Feature] tilize/to_layout: support FP8_E4M3 input (-> any float TILE format)

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_to_layout.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_layout.py
@@ -16,7 +16,7 @@ from tests.ttnn.utils_for_testing import (
     check_with_pcc_without_tensor_printout,
 )
 from tests.ttnn.unit_tests.base_functionality.test_narrow import assert_quality
-from models.common.utility_functions import torch_random
+from models.common.utility_functions import torch_random, run_for_blackhole
 
 
 @pytest.mark.parametrize("mesh_device", [(2, 4)], ids=["t3k"], indirect=True)
@@ -1588,3 +1588,28 @@ def test_to_layout_nd_sharded_tile_to_rm_untilize_with_unpadding(
         output_mem_config,
         from_layout=ttnn.TILE_LAYOUT,
     )
+
+
+# to_layout must tilize a ROW_MAJOR-only fp8 input to any float TILE output. golden is the host-quantized
+# fp8 source (fp8 can't go to host). "ragged" (height not tile-aligned) exercises the pad + tilize_with_val_padding path.
+@run_for_blackhole()
+@pytest.mark.parametrize(
+    "out_dtype,min_pcc",
+    [(ttnn.float32, 0.9999), (ttnn.bfloat16, 0.9999), (ttnn.bfloat8_b, 0.999), (ttnn.bfloat4_b, 0.98)],
+    ids=["out_fp32", "out_bf16", "out_bfp8", "out_bfp4"],
+)
+@pytest.mark.parametrize("shape", [(1, 1, 64, 128), (1, 32, 64, 512), (1, 1, 65, 128)], ids=["small", "wide", "ragged"])
+def test_to_layout_fp8_input_to_tile(device, shape, out_dtype, min_pcc):
+    torch.manual_seed(0)
+    torch_input = torch.randn(*shape, dtype=torch.float32)
+    golden = torch_input.to(torch.float8_e4m3fn).to(torch.float32)
+    tt_in = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.fp8_e4m3,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    tt_out = ttnn.to_layout(tt_in, ttnn.TILE_LAYOUT, dtype=out_dtype)
+    assert tt_out.layout == ttnn.TILE_LAYOUT and tt_out.dtype == out_dtype
+    assert_with_pcc(golden, ttnn.to_torch(tt_out).float(), min_pcc)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_tilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_tilize.py
@@ -11,8 +11,8 @@ import ttnn
 from models.perf.benchmarking_utils import BenchmarkProfiler
 from tracy import signpost
 
-from tests.ttnn.utils_for_testing import assert_equal, assert_allclose
-from models.common.utility_functions import skip_for_slow_dispatch
+from tests.ttnn.utils_for_testing import assert_equal, assert_allclose, assert_with_pcc
+from models.common.utility_functions import skip_for_slow_dispatch, run_for_blackhole
 
 shapes = [[[1, 1, 32, 32]], [[3, 1, 320, 384]], [[1, 1, 128, 7328]]]
 
@@ -532,3 +532,28 @@ def test_tilize_width_sharded_dram_input_45331(device, shard_shape):
     assert tt_tile.layout == ttnn.TILE_LAYOUT
     torch_out = ttnn.to_torch(tt_tile)
     assert torch.equal(torch_tensor, torch_out), "tilize round-trip mismatch"
+
+
+# fp8 is a valid tile INPUT (it tilizes to any float TILE output) though ROW_MAJOR-only as a dtype. Even
+# tile-widths only (odd fp8 widths hit a separate reader NoC bug); golden is the host-quantized fp8 source.
+@run_for_blackhole()
+@pytest.mark.parametrize(
+    "out_dtype,min_pcc",
+    [(ttnn.float32, 0.9999), (ttnn.bfloat16, 0.9999), (ttnn.bfloat8_b, 0.999), (ttnn.bfloat4_b, 0.98)],
+    ids=["out_fp32", "out_bf16", "out_bfp8", "out_bfp4"],
+)
+@pytest.mark.parametrize("shape", [(1, 1, 64, 128), (1, 32, 64, 512)], ids=["small", "wide"])
+def test_tilize_fp8_input(device, shape, out_dtype, min_pcc):
+    torch.manual_seed(0)
+    torch_input = torch.randn(*shape, dtype=torch.float32)
+    golden = torch_input.to(torch.float8_e4m3fn).to(torch.float32)  # match device fp8 quantization
+    tt_in = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.fp8_e4m3,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    tt_out = ttnn.tilize(tt_in, dtype=out_dtype)
+    assert tt_out.layout == ttnn.TILE_LAYOUT and tt_out.dtype == out_dtype
+    assert_with_pcc(golden, ttnn.to_torch(tt_out).float(), min_pcc)

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -33,9 +33,11 @@ bool requires_padding_change(const ttnn::Tensor& tensor, ttnn::Layout layout) {
         page_config = tt::tt_metal::PageConfig(layout, tensor.tensor_spec().tile());
     }
 
-    TensorSpec padded_spec(
-        tensor.padded_shape(), tt::tt_metal::TensorLayout(tensor.dtype(), page_config, tensor.memory_config()));
-    return tensor.padded_shape() != padded_spec.padded_shape();
+    // Padded shape only (dtype-independent). Use TensorLayout, not a TensorSpec: TensorSpec rejects
+    // FP8_E4M3 + TILE (fp8 is ROW_MAJOR-only) though fp8 is a valid tilize input.
+    const auto padded_shape = tt::tt_metal::TensorLayout(tensor.dtype(), page_config, tensor.memory_config())
+                                  .compute_padded_shape(tensor.padded_shape());
+    return tensor.padded_shape() != padded_shape;
 }
 
 bool is_allowed_row_major_dtype(ttnn::DataType tensor_dtype, std::optional<ttnn::DataType> requested_dtype) {
@@ -93,10 +95,11 @@ Tensor to_layout_impl(
     if (tensor_arg.layout() == Layout::TILE) {
         page_config = tt::tt_metal::PageConfig(Layout::TILE, tensor_arg.tensor_spec().tile());
     }
-    TensorSpec tile_spec = TensorSpec(
-        tensor_arg.logical_shape(), tt::tt_metal::TensorLayout(tensor_arg.dtype(), page_config, output_memory_config));
-
-    auto padded_output_shape = tile_spec.padded_shape();
+    // Padded shape only (dtype-independent). Use TensorLayout, not a TensorSpec: TensorSpec rejects
+    // FP8_E4M3 + TILE (fp8 is ROW_MAJOR-only) though fp8 is a valid tilize input; the real output dtype
+    // flows through `dtype` into tilize()/untilize() below.
+    auto padded_output_shape = tt::tt_metal::TensorLayout(tensor_arg.dtype(), page_config, output_memory_config)
+                                   .compute_padded_shape(tensor_arg.logical_shape());
     auto original_rank = tensor_arg.logical_shape().rank();
     const auto& original_shape = tensor_arg.logical_shape();
 

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
@@ -111,10 +111,15 @@ void TilizeDeviceOperation::validate_on_program_cache_miss(
             input_tensor_a.dtype() == DataType::UINT32 or input_tensor_a.dtype() == DataType::INT32 or
             input_tensor_a.dtype() == DataType::UINT16 or input_tensor_a.dtype() == DataType::FP8_E4M3,
         "data type must be bfloat16, float32, uint32, int32, uint16, or fp8_e4m3");
-    TT_FATAL(
-        input_tensor_a.dtype() != DataType::FP8_E4M3 || (operation_attributes.output_dtype == DataType::BFLOAT8_B),
-        "FP8_E4M3 input requires output_dtype=BFLOAT8_B for tilize; the default output dtype would produce an "
-        "invalid TILE output specification");
+    // fp8 tile INPUT unpacks to fp32 in DEST and packs to any float TILE format. Reject non-float outputs:
+    // fp8 itself is ROW_MAJOR-only, and integer outputs are meaningless for a float input.
+    {
+        const DataType out_dt = operation_attributes.output_dtype;
+        // Valid TILE float output = a float dtype other than FP8_E4M3 (which is itself ROW_MAJOR-only).
+        TT_FATAL(
+            input_tensor_a.dtype() != DataType::FP8_E4M3 || (is_floating_point(out_dt) && out_dt != DataType::FP8_E4M3),
+            "FP8_E4M3 input to tilize requires a float TILE output (FLOAT32, BFLOAT16, BFLOAT8_B, or BFLOAT4_B)");
+    }
 
     uint32_t stick_size = stick_s * input_tensor_a.element_size();  // Assuming bfloat16 dataformat
 

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_factory_helper.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_factory_helper.cpp
@@ -7,6 +7,7 @@
 #include <bit>
 
 #include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/float8.hpp>
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 using namespace tt::tt_metal;
@@ -33,6 +34,10 @@ uint32_t get_packed_value(const Tensor& tensor, const PadValue& pad_value) {
                 if (tensor.dtype() == DataType::INT32) {
                     return std::bit_cast<uint32_t>(static_cast<int32_t>(pad_value));
                 }
+                if (tensor.dtype() == DataType::FP8_E4M3) {  // 4 fp8 bytes per word
+                    const float8_e4m3 v(static_cast<float>(pad_value));
+                    return pack_four_float8_e4m3_into_uint32(v, v, v, v);
+                }
                 TT_FATAL(
                     tensor.dtype() == DataType::UINT32, "only supporting bfloat16, float32, and uint32/int32/uint16");
                 return static_cast<uint32_t>(pad_value);
@@ -46,6 +51,10 @@ uint32_t get_packed_value(const Tensor& tensor, const PadValue& pad_value) {
                     uint16_t uint16_pad_value = static_cast<uint16_t>(pad_value);
                     return ttnn::operations::data_movement::pack_two_uint16_into_uint32(
                         {uint16_pad_value, uint16_pad_value});
+                }
+                if (tensor.dtype() == DataType::FP8_E4M3) {  // 4 fp8 bytes per word
+                    const float8_e4m3 v(static_cast<float>(pad_value));
+                    return pack_four_float8_e4m3_into_uint32(v, v, v, v);
                 }
                 TT_FATAL(
                     tensor.dtype() == DataType::FLOAT32 or tensor.dtype() == DataType::INT32 or

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_dims_split_rows_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_dims_split_rows_multicore.cpp
@@ -22,8 +22,9 @@
 // uint32_t 'val'. Ex: two bfloat16 vals in upper 16 bits and lower 16 bits.
 template <uint32_t val_size>
 FORCE_INLINE void fill_with_val(uint32_t start_addr, uint32_t n_bytes, uint32_t val) {
-    static_assert(val_size == 2 || val_size == 4, "Unsupported val_size");
-    using IntType = std::conditional_t<(val_size == 2), uint16_t, uint32_t>;
+    static_assert(val_size == 1 || val_size == 2 || val_size == 4, "Unsupported val_size");
+    using IntType =
+        std::conditional_t<(val_size == 1), uint8_t, std::conditional_t<(val_size == 2), uint16_t, uint32_t>>;
 
     uint32_t end_addr = start_addr + n_bytes;
     uint32_t start_addr_4B = (start_addr + 0x3) & 0xFFFFFFFC;  // ceil(address aligned to 4Bytes)

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
@@ -91,8 +91,17 @@ void TilizeWithValPaddingDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(
         input_tensor.dtype() == DataType::BFLOAT16 or input_tensor.dtype() == DataType::INT32 or
             input_tensor.dtype() == DataType::UINT32 or input_tensor.dtype() == DataType::FLOAT32 or
-            input_tensor.dtype() == DataType::UINT16,
-        "Can only tilize bfloat16/float32 or int32/uint32/uint16 tensors");
+            input_tensor.dtype() == DataType::UINT16 or input_tensor.dtype() == DataType::FP8_E4M3,
+        "Can only tilize bfloat16/float32 or int32/uint32/uint16 or fp8_e4m3 tensors");
+    // fp8 tile INPUT unpacks to fp32 in DEST and packs to any float TILE format. Reject non-float outputs:
+    // fp8 itself is ROW_MAJOR-only, and integer outputs are meaningless for a float input.
+    if (input_tensor.dtype() == DataType::FP8_E4M3) {
+        // Valid TILE float output = a float dtype other than FP8_E4M3 (which is itself ROW_MAJOR-only).
+        const DataType out_dt = operation_attributes.output_dtype;
+        TT_FATAL(
+            is_floating_point(out_dt) && out_dt != DataType::FP8_E4M3,
+            "FP8_E4M3 input to tilize requires a float TILE output (FLOAT32, BFLOAT16, BFLOAT8_B, or BFLOAT4_B)");
+    }
 
     if (input_shape.rank() == 1) {
         // Special case: if input tensor is 1D row-major, output tiled tensor will have 1D logical shape


### PR DESCRIPTION
### PR Category
Feature

### Summary
`FP8_E4M3` is ROW_MAJOR-only on device, so it can never be a tile **output** dtype — but it is a perfectly valid tile **input**: the fp8 unpacks to fp32 in DEST and the packer converts to any float TILE output (`FLOAT32` / `BFLOAT16` / `BFLOAT8_B` / `BFLOAT4_B`). The compute side already enabled this (`fp32_dest_acc_en` is set for fp8 inputs in every tilize program factory), but several host-side gates rejected fp8 before it could run. This PR closes those gates so `ttnn.tilize(fp8, ...)` and `ttnn.to_layout(fp8, TILE, ...)` work for both tile-aligned and non-tile-aligned shapes.

Verified on Blackhole — PCC vs the host-quantized fp8 source: `FLOAT32` 1.0, `BFLOAT16` 1.0, `BFLOAT8_B` 0.99999, `BFLOAT4_B` 0.983.

Gaps closed:
1. **`to_layout(fp8, TILE)` FATAL'd at `tensor_spec.cpp`.** `to_layout` / `requires_padding_change` only needed the tiled *padded shape* but obtained it by constructing a throwaway `TensorSpec` from the input's fp8 dtype + a TILE `PageConfig`; `TensorSpec`'s constructor validates dtype/layout and rejects `FP8_E4M3`+TILE. The padded shape is dtype-independent, so it is now computed via `TensorLayout::compute_padded_shape` (the same API `pad`/`reshape`/`copy` use) — no `TensorSpec`, no faked dtype.
2. **`tilize` and `tilize_with_val_padding` validators rejected fp8 input.** Now allowed when the output is a float TILE dtype (`is_floating_point(out) && out != FP8_E4M3`; integer outputs are meaningless for an fp8 input).
3. **`tilize_with_val_padding` pad-value helper had no fp8 case** (fp8 is 1 byte; 4 pack per `uint32`). Encoded via `float8_e4m3` + `pack_four_float8_e4m3_into_uint32`.
4. **The val-padding reader's `fill_with_val` only handled 2/4-byte elements.** Added the 1-byte (fp8, `uint8_t`) case; the existing `<4-byte` tail path covers the rest.

Tests (folded into the existing files, Blackhole-only):
- `test_tilize.py::test_tilize_fp8_input` — {fp32, bf16, bfp8, bfp4} × 2 shapes (8/8)
- `test_to_layout.py::test_to_layout_fp8_input_to_tile` — adds a non-tile-aligned ("ragged") shape that exercises the pad path; {fp32, bf16, bfp8, bfp4} × 3 shapes (12/12)

### Notes for reviewers
- Compute-side `fp32_dest_acc_en` for fp8 was already present in all tilize factories (added with the shipped fp8→bfp8_b path), so this PR is host-side validation + pad-value/reader plumbing only.
- Focus areas: the `compute_padded_shape` refactor in `to_layout_op.cpp` (now used for all dtypes — behavior is identical to the old `TensorSpec(...).padded_shape()` for non-fp8, just without building a `TensorSpec`), and the reader `fill_with_val` 1-byte case.
- Known limitation (pre-existing, out of scope): odd tile-**width** fp8 hits a separate reader NoC 64B-alignment bug; all test widths are even.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/tilize_fp8_input)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/tilize_fp8_input)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/tilize_fp8_input)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/tilize_fp8_input)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/tilize_fp8_input)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/tilize_fp8_input)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/tilize_fp8_input)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/tilize_fp8_input)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/tilize_fp8_input)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/tilize_fp8_input)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/tilize_fp8_input)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/tilize_fp8_input)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/tilize_fp8_input)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/tilize_fp8_input)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/tilize_fp8_input)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/tilize_fp8_input)