### PR TITLE
Improve fatal message for HEIGHT_SHARDED in0 on multi-column grid with 2D mcast config

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -1533,7 +1533,7 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
                         TT_FATAL(
                             input_tensor_a.shard_spec()->grid.bounding_box().start_coord.x ==
                                 input_tensor_a.shard_spec()->grid.bounding_box().end_coord.x,
-                            "Input tensor A must have a single-column shard grid for "
+                            "When input tensor A is HEIGHT_SHARDED, it must have a single-column shard grid for "
                             "MatmulMultiCoreReuseMultiCastProgramConfig (got x={} to x={}). Use "
                             "MatmulMultiCoreReuseProgramConfig for multi-column HEIGHT_SHARDED inputs.",
                             input_tensor_a.shard_spec()->grid.bounding_box().start_coord.x,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -1533,7 +1533,9 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
                         TT_FATAL(
                             input_tensor_a.shard_spec()->grid.bounding_box().start_coord.x ==
                                 input_tensor_a.shard_spec()->grid.bounding_box().end_coord.x,
-                            "Grid bounding box x coordinates must match, got start: {} vs end: {}",
+                            "MatmulMultiCoreReuseMultiCastProgramConfig requires HEIGHT_SHARDED in0 on a single "
+                            "column (got x={} to x={}). Use MatmulMultiCoreReuseProgramConfig for multi-column "
+                            "inputs.",
                             input_tensor_a.shard_spec()->grid.bounding_box().start_coord.x,
                             input_tensor_a.shard_spec()->grid.bounding_box().end_coord.x);
                     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -1533,9 +1533,9 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
                         TT_FATAL(
                             input_tensor_a.shard_spec()->grid.bounding_box().start_coord.x ==
                                 input_tensor_a.shard_spec()->grid.bounding_box().end_coord.x,
-                            "MatmulMultiCoreReuseMultiCastProgramConfig requires HEIGHT_SHARDED in0 on a single "
-                            "column (got x={} to x={}). Use MatmulMultiCoreReuseProgramConfig for multi-column "
-                            "inputs.",
+                            "Input tensor A must have a single-column shard grid for "
+                            "MatmulMultiCoreReuseMultiCastProgramConfig (got x={} to x={}). Use "
+                            "MatmulMultiCoreReuseProgramConfig for multi-column HEIGHT_SHARDED inputs.",
                             input_tensor_a.shard_spec()->grid.bounding_box().start_coord.x,
                             input_tensor_a.shard_spec()->grid.bounding_box().end_coord.x);
                     }


### PR DESCRIPTION
## Summary
-Fixes: #22679

Improves the fatal message for `MatmulMultiCoreReuseMultiCastProgramConfig` when `HEIGHT_SHARDED` input A spans multiple columns — the old message only reported raw coordinates with no explanation of the constraint or what config to use instead.


## Root Cause

Issue #22679 came from trying to switch SentenceBERT pre-softmax matmul (`Q @ K^T`) from `MatmulMultiCoreReuseProgramConfig` to `MatmulMultiCoreReuseMultiCastProgramConfig`.

For this path:
- `Q` is `HEIGHT_SHARDED` across the full `(6, 8)` grid (multi-column).
- 2D mcast requires `HEIGHT_SHARDED` input A to be single-column for its multicast pattern.
- Multi-column `HEIGHT_SHARDED` violates that requirement, so the bounding-box validation fatal is expected.

The old message only reported raw coordinates with no explanation of the constraint or what config to use instead.

## What Changed

Updated the fatal message at the `HEIGHT_SHARDED` bounding-box check for `MatmulMultiCoreReuseMultiCastProgramConfig` to:
- state the single-column requirement explicitly,
- print the observed x-column range,
- suggest `MatmulMultiCoreReuseProgramConfig` for multi-column `HEIGHT_SHARDED` input A.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/grid-mismatch-with-2d-mcast-22679)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/grid-mismatch-with-2d-mcast-22679)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/grid-mismatch-with-2d-mcast-22679)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/grid-mismatch-with-2d-mcast-22679)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/grid-mismatch-with-2d-mcast-22679)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/grid-mismatch-with-2d-mcast-22679)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/grid-mismatch-with-2d-mcast-22679)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/grid-mismatch-with-2d-mcast-22679)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/grid-mismatch-with-2d-mcast-22679)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/grid-mismatch-with-2d-mcast-22679)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/grid-mismatch-with-2d-mcast-22679)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/grid-mismatch-with-2d-mcast-22679)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/grid-mismatch-with-2d-mcast-22679)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/grid-mismatch-with-2d-mcast-22679)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/grid-mismatch-with-2d-mcast-22679)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/grid-mismatch-with-2d-mcast-22679)