### PR TITLE
[LLK] Fix BH 8-bit tilize MOP: program the intended two-op body (U1)

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
@@ -39,20 +39,28 @@ inline void _llk_unpack_tilize_mop_config_(const bool narrow_tile = false, const
     const std::uint32_t outerloop = (!skip_bh_workaround || (skip_bh_workaround && narrow_tile)) ? 1 : 2;
     const std::uint32_t innerloop = 1;
 
-    ckernel_template tmp(outerloop, innerloop, unpack_to_dest ? unpack_srca_to_dest : unpack_srcb_set_dvalid);
-
+    // ckernel_template is non-assignable, so build and program each variant in its own scope.
+    // skip_bh_workaround (8-bit formats) uses the two-op body (zerosrc + set_dvalid), mirroring Wormhole;
+    // otherwise the single-op BH workaround body is used. Both prepend unpack_srca unless unpacking to dest.
     if (skip_bh_workaround)
     {
         static constexpr std::uint32_t unpack_srcb_zerosrc = TT_OP_UNPACR_NOP(SrcB, 0, 0, p_unpacr_nop::UNP_NOP, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
         ckernel_template tmp(outerloop, innerloop, unpack_srcb_zerosrc, unpack_srcb_set_dvalid);
+        if (!unpack_to_dest)
+        {
+            tmp.set_start_op(unpack_srca);
+        }
+        tmp.program();
     }
-
-    if (!unpack_to_dest)
+    else
     {
-        tmp.set_start_op(unpack_srca);
+        ckernel_template tmp(outerloop, innerloop, unpack_to_dest ? unpack_srca_to_dest : unpack_srcb_set_dvalid);
+        if (!unpack_to_dest)
+        {
+            tmp.set_start_op(unpack_srca);
+        }
+        tmp.program();
     }
-
-    tmp.program();
 }
 
 /**


### PR DESCRIPTION
Issue : https://github.com/tenstorrent/tt-llk/issues/1654

_llk_unpack_tilize_mop_config_ declared an inner `ckernel_template tmp` inside the skip_bh_workaround branch that shadowed the outer `tmp` and was destroyed unused; the outer template (single-op body) was the one programmed, so the intended (unpack_srcb_zerosrc, unpack_srcb_set_dvalid) body was silently dropped for 8-bit formats (skip_bh_workaround = is_8bit_format).

ckernel_template is non-copyable/non-assignable, so the fix builds and programs each variant in its own scope (matching Wormhole's mop_config structure):
- skip_bh_workaround -> two-op body (zerosrc + set_dvalid), mirroring WH
- otherwise -> the single-op BH workaround body Both prepend unpack_srca unless unpacking to dest.

Found in the LLK ISA audit (P1, U1). Compile-verified (test_unpack_tilize.py, BH).

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/llk-fix-u1-tilize-mop-shadowing)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/llk-fix-u1-tilize-mop-shadowing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/llk-fix-u1-tilize-mop-shadowing)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/llk-fix-u1-tilize-mop-shadowing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/llk-fix-u1-tilize-mop-shadowing)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/llk-fix-u1-tilize-mop-shadowing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/llk-fix-u1-tilize-mop-shadowing)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/llk-fix-u1-tilize-mop-shadowing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/llk-fix-u1-tilize-mop-shadowing)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/llk-fix-u1-tilize-mop-shadowing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/llk-fix-u1-tilize-mop-shadowing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/llk-fix-u1-tilize-mop-shadowing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/llk-fix-u1-tilize-mop-shadowing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/llk-fix-u1-tilize-mop-shadowing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/llk-fix-u1-tilize-mop-shadowing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/llk-fix-u1-tilize-mop-shadowing)