### PR TITLE
precise pipeline prefill chunk timing + code_debug default for kimi

### DIFF
--- a/models/demos/deepseek_v3_d_p/scripts/plot_pipeline_trace.py
+++ b/models/demos/deepseek_v3_d_p/scripts/plot_pipeline_trace.py
@@ -29,12 +29,17 @@ from matplotlib.patches import FancyArrowPatch
 # Lines are MPI-tagged ([1,R]<stderr>:) and the message also carries [pp rank R]; key off the latter
 # so the parser is independent of the MPI tag.
 _CHUNK_START = re.compile(r"\[pp rank (\d+)\] CHUNK_START c=(\d+) compute_start=([\d.]+)")
+_CHUNK_COMPUTE = re.compile(r"\[pp rank (\d+)\] CHUNK_COMPUTE c=(\d+) compute_ms=([\d.]+)")
 _E2E = re.compile(r"\[pp rank (\d+)\] E2E_CLOCK first_compute_start=([\d.]+) last_compute_end=([\d.]+)")
 
 
 def parse(path):
-    """-> (starts[rank][chunk] = epoch, last_end[rank] = epoch)."""
+    """-> (starts[rank][chunk] = epoch, last_end[rank] = epoch, measured[rank][chunk] = compute seconds).
+
+    measured is populated only when the runner ran with PREFILL_SYNC_PER_CHUNK (CHUNK_COMPUTE lines) —
+    an exact per-chunk device compute, so the plot needs no downstream-start proxy or last-rank estimate."""
     starts = defaultdict(dict)
+    measured = defaultdict(dict)
     last_end = {}
     with open(path, errors="ignore") as f:
         for line in f:
@@ -42,12 +47,16 @@ def parse(path):
             if m:
                 starts[int(m.group(1))][int(m.group(2))] = float(m.group(3))
                 continue
+            m = _CHUNK_COMPUTE.search(line)
+            if m:
+                measured[int(m.group(1))][int(m.group(2))] = float(m.group(3)) / 1000.0
+                continue
             m = _E2E.search(line)
             if m:
                 last_end[int(m.group(1))] = float(m.group(3))
     if not starts:
         raise SystemExit(f"no CHUNK_START lines found in {path} (the pipeline loop always logs CHUNK_START)")
-    return starts, last_end
+    return starts, last_end, measured
 
 
 def slot_end(starts, last_end, rank, chunk, ordered):
@@ -71,7 +80,7 @@ def main():
     ap.add_argument("--no-arrows", action="store_true", help="omit the rank->rank handoff arrows")
     args = ap.parse_args()
 
-    starts, last_end = parse(args.log)
+    starts, last_end, measured = parse(args.log)
     ranks = sorted(starts)
     origin = min(s for r in ranks for s in starts[r].values())  # t=0 at the first chunk start
 
@@ -97,12 +106,27 @@ def main():
         for c in ordered:
             s = starts[rank][c]
             slot_e = slot_end(starts, last_end, rank, c, ordered)
-            dur = compute_dur(rank, c)
+            # Exact measured compute (PREFILL_SYNC_PER_CHUNK) wins over the downstream-start proxy.
+            dur = measured.get(rank, {}).get(c)
             estimated = dur is None
+            if estimated:
+                dur = compute_dur(rank, c)
+                estimated = dur is None
             if estimated:
                 # last rank: clamp the upstream-median estimate to the slot. With no proxy data at all
                 # (single rank), there is no pipeline overlap, so the whole slot IS the compute.
-                dur = min(est_compute, slot_e - s) if est_compute > 0 else (slot_e - s)
+                slot = slot_e - s
+                if est_compute > 0:
+                    # slot<=0 means the final chunk has no end marker (E2E_CLOCK didn't flush, so
+                    # last_end is empty and slot_e degenerates to s); use the estimate so the last
+                    # rank's last bar isn't drawn zero-width.
+                    dur = min(est_compute, slot) if slot > 0 else est_compute
+                else:
+                    own = [
+                        b - a
+                        for a, b in zip([starts[rank][x] for x in ordered], [starts[rank][x] for x in ordered[1:]])
+                    ]
+                    dur = slot if slot > 0 else median(own)
             comp_end = s + dur
             color = cmap(c % cmap.N)
             # Compute block (solid). The idle time (comp_end -> next chunk start) is left UNDRAWN, so
@@ -154,16 +178,21 @@ def main():
 
     from matplotlib.patches import Patch
 
-    ax.legend(
-        handles=[
-            Patch(facecolor="grey", edgecolor="black", label="compute (downstream-start proxy)"),
-            Patch(facecolor="white", edgecolor="grey", label="idle / waiting (white gap)"),
-            Patch(facecolor="grey", hatch="//", edgecolor="black", label="last rank: compute estimated (median)"),
-        ],
-        loc="upper left",
-        fontsize=8,
-        framealpha=0.9,
-    )
+    # With CHUNK_COMPUTE every bar is exact, so the proxy/estimate legend entries would misdescribe it.
+    any_measured = any(measured.get(r) for r in ranks)
+    handles = [
+        Patch(
+            facecolor="grey",
+            edgecolor="black",
+            label="compute (measured, per-chunk sync)" if any_measured else "compute (downstream-start proxy)",
+        ),
+        Patch(facecolor="white", edgecolor="grey", label="idle / waiting (white gap)"),
+    ]
+    if not any_measured:
+        handles.append(
+            Patch(facecolor="grey", hatch="//", edgecolor="black", label="last rank: compute estimated (median)")
+        )
+    ax.legend(handles=handles, loc="upper left", fontsize=8, framealpha=0.9)
     ax.set_yticks(ranks)
     ax.set_yticklabels([f"rank {r}" for r in ranks])
     # rank 0 at the bottom; the pipeline flows upward (default y increases upward).

--- a/models/demos/deepseek_v3_d_p/tests/model_variants.py
+++ b/models/demos/deepseek_v3_d_p/tests/model_variants.py
@@ -113,9 +113,10 @@ KIMI_V2_6 = TestVariant(
     ttnn_cache_env="TT_KIMI_PREFILL_TTNN_CACHE",
     mla_pcc_threshold=0.995,
     moe_pcc_threshold=0.971,
-    # vllm-traced golden: metadata.json + kv_cache nest under a run-hash subdir (resolve_trace_dir
-    # descends), and kv_post_transform is row-sharded (the transformer test's loader reassembles it).
-    prefill_trace_default="/mnt/models/deepseek-prefill-cache/golden/kimi-26/kimi_longbook_56320",
+    # vllm-traced golden: metadata.json at top level + row-sharded kv_post_transform
+    # (kv_cache/layer_N/rows_*.safetensors, the transformer test's loader reassembles it).
+    # resolve_trace_dir descends a run-hash subdir if metadata.json isn't at the top level.
+    prefill_trace_default="/mnt/models/deepseek-prefill-cache/golden/structured_traces/kimi_debug_55k_vllm",
     prefill_trace_layout="chunked_group_a_v1",
 )
 

--- a/models/demos/deepseek_v3_d_p/tt/runners/prefill_runner.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/prefill_runner.py
@@ -82,6 +82,9 @@ _gate_mode_name = os.environ.get("PREFILL_GATE_FALLBACK_MODE", VARIANT.default_g
 # When on (default), the last transformer layer runs kv-only: it fills the KV cache for migration and
 # skips its Q/SDPA/wo, FFN/MoE, final norm, and LM head. In a pipeline only the last rank applies it.
 KV_ONLY_LAST_LAYER = os.environ.get("PREFILL_KV_ONLY_LAST_LAYER", "1") == "1"
+# Measurement-only: synchronize the device after each chunk's forward and log the isolated per-rank
+# compute (CHUNK_COMPUTE). Off in production — the sync serializes dispatch and kills pipeline overlap.
+SYNC_PER_CHUNK = os.environ.get("PREFILL_SYNC_PER_CHUNK", "0") == "1"
 # Kimi (single expert group, device gate) routes the MoE routing all-gather's global semaphores to
 # L1_SMALL so they don't pin the main-L1 floor and clash with the next layer's MLA static CBs. This
 # requires opening the mesh with an L1_SMALL region. Off for DeepSeek (semaphores stay in main L1).
@@ -287,6 +290,11 @@ def _compute_and_send(runtime: TtPrefillRuntime, rank: int, c: int, inp, meta: d
     out = runtime.prefill(
         inp, slot_id=meta["slot_id"], actual_start=meta["actual_start"], actual_end=meta["actual_end"]
     )
+    if SYNC_PER_CHUNK:
+        # Block on device completion before the send so the delta is this rank's forward alone, not the
+        # downstream-start proxy. Serializes dispatch (no overlap) — measurement runs only.
+        ttnn.synchronize_device(runtime.mesh_device)
+        logger.info(f"[pp rank {rank}] CHUNK_COMPUTE c={c} compute_ms={(time.time() - t_start) * 1000.0:.3f}")
     if not runtime.config.is_last_rank:
         _d2d_send(d2d_out, out, rank, meta)  # push + free; the grant below forwards it over fabric
     if d2d_out is not None:


### PR DESCRIPTION
Summary

Adds ground-truth per-rank compute measurement to the pipeline-prefill runner and teaches the trace plotter to use it.

1. PREFILL_SYNC_PER_CHUNK (default off) — synchronizes the device after each chunk's forward and logs CHUNK_COMPUTE c=N compute_ms=M, the isolated per-rank compute. Without it, per-chunk duration could only be inferred from the downstream rank's start — a proxy that conflates compute with pipeline-flow gating and leaves the last rank with no measurement at all.
2. plot_pipeline_trace.py — uses CHUNK_COMPUTE when present (solid bars, no proxy/estimate); fixes a bug where the last rank's final bar collapsed to zero width when E2E_CLOCK didn't flush (the rough multi-rank SIGTERM shutdown); legend now reflects measured-vs-proxied mode.

Why

Investigating per-rank balance on the 4-galaxy Kimi pipeline, proxy-based durations were misleading (e.g. rank 2's last chunk appeared inflated only because the downstream rank fell behind). The sync gives the real number.

Findings (4× galaxy, Kimi, 56320 tok / 11 chunks)

- Isolated per-rank compute (median): r0 412ms · r1 391ms · r2 413ms · r3 439ms — rank 3 is the bottleneck (not the lm_head; kv_only_last_layer is on by default).
- Per-chunk compute grows ~11% with KV position (attention over the growing cache).
- Prefill is compute-bound: enabling the per-chunk sync moved e2e <1% (6.05→6.03s) — host dispatch overlap was never on the critical path.

Test

Gated off by default (no production impact). Verified on the c09/c10 4-galaxy Kimi pipeline; both measured (sync) and proxied (async) plot paths render correctly.

without PREFILL_SYNC_PER_CHUNK
<img width="2000" height="924" alt="image" src="https://github.com/user-attachments/assets/1e0e5f72-d5e0-409b-b83d-20966d3d53be" />

with PREFILL_SYNC_PER_CHUNK
<img width="2002" height="932" alt="image" src="https://github.com/user-attachments/assets/0aede7a8-bcd0-4eed-8167-c8b12c0c080c" />

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/prefill-chunk-timing)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/prefill-chunk-timing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jjovicic/prefill-chunk-timing)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jjovicic/prefill-chunk-timing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jjovicic/prefill-chunk-timing)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jjovicic/prefill-chunk-timing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/prefill-chunk-timing)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/prefill-chunk-timing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jjovicic/prefill-chunk-timing)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jjovicic/prefill-chunk-timing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/prefill-chunk-timing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/prefill-chunk-timing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jjovicic/prefill-chunk-timing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jjovicic/prefill-chunk-timing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jjovicic/prefill-chunk-timing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jjovicic/prefill-chunk-timing)