### PR TITLE
Tilize - float32 precision tests

### DIFF
--- a/tests/pipeline_reorg/ttnn_sanity_tests.yaml
+++ b/tests/pipeline_reorg/ttnn_sanity_tests.yaml
@@ -13,6 +13,7 @@
   cmd: >-
     pytest --timeout 60 -xv
     tests/ttnn/unit_tests/operations/data_movement/test_tilize.py::test_tilize_test
+    tests/ttnn/unit_tests/operations/data_movement/test_tilize.py::test_tilize_fp32_lossless
     tests/ttnn/unit_tests/operations/data_movement/test_tilize_with_val_padding.py::test_run_tilize_with_val_padding_test
     tests/ttnn/unit_tests/operations/data_movement/test_untilize.py::test_untilize_single_core_interleaved_to_interleaved
     tests/ttnn/unit_tests/operations/data_movement/test_untilize_with_unpadding.py::test_untilize_with_unpadding_height_sharded

--- a/tests/ttnn/unit_tests/operations/data_movement/test_tilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_tilize.py
@@ -557,3 +557,114 @@ def test_tilize_fp8_input(device, shape, out_dtype, min_pcc):
     tt_out = ttnn.tilize(tt_in, dtype=out_dtype)
     assert tt_out.layout == ttnn.TILE_LAYOUT and tt_out.dtype == out_dtype
     assert_with_pcc(golden, ttnn.to_torch(tt_out).float(), min_pcc)
+
+
+def _make_fp32_precision_tensor(shape):
+    """Build a fp32 tensor with values that require full 23-bit mantissa precision.
+
+    These values are NOT representable in bfloat16 (7-bit mantissa) or TF32
+    (10-bit mantissa).  Any silent truncation will cause torch.equal to fail.
+    """
+    torch.manual_seed(35303)
+    t = torch.randn(shape, dtype=torch.float32)
+    precision_values = torch.tensor(
+        [
+            1.0000001192092896,  # smallest fp32 > 1.0  (bit 0x3F800001)
+            -1.0000001192092896,
+            0.693147182464599609,
+            -0.693147182464599609,
+            3.14159265358979,  # pi at full fp32 precision
+            -3.14159265358979,
+            16777217.0,  # 2^24 + 1, not representable in bf16
+            -16777217.0,
+            8388609.0,  # 2^23 + 1
+            -8388609.0,
+            1.41421353816986084,
+            -1.41421353816986084,
+            1.1920928955078125e-07,  # machine epsilon for fp32
+            -1.1920928955078125e-07,
+            1.9908e-05,  # regression value from issue #39310
+            -1.9908e-05,
+            1234567.125,  # large with fractional low bits
+            -1234567.125,
+            1.17549435e-38,  # smallest positive normal fp32
+            -1.17549435e-38,
+            3.40282347e38,  # FLT_MAX
+            -3.40282347e38,
+            0.333333343267440796,  # 1/3 at full fp32 precision
+            -0.333333343267440796,
+            2.7182817459106445,  # e at full fp32 precision
+            -2.7182817459106445,
+        ],
+        dtype=torch.float32,
+    )
+    n = min(precision_values.numel(), t.shape[-1])
+    t.view(-1, t.shape[-1])[0, :n] = precision_values[:n]
+    return t
+
+
+@pytest.mark.parametrize("shape", [(32, 32), (64, 128), (256, 512)])
+@pytest.mark.parametrize("use_multicore", [False, True])
+def test_tilize_fp32_lossless(device, shape, use_multicore):
+    """Tilize must preserve fp32 values with perfect bitwise equality."""
+    input_tensor = _make_fp32_precision_tensor(shape)
+
+    tt_input = ttnn.from_torch(input_tensor, dtype=ttnn.float32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    tt_output = ttnn.tilize(tt_input, use_multicore=use_multicore)
+    output_tensor = ttnn.to_torch(tt_output)
+
+    assert torch.equal(input_tensor, output_tensor)
+
+
+@pytest.mark.parametrize("shape", [(32, 32), (128, 256)])
+def test_tilize_untilize_fp32_roundtrip(device, shape):
+    """Full tilize -> untilize round-trip must be bit-exact for fp32."""
+    input_tensor = _make_fp32_precision_tensor(shape)
+
+    tt_input = ttnn.from_torch(input_tensor, dtype=ttnn.float32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    tt_tiled = ttnn.tilize(tt_input)
+    tt_rm = ttnn.untilize(tt_tiled)
+    output_tensor = ttnn.to_torch(tt_rm)
+
+    assert torch.equal(input_tensor, output_tensor)
+
+
+@pytest.mark.parametrize("shape", [(48, 80), (33, 65)])
+@pytest.mark.parametrize("use_multicore", [False, True])
+def test_tilize_with_zero_padding_fp32_lossless(device, shape, use_multicore):
+    """tilize_with_zero_padding must preserve fp32 data region exactly."""
+    input_tensor = _make_fp32_precision_tensor(shape)
+
+    tt_input = ttnn.from_torch(input_tensor, dtype=ttnn.float32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    tt_output = ttnn.tilize_with_zero_padding(tt_input, use_multicore=use_multicore)
+    output_tensor = ttnn.to_torch(tt_output)
+
+    H, W = shape
+    assert torch.equal(input_tensor, output_tensor[:H, :W])
+
+
+@pytest.mark.parametrize("shape", [(48, 80), (33, 65)])
+@pytest.mark.parametrize("use_multicore", [False, True])
+def test_tilize_with_val_padding_fp32_lossless(device, shape, use_multicore):
+    """tilize_with_val_padding must preserve fp32 data region exactly."""
+    input_tensor = _make_fp32_precision_tensor(shape)
+    H, W = shape
+    padded_H = math.ceil(H / 32) * 32
+    padded_W = math.ceil(W / 32) * 32
+
+    tt_input = ttnn.from_torch(input_tensor, dtype=ttnn.float32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    tt_output = ttnn.tilize_with_val_padding(tt_input, [padded_H, padded_W], 1.0075, use_multicore=use_multicore)
+    output_tensor = ttnn.to_torch(tt_output)
+
+    assert torch.equal(input_tensor, output_tensor[:H, :W])
+
+
+def test_tilize_fp32_lossless_via_to_layout(device):
+    """to_layout (host→device tilize path) must be bit-exact for fp32."""
+    input_tensor = _make_fp32_precision_tensor((64, 128))
+
+    tt_input = ttnn.from_torch(input_tensor, dtype=ttnn.float32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    tt_output = ttnn.to_layout(tt_input, ttnn.TILE_LAYOUT)
+    output_tensor = ttnn.to_torch(tt_output)
+
+    assert torch.equal(input_tensor, output_tensor)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_tilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_tilize.py
@@ -52,18 +52,6 @@ def test_tilize_test(input_shapes, tilize_args, device, function_level_defaults)
     assert_equal(torch_input, torch_output)
 
 
-@pytest.mark.parametrize("shape", [(64, 128), (512, 512)])
-@pytest.mark.parametrize("use_multicore", [False, True])
-def test_tilize_fp32_truncation(device, shape, use_multicore):
-    torch.manual_seed(2005)
-    input_a = torch.full(shape, 1.9908e-05, dtype=torch.float32)
-    # Use the fixture-provided device directly
-    input_tensor = ttnn.from_torch(input_a, device=device, layout=ttnn.ROW_MAJOR_LAYOUT)
-    input_tensor = ttnn.tilize(input_tensor, use_multicore=use_multicore)
-    output_tensor = ttnn.to_torch(input_tensor)
-    assert torch.allclose(input_a, output_tensor)
-
-
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
 @pytest.mark.parametrize("tensor_shape", [[32, 256 * 64]])
 @pytest.mark.parametrize("shard_shape", [[32, 256]])


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Test Only

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
#35303

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
Added float32 tests for tilize.
<img width="1280" height="587" alt="image" src="https://github.com/user-attachments/assets/4944fa63-709e-40c5-b213-2eb92456911a" />

Sanity run
<img width="1071" height="721" alt="image" src="https://github.com/user-attachments/assets/a756229e-080b-49d5-bf1e-7797be9f0c4a" />


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kalaivani/tilize_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kalaivani/tilize_fp32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kalaivani/tilize_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kalaivani/tilize_fp32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=kalaivani/tilize_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:kalaivani/tilize_fp32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kalaivani/tilize_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kalaivani/tilize_fp32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kalaivani/tilize_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kalaivani/tilize_fp32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kalaivani/tilize_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kalaivani/tilize_fp32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kalaivani/tilize_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kalaivani/tilize_fp32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kalaivani/tilize_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kalaivani/tilize_fp32)