### PR TITLE
Add FFT and inverse FFT support

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/test_fft.py
+++ b/tests/ttnn/nightly/unit_tests/operations/test_fft.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize("size", [32, 64, 128])
+@pytest.mark.parametrize("dim", [-1, -2])
+def test_fft_accuracy(device, dtype, size, dim):
+    # Setup input shape
+    # We use a 4D shape standard in ttnn
+    input_shape = (1, 1, 64, 128) if dim == -1 else (1, 1, 128, 64)
+    # Ensure the dimension size matches 'size'
+    shape_list = list(input_shape)
+    shape_list[dim] = size
+    input_shape = tuple(shape_list)
+
+    # Generate random real and imaginary parts
+    torch.manual_seed(42)
+    x_real = torch.randn(input_shape, dtype=torch.float32)
+    x_imag = torch.randn(input_shape, dtype=torch.float32)
+    x_torch = torch.complex(x_real, x_imag)
+
+    # Convert torch complex tensor to ttnn ComplexTensor on device
+    t_real = ttnn.Tensor(x_real, dtype).to(ttnn.TILE_LAYOUT).to(device)
+    t_imag = ttnn.Tensor(x_imag, dtype).to(ttnn.TILE_LAYOUT).to(device)
+    t_complex = ttnn.complex_tensor(t_real, t_imag)
+
+    # Run ttnn FFT
+    y_complex = ttnn.fft.fft(t_complex, dim=dim)
+
+    # Extract real and imag parts, bring back to host
+    y_real_dev = y_complex.real.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+    y_imag_dev = y_complex.imag.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+    y_dev = torch.complex(y_real_dev, y_imag_dev)
+
+    # Run PyTorch reference
+    y_torch = torch.fft.fft(x_torch, dim=dim)
+
+    # Verify accuracy
+    passing, output = comp_pcc(y_torch, y_dev, 0.99)
+    assert passing, f"FFT failed: {output}"
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize("size", [32, 64, 128])
+@pytest.mark.parametrize("dim", [-1, -2])
+def test_ifft_accuracy(device, dtype, size, dim):
+    # Setup input shape
+    input_shape = (1, 1, 64, 128) if dim == -1 else (1, 1, 128, 64)
+    shape_list = list(input_shape)
+    shape_list[dim] = size
+    input_shape = tuple(shape_list)
+
+    torch.manual_seed(42)
+    x_real = torch.randn(input_shape, dtype=torch.float32)
+    x_imag = torch.randn(input_shape, dtype=torch.float32)
+    x_torch = torch.complex(x_real, x_imag)
+
+    t_real = ttnn.Tensor(x_real, dtype).to(ttnn.TILE_LAYOUT).to(device)
+    t_imag = ttnn.Tensor(x_imag, dtype).to(ttnn.TILE_LAYOUT).to(device)
+    t_complex = ttnn.complex_tensor(t_real, t_imag)
+
+    # Run ttnn IFFT
+    y_complex = ttnn.fft.ifft(t_complex, dim=dim)
+
+    # Extract real and imag parts, bring back to host
+    y_real_dev = y_complex.real.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+    y_imag_dev = y_complex.imag.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+    y_dev = torch.complex(y_real_dev, y_imag_dev)
+
+    # Run PyTorch reference
+    y_torch = torch.fft.ifft(x_torch, dim=dim)
+
+    # Verify accuracy
+    passing, output = comp_pcc(y_torch, y_dev, 0.99)
+    assert passing, f"IFFT failed: {output}"
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+def test_fft_real_input(device, dtype):
+    # Test FFT with real input tensor
+    input_shape = (1, 1, 32, 64)
+    x_real = torch.randn(input_shape, dtype=torch.float32)
+    t_real = ttnn.Tensor(x_real, dtype).to(ttnn.TILE_LAYOUT).to(device)
+
+    # Run ttnn FFT
+    y_complex = ttnn.fft.fft(t_real, dim=-1)
+
+    y_real_dev = y_complex.real.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+    y_imag_dev = y_complex.imag.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+    y_dev = torch.complex(y_real_dev, y_imag_dev)
+
+    x_torch = torch.complex(x_real, torch.zeros_like(x_real))
+    y_torch = torch.fft.fft(x_torch, dim=-1)
+
+    passing, output = comp_pcc(y_torch, y_dev, 0.99)
+    assert passing, f"Real FFT failed: {output}"

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -31,44 +31,44 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_fp32_accurate_(sfpi::vFloat val) {
 
     constexpr float POLYNOMIAL_THRESHOLD = 0.6f;
 
-    sfpi::vInt exponent = sfpi::exexp(val, sfpi::ExponentMode::NoDebias);
-    sfpi::vInt mantissa = sfpi::exman(val);
-    // exp==255: NaN (default) or ±Inf (mantissa==0)
-    v_if(exponent == 255) {
-        result = std::numeric_limits<float>::quiet_NaN();
-        v_if(mantissa == 0) {
-            sfpi::vFloat one = sfpi::vConst1;
-            result = sfpi::copysgn(one, val);
-        }
-        v_endif;
+    sfpi::vFloat abs_val = sfpi::abs(val);
+
+    v_if(abs_val < POLYNOMIAL_THRESHOLD) {
+        // Small |x|: Use minimax polynomial for better accuracy
+        // Polynomial coefficients found with Sollya using the following command:
+        // fpminimax(tanh(x)/x, [|0,2,4,6,8|], [|single...|], [-0.6; -2^(-40)] + [2^(-40); 0.6], relative);
+        sfpi::vFloat x2 = val * val;
+
+        sfpi::vFloat p = PolynomialEvaluator::eval(
+            x2,
+            0.999999940395355224609375f,
+            -0.33332359790802001953125f,
+            0.13310669362545013427734375f,
+            -5.21197654306888580322265625e-2f,
+            1.5497927553951740264892578125e-2f);
+
+        result = val * p;
     }
     v_else {
-        sfpi::vFloat abs_val = sfpi::abs(val);
-
-        v_if(abs_val < POLYNOMIAL_THRESHOLD) {
-            // Small |x|: Use minimax polynomial for better accuracy
-            // Polynomial coefficients found with Sollya using the following command:
-            // fpminimax(tanh(x)/x, [|0,2,4,6,8|], [|single...|], [-0.6; -2^(-40)] + [2^(-40); 0.6], relative);
-            sfpi::vFloat x2 = val * val;
-
-            sfpi::vFloat p = PolynomialEvaluator::eval(
-                x2,
-                0.999999940395355224609375f,
-                -0.33332359790802001953125f,
-                0.13310669362545013427734375f,
-                -5.21197654306888580322265625e-2f,
-                1.5497927553951740264892578125e-2f);
-
-            result = val * p;
-            result = sfpi::copysgn(result, val);  // Preserve input sign on zero (tanh(-0.0) = -0.0);
+        sfpi::vInt exponent = sfpi::exexp(val, sfpi::ExponentMode::NoDebias);
+        // exp==255: NaN (default) or ±Inf (mantissa==0)
+        v_if(exponent == 255) {
+            sfpi::vInt mantissa = sfpi::exman(val);
+            result = std::numeric_limits<float>::quiet_NaN();
+            v_if(mantissa == 0) {
+                sfpi::vFloat one = sfpi::vConst1;
+                result = sfpi::copysgn(one, val);
+            }
+            v_endif;
         }
         v_else {
-            // Normal region: Use tanh(x) = 2*sigmoid(2x) - 1
-            sfpi::vFloat two_x = 2.f * val;
+            // Normal region: Use tanh(x) = sign(x) * (2*sigmoid(2*|x|) - 1)
+            sfpi::vFloat two_x = 2.f * abs_val;
             sfpi::vFloat sig = _sfpu_sigmoid_<is_fp32_dest_acc_en>(two_x);
 
-            // Compute 2*sigmoid(2x) - 1
-            result = 2.f * sig - sfpi::vConst1;
+            // Compute 2*sigmoid(2*|x|) - 1
+            sfpi::vFloat res_abs = 2.f * sig - sfpi::vConst1;
+            result = sfpi::copysgn(res_abs, val);
         }
         v_endif;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -12,6 +12,7 @@
 #include "ckernel_sfpu_sqrt_custom.h"
 #include "ckernel_sfpu_exp.h"
 #include "sfpu/ckernel_sfpu_log.h"
+#include "ckernel_sfpu_log1p.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
 #include "sfpi.h"
 
@@ -789,20 +790,28 @@ inline void _calculate_cosine_(const int iterations) {
 
 // https://en.wikipedia.org/wiki/Inverse_hyperbolic_functions#Definitions_in_terms_of_logarithms
 // acosh(x) = log(x + sqrt(x^2 - 1))
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_acosh() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat inp = sfpi::dst_reg[0];
         sfpi::vFloat res;
-        v_if(inp < sfpi::vConst1) { res = std::numeric_limits<float>::quiet_NaN(); }
-        v_elseif(inp == sfpi::vConst1) { res = sfpi::vConst0; }
-        v_else {
-            sfpi::vFloat tmp = inp * inp;
-            tmp = tmp - sfpi::vConst1;
-            tmp = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-            tmp = tmp + inp;
+        v_if(inp < sfpi::vConst1) {
+            res = std::numeric_limits<float>::quiet_NaN();
+        }
+        v_elseif(inp == sfpi::vConst1) {
+            res = sfpi::vConst0;
+        }
+        v_elseif(inp > 10000.0f) {
+            sfpi::vFloat tmp = inp + inp;
             res = _calculate_log_body_no_init_(tmp);
+        }
+        v_else {
+            sfpi::vFloat sub1 = inp - sfpi::vConst1;
+            sfpi::vFloat add1 = inp + sfpi::vConst1;
+            sfpi::vFloat sqrt_term = _calculate_sqrt_body_<APPROXIMATION_MODE>(sub1 * add1);
+            sfpi::vFloat y = sub1 + sqrt_term;
+            res = calculate_log1p_fp32<is_fp32_dest_acc_en>(y);
         }
         v_endif;
         sfpi::dst_reg[0] = res;
@@ -811,17 +820,33 @@ inline void calculate_acosh() {
 }
 
 // asinh(x) = log(x + sqrt(x^2 + 1))
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_asinh() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat inp = sfpi::dst_reg[0];
-        sfpi::vFloat tmp = inp * inp + sfpi::vConst1;
-        tmp = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-        tmp = tmp + sfpi::abs(inp);
-        auto res = _calculate_log_body_no_init_(tmp);
-        v_if(inp < sfpi::vConst0) { res = -res; }
+        sfpi::vFloat abs_inp = sfpi::abs(inp);
+        sfpi::vFloat res;
+        v_if(abs_inp > 10000.0f) {
+            sfpi::vFloat tmp = abs_inp + abs_inp;
+            res = _calculate_log_body_no_init_(tmp);
+        }
+        v_else {
+            sfpi::vFloat x2 = abs_inp * abs_inp;
+            sfpi::vFloat sqrt_term = _calculate_sqrt_body_<APPROXIMATION_MODE>(x2 + sfpi::vConst1);
+            sfpi::vFloat den = sfpi::vConst1 + sqrt_term;
+            sfpi::vFloat tmp = sfpu_reciprocal_iter<APPROXIMATION_MODE ? 0 : 2>(den);
+            tmp = sfpi::copysgn(tmp, den);
+            if constexpr (is_fp32_dest_acc_en || APPROXIMATION_MODE) {
+                den = tmp;
+            } else {
+                den = sfpi::convert<sfpi::vFloat16b>(tmp, sfpi::RoundMode::Nearest);
+            }
+            sfpi::vFloat y = abs_inp + x2 * den;
+            res = calculate_log1p_fp32<is_fp32_dest_acc_en>(y);
+        }
         v_endif;
+        res = sfpi::copysgn(res, inp);
         sfpi::dst_reg[0] = res;
         sfpi::dst_reg++;
     }
@@ -841,8 +866,8 @@ inline void calculate_atanh() {
             res = sfpi::copysgn(inf, inp);
         }
         v_else {
-            sfpi::vFloat num = sfpi::vConst1 + inp;
-            sfpi::vFloat den = sfpi::vConst1 - inp;
+            sfpi::vFloat num = abs_inp + abs_inp;
+            sfpi::vFloat den = sfpi::vConst1 - abs_inp;
             sfpi::vFloat tmp = sfpu_reciprocal_iter<APPROXIMATION_MODE ? 0 : 2>(den);
             tmp = sfpi::copysgn(tmp, den);
             if constexpr (is_fp32_dest_acc_en || APPROXIMATION_MODE) {
@@ -850,9 +875,10 @@ inline void calculate_atanh() {
             } else {
                 den = sfpi::convert<sfpi::vFloat16b>(tmp, sfpi::RoundMode::Nearest);
             }
-            num = num * den;
-            den = _calculate_log_body_no_init_(num);
-            res = 0.5f * den;
+            sfpi::vFloat val = num * den;
+            sfpi::vFloat log_res = calculate_log1p_fp32<is_fp32_dest_acc_en>(val);
+            res = 0.5f * log_res;
+            res = sfpi::copysgn(res, inp);
         }
         v_endif;
         sfpi::dst_reg[0] = res;
@@ -860,14 +886,17 @@ inline void calculate_atanh() {
     }
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void init_inverse_hyperbolic() {
     sqrt_init<APPROXIMATION_MODE>();
+    sfpu_reciprocal_init<APPROXIMATION_MODE>();
+    log1p_init<APPROXIMATION_MODE, false, is_fp32_dest_acc_en>();
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void init_atanh() {
     sfpu_reciprocal_init<APPROXIMATION_MODE>();
+    log1p_init<APPROXIMATION_MODE, false, is_fp32_dest_acc_en>();
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -10,6 +10,57 @@
 namespace ckernel {
 namespace sfpu {
 
+template <bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat _sfpu_tanh_fp32_accurate_(sfpi::vFloat val) {
+    sfpi::vFloat result = sfpi::vConst0;
+
+    constexpr float POLYNOMIAL_THRESHOLD = 0.6f;
+
+    sfpi::vFloat abs_val = sfpi::abs(val);
+
+    v_if(abs_val < POLYNOMIAL_THRESHOLD) {
+        // Small |x|: Use minimax polynomial for better accuracy
+        // Polynomial coefficients found with Sollya using the following command:
+        // fpminimax(tanh(x)/x, [|0,2,4,6,8|], [|single...|], [-0.6; -2^(-40)] + [2^(-40); 0.6], relative);
+        sfpi::vFloat x2 = val * val;
+
+        sfpi::vFloat p = PolynomialEvaluator::eval(
+            x2,
+            0.999999940395355224609375f,
+            -0.33332359790802001953125f,
+            0.13310669362545013427734375f,
+            -5.21197654306888580322265625e-2f,
+            1.5497927553951740264892578125e-2f);
+
+        result = val * p;
+    }
+    v_else {
+        // Normal region: Use tanh(x) = sign(x) * (2*sigmoid(2*|x|) - 1)
+        sfpi::vFloat two_x = 2.f * abs_val;
+        sfpi::vFloat sig = _sfpu_sigmoid_<is_fp32_dest_acc_en>(two_x);
+
+        // Compute 2*sigmoid(2*|x|) - 1
+        sfpi::vFloat res_abs = 2.f * sig - sfpi::vConst1;
+        result = sfpi::copysgn(res_abs, val);
+
+        sfpi::vInt exponent = sfpi::exexp(val, sfpi::ExponentMode::NoDebias);
+        // exp==255: NaN (default) or ±Inf (mantissa==0)
+        v_if(exponent == 255) {
+            sfpi::vInt mantissa = sfpi::exman(val);
+            result = std::numeric_limits<float>::quiet_NaN();
+            v_if(mantissa == 0) {
+                sfpi::vFloat one = sfpi::vConst1;
+                result = sfpi::copysgn(one, val);
+            }
+            v_endif;
+        }
+        v_endif;
+    }
+    v_endif;
+
+    return result;
+}
+
 // Calculates tanh for number of rows of output SFPU ops (Quasar = 2 rows)
 inline void _calculate_tanh_sfp_rows_() {
     TTI_SFPLOAD(

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -31,44 +31,44 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_fp32_accurate_(sfpi::vFloat val) {
 
     constexpr float POLYNOMIAL_THRESHOLD = 0.6f;
 
-    sfpi::vInt exponent = sfpi::exexp(val, sfpi::ExponentMode::NoDebias);
-    sfpi::vInt mantissa = sfpi::exman(val);
-    // exp==255: NaN (default) or ±Inf (mantissa==0)
-    v_if(exponent == 255) {
-        result = std::numeric_limits<float>::quiet_NaN();
-        v_if(mantissa == 0) {
-            sfpi::vFloat one = sfpi::vConst1;
-            result = sfpi::copysgn(one, val);
-        }
-        v_endif;
+    sfpi::vFloat abs_val = sfpi::abs(val);
+
+    v_if(abs_val < POLYNOMIAL_THRESHOLD) {
+        // Small |x|: Use minimax polynomial for better accuracy
+        // Polynomial coefficients found with Sollya using the following command:
+        // fpminimax(tanh(x)/x, [|0,2,4,6,8|], [|single...|], [-0.6; -2^(-40)] + [2^(-40); 0.6], relative);
+        sfpi::vFloat x2 = val * val;
+
+        sfpi::vFloat p = PolynomialEvaluator::eval(
+            x2,
+            0.999999940395355224609375f,
+            -0.33332359790802001953125f,
+            0.13310669362545013427734375f,
+            -5.21197654306888580322265625e-2f,
+            1.5497927553951740264892578125e-2f);
+
+        result = val * p;
     }
     v_else {
-        sfpi::vFloat abs_val = sfpi::abs(val);
-
-        v_if(abs_val < POLYNOMIAL_THRESHOLD) {
-            // Small |x|: Use minimax polynomial for better accuracy
-            // Polynomial coefficients found with Sollya using the following command:
-            // fpminimax(tanh(x)/x, [|0,2,4,6,8|], [|single...|], [-0.6; -2^(-40)] + [2^(-40); 0.6], relative);
-            sfpi::vFloat x2 = val * val;
-
-            sfpi::vFloat p = PolynomialEvaluator::eval(
-                x2,
-                0.999999940395355224609375f,
-                -0.33332359790802001953125f,
-                0.13310669362545013427734375f,
-                -5.21197654306888580322265625e-2f,
-                1.5497927553951740264892578125e-2f);
-
-            result = val * p;
-            result = sfpi::copysgn(result, val);  // restore sign (i.e. tanh(-x) = -tanh(x))
+        sfpi::vInt exponent = sfpi::exexp(val, sfpi::ExponentMode::NoDebias);
+        // exp==255: NaN (default) or ±Inf (mantissa==0)
+        v_if(exponent == 255) {
+            sfpi::vInt mantissa = sfpi::exman(val);
+            result = std::numeric_limits<float>::quiet_NaN();
+            v_if(mantissa == 0) {
+                sfpi::vFloat one = sfpi::vConst1;
+                result = sfpi::copysgn(one, val);
+            }
+            v_endif;
         }
         v_else {
-            // Normal region: Use tanh(x) = 2*sigmoid(2x) - 1
-            sfpi::vFloat two_x = 2.f * val;
+            // Normal region: Use tanh(x) = sign(x) * (2*sigmoid(2*|x|) - 1)
+            sfpi::vFloat two_x = 2.f * abs_val;
             sfpi::vFloat sig = _sfpu_sigmoid_<is_fp32_dest_acc_en>(two_x);
 
-            // Compute 2*sigmoid(2x) - 1
-            result = 2.f * sig - sfpi::vConst1;
+            // Compute 2*sigmoid(2*|x|) - 1
+            sfpi::vFloat res_abs = 2.f * sig - sfpi::vConst1;
+            result = sfpi::copysgn(res_abs, val);
         }
         v_endif;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -12,6 +12,7 @@
 #include "ckernel_sfpu_sqrt_custom.h"
 #include "ckernel_sfpu_exp.h"
 #include "sfpu/ckernel_sfpu_log.h"
+#include "ckernel_sfpu_log1p.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
 #include "sfpi.h"
 
@@ -818,37 +819,63 @@ inline void _calculate_cosine_(const int iterations) {
 
 // https://en.wikipedia.org/wiki/Inverse_hyperbolic_functions#Definitions_in_terms_of_logarithms
 // acosh(x) = log(x + sqrt(x^2 - 1))
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_acosh() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat inp = sfpi::dst_reg[0];
-        v_if(inp < sfpi::vConst1) { sfpi::dst_reg[0] = std::numeric_limits<float>::quiet_NaN(); }
-        v_elseif(inp == sfpi::vConst1) { sfpi::dst_reg[0] = sfpi::vConst0; }
+        sfpi::vFloat res;
+        v_if(inp < sfpi::vConst1) {
+            res = std::numeric_limits<float>::quiet_NaN();
+        }
+        v_elseif(inp == sfpi::vConst1) {
+            res = sfpi::vConst0;
+        }
+        v_elseif(inp > 10000.0f) {
+            sfpi::vFloat tmp = inp + inp;
+            res = _calculate_log_body_no_init_(tmp);
+        }
         v_else {
-            sfpi::vFloat tmp = inp * inp;
-            tmp = tmp - sfpi::vConst1;
-            tmp = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-            tmp = tmp + inp;
-            sfpi::dst_reg[0] = _calculate_log_body_no_init_(tmp);
+            sfpi::vFloat sub1 = inp - sfpi::vConst1;
+            sfpi::vFloat add1 = inp + sfpi::vConst1;
+            sfpi::vFloat sqrt_term = _calculate_sqrt_body_<APPROXIMATION_MODE>(sub1 * add1);
+            sfpi::vFloat y = sub1 + sqrt_term;
+            res = calculate_log1p_fp32<is_fp32_dest_acc_en>(y);
         }
         v_endif;
+        sfpi::dst_reg[0] = res;
         sfpi::dst_reg++;
     }
 }
 
 // asinh(x) = log(x + sqrt(x^2 + 1))
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_asinh() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat inp = sfpi::dst_reg[0];
-        sfpi::vFloat tmp = inp * inp + sfpi::vConst1;
-        tmp = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-        tmp = tmp + sfpi::abs(inp);
-        auto res = _calculate_log_body_no_init_(tmp);
-        v_if(inp < sfpi::vConst0) { res = -res; }
+        sfpi::vFloat abs_inp = sfpi::abs(inp);
+        sfpi::vFloat res;
+        v_if(abs_inp > 10000.0f) {
+            sfpi::vFloat tmp = abs_inp + abs_inp;
+            res = _calculate_log_body_no_init_(tmp);
+        }
+        v_else {
+            sfpi::vFloat x2 = abs_inp * abs_inp;
+            sfpi::vFloat sqrt_term = _calculate_sqrt_body_<APPROXIMATION_MODE>(x2 + sfpi::vConst1);
+            sfpi::vFloat den = sfpi::vConst1 + sqrt_term;
+            sfpi::vFloat tmp = sfpu_reciprocal_iter<APPROXIMATION_MODE ? 0 : 2>(den);
+            tmp = sfpi::copysgn(tmp, den);
+            if constexpr (is_fp32_dest_acc_en || APPROXIMATION_MODE) {
+                den = tmp;
+            } else {
+                den = sfpi::convert<sfpi::vFloat16b>(tmp, sfpi::RoundMode::Nearest);
+            }
+            sfpi::vFloat y = abs_inp + x2 * den;
+            res = calculate_log1p_fp32<is_fp32_dest_acc_en>(y);
+        }
         v_endif;
+        res = sfpi::copysgn(res, inp);
         sfpi::dst_reg[0] = res;
         sfpi::dst_reg++;
     }
@@ -868,8 +895,8 @@ inline void calculate_atanh() {
             res = sfpi::copysgn(inf, inp);
         }
         v_else {
-            sfpi::vFloat num = sfpi::vConst1 + inp;
-            sfpi::vFloat den = sfpi::vConst1 - inp;
+            sfpi::vFloat num = abs_inp + abs_inp;
+            sfpi::vFloat den = sfpi::vConst1 - abs_inp;
             sfpi::vFloat tmp = sfpu_reciprocal_iter<APPROXIMATION_MODE ? 0 : 2>(den);
             tmp = sfpi::copysgn(tmp, den);
             if constexpr (is_fp32_dest_acc_en || APPROXIMATION_MODE) {
@@ -877,9 +904,10 @@ inline void calculate_atanh() {
             } else {
                 den = sfpi::convert<sfpi::vFloat16b>(tmp, sfpi::RoundMode::Nearest);
             }
-            num = num * den;
-            den = _calculate_log_body_no_init_(num);
-            res = 0.5f * den;
+            sfpi::vFloat val = num * den;
+            sfpi::vFloat log_res = calculate_log1p_fp32<is_fp32_dest_acc_en>(val);
+            res = 0.5f * log_res;
+            res = sfpi::copysgn(res, inp);
         }
         v_endif;
         sfpi::dst_reg[0] = res;
@@ -887,14 +915,17 @@ inline void calculate_atanh() {
     }
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void init_inverse_hyperbolic() {
     sqrt_init<APPROXIMATION_MODE>();
+    sfpu_reciprocal_init<APPROXIMATION_MODE>();
+    log1p_init<APPROXIMATION_MODE, false, is_fp32_dest_acc_en>();
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void init_atanh() {
     sfpu_reciprocal_init<APPROXIMATION_MODE>();
+    log1p_init<APPROXIMATION_MODE, false, is_fp32_dest_acc_en>();
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/trigonometry.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/trigonometry.h
@@ -73,7 +73,7 @@ ALWI void cos_tile(uint32_t idst) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void acosh_tile_init() { MATH(SFPU_UNARY_INIT_FN(acosh, ckernel::sfpu::init_inverse_hyperbolic, (APPROX))); }
+ALWI void acosh_tile_init() { MATH(SFPU_UNARY_INIT_FN(acosh, ckernel::sfpu::init_inverse_hyperbolic, (APPROX, DST_ACCUM_MODE))); }
 
 // clang-format off
 /**
@@ -91,7 +91,7 @@ ALWI void acosh_tile_init() { MATH(SFPU_UNARY_INIT_FN(acosh, ckernel::sfpu::init
 // clang-format on
 ALWI void acosh_tile(uint32_t idst) {
     MATH(SFPU_UNARY_CALL(
-        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_acosh, (APPROX, 8 /*ITERATIONS*/), idst, VectorMode::RC));
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_acosh, (APPROX, DST_ACCUM_MODE, 8 /*ITERATIONS*/), idst, VectorMode::RC));
 }
 
 /**
@@ -126,7 +126,7 @@ ALWI void tan_tile(uint32_t idst) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void asinh_tile_init() { MATH(SFPU_UNARY_INIT_FN(asinh, ckernel::sfpu::init_inverse_hyperbolic, (APPROX))); }
+ALWI void asinh_tile_init() { MATH(SFPU_UNARY_INIT_FN(asinh, ckernel::sfpu::init_inverse_hyperbolic, (APPROX, DST_ACCUM_MODE))); }
 
 // clang-format off
 /**
@@ -144,13 +144,13 @@ ALWI void asinh_tile_init() { MATH(SFPU_UNARY_INIT_FN(asinh, ckernel::sfpu::init
 // clang-format on
 ALWI void asinh_tile(uint32_t idst) {
     MATH(SFPU_UNARY_CALL(
-        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_asinh, (APPROX, 8 /*ITERATIONS*/), idst, VectorMode::RC));
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_asinh, (APPROX, DST_ACCUM_MODE, 8 /*ITERATIONS*/), idst, VectorMode::RC));
 }
 
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void atanh_tile_init() { MATH(SFPU_UNARY_INIT_FN(atanh, ckernel::sfpu::init_atanh, (APPROX))); }
+ALWI void atanh_tile_init() { MATH(SFPU_UNARY_INIT_FN(atanh, ckernel::sfpu::init_atanh, (APPROX, DST_ACCUM_MODE))); }
 
 // clang-format off
 /**

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
@@ -318,11 +318,11 @@ void call_unary_sfpu_operation_init()
 {
     if constexpr (OPERATION == SfpuType::acosh || OPERATION == SfpuType::asinh)
     {
-        llk_math_eltwise_unary_sfpu_init<OPERATION>(init_inverse_hyperbolic<APPROX_MODE>);
+        llk_math_eltwise_unary_sfpu_init<OPERATION>(init_inverse_hyperbolic<APPROX_MODE, is_fp32_dest_acc_en>);
     }
     else if constexpr (OPERATION == SfpuType::atanh)
     {
-        llk_math_eltwise_unary_sfpu_init<OPERATION>(init_atanh<APPROX_MODE>);
+        llk_math_eltwise_unary_sfpu_init<OPERATION>(init_atanh<APPROX_MODE, is_fp32_dest_acc_en>);
     }
     else if constexpr (OPERATION == SfpuType::cosine)
     {
@@ -432,11 +432,11 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
     }
     else if constexpr (OPERATION == SfpuType::acosh)
     {
-        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_acosh, (APPROX_MODE, ITERATIONS), dst_index, vector_mode);
+        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_acosh, (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS), dst_index, vector_mode);
     }
     else if constexpr (OPERATION == SfpuType::asinh)
     {
-        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_asinh, (APPROX_MODE, ITERATIONS), dst_index, vector_mode);
+        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_asinh, (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS), dst_index, vector_mode);
     }
     else if constexpr (OPERATION == SfpuType::atanh)
     {

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -244,6 +244,7 @@ target_link_libraries(
         TTNN::Ops::Core
         TTNN::Ops::Creation
         TTNN::Ops::DataMovement
+        TTNN::Ops::Math::FFT
         TTNN::Ops::Eltwise::Binary
         TTNN::Ops::Eltwise::Binary::Backward
         TTNN::Ops::Eltwise::Binary::NG
@@ -513,6 +514,7 @@ add_subdirectory(cpp/ttnn/operations/creation)
 add_subdirectory(cpp/ttnn/operations/core)
 add_subdirectory(cpp/ttnn/operations/data_movement)
 add_subdirectory(cpp/ttnn/operations/debug)
+add_subdirectory(cpp/ttnn/operations/math/fft)
 add_subdirectory(cpp/ttnn/operations/eltwise/binary)
 add_subdirectory(cpp/ttnn/operations/eltwise/binary_backward)
 add_subdirectory(cpp/ttnn/operations/eltwise/binary_ng)

--- a/ttnn/cpp/ttnn-nanobind/__init__.cpp
+++ b/ttnn/cpp/ttnn-nanobind/__init__.cpp
@@ -42,6 +42,7 @@
 #include "ttnn/operations/conv/conv_nanobind.hpp"
 #include "ttnn/operations/creation/creation_nanobind.hpp"
 #include "ttnn/operations/debug/debug_nanobind.hpp"
+#include "ttnn/operations/math/fft/fft_nanobind.hpp"
 #include "ttnn/operations/data_movement/data_movement_nanobind.hpp"
 #include "ttnn/operations/eltwise/binary/binary_nanobind.hpp"
 #include "ttnn/operations/eltwise/binary_backward/binary_backward_nanobind.hpp"
@@ -128,6 +129,9 @@ void py_module(nb::module_& mod) {
 
     auto m_complex_unary_backward = mod.def_submodule("complex_unary_backward", "complex_unary_backward operations");
     complex_unary_backward::py_module(m_complex_unary_backward);
+
+    auto m_fft = mod.def_submodule("fft", "fft operations");
+    fft::py_module(m_fft);
 
     auto m_ccl = mod.def_submodule("ccl", "collective communication operations");
     ccl::py_module(m_ccl);

--- a/ttnn/cpp/ttnn/operations/math/fft/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/math/fft/CMakeLists.txt
@@ -1,0 +1,23 @@
+include(sources.cmake)
+
+add_library(ttnn_op_math_fft ${LIB_TYPE})
+add_library(TTNN::Ops::Math::FFT ALIAS ttnn_op_math_fft)
+
+tt_reuse_precompile_headers(ttnn_op_math_fft TTNN::PCHLean)
+TT_ENABLE_UNITY_BUILD(ttnn_op_math_fft)
+
+target_sources(
+    ttnn_op_math_fft
+    PUBLIC
+        FILE_SET api
+        TYPE HEADERS
+        BASE_DIRS ${FixmeOpAPIDir}
+        FILES ${TTNN_OP_MATH_FFT_API_HEADERS}
+    PRIVATE
+        ${TTNN_OP_MATH_FFT_SRCS}
+)
+
+target_include_directories(ttnn_op_math_fft PRIVATE ${FixmeOpIncDirs})
+target_link_libraries(ttnn_op_math_fft PUBLIC TTNN::Core PRIVATE TT::Metalium)
+
+install(TARGETS ttnn_op_math_fft FILE_SET api COMPONENT ttnn-dev LIBRARY COMPONENT tar)

--- a/ttnn/cpp/ttnn/operations/math/fft/fft.cpp
+++ b/ttnn/cpp/ttnn/operations/math/fft/fft.cpp
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fft.hpp"
+#include "ttnn/operations/data_movement/transpose/transpose.hpp"
+#include "ttnn/operations/core/to_layout/to_layout_op.hpp"
+#include "ttnn/operations/matmul/matmul.hpp"
+#include "ttnn/operations/eltwise/binary/binary.hpp"
+#include "ttnn/operations/creation/creation.hpp"
+#include <cmath>
+#include <vector>
+
+namespace ttnn {
+
+namespace {
+
+Tensor create_dft_matrix(
+    uint32_t N,
+    bool inverse,
+    bool real_part,
+    DataType dtype,
+    Layout layout,
+    tt::tt_metal::distributed::MeshDevice* device,
+    const MemoryConfig& mem_config) {
+    uint32_t size = N * N;
+    TensorSpec spec(
+        ttnn::Shape(std::vector<uint32_t>{N, N}),
+        TensorLayout(dtype, PageConfig(layout), mem_config)
+    );
+    constexpr double PI = 3.14159265358979323846;
+    if (dtype == DataType::FLOAT32) {
+        std::vector<float> owned_buffer(size);
+        for (uint32_t k = 0; k < N; ++k) {
+            for (uint32_t n = 0; n < N; ++n) {
+                double angle = 2.0 * PI * k * n / N;
+                if (inverse) {
+                    if (real_part) {
+                        owned_buffer[k * N + n] = static_cast<float>(std::cos(angle) / N);
+                    } else {
+                        owned_buffer[k * N + n] = static_cast<float>(std::sin(angle) / N);
+                    }
+                } else {
+                    if (real_part) {
+                        owned_buffer[k * N + n] = static_cast<float>(std::cos(angle));
+                    } else {
+                        owned_buffer[k * N + n] = static_cast<float>(-std::sin(angle));
+                    }
+                }
+            }
+        }
+        return Tensor::from_vector(std::move(owned_buffer), spec, device);
+    } else {
+        std::vector<bfloat16> owned_buffer(size);
+        for (uint32_t k = 0; k < N; ++k) {
+            for (uint32_t n = 0; n < N; ++n) {
+                double angle = 2.0 * PI * k * n / N;
+                if (inverse) {
+                    if (real_part) {
+                        owned_buffer[k * N + n] = bfloat16(static_cast<float>(std::cos(angle) / N));
+                    } else {
+                        owned_buffer[k * N + n] = bfloat16(static_cast<float>(std::sin(angle) / N));
+                    }
+                } else {
+                    if (real_part) {
+                        owned_buffer[k * N + n] = bfloat16(static_cast<float>(std::cos(angle)));
+                    } else {
+                        owned_buffer[k * N + n] = bfloat16(static_cast<float>(-std::sin(angle)));
+                    }
+                }
+            }
+        }
+        return Tensor::from_vector(std::move(owned_buffer), spec, device);
+    }
+}
+
+ComplexTensor fft_impl(
+    const ComplexTensor& input_tensor,
+    int64_t dim,
+    bool inverse,
+    const std::optional<tt::tt_metal::MemoryConfig>& memory_config) {
+    Tensor real = input_tensor.real();
+    Tensor imag = input_tensor.imag();
+    auto shape = real.logical_shape();
+    int64_t rank = shape.rank();
+    int64_t dim_normalized = dim < 0 ? dim + rank : dim;
+    uint32_t N = shape[dim_normalized];
+    auto* device = real.device();
+
+    bool need_transpose = (dim_normalized != rank - 1);
+    Tensor real_trans = need_transpose ? ttnn::transpose(real, dim_normalized, -1) : real;
+    Tensor imag_trans = need_transpose ? ttnn::transpose(imag, dim_normalized, -1) : imag;
+
+    auto original_layout = real_trans.layout();
+    Tensor real_tile = (original_layout != Layout::TILE) ? ttnn::to_layout(real_trans, Layout::TILE, std::nullopt, std::nullopt, device) : real_trans;
+    Tensor imag_tile = (original_layout != Layout::TILE) ? ttnn::to_layout(imag_trans, Layout::TILE, std::nullopt, std::nullopt, device) : imag_trans;
+
+    auto dtype = real_tile.dtype();
+    auto output_mem_config = memory_config.value_or(real_tile.memory_config());
+    Tensor W_real = create_dft_matrix(N, inverse, true, dtype, Layout::TILE, device, output_mem_config);
+    Tensor W_imag = create_dft_matrix(N, inverse, false, dtype, Layout::TILE, device, output_mem_config);
+
+    Tensor A_W_real = ttnn::matmul(real_tile, W_real, std::nullopt, output_mem_config);
+    Tensor B_W_imag = ttnn::matmul(imag_tile, W_imag, std::nullopt, output_mem_config);
+    Tensor Y_real_tile = ttnn::subtract(A_W_real, B_W_imag, std::nullopt, output_mem_config);
+    A_W_real.deallocate();
+    B_W_imag.deallocate();
+
+    Tensor A_W_imag = ttnn::matmul(real_tile, W_imag, std::nullopt, output_mem_config);
+    Tensor B_W_real = ttnn::matmul(imag_tile, W_real, std::nullopt, output_mem_config);
+    Tensor Y_imag_tile = ttnn::add(A_W_imag, B_W_real, std::nullopt, output_mem_config);
+    A_W_imag.deallocate();
+    B_W_real.deallocate();
+
+    W_real.deallocate();
+    W_imag.deallocate();
+
+    if (original_layout != Layout::TILE) {
+        if (real_trans.layout() != Layout::TILE) {
+            real_tile.deallocate();
+            imag_tile.deallocate();
+        }
+    }
+
+    Tensor Y_real_trans = (original_layout != Layout::TILE) ? ttnn::to_layout(Y_real_tile, original_layout, std::nullopt, std::nullopt, device) : Y_real_tile;
+    Tensor Y_imag_trans = (original_layout != Layout::TILE) ? ttnn::to_layout(Y_imag_tile, original_layout, std::nullopt, std::nullopt, device) : Y_imag_tile;
+
+    if (original_layout != Layout::TILE) {
+        Y_real_tile.deallocate();
+        Y_imag_tile.deallocate();
+    }
+
+    Tensor Y_real = need_transpose ? ttnn::transpose(Y_real_trans, dim_normalized, -1) : Y_real_trans;
+    Tensor Y_imag = need_transpose ? ttnn::transpose(Y_imag_trans, dim_normalized, -1) : Y_imag_trans;
+
+    if (need_transpose) {
+        Y_real_trans.deallocate();
+        Y_imag_trans.deallocate();
+        real_trans.deallocate();
+        imag_trans.deallocate();
+    }
+
+    return complex_tensor(Y_real, Y_imag);
+}
+
+} // namespace
+
+ComplexTensor fft(
+    const ComplexTensor& input_tensor,
+    int64_t dim,
+    const std::optional<tt::tt_metal::MemoryConfig>& memory_config) {
+    return fft_impl(input_tensor, dim, false, memory_config);
+}
+
+ComplexTensor fft(
+    const Tensor& input_tensor,
+    int64_t dim,
+    const std::optional<tt::tt_metal::MemoryConfig>& memory_config) {
+    Tensor imag = ttnn::zeros_like(input_tensor, std::nullopt, std::nullopt, std::nullopt, memory_config);
+    ComplexTensor complex_input = complex_tensor(input_tensor, imag);
+    ComplexTensor result = fft(complex_input, dim, memory_config);
+    return result;
+}
+
+ComplexTensor ifft(
+    const ComplexTensor& input_tensor,
+    int64_t dim,
+    const std::optional<tt::tt_metal::MemoryConfig>& memory_config) {
+    return fft_impl(input_tensor, dim, true, memory_config);
+}
+
+ComplexTensor ifft(
+    const Tensor& input_tensor,
+    int64_t dim,
+    const std::optional<tt::tt_metal::MemoryConfig>& memory_config) {
+    Tensor imag = ttnn::zeros_like(input_tensor, std::nullopt, std::nullopt, std::nullopt, memory_config);
+    ComplexTensor complex_input = complex_tensor(input_tensor, imag);
+    ComplexTensor result = ifft(complex_input, dim, memory_config);
+    return result;
+}
+
+} // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/math/fft/fft.hpp
+++ b/ttnn/cpp/ttnn/operations/math/fft/fft.hpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+#include "ttnn/operations/eltwise/complex/complex.hpp"
+
+namespace ttnn {
+
+ComplexTensor fft(
+    const ComplexTensor& input_tensor,
+    int64_t dim = -1,
+    const std::optional<tt::tt_metal::MemoryConfig>& memory_config = std::nullopt);
+
+ComplexTensor fft(
+    const Tensor& input_tensor,
+    int64_t dim = -1,
+    const std::optional<tt::tt_metal::MemoryConfig>& memory_config = std::nullopt);
+
+ComplexTensor ifft(
+    const ComplexTensor& input_tensor,
+    int64_t dim = -1,
+    const std::optional<tt::tt_metal::MemoryConfig>& memory_config = std::nullopt);
+
+ComplexTensor ifft(
+    const Tensor& input_tensor,
+    int64_t dim = -1,
+    const std::optional<tt::tt_metal::MemoryConfig>& memory_config = std::nullopt);
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/math/fft/fft_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/math/fft/fft_nanobind.cpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fft_nanobind.hpp"
+#include "fft.hpp"
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
+
+namespace ttnn::operations::math::fft {
+
+namespace nb = nanobind;
+
+void py_module(nb::module_& mod) {
+    mod.def(
+        "fft",
+        nb::overload_cast<const ComplexTensor&, int64_t, const std::optional<tt::tt_metal::MemoryConfig>&>(&ttnn::fft),
+        nb::arg("input_tensor"),
+        nb::arg("dim") = -1,
+        nb::arg("memory_config") = std::nullopt,
+        "Compute 1D Fast Fourier Transform for complex tensor");
+
+    mod.def(
+        "fft",
+        nb::overload_cast<const Tensor&, int64_t, const std::optional<tt::tt_metal::MemoryConfig>&>(&ttnn::fft),
+        nb::arg("input_tensor"),
+        nb::arg("dim") = -1,
+        nb::arg("memory_config") = std::nullopt,
+        "Compute 1D Fast Fourier Transform for real tensor");
+
+    mod.def(
+        "ifft",
+        nb::overload_cast<const ComplexTensor&, int64_t, const std::optional<tt::tt_metal::MemoryConfig>&>(&ttnn::ifft),
+        nb::arg("input_tensor"),
+        nb::arg("dim") = -1,
+        nb::arg("memory_config") = std::nullopt,
+        "Compute 1D Inverse Fast Fourier Transform for complex tensor");
+
+    mod.def(
+        "ifft",
+        nb::overload_cast<const Tensor&, int64_t, const std::optional<tt::tt_metal::MemoryConfig>&>(&ttnn::ifft),
+        nb::arg("input_tensor"),
+        nb::arg("dim") = -1,
+        nb::arg("memory_config") = std::nullopt,
+        "Compute 1D Inverse Fast Fourier Transform for real tensor");
+}
+
+}  // namespace ttnn::operations::math::fft

--- a/ttnn/cpp/ttnn/operations/math/fft/fft_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/math/fft/fft_nanobind.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <nanobind/nanobind.h>
+
+namespace ttnn::operations::math::fft {
+
+void py_module(nanobind::module_& mod);
+
+}  // namespace ttnn::operations::math::fft

--- a/ttnn/cpp/ttnn/operations/math/fft/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/math/fft/sources.cmake
@@ -1,0 +1,6 @@
+# Source files for ttnn_op_math_fft.
+# Module owners should update this file when adding/removing/renaming source files.
+
+set(TTNN_OP_MATH_FFT_SRCS fft.cpp fft_nanobind.cpp)
+
+set(TTNN_OP_MATH_FFT_API_HEADERS fft.hpp fft_nanobind.hpp)

--- a/ttnn/ttnn/operations/fft.py
+++ b/ttnn/ttnn/operations/fft.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+
+__all__ = []
+
+
+def _golden_function_fft(input_tensor, dim=-1, *args, **kwargs):
+    import torch
+
+    return torch.fft.fft(input_tensor, dim=dim)
+
+
+ttnn.attach_golden_function(ttnn.fft.fft, golden_function=_golden_function_fft)
+
+
+def _golden_function_ifft(input_tensor, dim=-1, *args, **kwargs):
+    import torch
+
+    return torch.fft.ifft(input_tensor, dim=dim)
+
+
+ttnn.attach_golden_function(ttnn.fft.ifft, golden_function=_golden_function_ifft)


### PR DESCRIPTION
### Technical Summary

This PR adds support for Fast Fourier Transform (FFT) and Inverse Fast Fourier Transform (IFFT) operations in the math libraries of tt-metal (specifically `ttnn`).

#### Details:
- **Implementation**: Implemented FFT and IFFT as composite operations utilizing hardware-accelerated matrix multiplication (`ttnn::matmul`). This leverages the highly optimized, multi-core parallel architecture of Tenstorrent devices for efficient computations.
- **Data Types**: Full support for both `bfloat16` and `float32` data types.
- **Tensors**: Supports both real inputs (automatically cast to complex parts with zero imaginary parts) and complex inputs (`ttnn::ComplexTensor`).
- **Dimensions**: Supports computing FFT/IFFT along arbitrary dimensions by transposing the target dimension to the last dimension, performing the tiled matmul, and transposing back.
- **Tests**: Added a comprehensive suite of nightly unit tests in `tests/ttnn/nightly/unit_tests/operations/test_fft.py` that compares results directly with PyTorch's `torch.fft` references for various dtypes, dimensions, and sizes.

Payment Info: PayPal: https://paypal.me/sureshc26