### PR TITLE
[Bug fix][Conv3D] Default C_in_block to the minimal valid block for pre-prepared weights (fix L1 overflow)

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv3d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv3d.py
@@ -1023,7 +1023,7 @@ def test_conv3d_prepare_default_blocking(device, input_shape, out_channels, kern
 
 def test_conv3d_preprepared_weight_no_config(device):
     """Pre-prepared (rank-2) weight + no config: conv3d's fallback C_in_block must match
-    prepare's default (0 = full), since it does not re-block the weight (issue #47316). C_in=64."""
+    prepare's default, since it does not re-block the weight (issue #47316). C_in=64."""
     input_shape, out_channels, kernel_size, stride, padding = (1, 64, 8, 10, 9), 64, (3, 3, 3), (1, 1, 1), (0, 1, 1)
     tt_input, conv3d_module, gt_output, kernel_config, output_dims = setup_conv3d_test(
         input_shape, out_channels, kernel_size, stride, 1, padding, "zeros", device
@@ -1065,4 +1065,59 @@ def test_conv3d_preprepared_weight_no_config(device):
     assert tt_output.shape == gt_output.shape
     pcc_passed, pcc_message = check_with_pcc(gt_output, tt_output, pcc=0.999)
     logger.info(f"Compare conv3d (pre-prepared weight, no config) torch vs ttnn: {pcc_message}")
+    assert pcc_passed, pcc_message
+
+
+def test_conv3d_preprepared_large_kernel_no_config(device):
+    """Pre-prepared (rank-2) weight + no config for the Qwen2.5-VL patch-embed shape
+    (C_in=3, kernel=stride=(2,14,14), out=1280). A full-channel default block put the
+    whole K reduction in one matmul block and overflowed L1; the minimal-block default
+    (shared by prepare and conv3d) both fits L1 and matches the prepared weight (#42146)."""
+    input_shape, out_channels, kernel_size, stride, padding = (
+        (8, 3, 2, 14, 14),
+        1280,
+        (2, 14, 14),
+        (2, 14, 14),
+        (0, 0, 0),
+    )
+    tt_input, conv3d_module, gt_output, kernel_config, output_dims = setup_conv3d_test(
+        input_shape, out_channels, kernel_size, stride, 1, padding, "zeros", device
+    )
+    N, D_out, H_out, W_out = output_dims
+
+    # Prepare with default blocking -> rank-2 weight.
+    w = conv3d_module.weight.data
+    tt_weight = ttnn.from_torch(w, dtype=ttnn.DataType.BFLOAT16, pad_value=0)
+    tt_weight = ttnn.experimental.prepare_conv3d_weights(
+        weight_tensor=tt_weight, groups=1, alignment=ALIGNMENT, device=device
+    )
+    assert len(tt_weight.shape) == 2
+    tt_bias = ttnn.from_torch(
+        conv3d_module.bias.data.reshape(1, -1),
+        device=device,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.TILE_LAYOUT,
+        pad_value=0,
+    )
+
+    # No config -> default minimal block; must fit L1 and match the prepared weight.
+    tt_output = ttnn.experimental.conv3d(
+        input_tensor=tt_input,
+        weight_tensor=tt_weight,
+        device=device,
+        bias_tensor=tt_bias,
+        dtype=ttnn.bfloat16,
+        output_channels=out_channels,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        padding_mode="zeros",
+        groups=1,
+        compute_kernel_config=kernel_config,
+    )
+
+    tt_output = reshape_output(tt_output, N, D_out, H_out, W_out, out_channels, device)
+    assert tt_output.shape == gt_output.shape
+    pcc_passed, pcc_message = check_with_pcc(gt_output, tt_output, pcc=0.999)
+    logger.info(f"Compare conv3d (pre-prepared large kernel, no config) torch vs ttnn: {pcc_message}")
     assert pcc_passed, pcc_message

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d.cpp
@@ -56,20 +56,13 @@ ttnn::Tensor conv3d(
     uint32_t groups_,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
-    // Conservative default blocking: minimal spatial blocks, smallest valid C_in_block.
-    // C_in_block must satisfy: kernel_vol * C_in_block ≡ 0 (mod TILE_WIDTH) for weight tile
-    // alignment, and C_in_block % l1_alignment == 0 for L1 alignment.
-    uint32_t kernel_vol = kernel_size_[0] * kernel_size_[1] * kernel_size_[2];
-    uint32_t tile_align_factor = tt::constants::TILE_WIDTH / std::gcd(kernel_vol, (uint32_t)tt::constants::TILE_WIDTH);
-    uint32_t l1_alignment = tt::tt_metal::hal::get_l1_alignment();
-    uint32_t min_c_in_block = std::lcm(l1_alignment, tile_align_factor);
-
-    // Default C_in_block must match the weight's blocking or the matmul contracts mismatched rows
-    // -> near-zero PCC (issue #47316). rank-5 (unprepared): blocked + computed here, so
-    // min_c_in_block keeps large kernels in L1. rank-2 (pre-prepared): not re-blocked, so match
-    // prepare_conv3d_weights' own default of 0 (full block).
-    const bool weight_already_prepared = weight_tensor.logical_shape().rank() == 2;
-    const uint32_t default_c_in_block = weight_already_prepared ? 0u : min_c_in_block;
+    // Default blocking: minimal spatial blocks, smallest valid C_in_block. The same
+    // default is used by prepare_conv3d_weights, so the prepared weight's K-row
+    // blocking always matches the conv compute -- no near-zero-PCC mismatch (#47316) --
+    // and the minimal block keeps large kernels within L1 (#42146). This holds for both
+    // a rank-5 (prepared here) and a rank-2 (pre-prepared with the same default) weight.
+    const uint32_t default_c_in_block = ttnn::operations::experimental::conv3d::default_c_in_block(
+        kernel_size_[0] * kernel_size_[1] * kernel_size_[2]);
 
     auto config = config_opt.value_or(ttnn::experimental::prim::Conv3dConfig(
         tt::tt_metal::DataType::BFLOAT16,                        // weights_dtype
@@ -83,6 +76,14 @@ ttnn::Tensor conv3d(
         32,                                                      // alignment
         input_tensor.device()->compute_with_storage_grid_size()  // use full device grid
         ));
+
+    // An explicitly-provided config may still carry C_in_block == 0 ("auto"). Resolve it to the
+    // same default so prepare_conv3d_weights and the conv compute use one identical, non-zero
+    // block -- otherwise the internal prepare and the device op disagree on the K-row blocking
+    // (near-zero PCC, #47316). This mirrors prepare_conv3d_weights' own 0 handling.
+    if (config.C_in_block == 0) {
+        config.C_in_block = default_c_in_block;
+    }
 
     Tensor prepared_weight_tensor = prepare_and_check_weight_tensor(weight_tensor, groups_, config, device);
     return ttnn::prim::conv3d(

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d_nanobind.cpp
@@ -72,8 +72,9 @@ void bind_conv3d(nb::module_& mod) {
         nb::kw_only(),
         nb::arg("weight_tensor"),
         nb::arg("groups") = 1u,
-        // 0 == single full-channel block; must match Conv3dConfig's default so the prepared weight
-        // and conv compute agree on K-row blocking. A mismatch silently reorders rows (issue #47316).
+        // 0 == use the default minimal valid block (default_c_in_block), the same value conv3d
+        // defaults to, so the prepared weight and the conv compute agree on K-row blocking and
+        // stay within L1. A mismatch silently reorders rows (issues #42146, #47316).
         nb::arg("C_in_block") = 0u,
         nb::arg("alignment") = 32u,
         nb::arg("device") = nb::none());

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/prepare_conv3d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/prepare_conv3d_weights.cpp
@@ -12,13 +12,26 @@
 #include "ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/hal.hpp>
+#include "ttnn/common/constants.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 #include <vector>
 #include <algorithm>
+#include <numeric>
 
 using namespace tt::tt_metal;
 
 namespace ttnn::operations::experimental::conv3d {
+
+uint32_t default_c_in_block(uint32_t kernel_vol) {
+    // C_in_block must satisfy: kernel_vol * C_in_block divisible by TILE_WIDTH (weight
+    // tile alignment) and C_in_block % l1_alignment == 0 (L1 alignment). The minimum
+    // such value gives the smallest circular buffers, keeping large kernels within L1.
+    uint32_t tile_align_factor =
+        tt::constants::TILE_WIDTH / std::gcd(kernel_vol, static_cast<uint32_t>(tt::constants::TILE_WIDTH));
+    uint32_t l1_alignment = tt::tt_metal::hal::get_l1_alignment();
+    return std::lcm(l1_alignment, tile_align_factor);
+}
 
 template <typename T, typename Fn>
 Tensor convert_tensor(const Tensor& input_tensor, const Fn& compute, const TensorSpec& output_spec) {
@@ -166,7 +179,10 @@ Tensor prepare_conv3d_weights(
     auto out_channels = weights_shape[4];
 
     if (C_in_block == 0) {
-        C_in_block = C_in_aligned;
+        // Default to the minimal valid block (same default conv3d uses) rather than a
+        // full channel block, so the prepared weight fits in L1 for large kernels and
+        // its K-row blocking matches the conv compute's default (issues #42146, #47316).
+        C_in_block = std::min(default_c_in_block(kD * kH * kW), static_cast<uint32_t>(C_in_aligned));
     }
     uint32_t num_C_in_blocks = C_in_aligned / C_in_block;
     TT_FATAL(num_C_in_blocks * C_in_block == C_in_aligned, "C_in_aligned must be divisible by C_in_block");

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/prepare_conv3d_weights.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/prepare_conv3d_weights.hpp
@@ -17,6 +17,13 @@
 
 namespace ttnn::operations::experimental::conv3d {
 
+// Minimal valid C_in_block for a conv3d with the given kernel volume (kD*kH*kW).
+// It satisfies weight tile-alignment (kernel_vol * C_in_block divisible by
+// TILE_WIDTH) and L1 alignment, and is the smallest such value -> smallest
+// circular buffers. Used as the shared default in both prepare_conv3d_weights
+// and conv3d so their K-row blocking always agrees (issues #42146, #47316).
+uint32_t default_c_in_block(uint32_t kernel_vol);
+
 Tensor convert_conv_weight_tensor_to_grouped_layout(
     const Tensor& conv_weight_tensor, uint32_t num_groups, DataType output_dtype);
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`ttnn::experimental::conv3d` overflows L1 when called with a **pre-prepared (rank-2) weight** and **no `Conv3dConfig`**, for large kernels such as the Qwen2.5-VL vision patch-embed (`C_in=3`, kernel = stride = `(2,14,14)`, `out=1280`):

```
TT_THROW: Statically allocated circular buffers on core range [(x=0,y=0) - (x=7,y=7)]
grow to 1739040 B which is beyond max L1 size of 1499136 B
```

**Root cause.** #43715 set the auto-blocking (rank-5) default `C_in_block` to the *minimal valid* value (`lcm(l1_alignment, TILE_WIDTH / gcd(kernel_vol, TILE_WIDTH))`), fixing the overflow on that path (#42146). #47343 then fixed a near-zero-PCC mismatch (#47316) by setting the **rank-2 (pre-prepared)** default to `0` = *full channel block*, to match `prepare_conv3d_weights`' own `0`-default. But a full block puts the whole `K = kernel_vol · C_in_aligned` reduction (12544 for Qwen) into one matmul block, so the `vol2col`/`weight` circular buffers exceed L1 — re-introducing #42146 on the pre-prepared path. The prepared weight carries no blocking metadata, so validation can't catch it.

**Fix.** Make `C_in_block == 0` mean *"the minimal valid block"* (not "full block") consistently in both surfaces, via one shared `default_c_in_block(kernel_vol)` helper:
- `prepare_conv3d_weights`: `0` → minimal block instead of `C_in_aligned`.
- `conv3d`: both rank-2 and rank-5 default to the same `default_c_in_block(...)`, so the prepared weight's K-row blocking always matches the conv compute (dropping #47343's rank-2 special case).

Prepare-default and conv-default are now identical by construction → no PCC mismatch (#47316) and no overflow (#42146). The prepared-weight shape is unchanged (`C_in_block` cancels out of the row count), so this is not a layout-format change.

Fixes #48149.
Relates to #42146, #47316, #43715.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sonalib/conv3d-default-min-cin-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sonalib/conv3d-default-min-cin-block)
**Note: The sanity failure is in test_to_layout_fp8_input_to_tile (FP8 → TILE to_layout). This PR changes only conv3d code and touches no to_layout/FP8/tilize code, so these worker crashes are unrelated to this change.**
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sonalib/conv3d-default-min-cin-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sonalib/conv3d-default-min-cin-block)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sonalib/conv3d-default-min-cin-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sonalib/conv3d-default-min-cin-block)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sonalib/conv3d-default-min-cin-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sonalib/conv3d-default-min-cin-block)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sonalib/conv3d-default-min-cin-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sonalib/conv3d-default-min-cin-block)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sonalib/conv3d-default-min-cin-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sonalib/conv3d-default-min-cin-block)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sonalib/conv3d-default-min-cin-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sonalib/conv3d-default-min-cin-block)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sonalib/conv3d-default-min-cin-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sonalib/conv3d-default-min-cin-block)