### PR TITLE
[LLK][skip-ci] Document the to_from_int8 reconfig caller contract for stale unsigned/INT8 bits (F5)

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
@@ -133,6 +133,11 @@ inline void _llk_unpack_configure_stoch_rnd_()
  * @param tile_size: New tile size of operand A stored to the tile-size GPR.
  * @param unpack_face_r_dim: Rows per face, used when reprogramming dim/stride.
  * @param unpack_num_faces: Number of faces, valid values = <1, 2, 4>.
+ * @note Caller contract: the SrcA-unsigned ALU bit (ALU_FORMAT_SPEC_REG0_SrcAUnsigned), and the math-side
+ *       INT8 math-enable in @ref _llk_math_reconfig_data_format_srca_, are only reprogrammed when
+ *       to_from_int8 is set. Set to_from_int8 = true for ANY reconfig that transitions to OR from an
+ *       8-bit-integer / Int8 / Int32 format (e.g. UInt8 -> float); otherwise the previous unsigned/INT8
+ *       state is left stale and the next op misinterprets the operand.
  */
 // TODO NC: Clean up as the part of tt-metal#34499
 template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
@@ -212,6 +217,11 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
  * @param tile_size: New tile size of operand B stored to the tile-size GPR.
  * @param unpack_face_r_dim: Rows per face, used when reprogramming dim/stride.
  * @param unpack_num_faces: Number of faces, valid values = <1, 2, 4>.
+ * @note Caller contract: the SrcB-unsigned ALU bit (ALU_FORMAT_SPEC_REG0_SrcBUnsigned), and the math-side
+ *       INT8 math-enable in @ref _llk_math_reconfig_data_format_srcb_, are only reprogrammed when
+ *       to_from_int8 is set. Set to_from_int8 = true for ANY reconfig that transitions to OR from an
+ *       8-bit-integer / Int8 / Int32 format (e.g. UInt8 -> float); otherwise the previous unsigned/INT8
+ *       state is left stale and the next op misinterprets the operand.
  */
 // TODO NC: Clean up as the part of tt-metal#34499
 template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
@@ -138,6 +138,11 @@ inline void _llk_unpack_configure_stoch_rnd_()
  * @param tile_size: New tile size of operand A stored to the tile-size GPR.
  * @param unpack_face_r_dim: Rows per face, used when reprogramming dim/stride.
  * @param unpack_num_faces: Number of faces, valid values = <1, 2, 4>.
+ * @note Caller contract: the SrcA-unsigned ALU bit (ALU_FORMAT_SPEC_REG0_SrcAUnsigned), and the math-side
+ *       INT8 math-enable in @ref _llk_math_reconfig_data_format_srca_, are only reprogrammed when
+ *       to_from_int8 is set. Set to_from_int8 = true for ANY reconfig that transitions to OR from an
+ *       8-bit-integer / Int8 / Int32 format (e.g. UInt8 -> float); otherwise the previous unsigned/INT8
+ *       state is left stale and the next op misinterprets the operand.
  */
 // TODO NC: Clean up as the part of tt-metal#34499
 template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
@@ -214,6 +219,11 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
  * @param tile_size: New tile size of operand B stored to the tile-size GPR.
  * @param unpack_face_r_dim: Rows per face, used when reprogramming dim/stride.
  * @param unpack_num_faces: Number of faces, valid values = <1, 2, 4>.
+ * @note Caller contract: the SrcB-unsigned ALU bit (ALU_FORMAT_SPEC_REG0_SrcBUnsigned), and the math-side
+ *       INT8 math-enable in @ref _llk_math_reconfig_data_format_srcb_, are only reprogrammed when
+ *       to_from_int8 is set. Set to_from_int8 = true for ANY reconfig that transitions to OR from an
+ *       8-bit-integer / Int8 / Int32 format (e.g. UInt8 -> float); otherwise the previous unsigned/INT8
+ *       state is left stale and the next op misinterprets the operand.
  */
 // TODO NC: Clean up as the part of tt-metal#34499
 template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
@@ -266,7 +276,6 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
         cfg_reg_rmw_tensix<THCON_SEC1_REG0_TileDescriptor_ADDR32 + 1, 0, TILE_DESC_UPPER_HALFWORD_MASK>(0 | (unpack_num_faces << 16));
     }
 }
-
 
 /**
  * @brief Enable Int8 math on the FPU.


### PR DESCRIPTION
https://github.com/tenstorrent/tt-llk/issues/1652

The unpack reconfig helpers _llk_unpack_reconfig_data_format_srca_impl_ / _srcb_impl_ only reprogram the SrcA/SrcB-unsigned ALU bit (ALU_FORMAT_SPEC_REG0_SrcA/BUnsigned) when the to_from_int8 template flag is set, mirroring the math-side INT8 math-enable in _llk_math_reconfig_data_format_srca_/ _srcb_. A reconfig away from a UInt8 (or Int8/Int32) format performed with to_from_int8 = false therefore leaves the previous unsigned / INT8-math state in place, so the next op reads the operand with the wrong signedness or through the wrong (INT8 vs float) datapath.

This is a caller contract rather than a recomputation bug: silently recomputing these bits unconditionally on every reconfig would change behavior for the common non-int8 reconfig path and is out of scope for a latent-contract fix. Document the contract on the to_from_int8 template parameter (both operands, both Wormhole B0 and Blackhole) so callers know they MUST set to_from_int8 = true for any transition to or from an 8-bit-integer / Int8 / Int32 format. No functional change.

Found in the LLK ISA audit (P2, F5).

### PR Category
NFC

### Notes for reviewers
Merging decision upto reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/llk-fix-f5-int8-reconfig-contract)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/llk-fix-f5-int8-reconfig-contract)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/llk-fix-f5-int8-reconfig-contract)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/llk-fix-f5-int8-reconfig-contract)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/llk-fix-f5-int8-reconfig-contract)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/llk-fix-f5-int8-reconfig-contract)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/llk-fix-f5-int8-reconfig-contract)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/llk-fix-f5-int8-reconfig-contract)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/llk-fix-f5-int8-reconfig-contract)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/llk-fix-f5-int8-reconfig-contract)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/llk-fix-f5-int8-reconfig-contract)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/llk-fix-f5-int8-reconfig-contract)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/llk-fix-f5-int8-reconfig-contract)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/llk-fix-f5-int8-reconfig-contract)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/llk-fix-f5-int8-reconfig-contract)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/llk-fix-f5-int8-reconfig-contract)