### PR TITLE
[Metal 2.0] Back run-arg Tables with a small-vector

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/utility/table.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/utility/table.hpp
@@ -19,6 +19,7 @@
 
 #include <tt_stl/assert.hpp>
 #include <tt_stl/optional_reference.hpp>
+#include <tt_stl/small_vector.hpp>
 
 // Forward declarations of the ttsl::hash entry points used by the std::hash<Table> specialization
 // below, so this header need not pull in the (heavy) <tt_stl/reflection.hpp>. The definitions live
@@ -67,7 +68,10 @@ private:
     // Entries are stored as a mutable std::pair<K, V> (so the backing vector stays
     // easy to grow, erase, and assign), but exposed through the iterators below as
     // the const-key value_type.
-    using Storage = std::vector<std::pair<K, V>>;
+    // Small-vector backing: Tables typically hold only a handful of entries, so the inline storage
+    // avoids a heap allocation in the common case. Larger Tables spill to the heap with identical
+    // semantics, so correctness never depends on the inline capacity.
+    using Storage = ttsl::SmallVector<std::pair<K, V>, 8>;
 
 public:
     // Wraps a backing iterator and re-presents the stored pair it points at as the


### PR DESCRIPTION
## What

Switch the `Table` backing storage in the `metal2_host_api` run-args framework from `std::vector` to `ttsl::SmallVector<,8>`.

Tables in the run-args framework typically hold only a handful of entries, so inline storage avoids a heap allocation in the common case. Larger Tables spill to the heap with identical semantics, so correctness never depends on the inline capacity.

## Context

Split out from #47471, which bundled this with a separate run-arg-key change (`RtaName`). Per review, the SmallVector change is the uncontroversial win and lands on its own; the key-type change is held back for separate measurement and a possible uniform rollout across the Metal 2.0 named-field APIs.

Host-side optimization only — no behavioral or API change.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/metal2-table-small-vector)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/metal2-table-small-vector)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/metal2-table-small-vector)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/metal2-table-small-vector)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/metal2-table-small-vector)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/metal2-table-small-vector)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/metal2-table-small-vector)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/metal2-table-small-vector)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/metal2-table-small-vector)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/metal2-table-small-vector)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/metal2-table-small-vector)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/metal2-table-small-vector)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/metal2-table-small-vector)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/metal2-table-small-vector)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/metal2-table-small-vector)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/metal2-table-small-vector)