### PR TITLE
[Quasar] Add quant/requant/dequant int32 SFPU kernels

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
@@ -1,0 +1,195 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <cstdint>
+
+#include "ckernel_instr_params.h"
+#include "ckernel_ops.h"
+#include "ckernel_trisc_common.h"
+#include "cmath_common.h"
+#include "sfpi.h"
+
+namespace ckernel::sfpu {
+
+// The three quant-family binary ops, selected at compile time by one op-templated
+// init/execute pair below (quant / requant / dequant).
+enum class QuantVariant : std::uint8_t { Quant, Requant, Dequant };
+
+inline constexpr bool is_quant_variant(QuantVariant op) {
+    return op == QuantVariant::Quant || op == QuantVariant::Requant || op == QuantVariant::Dequant;
+}
+
+// Shared LREG layout across all three quant ops:
+//   LREG0 = operand A load / running accumulator / result before store
+//   LREG1 = operand B (fp32 scale)
+//   LREG2 = zero-point (fp32), loaded once by the matching init
+// LREG3-7 stay free. Each init must run before the first call to its kernel.
+//
+// SIGN_MAGNITUDE_FORMAT gates the SM<->2's-comp casts: the default (false) path
+// treats int32 dest content as 2's-complement (UNP_DEST / Int32-L1), while
+// STOCH_RND emits sign-magnitude (SMAG32). Inputs/outputs are therefore cast on
+// the !SIGN_MAGNITUDE_FORMAT path; the true path stores STOCH_RND output as-is.
+//
+// Replay-buffer optimization (mirrors the Blackhole reference):
+// the per-iteration REGISTER-ONLY compute middle of each op (no runtime
+// addresses) is recorded ONCE by the matching init via load_replay_buf and
+// then replayed per loop iteration with TTI_REPLAY. The runtime-address
+// SFPLOADs/SFPSTORE (base + (d<<1)) stay INLINE and are NOT recorded - exactly
+// as Blackhole keeps its runtime-address loads/stores inline. Recording uses
+// load_mode=1 with execute_while_loading=false (the load_replay_buf default),
+// i.e. the body is streamed into the replay buffer WITHOUT executing it at
+// record time, so it never reads the undefined LREG0/LREG1 at init.
+//
+// Per-op slots are non-overlapping and sized to the larger (2's-complement)
+// variant; the matching sign-magnitude variant records fewer instructions into
+// the same slot and replays the shorter length. Distinct slots between ops let
+// a single compute kernel mix all three ops without an init clobbering another
+// op's recording.
+//   QUANT   (2s-comp, 3) : SFPMAD, STOCH_RND, SFPCAST
+//   QUANT   (sign-m, 2)  : SFPMAD, STOCH_RND
+//   REQUANT (2s-comp, 5) : SFPCAST(in), SFPCAST(int->fp32), SFPMAD, STOCH_RND, SFPCAST(out)
+//   REQUANT (sign-m, 3)  : SFPCAST(int->fp32), SFPMAD, STOCH_RND
+//   DEQUANT (2s-comp, 4) : SFPCAST(in), SFPCAST(int->fp32), SFPMAD, SFPMUL
+//   DEQUANT (sign-m, 3)  : SFPCAST(int->fp32), SFPMAD, SFPMUL
+constexpr std::uint32_t QUANT_REPLAY_SLOT = 0;
+constexpr std::uint32_t QUANT_REPLAY_LEN_2S_COMP = 3;
+constexpr std::uint32_t QUANT_REPLAY_LEN_SIGN_MAGN = 2;
+
+constexpr std::uint32_t REQUANT_REPLAY_SLOT = QUANT_REPLAY_SLOT + QUANT_REPLAY_LEN_2S_COMP;
+constexpr std::uint32_t REQUANT_REPLAY_LEN_2S_COMP = 5;
+constexpr std::uint32_t REQUANT_REPLAY_LEN_SIGN_MAGN = 3;
+
+constexpr std::uint32_t DEQUANT_REPLAY_SLOT = REQUANT_REPLAY_SLOT + REQUANT_REPLAY_LEN_2S_COMP;
+constexpr std::uint32_t DEQUANT_REPLAY_LEN_2S_COMP = 4;
+constexpr std::uint32_t DEQUANT_REPLAY_LEN_SIGN_MAGN = 3;
+
+// Replay slot base (per op) and recorded length (per op, per format) for the
+// register-only compute middle.
+template <QuantVariant OP>
+inline constexpr std::uint32_t quant_replay_slot() {
+    if constexpr (OP == QuantVariant::Quant) {
+        return QUANT_REPLAY_SLOT;
+    } else if constexpr (OP == QuantVariant::Requant) {
+        return REQUANT_REPLAY_SLOT;
+    } else {
+        return DEQUANT_REPLAY_SLOT;
+    }
+}
+
+template <QuantVariant OP, bool SIGN_MAGNITUDE_FORMAT>
+inline constexpr std::uint32_t quant_replay_len() {
+    if constexpr (OP == QuantVariant::Quant) {
+        return SIGN_MAGNITUDE_FORMAT ? QUANT_REPLAY_LEN_SIGN_MAGN : QUANT_REPLAY_LEN_2S_COMP;
+    } else if constexpr (OP == QuantVariant::Requant) {
+        return SIGN_MAGNITUDE_FORMAT ? REQUANT_REPLAY_LEN_SIGN_MAGN : REQUANT_REPLAY_LEN_2S_COMP;
+    } else {
+        return SIGN_MAGNITUDE_FORMAT ? DEQUANT_REPLAY_LEN_SIGN_MAGN : DEQUANT_REPLAY_LEN_2S_COMP;
+    }
+}
+
+/**
+ * @brief Record the register-only compute middle for a quant-family op into its replay slot.
+ *
+ * Loads the fp32 zero-point into LREG2, then streams the op's compute body into a replay
+ * buffer (NoExec: LREG0/LREG1 are undefined at init time). The body is replayed per loop
+ * iteration by @ref _quant_family_. Op math (A = operand, B = fp32 scale, zp = zero-point):
+ *   Quant   : out = round_to_int8(A_fp32 * B + zp)
+ *   Requant : out = round_to_int8(int32_to_fp32(A) * B + zp)
+ *   Dequant : out = (int32_to_fp32(A) + zp) * B   -- caller passes bits of -zero_point
+ *
+ * @tparam OP: Which quant-family op, values = <Quant/Requant/Dequant>
+ * @tparam SIGN_MAGNITUDE_FORMAT: If true, treat int32 dest as SMAG32 and skip the SM<->2's-comp casts.
+ * @param zero_point: fp32 bit-pattern of the zero-point (Dequant expects the bits of -zero_point).
+ * @note Call once before @ref _quant_family_ with the same OP / SIGN_MAGNITUDE_FORMAT.
+ */
+template <QuantVariant OP, bool SIGN_MAGNITUDE_FORMAT = false>
+inline void _quant_family_init_(const std::uint32_t zero_point) {
+    static_assert(is_quant_variant(OP), "_quant_family_init_: OP must be Quant/Requant/Dequant");
+
+    TT_SFPLOADI(p_sfpu::LREG2, sfpi::SFPLOADI_MOD0_LOWER, zero_point & 0xFFFF);  // zp low half
+    TT_SFPLOADI(p_sfpu::LREG2, sfpi::SFPLOADI_MOD0_UPPER, zero_point >> 16);     // zp high half -> LREG2 = fp32 zp
+
+    constexpr std::uint32_t slot = quant_replay_slot<OP>();
+    constexpr std::uint32_t len = quant_replay_len<OP, SIGN_MAGNITUDE_FORMAT>();
+    load_replay_buf<slot, len, /*exec_while_loading=*/false>([] {
+        // Requant/Dequant take an int32 operand A -> bring it to fp32 first.
+        if constexpr (OP == QuantVariant::Requant || OP == QuantVariant::Dequant) {
+            if constexpr (!SIGN_MAGNITUDE_FORMAT) {
+                TTI_SFPCAST(
+                    p_sfpu::LREG0, p_sfpu::LREG0, p_sfpu::sfp_sfpcast_mod::TWO_SC_TO_SM);  // 2's-comp -> sign-mag input
+            }
+            TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0 /* mod1: int32(sign-mag) -> fp32 RNE */);
+        }
+
+        if constexpr (OP == QuantVariant::Quant || OP == QuantVariant::Requant) {
+            TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::LREG0, 0 /* mod1 */);  // A*B + zp
+
+            // fp32 -> signed int8 (SMAG32 container), round-nearest-even; (1<<3) selects the imm8 descale slot (0 = no
+            // descale)
+            TTI_SFP_STOCH_RND(
+                p_sfpu::sfp_stochrnd_rnd_mod::NearEven,
+                0 /* imm8 descale */,
+                0 /* lreg_b (unused on fp32 path) */,
+                p_sfpu::LREG0,
+                p_sfpu::LREG0,
+                (1 << 3) | p_sfpu::sfp_stochrnd_mod::FP32_TO_INT8);
+
+            if constexpr (!SIGN_MAGNITUDE_FORMAT) {
+                TTI_SFPCAST(
+                    p_sfpu::LREG0, p_sfpu::LREG0, p_sfpu::sfp_sfpcast_mod::SM32_TO_2SC);  // sign-mag -> 2's-comp output
+            }
+        } else {  // Dequant: (A + (-zp)) * B, fp32 output (no round / no output cast)
+            // LCONST_1 = 1.0 -> A*1 + (-zp) = A - zp ; then LCONST_0 = 0.0 ignored as +C -> (A - zp) * B
+            TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG2, p_sfpu::LREG0, 0 /* mod1 */);
+            TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0 /* mod1 */);
+        }
+    });
+}
+
+/**
+ * @brief Apply a quant-family op over a tile: per iteration load A/B, replay the compute middle, store.
+ *
+ * Operand A is loaded as fp32 for Quant and int32 for Requant/Dequant; the result is stored as
+ * int32 for Quant/Requant and fp32 for Dequant. The runtime-address loads/store stay inline; the
+ * register-only middle recorded by @ref _quant_family_init_ is replayed each iteration.
+ *
+ * @tparam OP: Which quant-family op, values = <Quant/Requant/Dequant>
+ * @tparam ITERATIONS: Number of SFPU passes spanning the tile (default = SFPU_ITERATIONS).
+ * @tparam SIGN_MAGNITUDE_FORMAT: Must match the value passed to @ref _quant_family_init_.
+ * @tparam TILE_SHAPE: Dest tile shape used to scale the tile indices into row offsets.
+ * @param dst_index_in0,dst_index_in1,dst_index_out: Dest tile indices of operand A, operand B, and the result.
+ * @note Call @ref _quant_family_init_ with the same OP / SIGN_MAGNITUDE_FORMAT before this.
+ */
+template <
+    QuantVariant OP,
+    int ITERATIONS = SFPU_ITERATIONS,
+    bool SIGN_MAGNITUDE_FORMAT = false,
+    trisc::DstTileShape TILE_SHAPE = trisc::DstTileShape::Tile32x32>
+inline void _quant_family_(
+    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
+    static_assert(is_quant_variant(OP), "_quant_family_: OP must be Quant/Requant/Dequant");
+
+    constexpr std::uint32_t slot = quant_replay_slot<OP>();
+    constexpr std::uint32_t len = quant_replay_len<OP, SIGN_MAGNITUDE_FORMAT>();
+    constexpr auto A_FORMAT = (OP == QuantVariant::Quant) ? p_sfpu::sfpmem::FP32 : p_sfpu::sfpmem::INT32;
+    constexpr auto OUT_FORMAT = (OP == QuantVariant::Dequant) ? p_sfpu::sfpmem::FP32 : p_sfpu::sfpmem::INT32;
+
+    constexpr std::uint32_t tile_stride = 1U << trisc::get_dest_tile_size_log2(TILE_SHAPE);
+    const std::uint32_t in0_offset = dst_index_in0 * tile_stride;
+    const std::uint32_t in1_offset = dst_index_in1 * tile_stride;
+    const std::uint32_t out_offset = dst_index_out * tile_stride;
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        TT_SFPLOAD(p_sfpu::LREG0, A_FORMAT, ADDR_MOD_7, 0, in0_offset + (d << 1));  // operand A
+        TT_SFPLOAD(
+            p_sfpu::LREG1, p_sfpu::sfpmem::FP32, ADDR_MOD_7, 0, in1_offset + (d << 1));  // operand B (fp32 scale)
+
+        TTI_REPLAY(slot, len, 0, 0, 0, 0);  // recorded compute middle
+
+        TT_SFPSTORE(p_sfpu::LREG0, OUT_FORMAT, ADDR_MOD_7, 0, out_offset + (d << 1));  // store result
+    }
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
@@ -16,9 +16,10 @@ namespace ckernel::sfpu {
 // init/execute pair below (quant / requant / dequant).
 enum class QuantVariant : std::uint8_t { Quant, Requant, Dequant };
 
-inline constexpr bool is_quant_variant(QuantVariant op) {
-    return op == QuantVariant::Quant || op == QuantVariant::Requant || op == QuantVariant::Dequant;
-}
+// Never-true predicate for the terminal `else` of an OP dispatch: keeps the static_assert
+// dependent on OP so it only fires for a QuantVariant the dispatch does not handle.
+template <QuantVariant>
+inline constexpr bool quant_unhandled_variant = false;
 
 // Shared LREG layout across all three quant ops:
 //   LREG0 = operand A load / running accumulator / result before store
@@ -31,21 +32,13 @@ inline constexpr bool is_quant_variant(QuantVariant op) {
 // STOCH_RND emits sign-magnitude (SMAG32). Inputs/outputs are therefore cast on
 // the !SIGN_MAGNITUDE_FORMAT path; the true path stores STOCH_RND output as-is.
 //
-// Replay-buffer optimization (mirrors the Blackhole reference):
-// the per-iteration REGISTER-ONLY compute middle of each op (no runtime
-// addresses) is recorded ONCE by the matching init via load_replay_buf and
-// then replayed per loop iteration with TTI_REPLAY. The runtime-address
-// SFPLOADs/SFPSTORE (base + (d<<1)) stay INLINE and are NOT recorded - exactly
-// as Blackhole keeps its runtime-address loads/stores inline. Recording uses
-// load_mode=1 with execute_while_loading=false (the load_replay_buf default),
-// i.e. the body is streamed into the replay buffer WITHOUT executing it at
-// record time, so it never reads the undefined LREG0/LREG1 at init.
+// The init records once the register-to-register math that turns the loaded
+// operands into the result; the kernel replays it each iteration around inline
+// operand loads and a result store.
 //
 // Per-op slots are non-overlapping and sized to the larger (2's-complement)
-// variant; the matching sign-magnitude variant records fewer instructions into
-// the same slot and replays the shorter length. Distinct slots between ops let
-// a single compute kernel mix all three ops without an init clobbering another
-// op's recording.
+// variant (the sign-magnitude variant records fewer instructions into the same
+// slot), so one compute kernel can mix all three ops without cross-clobbering:
 //   QUANT   (2s-comp, 3) : SFPMAD, STOCH_RND, SFPCAST
 //   QUANT   (sign-m, 2)  : SFPMAD, STOCH_RND
 //   REQUANT (2s-comp, 5) : SFPCAST(in), SFPCAST(int->fp32), SFPMAD, STOCH_RND, SFPCAST(out)
@@ -72,8 +65,10 @@ inline constexpr std::uint32_t quant_replay_slot() {
         return QUANT_REPLAY_SLOT;
     } else if constexpr (OP == QuantVariant::Requant) {
         return REQUANT_REPLAY_SLOT;
-    } else {
+    } else if constexpr (OP == QuantVariant::Dequant) {
         return DEQUANT_REPLAY_SLOT;
+    } else {
+        static_assert(quant_unhandled_variant<OP>, "quant_replay_slot: unhandled QuantVariant");
     }
 }
 
@@ -83,8 +78,10 @@ inline constexpr std::uint32_t quant_replay_len() {
         return SIGN_MAGNITUDE_FORMAT ? QUANT_REPLAY_LEN_SIGN_MAGN : QUANT_REPLAY_LEN_2S_COMP;
     } else if constexpr (OP == QuantVariant::Requant) {
         return SIGN_MAGNITUDE_FORMAT ? REQUANT_REPLAY_LEN_SIGN_MAGN : REQUANT_REPLAY_LEN_2S_COMP;
-    } else {
+    } else if constexpr (OP == QuantVariant::Dequant) {
         return SIGN_MAGNITUDE_FORMAT ? DEQUANT_REPLAY_LEN_SIGN_MAGN : DEQUANT_REPLAY_LEN_2S_COMP;
+    } else {
+        static_assert(quant_unhandled_variant<OP>, "quant_replay_len: unhandled QuantVariant");
     }
 }
 
@@ -93,7 +90,7 @@ inline constexpr std::uint32_t quant_replay_len() {
  *
  * Loads the fp32 zero-point into LREG2, then streams the op's compute body into a replay
  * buffer (NoExec: LREG0/LREG1 are undefined at init time). The body is replayed per loop
- * iteration by @ref _quant_family_. Op math (A = operand, B = fp32 scale, zp = zero-point):
+ * iteration by @ref quant_family. Op math (A = operand, B = fp32 scale, zp = zero-point):
  *   Quant   : out = round_to_int8(A_fp32 * B + zp)
  *   Requant : out = round_to_int8(int32_to_fp32(A) * B + zp)
  *   Dequant : out = (int32_to_fp32(A) + zp) * B   -- caller passes bits of -zero_point
@@ -101,12 +98,10 @@ inline constexpr std::uint32_t quant_replay_len() {
  * @tparam OP: Which quant-family op, values = <Quant/Requant/Dequant>
  * @tparam SIGN_MAGNITUDE_FORMAT: If true, treat int32 dest as SMAG32 and skip the SM<->2's-comp casts.
  * @param zero_point: fp32 bit-pattern of the zero-point (Dequant expects the bits of -zero_point).
- * @note Call once before @ref _quant_family_ with the same OP / SIGN_MAGNITUDE_FORMAT.
+ * @note Call once before @ref quant_family with the same OP / SIGN_MAGNITUDE_FORMAT.
  */
 template <QuantVariant OP, bool SIGN_MAGNITUDE_FORMAT = false>
-inline void _quant_family_init_(const std::uint32_t zero_point) {
-    static_assert(is_quant_variant(OP), "_quant_family_init_: OP must be Quant/Requant/Dequant");
-
+inline void quant_family_init(const std::uint32_t zero_point) {
     TT_SFPLOADI(p_sfpu::LREG2, sfpi::SFPLOADI_MOD0_LOWER, zero_point & 0xFFFF);  // zp low half
     TT_SFPLOADI(p_sfpu::LREG2, sfpi::SFPLOADI_MOD0_UPPER, zero_point >> 16);     // zp high half -> LREG2 = fp32 zp
 
@@ -152,24 +147,22 @@ inline void _quant_family_init_(const std::uint32_t zero_point) {
  *
  * Operand A is loaded as fp32 for Quant and int32 for Requant/Dequant; the result is stored as
  * int32 for Quant/Requant and fp32 for Dequant. The runtime-address loads/store stay inline; the
- * register-only middle recorded by @ref _quant_family_init_ is replayed each iteration.
+ * register-only middle recorded by @ref quant_family_init is replayed each iteration.
  *
  * @tparam OP: Which quant-family op, values = <Quant/Requant/Dequant>
  * @tparam ITERATIONS: Number of SFPU passes spanning the tile (default = SFPU_ITERATIONS).
- * @tparam SIGN_MAGNITUDE_FORMAT: Must match the value passed to @ref _quant_family_init_.
+ * @tparam SIGN_MAGNITUDE_FORMAT: Must match the value passed to @ref quant_family_init.
  * @tparam TILE_SHAPE: Dest tile shape used to scale the tile indices into row offsets.
  * @param dst_index_in0,dst_index_in1,dst_index_out: Dest tile indices of operand A, operand B, and the result.
- * @note Call @ref _quant_family_init_ with the same OP / SIGN_MAGNITUDE_FORMAT before this.
+ * @note Call @ref quant_family_init with the same OP / SIGN_MAGNITUDE_FORMAT before this.
  */
 template <
     QuantVariant OP,
     int ITERATIONS = SFPU_ITERATIONS,
     bool SIGN_MAGNITUDE_FORMAT = false,
     trisc::DstTileShape TILE_SHAPE = trisc::DstTileShape::Tile32x32>
-inline void _quant_family_(
+inline void quant_family(
     const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
-    static_assert(is_quant_variant(OP), "_quant_family_: OP must be Quant/Requant/Dequant");
-
     constexpr std::uint32_t slot = quant_replay_slot<OP>();
     constexpr std::uint32_t len = quant_replay_len<OP, SIGN_MAGNITUDE_FORMAT>();
     constexpr auto A_FORMAT = (OP == QuantVariant::Quant) ? p_sfpu::sfpmem::FP32 : p_sfpu::sfpmem::INT32;

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
@@ -43,7 +43,7 @@
 //    (and init_binary_sfpu_operation_quasar() if it needs an init step).
 #include "llk_sfpu/ckernel_sfpu_binary.h"         // calculate_sfpu_binary / sfpu_binary_init (float mul/div)
 #include "llk_sfpu/ckernel_sfpu_binary_max_min.h" // calculate_binary_max_min / _init_binary_max_min_
-#include "llk_sfpu/ckernel_sfpu_quant.h"          // _quant_family_ / _quant_family_init_ (quant/requant/dequant)
+#include "llk_sfpu/ckernel_sfpu_quant.h"          // quant_family / quant_family_init (quant/requant/dequant)
 #include "llk_sfpu/llk_math_eltwise_binary_sfpu_macros.h"
 #include "sfpu/ckernel_sfpu_add.h"         // _add_int_ (int add)
 #include "sfpu/ckernel_sfpu_binary_comp.h" // calculate_binary_comp_int32 (int gt/lt/le/ge)
@@ -54,6 +54,9 @@ namespace test_utils
 using namespace ckernel;
 using namespace ckernel::math;
 using namespace ckernel::sfpu;
+
+template <auto>
+inline constexpr bool unhandled_op = false;
 
 /**
  * @brief Whether OPERATION is one of the six comparison-to-zero modes.
@@ -277,7 +280,7 @@ void call_unary_sfpu_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_f
     }
     else
     {
-        LLK_ASSERT(false, "Unsupported Quasar unary SFPU operation");
+        static_assert(unhandled_op<OPERATION>, "call_unary_sfpu_operation_quasar: unhandled Quasar unary SFPU operation");
     }
 }
 
@@ -292,23 +295,39 @@ constexpr bool quasar_binary_op_is_quant(ckernel::BinaryOp op)
 }
 
 // Map the shared BinaryOp enum onto the quant kernel's op-templated QuantVariant.
-constexpr ckernel::sfpu::QuantVariant quant_variant_of(ckernel::BinaryOp op)
+template <ckernel::BinaryOp OP>
+constexpr ckernel::sfpu::QuantVariant quant_variant_of()
 {
-    return op == ckernel::BinaryOp::QUANT     ? ckernel::sfpu::QuantVariant::Quant
-           : op == ckernel::BinaryOp::REQUANT ? ckernel::sfpu::QuantVariant::Requant
-                                              : ckernel::sfpu::QuantVariant::Dequant;
+    if constexpr (OP == ckernel::BinaryOp::QUANT)
+    {
+        return ckernel::sfpu::QuantVariant::Quant;
+    }
+    else if constexpr (OP == ckernel::BinaryOp::REQUANT)
+    {
+        return ckernel::sfpu::QuantVariant::Requant;
+    }
+    else if constexpr (OP == ckernel::BinaryOp::DEQUANT)
+    {
+        return ckernel::sfpu::QuantVariant::Dequant;
+    }
+    else
+    {
+        static_assert(unhandled_op<OP>, "quant_variant_of: unhandled quant BinaryOp");
+    }
 }
 
 /**
  * @brief Run the per-operation init step for a Quasar binary SFPU op.
  *
  * @tparam OP The binary op (compile-time `ckernel::BinaryOp` constant).
+ * @tparam SIGN_MAGNITUDE_FORMAT Quant family only: if true, treat int32 Dest as SMAG32
+ *         and skip the sign-magnitude<->2's-complement casts. Must match the calculate step.
  * @param zero_point fp32 bit-pattern of the zero-point loaded once by the quant
  *        family init (DEQUANT expects the bits of -zero_point); ignored by the
  *        other ops, which have no runtime init argument.
  * @note Pair with @ref call_binary_sfpu_operation_quasar for the calculate step.
  */
-template <ckernel::BinaryOp OP>
+template <ckernel::BinaryOp OP, bool SIGN_MAGNITUDE_FORMAT = false>
 void init_binary_sfpu_operation_quasar([[maybe_unused]] std::uint32_t zero_point = 0)
 {
     if constexpr (OP == BinaryOp::MUL)
@@ -326,7 +345,7 @@ void init_binary_sfpu_operation_quasar([[maybe_unused]] std::uint32_t zero_point
     else if constexpr (quasar_binary_op_is_quant(OP))
     {
         // One op-templated quant kernel; DEQUANT's caller passes bits of -zero_point.
-        _quant_family_init_<quant_variant_of(OP)>(zero_point);
+        quant_family_init<quant_variant_of<OP>(), SIGN_MAGNITUDE_FORMAT>(zero_point);
     }
     // ADD / SUB / GT / LT / LE / GE are stateless — no init.
 }
@@ -338,11 +357,13 @@ void init_binary_sfpu_operation_quasar([[maybe_unused]] std::uint32_t zero_point
  * @tparam DST_SYNC Destination synchronization mode used for bounds checking.
  * @tparam is_fp32_dest_acc_en Whether Dest is in FP32 mode.
  * @tparam ITERATIONS Number of SFPU loop iterations.
+ * @tparam SIGN_MAGNITUDE_FORMAT Quant family only: if true, treat int32 Dest as SMAG32
+ *         and skip the sign-magnitude<->2's-complement casts. Must match the init step.
  * @param src0_tile,src1_tile,dst_tile Operand / result tile indices.
  * @param math_format Dest math format (Int32 vs float path for MUL and max/min).
  * @note Must be preceded by @ref init_binary_sfpu_operation_quasar for the same op.
  */
-template <ckernel::BinaryOp OP, DstSync DST_SYNC, bool is_fp32_dest_acc_en, int ITERATIONS = SFPU_ITERATIONS>
+template <ckernel::BinaryOp OP, DstSync DST_SYNC, bool is_fp32_dest_acc_en, int ITERATIONS = SFPU_ITERATIONS, bool SIGN_MAGNITUDE_FORMAT = false>
 void call_binary_sfpu_operation_quasar(std::uint32_t src0_tile, std::uint32_t src1_tile, std::uint32_t dst_tile, [[maybe_unused]] DataFormat math_format)
 {
     if constexpr (OP == BinaryOp::ADD)
@@ -432,7 +453,14 @@ void call_binary_sfpu_operation_quasar(std::uint32_t src0_tile, std::uint32_t sr
     else if constexpr (quasar_binary_op_is_quant(OP))
     {
         SFPU_BINARY_CALL(
-            DST_SYNC, is_fp32_dest_acc_en, _quant_family_, (quant_variant_of(OP), ITERATIONS), src0_tile, src1_tile, dst_tile, VectorMode::RC);
+            DST_SYNC,
+            is_fp32_dest_acc_en,
+            quant_family,
+            (quant_variant_of<OP>(), ITERATIONS, SIGN_MAGNITUDE_FORMAT),
+            src0_tile,
+            src1_tile,
+            dst_tile,
+            VectorMode::RC);
     }
     else if constexpr (quasar_binary_op_is_max_min(OP))
     {
@@ -465,11 +493,7 @@ void call_binary_sfpu_operation_quasar(std::uint32_t src0_tile, std::uint32_t sr
     }
     else
     {
-        // Catches BinaryOp values this dispatcher does not implement;
-        // a compile-time static_assert can't be used here because OP is a
-        // non-type param, so sizeof(OP)==0 is non-dependent and fires for every
-        // instantiation (matches the runtime guard in the unary dispatcher).
-        LLK_ASSERT(false, "Unsupported Quasar binary SFPU operation");
+        static_assert(unhandled_op<OP>, "call_binary_sfpu_operation_quasar: unhandled Quasar binary SFPU operation");
     }
 }
 

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
@@ -43,6 +43,7 @@
 //    (and init_binary_sfpu_operation_quasar() if it needs an init step).
 #include "llk_sfpu/ckernel_sfpu_binary.h"         // calculate_sfpu_binary / sfpu_binary_init (float mul/div)
 #include "llk_sfpu/ckernel_sfpu_binary_max_min.h" // calculate_binary_max_min / _init_binary_max_min_
+#include "llk_sfpu/ckernel_sfpu_quant.h"          // _quant_family_ / _quant_family_init_ (quant/requant/dequant)
 #include "llk_sfpu/llk_math_eltwise_binary_sfpu_macros.h"
 #include "sfpu/ckernel_sfpu_add.h"         // _add_int_ (int add)
 #include "sfpu/ckernel_sfpu_binary_comp.h" // calculate_binary_comp_int32 (int gt/lt/le/ge)
@@ -285,14 +286,30 @@ constexpr bool quasar_binary_op_is_max_min(ckernel::BinaryOp op)
     return op == ckernel::BinaryOp::MAX || op == ckernel::BinaryOp::MIN;
 }
 
+constexpr bool quasar_binary_op_is_quant(ckernel::BinaryOp op)
+{
+    return op == ckernel::BinaryOp::QUANT || op == ckernel::BinaryOp::REQUANT || op == ckernel::BinaryOp::DEQUANT;
+}
+
+// Map the shared BinaryOp enum onto the quant kernel's op-templated QuantVariant.
+constexpr ckernel::sfpu::QuantVariant quant_variant_of(ckernel::BinaryOp op)
+{
+    return op == ckernel::BinaryOp::QUANT     ? ckernel::sfpu::QuantVariant::Quant
+           : op == ckernel::BinaryOp::REQUANT ? ckernel::sfpu::QuantVariant::Requant
+                                              : ckernel::sfpu::QuantVariant::Dequant;
+}
+
 /**
  * @brief Run the per-operation init step for a Quasar binary SFPU op.
  *
  * @tparam OP The binary op (compile-time `ckernel::BinaryOp` constant).
+ * @param zero_point fp32 bit-pattern of the zero-point loaded once by the quant
+ *        family init (DEQUANT expects the bits of -zero_point); ignored by the
+ *        other ops, which have no runtime init argument.
  * @note Pair with @ref call_binary_sfpu_operation_quasar for the calculate step.
  */
 template <ckernel::BinaryOp OP>
-void init_binary_sfpu_operation_quasar()
+void init_binary_sfpu_operation_quasar([[maybe_unused]] std::uint32_t zero_point = 0)
 {
     if constexpr (OP == BinaryOp::MUL)
     {
@@ -305,6 +322,11 @@ void init_binary_sfpu_operation_quasar()
     else if constexpr (quasar_binary_op_is_max_min(OP))
     {
         _init_binary_max_min_();
+    }
+    else if constexpr (quasar_binary_op_is_quant(OP))
+    {
+        // One op-templated quant kernel; DEQUANT's caller passes bits of -zero_point.
+        _quant_family_init_<quant_variant_of(OP)>(zero_point);
     }
     // ADD / SUB / GT / LT / LE / GE are stateless — no init.
 }
@@ -406,6 +428,11 @@ void call_binary_sfpu_operation_quasar(std::uint32_t src0_tile, std::uint32_t sr
             src1_tile,
             dst_tile,
             VectorMode::RC);
+    }
+    else if constexpr (quasar_binary_op_is_quant(OP))
+    {
+        SFPU_BINARY_CALL(
+            DST_SYNC, is_fp32_dest_acc_en, _quant_family_, (quant_variant_of(OP), ITERATIONS), src0_tile, src1_tile, dst_tile, VectorMode::RC);
     }
     else if constexpr (quasar_binary_op_is_max_min(OP))
     {

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
@@ -612,6 +612,18 @@ class ZERO_POINT(RuntimeParameter):
 
 
 @dataclass
+class SIGN_MAGNITUDE_FORMAT(TemplateParameter):
+    """Quant-family SMAG32 datapath toggle; read only by the quant binary ops."""
+
+    sign_magnitude: bool = False
+
+    def convert_to_cpp(self) -> str:
+        return (
+            f"constexpr bool SFPU_SIGN_MAGNITUDE = {str(self.sign_magnitude).lower()};"
+        )
+
+
+@dataclass
 class L1_ACC(RuntimeParameter):
     l1_acc: L1Accumulation = L1Accumulation.No
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
@@ -597,6 +597,21 @@ class SFPU_TILE_INDICES(RuntimeParameter):
 
 
 @dataclass
+class ZERO_POINT(RuntimeParameter):
+    """fp32 bit-pattern of the quant-family zero-point, passed to the binary SFPU
+    init at runtime. DEQUANT expects the bits of -zero_point (the init negates the
+    contract by loading these bits directly). Ignored by non-quant binary ops."""
+
+    zero_point_bits: int = 0
+
+    def convert_to_cpp(self) -> str:
+        return f"constexpr std::uint32_t ZERO_POINT = {self.zero_point_bits}u;"
+
+    def convert_to_struct_fields(self) -> tuple[str, str]:
+        return "std::uint32_t ZERO_POINT;", "I"
+
+
+@dataclass
 class L1_ACC(RuntimeParameter):
     l1_acc: L1Accumulation = L1Accumulation.No
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_sfpu_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_sfpu_quasar.py
@@ -676,7 +676,6 @@ def _run_quant(binary_op, tile_indices):
     output_format = DataFormat.Float32 if is_dequant else DataFormat.Int32
 
     # ---- stimuli (one tile's worth of active datums) ----
-    torch.manual_seed(42)
     n = MAX_TILE_ELEMENTS
 
     # Scale: small positive fp32 so the quantized magnitudes stay inside [-127,127].
@@ -789,8 +788,10 @@ def _run_quant(binary_op, tile_indices):
 
 
 @pytest.mark.quasar
-@pytest.mark.parametrize("tile_indices", _TILE_INDEX_VARIANTS)
-@pytest.mark.parametrize("binary_op", _QUANT_OPS, ids=_QUANT_OPS)
+@parametrize(
+    binary_op=_QUANT_OPS,
+    tile_indices=runtime(_TILE_INDEX_VARIANTS),
+)
 def test_eltwise_binary_sfpu_quant_quasar(binary_op, tile_indices):
     """Binary SFPU quant family (quant / requant / dequant), Int32-staged operands
     with a runtime fp32 zero-point; output Int32 (quant/requant) or Float32

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_sfpu_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_sfpu_quasar.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
+import struct
 from typing import List
 
 import pytest
@@ -44,6 +45,7 @@ from helpers.test_variant_parameters import (
     NUM_FACES,
     SFPU_BINARY_OP,
     SFPU_TILE_INDICES,
+    SIGN_MAGNITUDE_FORMAT,
     TEST_FACE_DIMS,
     TILE_COUNT,
     TYPECAST_FORMATS,
@@ -148,6 +150,8 @@ def _run_sfpu_binary_llk_golden(
             DATA_COPY_TYPE(DataCopyType.A2D),
             UNPACKER_ENGINE_SEL(UnpackerEngine.UnpDest),
             DEST_SYNC(),
+            # 2's-complement datapath (default); only the quant family reads this.
+            SIGN_MAGNITUDE_FORMAT(False),
             # The shared unary-SFPU dispatch in sfpu_operations_quasar.h has a typecast
             # branch that references the non-dependent globals TYPECAST_IN_FORMAT /
             # TYPECAST_OUT_FORMAT, so every build that includes it must define them.
@@ -530,6 +534,8 @@ def _run_max_min(
                 UnpackerEngine.UnpDest if unpack_to_dest else UnpackerEngine.UnpA
             ),
             DEST_SYNC(),
+            # 2's-complement datapath (default); only the quant family reads this.
+            SIGN_MAGNITUDE_FORMAT(False),
             # The shared unary-SFPU dispatch in sfpu_operations_quasar.h has a typecast
             # branch that references the non-dependent globals TYPECAST_IN_FORMAT /
             # TYPECAST_OUT_FORMAT, so every build that includes it must define them.
@@ -663,10 +669,18 @@ def _fp32_bits_as_int32(t: torch.Tensor) -> torch.Tensor:
     return t.to(torch.float32).contiguous().view(torch.int32)
 
 
+def _int32_to_smag32(t: torch.Tensor) -> torch.Tensor:
+    """Encode a 2's-complement int32 tensor as sign-magnitude 32-bit (SMAG32):
+    bit31 = sign, bits[30:0] = magnitude. Used to stage operands for and model
+    the SIGN_MAGNITUDE_FORMAT kernel path, which skips the 2's-comp<->SM casts."""
+    v = t.to(torch.int64)
+    return (v.abs() | ((v < 0).to(torch.int64) << 31)).to(torch.int32)
+
+
 _QUANT_OPS = ["QUANT", "REQUANT", "DEQUANT"]
 
 
-def _run_quant(binary_op, tile_indices):
+def _run_quant(binary_op, tile_indices, sign_magnitude=False):
     src0_idx, src1_idx, dst_idx = tile_indices
     dest_acc = DestAccumulation.Yes  # all quant endpoints are 32-bit
     num_faces = MAX_NUM_FACES
@@ -687,7 +701,9 @@ def _run_quant(binary_op, tile_indices):
         # int32 operand A in a modest range so int*scale stays well within int8.
         a_vals = torch.randint(-2000, 2000, (n,), dtype=torch.int32)
         a_float = a_vals.to(torch.float32)
-        a_staged = a_vals  # already int32 (2's-comp; twos_complement=True stages raw)
+        # The SIGN_MAGNITUDE_FORMAT path skips the 2's-comp->SM input cast, so operand
+        # A must already be SMAG32; the default path expects raw 2's-complement.
+        a_staged = _int32_to_smag32(a_vals) if sign_magnitude else a_vals
     else:
         # fp32 operand A.
         a_float = (torch.rand(n, dtype=torch.float32) - 0.5) * 4000.0  # +/-2000
@@ -708,23 +724,27 @@ def _run_quant(binary_op, tile_indices):
     else:
         prod = a_float * scale + zero_point
         rounded = torch.round(prod)  # round-half-to-even matches SFP STOCH_RND NearEven
-        clamped = torch.clamp(rounded, _QUANT_INT8_MIN, _QUANT_INT8_MAX)
-        golden_active = clamped.to(torch.int32)
-        # STOCH_RND emits a sign-magnitude result: a negative value whose magnitude
-        # rounds to 0 becomes sign-magnitude negative-zero (0x80000000). The
-        # SM32_TO_2SC cast maps that to 2's-complement -1 (not +0), so model it.
-        neg_zero = (golden_active == 0) & (prod < 0)
-        golden_active[neg_zero] = -1
+        clamped = torch.clamp(rounded, _QUANT_INT8_MIN, _QUANT_INT8_MAX).to(torch.int32)
+        # STOCH_RND emits a sign-magnitude int8 result. A negative value whose
+        # magnitude rounds to 0 becomes sign-magnitude negative-zero (0x80000000).
+        neg_zero = (clamped == 0) & (prod < 0)
+        if sign_magnitude:
+            # SM path stores the STOCH_RND SMAG32 result as-is (no SM32_TO_2SC cast):
+            # negatives keep bit31|magnitude and negative-zero stays 0x80000000.
+            golden_active = _int32_to_smag32(clamped)
+            golden_active[neg_zero] = torch.tensor(-(2**31), dtype=torch.int32)
+        else:
+            # 2's-comp path: SM32_TO_2SC maps STOCH_RND negative-zero to -1 (not +0).
+            golden_active = clamped
+            golden_active[neg_zero] = -1
         out_dtype = torch.int32
 
     golden_tensor = torch.zeros(MAX_TILE_ELEMENTS, dtype=out_dtype)
     golden_tensor[:_PROCESSED_ELEMS] = golden_active[:_PROCESSED_ELEMS]
 
     # zero_point bits passed to the kernel init (DEQUANT negates the contract).
-    import struct as _struct
-
     zp_for_kernel = -zero_point if is_dequant else zero_point
-    zp_bits = _struct.unpack("<I", _struct.pack("<f", zp_for_kernel))[0]
+    zp_bits = struct.unpack("<I", struct.pack("<f", zp_for_kernel))[0]
 
     # buffer_A is raw int32; operand B's fp32 bits ride along as int32 words.
     formats = InputOutputFormat(
@@ -740,6 +760,7 @@ def _run_quant(binary_op, tile_indices):
             DATA_COPY_TYPE(DataCopyType.A2D),
             UNPACKER_ENGINE_SEL(UnpackerEngine.UnpDest),
             DEST_SYNC(),
+            SIGN_MAGNITUDE_FORMAT(sign_magnitude),
             TYPECAST_FORMATS(),
         ],
         runtimes=[
@@ -784,16 +805,18 @@ def _run_quant(binary_op, tile_indices):
         golden_tensor[:_PROCESSED_ELEMS],
         res_tensor[:_PROCESSED_ELEMS],
         output_format,
-    ), f"{binary_op} mismatch (tile_indices={tile_indices})"
+    ), f"{binary_op} (sign_magnitude={sign_magnitude}) mismatch (tile_indices={tile_indices})"
 
 
 @pytest.mark.quasar
 @parametrize(
     binary_op=_QUANT_OPS,
+    sign_magnitude=[False, True],
     tile_indices=runtime(_TILE_INDEX_VARIANTS),
 )
-def test_eltwise_binary_sfpu_quant_quasar(binary_op, tile_indices):
+def test_eltwise_binary_sfpu_quant_quasar(binary_op, sign_magnitude, tile_indices):
     """Binary SFPU quant family (quant / requant / dequant), Int32-staged operands
     with a runtime fp32 zero-point; output Int32 (quant/requant) or Float32
-    (dequant)."""
-    _run_quant(binary_op, tile_indices)
+    (dequant). Exercised on both the 2's-complement and SIGN_MAGNITUDE_FORMAT
+    (SMAG32) datapaths."""
+    _run_quant(binary_op, tile_indices, sign_magnitude)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_sfpu_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_sfpu_quasar.py
@@ -48,6 +48,7 @@ from helpers.test_variant_parameters import (
     TILE_COUNT,
     TYPECAST_FORMATS,
     UNPACKER_ENGINE_SEL,
+    ZERO_POINT,
 )
 from helpers.tile_constants import MAX_NUM_FACES, MAX_TILE_ELEMENTS
 from helpers.utils import passed_test
@@ -64,6 +65,28 @@ _CPP_SOURCE = "sources/quasar/eltwise_binary_sfpu_quasar_test.cpp"
 # Shared (src0_idx, src1_idx, dst_idx) tile-index variants exercised by every
 # binary SFPU family
 _TILE_INDEX_VARIANTS = [(0, 1, 0), (2, 3, 0)]
+
+
+def _stage_binary_operands(op0_flat, op1_flat, tile_indices, dtype):
+    """Lay two binary operands into a TILE_CNT-tile buffer_A so buffer_A[i] maps
+    to Dest[i]: op0 at tile src0_idx, op1 at tile src1_idx, gaps zero-filled.
+    The kernel writes the result to Dest[dst_idx], which may alias an operand
+    tile (e.g. (0, 1, 0)) or be disjoint (e.g. (2, 3, 0)). Shared by the max/min
+    (float/int) and quant (raw-int32) families."""
+    src0_idx, src1_idx, dst_idx = tile_indices
+    tile_cnt = max(src0_idx, src1_idx, dst_idx) + 1
+
+    def _pad_to_tile(flat):
+        if len(flat) < MAX_TILE_ELEMENTS:
+            return torch.cat(
+                [flat, torch.zeros(MAX_TILE_ELEMENTS - len(flat), dtype=dtype)]
+            )
+        return flat
+
+    tiles = [torch.zeros(MAX_TILE_ELEMENTS, dtype=dtype) for _ in range(tile_cnt)]
+    tiles[src0_idx] = _pad_to_tile(op0_flat.flatten())
+    tiles[src1_idx] = _pad_to_tile(op1_flat.flatten())
+    return torch.cat(tiles), tile_cnt
 
 
 def _get_valid_implied_math_formats(fmt: FormatConfig):
@@ -136,6 +159,7 @@ def _run_sfpu_binary_llk_golden(
             TEST_FACE_DIMS(),
             DEST_INDEX(0),
             SFPU_TILE_INDICES(src0_idx, src1_idx, dst_idx),
+            ZERO_POINT(0),
         ],
         variant_stimuli=StimuliConfig(
             src_A,
@@ -418,27 +442,6 @@ def _generate_max_min_combinations(
     return combinations
 
 
-def _stage_max_min_operands(op0_flat, op1_flat, tile_indices, dtype):
-    """Lay the two max/min operands into a TILE_CNT-tile buffer_A so buffer_A[i]
-    maps to Dest[i]: op0 at tile src0_idx, op1 at tile src1_idx, gaps zero-filled.
-    The kernel writes the result to Dest[dst_idx], which may alias an operand
-    tile (e.g. (0, 1, 0)) or be disjoint (e.g. (2, 3, 0))."""
-    src0_idx, src1_idx, dst_idx = tile_indices
-    tile_cnt = max(src0_idx, src1_idx, dst_idx) + 1
-
-    def _pad_to_tile(flat):
-        if len(flat) < MAX_TILE_ELEMENTS:
-            return torch.cat(
-                [flat, torch.zeros(MAX_TILE_ELEMENTS - len(flat), dtype=dtype)]
-            )
-        return flat
-
-    tiles = [torch.zeros(MAX_TILE_ELEMENTS, dtype=dtype) for _ in range(tile_cnt)]
-    tiles[src0_idx] = _pad_to_tile(op0_flat)
-    tiles[src1_idx] = _pad_to_tile(op1_flat)
-    return torch.cat(tiles), tile_cnt
-
-
 def _run_max_min(
     formats,
     dest_acc,
@@ -476,8 +479,8 @@ def _run_max_min(
             else torch.minimum(in0_int, in1_int)
         )
         golden_tensor = golden_int.to(torch.float32)
-        buffer_A_combined, tile_cnt = _stage_max_min_operands(
-            in0_int.flatten(), in1_int.flatten(), tile_indices, torch.int32
+        buffer_A_combined, tile_cnt = _stage_binary_operands(
+            in0_int, in1_int, tile_indices, torch.int32
         )
         buffer_B_dummy = in1_int
         disable_format_inference = False
@@ -506,8 +509,8 @@ def _run_max_min(
             golden_tensor = quantize_mx_stimuli(
                 golden_tensor.flatten(), formats.output_format, num_faces
             ).reshape(golden_tensor.shape)
-        buffer_A_combined, tile_cnt = _stage_max_min_operands(
-            in0.flatten(), in1.flatten(), tile_indices, in0.dtype
+        buffer_A_combined, tile_cnt = _stage_binary_operands(
+            in0, in1, tile_indices, in0.dtype
         )
         buffer_B_dummy = in1
         disable_format_inference = formats.input_format.is_mx_format()
@@ -538,6 +541,7 @@ def _run_max_min(
             TEST_FACE_DIMS(),
             DEST_INDEX(0),
             SFPU_TILE_INDICES(src0_idx, src1_idx, dst_idx),
+            ZERO_POINT(0),
         ],
         variant_stimuli=StimuliConfig(
             buffer_A_combined,
@@ -627,3 +631,167 @@ def test_eltwise_binary_sfpu_max_min_int32_quasar(
         tile_indices,
         is_int=True,
     )
+
+
+# ===========================================================================
+# Family 4 — quant / requant / dequant. Mixed int/float operands with a runtime
+# fp32 zero-point. Ported from Blackhole ckernel_sfpu_quant.h.
+#
+#   quant:   out_int32 = clamp(round(A_fp32 * scale_fp32 + zp), -127, 127)
+#   requant: out_int32 = clamp(round(int32_to_fp32(A) * scale_fp32 + zp), -127, 127)
+#   dequant: out_fp32  = (int32_to_fp32(A) - zp) * scale_fp32
+#
+# Operand A and the fp32 scale B are both staged into buffer_A as raw 32-bit words
+# (Int32 tag, twos_complement=True => identity bit copy). The unpack-to-dest path
+# moves the raw 32 bits into Dest unchanged; the kernel re-interprets each operand
+# via its explicit per-operand SFPLOAD sfpmem mode (FP32 vs INT32). The packer
+# format is set per op (Int32 for quant/requant, Float32 for dequant) by patching
+# the inferred FormatConfig, since input and output formats differ.
+# ===========================================================================
+# The binary SFPU params wrapper calls the kernel once per face (4 faces); each
+# call runs ITERATIONS=8 unrolled rows, covering the whole 1024-element dst tile.
+_PROCESSED_ELEMS = MAX_TILE_ELEMENTS
+
+# SMAG8 saturation: the STOCH_RND fp32->sint8 path clamps magnitude to 127, so the
+# representable output range is [-127, +127] (-128 is NOT representable).
+_QUANT_INT8_MIN = -127
+_QUANT_INT8_MAX = 127
+
+
+def _fp32_bits_as_int32(t: torch.Tensor) -> torch.Tensor:
+    """Reinterpret a float32 tensor's bits as int32 (no numeric conversion)."""
+    return t.to(torch.float32).contiguous().view(torch.int32)
+
+
+_QUANT_OPS = ["QUANT", "REQUANT", "DEQUANT"]
+
+
+def _run_quant(binary_op, tile_indices):
+    src0_idx, src1_idx, dst_idx = tile_indices
+    dest_acc = DestAccumulation.Yes  # all quant endpoints are 32-bit
+    num_faces = MAX_NUM_FACES
+
+    is_dequant = binary_op == "DEQUANT"
+    a_is_int = binary_op in ("REQUANT", "DEQUANT")
+    output_format = DataFormat.Float32 if is_dequant else DataFormat.Int32
+
+    # ---- stimuli (one tile's worth of active datums) ----
+    torch.manual_seed(42)
+    n = MAX_TILE_ELEMENTS
+
+    # Scale: small positive fp32 so the quantized magnitudes stay inside [-127,127].
+    scale = torch.rand(n, dtype=torch.float32) * 0.04 + 0.01  # [0.01, 0.05)
+    # Zero-point: a small fp32 offset.
+    zero_point = 3.0
+
+    if a_is_int:
+        # int32 operand A in a modest range so int*scale stays well within int8.
+        a_vals = torch.randint(-2000, 2000, (n,), dtype=torch.int32)
+        a_float = a_vals.to(torch.float32)
+        a_staged = a_vals  # already int32 (2's-comp; twos_complement=True stages raw)
+    else:
+        # fp32 operand A.
+        a_float = (torch.rand(n, dtype=torch.float32) - 0.5) * 4000.0  # +/-2000
+        a_vals = a_float
+        a_staged = _fp32_bits_as_int32(a_float)
+
+    b_staged = _fp32_bits_as_int32(scale)
+
+    buffer_A, tile_cnt = _stage_binary_operands(
+        a_staged, b_staged, tile_indices, torch.int32
+    )
+
+    # ---- golden ----
+    if is_dequant:
+        golden_active = (a_float - zero_point) * scale  # fp32
+        golden_active = golden_active.to(torch.float32)
+        out_dtype = torch.float32
+    else:
+        prod = a_float * scale + zero_point
+        rounded = torch.round(prod)  # round-half-to-even matches SFP STOCH_RND NearEven
+        clamped = torch.clamp(rounded, _QUANT_INT8_MIN, _QUANT_INT8_MAX)
+        golden_active = clamped.to(torch.int32)
+        # STOCH_RND emits a sign-magnitude result: a negative value whose magnitude
+        # rounds to 0 becomes sign-magnitude negative-zero (0x80000000). The
+        # SM32_TO_2SC cast maps that to 2's-complement -1 (not +0), so model it.
+        neg_zero = (golden_active == 0) & (prod < 0)
+        golden_active[neg_zero] = -1
+        out_dtype = torch.int32
+
+    golden_tensor = torch.zeros(MAX_TILE_ELEMENTS, dtype=out_dtype)
+    golden_tensor[:_PROCESSED_ELEMS] = golden_active[:_PROCESSED_ELEMS]
+
+    # zero_point bits passed to the kernel init (DEQUANT negates the contract).
+    import struct as _struct
+
+    zp_for_kernel = -zero_point if is_dequant else zero_point
+    zp_bits = _struct.unpack("<I", _struct.pack("<f", zp_for_kernel))[0]
+
+    # buffer_A is raw int32; operand B's fp32 bits ride along as int32 words.
+    formats = InputOutputFormat(
+        input_format=DataFormat.Int32, output_format=output_format
+    )
+
+    configuration = TestConfig(
+        _CPP_SOURCE,
+        formats,
+        templates=[
+            SFPU_BINARY_OP(binary_op),
+            IMPLIED_MATH_FORMAT(ImpliedMathFormat.No),
+            DATA_COPY_TYPE(DataCopyType.A2D),
+            UNPACKER_ENGINE_SEL(UnpackerEngine.UnpDest),
+            DEST_SYNC(),
+        ],
+        runtimes=[
+            TILE_COUNT(tile_cnt),
+            NUM_FACES(num_faces),
+            TEST_FACE_DIMS(),
+            DEST_INDEX(0),
+            SFPU_TILE_INDICES(src0_idx, src1_idx, dst_idx),
+            ZERO_POINT(zp_bits),
+        ],
+        variant_stimuli=StimuliConfig(
+            buffer_A,
+            DataFormat.Int32,
+            buffer_A[:MAX_TILE_ELEMENTS],  # dummy buffer_B (unused by kernel)
+            DataFormat.Int32,
+            output_format,
+            tile_count_A=tile_cnt,
+            tile_count_B=1,
+            tile_count_res=1,
+            num_faces=num_faces,
+            twos_complement=True,  # raw 32-bit identity staging
+        ),
+        unpack_to_dest=True,
+        dest_acc=dest_acc,
+        disable_format_inference=True,
+    )
+
+    # Packer reads the SFPU result tile from Dest. For dequant the result is fp32;
+    # for quant/requant it is int32. disable_format_inference ties pack_src to the
+    # (Int32) input format, so override it to match the actual output datum width.
+    fc = configuration.formats_config[0]
+    fc.pack_src = output_format
+    fc.pack_dst = output_format
+    fc.pack_S_src = output_format
+    fc.pack_S_dst = output_format
+
+    res_from_L1 = configuration.run().result
+    assert len(res_from_L1) == len(golden_tensor)
+    res_tensor = torch.tensor(res_from_L1, dtype=out_dtype)
+    # Compare only the rows the kernel processes (8 iterations * faces).
+    assert passed_test(
+        golden_tensor[:_PROCESSED_ELEMS],
+        res_tensor[:_PROCESSED_ELEMS],
+        output_format,
+    ), f"{binary_op} mismatch (tile_indices={tile_indices})"
+
+
+@pytest.mark.quasar
+@pytest.mark.parametrize("tile_indices", _TILE_INDEX_VARIANTS)
+@pytest.mark.parametrize("binary_op", _QUANT_OPS, ids=_QUANT_OPS)
+def test_eltwise_binary_sfpu_quant_quasar(binary_op, tile_indices):
+    """Binary SFPU quant family (quant / requant / dequant), Int32-staged operands
+    with a runtime fp32 zero-point; output Int32 (quant/requant) or Float32
+    (dequant)."""
+    _run_quant(binary_op, tile_indices)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_sfpu_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_sfpu_quasar.py
@@ -741,6 +741,7 @@ def _run_quant(binary_op, tile_indices):
             DATA_COPY_TYPE(DataCopyType.A2D),
             UNPACKER_ENGINE_SEL(UnpackerEngine.UnpDest),
             DEST_SYNC(),
+            TYPECAST_FORMATS(),
         ],
         runtimes=[
             TILE_COUNT(tile_cnt),

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_sfpu_quasar_test.cpp
@@ -162,7 +162,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
 
     _llk_math_eltwise_sfpu_init_();
-    test_utils::init_binary_sfpu_operation_quasar<SFPU_BINARY_OP>();
+    test_utils::init_binary_sfpu_operation_quasar<SFPU_BINARY_OP>(params.ZERO_POINT);
     test_utils::call_binary_sfpu_operation_quasar<SFPU_BINARY_OP, dest_sync, is_fp32_dest_acc_en>(
         params.SRC0_TILE_IDX, params.SRC1_TILE_IDX, params.DST_TILE_IDX, math_format);
 

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_sfpu_quasar_test.cpp
@@ -162,8 +162,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
 
     _llk_math_eltwise_sfpu_init_();
-    test_utils::init_binary_sfpu_operation_quasar<SFPU_BINARY_OP>(params.ZERO_POINT);
-    test_utils::call_binary_sfpu_operation_quasar<SFPU_BINARY_OP, dest_sync, is_fp32_dest_acc_en>(
+    test_utils::init_binary_sfpu_operation_quasar<SFPU_BINARY_OP, SFPU_SIGN_MAGNITUDE>(params.ZERO_POINT);
+    test_utils::call_binary_sfpu_operation_quasar<SFPU_BINARY_OP, dest_sync, is_fp32_dest_acc_en, SFPU_ITERATIONS, SFPU_SIGN_MAGNITUDE>(
         params.SRC0_TILE_IDX, params.SRC1_TILE_IDX, params.DST_TILE_IDX, math_format);
 
     _llk_math_set_dvalid_<p_cleardvalid::SFPU, dest_sync>();

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_defs.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_defs.h
@@ -60,6 +60,9 @@ enum class BinaryOp : std::uint8_t
     GE,
     MAX,
     MIN,
+    QUANT,
+    REQUANT,
+    DEQUANT,
 };
 
 // For instructions that address lower/upper 16 bits of a register


### PR DESCRIPTION
## What

Port the **quant / requant / dequant** int32 SFPU op family to Quasar, referencing the Blackhole implementation in `tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h`.

All three are binary-operand SFPU ops (operand A, fp32 scale B, fp32 zero-point loaded by `init`) addressing three Dest tile indices `(in0, in1, out)`:

| op | computation | A | out |
|----|-------------|---|-----|
| quant   | `round_to_int8(A * B + zero_point)`            | fp32  | int32 |
| requant | `round_to_int8(A→fp32 * B + zero_point)`       | int32 | int32 |
| dequant | `(A→fp32 - zero_point) * B`                    | int32 | fp32  |

New file: `tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h`. Unlike Blackhole's six separate helpers, Quasar has a **single op-templated pair** selected by `enum class QuantVariant { Quant, Requant, Dequant }`:

- `quant_family_init<OP, SIGN_MAGNITUDE_FORMAT>(zero_point)`
- `quant_family<OP, ITERATIONS, SIGN_MAGNITUDE_FORMAT, TILE_SHAPE>(in0, in1, out)`

## Implementation

**Replay buffers, like Blackhole.** `quant_family_init` records the register-only compute middle into the op's replay slot via Quasar's `load_replay_buf<slot, len, /*exec_while_loading=*/false>` (record-only — Quasar does not support execute-while-recording), and `quant_family` issues `TTI_REPLAY(slot, len, ...)` once per iteration around inline operand loads and the result store. Per-op slots are non-overlapping and sized for the longer 2's-complement variant, so one compute kernel can mix all three ops without cross-clobbering.

**LREG layout** (shared by all three ops): `LREG0` = operand A / accumulator / result, `LREG1` = fp32 scale B, `LREG2` = zero-point loaded once by `init`. `LREG3`-`LREG7` stay free.

**`SIGN_MAGNITUDE_FORMAT` template flag** gates the SM ↔ 2's-complement conversions:
- `false` (default) — int32 Dest content is 2's-complement (UNP_DEST / Int32-L1), so the math is bracketed by `TTI_SFPCAST` `TWO_SC_TO_SM` on int inputs and `SM32_TO_2SC` on int outputs.
- `true` — Dest is SMAG32 (what `SFP_STOCH_RND` natively emits), and both casts are skipped.

**Rounding / math.** quant & requant end in `TTI_SFP_STOCH_RND` (`NearEven`, fp32→sint8); dequant stays in fp32 (`SFPMAD` with `LCONST_1` for `A - zp`, then `SFPMUL` by the scale). Recorded lengths per op/format are given in the header comment.

**Addressing.** 8× `#pragma GCC unroll` with explicit `base + (d<<1)` `ADDR_MOD_7` offsets, and a per-operand `sfpmem` mode (`FP32` for the fp32 scale and quant's A, `INT32` for int operands/results) that re-interprets the raw Dest bits.

**Dropped from the Blackhole version:**
- `apply_sign_magnitude_conversion` (the `SFPCAST` + `SETSGN` pair working around BH RTL bug `tt-llk-bh#16`) — Quasar needs only a single `TTI_SFPCAST` per direction.
- `ADDR_MOD_6` dest auto-increment for the store — Quasar uses explicit per-iteration offsets under `ADDR_MOD_7`.

## Test wiring (unified binary SFPU harness)

- New `ckernel::BinaryOp` entries `QUANT`/`REQUANT`/`DEQUANT` (appended, no reorder).
- New `ZERO_POINT` runtime parameter (fp32 bit pattern; the dequant caller passes the bits of `-zero_point`) and `SIGN_MAGNITUDE_FORMAT` template parameter, both threaded through the dispatcher: `init_binary_sfpu_operation_quasar<OP, SIGN_MAGNITUDE_FORMAT>(zero_point)` and `call_binary_sfpu_operation_quasar<..., SIGN_MAGNITUDE_FORMAT>`, with `quant_variant_of<OP>()` mapping `BinaryOp` → `QuantVariant`.
- Both dispatchers' terminal `else` now fires a dependent `static_assert(unhandled_op<OP>, ...)` instead of a runtime `LLK_ASSERT(false)`, so an unhandled op is a compile error.
- `_stage_max_min_operands` → `_stage_binary_operands`, now shared by the max/min and quant families (flatten moved inside).
- Operands are staged as raw 32-bit words (`Int32` tag, `twos_complement=True` identity copy) because input and output formats differ; `pack_src`/`pack_dst` are patched per op (`Int32` for quant/requant, `Float32` for dequant).
- Golden models the `STOCH_RND` fp32→sint8 **SMAG saturation to [-127, +127]** (-128 is not representable) and the **SMAG negative-zero** mapping: → `-1` on the 2's-complement path, → `0x80000000` on the SMAG32 path.

## Testing

`test_eltwise_binary_sfpu_quant_quasar` on the Quasar simulator — 12 parametrized variants:
**3 ops** (quant `Float32→Int32`, requant `Int32→Int32`, dequant `Int32→Float32`) × **2 datapaths** (2's-complement, `SIGN_MAGNITUDE_FORMAT` SMAG32) × **2 tile layouts** (result aliasing an operand `(0, 1, 0)`, and disjoint `(2, 3, 0)`).

## Review feedback addressed

- Removed the manual seed (conftest already seeds) and switched the new test to `@parametrize`.
- Removed the runtime `is_quant_variant` helper; slot/length selection is now `if constexpr` dispatch ending in `static_assert(quant_unhandled_variant<OP>, ...)`, so a newly added `QuantVariant` that isn't handled fails to compile.
- This description previously claimed replay buffers were dropped and that `lltt.h`/replay are unavailable on Quasar. Both were wrong: the kernel uses replay throughout, and `lltt.h` is available (the sibling `ckernel_sfpu_binary_max_min.h` uses `lltt::record`/`replay`). Corrected above.

## Provenance

Initial version generated via the LLK codegen pipeline (analyzer → writer → tester → optimizer → format), then revised by hand in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ai-code-gen/generate-quant-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ai-code-gen/generate-quant-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ai-code-gen/generate-quant-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ai-code-gen/generate-quant-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ai-code-gen/generate-quant-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ai-code-gen/generate-quant-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ai-code-gen/generate-quant-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ai-code-gen/generate-quant-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ai-code-gen/generate-quant-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ai-code-gen/generate-quant-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ai-code-gen/generate-quant-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ai-code-gen/generate-quant-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ai-code-gen/generate-quant-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ai-code-gen/generate-quant-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ai-code-gen/generate-quant-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ai-code-gen/generate-quant-quasar-v1)
