### PR TITLE
ds_prefill - Remove unnecessary reading of weights tensor from dispatch operator

### DIFF
--- a/models/demos/deepseek_v3_d_p/reference/tt/moe/dispatch.py
+++ b/models/demos/deepseek_v3_d_p/reference/tt/moe/dispatch.py
@@ -45,7 +45,7 @@ class TorchDispatchModule(torch.nn.Module):
             dispatch_group_size: Number of chips in each dispatch group
             experts_per_chip: Number of experts per chip
             num_routed_experts: Total number of routed experts across all chips
-            metadata_len: Length of metadata per token (stores: chip, token, topk_idx, routed_expert, weight)
+            metadata_len: Length of metadata per token (3 fields: chip, token, topk_idx)
             max_dispatched_tokens_per_expert: Per-expert theoretical upper bound on the number of tokens any
                 single expert may receive (full sequence length of the dispatch group).
             max_dispatch_buffer_token_size: Total token capacity of the flat dispatch buffer per chip
@@ -163,16 +163,7 @@ class TorchDispatchModule(torch.nn.Module):
                             chip, group, self.num_dispatch_groups
                         )
                         dispatched_metadata[group, expert_chip, dst_index] = torch.tensor(
-                            [
-                                linearized_coord,
-                                token,
-                                topk_idx,
-                                routed_expert,
-                                torch.tensor(weights[chip, token, topk_idx].item(), dtype=torch.bfloat16)
-                                .view(torch.int16)
-                                .item(),
-                            ]
-                            + [0] * (self.metadata_len - 5),
+                            [linearized_coord, token, topk_idx],
                             dtype=dispatched_metadata.dtype,
                         )
                         offset_copy[chip, routed_expert] += 1

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_dispatch_combine_l1_small_semaphores.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_dispatch_combine_l1_small_semaphores.py
@@ -135,7 +135,6 @@ def run_dispatch_op(mesh_device, use_l1_small):
 
     dispatched_buffer, dispatch_metadata = ttnn.experimental.deepseek_prefill.dispatch(
         input_tensor=tt_x,
-        weights_tensor=tt_weights,
         indices_tensor=tt_indices,
         expert_offsets_tensor=tt_expert_offsets,
         expert_dispatch_table_tensor=tt_expert_dispatch_table,

--- a/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
@@ -476,7 +476,7 @@ def compute_constants(
         experts_per_chip = experts_per_chip_override
     else:
         experts_per_chip = num_routed_experts // num_devices
-    metadata_len = 5  # chip, token, topk_idx, routed_expert, weight
+    metadata_len = 3  # chip, token, topk_idx
 
     # TODO: For now, we are ignoring the num_experts_per_tok, but it will be needed once
     # we support replicated experts (See Issue #41293)

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_combine.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_combine.py
@@ -115,8 +115,8 @@ class TtCombineModule(LightweightModule):
                 Shape per device: (1, 1, max_dispatch_buffer_token_size, emb_dim).
                 BFLOAT16 ROW_MAJOR.
             dispatched_metadata: Per-token routing metadata produced by TtDispatchModule.forward().
-                Shape per device: (1, 1, max_dispatch_buffer_token_size, metadata_len=5).
-                INT32 ROW_MAJOR. Fields per token: [linearized_mesh_coord, token_idx, topk_idx, routed_expert, weight].
+                Shape per device: (1, 1, max_dispatch_buffer_token_size, metadata_len=3).
+                INT32 ROW_MAJOR. Fields per token: [linearized_mesh_coord, token_idx, topk_idx].
             expert_token_counts: Number of tokens dispatched to each expert, used to bound the
                 valid range of token slots read per expert in dispatched_buffer.
                 Shape per device: (1, 1, num_routed_experts). INT32 ROW_MAJOR.

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_dispatch.py
@@ -29,7 +29,7 @@ devices. The buffer is flat: all experts_per_chip experts share a single token
 dimension of total capacity max_dispatch_buffer_token_size, packed dynamically with
 each expert's region starting at a TILE_HEIGHT-aligned offset. The per-device shape is:
   dispatched_buffer: (1, 1, max_dispatch_buffer_token_size, emb_dim)
-  metadata:          (1, 1, max_dispatch_buffer_token_size, metadata_len=5)
+  metadata:          (1, 1, max_dispatch_buffer_token_size, metadata_len=3)
 
 TtCombineModule reads from these buffers using the same offsets to reconstruct the
 original token ordering after expert processing.
@@ -78,8 +78,7 @@ class TtDispatchModule(LightweightModule):
             experts_per_chip: Number of experts hosted on each destination device.
             num_routed_experts: Total number of routed experts across all devices.
             num_experts_per_tok: Number of experts each token is routed to (top-k).
-            metadata_len: Number of fields in per-token metadata (5: chip, token, topk_idx,
-                routed_expert, weight).
+            metadata_len: Number of fields in per-token metadata (3: chip, token, topk_idx).
             max_dispatch_buffer_token_size: Total token capacity of the flat dispatch
                 buffer per chip. Tokens that would push the total past this cap are
                 silently dropped by the kernel (prevents out-of-bounds DRAM writes).
@@ -216,7 +215,9 @@ class TtDispatchModule(LightweightModule):
         Args:
             x: Input token embeddings.
                 Shape per device: (1, seq_len_per_chip, emb_dim)
-            weights: Router weights for each token's top-k experts.
+            weights: Router weights for each token's top-k experts. Retained for call-site
+                compatibility; the dispatch op no longer consumes it (gate weighting is applied
+                downstream by the reduce op from its own weights tensor).
                 Shape per device: (1, seq_len_per_chip, num_experts_per_tok)
             indices: Top-k expert indices for each token.
                 Shape per device: (1, seq_len_per_chip, num_experts_per_tok)
@@ -239,9 +240,9 @@ class TtDispatchModule(LightweightModule):
                 Token at index i belongs to the expert whose region covers index i; regions are
                 TILE_HEIGHT-aligned and laid out by the expert region offsets from offset_cumsum.
             metadata: Per-token routing metadata written alongside dispatched_buffer.
-                Shape per device: (1, 1, max_dispatch_buffer_token_size, metadata_len=5),
+                Shape per device: (1, 1, max_dispatch_buffer_token_size, metadata_len=3),
                 int32, ROW_MAJOR.
-                Fields per token: [linearized_mesh_coord, token_idx, topk_idx, routed_expert, weight].
+                Fields per token: [linearized_mesh_coord, token_idx, topk_idx].
                 Used by TtCombineModule to route processed tokens back to their origin.
         """
         logger.debug(f"[TtDispatchModule.forward] INPUT SHAPES:")
@@ -263,7 +264,6 @@ class TtDispatchModule(LightweightModule):
             tt_dispatch_metadata,
         ) = ttnn.experimental.deepseek_prefill.dispatch(
             input_tensor=x,
-            weights_tensor=weights,
             indices_tensor=indices,
             expert_offsets_tensor=tt_expert_offsets,
             expert_dispatch_table_tensor=tt_expert_dispatch_table,

--- a/models/demos/deepseek_v3_d_p/tt/moe/validation_helpers.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/validation_helpers.py
@@ -1078,10 +1078,9 @@ def validate_dispatch_metadata(
     """
     Validate dispatch metadata against torch reference.
 
-    Handles:
+    Metadata is 3 fields per token; all are validated:
     - Linearized mesh coord conversion (field 0)
-    - Direct comparison of fields 1-3
-    - Weight bfloat16 bit reinterpretation (field 4)
+    - Direct comparison of fields 1-2 (global token idx, top-k slot)
 
     Args:
         torch_metadata: Reference metadata
@@ -1130,43 +1129,31 @@ def validate_dispatch_metadata(
                 # expert_region_offsets directly gives the expert region start position
                 start = int(expert_region_offsets[r, dst_chip_id, global_expert_idx].item())
 
-                # Compare fields 1-3 directly
-                out = ttnn_metadata[r, dst_chip_id, start : start + count, 1:4]
-                ref = torch_metadata[r, dst_chip_id, start : start + count, 1:4]
+                # Compare fields 1-2 (global token idx, top-k slot) directly
+                out = ttnn_metadata[r, dst_chip_id, start : start + count, 1:3]
+                ref = torch_metadata[r, dst_chip_id, start : start + count, 1:3]
 
-                # Both Torch and TTNN now embed linearized mesh coord in field 0
+                # Both Torch and TTNN embed linearized mesh coord in field 0
                 out_linearized_mesh_coord = ttnn_metadata[r, dst_chip_id, start : start + count, 0]
                 ref_linearized_mesh_coord = torch_metadata[r, dst_chip_id, start : start + count, 0]
-
-                # Compare weights (metadata[4]):
-                # TTNN stores raw bfloat16 bits as uint16 in int32 - convert to bfloat16
-                out_weight_bf16 = (
-                    ttnn_metadata[r, dst_chip_id, start : start + count, 4].to(torch.int16).view(torch.bfloat16)
-                )
-                # Torch stores bfloat16 value directly
-                ref_weight_bf16 = (
-                    torch_metadata[r, dst_chip_id, start : start + count, 4].to(torch.int16).view(torch.bfloat16)
-                )
 
                 metadata_match = torch.allclose(out, ref, atol=1e-6)
                 coord_match = torch.allclose(
                     out_linearized_mesh_coord.float(), ref_linearized_mesh_coord.float(), atol=1e-6
                 )
 
-                gate_weight_match, gate_pcc = comp_pcc(ref_weight_bf16.float(), out_weight_bf16.float(), pcc=0.99)
-
-                if metadata_match and coord_match and gate_weight_match:
+                if metadata_match and coord_match:
                     matches += 1
                     logger.debug(f"✅ {r} Metadata {dst_chip_id=} {expert_id=} {count=}")
                 else:
-                    error_detail = f"metadata={metadata_match}, coord={coord_match}, weight={gate_weight_match}"
+                    error_detail = f"metadata={metadata_match}, coord={coord_match}"
                     logger.error(f"❌ {r} Metadata {dst_chip_id=} {expert_id=} {count=} ({error_detail})")
                     mismatches.append((r, dst_chip_id, expert_id, error_detail))
 
                     if verbose:
                         for slot in range(count):
-                            torch_data = torch_metadata[r, dst_chip_id, start + slot, :4]
-                            kernel_data = ttnn_metadata[r, dst_chip_id, start + slot, :4]
+                            torch_data = torch_metadata[r, dst_chip_id, start + slot, :3]
+                            kernel_data = ttnn_metadata[r, dst_chip_id, start + slot, :3]
                             slot_data_match = torch.allclose(torch_data, kernel_data, atol=1e-6)
                             if not slot_data_match:
                                 logger.error(
@@ -1174,11 +1161,6 @@ def validate_dispatch_metadata(
                                     f"ref_coord={ref_linearized_mesh_coord[slot].item()}, "
                                     f"out_coord={out_linearized_mesh_coord[slot].item()}, "
                                     f"torch={torch_data.tolist()}, kernel={kernel_data.tolist()}"
-                                )
-                            if not gate_weight_match:
-                                logger.error(
-                                    f"    Slot {slot}: Weight mismatch gate pcc={gate_pcc:.3f}: "
-                                    f"ref={ref_weight_bf16[slot].item()}, out={out_weight_bf16[slot].item()}"
                                 )
 
     passed = len(mismatches) == 0

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/combine_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/combine_nanobind.cpp
@@ -39,8 +39,8 @@ void bind_combine(nb::module_& mod) {
                 Shape per device: (1, 1, max_dispatch_buffer_token_size, hidden_dim).
                 BFLOAT16 ROW_MAJOR.
             dispatched_metadata (ttnn.Tensor): Per-token routing metadata produced by the dispatch op.
-                Shape per device: (1, 1, max_dispatch_buffer_token_size, metadata_len=5).
-                INT32 ROW_MAJOR. Fields per token: [linearized_mesh_coord, token_idx, topk_idx, routed_expert, weight].
+                Shape per device: (1, 1, max_dispatch_buffer_token_size, metadata_len=3).
+                INT32 ROW_MAJOR. Fields per token: [linearized_mesh_coord, token_idx, topk_idx].
             expert_token_counts (ttnn.Tensor): Number of tokens dispatched to each expert, used to bound
                 the valid range of token slots read per expert in dispatched_buffer.
                 Shape per device: (1, 1, num_routed_experts). INT32 or UINT32 ROW_MAJOR.

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.cpp
@@ -15,9 +15,6 @@ namespace ttnn::operations::experimental::deepseek_prefill::dispatch {
 void DispatchDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     TT_FATAL(
-        tensor_args.weights_tensor.layout() == tt::tt_metal::Layout::ROW_MAJOR,
-        "Weights tensor must be ROW_MAJOR layout");
-    TT_FATAL(
         tensor_args.indices_tensor.layout() == tt::tt_metal::Layout::ROW_MAJOR,
         "Indices tensor must be ROW_MAJOR layout");
     TT_FATAL(
@@ -32,10 +29,6 @@ void DispatchDeviceOperation::validate_on_program_cache_miss(
         tensor_args.input_tensor.dtype() == DataType::BFLOAT16,
         "Input tensor must be BFLOAT16, got {}",
         tensor_args.input_tensor.dtype());
-    TT_FATAL(
-        tensor_args.weights_tensor.dtype() == DataType::BFLOAT16,
-        "Weights tensor must be BFLOAT16, got {}",
-        tensor_args.weights_tensor.dtype());
     TT_FATAL(
         tensor_args.indices_tensor.dtype() == DataType::UINT16,
         "Indices tensor must be UINT16 (matching moe_grouped_topk output), got {}",
@@ -157,7 +150,6 @@ namespace ttnn::prim {
 ttnn::operations::experimental::deepseek_prefill::dispatch::DispatchDeviceOperation::tensor_return_value_t
 prefill_dispatch(
     const ttnn::Tensor& input_tensor,
-    const ttnn::Tensor& weights_tensor,
     const ttnn::Tensor& indices_tensor,
     const ttnn::Tensor& expert_offsets_tensor,
     const ttnn::Tensor& expert_dispatch_table_tensor,
@@ -196,7 +188,6 @@ prefill_dispatch(
             .has_padding_config = padding_config.has_value()},
         OperationType::tensor_args_t{
             .input_tensor = input_tensor,
-            .weights_tensor = weights_tensor,
             .indices_tensor = indices_tensor,
             .expert_offsets_tensor = expert_offsets_tensor,
             .expert_dispatch_table_tensor = expert_dispatch_table_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.hpp
@@ -16,11 +16,7 @@ namespace ttnn::operations::experimental::deepseek_prefill::dispatch {
 namespace detail {
 
 std::pair<std::array<uint32_t, 2>, std::array<uint32_t, 2>> get_cb_sizes(
-    const Tensor& input_tensor,
-    const Tensor& weights_tensor,
-    const Tensor& indices_tensor,
-    uint32_t num_links,
-    std::optional<uint32_t> axis);
+    const Tensor& input_tensor, const Tensor& indices_tensor, uint32_t num_links, std::optional<uint32_t> axis);
 
 }  // namespace detail
 
@@ -46,7 +42,6 @@ namespace ttnn::prim {
 ttnn::operations::experimental::deepseek_prefill::dispatch::DispatchDeviceOperation::tensor_return_value_t
 prefill_dispatch(
     const ttnn::Tensor& input_tensor,
-    const ttnn::Tensor& weights_tensor,
     const ttnn::Tensor& indices_tensor,
     const ttnn::Tensor& expert_offsets_tensor,
     const ttnn::Tensor& expert_dispatch_table_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -501,8 +501,8 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
     std::vector<uint32_t> compile_time_args = {
         // CB IDs (9)
         static_cast<uint32_t>(tt::CBIndex::c_0),  // cb_input_id (row-major path only)
-        static_cast<uint32_t>(
-            tt::CBIndex::c_1),  // cb_indices_id        static_cast<uint32_t>(tt::CBIndex::c_3),  // cb_offsets_id
+        static_cast<uint32_t>(tt::CBIndex::c_1),  // cb_indices_id
+        static_cast<uint32_t>(tt::CBIndex::c_3),  // cb_offsets_id
         static_cast<uint32_t>(tt::CBIndex::c_4),  // cb_route_info_id
         static_cast<uint32_t>(tt::CBIndex::c_5),  // cb_payload_for_writer_id
         static_cast<uint32_t>(tt::CBIndex::c_6),  // cb_metadata_for_writer_id
@@ -1186,8 +1186,8 @@ tt::tt_metal::ProgramDescriptor create_at_row_major(
     std::vector<uint32_t> compile_time_args = {
         // CB IDs (9)
         static_cast<uint32_t>(tt::CBIndex::c_0),  // cb_input_id
-        static_cast<uint32_t>(
-            tt::CBIndex::c_1),  // cb_indices_id        static_cast<uint32_t>(tt::CBIndex::c_3),  // cb_offsets_id
+        static_cast<uint32_t>(tt::CBIndex::c_1),  // cb_indices_id
+        static_cast<uint32_t>(tt::CBIndex::c_3),  // cb_offsets_id
         static_cast<uint32_t>(tt::CBIndex::c_4),  // cb_route_info_id
         static_cast<uint32_t>(tt::CBIndex::c_5),  // cb_payload_for_writer_id
         static_cast<uint32_t>(tt::CBIndex::c_6),  // cb_metadata_for_writer_id

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -1340,8 +1340,8 @@ tt::tt_metal::ProgramDescriptor create_at_row_major(
         num_cores,                    // num_dispatch_cores
     };
 
-    // Reader-only: padding_config base address sits at fixed index 13 and is promoted to a Buffer*
-    // so its BufferBinding refreshes on cache hit. The writer's index 13 is its exit_semaphore
+    // Reader-only: padding_config base address sits at fixed index 12 and is promoted to a Buffer*
+    // so its BufferBinding refreshes on cache hit. The writer's index 12 is its exit_semaphore
     // (stable GlobalSemaphore address) and must stay a plain uint32_t.
     auto promote_rt_args_with_buffer_bindings = [&](const std::vector<uint32_t>& raw_args, bool is_reader) {
         tt::tt_metal::KernelDescriptor::RTArgList args;
@@ -1352,8 +1352,8 @@ tt::tt_metal::ProgramDescriptor create_at_row_major(
         args.push_back(output_tensor.buffer());
         args.push_back(metadata_tensor.buffer());
         args.push_back(dispatch_table_tensor.buffer());
-        for (size_t i = 7; i < raw_args.size(); ++i) {
-            if (is_reader && has_padding_config && i == 13) {
+        for (size_t i = 6; i < raw_args.size(); ++i) {
+            if (is_reader && has_padding_config && i == 12) {
                 args.push_back(tensor_args.padding_config.value().buffer());
             } else {
                 args.push_back(raw_args[i]);
@@ -1370,13 +1370,13 @@ tt::tt_metal::ProgramDescriptor create_at_row_major(
         reader_runtime_args[10] = core_idx;
         writer_runtime_args[10] = core_idx;
 
-        // Reader-only: padding_config address at index 13 (right after the 13 base args). The
+        // Reader-only: padding_config address at index 12 (right after the 12 base args). The
         // promote helper rebinds it to a Buffer* so it refreshes on cache hit.
         if (has_padding_config) {
             reader_runtime_args.push_back((uint32_t)tensor_args.padding_config.value()
                                               .buffer()
                                               ->address());  // smuggled-rta-ok: promoted to a Buffer* binding at reader
-                                                             // index 13 below — refreshes on cache hit
+                                                             // index 12 below — refreshes on cache hit
         }
 
         // Writer-only: exit semaphore address (separate from init_semaphore to avoid

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -131,7 +131,6 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
 
     auto input_tensor = tensor_args.input_tensor;
     auto indices_tensor = tensor_args.indices_tensor;
-    auto weights_tensor = tensor_args.weights_tensor;
     auto offsets_tensor = tensor_args.expert_offsets_tensor;
     auto dispatch_table_tensor = tensor_args.expert_dispatch_table_tensor;
 
@@ -306,14 +305,6 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
         /*buffering_factor=*/read_batch_size,
         /*cb_id=*/tt::CBIndex::c_1,
         "untilize_indices_scratch");
-    // c_2: weights scratch
-    detail::create_tensor_cb(
-        desc,
-        untilize_core_grid,
-        weights_tensor,
-        /*buffering_factor=*/read_batch_size,
-        /*cb_id=*/tt::CBIndex::c_2,
-        "untilize_weights_scratch");
     // c_3: offsets (full tensor, mutated in place per batch as the shared running counter).
     // The owner untilize core (local_core_id==0) loads expert_offsets[] here once at startup;
     // non-owners leave it uninitialized and pull/push the owner's copy under the baton each
@@ -508,11 +499,10 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
 
     // ==================== Compile-time args for the sender writer kernel ====================
     std::vector<uint32_t> compile_time_args = {
-        // CB IDs (10)
+        // CB IDs (9)
         static_cast<uint32_t>(tt::CBIndex::c_0),  // cb_input_id (row-major path only)
-        static_cast<uint32_t>(tt::CBIndex::c_1),  // cb_indices_id
-        static_cast<uint32_t>(tt::CBIndex::c_2),  // cb_weights_id
-        static_cast<uint32_t>(tt::CBIndex::c_3),  // cb_offsets_id
+        static_cast<uint32_t>(
+            tt::CBIndex::c_1),  // cb_indices_id        static_cast<uint32_t>(tt::CBIndex::c_3),  // cb_offsets_id
         static_cast<uint32_t>(tt::CBIndex::c_4),  // cb_route_info_id
         static_cast<uint32_t>(tt::CBIndex::c_5),  // cb_payload_for_writer_id
         static_cast<uint32_t>(tt::CBIndex::c_6),  // cb_metadata_for_writer_id
@@ -520,19 +510,17 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
         static_cast<uint32_t>(tt::CBIndex::c_8),  // cb_packet_header_id
         static_cast<uint32_t>(tt::CBIndex::c_9),  // cb_dispatch_table_id
 
-        // Page counts (7)
+        // Page counts (6)
         detail::get_num_pages(input_tensor),
         detail::get_num_pages(indices_tensor),
-        detail::get_num_pages(weights_tensor),
         detail::get_num_pages(offsets_tensor),
         detail::get_num_pages(output_tensor),
         detail::get_num_pages(metadata_tensor),
         detail::get_num_pages(dispatch_table_tensor),
 
-        // Page sizes (7)
+        // Page sizes (6)
         detail::get_page_size(input_tensor),
         detail::get_page_size(indices_tensor),
-        detail::get_page_size(weights_tensor),
         detail::get_page_size(offsets_tensor),
         detail::get_page_size(output_tensor),
         detail::get_page_size(metadata_tensor),
@@ -554,10 +542,9 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
         mesh_view.num_cols(),
         linearized_mesh_coord,
 
-        // Aligned page sizes (7)
+        // Aligned page sizes (6)
         detail::get_aligned_page_size(input_tensor),
         detail::get_aligned_page_size(indices_tensor),
-        detail::get_aligned_page_size(weights_tensor),
         detail::get_aligned_page_size(offsets_tensor),
         detail::get_aligned_page_size(output_tensor),
         detail::get_aligned_page_size(metadata_tensor),
@@ -577,10 +564,9 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
         operation_attributes.max_dispatch_buffer_token_size,
     };
 
-    // Append TensorAccessorArgs for all 7 tensors
+    // Append TensorAccessorArgs for all 6 tensors
     tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(compile_time_args);
     tt::tt_metal::TensorAccessorArgs(indices_tensor.buffer()).append_to(compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(weights_tensor.buffer()).append_to(compile_time_args);
     tt::tt_metal::TensorAccessorArgs(offsets_tensor.buffer()).append_to(compile_time_args);
     tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(compile_time_args);
     tt::tt_metal::TensorAccessorArgs(metadata_tensor.buffer()).append_to(compile_time_args);
@@ -646,7 +632,7 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
     }
 
     // ==================== Untilize core kernels ====================
-    // Reader (RISCV_1): routing decisions, DRAM reads for input/indices/weights/offsets/dispatch_table,
+    // Reader (RISCV_1): routing decisions, DRAM reads for input/indices/offsets/dispatch_table,
     //                   publishes per-batch route plan to writer via c_14.
     // Writer (RISCV_0): drains c_14 plan, executes local DRAM writes for the local path and direct
     //                   NOC writes into the owning sender's writer-CB set for local_core_id (set s)
@@ -674,32 +660,29 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
             local_core_id,                                         // 5
             total_workers,                                         // 6
             static_cast<uint32_t>(tt::CBIndex::c_1),               // 7: cb_indices_id
-            static_cast<uint32_t>(tt::CBIndex::c_2),               // 8: cb_weights_id
-            static_cast<uint32_t>(tt::CBIndex::c_3),               // 9: cb_offsets_id
-            static_cast<uint32_t>(tt::CBIndex::c_9),               // 10: cb_dispatch_table_id
-            static_cast<uint32_t>(tt::CBIndex::c_14),              // 11: cb_plan_id
-            read_batch_size,                                       // 12
-            detail::get_aligned_page_size(indices_tensor),         // 13
-            detail::get_aligned_page_size(weights_tensor),         // 14
-            detail::get_aligned_page_size(offsets_tensor),         // 15
-            detail::get_aligned_page_size(dispatch_table_tensor),  // 16
-            detail::get_num_pages(offsets_tensor),                 // 17: offsets_pages
-            detail::get_num_pages(dispatch_table_tensor),          // 18: dispatch_table_pages
-            operation_attributes.num_experts_per_tok,              // 19
-            operation_attributes.num_routed_experts,               // 20: n_routed_experts
-            operation_attributes.max_dispatch_buffer_token_size,   // 21
-            s,                                                     // 22: dispatch_core_idx
-            num_cores,                                             // 23: num_dispatch_cores
-            mesh_view.num_devices(),                               // 24: num_devices
-            mesh_view.num_rows(),                                  // 25
-            mesh_view.num_cols(),                                  // 26
-            linearized_mesh_coord,                                 // 27
-            static_cast<uint32_t>(topology),                       // 28
-            block_ct_dim_dispatch,                                 // 29: must match the compute kernel
+            static_cast<uint32_t>(tt::CBIndex::c_3),               // 8: cb_offsets_id
+            static_cast<uint32_t>(tt::CBIndex::c_9),               // 9: cb_dispatch_table_id
+            static_cast<uint32_t>(tt::CBIndex::c_14),              // 10: cb_plan_id
+            read_batch_size,                                       // 11
+            detail::get_aligned_page_size(indices_tensor),         // 12
+            detail::get_aligned_page_size(offsets_tensor),         // 13
+            detail::get_aligned_page_size(dispatch_table_tensor),  // 14
+            detail::get_num_pages(offsets_tensor),                 // 15: offsets_pages
+            detail::get_num_pages(dispatch_table_tensor),          // 16: dispatch_table_pages
+            operation_attributes.num_experts_per_tok,              // 17
+            operation_attributes.num_routed_experts,               // 18: n_routed_experts
+            operation_attributes.max_dispatch_buffer_token_size,   // 19
+            s,                                                     // 20: dispatch_core_idx
+            num_cores,                                             // 21: num_dispatch_cores
+            mesh_view.num_devices(),                               // 22: num_devices
+            mesh_view.num_rows(),                                  // 23
+            mesh_view.num_cols(),                                  // 24
+            linearized_mesh_coord,                                 // 25
+            static_cast<uint32_t>(topology),                       // 26
+            block_ct_dim_dispatch,                                 // 27: must match the compute kernel
         };
         tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(untilize_reader_compile_args);
         tt::tt_metal::TensorAccessorArgs(indices_tensor.buffer()).append_to(untilize_reader_compile_args);
-        tt::tt_metal::TensorAccessorArgs(weights_tensor.buffer()).append_to(untilize_reader_compile_args);
         tt::tt_metal::TensorAccessorArgs(offsets_tensor.buffer()).append_to(untilize_reader_compile_args);
         tt::tt_metal::TensorAccessorArgs(dispatch_table_tensor.buffer()).append_to(untilize_reader_compile_args);
         if (has_padding_config) {
@@ -820,7 +803,6 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
     std::vector<uint32_t> base_runtime_args = {
         input_tensor.buffer()->address(),
         indices_tensor.buffer()->address(),
-        weights_tensor.buffer()->address(),
         offsets_tensor.buffer()->address(),
         output_tensor.buffer()->address(),
         metadata_tensor.buffer()->address(),
@@ -834,19 +816,18 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
     };
 
     // Helper: promote a flat uint32_t RT arg vector into an RTArgList with the
-    // first 7 positions converted to Buffer* (so BufferBindings are auto-
+    // first 6 positions converted to Buffer* (so BufferBindings are auto-
     // registered for those slots), preserving all other positions verbatim.
     auto promote_rt_args_with_buffer_bindings = [&](const std::vector<uint32_t>& raw_args) {
         tt::tt_metal::KernelDescriptor::RTArgList args;
         args.reserve(raw_args.size());
         args.push_back(input_tensor.buffer());
         args.push_back(indices_tensor.buffer());
-        args.push_back(weights_tensor.buffer());
         args.push_back(offsets_tensor.buffer());
         args.push_back(output_tensor.buffer());
         args.push_back(metadata_tensor.buffer());
         args.push_back(dispatch_table_tensor.buffer());
-        for (size_t i = 7; i < raw_args.size(); ++i) {
+        for (size_t i = 6; i < raw_args.size(); ++i) {
             args.push_back(raw_args[i]);
         }
         return args;
@@ -859,7 +840,7 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
         const auto& group = sender_untilize_groups[core_idx];
 
         std::vector<uint32_t> writer_runtime_args = base_runtime_args;
-        writer_runtime_args[11] = core_idx;  // dispatch_core_idx
+        writer_runtime_args[10] = core_idx;  // dispatch_core_idx
 
         // Writer-only: exit semaphore address (separate from init_semaphore to avoid
         // init/exit reuse race where a fast peer's exit-inc lands during the post-init
@@ -946,7 +927,6 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
         tt::tt_metal::KernelDescriptor::RTArgList untilize_reader_rt_args;
         untilize_reader_rt_args.push_back(input_tensor.buffer());
         untilize_reader_rt_args.push_back(indices_tensor.buffer());
-        untilize_reader_rt_args.push_back(weights_tensor.buffer());
         untilize_reader_rt_args.push_back(offsets_tensor.buffer());
         untilize_reader_rt_args.push_back(dispatch_table_tensor.buffer());
         untilize_reader_rt_args.push_back(0u);                           // token_start_idx
@@ -1010,7 +990,6 @@ tt::tt_metal::ProgramDescriptor create_at_row_major(
 
     auto input_tensor = tensor_args.input_tensor;
     auto indices_tensor = tensor_args.indices_tensor;
-    auto weights_tensor = tensor_args.weights_tensor;
     auto offsets_tensor = tensor_args.expert_offsets_tensor;
     auto dispatch_table_tensor = tensor_args.expert_dispatch_table_tensor;
 
@@ -1097,14 +1076,6 @@ tt::tt_metal::ProgramDescriptor create_at_row_major(
         /*buffering_factor=*/read_batch_size,
         /*cb_id=*/tt::CBIndex::c_1,
         "indices_scratch");
-    // c_2: weights scratch (reader-only)
-    detail::create_tensor_cb(
-        desc,
-        sender_core_grid,
-        weights_tensor,
-        /*buffering_factor=*/read_batch_size,
-        /*cb_id=*/tt::CBIndex::c_2,
-        "weights_scratch");
     // c_3: offsets (reader-only, full tensor)
     detail::create_tensor_cb(
         desc,
@@ -1213,11 +1184,10 @@ tt::tt_metal::ProgramDescriptor create_at_row_major(
 
     // Compile-time args shared by reader and writer
     std::vector<uint32_t> compile_time_args = {
-        // CB IDs (10)
+        // CB IDs (9)
         static_cast<uint32_t>(tt::CBIndex::c_0),  // cb_input_id
-        static_cast<uint32_t>(tt::CBIndex::c_1),  // cb_indices_id
-        static_cast<uint32_t>(tt::CBIndex::c_2),  // cb_weights_id
-        static_cast<uint32_t>(tt::CBIndex::c_3),  // cb_offsets_id
+        static_cast<uint32_t>(
+            tt::CBIndex::c_1),  // cb_indices_id        static_cast<uint32_t>(tt::CBIndex::c_3),  // cb_offsets_id
         static_cast<uint32_t>(tt::CBIndex::c_4),  // cb_route_info_id
         static_cast<uint32_t>(tt::CBIndex::c_5),  // cb_payload_for_writer_id
         static_cast<uint32_t>(tt::CBIndex::c_6),  // cb_metadata_for_writer_id
@@ -1225,19 +1195,17 @@ tt::tt_metal::ProgramDescriptor create_at_row_major(
         static_cast<uint32_t>(tt::CBIndex::c_8),  // cb_packet_header_id
         static_cast<uint32_t>(tt::CBIndex::c_9),  // cb_dispatch_table_id
 
-        // Page counts (7)
+        // Page counts (6)
         detail::get_num_pages(input_tensor),
         detail::get_num_pages(indices_tensor),
-        detail::get_num_pages(weights_tensor),
         detail::get_num_pages(offsets_tensor),
         detail::get_num_pages(output_tensor),
         detail::get_num_pages(metadata_tensor),
         detail::get_num_pages(dispatch_table_tensor),
 
-        // Page sizes (7)
+        // Page sizes (6)
         detail::get_page_size(input_tensor),
         detail::get_page_size(indices_tensor),
-        detail::get_page_size(weights_tensor),
         detail::get_page_size(offsets_tensor),
         detail::get_page_size(output_tensor),
         detail::get_page_size(metadata_tensor),
@@ -1259,10 +1227,9 @@ tt::tt_metal::ProgramDescriptor create_at_row_major(
         mesh_view.num_cols(),
         linearized_mesh_coord,
 
-        // Aligned page sizes (7)
+        // Aligned page sizes (6)
         detail::get_aligned_page_size(input_tensor),
         detail::get_aligned_page_size(indices_tensor),
-        detail::get_aligned_page_size(weights_tensor),
         detail::get_aligned_page_size(offsets_tensor),
         detail::get_aligned_page_size(output_tensor),
         detail::get_aligned_page_size(metadata_tensor),
@@ -1282,10 +1249,9 @@ tt::tt_metal::ProgramDescriptor create_at_row_major(
         operation_attributes.max_dispatch_buffer_token_size,
     };
 
-    // Append TensorAccessorArgs for all 7 tensors
+    // Append TensorAccessorArgs for all 6 tensors
     tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(compile_time_args);
     tt::tt_metal::TensorAccessorArgs(indices_tensor.buffer()).append_to(compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(weights_tensor.buffer()).append_to(compile_time_args);
     tt::tt_metal::TensorAccessorArgs(offsets_tensor.buffer()).append_to(compile_time_args);
     tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(compile_time_args);
     tt::tt_metal::TensorAccessorArgs(metadata_tensor.buffer()).append_to(compile_time_args);
@@ -1358,11 +1324,10 @@ tt::tt_metal::ProgramDescriptor create_at_row_major(
 
     // Runtime args: all cores process all tokens, experts split round-robin.
     // Build as a flat uint32_t vector so the fabric helper can extend it, then
-    // promote to an RTArgList with Buffer* in the first seven slots.
+    // promote to an RTArgList with Buffer* in the first six slots.
     std::vector<uint32_t> base_runtime_args = {
         input_tensor.buffer()->address(),
         indices_tensor.buffer()->address(),
-        weights_tensor.buffer()->address(),
         offsets_tensor.buffer()->address(),
         output_tensor.buffer()->address(),
         metadata_tensor.buffer()->address(),
@@ -1383,7 +1348,6 @@ tt::tt_metal::ProgramDescriptor create_at_row_major(
         args.reserve(raw_args.size());
         args.push_back(input_tensor.buffer());
         args.push_back(indices_tensor.buffer());
-        args.push_back(weights_tensor.buffer());
         args.push_back(offsets_tensor.buffer());
         args.push_back(output_tensor.buffer());
         args.push_back(metadata_tensor.buffer());
@@ -1403,8 +1367,8 @@ tt::tt_metal::ProgramDescriptor create_at_row_major(
         std::vector<uint32_t> reader_runtime_args = base_runtime_args;
         std::vector<uint32_t> writer_runtime_args = base_runtime_args;
 
-        reader_runtime_args[11] = core_idx;
-        writer_runtime_args[11] = core_idx;
+        reader_runtime_args[10] = core_idx;
+        writer_runtime_args[10] = core_idx;
 
         // Reader-only: padding_config address at index 13 (right after the 13 base args). The
         // promote helper rebinds it to a Buffer* so it refreshes on cache hit.

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_types.hpp
@@ -74,7 +74,6 @@ struct DispatchParams {
 
 struct DispatchInputs {
     Tensor input_tensor;
-    Tensor weights_tensor;
     Tensor indices_tensor;
     Tensor expert_offsets_tensor;
     Tensor expert_dispatch_table_tensor;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_dispatch.cpp
@@ -7,14 +7,14 @@
 // RISCV_1, paired with writer_dispatch.cpp on RISCV_0.  (The tile-layout path
 // uses untilize cores instead and has no sender-side reader kernel.)
 //
-// Streams row-major input/indices/weights from DRAM and, per routed token, either
+// Streams row-major input/indices from DRAM and, per routed token, either
 // writes it straight to local DRAM or hands (route_info, payload, metadata) to the
 // writer for a fabric send to the destination device.
 //
 // Tokens [token_start_idx, token_end_idx) are processed in batches of
 // read_batch_size.  Reads are pipelined: the next batch's DRAM reads are issued
 // before the current batch's write barrier so the read and write NOC channels
-// overlap.  (The input/indices/weights scratch is a single region reused per
+// overlap.  (The input/indices scratch is a single region reused per
 // batch, not a FIFO — see the reservation note below.)
 //
 // Startup: load offsets[] (per-expert DRAM page allocators) and the read-only
@@ -50,77 +50,72 @@ void kernel_main() {
     using namespace ttnn::operations::ccl::common;
 
     // ===== Compile Time Args =====
-    // CB IDs (indices 0-9)
+    // CB IDs (indices 0-8)
     constexpr uint32_t cb_input_id = get_compile_time_arg_val(0);
     constexpr uint32_t cb_indices_id = get_compile_time_arg_val(1);
-    constexpr uint32_t cb_weights_id = get_compile_time_arg_val(2);
-    constexpr uint32_t cb_offsets_id = get_compile_time_arg_val(3);
-    constexpr uint32_t cb_route_info_id = get_compile_time_arg_val(4);
-    constexpr uint32_t cb_payload_for_writer_id = get_compile_time_arg_val(5);
-    constexpr uint32_t cb_metadata_for_writer_id = get_compile_time_arg_val(6);
-    constexpr uint32_t cb_metadata_temp_id = get_compile_time_arg_val(7);
-    constexpr uint32_t cb_packet_header_id = get_compile_time_arg_val(8);
-    constexpr uint32_t cb_dispatch_table_id = get_compile_time_arg_val(9);
+    constexpr uint32_t cb_offsets_id = get_compile_time_arg_val(2);
+    constexpr uint32_t cb_route_info_id = get_compile_time_arg_val(3);
+    constexpr uint32_t cb_payload_for_writer_id = get_compile_time_arg_val(4);
+    constexpr uint32_t cb_metadata_for_writer_id = get_compile_time_arg_val(5);
+    constexpr uint32_t cb_metadata_temp_id = get_compile_time_arg_val(6);
+    constexpr uint32_t cb_packet_header_id = get_compile_time_arg_val(7);
+    constexpr uint32_t cb_dispatch_table_id = get_compile_time_arg_val(8);
 
-    // Page counts (indices 10-16)
-    constexpr uint32_t input_pages = get_compile_time_arg_val(10);
-    constexpr uint32_t indices_pages = get_compile_time_arg_val(11);
-    constexpr uint32_t weights_pages = get_compile_time_arg_val(12);
-    constexpr uint32_t offsets_pages = get_compile_time_arg_val(13);
-    constexpr uint32_t output_pages = get_compile_time_arg_val(14);
-    constexpr uint32_t metadata_pages = get_compile_time_arg_val(15);
-    constexpr uint32_t dispatch_table_pages = get_compile_time_arg_val(16);
+    // Page counts (indices 9-14)
+    constexpr uint32_t input_pages = get_compile_time_arg_val(9);
+    constexpr uint32_t indices_pages = get_compile_time_arg_val(10);
+    constexpr uint32_t offsets_pages = get_compile_time_arg_val(11);
+    constexpr uint32_t output_pages = get_compile_time_arg_val(12);
+    constexpr uint32_t metadata_pages = get_compile_time_arg_val(13);
+    constexpr uint32_t dispatch_table_pages = get_compile_time_arg_val(14);
 
-    // Page sizes (indices 17-23)
-    constexpr uint32_t input_page_size = get_compile_time_arg_val(17);
-    constexpr uint32_t indices_page_size = get_compile_time_arg_val(18);
-    constexpr uint32_t weights_page_size = get_compile_time_arg_val(19);
-    constexpr uint32_t output_page_size = get_compile_time_arg_val(21);
-    constexpr uint32_t metadata_page_size = get_compile_time_arg_val(22);
+    // Page sizes (indices 15-20; offsets/dispatch_table page sizes unused by the reader)
+    constexpr uint32_t input_page_size = get_compile_time_arg_val(15);
+    constexpr uint32_t indices_page_size = get_compile_time_arg_val(16);
+    constexpr uint32_t output_page_size = get_compile_time_arg_val(18);
+    constexpr uint32_t metadata_page_size = get_compile_time_arg_val(19);
 
-    // Operation parameters (indices 24-30)
-    constexpr uint32_t num_devices = get_compile_time_arg_val(24);
-    constexpr uint32_t hidden_size = get_compile_time_arg_val(25);
-    constexpr uint32_t experts_per_chip = get_compile_time_arg_val(26);
-    constexpr uint32_t n_routed_experts = get_compile_time_arg_val(27);
-    constexpr uint32_t num_experts_per_tok = get_compile_time_arg_val(28);
-    constexpr uint32_t metadata_len = get_compile_time_arg_val(29);
-    constexpr uint32_t tokens_per_device = get_compile_time_arg_val(30);
+    // Operation parameters (indices 21-27)
+    constexpr uint32_t num_devices = get_compile_time_arg_val(21);
+    constexpr uint32_t hidden_size = get_compile_time_arg_val(22);
+    constexpr uint32_t experts_per_chip = get_compile_time_arg_val(23);
+    constexpr uint32_t n_routed_experts = get_compile_time_arg_val(24);
+    constexpr uint32_t num_experts_per_tok = get_compile_time_arg_val(25);
+    constexpr uint32_t metadata_len = get_compile_time_arg_val(26);
+    constexpr uint32_t tokens_per_device = get_compile_time_arg_val(27);
 
-    // Mesh information (indices 31-35)
-    constexpr uint32_t src_mesh_id = get_compile_time_arg_val(31);
-    constexpr uint32_t src_chip_id = get_compile_time_arg_val(32);
-    constexpr uint32_t mesh_rows = get_compile_time_arg_val(33);
-    constexpr uint32_t mesh_cols = get_compile_time_arg_val(34);
-    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(35);
+    // Mesh information (indices 28-32)
+    constexpr uint32_t src_mesh_id = get_compile_time_arg_val(28);
+    constexpr uint32_t src_chip_id = get_compile_time_arg_val(29);
+    constexpr uint32_t mesh_rows = get_compile_time_arg_val(30);
+    constexpr uint32_t mesh_cols = get_compile_time_arg_val(31);
+    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(32);
 
-    // Aligned page sizes (indices 36-42)
-    constexpr uint32_t aligned_input_page_size = get_compile_time_arg_val(36);
-    constexpr uint32_t aligned_indices_page_size = get_compile_time_arg_val(37);
-    constexpr uint32_t aligned_weights_page_size = get_compile_time_arg_val(38);
-    constexpr uint32_t aligned_offsets_page_size = get_compile_time_arg_val(39);
-    constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(40);
-    constexpr uint32_t aligned_metadata_page_size = get_compile_time_arg_val(41);
-    constexpr uint32_t aligned_dispatch_table_page_size = get_compile_time_arg_val(42);
+    // Aligned page sizes (indices 33-38)
+    constexpr uint32_t aligned_input_page_size = get_compile_time_arg_val(33);
+    constexpr uint32_t aligned_indices_page_size = get_compile_time_arg_val(34);
+    constexpr uint32_t aligned_offsets_page_size = get_compile_time_arg_val(35);
+    constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(36);
+    constexpr uint32_t aligned_metadata_page_size = get_compile_time_arg_val(37);
+    constexpr uint32_t aligned_dispatch_table_page_size = get_compile_time_arg_val(38);
 
-    // Fabric configuration (indices 43-46)
-    constexpr uint32_t fabric_max_packet_size = get_compile_time_arg_val(43);
-    constexpr uint32_t l1_alignment = get_compile_time_arg_val(44);
-    constexpr uint32_t num_links = get_compile_time_arg_val(45);
-    constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(46);
+    // Fabric configuration (indices 39-42)
+    constexpr uint32_t fabric_max_packet_size = get_compile_time_arg_val(39);
+    constexpr uint32_t l1_alignment = get_compile_time_arg_val(40);
+    constexpr uint32_t num_links = get_compile_time_arg_val(41);
+    constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(42);
 
-    // Batch configuration (indices 47)
-    constexpr uint32_t read_batch_size = get_compile_time_arg_val(47);
+    // Batch configuration (index 43)
+    constexpr uint32_t read_batch_size = get_compile_time_arg_val(43);
 
     // Total dispatch buffer token capacity (shared across all local experts).
-    constexpr uint32_t max_dispatch_buffer_token_size = get_compile_time_arg_val(48);
+    constexpr uint32_t max_dispatch_buffer_token_size = get_compile_time_arg_val(44);
 
-    // TensorAccessorArgs for all 7 tensors (starting at index 49, after the
+    // TensorAccessorArgs for all 6 tensors (starting at index 45, after the
     // trailing max_dispatch_buffer_token_size arg).
-    constexpr auto input_args = TensorAccessorArgs<49>();
+    constexpr auto input_args = TensorAccessorArgs<45>();
     constexpr auto indices_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
-    constexpr auto weights_args = TensorAccessorArgs<indices_args.next_compile_time_args_offset()>();
-    constexpr auto offsets_args = TensorAccessorArgs<weights_args.next_compile_time_args_offset()>();
+    constexpr auto offsets_args = TensorAccessorArgs<indices_args.next_compile_time_args_offset()>();
     constexpr auto output_args = TensorAccessorArgs<offsets_args.next_compile_time_args_offset()>();
     constexpr auto metadata_args = TensorAccessorArgs<output_args.next_compile_time_args_offset()>();
     constexpr auto dispatch_table_args = TensorAccessorArgs<metadata_args.next_compile_time_args_offset()>();
@@ -137,7 +132,6 @@ void kernel_main() {
     uint32_t rt_args = 0;
     uint32_t input_tensor_address = get_arg_val<uint32_t>(rt_args++);
     uint32_t indices_tensor_address = get_arg_val<uint32_t>(rt_args++);
-    uint32_t weights_tensor_address = get_arg_val<uint32_t>(rt_args++);
     uint32_t offsets_tensor_address = get_arg_val<uint32_t>(rt_args++);
     uint32_t output_tensor_address = get_arg_val<uint32_t>(rt_args++);
     uint32_t metadata_tensor_address = get_arg_val<uint32_t>(rt_args++);
@@ -229,13 +223,10 @@ void kernel_main() {
     // copies below are done one page at a time — this avoids CB FIFO pointer wrapping
     cb_reserve_back(cb_indices_id, read_batch_size);
     uint32_t indices_base = get_write_ptr(cb_indices_id);
-    cb_reserve_back(cb_weights_id, read_batch_size);
-    uint32_t weights_base = get_write_ptr(cb_weights_id);
     cb_reserve_back(cb_input_id, read_batch_size);
     uint32_t input_base = get_write_ptr(cb_input_id);
     const auto input_addr_gen = TensorAccessor(input_args, input_tensor_address);
     const auto indices_addr_gen = TensorAccessor(indices_args, indices_tensor_address);
-    const auto weights_addr_gen = TensorAccessor(weights_args, weights_tensor_address);
     const auto output_addr_gen = TensorAccessor(output_args, output_tensor_address);
     const auto metadata_addr_gen = TensorAccessor(metadata_args, metadata_tensor_address);
 
@@ -250,7 +241,6 @@ void kernel_main() {
         for (uint32_t t = 0; t < first_batch_count; t++) {
             noc_async_read_page(token_start_idx + t, input_addr_gen, input_base + t * aligned_input_page_size);
             noc_async_read_page(token_start_idx + t, indices_addr_gen, indices_base + t * aligned_indices_page_size);
-            noc_async_read_page(token_start_idx + t, weights_addr_gen, weights_base + t * aligned_weights_page_size);
         }
         noc_async_read_barrier();
     }
@@ -268,8 +258,6 @@ void kernel_main() {
             uint32_t token_input_addr = input_base + t * aligned_input_page_size;
             tt_l1_ptr uint16_t* indices =
                 reinterpret_cast<tt_l1_ptr uint16_t*>(indices_base + t * aligned_indices_page_size);
-            tt_l1_ptr uint16_t* weights =
-                reinterpret_cast<tt_l1_ptr uint16_t*>(weights_base + t * aligned_weights_page_size);
 
             for (uint32_t k = 0; k < num_experts_per_tok; ++k) {
                 uint32_t routed_expert = (uint32_t)indices[k];
@@ -298,16 +286,13 @@ void kernel_main() {
                 // Local: expert lives on this device — write payload + metadata straight to DRAM.
                 if (expert_chip == linearized_mesh_coord) {
                     {
-                        // Metadata layout (5 × int32): [src chip, global token idx, top-k slot,
-                        // routed expert, routing weight].  Staged in scratch, then written to the
-                        // same DRAM page index as the payload.
+                        // Per-token metadata (3 × int32): [src chip, global token idx, top-k slot].
+                        // Staged in scratch, then written to the payload's DRAM page.
                         volatile tt_l1_ptr int32_t* metadata =
                             reinterpret_cast<volatile tt_l1_ptr int32_t*>(metadata_temp_addr);
                         metadata[0] = linearized_mesh_coord;
                         metadata[1] = token_idx;
                         metadata[2] = k;
-                        metadata[3] = routed_expert;
-                        metadata[4] = static_cast<int16_t>(weights[k]);
 
                         noc_async_write_page(page_idx, output_addr_gen, token_input_addr);
                         noc_async_write_page(page_idx, metadata_addr_gen, metadata_temp_addr);
@@ -348,8 +333,6 @@ void kernel_main() {
                         meta_dst[0] = linearized_mesh_coord;
                         meta_dst[1] = token_idx;
                         meta_dst[2] = k;
-                        meta_dst[3] = routed_expert;
-                        meta_dst[4] = static_cast<int16_t>(weights[k]);
                         cb_push_back(cb_metadata_for_writer_id, 1);
                     }
                 }
@@ -370,8 +353,6 @@ void kernel_main() {
                 noc_async_read_page(next_batch_start + t, input_addr_gen, input_base + t * aligned_input_page_size);
                 noc_async_read_page(
                     next_batch_start + t, indices_addr_gen, indices_base + t * aligned_indices_page_size);
-                noc_async_read_page(
-                    next_batch_start + t, weights_addr_gen, weights_base + t * aligned_weights_page_size);
             }
         }
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_untilize_dispatch.cpp
@@ -24,7 +24,7 @@
 //   1. Signal compute to start untilizing this batch (cb_signal_id).
 //   2. Stream the tiled input stripe from DRAM → cb_input_id, block_ct_dim tiles
 //      at a time, for compute to untilize.
-//   3. Read this batch's indices and weights pages from DRAM.
+//   3. Read this batch's indices pages from DRAM.
 //   4. Take the baton, then build the route plan into cb_plan_id: for each
 //      (token, top-k) routed to this dispatch core, allocate a DRAM page from
 //      offsets[expert] (drop if the dispatch buffer is full), classify it local
@@ -34,6 +34,7 @@
 // After the last batch: push an end-of-plan sentinel — ROUTE_INFO_SENTINEL to
 // compute (cb_signal_id) and a zero-entry sentinel plan page to the writer.
 
+#include "tools/profiler/kernel_profiler.hpp"
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
 #include "api/debug/dprint.h"
@@ -66,41 +67,38 @@ void kernel_main() {
     constexpr uint32_t total_workers = get_compile_time_arg_val(6);
 
     constexpr uint32_t cb_indices_id = get_compile_time_arg_val(7);
-    constexpr uint32_t cb_weights_id = get_compile_time_arg_val(8);
-    constexpr uint32_t cb_offsets_id = get_compile_time_arg_val(9);
-    constexpr uint32_t cb_dispatch_table_id = get_compile_time_arg_val(10);
-    constexpr uint32_t cb_plan_id = get_compile_time_arg_val(11);
+    constexpr uint32_t cb_offsets_id = get_compile_time_arg_val(8);
+    constexpr uint32_t cb_dispatch_table_id = get_compile_time_arg_val(9);
+    constexpr uint32_t cb_plan_id = get_compile_time_arg_val(10);
 
-    constexpr uint32_t read_batch_size = get_compile_time_arg_val(12);
-    constexpr uint32_t aligned_indices_page_size = get_compile_time_arg_val(13);
-    constexpr uint32_t aligned_weights_page_size = get_compile_time_arg_val(14);
-    constexpr uint32_t aligned_offsets_page_size = get_compile_time_arg_val(15);
-    constexpr uint32_t aligned_dispatch_table_page_size = get_compile_time_arg_val(16);
+    constexpr uint32_t read_batch_size = get_compile_time_arg_val(11);
+    constexpr uint32_t aligned_indices_page_size = get_compile_time_arg_val(12);
+    constexpr uint32_t aligned_offsets_page_size = get_compile_time_arg_val(13);
+    constexpr uint32_t aligned_dispatch_table_page_size = get_compile_time_arg_val(14);
 
-    constexpr uint32_t offsets_pages = get_compile_time_arg_val(17);
-    constexpr uint32_t dispatch_table_pages = get_compile_time_arg_val(18);
+    constexpr uint32_t offsets_pages = get_compile_time_arg_val(15);
+    constexpr uint32_t dispatch_table_pages = get_compile_time_arg_val(16);
 
-    constexpr uint32_t num_experts_per_tok = get_compile_time_arg_val(19);
-    constexpr uint32_t n_routed_experts = get_compile_time_arg_val(20);
-    constexpr uint32_t max_dispatch_buffer_token_size = get_compile_time_arg_val(21);
-    constexpr uint32_t dispatch_core_idx = get_compile_time_arg_val(22);
-    constexpr uint32_t num_dispatch_cores = get_compile_time_arg_val(23);
+    constexpr uint32_t num_experts_per_tok = get_compile_time_arg_val(17);
+    constexpr uint32_t n_routed_experts = get_compile_time_arg_val(18);
+    constexpr uint32_t max_dispatch_buffer_token_size = get_compile_time_arg_val(19);
+    constexpr uint32_t dispatch_core_idx = get_compile_time_arg_val(20);
+    constexpr uint32_t num_dispatch_cores = get_compile_time_arg_val(21);
     constexpr uint32_t core_mask = num_dispatch_cores - 1;
     // Batches are assigned round-robin (batch i -> core i % total_workers); all cores
     // grow offsets[] left-to-right from the single shared owner copy under the baton.
 
-    constexpr uint32_t num_devices = get_compile_time_arg_val(24);
-    constexpr uint32_t mesh_rows = get_compile_time_arg_val(25);
-    constexpr uint32_t mesh_cols = get_compile_time_arg_val(26);
-    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(27);
-    constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(28);
+    constexpr uint32_t num_devices = get_compile_time_arg_val(22);
+    constexpr uint32_t mesh_rows = get_compile_time_arg_val(23);
+    constexpr uint32_t mesh_cols = get_compile_time_arg_val(24);
+    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(25);
+    constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(26);
 
-    constexpr uint32_t block_ct_dim = get_compile_time_arg_val(29);
+    constexpr uint32_t block_ct_dim = get_compile_time_arg_val(27);
 
-    constexpr auto input_args = TensorAccessorArgs<30>();
+    constexpr auto input_args = TensorAccessorArgs<28>();
     constexpr auto indices_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
-    constexpr auto weights_args = TensorAccessorArgs<indices_args.next_compile_time_args_offset()>();
-    constexpr auto offsets_args = TensorAccessorArgs<weights_args.next_compile_time_args_offset()>();
+    constexpr auto offsets_args = TensorAccessorArgs<indices_args.next_compile_time_args_offset()>();
     constexpr auto dispatch_table_args = TensorAccessorArgs<offsets_args.next_compile_time_args_offset()>();
 
 #ifdef HAS_PADDING_CONFIG
@@ -129,7 +127,6 @@ void kernel_main() {
     uint32_t rt_idx = 0;
     uint32_t input_tensor_address = get_arg_val<uint32_t>(rt_idx++);
     uint32_t indices_tensor_address = get_arg_val<uint32_t>(rt_idx++);
-    uint32_t weights_tensor_address = get_arg_val<uint32_t>(rt_idx++);
     uint32_t offsets_tensor_address = get_arg_val<uint32_t>(rt_idx++);
     uint32_t dispatch_table_tensor_address = get_arg_val<uint32_t>(rt_idx++);
     uint32_t token_start_idx = get_arg_val<uint32_t>(rt_idx++);
@@ -149,7 +146,6 @@ void kernel_main() {
 
     const auto input_addr_gen = TensorAccessor(input_args, input_tensor_address, aligned_input_page_size);
     const auto indices_addr_gen = TensorAccessor(indices_args, indices_tensor_address, aligned_indices_page_size);
-    const auto weights_addr_gen = TensorAccessor(weights_args, weights_tensor_address, aligned_weights_page_size);
     const auto offsets_addr_gen = TensorAccessor(offsets_args, offsets_tensor_address);
     const auto dispatch_table_addr_gen = TensorAccessor(dispatch_table_args, dispatch_table_tensor_address);
 
@@ -197,11 +193,9 @@ void kernel_main() {
         (uint32_t)total_batches,
         (uint32_t)total_workers);
 
-    // ===== Indices / weights scratch (overwritten per batch, single page slot used) =====
+    // ===== Indices scratch (overwritten per batch, single page slot used) =====
     cb_reserve_back(cb_indices_id, read_batch_size);
     uint32_t indices_base = get_write_ptr(cb_indices_id);
-    cb_reserve_back(cb_weights_id, read_batch_size);
-    uint32_t weights_base = get_write_ptr(cb_weights_id);
 
     // Shrink the batch loop to this device's real (unpadded) tokens when right-padded (pad_side == 0).
     // The writer applies the same reduction so they agree on the end-of-plan handshake. Padded tokens
@@ -254,12 +248,14 @@ void kernel_main() {
             cb_push_back(cb_input_id, block_ct_dim);
         }
 
-        // 3. Read this batch's indices and weights pages
-        for (uint32_t t = 0; t < batch_count; t++) {
-            noc_async_read_page(batch_start + t, indices_addr_gen, indices_base + t * aligned_indices_page_size);
-            noc_async_read_page(batch_start + t, weights_addr_gen, weights_base + t * aligned_weights_page_size);
+        // 3. Read this batch's indices pages
+        {
+            DeviceZoneScopedN("batch-DRAM-read-indices-weights");
+            for (uint32_t t = 0; t < batch_count; t++) {
+                noc_async_read_page(batch_start + t, indices_addr_gen, indices_base + t * aligned_indices_page_size);
+            }
+            noc_async_read_barrier();
         }
-        noc_async_read_barrier();
 
         // 4. Build per-batch route plan into c_14.
         DPRINT_DISPATCH(
@@ -292,8 +288,6 @@ void kernel_main() {
         for (uint32_t t = 0; t < batch_count; t++) {
             tt_l1_ptr uint16_t* indices_t =
                 reinterpret_cast<tt_l1_ptr uint16_t*>(indices_base + t * aligned_indices_page_size);
-            tt_l1_ptr uint16_t* weights_t =
-                reinterpret_cast<tt_l1_ptr uint16_t*>(weights_base + t * aligned_weights_page_size);
             uint32_t token_idx = batch_start + t;
 
             // Walk this token's top-k experts; emit a plan entry for each one routed to this
@@ -323,7 +317,6 @@ void kernel_main() {
 
                 uint32_t expert_chip = device_begin_idx + (uint32_t)expert_chip_og * device_stride;
                 bool is_local = (expert_chip == linearized_mesh_coord);
-                int16_t weight = (int16_t)weights_t[k];
 
                 volatile tt_l1_ptr PlanEntry* entry = &entries[entry_count];
                 entry->flags = is_local ? PLAN_FLAG_LOCAL : 0;
@@ -332,7 +325,7 @@ void kernel_main() {
                 entry->page_idx = page_idx;
                 entry->token_idx = token_idx;
                 // Single aligned 32-bit store: baby-RISC sub-word L1 stores are unreliable on BH.
-                entry->weight_k = pack_weight_k(weight, (uint16_t)k);
+                entry->weight_k = pack_weight_k(0, (uint16_t)k);
                 // Linearized destination device index. Under 1D it is unused by the fabric writer
                 // (route/distance drive the send); under 2D it is the only routing input — the
                 // writer recomputes the EDM direction and (mesh,chip) header from it.

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_untilize_dispatch.cpp
@@ -250,7 +250,7 @@ void kernel_main() {
 
         // 3. Read this batch's indices pages
         {
-            DeviceZoneScopedN("batch-DRAM-read-indices-weights");
+            // DeviceZoneScopedN("batch-DRAM-read-indices-weights");
             for (uint32_t t = 0; t < batch_count; t++) {
                 noc_async_read_page(batch_start + t, indices_addr_gen, indices_base + t * aligned_indices_page_size);
             }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_dispatch.cpp
@@ -44,68 +44,63 @@ void kernel_main() {
     using namespace ttnn::operations::ccl::common;
 
     // ===== Compile Time Args =====
-    // CB IDs (indices 0-9)
+    // CB IDs (indices 0-8)
     constexpr uint32_t cb_input_id = get_compile_time_arg_val(0);
     constexpr uint32_t cb_indices_id = get_compile_time_arg_val(1);
-    constexpr uint32_t cb_weights_id = get_compile_time_arg_val(2);
-    constexpr uint32_t cb_offsets_id = get_compile_time_arg_val(3);
-    constexpr uint32_t cb_route_info_id = get_compile_time_arg_val(4);
-    constexpr uint32_t cb_payload_for_writer_id = get_compile_time_arg_val(5);
-    constexpr uint32_t cb_metadata_for_writer_id = get_compile_time_arg_val(6);
-    constexpr uint32_t cb_metadata_temp_id = get_compile_time_arg_val(7);
-    constexpr uint32_t cb_packet_header_id = get_compile_time_arg_val(8);
-    constexpr uint32_t cb_dispatch_table_id = get_compile_time_arg_val(9);
+    constexpr uint32_t cb_offsets_id = get_compile_time_arg_val(2);
+    constexpr uint32_t cb_route_info_id = get_compile_time_arg_val(3);
+    constexpr uint32_t cb_payload_for_writer_id = get_compile_time_arg_val(4);
+    constexpr uint32_t cb_metadata_for_writer_id = get_compile_time_arg_val(5);
+    constexpr uint32_t cb_metadata_temp_id = get_compile_time_arg_val(6);
+    constexpr uint32_t cb_packet_header_id = get_compile_time_arg_val(7);
+    constexpr uint32_t cb_dispatch_table_id = get_compile_time_arg_val(8);
 
-    // Page counts (indices 10-16)
-    constexpr uint32_t input_pages = get_compile_time_arg_val(10);
-    constexpr uint32_t indices_pages = get_compile_time_arg_val(11);
-    constexpr uint32_t weights_pages = get_compile_time_arg_val(12);
-    constexpr uint32_t offsets_pages = get_compile_time_arg_val(13);
-    constexpr uint32_t output_pages = get_compile_time_arg_val(14);
-    constexpr uint32_t metadata_pages = get_compile_time_arg_val(15);
-    constexpr uint32_t dispatch_table_pages = get_compile_time_arg_val(16);
+    // Page counts (indices 9-14)
+    constexpr uint32_t input_pages = get_compile_time_arg_val(9);
+    constexpr uint32_t indices_pages = get_compile_time_arg_val(10);
+    constexpr uint32_t offsets_pages = get_compile_time_arg_val(11);
+    constexpr uint32_t output_pages = get_compile_time_arg_val(12);
+    constexpr uint32_t metadata_pages = get_compile_time_arg_val(13);
+    constexpr uint32_t dispatch_table_pages = get_compile_time_arg_val(14);
 
-    // Page sizes (indices 17-23)
-    constexpr uint32_t input_page_size = get_compile_time_arg_val(17);
-    constexpr uint32_t indices_page_size = get_compile_time_arg_val(18);
-    constexpr uint32_t weights_page_size = get_compile_time_arg_val(19);
-    constexpr uint32_t offsets_page_size = get_compile_time_arg_val(20);
-    constexpr uint32_t output_page_size = get_compile_time_arg_val(21);
-    constexpr uint32_t metadata_page_size = get_compile_time_arg_val(22);
-    constexpr uint32_t dispatch_table_page_size = get_compile_time_arg_val(23);
+    // Page sizes (indices 15-20)
+    constexpr uint32_t input_page_size = get_compile_time_arg_val(15);
+    constexpr uint32_t indices_page_size = get_compile_time_arg_val(16);
+    constexpr uint32_t offsets_page_size = get_compile_time_arg_val(17);
+    constexpr uint32_t output_page_size = get_compile_time_arg_val(18);
+    constexpr uint32_t metadata_page_size = get_compile_time_arg_val(19);
+    constexpr uint32_t dispatch_table_page_size = get_compile_time_arg_val(20);
 
-    // Operation parameters (indices 24-30)
-    constexpr uint32_t num_devices = get_compile_time_arg_val(24);
-    constexpr uint32_t hidden_size = get_compile_time_arg_val(25);
+    // Operation parameters (indices 21-27; only num_devices/hidden_size used by the writer)
+    constexpr uint32_t num_devices = get_compile_time_arg_val(21);
+    constexpr uint32_t hidden_size = get_compile_time_arg_val(22);
 
-    // Mesh information (indices 31-35)
-    constexpr uint32_t src_mesh_id = get_compile_time_arg_val(31);
-    constexpr uint32_t src_chip_id = get_compile_time_arg_val(32);
-    constexpr uint32_t mesh_rows = get_compile_time_arg_val(33);
-    constexpr uint32_t mesh_cols = get_compile_time_arg_val(34);
-    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(35);
+    // Mesh information (indices 28-32)
+    constexpr uint32_t src_mesh_id = get_compile_time_arg_val(28);
+    constexpr uint32_t src_chip_id = get_compile_time_arg_val(29);
+    constexpr uint32_t mesh_rows = get_compile_time_arg_val(30);
+    constexpr uint32_t mesh_cols = get_compile_time_arg_val(31);
+    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(32);
 
-    // Aligned page sizes (indices 36-42)
-    constexpr uint32_t aligned_input_page_size = get_compile_time_arg_val(36);
-    constexpr uint32_t aligned_indices_page_size = get_compile_time_arg_val(37);
-    constexpr uint32_t aligned_weights_page_size = get_compile_time_arg_val(38);
-    constexpr uint32_t aligned_offsets_page_size = get_compile_time_arg_val(39);
-    constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(40);
-    constexpr uint32_t aligned_metadata_page_size = get_compile_time_arg_val(41);
-    constexpr uint32_t aligned_dispatch_table_page_size = get_compile_time_arg_val(42);
+    // Aligned page sizes (indices 33-38)
+    constexpr uint32_t aligned_input_page_size = get_compile_time_arg_val(33);
+    constexpr uint32_t aligned_indices_page_size = get_compile_time_arg_val(34);
+    constexpr uint32_t aligned_offsets_page_size = get_compile_time_arg_val(35);
+    constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(36);
+    constexpr uint32_t aligned_metadata_page_size = get_compile_time_arg_val(37);
+    constexpr uint32_t aligned_dispatch_table_page_size = get_compile_time_arg_val(38);
 
-    // Fabric configuration (indices 43-46)
-    constexpr uint32_t fabric_max_packet_size = get_compile_time_arg_val(43);
-    constexpr uint32_t l1_alignment = get_compile_time_arg_val(44);
-    constexpr uint32_t num_links = get_compile_time_arg_val(45);
+    // Fabric configuration (indices 39-42)
+    constexpr uint32_t fabric_max_packet_size = get_compile_time_arg_val(39);
+    constexpr uint32_t l1_alignment = get_compile_time_arg_val(40);
+    constexpr uint32_t num_links = get_compile_time_arg_val(41);
     [[maybe_unused]] constexpr tt::tt_fabric::Topology topology =
-        (tt::tt_fabric::Topology)get_compile_time_arg_val(46);  // used by the FABRIC_1D #else handshake
+        (tt::tt_fabric::Topology)get_compile_time_arg_val(42);  // used by the FABRIC_1D #else handshake
 
-    // TensorAccessorArgs for all 7 tensors (starting at index 49)
-    constexpr auto input_args = TensorAccessorArgs<49>();
+    // TensorAccessorArgs for all 6 tensors (starting at index 45)
+    constexpr auto input_args = TensorAccessorArgs<45>();
     constexpr auto indices_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
-    constexpr auto weights_args = TensorAccessorArgs<indices_args.next_compile_time_args_offset()>();
-    constexpr auto offsets_args = TensorAccessorArgs<weights_args.next_compile_time_args_offset()>();
+    constexpr auto offsets_args = TensorAccessorArgs<indices_args.next_compile_time_args_offset()>();
     constexpr auto output_args = TensorAccessorArgs<offsets_args.next_compile_time_args_offset()>();
     constexpr auto metadata_args = TensorAccessorArgs<output_args.next_compile_time_args_offset()>();
     [[maybe_unused]] constexpr auto dispatch_table_args =
@@ -122,7 +117,6 @@ void kernel_main() {
     size_t rt_args_idx = 0;
     uint32_t input_tensor_address = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t indices_tensor_address = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t weights_tensor_address = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t offsets_tensor_address = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t output_tensor_address = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t metadata_tensor_address = get_arg_val<uint32_t>(rt_args_idx++);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_untilize_dispatch.cpp
@@ -213,12 +213,10 @@ void kernel_main() {
                 volatile tt_l1_ptr PlanEntry* entry = &entries[e];
                 uint32_t flags = entry->flags;
                 uint32_t token_t = entry->token_t;
-                uint32_t routed_expert = entry->routed_expert;
                 uint32_t page_idx = entry->page_idx;
                 uint32_t token_idx = entry->token_idx;
                 uint32_t weight_k = entry->weight_k;
                 uint32_t k = unpack_k(weight_k);
-                int16_t weight = unpack_weight(weight_k);
 
                 // Payload source: this token's untilized row inside the compute output CB.
                 uint32_t src_addr = untilize_read_ptr + token_t * aligned_output_page_size;
@@ -235,8 +233,7 @@ void kernel_main() {
                         aligned_output_page_size,
                         {.offset_bytes = token_t * aligned_output_page_size},
                         {.page_id = page_idx});
-                    // Per-token metadata layout (5 × int32): [src chip, global token idx, top-k
-                    // slot, routed expert, routing weight].  Built into the next ring slot, then
+                    // Per-token metadata layout (3 × int32): [src chip, global token idx, top-k slot].  Built into the next ring slot, then
                     // written to the same DRAM page index as the payload.
                     uint32_t meta_addr =
                         metadata_scratch_addr + (local_count % meta_scratch_slots) * aligned_metadata_page_size;
@@ -244,8 +241,6 @@ void kernel_main() {
                     meta[0] = (int32_t)linearized_mesh_coord;
                     meta[1] = (int32_t)token_idx;
                     meta[2] = (int32_t)k;
-                    meta[3] = (int32_t)routed_expert;
-                    meta[4] = (int32_t)weight;
                     noc.async_write(
                         cb_metadata_scratch,
                         metadata_addr_gen,
@@ -298,15 +293,13 @@ void kernel_main() {
                         off += chunk;
                     }
 
-                    // Metadata: same 5 × int32 layout as the local path, staged in the dedicated
-                    // cross-device scratch slot, then written to the sender's c_6 slot.
+                    // Metadata: same [chip, token, top-k slot] layout as the local path, staged in
+                    // the cross-device scratch slot, then written to the sender's c_6 slot.
                     volatile tt_l1_ptr int32_t* meta =
                         reinterpret_cast<volatile tt_l1_ptr int32_t*>(xdev_metadata_scratch_addr);
                     meta[0] = (int32_t)linearized_mesh_coord;
                     meta[1] = (int32_t)token_idx;
                     meta[2] = (int32_t)k;
-                    meta[3] = (int32_t)routed_expert;
-                    meta[4] = (int32_t)weight;
                     uint64_t c6_slot = sender_c6_base_noc_addr + slot * aligned_metadata_page_size;
                     noc_async_write_one_packet_with_trid(
                         xdev_metadata_scratch_addr, c6_slot, aligned_metadata_page_size, TRID_NON_LOCAL_WRITE);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch.cpp
@@ -14,7 +14,6 @@ namespace ttnn::operations::experimental::deepseek_prefill::dispatch {
 
 std::array<ttnn::Tensor, 2> dispatch(
     const ttnn::Tensor& input_tensor,
-    const ttnn::Tensor& weights_tensor,
     const ttnn::Tensor& indices_tensor,
     const ttnn::Tensor& expert_offsets_tensor,
     const ttnn::Tensor& expert_dispatch_table_tensor,
@@ -61,7 +60,6 @@ std::array<ttnn::Tensor, 2> dispatch(
 
     return ttnn::prim::prefill_dispatch(
         input_tensor,
-        weights_tensor,
         indices_tensor,
         expert_offsets_tensor,
         expert_dispatch_table_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch.hpp
@@ -15,7 +15,6 @@ namespace ttnn::operations::experimental::deepseek_prefill::dispatch {
 
 std::array<ttnn::Tensor, 2> dispatch(
     const ttnn::Tensor& input_tensor,
-    const ttnn::Tensor& weights_tensor,
     const ttnn::Tensor& indices_tensor,
     const ttnn::Tensor& expert_offsets_tensor,
     const ttnn::Tensor& expert_dispatch_table_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch_nanobind.cpp
@@ -39,8 +39,6 @@ void bind_dispatch(nb::module_& mod) {
         Args:
             input_tensor (ttnn.Tensor): Input token embeddings.
                 Shape per device: (1, seq_len_per_chip, hidden_dim).
-            weights_tensor (ttnn.Tensor): Router weights for each token's top-k experts.
-                Shape per device: (1, seq_len_per_chip, num_experts_per_tok).
             indices_tensor (ttnn.Tensor): Top-k expert indices for each token.
                 Shape per device: (1, seq_len_per_chip, num_experts_per_tok).
             expert_offsets_tensor (ttnn.Tensor): Starting token index per source device per expert
@@ -56,8 +54,8 @@ void bind_dispatch(nb::module_& mod) {
             experts_per_chip (int): Number of experts hosted on each destination device.
             num_routed_experts (int): Total number of routed experts across all devices.
             num_experts_per_tok (int): Number of experts each token is routed to (top-k).
-            metadata_len (int): Number of fields per token in the metadata buffer (5:
-                linearized_mesh_coord, token_idx, topk_idx, routed_expert, weight).
+            metadata_len (int): Number of fields per token in the metadata buffer (3:
+                linearized_mesh_coord, token_idx, topk_idx).
             max_dispatch_buffer_token_size (int): Total token capacity of the flat dispatch
                 buffer per chip (shared across all local experts via dynamic offsets).
                 Used as the in-kernel bounds check ceiling.
@@ -88,13 +86,12 @@ void bind_dispatch(nb::module_& mod) {
                 dispatched_buffer: Flat expert-centric token buffer on each destination device.
                     Shape per device: (1, 1, max_dispatch_buffer_token_size, hidden_dim).
                 metadata: Per-token metadata written alongside dispatched_buffer.
-                    Shape per device: (1, 1, max_dispatch_buffer_token_size, metadata_len=5).
-                    Fields: [linearized_mesh_coord, token_idx, topk_idx, routed_expert, weight].
+                    Shape per device: (1, 1, max_dispatch_buffer_token_size, metadata_len=3).
+                    Fields: [linearized_mesh_coord, token_idx, topk_idx].
                     Used by the combine op to route processed tokens back to their origin.
         )doc",
         &dispatch,
         nb::arg("input_tensor").noconvert(),
-        nb::arg("weights_tensor").noconvert(),
         nb::arg("indices_tensor").noconvert(),
         nb::arg("expert_offsets_tensor").noconvert(),
         nb::arg("expert_dispatch_table_tensor").noconvert(),


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/48038

### What

The prefill dispatch op (ttnn.experimental.deepseek_prefill.dispatch) read the per-token router weights_tensor from DRAM solely to pack it into the per-token metadata tensor (metadata[4]), and also wrote routed_expert into metadata[3]. Neither field is consumed at runtime: combine reads only metadata[0..2] (src_chip, token_idx, topk_slot), and gate weighting is applied downstream by the separate reduce/post_combine_reduce op from its own weights tensor. The metadata weight/routed_expert fields were read only by the test-time validate_dispatch_metadata helper.

This PR removes the weights_tensor input from the dispatch op entirely (eliminating the dead per-token DRAM reads + L1 CB), stops writing the unused metadata fields, and trims metadata_len 5 → 3.

### Changes

- Dispatch op signature: dropped weights_tensor from the public op (dispatch.{hpp,cpp}, dispatch_device_operation.{hpp,cpp}, dispatch_types.hpp DispatchInputs, dispatch_nanobind.cpp) and its layout/dtype validation asserts.
- Kernels: removed the weights CB, DRAM reads, and accessor from reader_dispatch, writer_dispatch, reader_untilize_dispatch; stopped writing meta[3]/meta[4]. Required a synchronized compile-time/runtime arg reindex across these kernels and both program-factory paths (create_at_tile_layout + create_at_row_major), including the weights c_2 CB removal and the dispatch_core_idx RT-arg index shift.
- metadata_len 5 → 3 (init_helpers.py): row is now exactly [src_chip, token_idx, topk_slot]. Note: this is for clarity, not memory — the INT32 row is below the 32 B DRAM alignment floor, so the aligned page size is unchanged.
- Reference + validator: torch dispatch.py writes only 3 fields; validate_dispatch_metadata compares cols 0–2 and drops the weight/routed_expert checks. Docstrings (tt_dispatch.py, tt_combine.py, nanobind) updated.
- TtDispatchModule.forward(weights=...) is retained as a no-op param (documented) to avoid churning positional call sites; the op no longer consumes it.

### Impact

- Breaking: removes the weights_tensor positional arg from the dispatch op. Direct op callers updated (tt_dispatch.py, test_dispatch_combine_l1_small_semaphores.py).
- Eliminates the dispatch-side weights DRAM readand the associated L1 scratch.

Before: `2.1 us per batch`
<img width="3052" height="660" alt="image" src="https://github.com/user-attachments/assets/ed338339-f811-4f9d-ae21-0098f878981c" />

After perf optimization: `1.3 us per batch`
<img width="4088" height="486" alt="image" src="https://github.com/user-attachments/assets/547e129e-55d3-40f3-8052-a7b128e8221d" />

### DeepSeek CI

- [x] [![(T3K) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=pmilojevic/metadata-optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:pmilojevic/metadata-optimization)
- [x] [![(BH) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pmilojevic/metadata-optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pmilojevic/metadata-optimization)
- [x] [![Demo SP
Release](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=pmilojevic/metadata-optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:pmilojevic/metadata-optimization)
- [x] [![(Galaxy) DeepSeek Prefill
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=pmilojevic/metadata-optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:pmilojevic/metadata-optimization)


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pmilojevic/metadata-optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pmilojevic/metadata-optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pmilojevic/metadata-optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pmilojevic/metadata-optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pmilojevic/metadata-optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pmilojevic/metadata-optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilojevic/metadata-optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilojevic/metadata-optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pmilojevic/metadata-optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pmilojevic/metadata-optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pmilojevic/metadata-optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pmilojevic/metadata-optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pmilojevic/metadata-optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pmilojevic/metadata-optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pmilojevic/metadata-optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pmilojevic/metadata-optimization)