### PR TITLE
group_norm: reject ROW_MAJOR interleaved input instead of hanging (#47972)

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -1273,6 +1273,42 @@ def test_group_norm_negative_tests(
         )
 
 
+def test_group_norm_rejects_non_tile_aligned_spatial(device, expect_error):
+    # group_norm reduces over the flattened spatial dimension (N*H*W) in 32-row
+    # tiles, so that dimension must be a whole number of tiles -- otherwise the
+    # trailing partial tile would be silently dropped from the mean/variance,
+    # producing wrong results. Here N*H*W = 16, which is not a multiple of 32.
+    #
+    # A TILE input cannot exercise this (TILE pads the row dim up to 32), and a
+    # ROW_MAJOR interleaved input is rejected earlier as unsupported on the
+    # non-sharded path. A sharded input keeps the unpadded row dim and reaches the
+    # invariant check, so use that to cover it.
+    C, HW, num_groups = 320, 16, 32
+    torch_input_tensor = torch.rand((1, 1, HW, C), dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))})
+    shard_spec = ttnn.ShardSpec(shard_grid, (HW, C), ttnn.ShardOrientation.ROW_MAJOR)
+    sharded_mem_config = ttnn.MemoryConfig(
+        ttnn.types.TensorMemoryLayout.BLOCK_SHARDED, ttnn.types.BufferType.L1, shard_spec
+    )
+    input_tensor = ttnn.to_memory_config(input_tensor, memory_config=sharded_mem_config)
+
+    with expect_error(RuntimeError, "must be divisible by the tile size"):
+        ttnn.group_norm(
+            input_tensor,
+            num_groups=num_groups,
+            memory_config=sharded_mem_config,
+            core_grid=ttnn.CoreGrid(y=1, x=1),
+        )
+
+
 def test_group_norm_rejects_host_input_mask(device, expect_error):
     # TILE layout: a ROW_MAJOR interleaved input is rejected earlier (it is unsupported
     # on the non-sharded path), which would pre-empt the host-input-mask check this test

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -107,7 +107,10 @@ OPTIONAL_WEIGHT_BIAS_AFFINE_PARAMS = [
 OPTIONAL_WEIGHT_BIAS_AFFINE_IDS = ["no_affine", "weight_only", "bias_only"]
 
 NEGATIVE_TESTS_PARAMS = [
-    ((2, 1, 16, 32), 8, "must be a multiple of the tile height"),
+    # ttnn.empty produces a ROW_MAJOR interleaved input, which the non-sharded path
+    # rejects up front (it is unsupported there); this fires before the tile-height
+    # check that this shape would otherwise trip.
+    ((2, 1, 16, 32), 8, "interleaved \\(non-sharded\\) input must be in TILE layout"),
 ]
 
 
@@ -1258,9 +1261,10 @@ def test_group_norm_negative_tests(
     num_groups,
     msg_pattern,
     device,
+    expect_error,
 ):
     input_tensor = ttnn.empty(input_shape, device=device)
-    with pytest.raises(RuntimeError, match=msg_pattern):
+    with expect_error(RuntimeError, msg_pattern):
         ttnn.group_norm(
             input_tensor,
             num_groups=num_groups,
@@ -1269,11 +1273,14 @@ def test_group_norm_negative_tests(
         )
 
 
-def test_group_norm_rejects_host_input_mask(device):
-    input_tensor = ttnn.empty((1, 1, 32, 320), device=device)
+def test_group_norm_rejects_host_input_mask(device, expect_error):
+    # TILE layout: a ROW_MAJOR interleaved input is rejected earlier (it is unsupported
+    # on the non-sharded path), which would pre-empt the host-input-mask check this test
+    # targets.
+    input_tensor = ttnn.empty((1, 1, 32, 320), device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
     input_mask = ttnn.create_group_norm_input_mask(320, 32, 1, ttnn.DataType.BFLOAT16)
 
-    with pytest.raises(RuntimeError, match="Input mask must be on device"):
+    with expect_error(RuntimeError, "Input mask must be on device"):
         ttnn.group_norm(
             input_tensor,
             num_groups=32,
@@ -1283,7 +1290,7 @@ def test_group_norm_rejects_host_input_mask(device):
         )
 
 
-def test_group_norm_rejects_host_negative_mask(device):
+def test_group_norm_rejects_host_negative_mask(device, expect_error):
     grid_size = ttnn.CoreGrid(y=1, x=1)
     torch_input_tensor = torch.rand((1, 320, 32, 32), dtype=torch.bfloat16)
     input_tensor = torch_input_tensor.permute(0, 2, 3, 1).view(1, 1, 32 * 32, 320)
@@ -1306,7 +1313,7 @@ def test_group_norm_rejects_host_negative_mask(device):
     )
     input_tensor = ttnn.to_memory_config(input_tensor, memory_config=sharded_mem_config)
 
-    with pytest.raises(RuntimeError, match="Negative mask must be on device"):
+    with expect_error(RuntimeError, "Negative mask must be on device"):
         ttnn.group_norm(
             input_tensor,
             num_groups=32,

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
@@ -183,6 +183,21 @@ Tensor group_norm(
         input_tensor.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
         "Unsupported memory layout: Input tensor cannot be width-sharded.");
 
+    // The non-sharded (interleaved) group_norm only has a correct TILE-input /
+    // TILE-output compute path. See #47972 and #48142
+    if (!input_tensor.is_sharded()) {
+        TT_FATAL(
+            input_tensor.layout() == Layout::TILE,
+            "group_norm: interleaved (non-sharded) input must be in TILE layout, got ROW_MAJOR. "
+            "Convert the input with ttnn.to_layout(input, ttnn.TILE_LAYOUT) before calling group_norm. "
+            "ROW_MAJOR is supported only for sharded inputs.");
+        TT_FATAL(
+            output_layout.value_or(Layout::TILE) == Layout::TILE,
+            "group_norm: interleaved (non-sharded) output must be in TILE layout, got ROW_MAJOR output_layout. "
+            "Request TILE output and convert it yourself with ttnn.to_layout(output, ttnn.ROW_MAJOR_LAYOUT). "
+            "ROW_MAJOR output is supported only for sharded inputs.");
+    }
+
     const auto& input_shape = input_tensor.logical_shape();
     TT_FATAL(
         input_shape.rank() == 4, "Invalid tensor shape: Input tensor must have rank 4. (rank={})", input_shape.rank());

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
@@ -82,6 +82,11 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
                     * - BFLOAT16
                       - TILE, ROW_MAJOR
 
+                ROW_MAJOR input is supported only for sharded inputs. An interleaved
+                (non-sharded) input must be in TILE layout; convert it first with
+                ``ttnn.to_layout(input, ttnn.TILE_LAYOUT)`` (and convert the output
+                back with ``ttnn.to_layout`` if a ROW_MAJOR result is required).
+
                 .. list-table:: weight (gamma) and bias (beta)
                     :header-rows: 1
 


### PR DESCRIPTION
### Problem

`ttnn.group_norm` deadlocks the host forever when given a ROW_MAJOR interleaved (non-sharded) DRAM input (#47972). The program is dispatched but never signals completion, so the host spins at ~100% CPU in `completion_queue_wait_front`.

### Root cause

The non-sharded group_norm only has a correct **TILE-input / TILE-output** compute path. Its ROW_MAJOR kernel paths were forked from the sharded kernels but never wired up for the DRAM-streaming model, so on the interleaved path ROW_MAJOR is broken in both directions:

- **ROW_MAJOR input** (`TILIZE_IN`): the compute kernel tilizes the per-core input once upfront and assumes it stays resident across all three group-norm passes (true for sharded, where the input is the L1 shard). The interleaved reader instead re-streams the input from DRAM per pass, so the `cb_in0`/`cb_in` producer/consumer counts never balance → deadlock.
- **ROW_MAJOR output** (`UNTILIZE_OUT`): the row-major stick-write lives only behind `READER_REPACK`, which the host enables only for non-tile-aligned channels. For tile-aligned channels (e.g. C=32) the untilized data is never written → silently numerically wrong output (verified: max abs error ~4 vs ~0.03 TILE baseline).

No test exercised either ROW_MAJOR path (every DRAM test host-tilizes and requests TILE output), which is why this went unnoticed despite the docs advertising ROW_MAJOR as a supported input layout.

### This change

Implementing the ROW_MAJOR path correctly is a real kernel effort (tracked in #48142). As a stopgap, turn the silent failures into actionable errors: on the non-sharded path, reject both a ROW_MAJOR input and a ROW_MAJOR `output_layout` up front and tell the caller to tilize/untilize themselves with `ttnn.to_layout` — verified to work correctly against the unmodified op. The **sharded** path is unaffected (it has dedicated, correct row-major kernels). Op docs updated to state ROW_MAJOR input is supported only for sharded inputs.

### Testing

Verified on Blackhole:
- ROW_MAJOR interleaved input → actionable `TT_FATAL` immediately instead of hanging.
- TILE input + explicit `output_layout=ROW_MAJOR` → actionable `TT_FATAL` (previously returned silently-wrong results).
- TILE input with default and explicit TILE output → still run correctly.
- The documented host-side workaround (tilize → group_norm TILE→TILE → untilize) produces correct results (0 NaN, max abs diff 0.0312, matching the TILE→TILE baseline).
- Existing TILE-input DRAM tests still pass; the sharded ROW_MAJOR path is untouched.

Fixes #47972.
Follow-up for real in-kernel ROW_MAJOR support: #48142.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rmillerTT/47972_group_norm_deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rmillerTT/47972_group_norm_deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rmillerTT/47972_group_norm_deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rmillerTT/47972_group_norm_deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rmillerTT/47972_group_norm_deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rmillerTT/47972_group_norm_deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rmillerTT/47972_group_norm_deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rmillerTT/47972_group_norm_deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rmillerTT/47972_group_norm_deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rmillerTT/47972_group_norm_deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rmillerTT/47972_group_norm_deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rmillerTT/47972_group_norm_deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rmillerTT/47972_group_norm_deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rmillerTT/47972_group_norm_deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rmillerTT/47972_group_norm_deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rmillerTT/47972_group_norm_deadlock)