### PR TITLE
#48155: plumb quasar through stack to allow models pytests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -908,6 +908,7 @@ ALL_ARCHS = set(
         "grayskull",
         "wormhole_b0",
         "blackhole",
+        "quasar",
     ]
 )
 

--- a/models/common/utility_functions.py
+++ b/models/common/utility_functions.py
@@ -1016,6 +1016,11 @@ def is_single_chip():
     return ttnn.GetNumAvailableDevices() == 1
 
 
+def is_quasar():
+    ARCH_NAME = ttnn.get_arch_name()
+    return "quasar" in ARCH_NAME
+
+
 def is_blackhole():
     ARCH_NAME = ttnn.get_arch_name()
     return "blackhole" in ARCH_NAME

--- a/models/tt_transformers/demo/trace_region_config.py
+++ b/models/tt_transformers/demo/trace_region_config.py
@@ -8,7 +8,7 @@ import re
 from loguru import logger
 
 import ttnn
-from models.common.utility_functions import is_blackhole, is_wormhole_b0
+from models.common.utility_functions import is_blackhole, is_quasar, is_wormhole_b0
 from models.demos.utils.model_targets import normalize_sku
 from models.demos.utils.trace_region_sizes import hf_model_name_candidates, resolve_trace_region_size_for_candidates
 
@@ -49,6 +49,10 @@ def get_mesh_device_name(num_devices, mesh_device_name):
             4: "N150x4",
             8: "T3K",
             32: "TG",
+        }
+    elif is_quasar():
+        dict_device_names = {
+            1: "QUASAR_BOARD",
         }
     else:
         raise ValueError(f"Unsupported architecture: {arch_name}")

--- a/tt_metal/common/tt_backend_api_types.cpp
+++ b/tt_metal/common/tt_backend_api_types.cpp
@@ -14,6 +14,7 @@ std::string tt::get_string(tt::ARCH arch) {
     switch (arch) {
         case tt::ARCH::WORMHOLE_B0: return "WORMHOLE_B0"; break;
         case tt::ARCH::BLACKHOLE: return "BLACKHOLE"; break;
+        case tt::ARCH::QUASAR: return "QUASAR"; break;
         case tt::ARCH::Invalid:
         default: return "Invalid"; break;
     }
@@ -23,6 +24,7 @@ std::string tt::get_string_lowercase(tt::ARCH arch) {
     switch (arch) {
         case tt::ARCH::WORMHOLE_B0: return "wormhole_b0"; break;
         case tt::ARCH::BLACKHOLE: return "blackhole"; break;
+        case tt::ARCH::QUASAR: return "quasar"; break;
         case tt::ARCH::Invalid:
         default: return "invalid"; break;
     }
@@ -32,6 +34,7 @@ std::string tt::get_alias(tt::ARCH arch) {
     switch (arch) {
         case tt::ARCH::WORMHOLE_B0: return "wormhole"; break;
         case tt::ARCH::BLACKHOLE: return "blackhole"; break;
+        case tt::ARCH::QUASAR: return "quasar"; break;
         default: return "invalid"; break;
     }
 }

--- a/ttnn/cpp/ttnn-nanobind/device.cpp
+++ b/ttnn/cpp/ttnn-nanobind/device.cpp
@@ -110,7 +110,8 @@ namespace ttnn::device {
 void py_device_module_types(nb::module_& m_device) {
     nb::enum_<tt::ARCH>(m_device, "Arch", "Enum of types of Tenstorrent accelerator devices.")
         .value("WORMHOLE_B0", tt::ARCH::WORMHOLE_B0)
-        .value("BLACKHOLE", tt::ARCH::BLACKHOLE);
+        .value("BLACKHOLE", tt::ARCH::BLACKHOLE)
+        .value("QUASAR", tt::ARCH::QUASAR);
 
     nb::enum_<tt::tt_metal::DispatchCoreType>(m_device, "DispatchCoreType", "Enum of types of dispatch cores.")
         .value("WORKER", tt::tt_metal::DispatchCoreType::WORKER)


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #48155 

Quasar related code was not plumbed enough for `pytest models/...` to work. This has been addressed and tested locally.

QUASAR_BOARD comes from UMD: https://github.com/tenstorrent/tt-umd/blob/cd33a7cbe3c219830c0aeefa77f0a30a2f743d2d/device/api/umd/device/types/cluster_descriptor_types.hpp#L37
At some point once there is a better name in UMD this can be updated, but that is probably not a worry until we need to deal with multi-device model pytests on Quasar.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-48155_qsr_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-48155_qsr_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-48155_qsr_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-48155_qsr_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-48155_qsr_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-48155_qsr_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-48155_qsr_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-48155_qsr_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-48155_qsr_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-48155_qsr_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-48155_qsr_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-48155_qsr_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-48155_qsr_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-48155_qsr_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-48155_qsr_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-48155_qsr_test)