### PR TITLE
[Metal 2.0][WIP/REVIEW] create_output_tensors: memoize BufferDistributionSpec + wire builder into i2s

### DIFF
--- a/tt_metal/impl/buffers/buffer_distribution_spec.cpp
+++ b/tt_metal/impl/buffers/buffer_distribution_spec.cpp
@@ -8,6 +8,8 @@
 #include <tt-metalium/math.hpp>
 
 #include <algorithm>
+#include <mutex>
+#include <unordered_map>
 #include <utility>
 
 namespace tt::tt_metal {
@@ -94,8 +96,47 @@ BufferDistributionSpec BufferDistributionSpec::from_shard_spec(
     ShardDistributionStrategy shard_distribution_strategy) {
     auto tensor_shape_in_pages = CMAKE_UNIQUE_NAMESPACE::convert_shape_to_pages(std::move(tensor_shape), page_shape);
     auto shard_shape_in_pages = CMAKE_UNIQUE_NAMESPACE::convert_shape_to_pages(std::move(shard_shape), page_shape);
-    return BufferDistributionSpec(
+
+    // Memo: the ctor's core-list / CoreRangeSet / core-groups work is a pure function of these inputs and
+    // is recomputed identically every dispatch for a fixed sharded spec. Cache it (operator== guards
+    // correctness; the hash is only for bucketing, so collisions can't return a wrong spec).
+    struct Key {
+        Shape tensor_shape_in_pages;
+        Shape shard_shape_in_pages;
+        CoreRangeSet core_range_set;
+        ShardOrientation orientation;
+        ShardDistributionStrategy strategy;
+        bool operator==(const Key& o) const {
+            return tensor_shape_in_pages == o.tensor_shape_in_pages && shard_shape_in_pages == o.shard_shape_in_pages &&
+                   core_range_set == o.core_range_set && orientation == o.orientation && strategy == o.strategy;
+        }
+    };
+    struct KeyHash {
+        size_t operator()(const Key& k) const {
+            size_t h = std::hash<CoreRangeSet>{}(k.core_range_set);
+            auto comb = [&h](size_t v) { h ^= v + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2); };
+            for (auto d : k.tensor_shape_in_pages.view()) {
+                comb(d);
+            }
+            for (auto d : k.shard_shape_in_pages.view()) {
+                comb(d);
+            }
+            comb(static_cast<size_t>(k.orientation));
+            comb(static_cast<size_t>(k.strategy));
+            return h;
+        }
+    };
+    static std::mutex mtx;
+    static std::unordered_map<Key, BufferDistributionSpec, KeyHash> cache;
+    Key key{
+        tensor_shape_in_pages, shard_shape_in_pages, core_range_set, shard_orientation, shard_distribution_strategy};
+    std::lock_guard<std::mutex> lock(mtx);
+    if (auto it = cache.find(key); it != cache.end()) {
+        return it->second;
+    }
+    BufferDistributionSpec result(
         tensor_shape_in_pages, shard_shape_in_pages, core_range_set, shard_orientation, shard_distribution_strategy);
+    return cache.emplace(std::move(key), std::move(result)).first->second;
 }
 
 BufferDistributionSpec::BufferDistributionSpec(

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
+#include "ttnn/spec_run_args.hpp"
 #include "ttnn/operations/ccl/sharding_addrgen_helper.hpp"
 #include "ttnn/operations/data_movement/sharded/sharded_common.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
@@ -312,11 +313,52 @@ ttnn::device_operation::ProgramSpecArtifacts InterleavedToShardedProgramFactory:
     }
     spec.work_units = {WorkUnitSpec{.name = "main", .kernels = wu_kernels, .target_nodes = all_cores}};
 
-    // ---- Build the ProgramRunArgs (per-core runtime args) ----
-    ProgramRunArgs run_args;
-    KernelRunArgs reader_run{.kernel = I2S_READER};
-    KernelRunArgs writer_run{.kernel = I2S_WRITER};
-    KernelRunArgs compute_run{.kernel = I2S_COMPUTE};
+    // ---- Build the ProgramRunArgs via the ttnn::spec builder (names declared once per branch; emit
+    // positional per core via append_unchecked -> O(N); take() moves -> no init-list copy). ----
+    ttnn::spec::ProgramRunArgsBuilder rab;
+    auto& reader_b = is_tile ? rab.kernel(
+                                   I2S_READER,
+                                   {"block_height_tiles",
+                                    "block_width_tiles",
+                                    "padded_offset_bytes",
+                                    "input_width_offset_tiles",
+                                    "block_num_tiles",
+                                    "start_id_offset",
+                                    "start_id_base"})
+                             : rab.kernel(
+                                   I2S_READER,
+                                   {"block_height",
+                                    "block_width_bytes",
+                                    "padded_block_width_bytes",
+                                    "aligned",
+                                    "aligned_input_width_offset_bytes",
+                                    "aligned_block_width_bytes",
+                                    "aligned_offset",
+                                    "start_id"});
+    ttnn::spec::KernelRunArgsBuilder* writer_b = nullptr;
+    if (is_tile && dst_is_dram) {
+        writer_b = &rab.kernel(
+            I2S_WRITER,
+            {"block_height_tiles",
+             "block_width_tiles",
+             "padded_offset",
+             "block_width_padded_num_tiles",
+             "output_width_tiles",
+             "start_id_offset",
+             "start_id_base"});
+    } else if (!is_tile && dst_is_dram) {
+        writer_b = &rab.kernel(
+            I2S_WRITER,
+            {"block_height", "block_width_bytes", "padded_block_width_bytes", "start_id", "output_width_in_pages"});
+    } else {
+        writer_b = &rab.kernel(I2S_WRITER, {"num_units"});
+    }
+    ttnn::spec::KernelRunArgsBuilder* compute_b = convert_df ? &rab.kernel(I2S_COMPUTE, {"num_units"}) : nullptr;
+    reader_b.reserve(cores.size());
+    writer_b->reserve(cores.size());
+    if (compute_b != nullptr) {
+        compute_b->reserve(cores.size());
+    }
 
     uint32_t starting_idx_h =
         operations::data_movement::detail::calculate_starting_idx_h(input, num_slices, slice_index);
@@ -360,33 +402,30 @@ ttnn::device_operation::ProgramSpecArtifacts InterleavedToShardedProgramFactory:
             curr_num_units_per_shard = shard_height * num_units_per_shard_width;
 
             // Reader run-time args (buffer-address slot 0 is gone — bound via TensorParameter).
-            reader_run.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
-                .node = core,
-                .args = {
-                    {"block_height_tiles", shard_height},
-                    {"block_width_tiles", shard_width},
-                    {"padded_offset_bytes", padded_offset},
-                    {"input_width_offset_tiles", num_units_offset},
-                    {"block_num_tiles", curr_num_units_per_shard},
-                    {"start_id_offset", curr_idx_h + curr_idx_w},
-                    {"start_id_base", starting_idx_h}}});
+            reader_b.emit(
+                core,
+                shard_height,
+                shard_width,
+                padded_offset,
+                num_units_offset,
+                curr_num_units_per_shard,
+                curr_idx_h + curr_idx_w,
+                starting_idx_h);
 
             // Writer run-time args
             uint32_t pad_offset = (num_units_per_shard_width - shard_width) * output_unit_size;
             if (dst_is_dram) {
-                writer_run.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
-                    .node = core,
-                    .args = {
-                        {"block_height_tiles", shard_height},
-                        {"block_width_tiles", shard_width},
-                        {"padded_offset", pad_offset},
-                        {"block_width_padded_num_tiles", curr_num_units_per_shard},
-                        {"output_width_tiles", num_units_offset},
-                        {"start_id_offset", curr_idx_h + curr_idx_w},
-                        {"start_id_base", starting_idx_h}}});
+                writer_b->emit(
+                    core,
+                    shard_height,
+                    shard_width,
+                    pad_offset,
+                    curr_num_units_per_shard,
+                    num_units_offset,
+                    curr_idx_h + curr_idx_w,
+                    starting_idx_h);
             } else {
-                writer_run.runtime_arg_values.push_back(
-                    KernelRunArgs::NodeRuntimeArgs{.node = core, .args = {{"num_units", curr_num_units_per_shard}}});
+                writer_b->emit(core, curr_num_units_per_shard);
             }
 
             // Update indexing
@@ -460,34 +499,25 @@ ttnn::device_operation::ProgramSpecArtifacts InterleavedToShardedProgramFactory:
             // Reader run-time args (buffer-address slot 0 is gone — bound via TensorParameter;
             // legacy slot 1 `num_units_per_row` was emitted but never read by the kernel, so it
             // is dropped here to match the kernel's actual reads).
-            reader_run.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
-                .node = core,
-                .args = {
-                    {"block_height", shard_height},
-                    {"block_width_bytes", shard_width},
-                    {"padded_block_width_bytes", padded_offset_bytes},
-                    {"aligned", static_cast<uint32_t>(aligned)},
-                    {"aligned_input_width_offset_bytes", aligned_width_offset},
-                    {"aligned_block_width_bytes", aligned_shard_width},
-                    {"aligned_offset", aligned_offset},
-                    {"start_id", curr_idx_h}}});
+            reader_b.emit(
+                core,
+                shard_height,
+                shard_width,
+                padded_offset_bytes,
+                static_cast<uint32_t>(aligned),
+                aligned_width_offset,
+                aligned_shard_width,
+                aligned_offset,
+                curr_idx_h);
 
             // Writer run-time args
             if (dst_is_dram) {
                 uint32_t page_id_within_row = curr_idx_w / input_unit_size;
                 uint32_t output_width_in_pages = tt::div_up(num_units_per_row, input_unit_size);
                 uint32_t start_id = (curr_idx_h * output_width_in_pages) + page_id_within_row;
-                writer_run.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
-                    .node = core,
-                    .args = {
-                        {"block_height", shard_height},
-                        {"block_width_bytes", shard_width},
-                        {"padded_block_width_bytes", padded_offset_bytes},
-                        {"start_id", start_id},
-                        {"output_width_in_pages", output_width_in_pages}}});
+                writer_b->emit(core, shard_height, shard_width, padded_offset_bytes, start_id, output_width_in_pages);
             } else {
-                writer_run.runtime_arg_values.push_back(
-                    KernelRunArgs::NodeRuntimeArgs{.node = core, .args = {{"num_units", curr_num_units_per_shard}}});
+                writer_b->emit(core, curr_num_units_per_shard);
             }
 
             // Update indexing
@@ -497,17 +527,12 @@ ttnn::device_operation::ProgramSpecArtifacts InterleavedToShardedProgramFactory:
                 curr_idx_h += num_units_per_shard_height;
             }
         }
-        if (convert_df) {
-            compute_run.runtime_arg_values.push_back(
-                KernelRunArgs::NodeRuntimeArgs{.node = core, .args = {{"num_units", curr_num_units_per_shard}}});
+        if (compute_b != nullptr) {
+            compute_b->emit(core, curr_num_units_per_shard);
         }
     }
 
-    run_args.kernel_run_args.push_back(std::move(reader_run));
-    run_args.kernel_run_args.push_back(std::move(writer_run));
-    if (convert_df) {
-        run_args.kernel_run_args.push_back(std::move(compute_run));
-    }
+    ProgramRunArgs run_args = rab.take();
 
     // Tensor arguments: reference the same MeshTensors the parameters were declared from.
     run_args.tensor_args.emplace(I2S_INPUT, TensorArgument{input.mesh_tensor()});


### PR DESCRIPTION
## What this is

**Draft / review-only, WIP — not validated this session.** This is the create_output_tensors / output-allocation lever that wasn't yet visible anywhere (it was uncommitted in my worktree). Pushing it so the approach can be reviewed before I build + measure it.

Base is `dgomez/metal2-spec-runargs-builders` (#48250), so the diff here is **only** these two commits.

## The two commits

### 1. `46bbffa` — Wire run-args builder into i2s per-core loop
Completes the "builder not yet wired into i2s's branchy per-core loop" TODO from #48250. i2s's tile/RM × DRAM/L1 loop hand-built `KernelRunArgs` via init-list `NodeRuntimeArgs`; now routed through `ttnn::spec::ProgramRunArgsBuilder` (declare names once per branch, `emit()` positional per core via `append_unchecked` → O(N), `take()`-moves → no init-list copy). Same build-side win transpose already gets.

### 2. `236da12` — Memoize `BufferDistributionSpec::from_shard_spec` (the create_output_tensors lever)
`create_output_tensors` rebuilds the sharded buffer layout every dispatch — `from_shard_spec` recomputes the core list / `CoreRangeSet` / core-groups, which is **identical each time for a fixed sharded spec** (~3 µs `CoreRangeSet::merge` on the spec-as-key i2s op). This memoizes the result on the `(tensor/shard pages, CoreRangeSet, orientation, strategy)` key. `operator==` guards correctness; the hash only buckets, so a collision cannot return a wrong spec.

## ⚠️ Review caveats (why this is WIP)

- **Footgun-class:** it's a **process-global static cache, unbounded** — grows for the lifetime of the process, one entry per distinct sharded spec. Fine for a benchmark, not for shipping as-is.
- The **footgun-free target** (per `tech_reports/Metal2OpMigration/SPEC_AS_KEY_RUNARGS_PERF.md`) is a layout sidecar keyed on the **spec hash** (the cache key) — staleness impossible by construction, scoped to the program cache lifetime instead of the whole process.
- **Not measured this session.** The next step is a fresh `./build_metal.sh` + the locked methodology (i2s vs legacy, DIM 1024, `TT_METAL_INSPECTOR=0`, warm cache, min/median) to confirm the `CoreRangeSet::merge` cost actually drops.

So: review the **approach** here; the shippable form keys on the spec hash, and numbers come after the build.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/metal2-output-alloc-memo)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/metal2-output-alloc-memo)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/metal2-output-alloc-memo)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/metal2-output-alloc-memo)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/metal2-output-alloc-memo)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/metal2-output-alloc-memo)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/metal2-output-alloc-memo)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/metal2-output-alloc-memo)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/metal2-output-alloc-memo)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/metal2-output-alloc-memo)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/metal2-output-alloc-memo)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/metal2-output-alloc-memo)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/metal2-output-alloc-memo)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/metal2-output-alloc-memo)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/metal2-output-alloc-memo)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/metal2-output-alloc-memo)