### PR TITLE
Remove skip_for_BH and add op tests to L2 tests pipeline

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -83,6 +83,9 @@ ttnn:
     wh_n150_civ2: 1175
     wh_n300_civ2: 1175
     bh_p150b_civ2_viommu: 115
+  unit_tier3:
+    wh_n150: 10
+    bh_p150: 10
   e2e:
     wh_llmbox: 90
     wh_galaxy: 120

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -79,13 +79,10 @@ ttnn:
     wh_llmbox: 50
     wh_galaxy: 35
     bh_p100: 780
-    bh_p150b_civ2: 1035
-    wh_n150_civ2: 1175
+    bh_p150b_civ2: 1045
+    wh_n150_civ2: 1185
     wh_n300_civ2: 1175
     bh_p150b_civ2_viommu: 115
-  unit_tier3:
-    wh_n150: 10
-    bh_p150: 10
   e2e:
     wh_llmbox: 90
     wh_galaxy: 120

--- a/models/common/modules/moe/tt_moe_gate.py
+++ b/models/common/modules/moe/tt_moe_gate.py
@@ -42,7 +42,6 @@ import torch
 
 import ttnn
 from models.common.modules.moe.tt_moe_gate_config import TTMoEGateConfig
-from models.common.utility_functions import is_blackhole
 
 _TOKEN_SHAPE = (16, 16)  # 256 experts laid out as a 16×16 face per token
 _SHARD_SHAPE = (32, 32)  # one 32×32 tile per core (the op's per-token shard)
@@ -172,18 +171,6 @@ class TTMoEGate:
             raise ValueError(
                 f"generalized_moe_gate kernel op supports topk {_KERNEL_TOPK}; got {select_experts_k} "
                 "(this k should have taken the ttnn fallback)"
-            )
-        # Blackhole: the generalized_moe_gate KERNEL op has no Blackhole LLK (only tt_llk_wormhole_b0 ships
-        # llk_*generalized_moe_gate*; the compute API header has no ARCH_BLACKHOLE branch), so the n_group=1
-        # kernel path (k∈{4,6,8}, N≤512) does not build on BH. Fail here with a clear reason instead of a
-        # cryptic kernel-compile error deep in the op. EXEMPT (both run on BH): the grouped deepseek_moe_gate
-        # (n_group=8, which DOES ship a Blackhole LLK) and the arch-portable ttnn fallback (use_fallback).
-        if n_group == 1 and not use_fallback and is_blackhole():
-            raise NotImplementedError(
-                f"TTMoEGate: the generalized_moe_gate kernel op is Wormhole-only (no Blackhole LLK yet), so "
-                f"the n_group=1 kernel path (k={select_experts_k}, N={num_experts} ≤ 512) is unsupported on "
-                "Blackhole. Run on Wormhole/Galaxy, or use a config that takes the ttnn fallback "
-                "(k∉{4,6,8} or N>512). Pending a BH LLK port (tracked follow-up)."
             )
 
         self.mesh_device = mesh_device

--- a/models/common/tests/modules/moe/test_tt_moe_gate.py
+++ b/models/common/tests/modules/moe/test_tt_moe_gate.py
@@ -29,7 +29,6 @@ from loguru import logger
 import ttnn
 from models.common.modules.moe.tt_moe_gate import TTMoEGate
 from models.common.modules.moe.tt_moe_gate_config import TTMoEGateConfig
-from models.common.utility_functions import skip_for_blackhole
 from tests.ttnn.utils_for_testing import comp_pcc
 
 CONFIGS_DIR = Path(__file__).resolve().parents[3] / "modules/moe/configs"
@@ -41,13 +40,6 @@ def _config_id(path: Path) -> str:
     return path.stem
 
 
-@skip_for_blackhole(
-    # WH/Galaxy-only for now: the generalized_moe_gate kernel op (n_group=1, the majority of configs) has no
-    # Blackhole LLK yet — only tt_llk_wormhole_b0 ships it — so that path doesn't build on BH (TTMoEGate.__init__
-    # raises NotImplementedError there). The grouped deepseek_moe_gate (n_group=8) and the ttnn fallback DO run on
-    # BH; a BH-guarded subset covering just those can be added once the generalized BH LLK lands (tracked follow-up).
-    "generalized_moe_gate has no Blackhole LLK yet (WH-only); the n_group=1 kernel-op gate can't build on BH."
-)
 @pytest.mark.parametrize(
     # 4×8 = 32-chip mesh (TG/Galaxy). TTMoEGate is a PER-DEVICE gate (no cross-chip comms): its weight +
     # op buffers replicate to every chip, so each chip runs the same one-token-per-core routing independently.

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -679,16 +679,3 @@
       tier: 1
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
-
-- name: Generalized MoE gate op unit tests
-  cmd: pytest --timeout 600 models/common/tests/modules/moe/test_generalized_moe_gate.py
-  model: moe-gate
-  skus:
-    wh_n150:
-      timeout: 10
-      tier: 3
-    bh_p150:
-      timeout: 10
-      tier: 3
-  owner_id: U0A2EGX0Z29 # Ronnie Li
-  team: ttnn

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -687,9 +687,6 @@
     wh_n150:
       timeout: 10
       tier: 3
-    wh_n300:
-      timeout: 10
-      tier: 3
     bh_p150:
       timeout: 10
       tier: 3

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -679,3 +679,19 @@
       tier: 1
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+
+- name: Generalized MoE gate op unit tests
+  cmd: pytest --timeout 600 models/common/tests/modules/moe/test_generalized_moe_gate.py
+  model: moe-gate
+  skus:
+    wh_n150:
+      timeout: 10
+      tier: 3
+    wh_n300:
+      timeout: 10
+      tier: 3
+    bh_p150:
+      timeout: 10
+      tier: 3
+  owner_id: U0A2EGX0Z29 # Ronnie Li
+  team: ttnn

--- a/tests/pipeline_reorg/ops_unit_tests.yaml
+++ b/tests/pipeline_reorg/ops_unit_tests.yaml
@@ -109,6 +109,17 @@
   team: ttnn
   category: experimental
 
+- name: ttnn nightly experimental generalized MoE gate op tests
+  cmd: 'pytest models/common/tests/modules/moe/test_generalized_moe_gate.py -xv --timeout=600'
+  skus:
+    wh_n150_civ2:
+      timeout: 10
+    bh_p150b_civ2:
+      timeout: 10
+  owner_id: U0A2EGX0Z29 # Ronnie Li
+  team: ttnn
+  category: experimental
+
 - name: ttnn nightly pool tests
   cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/pool -xv -m "not disable_fast_runtime_mode" --timeout=600'
   skus:


### PR DESCRIPTION
### PR Category
Feature

### Summary
This PR builds a generalized MoEGate module for all the models listed in [#41132](https://github.com/tenstorrent/tt-metal/issues/41132), generalizing the existing optimized DeepSeek-V3 MoEGate to cover most of them.

### Features supported

1. Support generalized MoEGate module on BH.
2. Add generalized MoEGate op unit test to nightly tt-metal L2 tests.

This table lists how this op is generalized to each model and the perf time

| Model                            | Gate Operation Sequence                                                                           | Supported              | Notes                                                                                                                    | Wormhole Op (μs) | Wormhole Module (μs)                                                                      | Blackhole Op (μs) | Blackhole Module (μs) |
| -------------------------------- | ------------------------------------------------------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------- | ----------------------------------------------------------------------------------------- | ----------------- | --------------------- |
| **DeepSeek V3**                  | linear → sigmoid → add bias → grouped TopK (8 groups → top8 experts) → gather → normalize & scale | ✅ Yes                  | —                                                                                                                        | 3.74             | 77.17                                                                                     | 2.17              | 42.82                 |
| **GPT OSS**                      | linear → add bias → TopK → softmax                                                                | ✅ Yes                  | Optimized op already exists (53.68 μs vs. 64.7 μs base)                                                                  | 3.68             | 53.68                                                                                     | 2.28              | 31.74                 |
| **GLM-4.7**                      | linear → sigmoid → add bias → grouped TopK (1 group) → gather → normalize & scale                 | ✅ Yes                  | —                                                                                                                        | 4.20             | 66.48                                                                                     | 2.49              | 37.51                 |
| **GLM-5**                        | linear → sigmoid → add bias → grouped TopK (1 group) → gather → normalize & scale                 | ✅ Yes                  | —                                                                                                                        | 4.20             | 72.34                                                                                     | 2.48              | 40.19                 |
| **Kimi K2.5**                    | linear → sigmoid → add bias → grouped TopK (1 group, 384 experts) → gather → normalize & scale    | ✅ Yes                  | —                                                                                                                        | 12.63            | 92.78                                                                                     | 7.33              | 48.87                 |
| **Qwen 3.5 (MoE, 397B)**         | linear → softmax → TopK (512 experts, top10) → normalization                                      | ❌ No                   | Softmax + Top10 + 512 experts not natively supported; falls back to standard ttnn ops                                    | 294.21           | 397.44                                                                                    | 84.28             | 141.45                |
| **Qwen 3.5 35B-A3B**             | linear → softmax → TopK → normalization                                                           | ⚠️ Yes with workaround | Softmax is moved to the end of the op alongside normalization; mathematically equivalent but unverified with real inputs | 3.67             | 49.53                                                                                     | 2.28              | 29.27                 |
| **Qwen3 (MoE)**                  | linear → softmax → TopK → normalization                                                           | ⚠️ Yes with workaround | Softmax is moved to the end of the op alongside normalization; mathematically equivalent but unverified with real inputs | 3.69             | 60.51                                                                                     | 2.28              | 34.57                 |
| **DeepSeek OCR**                 | linear → softmax → TopK → normalize & scale                                                       | ⚠️ Yes with workaround | Softmax is moved to the end of the op alongside normalization; mathematically equivalent but unverified with real inputs | 3.71             | 44.25                                                                                     | 2.28              | 26.68                 |
| **Mistral Large 3**              | linear → TopK → softmax                                                                           | ✅ Yes                  | —                                                                                                                        | 3.69             | 76.89                                                                                     | 2.28              | 43.02                 |
| **Ling-MoE 1T**                  | linear → sigmoid → add bias → grouped TopK (8 groups → top8 experts) → gather → normalize & scale | ✅ Yes                  | —                                                                                                                        | 3.74             | 82.20                                                                                     | 2.18              | 45.20                 |
| **Qwen3-Omni 30B-A3B (thinker)** | linear → softmax → TopK → normalization                                                           | ⚠️ Yes with workaround | Softmax is moved to the end of the op alongside normalization; mathematically equivalent but unverified with real inputs | 3.68             | 49.38                                                                                     | 2.27              | 29.26                 |
| **Qwen3-Omni 30B-A3B (talker)**  | linear → softmax → TopK (6 chosen) → normalization                                                | ⚠️ Yes with workaround | Softmax is moved to the end of the op alongside normalization; mathematically equivalent but unverified with real inputs | 3.70             | 43.71                                                                                     | 2.29              | 26.06                 |
| **Gemma 4 26B-A4B**              | RMSNorm → scale → linear → softmax → TopK → normalize & scale                                     | ⚠️ Yes with workaround | Softmax moved to end; initial RMSNorm/scaling and per-expert post-scaling not natively supported by the module           | 3.68             | 53.25   (Note: This time only covers from linear to normalize, excluding the final scale) | 2.28              | 31.46                 |
| **DeepSeek V4 Pro**              | linear → sqrtsoftplus → add bias → TopK → gather → normalize & scale                              | ⚠️ Yes with workaround | sqrtsoftplus is handled via a separate op within the module                                                              | 11.35            | 100.80                                                                                    | 6.82              | 54.80                 |
| **DeepSeek V4 Flash**            | linear → sqrtsoftplus → add bias → TopK → gather → normalize & scale                              | ⚠️ Yes with workaround | sqrtsoftplus is handled via a separate op within the module                                                              | 3.61             | 70.58                                                                                     | 2.24              | 40.66                 |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ronnie/generalize_moe_gate_BH_module)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ronnie/generalize_moe_gate_BH_module)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ronnie/generalize_moe_gate_BH_module)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ronnie/generalize_moe_gate_BH_module)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ronnie/generalize_moe_gate_BH_module)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ronnie/generalize_moe_gate_BH_module)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ronnie/generalize_moe_gate_BH_module)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ronnie/generalize_moe_gate_BH_module)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ronnie/generalize_moe_gate_BH_module)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ronnie/generalize_moe_gate_BH_module)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ronnie/generalize_moe_gate_BH_module)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ronnie/generalize_moe_gate_BH_module)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ronnie/generalize_moe_gate_BH_module)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ronnie/generalize_moe_gate_BH_module)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ronnie/generalize_moe_gate_BH_module)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ronnie/generalize_moe_gate_BH_module)

Note that the failing test case also failed on main branch