### PR TITLE
indexer_score: MiniMax M3 GQA support (indexer_score_msa)

### DIFF
--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -409,7 +409,7 @@ jobs:
           commands: |
             pytest tests/ttnn/perf_tests/operations/conv -m models_device_performance_bare_metal --timeout=300
             ${{ matrix.test-info.arch == 'blackhole' && 'SDPA_PERF_CHECKS=1 pytest tests/nightly/blackhole/sdpa/test_scaled_dot_product_attention_sprint.py::test_sdpa_perf_check -svv' || '' }}
-            ${{ matrix.test-info.arch == 'blackhole' && 'INDEXER_SCORE_PERF_CHECKS=1 pytest tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py::test_indexer_score_perf_check -svv' || '' }}
+            ${{ matrix.test-info.arch == 'blackhole' && 'INDEXER_SCORE_PERF_CHECKS=1 pytest tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py::test_indexer_score_math_util -svv' || '' }}
         if: ${{ !cancelled() && matrix.test-info.civ2-compatible && (!matrix.test-info.job-set1 || matrix.test-info.job-blackhole-set1) && fromJSON(needs.define-models.outputs.models-to-run)['ops-perf-tests'] }}
         timeout-minutes: ${{ matrix.test-info.timeout }}
 

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -484,7 +484,8 @@ Transformer
    ttnn.transformer.sparse_sdpa
    ttnn.transformer.split_query_key_value_and_split_heads
    ttnn.transformer.windowed_scaled_dot_product_attention
-   ttnn.experimental.indexer_score
+   ttnn.experimental.indexer_score_dsa
+   ttnn.experimental.indexer_score_msa
 
 CCL
 ===

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -48,26 +48,40 @@ GLX_CASES = [("glm5", 8), ("dsv32", 16)]
 GLX_IDS = [c[0] for c in GLX_CASES]
 
 
-def indexer_score_ref(q, k, w, chunk_start, apply_relu=True):
-    """Per-head fp32 accumulation (a full [Hi,Sq,T] tensor is many GB at GLX sizes).
-
-    apply_relu=True  -> sum_h relu(q.kT) * w   (DeepSeek-V3.2 / GLM-5 lightning indexer)
-    apply_relu=False -> sum_h (q.kT)    * w    (MiniMax M3 MSA: raw dot, scale folded into w)
+def indexer_score_dsa_ref(q, k, w, chunk_start):
+    """DeepSeek-V3.2 / GLM-5 DSA reference: sum_h relu(q.kT) * w over ALL Hi heads into one plane
+    -> [b, 1, sq, t]. Per-head fp32 accumulation (a full [Hi,Sq,T] tensor is many GB at GLX sizes).
     """
     b, hi, sq, _ = q.shape
     t = k.shape[2]
     q, k, w = q.float(), k.float(), w.float()
     score = torch.zeros(b, sq, t)
     for h in range(hi):
-        qk = q[:, h] @ k[:, 0].transpose(-2, -1)
-        score += (torch.relu(qk) if apply_relu else qk) * w[:, h]
+        score += torch.relu(q[:, h] @ k[:, 0].transpose(-2, -1)) * w[:, h]
     future = torch.arange(t).unsqueeze(0) > chunk_start + torch.arange(sq).unsqueeze(1)
     return score.masked_fill(future, float("-inf")).unsqueeze(1)
 
 
-def indexer_score_grouped_ref(q, k, w, chunk_start, num_groups, apply_relu=True):
-    """Per-GQA-group reference: partition the Hi heads into num_groups contiguous groups of Hi/num_groups
-    and sum act(q.kT)*w WITHIN each group only -> [b, num_groups, sq, t]. num_groups==1 == indexer_score_ref.
+def msa_block_max_pool(scores, block_size, chunk_start):
+    """MSA block-max-pool + forced-local (the M3 selection step, MSA-only): max over each block_size-key
+    block of the causal-masked scores [b,g,sq,t] -> [b,g,sq,t//block_size]. A fully-future block is -inf.
+    Then forced-local (sparse_local_block=1): each query's own block (= (chunk_start + s) // block_size) is
+    set to +inf. Used both inside indexer_score_msa_ref (block_size>0) and to pool the op's own unpooled
+    output in the exact-vs-unpooled cross-checks."""
+    b, g, sq, t = scores.shape
+    nb = t // block_size
+    pooled = scores.reshape(b, g, sq, nb, block_size).amax(dim=-1)
+    local = (chunk_start + torch.arange(sq)) // block_size  # each query's own block column [sq]
+    pooled[:, :, torch.arange(sq), local] = float("inf")
+    return pooled
+
+
+def indexer_score_msa_ref(q, k, w, chunk_start, num_groups=1, block_size=0):
+    """MiniMax-M3 MSA reference (mirrors the indexer_score_msa op): raw dot (NO relu), gated by w (the
+    constant 1/sqrt(d) scale), partitioned into num_groups contiguous GQA groups of Hi/num_groups and summed
+    WITHIN each group only -> [b, num_groups, sq, t]. num_groups==1 sums all heads into one plane.
+
+    block_size>0 block-max-pools the planes into the M3 block selection -> [b, num_groups, sq, t//block_size].
     """
     b, hi, sq, _ = q.shape
     t = k.shape[2]
@@ -78,10 +92,10 @@ def indexer_score_grouped_ref(q, k, w, chunk_start, num_groups, apply_relu=True)
     for g in range(num_groups):
         score = torch.zeros(b, sq, t)
         for h in range(g * hog, (g + 1) * hog):
-            qk = q[:, h] @ k[:, 0].transpose(-2, -1)
-            score += (torch.relu(qk) if apply_relu else qk) * w[:, h]
+            score += (q[:, h] @ k[:, 0].transpose(-2, -1)) * w[:, h]
         planes.append(score.masked_fill(future, float("-inf")))
-    return torch.stack(planes, dim=1)  # [b, num_groups, sq, t]
+    scores = torch.stack(planes, dim=1)  # [b, num_groups, sq, t]
+    return msa_block_max_pool(scores, block_size, chunk_start) if block_size else scores
 
 
 def make_inputs(heads, dim, sq, t, seed=42):
@@ -187,18 +201,6 @@ def assert_grouped_match(out, ref, num_groups, sq, t):
     assert pcc >= 0.999, f"PCC {pcc} < 0.999"
 
 
-def block_max_pool_ref(scores, block_size, chunk_start):
-    """Reference block-max-pool: max over each block_size-key block of the causal-masked scores
-    [b,g,sq,t] -> [b,g,sq,t//block_size]. A fully-future block is -inf. Then forced-local (M3
-    sparse_local_block=1): each query's own block (= (chunk_start + s) // block_size) is set to +inf."""
-    b, g, sq, t = scores.shape
-    nb = t // block_size
-    pooled = scores.reshape(b, g, sq, nb, block_size).amax(dim=-1)
-    local = (chunk_start + torch.arange(sq)) // block_size  # each query's own block column [sq]
-    pooled[:, :, torch.arange(sq), local] = float("inf")
-    return pooled
-
-
 def assert_pooled_match(out, ref, num_groups, sq, nblocks, pcc_floor=0.999):
     """Pooled [1,G,Sq,nblocks] check: exact -inf map + exact +inf (forced-local) map + PCC on the rest.
     block-max amplifies the bf16 per-token error, so the PCC floor is relaxed for the large-T shape."""
@@ -240,7 +242,7 @@ def test_indexer_score_accuracy(device, sp_rank, q_dtype, case_id, heads):
     out = run_dsa(
         q, k, w, chunk_start, device, program_config=glx_config(heads), q_dtype=q_dtype, k_dtype=ttnn.bfloat8_b
     )
-    ref = indexer_score_ref(q, k, w, chunk_start)
+    ref = indexer_score_dsa_ref(q, k, w, chunk_start)
     assert_indexer_match(out, ref, GLX_SQ, GLX_T, check_neg=True)
 
 
@@ -256,7 +258,7 @@ def _run_and_check(device, heads, dim, sq, t, chunk_start, q_chunk, k_chunk, hea
     cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=q_chunk, k_chunk_size=k_chunk, head_group_size=head_group)
     q, k, w = make_inputs(heads, dim, sq, t)
     out = run_dsa(q, k, w, chunk_start, device, program_config=cfg)
-    ref = indexer_score_ref(q, k, w, chunk_start)
+    ref = indexer_score_dsa_ref(q, k, w, chunk_start)
     assert_indexer_match(out, ref, sq, t, check_neg=True)
 
 
@@ -341,7 +343,7 @@ def _indexed_inputs(num_slots, seed=11):
 def _check_slot(out, q, k_cache, w, b):
     """Compare a slot's device output against the reference computed on that [1,1,T,D] slice."""
     c = IDX_CACHE
-    ref = indexer_score_ref(q, k_cache[b : b + 1], w, c["chunk_start"])
+    ref = indexer_score_dsa_ref(q, k_cache[b : b + 1], w, c["chunk_start"])
     assert_indexer_match(out, ref, c["sq"], c["t"], check_neg=True)
 
 
@@ -468,7 +470,7 @@ def test_indexer_score_nd_sharded_k_multi_T(device):
         out = ttnn.to_torch(
             ttnn.experimental.indexer_score_dsa(q_dev, k_dev, w_dev, chunk_start_idx=chunk_start, program_config=cfg)
         )
-        assert_indexer_match(out, indexer_score_ref(q, k, w, chunk_start), sq, t, check_neg=True)
+        assert_indexer_match(out, indexer_score_dsa_ref(q, k, w, chunk_start), sq, t, check_neg=True)
     assert device.num_program_cache_entries() == 2, "two distinct T must build two programs (T is hashed)"
 
 
@@ -494,7 +496,7 @@ def _check_kv_len(out, q, k, w, kv_len):
     of the [1,1,Sq,T] output is the stale tail and is sliced off)."""
     c = KV_LEN
     assert out.shape == (1, 1, c["sq"], c["t"])
-    ref = indexer_score_ref(q, k[:, :, :kv_len, :], w, c["chunk_start"])  # [1,1,Sq,kv_len]
+    ref = indexer_score_dsa_ref(q, k[:, :, :kv_len, :], w, c["chunk_start"])  # [1,1,Sq,kv_len]
     assert_indexer_match(out[:, :, :, :kv_len], ref, c["sq"], kv_len, check_neg=True)
 
 
@@ -609,7 +611,7 @@ def test_indexer_score_msa_compute_paths(device, q_chunk, k_chunk, head_group):
     q, k, _ = make_inputs(heads, dim, sq, t)
     out = run_msa(q, k, chunk_start, device, scale=scale, program_config=cfg)
     w_scale = torch.full((1, heads, sq, 1), scale, dtype=torch.bfloat16)  # MSA's constant gate = scale
-    ref = indexer_score_ref(q, k, w_scale, chunk_start, apply_relu=False)
+    ref = indexer_score_msa_ref(q, k, w_scale, chunk_start)
     assert_indexer_match(out, ref, sq, t)
 
 
@@ -642,7 +644,7 @@ def test_indexer_score_m3_per_group(device, k_dtype, q_dtype, sp_rank):
     q, k, _ = make_inputs(heads, dim, sq, t)
     out = run_msa(q, k, chunk_start, device, scale=scale, program_config=cfg, q_dtype=q_dtype, k_dtype=k_dtype)
     w_scale = torch.full((1, heads, sq, 1), scale, dtype=torch.bfloat16)
-    ref = indexer_score_ref(q, k, w_scale, chunk_start, apply_relu=False)
+    ref = indexer_score_msa_ref(q, k, w_scale, chunk_start)
     assert_indexer_match(out, ref, sq, t)
 
 
@@ -666,7 +668,7 @@ def test_indexer_score_multigroup(device, heads, num_groups):
     q, k, _ = make_inputs(heads, dim, sq, t)
     out = run_msa(q, k, chunk_start, device, scale=scale, num_groups=num_groups, program_config=cfg)
     w_scale = torch.full((1, heads, sq, 1), scale, dtype=torch.bfloat16)  # MSA's constant gate = scale
-    ref = indexer_score_grouped_ref(q, k, w_scale, chunk_start, num_groups, apply_relu=False)
+    ref = indexer_score_msa_ref(q, k, w_scale, chunk_start, num_groups)
     assert_grouped_match(out, ref, num_groups, sq, t)
 
 
@@ -682,7 +684,7 @@ def test_indexer_score_multigroup_m3(device):
     q, k, _ = make_inputs(heads, dim, sq, t)
     out = run_msa(q, k, chunk_start, device, scale=scale, num_groups=num_groups, program_config=cfg)
     w_scale = torch.full((1, heads, sq, 1), scale, dtype=torch.bfloat16)
-    ref = indexer_score_grouped_ref(q, k, w_scale, chunk_start, num_groups, apply_relu=False)
+    ref = indexer_score_msa_ref(q, k, w_scale, chunk_start, num_groups)
     assert_grouped_match(out, ref, num_groups, sq, t)
 
 
@@ -736,7 +738,7 @@ def test_indexer_score_compute_kernel_config(device, math_fidelity):
     ckc = ttnn.init_device_compute_kernel_config(device.arch(), math_fidelity=math_fidelity)
     q, k, w = make_inputs(heads, dim, sq, t)
     out = run_dsa(q, k, w, chunk_start, device, program_config=cfg, compute_kernel_config=ckc)
-    ref = indexer_score_ref(q, k, w, chunk_start)
+    ref = indexer_score_dsa_ref(q, k, w, chunk_start)
     assert_indexer_match(out, ref, sq, t, check_neg=True)
 
 
@@ -932,7 +934,7 @@ def _per_sp_ref(q_g, k_g, w_g, sp_count, history):
     refs = []
     for sp in range(sp_count):
         sl = slice(sp * QB_SQ, (sp + 1) * QB_SQ)
-        refs.append(indexer_score_ref(q_g[:, :, sl, :], k_g, w_g[:, :, sl, :], history + sp * QB_SQ))
+        refs.append(indexer_score_dsa_ref(q_g[:, :, sl, :], k_g, w_g[:, :, sl, :], history + sp * QB_SQ))
     return torch.cat(refs, dim=2)
 
 
@@ -1055,12 +1057,12 @@ M3_QB_SCALE = QB_DIM**-0.5  # 1/sqrt(d), the M3 indexer scale (folded into the c
 
 def _msa_per_sp_ref(q_g, k_g, sp_count, history):
     """MSA reference: each SP rank's raw-dot, scale-gated, head-summed score (chunk_start = history + sp*Sq),
-    concatenated along seq. No learned gates -> a constant M3_QB_SCALE gate with apply_relu=False."""
+    concatenated along seq. No learned gates -> a constant M3_QB_SCALE gate, raw dot (no relu)."""
     w = torch.full((1, q_g.shape[1], QB_SQ, 1), M3_QB_SCALE, dtype=torch.bfloat16)
     refs = []
     for sp in range(sp_count):
         sl = slice(sp * QB_SQ, (sp + 1) * QB_SQ)
-        refs.append(indexer_score_ref(q_g[:, :, sl, :], k_g, w, history + sp * QB_SQ, apply_relu=False))
+        refs.append(indexer_score_msa_ref(q_g[:, :, sl, :], k_g, w, history + sp * QB_SQ))
     return torch.cat(refs, dim=2)
 
 
@@ -1194,7 +1196,7 @@ _MATH_UTIL_CASES = [
         "test_indexer_score_msa_m3_perf_impl",
         "ttnn_indexer_score_msa_m3",
         lambda: m3_valid_tiles() * (32 * 32) * (2 * M3_DIM),
-        44.1,
+        43.55,
     ),
 ]
 
@@ -1258,7 +1260,7 @@ BLOCK_POOL_BS = 128  # MiniMax M3 sparse_block_size
 @pytest.mark.parametrize("k_dtype", [ttnn.bfloat16, ttnn.bfloat8_b], ids=["k_bf16", "k_bfp8"])
 def test_indexer_score_block_pool(device, k_dtype, num_groups):
     """block_size=128 block-max-pool on a small MSA shape. Small chunk_start -> some blocks fully future
-    (-inf) and one straddles the causal boundary. Checked per group against block_max_pool_ref. 0.995 PCC
+    (-inf) and one straddles the causal boundary. Checked per group against indexer_score_msa_ref. 0.995 PCC
     floor: block-max amplifies the bf16 raw-dot error; the pool itself is pinned exact by the tests below."""
     heads, dim, sq, t = 4, GLX_DIM, 128, 2048
     chunk_start = 512  # leaves fully-future blocks for early queries + a straddling block
@@ -1277,9 +1279,7 @@ def test_indexer_score_block_pool(device, k_dtype, num_groups):
         program_config=cfg,
     )
     w_scale = torch.full((1, heads, sq, 1), scale, dtype=torch.bfloat16)
-    ref = block_max_pool_ref(
-        indexer_score_grouped_ref(q, k, w_scale, chunk_start, num_groups, apply_relu=False), BLOCK_POOL_BS, chunk_start
-    )
+    ref = indexer_score_msa_ref(q, k, w_scale, chunk_start, num_groups, block_size=BLOCK_POOL_BS)
     assert_pooled_match(out, ref, num_groups, sq, t // BLOCK_POOL_BS, pcc_floor=0.995)
 
 
@@ -1305,9 +1305,7 @@ def test_indexer_score_block_pool_m3(device, k_dtype, sp_rank):
         program_config=cfg,
     )
     w_scale = torch.full((1, heads, sq, 1), scale, dtype=torch.bfloat16)
-    ref = block_max_pool_ref(
-        indexer_score_grouped_ref(q, k, w_scale, chunk_start, heads, apply_relu=False), BLOCK_POOL_BS, chunk_start
-    )
+    ref = indexer_score_msa_ref(q, k, w_scale, chunk_start, heads, block_size=BLOCK_POOL_BS)
     # 0.995 floor: block-max amplifies the bf16 raw-dot error; the exact pool logic is pinned by the -inf
     # map here and by test_indexer_score_block_pool_exact_vs_unpooled.
     assert_pooled_match(out, ref, heads, sq, t // BLOCK_POOL_BS, pcc_floor=0.995)
@@ -1324,7 +1322,7 @@ def test_indexer_score_block_pool_exact_vs_unpooled(device):
     unpooled = run_msa(q, k, chunk_start, device, num_groups=heads, program_config=cfg)
     pooled = run_msa(q, k, chunk_start, device, num_groups=heads, block_size=BLOCK_POOL_BS, program_config=cfg)
     # torch max over the op's own [1,G,Sq,T] scores, with the same forced-local (+inf) the pooled path applies.
-    ref = block_max_pool_ref(unpooled.float(), BLOCK_POOL_BS, chunk_start)
+    ref = msa_block_max_pool(unpooled.float(), BLOCK_POOL_BS, chunk_start)
     masked = ref == float("-inf")
     assert torch.equal(pooled <= torch.finfo(torch.bfloat16).min, masked)
     # bf16 max is exact selection of identical values -> the visible block maxes must match bit-for-bit
@@ -1353,7 +1351,7 @@ def test_indexer_score_block_pool_large_blocks_per_unit(device, num_groups, bloc
     cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=k_chunk_size, head_group_size=0)
     unpooled = run_msa(q, k, chunk_start, device, num_groups=num_groups, program_config=cfg)
     pooled = run_msa(q, k, chunk_start, device, num_groups=num_groups, block_size=block_size, program_config=cfg)
-    ref = block_max_pool_ref(unpooled.float(), block_size, chunk_start)
+    ref = msa_block_max_pool(unpooled.float(), block_size, chunk_start)
     masked = ref == float("-inf")
     assert torch.equal(pooled <= torch.finfo(torch.bfloat16).min, masked)
     assert torch.equal(pooled[~masked].float(), ref[~masked])

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -2,26 +2,28 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Tests for the DeepSeek-V3.2 DSA ``indexer_score`` op (GLM5 and DSv32 deployments).
+Tests for the two lightning-indexer scorers that share one device op:
 
-    score[b, s, t] = sum_h relu(q[b, h, s, :] . k[b, t, :]) * w[b, h, s]
+  indexer_score_dsa - DeepSeek-V3.2 DSA / GLM-5:
+      score[b, 0, s, t] = sum_h relu(q[b,h,s,:] . k[b,t,:]) * w[b,h,s]
+      ReLU + learned per-head gates, ALL heads summed into one row [B,1,Sq,T].
 
-Causality from scalar ``chunk_start``: key ``t`` visible to query ``s`` iff
-``t <= chunk_start + s``; future columns are -inf.
+  indexer_score_msa - MiniMax M3 MSA:
+      score[b, g, s, t] = sum_{h in group g} (q[b,h,s,:] . k[b,t,:]) * scale
+      Raw dot, no learned gates (just a 1/sqrt(d) ``scale``), Hi heads partitioned into
+      ``num_groups`` GQA groups summed within each group (one plane per group), optionally
+      block-max-pooled (``block_size>0``) to [B,G,Sq,T/block_size] for the block top-k.
 
-Two deployments, both Galaxy chunked prefill (50K history + 5K chunk =
-55K all-gathered keys; the 5K-query chunk is sharded SP=8 -> 640 queries/device):
+Both share the factory + kernels (the flavour is compile-time args). Causality: key ``t``
+visible to query ``s`` iff ``t <= chunk_start + s``; future columns/blocks are -inf.
 
-    GLM5   -  8 heads (per-device indexer)
-    DSv32  - 16 heads (64-head indexer split across TP=4; the op sums only its
-             heads and the -inf mask is head-independent, so -inf survives the
-             cross-TP sum)
+Deployments are Galaxy chunked prefill (50K history + 5K chunk = 55K keys; the chunk is SP=8
+-> 640 q/device): GLM5 (8h), DSv32 (16h, 64-head DSA split across TP=4), M3 (MSA per-GQA-group,
+block-max-pooled). Most cases run on one chip with explicit ``chunk_start`` (``sp_rank`` =
+ring position); the QuietBox tests derive ``chunk_start`` per device from the mesh coordinate.
 
-We test on single chip with an explicit ``chunk_start``, ``sp_rank`` selecting the ring
-position. The multi-device QuietBox tests at the end instead derive ``chunk_start`` per
-device from the real mesh coordinate (one hash-excluded program serving every SP rank).
-This file is deliberately narrow (GLM5/DSv32 shapes only); broader knob/corner/validation
-coverage will be migrated in separately.
+Run all (perf/tracy self-skip unless INDEXER_SCORE_PERF_CHECKS=1):
+    scripts/run_safe_pytest.sh --run-all <this file>
 """
 
 import os
@@ -46,16 +48,40 @@ GLX_CASES = [("glm5", 8), ("dsv32", 16)]
 GLX_IDS = [c[0] for c in GLX_CASES]
 
 
-def indexer_score_ref(q, k, w, chunk_start):
-    """Per-head fp32 accumulation (a full [Hi,Sq,T] tensor is many GB at GLX sizes)."""
+def indexer_score_ref(q, k, w, chunk_start, apply_relu=True):
+    """Per-head fp32 accumulation (a full [Hi,Sq,T] tensor is many GB at GLX sizes).
+
+    apply_relu=True  -> sum_h relu(q.kT) * w   (DeepSeek-V3.2 / GLM-5 lightning indexer)
+    apply_relu=False -> sum_h (q.kT)    * w    (MiniMax M3 MSA: raw dot, scale folded into w)
+    """
     b, hi, sq, _ = q.shape
     t = k.shape[2]
     q, k, w = q.float(), k.float(), w.float()
     score = torch.zeros(b, sq, t)
     for h in range(hi):
-        score += torch.relu(q[:, h] @ k[:, 0].transpose(-2, -1)) * w[:, h]
+        qk = q[:, h] @ k[:, 0].transpose(-2, -1)
+        score += (torch.relu(qk) if apply_relu else qk) * w[:, h]
     future = torch.arange(t).unsqueeze(0) > chunk_start + torch.arange(sq).unsqueeze(1)
     return score.masked_fill(future, float("-inf")).unsqueeze(1)
+
+
+def indexer_score_grouped_ref(q, k, w, chunk_start, num_groups, apply_relu=True):
+    """Per-GQA-group reference: partition the Hi heads into num_groups contiguous groups of Hi/num_groups
+    and sum act(q.kT)*w WITHIN each group only -> [b, num_groups, sq, t]. num_groups==1 == indexer_score_ref.
+    """
+    b, hi, sq, _ = q.shape
+    t = k.shape[2]
+    hog = hi // num_groups
+    q, k, w = q.float(), k.float(), w.float()
+    future = torch.arange(t).unsqueeze(0) > chunk_start + torch.arange(sq).unsqueeze(1)
+    planes = []
+    for g in range(num_groups):
+        score = torch.zeros(b, sq, t)
+        for h in range(g * hog, (g + 1) * hog):
+            qk = q[:, h] @ k[:, 0].transpose(-2, -1)
+            score += (torch.relu(qk) if apply_relu else qk) * w[:, h]
+        planes.append(score.masked_fill(future, float("-inf")))
+    return torch.stack(planes, dim=1)  # [b, num_groups, sq, t]
 
 
 def make_inputs(heads, dim, sq, t, seed=42):
@@ -75,7 +101,14 @@ def to_device(t, device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT):
     return ttnn.from_torch(t, device=device, layout=layout, dtype=dtype)
 
 
-def run_indexer(
+def _extra_kwargs(program_config, compute_kernel_config):
+    kwargs = {} if program_config is None else {"program_config": program_config}
+    if compute_kernel_config is not None:
+        kwargs["compute_kernel_config"] = compute_kernel_config
+    return kwargs
+
+
+def run_dsa(
     q,
     k,
     w,
@@ -86,19 +119,45 @@ def run_indexer(
     k_dtype=ttnn.bfloat16,
     compute_kernel_config=None,
 ):
-    """Run the device op and return the row-major bf16 score as a torch tensor.
+    """Run indexer_score_dsa (relu + learned gates + head-sum) and return the bf16 score as torch.
 
     q (srcB) and k (srcA) may be bfp8_b; weights stay bf16.
     """
-    kwargs = {} if program_config is None else {"program_config": program_config}
-    if compute_kernel_config is not None:
-        kwargs["compute_kernel_config"] = compute_kernel_config
-    out = ttnn.experimental.indexer_score(
+    out = ttnn.experimental.indexer_score_dsa(
         to_device(q, device, dtype=q_dtype),
         to_device(k, device, dtype=k_dtype),
         to_device(w, device),
         chunk_start_idx=chunk_start,
-        **kwargs,
+        **_extra_kwargs(program_config, compute_kernel_config),
+    )
+    return ttnn.to_torch(out)
+
+
+def run_msa(
+    q,
+    k,
+    chunk_start,
+    device,
+    scale=1.0,
+    num_groups=1,
+    block_size=0,
+    program_config=None,
+    q_dtype=ttnn.bfloat16,
+    k_dtype=ttnn.bfloat16,
+    compute_kernel_config=None,
+):
+    """Run indexer_score_msa (raw dot, constant `scale` gate, per-group planes) and return torch.
+
+    No weights tensor: M3 has no learned gates, only `scale` (run as a constant gate in-op).
+    """
+    out = ttnn.experimental.indexer_score_msa(
+        to_device(q, device, dtype=q_dtype),
+        to_device(k, device, dtype=k_dtype),
+        chunk_start_idx=chunk_start,
+        scale=scale,
+        num_groups=num_groups,
+        block_size=block_size,
+        **_extra_kwargs(program_config, compute_kernel_config),
     )
     return ttnn.to_torch(out)
 
@@ -118,15 +177,47 @@ def assert_indexer_match(out, ref, sq, t, check_neg=False):
         assert (ref[~masked] < 0).any()
 
 
+def assert_grouped_match(out, ref, num_groups, sq, t):
+    """Per-group [1,G,Sq,T] check: exact -inf map + PCC>=0.999 (cross-group leakage fails the PCC)."""
+    assert out.shape == (1, num_groups, sq, t)
+    masked = ref == float("-inf")
+    assert torch.equal(out <= torch.finfo(torch.bfloat16).min, masked)
+    a, b = out[~masked].flatten().float(), ref[~masked].flatten().float()
+    pcc = torch.corrcoef(torch.stack([a, b]))[0, 1].item()
+    assert pcc >= 0.999, f"PCC {pcc} < 0.999"
+
+
+def block_max_pool_ref(scores, block_size, chunk_start):
+    """Reference block-max-pool: max over each block_size-key block of the causal-masked scores
+    [b,g,sq,t] -> [b,g,sq,t//block_size]. A fully-future block is -inf. Then forced-local (M3
+    sparse_local_block=1): each query's own block (= (chunk_start + s) // block_size) is set to +inf."""
+    b, g, sq, t = scores.shape
+    nb = t // block_size
+    pooled = scores.reshape(b, g, sq, nb, block_size).amax(dim=-1)
+    local = (chunk_start + torch.arange(sq)) // block_size  # each query's own block column [sq]
+    pooled[:, :, torch.arange(sq), local] = float("inf")
+    return pooled
+
+
+def assert_pooled_match(out, ref, num_groups, sq, nblocks, pcc_floor=0.999):
+    """Pooled [1,G,Sq,nblocks] check: exact -inf map + exact +inf (forced-local) map + PCC on the rest.
+    block-max amplifies the bf16 per-token error, so the PCC floor is relaxed for the large-T shape."""
+    assert out.shape == (1, num_groups, sq, nblocks), f"{out.shape} != {(1, num_groups, sq, nblocks)}"
+    masked = ref == float("-inf")
+    assert torch.equal(out <= torch.finfo(torch.bfloat16).min, masked)
+    forced = ref == float("inf")  # forced-local block (sparse_local_block=1)
+    assert torch.equal(out == float("inf"), forced), "forced-local +inf block mismatch"
+    keep = ~masked & ~forced
+    a, b = out[keep].flatten().float(), ref[keep].flatten().float()
+    pcc = torch.corrcoef(torch.stack([a, b]))[0, 1].item()
+    assert pcc >= pcc_floor, f"PCC {pcc} < {pcc_floor}"
+
+
 def glx_config(heads):
     """GLX chunked-prefill knobs for the two deployments (GLM5 8h, DSv32 16h).
 
-    - head_group_size=0 keeps all heads resident; head streaming re-reads q per output tile and is
-      ~24x slower, so never used here.
-    - QC=2 (q_chunk_size=64) reuses each resident K chunk across 2 q-rows, ~2x fewer redundant K
-      reads (heads8 sp7 bfp8 0.73 -> 0.48 ms). Fits L1 for both 8 and 16 heads.
-    - k_chunk: GLM5 (8h) uses KC=16 (k_chunk=512), the compute-ceiling optimum at 8 heads; DSv32
-      (16h) is matmul-bound and stays KC=8 (k_chunk=256).
+    head_group_size=0 keeps all heads resident (streaming is ~24x slower). QC=2 reuses each K chunk
+    across 2 q-rows (~2x fewer K reads). k_chunk: GLM5 KC=16 (compute optimum), DSv32 KC=8 (matmul-bound).
     """
     return ttnn.IndexerScoreProgramConfig(
         q_chunk_size=64,
@@ -146,7 +237,7 @@ def test_indexer_score_accuracy(device, sp_rank, q_dtype, case_id, heads):
     """
     chunk_start = GLX_HISTORY + sp_rank * GLX_SQ
     q, k, w = make_inputs(heads, GLX_DIM, GLX_SQ, GLX_T)
-    out = run_indexer(
+    out = run_dsa(
         q, k, w, chunk_start, device, program_config=glx_config(heads), q_dtype=q_dtype, k_dtype=ttnn.bfloat8_b
     )
     ref = indexer_score_ref(q, k, w, chunk_start)
@@ -164,7 +255,7 @@ MINI = dict(heads=64, dim=128, sq=64, t=256)  # 64 heads, D=128, Sq=2 tiles, T=8
 def _run_and_check(device, heads, dim, sq, t, chunk_start, q_chunk, k_chunk, head_group):
     cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=q_chunk, k_chunk_size=k_chunk, head_group_size=head_group)
     q, k, w = make_inputs(heads, dim, sq, t)
-    out = run_indexer(q, k, w, chunk_start, device, program_config=cfg)
+    out = run_dsa(q, k, w, chunk_start, device, program_config=cfg)
     ref = indexer_score_ref(q, k, w, chunk_start)
     assert_indexer_match(out, ref, sq, t, check_neg=True)
 
@@ -225,8 +316,7 @@ def test_indexer_score_knobs(device, q_chunk, k_chunk, head_group, chunk_start):
 )
 def test_indexer_score_shapes(device, heads, dim, sq, t, chunk_start, q_chunk, k_chunk, head_group):
     """Shape/geometry coverage: prefill corners, single/partial k-tiles, narrow/wide head dims, KC not
-    dividing Tt (partial last unit clipped by the writer), and a multicore QC=2 split where a single
-    q-row-group is dealt across cores."""
+    dividing Tt (partial last unit), and a multicore QC=2 split."""
     _run_and_check(device, heads, dim, sq, t, chunk_start, q_chunk, k_chunk, head_group)
 
 
@@ -282,7 +372,7 @@ def test_indexer_score_indexed_cache(device):
 
     def run(b):
         return ttnn.to_torch(
-            ttnn.experimental.indexer_score(
+            ttnn.experimental.indexer_score_dsa(
                 q_dev, k_dev, w_dev, chunk_start_idx=c["chunk_start"], program_config=cfg, cache_batch_idx=b
             )
         )
@@ -309,7 +399,7 @@ def test_indexer_score_indexed_cache_nd_sharded_k(device):
 
     for b in range(B):
         out = ttnn.to_torch(
-            ttnn.experimental.indexer_score(
+            ttnn.experimental.indexer_score_dsa(
                 q_dev, k_dev, w_dev, chunk_start_idx=c["chunk_start"], program_config=cfg, cache_batch_idx=b
             )
         )
@@ -328,11 +418,11 @@ def test_indexer_score_indexed_cache_rejects_oob(device, expect_error):
 
     # Warm the program cache with a valid slot; an OOB slot then hits the SAME program (same hash) and must
     # still be rejected by the cache-hit validation.
-    ttnn.experimental.indexer_score(
+    ttnn.experimental.indexer_score_dsa(
         q_dev, k_dev, w_dev, chunk_start_idx=c["chunk_start"], program_config=cfg, cache_batch_idx=0
     )
     with expect_error(RuntimeError, "cache_batch_idx"):
-        ttnn.experimental.indexer_score(
+        ttnn.experimental.indexer_score_dsa(
             q_dev, k_dev, w_dev, chunk_start_idx=c["chunk_start"], program_config=cfg, cache_batch_idx=B
         )
 
@@ -346,7 +436,7 @@ def test_indexer_score_indexed_cache_requires_idx_for_multislot(device, expect_e
     q, w, k_cache = _indexed_inputs(2)  # B=2 slots, but no cache_batch_idx supplied below
     q_dev, w_dev, k_dev = to_device(q, device), to_device(w, device), to_device(k_cache, device)
     with expect_error(RuntimeError, "batch must be 1"):
-        ttnn.experimental.indexer_score(q_dev, k_dev, w_dev, chunk_start_idx=c["chunk_start"], program_config=cfg)
+        ttnn.experimental.indexer_score_dsa(q_dev, k_dev, w_dev, chunk_start_idx=c["chunk_start"], program_config=cfg)
 
 
 def test_indexer_score_rejects_sharded_q(device, expect_error):
@@ -359,7 +449,7 @@ def test_indexer_score_rejects_sharded_q(device, expect_error):
     q_dev = ttnn.from_torch(q, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=q_mem)
     w_dev, k_dev = to_device(w, device), to_device(k_cache, device)
     with expect_error(RuntimeError, "interleaved"):
-        ttnn.experimental.indexer_score(q_dev, k_dev, w_dev, chunk_start_idx=c["chunk_start"], program_config=cfg)
+        ttnn.experimental.indexer_score_dsa(q_dev, k_dev, w_dev, chunk_start_idx=c["chunk_start"], program_config=cfg)
 
 
 def test_indexer_score_nd_sharded_k_multi_T(device):
@@ -376,7 +466,7 @@ def test_indexer_score_nd_sharded_k_multi_T(device):
         q_dev, w_dev = to_device(q, device), to_device(w, device)
         k_dev = ttnn.from_torch(k, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=k_mem)
         out = ttnn.to_torch(
-            ttnn.experimental.indexer_score(q_dev, k_dev, w_dev, chunk_start_idx=chunk_start, program_config=cfg)
+            ttnn.experimental.indexer_score_dsa(q_dev, k_dev, w_dev, chunk_start_idx=chunk_start, program_config=cfg)
         )
         assert_indexer_match(out, indexer_score_ref(q, k, w, chunk_start), sq, t, check_neg=True)
     assert device.num_program_cache_entries() == 2, "two distinct T must build two programs (T is hashed)"
@@ -419,10 +509,9 @@ def _check_kv_len(out, q, k, w, kv_len):
     ids=["resident", "stream", "chunked_k", "qc2"],
 )
 def test_indexer_score_runtime_kv_len(device, q_chunk, k_chunk, head_group):
-    """One oversized k buffer (T=512) scored at several kv_len <= T: each writes only [0, kv_len) and
-    matches the reference on the first kv_len keys, and growing kv_len on the SAME buffer does NOT recompile
-    (kv_len is a runtime arg excluded from the hash). This is the persistent-cache serving loop, swept over
-    the kernel paths (resident / head-streaming / chunked-k / multi-row group)."""
+    """One oversized k buffer (T=512) scored at several kv_len <= T: each writes only [0, kv_len), matches
+    the reference there, and growing kv_len does NOT recompile (kv_len is hash-excluded). Swept over the
+    kernel paths (resident / streaming / chunked-k / multi-row)."""
     c = KV_LEN
     cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=q_chunk, k_chunk_size=k_chunk, head_group_size=head_group)
     q, w, k = _kv_len_inputs()
@@ -430,7 +519,7 @@ def test_indexer_score_runtime_kv_len(device, q_chunk, k_chunk, head_group):
 
     def run(kv_len):
         return ttnn.to_torch(
-            ttnn.experimental.indexer_score(
+            ttnn.experimental.indexer_score_dsa(
                 q_dev, k_dev, w_dev, chunk_start_idx=c["chunk_start"], program_config=cfg, kv_len=kv_len
             )
         )
@@ -452,26 +541,21 @@ def test_indexer_score_rejects_bad_kv_len(device, expect_error):
     q_dev, w_dev, k_dev = to_device(q, device), to_device(w, device), to_device(k, device)
 
     # Warm the program cache with a valid kv_len; each bad one then hits the SAME program and must still fail.
-    ttnn.experimental.indexer_score(
+    ttnn.experimental.indexer_score_dsa(
         q_dev, k_dev, w_dev, chunk_start_idx=c["chunk_start"], program_config=cfg, kv_len=128
     )
     for bad, why in [(c["t"] + 32, "above T"), (100, "not tile-aligned"), (32, "causal window > kv_len")]:
         with expect_error(RuntimeError, "kv_len"):
-            ttnn.experimental.indexer_score(
+            ttnn.experimental.indexer_score_dsa(
                 q_dev, k_dev, w_dev, chunk_start_idx=c["chunk_start"], program_config=cfg, kv_len=bad
             )
 
 
 @pytest.mark.parametrize("case_id, heads", GLX_CASES, ids=GLX_IDS)
 def test_indexer_score_determinism(device, case_id, heads):
-    """Determinism on the production deployments (GLM5.1 8h, DSv32 16h, GLX chunked-prefill knobs at
-    sp_rank 7, deployed bf16 q + bfp8 k). The op feeds a downstream top-k key selection, so any
-    nondeterminism (reduction order, an unstable -inf boundary) would silently change which keys are kept.
-
-    Follows the ring-joint-SDPA determinism rule: upload the device inputs once and reuse them for every
-    iteration (this tests device-side determinism, not host re-generation), then require each output to be
-    bit-identical to the first run.
-    """
+    """Determinism on the deployments (sp_rank 7, bf16 q + bfp8 k). The op feeds a downstream top-k, so any
+    nondeterminism would silently change which keys are kept. Inputs uploaded once and reused (device-side
+    determinism); every output must be bit-identical to the first run."""
     num_iterations = 10
     chunk_start = GLX_HISTORY + 7 * GLX_SQ  # sp_rank 7: fullest causal case
     cfg = glx_config(heads)
@@ -484,7 +568,7 @@ def test_indexer_score_determinism(device, case_id, heads):
     reference = None
     for i in range(num_iterations):
         out = ttnn.to_torch(
-            ttnn.experimental.indexer_score(q_dev, k_dev, w_dev, chunk_start_idx=chunk_start, program_config=cfg)
+            ttnn.experimental.indexer_score_dsa(q_dev, k_dev, w_dev, chunk_start_idx=chunk_start, program_config=cfg)
         )
         if reference is None:
             reference = out
@@ -502,10 +586,142 @@ def test_indexer_score_determinism(device, case_id, heads):
     logger.info(f"indexer_score {case_id} determinism verified: all {num_iterations} outputs identical")
 
 
-# Blackhole post-commit / sanity coverage reuses test_indexer_score_accuracy above: the CI entry in
-# tests/pipeline_reorg/ttnn-tests.yaml selects its sp_rank-7 GLM5.1/DSv32 cases via `-k "accuracy and
-# rank7"`. No separate post-commit test (that would re-run the same cases under nightly); post-commit just
-# runs a subset of the nightly accuracy parametrization.
+# Post-commit reuses test_indexer_score_accuracy: the CI entry in tests/pipeline_reorg/ttnn-tests.yaml
+# selects its sp_rank-7 cases via `-k "accuracy and rank7"`.
+
+
+# ---------------------------------------------------------------------------
+# MiniMax M3 MSA path (indexer_score_msa): raw dot (no ReLU), no per-head gates, just a 1/sqrt(d) scale.
+# At the group-aligned deployment each device owns one index head (Hi=1), so num_groups=1 and [1,1,Sq,T]
+# is that group's score row for the downstream block-max top-k.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "q_chunk, k_chunk, head_group",
+    [(32, 32, 0), (32, 128, 0), (32, 32, 8)],
+    ids=["fallback_kc1", "fullstrip_kc4", "stream_hb8"],
+)
+def test_indexer_score_msa_compute_paths(device, q_chunk, k_chunk, head_group):
+    """MSA raw dot (no relu) over every compute path: per-column fallback (KC=1), head-major full-strip
+    (KC=4 all-resident), and head streaming (HB=8). MINI shape, num_groups=1, scale gate."""
+    heads, dim, sq, t, chunk_start = MINI["heads"], MINI["dim"], MINI["sq"], MINI["t"], 128
+    scale = dim**-0.5
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=q_chunk, k_chunk_size=k_chunk, head_group_size=head_group)
+    q, k, _ = make_inputs(heads, dim, sq, t)
+    out = run_msa(q, k, chunk_start, device, scale=scale, program_config=cfg)
+    w_scale = torch.full((1, heads, sq, 1), scale, dtype=torch.bfloat16)  # MSA's constant gate = scale
+    ref = indexer_score_ref(q, k, w_scale, chunk_start, apply_relu=False)
+    assert_indexer_match(out, ref, sq, t)
+
+
+def test_indexer_score_dsa_msa_differ(device):
+    """DSA and MSA must differ: with the SAME constant gate the only difference is DSA's relu, so on
+    negative dot products the visible scores must differ (guards against the frontends sharing a path)."""
+    heads, dim, sq, t, chunk_start = MINI["heads"], MINI["dim"], MINI["sq"], MINI["t"], 128
+    scale = 1.0
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=128, head_group_size=0)
+    q, k, _ = make_inputs(heads, dim, sq, t)
+    w_const = torch.full((1, heads, sq, 1), scale, dtype=torch.bfloat16)  # match MSA's gate so only relu differs
+    out_dsa = run_dsa(q, k, w_const, chunk_start, device, program_config=cfg)
+    out_msa = run_msa(q, k, chunk_start, device, scale=scale, program_config=cfg)
+    visible = out_dsa > torch.finfo(torch.bfloat16).min  # exclude the -inf causal mask
+    assert not torch.equal(out_dsa[visible], out_msa[visible]), "DSA == MSA (relu had no effect / shared path)"
+
+
+@pytest.mark.parametrize("sp_rank", [0, 7], ids=["rank0", "rank7"])
+@pytest.mark.parametrize("q_dtype", [ttnn.bfloat16, ttnn.bfloat8_b], ids=["q_bf16", "q_bfp8"])
+@pytest.mark.parametrize("k_dtype", [ttnn.bfloat16, ttnn.bfloat8_b], ids=["k_bf16", "k_bfp8"])
+def test_indexer_score_m3_per_group(device, k_dtype, q_dtype, sp_rank):
+    """MiniMax M3 MSA indexer, per GQA group as deployed at TP=4 (one index head per device, Hi=1): raw
+    dot scaled by 1/sqrt(d), no ReLU, no gates. GLX chunked-prefill geometry; output [1,1,Sq,T] is the
+    group's score row. bfp8 k is the deployed dtype."""
+    heads, dim = 1, GLX_DIM  # one GQA group's single index head, head_dim 128
+    sq, t = GLX_SQ, GLX_T
+    chunk_start = GLX_HISTORY + sp_rank * GLX_SQ
+    scale = dim**-0.5
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=512, head_group_size=0)
+    q, k, _ = make_inputs(heads, dim, sq, t)
+    out = run_msa(q, k, chunk_start, device, scale=scale, program_config=cfg, q_dtype=q_dtype, k_dtype=k_dtype)
+    w_scale = torch.full((1, heads, sq, 1), scale, dtype=torch.bfloat16)
+    ref = indexer_score_ref(q, k, w_scale, chunk_start, apply_relu=False)
+    assert_indexer_match(out, ref, sq, t)
+
+
+# ---------------------------------------------------------------------------
+# indexer_score_msa num_groups > 1: per-GQA-group output [B, G, Sq, T], multiple groups resident on ONE
+# chip (the TP < 4 fallback; the head-reduction is partitioned into G accumulators in-kernel, one plane
+# per group, NO cross-group sum). Requires all heads resident + full-strip (KC>=2).
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "heads, num_groups",
+    [(4, 4), (8, 4), (8, 2), (64, 4)],
+    ids=["g4_hog1", "g4_hog2", "g2_hog4", "g4_hog16"],
+)
+def test_indexer_score_multigroup(device, heads, num_groups):
+    """num_groups>1 emits one plane per group, each summing only its Hi/G heads (no cross-group sum). Spans
+    hog=1/2/4 and the 64-head MINI geometry; each plane checked against the per-group reference (a plane
+    summing the wrong heads fails the PCC)."""
+    dim, sq, t, chunk_start = 128, 64, 256, 128
+    scale = dim**-0.5
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=64, head_group_size=0)  # all resident, KC=2
+    q, k, _ = make_inputs(heads, dim, sq, t)
+    out = run_msa(q, k, chunk_start, device, scale=scale, num_groups=num_groups, program_config=cfg)
+    w_scale = torch.full((1, heads, sq, 1), scale, dtype=torch.bfloat16)  # MSA's constant gate = scale
+    ref = indexer_score_grouped_ref(q, k, w_scale, chunk_start, num_groups, apply_relu=False)
+    assert_grouped_match(out, ref, num_groups, sq, t)
+
+
+def test_indexer_score_multigroup_m3(device):
+    """MiniMax M3 with multiple GQA groups on one chip (TP<4 fallback): 4 groups, one index head each,
+    raw dot, scale gate = 1/sqrt(d). Output [1,4,Sq,T] is the 4 per-group score rows for the downstream
+    block-max top-k.
+    """
+    heads, num_groups, dim = 4, 4, 128
+    sq, t, chunk_start = 128, 256, 128
+    scale = dim**-0.5
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=64, head_group_size=0)
+    q, k, _ = make_inputs(heads, dim, sq, t)
+    out = run_msa(q, k, chunk_start, device, scale=scale, num_groups=num_groups, program_config=cfg)
+    w_scale = torch.full((1, heads, sq, 1), scale, dtype=torch.bfloat16)
+    ref = indexer_score_grouped_ref(q, k, w_scale, chunk_start, num_groups, apply_relu=False)
+    assert_grouped_match(out, ref, num_groups, sq, t)
+
+
+def test_indexer_score_multigroup_equals_single(device):
+    """num_groups=Hi (one head per group) must equal running each head as its own single-group MSA op:
+    plane g of the grouped output == indexer_score_msa(q[:, g:g+1]). Direct cross-check that the in-kernel
+    per-group split matches the validated single-plane path head-for-head (same scale gate for both).
+    """
+    heads, dim, sq, t, chunk_start = 4, 128, 64, 256, 128
+    scale = 1.0  # same constant gate for grouped and single so the comparison is exact
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=64, head_group_size=0)
+    q, k, _ = make_inputs(heads, dim, sq, t)
+    grouped = run_msa(q, k, chunk_start, device, scale=scale, num_groups=heads, program_config=cfg)
+    for g in range(heads):
+        single = run_msa(q[:, g : g + 1], k, chunk_start, device, scale=scale, program_config=cfg)
+        assert torch.equal(grouped[:, g : g + 1], single), f"group {g} plane != single-head op"
+
+
+@pytest.mark.parametrize(
+    "k_chunk, head_group, match",
+    [(32, 0, "k_chunk_size"), (64, 4, "all heads resident")],
+    ids=["kc1_rejected", "streaming_rejected"],
+)
+def test_indexer_score_multigroup_rejects(device, expect_error, k_chunk, head_group, match):
+    """num_groups>1 requires all heads resident + the full-strip path; reject KC<2 and head streaming."""
+    heads, dim, sq, t = 8, 128, 64, 256
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=k_chunk, head_group_size=head_group)
+    q, k, _ = make_inputs(heads, dim, sq, t)
+    with expect_error(RuntimeError, match):
+        run_msa(q, k, 128, device, num_groups=2, program_config=cfg)
+
+
+def test_indexer_score_multigroup_rejects_indivisible(device, expect_error):
+    """num_groups must divide Hi -- e.g. 8 heads / 3 groups is rejected (uneven group sizes)."""
+    heads, dim, sq, t = 8, 128, 64, 256
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=64, head_group_size=0)
+    q, k, _ = make_inputs(heads, dim, sq, t)
+    with expect_error(RuntimeError, "and divide Hi 8"):
+        run_msa(q, k, 128, device, num_groups=3, program_config=cfg)
 
 
 # ---------------------------------------------------------------------------
@@ -519,7 +735,7 @@ def test_indexer_score_compute_kernel_config(device, math_fidelity):
     cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=32, head_group_size=0)
     ckc = ttnn.init_device_compute_kernel_config(device.arch(), math_fidelity=math_fidelity)
     q, k, w = make_inputs(heads, dim, sq, t)
-    out = run_indexer(q, k, w, chunk_start, device, program_config=cfg, compute_kernel_config=ckc)
+    out = run_dsa(q, k, w, chunk_start, device, program_config=cfg, compute_kernel_config=ckc)
     ref = indexer_score_ref(q, k, w, chunk_start)
     assert_indexer_match(out, ref, sq, t, check_neg=True)
 
@@ -531,19 +747,15 @@ def test_indexer_score_rejects_fp32_dest_acc(device, expect_error):
     ckc = ttnn.init_device_compute_kernel_config(device.arch(), fp32_dest_acc_en=True)
     q, k, w = make_inputs(heads, dim, sq, t)
     with expect_error(RuntimeError, "fp32_dest_acc_en=false"):
-        run_indexer(q, k, w, 128, device, program_config=cfg, compute_kernel_config=ckc)
+        run_dsa(q, k, w, 128, device, program_config=cfg, compute_kernel_config=ckc)
 
 
 @pytest.mark.skipif(os.environ.get("CI") == "true", reason="perf test - run locally")
 @pytest.mark.parametrize("case_id, heads", GLX_CASES, ids=GLX_IDS)
 def test_indexer_score_perf(device, case_id, heads):
-    """Wall-clock latency per op for the GLX shape at the fullest causal rank (sp7), bfp8 k.
-
-    Inputs placed on device once (host transfer excluded), run program-cache-warm with a device sync
-    around a fixed iteration count. Host-dispatched single-op latency (includes enqueue overhead, not
-    pure device-kernel time -- use tracy for that). Logged ms is the signal; the assert is only a
-    coarse hang / gross-regression guard (thresholds are board-dependent).
-    """
+    """Wall-clock latency per op for the GLX shape at the fullest causal rank (sp7), bfp8 k. Host-dispatched
+    single-op latency (includes enqueue overhead; use tracy for pure device time). Logged ms is the signal;
+    the assert is a coarse hang/regression guard (board-dependent)."""
     warmup_iters, measured_iters = 3, 20
     chunk_start = GLX_HISTORY + 7 * GLX_SQ
     cfg = glx_config(heads)
@@ -553,7 +765,7 @@ def test_indexer_score_perf(device, case_id, heads):
     w_dev = to_device(w, device)
 
     def run_once():
-        return ttnn.experimental.indexer_score(q_dev, k_dev, w_dev, chunk_start_idx=chunk_start, program_config=cfg)
+        return ttnn.experimental.indexer_score_dsa(q_dev, k_dev, w_dev, chunk_start_idx=chunk_start, program_config=cfg)
 
     for _ in range(warmup_iters):  # compile + program-cache warm
         run_once().deallocate()
@@ -573,16 +785,14 @@ def test_indexer_score_perf(device, case_id, heads):
 
 
 # ---------------------------------------------------------------------------
-# sp_rank 7 math-utilization perf check (tracy device profiler; no accuracy check)
-# math_util = matmul FLOPs / (cores x device cycles x matmul peak); duration from tracy, FLOPs from
-# shape. Run locally with the profiler build (default):
-#   pytest tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py::test_indexer_score_sp7_math_util
+# sp_rank 7 perf helpers (tracy device profiler; no accuracy check). math_util = matmul FLOPs /
+# (cores x device cycles x matmul peak); duration from tracy, FLOPs from shape. Consumed by the three
+# band checks in test_indexer_score_math_util (run with INDEXER_SCORE_PERF_CHECKS=1).
 # ---------------------------------------------------------------------------
 SP7_CHUNK_START = GLX_HISTORY + 7 * GLX_SQ  # fullest causal case (99.5% valid)
 
-# Blackhole matmul peak (tests/nightly/sdpa_perf_utils.py): 4096 mm FLOP/cycle/core at LoFi,
-# halved per extra math-fidelity phase. The `fidelity` param below must match the factory's
-# choice for the measured q/k dtypes (LoFi when both bfp8, else HiFi2).
+# Blackhole matmul peak (tests/nightly/sdpa_perf_utils.py): 4096 mm FLOP/cycle/core at LoFi, halved per
+# extra math-fidelity phase. The band checks measure the deployed HiFi2 path (bf16 q, bfp8 k).
 _BH_CLOCK_GHZ = 1.35
 _MM_FLOPS_PER_CYCLE_PER_CORE = {"LoFi": 4096, "HiFi2": 2048, "HiFi3": 1365, "HiFi4": 1024}
 
@@ -601,156 +811,32 @@ def indexer_mm_flops(valid_tiles, heads):
     return valid_tiles * heads * (32 * 32) * (2 * GLX_DIM)
 
 
-# (heads, q_id, k_id, fidelity) cases for the sp7 profiler tests. fidelity must match the factory:
-# q and k both bfp8 -> LoFi (1 phase), any bf16 input -> HiFi2. id is shared by perf_impl and math_util
-# (which spawns it by id), so they must stay in lockstep. Both deployments run bfp8 k; the q_bfp8 rows
-# add the LoFi path (bfp8 q halves the dominant q read and doubles matmul peak).
-_SP7_PERF_CASES = [
-    (8, "q_bf16", "k_bfp8", "HiFi2"),  # GLM5
-    (16, "q_bf16", "k_bfp8", "HiFi2"),  # DSv32
-    (8, "q_bfp8", "k_bfp8", "LoFi"),  # GLM5, bfp8 q -> LoFi
-    (16, "q_bfp8", "k_bfp8", "LoFi"),  # DSv32, bfp8 q -> LoFi
-]
-_SP7_PERF_IDS = [f"heads{h}_{q}_{k}" for h, q, k, _ in _SP7_PERF_CASES]
-
-
+# perf_impl inner targets profiled by tracy, at the deployed HiFi2 dtypes (bf16 q + bfp8 k). One node per
+# model deployment; test_indexer_score_math_util spawns them by id, so the ids must stay in lockstep.
 @pytest.mark.skipif(os.environ.get("CI") == "true", reason="perf test - run locally with tracy")
-@pytest.mark.parametrize("heads, q_id, k_id", [(h, q, k) for h, q, k, _ in _SP7_PERF_CASES], ids=_SP7_PERF_IDS)
-def test_indexer_score_sp7_perf_impl(device, heads, q_id, k_id):
-    """Inner test profiled by tracy: a few indexer_score ops at GLX sp_rank 7. No accuracy check."""
-    q_dtype = ttnn.bfloat16 if q_id == "q_bf16" else ttnn.bfloat8_b
-    k_dtype = ttnn.bfloat16 if k_id == "k_bf16" else ttnn.bfloat8_b
+@pytest.mark.parametrize("case_id, heads", [("glm5", 8), ("dsv32", 16)], ids=["glm5", "dsv32"])
+def test_indexer_score_sp7_perf_impl(device, case_id, heads):
+    """Inner test profiled by tracy: a few indexer_score_dsa ops at GLX sp_rank 7 (bf16 q, bfp8 k). No
+    accuracy check."""
     q, k, w = make_inputs(heads, GLX_DIM, GLX_SQ, GLX_T)
-    q_dev = to_device(q, device, dtype=q_dtype)
-    k_dev = to_device(k, device, dtype=k_dtype)
+    q_dev = to_device(q, device, dtype=ttnn.bfloat16)
+    k_dev = to_device(k, device, dtype=ttnn.bfloat8_b)
     w_dev = to_device(w, device)
     cfg = glx_config(heads)
     for _ in range(5):  # tracy logs each op's device duration; the outer test takes the min
-        ttnn.experimental.indexer_score(
+        ttnn.experimental.indexer_score_dsa(
             q_dev, k_dev, w_dev, chunk_start_idx=SP7_CHUNK_START, program_config=cfg
         ).deallocate()
     ttnn.synchronize_device(device)
 
 
-@pytest.mark.skipif(os.environ.get("CI") == "true", reason="perf test - run locally with tracy")
-@pytest.mark.parametrize("heads, q_id, k_id, fidelity", _SP7_PERF_CASES, ids=_SP7_PERF_IDS)
-def test_indexer_score_sp7_math_util(heads, q_id, k_id, fidelity):
-    """sp_rank 7 matmul math utilization from a tracy device-kernel-duration measurement.
-
-    Spawns the inner perf_impl test under the device profiler, reads the minimum
-    DEVICE KERNEL DURATION, and reports math_util = mm_flops / (cores * cycles * peak).
-    No accuracy check.
-    """
-    from tracy.process_model_log import run_device_profiler
-    from tests.nightly.sdpa_perf_utils import post_process_ops_log
-
-    subdir = "ttnn_indexer_score_sp7"
-    perf_id = f"heads{heads}_{q_id}_{k_id}"
-    command = (
-        "pytest tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py::"
-        f"test_indexer_score_sp7_perf_impl[{perf_id}]"
-    )
-    with mock.patch.dict(os.environ, {"CI": "false"}):
-        run_device_profiler(command, subdir, device_analysis_types=["device_kernel_duration"])
-    r = post_process_ops_log(
-        subdir,
-        float_columns=["CORE COUNT", "DEVICE KERNEL DURATION [ns]"],
-        columns=["ATTRIBUTES"],
-        sum_vals=False,
-        has_signposts=False,
-    )
-    assert len(r["DEVICE KERNEL DURATION [ns]"]) > 0, "profiler returned no indexer_score ops"
-
-    core_count = int(r["CORE COUNT"][0])
-    duration_ns = float(r["DEVICE KERNEL DURATION [ns]"].min())
-
-    valid_tiles = sp7_valid_tiles()
-    mm_flops = indexer_mm_flops(valid_tiles, heads)
-    peak = _MM_FLOPS_PER_CYCLE_PER_CORE[fidelity]
-    cycles = duration_ns * _BH_CLOCK_GHZ
-    theoretical_flops = core_count * cycles * peak
-    math_util = (mm_flops / theoretical_flops) * 100 if theoretical_flops > 0 else 0.0
-
-    logger.info(
-        f"indexer_score sp7 heads={heads} {q_id} {k_id} ({fidelity}): device={duration_ns / 1e6:.3f} ms, "
-        f"cores={core_count}, V={valid_tiles} tiles, mm={mm_flops / 1e9:.1f} GFLOP, "
-        f"peak={peak} FLOP/cyc/core @ {_BH_CLOCK_GHZ} GHz -> math_util={math_util:.1f}%"
-    )
+INDEXER_PERF_MARGIN = 0.02  # symmetric +/- 2% band on the expected math util (catches regressions AND speedups)
 
 
 # ---------------------------------------------------------------------------
-# Device-perf op-test band check (CI-gated by INDEXER_SCORE_PERF_CHECKS=1; runs in the "ops perf tests"
-# job of perf-device-models). Mirrors SDPA's test_sdpa_perf_check: measure sp_rank-7 HiFi2 math
-# utilization (the deployed bf16 q + bfp8 k path) via tracy and assert it stays within a symmetric +/-
-# band, catching both regressions and unexpected speedups. Expected values were measured on a Blackhole
-# dev board; the band is wider than SDPA's 1% while the op's cross-board perf is still being characterized.
-# ---------------------------------------------------------------------------
-INDEXER_PERF_MARGIN = 0.02  # symmetric +/- 2%
-
-_INDEXER_PERF_CHECK_CONFIGS = [
-    # (case_id, heads, expected_util) at HiFi2 (bf16 q, bfp8 k), sp_rank 7
-    ("glm5", 8, 70.1),
-    ("dsv32", 16, 76.1),
-]
-
-
-@pytest.mark.skipif(
-    os.environ.get("INDEXER_SCORE_PERF_CHECKS") != "1",
-    reason="Set INDEXER_SCORE_PERF_CHECKS=1 to run (CI: ops perf tests job)",
-)
-@pytest.mark.parametrize(
-    "case_id, heads, expected_util",
-    _INDEXER_PERF_CHECK_CONFIGS,
-    ids=[f"{case_id}_heads{heads}" for case_id, heads, _ in _INDEXER_PERF_CHECK_CONFIGS],
-)
-def test_indexer_score_perf_check(case_id, heads, expected_util):
-    """GLM5.1 / DSv32 sp_rank-7 HiFi2 math utilization via tracy, asserted within +/- INDEXER_PERF_MARGIN."""
-    from tracy.process_model_log import run_device_profiler
-    from tests.nightly.sdpa_perf_utils import post_process_ops_log
-
-    subdir = "ttnn_indexer_score_perf_check"
-    perf_id = f"heads{heads}_q_bf16_k_bfp8"  # HiFi2 (bf16 q, bfp8 k)
-    command = (
-        "pytest tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py::"
-        f"test_indexer_score_sp7_perf_impl[{perf_id}]"
-    )
-    with mock.patch.dict(os.environ, {"CI": "false"}):
-        run_device_profiler(command, subdir, device_analysis_types=["device_kernel_duration"])
-    r = post_process_ops_log(
-        subdir,
-        float_columns=["CORE COUNT", "DEVICE KERNEL DURATION [ns]"],
-        columns=["ATTRIBUTES"],
-        sum_vals=False,
-        has_signposts=False,
-    )
-    assert len(r["DEVICE KERNEL DURATION [ns]"]) > 0, "profiler returned no indexer_score ops"
-
-    core_count = int(r["CORE COUNT"][0])
-    duration_ns = float(r["DEVICE KERNEL DURATION [ns]"].min())
-    mm_flops = indexer_mm_flops(sp7_valid_tiles(), heads)
-    peak = _MM_FLOPS_PER_CYCLE_PER_CORE["HiFi2"]
-    cycles = duration_ns * _BH_CLOCK_GHZ
-    utilization = (mm_flops / (core_count * cycles * peak)) * 100 if core_count > 0 else 0.0
-
-    lower = expected_util * (1 - INDEXER_PERF_MARGIN)
-    upper = expected_util * (1 + INDEXER_PERF_MARGIN)
-    logger.info(
-        f"indexer_score perf check {case_id} heads={heads} (HiFi2): duration={duration_ns / 1e6:.3f} ms, "
-        f"math_util={utilization:.2f}% (expected {expected_util:.2f}%, band [{lower:.2f}, {upper:.2f}])"
-    )
-    assert lower <= utilization <= upper, (
-        f"Math utilization {utilization:.2f}% outside band [{lower:.2f}, {upper:.2f}] "
-        f"(expected {expected_util:.2f}%, margin +/- {INDEXER_PERF_MARGIN * 100:.1f}%)"
-    )
-
-
-# ---------------------------------------------------------------------------
-# Generalized-multicast regime coverage (accuracy): exercises the banded-product scheduler paths the
-# small knobs/shapes tests miss -- chiefly G > grid.y (groups phase-stacked onto rows, the case that
-# would deadlock the k-mcast column if rows took uneven group counts), G prime > grid.y (rows_used==1,
-# k-mcast off but still correct), uneven k-band split across columns (U not a multiple of grid.x),
-# partial last band, and phase-stacking under head streaming. Same exact -inf + PCC + negative-gate
-# check as the deployments. q_chunk/k_chunk are in ELEMENTS (tiles*32); head_group 0 = all resident.
+# Generalized-multicast regime coverage (accuracy): scheduler paths the knobs/shapes tests miss -- G >
+# grid.y (groups phase-stacked onto rows), prime G (rows_used==1, k-mcast off), uneven k-band split,
+# partial last band, and phase-stacking under streaming. Same exact -inf + PCC check as the deployments.
 # ---------------------------------------------------------------------------
 @pytest.mark.parametrize(
     "heads, dim, sq, t, chunk_start, q_chunk, k_chunk, head_group",
@@ -785,17 +871,10 @@ def test_indexer_score_genmcast_regimes(device, heads, dim, sq, t, chunk_start, 
 
 
 def test_indexer_score_streaming_qmcast_uneven_bands(device):
-    """Streaming (HB<Hi) q-mcast with an UNEVEN k-band split across a grid row -- the situation a naive
-    per-output-tile q-mcast would deadlock on: cores in the same row own different band counts, so they
-    would issue different numbers of q reads / mcast rendezvous and the row's sender would wait forever
-    on receivers that already finished.
-
-    The dummy-pad scheduler fixes this by padding every core's streaming band loop to max_bands (the
-    row's widest column) with phantom q-only bands, so the q-mcast handshake count is uniform per row.
-    This test pins that the op stays correct (no hang, exact -inf + PCC) on that shape. U=23 is prime,
-    so min(U, grid.x) never divides it -> the band split is uneven (max_bands > min band count) on any
-    Blackhole grid width.
-    """
+    """Streaming (HB<Hi) q-mcast with an UNEVEN k-band split across a grid row -- a naive per-output-tile
+    q-mcast would deadlock (cores in a row issue different q-read counts). The phantom-band pad to
+    max_bands keeps the q-mcast count uniform; this pins no-hang + exact -inf + PCC. U=23 is prime, so the
+    band split is uneven on any Blackhole grid width."""
     heads, dim, sq, t = 16, 128, 128, 736  # Hi=16, Sqt=4, Tt=23
     chunk_start, q_chunk, k_chunk, head_group = 128, 32, 32, 8  # QC=1, KC=1, HB=8 (< Hi -> streaming)
 
@@ -816,13 +895,12 @@ def test_indexer_score_streaming_qmcast_uneven_bands(device):
 # ==============================================================================================
 # Multi-device (QuietBox, 4 BH) tests: PER-DEVICE chunk_start derived from the mesh coordinate.
 # ==============================================================================================
-# Use the `mesh_device` fixture (vs `device` above); they auto-skip on a single chip (the fixture skips
-# when requested devices exceed the machine's), so they no-op on the single-chip nightly and run on a
-# QuietBox. A SINGLE mesh dispatch where each device is a different SP rank: chunk_start = chunk_start_idx
-# + r*Sq (r = linearized index along cluster_axis), one hash-excluded program for all. Two layouts:
+# Use the `mesh_device` fixture (auto-skips on a single chip). A SINGLE mesh dispatch where each device is
+# a different SP rank: chunk_start = chunk_start_idx + r*Sq (r = linearized index along cluster_axis), one
+# hash-excluded program for all. Two layouts:
 #   - 1D SP=4 (flat mesh): history 25600 + chunk 4*640 -> T 28160; cluster_axis unset (linear order).
 #   - 2D SP=2 x TP=2:      history 25600 + chunk 2*640 -> T 26880; cluster_axis = SP axis, heads split.
-# Functional only (exact -inf map + PCC >= 0.999 per SP rank); reuse indexer_score_ref / assert_indexer_match.
+# Functional only (exact -inf map + PCC >= 0.999 per SP rank).
 
 QB_DIM = 128  # indexer head dim
 QB_SQ = 640  # queries per SP rank (preserved from the SP=8 deployment)
@@ -883,7 +961,7 @@ def test_indexer_score_qb_per_device_chunk_start(mesh_device, case_id, heads):
 
     # chunk_start_idx OMITTED -> the op deduces base = T - sp_ring*Sq = QB_HISTORY (sp_ring = 4 devices,
     # cluster_axis unset), then device r gets base + r*Sq. No chunk_start passed at all.
-    out = ttnn.experimental.indexer_score(q_dev, k_dev, w_dev, program_config=glx_config(heads))
+    out = ttnn.experimental.indexer_score_dsa(q_dev, k_dev, w_dev, program_config=glx_config(heads))
     out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=2))
 
     ref = _per_sp_ref(q_g, k_g, w_g, QB_SP, QB_HISTORY)
@@ -902,7 +980,7 @@ def test_indexer_score_qb_one_compile_all_chunk_starts(mesh_device, case_id, hea
 
     entries_before = mesh_device.num_program_cache_entries()
     for base in bases:
-        ttnn.experimental.indexer_score(
+        ttnn.experimental.indexer_score_dsa(
             q_dev, k_dev, w_dev, chunk_start_idx=base, program_config=glx_config(heads)
         ).deallocate()
 
@@ -949,7 +1027,7 @@ def test_indexer_score_qb_sp2_tp2(mesh_device, case_id, heads):
     # chunk_start_idx OMITTED: the op deduces base = T - sp_ring*Sq, where sp_ring is the mesh extent
     # along cluster_axis (2, the SP axis) -- NOT the total device count (4). Device (sp, tp) then gets
     # chunk_start = base + sp*Sq -- identical for both TP devices at SP position sp.
-    out = ttnn.experimental.indexer_score(
+    out = ttnn.experimental.indexer_score_dsa(
         q_dev,
         k_dev,
         w_dev,
@@ -965,3 +1043,339 @@ def test_indexer_score_qb_sp2_tp2(mesh_device, case_id, heads):
 
     ref = _per_sp_ref(q_g, k_g, w_g, QB2_SP, QB_HISTORY)
     assert_indexer_match(out_t, ref, QB2_CHUNK, QB2_T, check_neg=True)
+
+
+# ==============================================================================================
+# Multichip MSA (MiniMax M3): the same per-device chunk_start mechanism as the DSA QB tests, through the
+# indexer_score_msa frontend (raw dot, constant 1/sqrt(d) scale, no weights). num_groups=1 head-sums into
+# one [1,1,Sq,T] plane; the 2x2 case splits heads across TP and sums the partials back. Functional only.
+M3_QB_HEADS = 4  # MiniMax M3 sparse_num_index_heads
+M3_QB_SCALE = QB_DIM**-0.5  # 1/sqrt(d), the M3 indexer scale (folded into the constant gate)
+
+
+def _msa_per_sp_ref(q_g, k_g, sp_count, history):
+    """MSA reference: each SP rank's raw-dot, scale-gated, head-summed score (chunk_start = history + sp*Sq),
+    concatenated along seq. No learned gates -> a constant M3_QB_SCALE gate with apply_relu=False."""
+    w = torch.full((1, q_g.shape[1], QB_SQ, 1), M3_QB_SCALE, dtype=torch.bfloat16)
+    refs = []
+    for sp in range(sp_count):
+        sl = slice(sp * QB_SQ, (sp + 1) * QB_SQ)
+        refs.append(indexer_score_ref(q_g[:, :, sl, :], k_g, w, history + sp * QB_SQ, apply_relu=False))
+    return torch.cat(refs, dim=2)
+
+
+@pytest.mark.parametrize("mesh_device", [QB_SP], indirect=True)
+def test_indexer_score_msa_qb_per_device_chunk_start(mesh_device):
+    """MSA over 4 BH devices (SP=4), each deriving its own chunk_start from its coordinate (cluster_axis
+    unset -> linear order). Raw dot + constant scale, num_groups=1 -> one head-summed [1,1,Sq,T] plane."""
+    q_g, k_g, _ = _global_inputs(M3_QB_HEADS, QB_CHUNK, QB_T, seed=42)
+    shard = ttnn.ShardTensorToMesh(mesh_device, dim=2)
+    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard)
+    k_dev = _to_mesh(mesh_device, k_g, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
+
+    # chunk_start_idx OMITTED -> the op deduces base = T - sp_ring*Sq = QB_HISTORY, then device r gets
+    # base + r*Sq (r = linearized index, cluster_axis unset). The constant gate is synthesized per-device.
+    out = ttnn.experimental.indexer_score_msa(
+        q_dev, k_dev, scale=M3_QB_SCALE, num_groups=1, program_config=glx_config(M3_QB_HEADS)
+    )
+    out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=2))
+
+    ref = _msa_per_sp_ref(q_g, k_g, QB_SP, QB_HISTORY)
+    assert_indexer_match(out_t, ref, QB_CHUNK, QB_T, check_neg=True)
+
+
+@pytest.mark.parametrize("mesh_device", [(QB2_SP, QB2_TP)], ids=["2x2"], indirect=True)
+def test_indexer_score_msa_qb_sp2_tp2(mesh_device):
+    """MSA over a 2x2 mesh: chunk_start derived per-device along cluster_axis (SP), constant across TP; the
+    M3 index heads split across TP. Each device head-sums its half (num_groups=1); the test sums the TP
+    partials (the all-reduce) and validates per SP rank against its own raw-dot, own-chunk_start reference."""
+    q_g, k_g, _ = _global_inputs(M3_QB_HEADS, QB2_CHUNK, QB2_T, seed=42)
+
+    # q: seq (dim 2) sharded along the SP axis, heads (dim 1) along the TP axis. k replicated.
+    mesh_shape = tuple(mesh_device.shape)
+    q_dims = _axis_dims(sp_dim=2, tp_dim=1)
+    shard_q = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=q_dims)
+    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard_q)
+    k_dev = _to_mesh(mesh_device, k_g, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
+
+    # chunk_start_idx OMITTED: base deduced as T - sp_ring*Sq, sp_ring = mesh extent along cluster_axis (2,
+    # the SP axis). Device (sp, tp) gets chunk_start = base + sp*Sq -- identical for both TP devices at sp.
+    out = ttnn.experimental.indexer_score_msa(
+        q_dev,
+        k_dev,
+        cluster_axis=QB2_SP_AXIS,
+        scale=M3_QB_SCALE,
+        num_groups=1,
+        program_config=glx_config(M3_QB_HEADS // QB2_TP),  # per-device head count
+    )
+    out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=q_dims))
+    out_t = out_t.float().sum(dim=1, keepdim=True)  # TP all-reduce: sum the head-partials
+
+    ref = _msa_per_sp_ref(q_g, k_g, QB2_SP, QB_HISTORY)
+    assert_indexer_match(out_t, ref, QB2_CHUNK, QB2_T, check_neg=True)
+
+
+# MiniMax M3 MSA math-utilization perf check (tracy; no accuracy check). ONE device of an SP=8 x TP=4 mesh:
+# TP=4 = one GQA group/device (num_groups=1, Hi=1, no cross-TP all-reduce); SP=8 shards the chunk (640
+# q/device); KV all-gathered (50176 prefix + 5120 chunk = 55296 keys). Same FLOP model as the DSA util
+# test (the scoring matmul is identical). Measured at the deployed fused config: block_size=128 with QC=2
+# and the grid-aligned q/K multicast (see M3_T). With one index head the matmul is a small slice (DMA +
+# block-pool dominate), so util is far below the 8/16-head numbers; the TP<4 fallback (num_groups>1) is higher.
+# ---------------------------------------------------------------------------
+M3_DIM = 128  # sparse_index_dim (== GLX_DIM)
+M3_SQ = 640  # queries/device: 5120 prefill chunk / SP=8
+M3_HISTORY = 50176  # ~50K cached prefix, tile- and k_chunk-aligned
+M3_T = 56320  # 55296 real keys PADDED to 1760*32 = 11*160*32, so Tt=1760 divides the 11-wide BH grid -> the
+# dense deal grid-aligns, enabling the q/K multicast. The 1024 padded keys are causally masked (future), so
+# m3_valid_tiles is unchanged.
+M3_CHUNK_START = M3_HISTORY + 7 * M3_SQ  # sp_rank 7 = fullest-causal device
+
+
+def m3_valid_tiles():
+    """Causal-valid output tiles V at the fullest (sp_rank 7) M3 device: sum_s min(Tt, chunk_t + s + 1)
+    over this device's q-tile-rows (one index head, so no head factor)."""
+    chunk_t = M3_CHUNK_START // 32
+    tt_tiles = M3_T // 32
+    sqt = M3_SQ // 32
+    return sum(min(tt_tiles, chunk_t + s + 1) for s in range(sqt))
+
+
+@pytest.mark.skipif(os.environ.get("CI") == "true", reason="perf test - run locally with tracy")
+def test_indexer_score_msa_m3_perf_impl(device):
+    """Inner test profiled by tracy: a few indexer_score_msa ops for one SP=8 x TP=4 M3 device (1 group,
+    640 q, 55296 kv, raw dot, scale=1/sqrt(d), bf16 q + bfp8 k). No accuracy check."""
+    q, k, _ = make_inputs(1, M3_DIM, M3_SQ, M3_T)
+    q_dev = to_device(q, device, dtype=ttnn.bfloat16)
+    k_dev = to_device(k, device, dtype=ttnn.bfloat8_b)
+    # Deployed config: block_size=128 fuses the per-128-key block max (the writer emits the tiny block-score
+    # tensor, not the full ~70 MB score that made the unfused path memory-bound). QC=2 + grid-aligned q/K
+    # multicast removes K-read redundancy; KC=32 (blocks_per_unit=8) is the largest pool unit that fits L1.
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=1024, head_group_size=0)
+    for _ in range(5):  # tracy logs each op's device duration; the outer test takes the min
+        ttnn.experimental.indexer_score_msa(
+            q_dev,
+            k_dev,
+            chunk_start_idx=M3_CHUNK_START,
+            scale=M3_DIM**-0.5,
+            num_groups=1,
+            block_size=128,
+            program_config=cfg,
+        ).deallocate()
+    ttnn.synchronize_device(device)
+
+
+# ---------------------------------------------------------------------------
+# The three math-utilization band checks (CI-gated by INDEXER_SCORE_PERF_CHECKS=1): GLM5, DSv32, and
+# MiniMax-M3, all at the deployed HiFi2 dtypes (bf16 q + bfp8 k), sp_rank 7. Each spawns its perf_impl
+# under tracy, reads the min DEVICE KERNEL DURATION, computes math_util = matmul FLOPs / (cores x device
+# cycles x matmul peak), and asserts it within +/- INDEXER_PERF_MARGIN of the value measured on a Blackhole
+# dev board. mm_flops is a thunk so the shape-derived FLOP count is evaluated at run time.
+# (M3 is a single index head, so its matmul is a small slice -- the block-pool dominates -- hence the much
+# lower expected util than the multi-head DSA cases.)
+# ---------------------------------------------------------------------------
+_MATH_UTIL_CASES = [
+    # (case_id, perf_impl_node_id, profiler_subdir, mm_flops_thunk, expected_util) -- HiFi2 (bf16 q, bfp8 k)
+    (
+        "glm5",
+        "test_indexer_score_sp7_perf_impl[glm5]",
+        "ttnn_indexer_score_sp7",
+        lambda: indexer_mm_flops(sp7_valid_tiles(), 8),
+        70.1,
+    ),
+    (
+        "dsv32",
+        "test_indexer_score_sp7_perf_impl[dsv32]",
+        "ttnn_indexer_score_sp7",
+        lambda: indexer_mm_flops(sp7_valid_tiles(), 16),
+        76.1,
+    ),
+    (
+        "minimax_m3",
+        "test_indexer_score_msa_m3_perf_impl",
+        "ttnn_indexer_score_msa_m3",
+        lambda: m3_valid_tiles() * (32 * 32) * (2 * M3_DIM),
+        44.1,
+    ),
+]
+
+
+@pytest.mark.skipif(
+    os.environ.get("INDEXER_SCORE_PERF_CHECKS") != "1",
+    reason="Set INDEXER_SCORE_PERF_CHECKS=1 to run (CI: ops perf tests job)",
+)
+@pytest.mark.parametrize(
+    "case_id, perf_id, subdir, mm_flops_thunk, expected_util",
+    _MATH_UTIL_CASES,
+    ids=[c[0] for c in _MATH_UTIL_CASES],
+)
+def test_indexer_score_math_util(case_id, perf_id, subdir, mm_flops_thunk, expected_util):
+    """GLM5 / DSv32 / MiniMax-M3 sp_rank-7 HiFi2 (bf16 q, bfp8 k) matmul math utilization via tracy, asserted
+    within +/- INDEXER_PERF_MARGIN. Spawns the case's perf_impl under the profiler and compares the achieved
+    math_util to the expected value (measured on a BH dev board)."""
+    from tracy.process_model_log import run_device_profiler
+    from tests.nightly.sdpa_perf_utils import post_process_ops_log
+
+    command = "pytest tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py::" + perf_id
+    with mock.patch.dict(os.environ, {"CI": "false"}):
+        run_device_profiler(command, subdir, device_analysis_types=["device_kernel_duration"])
+    r = post_process_ops_log(
+        subdir,
+        float_columns=["CORE COUNT", "DEVICE KERNEL DURATION [ns]"],
+        columns=["ATTRIBUTES"],
+        sum_vals=False,
+        has_signposts=False,
+    )
+    assert len(r["DEVICE KERNEL DURATION [ns]"]) > 0, "profiler returned no indexer_score ops"
+
+    core_count = int(r["CORE COUNT"][0])
+    duration_ns = float(r["DEVICE KERNEL DURATION [ns]"].min())
+    peak = _MM_FLOPS_PER_CYCLE_PER_CORE["HiFi2"]
+    cycles = duration_ns * _BH_CLOCK_GHZ
+    utilization = (mm_flops_thunk() / (core_count * cycles * peak)) * 100 if core_count > 0 else 0.0
+
+    lower = expected_util * (1 - INDEXER_PERF_MARGIN)
+    upper = expected_util * (1 + INDEXER_PERF_MARGIN)
+    logger.info(
+        f"indexer_score math util {case_id} (HiFi2): duration={duration_ns / 1e6:.3f} ms, cores={core_count}, "
+        f"math_util={utilization:.2f}% (expected {expected_util:.2f}%, band [{lower:.2f}, {upper:.2f}])"
+    )
+    assert lower <= utilization <= upper, (
+        f"{case_id} math utilization {utilization:.2f}% outside band [{lower:.2f}, {upper:.2f}] "
+        f"(expected {expected_util:.2f}%, margin +/- {INDEXER_PERF_MARGIN * 100:.1f}%)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# block-max-pool (block_size > 0): MiniMax M3 MSA block scoring. The op fuses the per-block max, so the
+# output is [B, G, Sq, T/block_size]; the downstream topk picks per-group top-k BLOCKS. block_size==0 is
+# byte-identical to before. Pooled-path constraints: T % bs == 0, k_chunk % bs == 0, k_chunk | T, and
+# k_chunk/bs in {8,16,24,32} (16 B output-slice alignment). bs=128, k_chunk=1024 -> blocks_per_unit=8.
+# ---------------------------------------------------------------------------
+BLOCK_POOL_BS = 128  # MiniMax M3 sparse_block_size
+
+
+@pytest.mark.parametrize("num_groups", [1, 4], ids=["g1", "g4"])
+@pytest.mark.parametrize("k_dtype", [ttnn.bfloat16, ttnn.bfloat8_b], ids=["k_bf16", "k_bfp8"])
+def test_indexer_score_block_pool(device, k_dtype, num_groups):
+    """block_size=128 block-max-pool on a small MSA shape. Small chunk_start -> some blocks fully future
+    (-inf) and one straddles the causal boundary. Checked per group against block_max_pool_ref. 0.995 PCC
+    floor: block-max amplifies the bf16 raw-dot error; the pool itself is pinned exact by the tests below."""
+    heads, dim, sq, t = 4, GLX_DIM, 128, 2048
+    chunk_start = 512  # leaves fully-future blocks for early queries + a straddling block
+    scale = dim**-0.5
+    q, k, _ = make_inputs(heads, dim, sq, t)
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=1024, head_group_size=0)
+    out = run_msa(
+        q,
+        k,
+        chunk_start,
+        device,
+        scale=scale,
+        num_groups=num_groups,
+        block_size=BLOCK_POOL_BS,
+        k_dtype=k_dtype,
+        program_config=cfg,
+    )
+    w_scale = torch.full((1, heads, sq, 1), scale, dtype=torch.bfloat16)
+    ref = block_max_pool_ref(
+        indexer_score_grouped_ref(q, k, w_scale, chunk_start, num_groups, apply_relu=False), BLOCK_POOL_BS, chunk_start
+    )
+    assert_pooled_match(out, ref, num_groups, sq, t // BLOCK_POOL_BS, pcc_floor=0.995)
+
+
+@pytest.mark.parametrize("k_dtype", [ttnn.bfloat16, ttnn.bfloat8_b], ids=["k_bf16", "k_bfp8"])
+@pytest.mark.parametrize("sp_rank", [0, 7], ids=["rank0", "rank7"])
+def test_indexer_score_block_pool_m3(device, k_dtype, sp_rank):
+    """MSA block scoring at GLX geometry: 4 GQA groups on one chip (TP<4 fallback), raw dot, scale gate,
+    block_size=128 -> per-group block scores [1,4,640,440]."""
+    heads, dim, sq, t = 4, GLX_DIM, GLX_SQ, GLX_T
+    chunk_start = GLX_HISTORY + sp_rank * GLX_SQ
+    scale = 1.0 / (dim**0.5)
+    q, k, _ = make_inputs(heads, dim, sq, t)
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=1024, head_group_size=0)
+    out = run_msa(
+        q,
+        k,
+        chunk_start,
+        device,
+        scale=scale,
+        num_groups=heads,
+        block_size=BLOCK_POOL_BS,
+        k_dtype=k_dtype,
+        program_config=cfg,
+    )
+    w_scale = torch.full((1, heads, sq, 1), scale, dtype=torch.bfloat16)
+    ref = block_max_pool_ref(
+        indexer_score_grouped_ref(q, k, w_scale, chunk_start, heads, apply_relu=False), BLOCK_POOL_BS, chunk_start
+    )
+    # 0.995 floor: block-max amplifies the bf16 raw-dot error; the exact pool logic is pinned by the -inf
+    # map here and by test_indexer_score_block_pool_exact_vs_unpooled.
+    assert_pooled_match(out, ref, heads, sq, t // BLOCK_POOL_BS, pcc_floor=0.995)
+
+
+def test_indexer_score_block_pool_exact_vs_unpooled(device):
+    """Pool exactness, free of matmul precision: block-max-pooling the op's OWN unpooled bf16 scores must
+    equal the op's pooled output (both share the same matmul accumulator, so only the in-kernel reduce-MAX
+    differs). Isolates the fused pool from the bf16 q.kT error that relaxes the fp32-reference comparison."""
+    heads, dim, sq, t = 4, GLX_DIM, 128, 2048
+    chunk_start = 512
+    q, k, _ = make_inputs(heads, dim, sq, t)
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=1024, head_group_size=0)
+    unpooled = run_msa(q, k, chunk_start, device, num_groups=heads, program_config=cfg)
+    pooled = run_msa(q, k, chunk_start, device, num_groups=heads, block_size=BLOCK_POOL_BS, program_config=cfg)
+    # torch max over the op's own [1,G,Sq,T] scores, with the same forced-local (+inf) the pooled path applies.
+    ref = block_max_pool_ref(unpooled.float(), BLOCK_POOL_BS, chunk_start)
+    masked = ref == float("-inf")
+    assert torch.equal(pooled <= torch.finfo(torch.bfloat16).min, masked)
+    # bf16 max is exact selection of identical values -> the visible block maxes must match bit-for-bit
+    # (forced-local blocks are +inf on both sides: inf == inf under torch.equal).
+    assert torch.equal(pooled[~masked].float(), ref[~masked])
+
+
+@pytest.mark.parametrize(
+    "block_size, k_chunk_size, blocks_per_unit",
+    # blocks_per_unit = KC / block_tiles = k_chunk_size / block_size. Keep KC=32 (same as the passing
+    # tests above, so L1 fits) and shrink block_size to push blocks_per_unit past 8.
+    [
+        (64, 1024, 16),  # block_tiles=2, KC=32 -> 16
+        (32, 1024, 32),  # block_tiles=1, KC=32 -> 32 (max allowed)
+    ],
+    ids=["bpu16", "bpu32"],
+)
+@pytest.mark.parametrize("num_groups", [1, 4], ids=["g1", "g4"])
+def test_indexer_score_block_pool_large_blocks_per_unit(device, num_groups, block_size, k_chunk_size, blocks_per_unit):
+    """blocks_per_unit > 8 routes the in-kernel pool to the library reduce (compute_kernel_lib::reduce)
+    instead of the batched custom reduce (the <=8 fast path). Exact-vs-unpooled pins the reduce bit-for-bit,
+    free of bf16 matmul noise, confirming the fallback lands each block max in col 0 as the writer expects."""
+    heads, dim, sq, t = 4, GLX_DIM, 128, 2048
+    chunk_start = 512
+    q, k, _ = make_inputs(heads, dim, sq, t)
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=k_chunk_size, head_group_size=0)
+    unpooled = run_msa(q, k, chunk_start, device, num_groups=num_groups, program_config=cfg)
+    pooled = run_msa(q, k, chunk_start, device, num_groups=num_groups, block_size=block_size, program_config=cfg)
+    ref = block_max_pool_ref(unpooled.float(), block_size, chunk_start)
+    masked = ref == float("-inf")
+    assert torch.equal(pooled <= torch.finfo(torch.bfloat16).min, masked)
+    assert torch.equal(pooled[~masked].float(), ref[~masked])
+
+
+@pytest.mark.parametrize(
+    "block_size, k_chunk_size, t, match",
+    [
+        # bs=48 is not a multiple of 32 -> rejected before the divisibility checks
+        (48, 1024, 2048, "block_size 48 must be a multiple of 32"),
+        # bs=128, KC=16 -> blocks_per_unit=4, not a multiple of 8 (16 B output-slice alignment)
+        (128, 512, 2048, "to be a multiple of 8 so each unit"),
+        # Tt=80 not divisible by KC=32 -> a partial last work unit
+        (128, 1024, 2560, "to divide T 2560"),
+    ],
+    ids=["bs_not_tile_multiple", "slice_unaligned", "partial_unit"],
+)
+def test_indexer_score_block_pool_validation(device, expect_error, block_size, k_chunk_size, t, match):
+    """The pooled-path constraints are rejected loudly (asserting the SPECIFIC FATAL fires) rather than
+    silently producing a misaligned write -- `match` pins each case to its own guard."""
+    heads, dim, sq = 4, GLX_DIM, 128
+    q, k, _ = make_inputs(heads, dim, sq, t)
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=k_chunk_size, head_group_size=0)
+    with expect_error(RuntimeError, match):
+        run_msa(q, k, 512, device, num_groups=heads, block_size=block_size, program_config=cfg)

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -11,24 +11,28 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
 
-#include "kernels/indexer_score_work_split.hpp"    // banded grid mapping (rows_for_groups / cols_for_bands)
-#include "ttnn/operations/ccl/ccl_common.hpp"      // get_linearized_index_from_physical_coord
-#include "ttnn/operations/creation/creation.hpp"  // ttnn::full for the synthesized constant gate
+#include "kernels/indexer_score_work_split.hpp"  // banded grid mapping (rows_for_groups / cols_for_bands)
+#include "ttnn/operations/ccl/ccl_common.hpp"    // get_linearized_index_from_physical_coord
 
 namespace ttnn::operations::experimental::indexer_score {
 
 namespace {
-// Largest per-device chunk_start = base + max_rank*Sq (max_rank = largest linearized index along
-// cluster_axis, 0 on a single device). Used by the worst-case window check.
-uint32_t max_chunk_start(const operation_attributes_t& attrs, const Tensor& q, uint32_t Sq) {
+// Largest linearized index of q's devices along cluster_axis (0 on a single device). Single source for the
+// worst-case window check (max_chunk_start) and the host-side chunk_start deduction, so a future change to
+// the coord/linearization semantics can't desync the deduced base from the validated window.
+uint32_t max_linearized_rank(const Tensor& q, std::optional<uint32_t> cluster_axis) {
     uint32_t max_rank = 0;
     if (q.device_storage().get_coords().size() > 1) {
         for (const auto& coord : q.device_storage().get_coords()) {
-            max_rank =
-                std::max(max_rank, ttnn::ccl::get_linearized_index_from_physical_coord(q, coord, attrs.cluster_axis));
+            max_rank = std::max(max_rank, ttnn::ccl::get_linearized_index_from_physical_coord(q, coord, cluster_axis));
         }
     }
-    return attrs.chunk_start_idx + max_rank * Sq;
+    return max_rank;
+}
+
+// Largest per-device chunk_start = base + max_rank*Sq. Used by the worst-case window check.
+uint32_t max_chunk_start(const operation_attributes_t& attrs, const Tensor& q, uint32_t Sq) {
+    return attrs.chunk_start_idx + max_linearized_rank(q, attrs.cluster_axis) * Sq;
 }
 
 // Miss-only checks: hash-pinned (placement, non-indexed k batch shape) so they can't differ on a hit. The
@@ -136,6 +140,8 @@ ttsl::hash::hash_t IndexerScoreDeviceOperation::compute_program_hash(
         attrs.apply_relu,
         attrs.num_groups,
         attrs.block_size,
+        attrs.synthesize_gate,  // gate read from DRAM vs filled in-kernel -> different reader binary
+        attrs.gate_scale,       // the in-kernel fill value; distinct scales get distinct programs
         attrs.program_config,
         attrs.compute_kernel_config,
         attrs.cluster_axis.has_value(),
@@ -182,19 +188,24 @@ void IndexerScoreDeviceOperation::validate_on_program_cache_miss(
     validate_runtime_values(attrs, tensor_args);
 
     // Shapes: q [B, Hi, Sq, D], k [B, 1, T, D] (single shared head), weights [B, Hi, Sq, 1].
-    TT_FATAL(q_shape.rank() == 4 && k_shape.rank() == 4 && w_shape.rank() == 4, "q, k, weights must be rank 4");
+    TT_FATAL(q_shape.rank() == 4 && k_shape.rank() == 4, "q, k must be rank 4");
     TT_FATAL(k_shape[1] == 1, "k must be single-head [B, 1, T, D], got {} heads", k_shape[1]);
     TT_FATAL(q_shape[3] == k_shape[3], "q head dim {} != k head dim {}", q_shape[3], k_shape[3]);
-    TT_FATAL(
-        w_shape[1] == q_shape[1] && w_shape[2] == q_shape[2] && w_shape[3] == 1,
-        "weights must be [B, Hi, Sq, 1] matching q [B, Hi, Sq, D]");
-    // q/weights are always batch 1; k's batch is the cache-slot count B, so it is NOT tied to q here.
-    TT_FATAL(q_shape[0] == w_shape[0], "q/weights batch mismatch ({} vs {})", q_shape[0], w_shape[0]);
-    TT_FATAL(q_shape[0] == 1, "q/weights batch 1 only, got {}", q_shape[0]);
+    TT_FATAL(q_shape[0] == 1, "q batch 1 only, got {}", q_shape[0]);
+    // The learned-gate weights are validated only when present; MSA synthesizes a constant gate in-kernel
+    // (the weights handle is an unused q placeholder), so its shape/dtype carry no meaning.
+    if (!attrs.synthesize_gate) {
+        TT_FATAL(w_shape.rank() == 4, "weights must be rank 4");
+        TT_FATAL(
+            w_shape[1] == q_shape[1] && w_shape[2] == q_shape[2] && w_shape[3] == 1,
+            "weights must be [B, Hi, Sq, 1] matching q [B, Hi, Sq, D]");
+        TT_FATAL(q_shape[0] == w_shape[0], "q/weights batch mismatch ({} vs {})", q_shape[0], w_shape[0]);
+        TT_FATAL(w.dtype() == DataType::BFLOAT16, "weights must be bfloat16 (got {})", w.dtype());
+        TT_FATAL(w.layout() == Layout::TILE, "weights must be TILE layout");
+    }
 
     // q/k are matmul inputs (never packed), so each may be bfp8_b (halves BW); both bfp8 -> LoFi, any bf16
-    // -> HiFi2. weights are bf16.
-    TT_FATAL(w.dtype() == DataType::BFLOAT16, "weights must be bfloat16 (got {})", w.dtype());
+    // -> HiFi2.
     TT_FATAL(
         q.dtype() == DataType::BFLOAT16 || q.dtype() == DataType::BFLOAT8_B,
         "q must be bfloat16 or bfloat8_b (got {})",
@@ -203,9 +214,7 @@ void IndexerScoreDeviceOperation::validate_on_program_cache_miss(
         k.dtype() == DataType::BFLOAT16 || k.dtype() == DataType::BFLOAT8_B,
         "k must be bfloat16 or bfloat8_b (got {})",
         k.dtype());
-    TT_FATAL(
-        q.layout() == Layout::TILE && k.layout() == Layout::TILE && w.layout() == Layout::TILE,
-        "q, k, weights must be TILE layout");
+    TT_FATAL(q.layout() == Layout::TILE && k.layout() == Layout::TILE, "q, k must be TILE layout");
 
     // Tile alignment and the causal chunk window.
     const uint32_t Hi = q_shape[1];
@@ -379,6 +388,8 @@ IndexerScoreDeviceOperation::invoke(
     bool apply_relu,
     uint32_t num_groups,
     uint32_t block_size,
+    bool synthesize_gate,
+    float gate_scale,
     const IndexerScoreProgramConfig& program_config,
     const DeviceComputeKernelConfig& compute_kernel_config,
     std::optional<uint32_t> cache_batch_idx,
@@ -391,6 +402,8 @@ IndexerScoreDeviceOperation::invoke(
             .apply_relu = apply_relu,
             .num_groups = num_groups,
             .block_size = block_size,
+            .synthesize_gate = synthesize_gate,
+            .gate_scale = gate_scale,
             .program_config = program_config,
             .compute_kernel_config = compute_kernel_config,
             .cache_batch_idx = cache_batch_idx,
@@ -414,6 +427,8 @@ ttnn::Tensor launch_indexer_score(
     bool apply_relu,
     uint32_t num_groups,
     uint32_t block_size,
+    bool synthesize_gate,
+    float gate_scale,
     const ttnn::operations::experimental::indexer_score::IndexerScoreProgramConfig& program_config,
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
     std::optional<uint32_t> cache_batch_idx,
@@ -431,12 +446,9 @@ ttnn::Tensor launch_indexer_score(
         const uint32_t Sq = q.logical_shape()[2];
         const uint32_t T = k.logical_shape()[2];
         // sp_ring = max_rank + 1 (get_linearized_index returns coord-min; get_topological_dimension would
-        // over-count on a nonzero-offset sub-mesh).
-        uint32_t max_rank = 0;
-        for (const auto& coord : q.device_storage().get_coords()) {  // single device -> max_rank 0
-            max_rank = std::max(max_rank, ttnn::ccl::get_linearized_index_from_physical_coord(q, coord, cluster_axis));
-        }
-        const uint32_t sp_ring = max_rank + 1;
+        // over-count on a nonzero-offset sub-mesh). max_linearized_rank is shared with the validated window.
+        const uint32_t sp_ring =
+            ttnn::operations::experimental::indexer_score::max_linearized_rank(q, cluster_axis) + 1;
         TT_FATAL(
             T >= sp_ring * Sq,
             "indexer_score: cannot deduce chunk_start_idx -- T={} < sp_ring({})*Sq({}). Pass chunk_start_idx "
@@ -465,6 +477,8 @@ ttnn::Tensor launch_indexer_score(
         apply_relu,
         num_groups,
         block_size,
+        synthesize_gate,
+        gate_scale,
         program_config,
         resolved,
         cache_batch_idx,
@@ -485,7 +499,7 @@ ttnn::Tensor indexer_score_dsa(
     std::optional<uint32_t> cache_batch_idx,
     std::optional<uint32_t> kv_len,
     std::optional<uint32_t> cluster_axis) {
-    // DSA/GLM: relu, learned per-head gates, one head-summed plane, no pooling.
+    // DSA/GLM: relu, learned per-head gates, one head-summed plane, no pooling. Reads its real weights tensor.
     return launch_indexer_score(
         q,
         k,
@@ -494,6 +508,8 @@ ttnn::Tensor indexer_score_dsa(
         /*apply_relu=*/true,
         /*num_groups=*/1,
         /*block_size=*/0,
+        /*synthesize_gate=*/false,
+        /*gate_scale=*/1.0f,
         program_config,
         compute_kernel_config,
         cache_batch_idx,
@@ -504,27 +520,27 @@ ttnn::Tensor indexer_score_dsa(
 ttnn::Tensor indexer_score_msa(
     const ttnn::Tensor& q,
     const ttnn::Tensor& k,
+    uint32_t num_groups,
     std::optional<uint32_t> chunk_start_idx,
     float scale,
-    uint32_t num_groups,
     uint32_t block_size,
     const ttnn::operations::experimental::indexer_score::IndexerScoreProgramConfig& program_config,
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
     std::optional<uint32_t> cluster_axis) {
-    // M3 has no learned gates, only a 1/sqrt(d) scale: synthesize a constant gate (= scale) of shape
-    // [B,Hi,Sq,1] so the kernel's gate-multiply path is reused unchanged. The local lives until launch()
-    // returns (where its buffer is read). MSA fixes apply_relu=false; num_groups/block_size are selection knobs.
-    const auto& qs = q.logical_shape();
-    const ttnn::Tensor w =
-        ttnn::full(ttnn::Shape({qs[0], qs[1], qs[2], 1}), scale, DataType::BFLOAT16, Layout::TILE, *q.device());
+    // M3 has no learned gates, only a 1/sqrt(d) scale. Rather than materialize a constant [B,Hi,Sq,1] gate
+    // tensor (an extra fill op dispatched every call), the reader fills cb_w with `scale` in L1 in-kernel
+    // (synthesize_gate); q is passed as the unused weights placeholder so the op infra still has a valid
+    // on-device tensor. MSA fixes apply_relu=false; num_groups/block_size are selection knobs.
     return launch_indexer_score(
         q,
         k,
-        w,
+        /*weights=*/q,
         chunk_start_idx,
         /*apply_relu=*/false,
         num_groups,
         block_size,
+        /*synthesize_gate=*/true,
+        /*gate_scale=*/scale,
         program_config,
         compute_kernel_config,
         /*cache_batch_idx=*/std::nullopt,

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -11,14 +11,15 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
 
-#include "kernels/indexer_score_work_split.hpp"  // shared banded grid mapping (rows_for_groups / cols_for_bands)
-#include "ttnn/operations/ccl/ccl_common.hpp"    // get_linearized_index_from_physical_coord
+#include "kernels/indexer_score_work_split.hpp"    // banded grid mapping (rows_for_groups / cols_for_bands)
+#include "ttnn/operations/ccl/ccl_common.hpp"      // get_linearized_index_from_physical_coord
+#include "ttnn/operations/creation/creation.hpp"  // ttnn::full for the synthesized constant gate
 
 namespace ttnn::operations::experimental::indexer_score {
 
 namespace {
-// Largest per-device chunk_start across the mesh = base + max_rank*Sq, where max_rank is the largest
-// linearized index along cluster_axis (0 on a single device). Used by the worst-case window check.
+// Largest per-device chunk_start = base + max_rank*Sq (max_rank = largest linearized index along
+// cluster_axis, 0 on a single device). Used by the worst-case window check.
 uint32_t max_chunk_start(const operation_attributes_t& attrs, const Tensor& q, uint32_t Sq) {
     uint32_t max_rank = 0;
     if (q.device_storage().get_coords().size() > 1) {
@@ -30,16 +31,14 @@ uint32_t max_chunk_start(const operation_attributes_t& attrs, const Tensor& q, u
     return attrs.chunk_start_idx + max_rank * Sq;
 }
 
-// Miss-only checks: either hash-pinned (placement, non-indexed k batch shape) so they can't differ on a
-// hit, or caller errors the framework rules out anyway (device residency, allocation, same-device) and
-// never checked on a hit pre-PR. The slot/kv_len values that do differ on a hit live in
-// validate_runtime_values.
+// Miss-only checks: hash-pinned (placement, non-indexed k batch shape) so they can't differ on a hit. The
+// slot/kv_len values that do differ on a hit live in validate_runtime_values.
 void validate_static(const operation_attributes_t& attrs, const tensor_args_t& t) {
     const auto& q = t.q;
     const auto& k = t.k;
     const auto& w = t.weights;
-    // On device + allocated. q/weights interleaved; k may be interleaved OR ND-sharded DRAM (the reader's
-    // TensorAccessor handles both; a sharded k pins its bank mapping via the hashed spec).
+    // On device + allocated. q/weights interleaved; k may be interleaved OR ND-sharded DRAM (a sharded k
+    // pins its bank mapping via the hashed spec).
     for (const auto& [tp, name, allow_sharded] :
          {std::tuple{&q, "q", false}, std::tuple{&k, "k", true}, std::tuple{&w, "weights", false}}) {
         TT_FATAL(tp->storage_type() == StorageType::DEVICE, "indexer_score {} must be on device", name);
@@ -51,21 +50,18 @@ void validate_static(const operation_attributes_t& attrs, const tensor_args_t& t
     TT_FATAL(
         q.device() == k.device() && q.device() == w.device(), "indexer_score q, k, weights must be on the same device");
 
-    // Non-indexed k must be single-slot [1,1,T,D]. has_value() and kB are both hashed, so this only fires on
-    // a miss (the indexed slot < B check is a runtime value -> validate_runtime_values).
+    // Non-indexed k must be single-slot [1,1,T,D] (the indexed slot < B check is runtime -> below).
     if (!attrs.cache_batch_idx.has_value()) {
         const uint32_t kB = k.logical_shape()[0];
         TT_FATAL(kB == 1, "indexer_score k batch must be 1 unless cache_batch_idx is set (got {})", kB);
     }
 }
 
-// The slot/kv_len values: hashed only by has_value(), so they can differ on a cache hit and feed kernel
-// addressing (page offset / read width). Cheap integer checks on shape metadata, run on miss AND hit.
+// The slot/kv_len values: hashed only by has_value(), so they can differ on a hit. Run on miss AND hit.
 void validate_runtime_values(const operation_attributes_t& attrs, const tensor_args_t& t) {
     const auto& k = t.k;
 
-    // Indexed KV cache: k is [B,1,T,D]; cache_batch_idx picks a slot (q/weights are batch 1). An
-    // out-of-range slot offsets every k page id OOB.
+    // Indexed KV cache: cache_batch_idx picks a slot of [B,1,T,D] k; an out-of-range slot offsets pages OOB.
     if (attrs.cache_batch_idx.has_value()) {
         const uint32_t kB = k.logical_shape()[0];
         TT_FATAL(
@@ -75,9 +71,8 @@ void validate_runtime_values(const operation_attributes_t& attrs, const tensor_a
             kB);
     }
 
-    // Runtime KV length: k is a persistent buffer of (hashed) length T; kv_len <= T is the valid prefix
-    // this dispatch (value not hashed -> re-checked here). The chunk-window-vs-kv_len bound lives in
-    // validate_chunk_start, which keeps every chunk_start check in one place.
+    // Runtime KV length: kv_len <= T is the valid prefix this dispatch (not hashed -> re-checked here). The
+    // chunk-window-vs-kv_len bound lives in validate_chunk_start.
     if (attrs.kv_len.has_value()) {
         const uint32_t T = k.logical_shape()[2];
         const uint32_t kv_len = attrs.kv_len.value();
@@ -90,9 +85,8 @@ void validate_runtime_values(const operation_attributes_t& attrs, const tensor_a
     }
 }
 
-// Runs on cache miss AND hit (chunk_start is hash-excluded). All chunk_start checks in one place: base
-// alignment, and the fullest device's window against T and -- when set -- kv_len. Per-rank stride Sq is
-// tile-aligned by the shape check, so only the base needs an alignment check.
+// Runs on miss AND hit (chunk_start is hash-excluded). All chunk_start checks in one place: base alignment
+// and the fullest device's window against T and (when set) kv_len.
 void validate_chunk_start(const operation_attributes_t& attrs, const tensor_args_t& t) {
     const uint32_t Sq = t.q.logical_shape()[2];
     const uint32_t T = t.k.logical_shape()[2];
@@ -110,7 +104,7 @@ void validate_chunk_start(const operation_attributes_t& attrs, const tensor_args
         T,
         attrs.chunk_start_idx,
         Sq);
-    // Causal window must also stay inside the valid prefix (kv_len <= T already checked above).
+    // Causal window must also stay inside the valid prefix.
     if (attrs.kv_len.has_value()) {
         const uint32_t kv_len = attrs.kv_len.value();
         TT_FATAL(
@@ -134,11 +128,14 @@ IndexerScoreDeviceOperation::program_factory_t IndexerScoreDeviceOperation::sele
 
 ttsl::hash::hash_t IndexerScoreDeviceOperation::compute_program_hash(
     const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-    // Hash what shapes the binary, NOT the runtime values: chunk_start_idx is EXCLUDED (per-device runtime),
-    // cache_batch_idx / kv_len contribute only has_value() -- so distinct slot / kv_len / chunk_start reuse
-    // one program. cluster_axis IS hashed (fixes each device's linearized index); tensor_args cover dtype +
-    // shape. Do NOT add chunk_start_idx or the slot/kv_len values here or they will recompile.
+    // Hash what shapes the binary, NOT the runtime values: chunk_start_idx is EXCLUDED, cache_batch_idx /
+    // kv_len contribute only has_value() (so distinct slot / kv_len / chunk_start reuse one program).
+    // cluster_axis IS hashed; tensor_args cover dtype + shape. apply_relu / num_groups / block_size pick the
+    // compile-time kernel path, so they MUST be hashed (else DSA vs MSA, or pooled vs unpooled, would collide).
     return tt::tt_metal::operation::hash_operation<IndexerScoreDeviceOperation>(
+        attrs.apply_relu,
+        attrs.num_groups,
+        attrs.block_size,
         attrs.program_config,
         attrs.compute_kernel_config,
         attrs.cluster_axis.has_value(),
@@ -150,7 +147,7 @@ ttsl::hash::hash_t IndexerScoreDeviceOperation::compute_program_hash(
 
 void IndexerScoreDeviceOperation::validate_on_program_cache_hit(
     const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-    // chunk_start, cache slot, and kv_len are all hash-excluded runtime values, so their checks run on hits too.
+    // chunk_start, cache slot, kv_len are hash-excluded runtime values -> re-checked on hits.
     validate_runtime_values(attrs, tensor_args);
     validate_chunk_start(attrs, tensor_args);
 }
@@ -165,14 +162,13 @@ void IndexerScoreDeviceOperation::validate_on_program_cache_miss(
     const auto& k_shape = k.logical_shape();
     const auto& w_shape = w.logical_shape();
 
-    // Blackhole-only: the compute kernel relies on BH fast-untilize + custom BH LLK paths. Enforce in
-    // C++ (not just the pytest skip) so a Wormhole caller fails cleanly instead of hanging at launch.
+    // Blackhole-only: the compute kernel relies on BH fast-untilize + custom BH LLK paths. Enforce in C++
+    // so a Wormhole caller fails cleanly instead of hanging at launch.
     const tt::ARCH arch = tt::tt_metal::hal::get_arch();
     TT_FATAL(arch == tt::ARCH::BLACKHOLE, "indexer_score is only supported on Blackhole, got {}", arch);
 
-    // The compute kernel honors the config's math_fidelity (default: dtype-derived), but its custom
-    // blocked bcast-col LLK + half-sync 8-head subblock are validated only for bf16 DEST in half-sync.
-    // Reject the unvalidated knobs loudly instead of silently building a path that can drop the -inf mask.
+    // The custom blocked bcast-col LLK + half-sync 8-head subblock are validated only for bf16 DEST in
+    // half-sync; reject the unvalidated knobs loudly (a silent path could drop the -inf mask).
     const auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         ttnn::get_compute_kernel_config_args(arch, attrs.compute_kernel_config);
     TT_FATAL(
@@ -180,8 +176,8 @@ void IndexerScoreDeviceOperation::validate_on_program_cache_miss(
         "indexer_score requires fp32_dest_acc_en=false (bf16 DEST; the custom LLK is not validated for fp32 DEST)");
     TT_FATAL(!dst_full_sync_en, "indexer_score requires dst_full_sync_en=false (the kernel is built half-sync)");
 
-    // Placement, layout, same-device and the non-indexed k batch shape are hash-pinned (miss only). The
-    // slot/kv_len runtime values are re-checked on every dispatch (here and on a cache hit).
+    // Placement/layout/same-device and the non-indexed k batch shape are hash-pinned (miss only); the
+    // slot/kv_len runtime values are re-checked every dispatch.
     validate_static(attrs, tensor_args);
     validate_runtime_values(attrs, tensor_args);
 
@@ -192,14 +188,12 @@ void IndexerScoreDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(
         w_shape[1] == q_shape[1] && w_shape[2] == q_shape[2] && w_shape[3] == 1,
         "weights must be [B, Hi, Sq, 1] matching q [B, Hi, Sq, D]");
-    // q/weights are always batch 1; k's batch is the cache-slot count B (checked in validate_static /
-    // validate_runtime_values), so it is intentionally NOT tied to q's batch here.
+    // q/weights are always batch 1; k's batch is the cache-slot count B, so it is NOT tied to q here.
     TT_FATAL(q_shape[0] == w_shape[0], "q/weights batch mismatch ({} vs {})", q_shape[0], w_shape[0]);
     TT_FATAL(q_shape[0] == 1, "q/weights batch 1 only, got {}", q_shape[0]);
 
-    // weights are bf16 tiles. q and k are matmul inputs (q is srcB, k is srcA), neither is ever
-    // packed, so each may be bfp8_b (halves its BW). q+k both bfp8 drops the matmul to LoFi (1 phase);
-    // any bf16 input keeps HiFi2. Mismatched dtype/layout corrupts or hangs.
+    // q/k are matmul inputs (never packed), so each may be bfp8_b (halves BW); both bfp8 -> LoFi, any bf16
+    // -> HiFi2. weights are bf16.
     TT_FATAL(w.dtype() == DataType::BFLOAT16, "weights must be bfloat16 (got {})", w.dtype());
     TT_FATAL(
         q.dtype() == DataType::BFLOAT16 || q.dtype() == DataType::BFLOAT8_B,
@@ -225,7 +219,7 @@ void IndexerScoreDeviceOperation::validate_on_program_cache_miss(
         Sq,
         T,
         D);
-    validate_chunk_start(attrs, tensor_args);  // base/stride alignment + worst-device window (also runs on cache hit)
+    validate_chunk_start(attrs, tensor_args);  // base/stride alignment + worst-device window
 
     // Work-unit knobs (elements, tile-aligned); see IndexerScoreProgramConfig.
     const auto& cfg = attrs.program_config;
@@ -243,17 +237,69 @@ void IndexerScoreDeviceOperation::validate_on_program_cache_miss(
         cfg.q_chunk_size,
         Sq);
     TT_FATAL(KC > 0 && KC <= T / tt::constants::TILE_WIDTH, "k_chunk_size {} out of range (T={})", cfg.k_chunk_size, T);
-    // KC need not divide Tt: the last unit is then partial. Compute still runs a full KC-wide strip
-    // (pad cols matmul stale k, overwritten with full -inf) and the writer clips to the valid width.
+    // KC need not divide Tt: the last unit is then partial (compute runs a full KC strip, writer clips).
     TT_FATAL(HB > 0 && Hi % HB == 0, "head_group_size {} must divide Hi {}", HB, Hi);
+
+    // num_groups: 1 sums all heads (DSA/GLM); G>1 emits G per-group planes (M3). G>1 reuses the all-resident
+    // full-strip path one group at a time (the streaming/per-column fallback is not wired for groups).
+    const uint32_t G = attrs.num_groups;
+    TT_FATAL(G >= 1 && Hi % G == 0, "num_groups {} must be >= 1 and divide Hi {}", G, Hi);
+    if (G > 1) {
+        TT_FATAL(HB == Hi, "num_groups {}>1 requires all heads resident (head_group_size 0 or Hi); got HB={}", G, HB);
+        TT_FATAL(
+            KC >= 2,
+            "num_groups {}>1 requires k_chunk_size>=64 (the full-strip path); got k_chunk_size={}",
+            G,
+            cfg.k_chunk_size);
+    }
+
+    // block_size: 0 = no pooling; >0 = block-max-pool -> [B,G,Sq,T/block_size] (M3). Guards fire only when
+    // pooling. A block must align to T and the k-chunk boundary, and blocks-per-unit must fit TILE_HEIGHT.
+    const uint32_t bs = attrs.block_size;
+    if (bs > 0) {
+        TT_FATAL(
+            bs % tt::constants::TILE_WIDTH == 0,
+            "block_size {} must be a multiple of {}",
+            bs,
+            tt::constants::TILE_WIDTH);
+        TT_FATAL(T % bs == 0, "block_size {} must divide T {}", bs, T);
+        TT_FATAL(
+            cfg.k_chunk_size % bs == 0,
+            "block_size {} must divide k_chunk_size {} (a block can't straddle a work unit)",
+            bs,
+            cfg.k_chunk_size);
+        // No partial last unit: every unit emits exactly blocks_per_unit aligned block-scores.
+        const uint32_t Tt = T / tt::constants::TILE_WIDTH;
+        TT_FATAL(Tt % KC == 0, "block_size pooling requires k_chunk_size {} to divide T {}", cfg.k_chunk_size, T);
+        const uint32_t block_tiles = bs / tt::constants::TILE_WIDTH;
+        const uint32_t blocks_per_unit = KC / block_tiles;
+        // The writer writes each unit's bf16 output slice at offset unit*blocks_per_unit*2; Blackhole's 16 B
+        // write/source alignment requires blocks_per_unit a multiple of 8. Net: k_chunk_size/block_size in
+        // {8,16,24,32}.
+        constexpr uint32_t kBf16AlignBlocks = 8;  // 16 B / 2 B
+        TT_FATAL(
+            blocks_per_unit % kBf16AlignBlocks == 0,
+            "block_size pooling needs k_chunk_size/block_size (= {}) to be a multiple of {} so each unit's "
+            "row-major output slice is 16 B-aligned; set k_chunk_size to a multiple of {}*block_size",
+            blocks_per_unit,
+            kBf16AlignBlocks,
+            kBf16AlignBlocks);
+        TT_FATAL(
+            blocks_per_unit <= tt::constants::TILE_HEIGHT,
+            "blocks per work unit (k_chunk_size/block_size = {}) must be <= {}; reduce k_chunk_size",
+            blocks_per_unit,
+            tt::constants::TILE_HEIGHT);
+    }
 }
 
 IndexerScoreDeviceOperation::spec_return_value_t IndexerScoreDeviceOperation::compute_output_specs(
-    const operation_attributes_t&, const tensor_args_t& tensor_args) {
+    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
     const auto& q_shape = tensor_args.q.logical_shape();
     const auto& k_shape = tensor_args.k.logical_shape();
-    // score [B, 1, Sq, T], row-major bf16 (consumed by the row-major topk)
-    ttnn::Shape out_shape({q_shape[0], 1, q_shape[2], k_shape[2]});
+    // score [B, num_groups, Sq, T_out], row-major bf16. num_groups==1 = head-summed (DSA/GLM); >1 = one
+    // plane per GQA group (M3). T_out = T, or T/block_size when block-max-pooling.
+    const uint32_t T_out = attrs.block_size ? k_shape[2] / attrs.block_size : k_shape[2];
+    ttnn::Shape out_shape({q_shape[0], attrs.num_groups, q_shape[2], T_out});
     return TensorSpec(
         out_shape,
         tt::tt_metal::TensorLayout(
@@ -265,11 +311,9 @@ IndexerScoreDeviceOperation::tensor_return_value_t IndexerScoreDeviceOperation::
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.q.device());
 }
 
-// Matmul-FLOP performance model. Mirrors SDPAOperation::create_op_performance_model: report ideal
-// matmul cycles = num_mul_adds / (cores * peak), and the profiler's ideal/actual ratio is then exactly
-// the math-util test's math_util = mm_flops / (cores * device_cycles * peak). Every term is matched to
-// the test (test_indexer_score_sp7_math_util): causal-valid output tiles only, actual cores, and the
-// fidelity-scaled Blackhole matmul peak.
+// Matmul-FLOP performance model: report ideal matmul cycles = num_mul_adds / (cores * peak), so the
+// profiler's ideal/actual ratio equals the math-util test's mm_flops / (cores * device_cycles * peak).
+// Every term matches the test: causal-valid output tiles only, actual cores, fidelity-scaled BH peak.
 tt::tt_metal::operation::OpPerformanceModelGeneral<IndexerScoreDeviceOperation::tensor_return_value_t>
 IndexerScoreDeviceOperation::create_op_performance_model(
     const operation_attributes_t& attrs, const tensor_args_t& tensor_args, tensor_return_value_t& output) {
@@ -277,7 +321,7 @@ IndexerScoreDeviceOperation::create_op_performance_model(
     const auto& k = tensor_args.k;
     const tt::tt_metal::operation::Tensors input_tensors = {q, k, tensor_args.weights};
 
-    // Matmul throughput model is Blackhole-specific (the only validated arch). q is always on device.
+    // Matmul throughput model is Blackhole-specific (the only validated arch).
     const tt::ARCH arch = q.device()->arch();
     if (arch != tt::ARCH::BLACKHOLE) {
         return tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t>(input_tensors, output, 0);
@@ -292,22 +336,21 @@ IndexerScoreDeviceOperation::create_op_performance_model(
     const uint32_t Tt = k_shape[2] / tt::constants::TILE_WIDTH;
     const uint32_t chunk_t = attrs.chunk_start_idx / tt::constants::TILE_WIDTH;
 
-    // Causal-valid output tiles V = sum over q-tile-rows of min(kv_len_tiles, chunk_t + row + 1) -- useful
-    // matmul work, masked future/unwritten tiles excluded (matches the test's sp7_valid_tiles()). kv_len
-    // caps the per-row valid columns; nullopt == full Tt.
+    // Causal-valid output tiles V = sum_rows min(kv_len_tiles, chunk_t + row + 1) (masked future excluded;
+    // matches the test's sp7_valid_tiles()). kv_len caps per-row valid columns; nullopt == full Tt.
     const uint32_t kv_len_tiles = attrs.kv_len.has_value() ? attrs.kv_len.value() / tt::constants::TILE_WIDTH : Tt;
     uint64_t valid_tiles = 0;
     for (uint32_t s = 0; s < Sqt; ++s) {
         valid_tiles += std::min<uint64_t>(kv_len_tiles, (uint64_t)chunk_t + s + 1);
     }
 
-    // Per valid 32x32 output tile, per head: a 32x32 x D matmul = (32*32) outputs x 2*D FLOPs (2/FMA);
-    // summed over heads, valid tiles, and batch (matches the test's indexer_mm_flops()).
+    // Per valid 32x32 tile per head: (32*32) outputs x 2*D FLOPs; summed over heads/tiles/batch
+    // (matches the test's indexer_mm_flops()).
     const uint64_t num_mul_adds =
         2ull * valid_tiles * Hi * B * static_cast<uint64_t>(tt::constants::TILE_HEIGHT * tt::constants::TILE_WIDTH) * D;
 
-    // Cores used: the banded schedule's rows_for_groups x cols_for_bands rectangle. Shares the mapping
-    // with the factory, so this count equals the factory's (and tracy's CORE COUNT).
+    // Cores used: the banded schedule's rows_for_groups x cols_for_bands rectangle (shares the factory's
+    // mapping, so this equals tracy's CORE COUNT).
     const uint32_t QC = attrs.program_config.q_chunk_size / tt::constants::TILE_HEIGHT;
     const uint32_t KC = attrs.program_config.k_chunk_size / tt::constants::TILE_WIDTH;
     const uint32_t group_count = Sqt / QC;
@@ -316,8 +359,7 @@ IndexerScoreDeviceOperation::create_op_performance_model(
     const uint64_t num_cores =
         static_cast<uint64_t>(rows_for_groups(group_count, grid.y)) * cols_for_bands(band_count, grid.x);
 
-    // Blackhole matmul peak: 4096 mul-adds/cycle/core at LoFi, scaled by the fidelity multiplier (the
-    // test's peak table is 4096 / multiplier). Fidelity comes from the resolved compute config.
+    // Blackhole matmul peak: 4096 mul-adds/cycle/core at LoFi, scaled by the fidelity multiplier.
     const auto math_fidelity = std::get<0>(ttnn::get_compute_kernel_config_args(arch, attrs.compute_kernel_config));
     constexpr uint64_t tensix_mul_adds_per_cycle_lofi = 4096;
     const int ideal_compute_cycles = static_cast<int>(std::ceil(
@@ -334,6 +376,9 @@ IndexerScoreDeviceOperation::invoke(
     const Tensor& k,
     const Tensor& weights,
     uint32_t chunk_start_idx,
+    bool apply_relu,
+    uint32_t num_groups,
+    uint32_t block_size,
     const IndexerScoreProgramConfig& program_config,
     const DeviceComputeKernelConfig& compute_kernel_config,
     std::optional<uint32_t> cache_batch_idx,
@@ -343,6 +388,9 @@ IndexerScoreDeviceOperation::invoke(
         operation_attributes_t{
             .chunk_start_idx = chunk_start_idx,
             .cluster_axis = cluster_axis,
+            .apply_relu = apply_relu,
+            .num_groups = num_groups,
+            .block_size = block_size,
             .program_config = program_config,
             .compute_kernel_config = compute_kernel_config,
             .cache_batch_idx = cache_batch_idx,
@@ -354,11 +402,18 @@ IndexerScoreDeviceOperation::invoke(
 
 namespace ttnn::experimental {
 
-ttnn::Tensor indexer_score(
+namespace {
+
+// Shared launch path for both frontends: resolve the compute-kernel config from the matmul-input dtypes,
+// then pack and launch the one device op. The flavour knobs are decided by the caller below.
+ttnn::Tensor launch_indexer_score(
     const ttnn::Tensor& q,
     const ttnn::Tensor& k,
     const ttnn::Tensor& weights,
     std::optional<uint32_t> chunk_start_idx,
+    bool apply_relu,
+    uint32_t num_groups,
+    uint32_t block_size,
     const ttnn::operations::experimental::indexer_score::IndexerScoreProgramConfig& program_config,
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
     std::optional<uint32_t> cache_batch_idx,
@@ -366,20 +421,19 @@ ttnn::Tensor indexer_score(
     std::optional<uint32_t> cluster_axis) {
     using OperationType = ttnn::operations::experimental::indexer_score::IndexerScoreDeviceOperation;
 
-    // base = rank 0's absolute chunk_start. Multichip: omit it -> deduce base = T - sp_ring*Sq (assumes K is
-    // history + the full SP-gathered chunk). Caveats: (1) deduced window ends exactly at T, so it's incompatible
-    // with a growing kv_len < T -- pass chunk_start_idx explicitly there; (2) single-chip default flipped to
-    // nullopt (was 0), so omitting now gives base = T - Sq, not 0.
+    // base = rank 0's absolute chunk_start. Omit it on a mesh -> deduce base = T - sp_ring*Sq (assumes K is
+    // history + the full SP-gathered chunk). Caveats: the deduced window ends at T (incompatible with a
+    // growing kv_len < T -- pass chunk_start_idx there); omitting on one chip now gives base = T - Sq, not 0.
     uint32_t base = 0;
     if (chunk_start_idx.has_value()) {
         base = *chunk_start_idx;
     } else {
         const uint32_t Sq = q.logical_shape()[2];
         const uint32_t T = k.logical_shape()[2];
-        // sp_ring with the per-device rank's min-relative convention (get_linearized_index returns coord-min, so
-        // sp_ring = max_rank + 1). get_topological_dimension (max+1) would over-count on a nonzero-offset sub-mesh.
+        // sp_ring = max_rank + 1 (get_linearized_index returns coord-min; get_topological_dimension would
+        // over-count on a nonzero-offset sub-mesh).
         uint32_t max_rank = 0;
-        for (const auto& coord : q.device_storage().get_coords()) {  // single device -> one coord, max_rank 0
+        for (const auto& coord : q.device_storage().get_coords()) {  // single device -> max_rank 0
             max_rank = std::max(max_rank, ttnn::ccl::get_linearized_index_from_physical_coord(q, coord, cluster_axis));
         }
         const uint32_t sp_ring = max_rank + 1;
@@ -392,9 +446,8 @@ ttnn::Tensor indexer_score(
             Sq);
         base = T - sp_ring * Sq;
     }
-    // Default math_fidelity follows the matmul-input dtypes (both bfp8 -> LoFi for the 2x peak, else
-    // HiFi2 to keep the bf16 mantissa); a caller-supplied config overrides per field. fp32-dest acc and
-    // full-sync default off -- the only modes this op's custom LLK is validated for (see validate).
+    // Default math_fidelity follows the matmul-input dtypes (both bfp8 -> LoFi, else HiFi2); a caller config
+    // overrides per field. fp32-dest acc / full-sync default off (the only modes the custom LLK is validated for).
     const bool both_bfp8 = q.dtype() == DataType::BFLOAT8_B && k.dtype() == DataType::BFLOAT8_B;
     const auto resolved = ttnn::init_device_compute_kernel_config(
         q.device()->arch(),
@@ -404,10 +457,79 @@ ttnn::Tensor indexer_score(
         /*default_fp32_acc=*/false,
         /*default_l1_acc=*/false,
         /*default_dst_full_sync_en=*/false);
-    // Reuse invoke() so attribute/tensor packing lives in one place.
-    auto [operation_attributes, tensor_args] =
-        OperationType::invoke(q, k, weights, base, program_config, resolved, cache_batch_idx, kv_len, cluster_axis);
+    auto [operation_attributes, tensor_args] = OperationType::invoke(
+        q,
+        k,
+        weights,
+        base,
+        apply_relu,
+        num_groups,
+        block_size,
+        program_config,
+        resolved,
+        cache_batch_idx,
+        kv_len,
+        cluster_axis);
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
+}
+
+}  // namespace
+
+ttnn::Tensor indexer_score_dsa(
+    const ttnn::Tensor& q,
+    const ttnn::Tensor& k,
+    const ttnn::Tensor& weights,
+    std::optional<uint32_t> chunk_start_idx,
+    const ttnn::operations::experimental::indexer_score::IndexerScoreProgramConfig& program_config,
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
+    std::optional<uint32_t> cache_batch_idx,
+    std::optional<uint32_t> kv_len,
+    std::optional<uint32_t> cluster_axis) {
+    // DSA/GLM: relu, learned per-head gates, one head-summed plane, no pooling.
+    return launch_indexer_score(
+        q,
+        k,
+        weights,
+        chunk_start_idx,
+        /*apply_relu=*/true,
+        /*num_groups=*/1,
+        /*block_size=*/0,
+        program_config,
+        compute_kernel_config,
+        cache_batch_idx,
+        kv_len,
+        cluster_axis);
+}
+
+ttnn::Tensor indexer_score_msa(
+    const ttnn::Tensor& q,
+    const ttnn::Tensor& k,
+    std::optional<uint32_t> chunk_start_idx,
+    float scale,
+    uint32_t num_groups,
+    uint32_t block_size,
+    const ttnn::operations::experimental::indexer_score::IndexerScoreProgramConfig& program_config,
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
+    std::optional<uint32_t> cluster_axis) {
+    // M3 has no learned gates, only a 1/sqrt(d) scale: synthesize a constant gate (= scale) of shape
+    // [B,Hi,Sq,1] so the kernel's gate-multiply path is reused unchanged. The local lives until launch()
+    // returns (where its buffer is read). MSA fixes apply_relu=false; num_groups/block_size are selection knobs.
+    const auto& qs = q.logical_shape();
+    const ttnn::Tensor w =
+        ttnn::full(ttnn::Shape({qs[0], qs[1], qs[2], 1}), scale, DataType::BFLOAT16, Layout::TILE, *q.device());
+    return launch_indexer_score(
+        q,
+        k,
+        w,
+        chunk_start_idx,
+        /*apply_relu=*/false,
+        num_groups,
+        block_size,
+        program_config,
+        compute_kernel_config,
+        /*cache_batch_idx=*/std::nullopt,
+        /*kv_len=*/std::nullopt,
+        cluster_axis);
 }
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
@@ -47,6 +47,8 @@ struct IndexerScoreDeviceOperation {
         bool apply_relu,
         uint32_t num_groups,
         uint32_t block_size,
+        bool synthesize_gate,
+        float gate_scale,
         const IndexerScoreProgramConfig& program_config,
         const DeviceComputeKernelConfig& compute_kernel_config,
         std::optional<uint32_t> cache_batch_idx,
@@ -85,12 +87,14 @@ ttnn::Tensor indexer_score_dsa(
 // num_groups: G output planes (no cross-group sum); G==1 = TP=4 group-aligned (Hi=1/device), G>1 needs all
 //   heads resident + k_chunk>=64. block_size: 0 = full [B,G,Sq,T]; >0 = block-max-pool -> [B,G,Sq,T/bs].
 // chunk_start_idx / cluster_axis: same SP-ring semantics as indexer_score_dsa.
+// num_groups is required (no default): per-GQA-group selection is MSA's purpose, so the caller must state
+// the group count explicitly. It is placed before the defaulted optionals so the signature stays well-formed.
 ttnn::Tensor indexer_score_msa(
     const ttnn::Tensor& q,
     const ttnn::Tensor& k,
+    uint32_t num_groups,
     std::optional<uint32_t> chunk_start_idx = std::nullopt,
     float scale = 1.0f,
-    uint32_t num_groups = 1,
     uint32_t block_size = 0,
     const ttnn::operations::experimental::indexer_score::IndexerScoreProgramConfig& program_config = {},
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
@@ -24,20 +24,18 @@ struct IndexerScoreDeviceOperation {
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
 
-    // Custom hash: the runtime values (cache_batch_idx / kv_len / chunk_start_idx) are excluded so they reuse
-    // one compiled program; cluster_axis IS hashed. See the definition for the full rationale.
+    // Custom hash: runtime values (cache_batch_idx / kv_len / chunk_start_idx) are excluded so they reuse
+    // one program; cluster_axis IS hashed.
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
-    // Re-checks the runtime values that can change on a hit: persistent-cache values (slot < B, kv_len bounds)
-    // and the hash-excluded chunk_start window/alignment (mirrors ring_joint_sdpa's runtime revalidation).
+    // Re-checks the runtime values that can change on a hit (slot < B, kv_len bounds, chunk_start window).
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    // Matmul-FLOP performance model (mirrors SDPAOperation::create_op_performance_model): reports ideal
-    // matmul cycles so tracy's ideal/actual utilization equals the math-util test's mm_flops/(cores x
-    // cycles x peak). FLOPs count causal-valid tiles only; cores/fidelity match the factory.
+    // Matmul-FLOP performance model: reports ideal matmul cycles so tracy's util matches the math-util
+    // test's mm_flops/(cores x cycles x peak). FLOPs count causal-valid tiles only.
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
 
@@ -46,6 +44,9 @@ struct IndexerScoreDeviceOperation {
         const Tensor& k,
         const Tensor& weights,
         uint32_t chunk_start_idx,
+        bool apply_relu,
+        uint32_t num_groups,
+        uint32_t block_size,
         const IndexerScoreProgramConfig& program_config,
         const DeviceComputeKernelConfig& compute_kernel_config,
         std::optional<uint32_t> cache_batch_idx,
@@ -57,24 +58,16 @@ struct IndexerScoreDeviceOperation {
 
 namespace ttnn::experimental {
 
-// DeepSeek-V3.2 DSA lightning-indexer scorer (the public callable, ttnn.experimental.indexer_score):
-//   score[b, s, t] = sum_h relu(q[b,h,s,:] . k[b,t,:]) * weights[b,h,s]
-// q [B, Hi, Sq, D], k [B, 1, T, D], weights [B, Hi, Sq, 1] -> score [B, 1, Sq, T] (row-major bf16).
-// Causality from chunk_start_idx: key t visible to query s iff t <= chunk_start_idx + s.
-//
-// cache_batch_idx: when set, k is a shared [B, 1, T, D] cache and this selects the batch slot to score
-// against (k may then also be ND-sharded across DRAM banks).
-// kv_len: when set, only the first kv_len key positions of k are valid this dispatch (rest masked out);
-// must be tile-aligned, in (0, T], with chunk_start_idx + Sq <= kv_len. Output is still [B, 1, Sq, T] with
-// only columns [0, kv_len) written.
-// chunk_start_idx is the ABSOLUTE chunk_start of rank 0 (lowest cluster_axis coord); rank r uses
-// chunk_start_idx + r*Sq, so one dispatch gives each SP rank its own chunk_start. OMIT it on multichip: the
-// base is deduced as T - sp_ring*Sq (sp_ring = mesh extent along cluster_axis, whole mesh if unset -- a 2D
-// SP x TP mesh uses the SP-axis length, not total devices). On single chip (one device = rank 0) set it to
-// history + rank*Sq to simulate any rank. cluster_axis selects the SP ring axis.
-// All of cache_batch_idx / kv_len / chunk_start are re-applied each dispatch and excluded from the program
-// hash, so switching slot, growing kv_len, or changing chunk_start reuses ONE program -- no recompile.
-ttnn::Tensor indexer_score(
+// Two public frontends over one shared device op: the lightning indexer's two flavours differ only in
+// fixed knobs, so each gets its own callable. Both share the program factory + 3 kernels (flavour = compile-
+// time args) and produce a row-major bf16 score. Causality: key t visible to query s iff t <= chunk_start + s.
+
+// DeepSeek-V3.2 DSA / GLM-5 (ttnn.experimental.indexer_score_dsa):
+//   score[b, 0, s, t] = sum_h relu(q[b,h,s,:] . k[b,t,:]) * weights[b,h,s]
+// q [B,Hi,Sq,D], k [B,1,T,D], weights [B,Hi,Sq,1] -> score [B,1,Sq,T] (all heads relu'd + summed).
+// cache_batch_idx/kv_len/chunk_start_idx are re-applied each dispatch and hash-excluded (no recompile); see
+// the nanobind docs for their full semantics. OMIT chunk_start_idx on a mesh (deduced as T - sp_ring*Sq).
+ttnn::Tensor indexer_score_dsa(
     const ttnn::Tensor& q,
     const ttnn::Tensor& k,
     const ttnn::Tensor& weights,
@@ -83,6 +76,24 @@ ttnn::Tensor indexer_score(
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
     std::optional<uint32_t> cache_batch_idx = std::nullopt,
     std::optional<uint32_t> kv_len = std::nullopt,
+    std::optional<uint32_t> cluster_axis = std::nullopt);
+
+// MiniMax-M3 MSA (ttnn.experimental.indexer_score_msa):
+//   score[b, g, s, t] = sum_{h in group g} (q[b,h,s,:] . k[b,t,:]) * scale
+// Raw dot, no learned gates -- only a 1/sqrt(d) `scale` (synthesized as a constant gate, so no weights
+// tensor). q [B,Hi,Sq,D], k [B,1,T,D] -> score [B,num_groups,Sq,T_out].
+// num_groups: G output planes (no cross-group sum); G==1 = TP=4 group-aligned (Hi=1/device), G>1 needs all
+//   heads resident + k_chunk>=64. block_size: 0 = full [B,G,Sq,T]; >0 = block-max-pool -> [B,G,Sq,T/bs].
+// chunk_start_idx / cluster_axis: same SP-ring semantics as indexer_score_dsa.
+ttnn::Tensor indexer_score_msa(
+    const ttnn::Tensor& q,
+    const ttnn::Tensor& k,
+    std::optional<uint32_t> chunk_start_idx = std::nullopt,
+    float scale = 1.0f,
+    uint32_t num_groups = 1,
+    uint32_t block_size = 0,
+    const ttnn::operations::experimental::indexer_score::IndexerScoreProgramConfig& program_config = {},
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
     std::optional<uint32_t> cluster_axis = std::nullopt);
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
@@ -43,6 +43,13 @@ struct operation_attributes_t {
     // (M3 block selection). Compile-time (block_tiles = block_size/TILE_WIDTH; bs==0 byte-identical). >0 needs
     // bs % TILE_WIDTH == 0, T % bs == 0, k_chunk_size % bs == 0, and blocks-per-unit <= TILE_HEIGHT.
     uint32_t block_size{0};
+    // MSA has no learned gates, only a constant 1/sqrt(d) scale: when true the reader fills cb_w with
+    // gate_scale in L1 (no weights tensor, no extra fill op) instead of reading DRAM. The weights handle in
+    // tensor_args is then an unused placeholder (the caller passes q). Compile-time + hashed (changes the
+    // reader binary); gate_scale is hashed too so distinct scales get distinct programs. DSA: false (reads
+    // its learned weights), byte-identical to before.
+    bool synthesize_gate{false};
+    float gate_scale{1.0f};
     IndexerScoreProgramConfig program_config{};
     // Resolved (not optional) so it is part of the program-cache key; the callable fills it from the user's
     // optional config, defaulting math_fidelity to the dtype-derived choice.

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
@@ -28,24 +28,31 @@ inline uint32_t resolve_head_group(const IndexerScoreProgramConfig& cfg, uint32_
 }
 
 struct operation_attributes_t {
-    // Absolute chunk_start of rank 0 (lowest cluster_axis coord; the only device on a single chip). Rank r
-    // uses chunk_start_idx + r*Sq (Sq = per-device q seq len; r = linearized index along cluster_axis), so
-    // the per-device value is derived host-side and passed to compute as a RUNTIME arg, hash-excluded --
-    // distinct values reuse one program (see compute_program_hash).
-    uint32_t chunk_start_idx{0};             // absolute chunk_start of rank 0 (elements, tile-aligned)
+    // Absolute chunk_start of rank 0. Rank r uses chunk_start_idx + r*Sq; the per-device value is derived
+    // host-side and passed to compute as a RUNTIME arg (hash-excluded), so distinct values reuse one program.
+    uint32_t chunk_start_idx{0};             // elements, tile-aligned
     std::optional<uint32_t> cluster_axis{};  // mesh axis that is the SP ring; unset = linear device order
+    // ReLU on each per-head q.kT before the gate-mul. true = DSA/GLM (relu(q.k)*w); false = raw dot (M3 MSA).
+    // Compile-time, so the true path is byte-identical to before.
+    bool apply_relu{true};
+    // Output groups. 1 = sum ALL Hi heads -> [B,1,Sq,T] (DSA/GLM). G>1 = partition into G groups of Hi/G,
+    // sum within each -> [B,G,Sq,T] (M3 per-GQA-group). Compile-time (G==1 byte-identical). G>1 needs all
+    // heads resident (head_group_size 0 or Hi) and the full-strip path (k_chunk_size>=64).
+    uint32_t num_groups{1};
+    // Block-max-pool width in keys. 0 = no pooling -> [B,G,Sq,T]. >0 = max over each block -> [B,G,Sq,T/bs]
+    // (M3 block selection). Compile-time (block_tiles = block_size/TILE_WIDTH; bs==0 byte-identical). >0 needs
+    // bs % TILE_WIDTH == 0, T % bs == 0, k_chunk_size % bs == 0, and blocks-per-unit <= TILE_HEIGHT.
+    uint32_t block_size{0};
     IndexerScoreProgramConfig program_config{};
-    // Resolved (not optional) so it is part of the reflected program-cache key; the public callable
-    // fills it from the user's optional config, defaulting math_fidelity to the dtype-derived choice.
+    // Resolved (not optional) so it is part of the program-cache key; the callable fills it from the user's
+    // optional config, defaulting math_fidelity to the dtype-derived choice.
     DeviceComputeKernelConfig compute_kernel_config{};
     // Indexed KV cache: selects the batch slot of a shared [B,1,T,D] k (page ids offset by
-    // cache_batch_idx * Tt * Dt). k may then also be ND-sharded across DRAM banks. Value is NOT hashed and
-    // is re-applied in override_runtime_arguments, so switching slots does NOT recompile.
+    // cache_batch_idx * Tt * Dt). NOT hashed, re-applied each dispatch, so switching slots does NOT recompile.
     std::optional<uint32_t> cache_batch_idx{std::nullopt};
     bool has_indexed_kv_cache() const { return cache_batch_idx.has_value(); }
-    // Runtime KV length: the valid prefix this dispatch of a k allocated at its full T; the rest is
-    // masked out. Value is NOT hashed (re-applied per dispatch), so growing kv_len <= T reuses ONE program.
-    // grid/work-split/output width stay keyed on the hashed T. nullopt == T.
+    // Runtime KV length: the valid prefix this dispatch (rest masked). NOT hashed, so growing kv_len <= T
+    // reuses ONE program. grid/work-split/output width stay keyed on the hashed T. nullopt == T.
     std::optional<uint32_t> kv_len{std::nullopt};
     bool has_runtime_kv_len() const { return kv_len.has_value(); }
 };

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
@@ -257,8 +257,9 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
     const tt::DataFormat acc_fmt = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
     const uint32_t acc_tile = fp32_dest_acc_en ? fp32_tile : bf16_tile;
     // cb_qk buffers a batch of relu(q.kT) tiles so compute runs the batch's matmuls then mul+accumulates,
-    // hoisting the matmul<->eltwise reinit out of the per-head loop. QC==1 batches the whole group; QC>1 caps at 32.
-    const uint32_t qk_batch_cap = (QC == 1) ? subblock_basis : 32u;
+    // hoisting the matmul<->eltwise reinit out of the per-head loop. QC==1 batches the whole group; QC>1 caps
+    // at one tile-row of heads (TILE_HEIGHT).
+    const uint32_t qk_batch_cap = (QC == 1) ? subblock_basis : tt::constants::TILE_HEIGHT;
     const uint32_t qk_batch_heads = std::min<uint32_t>(subblock_basis, qk_batch_cap);  // multiple of qk_subblock_h
     // Per-plane head count must be a whole multiple of qk_batch_heads or the last chunk over-reads (only
     // reachable when the 32-cap engages; deployed cases never hit it).
@@ -301,10 +302,16 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
     std::vector<uint32_t> common_ct = {Hi, Sqt, Tt, Dt, QC, KC, HB, G, block_tiles};
     common_ct.insert(common_ct.end(), cb_id.begin(), cb_id.end());
 
+    // MSA synthesizes the constant gate in-kernel (no weights tensor / no fill op): the reader fills cb_w
+    // with `gate_scale` instead of reading DRAM, and the weights accessor below is the unused q placeholder.
+    // Pack the scale into a bf16 pair (two values per word) for the reader's word-wise fill.
+    const uint16_t gate_scale_bf16 = static_cast<uint16_t>(__builtin_bit_cast(uint32_t, args.gate_scale) >> 16);
+    const uint32_t gate_scale_bits = (static_cast<uint32_t>(gate_scale_bf16) << 16) | gate_scale_bf16;
+
     std::vector<uint32_t> reader_ct = common_ct;
     tt::tt_metal::TensorAccessorArgs(*q.buffer()).append_to(reader_ct);
     tt::tt_metal::TensorAccessorArgs(*k.buffer()).append_to(reader_ct);
-    tt::tt_metal::TensorAccessorArgs(*w.buffer()).append_to(reader_ct);
+    tt::tt_metal::TensorAccessorArgs(*w.buffer()).append_to(reader_ct);  // q placeholder when synthesize_gate
     // multicast: on/off per direction (q_mcast_on covers q and w) then the 6 semaphore ids.
     reader_ct.push_back(k_mcast_on);
     reader_ct.push_back(q_mcast_on);
@@ -317,6 +324,8 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
     // Fused single-head: reader reads q+w FIRST (the matmul gate needs them), then streams k (when no mcast).
     reader_ct.push_back(fuse_single ? 1u : 0u);
     reader_ct.push_back(fused_stream_k ? 1u : 0u);  // fused: stream k (no mcast) vs whole mcast block
+    reader_ct.push_back(args.synthesize_gate ? 1u : 0u);  // fill cb_w with gate_scale in L1 vs read DRAM
+    reader_ct.push_back(gate_scale_bits);                 // bf16 pair, the in-kernel gate fill value
 
     std::vector<uint32_t> writer_ct = common_ct;
     const uint32_t out_elem_bytes = out.element_size();  // bf16 today

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
@@ -31,10 +31,9 @@ namespace rt_arg {
 constexpr uint32_t reader_q_addr = 0;
 constexpr uint32_t reader_k_addr = 1;
 constexpr uint32_t reader_w_addr = 2;
-constexpr uint32_t compute_chunk_start_tiles = 7;  // after the 6 sched scalars + kv_len[6]; match the compute kernel
+constexpr uint32_t compute_chunk_start_tiles = 7;  // after 6 sched scalars + kv_len[6]
 constexpr uint32_t writer_out_addr = 0;
-// Persistent-cache args, appended after the schedule/mcast args of each kernel (excluded from the hash,
-// re-patched on a cache hit). Reader: 3 addrs + 6 schedule + 2 mcast dirs * 8 = 25, then the two below.
+// Persistent-cache args, appended after each kernel's schedule/mcast args (hash-excluded, re-patched on a hit).
 constexpr uint32_t reader_num_scalars = 3 + 6;  // q/k/w addrs + schedule {row_group0..max_bands}
 constexpr uint32_t mcast_args_per_dir = 8;      // role, rect (xs,ys,xe,ye), sender (sx,sy), ndst
 constexpr uint32_t reader_num_mcast_dirs = 2;   // K column, then Q/W row
@@ -42,11 +41,11 @@ constexpr uint32_t reader_k_batch_offset = reader_num_scalars + reader_num_mcast
 constexpr uint32_t reader_kv_len_tiles = reader_k_batch_offset + 1;                                          // 26
 constexpr uint32_t compute_kv_len_tiles = 6;     // after the 6 schedule scalars {row_group0..max_bands}
 constexpr uint32_t writer_kv_len_tiles = 1 + 6;  // out_addr + the 6 schedule scalars {row_group0..max_bands}
+constexpr uint32_t writer_chunk_start_tiles = 1 + 7;  // after out_addr + 6 sched scalars + kv_len[7]; match writer
 }  // namespace rt_arg
 
-// Per-device chunk_start (in tiles): base + rank*Sq, /TILE_WIDTH (the per-rank stride is exactly the
-// per-device query count Sq). Shared by create_at (derives device_index from the coordinate) and
-// override (reuses the stored device_index).
+// Per-device chunk_start (tiles): (base + rank*Sq) / TILE_WIDTH. Shared by create_at (device_index from
+// the coordinate) and override (stored device_index).
 inline uint32_t chunk_start_tiles_for(const operation_attributes_t& args, uint32_t device_index, uint32_t Sq) {
     return (args.chunk_start_idx + device_index * Sq) / tt::constants::TILE_WIDTH;
 }
@@ -66,9 +65,8 @@ inline void patch_arg(tt::tt_metal::RuntimeArgsData& args, uint32_t index, uint3
     args[index] = value;
 }
 
-// The two non-hashed runtime args derived from k's (hashed) shape + the optionals. Single source for both
-// create() (bakes them at miss) and override_runtime_arguments() (re-patches them on a hit) -- a divergence
-// would silently mis-patch the slot/kv_len on a cache hit.
+// The two non-hashed runtime args derived from k's shape + the optionals. Single source for both create()
+// (bakes at miss) and override_runtime_arguments() (re-patches on a hit).
 struct PersistentCacheArgs {
     uint32_t k_batch_page_offset;  // cache_batch_idx * Tt * Dt; 0 when not indexed
     uint32_t kv_len_tiles;         // valid key prefix in tiles; full Tt when kv_len unset
@@ -82,11 +80,9 @@ inline PersistentCacheArgs persistent_cache_args(const operation_attributes_t& a
         .kv_len_tiles = attrs.kv_len.value_or(shape[2]) / tt::constants::TILE_WIDTH};
 }
 
-// Banded-product schedule: the work space (group_count q-row-groups x band_count k-bands) tiles onto
-// a rows_used x cols_used core rectangle -- groups -> rows (q/w multicast along a row), bands ->
-// columns (k multicast down a column). One (group, band) cell = one work unit of QC q-tile-rows x
-// up-to-KC k-tiles. Heads stream in HB-head groups; the causal masked suffix is stamped to -inf by
-// compute (zeros unsafe: gates can be negative). See indexer_score_work_split.hpp for the grid map.
+// Banded-product schedule: the work space (group_count q-row-groups x band_count k-bands) tiles onto a
+// rows_used x cols_used core rectangle -- groups -> rows (q/w mcast along a row), bands -> columns (k
+// mcast down a column). One cell = one QC x up-to-KC work unit. See indexer_score_work_split.hpp.
 IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_at(
     const operation_attributes_t& args,
     const ttnn::MeshCoordinate& coord,
@@ -105,8 +101,8 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
     const uint32_t D = q.logical_shape()[3];
     const uint32_t T = k.logical_shape()[2];
 
-    // This device's SP-ring index and chunk_start (tiles), derived from the mesh coordinate (stride = Sq).
-    // chunk_t is a compute RUNTIME arg (not compile-time), so the binary is identical across coords and steps.
+    // This device's SP-ring index and chunk_start (tiles), from the coordinate. chunk_t is a compute RUNTIME
+    // arg, so the binary is identical across coords and steps.
     const uint32_t device_index = device_index_for(args, coord, q);
     const uint32_t chunk_t = chunk_start_tiles_for(args, device_index, Sq);
 
@@ -120,26 +116,38 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
     const uint32_t KC = cfg.k_chunk_size / tt::constants::TILE_WIDTH;
     const uint32_t HB = resolve_head_group(cfg, Hi);
 
-    // Compute knobs from the resolved compute config. math_fidelity defaults to the dtype-derived
-    // choice (bf16 -> HiFi2, both bfp8 -> LoFi) but a caller can override it; validate guarantees
-    // fp32_dest_acc_en==false / dst_full_sync_en==false (the bf16-DEST half-sync layout the custom
-    // blocked bcast-col MUL LLK + packer path are validated for).
+    // num_groups: G==1 sums all heads (DSA/GLM); G>1 sums Hi/G heads per group into G planes (M3). The
+    // subblock height and cb_qk batch key off the per-plane width: HB when G==1, plane_heads when G>1.
+    const uint32_t G = args.num_groups;
+    const uint32_t plane_heads = Hi / G;
+    const uint32_t subblock_basis = (G > 1) ? plane_heads : HB;
+
+    // block-max-pool: 0 = off; >0 = max over each block_size-key block -> [.,.,Sq,T/block_size] (M3).
+    // block_tiles k-tiles per block; a unit's KC tiles pool to blocks_per_unit block scores.
+    const uint32_t block_tiles = args.block_size ? args.block_size / tt::constants::TILE_WIDTH : 0;
+    const bool block_pool = block_tiles != 0;
+    const uint32_t blocks_per_unit = block_pool ? (KC / block_tiles) : KC;
+    const uint32_t nblocks = block_pool ? (Tt / block_tiles) : 0;  // total block columns per output row (pool only)
+
+    // Compute knobs from the resolved config (validate guarantees fp32_dest_acc_en / dst_full_sync_en false).
     const auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         ttnn::get_compute_kernel_config_args(q.device()->arch(), args.compute_kernel_config);
 
-    // qk matmul subblock: heads are output rows, k column is 1 tile wide (SDPA-style), so only the
-    // subblock height (head rows) is needed.
+    // qk matmul subblock: heads are output rows, k column is 1 tile wide, so only the subblock height matters.
     const uint32_t dst_size = fp32_dest_acc_en ? 4 : 8;  // half-sync, as in sdpa_program_factory
-    const uint32_t qk_subblock_h = ttnn::prim::detail::determine_largest_subblock_size(HB, 1, dst_size).first;
-    TT_FATAL(HB % qk_subblock_h == 0, "head group {} must be divisible by qk_subblock_h={}", HB, qk_subblock_h);
+    const uint32_t qk_subblock_h =
+        ttnn::prim::detail::determine_largest_subblock_size(subblock_basis, 1, dst_size).first;
+    TT_FATAL(
+        subblock_basis % qk_subblock_h == 0,
+        "per-plane head count {} must be divisible by qk_subblock_h={}",
+        subblock_basis,
+        qk_subblock_h);
 
-    // QC/KC/HB are verbatim from the config -- no auto-tune; the caller owns the perf trade-off (see
-    // glx_config() in the test). An oversized config is not clamped; it fails at CB allocation.
+    // QC/KC/HB are verbatim from the config (no auto-tune; caller owns the trade-off, oversized fails at
+    // CB allocation).
 
     // ---- banded-product schedule -------------------------------------------------------------
-    // Work space = group_count q-row-groups x band_count k-bands, tiled onto a rows_used x cols_used
-    // rectangle: groups -> rows (q/w mcast along a row), bands -> columns (k mcast down a column). Rows
-    // phase-stack groups when group_count > grid_y; each column owns a contiguous chunk of bands.
+    // groups -> rows (phase-stack when group_count > grid_y), bands -> columns (each owns a contiguous chunk).
     const uint32_t group_count = Sqt / QC;
     const uint32_t band_count = units_in_group(KC, Tt);  // ceil(Tt/KC)
     const auto grid = q.device()->compute_with_storage_grid_size();
@@ -160,12 +168,10 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
             off += col_band_size[col];
         }
     }
-    // rows_used divides group_count, so every row runs the same num_groups (group = y + p*rows_used).
-    // Uniformity keeps every column's k-mcast in lockstep.
+    // rows_used divides group_count, so every row runs the same num_groups (k-mcast lockstep).
     const uint32_t num_groups = group_count / rows_used;
-    // Widest column's band count: the streaming q-mcast pad target. Streaming re-reads q per output tile,
-    // so the uneven per-column band counts would desync the row's q-mcast; the kernels pad each row to
-    // max_bands with dummy q-only "phantom" bands (band-independent data) to keep the rendezvous uniform.
+    // Widest column's band count: the streaming q-mcast pad target (the kernels pad each row to max_bands
+    // with q-only phantom bands so the rendezvous stays uniform).
     const uint32_t max_bands = (band_count + cols_used - 1) / cols_used;
 
     const CoreRange core_rect(CoreCoord{0, 0}, CoreCoord{cols_used - 1, rows_used - 1});
@@ -179,13 +185,12 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
         }
     }
 
-    // k-mcast needs >1 row down a column; q/w-mcast needs >1 column along a row. Both are HB-independent:
-    // streaming keeps q-mcast via the phantom-band pad (see max_bands above), so neither gates on HB.
+    // k-mcast needs >1 row down a column; q/w-mcast needs >1 column along a row (both HB-independent).
     const uint32_t k_mcast_on = (rows_used > 1) ? 1u : 0u;
     const uint32_t q_mcast_on = (cols_used > 1) ? 1u : 0u;
 
     // 3 semaphores per active direction: send (receivers ready), recv (sender relays valid in), valid
-    // (constant 1, relay source). Mirrors SDPA chain_link's handshake.
+    // (constant 1). Mirrors SDPA chain_link's handshake.
     const uint32_t k_send_sem = k_mcast_on ? tt::tt_metal::CreateSemaphore(program, core_ranges, 0) : 0;
     const uint32_t k_recv_sem = k_mcast_on ? tt::tt_metal::CreateSemaphore(program, core_ranges, 0) : 0;
     const uint32_t k_valid_sem = k_mcast_on ? tt::tt_metal::CreateSemaphore(program, core_ranges, 1) : 0;
@@ -196,19 +201,24 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
     const uint32_t bf16_tile = tt::tile_size(tt::DataFormat::Float16_b);
     const uint32_t fp32_tile = tt::tile_size(tt::DataFormat::Float32);
 
-    // q (srcB) and k (srcA) are matmul inputs; either may be bfp8_b to halve its DRAM/L1 footprint
-    // (w stays bf16). The format flows into the CB; the compute kernel needs no change.
+    // q (srcB) and k (srcA) are matmul inputs; either may be bfp8_b to halve its footprint (w stays bf16).
     const bool q_is_bfp8 = q.dtype() == tt::tt_metal::DataType::BFLOAT8_B;
     const bool k_is_bfp8 = k.dtype() == tt::tt_metal::DataType::BFLOAT8_B;
+    // Fused single-head fast path: one head/plane, no ReLU, bf16 q -> the matmul writes the gated score
+    // straight to the accumulator (cb_qk sized to 1, cb_out_strip deepened). Composes with the multicast.
+    // bfp8 q is EXCLUDED: the in-place gate-fold (scale_q_by_w_inplace) re-packs gated q to bfp8 and the
+    // matmul then misreads it (PCC ~0, garbage magnitudes) -- bf16 q has no shared-exponent section so it is
+    // unaffected. bfp8 q therefore stays on the non-fused path (gate applied on the fp32 matmul output).
+    const bool fuse_single = (plane_heads == 1) && !args.apply_relu && !q_is_bfp8;
+    // Fused + mcast: K is one block -> wait whole chunk. Fused + no mcast: stream K in column sub-chunks.
+    const bool fused_stream_k = fuse_single && (k_mcast_on == 0) && (q_mcast_on == 0);
     const tt::DataFormat q_fmt = q_is_bfp8 ? tt::DataFormat::Bfp8_b : tt::DataFormat::Float16_b;
     const tt::DataFormat k_fmt = k_is_bfp8 ? tt::DataFormat::Bfp8_b : tt::DataFormat::Float16_b;
     const uint32_t q_tile = tt::tile_size(q_fmt);
     const uint32_t k_tile = tt::tile_size(k_fmt);
 
-    // Continuous CB indices, allocated on demand: each make_cb claims the next free index (c_0, c_1, ...)
-    // and records it under its CbArg slot. The whole array is forwarded to the kernels as compile-time
-    // args (CbArg is the shared slot order; see indexer_score_cb.hpp), so every buffer is resolved through
-    // this one allocation and indices can never drift host<->device.
+    // Continuous CB indices: each make_cb claims the next free index and records it under its CbArg slot.
+    // The whole array is forwarded to the kernels (CbArg = shared slot order), so indices can't drift.
     std::array<uint32_t, num_cb_args> cb_id{};
     uint32_t next_cb_index = tt::CBIndex::c_0;
     auto make_cb = [&](uint32_t slot, uint32_t ntiles, tt::DataFormat fmt, uint32_t tile_bytes) {
@@ -222,8 +232,7 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
 
     const bool stream_heads = HB < Hi;
 
-    // One-line schedule/mcast summary (per program-cache miss) so profiling can read the active
-    // multicast directions without decoding compile-time args.
+    // One-line schedule/mcast summary (per cache miss) for profiling.
     log_debug(
         tt::LogOp,
         "indexer_score schedule: G={} U={} grid={}x{} rows_used={} cols_used={} num_groups={} "
@@ -247,49 +256,56 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
     make_cb(cb_mask_arg, num_mask_tiles, tt::DataFormat::Float16_b, bf16_tile);
     const tt::DataFormat acc_fmt = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
     const uint32_t acc_tile = fp32_dest_acc_en ? fp32_tile : bf16_tile;
-    // cb_qk buffers a batch of the group's relu(q.kT) tiles so compute runs that batch's matmuls then
-    // its mul+accumulates, hoisting the matmul<->eltwise reinit out of the per-head-pass loop.
-    // QC==1 has spare L1 -> batch the whole group; QC>1 doubles cb_q/cb_w, so cap at 32.
-    const uint32_t qk_batch_cap = (QC == 1) ? HB : 32u;
-    const uint32_t qk_batch_heads = std::min<uint32_t>(HB, qk_batch_cap);  // multiple of qk_subblock_h
-    // The compute kernel walks HB in qk_batch_heads-sized chunks (chunk += qk_batch_heads), so HB must
-    // be a whole multiple or the last chunk over-reads past the resident head group. Only reachable when
-    // the 32-cap engages (HB > 32 && QC > 1); the deployed cases never hit it, but guard loudly.
+    // cb_qk buffers a batch of relu(q.kT) tiles so compute runs the batch's matmuls then mul+accumulates,
+    // hoisting the matmul<->eltwise reinit out of the per-head loop. QC==1 batches the whole group; QC>1 caps at 32.
+    const uint32_t qk_batch_cap = (QC == 1) ? subblock_basis : 32u;
+    const uint32_t qk_batch_heads = std::min<uint32_t>(subblock_basis, qk_batch_cap);  // multiple of qk_subblock_h
+    // Per-plane head count must be a whole multiple of qk_batch_heads or the last chunk over-reads (only
+    // reachable when the 32-cap engages; deployed cases never hit it).
     TT_FATAL(
-        HB % qk_batch_heads == 0,
-        "head_group {} not divisible by qk_batch_heads {} (QC>1 with HB>32); reduce head_group_size or q_chunk_size",
-        HB,
+        subblock_basis % qk_batch_heads == 0,
+        "per-plane head count {} not divisible by qk_batch_heads {} (QC>1 with >32 heads); reduce head_group_size, "
+        "q_chunk_size, or raise num_groups",
+        subblock_basis,
         qk_batch_heads);
-    // Full-strip path batches the whole k chunk's columns per matmul<->mul mode switch (one switch per
-    // batch, not per output tile): w is column-independent and the whole k chunk is resident, so a row's
-    // columns share one switch. Only when the group is a single chunk (qk_batch_heads == Hi) and the fast
-    // strip is used (KC >= 2); cb_qk then holds KC * qk_batch_heads tiles and fails at allocation if the
-    // caller's k_chunk_size is too large for L1 (the caller owns the knob trade-off).
-    const bool single_chunk = (qk_batch_heads == Hi) && !stream_heads;
+    // Full-strip path batches the whole k chunk's columns per matmul<->mul switch (w is column-independent,
+    // the chunk is resident). Only for a single-chunk group (qk_batch_heads == basis) with KC >= 2.
+    const bool single_chunk = (qk_batch_heads == subblock_basis) && !stream_heads;
     const uint32_t qk_col_batch = (KC >= 2 && single_chunk) ? KC : 1u;
-    make_cb(cb_qk_arg, qk_col_batch * qk_batch_heads, acc_fmt, acc_tile);
-    // cb_out_strip holds a unit's untilized output. Uniform KC push/pop keeps the packer's KC-tile
-    // reads contiguous (a non-uniform push would wrap the ring mid-strip).
-    make_cb(cb_out_strip_arg, 2 * KC, tt::DataFormat::Float16_b, bf16_tile);
-    // cb_acc_strip accumulates a whole unit's QC*KC strip, then all QC strips untilize under ONE
-    // pack_untilize bracket (per-strip cost amortizes over QC*KC, not KC). max(2*KC, .) keeps the
-    // QC<=2 double buffer and a whole multiple of the QC*KC batch so a uniform push never wraps mid-unit.
+    // G>1 reuses the full-strip path (the fallback is not wired for groups); only fires if plane_heads
+    // exceeds the batch cap (QC>1 with plane_heads>32).
+    TT_FATAL(
+        G == 1 || qk_col_batch > 1,
+        "num_groups {}>1 requires the full-strip path (got qk_col_batch=1; plane_heads {} likely > batch cap)",
+        G,
+        plane_heads);
+    // cb_qk stages the matmul output for the gate-mul phase; the fused path writes straight to the
+    // accumulator, so cb_qk is unused there (1 tile, L1 spent on a deeper cb_out_strip).
+    make_cb(cb_qk_arg, fuse_single ? 1u : (qk_col_batch * qk_batch_heads), acc_fmt, acc_tile);
+    // cb_out_strip holds the pooled/untilized output, normally double-buffered. The fused block-pool path
+    // deepens it to the whole unit's blocks so the pool and writer decouple (no 2-row-ring mutual stall).
+    const uint32_t out_strip_tiles =
+        (fuse_single && block_pool) ? (QC * blocks_per_unit) : 2 * (block_pool ? blocks_per_unit : KC);
+    make_cb(cb_out_strip_arg, out_strip_tiles, tt::DataFormat::Float16_b, bf16_tile);
+    // Block-max-pool scratch CBs (only when pooling): cb_scaler = one 1.0 reduce-MAX tile; cb_pool_scratch
+    // = the writer's one-tile row-assembly buffer.
+    if (block_pool) {
+        make_cb(cb_scaler_arg, 1, tt::DataFormat::Float16_b, bf16_tile);
+        make_cb(cb_pool_scratch_arg, 1, tt::DataFormat::Float16_b, bf16_tile);
+    }
+    // cb_acc_strip accumulates a whole unit's QC*KC strip, then untilizes under ONE pack_untilize bracket.
+    // max(2*KC, .) keeps the QC<=2 double buffer and a whole multiple of QC*KC so a push never wraps mid-unit.
     make_cb(cb_acc_strip_arg, std::max(2u * KC, QC * KC), acc_fmt, acc_tile);
 
-    // No up-front L1-fit guard: an oversized QC/KC/head_group config fails at CB allocation. The caller
-    // owns the knob trade-off (see glx_config() in the test).
-
-    // Common args: 7 dims then the CB indices in CbArg order (kernels read both from this shared base).
-    // chunk_t is NOT here -- it is a per-device compute runtime arg (derived from the coordinate above).
-    std::vector<uint32_t> common_ct = {Hi, Sqt, Tt, Dt, QC, KC, HB};
+    // Common args: 9 dims then the CB indices in CbArg order. chunk_t is NOT here (per-device runtime arg).
+    std::vector<uint32_t> common_ct = {Hi, Sqt, Tt, Dt, QC, KC, HB, G, block_tiles};
     common_ct.insert(common_ct.end(), cb_id.begin(), cb_id.end());
 
     std::vector<uint32_t> reader_ct = common_ct;
     tt::tt_metal::TensorAccessorArgs(*q.buffer()).append_to(reader_ct);
     tt::tt_metal::TensorAccessorArgs(*k.buffer()).append_to(reader_ct);
     tt::tt_metal::TensorAccessorArgs(*w.buffer()).append_to(reader_ct);
-    // multicast: on/off per direction (q_mcast_on covers q and w) then the 6 semaphore ids, at fixed
-    // offsets right after the three TensorAccessors.
+    // multicast: on/off per direction (q_mcast_on covers q and w) then the 6 semaphore ids.
     reader_ct.push_back(k_mcast_on);
     reader_ct.push_back(q_mcast_on);
     reader_ct.push_back(k_send_sem);
@@ -298,16 +314,26 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
     reader_ct.push_back(q_send_sem);
     reader_ct.push_back(q_recv_sem);
     reader_ct.push_back(q_valid_sem);
+    // Fused single-head: reader reads q+w FIRST (the matmul gate needs them), then streams k (when no mcast).
+    reader_ct.push_back(fuse_single ? 1u : 0u);
+    reader_ct.push_back(fused_stream_k ? 1u : 0u);  // fused: stream k (no mcast) vs whole mcast block
 
     std::vector<uint32_t> writer_ct = common_ct;
-    const uint32_t out_elem_bytes = out.element_size();  // from the output tensor's dtype (bf16 today)
-    writer_ct.push_back(T * out_elem_bytes);             // row-major page = one full row of T scores
+    const uint32_t out_elem_bytes = out.element_size();  // bf16 today
+    // row-major page = one output row: T scores, or nblocks block-scores when pooling.
+    const uint32_t out_row_elems = block_pool ? nblocks : T;
+    writer_ct.push_back(out_row_elems * out_elem_bytes);
     tt::tt_metal::TensorAccessorArgs(*out.buffer()).append_to(writer_ct);
 
     std::vector<uint32_t> compute_ct = common_ct;
     compute_ct.push_back(qk_subblock_h);
-    compute_ct.push_back(qk_batch_heads);  // head tiles per matmul/mul phase chunk
-    compute_ct.push_back(qk_col_batch);    // k-columns batched per mode switch in the full-strip path
+    compute_ct.push_back(qk_batch_heads);             // head tiles per matmul/mul phase chunk
+    compute_ct.push_back(qk_col_batch);               // k-columns batched per mode switch in the full-strip path
+    compute_ct.push_back(args.apply_relu ? 1u : 0u);  // 1 = relu(q.kT) (DSA/GLM), 0 = raw q.kT (M3)
+    // Fused single-head fast path: plane_heads==1, no ReLU, bf16 q (the gate is applied to q in place, so
+    // bfp8 q falls back). GLM/DSv32 and bfp8-q MSA fall back, byte-identical.
+    compute_ct.push_back(fuse_single ? 1u : 0u);
+    compute_ct.push_back(fused_stream_k ? 1u : 0u);  // fused: incremental k wait (stream) vs whole-chunk
 
     const std::string kdir = "ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/";
     auto reader_id = tt::tt_metal::CreateKernel(
@@ -326,13 +352,10 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
             .compile_args = compute_ct});
 
     // Per-core args: schedule {row_group0, group_stride, num_groups, band0, num_bands, max_bands} then
-    // (reader only) the K-column + Q/W-row mcast 8-tuples. role is a McastRole (none = per-core DRAM read); rect
-    // (xs,ys,xe,ye) + sender (sx,sy) are physical NoC; ndst = #receivers. mcast rects are fixed per core
-    // (one column for k, one row for q); only the data changes per group/band phase.
+    // (reader only) the K-column + Q/W-row mcast 8-tuples (role, rect xs/ys/xe/ye, sender sx/sy, ndst). The
+    // mcast rects are fixed per core; only the data changes per phase.
     const auto u32 = [](auto v) { return static_cast<uint32_t>(v); };
-    // Indexed-cache k page offset and valid kv_len, baked here for the cache-miss build and re-applied each
-    // dispatch in override_runtime_arguments (both excluded from the hash). The grid/work-split above stay
-    // keyed on the hashed Tt; kv_len_tiles only narrows the per-cell columns the kernels touch.
+    // Indexed-cache k page offset + valid kv_len, baked at miss and re-applied each dispatch (both hash-excluded).
     const auto [k_batch_page_offset, kv_len_tiles] = persistent_cache_args(args, k);
     std::vector<CoreCoord> cores;
     cores.reserve(num_cores);
@@ -358,8 +381,7 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
 
             const CoreCoord core{col, row};
             cores.push_back(core);
-            // {row_group0, group_stride, num_groups, band0, num_bands, max_bands}. max_bands is uniform
-            // (the row's widest column); the streaming reader/compute pad their band loop to it.
+            // max_bands is uniform (the row's widest column); streaming pads its band loop to it.
             const std::array<uint32_t, 6> sched = {
                 row, rows_used, num_groups, col_band_start[col], col_band_size[col], max_bands};
 
@@ -399,13 +421,11 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
                 q_py,
                 q_sender,
                 cols_used - 1);
-            // Persistent-cache args last (slots reader[25,26]): after the mcast tuples in both branches.
+            // Persistent-cache args last (slots reader[25,26]).
             reader_rt.push_back(k_batch_page_offset);
             reader_rt.push_back(kv_len_tiles);
             tt::tt_metal::SetRuntimeArgs(program, reader_id, core, reader_rt);
-            // compute: schedule scalars[0-5], then kv_len_tiles[6] and chunk_start_tiles[7]. Both are
-            // hash-excluded runtime values -- kv_len is per-dispatch, chunk_t is per-device (from the
-            // coordinate) -- so distinct values reuse one compiled program.
+            // compute: schedule[0-5], then kv_len_tiles[6] + chunk_start_tiles[7] (both hash-excluded runtime).
             std::vector<uint32_t> compute_rt(sched.begin(), sched.end());
             compute_rt.push_back(kv_len_tiles);  // slot [6]
             compute_rt.push_back(chunk_t);       // slot [7]
@@ -413,6 +433,7 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
             std::vector<uint32_t> writer_rt = {out.buffer()->address()};
             writer_rt.insert(writer_rt.end(), sched.begin(), sched.end());
             writer_rt.push_back(kv_len_tiles);  // slot [7], after out_addr + the 6 schedule scalars
+            writer_rt.push_back(chunk_t);       // slot [8], per-device chunk-start (tiles); block-pool forced-local
             tt::tt_metal::SetRuntimeArgs(program, writer_id, core, writer_rt);
         }
     }
@@ -434,8 +455,7 @@ IndexerScoreProgramFactory::cached_mesh_workload_t IndexerScoreProgramFactory::c
     tensor_return_value_t& out) {
     tt::tt_metal::distributed::MeshWorkload mesh_workload;
     std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
-    // One program per coordinate: each device derives its own chunk_start from its coordinate. A single
-    // device is a 1x1 mesh, so this loops once with index 0 (the single-chip / scalar path).
+    // One program per coordinate (each device derives its own chunk_start); a single device loops once at index 0.
     for (const auto& range : tensor_coords.ranges()) {
         for (const auto& coord : range) {
             const ttnn::MeshCoordinateRange single{coord, coord};
@@ -452,9 +472,8 @@ void IndexerScoreProgramFactory::override_runtime_arguments(
     const operation_attributes_t& args,
     const tensor_args_t& tensors,
     tensor_return_value_t& out) {
-    // All hash-excluded runtime values re-applied on a cache hit: buffer addresses (uniform across the mesh),
-    // cache_batch_idx / kv_len (per-dispatch), and chunk_start (per-coordinate, recomputed from the stored
-    // device_index) -- so a hit patches all of them without recompiling.
+    // Re-apply all hash-excluded runtime values on a hit: buffer addresses, cache_batch_idx / kv_len, and
+    // chunk_start (per-coordinate, from the stored device_index).
     const uint32_t Sq = tensors.q.logical_shape()[2];
     const auto [k_batch_page_offset, kv_len_tiles] = persistent_cache_args(args, tensors.k);
     for (auto& [range, shared] : cached.shared_variables) {
@@ -474,6 +493,7 @@ void IndexerScoreProgramFactory::override_runtime_arguments(
             patch_arg(compute_args[core.x][core.y], rt_arg::compute_chunk_start_tiles, chunk_t, "compute.chunk_start");
             patch_arg(writer_args[core.x][core.y], rt_arg::writer_out_addr, out.buffer()->address(), "writer.out_addr");
             patch_arg(writer_args[core.x][core.y], rt_arg::writer_kv_len_tiles, kv_len_tiles, "writer.kv_len_tiles");
+            patch_arg(writer_args[core.x][core.y], rt_arg::writer_chunk_start_tiles, chunk_t, "writer.chunk_start");
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/compute_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/compute_indexer_score.cpp
@@ -2,11 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Compute for indexer_score. Per work unit (QC q-rows x KC k-cols):
-//   acc[r,c] = sum_h relu(q[h,row] @ k[col]^T) * w[h,row], then causal -inf mask,
-//   then pack_untilize -> bf16 row-major out.
-// Heads stream in groups (heads_per_dest_pass rows per DEST pass, half-sync bf16 DEST);
-// q/w stay resident when all heads fit.
+// Compute for indexer_score. Per work unit (QC q-rows x KC k-cols), per output plane:
+//   acc = sum_{h in group} act(q[h]@k^T)*w[h], causal -inf mask, then untilize (or block-max-pool).
+//   act = relu when apply_relu, else identity (raw dot). num_out_groups==1 sums all heads -> 1 plane;
+//   >1 keeps the groups separate. Heads stream in DEST passes (half-sync bf16); q/w resident when they fit.
 
 #include <cstdint>
 #include "api/compute/compute_kernel_api.h"
@@ -17,46 +16,61 @@
 #include "api/compute/reconfig_data_format.h"
 #include "api/compute/cb_api.h"
 #include "api/compute/tile_move_copy.h"
+#include "api/compute/reduce.h"            // block-max-pool: PoolType / ReduceDim enums
+#include "api/compute/reduce_custom.h"     // block-max-pool: batched reduce_block_max_row (scaler-resident)
 #include "api/dataflow/circular_buffer.h"  // Device 2.0 CircularBuffer wrapper (cb ops)
 
 #include "ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"  // block-max-pool: compute_kernel_lib::reduce
 #include "indexer_score_common.hpp"  // shared CB indices, compile-time dims, work-unit walk
 #include "api/compute/experimental/indexer_mul_custom.h"
 
-// qk subblock height (head rows per DEST pass); first per-kernel compile-time arg.
+// qk subblock height (head rows per DEST pass).
 constexpr uint32_t heads_per_dest_pass = get_compile_time_arg_val(num_common_ct_args);
 // heads buffered in cb_qk per matmul/mul phase chunk (multiple of HP).
 constexpr uint32_t qk_batch_heads = get_compile_time_arg_val(num_common_ct_args + 1);
-// k-columns batched per matmul<->mul mode switch in the full-strip path (1 = per-column, no batching).
+// k-cols batched per matmul<->mul mode switch in the full-strip path (1 = per-column).
 constexpr uint32_t qk_col_batch = get_compile_time_arg_val(num_common_ct_args + 2);
+// 1 = relu(q.kT) before the gate-mul; 0 = raw q.kT (no relu).
+constexpr bool apply_relu = get_compile_time_arg_val(num_common_ct_args + 3) != 0;
 
-// k-cols sharing ONE dest acquire in the blocked-custom mul; bounded by the dest budget. One unpack
-// context per head loads w[h] + ct_dim qk cols, so unpack-context sync is paid 1/ct_dim as often as
-// the per-tile bcast-mul (the mul-phase bottleneck).
+// Fused single-head path (one head/plane, no relu, bf16 q; host-decided). Gate w folded onto q up front
+// ((w*q).k == w*(q.k), valid without relu) so the matmul writes the gated score straight to the
+// accumulator -- no cb_qk staging, no gate-mul phase. reduce_heads==1 keeps the per-row gate exact.
+constexpr bool fuse_single = get_compile_time_arg_val(num_common_ct_args + 4) != 0;
+// Fused + no mcast: stream k (waited incrementally in the matmul). Fused + mcast: k is one block, waited whole.
+constexpr bool fused_stream_k = get_compile_time_arg_val(num_common_ct_args + 5) != 0;
+
+// k-cols sharing ONE dest acquire in the blocked-custom mul (dest-bounded). One unpack context per head
+// (w[h] + ct_dim qk cols), so unpack-context sync is paid 1/ct_dim of the per-tile bcast-mul rate.
 constexpr uint32_t mul_ct_dim = (k_tiles_per_unit < heads_per_dest_pass) ? k_tiles_per_unit : heads_per_dest_pass;
 
-// Head reduction splits into a matmul phase (fill cb_qk with relu(q.kT)) and a mul phase (gate +
-// head-reduce into the accumulator) so the matmul<->eltwise reconfig happens once per batch, not per
-// head pass. Two implementations of that split live below: the head-major path
-// (matmul_phase + mul_phase, blocked-custom MUL, qk_col_batch > 1) and the per-column streaming
-// FALLBACK (accumulate_heads, qk_col_batch == 1). The set_*/set_mul_* helpers are shared by both.
+// Head reduction splits into a matmul phase (fill cb_qk) and a mul phase (gate + head-reduce) so the
+// matmul<->eltwise reconfig is per batch, not per head. Two impls: head-major (matmul_phase + mul_phase,
+// blocked-custom MUL, qk_col_batch > 1) and per-column streaming FALLBACK (accumulate_heads,
+// qk_col_batch == 1). The set_*/set_mul_* helpers are shared.
 
-/** srcA<-k, srcB<-q, matmul mode for the matmul phase. Reconfig order matters: matmul maps
- *  in1->srcA, in0->srcB, so swapping the reconfig misreads bfp8 k (bf16 k is unaffected). */
+/** srcA<-k, srcB<-q matmul mode. Reconfig order matters: matmul maps in1->srcA, in0->srcB, so swapping
+ *  it misreads bfp8 k (bf16 k unaffected). */
 template <uint32_t q_cb, uint32_t k_cb, uint32_t qk_cb>
 inline void set_matmul_mode() {
-    // guarded reconfig: srcA qk->k changes format (fires); srcB w->q is bf16->bf16 (skipped).
+    // guarded: srcA qk->k fires; srcB w->q is bf16->bf16 (skipped).
     reconfig_data_format(qk_cb, k_cb, cb_w, q_cb);
-    // guarded: no-op in the bf16 path; only the fp32-dest fallback (qk=fp32, out=bf16) reconfigs.
+    // guarded: no-op in bf16; only the fp32-dest fallback reconfigs.
     pack_reconfig_data_format(cb_out_strip, qk_cb);
-    pack_reconfig_l1_acc(0);  // cb_qk packs overwrite (mul phase turns L1-acc on for cb_acc_strip)
+    pack_reconfig_l1_acc(0);  // cb_qk packs overwrite
     mm_block_init_short(
         q_cb, k_cb, 1 /*transpose k*/, 1 /*ct_dim*/, heads_per_dest_pass /*rt_dim*/, head_dim_tiles /*kt_dim*/);
-    pack_relu_config(ReluConfig::zero());  // relu in the packer for the whole matmul phase
+    // relu(q.kT) in the packer when apply_relu; else linear, so the raw dot flows to the gate-mul.
+    if constexpr (apply_relu) {
+        pack_relu_config(ReluConfig::zero());
+    } else {
+        pack_relu_config(ReluConfig::none());
+    }
 }
 
-/** Matmul one DEST pass of relu(q.kT): HP head-rows of q-row q_row vs k-col k_col, left in DEST (caller
- *  packs). q blocks are [QC][HG][Dt] so head rows stride head_dim_tiles. Assumes set_matmul_mode() ran. */
+/** One DEST pass of q.kT (relu'd in the packer when apply_relu): HP head-rows of q_row vs k_col, left in
+ *  DEST (caller packs). q blocks are [QC][HG][Dt] so head rows stride head_dim_tiles. Assumes set_matmul_mode(). */
 template <uint32_t q_cb, uint32_t k_cb>
 inline void emit_qk_matmul_block(uint32_t head_in_group, uint32_t q_row, uint32_t k_col) {
     tile_regs_acquire();
@@ -76,7 +90,7 @@ inline void emit_qk_matmul_block(uint32_t head_in_group, uint32_t q_row, uint32_
     tile_regs_commit();
 }
 
-/** One matmul-phase DEST pass: relu(q-row q_row @ k-col k_col^T) block-packed into cb_qk front. */
+/** One matmul-phase DEST pass: act(q-row q_row @ k-col k_col^T) block-packed into cb_qk front. */
 template <uint32_t q_cb, uint32_t k_cb, uint32_t qk_cb>
 void matmul_relu_pass(uint32_t head_in_group, uint32_t q_row, uint32_t k_col) {
     CircularBuffer qk(qk_cb);
@@ -88,14 +102,13 @@ void matmul_relu_pass(uint32_t head_in_group, uint32_t q_row, uint32_t k_col) {
     qk.push_back(heads_per_dest_pass);
 }
 
-/** srcA<-qk, srcB<-w + pack format for a mul+accumulate phase (shared by the standard and
- *  blocked-custom mul; only the following bcast-mul init differs). */
+/** srcA<-qk, srcB<-w + pack format for a mul+accumulate phase (shared; only the bcast-mul init differs). */
 template <uint32_t qk_cb, uint32_t w_cb, uint32_t acc_cb>
 inline void set_mul_reconfig() {
     pack_relu_config(ReluConfig::none());  // accumulator packs stay linear (negative gates)
-    // guarded reconfig: srcA k->qk changes format (fires); srcB q->w is bf16->bf16 (skipped).
+    // guarded: srcA k->qk fires; srcB q->w is bf16->bf16 (skipped).
     reconfig_data_format(cb_k, qk_cb, cb_q, w_cb);
-    pack_reconfig_data_format(qk_cb, acc_cb);  // guarded: qk and acc share acc_fmt -> no-op.
+    pack_reconfig_data_format(qk_cb, acc_cb);  // guarded: qk/acc share acc_fmt -> no-op.
 }
 
 /** srcA<-qk, srcB<-w + bcast-mul mode for the mul+accumulate phase. */
@@ -103,15 +116,14 @@ template <uint32_t qk_cb, uint32_t w_cb, uint32_t acc_cb>
 inline void set_mul_mode() {
     set_mul_reconfig<qk_cb, w_cb, acc_cb>();
     mul_bcast_cols_init_short(qk_cb, w_cb);
-    // acc_to_dest=1: each mul MACs onto the same DEST tile (tile_regs_acquire zeroes it, head 0
-    // seeds), so the chunk's head reduction needs one pack, not a per-head packer-L1-acc RMW.
+    // acc_to_dest=1: each mul MACs onto the same DEST tile (head 0 seeds the acquire-zeroed reg), so the
+    // chunk's head reduction needs one pack, not a per-head packer-L1-acc RMW.
     MATH((llk_math_eltwise_binary_init<ckernel::EltwiseBinaryType::ELWMUL, ckernel::BroadcastType::COL, MATH_FIDELITY>(
         qk_cb, w_cb, 1 /*acc_to_dest*/)));
 }
 
-/** Mul+accumulate `chunk_heads` resident heads onto the output tile via hw MAC:
- *  dst0 += sum_h relu(qk[h]) * w[w_base+h], packed once to acc_cb[acc_slot]. `first` overwrites the
- *  slot (l1_acc off); later chunks L1-accumulate. Caller owns acc_cb and the l1_acc reset. */
+/** Mul+accumulate `chunk_heads` resident heads via hw MAC: dst0 += sum_h qk[h]*w[w_base+h], packed once
+ *  to acc_cb[acc_slot]. `first` overwrites the slot (l1_acc off); later chunks L1-accumulate. */
 template <uint32_t qk_cb, uint32_t w_cb, uint32_t acc_cb>
 void mul_accum_chunk(uint32_t w_base, uint32_t chunk_heads, bool first, uint32_t acc_slot) {
     CircularBuffer qk(qk_cb);
@@ -122,38 +134,41 @@ void mul_accum_chunk(uint32_t w_base, uint32_t chunk_heads, bool first, uint32_t
     }
     tile_regs_commit();
     tile_regs_wait();
-    pack_reconfig_l1_acc(first ? 0 : 1);  // first chunk seeds (overwrite), later chunks accumulate
+    pack_reconfig_l1_acc(first ? 0 : 1);  // first chunk overwrites, later chunks accumulate
     pack_tile<true>(0, acc_cb, acc_slot);
     tile_regs_release();
     qk.pop_front(chunk_heads);
 }
 
-/** Matmul DEST pass packed HEAD-MAJOR: head h's `cols` columns land contiguous in cb_qk (slot
- *  (head+d)*cols + col_in_batch), the layout the blocked mul streams as SrcA. Uses llk_matmul_pack
- *  out_of_order (generic pack misreads the matmul DEST layout). Caller reserves cols*num_heads once. */
+/** act(q.kT) DEST pass packed HEAD-MAJOR: head's `cols` cols land contiguous in cb_qk at slot
+ *  (pack_head+d)*cols + col_in_batch (the layout the blocked mul streams as SrcA). q_head = global head
+ *  for the matmul; pack_head = its index in the output group. Needs llk_matmul_pack out_of_order (generic
+ *  pack misreads the matmul DEST layout). Caller reserves cols*reduce_heads once. */
 template <uint32_t q_cb, uint32_t k_cb, uint32_t qk_cb>
 void matmul_relu_pass_headmajor(
-    uint32_t head_in_group, uint32_t q_row, uint32_t k_col, uint32_t col_in_batch, uint32_t cols) {
-    emit_qk_matmul_block<q_cb, k_cb>(head_in_group, q_row, k_col);
+    uint32_t q_head, uint32_t pack_head, uint32_t r, uint32_t c, uint32_t col_in_batch, uint32_t cols) {
+    emit_qk_matmul_block<q_cb, k_cb>(q_head, r, c);
     tile_regs_wait();
-    for (uint32_t dim_tile = 0; dim_tile < heads_per_dest_pass; ++dim_tile) {
+    for (uint32_t d = 0; d < heads_per_dest_pass; ++d) {
         PACK((llk_matmul_pack<DST_ACCUM_MODE, true /*out_of_order*/, PackMode::Default>(
-            dim_tile, qk_cb, 1 /*ntiles*/, (head_in_group + dim_tile) * cols + col_in_batch)));  // head-major slot
+            d,
+            qk_cb,
+            1 /*ntiles*/,
+            (pack_head + d) * cols + col_in_batch)));  // act(q.kT), head-major slot
     }
     tile_regs_release();
 }
 
-/** Like set_mul_mode but with the blocked-custom bcast-col MUL (one unpack context per head: w[h]
- *  loaded once + ct_dim qk cols, MAC-reduced in dest). Same reconfig. */
+/** Like set_mul_mode but with the blocked-custom bcast-col MUL (one unpack context per head: w[h] once +
+ *  ct_dim qk cols, MAC-reduced in dest). Same reconfig. */
 template <uint32_t qk_cb, uint32_t w_cb, uint32_t acc_cb>
 inline void set_mul_mode_custom() {
     set_mul_reconfig<qk_cb, w_cb, acc_cb>();
     mul_bcast_cols_init_short_custom(qk_cb, w_cb);
 }
 
-/** Per-column (qk_col_batch==1) head reduction for output tile (q_row, k_col): acc_cb[acc_slot] =
- *  sum_h relu(q[h,q_row].k[k_col]^T)*w[h,q_row], MAC'd in DEST per chunk, L1-acc only across chunks.
- *  Caller owns acc_cb. */
+/** Per-column (qk_col_batch==1) head reduction for tile (q_row, k_col): acc_cb[acc_slot] =
+ *  sum_h act(q[h,q_row].k[k_col]^T)*w[h,q_row], MAC'd in DEST per chunk, L1-acc only across chunks. */
 template <uint32_t acc_cb>
 inline void accumulate_heads(uint32_t q_row, uint32_t k_col, uint32_t acc_slot) {
     CircularBuffer q(cb_q);
@@ -162,8 +177,8 @@ inline void accumulate_heads(uint32_t q_row, uint32_t k_col, uint32_t acc_slot) 
         if constexpr (stream_heads) {
             q.wait_front(q_group_tiles);
         }
-        // per chunk (cb_qk capacity): run its matmuls, then MAC the chunk's head sum into DEST once,
-        // so the matmul<->eltwise reinit and the acc pack happen per chunk, not per head
+        // per chunk (cb_qk capacity): matmul it, then MAC its head sum into DEST once -- so the
+        // matmul<->eltwise reinit and the acc pack are per chunk, not per head
         for (uint32_t chunk = 0; chunk < heads_per_group; chunk += qk_batch_heads) {
             const uint32_t chunk_end = chunk + qk_batch_heads;
             set_matmul_mode<cb_q, cb_k, cb_qk>();
@@ -183,11 +198,10 @@ inline void accumulate_heads(uint32_t q_row, uint32_t k_col, uint32_t acc_slot) 
     pack_reconfig_l1_acc(0);  // done accumulating; downstream packs (mask, untilize) overwrite
 }
 
-/** Stamp the causal mask for absolute column `k_tile` onto acc write slot `slot` (written into the
- *  already-reserved acc_cb slot before its push_back, no repush). Two cases:
+/** Stamp the causal mask for absolute column `k_tile` onto acc slot `slot` (in place, no repush):
  *   - diagonal (k_tile == diag_tile): L1-ACCUMULATE the strict-upper -inf tile, keeping the lower tri.
- *   - past diagonal (incl. pad cols >= Tt): OVERWRITE with -inf, so stale-k garbage in a pad column is
- *     discarded rather than turned to nan by `garbage + -inf`. */
+ *   - past diagonal (incl. pad cols >= Tt): OVERWRITE with -inf, so stale-k garbage is discarded rather
+ *     than turned to nan by `garbage + -inf`. */
 template <uint32_t acc_cb, uint32_t mask_cb>
 inline void stamp_mask_tile(uint32_t slot, uint32_t k_tile, uint32_t diag_tile) {
     const bool is_diag = (k_tile == diag_tile);
@@ -204,49 +218,50 @@ inline void stamp_mask_tile(uint32_t slot, uint32_t k_tile, uint32_t diag_tile) 
 }
 
 // ---------------------------------------------------------------------------------------------------
-// The three per-unit phases, called in order from kernel_main:
-//   PHASE 1 matmul_phase  -- fill cb_qk with relu(q.kT) for a batch of a row's k-columns
-//   PHASE 2 mul_phase     -- gate-scale + head-reduce that batch into the unit accumulator
-//   PHASE 3 (inline)      -- untilize the whole accumulated QC x KC unit in one pack_untilize bracket
-// Phases 1/2 run per k-column batch: cb_qk holds one batch, so they alternate. When the batch is the
-// whole row (qk_col_batch == KC, heads8/16) that's one matmul + one mul per row; heads64
-// (qk_col_batch=2 < KC) interleaves per 2-column batch.
+// The three per-unit phases (in order from kernel_main):
+//   PHASE 1 matmul_phase -- fill cb_qk with act(q.kT) for a batch of a row's k-cols
+//   PHASE 2 mul_phase    -- gate-scale + head-reduce that batch into the accumulator
+//   PHASE 3 (inline)     -- untilize the whole QC x KC unit in one pack_untilize bracket
+// Phases 1/2 alternate per k-col batch (cb_qk holds one batch). A whole-row batch (qk_col_batch==KC) does
+// one of each per row; a smaller batch (qk_col_batch < KC) interleaves per batch.
 // ---------------------------------------------------------------------------------------------------
 
-/** PHASE 1 -- fill cb_qk HEAD-MAJOR with relu(q[:,q_row].k[col_base..]^T) for one k-col batch of q_row.
- *  One set_matmul_mode for the batch (reinit hoisted out of the col loop), one cb_qk reserve/push. */
-inline void matmul_phase(uint32_t q_row, uint32_t col_base, uint32_t cols) {
-    const uint32_t batch_tiles = cols * num_heads;
+/** PHASE 1 -- fill cb_qk HEAD-MAJOR with act(q[:,q_row].k[col_base..]^T) for one k-col batch of q_row.
+ *  One set_matmul_mode for the batch, one cb_qk reserve/push. */
+inline void matmul_phase(uint32_t r, uint32_t col_base, uint32_t cols, uint32_t head_base) {
+    const uint32_t batch_tiles = cols * reduce_heads;
     CircularBuffer qk(cb_qk);
     set_matmul_mode<cb_q, cb_k, cb_qk>();
     qk.reserve_back(batch_tiles);
     for (uint32_t col_in_batch = 0; col_in_batch < cols; ++col_in_batch) {
-        for (uint32_t head = 0; head < num_heads; head += heads_per_dest_pass) {
-            matmul_relu_pass_headmajor<cb_q, cb_k, cb_qk>(head, q_row, col_base + col_in_batch, col_in_batch, cols);
+        // hl walks this group's heads [head_base, +reduce_heads), packed head-major at hl.
+        for (uint32_t hl = 0; hl < reduce_heads; hl += heads_per_dest_pass) {
+            matmul_relu_pass_headmajor<cb_q, cb_k, cb_qk>(
+                head_base + hl, hl, r, col_base + col_in_batch, col_in_batch, cols);
         }
     }
     qk.push_back(batch_tiles);
 }
 
 /** PHASE 2 -- gate-multiply the batch's cb_qk by w and head-reduce into cb_acc_strip via the blocked
- *  bcast-col MUL. Per ct_dim-col sub-batch, one dest acquire holds the column accumulators; each head
- *  is one unpack context (w[h] once + ct_dim cols) that MACs onto dest[0..n_cols), so unpack-context
- *  sync is per head, not per (col, head). ELWMUL accumulates in dest -> one pack per column. cb_qk is
- *  head-major (head h's cols contiguous); whole batch shares one set_mul_mode (w is column-independent). */
-inline void mul_phase(uint32_t q_row, uint32_t slot_base, uint32_t col_base, uint32_t cols) {
-    const uint32_t batch_tiles = cols * num_heads;
-    const uint32_t w_base = q_row * num_heads;  // single chunk (group_start = 0); gate per (head, q_row)
-    // gates consumed only here: wait now (after this batch's matmuls) so the reader reads w behind the
-    // latency-critical q/k. Cumulative wait -> no-op once the resident group is in.
+ *  bcast-col MUL. Per ct_dim-col sub-batch, one dest acquire holds the col accumulators; each head is one
+ *  unpack context (w[h] once + ct_dim cols) MAC'ing onto dest[0..n_cols), so unpack-context sync is per
+ *  head, not per (col, head). cb_qk is head-major; whole batch shares one set_mul_mode (w col-independent). */
+inline void mul_phase(uint32_t r, uint32_t slot_base, uint32_t col_base, uint32_t cols, uint32_t head_base) {
+    const uint32_t batch_tiles = cols * reduce_heads;
+    // gate per (head, row); this group's heads are [head_base, +reduce_heads) of row r.
+    const uint32_t w_base = r * num_heads + head_base;
+    // gates used only here: wait now (after the matmuls) so the reader reads w behind the latency-critical
+    // q/k. Cumulative -> no-op once the resident group is in.
     CircularBuffer qk(cb_qk);
-    CircularBuffer(cb_w).wait_front(w_group_tiles);  // single use here; gates popped in kernel_main
+    CircularBuffer(cb_w).wait_front(w_group_tiles);  // gates popped in kernel_main
     set_mul_mode_custom<cb_qk, cb_w, cb_acc_strip>();
     qk.wait_front(batch_tiles);
     for (uint32_t sub_base = 0; sub_base < cols; sub_base += mul_ct_dim) {
         const uint32_t n_cols = (sub_base + mul_ct_dim <= cols) ? mul_ct_dim : (cols - sub_base);
         tile_regs_acquire();
-        for (uint32_t head = 0; head < num_heads; ++head) {
-            mul_tiles_bcast_cols_custom(cb_qk, cb_w, head * cols + sub_base, w_base + head, 0, n_cols);
+        for (uint32_t hl = 0; hl < reduce_heads; ++hl) {
+            mul_tiles_bcast_cols_custom(cb_qk, cb_w, hl * cols + sub_base, w_base + hl, 0, n_cols);
         }
         tile_regs_commit();
         tile_regs_wait();
@@ -259,19 +274,17 @@ inline void mul_phase(uint32_t q_row, uint32_t slot_base, uint32_t col_base, uin
 }
 
 /** PHASE 1+2 fallback for head-streaming / KC==1 (qk_col_batch == 1): each k-col runs accumulate_heads
- *  (matmul + STANDARD bcast-mul interleaved per head group). It reads cb_w by index, so wait the gates
- *  here (k already waited in kernel_main). */
+ *  (matmul + STANDARD bcast-mul per head group). Reads cb_w by index, so wait the gates here. */
 inline void accumulate_row_streaming(uint32_t q_row, uint32_t slot_base) {
     CircularBuffer(cb_w).wait_front(w_group_tiles);
     for (uint32_t k_col = 0; k_col < k_tiles_per_unit; ++k_col) {
-        accumulate_heads<cb_acc_strip>(q_row, k_col, slot_base + k_col);  // head reduction -> cb_acc_strip slot
+        accumulate_heads<cb_acc_strip>(q_row, k_col, slot_base + k_col);
     }
 }
 
-/** Streaming pad: a phantom band carries no k / no output -- it exists only to keep the row's q-mcast
- *  in lockstep (the reader re-issues the band-independent q reads on the short columns). Drain exactly
- *  the q blocks the reader pushed for one band -- QC*KC tiles x (Hi/HB) head groups -- consuming them
- *  without compute. Must mirror the reader's streaming q loop and accumulate_heads' q wait/pop count. */
+/** Streaming pad: a phantom band carries no k/output -- it only keeps the row's q-mcast in lockstep (the
+ *  reader re-issues the band-independent q reads on short columns). Drain exactly the q blocks the reader
+ *  pushed for one band -- QC*KC tiles x (Hi/HB) head groups -- without compute. Mirrors the reader's loop. */
 inline void drain_phantom_band_q() {
     CircularBuffer q(cb_q);
     for (uint32_t tile_idx = 0; tile_idx < q_tiles_per_unit * k_tiles_per_unit; ++tile_idx) {
@@ -282,8 +295,107 @@ inline void drain_phantom_band_q() {
     }
 }
 
-/** Stamp the causal -inf mask onto q_row's masked suffix [valid, KC) in place, so the strip still
- *  untilizes via the fast W=KC path (empty loop when the row is fully valid). */
+/** Fused single-head: scale resident q in place by gate w (per-query, bcast over head-dim).
+ *  q tile (head_base, row r, dim d) *= w[r, head_base]. One mul per q-tile instead of the per-output
+ *  gate-mul over KC columns. */
+inline void scale_q_by_w_inplace(uint32_t head_base) {
+    CircularBuffer q(cb_q);
+    CircularBuffer w(cb_w);
+    q.wait_front(q_group_tiles);
+    w.wait_front(w_group_tiles);
+    pack_relu_config(ReluConfig::none());
+    reconfig_data_format(cb_k, cb_q, cb_acc_strip, cb_w);  // srcA->q, srcB->w (guarded)
+    pack_reconfig_data_format(cb_out_strip, cb_q);         // pack->cb_q (bf16, in place)
+    mul_bcast_cols_init_short(cb_q, cb_w);
+    for (uint32_t r = 0; r < q_tiles_per_unit; ++r) {
+        const uint32_t w_idx = r * num_heads + head_base;
+        for (uint32_t d = 0; d < head_dim_tiles; ++d) {
+            const uint32_t q_idx = (r * heads_per_group + head_base) * head_dim_tiles + d;
+            tile_regs_acquire();
+            mul_tiles_bcast_cols(cb_q, cb_w, q_idx, w_idx, 0);
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_tile<true>(0, cb_q, q_idx);  // gated q back in place
+            tile_regs_release();
+        }
+    }
+}
+
+/** Fused single-head: srcA<-k, srcB<-q matmul mode packing straight to cb_acc_strip, no relu (raw dot;
+ *  q pre-gated by scale_q_by_w_inplace). */
+template <uint32_t q_cb, uint32_t k_cb, uint32_t acc_cb>
+inline void set_matmul_to_acc_mode() {
+    reconfig_data_format(cb_q, k_cb, cb_w, q_cb);  // srcA(q)->k, srcB(w)->q [guarded]
+    pack_reconfig_data_format(cb_q, acc_cb);       // pack->acc
+    pack_reconfig_l1_acc(0);
+    mm_block_init_short(q_cb, k_cb, 1 /*transpose k*/, 1 /*ct_dim*/, heads_per_dest_pass, head_dim_tiles);
+    pack_relu_config(ReluConfig::none());
+}
+
+/** Fused single-head matmul of n_cols tiles (row r, cols [c_base, +n_cols)) in ONE tile_regs acquire --
+ *  one DEST reg per col (n_cols <= DEST cap), each accumulating the head-dim matmul -- then pack together.
+ *  Amortizes the per-output acquire/release + pack overhead. Assumes set_matmul_to_acc_mode ran. */
+template <uint32_t q_cb, uint32_t k_cb, uint32_t acc_cb>
+inline void matmul_cols_to_acc(uint32_t head, uint32_t r, uint32_t c_base, uint32_t n_cols, uint32_t acc_slot_base) {
+    const uint32_t q_base = (r * heads_per_group + head) * head_dim_tiles;
+    tile_regs_acquire();
+    for (uint32_t col = 0; col < n_cols; ++col) {
+        for (uint32_t d = 0; d < head_dim_tiles; ++d) {
+            matmul_block(
+                q_cb,
+                k_cb,
+                q_base + d,
+                (c_base + col) * head_dim_tiles + d,
+                col,
+                1 /*transpose k*/,
+                1,
+                heads_per_dest_pass,
+                head_dim_tiles);
+        }
+    }
+    tile_regs_commit();
+    tile_regs_wait();
+    for (uint32_t col = 0; col < n_cols; ++col) {
+        pack_tile<true>(col, acc_cb, acc_slot_base + col);
+    }
+    tile_regs_release();
+}
+
+/** Custom batched block-max-pool (vs compute_kernel_lib::reduce<MAX,REDUCE_ROW> for the pooled path). bf16
+ *  MAX+REDUCE_ROW is the FPU/GMPOOL path, so per-output cost beyond the reduce is just acquire/release +
+ *  pack. The library reduces ONE block per acquire; this batches ALL blocks_per_unit blocks of a q-row
+ *  into one acquire (one DEST reg per block), cutting acquire/release ~blocks_per_unit x. reduce_init's
+ *  packer mask puts each block's per-query max in col 0 (writer reads col 0). Requires
+ *  blocks_per_unit <= DEST cap (8 half-sync); fall back to the library reduce when it exceeds that. */
+template <uint32_t acc_cb, uint32_t scaler_cb, uint32_t out_cb>
+inline void block_max_pool_batched(uint32_t unit_strip) {
+    CircularBuffer acc(acc_cb);
+    CircularBuffer out(out_cb);
+    acc.wait_front(unit_strip);
+    // One reduce_block_max_row per block folds block_tiles k-tiles into DEST[b] in one call, the 1.0
+    // scaler resident in srcB across the block_tiles GMPOOL-MAX ops -- killing the per-reduce_tile
+    // math-thread dispatch overhead that bound the pool. block_tiles is compile-time -> template arg.
+    reduce_block_max_row_init<block_tiles>(out_cb);
+    for (uint32_t r = 0; r < q_tiles_per_unit; ++r) {
+        out.reserve_back(blocks_per_unit);
+        tile_regs_acquire();
+        for (uint32_t b = 0; b < blocks_per_unit; ++b) {
+            const uint32_t base = r * k_tiles_per_unit + b * block_tiles;
+            reduce_block_max_row<block_tiles>(acc_cb, scaler_cb, base, b);
+        }
+        tile_regs_commit();
+        tile_regs_wait();
+        for (uint32_t b = 0; b < blocks_per_unit; ++b) {
+            pack_tile<true>(b, out_cb, b);  // DEST[b] (block b col-0 maxes) -> slot b
+        }
+        tile_regs_release();
+        out.push_back(blocks_per_unit);
+    }
+    reduce_block_max_row_uninit(acc_cb);
+    acc.pop_front(unit_strip);
+}
+
+/** Stamp the causal -inf mask onto row r's masked suffix [valid, KC) in place (empty when fully valid). */
 inline void stamp_masked_suffix(
     const WorkUnitSpan& span,
     uint32_t q_row,
@@ -299,19 +411,19 @@ inline void stamp_masked_suffix(
 }
 
 void kernel_main() {
-    // Generalized banded schedule: this core owns a (group-phase x band) rectangle. groups stream in
-    // num_groups phases (absolute group = row_group0 + p*group_stride); within each it walks num_bands
-    // contiguous k-bands (absolute band = band0 + j). One (group, band) cell == one QC x KC work unit.
+    // Banded schedule: this core owns a (group-phase x band) rectangle. groups stream in num_groups phases
+    // (group = row_group0 + p*group_stride); each walks num_bands k-bands (band = band0 + j). One cell ==
+    // one QC x KC work unit.
     const uint32_t row_group0 = get_arg_val<uint32_t>(0);
     const uint32_t group_stride = get_arg_val<uint32_t>(1);
     const uint32_t num_groups = get_arg_val<uint32_t>(2);
     const uint32_t band0 = get_arg_val<uint32_t>(3);
     const uint32_t num_bands = get_arg_val<uint32_t>(4);
     const uint32_t max_bands = get_arg_val<uint32_t>(5);  // row's widest column; streaming drains q to this
-    // Valid KV length in tiles: caps each cell's valid columns (the causal mask suffix grows to cover the
-    // unwritten tail). Full k_len_tiles when not set, so the dense path is unchanged. Excluded from the hash.
+    // Valid KV length in tiles: caps each cell's valid cols (mask suffix grows over the tail). Full when
+    // unset (dense path unchanged). Hash-excluded.
     const uint32_t kv_len_tiles = get_arg_val<uint32_t>(6);
-    // Per-device chunk-start offset (tiles), from the mesh coordinate; runtime so distinct values reuse one program.
+    // Per-device chunk-start offset (tiles); runtime so distinct values reuse one program.
     const uint32_t chunk_start_tiles = get_arg_val<uint32_t>(7);
     if (num_groups == 0 || num_bands == 0) {
         return;
@@ -319,9 +431,11 @@ void kernel_main() {
 
     mm_block_init(
         cb_q, cb_k, cb_qk, 1 /*transpose k*/, 1 /*ct_dim*/, heads_per_dest_pass /*rt_dim*/, head_dim_tiles /*kt_dim*/);
-    CircularBuffer(cb_mask).wait_front(num_mask_tiles);  // single use; the mask CB is never popped
+    CircularBuffer(cb_mask).wait_front(num_mask_tiles);  // never popped
+    if constexpr (block_pool) {
+        CircularBuffer(cb_scaler).wait_front(1);  // 1.0 reduce-MAX scaler, reused, never popped
+    }
 
-    // CBs touched twice below (wait/pop, reserve/push) get one instance each.
     CircularBuffer k(cb_k);
     CircularBuffer acc(cb_acc_strip);
     CircularBuffer q(cb_q);
@@ -332,62 +446,132 @@ void kernel_main() {
     constexpr uint32_t unit_strip = q_tiles_per_unit * k_tiles_per_unit;  // QC x KC accumulator slots
     constexpr uint32_t q_row_tiles = q_group_tiles / q_tiles_per_unit;    // heads_per_group * head_dim_tiles
 
-    // group-OUTER, band-INNER: q/w resident for a group's whole band run (reader pushes one q+w block per
-    // group); each band is one QC x KC unit. The dense schedule may leave a partial last band (valid < KC),
-    // masked in stamp_masked_suffix.
-    //
-    // Streaming pads the band loop to max_bands to match the reader's q-mcast lockstep across the row: a
-    // phantom band [num_bands, max_bands) only drains the (band-independent) q the reader re-issued -- no
-    // k, no compute, no output. Resident never pads (band_iters == num_bands).
+    // group-OUTER, band-INNER: q/w resident for a group's whole band run; each band is one QC x KC unit.
+    // A partial last band (valid < KC) is masked in stamp_masked_suffix. Streaming pads the loop to
+    // max_bands for q-mcast lockstep: a phantom band [num_bands, max_bands) only drains the re-issued q
+    // (no k/compute/output). Resident never pads.
     const uint32_t band_iters = stream_heads ? max_bands : num_bands;
     for (uint32_t phase = 0; phase < num_groups; ++phase) {
         const uint32_t group = row_group0 + phase * group_stride;
         for (uint32_t band = 0; band < band_iters; ++band) {
             if constexpr (stream_heads) {
                 if (band >= num_bands) {
-                    drain_phantom_band_q();  // padded q-mcast rendezvous only; no compute/output
+                    drain_phantom_band_q();  // q-mcast rendezvous only; no compute/output
                     continue;
                 }
             }
             span.set(group, band0 + band);
-            k.wait_front(k_chunk_tiles);
+            // Fused + streamed k waits incrementally inside the matmul (overlap the DRAM read); all other
+            // paths wait the whole chunk here.
+            if constexpr (!fuse_single || !fused_stream_k) {
+                k.wait_front(k_chunk_tiles);
+            }
             const uint32_t k_tiles_in_unit = span.k_tiles();
 
-            acc.reserve_back(unit_strip);
-            for (uint32_t q_row = 0; q_row < q_tiles_per_unit; ++q_row) {
-                // wait q rows 0..q_row only (reader pushes per row): row q_row reads only its row, so row 0
-                // runs while row 1 arrives. Cumulative + non-consuming -> immediate once q is resident.
-                if constexpr (!stream_heads) {
-                    q.wait_front((q_row + 1) * q_row_tiles);
+            // Fused single-head: gate resident q by w IN PLACE once per group load (band 0; q is reused
+            // across bands, so per-band scaling would compound w). One pass per output plane's head.
+            if constexpr (fuse_single) {
+                if (band == 0) {
+                    for (uint32_t g = 0; g < num_out_groups; ++g) {
+                        scale_q_by_w_inplace(g * reduce_heads);
+                    }
                 }
-                const uint32_t slot_base = q_row * k_tiles_per_unit;
+            }
 
-                // PHASE 1 (matmul) + PHASE 2 (mul) per k-col batch. cb_qk holds one batch, so they
-                // alternate; GLM5/DSv32 (heads8/16) = one of each per row.
-                if constexpr (qk_col_batch > 1) {
-                    for (uint32_t col_base = 0; col_base < k_tiles_per_unit; col_base += qk_col_batch) {
-                        const uint32_t cols = (col_base + qk_col_batch <= k_tiles_per_unit)
-                                                  ? qk_col_batch
-                                                  : (k_tiles_per_unit - col_base);
-                        matmul_phase(q_row, col_base, cols);          // PHASE 1: relu(q.kT) -> cb_qk (head-major)
-                        mul_phase(q_row, slot_base, col_base, cols);  // PHASE 2: gate-mul + head-reduce
+            // One output plane per group (g-major): group g sums only its reduce_heads heads into the
+            // accumulator, then untilizes/pools its own plane. num_out_groups==1 = head-summed (one plane);
+            // >1 = per-group planes. k/q/w resident across all groups.
+            for (uint32_t g = 0; g < num_out_groups; ++g) {
+                const uint32_t head_base = g * reduce_heads;
+                if constexpr (fuse_single) {
+                    // Matmul the whole unit straight to the accumulator (q pre-gated). Matmul-all then
+                    // mask-all keeps ONE matmul-mode set and ONE srcA reconfig.
+                    acc.reserve_back(unit_strip);
+                    set_matmul_to_acc_mode<cb_q, cb_k, cb_acc_strip>();
+                    {
+                        // mm_col_batch: DEST column batch (half-sync bf16 capacity), shared with the reader's
+                        // k-stream chunk so producer/consumer granularities match (indexer_score_common.hpp).
+                        // Column-outer: wait only this sub-chunk's k tiles, matmul for ALL rows, then next --
+                        // consuming k as the reader streams it. k indexed absolutely into cb_k.
+                        for (uint32_t c = 0; c < k_tiles_per_unit; c += mm_col_batch) {
+                            const uint32_t c_end =
+                                (c + mm_col_batch <= k_tiles_per_unit) ? (c + mm_col_batch) : k_tiles_per_unit;
+                            const uint32_t n = c_end - c;
+                            if constexpr (fused_stream_k) {
+                                k.wait_front(c_end * head_dim_tiles);  // streamed: wait k cols [0, c_end)
+                            }
+                            for (uint32_t r = 0; r < q_tiles_per_unit; ++r) {
+                                matmul_cols_to_acc<cb_q, cb_k, cb_acc_strip>(head_base, r, c, n, r * k_tiles_per_unit + c);
+                            }
+                        }
+                    }
+                    // Matmul left srcA in k's format; the mask copies a bf16 -inf tile -> reconfig srcA to bf16.
+                    reconfig_data_format_srca(cb_k, cb_mask);
+                    for (uint32_t r = 0; r < q_tiles_per_unit; ++r) {
+                        stamp_masked_suffix(span, r, r * k_tiles_per_unit, k_tiles_in_unit, chunk_start_tiles);
+                    }
+                    acc.push_back(unit_strip);
+                } else {
+                    acc.reserve_back(unit_strip);
+                    for (uint32_t q_row = 0; q_row < q_tiles_per_unit; ++q_row) {
+                        // wait q rows 0..q_row only (reader pushes per row), so row 0 runs while row 1
+                        // arrives. Cumulative + non-consuming -> immediate once resident; no-op for g>0.
+                        if constexpr (!stream_heads) {
+                            q.wait_front((q_row + 1) * q_row_tiles);
+                        }
+                        const uint32_t slot_base = q_row * k_tiles_per_unit;
+
+                        // PHASE 1 (matmul) + PHASE 2 (mul) per k-col batch (cb_qk holds one batch, so they
+                        // alternate); a whole-row batch = one of each per row.
+                        if constexpr (qk_col_batch > 1) {
+                            for (uint32_t col_base = 0; col_base < k_tiles_per_unit; col_base += qk_col_batch) {
+                                const uint32_t cols = (col_base + qk_col_batch <= k_tiles_per_unit)
+                                                          ? qk_col_batch
+                                                          : (k_tiles_per_unit - col_base);
+                                matmul_phase(q_row, col_base, cols, head_base);          // act(q.kT)->cb_qk
+                                mul_phase(q_row, slot_base, col_base, cols, head_base);  // gate-mul + reduce
+                            }
+                        } else {
+                            // head-streaming / KC==1 fallback (all heads -> one plane; G==1 only).
+                            accumulate_row_streaming(q_row, slot_base);
+                        }
+
+                        stamp_masked_suffix(span, q_row, slot_base, k_tiles_in_unit, chunk_start_tiles);
+                    }
+                    acc.push_back(unit_strip);
+                }
+
+                // PHASE 3 -- emit this plane's output. block_size==0: untilize the QC strips in one
+                // pack_untilize bracket. block-pool: reduce<MAX,REDUCE_ROW> over the masked unit, each block
+                // folded to one col-0 tile (writer reads col 0). Future keys are -inf so straddling/future
+                // blocks pool correctly.
+                if constexpr (block_pool) {
+                    // Batch all blocks of a q-row into one DEST acquire when they fit (<= 8 half-sync);
+                    // else the library reduce (one acquire per block).
+                    if constexpr (blocks_per_unit <= 8) {
+                        block_max_pool_batched<cb_acc_strip, cb_scaler, cb_out_strip>(unit_strip);
+                    } else {
+                        compute_kernel_lib::reduce<
+                            PoolType::MAX,
+                            ReduceDim::REDUCE_ROW,
+                            cb_acc_strip,
+                            cb_scaler,
+                            cb_out_strip,
+                            compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(
+                            compute_kernel_lib::ReduceInputBlockShape::of(
+                                /*rows = blocks/row */ blocks_per_unit,
+                                /*cols = tiles/block */ block_tiles,
+                                /*batches = q-rows */ q_tiles_per_unit));
                     }
                 } else {
-                    accumulate_row_streaming(q_row, slot_base);  // PHASE 1+2 head-streaming / KC==1 fallback
+                    compute_kernel_lib::untilize<k_tiles_per_unit, cb_acc_strip, cb_out_strip>(q_tiles_per_unit);
                 }
-
-                // causal -inf on masked suffix; chunk_start_tiles is the per-device runtime offset.
-                stamp_masked_suffix(span, q_row, slot_base, k_tiles_in_unit, chunk_start_tiles);
             }
-            acc.push_back(unit_strip);
-
-            // PHASE 3 -- untilize all QC strips in ONE pack_untilize bracket (cost amortizes over QC*KC).
-            compute_kernel_lib::untilize<k_tiles_per_unit, cb_acc_strip, cb_out_strip>(q_tiles_per_unit);
 
             k.pop_front(k_chunk_tiles);
         }
-        // group's bands done: release this group's resident q/w (one block was pushed per group).
-        CircularBuffer(cb_w).pop_front(w_group_tiles);  // gates waited in the mul phase
+        // group's bands done: release its resident q/w (one block per group).
+        CircularBuffer(cb_w).pop_front(w_group_tiles);  // gates waited in the mul/scale phase
         if constexpr (!stream_heads) {
             q.pop_front(q_group_tiles);
         }

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_cb.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_cb.hpp
@@ -2,10 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// CB-index argument layout for indexer_score. The factory allocates the concrete (continuous)
-// circular-buffer indices and forwards them to the reader / compute / writer kernels as compile-time
-// args; this enum is the single-sourced slot order both sides agree on (host push-order ==
-// device read-order), so the index of any buffer can never drift between host and device.
+// CB-index argument layout for indexer_score. The factory forwards the concrete CB indices to the kernels
+// as compile-time args; this enum is the single-sourced slot order both sides agree on (host push-order ==
+// device read-order), so no buffer index can drift between host and device.
 
 #pragma once
 
@@ -13,24 +12,26 @@
 
 namespace ttnn::operations::experimental::indexer_score {
 
-// One slot per circular buffer, in the order the factory appends the CB indices to the common
-// compile-time args. Kernels read each back at (num common dim args) + the matching slot.
+// One slot per circular buffer, in the order the factory appends the CB indices. Kernels read each back
+// at (num common dim args) + the matching slot.
 enum CbArg : uint32_t {
-    cb_q_arg,          // q head-group block: heads_per_group * QC * Dt tiles
-    cb_k_arg,          // k chunk, double buffered
-    cb_w_arg,          // resident gate (w) group: Hi * QC tiles
-    cb_mask_arg,       // [diag strict-upper -inf, full -inf], built once
-    cb_qk_arg,         // relu(q.kT) for a whole head group
-    cb_acc_strip_arg,  // unit accumulator: QC x KC strip (untilize input)
-    cb_out_strip_arg,  // untilized row-major strip output
+    cb_q_arg,             // q head-group block: heads_per_group * QC * Dt tiles
+    cb_k_arg,             // k chunk, double buffered
+    cb_w_arg,             // resident gate (w) group: Hi * QC tiles
+    cb_mask_arg,          // [diag strict-upper -inf, full -inf], built once
+    cb_qk_arg,            // act(q.kT) for a whole head group
+    cb_acc_strip_arg,     // unit accumulator: QC x KC strip (untilize input)
+    cb_out_strip_arg,     // untilized row-major strip output (block_size==0); tilized col-0 block-max (pool)
+    cb_scaler_arg,        // block-max-pool only: one 1.0 tile (reduce-MAX scaler); index 0 / unused otherwise
+    cb_pool_scratch_arg,  // block-max-pool only: writer's one-tile row-assembly scratch; unused otherwise
     num_cb_args
 };
 
 // Two mask tiles in cb_mask: index 0 = diagonal strict-upper -inf, index 1 = full -inf.
 constexpr uint32_t num_mask_tiles = 2;
 
-// Per-direction multicast role, written by the factory into the reader's runtime args and switched on by
-// the reader. Single-sourced here so the host writer and device reader can't drift on the encoding.
+// Per-direction multicast role, written by the factory into the reader's runtime args. Single-sourced
+// here so host and device can't drift on the encoding.
 enum McastRole : uint32_t {
     mcast_role_none = 0,      // no multicast: plain per-core DRAM read
     mcast_role_sender = 1,    // reads DRAM, then multicasts the block to the rect

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_common.hpp
@@ -2,9 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Shared by indexer_score reader / compute / writer: common compile-time dims (args
-// 0..7), CB indices, derived group/chunk tile counts, and WorkUnitSpan (this core's
-// cursor over its (group-phase x k-band) rectangle). One cell = QC q-tile-rows x up-to-KC k-tiles.
+// Shared by reader/compute/writer: common compile-time dims, CB indices, derived tile counts, and
+// WorkUnitSpan (this core's cursor over its (group-phase x k-band) rectangle; one cell = QC x up-to-KC).
 
 #pragma once
 
@@ -15,8 +14,8 @@
 
 namespace iscore = ttnn::operations::experimental::indexer_score;
 
-// Common dim args 0..6 (same in every kernel). chunk_start is NOT here -- it is a per-device RUNTIME arg
-// (from the mesh coordinate; see the factory and compute kernel_main), so distinct values reuse one program.
+// Common dim args 0..8 (same in every kernel). chunk_start is NOT here -- it's a per-device RUNTIME arg,
+// so distinct values reuse one program.
 constexpr uint32_t num_heads = get_compile_time_arg_val(0);         // indexer heads
 constexpr uint32_t q_len_tiles = get_compile_time_arg_val(1);       // q chunk rows, in tiles
 constexpr uint32_t k_len_tiles = get_compile_time_arg_val(2);       // total k positions, in tiles
@@ -24,10 +23,20 @@ constexpr uint32_t head_dim_tiles = get_compile_time_arg_val(3);    // head dim,
 constexpr uint32_t q_tiles_per_unit = get_compile_time_arg_val(4);  // q-tile-rows per work unit (q_chunk knob)
 constexpr uint32_t k_tiles_per_unit = get_compile_time_arg_val(5);  // k tiles per work unit (k_chunk knob)
 constexpr uint32_t heads_per_group = get_compile_time_arg_val(6);   // heads resident at once (head_group knob)
-constexpr uint32_t num_dim_args = 7;
+constexpr uint32_t num_out_groups = get_compile_time_arg_val(7);    // output groups; score [B, num_out_groups, Sq, T]
+constexpr uint32_t block_tiles = get_compile_time_arg_val(8);       // block-max-pool width in k-tiles; 0 = no pooling
+constexpr uint32_t num_dim_args = 9;
 
-// CB indices, forwarded from the factory in CbArg order right after the dim args. Bare names so
-// kernels (and their template-arg uses) read like the host-side constants did.
+// Heads summed per output plane. num_out_groups==1 sums all heads into one plane; >1 partitions into
+// num_out_groups groups of reduce_heads each, summed within a group (per-group planes).
+constexpr uint32_t reduce_heads = num_heads / num_out_groups;
+
+// Block-max-pool: each block_tiles consecutive k-tiles max-reduce to ONE block score, so a unit emits
+// blocks_per_unit tiles (col-0 = per-query block max) instead of the full KC strip.
+constexpr bool block_pool = block_tiles != 0;
+constexpr uint32_t blocks_per_unit = block_pool ? (k_tiles_per_unit / block_tiles) : k_tiles_per_unit;
+
+// CB indices, forwarded from the factory in CbArg order after the dim args.
 constexpr uint32_t cb_q = get_compile_time_arg_val(num_dim_args + iscore::cb_q_arg);
 constexpr uint32_t cb_k = get_compile_time_arg_val(num_dim_args + iscore::cb_k_arg);
 constexpr uint32_t cb_w = get_compile_time_arg_val(num_dim_args + iscore::cb_w_arg);
@@ -35,6 +44,8 @@ constexpr uint32_t cb_mask = get_compile_time_arg_val(num_dim_args + iscore::cb_
 constexpr uint32_t cb_qk = get_compile_time_arg_val(num_dim_args + iscore::cb_qk_arg);
 constexpr uint32_t cb_acc_strip = get_compile_time_arg_val(num_dim_args + iscore::cb_acc_strip_arg);
 constexpr uint32_t cb_out_strip = get_compile_time_arg_val(num_dim_args + iscore::cb_out_strip_arg);
+constexpr uint32_t cb_scaler = get_compile_time_arg_val(num_dim_args + iscore::cb_scaler_arg);
+constexpr uint32_t cb_pool_scratch = get_compile_time_arg_val(num_dim_args + iscore::cb_pool_scratch_arg);
 
 // Dim args + CB indices are common to all kernels; per-kernel compile-time args start here.
 constexpr uint32_t num_common_ct_args = num_dim_args + iscore::num_cb_args;
@@ -44,6 +55,13 @@ constexpr uint32_t num_mask_tiles = iscore::num_mask_tiles;
 
 // True when heads don't all fit L1 resident, so they stream in groups.
 constexpr bool stream_heads = heads_per_group < num_heads;
+
+// Fused single-head k-column batch: score columns matmul'd per DEST acquire on the compute side, and the
+// k-tile sub-chunk the reader streams+pushes so compute consumes a batch while the reader fetches the next
+// (read/compute overlap). Sized to the usable DEST tile capacity in half-sync bf16 (the 16-tile DEST is
+// split into two 8-tile banks so math and pack ping-pong) -> one score column per DEST reg, 8 per acquire.
+// Shared so the producer (reader) and consumer (compute) granularities can't drift apart.
+constexpr uint32_t mm_col_batch = 8;
 
 // Derived tile counts for the per-unit circular-buffer blocks.
 constexpr uint32_t q_group_tiles = heads_per_group * q_tiles_per_unit * head_dim_tiles;  // [QC][HB][Dt]
@@ -58,14 +76,11 @@ inline uint32_t row_valid_prefix(
     return iscore::valid_prefix_tiles(q_row_abs, k_tile_start, k_tiles_in_unit, chunk_start_tiles);
 }
 
-/** (group, band) cell cursor. The generalized scheduler maps groups -> grid rows and k-bands ->
- *  grid columns; each core walks its own (group-phase x band) rectangle and sets the cursor per cell.
- *  group = absolute q-row-group index; band = absolute k-band index. The per-cell accessors below feed
- *  every per-unit body (matmul / mask / untilize) identically, independent of how the grid was tiled.
+/** (group, band) cell cursor. group = absolute q-row-group index; band = absolute k-band index; the
+ *  per-cell accessors feed every per-unit body (matmul / mask / untilize) identically.
  *
- *  The grid (bands per column, the host deal) stays keyed on the COMPILE-TIME k_len_tiles (the allocated
- *  buffer), so it is fixed. valid_k_len_tiles (runtime, <= k_len_tiles, defaults to the full buffer) only
- *  narrows the valid-column count per cell: bands entirely past it score nothing (k_tiles() == 0). */
+ *  The grid stays keyed on the COMPILE-TIME k_len_tiles (fixed). valid_k_len_tiles (runtime, <= k_len_tiles)
+ *  only narrows the valid-column count per cell: bands entirely past it score nothing (k_tiles() == 0). */
 struct WorkUnitSpan {
     uint32_t group = 0;
     uint32_t band = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
@@ -17,6 +17,7 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/core_local_mem.h"
 #include "ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"  // block-max-pool: calculate_and_prepare_reduce_scaler
 
 #include "indexer_score_common.hpp"  // shared CB indices, compile-time dims, work-unit walk
 
@@ -44,6 +45,9 @@ constexpr uint32_t q_valid_sem = get_compile_time_arg_val(mc_ct_base + 7);
 constexpr uint32_t fuse_single = get_compile_time_arg_val(mc_ct_base + 8);
 // Fused + no mcast: STREAM k in column sub-chunks (overlap the DRAM read). With mcast, read whole.
 constexpr uint32_t fused_stream_k = get_compile_time_arg_val(mc_ct_base + 9);
+// MSA constant gate: fill cb_w with gate_scale in L1 (no DRAM read, no mcast) instead of reading weights.
+constexpr uint32_t synthesize_gate = get_compile_time_arg_val(mc_ct_base + 10);
+constexpr uint32_t gate_scale_bits = get_compile_time_arg_val(mc_ct_base + 11);  // bf16 pair (two per word)
 
 // Receiver rectangle / sender coords for one mcast direction (physical NoC), set per core on host.
 struct McastDir {
@@ -129,19 +133,6 @@ inline void build_mask_tiles(Noc noc) {
     cb.push_back(num_mask_tiles);
 }
 
-/** Fill cb_scaler with one bf16 tile of 1.0 (the reduce-MAX scaler; never popped). */
-inline void build_scaler_tile() {
-    CircularBuffer cb(cb_scaler);
-    cb.reserve_back(1);
-    volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb.get_write_ptr());
-    constexpr uint32_t total_words = bf16_tile_bytes / sizeof(uint32_t);
-    constexpr uint32_t one_bf16_pair = 0x3F803F80;  // two bf16 1.0 values per word
-    for (uint32_t i = 0; i < total_words; ++i) {
-        ptr[i] = one_bf16_pair;
-    }
-    cb.push_back(1);
-}
-
 /** Read ONE q-row (heads_per_group heads x head_dim_tiles tiles from first_head) into L1 at `ptr`;
  *  returns the advanced ptr. Shared by resident (read_q_rows) and streaming (read_q_block) paths.
  *  q page layout is [Hi][q_len_tiles][head_dim_tiles]. */
@@ -198,9 +189,27 @@ inline void read_q_rows(Noc noc, const QAcc& q_acc, uint32_t q_row_start, const 
     }
 }
 
-/** resident w (gates) group [q_tiles_per_unit][num_heads], role-aware (q row mcast). */
+/** MSA constant gate: fill the resident w group with gate_scale in L1 (no DRAM read, no mcast). Every core
+ *  fills its own cb_w -- the gate is the same scalar for every (head, query). Mirrors the mask/scaler fills. */
+inline void fill_w_group_const() {
+    CircularBuffer cb(cb_w);
+    cb.reserve_back(w_group_tiles);
+    volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb.get_write_ptr());
+    constexpr uint32_t total_words = w_group_tiles * (bf16_tile_bytes / sizeof(uint32_t));
+    for (uint32_t i = 0; i < total_words; ++i) {
+        ptr[i] = gate_scale_bits;
+    }
+    cb.push_back(w_group_tiles);
+}
+
+/** resident w (gates) group [q_tiles_per_unit][num_heads], role-aware (q row mcast). MSA fills a constant
+ *  scale in L1 instead (no weights tensor); the q placeholder accessor is then unused. */
 template <typename WAcc>
 inline void read_w_group(Noc noc, const WAcc& w_acc, uint32_t q_row_start, const McastDir& q_dir) {
+    if constexpr (synthesize_gate) {
+        fill_w_group_const();
+        return;
+    }
     read_block_or_mcast<cb_w, q_mcast_on, q_send_sem, q_recv_sem, q_valid_sem>(
         noc, w_group_tiles, w_group_tiles * bf16_tile_bytes, q_dir, [&](uint32_t addr) {
             uint32_t ptr = addr;
@@ -301,7 +310,9 @@ void kernel_main() {
 
     build_mask_tiles(noc);
     if constexpr (block_pool) {
-        build_scaler_tile();  // 1.0 reduce-MAX scaler for the block-max-pool
+        // 1.0 reduce-MAX scaler for the block-max-pool (row-0 fill, the layout reduce_block_max_row expects).
+        dataflow_kernel_lib::
+            calculate_and_prepare_reduce_scaler<cb_scaler, ckernel::PoolType::MAX, ckernel::ReduceDim::REDUCE_ROW>();
     }
 
     WorkUnitSpan span;

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
@@ -2,13 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Reader for indexer_score (DMA bottleneck). Walks this core's (group-phase x k-band) rectangle
-// (each cell = QC q-rows x up-to-KC k-tiles): per group pushes resident w + (if all heads fit) q,
-// per band pushes the k chunk. Builds the [diag, full] -inf mask tiles once.
+// Reader for indexer_score (DMA bottleneck). Walks this core's (group-phase x k-band) rectangle: per
+// group pushes resident w + (if all heads fit) q, per band pushes the k chunk. Builds the [diag, full]
+// -inf mask tiles once, plus a 1.0 reduce-scaler when block-max-pooling. G-agnostic.
 //
-// Banded-product multicast: a grid ROW shares q/w (q-mcast), a grid COLUMN shares the k-band
-// (k-mcast). role sender reads DRAM + mcasts; role receiver takes the L1->L1 copy; role none is a
-// plain DRAM read. Q/W (row) and K (column) mcast are independent; either may be off (role none).
+// Banded-product multicast: a grid ROW shares q/w (q-mcast), a COLUMN shares the k-band (k-mcast). role
+// sender reads DRAM + mcasts; receiver takes the L1->L1 copy; none is a plain DRAM read. q/w (row) and k
+// (column) mcast are independent; either may be off.
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
@@ -40,6 +40,10 @@ constexpr uint32_t k_valid_sem = get_compile_time_arg_val(mc_ct_base + 4);
 constexpr uint32_t q_send_sem = get_compile_time_arg_val(mc_ct_base + 5);
 constexpr uint32_t q_recv_sem = get_compile_time_arg_val(mc_ct_base + 6);
 constexpr uint32_t q_valid_sem = get_compile_time_arg_val(mc_ct_base + 7);
+// Fused single-head: read q+w first (the matmul gate needs them), then k.
+constexpr uint32_t fuse_single = get_compile_time_arg_val(mc_ct_base + 8);
+// Fused + no mcast: STREAM k in column sub-chunks (overlap the DRAM read). With mcast, read whole.
+constexpr uint32_t fused_stream_k = get_compile_time_arg_val(mc_ct_base + 9);
 
 // Receiver rectangle / sender coords for one mcast direction (physical NoC), set per core on host.
 struct McastDir {
@@ -125,10 +129,22 @@ inline void build_mask_tiles(Noc noc) {
     cb.push_back(num_mask_tiles);
 }
 
-/** Read ONE q-row (heads_per_group heads x head_dim_tiles tiles, heads starting at first_head) from
- *  DRAM into L1 at `ptr`; returns the advanced write pointer. Shared inner loop of the resident
- *  (read_q_rows, first_head=0) and head-streaming (read_q_block, varying first_head) paths -- the q
- *  page layout is [Hi][q_len_tiles][head_dim_tiles]. */
+/** Fill cb_scaler with one bf16 tile of 1.0 (the reduce-MAX scaler; never popped). */
+inline void build_scaler_tile() {
+    CircularBuffer cb(cb_scaler);
+    cb.reserve_back(1);
+    volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb.get_write_ptr());
+    constexpr uint32_t total_words = bf16_tile_bytes / sizeof(uint32_t);
+    constexpr uint32_t one_bf16_pair = 0x3F803F80;  // two bf16 1.0 values per word
+    for (uint32_t i = 0; i < total_words; ++i) {
+        ptr[i] = one_bf16_pair;
+    }
+    cb.push_back(1);
+}
+
+/** Read ONE q-row (heads_per_group heads x head_dim_tiles tiles from first_head) into L1 at `ptr`;
+ *  returns the advanced ptr. Shared by resident (read_q_rows) and streaming (read_q_block) paths.
+ *  q page layout is [Hi][q_len_tiles][head_dim_tiles]. */
 template <typename QAcc>
 inline uint32_t read_q_row_into(Noc noc, const QAcc& q_acc, uint32_t ptr, uint32_t q_row_abs, uint32_t first_head) {
     for (uint32_t head = first_head; head < first_head + heads_per_group; ++head) {
@@ -141,9 +157,8 @@ inline uint32_t read_q_row_into(Noc noc, const QAcc& q_acc, uint32_t ptr, uint32
     return ptr;
 }
 
-/** q head-group block [QC][heads_per_group][head_dim_tiles], role-aware (q row mcast).
- *  ONE block / ONE mcast handshake: unit-0 startup is bound by the COUNT of mcast rendezvous,
- *  so one handshake beats per-row streaming (which multiplies the count). */
+/** q head-group block [QC][heads_per_group][head_dim_tiles], role-aware (q row mcast). ONE block / ONE
+ *  mcast handshake (unit-0 startup is bound by the rendezvous count). */
 template <typename QAcc>
 inline void read_q_block(Noc noc, const QAcc& q_acc, uint32_t q_row_start, uint32_t first_head, const McastDir& q_dir) {
     read_block_or_mcast<cb_q, q_mcast_on, q_send_sem, q_recv_sem, q_valid_sem>(
@@ -156,8 +171,7 @@ inline void read_q_block(Noc noc, const QAcc& q_acc, uint32_t q_row_start, uint3
 }
 
 /** Resident-heads q, read/mcast ONE q-row at a time (QC pushes) so compute starts row-0 matmuls while
- *  row 1 still drains. Costs one mcast rendezvous PER ROW (QC) vs the block's one, still near the startup
- *  optimum. QC==1 is byte-identical to read_q_block. first_head always 0 (resident). */
+ *  row 1 drains. One mcast rendezvous per row. QC==1 is byte-identical to read_q_block. */
 template <typename QAcc>
 inline void read_q_rows(Noc noc, const QAcc& q_acc, uint32_t q_row_start, const McastDir& q_dir) {
     constexpr uint32_t row_tiles = heads_per_group * head_dim_tiles;  // one q-row across all resident heads
@@ -167,7 +181,7 @@ inline void read_q_rows(Noc noc, const QAcc& q_acc, uint32_t q_row_start, const 
     for (uint32_t q_row = 0; q_row < q_tiles_per_unit; ++q_row) {
         const uint32_t row_addr = base + q_row * row_tiles * q_tile_bytes;
         if constexpr (q_mcast_on) {
-            if (q_dir.role == iscore::mcast_role_receiver) {  // one mcast handshake per row -> row_addr
+            if (q_dir.role == iscore::mcast_role_receiver) {  // one handshake per row -> row_addr
                 mcast_recv<q_send_sem, q_recv_sem>(noc, q_dir);
                 cb.push_back(row_tiles);
                 continue;
@@ -176,7 +190,7 @@ inline void read_q_rows(Noc noc, const QAcc& q_acc, uint32_t q_row_start, const 
         read_q_row_into(noc, q_acc, row_addr, q_row_start + q_row, /*first_head=*/0);
         noc.async_read_barrier();
         if constexpr (q_mcast_on) {
-            if (q_dir.role == iscore::mcast_role_sender) {  // broadcast this row to the rest of the grid row
+            if (q_dir.role == iscore::mcast_role_sender) {  // broadcast this row down the grid row
                 mcast_send<q_send_sem, q_recv_sem, q_valid_sem>(noc, q_dir, row_addr, row_tiles * q_tile_bytes);
             }
         }
@@ -204,8 +218,7 @@ inline void read_w_group(Noc noc, const WAcc& w_acc, uint32_t q_row_start, const
         });
 }
 
-/** k chunk [k_tiles_in_unit][head_dim_tiles], role-aware (k col mcast). ONE chunk / ONE mcast
- *  handshake to minimize startup rendezvous. */
+/** k chunk [k_tiles_in_unit][head_dim_tiles], role-aware (k col mcast). ONE chunk / ONE mcast handshake. */
 template <typename KAcc>
 inline void read_k_chunk(
     Noc noc,
@@ -214,9 +227,9 @@ inline void read_k_chunk(
     uint32_t k_tiles_in_unit,
     const McastDir& k_dir,
     uint32_t k_batch_page_offset) {
-    // Reserves/pushes the full k_chunk_tiles to keep the 2-chunk ring half-aligned, but reads only the
-    // k_tiles_in_unit valid columns (pad slots stay stale; compute masks them). k_batch_page_offset shifts
-    // every page into the indexed cache slot; 0 when not indexed.
+    // Reserves/pushes the full k_chunk_tiles (keeps the 2-chunk ring half-aligned) but reads only the
+    // k_tiles_in_unit valid cols (pad slots stale, compute masks them). k_batch_page_offset = indexed-cache
+    // slot shift; 0 when not indexed.
     read_block_or_mcast<cb_k, k_mcast_on, k_send_sem, k_recv_sem, k_valid_sem>(
         noc, k_chunk_tiles, k_chunk_tiles * k_tile_bytes, k_dir, [&](uint32_t addr) {
             uint32_t ptr = addr;
@@ -234,12 +247,40 @@ inline void read_k_chunk(
         });
 }
 
+/** Fused path: read the k chunk in mm_col_batch sub-chunks, pushing each as it lands so compute matmuls
+ *  it while the next reads (overlap). Pushes the full k_chunk_tiles (pad cols stale, compute masks them).
+ *  No mcast. mm_col_batch is shared with the compute kernel's DEST column batch (indexer_score_common.hpp). */
+template <typename KAcc>
+inline void read_k_chunk_streaming(Noc noc, const KAcc& k_acc, uint32_t k_tile_start, uint32_t k_tiles_in_unit) {
+    CircularBuffer cb(cb_k);
+    for (uint32_t cbase = 0; cbase < k_tiles_per_unit; cbase += mm_col_batch) {
+        const uint32_t c_end = (cbase + mm_col_batch <= k_tiles_per_unit) ? (cbase + mm_col_batch) : k_tiles_per_unit;
+        const uint32_t sub_tiles = (c_end - cbase) * head_dim_tiles;
+        cb.reserve_back(sub_tiles);
+        uint32_t ptr = cb.get_write_ptr();
+        for (uint32_t c = cbase; c < c_end; ++c) {
+            if (c < k_tiles_in_unit) {
+                for (uint32_t d = 0; d < head_dim_tiles; ++d) {
+                    noc.async_read(
+                        k_acc,
+                        CoreLocalMem<uint32_t>(ptr),
+                        k_tile_bytes,
+                        {.page_id = (k_tile_start + c) * head_dim_tiles + d},
+                        {});
+                    ptr += k_tile_bytes;
+                }
+            }
+        }
+        noc.async_read_barrier();
+        cb.push_back(sub_tiles);
+    }
+}
+
 void kernel_main() {
     const uint32_t q_addr = get_arg_val<uint32_t>(0);
     const uint32_t k_addr = get_arg_val<uint32_t>(1);
     const uint32_t w_addr = get_arg_val<uint32_t>(2);
-    // Generalized banded schedule: this core owns a (group-phase x band) rectangle. groups -> grid rows
-    // (q/w shared along a row = q_dir mcast), k-bands -> grid columns (k shared down a column = k_dir mcast).
+    // Banded schedule: groups -> grid rows (q/w shared = q_dir mcast), k-bands -> columns (k shared = k_dir mcast).
     const uint32_t row_group0 = get_arg_val<uint32_t>(3);
     const uint32_t group_stride = get_arg_val<uint32_t>(4);
     const uint32_t num_groups = get_arg_val<uint32_t>(5);
@@ -248,10 +289,9 @@ void kernel_main() {
     const uint32_t max_bands = get_arg_val<uint32_t>(8);  // row's widest column; streaming pads q to this
     const McastDir k_dir = read_mcast_dir(9);             // K column mcast: args [9, 17)
     const McastDir q_dir = read_mcast_dir(17);            // Q/W row mcast: args [17, 25)
-    // Persistent-cache runtime args (excluded from the hash, re-applied each dispatch), after the mcast
-    // tuples so they never perturb the fixed read_mcast_dir() offsets.
-    const uint32_t k_batch_page_offset = get_arg_val<uint32_t>(25);  // indexed-cache k page offset; 0 when not indexed
-    const uint32_t kv_len_tiles = get_arg_val<uint32_t>(26);  // valid KV length in tiles (full k_len_tiles when unset)
+    // Persistent-cache args (hash-excluded, re-applied each dispatch), after the mcast tuples.
+    const uint32_t k_batch_page_offset = get_arg_val<uint32_t>(25);  // indexed-cache page offset; 0 when not indexed
+    const uint32_t kv_len_tiles = get_arg_val<uint32_t>(26);         // valid KV length in tiles (full when unset)
 
     const auto q_acc = TensorAccessor(q_args, q_addr, q_tile_bytes);
     const auto k_acc = TensorAccessor(k_args, k_addr, k_tile_bytes);
@@ -260,23 +300,28 @@ void kernel_main() {
     Noc noc;
 
     build_mask_tiles(noc);
+    if constexpr (block_pool) {
+        build_scaler_tile();  // 1.0 reduce-MAX scaler for the block-max-pool
+    }
 
     WorkUnitSpan span;
     span.set_valid_k_len_tiles(kv_len_tiles);
 
-    // group-OUTER, band-INNER. Resident-heads order within a group: k -> q -> w (w/gates consumed only in
-    // the mul phase, so read LAST behind latency-critical q/k). Streaming path reads w FIRST: compute's mul
-    // drains streamed q, so w must be present or both kernels block => deadlock. q/w are read once per
-    // group (j==0); k-mcast fires every band down the column, q/w-mcast once per group along the row.
-    //
-    // Streaming pads the band loop to max_bands so every core in a row issues the SAME number of q reads
-    // (hence q-mcast rendezvous): columns own uneven band counts, but a phantom band [num_bands, max_bands)
-    // re-issues only the band-independent q reads -- no k (k-mcast is per column, already balanced) and no
-    // output -- keeping the row's q-mcast in lockstep. Resident reads q once per group, so it never pads.
+    // group-OUTER, band-INNER. Read order within a group: resident reads k -> q -> w (gates last, behind
+    // latency-critical q/k); streaming reads w FIRST (else compute's mul drains streamed q with no w =>
+    // deadlock); fused reads q+w FIRST (gates q before the matmul), then k (streamed when no mcast).
+    // Streaming pads the band loop to max_bands so every core in a row issues the same q reads (q-mcast
+    // lockstep): a phantom band [num_bands, max_bands) re-issues only the band-independent q (no k/output).
+    // Resident reads q once per group, so it never pads.
     const uint32_t band_iters = stream_heads ? max_bands : num_bands;
     for (uint32_t phase = 0; phase < num_groups; ++phase) {
         const uint32_t group = row_group0 + phase * group_stride;
         const uint32_t q_row_start = group * q_tiles_per_unit;
+        if constexpr (fuse_single) {
+            // Fused: q+w FIRST (the matmul gate needs them), once per group.
+            read_q_rows(noc, q_acc, q_row_start, q_dir);
+            read_w_group(noc, w_acc, q_row_start, q_dir);
+        }
         if constexpr (stream_heads) {
             read_w_group(noc, w_acc, q_row_start, q_dir);  // gates before the streamed q (once per group)
         }
@@ -284,20 +329,23 @@ void kernel_main() {
             const bool real_band = band < num_bands;  // phantom bands (streaming pad) carry q-mcast only
             if (real_band) {
                 span.set(group, band0 + band);
-                // k FIRST: compute waits the whole k chunk before any row, so reading k ahead of q lets the
-                // split q-row0 push unblock the first matmul (else the k wait re-serializes it).
-                read_k_chunk(noc, k_acc, span.k_tile_start(), span.k_tiles(), k_dir, k_batch_page_offset);
-                if (band == 0 && !stream_heads) {
-                    read_q_rows(noc, q_acc, q_row_start, q_dir);   // per-row: compute starts on row 0
-                    read_w_group(noc, w_acc, q_row_start, q_dir);  // gates deferred behind q/k
+                if constexpr (fuse_single && fused_stream_k) {
+                    read_k_chunk_streaming(noc, k_acc, span.k_tile_start(), span.k_tiles());  // no mcast: stream
+                } else {
+                    // k FIRST: compute waits the whole k chunk, so reading k ahead lets the split q-row0 push
+                    // unblock the first matmul.
+                    read_k_chunk(noc, k_acc, span.k_tile_start(), span.k_tiles(), k_dir, k_batch_page_offset);
+                }
+                if (band == 0 && !stream_heads && !fuse_single) {
+                    // Non-fused resident: q/w deferred behind q/k here.
+                    read_q_rows(noc, q_acc, q_row_start, q_dir);
+                    read_w_group(noc, w_acc, q_row_start, q_dir);
                 }
             }
             if constexpr (stream_heads) {
-                // one q-block per (q_row, k_col) output tile per head group; must match compute's order, which
-                // walks the FULL k_tiles_per_unit columns (compute masks the padded tail of a partial last
-                // band). Using span.k_tiles() here would under-produce q blocks on a partial band and hang
-                // compute, which still waits/pops a q block for every padded column. q is band-independent,
-                // so the phantom band re-issues this identical sequence purely to keep the row in lockstep.
+                // one q-block per output tile per head group, matching compute's order over the FULL
+                // k_tiles_per_unit cols (compute masks a partial last band's tail). span.k_tiles() here would
+                // under-produce q and hang compute. q is band-independent -> the phantom band re-issues this.
                 for (uint32_t tile_idx = 0; tile_idx < q_tiles_per_unit * k_tiles_per_unit; ++tile_idx) {
                     for (uint32_t first_head = 0; first_head < num_heads; first_head += heads_per_group) {
                         read_q_block(noc, q_acc, q_row_start, first_head, q_dir);

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/writer_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/writer_indexer_score.cpp
@@ -2,10 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Writer for indexer_score. Pops untilized bf16 strips and scatters each strip's
-// 32 rows into the row-major output (page = row, one contiguous run per row). Under the dense schedule
-// compute covers every column of every row (future keys already stamped to -inf), so the writer just
-// scatters each unit's strip -- there is no separate row-tail fill.
+// Writer for indexer_score: drains compute's output and scatters it row-major (page = row; future keys
+// pre-stamped -inf). Loops num_out_groups planes (page offset g*Sq). block_size==0: scatter each untilized
+// KC strip's 32 rows. block_size>0: extract per-query block maxes from the pooled tiles' col 0, force each
+// query's own block to +inf, scatter (forced-local block / sparse_local_block).
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
@@ -19,25 +19,24 @@ constexpr uint32_t page_bytes = get_compile_time_arg_val(num_common_ct_args);  /
 
 constexpr uint32_t frag_bytes = tt::constants::TILE_WIDTH * sizeof(uint16_t);  // one bf16 tile row
 
-/** Scatter one strip into the 32 output rows of q-tile-row q_row at column tile k_tile_start. Strip is
- *  always KC tiles wide; each row written as ONE contiguous run (1 async_write/row, not KC fragments).
- *  `valid_w` = KC tiles inside T (< KC on a partial last unit; KC need not divide Tt). CB always pops
- *  full KC; only the in-bounds prefix is written. */
+/** Scatter one KC-wide strip into 32 output rows from page `page_row_start`, col tile k_tile_start (1
+ *  async_write/row). `valid_w` = in-bounds tiles (< KC on a partial last unit); the CB always pops full KC. */
 template <typename OutAcc>
-inline void write_strip(Noc noc, const OutAcc& out_acc, uint32_t q_row, uint32_t k_tile_start, uint32_t valid_w) {
+inline void write_strip(
+    Noc noc, const OutAcc& out_acc, uint32_t page_row_start, uint32_t k_tile_start, uint32_t valid_w) {
     CircularBuffer cb(cb_out_strip);
-    cb.wait_front(k_tiles_per_unit);  // compute always pushes a full KC strip; pop it whether or not we write
-    if (valid_w != 0) {               // valid_w == 0 when the cell is entirely past the valid kv_len: nothing to write
+    cb.wait_front(k_tiles_per_unit);  // always pop the full KC strip
+    if (valid_w != 0) {               // 0 when the cell is entirely past valid kv_len
         uint32_t src = cb.get_read_ptr();
         const uint32_t row_pitch = k_tiles_per_unit * frag_bytes;  // strip row stride (full KC)
-        const uint32_t write_bytes = valid_w * frag_bytes;         // only the in-bounds columns
+        const uint32_t write_bytes = valid_w * frag_bytes;         // only in-bounds columns
         for (uint32_t rr = 0; rr < tt::constants::TILE_HEIGHT; ++rr) {
             noc.async_write(
                 CoreLocalMem<uint32_t>(src),
                 out_acc,
                 write_bytes,
                 {},
-                {.page_id = q_row * tt::constants::TILE_HEIGHT + rr, .offset_bytes = k_tile_start * frag_bytes});
+                {.page_id = page_row_start + rr, .offset_bytes = k_tile_start * frag_bytes});
             src += row_pitch;
         }
         noc.async_write_barrier();
@@ -45,17 +44,86 @@ inline void write_strip(Noc noc, const OutAcc& out_acc, uint32_t q_row, uint32_t
     cb.pop_front(k_tiles_per_unit);
 }
 
+// ---- block-max-pool output (block_size>0) -----------------------------------------------------------
+// Compute pushes blocks_per_unit tiles per q-tile-row, each tile's COLUMN 0 holding that block's per-query
+// max. A 32x32 bf16 tile is four 16x16 faces; col 0 is in the left faces, so row R's col-0 datum is at
+// (R/16)*POOL_FACE_ROW_STRIDE + (R%16)*FACE_WIDTH (uint16 elements).
+constexpr uint32_t POOL_FACE_ROWS = tt::constants::TILE_HEIGHT / tt::constants::FACE_HEIGHT;
+constexpr uint32_t POOL_FACE_ROW_STRIDE =
+    (tt::constants::TILE_WIDTH / tt::constants::FACE_WIDTH) * tt::constants::FACE_HEIGHT * tt::constants::FACE_WIDTH;
+constexpr uint32_t POOL_TILE_HW = tt::constants::TILE_HEIGHT * tt::constants::TILE_WIDTH;
+constexpr uint16_t POOL_POS_INF_BF16 = 0x7F80;                                                  // +inf in bf16
+constexpr uint32_t POOL_BLOCK_KEYS = block_pool ? block_tiles * tt::constants::TILE_WIDTH : 1;  // 1: avoid /0 codegen
+
+/** Gather each pooled tile's col-0 into a query-major [TILE_HEIGHT][valid_blocks] scratch, force each
+ *  query's own block to +inf (forced-local / sparse_local_block), then write each query row's run once.
+ *  `q_seq_row0` = sequence-local index of this tile-row's query 0 (within Sq). */
+template <typename OutAcc>
+inline void write_pooled_strip(
+    Noc noc,
+    const OutAcc& out_acc,
+    uint32_t page_row_start,
+    uint32_t q_seq_row0,
+    uint32_t col_off_blocks,
+    uint32_t valid_blocks,
+    uint32_t chunk_start_keys) {
+    CircularBuffer cb(cb_out_strip);
+    cb.wait_front(blocks_per_unit);
+    volatile tt_l1_ptr uint16_t* src = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(cb.get_read_ptr());
+
+    CircularBuffer scratch_cb(cb_pool_scratch);
+    const uint32_t scratch_addr = scratch_cb.get_write_ptr();
+    uint16_t* scratch = reinterpret_cast<uint16_t*>(scratch_addr);  // query-major
+
+    for (uint32_t b = 0; b < valid_blocks; ++b) {
+        volatile tt_l1_ptr uint16_t* tile = src + b * POOL_TILE_HW;
+        uint32_t qrow = 0;
+        for (uint32_t fr = 0; fr < POOL_FACE_ROWS; ++fr) {
+            const uint32_t face_base = fr * POOL_FACE_ROW_STRIDE;
+            for (uint32_t rr = 0; rr < tt::constants::FACE_HEIGHT; ++rr) {
+                scratch[qrow * valid_blocks + b] = tile[face_base + rr * tt::constants::FACE_WIDTH];  // col 0, row qrow
+                ++qrow;
+            }
+        }
+    }
+
+    // Forced-local block (sparse_local_block=1): force each query's own block to +inf so top-k always
+    // keeps it. Query (q_seq_row0 + rr)'s block = (chunk_start_keys + q_seq_row0 + rr) / POOL_BLOCK_KEYS;
+    // stamp only when it lands in this unit's [col_off_blocks, +valid).
+    for (uint32_t rr = 0; rr < tt::constants::TILE_HEIGHT; ++rr) {
+        const uint32_t local_block = (chunk_start_keys + q_seq_row0 + rr) / POOL_BLOCK_KEYS;
+        if (local_block >= col_off_blocks && local_block < col_off_blocks + valid_blocks) {
+            scratch[rr * valid_blocks + (local_block - col_off_blocks)] = POOL_POS_INF_BF16;
+        }
+    }
+
+    const uint32_t row_bytes = valid_blocks * sizeof(uint16_t);
+    const uint32_t col_off_bytes = col_off_blocks * sizeof(uint16_t);
+    for (uint32_t rr = 0; rr < tt::constants::TILE_HEIGHT; ++rr) {
+        noc.async_write(
+            CoreLocalMem<uint32_t>(scratch_addr + rr * row_bytes),
+            out_acc,
+            row_bytes,
+            {},
+            {.page_id = page_row_start + rr, .offset_bytes = col_off_bytes});
+    }
+    noc.async_write_barrier();  // drain before scratch / the CB page is reused
+    cb.pop_front(blocks_per_unit);
+}
+
 void kernel_main() {
     const uint32_t out_addr = get_arg_val<uint32_t>(0);
-    // Generalized banded schedule (matches reader/compute): group-phase x band rectangle.
+    // Banded schedule (matches reader/compute): group-phase x band rectangle.
     const uint32_t row_group0 = get_arg_val<uint32_t>(1);
     const uint32_t group_stride = get_arg_val<uint32_t>(2);
     const uint32_t num_groups = get_arg_val<uint32_t>(3);
     const uint32_t band0 = get_arg_val<uint32_t>(4);
     const uint32_t num_bands = get_arg_val<uint32_t>(5);
-    // Schedule arg [6] is max_bands (unused by the writer). Valid KV length in tiles follows at [7]: caps the
-    // columns written per cell (page width stays the full T). Full k_len_tiles when not set. Excluded from hash.
+    // [6] max_bands (unused). [7] kv_len_tiles caps columns written per cell (full when unset).
     const uint32_t kv_len_tiles = get_arg_val<uint32_t>(7);
+    // [8] per-device chunk-start (tiles); runtime so distinct values reuse one program. Only the block-pool
+    // forced-local stamp uses it; always set.
+    const uint32_t chunk_start_keys = get_arg_val<uint32_t>(8) * tt::constants::TILE_WIDTH;
 
     constexpr auto out_args = TensorAccessorArgs<num_common_ct_args + 1>();
     const auto out_acc = TensorAccessor(out_args, out_addr, page_bytes);
@@ -65,15 +133,31 @@ void kernel_main() {
     WorkUnitSpan span;
     span.set_valid_k_len_tiles(kv_len_tiles);
 
+    // Output [B, num_out_groups, Sq, T]: plane g occupies rows [g*Sq, (g+1)*Sq). Compute pushes
+    // num_out_groups * QC strips per cell in g-major order; drain them the same way.
+    constexpr uint32_t sq_rows = q_len_tiles * tt::constants::TILE_HEIGHT;  // rows per plane (Sq)
+
     for (uint32_t phase = 0; phase < num_groups; ++phase) {
         const uint32_t group = row_group0 + phase * group_stride;
         for (uint32_t band = 0; band < num_bands; ++band) {
             span.set(group, band0 + band);
             const uint32_t k_tile0 = span.k_tile_start();
             const uint32_t valid_w = span.k_tiles();  // == KC for interior bands, < KC for a partial last band
-            // One KC-wide strip per row; masked suffix already stamped by compute. Write only valid_w columns.
-            for (uint32_t q_row = 0; q_row < q_tiles_per_unit; ++q_row) {
-                write_strip(noc, out_acc, span.q_tile_start() + q_row, k_tile0, valid_w);
+            // block-pool: this band's slice starts at block-column k_tile0/block_tiles, width valid_blocks.
+            const uint32_t col_off_blocks = block_pool ? (k_tile0 / block_tiles) : 0;
+            const uint32_t valid_blocks = block_pool ? (valid_w / block_tiles) : 0;  // == blocks_per_unit (no partial)
+            for (uint32_t g = 0; g < num_out_groups; ++g) {
+                const uint32_t plane_row0 = g * sq_rows;
+                for (uint32_t q_row = 0; q_row < q_tiles_per_unit; ++q_row) {
+                    const uint32_t q_seq_row0 = (span.q_tile_start() + q_row) * tt::constants::TILE_HEIGHT;  // within Sq
+                    const uint32_t page_row_start = plane_row0 + q_seq_row0;
+                    if constexpr (block_pool) {
+                        write_pooled_strip(
+                            noc, out_acc, page_row_start, q_seq_row0, col_off_blocks, valid_blocks, chunk_start_keys);
+                    } else {
+                        write_strip(noc, out_acc, page_row_start, k_tile0, valid_w);
+                    }
+                }
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score.hpp
@@ -4,6 +4,6 @@
 
 #pragma once
 
-// Public op surface: the ttnn.experimental.indexer_score callable and the
+// Public op surface: the ttnn.experimental.indexer_score_dsa / indexer_score_msa callables and the
 // IndexerScoreProgramConfig knobs are declared by the device operation header.
 #include "device/indexer_score_device_operation.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
@@ -99,8 +99,8 @@ void bind_indexer_score(nb::module_& mod) {
                 OMIT on a mesh -> deduced as T - sp_ring*Sq; single device: set to
                 history + rank*Sq per rank (same semantics as indexer_score_dsa).
             scale: constant gate applied to every head (e.g. 1/sqrt(d))
-            num_groups: 1 sums all Hi heads into one plane (the TP=4 group-aligned
-                deployment, Hi=1/device). G>1 partitions the heads into G groups
+            num_groups: REQUIRED (no default). 1 sums all Hi heads into one plane
+                (the TP=4 group-aligned deployment, Hi=1/device). G>1 partitions the heads into G groups
                 of Hi/G and sums within each group -> output [B, G, Sq, T] (multiple
                 GQA groups on one chip). G>1 needs all heads resident
                 (head_group_size 0 or Hi) and k_chunk_size >= 64.
@@ -126,9 +126,9 @@ void bind_indexer_score(nb::module_& mod) {
         nb::arg("q"),
         nb::arg("k"),
         nb::kw_only(),
+        nb::arg("num_groups"),  // required: per-GQA-group selection is MSA's purpose, no implicit default
         nb::arg("chunk_start_idx") = std::nullopt,
         nb::arg("scale") = 1.0f,
-        nb::arg("num_groups") = 1,
         nb::arg("block_size") = 0,
         nb::arg("program_config") = IndexerScoreProgramConfig{},
         nb::arg("compute_kernel_config") = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
@@ -21,17 +21,22 @@ void bind_indexer_score(nb::module_& mod) {
         .def_rw("k_chunk_size", &IndexerScoreProgramConfig::k_chunk_size)
         .def_rw("head_group_size", &IndexerScoreProgramConfig::head_group_size);
 
-    ttnn::bind_function<"indexer_score", "ttnn.experimental.">(
+    ttnn::bind_function<"indexer_score_dsa", "ttnn.experimental.">(
         mod,
         R"doc(
-        DeepSeek-V3.2 DSA lightning-indexer scorer.
+        DeepSeek-V3.2 DSA / GLM-5 lightning-indexer scorer.
 
-        score[b, s, t] = sum_h relu(q[b,h,s,:] . k[b,t,:]) * weights[b,h,s]
+        score[b, 0, s, t] = sum_h relu(q[b,h,s,:] . k[b,t,:]) * weights[b,h,s]
+
+        ReLU(q.kT) gated by the learned per-head weights and summed over ALL Hi
+        index heads into one shared selection row [B, 1, Sq, T]. For MiniMax M3's
+        raw-dot, per-GQA-group indexer, use ``indexer_score_msa`` instead.
 
         Args:
             q: [B, Hi, Sq, D] bf16 or bfp8_b tiled (post non-interleaved RoPE)
             k: [B, 1, T, D] bf16 or bfp8_b tiled, single shared head
-            weights: [B, Hi, Sq, 1] bf16 tiled, scales pre-folded
+            weights: [B, Hi, Sq, 1] bf16 tiled learned per-head gates (scale
+                pre-folded)
             chunk_start_idx: absolute global position of rank 0's query row 0
                 (rank 0 = lowest cluster_axis coord; causality: key t visible to
                 query s iff t <= chunk_start + s). OMIT on a mesh -> deduced as
@@ -60,7 +65,7 @@ void bind_indexer_score(nb::module_& mod) {
 
         Returns: score [B, 1, Sq, T] bf16 row-major; future/pad columns -inf.
         )doc",
-        &ttnn::experimental::indexer_score,
+        &ttnn::experimental::indexer_score_dsa,
         nb::arg("q"),
         nb::arg("k"),
         nb::arg("weights"),
@@ -70,6 +75,63 @@ void bind_indexer_score(nb::module_& mod) {
         nb::arg("compute_kernel_config") = std::nullopt,
         nb::arg("cache_batch_idx") = std::nullopt,
         nb::arg("kv_len") = std::nullopt,
+        nb::arg("cluster_axis") = std::nullopt);
+
+    ttnn::bind_function<"indexer_score_msa", "ttnn.experimental.">(
+        mod,
+        R"doc(
+        MiniMax-M3 MSA lightning-indexer scorer.
+
+        score[b, g, s, t] = sum_{h in group g} (q[b,h,s,:] . k[b,t,:]) * scale
+
+        Raw dot product (no ReLU), no learned gates -- only a 1/sqrt(d) ``scale``
+        (applied as a constant gate). The Hi index heads are partitioned into
+        ``num_groups`` GQA groups and summed WITHIN each group only, giving one
+        output plane per group (no cross-group sum) for per-group selection.
+        For DeepSeek-V3.2 / GLM-5's relu + gated + head-summed indexer, use
+        ``indexer_score_dsa`` instead.
+
+        Args:
+            q: [B, Hi, Sq, D] bf16 or bfp8_b tiled (post non-interleaved RoPE)
+            k: [B, 1, T, D] bf16 or bfp8_b tiled, single shared head
+            chunk_start_idx: absolute global position of rank 0's query row 0
+                (causality: key t visible to query s iff t <= chunk_start + s).
+                OMIT on a mesh -> deduced as T - sp_ring*Sq; single device: set to
+                history + rank*Sq per rank (same semantics as indexer_score_dsa).
+            scale: constant gate applied to every head (e.g. 1/sqrt(d))
+            num_groups: 1 sums all Hi heads into one plane (the TP=4 group-aligned
+                deployment, Hi=1/device). G>1 partitions the heads into G groups
+                of Hi/G and sums within each group -> output [B, G, Sq, T] (multiple
+                GQA groups on one chip). G>1 needs all heads resident
+                (head_group_size 0 or Hi) and k_chunk_size >= 64.
+            block_size: 0 (default) = no pooling -> score [B, G, Sq, T]. >0 =
+                block-max-pool over block_size keys -> score [B, G, Sq, T/block_size]
+                (block selection; the downstream topk then picks per-group top-k
+                blocks). Requires block_size a multiple of 32, T % block_size == 0,
+                and k_chunk_size % block_size == 0.
+            program_config: work-unit knobs (q_chunk_size, k_chunk_size,
+                head_group_size; elements, tile-aligned). Defaults always fit L1.
+            compute_kernel_config: optional DeviceComputeKernelConfig. Only
+                math_fidelity is honored (default: HiFi2, or LoFi when q and k
+                are both bfloat8_b); fp32_dest_acc_en / dst_full_sync_en must
+                stay false (the custom LLK is validated for bf16 DEST half-sync).
+            cluster_axis: mesh axis that is the SP ring. On a mesh, device r uses
+                chunk_start = chunk_start_idx + r*Sq, where r is its linearized
+                index along this axis. None = linear device order.
+
+        Returns: score [B, num_groups, Sq, T_out] bf16 row-major (T_out = T, or
+            T/block_size when block-max-pooling); future/pad columns/blocks -inf.
+        )doc",
+        &ttnn::experimental::indexer_score_msa,
+        nb::arg("q"),
+        nb::arg("k"),
+        nb::kw_only(),
+        nb::arg("chunk_start_idx") = std::nullopt,
+        nb::arg("scale") = 1.0f,
+        nb::arg("num_groups") = 1,
+        nb::arg("block_size") = 0,
+        nb::arg("program_config") = IndexerScoreProgramConfig{},
+        nb::arg("compute_kernel_config") = std::nullopt,
         nb::arg("cluster_axis") = std::nullopt);
 }
 


### PR DESCRIPTION
## Summary

Adds **`indexer_score_msa`** — a second public frontend on the existing `indexer_score` device op — for **MiniMax M3**. The existing `indexer_score_dsa` (DeepSeek-V3.2 / GLM-5) path is unchanged (byte-identical).

**What is MSA?** MiniMax Sparse Attention — M3's sparse-attention *lightning indexer*: a cheap scaled dot-product `q·kᵀ` that scores key blocks so a downstream top-k picks which blocks each query attends to.

**Where it's used.** MiniMax M3 GQA prefill (Galaxy SP8×TP4), producing per-GQA-group block scores for block selection.

## What's added

- **`indexer_score_msa(q, k, scale, num_groups, block_size, …)`**: raw dot (no ReLU), constant `1/√d` scale, per-GQA-group output planes, optional fused block-max-pool → `[B, G, Sq, T/block_size]`.
- Three compile-time op attrs (`apply_relu`, `num_groups`, `block_size`), `if constexpr`-gated so the DSA path compiles identically.
- SP8×TP4 M3 perf tuning: gate folded into q (matmul writes straight to the accumulator), grid-aligned q/K multicast, batched block-max reduce.
- Tests: DSA + MSA accuracy/PCC, per-group, block-pool; **3 math-util perf checks** (`glm5`, `dsv32`, `minimax_m3`) wired into the Blackhole ops-perf CI job.

**M3 deployed case** (SP8×TP4, 1 group, 640 q × 55296 kv, HiFi2): **0.068 ms, 43.78% matmul utilization**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/indexer_score_m3_gqa)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/indexer_score_m3_gqa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/indexer_score_m3_gqa)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/indexer_score_m3_gqa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/indexer_score_m3_gqa)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skrstic/indexer_score_m3_gqa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/indexer_score_m3_gqa)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/indexer_score_m3_gqa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/indexer_score_m3_gqa)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/indexer_score_m3_gqa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/indexer_score_m3_gqa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/indexer_score_m3_gqa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/indexer_score_m3_gqa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/indexer_score_m3_gqa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/indexer_score_m3_gqa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/indexer_score_m3_gqa)
### Triggered CI runs for this change

- **bhpc** (Blackhole post-commit): https://github.com/tenstorrent/tt-metal/actions/runs/28225368351
- **L2 nightly** (experimental only, BH): https://github.com/tenstorrent/tt-metal/actions/runs/28225373776
- **Device perf** (ops-perf-tests, BH): https://github.com/tenstorrent/tt-metal/actions/runs/28225379648
