### PR TITLE
[LLK] Invalidate src zero-flag tracker after WH UInt16 B2D restore (M1)

### DIFF
--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -242,6 +242,10 @@ inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t dst_index, con
             {
                 cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(0);
                 cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(0);
+                // The Zero_Flag_disabled_src bit was set/cleared above via raw RMW, bypassing the math
+                // state tracker; invalidate the tracked state so the next configurator re-applies the flag
+                // instead of taking its skip-if-set fast path (matches the Blackhole path).
+                math::_invalidate_src_zero_flag_state_();
             }
         }
 


### PR DESCRIPTION
Issue : https://github.com/tenstorrent/tt-llk/issues/1652

The Wormhole fp32-dest UInt16 B2D path (is_fp32_dest_acc_en, non-NONE broadcast, dst_format == UInt16) asserts ALU_ACC_CTRL_Zero_Flag_disabled_src via a raw cfg_reg_rmw_tensix before running the MOP, then clears it via raw RMW afterward. Both writes bypass the math-thread src zero-flag state tracker (src_zero_flag_state), so the tracker is left stale: a subsequent configurator (_configure_default/unary_preserve/mov_ops_zero_flag_state_) can hit its skip-if-already-in-state fast path and fail to re-apply the intended HW flag, leaking the disabled state (or a wrong value) into the next op.

The Blackhole twin already calls _invalidate_src_zero_flag_state_() in the same restore block. Add the matching invalidate after the Wormhole UInt16 restore so the next configurator always re-applies the flag.

This is a state-leak latent: it only manifests when a later op relies on the tracker fast path after this exact UInt16 B2D path, so there is no deterministic standalone test; correctness is established by matching the safer Blackhole behavior and the tracker's documented contract.

Found in the LLK ISA audit (P2, M1).

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/llk-fix-m1-wh-uint16-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/llk-fix-m1-wh-uint16-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/llk-fix-m1-wh-uint16-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/llk-fix-m1-wh-uint16-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/llk-fix-m1-wh-uint16-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/llk-fix-m1-wh-uint16-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/llk-fix-m1-wh-uint16-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/llk-fix-m1-wh-uint16-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/llk-fix-m1-wh-uint16-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/llk-fix-m1-wh-uint16-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/llk-fix-m1-wh-uint16-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/llk-fix-m1-wh-uint16-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/llk-fix-m1-wh-uint16-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/llk-fix-m1-wh-uint16-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/llk-fix-m1-wh-uint16-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/llk-fix-m1-wh-uint16-invalidate)