### PR TITLE
[tt-train] Enable fused q_rope, qkv_assemble, kv_down_split in mla

### DIFF
--- a/tt-train/sources/ttml/ttml/models/deepseek/mla.py
+++ b/tt-train/sources/ttml/ttml/models/deepseek/mla.py
@@ -19,18 +19,18 @@ import ttml
 from ttml.modules import AbstractModuleBase, LinearLayer
 
 from .transformer import RMSNormLayer
-from .autograd_ops import autograd_slice, autograd_concat, autograd_split, split_heads
+from .autograd_ops import autograd_split
 
 
 class MultiHeadLatentAttention(AbstractModuleBase):
     """Multi-head Latent Attention (MLA) layer.
 
     Follows the DeepSeek-V3 naive-mode attention:
-      Q (q_lora_rank > 0): x -> wq_a -> norm -> wq_b -> split_heads
-      Q (q_lora_rank == 0): x -> wq -> split_heads   (direct, no LoRA bottleneck)
-      Both: -> [q_nope, q_pe] -> RoPE(q_pe) -> cat
-      KV: x -> wkv_a -> [kv_latent, k_pe] -> norm(kv_latent) -> wkv_b -> split_heads
-          -> [k_nope, v] + RoPE(k_pe) broadcast -> cat(k_nope, k_pe)
+      Q (q_lora_rank > 0): x -> wq_a -> norm -> wq_b
+      Q (q_lora_rank == 0): x -> wq (direct, no LoRA bottleneck)
+      KV: x -> wkv_a -> split(kv_latent, k_pe) -> norm(kv_latent) -> wkv_b
+          -> RoPE(k_pe) broadcast
+      Q/K/V assembly: qkv_assemble + mla_q_rope on Q
       Attention: fused causal SDPA(Q, K, V) -> fuse_heads -> wo
 
     Causal-only: the fused SDPA generates the causal mask on chip, so this layer
@@ -75,11 +75,9 @@ class MultiHeadLatentAttention(AbstractModuleBase):
         self.wo = LinearLayer(config.n_heads * config.v_head_dim, config.dim, has_bias=False)
 
     def forward(self, x: ttml.autograd.Tensor) -> ttml.autograd.Tensor:
-        B, _, S, _ = list(x.get_value().shape)
         n_heads = self.n_heads
         qk_nope = self.qk_nope_head_dim
         qk_rope = self.qk_rope_head_dim
-        qk_head = self.qk_head_dim
         v_dim = self.v_head_dim
 
         # ── Q path ──

--- a/tt-train/sources/ttml/ttml/models/deepseek/mla.py
+++ b/tt-train/sources/ttml/ttml/models/deepseek/mla.py
@@ -21,6 +21,31 @@ from ttml.modules import AbstractModuleBase, LinearLayer
 from .transformer import RMSNormLayer
 from .autograd_ops import autograd_slice, autograd_concat, autograd_split, split_heads
 
+composite = True
+
+
+def kv_down_split(kv_full, B, S, kv_lora, qk_rope):
+    kv = autograd_slice(kv_full, [0, 0, 0, 0], [B, 1, S, kv_lora])
+    k_pe = autograd_slice(kv_full, [0, 0, 0, kv_lora], [B, 1, S, kv_lora + qk_rope])
+    return kv, k_pe
+
+
+def qkv_assemble(q_pre, kv_up, k_pe, B, n_heads, S, qk_nope, v_head_dim):
+    q = split_heads(q_pre, n_heads)
+    kv_up_heads = split_heads(kv_up, n_heads)
+    k_nope = autograd_slice(kv_up_heads, [0, 0, 0, 0], [B, n_heads, S, qk_nope])
+    v = autograd_slice(kv_up_heads, [0, 0, 0, qk_nope], [B, n_heads, S, qk_nope + v_head_dim])
+    k_pe_broadcast = autograd_concat([k_pe] * n_heads, dim=1)
+    k_full = autograd_concat([k_nope, k_pe_broadcast], dim=3)
+    return q, k_full, v
+
+
+def q_rope(q, rope_params, B, n_heads, S, qk_nope, qk_head):
+    q_nope = autograd_slice(q, [0, 0, 0, 0], [B, n_heads, S, qk_nope])
+    q_pe = autograd_slice(q, [0, 0, 0, qk_nope], [B, n_heads, S, qk_head])
+    q_pe = ttml.ops.rope.rope(q_pe, rope_params)
+    return autograd_concat([q_nope, q_pe], dim=3)
+
 
 class MultiHeadLatentAttention(AbstractModuleBase):
     """Multi-head Latent Attention (MLA) layer.
@@ -84,36 +109,30 @@ class MultiHeadLatentAttention(AbstractModuleBase):
 
         # ── Q path ──
         if self.q_lora_rank == 0:
-            q = self.wq(x)  # [B, 1, S, n_heads * qk_head]
+            q_pre = self.wq(x)  # [B, 1, S, n_heads * qk_head]
         else:
-            q = self.wq_b(self.q_norm(self.wq_a(x)))  # [B, 1, S, n_heads * qk_head]
-        q = split_heads(q, n_heads)  # [B, n_heads, S, qk_head]
-
-        q_full = ttml.ops.rope.mla_q_rope(q, self.rope_params, qk_nope, qk_rope)
+            q_pre = self.wq_b(self.q_norm(self.wq_a(x)))  # [B, 1, S, n_heads * qk_head]
 
         # ── KV path ──
         kv_full = self.wkv_a(x)  # [B, 1, S, kv_lora_rank + qk_rope]
-        kv_lora = self.kv_lora_rank
-
-        # Single split (one concat in backward) instead of two autograd_slice
-        # (which each rebuild a full-width grad with zeros + concat, then sum).
-        kv, k_pe = autograd_split(kv_full, [kv_lora, qk_rope], dim=3)
+        if composite:
+            kv, k_pe = kv_down_split(kv_full, B, S, self.kv_lora_rank, qk_rope)
+        else:
+            kv, k_pe = autograd_split(kv_full, [self.kv_lora_rank, qk_rope], dim=3)
 
         # RoPE on k_pe (shared across heads, shape [B, 1, S, qk_rope])
         k_pe = ttml.ops.rope.rope(k_pe, self.rope_params)
 
-        # Expand k_pe to all heads: [B, 1, S, qk_rope] -> [B, n_heads, S, qk_rope]
-        k_pe = autograd_concat([k_pe] * n_heads, dim=1)
-
-        # Up-project KV latent and split into per-head k_nope and v
         kv_up = self.wkv_b(self.kv_norm(kv))  # [B, 1, S, n_heads * (qk_nope + v_dim)]
-        kv_up = split_heads(kv_up, n_heads)  # [B, n_heads, S, qk_nope + v_dim]
 
-        k_nope = autograd_slice(kv_up, [0, 0, 0, 0], [B, n_heads, S, qk_nope])
-        v = autograd_slice(kv_up, [0, 0, 0, qk_nope], [B, n_heads, S, qk_nope + v_dim])
-
-        # Assemble full K
-        k_full = autograd_concat([k_nope, k_pe], dim=3)  # [B, H, S, qk_head]
+        if composite:
+            q, k_full, v = qkv_assemble(q_pre, kv_up, k_pe, B, n_heads, S, qk_nope, v_dim)
+        else:
+            q, k_full, v = ttml.ops.mla.qkv_assemble(q_pre, kv_up, k_pe, n_heads, qk_nope, qk_rope, v_dim)
+        if composite:
+            q_full = q_rope(q, self.rope_params, B, n_heads, S, qk_nope, qk_head)
+        else:
+            q_full = ttml.ops.rope.mla_q_rope(q, self.rope_params, qk_nope, qk_rope)
 
         # ── Attention (causal-only) ──
         # None -> fused SDPA generates the causal mask on chip and takes the faster

--- a/tt-train/sources/ttml/ttml/models/deepseek/mla.py
+++ b/tt-train/sources/ttml/ttml/models/deepseek/mla.py
@@ -21,31 +21,6 @@ from ttml.modules import AbstractModuleBase, LinearLayer
 from .transformer import RMSNormLayer
 from .autograd_ops import autograd_slice, autograd_concat, autograd_split, split_heads
 
-composite = True
-
-
-def kv_down_split(kv_full, B, S, kv_lora, qk_rope):
-    kv = autograd_slice(kv_full, [0, 0, 0, 0], [B, 1, S, kv_lora])
-    k_pe = autograd_slice(kv_full, [0, 0, 0, kv_lora], [B, 1, S, kv_lora + qk_rope])
-    return kv, k_pe
-
-
-def qkv_assemble(q_pre, kv_up, k_pe, B, n_heads, S, qk_nope, v_head_dim):
-    q = split_heads(q_pre, n_heads)
-    kv_up_heads = split_heads(kv_up, n_heads)
-    k_nope = autograd_slice(kv_up_heads, [0, 0, 0, 0], [B, n_heads, S, qk_nope])
-    v = autograd_slice(kv_up_heads, [0, 0, 0, qk_nope], [B, n_heads, S, qk_nope + v_head_dim])
-    k_pe_broadcast = autograd_concat([k_pe] * n_heads, dim=1)
-    k_full = autograd_concat([k_nope, k_pe_broadcast], dim=3)
-    return q, k_full, v
-
-
-def q_rope(q, rope_params, B, n_heads, S, qk_nope, qk_head):
-    q_nope = autograd_slice(q, [0, 0, 0, 0], [B, n_heads, S, qk_nope])
-    q_pe = autograd_slice(q, [0, 0, 0, qk_nope], [B, n_heads, S, qk_head])
-    q_pe = ttml.ops.rope.rope(q_pe, rope_params)
-    return autograd_concat([q_nope, q_pe], dim=3)
-
 
 class MultiHeadLatentAttention(AbstractModuleBase):
     """Multi-head Latent Attention (MLA) layer.
@@ -115,24 +90,15 @@ class MultiHeadLatentAttention(AbstractModuleBase):
 
         # ── KV path ──
         kv_full = self.wkv_a(x)  # [B, 1, S, kv_lora_rank + qk_rope]
-        if composite:
-            kv, k_pe = kv_down_split(kv_full, B, S, self.kv_lora_rank, qk_rope)
-        else:
-            kv, k_pe = autograd_split(kv_full, [self.kv_lora_rank, qk_rope], dim=3)
+        kv, k_pe = autograd_split(kv_full, [self.kv_lora_rank, qk_rope], dim=3)
 
         # RoPE on k_pe (shared across heads, shape [B, 1, S, qk_rope])
         k_pe = ttml.ops.rope.rope(k_pe, self.rope_params)
 
         kv_up = self.wkv_b(self.kv_norm(kv))  # [B, 1, S, n_heads * (qk_nope + v_dim)]
 
-        if composite:
-            q, k_full, v = qkv_assemble(q_pre, kv_up, k_pe, B, n_heads, S, qk_nope, v_dim)
-        else:
-            q, k_full, v = ttml.ops.mla.qkv_assemble(q_pre, kv_up, k_pe, n_heads, qk_nope, qk_rope, v_dim)
-        if composite:
-            q_full = q_rope(q, self.rope_params, B, n_heads, S, qk_nope, qk_head)
-        else:
-            q_full = ttml.ops.rope.mla_q_rope(q, self.rope_params, qk_nope, qk_rope)
+        q, k_full, v = ttml.ops.mla.qkv_assemble(q_pre, kv_up, k_pe, n_heads, qk_nope, qk_rope, v_dim)
+        q_full = ttml.ops.rope.mla_q_rope(q, self.rope_params, qk_nope, qk_rope)
 
         # ── Attention (causal-only) ──
         # None -> fused SDPA generates the causal mask on chip and takes the faster

--- a/tt-train/sources/ttml/ttml/models/deepseek/mla.py
+++ b/tt-train/sources/ttml/ttml/models/deepseek/mla.py
@@ -89,9 +89,7 @@ class MultiHeadLatentAttention(AbstractModuleBase):
             q = self.wq_b(self.q_norm(self.wq_a(x)))  # [B, 1, S, n_heads * qk_head]
         q = split_heads(q, n_heads)  # [B, n_heads, S, qk_head]
 
-        q_nope = autograd_slice(q, [0, 0, 0, 0], [B, n_heads, S, qk_nope])
-        q_pe = autograd_slice(q, [0, 0, 0, qk_nope], [B, n_heads, S, qk_head])
-        q_pe = ttml.ops.rope.rope(q_pe, self.rope_params)
+        q_full = ttml.ops.rope.mla_q_rope(q, self.rope_params, qk_nope, qk_rope)
 
         # ── KV path ──
         kv_full = self.wkv_a(x)  # [B, 1, S, kv_lora_rank + qk_rope]
@@ -114,8 +112,7 @@ class MultiHeadLatentAttention(AbstractModuleBase):
         k_nope = autograd_slice(kv_up, [0, 0, 0, 0], [B, n_heads, S, qk_nope])
         v = autograd_slice(kv_up, [0, 0, 0, qk_nope], [B, n_heads, S, qk_nope + v_dim])
 
-        # Assemble full Q and K
-        q_full = autograd_concat([q_nope, q_pe], dim=3)  # [B, H, S, qk_head]
+        # Assemble full K
         k_full = autograd_concat([k_nope, k_pe], dim=3)  # [B, H, S, qk_head]
 
         # ── Attention (causal-only) ──


### PR DESCRIPTION
## Summary

Wire three MLA fusions into DeepSeek training in `mla.py`, replacing composite Python/TTNN paths with single autograd ops:

```python
# kv_down_split — split wkv_a output into kv latent + k_pe
kv, k_pe = autograd_split(kv_full, [kv_lora, qk_rope], dim=3)

# qkv_assemble — head-split Q, demux k_nope/v, broadcast k_pe into K
q, k_full, v = ttml.ops.mla.qkv_assemble(
    q_pre, kv_up, k_pe, n_heads, qk_nope, qk_rope, v_dim
)

# q_rope — RoPE on Q's rope suffix only
q_full = ttml.ops.rope.mla_q_rope(q, self.rope_params, qk_nope, qk_rope)
```

Previously these stages were implemented as many separate ops per forward/backward pass (slices, reshapes, concats, and a standalone RoPE). The fused paths cut kernel dispatch overhead and intermediate tensor traffic without changing model semantics.

## Motivation

Three hotspots were identified in the MLA forward path ([`mla_profile_benchmark.py`](https://github.com/tenstorrent/tt-metal/pull/45036)):

| Stage | Composite path | Fused replacement | 
|-------|----------------|-----------------|
| **kv_down_split** | Two `autograd_slice` on `wkv_a` output | `autograd_split` (single concat backward) |
| **qkv_assemble** | `split_heads` + slice + concat + `k_pe` broadcast | `ttml.ops.mla.qkv_assemble` |
| **q_rope** | `autograd_slice` + `rope` + `autograd_concat` | `ttml.ops.rope.mla_q_rope` |

## What changed

**File:** `tt-train/sources/ttml/ttml/models/deepseek/mla.py`

### kv_down_split

| Before | After |
|--------|-------|
| `autograd_slice` → `kv` | `autograd_split(kv_full, [kv_lora, qk_rope], dim=3)` |
| `autograd_slice` → `k_pe` | (same op; both outputs returned) |

Backward: two adjacent slices each rebuild a full-width grad (zeros + concat) that are then summed. `autograd_split` backward is a single `ttnn.concat` of chunk gradients.

### qkv_assemble

| Before | After |
|--------|-------|
| `split_heads(q_pre)` | |
| `split_heads(kv_up)` | `ttml.ops.mla.qkv_assemble(q_pre, kv_up, k_pe, …)` |
| Slice `k_nope`, slice `v` from `kv_up` | → `q`, `k_full`, `v` |
| `autograd_concat([k_pe] * n_heads, dim=1)` | |
| `autograd_concat([k_nope, k_pe_broadcast], dim=3)` | |

Pure data movement: head-split Q (not yet RoPE'd), demux per-head `k_nope`/`v`, broadcast shared `k_pe` into each head's K rope suffix.

### q_rope

| Before | After |
|--------|-------|
| Slice `q_nope` and `q_pe` from head-split `q` | Head-split `q` passed directly to fused op |
| `ttml.ops.rope.rope(q_pe, …)` | — |
| `autograd_concat([q_nope, q_pe], dim=3)` | `ttml.ops.rope.mla_q_rope(q, rope_params, qk_nope, qk_rope)` |

**Unchanged:**
- Q projection (`wq` / `wq_a → norm → wq_b`)
- `wkv_a`, `k_pe` RoPE, `wkv_b` up-projection
- Fused causal SDPA and output projection

## Correctness

- **kv_down_split:** `test_deepseek_autograd_split.py` — `autograd_split` matches dual `autograd_slice` forward/backward.
- **qkv_assemble:** `mla_qkv_assemble_op_test.cpp` — fused output matches composite `split_heads` + slice + concat reference within BF16 tolerance; autograd parity included.
- **q_rope:** `mla_q_rope_op_test.cpp` (`MLA_QRopeShapes/*`) — fused output matches composite slice + `rotary_embedding_llama` + concat reference.

## Training results

Compared **composite baseline** (dual-slice kv split + `qkv_assemble` + `q_rope`) vs **all three fusions enabled** on Blackhole. Each run: 1000 training steps; step time = mean over 985 measured steps (15-step warmup); final loss = average of last 100 steps.

| Config | Composite step (ms) | Fused step (ms) | Speedup | Composite loss | Fused loss |
|--------|--------------------:|----------------:|--------:|---------------:|-----------:|
| Nano DeepSeek, seq=256 | 334.46 | 255.28 | **1.31×** | 1.124297 | 1.128125 |
| Tiny DeepSeek, seq=512 | 1921.86 | 1785.54 | **1.08×** | 2.036484 | 2.025078 |
| Tiny DeepSeek, seq=1024 | 1923.17 | 1821.05 | **1.06×** | 1.858125 | 1.869999 |
| Tiny DeepSeek, seq=2048 | 3958.00 | 3415.14 | **1.16×** | 1.280000 | 1.281016 |

Combined fusion yields **~6–31%** end-to-end step-time reduction vs the full composite MLA path, with matched loss convergence.


All configs has batch = 1 for tiny and 32 for nano if not stated otherwise.

### q_rope + qkv_assemble + kv_down_split modified

#### Tiny DeepSeek, seq=2048, batch=4
**Step time** — composite 3958 ms, fused 3415 ms (1.16×)
<img width="2484" height="1314" alt="step_time" src="https://github.com/user-attachments/assets/1988deb4-d02d-47cf-9372-1d2fc4ebba58" />
**Loss** — composite 1.280, fused 1.281 (last 100 steps avg)
<img width="2429" height="1314" alt="losses" src="https://github.com/user-attachments/assets/337a4e72-a512-40f3-878b-8df7eca00699" />


#### Tiny DeepSeek, seq=1024, batch=1
**Step time** — composite 1923 ms, fused 1821 ms (1.06×)
<img width="2485" height="1314" alt="step_time" src="https://github.com/user-attachments/assets/606ba854-48af-47f0-b97a-c1d7092c4cb0" />
**Loss** — composite 1.858, fused 1.870 (last 100 steps avg)
<img width="2429" height="1314" alt="losses" src="https://github.com/user-attachments/assets/1b69293f-eb45-49d6-805a-8fb335b767ca" />

#### Tiny DeepSeek, seq=512, batch=1
**Step time** — composite 1922 ms, fused 1786 ms (1.08×)
<img width="2485" height="1314" alt="step_time" src="https://github.com/user-attachments/assets/e4fffcf2-dcdf-4bdd-8340-47710f89d61b" />
**Loss** — composite 2.036, fused 2.025 (last 100 steps avg)
<img width="2429" height="1314" alt="losses" src="https://github.com/user-attachments/assets/17ef127a-b296-4f28-891f-2e7bc37b7af5" />

##### Nano DeepSeek, seq=256
**Step time** — composite 334 ms, fused 255 ms (1.31×)
<img width="2466" height="1314" alt="step_time" src="https://github.com/user-attachments/assets/a0ca2bd5-7d78-4fb8-a5ca-5f1b8af4aeee" />
**Loss** — composite 1.124, fused 1.128 (last 100 steps avg)
<img width="2457" height="1314" alt="losses" src="https://github.com/user-attachments/assets/6baee3b1-4c9d-4547-9c4a-99a0bf89e97d" />


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lgalasTT/enable_mla_q_rope)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lgalasTT/enable_mla_q_rope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lgalasTT/enable_mla_q_rope)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lgalasTT/enable_mla_q_rope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=lgalasTT/enable_mla_q_rope)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:lgalasTT/enable_mla_q_rope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lgalasTT/enable_mla_q_rope)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lgalasTT/enable_mla_q_rope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lgalasTT/enable_mla_q_rope)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lgalasTT/enable_mla_q_rope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lgalasTT/enable_mla_q_rope)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lgalasTT/enable_mla_q_rope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lgalasTT/enable_mla_q_rope)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lgalasTT/enable_mla_q_rope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lgalasTT/enable_mla_q_rope)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lgalasTT/enable_mla_q_rope)