### PR TITLE
[Feature] LocalTensorAccessor: node-local tensor access (legacy + Metal 2.0)

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
@@ -1835,12 +1835,9 @@ TEST_F(ProgramRunArgsTestGen1, UpdateTensorArgs_LeavesNamedCRTAsUnchanged) {
 }
 
 TEST_F(ProgramRunArgsTestGen1, UpdateTensorArgs_PatchesAllKernelsBoundToSameTensor) {
-    // TEMPORARILY SKIPPED: this test binds the shared tensor to the compute kernel (kernels[1]),
-    // which ValidateProgramSpec now rejects until compute-path tensor bindings are supported (a day
-    // or two out). The host-side patching it exercises is unaffected by that gap; re-enable this test
-    // when the temporary compute-kernel tensor-binding guard in ValidateProgramSpec is removed.
-    GTEST_SKIP() << "Compute-kernel tensor bindings are temporarily rejected by ValidateProgramSpec.";
-
+    // Binds the shared tensor to both a DM kernel and the compute kernel (kernels[1]) — now legal,
+    // since a compute kernel constructs a LocalTensorAccessor from the binding token. Exercises the
+    // host-side address patching reaching every kernel bound to the same tensor.
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     auto binding = MakeMinimalTensorParameter("shared_tensor");

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -1179,17 +1179,16 @@ TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingDuplicateAccessorFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("duplicate semaphore accessor_name 'same'")));
 }
 
-TEST_F(ProgramSpecTestQuasar, TensorBindingOnComputeKernelTemporarilyUnsupportedFails) {
-    // TEMPORARY restriction: a TensorAccessor cannot yet be constructed in a compute kernel, so
-    // binding a tensor to one is rejected up front in ValidateProgramSpec with an apologetic message.
-    // Delete this test when compute-path tensor bindings are supported (the guard goes with it).
+TEST_F(ProgramSpecTestQuasar, TensorBindingOnComputeKernelIsAccepted) {
+    // A tensor binding on a compute kernel is legal: the kernel constructs a LocalTensorAccessor
+    // (NOC-free) from the binding token rather than a TensorAccessor. ValidateProgramSpec accepts it;
+    // there is no host-side residency check. (The compile/dispatch path is proven in the HW test
+    // LocalTensorAccessorBindingCompileComputeKernel.)
     ProgramSpec spec = MakeMinimalValidProgramSpec();
     spec.tensor_parameters = {MakeMinimalTensorParameter("t")};
     BindTensorParameterToKernel(spec.kernels[1], "t", "t_acc");  // kernels[1] == compute_kernel
 
-    EXPECT_THAT(
-        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("compute kernel with a tensor binding")));
+    EXPECT_NO_THROW({ MakeProgramFromSpec(*mesh_device_, spec); });
 }
 
 TEST_F(ProgramSpecTestQuasar, SemaphoreNonZeroInitialValueFailsOnQuasar) {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -38,6 +38,7 @@ using test_helpers::MakeMinimalComputeKernel;
 using test_helpers::MakeMinimalDFB;
 using test_helpers::MakeMinimalGen1DMKernel;
 using test_helpers::MakeMinimalWorkUnit;
+using test_helpers::MakeShardedTensorParameter;
 
 // ============================================================================
 // Test Fixture
@@ -717,8 +718,9 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
 //   Consumer DM kernel (NCRISC): DFB → output MeshTensor, via TensorAccessor(tensor::output_tensor)
 //   Host reads output MeshTensor and verifies match
 //
-// DM-only on purpose. The TensorAccessor library is currently DM-only (TRISC builds don't
-// compile its NoC-using includes); compute-kernel TA bindings are out of scope for this PR.
+// DM-only on purpose: TensorAccessor is the NOC-capable accessor and only compiles on DM builds.
+// The compute (TRISC) path uses LocalTensorAccessor instead — proven by
+// LocalTensorAccessorBindingCompileComputeKernel below.
 
 TEST_F(ProgramSpecHWTest, TensorAccessorBindingLoopback) {
     auto mesh_device = devices_.at(0);
@@ -830,6 +832,107 @@ TEST_F(ProgramSpecHWTest, TensorAccessorBindingLoopback) {
 
     ASSERT_EQ(output_data.size(), input_data.size());
     EXPECT_EQ(output_data, input_data);
+}
+
+// ============================================================================
+// LocalTensorAccessor Binding — Compute (TRISC) Compile + Token-Wiring Proof
+// ============================================================================
+//
+// Proves the compute-kernel path for tensor bindings, which previously could not compile:
+//   1. A compute (TRISC) kernel binds a tensor and constructs LocalTensorAccessor<uint32_t> from the
+//      binding token. The generated header emits only the NOC-free token header on the TRISC build, so
+//      this compiles (tensor_accessor.h would not — it needs NOC_INDEX, absent on compute builds).
+//   2. ValidateProgramSpec accepts the compute-kernel tensor binding (the old guard is gone).
+//   3. The binding's base-address CRTA is broadcast to the compute kernel and resolves to the local
+//      L1 shard address — verified by comparing the reported address to the bound tensor's address.
+//
+// Pipeline (compute-only producer, no DM producer needed):
+//   Compute kernel (TRISC) — constructs LocalTensorAccessor, deposits {base_address, page_size, rank,
+//       get_unsafe_ptr, &operator[]} into each out_dfb entry (raw L1 writes from PACK).
+//   DM consumer (NCRISC)   — out_dfb → DRAM output.
+//
+// The tensor is a single-shard L1 tensor on core (0,0) (the compute kernel's core), so its shard base
+// address equals MeshTensor::address(). No dereference of the shard occurs (address-of only), so the
+// proof does not depend on the shard's contents.
+
+TEST_F(ProgramSpecHWTest, LocalTensorAccessorBindingCompileComputeKernel) {
+    auto mesh_device = devices_.at(0);
+    IDevice* device = mesh_device->get_devices()[0];
+
+    constexpr uint32_t entry_size = 1024;
+    constexpr uint32_t num_entries_in_dfb = 4;
+    constexpr uint32_t num_tiles = 2;  // entries the compute kernel pushes
+    constexpr uint32_t total_bytes = entry_size * num_tiles;
+
+    const NodeCoord node{0, 0};
+
+    InterleavedBufferConfig dram_config{
+        .device = device, .size = total_bytes, .page_size = total_bytes, .buffer_type = BufferType::DRAM};
+    auto output_buffer = CreateBuffer(dram_config);
+
+    // Single-shard L1 tensor on core (0,0): one 32x32 BFLOAT16 tile.
+    auto tensor_param = MakeShardedTensorParameter("local_t", Shape{32, 32}, {32, 32}, /*num_cores=*/1);
+    MeshTensor local_tensor = MeshTensor::allocate_on_device(*mesh_device, tensor_param.spec, TensorTopology{});
+
+    ProgramSpec spec;
+    spec.name = "local_tensor_accessor_compute";
+
+    // Compute kernel (the kernel under test) — binds the tensor, produces into out_dfb.
+    auto compute = MakeMinimalComputeKernel("compute");
+    compute.source = "tests/tt_metal/tt_metal/test_kernels/compute/local_tensor_accessor_compute.cpp";
+    compute.compile_time_args = {{"entry_size", entry_size}, {"num_tiles", num_tiles}};
+    BindTensorParameterToKernel(compute, "local_t", "local_t");
+
+    // Consumer (NCRISC): drains out_dfb → DRAM. Reuses dfb_accessor_loopback_consumer.cpp verbatim.
+    auto consumer = MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
+    consumer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_consumer.cpp";
+    consumer.advanced_options.num_runtime_varargs = 3;
+
+    auto out_dfb = MakeMinimalDFB("out_dfb", entry_size, num_entries_in_dfb);
+    out_dfb.data_format_metadata = tt::DataFormat::Float16_b;
+
+    compute.dfb_bindings.push_back(ProducerOf(DFBSpecName{"out_dfb"}, "out_dfb"));
+    consumer.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"out_dfb"}, "a_dfb_named_bob"));
+
+    spec.kernels = {compute, consumer};
+    spec.dataflow_buffers = {out_dfb};
+    spec.tensor_parameters = {tensor_param};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", node, {"compute", "consumer"})};
+
+    Program program = MakeProgramFromSpec(*mesh_device, spec);
+
+    ProgramRunArgs params;
+    params.kernel_run_args = {
+        ProgramRunArgs::KernelRunArgs{.kernel = KernelSpecName{"compute"}},
+        ProgramRunArgs::KernelRunArgs{
+            .kernel = KernelSpecName{"consumer"},
+            .advanced_options =
+                AdvancedKernelRunArgs{
+                    .runtime_varargs = {{node, {output_buffer->address(), 0u, num_tiles}}},
+                },
+        },
+    };
+    params.tensor_args = {
+        {TensorParamName{"local_t"}, TensorArgument{local_tensor}},
+    };
+    SetProgramRunArgs(program, params);
+
+    detail::LaunchProgram(device, program);
+
+    std::vector<uint32_t> output_data;
+    detail::ReadFromBuffer(output_buffer, output_data);
+
+    const uint32_t expected_address = static_cast<uint32_t>(local_tensor.address());
+    constexpr uint32_t words_per_entry = entry_size / sizeof(uint32_t);
+    ASSERT_EQ(output_data.size(), total_bytes / sizeof(uint32_t));
+    for (uint32_t e = 0; e < num_tiles; ++e) {
+        const uint32_t* entry = output_data.data() + e * words_per_entry;
+        EXPECT_EQ(entry[0], expected_address) << "entry " << e << ": get_bank_base_address mismatch";
+        EXPECT_GT(entry[1], 0u) << "entry " << e << ": get_aligned_page_size should be non-zero";
+        EXPECT_GT(entry[2], 0u) << "entry " << e << ": rank should be non-zero";
+        EXPECT_EQ(entry[3], expected_address) << "entry " << e << ": get_unsafe_ptr mismatch";
+        EXPECT_EQ(entry[4], expected_address) << "entry " << e << ": &operator[] mismatch";
+    }
 }
 
 // ============================================================================

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -847,8 +847,9 @@ TEST_F(ProgramSpecHWTest, TensorAccessorBindingLoopback) {
 //      L1 shard address — verified by comparing the reported address to the bound tensor's address.
 //
 // Pipeline (compute-only producer, no DM producer needed):
-//   Compute kernel (TRISC) — constructs LocalTensorAccessor, deposits {base_address, page_size, rank,
-//       get_unsafe_ptr, &operator[]} into each out_dfb entry (raw L1 writes from PACK).
+//   Compute kernel (TRISC) — constructs LocalTensorAccessor (token ctor) and a second via the legacy
+//       base-address ctor, deposits {base_address, get_unsafe_ptr, &operator[], legacy-ctor base} into
+//       each out_dfb entry (raw L1 writes from PACK); all four should equal the bound tensor's address.
 //   DM consumer (NCRISC)   — out_dfb → DRAM output.
 //
 // The tensor is a single-shard L1 tensor on core (0,0) (the compute kernel's core), so its shard base
@@ -928,10 +929,9 @@ TEST_F(ProgramSpecHWTest, LocalTensorAccessorBindingCompileComputeKernel) {
     for (uint32_t e = 0; e < num_tiles; ++e) {
         const uint32_t* entry = output_data.data() + e * words_per_entry;
         EXPECT_EQ(entry[0], expected_address) << "entry " << e << ": get_bank_base_address mismatch";
-        EXPECT_GT(entry[1], 0u) << "entry " << e << ": get_aligned_page_size should be non-zero";
-        EXPECT_GT(entry[2], 0u) << "entry " << e << ": rank should be non-zero";
-        EXPECT_EQ(entry[3], expected_address) << "entry " << e << ": get_unsafe_ptr mismatch";
-        EXPECT_EQ(entry[4], expected_address) << "entry " << e << ": &operator[] mismatch";
+        EXPECT_EQ(entry[1], expected_address) << "entry " << e << ": get_unsafe_ptr mismatch";
+        EXPECT_EQ(entry[2], expected_address) << "entry " << e << ": &operator[] mismatch";
+        EXPECT_EQ(entry[3], expected_address) << "entry " << e << ": legacy base-address ctor mismatch";
     }
 }
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/local_tensor_accessor_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/local_tensor_accessor_compute.cpp
@@ -10,9 +10,9 @@
 // not define). LocalTensorAccessor carries no NOC machinery, so it compiles here.
 //
 // The accessor is constructed on all three TRISC threads (UNPACK/MATH/PACK) — the strongest compile
-// proof — and its full surface (get_bank_base_address / get_aligned_page_size / rank / get_unsafe_ptr /
-// operator[]) is exercised so every method is instantiated. The PACK thread deposits the reported
-// values into each output DFB entry; a DM consumer carries them to DRAM for host verification.
+// proof — and its full surface (get_bank_base_address / get_unsafe_ptr / operator[]) is exercised so
+// every method is instantiated. The PACK thread deposits the reported values into each output DFB
+// entry; a DM consumer carries them to DRAM for host verification.
 //
 // The host checks that the reported base address equals the bound tensor's address — proving the
 // binding token reached the compute kernel and resolved to the correct local L1 shard address. The
@@ -34,12 +34,15 @@ void kernel_main() {
     LocalTensorAccessor<uint32_t> acc(tensor::local_t);
 
     const uint32_t base_address = acc.get_bank_base_address();
-    const uint32_t page_size = acc.get_aligned_page_size();
-    const uint32_t rank = acc.rank();
     // Instantiate the element-access surface too, so it is compile-proven on TRISC. Both resolve to the
     // base address; address-of avoids an actual L1 load/store.
     const uint32_t via_unsafe_ptr = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(acc.get_unsafe_ptr()));
     const uint32_t via_subscript = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(&acc[0]));
+
+    // Also exercise the legacy (raw base-address) ctor: compile-proves it on TRISC and confirms it
+    // agrees with the token-built accessor.
+    LocalTensorAccessor<uint32_t> acc_legacy(base_address);
+    const uint32_t legacy_base = acc_legacy.get_bank_base_address();
 
     DataflowBuffer dfb_out(dfb::out_dfb);
 
@@ -52,12 +55,11 @@ void kernel_main() {
         {
             volatile tt_l1_ptr uint32_t* out_ptr = (volatile tt_l1_ptr uint32_t*)(dfb_out.get_write_ptr() << 4);
             out_ptr[0] = base_address;
-            out_ptr[1] = page_size;
-            out_ptr[2] = rank;
-            out_ptr[3] = via_unsafe_ptr;
-            out_ptr[4] = via_subscript;
+            out_ptr[1] = via_unsafe_ptr;
+            out_ptr[2] = via_subscript;
+            out_ptr[3] = legacy_base;
             const uint32_t words = entry_size / sizeof(uint32_t);
-            for (uint32_t w = 5; w < words; ++w) {
+            for (uint32_t w = 4; w < words; ++w) {
                 out_ptr[w] = 0;
             }
         }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/local_tensor_accessor_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/local_tensor_accessor_compute.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Test kernel: Metal 2.0 LocalTensorAccessor compile + token-wiring proof (compute side).
+//
+// Binds a tensor and constructs a LocalTensorAccessor<uint32_t> from the binding token on a compute
+// (TRISC) kernel — the path that previously could not compile, because the generated header pulled in
+// tensor_accessor.h, whose NOC helpers require NOC_INDEX (which compute kernel builds intentionally do
+// not define). LocalTensorAccessor carries no NOC machinery, so it compiles here.
+//
+// The accessor is constructed on all three TRISC threads (UNPACK/MATH/PACK) — the strongest compile
+// proof — and its full surface (get_bank_base_address / get_aligned_page_size / rank / get_unsafe_ptr /
+// operator[]) is exercised so every method is instantiated. The PACK thread deposits the reported
+// values into each output DFB entry; a DM consumer carries them to DRAM for host verification.
+//
+// The host checks that the reported base address equals the bound tensor's address — proving the
+// binding token reached the compute kernel and resolved to the correct local L1 shard address. The
+// get_unsafe_ptr / operator[] reports resolve to the same address (address-of avoids an actual load).
+
+#include <cstdint>
+
+#include "api/compute/common.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/tensor/local_tensor_accessor.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    // CTAs — compile-time constants.
+    constexpr uint32_t entry_size = get_arg(args::entry_size);
+    constexpr uint32_t num_tiles = get_arg(args::num_tiles);
+
+    // Construct on every TRISC thread (the binding's base-address CRTA is broadcast to all three).
+    LocalTensorAccessor<uint32_t> acc(tensor::local_t);
+
+    const uint32_t base_address = acc.get_bank_base_address();
+    const uint32_t page_size = acc.get_aligned_page_size();
+    const uint32_t rank = acc.rank();
+    // Instantiate the element-access surface too, so it is compile-proven on TRISC. Both resolve to the
+    // base address; address-of avoids an actual L1 load/store.
+    const uint32_t via_unsafe_ptr = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(acc.get_unsafe_ptr()));
+    const uint32_t via_subscript = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(&acc[0]));
+
+    DataflowBuffer dfb_out(dfb::out_dfb);
+
+    for (uint32_t t = 0; t < num_tiles; ++t) {
+        dfb_out.reserve_back(1);  // implementation gates this to PACK only
+
+        // PACK is the only TRISC that populates the L1 slot. On tt-1xx TRISCs, fifo_wr_ptr is a
+        // 16-byte unit address; shift left 4 to get a byte address (mirrors named_args_loopback_compute).
+#ifdef TRISC_PACK
+        {
+            volatile tt_l1_ptr uint32_t* out_ptr = (volatile tt_l1_ptr uint32_t*)(dfb_out.get_write_ptr() << 4);
+            out_ptr[0] = base_address;
+            out_ptr[1] = page_size;
+            out_ptr[2] = rank;
+            out_ptr[3] = via_unsafe_ptr;
+            out_ptr[4] = via_subscript;
+            const uint32_t words = entry_size / sizeof(uint32_t);
+            for (uint32_t w = 5; w < words; ++w) {
+                out_ptr[w] = 0;
+            }
+        }
+#endif
+
+        dfb_out.push_back(1);  // implementation gates this to PACK only
+    }
+}

--- a/tt_metal/hw/inc/api/tensor/local_tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/local_tensor_accessor.h
@@ -20,6 +20,7 @@
  * USAGE:
  *   // The kernel author declares the element type T of the local shard
  *   auto a = LocalTensorAccessor<T>(tensor::my_host_declared_accessor_name); // Metal 2.0 ctor
+ *   auto b = LocalTensorAccessor<T>(l1_base_address);                        // legacy ctor
  *   auto& lut = a[0];   // read or write
  *
  * NOTE:
@@ -27,27 +28,29 @@
  *
  * FEATURES:
  *   Constructors are provided for both Metal 2.0 and legacy kernels.
- *   Basic memory access via operator[].
- *   Basic getters for tensor info.
+ *   Read/write memory access via operator[] (and get_unsafe_ptr() / get_bank_base_address()).
+ *
+ *   This is a skeleton only; additional features will be added as needed.
  *
  * @tparam T  Element type stored in the local shard.
  */
 template <typename T>
 class LocalTensorAccessor {
 public:
-    // Construct from a Metal 2.0 binding token:
+    // Construct from a Metal 2.0 binding token. The binding's base address is the first word of its
+    // CRTA section.
     template <uint32_t CTA_OFFSET, uint32_t ADDR_CRTA_OFFSET>
     explicit LocalTensorAccessor(tensor_accessor::TensorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>) :
-        // Base address is stored in the first CRTA word
-        mem_(static_cast<uintptr_t>(get_common_arg_val<uint32_t>(ADDR_CRTA_OFFSET / sizeof(uint32_t)))),
-        // Runtime accessor fields (if any) follow the base-address slot
-        aligned_page_size_(
-            TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>{}.get_aligned_page_size()),
-        rank_(TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>{}.get_rank()) {
-        // ADDR_CRTA_OFFSET must be word_aligned
+        mem_(static_cast<uintptr_t>(get_common_arg_val<uint32_t>(ADDR_CRTA_OFFSET / sizeof(uint32_t)))) {
+        // ADDR_CRTA_OFFSET is a byte offset host codegen produces as crta_word_index * sizeof(u32), so
+        // it is word-aligned by construction; the /sizeof(u32) conversion would silently truncate otherwise.
         static_assert(
             ADDR_CRTA_OFFSET % sizeof(uint32_t) == 0, "TensorBindingToken: ADDR_CRTA_OFFSET must be 4-byte aligned");
     }
+
+    // Legacy constructor: from a raw node-local L1 base address. This is a byte address,
+    // typically the (legacy) Buffer's address passed into the kernel as a CRTA.
+    explicit LocalTensorAccessor(uint32_t bank_base_address) : mem_(static_cast<uintptr_t>(bank_base_address)) {}
 
     // Element access into the local shard (read and write), bounds-checked in debug builds.
     T& operator[](uint32_t index) const { return mem_[index]; }
@@ -58,18 +61,10 @@ public:
     // L1 base address of the local shard.
     uint32_t get_bank_base_address() const { return static_cast<uint32_t>(mem_.get_address()); }
 
-    // Page size in bytes.
-    uint32_t get_aligned_page_size() const { return aligned_page_size_; }
-
-    // Tensor rank.
-    uint32_t rank() const { return rank_; }
-
     // The underlying typed L1 view, for callers wanting the full CoreLocalMem<T> surface
     // (pointer arithmetic, scoped_lock, comparisons, ...).
     const CoreLocalMem<T>& local_mem() const { return mem_; }
 
 private:
     CoreLocalMem<T> mem_;
-    uint32_t aligned_page_size_;
-    uint32_t rank_;
 };

--- a/tt_metal/hw/inc/api/tensor/local_tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/local_tensor_accessor.h
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "api/core_local_mem.h"
+#include "api/tensor/tensor_accessor_args.h"
+#include "api/tensor/tensor_binding_token.h"
+#include "internal/risc_attribs.h"  // tt_l1_ptr (named in get_unsafe_ptr's return type)
+
+/**
+ * @brief A minimal accessor for a tensor's node-local L1 shard.
+ *
+ * LocalTensorAccessor is the local-only counterpart to TensorAccessor.
+ * Unlike TensorAccessor, it can be used on both data movement and compute kernels.
+ *
+ * USAGE:
+ *   // The kernel author declares the element type T of the local shard
+ *   auto a = LocalTensorAccessor<T>(tensor::my_host_declared_accessor_name); // Metal 2.0 ctor
+ *   auto& lut = a[0];   // read or write
+ *
+ * NOTE:
+ *   LocalTensorAccessor replaces the "pinned CB as L1 pointer" legacy pattern (get_pointer_to_cb_data<T>).
+ *
+ * FEATURES:
+ *   Constructors are provided for both Metal 2.0 and legacy kernels.
+ *   Basic memory access via operator[].
+ *   Basic getters for tensor info.
+ *
+ * @tparam T  Element type stored in the local shard.
+ */
+template <typename T>
+class LocalTensorAccessor {
+public:
+    // Construct from a Metal 2.0 binding token:
+    template <uint32_t CTA_OFFSET, uint32_t ADDR_CRTA_OFFSET>
+    explicit LocalTensorAccessor(tensor_accessor::TensorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>) :
+        // Base address is stored in the first CRTA word
+        mem_(static_cast<uintptr_t>(get_common_arg_val<uint32_t>(ADDR_CRTA_OFFSET / sizeof(uint32_t)))),
+        // Runtime accessor fields (if any) follow the base-address slot
+        aligned_page_size_(
+            TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>{}.get_aligned_page_size()),
+        rank_(TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>{}.get_rank()) {
+        // ADDR_CRTA_OFFSET must be word_aligned
+        static_assert(
+            ADDR_CRTA_OFFSET % sizeof(uint32_t) == 0, "TensorBindingToken: ADDR_CRTA_OFFSET must be 4-byte aligned");
+    }
+
+    // Element access into the local shard (read and write), bounds-checked in debug builds.
+    T& operator[](uint32_t index) const { return mem_[index]; }
+
+    // Raw, directly-dereferenceable L1 pointer to the start of the local shard.
+    tt_l1_ptr T* get_unsafe_ptr() const { return mem_.get_unsafe_ptr(); }
+
+    // L1 base address of the local shard.
+    uint32_t get_bank_base_address() const { return static_cast<uint32_t>(mem_.get_address()); }
+
+    // Page size in bytes.
+    uint32_t get_aligned_page_size() const { return aligned_page_size_; }
+
+    // Tensor rank.
+    uint32_t rank() const { return rank_; }
+
+    // The underlying typed L1 view, for callers wanting the full CoreLocalMem<T> surface
+    // (pointer arithmetic, scoped_lock, comparisons, ...).
+    const CoreLocalMem<T>& local_mem() const { return mem_; }
+
+private:
+    CoreLocalMem<T> mem_;
+    uint32_t aligned_page_size_;
+    uint32_t rank_;
+};

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor.h
@@ -6,6 +6,7 @@
 
 #include <type_traits>
 #include "api/tensor/tensor_accessor_args.h"
+#include "api/tensor/tensor_binding_token.h"
 #include "internal/tensor/array_wrapper.h"
 #include "internal/tensor/dspec.h"
 #include "internal/tensor/helpers.h"
@@ -25,9 +26,6 @@ template <typename T>
 T get_arg_val(int arg_idx);
 
 namespace tensor_accessor {
-
-template <uint32_t CTA_OFFSET, uint32_t ADDR_CRTA_OFFSET>
-struct TensorAccessorBindingToken;  // definition below
 
 // This helper gets proper additional offset from interleaved_addr_gen::get_bank_offset +
 //      Adds proper xy coordinates for NOC address
@@ -96,7 +94,7 @@ public:
     // opts into a dynamic field like dynamic_tensor_shape) start at the word immediately
     // following the address slot, so the TAA's CRTA_OFFSET is ADDR_CRTA_OFFSET/sizeof(u32)+1.
     template <uint32_t CTA_OFFSET, uint32_t ADDR_CRTA_OFFSET>
-    TensorAccessor(tensor_accessor::TensorAccessorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>) :
+    TensorAccessor(tensor_accessor::TensorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>) :
         TensorAccessor(
             TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>{},
             static_cast<size_t>(get_common_arg_val<uint32_t>(ADDR_CRTA_OFFSET / sizeof(uint32_t)))) {
@@ -105,8 +103,7 @@ public:
         // construction. The conversions to a CRTA word index (`/sizeof(uint32_t)`) silently
         // truncate otherwise — catch any future codegen change that violates the invariant.
         static_assert(
-            ADDR_CRTA_OFFSET % sizeof(uint32_t) == 0,
-            "TensorAccessorBindingToken: ADDR_CRTA_OFFSET must be 4-byte aligned");
+            ADDR_CRTA_OFFSET % sizeof(uint32_t) == 0, "TensorBindingToken: ADDR_CRTA_OFFSET must be 4-byte aligned");
     }
 
     constexpr const auto& dspec() const {
@@ -386,7 +383,7 @@ struct TensorAccessor<tensor_accessor::DistributionSpec<
     // Construct TensorAccessor directly from a Metal 2.0 binding token.
     // (See the sharded specialization for the binding's CRTA section layout and the alignment rationale.)
     template <uint32_t CTA_OFFSET, uint32_t ADDR_CRTA_OFFSET>
-    TensorAccessor(tensor_accessor::TensorAccessorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>) :
+    TensorAccessor(tensor_accessor::TensorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>) :
         TensorAccessor(
             // TensorAccessorArgs: Create the args object from the token's CTA offset and CRTA offset.
             //   (But, add 1 to the token's CRTA offset to jump over the base address slot)
@@ -394,8 +391,7 @@ struct TensorAccessor<tensor_accessor::DistributionSpec<
             // Bank base address: Get the base address from the front of the token's CRTA section.
             static_cast<uint32_t>(get_common_arg_val<uint32_t>(ADDR_CRTA_OFFSET / sizeof(uint32_t)))) {
         static_assert(
-            ADDR_CRTA_OFFSET % sizeof(uint32_t) == 0,
-            "TensorAccessorBindingToken: ADDR_CRTA_OFFSET must be 4-byte aligned");
+            ADDR_CRTA_OFFSET % sizeof(uint32_t) == 0, "TensorBindingToken: ADDR_CRTA_OFFSET must be 4-byte aligned");
     }
 
     template <typename DSpec_ = DSpec, std::enable_if_t<std::is_same_v<std::decay_t<DSpec_>, DSpec>, int> = 0>
@@ -515,7 +511,7 @@ TensorAccessor(const TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>& args, size_t)
 // binding's base-address slot; any runtime accessor fields start at the next word,
 // so the TAA's CRTA_OFFSET is ADDR_CRTA_OFFSET/sizeof(u32)+1.
 template <uint32_t CTA_OFFSET, uint32_t ADDR_CRTA_OFFSET>
-TensorAccessor(tensor_accessor::TensorAccessorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>)
+TensorAccessor(tensor_accessor::TensorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>)
     -> TensorAccessor<tensor_accessor::DistributionSpec<
         /* RankCT */ TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>::RankCT,
         /* NumBanksCT */ TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>::NumBanksCT,
@@ -602,48 +598,6 @@ auto make_tensor_accessor_tuple(const std::tuple<Args...>& args, uint32_t addres
     return tensor_accessor::detail::make_tensor_accessor_tuple(
         args, address_rt_arg_index_start, std::make_integer_sequence<uint32_t, sizeof...(Args)>());
 }
-
-// Convention:
-//  - main TensorAccessor public API is in the global namespace
-//  - public API opaque types live in tensor_accessor namespace
-namespace tensor_accessor {
-
-// TensorAccessorBindingToken:
-//
-// == What is it? ==
-// This is a codegen-emitted handle for a Metal 2.0 kernel's tensor binding.
-// The user never interacts with this type directly; they use an opaque token (defined in the
-// auto-generated kernel_bindings_generated.h) to construct the TensorAccessor directly.
-//
-// The user's kernel code looks like:
-//  auto ta = TensorAccessor(tensor::my_host_declared_accessor_name);
-//
-// No more fussing around with TensorAccessorArgs!
-// All of the boilerplate, nasty args offset logic, and raw base pointer are now fully hidden
-// from the kernel author.
-//
-// == How does it work? ==
-// For each kernel tensor binding, headergen emits the following into kernel_bindings_generated.h:
-//   - A type alias:  using my_TA_name_t = TensorAccessorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>;
-//   - A token value: constexpr my_TA_name_t my_TA_name{};
-//
-// This indirection gives us ultimate future-proofing flexibility over what actually goes into the
-// TensorAccessorBindingToken. We can change TensorAccessorBindingToken at any time, or add a
-// wrapper-type indirection, all without disturbing any existing Metal 2.0 kernel code.
-// (Probably overkill, but cheap insurance.)
-//
-// == Current limitations ==
-// The Metal 2.0 binding flow currently packs all DSpec metadata (shape, shard shape, bank coords)
-// as (static) CTAs; the (dynamic) CRTA-based metadata is a planned follow-up.
-//
-template <uint32_t CTA_OFFSET, uint32_t ADDR_CRTA_OFFSET>
-struct TensorAccessorBindingToken {
-    using args_t = TensorAccessorArgs<CTA_OFFSET>;
-    static constexpr args_t args{};
-    static constexpr uint32_t addr_crta_offset = ADDR_CRTA_OFFSET;  // in bytes
-};
-
-}  // namespace tensor_accessor
 
 /**
  * @brief AbstractTensorAccessorWrapper provides a unified interface over templated tensor accessors.

--- a/tt_metal/hw/inc/api/tensor/tensor_binding_token.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_binding_token.h
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "api/tensor/tensor_accessor_args.h"
+
+namespace tensor_accessor {
+
+// TensorBindingToken:
+//
+// == What is it? ==
+// This is a codegen-emitted handle for a Metal 2.0 kernel's tensor binding.
+// The user never interacts with this type directly; they use an opaque token (defined in the
+// auto-generated kernel_bindings_generated.h) to construct an accessor from it.
+// (Either a TensorAccessor or a LocalTensorAccessor, depending on the kernel's needs.)
+//
+// The user's kernel code looks like:
+//  auto a = TensorAccessor(tensor::my_host_declared_accessor_name);         // DM kernels only
+//  auto b = LocalTensorAccessor<T>(tensor::my_host_declared_accessor_name); // DM or compute kernels
+//
+// No more fussing around with TensorAccessorArgs!
+// All of the boilerplate, nasty args offset logic, and raw base pointer are now fully hidden
+// from the kernel author.
+//
+// == How does it work? ==
+// For each kernel tensor binding, headergen emits the following into kernel_bindings_generated.h:
+//   - A type alias:  using my_TA_name_t = TensorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>;
+//   - A token value: constexpr my_TA_name_t my_TA_name{};
+//
+// This indirection gives us ultimate future-proofing flexibility over what actually goes into the
+// TensorBindingToken. We can change TensorBindingToken at any time, or add a wrapper-type indirection,
+// all without disturbing any existing Metal 2.0 kernel code. (Probably overkill, but cheap insurance.)
+//
+// == Current limitations ==
+// The Metal 2.0 binding flow currently supports only a subset of the CRTA-dynamic DSpec metadata that
+// TensorAccessorArgs nominally supports.
+//
+template <uint32_t CTA_OFFSET, uint32_t ADDR_CRTA_OFFSET>
+struct TensorBindingToken {
+    using args_t = TensorAccessorArgs<CTA_OFFSET>;
+    static constexpr args_t args{};
+    static constexpr uint32_t addr_crta_offset = ADDR_CRTA_OFFSET;  // in bytes
+};
+
+}  // namespace tensor_accessor

--- a/tt_metal/hw/sources.cmake
+++ b/tt_metal/hw/sources.cmake
@@ -23,6 +23,8 @@ set(HW_JIT_API_HEADERS
     inc/api/kernel_thread_globals.h
     inc/api/tensor/tensor_accessor.h
     inc/api/tensor/tensor_accessor_args.h
+    inc/api/tensor/tensor_binding_token.h
+    inc/api/tensor/local_tensor_accessor.h
     inc/api/tensor/shard_pages_address_iterator.h
     inc/api/tensor/pages_address_iterator.h
     inc/api/tensor/page.h

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -759,8 +759,8 @@ static void emit_metal2_namespaces(
     if (!s.ta_accessors.empty()) {
         f << "namespace tensor {\n";
         for (const auto& ta : s.ta_accessors) {
-            f << "using " << ta.name << "_t = ::tensor_accessor::TensorAccessorBindingToken<"
-              << ta.cta_offset << "u, " << ta.addr_crta_offset << "u>;\n";
+            f << "using " << ta.name << "_t = ::tensor_accessor::TensorBindingToken<" << ta.cta_offset << "u, "
+              << ta.addr_crta_offset << "u>;\n";
             f << "constexpr " << ta.name << "_t " << ta.name << "{};\n";
         }
         f << "}  // namespace tensor\n";

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -718,7 +718,7 @@ static void emit_metal2_namespaces(
         f << "#include <cstdint>\n";
     }
     if (!s.ta_accessors.empty()) {
-        f << "#include \"api/tensor/tensor_accessor.h\"\n";
+        f << "#include \"api/tensor/tensor_binding_token.h\"\n";
     }
 
     if (has_args) {

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -464,19 +464,9 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
 
     // Validate kernel tensor bindings
     for (const auto& kernel : spec.kernels) {
-        // TEMPORARY: tensor bindings on compute kernels are not yet supported end-to-end. A
-        // TensorAccessor cannot currently be constructed in a compute kernel, so a spec that binds a
-        // tensor to a compute kernel looks valid here but fails once it reaches the kernel. Reject it
-        // up front with an honest message until the compute-path support lands (expected within a day
-        // or two of 2026-06-16). Remove this guard when that ships.
-        TT_FATAL(
-            !kernel.is_compute_kernel() || kernel.tensor_bindings.empty(),
-            "Kernel '{}' is a compute kernel with a tensor binding ('{}'). Tensor bindings on compute "
-            "kernels are not yet supported — a TensorAccessor cannot currently be constructed in a "
-            "compute kernel, so this spec would compile but fail in the kernel. This is a temporary "
-            "restriction that will be lifted soon.",
-            kernel.unique_id,
-            kernel.tensor_bindings.empty() ? std::string{} : kernel.tensor_bindings.front().accessor_name);
+        // A tensor binding is legal on both DM and compute kernels:
+        //   - a DM kernel can use the binding token to construct a TensorAccessor or LocalTensorAccessor
+        //   - a compute kernel can only use LocalTensorAccessor (NOC-free, local-L1 only)
 
         std::unordered_set<std::string> accessor_names;
         for (const auto& binding : kernel.tensor_bindings) {

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -151,7 +151,9 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
             content << "#include <cstdint>\n";
         }
         if (!ta_entries.empty()) {
-            content << "#include \"api/tensor/tensor_accessor.h\"\n";
+            // This header defines TensorBindingToken, a type which can be used
+            // to construct a TensorAccessor or LocalTensorAccessor.
+            content << "#include \"api/tensor/tensor_binding_token.h\"\n";
         }
         content << "\n";
 
@@ -172,17 +174,17 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
         }
 
         if (!ta_entries.empty()) {
-            // TensorAccessorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>: pairs the binding's
+            // TensorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>: pairs the binding's
             // static layout metadata (TensorAccessorArgs<CTA_OFFSET>) with the byte offset of
-            // its implicit base-address CRTA. The kernel-side TensorAccessor(token) constructor
-            // unpacks both pieces.
+            // its implicit base-address CRTA.
+            // The kernel-side TensorAccessor (or LocalTensorAccessor) constructor unpacks both pieces.
             //
             // Per-binding type alias (`<name>_t`) lets the framework extend the underlying token
             // template with extra metadata in the future without touching kernel source.
             content << "namespace tensor {\n";
             for (const auto& entry : ta_entries) {
-                content << "using " << entry.name << "_t = ::tensor_accessor::TensorAccessorBindingToken<"
-                        << entry.cta_offset << "u, " << entry.addr_crta_offset << "u>;\n";
+                content << "using " << entry.name << "_t = ::tensor_accessor::TensorBindingToken<" << entry.cta_offset
+                        << "u, " << entry.addr_crta_offset << "u>;\n";
                 content << "constexpr " << entry.name << "_t " << entry.name << "{};\n";
             }
             content << "}  // namespace tensor\n";


### PR DESCRIPTION
## PR Category
Feature

## Summary

`LocalTensorAccessor` is a simple NOC-free device-side accessor that gives kernels read/write access to a tensor's node-local L1 shard. It can be used by either Metal 2.0 or legacy kernels.

This is intended to replace a problematic legacy pattern where a kernel uses a CB build on borrowed memory purely as an L1 address shim (no FIFO semantics) — the "pinned CB as pointer" pattern. This legacy pattern will not be permissible in Metal 2.0 and Quasar, where DFBs consume scarce hardware resources and should only be used for legitimate cross-kernel synchronization.

### Legacy

The `LocalTensorAccessor` is trivial to use in a legacy kernel. It's just constructed from the L1's base address, which is passed into the kernel as a CRTA (exactly as a legacy `TensorAccessor` would use).
```cpp
LocalTensorAccessor<uint32_t> acc(my_base_ptr);  // wrap the local L1 base address
acc[0] = acc[1] + 1;                             // read/write — no CB needed
```

### Metal 2.0

Metal 2.0 introduces the semantics of resource bindings for kernels. Program-scope resources and parameters are declared at the `ProgramSpec` level. Kernels declare bindings to those resources they need to access. On the device side, they construct the resource object using the host-supplied token.

```cpp
// Device code stub
// Build the accessor from the binding token. T is the element type (kernel's choice).
LocalTensorAccessor<uint32_t> acc(tensor::my_name);
acc[0] = acc[1] + 1;  // read/write
}
```

```cpp
// Host code stub

auto tp = TensorParameter{.unique_id = TensorParamName{"my_param"}, .spec = my_l1_sharded_spec};
auto tb = TensorBinding{.tensor_parameter_name = "my_param", .accessor_name = "my_name"};

ProgramSpec spec{
    .name = "my_program",
    .kernels = {
        KernelSpec{
            ...
            .tensor_bindings = {tb},
        },
    },
    ...
    .tensor_parameters = {tp},
    ...
};
```

### Changes

- **local_tensor_accessor.h**: Add `LocalTensorAccessor` header, with initial basic functionality only. It's built on top of Device 2.0 `CoreLocalMem<T>`, so it inherits typed pointer access + debug L1 sanitization.
- **tensor_binding_token.h** + **tensor_accessor.h:** Rename `TensorAccessorBindingToken` to `TensorBindingToken`, and move it out of `tensor_accessor.h` and into its own header for Metal 2.0.
- **genfiles.cpp**: Add the new `tensor_binding_token.h` to the autogenerated kernel bindings header.
- **program_spec.cpp**: Remove the legality check preventing compute kernels from binding tensors. Compute kernels can't use `TensorAccessor`, but the can use `LocalTensorAccessor`.


## Notes for reviewers
This initial checkin is skeletal; the intent is to match the legacy CB shim functional first, and add features later. Near the top of my list would be a `get_shard_volume` method to return the size of the local L1 shard.

It'll be relatively easy to add this on the Metal 2.0 side, but we won't be able to match it on legacy.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/local-tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/local-tensor-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/local-tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/local-tensor-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/local-tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/local-tensor-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/local-tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/local-tensor-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/local-tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/local-tensor-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/local-tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/local-tensor-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/local-tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/local-tensor-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/local-tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/local-tensor-accessor)