### PR TITLE
[LLK] Assert FP32 Dest mode when initial math hw_configure enables 

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
@@ -10,6 +10,7 @@
 #include "ckernel_include.h"
 #include "ckernel_ops.h"
 #include "cmath_common.h"
+#include "llk_assert.h"
 #include "sanitizer/api.h"
 
 using namespace ckernel::math;
@@ -53,6 +54,14 @@ inline void _llk_math_hw_configure_(const std::uint32_t srca_data_format, const 
                                       (masked_data_format(srcb_data_format) == ckernel::to_underlying(DataFormat::Int8)) ||
                                       (srca_data_format == ckernel::to_underlying(DataFormat::Int32)) ||
                                       (srcb_data_format == ckernel::to_underlying(DataFormat::Int32));
+    // int8/int32 math writes 32-bit (INT32) results to DEST: ELWADD/MVMUL force UseDst32b whenever
+    // ALU_ACC_CTRL_INT8_math_enabled is set, independent of ALU_ACC_CTRL_Fp32_enabled (see
+    // BlackholeA0/TensixTile/TensixCoprocessor/ELWADD.md, MVMUL.md). The int8 op itself therefore doesn't depend
+    // on the Fp32_enabled bit -- but the kernel's DEST must still be in 32-bit mode (is_fp32_dest_acc_en) so tile
+    // geometry / addressing / packer config match those 32-bit writes. A caller that passes int8 formats with
+    // is_fp32_dest_acc_en=false silently runs 32-bit-dest math under a 16-bit-dest layout. Mirrors the
+    // static_assert in _llk_math_reconfig_data_format_*; here int8 is derived at runtime, so it's a runtime assert.
+    LLK_ASSERT(!int8_math_enabled || is_fp32_dest_acc_en, "Configuring math for Int8/Int32 formats requires FP32 Dest mode enabled");
     cfg_reg_rmw_tensix<ALU_ACC_CTRL_INT8_math_enabled_RMW>(int8_math_enabled);
 
     cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(is_fp32_dest_acc_en);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
@@ -10,6 +10,7 @@
 #include "ckernel_include.h"
 #include "ckernel_ops.h"
 #include "cmath_common.h"
+#include "llk_assert.h"
 #include "sanitizer/api.h"
 
 using namespace ckernel::math;
@@ -48,6 +49,14 @@ inline void _llk_math_hw_configure_(const std::uint32_t srca_data_format, const 
     std::uint32_t int8_math_enabled = (masked_data_format(srca_data_format) == to_underlying(DataFormat::Int8)) ||
                                       (masked_data_format(srcb_data_format) == to_underlying(DataFormat::Int8)) ||
                                       (srca_data_format == to_underlying(DataFormat::Int32)) || (srcb_data_format == to_underlying(DataFormat::Int32));
+    // int8/int32 math writes 32-bit (INT32) results to DEST: ELWADD/MVMUL force UseDst32b whenever
+    // ALU_ACC_CTRL_INT8_math_enabled is set, independent of ALU_ACC_CTRL_Fp32_enabled (see
+    // WormholeB0/TensixTile/TensixCoprocessor/ELWADD.md, MVMUL.md). The int8 op itself therefore doesn't depend
+    // on the Fp32_enabled bit -- but the kernel's DEST must still be in 32-bit mode (is_fp32_dest_acc_en) so tile
+    // geometry / addressing / packer config match those 32-bit writes. A caller that passes int8 formats with
+    // is_fp32_dest_acc_en=false silently runs 32-bit-dest math under a 16-bit-dest layout. Mirrors the
+    // static_assert in _llk_math_reconfig_data_format_*; here int8 is derived at runtime, so it's a runtime assert.
+    LLK_ASSERT(!int8_math_enabled || is_fp32_dest_acc_en, "Configuring math for Int8/Int32 formats requires FP32 Dest mode enabled");
     std::uint32_t config_data = (srca_data_format << ALU_FORMAT_SPEC_REG0_SrcA_SHAMT) | (srcb_data_format << ALU_FORMAT_SPEC_REG1_SrcB_SHAMT) |
                                 (int8_math_enabled << ALU_ACC_CTRL_INT8_math_enabled_SHAMT);
     constexpr std::uint32_t config_mask = ALU_FORMAT_SPEC_REG0_SrcA_MASK | ALU_FORMAT_SPEC_REG1_SrcB_MASK | ALU_ACC_CTRL_INT8_math_enabled_MASK;


### PR DESCRIPTION
Issue : https://github.com/tenstorrent/tt-llk/issues/1652

_llk_math_reconfig_data_format_srca_/_srcb_/_ guard their INT8 path with static_assert(is_fp32_dest_acc_en, "Reconfiguring math to/from Int8 formats requires FP32 Dest mode enabled"), but the initial _llk_math_hw_configure_ enabled INT8 math from Int8/Int32 source formats with no equivalent check.

Per the ISA (ELWADD.md / MVMUL.md, WH+BH): when ALU_ACC_CTRL_INT8_math_enabled is set, the FPU forces UseDst32b=true and writes 32-bit (INT32) results to DEST, *independent* of ALU_ACC_CTRL_Fp32_enabled. So the int8 op itself does not depend on the Fp32_enabled bit -- but the kernel's DEST must still be in 32-bit mode (is_fp32_dest_acc_en) so that tile geometry, addressing, and packer config match those 32-bit writes. A caller that passes int8 formats with is_fp32_dest_acc_en=false believes DEST is 16-bit and lays it out as such, while the HW silently writes 32-bit results -- corrupting silently with no other guard.

Unlike the reconfig helpers, which know at compile time (to_from_int8) that they are on the INT8 path, hw_configure derives int8_math_enabled at runtime from the format arguments, so a literal static_assert(is_fp32_dest_acc_en) would fire for every legal non-FP32 float configuration. The faithful equivalent is a runtime assert that only triggers when INT8 math is actually being enabled: LLK_ASSERT(!int8_math_enabled || is_fp32_dest_acc_en, ...). Added the llk_assert.h include and this assert in both Wormhole B0 and Blackhole. No change to programmed register values; assert-only.

Found in the LLK ISA audit (P2, F7).

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/llk-fix-f7-hw-configure-int8-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/llk-fix-f7-hw-configure-int8-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/llk-fix-f7-hw-configure-int8-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/llk-fix-f7-hw-configure-int8-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/llk-fix-f7-hw-configure-int8-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/llk-fix-f7-hw-configure-int8-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/llk-fix-f7-hw-configure-int8-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/llk-fix-f7-hw-configure-int8-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/llk-fix-f7-hw-configure-int8-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/llk-fix-f7-hw-configure-int8-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/llk-fix-f7-hw-configure-int8-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/llk-fix-f7-hw-configure-int8-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/llk-fix-f7-hw-configure-int8-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/llk-fix-f7-hw-configure-int8-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/llk-fix-f7-hw-configure-int8-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/llk-fix-f7-hw-configure-int8-assert)