### PR TITLE
[skip ci] Skip test_decoder unpaged/decode_low_latency/4x8 on Wormhole Galaxy

### DIFF
--- a/models/demos/gpt_oss/tests/unit/test_modules.py
+++ b/models/demos/gpt_oss/tests/unit/test_modules.py
@@ -7,7 +7,7 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.common.utility_functions import is_blackhole
+from models.common.utility_functions import is_blackhole, is_wormhole_b0
 from models.tt_transformers.tt.common import gather_cos_sin, precompute_freqs, rope_scaling_model_factory
 from models.tt_transformers.tt.load_checkpoints import convert_hf_qkv_to_meta_format
 from models.tt_transformers.tt.rope import RotarySetup
@@ -707,6 +707,19 @@ def test_decoder(
         pytest.skip(
             f"Skipping batch={batch_size} seq_len={seq_len} on Blackhole {tuple(mesh_device.shape)}: "
             "this configuration uses throughput experts which are not supported on Blackhole."
+        )
+
+    if (
+        is_wormhole_b0()
+        and tuple(mesh_device.shape) == (4, 8)
+        and not paged
+        and seq_len == 1
+        and batch_size == 1
+        and layer_idx == 0
+    ):
+        pytest.skip(
+            "Skipping test_decoder[wormhole_b0-unpaged-layer_0-decode_low_latency-4x8]: "
+            "device timeout / hang on Wormhole Galaxy 4x8 mesh, refs #47405"
         )
 
     assert batch_size == 1 or seq_len == 1, "Only single user prefill or single token decode is supported"


### PR DESCRIPTION
Temporarily skip `test_decoder[wormhole_b0-unpaged-layer_0-decode_low_latency-4x8]` on the Wormhole Galaxy (4x8 mesh) due to a device timeout / potential hang that has been failing for 7+ days.

The skip is scoped to exactly the failing parametrization: `paged=False`, `layer_idx=0`, `batch_size=1`, `seq_len=1` (decode_low_latency), mesh shape `(4, 8)`, on Wormhole B0 only.

refs #47405

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47405)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lifecycle/disable-issue-47405)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47405)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lifecycle/disable-issue-47405)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=lifecycle/disable-issue-47405)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:lifecycle/disable-issue-47405)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lifecycle/disable-issue-47405)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lifecycle/disable-issue-47405)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47405)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lifecycle/disable-issue-47405)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lifecycle/disable-issue-47405)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lifecycle/disable-issue-47405)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lifecycle/disable-issue-47405)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lifecycle/disable-issue-47405)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lifecycle/disable-issue-47405)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lifecycle/disable-issue-47405)