### PR TITLE
[tt_dit] Fix multi-host weight cache load broken by non-local pin TT_FATAL

### DIFF
--- a/models/tt_dit/layers/module.py
+++ b/models/tt_dit/layers/module.py
@@ -394,7 +394,11 @@ class Parameter:
         )
 
     def save(self, path: str | Path, /) -> None:
-        ttnn.dump_tensor(path, self.data)
+        # Dump only this rank's locally-owned shards. In a multi-host run a fully-gathered file
+        # would force `to_device` to pin chips owned by other hosts on load, which TT_FATALs since
+        # baca09000d3. With LOCAL every shard in the file is local to the rank that reads it back.
+        # On a single host this is equivalent to the previous (gathered) dump.
+        ttnn.dump_tensor(path, self.data, mode=ttnn.DumpTensorMode.LOCAL)
 
     def load(self, path: str | Path, /) -> None:
         try:

--- a/models/tt_dit/layers/module.py
+++ b/models/tt_dit/layers/module.py
@@ -394,10 +394,6 @@ class Parameter:
         )
 
     def save(self, path: str | Path, /) -> None:
-        # Dump only this rank's locally-owned shards. In a multi-host run a fully-gathered file
-        # would force `to_device` to pin chips owned by other hosts on load, which TT_FATALs since
-        # baca09000d3. With LOCAL every shard in the file is local to the rank that reads it back.
-        # On a single host this is equivalent to the previous (gathered) dump.
         ttnn.dump_tensor(path, self.data, mode=ttnn.DumpTensorMode.LOCAL)
 
     def load(self, path: str | Path, /) -> None:

--- a/models/tt_dit/utils/cache.py
+++ b/models/tt_dit/utils/cache.py
@@ -145,7 +145,29 @@ def model_cache_dir(
     if is_fsdp:
         key += "_FSDP"
 
-    return Path(cache_dir) / model_name / subfolder / key
+    path = Path(cache_dir) / model_name / subfolder / key
+
+    # On a multi-host run each rank dumps only its locally-owned shards (DumpTensorMode.LOCAL) and
+    # must therefore read/write its own cache directory; a shared, fully-gathered file would make
+    # `to_device` try to pin chips owned by other hosts, which TT_FATALs. Single-process runs keep
+    # the original (un-suffixed) layout so existing caches remain valid.
+    world_size = _distributed_world_size()
+    if world_size > 1:
+        path = path / f"rank_{int(ttnn.distributed_context_world_rank())}"
+
+    return path
+
+
+def _distributed_world_size() -> int:
+    """Distributed world size, or 1 when no distributed context is active.
+
+    `distributed_context_world_size()` raises if the context has not been initialized, so the
+    `is_initialized()` check must come first. A plain single-process run has no context and is
+    treated as world size 1.
+    """
+    if not ttnn.distributed_context_is_initialized():
+        return 1
+    return int(ttnn.distributed_context_world_size())
 
 
 def _cache_root() -> str | None:

--- a/models/tt_dit/utils/cache.py
+++ b/models/tt_dit/utils/cache.py
@@ -120,9 +120,6 @@ def load_model(
     if create_cache:
         logger.info(f"Writing cache to '{cache_dir}'.")
         tt_model.save(cache_dir)
-        # Commit marker written last: a directory without it (e.g. an interrupted save) is treated
-        # as a miss and regenerated rather than half-loaded. Mirrors the deepseek CAS cache, which
-        # only counts an entry as present when its committed data file exists.
         _mark_cache_complete(cache_dir)
 
 
@@ -152,40 +149,21 @@ def model_cache_dir(
 
     path = Path(cache_dir) / model_name / subfolder / key
 
-    # On a multi-host run each rank dumps only its locally-owned shards (DumpTensorMode.LOCAL) and
-    # must therefore read/write its own cache directory; a shared, fully-gathered file would make
-    # `to_device` try to pin chips owned by other hosts, which TT_FATALs. Single-process runs keep
-    # the original (un-suffixed) layout so existing caches remain valid.
-    world_size = _distributed_world_size()
-    if world_size > 1:
+    if _distributed_world_size() > 1:
         path = path / f"rank_{int(ttnn.distributed_context_world_rank())}"
 
     return path
 
 
 def _cache_is_complete(cache_dir: str | Path) -> bool:
-    """Whether `cache_dir` holds a fully-written cache.
-
-    Following the deepseek content-addressed cache, presence is decided by the committed-data
-    marker rather than mere directory existence: `Module.save` creates the directory up front, so a
-    crashed/interrupted save leaves a directory that exists but is incomplete. Requiring the marker
-    means such a directory is treated as a miss (and regenerated) instead of partially loaded.
-    """
     return (Path(cache_dir) / CACHE_DICT_FILE).is_file()
 
 
 def _mark_cache_complete(cache_dir: str | Path) -> None:
-    """Write the commit marker as the final step of a successful save."""
     (Path(cache_dir) / CACHE_DICT_FILE).write_text(json.dumps({"complete": True}))
 
 
 def _distributed_world_size() -> int:
-    """Distributed world size, or 1 when no distributed context is active.
-
-    `distributed_context_world_size()` raises if the context has not been initialized, so the
-    `is_initialized()` check must come first. A plain single-process run has no context and is
-    treated as world size 1.
-    """
     if not ttnn.distributed_context_is_initialized():
         return 1
     return int(ttnn.distributed_context_world_size())

--- a/models/tt_dit/utils/cache.py
+++ b/models/tt_dit/utils/cache.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
@@ -100,7 +101,7 @@ def load_model(
         ttnn.distributed_context_barrier()
         return
 
-    if Path(cache_dir).is_dir():
+    if _cache_is_complete(cache_dir):
         logger.info(f"loading cache at '{cache_dir}'.")
         tt_model.load(cache_dir)
         ttnn.distributed_context_barrier()
@@ -119,6 +120,10 @@ def load_model(
     if create_cache:
         logger.info(f"Writing cache to '{cache_dir}'.")
         tt_model.save(cache_dir)
+        # Commit marker written last: a directory without it (e.g. an interrupted save) is treated
+        # as a miss and regenerated rather than half-loaded. Mirrors the deepseek CAS cache, which
+        # only counts an entry as present when its committed data file exists.
+        _mark_cache_complete(cache_dir)
 
 
 def model_cache_dir(
@@ -156,6 +161,22 @@ def model_cache_dir(
         path = path / f"rank_{int(ttnn.distributed_context_world_rank())}"
 
     return path
+
+
+def _cache_is_complete(cache_dir: str | Path) -> bool:
+    """Whether `cache_dir` holds a fully-written cache.
+
+    Following the deepseek content-addressed cache, presence is decided by the committed-data
+    marker rather than mere directory existence: `Module.save` creates the directory up front, so a
+    crashed/interrupted save leaves a directory that exists but is incomplete. Requiring the marker
+    means such a directory is treated as a miss (and regenerated) instead of partially loaded.
+    """
+    return (Path(cache_dir) / CACHE_DICT_FILE).is_file()
+
+
+def _mark_cache_complete(cache_dir: str | Path) -> None:
+    """Write the commit marker as the final step of a successful save."""
+    (Path(cache_dir) / CACHE_DICT_FILE).write_text(json.dumps({"complete": True}))
 
 
 def _distributed_world_size() -> int:

--- a/models/tt_dit/utils/cache.py
+++ b/models/tt_dit/utils/cache.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import json
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
@@ -160,7 +159,7 @@ def _cache_is_complete(cache_dir: str | Path) -> bool:
 
 
 def _mark_cache_complete(cache_dir: str | Path) -> None:
-    (Path(cache_dir) / CACHE_DICT_FILE).write_text(json.dumps({"complete": True}))
+    (Path(cache_dir) / CACHE_DICT_FILE).touch()
 
 
 def _distributed_world_size() -> int:


### PR DESCRIPTION
## Summary
- `baca09000d3` (#46138) changed the silent skip of non-local chips in tensor write APIs into a `TT_FATAL`. This broke the tt_dit weight cache on **multi-host** runs: every rank loaded the same fully-gathered file and `to_device(full_mesh_device)` tried to pin chips owned by other hosts, hitting the new fatal in `try_pin → compute_device_ids → get_device(remote_coord)`.
- **Fix (Python-only, no C++), following the deepseek_v3_b1 CAS cache pattern:**
  - `module.py` — `Parameter.save` dumps with `mode=ttnn.DumpTensorMode.LOCAL`, so each rank writes only its locally-owned shards. On load every shard coordinate is local, `is_local()` is always true, and the fatal never fires.
  - `cache.py` — `model_cache_dir` appends `rank_{N}/` so each rank reads/writes its own directory instead of a shared gathered file.
  - `cache.py` — cache hits are gated on a committed-data marker (`cache_dict.json`) written as the **last** step of a successful save, instead of trusting `Path(cache_dir).is_dir()`. `Module.save` creates the directory up front, so an interrupted save previously looked like a hit and was partially loaded; now such a directory is a miss and is regenerated. (Mirrors deepseek's `Present`/`Corrupt` classification, which only counts an entry as present when its committed data file exists.)

## Why LOCAL (not DISTRIBUTED_GATHER)
`load_tensor_flatbuffer` unconditionally does `to_device(full_mesh)` and there is no Python knob to place only local shards — the only thing that made the single-file path work was the silent remote-skip #46138 deliberately removed. A LOCAL-dumped file contains only local shards, each tagged with its mesh coordinate (`tensor_flatbuffer.cpp` serializes/restores per-shard `mesh_coordinate`), so `load_tensor(path, device=full_mesh)` places only local coords. This is already the production pattern in `models/demos/deepseek_v3_b1/weights/cache/cache.py` (LOCAL dump → plain `load_tensor(device=...)`), so no new C++ load mode is required.

## Non-multihost safety / backward compat
- `distributed_context_world_size()` / `world_rank()` **throw** if no distributed context is initialized, so the per-rank suffix is gated behind `distributed_context_is_initialized()` (which does not throw). No distributed context → world size treated as 1 → **no rank suffix → path identical to before**, and the direct `model_cache_dir` callers in `test_transformer_sd35.py` / `test_transformer_mochi.py` don't throw.
- Single host: `LOCAL` dump writes the whole (only) shard, equivalent to the previous gathered dump.
- All `load_model` callers pass a `get_torch_state_dict` fallback, so a pre-existing cache written before this change (no marker) is regenerated **once** with the marker rather than failing — backward compatible. (The cache-only `MissingCacheError` path, `get_torch_state_dict=None`, has no in-tree callers.)

## Test plan
- [ ] Multi-host run that previously hit the `try_pin` `TT_FATAL`: confirm per-rank cache is written and reloads cleanly on a second run.
- [ ] Single-host T3000 tt_dit model (e.g. SD3.5 transformer): confirm cache write/read works; an existing single-host cache regenerates once then hits.
- [ ] Interrupt a save mid-write, rerun: confirm the incomplete directory is treated as a miss and regenerated (no partial load).
- [ ] `test_transformer_sd35.py` / `test_transformer_mochi.py` (direct `model_cache_dir` callers) pass without a distributed context.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kevinmi/fix-multihost-cache-local-dump)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kevinmi/fix-multihost-cache-local-dump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kevinmi/fix-multihost-cache-local-dump)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kevinmi/fix-multihost-cache-local-dump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kevinmi/fix-multihost-cache-local-dump)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kevinmi/fix-multihost-cache-local-dump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kevinmi/fix-multihost-cache-local-dump)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kevinmi/fix-multihost-cache-local-dump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kevinmi/fix-multihost-cache-local-dump)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kevinmi/fix-multihost-cache-local-dump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kevinmi/fix-multihost-cache-local-dump)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kevinmi/fix-multihost-cache-local-dump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kevinmi/fix-multihost-cache-local-dump)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kevinmi/fix-multihost-cache-local-dump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kevinmi/fix-multihost-cache-local-dump)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kevinmi/fix-multihost-cache-local-dump)