### PR TITLE
Fix two BH SDPA nightly regressions: MSA kernel compile + ring-joint program cache

### DIFF
--- a/tests/nightly/blackhole/sdpa/test_ring_joint_attention.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_attention.py
@@ -2,8 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import torch
-
 import ttnn
 from loguru import logger
 import pytest
@@ -90,7 +88,7 @@ def test_ring_joint_sdpa_dit_bh_qb_ge(
     ],
     ids=["sd35"],
 )
-@pytest.mark.parametrize("n_iters, trace_enabled", [(1, False)], ids=["no_trace"])
+@pytest.mark.parametrize("n_iters, trace_enabled", [(3, False)], ids=["no_trace"])
 @pytest.mark.parametrize("num_links", [2])
 @pytest.mark.parametrize(
     "device_params, all_gather_topology",
@@ -148,37 +146,31 @@ def test_ring_joint_sdpa_program_cache(
 
     skip_check = False
 
-    dummy_tensors = []
-    for i in range(3):
-        dummy_tensors.append(
-            ttnn.from_torch(
-                torch.rand((b, nh, seq_len, d)),
-                device=submesh,
-                layout=ttnn.TILE_LAYOUT,
-                dtype=dtype,
-                mesh_mapper=ttnn.ShardTensor2dMesh(submesh, mesh_shape=tuple(submesh.shape), dims=[None, None]),
-            )
-        )
-
-        run_ring_joint_sdpa(
-            submesh,
-            b,
-            nh,
-            seq_len,
-            seq_len,
-            joint_seq_len,
-            d,
-            q_chunk_size,
-            k_chunk_size,
-            dtype,
-            n_iters,
-            trace_enabled,
-            num_links,
-            rp_axis,
-            up_axis,
-            all_gather_topology,
-            skip_check,
-            pcc_threshold,
-        )
+    # Run the op n_iters (>1) times within a SINGLE run_ring_joint_sdpa invocation. The op must be
+    # exercised under one sub-device-manager lifetime: run_ring_joint_sdpa loads a sub-device manager
+    # on entry, which clears the program cache (mesh_device.cpp clear_program_cache on manager switch),
+    # so looping the whole helper would clear the cache between calls and defeat the reuse check.
+    # run_ring_joint_sdpa's internal loop runs the op n_iters times with distinct per-iter persistent
+    # buffers and global semaphores, so cache reuse is still validated against address variation.
+    run_ring_joint_sdpa(
+        submesh,
+        b,
+        nh,
+        seq_len,
+        seq_len,
+        joint_seq_len,
+        d,
+        q_chunk_size,
+        k_chunk_size,
+        dtype,
+        n_iters,
+        trace_enabled,
+        num_links,
+        rp_axis,
+        up_axis,
+        all_gather_topology,
+        skip_check,
+        pcc_threshold,
+    )
 
     assert submesh.cache_entries_counter.total == 1

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_msa_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_msa_compute.cpp
@@ -134,7 +134,6 @@ void kernel_main() {
                             /*subblock_h=*/qsb,
                             /*inner_dim=*/DHt,
                             /*matmul_stride=*/DHt,
-                            /*trigger_reduce=*/false,
                             /*skip_pack_configure=*/true);
                     }
                     // Publish the band to UNPACK while holding wr_ptr for in-place sub_exp.
@@ -192,7 +191,6 @@ void kernel_main() {
                             /*subblock_h=*/qsb,
                             /*inner_dim=*/Skt,
                             /*matmul_stride=*/KT_stride,
-                            /*trigger_reduce=*/false,
                             /*skip_pack_configure=*/true);
                     }
                     pack_to_unpack_sync();                // publish held out_cur packs before flash combine


### PR DESCRIPTION
## Summary

Fixes four auto-triage CI reports = two distinct root causes, each reported twice across different jobs/OS images. Both verified on a 4-chip Blackhole box.

| Issue | Job | Root cause |
|-------|-----|-----------|
| #48375, #48373 | P150b `ttnn sdpa` | MSA compute kernel fails trisc0 JIT build |
| #48372, #48374 | BH QB2 2x2 mesh | ring-joint SDPA program-cache `assert 3 == 1` |

## 1) MSA compute kernel compile failure (#48375, #48373)

Merge race between two PRs that landed close together:
- #48045 (sparse_sdpa_msa native GQA) calls `blocked_matmul_and_pack`.
- #48061 (`92158512114`, ring_mla reduce_trigger determinism) removed the now-dead `trigger_reduce` parameter from `blocked_matmul_and_pack`.

Neither was rebased on the other, so the MSA call sites passed `trigger_reduce=false` (13 args) to a 12-arg function:

```
error: no matching function for call to 'blocked_matmul_and_pack(...)'
note: candidate expects 12 arguments, 13 provided
```

**Fix:** drop the obsolete `/*trigger_reduce=*/false,` argument at both MSA call sites (QK and AV matmuls).

**Verified:** `test_msa_native_pcc_random_selection` + full `test_sparse_sdpa_msa.py` (12/12) pass on silicon.

## 2) Ring-joint SDPA program-cache regression (#48372, #48374)

**Root cause:** #47921 (`14c8ead609f`, "#45821: clear program cache on MeshDevice reconfiguration") added `clear_program_cache()` inside `MeshDeviceImpl::load_sub_device_manager()`. Cached programs bake in worker-core ranges that a sub-device manager switch can remap, so this is **correct, safe behavior and is not reverted.**

The test called `run_ring_joint_sdpa()` three times in a loop, and that helper loads a fresh sub-device manager on every call. Before #47921 the cache survived the reload (3 runs → 1 cached program → `total == 1`); after #47921 each reload wipes the cache, so every run recompiles → `total == 3`.

This is **not** a hashing problem and is **unrelated to #47559**. Instrumented runs confirm the op's program hash, canonical key, and mesh-coordinate-folded hash are byte-identical across iterations, and `num_program_cache_entries()` is 1 after every iteration — the counter only grows because `measure()` observes an empty (just-cleared) cache at the start of each call.

**Fix:** exercise the op multiple times within a **single** sub-device-manager lifetime — call `run_ring_joint_sdpa()` once with `n_iters=3` (its internal loop runs the op N× under one sub-device setup, with distinct per-iter persistent buffers and global semaphores, so cache reuse is still validated against address variation) instead of looping the whole helper.

**Verified:** `test_ring_joint_sdpa_program_cache` passes for all three dtypes (bf16, bf8_b, bf4_b) on a Blackhole 2x2 mesh.

## Notes

- Issues #48372 / #48374 are not caused by this owner's changes; they are a test that relied on pre-#47921 cache behavior.

Closes #48375
Closes #48373
Closes #48372
Closes #48374

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-bh-sdpa-nightly-regressions)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fix-bh-sdpa-nightly-regressions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-bh-sdpa-nightly-regressions)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fix-bh-sdpa-nightly-regressions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/fix-bh-sdpa-nightly-regressions)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/fix-bh-sdpa-nightly-regressions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix-bh-sdpa-nightly-regressions)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix-bh-sdpa-nightly-regressions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fix-bh-sdpa-nightly-regressions)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fix-bh-sdpa-nightly-regressions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fix-bh-sdpa-nightly-regressions)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fix-bh-sdpa-nightly-regressions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fix-bh-sdpa-nightly-regressions)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fix-bh-sdpa-nightly-regressions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fix-bh-sdpa-nightly-regressions)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fix-bh-sdpa-nightly-regressions)