### PR TITLE
Use new sfpi float predicates

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_isinf_isnan.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_isinf_isnan.h
@@ -11,141 +11,57 @@
 namespace ckernel::sfpu
 {
 
-/* Checks if the exponent is 128 and mantissa is 0.
-If both conditions are met, the number is marked as
-infinity, so '1' is written in the location of the DEST
-where the number was stored. Otherwise, `0` is written instead
-of the number.
-*/
-template <bool APPROXIMATION_MODE>
-inline sfpi::vFloat _calculate_isinf_(const sfpi::vFloat& in)
-{
-    // SFPU microcode
-    sfpi::vInt exp   = sfpi::exexp(in);
-    sfpi::vInt man   = sfpi::exman(in);
-    sfpi::vFloat out = sfpi::vConst0;
-    v_if (exp == 128 && man == 0)
-    {
-        out = sfpi::vConst1;
-    }
-    v_endif;
-    return out;
-}
-
-/* Checks if the sign bit of the floating point number in DEST
-is positive. Checks if the exponent is 128 and mantissa is 0.
-If all of the three conditions are met, the number is marked as
-positive infinity, so '1' is written in the location of the DEST
-where the number was stored. Otherwise, `0` is written instead
-of the number.
-*/
-template <bool APPROXIMATION_MODE>
-inline sfpi::vFloat _calculate_isposinf_(const sfpi::vFloat& in)
-{
-    // SFPU microcode
-    sfpi::vInt exp     = sfpi::exexp(in);
-    sfpi::vInt man     = sfpi::exman(in);
-    sfpi::vFloat out   = sfpi::vConst0;
-    sfpi::vInt signbit = sfpi::as<sfpi::vInt>(in) & 0x80000000; // returns 0 for +ve value
-    v_if (signbit == 0 && exp == 128 && man == 0)
-    {
-        out = sfpi::vConst1;
-    }
-    v_endif;
-    return out;
-}
-
-/* Checks if the sign bit of the floating point number in DEST
-is negative. Checks if the exponent is 128 and mantissa is 0.
-If all of the three conditions are met, the number is marked as
-negative infinity, so '1' is written in the location of the DEST
-where the number was stored. Otherwise, `0` is written instead
-of the number.
-*/
-template <bool APPROXIMATION_MODE>
-inline sfpi::vFloat _calculate_isneginf_(const sfpi::vFloat& in)
-{
-    // SFPU microcode
-    sfpi::vInt exp     = sfpi::exexp(in);
-    sfpi::vInt man     = sfpi::exman(in);
-    sfpi::vFloat out   = sfpi::vConst0;
-    sfpi::vInt signbit = sfpi::as<sfpi::vInt>(in) & 0x80000000; // returns 0x80000000 for -ve value
-    v_if (signbit == 0x80000000 && exp == 128 && man == 0)
-    {
-        out = sfpi::vConst1;
-    }
-    v_endif;
-    return out;
-}
-
-/* Checks if the exponent is 128 and mantissa is not 0.
-If both conditions are met, the number is marked as
-nan, so '1' is written in the location of the DEST
-where the number was stored. Otherwise, `0` is written instead
-of the number.
-*/
-template <bool APPROXIMATION_MODE>
-inline sfpi::vFloat _calculate_isnan_(const sfpi::vFloat& in)
-{
-    // SFPU microcode
-    sfpi::vInt exp   = sfpi::exexp(in);
-    sfpi::vInt man   = sfpi::exman(in);
-    sfpi::vFloat out = sfpi::vConst0;
-    v_if (exp == 128 && man != 0)
-    {
-        out = sfpi::vConst1;
-    }
-    v_endif;
-    return out;
-}
-
-template <bool APPROXIMATION_MODE>
-inline sfpi::vFloat _calculate_isfinite_(const sfpi::vFloat& v)
-{
-    // SFPU microcode
-    // A number is finite if it's neither infinity nor NaN
-    sfpi::vInt exp      = sfpi::exexp(v);
-    sfpi::vFloat result = sfpi::vConst1; // Assume finite (1.0f) by default
-
-    // If exponent is 128, the number is either infinity or NaN (not finite)
-    v_if (exp == 128)
-    {
-        result = sfpi::vConst0;
-    }
-    v_endif;
-
-    return result;
-}
-
 template <SfpuType operation, bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _calculate_sfpu_isinf_isnan_()
 {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat in = sfpi::dst_reg[0];
+        sfpi::vFloat in  = sfpi::dst_reg[0];
+        sfpi::vFloat res = 0.0f;
 
         if constexpr (operation == SfpuType::isinf)
         {
-            sfpi::dst_reg[0] = _calculate_isinf_<APPROXIMATION_MODE>(in);
+            v_if (sfpi::is_inf(in))
+            {
+                res = 1.0f;
+            }
+            v_endif;
         }
         else if constexpr (operation == SfpuType::isposinf)
         {
-            sfpi::dst_reg[0] = _calculate_isposinf_<APPROXIMATION_MODE>(in);
+            v_if (sfpi::is_pos(in) && sfpi::is_inf(in))
+            {
+                res = 1.0f;
+            }
+            v_endif;
         }
         else if constexpr (operation == SfpuType::isneginf)
         {
-            sfpi::dst_reg[0] = _calculate_isneginf_<APPROXIMATION_MODE>(in);
+            v_if (sfpi::is_neg(in) && sfpi::is_inf(in))
+            {
+                res = 1.0f;
+            }
+            v_endif;
         }
         else if constexpr (operation == SfpuType::isnan)
         {
-            sfpi::dst_reg[0] = _calculate_isnan_<APPROXIMATION_MODE>(in);
+            v_if (sfpi::is_nan(in))
+            {
+                res = 1.0f;
+            }
+            v_endif;
         }
         else if constexpr (operation == SfpuType::isfinite)
         {
-            sfpi::dst_reg[0] = _calculate_isfinite_<APPROXIMATION_MODE>(in);
+            v_if (sfpi::is_finite(in))
+            {
+                res = 1.0f;
+            }
+            v_endif;
         }
 
+        sfpi::dst_reg[0] = res;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_isinf_isnan.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_isinf_isnan.h
@@ -11,141 +11,57 @@
 namespace ckernel::sfpu
 {
 
-/* Checks if the exponent is 128 and mantissa is 0.
-If both conditions are met, the number is marked as
-infinity, so '1' is written in the location of the DEST
-where the number was stored. Otherwise, `0` is written instead
-of the number.
-*/
-template <bool APPROXIMATION_MODE>
-inline sfpi::vFloat _calculate_isinf_(const sfpi::vFloat& in)
-{
-    // SFPU microcode
-    sfpi::vInt exp   = sfpi::exexp(in);
-    sfpi::vInt man   = sfpi::exman(in);
-    sfpi::vFloat out = sfpi::vConst0;
-    v_if (exp == 128 && man == 0)
-    {
-        out = sfpi::vConst1;
-    }
-    v_endif;
-    return out;
-}
-
-/* Checks if the sign bit of the floating point number in DEST
-is positive. Checks if the exponent is 128 and mantissa is 0.
-If all of the three conditions are met, the number is marked as
-positive infinity, so '1' is written in the location of the DEST
-where the number was stored. Otherwise, `0` is written instead
-of the number.
-*/
-template <bool APPROXIMATION_MODE>
-inline sfpi::vFloat _calculate_isposinf_(const sfpi::vFloat& in)
-{
-    // SFPU microcode
-    sfpi::vInt exp     = sfpi::exexp(in);
-    sfpi::vInt man     = sfpi::exman(in);
-    sfpi::vFloat out   = sfpi::vConst0;
-    sfpi::vInt signbit = sfpi::as<sfpi::vInt>(in) & 0x80000000; // returns 0 for +ve value
-    v_if (signbit == 0 && exp == 128 && man == 0)
-    {
-        out = sfpi::vConst1;
-    }
-    v_endif;
-    return out;
-}
-
-/* Checks if the sign bit of the floating point number in DEST
-is negative. Checks if the exponent is 128 and mantissa is 0.
-If all of the three conditions are met, the number is marked as
-negative infinity, so '1' is written in the location of the DEST
-where the number was stored. Otherwise, `0` is written instead
-of the number.
-*/
-template <bool APPROXIMATION_MODE>
-inline sfpi::vFloat _calculate_isneginf_(const sfpi::vFloat& in)
-{
-    // SFPU microcode
-    sfpi::vInt exp     = sfpi::exexp(in);
-    sfpi::vInt man     = sfpi::exman(in);
-    sfpi::vFloat out   = sfpi::vConst0;
-    sfpi::vInt signbit = sfpi::as<sfpi::vInt>(in) & 0x80000000; // returns 0x80000000 for -ve value
-    v_if (signbit == 0x80000000 && exp == 128 && man == 0)
-    {
-        out = sfpi::vConst1;
-    }
-    v_endif;
-    return out;
-}
-
-/* Checks if the exponent is 128 and mantissa is not 0.
-If both conditions are met, the number is marked as
-nan, so '1' is written in the location of the DEST
-where the number was stored. Otherwise, `0` is written instead
-of the number.
-*/
-template <bool APPROXIMATION_MODE>
-inline sfpi::vFloat _calculate_isnan_(const sfpi::vFloat& in)
-{
-    // SFPU microcode
-    sfpi::vInt exp   = sfpi::exexp(in);
-    sfpi::vInt man   = sfpi::exman(in);
-    sfpi::vFloat out = sfpi::vConst0;
-    v_if (exp == 128 && man != 0)
-    {
-        out = sfpi::vConst1;
-    }
-    v_endif;
-    return out;
-}
-
-template <bool APPROXIMATION_MODE>
-inline sfpi::vFloat _calculate_isfinite_(const sfpi::vFloat& v)
-{
-    // SFPU microcode
-    // A number is finite if it's neither infinity nor NaN
-    sfpi::vInt exp      = sfpi::exexp(v);
-    sfpi::vFloat result = sfpi::vConst1; // Assume finite (1.0f) by default
-
-    // If exponent is 128, the number is either infinity or NaN (not finite)
-    v_if (exp == 128)
-    {
-        result = sfpi::vConst0;
-    }
-    v_endif;
-
-    return result;
-}
-
 template <SfpuType operation, bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _calculate_sfpu_isinf_isnan_()
 {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat in = sfpi::dst_reg[0];
+        sfpi::vFloat in  = sfpi::dst_reg[0];
+        sfpi::vFloat res = 0.0f;
 
         if constexpr (operation == SfpuType::isinf)
         {
-            sfpi::dst_reg[0] = _calculate_isinf_<APPROXIMATION_MODE>(in);
+            v_if (sfpi::is_inf(in))
+            {
+                res = 1.0f;
+            }
+            v_endif;
         }
         else if constexpr (operation == SfpuType::isposinf)
         {
-            sfpi::dst_reg[0] = _calculate_isposinf_<APPROXIMATION_MODE>(in);
+            v_if (sfpi::is_pos(in) && sfpi::is_inf(in))
+            {
+                res = 1.0f;
+            }
+            v_endif;
         }
         else if constexpr (operation == SfpuType::isneginf)
         {
-            sfpi::dst_reg[0] = _calculate_isneginf_<APPROXIMATION_MODE>(in);
+            v_if (sfpi::is_neg(in) && sfpi::is_inf(in))
+            {
+                res = 1.0f;
+            }
+            v_endif;
         }
         else if constexpr (operation == SfpuType::isnan)
         {
-            sfpi::dst_reg[0] = _calculate_isnan_<APPROXIMATION_MODE>(in);
+            v_if (sfpi::is_nan(in))
+            {
+                res = 1.0f;
+            }
+            v_endif;
         }
         else if constexpr (operation == SfpuType::isfinite)
         {
-            sfpi::dst_reg[0] = _calculate_isfinite_<APPROXIMATION_MODE>(in);
+            v_if (sfpi::is_finite(in))
+            {
+                res = 1.0f;
+            }
+            v_endif;
         }
 
+        sfpi::dst_reg[0] = res;
         sfpi::dst_reg++;
     }
 }


### PR DESCRIPTION
### PR Category
Cleanup, Bug Fix

### Summary
#29305 requested float categorization predicates in sfpi.  These are implemented in 7.62.0 and this uses them.

You'll not I didn't implement `is_posinf` and `is_neginf` -- you can synthesize them yourself from `is_{pos,neg} && is_inf` as this patch does.

As with the std scalar `is normal`, `sfpi::is_normal` indicates a finite non-zero, non-subnormal number (so `is_nornal` and `is_finite` are not the same.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/preds-29305)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/preds-29305)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsidwell/preds-29305)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsidwell/preds-29305)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsidwell/preds-29305)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsidwell/preds-29305)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/preds-29305)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/preds-29305)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsidwell/preds-29305)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsidwell/preds-29305)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/preds-29305)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/preds-29305)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/preds-29305)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/preds-29305)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/preds-29305)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/preds-29305)