### PR TITLE
[LLK][BH] Drain packer in set_packer_strides to fix fast-tilize/untilize uninit

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cpack_common.h
@@ -314,7 +314,10 @@ inline void set_packer_strides(const std::uint32_t pack_src_format, const std::u
     TT_SETDMAREG(0, UPPER_HALFWORD((y_stride << PCK0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT)), 0, HI_16(p_gpr_pack::TMP0));
     TT_SETDMAREG(0, LOWER_HALFWORD((z_stride << PCK0_ADDR_CTRL_ZW_REG_0_Zstride_SHAMT)), 0, LO_16(p_gpr_pack::TMP1));
     TT_SETDMAREG(0, UPPER_HALFWORD((w_stride << PCK0_ADDR_CTRL_ZW_REG_0_Wstride_SHAMT)), 0, HI_16(p_gpr_pack::TMP1));
-    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
+    // Drain the packer (PACK), not just order against THCON: the packer reads these stride config
+    // registers while running, and callers (e.g. fast-tilize/untilize uninit) reprogram them right
+    // after packing when the packer may still be busy.
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK | p_stall::THCON);
     TTI_WRCFG(p_gpr_pack::TMP0, p_cfg::WRCFG_32b, PCK0_ADDR_CTRL_XY_REG_0_Xstride_ADDR32);
     TTI_WRCFG(p_gpr_pack::TMP1, p_cfg::WRCFG_32b, PCK0_ADDR_CTRL_ZW_REG_0_Zstride_ADDR32);
     TTI_NOP;


### PR DESCRIPTION
**### THIS PR NEEDS COMPLETION OF ISA DOC REGARDING TIMES OF REGISTER SAMPLING**

https://github.com/tenstorrent/tt-llk/issues/747

On Blackhole, set_packer_strides reprograms packer stride config registers (PCK0_ADDR_CTRL_XY/ZW_REG_0) guarded only by STALLWAIT(STALL_CFG, THCON), which orders the GPR->cfg write but does NOT drain the packer pipeline.

_llk_pack_fast_tilize_uninit_ (non-fp32 path) and _llk_pack_fast_untilize_uninit_ call set_packer_strides immediately after packing, when the packer is not guaranteed idle. Reprogramming live packer config there can corrupt an in-flight pack. The Wormhole equivalent avoids this (its set_packer_strides waits on PACK, and the fast-tilize uninit opens with STALLWAIT(STALL_CFG, PACK)).

Widen the condition mask to PACK | THCON so the stall also drains the packer, mirroring the fp32 reconfig path (reconfig_packer_data_format). Where the packer is already idle (normal pack init / reconfig callers), the added PACK condition is satisfied immediately and is effectively a no-op.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/bh-pack-fast-tilize-uninit-packer-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/bh-pack-fast-tilize-uninit-packer-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/bh-pack-fast-tilize-uninit-packer-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/bh-pack-fast-tilize-uninit-packer-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/bh-pack-fast-tilize-uninit-packer-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/bh-pack-fast-tilize-uninit-packer-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/bh-pack-fast-tilize-uninit-packer-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/bh-pack-fast-tilize-uninit-packer-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/bh-pack-fast-tilize-uninit-packer-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/bh-pack-fast-tilize-uninit-packer-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/bh-pack-fast-tilize-uninit-packer-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/bh-pack-fast-tilize-uninit-packer-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/bh-pack-fast-tilize-uninit-packer-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/bh-pack-fast-tilize-uninit-packer-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/bh-pack-fast-tilize-uninit-packer-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/bh-pack-fast-tilize-uninit-packer-drain)