### PR TITLE
[Test Only] Fix LLK assert sanity coverage

### DIFF
--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_flash_mla.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_flash_mla.py
@@ -12,11 +12,10 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.common.utility_functions import comp_pcc, is_blackhole, is_watcher_enabled, skip_with_llk_assert
+from models.common.utility_functions import comp_pcc, is_blackhole, is_watcher_enabled
 from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import FlashMLADecode
 
 
-@skip_with_llk_assert("Hit LLK_ASSERT for unpacker configuration verification. Issue: #39472")
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize(
     "decode_position",

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_sampling.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_sampling.py
@@ -9,7 +9,7 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.common.utility_functions import is_blackhole, skip_with_llk_assert
+from models.common.utility_functions import is_blackhole
 from models.demos.deepseek_v3_b1.micro_ops.sampling.op import SamplingOp
 from models.demos.deepseek_v3_b1.utils import float_to_uint32
 
@@ -261,7 +261,6 @@ def _run_sampling_argmax_single_device_101_cores(device, seed: int, final_core_i
     )
 
 
-@skip_with_llk_assert("Hit LLK_ASSERT in sampling kernel. Issue: #47805")
 @pytest.mark.parametrize(
     "seed, final_core_idx",
     [

--- a/models/demos/deepseek_v3_b1/unified_kernels/sampling.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/sampling.hpp
@@ -351,7 +351,7 @@ void trisc_fused_softmax_top_p_sampling_block() {
         pack_tile(0, probs_cb);
         cb_push_back(probs_cb, 1);
         tile_regs_release();
-        reconfig_data_format_srca(exp_cb, probs_cb);
+        reconfig_data_format_srca<false, true>(exp_cb, probs_cb);
         cb_wait_front(probs_cb, 1);
         cb_wait_front(p_cb, 1);
         tile_regs_acquire();
@@ -453,7 +453,7 @@ void trisc_fused_softmax_top_p_sampling_block() {
         recip_tile_init();
         MATH((sampling_recip_tile_scalar(0)));
     }
-    // Step 19: Compute DST[6] = cumsum * 1/cum_kept (rescaled CDF over the kept set).
+    // Step 19: Compute DST[2] = cumsum * 1/cum_kept (rescaled CDF over the kept set).
     // SrcA reads out_cb (Step 15's T(cumsum)), SrcB scalar comes from
     // DST[0] (Step 18.75's recomputed 1/cum_kept).
     // NOTE: rescaled_cumsum_i = cumsum(softmax_out_i, dim=0) * 1/cum_kept
@@ -467,7 +467,7 @@ void trisc_fused_softmax_top_p_sampling_block() {
             EltwiseBinaryType::ELWMUL,
             /*num_tiles=*/1,
             MathFidelity::HiFi4,
-            /*clear_dest=*/false>(out_cb, /*in_tile=*/0, /*src=*/0, /*dst=*/6);
+            /*clear_dest=*/false>(out_cb, /*in_tile=*/0, /*src=*/0, /*dst=*/2);
     }
     // Step 20: DST[1] = rand (column-0 broadcast staged by BRISC into rand_bcast_cb).
     copy_tile_to_dst_init_short(rand_bcast_cb);
@@ -476,7 +476,7 @@ void trisc_fused_softmax_top_p_sampling_block() {
     {
         DeviceZoneScopedN("SP-TOPP-TRISC-15");
         ge_binary_tile_init();
-        MATH((sampling_ge_binary_tile_first_column(6, 1, 2)));
+        MATH((sampling_ge_binary_tile_first_column(2, 1, 2)));
         tile_regs_commit();
     }
     tile_regs_wait();
@@ -543,6 +543,7 @@ void run_top32_llk(uint32_t row_elements, uint32_t num_input_tiles, uint32_t pha
     tile_regs_acquire();
 
     uint32_t num_faces = 4;
+    PACK((void)num_faces);
     reconfig_data_format_srca(in_scores_cb);
     UNPACK((llk_unpack_A_top32_rm_init(in_scores_cb)));
     UNPACK((llk_unpack_A_top32_rm(in_scores_cb, 0, num_faces)));
@@ -601,6 +602,7 @@ void run_top32_llk(uint32_t row_elements, uint32_t num_input_tiles, uint32_t pha
             num_faces = 4;
         }
 
+        PACK((void)num_faces);
         reconfig_data_format_srca(in_scores_cb);
         UNPACK((llk_unpack_A_top32_rm_init(in_scores_cb)));
         UNPACK((llk_unpack_A_top32_rm(in_scores_cb, i / 64, num_faces)));
@@ -676,12 +678,15 @@ void run_top32_llk(uint32_t row_elements, uint32_t num_input_tiles, uint32_t pha
     // 16 rows (32 elements total) for the topk output, which requires
     // pack_reads_per_xy_plane = FACE_R_DIM = 16 so the tile position generator counts
     // 16 rows before resetting. Save FACE_R_DIM here and restore 1 after pack_tile.
+    ckernel::pack_reconfig_data_format(out_scores_cb);
     PACK((cfg_reg_rmw_tensix<PACK_COUNTERS_SEC0_pack_reads_per_xy_plane_RMW>(FACE_R_DIM)));
     PACK(TTI_SETADCXX(p_setadc::PAC, 1 - 1, 0x0));
-
-    ckernel::pack_reconfig_data_format(out_scores_cb);
     ckernel::pack_tile(value_offset_tiles, out_scores_cb);
+    PACK((cfg_reg_rmw_tensix<PACK_COUNTERS_SEC0_pack_reads_per_xy_plane_RMW>(1)));
+
     ckernel::pack_reconfig_data_format(out_indices_cb);
+    PACK((cfg_reg_rmw_tensix<PACK_COUNTERS_SEC0_pack_reads_per_xy_plane_RMW>(FACE_R_DIM)));
+    PACK(TTI_SETADCXX(p_setadc::PAC, 1 - 1, 0x0));
     ckernel::pack_tile(index_offset_tiles, out_indices_cb);
     PACK(TTI_SETADCXX(p_setadc::PAC, FACE_C_DIM - 1, 0x0));
     PACK((cfg_reg_rmw_tensix<PACK_COUNTERS_SEC0_pack_reads_per_xy_plane_RMW>(1)));
@@ -785,6 +790,7 @@ void run_top32_llk_presorted_1024_opt(uint32_t row_elements, uint32_t num_input_
 
     // Steps 7-9: handle trailing (<1024) values in 64-element chunks.
     uint32_t num_faces = 4;
+    PACK((void)num_faces);
     for (uint32_t i = num_chunks * chunk_size; i < row_elements; i += 64) {
         num_faces = (i + 64 > row_elements) ? 2 : 4;
 
@@ -853,12 +859,15 @@ void run_top32_llk_presorted_1024_opt(uint32_t row_elements, uint32_t num_input_
     // 16 rows (32 elements total) for the topk output, which requires
     // pack_reads_per_xy_plane = FACE_R_DIM = 16 so the tile position generator counts
     // 16 rows before resetting. Save FACE_R_DIM here and restore 1 after pack_tile.
+    ckernel::pack_reconfig_data_format(out_scores_cb);
     PACK((cfg_reg_rmw_tensix<PACK_COUNTERS_SEC0_pack_reads_per_xy_plane_RMW>(FACE_R_DIM)));
     PACK(TTI_SETADCXX(p_setadc::PAC, 1 - 1, 0x0));
-
-    ckernel::pack_reconfig_data_format(out_scores_cb);
     ckernel::pack_tile(value_offset_tiles, out_scores_cb);
+    PACK((cfg_reg_rmw_tensix<PACK_COUNTERS_SEC0_pack_reads_per_xy_plane_RMW>(1)));
+
     ckernel::pack_reconfig_data_format(out_indices_cb);
+    PACK((cfg_reg_rmw_tensix<PACK_COUNTERS_SEC0_pack_reads_per_xy_plane_RMW>(FACE_R_DIM)));
+    PACK(TTI_SETADCXX(p_setadc::PAC, 1 - 1, 0x0));
     ckernel::pack_tile(index_offset_tiles, out_indices_cb);
 
     PACK(TTI_SETADCXX(p_setadc::PAC, FACE_C_DIM - 1, 0x0));

--- a/tests/ttnn/unit_tests/operations/fused/test_layer_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_layer_norm.py
@@ -169,9 +169,7 @@ def test_layer_norm_with_weight_and_bias_row_major(device, h, w, use_welford):
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 def test_layer_norm_with_weight_bias_and_residual_input(device, h, w, use_welford, dtype):
     if is_blackhole() and is_llk_assert_enabled() and not use_welford and w == 4096:
-        pytest.skip(
-            "Large FP32 residual layer norm fails numeric checks on Blackhole with LLK asserts enabled. Issue #48065."
-        )
+        pytest.skip("Residual layer norm fails numeric checks on Blackhole with LLK asserts enabled. Issue #48065.")
 
     torch.manual_seed(0)
 
@@ -413,7 +411,7 @@ def test_large_layer_norm_with_legacy_reduction_and_rsqrt(device, h, w, legacy_r
 def test_large_layer_norm_with_weight_bias_and_residual_input(device, h, w, use_welford, dtype):
     if is_blackhole() and is_llk_assert_enabled() and (h, w) in ((32, 3232), (19, 4083), (1001, 4083)):
         pytest.skip(
-            "Large FP32 residual layer norm fails numeric checks on Blackhole with LLK asserts enabled. Issue #48065."
+            "Large residual layer norm fails numeric checks on Blackhole with LLK asserts enabled. Issue #48065."
         )
 
     torch.manual_seed(3333)

--- a/tests/ttnn/unit_tests/operations/fused/test_layer_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_layer_norm.py
@@ -548,11 +548,10 @@ def test_layer_norm_with_padding(device, h, w, use_welford, dtype):
     assert_output_accuracy(golden_output, output_ttnn)
 
 
-def test_layer_norm_inputs_requires_input_tensor():
+def test_layer_norm_inputs_requires_input_tensor(expect_error):
     """``LayerNormInputs()`` without an input tensor must raise."""
-    import pytest
 
-    with pytest.raises(TypeError):
+    with expect_error(TypeError, "."):
         ttnn.LayerNormInputs()
 
 

--- a/tests/ttnn/unit_tests/operations/fused/test_layer_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_layer_norm.py
@@ -169,10 +169,9 @@ def test_layer_norm_with_weight_and_bias_row_major(device, h, w, use_welford):
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 def test_layer_norm_with_weight_bias_and_residual_input(device, h, w, use_welford, dtype):
     if is_blackhole() and is_llk_assert_enabled() and not use_welford and w == 4096:
-        if dtype == torch.bfloat16 and h in (24, 32, 2048):
-            pytest.skip("Large BF16 residual layer norm fails numeric checks on Blackhole with LLK asserts enabled.")
-        if dtype == torch.float32 and h in (32, 2048):
-            pytest.skip("Large FP32 residual layer norm fails numeric checks on Blackhole with LLK asserts enabled.")
+        pytest.skip(
+            "Large FP32 residual layer norm fails numeric checks on Blackhole with LLK asserts enabled. Issue #48065."
+        )
 
     torch.manual_seed(0)
 
@@ -412,11 +411,10 @@ def test_large_layer_norm_with_legacy_reduction_and_rsqrt(device, h, w, legacy_r
 @pytest.mark.parametrize("use_welford", [True, False])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 def test_large_layer_norm_with_weight_bias_and_residual_input(device, h, w, use_welford, dtype):
-    if is_blackhole() and is_llk_assert_enabled() and not use_welford:
-        if dtype == torch.bfloat16 and (h, w) in ((32, 3232), (19, 4083), (1001, 4083)):
-            pytest.skip("Large BF16 residual layer norm fails numeric checks on Blackhole with LLK asserts enabled.")
-        if dtype == torch.float32 and (h, w) in ((32, 3232), (19, 4083), (1001, 4083)):
-            pytest.skip("Large FP32 residual layer norm fails numeric checks on Blackhole with LLK asserts enabled.")
+    if is_blackhole() and is_llk_assert_enabled() and (h, w) in ((32, 3232), (19, 4083), (1001, 4083)):
+        pytest.skip(
+            "Large FP32 residual layer norm fails numeric checks on Blackhole with LLK asserts enabled. Issue #48065."
+        )
 
     torch.manual_seed(3333)
 

--- a/tests/ttnn/unit_tests/operations/fused/test_layer_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_layer_norm.py
@@ -2,14 +2,14 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
+from dataclasses import dataclass
 
+import pytest
 import torch
 
 import ttnn
-
+from models.common.utility_functions import is_blackhole, is_llk_assert_enabled
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
-from dataclasses import dataclass
 
 pytestmark = pytest.mark.use_module_device
 
@@ -168,6 +168,12 @@ def test_layer_norm_with_weight_and_bias_row_major(device, h, w, use_welford):
 @pytest.mark.parametrize("use_welford", [True, False])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 def test_layer_norm_with_weight_bias_and_residual_input(device, h, w, use_welford, dtype):
+    if is_blackhole() and is_llk_assert_enabled() and not use_welford and w == 4096:
+        if dtype == torch.bfloat16 and h in (24, 32, 2048):
+            pytest.skip("Large BF16 residual layer norm fails numeric checks on Blackhole with LLK asserts enabled.")
+        if dtype == torch.float32 and h in (32, 2048):
+            pytest.skip("Large FP32 residual layer norm fails numeric checks on Blackhole with LLK asserts enabled.")
+
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((h, w), dtype=dtype)
@@ -406,6 +412,12 @@ def test_large_layer_norm_with_legacy_reduction_and_rsqrt(device, h, w, legacy_r
 @pytest.mark.parametrize("use_welford", [True, False])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 def test_large_layer_norm_with_weight_bias_and_residual_input(device, h, w, use_welford, dtype):
+    if is_blackhole() and is_llk_assert_enabled() and not use_welford:
+        if dtype == torch.bfloat16 and (h, w) in ((32, 3232), (19, 4083), (1001, 4083)):
+            pytest.skip("Large BF16 residual layer norm fails numeric checks on Blackhole with LLK asserts enabled.")
+        if dtype == torch.float32 and (h, w) in ((32, 3232), (19, 4083), (1001, 4083)):
+            pytest.skip("Large FP32 residual layer norm fails numeric checks on Blackhole with LLK asserts enabled.")
+
     torch.manual_seed(3333)
 
     torch_input_tensor = torch.rand((h, w), dtype=dtype)

--- a/tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py
@@ -2,11 +2,12 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import ttnn
 import math
+
 import pytest
+
+import ttnn
 from tests.ttnn.nightly.unit_tests.operations.pool.test_maxpool2d import run_max_pool2d
-from models.common.utility_functions import skip_with_llk_assert
 
 
 # Cache map used for torch tensor reuse - the tensor will not be generated if a tensor of the same dimensions has already been generated
@@ -135,7 +136,6 @@ parameters = {
 }
 
 
-@skip_with_llk_assert("Hit LLK_ASSERT for unpacker configuration verification. Issue: #39448")
 @pytest.mark.parametrize("input_spec", parameters["dram_slice_tests"]["input_specs"])
 @pytest.mark.parametrize("in_specs", parameters["dram_slice_tests"]["in_specs"])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
@@ -191,7 +191,6 @@ def test_max_pool2d_dram_slice(device, in_specs, input_spec):
     )
 
 
-@skip_with_llk_assert("Hit LLK_ASSERT for unpacker configuration verification. Issue: #39448")
 @pytest.mark.parametrize("input_spec", parameters["height_shard_tests"]["input_specs"])
 @pytest.mark.parametrize("in_dtype", parameters["height_shard_tests"]["in_dtype"])
 def test_max_pool2d_height_shard(device, in_dtype, input_spec, tensor_map):
@@ -227,7 +226,6 @@ def test_max_pool2d_height_shard(device, in_dtype, input_spec, tensor_map):
     )
 
 
-@skip_with_llk_assert("Hit LLK_ASSERT for unpacker configuration verification. Issue: #39448")
 @pytest.mark.parametrize("input_spec", parameters["width_shard_tests"]["input_specs"])
 @pytest.mark.parametrize("in_dtype", parameters["width_shard_tests"]["in_dtype"])
 def test_max_pool2d_width_shard(device, in_dtype, input_spec, tensor_map):
@@ -263,7 +261,6 @@ def test_max_pool2d_width_shard(device, in_dtype, input_spec, tensor_map):
     )
 
 
-@skip_with_llk_assert("Hit LLK_ASSERT for unpacker configuration verification. Issue: #39448")
 @pytest.mark.parametrize("input_spec", parameters["block_shard_tests"]["input_specs"])
 @pytest.mark.parametrize("in_dtype", parameters["block_shard_tests"]["in_dtype"])
 def test_max_pool2d_block_shard(device, in_dtype, input_spec, tensor_map):
@@ -299,7 +296,6 @@ def test_max_pool2d_block_shard(device, in_dtype, input_spec, tensor_map):
     )
 
 
-@skip_with_llk_assert("Hit LLK_ASSERT for unpacker configuration verification. Issue: #39448")
 @pytest.mark.parametrize("input_spec", parameters["out_mem_config_tests"]["input_specs"])
 @pytest.mark.parametrize("in_dtype", parameters["out_mem_config_tests"]["in_dtype"])
 @pytest.mark.parametrize("out_memory_config", [ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG])
@@ -337,7 +333,6 @@ def test_max_pool2d_mem_config(device, in_dtype, input_spec, out_memory_config, 
     )
 
 
-@skip_with_llk_assert("Hit LLK_ASSERT for unpacker configuration verification. Issue: #39448")
 @pytest.mark.parametrize("input_spec", parameters["tiled_out_tests"]["input_specs"])
 @pytest.mark.parametrize("in_dtype", parameters["tiled_out_tests"]["in_dtype"])
 @pytest.mark.parametrize("out_dtype", parameters["tiled_out_tests"]["out_dtype"])
@@ -378,7 +373,6 @@ def test_max_pool2d_tiled_out(device, in_dtype, input_spec, out_dtype, tensor_ma
     )
 
 
-@skip_with_llk_assert("Hit LLK_ASSERT for unpacker configuration verification. Issue: #39448")
 @pytest.mark.parametrize("input_spec", parameters["in_mem_config_tests"]["input_specs"])
 @pytest.mark.parametrize("cores", parameters["in_mem_config_tests"]["cores"])
 def test_max_pool2d_in_mem_config(device, input_spec, cores, tensor_map):


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Fixes #47805.

Relates to #39448, #39472, and #48065.

This branch fixes the DeepSeek v3 B1 sampling LLK assert failure, then removes the corresponding `skip_with_llk_assert` coverage skips from the sampling test. It also removes LLK-assert skips from the flash MLA and maxpool2d tests that now run under the LLK-assert sanity configuration.

For fused layer norm residual-input cases that still fail numeric checks on Blackhole with LLK asserts enabled, this PR adds targeted skips that point at the new tracking issue #48065.

Started validation run:

- https://github.com/tenstorrent/tt-metal/actions/runs/28180676087
- https://github.com/tenstorrent/tt-metal/actions/runs/28235183688
- Workflow: Sanity tests nightly debug run with LLK asserts

### Notes for reviewers
Review focus should be on the sampling LLK fix in `models/demos/deepseek_v3_b1/unified_kernels/sampling.hpp` and whether the remaining fused layer norm skips are scoped narrowly enough for #48065.

The local working tree has untracked debug artifacts (`assert.txt`, `test.txt`) that are intentionally not part of this PR.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/fix_nightly_sanity_with_llk_asserts_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/fix_nightly_sanity_with_llk_asserts_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/fix_nightly_sanity_with_llk_asserts_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/fix_nightly_sanity_with_llk_asserts_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/fix_nightly_sanity_with_llk_asserts_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/fix_nightly_sanity_with_llk_asserts_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/fix_nightly_sanity_with_llk_asserts_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/fix_nightly_sanity_with_llk_asserts_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/fix_nightly_sanity_with_llk_asserts_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/fix_nightly_sanity_with_llk_asserts_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/fix_nightly_sanity_with_llk_asserts_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/fix_nightly_sanity_with_llk_asserts_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/fix_nightly_sanity_with_llk_asserts_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/fix_nightly_sanity_with_llk_asserts_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/fix_nightly_sanity_with_llk_asserts_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/fix_nightly_sanity_with_llk_asserts_2)