### PR TITLE
#47797: nlp_create_qkv_heads_decode — single-producer output CBs (Metal 2.0 SPSC prereq)

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_interleaved_program_factory.cpp
@@ -144,7 +144,8 @@ tt::tt_metal::ProgramDescriptor NLPCreateQKVHeadsDecodeInterleavedProgramFactory
         num_q_heads,
         num_kv_heads,
         head_tiles,
-        1,  // read the first phase
+        0,  // read all phases on a single RISC -> single producer per output CB (SPSC pre-port fix;
+            // the former two-RISC phase split was an L1/NOC-bandwidth optimization, deferred)
         static_cast<uint32_t>(use_aligned_path),
         dram_alignment,
         reader_scratch_cb_index,
@@ -160,18 +161,12 @@ tt::tt_metal::ProgramDescriptor NLPCreateQKVHeadsDecodeInterleavedProgramFactory
     reader_desc.compile_time_args = reader_compile_time_args;
     reader_desc.config = ReaderConfigDescriptor{};
 
-    std::vector<uint32_t> writer_compile_time_args = reader_compile_time_args;
-    writer_compile_time_args[9] = 2;  // read the second phase
-    writer_compile_time_args[12] = writer_scratch_cb_index;
-
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/"
-        "reader_interleaved_tm_tile_layout_nlp_create_qkv_heads_decode.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = q_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterConfigDescriptor{};
+    // SPSC pre-port fix: the output CBs c_16/c_17/c_18 are borrowed-memory output CBs; the former
+    // design ran this kernel on two RISCs (phase 1 / phase 2) that BOTH wrote the same output CBs
+    // -> two producers per node. Collapse to a single reader RISC reading all phases (CTA[9]=0
+    // above) so each output CB has exactly one producer. (void) the now-unused writer scratch CB
+    // index to keep the aligned-path allocation harmless.
+    (void)writer_scratch_cb_index;
 
     uint32_t num_cores = q_cores.num_cores();  // number of cores of the output
     auto core_grid = q_cores.bounding_box();
@@ -184,11 +179,9 @@ tt::tt_metal::ProgramDescriptor NLPCreateQKVHeadsDecodeInterleavedProgramFactory
 
         const auto& core = cores[i];
         reader_desc.emplace_runtime_args(core, {in_tile_offset_by_batch, in_buffer});
-        writer_desc.emplace_runtime_args(core, {in_tile_offset_by_batch, in_buffer});
     }
 
     desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
 
     return desc;
 }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_sharded_program_factory.cpp
@@ -31,9 +31,10 @@ tt::tt_metal::ProgramDescriptor NLPCreateQKVHeadsDecodeShardedProgramFactory::cr
     ProgramDescriptor desc;
 
     IDevice* device = input_tensor.device();
-    // Create CBs for reader/writer for batch_offset
+    // Single batch_offset CB: the op now reads all phases on one RISC per q/k (SPSC pre-port fix),
+    // so only the reader's batch_offset CB is needed. (The former design allocated a second CB
+    // (c_14) for the phase-2 writer RISC; that RISC is gone, so c_14 is dropped.)
     uint32_t batch_offset_cb_index_reader = CBIndex::c_15;
-    uint32_t batch_offset_cb_index_writer = CBIndex::c_14;
 
     tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
 
@@ -71,16 +72,6 @@ tt::tt_metal::ProgramDescriptor NLPCreateQKVHeadsDecodeShardedProgramFactory::cr
             .core_ranges = qk_cores,
             .format_descriptors = {{CBFormatDescriptor{
                 .buffer_index = static_cast<uint8_t>(batch_offset_cb_index_reader),
-                .data_format = cb_batch_offset_data_format,
-                .page_size = 1,
-            }}},
-        });
-
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = single_batch_offset_tile_size,
-            .core_ranges = qk_cores,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(batch_offset_cb_index_writer),
                 .data_format = cb_batch_offset_data_format,
                 .page_size = 1,
             }}},
@@ -166,8 +157,11 @@ tt::tt_metal::ProgramDescriptor NLPCreateQKVHeadsDecodeShardedProgramFactory::cr
         process_k = 0;
     }
 
-    // We parallelize the reader on risc0 and risc1, where each risc reads a sub-tile of the input (phase1 and phase2
-    // of a tile respectively)
+    // SPSC pre-port fix: read all phases on a single RISC per q/k so each output CB (c_16/c_17/c_18)
+    // has exactly one producer. The former design split phase1/phase2 across two RISCs (reader +
+    // writer) that both wrote the same output CBs -> two producers per node. The split was an
+    // L1/NOC-bandwidth optimization; it is deferred until the framework supports multi-producer DFB
+    // endpoints.
     std::vector<uint32_t> q_reader_compile_time_args = {
         (std::uint32_t)element_size,
         (std::uint32_t)sub_tile_line_bytes,
@@ -178,7 +172,7 @@ tt::tt_metal::ProgramDescriptor NLPCreateQKVHeadsDecodeShardedProgramFactory::cr
         num_q_heads,
         num_kv_heads,
         head_tiles,
-        1,  // read the first phase
+        0,  // read all phases on this single RISC
         in_num_cores_x,
         in_num_cores_y,
         process_qv,                        // read and write q and v heads
@@ -197,20 +191,7 @@ tt::tt_metal::ProgramDescriptor NLPCreateQKVHeadsDecodeShardedProgramFactory::cr
     q_reader_desc.compile_time_args = q_reader_compile_time_args;
     q_reader_desc.config = ReaderConfigDescriptor{};
 
-    std::vector<uint32_t> q_writer_compile_time_args = q_reader_compile_time_args;
-    q_writer_compile_time_args[9] = 2;  // read the second phase
-
-    KernelDescriptor q_writer_desc;
-    q_writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/"
-        "reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp";
-    q_writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    q_writer_desc.core_ranges = q_cores;
-    q_writer_desc.compile_time_args = std::move(q_writer_compile_time_args);
-    q_writer_desc.config = WriterConfigDescriptor{};
-
     KernelDescriptor k_reader_desc;
-    KernelDescriptor k_writer_desc;
     if (!overlap_qk_coregrid) {
         // Switch process_qv and process_k for k kernels
         process_qv = 0;
@@ -226,17 +207,6 @@ tt::tt_metal::ProgramDescriptor NLPCreateQKVHeadsDecodeShardedProgramFactory::cr
         k_reader_desc.core_ranges = k_cores;
         k_reader_desc.compile_time_args = k_reader_compile_time_args;
         k_reader_desc.config = ReaderConfigDescriptor{};
-
-        std::vector<uint32_t> k_writer_compile_time_args = k_reader_compile_time_args;
-        k_writer_compile_time_args[9] = 2;  // read the second phase
-
-        k_writer_desc.kernel_source =
-            "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/"
-            "reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp";
-        k_writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        k_writer_desc.core_ranges = k_cores;
-        k_writer_desc.compile_time_args = std::move(k_writer_compile_time_args);
-        k_writer_desc.config = WriterConfigDescriptor{};
     }
 
     auto push_batch_offset = [&](KernelDescriptor::RTArgList& rt) {
@@ -258,7 +228,6 @@ tt::tt_metal::ProgramDescriptor NLPCreateQKVHeadsDecodeShardedProgramFactory::cr
         rt.append(noc_y_coords);
 
         q_reader_desc.emplace_runtime_args(core, rt);
-        q_writer_desc.emplace_runtime_args(core, rt);
     }
 
     if (!overlap_qk_coregrid) {
@@ -273,15 +242,12 @@ tt::tt_metal::ProgramDescriptor NLPCreateQKVHeadsDecodeShardedProgramFactory::cr
             rt.append(noc_y_coords);
 
             k_reader_desc.emplace_runtime_args(core, rt);
-            k_writer_desc.emplace_runtime_args(core, rt);
         }
     }
 
     desc.kernels.push_back(std::move(q_reader_desc));
-    desc.kernels.push_back(std::move(q_writer_desc));
     if (!overlap_qk_coregrid) {
         desc.kernels.push_back(std::move(k_reader_desc));
-        desc.kernels.push_back(std::move(k_writer_desc));
     }
 
     return desc;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_sharded_subcoregrid_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_sharded_subcoregrid_program_factory.cpp
@@ -31,9 +31,10 @@ tt::tt_metal::ProgramDescriptor NLPCreateQKVHeadsDecodeShardedSubcoregridProgram
     ProgramDescriptor desc;
 
     IDevice* device = input_tensor.device();
-    // Create CBs for reader/writer for batch_offset
+    // Single batch_offset CB: the op now reads all phases on one RISC per q/k (SPSC pre-port fix),
+    // so only the reader's batch_offset CB is needed. (The former design allocated a second CB
+    // (c_14) for the phase-2 writer RISC; that RISC is gone, so c_14 is dropped.)
     uint32_t batch_offset_cb_index_reader = CBIndex::c_15;
-    uint32_t batch_offset_cb_index_writer = CBIndex::c_14;
 
     tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
 
@@ -71,16 +72,6 @@ tt::tt_metal::ProgramDescriptor NLPCreateQKVHeadsDecodeShardedSubcoregridProgram
             .core_ranges = qk_cores,
             .format_descriptors = {{CBFormatDescriptor{
                 .buffer_index = static_cast<uint8_t>(batch_offset_cb_index_reader),
-                .data_format = cb_batch_offset_data_format,
-                .page_size = 1,
-            }}},
-        });
-
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = single_batch_offset_tile_size,
-            .core_ranges = qk_cores,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(batch_offset_cb_index_writer),
                 .data_format = cb_batch_offset_data_format,
                 .page_size = 1,
             }}},
@@ -162,8 +153,11 @@ tt::tt_metal::ProgramDescriptor NLPCreateQKVHeadsDecodeShardedSubcoregridProgram
         process_k = 0;
     }
 
-    // We parallelize the reader on risc0 and risc1, where each risc reads a sub-tile of the input (phase1 and phase2
-    // of a tile respectively)
+    // SPSC pre-port fix: read all phases on a single RISC per q/k so each output CB (c_16/c_17/c_18)
+    // has exactly one producer. The former design split phase1/phase2 across two RISCs (reader +
+    // writer) that both wrote the same output CBs -> two producers per node. The split was an
+    // L1/NOC-bandwidth optimization; it is deferred until the framework supports multi-producer DFB
+    // endpoints.
     std::vector<uint32_t> q_reader_compile_time_args = {
         element_size,
         sub_tile_line_bytes,
@@ -174,7 +168,7 @@ tt::tt_metal::ProgramDescriptor NLPCreateQKVHeadsDecodeShardedSubcoregridProgram
         num_q_heads,
         num_kv_heads,
         head_tiles,
-        1,  // read the first phase
+        0,  // read all phases on this single RISC
         in_num_cores,
         process_qv,                        // read and write q and v heads
         process_k,                         // read and write k heads
@@ -193,21 +187,7 @@ tt::tt_metal::ProgramDescriptor NLPCreateQKVHeadsDecodeShardedSubcoregridProgram
     q_reader_desc.compile_time_args = q_reader_compile_time_args;
     q_reader_desc.config = ReaderConfigDescriptor{};
 
-    std::vector<uint32_t> q_writer_compile_time_args = q_reader_compile_time_args;
-    q_writer_compile_time_args[9] = 2;  // read the second phase
-    q_writer_compile_time_args[15] = batch_offset_cb_index_writer;
-
-    KernelDescriptor q_writer_desc;
-    q_writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/"
-        "reader_tm_tile_layout_nlp_create_qkv_heads_decode_on_subcoregrids.cpp";
-    q_writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    q_writer_desc.core_ranges = q_cores;
-    q_writer_desc.compile_time_args = std::move(q_writer_compile_time_args);
-    q_writer_desc.config = WriterConfigDescriptor{};
-
     KernelDescriptor k_reader_desc;
-    KernelDescriptor k_writer_desc;
     if (!overlap_qk_coregrid) {
         // Switch process_qv and process_k for k kernels
         process_qv = 0;
@@ -223,18 +203,6 @@ tt::tt_metal::ProgramDescriptor NLPCreateQKVHeadsDecodeShardedSubcoregridProgram
         k_reader_desc.core_ranges = k_cores;
         k_reader_desc.compile_time_args = k_reader_compile_time_args;
         k_reader_desc.config = ReaderConfigDescriptor{};
-
-        std::vector<uint32_t> k_writer_compile_time_args = k_reader_compile_time_args;
-        k_writer_compile_time_args[9] = 2;  // read the second phase
-        k_writer_compile_time_args[15] = batch_offset_cb_index_writer;
-
-        k_writer_desc.kernel_source =
-            "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/"
-            "reader_tm_tile_layout_nlp_create_qkv_heads_decode_on_subcoregrids.cpp";
-        k_writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        k_writer_desc.core_ranges = k_cores;
-        k_writer_desc.compile_time_args = std::move(k_writer_compile_time_args);
-        k_writer_desc.config = WriterConfigDescriptor{};
     }
 
     auto push_batch_offset = [&](KernelDescriptor::RTArgList& rt) {
@@ -255,7 +223,6 @@ tt::tt_metal::ProgramDescriptor NLPCreateQKVHeadsDecodeShardedSubcoregridProgram
         rt.append(noc_x_coords);
         rt.append(noc_y_coords);
         q_reader_desc.emplace_runtime_args(core, rt);
-        q_writer_desc.emplace_runtime_args(core, rt);
     }
 
     if (!overlap_qk_coregrid) {
@@ -269,15 +236,12 @@ tt::tt_metal::ProgramDescriptor NLPCreateQKVHeadsDecodeShardedSubcoregridProgram
             rt.append(noc_x_coords);
             rt.append(noc_y_coords);
             k_reader_desc.emplace_runtime_args(core, rt);
-            k_writer_desc.emplace_runtime_args(core, rt);
         }
     }
 
     desc.kernels.push_back(std::move(q_reader_desc));
-    desc.kernels.push_back(std::move(q_writer_desc));
     if (!overlap_qk_coregrid) {
         desc.kernels.push_back(std::move(k_reader_desc));
-        desc.kernels.push_back(std::move(k_writer_desc));
     }
 
     return desc;


### PR DESCRIPTION
## What

Pre-port fix for `nlp_create_qkv_heads_decode` to satisfy the Metal 2.0 **single-producer-single-consumer (SPSC)** dataflow-buffer invariant.

All three program factories (interleaved, sharded, sharded_subcoregrid) instantiated the same reader kernel on **two RISCs**, each reading one tile phase and **both writing the output CBs** `c_16` (Q) / `c_17` (K) / `c_18` (V) → two producer endpoints per node. The op's `METAL2_PREPORT_AUDIT.md` flagged this as a RED SPSC blocker.

This collapses each factory to a **single reader RISC reading all phases** (reader compile-time phase-select = `0` → "read all phases"), so every output CB has exactly one producer. The dead writer scratch CB is dropped.

## Why this is safe

**Output-preserving — no functional/PCC change.** The two-RISC phase split was purely an L1/NOC-bandwidth optimization; it is **deferred**, not lost — it can be reintroduced after the port as a `QuasarDataMovementKernel` split that keeps one producer per CB.

## Validation (0 new failures vs baseline)

| Target | Result |
|---|---|
| WH n150 (HW) — full test file | **205 passed / 39 skipped** (244) across all 3 factories |
| &nbsp;&nbsp;• interleaved | 168 passed / 24 skipped = baseline |
| &nbsp;&nbsp;• sharded + subcoregrid | 37 passed / 15 skipped |
| WH craqsim (functional sim) — interleaved | 48 / 48 PASS |
| Quasar craqsim | host-blocks at `kernel.hpp:340` (legacy `DataMovementKernel`, op not yet ported) — **unchanged by this fix**, as expected |

The Quasar block is the "port-ready, not ported" wall: this PR clears the SPSC audit blocker so the op *can* be ported; the actual Metal 2.0 port (legacy `ProgramDescriptor` → `ProgramArtifacts` + `QuasarDataMovementKernel`) is a separate follow-up where Quasar/emu PCC validation will happen.

## Context

- Prereq for the Metal 2.0 migration umbrella #46909
- Documented in the audit PR #48139 (`METAL2_PREPORT_AUDIT.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
