### PR TITLE
#47797: rotary_embedding_llama → Metal 2.0 (decode + MultiCore; PrefillSharded follow-up)

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/compute/rotary_embedding_llama_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/compute/rotary_embedding_llama_metal2.cpp
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of rotary_embedding_llama.cpp. The legacy compute kernel is still bound by the
+// PrefillSharded factory on the ProgramDescriptor path, so the Metal 2.0 MultiCore (interleaved)
+// factory binds this forked copy with named args (args::) and DFB handles (dfb::). Behavior is
+// identical to the legacy kernel — only the CB/arg access idioms differ.
+
+#include <cstdint>
+
+#include "api/compute/common.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/bcast.h"
+#include "api/compute/matmul.h"
+#include "api/compute/compute_kernel_hw_startup.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "experimental/kernel_args.h"
+
+ALWI void ACQ() {
+    tile_regs_acquire();
+    tile_regs_wait();
+}
+ALWI void REL() {
+    tile_regs_commit();
+    tile_regs_release();
+}
+
+void kernel_main() {
+    uint32_t batch_start = get_arg(args::batch_start);
+    uint32_t batch_end = get_arg(args::batch_end);
+    uint32_t seq_t_start = get_arg(args::seq_t_start);
+    uint32_t seq_t_end = get_arg(args::seq_t_end);
+
+    constexpr uint32_t onetile = 1;
+    constexpr auto in_cb = dfb::in;
+    constexpr auto cos_cb = dfb::cos;
+    constexpr auto sin_cb = dfb::sin;
+    constexpr auto trans_mat_cb = dfb::trans_mat;
+
+    constexpr auto rotated_in_interm_cb = dfb::rotated_in_interm;
+    constexpr auto cos_interm_cb = dfb::cos_interm;
+    constexpr auto sin_interm_cb = dfb::sin_interm;
+    constexpr auto out_cb = dfb::out;
+    constexpr uint32_t Wt = get_arg(args::Wt);
+    constexpr uint32_t n_heads = get_arg(args::n_heads);
+    constexpr uint32_t rotary_Ht = get_arg(args::rotary_Ht);
+
+    DataflowBuffer in_cb_obj(in_cb);
+    DataflowBuffer cos_cb_obj(cos_cb);
+    DataflowBuffer sin_cb_obj(sin_cb);
+    DataflowBuffer trans_mat_cb_obj(trans_mat_cb);
+    DataflowBuffer rotated_in_interm_cb_obj(rotated_in_interm_cb);
+    DataflowBuffer cos_interm_cb_obj(cos_interm_cb);
+    DataflowBuffer sin_interm_cb_obj(sin_interm_cb);
+    DataflowBuffer out_cb_obj(out_cb);
+
+    const uint32_t rotary_seq_t_end = seq_t_end < rotary_Ht ? seq_t_end : rotary_Ht;
+    const uint32_t my_rotary_seq_tiles = seq_t_start < rotary_seq_t_end ? rotary_seq_t_end - seq_t_start : 0;
+    const uint32_t my_cos_sin_tiles = my_rotary_seq_tiles * Wt;
+
+    compute_kernel_hw_startup<SrcOrder::Reverse>(in_cb, trans_mat_cb, out_cb);
+    matmul_init(in_cb, trans_mat_cb);
+    binary_op_init_common(rotated_in_interm_cb, cos_cb, out_cb);  // General Init for all binary ops
+
+    // Get the trans_mat
+    trans_mat_cb_obj.wait_front(onetile);
+
+    uint32_t in0_index = 0;
+    uint32_t in1_index = 0;
+    uint32_t interm_index = 0;
+
+    for (uint32_t batch_id = batch_start; batch_id < batch_end; ++batch_id) {
+#if RELOAD_IMPL == 0
+        if (my_cos_sin_tiles > 0) {
+            sin_cb_obj.wait_front(my_cos_sin_tiles);
+            cos_cb_obj.wait_front(my_cos_sin_tiles);
+        }
+#endif
+        for (uint32_t head_num = 0; head_num < n_heads; ++head_num) {
+            uint32_t sin_cos_row_cnt = 0;
+            for (uint32_t seq_tile = seq_t_start; seq_tile < rotary_seq_t_end; ++seq_tile) {
+                // input cb wait and reserve
+                in_cb_obj.wait_front(Wt);
+#if RELOAD_IMPL == 1
+                sin_cb_obj.wait_front(Wt);
+                cos_cb_obj.wait_front(Wt);
+#endif
+
+                rotated_in_interm_cb_obj.reserve_back(Wt);
+                sin_interm_cb_obj.reserve_back(Wt);
+                cos_interm_cb_obj.reserve_back(Wt);
+                out_cb_obj.reserve_back(Wt);
+
+                // // rotated = x @ trans_mat
+                matmul_init(in_cb, trans_mat_cb);
+                ACQ();
+                for (uint32_t j = 0; j < Wt; ++j) {
+                    matmul_tiles(in_cb, trans_mat_cb, j, in1_index, j);
+                    pack_tile(j, rotated_in_interm_cb, j);
+                }
+                REL();
+                rotated_in_interm_cb_obj.push_back(Wt);
+                rotated_in_interm_cb_obj.wait_front(Wt);
+
+                mul_tiles_init(rotated_in_interm_cb, sin_cb);
+                ACQ();
+                for (uint32_t j = 0; j < Wt; ++j) {
+                    // sin_interim = rotated * sin
+                    mul_tiles(rotated_in_interm_cb, sin_cb, j, j + (sin_cos_row_cnt * Wt), j);
+                    pack_tile(j, sin_interm_cb, j);
+                }
+                REL();
+                sin_interm_cb_obj.push_back(Wt);
+                rotated_in_interm_cb_obj.pop_front(Wt);
+
+                ACQ();
+                for (uint32_t j = 0; j < Wt; ++j) {
+                    // cos_interim = x * cos
+                    mul_tiles(in_cb, cos_cb, j, j + (sin_cos_row_cnt * Wt), j);
+                    pack_tile(j, cos_interm_cb, j);
+                }
+                REL();
+                cos_interm_cb_obj.push_back(Wt);
+                in_cb_obj.pop_front(Wt);  // Done with input
+#if RELOAD_IMPL == 1
+                sin_cb_obj.pop_front(Wt);
+                cos_cb_obj.pop_front(Wt);
+#endif
+
+                sin_interm_cb_obj.wait_front(Wt);
+                cos_interm_cb_obj.wait_front(Wt);
+                add_tiles_init(cos_interm_cb, sin_interm_cb);
+                ACQ();
+                for (uint32_t j = 0; j < Wt; ++j) {
+                    // out = cos_interim + sin_interim
+                    add_tiles(cos_interm_cb, sin_interm_cb, j, j, j);
+                    pack_tile(j, out_cb, j);
+                }
+                REL();
+                out_cb_obj.push_back(Wt);
+                sin_interm_cb_obj.pop_front(Wt);
+                cos_interm_cb_obj.pop_front(Wt);
+
+#if RELOAD_IMPL == 0
+                // no-reload needs to increment this counter
+                // Used a sin/cos row
+                sin_cos_row_cnt++;
+#endif
+            }
+        }
+
+#if RELOAD_IMPL == 0
+        if (my_cos_sin_tiles > 0) {
+            sin_cb_obj.pop_front(my_cos_sin_tiles);
+            cos_cb_obj.pop_front(my_cos_sin_tiles);
+        }
+#endif
+    }
+
+    // Done with the transformation matrix, so remove from CB
+    trans_mat_cb_obj.pop_front(onetile);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/compute/rotary_embedding_llama_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/compute/rotary_embedding_llama_sharded.cpp
@@ -9,7 +9,8 @@
 #include "api/compute/bcast.h"
 #include "api/compute/matmul.h"
 #include "api/compute/compute_kernel_hw_startup.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "experimental/kernel_args.h"
 
 ALWI void ACQ() {
     tile_regs_acquire();
@@ -22,26 +23,26 @@ ALWI void REL() {
 
 void kernel_main() {
     constexpr uint32_t onetile = 1;
-    constexpr uint32_t in_cb = get_compile_time_arg_val(0);
-    constexpr uint32_t cos_cb = get_compile_time_arg_val(1);
-    constexpr uint32_t sin_cb = get_compile_time_arg_val(2);
-    constexpr uint32_t trans_mat_cb = get_compile_time_arg_val(3);
+    constexpr auto in_cb = dfb::in;
+    constexpr auto cos_cb = dfb::cos;
+    constexpr auto sin_cb = dfb::sin;
+    constexpr auto trans_mat_cb = dfb::trans_mat;
 
-    constexpr uint32_t rotated_in_interm_cb = get_compile_time_arg_val(4);
-    constexpr uint32_t cos_interm_cb = get_compile_time_arg_val(5);
-    constexpr uint32_t sin_interm_cb = get_compile_time_arg_val(6);
-    constexpr uint32_t out_cb = get_compile_time_arg_val(7);
-    constexpr uint32_t Wt = get_compile_time_arg_val(8);
-    constexpr uint32_t Ht = get_compile_time_arg_val(9);  // How many rows (tiles) in n_heads dimension
+    constexpr auto rotated_in_interm_cb = dfb::rotated_in_interm;
+    constexpr auto cos_interm_cb = dfb::cos_interm;
+    constexpr auto sin_interm_cb = dfb::sin_interm;
+    constexpr auto out_cb = dfb::out;
+    constexpr uint32_t Wt = get_arg(args::Wt);
+    constexpr uint32_t Ht = get_arg(args::Ht);  // How many rows (tiles) in n_heads dimension
 
-    CircularBuffer in_cb_obj(in_cb);
-    CircularBuffer cos_cb_obj(cos_cb);
-    CircularBuffer sin_cb_obj(sin_cb);
-    CircularBuffer trans_mat_cb_obj(trans_mat_cb);
-    CircularBuffer rotated_in_interm_cb_obj(rotated_in_interm_cb);
-    CircularBuffer cos_interm_cb_obj(cos_interm_cb);
-    CircularBuffer sin_interm_cb_obj(sin_interm_cb);
-    CircularBuffer out_cb_obj(out_cb);
+    DataflowBuffer in_cb_obj(in_cb);
+    DataflowBuffer cos_cb_obj(cos_cb);
+    DataflowBuffer sin_cb_obj(sin_cb);
+    DataflowBuffer trans_mat_cb_obj(trans_mat_cb);
+    DataflowBuffer rotated_in_interm_cb_obj(rotated_in_interm_cb);
+    DataflowBuffer cos_interm_cb_obj(cos_interm_cb);
+    DataflowBuffer sin_interm_cb_obj(sin_interm_cb);
+    DataflowBuffer out_cb_obj(out_cb);
 
     compute_kernel_hw_startup<SrcOrder::Reverse>(in_cb, trans_mat_cb, out_cb);
     matmul_init(in_cb, trans_mat_cb);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/dataflow/reader_rotary_embedding_llama_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/dataflow/reader_rotary_embedding_llama_interleaved_start_id.cpp
@@ -2,62 +2,78 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Metal 2.0 reader for the rotary_embedding_llama MultiCore (interleaved prefill) factory. This
+// reader is owned exclusively by that factory, so it is ported in place: named args (args::), DFB
+// handles (dfb::), and typed tensor bindings (TensorAccessor(tensor::name)) replace the legacy
+// CB-index CTAs, base-address RTAs, and TensorAccessorArgs plumbing. Behavior is identical.
+
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+FORCE_INLINE void zero_tile_at(uint32_t l1_write_addr, uint32_t tile_bytes) {
+    volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_addr);
+    for (uint32_t i = 0; i < tile_bytes / sizeof(uint32_t); ++i) {
+        ptr[i] = 0;
+    }
+}
 
 void kernel_main() {
     Noc noc;
 
-    uint32_t argrt = 0;
-    uint32_t src_addr = get_arg_val<uint32_t>(argrt++);
-    uint32_t cos_addr = get_arg_val<uint32_t>(argrt++);
-    uint32_t sin_addr = get_arg_val<uint32_t>(argrt++);
-    uint32_t trans_mat_addr = get_arg_val<uint32_t>(argrt++);
-    uint32_t batch_start = get_arg_val<uint32_t>(argrt++);
-    uint32_t batch_end = get_arg_val<uint32_t>(argrt++);
-    uint32_t seq_t_start = get_arg_val<uint32_t>(argrt++);
-    uint32_t seq_t_end = get_arg_val<uint32_t>(argrt++);
+    uint32_t batch_start = get_arg(args::batch_start);
+    uint32_t batch_end = get_arg(args::batch_end);
+    uint32_t seq_t_start = get_arg(args::seq_t_start);
+    uint32_t seq_t_end = get_arg(args::seq_t_end);
 
-    constexpr uint32_t input_cb_id = get_compile_time_arg_val(0);
-    constexpr uint32_t cos_cb_id = get_compile_time_arg_val(1);
-    constexpr uint32_t sin_cb_id = get_compile_time_arg_val(2);
-    constexpr uint32_t trans_mat_cb_id = get_compile_time_arg_val(3);
-    constexpr uint32_t n_heads = get_compile_time_arg_val(4);
-    constexpr uint32_t Ht = get_compile_time_arg_val(5);
-    constexpr uint32_t Wt = get_compile_time_arg_val(6);
-    constexpr bool freq_per_head = get_compile_time_arg_val(7) == 1;
-    constexpr uint32_t cos_Ht = get_compile_time_arg_val(8);
-    constexpr uint32_t sin_Ht = get_compile_time_arg_val(9);
-    constexpr uint32_t rotary_Ht = get_compile_time_arg_val(10);
-    constexpr auto input_args = TensorAccessorArgs<11>();
-    constexpr auto cos_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
-    constexpr auto sin_args = TensorAccessorArgs<cos_args.next_compile_time_args_offset()>();
-    constexpr auto trans_mat_args = TensorAccessorArgs<sin_args.next_compile_time_args_offset()>();
+    constexpr auto input_cb_id = dfb::in;
+    constexpr auto cos_cb_id = dfb::cos;
+    constexpr auto sin_cb_id = dfb::sin;
+    constexpr auto trans_mat_cb_id = dfb::trans_mat;
+    constexpr uint32_t n_heads = get_arg(args::n_heads);
+    constexpr uint32_t Ht = get_arg(args::Ht);
+    constexpr uint32_t Wt = get_arg(args::Wt);
+    constexpr bool freq_per_head = get_arg(args::freq_per_head) == 1;
+    constexpr uint32_t cos_Ht = get_arg(args::cos_Ht);
+    constexpr uint32_t sin_Ht = get_arg(args::sin_Ht);
+    constexpr uint32_t rotary_Ht = get_arg(args::rotary_Ht);
 
     const uint32_t rotary_seq_t_end = seq_t_end < rotary_Ht ? seq_t_end : rotary_Ht;
     const uint32_t my_rotary_seq_tiles = seq_t_start < rotary_seq_t_end ? rotary_seq_t_end - seq_t_start : 0;
     const uint32_t my_cos_sin_tiles = my_rotary_seq_tiles * Wt;
 
     constexpr uint32_t onetile = 1;
-    const uint32_t input_tile_bytes = get_tile_size(input_cb_id);
-    const auto s0 = TensorAccessor(input_args, src_addr);
+    const auto s0 = TensorAccessor(tensor::in);
+    const auto s1 = TensorAccessor(tensor::cos);
+    const auto s2 = TensorAccessor(tensor::sin);
+    const auto s3 = TensorAccessor(tensor::trans_mat);
 
-    const uint32_t cos_tile_bytes = get_tile_size(cos_cb_id);
-    const auto s1 = TensorAccessor(cos_args, cos_addr);
+    DataflowBuffer cb_input(input_cb_id);
+    DataflowBuffer cb_cos(cos_cb_id);
+    DataflowBuffer cb_sin(sin_cb_id);
+    DataflowBuffer cb_trans_mat(trans_mat_cb_id);
+    DataflowBuffer cb_zero(dfb::zero);
 
-    const uint32_t sin_tile_bytes = get_tile_size(sin_cb_id);
-    const auto s2 = TensorAccessor(sin_args, sin_addr);
+    const uint32_t input_tile_bytes = cb_input.get_entry_size();
+    const uint32_t cos_tile_bytes = cb_cos.get_entry_size();
+    const uint32_t sin_tile_bytes = cb_sin.get_entry_size();
+    const uint32_t trans_mat_tile_bytes = cb_trans_mat.get_entry_size();
 
-    const auto s3 = TensorAccessor(trans_mat_args, trans_mat_addr);
-
-    CircularBuffer cb_input(input_cb_id);
-    CircularBuffer cb_cos(cos_cb_id);
-    CircularBuffer cb_sin(sin_cb_id);
-    CircularBuffer cb_trans_mat(trans_mat_cb_id);
+    // Fill the zero scratchpad once (Wt tiles). A data-movement kernel cannot self-loop a DFB on
+    // Gen1, so the writer's legacy zero-fill is hoisted here: the reader produces the Wt zero
+    // tiles, the writer consumes them once and reuses them for every zero-fill tail tile.
+    const uint32_t zero_tile_bytes = cb_zero.get_entry_size();
+    cb_zero.reserve_back(Wt);
+    uint32_t zero_l1_write_addr = cb_zero.get_write_ptr();
+    for (uint32_t j = 0; j < Wt; ++j) {
+        zero_tile_at(zero_l1_write_addr, zero_tile_bytes);
+        zero_l1_write_addr += zero_tile_bytes;
+    }
+    cb_zero.push_back(Wt);
 
     uint32_t trans_mat_curr_idx = 0;
 
@@ -65,11 +81,7 @@ void kernel_main() {
     cb_trans_mat.reserve_back(onetile);
     uint32_t trans_mat_l1_write_addr = cb_trans_mat.get_write_ptr();
     noc.async_read(
-        s3,
-        CoreLocalMem<uint32_t>(trans_mat_l1_write_addr),
-        get_tile_size(trans_mat_cb_id),
-        {.page_id = trans_mat_curr_idx},
-        {});
+        s3, CoreLocalMem<uint32_t>(trans_mat_l1_write_addr), trans_mat_tile_bytes, {.page_id = trans_mat_curr_idx}, {});
     noc.async_read_barrier();
     cb_trans_mat.push_back(onetile);
 
@@ -122,26 +134,17 @@ void kernel_main() {
                 for (uint32_t j = 0; j < Wt; ++j) {
                     // Read input into CB
                     noc.async_read(
-                        s0,
-                        CoreLocalMem<uint32_t>(input_l1_write_addr),
-                        input_tile_bytes,
-                        {.page_id = input_curr_idx},
+                        s0, CoreLocalMem<uint32_t>(input_l1_write_addr), input_tile_bytes, {.page_id = input_curr_idx},
                         {});
                     input_curr_idx++;
                     input_l1_write_addr += input_tile_bytes;
 
                     if (!done_sin_cos) {
                         noc.async_read(
-                            s2,
-                            CoreLocalMem<uint32_t>(sin_l1_write_addr),
-                            sin_tile_bytes,
-                            {.page_id = sin_curr_idx},
+                            s2, CoreLocalMem<uint32_t>(sin_l1_write_addr), sin_tile_bytes, {.page_id = sin_curr_idx},
                             {});
                         noc.async_read(
-                            s1,
-                            CoreLocalMem<uint32_t>(cos_l1_write_addr),
-                            cos_tile_bytes,
-                            {.page_id = cos_curr_idx},
+                            s1, CoreLocalMem<uint32_t>(cos_l1_write_addr), cos_tile_bytes, {.page_id = cos_curr_idx},
                             {});
                         sin_curr_idx++;
                         cos_curr_idx++;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/dataflow/writer_rotary_embedding_llama_interleaved_start_id_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/dataflow/writer_rotary_embedding_llama_interleaved_start_id_metal2.cpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of writer_rotary_embedding_llama_interleaved_start_id.cpp. The legacy writer is
+// still bound by the PrefillSharded factory on the ProgramDescriptor path, so the Metal 2.0
+// MultiCore (interleaved) factory binds this forked copy with named args (args::), DFB handles
+// (dfb::), and a typed output tensor binding (TensorAccessor(tensor::output)). Behavior is
+// identical to the legacy kernel — only the CB/arg/accessor idioms differ.
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    Noc noc;
+
+    uint32_t batch_start = get_arg(args::batch_start);
+    uint32_t batch_end = get_arg(args::batch_end);
+    uint32_t seq_t_start = get_arg(args::seq_t_start);
+    uint32_t seq_t_end = get_arg(args::seq_t_end);
+
+    constexpr auto cb_id_out = dfb::out;
+    constexpr auto cb_id_zero = dfb::zero;
+    constexpr uint32_t n_heads = get_arg(args::n_heads);
+    constexpr uint32_t Wt = get_arg(args::Wt);
+    constexpr uint32_t Ht = get_arg(args::Ht);
+    constexpr uint32_t rotary_Ht = get_arg(args::rotary_Ht);
+
+    DataflowBuffer cb_out(cb_id_out);
+    DataflowBuffer cb_zero(cb_id_zero);
+
+    const uint32_t tile_bytes = cb_out.get_entry_size();
+    const uint32_t zero_tile_bytes = cb_zero.get_entry_size();
+    const auto s = TensorAccessor(tensor::output);
+
+    // The reader fills the Wt zero tiles (DM kernels cannot self-loop a DFB on Gen1); the writer
+    // consumes them once and reuses the same Wt tiles for every zero-fill tail tile.
+    cb_zero.wait_front(Wt);
+
+    for (uint32_t batch_id = batch_start; batch_id < batch_end; ++batch_id) {
+        for (uint32_t head_num = 0; head_num < n_heads; ++head_num) {
+            for (uint32_t seq_tile = seq_t_start; seq_tile < seq_t_end; ++seq_tile) {
+                uint32_t output_curr_idx = batch_id * n_heads * Ht * Wt + head_num * Ht * Wt + seq_tile * Wt;
+                const bool write_rotary_output = seq_tile < rotary_Ht;
+                if (write_rotary_output) {
+                    cb_out.wait_front(Wt);
+                }
+
+                uint32_t l1_read_addr = write_rotary_output ? cb_out.get_read_ptr() : cb_zero.get_read_ptr();
+                const uint32_t l1_read_stride = write_rotary_output ? tile_bytes : zero_tile_bytes;
+                const uint32_t write_bytes = write_rotary_output ? tile_bytes : zero_tile_bytes;
+                for (uint32_t j = 0; j < Wt; j++) {
+                    noc.async_write(
+                        CoreLocalMem<uint32_t>(l1_read_addr), s, write_bytes, {}, {.page_id = output_curr_idx});
+                    l1_read_addr += l1_read_stride;
+                    output_curr_idx++;
+                }
+                noc.async_write_barrier();
+
+                if (write_rotary_output) {
+                    cb_out.pop_front(Wt);
+                }
+            }
+        }
+    }
+
+    cb_zero.pop_front(Wt);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_program_factory.cpp
@@ -3,41 +3,66 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "rotary_embedding_llama_multi_core_program_factory.hpp"
+
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/host_api.hpp>
+
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+
+#include <filesystem>
 
 namespace ttnn::experimental::prim {
 
 using namespace tt;
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
-ProgramDescriptor RotaryEmbeddingLlamaMultiCore::create_descriptor(
+ttnn::device_operation::ProgramArtifacts RotaryEmbeddingLlamaMultiCore::create_program_artifacts(
     const RotaryEmbeddingLlamaParams& operation_attributes,
     const RotaryEmbeddingLlamaInputs& tensor_args,
     tt::tt_metal::Tensor& output) {
-    ProgramDescriptor desc;
+    // Metal 2.0 named resource handles (declared as LOCALS for unity-build hygiene).
+    const DFBSpecName IN_DFB{"in"};
+    const DFBSpecName COS_DFB{"cos"};
+    const DFBSpecName SIN_DFB{"sin"};
+    const DFBSpecName TRANS_MAT_DFB{"trans_mat"};
+    const DFBSpecName ROTATED_INTERM_DFB{"rotated_in_interm"};
+    const DFBSpecName COS_INTERM_DFB{"cos_interm"};
+    const DFBSpecName SIN_INTERM_DFB{"sin_interm"};
+    const DFBSpecName OUT_DFB{"out"};
+    const DFBSpecName ZERO_DFB{"zero"};
+
+    const TensorParamName IN_TENSOR{"in_tensor"};
+    const TensorParamName COS_TENSOR{"cos_tensor"};
+    const TensorParamName SIN_TENSOR{"sin_tensor"};
+    const TensorParamName TRANS_MAT_TENSOR{"trans_mat_tensor"};
+    const TensorParamName OUT_TENSOR{"out_tensor"};
+
+    const KernelSpecName READER_KERNEL{"reader"};
+    const KernelSpecName WRITER_KERNEL{"writer"};
+    const KernelSpecName COMPUTE_KERNEL{"compute"};
 
     const auto& input = tensor_args.input_tensor;
     const auto& cos = tensor_args.cos_cache;
     const auto& sin = tensor_args.sin_cache;
     const auto& trans_mat = tensor_args.trans_mat;
 
-    const tt::DataFormat input_cb_data_format = tt_metal::datatype_to_dataformat_converter(input.dtype());
+    const tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(input.dtype());
     const uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
 
-    const tt::DataFormat cos_cb_data_format = tt_metal::datatype_to_dataformat_converter(cos.dtype());
+    const tt::DataFormat cos_cb_data_format = datatype_to_dataformat_converter(cos.dtype());
     const uint32_t cos_single_tile_size = tt::tile_size(cos_cb_data_format);
 
-    const tt::DataFormat sin_cb_data_format = tt_metal::datatype_to_dataformat_converter(sin.dtype());
+    const tt::DataFormat sin_cb_data_format = datatype_to_dataformat_converter(sin.dtype());
     const uint32_t sin_single_tile_size = tt::tile_size(sin_cb_data_format);
 
-    const tt::DataFormat trans_mat_cb_data_format = tt_metal::datatype_to_dataformat_converter(trans_mat.dtype());
+    const tt::DataFormat trans_mat_cb_data_format = datatype_to_dataformat_converter(trans_mat.dtype());
     const uint32_t trans_mat_single_tile_size = tt::tile_size(trans_mat_cb_data_format);
 
-    const tt::DataFormat output_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
+    const tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
     const uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
 
     const uint32_t batch = input.padded_shape()[0];
@@ -101,204 +126,207 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCore::create_descriptor(
         num_cos_sin_tiles = num_input_tiles;
     }
 
-    constexpr uint8_t input_cb_index = CBIndex::c_0;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = input_cb_num_tiles * input_single_tile_size,
-        .core_ranges = CoreRangeSet(all_cores),
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = input_cb_index,
-            .data_format = input_cb_data_format,
-            .page_size = input_single_tile_size,
-        }}},
-    });
+    const uint32_t num_interm_tiles = head_dim_t;
+    const std::string reload_define = use_reload_impl ? "1" : "0";
 
-    constexpr uint8_t cos_cb_index = CBIndex::c_1;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_cos_sin_tiles * cos_single_tile_size,
-        .core_ranges = CoreRangeSet(all_cores),
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = cos_cb_index,
-            .data_format = cos_cb_data_format,
-            .page_size = cos_single_tile_size,
-        }}},
-    });
+    // ----------------------------------------------------------------------------
+    // Tensor parameters — all five tensors are Case 1 (the reader/writer build a
+    // TensorAccessor from each binding). No borrowed-memory DFB in this interleaved factory.
+    // ----------------------------------------------------------------------------
+    TensorParameter in_param{.unique_id = IN_TENSOR, .spec = input.tensor_spec()};
+    TensorParameter cos_param{.unique_id = COS_TENSOR, .spec = cos.tensor_spec()};
+    TensorParameter sin_param{.unique_id = SIN_TENSOR, .spec = sin.tensor_spec()};
+    TensorParameter trans_mat_param{.unique_id = TRANS_MAT_TENSOR, .spec = trans_mat.tensor_spec()};
+    TensorParameter out_param{.unique_id = OUT_TENSOR, .spec = output.tensor_spec()};
 
-    constexpr uint8_t sin_cb_index = CBIndex::c_2;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_cos_sin_tiles * sin_single_tile_size,
-        .core_ranges = CoreRangeSet(all_cores),
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = sin_cb_index,
-            .data_format = sin_cb_data_format,
-            .page_size = sin_single_tile_size,
-        }}},
-    });
-
-    constexpr uint8_t trans_mat_cb_index = CBIndex::c_3;
-    // We only take one tile of trans_mat
-    uint32_t num_trans_mat_tiles = 1;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_trans_mat_tiles * trans_mat_single_tile_size,
-        .core_ranges = CoreRangeSet(all_cores),
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = trans_mat_cb_index,
-            .data_format = trans_mat_cb_data_format,
-            .page_size = trans_mat_single_tile_size,
-        }}},
-    });
-
-    uint32_t num_interm_tiles = head_dim_t;
-    constexpr uint8_t rotated_input_interm_cb_index = CBIndex::c_24;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_interm_tiles * input_single_tile_size,
-        .core_ranges = CoreRangeSet(all_cores),
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = rotated_input_interm_cb_index,
-            .data_format = input_cb_data_format,
-            .page_size = input_single_tile_size,
-        }}},
-    });
-
-    constexpr uint8_t cos_interm_cb_index = CBIndex::c_25;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_interm_tiles * cos_single_tile_size,
-        .core_ranges = CoreRangeSet(all_cores),
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = cos_interm_cb_index,
-            .data_format = cos_cb_data_format,
-            .page_size = cos_single_tile_size,
-        }}},
-    });
-
-    constexpr uint8_t sin_interm_cb_index = CBIndex::c_26;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_interm_tiles * sin_single_tile_size,
-        .core_ranges = CoreRangeSet(all_cores),
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = sin_interm_cb_index,
-            .data_format = sin_cb_data_format,
-            .page_size = sin_single_tile_size,
-        }}},
-    });
-
-    constexpr uint8_t output_cb_index = CBIndex::c_16;  // output operands start at index 16
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_output_tiles * output_single_tile_size,
-        .core_ranges = CoreRangeSet(all_cores),
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = output_cb_index,
-            .data_format = output_cb_data_format,
-            .page_size = output_single_tile_size,
-        }}},
-    });
-
-    constexpr uint8_t zero_cb_index = CBIndex::c_27;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = head_dim_t * output_single_tile_size,
-        .core_ranges = CoreRangeSet(all_cores),
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = zero_cb_index,
-            .data_format = output_cb_data_format,
-            .page_size = output_single_tile_size,
-        }}},
-    });
-
-    KernelDescriptor::Defines kernel_defines;
-    kernel_defines.emplace_back("RELOAD_IMPL", use_reload_impl ? "1" : "0");
-
-    auto* src_buffer = input.buffer();
-    auto* cos_buffer = cos.buffer();
-    auto* sin_buffer = sin.buffer();
-    auto* trans_mat_buffer = trans_mat.buffer();
-    auto* dst_buffer = output.buffer();
-
-    std::vector<uint32_t> reader_compile_time_args = {
-        (std::uint32_t)input_cb_index,
-        (std::uint32_t)cos_cb_index,
-        (std::uint32_t)sin_cb_index,
-        (std::uint32_t)trans_mat_cb_index,
-        (std::uint32_t)n_heads,
-        (std::uint32_t)seq_len_t,
-        (std::uint32_t)head_dim_t,
-        (std::uint32_t)freq_per_head,
-        (std::uint32_t)cos_seq_len_t,
-        (std::uint32_t)sin_seq_len_t,
-        (std::uint32_t)rotary_seq_len_t,
+    // ----------------------------------------------------------------------------
+    // Dataflow buffers (all program-local FIFOs; none borrowed).
+    //   reader -> compute: in (c_0), cos (c_1), sin (c_2), trans_mat (c_3)
+    //   compute self-loop: rotated_in_interm (c_24), cos_interm (c_25), sin_interm (c_26)
+    //   compute -> writer:  out (c_16)
+    //   writer self-loop:   zero (c_27)
+    // ----------------------------------------------------------------------------
+    DataflowBufferSpec in_dfb_spec{
+        .unique_id = IN_DFB,
+        .entry_size = input_single_tile_size,
+        .num_entries = input_cb_num_tiles,
+        .data_format_metadata = input_cb_data_format,
     };
-    tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(*cos_buffer).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(*sin_buffer).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(*trans_mat_buffer).append_to(reader_compile_time_args);
-    std::vector<uint32_t> writer_compile_time_args = {
-        (std::uint32_t)output_cb_index,
-        (std::uint32_t)zero_cb_index,
-        (std::uint32_t)n_heads,
-        (std::uint32_t)head_dim_t,
-        (std::uint32_t)seq_len_t,
-        (std::uint32_t)rotary_seq_len_t,
+    DataflowBufferSpec cos_dfb_spec{
+        .unique_id = COS_DFB,
+        .entry_size = cos_single_tile_size,
+        .num_entries = num_cos_sin_tiles,
+        .data_format_metadata = cos_cb_data_format,
     };
-    tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
-
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/dataflow/"
-        "reader_rotary_embedding_llama_interleaved_start_id.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = CoreRangeSet(all_cores);
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.defines = kernel_defines;
-    reader_desc.config = ReaderConfigDescriptor{};
-
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/dataflow/"
-        "writer_rotary_embedding_llama_interleaved_start_id.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = CoreRangeSet(all_cores);
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.defines = kernel_defines;
-    writer_desc.config = WriterConfigDescriptor{};
-
-    std::vector<uint32_t> compute_kernel_args = {
-        (std::uint32_t)input_cb_index,
-        (std::uint32_t)cos_cb_index,
-        (std::uint32_t)sin_cb_index,
-        (std::uint32_t)trans_mat_cb_index,
-        (std::uint32_t)rotated_input_interm_cb_index,
-        (std::uint32_t)cos_interm_cb_index,
-        (std::uint32_t)sin_interm_cb_index,
-        (std::uint32_t)output_cb_index,
-        (std::uint32_t)head_dim_t,
-        (std::uint32_t)n_heads,
-        (std::uint32_t)rotary_seq_len_t,
+    DataflowBufferSpec sin_dfb_spec{
+        .unique_id = SIN_DFB,
+        .entry_size = sin_single_tile_size,
+        .num_entries = num_cos_sin_tiles,
+        .data_format_metadata = sin_cb_data_format,
+    };
+    DataflowBufferSpec trans_mat_dfb_spec{
+        .unique_id = TRANS_MAT_DFB,
+        .entry_size = trans_mat_single_tile_size,
+        .num_entries = 1,
+        .data_format_metadata = trans_mat_cb_data_format,
+    };
+    DataflowBufferSpec rotated_in_interm_dfb_spec{
+        .unique_id = ROTATED_INTERM_DFB,
+        .entry_size = input_single_tile_size,
+        .num_entries = num_interm_tiles,
+        .data_format_metadata = input_cb_data_format,
+    };
+    DataflowBufferSpec cos_interm_dfb_spec{
+        .unique_id = COS_INTERM_DFB,
+        .entry_size = cos_single_tile_size,
+        .num_entries = num_interm_tiles,
+        .data_format_metadata = cos_cb_data_format,
+    };
+    DataflowBufferSpec sin_interm_dfb_spec{
+        .unique_id = SIN_INTERM_DFB,
+        .entry_size = sin_single_tile_size,
+        .num_entries = num_interm_tiles,
+        .data_format_metadata = sin_cb_data_format,
+    };
+    DataflowBufferSpec out_dfb_spec{
+        .unique_id = OUT_DFB,
+        .entry_size = output_single_tile_size,
+        .num_entries = num_output_tiles,
+        .data_format_metadata = output_cb_data_format,
+    };
+    DataflowBufferSpec zero_dfb_spec{
+        .unique_id = ZERO_DFB,
+        .entry_size = output_single_tile_size,
+        .num_entries = num_interm_tiles,
+        .data_format_metadata = output_cb_data_format,
     };
 
-    KernelDescriptor compute_desc;
-    compute_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/compute/"
-        "rotary_embedding_llama.cpp";
-    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    compute_desc.core_ranges = CoreRangeSet(all_cores);
-    compute_desc.compile_time_args = std::move(compute_kernel_args);
-    compute_desc.defines = std::move(kernel_defines);
-    compute_desc.config = ComputeConfigDescriptor{
-        .math_fidelity = math_fidelity,
-        .fp32_dest_acc_en = fp32_dest_acc_en,
+    // ----------------------------------------------------------------------------
+    // Reader: reads input/cos/sin/trans_mat from DRAM (TensorAccessor) into c_0..c_3.
+    // ----------------------------------------------------------------------------
+    KernelSpec reader_spec{
+        .unique_id = READER_KERNEL,
+        .source = std::filesystem::path{
+            "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/dataflow/"
+            "reader_rotary_embedding_llama_interleaved_start_id.cpp"},
+        .compiler_options = {.defines = {{"RELOAD_IMPL", reload_define}}},
+        .dfb_bindings =
+            {DFBBinding{.dfb_spec_name = IN_DFB, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{.dfb_spec_name = COS_DFB, .accessor_name = "cos", .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{.dfb_spec_name = SIN_DFB, .accessor_name = "sin", .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{
+                 .dfb_spec_name = TRANS_MAT_DFB,
+                 .accessor_name = "trans_mat",
+                 .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{.dfb_spec_name = ZERO_DFB, .accessor_name = "zero", .endpoint_type = DFBEndpointType::PRODUCER}},
+        .tensor_bindings =
+            {TensorBinding{.tensor_parameter_name = IN_TENSOR, .accessor_name = "in"},
+             TensorBinding{.tensor_parameter_name = COS_TENSOR, .accessor_name = "cos"},
+             TensorBinding{.tensor_parameter_name = SIN_TENSOR, .accessor_name = "sin"},
+             TensorBinding{.tensor_parameter_name = TRANS_MAT_TENSOR, .accessor_name = "trans_mat"}},
+        .compile_time_args =
+            {{"n_heads", n_heads},
+             {"Ht", seq_len_t},
+             {"Wt", head_dim_t},
+             {"freq_per_head", static_cast<uint32_t>(freq_per_head)},
+             {"cos_Ht", cos_seq_len_t},
+             {"sin_Ht", sin_seq_len_t},
+             {"rotary_Ht", rotary_seq_len_t}},
+        .runtime_arg_schema = {.runtime_arg_names = {"batch_start", "batch_end", "seq_t_start", "seq_t_end"}},
+        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
     };
 
-    const auto& cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, row_major);
+    // ----------------------------------------------------------------------------
+    // Compute: consumes c_0..c_3, produces c_16; c_24/25/26 are intra self-loops.
+    // ----------------------------------------------------------------------------
+    KernelSpec compute_spec{
+        .unique_id = COMPUTE_KERNEL,
+        .source = std::filesystem::path{
+            "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/compute/"
+            "rotary_embedding_llama_metal2.cpp"},
+        .compiler_options = {.defines = {{"RELOAD_IMPL", reload_define}}},
+        .dfb_bindings =
+            {DFBBinding{.dfb_spec_name = IN_DFB, .accessor_name = "in", .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{.dfb_spec_name = COS_DFB, .accessor_name = "cos", .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{.dfb_spec_name = SIN_DFB, .accessor_name = "sin", .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{
+                 .dfb_spec_name = TRANS_MAT_DFB,
+                 .accessor_name = "trans_mat",
+                 .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{
+                 .dfb_spec_name = ROTATED_INTERM_DFB,
+                 .accessor_name = "rotated_in_interm",
+                 .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{
+                 .dfb_spec_name = ROTATED_INTERM_DFB,
+                 .accessor_name = "rotated_in_interm",
+                 .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{
+                 .dfb_spec_name = COS_INTERM_DFB,
+                 .accessor_name = "cos_interm",
+                 .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{
+                 .dfb_spec_name = COS_INTERM_DFB,
+                 .accessor_name = "cos_interm",
+                 .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{
+                 .dfb_spec_name = SIN_INTERM_DFB,
+                 .accessor_name = "sin_interm",
+                 .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{
+                 .dfb_spec_name = SIN_INTERM_DFB,
+                 .accessor_name = "sin_interm",
+                 .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{.dfb_spec_name = OUT_DFB, .accessor_name = "out", .endpoint_type = DFBEndpointType::PRODUCER}},
+        .compile_time_args = {{"Wt", head_dim_t}, {"n_heads", n_heads}, {"rotary_Ht", rotary_seq_len_t}},
+        .runtime_arg_schema = {.runtime_arg_names = {"batch_start", "batch_end", "seq_t_start", "seq_t_end"}},
+        .hw_config =
+            ComputeHardwareConfig{
+                .math_fidelity = math_fidelity,
+                .fp32_dest_acc_en = fp32_dest_acc_en,
+            },
+    };
+    compute_spec.advanced_options.dfb_self_loop_connectivities = {
+        {ROTATED_INTERM_DFB, DFBSelfLoopConnectivity::INTRA},
+        {COS_INTERM_DFB, DFBSelfLoopConnectivity::INTRA},
+        {SIN_INTERM_DFB, DFBSelfLoopConnectivity::INTRA},
+    };
 
-    /*
-        Overall loop iterations: # total cores
-    */
+    // ----------------------------------------------------------------------------
+    // Writer: consumes c_16, writes to DRAM (TensorAccessor); c_27 is an intra self-loop.
+    // ----------------------------------------------------------------------------
+    KernelSpec writer_spec{
+        .unique_id = WRITER_KERNEL,
+        .source = std::filesystem::path{
+            "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/dataflow/"
+            "writer_rotary_embedding_llama_interleaved_start_id_metal2.cpp"},
+        .compiler_options = {.defines = {{"RELOAD_IMPL", reload_define}}},
+        // The 'zero' DFB holds Wt zero tiles, filled once by the reader (PRODUCER) and consumed
+        // here. A data-movement kernel cannot self-loop a DFB on Gen1, so the fill lives in the
+        // reader rather than the writer; the writer wait_fronts the Wt zeros once and reuses them
+        // for every zero-fill tail tile (pop_front at the end), exactly as the legacy writer did.
+        .dfb_bindings =
+            {DFBBinding{.dfb_spec_name = OUT_DFB, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{.dfb_spec_name = ZERO_DFB, .accessor_name = "zero", .endpoint_type = DFBEndpointType::CONSUMER}},
+        .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUT_TENSOR, .accessor_name = "output"}},
+        .compile_time_args =
+            {{"n_heads", n_heads}, {"Wt", head_dim_t}, {"Ht", seq_len_t}, {"rotary_Ht", rotary_seq_len_t}},
+        .runtime_arg_schema = {.runtime_arg_names = {"batch_start", "batch_end", "seq_t_start", "seq_t_end"}},
+        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+    };
 
-    // Per-core args tracked as {start_batch, end_batch, start_seq, end_seq, active}.
+    // ----------------------------------------------------------------------------
+    // Per-core runtime args: {batch_start, batch_end, seq_t_start, seq_t_end}. Cores with no
+    // work keep the {0,0,0,0} default (their kernel loops are empty) — mirrors the legacy factory,
+    // which placed all three kernels on the full grid and skipped idle cores via these args.
+    // ----------------------------------------------------------------------------
     struct CoreArgs {
         uint32_t start_batch = 0;
         uint32_t end_batch = 0;
         uint32_t start_seq = 0;
         uint32_t end_seq = 0;
     };
+    const auto& cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, row_major);
     std::vector<CoreArgs> per_core_args(cores.size());
 
     for (uint32_t batch_parallel = 0; batch_parallel < batch_parallel_factor; batch_parallel++) {
@@ -310,41 +338,63 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCore::create_descriptor(
             uint32_t end_seq = std::min(start_seq + seq_per_core, seq_len_t);
 
             if (start_seq >= seq_len_t || start_batch >= batch) {
-                // Important to skip cores which have no work to do, otherwise they will wait
-                // on cos/sin data which will never arrive.
                 continue;
             }
-            log_debug(
-                tt::LogTest,
-                "core: {}, start_batch: {}, end_batch: {}, start_seq: {}, end_seq: {}",
-                core_idx,
-                start_batch,
-                end_batch,
-                start_seq,
-                end_seq);
-
             per_core_args[core_idx] = CoreArgs{start_batch, end_batch, start_seq, end_seq};
         }
     }
 
-    reader_desc.runtime_args.reserve(cores.size());
-    writer_desc.runtime_args.reserve(cores.size());
-    compute_desc.runtime_args.reserve(cores.size());
+    KernelRunArgs reader_run{.kernel = READER_KERNEL};
+    KernelRunArgs writer_run{.kernel = WRITER_KERNEL};
+    KernelRunArgs compute_run{.kernel = COMPUTE_KERNEL};
+    reader_run.runtime_arg_values.reserve(cores.size());
+    writer_run.runtime_arg_values.reserve(cores.size());
+    compute_run.runtime_arg_values.reserve(cores.size());
     for (uint32_t i = 0; i < cores.size(); ++i) {
         const auto& a = per_core_args[i];
-        reader_desc.emplace_runtime_args(
-            cores[i],
-            {src_buffer, cos_buffer, sin_buffer, trans_mat_buffer, a.start_batch, a.end_batch, a.start_seq, a.end_seq});
-        writer_desc.emplace_runtime_args(cores[i], {dst_buffer, a.start_batch, a.end_batch, a.start_seq, a.end_seq});
-        compute_desc.runtime_args.emplace_back(
-            cores[i], std::vector<uint32_t>{a.start_batch, a.end_batch, a.start_seq, a.end_seq});
+        KernelRunArgs::RuntimeArgValues vals{
+            {"batch_start", a.start_batch},
+            {"batch_end", a.end_batch},
+            {"seq_t_start", a.start_seq},
+            {"seq_t_end", a.end_seq}};
+        reader_run.runtime_arg_values.push_back({cores[i], vals});
+        writer_run.runtime_arg_values.push_back({cores[i], vals});
+        compute_run.runtime_arg_values.push_back({cores[i], vals});
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
-    desc.kernels.push_back(std::move(compute_desc));
+    WorkUnitSpec wu{
+        .name = "rotary_embedding_llama_interleaved",
+        .kernels = {READER_KERNEL, WRITER_KERNEL, COMPUTE_KERNEL},
+        .target_nodes = CoreRangeSet(all_cores),
+    };
 
-    return desc;
+    ProgramSpec spec{
+        .name = "rotary_embedding_llama_interleaved",
+        .kernels = {reader_spec, writer_spec, compute_spec},
+        .dataflow_buffers =
+            {in_dfb_spec,
+             cos_dfb_spec,
+             sin_dfb_spec,
+             trans_mat_dfb_spec,
+             rotated_in_interm_dfb_spec,
+             cos_interm_dfb_spec,
+             sin_interm_dfb_spec,
+             out_dfb_spec,
+             zero_dfb_spec},
+        .tensor_parameters = {in_param, cos_param, sin_param, trans_mat_param, out_param},
+        .work_units = {wu},
+    };
+
+    ProgramRunArgs run_args;
+    run_args.kernel_run_args = {reader_run, writer_run, compute_run};
+    run_args.tensor_args = {
+        {IN_TENSOR, TensorArgument{std::cref(input.mesh_tensor())}},
+        {COS_TENSOR, TensorArgument{std::cref(cos.mesh_tensor())}},
+        {SIN_TENSOR, TensorArgument{std::cref(sin.mesh_tensor())}},
+        {TRANS_MAT_TENSOR, TensorArgument{std::cref(trans_mat.mesh_tensor())}},
+        {OUT_TENSOR, TensorArgument{std::cref(output.mesh_tensor())}}};
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_program_factory.hpp
@@ -5,21 +5,21 @@
 #pragma once
 
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/device_operation.hpp"
 #include "rotary_embedding_llama_device_operation_types.hpp"
 
 namespace ttnn::experimental::prim {
 
 struct RotaryEmbeddingLlamaMultiCore {
-    // Contract (1): single ProgramDescriptor for the interleaved (non-sharded) case.
-    // Per-core reader/writer/compute runtime args are re-applied by the framework via
-    // apply_descriptor_runtime_args; idle cores get zero-filled args so they don't wait
-    // on cos/sin data that never arrives.
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    // Metal 2.0 (MetalV2FactoryConcept): ProgramSpec for the interleaved (non-sharded) prefill
+    // case. reader -> compute -> writer pipeline; the five tensors are Case 1 (TensorAccessor
+    // bindings on the reader/writer). Per-core reader/writer/compute runtime args
+    // {batch_start,batch_end,seq_t_start,seq_t_end} are named RTAs; idle cores get zero-filled
+    // args so they don't wait on cos/sin data that never arrives.
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const RotaryEmbeddingLlamaParams& operation_attributes,
         const RotaryEmbeddingLlamaInputs& tensor_args,
-        tt::tt_metal::Tensor& output);
+        tt::tt_metal::Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_sharded_program_factory.cpp
@@ -3,45 +3,67 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "rotary_embedding_llama_sharded_program_factory.hpp"
+
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/host_api.hpp>
+
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+
+#include <filesystem>
 
 namespace ttnn::experimental::prim {
 
 using namespace tt;
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
-ProgramDescriptor RotaryEmbeddingLlamaMultiCoreSharded::create_descriptor(
+ttnn::device_operation::ProgramArtifacts RotaryEmbeddingLlamaMultiCoreSharded::create_program_artifacts(
     const RotaryEmbeddingLlamaParams& operation_attributes,
     const RotaryEmbeddingLlamaInputs& tensor_args,
     tt::tt_metal::Tensor& output) {
-    ProgramDescriptor desc;
+    // Metal 2.0 named resource handles (declared as LOCALS for unity-build hygiene).
+    const DFBSpecName IN_DFB{"in"};
+    const DFBSpecName COS_DFB{"cos"};
+    const DFBSpecName SIN_DFB{"sin"};
+    const DFBSpecName TRANS_MAT_DFB{"trans_mat"};
+    const DFBSpecName ROTATED_INTERM_DFB{"rotated_in_interm"};
+    const DFBSpecName COS_INTERM_DFB{"cos_interm"};
+    const DFBSpecName SIN_INTERM_DFB{"sin_interm"};
+    const DFBSpecName OUT_DFB{"out"};
+
+    const TensorParamName IN_TENSOR{"in_tensor"};
+    const TensorParamName COS_TENSOR{"cos_tensor"};
+    const TensorParamName SIN_TENSOR{"sin_tensor"};
+    const TensorParamName TRANS_MAT_TENSOR{"trans_mat_tensor"};
+    const TensorParamName OUT_TENSOR{"out_tensor"};
+
+    const KernelSpecName COMPUTE_KERNEL{"compute"};
 
     const auto& input = tensor_args.input_tensor;
     const auto& cos = tensor_args.cos_cache;
     const auto& sin = tensor_args.sin_cache;
     const auto& trans_mat = tensor_args.trans_mat;
 
-    const tt::DataFormat input_cb_data_format = tt_metal::datatype_to_dataformat_converter(input.dtype());
+    const tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(input.dtype());
     const uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
 
-    const tt::DataFormat cos_cb_data_format = tt_metal::datatype_to_dataformat_converter(cos.dtype());
+    const tt::DataFormat cos_cb_data_format = datatype_to_dataformat_converter(cos.dtype());
     const uint32_t cos_single_tile_size = tt::tile_size(cos_cb_data_format);
 
-    const tt::DataFormat sin_cb_data_format = tt_metal::datatype_to_dataformat_converter(sin.dtype());
+    const tt::DataFormat sin_cb_data_format = datatype_to_dataformat_converter(sin.dtype());
     const uint32_t sin_single_tile_size = tt::tile_size(sin_cb_data_format);
 
-    const tt::DataFormat trans_mat_cb_data_format = tt_metal::datatype_to_dataformat_converter(trans_mat.dtype());
+    const tt::DataFormat trans_mat_cb_data_format = datatype_to_dataformat_converter(trans_mat.dtype());
     const uint32_t trans_mat_single_tile_size = tt::tile_size(trans_mat_cb_data_format);
 
-    const tt::DataFormat output_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
+    const tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
     const uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
 
-    bool in_sharded = input.shard_spec().has_value();
-    std::optional<ShardSpec> shard_spec = in_sharded ? input.shard_spec() : output.shard_spec();
+    const bool in_sharded = input.shard_spec().has_value();
+    const std::optional<ShardSpec> shard_spec = in_sharded ? input.shard_spec() : output.shard_spec();
 
     const uint32_t batch = input.padded_shape()[1];
     const uint32_t n_heads_t = shard_spec->shape[0] / constants::TILE_HEIGHT;
@@ -52,9 +74,9 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCoreSharded::create_descriptor(
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config);
 
-    CoreRange all_cores = shard_spec->grid.bounding_box();
-    uint32_t num_cores_x = all_cores.grid_size().x;
-    uint32_t num_cores_y = all_cores.grid_size().y;
+    const CoreRange all_cores = shard_spec->grid.bounding_box();
+    const uint32_t num_cores_x = all_cores.grid_size().x;
+    const uint32_t num_cores_y = all_cores.grid_size().y;
 
     const uint32_t num_input_tiles = n_heads_t * head_dim_t;
     const uint32_t num_output_tiles = num_input_tiles;
@@ -66,140 +88,193 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCoreSharded::create_descriptor(
                                     batch_parallel_factor;  // TODO: To make general, add support for batch_per_core > 1
 
     const uint32_t num_sin_cos_rows_per_core = batch_per_core;
-    uint32_t num_cos_sin_tiles = head_dim_t * num_sin_cos_rows_per_core;
+    const uint32_t num_cos_sin_tiles = head_dim_t * num_sin_cos_rows_per_core;
 
-    // Set up the CBs
-    auto* src_buffer = input.buffer();
-    auto* cos_buffer = cos.buffer();
-    auto* sin_buffer = sin.buffer();
-    auto* trans_mat_buffer = trans_mat.buffer();
-    auto* dst_buffer = output.buffer();
-
-    constexpr uint8_t input_cb_index = CBIndex::c_0;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_input_tiles * input_single_tile_size,
-        .core_ranges = CoreRangeSet(all_cores),
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = input_cb_index,
-            .data_format = input_cb_data_format,
-            .page_size = input_single_tile_size,
-        }}},
-        .buffer = src_buffer,
-    });
-
-    constexpr uint8_t cos_cb_index = CBIndex::c_1;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_cos_sin_tiles * cos_single_tile_size,
-        .core_ranges = CoreRangeSet(all_cores),
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = cos_cb_index,
-            .data_format = cos_cb_data_format,
-            .page_size = cos_single_tile_size,
-        }}},
-        .buffer = cos_buffer,
-    });
-
-    constexpr uint8_t sin_cb_index = CBIndex::c_2;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_cos_sin_tiles * sin_single_tile_size,
-        .core_ranges = CoreRangeSet(all_cores),
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = sin_cb_index,
-            .data_format = sin_cb_data_format,
-            .page_size = sin_single_tile_size,
-        }}},
-        .buffer = sin_buffer,
-    });
-
-    constexpr uint8_t trans_mat_cb_index = CBIndex::c_3;
     // We only take one tile of trans_mat
-    uint32_t num_trans_mat_tiles = 1;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_trans_mat_tiles * trans_mat_single_tile_size,
-        .core_ranges = CoreRangeSet(all_cores),
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = trans_mat_cb_index,
-            .data_format = trans_mat_cb_data_format,
-            .page_size = trans_mat_single_tile_size,
-        }}},
-        .buffer = trans_mat_buffer,
-    });
+    const uint32_t num_trans_mat_tiles = 1;
 
-    uint32_t num_interm_tiles = head_dim_t;
-    constexpr uint8_t rotated_input_interm_cb_index = CBIndex::c_24;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_interm_tiles * input_single_tile_size,
-        .core_ranges = CoreRangeSet(all_cores),
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = rotated_input_interm_cb_index,
-            .data_format = input_cb_data_format,
-            .page_size = input_single_tile_size,
-        }}},
-    });
+    const uint32_t num_interm_tiles = head_dim_t;
 
-    constexpr uint8_t cos_interm_cb_index = CBIndex::c_25;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_interm_tiles * input_single_tile_size,
-        .core_ranges = CoreRangeSet(all_cores),
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = cos_interm_cb_index,
-            .data_format = cos_cb_data_format,
-            .page_size = cos_single_tile_size,
-        }}},
-    });
+    // ----------------------------------------------------------------------------
+    // Tensor parameters. Each of the 5 backing tensors backs exactly one borrowed
+    // DFB (resident, sharded L1). NONE is bound as a TensorBinding: the compute kernel
+    // touches every CB by id only (FIFO ops / LLK operands), never builds a
+    // TensorAccessor and never reads a base address. The borrowed DFB resolves its
+    // address from the matching TensorArgument at runtime.
+    // ----------------------------------------------------------------------------
+    TensorParameter in_param{.unique_id = IN_TENSOR, .spec = input.tensor_spec()};
+    TensorParameter cos_param{.unique_id = COS_TENSOR, .spec = cos.tensor_spec()};
+    TensorParameter sin_param{.unique_id = SIN_TENSOR, .spec = sin.tensor_spec()};
+    TensorParameter trans_mat_param{.unique_id = TRANS_MAT_TENSOR, .spec = trans_mat.tensor_spec()};
+    TensorParameter out_param{.unique_id = OUT_TENSOR, .spec = output.tensor_spec()};
 
-    constexpr uint8_t sin_interm_cb_index = CBIndex::c_26;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_interm_tiles * input_single_tile_size,
-        .core_ranges = CoreRangeSet(all_cores),
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = sin_interm_cb_index,
-            .data_format = sin_cb_data_format,
-            .page_size = sin_single_tile_size,
-        }}},
-    });
-
-    constexpr uint8_t output_cb_index = CBIndex::c_16;  // output operands start at index 16
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_output_tiles * output_single_tile_size,
-        .core_ranges = CoreRangeSet(all_cores),
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = output_cb_index,
-            .data_format = output_cb_data_format,
-            .page_size = output_single_tile_size,
-        }}},
-        .buffer = dst_buffer,
-    });
-
-    // Set up the kernel
-    std::vector<uint32_t> compute_kernel_args = {
-        (std::uint32_t)input_cb_index,
-        (std::uint32_t)cos_cb_index,
-        (std::uint32_t)sin_cb_index,
-        (std::uint32_t)trans_mat_cb_index,
-        (std::uint32_t)rotated_input_interm_cb_index,
-        (std::uint32_t)cos_interm_cb_index,
-        (std::uint32_t)sin_interm_cb_index,
-        (std::uint32_t)output_cb_index,
-        (std::uint32_t)head_dim_t,
-        (std::uint32_t)n_heads_t,
+    // ----------------------------------------------------------------------------
+    // Dataflow buffers. One DFB per legacy CBDescriptor.
+    //   - 5 borrowed-memory DFBs (legacy CBs with .buffer set): in (c_0), cos (c_1),
+    //     sin (c_2), trans_mat (c_3), out (c_16).
+    //   - 3 program-local scratch DFBs (legacy CBs with no .buffer): rotated_in_interm
+    //     (c_24), cos_interm (c_25), sin_interm (c_26). Real intra-kernel FIFOs.
+    // ----------------------------------------------------------------------------
+    DataflowBufferSpec in_dfb_spec{
+        .unique_id = IN_DFB,
+        .entry_size = input_single_tile_size,
+        .num_entries = num_input_tiles,
+        .data_format_metadata = input_cb_data_format,
+        .borrowed_from = IN_TENSOR,
+    };
+    DataflowBufferSpec cos_dfb_spec{
+        .unique_id = COS_DFB,
+        .entry_size = cos_single_tile_size,
+        .num_entries = num_cos_sin_tiles,
+        .data_format_metadata = cos_cb_data_format,
+        .borrowed_from = COS_TENSOR,
+    };
+    DataflowBufferSpec sin_dfb_spec{
+        .unique_id = SIN_DFB,
+        .entry_size = sin_single_tile_size,
+        .num_entries = num_cos_sin_tiles,
+        .data_format_metadata = sin_cb_data_format,
+        .borrowed_from = SIN_TENSOR,
+    };
+    DataflowBufferSpec trans_mat_dfb_spec{
+        .unique_id = TRANS_MAT_DFB,
+        .entry_size = trans_mat_single_tile_size,
+        .num_entries = num_trans_mat_tiles,
+        .data_format_metadata = trans_mat_cb_data_format,
+        .borrowed_from = TRANS_MAT_TENSOR,
+    };
+    DataflowBufferSpec rotated_in_interm_dfb_spec{
+        .unique_id = ROTATED_INTERM_DFB,
+        .entry_size = input_single_tile_size,
+        .num_entries = num_interm_tiles,
+        .data_format_metadata = input_cb_data_format,
+    };
+    DataflowBufferSpec cos_interm_dfb_spec{
+        .unique_id = COS_INTERM_DFB,
+        .entry_size = cos_single_tile_size,
+        .num_entries = num_interm_tiles,
+        .data_format_metadata = cos_cb_data_format,
+    };
+    DataflowBufferSpec sin_interm_dfb_spec{
+        .unique_id = SIN_INTERM_DFB,
+        .entry_size = sin_single_tile_size,
+        .num_entries = num_interm_tiles,
+        .data_format_metadata = sin_cb_data_format,
+    };
+    DataflowBufferSpec out_dfb_spec{
+        .unique_id = OUT_DFB,
+        .entry_size = output_single_tile_size,
+        .num_entries = num_output_tiles,
+        .data_format_metadata = output_cb_data_format,
+        .borrowed_from = OUT_TENSOR,
     };
 
-    KernelDescriptor compute_desc;
-    compute_desc.kernel_source =
+    // ----------------------------------------------------------------------------
+    // Single compute KernelSpec. Every DFB is bound on this kernel as a self-loop
+    // (PRODUCER + CONSUMER): the op is compute-only and the data is resident, so each
+    // DFB is one-ended from the validator's view. Each self-loop DFB is declared INTRA.
+    //   - in/cos/sin/trans_mat/out: borrowed-memory FAKE-CB self-loops.
+    //   - rotated_in_interm/cos_interm/sin_interm: real intra-kernel FIFO self-loops.
+    // ----------------------------------------------------------------------------
+    const std::string compute_kernel_path =
         "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/compute/"
         "rotary_embedding_llama_sharded.cpp";
-    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    compute_desc.core_ranges = CoreRangeSet(all_cores);
-    compute_desc.compile_time_args = std::move(compute_kernel_args);
-    compute_desc.config = ComputeConfigDescriptor{
-        .math_fidelity = math_fidelity,
-        .fp32_dest_acc_en = fp32_dest_acc_en,
+
+    KernelSpec compute_spec{
+        .unique_id = COMPUTE_KERNEL,
+        .source = std::filesystem::path{compute_kernel_path},
+        .dfb_bindings =
+            {DFBBinding{.dfb_spec_name = IN_DFB, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{.dfb_spec_name = IN_DFB, .accessor_name = "in", .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{.dfb_spec_name = COS_DFB, .accessor_name = "cos", .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{.dfb_spec_name = COS_DFB, .accessor_name = "cos", .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{.dfb_spec_name = SIN_DFB, .accessor_name = "sin", .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{.dfb_spec_name = SIN_DFB, .accessor_name = "sin", .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{
+                 .dfb_spec_name = TRANS_MAT_DFB,
+                 .accessor_name = "trans_mat",
+                 .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{
+                 .dfb_spec_name = TRANS_MAT_DFB,
+                 .accessor_name = "trans_mat",
+                 .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{
+                 .dfb_spec_name = ROTATED_INTERM_DFB,
+                 .accessor_name = "rotated_in_interm",
+                 .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{
+                 .dfb_spec_name = ROTATED_INTERM_DFB,
+                 .accessor_name = "rotated_in_interm",
+                 .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{
+                 .dfb_spec_name = COS_INTERM_DFB,
+                 .accessor_name = "cos_interm",
+                 .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{
+                 .dfb_spec_name = COS_INTERM_DFB,
+                 .accessor_name = "cos_interm",
+                 .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{
+                 .dfb_spec_name = SIN_INTERM_DFB,
+                 .accessor_name = "sin_interm",
+                 .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{
+                 .dfb_spec_name = SIN_INTERM_DFB,
+                 .accessor_name = "sin_interm",
+                 .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{.dfb_spec_name = OUT_DFB, .accessor_name = "out", .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{.dfb_spec_name = OUT_DFB, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
+        .compile_time_args = {{"Wt", head_dim_t}, {"Ht", n_heads_t}},
+        .hw_config =
+            ComputeHardwareConfig{
+                .math_fidelity = math_fidelity,
+                .fp32_dest_acc_en = fp32_dest_acc_en,
+            },
+    };
+    // Compute-kernel self-loops must declare their thread connectivity. All are INTRA
+    // (each TRISC thread self-loops; no cross-thread production).
+    compute_spec.advanced_options.dfb_self_loop_connectivities = {
+        {IN_DFB, DFBSelfLoopConnectivity::INTRA},
+        {COS_DFB, DFBSelfLoopConnectivity::INTRA},
+        {SIN_DFB, DFBSelfLoopConnectivity::INTRA},
+        {TRANS_MAT_DFB, DFBSelfLoopConnectivity::INTRA},
+        {ROTATED_INTERM_DFB, DFBSelfLoopConnectivity::INTRA},
+        {COS_INTERM_DFB, DFBSelfLoopConnectivity::INTRA},
+        {SIN_INTERM_DFB, DFBSelfLoopConnectivity::INTRA},
+        {OUT_DFB, DFBSelfLoopConnectivity::INTRA},
     };
 
-    desc.kernels.push_back(std::move(compute_desc));
+    WorkUnitSpec wu{
+        .name = "rotary_embedding_llama_sharded",
+        .kernels = {COMPUTE_KERNEL},
+        .target_nodes = CoreRangeSet(all_cores),
+    };
 
-    return desc;
+    ProgramSpec spec{
+        .name = "rotary_embedding_llama_sharded",
+        .kernels = {compute_spec},
+        .dataflow_buffers =
+            {in_dfb_spec,
+             cos_dfb_spec,
+             sin_dfb_spec,
+             trans_mat_dfb_spec,
+             rotated_in_interm_dfb_spec,
+             cos_interm_dfb_spec,
+             sin_interm_dfb_spec,
+             out_dfb_spec},
+        .tensor_parameters = {in_param, cos_param, sin_param, trans_mat_param, out_param},
+        .work_units = {wu},
+    };
+
+    ProgramRunArgs run_args;
+    run_args.tensor_args = {
+        {IN_TENSOR, TensorArgument{std::cref(input.mesh_tensor())}},
+        {COS_TENSOR, TensorArgument{std::cref(cos.mesh_tensor())}},
+        {SIN_TENSOR, TensorArgument{std::cref(sin.mesh_tensor())}},
+        {TRANS_MAT_TENSOR, TensorArgument{std::cref(trans_mat.mesh_tensor())}},
+        {OUT_TENSOR, TensorArgument{std::cref(output.mesh_tensor())}}};
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_sharded_program_factory.hpp
@@ -5,21 +5,22 @@
 #pragma once
 
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/device_operation.hpp"
 #include "rotary_embedding_llama_device_operation_types.hpp"
 
 namespace ttnn::experimental::prim {
 
 struct RotaryEmbeddingLlamaMultiCoreSharded {
-    // Contract (1): single ProgramDescriptor for the fully-sharded decode case.
-    // All five working CBs (input/cos/sin/trans_mat/output) bind through
-    // CBDescriptor::buffer so the framework patches dynamic addresses on cache hit,
-    // matching the legacy UpdateDynamicCircularBufferAddress chain.
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    // Metal 2.0 (MetalV2FactoryConcept): single ProgramSpec for the fully-sharded decode
+    // case. All five working tensors (input/cos/sin/trans_mat/output) back borrowed-memory
+    // DFBs via DataflowBufferSpec::borrowed_from, so the framework patches dynamic addresses
+    // on cache hit (matching the legacy UpdateDynamicCircularBufferAddress chain). The op is
+    // compute-only, so every DFB is one-ended from the validator's view and is bound on the
+    // single compute kernel as an INTRA self-loop (PRODUCER + CONSUMER).
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const RotaryEmbeddingLlamaParams& operation_attributes,
         const RotaryEmbeddingLlamaInputs& tensor_args,
-        tt::tt_metal::Tensor& output);
+        tt::tt_metal::Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::experimental::prim


### PR DESCRIPTION
## What

Ports `rotary_embedding_llama` from the legacy `ProgramDescriptor` (`create_descriptor`) API to the Metal 2.0 `create_program_artifacts` / `ProgramSpec` API (`MetalV2FactoryConcept`). The op has three program factories; **two of three** are ported here:

| Factory | This PR |
|---|---|
| `RotaryEmbeddingLlamaMultiCoreSharded` (decode) | ✅ ported (commit 1) |
| `RotaryEmbeddingLlamaMultiCore` (prefill, interleaved) | ✅ ported (commit 2) |
| `RotaryEmbeddingLlamaMultiCorePrefillSharded` (prefill, sharded) | ⏸️ deferred — see *Follow-up* |

The device-op `program_factory_t` variant is now a mixed metal2/legacy set; the framework's `std::visit` dispatch (`device_operation.hpp`) handles each alternative by its concept, so the op stays fully functional during the incremental port. No device-op change was needed (no custom `compute_program_hash` to delete — already gone). Modeled on the merged `rotary_embedding_llama_fused_qk` port (#47879).

## How (behavior-preserving)

- **Decode factory:** 5 working tensors → borrowed-memory DFBs (`DataflowBufferSpec::borrowed_from`), 3 intermediates → scratch DFBs. Compute-only, so every DFB is bound on the compute kernel as an INTRA self-loop (PRODUCER+CONSUMER) — the sanctioned workaround for the producer-only output CB `c_16`. Compute kernel converted to `DataflowBuffer`/`dfb::`/`args::` with the FIFO sequence preserved exactly.
- **MultiCore factory:** reader/compute/writer; the 5 tensors are Case-1 (`TensorParameter` + `TensorBinding`, kernel builds `TensorAccessor(tensor::…)`), dropping the per-RISC base-address RTAs + `TensorAccessorArgs` CTA plumbing. interm/zero CBs → scratch DFBs; per-core `start_batch/end_batch/start_seq/end_seq` stay as named RTAs. `RELOAD_IMPL` kept as a define. To avoid disturbing the still-legacy PrefillSharded factory, the two **shared** kernels were forked to `_metal2` copies (`writer_..._interleaved_start_id_metal2.cpp`, `compute/rotary_embedding_llama_metal2.cpp`).

### Constraint discovered: Gen1 DM kernels can't self-loop a DFB
The legacy MultiCore writer fabricated its own zero-fill tiles via a producer-only `zero` CB. Binding that as a writer self-loop hit `TT_FATAL: DataflowBuffer 'zero' is self-looped by data-movement kernel` — only **compute** kernels may self-loop a DFB on Gen1. Fixed cleanly by hoisting the zero-fill to a **reader (PRODUCER) → writer (CONSUMER)** cross-kernel DFB; the writer `wait_front`s once and reuses the tile for every tail position. Output-identical.

## Validation (n150 — all via the correct worktree `_ttnn.so`)

| Suite | Result |
|---|---|
| `test_rotary_embedding_llama -k decode` | 25 passed / 5 skipped / 0 failed |
| `test_rotary_embedding_llama -k prefill` (MultiCore) | 54 passed / 0 failed |
| `test_rotary_embedding_llama_prefill_cos_sin_and_trans_mat_sharding` (PrefillSharded regression) | 324 passed / 0 failed |
| `test_rotary_embedding_llama_with_program_cache` (cache-hit borrowed-DFB address patching) | 8 passed / 0 failed |
| `test_rotary_embedding_llama_per_head` | 8 passed / 0 failed |
| `test_rotary_embedding_llama_direct_cos_padding_tail` | 4 passed / 0 failed |
| **Total** | **423 passed, 5 skipped, 0 failed**, all PCC ≥ 0.9997 |

## Follow-up (3/3): PrefillSharded

PrefillSharded does **not** map cleanly to program-wide DFBs. When the cos/sin/trans_mat **shard grid is smaller than the device grid** (`partial_cos_sin` / `partial_tm`), the legacy factory defines the *same* CB index (`c_1`/`c_2`/`c_3`) **twice** — borrowed (`.buffer=…`) on the shard-grid cores and plain scratch on the remaining cores. A Metal 2.0 `DataflowBufferSpec` is program-wide (one `borrowed_from` per id), so a CB that is borrowed on some nodes and scratch on others has no clean expression today. It needs either a framework per-node-borrowed binding feature or a restructure constraining the shard grid to equal the active-core set. (The original audit graded the op GREEN and missed this; the audit will be updated.) PrefillSharded is left on the legacy `create_descriptor` path here (regression-clean above).

Part of the Metal 2.0 migration umbrella #46909; audit in #48139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vsureshTT/metal2-port-rotary-embedding-llama)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vsureshTT/metal2-port-rotary-embedding-llama)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vsureshTT/metal2-port-rotary-embedding-llama)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vsureshTT/metal2-port-rotary-embedding-llama)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vsureshTT/metal2-port-rotary-embedding-llama)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vsureshTT/metal2-port-rotary-embedding-llama)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vsureshTT/metal2-port-rotary-embedding-llama)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vsureshTT/metal2-port-rotary-embedding-llama)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vsureshTT/metal2-port-rotary-embedding-llama)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vsureshTT/metal2-port-rotary-embedding-llama)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vsureshTT/metal2-port-rotary-embedding-llama)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vsureshTT/metal2-port-rotary-embedding-llama)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vsureshTT/metal2-port-rotary-embedding-llama)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vsureshTT/metal2-port-rotary-embedding-llama)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vsureshTT/metal2-port-rotary-embedding-llama)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vsureshTT/metal2-port-rotary-embedding-llama)