### PR TITLE
[LLK] Make WH set_packer_strides self-draining (C3, WH side)

### DIFF
--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
@@ -359,12 +359,21 @@ inline void set_packer_strides(const std::uint32_t pack_src_format)
 
     std::uint32_t xy_stride = (x_stride << PCK0_ADDR_CTRL_XY_REG_0_Xstride_SHAMT) | (y_stride << PCK0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT);
     std::uint32_t zw_stride = (z_stride << PCK0_ADDR_CTRL_ZW_REG_0_Zstride_SHAMT) | (w_stride << PCK0_ADDR_CTRL_ZW_REG_0_Wstride_SHAMT);
+
+    // Load both stride words (TMP0/TMP1) up front, then drain the packer, then issue both WRCFGs.
+    // Draining is required so an in-flight pack cannot sample the stride config mid-update -- this makes
+    // set_packer_strides self-draining instead of relying on every caller to leave the packer idle.
+    // The STALLWAIT is placed AFTER the SETDMAREGs so those Scalar-Unit writes overlap the packer drain:
+    // STALL_CFG blocks WRCFG, and since the Wait Gate is in-order, the first blocked WRCFG would otherwise
+    // strand any SETDMAREG sequenced behind it until the drain completed. No THCON fence is needed --
+    // same-thread Scalar-Unit serialization guarantees each SETDMAREG write lands before its WRCFG reads it.
     TT_SETDMAREG(0, LOWER_HALFWORD(xy_stride), 0, LO_16(p_gpr_pack::TMP0));
     TT_SETDMAREG(0, UPPER_HALFWORD(xy_stride), 0, HI_16(p_gpr_pack::TMP0));
+    TT_SETDMAREG(0, LOWER_HALFWORD(zw_stride), 0, LO_16(p_gpr_pack::TMP1));
+    TT_SETDMAREG(0, UPPER_HALFWORD(zw_stride), 0, HI_16(p_gpr_pack::TMP1));
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK);
     TTI_WRCFG(p_gpr_pack::TMP0, p_cfg::WRCFG_32b, PCK0_ADDR_CTRL_XY_REG_0_Xstride_ADDR32);
-    TT_SETDMAREG(0, LOWER_HALFWORD(zw_stride), 0, LO_16(p_gpr_pack::TMP0));
-    TT_SETDMAREG(0, UPPER_HALFWORD(zw_stride), 0, HI_16(p_gpr_pack::TMP0));
-    TTI_WRCFG(p_gpr_pack::TMP0, p_cfg::WRCFG_32b, PCK0_ADDR_CTRL_ZW_REG_0_Zstride_ADDR32);
+    TTI_WRCFG(p_gpr_pack::TMP1, p_cfg::WRCFG_32b, PCK0_ADDR_CTRL_ZW_REG_0_Zstride_ADDR32);
     TTI_NOP;
     TTI_NOP;
 }


### PR DESCRIPTION
https://github.com/tenstorrent/tt-llk/issues/747

To finalize this we need to know: https://github.com/tenstorrent/tt-isa-documentation/issues/56
And whether WRCFG can have a race with SETDMAREG or not. 

set_packer_strides on Wormhole had no stall: it reprogrammed the packer PCK0_ADDR_CTRL_* stride registers via WRCFG with no packer drain, relying on every caller to leave the packer idle first. An in-flight pack whose PACR has not yet started could then sample half-updated strides.

Add STALLWAIT(STALL_CFG, PACK) before the stride WRCFGs so the function drains the packer itself -- the root-cause fix that collapses the dependent packer-reconfig hardening gaps. Blackhole's side is handled separately by PR #48150 (STALL_CFG, PACK|THCON in BH set_packer_strides), so this branch is WH-only.

Found in the LLK ISA audit (P1, C3). Compile-verified (test_pack.py, WH).

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
