### PR TITLE
[LLK] Informational cleanups: docstrings, comments, dead code, asserts

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cpack_common.h
@@ -685,12 +685,11 @@ inline void select_packer_dest_registers()
 inline void program_packer_destination(std::uint32_t addr)
 {
     LLK_ASSERT(is_valid_L1_address(addr), "L1 address must be in valid L1 memory region");
-    /*
-       The GPR OUTPUT_ADDR is only used by the packer mop when writing tile headers.
-       Since we do not write tile headers in tt-metal, we do not need to wait for
-       packer to finish or say put a stallwait at this point.
-       We just need to make sure we wait before issuing the WRCFG.
-    */
+    // No packer-drain STALLWAIT is needed before reprogramming the destination: the pack thread issues its
+    // instruction stream in order, so each tile's PACR has already started -- and latched L1_Dest_addr,
+    // sampled at PACR start -- before the next call's WRCFG reprograms it, and the Last=1 PACR that ends each
+    // pack MOP drains the packer and forces the next pack to re-sample L1_Dest_addr. The STALLWAIT below is
+    // only the GPR-producer fence: it ensures the SETDMAREG write to OUTPUT_ADDR retires before WRCFG reads it.
     std::uint32_t new_l1_addr = (1 << 31) | addr;
     TT_SETDMAREG(0, LOWER_HALFWORD(addr), 0, LO_16(p_gpr_pack::OUTPUT_ADDR));
     TT_SETDMAREG(0, UPPER_HALFWORD(new_l1_addr), 0, HI_16(p_gpr_pack::OUTPUT_ADDR));

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_ternary_sfpu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_ternary_sfpu.h
@@ -26,7 +26,7 @@ inline void eltwise_ternary_sfpu_configure_addrmod()
     }
         .set(ADDR_MOD_7);
 
-    if (sfpu_op == SfpuType::where)
+    if constexpr (sfpu_op == SfpuType::where)
     {
         addr_mod_t {
             .srca = {.incr = 0},

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_matmul.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_matmul.h
@@ -159,16 +159,18 @@ inline void matmul_configure_addrmod(
             if (transpose)
             {
                 addr_mod_t {
-                    .srca = {.incr = 32, .clr = 0, .cr = 0}, .srcb = {.incr = 0, .clr = 0, .cr = 0}, .dest = {.incr = 16, .clr = 0, .cr = 0},
-                    // .bias = {.incr = 1},
+                    .srca = {.incr = 32, .clr = 0, .cr = 0},
+                    .srcb = {.incr = 0, .clr = 0, .cr = 0},
+                    .dest = {.incr = 16, .clr = 0, .cr = 0},
                 }
                     .set(ADDR_MOD_2);
             }
             else
             {
                 addr_mod_t {
-                    .srca = {.incr = 16, .clr = 0, .cr = 0}, .srcb = {.incr = 0, .clr = 0, .cr = 0}, .dest = {.incr = 16, .clr = 0, .cr = 0},
-                    // .bias = {.incr = 1},
+                    .srca = {.incr = 16, .clr = 0, .cr = 0},
+                    .srcb = {.incr = 0, .clr = 0, .cr = 0},
+                    .dest = {.incr = 16, .clr = 0, .cr = 0},
                 }
                     .set(ADDR_MOD_2);
             }
@@ -215,15 +217,15 @@ inline void matmul_configure_addrmod(
                     .srca = {.incr = 16, .clr = 0, .cr = 1}, // srca=16
                     .srcb = {.incr = 16, .clr = 0, .cr = 0},
                     .dest = {.incr = 0, .clr = 1, .cr = 0},
-                    // .bias = {.incr = 1},
                 }
                     .set(ADDR_MOD_4);
             }
             else
             {
                 addr_mod_t {
-                    .srca = {.incr = 16, .clr = 0, .cr = 0}, .srcb = {.incr = 16, .clr = 0, .cr = 0}, .dest = {.incr = 0, .clr = 1, .cr = 0},
-                    // .bias = {.incr = 1},
+                    .srca = {.incr = 16, .clr = 0, .cr = 0},
+                    .srcb = {.incr = 16, .clr = 0, .cr = 0},
+                    .dest = {.incr = 0, .clr = 1, .cr = 0},
                 }
                     .set(ADDR_MOD_4);
             }
@@ -236,15 +238,15 @@ inline void matmul_configure_addrmod(
                     .srca = {.incr = 16, .clr = 0, .cr = 1}, // srca=16
                     .srcb = {.incr = 16, .clr = 0, .cr = 1},
                     .dest = {.incr = 0, .clr = 0, .cr = 1},
-                    // .bias = {.incr = 1},
                 }
                     .set(ADDR_MOD_4);
             }
             else
             {
                 addr_mod_t {
-                    .srca = {.incr = 16, .clr = 0, .cr = 0}, .srcb = {.incr = 16, .clr = 0, .cr = 1}, .dest = {.incr = 0, .clr = 0, .cr = 1},
-                    // .bias = {.incr = 1},
+                    .srca = {.incr = 16, .clr = 0, .cr = 0},
+                    .srcb = {.incr = 16, .clr = 0, .cr = 1},
+                    .dest = {.incr = 0, .clr = 0, .cr = 1},
                 }
                     .set(ADDR_MOD_4);
             }
@@ -253,16 +255,18 @@ inline void matmul_configure_addrmod(
     else if (is_in0_32x16)
     {
         addr_mod_t {
-            .srca = {.incr = 0, .clr = 0, .cr = 1}, .srcb = {.incr = 16, .clr = 0, .cr = 1}, .dest = {.incr = 8, .clr = 0, .cr = 0},
-            // .bias = {.incr = 1},
+            .srca = {.incr = 0, .clr = 0, .cr = 1},
+            .srcb = {.incr = 16, .clr = 0, .cr = 1},
+            .dest = {.incr = 8, .clr = 0, .cr = 0},
         }
             .set(ADDR_MOD_4);
     }
     else if (is_in1_32x16)
     {
         addr_mod_t {
-            .srca = {.incr = 0, .clr = 0, .cr = 1}, .srcb = {.incr = 8, .clr = 0, .cr = 0}, .dest = {.incr = 16, .clr = 0, .cr = 1},
-            // .bias = {.incr = 1},
+            .srca = {.incr = 0, .clr = 0, .cr = 1},
+            .srcb = {.incr = 8, .clr = 0, .cr = 0},
+            .dest = {.incr = 16, .clr = 0, .cr = 1},
         }
             .set(ADDR_MOD_4);
     }
@@ -274,7 +278,6 @@ inline void matmul_configure_addrmod(
                 .srca = {.incr = 16, .clr = 0, .cr = 1},
                 .srcb = {.incr = 48, .clr = 0, .cr = 1}, // cr=32 before, cr+48=16 after wrapping
                 .dest = {.incr = 0, .clr = 0, .cr = 1},
-                // .bias = {.incr = 1},
             }
                 .set(ADDR_MOD_4);
         }
@@ -285,7 +288,6 @@ inline void matmul_configure_addrmod(
                 //.srca = {.incr = srca_set, .clr = 0, .cr = 1},
                 .srcb = {.incr = 48, .clr = 0, .cr = 1}, // cr=32 before, cr+48=16 after wrapping
                 .dest = {.incr = 0, .clr = 0, .cr = 1},
-                // .bias = {.incr = 1},
             }
                 .set(ADDR_MOD_4);
         }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_A.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_A.h
@@ -314,14 +314,13 @@ inline void _llk_unpack_A_init_(
 }
 
 /**
- * @brief Restore unpacker datum-count state after single-operand (A) unpacking.
+ * @brief No-op teardown after single-operand (A) unpacking.
  *
- * Resets the X-dimension address counter for the unpacker used by this broadcast mode back to
- * a full face worth of datums.
+ * The unpacker x-start/x-end (datum-count) state is transient and reprogrammed by each operation's
+ * init (see tt-llk#1036), so there is nothing to restore here.
  *
  * @tparam BType: Broadcast type, values = <NONE/COL/ROW/SCALAR>
- * @param face_r_dim: Number of rows per face, used to compute the restored datum count.
- * @note Call @ref _llk_unpack_A_init_ with matching template args before this function.
+ * @note Call @ref _llk_unpack_A_init_ before this function.
  */
 template <BroadcastType BType = BroadcastType::NONE>
 inline void _llk_unpack_A_uninit_()

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
@@ -205,13 +205,11 @@ inline void _llk_unpack_AB_init_(const ckernel::TensorShape tensor_shape, const 
 }
 
 /**
- * @brief Uninitialize unpacker after AB unpacking operations
+ * @brief No-op teardown after AB (two-operand) unpacking.
  *
- * Resets the unpacker address counters for both SrcA and SrcB to their default
- * tile element counts based on the provided tensor shapes.
+ * The SrcA/SrcB unpacker x-start/x-end (datum-count) state is transient and reprogrammed by each
+ * operation's init (see tt-llk#1036), so there is nothing to restore here.
  *
- * @param unpA_tensor_shape: Tensor shape for source A operand
- * @param unpB_tensor_shape: Tensor shape for source B operand
  * @note Call @ref _llk_unpack_AB_init_ before this function.
  */
 inline void _llk_unpack_AB_uninit_()

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_untilize.h
@@ -116,7 +116,7 @@ inline void _llk_unpack_untilize_init_(const std::uint32_t unpack_dst_format, co
     // Configure unpacker registers
     // Get pointer to registers for current state ID
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK);
-    cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32, UNP0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT, UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK>(unpA_ch1_y_stride);
+    cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32, UNP0_ADDR_CTRL_XY_REG_1_Ystride_SHAMT, UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK>(unpA_ch1_y_stride);
     cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, 0xFFFF>(FACE_C_DIM);
 
     // Configure tile dimensions
@@ -163,7 +163,7 @@ inline void _llk_unpack_untilize_uninit_(const std::uint32_t unpack_dst_format, 
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
     TTI_WRCFG(p_gpr_unpack::FACE_DIM_16x16, p_cfg::WRCFG_32b, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32);
     cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, 0xFFFF>(1);
-    cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32, UNP0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT, UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK>(unpA_ch1_y_stride);
+    cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32, UNP0_ADDR_CTRL_XY_REG_1_Ystride_SHAMT, UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK>(unpA_ch1_y_stride);
 
     TTI_NOP;
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
@@ -351,8 +351,8 @@ inline void cache_exponential_section_sizes_in_gprs(const std::uint32_t num_face
 inline void set_packer_strides(const std::uint32_t pack_src_format)
 {
     std::uint32_t x_stride = datum_size_in_bytes(pack_src_format);
-    std::uint32_t y_stride = FACE_R_DIM * x_stride;
-    std::uint32_t z_stride = FACE_C_DIM * y_stride;
+    std::uint32_t y_stride = FACE_C_DIM * x_stride; // Y steps across a row of FACE_C_DIM datums (== FACE_R_DIM for square faces)
+    std::uint32_t z_stride = FACE_R_DIM * y_stride; // Z steps a full face of FACE_R_DIM rows (== FACE_C_DIM for square faces)
     std::uint32_t w_stride = TILE_NUM_FACES * z_stride;
 
     std::uint32_t xy_stride = (x_stride << PCK0_ADDR_CTRL_XY_REG_0_Xstride_SHAMT) | (y_stride << PCK0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT);
@@ -560,14 +560,18 @@ inline void reconfigure_exp_threshold(const std::uint32_t pack_dst_format)
         }
     }
 
+    static_assert(
+        THCON_SEC0_REG1_Exp_threshold_en_ADDR32 == THCON_SEC0_REG1_Exp_threshold_ADDR32,
+        "THCON_SEC0_REG1_Exp_threshold_en and Exp_threshold must share ADDR32 for combined RMW");
+
     constexpr std::uint32_t THRESHOLD_RMW_MASK = THCON_SEC0_REG1_Exp_threshold_en_MASK | THCON_SEC0_REG1_Exp_threshold_MASK;
 
     std::uint32_t threshold_rmw_data = (threshold << THCON_SEC0_REG1_Exp_threshold_SHAMT) | (enable << THCON_SEC0_REG1_Exp_threshold_en_SHAMT);
 
-    cfg_reg_rmw_tensix<THCON_SEC0_REG1_Row_start_section_size_ADDR32 + 3, 0, THRESHOLD_RMW_MASK>(threshold_rmw_data);
-    cfg_reg_rmw_tensix<THCON_SEC1_REG1_Row_start_section_size_ADDR32 + 3, 0, THRESHOLD_RMW_MASK>(threshold_rmw_data);
-    cfg_reg_rmw_tensix<THCON_SEC0_REG8_Row_start_section_size_ADDR32 + 3, 0, THRESHOLD_RMW_MASK>(threshold_rmw_data);
-    cfg_reg_rmw_tensix<THCON_SEC1_REG8_Row_start_section_size_ADDR32 + 3, 0, THRESHOLD_RMW_MASK>(threshold_rmw_data);
+    cfg_reg_rmw_tensix<THCON_SEC0_REG1_Exp_threshold_ADDR32, 0, THRESHOLD_RMW_MASK>(threshold_rmw_data);
+    cfg_reg_rmw_tensix<THCON_SEC1_REG1_Exp_threshold_ADDR32, 0, THRESHOLD_RMW_MASK>(threshold_rmw_data);
+    cfg_reg_rmw_tensix<THCON_SEC0_REG8_Exp_threshold_ADDR32, 0, THRESHOLD_RMW_MASK>(threshold_rmw_data);
+    cfg_reg_rmw_tensix<THCON_SEC1_REG8_Exp_threshold_ADDR32, 0, THRESHOLD_RMW_MASK>(threshold_rmw_data);
 }
 
 // Forward declaration: defined later in this file. Needed here so that the non-dependent call
@@ -809,7 +813,13 @@ inline void program_packer_destination(std::uint32_t addr, bool restore = true)
     TT_SETDMAREG(0, LOWER_HALFWORD(addr), 0, LO_16(p_gpr_pack::OUTPUT_ADDR));
     TT_SETDMAREG(0, UPPER_HALFWORD(new_l1_addr), 0, HI_16(p_gpr_pack::OUTPUT_ADDR));
 
-    // TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::PACK);
+    // No STALLWAIT is needed before this config write (unlike the BH counterpart):
+    // REG2FLOP executes on ThCon, in program order after the SETDMAREG GPR writes above, so it reads the
+    // freshly written OUTPUT_ADDR without a fence (BH uses WRCFG on the separate Config Unit, hence its
+    // STALL_CFG/THCON guard). No packer-drain (STALL_THCON/PACK) is needed either: the pack thread issues
+    // its instruction stream in order, so each tile's PACR has already started -- and latched L1_Dest_addr,
+    // which is sampled at PACR start -- before the next call's REG2FLOP reprograms it. The Flush PACR below
+    // drains the previous pack's output buffers and arms a fresh start address.
     TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC0_REG1_L1_Dest_addr_ADDR32 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::OUTPUT_ADDR);
 
     TTI_PACR(ADDR_MOD_2, 0, 0xf, 0, 0, 1, 0); // pack flush
@@ -827,6 +837,8 @@ inline void program_packer_untilized_destination(const std::uint32_t addr, const
 
     if constexpr (diagonal)
     {
+        // Diagonal untilize drives only packers 0 and 1; the offset2/offset3 + packer-2/3 (SEC1) lines below are
+        // intentionally disabled and kept as reference for a possible 4-packer extension.
         const std::uint32_t block_size  = SCALE_DATUM_SIZE(pack_dst_format, FACE_C_DIM);
         constexpr std::uint32_t offset0 = 0;
         const std::uint32_t offset1     = (1 * block_size) / 16;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_ternary_sfpu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_ternary_sfpu.h
@@ -27,7 +27,7 @@ inline void eltwise_ternary_sfpu_configure_addrmod()
     }
         .set(ADDR_MOD_7);
 
-    if (sfpu_op == SfpuType::where)
+    if constexpr (sfpu_op == SfpuType::where)
     {
         addr_mod_t {
             .srca = {.incr = 0},

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
@@ -433,6 +433,9 @@ inline void matmul_configure_mop(
         }
     }
 
+    // NOTE: addr_mods live in two banks of 4. A preceding MVMUL whose addr_mod has bias.incr=1 (the ADDR_MOD_3
+    // step above) sets the RWC ExtraAddrModBit, which adds +4 to the *next* instruction's 2-bit addr_mod index.
+    // So the ADDR_MOD_1 encoded below resolves to ADDR_MOD_5 -- reset srca/srcb/dest + increment fidelity phase.
     if constexpr (high_fidelity)
     {
         TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5)

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
@@ -424,14 +424,13 @@ inline void _llk_unpack_A_(const std::uint32_t address, const std::uint32_t unpa
 }
 
 /**
- * @brief Restore unpacker datum-count state after single-operand (A) unpacking.
+ * @brief No-op teardown after single-operand (A) unpacking.
  *
- * Resets the X-dimension address counter for the unpacker used by this broadcast mode back to
- * a full face worth of datums.
+ * The unpacker x-start/x-end (datum-count) state is transient and reprogrammed by each operation's
+ * init (see tt-llk#1036), so there is nothing to restore here.
  *
  * @tparam BType: Broadcast type, values = <NONE/COL/ROW/SCALAR>
- * @param face_r_dim: Number of rows per face, used to compute the restored datum count.
- * @note Call @ref _llk_unpack_A_init_ with matching template args before this function.
+ * @note Call @ref _llk_unpack_A_init_ before this function.
  */
 template <BroadcastType BType = BroadcastType::NONE>
 inline void _llk_unpack_A_uninit_()

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
@@ -194,13 +194,11 @@ inline void _llk_unpack_AB_init_(const ckernel::TensorShape tensor_shape, const 
 }
 
 /**
- * @brief Uninitialize unpacker after AB unpacking operations
+ * @brief No-op teardown after AB (two-operand) unpacking.
  *
- * Resets the unpacker address counters for both SrcA and SrcB to their default
- * tile element counts based on the provided tensor shapes.
+ * The SrcA/SrcB unpacker x-start/x-end (datum-count) state is transient and reprogrammed by each
+ * operation's init (see tt-llk#1036), so there is nothing to restore here.
  *
- * @param unpA_tensor_shape: Tensor shape for source A operand
- * @param unpB_tensor_shape: Tensor shape for source B operand
  * @note Call @ref _llk_unpack_AB_init_ before this function.
  */
 inline void _llk_unpack_AB_uninit_()

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_untilize.h
@@ -106,7 +106,7 @@ inline void _llk_unpack_untilize_init_(const std::uint32_t unpack_dst_format, co
 
     // Get pointer to registers for current state ID
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK);
-    cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32, UNP0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT, UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK>(unpA_ch1_y_stride);
+    cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32, UNP0_ADDR_CTRL_XY_REG_1_Ystride_SHAMT, UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK>(unpA_ch1_y_stride);
     cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, 0xFFFF>(FACE_C_DIM);
     TTI_REG2FLOP(
         1, 0, 0, 0, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32 - THCON_CFGREG_BASE_ADDR32, p_gpr_unpack::FACE_DIM_1x16); // GPR preloaded with  16 | (16 << 16)


### PR DESCRIPTION
Issue : https://github.com/tenstorrent/tt-llk/issues/1652

Batch of P3 "informational" findings from the LLK ISA-grounded audit. No change to emitted kernels except provably-numerically-identical renames:

- U6: fix stale uninit docstrings (unpack_A/AB) — claimed to reset counters / listed phantom params, but the bodies are no-ops (state reprogrammed by the next init). WH+BH.
- M5: keep the matmul "addr_mod_5" annotations (they are correct) and add a NOTE explaining the HW bank-select: an MVMUL encoding ADDR_MOD_1 resolves to ADDR_MOD_5 because a preceding bias.incr=1 addr_mod sets the RWC ExtraAddrModBit, which adds +4 to the next instruction's addr_mod index. WH.
- S3: ternary SFPU configure_addrmod uses `if constexpr` (matches unary/binary; was a runtime `if` on a constexpr template param). WH+BH.
- R2: reconfigure_exp_threshold writes the named Exp_threshold_ADDR32 registers directly instead of Row_start_section_size+3, matching what BH already does; keep BH's static_assert that Exp_threshold{,_en} share a config word (the precondition for the combined-mask RMW). Numerically identical. WH.
- R3: untilize Ystride RMW pairs REG_1 ADDR/MASK with REG_1 SHAMT (was REG_0 SHAMT; numerically identical, both SHAMT equal). WH+BH.
- PK3: pack y_stride uses FACE_C_DIM (Y steps a row of FACE_C_DIM datums; == FACE_R_DIM for square faces) — semantic, numerically identical. WH.
- PK1: document why program_packer_destination needs no packer-drain STALLWAIT (the pack thread issues its stream in order, so each tile's PACR has already started and latched L1_Dest_addr -- sampled at PACR start -- before the next call reprograms it; the Flush/Last PACR drains the prior pack). WH: replace the dead commented-out STALLWAIT with this rationale. BH: rewrite the stale comment that misattributed this to packer tile-header writes (OUTPUT_ADDR actually feeds the ordinary L1_Dest_addr path every PACR reads). WH+BH.
- PK2: add rationale for the disabled diagonal packer-2/3 lines. WH.
- S4: remove 10 dead commented `// .bias = {.incr = 1},` lines. BH.

Findings catalogued on branch amahmud/llk-audit-notes. Not built on a device here (header doc/comment/assert changes); relies on CI.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/llk-informational-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/llk-informational-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/llk-informational-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/llk-informational-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/llk-informational-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/llk-informational-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/llk-informational-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/llk-informational-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/llk-informational-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/llk-informational-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/llk-informational-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/llk-informational-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/llk-informational-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/llk-informational-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/llk-informational-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/llk-informational-fixes)