### PR TITLE
[skip ci] ci: speed up ttsim llk test runs

### DIFF
--- a/tt_metal/tt-llk/tests/run_ttsim_regression.sh
+++ b/tt_metal/tt-llk/tests/run_ttsim_regression.sh
@@ -212,21 +212,22 @@ mkdir -p "$RESULTS_DIR"
 # Build pytest argv
 # ──────────────────────────────────────────────────────────────
 PYTEST_BASE_ARGS=(
-    # Display config: this is the verbose, capture-untouched setup that we
-    # confirmed actually preserves the child's captured stdout in the junit
-    # XML. -v gives one line per test result, sugar stays off (it confused
-    # the failure tally with pytest-forked anyway), and we deliberately do
-    # NOT override `-s` from python_tests/pytest.ini or `log_cli=true` —
-    # both of those overrides empirically caused pytest-forked's child
-    # output to disappear from <system-out>, so the ttsim ERROR lines were
-    # missing from the HTML report.
-    -v
+    # Display config: capture-untouched setup that we confirmed actually
+    # preserves the child's captured stdout in the junit XML. -q keeps the
+    # terminal to one dot per test, `console_output_style=classic` drops the
+    # trailing percentage column so it's pure dots, sugar stays off (it
+    # confused the failure tally with pytest-forked anyway), and we
+    # deliberately do NOT override `-s` from python_tests/pytest.ini or
+    # `log_cli=true` — both of those overrides empirically caused
+    # pytest-forked's child output to disappear from <system-out>, so the
+    # ttsim ERROR lines were missing from the HTML report.
+    -q
+    -o console_output_style=classic
     -p no:sugar
     --run-simulator
     --timeout="$TIMEOUT"
     --forked
-    --show-progress
-    -m "not quasar and not nightly and not perf"
+    -m "not quasar and not nightly and not perf and not accuracy"
     --junit-xml="$XML_PATH"
     # ttsim writes via printf (stdout), so caplog and stderr are always
     # empty for these tests. Capture only stdout to keep the XML and the


### PR DESCRIPTION
Updated pytest arguments for regression testing to improve output clarity and prevent missing error lines in reports.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fvranicTT/test-ttsim-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fvranicTT/test-ttsim-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fvranicTT/test-ttsim-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fvranicTT/test-ttsim-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fvranicTT/test-ttsim-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fvranicTT/test-ttsim-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fvranicTT/test-ttsim-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fvranicTT/test-ttsim-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fvranicTT/test-ttsim-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fvranicTT/test-ttsim-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fvranicTT/test-ttsim-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fvranicTT/test-ttsim-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fvranicTT/test-ttsim-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fvranicTT/test-ttsim-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fvranicTT/test-ttsim-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fvranicTT/test-ttsim-regression)