### PR TITLE
[tt-train] Bitwise-identical checkpointing

### DIFF
--- a/tt-train/sources/examples/train/checkpointing.py
+++ b/tt-train/sources/examples/train/checkpointing.py
@@ -12,11 +12,20 @@ import time
 from pathlib import Path
 from typing import Callable
 
+import ttml
 from ttml.checkpointing import load_checkpoint, read_header, save_checkpoint
 from ttml.common.data import CharTokenizer
 from ttml.trainers import SFTTrainer
 
 from model_builders import Model, ModelConfig, create_model
+
+
+def _capture_rng_state() -> dict:
+    return {"cpp": ttml.autograd.AutoContext.get_instance().get_generator_state()}
+
+
+def _restore_rng_state(state: dict) -> None:
+    ttml.autograd.AutoContext.get_instance().set_generator_state(state["cpp"])
 
 
 def _human_size(num_bytes: int) -> str:
@@ -56,7 +65,13 @@ def build_checkpoint_io(
         start = time.perf_counter()
         save_checkpoint(
             path,
-            header={"step": trainer.step, "tokenizer": tokenizer, "model_config": model_cfg},
+            header={
+                "step": trainer.step,
+                "tokenizer": tokenizer,
+                "model_config": model_cfg,
+                "rng": _capture_rng_state(),
+                "dataloader": trainer.train_dataloader.get_state_dict(),
+            },
             model_params=trainer.model.parameters(),
             optimizer=trainer.optimizer,
             display_progress=_show_progress(),
@@ -73,6 +88,8 @@ def build_checkpoint_io(
             optimizer=trainer.optimizer,
             display_progress=_show_progress(),
         )
+        _restore_rng_state(header["rng"])
+        trainer.train_dataloader.set_state_dict(header["dataloader"])
         elapsed = time.perf_counter() - start
         print(f"  Loaded checkpoint from {path} (in {_human_time(elapsed)})")
         return int(header["step"])

--- a/tt-train/sources/examples/train/train.py
+++ b/tt-train/sources/examples/train/train.py
@@ -530,7 +530,9 @@ def run_training(
     else:
         mapper = None
     collate = partial(causal_lm_collate_fn, seq_len=seq_len, mapper=mapper)
-    dataloader = InMemoryDataloader(dataset, collate, batch_size=training_cfg.batch_size, shuffle=True, drop_last=True)
+    dataloader = InMemoryDataloader(
+        dataset, collate, batch_size=training_cfg.batch_size, shuffle=True, drop_last=True, seed=training_cfg.seed
+    )
 
     peak_tflops = get_device_peak_tflops_bf16() * mesh.num_devices() if flops_per_token > 0 else 0.0
 

--- a/tt-train/sources/ttml/autograd/auto_context.cpp
+++ b/tt-train/sources/ttml/autograd/auto_context.cpp
@@ -5,6 +5,7 @@
 #include "auto_context.hpp"
 
 #include <optional>
+#include <sstream>
 
 #include "core/tt_profiler.hpp"
 #include "ttnn_fixed/distributed/tt_metal.hpp"
@@ -17,6 +18,17 @@ std::mt19937& AutoContext::get_generator() {
 
 void AutoContext::set_generator(const std::mt19937& generator) {
     m_generator = generator;
+}
+
+std::string AutoContext::get_generator_state() const {
+    std::ostringstream oss;
+    oss << m_generator;  // mt19937's stream operator emits its full internal state (624 words + position)
+    return oss.str();
+}
+
+void AutoContext::set_generator_state(const std::string& state) {
+    std::istringstream iss(state);
+    iss >> m_generator;
 }
 
 void AutoContext::set_seed(uint32_t seed) {

--- a/tt-train/sources/ttml/autograd/auto_context.cpp
+++ b/tt-train/sources/ttml/autograd/auto_context.cpp
@@ -29,6 +29,9 @@ std::string AutoContext::get_generator_state() const {
 void AutoContext::set_generator_state(const std::string& state) {
     std::istringstream iss(state);
     iss >> m_generator;
+    if (iss.fail()) {
+        throw std::runtime_error("Failed to deserialize RNG generator state.");
+    }
 }
 
 void AutoContext::set_seed(uint32_t seed) {

--- a/tt-train/sources/ttml/autograd/auto_context.hpp
+++ b/tt-train/sources/ttml/autograd/auto_context.hpp
@@ -7,6 +7,7 @@
 #include <core/ttnn_all_includes.hpp>
 #include <memory>
 #include <random>
+#include <string>
 
 #include "core/distributed/ccl_resources.hpp"
 #include "core/distributed/socket_manager.hpp"
@@ -79,6 +80,9 @@ public:
 
     std::mt19937& get_generator();
     void set_generator(const std::mt19937& generator);
+
+    [[nodiscard]] std::string get_generator_state() const;
+    void set_generator_state(const std::string& state);
 
     void set_seed(uint32_t seed);
 

--- a/tt-train/sources/ttml/nanobind/nb_autograd.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_autograd.cpp
@@ -222,6 +222,13 @@ void py_module(nb::module_& m) {
         py_auto_context.def("set_seed", &AutoContext::set_seed, nb::arg("seed"), "Set seed");
         py_auto_context.def("get_seed", &AutoContext::get_seed, "Get seed");
         py_auto_context.def(
+            "get_generator_state", &AutoContext::get_generator_state, "Serialize the RNG generator state");
+        py_auto_context.def(
+            "set_generator_state",
+            &AutoContext::set_generator_state,
+            nb::arg("state"),
+            "Restore the RNG generator state");
+        py_auto_context.def(
             "add_backward_node",
             [](AutoContext& self, GradFunction grad_function, std::optional<nb::list> links_obj) {
                 // Handle empty list case where nanobind can't infer element type

--- a/tt-train/sources/ttml/ttml/datasets/dataloader.py
+++ b/tt-train/sources/ttml/ttml/datasets/dataloader.py
@@ -77,3 +77,11 @@ class TTMLDataloader(ABC):
     def __len__(self) -> int:
         """Total number of batches available in one pass over the dataset."""
         pass
+
+    def get_state_dict(self) -> dict:
+        """Serializable iteration state for checkpoint/resume. Stateless loaders return ``{}``."""
+        return {}
+
+    def set_state_dict(self, state: dict) -> None:
+        """Restore iteration state produced by :meth:`get_state_dict`. No-op by default."""
+        pass

--- a/tt-train/sources/ttml/ttml/datasets/hf_dataloader.py
+++ b/tt-train/sources/ttml/ttml/datasets/hf_dataloader.py
@@ -20,8 +20,8 @@ class InMemoryDataloader(TTMLDataloader):
     Iterates the dataset by index, groups examples into batches, and calls the
     injected ``collate_fn`` to produce :class:`Batch` objects with ttml tensors.
 
-    Yields a single pass over the dataset.  When ``shuffle=True`` the indices
-    are randomly permuted before iteration.  The caller (e.g. ``SFTTrainer``)
+    Each pass is one epoch. When ``shuffle=True`` the order is a pure function of ``(seed, epoch)``
+    via a local generator. The caller (e.g. ``SFTTrainer``)
     is responsible for re-iterating when another epoch is needed.
 
     Example::
@@ -32,7 +32,7 @@ class InMemoryDataloader(TTMLDataloader):
 
         dataset = load_dataset("trl-lib/Capybara", split="train")
         collate = partial(sft_collate_fn, max_seq_len=2048, pad_token_id=tokenizer.pad_token_id)
-        loader = InMemoryDataloader(dataset, collate, batch_size=8, shuffle=True)
+        loader = InMemoryDataloader(dataset, collate, batch_size=8, shuffle=True, seed=42)
     """
 
     def __init__(
@@ -42,23 +42,44 @@ class InMemoryDataloader(TTMLDataloader):
         batch_size: int,
         shuffle: bool = False,
         drop_last: bool = True,
+        seed: int = 0,
     ) -> None:
         super().__init__(dataset, collate_fn, batch_size)
         self.shuffle = shuffle
         self.drop_last = drop_last
+        self.seed = seed
+        self._epoch = 0
+        self._position = 0  # batches yielded so far in the current epoch (the mid-epoch resume offset)
+
+    def _epoch_indices(self, epoch: int) -> np.ndarray:
+        """Index order for ``epoch`` — a pure function of ``(seed, epoch)``, off a local generator."""
+        n = len(self.dataset)
+        if not self.shuffle:
+            return np.arange(n)
+        return np.random.default_rng([self.seed, epoch]).permutation(n)
 
     def __iter__(self) -> Iterator[Batch]:
         n = len(self.dataset)
-        indices = list(range(n))
-        if self.shuffle:
-            np.random.shuffle(indices)
+        indices = self._epoch_indices(self._epoch)
         end = (n // self.batch_size) * self.batch_size if self.drop_last else n
-        for i in range(0, end, self.batch_size):
+        for i in range(self._position * self.batch_size, end, self.batch_size):  # resume offset
             batch_indices = indices[i : i + self.batch_size]
             if self.drop_last and len(batch_indices) < self.batch_size:
                 break
-            examples = [self.dataset[j] for j in batch_indices]
+            examples = [self.dataset[int(j)] for j in batch_indices]
+            self._position += 1
             yield self.collate_fn(examples)
+        # Reached only on full exhaustion: advance to the next epoch's order, reset the offset.
+        self._epoch += 1
+        self._position = 0
+
+    def get_state_dict(self) -> dict:
+        return {"seed": self.seed, "epoch": self._epoch, "position": self._position}
+
+    def set_state_dict(self, state: dict) -> None:
+        self.seed = state["seed"]
+        self._epoch = state["epoch"]
+        self._position = state["position"]
 
     def __len__(self) -> int:
         n = len(self.dataset)

--- a/tt-train/tests/python/test_checkpointing.py
+++ b/tt-train/tests/python/test_checkpointing.py
@@ -227,6 +227,25 @@ def test_bf16_dtype_preserved_on_disk(tmp_path):
     ctx.reset_graph()
 
 
+def test_rng_state_roundtrips_in_header(tmp_path):
+    """The opaque header round-trips its payload byte-for-byte through pickle. train.py's saver stores the
+    C++ generator string under "rng"; this test also bundles a numpy state tuple to prove the header
+    preserves embedded ndarrays exactly, not just strings. Host-only: no model tensors."""
+    ctx = ttml.autograd.AutoContext.get_instance()
+    ctx.set_seed(7)
+    np.random.seed(7)
+    rng = {"cpp": ctx.get_generator_state(), "numpy": np.random.get_state()}
+
+    path = str(tmp_path / "rng.pkl")
+    checkpointing.save_checkpoint(path, header={"step": 0, "rng": rng})
+
+    restored = checkpointing.load_checkpoint(path)["rng"]
+    assert restored["cpp"] == rng["cpp"]
+    assert restored["numpy"][0] == rng["numpy"][0]  # algorithm tag ("MT19937")
+    np.testing.assert_array_equal(restored["numpy"][1], rng["numpy"][1])  # 624-word state
+    assert restored["numpy"][2:] == rng["numpy"][2:]  # position + cached-gaussian fields
+
+
 def test_bad_file_raises(tmp_path, expect_error):
     """A non-checkpoint, empty, or wrong-format file raises a clear ValueError (host-only — no device)."""
     not_pickle = tmp_path / "garbage.pkl"

--- a/tt-train/tests/python/test_randn.py
+++ b/tt-train/tests/python/test_randn.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import math
+import numpy as np
 import pytest
 import torch
 import ttnn
@@ -147,9 +148,26 @@ class TestRandn:
             ttnn.to_torch(t2.get_value(precision=FULL_PRECISION)),
         ), "Different seeds should produce different tensors"
 
+    # --- generator state (checkpoint resume) ---
+
+    def test_generator_state_roundtrip(self):
+        """Restoring the serialized generator state reproduces the RNG stream, not just the seed."""
+        ctx = ttml.autograd.AutoContext.get_instance()
+        ctx.set_seed(0)
+
+        state = ctx.get_generator_state()
+        assert isinstance(state, str) and state, "generator state should be a non-empty string"
+
+        a = ttml.ops.randn(DEFAULT_SHAPE, dtype=ttnn.DataType.FLOAT32).to_numpy(ttnn.DataType.FLOAT32)
+        assert ctx.get_generator_state() != state, "drawing from the generator should advance its state"
+
+        ctx.set_generator_state(state)
+        b = ttml.ops.randn(DEFAULT_SHAPE, dtype=ttnn.DataType.FLOAT32).to_numpy(ttnn.DataType.FLOAT32)
+        np.testing.assert_array_equal(a, b, err_msg="restored generator state should reproduce the same draw")
+
     # --- invalid args ---
 
-    def test_randn_invalid_args(self):
-        with pytest.raises(Exception):
+    def test_randn_invalid_args(self, expect_error):
+        with expect_error(RuntimeError, "stddev must be non-negative"):
             # negative std must be rejected
             ttml.ops.randn(DEFAULT_SHAPE, std=-1.0)

--- a/tt-train/tests/python/test_sft_trainer.py
+++ b/tt-train/tests/python/test_sft_trainer.py
@@ -42,9 +42,7 @@ class _FakeTensor:
 @pytest.fixture(autouse=True)
 def patch_tensor(monkeypatch):
     """Replace Tensor.from_numpy with a device-free stub for every test."""
-    monkeypatch.setattr(
-        ttml.autograd.Tensor, "from_numpy", staticmethod(_FakeTensor.from_numpy)
-    )
+    monkeypatch.setattr(ttml.autograd.Tensor, "from_numpy", staticmethod(_FakeTensor.from_numpy))
 
 
 # ---------------------------------------------------------------------------
@@ -64,8 +62,8 @@ def test_batch_fields():
 # ---------------------------------------------------------------------------
 
 
-def test_ttml_dataloader_is_abstract():
-    with pytest.raises(TypeError):
+def test_ttml_dataloader_is_abstract(expect_error):
+    with expect_error(TypeError, "abstract class TTMLDataloader"):
         TTMLDataloader(dataset=[], collate_fn=lambda x: x, batch_size=1)
 
 
@@ -137,14 +135,21 @@ def test_sft_collate_fn_prompt_zeroed_completion_nonzero():
 
 
 def _sft_examples(n):
-    return [
-        {"input_ids": list(range(i, i + 4)), "labels": [-100, i + 1, i + 2, i + 3]}
-        for i in range(n)
-    ]
+    return [{"input_ids": list(range(i, i + 4)), "labels": [-100, i + 1, i + 2, i + 3]} for i in range(n)]
 
 
 def _collate(examples):
     return sft_collate_fn(examples, max_seq_len=8, pad_token_id=0)
+
+
+def _lead_token(batch):
+    """First token of a batch's lead example — a per-batch identifier (assumes the identity `lambda x: x` collate)."""
+    return batch[0]["input_ids"][0]
+
+
+def _batch_order(loader):
+    """Sequence of per-batch lead tokens — a fingerprint of the loader's iteration order."""
+    return [_lead_token(batch) for batch in loader]
 
 
 def test_in_memory_dataloader_len():
@@ -161,16 +166,50 @@ def test_in_memory_dataloader_yields_batch_objects():
 
 
 def test_in_memory_dataloader_shuffle_changes_order():
+    """Order is a pure function of the loader's seed — independent of the global np.random."""
     data = _sft_examples(20)
 
-    np.random.seed(0)
-    loader = InMemoryDataloader(data, lambda x: x, batch_size=1, shuffle=True)
-    order_a = [b[0]["input_ids"][0] for b in loader]
+    order_a = _batch_order(InMemoryDataloader(data, lambda x: x, batch_size=1, shuffle=True, seed=0))
+    order_b = _batch_order(InMemoryDataloader(data, lambda x: x, batch_size=1, shuffle=True, seed=99))
+    order_a_again = _batch_order(InMemoryDataloader(data, lambda x: x, batch_size=1, shuffle=True, seed=0))
 
-    np.random.seed(99)
-    order_b = [b[0]["input_ids"][0] for b in loader]
+    assert order_a != order_b  # different seed -> different order
+    assert order_a == order_a_again  # same seed -> reproducible epoch-0 order
 
-    assert order_a != order_b
+
+def test_in_memory_dataloader_resume_matches_uninterrupted():
+    """Saving (epoch, position) mid-epoch and restoring into a fresh loader reproduces the exact
+    remaining batch sequence — first_k + resumed_remainder == one uninterrupted epoch."""
+    data = _sft_examples(20)
+
+    uninterrupted = _batch_order(InMemoryDataloader(data, lambda x: x, batch_size=2, shuffle=True, seed=7))
+
+    k = 3
+    partial_loader = InMemoryDataloader(data, lambda x: x, batch_size=2, shuffle=True, seed=7)
+    it = iter(partial_loader)
+    first = [_lead_token(next(it)) for _ in range(k)]
+    state = partial_loader.get_state_dict()
+
+    # Built with a deliberately wrong seed: set_state_dict must restore seed=7 from the state, or the
+    # resumed order wouldn't line up with the uninterrupted run.
+    resumed = InMemoryDataloader(data, lambda x: x, batch_size=2, shuffle=True, seed=999)
+    resumed.set_state_dict(state)
+    remainder = _batch_order(resumed)
+
+    assert first + remainder == uninterrupted
+
+
+def test_dataloader_state_dict_roundtrip():
+    """get_state_dict -> set_state_dict carries (seed, epoch, position) onto a fresh loader."""
+    loader = InMemoryDataloader(_sft_examples(8), lambda x: x, batch_size=2, shuffle=True, seed=5)
+    it = iter(loader)
+    next(it)
+    state = loader.get_state_dict()
+    assert state == {"seed": 5, "epoch": 0, "position": 1}
+
+    restored = InMemoryDataloader(_sft_examples(8), lambda x: x, batch_size=2, seed=0)
+    restored.set_state_dict(state)
+    assert restored.get_state_dict() == state
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes https://github.com/tenstorrent/tt-metal/issues/47949

### Summary

Implemented bitwise-identical checkpointing by:
- checkpointing C++ autograd RNG state via straightforward capture/restore helpers
- checkpointing dataloader via get/set_state_dict and making dataset shuffling depend on local derived RNG from seed, epoch, and position, instead of a global RNG state

Added related tests.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=imichalak/train-byte-identical-checkpointing)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:imichalak/train-byte-identical-checkpointing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=imichalak/train-byte-identical-checkpointing)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:imichalak/train-byte-identical-checkpointing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=imichalak/train-byte-identical-checkpointing)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:imichalak/train-byte-identical-checkpointing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=imichalak/train-byte-identical-checkpointing)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:imichalak/train-byte-identical-checkpointing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=imichalak/train-byte-identical-checkpointing)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:imichalak/train-byte-identical-checkpointing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=imichalak/train-byte-identical-checkpointing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:imichalak/train-byte-identical-checkpointing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=imichalak/train-byte-identical-checkpointing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:imichalak/train-byte-identical-checkpointing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=imichalak/train-byte-identical-checkpointing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:imichalak/train-byte-identical-checkpointing)