### PR TITLE
[LLK] Invalidate src zero-flag tracker after WH 32b unpack-to-dest block (M2)

### DIFF
--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -190,6 +190,12 @@ inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t dst_index, con
             TTI_CLEARDVALID(0b10, 0);
         }
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(0);
+
+        // This 32b hi16/lo16 MOV sequence drove the Src zero-substitution flag (and the SrcA format
+        // override bank) directly for the duration of the block; invalidate the tracked state so the
+        // next configurator re-applies the flag from a known baseline instead of taking its
+        // skip-if-set fast path (matches the Blackhole path).
+        math::_invalidate_src_zero_flag_state_();
     }
     else
     {


### PR DESCRIPTION
Issue : https://github.com/tenstorrent/tt-llk/issues/1652


The Wormhole 32b unpack-to-dest broadcast path (unpack_to_dest && is_32bit_input, ROW/SCALAR/COL) enters MOV_OPS state via _configure_mov_ops_zero_flag_state_() and then, for the duration of the hi16/lo16 MOVB2D sequence, drives the SrcA format override bank (ALU_FORMAT_SPEC_REG_SrcA_override / _val) directly. At the end it clears the override bank but leaves src_zero_flag_state == MOV_OPS, so a later configurator can take its skip-if-already-in-state fast path against a tracker value that no longer reflects a clean baseline after the direct register manipulation.

The Blackhole twin manipulates the flag with raw RMW in this block and calls _invalidate_src_zero_flag_state_() at the end so the next configurator always re-applies. Add the matching invalidate at the end of the Wormhole 32b block for the same guarantee and cross-arch consistency.

State-leak latent: only manifests when a later op relies on the tracker fast path after this exact 32b unpack-to-dest path, so there is no deterministic standalone test; correctness is established by matching the Blackhole behavior and the tracker's documented contract.

Found in the LLK ISA audit (P2, M2).

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/llk-fix-m2-wh-32b-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/llk-fix-m2-wh-32b-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/llk-fix-m2-wh-32b-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/llk-fix-m2-wh-32b-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/llk-fix-m2-wh-32b-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/llk-fix-m2-wh-32b-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/llk-fix-m2-wh-32b-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/llk-fix-m2-wh-32b-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/llk-fix-m2-wh-32b-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/llk-fix-m2-wh-32b-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/llk-fix-m2-wh-32b-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/llk-fix-m2-wh-32b-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/llk-fix-m2-wh-32b-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/llk-fix-m2-wh-32b-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/llk-fix-m2-wh-32b-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/llk-fix-m2-wh-32b-invalidate)