### PR TITLE
[LLK][skip-ci] Document cross-thread RMW of the ALU format/control word in math config (C2)

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
@@ -102,6 +102,13 @@ inline void _llk_math_hw_configure_(const std::uint32_t srca_data_format, const 
                                       (masked_data_format(srcb_data_format) == ckernel::to_underlying(DataFormat::Int8)) ||
                                       (srca_data_format == ckernel::to_underlying(DataFormat::Int32)) ||
                                       (srcb_data_format == ckernel::to_underlying(DataFormat::Int32));
+    // Cross-thread note: the INT8 math-enable bit lives in ALU_FORMAT_SPEC_REG0_SrcA_ADDR32, a config word the
+    // UNPACK thread also programs (SrcA/SrcBUnsigned and rounding mode in configure_unpack_AB, which takes
+    // mutex::REG_RMW). The math thread does NOT take that mutex here. This is safe because cfg_reg_rmw_tensix
+    // lowers to per-byte RMWCIB, and each RMWCIB is a HW-atomic masked read-modify-write of one config byte (see
+    // BlackholeA0/TensixTile/TensixCoprocessor/RMWCIB.md), so disjoint-mask writes from different threads cannot
+    // lose each other's bits. Logical ordering between unpack- and math-programmed fields relies on the
+    // unpack->math dataflow semaphore (and sequenced init), not on holding mutex::REG_RMW.
     cfg_reg_rmw_tensix<ALU_ACC_CTRL_INT8_math_enabled_RMW>(int8_math_enabled);
 
     cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(is_fp32_dest_acc_en);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
@@ -99,6 +99,13 @@ inline void _llk_math_hw_configure_(const std::uint32_t srca_data_format, const 
     std::uint32_t config_data = (srca_data_format << ALU_FORMAT_SPEC_REG0_SrcA_SHAMT) | (srcb_data_format << ALU_FORMAT_SPEC_REG1_SrcB_SHAMT) |
                                 (int8_math_enabled << ALU_ACC_CTRL_INT8_math_enabled_SHAMT);
     constexpr std::uint32_t config_mask = ALU_FORMAT_SPEC_REG0_SrcA_MASK | ALU_FORMAT_SPEC_REG1_SrcB_MASK | ALU_ACC_CTRL_INT8_math_enabled_MASK;
+    // Cross-thread note: ALU_FORMAT_SPEC_REG0_SrcA_ADDR32 also carries fields the UNPACK thread programs
+    // (SrcA/SrcBUnsigned and rounding mode in configure_unpack_AB, which takes mutex::REG_RMW). The math thread
+    // does NOT take that mutex here. This is safe because cfg_reg_rmw_tensix lowers to per-byte RMWCIB, and each
+    // RMWCIB is a HW-atomic masked read-modify-write of one config byte (see WormholeB0/TensixTile/
+    // TensixCoprocessor/RMWCIB.md), so disjoint-mask writes from different threads cannot lose each other's bits.
+    // Logical ordering between unpack-programmed and math-programmed fields relies on the unpack->math dataflow
+    // semaphore (and sequenced init), not on holding mutex::REG_RMW. Do not assume mutual exclusion with unpack here.
     cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_ADDR32, 0, config_mask>(config_data);
 
     cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(is_fp32_dest_acc_en);
@@ -258,6 +265,10 @@ inline void _llk_math_reconfig_data_format_(const std::uint32_t srca_data_format
 {
     llk::san::math_operand_configure<true>(srca_data_format, srcb_data_format);
 
+    // Cross-thread note: the RMWs below target ALU_FORMAT_SPEC_REG0_SrcA_ADDR32, a config word the UNPACK thread
+    // also programs (see _llk_math_hw_configure_ for the full rationale). The math thread intentionally does NOT
+    // take mutex::REG_RMW: per-byte RMWCIB is HW-atomic with masking, so disjoint-mask cross-thread writes are
+    // safe, and logical ordering relies on the unpack->math dataflow semaphore.
     if constexpr (to_from_int8)
     {
         static_assert(is_fp32_dest_acc_en, "Reconfiguring math to/from Int8 formats requires FP32 Dest mode enabled");


### PR DESCRIPTION
https://github.com/tenstorrent/tt-llk/issues/1652

ALU_FORMAT_SPEC_REG0_SrcA_ADDR32 is a single backend config word programmed by BOTH the unpack thread (SrcA/SrcBUnsigned + rounding mode in configure_unpack_AB, and the INT8-enable bit in enable_int8_fpu_math) and the math thread (SrcA/SrcB ALU formats on Wormhole, plus the INT8 math-enable bit on both arches, in _llk_math_hw_configure_ and the _llk_math_reconfig_data_format_* helpers). The unpack/pack sides take mutex::REG_RMW for their read-modify-write of this word; the math side does not, and the per-thread STALLWAITs do not provide mutual exclusion. This looked like a latent cross-thread concurrency hazard.

ISA review shows it is actually safe: cfg_reg_rmw_tensix lowers to per-byte RMWCIB instructions, and each RMWCIB is a HW-atomic masked read-modify-write of one config byte (WormholeB0/BlackholeA0/TensixTile/TensixCoprocessor/RMWCIB.md: "atomic { OldValue = *CfgAddress; *CfgAddress = (NewValue & Mask) | (OldValue & ~Mask); }"). Because every write is masked, disjoint-mask updates from different threads to the same byte cannot lose each other's bits, so the math side does not need mutex::REG_RMW to avoid torn updates. The logical ordering between unpack-programmed and math-programmed fields is governed by the unpack->math dataflow semaphore (and sequenced init), not by the mutex.

Document this invariant at the math-side RMW sites (hw_configure on both arches, and the reconfig path on Wormhole) so the missing mutex is understood as intentional rather than an oversight. No behavior change.

Found in the LLK ISA audit (P2, C2).

### PR Category
NFC

### Notes for reviewers
Merging decision upto reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/llk-fix-c2-format-reg-dual-thread)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/llk-fix-c2-format-reg-dual-thread)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/llk-fix-c2-format-reg-dual-thread)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/llk-fix-c2-format-reg-dual-thread)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=amahmud/llk-fix-c2-format-reg-dual-thread)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:amahmud/llk-fix-c2-format-reg-dual-thread)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/llk-fix-c2-format-reg-dual-thread)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/llk-fix-c2-format-reg-dual-thread)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/llk-fix-c2-format-reg-dual-thread)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/llk-fix-c2-format-reg-dual-thread)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/llk-fix-c2-format-reg-dual-thread)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/llk-fix-c2-format-reg-dual-thread)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/llk-fix-c2-format-reg-dual-thread)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/llk-fix-c2-format-reg-dual-thread)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/llk-fix-c2-format-reg-dual-thread)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/llk-fix-c2-format-reg-dual-thread)