### PR TITLE
Fix [CI] test_pow_fractional_composite PCC

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_pow_fractional.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_pow_fractional.py
@@ -32,7 +32,7 @@ def test_pow_fractional_composite(device):
     y = 3 + torch.randn(1, 1, 1, 1).bfloat16().float()
     yt = y
     yt_floor = math.floor(yt)
-    yt_trunc = yt - yt_floor
+    yt_trunc = (yt - yt_floor).item()
     pow_trunc_log = ttnn.multiply(ttnn.log(xt, fast_and_approximate_mode=True), yt_trunc)
     pow_frac = ttnn.exp(pow_trunc_log)
     xtt = ttnn.mul(ttnn.pow(xt, yt_floor), pow_frac)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/48053
https://github.com/tenstorrent/tt-metal/issues/48052

### Problem
tests/tt_eager/python_api_testing/unit_testing/misc/test_pow_fractional.py::test_pow_fractional_composite fails with PCC = 0.6391644024467981
Failing job URLs (last 2 runs):
https://github.com/tenstorrent/tt-metal/actions/runs/28151153934/job/83377688898
https://github.com/tenstorrent/tt-metal/actions/runs/28079421656/job/83140314814
 
### Summary
`yt_trunc` is a [1,1,1,1] torch tensor `tensor([[[[0.5371]]]])`, not a Python scalar. So `ttnn.multiply(log(x), yt_trunc)` has no overload that accepts a torch.Tensor for input_tensor_b (there is no implicit torch.Tensor → ttnn.Tensor conversion) and the call binds to the tensor–scalar overload, whose signature is:
`multiply(input_tensor_a: ttnn.Tensor, input_tensor_b: int | int | float, ...)`

This `ScalarVariant = std::variant<uint32_t, int32_t, float>` is introduced for multiply/divide in https://github.com/tenstorrent/tt-metal/pull/45984, which changed the param from a plain `float`.
As a result, nanobind resolves a `std::variant` by trying its alternatives left-to-right and the integer alternatives (uint32_t, int32_t) come before float. A 1-element float tensor satisfies the integer conversion via truncation (int(torch.tensor(0.537)) == 0), so the scalar is silently taken as 0 instead of 0.537. Earlier, the parameter was float, so the same 1-element tensor converted through the float protocol to 0.537 and the test passed. This is why a deterministic regression first appears in this [integration test](https://github.com/tenstorrent/tt-metal/actions/runs/27666415743/job/81822402131#step:7:11787) 

The following change fixes the issue by extracting the scalar: 
```
- yt_trunc = y.item() - yt_floor
+ yt_trunc = (y.item() - yt_floor).item()
```

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-integration-tests.yaml/badge.svg?branch=anasuya/ci_pow_fractional)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-integration-tests.yaml?query=branch:anasuya/ci_pow_fractional)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=anasuya/ci_pow_fractional)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:anasuya/ci_pow_fractional)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=anasuya/ci_pow_fractional)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:anasuya/ci_pow_fractional)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=anasuya/ci_pow_fractional)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:anasuya/ci_pow_fractional)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anasuya/ci_pow_fractional)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anasuya/ci_pow_fractional)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=anasuya/ci_pow_fractional)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:anasuya/ci_pow_fractional)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=anasuya/ci_pow_fractional)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:anasuya/ci_pow_fractional)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=anasuya/ci_pow_fractional)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:anasuya/ci_pow_fractional)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=anasuya/ci_pow_fractional)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:anasuya/ci_pow_fractional)