### PR TITLE
[LLK] Fix BH untilize uninit state leak: restore saved config

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_untilize.h
@@ -145,13 +145,9 @@ inline void _llk_unpack_untilize_init_(const std::uint32_t unpack_dst_format, co
  * @param face_r_dim: Rows per face, used to compute the restored datum count and Y stride.
  * @note Call @ref _llk_unpack_untilize_init_ before this function.
  */
-inline void _llk_unpack_untilize_uninit_(const std::uint32_t unpack_dst_format, const std::uint32_t face_r_dim)
+inline void _llk_unpack_untilize_uninit_([[maybe_unused]] const std::uint32_t unpack_dst_format, [[maybe_unused]] const std::uint32_t face_r_dim)
 {
     llk::san::operation_uninit<llk::san::Operation::UnpackUntilize>();
-
-    const DataFormat dst_format           = static_cast<DataFormat>(unpack_dst_format & 0x3);
-    const std::uint32_t unpA_ch1_x_stride = dst_format == DataFormat::Float32 ? 4 : dst_format == DataFormat::Float16 ? 2 : 1;
-    const std::uint32_t unpA_ch1_y_stride = FACE_C_DIM * face_r_dim * unpA_ch1_x_stride;
 
     // Check that unpacker is done (all contexts freed up) before starting hw configuration
     wait_for_idle();
@@ -162,10 +158,12 @@ inline void _llk_unpack_untilize_uninit_(const std::uint32_t unpack_dst_format, 
     // Wait for cfg to be free to edit
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK);
 
-    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
-    TTI_WRCFG(p_gpr_unpack::FACE_DIM_16x16, p_cfg::WRCFG_32b, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32);
-    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, 0xFFFF>(1);
-    cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32, UNP0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT, UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK>(unpA_ch1_y_stride);
+    // Restore the unpacker config saved by _llk_unpack_untilize_init_ (full words via WRCFG, matching WH).
+    // The previous code wrote hardcoded defaults (FACE_DIM_16x16 / descriptor+1 = 1) and a recomputed
+    // Ystride, clobbering any non-default prior state (and the descriptor RMW only touched the low 16 bits).
+    TTI_WRCFG(p_gpr_unpack::SR_UNPACK_UNTILIZER_STATE_0, p_cfg::WRCFG_32b, UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32);
+    TTI_WRCFG(p_gpr_unpack::SR_UNPACK_UNTILIZER_STATE_1, p_cfg::WRCFG_32b, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32);
+    TTI_WRCFG(p_gpr_unpack::SR_UNPACK_UNTILIZER_STATE_2, p_cfg::WRCFG_32b, THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1);
 
     TTI_NOP;
 }


### PR DESCRIPTION
Issue https://github.com/tenstorrent/tt-llk/issues/1656

### **THIS IS A DRAFT BECAUSE FINAL SOLUTION IS YET TO BE DECIDED, SEE ISSUE**

_llk_unpack_untilize_uninit_ on Blackhole never read the unpacker config that _llk_unpack_untilize_init_ saved into SR_UNPACK_UNTILIZER_STATE_0/1/2. It instead wrote hardcoded defaults (Tile_x_dim = FACE_DIM_16x16, TileDescriptor+1 = 1) and a recomputed ch1 Ystride, clobbering any non-default prior state. Two concrete defects:
- the descriptor restore was a 16-bit RMW (mask 0xFFFF) leaving the word's upper half stale;
- the recomputed Ystride used FACE_C_DIM*face_r_dim*x_stride, differing from the value init programmed (FACE_R_DIM*x_stride) when face_r_dim < FACE_R_DIM (U3).

Mirror Wormhole: restore all three words verbatim from the saved GPRs via WRCFG_32b. The params are now unused ([[maybe_unused]]); the signature is kept to avoid churning the metal llk_api / compute API layers (dropping them fully is a follow-up).

Found in the LLK ISA audit (P1 U2, folds P2 U3). The unpack-untilize path is compiled via the metal untilize op (CI); every symbol used here is already used by this file's init.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/llk-fix-u2-bh-untilize-uninit-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/llk-fix-u2-bh-untilize-uninit-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/llk-fix-u2-bh-untilize-uninit-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/llk-fix-u2-bh-untilize-uninit-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=amahmud/llk-fix-u2-bh-untilize-uninit-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:amahmud/llk-fix-u2-bh-untilize-uninit-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/llk-fix-u2-bh-untilize-uninit-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/llk-fix-u2-bh-untilize-uninit-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/llk-fix-u2-bh-untilize-uninit-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/llk-fix-u2-bh-untilize-uninit-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/llk-fix-u2-bh-untilize-uninit-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/llk-fix-u2-bh-untilize-uninit-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/llk-fix-u2-bh-untilize-uninit-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/llk-fix-u2-bh-untilize-uninit-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/llk-fix-u2-bh-untilize-uninit-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/llk-fix-u2-bh-untilize-uninit-leak)