### PR TITLE
[Bug fix/Workaround] Workaround for trisc reset deassert race

### DIFF
--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -101,6 +101,8 @@ void invalidate_trisc_instruction_cache() {
 }
 
 void deassert_trisc() {
+    // Temporary workaround due to race vs. host deasserting TRISC reset.
+    // https://github.com/tenstorrent/tt-metal/issues/48064
     assert_trisc_reset();
     subordinate_sync->allNeo0 = RUN_SYNC_MSG_ALL_INIT;
     subordinate_sync->allNeo1 = RUN_SYNC_MSG_ALL_INIT;

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -101,6 +101,7 @@ void invalidate_trisc_instruction_cache() {
 }
 
 void deassert_trisc() {
+    assert_trisc_reset();
     subordinate_sync->allNeo0 = RUN_SYNC_MSG_ALL_INIT;
     subordinate_sync->allNeo1 = RUN_SYNC_MSG_ALL_INIT;
     subordinate_sync->allNeo2 = RUN_SYNC_MSG_ALL_INIT;

--- a/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
@@ -117,6 +117,12 @@ inline void assert_trisc_reset() {
     uint32_t soft_reset_0 = READ_REG(NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_SOFT_RESET_0_REG_ADDR);
     uint32_t trisc_reset_mask = T6_DEBUG_REGS_SOFT_RESET_0_RISC_CONTROL_SOFT_RESET_MASK;
     WRITE_REG(NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_SOFT_RESET_0_REG_ADDR, soft_reset_0 | trisc_reset_mask);
+    soft_reset_0 = READ_REG(NEO_REGS_1__LOCAL_REGS_DEBUG_REGS_SOFT_RESET_0_REG_ADDR);
+    WRITE_REG(NEO_REGS_1__LOCAL_REGS_DEBUG_REGS_SOFT_RESET_0_REG_ADDR, soft_reset_0 | trisc_reset_mask);
+    soft_reset_0 = READ_REG(NEO_REGS_2__LOCAL_REGS_DEBUG_REGS_SOFT_RESET_0_REG_ADDR);
+    WRITE_REG(NEO_REGS_2__LOCAL_REGS_DEBUG_REGS_SOFT_RESET_0_REG_ADDR, soft_reset_0 | trisc_reset_mask);
+    soft_reset_0 = READ_REG(NEO_REGS_3__LOCAL_REGS_DEBUG_REGS_SOFT_RESET_0_REG_ADDR);
+    WRITE_REG(NEO_REGS_3__LOCAL_REGS_DEBUG_REGS_SOFT_RESET_0_REG_ADDR, soft_reset_0 | trisc_reset_mask);
 }
 
 inline void deassert_trisc_reset() {


### PR DESCRIPTION
### PR Category
Workaround for bug #48064 

### Summary
There is currently an incorrect sequence in deasserting trisc resets:

1. UMD asserts reset on all cores, including triscs (correct behaviour)
2. UMD deasserts reset on all cores, including triscs.
3. DM0 sets trisc status to INIT, then deasserts reset on triscs. If triscs have already been deasserted by UMD, they miss the INIT signal

Workaround in this change:
In step 3, DM0 asserts trisc reset, sets trisc status to INIT, deasserts trisc reset

Proper fix:
In step 2, UMD should only deassert reset on DM & DM uncore. However, when this change is made in emulation environment, DM0 in step 3 is not able to deassert trisc reset successfully. Making this proper fix is tracked in #48064 

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kstevens/trisc_reset_workaround)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kstevens/trisc_reset_workaround)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kstevens/trisc_reset_workaround)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kstevens/trisc_reset_workaround)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kstevens/trisc_reset_workaround)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kstevens/trisc_reset_workaround)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kstevens/trisc_reset_workaround)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kstevens/trisc_reset_workaround)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kstevens/trisc_reset_workaround)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kstevens/trisc_reset_workaround)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kstevens/trisc_reset_workaround)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kstevens/trisc_reset_workaround)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kstevens/trisc_reset_workaround)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kstevens/trisc_reset_workaround)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kstevens/trisc_reset_workaround)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kstevens/trisc_reset_workaround)