### PR TITLE
[LLK][BH] fast-untilize BFP: write SCRATCH_SEC0_val via ordered WRCFG

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_fast_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_fast_untilize.h
@@ -109,12 +109,20 @@ inline void _llk_unpack_fast_untilize_bfp_block_(const std::uint32_t address, co
     const bool use_context_0     = unp_cfg_context == 0;
     const std::uint32_t upk0_reg = use_context_0 ? THCON_SEC0_REG3_Base_address_ADDR32 : THCON_SEC0_REG3_Base_cntx1_address_ADDR32;
     cfg[upk0_reg]                = address;
-    cfg[SCRATCH_SEC0_val_ADDR32] = tile_stride_16B;
+
+    // SCRATCH_SEC0_val is not context-double-buffered and is consumed by the per-tile
+    // CFGSHIFTMASK updates below. Program it with an ordered Tensix WRCFG (as in
+    // llk_unpack_tilize.h) rather than a raw MMIO store, so it is stream-ordered after a
+    // prior call's still-in-flight CFGSHIFTMASK that reads it (a trailing TRISC_CFG stall
+    // only orders the write before the next run, not against that prior consumer).
+    TT_SETDMAREG(0, LOWER_HALFWORD(tile_stride_16B), 0, LO_16(p_gpr_unpack::TMP0));
+    TT_SETDMAREG(0, UPPER_HALFWORD(tile_stride_16B), 0, HI_16(p_gpr_unpack::TMP0));
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
+    TTI_WRCFG(p_gpr_unpack::TMP0, 0, SCRATCH_SEC0_val_ADDR32);
 
     semaphore_post(semaphore::UNPACK_SYNC);
-    // Orders the RISCV writes to the unpack base address and scratch stride
-    // before any UNPACR from the MOP can start. The scratch value is consumed by
-    // later CFGSHIFTMASK address updates in this BFP loop.
+    // Order the RISCV MMIO write to the unpack base address before any UNPACR from the MOP
+    // can start (the scratch stride above is already ordered via WRCFG).
     // ISA: STALLWAIT C10 plus the RISCV-store-to-Tensix-instruction ordering rule.
     TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
 


### PR DESCRIPTION
https://github.com/tenstorrent/tt-llk/issues/1250

**THIS IS MORE LIKE AN NFC OR DEFENSIVE CHANGE, THE RACE WAS HARMLESS AND UNLIKELY.**

_llk_unpack_fast_untilize_bfp_block_ wrote the CFGSHIFTMASK stride scratch register with a raw MMIO store: cfg[SCRATCH_SEC0_val_ADDR32] = tile_stride_16B. Unlike the unpack base address next to it, SCRATCH_SEC0_val is NOT context-double-buffered, and it is consumed by the per-tile TTI_CFGSHIFTMASK address updates in the BFP loop. The trailing STALLWAIT(STALL_UNPACK, TRISC_CFG) orders the MMIO write before the NEXT run, but does not order it against a prior call's still-in-flight CFGSHIFTMASK that reads the same (single, non-banked) scratch register, so back-to-back calls could in principle race.

Although if all the calls write the same value the race wont manifest. Still it looks bad.

Program it with the same ordered Tensix sequence already used for this exact register in llk_unpack_tilize.h (SETDMAREG + STALLWAIT(STALL_CFG, THCON) + WRCFG). WRCFG is issued in the unpack thread's instruction stream, so it is ordered through the config unit after any prior CFGSHIFTMASK and before the following run()/CFGSHIFTMASK, closing the gap without relying on call ordering. The base-address MMIO write is left as-is: it is context-double-buffered and gated by the existing TRISC_CFG stall.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/bh-fast-untilize-bfp-scratch-ordered-write)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/bh-fast-untilize-bfp-scratch-ordered-write)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/bh-fast-untilize-bfp-scratch-ordered-write)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/bh-fast-untilize-bfp-scratch-ordered-write)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/bh-fast-untilize-bfp-scratch-ordered-write)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/bh-fast-untilize-bfp-scratch-ordered-write)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/bh-fast-untilize-bfp-scratch-ordered-write)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/bh-fast-untilize-bfp-scratch-ordered-write)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/bh-fast-untilize-bfp-scratch-ordered-write)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/bh-fast-untilize-bfp-scratch-ordered-write)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/bh-fast-untilize-bfp-scratch-ordered-write)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/bh-fast-untilize-bfp-scratch-ordered-write)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/bh-fast-untilize-bfp-scratch-ordered-write)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/bh-fast-untilize-bfp-scratch-ordered-write)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/bh-fast-untilize-bfp-scratch-ordered-write)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/bh-fast-untilize-bfp-scratch-ordered-write)