### PR TITLE
[LLK] BH math config writes: stall on SFPU when writing SFPU-read

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
@@ -21,7 +21,8 @@ using namespace ckernel::math;
  */
 inline void _llk_math_set_fp32_dest_acc_(bool enable)
 {
-    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH);
+    // SFPU_Fp32_enabled is read by SFPLOAD/SFPSTORE (MOD0_FMT_SRCB), so the SFPU must drain too, not just the FPU.
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
     cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(enable);
     cfg_reg_rmw_tensix<ALU_ACC_CTRL_SFPU_Fp32_enabled_RMW>(enable);
 }
@@ -48,7 +49,8 @@ inline void _llk_math_hw_configure_(const std::uint32_t srca_data_format, const 
 
     // Configure ZEROACC to auto-detect destination bank (non-legacy mode).
     cfg_reg_rmw_tensix<DEST_ACCESS_CFG_zeroacc_absolute_tile_mode_RMW>(0);
-    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH);
+    // SFPU_Fp32_enabled (written below) is read by SFPLOAD/SFPSTORE (MOD0_FMT_SRCB), so the SFPU must drain too.
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
     std::uint32_t int8_math_enabled = is_int8_or_int32_format(srca_data_format) || is_int8_or_int32_format(srcb_data_format);
     cfg_reg_rmw_tensix<ALU_ACC_CTRL_INT8_math_enabled_RMW>(int8_math_enabled);
 
@@ -166,6 +168,9 @@ inline void _llk_math_reconfig_data_format_srca_(const std::uint32_t srca_data_f
     if constexpr (to_from_int8)
     {
         static_assert(is_fp32_dest_acc_en, "Reconfiguring math to/from Int8 formats requires FP32 Dest mode enabled");
+        // Only INT8_math_enabled is written here; it is FPU-only (the SFPU never reads it, and on Blackhole SrcB
+        // format is inferred rather than rewritten here), so draining the FPU (MATH) suffices -- no WAIT_SFPU.
+        // (Wormhole's twin uses WAIT_SFPU because there the reconfig also rewrites the SFPU-read SrcB format.)
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH);
         std::uint32_t int8_math_enabled = is_int8_or_int32_format(srca_data_format);
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_INT8_math_enabled_RMW>(int8_math_enabled);
@@ -193,6 +198,9 @@ inline void _llk_math_reconfig_data_format_srcb_(const std::uint32_t srcb_data_f
     if constexpr (to_from_int8)
     {
         static_assert(is_fp32_dest_acc_en, "Reconfiguring math to/from Int8 formats requires FP32 Dest mode enabled");
+        // Only INT8_math_enabled is written here; it is FPU-only (the SFPU never reads it, and on Blackhole SrcB
+        // format is inferred rather than rewritten here), so draining the FPU (MATH) suffices -- no WAIT_SFPU.
+        // (Wormhole's twin uses WAIT_SFPU because there the reconfig also rewrites the SFPU-read SrcB format.)
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH);
         std::uint32_t int8_math_enabled = is_int8_or_int32_format(srcb_data_format);
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_INT8_math_enabled_RMW>(int8_math_enabled);
@@ -222,6 +230,9 @@ inline void _llk_math_reconfig_data_format_(const std::uint32_t srca_data_format
     if constexpr (to_from_int8)
     {
         static_assert(is_fp32_dest_acc_en, "Reconfiguring math to/from Int8 formats requires FP32 Dest mode enabled");
+        // Only INT8_math_enabled is written here; it is FPU-only (the SFPU never reads it, and on Blackhole SrcB
+        // format is inferred rather than rewritten here), so draining the FPU (MATH) suffices -- no WAIT_SFPU.
+        // (Wormhole's twin uses WAIT_SFPU because there the reconfig also rewrites the SFPU-read SrcB format.)
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH);
         std::uint32_t int8_math_enabled = is_int8_or_int32_format(srca_data_format) || is_int8_or_int32_format(srcb_data_format);
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_INT8_math_enabled_RMW>(int8_math_enabled);


### PR DESCRIPTION
Issues : https://github.com/tenstorrent/tt-llk/issues/1652
https://github.com/tenstorrent/tt-llk/issues/747

Two config-write stalls in Blackhole's llk_math_common.h drain only the FPU pipeline (p_stall::MATH), but they guard a write to ALU_ACC_CTRL_SFPU_Fp32_enabled -- a bit the SFPU reads. Per the ISA SFPLOAD/SFPSTORE functional models (BlackholeA0), the Vector Unit resolves MOD0_FMT_SRCB by reading ALU_ACC_CTRL_SFPU_Fp32_enabled (and ALU_FORMAT_SPEC_REG1_SrcB). Updating that bit with only the FPU drained lets an in-flight SFPLOAD/SFPSTORE straddle the write, so these two stalls need WAIT_SFPU as well:
  - _llk_math_set_fp32_dest_acc_
  - _llk_math_hw_configure_

The three _reconfig_data_format_* int8 branches are deliberately left as MATH-only: they write *only* ALU_ACC_CTRL_INT8_math_enabled, which is FPU-only (it appears in the FPU instruction models -- MVMUL/ELWADD/ELWMUL/MOVD2A,B -- and in neither SFPLOAD nor SFPSTORE), and on Blackhole the SFPU-read SrcB format is inferred rather than rewritten here. Adding WAIT_SFPU there would be pure over-serialization with no ordering benefit. (Wormhole's twins carry WAIT_SFPU on their reconfig because there the reconfig also rewrites the SFPU-read SrcB format -- a divergence, not a bug to mirror.) Comments record this so the asymmetry with WH isn't "fixed" later.

Latent today (only bites when an SFPU op is mid-flight across the fp32-dest toggle). Found in the LLK ISA audit (P2, S1). Compile-verified (test_eltwise_binary.py int8/fp32-dest variant, BH).

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/llk-fix-s1-bh-math-config-wait-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/llk-fix-s1-bh-math-config-wait-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/llk-fix-s1-bh-math-config-wait-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/llk-fix-s1-bh-math-config-wait-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/llk-fix-s1-bh-math-config-wait-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/llk-fix-s1-bh-math-config-wait-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/llk-fix-s1-bh-math-config-wait-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/llk-fix-s1-bh-math-config-wait-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/llk-fix-s1-bh-math-config-wait-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/llk-fix-s1-bh-math-config-wait-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/llk-fix-s1-bh-math-config-wait-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/llk-fix-s1-bh-math-config-wait-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/llk-fix-s1-bh-math-config-wait-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/llk-fix-s1-bh-math-config-wait-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/llk-fix-s1-bh-math-config-wait-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/llk-fix-s1-bh-math-config-wait-sfpu)