### PR TITLE
[Metal 2.0][DRAFT/REVIEW] Spec-as-key run-args builders + transpose/i2s migrations

### DIFF
--- a/tech_reports/Metal2OpMigration/SPEC_AS_KEY_RUNARGS_PERF.md
+++ b/tech_reports/Metal2OpMigration/SPEC_AS_KEY_RUNARGS_PERF.md
@@ -1,0 +1,101 @@
+# Spec-as-key run-args perf: builders, profiling, and the output-allocation lever
+
+Status: WIP exploration branch `dgomez/metal2-spec-runargs-builders`. Captures the spec-as-key
+host-dispatch perf work — what was built, how it was measured, what was found, and what's next.
+
+## Background: which path we're optimizing
+
+Quasar (Metal 2.0) ops can sit on three host-side concepts:
+
+| concept | factory entry | cache key | cache-hit cost |
+|---|---|---|---|
+| `ProgramDescriptorFactoryConcept` | `create_descriptor` | attribute hash | cheap (legacy-like) |
+| `MetalV2FactoryConcept` | `create_program_artifacts` | attribute hash | cheap — `UpdateTensorArgs` on hit, **no spec rebuild** |
+| **`ProgramSpecFactoryConcept` / `…WithOwnedTensorsConcept`** | `create_program_spec` (+ owned-tensor span) | **the ProgramSpec content** | **rebuild + re-hash the whole spec every dispatch** ("build-to-hash") |
+
+This work targets the **spec-as-key** path (`ProgramSpecFactoryWithOwnedTensorsConcept`), defined on the
+`#47473` base. It is intentionally more expensive than MetalV2/legacy: the spec is rebuilt every dispatch
+so its content can be hashed into the cache key. The question is how cheap we can make that rebuild while
+keeping the spec-as-key contract (the cache key stays the spec; nothing else).
+
+## Measurement methodology (locked)
+
+- Op vs its legacy twin, **same shape**, on hardware.
+- **Fixed condition: DIM 1024, `TT_METAL_INSPECTOR=0`.** (The Inspector debug recorder does a synchronous
+  per-dispatch file `write()`/`flush()` ~5 µs that inflates both paths; off = production-like.)
+- Warm the program cache, then time N iters in batches; report **min/median µs/op** (min ≈ least-contended
+  host work). Beware bimodal noise — single-rep numbers lie.
+- **Verify the binary before every measurement:** `_ttnncpp.so` timestamp is fresh AND
+  `nm -C _ttnncpp.so | grep <new symbol>` > 0. Do **not** trust the build exit code — a `build_metal.sh`
+  on a tests-configured tree can exit while ninja stopped on a broken test *before relinking the libs*,
+  leaving a stale `.so`. (This cost real time here: several "no change" measurements were a stale binary.)
+
+## The helpers (`ttnn/api/ttnn/spec_run_args.hpp`)
+
+Goal: give op authors spec-building tools that are easier to write **and** faster than hand-rolling, so
+not using them is the wrong choice. Each helper bakes in an invariant the general API can't assume.
+
+- `Table::append_unchecked` (metal) — append without the `find()` dup-scan; O(N) fill instead of O(N²).
+  Safe because schema names are unique by construction.
+- `ttnn::spec::KernelRunArgsBuilder` — one kernel's per-node run-args: declare names once, `emit(node,
+  v0, v1, …)` positional + arity-checked, fills each Table via `append_unchecked`.
+- `ttnn::spec::ProgramRunArgsBuilder` — whole program: `kernel()` per kernel, `emit()` per node,
+  `take()` **moves** every kernel into the `ProgramRunArgs`. This makes the
+  `kernel_run_args = {std::move(a), b, c}` bug impossible — `std::initializer_list` elements are `const`,
+  so that braced-init silently **copies** every per-node Table. (`take()` + `push_back(std::move)` move.)
+
+## Results (DIM 1024, inspector off, PCC 1.0)
+
+| op | spec-as-key baseline | + run-args builder | legacy |
+|---|---|---|---|
+| **transpose** (WH) | ~41 µs (1.56×) | **~35 µs (1.34×)** | ~26 µs |
+| **interleaved_to_sharded** | **~48 µs (~2.0×)** (builder not yet wired) | — | ~24 µs |
+
+The builder is a real **−6 µs / −15%** on transpose. i2s was migrated (concept generalizes cleanly, PCC
+1.0) but its branchy per-core loop (DRAM writer 7 args vs L1 writer 1 arg) hasn't had the builder wired,
+so it shows the spec-as-key cost, not yet the builder win.
+
+## Profiling — where the remaining gap is
+
+**transpose, ~9 µs over legacy** (frames present in quasar, absent in legacy):
+- per-dispatch spec **rebuild** (`create_program_spec`: KernelSpec ctors, DFB/CB specs, tensor params) ~4–5 µs
+- spec **hash** for the key (`program_spec_cache_key` → reflection `hash_objects`) ~1.1 µs
+- run-args build (now ~parity with legacy's `GetRuntimeArgs`)
+- `std::filesystem::path` (kernel `source`) construct + hash ~0.8 µs
+- `~ProgramSpec`/`~KernelSpec` teardown ~0.7 µs
+
+**i2s, ~48 µs:**
+- output tensor **alloc + free** (`MeshBuffer`/`Buffer` create+dtor, `MeshTensorHolder` dealloc) ~45% — **shared with legacy** (the floor)
+- **`CoreRangeSet::merge` + `_Rb_tree<CoreRange>` ~3 µs — i2s-specific**: rebuilds+sorts the shard core ranges every dispatch
+- spec hash ~3 µs; run-args/KernelSpec build ~2.4 µs (builder not wired); `compute_output_specs` ~1.4 µs
+
+## Findings / dead ends (don't redo)
+
+- **skip-validate-on-hit is not an optimization** — it's a parameter (`SetProgramRunArgs(..., skip_validation=true)`),
+  already wired in the owned adapter's `apply_run_args`. Confirmed on the hot path.
+- **Flat `Table<RtaName,size_t>` slot map regresses at high RTA count.** Sweep: O(N²) linear scan beats the
+  hash map only below ~4–8 RTAs (N=2→1.4 µs, N=16→16 µs, N=32→61 µs). Reverted. The by-slot run-args
+  *eliminates* the lookup instead — but the run-args copy turned out to be wall-clock-cheap anyway.
+- **Run-args memoization is a frozen-args footgun.** Caching per-core run-args keyed on an author-defined
+  invariance key is exactly the staleness bug class that's caused regressions (work-core-set-change). Not
+  shipped as a general tool. The *safe* version would key on the spec — which needs a framework change.
+
+## The principle, and the next lever (output allocation)
+
+**Spec-derived data can be safely memoized on the spec hash; not-spec-derived data (run-args, tensor
+addresses) cannot.** The spec *is* the cache key, so a different spec ⇒ different hash ⇒ miss ⇒ recompute —
+staleness is impossible by construction. Run-args aren't part of the key, which is why memoizing them is a
+footgun; spec-derived layout is not.
+
+Output allocation (~45% of dispatch, shared with legacy) splits into:
+- **Irreducible:** the physical address allocation. The caller owns the returned output tensor, so its
+  memory can't be pooled/reused while held.
+- **Memoizable, spec-exclusive, footgun-free:** the spec-*derived* buffer **layout** —
+  `generate_buffer_page_mapping`, the buffer distribution spec, and (sharded) the shard `CoreRangeSet`.
+  These are pure functions of the output `TensorSpec`, which is encoded in the ProgramSpec = the cache key.
+
+**Proposed prototype:** park the computed buffer layout (page mapping + distribution spec + shard
+`CoreRangeSet`) on the spec cache entry, keyed on the spec hash already computed for the program cache. On
+a hit: reuse the layout, do only the physical allocation. Spec-exclusive (legacy has no spec hash; it's a
+derived-data sidecar, not a change to the program cache). Expected to recover the "redundant `Buffer::create`"
+recompute and i2s's `CoreRangeSet::merge` (~3 µs). Measured on i2s (where the CoreRangeSet cost is biggest).

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
@@ -841,8 +841,8 @@ TEST_F(ProgramRunArgsTestQuasar, MultiNode_MissingOneNodeFails) {
 inline ProgramSpec MakeSpecWithNamedArgs(
     const NodeCoord& node, const std::vector<std::string>& named_rtas, const std::vector<std::string>& named_crtas) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
-    spec.kernels[0].runtime_arg_schema.runtime_arg_names = named_rtas;
-    spec.kernels[0].runtime_arg_schema.common_runtime_arg_names = named_crtas;
+    spec.kernels[0].runtime_arg_schema.runtime_arg_names.assign(named_rtas.begin(), named_rtas.end());
+    spec.kernels[0].runtime_arg_schema.common_runtime_arg_names.assign(named_crtas.begin(), named_crtas.end());
     (void)node;  // node inherited from MakeMinimalValidProgramSpec (0,0)
     return spec;
 }

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
@@ -105,7 +105,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramSh
 
     KernelSpec::CompileTimeArgs cta_bindings(reader_compile_args);
 
-    std::vector<std::string> named_rtas = {"src_addr", "l1_addr"};
+    std::vector<tt::tt_metal::experimental::RtaName> named_rtas = {"src_addr", "l1_addr"};
 
     KernelSpec reader_spec{
         .unique_id = KernelSpecName{"reader"},

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -359,7 +359,7 @@ void run_single_core_reduce_program(
     std::string reader_kernel_path;
     experimental::KernelSpec::CompileTimeArgs reader_cta_bindings;
     experimental::KernelSpec::CompilerOptions::Defines reader_defines;
-    std::vector<std::string> reader_runtime_arg_names;
+    std::vector<tt::tt_metal::experimental::RtaName> reader_runtime_arg_names;
     if (test_config.reduce_dim == ReduceDim::H) {
         reader_kernel_path = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_transpose_wh_interleaved.cpp";
         bfloat16 bfloat_scaler_value = bfloat16(scaler);

--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -3,13 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gmock/gmock.h>
+#include <span>
 #include <type_traits>
+#include <vector>
 
 #include "ttnn/distributed/api.hpp"
 #include "ttnn/distributed/distributed_tensor.hpp"
 #include "ttnn/mesh_device_operation_adapter.hpp"
 #include "ttnn/mesh_device_operation_utils.hpp"
 #include "ttnn/metal_v2_artifacts.hpp"
+#include "ttnn/program_spec_artifacts.hpp"
 #include "ttnn/operation_concepts.hpp"
 #include "ttnn/operations/examples/example/device/example_device_operation.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -150,6 +153,55 @@ TEST(LaunchOperationTest, MetalV2AdapterCompiles) {
     [[maybe_unused]] auto create = &Adapter::create_mesh_workload;
     [[maybe_unused]] auto apply = &Adapter::apply_descriptor;
     [[maybe_unused]] auto resolve = &Adapter::resolve_bindings;
+    SUCCEED();
+}
+
+// === Spec (ProgramSpecFactoryConcept) compile-coverage ===
+// No real op uses create_program_spec yet, so force-instantiate the ProgramSpec adapter bodies here.
+// Runtime behavior (miss->hit re-bind, owned-tensor liveness) needs a real dispatched op.
+struct ProgramSpecFactory {
+    static ttnn::device_operation::ProgramSpecArtifacts create_program_spec(
+        const OperationAttributes& /*attrs*/, const Tensor& /*tensor_args*/, Tensor& /*tensor_return_value*/) {
+        return ttnn::device_operation::ProgramSpecArtifacts{};
+    }
+};
+
+// Spec factory that also owns tensors: get_owned_tensors + the span overload of create_program_spec.
+struct ProgramSpecOwnedFactory {
+    static std::vector<tt::tt_metal::MeshTensor> get_owned_tensors(
+        const OperationAttributes& /*attrs*/, const Tensor& /*tensor_args*/, Tensor& /*tensor_return_value*/) {
+        return {};
+    }
+    static ttnn::device_operation::ProgramSpecArtifacts create_program_spec(
+        const OperationAttributes& /*attrs*/,
+        const Tensor& /*tensor_args*/,
+        Tensor& /*tensor_return_value*/,
+        std::span<const tt::tt_metal::MeshTensor> /*owned*/) {
+        return ttnn::device_operation::ProgramSpecArtifacts{};
+    }
+};
+
+static_assert(ttnn::device_operation::ProgramSpecFactoryConcept<ProgramSpecFactory>);
+static_assert(!ttnn::device_operation::MetalV2FactoryConcept<ProgramSpecFactory>);
+static_assert(!ttnn::device_operation::ProgramFactoryConcept<ProgramSpecFactory>);
+static_assert(!ttnn::device_operation::ProgramDescriptorFactoryConcept<ProgramSpecFactory>);
+static_assert(!ttnn::device_operation::ProgramSpecFactoryWithOwnedTensorsConcept<ProgramSpecFactory>);
+static_assert(ttnn::device_operation::ProgramSpecFactoryConcept<ProgramSpecOwnedFactory>);
+static_assert(ttnn::device_operation::ProgramSpecFactoryWithOwnedTensorsConcept<ProgramSpecOwnedFactory>);
+
+TEST(LaunchOperationTest, ProgramSpecAdapterCompiles) {
+    using Adapter = device_operation::MeshDeviceOperationAdapter<
+        MetalV2MinimalOp>::ProgramSpecMeshWorkloadFactoryAdapter<ProgramSpecFactory>;
+    [[maybe_unused]] auto create_spec = &Adapter::create_spec;
+    [[maybe_unused]] auto cache_hash = &Adapter::cache_hash;
+    [[maybe_unused]] auto build = &Adapter::build_mesh_workload;
+    [[maybe_unused]] auto apply = &Adapter::apply_run_args;
+
+    using OwnedAdapter = device_operation::MeshDeviceOperationAdapter<
+        MetalV2MinimalOp>::ProgramSpecWithOwnedTensorsMeshWorkloadFactoryAdapter<ProgramSpecOwnedFactory>;
+    [[maybe_unused]] auto owned_create_spec = &OwnedAdapter::create_spec;
+    [[maybe_unused]] auto owned_build = &OwnedAdapter::build_mesh_workload;
+    [[maybe_unused]] auto owned_apply = &OwnedAdapter::apply_run_args;
     SUCCEED();
 }
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
+#include <tt-metalium/experimental/metal2_host_api/runtime_arg_name.hpp>
 #include <tt-metalium/experimental/metal2_host_api/utility/group.hpp>
 #include <tt-metalium/experimental/metal2_host_api/utility/table.hpp>
 #include <tt_stl/strong_type.hpp>
@@ -54,8 +55,8 @@ struct KernelAdvancedOptions {
     //
     // CAUTION: This feature is unsafe if used incorrectly! The onus is on the programmer
     // to ensure that the designated arguments remain valid across enqueues.
-    Group<std::string> enqueue_invariant_runtime_args;
-    Group<std::string> enqueue_invariant_common_runtime_args;
+    Group<RtaName> enqueue_invariant_runtime_args;
+    Group<RtaName> enqueue_invariant_common_runtime_args;
 
     ////////////////////////////////////////////////////////////////////////////////
     // Varargs

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -16,6 +16,7 @@
 #include <tt-metalium/experimental/metal2_host_api/data_movement_hardware_config.hpp>
 #include <tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
+#include <tt-metalium/experimental/metal2_host_api/runtime_arg_name.hpp>
 #include <tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/utility/group.hpp>
 #include <tt-metalium/experimental/metal2_host_api/utility/table.hpp>
@@ -178,10 +179,10 @@ struct KernelSpec {
 
     struct RuntimeArgSchema {
         // Runtime argument names (must be unique, valid C++ identifiers.)
-        Group<std::string> runtime_arg_names;
+        Group<RtaName> runtime_arg_names;
 
         // Common runtime argument names (must be unique, valid C++ identifiers.)
-        Group<std::string> common_runtime_arg_names;
+        Group<RtaName> common_runtime_arg_names;
     };
     RuntimeArgSchema runtime_arg_schema{};
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_args.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_args.hpp
@@ -15,6 +15,7 @@
 #include <tt-metalium/experimental/metal2_host_api/advanced_options.hpp>
 #include <tt-metalium/experimental/metal2_host_api/kernel_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/runtime_arg_name.hpp>
 #include <tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp>
 #include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
 #include <tt-metalium/experimental/metal2_host_api/utility/group.hpp>
@@ -57,7 +58,10 @@ struct ProgramRunArgs {
         //
         // NOTE: If a kernel runtime argument always has the same value for all nodes,
         // passing a common runtime argument would provide better dispatch efficiency.
-        using RuntimeArgValues = Table<std::string, uint32_t>;
+        //
+        // Names are keyed by RtaName (an inline, heap-free key); see runtime_arg_name.hpp.
+        // Ops still write {{"name", value}} -- string literals convert implicitly.
+        using RuntimeArgValues = Table<RtaName, uint32_t>;
         struct NodeRuntimeArgs {
             NodeCoord node;
             RuntimeArgValues args;

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/runtime_arg_name.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/runtime_arg_name.hpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <string>
+#include <string_view>
+
+#include <fmt/format.h>
+#include <tt_stl/assert.hpp>
+
+namespace tt::tt_metal::experimental {
+
+// Inline, fixed-capacity key for runtime-argument names.
+//
+// Used as the key type wherever a runtime-argument name is stored or looked up: the per-node and
+// common run-arg value Tables, the schema name lists and name->slot maps, and the enqueue-invariant
+// name sets. Those structures are rebuilt on every dispatch, so a std::string key allocates on the
+// heap for any name past the short-string-optimization threshold. RtaName stores the characters
+// inline -- it is a trivially-copyable POD, so it relocates by memcpy, compares with a length-gated
+// memcmp, and never touches the heap.
+//
+// Implicitly constructible from a string, so call sites keep declaring and supplying names as plain
+// string literals. The capacity is validated when a ProgramSpec is built; the constructor enforces
+// it as a backstop, failing loudly rather than silently truncating (truncation would alias two
+// distinct names to the same key).
+struct RtaName {
+    static constexpr std::size_t CAP = 47;  // 48-byte key including the length; longest name in use is 28 chars
+    char data_[CAP] = {};
+    std::uint8_t len_ = 0;
+
+    RtaName() = default;
+    RtaName(std::string_view s) {  // NOLINT(google-explicit-constructor): implicit by design
+        TT_FATAL(s.size() <= CAP, "Runtime-arg name '{}' exceeds the {}-character limit ({} chars)", s, CAP, s.size());
+        len_ = static_cast<std::uint8_t>(s.size());
+        std::memcpy(data_, s.data(), len_);
+    }
+    RtaName(const char* s) : RtaName(std::string_view(s)) {}         // NOLINT(google-explicit-constructor)
+    RtaName(const std::string& s) : RtaName(std::string_view(s)) {}  // NOLINT(google-explicit-constructor)
+
+    std::string_view view() const { return std::string_view(data_, len_); }
+
+    // Reader-side conversion for the (minority) call sites that consume a name as a std::string.
+    operator std::string() const { return std::string(view()); }  // NOLINT(google-explicit-constructor)
+
+    bool operator==(const RtaName& o) const { return len_ == o.len_ && std::memcmp(data_, o.data_, len_) == 0; }
+};
+
+}  // namespace tt::tt_metal::experimental
+
+template <>
+struct fmt::formatter<tt::tt_metal::experimental::RtaName> : fmt::formatter<std::string_view> {
+    auto format(const tt::tt_metal::experimental::RtaName& n, fmt::format_context& ctx) const {
+        return fmt::formatter<std::string_view>::format(n.view(), ctx);
+    }
+};
+
+template <>
+struct std::hash<tt::tt_metal::experimental::RtaName> {
+    std::size_t operator()(const tt::tt_metal::experimental::RtaName& n) const noexcept {
+        // Delegate to the platform's optimized byte hash (chunked) rather than a naive
+        // per-byte FNV loop -- the apply path does ~hundreds of slot-map lookups per dispatch.
+        return std::hash<std::string_view>{}(n.view());
+    }
+};

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/utility/table.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/utility/table.hpp
@@ -19,6 +19,7 @@
 
 #include <tt_stl/assert.hpp>
 #include <tt_stl/optional_reference.hpp>
+#include <tt_stl/small_vector.hpp>
 
 // Forward declarations of the ttsl::hash entry points used by the std::hash<Table> specialization
 // below, so this header need not pull in the (heavy) <tt_stl/reflection.hpp>. The definitions live
@@ -67,7 +68,10 @@ private:
     // Entries are stored as a mutable std::pair<K, V> (so the backing vector stays
     // easy to grow, erase, and assign), but exposed through the iterators below as
     // the const-key value_type.
-    using Storage = std::vector<std::pair<K, V>>;
+    // Small-vector backing: Tables typically hold only a handful of entries, so the inline storage
+    // avoids a heap allocation in the common case. Larger Tables spill to the heap with identical
+    // semantics, so correctness never depends on the inline capacity.
+    using Storage = ttsl::SmallVector<std::pair<K, V>, 8>;
 
 public:
     // Wraps a backing iterator and re-presents the stored pair it points at as the

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/utility/table.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/utility/table.hpp
@@ -153,6 +153,18 @@ public:
     [[nodiscard]] size_type size() const noexcept { return entries_.size(); }
     void clear() noexcept { entries_.clear(); }
 
+    // Reserves backing storage for at least `n` entries, so a sized fill never reallocates.
+    void reserve(size_type n) { entries_.reserve(n); }
+
+    // Appends without checking the key is absent, skipping insert()'s find() scan (O(N) not O(N^2)).
+    // Caller MUST guarantee uniqueness (e.g. schema names); a duplicate key breaks find()/==/hashing.
+    void append_unchecked(const value_type& entry) { entries_.push_back(entry); }
+    void append_unchecked(value_type&& entry) { entries_.push_back(std::move(entry)); }
+    template <typename KeyArg, typename ValArg>
+    void append_unchecked(KeyArg&& key, ValArg&& value) {
+        entries_.emplace_back(std::forward<KeyArg>(key), std::forward<ValArg>(value));
+    }
+
     // Returns an iterator to the entry for `key`, or end() if the key is absent.
     [[nodiscard]] iterator find(const K& key) {
         return iterator{std::ranges::find(entries_, key, &Storage::value_type::first)};

--- a/tt_metal/impl/metal2_host_api/program_run_args.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_args.cpp
@@ -206,7 +206,7 @@ void ValidateProgramRunArgs(const Program& program, const ProgramRunArgs& params
 
         // Validate named RTAs: every declared name set per-node, no extras, no duplicate node entries.
         const auto& named_rta_names = schema->runtime_arg_names;
-        const std::unordered_set<std::string> named_rta_name_set(named_rta_names.begin(), named_rta_names.end());
+        const std::unordered_set<RtaName> named_rta_name_set(named_rta_names.begin(), named_rta_names.end());
 
         std::unordered_set<NodeCoord> nodes_with_named_params;
         for (const auto& [node, args] : kernel_params.runtime_arg_values) {
@@ -612,7 +612,7 @@ void SetProgramRunArgs(Program& program, const ProgramRunArgs& params, bool skip
             // before allocating. Build the node->values lookups and walk the kernel's logical cores
             // (the node coverage validation has confirmed) to assemble each combined buffer. This
             // runs once; every subsequent call takes the fast path above.
-            std::unordered_map<NodeCoord, const Table<std::string, uint32_t>*> named_rtas_by_node;
+            std::unordered_map<NodeCoord, const Table<RtaName, uint32_t>*> named_rtas_by_node;
             named_rtas_by_node.reserve(kernel_params.runtime_arg_values.size());
             for (const auto& [node, args] : kernel_params.runtime_arg_values) {
                 named_rtas_by_node[node] = &args;
@@ -948,8 +948,8 @@ void ValidateUpdateProgramRunArgs(const Program& program, const ProgramRunArgs& 
         // --- Named RTAs: supplied names must be declared (no extras); every non-invariant name
         //     must be supplied for every node; invariant names may be omitted. ---
         const auto& named_rta_names = schema->runtime_arg_names;
-        const std::unordered_set<std::string> named_rta_name_set(named_rta_names.begin(), named_rta_names.end());
-        std::vector<std::string> regular_rta_names;
+        const std::unordered_set<RtaName> named_rta_name_set(named_rta_names.begin(), named_rta_names.end());
+        std::vector<RtaName> regular_rta_names;
         for (const auto& n : named_rta_names) {
             if (!schema->enqueue_invariant_runtime_arg_names.contains(n)) {
                 regular_rta_names.push_back(n);
@@ -999,7 +999,7 @@ void ValidateUpdateProgramRunArgs(const Program& program, const ProgramRunArgs& 
 
         // --- Named CRTAs: regular ones must be supplied; invariant may be omitted; no extras. ---
         const auto& named_crta_names = schema->common_runtime_arg_names;
-        const std::unordered_set<std::string> named_crta_name_set(named_crta_names.begin(), named_crta_names.end());
+        const std::unordered_set<RtaName> named_crta_name_set(named_crta_names.begin(), named_crta_names.end());
         for (const auto& [name, _value] : kernel_params.common_runtime_arg_values) {
             (void)_value;
             TT_FATAL(

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -680,6 +680,16 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                 kernel.unique_id,
                 kind,
                 name);
+            // Runtime-arg names are keyed by the fixed-capacity RtaName; enforce the shared limit here
+            // so an over-long name is rejected when the ProgramSpec is built, not at dispatch time.
+            TT_FATAL(
+                name.size() <= experimental::RtaName::CAP,
+                "KernelSpec '{}' {} name '{}' exceeds the {}-character limit ({} chars).",
+                kernel.unique_id,
+                kind,
+                name,
+                experimental::RtaName::CAP,
+                name.size());
             auto [it, inserted] = seen.try_emplace(name, kind);
             TT_FATAL(
                 inserted,
@@ -2752,7 +2762,12 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
         // Resolve TensorBindings for this kernel:
         //  - pack each binding's pre-resolved CTA payload into the kernel's positional CTA buffer
         //  - assign each binding a slot in the kernel's CRTA buffer (TensorBinding address section)
-        const auto& user_named_crtas = kernel_spec.runtime_arg_schema.common_runtime_arg_names;
+        // Materialize the declared names as std::string for the legacy Kernel ctor (which takes
+        // std::vector<std::string>) and the impl schema's declaration-order lists. The hot-path
+        // lookups use the RtaName-keyed *_name_to_slot maps built below.
+        const std::vector<std::string> user_named_crtas(
+            kernel_spec.runtime_arg_schema.common_runtime_arg_names.begin(),
+            kernel_spec.runtime_arg_schema.common_runtime_arg_names.end());
         TensorBindingsForKernel ta_bindings = ResolveTensorBindingsForKernel(
             kernel_spec, resolved_tensor_parameters, /*base_named_crta_count=*/user_named_crtas.size());
 
@@ -2763,7 +2778,9 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
         // emit kernel_args_generated.h and factor into the kernel cache key. The TensorBinding
         // address section is tracked separately (via tensor_binding_handles), so we pass the user
         // CRTA list through unchanged.
-        const auto& named_rtas = kernel_spec.runtime_arg_schema.runtime_arg_names;
+        const std::vector<std::string> named_rtas(
+            kernel_spec.runtime_arg_schema.runtime_arg_names.begin(),
+            kernel_spec.runtime_arg_schema.runtime_arg_names.end());
 
         // Create the kernel object
         std::shared_ptr<Kernel> kernel;
@@ -2855,9 +2872,8 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
         // An explicit override of 0 erases the scalar-default entry so run-params treats
         // that node as having no varargs (rather than requiring an "empty" value list).
         // Overlapping override entries (two entries covering the same node) are an error.
-        const auto& user_schema = kernel_spec.runtime_arg_schema;
         detail::ProgramImpl::KernelRTASchema runtime_schema;
-        runtime_schema.runtime_arg_names = user_schema.runtime_arg_names;
+        runtime_schema.runtime_arg_names = named_rtas;
 
         // Pass the user CRTA list through.
         // NOTE: The TensorBinding address section is tracked separately on the Kernel

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -18,6 +18,7 @@
 #include "impl/buffers/semaphore.hpp"
 #include "tt-metalium/sub_device_types.hpp"
 #include "tt-metalium/experimental/tensor/spec/tensor_spec.hpp"  // Metal 2.0 TensorParameter registry
+#include "tt-metalium/experimental/metal2_host_api/runtime_arg_name.hpp"  // RtaName (RTA slot-map key)
 #include "tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp"
 
 #include <umd/device/types/core_coordinates.hpp>        // CoreType
@@ -387,6 +388,9 @@ public:
     struct KernelRTASchema {
         // Named arg names, in declaration order. Used to serialize ProgramRunArgs values
         // into the dispatch buffer and to validate that every declared name is supplied.
+        // std::string (not RtaName): these declaration-order lists bridge to the legacy Kernel
+        // constructor (kernel.hpp), which takes std::vector<std::string>, and are iteration lists
+        // rather than hot-path lookups. The RtaName-keyed *_name_to_slot maps below are the hot path.
         std::vector<std::string> runtime_arg_names;
         std::vector<std::string> common_runtime_arg_names;
 
@@ -395,8 +399,10 @@ public:
         // hot UpdateProgramRunArgs path does O(1) lookups instead of rebuilding a map per call —
         // that path is not bypassable via skip_validation, so per-call construction would be pure
         // host overhead on the inner re-enqueue loop.
-        std::unordered_map<std::string, size_t> runtime_arg_name_to_slot;
-        std::unordered_map<std::string, size_t> common_runtime_arg_name_to_slot;
+        // Keyed by RtaName (heap-free inline key) to match RuntimeArgValues' key type, so the hot
+        // apply-path lookup (slot_of.find(name)) is a memcmp, not a std::string hash+compare.
+        std::unordered_map<experimental::RtaName, size_t> runtime_arg_name_to_slot;
+        std::unordered_map<experimental::RtaName, size_t> common_runtime_arg_name_to_slot;
 
         // Vararg counts. RTA vararg count is per-node (stored post-expansion from the
         // user-facing schema, which groups nodes that share a count); CRTA vararg is a single
@@ -408,8 +414,8 @@ public:
         // enqueue-loop invariant via KernelAdvancedOptions. These named args may be omitted
         // from a partial UpdateProgramRunArgs call, in which case the value installed by the
         // most recent SetProgramRunArgs is retained. (Varargs cannot be marked invariant.)
-        std::unordered_set<std::string> enqueue_invariant_runtime_arg_names;
-        std::unordered_set<std::string> enqueue_invariant_common_runtime_arg_names;
+        std::unordered_set<experimental::RtaName> enqueue_invariant_runtime_arg_names;
+        std::unordered_set<experimental::RtaName> enqueue_invariant_common_runtime_arg_names;
     };
 
     // Metal 2.0: Runtime argument schema registration and lookup

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -356,6 +356,128 @@ void create_and_cache_mesh_workload(
         });
 }
 
+// True iff every alternative of the op's program_factory_t is a ProgramSpecFactoryConcept -- i.e. this
+// op uses the spec-as-key path and is launched via launch_mesh_program_spec.
+template <typename Variant, std::size_t... Is>
+consteval bool all_alternatives_program_spec(std::index_sequence<Is...>) {
+    return (ProgramSpecFactoryConcept<std::variant_alternative_t<Is, Variant>> && ...);
+}
+template <typename mesh_device_operation_t>
+inline constexpr bool is_program_spec_mesh_op_v =
+    all_alternatives_program_spec<typename mesh_device_operation_t::program_factory_t>(
+        std::make_index_sequence<std::variant_size_v<typename mesh_device_operation_t::program_factory_t>>{});
+
+// Shared spec-as-key flow, parameterized on the spec adapter (base or owned-tensor). Build the
+// ProgramSpec once (the explicit create_spec step), key the cache on its content -- always from the spec,
+// never a cheap attribute hash -- then re-apply run args on a hit or build the workload on a miss.
+template <typename Adapter, DeviceOperationWithMeshDeviceAdapter mesh_device_operation_t>
+void run_spec_flow(
+    const typename mesh_device_operation_t::operation_attributes_t& operation_attributes,
+    const typename mesh_device_operation_t::tensor_args_t& tensor_args,
+    typename mesh_device_operation_t::tensor_return_value_t& tensor_return_value,
+    ttnn::MeshDevice* mesh_device,
+    std::size_t program_factory_index) {
+    using cached_mesh_workload_t = typename Adapter::cached_mesh_workload_t;
+    auto& program_cache = mesh_device->get_program_cache();
+
+    // Target mesh coordinates, extracted once and reused for the range set and the key.
+    const auto target_coords = mesh_device_operation_utils::extract_tensor_coordinates(tensor_args, mesh_device);
+    ttnn::MeshCoordinateRangeSet tensor_coords;
+    if (mesh_device_operation_utils::all_tensors_have_uniform_storage(tensor_args)) {
+        tensor_coords.merge(ttnn::MeshCoordinateRange(mesh_device->shape()));
+    } else {
+        for (const auto& coord : target_coords) {
+            tensor_coords.merge(ttnn::MeshCoordinateRange(coord, coord));
+        }
+    }
+
+    // Build the spec once, explicitly; its ProgramSpec content is the cache key.
+    auto built = Adapter::create_spec(operation_attributes, tensor_args, tensor_return_value);
+
+    ProgramCacheKey program_key;
+    bool program_cache_hit = false;
+    if (program_cache.is_enabled()) {
+        program_key.hash = Adapter::cache_hash(built.artifacts);
+        for (const auto& coord : target_coords) {
+            program_key.hash = ttsl::hash::hash_objects(program_key.hash, coord);
+        }
+        // Keyed on the ProgramSpec content, so the canonical companion is just the op identity.
+        program_key.canonical =
+            std::string{ttsl::get_type_name<typename mesh_device_operation_t::device_operation_t>()};
+        program_cache_hit = program_cache.contains(program_key);
+        if (!program_cache_hit && !program_cache.cache_misses_allowed()) {
+            auto op_name = get_operation_name<mesh_device_operation_t>(operation_attributes);
+            TT_THROW("Device operation \"{}\": program cache miss occurred, but cache misses are forbidden", op_name);
+        }
+    }
+
+    log_operation<mesh_device_operation_t>(
+        mesh_device->id(), operation_attributes, tensor_args, program_key.hash, program_cache_hit);
+
+    if (program_cache_hit) {
+        if constexpr (HasValidateOnProgramCacheHit<mesh_device_operation_t>) {
+            mesh_device_operation_t::validate_on_program_cache_hit(operation_attributes, tensor_args);
+        } else {
+            mesh_device_operation_t::validate_on_program_cache_miss(operation_attributes, tensor_args);
+        }
+        auto& cached_program_factory = program_cache.get(program_key);
+        auto& cached_mesh_workload = cached_program_factory.cached_program.template get<cached_mesh_workload_t>();
+        Adapter::apply_run_args(cached_mesh_workload, built);
+        enqueue_mesh_workload<mesh_device_operation_t>(
+            operation_attributes, tensor_args, tensor_return_value, mesh_device, cached_mesh_workload.workload);
+    } else {
+        mesh_device_operation_t::validate_on_program_cache_miss(operation_attributes, tensor_args);
+        auto cached_workload = Adapter::build_mesh_workload(built, tensor_coords, mesh_device);
+
+        bool hook_blocks = false;
+        if (auto hook = tt::tt_metal::GraphTracker::instance().get_hook()) {
+            auto* processor_hooks = dynamic_cast<ttnn::graph::ProcessorHooks*>(hook.get());
+            if (processor_hooks) {
+                hook_blocks = processor_hooks->get_block();
+            }
+        }
+        if (program_cache.is_enabled() && !hook_blocks) {
+            program_cache.insert(program_key, CachedProgramFactory{std::move(cached_workload), program_factory_index});
+            auto& cached_program_factory = program_cache.get(program_key);
+            auto& workload = cached_program_factory.cached_program.template get<cached_mesh_workload_t>().workload;
+            enqueue_mesh_workload<mesh_device_operation_t>(
+                operation_attributes, tensor_args, tensor_return_value, mesh_device, workload);
+        } else {
+            enqueue_mesh_workload<mesh_device_operation_t>(
+                operation_attributes, tensor_args, tensor_return_value, mesh_device, cached_workload.workload);
+        }
+    }
+}
+
+// Launch path for Spec ops: route to the base spec adapter, or -- for the discouraged owned-tensor opt-in
+// -- the separate owned adapter, which exists apart precisely so it reads as "you are doing something
+// wrong" and can be deleted wholesale once no op needs it.
+template <DeviceOperationWithMeshDeviceAdapter mesh_device_operation_t>
+void launch_mesh_program_spec(
+    const typename mesh_device_operation_t::operation_attributes_t& operation_attributes,
+    const typename mesh_device_operation_t::tensor_args_t& tensor_args,
+    typename mesh_device_operation_t::tensor_return_value_t& tensor_return_value,
+    ttnn::MeshDevice* mesh_device) {
+    auto program_factory = mesh_device_operation_t::select_program_factory(operation_attributes, tensor_args);
+    auto program_factory_index = program_factory.index();
+    std::visit(
+        [&]<ProgramSpecFactoryConcept SpecFactory>(const SpecFactory&) {
+            if constexpr (ProgramSpecFactoryWithOwnedTensorsConcept<SpecFactory>) {
+                run_spec_flow<
+                    typename mesh_device_operation_t::template ProgramSpecWithOwnedTensorsMeshWorkloadFactoryAdapter<
+                        SpecFactory>,
+                    mesh_device_operation_t>(
+                    operation_attributes, tensor_args, tensor_return_value, mesh_device, program_factory_index);
+            } else {
+                run_spec_flow<
+                    typename mesh_device_operation_t::template ProgramSpecMeshWorkloadFactoryAdapter<SpecFactory>,
+                    mesh_device_operation_t>(
+                    operation_attributes, tensor_args, tensor_return_value, mesh_device, program_factory_index);
+            }
+        },
+        program_factory);
+}
+
 // Main function to launch operations on mesh devices with special handling for MeshDeviceOperationAdapter
 template <DeviceOperationWithMeshDeviceAdapter mesh_device_operation_t>
 void launch_operation_with_adapter(
@@ -368,6 +490,13 @@ void launch_operation_with_adapter(
         if (mesh_device_operation_t::skip_launch(operation_attributes, tensor_args, tensor_return_value)) {
             return;
         }
+    }
+
+    // Spec ops take the dedicated spec-as-key path (build the spec, key on it, apply or build).
+    if constexpr (is_program_spec_mesh_op_v<mesh_device_operation_t>) {
+        launch_mesh_program_spec<mesh_device_operation_t>(
+            operation_attributes, tensor_args, tensor_return_value, mesh_device);
+        return;
     }
 
     auto& program_cache = mesh_device->get_program_cache();

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -493,12 +493,12 @@ void launch_operation_with_adapter(
     }
 
     // Spec ops take the dedicated spec-as-key path (build the spec, key on it, apply or build).
+    // The generic mesh-adapter body below is in an `else` (not just guarded by an early return) so
+    // it is not *instantiated* for spec ops -- its visitor has no ProgramSpecFactoryConcept overload.
     if constexpr (is_program_spec_mesh_op_v<mesh_device_operation_t>) {
         launch_mesh_program_spec<mesh_device_operation_t>(
             operation_attributes, tensor_args, tensor_return_value, mesh_device);
-        return;
-    }
-
+    } else {
     auto& program_cache = mesh_device->get_program_cache();
     // The cache key is the 64-bit hash plus an exact canonical encoding; a hash collision is
     // resolved by std::unordered_map's own operator== on the canonical part (issue #45821).
@@ -531,6 +531,7 @@ void launch_operation_with_adapter(
     } else {
         create_and_cache_mesh_workload<mesh_device_operation_t>(
             operation_attributes, tensor_args, tensor_return_value, mesh_device, program_cache, program_key);
+    }
     }
 }
 

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -853,7 +853,9 @@ public:
         // run_params reference this dispatch's tensors.)
         static void apply_run_args(cached_mesh_workload_t& cached_workload, const BuiltSpec& built) {
             for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-                tt::tt_metal::experimental::SetProgramRunArgs(program, built.artifacts.run_params);
+                // skip_validation: the args were validated on the cache miss, and the factory rebuilds
+                // them conformant to the (matched) spec every dispatch -- re-validating on a hit is redundant.
+                tt::tt_metal::experimental::SetProgramRunArgs(program, built.artifacts.run_params, /*skip_validation=*/true);
             }
         }
     };
@@ -914,7 +916,8 @@ public:
         // Cache hit: apply this dispatch's fresh run args and re-park this dispatch's owned tensors.
         static void apply_run_args(cached_mesh_workload_t& cached_workload, const BuiltSpec& built) {
             for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-                tt::tt_metal::experimental::SetProgramRunArgs(program, built.artifacts.run_params);
+                // skip_validation: validated on the cache miss; the factory rebuilds conformant args every hit.
+                tt::tt_metal::experimental::SetProgramRunArgs(program, built.artifacts.run_params, /*skip_validation=*/true);
                 cached_workload.shared_variables.at(coordinate_range).owned_tensors = built.owned;
             }
         }

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -24,11 +24,14 @@
 #include <unordered_map>
 #include <variant>
 #include <vector>
+#include <span>
 #include <array>
 #include <tuple>
 #include "ttnn/distributed/types.hpp"
 #include "ttnn/mesh_device_operation_utils.hpp"
 #include "ttnn/metal_v2_artifacts.hpp"
+#include "ttnn/program_spec_artifacts.hpp"
+#include "ttnn/program_spec_hash.hpp"
 #include "ttnn/operation_concepts.hpp"
 #include "ttnn/operation.hpp"
 #include <tt_stl/reflection.hpp>
@@ -794,6 +797,125 @@ public:
                     fresh_tensor_args.emplace(b.tensor_parameter_name, TensorArgument{mesh_tensors[b.tensor_idx]});
                 }
                 tt::tt_metal::experimental::UpdateTensorArgs(program, fresh_tensor_args);
+            }
+        }
+    };
+
+    // -----------------------------------------------------------------------
+    // ProgramSpecMeshWorkloadFactoryAdapter (Spec)
+    //
+    // Adapts a ProgramSpecFactoryConcept factory. The launch builds the spec once (create_spec), hashes
+    // its ProgramSpec content for the cache key (always from the spec), then builds a Program per
+    // coordinate range on a miss or re-binds tensors on a hit.
+    // -----------------------------------------------------------------------
+    template <ProgramSpecFactoryConcept SpecFactory>
+    struct ProgramSpecMeshWorkloadFactoryAdapter {
+        // No per-entry state: a Spec op's run args are rebuilt from the spec every dispatch.
+        struct shared_variables_t {};
+        using cached_mesh_workload_t = AdaptedCachedMeshWorkload<shared_variables_t>;
+
+        // The build product of one dispatch: just the artifacts (spec + run args).
+        struct BuiltSpec {
+            ProgramSpecArtifacts artifacts;
+        };
+
+        // Explicit create_spec: build the ProgramSpecArtifacts. Run args reference this dispatch's
+        // tensors, so they can be applied directly on both miss and hit.
+        static BuiltSpec create_spec(
+            const operation_attributes_t& attrs,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value) {
+            return BuiltSpec{SpecFactory::create_program_spec(attrs, tensor_args, tensor_return_value)};
+        }
+
+        // Cache key: the ProgramSpec content combined with the op type. Always from the spec.
+        static ttsl::hash::hash_t cache_hash(const ProgramSpecArtifacts& artifacts) {
+            return ttsl::hash::hash_objects(
+                ttsl::hash::type_hash<DeviceOperation>, program_spec_cache_key(artifacts.spec));
+        }
+
+        // Cache miss: build one Program per coordinate range from the spec and supply its run args.
+        static cached_mesh_workload_t build_mesh_workload(
+            const BuiltSpec& built, const ttnn::MeshCoordinateRangeSet& tensor_coords, ttnn::MeshDevice* mesh_device) {
+            tt::tt_metal::distributed::MeshWorkload mesh_workload;
+            std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
+            for (const auto& range : tensor_coords.ranges()) {
+                auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, built.artifacts.spec);
+                tt::tt_metal::experimental::SetProgramRunArgs(program, built.artifacts.run_params);
+                shared_variables.emplace(range, shared_variables_t{});
+                mesh_workload.add_program(range, std::move(program));
+            }
+            return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
+        }
+
+        // Cache hit: supply this dispatch's freshly-built run args to each cached Program -- the canonical
+        // per-execution apply, not a tensor-arg patch. (create_spec already ran to produce the key, so
+        // run_params reference this dispatch's tensors.)
+        static void apply_run_args(cached_mesh_workload_t& cached_workload, const BuiltSpec& built) {
+            for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
+                tt::tt_metal::experimental::SetProgramRunArgs(program, built.artifacts.run_params);
+            }
+        }
+    };
+
+    // -----------------------------------------------------------------------
+    // ProgramSpecWithOwnedTensorsMeshWorkloadFactoryAdapter (SpecWithOwnedTensors)
+    //
+    // Opt-in and discouraged: the factory allocates its own device tensors via get_owned_tensors that its
+    // run args reference. ttnn keeps them alive for the cache entry so they outlive the async enqueue.
+    // Everything owned-tensor-specific lives here -- the base Spec adapter has none of it. Reach for this
+    // only if an op genuinely cannot express every tensor as an io arg.
+    // -----------------------------------------------------------------------
+    template <ProgramSpecFactoryWithOwnedTensorsConcept SpecFactory>
+    struct ProgramSpecWithOwnedTensorsMeshWorkloadFactoryAdapter {
+        struct shared_variables_t {
+            // Op-owned tensors kept alive for the cache entry so they outlive the async enqueue.
+            std::shared_ptr<std::vector<tt::tt_metal::MeshTensor>> owned_tensors;
+        };
+        using cached_mesh_workload_t = AdaptedCachedMeshWorkload<shared_variables_t>;
+
+        // The build product of one dispatch: the artifacts plus the owned tensors they reference.
+        struct BuiltSpec {
+            ProgramSpecArtifacts artifacts;
+            std::shared_ptr<std::vector<tt::tt_metal::MeshTensor>> owned;
+        };
+
+        // Explicit create_spec: allocate the owned tensors, then build the artifacts referencing them.
+        static BuiltSpec create_spec(
+            const operation_attributes_t& attrs,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value) {
+            auto owned = std::make_shared<std::vector<tt::tt_metal::MeshTensor>>(
+                SpecFactory::get_owned_tensors(attrs, tensor_args, tensor_return_value));
+            auto artifacts = SpecFactory::create_program_spec(
+                attrs, tensor_args, tensor_return_value, std::span<const tt::tt_metal::MeshTensor>(*owned));
+            return BuiltSpec{std::move(artifacts), std::move(owned)};
+        }
+
+        static ttsl::hash::hash_t cache_hash(const ProgramSpecArtifacts& artifacts) {
+            return ttsl::hash::hash_objects(
+                ttsl::hash::type_hash<DeviceOperation>, program_spec_cache_key(artifacts.spec));
+        }
+
+        // Cache miss: build a Program per range from the spec and park the owned tensors so they stay alive.
+        static cached_mesh_workload_t build_mesh_workload(
+            const BuiltSpec& built, const ttnn::MeshCoordinateRangeSet& tensor_coords, ttnn::MeshDevice* mesh_device) {
+            tt::tt_metal::distributed::MeshWorkload mesh_workload;
+            std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
+            for (const auto& range : tensor_coords.ranges()) {
+                auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, built.artifacts.spec);
+                tt::tt_metal::experimental::SetProgramRunArgs(program, built.artifacts.run_params);
+                shared_variables.emplace(range, shared_variables_t{.owned_tensors = built.owned});
+                mesh_workload.add_program(range, std::move(program));
+            }
+            return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
+        }
+
+        // Cache hit: apply this dispatch's fresh run args and re-park this dispatch's owned tensors.
+        static void apply_run_args(cached_mesh_workload_t& cached_workload, const BuiltSpec& built) {
+            for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
+                tt::tt_metal::experimental::SetProgramRunArgs(program, built.artifacts.run_params);
+                cached_workload.shared_variables.at(coordinate_range).owned_tensors = built.owned;
             }
         }
     };

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -72,6 +72,8 @@ template <typename T>
 concept ProgramDescriptorFactoryConcept = (requires { &T::create_descriptor; } || WorkloadDescriptorConcept<T>) &&
                                           !ProgramFactoryConcept<T> && !MeshWorkloadFactoryConcept<T>;
 
+// === Temporary Solution to Unblock Quasar === op-porting concept owned elsewhere; keep as-is, to be
+// deleted once ports move to ProgramSpecFactoryConcept below.
 // Metal 2.0 op-porting stepping-stone factory concept: factories that return
 // ProgramArtifacts (a ProgramSpec + ProgramRunArgs + any op-owned tensors) from
 // create_program_artifacts. The framework adapter stamps a Program from the spec onto
@@ -90,6 +92,18 @@ concept ProgramDescriptorFactoryConcept = (requires { &T::create_descriptor; } |
 template <typename T>
 concept MetalV2FactoryConcept = requires { &T::create_program_artifacts; } && !ProgramFactoryConcept<T> &&
                                 !MeshWorkloadFactoryConcept<T> && !ProgramDescriptorFactoryConcept<T>;
+
+// === Spec === keys the program cache on the ProgramSpec content (always hashed from the spec, never a
+// cheap attribute hash). Factory returns ProgramSpecArtifacts from create_program_spec.
+template <typename T>
+concept ProgramSpecFactoryConcept =
+    requires { &T::create_program_spec; } && !ProgramFactoryConcept<T> && !MeshWorkloadFactoryConcept<T> &&
+    !ProgramDescriptorFactoryConcept<T> && !MetalV2FactoryConcept<T>;
+
+// === SpecWithOwnedTensors === a Spec factory that also allocates its own device tensors via
+// get_owned_tensors (scratch/config). Discouraged; prefer expressing every tensor as an io arg.
+template <typename T>
+concept ProgramSpecFactoryWithOwnedTensorsConcept = ProgramSpecFactoryConcept<T> && requires { &T::get_owned_tensors; };
 
 // Detect operations that put create_descriptor directly on the operation struct
 // (no program_factory_t wrapper needed for single-descriptor operations).
@@ -126,9 +140,8 @@ concept HasSelectProgramFactory = requires(
     } -> std::same_as<typename device_operation_t::program_factory_t>;
 };
 
-// Validate that all variant alternatives in a program_factory_t satisfy exactly one of
-// ProgramFactoryConcept, MeshWorkloadFactoryConcept, ProgramDescriptorFactoryConcept,
-// or MetalV2FactoryConcept.
+// Each variant alternative must satisfy exactly one factory concept. SpecWithOwnedTensors is a
+// refinement of ProgramSpecFactoryConcept, so it is not counted as a separate bucket.
 namespace detail {
 template <typename Variant, std::size_t... Is>
 consteval bool all_factories_valid(std::index_sequence<Is...>) {
@@ -136,7 +149,8 @@ consteval bool all_factories_valid(std::index_sequence<Is...>) {
         ((ProgramFactoryConcept<std::variant_alternative_t<Is, Variant>> +
           MeshWorkloadFactoryConcept<std::variant_alternative_t<Is, Variant>> +
           ProgramDescriptorFactoryConcept<std::variant_alternative_t<Is, Variant>> +
-          MetalV2FactoryConcept<std::variant_alternative_t<Is, Variant>>) == 1) &&
+          MetalV2FactoryConcept<std::variant_alternative_t<Is, Variant>> +
+          ProgramSpecFactoryConcept<std::variant_alternative_t<Is, Variant>>) == 1) &&
         ...);
 }
 }  // namespace detail

--- a/ttnn/api/ttnn/program_spec_artifacts.hpp
+++ b/ttnn/api/ttnn/program_spec_artifacts.hpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+
+namespace ttnn::device_operation {
+
+// Build product of a ProgramSpecFactoryConcept factory's create_program_spec: the immutable
+// ProgramSpec (the program-cache key) plus the ProgramRunArgs that bind it to this dispatch's tensors.
+struct ProgramSpecArtifacts {
+    tt::tt_metal::experimental::ProgramSpec spec;
+    tt::tt_metal::experimental::ProgramRunArgs run_params;
+};
+
+}  // namespace ttnn::device_operation

--- a/ttnn/api/ttnn/program_spec_hash.hpp
+++ b/ttnn/api/ttnn/program_spec_hash.hpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Content hash of a Metal 2.0 ProgramSpec, for use as a program-cache key.
+//
+// The ProgramSpec fully defines a compiled Program, so hashing it keys the cache
+// at program identity: two specs collide iff they describe the same Program. This
+// is the correct-by-construction replacement for hand-maintained per-op
+// compute_program_hash, which has to be kept in sync with the program by hand.
+//
+// ProgramSpec is reflection-hashable via ttsl::hash out of the box, so almost all
+// of it is hashed generically. The single semantic generic reflection can't express
+// is shape *relaxation*: a TensorParameter may declare dynamic_tensor_shape /
+// match_padded_shape_only, meaning the Program is invariant to (part of) the tensor
+// shape. The implementation honors that so volume-equivalent shapes (e.g. [2,3] and
+// [3,2], both one tile) share a cache entry instead of fragmenting it. Every other
+// field is folded in via reflection, so adding a field to
+// KernelSpec/DataflowBufferSpec/etc. is picked up automatically; a static_assert in
+// the .cpp guards the one place that isn't (the top-level ProgramSpec field set), so
+// a new ProgramSpec member can't silently slip out of the key.
+
+#include <cstddef>
+
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+
+namespace ttnn::device_operation {
+
+// Content hash of `spec`, suitable as a program-cache key. Combine with the op's
+// type hash at the call site so distinct ops with coincidentally-identical specs
+// don't collide.
+std::size_t program_spec_cache_key(const tt::tt_metal::experimental::ProgramSpec& spec);
+
+}  // namespace ttnn::device_operation

--- a/ttnn/api/ttnn/spec_run_args.hpp
+++ b/ttnn/api/ttnn/spec_run_args.hpp
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <deque>
 #include <initializer_list>
 #include <type_traits>
 #include <utility>
@@ -63,6 +64,31 @@ public:
 private:
     ttsl::SmallVector<RtaName, 8> names_;
     KernelRunArgs result_;
+};
+
+// Builds a whole program's run-args: declare each kernel once, emit per node, take() the lot.
+// take() MOVES every kernel in -- authors never write `kernel_run_args = {…}` (which silently copies).
+using tt::tt_metal::experimental::ProgramRunArgs;
+
+class ProgramRunArgsBuilder {
+public:
+    // Declare a kernel and its RTA names; returns a stable emitter (deque-backed, never invalidated).
+    KernelRunArgsBuilder& kernel(KernelSpecName name, std::initializer_list<RtaName> rta_names) {
+        return kernels_.emplace_back(std::move(name), rta_names);
+    }
+
+    // Move every kernel's run-args into one ProgramRunArgs. No copy: each KernelRunArgs is moved in.
+    ProgramRunArgs take() {
+        ProgramRunArgs out;
+        out.kernel_run_args.reserve(kernels_.size());
+        for (auto& k : kernels_) {
+            out.kernel_run_args.push_back(k.take());
+        }
+        return out;
+    }
+
+private:
+    std::deque<KernelRunArgsBuilder> kernels_;
 };
 
 }  // namespace ttnn::spec

--- a/ttnn/api/ttnn/spec_run_args.hpp
+++ b/ttnn/api/ttnn/spec_run_args.hpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <initializer_list>
+#include <type_traits>
+#include <utility>
+
+#include <tt_stl/assert.hpp>
+#include <tt_stl/small_vector.hpp>
+
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/runtime_arg_name.hpp>
+#include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
+#include <tt-metalium/experimental/metal2_host_api/kernel_spec.hpp>
+
+namespace ttnn::spec {
+
+using tt::tt_metal::experimental::KernelRunArgs;
+using tt::tt_metal::experimental::KernelSpecName;
+using tt::tt_metal::experimental::NodeCoord;
+using tt::tt_metal::experimental::RtaName;
+
+// Builds a kernel's per-node run-arg values: declare names once, then emit(node, v0, v1, ...) per node.
+// Fills each Table via append_unchecked (names unique by schema), so it is cleaner AND O(N) per node.
+class KernelRunArgsBuilder {
+public:
+    KernelRunArgsBuilder(KernelSpecName kernel, std::initializer_list<RtaName> names) : names_(names) {
+        result_.kernel = std::move(kernel);
+    }
+
+    // Reserve space for `n` nodes up front (one emit() per node).
+    KernelRunArgsBuilder& reserve(std::size_t n) {
+        result_.runtime_arg_values.reserve(n);
+        return *this;
+    }
+
+    // Append one node's values, matched positionally to the declared names.
+    template <typename... Vs>
+    KernelRunArgsBuilder& emit(const NodeCoord& node, Vs... values) {
+        static_assert(
+            (std::is_convertible_v<Vs, uint32_t> && ...), "KernelRunArgsBuilder::emit values must convert to uint32_t");
+        TT_FATAL(
+            sizeof...(values) == names_.size(),
+            "KernelRunArgsBuilder::emit received {} values but {} names were declared",
+            sizeof...(values),
+            names_.size());
+        KernelRunArgs::RuntimeArgValues args;
+        args.reserve(names_.size());
+        std::size_t i = 0;
+        ((args.append_unchecked(names_[i++], static_cast<uint32_t>(values))), ...);
+        result_.runtime_arg_values.push_back({node, std::move(args)});
+        return *this;
+    }
+
+    // Hand off the built KernelRunArgs. The builder is empty afterward.
+    KernelRunArgs take() { return std::move(result_); }
+
+private:
+    ttsl::SmallVector<RtaName, 8> names_;
+    KernelRunArgs result_;
+};
+
+}  // namespace ttnn::spec

--- a/ttnn/core/program_spec_hash.cpp
+++ b/ttnn/core/program_spec_hash.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/program_spec_hash.hpp"
+
+#include <cstdint>
+
+#include <reflect>
+#include <tt_stl/reflection.hpp>
+
+namespace ttnn::device_operation {
+
+namespace {
+
+// TensorParameter, with shape folded in per its declared relaxations. (Everything
+// else about the parameter is identity-relevant and always hashed.)
+std::size_t hash_tensor_parameter(const tt::tt_metal::experimental::TensorParameter& p) {
+    const auto& spec = p.spec;
+    // Data type, layout and memory config (which carries the sharding configuration) are always
+    // identity-relevant, so they always go into the hash. Only the *shape* is folded in conditionally,
+    // per the parameter's declared relaxations below.
+    std::size_t hash = ttsl::hash::hash_objects_with_default_seed(
+        p.unique_id.get(), spec.data_type(), spec.layout(), spec.memory_config());
+
+    if (p.advanced_options.dynamic_tensor_shape) {
+        // Program depends only on element/page count, not on tensor shape.
+        hash = ttsl::hash::hash_objects(hash, static_cast<uint64_t>(spec.padded_shape().volume()));
+    } else if (p.advanced_options.match_padded_shape_only) {
+        // Logical shape may vary; the padded shape (and thus access pattern) is fixed.
+        hash = ttsl::hash::hash_objects(hash, spec.padded_shape());
+    } else {
+        hash = ttsl::hash::hash_objects(hash, spec.logical_shape(), spec.padded_shape());
+    }
+    return hash;
+}
+
+}  // namespace
+
+std::size_t program_spec_cache_key(const tt::tt_metal::experimental::ProgramSpec& spec) {
+    // ProgramSpec currently has 7 fields; tensor_parameters is the only one needing
+    // relaxation-aware handling, so it is hashed separately below and the other six
+    // are hashed generically. If a field is added/removed, update this function (and
+    // this count) so the new field participates in the key.
+    static_assert(reflect::size<tt::tt_metal::experimental::ProgramSpec>() == 7);
+
+    std::size_t hash = ttsl::hash::hash_objects_with_default_seed(
+        spec.name,
+        spec.kernels,
+        spec.dataflow_buffers,
+        spec.cross_node_dataflow_buffers,
+        spec.semaphores,
+        spec.work_units);
+
+    for (const auto& p : spec.tensor_parameters) {
+        hash = ttsl::hash::hash_objects(hash, hash_tensor_parameter(p));
+    }
+    return hash;
+}
+
+}  // namespace ttnn::device_operation

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
@@ -46,10 +46,18 @@ const KernelSpecName I2S_COMPUTE{"i2s_compute"};
 constexpr uint32_t num_slices = 1;
 constexpr uint32_t slice_index = 0;
 
-ttnn::device_operation::ProgramArtifacts InterleavedToShardedProgramFactory::create_program_artifacts(
+std::vector<tt::tt_metal::MeshTensor> InterleavedToShardedProgramFactory::get_owned_tensors(
+    const InterleavedToShardedParams& /*operation_attributes*/,
+    const InterleavedToShardedInputs& /*tensor_args*/,
+    Tensor& /*output_tensor*/) {
+    return {};
+}
+
+ttnn::device_operation::ProgramSpecArtifacts InterleavedToShardedProgramFactory::create_program_spec(
     const InterleavedToShardedParams& /*operation_attributes*/,
     const InterleavedToShardedInputs& tensor_args,
-    Tensor& output_tensor) {
+    Tensor& output_tensor,
+    std::span<const tt::tt_metal::MeshTensor> /*owned_tensors*/) {
     const auto& input = tensor_args.input_tensor;
     const auto& output = output_tensor;
     // Keep explicit bool init to match legacy behavior which forced it true
@@ -495,17 +503,17 @@ ttnn::device_operation::ProgramArtifacts InterleavedToShardedProgramFactory::cre
         }
     }
 
-    run_args.kernel_run_args.push_back(reader_run);
-    run_args.kernel_run_args.push_back(writer_run);
+    run_args.kernel_run_args.push_back(std::move(reader_run));
+    run_args.kernel_run_args.push_back(std::move(writer_run));
     if (convert_df) {
-        run_args.kernel_run_args.push_back(compute_run);
+        run_args.kernel_run_args.push_back(std::move(compute_run));
     }
 
     // Tensor arguments: reference the same MeshTensors the parameters were declared from.
     run_args.tensor_args.emplace(I2S_INPUT, TensorArgument{input.mesh_tensor()});
     run_args.tensor_args.emplace(I2S_OUTPUT, TensorArgument{output.mesh_tensor()});
 
-    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
+    return ttnn::device_operation::ProgramSpecArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.hpp
@@ -5,16 +5,28 @@
 #pragma once
 
 #include "ttnn/device_operation.hpp"
-#include "ttnn/metal_v2_artifacts.hpp"
+#include "ttnn/program_spec_artifacts.hpp"
 #include "interleaved_to_sharded_op_types.hpp"
+
+#include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
+#include <span>
+#include <vector>
 
 namespace ttnn::prim::qsr {
 
+// Metal 2.0 (ProgramSpecFactoryWithOwnedTensorsConcept) factory for interleaved->sharded.
 struct InterleavedToShardedProgramFactory {
-    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
+    // No scratch/config tensors; routes through the owned-tensors adapter for parity with other spec ops.
+    static std::vector<tt::tt_metal::MeshTensor> get_owned_tensors(
         const InterleavedToShardedParams& operation_attributes,
         const InterleavedToShardedInputs& tensor_args,
         Tensor& output_tensor);
+
+    static ttnn::device_operation::ProgramSpecArtifacts create_program_spec(
+        const InterleavedToShardedParams& operation_attributes,
+        const InterleavedToShardedInputs& tensor_args,
+        Tensor& output_tensor,
+        std::span<const tt::tt_metal::MeshTensor> owned_tensors);
 };
 
 }  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_overlap_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_overlap_program_factory.cpp
@@ -173,7 +173,7 @@ ttnn::device_operation::ProgramArtifacts MoveOverlapProgramFactory::create_progr
     // Named RTA schema (per-node values supplied below). One named arg per legacy
     // positional slot; the legacy src/dst-address (slots 0,1) and semaphore-id (slot 4)
     // slots are gone — those are now bindings.
-    m2::Group<std::string> rta_names = {
+    m2::Group<m2::RtaName> rta_names = {
         "start_id",      "num_pages",           "controller_noc_x",    "controller_noc_y",  "control_value",
         "is_controller", "range_0_start_noc_x", "range_0_start_noc_y", "range_0_end_noc_x", "range_0_end_noc_y",
         "range_0_size",  "range_1_start_noc_x", "range_1_start_noc_y", "range_1_end_noc_x", "range_1_end_noc_y",

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_cn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_cn_program_factory.cpp
@@ -29,7 +29,7 @@ const TensorParamName OUTPUT{"output"};
 
 }  // namespace
 
-ttnn::device_operation::ProgramArtifacts TransposeCNProgramFactory::create_program_artifacts(
+ttnn::device_operation::ProgramSpecArtifacts TransposeCNProgramFactory::create_program_spec(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
     const auto& input_tensor = tensor_args.input;
     const auto& input_mesh_tensor = input_tensor.mesh_tensor();
@@ -232,7 +232,7 @@ ttnn::device_operation::ProgramArtifacts TransposeCNProgramFactory::create_progr
     run_args.tensor_args.emplace(INPUT, input_mesh_tensor);
     run_args.tensor_args.emplace(OUTPUT, output_mesh_tensor);
 
-    return ttnn::device_operation::ProgramArtifacts{
+    return ttnn::device_operation::ProgramSpecArtifacts{
         .spec = std::move(spec),
         .run_params = std::move(run_args),
     };

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_cn_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_cn_program_factory.hpp
@@ -6,12 +6,12 @@
 #include "transpose_device_operation_types.hpp"
 
 #include "ttnn/device_operation.hpp"
-#include "ttnn/metal_v2_artifacts.hpp"
+#include "ttnn/program_spec_artifacts.hpp"
 
 namespace ttnn::prim::qsr {
 
 struct TransposeCNProgramFactory {
-    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
+    static ttnn::device_operation::ProgramSpecArtifacts create_program_spec(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_device_operation.hpp
@@ -8,7 +8,6 @@
 #include "transpose_hc_rm_program_factory.hpp"
 #include "transpose_hc_sharded_program_factory.hpp"
 #include "transpose_hc_tiled_interleaved_program_factory.hpp"
-#include "transpose_hc_tiled_program_factory.hpp"
 #include "transpose_wh_program_factory.hpp"
 #include "transpose_wh_sharded_program_factory.hpp"
 #include "transpose_wh_sharded_rm_program_factory.hpp"
@@ -30,7 +29,6 @@ struct TransposeDeviceOperation {
         TransposeWHShardedProgramFactory,
         TransposeWHShardedRMProgramFactory,
         TransposeHCTiledInterleavedProgramFactory,
-        TransposeHCTiledProgramFactory,
         TransposeHCRMProgramFactory,
         TransposeHCShardedProgramFactory,
         TransposeCNProgramFactory>;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_rm_program_factory.cpp
@@ -21,7 +21,7 @@ using namespace tt::tt_metal::experimental;
 
 namespace ttnn::prim::qsr {
 
-ttnn::device_operation::ProgramArtifacts TransposeHCRMProgramFactory::create_program_artifacts(
+ttnn::device_operation::ProgramSpecArtifacts TransposeHCRMProgramFactory::create_program_spec(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
     // Metal 2.0 named resource handles (locals to avoid unity-build name collisions).
     const DFBSpecName CB_IN0{"cb_in0"};  // legacy c_0: stick stream (reader produces, writer consumes)
@@ -214,7 +214,7 @@ ttnn::device_operation::ProgramArtifacts TransposeHCRMProgramFactory::create_pro
         {INPUT_TENSOR, TensorArgument{std::cref(input_tensor.mesh_tensor())}},
         {OUTPUT_TENSOR, TensorArgument{std::cref(output_tensor.mesh_tensor())}}};
 
-    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
+    return ttnn::device_operation::ProgramSpecArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_rm_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_rm_program_factory.hpp
@@ -6,15 +6,15 @@
 #include "transpose_device_operation_types.hpp"
 
 #include "ttnn/device_operation.hpp"
-#include "ttnn/metal_v2_artifacts.hpp"
+#include "ttnn/program_spec_artifacts.hpp"
 
 #include <tt-metalium/core_coord.hpp>
 
 namespace ttnn::prim::qsr {
 
-// Metal 2.0 (MetalV2FactoryConcept) factory for the H<->C row-major transpose path.
+// Metal 2.0 (ProgramSpecFactoryConcept) factory for the H<->C row-major transpose path.
 struct TransposeHCRMProgramFactory {
-    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
+    static ttnn::device_operation::ProgramSpecArtifacts create_program_spec(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_sharded_program_factory.cpp
@@ -288,7 +288,7 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
 
 }  // namespace
 
-ttnn::device_operation::ProgramArtifacts TransposeHCShardedProgramFactory::create_program_artifacts(
+ttnn::device_operation::ProgramSpecArtifacts TransposeHCShardedProgramFactory::create_program_spec(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
     // Metal 2.0 named resource handles (locals to avoid unity-build name collisions).
     const DFBSpecName CB_IN{"cb_in"};    // legacy c_0: input shard (borrowed)
@@ -542,7 +542,7 @@ ttnn::device_operation::ProgramArtifacts TransposeHCShardedProgramFactory::creat
         {INPUT_TENSOR, TensorArgument{std::cref(input_tensor.mesh_tensor())}},
         {OUTPUT_TENSOR, TensorArgument{std::cref(output_tensor.mesh_tensor())}}};
 
-    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
+    return ttnn::device_operation::ProgramSpecArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_sharded_program_factory.hpp
@@ -6,20 +6,20 @@
 #include "transpose_device_operation_types.hpp"
 
 #include "ttnn/device_operation.hpp"
-#include "ttnn/metal_v2_artifacts.hpp"
+#include "ttnn/program_spec_artifacts.hpp"
 
 #include <tt-metalium/core_coord.hpp>
 
 namespace ttnn::prim::qsr {
 
-// Metal 2.0 (MetalV2FactoryConcept) factory for the sharded, row-major H<->C transpose path.
+// Metal 2.0 (ProgramSpecFactoryConcept) factory for the sharded, row-major H<->C transpose path.
 // The input/output shards live in L1, so cb_in/cb_out are borrowed-memory DFBs aliasing the
 // input/output tensor shard buffers; sticks are reshuffled across cores purely by NoC reads. The
 // generic path uses a single reader (cb_in/cb_out self-loop); the special case splits the work
 // across a reader + writer. The per-core NoC-coordinate / stick-offset lists are passed as runtime
 // varargs (variable length, recovered on device from named args).
 struct TransposeHCShardedProgramFactory {
-    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
+    static ttnn::device_operation::ProgramSpecArtifacts create_program_spec(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
@@ -38,7 +38,7 @@ const TensorParamName OUTPUT{"output"};
 
 }  // namespace
 
-ttnn::device_operation::ProgramArtifacts TransposeHCTiledInterleavedProgramFactory::create_program_artifacts(
+ttnn::device_operation::ProgramSpecArtifacts TransposeHCTiledInterleavedProgramFactory::create_program_spec(
     const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor) {
     const auto& input_tensor = tensor_args.input;
     const auto& input_mesh_tensor = input_tensor.mesh_tensor();
@@ -297,7 +297,7 @@ ttnn::device_operation::ProgramArtifacts TransposeHCTiledInterleavedProgramFacto
     run_args.tensor_args.emplace(INPUT, input_mesh_tensor);
     run_args.tensor_args.emplace(OUTPUT, output_mesh_tensor);
 
-    return ttnn::device_operation::ProgramArtifacts{
+    return ttnn::device_operation::ProgramSpecArtifacts{
         .spec = std::move(spec),
         .run_params = std::move(run_args),
     };

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_tiled_interleaved_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_tiled_interleaved_program_factory.hpp
@@ -6,12 +6,12 @@
 #include "transpose_device_operation_types.hpp"
 
 #include "ttnn/device_operation.hpp"
-#include "ttnn/metal_v2_artifacts.hpp"
+#include "ttnn/program_spec_artifacts.hpp"
 
 namespace ttnn::prim::qsr {
 
 struct TransposeHCTiledInterleavedProgramFactory {
-    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
+    static ttnn::device_operation::ProgramSpecArtifacts create_program_spec(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_program_factory.cpp
@@ -21,7 +21,7 @@ using namespace tt::tt_metal::experimental;
 
 namespace ttnn::prim::qsr {
 
-ttnn::device_operation::ProgramArtifacts TransposeWHProgramFactory::create_program_artifacts(
+ttnn::device_operation::ProgramSpecArtifacts TransposeWHProgramFactory::create_program_spec(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
     // Metal 2.0 named resource handles (locals to avoid unity-build name collisions).
     const DFBSpecName CB_IN0{"cb_in0"};        // legacy c_0: input tile stream
@@ -344,7 +344,7 @@ ttnn::device_operation::ProgramArtifacts TransposeWHProgramFactory::create_progr
         {INPUT_TENSOR, TensorArgument{std::cref(input_tensor.mesh_tensor())}},
         {OUTPUT_TENSOR, TensorArgument{std::cref(output_tensor.mesh_tensor())}}};
 
-    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
+    return ttnn::device_operation::ProgramSpecArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_program_factory.cpp
@@ -21,8 +21,18 @@ using namespace tt::tt_metal::experimental;
 
 namespace ttnn::prim::qsr {
 
+std::vector<tt::tt_metal::MeshTensor> TransposeWHProgramFactory::get_owned_tensors(
+    const TransposeParams& /*operation_attributes*/,
+    const TransposeInputs& /*tensor_args*/,
+    Tensor& /*output_tensor*/) {
+    return {};
+}
+
 ttnn::device_operation::ProgramSpecArtifacts TransposeWHProgramFactory::create_program_spec(
-    const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
+    const TransposeParams& /*operation_attributes*/,
+    const TransposeInputs& tensor_args,
+    Tensor& output_tensor,
+    std::span<const tt::tt_metal::MeshTensor> /*owned_tensors*/) {
     // Metal 2.0 named resource handles (locals to avoid unity-build name collisions).
     const DFBSpecName CB_IN0{"cb_in0"};        // legacy c_0: input tile stream
     const DFBSpecName CB_OUT0{"cb_out0"};      // legacy c_16: transposed output stream

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_program_factory.cpp
@@ -129,9 +129,7 @@ ttnn::device_operation::ProgramSpecArtifacts TransposeWHProgramFactory::create_p
     };
 
     std::vector<KernelSpec> kernels;
-    KernelRunArgs reader_run;
-    KernelRunArgs writer_run;
-    KernelRunArgs compute_run;
+    ttnn::spec::ProgramRunArgsBuilder rab;
 
     if (row_major) {
         // --------------------------------------------------------------------
@@ -220,14 +218,15 @@ ttnn::device_operation::ProgramSpecArtifacts TransposeWHProgramFactory::create_p
             compute_spec.compiler_options.defines = {{"DST_ACCUM_MODE", "1"}};
         }
 
-        kernels = {std::move(reader_spec), std::move(writer_spec), std::move(compute_spec)};
+        // push_back(move) not `= {…}`: initializer_list elements are const, so a braced move silently copies.
+        kernels.reserve(3);
+        kernels.push_back(std::move(reader_spec));
+        kernels.push_back(std::move(writer_spec));
+        kernels.push_back(std::move(compute_spec));
 
-        ttnn::spec::KernelRunArgsBuilder reader_b(READER_KERNEL, {"start_id", "num_hw_blocks"});
-        ttnn::spec::KernelRunArgsBuilder compute_b(COMPUTE_KERNEL, {"num_hw_blocks"});
-        ttnn::spec::KernelRunArgsBuilder writer_b(WRITER_KERNEL, {"start_id", "num_hw_blocks"});
-        reader_b.reserve(num_cores_total);
-        compute_b.reserve(num_cores_total);
-        writer_b.reserve(num_cores_total);
+        auto& reader_b = rab.kernel(READER_KERNEL, {"start_id", "num_hw_blocks"}).reserve(num_cores_total);
+        auto& compute_b = rab.kernel(COMPUTE_KERNEL, {"num_hw_blocks"}).reserve(num_cores_total);
+        auto& writer_b = rab.kernel(WRITER_KERNEL, {"start_id", "num_hw_blocks"}).reserve(num_cores_total);
 
         for (uint32_t i = 0, num_sticks_read = 0, num_sticks_write = 0; i < num_cores_total; i++) {
             const CoreCoord core = {i / num_cores_y, i % num_cores_y};
@@ -248,9 +247,6 @@ ttnn::device_operation::ProgramSpecArtifacts TransposeWHProgramFactory::create_p
             num_sticks_read += num_hw_blocks_per_core * H;
             num_sticks_write += num_hw_blocks_per_core * W;
         }
-        reader_run = reader_b.take();
-        compute_run = compute_b.take();
-        writer_run = writer_b.take();
     } else {
         // --------------------------------------------------------------------
         // Tiled path: reader streams tiles in NWH order into cb_in0, compute transposes each tile
@@ -301,7 +297,11 @@ ttnn::device_operation::ProgramSpecArtifacts TransposeWHProgramFactory::create_p
             .hw_config = compute_cfg,
         };
 
-        kernels = {std::move(reader_spec), std::move(writer_spec), std::move(compute_spec)};
+        // push_back(move) not `= {…}`: initializer_list elements are const, so a braced move silently copies.
+        kernels.reserve(3);
+        kernels.push_back(std::move(reader_spec));
+        kernels.push_back(std::move(writer_spec));
+        kernels.push_back(std::move(compute_spec));
 
         // Tiled work walk uses padded-shape tile counts (preserved from legacy).
         const auto input_shape = input_tensor.padded_shape();
@@ -309,13 +309,11 @@ ttnn::device_operation::ProgramSpecArtifacts TransposeWHProgramFactory::create_p
         const uint32_t Ht_walk = input_shape[2] / TILE_HEIGHT;
         const uint32_t HtWt_walk = Ht_walk * Wt_walk;
 
-        ttnn::spec::KernelRunArgsBuilder reader_b(
-            READER_KERNEL, {"num_tiles", "start_id", "start_ht", "start_wt", "Ht", "Wt", "HtWt"});
-        ttnn::spec::KernelRunArgsBuilder compute_b(COMPUTE_KERNEL, {"NHtWt"});
-        ttnn::spec::KernelRunArgsBuilder writer_b(WRITER_KERNEL, {"num_pages", "start_id"});
-        reader_b.reserve(num_cores_total);
-        compute_b.reserve(num_cores_total);
-        writer_b.reserve(num_cores_total);
+        auto& reader_b =
+            rab.kernel(READER_KERNEL, {"num_tiles", "start_id", "start_ht", "start_wt", "Ht", "Wt", "HtWt"})
+                .reserve(num_cores_total);
+        auto& compute_b = rab.kernel(COMPUTE_KERNEL, {"NHtWt"}).reserve(num_cores_total);
+        auto& writer_b = rab.kernel(WRITER_KERNEL, {"num_pages", "start_id"}).reserve(num_cores_total);
 
         for (uint32_t i = 0, num_tiles_read = 0; i < num_cores_total; i++) {
             const CoreCoord core = {i / num_cores_y, i % num_cores_y};
@@ -346,9 +344,6 @@ ttnn::device_operation::ProgramSpecArtifacts TransposeWHProgramFactory::create_p
 
             num_tiles_read += num_tiles_per_core;
         }
-        reader_run = reader_b.take();
-        compute_run = compute_b.take();
-        writer_run = writer_b.take();
     }
 
     WorkUnitSpec wu{
@@ -365,8 +360,8 @@ ttnn::device_operation::ProgramSpecArtifacts TransposeWHProgramFactory::create_p
         .work_units = {wu},
     };
 
-    ProgramRunArgs run_args;
-    run_args.kernel_run_args = {std::move(reader_run), std::move(writer_run), std::move(compute_run)};
+    // take() moves every kernel's run-args in -- no braced-init copy, no manual assembly.
+    ProgramRunArgs run_args = rab.take();
     run_args.tensor_args = {
         {INPUT_TENSOR, TensorArgument{std::cref(input_tensor.mesh_tensor())}},
         {OUTPUT_TENSOR, TensorArgument{std::cref(output_tensor.mesh_tensor())}}};

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_program_factory.cpp
@@ -13,6 +13,8 @@
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 
+#include "ttnn/spec_run_args.hpp"
+
 #include <vector>
 
 using namespace tt::constants;
@@ -127,12 +129,9 @@ ttnn::device_operation::ProgramSpecArtifacts TransposeWHProgramFactory::create_p
     };
 
     std::vector<KernelSpec> kernels;
-    KernelRunArgs reader_run{.kernel = READER_KERNEL};
-    KernelRunArgs writer_run{.kernel = WRITER_KERNEL};
-    KernelRunArgs compute_run{.kernel = COMPUTE_KERNEL};
-    reader_run.runtime_arg_values.reserve(num_cores_total);
-    writer_run.runtime_arg_values.reserve(num_cores_total);
-    compute_run.runtime_arg_values.reserve(num_cores_total);
+    KernelRunArgs reader_run;
+    KernelRunArgs writer_run;
+    KernelRunArgs compute_run;
 
     if (row_major) {
         // --------------------------------------------------------------------
@@ -223,6 +222,13 @@ ttnn::device_operation::ProgramSpecArtifacts TransposeWHProgramFactory::create_p
 
         kernels = {std::move(reader_spec), std::move(writer_spec), std::move(compute_spec)};
 
+        ttnn::spec::KernelRunArgsBuilder reader_b(READER_KERNEL, {"start_id", "num_hw_blocks"});
+        ttnn::spec::KernelRunArgsBuilder compute_b(COMPUTE_KERNEL, {"num_hw_blocks"});
+        ttnn::spec::KernelRunArgsBuilder writer_b(WRITER_KERNEL, {"start_id", "num_hw_blocks"});
+        reader_b.reserve(num_cores_total);
+        compute_b.reserve(num_cores_total);
+        writer_b.reserve(num_cores_total);
+
         for (uint32_t i = 0, num_sticks_read = 0, num_sticks_write = 0; i < num_cores_total; i++) {
             const CoreCoord core = {i / num_cores_y, i % num_cores_y};
             uint32_t num_hw_blocks_per_core;
@@ -235,15 +241,16 @@ ttnn::device_operation::ProgramSpecArtifacts TransposeWHProgramFactory::create_p
             }
 
             const NodeCoord node = core;
-            reader_run.runtime_arg_values.push_back(
-                {node, {{"start_id", num_sticks_read}, {"num_hw_blocks", num_hw_blocks_per_core}}});
-            compute_run.runtime_arg_values.push_back({node, {{"num_hw_blocks", num_hw_blocks_per_core}}});
-            writer_run.runtime_arg_values.push_back(
-                {node, {{"start_id", num_sticks_write}, {"num_hw_blocks", num_hw_blocks_per_core}}});
+            reader_b.emit(node, num_sticks_read, num_hw_blocks_per_core);
+            compute_b.emit(node, num_hw_blocks_per_core);
+            writer_b.emit(node, num_sticks_write, num_hw_blocks_per_core);
 
             num_sticks_read += num_hw_blocks_per_core * H;
             num_sticks_write += num_hw_blocks_per_core * W;
         }
+        reader_run = reader_b.take();
+        compute_run = compute_b.take();
+        writer_run = writer_b.take();
     } else {
         // --------------------------------------------------------------------
         // Tiled path: reader streams tiles in NWH order into cb_in0, compute transposes each tile
@@ -302,6 +309,14 @@ ttnn::device_operation::ProgramSpecArtifacts TransposeWHProgramFactory::create_p
         const uint32_t Ht_walk = input_shape[2] / TILE_HEIGHT;
         const uint32_t HtWt_walk = Ht_walk * Wt_walk;
 
+        ttnn::spec::KernelRunArgsBuilder reader_b(
+            READER_KERNEL, {"num_tiles", "start_id", "start_ht", "start_wt", "Ht", "Wt", "HtWt"});
+        ttnn::spec::KernelRunArgsBuilder compute_b(COMPUTE_KERNEL, {"NHtWt"});
+        ttnn::spec::KernelRunArgsBuilder writer_b(WRITER_KERNEL, {"num_pages", "start_id"});
+        reader_b.reserve(num_cores_total);
+        compute_b.reserve(num_cores_total);
+        writer_b.reserve(num_cores_total);
+
         for (uint32_t i = 0, num_tiles_read = 0; i < num_cores_total; i++) {
             const CoreCoord core = {i / num_cores_y, i % num_cores_y};
             uint32_t num_tiles_per_core;
@@ -317,21 +332,23 @@ ttnn::device_operation::ProgramSpecArtifacts TransposeWHProgramFactory::create_p
             const uint32_t w = num_tiles_read / Ht_walk % Wt_walk;
 
             const NodeCoord node = core;
-            reader_run.runtime_arg_values.push_back(
-                {node,
-                 {{"num_tiles", num_tiles_per_core},
-                  {"start_id", tt::round_down(num_tiles_read, HtWt_walk) + (h * Wt_walk) + w},
-                  {"start_ht", h},
-                  {"start_wt", w},
-                  {"Ht", Ht_walk},
-                  {"Wt", Wt_walk},
-                  {"HtWt", HtWt_walk}}});
-            compute_run.runtime_arg_values.push_back({node, {{"NHtWt", num_tiles_per_core}}});
-            writer_run.runtime_arg_values.push_back(
-                {node, {{"num_pages", num_tiles_per_core}, {"start_id", num_tiles_read}}});
+            reader_b.emit(
+                node,
+                num_tiles_per_core,
+                tt::round_down(num_tiles_read, HtWt_walk) + (h * Wt_walk) + w,
+                h,
+                w,
+                Ht_walk,
+                Wt_walk,
+                HtWt_walk);
+            compute_b.emit(node, num_tiles_per_core);
+            writer_b.emit(node, num_tiles_per_core, num_tiles_read);
 
             num_tiles_read += num_tiles_per_core;
         }
+        reader_run = reader_b.take();
+        compute_run = compute_b.take();
+        writer_run = writer_b.take();
     }
 
     WorkUnitSpec wu{

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_program_factory.hpp
@@ -9,13 +9,24 @@
 #include "ttnn/program_spec_artifacts.hpp"
 
 #include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
+
+#include <span>
+#include <vector>
 
 namespace ttnn::prim::qsr {
 
-// Metal 2.0 (ProgramSpecFactoryConcept) factory for the W<->H transpose path (tiled + row-major).
+// Metal 2.0 (ProgramSpecFactoryWithOwnedTensorsConcept) factory for the W<->H transpose path (tiled + row-major).
 struct TransposeWHProgramFactory {
-    static ttnn::device_operation::ProgramSpecArtifacts create_program_spec(
+    // Transpose owns no scratch/config tensors; routes through the owned-tensors adapter all the same.
+    static std::vector<tt::tt_metal::MeshTensor> get_owned_tensors(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
+
+    static ttnn::device_operation::ProgramSpecArtifacts create_program_spec(
+        const TransposeParams& operation_attributes,
+        const TransposeInputs& tensor_args,
+        Tensor& output_tensor,
+        std::span<const tt::tt_metal::MeshTensor> owned_tensors);
 };
 
 }  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_program_factory.hpp
@@ -6,15 +6,15 @@
 #include "transpose_device_operation_types.hpp"
 
 #include "ttnn/device_operation.hpp"
-#include "ttnn/metal_v2_artifacts.hpp"
+#include "ttnn/program_spec_artifacts.hpp"
 
 #include <tt-metalium/core_coord.hpp>
 
 namespace ttnn::prim::qsr {
 
-// Metal 2.0 (MetalV2FactoryConcept) factory for the W<->H transpose path (tiled + row-major).
+// Metal 2.0 (ProgramSpecFactoryConcept) factory for the W<->H transpose path (tiled + row-major).
 struct TransposeWHProgramFactory {
-    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
+    static ttnn::device_operation::ProgramSpecArtifacts create_program_spec(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_sharded_program_factory.cpp
@@ -19,7 +19,7 @@ using namespace tt::tt_metal::experimental;
 
 namespace ttnn::prim::qsr {
 
-ttnn::device_operation::ProgramArtifacts TransposeWHShardedProgramFactory::create_program_artifacts(
+ttnn::device_operation::ProgramSpecArtifacts TransposeWHShardedProgramFactory::create_program_spec(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
     // Metal 2.0 named resource handles (locals to avoid unity-build name collisions).
     const DFBSpecName CB_IN0{"cb_in0"};    // legacy c_0: input shard (borrowed)
@@ -198,7 +198,7 @@ ttnn::device_operation::ProgramArtifacts TransposeWHShardedProgramFactory::creat
         {INPUT_TENSOR, TensorArgument{std::cref(input_tensor.mesh_tensor())}},
         {OUTPUT_TENSOR, TensorArgument{std::cref(output_tensor.mesh_tensor())}}};
 
-    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
+    return ttnn::device_operation::ProgramSpecArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_sharded_program_factory.hpp
@@ -6,17 +6,17 @@
 #include "transpose_device_operation_types.hpp"
 
 #include "ttnn/device_operation.hpp"
-#include "ttnn/metal_v2_artifacts.hpp"
+#include "ttnn/program_spec_artifacts.hpp"
 
 #include <tt-metalium/core_coord.hpp>
 
 namespace ttnn::prim::qsr {
 
-// Metal 2.0 (MetalV2FactoryConcept) factory for the sharded, tiled W<->H transpose path. The
+// Metal 2.0 (ProgramSpecFactoryConcept) factory for the sharded, tiled W<->H transpose path. The
 // input/output shards already live in L1, so cb_in0/cb_out0 are borrowed-memory DFBs that alias the
 // input/output tensor shard buffers; the reader/writer are trivial sharded stubs.
 struct TransposeWHShardedProgramFactory {
-    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
+    static ttnn::device_operation::ProgramSpecArtifacts create_program_spec(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
@@ -19,7 +19,7 @@ using namespace tt::tt_metal::experimental;
 
 namespace ttnn::prim::qsr {
 
-ttnn::device_operation::ProgramArtifacts TransposeWHShardedRMProgramFactory::create_program_artifacts(
+ttnn::device_operation::ProgramSpecArtifacts TransposeWHShardedRMProgramFactory::create_program_spec(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
     // Metal 2.0 named resource handles (locals to avoid unity-build name collisions).
     const DFBSpecName CB_IN0{"cb_in0"};              // legacy c_0: input shard (borrowed)
@@ -270,7 +270,7 @@ ttnn::device_operation::ProgramArtifacts TransposeWHShardedRMProgramFactory::cre
         {INPUT_TENSOR, TensorArgument{std::cref(input_tensor.mesh_tensor())}},
         {OUTPUT_TENSOR, TensorArgument{std::cref(output_tensor.mesh_tensor())}}};
 
-    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
+    return ttnn::device_operation::ProgramSpecArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_sharded_rm_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_sharded_rm_program_factory.hpp
@@ -6,19 +6,19 @@
 #include "transpose_device_operation_types.hpp"
 
 #include "ttnn/device_operation.hpp"
-#include "ttnn/metal_v2_artifacts.hpp"
+#include "ttnn/program_spec_artifacts.hpp"
 
 #include <tt-metalium/core_coord.hpp>
 
 namespace ttnn::prim::qsr {
 
-// Metal 2.0 (MetalV2FactoryConcept) factory for the sharded, row-major W<->H transpose path.
+// Metal 2.0 (ProgramSpecFactoryConcept) factory for the sharded, row-major W<->H transpose path.
 // The input/output shards live in L1, so cb_in0/cb_out0 are borrowed-memory DFBs aliasing the
 // input/output tensor shard buffers; the reader gathers rows into a tile-staging DFB, the compute
 // kernel tilizes + transposes + pack-untilizes, and (only when ht>8) a writer drains a staging DFB
 // into the output shard.
 struct TransposeWHShardedRMProgramFactory {
-    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
+    static ttnn::device_operation::ProgramSpecArtifacts create_program_spec(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
 };
 

--- a/ttnn/sources.cmake
+++ b/ttnn/sources.cmake
@@ -13,6 +13,7 @@ set(TTNN_CORE_SRCS
     core/core.cpp
     core/device.cpp
     core/device_operation_detail.cpp
+    core/program_spec_hash.cpp
     cpp/tools/profiler/op_profiler_json.cpp
     core/distributed/api.cpp
     core/distributed/distributed_tensor.cpp


### PR DESCRIPTION
## What this is

**Draft / review-only.** A single place to read all the spec-as-key host-dispatch optimization work that is **not yet covered by a pending PR**. Not intended to merge as-is — it stacks on the spec-as-key infra and carries two commits that already have their own PRs (see legend). Open it to review the code; the standalone pieces land via their own PRs.

The target is the **spec-as-key** path (`ProgramSpecFactoryWithOwnedTensorsConcept`, from #47473): the ProgramSpec is rebuilt every dispatch so its content can be hashed into the cache key ("build-to-hash"). This work makes that rebuild cheaper without weakening the contract (the cache key stays the ProgramSpec; nothing else).

## Commit legend

| commit | what | status |
|---|---|---|
| `3644ebf` | Spec-as-key infra (own `ProgramSpecFactoryConcept` + `create_spec` launch) | base — review copy of #47473 |
| `c2418a1` | Inline `RtaName` key | **already in pending #48071** — skip |
| `f34b04c` | Skip run-arg validation on hit | **already in pending #48138** — skip |
| `1418050` | Small-vector run-arg `Table`s | from closed #47471 |
| `b654b6e`, `c6592a8` | Transpose→concept + launcher guard (experiments) | net-new |
| `e45c348` | Migrate transpose WH factory to owned-tensors concept | **net-new** |
| `76cf114` | `Table::append_unchecked` + `ttnn::spec` run-args builder | **net-new — main contribution** |
| `3765bed` | Test fix: `.assign()` for `RtaName`-typed schema names | net-new |
| `8597d96` | `ProgramRunArgsBuilder`; wire into transpose | **net-new — main contribution** |
| `545cc58` | Migrate interleaved_to_sharded to owned-tensors concept | **net-new** |
| `f986e0d` | Perf writeup doc | net-new |

## The optimization (net-new)

`ttnn/api/ttnn/spec_run_args.hpp` — spec-building helpers that are easier to write **and** faster than hand-rolling, so not using them is the wrong choice:

- `Table::append_unchecked` — append without the `find()` dup-scan; O(N) fill instead of O(N²). Safe because schema names are unique by construction.
- `ttnn::spec::KernelRunArgsBuilder` — one kernel's per-node run-args: declare names once, `emit(node, v0, v1, …)` positional + arity-checked.
- `ttnn::spec::ProgramRunArgsBuilder` — whole program: `kernel()` per kernel, `emit()` per node, `take()` **moves** every kernel into the `ProgramRunArgs`. This makes the `kernel_run_args = {std::move(a), b, c}` copy bug structurally impossible (`std::initializer_list` elements are `const`, so braced-init silently copies every per-node `Table`).

Two ops migrated to the owned-tensors concept to exercise it: transpose (WH) and interleaved_to_sharded (PCC 1.0 both).

## Results (DIM 1024, `TT_METAL_INSPECTOR=0`, warm cache, min/median, PCC 1.0)

| op | spec-as-key baseline | + run-args builder | legacy |
|---|---|---|---|
| transpose (WH) | ~41 µs (1.56×) | **~35 µs (1.34×)** | ~26 µs |
| interleaved_to_sharded | **~48 µs (~2.0×)** (builder not yet wired into its branchy per-core loop) | — | ~24 µs |

The builder is a real **−6 µs / −15%** on transpose.

## Remaining gap & next lever

transpose's ~9 µs residual is structural (spec rebuild ~4–5 µs + reflection hash ~1.1 µs + `filesystem::path` source ~0.8 µs + teardown). The next unexploited lever — **output-allocation layout sidecar**: output alloc is ~45% of dispatch. Memoize the spec-*derived* buffer layout (`generate_buffer_page_mapping`, distribution spec, shard `CoreRangeSet`) on the spec hash. Footgun-free: the spec *is* the cache key, so a different spec ⇒ different hash ⇒ miss ⇒ recompute — staleness is impossible by construction. Targets i2s's `CoreRangeSet::merge` (~3 µs) + redundant `Buffer::create` (~2 µs).

Full methodology, profiling, and dead-ends in `tech_reports/Metal2OpMigration/SPEC_AS_KEY_RUNARGS_PERF.md` (commit `f986e0d`).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/metal2-spec-runargs-builders)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/metal2-spec-runargs-builders)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/metal2-spec-runargs-builders)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/metal2-spec-runargs-builders)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/metal2-spec-runargs-builders)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/metal2-spec-runargs-builders)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/metal2-spec-runargs-builders)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/metal2-spec-runargs-builders)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/metal2-spec-runargs-builders)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/metal2-spec-runargs-builders)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/metal2-spec-runargs-builders)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/metal2-spec-runargs-builders)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/metal2-spec-runargs-builders)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/metal2-spec-runargs-builders)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/metal2-spec-runargs-builders)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/metal2-spec-runargs-builders)