### PR TITLE
[GPT-OSS] Fix tokenizers.Encoding dtype error in encode_prompt

### DIFF
--- a/models/demos/gpt_oss/tt/model_config.py
+++ b/models/demos/gpt_oss/tt/model_config.py
@@ -217,11 +217,18 @@ class ModelArgs:
             # prompt_text is already a list of chat messages
             encoded = self.tokenizer.apply_chat_template(prompt_text, add_generation_prompt=True, tokenize=True)
 
-        # Depending on the tokenizer, apply_chat_template(tokenize=True) may return a
-        # tokenizers.Encoding (fast-tokenizer path) rather than a plain List[int].
-        # Normalize to a list of token ids so downstream torch.tensor(...) can infer a dtype.
-        if hasattr(encoded, "ids"):
-            encoded = encoded.ids
+        # Depending on the tokenizer/transformers version, apply_chat_template(tokenize=True)
+        # may return a plain List[int], a single tokenizers.Encoding, or a list of
+        # tokenizers.Encoding objects (observed with the GPT-OSS fast tokenizer, which
+        # otherwise yields `torch.tensor(...)` "Could not infer dtype of tokenizers.Encoding"
+        # downstream). Normalize to a flat List[int] of token ids.
+        if hasattr(encoded, "ids"):  # single tokenizers.Encoding
+            encoded = list(encoded.ids)
+        elif isinstance(encoded, (list, tuple)) and any(hasattr(e, "ids") for e in encoded):
+            flat = []
+            for e in encoded:
+                flat.extend(e.ids if hasattr(e, "ids") else ([e] if isinstance(e, int) else list(e)))
+            encoded = flat
         return encoded
 
     @staticmethod

--- a/models/demos/gpt_oss/tt/model_config.py
+++ b/models/demos/gpt_oss/tt/model_config.py
@@ -212,10 +212,17 @@ class ModelArgs:
                 chat.append({"role": "system", "content": system_prompt_text})
             if prompt_text:
                 chat.append({"role": "user", "content": prompt_text})
-            return self.tokenizer.apply_chat_template(chat, add_generation_prompt=True, tokenize=True)
+            encoded = self.tokenizer.apply_chat_template(chat, add_generation_prompt=True, tokenize=True)
         else:
             # prompt_text is already a list of chat messages
-            return self.tokenizer.apply_chat_template(prompt_text, add_generation_prompt=True, tokenize=True)
+            encoded = self.tokenizer.apply_chat_template(prompt_text, add_generation_prompt=True, tokenize=True)
+
+        # Depending on the tokenizer, apply_chat_template(tokenize=True) may return a
+        # tokenizers.Encoding (fast-tokenizer path) rather than a plain List[int].
+        # Normalize to a list of token ids so downstream torch.tensor(...) can infer a dtype.
+        if hasattr(encoded, "ids"):
+            encoded = encoded.ids
+        return encoded
 
     @staticmethod
     def load_state_dict(weights_path, dummy_weights=False, convert_to_meta_format=True):

--- a/models/demos/gpt_oss/tt/model_config.py
+++ b/models/demos/gpt_oss/tt/model_config.py
@@ -217,18 +217,32 @@ class ModelArgs:
             # prompt_text is already a list of chat messages
             encoded = self.tokenizer.apply_chat_template(prompt_text, add_generation_prompt=True, tokenize=True)
 
-        # Depending on the tokenizer/transformers version, apply_chat_template(tokenize=True)
-        # may return a plain List[int], a single tokenizers.Encoding, or a list of
-        # tokenizers.Encoding objects (observed with the GPT-OSS fast tokenizer, which
-        # otherwise yields `torch.tensor(...)` "Could not infer dtype of tokenizers.Encoding"
-        # downstream). Normalize to a flat List[int] of token ids.
-        if hasattr(encoded, "ids"):  # single tokenizers.Encoding
-            encoded = list(encoded.ids)
-        elif isinstance(encoded, (list, tuple)) and any(hasattr(e, "ids") for e in encoded):
-            flat = []
-            for e in encoded:
-                flat.extend(e.ids if hasattr(e, "ids") else ([e] if isinstance(e, int) else list(e)))
-            encoded = flat
+        # Normalize whatever apply_chat_template(tokenize=True) returns into a flat List[int].
+        # Across tokenizer/transformers versions this may be a List[int], a tokenizers.Encoding,
+        # a list of Encodings, or a BatchEncoding/dict ({"input_ids": ...}). The GPT-OSS fast
+        # tokenizer in CI returns a non-list form, which made downstream torch.tensor(...) raise
+        # "Could not infer dtype of tokenizers.Encoding".
+        raw_type = type(encoded).__name__
+        # BatchEncoding / dict -> take input_ids
+        if isinstance(encoded, dict) or hasattr(encoded, "input_ids"):
+            encoded = encoded["input_ids"] if "input_ids" in encoded else getattr(encoded, "input_ids")
+
+        def _to_ids(obj):
+            if hasattr(obj, "ids"):  # tokenizers.Encoding
+                return list(obj.ids)
+            if isinstance(obj, (list, tuple)):
+                flat = []
+                for item in obj:
+                    flat.append(item) if isinstance(item, int) else flat.extend(_to_ids(item))
+                return flat
+            return obj
+
+        encoded = _to_ids(encoded)
+        if not (isinstance(encoded, list) and (len(encoded) == 0 or isinstance(encoded[0], int))):
+            logger.warning(
+                f"[gpt-oss encode_prompt] unexpected token container: raw={raw_type}, "
+                f"normalized={type(encoded).__name__}"
+            )
         return encoded
 
     @staticmethod


### PR DESCRIPTION
## Problem

GPT-OSS e2e demos are failing across all SKUs (bh_galaxy, bh_quietbox_2, wh_galaxy_perf) in the scheduled model pipelines with:

```
RuntimeError: Could not infer dtype of tokenizers.Encoding
```

Traceback points to shared code in `models/tt_transformers/tt/common.py:336`:

```python
input_tokens_prefill_i[0, : len(encoded[:])] = torch.tensor(encoded[:]).to(input_tokens_prefill_i)
```

## Root cause

`encoded` comes from `GPT-OSS model_args.encode_prompt()`, which returns whatever
`tokenizer.apply_chat_template(..., tokenize=True)` produces. For the GPT-OSS tokenizer
this is a `tokenizers.Encoding` object (fast-tokenizer path), not a plain `List[int]`,
so `torch.tensor(...)` cannot infer a dtype.

## Fix

Normalize `encode_prompt` (in `models/demos/gpt_oss/tt/model_config.py`) to return the
token ids when an `Encoding` is returned:

```python
if hasattr(encoded, "ids"):
    encoded = encoded.ids
return encoded
```

- **GPT-OSS-scoped** — no change to shared `common.py` or other models.
- **Backward-compatible** — guarded with `hasattr(encoded, "ids")`, so a plain `List[int]`
  (every other tokenizer / older transformers behavior) passes straight through.

## Testing

- `python -m py_compile` passes.
- Logic fix verified against the CI traceback; requires Blackhole/Galaxy hardware + GPT-OSS
  weights to validate end-to-end, which will happen by re-running the GPT-OSS e2e/unit jobs in CI.

## Related

Surfaced while triaging the latest scheduled `main` model pipelines (T1-e2e). This is a
pre-existing failure on `main`, not introduced by any in-flight PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/gpt-oss-encoding-dtype-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/gpt-oss-encoding-dtype-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/gpt-oss-encoding-dtype-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/gpt-oss-encoding-dtype-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mtairum/gpt-oss-encoding-dtype-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mtairum/gpt-oss-encoding-dtype-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/gpt-oss-encoding-dtype-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/gpt-oss-encoding-dtype-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/gpt-oss-encoding-dtype-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/gpt-oss-encoding-dtype-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/gpt-oss-encoding-dtype-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/gpt-oss-encoding-dtype-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/gpt-oss-encoding-dtype-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/gpt-oss-encoding-dtype-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/gpt-oss-encoding-dtype-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/gpt-oss-encoding-dtype-fix)
## CI validation

GPT-OSS-only runs (Tiers 1+2, unit+e2e, all SKUs):
- Run 1 (d24380a): https://github.com/tenstorrent/tt-metal/actions/runs/28286327628 — revealed `apply_chat_template` returns a non-single-Encoding container; first fix insufficient.
- Run 2 (81bdca7, flatten list-of-Encodings): https://github.com/tenstorrent/tt-metal/actions/runs/28293086703 — still failed; logs consistently showed `Encoded prompt lengths: 2`, pointing to a BatchEncoding/dict shape.
- Run 3 (52d4f37, robust normalizer for dict/BatchEncoding/Encoding/list + diagnostic log): https://github.com/tenstorrent/tt-metal/actions/runs/28293870001
