### PR TITLE
moving AccumulationDeviceOperation to the default hash calculation logic

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_device_operation.cpp
@@ -102,22 +102,6 @@ AccumulationDeviceOperation::tensor_return_value_t AccumulationDeviceOperation::
         compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor.device());
 }
 
-operation::Hash AccumulationDeviceOperation::compute_program_hash(
-    const operation_attributes_t& op_args, const tensor_args_t& tensor_args) {
-    return operation::hash_operation<AccumulationDeviceOperation>(
-        op_args.dim,
-        op_args.output_memory_config,
-        op_args.flip,
-        op_args.dtype,
-        op_args.op,
-        tensor_args.input_tensor.logical_shape(),
-        tensor_args.input_tensor.dtype(),
-        tensor_args.input_tensor.memory_config(),
-        tensor_args.opt_output.has_value() ? tensor_args.opt_output.value().logical_shape() : Shape{},
-        tensor_args.opt_output.has_value() ? tensor_args.opt_output.value().memory_config() : MemoryConfig{},
-        tensor_args.opt_output.has_value() ? tensor_args.opt_output.value().dtype() : DataType{});
-}
-
 ttnn::Tensor accumulation(
     const Tensor& input_tensor,
     const int32_t& dim,

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_device_operation.hpp
@@ -60,8 +60,6 @@ struct AccumulationDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static operation::Hash compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 ttnn::Tensor accumulation(


### PR DESCRIPTION
### PR Category
hash calculation unification for operation AccumulationDeviceOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for AccumulationDeviceOperation

### Notes for reviewers
NA

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_u_AccumulationDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_u_AccumulationDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_u_AccumulationDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_u_AccumulationDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_u_AccumulationDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_u_AccumulationDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_u_AccumulationDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_u_AccumulationDeviceOperation)
