### PR TITLE
Add FastAPI serving layer for pplx-embed-v1-0.6B (DP=32)

### DIFF
--- a/models/demos/blackhole/pplx_embed_0_6b/README.md
+++ b/models/demos/blackhole/pplx_embed_0_6b/README.md
@@ -276,11 +276,8 @@ pip install fastapi "uvicorn[standard]" orjson
 
 ```bash
 python models/demos/blackhole/pplx_embed_0_6b/demo/serve.py --dp 32
-# CLI: --dp N (chips, default 32), --host (default 0.0.0.0), --port (default 8000),
-#      --server-phys S    (physical cores reserved for the server; default 4 = recommended)
-#      --cores-per-worker K (pin K physical cores per worker; default 0 = OS-float; NOT recommended)
-#      --fastokens / --server-tokenize  (experimental; NOT recommended — measured to
-#                                         REGRESS DP=32 throughput; see "Tokenization" below)
+# --dp N         chips (default 32)
+# --host/--port  bind address (default 0.0.0.0:8000)
 ```
 
 **Fixed worker configuration** (tuned for lowest per-request latency, not
@@ -288,22 +285,11 @@ per-request toggles): ISL 512, `BucketedEncoder` ON (short text routes to the
 faster 128/256 trace), masked-attn ON (real-token mean-pool + SDPA padding mask,
 near-reference accuracy at any length), batch 1 per chip, 1 command queue.
 
-**Core allocation — isolate the server, OS-float the workers.** The single
-biggest scaling lever is *which process gets dedicated CPU*. Each worker is
-device-bound (its ~7.6 ms is on-chip) and only needs short, un-starved host bursts
-for tokenize + dispatch, so the 32 workers are left **OS-scheduled** — pinning a
-worker to dedicated cores starves its tt-metal dispatch/completion threads and
-causes catastrophic tails (e.g. e2e p99 jumps to ~128 ms). The HTTP **server** is
-the opposite: a *single* process (event loop + result collector + HTTP) serving
-all 32 chips, i.e. the one shared host serialization point. By default
-(`--server-phys 4`) it gets 4 dedicated physical cores while workers float on the
-rest. Measured effect at full load (vs. everything OS-floating): **+46 % throughput
-(1,777 → 2,589 req/s) and −42 % p99 latency at 64 in-flight**, with on-device
-replay still flat at ~7.6 ms. Set `--server-phys 0` to disable, or
-`--cores-per-worker K>0` to dedicate cores per worker (measured to be *worse* —
-provided only for experimentation). Concurrency itself comes from the 32 chips
-running in parallel — the scheduler hands each input to the next idle chip (up to
-32 in flight), and a batched request (`input: [...]`) fans out across free chips.
+Concurrency comes from the 32 chips running in parallel — the scheduler hands each
+input to the next idle chip (up to 32 in flight), and a batched request
+(`input: [...]`) fans out across free chips. The single HTTP server process is
+given a few dedicated cores while the device-bound workers stay OS-scheduled, which
+keeps per-chip latency flat under load.
 
 ### API
 
@@ -366,8 +352,6 @@ concurrency level, each input padded to the full 512-token bucket (worst case).
 "In-flight" is the number of concurrent requests; "on-device replay" is the
 per-chip prefill+RMSNorm+pool latency reported by the worker (`GET /metrics`).
 
-Default core allocation (`--server-phys 4`, workers OS-float):
-
 | In-flight | Throughput (req/s) | Throughput (tok/s) | On-device replay p50 / p99 (ms) | Client e2e p50 / p99 (ms) |
 | --------: | -----------------: | -----------------: | :-----------------------------: | :-----------------------: |
 |         1 |                 81 |              41.4k |          7.81 / 7.92            |        12.5 / 13.2        |
@@ -379,78 +363,9 @@ Default core allocation (`--server-phys 4`, workers OS-float):
 at ~7.6–7.8 ms (p99 < 8 ms) from 1 to 64 concurrent requests: a request served
 while all 32 chips are busy costs the same on-device as one served in isolation.
 
-**Why the server gets dedicated cores (CPU-allocation sweep).** Client e2e p50/p99
-and throughput at 64 in-flight, same workload, three allocations:
-
-| Allocation | e2e p50 / p99 (ms) | Throughput (req/s) |
-| --- | :---: | ---: |
-| Everything OS-floats | 31.0 / 98.7 | 1,777 |
-| 1 dedicated core per worker | 32.8 / 76.7 (p99 **128** at c=1) | 1,805 |
-| **Server isolated (4 phys), workers float — default** | **22.2 / 57.0** | **2,589** |
-
-Workers are device-bound, so dedicating cores to them only starves their tt-metal
-dispatch threads (huge tails); the single server process is the shared host
-bottleneck, so isolating *it* is the win (+46 % throughput, −42 % p99).
-
-Sweeping `--server-phys` shows a clear optimum at **4** (c=64 throughput): 2 phys
-→ 2,372 req/s (the single event loop occasionally starves under load), **4 phys →
-2,589 req/s**, 8 phys → 2,255 req/s (steals cores from the 32 workers). The server
-is one event loop + one collector thread, so ~4 physical cores saturate it; more
-just costs worker throughput.
-
-**Per-request overhead (concurrency 1, p50 ms).** `GET /metrics` decomposes each
-request into its hops. The end-to-end latency is the on-device replay plus a small
-fixed host/IPC/HTTP cost:
-
-| Hop | p50 (ms) | Notes |
-| --- | -------: | ----- |
-| tokenize | 1.3 | host CPU, HF Rust `backend_tokenizer`, in the worker (overlaps across all 32 chips) |
-| build host tensors | 0.14 | token tensor only; page table is cached, RoPE is baked into the trace |
-| task_q (dispatch→worker) | 0.15 | mp.Queue transit |
-| **on-device replay** | **7.5** | prefill + RMSNorm + mean-pool (device-bound floor) |
-| (H2D/D2H/host finalize) | 0.20 | inside worker_total (~7.6) |
-| result (worker→future) | 0.36 | mp.Queue transit + event-loop wakeup |
-| HTTP (parse + base64 resp) | ~0.8 | uvloop + httptools, ~5.5 KB base64 |
-| **client e2e** | **~10.4** | at the c=32 operating point |
-
-The host overhead beyond the device replay is the tokenizer plus a fixed
-IPC/HTTP cost. An earlier version spent an extra ~5 ms in `prepare` because it
-re-tokenized twice and rebuilt the (request-independent) RoPE matrices and page
-table every call; those are now cached/skipped, cutting concurrency-1 e2e from
-~16 ms to ~10–12 ms. Tokenization runs **in the workers** by default, where it is
-distributed across the 32 processes and overlaps device work — so its ~1.3 ms
-does not limit throughput (the system is device-bound at ~2,760 req/s).
-
-#### Tokenization: why fastokens / server-side did *not* help here (`--fastokens`, experimental)
-
-The [fastokens](https://github.com/Atero-ai/fastokens) Rust engine
-(Crusoe/NVIDIA-Dynamo) is genuinely faster in isolation — ~0.09 ms vs HF's
-~0.75 ms for a 512-token input, byte-identical ids on this `Qwen2TokenizerFast`.
-But on this DP=32 server it does **not** improve the operating point, and both
-placements measured *worse* than the default worker-side HF path:
-
-| Config (c=32, ISL 512) | Throughput | e2e p50 |
-| --- | ---: | ---: |
-| **worker-side HF (default)** | **~2,760 req/s** | **~10.4 ms** |
-| server-side + fastokens | ~2,240 req/s | ~13.5 ms |
-| worker-side + fastokens (×32, even `RAYON_NUM_THREADS=1`) | ~510 req/s | ~60 ms |
-
-Why:
-
-* **The single server process is the throughput bottleneck**, not the tokenizer.
-  Moving tokenization onto its 4 dedicated cores adds work to the bottleneck and
-  slows the event loop's dispatch/collect hops (≈ −19 % throughput).
-* **fastokens replicated across 32 workers is pathological** — each instance
-  spins up its own thread pool, oversubscribing the host (tokenize p50 jumps to
-  ~2.6 ms with a ~26 ms tail), regardless of `RAYON_NUM_THREADS`.
-* **At the throughput operating point the tokenizer is off the critical path** —
-  the system is device-bound (~7.5 ms replay × 32 chips), so worker-side HF's
-  ~1.3 ms overlaps and is effectively free. fastokens only helps single-stream
-  (c=1) latency by ~1 ms, which is not the regime that matters here.
-
-**Conclusion: leave tokenization on the worker with the HF tokenizer (the
-default).** `--fastokens` / `--server-tokenize` remain as opt-in experimental
-flags but are **not recommended** for DP=32 serving.
+Tokenization runs in the workers, distributed across the 32 processes and
+overlapping device work, so its host cost does not limit throughput (the system is
+device-bound).
 
 **Operating point.** Throughput peaks around **~2,600 req/s (~1.3M tokens/s)** at
 64 in-flight requests (two per chip, pipelined). Beyond that the chips are

--- a/models/demos/blackhole/pplx_embed_0_6b/README.md
+++ b/models/demos/blackhole/pplx_embed_0_6b/README.md
@@ -259,6 +259,208 @@ round-robin), or run `live_demo.py --dp 32` directly.
 
 ---
 
+## Serving (HTTP, DP=32)
+
+[`demo/serve.py`](demo/serve.py) puts a lightweight async **FastAPI + uvicorn**
+layer on top of the 32 resident chip workers and exposes an **OpenAI-compatible**
+`/v1/embeddings` API. It is built for high request throughput at low per-request
+latency.
+
+**Install** (one-time):
+
+```bash
+pip install fastapi "uvicorn[standard]" orjson
+```
+
+**Run** (loads one encoder per chip; ~1-2 min build, then resident):
+
+```bash
+python models/demos/blackhole/pplx_embed_0_6b/demo/serve.py --dp 32
+# CLI: --dp N (chips, default 32), --host (default 0.0.0.0), --port (default 8000),
+#      --server-phys S    (physical cores reserved for the server; default 4 = recommended)
+#      --cores-per-worker K (pin K physical cores per worker; default 0 = OS-float; NOT recommended)
+#      --fastokens / --server-tokenize  (experimental; NOT recommended — measured to
+#                                         REGRESS DP=32 throughput; see "Tokenization" below)
+```
+
+**Fixed worker configuration** (tuned for lowest per-request latency, not
+per-request toggles): ISL 512, `BucketedEncoder` ON (short text routes to the
+faster 128/256 trace), masked-attn ON (real-token mean-pool + SDPA padding mask,
+near-reference accuracy at any length), batch 1 per chip, 1 command queue.
+
+**Core allocation — isolate the server, OS-float the workers.** The single
+biggest scaling lever is *which process gets dedicated CPU*. Each worker is
+device-bound (its ~7.6 ms is on-chip) and only needs short, un-starved host bursts
+for tokenize + dispatch, so the 32 workers are left **OS-scheduled** — pinning a
+worker to dedicated cores starves its tt-metal dispatch/completion threads and
+causes catastrophic tails (e.g. e2e p99 jumps to ~128 ms). The HTTP **server** is
+the opposite: a *single* process (event loop + result collector + HTTP) serving
+all 32 chips, i.e. the one shared host serialization point. By default
+(`--server-phys 4`) it gets 4 dedicated physical cores while workers float on the
+rest. Measured effect at full load (vs. everything OS-floating): **+46 % throughput
+(1,777 → 2,589 req/s) and −42 % p99 latency at 64 in-flight**, with on-device
+replay still flat at ~7.6 ms. Set `--server-phys 0` to disable, or
+`--cores-per-worker K>0` to dedicate cores per worker (measured to be *worse* —
+provided only for experimentation). Concurrency itself comes from the 32 chips
+running in parallel — the scheduler hands each input to the next idle chip (up to
+32 in flight), and a batched request (`input: [...]`) fans out across free chips.
+
+### API
+
+`POST /v1/embeddings` (OpenAI schema). `input` is a string or list of strings;
+`encoding_format` is `"float"` (JSON floats) or `"base64"` (float32
+little-endian, ~6× smaller — recommended for high-RPS clients).
+
+```bash
+# Single input, float vector
+curl http://localhost:8000/v1/embeddings \
+  -H 'Content-Type: application/json' \
+  -d '{"model": "pplx-embed-v1-0.6b", "input": "hello world"}'
+
+# Batch input, compact base64 payload (fans out across free chips)
+curl http://localhost:8000/v1/embeddings \
+  -H 'Content-Type: application/json' \
+  -d '{"model": "pplx-embed-v1-0.6b",
+       "input": ["what is a tensor?", "define BM25"],
+       "encoding_format": "base64"}'
+
+# Liveness / chip count, and model list
+curl http://localhost:8000/health      # {"status":"ok","chips_ready":32,"chips_total":32}
+curl http://localhost:8000/v1/models
+
+# Per-request latency breakdown (on-device replay vs. server overhead), ms.
+# Add ?reset=true to clear the rolling window.
+curl http://localhost:8000/metrics
+```
+
+Response (OpenAI schema):
+
+```json
+{
+  "object": "list",
+  "data": [{"object": "embedding", "index": 0, "embedding": [/* 1024 floats */]}],
+  "model": "pplx-embed-v1-0.6b",
+  "usage": {"prompt_tokens": 2, "total_tokens": 2}
+}
+```
+
+Because the API is OpenAI-compatible, the `openai` Python SDK works pointed at
+the local base URL. A dependency-light async client + load test is provided in
+[`demo/embed_client.py`](demo/embed_client.py):
+
+```bash
+# Embed inline texts
+python models/demos/blackhole/pplx_embed_0_6b/demo/embed_client.py "hello world" "what is a tensor?"
+
+# Concurrent load test: 1500 requests, 64 in flight, full ISL-512 inputs, base64.
+# After the run it also prints the server-side device-vs-overhead breakdown
+# (pulled from GET /metrics).
+python models/demos/blackhole/pplx_embed_0_6b/demo/embed_client.py \
+    --load 1500 --concurrency 64 --encoding base64 --long
+```
+
+### Load benchmark (DP=32, ISL 512, base64)
+
+Measured on the Blackhole Galaxy with all 32 chips resident, 1200 requests per
+concurrency level, each input padded to the full 512-token bucket (worst case).
+"In-flight" is the number of concurrent requests; "on-device replay" is the
+per-chip prefill+RMSNorm+pool latency reported by the worker (`GET /metrics`).
+
+Default core allocation (`--server-phys 4`, workers OS-float):
+
+| In-flight | Throughput (req/s) | Throughput (tok/s) | On-device replay p50 / p99 (ms) | Client e2e p50 / p99 (ms) |
+| --------: | -----------------: | -----------------: | :-----------------------------: | :-----------------------: |
+|         1 |                 81 |              41.4k |          7.81 / 7.92            |        12.5 / 13.2        |
+|         8 |                636 |               326k |          7.66 / 7.70            |        12.2 / 18.8        |
+|        32 |              2,383 |              1.22M |          7.64 / 7.68            |        11.9 / 41.0        |
+|        64 |              2,589 |              1.33M |          7.63 / 7.67            |        22.2 / 57.0        |
+
+**Key result — per-chip latency is flat under full load.** On-device replay stays
+at ~7.6–7.8 ms (p99 < 8 ms) from 1 to 64 concurrent requests: a request served
+while all 32 chips are busy costs the same on-device as one served in isolation.
+
+**Why the server gets dedicated cores (CPU-allocation sweep).** Client e2e p50/p99
+and throughput at 64 in-flight, same workload, three allocations:
+
+| Allocation | e2e p50 / p99 (ms) | Throughput (req/s) |
+| --- | :---: | ---: |
+| Everything OS-floats | 31.0 / 98.7 | 1,777 |
+| 1 dedicated core per worker | 32.8 / 76.7 (p99 **128** at c=1) | 1,805 |
+| **Server isolated (4 phys), workers float — default** | **22.2 / 57.0** | **2,589** |
+
+Workers are device-bound, so dedicating cores to them only starves their tt-metal
+dispatch threads (huge tails); the single server process is the shared host
+bottleneck, so isolating *it* is the win (+46 % throughput, −42 % p99).
+
+Sweeping `--server-phys` shows a clear optimum at **4** (c=64 throughput): 2 phys
+→ 2,372 req/s (the single event loop occasionally starves under load), **4 phys →
+2,589 req/s**, 8 phys → 2,255 req/s (steals cores from the 32 workers). The server
+is one event loop + one collector thread, so ~4 physical cores saturate it; more
+just costs worker throughput.
+
+**Per-request overhead (concurrency 1, p50 ms).** `GET /metrics` decomposes each
+request into its hops. The end-to-end latency is the on-device replay plus a small
+fixed host/IPC/HTTP cost:
+
+| Hop | p50 (ms) | Notes |
+| --- | -------: | ----- |
+| tokenize | 1.3 | host CPU, HF Rust `backend_tokenizer`, in the worker (overlaps across all 32 chips) |
+| build host tensors | 0.14 | token tensor only; page table is cached, RoPE is baked into the trace |
+| task_q (dispatch→worker) | 0.15 | mp.Queue transit |
+| **on-device replay** | **7.5** | prefill + RMSNorm + mean-pool (device-bound floor) |
+| (H2D/D2H/host finalize) | 0.20 | inside worker_total (~7.6) |
+| result (worker→future) | 0.36 | mp.Queue transit + event-loop wakeup |
+| HTTP (parse + base64 resp) | ~0.8 | uvloop + httptools, ~5.5 KB base64 |
+| **client e2e** | **~10.4** | at the c=32 operating point |
+
+The host overhead beyond the device replay is the tokenizer plus a fixed
+IPC/HTTP cost. An earlier version spent an extra ~5 ms in `prepare` because it
+re-tokenized twice and rebuilt the (request-independent) RoPE matrices and page
+table every call; those are now cached/skipped, cutting concurrency-1 e2e from
+~16 ms to ~10–12 ms. Tokenization runs **in the workers** by default, where it is
+distributed across the 32 processes and overlaps device work — so its ~1.3 ms
+does not limit throughput (the system is device-bound at ~2,760 req/s).
+
+#### Tokenization: why fastokens / server-side did *not* help here (`--fastokens`, experimental)
+
+The [fastokens](https://github.com/Atero-ai/fastokens) Rust engine
+(Crusoe/NVIDIA-Dynamo) is genuinely faster in isolation — ~0.09 ms vs HF's
+~0.75 ms for a 512-token input, byte-identical ids on this `Qwen2TokenizerFast`.
+But on this DP=32 server it does **not** improve the operating point, and both
+placements measured *worse* than the default worker-side HF path:
+
+| Config (c=32, ISL 512) | Throughput | e2e p50 |
+| --- | ---: | ---: |
+| **worker-side HF (default)** | **~2,760 req/s** | **~10.4 ms** |
+| server-side + fastokens | ~2,240 req/s | ~13.5 ms |
+| worker-side + fastokens (×32, even `RAYON_NUM_THREADS=1`) | ~510 req/s | ~60 ms |
+
+Why:
+
+* **The single server process is the throughput bottleneck**, not the tokenizer.
+  Moving tokenization onto its 4 dedicated cores adds work to the bottleneck and
+  slows the event loop's dispatch/collect hops (≈ −19 % throughput).
+* **fastokens replicated across 32 workers is pathological** — each instance
+  spins up its own thread pool, oversubscribing the host (tokenize p50 jumps to
+  ~2.6 ms with a ~26 ms tail), regardless of `RAYON_NUM_THREADS`.
+* **At the throughput operating point the tokenizer is off the critical path** —
+  the system is device-bound (~7.5 ms replay × 32 chips), so worker-side HF's
+  ~1.3 ms overlaps and is effectively free. fastokens only helps single-stream
+  (c=1) latency by ~1 ms, which is not the regime that matters here.
+
+**Conclusion: leave tokenization on the worker with the HF tokenizer (the
+default).** `--fastokens` / `--server-tokenize` remain as opt-in experimental
+flags but are **not recommended** for DP=32 serving.
+
+**Operating point.** Throughput peaks around **~2,600 req/s (~1.3M tokens/s)** at
+64 in-flight requests (two per chip, pipelined). Beyond that the chips are
+saturated, so extra concurrency only adds queuing delay (client e2e tail grows
+while on-device stays flat). The host overhead overlaps across the 32 workers, so
+it costs throughput but not device time. Keep 32–64 requests in flight and prefer
+`encoding_format: "base64"` to minimize host serialization.
+
+---
+
 ## 3. Performance
 
 All numbers measured on Blackhole P150. Optimizations (Section 5) are on by

--- a/models/demos/blackhole/pplx_embed_0_6b/README.md
+++ b/models/demos/blackhole/pplx_embed_0_6b/README.md
@@ -347,31 +347,31 @@ python models/demos/blackhole/pplx_embed_0_6b/demo/embed_client.py \
 
 ### Load benchmark (DP=32, ISL 512, base64)
 
-Measured on the Blackhole Galaxy with all 32 chips resident, 1200 requests per
-concurrency level, each input padded to the full 512-token bucket (worst case).
-"In-flight" is the number of concurrent requests; "on-device replay" is the
-per-chip prefill+RMSNorm+pool latency reported by the worker (`GET /metrics`).
+Measured on the Blackhole Galaxy with all 32 chips resident (400–1500 requests
+per concurrency level), each input padded to the full 512-token bucket (worst
+case). "In-flight" is the number of concurrent requests; "on-device replay" is
+the per-chip prefill+RMSNorm+pool latency reported by the worker (`GET /metrics`).
 
 | In-flight | Throughput (req/s) | Throughput (tok/s) | On-device replay p50 / p99 (ms) | Client e2e p50 / p99 (ms) |
 | --------: | -----------------: | -----------------: | :-----------------------------: | :-----------------------: |
-|         1 |                 81 |              41.4k |          7.81 / 7.92            |        12.5 / 13.2        |
-|         8 |                636 |               326k |          7.66 / 7.70            |        12.2 / 18.8        |
-|        32 |              2,383 |              1.22M |          7.64 / 7.68            |        11.9 / 41.0        |
-|        64 |              2,589 |              1.33M |          7.63 / 7.67            |        22.2 / 57.0        |
+|         1 |                 86 |              43.9k |          7.42 / 7.55            |        11.7 / 12.6        |
+|         8 |                690 |               353k |          7.41 / 7.45            |        11.2 / 14.4        |
+|        32 |              2,461 |              1.26M |          7.38 / 7.42            |        11.5 / 43.9        |
+|        64 |              2,840 |              1.45M |          7.37 / 7.41            |        20.4 / 54.0        |
 
 **Key result — per-chip latency is flat under full load.** On-device replay stays
-at ~7.6–7.8 ms (p99 < 8 ms) from 1 to 64 concurrent requests: a request served
+at ~7.4 ms (p99 < 7.6 ms) from 1 to 64 concurrent requests: a request served
 while all 32 chips are busy costs the same on-device as one served in isolation.
 
 Tokenization runs in the workers, distributed across the 32 processes and
 overlapping device work, so its host cost does not limit throughput (the system is
 device-bound).
 
-**Operating point.** Throughput peaks around **~2,600 req/s (~1.3M tokens/s)** at
-64 in-flight requests (two per chip, pipelined). Beyond that the chips are
-saturated, so extra concurrency only adds queuing delay (client e2e tail grows
-while on-device stays flat). The host overhead overlaps across the 32 workers, so
-it costs throughput but not device time. Keep 32–64 requests in flight and prefer
+**Operating point.** Throughput peaks around **~2,840 req/s (~1.45M tokens/s)** at
+64 in-flight requests (two per chip, pipelined). For the lowest latency, keep
+**~32 in flight** — e2e p50 stays ~11.5 ms at ~2,460 req/s, whereas at 64 the
+extra queuing pushes e2e p50 to ~20 ms while on-device replay stays flat. Beyond
+64 the chips are saturated, so more concurrency only adds queuing delay. Prefer
 `encoding_format: "base64"` to minimize host serialization.
 
 ---

--- a/models/demos/blackhole/pplx_embed_0_6b/demo/embed_client.py
+++ b/models/demos/blackhole/pplx_embed_0_6b/demo/embed_client.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Minimal async client + load test for the pplx-embed-v1-0.6b embedding server
+(``serve.py``).  The server speaks the OpenAI ``/v1/embeddings`` schema, so the
+``openai`` Python SDK works too — this is a dependency-light ``aiohttp`` example
+that also doubles as a quick throughput probe.
+
+Examples
+--------
+    # Embed a few inline texts (float vectors):
+    python models/demos/blackhole/pplx_embed_0_6b/demo/embed_client.py \\
+        "hello world" "what is a tensor?"
+
+    # Concurrent load test: 2000 requests, 64 in flight, base64 payloads:
+    python models/demos/blackhole/pplx_embed_0_6b/demo/embed_client.py \\
+        --load 2000 --concurrency 64 --encoding base64
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import time
+from typing import List
+
+import aiohttp
+import numpy as np
+
+
+def decode_embedding(item: dict) -> np.ndarray:
+    """Decode one OpenAI ``data[i].embedding`` (float list or base64) -> ndarray."""
+    emb = item["embedding"]
+    if isinstance(emb, str):
+        return np.frombuffer(base64.b64decode(emb), dtype="<f4")
+    return np.asarray(emb, dtype=np.float32)
+
+
+async def embed(session: aiohttp.ClientSession, url: str, inputs, model: str, encoding: str):
+    payload = {"model": model, "input": inputs, "encoding_format": encoding}
+    async with session.post(url, json=payload) as resp:
+        resp.raise_for_status()
+        body = await resp.json()
+    return [decode_embedding(d) for d in body["data"]], body.get("usage", {})
+
+
+async def _run_inline(args, url: str) -> None:
+    async with aiohttp.ClientSession() as session:
+        vecs, usage = await embed(session, url, args.texts, args.model, args.encoding)
+    for text, v in zip(args.texts, vecs):
+        preview = ", ".join(f"{x:+.4f}" for x in v[:8])
+        print(f"  dim={v.shape[0]}  |emb|={np.linalg.norm(v):.4f}  [{preview}, ...]  <- {text[:48]!r}")
+    print(f"  usage: {usage}")
+
+
+def _base_url(embeddings_url: str) -> str:
+    return embeddings_url.split("/v1/embeddings")[0].rstrip("/")
+
+
+async def _fetch_metrics(session: aiohttp.ClientSession, base: str, reset: bool = False) -> dict:
+    try:
+        async with session.get(f"{base}/metrics", params={"reset": "true"} if reset else {}) as resp:
+            if resp.status != 200:
+                return {}
+            return await resp.json()
+    except Exception:
+        return {}
+
+
+def _make_corpus(n: int, approx_tokens: int = 460) -> List[str]:
+    """Pool of ``n`` DISTINCT ~512-token texts (defeats the tokenizer's per-input
+    cache, so server-side tokenization cost is measured realistically under load).
+    """
+    import random
+
+    rng = random.Random(0)
+    words = (
+        "model inference latency throughput tokenization embedding transformer attention "
+        "kernel matmul pipeline scheduler request response server client vector retrieval "
+        "semantic search index document corpus benchmark profile memory bandwidth cache miss "
+        "thread process core socket numa affinity blackhole galaxy tensix accelerator device "
+        "host dispatch trace replay prefill decode batch sequence length padding mask normalize"
+    ).split()
+    # ~1.3 tokens/word for this vocab -> scale word count to hit approx_tokens.
+    n_words = int(approx_tokens / 1.3)
+    return [" ".join(rng.choice(words) for _ in range(n_words)) + f" #{i}" for i in range(n)]
+
+
+async def _run_load(args, url: str) -> None:
+    # A ~512-token input (forces the full ISL-512 bucket, matching the ~7.1-7.4ms
+    # per-chip figure) when --long is set; otherwise a short input.
+    if args.long:
+        text = "the quick brown fox jumps over the lazy dog while the curious cat watches nearby " * 40
+    else:
+        text = "the quick brown fox jumps over the lazy dog " * 4
+    corpus = _make_corpus(max(256, args.concurrency * 8)) if args.vary else None
+    base = _base_url(url)
+    sem = asyncio.Semaphore(args.concurrency)
+    latencies: List[float] = []
+    total_tokens = 0
+
+    async with aiohttp.ClientSession() as session:
+        # warm the connection pool / server, then clear server-side metrics
+        await embed(session, url, text, args.model, args.encoding)
+        await _fetch_metrics(session, base, reset=True)
+
+        async def one(i: int):
+            nonlocal total_tokens
+            inp = corpus[i % len(corpus)] if corpus is not None else text
+            async with sem:
+                t0 = time.perf_counter()
+                _vecs, usage = await embed(session, url, inp, args.model, args.encoding)
+                latencies.append((time.perf_counter() - t0) * 1000)
+                total_tokens += int(usage.get("total_tokens", 0))
+
+        t0 = time.perf_counter()
+        await asyncio.gather(*(one(i) for i in range(args.load)))
+        wall = time.perf_counter() - t0
+
+        server = await _fetch_metrics(session, base)
+
+    lat = np.array(latencies)
+    print(
+        f"\n  requests:    {args.load}  (concurrency {args.concurrency}, encoding {args.encoding}, "
+        f"{'long~512tok' if args.long else 'short'})"
+    )
+    print(f"  wall:        {wall:.2f}s")
+    print(f"  throughput:  {args.load / wall:,.0f} req/s   {total_tokens / wall:,.0f} tok/s")
+    print(
+        f"  client e2e ms (incl. HTTP):  p50={np.percentile(lat, 50):.1f}  "
+        f"p90={np.percentile(lat, 90):.1f}  p99={np.percentile(lat, 99):.1f}  max={lat.max():.1f}"
+    )
+
+    if server and server.get("count"):
+        print(f"\n  server-side per-request breakdown ({server['count']} samples, buckets {server.get('buckets')}):")
+        for key, label in (
+            ("device", "on-device replay (prefill+norm+pool)"),
+            ("worker_total", "worker total (H2D+device+D2H+host)"),
+            ("server_wall", "server wall (dispatch->result)"),
+            ("overhead", "scheduling/queue overhead"),
+            ("server_tok", "  hop: server_tok (server-side tokenize)"),
+            ("chip_wait", "  hop: chip_wait (await idle chip)"),
+            ("task_q", "  hop: task_q (dispatch->worker)"),
+            ("prepare", "  hop: prepare (tokenize+host tensors)"),
+            ("tok", "      sub: tokenize"),
+            ("build", "      sub: build host tensors"),
+            ("replay", "  hop: replay (== worker_total)"),
+            ("result", "  hop: result (worker->future resolved)"),
+        ):
+            s = server.get(key, {})
+            if s:
+                print(
+                    f"    {label:<40} p50={s['p50']:.2f}  p90={s['p90']:.2f}  "
+                    f"p99={s['p99']:.2f}  max={s['max']:.2f}  mean={s['mean']:.2f}  ms"
+                )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Async client / load test for the pplx-embed server.")
+    parser.add_argument("texts", nargs="*", help="Texts to embed (inline mode).")
+    parser.add_argument("--url", default="http://localhost:8000/v1/embeddings", help="Embeddings endpoint URL.")
+    parser.add_argument("--model", default="pplx-embed-v1-0.6b", help="Model id to send.")
+    parser.add_argument("--encoding", default="float", choices=["float", "base64"], help="encoding_format.")
+    parser.add_argument("--load", type=int, default=0, help="Run a load test with this many requests.")
+    parser.add_argument("--concurrency", type=int, default=64, help="Max in-flight requests in load mode.")
+    parser.add_argument("--long", action="store_true", help="Use a ~512-token input (full ISL bucket) in load mode.")
+    parser.add_argument(
+        "--vary",
+        action="store_true",
+        help="Send DISTINCT ~512-token texts per request (defeats tokenizer input "
+        "caching) so server-side tokenization cost is measured realistically.",
+    )
+    args = parser.parse_args()
+
+    if args.load > 0:
+        asyncio.run(_run_load(args, args.url))
+    else:
+        if not args.texts:
+            args.texts = ["hello world", "what is a tensor?"]
+        asyncio.run(_run_inline(args, args.url))
+
+
+if __name__ == "__main__":
+    main()

--- a/models/demos/blackhole/pplx_embed_0_6b/demo/live_demo.py
+++ b/models/demos/blackhole/pplx_embed_0_6b/demo/live_demo.py
@@ -133,6 +133,51 @@ def encode_one(generator, model, kv_cache, page_table, tokenizer, norm_weight, e
     return emb
 
 
+def maybe_patch_fastokens():
+    """Best-effort global patch of HF ``AutoTokenizer`` with crusoe/atero ``fastokens``.
+
+    Enabled when ``PPLX_FASTOKENS=1`` is set in the environment (the server's
+    ``main`` propagates it to spawned workers). A no-op (with a warning) if the
+    package is not installed, so the import is never a hard dependency. Must run
+    *before* any ``from_pretrained`` so the fast Rust engine is adopted.
+    Returns ``True`` if the patch was applied.
+    """
+    if os.environ.get("PPLX_FASTOKENS", "0") != "1":
+        return False
+    try:
+        import fastokens
+
+        fastokens.patch_transformers()
+        return True
+    except Exception as exc:  # pragma: no cover - optional dependency
+        logger.warning(f"PPLX_FASTOKENS=1 but fastokens unavailable ({exc}); using HF tokenizer.")
+        return False
+
+
+def _fast_encode(tokenizer, text, max_len):
+    """Tokenize ``text`` to a ``list[int]`` (special tokens included), truncated
+    to ``max_len``, using the raw Rust ``backend_tokenizer`` when available.
+
+    The HF Python wrappers (``__call__``/``encode``) add several milliseconds of
+    BatchEncoding/truncation bookkeeping per call; the backend tokenizer's
+    ``encode(text).ids`` is the same result with far less host overhead. Falls
+    back to ``tokenizer.encode`` if no fast backend is present.
+    """
+    raw = getattr(tokenizer, "_tt_raw_backend", "unset")
+    if raw == "unset":
+        raw = getattr(tokenizer, "backend_tokenizer", None)
+        try:
+            tokenizer._tt_raw_backend = raw  # cache on the tokenizer instance
+        except Exception:
+            pass
+    if raw is not None:
+        ids = raw.encode(text).ids
+        if len(ids) > max_len:
+            ids = ids[:max_len]
+        return ids
+    return tokenizer.encode(text, truncation=True, max_length=max_len)
+
+
 class TracedEncoder:
     """Fixed-ISL encoder that replays a captured prefill trace per request.
 
@@ -274,17 +319,61 @@ class TracedEncoder:
         v[:, :, :, :n] = 1.0 / n
         return ttnn.from_torch(v, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
 
-    def _prepare(self, text):
-        """Tokenize + build host input tensors (host-side, not timed as replay)."""
-        enc = self.tokenizer(text, truncation=True, max_length=self.seq_len, return_tensors="pt")
-        ids = enc["input_ids"]
-        n = min(int(ids.shape[1]), self.seq_len)
+    def _tokenize(self, text):
+        """Tokenize ``text`` to a list of ids, capped at this encoder's ISL.
+
+        Prefers the raw Rust ``backend_tokenizer`` (much faster than the HF Python
+        ``__call__``/``encode`` wrappers, which carry BatchEncoding + truncation
+        bookkeeping overhead), falling back to ``.encode`` if unavailable.
+        """
+        ids = _fast_encode(self.tokenizer, text, self.seq_len)
+        return ids, min(len(ids), self.seq_len)
+
+    def _build_inputs(self, ids, n):
+        """Build host input tensors from pre-tokenized ids (host-side, not replay).
+
+        ``ids`` is a ``list[int]``. Only the token tensor is request-dependent.
+        The page table is static, so it is built once and cached. The rotary
+        matrices that ``prepare_prefill_inputs_trace`` also computes are baked into
+        the captured trace and unused here, so we skip recomputing them every
+        request (this was the bulk of the old per-request host overhead).
+        """
         if n == 0:
             return None
-        ids_padded = torch.zeros(1, self.seq_len, dtype=torch.long)
-        ids_padded[0, :n] = ids[0, :n]
-        host_inputs = self.model.prepare_prefill_inputs_trace(ids_padded, page_table=self.page_table_user)
-        return (host_inputs[0], host_inputs[3], host_inputs[4]), n
+        ids_padded = torch.zeros(1, 1, 1, self.seq_len, dtype=torch.long)
+        ids_padded[0, 0, 0, :n] = torch.as_tensor(ids[:n], dtype=torch.long)
+        tokens_host = ttnn.from_torch(
+            ids_padded,
+            device=None,
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.model.mesh_device),
+        )
+        if getattr(self, "_static_host_inputs", None) is None:
+            full = self.model.prepare_prefill_inputs_trace(
+                torch.zeros(1, self.seq_len, dtype=torch.long), page_table=self.page_table_user
+            )
+            self._static_host_inputs = (full[3], full[4])
+        return (tokens_host, self._static_host_inputs[0], self._static_host_inputs[1]), n
+
+    def _prepare(self, text):
+        """Tokenize + build host input tensors (host-side, not timed as replay)."""
+        ids, n = self._tokenize(text)
+        if n == 0:
+            return None
+        return self._build_inputs(ids, n)
+
+    def _prepare_from_ids(self, ids):
+        """Build host input tensors from ids tokenized elsewhere (e.g. the server).
+
+        Skips the tokenizer entirely — used by the server-side tokenization path
+        where the HTTP layer tokenizes on its dedicated cores and ships token ids
+        to the worker, so the worker never contends for CPU on the tokenizer.
+        """
+        n = min(len(ids), self.seq_len)
+        if n == 0:
+            return None
+        return self._build_inputs(ids, n)
 
     def _write_inputs(self, ext_host, n):
         """1-CQ input update: H2D tokens (+ mask/pool on length change) on CQ0."""
@@ -477,13 +566,41 @@ class BucketedEncoder:
         return self.encoders[self._pick(n)], n
 
     def _prepare(self, text):
-        te, _ = self._bucket_for_text(text)
-        prepared = te._prepare(text)
-        if prepared is None:
+        # Tokenize once (at the largest bucket's limit), pick the smallest bucket
+        # that fits, then build inputs from the already-tokenized ids — avoids the
+        # double tokenization of the old _bucket_for_text + te._prepare path.
+        t0 = time.perf_counter()
+        ids = _fast_encode(self.tokenizer, text, self.max_seq)
+        n = len(ids)
+        if n == 0:
             self._active = None
             return None
+        te = self.encoders[self._pick(n)]
         self._active = te
-        return prepared
+        t1 = time.perf_counter()
+        out = te._build_inputs(ids, min(n, te.seq_len))
+        self._prep_tok_ms = (t1 - t0) * 1000.0
+        self._prep_build_ms = (time.perf_counter() - t1) * 1000.0
+        return out
+
+    def _prepare_from_ids(self, ids):
+        """Pick a bucket + build host tensors from ids tokenized elsewhere.
+
+        The server-side tokenization counterpart of ``_prepare``: token ids are
+        produced on the HTTP layer's cores, so here we only select the smallest
+        bucket that fits and build the (cheap) per-request token tensor.
+        """
+        n = len(ids)
+        if n == 0:
+            self._active = None
+            return None
+        te = self.encoders[self._pick(n)]
+        self._active = te
+        t1 = time.perf_counter()
+        out = te._build_inputs(ids, min(n, te.seq_len))
+        self._prep_tok_ms = 0.0  # tokenized off-worker (server threadpool)
+        self._prep_build_ms = (time.perf_counter() - t1) * 1000.0
+        return out
 
     @torch.no_grad()
     def _replay(self, ext_host, n, normalize=True):
@@ -614,8 +731,48 @@ def _run_repl(encode_fn, traced=None, normalize=True, metrics=False):
 # ──────────────────────────────────────────────────────────────────────────────
 
 
-def _dp_worker(chip_id, args, normalize, task_q, result_q, ready_q, cores_per_worker):
+def _smt_cores(phys_ids, n_phys):
+    """Expand physical core ids to all their SMT-sibling logical cpu ids.
+
+    On a 2-threads/core host, physical core ``p`` owns logical cpus ``p`` and
+    ``p + n_phys`` (verified via /sys thread_siblings).
+    """
+    cores = set()
+    for p in phys_ids:
+        cores.add(int(p))
+        cores.add(int(p) + n_phys)
+    return cores
+
+
+def compute_worker_cores(chip_id, n_workers, cpw, server_phys=0, total_logical=None):
+    """Logical-cpu affinity set for worker ``chip_id`` (or ``None`` => OS-float).
+
+    SMT-aware: physical core ``p`` -> logical ``{p, p+n_phys}``.
+      * ``cpw > 0``  : dedicate ``cpw`` physical cores per worker (round-robin over
+                       the worker pool) -> clean per-worker isolation (each worker
+                       owns whole physical cores incl. both hyperthreads).
+      * ``cpw == 0`` : workers share the pool. Returns ``None`` (unset affinity)
+                       when the pool is every core; otherwise the shared set.
+    ``server_phys`` physical cores at the top are reserved for the server.
+    """
+    total_logical = total_logical or os.cpu_count() or 64
+    n_phys = max(1, total_logical // 2)
+    pool_phys = max(1, n_phys - max(0, int(server_phys)))  # worker pool = phys [0, pool_phys)
+    if cpw and cpw > 0:
+        phys = [(chip_id * cpw + i) % pool_phys for i in range(cpw)]
+        return _smt_cores(phys, n_phys)
+    if server_phys and server_phys > 0:
+        return _smt_cores(range(pool_phys), n_phys)
+    return None  # everything floats (OS-scheduled)
+
+
+def _dp_worker(chip_id, args, normalize, task_q, result_q, ready_q, worker_cores):
     """Single chip: build a resident TracedEncoder, then serve from ``task_q``.
+
+    ``worker_cores`` is a precomputed set of logical cpu ids to pin to, or ``None``
+    to leave affinity unset (OS-scheduled). Pinning a worker to a *single
+    hyperthread* starves the device dispatch/completion thread and adds large tail
+    latency; whole physical cores (both siblings) or OS-float are preferred.
 
     Protocol:
       * On ready (after warmup) puts ``(chip_id, build_sec)`` on ``ready_q``.
@@ -624,12 +781,16 @@ def _dp_worker(chip_id, args, normalize, task_q, result_q, ready_q, cores_per_wo
       * A ``None`` task terminates the worker.
     """
     os.environ["TT_VISIBLE_DEVICES"] = str(chip_id)
-    total_cores = os.cpu_count() or 64
-    start_core = (chip_id * cores_per_worker) % total_cores
-    try:
-        os.sched_setaffinity(0, set(range(start_core, min(start_core + cores_per_worker, total_cores))))
-    except (OSError, AttributeError):
-        pass
+    # Keep each worker's tokenizer single-threaded: with 32 workers, the HF Rust
+    # tokenizer's intra-op thread pool would otherwise fan out to 32xN threads and
+    # oversubscribe the host. (Also silences the post-fork parallelism warning.)
+    os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+    maybe_patch_fastokens()
+    if worker_cores:
+        try:
+            os.sched_setaffinity(0, set(worker_cores))
+        except (OSError, AttributeError):
+            pass
 
     try:
         import numpy as np
@@ -689,16 +850,30 @@ def _dp_worker(chip_id, args, normalize, task_q, result_q, ready_q, cores_per_wo
 
         while True:
             task = task_q.get()
+            t_recv = time.perf_counter()
             if task is None:
                 break
-            idx, text = task
-            prepared = enc._prepare(text)
+            idx, payload = task
+            # ``payload`` is either the raw text (worker tokenizes) or a list of
+            # pre-tokenized ids (server-side tokenization path).
+            if isinstance(payload, str):
+                prepared = enc._prepare(payload)
+            else:
+                prepared = enc._prepare_from_ids(payload)
+            t_prep = time.perf_counter()
             if prepared is None:
-                result_q.put((idx, chip_id, None, None))
+                result_q.put((idx, chip_id, None, None, 0))
                 continue
             ext_host, n = prepared
             emb, steps = enc._replay_timed(ext_host, n, normalize=normalize)
-            result_q.put((idx, chip_id, emb.float().numpy().astype(np.float32), steps))
+            # Cross-process timestamps (CLOCK_MONOTONIC, comparable to the server)
+            # so the server can localize host-side overhead per hop.
+            steps["t_recv"] = t_recv
+            steps["t_prep"] = t_prep
+            steps["t_done"] = time.perf_counter()
+            steps["tok"] = getattr(enc, "_prep_tok_ms", 0.0)
+            steps["build"] = getattr(enc, "_prep_build_ms", 0.0)
+            result_q.put((idx, chip_id, emb.float().numpy().astype(np.float32), steps, n))
     except Exception as exc:  # surface build/serve failures to the parent
         try:
             ready_q.put((chip_id, None, f"{type(exc).__name__}: {exc}"))
@@ -714,20 +889,19 @@ def _dp_worker(chip_id, args, normalize, task_q, result_q, ready_q, cores_per_wo
 class _DPServer:
     """Spawns N chip workers and dispatches embedding requests across them."""
 
-    def __init__(self, args, normalize):
+    def __init__(self, args, normalize, cores_per_worker=0):
         self.n = args.dp
         self.normalize = normalize
         ctx = mp.get_context("spawn")
-        total_cores = os.cpu_count() or 64
-        cores_per_worker = max(1, total_cores // self.n)
         self.task_qs = [ctx.Queue() for _ in range(self.n)]
         self.result_q = ctx.Queue()
         ready_q = ctx.Queue()
         self.procs = []
         for i in range(self.n):
+            worker_cores = compute_worker_cores(i, self.n, cores_per_worker, server_phys=0)
             p = ctx.Process(
                 target=_dp_worker,
-                args=(i, args, normalize, self.task_qs[i], self.result_q, ready_q, cores_per_worker),
+                args=(i, args, normalize, self.task_qs[i], self.result_q, ready_q, worker_cores),
                 name=f"chip-{i}",
                 daemon=True,
             )
@@ -767,7 +941,7 @@ class _DPServer:
             self.task_qs[c].put((0, text))
         got = [self.result_q.get() for _ in chips]
         wall_ms = (time.perf_counter() - t0) * 1000
-        return [(c, e, s) for (_, c, e, s) in got], wall_ms
+        return [(c, e, s) for (_, c, e, s, _n) in got], wall_ms
 
     def map(self, texts):
         """Distribute a list of texts round-robin across chips; return embeddings
@@ -779,7 +953,7 @@ class _DPServer:
         out = [None] * len(texts)
         steps_list = []
         for _ in range(len(texts)):
-            idx, _chip, emb, steps = self.result_q.get()
+            idx, _chip, emb, steps, _n = self.result_q.get()
             out[idx] = emb
             if steps is not None:
                 steps_list.append(steps)

--- a/models/demos/blackhole/pplx_embed_0_6b/demo/serve.py
+++ b/models/demos/blackhole/pplx_embed_0_6b/demo/serve.py
@@ -90,7 +90,7 @@ class AsyncEmbeddingPool:
         normalize: bool = True,
         cores_per_worker: int = 0,
         server_phys: int = 0,
-        server_tokenize: bool = True,
+        server_tokenize: bool = False,
     ):
         self.n = dp
         self.normalize = normalize

--- a/models/demos/blackhole/pplx_embed_0_6b/demo/serve.py
+++ b/models/demos/blackhole/pplx_embed_0_6b/demo/serve.py
@@ -1,0 +1,569 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Lightweight OpenAI-compatible embedding server for pplx-embed-v1-0.6B on a
+Blackhole Galaxy (DP=32).
+
+This puts a thin async **FastAPI + uvicorn** layer on top of the resident chip
+workers from ``live_demo.py``.  Each of the 32 chips runs one resident encoder
+pinned to its own CPU core (cores ``0..dp-1``); the HTTP server's event loop and
+thread-pool run on the *remaining* cores (``dp..N``), so request handling never
+competes with the device workers.
+
+Worker configuration is **fixed** for lowest per-request latency at batch 1:
+
+  * ISL = 512 (``max_length=512``) — bucketed traces at 128 / 256 / 512.
+  * ``BucketedEncoder`` ON — every request replays the smallest length tier that
+    fits (short text ~5.5ms@128 vs ~7.8ms@512).
+  * masked-attn ON (real-token mean-pool + SDPA padding mask) — near-reference
+    accuracy at any length.
+  * batch 1 per worker, 1 in-flight request per chip, 1 command queue.
+
+Concurrency comes from the 32 chips running in parallel: the scheduler hands each
+input to the next idle chip, so up to 32 requests run at once and a batched
+request (``input: [...]``) fans out across all free chips.
+
+Run
+---
+    python models/demos/blackhole/pplx_embed_0_6b/demo/serve.py --dp 32
+
+Then (OpenAI-compatible)::
+
+    curl http://localhost:8000/v1/embeddings \\
+      -H 'Content-Type: application/json' \\
+      -d '{"model": "pplx-embed-v1-0.6b", "input": "hello world"}'
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import multiprocessing as mp
+import os
+import sys
+import threading
+import time
+from collections import deque
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import asynccontextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from typing import List, Optional, Union
+
+import numpy as np
+from loguru import logger
+
+# Make ``models...`` importable when run as a script.
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from models.demos.blackhole.pplx_embed_0_6b.demo.live_demo import (  # noqa: E402
+    _dp_worker,
+    _fast_encode,
+    _smt_cores,
+    compute_worker_cores,
+    maybe_patch_fastokens,
+)
+
+MODEL_ID = os.environ.get("HF_MODEL", "pplx-embed-v1-0.6b")
+EMBED_DIM = 1024
+
+
+# --------------------------------------------------------------------------- #
+# Async chip pool
+# --------------------------------------------------------------------------- #
+class AsyncEmbeddingPool:
+    """Spawns N resident chip workers and schedules requests across idle chips.
+
+    Each worker is the same ``_dp_worker`` used by ``live_demo.py`` (ISL 512,
+    BucketedEncoder, masked-attn, bs1, 1-CQ), pinned to a single core.  A
+    background collector thread drains the shared mp result queue and resolves
+    per-request asyncio futures, returning the chip to the idle pool.
+    """
+
+    def __init__(
+        self,
+        dp: int,
+        normalize: bool = True,
+        cores_per_worker: int = 0,
+        server_phys: int = 0,
+        server_tokenize: bool = True,
+    ):
+        self.n = dp
+        self.normalize = normalize
+        self.isl = 512
+        args = SimpleNamespace(
+            dp=dp,
+            max_length=self.isl,
+            mask=True,
+            no_bucket=False,
+            cq2=False,
+        )
+        # Server-side tokenization: tokenize on the HTTP layer's dedicated cores
+        # (in a GIL-releasing thread pool) and ship token ids to workers, instead
+        # of tokenizing inside each device worker where it contends with the 32
+        # workers' tt-metal dispatch threads. Falls back to worker-side tokenize.
+        self.server_tokenize = server_tokenize
+        self.tokenizer = None
+        self._tok_pool: Optional[ThreadPoolExecutor] = None
+        if self.server_tokenize:
+            maybe_patch_fastokens()
+            from transformers import AutoTokenizer
+
+            self.tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+            # Threads run on the server's pinned cores (inherited affinity); the HF
+            # Rust tokenizer releases the GIL during ``encode`` so they parallelize.
+            n_tok_threads = max(4, 2 * server_phys) if server_phys > 0 else 8
+            self._tok_pool = ThreadPoolExecutor(max_workers=n_tok_threads, thread_name_prefix="tok")
+            logger.info(f"Server-side tokenization ON ({n_tok_threads} tokenizer threads).")
+        ctx = mp.get_context("spawn")
+        self.task_qs = [ctx.Queue() for _ in range(self.n)]
+        self.result_q = ctx.Queue()
+        ready_q = ctx.Queue()
+        self.procs = []
+        for i in range(self.n):
+            worker_cores = compute_worker_cores(i, self.n, cores_per_worker, server_phys=server_phys)
+            p = ctx.Process(
+                target=_dp_worker,
+                args=(i, args, normalize, self.task_qs[i], self.result_q, ready_q, worker_cores),
+                name=f"chip-{i}",
+                daemon=True,
+            )
+            p.start()
+            self.procs.append(p)
+
+        logger.info(f"Building {self.n} resident encoders (one per chip) — this takes ~1-2 min...")
+        self.ready, self.failed = set(), {}
+        for _ in range(self.n):
+            msg = ready_q.get()
+            if len(msg) == 3 and msg[1] is None:
+                self.failed[msg[0]] = msg[2]
+            else:
+                self.ready.add(msg[0])
+                logger.info(f"  chip {msg[0]:>2} ready (build {msg[1]:.0f}s) [{len(self.ready)}/{self.n}]")
+        if self.failed:
+            logger.error(f"{len(self.failed)} chip(s) failed to build:")
+            for cid, err in sorted(self.failed.items()):
+                logger.error(f"  chip {cid}: {err[:200]}")
+        if not self.ready:
+            raise RuntimeError("All DP workers failed to build.")
+        logger.info(f"Embedding pool ready: {len(self.ready)}/{self.n} chips live.")
+
+        # Async scheduling state — bound to the event loop in ``start()``.
+        self.loop: Optional[asyncio.AbstractEventLoop] = None
+        self.idle_chips: Optional[asyncio.Queue] = None
+        self.pending: dict = {}
+        self._req_id = 0
+        self._collector: Optional[threading.Thread] = None
+        # Per-request timing samples (written only from the event loop).
+        self.metrics: deque = deque(maxlen=200_000)
+
+    def start(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Bind the pool to the running event loop and start the collector."""
+        self.loop = loop
+        self.idle_chips = asyncio.Queue()
+        for chip in sorted(self.ready):
+            self.idle_chips.put_nowait(chip)
+        self._collector = threading.Thread(target=self._collect, name="result-collector", daemon=True)
+        self._collector.start()
+
+    def _collect(self) -> None:
+        while True:
+            item = self.result_q.get()
+            if item is None:  # shutdown sentinel
+                break
+            req_id, chip, emb, steps, n = item
+            fut = self.pending.pop(req_id, None)
+            if fut is not None:
+                self.loop.call_soon_threadsafe(self._resolve, fut, emb, n, steps)
+            self.loop.call_soon_threadsafe(self.idle_chips.put_nowait, chip)
+
+    @staticmethod
+    def _resolve(fut: asyncio.Future, emb, n: int, steps) -> None:
+        if fut.done():
+            return
+        if emb is None:
+            fut.set_exception(ValueError("empty input"))
+        else:
+            fut.set_result((emb, n, steps))
+
+    async def embed_one(self, text: str):
+        """Embed one text on the next idle chip.
+
+        Returns ``(emb_np_f32, n_tokens, steps)`` where ``steps`` is the worker's
+        per-step device timing.  Records a timing sample so the server can report
+        device-vs-overhead latency under load via ``/metrics``.
+        """
+        t0 = time.perf_counter()
+        # Tokenize on the server's dedicated cores (off the contended worker
+        # cores) before reserving a chip, so the chip is held only for device work.
+        if self.server_tokenize:
+            payload = await self.loop.run_in_executor(self._tok_pool, _fast_encode, self.tokenizer, text, self.isl)
+            if not payload:
+                raise ValueError("empty input")
+        else:
+            payload = text
+        t_tok = time.perf_counter()
+
+        chip = await self.idle_chips.get()
+        req_id = self._req_id
+        self._req_id += 1
+        fut = self.loop.create_future()
+        self.pending[req_id] = fut
+        t_disp = time.perf_counter()
+        self.task_qs[chip].put((req_id, payload))
+        emb, n, steps = await fut
+        t_end = time.perf_counter()
+        wall = (t_end - t0) * 1000.0
+        if steps is not None:
+            worker_total = float(steps.get("total", 0.0))
+            sample = {
+                "device": float(steps.get("device", 0.0)),
+                "worker_total": worker_total,
+                "server_wall": wall,
+                "overhead": wall - worker_total,
+                "bucket": int(steps.get("bucket", 0)),
+                # Server-side tokenization hop (0.0 when tokenizing in the worker).
+                "server_tok": (t_tok - t0) * 1000.0,
+                "chip_wait": (t_disp - t_tok) * 1000.0,
+            }
+            # Per-hop breakdown of the server_wall (all in ms), if the worker
+            # reported cross-process timestamps:
+            #   server_tok : tokenize on the server threadpool (server path only)
+            #   chip_wait  : wait for an idle chip (queueing under load)
+            #   task_q     : dispatch -> worker dequeues the task (mp.Queue in)
+            #   prepare    : (tokenize, if worker-side) + build host input tensors
+            #   replay     : on-device + D2H + host finalize (== worker_total)
+            #   result     : worker enqueues result -> future resolved on event loop
+            t_recv, t_prep, t_done = steps.get("t_recv"), steps.get("t_prep"), steps.get("t_done")
+            if t_recv and t_prep and t_done:
+                sample["task_q"] = (t_recv - t_disp) * 1000.0
+                sample["prepare"] = (t_prep - t_recv) * 1000.0
+                sample["replay"] = (t_done - t_prep) * 1000.0
+                sample["result"] = (t_end - t_done) * 1000.0
+            if "tok" in steps:
+                sample["tok"] = float(steps["tok"])
+                sample["build"] = float(steps["build"])
+            self.metrics.append(sample)
+        return emb, n, steps
+
+    async def embed_batch(self, texts: List[str]):
+        """Embed a list of texts, auto load-balanced across free chips."""
+        return await asyncio.gather(*(self.embed_one(t) for t in texts))
+
+    def stats(self, reset: bool = False) -> dict:
+        """Percentile summary of recent per-request timings (ms)."""
+        samples = list(self.metrics)
+        if reset:
+            self.metrics.clear()
+        out: dict = {"count": len(samples)}
+        if not samples:
+            return out
+
+        def pct(vals, p):
+            vals = sorted(vals)
+            if not vals:
+                return None
+            k = (len(vals) - 1) * (p / 100.0)
+            lo = int(k)
+            hi = min(lo + 1, len(vals) - 1)
+            return vals[lo] + (vals[hi] - vals[lo]) * (k - lo)
+
+        keys = (
+            "device",
+            "worker_total",
+            "server_wall",
+            "overhead",
+            "server_tok",
+            "chip_wait",
+            "task_q",
+            "prepare",
+            "tok",
+            "build",
+            "replay",
+            "result",
+        )
+        for key in keys:
+            vals = [s[key] for s in samples if key in s]
+            if not vals:
+                continue
+            out[key] = {
+                "p50": round(pct(vals, 50), 3),
+                "p90": round(pct(vals, 90), 3),
+                "p99": round(pct(vals, 99), 3),
+                "max": round(max(vals), 3),
+                "mean": round(sum(vals) / len(vals), 3),
+            }
+        buckets: dict = {}
+        for s in samples:
+            buckets[s["bucket"]] = buckets.get(s["bucket"], 0) + 1
+        out["buckets"] = buckets
+        return out
+
+    def close(self) -> None:
+        if self._tok_pool is not None:
+            self._tok_pool.shutdown(wait=False, cancel_futures=True)
+        # Ask workers to stop, then force-kill promptly. Device teardown
+        # (ttnn.close_device) can hang/SIGABRT under load, so we don't wait on
+        # graceful joins — SIGKILL frees the chips cleanly for the next run.
+        for c in sorted(self.ready):
+            try:
+                self.task_qs[c].put(None)
+            except Exception:
+                pass
+        try:
+            self.result_q.put(None)  # stop collector
+        except Exception:
+            pass
+        deadline = time.time() + 3.0
+        for p in self.procs:
+            p.join(timeout=max(0.0, deadline - time.time()))
+        for p in self.procs:
+            if p.is_alive():
+                p.terminate()
+        time.sleep(0.5)
+        for p in self.procs:
+            if p.is_alive():
+                try:
+                    p.kill()
+                except Exception:
+                    pass
+
+
+# --------------------------------------------------------------------------- #
+# FastAPI app
+# --------------------------------------------------------------------------- #
+from fastapi import FastAPI, HTTPException  # noqa: E402
+from pydantic import BaseModel, Field  # noqa: E402
+
+try:
+    from fastapi.responses import ORJSONResponse as _JSONResponse  # uses orjson
+
+    _DEFAULT_RESPONSE_CLASS = _JSONResponse
+except Exception:  # pragma: no cover - orjson optional
+    from fastapi.responses import JSONResponse as _DEFAULT_RESPONSE_CLASS
+
+
+class EmbeddingRequest(BaseModel):
+    input: Union[str, List[str]]
+    model: str = MODEL_ID
+    encoding_format: str = Field("float", description='"float" or "base64"')
+
+
+# Module-level config, set by ``main`` before uvicorn imports the app.
+_CONFIG = SimpleNamespace(dp=32, cores_per_worker=0, server_phys=4, server_tokenize=False)
+_POOL: Optional[AsyncEmbeddingPool] = None
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    global _POOL
+    loop = asyncio.get_running_loop()
+    # Build the (blocking) pool off the event loop so startup stays responsive.
+    _POOL = await loop.run_in_executor(
+        None,
+        lambda: AsyncEmbeddingPool(
+            dp=_CONFIG.dp,
+            normalize=True,
+            cores_per_worker=_CONFIG.cores_per_worker,
+            server_phys=_CONFIG.server_phys,
+            server_tokenize=_CONFIG.server_tokenize,
+        ),
+    )
+    _POOL.start(loop)
+    try:
+        yield
+    finally:
+        if _POOL is not None:
+            _POOL.close()
+            _POOL = None
+
+
+app = FastAPI(title="pplx-embed-v1-0.6b server", default_response_class=_DEFAULT_RESPONSE_CLASS, lifespan=lifespan)
+
+
+def _encode_vector(emb: np.ndarray, fmt: str):
+    if fmt == "base64":
+        return base64.b64encode(np.ascontiguousarray(emb, dtype="<f4").tobytes()).decode("ascii")
+    return np.asarray(emb, dtype=np.float32).tolist()
+
+
+@app.post("/v1/embeddings")
+async def create_embeddings(req: EmbeddingRequest):
+    if _POOL is None:
+        raise HTTPException(status_code=503, detail="pool not ready")
+    fmt = req.encoding_format
+    if fmt not in ("float", "base64"):
+        raise HTTPException(status_code=400, detail='encoding_format must be "float" or "base64"')
+    texts = [req.input] if isinstance(req.input, str) else list(req.input)
+    if not texts:
+        raise HTTPException(status_code=400, detail="input must not be empty")
+
+    try:
+        results = await _POOL.embed_batch(texts)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    data = []
+    total_tokens = 0
+    for i, (emb, n, _steps) in enumerate(results):
+        total_tokens += int(n)
+        data.append({"object": "embedding", "index": i, "embedding": _encode_vector(emb, fmt)})
+    return {
+        "object": "list",
+        "data": data,
+        "model": req.model or MODEL_ID,
+        "usage": {"prompt_tokens": total_tokens, "total_tokens": total_tokens},
+    }
+
+
+@app.get("/health")
+async def health():
+    ready = len(_POOL.ready) if _POOL is not None else 0
+    total = _CONFIG.dp
+    return {"status": "ok" if ready else "starting", "chips_ready": ready, "chips_total": total}
+
+
+@app.get("/v1/models")
+async def list_models():
+    return {
+        "object": "list",
+        "data": [{"id": MODEL_ID, "object": "model", "owned_by": "tenstorrent"}],
+    }
+
+
+@app.get("/metrics")
+async def metrics(reset: bool = False):
+    """Per-request latency breakdown (ms): on-device replay vs. server overhead.
+
+    ``device`` is the per-chip prefill+norm+pool replay; ``worker_total`` adds
+    H2D/D2H/host-finalize inside the worker; ``server_wall`` is dispatch->result
+    measured on the event loop; ``overhead`` = server_wall - worker_total
+    (mp.Queue transit + scheduling). Under full load ``device`` should stay flat.
+    """
+    if _POOL is None:
+        raise HTTPException(status_code=503, detail="pool not ready")
+    return _POOL.stats(reset=reset)
+
+
+# --------------------------------------------------------------------------- #
+# Launch
+# --------------------------------------------------------------------------- #
+def _pin_server_cores(server_phys: int) -> None:
+    """Reserve the top ``server_phys`` physical cores (both SMT siblings) for the
+    server's event loop / collector / HTTP threads.
+
+    ``server_phys <= 0`` leaves the server unpinned (workers OS-float across all
+    cores) — lowest tail latency for the worker-bound default.
+    """
+    if not server_phys or server_phys <= 0:
+        logger.info("Server unpinned (OS-scheduled).")
+        return
+    try:
+        total = os.cpu_count() or 64
+        n_phys = max(1, total // 2)
+        cores = _smt_cores(range(n_phys - server_phys, n_phys), n_phys)
+        os.sched_setaffinity(0, cores)
+        logger.info(
+            f"Server pinned to {server_phys} physical core(s): logical {sorted(cores)} "
+            f"(workers use physical 0-{n_phys - server_phys - 1})."
+        )
+    except (OSError, AttributeError):
+        pass
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="OpenAI-compatible embedding server (DP=N) for pplx-embed-v1-0.6b.")
+    parser.add_argument("--dp", type=int, default=32, help="Number of chips / workers (default 32).")
+    parser.add_argument("--host", default="0.0.0.0", help="Bind host (default 0.0.0.0).")
+    parser.add_argument("--port", type=int, default=8000, help="Bind port (default 8000).")
+    parser.add_argument(
+        "--cores-per-worker",
+        type=int,
+        default=0,
+        help="Physical cores dedicated per worker (SMT-aware; both hyperthreads). "
+        "0 (default) = OS-scheduled across the worker pool (recommended).",
+    )
+    parser.add_argument(
+        "--server-phys",
+        type=int,
+        default=4,
+        help="Physical cores (top of the range) reserved for the server's event "
+        "loop / result collector / HTTP threads; workers OS-float on the rest. "
+        "Default 4 — isolating the single server process from the 32 workers is "
+        "the biggest scaling win (~+45%% throughput at high concurrency). 0 = off.",
+    )
+    tok_group = parser.add_mutually_exclusive_group()
+    tok_group.add_argument(
+        "--server-tokenize",
+        dest="server_tokenize",
+        action="store_true",
+        default=None,
+        help="Tokenize on the server's dedicated cores (one process) and ship token "
+        "ids to workers. This is the only safe home for --fastokens (its internal "
+        "thread pool oversubscribes if replicated across 32 workers). Default: ON "
+        "when --fastokens is set, else OFF (worker-side).",
+    )
+    tok_group.add_argument(
+        "--worker-tokenize",
+        dest="server_tokenize",
+        action="store_false",
+        help="Tokenize inside each device worker (the original path).",
+    )
+    parser.add_argument(
+        "--fastokens",
+        action="store_true",
+        help="EXPERIMENTAL, NOT recommended for DP=32. Patch HF AutoTokenizer with the "
+        "crusoe/atero 'fastokens' Rust engine. It is faster in isolation but measured to "
+        "REGRESS server throughput here (server-side loads the single-process bottleneck; "
+        "per-worker oversubscribes the host). The default worker-side HF path is best. "
+        "Implies --server-tokenize unless --worker-tokenize is given.",
+    )
+    args = parser.parse_args()
+
+    # Default: server-side tokenization iff fastokens (keeps fastokens single-process;
+    # plain HF on the small server pool can worsen the tail under heavy concurrency).
+    if args.server_tokenize is None:
+        args.server_tokenize = args.fastokens
+
+    if args.fastokens and not args.server_tokenize:
+        logger.warning(
+            "--fastokens with --worker-tokenize: fastokens' internal thread pool runs "
+            "in all 32 workers and oversubscribes the host (large tail under load). "
+            "Prefer --server-tokenize (the default with --fastokens)."
+        )
+    if args.fastokens:
+        os.environ["PPLX_FASTOKENS"] = "1"  # propagated to spawned workers
+    os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+
+    total = os.cpu_count() or 64
+    n_phys = max(1, total // 2)
+    server_phys = max(0, min(args.server_phys, n_phys - 1))
+
+    _CONFIG.dp = args.dp
+    _CONFIG.cores_per_worker = args.cores_per_worker
+    _CONFIG.server_phys = server_phys
+    _CONFIG.server_tokenize = args.server_tokenize
+    _pin_server_cores(server_phys)
+
+    import uvicorn
+
+    uvicorn.run(
+        app,
+        host=args.host,
+        port=args.port,
+        loop="uvloop",
+        http="httptools",
+        workers=1,
+        log_level="info",
+        # Per-request access logging runs on the single event-loop thread for every
+        # request; disabling it removes that fixed cost from the HTTP critical path.
+        access_log=False,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds a lightweight async **FastAPI + uvicorn** serving layer (`demo/serve.py`) on top of the 32 resident chip workers, exposing an **OpenAI-compatible** `/v1/embeddings` API, plus a dependency-light async client / load test (`demo/embed_client.py`).
- Extends `demo/live_demo.py` with the worker plumbing the server reuses (server/worker tokenization split, SMT-aware core allocation, richer per-hop timing). Existing `live_demo.py --dp 32` REPL + DP behavior is preserved.
- Documents serving in the README with **customer-facing essentials only** (install, run, API + client, headline load numbers, operating point) — internal tuning deep-dives intentionally omitted.

## What this merges
Server addons on top of the previously delivered live_demo + model inference (`ign/qwen3_0.6b_optimization`). The only existing-code change is in `live_demo.py` (worker result protocol 4-tuple -> 5-tuple); all consumers (`broadcast`, `map`, `serve.py`) updated, default `cores_per_worker=0` keeps the prior OS-float behavior.

## Best config by default
`python demo/serve.py --dp 32` runs the tuned setup: server isolated on 4 physical cores, workers OS-float, worker-side HF tokenization (fastokens off).

## Performance (DP=32, ISL 512, base64, idle 32-chip Galaxy)
| In-flight | req/s | tok/s | On-device replay p50/p99 (ms) | Client e2e p50/p99 (ms) |
| --: | --: | --: | :--: | :--: |
| 1 | 86 | 43.9k | 7.42 / 7.55 | 11.7 / 12.6 |
| 8 | 690 | 353k | 7.41 / 7.45 | 11.2 / 14.4 |
| 32 | 2,461 | 1.26M | 7.38 / 7.42 | 11.5 / 43.9 |
| 64 | 2,840 | 1.45M | 7.37 / 7.41 | 20.4 / 54.0 |

Per-chip on-device replay stays flat at ~7.4 ms from 1->64 in-flight. Low-latency operating point ~32 in-flight (e2e p50 ~11.5 ms); throughput peaks ~2,840 req/s at 64.

## Test plan
- [x] `serve.py`, `live_demo.py`, `embed_client.py` compile
- [x] DP=32 server builds 32/32 chips and serves `/v1/embeddings` + `/health` + `/metrics`
- [x] Load sweep (c=1/8/32/64) re-measured on idle hardware
- [ ] Reviewer: confirm OpenAI-compatible response schema against target client stack

Made with [Cursor](https://cursor.com)