### PR TITLE
[Bug Fix]: Fix MAX_GEN_LEN param for Whisper after transformers version upgrade

### DIFF
--- a/models/demos/audio/whisper/tt/whisper_generator.py
+++ b/models/demos/audio/whisper/tt/whisper_generator.py
@@ -1018,7 +1018,7 @@ class WhisperGenerator:
             input_ids = self._pad_input_32(input_ids, self.config.pad_token_id).to(torch.long)
             decoder_start_values = self.generation_config.pad_token_id * torch.ones(1, 32).to(torch.long)
 
-        MAX_GEN_LEN = self.config.max_length
+        MAX_GEN_LEN = self.generation_config.max_length
         # Collect token IDs (not per-token decoded strings) for every non-timestamp run, both
         # streaming and non-streaming. The full ID sequence is decoded once at the end so that
         # multi-byte UTF-8 characters (e.g. CJK) split across BPE tokens are reassembled correctly.


### PR DESCRIPTION
transformers >= 5 dropped the legacy generation attributes (e.g. max_length) from the model config 
they now live on generation_config (448 for all supported Whisper variants).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=atupe/whisper-fix-transformers-upgrade)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:atupe/whisper-fix-transformers-upgrade)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=atupe/whisper-fix-transformers-upgrade)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:atupe/whisper-fix-transformers-upgrade)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=atupe/whisper-fix-transformers-upgrade)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:atupe/whisper-fix-transformers-upgrade)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=atupe/whisper-fix-transformers-upgrade)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:atupe/whisper-fix-transformers-upgrade)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=atupe/whisper-fix-transformers-upgrade)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:atupe/whisper-fix-transformers-upgrade)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=atupe/whisper-fix-transformers-upgrade)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:atupe/whisper-fix-transformers-upgrade)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=atupe/whisper-fix-transformers-upgrade)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:atupe/whisper-fix-transformers-upgrade)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=atupe/whisper-fix-transformers-upgrade)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:atupe/whisper-fix-transformers-upgrade)