### PR TITLE
[Cleanup] Remove MeshTensor::address

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
@@ -272,7 +272,7 @@ void run_borrowed_memory_dfb_program(
     // stays PINNED across a size override (no reallocation).
     EXPECT_EQ(
         program.impl().dataflow_buffers()[0]->uniform_alloc_addr(),
-        static_cast<uint32_t>(ring_tensor.address()));
+        static_cast<uint32_t>(ring_tensor.mesh_buffer().address()));
 
     if (cfg.num_entries_override.has_value()) {
         EXPECT_EQ(program.impl().dataflow_buffers()[0]->config.num_entries, *cfg.num_entries_override)

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
@@ -1265,7 +1265,7 @@ TEST_F(ProgramRunArgsTestQuasar, BorrowedDFB_AttachWritesTensorAddressToDFB) {
     };
     SetProgramRunArgs(program, params);
 
-    EXPECT_EQ(PeekBorrowedDFBAddress(program, "dfb"), static_cast<uint32_t>(tensor.address()))
+    EXPECT_EQ(PeekBorrowedDFBAddress(program, "dfb"), static_cast<uint32_t>(tensor.mesh_buffer().address()))
         << "DFB base addr should match the borrowed MeshTensor's address after attach";
 }
 
@@ -1391,7 +1391,7 @@ TEST_F(ProgramRunArgsTestQuasar, BindingOnlyKernelOmittedFromRunArgsSucceeds) {
     auto kernel = program.impl().get_kernel_by_spec_name("dm_kernel");
     ASSERT_FALSE(kernel->common_runtime_args().empty())
         << "binding-only kernel's CRTA buffer should have been allocated by SetProgramRunArgs";
-    EXPECT_EQ(kernel->common_runtime_args()[0], static_cast<uint32_t>(tensor.address()))
+    EXPECT_EQ(kernel->common_runtime_args()[0], static_cast<uint32_t>(tensor.mesh_buffer().address()))
         << "binding base address should be written even though the kernel was omitted from kernel_run_args";
 }
 
@@ -2230,7 +2230,9 @@ TEST_F(ProgramRunArgsTestGen1, TensorBindingOnlyKernelOmittedFromRunArgsSucceeds
     };
 
     EXPECT_NO_THROW(SetProgramRunArgs(program, params));
-    EXPECT_EQ(ReadBindingAddressFromCRTA(program, "dm_kernel", "input_tensor"), static_cast<uint32_t>(tensor.address()))
+    EXPECT_EQ(
+        ReadBindingAddressFromCRTA(program, "dm_kernel", "input_tensor"),
+        static_cast<uint32_t>(tensor.mesh_buffer().address()))
         << "binding address should be written even though the kernel was omitted from kernel_run_args";
 }
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -703,7 +703,7 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
 //   1. Spec → MakeProgramFromSpec resolves the binding's TensorSpec into a correct CTA payload
 //      (page size, args_config, bank coords, alignment).
 //   2. Each binding's slot in the kernel's TensorBinding address section is filled with
-//      MeshTensor::address() at enqueue.
+//      the MeshTensor's mesh_buffer().address() at enqueue.
 //   3. kernel_bindings_generated.h emits a `tensor::` namespace with a working type alias + token.
 //   4. TensorAccessor(tensor::name) constructs an accessor whose get_noc_addr returns
 //      addresses that NoC reads/writes actually use correctly.
@@ -849,7 +849,7 @@ TEST_F(ProgramSpecHWTest, TensorAccessorBindingLoopback) {
 //   DM consumer (NCRISC)   — out_dfb → DRAM output.
 //
 // The tensor is a single-shard L1 tensor on core (0,0) (the compute kernel's core), so its shard base
-// address equals MeshTensor::address(). No dereference of the shard occurs (address-of only), so the
+// address equals the MeshTensor's mesh_buffer().address(). No dereference of the shard occurs (address-of only), so the
 // proof does not depend on the shard's contents.
 
 TEST_F(ProgramSpecHWTest, LocalTensorAccessorBindingCompileComputeKernel) {
@@ -919,7 +919,7 @@ TEST_F(ProgramSpecHWTest, LocalTensorAccessorBindingCompileComputeKernel) {
     std::vector<uint32_t> output_data;
     detail::ReadFromBuffer(output_buffer, output_data);
 
-    const uint32_t expected_address = static_cast<uint32_t>(local_tensor.address());
+    const uint32_t expected_address = static_cast<uint32_t>(local_tensor.mesh_buffer().address());
     constexpr uint32_t words_per_entry = entry_size / sizeof(uint32_t);
     ASSERT_EQ(output_data.size(), total_bytes / sizeof(uint32_t));
     for (uint32_t e = 0; e < num_tiles; ++e) {

--- a/tests/tt_metal/tt_metal/api/tensor/test_mesh_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_mesh_tensor.cpp
@@ -118,7 +118,7 @@ TEST_F(MeshTensorDeviceTest, ConstructionWithMeshBuffer) {
     auto buffer_address = mesh_buffer->address();
     MeshTensor tensor = MeshTensor::from_buffer(std::move(*mesh_buffer), std::move(spec), std::move(topology));
 
-    EXPECT_EQ(tensor.address(), buffer_address);
+    EXPECT_EQ(tensor.mesh_buffer().address(), buffer_address);
     EXPECT_EQ(&tensor.device(), mesh_device_.get());
     EXPECT_EQ(tensor.dtype(), DataType::BFLOAT16);
     EXPECT_EQ(tensor.layout(), Layout::ROW_MAJOR);

--- a/tests/ttnn/unit_tests/gtests/tensor/test_device_storage_ownership.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_device_storage_ownership.cpp
@@ -215,7 +215,7 @@ TEST_F(DeviceStorageOwnershipTest, DeviceStorage_ReleaseMeshTensorMovesOutUnderl
     // The released tensor is valid and owns the very same MeshBuffer that the storage held —
     // proving the memory was moved out, not copied or reallocated.
     EXPECT_FALSE(released.is_valueless_after_move());
-    EXPECT_EQ(released.address(), address);
+    EXPECT_EQ(released.mesh_buffer().address(), address);
 }
 
 TEST_F(DeviceStorageOwnershipTest, DeviceStorage_ReleaseMeshTensorLeavesDefaultConstructedState) {

--- a/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
@@ -156,8 +156,6 @@ public:
     const std::optional<ShardSpec>& shard_spec() const;
     const std::optional<NdShardSpec>& nd_shard_spec() const;
 
-    DeviceAddr address() const;
-
     // Utils:
 
     /**

--- a/tt_metal/impl/metal2_host_api/program_run_args.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_args.cpp
@@ -353,7 +353,7 @@ void ValidateProgramRunArgs(const Program& program, const ProgramRunArgs& params
 // here, so it must not be forwarded/moved-from.
 template <typename Emit>
 void EmitBindingCrtaValues(const TensorBindingHandle& handle, const MeshTensor& tensor, const Emit& emit) {
-    const auto address = tensor.address();
+    const auto address = tensor.mesh_buffer().address();
     TT_FATAL(
         address <= std::numeric_limits<uint32_t>::max(),
         "Tensor argument for TensorParameter '{}' base address {} exceeds uint32_t max",

--- a/tt_metal/impl/tensor/mesh_tensor.cpp
+++ b/tt_metal/impl/tensor/mesh_tensor.cpp
@@ -41,8 +41,6 @@ const TensorTopology& MeshTensor::tensor_topology() const { return impl().topolo
 
 bool MeshTensor::is_valueless_after_move() const { return impl_ == nullptr; }
 
-DeviceAddr MeshTensor::address() const { return mesh_buffer().address(); }
-
 DataType MeshTensor::dtype() const { return tensor_spec().data_type(); }
 
 Layout MeshTensor::layout() const { return tensor_spec().layout(); }

--- a/ttnn/api/ttnn/tensor/tensor_utils.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_utils.hpp
@@ -88,7 +88,7 @@ inline uint32_t get_cb_address(const CBDescriptor& desc) {
         return desc.buffer->address() + addr_offset;
     }
     if (desc.tensor != nullptr) {
-        return desc.tensor->address() + addr_offset;
+        return desc.tensor->mesh_buffer().address() + addr_offset;
     }
     return addr_offset;
 }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -987,7 +987,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
         else if (core == start_core) {
             std::vector<uint32_t> mm_in0_sender_args = {
                 // in0 tensor args
-                (std::uint32_t)in0_tensor.address(),
+                (std::uint32_t)in0_tensor.mesh_buffer().address(),
                 (std::uint32_t)in0_tensor_start_tile_id_stride * output_idx_y,  // in0_tensor_start_tile_id
                 // in0 mcast args
                 (std::uint32_t)start_core_noc.x,  // in0_mcast_dest_noc_start_x
@@ -1026,7 +1026,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
             std::vector<uint32_t> mm_in1_sender_writer_args = {
                 // READER
                 // in1 tensor args
-                (std::uint32_t)in1_tensor.address(),
+                (std::uint32_t)in1_tensor.mesh_buffer().address(),
                 (std::uint32_t)in1_tensor_start_tile_id_stride * output_idx_x,  // in1_tensor_start_tile_id
                 // in1 mcast args
                 (std::uint32_t)0,  // in1_mcast_dest_noc_start_x
@@ -1039,7 +1039,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
 
                 // WRITER
                 // out tensor args
-                (std::uint32_t)out_tensor.address(),
+                (std::uint32_t)out_tensor.mesh_buffer().address(),
                 ((std::uint32_t)output_idx_x * per_core_N) +
                     (output_idx_y * per_core_M * N)  // out_tensor_start_tile_id
             };
@@ -1073,7 +1073,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
             }
 
             mm_in1_sender_writer_args.push_back(
-                bias_tensor.has_value() ? (std::uint32_t)bias_tensor->address() : 0);  // smuggled-rta-ok
+                bias_tensor.has_value() ? (std::uint32_t)bias_tensor->mesh_buffer().address() : 0);  // smuggled-rta-ok
             mm_in1_sender_writer_args.push_back(
                 bias_tensor.has_value() ? (std::uint32_t)per_core_N * output_idx_x : 0);  // in3_tensor_start_tile_id
             if (!output_is_sharded) {
@@ -1817,7 +1817,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
             std::vector<uint32_t> mm_in1_sender_writer_args = {
                 // READER
                 // in1 tensor args
-                (std::uint32_t)in1_tensor.address(),
+                (std::uint32_t)in1_tensor.mesh_buffer().address(),
                 (std::uint32_t)in1_tensor_start_tile_id_stride * output_idx_x,  // in1_tensor_start_tile_id
                 // in1 mcast args
                 (std::uint32_t)start_core_noc.x,  // in1_mcast_dest_noc_start_x
@@ -1830,7 +1830,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
 
                 // WRITER
                 // out tensor args
-                (std::uint32_t)out_tensor.address(),
+                (std::uint32_t)out_tensor.mesh_buffer().address(),
                 ((std::uint32_t)output_idx_x * per_core_N) +
                     (output_idx_y * per_core_M * N),  // out_tensor_start_tile_id
 
@@ -1847,7 +1847,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
                 (std::uint32_t)0};
 
             if (bias_tensor.has_value()) {
-                mm_in1_sender_writer_args.push_back((std::uint32_t)bias_tensor->address());  // smuggled-rta-ok
+                mm_in1_sender_writer_args.push_back(
+                    (std::uint32_t)bias_tensor->mesh_buffer().address());  // smuggled-rta-ok
                 mm_in1_sender_writer_args.push_back(
                     (std::uint32_t)per_core_N * output_idx_x);  // in3_tensor_start_tile_id
             } else {
@@ -1871,7 +1872,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
 
                 // WRITER
                 // out tensor args
-                (std::uint32_t)out_tensor.address(),  // out_tensor_addr
+                (std::uint32_t)out_tensor.mesh_buffer().address(),  // out_tensor_addr
                 ((std::uint32_t)output_idx_x * per_core_N) +
                     (output_idx_y * per_core_M * N)  // out_tensor_start_tile_id
             };
@@ -1917,7 +1918,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         }
         std::vector<uint32_t> mm_in0_sender_args = {
             // in0 tensor args
-            (std::uint32_t)in0_tensor.address(),
+            (std::uint32_t)in0_tensor.mesh_buffer().address(),
             (std::uint32_t)in0_tensor_start_tile_id_stride * output_idx_y,  // in0_tensor_start_tile_id
             // in0 mcast args
             (std::uint32_t)0,  // in0_mcast_dest_noc_start_x
@@ -2563,8 +2564,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
         /* in1 */
         std::vector<uint32_t> mm_in1_args = {
             (std::uint32_t)core_type,
-            in1_tensor.address(),  // in1_tensor_addr
-            i,                     // ring_idx
+            in1_tensor.mesh_buffer().address(),  // in1_tensor_addr
+            i,                                   // ring_idx
         };
         if (in1_is_dram_sharded) {
             // Look up bank_id based on core.y and which column group core.x belongs to
@@ -2734,15 +2735,15 @@ inline void override_mcast_in1_program_parameters(
         // in0 sender
         auto& reader_runtime_args =
             reader_runtime_args_by_core[override_variables.start_core.x][override_variables.start_core.y];
-        reader_runtime_args[0] = src_a_tensor.address();
+        reader_runtime_args[0] = src_a_tensor.mesh_buffer().address();
 
         // in1 sender
         auto& sender_writer_runtime_args =
             GetRuntimeArgs(program, override_variables.kernels.at(1), override_variables.start_core);
-        sender_writer_runtime_args[0] = src_b_tensor.address();
-        sender_writer_runtime_args[7] = dst_tensor.address();
+        sender_writer_runtime_args[0] = src_b_tensor.mesh_buffer().address();
+        sender_writer_runtime_args[7] = dst_tensor.mesh_buffer().address();
         if (bias_tensor.has_value()) {
-            sender_writer_runtime_args[18] = bias_mesh_tensor->address();
+            sender_writer_runtime_args[18] = bias_mesh_tensor->mesh_buffer().address();
         }
     }
 
@@ -2756,9 +2757,9 @@ inline void override_mcast_in1_program_parameters(
         auto& writer_runtime_args = receiver_writer_runtime_args_by_core[core.x][core.y];
 
         // in0 sender
-        reader_runtime_args[0] = src_a_tensor.address();
+        reader_runtime_args[0] = src_a_tensor.mesh_buffer().address();
         // in1 receiver
-        writer_runtime_args[2] = dst_tensor.address();
+        writer_runtime_args[2] = dst_tensor.mesh_buffer().address();
     }
 
     if (src0_sharded) {
@@ -2813,7 +2814,7 @@ static void override_mcast_in0_program_parameters(
         // in0 sender
         auto& reader_sender_runtime_args =
             GetRuntimeArgs(program, override_variables.kernels.at(0), override_variables.start_core);
-        reader_sender_runtime_args[0] = src_a_tensor.address();
+        reader_sender_runtime_args[0] = src_a_tensor.mesh_buffer().address();
     }
 
     if (src1_sharded) {
@@ -2832,10 +2833,10 @@ static void override_mcast_in0_program_parameters(
         auto& writer_runtime_args = writer_runtime_args_by_core[core.x][core.y];
 
         // in1 sender
-        writer_runtime_args[0] = src_b_tensor.address();
-        writer_runtime_args[7] = dst_tensor.address();
+        writer_runtime_args[0] = src_b_tensor.mesh_buffer().address();
+        writer_runtime_args[7] = dst_tensor.mesh_buffer().address();
         if (bias_tensor.has_value()) {
-            writer_runtime_args[18] = bias_mesh_tensor->address();
+            writer_runtime_args[18] = bias_mesh_tensor->mesh_buffer().address();
         }
     }
 
@@ -2886,7 +2887,7 @@ inline void override_gather_in0_program_parameters(
         auto& writer_runtime_args = writer_runtime_args_by_core[core.x][core.y];
 
         /* in1 */
-        writer_runtime_args[1] = src_b_tensor.address();
+        writer_runtime_args[1] = src_b_tensor.mesh_buffer().address();
     }
 }
 
@@ -3804,7 +3805,7 @@ void override_program_parameters(
         else if (core == start_core) {
             std::vector<uint32_t> mm_in0_sender_args = {
                 // in0 tensor args
-                (std::uint32_t)in0_tensor.address(),
+                0u,
                 (std::uint32_t)in0_tensor_start_tile_id_stride * output_idx_y,  // in0_tensor_start_tile_id
                 // in0 mcast args
                 (std::uint32_t)start_core_noc.x,  // in0_mcast_dest_noc_start_x
@@ -3843,7 +3844,7 @@ void override_program_parameters(
             std::vector<uint32_t> mm_in1_sender_writer_args = {
                 // READER
                 // in1 tensor args
-                (std::uint32_t)in1_tensor.address(),
+                0u,
                 (std::uint32_t)in1_tensor_start_tile_id_stride * output_idx_x,  // in1_tensor_start_tile_id
                 // in1 mcast args
                 (std::uint32_t)0,  // in1_mcast_dest_noc_start_x
@@ -3856,7 +3857,7 @@ void override_program_parameters(
 
                 // WRITER
                 // out tensor args
-                (std::uint32_t)out_tensor.address(),
+                0u,
                 ((std::uint32_t)output_idx_x * per_core_N) +
                     (output_idx_y * per_core_M * N)  // out_tensor_start_tile_id
             };
@@ -3889,8 +3890,7 @@ void override_program_parameters(
                 mm_in1_sender_writer_args.push_back(0);
             }
 
-            mm_in1_sender_writer_args.push_back(
-                bias_tensor.has_value() ? (std::uint32_t)bias_tensor->address() : 0);  // smuggled-rta-ok
+            mm_in1_sender_writer_args.push_back(0u);
             mm_in1_sender_writer_args.push_back(
                 bias_tensor.has_value() ? (std::uint32_t)per_core_N * output_idx_x : 0);  // in3_tensor_start_tile_id
             if (!output_is_sharded) {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
@@ -1210,7 +1210,7 @@ namespace reuse_mcast_optimized_helpers {
         } else if (in1_idx == 0) {
             std::vector<uint32_t> mm_in0_sender_args = {
                 // in0 tensor args
-                (std::uint32_t)in0_tensor.address(),
+                0u,
                 (std::uint32_t)in0_tensor_start_tile_id_stride * in0_idx,  // in0_tensor_start_tile_id
                 // in0 mcast args
                 (std::uint32_t)in0_mcast_start.x,  // in0_mcast_dest_noc_start_x
@@ -1262,7 +1262,7 @@ namespace reuse_mcast_optimized_helpers {
                 std::vector<uint32_t> mm_in1_sender_writer_args = {
                     // READER
                     // in1 tensor args
-                    (std::uint32_t)in1_tensor.address(),
+                    0u,
                     (std::uint32_t)in1_tensor_start_tile_id_stride * in1_idx,  // in1_tensor_start_tile_id
                     // in1 mcast args
                     (std::uint32_t)in1_mcast_start.x,  // in1_mcast_dest_noc_start_x
@@ -1275,7 +1275,7 @@ namespace reuse_mcast_optimized_helpers {
 
                     // WRITER
                     // out tensor args
-                    (std::uint32_t)out_tensor.address(),
+                    0u,
                     ((std::uint32_t)in1_idx * per_core_N) + (in0_idx * per_core_M * N)  // out_tensor_start_tile_id
                 };
 
@@ -1307,8 +1307,7 @@ namespace reuse_mcast_optimized_helpers {
                     mm_in1_sender_writer_args.push_back(0);
                 }
 
-                mm_in1_sender_writer_args.push_back(
-                    bias_mesh.has_value() ? (std::uint32_t)bias_mesh->address() : 0);  // smuggled-rta-ok
+                mm_in1_sender_writer_args.push_back(0u);
                 mm_in1_sender_writer_args.push_back(
                     bias_mesh.has_value() ? (std::uint32_t)per_core_N * in1_idx : 0);  // in1_tensor_start_tile_id
                 if (!output_is_sharded) {
@@ -1416,7 +1415,7 @@ namespace reuse_mcast_optimized_helpers {
 
                     // WRITER
                     // out tensor args
-                    (std::uint32_t)out_tensor.address(),                                // out_tensor_addr
+                    0u,                                                                 // out_tensor_addr
                     ((std::uint32_t)in1_idx * per_core_N) + (in0_idx * per_core_M * N)  // out_tensor_start_tile_id
                 };
 
@@ -2669,7 +2668,7 @@ create_program_mcast_in0_in1(
         } else if (in1_idx == 0) {
             std::vector<uint32_t> mm_in0_sender_args = {
                 // in0 tensor args
-                (std::uint32_t)in0_tensor.address(),
+                (std::uint32_t)in0_tensor.mesh_buffer().address(),
                 (std::uint32_t)in0_tensor_start_tile_id_stride * in0_idx,  // in0_tensor_start_tile_id
                 // in0 mcast args
                 (std::uint32_t)in0_mcast_start.x,  // in0_mcast_dest_noc_start_x
@@ -2717,7 +2716,7 @@ create_program_mcast_in0_in1(
                 std::vector<uint32_t> mm_in1_sender_writer_args = {
                     // READER
                     // in1 tensor args
-                    (std::uint32_t)in1_tensor.address(),
+                    (std::uint32_t)in1_tensor.mesh_buffer().address(),
                     (std::uint32_t)in1_tensor_start_tile_id_stride * in1_idx,  // in1_tensor_start_tile_id
                     // in1 mcast args
                     (std::uint32_t)in1_mcast_start.x,  // in1_mcast_dest_noc_start_x
@@ -2730,7 +2729,7 @@ create_program_mcast_in0_in1(
 
                     // WRITER
                     // out tensor args
-                    (std::uint32_t)out_tensor.address(),
+                    (std::uint32_t)out_tensor.mesh_buffer().address(),
                     ((std::uint32_t)in1_idx * per_core_N) + (in0_idx * per_core_M * N)  // out_tensor_start_tile_id
                 };
 
@@ -2763,7 +2762,7 @@ create_program_mcast_in0_in1(
                 }
 
                 mm_in1_sender_writer_args.push_back(
-                    bias_mesh.has_value() ? (std::uint32_t)bias_mesh->address() : 0);  // smuggled-rta-ok
+                    bias_mesh.has_value() ? (std::uint32_t)bias_mesh->mesh_buffer().address() : 0);  // smuggled-rta-ok
                 mm_in1_sender_writer_args.push_back(
                     bias_mesh.has_value() ? (std::uint32_t)per_core_N * in1_idx : 0);  // in1_tensor_start_tile_id
                 if (!output_is_sharded) {
@@ -2863,7 +2862,7 @@ create_program_mcast_in0_in1(
 
                     // WRITER
                     // out tensor args
-                    (std::uint32_t)out_tensor.address(),                                // out_tensor_addr
+                    (std::uint32_t)out_tensor.mesh_buffer().address(),                  // out_tensor_addr
                     ((std::uint32_t)in1_idx * per_core_N) + (in0_idx * per_core_M * N)  // out_tensor_start_tile_id
                 };
 
@@ -3017,7 +3016,7 @@ void override_runtime_arguments_impl(
         auto& reader_sender_runtime_args_by_core = GetRuntimeArgs(program, mm_kernel_in0_sender_id);
         for (const auto& core : in0_sender_interleaved_cores) {
             auto& reader_runtime_args = reader_sender_runtime_args_by_core[core.x][core.y];
-            reader_runtime_args[0] = in0.address();
+            reader_runtime_args[0] = in0.mesh_buffer().address();
         }
     }
 
@@ -3025,10 +3024,10 @@ void override_runtime_arguments_impl(
     auto& sender_writer_runtime_args_by_core = GetRuntimeArgs(program, mm_kernel_in1_sender_writer_id);
     for (const auto& core : in1_sender_cores) {
         auto& writer_runtime_args = sender_writer_runtime_args_by_core[core.x][core.y];
-        writer_runtime_args[0] = in1.address();
-        writer_runtime_args[7] = out.address();
+        writer_runtime_args[0] = in1.mesh_buffer().address();
+        writer_runtime_args[7] = out.mesh_buffer().address();
         if (bias_tensor.has_value()) {
-            writer_runtime_args[18] = bias_mesh->address();
+            writer_runtime_args[18] = bias_mesh->mesh_buffer().address();
         }
     }
 
@@ -3036,14 +3035,14 @@ void override_runtime_arguments_impl(
     auto& receiver_writer_runtime_args_by_core = GetRuntimeArgs(program, mm_kernel_in1_receiver_writer_id);
     for (const auto& core : in1_receiver_cores) {
         auto& writer_runtime_args = receiver_writer_runtime_args_by_core[core.x][core.y];
-        writer_runtime_args[2] = out.address();
+        writer_runtime_args[2] = out.mesh_buffer().address();
     }
     if (mm_kernel_in1_receiver_writer_id != mm_kernel_in1_receiver_writer_other_noc_setup_id) {
         auto& receiver_writer_runtime_args_by_core =
             GetRuntimeArgs(program, mm_kernel_in1_receiver_writer_other_noc_setup_id);
         for (const auto& core : in1_receiver_other_cores) {
             auto& writer_runtime_args = receiver_writer_runtime_args_by_core[core.x][core.y];
-            writer_runtime_args[2] = out.address();
+            writer_runtime_args[2] = out.mesh_buffer().address();
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -978,7 +978,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
         else if (core == start_core) {
             std::vector<uint32_t> mm_in0_sender_args = {
                 // in0 tensor args
-                (std::uint32_t)in0_tensor.address(),
+                (std::uint32_t)in0_tensor.mesh_buffer().address(),
                 (std::uint32_t)in0_tensor_start_tile_id_stride * output_idx_y,  // in0_tensor_start_tile_id
                 // in0 mcast args
                 (std::uint32_t)start_core_noc.x,  // in0_mcast_dest_noc_start_x
@@ -1017,7 +1017,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
             std::vector<uint32_t> mm_in1_sender_writer_args = {
                 // READER
                 // in1 tensor args
-                (std::uint32_t)in1_tensor.address(),
+                (std::uint32_t)in1_tensor.mesh_buffer().address(),
                 (std::uint32_t)in1_tensor_start_tile_id_stride * output_idx_x,  // in1_tensor_start_tile_id
                 // in1 mcast args
                 (std::uint32_t)0,  // in1_mcast_dest_noc_start_x
@@ -1030,7 +1030,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
 
                 // WRITER
                 // out tensor args
-                (std::uint32_t)out_tensor.address(),
+                (std::uint32_t)out_tensor.mesh_buffer().address(),
                 ((std::uint32_t)output_idx_x * per_core_N) +
                     (output_idx_y * per_core_M * N)  // out_tensor_start_tile_id
             };
@@ -1065,7 +1065,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
 
             // Bias base address; patched on program-cache hit by override_mcast_in0_program_parameters (idx 18).
             mm_in1_sender_writer_args.push_back(
-                bias_tensor.has_value() ? (std::uint32_t)bias_tensor->address() : 0);  // smuggled-rta-ok
+                bias_tensor.has_value() ? (std::uint32_t)bias_tensor->mesh_buffer().address() : 0);  // smuggled-rta-ok
             mm_in1_sender_writer_args.push_back(
                 bias_tensor.has_value() ? (std::uint32_t)per_core_N * output_idx_x : 0);  // in3_tensor_start_tile_id
             if (!output_is_sharded) {
@@ -1809,7 +1809,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
             std::vector<uint32_t> mm_in1_sender_writer_args = {
                 // READER
                 // in1 tensor args
-                (std::uint32_t)in1_tensor.address(),
+                (std::uint32_t)in1_tensor.mesh_buffer().address(),
                 (std::uint32_t)in1_tensor_start_tile_id_stride * output_idx_x,  // in1_tensor_start_tile_id
                 // in1 mcast args
                 (std::uint32_t)start_core_noc.x,  // in1_mcast_dest_noc_start_x
@@ -1822,7 +1822,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
 
                 // WRITER
                 // out tensor args
-                (std::uint32_t)out_tensor.address(),
+                (std::uint32_t)out_tensor.mesh_buffer().address(),
                 ((std::uint32_t)output_idx_x * per_core_N) +
                     (output_idx_y * per_core_M * N),  // out_tensor_start_tile_id
 
@@ -1840,7 +1840,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
 
             if (bias_tensor.has_value()) {
                 // Bias base address; patched on program-cache hit by override_mcast_in1_program_parameters (idx 18).
-                mm_in1_sender_writer_args.push_back((std::uint32_t)bias_tensor->address());  // smuggled-rta-ok
+                mm_in1_sender_writer_args.push_back(
+                    (std::uint32_t)bias_tensor->mesh_buffer().address());  // smuggled-rta-ok
                 mm_in1_sender_writer_args.push_back(
                     (std::uint32_t)per_core_N * output_idx_x);  // in3_tensor_start_tile_id
             } else {
@@ -1864,7 +1865,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
 
                 // WRITER
                 // out tensor args
-                (std::uint32_t)out_tensor.address(),  // out_tensor_addr
+                (std::uint32_t)out_tensor.mesh_buffer().address(),  // out_tensor_addr
                 ((std::uint32_t)output_idx_x * per_core_N) +
                     (output_idx_y * per_core_M * N)  // out_tensor_start_tile_id
             };
@@ -1910,7 +1911,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         }
         std::vector<uint32_t> mm_in0_sender_args = {
             // in0 tensor args
-            (std::uint32_t)in0_tensor.address(),
+            (std::uint32_t)in0_tensor.mesh_buffer().address(),
             (std::uint32_t)in0_tensor_start_tile_id_stride * output_idx_y,  // in0_tensor_start_tile_id
             // in0 mcast args
             (std::uint32_t)0,  // in0_mcast_dest_noc_start_x
@@ -2582,8 +2583,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
         /* in1 */
         std::vector<uint32_t> mm_in1_args = {
             (std::uint32_t)core_type,
-            in1_tensor.address(),  // in1_tensor_addr
-            i,                     // ring_idx
+            in1_tensor.mesh_buffer().address(),  // in1_tensor_addr
+            i,                                   // ring_idx
         };
         if (in1_is_dram_sharded) {
             // Look up bank_id based on core.y and which column group core.x belongs to
@@ -2753,15 +2754,15 @@ inline void override_mcast_in1_program_parameters(
         // in0 sender
         auto& reader_runtime_args =
             reader_runtime_args_by_core[override_variables.start_core.x][override_variables.start_core.y];
-        reader_runtime_args[0] = src_a_tensor.address();
+        reader_runtime_args[0] = src_a_tensor.mesh_buffer().address();
 
         // in1 sender
         auto& sender_writer_runtime_args =
             GetRuntimeArgs(program, override_variables.kernels.at(1), override_variables.start_core);
-        sender_writer_runtime_args[0] = src_b_tensor.address();
-        sender_writer_runtime_args[7] = dst_tensor.address();
+        sender_writer_runtime_args[0] = src_b_tensor.mesh_buffer().address();
+        sender_writer_runtime_args[7] = dst_tensor.mesh_buffer().address();
         if (bias_tensor.has_value()) {
-            sender_writer_runtime_args[18] = bias_mesh_tensor->address();
+            sender_writer_runtime_args[18] = bias_mesh_tensor->mesh_buffer().address();
         }
     }
 
@@ -2775,9 +2776,9 @@ inline void override_mcast_in1_program_parameters(
         auto& writer_runtime_args = receiver_writer_runtime_args_by_core[core.x][core.y];
 
         // in0 sender
-        reader_runtime_args[0] = src_a_tensor.address();
+        reader_runtime_args[0] = src_a_tensor.mesh_buffer().address();
         // in1 receiver
-        writer_runtime_args[2] = dst_tensor.address();
+        writer_runtime_args[2] = dst_tensor.mesh_buffer().address();
     }
 
     if (src0_sharded) {
@@ -2832,7 +2833,7 @@ static void override_mcast_in0_program_parameters(
         // in0 sender
         auto& reader_sender_runtime_args =
             GetRuntimeArgs(program, override_variables.kernels.at(0), override_variables.start_core);
-        reader_sender_runtime_args[0] = src_a_tensor.address();
+        reader_sender_runtime_args[0] = src_a_tensor.mesh_buffer().address();
     }
 
     if (src1_sharded) {
@@ -2851,10 +2852,10 @@ static void override_mcast_in0_program_parameters(
         auto& writer_runtime_args = writer_runtime_args_by_core[core.x][core.y];
 
         // in1 sender
-        writer_runtime_args[0] = src_b_tensor.address();
-        writer_runtime_args[7] = dst_tensor.address();
+        writer_runtime_args[0] = src_b_tensor.mesh_buffer().address();
+        writer_runtime_args[7] = dst_tensor.mesh_buffer().address();
         if (bias_tensor.has_value()) {
-            writer_runtime_args[18] = bias_mesh_tensor->address();
+            writer_runtime_args[18] = bias_mesh_tensor->mesh_buffer().address();
         }
     }
 
@@ -2905,7 +2906,7 @@ inline void override_gather_in0_program_parameters(
         auto& writer_runtime_args = writer_runtime_args_by_core[core.x][core.y];
 
         /* in1 */
-        writer_runtime_args[1] = src_b_tensor.address();
+        writer_runtime_args[1] = src_b_tensor.mesh_buffer().address();
     }
 }
 
@@ -3821,7 +3822,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
         else if (core == start_core) {
             std::vector<uint32_t> mm_in0_sender_args = {
                 // in0 tensor args
-                (std::uint32_t)in0_tensor.address(),
+                0u,
                 (std::uint32_t)in0_tensor_start_tile_id_stride * output_idx_y,  // in0_tensor_start_tile_id
                 // in0 mcast args
                 (std::uint32_t)start_core_noc.x,  // in0_mcast_dest_noc_start_x
@@ -3860,7 +3861,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
             std::vector<uint32_t> mm_in1_sender_writer_args = {
                 // READER
                 // in1 tensor args
-                (std::uint32_t)in1_tensor.address(),
+                0u,
                 (std::uint32_t)in1_tensor_start_tile_id_stride * output_idx_x,  // in1_tensor_start_tile_id
                 // in1 mcast args
                 (std::uint32_t)0,  // in1_mcast_dest_noc_start_x
@@ -3873,7 +3874,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
 
                 // WRITER
                 // out tensor args
-                (std::uint32_t)out_tensor.address(),
+                0u,
                 ((std::uint32_t)output_idx_x * per_core_N) +
                     (output_idx_y * per_core_M * N)  // out_tensor_start_tile_id
             };
@@ -3907,8 +3908,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
             }
 
             // Bias base address placeholder; rebound to a tensor binding via in1_sender_variant[18] below.
-            mm_in1_sender_writer_args.push_back(
-                bias_tensor.has_value() ? (std::uint32_t)bias_tensor->address() : 0);  // smuggled-rta-ok
+            mm_in1_sender_writer_args.push_back(0u);
             mm_in1_sender_writer_args.push_back(
                 bias_tensor.has_value() ? (std::uint32_t)per_core_N * output_idx_x : 0);  // in3_tensor_start_tile_id
             if (!output_is_sharded) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
@@ -1197,7 +1197,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
         } else if (in1_idx == 0) {
             std::vector<uint32_t> mm_in0_sender_args = {
                 // in0 tensor args
-                (std::uint32_t)in0_tensor.address(),
+                0u,
                 (std::uint32_t)in0_tensor_start_tile_id_stride * in0_idx,  // in0_tensor_start_tile_id
                 // in0 mcast args
                 (std::uint32_t)in0_mcast_start.x,  // in0_mcast_dest_noc_start_x
@@ -1249,7 +1249,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
                 std::vector<uint32_t> mm_in1_sender_writer_args = {
                     // READER
                     // in1 tensor args
-                    (std::uint32_t)in1_tensor.address(),
+                    0u,
                     (std::uint32_t)in1_tensor_start_tile_id_stride * in1_idx,  // in1_tensor_start_tile_id
                     // in1 mcast args
                     (std::uint32_t)in1_mcast_start.x,  // in1_mcast_dest_noc_start_x
@@ -1262,7 +1262,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
 
                     // WRITER
                     // out tensor args
-                    (std::uint32_t)out_tensor.address(),
+                    0u,
                     ((std::uint32_t)in1_idx * per_core_N) + (in0_idx * per_core_M * N)  // out_tensor_start_tile_id
                 };
 
@@ -1294,7 +1294,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
                     mm_in1_sender_writer_args.push_back(0);
                 }
 
-                mm_in1_sender_writer_args.push_back(bias_mesh.has_value() ? (std::uint32_t)bias_mesh->address() : 0);
+                mm_in1_sender_writer_args.push_back(0u);
                 mm_in1_sender_writer_args.push_back(
                     bias_mesh.has_value() ? (std::uint32_t)per_core_N * in1_idx : 0);  // in1_tensor_start_tile_id
                 if (!output_is_sharded) {
@@ -1402,7 +1402,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
 
                     // WRITER
                     // out tensor args
-                    (std::uint32_t)out_tensor.address(),                                // out_tensor_addr
+                    0u,                                                                 // out_tensor_addr
                     ((std::uint32_t)in1_idx * per_core_N) + (in0_idx * per_core_M * N)  // out_tensor_start_tile_id
                 };
 
@@ -2655,7 +2655,7 @@ create_program_mcast_in0_in1(
         } else if (in1_idx == 0) {
             std::vector<uint32_t> mm_in0_sender_args = {
                 // in0 tensor args
-                (std::uint32_t)in0_tensor.address(),
+                (std::uint32_t)in0_tensor.mesh_buffer().address(),
                 (std::uint32_t)in0_tensor_start_tile_id_stride * in0_idx,  // in0_tensor_start_tile_id
                 // in0 mcast args
                 (std::uint32_t)in0_mcast_start.x,  // in0_mcast_dest_noc_start_x
@@ -2703,7 +2703,7 @@ create_program_mcast_in0_in1(
                 std::vector<uint32_t> mm_in1_sender_writer_args = {
                     // READER
                     // in1 tensor args
-                    (std::uint32_t)in1_tensor.address(),
+                    (std::uint32_t)in1_tensor.mesh_buffer().address(),
                     (std::uint32_t)in1_tensor_start_tile_id_stride * in1_idx,  // in1_tensor_start_tile_id
                     // in1 mcast args
                     (std::uint32_t)in1_mcast_start.x,  // in1_mcast_dest_noc_start_x
@@ -2716,7 +2716,7 @@ create_program_mcast_in0_in1(
 
                     // WRITER
                     // out tensor args
-                    (std::uint32_t)out_tensor.address(),
+                    (std::uint32_t)out_tensor.mesh_buffer().address(),
                     ((std::uint32_t)in1_idx * per_core_N) + (in0_idx * per_core_M * N)  // out_tensor_start_tile_id
                 };
 
@@ -2748,7 +2748,8 @@ create_program_mcast_in0_in1(
                     mm_in1_sender_writer_args.push_back(0);
                 }
 
-                mm_in1_sender_writer_args.push_back(bias_mesh.has_value() ? (std::uint32_t)bias_mesh->address() : 0);
+                mm_in1_sender_writer_args.push_back(
+                    bias_mesh.has_value() ? (std::uint32_t)bias_mesh->mesh_buffer().address() : 0);
                 mm_in1_sender_writer_args.push_back(
                     bias_mesh.has_value() ? (std::uint32_t)per_core_N * in1_idx : 0);  // in1_tensor_start_tile_id
                 if (!output_is_sharded) {
@@ -2848,7 +2849,7 @@ create_program_mcast_in0_in1(
 
                     // WRITER
                     // out tensor args
-                    (std::uint32_t)out_tensor.address(),                                // out_tensor_addr
+                    (std::uint32_t)out_tensor.mesh_buffer().address(),                  // out_tensor_addr
                     ((std::uint32_t)in1_idx * per_core_N) + (in0_idx * per_core_M * N)  // out_tensor_start_tile_id
                 };
 
@@ -3002,7 +3003,7 @@ void override_runtime_arguments_impl(
         auto& reader_sender_runtime_args_by_core = GetRuntimeArgs(program, mm_kernel_in0_sender_id);
         for (const auto& core : in0_sender_interleaved_cores) {
             auto& reader_runtime_args = reader_sender_runtime_args_by_core[core.x][core.y];
-            reader_runtime_args[0] = in0.address();
+            reader_runtime_args[0] = in0.mesh_buffer().address();
         }
     }
 
@@ -3010,10 +3011,10 @@ void override_runtime_arguments_impl(
     auto& sender_writer_runtime_args_by_core = GetRuntimeArgs(program, mm_kernel_in1_sender_writer_id);
     for (const auto& core : in1_sender_cores) {
         auto& writer_runtime_args = sender_writer_runtime_args_by_core[core.x][core.y];
-        writer_runtime_args[0] = in1.address();
-        writer_runtime_args[7] = out.address();
+        writer_runtime_args[0] = in1.mesh_buffer().address();
+        writer_runtime_args[7] = out.mesh_buffer().address();
         if (bias_tensor.has_value()) {
-            writer_runtime_args[18] = bias_mesh->address();
+            writer_runtime_args[18] = bias_mesh->mesh_buffer().address();
         }
     }
 
@@ -3021,14 +3022,14 @@ void override_runtime_arguments_impl(
     auto& receiver_writer_runtime_args_by_core = GetRuntimeArgs(program, mm_kernel_in1_receiver_writer_id);
     for (const auto& core : in1_receiver_cores) {
         auto& writer_runtime_args = receiver_writer_runtime_args_by_core[core.x][core.y];
-        writer_runtime_args[2] = out.address();
+        writer_runtime_args[2] = out.mesh_buffer().address();
     }
     if (mm_kernel_in1_receiver_writer_id != mm_kernel_in1_receiver_writer_other_noc_setup_id) {
         auto& receiver_writer_runtime_args_by_core =
             GetRuntimeArgs(program, mm_kernel_in1_receiver_writer_other_noc_setup_id);
         for (const auto& core : in1_receiver_other_cores) {
             auto& writer_runtime_args = receiver_writer_runtime_args_by_core[core.x][core.y];
-            writer_runtime_args[2] = out.address();
+            writer_runtime_args[2] = out.mesh_buffer().address();
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
@@ -760,8 +760,8 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
         bool is_worker_core = true;
         std::vector<uint32_t> mm_in1_sender_writer_args;
         mm_in1_sender_writer_args.push_back((std::uint32_t)is_worker_core);
-        mm_in1_sender_writer_args.push_back(in1_tensor.address());  // [1]: will be replaced by Buffer*
-        mm_in1_sender_writer_args.push_back(bias.has_value() ? bias->address() : 0u);  // [2]: may be replaced
+        mm_in1_sender_writer_args.push_back(0u);  // [1]: in1_tensor address, bound below
+        mm_in1_sender_writer_args.push_back(0u);  // [2]: bias address (if present), bound below
 
         uint32_t vc = bank_id & 0x3;
         bank_ids.push_back(bank_id);


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Cleanup

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

`MeshTensor::address` was added originally as a convince function mirroring the general use case of grabbing the address of a `ttnn::Tensor` and passing it to the kernel side.

However, this pattern is discouraged as we're moving towards accessing `MeshTensor` via Tensor bindings in metal 2.0 .
Grabbing the address of MeshTensor is discouraged.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

I apologize for the churn this PR causes, should not have added this function when lowering tensors.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/mt-rm-address)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/mt-rm-address)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/mt-rm-address)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/mt-rm-address)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=riverwu/mt-rm-address)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:riverwu/mt-rm-address)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/mt-rm-address)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/mt-rm-address)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/mt-rm-address)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/mt-rm-address)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/mt-rm-address)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/mt-rm-address)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/mt-rm-address)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/mt-rm-address)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/mt-rm-address)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/mt-rm-address)