### PR TITLE
#47797: sampling SamplingProgramFactory → Metal 2.0 (cross-kernel DFB bridge)

### DIFF
--- a/ttnn/cpp/ttnn/kernel/dataflow/generate_bcast_scalar.hpp
+++ b/ttnn/cpp/ttnn/kernel/dataflow/generate_bcast_scalar.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/circular_buffer.h"
 
 // W-bcast scalar
 // Tile is assumed to have 16-bit elements
@@ -41,9 +42,9 @@ FORCE_INLINE void generate_bcast_row_scalar(const uint32_t cb_id, const uint32_t
 // Tile is assumed to have 16-bit elements
 // Scalar is assumed to be a 16-bit value double packed into a u32
 FORCE_INLINE void generate_bcast_unary_scalar(const uint32_t cb_id, const uint32_t scalar) {
-    const uint32_t scalar_val = scalar >> 16;
-    cb_reserve_back(cb_id, 1);
-    volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
+    CircularBuffer cb(cb_id);
+    cb.reserve_back(1);
+    volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb.get_write_ptr());
     ptr[0] = scalar >> 16;
-    cb_push_back(cb_id, 1);
+    cb.push_back(1);
 }

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/compute/sampling.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/compute/sampling.cpp
@@ -18,7 +18,8 @@
 #include "api/compute/pack.h"
 #include "ckernel_sfpu.h"
 #include "api/compute/tilize.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "experimental/kernel_args.h"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 
 #define DEBUG_PRINT 0
@@ -27,7 +28,7 @@ using namespace ckernel;
 void generate_rand_tile(const uint32_t cb_id, const uint32_t seed) {
     init_sfpu(cb_id, cb_id);
 
-    CircularBuffer cb_obj(cb_id);
+    DataflowBuffer cb_obj(cb_id);
 
     uint32_t rand_scale = 0;
     const float one_f = 1.0f;
@@ -56,8 +57,8 @@ void sub_exp_block_bcast_cols_inplace() {
     // Postcondition: in0_cb has rows*cols produced
     // Postcondition: in1_cb has rows produced
 
-    CircularBuffer in0_cb_obj(in0_cb);
-    CircularBuffer in1_cb_obj(in1_cb);
+    DataflowBuffer in0_cb_obj(in0_cb);
+    DataflowBuffer in1_cb_obj(in1_cb);
 
     sub_bcast_cols_init_short(in0_cb, in1_cb);
     exp_tile_init<true>();
@@ -93,8 +94,8 @@ void add_block_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num_tiles) {
     // Precondition: in0_cb and in1_cb have num_tiles produced
     // Postcondition: in0_cb has num_tiles produced
     // Postcondition: in1_cb has num_tiles produced
-    CircularBuffer in0_cb_obj(in0_cb);
-    CircularBuffer in1_cb_obj(in1_cb);
+    DataflowBuffer in0_cb_obj(in0_cb);
+    DataflowBuffer in1_cb_obj(in1_cb);
 
     reconfig_data_format(in0_cb, in1_cb);
     add_tiles_init(in0_cb, in1_cb);
@@ -123,9 +124,9 @@ void mul_block_bcast_cols(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uin
     // Postcondition: in0_cb has rows*cols produced
     // Postcondition: in1_cb has rows consumed
 
-    CircularBuffer in0_cb_obj(in0_cb);
-    CircularBuffer in1_cb_obj(in1_cb);
-    CircularBuffer out_cb_obj(out_cb);
+    DataflowBuffer in0_cb_obj(in0_cb);
+    DataflowBuffer in1_cb_obj(in1_cb);
+    DataflowBuffer out_cb_obj(out_cb);
 
     uint32_t num_tiles = rows * cols;
     mul_bcast_cols_init_short(in0_cb, in1_cb);
@@ -153,7 +154,7 @@ void mul_block_bcast_cols(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uin
 void recip_block_inplace(uint32_t in_cb, uint32_t num_tiles) {
     // Precondition: in_cb has num_tiles produced
     // Postcondition: in_cb has num_tiles produced
-    CircularBuffer in_cb_obj(in_cb);
+    DataflowBuffer in_cb_obj(in_cb);
 
     copy_tile_to_dst_init_short(in_cb);
     recip_tile_init();
@@ -222,12 +223,12 @@ void top_k() {
     constexpr uint32_t index_dest_end = 3;
     ckernel::topk_tile_init();
 
-    CircularBuffer input_cb(input_cb_index);
-    CircularBuffer index_cb(index_cb_index);
-    CircularBuffer input_transposed_cb(input_transposed_cb_index);
-    CircularBuffer index_transposed_cb(index_transposed_cb_index);
-    CircularBuffer values_cb(values_cb_index);
-    CircularBuffer output_ind_cb(output_ind_cb_index);
+    DataflowBuffer input_cb(input_cb_index);
+    DataflowBuffer index_cb(index_cb_index);
+    DataflowBuffer input_transposed_cb(input_transposed_cb_index);
+    DataflowBuffer index_transposed_cb(index_transposed_cb_index);
+    DataflowBuffer values_cb(values_cb_index);
+    DataflowBuffer output_ind_cb(output_ind_cb_index);
 
     if (first_call) {
         transpose_wh_init(input_cb_index, input_transposed_cb_index);
@@ -382,8 +383,8 @@ void mul_block_bcast_scalar_inplace() {
     // Postcondition: in0_cb has num_tiles produced
     // Postcondition: in1_scalar_cb has 1 produced
 
-    CircularBuffer in0_cb_obj(in0_cb);
-    CircularBuffer in1_scalar_cb_obj(in1_scalar_cb);
+    DataflowBuffer in0_cb_obj(in0_cb);
+    DataflowBuffer in1_scalar_cb_obj(in1_scalar_cb);
 
     uint32_t dst_tiles = num_tiles;
     uint32_t granularity = 1;
@@ -414,26 +415,26 @@ void mul_block_bcast_scalar_inplace() {
 }
 
 void kernel_main() {
-    constexpr uint32_t input_values_cb_index = get_compile_time_arg_val(0);
-    constexpr uint32_t index_cb_index = get_compile_time_arg_val(1);
-    constexpr uint32_t input_transposed_cb_index = get_compile_time_arg_val(2);
-    constexpr uint32_t index_transposed_cb_index = get_compile_time_arg_val(3);
-    constexpr uint32_t values_cb_index = get_compile_time_arg_val(4);
-    constexpr uint32_t output_ind_cb_index = get_compile_time_arg_val(5);
+    constexpr uint32_t input_values_cb_index = dfb::input_values;
+    constexpr uint32_t index_cb_index = dfb::index;
+    constexpr uint32_t input_transposed_cb_index = dfb::input_transposed;
+    constexpr uint32_t index_transposed_cb_index = dfb::index_transposed;
+    constexpr uint32_t values_cb_index = dfb::values;
+    constexpr uint32_t output_ind_cb_index = dfb::output_ind;
 
-    constexpr uint32_t topk_mask_cb_index = get_compile_time_arg_val(6);
-    constexpr uint32_t scaler_max_cb_index = get_compile_time_arg_val(7);
-    constexpr uint32_t scaler_sum_cb_index = get_compile_time_arg_val(8);
-    constexpr uint32_t cb_cur_max = get_compile_time_arg_val(9);
-    constexpr uint32_t cb_cur_sum = get_compile_time_arg_val(10);
-    constexpr uint32_t Ht = get_compile_time_arg_val(11);
-    constexpr uint32_t Wt = get_compile_time_arg_val(12);
-    constexpr uint32_t logWt = get_compile_time_arg_val(13);
-    constexpr uint32_t rand_tile_index = get_compile_time_arg_val(14);
-    constexpr uint32_t seed = get_compile_time_arg_val(15);
-    constexpr uint32_t cb_local_vals = get_compile_time_arg_val(16);
-    constexpr uint32_t temp_cb_index = get_compile_time_arg_val(17);
-    constexpr uint32_t tile_width = get_compile_time_arg_val(18);
+    constexpr uint32_t topk_mask_cb_index = dfb::topk_mask;
+    constexpr uint32_t scaler_max_cb_index = dfb::scaler_max;
+    constexpr uint32_t scaler_sum_cb_index = dfb::scaler_sum;
+    constexpr uint32_t cb_cur_max = dfb::cur_max;
+    constexpr uint32_t cb_cur_sum = dfb::cur_sum;
+    constexpr uint32_t Ht = get_arg(args::Ht);
+    constexpr uint32_t Wt = get_arg(args::Wt);
+    constexpr uint32_t logWt = get_arg(args::logWt);
+    constexpr uint32_t rand_tile_index = dfb::rand;
+    constexpr uint32_t seed = get_arg(args::seed);
+    constexpr uint32_t cb_local_vals = dfb::local_vals;
+    constexpr uint32_t temp_cb_index = dfb::temp;
+    constexpr uint32_t tile_width = get_arg(args::tile_width);
     generate_rand_tile(rand_tile_index, seed);
 
     const uint32_t nearest32_K = 32;
@@ -459,7 +460,7 @@ void kernel_main() {
     // scale temperature
 
     // mask out all values except the top-k
-    CircularBuffer topk_mask_cb(topk_mask_cb_index);
+    DataflowBuffer topk_mask_cb(topk_mask_cb_index);
     topk_mask_cb.wait_front(Kt);
     add_block_inplace(values_cb_index, topk_mask_cb_index, Ht * Kt);
     mul_block_bcast_scalar_inplace<values_cb_index, temp_cb_index, Ht * Kt>();
@@ -470,4 +471,12 @@ void kernel_main() {
     reduce_c<PoolType::SUM, ReduceDim::REDUCE_ROW, values_cb_index, scaler_sum_cb_index, cb_cur_sum, Ht, Kt>();
     recip_block_inplace(cb_cur_sum, Ht);
     mul_block_bcast_cols(values_cb_index, cb_cur_sum, cb_local_vals, Ht, Kt);
+
+    // Cross-kernel DFB bridge: the writer-assembled output CB (c_13) is produced by the (DM) writer
+    // and has no real consumer. A DM kernel cannot self-loop a DFB, so bind a terminal no-op
+    // CONSUMER here on the compute kernel to satisfy the Metal 2.0 SPSC (1 producer + 1 consumer)
+    // requirement. We never read the data — this only drains the FIFO slot the writer publishes.
+    DataflowBuffer output_cb(dfb::output);
+    output_cb.wait_front(1);
+    output_cb.pop_front(1);
 }

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/reader_values_indices_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/reader_values_indices_tensor.cpp
@@ -5,9 +5,10 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 /**
  * add a cb full of indices for the tile
  * each row is identical in the index tensor, so we just need to add an offset based on which row tile it is
@@ -20,7 +21,7 @@
 template <bool USE_32BIT>
 FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt) {
     // TODO: investigate moving to compile time (binary size is at risk)
-    CircularBuffer cb(cb_id);
+    DataflowBuffer cb(cb_id);
     cb.reserve_back(1);
     CoreLocalMem<volatile uint32_t> ptr(cb.get_write_ptr());
     uint32_t wt_offset = wt << 5;
@@ -49,39 +50,32 @@ FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt) {
 }
 
 void kernel_main() {
-    uint32_t values_addr = get_arg_val<uint32_t>(0);
-    uint32_t indices_addr = get_arg_val<uint32_t>(1);
-
-    constexpr uint32_t input_values_cb_index = get_compile_time_arg_val(0);
-    constexpr uint32_t input_indices_cb_index = get_compile_time_arg_val(1);
-    constexpr uint32_t cb_intermed_index = get_compile_time_arg_val(2);
-
-    constexpr uint32_t Ht = get_compile_time_arg_val(3);
-    constexpr uint32_t Wt = get_compile_time_arg_val(4);
-    constexpr uint32_t input_indices_page_size = get_compile_time_arg_val(5);
-    constexpr uint32_t tile_height = get_compile_time_arg_val(6);
-    constexpr bool use_32bit_index = get_compile_time_arg_val(7) == 1;
+    constexpr uint32_t Ht = get_arg(args::Ht);
+    constexpr uint32_t Wt = get_arg(args::Wt);
+    constexpr uint32_t input_indices_page_size = get_arg(args::final_indices_page_size);
+    constexpr bool use_32bit_index = get_arg(args::use_32bit_index) == 1;
     // Number of logical users (== number of running cores). Only this many input-index rows exist
     // and are streamed in, even though the values tile is padded to a full tile_height.
-    constexpr uint32_t num_users = get_compile_time_arg_val(8);
+    constexpr uint32_t num_users = get_arg(args::num_users);
+    constexpr uint32_t k_chunk_size = get_arg(args::k_chunk_size);
+    constexpr uint32_t p_chunk_size = get_arg(args::p_chunk_size);
 
-    constexpr auto s0_args = TensorAccessorArgs<9>();
-    constexpr auto s1_args = TensorAccessorArgs<s0_args.next_compile_time_args_offset()>();
+    constexpr auto input_values_cb_index = dfb::input_values;
+    constexpr auto cb_intermed_index = dfb::index;
+    constexpr auto input_indices_cb_index = dfb::final_indices;
 
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
 
-    const auto s0 = TensorAccessor(s0_args, values_addr);
-
-    const auto s1 = TensorAccessor(s1_args, indices_addr);
+    const auto s0 = TensorAccessor(tensor::input_values);
+    const auto s1 = TensorAccessor(tensor::input_indices);
 
     Noc noc;
-    CircularBuffer input_values_cb(input_values_cb_index);
-    CircularBuffer input_indices_cb(input_indices_cb_index);
+    DataflowBuffer input_values_cb(input_values_cb_index);
+    DataflowBuffer input_indices_cb(input_indices_cb_index);
     const uint32_t tile_bytes_input_values = input_values_cb.get_tile_size();
 
     uint32_t tile_id_input_values = 0;
-    uint32_t tile_id_input_indices = 0;
     for (uint32_t i = 0; i < Ht; ++i) {
         // input values TILE
         for (uint32_t j = 0; j < Wt; ++j) {
@@ -95,12 +89,28 @@ void kernel_main() {
         }
     }
 
-    // input indices RM — push one stick per running core/user. Previously hard-coded to
-    // Ht * tile_height (== 32); now `num_users` so fewer-than-32-user configs don't over-read.
+    // input indices RM — push one stick per running core/user.
     for (uint32_t j = 0; j < num_users; ++j) {
         input_indices_cb.reserve_back(onetile);
         noc.async_read(s1, input_indices_cb, input_indices_page_size, {.page_id = j}, {.offset_bytes = 0});
         noc.async_read_barrier();
         input_indices_cb.push_back(onetile);
     }
+
+    // Relocated from the writer (cross-kernel DFB bridge): read the full k / p chunks once so the
+    // writer's k/p CBs (c_14/c_15) have a legal reader-PRODUCER -> writer-CONSUMER pairing. The
+    // writer indexes its own core_id value out of the chunk.
+    const auto s_k = TensorAccessor(tensor::k);
+    DataflowBuffer cb_k(dfb::k);
+    cb_k.reserve_back(1);
+    noc.async_read(s_k, cb_k, k_chunk_size, {.page_id = 0}, {.offset_bytes = 0});
+    noc.async_read_barrier();
+    cb_k.push_back(1);
+
+    const auto s_p = TensorAccessor(tensor::p);
+    DataflowBuffer cb_p(dfb::p);
+    cb_p.reserve_back(1);
+    noc.async_read(s_p, cb_p, p_chunk_size, {.page_id = 0}, {.offset_bytes = 0});
+    noc.async_read_barrier();
+    cb_p.push_back(1);
 }

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/writer_interleaved.cpp
@@ -7,27 +7,21 @@
 #include <type_traits>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 #include "ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
 /* This kernel does:
-Top-p Cumulative Probability Filtering:
-Iteratively accumulates probabilities, comparing them against the nucleus threshold p to determine the smallest set of
-tokens satisfying cumulative probability > p condition.
-
-Top-k Sampling:
-Samples from the top-k subset by comparing cumulative sums of probabilities with a random threshold to select the
-appropriate index.
-*/
+Top-p Cumulative Probability Filtering + Top-k Sampling. */
 
 constexpr uint32_t FACE_WIDTH = 16;
 constexpr uint32_t FACE_HEIGHT = 16;
 
 // Widen bf16 to float32 — exact since bf16 is a subset of float32.
-// Uses soft-float on the data-movement RISC-V core.
 FORCE_INLINE float bf16_to_f32(uint16_t bf16) {
     uint32_t bits = (uint32_t)bf16 << 16;
     float result;
@@ -36,98 +30,73 @@ FORCE_INLINE float bf16_to_f32(uint16_t bf16) {
 }
 
 void kernel_main() {
-    uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    uint32_t temp_addr = get_arg_val<uint32_t>(1);
-    uint32_t k_addr = get_arg_val<uint32_t>(2);
-    uint32_t p_addr = get_arg_val<uint32_t>(3);
+    const uint32_t core_id = get_arg(args::core_id);
 
-    uint32_t arg_id = 0;
-    constexpr auto dst_args = TensorAccessorArgs<0>();
-    constexpr auto temp_args = TensorAccessorArgs<dst_args.next_compile_time_args_offset()>();
-    constexpr auto k_args = TensorAccessorArgs<temp_args.next_compile_time_args_offset()>();
-    constexpr auto p_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
+    constexpr uint32_t final_indices_stick_size = get_arg(args::final_indices_stick_size);
+    constexpr uint32_t ids_per_batch = get_arg(args::ids_per_batch);
+    constexpr uint32_t num_cores = get_arg(args::num_cores);
+    // Local sort-index width: 32-bit (Int32) on Quasar, 16-bit (UInt16) on WH/BH.
+    constexpr bool use_32bit_index = get_arg(args::use_32bit_index) == 1;
+    constexpr uint32_t num_users = get_arg(args::num_users);
 
-    constexpr uint32_t args_base = p_args.next_compile_time_args_offset();
-    constexpr uint32_t cb_id_out = get_compile_time_arg_val(args_base + 0);
-    constexpr uint32_t cb_id_mask = get_compile_time_arg_val(args_base + 1);
-    constexpr uint32_t scaler_max_cb_id = get_compile_time_arg_val(args_base + 2);
-    constexpr uint32_t scaler_sum_cb_id = get_compile_time_arg_val(args_base + 3);
-    constexpr uint32_t output_final_indices_rm_cb_index = get_compile_time_arg_val(args_base + 4);
-    constexpr uint32_t output_local_values_cb_index = get_compile_time_arg_val(args_base + 5);
-    constexpr uint32_t output_local_indices_cb_index = get_compile_time_arg_val(args_base + 6);
-    constexpr uint32_t final_indices_stick_size = get_compile_time_arg_val(args_base + 7);
-    // args_base + 8: out_stick_size (passed from factory, unused in kernel)
-    constexpr uint32_t rand_tile_index = get_compile_time_arg_val(args_base + 9);
-    constexpr uint32_t cb_id_k = get_compile_time_arg_val(args_base + 10);
-    constexpr uint32_t cb_id_p = get_compile_time_arg_val(args_base + 11);
-    constexpr uint32_t cb_id_temp = get_compile_time_arg_val(args_base + 12);
-    constexpr uint32_t core_id = get_compile_time_arg_val(args_base + 13);
-    constexpr uint32_t ids_per_batch = get_compile_time_arg_val(args_base + 14);
-    constexpr uint32_t num_cores = get_compile_time_arg_val(args_base + 15);
-    // Local sort-index width must match the index CB format / fp32_dest_acc_en chosen by the host:
-    // 32-bit (Int32) on Quasar, 16-bit (UInt16) on WH/BH.
-    constexpr bool use_32bit_index = get_compile_time_arg_val(args_base + 16) == 1;
-    // Number of running cores / users. The final-indices CB holds one stick per user (no longer
-    // hard-coded to 32), so this kernel waits/pops exactly `num_users` sticks.
-    constexpr uint32_t num_users = get_compile_time_arg_val(args_base + 17);
-    constexpr uint32_t k_chunk_size = num_cores * sizeof(uint32_t);     // 4 bytes per uint32_t
-    constexpr uint32_t p_chunk_size = num_cores * sizeof(uint16_t);     // 2 bytes per uint16_t
+    constexpr uint32_t cb_id_out = dfb::output;
+    constexpr uint32_t cb_id_mask = dfb::topk_mask;
+    constexpr uint32_t scaler_max_cb_id = dfb::scaler_max;
+    constexpr uint32_t scaler_sum_cb_id = dfb::scaler_sum;
+    constexpr uint32_t cb_id_temp = dfb::temp;
+
+    constexpr auto output_final_indices_rm_cb_index = dfb::final_indices;
+    constexpr auto output_local_values_cb_index = dfb::local_vals;
+    constexpr auto output_local_indices_cb_index = dfb::output_ind;
+    constexpr auto rand_tile_index = dfb::rand;
+    constexpr auto cb_id_k = dfb::k;
+    constexpr auto cb_id_p = dfb::p;
+
     constexpr uint32_t temp_chunk_size = num_cores * sizeof(uint16_t);  // 2 bytes per uint16_t
-    constexpr uint32_t out_chunk_size = num_cores * sizeof(uint32_t);   // 4 bytes per uint32_t
+
     dataflow_kernel_lib::
         calculate_and_prepare_reduce_scaler<scaler_max_cb_id, ckernel::PoolType::MAX, ckernel::ReduceDim::REDUCE_ROW>();
     dataflow_kernel_lib::
         calculate_and_prepare_reduce_scaler<scaler_sum_cb_id, ckernel::PoolType::SUM, ckernel::ReduceDim::REDUCE_ROW>();
-    // read k, p, temp
 
     Noc noc;
-    CircularBuffer cb_k(cb_id_k);
-    CircularBuffer cb_p(cb_id_p);
-    CircularBuffer cb_temp(cb_id_temp);
-    CircularBuffer cb_rand(rand_tile_index);
-    CircularBuffer cb_final_indices(output_final_indices_rm_cb_index);
-    CircularBuffer cb_local_values(output_local_values_cb_index);
-    CircularBuffer cb_local_indices(output_local_indices_cb_index);
+    DataflowBuffer cb_k(cb_id_k);
+    DataflowBuffer cb_p(cb_id_p);
+    DataflowBuffer cb_temp(cb_id_temp);
+    DataflowBuffer cb_rand(rand_tile_index);
+    DataflowBuffer cb_final_indices(output_final_indices_rm_cb_index);
+    DataflowBuffer cb_local_values(output_local_values_cb_index);
+    DataflowBuffer cb_local_indices(output_local_indices_cb_index);
+    // cb_out uses CircularBuffer for the use<AddrSelector::WRITE_PTR> noc-source helper (DataflowBuffer
+    // has no AddrSelector); same physical cb id, FIFO ops drive the cross-kernel bridge to compute.
     CircularBuffer cb_out(cb_id_out);
 
-    const auto addrg_k = TensorAccessor(k_args, k_addr);
-    cb_k.reserve_back(1);
-    uint32_t cb_id_k_ptr = cb_k.get_write_ptr();
-    // Read the entire aligned chunk to avoid NOC alignment issues
-    noc.async_read(addrg_k, cb_k, k_chunk_size, {.page_id = 0}, {.offset_bytes = 0});
-    noc.async_read_barrier();
-    cb_k.push_back(1);
-    CoreLocalMem<volatile uint32_t> k_ptr(cb_id_k_ptr);
-    // Index into the chunk to get this core's value
+    // k / p are produced by the reader (cross-kernel bridge): consume + index this core's value.
+    cb_k.wait_front(1);
+    CoreLocalMem<volatile uint32_t> k_ptr(cb_k.get_read_ptr());
     uint32_t k = k_ptr[core_id];
+    cb_k.pop_front(1);
 
-    const auto addrg_p = TensorAccessor(p_args, p_addr);
-    cb_p.reserve_back(1);
-    uint32_t cb_id_p_ptr = cb_p.get_write_ptr();
-    // Read the entire aligned chunk to avoid NOC alignment issues
-    noc.async_read(addrg_p, cb_p, p_chunk_size, {.page_id = 0}, {.offset_bytes = 0});
-    noc.async_read_barrier();
-    cb_p.push_back(1);
-    CoreLocalMem<volatile uint16_t> p_ptr(cb_id_p_ptr);
-    // Index into the chunk to get this core's value
+    cb_p.wait_front(1);
+    CoreLocalMem<volatile uint16_t> p_ptr(cb_p.get_read_ptr());
     uint32_t p = p_ptr[core_id];
+    cb_p.pop_front(1);
 
-    const auto addrg_temp = TensorAccessor(temp_args, temp_addr);
-    // cb_temp.reserve_back(1);
+    // temp: read the chunk into the temp CB's L1, index this core's value, then produce the
+    // broadcast-scalar tile that the compute kernel consumes.
+    const auto addrg_temp = TensorAccessor(tensor::temp);
     uint32_t cb_id_temp_ptr = cb_temp.get_write_ptr();
-    // Read the entire aligned chunk to avoid NOC alignment issues
     noc.async_read(addrg_temp, cb_temp, temp_chunk_size, {.page_id = 0}, {.offset_bytes = 0});
     noc.async_read_barrier();
-    // cb_temp.push_back(1);
-
     CoreLocalMem<volatile uint16_t> temp_ptr(cb_id_temp_ptr);
-    // Index into the chunk to get this core's value
     uint16_t temp = temp_ptr[core_id];
     uint32_t temp_packed = (static_cast<uint32_t>(temp) << 16) + static_cast<uint32_t>(temp);
     generate_bcast_unary_scalar(cb_id_temp, temp_packed);
+
     // generate the top-k mask
     constexpr uint32_t one = 1;
     generate_mask<cb_id_mask, one>(one, ids_per_batch / 32, k - 1);
+
     // get random number
     cb_rand.wait_front(1);
     CoreLocalMem<volatile uint16_t> rand_values(cb_rand.get_read_ptr());
@@ -144,6 +113,8 @@ void kernel_main() {
 
     CoreLocalMem<volatile uint32_t> final_indices(cb_final_indices.get_read_ptr() + core_id * final_indices_stick_size);
 
+    // Output staging CB (cross-kernel bridge: producer here, terminal no-op consumer on compute).
+    cb_out.reserve_back(1);
     uint32_t out_addr = cb_out.get_write_ptr();
     CoreLocalMem<volatile uint32_t> index_out(out_addr);
 
@@ -236,7 +207,7 @@ void kernel_main() {
     cb_local_indices.pop_front(1);
     cb_final_indices.pop_front(num_users);
 
-    const auto s_out = TensorAccessor(dst_args, dst_addr);
+    const auto s_out = TensorAccessor(tensor::output);
     // Write individual core result - output buffer should handle alignment
     noc.async_write(
         use<CircularBuffer::AddrSelector::WRITE_PTR>(cb_out),
@@ -245,4 +216,6 @@ void kernel_main() {
         {.offset_bytes = core_id * 4},
         {.page_id = 0, .offset_bytes = core_id * 4});
     noc.async_write_barrier();
+    // Publish the staged output so the compute kernel's terminal no-op consumer can drain it.
+    cb_out.push_back(1);
 }

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
@@ -6,20 +6,53 @@
 
 #include <algorithm>
 #include <cmath>
+#include <filesystem>
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/math.hpp>
 #include <tt-metalium/work_split.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include "ttnn/operation.hpp"
 #include "ttnn/operations/reduction/reduce_op_validation.hpp"
 
 namespace ttnn::prim {
 
-tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
+using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
+
+ttnn::device_operation::ProgramArtifacts SamplingProgramFactory::create_program_artifacts(
     const SamplingParams& operation_attributes, const SamplingInputs& tensor_args, Tensor& output_tensor) {
-    using namespace tt::tt_metal;
+    // ---- Metal 2.0 named handles (locals for unity-build hygiene) ----
+    const DFBSpecName INPUT_VALUES_DFB{"input_values"};
+    const DFBSpecName INDEX_DFB{"index"};
+    const DFBSpecName SCALER_MAX_DFB{"scaler_max"};
+    const DFBSpecName SCALER_SUM_DFB{"scaler_sum"};
+    const DFBSpecName TOPK_MASK_DFB{"topk_mask"};
+    const DFBSpecName INPUT_TRANSPOSED_DFB{"input_transposed"};
+    const DFBSpecName INDEX_TRANSPOSED_DFB{"index_transposed"};
+    const DFBSpecName VALUES_DFB{"values"};
+    const DFBSpecName LOCAL_VALS_DFB{"local_vals"};
+    const DFBSpecName OUTPUT_IND_DFB{"output_ind"};
+    const DFBSpecName CUR_MAX_DFB{"cur_max"};
+    const DFBSpecName CUR_SUM_DFB{"cur_sum"};
+    const DFBSpecName RAND_DFB{"rand"};
+    const DFBSpecName FINAL_INDICES_DFB{"final_indices"};
+    const DFBSpecName OUTPUT_DFB{"output"};
+    const DFBSpecName K_DFB{"k"};
+    const DFBSpecName P_DFB{"p"};
+    const DFBSpecName TEMP_DFB{"temp"};
+
+    const TensorParamName INPUT_VALUES_TENSOR{"input_values_tensor"};
+    const TensorParamName INPUT_INDICES_TENSOR{"input_indices_tensor"};
+    const TensorParamName OUTPUT_TENSOR{"output_tensor"};
+    const TensorParamName TEMP_TENSOR{"temp_tensor"};
+    const TensorParamName K_TENSOR{"k_tensor"};
+    const TensorParamName P_TENSOR{"p_tensor"};
+
+    const KernelSpecName READER_KERNEL{"reader"};
+    const KernelSpecName WRITER_KERNEL{"writer"};
+    const KernelSpecName COMPUTE_KERNEL{"compute"};
 
     const auto& input_values_tensor = tensor_args.input_values.mesh_tensor();
     const auto& input_indices_tensor = tensor_args.input_indices.mesh_tensor();
@@ -34,13 +67,8 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
 
     auto* device = &input_values_tensor.mutable_device();
 
-    // The bitonic top-k LLK carries sort indices through the dest register, and the index
-    // load/store width is tied to fp32_dest_acc_en (INT32 when enabled, LO16 otherwise). WH/BH
-    // support the cheaper 16-bit (UInt16) path with fp32 dest accumulation disabled (unchanged
-    // behaviour) so that WH/BH does not suffer any restrictions on the dest register. Every other
-    // architecture (e.g. Quasar, which additionally lacks UInt16/UInt32 tile (DFB) metadata
-    // support) uses 32-bit (Int32) index intermediates with fp32 dest accumulation enabled. This
-    // is gated on !(WH || BH) so new architectures default to the safe 32-bit path.
+    // See legacy notes: WH/BH use the cheaper 16-bit (UInt16) index path with fp32 dest acc off;
+    // every other arch (Quasar) uses 32-bit (Int32) indices with fp32 dest acc on.
     const bool use_32bit_index = !(device->arch() == tt::ARCH::WORMHOLE_B0 || device->arch() == tt::ARCH::BLACKHOLE);
 
     tt::DataFormat input_values_cb_data_format =
@@ -48,8 +76,6 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
     tt::DataFormat input_indices_cb_data_format =
         tt::tt_metal::datatype_to_dataformat_converter(input_indices_tensor.dtype());
     tt::DataFormat index_cb_data_format = use_32bit_index ? tt::DataFormat::Int32 : tt::DataFormat::UInt16;
-    // On the 32-bit path (e.g. Quasar), validation already requires k to be INT32 (UInt32 DFB
-    // metadata is unsupported there), so the dtype-derived format is correct as-is.
     tt::DataFormat k_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(k.dtype());
     tt::DataFormat p_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(p.dtype());
     tt::DataFormat temp_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(temp.dtype());
@@ -62,11 +88,6 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
     auto input_shape = input_values_tensor.logical_shape();
     const uint32_t tile_height = input_values_tensor.tensor_spec().tile().get_height();
     const uint32_t tile_width = input_values_tensor.tensor_spec().tile().get_width();
-    // `num_users` is the logical user count (rows in dim 2) in the range [1, 32]; validation
-    // guarantees N == C == 1, so it is just input_shape[2]. The data still occupies a single padded
-    // row-tile (Ht == 1) and only `num_users` cores run. Decoupling num_cores from Ht*tile_height is
-    // what lets <32 users work: the old `(.../tile_height)` would integer-divide to Ht == 0 (and
-    // num_cores == 0) for fewer than tile_height users.
     const uint32_t num_users = input_shape[2];
     uint32_t Ht = (num_users + tile_height - 1) / tile_height;  // == 1 for 1..32 users
     uint32_t Wt = input_shape[3] / tile_width;
@@ -80,9 +101,7 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
     }
     auto cores = corerange_to_cores(core_grid, num_cores, true);
 
-    // `sub_core_grids` may be over-provisioned (more cores than users); only the first `num_cores`
-    // cores actually run. Confine CB allocation and the reader kernel to exactly those cores so we
-    // don't place a reader (with unset runtime args) on the unused cores.
+    // Confine to exactly the running cores (sub_core_grids may be over-provisioned).
     if (core_grid.num_cores() != num_cores) {
         std::vector<CoreRange> active_core_ranges;
         active_core_ranges.reserve(cores.size());
@@ -108,348 +127,328 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
     uint32_t num_cb_unit = 2;
     uint32_t cb_in_units = 2 * num_cb_unit;
 
-    ProgramDescriptor desc;
-
-    // Two tiles are loaded in for sampling_local_sort at a time, and we double buffer to avoid stalls, so allocate four
-    // tiles of space
-    uint32_t input_values_cb_index = tt::CBIndex::c_0;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = cb_in_units * input_values_tile_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(input_values_cb_index),
-            .data_format = input_values_cb_data_format,
-            .page_size = input_values_tile_size,
-        }}},
-    });
-
-    uint32_t index_cb_index = tt::CBIndex::c_2;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = cb_in_units * index_tile_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(index_cb_index),
-            .data_format = index_cb_data_format,
-            .page_size = index_tile_size,
-        }}},
-    });
-
-    // Reduce scaler CBs — separate because MAX and SUM use different tile fill layouts
+    // ---- Sizing (mirrors the legacy CBDescriptor total_size / page_size) ----
     tt::DataFormat scalar_df =
         (input_values_tensor.dtype() == DataType::FLOAT32) ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
     uint32_t scale_tiles = 1;
     uint32_t scalar_tile_size = tile_size(scalar_df);
-
-    uint32_t scaler_max_cb_index = tt::CBIndex::c_3;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = scale_tiles * scalar_tile_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(scaler_max_cb_index),
-            .data_format = scalar_df,
-            .page_size = scalar_tile_size,
-        }}},
-    });
-
-    uint32_t scaler_sum_cb_index = tt::CBIndex::c_17;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = scale_tiles * scalar_tile_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(scaler_sum_cb_index),
-            .data_format = scalar_df,
-            .page_size = scalar_tile_size,
-        }}},
-    });
-
-    uint32_t topk_mask_cb_index = tt::CBIndex::c_4;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = cb_in_units * input_values_tile_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(topk_mask_cb_index),
-            .data_format = input_values_cb_data_format,
-            .page_size = input_values_tile_size,
-        }}},
-    });
-
-    // Compute kernel CBs
-    // Single buffered circular buffer that holds the transposed input tiles
-    uint32_t input_transposed_cb_index = tt::CBIndex::c_5;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = Wt * input_values_tile_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(input_transposed_cb_index),
-            .data_format = input_values_cb_data_format,
-            .page_size = input_values_tile_size,
-        }}},
-    });
-
-    // Single buffered circular buffer that holds the transposed index tiles
-    uint32_t index_transposed_cb_index = tt::CBIndex::c_6;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = Wt * index_tile_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(index_transposed_cb_index),
-            .data_format = index_cb_data_format,
-            .page_size = index_tile_size,
-        }}},
-    });
-
-    // Output sampling values
-    uint32_t values_cb_index = tt::CBIndex::c_7;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_cb_unit * input_values_tile_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(values_cb_index),
-            .data_format = input_values_cb_data_format,
-            .page_size = input_values_tile_size,
-        }}},
-    });
-
-    uint32_t cb_local_vals_index = tt::CBIndex::c_1;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_cb_unit * input_values_tile_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(cb_local_vals_index),
-            .data_format = input_values_cb_data_format,
-            .page_size = input_values_tile_size,
-        }}},
-    });
-
-    // Output local indices
-    uint32_t output_ind_cb_index = tt::CBIndex::c_8;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_cb_unit * index_tile_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(output_ind_cb_index),
-            .data_format = index_cb_data_format,
-            .page_size = index_tile_size,
-        }}},
-    });
-
     uint32_t num_out_tiles = Ht;
-    uint32_t cb_cur_max_index = tt::CBIndex::c_9;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_out_tiles * input_values_tile_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(cb_cur_max_index),
-            .data_format = input_values_cb_data_format,
-            .page_size = input_values_tile_size,
-        }}},
-    });
-
-    uint32_t cb_cur_sum_index = tt::CBIndex::c_10;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_out_tiles * input_values_tile_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(cb_cur_sum_index),
-            .data_format = input_values_cb_data_format,
-            .page_size = input_values_tile_size,
-        }}},
-    });
-
-    // RM CBs for sampling
-
-    // random number
     const uint32_t rand_tile_size = tile_size(tt::DataFormat::Float16_b);
-    constexpr uint32_t rand_tile_index = tt::CBIndex::c_11;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = rand_tile_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(rand_tile_index),
-            .data_format = tt::DataFormat::Float16_b,
-            .page_size = rand_tile_size,
-        }}},
-    });
 
-    // final indices
     uint32_t final_indices_rm_unit_size = input_indices_tensor.element_size();  // 4 for int32
     uint32_t aligned_final_indices_rm_unit_size = Wt * tile_width * final_indices_rm_unit_size;
-    uint32_t final_indices_rm_cb_index = tt::CBIndex::c_12;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = Ht * tile_height * aligned_final_indices_rm_unit_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(final_indices_rm_cb_index),
-            .data_format = input_indices_cb_data_format,
-            .page_size = aligned_final_indices_rm_unit_size,
-        }}},
-    });
 
-    // Output sampling indices
     uint32_t output_unit_size = output_mesh.element_size();
     uint32_t aligned_out0_unit_size = Ht * tile_height * output_unit_size;
-    uint32_t output_cb_index = tt::CBIndex::c_13;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = aligned_out0_unit_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(output_cb_index),
-            .data_format = index_cb_data_format,
-            .page_size = aligned_out0_unit_size,
-        }}},
-    });
 
-    // Add k and p circular buffers
     const uint32_t uint32_bytes = 4;
     const uint32_t bf16_bytes = 2;
-    uint32_t k_cb_index = tt::CBIndex::c_14;
-    // Increase buffer size to accommodate all cores to avoid unaligned NOC reads
     uint32_t k_chunk_size = num_cores * uint32_bytes;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = k_chunk_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(k_cb_index),
-            .data_format = k_cb_data_format,
-            .page_size = k_chunk_size,
-        }}},
-    });
-
-    uint32_t p_cb_index = tt::CBIndex::c_15;
-    // Increase buffer size to accommodate all cores to avoid unaligned NOC reads
     uint32_t p_chunk_size = num_cores * bf16_bytes;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = p_chunk_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(p_cb_index),
-            .data_format = p_cb_data_format,
-            .page_size = p_chunk_size,
-        }}},
-    });
-
-    // Add temp circular buffer
-    uint32_t temp_cb_index = tt::CBIndex::c_16;
-    // Increase buffer size to accommodate all cores to avoid unaligned NOC reads
     uint32_t temp_chunk_size = num_cores * bf16_bytes;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = temp_chunk_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(temp_cb_index),
-            .data_format = temp_cb_data_format,
-            .page_size = temp_chunk_size,
-        }}},
-    });
 
-    std::vector<uint32_t> reader_compile_time_args = {
-        input_values_cb_index,
-        final_indices_rm_cb_index,
-        index_cb_index,
-        Ht,
-        Wt,
-        aligned_final_indices_rm_unit_size,
-        tile_height,
-        static_cast<uint32_t>(use_32bit_index),
-        num_users};
-    tt::tt_metal::TensorAccessorArgs(input_values_tensor).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(input_indices_tensor).append_to(reader_compile_time_args);
+    // ---- Tensor parameters ----
+    TensorParameter input_values_param{.unique_id = INPUT_VALUES_TENSOR, .spec = input_values_tensor.tensor_spec()};
+    TensorParameter input_indices_param{.unique_id = INPUT_INDICES_TENSOR, .spec = input_indices_tensor.tensor_spec()};
+    TensorParameter output_param{.unique_id = OUTPUT_TENSOR, .spec = output_mesh.tensor_spec()};
+    TensorParameter temp_param{.unique_id = TEMP_TENSOR, .spec = temp.tensor_spec()};
+    TensorParameter k_param{.unique_id = K_TENSOR, .spec = k.tensor_spec()};
+    TensorParameter p_param{.unique_id = P_TENSOR, .spec = p.tensor_spec()};
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/reader_values_indices_tensor.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = core_grid;
-    reader_desc.compile_time_args = reader_compile_time_args;
-    reader_desc.config = ReaderConfigDescriptor{};
-    // The reader kernel is created once on the entire core_grid; set the same runtime args on every core
-    for (const auto& core : cores) {
-        reader_desc.emplace_runtime_args(
-            core,
-            {
-                input_values_tensor,
-                input_indices_tensor,
-            });
-    }
-    desc.kernels.push_back(std::move(reader_desc));
+    // ---- Dataflow buffers (one per legacy CB; entry_size = page_size, num_entries = total/page) ----
+    DataflowBufferSpec input_values_dfb_spec{
+        .unique_id = INPUT_VALUES_DFB,
+        .entry_size = input_values_tile_size,
+        .num_entries = cb_in_units,
+        .data_format_metadata = input_values_cb_data_format};
+    DataflowBufferSpec index_dfb_spec{
+        .unique_id = INDEX_DFB,
+        .entry_size = index_tile_size,
+        .num_entries = cb_in_units,
+        .data_format_metadata = index_cb_data_format};
+    DataflowBufferSpec scaler_max_dfb_spec{
+        .unique_id = SCALER_MAX_DFB,
+        .entry_size = scalar_tile_size,
+        .num_entries = scale_tiles,
+        .data_format_metadata = scalar_df};
+    DataflowBufferSpec scaler_sum_dfb_spec{
+        .unique_id = SCALER_SUM_DFB,
+        .entry_size = scalar_tile_size,
+        .num_entries = scale_tiles,
+        .data_format_metadata = scalar_df};
+    DataflowBufferSpec topk_mask_dfb_spec{
+        .unique_id = TOPK_MASK_DFB,
+        .entry_size = input_values_tile_size,
+        .num_entries = cb_in_units,
+        .data_format_metadata = input_values_cb_data_format};
+    DataflowBufferSpec input_transposed_dfb_spec{
+        .unique_id = INPUT_TRANSPOSED_DFB,
+        .entry_size = input_values_tile_size,
+        .num_entries = Wt,
+        .data_format_metadata = input_values_cb_data_format};
+    DataflowBufferSpec index_transposed_dfb_spec{
+        .unique_id = INDEX_TRANSPOSED_DFB,
+        .entry_size = index_tile_size,
+        .num_entries = Wt,
+        .data_format_metadata = index_cb_data_format};
+    DataflowBufferSpec values_dfb_spec{
+        .unique_id = VALUES_DFB,
+        .entry_size = input_values_tile_size,
+        .num_entries = num_cb_unit,
+        .data_format_metadata = input_values_cb_data_format};
+    DataflowBufferSpec local_vals_dfb_spec{
+        .unique_id = LOCAL_VALS_DFB,
+        .entry_size = input_values_tile_size,
+        .num_entries = num_cb_unit,
+        .data_format_metadata = input_values_cb_data_format};
+    DataflowBufferSpec output_ind_dfb_spec{
+        .unique_id = OUTPUT_IND_DFB,
+        .entry_size = index_tile_size,
+        .num_entries = num_cb_unit,
+        .data_format_metadata = index_cb_data_format};
+    DataflowBufferSpec cur_max_dfb_spec{
+        .unique_id = CUR_MAX_DFB,
+        .entry_size = input_values_tile_size,
+        .num_entries = num_out_tiles,
+        .data_format_metadata = input_values_cb_data_format};
+    DataflowBufferSpec cur_sum_dfb_spec{
+        .unique_id = CUR_SUM_DFB,
+        .entry_size = input_values_tile_size,
+        .num_entries = num_out_tiles,
+        .data_format_metadata = input_values_cb_data_format};
+    DataflowBufferSpec rand_dfb_spec{
+        .unique_id = RAND_DFB,
+        .entry_size = rand_tile_size,
+        .num_entries = 1,
+        .data_format_metadata = tt::DataFormat::Float16_b};
+    DataflowBufferSpec final_indices_dfb_spec{
+        .unique_id = FINAL_INDICES_DFB,
+        .entry_size = aligned_final_indices_rm_unit_size,
+        .num_entries = Ht * tile_height,
+        .data_format_metadata = input_indices_cb_data_format};
+    DataflowBufferSpec output_dfb_spec{
+        .unique_id = OUTPUT_DFB,
+        .entry_size = aligned_out0_unit_size,
+        .num_entries = 1,
+        .data_format_metadata = index_cb_data_format};
+    DataflowBufferSpec k_dfb_spec{
+        .unique_id = K_DFB, .entry_size = k_chunk_size, .num_entries = 1, .data_format_metadata = k_cb_data_format};
+    DataflowBufferSpec p_dfb_spec{
+        .unique_id = P_DFB, .entry_size = p_chunk_size, .num_entries = 1, .data_format_metadata = p_cb_data_format};
+    DataflowBufferSpec temp_dfb_spec{
+        .unique_id = TEMP_DFB,
+        .entry_size = temp_chunk_size,
+        .num_entries = 1,
+        .data_format_metadata = temp_cb_data_format};
 
+    // ---- Reader: streams input_values (c_0), generates index (c_2), reads input_indices ->
+    //      final_indices (c_12), and the k/p chunks (c_14/c_15, relocated from the writer). ----
+    KernelSpec reader_spec{
+        .unique_id = READER_KERNEL,
+        .source = std::filesystem::path{
+            "ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/reader_values_indices_tensor.cpp"},
+        .dfb_bindings =
+            {DFBBinding{
+                 .dfb_spec_name = INPUT_VALUES_DFB,
+                 .accessor_name = "input_values",
+                 .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{
+                 .dfb_spec_name = INDEX_DFB, .accessor_name = "index", .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{
+                 .dfb_spec_name = FINAL_INDICES_DFB,
+                 .accessor_name = "final_indices",
+                 .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{.dfb_spec_name = K_DFB, .accessor_name = "k", .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{.dfb_spec_name = P_DFB, .accessor_name = "p", .endpoint_type = DFBEndpointType::PRODUCER}},
+        .tensor_bindings =
+            {TensorBinding{.tensor_parameter_name = INPUT_VALUES_TENSOR, .accessor_name = "input_values"},
+             TensorBinding{.tensor_parameter_name = INPUT_INDICES_TENSOR, .accessor_name = "input_indices"},
+             TensorBinding{.tensor_parameter_name = K_TENSOR, .accessor_name = "k"},
+             TensorBinding{.tensor_parameter_name = P_TENSOR, .accessor_name = "p"}},
+        .compile_time_args =
+            {{"Ht", Ht},
+             {"Wt", Wt},
+             {"final_indices_page_size", aligned_final_indices_rm_unit_size},
+             {"tile_height", tile_height},
+             {"use_32bit_index", static_cast<uint32_t>(use_32bit_index)},
+             {"num_users", num_users},
+             {"num_cores", num_cores},
+             {"k_chunk_size", k_chunk_size},
+             {"p_chunk_size", p_chunk_size}},
+        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+    };
+
+    // ---- Writer: produces scaler_max/sum (c_3/c_17), topk_mask (c_4), temp (c_16); consumes
+    //      final_indices/rand/local_vals/output_ind/k/p; assembles + DMAs output (c_13). ----
+    KernelSpec writer_spec{
+        .unique_id = WRITER_KERNEL,
+        .source = std::filesystem::path{
+            "ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/writer_interleaved.cpp"},
+        .dfb_bindings =
+            {DFBBinding{
+                 .dfb_spec_name = FINAL_INDICES_DFB,
+                 .accessor_name = "final_indices",
+                 .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{.dfb_spec_name = RAND_DFB, .accessor_name = "rand", .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{
+                 .dfb_spec_name = LOCAL_VALS_DFB,
+                 .accessor_name = "local_vals",
+                 .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{
+                 .dfb_spec_name = OUTPUT_IND_DFB,
+                 .accessor_name = "output_ind",
+                 .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{.dfb_spec_name = K_DFB, .accessor_name = "k", .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{.dfb_spec_name = P_DFB, .accessor_name = "p", .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{
+                 .dfb_spec_name = SCALER_MAX_DFB,
+                 .accessor_name = "scaler_max",
+                 .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{
+                 .dfb_spec_name = SCALER_SUM_DFB,
+                 .accessor_name = "scaler_sum",
+                 .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{
+                 .dfb_spec_name = TOPK_MASK_DFB,
+                 .accessor_name = "topk_mask",
+                 .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{.dfb_spec_name = TEMP_DFB, .accessor_name = "temp", .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{
+                 .dfb_spec_name = OUTPUT_DFB, .accessor_name = "output", .endpoint_type = DFBEndpointType::PRODUCER}},
+        .tensor_bindings =
+            {TensorBinding{.tensor_parameter_name = OUTPUT_TENSOR, .accessor_name = "output"},
+             TensorBinding{.tensor_parameter_name = TEMP_TENSOR, .accessor_name = "temp"}},
+        .compile_time_args =
+            {{"final_indices_stick_size", aligned_final_indices_rm_unit_size},
+             {"out_stick_size", aligned_out0_unit_size},
+             {"ids_per_batch", tile_width},
+             {"num_cores", num_cores},
+             {"use_32bit_index", static_cast<uint32_t>(use_32bit_index)},
+             {"num_users", num_users}},
+        .runtime_arg_schema = {.runtime_arg_names = {"core_id"}},
+        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+    };
+
+    // ---- Compute: top-k + softmax; the OUTPUT DFB (c_13) is bound here as a TERMINAL no-op
+    //      CONSUMER so the writer-produced output CB has a legal cross-kernel consumer. ----
+    KernelSpec compute_spec{
+        .unique_id = COMPUTE_KERNEL,
+        .source =
+            std::filesystem::path{"ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/compute/sampling.cpp"},
+        .dfb_bindings =
+            {DFBBinding{
+                 .dfb_spec_name = INPUT_VALUES_DFB,
+                 .accessor_name = "input_values",
+                 .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{
+                 .dfb_spec_name = INDEX_DFB, .accessor_name = "index", .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{
+                 .dfb_spec_name = INPUT_TRANSPOSED_DFB,
+                 .accessor_name = "input_transposed",
+                 .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{
+                 .dfb_spec_name = INPUT_TRANSPOSED_DFB,
+                 .accessor_name = "input_transposed",
+                 .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{
+                 .dfb_spec_name = INDEX_TRANSPOSED_DFB,
+                 .accessor_name = "index_transposed",
+                 .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{
+                 .dfb_spec_name = INDEX_TRANSPOSED_DFB,
+                 .accessor_name = "index_transposed",
+                 .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{
+                 .dfb_spec_name = VALUES_DFB, .accessor_name = "values", .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{
+                 .dfb_spec_name = VALUES_DFB, .accessor_name = "values", .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{
+                 .dfb_spec_name = OUTPUT_IND_DFB,
+                 .accessor_name = "output_ind",
+                 .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{
+                 .dfb_spec_name = TOPK_MASK_DFB,
+                 .accessor_name = "topk_mask",
+                 .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{
+                 .dfb_spec_name = SCALER_MAX_DFB,
+                 .accessor_name = "scaler_max",
+                 .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{
+                 .dfb_spec_name = SCALER_SUM_DFB,
+                 .accessor_name = "scaler_sum",
+                 .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{
+                 .dfb_spec_name = CUR_MAX_DFB, .accessor_name = "cur_max", .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{
+                 .dfb_spec_name = CUR_MAX_DFB, .accessor_name = "cur_max", .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{
+                 .dfb_spec_name = CUR_SUM_DFB, .accessor_name = "cur_sum", .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{
+                 .dfb_spec_name = CUR_SUM_DFB, .accessor_name = "cur_sum", .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{.dfb_spec_name = RAND_DFB, .accessor_name = "rand", .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{
+                 .dfb_spec_name = LOCAL_VALS_DFB,
+                 .accessor_name = "local_vals",
+                 .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{.dfb_spec_name = TEMP_DFB, .accessor_name = "temp", .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{
+                 .dfb_spec_name = OUTPUT_DFB, .accessor_name = "output", .endpoint_type = DFBEndpointType::CONSUMER}},
+        .compile_time_args =
+            {{"Ht", Ht},
+             {"Wt", Wt},
+             {"logWt", static_cast<uint32_t>(std::log2(Wt))},
+             {"seed", random_seed},
+             {"tile_width", tile_width}},
+        .hw_config = ComputeHardwareConfig{.fp32_dest_acc_en = use_32bit_index},
+    };
+    // INTRA self-loops (compute-kernel-internal FIFOs) + the no-op output bridge consumer.
+    compute_spec.advanced_options.dfb_self_loop_connectivities = {
+        {INPUT_TRANSPOSED_DFB, DFBSelfLoopConnectivity::INTRA},
+        {INDEX_TRANSPOSED_DFB, DFBSelfLoopConnectivity::INTRA},
+        {VALUES_DFB, DFBSelfLoopConnectivity::INTRA},
+        {CUR_MAX_DFB, DFBSelfLoopConnectivity::INTRA},
+        {CUR_SUM_DFB, DFBSelfLoopConnectivity::INTRA},
+    };
+
+    // ---- Per-core runtime args: only the writer needs core_id (== index in `cores`). ----
+    KernelRunArgs writer_run{.kernel = WRITER_KERNEL};
+    writer_run.runtime_arg_values.reserve(cores.size());
     for (uint32_t i = 0; i < cores.size(); ++i) {
-        const auto& core = cores[i];
-        CoreRangeSet single_core{CoreRange(core, core)};
-
-        std::vector<uint32_t> writer_compile_time_args;
-        tt::tt_metal::TensorAccessorArgs(output_mesh).append_to(writer_compile_time_args);
-        tt::tt_metal::TensorAccessorArgs(temp).append_to(writer_compile_time_args);
-        tt::tt_metal::TensorAccessorArgs(k).append_to(writer_compile_time_args);
-        tt::tt_metal::TensorAccessorArgs(p).append_to(writer_compile_time_args);
-        writer_compile_time_args.insert(
-            writer_compile_time_args.end(),
-            {
-                output_cb_index,
-                topk_mask_cb_index,
-                scaler_max_cb_index,
-                scaler_sum_cb_index,
-                final_indices_rm_cb_index,
-                cb_local_vals_index,
-                output_ind_cb_index,
-                aligned_final_indices_rm_unit_size,
-                aligned_out0_unit_size,
-                rand_tile_index,
-                k_cb_index,
-                p_cb_index,
-                temp_cb_index,
-                i,
-                tile_width,
-                num_cores,
-                static_cast<uint32_t>(use_32bit_index),
-                num_users,
-            });
-
-        KernelDescriptor writer_desc;
-        writer_desc.kernel_source =
-            "ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/writer_interleaved.cpp";
-        writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        writer_desc.core_ranges = single_core;
-        writer_desc.compile_time_args = writer_compile_time_args;
-        writer_desc.config = WriterConfigDescriptor{};
-        writer_desc.emplace_runtime_args(core, {output_mesh, temp, k, p});
-        desc.kernels.push_back(std::move(writer_desc));
-
-        std::vector<uint32_t> compute_args = {
-            input_values_cb_index,
-            index_cb_index,
-            input_transposed_cb_index,
-            index_transposed_cb_index,
-            values_cb_index,
-            output_ind_cb_index,
-            topk_mask_cb_index,
-            scaler_max_cb_index,
-            scaler_sum_cb_index,
-            cb_cur_max_index,
-            cb_cur_sum_index,
-            Ht,
-            Wt,
-            static_cast<uint32_t>(std::log2(Wt)),
-            rand_tile_index,
-            random_seed,
-            cb_local_vals_index,
-            temp_cb_index,
-            tile_width};
-
-        KernelDescriptor compute_desc;
-        compute_desc.kernel_source = "ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/compute/sampling.cpp";
-        compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        compute_desc.core_ranges = single_core;
-        compute_desc.compile_time_args = compute_args;
-        // 32-bit (Int32) sort indices require fp32 dest accumulation so the top-k LLK loads/stores
-        // indices in INT32 mode; the 16-bit (UInt16) path uses LO16 mode with fp32 dest acc off.
-        compute_desc.config = ComputeConfigDescriptor{
-            .fp32_dest_acc_en = use_32bit_index,
-        };
-        desc.kernels.push_back(std::move(compute_desc));
+        writer_run.runtime_arg_values.push_back({cores[i], KernelRunArgs::RuntimeArgValues{{"core_id", i}}});
     }
 
-    return desc;
+    WorkUnitSpec wu{
+        .name = "sampling",
+        .kernels = {READER_KERNEL, WRITER_KERNEL, COMPUTE_KERNEL},
+        .target_nodes = core_grid,
+    };
+
+    ProgramSpec spec{
+        .name = "sampling",
+        .kernels = {reader_spec, writer_spec, compute_spec},
+        .dataflow_buffers =
+            {input_values_dfb_spec, index_dfb_spec,      scaler_max_dfb_spec,       scaler_sum_dfb_spec,
+             topk_mask_dfb_spec,    input_transposed_dfb_spec, index_transposed_dfb_spec, values_dfb_spec,
+             local_vals_dfb_spec,   output_ind_dfb_spec, cur_max_dfb_spec,          cur_sum_dfb_spec,
+             rand_dfb_spec,         final_indices_dfb_spec,    output_dfb_spec,           k_dfb_spec,
+             p_dfb_spec,            temp_dfb_spec},
+        .tensor_parameters =
+            {input_values_param, input_indices_param, output_param, temp_param, k_param, p_param},
+        .work_units = {wu},
+    };
+
+    ProgramRunArgs run_args;
+    run_args.kernel_run_args = {writer_run};
+    run_args.tensor_args = {
+        {INPUT_VALUES_TENSOR, TensorArgument{std::cref(input_values_tensor)}},
+        {INPUT_INDICES_TENSOR, TensorArgument{std::cref(input_indices_tensor)}},
+        {OUTPUT_TENSOR, TensorArgument{std::cref(output_mesh)}},
+        {TEMP_TENSOR, TensorArgument{std::cref(temp)}},
+        {K_TENSOR, TensorArgument{std::cref(k)}},
+        {P_TENSOR, TensorArgument{std::cref(p)}}};
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.hpp
@@ -11,7 +11,11 @@
 namespace ttnn::prim {
 
 struct SamplingProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    // Metal 2.0 (MetalV2FactoryConcept). DM-kernel sync-free CBs are handled via the cross-kernel
+    // DFB bridge: read-staging k/p (c_14/c_15) relocated reader->writer, and the writer-assembled
+    // output CB (c_13) bridged writer-PRODUCER -> compute-CONSUMER (terminal no-op) since a DM
+    // kernel cannot self-loop a DFB.
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const SamplingParams& operation_attributes, const SamplingInputs& tensor_args, Tensor& output_tensor);
 };
 


### PR DESCRIPTION
## What

Ports `reduction/sampling` `SamplingProgramFactory` from legacy `ProgramDescriptor` to the Metal 2.0 `create_program_artifacts` / `ProgramSpec` API.

> **Stacked on #48148** (the Device-2.0 `generate_bcast_scalar` donor prereq). Review/merge that first; the port-only diff is the 5 files below.

## Why this one is notable: the cross-kernel DFB bridge

The pre-port audit (#48139) initially graded this op portable "via the self-loop workaround", then I corrected it to "framework-blocked" — because Metal 2.0 needs 1 producer + 1 consumer per local DFB, has no scratch/sync-free DFB, and the self-loop escape is **compute-kernel-only** (a DM-kernel self-loop FATALs), and sampling's writer owns several **sync-free CBs**.

This PR demonstrates the actual resolution — **no framework change needed** — the **cross-kernel DFB bridge**: only a DM *self*-loop is illegal; a DM kernel paired *cross-kernel* with a different co-located kernel is legal (the same mechanism the merged JointSDPA port #48175 already uses for `mask`/`scale`/`col_identity`). Applied here per sync-free-CB type:

- **Read-staging** `c_14` (k) / `c_15` (p) — the writer used to read a DRAM chunk in and index it. **Relocated** the read to the reader: reader PRODUCER → writer CONSUMER (a real data dependency).
- **Write-staging** `c_13` (output) — the writer assembles the sampled result in L1 then `noc_async_write`s to DRAM (no consumer). **Bridged**: PRODUCER on the writer + a **terminal no-op CONSUMER on compute** (`wait_front`/`pop_front` that never reads the data). The SPSC validator accepts it (it only counts endpoints) and it runs with no deadlock at baseline numerics — this PR is the end-to-end confirmation of that variant.
- **Structural collapse**: the legacy factory created the writer/compute kernels *per core* with `core_id` baked as a CTA; collapsed to single `KernelSpec`s with `core_id` as a per-core RTA.

Full DFB map: reader→compute (`c_0`,`c_2`), reader→writer (`c_12`), writer→compute (`c_3`,`c_17`,`c_4`,`c_16`), compute→writer (`c_11`,`c_1`,`c_8`), compute INTRA self-loops (`c_5`,`c_6`,`c_7`,`c_9`,`c_10`), plus the two bridges above.

Two JIT details worth noting: `generate_bcast_unary_scalar` takes a `uint32_t` cb id; and `use<AddrSelector::WRITE_PTR>` is a `CircularBuffer`-only helper, so `c_13`'s noc-write source uses `CircularBuffer` (same physical id) while the DFB bridge drives the FIFO endpoints. No custom `compute_program_hash` (none present). Behavior-preserving.

## Validation (n150, correct worktree `_ttnn.so`)

`tests/ttnn/unit_tests/operations/reduce/test_sampling.py` → **26 passed / 0 failed** (= baseline), including the program-cache callback path. No `dfb`/`args` JIT errors, no `TT_FATAL`, no self-loop fatal, no deadlock.

## Significance

This is the first op unblocked *by the cross-kernel-bridge workaround*. The same pattern unblocks the rest of the DM-sync-free-CB class — **embedding** and **sdpa_decode** — with no framework change. (`create_qkv_decode` remains the lone exception: single-kernel/reader-only, so it has no co-located kernel to host a bridge endpoint.)

Part of the Metal 2.0 migration umbrella #46909; audit + revisions in #48139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
