### PR TITLE
[LLK] BH unpack-reduce: set SrcB Unp_LF8_4b_exp for Fp8_e4m3 scaler (F3)

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_reduce.h
@@ -68,6 +68,10 @@ inline void _llk_unpack_reduce_init_(
     // Configure SrcB format registers
     cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG1_SrcB_RMW>(unpB_dst_format);
     cfg_reg_rmw_tensix<THCON_SEC1_REG0_TileDescriptor_ADDR32, 0, 0xf>(unpB_src_format);
+
+    // Set FP8 E4M3 mode for SrcB; selects the e4m3 (vs e5m2) exponent layout and clears any stale 4b-exp setting.
+    cfg_reg_rmw_tensix<THCON_SEC1_REG1_Unp_LF8_4b_exp_RMW>(((unpB_src_format & 0x1F) == (std::uint32_t)DataFormat::Fp8_e4m3) ? 1 : 0);
+
     cfg_reg_rmw_tensix<THCON_SEC1_REG2_Out_data_format_RMW>(unpB_dst_format);
 
     TTI_WRCFG(p_gpr_unpack::L1_BUFFER_ADDR, p_cfg::WRCFG_32b, THCON_SEC1_REG3_Base_address_ADDR32);


### PR DESCRIPTION
Issue : https://github.com/tenstorrent/tt-llk/issues/1652

**This PR does not change things much as the function is unused anyways, but still better correct it.**


The SrcB reconfig in _llk_unpack_reduce_init_ programmed the SrcB tile descriptor, ALU and out-data-format registers but never wrote THCON_SEC1_REG1_Unp_LF8_4b_exp. As a result an Fp8_e4m3 reduce scaler was decoded with the wrong (e5m2) exponent layout, and any stale 4b-exp bit from a prior op was left uncleared. Every other BH unpack path (cunpack_common.h, llk_unpack_common.h) sets this bit keyed on the Fp8_e4m3 source format; mirror that for SrcB here.

Found in the LLK ISA audit (P2, F3).

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/llk-fix-f3-bh-reduce-fp8-exp)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/llk-fix-f3-bh-reduce-fp8-exp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/llk-fix-f3-bh-reduce-fp8-exp)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/llk-fix-f3-bh-reduce-fp8-exp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/llk-fix-f3-bh-reduce-fp8-exp)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/llk-fix-f3-bh-reduce-fp8-exp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/llk-fix-f3-bh-reduce-fp8-exp)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/llk-fix-f3-bh-reduce-fp8-exp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/llk-fix-f3-bh-reduce-fp8-exp)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/llk-fix-f3-bh-reduce-fp8-exp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/llk-fix-f3-bh-reduce-fp8-exp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/llk-fix-f3-bh-reduce-fp8-exp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/llk-fix-f3-bh-reduce-fp8-exp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/llk-fix-f3-bh-reduce-fp8-exp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/llk-fix-f3-bh-reduce-fp8-exp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/llk-fix-f3-bh-reduce-fp8-exp)