### PR TITLE
[LLK] BH SFPU teardown: drop the spurious addr-mod-base reset (S2)

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_ema_sfpu_entry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_ema_sfpu_entry.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include "llk_math_eltwise_ternary_sfpu.h"
 #include "sfpu/ckernel_sfpu_ema.h"
 
@@ -11,14 +12,16 @@ namespace ckernel {
 
 inline void llk_math_ema_sfpu_init() { _llk_math_eltwise_ternary_sfpu_init_<SfpuType::unused>(); }
 
-inline void llk_math_ema_sfpu_load_alpha_beta(uint32_t alpha, uint32_t beta) { sfpu::_load_alpha_beta_(alpha, beta); }
+inline void llk_math_ema_sfpu_load_alpha_beta(std::uint32_t alpha, std::uint32_t beta) {
+    sfpu::_load_alpha_beta_(alpha, beta);
+}
 
 inline void llk_math_ema_sfpu_clear_previous_output() { sfpu::_clear_previous_output_(); }
 
-inline void llk_math_ema_sfpu_tile(uint32_t input_dst_index) {
+inline void llk_math_ema_sfpu_tile(std::uint32_t input_dst_index) {
     _llk_math_eltwise_sfpu_start_(input_dst_index);
     sfpu::_calculate_ema_tile_();
-    _llk_math_eltwise_sfpu_done_with_addrmod_reset_();
+    _llk_math_eltwise_sfpu_done_();
 }
 
 }  // namespace ckernel

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_sfpu_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_sfpu_common.h
@@ -25,14 +25,6 @@ inline void _llk_math_eltwise_sfpu_done_()
     math::clear_dst_reg_addr();
 }
 
-inline void _llk_math_eltwise_sfpu_done_with_addrmod_reset_()
-{
-    math::clear_dst_reg_addr();
-
-    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::WAIT_SFPU);
-    TTI_SETC16(2, 0);
-}
-
 inline void _llk_math_eltwise_sfpu_inc_dst_face_addr_()
 {
     math::inc_dst_addr<8>();

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_ternary_sfpu_params.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_ternary_sfpu_params.h
@@ -24,5 +24,5 @@ inline void _llk_math_eltwise_ternary_sfpu_params_(
     _llk_math_eltwise_sfpu_apply_vector_mode_(
         std::forward<Callable>(sfpu_func), vector_mode, dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out, std::forward<Args>(args)...);
 
-    _llk_math_eltwise_sfpu_done_with_addrmod_reset_(); // Finalize
+    _llk_math_eltwise_sfpu_done_(); // Finalize
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_welfords_sfpu_params.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_welfords_sfpu_params.h
@@ -13,5 +13,5 @@ inline void _llk_math_welfords_sfpu_params_(Callable&& sfpu_func, std::uint32_t 
 {
     _llk_math_eltwise_sfpu_start_(dst_index0);
     std::forward<Callable>(sfpu_func)(std::forward<ARGS>(args)...);
-    _llk_math_eltwise_sfpu_done_with_addrmod_reset_(); // Finalize
+    _llk_math_eltwise_sfpu_done_(); // Finalize
 }


### PR DESCRIPTION
Master issue : https://github.com/tenstorrent/tt-llk/issues/1652

_llk_math_eltwise_sfpu_done_with_addrmod_reset_ ended with TTI_STALLWAIT(STALL_CFG, WAIT_SFPU); TTI_SETC16(2, 0) -- a mechanical copy of Wormhole's clear_addr_mod_base(), where cfg word 2 == ADDR_MOD_SET_Base. Blackhole has no addr-mod base (SFPU uses 3-bit direct addr mods, so _start_ never sets one and there is nothing to clear). On BH, cfg word 2 instead holds DISABLE_IMPLIED_SRCA_FMT_Base (plus packed STACC_RELU / Zero_Flag / DISABLE_RISC_BP fields), so the SETC16 does nothing useful and would clobber DISABLE_IMPLIED_SRCA_FMT_Base had a prior op (transpose_dest/datacopy/topk) set it.

Wormhole folds the addr-mod reset into _done_() because WH _start_ sets the base; BH _start_ doesn't, so BH needs no reset variant at all -- and indeed the Wormhole welford/ternary param helpers already call _done_() at the same site. Remove _llk_math_eltwise_sfpu_done_with_addrmod_reset_ and point its three callers (llk_math_welfords_sfpu_params.h, llk_math_eltwise_ternary_sfpu_params.h, and the metal entry llk_math_ema_sfpu_entry.h) at _done_(), matching WH.

Benign by default today (DISABLE_IMPLIED_SRCA_FMT_Base defaults to 0). Found in the LLK ISA audit (P2, S2). Compile-verified (test_ttnn_where.py, BH).

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/llk-fix-s2-bh-sfpu-addrmod-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/llk-fix-s2-bh-sfpu-addrmod-reset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/llk-fix-s2-bh-sfpu-addrmod-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/llk-fix-s2-bh-sfpu-addrmod-reset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/llk-fix-s2-bh-sfpu-addrmod-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/llk-fix-s2-bh-sfpu-addrmod-reset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/llk-fix-s2-bh-sfpu-addrmod-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/llk-fix-s2-bh-sfpu-addrmod-reset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/llk-fix-s2-bh-sfpu-addrmod-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/llk-fix-s2-bh-sfpu-addrmod-reset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/llk-fix-s2-bh-sfpu-addrmod-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/llk-fix-s2-bh-sfpu-addrmod-reset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/llk-fix-s2-bh-sfpu-addrmod-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/llk-fix-s2-bh-sfpu-addrmod-reset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/llk-fix-s2-bh-sfpu-addrmod-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/llk-fix-s2-bh-sfpu-addrmod-reset)