### PR TITLE
[Metal 2.0] Parallelize per-device program command write in mesh dispatch

### DIFF
--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -867,13 +867,9 @@ void FDMeshCommandQueue::increment_num_entries_in_completion_queue() {
 }
 
 void FDMeshCommandQueue::submit_memcpy_request(
-    std::unordered_map<IDevice*, uint32_t>& num_txns_per_device,
-    bool blocking,
-    std::vector<MemoryPin> memory_pins) {
+    std::unordered_map<IDevice*, uint32_t>& num_txns_per_device, bool blocking, std::vector<MemoryPin> memory_pins) {
     completion_queue_reads_.push(std::make_shared<MeshCompletionReaderVariant>(
-        std::in_place_type<MeshBufferReadDescriptor>,
-        std::move(num_txns_per_device),
-        std::move(memory_pins)));
+        std::in_place_type<MeshBufferReadDescriptor>, std::move(num_txns_per_device), std::move(memory_pins)));
 
     this->increment_num_entries_in_completion_queue();
 
@@ -1192,12 +1188,26 @@ void FDMeshCommandQueue::write_program_cmds_to_subgrid(
                                     .get_dispatch_core_manager()
                                     .get_dispatch_core_config();
     CoreType dispatch_core_type = get_core_type_from_config(dispatch_core_config);
+    // Per-device command-sequence writes are independent (each device has its own SystemMemoryManager;
+    // ProgramCommandSequence is read-only), so fan them out across the dispatch thread pool rather than
+    // writing serially -- mirrors enqueue_record_event. chip_ids_in_workload is not thread-safe, so it
+    // is populated serially and only the writes are parallelized.
     for_each_local(mesh_device_, sub_grid, [&](const auto& coord) {
         auto device = mesh_device_->impl().get_device(coord);
-        program_dispatch::write_program_command_sequence(
-            program_cmd_seq, device->sysmem_manager(), id_, dispatch_core_type, stall_first, stall_before_program);
         chip_ids_in_workload.insert(device->id());
+        dispatch_thread_pool_->enqueue(
+            [this, &program_cmd_seq, device, dispatch_core_type, stall_first, stall_before_program]() {
+                program_dispatch::write_program_command_sequence(
+                    program_cmd_seq,
+                    device->sysmem_manager(),
+                    id_,
+                    dispatch_core_type,
+                    stall_first,
+                    stall_before_program);
+            },
+            device->id());
     });
+    dispatch_thread_pool_->wait();
 }
 
 void FDMeshCommandQueue::write_go_signal_to_unused_sub_grids(

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -1188,10 +1188,14 @@ void FDMeshCommandQueue::write_program_cmds_to_subgrid(
                                     .get_dispatch_core_manager()
                                     .get_dispatch_core_config();
     CoreType dispatch_core_type = get_core_type_from_config(dispatch_core_config);
-    // Per-device command-sequence writes are independent (each device has its own SystemMemoryManager;
-    // ProgramCommandSequence is read-only), so fan them out across the dispatch thread pool rather than
-    // writing serially -- mirrors enqueue_record_event. chip_ids_in_workload is not thread-safe, so it
-    // is populated serially and only the writes are parallelized.
+    // Fan the per-device command-sequence writes out across the dispatch thread pool instead of writing
+    // serially (mirrors enqueue_record_event). This is safe because:
+    //   - each task writes to a distinct device's SystemMemoryManager, and the device-bound pool maps a
+    //     given device id to a fixed worker thread, so no two threads ever touch the same manager;
+    //   - program_cmd_seq is only read here -- it was finalized/patched serially in
+    //     update_program_dispatch_commands and is device-independent across this sub_grid;
+    //   - exceptions thrown in a task are captured and rethrown on this thread by dispatch_thread_pool_->wait().
+    // chip_ids_in_workload is not thread-safe, so it is populated serially and only the writes are parallelized.
     for_each_local(mesh_device_, sub_grid, [&](const auto& coord) {
         auto device = mesh_device_->impl().get_device(coord);
         chip_ids_in_workload.insert(device->id());
@@ -1217,20 +1221,37 @@ void FDMeshCommandQueue::write_go_signal_to_unused_sub_grids(
     bool mcast_go_signals,
     bool unicast_go_signals,
     const program_dispatch::ProgramDispatchMetadata& dispatch_md) {
+    // Same rationale as write_program_cmds_to_subgrid: each go-signal write targets a distinct device's
+    // SystemMemoryManager, so fan the writes out across the dispatch thread pool rather than writing
+    // serially. chip_ids_in_workload is only read here (fully populated by the program-command write
+    // above), and get_devices() returns local devices, each of which owns a pool thread.
+    const CoreCoord dispatch_core = this->virtual_program_dispatch_core();
     for (auto& device : mesh_device_->get_devices()) {
         if (!chip_ids_in_workload.contains(device->id())) {
-            write_go_signal(
-                id_,
-                mesh_device_,
-                sub_device_id,
-                device->sysmem_manager(),
-                expected_num_workers_completed,
-                this->virtual_program_dispatch_core(),
-                mcast_go_signals,
-                unicast_go_signals,
-                dispatch_md);
+            dispatch_thread_pool_->enqueue(
+                [this,
+                 device,
+                 sub_device_id,
+                 expected_num_workers_completed,
+                 dispatch_core,
+                 mcast_go_signals,
+                 unicast_go_signals,
+                 &dispatch_md]() {
+                    write_go_signal(
+                        id_,
+                        mesh_device_,
+                        sub_device_id,
+                        device->sysmem_manager(),
+                        expected_num_workers_completed,
+                        dispatch_core,
+                        mcast_go_signals,
+                        unicast_go_signals,
+                        dispatch_md);
+                },
+                device->id());
         }
     }
+    dispatch_thread_pool_->wait();
 }
 
 void FDMeshCommandQueue::enqueue_trace(const MeshTraceId& trace_id, bool blocking) {

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -888,13 +888,9 @@ void FDMeshCommandQueue::increment_num_entries_in_completion_queue() {
 }
 
 void FDMeshCommandQueue::submit_memcpy_request(
-    std::unordered_map<IDevice*, uint32_t>& num_txns_per_device,
-    bool blocking,
-    std::vector<MemoryPin> memory_pins) {
+    std::unordered_map<IDevice*, uint32_t>& num_txns_per_device, bool blocking, std::vector<MemoryPin> memory_pins) {
     completion_queue_reads_.push(std::make_shared<MeshCompletionReaderVariant>(
-        std::in_place_type<MeshBufferReadDescriptor>,
-        std::move(num_txns_per_device),
-        std::move(memory_pins)));
+        std::in_place_type<MeshBufferReadDescriptor>, std::move(num_txns_per_device), std::move(memory_pins)));
 
     this->increment_num_entries_in_completion_queue();
 
@@ -1206,12 +1202,21 @@ void FDMeshCommandQueue::write_program_cmds_to_subgrid(
     bool stall_first,
     bool stall_before_program,
     std::unordered_set<uint32_t>& chip_ids_in_workload) {
+    // Per-device command-sequence writes are independent (each device has its own SystemMemoryManager;
+    // ProgramCommandSequence is read-only), so fan them out across the dispatch thread pool rather than
+    // writing serially -- mirrors enqueue_record_event. chip_ids_in_workload is not thread-safe, so it
+    // is populated serially and only the writes are parallelized.
     for_each_local(mesh_device_, sub_grid, [&](const auto& coord) {
         auto device = mesh_device_->impl().get_device(coord);
-        program_dispatch::write_program_command_sequence(
-            program_cmd_seq, device->sysmem_manager(), id_, stall_first, stall_before_program);
         chip_ids_in_workload.insert(device->id());
+        dispatch_thread_pool_->enqueue(
+            [this, &program_cmd_seq, device, stall_first, stall_before_program]() {
+                program_dispatch::write_program_command_sequence(
+                    program_cmd_seq, device->sysmem_manager(), id_, stall_first, stall_before_program);
+            },
+            device->id());
     });
+    dispatch_thread_pool_->wait();
 }
 
 void FDMeshCommandQueue::write_go_signal_to_unused_sub_grids(

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -1202,10 +1202,14 @@ void FDMeshCommandQueue::write_program_cmds_to_subgrid(
     bool stall_first,
     bool stall_before_program,
     std::unordered_set<uint32_t>& chip_ids_in_workload) {
-    // Per-device command-sequence writes are independent (each device has its own SystemMemoryManager;
-    // ProgramCommandSequence is read-only), so fan them out across the dispatch thread pool rather than
-    // writing serially -- mirrors enqueue_record_event. chip_ids_in_workload is not thread-safe, so it
-    // is populated serially and only the writes are parallelized.
+    // Fan the per-device command-sequence writes out across the dispatch thread pool instead of writing
+    // serially (mirrors enqueue_record_event). This is safe because:
+    //   - each task writes to a distinct device's SystemMemoryManager, and the device-bound pool maps a
+    //     given device id to a fixed worker thread, so no two threads ever touch the same manager;
+    //   - program_cmd_seq is only read here -- it was finalized/patched serially in
+    //     update_program_dispatch_commands and is device-independent across this sub_grid;
+    //   - exceptions thrown in a task are captured and rethrown on this thread by dispatch_thread_pool_->wait().
+    // chip_ids_in_workload is not thread-safe, so it is populated serially and only the writes are parallelized.
     for_each_local(mesh_device_, sub_grid, [&](const auto& coord) {
         auto device = mesh_device_->impl().get_device(coord);
         chip_ids_in_workload.insert(device->id());
@@ -1226,20 +1230,37 @@ void FDMeshCommandQueue::write_go_signal_to_unused_sub_grids(
     bool mcast_go_signals,
     bool unicast_go_signals,
     const program_dispatch::ProgramDispatchMetadata& dispatch_md) {
+    // Same rationale as write_program_cmds_to_subgrid: each go-signal write targets a distinct device's
+    // SystemMemoryManager, so fan the writes out across the dispatch thread pool rather than writing
+    // serially. chip_ids_in_workload is only read here (fully populated by the program-command write
+    // above), and get_devices() returns local devices, each of which owns a pool thread.
+    const CoreCoord dispatch_core = this->virtual_program_dispatch_core();
     for (auto& device : mesh_device_->get_devices()) {
         if (!chip_ids_in_workload.contains(device->id())) {
-            write_go_signal(
-                id_,
-                mesh_device_,
-                sub_device_id,
-                device->sysmem_manager(),
-                expected_num_workers_completed,
-                this->virtual_program_dispatch_core(),
-                mcast_go_signals,
-                unicast_go_signals,
-                dispatch_md);
+            dispatch_thread_pool_->enqueue(
+                [this,
+                 device,
+                 sub_device_id,
+                 expected_num_workers_completed,
+                 dispatch_core,
+                 mcast_go_signals,
+                 unicast_go_signals,
+                 &dispatch_md]() {
+                    write_go_signal(
+                        id_,
+                        mesh_device_,
+                        sub_device_id,
+                        device->sysmem_manager(),
+                        expected_num_workers_completed,
+                        dispatch_core,
+                        mcast_go_signals,
+                        unicast_go_signals,
+                        dispatch_md);
+                },
+                device->id());
         }
     }
+    dispatch_thread_pool_->wait();
 }
 
 void FDMeshCommandQueue::enqueue_trace(const MeshTraceId& trace_id, bool blocking) {


### PR DESCRIPTION
## What

Mesh dispatch writes command sequences to each device's command queue **serially**, in two places, both scaling with device count:

1. `FDMeshCommandQueue::write_program_cmds_to_subgrid` — writes the program command sequence to every device running the program (`for_each_local`).
2. `FDMeshCommandQueue::write_go_signal_to_unused_sub_grids` — writes a go-signal to every device *not* running the program, to keep global state consistent.

This change fans both per-device loops out across the dispatch thread pool (`dispatch_thread_pool_`) instead of writing serially. The writes are independent — each device has its own `SystemMemoryManager`, the shared `ProgramCommandSequence` is read-only (finalized/patched serially in `update_program_dispatch_commands` beforehand), and the device-bound pool maps a given device id to a fixed worker thread, so no two threads ever touch the same manager. This mirrors `enqueue_record_event`, which already parallelizes the identical per-device pattern via the same pool. Exceptions thrown in a task are captured and rethrown on the calling thread by `dispatch_thread_pool_->wait()`. `chip_ids_in_workload` is not thread-safe, so it is populated serially and only the writes are parallelized.

Note: `write_go_signal_to_unused_sub_grids` is a no-op for full-mesh workloads (every device is in the workload, so there are no unused sub-grids); parallelizing it helps **partial/sub-mesh** workloads, and keeps the two per-device write loops consistent.

## Why

Profiling the host dispatch of a sharded op (interleaved_to_sharded) showed the per-device command write is the component that scales with device count (≈20% of host dispatch on a single device, growing ~linearly with the number of local devices). The build/hash of the program is incurred once per dispatch regardless of mesh size; the per-device command write is the part that grows. Parallelizing it should reduce multi-chip host-dispatch wall time. This helps both Metal 2.0 and legacy paths (shared code).

## Validation

- Default behavior change: both per-device write loops now run on the dispatch thread pool (same pool/pattern already used by `enqueue_record_event`).
- **Correctness** is exercised by the multi-chip CI (T3K) — the parallel path runs on real hardware there. The go-signal-to-unused-sub-grids path additionally requires a **partial/sub-mesh** workload to be covered.
- **Perf gain** is pending a multi-chip measurement (T3K / Galaxy); it cannot be measured meaningfully under the functional simulator (its per-device write is a cheap memcpy, so thread-pool overhead dominates and hides the win — the simulated per-device write cost is not representative of hardware).

Draft pending T3K validation.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/parallel-mesh-program-write)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/parallel-mesh-program-write)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/parallel-mesh-program-write)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/parallel-mesh-program-write)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/parallel-mesh-program-write)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/parallel-mesh-program-write)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/parallel-mesh-program-write)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/parallel-mesh-program-write)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/parallel-mesh-program-write)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/parallel-mesh-program-write)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/parallel-mesh-program-write)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/parallel-mesh-program-write)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/parallel-mesh-program-write)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/parallel-mesh-program-write)
