### PR TITLE
[tt_metal] Fix from_flatbuffer(SubDeviceId vector) iterating over the empty vector

### DIFF
--- a/tests/tt_metal/tt_metal/lightmetal/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/lightmetal/CMakeLists.txt
@@ -16,6 +16,7 @@ target_include_directories(
     unit_tests_lightmetal
     PRIVATE
         "$<TARGET_PROPERTY:Metalium::Metal,INCLUDE_DIRECTORIES>"
+        "$<TARGET_PROPERTY:Metalium::Metal::Impl,BINARY_DIR>/flatbuffers"
         ${PROJECT_SOURCE_DIR}/tests
         ${PROJECT_SOURCE_DIR}/tests/tt_metal/tt_metal/common
         ${CMAKE_CURRENT_SOURCE_DIR}

--- a/tests/tt_metal/tt_metal/lightmetal/sources.cmake
+++ b/tests/tt_metal/tt_metal/lightmetal/sources.cmake
@@ -4,4 +4,5 @@
 set(UNIT_TESTS_LIGHTMETAL_SRC
     test_lightmetal.cpp
     test_program_types_flatbuffer.cpp
+    test_program_types_vector_flatbuffer.cpp
 )

--- a/tests/tt_metal/tt_metal/lightmetal/sources.cmake
+++ b/tests/tt_metal/tt_metal/lightmetal/sources.cmake
@@ -1,4 +1,7 @@
 # Source files for tt_metal lightmetal tests
 # Module owners should update this file when adding/removing/renaming source files
 
-set(UNIT_TESTS_LIGHTMETAL_SRC test_lightmetal.cpp)
+set(UNIT_TESTS_LIGHTMETAL_SRC
+    test_lightmetal.cpp
+    test_program_types_flatbuffer.cpp
+)

--- a/tests/tt_metal/tt_metal/lightmetal/test_program_types_flatbuffer.cpp
+++ b/tests/tt_metal/tt_metal/lightmetal/test_program_types_flatbuffer.cpp
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+#include <flatbuffers/flatbuffers.h>
+#include <tt_stl/span.hpp>
+#include <sub_device_types.hpp>
+
+#include "flatbuffer/program_types_to_flatbuffer.hpp"
+#include "flatbuffer/program_types_from_flatbuffer.hpp"
+
+namespace tt::tt_metal {
+namespace {
+
+// Regression test for the from_flatbuffer(SubDeviceId vector) loop bug (PR #48181).
+//
+// The original loop iterated over the destination vector's size:
+//     sub_device_ids.reserve(fb_sub_device_ids->size());
+//     for (size_t i = 0; i < sub_device_ids.size(); ++i) { ... }   // size() is still 0!
+// reserve() only changes capacity, not size(), so the loop body never executed and
+// deserialization always returned an empty vector regardless of the input. The fix
+// iterates over fb_sub_device_ids->size() instead.
+//
+// Before the fix this test fails at the ASSERT_EQ below (0 != 3).
+TEST(ProgramTypesFromFlatbuffer, SubDeviceIdVectorRoundtrip) {
+    const std::vector<SubDeviceId> original = {SubDeviceId{0}, SubDeviceId{2}, SubDeviceId{5}};
+
+    flatbuffers::FlatBufferBuilder builder;
+    const auto fb_offset = to_flatbuffer(builder, tt::stl::Span<const SubDeviceId>(original.data(), original.size()));
+    builder.Finish(fb_offset);
+
+    const auto* fb_sub_device_ids = flatbuffers::GetRoot<flatbuffers::Vector<uint8_t>>(builder.GetBufferPointer());
+    const std::vector<SubDeviceId> roundtripped = from_flatbuffer(fb_sub_device_ids);
+
+    ASSERT_EQ(roundtripped.size(), original.size());
+    EXPECT_EQ(roundtripped, original);
+}
+
+// A null input is the documented "no sub-device ids" case and must yield an empty vector.
+TEST(ProgramTypesFromFlatbuffer, SubDeviceIdVectorNullIsEmpty) {
+    const std::vector<SubDeviceId> roundtripped =
+        from_flatbuffer(static_cast<const flatbuffers::Vector<uint8_t>*>(nullptr));
+    EXPECT_TRUE(roundtripped.empty());
+}
+
+// An empty (but non-null) flatbuffer vector must also round-trip to an empty vector.
+TEST(ProgramTypesFromFlatbuffer, SubDeviceIdVectorEmptyRoundtrip) {
+    const std::vector<SubDeviceId> original = {};
+
+    flatbuffers::FlatBufferBuilder builder;
+    const auto fb_offset = to_flatbuffer(builder, tt::stl::Span<const SubDeviceId>(original.data(), original.size()));
+    builder.Finish(fb_offset);
+
+    const auto* fb_sub_device_ids = flatbuffers::GetRoot<flatbuffers::Vector<uint8_t>>(builder.GetBufferPointer());
+    const std::vector<SubDeviceId> roundtripped = from_flatbuffer(fb_sub_device_ids);
+
+    EXPECT_TRUE(roundtripped.empty());
+}
+
+}  // namespace
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/lightmetal/test_program_types_flatbuffer.cpp
+++ b/tests/tt_metal/tt_metal/lightmetal/test_program_types_flatbuffer.cpp
@@ -17,16 +17,7 @@
 namespace tt::tt_metal {
 namespace {
 
-// Regression test for the from_flatbuffer(SubDeviceId vector) loop bug (PR #48181).
-//
-// The original loop iterated over the destination vector's size:
-//     sub_device_ids.reserve(fb_sub_device_ids->size());
-//     for (size_t i = 0; i < sub_device_ids.size(); ++i) { ... }   // size() is still 0!
-// reserve() only changes capacity, not size(), so the loop body never executed and
-// deserialization always returned an empty vector regardless of the input. The fix
-// iterates over fb_sub_device_ids->size() instead.
-//
-// Before the fix this test fails at the ASSERT_EQ below (0 != 3).
+// #48180: a SubDeviceId vector round-trips with all its elements (not an empty vector).
 TEST(ProgramTypesFromFlatbuffer, SubDeviceIdVectorRoundtrip) {
     const std::vector<SubDeviceId> original = {SubDeviceId{0}, SubDeviceId{2}, SubDeviceId{5}};
 

--- a/tests/tt_metal/tt_metal/lightmetal/test_program_types_vector_flatbuffer.cpp
+++ b/tests/tt_metal/tt_metal/lightmetal/test_program_types_vector_flatbuffer.cpp
@@ -16,10 +16,7 @@
 namespace tt::tt_metal {
 namespace {
 
-// Regression test for from_flatbuffer(std::vector<CoreCoord>): the deserializer
-// size-constructed the output vector (N default-initialized {0,0} entries) and then
-// emplace_back'd the real values on top, returning a vector of size 2N with junk at the
-// front. Before the fix this test fails (size is 2N, not N).
+// #48258: a CoreCoord vector round-trips to size N with the right values (not 2N with leading {0,0}s).
 TEST(ProgramTypesFromFlatbuffer, CoreCoordVectorRoundtrip) {
     const std::vector<CoreCoord> original = {CoreCoord{1, 2}, CoreCoord{3, 4}, CoreCoord{5, 6}};
 
@@ -48,9 +45,7 @@ TEST(ProgramTypesFromFlatbuffer, CoreCoordVectorEmptyRoundtrip) {
     EXPECT_TRUE(from_flatbuffer(fb).empty());
 }
 
-// Regression test for from_flatbuffer(std::vector<std::vector<uint32_t>>): same bug class as
-// above - the output was size-constructed (N empty sub-vectors) and then push_back'd onto,
-// returning size 2N with empty sub-vectors at the front. Before the fix this test fails.
+// #48259: a vector-of-vectors round-trips to size N with the right values (not 2N with leading empties).
 TEST(ProgramTypesFromFlatbuffer, UInt32VecOfVecRoundtrip) {
     const std::vector<std::vector<uint32_t>> original = {{1, 2, 3}, {4, 5}, {6}};
 

--- a/tests/tt_metal/tt_metal/lightmetal/test_program_types_vector_flatbuffer.cpp
+++ b/tests/tt_metal/tt_metal/lightmetal/test_program_types_vector_flatbuffer.cpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+#include <flatbuffers/flatbuffers.h>
+#include <core_coord.hpp>
+
+#include "flatbuffer/program_types_to_flatbuffer.hpp"
+#include "flatbuffer/program_types_from_flatbuffer.hpp"
+
+namespace tt::tt_metal {
+namespace {
+
+// Regression test for from_flatbuffer(std::vector<CoreCoord>): the deserializer
+// size-constructed the output vector (N default-initialized {0,0} entries) and then
+// emplace_back'd the real values on top, returning a vector of size 2N with junk at the
+// front. Before the fix this test fails (size is 2N, not N).
+TEST(ProgramTypesFromFlatbuffer, CoreCoordVectorRoundtrip) {
+    const std::vector<CoreCoord> original = {CoreCoord{1, 2}, CoreCoord{3, 4}, CoreCoord{5, 6}};
+
+    flatbuffers::FlatBufferBuilder builder;
+    builder.Finish(to_flatbuffer(builder, original));
+
+    const auto* fb = flatbuffers::GetRoot<flatbuffers::Vector<flatbuffers::Offset<flatbuffer::CoreCoord>>>(
+        builder.GetBufferPointer());
+    const std::vector<CoreCoord> roundtripped = from_flatbuffer(fb);
+
+    ASSERT_EQ(roundtripped.size(), original.size());
+    for (size_t i = 0; i < original.size(); ++i) {
+        EXPECT_EQ(roundtripped[i].x, original[i].x);
+        EXPECT_EQ(roundtripped[i].y, original[i].y);
+    }
+}
+
+TEST(ProgramTypesFromFlatbuffer, CoreCoordVectorEmptyRoundtrip) {
+    const std::vector<CoreCoord> original = {};
+
+    flatbuffers::FlatBufferBuilder builder;
+    builder.Finish(to_flatbuffer(builder, original));
+
+    const auto* fb = flatbuffers::GetRoot<flatbuffers::Vector<flatbuffers::Offset<flatbuffer::CoreCoord>>>(
+        builder.GetBufferPointer());
+    EXPECT_TRUE(from_flatbuffer(fb).empty());
+}
+
+// Regression test for from_flatbuffer(std::vector<std::vector<uint32_t>>): same bug class as
+// above - the output was size-constructed (N empty sub-vectors) and then push_back'd onto,
+// returning size 2N with empty sub-vectors at the front. Before the fix this test fails.
+TEST(ProgramTypesFromFlatbuffer, UInt32VecOfVecRoundtrip) {
+    const std::vector<std::vector<uint32_t>> original = {{1, 2, 3}, {4, 5}, {6}};
+
+    flatbuffers::FlatBufferBuilder builder;
+    builder.Finish(to_flatbuffer(builder, original));
+
+    const auto* fb = flatbuffers::GetRoot<flatbuffers::Vector<flatbuffers::Offset<flatbuffer::UInt32Vector>>>(
+        builder.GetBufferPointer());
+    const std::vector<std::vector<uint32_t>> roundtripped = from_flatbuffer(fb);
+
+    ASSERT_EQ(roundtripped.size(), original.size());
+    EXPECT_EQ(roundtripped, original);
+}
+
+TEST(ProgramTypesFromFlatbuffer, UInt32VecOfVecEmptyRoundtrip) {
+    const std::vector<std::vector<uint32_t>> original = {};
+
+    flatbuffers::FlatBufferBuilder builder;
+    builder.Finish(to_flatbuffer(builder, original));
+
+    const auto* fb = flatbuffers::GetRoot<flatbuffers::Vector<flatbuffers::Offset<flatbuffer::UInt32Vector>>>(
+        builder.GetBufferPointer());
+    EXPECT_TRUE(from_flatbuffer(fb).empty());
+}
+
+}  // namespace
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/flatbuffer/program_types_from_flatbuffer.cpp
+++ b/tt_metal/impl/flatbuffer/program_types_from_flatbuffer.cpp
@@ -90,8 +90,8 @@ std::vector<SubDeviceId> from_flatbuffer(const flatbuffers::Vector<uint8_t>* fb_
 
     std::vector<SubDeviceId> sub_device_ids;
     sub_device_ids.reserve(fb_sub_device_ids->size());
-    for (size_t i = 0; i < fb_sub_device_ids->size(); ++i) {
-        sub_device_ids.push_back(SubDeviceId{(*fb_sub_device_ids)[i]});
+    for (unsigned char fb_sub_device_id : *fb_sub_device_ids) {
+        sub_device_ids.push_back(SubDeviceId{fb_sub_device_id});
     }
 
     return sub_device_ids;

--- a/tt_metal/impl/flatbuffer/program_types_from_flatbuffer.cpp
+++ b/tt_metal/impl/flatbuffer/program_types_from_flatbuffer.cpp
@@ -90,7 +90,7 @@ std::vector<SubDeviceId> from_flatbuffer(const flatbuffers::Vector<uint8_t>* fb_
 
     std::vector<SubDeviceId> sub_device_ids;
     sub_device_ids.reserve(fb_sub_device_ids->size());
-    for (size_t i = 0; i < sub_device_ids.size(); ++i) {
+    for (size_t i = 0; i < fb_sub_device_ids->size(); ++i) {
         sub_device_ids.push_back(SubDeviceId{(*fb_sub_device_ids)[i]});
     }
 

--- a/tt_metal/impl/flatbuffer/program_types_from_flatbuffer.cpp
+++ b/tt_metal/impl/flatbuffer/program_types_from_flatbuffer.cpp
@@ -101,7 +101,8 @@ std::vector<CoreCoord> from_flatbuffer(
     const flatbuffers::Vector<flatbuffers::Offset<flatbuffer::CoreCoord>>* core_spec_fbs) {
     TT_FATAL(core_spec_fbs, "Invalid Vector of CoreCoord data from flatbuffer.");
 
-    std::vector<CoreCoord> core_spec(core_spec_fbs->size());
+    std::vector<CoreCoord> core_spec;
+    core_spec.reserve(core_spec_fbs->size());
     for (const auto* coord_fbs : *core_spec_fbs) {
         core_spec.emplace_back(coord_fbs->x(), coord_fbs->y());
     }
@@ -112,7 +113,8 @@ std::vector<std::vector<uint32_t>> from_flatbuffer(
     const flatbuffers::Vector<flatbuffers::Offset<flatbuffer::UInt32Vector>>* vec_of_vec_fbs) {
     TT_FATAL(vec_of_vec_fbs, "Invalid FlatBuffer data: expected a vector of vector of uint32_t.");
 
-    std::vector<std::vector<uint32_t>> result(vec_of_vec_fbs->size());
+    std::vector<std::vector<uint32_t>> result;
+    result.reserve(vec_of_vec_fbs->size());
     for (const auto* sub_vector_fbs : *vec_of_vec_fbs) {
         std::vector<uint32_t> sub_vector(sub_vector_fbs->values()->begin(), sub_vector_fbs->values()->end());
         result.push_back(std::move(sub_vector));


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/issues/48180
#48258 
#48259 

The loop bound used the freshly-reserved (still size()==0) output vector instead of the flatbuffer source, so the body never executed and SubDeviceId deserialization always returned an empty vector:

    sub_device_ids.reserve(fb_sub_device_ids->size());
    for (size_t i = 0; i < sub_device_ids.size(); ++i)   // always 0 -> no iterations

Iterate over fb_sub_device_ids->size() instead, so the reserved entries are actually filled.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/flatbuffer-subdevice-ids-loop)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/flatbuffer-subdevice-ids-loop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/flatbuffer-subdevice-ids-loop)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/flatbuffer-subdevice-ids-loop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=fix/flatbuffer-subdevice-ids-loop)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:fix/flatbuffer-subdevice-ids-loop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/flatbuffer-subdevice-ids-loop)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/flatbuffer-subdevice-ids-loop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/flatbuffer-subdevice-ids-loop)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/flatbuffer-subdevice-ids-loop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/flatbuffer-subdevice-ids-loop)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/flatbuffer-subdevice-ids-loop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/flatbuffer-subdevice-ids-loop)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/flatbuffer-subdevice-ids-loop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/flatbuffer-subdevice-ids-loop)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/flatbuffer-subdevice-ids-loop)