### PR TITLE
Fix divide-by-zero mask assertion in scalar matrix math test

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
@@ -822,11 +822,27 @@ def test_edgecase_dims_eltwise_scalar_matrix_math(input_shape, scalar, ttnn_fn, 
     torch_output_tensor = golden_fn(torch_input_tensor_a, scalar)
 
     if ttnn_fn == "divide" and scalar == 0.0:
+        # Golden/device can disagree on NaN vs Inf at a position; compare non-finite
+        # positions, then verify inf signs match where both sides are inf.
         g_nonfinite = ~torch.isfinite(torch_output_tensor)
         d_nonfinite = ~torch.isfinite(tt_output_tensor)
-        torch.testing.assert_close(
-            g_nonfinite, d_nonfinite, msg="Non-finite positions differ between golden and device"
-        )
+        assert torch.equal(g_nonfinite, d_nonfinite), "Non-finite positions differ between golden and device"
+        both_inf = torch.isinf(torch_output_tensor) & torch.isinf(tt_output_tensor)
+        if both_inf.any():
+            assert torch.equal(
+                torch.sign(torch_output_tensor[both_inf]),
+                torch.sign(tt_output_tensor[both_inf]),
+            ), "Inf sign mismatch between golden and device"
+        # ULP on elements where both sides are finite. Device-finite vs golden-non-finite
+        # is already caught by the mask assert above. Not reached today (randn/0.0 is
+        # all non-finite); guards future parametrizations with finite golden elements.
+        finite_mask = torch.isfinite(torch_output_tensor) & torch.isfinite(tt_output_tensor)
+        if finite_mask.any():
+            assert_with_ulp(
+                torch_output_tensor[finite_mask],
+                tt_output_tensor[finite_mask],
+                ulp_threshold=3,
+            )
     else:
         assert_with_ulp(
             torch_output_tensor,


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-metal/issues/49480

### PR Category
Test Only

### Summary

Fix the non-finite mask assertion in `test_edgecase_dims_eltwise_scalar_matrix_math` for the `divide(tensor, 0.0)` edge case.

### The problem

The old check used `torch.testing.assert_close` to compare boolean non-finite masks. `assert_close` is meant for numbers with tolerances, not booleans -`torch.equal` is the correct tool for an exact True/False comparison.

### Fix

- Replace `torch.testing.assert_close` with `assert torch.equal` for the  non-finite position mask — exact boolean match, no tolerance ambiguity.
- Add a guarded `assert_with_ulp(ulp_threshold=3)` on positions where both golden and device are finite. Not reached with current `randn` inputs (since `nonzero/0.0` is entirely non-finite), but serves as a safety net for future parametrizations. Device-finite vs golden-non-finite mismatches are already caught by the mask assert above.

### Pipeline Checks

- [x] Sanity
- [x] BHPC

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/pcc_fix_4)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/pcc_fix_4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/pcc_fix_4)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/pcc_fix_4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=virdhatchani/pcc_fix_4)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:virdhatchani/pcc_fix_4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/pcc_fix_4)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/pcc_fix_4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/pcc_fix_4)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/pcc_fix_4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/pcc_fix_4)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/pcc_fix_4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/pcc_fix_4)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/pcc_fix_4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/pcc_fix_4)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/pcc_fix_4)