### PR TITLE
[tt-train] Re-use parallel RNG for softmax tests

### DIFF
--- a/tt-train/sources/ttml/test_utils/random_data.hpp
+++ b/tt-train/sources/ttml/test_utils/random_data.hpp
@@ -30,22 +30,6 @@ inline void fill_uniform(std::span<T> data, const T min, const T max, const uint
     }
 }
 
-// This is a workaround for the Softmax test. Should be removed when we have a better way to generate
-// deterministic multi-threaded random data. See #46837
-template <typename T>
-inline void fill_uniform_sequential(std::span<T> data, const T min, const T max, const uint32_t seed) {
-    if constexpr (std::is_integral_v<T>) {
-        ttml::core::legacy::sequential_generate(
-            data, [min, max]() { return std::uniform_int_distribution<T>(min, max); }, seed);
-    } else {
-        using DistScalar = std::conditional_t<std::is_floating_point_v<T>, T, float>;
-        const DistScalar min_v = static_cast<DistScalar>(min);
-        const DistScalar max_v = static_cast<DistScalar>(max);
-        ttml::core::sequential_generate(
-            data, [min_v, max_v]() { return std::uniform_real_distribution<DistScalar>(min_v, max_v); }, seed);
-    }
-}
-
 template <typename T>
 inline std::vector<T> make_uniform_vector(const std::size_t vec_size, const T min, const T max, const uint32_t seed) {
     std::vector<T> data(vec_size);
@@ -53,7 +37,7 @@ inline std::vector<T> make_uniform_vector(const std::size_t vec_size, const T mi
     return data;
 }
 
-template <typename T, typename Shape, bool deterministic = false>
+template <typename T, typename Shape>
 inline xt::xarray<T> make_uniform_xarray(const Shape& shape, const T min, const T max, const uint32_t seed) {
     std::vector<std::size_t> xt_shape;
     xt_shape.reserve(std::size(shape));
@@ -61,11 +45,7 @@ inline xt::xarray<T> make_uniform_xarray(const Shape& shape, const T min, const 
         xt_shape.push_back(static_cast<std::size_t>(dim));
     }
     xt::xarray<T> x = xt::empty<T>(xt_shape);
-    if constexpr (deterministic) {
-        fill_uniform_sequential<T>(std::span<T>{x.data(), x.size()}, min, max, seed);
-    } else {
-        fill_uniform<T>(std::span<T>{x.data(), x.size()}, min, max, seed);
-    }
+    fill_uniform<T>(std::span<T>{x.data(), x.size()}, min, max, seed);
     return x;
 }
 

--- a/tt-train/tests/ops/softmax_test.cpp
+++ b/tt-train/tests/ops/softmax_test.cpp
@@ -51,7 +51,7 @@ TEST_F(SoftmaxTest, DISABLED_SoftmaxTest_Batch) {
     auto& rng = ttml::autograd::ctx().get_generator();
     uint32_t seed = rng();
     xt::xarray<float> input_tensor =
-        ttml::test_utils::make_uniform_xarray<float, shape_type, true>(shape, -10.0F, 10.0F, seed);
+        ttml::test_utils::make_uniform_xarray<float, shape_type>(shape, -10.0F, 10.0F, seed);
 
     auto input = core::from_xtensor(input_tensor, &autograd::ctx().get_device());
 
@@ -109,7 +109,7 @@ TEST_F(SoftmaxTest, NIGHTLY_SoftmaxTest_Huge_Batch) {
     auto& rng = ttml::autograd::ctx().get_generator();
     uint32_t seed = rng();
     xt::xarray<float> input_tensor =
-        ttml::test_utils::make_uniform_xarray<float, shape_type, true>(shape, -10.0F, 10.0F, seed);
+        ttml::test_utils::make_uniform_xarray<float, shape_type>(shape, -10.0F, 10.0F, seed);
 
     auto input = core::from_xtensor(input_tensor, &autograd::ctx().get_device());
 


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Clean-up

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

PR #46495 addressed non-deterministic tests by falling back to sequential RNG for softmax.
This PR switches back to parallel algorithms (now deterministic following PR #47431)

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

Note: Red tt-rain CI failures are unrelated. C++ tests are green.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nmaurice/tt-train-softmax-parallel-rng)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nmaurice/tt-train-softmax-parallel-rng)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nmaurice/tt-train-softmax-parallel-rng)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nmaurice/tt-train-softmax-parallel-rng)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nmaurice/tt-train-softmax-parallel-rng)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nmaurice/tt-train-softmax-parallel-rng)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmaurice/tt-train-softmax-parallel-rng)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmaurice/tt-train-softmax-parallel-rng)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nmaurice/tt-train-softmax-parallel-rng)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nmaurice/tt-train-softmax-parallel-rng)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmaurice/tt-train-softmax-parallel-rng)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmaurice/tt-train-softmax-parallel-rng)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmaurice/tt-train-softmax-parallel-rng)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmaurice/tt-train-softmax-parallel-rng)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmaurice/tt-train-softmax-parallel-rng)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmaurice/tt-train-softmax-parallel-rng)