### PR TITLE
[SFPU] Optimize atanh, asinh, and acosh with Numerically Stable log1p-Based Implementations

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -31,44 +31,44 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_fp32_accurate_(sfpi::vFloat val) {
 
     constexpr float POLYNOMIAL_THRESHOLD = 0.6f;
 
-    sfpi::vInt exponent = sfpi::exexp(val, sfpi::ExponentMode::NoDebias);
-    sfpi::vInt mantissa = sfpi::exman(val);
-    // exp==255: NaN (default) or ±Inf (mantissa==0)
-    v_if(exponent == 255) {
-        result = std::numeric_limits<float>::quiet_NaN();
-        v_if(mantissa == 0) {
-            sfpi::vFloat one = sfpi::vConst1;
-            result = sfpi::copysgn(one, val);
-        }
-        v_endif;
+    sfpi::vFloat abs_val = sfpi::abs(val);
+
+    v_if(abs_val < POLYNOMIAL_THRESHOLD) {
+        // Small |x|: Use minimax polynomial for better accuracy
+        // Polynomial coefficients found with Sollya using the following command:
+        // fpminimax(tanh(x)/x, [|0,2,4,6,8|], [|single...|], [-0.6; -2^(-40)] + [2^(-40); 0.6], relative);
+        sfpi::vFloat x2 = val * val;
+
+        sfpi::vFloat p = PolynomialEvaluator::eval(
+            x2,
+            0.999999940395355224609375f,
+            -0.33332359790802001953125f,
+            0.13310669362545013427734375f,
+            -5.21197654306888580322265625e-2f,
+            1.5497927553951740264892578125e-2f);
+
+        result = val * p;
     }
     v_else {
-        sfpi::vFloat abs_val = sfpi::abs(val);
-
-        v_if(abs_val < POLYNOMIAL_THRESHOLD) {
-            // Small |x|: Use minimax polynomial for better accuracy
-            // Polynomial coefficients found with Sollya using the following command:
-            // fpminimax(tanh(x)/x, [|0,2,4,6,8|], [|single...|], [-0.6; -2^(-40)] + [2^(-40); 0.6], relative);
-            sfpi::vFloat x2 = val * val;
-
-            sfpi::vFloat p = PolynomialEvaluator::eval(
-                x2,
-                0.999999940395355224609375f,
-                -0.33332359790802001953125f,
-                0.13310669362545013427734375f,
-                -5.21197654306888580322265625e-2f,
-                1.5497927553951740264892578125e-2f);
-
-            result = val * p;
-            result = sfpi::copysgn(result, val);  // Preserve input sign on zero (tanh(-0.0) = -0.0);
+        sfpi::vInt exponent = sfpi::exexp(val, sfpi::ExponentMode::NoDebias);
+        // exp==255: NaN (default) or ±Inf (mantissa==0)
+        v_if(exponent == 255) {
+            sfpi::vInt mantissa = sfpi::exman(val);
+            result = std::numeric_limits<float>::quiet_NaN();
+            v_if(mantissa == 0) {
+                sfpi::vFloat one = sfpi::vConst1;
+                result = sfpi::copysgn(one, val);
+            }
+            v_endif;
         }
         v_else {
-            // Normal region: Use tanh(x) = 2*sigmoid(2x) - 1
-            sfpi::vFloat two_x = 2.f * val;
+            // Normal region: Use tanh(x) = sign(x) * (2*sigmoid(2*|x|) - 1)
+            sfpi::vFloat two_x = 2.f * abs_val;
             sfpi::vFloat sig = _sfpu_sigmoid_<is_fp32_dest_acc_en>(two_x);
 
-            // Compute 2*sigmoid(2x) - 1
-            result = 2.f * sig - sfpi::vConst1;
+            // Compute 2*sigmoid(2*|x|) - 1
+            sfpi::vFloat res_abs = 2.f * sig - sfpi::vConst1;
+            result = sfpi::copysgn(res_abs, val);
         }
         v_endif;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -12,6 +12,7 @@
 #include "ckernel_sfpu_sqrt_custom.h"
 #include "ckernel_sfpu_exp.h"
 #include "sfpu/ckernel_sfpu_log.h"
+#include "ckernel_sfpu_log1p.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
 #include "sfpi.h"
 
@@ -789,20 +790,28 @@ inline void _calculate_cosine_(const int iterations) {
 
 // https://en.wikipedia.org/wiki/Inverse_hyperbolic_functions#Definitions_in_terms_of_logarithms
 // acosh(x) = log(x + sqrt(x^2 - 1))
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_acosh() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat inp = sfpi::dst_reg[0];
         sfpi::vFloat res;
-        v_if(inp < sfpi::vConst1) { res = std::numeric_limits<float>::quiet_NaN(); }
-        v_elseif(inp == sfpi::vConst1) { res = sfpi::vConst0; }
-        v_else {
-            sfpi::vFloat tmp = inp * inp;
-            tmp = tmp - sfpi::vConst1;
-            tmp = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-            tmp = tmp + inp;
+        v_if(inp < sfpi::vConst1) {
+            res = std::numeric_limits<float>::quiet_NaN();
+        }
+        v_elseif(inp == sfpi::vConst1) {
+            res = sfpi::vConst0;
+        }
+        v_elseif(inp > 10000.0f) {
+            sfpi::vFloat tmp = inp + inp;
             res = _calculate_log_body_no_init_(tmp);
+        }
+        v_else {
+            sfpi::vFloat sub1 = inp - sfpi::vConst1;
+            sfpi::vFloat add1 = inp + sfpi::vConst1;
+            sfpi::vFloat sqrt_term = _calculate_sqrt_body_<APPROXIMATION_MODE>(sub1 * add1);
+            sfpi::vFloat y = sub1 + sqrt_term;
+            res = calculate_log1p_fp32<is_fp32_dest_acc_en>(y);
         }
         v_endif;
         sfpi::dst_reg[0] = res;
@@ -811,17 +820,33 @@ inline void calculate_acosh() {
 }
 
 // asinh(x) = log(x + sqrt(x^2 + 1))
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_asinh() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat inp = sfpi::dst_reg[0];
-        sfpi::vFloat tmp = inp * inp + sfpi::vConst1;
-        tmp = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-        tmp = tmp + sfpi::abs(inp);
-        auto res = _calculate_log_body_no_init_(tmp);
-        v_if(inp < sfpi::vConst0) { res = -res; }
+        sfpi::vFloat abs_inp = sfpi::abs(inp);
+        sfpi::vFloat res;
+        v_if(abs_inp > 10000.0f) {
+            sfpi::vFloat tmp = abs_inp + abs_inp;
+            res = _calculate_log_body_no_init_(tmp);
+        }
+        v_else {
+            sfpi::vFloat x2 = abs_inp * abs_inp;
+            sfpi::vFloat sqrt_term = _calculate_sqrt_body_<APPROXIMATION_MODE>(x2 + sfpi::vConst1);
+            sfpi::vFloat den = sfpi::vConst1 + sqrt_term;
+            sfpi::vFloat tmp = sfpu_reciprocal_iter<APPROXIMATION_MODE ? 0 : 2>(den);
+            tmp = sfpi::copysgn(tmp, den);
+            if constexpr (is_fp32_dest_acc_en || APPROXIMATION_MODE) {
+                den = tmp;
+            } else {
+                den = sfpi::convert<sfpi::vFloat16b>(tmp, sfpi::RoundMode::Nearest);
+            }
+            sfpi::vFloat y = abs_inp + x2 * den;
+            res = calculate_log1p_fp32<is_fp32_dest_acc_en>(y);
+        }
         v_endif;
+        res = sfpi::copysgn(res, inp);
         sfpi::dst_reg[0] = res;
         sfpi::dst_reg++;
     }
@@ -841,8 +866,8 @@ inline void calculate_atanh() {
             res = sfpi::copysgn(inf, inp);
         }
         v_else {
-            sfpi::vFloat num = sfpi::vConst1 + inp;
-            sfpi::vFloat den = sfpi::vConst1 - inp;
+            sfpi::vFloat num = abs_inp + abs_inp;
+            sfpi::vFloat den = sfpi::vConst1 - abs_inp;
             sfpi::vFloat tmp = sfpu_reciprocal_iter<APPROXIMATION_MODE ? 0 : 2>(den);
             tmp = sfpi::copysgn(tmp, den);
             if constexpr (is_fp32_dest_acc_en || APPROXIMATION_MODE) {
@@ -850,9 +875,10 @@ inline void calculate_atanh() {
             } else {
                 den = sfpi::convert<sfpi::vFloat16b>(tmp, sfpi::RoundMode::Nearest);
             }
-            num = num * den;
-            den = _calculate_log_body_no_init_(num);
-            res = 0.5f * den;
+            sfpi::vFloat val = num * den;
+            sfpi::vFloat log_res = calculate_log1p_fp32<is_fp32_dest_acc_en>(val);
+            res = 0.5f * log_res;
+            res = sfpi::copysgn(res, inp);
         }
         v_endif;
         sfpi::dst_reg[0] = res;
@@ -860,14 +886,17 @@ inline void calculate_atanh() {
     }
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void init_inverse_hyperbolic() {
     sqrt_init<APPROXIMATION_MODE>();
+    sfpu_reciprocal_init<APPROXIMATION_MODE>();
+    log1p_init<APPROXIMATION_MODE, false, is_fp32_dest_acc_en>();
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void init_atanh() {
     sfpu_reciprocal_init<APPROXIMATION_MODE>();
+    log1p_init<APPROXIMATION_MODE, false, is_fp32_dest_acc_en>();
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -10,6 +10,57 @@
 namespace ckernel {
 namespace sfpu {
 
+template <bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat _sfpu_tanh_fp32_accurate_(sfpi::vFloat val) {
+    sfpi::vFloat result = sfpi::vConst0;
+
+    constexpr float POLYNOMIAL_THRESHOLD = 0.6f;
+
+    sfpi::vFloat abs_val = sfpi::abs(val);
+
+    v_if(abs_val < POLYNOMIAL_THRESHOLD) {
+        // Small |x|: Use minimax polynomial for better accuracy
+        // Polynomial coefficients found with Sollya using the following command:
+        // fpminimax(tanh(x)/x, [|0,2,4,6,8|], [|single...|], [-0.6; -2^(-40)] + [2^(-40); 0.6], relative);
+        sfpi::vFloat x2 = val * val;
+
+        sfpi::vFloat p = PolynomialEvaluator::eval(
+            x2,
+            0.999999940395355224609375f,
+            -0.33332359790802001953125f,
+            0.13310669362545013427734375f,
+            -5.21197654306888580322265625e-2f,
+            1.5497927553951740264892578125e-2f);
+
+        result = val * p;
+    }
+    v_else {
+        // Normal region: Use tanh(x) = sign(x) * (2*sigmoid(2*|x|) - 1)
+        sfpi::vFloat two_x = 2.f * abs_val;
+        sfpi::vFloat sig = _sfpu_sigmoid_<is_fp32_dest_acc_en>(two_x);
+
+        // Compute 2*sigmoid(2*|x|) - 1
+        sfpi::vFloat res_abs = 2.f * sig - sfpi::vConst1;
+        result = sfpi::copysgn(res_abs, val);
+
+        sfpi::vInt exponent = sfpi::exexp(val, sfpi::ExponentMode::NoDebias);
+        // exp==255: NaN (default) or ±Inf (mantissa==0)
+        v_if(exponent == 255) {
+            sfpi::vInt mantissa = sfpi::exman(val);
+            result = std::numeric_limits<float>::quiet_NaN();
+            v_if(mantissa == 0) {
+                sfpi::vFloat one = sfpi::vConst1;
+                result = sfpi::copysgn(one, val);
+            }
+            v_endif;
+        }
+        v_endif;
+    }
+    v_endif;
+
+    return result;
+}
+
 // Calculates tanh for number of rows of output SFPU ops (Quasar = 2 rows)
 inline void _calculate_tanh_sfp_rows_() {
     TTI_SFPLOAD(

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -31,44 +31,44 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_fp32_accurate_(sfpi::vFloat val) {
 
     constexpr float POLYNOMIAL_THRESHOLD = 0.6f;
 
-    sfpi::vInt exponent = sfpi::exexp(val, sfpi::ExponentMode::NoDebias);
-    sfpi::vInt mantissa = sfpi::exman(val);
-    // exp==255: NaN (default) or ±Inf (mantissa==0)
-    v_if(exponent == 255) {
-        result = std::numeric_limits<float>::quiet_NaN();
-        v_if(mantissa == 0) {
-            sfpi::vFloat one = sfpi::vConst1;
-            result = sfpi::copysgn(one, val);
-        }
-        v_endif;
+    sfpi::vFloat abs_val = sfpi::abs(val);
+
+    v_if(abs_val < POLYNOMIAL_THRESHOLD) {
+        // Small |x|: Use minimax polynomial for better accuracy
+        // Polynomial coefficients found with Sollya using the following command:
+        // fpminimax(tanh(x)/x, [|0,2,4,6,8|], [|single...|], [-0.6; -2^(-40)] + [2^(-40); 0.6], relative);
+        sfpi::vFloat x2 = val * val;
+
+        sfpi::vFloat p = PolynomialEvaluator::eval(
+            x2,
+            0.999999940395355224609375f,
+            -0.33332359790802001953125f,
+            0.13310669362545013427734375f,
+            -5.21197654306888580322265625e-2f,
+            1.5497927553951740264892578125e-2f);
+
+        result = val * p;
     }
     v_else {
-        sfpi::vFloat abs_val = sfpi::abs(val);
-
-        v_if(abs_val < POLYNOMIAL_THRESHOLD) {
-            // Small |x|: Use minimax polynomial for better accuracy
-            // Polynomial coefficients found with Sollya using the following command:
-            // fpminimax(tanh(x)/x, [|0,2,4,6,8|], [|single...|], [-0.6; -2^(-40)] + [2^(-40); 0.6], relative);
-            sfpi::vFloat x2 = val * val;
-
-            sfpi::vFloat p = PolynomialEvaluator::eval(
-                x2,
-                0.999999940395355224609375f,
-                -0.33332359790802001953125f,
-                0.13310669362545013427734375f,
-                -5.21197654306888580322265625e-2f,
-                1.5497927553951740264892578125e-2f);
-
-            result = val * p;
-            result = sfpi::copysgn(result, val);  // restore sign (i.e. tanh(-x) = -tanh(x))
+        sfpi::vInt exponent = sfpi::exexp(val, sfpi::ExponentMode::NoDebias);
+        // exp==255: NaN (default) or ±Inf (mantissa==0)
+        v_if(exponent == 255) {
+            sfpi::vInt mantissa = sfpi::exman(val);
+            result = std::numeric_limits<float>::quiet_NaN();
+            v_if(mantissa == 0) {
+                sfpi::vFloat one = sfpi::vConst1;
+                result = sfpi::copysgn(one, val);
+            }
+            v_endif;
         }
         v_else {
-            // Normal region: Use tanh(x) = 2*sigmoid(2x) - 1
-            sfpi::vFloat two_x = 2.f * val;
+            // Normal region: Use tanh(x) = sign(x) * (2*sigmoid(2*|x|) - 1)
+            sfpi::vFloat two_x = 2.f * abs_val;
             sfpi::vFloat sig = _sfpu_sigmoid_<is_fp32_dest_acc_en>(two_x);
 
-            // Compute 2*sigmoid(2x) - 1
-            result = 2.f * sig - sfpi::vConst1;
+            // Compute 2*sigmoid(2*|x|) - 1
+            sfpi::vFloat res_abs = 2.f * sig - sfpi::vConst1;
+            result = sfpi::copysgn(res_abs, val);
         }
         v_endif;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -12,6 +12,7 @@
 #include "ckernel_sfpu_sqrt_custom.h"
 #include "ckernel_sfpu_exp.h"
 #include "sfpu/ckernel_sfpu_log.h"
+#include "ckernel_sfpu_log1p.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
 #include "sfpi.h"
 
@@ -818,37 +819,63 @@ inline void _calculate_cosine_(const int iterations) {
 
 // https://en.wikipedia.org/wiki/Inverse_hyperbolic_functions#Definitions_in_terms_of_logarithms
 // acosh(x) = log(x + sqrt(x^2 - 1))
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_acosh() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat inp = sfpi::dst_reg[0];
-        v_if(inp < sfpi::vConst1) { sfpi::dst_reg[0] = std::numeric_limits<float>::quiet_NaN(); }
-        v_elseif(inp == sfpi::vConst1) { sfpi::dst_reg[0] = sfpi::vConst0; }
+        sfpi::vFloat res;
+        v_if(inp < sfpi::vConst1) {
+            res = std::numeric_limits<float>::quiet_NaN();
+        }
+        v_elseif(inp == sfpi::vConst1) {
+            res = sfpi::vConst0;
+        }
+        v_elseif(inp > 10000.0f) {
+            sfpi::vFloat tmp = inp + inp;
+            res = _calculate_log_body_no_init_(tmp);
+        }
         v_else {
-            sfpi::vFloat tmp = inp * inp;
-            tmp = tmp - sfpi::vConst1;
-            tmp = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-            tmp = tmp + inp;
-            sfpi::dst_reg[0] = _calculate_log_body_no_init_(tmp);
+            sfpi::vFloat sub1 = inp - sfpi::vConst1;
+            sfpi::vFloat add1 = inp + sfpi::vConst1;
+            sfpi::vFloat sqrt_term = _calculate_sqrt_body_<APPROXIMATION_MODE>(sub1 * add1);
+            sfpi::vFloat y = sub1 + sqrt_term;
+            res = calculate_log1p_fp32<is_fp32_dest_acc_en>(y);
         }
         v_endif;
+        sfpi::dst_reg[0] = res;
         sfpi::dst_reg++;
     }
 }
 
 // asinh(x) = log(x + sqrt(x^2 + 1))
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_asinh() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat inp = sfpi::dst_reg[0];
-        sfpi::vFloat tmp = inp * inp + sfpi::vConst1;
-        tmp = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-        tmp = tmp + sfpi::abs(inp);
-        auto res = _calculate_log_body_no_init_(tmp);
-        v_if(inp < sfpi::vConst0) { res = -res; }
+        sfpi::vFloat abs_inp = sfpi::abs(inp);
+        sfpi::vFloat res;
+        v_if(abs_inp > 10000.0f) {
+            sfpi::vFloat tmp = abs_inp + abs_inp;
+            res = _calculate_log_body_no_init_(tmp);
+        }
+        v_else {
+            sfpi::vFloat x2 = abs_inp * abs_inp;
+            sfpi::vFloat sqrt_term = _calculate_sqrt_body_<APPROXIMATION_MODE>(x2 + sfpi::vConst1);
+            sfpi::vFloat den = sfpi::vConst1 + sqrt_term;
+            sfpi::vFloat tmp = sfpu_reciprocal_iter<APPROXIMATION_MODE ? 0 : 2>(den);
+            tmp = sfpi::copysgn(tmp, den);
+            if constexpr (is_fp32_dest_acc_en || APPROXIMATION_MODE) {
+                den = tmp;
+            } else {
+                den = sfpi::convert<sfpi::vFloat16b>(tmp, sfpi::RoundMode::Nearest);
+            }
+            sfpi::vFloat y = abs_inp + x2 * den;
+            res = calculate_log1p_fp32<is_fp32_dest_acc_en>(y);
+        }
         v_endif;
+        res = sfpi::copysgn(res, inp);
         sfpi::dst_reg[0] = res;
         sfpi::dst_reg++;
     }
@@ -868,8 +895,8 @@ inline void calculate_atanh() {
             res = sfpi::copysgn(inf, inp);
         }
         v_else {
-            sfpi::vFloat num = sfpi::vConst1 + inp;
-            sfpi::vFloat den = sfpi::vConst1 - inp;
+            sfpi::vFloat num = abs_inp + abs_inp;
+            sfpi::vFloat den = sfpi::vConst1 - abs_inp;
             sfpi::vFloat tmp = sfpu_reciprocal_iter<APPROXIMATION_MODE ? 0 : 2>(den);
             tmp = sfpi::copysgn(tmp, den);
             if constexpr (is_fp32_dest_acc_en || APPROXIMATION_MODE) {
@@ -877,9 +904,10 @@ inline void calculate_atanh() {
             } else {
                 den = sfpi::convert<sfpi::vFloat16b>(tmp, sfpi::RoundMode::Nearest);
             }
-            num = num * den;
-            den = _calculate_log_body_no_init_(num);
-            res = 0.5f * den;
+            sfpi::vFloat val = num * den;
+            sfpi::vFloat log_res = calculate_log1p_fp32<is_fp32_dest_acc_en>(val);
+            res = 0.5f * log_res;
+            res = sfpi::copysgn(res, inp);
         }
         v_endif;
         sfpi::dst_reg[0] = res;
@@ -887,14 +915,17 @@ inline void calculate_atanh() {
     }
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void init_inverse_hyperbolic() {
     sqrt_init<APPROXIMATION_MODE>();
+    sfpu_reciprocal_init<APPROXIMATION_MODE>();
+    log1p_init<APPROXIMATION_MODE, false, is_fp32_dest_acc_en>();
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void init_atanh() {
     sfpu_reciprocal_init<APPROXIMATION_MODE>();
+    log1p_init<APPROXIMATION_MODE, false, is_fp32_dest_acc_en>();
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/trigonometry.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/trigonometry.h
@@ -73,7 +73,7 @@ ALWI void cos_tile(uint32_t idst) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void acosh_tile_init() { MATH(SFPU_UNARY_INIT_FN(acosh, ckernel::sfpu::init_inverse_hyperbolic, (APPROX))); }
+ALWI void acosh_tile_init() { MATH(SFPU_UNARY_INIT_FN(acosh, ckernel::sfpu::init_inverse_hyperbolic, (APPROX, DST_ACCUM_MODE))); }
 
 // clang-format off
 /**
@@ -91,7 +91,7 @@ ALWI void acosh_tile_init() { MATH(SFPU_UNARY_INIT_FN(acosh, ckernel::sfpu::init
 // clang-format on
 ALWI void acosh_tile(uint32_t idst) {
     MATH(SFPU_UNARY_CALL(
-        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_acosh, (APPROX, 8 /*ITERATIONS*/), idst, VectorMode::RC));
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_acosh, (APPROX, DST_ACCUM_MODE, 8 /*ITERATIONS*/), idst, VectorMode::RC));
 }
 
 /**
@@ -126,7 +126,7 @@ ALWI void tan_tile(uint32_t idst) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void asinh_tile_init() { MATH(SFPU_UNARY_INIT_FN(asinh, ckernel::sfpu::init_inverse_hyperbolic, (APPROX))); }
+ALWI void asinh_tile_init() { MATH(SFPU_UNARY_INIT_FN(asinh, ckernel::sfpu::init_inverse_hyperbolic, (APPROX, DST_ACCUM_MODE))); }
 
 // clang-format off
 /**
@@ -144,13 +144,13 @@ ALWI void asinh_tile_init() { MATH(SFPU_UNARY_INIT_FN(asinh, ckernel::sfpu::init
 // clang-format on
 ALWI void asinh_tile(uint32_t idst) {
     MATH(SFPU_UNARY_CALL(
-        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_asinh, (APPROX, 8 /*ITERATIONS*/), idst, VectorMode::RC));
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_asinh, (APPROX, DST_ACCUM_MODE, 8 /*ITERATIONS*/), idst, VectorMode::RC));
 }
 
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void atanh_tile_init() { MATH(SFPU_UNARY_INIT_FN(atanh, ckernel::sfpu::init_atanh, (APPROX))); }
+ALWI void atanh_tile_init() { MATH(SFPU_UNARY_INIT_FN(atanh, ckernel::sfpu::init_atanh, (APPROX, DST_ACCUM_MODE))); }
 
 // clang-format off
 /**

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
@@ -318,11 +318,11 @@ void call_unary_sfpu_operation_init()
 {
     if constexpr (OPERATION == SfpuType::acosh || OPERATION == SfpuType::asinh)
     {
-        llk_math_eltwise_unary_sfpu_init<OPERATION>(init_inverse_hyperbolic<APPROX_MODE>);
+        llk_math_eltwise_unary_sfpu_init<OPERATION>(init_inverse_hyperbolic<APPROX_MODE, is_fp32_dest_acc_en>);
     }
     else if constexpr (OPERATION == SfpuType::atanh)
     {
-        llk_math_eltwise_unary_sfpu_init<OPERATION>(init_atanh<APPROX_MODE>);
+        llk_math_eltwise_unary_sfpu_init<OPERATION>(init_atanh<APPROX_MODE, is_fp32_dest_acc_en>);
     }
     else if constexpr (OPERATION == SfpuType::cosine)
     {
@@ -432,11 +432,11 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
     }
     else if constexpr (OPERATION == SfpuType::acosh)
     {
-        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_acosh, (APPROX_MODE, ITERATIONS), dst_index, vector_mode);
+        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_acosh, (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS), dst_index, vector_mode);
     }
     else if constexpr (OPERATION == SfpuType::asinh)
     {
-        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_asinh, (APPROX_MODE, ITERATIONS), dst_index, vector_mode);
+        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_asinh, (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS), dst_index, vector_mode);
     }
     else if constexpr (OPERATION == SfpuType::atanh)
     {


### PR DESCRIPTION
### Technical Summary

This PR implements numerically stable log1p-based optimizations for `atanh`, `asinh`, and `acosh` SFPU kernels on Wormhole B0 and Blackhole architectures.

#### Implementations:
1. **`atanh(x)`**:
   Optimized using the identity $\text{atanh}(x) = 0.5 \ln(1 + 2x/(1-x))$. To maximize numerical stability and symmetry, this is formulated as:
   $$\text{atanh}(x) = \text{sign}(x) \cdot 0.5 \cdot \text{log1p}\left(\frac{2|x|}{1 - |x|}\right)$$
   This avoids precision loss for values close to 0 and provides symmetric handling.

2. **`asinh(x)`**:
   Optimized using `log1p` to maintain high precision for small values near 0:
   $$\text{asinh}(x) = \text{sign}(x) \cdot \text{log1p}\left(|x| + \frac{x^2}{1 + \sqrt{x^2 + 1}}\right)$$
   For large inputs ($|x| > 10000.0$), the approximation $\text{asinh}(x) \approx \text{sign}(x) \cdot \ln(2|x|)$ is used to prevent $x^2$ overflow.

3. **`acosh(x)`**:
   Optimized using `log1p` near $x=1$:
   $$\text{acosh}(x) = \text{log1p}\left((x-1) + \sqrt{(x-1)(x+1)}\right)$$
   This eliminates subtraction cancellation when $x \approx 1$. For large inputs ($x > 10000.0$), it branches to $\text{acosh}(x) \approx \ln(2x)$ to avoid multiplication overflow.

4. **Initialization & Configuration**:
   Updated `init_inverse_hyperbolic` and `init_atanh` in `ckernel_sfpu_trigonometry.h` to call `log1p_init` to ensure the program constants (`vConstFloatPrgm0/1/2`) are properly loaded. The template parameters are updated throughout the compute helper API (`trigonometry.h`) and tests (`sfpu_operations.h`) to pass down the destination accumulator format flag (`is_fp32_dest_acc_en` / `DST_ACCUM_MODE`).

Payment Info: PayPal: https://paypal.me/sureshc26