### PR TITLE
[LLK][BH] Self-drain the packer in fast-untilize clear_output_row_stride

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_pack_fast_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_pack_fast_untilize.h
@@ -235,10 +235,8 @@ inline void _llk_pack_fast_untilize_clear_output_row_stride_()
 {
     TT_SETDMAREG(0, 0, 0, LO_16(p_gpr_pack::TMP0));
     TT_SETDMAREG(0, 0, 0, HI_16(p_gpr_pack::TMP0));
-    // Same SETDMAREG->WRCFG dependency as row-stride programming above: clear
-    // TMP0 first, then keep the WRCFGs behind the established LLK barrier.
-    // ISA documents WRCFG's GPR source and STALLWAIT's CFG block mask.
-    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
+    // Drain the packer (PACK) here rather than relying on the order of caller function calls to leave it idle.
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK | p_stall::THCON);
     TTI_WRCFG(p_gpr_pack::TMP0, p_cfg::WRCFG_32b, PCK0_ADDR_CTRL_XY_REG_1_Xstride_ADDR32);
     TTI_WRCFG(p_gpr_pack::TMP0, p_cfg::WRCFG_32b, PCK0_ADDR_BASE_REG_1_Base_ADDR32);
     // Same self-contained WRCFG scheduling bubble as above before later pack


### PR DESCRIPTION
_llk_pack_fast_untilize_clear_output_row_stride_ reprograms packer config registers (PCK0_ADDR_CTRL_XY_REG_1_Xstride, PCK0_ADDR_BASE_REG_1_Base) guarded only by STALLWAIT(STALL_CFG, THCON), which orders the SETDMAREG->WRCFG write but does NOT drain the packer pipeline that reads those registers.

It runs during fast-untilize teardown (_llk_pack_fast_untilize_uninit_). Current callers are safe only because the surrounding teardown drains the packer first (_llk_pack_dest_section_done_, _llk_init_packer_dest_offset_registers_, reconfig_packer_data_format) -- an undocumented ordering dependency, not part of the LLK contract. A reorder or a new caller would hit an intermittent reconfig escape.

Widen the condition to PACK | THCON so the function self-drains the packer instead of relying on caller call order, matching the companion set_packer_strides change and Wormhole behavior. Where the packer is already idle the added PACK condition is satisfied immediately (constexpr fold, same emitted instruction); the packer conditions are per-thread so this cannot over-wait on another thread.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/bh-pack-fast-untilize-clear-row-stride-packer-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/bh-pack-fast-untilize-clear-row-stride-packer-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/bh-pack-fast-untilize-clear-row-stride-packer-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/bh-pack-fast-untilize-clear-row-stride-packer-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/bh-pack-fast-untilize-clear-row-stride-packer-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/bh-pack-fast-untilize-clear-row-stride-packer-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/bh-pack-fast-untilize-clear-row-stride-packer-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/bh-pack-fast-untilize-clear-row-stride-packer-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/bh-pack-fast-untilize-clear-row-stride-packer-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/bh-pack-fast-untilize-clear-row-stride-packer-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/bh-pack-fast-untilize-clear-row-stride-packer-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/bh-pack-fast-untilize-clear-row-stride-packer-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/bh-pack-fast-untilize-clear-row-stride-packer-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/bh-pack-fast-untilize-clear-row-stride-packer-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/bh-pack-fast-untilize-clear-row-stride-packer-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/bh-pack-fast-untilize-clear-row-stride-packer-drain)