### PR TITLE
#48195: adjust resnet50 quasar test for flexible grids

### DIFF
--- a/models/demos/vision/classification/resnet50/quasar/tests/common/resnet50_test_infra.py
+++ b/models/demos/vision/classification/resnet50/quasar/tests/common/resnet50_test_infra.py
@@ -228,12 +228,19 @@ class ResNet50TestInfra:
         n, c, h, w = torch_input_tensor.shape
         n = n // self.num_devices
 
+        # Tie the shard count to the device's real compute-core count. The per-batch `core_grid`
+        # above targets a full silicon part; Quasar has at most 32 Tensix neo clusters and the
+        # emulator 1-2, so requesting e.g. 48 (8x6) shards overflows the available L1 banks
+        # (TT_FATAL: num_shards <= num_compute_banks). Cap the requested cores to the device's
+        # compute grid (and to the number of shardable rows), then lay them out row-wise within
+        # that grid. On a full part this is a no-op when core_grid already fits.
+        compute_grid = device.compute_with_storage_grid_size()
+        max_num_cores = compute_grid.x * compute_grid.y
+        num_cores = min(core_grid.x * core_grid.y, max_num_cores, n * c * h)
+
         # sharded mem config for fold input
-        num_cores = core_grid.x * core_grid.y
         shard_h = (n * c * h + num_cores - 1) // num_cores
-        grid_size = core_grid
-        grid_coord = ttnn.CoreCoord(grid_size.x - 1, grid_size.y - 1)
-        shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), grid_coord)})
+        shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid, row_wise=True)
         shard_spec = ttnn.ShardSpec(shard_grid, (shard_h, w), ttnn.ShardOrientation.ROW_MAJOR)
         input_mem_config = ttnn.MemoryConfig(
             ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.types.BufferType.L1, shard_spec

--- a/models/demos/vision/classification/resnet50/quasar/tt/ttnn_functional_resnet50.py
+++ b/models/demos/vision/classification/resnet50/quasar/tt/ttnn_functional_resnet50.py
@@ -13,24 +13,71 @@ from models.common.utility_functions import _nearest_y, is_blackhole, is_wormhol
 from models.demos.vision.classification.resnet50.quasar.tt.ttnn_functional_resnet50_model_utils import is_blackhole_p100
 
 
+def fit_width_sharded_cores(width_elems, desired_cores, device):
+    """Tie a WIDTH_SHARDED core count to the device.
+
+    The model's per-batch grids target a full silicon part; Quasar has at most 32 Tensix neo
+    clusters and the emulator 1-2, so a hardcoded grid (e.g. 8x8=64) requests more shards than
+    there are L1 banks. Return (num_cores, core_range_set) where num_cores is the largest count
+    <= min(desired, device cores) that divides the width into tile-aligned (multiple of 32)
+    shards, so the shard width (width_elems // num_cores) stays exact and tile-aligned. On a full
+    part where the desired grid already fits this is a no-op.
+    """
+    grid = device.compute_with_storage_grid_size()
+    cap = min(desired_cores, grid.x * grid.y)
+    width_tiles = max(1, width_elems // 32)
+    num_cores = cap
+    while num_cores > 1 and width_tiles % num_cores != 0:
+        num_cores -= 1
+    return num_cores, ttnn.num_cores_to_corerangeset(num_cores, grid, row_wise=True)
+
+
+def fit_fc_grid(device, n_tiles, k_tiles):
+    """Pick a rectangular core grid for the resnet fc 1D-mcast matmul that fits the device and
+    evenly tiles the N output dimension.
+
+    Returns (grid_x, grid_y, num_cores, per_core_N, in0_block_w). The stock config is an 8x4=32
+    grid with per_core_N=1 (N=1024/32=32 tiles, one tile/core) and in0_block_w=2 (K=2048/32=64
+    tiles -> 2 tiles/core). On Quasar (32 cores) this is unchanged; on a smaller part (emulator)
+    we pick the largest rectangle that fits the device AND divides n_tiles, then raise per_core_N
+    so every N tile is still covered (num_cores * per_core_N == n_tiles). A rectangle (not a
+    row-wise core set) is required because both the matmul config and the activation width-shard
+    feeding it take a (grid_x, grid_y) and must agree.
+    """
+    grid = device.compute_with_storage_grid_size()
+    best_gx, best_gy, best_nc = 1, 1, 1
+    for gy in range(1, grid.y + 1):
+        for gx in range(1, grid.x + 1):
+            nc = gx * gy
+            if n_tiles % nc == 0 and nc > best_nc:
+                best_gx, best_gy, best_nc = gx, gy, nc
+    per_core_N = n_tiles // best_nc
+    kt_per_core = k_tiles // best_nc  # best_nc | n_tiles | k_tiles, so this is exact
+    in0_block_w = 2 if kt_per_core % 2 == 0 else kt_per_core
+    return best_gx, best_gy, best_nc, per_core_N, in0_block_w
+
+
 def ResnetLinear(
     weight: ttnn.Tensor,
     bias: ttnn.Tensor,
     output_mem_config,
     model_config,
     compute_kernel_config,
+    matmul_grid=(8, 4),
+    per_core_N=1,
+    in0_block_w=2,
 ):
     """
     Returns a function for linear operation in resnet with bias.
     """
 
     matmul_config = ttnn._ttnn.operations.experimental.quasar.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-        compute_with_storage_grid_size=(8, 4),
-        in0_block_w=2,
+        compute_with_storage_grid_size=matmul_grid,
+        in0_block_w=in0_block_w,
         out_subblock_h=1,
         out_subblock_w=1,
         per_core_M=1,
-        per_core_N=1,
+        per_core_N=per_core_N,
         fuse_batch=True,
         fused_activation=None,
         mcast_in0=True,
@@ -443,12 +490,22 @@ class resnet50:
         self.layer4_module2 = self.layer4[1]
         self.layer4_module3 = self.layer4[2]
 
+        # Tie the fc 1D-mcast matmul grid to the device. resnet50 fc: N=1000 -> padded 1024 = 32
+        # tiles, K=2048 = 64 tiles. On Quasar (32 cores) this stays the stock 8x4 grid /
+        # per_core_N=1; on a smaller part it shrinks the grid and raises per_core_N so all N tiles
+        # are covered. The same (grid_x, grid_y) is reused for the activation width-shard feeding
+        # fc (see run()), since mcast_in0 requires the input sharding to match the matmul grid.
+        fc_gx, fc_gy, self.fc_num_cores, fc_per_core_N, fc_in0_block_w = fit_fc_grid(device, n_tiles=32, k_tiles=64)
+        self.fc_matmul_grid = (fc_gx, fc_gy)
         self.fc = ResnetLinear(
             weight=ttnn.to_device(parameters.fc.weight, device),
             bias=ttnn.to_device(parameters.fc.bias, device),
             output_mem_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
             model_config=model_config,
             compute_kernel_config=compute_kernel_config,
+            matmul_grid=self.fc_matmul_grid,
+            per_core_N=fc_per_core_N,
+            in0_block_w=fc_in0_block_w,
         )  # num_classes = 1000
 
         act_block_h_override = 0
@@ -540,6 +597,17 @@ class resnet50:
             if is_blackhole_p100(device):
                 core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 7))})
             self.fold_compute_grid_size = core_grid
+
+        # Cap the fold compute grid to the device's real core count. The per-batch grids above target
+        # a full silicon part; Quasar has at most 32 Tensix neo clusters and the emulator 1-2, so an
+        # 8x8 (=64) fold grid would request more shards than there are L1 banks. Clamp to the device
+        # grid (no-op when it already fits) so this matches the (also-capped) input sharding.
+        _fold_compute_grid = device.compute_with_storage_grid_size()
+        _fold_max_cores = _fold_compute_grid.x * _fold_compute_grid.y
+        if self.fold_compute_grid_size.num_cores() > _fold_max_cores:
+            self.fold_compute_grid_size = ttnn.num_cores_to_corerangeset(
+                _fold_max_cores, _fold_compute_grid, row_wise=True
+            )
 
         conv_dummy_tensor = torch.rand((self.fold_output_shape), dtype=torch.bfloat16)
         conv_dummy_tensor = ttnn.from_torch(conv_dummy_tensor, layout=ttnn.ROW_MAJOR_LAYOUT)
@@ -903,10 +971,11 @@ class resnet50:
             layer_module="layer4_module3",
         )
 
-        grid_size = (8, 8)
+        # WIDTH_SHARDED grid tied to device core count.
+        num_cores, core_grid = fit_width_sharded_cores(x.shape[3], 8 * 8, device)
         width_mem_config = ttnn.create_sharded_memory_config_(
-            [nearest_32(x.shape[2]), x.shape[3] // (grid_size[0] * grid_size[1])],
-            ttnn.CoreGrid(x=grid_size[0], y=grid_size[1]),
+            [nearest_32(x.shape[2]), x.shape[3] // num_cores],
+            core_grid,
             ttnn.TensorMemoryLayout.WIDTH_SHARDED,
             ttnn.ShardOrientation.ROW_MAJOR,
             tile_layout=True,
@@ -930,10 +999,14 @@ class resnet50:
             ),
         )
 
-        grid_size = (8, 4)
+        # WIDTH_SHARDED activation for fc, on the SAME rectangular grid as the fc
+        # 1D-mcast matmul (mcast_in0 requires the input sharding to match the matmul grid). Both
+        # were derived together from the device in __init__ (fit_fc_grid), so this is the stock
+        # 8x4=32 layout on Quasar and a smaller rectangle on the emulator.
+        fc_core_grid = ttnn.CoreGrid(x=self.fc_matmul_grid[0], y=self.fc_matmul_grid[1])
         width_mem_config = ttnn.create_sharded_memory_config_(
-            [nearest_32(x.shape[2]), x.shape[3] // (grid_size[0] * grid_size[1])],
-            ttnn.CoreGrid(x=grid_size[0], y=grid_size[1]),
+            [nearest_32(x.shape[2]), x.shape[3] // self.fc_num_cores],
+            fc_core_grid,
             ttnn.TensorMemoryLayout.WIDTH_SHARDED,
             ttnn.ShardOrientation.ROW_MAJOR,
             tile_layout=True,


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Test Only

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #48195 

Quasar and Quasar emulators/simulators will have varying grids. Adjust test to be flexible vs a fixed grid from the original WH test. Tested locally.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-48195_resnet_grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-48195_resnet_grid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-48195_resnet_grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-48195_resnet_grid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-48195_resnet_grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-48195_resnet_grid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-48195_resnet_grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-48195_resnet_grid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-48195_resnet_grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-48195_resnet_grid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-48195_resnet_grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-48195_resnet_grid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-48195_resnet_grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-48195_resnet_grid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-48195_resnet_grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-48195_resnet_grid)