### PR TITLE
[Fix] sparse_sdpa: restore mm_init to fix fp8 determinism regression

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_compute.cpp
@@ -94,7 +94,7 @@ void kernel_main() {
     const uint32_t tok_count = get_arg_val<uint32_t>(1);
 
     compute_kernel_hw_startup(cb_q_rm, cb_q_in);
-    matmul_init(cb_q_in, cb_k_in);  // one-time matmul init; the no_mop matmuls reinit off this
+    mm_init(cb_q_in, cb_k_in, cb_out_im);  // one-time full matmul init; the no_mop matmuls reinit off this
 
     scale_cb.wait_front(1);  // persistent reduce scaler; the streaming reduce assumes it is ready
 


### PR DESCRIPTION
## Problem

`test_sparse_sdpa_determinism[fp8]` fails on Blackhole (L2 nightly) — fp8 output isn't bit-exact across repeated runs. `[bf16]` passes. Reproduces 3/3 locally.

Last failure ([run 28314872898](https://github.com/tenstorrent/tt-metal/actions/runs/28314872898), 2026-06-28, `bh_p150b_civ2`):
```
test_sparse_sdpa_determinism[fp8] FAILED
  AssertionError: sparse_sdpa output is not deterministic across repeated runs
  assert 1.0 == 0.0
```

## Root cause

Bisected to #48045, which swapped the one-time init in the compute kernel:
```cpp
- mm_init(cb_q_in, cb_k_in, cb_out_im);  // also inits PACK + DEST + math/pack sync
+ matmul_init(cb_q_in, cb_k_in);         // only UNPACK + MATH
```
fp8 forces `fp32_dest_acc_en` (32-bit DEST). Without `mm_init`'s `DST_ACCUM_MODE` PACK/dest/sync re-init, the half-sync MATH→PACK handshake is left configured for the wrong DEST geometry → PACK samples DEST at a run-to-run-variable boundary → nondeterministic. bf16 matches what startup configured, so it's unaffected.

## Fix

Restore `mm_init(cb_q_in, cb_k_in, cb_out_im)` (1 line).

## Validation (Blackhole, local)

- A/B 3× each: `main` **FAIL 3/3** → fix **PASS 3/3**.
- Full `test_sparse_sdpa.py`: **50/50 PASS**.
- No perf impact (once-per-launch init, outside all loops; restores pre-#48045 baseline).

## Pipelines

Dispatched on this branch (badges update live; click to filter runs by branch):

| Pipeline | Covers | Run |
|---|---|---|
| [![L2 nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/fix-sparse-sdpa-fp8-determinism)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/fix-sparse-sdpa-fp8-determinism) | BH, **sdpa** only — the failing suite | [run 28325492185](https://github.com/tenstorrent/tt-metal/actions/runs/28325492185) |
| [![BH post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/fix-sparse-sdpa-fp8-determinism)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skrstic/fix-sparse-sdpa-fp8-determinism) | Blackhole (P150) post-commit sanity | [run 28325495350](https://github.com/tenstorrent/tt-metal/actions/runs/28325495350) |
