### PR TITLE
Override compute_program_hash to prevent program-cache collision crash

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
@@ -1505,6 +1505,83 @@ def test_issue_42753_regression(device, input_shape, begins, ends, step):
     assert_with_pcc(torch_output, tt_output_torch, 0.99)
 
 
+def test_issue_47602_program_cache_collision_on_shape_change(device):
+    """Back-to-back slice calls with different input shapes must produce correct
+    outputs for both ROW_MAJOR and TILE layouts when the program cache is enabled.
+    """
+    torch.manual_seed(47602)
+
+    def _to_tt(t, layout, device):
+        return ttnn.from_torch(
+            t,
+            dtype=ttnn.bfloat16,
+            layout=layout,
+            device=device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+    # ── ROW_MAJOR path ──────────────────────────────────────────────────────
+    small_rm = torch.rand(1, 1, 32, 64, dtype=torch.bfloat16)
+    large_rm = torch.rand(1, 4, 512, 512, dtype=torch.bfloat16)
+
+    tt_small_rm = _to_tt(small_rm, ttnn.ROW_MAJOR_LAYOUT, device)
+    tt_large_rm = _to_tt(large_rm, ttnn.ROW_MAJOR_LAYOUT, device)
+
+    tt_out_small_rm = ttnn.slice(tt_small_rm, [0, 0, 0, 0], [1, 1, 32, 32], memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    entries_after_small_rm = device.num_program_cache_entries()
+
+    tt_out_large_rm = ttnn.slice(tt_large_rm, [0, 0, 0, 0], [1, 4, 256, 256], memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    entries_after_large_rm = device.num_program_cache_entries()
+
+    assert entries_after_large_rm > entries_after_small_rm, "large RM slice must be a cache-miss, not a hit"
+    assert_with_pcc(small_rm[:, :, :, :32], ttnn.to_torch(tt_out_small_rm), 0.9999)
+    assert_with_pcc(large_rm[:, :, :256, :256], ttnn.to_torch(tt_out_large_rm), 0.9999)
+
+    # ── TILE path ───────────────────────────────────────────────────────────
+    small_tile = torch.rand(1, 1, 32, 64, dtype=torch.bfloat16)
+    large_tile = torch.rand(1, 4, 512, 512, dtype=torch.bfloat16)
+
+    tt_small_tile = _to_tt(small_tile, ttnn.TILE_LAYOUT, device)
+    tt_large_tile = _to_tt(large_tile, ttnn.TILE_LAYOUT, device)
+
+    tt_out_small_tile = ttnn.slice(tt_small_tile, [0, 0, 0, 0], [1, 1, 32, 32], memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    entries_after_small_tile = device.num_program_cache_entries()
+
+    tt_out_large_tile = ttnn.slice(tt_large_tile, [0, 0, 0, 0], [1, 4, 256, 256], memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    entries_after_large_tile = device.num_program_cache_entries()
+
+    assert entries_after_large_tile > entries_after_small_tile, "large TILE slice must be a cache-miss, not a hit"
+    assert_with_pcc(small_tile[:, :, :, :32], ttnn.to_torch(tt_out_small_tile), 0.9999)
+    assert_with_pcc(large_tile[:, :, :256, :256], ttnn.to_torch(tt_out_large_tile), 0.9999)
+
+
+def test_issue_47602_same_shape_reuses_cache_entry(device):
+    """Same shape called twice must be a cache hit (entry count must not grow).
+
+    Verifies the hash is not over-aggressive: repeated slices with identical
+    inputs, shapes, and slice params reuse the same program rather than
+    compiling a new one each time.
+    """
+    torch.manual_seed(47602)
+
+    torch_input = torch.rand(1, 4, 128, 128, dtype=torch.bfloat16)
+    tt_input = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    ttnn.slice(tt_input, [0, 0, 0, 0], [1, 4, 64, 64], memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    entries_after_first = device.num_program_cache_entries()
+
+    ttnn.slice(tt_input, [0, 0, 0, 0], [1, 4, 64, 64], memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    entries_after_second = device.num_program_cache_entries()
+
+    assert entries_after_second == entries_after_first, "identical slice must be a cache hit, not a miss"
+
+
 @pytest.mark.parametrize(
     "shape, slice_start, slice_end",
     [

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
@@ -295,6 +295,60 @@ SliceDeviceOperation::program_factory_t SliceDeviceOperation::select_program_fac
     return SliceTileProgramFactory{};
 }
 
+ttsl::hash::hash_t SliceDeviceOperation::compute_program_hash(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    // Default hash has weak distribution for small-integer shape sequences (boost::hash_combine
+    // style), causing false cache hits when shapes differ but collide. Mix in full input/output
+    // specs and slice params so any two invocations with different core-grid sizes get distinct
+    // keys. Same pattern as concat fix in PR #45144 (issue #47602).
+    auto factory = select_program_factory(operation_attributes, tensor_args);
+    auto hash = tt::tt_metal::operation::hash_operation<SliceDeviceOperation>(
+        operation_attributes.slice_start,
+        operation_attributes.slice_end,
+        operation_attributes.step,
+        operation_attributes.use_tensor_args,
+        operation_attributes.slice_dim,
+        operation_attributes.num_devices,
+        operation_attributes.output_mem_config,
+        operation_attributes.sub_core_grids,
+        factory.index(),
+        tensor_args.start_tensor.has_value());
+
+    const auto& input = tensor_args.input;
+    hash = ttsl::hash::hash_objects(
+        hash,
+        input.logical_shape().rank(),
+        input.logical_shape(),
+        input.padded_shape(),
+        input.layout(),
+        input.dtype(),
+        input.memory_config());
+
+    if (tensor_args.start_tensor.has_value()) {
+        const auto& st = tensor_args.start_tensor.value();
+        hash = ttsl::hash::hash_objects(
+            hash,
+            st.logical_shape().rank(),
+            st.logical_shape(),
+            st.padded_shape(),
+            st.layout(),
+            st.dtype(),
+            st.memory_config());
+    }
+
+    const auto output_spec = compute_output_specs(operation_attributes, tensor_args);
+    hash = ttsl::hash::hash_objects(
+        hash,
+        output_spec.logical_shape().rank(),
+        output_spec.logical_shape(),
+        output_spec.padded_shape(),
+        output_spec.layout(),
+        output_spec.data_type(),
+        output_spec.memory_config());
+
+    return hash;
+}
+
 tt::tt_metal::operation::OpPerformanceModelGeneral<SliceDeviceOperation::tensor_return_value_t>
 SliceDeviceOperation::create_op_performance_model(
     const operation_attributes_t& /*args*/, const tensor_args_t& tensor_args, const Tensor& output) {

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.hpp
@@ -48,6 +48,8 @@ struct SliceDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t&, const tensor_args_t&, const Tensor&);
 };


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-metal/issues/47602

### Problem

`ttnn.slice` crashes with `TT_FATAL` when called back-to-back with two different input shapes in the same process (program cache enabled)

### Summary 
The default `compute_program_hash` uses a `boost::hash_combine`-style combiner over shape dimensions. This combiner has weak distribution for small integers - different shapes (e.g. `[1,1,32,64]` and `[1,4,512,512]`) can produce the same 64-bit hash key. On a false cache hit, the framework re-derives a descriptor for the new
(larger) shape and calls `apply_descriptor_runtime_args` against a cached program whose kernel was only placed on N cores. Accessing core `(0, N)` asserts. This is the same root cause as `ttnn.concat` issue #45089, fixed in PR #45144.

### Fix

Override `compute_program_hash` on `SliceDeviceOperation` (same pattern as the concat fix). The override mixes the following into the seed after the default attribute fields:

- `input` — rank, logical shape, padded shape, layout, dtype, memory config
- `start_tensor` descriptor (when present, for the tensor-args path)
- computed `output TensorSpec` — rank, logical/padded shapes, layout, dtype, memory config

The output spec directly encodes the core-grid size, so any two invocations that would place kernels on different core sets are guaranteed to produce distinct keys.

### Changes

| File | Change |
|---|---|
| `slice_device_operation.hpp` | Add `compute_program_hash` declaration |
| `slice_device_operation.cpp` | Implement `compute_program_hash` |
| `test_slice.py` | Add `test_issue_47602_program_cache_collision_on_shape_change` |

### Pipeline Status

- [x] Sanity
- [x] BHPC
- [x] Nighlty for all categories
- [x] Single card
- [x] T3K
- [x] Galaxy

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=virdhatchani/slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:virdhatchani/slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/slice)