### PR TITLE
[#48186 fix] MeshSocket: exchange resolved FabricNodeId in a handshake, so cross-rank submesh sockets route to the right chip

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/sockets/mesh_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/mesh_socket.hpp
@@ -198,6 +198,12 @@ private:
     SocketEndpoint socket_endpoint_type_;
     bool rank_scoped_socket_ = false;
     std::unordered_map<multihost::Rank, multihost::Rank> rank_translation_table_;
+
+    // Per-endpoint table of resolved fabric nodes, indexed by SocketEndpoint ([SENDER], [RECEIVER]).
+    // Each entry maps a socket connection's logical device coordinate (MeshCoordinate) to the physical
+    // tt_fabric::FabricNodeId {mesh_id, chip_id} of that endpoint's chip. Populated at construction from
+    // the endpoints' exchanged descriptors (each advertises its own offset-aware nodes) and read via
+    // get_fabric_node_id(); send_async/recv_async use it to address the peer endpoint over fabric.
     // TODO: replace with enchantum::array
     std::array<std::unordered_map<MeshCoordinate, tt::tt_fabric::FabricNodeId>, enchantum::count<SocketEndpoint>>
         fabric_node_id_map_;

--- a/tt_metal/distributed/flatbuffer/socket_peer_descriptor.fbs
+++ b/tt_metal/distributed/flatbuffer/socket_peer_descriptor.fbs
@@ -33,11 +33,18 @@ table SocketConfig {
     receiver_mesh_id: uint32;
 }
 
+table FabricNodeId {
+    mesh_id: uint32;
+    chip_id: uint32;
+}
+
 table SocketPeerDescriptor {
     config: SocketConfig;
     config_buffer_address: uint64;
     data_buffer_address: uint64;
     exchange_tag: uint32;
+    // Resolved fabric nodes for this endpoint's own coords, indexed by socket connection index.
+    fabric_node_ids: [FabricNodeId];
 }
 
 root_type SocketPeerDescriptor;

--- a/tt_metal/distributed/mesh_socket.cpp
+++ b/tt_metal/distributed/mesh_socket.cpp
@@ -269,11 +269,9 @@ void MeshSocket::connect_with_peer(const std::shared_ptr<multihost::DistributedC
         if (socket_endpoint_type_ == SocketEndpoint::SENDER) {
             forward_descriptor_to_peer(local_endpoint_desc, peer_rank, context);
             remote_endpoint_desc = receive_and_verify_descriptor_from_peer(local_endpoint_desc, peer_rank, context);
-            fabric_node_id_map_ = generate_fabric_node_id_map(config_);
         } else {
             remote_endpoint_desc = receive_and_verify_descriptor_from_peer(local_endpoint_desc, peer_rank, context);
             forward_descriptor_to_peer(local_endpoint_desc, peer_rank, context);
-            fabric_node_id_map_ = generate_fabric_node_id_map(config_);
         }
         write_socket_configs(config_buffer_, local_endpoint_desc, remote_endpoint_desc, socket_endpoint_type_);
         execute_with_timeout(
@@ -284,18 +282,31 @@ void MeshSocket::connect_with_peer(const std::shared_ptr<multihost::DistributedC
             forward_descriptor_to_peer(local_endpoint_desc, socket_endpoint_type_, context, rank_translation_table_);
             remote_endpoint_desc = receive_and_verify_descriptor_from_peer(
                 local_endpoint_desc, socket_endpoint_type_, context, rank_translation_table_);
-            fabric_node_id_map_ = generate_fabric_node_id_map(config_);
         } else {
             remote_endpoint_desc = receive_and_verify_descriptor_from_peer(
                 local_endpoint_desc, socket_endpoint_type_, context, rank_translation_table_);
             forward_descriptor_to_peer(local_endpoint_desc, socket_endpoint_type_, context, rank_translation_table_);
-            fabric_node_id_map_ = generate_fabric_node_id_map(config_);
         }
         write_socket_configs(config_buffer_, local_endpoint_desc, remote_endpoint_desc, socket_endpoint_type_);
 
         std::vector<Rank> sender_ranks = get_ranks_for_mesh_id(config_.sender_mesh_id.value(), rank_translation_table_);
         std::vector<Rank> recv_ranks = get_ranks_for_mesh_id(config_.receiver_mesh_id.value(), rank_translation_table_);
         execute_with_timeout([&]() { barrier_across_send_recv_ranks(sender_ranks, recv_ranks, context); });
+    }
+
+    // Build the [SENDER, RECEIVER] fabric node map from the exchanged descriptors. Works for
+    // submeshes because each endpoint advertised its own resolved nodes (indexed by connection); read
+    // later by the send/recv ops via MeshSocket::get_fabric_node_id.
+    const bool is_sender = socket_endpoint_type_ == SocketEndpoint::SENDER;
+    const SocketPeerDescriptor& sender_desc = is_sender ? local_endpoint_desc : remote_endpoint_desc;
+    const SocketPeerDescriptor& receiver_desc = is_sender ? remote_endpoint_desc : local_endpoint_desc;
+    auto& sender_map = fabric_node_id_map_[static_cast<std::underlying_type_t<SocketEndpoint>>(SocketEndpoint::SENDER)];
+    auto& receiver_map =
+        fabric_node_id_map_[static_cast<std::underlying_type_t<SocketEndpoint>>(SocketEndpoint::RECEIVER)];
+    const auto& connections = config_.socket_connection_config;
+    for (uint32_t i = 0; i < connections.size(); ++i) {
+        sender_map.insert_or_assign(connections[i].sender_core.device_coord, sender_desc.fabric_node_ids.at(i));
+        receiver_map.insert_or_assign(connections[i].receiver_core.device_coord, receiver_desc.fabric_node_ids.at(i));
     }
 }
 
@@ -325,7 +336,19 @@ std::pair<MeshSocket, MeshSocket> MeshSocket::create_socket_pair(
     write_socket_configs(
         recv_config_buffer, recv_peer_descriptor, send_peer_descriptor, SocketEndpoint::RECEIVER, sender);
 
-    auto fabric_node_id_map = generate_fabric_node_id_map(config, sender, receiver);
+    // Both endpoints are local; build the [SENDER, RECEIVER] map directly from the sender/receiver
+    // descriptors (each carries one resolved node per connection, indexed by connection).
+    std::array<std::unordered_map<MeshCoordinate, tt::tt_fabric::FabricNodeId>, 2> fabric_node_id_map;
+    auto& sender_map = fabric_node_id_map[static_cast<std::underlying_type_t<SocketEndpoint>>(SocketEndpoint::SENDER)];
+    auto& receiver_map =
+        fabric_node_id_map[static_cast<std::underlying_type_t<SocketEndpoint>>(SocketEndpoint::RECEIVER)];
+    const auto& connections = config.socket_connection_config;
+    for (uint32_t i = 0; i < connections.size(); ++i) {
+        sender_map.insert_or_assign(
+            connections[i].sender_core.device_coord, send_peer_descriptor.fabric_node_ids.at(i));
+        receiver_map.insert_or_assign(
+            connections[i].receiver_core.device_coord, recv_peer_descriptor.fabric_node_ids.at(i));
+    }
 
     sender_socket.fabric_node_id_map_ = fabric_node_id_map;
     receiver_socket.fabric_node_id_map_ = fabric_node_id_map;

--- a/tt_metal/distributed/mesh_socket_serialization.cpp
+++ b/tt_metal/distributed/mesh_socket_serialization.cpp
@@ -64,6 +64,21 @@ flatbuffers::Offset<distributed::flatbuffer::SocketMemoryConfig> to_flatbuffer(
         receiver_sub_device);
 }
 
+flatbuffers::Offset<distributed::flatbuffer::FabricNodeId> to_flatbuffer(
+    flatbuffers::FlatBufferBuilder& builder, const tt::tt_fabric::FabricNodeId& fabric_node_id) {
+    return distributed::flatbuffer::CreateFabricNodeId(builder, *fabric_node_id.mesh_id, fabric_node_id.chip_id);
+}
+
+flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<distributed::flatbuffer::FabricNodeId>>> to_flatbuffer(
+    flatbuffers::FlatBufferBuilder& builder, const std::vector<tt::tt_fabric::FabricNodeId>& fabric_node_ids) {
+    std::vector<flatbuffers::Offset<distributed::flatbuffer::FabricNodeId>> fb_fabric_node_ids;
+    fb_fabric_node_ids.reserve(fabric_node_ids.size());
+    for (const auto& fabric_node_id : fabric_node_ids) {
+        fb_fabric_node_ids.push_back(to_flatbuffer(builder, fabric_node_id));
+    }
+    return builder.CreateVector(fb_fabric_node_ids);
+}
+
 CoreCoord from_flatbuffer(const distributed::flatbuffer::CoreCoord* fb_core_coord) {
     return CoreCoord(fb_core_coord->x(), fb_core_coord->y());
 }
@@ -126,6 +141,19 @@ SocketMemoryConfig from_flatbuffer(const distributed::flatbuffer::SocketMemoryCo
     return socket_mem_config;
 }
 
+std::vector<tt::tt_fabric::FabricNodeId> from_flatbuffer(
+    const flatbuffers::Vector<flatbuffers::Offset<distributed::flatbuffer::FabricNodeId>>* fb_fabric_node_ids) {
+    std::vector<tt::tt_fabric::FabricNodeId> fabric_node_ids;
+    if (fb_fabric_node_ids) {
+        fabric_node_ids.reserve(fb_fabric_node_ids->size());
+        for (const auto* fb_fabric_node_id : *fb_fabric_node_ids) {
+            fabric_node_ids.emplace_back(
+                tt::tt_fabric::MeshId{fb_fabric_node_id->mesh_id()}, fb_fabric_node_id->chip_id());
+        }
+    }
+    return fabric_node_ids;
+}
+
 }  // namespace
 
 std::vector<uint8_t> serialize_to_bytes(const SocketPeerDescriptor& socket_peer_desc) {
@@ -144,13 +172,16 @@ std::vector<uint8_t> serialize_to_bytes(const SocketPeerDescriptor& socket_peer_
         *socket_config.receiver_rank,
         *socket_config.sender_mesh_id.value(),
         *socket_config.receiver_mesh_id.value());
+    // Build the per-connection resolved fabric nodes FlatBuffer
+    auto fabric_node_ids_fb = to_flatbuffer(builder, socket_peer_desc.fabric_node_ids);
     // Build the SocketPeerDescriptor FlatBuffer (root object)
     auto socket_peer_desc_fb = distributed::flatbuffer::CreateSocketPeerDescriptor(
         builder,
         socket_config_fb,
         socket_peer_desc.config_buffer_address,
         socket_peer_desc.data_buffer_address,
-        *(socket_peer_desc.exchange_tag));
+        *(socket_peer_desc.exchange_tag),
+        fabric_node_ids_fb);
 
     builder.Finish(socket_peer_desc_fb);
     // Extract the FlatBuffer data as a vector of bytes
@@ -181,6 +212,7 @@ SocketPeerDescriptor deserialize_from_bytes(const std::vector<uint8_t>& data) {
     socket_peer_desc.config_buffer_address = socket_peer_desc_fb->config_buffer_address();
     socket_peer_desc.data_buffer_address = socket_peer_desc_fb->data_buffer_address();
     socket_peer_desc.exchange_tag = multihost::Tag{static_cast<int>(socket_peer_desc_fb->exchange_tag())};
+    socket_peer_desc.fabric_node_ids = from_flatbuffer(socket_peer_desc_fb->fabric_node_ids());
     return socket_peer_desc;
 }
 

--- a/tt_metal/distributed/mesh_socket_utils.cpp
+++ b/tt_metal/distributed/mesh_socket_utils.cpp
@@ -312,15 +312,22 @@ void write_socket_configs(
     tt_fabric::FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
     const auto receiver_ids_per_sender = get_receiver_ids_per_sender(config);
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-    const auto& mesh_graph = control_plane.get_mesh_graph();
 
-    auto get_fabric_node_from_coord = [&](const MeshCoordinate& device_coord,
-                                          const std::shared_ptr<MeshDevice>& peer_device,
-                                          tt_fabric::MeshId peer_mesh_id) -> tt_fabric::FabricNodeId {
+    // Resolve the peer endpoint's FabricNodeId for a given connection. Same-process sockets pass
+    // the real peer device (offset-aware). Cross-rank sockets have no peer device and instead read
+    // the node the peer advertised in its descriptor, indexed by connection. There is no
+    // offset-blind fallback: a missing advertisement is a hard error rather than a silent misroute.
+    auto get_peer_fabric_node = [&](const MeshCoordinate& device_coord,
+                                    uint32_t connection_index,
+                                    const std::shared_ptr<MeshDevice>& peer_device) -> tt_fabric::FabricNodeId {
         if (peer_device) {
             return peer_device->get_fabric_node_id(device_coord);
         }
-        return tt_fabric::FabricNodeId(peer_mesh_id, mesh_graph.coordinate_to_chip(peer_mesh_id, device_coord));
+        TT_FATAL(
+            connection_index < peer_descriptor.fabric_node_ids.size(),
+            "Peer did not advertise a FabricNodeId for socket connection {}; cannot resolve cross-rank.",
+            connection_index);
+        return peer_descriptor.fabric_node_ids[connection_index];
     };
 
     if (is_sender) {
@@ -363,12 +370,13 @@ void write_socket_configs(
 
                 // Write one encoding per receiver, ordered by receiver ID
                 for (const auto& indexed_connection : connections) {
+                    uint32_t connection_index = indexed_connection.first;
                     const auto& connection = indexed_connection.second;
                     MeshCoordinate recv_device_coord = connection.receiver_core.device_coord;
                     auto recv_virtual_core =
                         mesh_device->worker_core_from_logical_core(connection.receiver_core.core_coord);
                     tt_fabric::FabricNodeId recv_fabric_node_id =
-                        get_fabric_node_from_coord(recv_device_coord, peer_device, config.receiver_mesh_id.value());
+                        get_peer_fabric_node(recv_device_coord, connection_index, peer_device);
                     uint32_t receiver_id = receiver_ids_per_sender.at(connection);
                     auto [downstream_mesh_id, downstream_chip_id] = get_sender_receiver_chip_fabric_encoding(
                         mesh_device->get_fabric_node_id(sender_core.device_coord),
@@ -398,13 +406,14 @@ void write_socket_configs(
             }
 
             for (const auto& [recv_core_coord, indexed_connections] : cores_map) {
-                const auto& connection =
-                    indexed_connections.front().second;  // Only one connection per receiver core for now
+                // Only one connection per receiver core for now
+                uint32_t connection_index = indexed_connections.front().first;
+                const auto& connection = indexed_connections.front().second;
                 MeshCoordinate sender_device_coord = connection.sender_core.device_coord;
                 auto sender_virtual_core =
                     mesh_device->worker_core_from_logical_core(connection.sender_core.core_coord);
                 tt_fabric::FabricNodeId sender_fabric_node_id =
-                    get_fabric_node_from_coord(sender_device_coord, peer_device, config.sender_mesh_id.value());
+                    get_peer_fabric_node(sender_device_coord, connection_index, peer_device);
                 MeshCoreCoord recv_core = {device_coord, recv_core_coord};
 
                 auto [upstream_mesh_id, upstream_chip_id] = get_sender_receiver_chip_fabric_encoding(
@@ -451,6 +460,17 @@ SocketPeerDescriptor generate_local_endpoint_descriptor(
         .config_buffer_address = socket_endpoint.get_config_buffer()->address(),
         .data_buffer_address = is_sender ? 0 : socket_endpoint.get_data_buffer()->address(),
         .exchange_tag = tag};
+
+    // Advertise this endpoint's own resolved fabric nodes, indexed by socket connection. The peer
+    // reads these instead of recomputing the chip from the global mesh graph (offset-blind for
+    // submeshes). Resolution uses this endpoint's live (sub)mesh device, so it is offset-aware.
+    auto* mesh_device = socket_endpoint.get_mesh_device();
+    local_endpoint_desc.fabric_node_ids.reserve(config.socket_connection_config.size());
+    for (const auto& connection : config.socket_connection_config) {
+        const auto& device_coord =
+            is_sender ? connection.sender_core.device_coord : connection.receiver_core.device_coord;
+        local_endpoint_desc.fabric_node_ids.push_back(mesh_device->get_fabric_node_id(device_coord));
+    }
     return local_endpoint_desc;
 }
 
@@ -645,37 +665,6 @@ SocketPeerDescriptor receive_and_verify_descriptor_from_peer(
             desc.exchange_tag);
     });
     return deserialize_from_bytes(serialized_remote);
-}
-
-std::array<std::unordered_map<MeshCoordinate, tt::tt_fabric::FabricNodeId>, 2> generate_fabric_node_id_map(
-    const SocketConfig& config,
-    const std::shared_ptr<MeshDevice>& sender_device,
-    const std::shared_ptr<MeshDevice>& receiver_device) {
-    std::array<std::unordered_map<MeshCoordinate, tt::tt_fabric::FabricNodeId>, 2> fabric_node_id_map;
-    const auto& mesh_graph = tt::tt_metal::MetalContext::instance().get_control_plane().get_mesh_graph();
-
-    auto resolve_fabric_node_id = [&](const MeshCoordinate& device_coord,
-                                      tt_fabric::MeshId mesh_id,
-                                      const std::shared_ptr<MeshDevice>& device) -> tt_fabric::FabricNodeId {
-        if (device) {
-            return device->get_fabric_node_id(device_coord);
-        }
-        return tt_fabric::FabricNodeId(mesh_id, mesh_graph.coordinate_to_chip(mesh_id, device_coord));
-    };
-
-    for (uint32_t i = 0; i < config.socket_connection_config.size(); ++i) {
-        const auto& connection = config.socket_connection_config[i];
-        TT_FATAL(config.sender_mesh_id.has_value(), "Sender mesh id is not set.");
-        TT_FATAL(config.receiver_mesh_id.has_value(), "Receiver mesh id is not set.");
-        fabric_node_id_map[static_cast<std::underlying_type_t<SocketEndpoint>>(SocketEndpoint::SENDER)].emplace(
-            connection.sender_core.device_coord,
-            resolve_fabric_node_id(connection.sender_core.device_coord, config.sender_mesh_id.value(), sender_device));
-        fabric_node_id_map[static_cast<std::underlying_type_t<SocketEndpoint>>(SocketEndpoint::RECEIVER)].emplace(
-            connection.receiver_core.device_coord,
-            resolve_fabric_node_id(
-                connection.receiver_core.device_coord, config.receiver_mesh_id.value(), receiver_device));
-    }
-    return fabric_node_id_map;
 }
 
 std::vector<multihost::Rank> get_ranks_for_mesh_id(

--- a/tt_metal/distributed/mesh_socket_utils.hpp
+++ b/tt_metal/distributed/mesh_socket_utils.hpp
@@ -35,6 +35,7 @@ struct SocketPeerDescriptor {
     DeviceAddr config_buffer_address = 0;
     DeviceAddr data_buffer_address = 0;
     multihost::Tag exchange_tag = multihost::Tag{0};
+    std::vector<tt::tt_fabric::FabricNodeId> fabric_node_ids;
 };
 
 // Create send/receive socket config buffers
@@ -77,11 +78,6 @@ SocketPeerDescriptor receive_and_verify_descriptor_from_peer(
     SocketEndpoint socket_endpoint_type,
     const std::shared_ptr<const multihost::DistributedContext>& context,
     const std::unordered_map<multihost::Rank, multihost::Rank>& rank_translation_table);
-
-std::array<std::unordered_map<MeshCoordinate, tt::tt_fabric::FabricNodeId>, 2> generate_fabric_node_id_map(
-    const SocketConfig& config,
-    const std::shared_ptr<MeshDevice>& sender_device = nullptr,
-    const std::shared_ptr<MeshDevice>& receiver_device = nullptr);
 
 std::vector<multihost::Rank> get_ranks_for_mesh_id(
     tt_fabric::MeshId mesh_id, const std::unordered_map<multihost::Rank, multihost::Rank>& rank_translation_table);


### PR DESCRIPTION
### PR Category
Fixes #48186 [MeshSocket doesn't work correctly with submeshes, all chips are resolved to chip 0 of a parent mesh of that submesh]

### Problem that this PR solves

Problem: When a MeshSocket is created across processes, each side must resolve "which physical chip is my peer?" — i.e. turn the peer's connection coordinate into a tt::tt_fabric::FabricNodeId. On main (without this PR), a process resolves the peer chip from the global mesh graph (MGD) using only the peer's rank/mesh id. That lookup is offset-blind: it has no knowledge that the peer opened a submesh. So when the peer's device is a submesh at a non-zero offset, the local-to-the-submesh coordinate (e.g. (0,0)) gets mapped against the full mesh and resolves to the wrong chip. The submesh offset is local to the peer's process and is never communicated, so the resolving side simply can't compute the correct chip — and the tensor is routed to the wrong chip over fabric (the socket hangs).

### Solution this PR provides

Each endpoint now advertises its own resolved tt::tt_fabric::FabricNodeId in the handshake payload (SocketPeerDescriptor). The owning process does know which submesh its devices belong to, so it computes the correct global FabricNodeId for its chips and ships it to the peer. The peer then uses the advertised node directly instead of recomputing it offset-blind from the MGD. This is symmetric: the sender advertises its chips so the receiver can address acks/credits back, and the receiver advertises its chips so the sender knows where to route the tensor — so both sides get correct, submesh-aware fabric addresses.

### Other approaches (not used in this PR)
*  Send a global/parent coordinate. Ship the peer's coordinate in the parent-mesh frame; the receiving side then runs coordinate_to_chip on that global coord. Rejected because it re-introduces a second computation that must match the device view (it can drift under reshaped/permuted views), whereas shipping the resolved node is the authoritative answer from the same object the peer itself uses.
 * Explicit submesh metadata. Ship is_submesh + parent mesh_id + offset + shape, and have the peer reconstruct the global coord then resolve. Rejected as the most consumer-side logic, brittle to reshaped/non-rectangular/nested submeshes, and it needs a new offset path (coordinate_to_chip only offsets via host_rank today). The peer doesn't actually need to know "it's a submesh" — it needs the resolved chip.

### Todos

* Write a test for a MeshSocket + submesh on sending & receiving side, observe that it doesn't hang
* Run existing MeshSocket tests to ensure the current functionality didn't break

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ichovpan/mesh-socket-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ichovpan/mesh-socket-patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ichovpan/mesh-socket-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ichovpan/mesh-socket-patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ichovpan/mesh-socket-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ichovpan/mesh-socket-patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ichovpan/mesh-socket-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ichovpan/mesh-socket-patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ichovpan/mesh-socket-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ichovpan/mesh-socket-patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ichovpan/mesh-socket-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ichovpan/mesh-socket-patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ichovpan/mesh-socket-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ichovpan/mesh-socket-patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ichovpan/mesh-socket-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ichovpan/mesh-socket-patch)