### PR TITLE
[Metal 2.0] Inline RtaName key for runtime-arg names (-17% spec-as-key dispatch)

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
@@ -28,6 +28,7 @@
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <chrono>
 #include <optional>
 
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
@@ -841,8 +842,8 @@ TEST_F(ProgramRunArgsTestQuasar, MultiNode_MissingOneNodeFails) {
 inline ProgramSpec MakeSpecWithNamedArgs(
     const NodeCoord& node, const std::vector<std::string>& named_rtas, const std::vector<std::string>& named_crtas) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
-    spec.kernels[0].runtime_arg_schema.runtime_arg_names = named_rtas;
-    spec.kernels[0].runtime_arg_schema.common_runtime_arg_names = named_crtas;
+    spec.kernels[0].runtime_arg_schema.runtime_arg_names.assign(named_rtas.begin(), named_rtas.end());
+    spec.kernels[0].runtime_arg_schema.common_runtime_arg_names.assign(named_crtas.begin(), named_crtas.end());
     (void)node;  // node inherited from MakeMinimalValidProgramSpec (0,0)
     return spec;
 }
@@ -2460,6 +2461,125 @@ TEST(MergeProgramRunArgs, AppendsDistinctKernel) {
     ProgramRunArgs merged = MergeProgramRunArgs(std::move(a), rest);
     EXPECT_NE(FindKernel(merged, "dm_kernel"), nullptr);
     EXPECT_NE(FindKernel(merged, "compute_kernel"), nullptr);
+}
+
+// DISABLED micro-benchmark (not a correctness test): times the host-side ProgramRunArgs update entry
+// points on a deliberately fat spec; the signal is the relative before/after on the same Release binary.
+//   <test_binary> --gtest_also_run_disabled_tests --gtest_filter='*FastPathBench*'
+TEST_F(ProgramRunArgsTestGen1, DISABLED_FastPathBench_UpdateEntryPoints) {
+    // Env-configurable so a sweep can vary one knob at a time; unset => the standard fat spec.
+    // Knobs: TT_BENCH_{RTAS,CRTAS,BINDINGS,NODES,ITERS}.
+    auto env_size = [](const char* name, size_t dflt) -> size_t {
+        const char* v = std::getenv(name);
+        return (v != nullptr && *v != '\0') ? static_cast<size_t>(std::stoul(v)) : dflt;
+    };
+    const size_t kNumNamedRTAs = env_size("TT_BENCH_RTAS", 16);
+    const size_t kNumNamedCRTAs = env_size("TT_BENCH_CRTAS", 8);
+    const size_t kNumBindings = env_size("TT_BENCH_BINDINGS", 8);
+    const size_t kIters = env_size("TT_BENCH_ITERS", 20000);
+
+    const CoreCoord grid = mesh_device_->compute_with_storage_grid_size();
+    const size_t grid_count = static_cast<size_t>(grid.x) * static_cast<size_t>(grid.y);
+    const size_t num_nodes = std::min(env_size("TT_BENCH_NODES", grid_count), grid_count);
+    // First `num_nodes` device cores in row-major order, as a set of single-core ranges, so the
+    // node count can be swept independently of the (rectangular) device grid shape.
+    std::vector<NodeCoord> nodes;
+    std::set<NodeRange> node_ranges;
+    for (size_t i = 0; i < num_nodes; ++i) {
+        const NodeCoord c{i % grid.x, i / grid.x};
+        nodes.push_back(c);
+        node_ranges.insert(NodeRange{c, c});
+    }
+    const NodeRangeSet all_nodes(node_ranges);
+
+    // Gen1 (WH) spec: DM producer + compute consumer + DFB. All per-enqueue state lives on the DM
+    // kernel (kernels[0]) -- tensor bindings on a compute kernel are rejected by a temporary guard.
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    auto& dm = spec.kernels[0];  // "dm_kernel"
+
+    std::vector<std::string> rta_names;
+    std::vector<std::string> crta_names;
+    for (size_t i = 0; i < kNumNamedRTAs; ++i) {
+        rta_names.push_back("rta_" + std::to_string(i));
+    }
+    for (size_t i = 0; i < kNumNamedCRTAs; ++i) {
+        crta_names.push_back("crta_" + std::to_string(i));
+    }
+    dm.runtime_arg_schema.runtime_arg_names.assign(rta_names.begin(), rta_names.end());
+    dm.runtime_arg_schema.common_runtime_arg_names.assign(crta_names.begin(), crta_names.end());
+
+    std::vector<TensorParameter> tparams;
+    for (size_t i = 0; i < kNumBindings; ++i) {
+        const auto name = "tensor_" + std::to_string(i);
+        tparams.push_back(MakeMinimalTensorParameter(name));
+        BindTensorParameterToKernel(dm, name, "acc_" + std::to_string(i));
+    }
+    spec.tensor_parameters = tparams;
+
+    // Place the work unit across the full device grid (per-node RTAs are the dominant cost).
+    spec.work_units = {MakeMinimalWorkUnit("wu", all_nodes, {"dm_kernel", "compute_kernel"})};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    // ---- Allocate backing tensors (stable addresses; outlive the loop) ----
+    std::vector<MeshTensor> tensors;
+    tensors.reserve(tparams.size());
+    for (const auto& tp : tparams) {
+        tensors.push_back(AllocateTensorForBinding(*mesh_device_, tp));
+    }
+
+    // ---- Build full ProgramRunArgs (DM-kernel named args for every node) ----
+    ProgramRunArgs params;
+    ProgramRunArgs::KernelRunArgs dm_args;
+    dm_args.kernel = KernelSpecName{"dm_kernel"};
+    for (const auto& node : nodes) {
+        ProgramRunArgs::KernelRunArgs::RuntimeArgValues vals;
+        for (size_t i = 0; i < kNumNamedRTAs; ++i) {
+            vals[rta_names[i]] = static_cast<uint32_t>(i + 1);
+        }
+        dm_args.runtime_arg_values.push_back(
+            ProgramRunArgs::KernelRunArgs::NodeRuntimeArgs{node, std::move(vals)});
+    }
+    for (size_t i = 0; i < kNumNamedCRTAs; ++i) {
+        dm_args.common_runtime_arg_values[crta_names[i]] = static_cast<uint32_t>(i + 1);
+    }
+    params.kernel_run_args.push_back(std::move(dm_args));
+    // compute_kernel has an empty RTA/CRTA schema and is legitimately omitted from kernel_run_args.
+
+    for (size_t i = 0; i < tparams.size(); ++i) {
+        params.tensor_args.insert({tparams[i].unique_id, TensorArgument{tensors[i]}});
+    }
+
+    // Tensor-only args for the UpdateTensorArgs path.
+    Table<TensorParamName, TensorArgument> tensor_only_args;
+    for (size_t i = 0; i < tparams.size(); ++i) {
+        tensor_only_args.insert({tparams[i].unique_id, TensorArgument{tensors[i]}});
+    }
+
+    auto bench = [](const char* label, size_t iters, auto&& fn) {
+        fn();  // warm-up: first-invocation buffer allocation happens here, off the clock
+        const auto t0 = std::chrono::steady_clock::now();
+        for (size_t i = 0; i < iters; ++i) {
+            fn();
+        }
+        const auto t1 = std::chrono::steady_clock::now();
+        const double ns = std::chrono::duration<double, std::nano>(t1 - t0).count() / static_cast<double>(iters);
+        std::cout << "[FASTPATH_BENCH] " << label << ": " << ns << " ns/call" << std::endl;
+    };
+
+    std::cout << "[FASTPATH_BENCH] spec: " << num_nodes << " nodes, " << kNumNamedRTAs << " RTAs, " << kNumNamedCRTAs
+              << " CRTAs, " << tparams.size() << " tensor bindings, " << kIters << " iters" << std::endl;
+
+    bench("SetProgramRunArgs    (skip_validation=true) ", kIters, [&] {
+        SetProgramRunArgs(program, params, /*skip_validation=*/true);
+    });
+    bench("SetProgramRunArgs    (skip_validation=false)", kIters, [&] {
+        SetProgramRunArgs(program, params, /*skip_validation=*/false);
+    });
+    bench("UpdateProgramRunArgs (skip_validation=true) ", kIters, [&] {
+        UpdateProgramRunArgs(program, params, /*skip_validation=*/true);
+    });
+    bench("UpdateTensorArgs     (validation always on) ", kIters, [&] { UpdateTensorArgs(program, tensor_only_args); });
 }
 
 }  // namespace

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
@@ -105,7 +105,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramSh
 
     KernelSpec::CompileTimeArgs cta_bindings(reader_compile_args);
 
-    std::vector<std::string> named_rtas = {"src_addr", "l1_addr"};
+    std::vector<tt::tt_metal::experimental::RtaName> named_rtas = {"src_addr", "l1_addr"};
 
     KernelSpec reader_spec{
         .unique_id = KernelSpecName{"reader"},

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -359,7 +359,7 @@ void run_single_core_reduce_program(
     std::string reader_kernel_path;
     experimental::KernelSpec::CompileTimeArgs reader_cta_bindings;
     experimental::KernelSpec::CompilerOptions::Defines reader_defines;
-    std::vector<std::string> reader_runtime_arg_names;
+    std::vector<tt::tt_metal::experimental::RtaName> reader_runtime_arg_names;
     if (test_config.reduce_dim == ReduceDim::H) {
         reader_kernel_path = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_transpose_wh_interleaved.cpp";
         bfloat16 bfloat_scaler_value = bfloat16(scaler);

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
+#include <tt-metalium/experimental/metal2_host_api/runtime_arg_name.hpp>
 #include <tt-metalium/experimental/metal2_host_api/utility/group.hpp>
 #include <tt-metalium/experimental/metal2_host_api/utility/table.hpp>
 #include <tt_stl/strong_type.hpp>
@@ -54,8 +55,8 @@ struct KernelAdvancedOptions {
     //
     // CAUTION: This feature is unsafe if used incorrectly! The onus is on the programmer
     // to ensure that the designated arguments remain valid across enqueues.
-    Group<std::string> enqueue_invariant_runtime_args;
-    Group<std::string> enqueue_invariant_common_runtime_args;
+    Group<RtaName> enqueue_invariant_runtime_args;
+    Group<RtaName> enqueue_invariant_common_runtime_args;
 
     ////////////////////////////////////////////////////////////////////////////////
     // Varargs

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -16,6 +16,7 @@
 #include <tt-metalium/experimental/metal2_host_api/data_movement_hardware_config.hpp>
 #include <tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
+#include <tt-metalium/experimental/metal2_host_api/runtime_arg_name.hpp>
 #include <tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/utility/group.hpp>
 #include <tt-metalium/experimental/metal2_host_api/utility/table.hpp>
@@ -178,10 +179,10 @@ struct KernelSpec {
 
     struct RuntimeArgSchema {
         // Runtime argument names (must be unique, valid C++ identifiers.)
-        Group<std::string> runtime_arg_names;
+        Group<RtaName> runtime_arg_names;
 
         // Common runtime argument names (must be unique, valid C++ identifiers.)
-        Group<std::string> common_runtime_arg_names;
+        Group<RtaName> common_runtime_arg_names;
     };
     RuntimeArgSchema runtime_arg_schema{};
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_args.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_args.hpp
@@ -15,6 +15,7 @@
 #include <tt-metalium/experimental/metal2_host_api/advanced_options.hpp>
 #include <tt-metalium/experimental/metal2_host_api/kernel_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/runtime_arg_name.hpp>
 #include <tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp>
 #include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
 #include <tt-metalium/experimental/metal2_host_api/utility/group.hpp>
@@ -57,7 +58,10 @@ struct ProgramRunArgs {
         //
         // NOTE: If a kernel runtime argument always has the same value for all nodes,
         // passing a common runtime argument would provide better dispatch efficiency.
-        using RuntimeArgValues = Table<std::string, uint32_t>;
+        //
+        // Names are keyed by RtaName (an inline, heap-free key); see runtime_arg_name.hpp.
+        // Ops still write {{"name", value}} -- string literals convert implicitly.
+        using RuntimeArgValues = Table<RtaName, uint32_t>;
         struct NodeRuntimeArgs {
             NodeCoord node;
             RuntimeArgValues args;

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/runtime_arg_name.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/runtime_arg_name.hpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <string>
+#include <string_view>
+
+#include <fmt/format.h>
+#include <tt_stl/assert.hpp>
+
+namespace tt::tt_metal::experimental {
+
+// Inline, fixed-capacity key for runtime-argument names.
+//
+// Used as the key type wherever a runtime-argument name is stored or looked up: the per-node and
+// common run-arg value Tables, the schema name lists and name->slot maps, and the enqueue-invariant
+// name sets. Those structures are rebuilt on every dispatch, so a std::string key allocates on the
+// heap for any name past the short-string-optimization threshold. RtaName stores the characters
+// inline -- it is a trivially-copyable POD, so it relocates by memcpy, compares with a length-gated
+// memcmp, and never touches the heap.
+//
+// Implicitly constructible from a string, so call sites keep declaring and supplying names as plain
+// string literals. The capacity is validated when a ProgramSpec is built; the constructor enforces
+// it as a backstop, failing loudly rather than silently truncating (truncation would alias two
+// distinct names to the same key).
+struct RtaName {
+    static constexpr std::size_t CAP = 47;  // 48-byte key including the length; longest name in use is 28 chars
+    char data_[CAP] = {};
+    std::uint8_t len_ = 0;
+
+    RtaName() = default;
+    RtaName(std::string_view s) {  // NOLINT(google-explicit-constructor): implicit by design
+        TT_FATAL(s.size() <= CAP, "Runtime-arg name '{}' exceeds the {}-character limit ({} chars)", s, CAP, s.size());
+        len_ = static_cast<std::uint8_t>(s.size());
+        std::memcpy(data_, s.data(), len_);
+    }
+    RtaName(const char* s) : RtaName(std::string_view(s)) {}         // NOLINT(google-explicit-constructor)
+    RtaName(const std::string& s) : RtaName(std::string_view(s)) {}  // NOLINT(google-explicit-constructor)
+
+    std::string_view view() const { return std::string_view(data_, len_); }
+
+    // Reader-side conversion for the (minority) call sites that consume a name as a std::string.
+    operator std::string() const { return std::string(view()); }  // NOLINT(google-explicit-constructor)
+
+    bool operator==(const RtaName& o) const { return len_ == o.len_ && std::memcmp(data_, o.data_, len_) == 0; }
+};
+
+}  // namespace tt::tt_metal::experimental
+
+template <>
+struct fmt::formatter<tt::tt_metal::experimental::RtaName> : fmt::formatter<std::string_view> {
+    auto format(const tt::tt_metal::experimental::RtaName& n, fmt::format_context& ctx) const {
+        return fmt::formatter<std::string_view>::format(n.view(), ctx);
+    }
+};
+
+template <>
+struct std::hash<tt::tt_metal::experimental::RtaName> {
+    std::size_t operator()(const tt::tt_metal::experimental::RtaName& n) const noexcept {
+        // Delegate to the platform's optimized byte hash (chunked) rather than a naive
+        // per-byte FNV loop -- the apply path does ~hundreds of slot-map lookups per dispatch.
+        return std::hash<std::string_view>{}(n.view());
+    }
+};

--- a/tt_metal/impl/metal2_host_api/program_run_args.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_args.cpp
@@ -206,7 +206,7 @@ void ValidateProgramRunArgs(const Program& program, const ProgramRunArgs& params
 
         // Validate named RTAs: every declared name set per-node, no extras, no duplicate node entries.
         const auto& named_rta_names = schema->runtime_arg_names;
-        const std::unordered_set<std::string> named_rta_name_set(named_rta_names.begin(), named_rta_names.end());
+        const std::unordered_set<RtaName> named_rta_name_set(named_rta_names.begin(), named_rta_names.end());
 
         std::unordered_set<NodeCoord> nodes_with_named_params;
         for (const auto& [node, args] : kernel_params.runtime_arg_values) {
@@ -625,7 +625,7 @@ void SetProgramRunArgs(Program& program, const ProgramRunArgs& params, bool skip
             // before allocating. Build the node->values lookups and walk the kernel's logical cores
             // (the node coverage validation has confirmed) to assemble each combined buffer. This
             // runs once; every subsequent call takes the fast path above.
-            std::unordered_map<NodeCoord, const Table<std::string, uint32_t>*> named_rtas_by_node;
+            std::unordered_map<NodeCoord, const Table<RtaName, uint32_t>*> named_rtas_by_node;
             named_rtas_by_node.reserve(kernel_params.runtime_arg_values.size());
             for (const auto& [node, args] : kernel_params.runtime_arg_values) {
                 named_rtas_by_node[node] = &args;
@@ -961,8 +961,8 @@ void ValidateUpdateProgramRunArgs(const Program& program, const ProgramRunArgs& 
         // --- Named RTAs: supplied names must be declared (no extras); every non-invariant name
         //     must be supplied for every node; invariant names may be omitted. ---
         const auto& named_rta_names = schema->runtime_arg_names;
-        const std::unordered_set<std::string> named_rta_name_set(named_rta_names.begin(), named_rta_names.end());
-        std::vector<std::string> regular_rta_names;
+        const std::unordered_set<RtaName> named_rta_name_set(named_rta_names.begin(), named_rta_names.end());
+        std::vector<RtaName> regular_rta_names;
         for (const auto& n : named_rta_names) {
             if (!schema->enqueue_invariant_runtime_arg_names.contains(n)) {
                 regular_rta_names.push_back(n);
@@ -1012,7 +1012,7 @@ void ValidateUpdateProgramRunArgs(const Program& program, const ProgramRunArgs& 
 
         // --- Named CRTAs: regular ones must be supplied; invariant may be omitted; no extras. ---
         const auto& named_crta_names = schema->common_runtime_arg_names;
-        const std::unordered_set<std::string> named_crta_name_set(named_crta_names.begin(), named_crta_names.end());
+        const std::unordered_set<RtaName> named_crta_name_set(named_crta_names.begin(), named_crta_names.end());
         for (const auto& [name, _value] : kernel_params.common_runtime_arg_values) {
             (void)_value;
             TT_FATAL(

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -680,6 +680,16 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                 kernel.unique_id,
                 kind,
                 name);
+            // Runtime-arg names are keyed by the fixed-capacity RtaName; enforce the shared limit here
+            // so an over-long name is rejected when the ProgramSpec is built, not at dispatch time.
+            TT_FATAL(
+                name.size() <= experimental::RtaName::CAP,
+                "KernelSpec '{}' {} name '{}' exceeds the {}-character limit ({} chars).",
+                kernel.unique_id,
+                kind,
+                name,
+                experimental::RtaName::CAP,
+                name.size());
             auto [it, inserted] = seen.try_emplace(name, kind);
             TT_FATAL(
                 inserted,
@@ -2810,7 +2820,12 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
         // Resolve TensorBindings for this kernel:
         //  - pack each binding's pre-resolved CTA payload into the kernel's positional CTA buffer
         //  - assign each binding a slot in the kernel's CRTA buffer (TensorBinding address section)
-        const auto& user_named_crtas = kernel_spec.runtime_arg_schema.common_runtime_arg_names;
+        // Materialize the declared names as std::string for the legacy Kernel ctor (which takes
+        // std::vector<std::string>) and the impl schema's declaration-order lists. The hot-path
+        // lookups use the RtaName-keyed *_name_to_slot maps built below.
+        const std::vector<std::string> user_named_crtas(
+            kernel_spec.runtime_arg_schema.common_runtime_arg_names.begin(),
+            kernel_spec.runtime_arg_schema.common_runtime_arg_names.end());
         TensorBindingsForKernel ta_bindings = ResolveTensorBindingsForKernel(
             kernel_spec, resolved_tensor_parameters, /*base_named_crta_count=*/user_named_crtas.size());
 
@@ -2821,7 +2836,9 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
         // emit kernel_args_generated.h and factor into the kernel cache key. The TensorBinding
         // address section is tracked separately (via tensor_binding_handles), so we pass the user
         // CRTA list through unchanged.
-        const auto& named_rtas = kernel_spec.runtime_arg_schema.runtime_arg_names;
+        const std::vector<std::string> named_rtas(
+            kernel_spec.runtime_arg_schema.runtime_arg_names.begin(),
+            kernel_spec.runtime_arg_schema.runtime_arg_names.end());
 
         // Create the kernel object
         std::shared_ptr<Kernel> kernel;
@@ -2913,9 +2930,8 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
         // An explicit override of 0 erases the scalar-default entry so run-params treats
         // that node as having no varargs (rather than requiring an "empty" value list).
         // Overlapping override entries (two entries covering the same node) are an error.
-        const auto& user_schema = kernel_spec.runtime_arg_schema;
         detail::ProgramImpl::KernelRTASchema runtime_schema;
-        runtime_schema.runtime_arg_names = user_schema.runtime_arg_names;
+        runtime_schema.runtime_arg_names = named_rtas;
 
         // Pass the user CRTA list through.
         // NOTE: The TensorBinding address section is tracked separately on the Kernel

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -18,6 +18,7 @@
 #include "impl/buffers/semaphore.hpp"
 #include "tt-metalium/sub_device_types.hpp"
 #include "tt-metalium/experimental/tensor/spec/tensor_spec.hpp"  // Metal 2.0 TensorParameter registry
+#include "tt-metalium/experimental/metal2_host_api/runtime_arg_name.hpp"  // RtaName (RTA slot-map key)
 #include "tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp"
 
 #include <umd/device/types/core_coordinates.hpp>        // CoreType
@@ -387,6 +388,9 @@ public:
     struct KernelRTASchema {
         // Named arg names, in declaration order. Used to serialize ProgramRunArgs values
         // into the dispatch buffer and to validate that every declared name is supplied.
+        // std::string (not RtaName): these declaration-order lists bridge to the legacy Kernel
+        // constructor (kernel.hpp), which takes std::vector<std::string>, and are iteration lists
+        // rather than hot-path lookups. The RtaName-keyed *_name_to_slot maps below are the hot path.
         std::vector<std::string> runtime_arg_names;
         std::vector<std::string> common_runtime_arg_names;
 
@@ -395,8 +399,10 @@ public:
         // hot UpdateProgramRunArgs path does O(1) lookups instead of rebuilding a map per call —
         // that path is not bypassable via skip_validation, so per-call construction would be pure
         // host overhead on the inner re-enqueue loop.
-        std::unordered_map<std::string, size_t> runtime_arg_name_to_slot;
-        std::unordered_map<std::string, size_t> common_runtime_arg_name_to_slot;
+        // Keyed by RtaName (heap-free inline key) to match RuntimeArgValues' key type, so the hot
+        // apply-path lookup (slot_of.find(name)) is a memcmp, not a std::string hash+compare.
+        std::unordered_map<experimental::RtaName, size_t> runtime_arg_name_to_slot;
+        std::unordered_map<experimental::RtaName, size_t> common_runtime_arg_name_to_slot;
 
         // Vararg counts. RTA vararg count is per-node (stored post-expansion from the
         // user-facing schema, which groups nodes that share a count); CRTA vararg is a single
@@ -408,8 +414,8 @@ public:
         // enqueue-loop invariant via KernelAdvancedOptions. These named args may be omitted
         // from a partial UpdateProgramRunArgs call, in which case the value installed by the
         // most recent SetProgramRunArgs is retained. (Varargs cannot be marked invariant.)
-        std::unordered_set<std::string> enqueue_invariant_runtime_arg_names;
-        std::unordered_set<std::string> enqueue_invariant_common_runtime_arg_names;
+        std::unordered_set<experimental::RtaName> enqueue_invariant_runtime_arg_names;
+        std::unordered_set<experimental::RtaName> enqueue_invariant_common_runtime_arg_names;
     };
 
     // Metal 2.0: Runtime argument schema registration and lookup

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_overlap_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_overlap_program_factory.cpp
@@ -173,7 +173,7 @@ ttnn::device_operation::ProgramArtifacts MoveOverlapProgramFactory::create_progr
     // Named RTA schema (per-node values supplied below). One named arg per legacy
     // positional slot; the legacy src/dst-address (slots 0,1) and semaphore-id (slot 4)
     // slots are gone — those are now bindings.
-    m2::Group<std::string> rta_names = {
+    m2::Group<m2::RtaName> rta_names = {
         "start_id",      "num_pages",           "controller_noc_x",    "controller_noc_y",  "control_value",
         "is_controller", "range_0_start_noc_x", "range_0_start_noc_y", "range_0_end_noc_x", "range_0_end_noc_y",
         "range_0_size",  "range_1_start_noc_x", "range_1_start_noc_y", "range_1_end_noc_x", "range_1_end_noc_y",


### PR DESCRIPTION
## What

Replace `std::string` with `RtaName` — an inline, fixed-capacity (47-char), trivially-copyable key — everywhere a runtime-argument **name** is stored or looked up in the `metal2_host_api`:

- `ProgramRunArgs` per-node and common run-arg value Tables (`RuntimeArgValues`)
- `KernelSpec::RuntimeArgSchema` name lists (`runtime_arg_names`, `common_runtime_arg_names`)
- enqueue-invariant name groups (`KernelAdvancedOptions`) and their impl sets
- `program_impl` name→slot maps

These structures are rebuilt on every dispatch. `RtaName` stores the name inline, so the backing small-vectors relocate by `memcpy` and lookups are a length-gated `memcmp` instead of a `std::string` hash + compare (and a heap allocation for any name past the SSO threshold).

The op-facing API is unchanged: names are still written as string literals (implicit ctor), and reader sites get an implicit `std::string` conversion. Because the schema name fields are `RtaName`, the ctor enforces the capacity at `KernelSpec` construction (before dispatch), failing loud rather than silently truncating.

The `program_impl` declaration-order name *vectors* stay `std::string` (they bridge to the legacy `Kernel` ctor and are iteration lists, not hot-path lookups). Unique-id types (`KernelSpecName`, `DFBSpecName`, …) and C++-identifier accessor names keep their existing string-backed abstraction — they are set once at spec construction, not on the dispatch path.

## Performance (measured this session, host-side dispatch)

Verified end-to-end on a **real op** — `ttnn.experimental.quasar.transpose` migrated to the spec-as-key path — over **1000 cache-hit ops** after cache prewarm (1024×1024 bf16 tiled, PCC-checked vs torch), with the legacy op as an unchanged control:

| | µs/op |
| --- | --- |
| spec-as-key dispatch, **before** this optimization | 81.5 |
| spec-as-key dispatch, **with** SmallVector (#48060) + RtaName | 67.7 |

**−13.8 µs/op (−17%)** on the spec-as-key cache-hit dispatch path (combined with #48060). RtaName's isolated contribution on top of the SmallVector baseline — measured with the host run-arg update entry-point micro-benchmark added here (`DISABLED_FastPathBench_*`) — is **−24…−31%** on those entry points; the `UpdateTensorArgs` control path (which RtaName does not touch) is flat, confirming the gain is the run-args path.

This is one of a series of spec-as-key dispatch optimizations; further gains land in follow-up PRs.

## Notes
- Independent of #48060 (SmallVector); they were measured together for the end-to-end number above.
- Addresses prior review feedback: the inline key is rolled out uniformly across the runtime-arg name fields (not a single field), the capacity is validated in `ProgramSpec` construction, and reader sites get a `std::string` conversion.
- Run the micro-benchmark: `unit_tests_api --gtest_also_run_disabled_tests --gtest_filter='*FastPathBench*'`
