### PR TITLE
Enable async scheduling for Gemma4 in vLLM

### DIFF
--- a/models/demos/gemma4/tt/generator.py
+++ b/models/demos/gemma4/tt/generator.py
@@ -108,9 +108,14 @@ def _patch_model_args(
 
 
 class Gemma4Generator(Generator):
+    # Kept in parity with ``Gemma4ForCausalLM.model_capabilities`` (the vLLM
+    # bridge that the TT platform actually reads). Async decode is supported:
+    # decode delegates to ``Generator.decode_forward`` (honours
+    # ``read_from_device=False``) and inherits ``read_decode_output`` with
+    # ``async_read=True``.
     model_capabilities = {
         "supports_prefix_caching": False,
-        "supports_async_decode": False,
+        "supports_async_decode": True,
     }
 
     def __init__(self, *args, **kwargs):

--- a/models/demos/gemma4/tt/generator_vllm.py
+++ b/models/demos/gemma4/tt/generator_vllm.py
@@ -105,7 +105,16 @@ class Gemma4ForCausalLM(HybridAttentionForCausalLM):
 
     model_capabilities = {
         "supports_prefix_caching": False,
-        "supports_async_decode": False,
+        # Async scheduling overlaps host scheduling/sampling with the next
+        # device step. Gemma4 satisfies the contract: ``decode_forward`` below
+        # routes the per-layer page tables and delegates to
+        # ``Generator.decode_forward`` (which honours ``read_from_device=False``,
+        # submitting decode without blocking), and Gemma4 inherits
+        # ``Generator.read_decode_output(..., async_read=True)`` for the deferred
+        # device->host read. On-device sampling (``supports_sample_on_device``)
+        # means decode already returns sampled tokens, so the async read carries
+        # the sampled ids directly.
+        "supports_async_decode": True,
         "supports_sample_on_device": True,
     }
 


### PR DESCRIPTION
### PR Category
Performance

### Summary
Set model_capabilities["supports_async_decode"] = True for Gemma4ForCausalLM (the vLLM bridge the TT plugin's platform.py reads) and Gemma4Generator (parity). Previously the TT platform force-disabled async scheduling at engine-core init because Gemma4 did not declare the capability.

The async-decode contract is satisfied: Gemma4ForCausalLM.decode_forward routes the per-layer page tables and delegates to Generator.decode_forward (which honours read_from_device=False to submit decode without blocking), and Gemma4 inherits Generator.read_decode_output(..., async_read=True) for the deferred device->host read. On-device sampling means decode already returns sampled tokens, so the async read carries the sampled ids directly.

Measured on QB2 (P300X2) gemma-4-12b-it, batch 1: decode TPOT improves ~9% (~+10% tok/s/u) with no TTFT change, since async overlaps host scheduling/sampling with the device forward pass.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dwadhwani/gemma4-vllm-async-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dwadhwani/gemma4-vllm-async-decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dwadhwani/gemma4-vllm-async-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dwadhwani/gemma4-vllm-async-decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dwadhwani/gemma4-vllm-async-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dwadhwani/gemma4-vllm-async-decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dwadhwani/gemma4-vllm-async-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dwadhwani/gemma4-vllm-async-decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dwadhwani/gemma4-vllm-async-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dwadhwani/gemma4-vllm-async-decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dwadhwani/gemma4-vllm-async-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dwadhwani/gemma4-vllm-async-decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dwadhwani/gemma4-vllm-async-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dwadhwani/gemma4-vllm-async-decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dwadhwani/gemma4-vllm-async-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dwadhwani/gemma4-vllm-async-decode)