### PR TITLE
fix llk blackhole ci timeout

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_typecast.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_typecast.py
@@ -171,7 +171,9 @@ def test_eltwise_unary_typecast(
         formats.output_format
     )
     if formats.input_format.is_integer():
-        spec_A = StimuliSpec.uniform(0, 15) if bfp_involved else None
+        spec_A = (
+            StimuliSpec.uniform(0, 15) if bfp_involved else StimuliSpec.uniform(0, 255)
+        )
     else:
         spec_A = _whole_number_float_spec(16 if bfp_involved else 201)
 

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_typecast.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_typecast.py
@@ -163,7 +163,8 @@ def test_eltwise_unary_typecast(
     # Stimuli selection per input/output dtype:
     #  * integer -> block-float: small ints (0..15) so int->fp16b->bfp is exact
     #    (full-range ints would differ from the golden by >1 bfp ULP);
-    #  * integer -> anything else: format-aware default spec (exact int/float cmp);
+    #  * integer -> anything else: bounded range (0..255) to avoid 0xFFFF values
+    #    that pack into 0xFFFFFFFF on readback, which BH NOC treats as a timeout;
     #  * float / block-float input: whole numbers so int conversions are exact and
     #    bf16 is lossless; small range when a block-float is involved so the
     #    shared-exponent quantization is (near-)exact per 16-elem block.


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

`test_eltwise_unary_typecast` test sometimes timed out on BH CI. Blackhole has a HW bug that forces reads to go over NOC ([`can_use_dma`](https://github.com/tenstorrent/tt-exalens/blob/2245157c792b43034bfbbb6dc558a60b13706c9f/ttexalens/umd_device.py#L116-L118)), which is slower. When typecasting integers, values like 0xFFFF appear frequently in the output, and when NOC reads back 0xFFFFFFFF, UMD treats it as [error](https://github.com/tenstorrent/tt-exalens/blob/2245157c792b43034bfbbb6dc558a60b13706c9f/ttexalens/umd_device.py#L165-L175), causing the test to timeout.

Fix
Restrict integer stimuli to [0, 255] so typecast outputs can't produce 0xFFFF patterns that trigger timeout.



### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=markoradosavljevic/fix-bh-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:markoradosavljevic/fix-bh-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=markoradosavljevic/fix-bh-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:markoradosavljevic/fix-bh-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=markoradosavljevic/fix-bh-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:markoradosavljevic/fix-bh-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=markoradosavljevic/fix-bh-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:markoradosavljevic/fix-bh-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=markoradosavljevic/fix-bh-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:markoradosavljevic/fix-bh-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=markoradosavljevic/fix-bh-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:markoradosavljevic/fix-bh-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=markoradosavljevic/fix-bh-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:markoradosavljevic/fix-bh-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=markoradosavljevic/fix-bh-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:markoradosavljevic/fix-bh-ci)