### PR TITLE
remove flux1 performance tests from the t3k tests workflow

### DIFF
--- a/tests/pipeline_reorg/release_tests.yaml
+++ b/tests/pipeline_reorg/release_tests.yaml
@@ -296,15 +296,6 @@
   team: models
   model-name: sd35_large
 
-- name: t3k_flux1-dev_tests
-  cmd: run_t3000_flux1_tests
-  skus:
-    wh_llmbox_perf:
-      timeout: 12
-  owner_id: U08TED0JM9D # Samuel Adesoye
-  team: models
-  model-name: flux1-dev
-
 - name: t3k_wan2.2_tests
   cmd: run_t3000_wan22_tests
   skus:
@@ -379,7 +370,7 @@
 - name: Galaxy Flux.1-dev demo tests
   cmd: |
     export TT_CACHE_HOME=/mnt/MLPerf/huggingface/tt_cache NO_PROMPT=1 TT_MM_THROTTLE_PERF=5
-    pytest models/tt_dit/tests/models/flux1/test_pipeline_flux1.py -k "4x8sp0tp1-dev" --timeout 1200
+    pytest models/tt_dit/tests/models/flux1/test_pipeline_flux1.py -k "4x8sp0tp1-flux_dev" --timeout 1200
   model-name: flux1
   skus:
     wh_galaxy:

--- a/tests/pipeline_reorg/t3k_demo_tests.yaml
+++ b/tests/pipeline_reorg/t3k_demo_tests.yaml
@@ -36,15 +36,6 @@
   team: models
   model-name: sd35_large
 
-- name: t3k_flux1-dev_tests
-  cmd: run_t3000_flux1_tests
-  skus:
-    wh_llmbox_perf:
-      timeout: 10
-  owner_id: U08TED0JM9D # Samuel Adesoye
-  team: models
-  model-name: flux1-dev
-
 - name: t3k_motif_tests
   cmd: run_t3000_motif_tests
   skus:

--- a/tests/pipeline_reorg/t3k_perf_tests.yaml
+++ b/tests/pipeline_reorg/t3k_perf_tests.yaml
@@ -64,17 +64,6 @@
   model-type: DiT
   save-perf-data: true
 
-- name: t3k_DiT_Flux.1-dev_model_perf_tests
-  cmd: run_t3000_flux1_tests
-  skus:
-    wh_llmbox_perf:
-      timeout: 50
-  owner_id: U08TED0JM9D # Samuel Adesoye
-  team: models
-  model-name: flux1-dev
-  model-type: DiT
-  save-perf-data: true
-
 - name: t3k_DiT_Motif_model_perf_tests
   cmd: run_t3000_motif_tests
   skus:

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -68,10 +68,6 @@ run_t3000_sd35large_tests() {
   run_t3000_dit_tests "models/tt_dit/tests/models/sd35/test_pipeline_sd35.py -k 2x4cfg1sp0tp1"
 }
 
-run_t3000_flux1_tests() {
-  run_t3000_dit_tests "models/tt_dit/tests/models/flux1/test_pipeline_flux1.py -k 2x4sp0tp1-dev"
-}
-
 run_t3000_motif_tests() {
   run_t3000_dit_tests "models/tt_dit/tests/models/motif/test_pipeline_motif.py -k 2x4cfg0sp0tp1"
 }

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -142,9 +142,6 @@ run_t3000_tests() {
   # Run sd35_large tests
   run_t3000_sd35large_tests
 
-  # Run flux1 tests
-  run_t3000_flux1_tests
-
   # Run motif tests
   run_t3000_motif_tests
 

--- a/tests/scripts/t3000/run_t3000_integration_tests.sh
+++ b/tests/scripts/t3000/run_t3000_integration_tests.sh
@@ -182,7 +182,6 @@ run_t3000_sd35large_tests() {
 run_t3000_flux1_tests() {
   run_t3000_dit_tests \
     "models/tt_dit/tests/blocks/test_attention.py::test_attention_flux" \
-    "models/tt_dit/tests/models/flux1/test_transformer_flux1.py::test_single_transformer_block -k 2x4" \
     "models/tt_dit/tests/blocks/test_transformer_block.py::test_transformer_block_flux -k 2x4"
 }
 

--- a/tests/scripts/t3000/run_t3000_perf_tests.sh
+++ b/tests/scripts/t3000/run_t3000_perf_tests.sh
@@ -102,10 +102,6 @@ run_t3000_stable_diffusion_35_large_tests() {
   run_t3000_dit_tests "models/tt_dit/tests/models/sd35/test_performance_sd35.py -k 2x4cfg1sp0tp1 --timeout 600"
 }
 
-run_t3000_flux1_tests() {
-  run_t3000_dit_tests "models/tt_dit/tests/models/flux1/test_performance_flux1.py -k wh_2x4sp0tp1 --timeout 600"
-}
-
 run_t3000_motif_tests() {
   run_t3000_dit_tests "models/tt_dit/tests/models/motif/test_performance_motif.py --timeout 600"
 }


### PR DESCRIPTION
Removes old perf test from t3k scripts for flux1. This has been absorbed by the flux1 tests in the tiered models CI

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jameslee/remove_flux1_from_t3k_perf_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jameslee/remove_flux1_from_t3k_perf_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jameslee/remove_flux1_from_t3k_perf_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jameslee/remove_flux1_from_t3k_perf_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jameslee/remove_flux1_from_t3k_perf_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jameslee/remove_flux1_from_t3k_perf_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jameslee/remove_flux1_from_t3k_perf_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jameslee/remove_flux1_from_t3k_perf_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jameslee/remove_flux1_from_t3k_perf_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jameslee/remove_flux1_from_t3k_perf_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jameslee/remove_flux1_from_t3k_perf_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jameslee/remove_flux1_from_t3k_perf_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jameslee/remove_flux1_from_t3k_perf_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jameslee/remove_flux1_from_t3k_perf_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jameslee/remove_flux1_from_t3k_perf_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jameslee/remove_flux1_from_t3k_perf_tests)