### PR TITLE
[Metal 2.0 prereq] Device 2.0 migration: writer_unary_stick_layout_interleaved_start_id (unblocks embedding)

### DIFF
--- a/ttnn/cpp/ttnn/kernel/dataflow/writer_unary_stick_layout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/kernel/dataflow/writer_unary_stick_layout_interleaved_start_id.cpp
@@ -4,7 +4,15 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
 
+// Device 2.0 idiom migration (behavior-preserving): the device-side API moves from free-function
+// CB/NoC calls (cb_wait_front/get_read_ptr/noc_async_write/cb_pop_front) to the Noc + CircularBuffer
+// wrapper objects. The runtime/compile-time arg layout (positional) is intentionally unchanged so
+// every legacy ProgramDescriptor consumer (embedding RM/tilized, indexed_fill, copy, concat, slice)
+// keeps working without edits. Per-stick async_write + barrier semantics are preserved exactly.
 void kernel_main() {
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
     uint32_t stick_size = get_arg_val<uint32_t>(1);
@@ -14,6 +22,8 @@ void kernel_main() {
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
     constexpr auto dst0_args = TensorAccessorArgs<2>();
 
+    Noc noc;
+    CircularBuffer cb_out0(cb_id_out0);
     const auto s0 = TensorAccessor(dst0_args, dst_addr);
 
 #ifdef BACKWARDS
@@ -23,11 +33,9 @@ void kernel_main() {
     uint32_t end_id = start_id + num_sticks;
     for (uint32_t i = start_id; i < end_id; ++i) {
 #endif
-        cb_wait_front(cb_id_out0, 1);
-        uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
-        uint64_t dst_noc_addr = s0.get_noc_addr(i);
-        noc_async_write(l1_read_addr, dst_noc_addr, stick_size);
-        noc_async_write_barrier();
-        cb_pop_front(cb_id_out0, 1);
+        cb_out0.wait_front(1);
+        noc.async_write(cb_out0, s0, stick_size, {}, {.page_id = i});
+        noc.async_write_barrier();
+        cb_out0.pop_front(1);
     }
 }


### PR DESCRIPTION
## Metal 2.0 prereq: Device 2.0 migration of the shared stick writer

Idiom-only, **behavior-preserving** conversion of `ttnn/cpp/ttnn/kernel/dataflow/writer_unary_stick_layout_interleaved_start_id.cpp` from Device 1.0 (`get_write_ptr(cb_id)`, raw `noc_async_write`, `cb_*` free functions) to Device 2.0 (`Noc` + `CircularBuffer` wrappers + `TensorAccessor`). No functional change, no L1/perf change, identical CTA layout (all callers unchanged).

**Why:** this shared writer being Device 1.0 is the sole gate that makes the `embedding` op's Metal 2.0 pre-port audit RED (blocks the RM + tilized-indices factories). This migration unblocks that port. The writer is also consumed by `indexed_fill`, `copy`, `concat`, and `slice`.

**Validation (Wormhole n150):**
- `embedding` **54/54 pass** — directly exercises this writer via the RM/tilized factories. ✅
- Full shared-consumer regression (indexed_fill/copy/concat/slice) **deferred to CI**: `test_indexed_fill` hangs after its first case **identically on baseline** (verified by stashing this change) — a pre-existing device flake, not introduced here.

This is a Metal-2.0 **prerequisite** (a separate, behavior-preserving change), not a port — kept out of any port PR per the migration methodology. Audit: `embedding/METAL2_PREPORT_AUDIT.md` (see #48139). Umbrella: #46909.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vsureshTT/metal2-prereq-embedding-d2-stick-writer)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vsureshTT/metal2-prereq-embedding-d2-stick-writer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vsureshTT/metal2-prereq-embedding-d2-stick-writer)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vsureshTT/metal2-prereq-embedding-d2-stick-writer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vsureshTT/metal2-prereq-embedding-d2-stick-writer)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vsureshTT/metal2-prereq-embedding-d2-stick-writer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vsureshTT/metal2-prereq-embedding-d2-stick-writer)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vsureshTT/metal2-prereq-embedding-d2-stick-writer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vsureshTT/metal2-prereq-embedding-d2-stick-writer)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vsureshTT/metal2-prereq-embedding-d2-stick-writer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vsureshTT/metal2-prereq-embedding-d2-stick-writer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vsureshTT/metal2-prereq-embedding-d2-stick-writer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vsureshTT/metal2-prereq-embedding-d2-stick-writer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vsureshTT/metal2-prereq-embedding-d2-stick-writer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vsureshTT/metal2-prereq-embedding-d2-stick-writer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vsureshTT/metal2-prereq-embedding-d2-stick-writer)