### PR TITLE
[Feature] LayerNorm: Added FP32 support for LayerNormPostAllGatherAdd and validation of welford & legacy configuration for FP32

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_post_allgather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_post_allgather.py
@@ -247,7 +247,9 @@ def test_layernorm_part_2_with_program_cache2(inp_shape, n_devices, is_rmsnorm, 
                     tt_memory_config=dram_memcfg,
                 )
             )
-        run_layernorm_part_2(inp_shape, n_devices, is_rmsnorm, dtype, dtype, device, fp32_enabled=fp32_enabled)
+        run_layernorm_part_2(
+            inp_shape, n_devices, is_rmsnorm, dtype, dtype, device, gamma_beta_dtype=dtype, fp32_enabled=fp32_enabled
+        )
 
     assert device.num_program_cache_entries() == 1, "Program cache should have only one entry" + str(
         device.num_program_cache_entries()

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_post_allgather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_post_allgather.py
@@ -25,7 +25,16 @@ def reference_layernorm(x, gamma, beta, epsilon, is_rmsnorm):
         return torch.nn.functional.layer_norm(x, x.shape[-1:], gamma, beta, epsilon)
 
 
-def run_layernorm_part_2(inp_shape, n_devices, is_rmsnorm, input_dtype, output_dtype, device, fp32_enabled=False):
+def run_layernorm_part_2(
+    inp_shape,
+    n_devices,
+    is_rmsnorm,
+    input_dtype,
+    output_dtype,
+    device,
+    gamma_beta_dtype,
+    fp32_enabled=False,
+):
     kernel_config = ttnn.init_device_compute_kernel_config(
         device.arch(),
         math_fidelity=ttnn.MathFidelity.HiFi4,  # Highest fidelity
@@ -78,21 +87,21 @@ def run_layernorm_part_2(inp_shape, n_devices, is_rmsnorm, input_dtype, output_d
         )
         tt_gamma = torch2tt_tensor(
             gamma_chunked[d].reshape(1, 1, -1, 32),
-            tt_dtype=ttnn.bfloat16,
+            tt_dtype=gamma_beta_dtype,
             tt_device=device,
             tt_layout=ttnn.ROW_MAJOR_LAYOUT,
             tt_memory_config=dram_memcfg,
         )
         tt_beta = torch2tt_tensor(
             beta_chunked[d].reshape(1, 1, -1, 32),
-            tt_dtype=ttnn.bfloat16,
+            tt_dtype=gamma_beta_dtype,
             tt_device=device,
             tt_layout=ttnn.ROW_MAJOR_LAYOUT,
             tt_memory_config=dram_memcfg,
         )
         tt_stats = torch2tt_tensor(
             stats_tiles,
-            tt_dtype=ttnn.bfloat16,
+            tt_dtype=input_dtype,
             tt_device=device,
             tt_layout=ttnn.TILE_LAYOUT,
             tt_memory_config=dram_memcfg,
@@ -141,15 +150,22 @@ def run_layernorm_part_2(inp_shape, n_devices, is_rmsnorm, input_dtype, output_d
         (ttnn.bfloat16, ttnn.bfloat16),
         (ttnn.bfloat8_b, ttnn.bfloat8_b),
         (ttnn.bfloat16, ttnn.bfloat8_b),
+        (ttnn.float32, ttnn.float32),
     ],
-    ids=["BFLOAT16", "BFLOAT8_B", "BFLOAT16_BFLOAT8_B"],
+    ids=["BFLOAT16", "BFLOAT8_B", "BFLOAT16_BFLOAT8_B", "FLOAT32"],
 )
+@pytest.mark.parametrize("gamma_beta_dtype", [ttnn.bfloat16, ttnn.float32], ids=["gb_bf16", "gb_fp32"])
 @pytest.mark.parametrize(
     "inp_shape",
     [
+        # Large (8192-wide) shapes for bf16/bf8.
         (1, 1, 2048, 8192),
         (1, 1, 128, 8192),
         (2, 1, 128, 8192),
+        # Small (2048-wide) shapes for FP32: FP32 doubles tile size, so the 8192-wide shapes
+        # exceed L1 for layernorm (2 stats tiles + beta). FP32 runs only on these.
+        (1, 1, 128, 2048),
+        (2, 1, 128, 2048),
     ],
 )
 @pytest.mark.parametrize(
@@ -167,15 +183,41 @@ def run_layernorm_part_2(inp_shape, n_devices, is_rmsnorm, input_dtype, output_d
     ids=["fp32_enabled", "fp32_disabled"],
 )
 def test_layernorm_part_2_with_program_cache(
-    inp_shape, n_devices, is_rmsnorm, input_dtype, output_dtype, fp32_enabled, device
+    inp_shape, n_devices, is_rmsnorm, input_dtype, output_dtype, gamma_beta_dtype, fp32_enabled, device
 ):
-    run_layernorm_part_2(inp_shape, n_devices, is_rmsnorm, input_dtype, output_dtype, device, fp32_enabled)
+    """Post-all-gather correctness matrix, covering FP32 (input + FP32 stats + bf16/fp32 gamma/beta)
+    alongside the bf16/bf8 cases. FP32 requires fp32_dest_acc_en=True and -- because it doubles tile
+    size -- only fits on the 2048-wide shapes; bf16/bf8 run on the 8192-wide shapes. The guard-skips
+    below keep each dtype on the shapes/flags it supports (this produces many skipped param IDs)."""
+    is_fp32 = input_dtype == ttnn.float32
+    is_small_shape = inp_shape[-1] <= 2048
+
+    # FP32 -> small shapes (L1); everything else -> large shapes.
+    if is_fp32 != is_small_shape:
+        pytest.skip("FP32 runs on the 2048-wide shapes (L1); bf16/bf8 on the 8192-wide shapes")
+    # FP32 requires fp32_dest_acc_en.
+    if is_fp32 and not fp32_enabled:
+        pytest.skip("FP32 input requires fp32_dest_acc_en=True")
+    # FP32 gamma/beta is only exercised with FP32 input; bf16/bf8 keep bf16 gamma/beta.
+    if gamma_beta_dtype == ttnn.float32 and not is_fp32:
+        pytest.skip("fp32 gamma/beta only exercised with FP32 input")
+
+    run_layernorm_part_2(
+        inp_shape,
+        n_devices,
+        is_rmsnorm,
+        input_dtype,
+        output_dtype,
+        device,
+        fp32_enabled=fp32_enabled,
+        gamma_beta_dtype=gamma_beta_dtype,
+    )
 
 
 @pytest.mark.parametrize(
     "dtype",
-    [ttnn.bfloat16],
-    ids=["BFLOAT16"],
+    [ttnn.bfloat16, ttnn.float32],
+    ids=["BFLOAT16", "FLOAT32"],
 )
 @pytest.mark.parametrize(
     "inp_shape",
@@ -196,6 +238,7 @@ def test_layernorm_part_2_with_program_cache2(inp_shape, n_devices, is_rmsnorm, 
     dummy_tensors = []
 
     dram_memcfg = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+    fp32_enabled = dtype == ttnn.float32  # FP32 requires fp32_dest_acc_en
 
     for i in range(2):
         if i > 0:
@@ -208,7 +251,7 @@ def test_layernorm_part_2_with_program_cache2(inp_shape, n_devices, is_rmsnorm, 
                     tt_memory_config=dram_memcfg,
                 )
             )
-        run_layernorm_part_2(inp_shape, n_devices, is_rmsnorm, dtype, dtype, device)
+        run_layernorm_part_2(inp_shape, n_devices, is_rmsnorm, dtype, dtype, device, fp32_enabled=fp32_enabled)
 
     assert device.num_program_cache_entries() == 1, "Program cache should have only one entry" + str(
         device.num_program_cache_entries()
@@ -341,7 +384,7 @@ def test_layer_norm_post_all_gather_bias_only_matches_torch(device):
     assert passing, output_str
 
 
-def test_layer_norm_post_all_gather_bias_only_rejects_mismatched_beta_row_major(device):
+def test_layer_norm_post_all_gather_bias_only_rejects_mismatched_beta_row_major(device, expect_error):
     """Invalid beta width must fail in validate even when weight is absent.
 
     ROW_MAJOR bias uses the physical_volume vs input width check (same as gamma). A TILE
@@ -387,7 +430,7 @@ def test_layer_norm_post_all_gather_bias_only_rejects_mismatched_beta_row_major(
         tt_memory_config=dram_memcfg,
     )
 
-    with pytest.raises(RuntimeError, match="Beta tensor dimensions must align"):
+    with expect_error(RuntimeError, "Beta tensor dimensions must align"):
         ttnn.layer_norm_post_all_gather(
             tt_inp,
             tt_stats,

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_post_allgather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_post_allgather.py
@@ -158,14 +158,9 @@ def run_layernorm_part_2(
 @pytest.mark.parametrize(
     "inp_shape",
     [
-        # Large (8192-wide) shapes for bf16/bf8.
         (1, 1, 2048, 8192),
         (1, 1, 128, 8192),
         (2, 1, 128, 8192),
-        # Small (2048-wide) shapes for FP32: FP32 doubles tile size, so the 8192-wide shapes
-        # exceed L1 for layernorm (2 stats tiles + beta). FP32 runs only on these.
-        (1, 1, 128, 2048),
-        (2, 1, 128, 2048),
     ],
 )
 @pytest.mark.parametrize(
@@ -186,21 +181,22 @@ def test_layernorm_part_2_with_program_cache(
     inp_shape, n_devices, is_rmsnorm, input_dtype, output_dtype, gamma_beta_dtype, fp32_enabled, device
 ):
     """Post-all-gather correctness matrix, covering FP32 (input + FP32 stats + bf16/fp32 gamma/beta)
-    alongside the bf16/bf8 cases. FP32 requires fp32_dest_acc_en=True and -- because it doubles tile
-    size -- only fits on the 2048-wide shapes; bf16/bf8 run on the 8192-wide shapes. The guard-skips
-    below keep each dtype on the shapes/flags it supports (this produces many skipped param IDs)."""
+    alongside the bf16/bf8 cases. The kernel processes inp_shape[-1] // n_devices per device, so L1
+    usage is driven by that per-device width, not the full width -- FP32 runs on the same 8192-wide
+    shapes as bf16/bf8. FP32 doubles tile size, and the one combination that overflows L1 is FP32
+    layernorm at per-device width 2048 (8192-wide / 4 devices: 2 stats tiles + beta), skipped below."""
     is_fp32 = input_dtype == ttnn.float32
-    is_small_shape = inp_shape[-1] <= 2048
+    per_device_width = inp_shape[-1] // n_devices
 
-    # FP32 -> small shapes (L1); everything else -> large shapes.
-    if is_fp32 != is_small_shape:
-        pytest.skip("FP32 runs on the 2048-wide shapes (L1); bf16/bf8 on the 8192-wide shapes")
     # FP32 requires fp32_dest_acc_en.
     if is_fp32 and not fp32_enabled:
         pytest.skip("FP32 input requires fp32_dest_acc_en=True")
     # FP32 gamma/beta is only exercised with FP32 input; bf16/bf8 keep bf16 gamma/beta.
     if gamma_beta_dtype == ttnn.float32 and not is_fp32:
         pytest.skip("fp32 gamma/beta only exercised with FP32 input")
+    # FP32 layernorm needs 2 stats tiles + beta in double-size tiles; per-device width 2048 overflows L1.
+    if is_fp32 and not is_rmsnorm and per_device_width >= 2048:
+        pytest.skip("FP32 layernorm overflows L1 at per-device width >= 2048")
 
     run_layernorm_part_2(
         inp_shape,

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm.py
@@ -211,8 +211,8 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
 )
 @pytest.mark.parametrize(
     "gamma_dtype",
-    (ttnn.bfloat16,),
-    ids=["BFLOAT16"],
+    (ttnn.bfloat16, ttnn.float32),
+    ids=["BFLOAT16", "FLOAT32"],
 )
 @pytest.mark.parametrize(
     "in_dtype",
@@ -362,4 +362,74 @@ def test_layer_norm_4D_llama(device, h, w, num_chunks):
         rtol=0.006,
         atol=0.018,
         frobenius_threshold=0.003,
+    )
+
+
+# ---------------------------------------------------------------------------------------------
+# FP32 coverage for the complete (non-distributed) interleaved LayerNorm op
+# Spans the full config matrix: {legacy, welford} x {fp32, bf16} input x {TILE, ROW_MAJOR} input
+# x {bf16, fp32} gamma/beta. FP32 requires fp32_dest_acc_en=True. Welford requires TILE input
+# (ROW_MAJOR input hangs for every dtype), so welford x rm_in is skipped to record the limitation
+# ---------------------------------------------------------------------------------------------
+@pytest.mark.parametrize("gamma_dtype", [ttnn.bfloat16, ttnn.float32], ids=["gb_bf16", "gb_fp32"])
+@pytest.mark.parametrize("input_layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT], ids=["tile_in", "rm_in"])
+@pytest.mark.parametrize("use_welford", [True, False], ids=["welford", "legacy"])
+@pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16, ttnn.bfloat8_b], ids=["fp32", "bf16", "bf8"])
+def test_layernorm_interleaved_all_config(device, dtype, use_welford, input_layout, gamma_dtype):
+    if use_welford and input_layout == ttnn.ROW_MAJOR_LAYOUT:
+        pytest.skip("Welford requires TILE input; ROW_MAJOR input hangs (dtype-independent limitation)")
+    if dtype == ttnn.bfloat8_b and input_layout == ttnn.ROW_MAJOR_LAYOUT:
+        pytest.skip("BFLOAT8_B is TILE-only (shared exponent per 16-elem sub-block is undefined under ROW_MAJOR)")
+
+    torch.manual_seed(0)
+    M, K = 256, 1024
+    x = torch.rand((1, 1, M, K), dtype=torch.float32)
+    w = torch.rand((K,), dtype=torch.float32)
+    b = torch.rand((K,), dtype=torch.float32)
+    ref = torch.nn.functional.layer_norm(x, (K,), weight=w, bias=b, eps=1e-12)
+
+    xt = ttnn.from_torch(x, dtype=dtype, layout=input_layout, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    wt = ttnn.from_torch(w.reshape(1, 1, 1, K), dtype=gamma_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    bt = ttnn.from_torch(b.reshape(1, 1, 1, K), dtype=gamma_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,  # required for FP32
+        packer_l1_acc=False,
+    )
+    cfg = ttnn.LayerNormDefaultProgramConfig(use_welford=use_welford)
+
+    recip = None
+    if use_welford:
+        grid = device.compute_with_storage_grid_size()
+        crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))})
+        recip = ttnn.create_layer_norm_reciprocals(device, crs, K)
+
+    out = ttnn.layer_norm(
+        xt,
+        epsilon=1e-12,
+        weight=wt,
+        bias=bt,
+        program_config=cfg,
+        compute_kernel_config=compute_kernel_config,
+        recip_tensor=recip,
+    )
+    ot = ttnn.to_torch(ttnn.from_device(out)).float().reshape(ref.shape)
+
+    if dtype == ttnn.bfloat8_b:
+        pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.02, 0.05, 0.012
+    elif dtype == ttnn.bfloat16:
+        pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.006, 0.019, 0.004
+    else:
+        pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.006, 0.012, 0.003
+
+    assert_numeric_metrics(
+        ref,
+        ot,
+        pcc_threshold=pcc_threshold,
+        rtol=rtol,
+        atol=atol,
+        frobenius_threshold=frobenius_threshold,
     )

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm_sharded.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm_sharded.py
@@ -35,8 +35,8 @@ def rms_norm(x, dim, gamma, beta, eps):
 )
 @pytest.mark.parametrize(
     "gamma_dtype",
-    (ttnn.bfloat16,),
-    ids=["BFLOAT16"],
+    (ttnn.bfloat16, ttnn.float32),
+    ids=["BFLOAT16", "FLOAT32"],
 )
 @pytest.mark.parametrize(
     "in_dtype",
@@ -303,8 +303,8 @@ def test_layernorm_sharded_mix_precision_rm(
 )
 @pytest.mark.parametrize(
     "gamma_dtype",
-    (ttnn.bfloat16,),
-    ids=["BFLOAT16"],
+    (ttnn.bfloat16, ttnn.float32),
+    ids=["BFLOAT16", "FLOAT32"],
 )
 @pytest.mark.parametrize(
     "in_dtype",
@@ -559,4 +559,92 @@ def test_layernorm_1d_sharded_mix_precision_rm(
         rtol=3.158,
         atol=0.087,
         frobenius_threshold=0.016,
+    )
+
+
+# ---------------------------------------------------------------------------------------------
+# FP32 coverage for the complete (non-distributed) block-sharded LayerNorm op.
+# Spans {legacy, welford} x {fp32, bf16} input x {bf16, fp32} ROW_MAJOR gamma/beta. FP32 requires
+# fp32_dest_acc_en=True. Input is TILE (welford requires TILE; ROW_MAJOR input hangs).
+# ---------------------------------------------------------------------------------------------
+@pytest.mark.parametrize("gamma_dtype", [ttnn.bfloat16, ttnn.float32], ids=["gb_bf16", "gb_fp32"])
+@pytest.mark.parametrize("use_welford", [True, False], ids=["welford", "legacy"])
+@pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16, ttnn.bfloat8_b], ids=["fp32", "bf16", "bf8"])
+def test_layernorm_block_sharded_all_config(device, dtype, use_welford, gamma_dtype):
+    torch.manual_seed(1234)
+    g = device.compute_with_storage_grid_size()
+    grid_size = [g.x, min(g.y, 8)]
+    batch = grid_size[1]
+    width = 128 * grid_size[1]
+    in0_shape = (batch, 1, 32 * grid_size[0], width)
+    M, K = in0_shape[2] * batch, in0_shape[3]
+
+    x = torch.rand(in0_shape, dtype=torch.float32) * 2 - 0.95
+    w = torch.rand(K, dtype=torch.float32) * 2 - 1
+    b = torch.rand(K, dtype=torch.float32) * 2 - 1.1
+    ref = torch.nn.functional.layer_norm(x, (K,), weight=w, bias=b, eps=1e-2)
+
+    xt = ttnn.from_torch(x, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    shard_shape = [M // grid_size[0], math.ceil(K / grid_size[1] / 32) * 32]
+    x_shard = ttnn.interleaved_to_sharded(
+        xt, grid_size, shard_shape, ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.ShardOrientation.COL_MAJOR
+    )
+
+    wt = ttnn.from_torch(w.reshape(1, 1, -1, 32), dtype=gamma_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    bt = ttnn.from_torch(b.reshape(1, 1, -1, 32), dtype=gamma_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+
+    cfg = ttnn.LayerNormShardedMultiCoreProgramConfig(
+        compute_with_storage_grid_size=grid_size,
+        subblock_w=4,
+        block_h=batch,
+        block_w=4,
+        inplace=False,
+        use_welford=use_welford,
+    )
+    out_mem = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1, x_shard.memory_config().shard_spec
+    )
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,  # required for FP32
+        packer_l1_acc=False,
+    )
+
+    recip = None
+    if use_welford:
+        sspec = x_shard.memory_config().shard_spec
+        recip = ttnn.create_layer_norm_reciprocals(device, sspec.grid, sspec.shape[1])
+
+    out = ttnn.layer_norm(
+        x_shard,
+        epsilon=1e-2,
+        weight=wt,
+        bias=bt,
+        memory_config=out_mem,
+        program_config=cfg,
+        compute_kernel_config=compute_kernel_config,
+        recip_tensor=recip,
+    )
+    ot = (
+        ttnn.to_torch(ttnn.from_device(ttnn.sharded_to_interleaved(out, ttnn.DRAM_MEMORY_CONFIG)))
+        .float()
+        .reshape(ref.shape)
+    )
+
+    if dtype == ttnn.bfloat8_b:
+        pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.02, 0.045, 0.011
+    elif dtype == ttnn.bfloat16:
+        pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.006, 0.019, 0.003
+    else:
+        pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.006, 0.013, 0.003
+
+    assert_numeric_metrics(
+        ref,
+        ot,
+        pcc_threshold=pcc_threshold,
+        rtol=rtol,
+        atol=atol,
+        frobenius_threshold=frobenius_threshold,
     )

--- a/tests/ttnn/unit_tests/operations/fused/distributed_norm_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/fused/distributed_norm_test_utils.py
@@ -157,6 +157,7 @@ def compute_ttnn_distributed_norm(
     mesh_device,
     norm_type,
     eps,
+    input_dtype,
     use_legacy=False,
     use_high_precision=True,
     weight_layout=ttnn.TILE_LAYOUT,
@@ -174,6 +175,7 @@ def compute_ttnn_distributed_norm(
         mesh_device: TTNN mesh device
         norm_type: "layer_norm" or "rms_norm"
         eps: Epsilon value
+        input_dtype: TTNN dtype for input/stats/gamma/beta (required)
         use_legacy: Whether to use legacy reduction/rsqrt
         use_high_precision: Whether to use high precision compute config
         weight_layout: Memory layout for weight tensor
@@ -192,7 +194,7 @@ def compute_ttnn_distributed_norm(
         torch_input,
         device=mesh_device,
         layout=ttnn.TILE_LAYOUT,
-        dtype=ttnn.bfloat16,
+        dtype=input_dtype,
         mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=-1),
     )
 
@@ -208,7 +210,7 @@ def compute_ttnn_distributed_norm(
 
     ttnn_weight = ttnn.from_torch(
         torch_weight.reshape(weight_shape),
-        dtype=ttnn.bfloat16,
+        dtype=input_dtype,
         device=mesh_device,
         layout=weight_layout,
         mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=weight_shard_dim),
@@ -228,7 +230,7 @@ def compute_ttnn_distributed_norm(
 
         ttnn_bias = ttnn.from_torch(
             torch_bias.reshape(bias_shape),
-            dtype=ttnn.bfloat16,
+            dtype=input_dtype,
             device=mesh_device,
             layout=bias_layout,
             mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=bias_shard_dim),
@@ -282,7 +284,7 @@ def compute_ttnn_distributed_norm(
         ttnn_stats = ttnn.layer_norm_pre_all_gather(
             ttnn_input,
             compute_kernel_config=compute_kernel_config,
-            dtype=ttnn.bfloat16,
+            dtype=input_dtype,
             program_config=program_config,
             recip_tensor=recip_tensor,
         )
@@ -376,6 +378,7 @@ def run_distributed_norm_test(
     hidden_dim,
     eps,
     norm_type,
+    input_dtype,
     mean=0,
     var=1,
     outlier_pct=0,
@@ -398,6 +401,7 @@ def run_distributed_norm_test(
         hidden_dim: Hidden dimension
         eps: Epsilon for numerical stability
         norm_type: "layer_norm" or "rms_norm"
+        input_dtype: TTNN dtype for input/stats/gamma/beta (required)
         mean: Mean of input distribution
         var: Variance of input distribution
         outlier_pct: Percentage of outliers
@@ -437,6 +441,7 @@ def run_distributed_norm_test(
         mesh_device,
         norm_type,
         eps,
+        input_dtype,
         use_legacy,
         use_high_precision,
         weight_layout,

--- a/tests/ttnn/unit_tests/operations/fused/test_distributed_layernorm_exhaustive.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_distributed_layernorm_exhaustive.py
@@ -26,6 +26,7 @@ def test_my_custom_config(mesh_device):
         hidden_dim=4096,        # Your hidden dimension
         eps=1e-6,               # Epsilon value
         norm_type="layer_norm", # "layer_norm" or "rms_norm"
+        input_dtype=ttnn.bfloat16,  # Input/stats/gamma/beta dtype (required)
         mean=0,                 # Input distribution mean
         var=1,                  # Input distribution variance
         outlier_pct=0,          # Percentage of outliers (0-1)
@@ -117,6 +118,7 @@ def test_distributed_norm_allclose(
         hidden_dim=hidden_dim,
         eps=eps,
         norm_type=norm_type,
+        input_dtype=ttnn.bfloat16,
         mean=mean,
         var=var,
         outlier_pct=outlier_pct,
@@ -168,6 +170,7 @@ def test_smoke(mesh_device, batch_size, seq_len, hidden_dim, eps, norm_type, use
         hidden_dim=hidden_dim,
         eps=eps,
         norm_type=norm_type,
+        input_dtype=ttnn.bfloat16,
         mean=0,
         var=1,
         outlier_pct=0,
@@ -178,6 +181,52 @@ def test_smoke(mesh_device, batch_size, seq_len, hidden_dim, eps, norm_type, use
         use_welford=use_welford,
     )
 
+    assert passes, (
+        f"TEST FAILED: Average relative difference {mean_rel_diff*100:.2f}% exceeds 5% threshold | "
+        f"max_abs_diff={max_abs_diff:.6e} | "
+        f"max_rel_diff={max_rel_diff:.6e}"
+    )
+
+
+# ============================================================================
+# FP32 Welford Test - FP32 input/stats/gamma/beta through the
+# full pre-all-gather (Welford) -> all-gather -> post-all-gather (Welford) path.
+# ============================================================================
+
+
+@pytest.mark.parametrize("hidden_dim", [2048])
+@pytest.mark.parametrize("eps", [1e-5])
+@pytest.mark.parametrize("input_dtype", [ttnn.float32, ttnn.bfloat16], ids=["fp32", "bf16"])
+@pytest.mark.parametrize(
+    "weight_layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT], ids=["tile_gamma_beta", "rm_gamma_beta"]
+)
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+    ],
+    indirect=True,
+)
+def test_distributed_layernorm_dtype(mesh_device, hidden_dim, eps, input_dtype, weight_layout):
+    """FP32 (and bf16 control) Welford layer_norm across pre-AG -> all-gather -> post-AG.
+    input_dtype drives input, stats, gamma and beta dtypes; fp32 requires fp32_dest_acc_en
+    (use_high_precision=True). Covers both TILE and ROW_MAJOR gamma/beta."""
+    passes, max_abs_diff, max_rel_diff, mean_rel_diff = run_distributed_norm_test(
+        mesh_device=mesh_device,
+        batch_size=1,
+        seq_len=128,
+        hidden_dim=hidden_dim,
+        eps=eps,
+        norm_type="layer_norm",
+        input_dtype=input_dtype,
+        use_legacy=False,
+        use_high_precision=True,
+        verbose=False,
+        use_welford=True,
+        weight_layout=weight_layout,
+        bias_layout=weight_layout,
+    )
     assert passes, (
         f"TEST FAILED: Average relative difference {mean_rel_diff*100:.2f}% exceeds 5% threshold | "
         f"max_abs_diff={max_abs_diff:.6e} | "
@@ -227,6 +276,7 @@ def test_distributed_layernorm_memory_layouts(mesh_device, norm_type, weight_lay
         hidden_dim=4096,
         eps=1e-6,
         norm_type=norm_type,
+        input_dtype=ttnn.bfloat16,
         mean=0,
         var=1,
         outlier_pct=0,
@@ -287,6 +337,7 @@ def test_distributed_rmsnorm_memory_layouts(mesh_device, norm_type, weight_layou
         hidden_dim=4096,
         eps=1e-6,
         norm_type=norm_type,
+        input_dtype=ttnn.bfloat16,
         mean=0,
         var=1,
         outlier_pct=0,
@@ -340,6 +391,7 @@ def test_distributed_norm_large_batch(mesh_device, norm_type, use_welford):
         hidden_dim=4096,
         eps=1e-6,
         norm_type=norm_type,
+        input_dtype=ttnn.bfloat16,
         mean=0,
         var=1,
         outlier_pct=0,
@@ -378,6 +430,7 @@ def test_distributed_layernorm_sweep_hidden_dim(mesh_device, hidden_dim):
         hidden_dim=hidden_dim,
         eps=1e-6,
         norm_type="layer_norm",
+        input_dtype=ttnn.bfloat16,
         mean=0,
         var=1,
         outlier_pct=0,
@@ -443,6 +496,7 @@ def test_distributed_rmsnorm_2d_core_grid(mesh_device, batch_size, seq_len, hidd
         hidden_dim=hidden_dim,
         eps=eps,
         norm_type="rms_norm",
+        input_dtype=ttnn.bfloat16,
         mean=0,
         var=1,
         outlier_pct=0,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb_post_allgather.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <stdint.h>
+#include <tt-metalium/constants.hpp>
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
@@ -19,27 +20,34 @@
 
 template <uint32_t t, typename AccessorType>
 void async_read_row_to_tile(
-    const Noc& noc, const AccessorType& accessor, uint32_t page_id, uint32_t L1_dst_addr) {
-    // Read 64 bytes (32 bfloat16 elements) from the start of the page
-    noc.async_read(accessor, CoreLocalMem<uint32_t>(L1_dst_addr), 64, {.page_id = page_id}, {});
+    const Noc& noc, const AccessorType& accessor, uint32_t page_id, uint32_t L1_dst_addr, uint32_t datum_bytes) {
+    // Byte offsets within a tile scale with the datum size (2B for bf16, 4B for fp32):
+    //   row_bytes  = one tile-width row  = TILE_WIDTH (32) datums
+    //   face_bytes = one 16x16 tile face = FACE_HW (256) datums (face 1 starts here within the tile)
+    //   half_row   = first FACE_WIDTH (16) datums of the row (face boundary inside a row-major stick)
+    const uint32_t row_bytes = tt::constants::TILE_WIDTH * datum_bytes;
+    const uint32_t face_bytes = tt::constants::FACE_HW * datum_bytes;
+    const uint32_t half_row_bytes = tt::constants::FACE_WIDTH * datum_bytes;
+    // Read one full row (32 datums) from the start of the page
+    noc.async_read(accessor, CoreLocalMem<uint32_t>(L1_dst_addr), row_bytes, {.page_id = page_id}, {});
 
     if constexpr (t == 0) {  // TILE LAYOUT
-        // Read 64 bytes from offset 512 within the same page (second tile face)
+        // Read the second tile face from its offset within the same page
         noc.async_read(
             accessor,
-            CoreLocalMem<uint32_t>(L1_dst_addr + 512),
-            64,
-            {.page_id = page_id, .offset_bytes = 512},
+            CoreLocalMem<uint32_t>(L1_dst_addr + face_bytes),
+            row_bytes,
+            {.page_id = page_id, .offset_bytes = face_bytes},
             {});
     } else if constexpr (t == 1) {  // ROW MAJOR LAYOUT
         noc.async_read_barrier();
-        // L1→L1 copy: rearrange 64 bytes from L1_dst_addr+32 into L1_dst_addr+512
+        // L1→L1 copy: move the second half of the row (datums 16..31) into the second face
         UnicastEndpoint self;
         noc.async_read(
             self,
-            CoreLocalMem<uint32_t>(L1_dst_addr + 512),
-            64,
-            {.noc_x = my_x[noc.get_noc_id()], .noc_y = my_y[noc.get_noc_id()], .addr = L1_dst_addr + 32},
+            CoreLocalMem<uint32_t>(L1_dst_addr + face_bytes),
+            row_bytes,
+            {.noc_x = my_x[noc.get_noc_id()], .noc_y = my_y[noc.get_noc_id()], .addr = L1_dst_addr + half_row_bytes},
             {});
     } else {
         static_assert(t == 0 || t == 1, "Layout must be ROW_MAJOR(t == 1) or TILE_LAYOUT(t == 0)");
@@ -69,6 +77,10 @@ void kernel_main() {
     // ublocks size defined in tiles
     const uint32_t src0_tile_bytes = get_tile_size(cb_inp);
     const uint32_t stats_tile_bytes = get_tile_size(cb_stats);
+    // datum size (bytes) of gamma/beta, derived from their tile size (TILE_HW = 32*32 = 1024 datums/tile).
+    // Used to scale the row/face byte offsets when packing a stick into tile layout (bf16=2B, fp32=4B).
+    const uint32_t gamma_datum_bytes = get_tile_size(cb_gamma) / tt::constants::TILE_HW;
+    const uint32_t beta_datum_bytes = get_tile_size(cb_beta) / tt::constants::TILE_HW;
 
     constexpr uint32_t blk = get_compile_time_arg_val(0);
     constexpr uint32_t stats_tiles_cols = get_compile_time_arg_val(1);
@@ -152,7 +164,8 @@ void kernel_main() {
                 for (uint32_t j = 0; j < cb_length; j++) {
                     cb_gamma_buf.reserve_back(1);
                     uint32_t l1_write_addr = cb_gamma_buf.get_write_ptr();
-                    async_read_row_to_tile<gamma_is_row_major>(noc, addrg, gamma_tile_count, l1_write_addr);
+                    async_read_row_to_tile<gamma_is_row_major>(
+                        noc, addrg, gamma_tile_count, l1_write_addr, gamma_datum_bytes);
                     gamma_tile_count++;
                     noc.async_read_barrier();
                     cb_gamma_buf.push_back(1);
@@ -162,7 +175,8 @@ void kernel_main() {
                 for (uint32_t j = 0; j < cb_length; j++) {
                     cb_beta_buf.reserve_back(1);
                     uint32_t l1_write_addr = cb_beta_buf.get_write_ptr();
-                    async_read_row_to_tile<beta_is_row_major>(noc, addrb, beta_tile_count, l1_write_addr);
+                    async_read_row_to_tile<beta_is_row_major>(
+                        noc, addrb, beta_tile_count, l1_write_addr, beta_datum_bytes);
                     beta_tile_count++;
                     noc.async_read_barrier();
                     cb_beta_buf.push_back(1);
@@ -184,7 +198,8 @@ void kernel_main() {
             for (uint32_t i = 0; i < cb_leftovers; i++) {
                 cb_gamma_buf.reserve_back(1);
                 uint32_t l1_write_addr = cb_gamma_buf.get_write_ptr();
-                async_read_row_to_tile<gamma_is_row_major>(noc, addrg, gamma_tile_count, l1_write_addr);
+                async_read_row_to_tile<gamma_is_row_major>(
+                    noc, addrg, gamma_tile_count, l1_write_addr, gamma_datum_bytes);
                 gamma_tile_count++;
                 noc.async_read_barrier();
                 cb_gamma_buf.push_back(1);
@@ -194,7 +209,7 @@ void kernel_main() {
             for (uint32_t i = 0; i < cb_leftovers; i++) {
                 cb_beta_buf.reserve_back(1);
                 uint32_t l1_write_addr = cb_beta_buf.get_write_ptr();
-                async_read_row_to_tile<beta_is_row_major>(noc, addrb, beta_tile_count, l1_write_addr);
+                async_read_row_to_tile<beta_is_row_major>(noc, addrb, beta_tile_count, l1_write_addr, beta_datum_bytes);
                 beta_tile_count++;
                 noc.async_read_barrier();
                 cb_beta_buf.push_back(1);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_device_operation.cpp
@@ -36,16 +36,17 @@ void LayerNormPostAllGatherDeviceOperation::validate_on_program_cache_miss(
 
     TT_FATAL(a.layout() == Layout::TILE, "Input tensor must have TILE layout, got: {}", a.layout());
     TT_FATAL(
-        a.dtype() == DataType::BFLOAT16 || a.dtype() == DataType::BFLOAT8_B,
-        "Input tensor must be BFLOAT16 or BFLOAT8_B, got: {}",
+        a.dtype() == DataType::BFLOAT16 || a.dtype() == DataType::BFLOAT8_B || a.dtype() == DataType::FLOAT32,
+        "Input tensor must be BFLOAT16, BFLOAT8_B, or FLOAT32, got: {}",
         a.dtype());
     TT_FATAL(a.storage_type() == StorageType::DEVICE, "Operands to layernorm need to be on device!");
     TT_FATAL(a.buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
 
     TT_FATAL(stats.layout() == Layout::TILE, "Stats tensor must have TILE layout, got: {}", stats.layout());
     TT_FATAL(
-        stats.dtype() == DataType::BFLOAT16 || stats.dtype() == DataType::BFLOAT8_B,
-        "Stats tensor must be BFLOAT16 or BFLOAT8_B, got: {}",
+        stats.dtype() == DataType::BFLOAT16 || stats.dtype() == DataType::BFLOAT8_B ||
+            stats.dtype() == DataType::FLOAT32,
+        "Stats tensor must be BFLOAT16, BFLOAT8_B, or FLOAT32, got: {}",
         stats.dtype());
     TT_FATAL(stats.storage_type() == StorageType::DEVICE, "Operands to layernorm need to be on device!");
     TT_FATAL(stats.buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
@@ -74,6 +75,10 @@ void LayerNormPostAllGatherDeviceOperation::validate_on_program_cache_miss(
 
     if (gamma.has_value()) {
         const auto& gamma_tensor = gamma.value();
+        TT_FATAL(
+            gamma_tensor.dtype() == DataType::BFLOAT16 || gamma_tensor.dtype() == DataType::FLOAT32,
+            "Gamma tensor must be BFLOAT16 or FLOAT32, got: {}",
+            gamma_tensor.dtype());
 
         if (gamma_tensor.layout() == Layout::TILE) {
             TT_FATAL(
@@ -110,15 +115,15 @@ void LayerNormPostAllGatherDeviceOperation::validate_on_program_cache_miss(
             TT_FATAL(
                 gamma_tensor.buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
             TT_FATAL(a.device() == gamma_tensor.device(), "Input and gamma tensors must be on same device");
-            TT_FATAL(
-                gamma_tensor.dtype() == DataType::BFLOAT16,
-                "Gamma tensor must be BFLOAT16, got: {}",
-                gamma_tensor.dtype());
         }
     }
 
     if (beta.has_value()) {
         const auto& beta_tensor = beta.value();
+        TT_FATAL(
+            beta_tensor.dtype() == DataType::BFLOAT16 || beta_tensor.dtype() == DataType::FLOAT32,
+            "Beta tensor must be BFLOAT16 or FLOAT32, got: {}",
+            beta_tensor.dtype());
         if (beta_tensor.layout() == Layout::TILE) {
             TT_FATAL(
                 a.logical_shape()[-1] == beta_tensor.logical_shape()[-1] &&
@@ -154,10 +159,6 @@ void LayerNormPostAllGatherDeviceOperation::validate_on_program_cache_miss(
             TT_FATAL(
                 beta_tensor.buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
             TT_FATAL(a.device() == beta_tensor.device(), "Input and beta tensors must be on same device");
-            TT_FATAL(
-                beta_tensor.dtype() == DataType::BFLOAT16,
-                "Beta tensor must be BFLOAT16, got: {}",
-                beta_tensor.dtype());
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_program_factory.cpp
@@ -76,6 +76,13 @@ tt::tt_metal::ProgramDescriptor LayerNormPostAllGatherProgramFactory::create_des
     tt::DataFormat in_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     tt::DataFormat stats_data_format = tt::tt_metal::datatype_to_dataformat_converter(stats.dtype());
     tt::DataFormat out_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    // FP32 input/stats require fp32_dest_acc_en: the intermediate CBs (cb_data_format) only become
+    // Float32 when it is set, otherwise a Float32 input/stats CB feeds Float16_b intermediates and
+    // precision is silently lost. Reject the unsupported combination up front.
+    TT_FATAL(
+        !((in_data_format == tt::DataFormat::Float32 || stats_data_format == tt::DataFormat::Float32) &&
+          !fp32_dest_acc_en),
+        "FLOAT32 input/stats require fp32_dest_acc_en=true in the compute kernel config.");
     tt::DataFormat cb_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
     tt::DataFormat gamma_cb_data_format = gamma.has_value()
                                               ? tt::tt_metal::datatype_to_dataformat_converter(gamma.value().dtype())

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_distributed_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_distributed_nanobind.cpp
@@ -133,7 +133,7 @@ void bind_normalization_layernorm_post_all_gather_operation(nb::module_& mod) {
 
                     * - dtype
                       - layout
-                    * - BFLOAT16, BFLOAT8_B
+                    * - BFLOAT16, BFLOAT8_B, FLOAT32
                       - TILE
 
                   .. list-table:: stats
@@ -141,7 +141,7 @@ void bind_normalization_layernorm_post_all_gather_operation(nb::module_& mod) {
 
                     * - dtype
                       - layout
-                    * - BFLOAT16
+                    * - BFLOAT16, BFLOAT8_B, FLOAT32
                       - TILE
 
                   .. list-table:: weight (gamma) and bias (beta)
@@ -149,16 +149,17 @@ void bind_normalization_layernorm_post_all_gather_operation(nb::module_& mod) {
 
                     * - dtype
                       - layout
-                    * - BFLOAT16
-                      - ROW_MAJOR
+                    * - BFLOAT16, FLOAT32
+                      - ROW_MAJOR, TILE
 
                   Output tensor will be in TILE layout and have the same dtype as the :attr:`input_tensor`
 
                 Limitations:
                   - Input tensors must be on-device and rank 4.
+                  - FLOAT32 :attr:`input_tensor` / :attr:`stats` require ``fp32_dest_acc_en=true`` in the compute kernel config.
                   - The last padded dim of :attr:`stats` must be a multiple of TILE_WIDTH.
                   - The first three padded dims of :attr:`stats` must match :attr:`input_tensor`.
-                  - :attr:`weight` (gamma) and :attr:`bias` (beta) are independently optional; when either is provided it must be BFLOAT16 and match :attr:`input_tensor` per the layout rules above.
+                  - :attr:`weight` (gamma) and :attr:`bias` (beta) are independently optional, may be BFLOAT16 or FLOAT32, and must match :attr:`input_tensor` per the layout rules above.
                   - Sharded runs: inputs cannot be height-sharded, padded height must equal TILE_HEIGHT (32), and :attr:`stats` must be sharded with `num_cores=1` and expected tile columns per device.
         )doc",
         &ttnn::layer_norm_post_all_gather,


### PR DESCRIPTION
## PR Category

Feature — FP32 support for **LayerNormPostAllGather** (distributed layernorm), issue #44650.

## Summary

The distributed LayerNorm **post-all-gather** op rejected FP32 input and FP32 stats, even though the **pre-all-gather** op already *emits* FP32 stats — so an FP32 pre-AG → post-AG pipeline could not round-trip. This PR accepts FP32 end-to-end on the post-all-gather path (input, stats, and gamma/beta), and adds comprehensive FP32 test coverage for the **complete (non-distributed) LayerNorm** op as well (whose FP32 compute path was already wired but untested for the Welford flavor).

FP32 here is **TF32-class precision** (the FPU reads operands via SrcA at a 10-bit mantissa; DEST accumulates in FP32). It requires `fp32_dest_acc_en=True`, which is enforced. Verified on Wormhole B0: post-all-gather FP32 PCC ≈ 0.9999995 vs torch.

## Changes Made

- **`layernorm_post_all_gather_device_operation.cpp`** — accept `FLOAT32` for **input** and **stats** (alongside BFLOAT16/BFLOAT8_B); accept `BFLOAT16 || FLOAT32` gamma/beta in both TILE and ROW_MAJOR.
- **`layernorm_post_all_gather_program_factory.cpp`** — `TT_FATAL` rejecting FP32 input/stats when `fp32_dest_acc_en=False` (otherwise a Float32 CB silently feeds Float16_b intermediates and precision is lost).
- **`reader_unary_interleaved_ln_rm_gb_post_allgather.cpp`** — made the ROW_MAJOR gamma/beta **stick reader datum-size-aware** (`row_bytes = TILE_WIDTH·datum`, `face_bytes = FACE_HW·datum`, `half_row = FACE_WIDTH·datum`). It previously hardcoded 64-byte (bf16) reads, so FP32 ROW_MAJOR gamma/beta read garbage (NaN).
- **`layernorm_distributed_nanobind.cpp`** — docstring dtype tables updated.
- **Tests:**
  - `test_distributed_layernorm_post_allgather.py` — folded the FP32 cases into `test_layernorm_part_2_with_program_cache` (FP32 input + FP32 stats + bf16/fp32 gamma/beta, layernorm + rmsnorm, n_devices 4/8); FP32 added to the program-cache-entry test; `run_layernorm_part_2` threads `gamma_beta_dtype`.
  - `test_layernorm.py` / `test_layernorm_sharded.py` — new `test_layernorm_interleaved_all_config` / `test_layernorm_block_sharded_all_config` covering the **non-distributed** op across {legacy, welford} × {fp32, bf16, bf8} × {TILE, RM input} × {bf16, fp32} gamma/beta; FP32 also added to the existing `gamma_dtype` of the mix-precision tests.
  - `distributed_norm_test_utils.py` + `test_distributed_layernorm_exhaustive.py` — `input_dtype` threaded through; new `test_welford_fp32` mesh round-trip (pre-AG FP32 stats → post-AG FP32).

## Notes for Reviewers

- The core op change is on the **post-all-gather** path only; the non-distributed LayerNorm op already had FP32 wired upstream — this PR adds its (previously missing) FP32 + Welford test coverage.
- The merged `test_layernorm_part_2_with_program_cache` uses **guard-skips** so FP32 runs on the 2048-wide shapes (FP32 doubles tile size → 8192-wide exceeds L1) and bf16/bf8 on the 8192-wide shapes; this intentionally produces many skipped param IDs.


------

## 
<!DOCTYPE html><h2 cid="n321" mdtype="heading" class="md-end-block md-heading md-focus" style="box-sizing: border-box; white-space: pre-wrap; break-after: avoid-page; break-inside: avoid; orphans: 4; font-size: 1.63rem; margin: 0px 0px 1.5rem; font-family: &quot;Lucida Grande&quot;, Corbel, sans-serif; font-weight: bold; clear: both; overflow-wrap: break-word; padding: 0px; color: rgb(222, 222, 222); line-height: 1.875rem; letter-spacing: -1px; position: relative; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span md-inline="plain" class="md-plain md-expand" style="box-sizing: border-box;">Supported configurations &amp; their tests</span></h2><figure class="md-table-fig table-figure" cid="n322" mdtype="table" style="box-sizing: border-box; margin: 1.2em 0px; overflow-x: auto; max-width: calc(100% + 16px); padding: 0px; cursor: default; color: rgb(184, 191, 198); font-family: &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">
Op / path | input fp32 | fp32 γ/β | Test (file::function) | -k
-- | -- | -- | -- | --
Post-all-gather (layernorm + rmsnorm, n_dev 4/8), FP32 input + FP32 stats | ✅ | ✅ | test_distributed_layernorm_post_allgather.py::test_layernorm_part_2_with_program_cache | FLOAT32
Post-all-gather, program-cache (1 entry under FP32) | ✅ | — | …::test_layernorm_part_2_with_program_cache2 | FLOAT32
Pre→post-AG mesh round-trip (needs T3K/8 dev) | ✅ | ✅ | test_distributed_layernorm_exhaustive.py::test_distributed_layernorm_dtype | —
Non-dist interleaved, legacy + welford, TILE input | ✅ | ✅ | test_layernorm.py::test_layernorm_interleaved_all_config | tile_in
Non-dist interleaved, legacy, ROW_MAJOR input | ✅ | ✅ | test_layernorm.py::test_layernorm_interleaved_all_config | legacy and rm_in
Non-dist interleaved, welford + ROW_MAJOR input | ⊘ skip (hangs, bf16 too) | — | …test_layernorm_interleaved_all_config (skipped) | welford and rm_in
Non-dist block-sharded, legacy + welford, TILE | ✅ | ✅ | test_layernorm_sharded.py::test_layernorm_block_sharded_all_config | —
Non-dist legacy mix-precision (interleaved + sharded), FP32 γ/β | ✅ | ✅ | test_layernorm_mix_precision, test_layernorm_sharded_*_mix_precision_rm | FLOAT32

</figure><p cid="n377" mdtype="paragraph" class="md-end-block md-p md-focus" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin-top: 0px; margin-bottom: 1.5rem; overflow-wrap: break-word; white-space: pre-wrap; position: relative; color: rgb(184, 191, 198); font-family: &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span md-inline="em" class="md-pair-s md-expand" style="box-sizing: border-box;"><em style="box-sizing: border-box; font-style: italic;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">(dtypes covered: fp32 / bf16 / bf8; bf8 uses PCC ≥ 0.98 and is TILE-only.)</span></em></span></p>

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/44650_fp32_layernorm_post_allgather)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/44650_fp32_layernorm_post_allgather)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/44650_fp32_layernorm_post_allgather)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/44650_fp32_layernorm_post_allgather)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ign/44650_fp32_layernorm_post_allgather)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ign/44650_fp32_layernorm_post_allgather)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/44650_fp32_layernorm_post_allgather)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/44650_fp32_layernorm_post_allgather)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/44650_fp32_layernorm_post_allgather)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/44650_fp32_layernorm_post_allgather)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/44650_fp32_layernorm_post_allgather)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/44650_fp32_layernorm_post_allgather)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/44650_fp32_layernorm_post_allgather)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/44650_fp32_layernorm_post_allgather)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/44650_fp32_layernorm_post_allgather)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/44650_fp32_layernorm_post_allgather)