### PR TITLE
[skip ci] Remove Llama from Galaxy stress pipeline (#47407)

### DIFF
--- a/.github/workflows/galaxy-stress-tests-impl.yaml
+++ b/.github/workflows/galaxy-stress-tests-impl.yaml
@@ -112,7 +112,6 @@ jobs:
         LD_LIBRARY_PATH: /work/build/lib
         LOGURU_LEVEL: INFO
         ARCH_NAME: wormhole_b0
-        LLAMA_DIR: /mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/
       volumes:
         - ${{ github.workspace }}/docker-job:/work
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/galaxy-stress-tests.yaml
+++ b/.github/workflows/galaxy-stress-tests.yaml
@@ -36,9 +36,7 @@ on:
         default: "all"
         options:
           - all
-          - galaxy-llama-nd-hang-stress
           - galaxy-fabric-stability-stress
-          - galaxy-llama-long-stress
       extra-tag:
         required: false
         type: string

--- a/tests/pipeline_reorg/galaxy_stress_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_stress_tests.yaml
@@ -10,19 +10,6 @@
 
 # Max timeouts: .github/time_budget.yaml (workflow key: stress)
 
-- id: galaxy-llama-nd-hang-stress
-  name: Llama Galaxy ND hang stress (loop)
-  team: models
-  owner_id: U053W15B6JF # Djordje Ivanovic
-  cmd: |
-    for i in {1..5}; do
-      echo "🔁 Run #$i"
-      timeout --preserve-status 1200 pytest models/demos/llama3_70b_galaxy/demo/demo_decode.py -k "nd-hang-test"
-    done
-  skus:
-    wh_galaxy_perf:
-      timeout: 360
-
 - id: galaxy-fabric-stability-stress
   name: Galaxy Fabric Stability Tests
   team: scaleout
@@ -32,13 +19,3 @@
   skus:
     wh_galaxy_perf:
       timeout: 100
-
-- id: galaxy-llama-long-stress
-  name: Llama Galaxy Long Stress Test
-  team: models
-  owner_id: U053W15B6JF # Djordje Ivanovic
-  cmd: |
-    LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ FAKE_DEVICE=TG pytest models/demos/llama3_70b_galaxy/demo/demo_decode.py -k "stress-test and not mini-stress-test"
-  skus:
-    wh_galaxy_perf:
-      timeout: 140


### PR DESCRIPTION
## What

Removes the Llama tests from the Galaxy stress pipeline.

## Why

The `Llama Galaxy Long Stress Test` fails consistently in the `(Galaxy) Stress` workflow with:

```
OSError: [Errno 30] Read-only file system: '/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/TG'
```

The `/mnt/MLPerf` weights mount is read-only on the `wh_galaxy_perf` runners, and the test attempts to create a directory under it. This is the failure tracked in #47407. Per the issue, we're removing Llama from the stress pipeline.

## Changes

- `tests/pipeline_reorg/galaxy_stress_tests.yaml` — remove both Llama stress entries (`galaxy-llama-long-stress` and `galaxy-llama-nd-hang-stress`); only `galaxy-fabric-stability-stress` remains.
- `.github/workflows/galaxy-stress-tests.yaml` — drop the two Llama ids from the `workflow_dispatch` `test-selection` choices.
- `.github/workflows/galaxy-stress-tests-impl.yaml` — remove the now-unused `LLAMA_DIR` container env var.

The conditional `/mnt/MLPerf:ro` perf-SKU mount is left in place — it's generic weights-mount infra, not Llama-specific.

Closes #47407

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/remove-llama-stress-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/remove-llama-stress-pipeline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/remove-llama-stress-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/remove-llama-stress-pipeline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mtairum/remove-llama-stress-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mtairum/remove-llama-stress-pipeline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/remove-llama-stress-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/remove-llama-stress-pipeline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/remove-llama-stress-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/remove-llama-stress-pipeline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/remove-llama-stress-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/remove-llama-stress-pipeline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/remove-llama-stress-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/remove-llama-stress-pipeline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/remove-llama-stress-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/remove-llama-stress-pipeline)