### PR TITLE
[Cleanup] Clarify Metal 2.0 header comments on kernel threading

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -104,11 +104,15 @@ struct KernelAdvancedOptions {
     // Multi-threaded self-loop DFBs on compute kernels
     ////////////////////////////////////////////////////////////////////////////////
 
-    // Self-loop DFBs on compute kernels (niche use case).
+    // Self-loop DFBs on compute kernels (niche multi-threaded use case).
     // This applies only to compute kernels that bind BOTH the producer and consumer
     // endpoints of the same DFB (self-loop).
     //
-    // The compute kernel threads can communicate via the DFB in two topologies:
+    // This is ONLY pertinent to multi-threaded compute kernels on Gen2 architectures.
+    // These settings have absolutely no effect on single-threaded kernels.
+    // (A Gen1 compute kernel is always single-threaded.)
+    //
+    // A compute kernel's threads can communicate via the DFB in two topologies:
     //
     //   INTRA (intra-thread): Each kernel thread uses the DFB in its own self-loop.
     //         (no cross-thread communication). This is the common case.

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_hardware_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_hardware_config.hpp
@@ -31,6 +31,11 @@ namespace tt::tt_metal::experimental {
 //
 // The ComputeHardwareConfig fields configure this pipeline.
 //
+// NOTE: The Unpack, Math, and Pack stages are hardware pipeline stages internal
+//       to a single kernel thread, not to be confused with KernelSpec::num_threads!
+//       Each thread of a multi-threaded compute kernel runs its own independent
+//       Unpack/Math/Pack pipeline.
+//
 // ============================================================================
 
 struct ComputeHardwareConfig {

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
@@ -40,8 +40,10 @@
 // INVARIANT: At the node level, a DFB instance has exactly one producer kernel
 //   instance and exactly one consumer kernel instance. You must respect this
 //   invariant across the DataflowBufferSpec's endpoint bindings.
-//   It is legal to bind more than one KernelSpec producer (or consumer) to a
-//   DFB endpoint, provided that they have:
+//   This is a per-node rule, not a per-spec one: you MAY bind more than one
+//   KernelSpec to a producer (or consumer) endpoint, because their non-overlapping
+//   node sets each still contribute exactly one instance per node. Such multiple
+//   bindings on one endpoint are legal provided they have:
 //     - non-overlapping node coverage, AND
 //     - the same kernel kind (compute or data movement), AND
 //     - identical binding-site parameters (access_pattern, num_threads)

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -34,10 +34,12 @@ namespace tt::tt_metal::experimental {
 //
 // A KernelSpec describes a *compiled kernel*: it specializes a kernel for
 // compilation, baking in the kernel's compile-time arguments and compiler options.
-// A compiled kernel may run as several cooperating threads (see num_threads) — a
-// small number of independent threads that each run the whole kernel function and
-// coordinate explicitly. How those threads map onto the node's physical RISC-V
-// cores — and how many binaries the kernel compiles to — is an implementation
+//
+// A compiled kernel may run as multiple threads (see num_threads), following the
+// SPMD (single-program, multiple-data) model: a small number of independent
+// threads that each run the whole kernel function, each with its own thread
+// index, coordinating explicitly. How those threads map onto the node's physical
+// RISC-V cores — and how many binaries the kernel compiles to — is an implementation
 // detail the programming model hides.
 //
 // The KernelSpec describes all the properties of a kernel:
@@ -78,8 +80,8 @@ struct KernelSpec {
     KernelSpecName unique_id;
 
     // Kernel source: either a path to a source file, or the source code itself.
-    // String literals bind directly to the path variant alternative; wrap inline
-    // source code with SourceCode{...}.
+    // To pass inline source code, wrap it in KernelSpec::SourceCode{...}.
+    // (A string literal binds directly to the path variant alternative.)
     struct SourceCode {
         std::string code;
     };
@@ -88,8 +90,12 @@ struct KernelSpec {
     // NOTE: The kernel's target node set is a DERIVED property, based on the
     //       WorkUnitSpec(s) that include this kernel.
 
-    // Kernel threading:
-    // Number of kernel threads
+    // Kernel threading: the number of SPMD threads this kernel has.
+    //
+    // The legality rules for num_threads are architecture and kernel-type dependent:
+    //  - Gen1 architectures (Wormhole, Blackhole) support single-threaded kernels only.
+    //  - Gen2 architectures (Quasar) support num_threads > 1.
+    //    Different rules apply for compute vs data-movement kernels.
     uint32_t num_threads = 1;
 
     // Kernel type (methods)
@@ -121,10 +127,12 @@ struct KernelSpec {
     struct DFBBinding {
         // Endpoint role this binding plays for the DFB.
         enum class EndpointType { PRODUCER, CONSUMER };
-        // How the kernel's threads iterate over the DFB's entries.
+        // How the kernel's threads iterate over the DFB's entries. (Only meaningful
+        // for multi-threaded kernels; at num_threads == 1 all patterns are equivalent.)
         //   STRIDED: a kernel thread accesses every N-th entry (where N = num_threads)
         //   ALL:     each kernel thread accesses every DFB entry
         //   BLOCKED: a kernel thread accesses blocks of N entries, in strides of N blocks
+        //            (NOT YET SUPPORTED — currently rejected at runtime)
         enum class AccessPattern { STRIDED, ALL, BLOCKED };
 
         DFBSpecName dfb_spec_name;   // identify the DFB within the ProgramSpec
@@ -147,7 +155,7 @@ struct KernelSpec {
     // Declares that this kernel accesses a tensor parameter (declared at the ProgramSpec level)
     // The kernel constructs the accessor via TensorAccessor(tensor::<accessor_name>)
     struct TensorBinding {
-        TensorParamName tensor_parameter_name;      // identify the TensorBinding within the ProgramSpec
+        TensorParamName tensor_parameter_name;      // identify the TensorParameter within the ProgramSpec
         std::string accessor_name;                  // tensor accessor name (used in the kernel source code)
     };
     Group<TensorBinding> tensor_bindings;


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Minor improvements to Metal 2.0 header comments concerning kernel threading. These are motivated by the confusion encountered by ops-porting AIs regarding INTRA/INTER DFBs, and the distinction between kernel threads and the unpack/math/pack compute pipeline stages. This is legitimately a confusing aspect of the programming model.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/tweak-header-comments)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/tweak-header-comments)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/tweak-header-comments)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/tweak-header-comments)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/tweak-header-comments)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/tweak-header-comments)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/tweak-header-comments)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/tweak-header-comments)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/tweak-header-comments)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/tweak-header-comments)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/tweak-header-comments)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/tweak-header-comments)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/tweak-header-comments)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/tweak-header-comments)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/tweak-header-comments)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/tweak-header-comments)