### PR TITLE
vsureshTT [Argmax] Fix reduce_core_id truncated by (bool) cast (#48235)

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
@@ -210,6 +210,59 @@ def test_argmax_nc_ties_first_index_wins(device):
         assert_equal(ref, ttnn.to_torch(ttnn.from_device(out)).to(torch.int32))
 
 
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32, torch.int32])
+@pytest.mark.parametrize("keepdim", [True, False])
+def test_argmax_multicore_reducer_collation(device, dtype, keepdim):
+    """Guard the multicore reducer-collation path (the logic governed by `reduce_core_id`).
+
+    A wide last dim on ROW_MAJOR with dim==-1 takes the multicore path and splits the
+    reduction dim across many worker cores; one designated reduce core then collates the
+    per-core partial (value, index) results into the global argmax. We deliberately place
+    each row's maximum at a *different* column so the winning element lands on different
+    worker cores across rows -- this forces the reduce core to pick winners that were
+    produced remotely (not just its own slice), which is precisely the path that breaks
+    if the reducer-core identity is mishandled (see issue #48235).
+    """
+    torch.manual_seed(0)
+    rows, red_dim = 16, 2048  # red_dim large enough to span well beyond 2 worker cores
+    # Spread the per-row max across the reduction dim so different cores own the winner.
+    cols = [(r * 257) % red_dim for r in range(rows)]
+
+    if dtype == torch.int32:
+        torch_tensor = torch.randint(0, 100, (rows, red_dim), dtype=dtype)
+        for r, c in enumerate(cols):
+            torch_tensor[r, c] = 1000  # unique, unambiguous max
+    else:
+        torch_tensor = torch.full((rows, red_dim), -1.0, dtype=dtype)
+        for r, c in enumerate(cols):
+            torch_tensor[r, c] = 2.0  # exactly representable in bf16/fp32, unique max
+
+    ref = torch.argmax(torch_tensor, dim=-1, keepdim=keepdim)
+
+    ttnn_tensor = ttnn.from_torch(torch_tensor, device=device, layout=ttnn.ROW_MAJOR_LAYOUT)
+    out = ttnn.argmax(ttnn_tensor, dim=-1, keepdim=keepdim)
+    assert_equal(ref, ttnn.to_torch(ttnn.from_device(out)).to(torch.int32))
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+def test_argmax_multicore_reduce_all_collation(device, dtype):
+    """reduce_all (dim=None) variant of the multicore reducer-collation path.
+
+    The global argmax is placed deep in the tensor so its owning worker core is not the
+    reduce core, exercising the same cross-core collation guarded by `reduce_core_id`.
+    """
+    torch.manual_seed(0)
+    n = 4096  # spans many worker cores on the multicore path
+    torch_tensor = torch.full((n,), -1.0, dtype=dtype)
+    torch_tensor[n - 7] = 5.0  # unique global max, owned by a high-index worker core
+
+    ref = torch.argmax(torch_tensor)
+
+    ttnn_tensor = ttnn.from_torch(torch_tensor, device=device, layout=ttnn.ROW_MAJOR_LAYOUT)
+    out = ttnn.argmax(ttnn_tensor)
+    assert_equal(ref, ttnn.to_torch(ttnn.from_device(out)).to(torch.int32))
+
+
 def test_argmax_nc_preallocated_output(device):
     torch.manual_seed(0)
     t = torch.randn(2, 3, 64, 64, dtype=torch.float32)

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
@@ -270,7 +270,7 @@ void kernel_main() {
     constexpr uint32_t num_cores = get_compile_time_arg_val(12);
 
     // Pick the core that will collate the intermediate outputs
-    constexpr uint32_t reduce_core_id = (bool)get_compile_time_arg_val(13);
+    constexpr uint32_t reduce_core_id = get_compile_time_arg_val(13);
 
     constexpr uint32_t reduce_core_x = get_compile_time_arg_val(14);
     constexpr uint32_t reduce_core_y = get_compile_time_arg_val(15);


### PR DESCRIPTION
### Ticket
Fixes #48235

### Problem
The multicore argmax reader kernel cast the reducer core index to `bool`:

```cpp
constexpr uint32_t reduce_core_id = (bool)get_compile_time_arg_val(13);  // reader_argmax_interleaved_multicore.cpp:273
```

`reduce_core_id` is a **worker core index** — it's compared against `core_id` and gates the cross-core collation of partial results — not a flag. The `(bool)` cast clamps it to `{0,1}`.

The host passes the true index in compile slot 13 (`argmax_multi_core_program_factory.cpp:356`) and the reducer's **physical** coordinates in slots 14/15 (which are *not* cast). So whenever `reduce_core_id >= 2`:
- the kernel believes the reducer is logical core `1` (`(bool)2 == 1`), but
- every core's `done_sem.up(...)` and remote partial-result writes target the physical coords of logical core `2`.

The believed reducer then does `done_sem.wait(num_cores)` on its **own** semaphore, which nobody increments → **device deadlock**.

Today `reduce_core_id` is hardcoded to `0` host-side (with a TODO: *"We can do perf optimization by tuning this in the future"*), so `(bool)0 == 0` masks the defect. It would surface the moment that constant is tuned.

### Fix
Drop the cast so the true core index flows through:

```cpp
constexpr uint32_t reduce_core_id = get_compile_time_arg_val(13);
```

### Tests
Adds two regression tests to `tests/ttnn/unit_tests/operations/reduce/test_argmax.py` that drive the multicore reducer-collation path across many worker cores, with the winning element placed on cores other than the reducer:
- `test_argmax_multicore_reducer_collation` (dim=-1; bf16/fp32/int32 × keepdim)
- `test_argmax_multicore_reduce_all_collation` (reduce_all / dim=None)

> Note: because `reduce_core_id` is still a hardcoded `0` not exposed to Python, these tests guard correctness of the collation path at the shipping config; they cannot themselves trip this specific bug in CI without the constant being made tunable. See verification below for the end-to-end proof.

### Verification (n150, Wormhole)
Same `[16, 2048]` multicore input, toggling only the kernel cast, with `reduce_core_id` temporarily set to `2`:

| Kernel | `reduce_core_id` | Result |
|---|---|---|
| Buggy (`(bool)` cast) | 2 | **Hang** — deadlock (killed at 120s; fixed build clears all cases in <5s) |
| Fixed (no cast) | 2 | **6/6 pass** (4.8s) |
| Fixed (no cast) | 0 (shipping) | **8/8 pass** (~1s) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/argmax-reduce-core-id-bool-cast-48235)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/argmax-reduce-core-id-bool-cast-48235)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/argmax-reduce-core-id-bool-cast-48235)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/argmax-reduce-core-id-bool-cast-48235)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/argmax-reduce-core-id-bool-cast-48235)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/argmax-reduce-core-id-bool-cast-48235)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/argmax-reduce-core-id-bool-cast-48235)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/argmax-reduce-core-id-bool-cast-48235)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/argmax-reduce-core-id-bool-cast-48235)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/argmax-reduce-core-id-bool-cast-48235)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/argmax-reduce-core-id-bool-cast-48235)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/argmax-reduce-core-id-bool-cast-48235)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/argmax-reduce-core-id-bool-cast-48235)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/argmax-reduce-core-id-bool-cast-48235)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/argmax-reduce-core-id-bool-cast-48235)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/argmax-reduce-core-id-bool-cast-48235)