### PR TITLE
[Metal 2.0] Spec-as-key: skip run-arg validation on cache hit (-29% dispatch)

### DIFF
--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -853,7 +853,9 @@ public:
         // run_params reference this dispatch's tensors.)
         static void apply_run_args(cached_mesh_workload_t& cached_workload, const BuiltSpec& built) {
             for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-                tt::tt_metal::experimental::SetProgramRunArgs(program, built.artifacts.run_params);
+                // skip_validation: the args were validated on the cache miss, and the factory rebuilds
+                // them conformant to the (matched) spec every dispatch -- re-validating on a hit is redundant.
+                tt::tt_metal::experimental::SetProgramRunArgs(program, built.artifacts.run_params, /*skip_validation=*/true);
             }
         }
     };
@@ -914,7 +916,8 @@ public:
         // Cache hit: apply this dispatch's fresh run args and re-park this dispatch's owned tensors.
         static void apply_run_args(cached_mesh_workload_t& cached_workload, const BuiltSpec& built) {
             for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-                tt::tt_metal::experimental::SetProgramRunArgs(program, built.artifacts.run_params);
+                // skip_validation: validated on the cache miss; the factory rebuilds conformant args every hit.
+                tt::tt_metal::experimental::SetProgramRunArgs(program, built.artifacts.run_params, /*skip_validation=*/true);
                 cached_workload.shared_variables.at(coordinate_range).owned_tensors = built.owned;
             }
         }


### PR DESCRIPTION
## What

On the spec-as-key **cache-hit** path, `apply_run_args` (both the base and owned-tensor adapters) called `SetProgramRunArgs` without `skip_validation`, so `ValidateProgramRunArgs` re-ran on **every dispatch**. This change passes `skip_validation=true` on the apply path.

The run args are already validated on the cache **miss**, and the factory rebuilds them conformant to the (hash-matched) spec on every dispatch — re-validating on a hit is redundant. The miss path (`build_mesh_workload`) still validates.

## Why — profile

A `py-spy --native` profile of the spec-as-key cache-hit dispatch (quasar transpose, ~400k dispatches) found `ValidateProgramRunArgs` at **~21.6% of the hot path** — about 72% of `SetProgramRunArgs`'s total cost — running on every hit.

## Performance (measured, host dispatch)

Real op (`ttnn.experimental.quasar.transpose` on the spec-as-key path), 1000 cache-hit ops after cache prewarm, PCC-checked vs torch, legacy `ttnn.transpose` as an unchanged control (26.3 µs/op across all runs):

| spec-as-key cache-hit dispatch | µs/op |
| --- | --- |
| + SmallVector + RtaName (prior optimizations) | 67.7 |
| **+ skip validation on hit (this PR)** | **47.8** |

**−19.9 µs/op (−29%).** Narrows the spec-as-key vs legacy gap from 2.6× to 1.8×.

## Notes
- Stacked on #47473 (the spec-as-key adapter `apply_run_args` it modifies does not exist on `main`).
- One of a series of spec-as-key dispatch optimizations; the next lever is the per-dispatch `create_program_spec` rebuild (~20%).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/metal2-spec-skip-validate-on-hit)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/metal2-spec-skip-validate-on-hit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/metal2-spec-skip-validate-on-hit)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/metal2-spec-skip-validate-on-hit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/metal2-spec-skip-validate-on-hit)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/metal2-spec-skip-validate-on-hit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/metal2-spec-skip-validate-on-hit)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/metal2-spec-skip-validate-on-hit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/metal2-spec-skip-validate-on-hit)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/metal2-spec-skip-validate-on-hit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/metal2-spec-skip-validate-on-hit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/metal2-spec-skip-validate-on-hit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/metal2-spec-skip-validate-on-hit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/metal2-spec-skip-validate-on-hit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/metal2-spec-skip-validate-on-hit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/metal2-spec-skip-validate-on-hit)