### PR TITLE
[Metal2 prereq] Device 2.0 migration of generate_bcast_scalar.hpp (unblocks sampling)

### DIFF
--- a/ttnn/cpp/ttnn/kernel/dataflow/generate_bcast_scalar.hpp
+++ b/ttnn/cpp/ttnn/kernel/dataflow/generate_bcast_scalar.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/circular_buffer.h"
 
 // W-bcast scalar
 // Tile is assumed to have 16-bit elements
@@ -41,9 +42,9 @@ FORCE_INLINE void generate_bcast_row_scalar(const uint32_t cb_id, const uint32_t
 // Tile is assumed to have 16-bit elements
 // Scalar is assumed to be a 16-bit value double packed into a u32
 FORCE_INLINE void generate_bcast_unary_scalar(const uint32_t cb_id, const uint32_t scalar) {
-    const uint32_t scalar_val = scalar >> 16;
-    cb_reserve_back(cb_id, 1);
-    volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
+    CircularBuffer cb(cb_id);
+    cb.reserve_back(1);
+    volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb.get_write_ptr());
     ptr[0] = scalar >> 16;
-    cb_push_back(cb_id, 1);
+    cb.push_back(1);
 }


### PR DESCRIPTION
## Summary

Device 2.0 idiom migration of `generate_bcast_unary_scalar` in `ttnn/cpp/ttnn/kernel/dataflow/generate_bcast_scalar.hpp`.

This is a **prerequisite** for the Metal 2.0 port of `reduction/sampling` (audited RED in #48139 because it depends on this shared Device-1.0 donor helper). The change is **behavior-preserving and signature-preserving**:

- Replaced the free-function CB idiom (`cb_reserve_back`/`get_write_ptr`/`cb_push_back`) with the Device 2.0 `CircularBuffer` wrapper (`.reserve_back`/`.get_write_ptr`/`.push_back`).
- Kept the `(const uint32_t cb_id, const uint32_t scalar)` signature unchanged, so **no callers need edits**.
- Only the `generate_bcast_unary_scalar` (HW-bcast) variant is migrated. The `col`/`row` variants are left as Device 1.0 — they're consumed by layernorm/groupnorm/rmsnorm, which are out of scope here.

## What was validated (Wormhole n150)

- **`reduction/sampling`** (direct consumer): 26/26 passed (43.44s).
- **`normalization/softmax`** attention kernels (direct consumer of the migrated unary variant): 144 passed, 0 failed (99.56s).

The full set of shared consumers (sdpa ring writers, bcast reader) is deferred to CI.

## Tracking

- Umbrella / tracking thread: #46909
- Source audit (documents why sampling was RED on this donor): #48139

🤖 Generated with [Claude Code](https://claude.com/claude-code)
