### PR TITLE
qwen2.5-vl: access vision tower via .model.visual for transformers 5.x

### DIFF
--- a/models/demos/qwen25_vl/tt/common.py
+++ b/models/demos/qwen25_vl/tt/common.py
@@ -12,6 +12,15 @@ import ttnn
 from models.tt_transformers.tt.load_checkpoints import convert_rope_style_hf_to_meta
 
 
+def get_hf_visual(model):
+    """Return the HF vision tower.
+
+    transformers 5.x nests the vision tower under ``model.model.visual`` (``Qwen2_5_VLModel``);
+    4.x exposed it directly as ``model.visual``. Accept either.
+    """
+    return model.visual if hasattr(model, "visual") else model.model.visual
+
+
 def merge_vision_tokens(
     input_ids,
     input_embeds,

--- a/models/demos/qwen25_vl/tt/generator_vllm.py
+++ b/models/demos/qwen25_vl/tt/generator_vllm.py
@@ -21,7 +21,12 @@ from vllm.multimodal import MULTIMODAL_REGISTRY
 
 import ttnn
 from models.common.utility_functions import is_wormhole_b0
-from models.demos.qwen25_vl.tt.common import merge_vision_tokens, multimodal_rope_from_hf, preprocess_inputs_prefill
+from models.demos.qwen25_vl.tt.common import (
+    get_hf_visual,
+    merge_vision_tokens,
+    multimodal_rope_from_hf,
+    preprocess_inputs_prefill,
+)
 from models.demos.qwen25_vl.tt.generator import Generator as QwenVLGenerator
 from models.demos.qwen25_vl.tt.model import DropInVisionTransformer, Transformer
 from models.demos.qwen25_vl.tt.model_config import VisionModelArgs
@@ -179,7 +184,7 @@ class Qwen2_5_VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
             optimizations=DecodersPrecision.performance(config.vision_config.depth, ref_model_name),
         )
         vision_model_args.hf_config.vision_config.depth = config.vision_config.depth
-        visual_model = DropInVisionTransformer(reference_model.visual, vision_model_args)
+        visual_model = DropInVisionTransformer(get_hf_visual(reference_model), vision_model_args)
 
         return cls(
             model,


### PR DESCRIPTION
transformers 5.x removed the `visual` backward-compat property on the Qwen2.5-VL ForConditionalGeneration classes; the vision tower now lives under `.model.visual`. Fall back to it via hasattr so the code runs on both 4.57 and 5.x. Same style as (much bigger) PR #47818 for Qwen3-VL.

## CI

https://github.com/tenstorrent/tt-metal/actions/runs/28356948800

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=viktorpus/qwen-vl-transformers5-visual)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:viktorpus/qwen-vl-transformers5-visual)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=viktorpus/qwen-vl-transformers5-visual)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:viktorpus/qwen-vl-transformers5-visual)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=viktorpus/qwen-vl-transformers5-visual)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:viktorpus/qwen-vl-transformers5-visual)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=viktorpus/qwen-vl-transformers5-visual)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:viktorpus/qwen-vl-transformers5-visual)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=viktorpus/qwen-vl-transformers5-visual)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:viktorpus/qwen-vl-transformers5-visual)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=viktorpus/qwen-vl-transformers5-visual)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:viktorpus/qwen-vl-transformers5-visual)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=viktorpus/qwen-vl-transformers5-visual)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:viktorpus/qwen-vl-transformers5-visual)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=viktorpus/qwen-vl-transformers5-visual)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:viktorpus/qwen-vl-transformers5-visual)