### PR TITLE
Use sfpi::as not sfpi::reinterpret

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_atan2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_atan2.h
@@ -62,10 +62,10 @@ sfpi_inline sfpi::vFloat _sfpu_atan2_(sfpi::vFloat y, sfpi::vFloat x) {
 
     // Special cases:
 
-    v_if(sfpi::reinterpret<sfpi::vInt>(min) >= sfpi::reinterpret<sfpi::vInt>(x_abs)) {
+    v_if(sfpi::as<sfpi::vInt>(min) >= sfpi::as<sfpi::vInt>(x_abs)) {
         // if |y| ≥ |x| then r = π/2 - r
         r = half_pi - r;
-        v_if(sfpi::reinterpret<sfpi::vInt>(min) >= sfpi::reinterpret<sfpi::vInt>(max)) {
+        v_if(sfpi::as<sfpi::vInt>(min) >= sfpi::as<sfpi::vInt>(max)) {
             // if |x| = |y| (including both infinite), then r = π/4
             r = sfpi::addexp(half_pi, -1);
             v_if(min == 0.0f) {
@@ -95,7 +95,7 @@ sfpi_inline sfpi::vFloat _sfpu_atan2_(sfpi::vFloat y, sfpi::vFloat x) {
 
     // If |x| = NaN or |y| = NaN, vec_min_max will ensure max=NaN as mentioned above.
     sfpi::vFloat infinity = std::numeric_limits<float>::infinity();
-    v_if(sfpi::reinterpret<sfpi::vInt>(infinity) < sfpi::reinterpret<sfpi::vInt>(max)) {
+    v_if(sfpi::as<sfpi::vInt>(infinity) < sfpi::as<sfpi::vInt>(max)) {
         // if |x| = NaN or |y| = NaN, then r = NaN
         r = std::numeric_limits<float>::quiet_NaN();
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
@@ -94,8 +94,8 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_21f_(sfpi::vFloat base, sfpi::vFloat
     const sfpi::vFloat bias = sfpi::vFloat(0x3f800000);
     sfpi::vInt z = _float_to_int32_positive_(z_f32 + bias);
 
-    sfpi::vInt zii = exexp(sfpi::reinterpret<sfpi::vFloat>(z));         // Note: z & 0x7f800000 in paper
-    sfpi::vInt zif = sfpi::exman(sfpi::reinterpret<sfpi::vFloat>(z));   // Note: z & 0x007fffff in paper
+    sfpi::vInt zii = exexp(sfpi::as<sfpi::vFloat>(z));        // Note: z & 0x7f800000 in paper
+    sfpi::vInt zif = sfpi::exman(sfpi::as<sfpi::vFloat>(z));  // Note: z & 0x007fffff in paper
 
     // Compute formula in Horner form
     sfpi::vFloat d1 = sfpi::vFloat(0.40196114e-7);
@@ -108,9 +108,9 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_21f_(sfpi::vFloat base, sfpi::vFloat
     zif = _float_to_int32_positive_(d2 * d3);
 
     // Restore exponent
-    zii = sfpi::reinterpret<sfpi::vInt>(sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(zif), 127U + zii));
+    zii = sfpi::as<sfpi::vInt>(sfpi::setexp(sfpi::as<sfpi::vFloat>(zif), 127U + zii));
 
-    sfpi::vFloat y = sfpi::reinterpret<sfpi::vFloat>(zii);
+    sfpi::vFloat y = sfpi::as<sfpi::vFloat>(zii);
 
     // Post-processing: ensure that special values (e.g. 0**0, -1**0.5, ...) are handled correctly
     // Check valid base range

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_conversions.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_conversions.h
@@ -33,7 +33,7 @@ sfpi_inline sfpi::vInt _float_to_int32_positive_(sfpi::vFloat in) {
 // This implements the "add 0x7fff + LSB" algorithm for correct tie-breaking
 sfpi_inline sfpi::vFloat float32_to_bf16_rne(sfpi::vFloat in) {
     // Get the float32 bits as unsigned integer
-    sfpi::vUInt bits = sfpi::reinterpret<sfpi::vUInt>(in);
+    sfpi::vUInt bits = sfpi::as<sfpi::vUInt>(in);
 
     // Extract the LSB of what will become the bf16 mantissa (bit 16 of float32)
     // This is needed for the tie-breaker: round to even
@@ -50,5 +50,5 @@ sfpi_inline sfpi::vFloat float32_to_bf16_rne(sfpi::vFloat in) {
     bits = bits & 0xFFFF0000U;
 
     // Reinterpret back as float
-    return sfpi::reinterpret<sfpi::vFloat>(bits);
+    return sfpi::as<sfpi::vFloat>(bits);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -307,7 +307,7 @@ sfpi_inline sfpi::vFloat _sfpu_round_to_nearest_int32_(sfpi::vFloat z, sfpi::vIn
 
     sfpi::vFloat tmp = z + c231;
     sfpi::vFloat k = tmp - c231;
-    k_int = sfpi::reinterpret<sfpi::vInt>(tmp) - sfpi::reinterpret<sfpi::vInt>(c231);
+    k_int = sfpi::as<sfpi::vInt>(tmp) - sfpi::as<sfpi::vInt>(c231);
 
     return k;
 }
@@ -452,13 +452,13 @@ sfpi_inline sfpi::vFloat _calculate_exponential_body_(sfpi::vFloat in) {
 
         // Clear exp bits
         sfpi::vInt c23_73 = p_exp::C23_73;
-        sfpi::vInt tmp = sfpi::reinterpret<sfpi::vInt>(conv) - c23_73;
+        sfpi::vInt tmp = sfpi::as<sfpi::vInt>(conv) - c23_73;
 
         // Add bias
         tmp += SP_BIAS;
 
         // SHL to move integer bits to exponent
-        out = sfpi::reinterpret<sfpi::vFloat>(tmp << (10 - FRAC_BITS));
+        out = sfpi::as<sfpi::vFloat>(tmp << (10 - FRAC_BITS));
     } else {
         // Force sign to 0 (make number positive)
         out = _sfpu_exp_(sfpi::setsgn(in, 0));

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -35,9 +35,9 @@ sfpi_inline sfpi::vFloat _sfpu_exp2_fp32_accurate_(sfpi::vFloat x) {
     r = 0x1.41cp-13f;
     r = r * f + 0x1.5f4p-10f;
     r = r * f + 0x1.3b4p-7f;
-    i = sfpi::abs(sfpi::reinterpret<sfpi::vInt>(sm));
+    i = sfpi::abs(sfpi::as<sfpi::vInt>(sm));
     y = r * f + sfpi::vConstFloatPrgm2;
-    i = sfpi::reinterpret<sfpi::vInt>(sfpi::copysgn(sfpi::reinterpret<sfpi::vFloat>(i), j));
+    i = sfpi::as<sfpi::vInt>(sfpi::copysgn(sfpi::as<sfpi::vFloat>(i), j));
     r = y * f + sfpi::vConstFloatPrgm1;
     y *= std::numeric_limits<float>::infinity();
     r = r * f + sfpi::vConstFloatPrgm0;
@@ -93,8 +93,8 @@ sfpi_inline sfpi::vFloat _sfpu_exp2_bf16_(sfpi::vFloat x) {
     //   fractional_part  = (xlog2 - floor) * 2^23   (integer in [0, 2^23))
     sfpi::vInt z = _float_to_int32_for_exp_21f_(xlog2);
 
-    sfpi::vInt exponential_part = sfpi::exexp(sfpi::reinterpret<sfpi::vFloat>(z), sfpi::ExponentMode::NoDebias);
-    sfpi::vMag fractional_part = sfpi::exman(sfpi::reinterpret<sfpi::vFloat>(z));
+    sfpi::vInt exponential_part = sfpi::exexp(sfpi::as<sfpi::vFloat>(z), sfpi::ExponentMode::NoDebias);
+    sfpi::vMag fractional_part = sfpi::exman(sfpi::as<sfpi::vFloat>(z));
 
     sfpi::vFloat frac = sfpi::convert<sfpi::vFloat>(fractional_part, sfpi::RoundMode::Nearest);
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -66,7 +66,7 @@ sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat a) {
         sfpi::vFloat scale, bias;
 
         r = 8.361816406e-03f;
-        sfpi::vInt i = sfpi::reinterpret<sfpi::vInt>(j);
+        sfpi::vInt i = sfpi::as<sfpi::vInt>(j);
         j = j - rounding_bias;
 
         sfpi::vFloat c2 = 4.177856445e-02f;
@@ -93,7 +93,7 @@ sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat a) {
             sfpi::vFloat jm2 = j + -2.0f;
             // Keep reconstruction half-scaled: scale is 0.5 * 2**i. Avoids
             // materialising 2**i directly near overflow boundary.
-            scale = sfpi::reinterpret<sfpi::vFloat>((i << 23) + sfpi::reinterpret<sfpi::vInt>(w));
+            scale = sfpi::as<sfpi::vFloat>((i << 23) + sfpi::as<sfpi::vInt>(w));
 
             sfpi::vFloat abs_jm2 = sfpi::abs(jm2);
             bias = scale - w;
@@ -115,7 +115,7 @@ sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat a) {
         sfpi::vFloat s, t, u, x, y;
 
         r = 1.974105835e-04f;
-        sfpi::vInt i = sfpi::reinterpret<sfpi::vInt>(j);
+        sfpi::vInt i = sfpi::as<sfpi::vInt>(j);
         j = j - rounding_bias;
 
         sfpi::vFloat c4 = 1.393107930e-3f;
@@ -130,7 +130,7 @@ sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat a) {
         r = r * f + 4.166680202e-2f;
         sfpi::vFloat w = 0.5f;
         r = r * f + sfpi::vConstFloatPrgm2;
-        sfpi::vFloat c0 = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(w) + -1);
+        sfpi::vFloat c0 = sfpi::as<sfpi::vFloat>(sfpi::as<sfpi::vInt>(w) + -1);
 
         u = f;
         sfpi::vFloat jm1 = j + -1.0f;
@@ -141,7 +141,7 @@ sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat a) {
 
         v_if(j != 0.0f) {
             v_if(jm1 != 0.0f) {
-                t = sfpi::reinterpret<sfpi::vFloat>((i << 23) + sfpi::reinterpret<sfpi::vInt>(w));
+                t = sfpi::as<sfpi::vFloat>((i << 23) + sfpi::as<sfpi::vInt>(w));
                 y = t - w;
                 sfpi::vFloat infinity = std::numeric_limits<float>::infinity();
                 x = t - y;  // double-float canonicalization of difference

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i1.h
@@ -56,8 +56,8 @@ inline sfpi::vFloat calculate_i1_asymptotic_(const sfpi::vFloat abs_x, const sfp
     // 1/sqrt(|x|) via Quake-style magic constant + two Newton refinements.
     // Computed first so that 1/|x| can be derived as rsqrt_y² without a
     // separate sfpu_reciprocal call.
-    const sfpi::vInt rsqrt_i = sfpi::reinterpret<sfpi::vInt>(sfpi::reinterpret<sfpi::vUInt>(abs_x) >> 1);
-    sfpi::vFloat rsqrt_y = sfpi::reinterpret<sfpi::vFloat>(sfpi::vInt(0x5f1110a0) - rsqrt_i);
+    const sfpi::vInt rsqrt_i = sfpi::as<sfpi::vInt>(sfpi::as<sfpi::vUInt>(abs_x) >> 1);
+    sfpi::vFloat rsqrt_y = sfpi::as<sfpi::vFloat>(sfpi::vInt(0x5f1110a0) - rsqrt_i);
     sfpi::vFloat c0 = (-rsqrt_y) * (abs_x * rsqrt_y);
     rsqrt_y = rsqrt_y * (sfpi::vFloat(2.2825186f) + c0 * (sfpi::vFloat(2.2533049f) + c0));
     c0 = sfpi::vConst1 + (-rsqrt_y) * (abs_x * rsqrt_y);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_isclose.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_isclose.h
@@ -48,8 +48,8 @@ inline void calculate_sfpu_isclose(
         // both the |b| computation for the tolerance and the merged Inf/NaN
         // fix-up branch below, so computing them once avoids any duplicated
         // bit-mask work.
-        sfpi::vInt a_bits = sfpi::reinterpret<sfpi::vInt>(a);
-        sfpi::vInt b_bits = sfpi::reinterpret<sfpi::vInt>(b);
+        sfpi::vInt a_bits = sfpi::as<sfpi::vInt>(a);
+        sfpi::vInt b_bits = sfpi::as<sfpi::vInt>(b);
         sfpi::vFloat a_abs = sfpi::abs(a);
         sfpi::vFloat b_abs = sfpi::abs(b);
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -42,15 +42,15 @@ namespace sfpu {
 template <bool FAST_APPROX, bool HAS_BASE_SCALING, bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat calculate_log_body(sfpi::vFloat a, const uint log_base_scale_factor) {
     sfpi::vFloat three_quarters = 0.75f;
-    sfpi::vInt e = sfpi::reinterpret<sfpi::vInt>(a) - sfpi::reinterpret<sfpi::vInt>(three_quarters);
+    sfpi::vInt e = sfpi::as<sfpi::vInt>(a) - sfpi::as<sfpi::vInt>(three_quarters);
 
     if constexpr (!FAST_APPROX) {
         // normalise a (-0.0 and subnormals become +0.0)
         a = a * sfpi::vConst1 + sfpi::vConst0;
     }
 
-    e = sfpi::reinterpret<sfpi::vInt>(sfpi::setman(sfpi::reinterpret<sfpi::vFloat>(e), 0));
-    sfpi::vFloat m = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(a) - e);
+    e = sfpi::as<sfpi::vInt>(sfpi::setman(sfpi::as<sfpi::vFloat>(e), 0));
+    sfpi::vFloat m = sfpi::as<sfpi::vFloat>(sfpi::as<sfpi::vInt>(a) - e);
     sfpi::vFloat result = std::numeric_limits<float>::quiet_NaN();
 
     // m in [0.75, 1.5). Compute log1p(m - 1) for m - 1 in [-0.25, 0.5).
@@ -93,11 +93,11 @@ sfpi_inline sfpi::vFloat calculate_log_body(sfpi::vFloat a, const uint log_base_
         a = sfpi::addexp(a, -1);
 
         r = r * s + m;
-        e_float = sfpi::copysgn(e_float, sfpi::reinterpret<sfpi::vFloat>(e));
+        e_float = sfpi::copysgn(e_float, sfpi::as<sfpi::vFloat>(e));
         result = e_float * sfpi::vConstFloatPrgm0 + r;
 
         if constexpr (HAS_BASE_SCALING) {
-            result *= sfpi::reinterpret<sfpi::vFloat>(sfpi::vUInt(log_base_scale_factor));
+            result *= sfpi::as<sfpi::vFloat>(sfpi::vUInt(log_base_scale_factor));
         }
 
         // For zero, result is negative before this multiply, so result * +inf

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -54,22 +54,22 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
 
     v_if(u >= 0.0f) {
         sfpi::vFloat three_quarters = 0.75f;
-        sfpi::vInt e = sfpi::reinterpret<sfpi::vInt>(three_quarters);
+        sfpi::vInt e = sfpi::as<sfpi::vInt>(three_quarters);
         sfpi::vFloat e_float;
 
         // Subtracting the encoding of 0.75 and then zeroing the mantissa isolates
         // the exponent-bit offset e = k << 23 for the unique k with
         // 2^(-k) * u in [0.75, 1.5).
-        e = sfpi::reinterpret<sfpi::vInt>(u) - e;
-        e = sfpi::reinterpret<sfpi::vInt>(sfpi::setman(sfpi::reinterpret<sfpi::vFloat>(e), 0));
+        e = sfpi::as<sfpi::vInt>(u) - e;
+        e = sfpi::as<sfpi::vInt>(sfpi::setman(sfpi::as<sfpi::vFloat>(e), 0));
 
         // Reinterpreting a - e applies the same 2^(-k) scaling to a.
         // Affine correction below reconstructs
         //   m <- 2^(-k) * a + (2^(-k) - 1) = 2^(-k) * (1 + a) - 1.
-        sfpi::vFloat m = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(a) - e);
+        sfpi::vFloat m = sfpi::as<sfpi::vFloat>(sfpi::as<sfpi::vInt>(a) - e);
         sfpi::vFloat neg_four = -4.0f;
         // Use s' = -4 * 2^(-k) instead of 4 * 2^(-k); see -0.25 for explanation.
-        sfpi::vFloat s = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(neg_four) - e);
+        sfpi::vFloat s = sfpi::as<sfpi::vFloat>(sfpi::as<sfpi::vInt>(neg_four) - e);
 
         // Use -0.25 (instead of 0.25) so we can reuse it in the bf16 Horner step later.
         sfpi::vFloat neg_quarter = -0.25f;
@@ -113,13 +113,13 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
         }
         // convert<vFloat> returns |e| as a real number in exponent-bit units;
         // restore sign and multiply by log(2) * 2^(-23) to recover k * log(2).
-        e_float = sfpi::copysgn(e_float, sfpi::reinterpret<sfpi::vFloat>(e));
+        e_float = sfpi::copysgn(e_float, sfpi::as<sfpi::vFloat>(e));
         r = r * s + m;
         sfpi::vFloat infinity = std::numeric_limits<float>::infinity();
         r = e_float * sfpi::vConstFloatPrgm0 + r;
 
         // since u>=0, safely checks for u == NaN or u == inf
-        v_if(sfpi::reinterpret<sfpi::vInt>(u) >= sfpi::reinterpret<sfpi::vInt>(infinity)) { r = u; }
+        v_if(sfpi::as<sfpi::vInt>(u) >= sfpi::as<sfpi::vInt>(infinity)) { r = u; }
         v_endif;
     }
     v_endif;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_piecewise_rational.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_piecewise_rational.h
@@ -46,7 +46,7 @@ inline void piecewise_exp_reduce(sfpi::vFloat x, sfpi::vFloat& s, sfpi::vInt& k_
     constexpr float NEG_LN2_LO = -3.19461832987e-05f;
     const sfpi::vFloat c231 = Converter::as_float(0x4B400000U);
     sfpi::vFloat tmp = x * INV_LN2 + c231;
-    k_int = sfpi::reinterpret<sfpi::vInt>(tmp) - sfpi::reinterpret<sfpi::vInt>(c231);
+    k_int = sfpi::as<sfpi::vInt>(tmp) - sfpi::as<sfpi::vInt>(c231);
     s = (tmp - c231) * NEG_LN2_LO + ((tmp - c231) * NEG_LN2_HI + x);
 }
 
@@ -62,7 +62,7 @@ inline void piecewise_trig_reduce(sfpi::vFloat x, sfpi::vFloat& s, sfpi::vInt& q
     // Compute x / pi and round-to-nearest integer value (c.f. Hacker's Delight)
     sfpi::vFloat tmp = x * FRAC_1_PI + c231;
     sfpi::vFloat q = tmp - c231;
-    q_int = sfpi::reinterpret<sfpi::vInt>(tmp) - sfpi::reinterpret<sfpi::vInt>(c231);
+    q_int = sfpi::as<sfpi::vInt>(tmp) - sfpi::as<sfpi::vInt>(c231);
     constexpr float NEG_PI_HI = -3.140625f;
     constexpr float NEG_PI_LO = -0.00096765358979323846f;
     s = q * NEG_PI_LO + (q * NEG_PI_HI + x);
@@ -70,8 +70,7 @@ inline void piecewise_trig_reduce(sfpi::vFloat x, sfpi::vFloat& s, sfpi::vInt& q
 
 inline sfpi::vFloat piecewise_trig_expand(sfpi::vFloat poly_result, sfpi::vInt q_int) {
     // Sign flip via bitwise XOR: (q_int << 31) ^ result
-    poly_result = sfpi::reinterpret<sfpi::vFloat>(
-        (sfpi::reinterpret<sfpi::vUInt>(q_int) << 31) ^ sfpi::reinterpret<sfpi::vUInt>(poly_result));
+    poly_result = sfpi::as<sfpi::vFloat>((sfpi::as<sfpi::vUInt>(q_int) << 31) ^ sfpi::as<sfpi::vUInt>(poly_result));
     return poly_result;
 }
 #endif

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
@@ -22,28 +22,28 @@ namespace sfpu {
 // Computes the square root or reciprocal square root of a positive floating point value x.
 template <bool APPROXIMATE = false, bool RECIPROCAL = false, bool FAST_APPROX = false>
 sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x) {
-    sfpi::vInt i = sfpi::reinterpret<sfpi::vInt>(sfpi::reinterpret<sfpi::vUInt>(x) >> 1);
-    sfpi::vFloat y = sfpi::reinterpret<sfpi::vFloat>(sfpi::vConstIntPrgm0 - i);
+    sfpi::vInt i = sfpi::as<sfpi::vInt>(sfpi::as<sfpi::vUInt>(x) >> 1);
+    sfpi::vFloat y = sfpi::as<sfpi::vFloat>(sfpi::vConstIntPrgm0 - i);
 
     if constexpr (APPROXIMATE) {
         // Algorithm SQRT_10-bits, with modifications for reciprocal.
         sfpi::vFloat c = x * y;
         sfpi::vFloat negative_y = -y;
         sfpi::vFloat infinity = sfpi::sFloat16b(std::numeric_limits<float>::infinity());
-        sfpi::vInt infinity_bits = sfpi::reinterpret<sfpi::vInt>(infinity);
+        sfpi::vInt infinity_bits = sfpi::as<sfpi::vInt>(infinity);
         sfpi::vFloat t = sfpi::vConstFloatPrgm1 + negative_y * c;
         if constexpr (RECIPROCAL) {
-            sfpi::vInt x_bits = sfpi::reinterpret<sfpi::vInt>(x);
+            sfpi::vInt x_bits = sfpi::as<sfpi::vInt>(x);
             sfpi::vInt infinity_minus_x_bits = infinity_bits - x_bits;
             // If x != inf and x != 0.
             v_if(infinity_minus_x_bits != 0 && x_bits != 0) { y = y * t; }
             // Otherwise, if x = 0, then y = inf; if x = inf, then y = 0.
-            v_else { y = sfpi::reinterpret<sfpi::vFloat>(infinity_minus_x_bits); }
+            v_else { y = sfpi::as<sfpi::vFloat>(infinity_minus_x_bits); }
             v_endif;
         } else {
             y = c;
             // If x != inf.  Otherwise, y = inf, since c = inf.
-            v_if(sfpi::reinterpret<sfpi::vInt>(x) != infinity_bits) { y = y * t; }
+            v_if(sfpi::as<sfpi::vInt>(x) != infinity_bits) { y = y * t; }
             v_endif;
         }
     } else {
@@ -52,7 +52,7 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x) {
         sfpi::vFloat negative_y = -y;
         sfpi::vFloat c = negative_y * xy;
         sfpi::vFloat infinity = sfpi::sFloat16b(std::numeric_limits<float>::infinity());
-        sfpi::vInt infinity_bits = sfpi::reinterpret<sfpi::vInt>(infinity);
+        sfpi::vInt infinity_bits = sfpi::as<sfpi::vInt>(infinity);
         y = y * (sfpi::vConstFloatPrgm1 + c * (sfpi::vConstFloatPrgm2 + c));
         xy = x * y;
         negative_y = -y;
@@ -60,17 +60,17 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x) {
 
         if constexpr (RECIPROCAL) {
             sfpi::vFloat half_y = sfpi::addexp(y, -1);
-            sfpi::vInt x_bits = sfpi::reinterpret<sfpi::vInt>(x);
+            sfpi::vInt x_bits = sfpi::as<sfpi::vInt>(x);
             sfpi::vInt infinity_minus_x_bits = infinity_bits - x_bits;
             // If x != inf and x != 0.
             v_if(infinity_minus_x_bits != 0 && x_bits != 0) { y = one_minus_xyy * half_y + y; }
             // Otherwise, if x = 0, then y = inf; if x = inf, then y = 0.
-            v_else { y = sfpi::reinterpret<sfpi::vFloat>(infinity_minus_x_bits); }
+            v_else { y = sfpi::as<sfpi::vFloat>(infinity_minus_x_bits); }
             v_endif;
         } else {
             sfpi::vFloat half_xy = 0.5f * xy;
             // If x == inf, we need to skip to avoid y = inf - inf = nan; y will already be inf.
-            v_if(sfpi::reinterpret<sfpi::vInt>(x) < infinity_bits) { y = one_minus_xyy * half_xy + xy; }
+            v_if(sfpi::as<sfpi::vInt>(x) < infinity_bits) { y = one_minus_xyy * half_xy + xy; }
             v_endif;
         }
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt_custom.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt_custom.h
@@ -17,8 +17,8 @@ sfpi_inline sfpi::vFloat sfpu_sqrt_custom(sfpi::vFloat in) {
     sfpi::vFloat out = val;
     v_if(val != 0.0f) {
         // Fast inverse square-root seed + two Newton-Raphson refinements.
-        sfpi::vUInt magic = sfpi::reinterpret<sfpi::vUInt>(sfpi::vFloat(sfpi::sFloat16b(0x5f37)));
-        sfpi::vFloat approx = sfpi::reinterpret<sfpi::vFloat>(magic - (sfpi::reinterpret<sfpi::vUInt>(val) >> 1));
+        sfpi::vUInt magic = sfpi::as<sfpi::vUInt>(sfpi::vFloat(sfpi::sFloat16b(0x5f37)));
+        sfpi::vFloat approx = sfpi::as<sfpi::vFloat>(magic - (sfpi::as<sfpi::vUInt>(val) >> 1));
         sfpi::vFloat neg_half_val = val * -0.5f;
         approx = ((approx * approx) * neg_half_val + 1.5f) * approx;
         approx = ((approx * approx) * neg_half_val + 1.5f) * approx;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -112,7 +112,7 @@ inline void calculate_tangent() {
             __builtin_rvtt_sfpmad(v.get(), inv_pio2.get(), rounding_bias.get(), sfpi::SFPMAD_MOD1_OFFSET_NONE);
 
         // We need the LSB of the integer later, to determine the sign of the result.
-        i = sfpi::reinterpret<sfpi::vInt>(j);
+        i = sfpi::as<sfpi::vInt>(j);
 
         // Shift mantissa bits back; j is now round(v / (PI/2)) in fp32.
         j += -rounding_bias;
@@ -174,7 +174,7 @@ inline void calculate_sine() {
 
         // At this point, the mantissa bits of j contain the integer.
         // Store for later; the LSB determines the sign of the result.
-        sfpi::vInt q = sfpi::reinterpret<sfpi::vInt>(j);
+        sfpi::vInt q = sfpi::as<sfpi::vInt>(j);
         // Shift mantissa bits back; j is now round(v / PI) in fp32.
         j = j - rounding_bias;
 
@@ -188,7 +188,7 @@ inline void calculate_sine() {
 
         q <<= 31;
         sfpi::vFloat s = a * a;
-        a = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(a) ^ q);
+        a = sfpi::as<sfpi::vFloat>(sfpi::as<sfpi::vInt>(a) ^ q);
 
         sfpi::vFloat r;
         if (is_fp32_dest_acc_en) {
@@ -256,7 +256,7 @@ inline void calculate_cosine() {
 
         // At this point, the mantissa bits of j contain the rounded integer.
         // Store for later; the LSB tracks quadrant parity for sign selection.
-        sfpi::vInt q = sfpi::reinterpret<sfpi::vInt>(j);
+        sfpi::vInt q = sfpi::as<sfpi::vInt>(j);
 
         j = j + NEG_ROUNDING_BIAS;
 
@@ -273,7 +273,7 @@ inline void calculate_cosine() {
 
         q <<= 31;
         sfpi::vFloat s = a * a;
-        a = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(a) ^ q);
+        a = sfpi::as<sfpi::vFloat>(sfpi::as<sfpi::vInt>(a) ^ q);
 
         sfpi::vFloat r;
         if constexpr (is_fp32_dest_acc_en) {
@@ -485,8 +485,7 @@ sfpi_inline sfpi::vFloat _sfpu_quarter_exp_abs_(sfpi::vFloat x) {
         r = r * f + 0.168174848f;
         i += 125;
         r = r * f + sfpi::vConstFloatPrgm2;
-        c1 = sfpi::reinterpret<sfpi::vFloat>(
-            sfpi::reinterpret<sfpi::vInt>(sfpi::vConst1) - 613);  // 0x3f7ffd9b = 0.999963462f
+        c1 = sfpi::as<sfpi::vFloat>(sfpi::as<sfpi::vInt>(sfpi::vConst1) - 613);  // 0x3f7ffd9b = 0.999963462f
         r = r * f + c1;
 
     } else {
@@ -509,7 +508,7 @@ sfpi_inline sfpi::vFloat _sfpu_quarter_exp_abs_(sfpi::vFloat x) {
     v_if(i < 255) {
         // Keep reconstruction quarter-scaled: scale is 0.25 * 2**i. Avoids
         // materialising 2**i directly near overflow boundary.
-        y = r * sfpi::reinterpret<sfpi::vFloat>(i << 23);
+        y = r * sfpi::as<sfpi::vFloat>(i << 23);
     }
     v_endif;
 
@@ -579,7 +578,7 @@ sfpi_inline sfpi::vFloat _sfpu_quarter_expm1_abs_(sfpi::vFloat x) {
 
     // Keep reconstruction quarter-scaled: scale is 0.25 * 2**i. Avoids
     // materialising 2**i directly near overflow boundary.
-    scale = sfpi::reinterpret<sfpi::vFloat>((i << 23) + sfpi::reinterpret<sfpi::vInt>(w));
+    scale = sfpi::as<sfpi::vFloat>((i << 23) + sfpi::as<sfpi::vInt>(w));
     bias = scale - w;
     // Handle a * log2(e) >= 130, while propagating NaN.
     y = a * std::numeric_limits<float>::infinity();

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -94,8 +94,8 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_21f_(sfpi::vFloat base, sfpi::vFloat 
     const sfpi::vFloat bias = sfpi::vFloat(0x3f800000);
     sfpi::vInt z = _float_to_int32_positive_(z_f32 + bias);
 
-    sfpi::vInt zii = sfpi::exexp(sfpi::reinterpret<sfpi::vFloat>(z));   // Note: z & 0x7f800000 in paper
-    sfpi::vInt zif = sfpi::exman(sfpi::reinterpret<sfpi::vFloat>(z));   // Note: z & 0x007fffff in paper
+    sfpi::vInt zii = sfpi::exexp(sfpi::as<sfpi::vFloat>(z));  // Note: z & 0x7f800000 in paper
+    sfpi::vInt zif = sfpi::exman(sfpi::as<sfpi::vFloat>(z));  // Note: z & 0x007fffff in paper
 
     // Compute formula in Horner form
     sfpi::vFloat d1 = sfpi::vFloat(0.40196114e-7);
@@ -107,9 +107,9 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_21f_(sfpi::vFloat base, sfpi::vFloat 
     zif = _float_to_int32_positive_(d2 * d3);
 
     // Restore exponent
-    zii = sfpi::reinterpret<sfpi::vInt>(sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(zif), 127U + zii));
+    zii = sfpi::as<sfpi::vInt>(sfpi::setexp(sfpi::as<sfpi::vFloat>(zif), 127U + zii));
 
-    sfpi::vFloat y = sfpi::reinterpret<sfpi::vFloat>(zii);
+    sfpi::vFloat y = sfpi::as<sfpi::vFloat>(zii);
 
     // Division by 0 when base is 0 and pow is negative => set to NaN (only for negative exponents)
     if constexpr (!IS_POSITIVE_EXPONENT) {

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -25,7 +25,7 @@ namespace sfpu {
  * @return bf16 value packed in the upper 16 bits of a float32
  */
 sfpi_inline sfpi::vFloat float32_to_bf16_rne(sfpi::vFloat in) {
-    sfpi::vUInt bits = sfpi::reinterpret<sfpi::vUInt>(in);
+    sfpi::vUInt bits = sfpi::as<sfpi::vUInt>(in);
 
     // Extract the LSB of what will become the bf16 mantissa (bit 16 of float32).
     // Needed for the tie-breaker: round to even.
@@ -42,7 +42,7 @@ sfpi_inline sfpi::vFloat float32_to_bf16_rne(sfpi::vFloat in) {
     // Clear the lower 16 bits to get bf16 in upper 16 bits (bf16 format in float32).
     bits = bits & 0xFFFF0000U;
 
-    return sfpi::reinterpret<sfpi::vFloat>(bits);
+    return sfpi::as<sfpi::vFloat>(bits);
 }
 
 /**

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_atan2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_atan2.h
@@ -62,10 +62,10 @@ sfpi_inline sfpi::vFloat _sfpu_atan2_(sfpi::vFloat y, sfpi::vFloat x) {
 
     // Special cases:
 
-    v_if(sfpi::reinterpret<sfpi::vInt>(min) >= sfpi::reinterpret<sfpi::vInt>(x_abs)) {
+    v_if(sfpi::as<sfpi::vInt>(min) >= sfpi::as<sfpi::vInt>(x_abs)) {
         // if |y| ≥ |x| then r = π/2 - r
         r = half_pi - r;
-        v_if(sfpi::reinterpret<sfpi::vInt>(min) >= sfpi::reinterpret<sfpi::vInt>(max)) {
+        v_if(sfpi::as<sfpi::vInt>(min) >= sfpi::as<sfpi::vInt>(max)) {
             // if |x| = |y| (including both infinite), then r = π/4
             r = sfpi::addexp(half_pi, -1);
             v_if(min == 0.0f) {
@@ -95,7 +95,7 @@ sfpi_inline sfpi::vFloat _sfpu_atan2_(sfpi::vFloat y, sfpi::vFloat x) {
 
     // If |x| = NaN or |y| = NaN, vec_min_max will ensure max=NaN as mentioned above.
     sfpi::vFloat infinity = std::numeric_limits<float>::infinity();
-    v_if(sfpi::reinterpret<sfpi::vInt>(infinity) < sfpi::reinterpret<sfpi::vInt>(max)) {
+    v_if(sfpi::as<sfpi::vInt>(infinity) < sfpi::as<sfpi::vInt>(max)) {
         // if |x| = NaN or |y| = NaN, then r = NaN
         r = std::numeric_limits<float>::quiet_NaN();
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
@@ -94,8 +94,8 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_21f_(sfpi::vFloat base, sfpi::vFloat
     const sfpi::vFloat bias = sfpi::vFloat(0x3f800000);
     sfpi::vInt z = _float_to_int32_positive_(z_f32 + bias);
 
-    sfpi::vInt zii = exexp(sfpi::reinterpret<sfpi::vFloat>(z));         // Note: z & 0x7f800000 in paper
-    sfpi::vInt zif = sfpi::exman(sfpi::reinterpret<sfpi::vFloat>(z));   // Note: z & 0x007fffff in paper
+    sfpi::vInt zii = sfpi::exexp(sfpi::as<sfpi::vFloat>(z));  // Note: z & 0x7f800000 in paper
+    sfpi::vInt zif = sfpi::exman(sfpi::as<sfpi::vFloat>(z));  // Note: z & 0x007fffff in paper
 
     // Compute formula in Horner form
     sfpi::vFloat d1 = sfpi::vFloat(0.40196114e-7);
@@ -108,9 +108,9 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_21f_(sfpi::vFloat base, sfpi::vFloat
     zif = _float_to_int32_positive_(d2 * d3);
 
     // Restore exponent
-    zii = sfpi::reinterpret<sfpi::vInt>(sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(zif), 127U + zii));
+    zii = sfpi::as<sfpi::vInt>(sfpi::setexp(sfpi::as<sfpi::vFloat>(zif), 127U + zii));
 
-    sfpi::vFloat y = sfpi::reinterpret<sfpi::vFloat>(zii);
+    sfpi::vFloat y = sfpi::as<sfpi::vFloat>(zii);
 
     // Post-processing: ensure that special values (e.g. 0**0, -1**0.5, ...) are handled correctly
     // Check valid base range

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
@@ -38,7 +38,7 @@ sfpi_inline sfpi::vInt compute_unsigned_remainder_int32(const sfpi::vInt& a_sign
 
     // First Newton-Raphson iteration: inv_b_f = inv_b_f * (2 - inv_b_f * b_f)
     sfpi::vFloat t = inv_b_f * neg_b_f + sfpi::vConst1;
-    scale = sfpi::reinterpret<sfpi::vFloat>((254 << 23) - sfpi::reinterpret<sfpi::vInt>(scale));
+    scale = sfpi::as<sfpi::vFloat>((254 << 23) - sfpi::as<sfpi::vInt>(scale));
     inv_b_f = t * inv_b_f + inv_b_f;
 
     // Second Newton-Raphson iteration (interleaved with abs(a) computation)

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_conversions.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_conversions.h
@@ -33,7 +33,7 @@ sfpi_inline sfpi::vInt _float_to_int32_positive_(sfpi::vFloat in) {
 // This implements the "add 0x7fff + LSB" algorithm for correct tie-breaking
 sfpi_inline sfpi::vFloat float32_to_bf16_rne(sfpi::vFloat in) {
     // Get the float32 bits as unsigned integer
-    sfpi::vUInt bits = sfpi::reinterpret<sfpi::vUInt>(in);
+    sfpi::vUInt bits = sfpi::as<sfpi::vUInt>(in);
 
     // Extract the LSB of what will become the bf16 mantissa (bit 16 of float32)
     // This is needed for the tie-breaker: round to even
@@ -50,5 +50,5 @@ sfpi_inline sfpi::vFloat float32_to_bf16_rne(sfpi::vFloat in) {
     bits = bits & 0xFFFF0000U;
 
     // Reinterpret back as float
-    return sfpi::reinterpret<sfpi::vFloat>(bits);
+    return sfpi::as<sfpi::vFloat>(bits);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
@@ -54,7 +54,7 @@ sfpi_inline void calculate_div_int32_body(
 
     // Newton-Raphson
     sfpi::vFloat t = inv_b_f * neg_b_f + sfpi::vConst1;
-    scale = sfpi::reinterpret<sfpi::vFloat>((254 << 23) - sfpi::reinterpret<sfpi::vInt>(scale));
+    scale = sfpi::as<sfpi::vFloat>((254 << 23) - sfpi::as<sfpi::vInt>(scale));
     inv_b_f = t * inv_b_f + inv_b_f;
 
     // Halley's Method

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -160,7 +160,7 @@ sfpi_inline sfpi::vFloat _sfpu_round_to_nearest_int32_(sfpi::vFloat z, sfpi::vIn
 
     sfpi::vFloat tmp = z + c231;
     sfpi::vFloat k = tmp - c231;
-    k_int = sfpi::reinterpret<sfpi::vInt>(tmp) - sfpi::reinterpret<sfpi::vInt>(c231);
+    k_int = sfpi::as<sfpi::vInt>(tmp) - sfpi::as<sfpi::vInt>(c231);
 
     return k;
 }
@@ -445,13 +445,13 @@ sfpi_inline sfpi::vFloat _calculate_exponential_body_(sfpi::vFloat in) {
 
         // Clear exp bits
         sfpi::vInt c23_73 = p_exp::C23_73;
-        sfpi::vInt tmp = sfpi::reinterpret<sfpi::vInt>(conv) - c23_73;
+        sfpi::vInt tmp = sfpi::as<sfpi::vInt>(conv) - c23_73;
 
         // Add bias
         tmp += SP_BIAS;
 
         // SHL to move integer bits to exponent
-        out = sfpi::reinterpret<sfpi::vFloat>(tmp << (10 - FRAC_BITS));
+        out = sfpi::as<sfpi::vFloat>(tmp << (10 - FRAC_BITS));
     } else {
         // Force sign to 0 (make number positive)
         out = _sfpu_exp_(sfpi::setsgn(in, 0));

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -35,9 +35,9 @@ sfpi_inline sfpi::vFloat _sfpu_exp2_fp32_accurate_(sfpi::vFloat x) {
     r = 0x1.41cp-13f;
     r = r * f + 0x1.5f4p-10f;
     r = r * f + 0x1.3b4p-7f;
-    i = sfpi::abs(sfpi::reinterpret<sfpi::vInt>(sm));
+    i = sfpi::abs(sfpi::as<sfpi::vInt>(sm));
     y = r * f + sfpi::vConstFloatPrgm2;
-    i = sfpi::reinterpret<sfpi::vInt>(sfpi::copysgn(sfpi::reinterpret<sfpi::vFloat>(i), j));
+    i = sfpi::as<sfpi::vInt>(sfpi::copysgn(sfpi::as<sfpi::vFloat>(i), j));
     r = y * f + sfpi::vConstFloatPrgm1;
     y *= std::numeric_limits<float>::infinity();
     r = r * f + sfpi::vConstFloatPrgm0;
@@ -93,8 +93,8 @@ sfpi_inline sfpi::vFloat _sfpu_exp2_bf16_(sfpi::vFloat x) {
     //   fractional_part  = (xlog2 - floor) * 2^23   (integer in [0, 2^23))
     sfpi::vInt z = _float_to_int32_for_exp_21f_(xlog2);
 
-    sfpi::vInt exponential_part = sfpi::exexp(sfpi::reinterpret<sfpi::vFloat>(z), sfpi::ExponentMode::NoDebias);
-    sfpi::vMag fractional_part = sfpi::exman(sfpi::reinterpret<sfpi::vFloat>(z));
+    sfpi::vInt exponential_part = sfpi::exexp(sfpi::as<sfpi::vFloat>(z), sfpi::ExponentMode::NoDebias);
+    sfpi::vMag fractional_part = sfpi::exman(sfpi::as<sfpi::vFloat>(z));
 
     sfpi::vFloat frac = sfpi::convert<sfpi::vFloat>(fractional_part, sfpi::RoundMode::Nearest);
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -66,7 +66,7 @@ sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat a) {
         sfpi::vFloat scale, bias;
 
         r = 8.361816406e-03f;
-        sfpi::vInt i = sfpi::reinterpret<sfpi::vInt>(j);
+        sfpi::vInt i = sfpi::as<sfpi::vInt>(j);
         j = j - rounding_bias;
 
         sfpi::vFloat c2 = 4.177856445e-02f;
@@ -93,7 +93,7 @@ sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat a) {
             sfpi::vFloat jm2 = j + -2.0f;
             // Keep reconstruction half-scaled: scale is 0.5 * 2**i. Avoids
             // materialising 2**i directly near overflow boundary.
-            scale = sfpi::reinterpret<sfpi::vFloat>((i << 23) + sfpi::reinterpret<sfpi::vInt>(w));
+            scale = sfpi::as<sfpi::vFloat>((i << 23) + sfpi::as<sfpi::vInt>(w));
 
             sfpi::vFloat abs_jm2 = sfpi::abs(jm2);
             bias = scale - w;
@@ -115,7 +115,7 @@ sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat a) {
         sfpi::vFloat s, t, u, x, y;
 
         r = 1.974105835e-04f;
-        sfpi::vInt i = sfpi::reinterpret<sfpi::vInt>(j);
+        sfpi::vInt i = sfpi::as<sfpi::vInt>(j);
         j = j - rounding_bias;
 
         sfpi::vFloat c4 = 1.393107930e-3f;
@@ -130,7 +130,7 @@ sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat a) {
         r = r * f + 4.166680202e-2f;
         sfpi::vFloat w = 0.5f;
         r = r * f + sfpi::vConstFloatPrgm2;
-        sfpi::vFloat c0 = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(w) + -1);
+        sfpi::vFloat c0 = sfpi::as<sfpi::vFloat>(sfpi::as<sfpi::vInt>(w) + -1);
 
         u = f;
         sfpi::vFloat jm1 = j + -1.0f;
@@ -141,7 +141,7 @@ sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat a) {
 
         v_if(j != 0.0f) {
             v_if(jm1 != 0.0f) {
-                t = sfpi::reinterpret<sfpi::vFloat>((i << 23) + sfpi::reinterpret<sfpi::vInt>(w));
+                t = sfpi::as<sfpi::vFloat>((i << 23) + sfpi::as<sfpi::vInt>(w));
                 y = t - w;
                 sfpi::vFloat infinity = std::numeric_limits<float>::infinity();
                 x = t - y;  // double-float canonicalization of difference

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i1.h
@@ -56,8 +56,8 @@ inline sfpi::vFloat calculate_i1_asymptotic_(const sfpi::vFloat abs_x, const sfp
     // 1/sqrt(|x|) via Quake-style magic constant + two Newton refinements.
     // Computed first so that 1/|x| can be derived as rsqrt_y² without a
     // separate sfpu_reciprocal call.
-    const sfpi::vInt rsqrt_i = sfpi::reinterpret<sfpi::vInt>(sfpi::reinterpret<sfpi::vUInt>(abs_x) >> 1);
-    sfpi::vFloat rsqrt_y = sfpi::reinterpret<sfpi::vFloat>(sfpi::vInt(0x5f1110a0) - rsqrt_i);
+    const sfpi::vInt rsqrt_i = sfpi::as<sfpi::vInt>(sfpi::as<sfpi::vUInt>(abs_x) >> 1);
+    sfpi::vFloat rsqrt_y = sfpi::as<sfpi::vFloat>(sfpi::vInt(0x5f1110a0) - rsqrt_i);
     sfpi::vFloat c0 = (-rsqrt_y) * (abs_x * rsqrt_y);
     rsqrt_y = rsqrt_y * (sfpi::vFloat(2.2825186f) + c0 * (sfpi::vFloat(2.2533049f) + c0));
     c0 = sfpi::vConst1 + (-rsqrt_y) * (abs_x * rsqrt_y);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_isclose.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_isclose.h
@@ -48,8 +48,8 @@ inline void calculate_sfpu_isclose(
         // both the |b| computation for the tolerance and the merged Inf/NaN
         // fix-up branch below, so computing them once avoids any duplicated
         // bit-mask work.
-        sfpi::vInt a_bits = sfpi::reinterpret<sfpi::vInt>(a);
-        sfpi::vInt b_bits = sfpi::reinterpret<sfpi::vInt>(b);
+        sfpi::vInt a_bits = sfpi::as<sfpi::vInt>(a);
+        sfpi::vInt b_bits = sfpi::as<sfpi::vInt>(b);
         sfpi::vFloat a_abs = sfpi::abs(a);
         sfpi::vFloat b_abs = sfpi::abs(b);
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -42,15 +42,15 @@ namespace sfpu {
 template <bool FAST_APPROX, bool HAS_BASE_SCALING, bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat calculate_log_body(sfpi::vFloat a, const uint log_base_scale_factor) {
     sfpi::vFloat three_quarters = 0.75f;
-    sfpi::vInt e = sfpi::reinterpret<sfpi::vInt>(a) - sfpi::reinterpret<sfpi::vInt>(three_quarters);
+    sfpi::vInt e = sfpi::as<sfpi::vInt>(a) - sfpi::as<sfpi::vInt>(three_quarters);
 
     if constexpr (!FAST_APPROX) {
         // normalise a (-0.0 and subnormals become +0.0)
         a = a * sfpi::vConst1 + sfpi::vConst0;
     }
 
-    e = sfpi::reinterpret<sfpi::vInt>(sfpi::setman(sfpi::reinterpret<sfpi::vFloat>(e), 0));
-    sfpi::vFloat m = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(a) - e);
+    e = sfpi::as<sfpi::vInt>(sfpi::setman(sfpi::as<sfpi::vFloat>(e), 0));
+    sfpi::vFloat m = sfpi::as<sfpi::vFloat>(sfpi::as<sfpi::vInt>(a) - e);
     sfpi::vFloat result = std::numeric_limits<float>::quiet_NaN();
 
     // m in [0.75, 1.5). Compute log1p(m - 1) for m - 1 in [-0.25, 0.5).
@@ -93,11 +93,11 @@ sfpi_inline sfpi::vFloat calculate_log_body(sfpi::vFloat a, const uint log_base_
         a = sfpi::addexp(a, -1);
 
         r = r * s + m;
-        e_float = sfpi::copysgn(e_float, sfpi::reinterpret<sfpi::vFloat>(e));
+        e_float = sfpi::copysgn(e_float, sfpi::as<sfpi::vFloat>(e));
         result = e_float * sfpi::vConstFloatPrgm0 + r;
 
         if constexpr (HAS_BASE_SCALING) {
-            result *= sfpi::reinterpret<sfpi::vFloat>(sfpi::vUInt(log_base_scale_factor));
+            result *= sfpi::as<sfpi::vFloat>(sfpi::vUInt(log_base_scale_factor));
         }
 
         // For zero, result is negative before this multiply, so result * +inf

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -54,22 +54,22 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
 
     v_if(u >= 0.0f) {
         sfpi::vFloat three_quarters = 0.75f;
-        sfpi::vInt e = sfpi::reinterpret<sfpi::vInt>(three_quarters);
+        sfpi::vInt e = sfpi::as<sfpi::vInt>(three_quarters);
         sfpi::vFloat e_float;
 
         // Subtracting the encoding of 0.75 and then zeroing the mantissa isolates
         // the exponent-bit offset e = k << 23 for the unique k with
         // 2^(-k) * u in [0.75, 1.5).
-        e = sfpi::reinterpret<sfpi::vInt>(u) - e;
-        e = sfpi::reinterpret<sfpi::vInt>(sfpi::setman(sfpi::reinterpret<sfpi::vFloat>(e), 0));
+        e = sfpi::as<sfpi::vInt>(u) - e;
+        e = sfpi::as<sfpi::vInt>(sfpi::setman(sfpi::as<sfpi::vFloat>(e), 0));
 
         // Reinterpreting a - e applies the same 2^(-k) scaling to a.
         // Affine correction below reconstructs
         //   m <- 2^(-k) * a + (2^(-k) - 1) = 2^(-k) * (1 + a) - 1.
-        sfpi::vFloat m = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(a) - e);
+        sfpi::vFloat m = sfpi::as<sfpi::vFloat>(sfpi::as<sfpi::vInt>(a) - e);
         sfpi::vFloat neg_four = -4.0f;
         // Use s' = -4 * 2^(-k) instead of 4 * 2^(-k); see -0.25 for explanation.
-        sfpi::vFloat s = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(neg_four) - e);
+        sfpi::vFloat s = sfpi::as<sfpi::vFloat>(sfpi::as<sfpi::vInt>(neg_four) - e);
 
         // Use -0.25 (instead of 0.25) so we can reuse it in the bf16 Horner step later.
         sfpi::vFloat neg_quarter = -0.25f;
@@ -113,13 +113,13 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
         }
         // convert<vFloat> returns |e| as a real number in exponent-bit units;
         // restore sign and multiply by log(2) * 2^(-23) to recover k * log(2).
-        e_float = sfpi::copysgn(e_float, sfpi::reinterpret<sfpi::vFloat>(e));
+        e_float = sfpi::copysgn(e_float, sfpi::as<sfpi::vFloat>(e));
         r = r * s + m;
         sfpi::vFloat infinity = std::numeric_limits<float>::infinity();
         r = e_float * sfpi::vConstFloatPrgm0 + r;
 
         // since u>=0, safely checks for u == NaN or u == inf
-        v_if(sfpi::reinterpret<sfpi::vInt>(u) >= sfpi::reinterpret<sfpi::vInt>(infinity)) { r = u; }
+        v_if(sfpi::as<sfpi::vInt>(u) >= sfpi::as<sfpi::vInt>(infinity)) { r = u; }
         v_endif;
     }
     v_endif;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_piecewise_rational.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_piecewise_rational.h
@@ -46,7 +46,7 @@ inline void piecewise_exp_reduce(sfpi::vFloat x, sfpi::vFloat& s, sfpi::vInt& k_
     constexpr float NEG_LN2_LO = -3.19461832987e-05f;
     const sfpi::vFloat c231 = Converter::as_float(0x4B400000U);
     sfpi::vFloat tmp = x * INV_LN2 + c231;
-    k_int = sfpi::reinterpret<sfpi::vInt>(tmp) - sfpi::reinterpret<sfpi::vInt>(c231);
+    k_int = sfpi::as<sfpi::vInt>(tmp) - sfpi::as<sfpi::vInt>(c231);
     s = (tmp - c231) * NEG_LN2_LO + ((tmp - c231) * NEG_LN2_HI + x);
 }
 
@@ -62,7 +62,7 @@ inline void piecewise_trig_reduce(sfpi::vFloat x, sfpi::vFloat& s, sfpi::vInt& q
     // Compute x / pi and round-to-nearest integer value (c.f. Hacker's Delight)
     sfpi::vFloat tmp = x * FRAC_1_PI + c231;
     sfpi::vFloat q = tmp - c231;
-    q_int = sfpi::reinterpret<sfpi::vInt>(tmp) - sfpi::reinterpret<sfpi::vInt>(c231);
+    q_int = sfpi::as<sfpi::vInt>(tmp) - sfpi::as<sfpi::vInt>(c231);
     constexpr float NEG_PI_HI = -3.140625f;
     constexpr float NEG_PI_LO = -0.00096765358979323846f;
     s = q * NEG_PI_LO + (q * NEG_PI_HI + x);
@@ -70,8 +70,7 @@ inline void piecewise_trig_reduce(sfpi::vFloat x, sfpi::vFloat& s, sfpi::vInt& q
 
 inline sfpi::vFloat piecewise_trig_expand(sfpi::vFloat poly_result, sfpi::vInt q_int) {
     // Sign flip via bitwise XOR: (q_int << 31) ^ result
-    poly_result = sfpi::reinterpret<sfpi::vFloat>(
-        (sfpi::reinterpret<sfpi::vUInt>(q_int) << 31) ^ sfpi::reinterpret<sfpi::vUInt>(poly_result));
+    poly_result = sfpi::as<sfpi::vFloat>((sfpi::as<sfpi::vUInt>(q_int) << 31) ^ sfpi::as<sfpi::vUInt>(poly_result));
     return poly_result;
 }
 #endif

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
@@ -41,13 +41,13 @@ sfpi_inline sfpi::vFloat sfpu_reciprocal_iter(const sfpi::vFloat in) {
     // Not only is 255-in.Exp more efficient via SFPNOT, but it also ensures
     // that in.Exp == 0 results in ±inf, and in.Exp == 255 results in ±0.
     // See the scale factor adjustment via scale*0.5 below for further details.
-    sfpi::vUInt scale_bits = ~sfpi::reinterpret<sfpi::vUInt>(in);
+    sfpi::vUInt scale_bits = ~sfpi::as<sfpi::vUInt>(in);
 
     // Continue with quadratic estimate.
     y = sfpi::vConstFloatPrgm2 + y * negative_x;
 
     // Scale factor: set mantissa to zero.
-    sfpi::vFloat scale = sfpi::setman(sfpi::reinterpret<sfpi::vFloat>(scale_bits), 0);
+    sfpi::vFloat scale = sfpi::setman(sfpi::as<sfpi::vFloat>(scale_bits), 0);
 
     // First iteration of Newton-Raphson: t = 1.0 - x*y.
     sfpi::vFloat t = sfpi::vConst1 + negative_x * y;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
@@ -22,28 +22,28 @@ namespace sfpu {
 // Computes the square root or reciprocal square root of a positive floating point value x.
 template <bool APPROXIMATE = false, bool RECIPROCAL = false, bool FAST_APPROX = false>
 sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x) {
-    sfpi::vInt i = sfpi::reinterpret<sfpi::vInt>(sfpi::reinterpret<sfpi::vUInt>(x) >> 1);
-    sfpi::vFloat y = sfpi::reinterpret<sfpi::vFloat>(sfpi::vConstIntPrgm0 - i);
+    sfpi::vInt i = sfpi::as<sfpi::vInt>(sfpi::as<sfpi::vUInt>(x) >> 1);
+    sfpi::vFloat y = sfpi::as<sfpi::vFloat>(sfpi::vConstIntPrgm0 - i);
 
     if constexpr (APPROXIMATE) {
         // Algorithm SQRT_10-bits, with modifications for reciprocal.
         sfpi::vFloat c = x * y;
         sfpi::vFloat negative_y = -y;
         sfpi::vFloat infinity = sfpi::sFloat16b(std::numeric_limits<float>::infinity());
-        sfpi::vInt infinity_bits = sfpi::reinterpret<sfpi::vInt>(infinity);
+        sfpi::vInt infinity_bits = sfpi::as<sfpi::vInt>(infinity);
         sfpi::vFloat t = sfpi::vConstFloatPrgm1 + negative_y * c;
         if constexpr (RECIPROCAL) {
-            sfpi::vInt x_bits = sfpi::reinterpret<sfpi::vInt>(x);
+            sfpi::vInt x_bits = sfpi::as<sfpi::vInt>(x);
             sfpi::vInt infinity_minus_x_bits = infinity_bits - x_bits;
             // If x != inf and x != 0.
             v_if(infinity_minus_x_bits != 0 && x_bits != 0) { y = y * t; }
             // Otherwise, if x = 0, then y = inf; if x = inf, then y = 0.
-            v_else { y = sfpi::reinterpret<sfpi::vFloat>(infinity_minus_x_bits); }
+            v_else { y = sfpi::as<sfpi::vFloat>(infinity_minus_x_bits); }
             v_endif;
         } else {
             y = c;
             // If x != inf.  Otherwise, y = inf, since c = inf.
-            v_if(sfpi::reinterpret<sfpi::vInt>(x) != infinity_bits) { y = y * t; }
+            v_if(sfpi::as<sfpi::vInt>(x) != infinity_bits) { y = y * t; }
             v_endif;
         }
     } else {
@@ -52,7 +52,7 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x) {
         sfpi::vFloat negative_y = -y;
         sfpi::vFloat c = negative_y * xy;
         sfpi::vFloat infinity = sfpi::sFloat16b(std::numeric_limits<float>::infinity());
-        sfpi::vInt infinity_bits = sfpi::reinterpret<sfpi::vInt>(infinity);
+        sfpi::vInt infinity_bits = sfpi::as<sfpi::vInt>(infinity);
         y = y * (sfpi::vConstFloatPrgm1 + c * (sfpi::vConstFloatPrgm2 + c));
         xy = x * y;
         negative_y = -y;
@@ -60,17 +60,17 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x) {
 
         if constexpr (RECIPROCAL) {
             sfpi::vFloat half_y = sfpi::addexp(y, -1);
-            sfpi::vInt x_bits = sfpi::reinterpret<sfpi::vInt>(x);
+            sfpi::vInt x_bits = sfpi::as<sfpi::vInt>(x);
             sfpi::vInt infinity_minus_x_bits = infinity_bits - x_bits;
             // If x != inf and x != 0.
             v_if(infinity_minus_x_bits != 0 && x_bits != 0) { y = one_minus_xyy * half_y + y; }
             // Otherwise, if x = 0, then y = inf; if x = inf, then y = 0.
-            v_else { y = sfpi::reinterpret<sfpi::vFloat>(infinity_minus_x_bits); }
+            v_else { y = sfpi::as<sfpi::vFloat>(infinity_minus_x_bits); }
             v_endif;
         } else {
             sfpi::vFloat half_xy = 0.5f * xy;
             // If x == inf, we need to skip to avoid y = inf - inf = nan; y will already be inf.
-            v_if(sfpi::reinterpret<sfpi::vInt>(x) < infinity_bits) { y = one_minus_xyy * half_xy + xy; }
+            v_if(sfpi::as<sfpi::vInt>(x) < infinity_bits) { y = one_minus_xyy * half_xy + xy; }
             v_endif;
         }
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt_custom.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt_custom.h
@@ -17,8 +17,8 @@ sfpi_inline sfpi::vFloat sfpu_sqrt_custom(sfpi::vFloat in) {
     sfpi::vFloat out = val;
     v_if(val != 0.0f) {
         // Fast inverse square-root seed + two Newton-Raphson refinements.
-        sfpi::vUInt magic = sfpi::reinterpret<sfpi::vUInt>(sfpi::vFloat(sfpi::sFloat16b(0x5f37)));
-        sfpi::vFloat approx = sfpi::reinterpret<sfpi::vFloat>(magic - (sfpi::reinterpret<sfpi::vUInt>(val) >> 1));
+        sfpi::vUInt magic = sfpi::as<sfpi::vUInt>(sfpi::vFloat(sfpi::sFloat16b(0x5f37)));
+        sfpi::vFloat approx = sfpi::as<sfpi::vFloat>(magic - (sfpi::as<sfpi::vUInt>(val) >> 1));
         sfpi::vFloat neg_half_val = val * -0.5f;
         approx = ((approx * approx) * neg_half_val + 1.5f) * approx;
         approx = ((approx * approx) * neg_half_val + 1.5f) * approx;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -56,9 +56,9 @@ sfpi_inline sfpi::vFloat sfpu_tan<true>(sfpi::vFloat a, sfpi::vInt i) {
         const float k1 = 1.4545459747314453125f;
         const float k2 = 2.121212482452392578125f;
 
-        sfpi::vInt scale_bits = ~sfpi::reinterpret<sfpi::vInt>(r);
+        sfpi::vInt scale_bits = ~sfpi::as<sfpi::vInt>(r);
         t = k1 + k0 * negative_x;
-        sfpi::vFloat scale = sfpi::setman(sfpi::reinterpret<sfpi::vFloat>(scale_bits), 0);
+        sfpi::vFloat scale = sfpi::setman(sfpi::as<sfpi::vFloat>(scale_bits), 0);
         t = k2 + t * negative_x;
         scale *= 0.5f;
 
@@ -97,9 +97,9 @@ sfpi_inline sfpi::vFloat sfpu_tan<false>(sfpi::vFloat a, sfpi::vInt i) {
 
         sfpi::vFloat negative_x = sfpi::copyman(-1.0f, r);
         t = k1 + k0 * negative_x;
-        sfpi::vInt scale_bits = ~sfpi::reinterpret<sfpi::vInt>(r);
+        sfpi::vInt scale_bits = ~sfpi::as<sfpi::vInt>(r);
         t = k2 + t * negative_x;
-        sfpi::vFloat scale = sfpi::setman(sfpi::reinterpret<sfpi::vFloat>(scale_bits), 0);
+        sfpi::vFloat scale = sfpi::setman(sfpi::as<sfpi::vFloat>(scale_bits), 0);
 
         // Newton-Raphson refinement.
         sfpi::vFloat e = sfpi::vConst1 + negative_x * t;
@@ -132,7 +132,7 @@ inline void calculate_tangent() {
             __builtin_rvtt_sfpmad(v.get(), inv_pio2.get(), rounding_bias.get(), sfpi::SFPMAD_MOD1_OFFSET_NONE);
 
         // We need the LSB of the integer later, to determine the sign of the result.
-        i = sfpi::reinterpret<sfpi::vInt>(j);
+        i = sfpi::as<sfpi::vInt>(j);
 
         // Shift mantissa bits back; j is now round(v / (PI/2)) in fp32.
         j += -rounding_bias;
@@ -194,7 +194,7 @@ inline void calculate_sine() {
 
         // At this point, the mantissa bits of j contain the integer.
         // Store for later; the LSB determines the sign of the result.
-        sfpi::vInt q = sfpi::reinterpret<sfpi::vInt>(j);
+        sfpi::vInt q = sfpi::as<sfpi::vInt>(j);
         // Shift mantissa bits back; j is now round(v / PI) in fp32.
         j = j - rounding_bias;
 
@@ -208,7 +208,7 @@ inline void calculate_sine() {
 
         q <<= 31;
         sfpi::vFloat s = a * a;
-        a = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(a) ^ q);
+        a = sfpi::as<sfpi::vFloat>(sfpi::as<sfpi::vInt>(a) ^ q);
 
         sfpi::vFloat r;
         if (is_fp32_dest_acc_en) {
@@ -276,7 +276,7 @@ inline void calculate_cosine() {
 
         // At this point, the mantissa bits of j contain the rounded integer.
         // Store for later; the LSB tracks quadrant parity for sign selection.
-        sfpi::vInt q = sfpi::reinterpret<sfpi::vInt>(j);
+        sfpi::vInt q = sfpi::as<sfpi::vInt>(j);
 
         j = j + NEG_ROUNDING_BIAS;
 
@@ -293,7 +293,7 @@ inline void calculate_cosine() {
 
         q <<= 31;
         sfpi::vFloat s = a * a;
-        a = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(a) ^ q);
+        a = sfpi::as<sfpi::vFloat>(sfpi::as<sfpi::vInt>(a) ^ q);
 
         sfpi::vFloat r;
         if constexpr (is_fp32_dest_acc_en) {
@@ -480,7 +480,7 @@ sfpi_inline sfpi::vFloat _sfpu_reciprocal_gt0_(sfpi::vFloat x) {
     constexpr uint MAGIC_SEED = 0xfef392e0;
 
     // initial estimate y = -reciprocal(x)
-    sfpi::vFloat y = sfpi::reinterpret<sfpi::vFloat>(MAGIC_SEED - sfpi::reinterpret<sfpi::vInt>(x));
+    sfpi::vFloat y = sfpi::as<sfpi::vFloat>(MAGIC_SEED - sfpi::as<sfpi::vInt>(x));
     sfpi::vFloat e = x * y + 1.0f;
 
     if constexpr (is_fp32_dest_acc_en) {
@@ -514,8 +514,7 @@ sfpi_inline sfpi::vFloat _sfpu_quarter_exp_abs_(sfpi::vFloat x) {
         r = r * f + 0.168174848f;
         i += 125;
         r = r * f + sfpi::vConstFloatPrgm2;
-        c1 = sfpi::reinterpret<sfpi::vFloat>(
-            sfpi::reinterpret<sfpi::vInt>(sfpi::vConst1) - 613);  // 0x3f7ffd9b = 0.999963462f
+        c1 = sfpi::as<sfpi::vFloat>(sfpi::as<sfpi::vInt>(sfpi::vConst1) - 613);  // 0x3f7ffd9b = 0.999963462f
         r = r * f + c1;
 
     } else {
@@ -538,7 +537,7 @@ sfpi_inline sfpi::vFloat _sfpu_quarter_exp_abs_(sfpi::vFloat x) {
     v_if(i < 255) {
         // Keep reconstruction quarter-scaled: scale is 0.25 * 2**i. Avoids
         // materialising 2**i directly near overflow boundary.
-        y = r * sfpi::reinterpret<sfpi::vFloat>(i << 23);
+        y = r * sfpi::as<sfpi::vFloat>(i << 23);
     }
     v_endif;
 
@@ -608,7 +607,7 @@ sfpi_inline sfpi::vFloat _sfpu_quarter_expm1_abs_(sfpi::vFloat x) {
 
     // Keep reconstruction quarter-scaled: scale is 0.25 * 2**i. Avoids
     // materialising 2**i directly near overflow boundary.
-    scale = sfpi::reinterpret<sfpi::vFloat>((i << 23) + sfpi::reinterpret<sfpi::vInt>(w));
+    scale = sfpi::as<sfpi::vFloat>((i << 23) + sfpi::as<sfpi::vInt>(w));
     bias = scale - w;
     // Handle a * log2(e) >= 130, while propagating NaN.
     y = a * std::numeric_limits<float>::infinity();

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -96,8 +96,8 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_21f_(sfpi::vFloat base, sfpi::vFloat 
     const sfpi::vFloat bias = sfpi::vFloat(0x3f800000);
     sfpi::vInt z = _float_to_int32_positive_(z_f32 + bias);
 
-    sfpi::vInt zii = sfpi::exexp(sfpi::reinterpret<sfpi::vFloat>(z));   // Note: z & 0x7f800000 in paper
-    sfpi::vInt zif = sfpi::exman(sfpi::reinterpret<sfpi::vFloat>(z));   // Note: z & 0x007fffff in paper
+    sfpi::vInt zii = sfpi::exexp(sfpi::as<sfpi::vFloat>(z));  // Note: z & 0x7f800000 in paper
+    sfpi::vInt zif = sfpi::exman(sfpi::as<sfpi::vFloat>(z));  // Note: z & 0x007fffff in paper
 
     // Compute formula in Horner form
     sfpi::vFloat d1 = sfpi::vFloat(0.40196114e-7);
@@ -109,9 +109,9 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_21f_(sfpi::vFloat base, sfpi::vFloat 
     zif = _float_to_int32_positive_(d2 * d3);
 
     // Restore exponent
-    zii = sfpi::reinterpret<sfpi::vInt>(sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(zif), 127U + zii));
+    zii = sfpi::as<sfpi::vInt>(sfpi::setexp(sfpi::as<sfpi::vFloat>(zif), 127U + zii));
 
-    sfpi::vFloat y = sfpi::reinterpret<sfpi::vFloat>(zii);
+    sfpi::vFloat y = sfpi::as<sfpi::vFloat>(zii);
 
     // Division by 0 when base is 0 and pow is negative => set to NaN (only for negative exponents)
     if constexpr (!IS_POSITIVE_EXPONENT) {

--- a/tt_metal/tt-llk/.claude/references/common-errors.md
+++ b/tt_metal/tt-llk/.claude/references/common-errors.md
@@ -59,7 +59,7 @@ v_if (val < 0.0f) { val = 0.0f; } v_endif;
 Use explicit conversion:
 ```cpp
 sfpi::vInt exp = exexp(val);
-sfpi::vInt bits = sfpi::reinterpret<sfpi::vInt>(val);
+sfpi::vInt bits = sfpi::as<sfpi::vInt>(val);
 ```
 
 ### Deprecated/Renamed Instruction

--- a/tt_metal/tt-llk/.cursor/context/common-errors.md
+++ b/tt_metal/tt-llk/.cursor/context/common-errors.md
@@ -59,7 +59,7 @@ v_if (val < 0.0f) { val = 0.0f; } v_endif;
 Use explicit conversion:
 ```cpp
 sfpi::vInt exp = exexp(val);
-sfpi::vInt bits = sfpi::reinterpret<sfpi::vInt>(val);
+sfpi::vInt bits = sfpi::as<sfpi::vInt>(val);
 ```
 
 ### Deprecated/Renamed Instruction

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_comp.h
@@ -76,7 +76,7 @@ sfpi_inline void _calculate_comp_(const int iterations, std::uint32_t exponent_s
             // Result will be either 0x0000(0.0) or 0x3F80(1.0)
             if constexpr (is_less_than_equal_zero)
             {
-                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vUInt>(flag1) | sfpi::reinterpret<sfpi::vUInt>(flag2));
+                result = sfpi::as<sfpi::vFloat>(sfpi::as<sfpi::vUInt>(flag1) | sfpi::as<sfpi::vUInt>(flag2));
             }
             else
             {
@@ -86,7 +86,7 @@ sfpi_inline void _calculate_comp_(const int iterations, std::uint32_t exponent_s
                 // Do a bitwise And (flag1 & flag2) to get > condition.
                 // flag2 >= 0 AND flag1 != 0 => DST is Greater than zero
                 // Result will be either 0x0000(0.0) or 0x3F80(1.0)
-                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vUInt>(flag1) & sfpi::reinterpret<sfpi::vUInt>(flag2));
+                result = sfpi::as<sfpi::vFloat>(sfpi::as<sfpi::vUInt>(flag1) & sfpi::as<sfpi::vUInt>(flag2));
             }
         }
         else

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_expm1_cw.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_expm1_cw.h
@@ -51,7 +51,7 @@ sfpi_inline sfpi::vFloat expm1_cw_clamped(sfpi::vFloat x)
     // Reconstruct: exp(x)-1 = (2^k - 1) + 2^k * expm1(r)
     // 0x4B3FFF81 = 0x4B400000 - 127: fuses k_int ISUB + bias IADD into a single ISUB
     constexpr int kC231Bias = 0x4B3FFF81;
-    sfpi::vFloat two_k      = sfpi::setexp(sfpi::vConst1, sfpi::reinterpret<sfpi::vInt>(tmp) - kC231Bias);
+    sfpi::vFloat two_k      = sfpi::setexp(sfpi::vConst1, sfpi::as<sfpi::vInt>(tmp) - kC231Bias);
     return (two_k - sfpi::vConst1) + two_k * h;
 }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_isinf_isnan.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_isinf_isnan.h
@@ -46,7 +46,7 @@ inline sfpi::vFloat _calculate_isposinf_(const sfpi::vFloat& in)
     sfpi::vInt exp     = sfpi::exexp(in);
     sfpi::vInt man     = sfpi::exman(in);
     sfpi::vFloat out   = sfpi::vConst0;
-    sfpi::vInt signbit = sfpi::reinterpret<sfpi::vInt>(in) & 0x80000000; // returns 0 for +ve value
+    sfpi::vInt signbit = sfpi::as<sfpi::vInt>(in) & 0x80000000; // returns 0 for +ve value
     v_if (signbit == 0 && exp == 128 && man == 0)
     {
         out = sfpi::vConst1;
@@ -69,7 +69,7 @@ inline sfpi::vFloat _calculate_isneginf_(const sfpi::vFloat& in)
     sfpi::vInt exp     = sfpi::exexp(in);
     sfpi::vInt man     = sfpi::exman(in);
     sfpi::vFloat out   = sfpi::vConst0;
-    sfpi::vInt signbit = sfpi::reinterpret<sfpi::vInt>(in) & 0x80000000; // returns 0x80000000 for -ve value
+    sfpi::vInt signbit = sfpi::as<sfpi::vInt>(in) & 0x80000000; // returns 0x80000000 for -ve value
     v_if (signbit == 0x80000000 && exp == 128 && man == 0)
     {
         out = sfpi::vConst1;

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
@@ -22,11 +22,11 @@ sfpi_inline sfpi::vFloat _sqrt_compat_(sfpi::vFloat val)
 
         // sqrt initial approximation
         //  adjust bias
-        sfpi::vUInt val_s = magic + sfpi::reinterpret<sfpi::vUInt>(val);
+        sfpi::vUInt val_s = magic + sfpi::as<sfpi::vUInt>(val);
 
         // approximation of square root
         val_s >>= 1;
-        result = sfpi::reinterpret<sfpi::vFloat>(val_s);
+        result = sfpi::as<sfpi::vFloat>(val_s);
     }
     else
     {
@@ -36,7 +36,7 @@ sfpi_inline sfpi::vFloat _sqrt_compat_(sfpi::vFloat val)
         v_if (val != 0.0f)
         {
             sfpi::vUInt magic   = 0x5f37 << 16;
-            sfpi::vFloat approx = sfpi::reinterpret<sfpi::vFloat>(magic - (sfpi::reinterpret<sfpi::vUInt>(val) >> 1));
+            sfpi::vFloat approx = sfpi::as<sfpi::vFloat>(magic - (sfpi::as<sfpi::vUInt>(val) >> 1));
 
             // Reciproot iterations
             for (int r = 0; r < RECIPROCAL_ITERATIONS; r++)

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_comp.h
@@ -76,7 +76,7 @@ sfpi_inline void _calculate_comp_(const int iterations, std::uint32_t exponent_s
             // Result will be either 0x0000(0.0) or 0x3F80(1.0)
             if constexpr (is_less_than_equal_zero)
             {
-                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vUInt>(flag1) | sfpi::reinterpret<sfpi::vUInt>(flag2));
+                result = sfpi::as<sfpi::vFloat>(sfpi::as<sfpi::vUInt>(flag1) | sfpi::as<sfpi::vUInt>(flag2));
             }
             else
             {
@@ -86,7 +86,7 @@ sfpi_inline void _calculate_comp_(const int iterations, std::uint32_t exponent_s
                 // Do a bitwise And (flag1 & flag2) to get > condition.
                 // flag2 >= 0 AND flag1 != 0 => DST is Greater than zero
                 // Result will be either 0x0000(0.0) or 0x3F80(1.0)
-                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vUInt>(flag1) & sfpi::reinterpret<sfpi::vUInt>(flag2));
+                result = sfpi::as<sfpi::vFloat>(sfpi::as<sfpi::vUInt>(flag1) & sfpi::as<sfpi::vUInt>(flag2));
             }
         }
         else

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_expm1_cw.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_expm1_cw.h
@@ -51,7 +51,7 @@ sfpi_inline sfpi::vFloat expm1_cw_clamped(sfpi::vFloat x)
     // Reconstruct: exp(x)-1 = (2^k - 1) + 2^k * expm1(r)
     // 0x4B3FFF81 = 0x4B400000 - 127: fuses k_int ISUB + bias IADD into a single ISUB
     constexpr int kC231Bias = 0x4B3FFF81;
-    sfpi::vFloat two_k      = sfpi::setexp(sfpi::vConst1, sfpi::reinterpret<sfpi::vInt>(tmp) - kC231Bias);
+    sfpi::vFloat two_k      = sfpi::setexp(sfpi::vConst1, sfpi::as<sfpi::vInt>(tmp) - kC231Bias);
     return (two_k - sfpi::vConst1) + two_k * h;
 }
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_isinf_isnan.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_isinf_isnan.h
@@ -46,7 +46,7 @@ inline sfpi::vFloat _calculate_isposinf_(const sfpi::vFloat& in)
     sfpi::vInt exp     = sfpi::exexp(in);
     sfpi::vInt man     = sfpi::exman(in);
     sfpi::vFloat out   = sfpi::vConst0;
-    sfpi::vInt signbit = sfpi::reinterpret<sfpi::vInt>(in) & 0x80000000; // returns 0 for +ve value
+    sfpi::vInt signbit = sfpi::as<sfpi::vInt>(in) & 0x80000000; // returns 0 for +ve value
     v_if (signbit == 0 && exp == 128 && man == 0)
     {
         out = sfpi::vConst1;
@@ -69,7 +69,7 @@ inline sfpi::vFloat _calculate_isneginf_(const sfpi::vFloat& in)
     sfpi::vInt exp     = sfpi::exexp(in);
     sfpi::vInt man     = sfpi::exman(in);
     sfpi::vFloat out   = sfpi::vConst0;
-    sfpi::vInt signbit = sfpi::reinterpret<sfpi::vInt>(in) & 0x80000000; // returns 0x80000000 for -ve value
+    sfpi::vInt signbit = sfpi::as<sfpi::vInt>(in) & 0x80000000; // returns 0x80000000 for -ve value
     v_if (signbit == 0x80000000 && exp == 128 && man == 0)
     {
         out = sfpi::vConst1;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_negative.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_negative.h
@@ -32,7 +32,7 @@ inline void _calculate_negative_int_()
         sfpi::vInt val = sfpi::dst_reg[0];
         v_if (val != 0)
         {
-            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vInt>(-sfpi::reinterpret<sfpi::vFloat>(val));
+            sfpi::dst_reg[0] = sfpi::as<sfpi::vInt>(-sfpi::as<sfpi::vFloat>(val));
         }
         v_endif;
         sfpi::dst_reg++;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
@@ -22,11 +22,11 @@ sfpi_inline sfpi::vFloat _sqrt_compat_(sfpi::vFloat val)
 
         // sqrt initial approximation
         //  adjust bias
-        sfpi::vUInt val_s = magic + sfpi::reinterpret<sfpi::vUInt>(val);
+        sfpi::vUInt val_s = magic + sfpi::as<sfpi::vUInt>(val);
 
         // approximation of square root
         val_s >>= 1;
-        result = sfpi::reinterpret<sfpi::vFloat>(val_s);
+        result = sfpi::as<sfpi::vFloat>(val_s);
     }
     else
     {
@@ -36,7 +36,7 @@ sfpi_inline sfpi::vFloat _sqrt_compat_(sfpi::vFloat val)
         v_if (val != 0.0f)
         {
             sfpi::vUInt magic   = 0x5f37 << 16;
-            sfpi::vFloat approx = sfpi::reinterpret<sfpi::vFloat>(magic - (sfpi::reinterpret<sfpi::vUInt>(val) >> 1));
+            sfpi::vFloat approx = sfpi::as<sfpi::vFloat>(magic - (sfpi::as<sfpi::vUInt>(val) >> 1));
 
             // Reciproot iterations
             for (int r = 0; r < RECIPROCAL_ITERATIONS; r++)


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Final bit of sfpi cleanup.  `sfpi::as` is much shorter than `sfpi::reinterpret`.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/as-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/as-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsidwell/as-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsidwell/as-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsidwell/as-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsidwell/as-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/as-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/as-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsidwell/as-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsidwell/as-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/as-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/as-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/as-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/as-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/as-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/as-40182)