### PR TITLE
ring_mla reduce_trigger determinism: two-phase handshake fix

### DIFF
--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -3204,7 +3204,6 @@ def test_ring_joint_attention_sdpa_determinism(model_names):
     RING_MLA_TEST_CONFIGS,
     ids=RING_MLA_TEST_CONFIG_IDS,
 )
-@skip_with_llk_assert("ring_mla deterministic replay is timing-sensitive with LLK asserts enabled. Issue #47906.")
 def test_ring_mla_determinism(
     b,
     sq,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_runtime_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_runtime_api.h
@@ -72,7 +72,8 @@ inline void llk_unpack_AB_reduce_block_max_row_runtime(
     const std::uint32_t operandA,
     const std::uint32_t operandB,
     const std::uint32_t row_start_index,
-    bool respect_trigger = false) {
+    bool respect_trigger = false,
+    bool overlap_first_half = false) {
     std::uint32_t operandA_id = get_operand_id(operandA);
     std::uint32_t operandB_id = get_operand_id(operandB);
     std::uint32_t base_address_a = get_local_cb_interface(operandA_id).fifo_rd_ptr - 1;
@@ -85,7 +86,7 @@ inline void llk_unpack_AB_reduce_block_max_row_runtime(
     // with this and does not want to plumb through the value.
     LLK_ASSERT(cb_access_within_bounds(operandA_id, row_start_index, 1), "Indexed tile read exceeds CB boundary");
 
-    _llk_unpack_AB_reduce_block_max_row_runtime_(address_a, base_address_b, respect_trigger);
+    _llk_unpack_AB_reduce_block_max_row_runtime_(address_a, base_address_b, respect_trigger, overlap_first_half);
 }
 
 /**
@@ -108,6 +109,7 @@ inline void llk_unpack_AB_reduce_block_max_row_runtime(
  * This function should NOT be used as a substitute for native llk_unpack_AB_reduce_init LLK.
  * Use standard LLK cleanup procedures for general-purpose operations.
  */
-inline void llk_unpack_AB_reduce_block_max_row_uninit_runtime(bool respect_trigger = false) {
-    _llk_unpack_AB_reduce_block_max_row_uninit_runtime_(respect_trigger);
+inline void llk_unpack_AB_reduce_block_max_row_uninit_runtime(
+    bool respect_trigger = false, bool overlap_first_half = false) {
+    _llk_unpack_AB_reduce_block_max_row_uninit_runtime_(respect_trigger, overlap_first_half);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_runtime_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_runtime_api.h
@@ -72,7 +72,8 @@ inline void llk_unpack_AB_reduce_block_max_row_runtime(
     const std::uint32_t operandA,
     const std::uint32_t operandB,
     const std::uint32_t row_start_index,
-    bool respect_trigger = false) {
+    bool respect_trigger = false,
+    bool overlap_first_half = false) {
     std::uint32_t operandA_id = get_operand_id(operandA);
     std::uint32_t operandB_id = get_operand_id(operandB);
     std::uint32_t base_address_a = get_local_cb_interface(operandA_id).fifo_rd_ptr - 1;
@@ -80,7 +81,7 @@ inline void llk_unpack_AB_reduce_block_max_row_runtime(
     std::uint32_t address_a = base_address_a + offset_address_a;
     std::uint32_t base_address_b = get_local_cb_interface(operandB_id).fifo_rd_ptr - 1;
 
-    _llk_unpack_AB_reduce_block_max_row_runtime_(address_a, base_address_b, respect_trigger);
+    _llk_unpack_AB_reduce_block_max_row_runtime_(address_a, base_address_b, respect_trigger, overlap_first_half);
 }
 
 /**
@@ -103,6 +104,7 @@ inline void llk_unpack_AB_reduce_block_max_row_runtime(
  * This function should NOT be used as a substitute for native llk_unpack_AB_reduce_init LLK.
  * Use standard LLK cleanup procedures for general-purpose operations.
  */
-inline void llk_unpack_AB_reduce_block_max_row_uninit_runtime(bool respect_trigger = false) {
-    _llk_unpack_AB_reduce_block_max_row_uninit_runtime_(respect_trigger);
+inline void llk_unpack_AB_reduce_block_max_row_uninit_runtime(
+    bool respect_trigger = false, bool overlap_first_half = false) {
+    _llk_unpack_AB_reduce_block_max_row_uninit_runtime_(respect_trigger, overlap_first_half);
 }

--- a/tt_metal/hw/inc/api/compute/reduce_custom.h
+++ b/tt_metal/hw/inc/api/compute/reduce_custom.h
@@ -228,19 +228,26 @@ ALWI void reduce_block_max_row_init_runtime(uint32_t ocb, uint32_t block_ct_dim,
 }
 
 ALWI void reduce_block_max_row_runtime(
-    uint32_t icb, uint32_t icb_scaler, uint32_t row_start_index, uint32_t idst, bool respect_trigger = false) {
-    UNPACK((llk_unpack_AB_reduce_block_max_row_runtime(icb, icb_scaler, row_start_index, respect_trigger)));
+    uint32_t icb,
+    uint32_t icb_scaler,
+    uint32_t row_start_index,
+    uint32_t idst,
+    bool respect_trigger = false,
+    bool overlap_first_half = false) {
+    UNPACK((llk_unpack_AB_reduce_block_max_row_runtime(
+        icb, icb_scaler, row_start_index, respect_trigger, overlap_first_half)));
     MATH((llk_math_reduce_block_max_row_runtime<DST_ACCUM_MODE>(idst)));
 }
 
-ALWI void reduce_block_max_row_uninit_runtime(uint32_t icb, bool respect_trigger = false) {
+ALWI void reduce_block_max_row_uninit_runtime(
+    uint32_t icb, bool respect_trigger = false, bool overlap_first_half = false) {
 #ifdef ARCH_BLACKHOLE
     MATH((llk_math_reduce_uninit<false>()));
 #else
     MATH((llk_math_reduce_uninit<false>(icb)));
 #endif
     PACK((llk_pack_reduce_mask_clear()));
-    UNPACK((llk_unpack_AB_reduce_block_max_row_uninit_runtime(respect_trigger)));
+    UNPACK((llk_unpack_AB_reduce_block_max_row_uninit_runtime(respect_trigger, overlap_first_half)));
 }
 
 }  // namespace ckernel

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
@@ -103,7 +103,8 @@ inline void _llk_unpack_AB_reduce_block_max_row_init_runtime_(std::uint32_t bloc
  * This function should NOT be used as a substitute for the native _llk_unpack_AB_ LLK.
  * Use the standard _llk_unpack_AB_ in a loop for general-purpose block reduction operations.
  */
-inline void _llk_unpack_AB_reduce_block_max_row_runtime_(const std::uint32_t address_a, const std::uint32_t address_b, bool respect_trigger = false)
+inline void _llk_unpack_AB_reduce_block_max_row_runtime_(
+    const std::uint32_t address_a, const std::uint32_t address_b, bool respect_trigger = false, bool overlap_first_half = false)
 {
     TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111); // reset counters
 
@@ -126,11 +127,20 @@ inline void _llk_unpack_AB_reduce_block_max_row_runtime_(const std::uint32_t add
 
     if (respect_trigger)
     {
-        // MOP is programmed for half of block_ct_dim; run first half immediately
+        // Barrier for the split reduce. run()#1 reads cols [0,N/2), run()#2 reads [N/2,N)
+        // (MOP outerloop = block_ct_dim/2; Z continues across the two run()s). Overlap path: run()#1
+        // waits on the early first-half token so it overlaps the second-half pack; else on FPU_SFPU.
+        // run()#2 always FPU_SFPU. Literal branch — TTI_SEMWAIT encodes the sem index as immediate.
+        if (overlap_first_half)
+        {
+            t6_semaphore_wait_on_zero<p_stall::STALL_UNPACK>(semaphore::UNPACK_MATH_DONE);
+        }
+        else
+        {
+            t6_semaphore_wait_on_zero<p_stall::STALL_UNPACK>(semaphore::FPU_SFPU);
+        }
         ckernel::ckernel_template::run();
-        // Wait for blocked_matmul_and_pack to signal that second-half data is ready
         t6_semaphore_wait_on_zero<p_stall::STALL_UNPACK>(semaphore::FPU_SFPU);
-        // Run MOP again for the second half (Z counter continues from where first half stopped)
         ckernel::ckernel_template::run();
     }
     else
@@ -160,7 +170,7 @@ inline void _llk_unpack_AB_reduce_block_max_row_runtime_(const std::uint32_t add
  * This function should NOT be used as a substitute for native reduce unpacking cleanup.
  * Standard _llk_unpack_AB_reduce_init_ operations typically don't require explicit cleanup.
  */
-inline void _llk_unpack_AB_reduce_block_max_row_uninit_runtime_(bool respect_trigger = false)
+inline void _llk_unpack_AB_reduce_block_max_row_uninit_runtime_(bool respect_trigger = false, bool overlap_first_half = false)
 {
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK);
     TTI_WRCFG(p_gpr_unpack::SR_UNPACK_UNTILIZER_STATE_0, p_cfg::WRCFG_32b, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32);
@@ -169,5 +179,10 @@ inline void _llk_unpack_AB_reduce_block_max_row_uninit_runtime_(bool respect_tri
     if (respect_trigger)
     {
         t6_semaphore_get(semaphore::FPU_SFPU);
+        if (overlap_first_half)
+        {
+            // Balance the first-half-token post; conditional so the non-overlap path leaves it untouched.
+            t6_semaphore_get(semaphore::UNPACK_MATH_DONE);
+        }
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
@@ -98,7 +98,8 @@ inline void _llk_unpack_AB_reduce_block_max_row_init_runtime_(std::uint32_t bloc
  * This function should NOT be used as a substitute for the native _llk_unpack_AB_ LLK.
  * Use the standard _llk_unpack_AB_ in a loop for general-purpose block reduction operations.
  */
-inline void _llk_unpack_AB_reduce_block_max_row_runtime_(const std::uint32_t address_a, const std::uint32_t address_b, bool respect_trigger = false)
+inline void _llk_unpack_AB_reduce_block_max_row_runtime_(
+    const std::uint32_t address_a, const std::uint32_t address_b, bool respect_trigger = false, bool overlap_first_half = false)
 {
     TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111); // reset counters
 
@@ -121,11 +122,20 @@ inline void _llk_unpack_AB_reduce_block_max_row_runtime_(const std::uint32_t add
 
     if (respect_trigger)
     {
-        // MOP is programmed for half of block_ct_dim; run first half immediately
+        // Barrier for the split reduce. run()#1 reads cols [0,N/2), run()#2 reads [N/2,N)
+        // (MOP outerloop = block_ct_dim/2; Z continues across the two run()s). Overlap path: run()#1
+        // waits on the early first-half token so it overlaps the second-half pack; else on FPU_SFPU.
+        // run()#2 always FPU_SFPU. Literal branch — TTI_SEMWAIT encodes the sem index as immediate.
+        if (overlap_first_half)
+        {
+            t6_semaphore_wait_on_zero<p_stall::STALL_UNPACK>(semaphore::UNPACK_MATH_DONE);
+        }
+        else
+        {
+            t6_semaphore_wait_on_zero<p_stall::STALL_UNPACK>(semaphore::FPU_SFPU);
+        }
         ckernel::ckernel_template::run();
-        // Wait for blocked_matmul_and_pack to signal that second-half data is ready
         t6_semaphore_wait_on_zero<p_stall::STALL_UNPACK>(semaphore::FPU_SFPU);
-        // Run MOP again for the second half (Z counter continues from where first half stopped)
         ckernel::ckernel_template::run();
     }
     else
@@ -155,7 +165,7 @@ inline void _llk_unpack_AB_reduce_block_max_row_runtime_(const std::uint32_t add
  * This function should NOT be used as a substitute for native reduce unpacking cleanup.
  * Standard _llk_unpack_AB_reduce_init_ operations typically don't require explicit cleanup.
  */
-inline void _llk_unpack_AB_reduce_block_max_row_uninit_runtime_(bool respect_trigger = false)
+inline void _llk_unpack_AB_reduce_block_max_row_uninit_runtime_(bool respect_trigger = false, bool overlap_first_half = false)
 {
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK);
     TTI_WRCFG(p_gpr_unpack::SR_UNPACK_UNTILIZER_STATE_1, p_cfg::WRCFG_32b, THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1);
@@ -163,5 +173,10 @@ inline void _llk_unpack_AB_reduce_block_max_row_uninit_runtime_(bool respect_tri
     if (respect_trigger)
     {
         t6_semaphore_get(semaphore::FPU_SFPU);
+        if (overlap_first_half)
+        {
+            // Balance the first-half-token post; conditional so the non-overlap path leaves it untouched.
+            t6_semaphore_get(semaphore::UNPACK_MATH_DONE);
+        }
     }
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -1150,6 +1150,57 @@ constexpr uint32_t largest_factor_le(uint32_t n, uint32_t max_val) {
     return 1;
 }
 
+// --- lightweight-mask predicates (single source of truth for "does this op / iter stamp a mask") ---
+
+// Compile-time: does this op configuration ever use the structured lightweight (causal / padding /
+// sliding-window) mask? Also selects the lightweight branch via `if constexpr`.
+template <bool ring_mode, bool is_causal, bool use_padded_mask, uint32_t sliding_window_size>
+constexpr bool sdpa_uses_lightweight_mask() {
+    return ring_mode || is_causal || use_padded_mask || sliding_window_size > 0;
+}
+
+// Runtime: does *this* K-chunk iteration actually stamp the lightweight mask?
+inline bool sdpa_lightweight_mask_stamped(
+    bool kv_pad_rotation_enabled, bool causal_applies, bool apply_sliding_window, bool partial_tile_mask) {
+    return kv_pad_rotation_enabled || causal_applies || apply_sliding_window || partial_tile_mask;
+}
+
+// Can the reduce's first half (run()#1, cols [0, active_Sk/2)) overlap the second-half pack? Only if
+// no masked column lands there: either nothing is stamped (no_mask_this_iter), or — on the plain
+// contiguous causal path — this q_subblock's lowest diagonal column (first_q_tile = q_subblock *
+// qkt_subblock_h) is already in the second half. A causal mask writes only cols >= the diagonal, and
+// a fully-visible column's value is its raw score, so reading it pre-mask is correct. Every other
+// variant (sliding window, kv-pad rotation, K straddle, padding/partial, provided mask) -> false.
+template <
+    bool is_causal_sdpa,
+    bool kv_pad_rotation_enabled,
+    uint32_t sliding_window_size,
+    bool use_provided_mask,
+    uint32_t Sk_chunk_t>
+inline bool sdpa_first_half_unmasked(
+    bool no_mask_this_iter,
+    bool apply_causal,
+    bool apply_sliding_window,
+    bool apply_mask,
+    uint32_t lw_partial_tile_idx,
+    uint32_t mask_straddle_col,
+    uint32_t mask_q_start_tile,
+    uint32_t mask_k_start_tile,
+    uint32_t first_q_tile,
+    uint32_t active_Sk) {
+    if (no_mask_this_iter) {
+        return true;
+    }
+    if constexpr (is_causal_sdpa && !kv_pad_rotation_enabled && sliding_window_size == 0 && !use_provided_mask) {
+        const bool plain_causal_stamp = apply_causal && !apply_sliding_window && mask_straddle_col == 0 &&
+                                        active_Sk == Sk_chunk_t && !(apply_mask && lw_partial_tile_idx > 0);
+        const int32_t first_diag_col =
+            static_cast<int32_t>(mask_q_start_tile + first_q_tile) - static_cast<int32_t>(mask_k_start_tile);
+        return plain_causal_stamp && first_diag_col >= static_cast<int32_t>(active_Sk / 2);
+    }
+    return false;
+}
+
 /**
  * One K-chunk iteration of the streaming SDPA algorithm (v2 — no row buffers).
  * Phase 1: Q@KT directly into cb_qkt_im with cb_push_back_hold_wr_ptr, in-place sub_exp.
@@ -1260,31 +1311,36 @@ static void sdpa_inner_loop_step(
         // When q_subblock == 0, no sub_exp → global stays set → skip there too.
         configure_row_pack_width(cb_qkt_im, actual_sbw);
 
-        // Mask predicates hoisted here (single source of truth, reused by the mask branch below).
+        // Mask plan for this q_subblock (single source of truth; reused by the mask stamp below).
         constexpr bool uses_lightweight_mask =
-            ring_mode || is_causal_sdpa || use_padded_mask || sliding_window_size > 0;
-        const bool should_apply_lightweight_mask = kv_pad_rotation_enabled || (is_causal_sdpa && apply_causal) ||
-                                                   apply_sliding_window || (apply_mask && lw_partial_tile_idx > 0);
+            sdpa_uses_lightweight_mask<ring_mode, is_causal_sdpa, use_padded_mask, sliding_window_size>();
+        const bool should_apply_lightweight_mask = sdpa_lightweight_mask_stamped(
+            kv_pad_rotation_enabled,
+            is_causal_sdpa && apply_causal,
+            apply_sliding_window,
+            apply_mask && lw_partial_tile_idx > 0);
         const bool no_mask_this_iter = !use_provided_mask && !(uses_lightweight_mask && should_apply_lightweight_mask);
 
-        // run()#1 reads only the first half [0, active_Sk/2), so it can overlap the second-half pack
-        // whenever no masked column lands there: either nothing is stamped, or this is a plain causal
-        // stamp whose lowest diagonal column (this q_subblock's earliest query row) is already in the
-        // second half. A causal mask writes only columns >= the diagonal, and a fully-visible column's
-        // value is just its raw score, so reading it pre-mask is correct. Restricted to the contiguous
-        // causal fast path; every other variant (sliding window, kv-pad rotation, K straddle,
-        // padding/partial, provided mask) keeps the conservative no-overlap fallback.
-        bool causal_first_half_unmasked = false;
-        if constexpr (is_causal_sdpa && !kv_pad_rotation_enabled && sliding_window_size == 0 && !use_provided_mask) {
-            const bool plain_causal_stamp = apply_causal && !apply_sliding_window && mask_straddle_col == 0 &&
-                                            active_Sk == Sk_chunk_t && !(apply_mask && lw_partial_tile_idx > 0);
-            const int32_t diag0 = static_cast<int32_t>(mask_q_start_tile + q_subblock * qkt_subblock_h) -
-                                  static_cast<int32_t>(mask_k_start_tile);
-            causal_first_half_unmasked = plain_causal_stamp && diag0 >= static_cast<int32_t>(active_Sk / 2);
-        }
-        const bool overlap_first_half = reduce_trigger && (no_mask_this_iter || causal_first_half_unmasked);
-        // Subblock covering the last first-half column [active_Sk/2 - 1]; PACK posts the first-half token after it.
-        // Committing a superset of [0, active_Sk/2) is safe (run()#1's cols are a subset).
+        // run()#1 (the reduce's first half) may overlap the second-half pack only if no masked
+        // column lands in [0, active_Sk/2) — see sdpa_first_half_unmasked.
+        const bool overlap_first_half = reduce_trigger && sdpa_first_half_unmasked<
+                                                              is_causal_sdpa,
+                                                              kv_pad_rotation_enabled,
+                                                              sliding_window_size,
+                                                              use_provided_mask,
+                                                              Sk_chunk_t>(
+                                                              no_mask_this_iter,
+                                                              apply_causal,
+                                                              apply_sliding_window,
+                                                              apply_mask,
+                                                              lw_partial_tile_idx,
+                                                              mask_straddle_col,
+                                                              mask_q_start_tile,
+                                                              mask_k_start_tile,
+                                                              q_subblock * qkt_subblock_h,
+                                                              active_Sk);
+        // PACK posts the first-half token after the subblock covering the last first-half column
+        // [active_Sk/2 - 1]; committing a superset of [0, active_Sk/2) is safe (run()#1's cols are a subset).
         const uint32_t first_half_last_sb = (active_Sk / 2 - 1) / actual_sbw;
 
         for (uint32_t kt_subblock = 0; kt_subblock < kt_num_full_subblocks; ++kt_subblock) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -233,11 +233,13 @@ ALWI bool configure_row_pack_width(uint32_t cb, uint32_t pack_width) {
 }
 
 ALWI void init_sdpa_streaming_semaphores() {
-    // reduce_trigger splits QK row-max reduce across a PACK->UNPACK handshake:
-    // PACK posts FPU_SFPU after QK writes are visible, then UNPACK waits before
-    // running the second half of the reduce MOP. Default firmware init covers
-    // common math/pack semaphores, but not FPU_SFPU, so initialize it here.
+    // reduce_trigger runs the QK row-max reduce as a split MOP gated by a PACK->UNPACK handshake on
+    // two T6 tokens (firmware inits neither). FPU_SFPU, posted after pack + mask + push, gates run()#2
+    // (and run()#1 on the non-overlap path). UNPACK_MATH_DONE (the first-half token) is borrowed (unused elsewhere
+    // in SDPA): PACK posts it early, once the first half is committed, to gate run()#1 on the overlap
+    // path so it overlaps the second-half pack.
     PACK((t6_semaphore_init(semaphore::FPU_SFPU, 0, 1)));
+    PACK((t6_semaphore_init(semaphore::UNPACK_MATH_DONE, 0, 1)));
 }
 
 #if defined(TRISC_MATH) && defined(ARCH_WORMHOLE)
@@ -323,7 +325,6 @@ void blocked_matmul_and_pack(
     uint32_t subblock_h,
     uint32_t inner_dim,
     uint32_t matmul_stride,
-    bool trigger_reduce = false,
     bool skip_pack_configure = false) {
     tile_regs_acquire();
     uint32_t dst_index = 0;
@@ -343,9 +344,6 @@ void blocked_matmul_and_pack(
     }
     pack_contiguous_rows_nocfg(
         out_cb, row_subblock_idx * subblock_h, subblock_h, out_num_cols, out_col_offset, subblock_w);
-    if (trigger_reduce) {
-        PACK((t6_semaphore_post<p_stall::NONE>(semaphore::FPU_SFPU)));
-    }
     tile_regs_release();
 }
 
@@ -408,7 +406,8 @@ void reduce_c_row_group(
     uint32_t sbh,
     uint32_t reduce_cols,
     bool respect_trigger = false,
-    uint32_t mirror_cb = INVALID_CB) {
+    uint32_t mirror_cb = INVALID_CB,
+    bool overlap_first_half = false) {
     const uint32_t group_size = sbh;
     const uint32_t row_start = row_group_index * group_size;
 
@@ -440,9 +439,9 @@ void reduce_c_row_group(
     reduce_block_max_row_init_runtime(out_cb, reduce_cols, respect_trigger);
     for (uint32_t i = 0; i < group_size; i++) {
         const uint32_t input_tile_start = (row_start + i) * row_stride;
-        reduce_block_max_row_runtime(in0_cb, scale_cb, input_tile_start, i, respect_trigger);
+        reduce_block_max_row_runtime(in0_cb, scale_cb, input_tile_start, i, respect_trigger, overlap_first_half);
     }
-    reduce_block_max_row_uninit_runtime(in0_cb, respect_trigger);
+    reduce_block_max_row_uninit_runtime(in0_cb, respect_trigger, overlap_first_half);
 
     tile_regs_commit();
     tile_regs_wait();
@@ -1260,6 +1259,34 @@ static void sdpa_inner_loop_step(
         // so blocked_matmul_and_pack must reconfigure when q_subblock > 0.
         // When q_subblock == 0, no sub_exp → global stays set → skip there too.
         configure_row_pack_width(cb_qkt_im, actual_sbw);
+
+        // Mask predicates hoisted here (single source of truth, reused by the mask branch below).
+        constexpr bool uses_lightweight_mask =
+            ring_mode || is_causal_sdpa || use_padded_mask || sliding_window_size > 0;
+        const bool should_apply_lightweight_mask = kv_pad_rotation_enabled || (is_causal_sdpa && apply_causal) ||
+                                                   apply_sliding_window || (apply_mask && lw_partial_tile_idx > 0);
+        const bool no_mask_this_iter = !use_provided_mask && !(uses_lightweight_mask && should_apply_lightweight_mask);
+
+        // run()#1 reads only the first half [0, active_Sk/2), so it can overlap the second-half pack
+        // whenever no masked column lands there: either nothing is stamped, or this is a plain causal
+        // stamp whose lowest diagonal column (this q_subblock's earliest query row) is already in the
+        // second half. A causal mask writes only columns >= the diagonal, and a fully-visible column's
+        // value is just its raw score, so reading it pre-mask is correct. Restricted to the contiguous
+        // causal fast path; every other variant (sliding window, kv-pad rotation, K straddle,
+        // padding/partial, provided mask) keeps the conservative no-overlap fallback.
+        bool causal_first_half_unmasked = false;
+        if constexpr (is_causal_sdpa && !kv_pad_rotation_enabled && sliding_window_size == 0 && !use_provided_mask) {
+            const bool plain_causal_stamp = apply_causal && !apply_sliding_window && mask_straddle_col == 0 &&
+                                            active_Sk == Sk_chunk_t && !(apply_mask && lw_partial_tile_idx > 0);
+            const int32_t diag0 = static_cast<int32_t>(mask_q_start_tile + q_subblock * qkt_subblock_h) -
+                                  static_cast<int32_t>(mask_k_start_tile);
+            causal_first_half_unmasked = plain_causal_stamp && diag0 >= static_cast<int32_t>(active_Sk / 2);
+        }
+        const bool overlap_first_half = reduce_trigger && (no_mask_this_iter || causal_first_half_unmasked);
+        // Subblock covering the last first-half column [active_Sk/2 - 1]; PACK posts the first-half token after it.
+        // Committing a superset of [0, active_Sk/2) is safe (run()#1's cols are a subset).
+        const uint32_t first_half_last_sb = (active_Sk / 2 - 1) / actual_sbw;
+
         for (uint32_t kt_subblock = 0; kt_subblock < kt_num_full_subblocks; ++kt_subblock) {
             if (q_subblock > 0) {
                 uint32_t prev_q_subblock = q_subblock - 1;
@@ -1280,8 +1307,6 @@ static void sdpa_inner_loop_step(
             }
             {
                 MaybeDeviceZoneScopedN(profiling_enabled, "Q@KT MM+Pack");
-                // The last subblock posts the semaphore — one post per reduce.
-                bool kt_trigger_reduce = reduce_trigger && (kt_subblock == kt_num_full_subblocks - 1);
                 blocked_matmul_and_pack<true, KT_stride, KT_stride>(
                     cb_q_in,
                     cb_kt_in,
@@ -1294,8 +1319,12 @@ static void sdpa_inner_loop_step(
                     qkt_subblock_h,
                     in0_block_w,
                     in0_block_w,
-                    kt_trigger_reduce,
                     /*skip_pack_configure=*/q_subblock == 0);
+                // Signal the first half is committed so run()#1 overlaps the second-half
+                // pack. STALL_PACK drains the L1 writes before the token retires.
+                if (overlap_first_half && kt_subblock == first_half_last_sb) {
+                    PACK((t6_semaphore_post<p_stall::STALL_PACK>(semaphore::UNPACK_MATH_DONE)));
+                }
                 kt_index_offset += actual_sbw;
             }
         }
@@ -1307,8 +1336,7 @@ static void sdpa_inner_loop_step(
         // user mask supplies all masking itself (causal/sliding/padding baked in by the caller),
         // so exactly one of these branches is compiled. The only config that stamps nothing is plain
         // non-causal attention with no mask at all (uses_lightweight_mask == false).
-        constexpr bool uses_lightweight_mask =
-            ring_mode || is_causal_sdpa || use_padded_mask || sliding_window_size > 0;
+        // uses_lightweight_mask hoisted above the kt loop.
         if constexpr (use_provided_mask) {
             // Dense user-provided mask: the full per-position mask, applied on every K chunk (no
             // chunk skipping); the user mask defines the visible region. begin_mask_l1_accumulate
@@ -1331,8 +1359,7 @@ static void sdpa_inner_loop_step(
         } else if constexpr (uses_lightweight_mask) {
             // Lightweight stamp: causal and/or padding masks. Active for ring, causal non-ring, or
             // non-causal padded with a partial-tile mask (single-chip streaming partial-K case).
-            const bool should_apply_lightweight_mask = kv_pad_rotation_enabled || (is_causal_sdpa && apply_causal) ||
-                                                       apply_sliding_window || (apply_mask && lw_partial_tile_idx > 0);
+            // should_apply_lightweight_mask hoisted above the kt loop.
             if (should_apply_lightweight_mask) {
                 begin_mask_l1_accumulate<false>(cb_qkt_im, cb_mask_in);
                 apply_lightweight_mask_streaming<
@@ -1370,6 +1397,13 @@ static void sdpa_inner_loop_step(
         // Push row (visible for UNPACK reads) but keep wr_ptr stable
         cb_push_back_hold_wr_ptr(cb_qkt_im, row_tiles);
 
+        // reduce_trigger barrier. Posted after pack + mask + push so it dominates every
+        // cb_qkt_im writer; gates run()#2 (and run()#1 on the non-overlap path). STALL_PACK drains
+        // the writes; one post / one uninit get stays balanced (wait_on_zero is non-consuming).
+        if (reduce_trigger) {
+            PACK((t6_semaphore_post<p_stall::STALL_PACK>(semaphore::FPU_SFPU)));
+        }
+
         // Max reduce: reads from cb_qkt_im at q_subblock position
         {
             MaybeDeviceZoneScopedN(profiling_enabled, "Reduce max");
@@ -1385,7 +1419,8 @@ static void sdpa_inner_loop_step(
                 qkt_subblock_h,
                 active_Sk,
                 reduce_trigger,
-                save_max_cb);
+                save_max_cb,
+                overlap_first_half);
             CircularBuffer(cur.max).push_back(qkt_subblock_h);
             if (save_max_cb != INVALID_CB) {
                 CircularBuffer(save_max_cb).push_back(qkt_subblock_h);
@@ -1502,7 +1537,6 @@ static void sdpa_inner_loop_step(
                                 qktv_h,
                                 matmul_inner,
                                 KT_stride,
-                                /*trigger_reduce=*/false,
                                 /*skip_pack_configure=*/true);
                             v_index_offset += qktv_subblock_w;
                         }
@@ -1673,7 +1707,6 @@ static void sdpa_inner_loop_step(
                         cur_h,
                         active_Sk,
                         KT_stride,
-                        /*trigger_reduce=*/false,
                         /*skip_pack_configure=*/true);
                     v_index_offset += qktv_subblock_w;
                 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_compute.cpp
@@ -176,7 +176,6 @@ void kernel_main() {
                             /*subblock_h=*/qsb,
                             /*inner_dim=*/DHt,
                             /*matmul_stride=*/DHt,
-                            /*trigger_reduce=*/false,
                             /*skip_pack_configure=*/true);
                     }
                     // Publish the band to UNPACK while holding wr_ptr (for the in-place mask/sub_exp).
@@ -262,7 +261,6 @@ void kernel_main() {
                             /*subblock_h=*/qsb,
                             /*inner_dim=*/Skt,
                             /*matmul_stride=*/KT_stride,
-                            /*trigger_reduce=*/false,
                             /*skip_pack_configure=*/true);
                     }
                     pack_to_unpack_sync();                // flush PV's HELD out_cur packs (push_back deferred to


### PR DESCRIPTION
### Tickets

Closes #47906
Closes #47911

## Problem

`reduce_trigger` (the split row-max reduce in streaming / ring SDPA) read the QK^T scores from `cb_qkt_im` **before the packer had written them**. The reduce's first-half MOP ran with no producer→consumer barrier, and since PACK (T2) trails UNPACK (T0), those early columns could be read stale → nondeterministic row-max → nondeterministic output on the ring path.

Repro: `test_ring_mla_determinism` fails iter1 ≠ iter0 under `TT_METAL_LLK_ASSERTS=1` (the test had been muted with `@skip_with_llk_assert`).

## Fix — two-phase handshake (barrier moved *earlier*, not removed → deterministic by construction)

- **Re-anchor `FPU_SFPU`**: post it after **pack + mask + push** (with `STALL_PACK` to drain L1) so it dominates every writer of `cb_qkt_im`. It gates `run()#2` (and `run()#1` on the non-overlap path). The old post sat inside the QK matmul — before the in-place mask and the push — and used `p_stall::NONE` (no drain).
- **Add a first-half token** (borrowed `UNPACK_MATH_DONE`, unused elsewhere in SDPA): PACK posts it early, the instant the first half is committed, to gate `run()#1` so it **overlaps the second-half pack** — preserving the latency-hiding the single-token barrier would give up.
- **Masked-iter overlap**: `run()#1` only reads `[0, active_Sk/2)`, so the early post is also safe on a causal masking iter whose lowest diagonal column is `>= active_Sk/2` (the mask writes only the high columns; a fully-visible column's value is its raw score). Gated to the contiguous causal fast path — sliding-window / kv-pad / K-straddle / padding / provided-mask keep the single-token barrier.
- Re-enables `test_ring_mla_determinism` (drops the skip).

LLK change is mirrored on Blackhole + Wormhole; `overlap_first_half` is plumbed through the llk_api wrappers and `reduce_custom.h`. Also removes the now-dead `trigger_reduce` param from `blocked_matmul_and_pack`.

## Validation (Blackhole, QuietBox ring4)

- **Determinism:** `test_ring_mla_determinism` **PASS** under `TT_METAL_LLK_ASSERTS=1` (was FAIL).
- **Perf (10 samples each, vs `main`):** unchanged — mla_100k and kimi50k math-util are within run-to-run noise of `main` (distributions overlap; |Δ| ≤ ~0.1pp) and inside the `SDPA_PERF_CHECKS` gates. `main` is the *nondeterministic* baseline, so this buys determinism at no measurable perf cost.
- **Compile/regression:** `sparse_sdpa` unit tests pass (shared `blocked_matmul_and_pack`).

## Caveat

The Wormhole LLK edit is **code-identical** to Blackhole but unvalidated on this BH-only box — relying on WH CI + the full nightly determinism/accuracy suite.


## Test plan

CI dispatched on this branch (`skrstic/ring-mla-determinism-fix`):

| pipeline | covers | run |
|---|---|---|
| **bhpc** — Blackhole post-commit | BH unit / ops / smoke sanity | https://github.com/tenstorrent/tt-metal/actions/runs/28175579094 |
| **debug bhpc + LLK asserts** — Sanity nightly debug | the determinism repro under `TT_METAL_LLK_ASSERTS` (re-enabled `test_ring_mla_determinism`) | https://github.com/tenstorrent/tt-metal/actions/runs/28175587107 |
| **classic sanity** — Sanity nightly debug (no asserts) | general BH debug sanity | https://github.com/tenstorrent/tt-metal/actions/runs/28176997058 |
| **device perf (ops)** — Single-card device perf, `ops-perf-tests` | op-level device-perf regression | https://github.com/tenstorrent/tt-metal/actions/runs/28175594647 |
| **L2 nightly (sdpa)** | SDPA op test suite | https://github.com/tenstorrent/tt-metal/actions/runs/28175875093 |
| **T3K integration** | T3000 (Wormhole) integration — exercises the WH LLK mirror | https://github.com/tenstorrent/tt-metal/actions/runs/28175610707 |
| **T3K e2e** | T3000 (Wormhole) end-to-end | https://github.com/tenstorrent/tt-metal/actions/runs/28175619454 |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/ring-mla-determinism-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/ring-mla-determinism-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/ring-mla-determinism-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/ring-mla-determinism-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/ring-mla-determinism-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skrstic/ring-mla-determinism-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/ring-mla-determinism-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/ring-mla-determinism-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/ring-mla-determinism-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/ring-mla-determinism-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/ring-mla-determinism-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/ring-mla-determinism-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/ring-mla-determinism-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/ring-mla-determinism-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/ring-mla-determinism-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/ring-mla-determinism-fix)