### PR TITLE
[Cleanup] Tweak order of operations on the slow dispatch path

### DIFF
--- a/tt_metal/impl/host_api/tt_metal.cpp
+++ b/tt_metal/impl/host_api/tt_metal.cpp
@@ -430,8 +430,10 @@ void DispatchCompiledProgramToDevice(IDevice* device, Program& program) {
         "Program has no logical cores to dispatch to device {}. Ensure the program has kernels.",
         device_id);
 
-    detail::WriteRuntimeArgsToDevice(device, program, /*force_slow_dispatch=*/false);
+    // First configure (allocate buffers + write configs/binaries), then write runtime args.
+    // This allows us to allocate ephemeral scratchpad buffers, and pass their locations as implicit CRTAs.
     detail::ConfigureDeviceWithProgram(device, program, /*force_slow_dispatch=*/false);
+    detail::WriteRuntimeArgsToDevice(device, program, /*force_slow_dispatch=*/false);
 
     MetalContext::instance().get_cluster().dram_barrier(device_id);
     MetalContext::instance().get_cluster().l1_barrier(device_id);
@@ -861,8 +863,10 @@ void LaunchProgram(IDevice* device, Program& program, bool wait_until_cores_done
             program.impl().finalize_offsets(device);
         }
 
-        detail::WriteRuntimeArgsToDevice(device, program, force_slow_dispatch);
+        // First configure (allocate buffers + write configs/binaries), then write runtime args.
+        // This allows us to allocate ephemeral scratchpad buffers, and pass their locations as implicit CRTAs.
         detail::ConfigureDeviceWithProgram(device, program, force_slow_dispatch);
+        detail::WriteRuntimeArgsToDevice(device, program, force_slow_dispatch);
 
         auto device_id = device->id();
 


### PR DESCRIPTION
## PR Category
Cleanup (no functional side effects)

## Summary

The PR swaps the order of `WriteRuntimeArgsToDevice` and `ConfigureDeviceWithProgram`  in `LaunchProgram` (slow dispatch). These two steps populate disjoint regions of the kernel config area, and (currently) have no coupling. 

Swapping the order should have no functional repercussions. 

### Motivation
To unblock Metal 2.0 ops porting, we need a "kernel scratchpad" feature. This is an allocated chunk of L1 with program execution lifetime (like a CB/DFB). The implementation is fairly trivial: allocate the memory, get the base pointer, pass it as an implicit CRTA via Metal 2.0 resources bindings.

This works fine on fast dispatch, but was blocked on slow dispatch by the order of operations.

### Testing
 - Runtime unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/28267280716
          - Blend of SD / FD, on WH + BH
 - Full nightly slow dispatch suite ( [internal] Slow Dispatch unit tests impl ), on n150
 - All runtime unit tests locally (with slow dispatch on), on n150
 - AI dependence analysis (first principles) found no ordering dependence between these steps

## Notes for reviewers
The runtime unit tests have failures, some of which seem to be intermittent. I see the same pattern of failures on main when I manually launch tests.

Please let me know if there are any other pipelines to run to guarantee the safety of this change.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/slow-dispatch-tweak)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/slow-dispatch-tweak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/slow-dispatch-tweak)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/slow-dispatch-tweak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/slow-dispatch-tweak)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/slow-dispatch-tweak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/slow-dispatch-tweak)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/slow-dispatch-tweak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/slow-dispatch-tweak)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/slow-dispatch-tweak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/slow-dispatch-tweak)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/slow-dispatch-tweak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/slow-dispatch-tweak)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/slow-dispatch-tweak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/slow-dispatch-tweak)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/slow-dispatch-tweak)