### PR TITLE
[LLK] Mask relu_config cfg write to preserve shared-word bits (C1)

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_common.h
@@ -143,12 +143,19 @@ TT_ALWAYS_INLINE void _llk_pack_relu_config_(const ckernel::ReluConfig& relu_con
 {
     const std::uint32_t mode = static_cast<std::uint32_t>(relu_config.get_mode());
     const std::uint32_t val  = (relu_config.get_threshold() << STACC_RELU_ReluThreshold_SHAMT) | (mode << STACC_RELU_ApplyRelu_SHAMT);
-    TT_SETDMAREG(0, val & 0xffff, 0, LO_16(p_gpr_pack::TMP0));
-    TT_SETDMAREG(0, val >> 16, 0, HI_16(p_gpr_pack::TMP0));
-    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK | p_stall::THCON);
-    TTI_WRCFG(p_gpr_pack::TMP0, p_cfg::WRCFG_32b, STACC_RELU_ApplyRelu_ADDR32);
-    TTI_NOP;
-    TTI_NOP;
+
+    // STACC_RELU shares this cfg word with ALU_ACC_CTRL_Zero_Flag_disabled_src/dst (bits 0-1, owned by the
+    // MATH/UNPACK threads). A whole-word WRCFG_32b would clobber those bits, so use a masked RMW under
+    // mutex::REG_RMW -- matching how configure_pack programs relu.
+    static_assert(STACC_RELU_ApplyRelu_ADDR32 == STACC_RELU_ReluThreshold_ADDR32, "STACC_RELU ApplyRelu and ReluThreshold must share ADDR32 for combined RMW");
+    constexpr std::uint32_t hw_relu_mask = STACC_RELU_ApplyRelu_MASK | STACC_RELU_ReluThreshold_MASK;
+
+    // Only the packer needs draining: RMWCIB takes the data as an immediate (no GPR), so there is no
+    // SETDMAREG->WRCFG producer to fence -- the THCON wait the old whole-word path used is no longer needed.
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK);
+    t6_mutex_acquire(mutex::REG_RMW);
+    cfg_reg_rmw_tensix<STACC_RELU_ApplyRelu_ADDR32, 0, hw_relu_mask>(val);
+    t6_mutex_release(mutex::REG_RMW);
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_common.h
@@ -201,12 +201,17 @@ TT_ALWAYS_INLINE void _llk_pack_relu_config_(const ckernel::ReluConfig& relu_con
 {
     const std::uint32_t mode = static_cast<std::uint32_t>(relu_config.get_mode());
     const std::uint32_t val  = (relu_config.get_threshold() << STACC_RELU_ReluThreshold_SHAMT) | (mode << STACC_RELU_ApplyRelu_SHAMT);
-    TT_SETDMAREG(0, val & 0xffff, 0, LO_16(p_gpr_pack::TMP0));
-    TT_SETDMAREG(0, val >> 16, 0, HI_16(p_gpr_pack::TMP0));
+
+    // STACC_RELU shares this cfg word with ALU_ACC_CTRL_Zero_Flag_disabled_src/dst (bits 0-1, owned by the
+    // MATH/UNPACK threads). A whole-word WRCFG_32b would clobber those bits, so use a masked RMW under
+    // mutex::REG_RMW -- matching how configure_pack programs relu.
+    static_assert(STACC_RELU_ApplyRelu_ADDR32 == STACC_RELU_ReluThreshold_ADDR32, "STACC_RELU ApplyRelu and ReluThreshold must share ADDR32 for combined RMW");
+    constexpr std::uint32_t hw_relu_mask = STACC_RELU_ApplyRelu_MASK | STACC_RELU_ReluThreshold_MASK;
+
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK);
-    TTI_WRCFG(p_gpr_pack::TMP0, p_cfg::WRCFG_32b, STACC_RELU_ApplyRelu_ADDR32);
-    TTI_NOP;
-    TTI_NOP;
+    t6_mutex_acquire(mutex::REG_RMW);
+    cfg_reg_rmw_tensix<STACC_RELU_ApplyRelu_ADDR32, 0, hw_relu_mask>(val);
+    t6_mutex_release(mutex::REG_RMW);
 }
 
 /**


### PR DESCRIPTION
Issue : https://github.com/tenstorrent/tt-llk/issues/1655

_llk_pack_relu_config_ (WH+BH) wrote the STACC_RELU word with a whole-word WRCFG_32b. That cfg word also holds ALU_ACC_CTRL_Zero_Flag_disabled_src/dst (bits 0-1), which the MATH and UNPACK threads own and write; the whole-word write zeroed them. It was guarded only by a per-thread STALLWAIT(STALL_CFG, PACK[,THCON]) -- nothing excluded the other threads' RMW of the same word.

Switch to a masked cfg_reg_rmw_tensix (RMWCIB, mask = ApplyRelu | ReluThreshold) under mutex::REG_RMW, mirroring how configure_pack programs relu. RMWCIB takes the data as an immediate (no SETDMAREG->WRCFG GPR producer), so only the packer needs draining: both arches now use STALLWAIT(STALL_CFG, PACK). The old BH THCON wait fenced the now-removed GPR write (WH never had it -- a latent gap, moot once the GPR is gone). Adds a static_assert that ApplyRelu and ReluThreshold share ADDR32.

Found in the LLK ISA audit (P1, C1). Compile-verified (test_pack.py, WH+BH).

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/llk-fix-c1-relu-config-masked-rmw)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/llk-fix-c1-relu-config-masked-rmw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/llk-fix-c1-relu-config-masked-rmw)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/llk-fix-c1-relu-config-masked-rmw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=amahmud/llk-fix-c1-relu-config-masked-rmw)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:amahmud/llk-fix-c1-relu-config-masked-rmw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/llk-fix-c1-relu-config-masked-rmw)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/llk-fix-c1-relu-config-masked-rmw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/llk-fix-c1-relu-config-masked-rmw)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/llk-fix-c1-relu-config-masked-rmw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/llk-fix-c1-relu-config-masked-rmw)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/llk-fix-c1-relu-config-masked-rmw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/llk-fix-c1-relu-config-masked-rmw)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/llk-fix-c1-relu-config-masked-rmw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/llk-fix-c1-relu-config-masked-rmw)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/llk-fix-c1-relu-config-masked-rmw)