### PR TITLE
Feat: uint8 support for Quantize Ops

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/test_quantization.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/test_quantization.py
@@ -624,9 +624,9 @@ def test_quant_dequant_requant_uint8_per_tensor_2d(device, x0, x1, input_dtype, 
     check_match_ratio(input_tr, result_rq, input_dtype)
 
 
-def test_quantize_uint8_saturation(device):
-    """Test quantize uint8 saturation to [0, 255]"""
-    row = [-5.0, -1.0, -0.2, 0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 2.0, 5.0]
+def test_quantize_uint8_upper_saturation(device):
+    """Test quantize uint8 upper saturation to 255"""
+    row = [0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 2.0, 5.0]
     input_tr = torch.tensor([row], dtype=torch.float32)
     scale, zero_point = 1.0 / 255.0, 0
     expected = torch.clamp(torch.round(input_tr / scale + zero_point), 0, 255).to(torch.uint8)
@@ -638,9 +638,9 @@ def test_quantize_uint8_saturation(device):
     assert torch.equal(result, expected), f"got {result.tolist()} expected {expected.tolist()}"
 
 
-def test_requantize_uint8_saturation(device):
-    """Test requantize uint8 saturation to [0, 255] on the output side"""
-    q_in = torch.tensor([[0, 50, 100, 200, 255, 300, 1000, -10]], dtype=torch.int32)
+def test_requantize_uint8_upper_saturation(device):
+    """Test requantize uint8 upper saturation to 255 on the output side"""
+    q_in = torch.tensor([[0, 50, 100, 200, 255, 300, 1000]], dtype=torch.int32)
     in_scale, in_zp, out_scale, out_zp = 1.0, 0, 1.0, 0
     expected = torch.clamp(torch.round((q_in - in_zp) * in_scale / out_scale + out_zp), 0, 255).to(torch.uint8)
 

--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/test_quantization.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/test_quantization.py
@@ -588,3 +588,36 @@ def test_requant_all_tensors_per_channel_to_per_tensor_2d(device, x0, x1, input_
     result_tr = ttnn.to_torch(derequantized_tt)
     check_pcc(input_tr, result_tr, True)
     check_match_ratio(input_tr, result_tr, input_dtype)
+
+
+# Option A uint8 output probe: q_max=127 stays inside the SFPU's internal FP32_TO_INT8 clamp,
+# while q_max=255 exercises the full uint8 range and reveals whether the int8 clamp / packer
+# narrowing prevents exact uint8 results (which would push us to Option B).
+@pytest.mark.parametrize("x0", [32, 128])
+@pytest.mark.parametrize("x1", [32, 128])
+@pytest.mark.parametrize("input_dtype", [ttnn.float32, ttnn.bfloat16])
+@pytest.mark.parametrize("q_max", [127, 255])
+def test_quant_uint8_per_tensor_2d(device, x0, x1, input_dtype, q_max):
+    torch.manual_seed(0)
+    input_tr = torch.rand(x0, x1, dtype=torch.float32)
+    scale, zero_point = calculate_scale_zero_point_per_tensor(input_tr, 0, q_max)
+
+    quantized_tr = torch.quantize_per_tensor(input_tr, scale, zero_point, dtype=torch.quint8)
+    golden = quantized_tr.int_repr().to(torch.int32)
+
+    input_tt = ttnn.from_torch(input_tr, dtype=input_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    quantized_tt = ttnn.quantize(input_tt, scale, zero_point, dtype=ttnn.uint8)
+
+    assert quantized_tt.dtype == ttnn.uint8
+    result_tr = ttnn.to_torch(quantized_tt).to(torch.int32)
+
+    exact_ratio = (golden == result_tr).float().mean().item()
+    close_ratio = ((golden - result_tr).abs() <= 1).float().mean().item()
+    max_abs_err = (golden - result_tr).abs().max().item()
+    print(f"uint8 quant q_max={q_max} dtype={input_dtype}: exact_ratio={exact_ratio:.4f} max_abs_err={max_abs_err}")
+    if input_dtype == ttnn.float32:
+        # fp32 input must round identically to torch and narrow exactly to uint8.
+        assert exact_ratio == 1.0, f"exact_ratio={exact_ratio} max_abs_err={max_abs_err}"
+    else:
+        # bf16 input loses mantissa precision, so allow round-half-to-even off-by-one vs torch's fp32.
+        assert close_ratio > 0.99, f"close_ratio={close_ratio} max_abs_err={max_abs_err}"

--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/test_quantization.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/test_quantization.py
@@ -590,34 +590,87 @@ def test_requant_all_tensors_per_channel_to_per_tensor_2d(device, x0, x1, input_
     check_match_ratio(input_tr, result_tr, input_dtype)
 
 
-# Option A uint8 output probe: q_max=127 stays inside the SFPU's internal FP32_TO_INT8 clamp,
-# while q_max=255 exercises the full uint8 range and reveals whether the int8 clamp / packer
-# narrowing prevents exact uint8 results (which would push us to Option B).
 @pytest.mark.parametrize("x0", [32, 128])
 @pytest.mark.parametrize("x1", [32, 128])
 @pytest.mark.parametrize("input_dtype", [ttnn.float32, ttnn.bfloat16])
 @pytest.mark.parametrize("q_max", [127, 255])
-def test_quant_uint8_per_tensor_2d(device, x0, x1, input_dtype, q_max):
+def test_quant_dequant_requant_uint8_per_tensor_2d(device, x0, x1, input_dtype, q_max):
+    """Test quantize, dequantize and requantize (per-tensor) for uint8"""
     torch.manual_seed(0)
     input_tr = torch.rand(x0, x1, dtype=torch.float32)
     scale, zero_point = calculate_scale_zero_point_per_tensor(input_tr, 0, q_max)
 
     quantized_tr = torch.quantize_per_tensor(input_tr, scale, zero_point, dtype=torch.quint8)
-    golden = quantized_tr.int_repr().to(torch.int32)
 
     input_tt = ttnn.from_torch(input_tr, dtype=input_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     quantized_tt = ttnn.quantize(input_tt, scale, zero_point, dtype=ttnn.uint8)
-
     assert quantized_tt.dtype == ttnn.uint8
-    result_tr = ttnn.to_torch(quantized_tt).to(torch.int32)
+    result_q = ttnn.to_torch(quantized_tt)
+    check_pcc(quantized_tr.int_repr(), result_q, False)
+    check_match_ratio(quantized_tr, result_q, ttnn.uint8)
 
-    exact_ratio = (golden == result_tr).float().mean().item()
-    close_ratio = ((golden - result_tr).abs() <= 1).float().mean().item()
-    max_abs_err = (golden - result_tr).abs().max().item()
-    print(f"uint8 quant q_max={q_max} dtype={input_dtype}: exact_ratio={exact_ratio:.4f} max_abs_err={max_abs_err}")
-    if input_dtype == ttnn.float32:
-        # fp32 input must round identically to torch and narrow exactly to uint8.
-        assert exact_ratio == 1.0, f"exact_ratio={exact_ratio} max_abs_err={max_abs_err}"
-    else:
-        # bf16 input loses mantissa precision, so allow round-half-to-even off-by-one vs torch's fp32.
-        assert close_ratio > 0.99, f"close_ratio={close_ratio} max_abs_err={max_abs_err}"
+    dequantized_tr = torch.dequantize(quantized_tr)
+    dequantized_tt = ttnn.dequantize(quantized_tt, scale, zero_point, dtype=input_dtype)
+    result_dq = ttnn.to_torch(dequantized_tt)
+    check_pcc(dequantized_tr, result_dq, False)
+    check_match_ratio(dequantized_tr, result_dq, input_dtype)
+
+    scale_r, zero_point_r = calculate_scale_zero_point_per_tensor(input_tr, 0, 200)
+    requantized_tt = ttnn.requantize(quantized_tt, scale, zero_point, scale_r, zero_point_r, dtype=ttnn.uint8)
+    assert requantized_tt.dtype == ttnn.uint8
+    rederequantized_tt = ttnn.dequantize(requantized_tt, scale_r, zero_point_r, dtype=input_dtype)
+    result_rq = ttnn.to_torch(rederequantized_tt)
+    check_pcc(input_tr, result_rq, True)
+    check_match_ratio(input_tr, result_rq, input_dtype)
+
+
+def test_quantize_uint8_saturation(device):
+    """Test quantize uint8 saturation to [0, 255]"""
+    row = [-5.0, -1.0, -0.2, 0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 2.0, 5.0]
+    input_tr = torch.tensor([row], dtype=torch.float32)
+    scale, zero_point = 1.0 / 255.0, 0
+    expected = torch.clamp(torch.round(input_tr / scale + zero_point), 0, 255).to(torch.uint8)
+
+    input_tt = ttnn.from_torch(input_tr, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    out_tt = ttnn.quantize(input_tt, scale, zero_point, dtype=ttnn.uint8)
+    assert out_tt.dtype == ttnn.uint8
+    result = ttnn.to_torch(out_tt)
+    assert torch.equal(result, expected), f"got {result.tolist()} expected {expected.tolist()}"
+
+
+def test_requantize_uint8_saturation(device):
+    """Test requantize uint8 saturation to [0, 255] on the output side"""
+    q_in = torch.tensor([[0, 50, 100, 200, 255, 300, 1000, -10]], dtype=torch.int32)
+    in_scale, in_zp, out_scale, out_zp = 1.0, 0, 1.0, 0
+    expected = torch.clamp(torch.round((q_in - in_zp) * in_scale / out_scale + out_zp), 0, 255).to(torch.uint8)
+
+    q_in_tt = ttnn.from_torch(q_in, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+    out_tt = ttnn.requantize(q_in_tt, in_scale, in_zp, out_scale, out_zp, dtype=ttnn.uint8)
+    assert out_tt.dtype == ttnn.uint8
+    result = ttnn.to_torch(out_tt)
+    assert torch.equal(result, expected), f"got {result.tolist()} expected {expected.tolist()}"
+
+
+@pytest.mark.parametrize("in_dtype,in_q_max", [(ttnn.int32, 127), (ttnn.uint8, 255)])
+@pytest.mark.parametrize("out_dtype,out_q_max", [(ttnn.int32, 127), (ttnn.uint8, 255)])
+def test_requant_uint8_mixed_dtype_per_tensor_2d(device, in_dtype, in_q_max, out_dtype, out_q_max):
+    """Test requant across int32/uint8 input and output dtype combinations (per-tensor)"""
+    torch.manual_seed(0)
+    input_tr = torch.rand(64, 64, dtype=torch.float32)
+
+    in_q_min = 0 if in_dtype == ttnn.uint8 else -128
+    scale, zero_point = calculate_scale_zero_point_per_tensor(input_tr, in_q_min, in_q_max)
+
+    input_tt = ttnn.from_torch(input_tr, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    quantized_tt = ttnn.quantize(input_tt, scale, zero_point, dtype=in_dtype)
+    assert quantized_tt.dtype == in_dtype
+
+    out_q_min = 0 if out_dtype == ttnn.uint8 else -100
+    scale_r, zero_point_r = calculate_scale_zero_point_per_tensor(input_tr, out_q_min, out_q_max)
+    requantized_tt = ttnn.requantize(quantized_tt, scale, zero_point, scale_r, zero_point_r, dtype=out_dtype)
+    assert requantized_tt.dtype == out_dtype
+
+    dequantized_tt = ttnn.dequantize(requantized_tt, scale_r, zero_point_r, dtype=ttnn.float32)
+    result_tr = ttnn.to_torch(dequantized_tt)
+    check_pcc(input_tr, result_tr, True)
+    check_match_ratio(input_tr, result_tr, ttnn.float32)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
@@ -22,9 +22,12 @@ namespace ckernel::sfpu {
 // invocation of the matching _{quant,requant,dequant}_int32_ kernel. The
 // two SIGN_MAGNITUDE_FORMAT variants of a given kernel safely share its
 // slot - the init writes whichever variant it was templated for and the
-// kernel uses the matching REPLAY_LEN. Distinct slots between kernels are
-// required so a single compute kernel can mix all three ops without each
-// init clobbering the others' recordings.
+// kernel uses the matching REPLAY_LEN. The IS_UNSIGNED (uint8 output) quant/
+// requant variant safely shares the slot for the same reason: it only swaps
+// the STOCH_RND rounding mode (FP32_TO_UINT8 vs FP32_TO_INT8), which does not
+// change the body length. Distinct slots between kernels are required so a single compute
+// kernel can mix all three ops without each init clobbering the others'
+// recordings.
 //
 // Body content (see the inits for the exact emission order). No SFPNOPs are
 // emitted: on Blackhole the SFPU implicitly stalls on read-after-write
@@ -101,8 +104,7 @@ void quant_init(const uint zero_point) {
         TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::LREG0, 0 /*mod1*/);
         // fp32 -> int. LCONST_0 (LREG9) is the HW-provided 0.0 used as the zero
         // descale. For unsigned (uint8) output, round into the full [0, 255]
-        // range; otherwise clamp to signed int8 [-128, 127]. The recorded body
-        // length is identical either way, so REPLAY_LEN accounting is unaffected.
+        // range, else clamp to signed int8 [-128, 127].
         if constexpr (IS_UNSIGNED) {
             TTI_SFP_STOCH_RND(
                 sfpi::SFPSTOCHRND_RND_EVEN,
@@ -120,23 +122,28 @@ void quant_init(const uint zero_point) {
                 p_sfpu::LREG0,
                 sfpi::SFPSTOCHRND_MOD1_FP32_TO_INT8);
         }
-        // Unsigned uint8 values are non-negative, so the sign-magnitude <-> 2's
-        // complement fix-up below is a no-op for them; it only matters for the
-        // signed int8 path.
         if constexpr (!SIGN_MAGNITUDE_FORMAT) {
-            // STOCH_RND output above is in sign-magnitude form; convert to
-            // 2's-complement so the trailing INT32_2S_COMP SFPSTORE writes
-            // out 2's-complement bits (on BH the store mode itself is a
-            // no-op, so the bits in LREG0 are what land in memory). LREG4
-            // is the helper's scratch destination; LREG0 receives the
-            // sign-fixed result. See INT_REPR_SWAP_CAST above for why the
-            // cast mode constant is direction-neutral.
+            // Convert STOCH_RND's sign-magnitude output to 2's-complement so the
+            // trailing INT32_2S_COMP SFPSTORE writes out 2's-complement bits
+            // (on BH the store mode itself is a no-op, so the bits in LREG0 are
+            // what land in memory). LREG4 is the helper's scratch destination;
+            // LREG0 receives the sign-fixed result. See INT_REPR_SWAP_CAST above
+            // for why the cast mode constant is direction-neutral.
+            //
+            // Signed (FP32_TO_INT8) output is sign-magnitude here, so the
+            // conversion is meaningful. Unsigned (IS_UNSIGNED, FP32_TO_UINT8)
+            // output is already in [0, 255] with bit 31 clear, where
+            // sign-magnitude and 2's-complement are bit-identical, so this is a
+            // no-op for uint8. It runs unconditionally so both paths share
+            // QUANT_REPLAY_LEN_2S_COMP; gating it off for unsigned would need a
+            // dedicated REPLAY_LEN. Revisit if apply_sign_magnitude_conversion
+            // stops being a no-op for bit-31-clear inputs.
             apply_sign_magnitude_conversion(p_sfpu::LREG0, p_sfpu::LREG4, INT_REPR_SWAP_CAST);
         }
     }
 }
 
-template <bool APPROXIMATION_MODE /*unused*/, bool SIGN_MAGNITUDE_FORMAT = false>
+template <bool APPROXIMATION_MODE /*unused*/, bool SIGN_MAGNITUDE_FORMAT = false, bool IS_UNSIGNED = false>
 void requant_init(const uint zero_point) {
     // One-time setup for requant_int32; see quant_init for the
     // record/replay rationale. Loads the zero point into LREG2, programs
@@ -166,18 +173,39 @@ void requant_init(const uint zero_point) {
         // stalls STOCH_RND below until SFPMAD's LREG0 write retires, so no
         // explicit pipeline-bubble TTI_SFPNOP is needed here.
         TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::LREG0, 0 /*mod1*/);
-        // fp32 -> int sign-magnitude. LCONST_0 (LREG9) provides the 0.0 descale.
-        TTI_SFP_STOCH_RND(
-            sfpi::SFPSTOCHRND_RND_EVEN,
-            0 /*imm8*/,
-            p_sfpu::LCONST_0,
-            p_sfpu::LREG0,
-            p_sfpu::LREG0,
-            sfpi::SFPSTOCHRND_MOD1_FP32_TO_INT8);
+        // fp32 -> int. LCONST_0 (LREG9) provides the 0.0 descale. For unsigned
+        // (uint8) output, round into the full [0, 255] range; otherwise clamp to
+        // signed int8 [-128, 127].
+        if constexpr (IS_UNSIGNED) {
+            TTI_SFP_STOCH_RND(
+                sfpi::SFPSTOCHRND_RND_EVEN,
+                0 /*imm8*/,
+                p_sfpu::LCONST_0,
+                p_sfpu::LREG0,
+                p_sfpu::LREG0,
+                sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT8);
+        } else {
+            TTI_SFP_STOCH_RND(
+                sfpi::SFPSTOCHRND_RND_EVEN,
+                0 /*imm8*/,
+                p_sfpu::LCONST_0,
+                p_sfpu::LREG0,
+                p_sfpu::LREG0,
+                sfpi::SFPSTOCHRND_MOD1_FP32_TO_INT8);
+        }
         if constexpr (!SIGN_MAGNITUDE_FORMAT) {
-            // STOCH_RND output is sign-magnitude; convert to 2's-complement
-            // for the trailing INT32_2S_COMP SFPSTORE. Same cast+SETSGN
-            // combo as the input side; see INT_REPR_SWAP_CAST above.
+            // Convert STOCH_RND's output to 2's-complement for the trailing
+            // INT32_2S_COMP SFPSTORE. Same cast+SETSGN combo as the input side;
+            // see INT_REPR_SWAP_CAST above.
+            //
+            // Signed (FP32_TO_INT8) output is sign-magnitude here, so the
+            // conversion is meaningful. Unsigned (IS_UNSIGNED, FP32_TO_UINT8)
+            // output is already in [0, 255] with bit 31 clear, where
+            // sign-magnitude and 2's-complement are bit-identical, so this is a
+            // no-op for uint8. It runs unconditionally for the same
+            // replay-length reason documented in quant_init's output-side
+            // conversion above; revisit if apply_sign_magnitude_conversion
+            // stops being a no-op for bit-31-clear inputs.
             apply_sign_magnitude_conversion(p_sfpu::LREG0, p_sfpu::LREG4, INT_REPR_SWAP_CAST);
         }
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
@@ -77,7 +77,7 @@ inline void _quant_kernels_configure_dest_incr_addrmod_() {
         .set(ADDR_MOD_6);
 }
 
-template <bool APPROXIMATION_MODE /*unused*/, bool SIGN_MAGNITUDE_FORMAT = false>
+template <bool APPROXIMATION_MODE /*unused*/, bool SIGN_MAGNITUDE_FORMAT = false, bool IS_UNSIGNED = false>
 void quant_init(const uint zero_point) {
     // One-time setup for calculate_quant_int32:
     //   1. load the fp32 zero-point constant into LREG2;
@@ -99,15 +99,30 @@ void quant_init(const uint zero_point) {
         // implicitly stalls SFP_STOCH_RND below until SFPMAD's LREG0 write
         // retires, so no explicit pipeline-bubble TTI_SFPNOP is needed here.
         TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::LREG0, 0 /*mod1*/);
-        // fp32 -> int sign-magnitude. LCONST_0 (LREG9) is the HW-provided 0.0
-        // used as the zero descale.
-        TTI_SFP_STOCH_RND(
-            sfpi::SFPSTOCHRND_RND_EVEN,
-            0 /*imm8*/,
-            p_sfpu::LCONST_0,
-            p_sfpu::LREG0,
-            p_sfpu::LREG0,
-            sfpi::SFPSTOCHRND_MOD1_FP32_TO_INT8);
+        // fp32 -> int. LCONST_0 (LREG9) is the HW-provided 0.0 used as the zero
+        // descale. For unsigned (uint8) output, round into the full [0, 255]
+        // range; otherwise clamp to signed int8 [-128, 127]. The recorded body
+        // length is identical either way, so REPLAY_LEN accounting is unaffected.
+        if constexpr (IS_UNSIGNED) {
+            TTI_SFP_STOCH_RND(
+                sfpi::SFPSTOCHRND_RND_EVEN,
+                0 /*imm8*/,
+                p_sfpu::LCONST_0,
+                p_sfpu::LREG0,
+                p_sfpu::LREG0,
+                sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT8);
+        } else {
+            TTI_SFP_STOCH_RND(
+                sfpi::SFPSTOCHRND_RND_EVEN,
+                0 /*imm8*/,
+                p_sfpu::LCONST_0,
+                p_sfpu::LREG0,
+                p_sfpu::LREG0,
+                sfpi::SFPSTOCHRND_MOD1_FP32_TO_INT8);
+        }
+        // Unsigned uint8 values are non-negative, so the sign-magnitude <-> 2's
+        // complement fix-up below is a no-op for them; it only matters for the
+        // signed int8 path.
         if constexpr (!SIGN_MAGNITUDE_FORMAT) {
             // STOCH_RND output above is in sign-magnitude form; convert to
             // 2's-complement so the trailing INT32_2S_COMP SFPSTORE writes

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
@@ -22,8 +22,8 @@ namespace ckernel::sfpu {
 // invocation of the matching _{quant,requant,dequant}_int32_ kernel. The
 // two SIGN_MAGNITUDE_FORMAT variants of a given kernel safely share its
 // slot - the init writes whichever variant it was templated for and the
-// kernel uses the matching REPLAY_LEN. The IS_UNSIGNED (uint8 output) quant/
-// requant variant safely shares the slot for the same reason: it only swaps
+// kernel uses the matching REPLAY_LEN. The OUTPUT_FORMAT == UInt8 (uint8 output)
+// quant/requant variant safely shares the slot for the same reason: it only swaps
 // the STOCH_RND rounding mode (FP32_TO_UINT8 vs FP32_TO_INT8), which does not
 // change the body length. Distinct slots between kernels are required so a single compute
 // kernel can mix all three ops without each init clobbering the others'
@@ -80,8 +80,18 @@ inline void _quant_kernels_configure_dest_incr_addrmod_() {
         .set(ADDR_MOD_6);
 }
 
-template <bool APPROXIMATION_MODE /*unused*/, bool SIGN_MAGNITUDE_FORMAT = false, bool IS_UNSIGNED = false>
+// OUTPUT_FORMAT selects the quantized output tensor dtype. Only the two dtypes
+// ttnn exposes for quantize output are supported: Int32 (the default) and UInt8.
+// Int32 rounds via FP32_TO_INT8 - i.e. int8-range values [-128, 127] held in an
+// int32 container - while UInt8 rounds via FP32_TO_UINT8 into [0, 255].
+template <
+    bool APPROXIMATION_MODE /*unused*/,
+    bool SIGN_MAGNITUDE_FORMAT = false,
+    DataFormat OUTPUT_FORMAT = DataFormat::Int32>
 void quant_init(const uint zero_point) {
+    static_assert(
+        OUTPUT_FORMAT == DataFormat::Int32 || OUTPUT_FORMAT == DataFormat::UInt8,
+        "quant_init OUTPUT_FORMAT must be Int32 or UInt8");
     // One-time setup for calculate_quant_int32:
     //   1. load the fp32 zero-point constant into LREG2;
     //   2. program ADDR_MOD_6 with dest+=2 for the per-iteration SFPSTORE;
@@ -105,7 +115,7 @@ void quant_init(const uint zero_point) {
         // fp32 -> int. LCONST_0 (LREG9) is the HW-provided 0.0 used as the zero
         // descale. For unsigned (uint8) output, round into the full [0, 255]
         // range, else clamp to signed int8 [-128, 127].
-        if constexpr (IS_UNSIGNED) {
+        if constexpr (OUTPUT_FORMAT == DataFormat::UInt8) {
             TTI_SFP_STOCH_RND(
                 sfpi::SFPSTOCHRND_RND_EVEN,
                 0 /*imm8*/,
@@ -131,7 +141,7 @@ void quant_init(const uint zero_point) {
             // for why the cast mode constant is direction-neutral.
             //
             // Signed (FP32_TO_INT8) output is sign-magnitude here, so the
-            // conversion is meaningful. Unsigned (IS_UNSIGNED, FP32_TO_UINT8)
+            // conversion is meaningful. Unsigned (UInt8, FP32_TO_UINT8)
             // output is already in [0, 255] with bit 31 clear, where
             // sign-magnitude and 2's-complement are bit-identical, so this is a
             // no-op for uint8. It runs unconditionally so both paths share
@@ -143,8 +153,14 @@ void quant_init(const uint zero_point) {
     }
 }
 
-template <bool APPROXIMATION_MODE /*unused*/, bool SIGN_MAGNITUDE_FORMAT = false, bool IS_UNSIGNED = false>
+template <
+    bool APPROXIMATION_MODE /*unused*/,
+    bool SIGN_MAGNITUDE_FORMAT = false,
+    DataFormat OUTPUT_FORMAT = DataFormat::Int32>
 void requant_init(const uint zero_point) {
+    static_assert(
+        OUTPUT_FORMAT == DataFormat::Int32 || OUTPUT_FORMAT == DataFormat::UInt8,
+        "requant_init OUTPUT_FORMAT must be Int32 or UInt8");
     // One-time setup for requant_int32; see quant_init for the
     // record/replay rationale. Loads the zero point into LREG2, programs
     // ADDR_MOD_6 with dest+=2, then records the register-only compute into
@@ -176,7 +192,7 @@ void requant_init(const uint zero_point) {
         // fp32 -> int. LCONST_0 (LREG9) provides the 0.0 descale. For unsigned
         // (uint8) output, round into the full [0, 255] range; otherwise clamp to
         // signed int8 [-128, 127].
-        if constexpr (IS_UNSIGNED) {
+        if constexpr (OUTPUT_FORMAT == DataFormat::UInt8) {
             TTI_SFP_STOCH_RND(
                 sfpi::SFPSTOCHRND_RND_EVEN,
                 0 /*imm8*/,
@@ -199,7 +215,7 @@ void requant_init(const uint zero_point) {
             // see INT_REPR_SWAP_CAST above.
             //
             // Signed (FP32_TO_INT8) output is sign-magnitude here, so the
-            // conversion is meaningful. Unsigned (IS_UNSIGNED, FP32_TO_UINT8)
+            // conversion is meaningful. Unsigned (UInt8, FP32_TO_UINT8)
             // output is already in [0, 255] with bit 31 clear, where
             // sign-magnitude and 2's-complement are bit-identical, so this is a
             // no-op for uint8. It runs unconditionally for the same

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
@@ -183,8 +183,14 @@ inline void calculate_dequant_int32(const uint dst_index_in0, const uint dst_ind
     }
 }
 
-template <bool APPROXIMATION_MODE /*unused*/, bool SIGN_MAGNITUDE_FORMAT /*unused*/ = false, bool IS_UNSIGNED = false>
+template <
+    bool APPROXIMATION_MODE /*unused*/,
+    bool SIGN_MAGNITUDE_FORMAT /*unused*/ = false,
+    DataFormat OUTPUT_FORMAT = DataFormat::Int32>
 void quant_init(const uint zero_point) {
+    static_assert(
+        OUTPUT_FORMAT == DataFormat::Int32 || OUTPUT_FORMAT == DataFormat::UInt8,
+        "quant_init OUTPUT_FORMAT must be Int32 or UInt8");
     // One-time setup for calculate_quant:
     //   1. load the fp32 zero-point constant into LREG2;
     //   2. program ADDR_MOD_6 with dest+=2 for the per-iteration SFPSTORE;
@@ -215,7 +221,7 @@ void quant_init(const uint zero_point) {
         // fp32 -> int. LCONST_0 (LREG9) is the HW-provided 0.0 used as the zero
         // descale. For unsigned (uint8) output, round into the full [0, 255]
         // range; otherwise clamp to signed int8 [-128, 127].
-        if constexpr (IS_UNSIGNED) {
+        if constexpr (OUTPUT_FORMAT == DataFormat::UInt8) {
             TTI_SFP_STOCH_RND(
                 sfpi::SFPSTOCHRND_RND_EVEN,
                 0 /*imm8*/,
@@ -235,8 +241,14 @@ void quant_init(const uint zero_point) {
     }
 }
 
-template <bool APPROXIMATION_MODE /*unused*/, bool SIGN_MAGNITUDE_FORMAT /*unused*/ = false, bool IS_UNSIGNED = false>
+template <
+    bool APPROXIMATION_MODE /*unused*/,
+    bool SIGN_MAGNITUDE_FORMAT /*unused*/ = false,
+    DataFormat OUTPUT_FORMAT = DataFormat::Int32>
 void requant_init(const uint zero_point) {
+    static_assert(
+        OUTPUT_FORMAT == DataFormat::Int32 || OUTPUT_FORMAT == DataFormat::UInt8,
+        "requant_init OUTPUT_FORMAT must be Int32 or UInt8");
     // One-time setup for calculate_requant; see quant_init for the
     // record/replay rationale. Loads the zero point into LREG2, programs
     // ADDR_MOD_6 with dest+=2, then records the register-only compute into
@@ -261,7 +273,7 @@ void requant_init(const uint zero_point) {
         // fp32 -> int. LCONST_0 (LREG9) provides the 0.0 descale. For unsigned
         // (uint8) output, round into the full [0, 255] range; otherwise clamp to
         // signed int8 [-128, 127].
-        if constexpr (IS_UNSIGNED) {
+        if constexpr (OUTPUT_FORMAT == DataFormat::UInt8) {
             TTI_SFP_STOCH_RND(
                 sfpi::SFPSTOCHRND_RND_EVEN,
                 0 /*imm8*/,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
@@ -214,9 +214,7 @@ void quant_init(const uint zero_point) {
         TTI_SFPNOP;
         // fp32 -> int. LCONST_0 (LREG9) is the HW-provided 0.0 used as the zero
         // descale. For unsigned (uint8) output, round into the full [0, 255]
-        // range; otherwise clamp to signed int8 [-128, 127]. Only this rounding
-        // mode differs - the recorded body length is identical either way, so
-        // the QUANT_REPLAY_LEN accounting above is unaffected.
+        // range; otherwise clamp to signed int8 [-128, 127].
         if constexpr (IS_UNSIGNED) {
             TTI_SFP_STOCH_RND(
                 sfpi::SFPSTOCHRND_RND_EVEN,
@@ -237,7 +235,7 @@ void quant_init(const uint zero_point) {
     }
 }
 
-template <bool APPROXIMATION_MODE /*unused*/, bool SIGN_MAGNITUDE_FORMAT /*unused*/ = false>
+template <bool APPROXIMATION_MODE /*unused*/, bool SIGN_MAGNITUDE_FORMAT /*unused*/ = false, bool IS_UNSIGNED = false>
 void requant_init(const uint zero_point) {
     // One-time setup for calculate_requant; see quant_init for the
     // record/replay rationale. Loads the zero point into LREG2, programs
@@ -260,14 +258,26 @@ void requant_init(const uint zero_point) {
         // SFPNOP (not TTI_NOP) so the bubble lands in the SFPU pipe and the
         // recorded body contains only SFPU-pipe opcodes.
         TTI_SFPNOP;
-        // fp32 -> int sign-magnitude. LCONST_0 (LREG9) provides the 0.0 descale.
-        TTI_SFP_STOCH_RND(
-            sfpi::SFPSTOCHRND_RND_EVEN,
-            0 /*imm8*/,
-            p_sfpu::LCONST_0,
-            p_sfpu::LREG0,
-            p_sfpu::LREG0,
-            sfpi::SFPSTOCHRND_MOD1_FP32_TO_INT8);
+        // fp32 -> int. LCONST_0 (LREG9) provides the 0.0 descale. For unsigned
+        // (uint8) output, round into the full [0, 255] range; otherwise clamp to
+        // signed int8 [-128, 127].
+        if constexpr (IS_UNSIGNED) {
+            TTI_SFP_STOCH_RND(
+                sfpi::SFPSTOCHRND_RND_EVEN,
+                0 /*imm8*/,
+                p_sfpu::LCONST_0,
+                p_sfpu::LREG0,
+                p_sfpu::LREG0,
+                sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT8);
+        } else {
+            TTI_SFP_STOCH_RND(
+                sfpi::SFPSTOCHRND_RND_EVEN,
+                0 /*imm8*/,
+                p_sfpu::LCONST_0,
+                p_sfpu::LREG0,
+                p_sfpu::LREG0,
+                sfpi::SFPSTOCHRND_MOD1_FP32_TO_INT8);
+        }
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
@@ -183,7 +183,7 @@ inline void calculate_dequant_int32(const uint dst_index_in0, const uint dst_ind
     }
 }
 
-template <bool APPROXIMATION_MODE /*unused*/, bool SIGN_MAGNITUDE_FORMAT /*unused*/ = false>
+template <bool APPROXIMATION_MODE /*unused*/, bool SIGN_MAGNITUDE_FORMAT /*unused*/ = false, bool IS_UNSIGNED = false>
 void quant_init(const uint zero_point) {
     // One-time setup for calculate_quant:
     //   1. load the fp32 zero-point constant into LREG2;
@@ -212,15 +212,28 @@ void quant_init(const uint zero_point) {
         // only SFPU-pipe opcodes (a hard requirement for replay-buffer
         // playback - the replay buffer feeds the SFPU pipe directly).
         TTI_SFPNOP;
-        // fp32 -> int sign-magnitude. LCONST_0 (LREG9) is the HW-provided 0.0
-        // used as the zero descale.
-        TTI_SFP_STOCH_RND(
-            sfpi::SFPSTOCHRND_RND_EVEN,
-            0 /*imm8*/,
-            p_sfpu::LCONST_0,
-            p_sfpu::LREG0,
-            p_sfpu::LREG0,
-            sfpi::SFPSTOCHRND_MOD1_FP32_TO_INT8);
+        // fp32 -> int. LCONST_0 (LREG9) is the HW-provided 0.0 used as the zero
+        // descale. For unsigned (uint8) output, round into the full [0, 255]
+        // range; otherwise clamp to signed int8 [-128, 127]. Only this rounding
+        // mode differs - the recorded body length is identical either way, so
+        // the QUANT_REPLAY_LEN accounting above is unaffected.
+        if constexpr (IS_UNSIGNED) {
+            TTI_SFP_STOCH_RND(
+                sfpi::SFPSTOCHRND_RND_EVEN,
+                0 /*imm8*/,
+                p_sfpu::LCONST_0,
+                p_sfpu::LREG0,
+                p_sfpu::LREG0,
+                sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT8);
+        } else {
+            TTI_SFP_STOCH_RND(
+                sfpi::SFPSTOCHRND_RND_EVEN,
+                0 /*imm8*/,
+                p_sfpu::LCONST_0,
+                p_sfpu::LREG0,
+                p_sfpu::LREG0,
+                sfpi::SFPSTOCHRND_MOD1_FP32_TO_INT8);
+        }
     }
 }
 

--- a/tt_metal/hw/inc/api/compute/quantization.h
+++ b/tt_metal/hw/inc/api/compute/quantization.h
@@ -98,7 +98,7 @@ ALWI void quant_tile_init(const uint32_t zero_point) {
  * */
 // clang-format on
 ALWI void quant_uint8_tile_init(const uint32_t zero_point) {
-    MATH((SFPU_BINARY_INIT_FN_ARGS(quant_int32, sfpu::quant_init, (APPROX, false, true), zero_point)));
+    MATH((SFPU_BINARY_INIT_FN_ARGS(quant_int32, sfpu::quant_init, (APPROX, false, DataFormat::UInt8), zero_point)));
 }
 
 // clang-format off
@@ -130,7 +130,7 @@ ALWI void requant_tile_init(const uint32_t zero_point) {
  * */
 // clang-format on
 ALWI void requant_uint8_tile_init(const uint32_t zero_point) {
-    MATH((SFPU_BINARY_INIT_FN_ARGS(requant_int32, sfpu::requant_init, (APPROX, false, true), zero_point)));
+    MATH((SFPU_BINARY_INIT_FN_ARGS(requant_int32, sfpu::requant_init, (APPROX, false, DataFormat::UInt8), zero_point)));
 }
 
 // clang-format off

--- a/tt_metal/hw/inc/api/compute/quantization.h
+++ b/tt_metal/hw/inc/api/compute/quantization.h
@@ -87,10 +87,15 @@ ALWI void quant_tile_init(const uint32_t zero_point) {
 
 // clang-format off
 /**
- * Same as quant_tile_init, but configures the quant SFPU to round into the unsigned
- * uint8 range [0, 255] instead of the signed int8 range [-128, 127]. Pair with quant_tile
- * when the quantize op output dtype is uint8 (the packer narrows the int32 result to uint8).
- */
+ * Initialize the sfpu with the zero point argument of the quantization Op, rounding into the
+ * unsigned uint8 range [0, 255]. To be called once at beginning of a kernel.
+ *
+ * Return value: None
+ *
+ * | Argument   | Description                           | Data type | Valid range | Required |
+ * |------------|---------------------------------------|-----------|-------------|----------|
+ * | zero_point | The zero point of the quantization Op | uint32_t  | Any number  | Yes      |
+ * */
 // clang-format on
 ALWI void quant_uint8_tile_init(const uint32_t zero_point) {
     MATH((SFPU_BINARY_INIT_FN_ARGS(quant_int32, sfpu::quant_init, (APPROX, false, true), zero_point)));
@@ -110,6 +115,22 @@ ALWI void quant_uint8_tile_init(const uint32_t zero_point) {
 // clang-format on
 ALWI void requant_tile_init(const uint32_t zero_point) {
     MATH((SFPU_BINARY_INIT_FN_ARGS(requant_int32, sfpu::requant_init, (APPROX), zero_point)));
+}
+
+// clang-format off
+/**
+ * Initialize the sfpu with the zero point argument of the re-quantization Op, rounding into the
+ * unsigned uint8 range [0, 255]. To be called once at beginning of a kernel.
+ *
+ * Return value: None
+ *
+ * | Argument   | Description                              | Data type | Valid range | Required |
+ * |------------|------------------------------------------|-----------|-------------|----------|
+ * | zero_point | The zero point of the re-quantization Op | uint32_t  | Any number  | Yes      |
+ * */
+// clang-format on
+ALWI void requant_uint8_tile_init(const uint32_t zero_point) {
+    MATH((SFPU_BINARY_INIT_FN_ARGS(requant_int32, sfpu::requant_init, (APPROX, false, true), zero_point)));
 }
 
 // clang-format off

--- a/tt_metal/hw/inc/api/compute/quantization.h
+++ b/tt_metal/hw/inc/api/compute/quantization.h
@@ -87,6 +87,17 @@ ALWI void quant_tile_init(const uint32_t zero_point) {
 
 // clang-format off
 /**
+ * Same as quant_tile_init, but configures the quant SFPU to round into the unsigned
+ * uint8 range [0, 255] instead of the signed int8 range [-128, 127]. Pair with quant_tile
+ * when the quantize op output dtype is uint8 (the packer narrows the int32 result to uint8).
+ */
+// clang-format on
+ALWI void quant_uint8_tile_init(const uint32_t zero_point) {
+    MATH((SFPU_BINARY_INIT_FN_ARGS(quant_int32, sfpu::quant_init, (APPROX, false, true), zero_point)));
+}
+
+// clang-format off
+/**
  * Initialize the sfpu with the zero point argument of the re-quantization Op.
  * To be called once at beginning of a kernel.
  *

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_dtype_policy.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_dtype_policy.cpp
@@ -43,9 +43,9 @@ std::span<const DataType> supported_tensor_a_dtypes(BinaryOpType op) {
         case BinaryOpType::GCD:
         case BinaryOpType::LCM:
         case BinaryOpType::DIV_FLOOR:
-        case BinaryOpType::DIV_TRUNC:
+        case BinaryOpType::DIV_TRUNC: return int32_only;
         case BinaryOpType::REQUANT:
-        case BinaryOpType::DEQUANT: return int32_only;
+        case BinaryOpType::DEQUANT: return requant_dequant;
         case BinaryOpType::LOGADDEXP:
         case BinaryOpType::LOGADDEXP2:
         case BinaryOpType::LDEXP:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_dtype_policy.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_dtype_policy.hpp
@@ -25,6 +25,14 @@ inline constexpr std::array maximum_minimum{
 
 inline constexpr std::array int32_only{DT::INT32};
 
+// Allowed input (tensor A) dtypes for REQUANT/DEQUANT: an int32 quantized tile,
+// or a uint8 quantized tile that the unpacker widens to int32 in DST before the
+// SFPU casts it to fp32. QUANT is intentionally NOT mapped to this set: its
+// input A is the original floating-point tensor (float_only), and only its
+// *output* can be uint8 (narrowed by the packer / FP32_TO_UINT8 rounding). Do
+// not add BinaryOpType::QUANT here - that would wrongly accept integer inputs.
+inline constexpr std::array requant_dequant{DT::INT32, DT::UINT8};
+
 inline constexpr std::array bitwise_shift{DT::UINT32, DT::UINT16, DT::INT32};
 
 inline constexpr std::array logical_right_shift{DT::UINT32, DT::INT32};

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -443,13 +443,16 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
 
     auto compute_kernel_defines = op_config.as_defines(a_dtype);
 
-    // as_defines() keys the SFPU init off the input dtype, but quant rounding depends on the
-    // *output* dtype: for uint8 output we need fp32->uint8 rounding (full [0,255] range) instead
-    // of the default fp32->int8 ([-128,127]). The per-tile quant_tile op is unchanged; the packer
-    // narrows the int32 SFPU result to uint8.
-    if (operation_attributes.binary_op_type == BinaryOpType::QUANT && c_dtype == DataType::UINT8) {
-        compute_kernel_defines["BINARY_SFPU_INIT"] =
-            "quant_uint8_tile_init(get_arg_val<uint32_t>(QUANT_ZERO_POINT_RT_ARGS_IDX));";
+    // Quant/requant rounding depends on the output dtype. For uint8, we need fp32->uint8 rounding instead
+    // of the default fp32->int8. The packer narrows the int32 SFPU result to uint8.
+    if (c_dtype == DataType::UINT8) {
+        if (operation_attributes.binary_op_type == BinaryOpType::QUANT) {
+            compute_kernel_defines["BINARY_SFPU_INIT"] =
+                "quant_uint8_tile_init(get_arg_val<uint32_t>(QUANT_ZERO_POINT_RT_ARGS_IDX));";
+        } else if (operation_attributes.binary_op_type == BinaryOpType::REQUANT) {
+            compute_kernel_defines["BINARY_SFPU_INIT"] =
+                "requant_uint8_tile_init(get_arg_val<uint32_t>(QUANT_ZERO_POINT_RT_ARGS_IDX));";
+        }
     }
 
     // Indices 3 and 4 in the compute runtime args vector are reserved for rtol and atol bits.

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -443,6 +443,15 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
 
     auto compute_kernel_defines = op_config.as_defines(a_dtype);
 
+    // as_defines() keys the SFPU init off the input dtype, but quant rounding depends on the
+    // *output* dtype: for uint8 output we need fp32->uint8 rounding (full [0,255] range) instead
+    // of the default fp32->int8 ([-128,127]). The per-tile quant_tile op is unchanged; the packer
+    // narrows the int32 SFPU result to uint8.
+    if (operation_attributes.binary_op_type == BinaryOpType::QUANT && c_dtype == DataType::UINT8) {
+        compute_kernel_defines["BINARY_SFPU_INIT"] =
+            "quant_uint8_tile_init(get_arg_val<uint32_t>(QUANT_ZERO_POINT_RT_ARGS_IDX));";
+    }
+
     // Indices 3 and 4 in the compute runtime args vector are reserved for rtol and atol bits.
     if (operation_attributes.binary_op_type == BinaryOpType::ISCLOSE) {
         compute_kernel_defines["ISCLOSE_OP"] = "1";
@@ -718,7 +727,10 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
                             c_data_format == tt::DataFormat::Float32 || a_data_format == tt::DataFormat::Float32 ||
                             b_data_format == tt::DataFormat::Float32 ||
                             (a_data_format == tt::DataFormat::Int32 && b_data_format == tt::DataFormat::Int32) ||
-                            (a_data_format == tt::DataFormat::UInt32 && b_data_format == tt::DataFormat::UInt32);
+                            (a_data_format == tt::DataFormat::UInt32 && b_data_format == tt::DataFormat::UInt32) ||
+                            // Quant SFPU kernels compute on the fp32 input in DST; keep fp32 dest
+                            // accumulation regardless of the (possibly narrow, e.g. uint8) output format.
+                            operation_attributes.is_quant_op;
 
     uint32_t src0_cb_index = tt::CBIndex::c_0;
     uint32_t src1_cb_index = tt::CBIndex::c_1;

--- a/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
@@ -200,13 +200,15 @@ Tensor quantize(
                                : input_tensor;
 
     const DataType a_dtype = input_a.dtype();
-    constexpr DataType c_dtype = DataType::INT32;
+    // Option A: the packer narrows the int32 SFPU result to the requested output format, so we only
+    // need to thread the resolved output dtype through to BinaryNg / the composite typecast tails.
+    const DataType c_dtype = get_output_dtype(output_dtype, optional_output_tensor, DataType::INT32);
 
     TT_FATAL(tt::tt_metal::is_floating_point(a_dtype), "Quantize only takes floating-point number inputs");
-    TT_FATAL(output_dtype.value_or(c_dtype) == c_dtype, "Quantize only supports int32 outputs for now");
-    if (optional_output_tensor.has_value()) {
-        TT_FATAL(optional_output_tensor->dtype() == c_dtype, "Quantize only supports int32 outputs for now");
-    }
+    TT_FATAL(
+        c_dtype == DataType::INT32 || c_dtype == DataType::UINT8,
+        "Quantize only supports int32 or uint8 outputs for now, got {}",
+        c_dtype);
 
     constexpr ttsl::Span<const operations::unary::EltwiseUnaryWithParam> none{};
 

--- a/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
@@ -200,8 +200,7 @@ Tensor quantize(
                                : input_tensor;
 
     const DataType a_dtype = input_a.dtype();
-    // Option A: the packer narrows the int32 SFPU result to the requested output format, so we only
-    // need to thread the resolved output dtype through to BinaryNg / the composite typecast tails.
+
     const DataType c_dtype = get_output_dtype(output_dtype, optional_output_tensor, DataType::INT32);
 
     TT_FATAL(tt::tt_metal::is_floating_point(a_dtype), "Quantize only takes floating-point number inputs");
@@ -209,6 +208,11 @@ Tensor quantize(
         c_dtype == DataType::INT32 || c_dtype == DataType::UINT8,
         "Quantize only supports int32 or uint8 outputs for now, got {}",
         c_dtype);
+    // per-channel path narrows with ttnn::typecast(float, uint8), which wraps
+    // mod 256 instead of saturating, so reject it here.
+    TT_FATAL(
+        !(axis.has_value() && c_dtype == DataType::UINT8),
+        "Per-channel (axis) quantize does not support uint8 output yet; use int32 output or per-tensor quantize");
 
     constexpr ttsl::Span<const operations::unary::EltwiseUnaryWithParam> none{};
 
@@ -325,13 +329,20 @@ Tensor requantize(
     const std::optional<MemoryConfig>& memory_config,
     std::optional<Tensor> optional_output_tensor) {
     const DataType a_dtype = input_tensor.dtype();
-    constexpr DataType c_dtype = DataType::INT32;
+    const DataType c_dtype = get_output_dtype(output_dtype, optional_output_tensor, DataType::INT32);
 
-    TT_FATAL(a_dtype == DataType::INT32, "Requantize only supports int32 inputs for now");
-    TT_FATAL(output_dtype.value_or(c_dtype) == c_dtype, "Requantize only supports int32 outputs for now");
-    if (optional_output_tensor.has_value()) {
-        TT_FATAL(optional_output_tensor->dtype() == c_dtype, "Requantize only supports int32 outputs for now");
-    }
+    TT_FATAL(
+        a_dtype == DataType::INT32 || a_dtype == DataType::UINT8,
+        "Requantize only supports int32 or uint8 inputs for now, got {}",
+        a_dtype);
+    TT_FATAL(
+        c_dtype == DataType::INT32 || c_dtype == DataType::UINT8,
+        "Requantize only supports int32 or uint8 outputs for now, got {}",
+        c_dtype);
+
+    TT_FATAL(
+        !(axis.has_value() && c_dtype == DataType::UINT8),
+        "Per-channel (axis) requantize does not support uint8 output yet; use int32 output or per-tensor requantize");
 
     constexpr ttsl::Span<const operations::unary::EltwiseUnaryWithParam> none{};
 
@@ -469,7 +480,10 @@ Tensor dequantize(
     const DataType a_dtype = input_tensor.dtype();
     const DataType c_dtype = get_output_dtype(output_dtype, optional_output_tensor, DataType::BFLOAT16);
 
-    TT_FATAL(a_dtype == DataType::INT32, "Dequantize only supports int32 inputs for now");
+    TT_FATAL(
+        a_dtype == DataType::INT32 || a_dtype == DataType::UINT8,
+        "Dequantize only supports int32 or uint8 inputs for now, got {}",
+        a_dtype);
     TT_FATAL(
         c_dtype == DataType::FLOAT32 || c_dtype == DataType::BFLOAT16,
         "Dequantize only supports bf16/f32 outputs for now");


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/26414 https://github.com/tenstorrent/tt-metal/issues/48607

### Problem
ttnn.quantize, ttnn.dequantize, ttnn.requantize only accepts int32 for their quantized operand (float-only input for quantize, int32-only output for quantize/requantize, int32-only input for dequantize/requantize). 

### Summary
- The hardware packer already narrows the int32 SFPU result in DST down to a uint8 output tile and the unpacker widens a uint8 input tile up to int32 in DST. So allow uint8 through host/device validation and thread the resolved dtype to the program factory.
- Quant/requant SFPU uses a stochastic-round instruction in FP32_TO_INT8 mode, which rounds and saturates to signed [-128, 127]. The upper half is clamped to 127 because the clamp happens inside the SFPU before the packer runs. Here we use FP32_TO_UINT8 when the output dtype is uint8. 

Op | Direction | uint8 side | Handled by packer/unpacker | Needs rounding-mode fix
-- | -- | -- | -- | --
quantize | float → int | output | packer narrows int32→uint8 | Yes (output saturation)
dequantize | int → float | input | unpacker widens uint8→int32 | No (output is float; nothing to clamp)
requantize | int → int | input + output | both | Yes (output saturation only)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-integration-tests.yaml/badge.svg?branch=anasuya/quant_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-integration-tests.yaml?query=branch:anasuya/quant_ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=anasuya/quant_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:anasuya/quant_ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=anasuya/quant_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:anasuya/quant_ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=anasuya/quant_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:anasuya/quant_ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anasuya/quant_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anasuya/quant_ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=anasuya/quant_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:anasuya/quant_ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=anasuya/quant_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:anasuya/quant_ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=anasuya/quant_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:anasuya/quant_ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=anasuya/quant_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:anasuya/quant_ops)